### PR TITLE
Add Todo API Cypress coverage

### DIFF
--- a/cypress/e2e/api/todos.cy.ts
+++ b/cypress/e2e/api/todos.cy.ts
@@ -1,0 +1,312 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+// cypress/e2e/api/todos.cy.ts
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+  jsonHeaders,
+} from '../../support/api-auth'
+
+describe('Todo API Tests', () => {
+  const badJwt = 'definitely-not-valid'
+  const uniqueTitle = `Todo-${Date.now()}`
+
+  let apiBase = ''
+  let baseUrl = ''
+  let setupAuth = ''
+  let userJwt = ''
+  let createdUserId: number | undefined
+  let todoId: number | undefined
+
+  before(() => {
+    getApiEnv().then((env) => {
+      apiBase = env.apiBase
+      baseUrl = `${apiBase}/todos`
+      setupAuth = env.adminToken
+    })
+
+    createLoggedInTestUser().then((auth) => {
+      userJwt = auth.token
+      createdUserId = auth.id
+    })
+  })
+
+  after(() => {
+    if (todoId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${baseUrl}/${todoId}`,
+        headers: bearerHeaders(userJwt),
+        failOnStatusCode: false,
+      })
+    }
+
+    deleteTestUser(apiBase, setupAuth, createdUserId)
+  })
+
+  // ── GET (unauthenticated) ──────────────────────────────────────────────────
+
+  it('should return 401 fetching todos without auth', () => {
+    cy.request({
+      method: 'GET',
+      url: baseUrl,
+      headers: jsonHeaders(),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  it('should return 401 fetching todos with invalid token', () => {
+    cy.request({
+      method: 'GET',
+      url: baseUrl,
+      headers: bearerHeaders(badJwt),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  // ── POST (unauthenticated) ────────────────────────────────────────────────
+
+  it('should return 401 creating a todo without auth', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: jsonHeaders(),
+      body: { title: uniqueTitle },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  it('should return 401 creating a todo with invalid token', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(badJwt),
+      body: { title: uniqueTitle },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  // ── POST (authenticated) ──────────────────────────────────────────────────
+
+  it('should return 400 creating a todo without a title', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(userJwt),
+      body: {},
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+    })
+  })
+
+  it('Create a new Todo with valid authentication', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(userJwt),
+      body: {
+        title: uniqueTitle,
+        description: 'Cypress test todo',
+        priority: 'HIGH',
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      expect(response.body.success).to.be.true
+      expect(response.body.data).to.be.an('object')
+      expect(response.body.data.title).to.eq(uniqueTitle)
+      expect(response.body.data.status).to.eq('OPEN')
+      expect(response.body.data.priority).to.eq('HIGH')
+
+      todoId = response.body.data.id
+    })
+  })
+
+  // ── GET (authenticated) ───────────────────────────────────────────────────
+
+  it('Fetch all todos for the authenticated user', () => {
+    cy.request({
+      method: 'GET',
+      url: baseUrl,
+      headers: bearerHeaders(userJwt),
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.success).to.be.true
+      expect(response.body.data).to.be.an('array').and.have.length.greaterThan(0)
+      const found = response.body.data.find((t: { id: number }) => t.id === todoId)
+      expect(found).to.exist
+    })
+  })
+
+  it('Fetch todos filtered by status=OPEN', () => {
+    cy.request({
+      method: 'GET',
+      url: `${baseUrl}?status=OPEN`,
+      headers: bearerHeaders(userJwt),
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.success).to.be.true
+      response.body.data.forEach((t: { status: string }) => {
+        expect(t.status).to.eq('OPEN')
+      })
+    })
+  })
+
+  // ── PATCH (unauthenticated) ───────────────────────────────────────────────
+
+  it('should return 401 updating a todo without auth', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${todoId}`,
+      headers: jsonHeaders(),
+      body: { title: 'Should not work' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  it('should return 401 updating a todo with invalid token', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${todoId}`,
+      headers: bearerHeaders(badJwt),
+      body: { title: 'Should not work' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  // ── PATCH (authenticated) ─────────────────────────────────────────────────
+
+  it('Update todo title with valid authentication', () => {
+    expect(todoId).to.exist
+
+    const updatedTitle = `Updated-${uniqueTitle}`
+
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${todoId}`,
+      headers: bearerHeaders(userJwt),
+      body: { title: updatedTitle },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.success).to.be.true
+      expect(response.body.data.title).to.eq(updatedTitle)
+      expect(response.body.data.status).to.eq('OPEN')
+    })
+  })
+
+  it('Mark todo as DONE', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${todoId}`,
+      headers: bearerHeaders(userJwt),
+      body: { status: 'DONE' },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.success).to.be.true
+      expect(response.body.data.status).to.eq('DONE')
+    })
+  })
+
+  it('Archive a todo', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${todoId}`,
+      headers: bearerHeaders(userJwt),
+      body: { status: 'ARCHIVED' },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.success).to.be.true
+      expect(response.body.data.status).to.eq('ARCHIVED')
+    })
+  })
+
+  it('Archived todo absent from default GET (no includeArchived)', () => {
+    cy.request({
+      method: 'GET',
+      url: baseUrl,
+      headers: bearerHeaders(userJwt),
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      const found = response.body.data.find((t: { id: number }) => t.id === todoId)
+      expect(found).to.be.undefined
+    })
+  })
+
+  it('Archived todo visible with includeArchived=true', () => {
+    cy.request({
+      method: 'GET',
+      url: `${baseUrl}?includeArchived=true`,
+      headers: bearerHeaders(userJwt),
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      const found = response.body.data.find((t: { id: number }) => t.id === todoId)
+      expect(found).to.exist
+    })
+  })
+
+  // ── DELETE (unauthenticated) ──────────────────────────────────────────────
+
+  it('should return 401 deleting a todo without auth', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'DELETE',
+      url: `${baseUrl}/${todoId}`,
+      headers: jsonHeaders(),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  it('should return 401 deleting a todo with invalid token', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'DELETE',
+      url: `${baseUrl}/${todoId}`,
+      headers: bearerHeaders(badJwt),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+    })
+  })
+
+  // ── DELETE (authenticated) ────────────────────────────────────────────────
+
+  it('Delete todo with valid authentication', () => {
+    expect(todoId).to.exist
+
+    cy.request({
+      method: 'DELETE',
+      url: `${baseUrl}/${todoId}`,
+      headers: bearerHeaders(userJwt),
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.success).to.be.true
+      expect(response.body.message).to.include('deleted')
+      todoId = undefined
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Salvages the Todo API Cypress suite from the old Claude branch.
- Adds CRUD/auth coverage for `/api/todos`: unauthenticated/invalid-token rejection, create validation, create/list/filter/update/archive/includeArchived/delete.
- Fixes the original hardcoded production URL by deriving `baseUrl` from `getApiEnv().apiBase`, so the spec can run against local, preview, staging, or production depending on Cypress env.

## Test plan
- Run the Todo spec with Cypress against an environment with seeded test auth:
  - `cypress/e2e/api/todos.cy.ts`
- Confirm `BASE_API_URL` switches the target API as expected.
- Confirm cleanup deletes any created todo and disposable test user when applicable.