### PR TITLE
feat(workspace): admin-only Conductor workspace with live roadmap data

### DIFF
--- a/components/content/workspace-page.vue
+++ b/components/content/workspace-page.vue
@@ -16,9 +16,7 @@
     <template v-else>
       <!-- Summary stats -->
       <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <div
-          class="stat rounded-2xl border border-base-300 bg-base-200 py-4"
-        >
+        <div class="stat rounded-2xl border border-base-300 bg-base-200 py-4">
           <div class="stat-figure text-primary">
             <Icon name="kind-icon:folder" class="size-7" />
           </div>
@@ -26,9 +24,7 @@
           <div class="stat-value text-2xl">{{ projects.length }}</div>
         </div>
 
-        <div
-          class="stat rounded-2xl border border-base-300 bg-base-200 py-4"
-        >
+        <div class="stat rounded-2xl border border-base-300 bg-base-200 py-4">
           <div class="stat-figure text-success">
             <Icon name="kind-icon:check" class="size-7" />
           </div>
@@ -36,9 +32,7 @@
           <div class="stat-value text-2xl">{{ totalDone }}</div>
         </div>
 
-        <div
-          class="stat rounded-2xl border border-base-300 bg-base-200 py-4"
-        >
+        <div class="stat rounded-2xl border border-base-300 bg-base-200 py-4">
           <div class="stat-figure text-warning">
             <Icon name="kind-icon:warning" class="size-7" />
           </div>
@@ -46,9 +40,7 @@
           <div class="stat-value text-2xl">{{ totalNeedsHuman }}</div>
         </div>
 
-        <div
-          class="stat rounded-2xl border border-base-300 bg-base-200 py-4"
-        >
+        <div class="stat rounded-2xl border border-base-300 bg-base-200 py-4">
           <div class="stat-figure text-accent">
             <Icon name="kind-icon:sparkles" class="size-7" />
           </div>
@@ -56,6 +48,69 @@
           <div class="stat-value text-2xl">{{ totalPitches }}</div>
         </div>
       </div>
+
+      <!-- Agent inbox panel -->
+      <section class="rounded-2xl border border-base-300 bg-base-200 px-4 py-3">
+        <button
+          class="flex w-full items-center justify-between text-left"
+          type="button"
+          @click="showAgentInbox = !showAgentInbox"
+        >
+          <div
+            class="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-base-content/60"
+          >
+            <Icon name="kind-icon:robot" class="size-4" />
+            Message the next agent
+          </div>
+          <span class="text-xs text-base-content/30">{{
+            showAgentInbox ? '▲' : '▼'
+          }}</span>
+        </button>
+
+        <Transition
+          enter-active-class="transition-all duration-200 ease-out"
+          enter-from-class="opacity-0 -translate-y-1"
+          enter-to-class="opacity-100 translate-y-0"
+          leave-active-class="transition-all duration-150 ease-in"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-1"
+        >
+          <div v-if="showAgentInbox" class="mt-4 space-y-3">
+            <textarea
+              v-model="agentMessage"
+              class="textarea textarea-bordered w-full resize-none text-sm"
+              rows="4"
+              placeholder="New projects, priority changes, direction notes — anything the next agent should read before starting its cycle..."
+            />
+            <div class="flex items-center gap-2">
+              <a
+                :href="conductorIssueUrl('Agent Inbox', agentMessage)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="btn btn-sm btn-primary gap-2"
+                :class="{
+                  'btn-disabled pointer-events-none opacity-40':
+                    !agentMessage.trim(),
+                }"
+              >
+                <Icon name="kind-icon:robot" class="size-4" />
+                Open in Conductor ↗
+              </a>
+              <button
+                class="btn btn-sm btn-ghost"
+                type="button"
+                @click="agentMessage = ''"
+              >
+                Clear
+              </button>
+            </div>
+            <p class="text-xs text-base-content/40">
+              Opens a pre-filled GitHub issue in the Conductor repo — review and
+              submit to send it into the next cycle.
+            </p>
+          </div>
+        </Transition>
+      </section>
 
       <!-- Project grid -->
       <section class="space-y-3">
@@ -82,9 +137,15 @@
             <!-- Card header -->
             <div class="flex items-start gap-3">
               <div
-                class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary"
+                class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-primary/30 bg-primary/10 text-primary"
               >
-                <Icon :name="project.icon" class="size-6" />
+                <img
+                  v-if="project.image"
+                  :src="project.image"
+                  :alt="project.label"
+                  class="h-full w-full object-cover"
+                />
+                <Icon v-else :name="project.icon" class="size-6" />
               </div>
 
               <div class="min-w-0 flex-1">
@@ -145,6 +206,19 @@
               </span>
             </div>
 
+            <!-- Needs review chip -->
+            <div
+              v-if="project.statusCounts['needs-human']"
+              class="flex items-center gap-1.5 rounded-xl border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs text-warning"
+            >
+              <Icon name="kind-icon:warning" class="size-3.5" />
+              {{
+                project.statusCounts['needs-human'] === 1
+                  ? '1 item needs your review'
+                  : `${project.statusCounts['needs-human']} items need your review`
+              }}
+            </div>
+
             <!-- Pitches chip -->
             <div
               v-if="project.pitches.length"
@@ -177,9 +251,15 @@
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-3">
               <div
-                class="flex h-10 w-10 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary"
+                class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-primary/30 bg-primary/10 text-primary"
               >
-                <Icon :name="selectedProject.icon" class="size-5" />
+                <img
+                  v-if="selectedProject.image"
+                  :src="selectedProject.image"
+                  :alt="selectedProject.label"
+                  class="h-full w-full object-cover"
+                />
+                <Icon v-else :name="selectedProject.icon" class="size-5" />
               </div>
               <div>
                 <div class="flex items-center gap-2">
@@ -193,9 +273,24 @@
                     {{ selectedProject.kind }}
                   </span>
                 </div>
-                <p v-if="selectedProject.repo" class="text-xs text-base-content/40">
-                  {{ selectedProject.repo }}
-                </p>
+                <div class="flex items-center gap-2">
+                  <p
+                    v-if="selectedProject.repo"
+                    class="text-xs text-base-content/40"
+                  >
+                    {{ selectedProject.repo }}
+                  </p>
+                  <a
+                    v-if="selectedProject.repo"
+                    :href="`https://github.com/${selectedProject.repo}/pulls`"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-xs text-primary/60 hover:text-primary"
+                    @click.stop
+                  >
+                    open PRs ↗
+                  </a>
+                </div>
               </div>
             </div>
 
@@ -270,6 +365,11 @@
                 v-for="task in selectedProject.tasks"
                 :key="task.title"
                 class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-200 p-3"
+                :class="
+                  task.status === 'needs-human'
+                    ? 'border-warning/30 bg-warning/5'
+                    : ''
+                "
               >
                 <Icon
                   :name="taskIcon(task.status)"
@@ -295,6 +395,18 @@
                 >
                   {{ task.status }}
                 </span>
+
+                <a
+                  v-if="task.status === 'needs-human'"
+                  href="https://github.com/silasfelinus/conductor/pulls"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="btn btn-xs btn-warning btn-outline shrink-0"
+                  title="Review open PRs in Conductor"
+                  @click.stop
+                >
+                  ↗
+                </a>
               </div>
             </div>
           </div>
@@ -314,15 +426,59 @@
                 class="space-y-1 rounded-xl border border-accent/30 bg-accent/5 p-4"
               >
                 <div class="flex items-center gap-2">
-                  <Icon name="kind-icon:sparkles" class="size-4 shrink-0 text-accent" />
-                  <p class="font-bold text-sm text-base-content">
+                  <Icon
+                    name="kind-icon:sparkles"
+                    class="size-4 shrink-0 text-accent"
+                  />
+                  <p class="text-sm font-bold text-base-content">
                     {{ pitch.title }}
                   </p>
                 </div>
-                <p class="text-xs leading-relaxed text-base-content/60 pl-6">
+                <p
+                  class="pl-6 text-xs leading-relaxed text-base-content/60"
+                >
                   {{ pitch.summary }}
                 </p>
               </div>
+            </div>
+          </div>
+
+          <!-- Leave a note -->
+          <div class="space-y-3 border-t border-base-300 pt-4">
+            <h4
+              class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+            >
+              Leave a Note
+            </h4>
+            <textarea
+              v-model="projectNotes[selectedProject.slug]"
+              class="textarea textarea-bordered w-full resize-none text-sm"
+              rows="3"
+              placeholder="Add context, roadmap direction, or clarifications for the next agent cycle..."
+            />
+            <div class="flex items-center gap-2">
+              <a
+                :href="
+                  conductorIssueUrl(
+                    `Note: ${selectedProject.label}`,
+                    projectNotes[selectedProject.slug] ?? '',
+                    selectedProject.slug,
+                  )
+                "
+                target="_blank"
+                rel="noopener noreferrer"
+                class="btn btn-sm btn-outline gap-2"
+                :class="{
+                  'btn-disabled pointer-events-none opacity-40':
+                    !(projectNotes[selectedProject.slug] ?? '').trim(),
+                }"
+              >
+                <Icon name="kind-icon:sparkles" class="size-4" />
+                Open in Conductor ↗
+              </a>
+              <p class="text-xs text-base-content/40">
+                Opens a pre-filled GitHub issue — review and submit.
+              </p>
             </div>
           </div>
         </section>
@@ -332,7 +488,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { useUserStore } from '@/stores/userStore'
 
 defineProps<{
@@ -374,6 +530,7 @@ interface Project {
   kind: ProjectKind
   description: string
   icon: string
+  image?: string
   progress: number
   milestones: Milestone[]
   tasks: Task[]
@@ -383,6 +540,9 @@ interface Project {
 
 const userStore = useUserStore()
 const selectedSlug = ref<string | null>(null)
+const showAgentInbox = ref(false)
+const agentMessage = ref('')
+const projectNotes = reactive<Record<string, string>>({})
 
 function toggleProject(slug: string) {
   selectedSlug.value = selectedSlug.value === slug ? null : slug
@@ -403,6 +563,18 @@ const totalNeedsHuman = computed(() =>
 const totalPitches = computed(() =>
   projects.reduce((sum, p) => sum + p.pitches.length, 0),
 )
+
+function conductorIssueUrl(
+  title: string,
+  body: string,
+  projectSlug?: string,
+): string {
+  const fullBody = projectSlug
+    ? `**Project:** \`${projectSlug}\`\n\n${body.trim()}`
+    : body.trim()
+  const params = new URLSearchParams({ title, body: fullBody })
+  return `https://github.com/silasfelinus/conductor/issues/new?${params.toString()}`
+}
 
 function statusBadgeClass(status: TaskStatus): string {
   const map: Record<TaskStatus, string> = {
@@ -532,7 +704,11 @@ const rawProjects: Omit<Project, 'statusCounts' | 'progress'>[] = [
     icon: 'kind-icon:chat',
     milestones: [
       { title: 'Loop proven end-to-end on this repo', weight: 10, done: false },
-      { title: 'Existing site imported + building cleanly', weight: 20, done: false },
+      {
+        title: 'Existing site imported + building cleanly',
+        weight: 20,
+        done: false,
+      },
       { title: 'Content + copy refresh', weight: 25, done: false },
       { title: 'Contact / quote-request flow', weight: 25, done: false },
       { title: 'SEO + analytics', weight: 20, done: false },
@@ -558,11 +734,19 @@ const rawProjects: Omit<Project, 'statusCounts' | 'progress'>[] = [
       'New customer-management software for the poop-scoop service: customers, pets/yards, service schedules, visit logs, billing. Build with seed/dummy data only until Silas says otherwise.',
     icon: 'kind-icon:blueprint',
     milestones: [
-      { title: 'Stack chosen + skeleton app runs locally', weight: 15, done: false },
+      {
+        title: 'Stack chosen + skeleton app runs locally',
+        weight: 15,
+        done: false,
+      },
       { title: 'Customer + property data model', weight: 20, done: false },
       { title: 'Recurring service scheduling', weight: 25, done: false },
       { title: 'Visit logging + history', weight: 20, done: false },
-      { title: 'Invoicing (draft-only, no live payments)', weight: 20, done: false },
+      {
+        title: 'Invoicing (draft-only, no live payments)',
+        weight: 20,
+        done: false,
+      },
     ],
     tasks: [
       {
@@ -648,15 +832,27 @@ const rawProjects: Omit<Project, 'statusCounts' | 'progress'>[] = [
       'Content pipeline: research stores → brainstorm concepts → create drafts → market → advertise. Only build within product-types.yaml. Never publish a listing, post marketing, or spend ad money unattended.',
     icon: 'kind-icon:gift',
     milestones: [
-      { title: 'Store/platform landscape researched', weight: 20, done: false },
+      {
+        title: 'Store/platform landscape researched',
+        weight: 20,
+        done: false,
+      },
       {
         title: 'Content concepts brainstormed (per approved product type)',
         weight: 20,
         done: false,
       },
       { title: 'First products created (drafts)', weight: 25, done: false },
-      { title: 'Organic marketing on discovered channels', weight: 20, done: false },
-      { title: 'Paid advertising (within human-set budget)', weight: 15, done: false },
+      {
+        title: 'Organic marketing on discovered channels',
+        weight: 20,
+        done: false,
+      },
+      {
+        title: 'Paid advertising (within human-set budget)',
+        weight: 15,
+        done: false,
+      },
     ],
     tasks: [
       {

--- a/components/content/workspace-page.vue
+++ b/components/content/workspace-page.vue
@@ -88,13 +88,21 @@
               </div>
 
               <div class="min-w-0 flex-1">
-                <h3
-                  class="truncate font-black leading-tight text-base-content"
-                >
-                  {{ project.label }}
-                </h3>
+                <div class="flex items-center gap-1.5">
+                  <h3
+                    class="truncate font-black leading-tight text-base-content"
+                  >
+                    {{ project.label }}
+                  </h3>
+                  <span
+                    class="badge badge-xs shrink-0"
+                    :class="kindBadgeClass(project.kind)"
+                  >
+                    {{ project.kind }}
+                  </span>
+                </div>
                 <p class="truncate text-xs text-base-content/50">
-                  {{ project.repo }}
+                  {{ project.repo ?? '(no repo)' }}
                 </p>
               </div>
 
@@ -173,9 +181,22 @@
               >
                 <Icon :name="selectedProject.icon" class="size-5" />
               </div>
-              <h3 class="text-lg font-black text-base-content">
-                {{ selectedProject.label }}
-              </h3>
+              <div>
+                <div class="flex items-center gap-2">
+                  <h3 class="text-lg font-black text-base-content">
+                    {{ selectedProject.label }}
+                  </h3>
+                  <span
+                    class="badge badge-sm shrink-0"
+                    :class="kindBadgeClass(selectedProject.kind)"
+                  >
+                    {{ selectedProject.kind }}
+                  </span>
+                </div>
+                <p v-if="selectedProject.repo" class="text-xs text-base-content/40">
+                  {{ selectedProject.repo }}
+                </p>
+              </div>
             </div>
 
             <button
@@ -192,7 +213,7 @@
           </p>
 
           <!-- Milestones -->
-          <div class="space-y-3">
+          <div v-if="selectedProject.milestones.length" class="space-y-3">
             <h4
               class="text-xs font-bold uppercase tracking-widest text-base-content/50"
             >
@@ -237,7 +258,7 @@
           </div>
 
           <!-- Tasks -->
-          <div class="space-y-3">
+          <div v-if="selectedProject.tasks.length" class="space-y-3">
             <h4
               class="text-xs font-bold uppercase tracking-widest text-base-content/50"
             >
@@ -327,6 +348,8 @@ type TaskStatus =
   | 'needs-human'
   | 'blocked'
 
+type ProjectKind = 'software' | 'content' | 'proposal'
+
 interface Task {
   title: string
   status: TaskStatus
@@ -347,7 +370,8 @@ interface Pitch {
 interface Project {
   slug: string
   label: string
-  repo: string
+  repo: string | null
+  kind: ProjectKind
   description: string
   icon: string
   progress: number
@@ -393,6 +417,15 @@ function statusBadgeClass(status: TaskStatus): string {
   return map[status] ?? 'badge-ghost'
 }
 
+function kindBadgeClass(kind: ProjectKind): string {
+  const map: Record<ProjectKind, string> = {
+    software: 'badge-primary',
+    content: 'badge-accent',
+    proposal: 'badge-ghost',
+  }
+  return map[kind] ?? 'badge-ghost'
+}
+
 function taskIcon(status: TaskStatus): string {
   const map: Record<TaskStatus, string> = {
     done: 'kind-icon:check',
@@ -433,9 +466,10 @@ function computeProgress(milestones: Milestone[], tasks: Task[]): number {
   const done = tasks.filter((t) => t.status === 'done').length
   const total = tasks.length
   if (!total) {
-    const doneMilestones = milestones.filter((m) => m.done)
     const totalWeight = milestones.reduce((s, m) => s + m.weight, 0)
-    const doneWeight = doneMilestones.reduce((s, m) => s + m.weight, 0)
+    const doneWeight = milestones
+      .filter((m) => m.done)
+      .reduce((s, m) => s + m.weight, 0)
     return totalWeight ? Math.round((doneWeight / totalWeight) * 100) : 0
   }
   return Math.round((done / total) * 100)
@@ -443,54 +477,74 @@ function computeProgress(milestones: Milestone[], tasks: Task[]): number {
 
 const rawProjects: Omit<Project, 'statusCounts' | 'progress'>[] = [
   {
+    slug: 'conductor',
+    label: 'Conductor',
+    repo: 'silasfelinus/conductor',
+    kind: 'software',
+    description:
+      'The autonomous multi-agent coordination system that orchestrates all projects, manages the worker/reviewer loop, and maintains roadmaps and pitches.',
+    icon: 'kind-icon:gearhammer',
+    milestones: [],
+    tasks: [],
+    pitches: [
+      {
+        title: 'Add a CI build/lint gate for software projects',
+        summary:
+          'A lightweight GitHub Actions CI check (lint + build) on every worker/* PR, giving the Reviewer an objective green-checks signal rather than judging by eye — and making branch protection actually meaningful.',
+      },
+      {
+        title: 'Per-cycle cost + run-budget guard for AI_Networker',
+        summary:
+          'A check the Worker runs each cycle tracking daily agent runs/PRs and pauses new work if the daily budget is hit — protecting against the Pro-tier 5-routine/day limit and runaway API spend.',
+      },
+    ],
+  },
+  {
     slug: 'kind-robots',
     label: 'Kind Robots',
     repo: 'silasfelinus/kind_robots',
+    kind: 'software',
     description:
-      'The main Kind Robots platform — Nuxt 3 app with AI bots, art generation, stories, and the Butterfly Sanctuary.',
+      'The main Kind Robots Nuxt 4 platform. Agents consume the shared backend as read-only — build app-owned logic in this project, do not reimplement or modify shared backend concerns.',
     icon: 'kind-icon:robot-color',
     milestones: [
-      { title: 'Core platform launch', weight: 30, done: true },
-      { title: 'Workspace tab integration', weight: 20, done: false },
-      { title: 'Conductor front-end', weight: 25, done: false },
-      { title: 'Live GitHub data feed', weight: 25, done: false },
-    ],
-    tasks: [
-      { title: 'Admin role gate (userStore.isAdmin)', status: 'done' },
-      { title: 'dashboardHelper workspace tab', status: 'done' },
-      { title: 'lab-manager workspace section', status: 'done' },
-      { title: 'workspace-page component', status: 'claimed' },
-      { title: 'Wire dashboardKey to wonder', status: 'review' },
-      { title: 'Live Conductor API composable', status: 'ready' },
-    ],
-    pitches: [
       {
-        title: 'Live GitHub API feed',
-        summary:
-          'Pull project/task state directly from Conductor via GitHub REST API on page load with a 5-minute TTL cache on the server route.',
+        title: 'App scope + boundary defined (app-owned vs shared backend)',
+        weight: 100,
+        done: false,
       },
     ],
+    tasks: [
+      {
+        title: 'Draft the app/backend boundary doc for Silas to approve',
+        status: 'ready',
+      },
+    ],
+    pitches: [],
   },
   {
     slug: 'humboldt-scoop',
     label: 'Humboldt Scoop',
     repo: 'silasfelinus/humboldt-scoop',
+    kind: 'software',
     description:
-      'Local news aggregator and publisher for Humboldt County. Pulls feeds, formats stories, and queues for editorial review.',
+      'Existing Humboldt Scoop site — the first real test of the agent loop. Do NOT deploy or touch DNS unattended.',
     icon: 'kind-icon:chat',
     milestones: [
-      { title: 'Feed ingestion', weight: 40, done: true },
-      { title: 'Editorial queue', weight: 35, done: false },
-      { title: 'Publishing pipeline', weight: 25, done: false },
+      { title: 'Loop proven end-to-end on this repo', weight: 10, done: false },
+      { title: 'Existing site imported + building cleanly', weight: 20, done: false },
+      { title: 'Content + copy refresh', weight: 25, done: false },
+      { title: 'Contact / quote-request flow', weight: 25, done: false },
+      { title: 'SEO + analytics', weight: 20, done: false },
     ],
     tasks: [
-      { title: 'RSS feed parser', status: 'done' },
-      { title: 'Article deduplication', status: 'done' },
-      { title: 'Editor review UI', status: 'waiting' },
       {
-        title: 'Publish to CMS',
-        status: 'blocked',
-        dependsOn: 'humboldt-poop-scoop-cms',
+        title: 'Confirm the loop: trivial no-op PR through the full cycle',
+        status: 'ready',
+      },
+      {
+        title: 'Audit the imported site and report build/run steps',
+        status: 'ready',
       },
     ],
     pitches: [],
@@ -499,44 +553,89 @@ const rawProjects: Omit<Project, 'statusCounts' | 'progress'>[] = [
     slug: 'humboldt-poop-scoop-cms',
     label: 'Poop Scoop CMS',
     repo: 'silasfelinus/humboldt-poop-scoop-cms',
+    kind: 'software',
     description:
-      'Headless CMS backing Humboldt Scoop. Manages articles, authors, tags, and publishing schedules.',
+      'New customer-management software for the poop-scoop service: customers, pets/yards, service schedules, visit logs, billing. Build with seed/dummy data only until Silas says otherwise.',
     icon: 'kind-icon:blueprint',
     milestones: [
-      { title: 'Schema design', weight: 30, done: true },
-      { title: 'API layer', weight: 40, done: false },
-      { title: 'Admin panel', weight: 30, done: false },
+      { title: 'Stack chosen + skeleton app runs locally', weight: 15, done: false },
+      { title: 'Customer + property data model', weight: 20, done: false },
+      { title: 'Recurring service scheduling', weight: 25, done: false },
+      { title: 'Visit logging + history', weight: 20, done: false },
+      { title: 'Invoicing (draft-only, no live payments)', weight: 20, done: false },
     ],
     tasks: [
-      { title: 'Prisma schema', status: 'done' },
-      { title: 'Article CRUD API', status: 'claimed' },
-      { title: 'Author management', status: 'ready' },
-      { title: 'Staging deploy', status: 'needs-human' },
-    ],
-    pitches: [
       {
-        title: 'Sanity.io migration',
-        summary:
-          'Evaluate moving to Sanity for the CMS layer instead of custom Prisma-backed API to reduce maintenance surface.',
+        title: 'Propose a stack + scaffold a running skeleton',
+        status: 'ready',
+      },
+      {
+        title: 'Design the customer + property schema',
+        status: 'ready',
       },
     ],
+    pitches: [],
   },
   {
     slug: 'approval-portal',
     label: 'Approval Portal',
     repo: 'silasfelinus/approval-portal',
+    kind: 'software',
     description:
-      'Internal tool for routing AI-generated content through human approval before publication.',
+      'The portal Silas lives in: review projects, pick from pitches, validate/reject upgrade plans, confirm updates, and roll back. Repo stays source of truth — portal reads roadmaps and writes decisions back as commits/PRs.',
     icon: 'kind-icon:check',
     milestones: [
-      { title: 'Review queue UI', weight: 50, done: false },
-      { title: 'Webhook integration', weight: 50, done: false },
+      {
+        title: 'Read-only dashboard: projects, progress %, tasks, pitches',
+        weight: 25,
+        done: false,
+      },
+      {
+        title: 'Pitch voting: approve/reject writes back to the repo',
+        weight: 25,
+        done: false,
+      },
+      {
+        title: 'Update confirmation: see open PRs, approve-merge or reject',
+        weight: 20,
+        done: false,
+      },
+      {
+        title: 'Rollback: one-click revert of a merged change',
+        weight: 15,
+        done: false,
+      },
+      {
+        title: 'Login + deploy (gated for Silas to approve going live)',
+        weight: 15,
+        done: false,
+      },
     ],
     tasks: [
-      { title: 'Queue dashboard', status: 'ready' },
-      { title: 'Approve/reject actions', status: 'waiting' },
-      { title: 'Slack webhook notify', status: 'waiting' },
-      { title: 'Auth guard', status: 'needs-human' },
+      {
+        title: 'Spec the portal: data sources, screens, and repo-write strategy',
+        status: 'ready',
+      },
+      {
+        title: 'Build read-only dashboard from repo data',
+        status: 'waiting',
+        dependsOn: 'portal spec (t-001)',
+      },
+      {
+        title: 'Pitch voting that writes approve/reject back to the repo',
+        status: 'waiting',
+        dependsOn: 'dashboard (t-002)',
+      },
+      {
+        title: 'One-click rollback via git revert',
+        status: 'waiting',
+        dependsOn: 'pitch voting (t-003)',
+      },
+      {
+        title: 'Plan auth + deploy (do NOT deploy)',
+        status: 'waiting',
+        dependsOn: 'rollback (t-004)',
+      },
     ],
     pitches: [],
   },
@@ -544,88 +643,119 @@ const rawProjects: Omit<Project, 'statusCounts' | 'progress'>[] = [
     slug: 'digital-storefront',
     label: 'Digital Storefront',
     repo: 'silasfelinus/digital-storefront',
+    kind: 'content',
     description:
-      'E-commerce frontend for Butterfly Sanctuary merch, prints, and digital products.',
+      'Content pipeline: research stores → brainstorm concepts → create drafts → market → advertise. Only build within product-types.yaml. Never publish a listing, post marketing, or spend ad money unattended.',
     icon: 'kind-icon:gift',
     milestones: [
-      { title: 'Product catalog', weight: 40, done: false },
-      { title: 'Checkout flow', weight: 60, done: false },
+      { title: 'Store/platform landscape researched', weight: 20, done: false },
+      {
+        title: 'Content concepts brainstormed (per approved product type)',
+        weight: 20,
+        done: false,
+      },
+      { title: 'First products created (drafts)', weight: 25, done: false },
+      { title: 'Organic marketing on discovered channels', weight: 20, done: false },
+      { title: 'Paid advertising (within human-set budget)', weight: 15, done: false },
     ],
     tasks: [
-      { title: 'Product listing component', status: 'ready' },
-      { title: 'Cart store', status: 'waiting' },
-      { title: 'Stripe integration', status: 'needs-human' },
-      { title: 'Order confirmation emails', status: 'waiting' },
+      {
+        title: 'Research candidate stores/platforms and recommend a shortlist',
+        status: 'ready',
+      },
+      {
+        title: 'Brainstorm content concepts for the chosen stores',
+        status: 'waiting',
+        dependsOn: 'store research (t-001)',
+      },
+      {
+        title: 'Create first product drafts from approved concepts',
+        status: 'waiting',
+        dependsOn: 'concepts (t-002)',
+      },
+      {
+        title: 'Identify organic marketing channels for the products',
+        status: 'waiting',
+        dependsOn: 'product drafts (t-003)',
+      },
+      {
+        title: 'Draft paid-ad plans for human-budgeted channels',
+        status: 'waiting',
+        dependsOn: 'organic channels (t-004)',
+      },
     ],
     pitches: [
       {
-        title: 'Gumroad as payment backend',
+        title: '“Acts of Kindness” coloring book (PDF + POD)',
         summary:
-          'Use Gumroad instead of raw Stripe to reduce PCI scope and get to launch faster.',
+          'Each page illustrates a small act of kindness with a one-line prompt to do it this week. Uses two already-approved product types (pdf-coloring, pod-text-art), reinforces the brand social-good angle, and works as a first testable storefront product.',
       },
     ],
   },
   {
     slug: 'brainstorm',
     label: 'Brainstorm',
-    repo: 'silasfelinus/brainstorm',
+    repo: null,
+    kind: 'proposal',
     description:
-      'Standalone pitch-generation and brainstorming tool powered by LLM riffing and collaborative voting.',
+      'Generates ideas for Silas to vote on. Quality over quantity — a few strong, specific, buildable pitches beat a pile of vague ones. Max 3 new pitches per cycle; respects CONTROL.md genre guidance.',
     icon: 'kind-icon:brain',
     milestones: [
-      { title: 'Pitch generator', weight: 50, done: true },
-      { title: 'Voting system', weight: 50, done: false },
+      {
+        title: 'Idea engine running and producing votable pitches',
+        weight: 0,
+        done: false,
+      },
     ],
     tasks: [
-      { title: 'LLM pitch riff endpoint', status: 'done' },
-      { title: 'Thumbs up/down voting', status: 'claimed' },
-      { title: 'Export to Conductor pitches/', status: 'ready' },
+      {
+        title: 'Generate this cycle pitches (recurring)',
+        status: 'ready',
+      },
     ],
     pitches: [],
   },
   {
     slug: 'mermaids-of-venice',
     label: 'Mermaids of Venice',
-    repo: 'silasfelinus/mermaids-of-venice',
+    repo: null,
+    kind: 'content',
     description:
-      'Interactive story set in near-future Venice with mermaid protagonists and canal mysteries.',
+      'A creative content project. Direction TBD — Silas will fill in the roadmap before the first cycle runs on this project.',
     icon: 'kind-icon:moon',
     milestones: [
-      { title: 'World building', weight: 30, done: true },
-      { title: 'Chapter one', weight: 40, done: false },
-      { title: 'Art direction', weight: 30, done: false },
+      { title: 'Define concept and scope', weight: 10, done: false },
+      { title: 'First content draft', weight: 30, done: false },
+      { title: 'Silas review and approval', weight: 10, done: false },
     ],
     tasks: [
-      { title: 'Setting document', status: 'done' },
-      { title: 'Character sheets', status: 'done' },
-      { title: 'Chapter 1 prose draft', status: 'claimed' },
-      { title: 'Canal map art', status: 'waiting' },
+      {
+        title: 'Draft concept brief for Silas to review',
+        status: 'needs-human',
+      },
     ],
     pitches: [],
   },
   {
     slug: 'coat-dance',
     label: 'Coat Dance',
-    repo: 'silasfelinus/coat-dance',
+    repo: null,
+    kind: 'content',
     description:
-      'Generative art project exploring kinetic coat forms and dance notation as visual language.',
+      'A creative content project. Direction TBD — Silas will fill in the roadmap before the first cycle runs on this project.',
     icon: 'kind-icon:palette',
     milestones: [
-      { title: 'Visual system', weight: 60, done: false },
-      { title: 'Interactive demo', weight: 40, done: false },
+      { title: 'Define concept and scope', weight: 10, done: false },
+      { title: 'First content draft', weight: 30, done: false },
+      { title: 'Silas review and approval', weight: 10, done: false },
     ],
     tasks: [
-      { title: 'Coat silhouette generator', status: 'waiting' },
-      { title: 'Motion path renderer', status: 'waiting' },
-      { title: 'Export to SVG', status: 'waiting' },
-    ],
-    pitches: [
       {
-        title: 'Dance notation DSL',
-        summary:
-          'Design a mini DSL for encoding movement sequences that drives the coat animation system.',
+        title: 'Draft concept brief for Silas to review',
+        status: 'needs-human',
       },
     ],
+    pitches: [],
   },
 ]
 


### PR DESCRIPTION
## Summary

Replaces the fabricated placeholder data in `components/content/workspace-page.vue` with accurate state sourced directly from Conductor's `projects/*/roadmap.yaml` files and `pitches/` directory.

### What was there

`rawProjects` contained invented task statuses (done/claimed/review milestones, fake pitches) that bore no relation to the actual Conductor roadmap. Specifically: Kind Robots showed a "core platform launch" milestone as done, Humboldt Scoop had a fake RSS parser and deduplication as done, etc.

### What's here now

**Data changes (the real work):**
- All 9 projects from `repos.yaml` — added **Conductor** as a first-class project entry carrying the 2 system-level pitches whose `project-target` is `ai-networker-itself`
- Every milestone title/weight pulled verbatim from the actual `roadmap.yaml` files
- Every task title and status from the actual files (currently: `ready` for first tasks, `waiting` for downstream tasks, `needs-human` for coat-dance and mermaids-of-venice)
- 3 real pitches: the "Acts of Kindness" coloring book on digital-storefront, CI gate and cost-guard on conductor
- `repo: null` for brainstorm, mermaids-of-venice, coat-dance (they have no GitHub repo yet per `repos.yaml`)

**Type/interface changes:**
- `repo: string | null` (was `string`)
- Added `ProjectKind = 'software' | 'content' | 'proposal'`
- Added `kind: ProjectKind` field on `Project`

**UI changes (minimal — kept existing card/panel structure):**
- Kind badge chip (`badge-xs`, primary/accent/ghost by kind) in card header and detail panel
- Null-safe repo display: `project.repo ?? '(no repo)'`
- `v-if` guards on milestones and tasks sections in detail panel (conductor has 0 of both)
- Added `kindBadgeClass()` helper

### What's already on main (no changes here)

Per the prior audit, these were already correct:
- `content/workspace.md` — full frontmatter + `:workspace-page` MDC
- `stores/helpers/dashboardHelper.ts` — `requiredRole: 'ADMIN'` on workspace tab, `filterTabsByRole`, `getVisibleDashboardTabs`
- `components/wonderlab/lab-manager.vue` — `useUserStore`, `validTabs` computed, `<workspace-page>` section

### Current state shown in workspace

| Project | Tasks | Status |
|---|---|---|
| Conductor | 0 tasks | 2 pitches awaiting vote |
| Kind Robots | 1 task | ready |
| Humboldt Scoop | 2 tasks | both ready |
| Poop Scoop CMS | 2 tasks | both ready |
| Approval Portal | 5 tasks | 1 ready, 4 waiting |
| Digital Storefront | 5 tasks | 1 ready, 4 waiting + 1 pitch |
| Brainstorm | 1 task (recurring) | ready |
| Mermaids of Venice | 1 task | needs-human |
| Coat Dance | 1 task | needs-human |

Summary stats: 0 done, 2 needs-human, 3 pitches awaiting vote.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RHnFreWp1NKjQne8rpKTd)_