### PR TITLE
Add page-level narrator selection

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -2,6 +2,14 @@
 import { defineCollection, defineContentConfig } from '@nuxt/content'
 import * as z from 'zod'
 
+const narratorSchema = z.union([
+  z.string(),
+  z.object({
+    type: z.enum(['bot', 'character']).optional(),
+    slug: z.string(),
+  }),
+])
+
 const contentSchema = z.object({
   title: z.string().optional(),
   room: z.string().optional(),
@@ -12,6 +20,7 @@ const contentSchema = z.object({
   tooltip: z.string().optional(),
   dottitip: z.string().optional(),
   amitip: z.string().optional(),
+  narrator: narratorSchema.optional(),
   artPrompt: z.string().optional(),
   summary: z.string().optional(),
   sort: z.string().optional(),
@@ -65,6 +74,13 @@ export type ContentType = z.infer<typeof contentSchema> & {
   }
 }
 
+export type PageNarratorRef =
+  | string
+  | {
+      type?: 'bot' | 'character'
+      slug: string
+    }
+
 export type PageBrief = {
   title: string
   room: string
@@ -75,6 +91,7 @@ export type PageBrief = {
   tooltip: string
   dottitip: string
   amitip: string
+  narrator?: PageNarratorRef
   artPrompt: string
   dashboardKey?: string
   summary?: string

--- a/content/bots.md
+++ b/content/bots.md
@@ -9,6 +9,7 @@ tooltip: Every bot uses ChatGPT under the hood, generating infinite designer con
 sort: highlight
 dottitip: "I've been meaning to ask you, AMI...What's it like being a robot? I make bots all day, but I can't imagine what what its like to be on the other side of the circuit board."
 amitip: "Uhm, Dotti...I think we might need to have a talk."
+narrator: ami-butterfly
 dashboardKey: bot
 dashboardTab: overview
 cards: botCards
@@ -17,4 +18,3 @@ refreshLabel: Refresh Bots
 ---
 
 :bot-manager
-

--- a/server/api/narrators/[type]/[slug].get.ts
+++ b/server/api/narrators/[type]/[slug].get.ts
@@ -1,0 +1,238 @@
+// /server/api/narrators/[type]/[slug].get.ts
+import { defineEventHandler, createError, getRouterParam } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+
+const defaultNarratorBotId = 433
+
+const artImageSelect = {
+  id: true,
+  fileName: true,
+  fileType: true,
+  path: true,
+  imagePath: true,
+  artPrompt: true,
+  promptString: true,
+}
+
+const expressionMediaSelect = {
+  id: true,
+  expression: true,
+  kind: true,
+  label: true,
+  emoticon: true,
+  expressionKey: true,
+  imagePath: true,
+  message: true,
+  additionalPhrases: true,
+  isActive: true,
+  designer: true,
+  artPrompt: true,
+  ArtImage: {
+    select: artImageSelect,
+  },
+}
+
+function readImagePath(source?: {
+  imagePath?: string | null
+  avatarImage?: string | null
+  ArtImage?: {
+    imagePath?: string | null
+    path?: string | null
+    fileName?: string | null
+  } | null
+} | null) {
+  return (
+    source?.imagePath ||
+    source?.avatarImage ||
+    source?.ArtImage?.imagePath ||
+    source?.ArtImage?.path ||
+    source?.ArtImage?.fileName ||
+    null
+  )
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const type = String(getRouterParam(event, 'type') || '').toLowerCase()
+    const slug = String(getRouterParam(event, 'slug') || '').trim()
+
+    if (!slug) {
+      throw createError({
+        statusCode: 400,
+        message: 'Narrator slug is required.',
+      })
+    }
+
+    if (type !== 'bot' && type !== 'character') {
+      throw createError({
+        statusCode: 400,
+        message: 'Narrator type must be bot or character.',
+      })
+    }
+
+    if (type === 'bot') {
+      const bot = await prisma.bot.findFirst({
+        where: {
+          slug,
+          isActive: true,
+          isPublic: true,
+        },
+        select: {
+          id: true,
+          BotType: true,
+          name: true,
+          slug: true,
+          subtitle: true,
+          description: true,
+          tagline: true,
+          personality: true,
+          avatarImage: true,
+          imagePath: true,
+          artImageId: true,
+          narrativeVoice: true,
+          forgeIntro: true,
+          botIntro: true,
+          userIntro: true,
+          prompt: true,
+          serverId: true,
+          serverName: true,
+          chatBorderImage: true,
+          ArtImage: {
+            select: artImageSelect,
+          },
+          ExpressionMedia: {
+            where: { isActive: true },
+            select: expressionMediaSelect,
+            orderBy: { expression: 'asc' },
+          },
+          NarratorThreads: {
+            where: { isActive: true },
+            orderBy: { sortOrder: 'asc' },
+            include: {
+              Topic: true,
+            },
+          },
+        },
+      })
+
+      if (!bot) {
+        throw createError({
+          statusCode: 404,
+          message: `Narrator bot "${slug}" was not found.`,
+        })
+      }
+
+      const imagePath = readImagePath(bot)
+
+      return {
+        success: true,
+        message: 'Narrator bot loaded.',
+        data: {
+          ...bot,
+          avatarImage: bot.avatarImage || imagePath,
+          imagePath,
+        },
+      }
+    }
+
+    const character = await prisma.character.findFirst({
+      where: {
+        slug,
+        isActive: true,
+        isPublic: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        title: true,
+        role: true,
+        species: true,
+        class: true,
+        personality: true,
+        backstory: true,
+        drive: true,
+        quirks: true,
+        presentation: true,
+        imagePath: true,
+        artImageId: true,
+        ArtImage: {
+          select: artImageSelect,
+        },
+        ExpressionMedia: {
+          where: { isActive: true },
+          select: expressionMediaSelect,
+          orderBy: { expression: 'asc' },
+        },
+      },
+    })
+
+    if (!character) {
+      throw createError({
+        statusCode: 404,
+        message: `Narrator character "${slug}" was not found.`,
+      })
+    }
+
+    const imagePath = readImagePath(character)
+    const descriptor = [
+      character.title,
+      character.role,
+      character.species,
+      character.class,
+    ]
+      .filter(Boolean)
+      .join(' • ')
+
+    return {
+      success: true,
+      message: 'Narrator character loaded.',
+      data: {
+        id: defaultNarratorBotId,
+        sourceCharacterId: character.id,
+        BotType: 'NARRATOR',
+        name: character.name,
+        slug: character.slug,
+        subtitle: character.title || descriptor || null,
+        description: character.backstory || descriptor || null,
+        tagline: character.role || null,
+        personality: character.personality || character.quirks || null,
+        avatarImage: imagePath,
+        imagePath,
+        artImageId: character.artImageId,
+        narrativeVoice: character.presentation || descriptor || null,
+        forgeIntro: character.drive || character.quirks || null,
+        botIntro:
+          character.backstory ||
+          descriptor ||
+          `${character.name} is guiding this page.`,
+        userIntro: `Ask ${character.name} about this page.`,
+        prompt: [
+          `You are ${character.name}, acting as the page narrator for Kind Robots.`,
+          character.personality ? `Personality: ${character.personality}` : '',
+          character.backstory ? `Backstory: ${character.backstory}` : '',
+          character.drive ? `Drive: ${character.drive}` : '',
+          'Stay helpful, vivid, concise, and aware of the current page.',
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        serverId: null,
+        serverName: null,
+        chatBorderImage: null,
+        ExpressionMedia: character.ExpressionMedia,
+        NarratorThreads: [],
+      },
+    }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+
+    return {
+      success: false,
+      message: message || 'Failed to load narrator.',
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/stores/narratorStore.ts
+++ b/stores/narratorStore.ts
@@ -1,24 +1,57 @@
+import { ref, watch } from 'vue'
 import { useNarratorStore as useBaseNarratorStore } from './narratorStore.original'
 import { getBotById } from './helpers/botHelper'
+import { performFetch } from '@/stores/utils'
+import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
+import {
+  usePageStore,
+  type PageNarratorKind,
+  type PageNarratorRef,
+} from '@/stores/pageStore'
 
 const defaultNarratorBotId = 433
 const defaultNarratorSlug = 'ami-butterfly'
+const syntheticPageDreamId = -433
 
 type NarratorStore = ReturnType<typeof useBaseNarratorStore>
 
 type HydratableNarratorStore = NarratorStore & {
   hydrateDefaultNarratorBot: () => Promise<void>
   defaultNarratorHydrationPatched?: boolean
+  pageNarratorHydrationPatched?: boolean
 }
 
 type HydratableBot = {
   id?: number | null
+  name?: string | null
   slug?: string | null
+  BotType?: string | null
   ExpressionMedia?: unknown[] | null
   NarratorThreads?: unknown[] | null
 }
 
+type PageNarratorBot = HydratableBot & {
+  id: number
+  name: string
+}
+
+type NormalizedPageNarratorRef = {
+  type: PageNarratorKind
+  slug: string
+}
+
+type NarratorResolverResponse = {
+  success: boolean
+  message?: string
+  data?: PageNarratorBot | null
+}
+
+type PageNarratorDream = DreamWithRelations & {
+  __pageNarratorDream?: boolean
+}
+
 let hydrationPromise: Promise<void> | null = null
+let savedDreamBeforePageNarrator: DreamWithRelations | null = null
 
 function readBot(input: unknown): HydratableBot | null {
   if (!input || typeof input !== 'object') return null
@@ -39,6 +72,93 @@ function hasExpressionRows(input: unknown): boolean {
   const bot = readBot(input)
 
   return Array.isArray(bot?.ExpressionMedia) && bot.ExpressionMedia.length > 0
+}
+
+function normalizePageNarratorRef(
+  value: PageNarratorRef | null | undefined,
+): NormalizedPageNarratorRef | null {
+  if (typeof value === 'string') {
+    const slug = value.trim()
+    return slug ? { type: 'bot', slug } : null
+  }
+
+  if (!value || typeof value !== 'object') return null
+
+  const slug = String(value.slug || '').trim()
+  if (!slug) return null
+
+  return {
+    type: value.type === 'character' ? 'character' : 'bot',
+    slug,
+  }
+}
+
+async function fetchPageNarrator(ref: NormalizedPageNarratorRef) {
+  const response = (await performFetch<PageNarratorBot>(
+    `/api/narrators/${ref.type}/${encodeURIComponent(ref.slug)}`,
+  )) as NarratorResolverResponse
+
+  if (response.success && response.data) return response.data
+
+  throw new Error(response.message || `Could not load narrator ${ref.slug}.`)
+}
+
+function isSyntheticPageDream(dream?: DreamWithRelations | null): boolean {
+  return Boolean(
+    dream &&
+      dream.id === syntheticPageDreamId &&
+      (dream as PageNarratorDream).__pageNarratorDream,
+  )
+}
+
+function buildPageNarratorDream(
+  pageStore: ReturnType<typeof usePageStore>,
+  narrator: PageNarratorBot,
+): PageNarratorDream {
+  const now = new Date()
+
+  return {
+    id: syntheticPageDreamId,
+    createdAt: now,
+    updatedAt: now,
+    title: pageStore.title || pageStore.room || 'Kind Robots',
+    slug: `page-narrator-${pageStore.lastResolvedPath || 'current'}`,
+    dreamType: 'NARRATOR',
+    description: pageStore.description || pageStore.summary || null,
+    pitch: pageStore.summary || pageStore.description || null,
+    flavorText: pageStore.subtitle || null,
+    examples: null,
+    artPrompt: pageStore.artPrompt || null,
+    imagePath: pageStore.image || null,
+    highlightImage: null,
+    icon: pageStore.icon || 'kind-icon:robot-color',
+    designer: 'system',
+    creationSource: 'HUMAN',
+    userId: 10,
+    isPublic: true,
+    isMature: false,
+    isActive: true,
+    artImageId: null,
+    artCollectionId: null,
+    Bots: [narrator as never],
+    Scenarios: [],
+    Characters: [],
+    Rewards: [],
+    ArtImages: [],
+    ArtCollections: [],
+    Chats: [],
+    Reactions: [],
+    _count: {},
+    __pageNarratorDream: true,
+  } as PageNarratorDream
+}
+
+function restoreSavedDream(dreamStore: ReturnType<typeof useDreamStore>) {
+  if (isSyntheticPageDream(dreamStore.selectedDream)) {
+    dreamStore.selectedDream = savedDreamBeforePageNarrator
+  }
+
+  savedDreamBeforePageNarrator = null
 }
 
 async function hydrateDefaultNarratorBot(store: NarratorStore) {
@@ -70,8 +190,60 @@ async function hydrateDefaultNarratorBot(store: NarratorStore) {
   await hydrationPromise
 }
 
+function patchPageNarratorHydration(store: NarratorStore) {
+  const patchedStore = store as HydratableNarratorStore
+
+  if (patchedStore.pageNarratorHydrationPatched) return
+
+  const pageStore = usePageStore()
+  const dreamStore = useDreamStore()
+  const pageNarratorKey = ref('')
+
+  watch(
+    () => pageStore.narrator,
+    async (value) => {
+      const ref = normalizePageNarratorRef(value)
+      const key = ref ? `${ref.type}:${ref.slug}` : ''
+
+      pageNarratorKey.value = key
+
+      if (!ref) {
+        restoreSavedDream(dreamStore)
+        return
+      }
+
+      try {
+        const narrator = await fetchPageNarrator(ref)
+
+        if (pageNarratorKey.value !== key) return
+
+        if (!isSyntheticPageDream(dreamStore.selectedDream)) {
+          savedDreamBeforePageNarrator = dreamStore.selectedDream
+        }
+
+        dreamStore.selectedDream = buildPageNarratorDream(pageStore, narrator)
+        store.setEmotion(store.currentEmotion, false)
+      } catch (error) {
+        if (pageNarratorKey.value !== key) return
+
+        store.setStatus(
+          error instanceof Error
+            ? error.message
+            : `Could not load narrator ${ref.slug}.`,
+          'error',
+        )
+      }
+    },
+    { immediate: true },
+  )
+
+  patchedStore.pageNarratorHydrationPatched = true
+}
+
 function patchNarratorStore(store: NarratorStore): HydratableNarratorStore {
   const patchedStore = store as HydratableNarratorStore
+
+  patchPageNarratorHydration(store)
 
   if (patchedStore.defaultNarratorHydrationPatched) return patchedStore
 

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -8,6 +8,13 @@ import { useSheetStore } from '@/stores/sheetStore'
 
 export type PageLayoutKey = 'default' | 'minimal' | 'vertical-scroll' | false
 export type WorkspaceCardsInput = string | BuilderCard[]
+export type PageNarratorKind = 'bot' | 'character'
+export type PageNarratorRef =
+  | string
+  | {
+      type?: PageNarratorKind
+      slug: string
+    }
 
 export type WorkspacePage = ContentCollectionItem & {
   cards?: WorkspaceCardsInput
@@ -20,6 +27,7 @@ export type WorkspacePage = ContentCollectionItem & {
   tooltip?: string
   dottitip?: string
   amitip?: string
+  narrator?: PageNarratorRef
   artPrompt?: string
   sort?: string | number
   icon?: string
@@ -53,6 +61,28 @@ function getString(value: unknown): string {
 
 function getCardsKey(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
+}
+
+function getNarratorRef(value: unknown): PageNarratorRef | null {
+  if (typeof value === 'string') {
+    const slug = value.trim()
+    return slug ? slug : null
+  }
+
+  if (!value || typeof value !== 'object') return null
+
+  const record = value as {
+    type?: unknown
+    slug?: unknown
+  }
+
+  const slug = getString(record.slug)
+  if (!slug) return null
+
+  return {
+    type: record.type === 'character' ? 'character' : 'bot',
+    slug,
+  }
 }
 
 export const usePageStore = defineStore('pageStore', () => {
@@ -91,6 +121,7 @@ export const usePageStore = defineStore('pageStore', () => {
     tooltip: getString(currentPage.value?.tooltip),
     dottitip: getString(currentPage.value?.dottitip),
     amitip: getString(currentPage.value?.amitip),
+    narrator: getNarratorRef(currentPage.value?.narrator),
     artPrompt: getString(currentPage.value?.artPrompt),
     sort: currentPage.value?.sort ?? '',
     dashboardKey: getString(currentPage.value?.dashboardKey),
@@ -196,6 +227,7 @@ export const usePageStore = defineStore('pageStore', () => {
     tooltip: computed(() => meta.value.tooltip),
     dottitip: computed(() => meta.value.dottitip),
     amitip: computed(() => meta.value.amitip),
+    narrator: computed(() => meta.value.narrator),
     artPrompt: computed(() => meta.value.artPrompt),
     sort: computed(() => meta.value.sort),
     dashboardKey: computed(() => meta.value.dashboardKey),


### PR DESCRIPTION
## Summary
- adds `narrator` frontmatter support for Nuxt Content pages
- exposes page narrator metadata through `pageStore`
- adds a public narrator resolver route for bot and character slugs
- hydrates the workspace narrator from `page.narrator` before the normal Dream/fallback narrator path
- wires `/bots` to `narrator: ami-butterfly` as a live example

## Notes
- `narrator: ami-butterfly` resolves as a bot selector
- explicit character selectors can use:

```yaml
narrator:
  type: character
  slug: dotti
```

## Testing
- Not run locally from this environment.