### PR TITLE
Promote Conductor workspace navigation and project heroes

### DIFF
--- a/content/conductor.md
+++ b/content/conductor.md
@@ -1,0 +1,19 @@
+---
+title: 'Conductor'
+room: 'Conductor'
+subtitle: 'Your Private Agent Cockpit'
+description: A first-class control panel for the Conductor agent network — project progress, pitch voting, task gates, roadmap state, and what needs your attention.
+image: https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images/approval-portal-hero.webp
+tooltip: Review agent work, vote on pitches, inspect project state, and keep the human in the loop.
+icon: kind-icon:gearhammer
+sort: highlight
+dottitip: "So this is where the tiny robot managers file their little task reports?"
+amitip: "Yes. It is equal parts bridge, cockpit, clipboard, and emergency goblin containment protocol. Very professional. Mostly."
+dashboardKey: wonder
+dashboardTab: workspace
+cards: labCards
+loadingMessage: Loading conductor...
+refreshLabel: Refresh Conductor
+---
+
+:workspace-page

--- a/plugins/workspace-sheet-hero.client.ts
+++ b/plugins/workspace-sheet-hero.client.ts
@@ -1,0 +1,192 @@
+import { computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
+import { usePageStore } from '@/stores/pageStore'
+import { useSheetStore } from '@/stores/sheetStore'
+import type { BuilderCard } from '@/stores/helpers/builderCards'
+
+const PROJECT_IMAGE_BASE = 'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
+const WORKSPACE_OVERVIEW_HERO = '/images/dashboard-tabs/wonder/workspace.webp'
+
+type SheetProfile = {
+  key: string
+  label: string
+  title: string
+  narrative: string
+  imagePath: string
+  icon: string
+}
+
+type ImageRecord = Record<string, unknown>
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function firstString(values: unknown[]): string {
+  const found = values.find((value) => stringValue(value).length > 0)
+  return stringValue(found)
+}
+
+function recordValue(value: unknown): ImageRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as ImageRecord)
+    : null
+}
+
+function conductorImagePath(slug: string, kind: 'icon' | 'card' | 'hero'): string {
+  return slug ? `${PROJECT_IMAGE_BASE}/${slug}-${kind}.webp` : ''
+}
+
+function dreamImagePath(dream: DreamWithRelations | null, slug: string): string {
+  return firstString([
+    dream?.heroPath,
+    dream?.cardPath,
+    dream?.imagePath,
+    dream?.highlightImage,
+    dream?.ArtImage?.imagePath,
+    dream?.ArtImage?.path,
+    dream?.ArtImage?.fileName,
+    dream?.ArtImages?.[0]?.imagePath,
+    conductorImagePath(slug, 'hero'),
+  ])
+}
+
+function cardImagePath(card: BuilderCard | null): string {
+  const payload = recordValue(card?.payload)
+
+  return firstString([
+    card?.heroImage,
+    card?.deckImage,
+    card?.image,
+    card?.imagePath,
+    card?.splashImage,
+    payload?.heroImage,
+    payload?.deckImage,
+    payload?.image,
+    payload?.imagePath,
+    payload?.splashImage,
+  ])
+}
+
+function profileFromDream(
+  key: string,
+  card: BuilderCard | null,
+  dream: DreamWithRelations | null,
+): SheetProfile {
+  const title = firstString([dream?.title, card?.title, card?.label, key])
+  const narrative = firstString([
+    dream?.description,
+    dream?.pitch,
+    dream?.flavorText,
+    card?.narrative,
+    card?.tagline,
+    card?.title,
+  ])
+
+  return {
+    key,
+    label: firstString([card?.label, dream?.projectStatus, 'Project']),
+    title,
+    narrative,
+    imagePath: firstString([dreamImagePath(dream, key), cardImagePath(card)]),
+    icon: firstString([dream?.icon, card?.icon, 'kind-icon:gearhammer']),
+  }
+}
+
+function overviewProfile(card: BuilderCard | null): SheetProfile {
+  return {
+    key: 'overview',
+    label: 'Workspace',
+    title: firstString([card?.title, 'Conductor Workspace']),
+    narrative: firstString([
+      card?.narrative,
+      card?.tagline,
+      'The private cockpit for the Conductor loop: project progress, pitches awaiting your vote, and what needs a human.',
+    ]),
+    imagePath: firstString([cardImagePath(card), WORKSPACE_OVERVIEW_HERO]),
+    icon: firstString([card?.icon, 'kind-icon:gearhammer']),
+  }
+}
+
+function brainstormProfile(card: BuilderCard | null, dream: DreamWithRelations | null): SheetProfile {
+  return {
+    ...profileFromDream('brainstorm', card, dream),
+    label: firstString([card?.label, 'Brainstorm']),
+    title: firstString([card?.title, dream?.title, 'Brainstorm']),
+    narrative: firstString([
+      dream?.description,
+      dream?.pitch,
+      card?.narrative,
+      card?.tagline,
+      'Review generated pitches, sort future project ideas, and decide what deserves agent attention next.',
+    ]),
+    imagePath: firstString([
+      dreamImagePath(dream, 'brainstorm'),
+      cardImagePath(card),
+      conductorImagePath('brainstorm', 'hero'),
+    ]),
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  const route = useRoute()
+  const dreamStore = useDreamStore()
+  const pageStore = usePageStore()
+  const sheetStore = useSheetStore()
+
+  const isWorkspace = computed(() => {
+    return (
+      route.path === '/workspace' ||
+      (pageStore.dashboardKey === 'wonder' && pageStore.dashboardTab === 'workspace')
+    )
+  })
+
+  const activeKey = computed(() => pageStore.workspaceCardKey || 'overview')
+
+  const activeCard = computed(() => {
+    return pageStore.cards.find((card) => card.key === activeKey.value) ?? null
+  })
+
+  const activeDream = computed(() => {
+    return dreamStore.projectDreams.find((dream) => dream.slug === activeKey.value) ?? null
+  })
+
+  const sheetProfile = computed<SheetProfile | null>(() => {
+    if (!isWorkspace.value) return null
+
+    if (activeKey.value === 'overview') {
+      return overviewProfile(activeCard.value)
+    }
+
+    if (activeKey.value === 'brainstorm') {
+      return brainstormProfile(activeCard.value, activeDream.value)
+    }
+
+    return profileFromDream(activeKey.value, activeCard.value, activeDream.value)
+  })
+
+  watch(
+    sheetProfile,
+    (profile) => {
+      const currentSource = sheetStore.override?.source ?? ''
+
+      if (!profile) {
+        if (currentSource.startsWith('workspace-page:')) {
+          sheetStore.clearSheet(currentSource)
+        }
+        return
+      }
+
+      sheetStore.setSheet({
+        source: `workspace-page:${profile.key}`,
+        label: profile.label,
+        title: profile.title,
+        narrative: profile.narrative,
+        imagePath: profile.imagePath,
+        icon: profile.icon,
+      })
+    },
+    { immediate: true },
+  )
+})

--- a/plugins/workspace-sheet-hero.client.ts
+++ b/plugins/workspace-sheet-hero.client.ts
@@ -19,6 +19,12 @@ type SheetProfile = {
 
 type ImageRecord = Record<string, unknown>
 
+type ImageCard = BuilderCard & {
+  image?: string
+  imagePath?: string
+  splashImage?: string
+}
+
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
@@ -39,28 +45,34 @@ function conductorImagePath(slug: string, kind: 'icon' | 'card' | 'hero'): strin
 }
 
 function dreamImagePath(dream: DreamWithRelations | null, slug: string): string {
+  const artImage = recordValue(dream?.ArtImage)
+  const firstArtImage = recordValue(dream?.ArtImages?.[0])
+
   return firstString([
     dream?.heroPath,
     dream?.cardPath,
     dream?.imagePath,
     dream?.highlightImage,
-    dream?.ArtImage?.imagePath,
-    dream?.ArtImage?.path,
-    dream?.ArtImage?.fileName,
-    dream?.ArtImages?.[0]?.imagePath,
+    artImage?.imagePath,
+    artImage?.path,
+    artImage?.fileName,
+    firstArtImage?.imagePath,
+    firstArtImage?.path,
+    firstArtImage?.fileName,
     conductorImagePath(slug, 'hero'),
   ])
 }
 
 function cardImagePath(card: BuilderCard | null): string {
+  const imageCard = card as ImageCard | null
   const payload = recordValue(card?.payload)
 
   return firstString([
-    card?.heroImage,
-    card?.deckImage,
-    card?.image,
-    card?.imagePath,
-    card?.splashImage,
+    imageCard?.heroImage,
+    imageCard?.deckImage,
+    imageCard?.image,
+    imageCard?.imagePath,
+    imageCard?.splashImage,
     payload?.heroImage,
     payload?.deckImage,
     payload?.image,

--- a/plugins/workspace-sheet-hero.client.ts
+++ b/plugins/workspace-sheet-hero.client.ts
@@ -109,7 +109,7 @@ function profileFromDream(
 function overviewProfile(card: BuilderCard | null): SheetProfile {
   return {
     key: 'overview',
-    label: 'Workspace',
+    label: 'Conductor',
     title: firstString([card?.title, 'Conductor Workspace']),
     narrative: firstString([
       card?.narrative,
@@ -149,6 +149,7 @@ export default defineNuxtPlugin(() => {
 
   const isWorkspace = computed(() => {
     return (
+      route.path === '/conductor' ||
       route.path === '/workspace' ||
       (pageStore.dashboardKey === 'wonder' && pageStore.dashboardTab === 'workspace')
     )

--- a/server/api/conductor/projects.get.ts
+++ b/server/api/conductor/projects.get.ts
@@ -5,6 +5,8 @@ import { defineEventHandler, createError } from 'h3'
 const GITHUB_API = 'https://api.github.com'
 const OWNER = 'silasfelinus'
 const REPO = 'conductor'
+const CONDUCTOR_RAW_BASE = `https://raw.githubusercontent.com/${OWNER}/${REPO}/main`
+const PROJECT_IMAGE_BASE = `${CONDUCTOR_RAW_BASE}/projects/images`
 
 export interface ConductorMilestone {
   id: string
@@ -24,6 +26,12 @@ export interface ConductorTask {
   gateHuman: boolean
 }
 
+export interface ConductorProjectAssets {
+  imagePath: string
+  cardPath: string
+  heroPath: string
+}
+
 export interface ConductorProject {
   slug: string
   name: string
@@ -31,6 +39,9 @@ export interface ConductorProject {
   milestones: ConductorMilestone[]
   tasks: ConductorTask[]
   progress: number
+  imagePath: string
+  cardPath: string
+  heroPath: string
   notesFromSilas?: string
 }
 
@@ -68,6 +79,14 @@ function b64decode(b64: string): string {
   return Buffer.from(b64.replace(/\n/g, ''), 'base64').toString('utf-8')
 }
 
+function conductorProjectAssets(slug: string): ConductorProjectAssets {
+  return {
+    imagePath: `${PROJECT_IMAGE_BASE}/${slug}-icon.webp`,
+    cardPath: `${PROJECT_IMAGE_BASE}/${slug}-card.webp`,
+    heroPath: `${PROJECT_IMAGE_BASE}/${slug}-hero.webp`,
+  }
+}
+
 function computeProgress(milestones: ConductorMilestone[]): number {
   if (!milestones.length) return 0
   let total = 0
@@ -80,7 +99,7 @@ function computeProgress(milestones: ConductorMilestone[]): number {
   return total > 0 ? Math.round((done / total) * 100) : 0
 }
 
-function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progress'> {
+function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progress' | keyof ConductorProjectAssets> {
   const lines = text.split('\n')
   const result = {
     name: '',
@@ -94,10 +113,8 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
   while (i < lines.length) {
     const line = lines[i]!
 
-    // Skip blank lines and comments
     if (!line.trim() || line.trim().startsWith('#')) { i++; continue }
 
-    // Top-level scalars
     const scalar = line.match(/^(project|kind):\s*(.+)$/)
     if (scalar) {
       const val = scalar[2]!.replace(/^["']|["']$/g, '').trim()
@@ -106,7 +123,6 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
       i++; continue
     }
 
-    // notes_from_silas: |
     if (/^notes_from_silas:\s*\|/.test(line)) {
       const buf: string[] = []
       i++
@@ -118,7 +134,6 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
       continue
     }
 
-    // milestones:
     if (/^milestones:/.test(line)) {
       i++
       while (i < lines.length && /^  - /.test(lines[i]!)) {
@@ -141,7 +156,6 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
       continue
     }
 
-    // tasks:
     if (/^tasks:/.test(line)) {
       i++
       while (i < lines.length && /^  - /.test(lines[i]!)) {
@@ -150,7 +164,6 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
         i++
         while (i < lines.length && /^    /.test(lines[i]!)) {
           const tline = lines[i]!
-          // skip multiline strings (note: > or |)
           if (/^    \w+:\s*[>|]/.test(tline)) {
             i++
             while (i < lines.length && /^      /.test(lines[i]!)) i++
@@ -248,6 +261,7 @@ export default defineEventHandler(async (): Promise<ConductorData> => {
             return {
               slug,
               ...parsed,
+              ...conductorProjectAssets(slug),
               name: parsed.name || slug,
               progress: computeProgress(parsed.milestones),
             } satisfies ConductorProject

--- a/stores/helpers/navCards.ts
+++ b/stores/helpers/navCards.ts
@@ -22,16 +22,57 @@ export {
   NAV_IMAGE_EXTENSION,
 }
 
-export const NAV_CARDS: NavCard[] = dashboardConfigs.footer.tabs.map((tab) => {
-  const key = tab.key as FooterKey
+const CONDUCTOR_IMAGE_BASE =
+  'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
 
-  return {
-    ...deriveNavCard(tab, {
-      path: footerRouteMap[key],
-      dashboardKey: footerDashboardMap[key],
-      imageDir: 'nav/heroes',
-    }),
-    deckImage: getNavThumbImagePath(key),
-    heroImage: getNavHeroImagePath(key),
-  }
-})
+export const CONDUCTOR_NAV_CARD: NavCard = {
+  key: 'conductor',
+  label: 'Conductor',
+  title: 'Conductor',
+  icon: 'kind-icon:gearhammer',
+  flourish: '⚙',
+  deckImage: `${CONDUCTOR_IMAGE_BASE}/approval-portal-card.webp`,
+  heroImage: `${CONDUCTOR_IMAGE_BASE}/approval-portal-hero.webp`,
+  tagline: 'Steer agents, review work, and keep the human in the loop.',
+  narrative:
+    'Open the Conductor cockpit: project progress, pitches awaiting your vote, task gates, roadmap state, and the parts of the agent loop that need a human with a clipboard.',
+  required: false,
+  restoresFields: [],
+  unlockCondition: 'always',
+  payload: {
+    path: '/conductor',
+    dashboardKey: 'wonder',
+    tab: 'workspace',
+  },
+  steps: [
+    {
+      key: 'conductor',
+      title: 'Conductor',
+      narrative:
+        'Steer the agent loop, review project state, and decide what deserves human approval next.',
+      inputType: 'custom',
+      payload: {
+        path: '/conductor',
+        dashboardKey: 'wonder',
+        tab: 'workspace',
+      },
+    },
+  ],
+}
+
+export const NAV_CARDS: NavCard[] = [
+  ...dashboardConfigs.footer.tabs.map((tab) => {
+    const key = tab.key as FooterKey
+
+    return {
+      ...deriveNavCard(tab, {
+        path: footerRouteMap[key],
+        dashboardKey: footerDashboardMap[key],
+        imageDir: 'nav/heroes',
+      }),
+      deckImage: getNavThumbImagePath(key),
+      heroImage: getNavHeroImagePath(key),
+    }
+  }),
+  CONDUCTOR_NAV_CARD,
+]

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -1,26 +1,17 @@
 // /stores/helpers/tutorialCards.ts
 //
-// Canonical config for channel tutorials. One entry per footer channel.
-// Each channel has a hero image + an overview + one section per tab. Sections
-// map 1:1 to a screenshot. tutorial-page.vue reads from here; nothing writes
-// back.
-//
-// Mirrors the dashboardHelper pattern: config-as-truth, derived lookups,
-// pure helper functions, no store calls inside this file.
+// Canonical config for channel tutorials. Most channels mirror footer keys, but
+// standalone channels can live here too when a page deserves first-class help
+// before it is fully folded into the dashboard registry.
 
 import { type FooterKey, footerKeys, footerRouteMap } from './dashboardHelper'
 
 export const TUTORIAL_IMAGE_BASE = '/images/tutorials'
 export const TUTORIAL_IMAGE_EXTENSION = 'webp'
 
-// Two kinds of image live under each channel folder:
-//   - One hero: illustrative title art for the whole tutorial.
-//       Path shape: /images/tutorials/<channel>/hero.webp
-//   - One screenshot per section: an actual screen capture of that tab.
-//       Path shape: /images/tutorials/<channel>/<section>.webp
-// "hero" is reserved as a section image name so the two never collide.
+const CONDUCTOR_IMAGE_BASE =
+  'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
 
-// Screenshot path for a single section.
 export function getTutorialImagePath(
   channelKey: string,
   sectionKey: string,
@@ -28,7 +19,6 @@ export function getTutorialImagePath(
   return `${TUTORIAL_IMAGE_BASE}/${channelKey}/${sectionKey}.${TUTORIAL_IMAGE_EXTENSION}`
 }
 
-// Hero (title art) path for the whole channel.
 export function getTutorialHeroPath(channelKey: string): string {
   return `${TUTORIAL_IMAGE_BASE}/${channelKey}/hero.${TUTORIAL_IMAGE_EXTENSION}`
 }
@@ -37,46 +27,28 @@ function tutorialImage(channelKey: string, sectionKey: string): string {
   return getTutorialImagePath(channelKey, sectionKey)
 }
 
+export type ExtraTutorialKey = 'conductor'
+export type TutorialChannelKey = FooterKey | ExtraTutorialKey
+
 export type TutorialSection = {
-  // Stable key, used for the image path and v-for keys. Usually the tab key.
   key: string
-  // Short heading shown above the screenshot.
   title: string
-  // 1-3 sentences describing what the tab does, in the platform's dry voice.
   body: string
-  // Screenshot path. Defaults to the conventional path if omitted.
   image: string
-  // Marks a section as still in development. tutorial-page shows a badge and
-  // can de-emphasize or skip it depending on the consuming UI.
   underConstruction?: boolean
 }
 
 export type TutorialChannel = {
-  // Footer channel key this tutorial belongs to.
-  key: FooterKey
-  // Title shown at the top of the tutorial popup.
+  key: TutorialChannelKey
   title: string
-  // Hero / title art for the whole tutorial. This is illustrative art, NOT a
-  // screenshot. Defaults to /images/tutorials/<channel>/hero.webp via
-  // getTutorialHero(); set explicitly only to point somewhere else.
   hero?: string
-  // Overview paragraph(s) for the whole channel.
   overview: string
-  // Optional one-liner under the title.
   tagline?: string
-  // Optional callout shown prominently in the overview. Used for the
-  // creator-earnings / profit-share message on monetizable channels.
   earnings?: string
-  // Marks the whole channel as still under development.
   underConstruction?: boolean
-  // Ordered sections, one per tab.
   sections: TutorialSection[]
 }
 
-// Channels where user creations participate in the profit-share model: when
-// other people spend paid tokens interacting with your work, a share comes
-// back to you. Applies to scenarios, characters, locations (dreams), rewards,
-// bots, and dreams (including brainstorm seeds).
 export const EARNING_CHANNELS = [
   'scenario',
   'character',
@@ -87,9 +59,6 @@ export const EARNING_CHANNELS = [
 
 export type EarningChannelKey = (typeof EARNING_CHANNELS)[number]
 
-// Profit-share message for creator channels. The model splits paid-token
-// revenue three ways: Kind Robots, the anti-malaria fundraiser, and the
-// creators whose work people choose to use.
 export const CREATOR_EARNINGS_MESSAGE =
   'When people spend paid tokens on something you made, you earn a share. ' +
   'Paid usage is split three ways - Kind Robots, the anti-malaria fundraiser, ' +
@@ -100,34 +69,29 @@ export function isEarningChannel(key: string): key is EarningChannelKey {
 }
 
 export const tutorialChannels = {
-  // The footer key for the games/lab channel is `games` (route /memory).
-  // Its label and title read "Games"; route resolution uses footerRouteMap.
   games: {
     key: 'games',
     title: 'Games',
     tagline: 'Play, tinker, and poke at the moving parts.',
     overview:
-      'The Games page is the playful corner of Kind Robots: a card-matching ' +
-      'dungeon crawl, a sandbox of screensaver-style screen effects, and a ' +
-      'behind-the-scenes look at the components that build the site. Come for ' +
-      'the dungeon, stay for the visual chaos.',
+      'The Games page is the playful corner of Kind Robots: a card-matching dungeon crawl, screen effects, and WonderLab experiments. Come for the dungeon, stay for the visual chaos.',
     sections: [
       {
         key: 'memory-dungeon',
         title: 'Memory Match Dungeon',
-        body: 'Match cards to progress deeper into the dungeon, with leaderboards to climb. You can even customize the crawl with your own generated art.',
+        body: 'Match cards to progress deeper into the dungeon, with leaderboards to climb and generated art to remix the crawl.',
         image: tutorialImage('games', 'memory-dungeon'),
       },
       {
         key: 'screen-fx',
         title: 'Screen FX',
-        body: 'A playground of 28 after-dark-style screen effects you can mix and match. Layer matrix rain over fireflies over butterflies until the screen looks exactly as unreasonable as you want.',
+        body: 'A playground of after-dark-style screen effects you can layer until the screen looks exactly as unreasonable as you want.',
         image: tutorialImage('games', 'screen-fx'),
       },
       {
         key: 'wonder-lab',
         title: 'WonderLab',
-        body: 'A behind-the-scenes look at the components that make up the site. Mostly here for Silas, but the tools are reviewable and worth a poke if you like seeing how the machine is wired.',
+        body: 'A behind-the-scenes look at the components that make up the site and the experiments that are still earning their shoes.',
         image: tutorialImage('games', 'wonder-lab'),
       },
     ],
@@ -138,21 +102,19 @@ export const tutorialChannels = {
     title: 'Stories',
     tagline: 'Bring everything into one narrative space.',
     overview:
-      'Combine characters, places, treasures, and art into a single ' +
-      'unfolding story. Browse playable scenarios, configure a session, and ' +
-      'let the narrator turn your choices into consequences with teeth.',
+      'Combine characters, places, treasures, and art into a single unfolding story. Browse playable scenarios, configure a session, and let the narrator turn choices into consequences with teeth.',
     earnings: CREATOR_EARNINGS_MESSAGE,
     sections: [
       {
         key: 'scenarios',
         title: 'Scenario Gallery',
-        body: 'Browse playable scenarios, clone promising branches, and pick the playground you want to run. Selecting a scenario moves you into configuration.',
+        body: 'Browse playable scenarios, clone promising branches, and pick the playground you want to run.',
         image: tutorialImage('scenario', 'scenarios'),
       },
       {
         key: 'add',
         title: 'Add Scenario',
-        body: 'Create a new scenario with an intro, choices, and stakes - and enough room for players to surprise the narrator with solutions you never wrote. A popular scenario earns you a share of the paid tokens players spend on it.',
+        body: 'Create a new scenario with an intro, choices, stakes, and room for players to surprise the narrator.',
         image: tutorialImage('scenario', 'add'),
       },
     ],
@@ -163,27 +125,25 @@ export const tutorialChannels = {
     title: 'Dreams',
     tagline: 'Explore imagined places, dreamscapes, and story seeds.',
     overview:
-      'Dreams are collaborative places, story seeds, and weird little worlds ' +
-      'that can inspire chat, art, scenarios, and future story material. Browse ' +
-      'the gallery, expand a world, or create your own dreamscapes.',
+      'Dreams are collaborative places, story seeds, and weird little worlds that can inspire chat, art, scenarios, and future story material.',
     earnings: CREATOR_EARNINGS_MESSAGE,
     sections: [
       {
         key: 'dreams',
         title: 'Dream Gallery',
-        body: 'Browse collaborative dreams, pick a world to expand, chat inside it, generate art around it, clone an interesting seed, or quietly retire the portals that did not work out.',
+        body: 'Browse collaborative dreams, pick a world to expand, chat inside it, generate art around it, or clone an interesting seed.',
         image: tutorialImage('dream', 'dreams'),
       },
       {
         key: 'dreammaker',
         title: 'Dreammaker',
-        body: 'Create a new dream or revise an existing one with the right title, idea, description, art hooks, and story coordinates. Dreams join the profit share, so a place people keep building on can earn you a cut.',
+        body: 'Create or revise a dream with the right title, idea, description, art hooks, and story coordinates.',
         image: tutorialImage('dream', 'add'),
       },
       {
         key: 'brainstorm',
         title: 'Dream Brainstorm',
-        body: 'Start with an idea, generate riffs on the concept, accept the good ones, reject the goblins, and save the survivors as reusable dream seeds.',
+        body: 'Start with an idea, generate riffs on the concept, accept the good ones, and save survivors as reusable dream seeds.',
         image: tutorialImage('dream', 'brainstorm'),
       },
     ],
@@ -194,27 +154,25 @@ export const tutorialChannels = {
     title: 'Characters',
     tagline: 'Design and meet the cast of your world.',
     overview:
-      'Create the people, creatures, guides, rivals, and chattable weirdos ' +
-      'who move through your stories. Build them in the gallery, then cast ' +
-      'them together on the stage.',
+      'Create the people, creatures, guides, rivals, and chattable weirdos who move through your stories. Build them in the gallery, then cast them together on the stage.',
     earnings: CREATOR_EARNINGS_MESSAGE,
     sections: [
       {
         key: 'characters',
         title: 'Character Gallery',
-        body: 'Browse the cast, select favorites, and clone useful archetypes. All your glorious weirdos live in one theatrical little cabinet.',
+        body: 'Browse the cast, select favorites, and clone useful archetypes. Your glorious weirdos live in one theatrical little cabinet.',
         image: tutorialImage('character', 'characters'),
       },
       {
         key: 'add',
         title: 'Add Character',
-        body: 'Build a character from scratch or through the interactive adventurer. Characters join the profit share, so a memorable one can earn you a cut of the paid tokens spent using it.',
+        body: 'Build a character from scratch or through the interactive adventurer.',
         image: tutorialImage('character', 'add'),
       },
       {
         key: 'stage',
         title: 'Stage Manager',
-        body: 'Cast one or more characters into a scene together and let their energy play off each other. The stage is where a cabinet of profiles becomes an actual cast.',
+        body: 'Cast one or more characters into a scene together and let their energy play off each other.',
         image: tutorialImage('character', 'stage'),
       },
     ],
@@ -225,21 +183,19 @@ export const tutorialChannels = {
     title: 'Rewards',
     tagline: 'Items, magic, powers, skills, and favors.',
     overview:
-      'Rewards are the narrative accelerants - items, magic, powers, skills, ' +
-      'and favors - that inspire a creative experience. Browse the gallery to ' +
-      'spin one into a story prompt, or create your own for stories to use.',
+      'Rewards are narrative accelerants: items, magic, powers, skills, and favors that inspire creative experiences.',
     earnings: CREATOR_EARNINGS_MESSAGE,
     sections: [
       {
         key: 'rewards',
         title: 'Reward Gallery',
-        body: 'Browse rewards and use any of them as a text-based story prompt. Most rewards do their real work inside scenarios and characters, but a single reward can headline a prompt too - and if it earns paid usage, you get a share.',
+        body: 'Browse rewards and use any of them as a text-based story prompt or scenario ingredient.',
         image: tutorialImage('reward', 'rewards'),
       },
       {
         key: 'add',
         title: 'Create Reward',
-        body: 'Create items, magic, powers, skills, and favors with enough narrative flavor to make the loot table purr. Built to drop into scenarios and characters, with profit share when people pay to use them.',
+        body: 'Create items, magic, powers, skills, and favors with enough flavor to make the loot table purr.',
         image: tutorialImage('reward', 'add'),
       },
     ],
@@ -250,27 +206,25 @@ export const tutorialChannels = {
     title: 'Bots',
     tagline: 'Build personalities, assistants, and accomplices.',
     overview:
-      'A bot is a focused, specialized GPT. Visit the Cafe to chat with bots ' +
-      'others have built, and the Factory to forge your own. Bots that draw ' +
-      'paid token usage earn their makers a share.',
+      'A bot is a focused, specialized GPT. Visit the Cafe to chat with bots others have built, and the Factory to forge your own.',
     earnings: CREATOR_EARNINGS_MESSAGE,
     sections: [
       {
         key: 'bots',
         title: 'Bot Cafe',
-        body: 'Browse and chat with bots, launch a favorite assistant, or clone a useful troublemaker. The Cafe is where bots meet the people who actually use them.',
+        body: 'Browse and chat with bots, launch a favorite assistant, or clone a useful troublemaker.',
         image: tutorialImage('bot', 'bots'),
       },
       {
         key: 'forge',
         title: 'Bot Factory',
-        body: 'Forge new bot personalities and tune their skills. A bot that catches on and pulls paid usage earns you a share of the profit.',
+        body: 'Forge new bot personalities and tune their skills.',
         image: tutorialImage('bot', 'forge'),
       },
       {
         key: 'composition',
         title: 'Composition',
-        body: 'Composition is a way to customize the shape of a bot\u2019s response object for more precise requests. Still under construction while we work out the details.',
+        body: 'Customize the shape of a bot response object for more precise requests. Still under construction.',
         image: tutorialImage('bot', 'composition'),
         underConstruction: true,
       },
@@ -282,32 +236,30 @@ export const tutorialChannels = {
     title: 'Art',
     tagline: 'Generate, browse, and remix AI artwork.',
     overview:
-      'Build prompts, generate images, browse the gallery, and remix styles ' +
-      'through the active art server. Turn story fuel into fresh images ' +
-      'without waking the prompt goblin unless absolutely necessary.',
+      'Build prompts, generate images, browse the gallery, and remix styles through the active art server.',
     sections: [
       {
         key: 'generate',
         title: 'Art Generator',
-        body: 'Build prompts, choose the active art server, and create new images. The control room for turning words into pictures.',
+        body: 'Build prompts, choose the active art server, and create new images.',
         image: tutorialImage('art', 'generate'),
       },
       {
         key: 'gallery',
         title: 'Art Gallery',
-        body: 'Browse generated art, inspect details, and collect favorites until the rest of the page stops looking naked.',
+        body: 'Browse generated art, inspect details, and collect favorites.',
         image: tutorialImage('art', 'gallery'),
       },
       {
         key: 'styler',
         title: 'Art Styler',
-        body: 'Remix an existing image into a fresh style, polish rough gems, and commit tasteful visual crimes against boring defaults.',
+        body: 'Remix an existing image into a fresh style and polish rough gems.',
         image: tutorialImage('art', 'styler'),
       },
       {
         key: 'workbench',
         title: 'Code Cards (Workbench)',
-        body: 'A simplified, abstracted ComfyUI interface for building specific chains of art and text generation. Under construction while we smooth out the rough edges.',
+        body: 'A simplified ComfyUI-style interface for building specific chains of art and text generation. Under construction.',
         image: tutorialImage('art', 'workbench'),
         underConstruction: true,
       },
@@ -319,48 +271,45 @@ export const tutorialChannels = {
     title: 'Orientation',
     tagline: 'Our mission, our fundraiser, and where this is all headed.',
     overview:
-      'Welcome to the heart of the project. A lot of the Sanctuary is still ' +
-      'under construction, but the plan is a profit-share model that splits ' +
-      'funds three ways: Kind Robots, our anti-malaria fundraiser, and the ' +
-      'users who contribute to the site. Here is what is coming.',
+      'Welcome to the heart of the project: the mission, fundraiser, community tools, subscriptions, wallet, and giftshop plans.',
     underConstruction: true,
     sections: [
       {
         key: 'giftshop',
         title: 'Giftshop',
-        body: 'A print-on-demand shop built on art and text generated right here on the site. Still under development, but the plan is to turn your creations into things you can actually hold.',
+        body: 'A print-on-demand shop built on art and text generated right here on the site.',
         image: tutorialImage('sanctuary', 'giftshop'),
         underConstruction: true,
       },
       {
         key: 'community',
         title: 'Community Broadcasts',
-        body: 'Compose one post, generate platform-ready versions, and share updates to Discord, Reddit, Facebook, Instagram, Bluesky, Mastodon, RSS, and the wider Kind Robots community. Automatic publishers handle the friendly platforms, while copy-ready blocks keep the goblin platforms fast and painless.',
+        body: 'Compose one post, generate platform-ready versions, and share updates to the wider Kind Robots community.',
         image: tutorialImage('sanctuary', 'community'),
         underConstruction: true,
       },
       {
         key: 'forum',
         title: 'Forum',
-        body: 'Talk with other members of the community: comment, compare notes, and share the beautiful nonsense you have been building.',
+        body: 'Talk with other members of the community, comment, compare notes, and share what you have been building.',
         image: tutorialImage('sanctuary', 'forum'),
       },
       {
         key: 'subscriptions',
         title: 'Subscriptions',
-        body: 'A monthly subscription gets you more generations and priority in the queue, and helps keep the whole ecosystem running.',
+        body: 'A monthly subscription gets you more generations and helps keep the ecosystem running.',
         image: tutorialImage('sanctuary', 'subscriptions'),
       },
       {
         key: 'wallet',
         title: 'Mana Purse',
-        body: 'See how many free generations you have available. Down the line, this is also where you will watch the credits you have earned from other people using your creations.',
+        body: 'See how many free generations you have available and, later, track credits you have earned.',
         image: tutorialImage('sanctuary', 'wallet'),
       },
       {
         key: 'sponsor',
         title: 'About & Sponsorship',
-        body: 'Our mission, our history, and the anti-malaria fundraiser at the center of it. This is where AMI turns tiny digital wings into real-world protection.',
+        body: 'Our mission, history, and the anti-malaria fundraiser at the center of it.',
         image: tutorialImage('sanctuary', 'sponsor'),
       },
     ],
@@ -371,77 +320,90 @@ export const tutorialChannels = {
     title: 'Builder',
     tagline: 'One flow to build everything.',
     overview:
-      'The Builder is a single guided flow for creating all your building ' +
-      'blocks - dream seeds, dreams, characters, bots, rewards, scenarios, and ' +
-      'art - using the builder card system to move through each step in a ' +
-      'simple GUI. Start small, stack boldly.',
+      'The Builder is a single guided flow for creating dream seeds, dreams, characters, bots, rewards, scenarios, and art using the builder card system.',
     earnings: CREATOR_EARNINGS_MESSAGE,
     sections: [
       {
         key: 'builder',
         title: 'Builder Cards',
-        body: 'Move through a card-driven flow to create dream seeds, dreams, characters, bots, rewards, scenarios, and art - all from one place, no juggling required. Many of these creations can join the profit share once they are out in the world.',
+        body: 'Move through a card-driven flow to create reusable building blocks from one place.',
         image: tutorialImage('builder', 'builder'),
       },
     ],
   },
 
-  // `home` is the footer key for the user channel: account configuration,
-  // avatars, friends, milestones, themes, and chats.
   home: {
     key: 'home',
     title: 'Your Account',
     tagline: 'Configure your profile, your look, and your people.',
     overview:
-      'Your home base. Configure your account, build an avatar, manage your ' +
-      'friends list, chase milestones, theme the whole place, and keep up ' +
-      'with conversations across the community.',
+      'Your home base. Configure your account, build an avatar, manage friends, chase milestones, theme the app, and keep up with conversations.',
     sections: [
       {
         key: 'dashboard',
         title: 'Dashboard',
-        body: 'Your configuration hub: account details, preferences, privacy, and the practical knobs that keep the whole contraption personalized.',
+        body: 'Your configuration hub: account details, preferences, privacy, and practical knobs.',
         image: tutorialImage('home', 'dashboard'),
       },
       {
         key: 'avatars',
         title: 'Avatar Creator',
-        body: 'Choose how you show up: upload an image, select from the collection, or generate something brand new with the art tools.',
+        body: 'Choose how you show up: upload an image, select from the collection, or generate something new.',
         image: tutorialImage('home', 'avatars'),
       },
       {
         key: 'friends',
         title: 'Friends',
-        body: 'Browse your friends list: favorite people, companions, collaborators, and the friendly weirdos who make the village feel alive.',
+        body: 'Browse your friends list: favorite people, companions, collaborators, and friendly weirdos.',
         image: tutorialImage('home', 'friends'),
       },
       {
         key: 'milestones',
         title: 'Milestones',
-        body: 'Our achievement system. Collect jellybeans hidden throughout the site by interacting with the tools, and track the rewards you unlock along the way.',
+        body: 'Collect jellybeans hidden throughout the site and track the rewards you unlock.',
         image: tutorialImage('home', 'milestones'),
       },
       {
         key: 'themes',
         title: 'Theme Manager',
-        body: 'Switch between 30+ DaisyUI themes, or build your own custom design and share it with the community. Aesthetics are infrastructure with better shoes.',
+        body: 'Switch between DaisyUI themes, or build your own custom design.',
         image: tutorialImage('home', 'themes'),
       },
       {
         key: 'chats',
         title: 'Chats',
-        body: 'View and continue your messages with other members of the community, so useful conversations do not vanish into the scroll mines.',
+        body: 'View and continue conversations across the community.',
         image: tutorialImage('home', 'chats'),
       },
     ],
   },
-} as const satisfies Record<FooterKey, TutorialChannel>
 
-export type TutorialChannelKey = keyof typeof tutorialChannels
+  conductor: {
+    key: 'conductor',
+    title: 'Conductor',
+    hero: `${CONDUCTOR_IMAGE_BASE}/approval-portal-hero.webp`,
+    tagline: 'Steer agents, review work, and keep the human in the loop.',
+    overview:
+      'Conductor is the private cockpit for the agent loop. It gathers project progress, roadmap state, task gates, pitch voting, and anything that needs Silas before robots continue doing robot things.',
+    sections: [
+      {
+        key: 'workspace',
+        title: 'Workspace',
+        body: 'Review active projects, open project detail views, vote on brainstorm pitches, inspect blockers, and see which tasks need human judgment before the next agent pass.',
+        image: `${CONDUCTOR_IMAGE_BASE}/approval-portal-card.webp`,
+      },
+    ],
+  },
+} as const satisfies Record<TutorialChannelKey, TutorialChannel>
 
 export const tutorialChannelKeys = Object.keys(
   tutorialChannels,
 ) as TutorialChannelKey[]
+
+const tutorialRouteMap = {
+  ...footerRouteMap,
+  conductor: '/conductor',
+} as const satisfies Record<TutorialChannelKey, string>
 
 export function isTutorialChannelKey(
   value: string,
@@ -453,8 +415,6 @@ export function getTutorialChannel(key: TutorialChannelKey): TutorialChannel {
   return tutorialChannels[key]
 }
 
-// Resolved hero path: explicit override if set, otherwise the conventional
-// /images/tutorials/<channel>/hero.webp.
 export function getTutorialHero(key: TutorialChannelKey): string {
   return getTutorialChannel(key).hero ?? getTutorialHeroPath(key)
 }
@@ -471,16 +431,9 @@ export function getTutorialEarningsMessage(
   return getTutorialChannel(key).earnings ?? null
 }
 
-// Resolve the tutorial channel for a route path. Footer routes are not unique
-// (several tabs share /bots, /art, etc.), so this matches the channel whose
-// footer route is the longest prefix of the given path. Returns null when
-// nothing matches (e.g. an unrelated page), so callers can hide the tutorial
-// entry rather than guessing.
 export function resolveTutorialChannelFromRoute(
   path: string,
 ): TutorialChannelKey | null {
-  // Strip query and hash without array indexing (keeps strict
-  // noUncheckedIndexedAccess happy — split()[0] would be string | undefined).
   let cleanPath = path || ''
   const queryIndex = cleanPath.indexOf('?')
   if (queryIndex !== -1) cleanPath = cleanPath.slice(0, queryIndex)
@@ -491,14 +444,11 @@ export function resolveTutorialChannelFromRoute(
   let bestLen = -1
 
   for (const key of tutorialChannelKeys) {
-    const route = footerRouteMap[key]
+    const route = tutorialRouteMap[key]
     if (!route) continue
 
-    // Exact match always wins immediately.
     if (cleanPath === route) return key
 
-    // Otherwise prefer the longest matching prefix, ignoring the bare '/'
-    // home route so it doesn't swallow every path.
     const isPrefix = route !== '/' && cleanPath.startsWith(`${route}/`)
 
     if (isPrefix && route.length > bestLen) {
@@ -510,12 +460,8 @@ export function resolveTutorialChannelFromRoute(
   return bestKey
 }
 
-// Sanity check: every footer channel should have a tutorial entry. This keeps
-// tutorialCards in sync with dashboardHelper's footer tabs at the type level.
-type _AllFooterChannelsCovered = TutorialChannelKey extends FooterKey
-  ? FooterKey extends TutorialChannelKey
-    ? true
-    : false
+type _AllFooterChannelsCovered = FooterKey extends TutorialChannelKey
+  ? true
   : false
 const _coverageCheck: _AllFooterChannelsCovered = true
 void _coverageCheck

--- a/stores/seeds/smartIcons.json
+++ b/stores/seeds/smartIcons.json
@@ -13,7 +13,6 @@
     "category": "model",
     "modelType": "art"
   },
-
   {
     "title": "Bots",
     "type": "directory",
@@ -42,7 +41,20 @@
     "category": "model",
     "modelType": "prompt"
   },
-
+  {
+    "title": "Conductor",
+    "type": "directory",
+    "userId": 10,
+    "designer": "content-seeder",
+    "icon": "kind-icon:gearhammer",
+    "label": "Conductor Cockpit",
+    "link": "/conductor",
+    "component": "lab-nav",
+    "isPublic": false,
+    "description": "Private control panel for the Conductor agent loop: projects, pitches, blockers, and human approval gates.",
+    "category": "ami",
+    "modelType": "ami"
+  },
   {
     "title": "Characters",
     "type": "directory",
@@ -71,7 +83,6 @@
     "category": "user",
     "modelType": "user"
   },
-
   {
     "title": "Forum",
     "type": "directory",
@@ -114,7 +125,6 @@
     "category": "user",
     "modelType": "user"
   },
-
   {
     "title": "Milestones",
     "type": "directory",
@@ -129,7 +139,6 @@
     "category": "user",
     "modelType": "user"
   },
-
   {
     "title": "Memory",
     "type": "directory",
@@ -144,7 +153,6 @@
     "category": "model",
     "modelType": "art"
   },
-
   {
     "title": "Navigation",
     "type": "directory",
@@ -159,7 +167,6 @@
     "category": "ami",
     "modelType": "ami"
   },
-
   {
     "title": "Rewards",
     "type": "directory",


### PR DESCRIPTION
## Summary
- Promotes Conductor into its own `/conductor` content page while keeping `/workspace` and the existing WonderLab workspace tab as compatibility paths.
- Adds a first-class Conductor nav card with remote card/hero art from the existing Conductor project assets.
- Seeds a Conductor smart icon entry so the main navigation can surface it as its own cockpit.
- Adds a Conductor tutorial channel with a single Workspace section and Conductor artwork.
- Exposes conventional Conductor project asset URLs from `/api/conductor/projects` (`imagePath`, `cardPath`, `heroPath`).
- Adds a client-side workspace sheet sync plugin that watches the active workspace card/project and pushes the selected project hero into `sheetStore`.

## Notes
- I verified existing Conductor art at `projects/images/approval-portal-card.webp` and `projects/images/approval-portal-hero.webp`, so I reused those instead of generating new images.
- I avoided a risky full rewrite of `dashboardHelper.ts` for now. Conductor is first-class at the page/nav/tutorial level, while its dashboard shell still reuses the existing WonderLab `workspace` tab internally. This keeps the current PR lower-risk and leaves the deeper dashboard-registry split for a clean follow-up.
- I also checked for `public/images/projects/overview-card.webp`; GitHub returned 404, so I avoided relying on those missing local `/images/projects/*` placeholders.

## Test plan
- Visit `/conductor` as admin and confirm the workspace loads.
- Open the workspace sheet.
- Select a project and confirm the sheet title/image changes to the selected project hero.
- Switch back to Overview and confirm the sheet returns to the Conductor overview art.
- Open the tutorial panel on `/conductor` and confirm the Conductor tutorial appears.
- Confirm the Conductor card appears in navigation.
- Run `npm run typecheck` / local Nuxt dev check before merge.