### PR TITLE
Harden Dream auth and centralize API response typing

### DIFF
--- a/server/api/dreams/[id].delete.ts
+++ b/server/api/dreams/[id].delete.ts
@@ -2,7 +2,7 @@
 import { defineEventHandler, createError, getQuery } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
-import { validateApiKey } from '@/server/utils/validateKey'
+import { requireApiUser } from '@/server/utils/authGuard'
 import { assertDreamAccess, dreamInclude, getDreamId } from './index'
 
 function parseBoolean(value: unknown): boolean {
@@ -18,30 +18,8 @@ export default defineEventHandler(async (event) => {
     const query = getQuery(event)
     const hardDelete = parseBoolean(query.hard)
 
-    const { isValid, user } = await validateApiKey(event)
-
-    if (!isValid || !user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired token.',
-      })
-    }
-
-    const userRecord = await prisma.user.findUnique({
-      where: { id: user.id },
-      select: {
-        id: true,
-        username: true,
-        Role: true,
-      },
-    })
-
-    if (!userRecord) {
-      throw createError({
-        statusCode: 401,
-        message: 'Authenticated user could not be found.',
-      })
-    }
+    const auth = await requireApiUser(event)
+    const user = auth.user
 
     const dream = await prisma.dream.findUnique({
       where: { id },
@@ -65,12 +43,12 @@ export default defineEventHandler(async (event) => {
 
     assertDreamAccess({
       dream,
-      userId: userRecord.id,
-      userRole: userRecord.Role,
+      userId: user.id,
+      userRole: user.Role,
       action: 'mutate',
     })
 
-    const actor = userRecord.username || `User ${userRecord.id}`
+    const actor = user.username || `User ${user.id}`
 
     if (!hardDelete) {
       const data = await prisma.dream.update({
@@ -87,7 +65,7 @@ export default defineEventHandler(async (event) => {
           sender: actor,
           content: `Dream archived: ${dream.title}`,
           title: dream.title,
-          userId: userRecord.id,
+          userId: user.id,
           dreamId: id,
           artImageId: dream.artImageId ?? undefined,
           isPublic: dream.isPublic,

--- a/server/api/dreams/[id].patch.ts
+++ b/server/api/dreams/[id].patch.ts
@@ -2,7 +2,7 @@
 import { defineEventHandler, createError, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
-import { validateApiKey } from '@/server/utils/validateKey'
+import { requireApiUser } from '@/server/utils/authGuard'
 import type {
   CreationSource,
   DreamType,
@@ -15,6 +15,7 @@ import {
   getDreamId,
   normalizeCreationSource,
   normalizeIdArray,
+  normalizeNullableId,
   normalizeOptionalText,
   normalizeSlug,
   relationFromNullableId,
@@ -49,6 +50,108 @@ type DreamPatchBody = {
   artCollectionIds?: number[]
   addArtImageToCollection?: boolean
   updateNote?: string | null
+}
+
+function uniqueIds(values: Array<number | null | undefined>): number[] {
+  return Array.from(
+    new Set(values.filter((id): id is number => Number.isInteger(id) && id > 0)),
+  )
+}
+
+function idsFromNullable(value: unknown): number[] {
+  const id = normalizeNullableId(value)
+  return id ? [id] : []
+}
+
+function forbiddenRelationError(label: string) {
+  return createError({
+    statusCode: 403,
+    message: `You do not have permission to attach one or more ${label} records to this Dream.`,
+  })
+}
+
+async function assertAttachableRelations(
+  body: DreamPatchBody,
+  userId: number,
+  userRole: string,
+) {
+  if (userRole === 'ADMIN') return
+
+  const artImageIds = uniqueIds([
+    ...idsFromNullable(body.artImageId),
+    ...(normalizeIdArray(body.artImageIds) ?? []),
+  ])
+
+  if (artImageIds.length) {
+    const count = await prisma.artImage.count({
+      where: {
+        id: { in: artImageIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== artImageIds.length) throw forbiddenRelationError('ArtImage')
+  }
+
+  const artCollectionIds = uniqueIds([
+    ...idsFromNullable(body.artCollectionId),
+    ...(normalizeIdArray(body.artCollectionIds) ?? []),
+  ])
+
+  if (artCollectionIds.length) {
+    const count = await prisma.artCollection.count({
+      where: {
+        id: { in: artCollectionIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== artCollectionIds.length)
+      throw forbiddenRelationError('ArtCollection')
+  }
+
+  const scenarioIds = uniqueIds([
+    ...idsFromNullable(body.scenarioId),
+    ...(normalizeIdArray(body.scenarioIds) ?? []),
+    ...(normalizeIdArray(body.Scenarios) ?? []),
+  ])
+
+  if (scenarioIds.length) {
+    const count = await prisma.scenario.count({
+      where: {
+        id: { in: scenarioIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== scenarioIds.length) throw forbiddenRelationError('Scenario')
+  }
+
+  const characterIds = normalizeIdArray(body.characterIds) ?? []
+
+  if (characterIds.length) {
+    const count = await prisma.character.count({
+      where: {
+        id: { in: characterIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== characterIds.length) throw forbiddenRelationError('Character')
+  }
+
+  const rewardIds = normalizeIdArray(body.rewardIds) ?? []
+
+  if (rewardIds.length) {
+    const count = await prisma.reward.count({
+      where: {
+        id: { in: rewardIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== rewardIds.length) throw forbiddenRelationError('Reward')
+  }
 }
 
 function setTextField<T extends keyof Prisma.DreamUpdateInput>(
@@ -111,14 +214,8 @@ export default defineEventHandler(async (event) => {
   try {
     id = getDreamId(event)
 
-    const { isValid, user } = await validateApiKey(event)
-
-    if (!isValid || !user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired token.',
-      })
-    }
+    const auth = await requireApiUser(event)
+    const user = auth.user
 
     const existingDream = await prisma.dream.findUnique({
       where: { id },
@@ -152,6 +249,8 @@ export default defineEventHandler(async (event) => {
         message: 'No data provided for update.',
       })
     }
+
+    await assertAttachableRelations(body, user.id, user.Role)
 
     const dataInput: Prisma.DreamUpdateInput = {}
 
@@ -300,12 +399,7 @@ export default defineEventHandler(async (event) => {
         include: dreamInclude,
       })) ?? updated
 
-    const userRecord = await prisma.user.findUnique({
-      where: { id: user.id },
-      select: { username: true },
-    })
-
-    const sender = userRecord?.username || `User ${user.id}`
+    const sender = user.username || `User ${user.id}`
     const updateNote = normalizeOptionalText(body.updateNote)
     const content = updateNote || getUpdateSummary(body)
 

--- a/stores/utils.ts
+++ b/stores/utils.ts
@@ -1,16 +1,7 @@
 // @/stores/util
 import { useUserStore } from '~/stores/userStore'
 import { useErrorStore, ErrorType } from '~/stores/errorStore'
-
-export type ApiResponse<T> = {
-  success: boolean
-  message: string
-  data?: T
-  user?: User
-  token?: string
-  apiKey?: string
-  usernames?: string[]
-}
+import type { ApiResponse } from '~/types/api'
 
 export async function performFetch<T = unknown>(
   url: string,
@@ -182,15 +173,15 @@ export enum Role {
 }
 
 export enum StringType {
-  TAG = 'TAG', // single unit tag phrase
-  PROMPT = 'PROMPT', // combined nlp prompt message
-  WILDCARD = 'WILDCARD', // list for randomized generations
-  RESPONSE = 'RESPONSE', // message response nlp to human
-  IMAGE_URL = 'IMAGE_URL', // image url
-  URL = 'URL', // generic web url
-  MASK_URL = 'MASK_URL', // url to an image mask
-  CODE = 'CODE', // validated codewall
-  ERROR = 'ERROR', // An Error message
+  TAG = 'TAG',
+  PROMPT = 'PROMPT',
+  WILDCARD = 'WILDCARD',
+  RESPONSE = 'RESPONSE',
+  IMAGE_URL = 'IMAGE_URL',
+  URL = 'URL',
+  MASK_URL = 'MASK_URL',
+  CODE = 'CODE',
+  ERROR = 'ERROR',
 }
 
 export enum BotType {

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,12 @@
+import type { User } from '~/prisma/generated/prisma/client'
+
+export type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T
+  statusCode?: number
+  user?: User
+  token?: string
+  apiKey?: string
+  usernames?: string[]
+}


### PR DESCRIPTION
## Summary

- Adds a shared `ApiResponse<T>` type in `types/api.ts`
- Updates `stores/utils.ts` to reuse the shared API response type
- Moves Dream PATCH and DELETE routes from direct `validateApiKey` calls to `requireApiUser`
- Adds relation attach checks in Dream PATCH so non-admin users can only connect owned or public ArtImage, ArtCollection, Scenario, Character, and Reward records
- Removes a redundant user lookup from Dream deletion by using the authenticated user returned by the auth guard

## Notes

This is intentionally narrow. It starts the auth/response cleanup without trying to refactor every API route at once.

I did not run the project test suite from here, so please run:

```bash
npm run test
npx cypress run --spec "cypress/e2e/api/dreams.cy.ts"
```

## Follow-ups worth doing next

- Tighten Dream Cypress failure expectations that currently allow multiple statuses
- Move more routes from `validateApiKey` to `requireApiUser` / `getOptionalApiUser`
- Extract relation attach authorization into a shared helper once the Dream implementation proves out
- Add response-shape tests that reject accidental `password`, `token`, or `apiKey` leaks
