### PR TITLE
Add project-specific fields and status tracking to Dream model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -396,6 +396,13 @@ model Dream {
   examples        String?         @db.LongText
   artPrompt       String?         @db.Text
   imagePath       String?         @db.Text
+  cardPath        String?         @db.Text
+  heroPath        String?         @db.Text
+  // ── Project-specific (dreamType = PROJECT) ────────────────────────────────
+  projectStatus   ProjectStatus?
+  repoUrl         String?         @db.VarChar(512)
+  liveUrl         String?         @db.VarChar(512)
+  allowReviews    Boolean         @default(false)
   highlightImage  String?         @db.VarChar(256)
   icon            String?
   designer        String?         @db.VarChar(256)
@@ -437,6 +444,7 @@ model Dream {
   @@index([isPublic])
   @@index([isActive])
   @@index([artCollectionId])
+  @@index([projectStatus])
 
 
 }
@@ -1360,11 +1368,19 @@ enum DreamType {
   PROMPTBOT
   NARRATOR
   CHARACTER
+  PROJECT
   REWARD
   SCENARIO
   LOCATION
   PITCH
   GENRE
+}
+
+enum ProjectStatus {
+  ACTIVE
+  PAUSED
+  DONE
+  ARCHIVED
 }
 
 enum Reaction_reactionCategory {


### PR DESCRIPTION
## Summary
Extended the Dream model to support project-type dreams with dedicated fields for project management, including status tracking, repository and live URLs, and review permissions.

## Key Changes
- Added `cardPath` and `heroPath` fields for project-specific image assets
- Introduced `ProjectStatus` enum with states: ACTIVE, PAUSED, DONE, ARCHIVED
- Added project-specific fields to Dream model:
  - `projectStatus`: Tracks the current state of a project dream
  - `repoUrl`: Stores the repository URL (up to 512 characters)
  - `liveUrl`: Stores the live deployment URL (up to 512 characters)
  - `allowReviews`: Boolean flag to control whether reviews are enabled (defaults to false)
- Added `PROJECT` to the `DreamType` enum
- Created database index on `projectStatus` field for query optimization

## Implementation Details
- Project-specific fields are grouped with a comment marker for clarity
- All new URL fields use `VarChar(512)` for database efficiency
- Image path fields use `Text` type for flexibility
- The `allowReviews` field defaults to false for safety
- Index on `projectStatus` enables efficient filtering of projects by their status

https://claude.ai/code/session_01W2xz6jkipVWCmcrRLnNEBW