### PR TITLE
Add Conductor to channel select

### DIFF
--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -86,11 +86,11 @@
                   Creation Tools
                 </p>
                 <p class="text-[0.58rem] font-bold text-base-content/45">
-                  Lab · Builder · Art · Bots
+                  Conductor · Lab · Builder · Art · Bots
                 </p>
               </div>
 
-              <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              <div class="grid grid-cols-2 gap-2 sm:grid-cols-5">
                 <NuxtLink
                   v-for="channel in creationChannels"
                   :key="channel.key"
@@ -242,6 +242,14 @@ const sanctuaryChannel: ChannelRoute = {
 
 const utilityChannels: ChannelRoute[] = [homeChannel, sanctuaryChannel]
 
+const conductorChannel: ChannelRoute = {
+  key: 'conductor',
+  label: 'Conductor',
+  path: '/conductor',
+  icon: 'kind-icon:gearhammer',
+  summary: 'Steer agents, review work, and approve what needs a human.',
+}
+
 const labChannel: ChannelRoute = {
   key: 'lab',
   label: 'Lab',
@@ -308,6 +316,7 @@ const scenariosChannel: ChannelRoute = {
 }
 
 const creationChannels: ChannelRoute[] = [
+  conductorChannel,
   labChannel,
   builderChannel,
   artChannel,


### PR DESCRIPTION
## Summary
- Adds Conductor as a first-class icon tile in `channel-select`.
- Places it at the front of the Creation Tools group, pointing to `/conductor`.
- Uses `kind-icon:gearhammer` and a short human-approval/agent-loop summary.
- Widens the Creation Tools desktop grid to five columns so Conductor, Lab, Builder, Art, and Narrators sit together cleanly.

## Test plan
- Open the channel-select menu.
- Confirm Conductor appears in Creation Tools.
- Click Conductor and confirm it routes to `/conductor`.
- Confirm the active channel icon switches to Conductor on `/conductor`.
- Run the local Nuxt/typecheck pass before merge.