### PR TITLE
Stabilize Cypress API cleanup

### DIFF
--- a/cypress/e2e/api/art.cy.ts
+++ b/cypress/e2e/api/art.cy.ts
@@ -1,24 +1,22 @@
-import { createLoggedInTestUser } from '../../support/api-auth'
 // cypress/e2e/api/art.cy.ts
 /* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import {
+  adminHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
 
 let userId = 0
 
 describe('ArtImage Management API Tests', () => {
-
-  // Auth migration: fresh disposable JWT user
-  before(() => {
-    return createLoggedInTestUser().then((auth) => {
-      userToken = auth.token
-      userId = auth.id
-    })
-  })
-
-  const apiRoot = 'https://kind-robots.vercel.app/api'
-  const artImageUrl = `${apiRoot}/art/image`
-  const artGenerateUrl = `${apiRoot}/art/generate`
   const invalidToken = 'someInvalidTokenValue'
   const adminUserId = 1
+
+  let apiRoot = ''
+  let artImageUrl = ''
+  let artGenerateUrl = ''
   let apiKey = ''
   let adminToken = ''
   let userToken = ''
@@ -28,16 +26,28 @@ describe('ArtImage Management API Tests', () => {
   let generatedPath = ''
 
   before(() => {
-    cy.env(['API_KEY', 'ADMIN_TOKEN', 'LOLA_TEST_SERVER_ID']).then((env) => {
-      apiKey = String(env.API_KEY || '')
-      adminToken = String(env.ADMIN_TOKEN || '')
+    getApiEnv().then((env) => {
+      apiRoot = env.apiBase
+      adminToken = env.adminToken
+      apiKey = env.adminToken
+      artImageUrl = `${apiRoot}/art/image`
+      artGenerateUrl = `${apiRoot}/art/generate`
+    })
+
+    cy.env(['API_KEY', 'LOLA_TEST_SERVER_ID']).then((env) => {
+      apiKey = String(env.API_KEY || apiKey)
 
       const parsedValue = Number(env.LOLA_TEST_SERVER_ID ?? 37)
       lolaTestServerId = Number.isFinite(parsedValue) ? parsedValue : 37
 
-      expect(apiKey, 'API_KEY').to.be.a('string').and.not.be.empty
+      expect(apiKey, 'API_KEY or ADMIN_TOKEN').to.be.a('string').and.not.be.empty
       expect(adminToken, 'ADMIN_TOKEN').to.be.a('string').and.not.be.empty
       expect(lolaTestServerId, 'LOLA_TEST_SERVER_ID').to.be.a('number')
+    })
+
+    createLoggedInTestUser({ fresh: true }).then((auth) => {
+      userToken = auth.token
+      userId = auth.id
     })
 
     cy.then(() => {
@@ -54,7 +64,7 @@ describe('ArtImage Management API Tests', () => {
           steps: 10,
           path: ' ',
           seed: -1,
-          userId: userId,
+          userId,
           imagePath: 'justfortesting',
         },
         failOnStatusCode: false,
@@ -79,29 +89,25 @@ describe('ArtImage Management API Tests', () => {
   })
 
   after(() => {
-    if (fixtureArtImageId) {
+    if (fixtureArtImageId && adminToken) {
       cy.request({
         method: 'DELETE',
         url: `${artImageUrl}/${fixtureArtImageId}`,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${userToken}`,
-        },
+        headers: adminHeaders(adminToken),
         failOnStatusCode: false,
       })
     }
 
-    if (generatedArtImageId) {
+    if (generatedArtImageId && adminToken) {
       cy.request({
         method: 'DELETE',
         url: `${artImageUrl}/${generatedArtImageId}`,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${userToken}`,
-        },
+        headers: adminHeaders(adminToken),
         failOnStatusCode: false,
       })
     }
+
+    deleteTestUser(apiRoot, adminToken, userId)
   })
 
   it('should not allow generating an ArtImage without a bearer token', () => {

--- a/cypress/e2e/api/characters.cy.ts
+++ b/cypress/e2e/api/characters.cy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 // cypress/e2e/api/character.cy.ts
 import {
+  adminHeaders,
   bearerHeaders,
   createLoggedInTestUser,
   deleteTestUser,
@@ -9,12 +10,12 @@ import {
 } from '../../support/api-auth'
 
 describe('Character Management API Tests', () => {
-  const baseUrl = 'https://kind-robots.vercel.app/api/characters'
   const badJwt = 'definitely-not-valid'
   const uniqueCharacterName = `Character-${Date.now()}`
 
   let apiBase = ''
-  let setupAuth = ''
+  let baseUrl = ''
+  let adminToken = ''
   let userJwt = ''
   let createdUserId: number | undefined
   let characterId: number | undefined
@@ -22,26 +23,27 @@ describe('Character Management API Tests', () => {
   before(() => {
     getApiEnv().then((env) => {
       apiBase = env.apiBase
-      setupAuth = env.adminToken
+      adminToken = env.adminToken
+      baseUrl = `${apiBase}/characters`
     })
 
-    createLoggedInTestUser().then((auth) => {
+    createLoggedInTestUser({ fresh: true }).then((auth) => {
       userJwt = auth.token
       createdUserId = auth.id
     })
   })
 
   after(() => {
-    if (characterId) {
+    if (characterId && adminToken) {
       cy.request({
         method: 'DELETE',
         url: `${baseUrl}/${characterId}`,
-        headers: bearerHeaders(userJwt),
+        headers: adminHeaders(adminToken),
         failOnStatusCode: false,
       })
     }
 
-    deleteTestUser(apiBase, setupAuth, createdUserId)
+    deleteTestUser(apiBase, adminToken, createdUserId)
   })
 
   it('should not allow creating a character without an authorization token', () => {
@@ -95,12 +97,14 @@ describe('Character Management API Tests', () => {
         level: 1,
         isPublic: false,
       },
+      failOnStatusCode: false,
     }).then((response) => {
-      expect(response.status).to.eq(201)
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body.success).to.be.true
       expect(response.body.data).to.be.an('object').that.is.not.empty
 
       characterId = response.body.data.id
+      expect(characterId).to.be.a('number').and.to.be.greaterThan(0)
     })
   })
 

--- a/cypress/e2e/api/codes.cy.ts
+++ b/cypress/e2e/api/codes.cy.ts
@@ -5,6 +5,7 @@
 /// <reference types="cypress" />
 
 import {
+  adminHeaders,
   bearerHeaders,
   createLoggedInTestUser,
   deleteTestUser,
@@ -21,8 +22,6 @@ interface ApiResponse<T = any> {
   count?: number
   statusCode?: number
 }
-
-type CleanupResponse = Cypress.Response<unknown> | null
 
 interface CodeNode {
   id: string
@@ -65,15 +64,7 @@ interface CodeRecord {
   isActive: boolean
 }
 
-let userId = 0
 describe('[Code] API Full CRUD + Auth Tests', () => {
-  // Auth migration: fresh disposable JWT user
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-      userId = auth.id
-    })
-  })
-
   const modelName = 'code'
 
   let apiBase = ''
@@ -169,7 +160,7 @@ describe('[Code] API Full CRUD + Auth Tests', () => {
       baseUrl = `${apiBase}/${modelName}`
     })
 
-    createLoggedInTestUser().then((auth) => {
+    createLoggedInTestUser({ fresh: true }).then((auth) => {
       testUser = auth
     })
   })
@@ -572,27 +563,17 @@ describe('[Code] API Full CRUD + Auth Tests', () => {
   })
 
   after(() => {
-    if (testUser && createdIds.length) {
+    if (createdIds.length && adminToken) {
       cy.wrap(createdIds).each((id) => {
         cy.request({
           method: 'DELETE',
           url: `${baseUrl}/${id}`,
-          headers: bearerHeaders(testUser!.token),
+          headers: adminHeaders(adminToken),
           failOnStatusCode: false,
         })
       })
     }
 
-    const cleanup = deleteTestUser(
-      apiBase,
-      adminToken,
-      testUser?.id,
-    ) as Cypress.Chainable<CleanupResponse>
-
-    cleanup.then((response: CleanupResponse) => {
-      if (response) {
-        cy.log('Code test user cleanup:', JSON.stringify(response.body))
-      }
-    })
+    deleteTestUser(apiBase, adminToken, testUser?.id)
   })
 })

--- a/cypress/e2e/api/compositions.cy.ts
+++ b/cypress/e2e/api/compositions.cy.ts
@@ -1,10 +1,16 @@
-import { createLoggedInTestUser } from '../../support/api-auth'
 // @ts-nocheck
 /* eslint-disable */
 // test-ignore
 
 // /cypress/e2e/api/composition.cy.ts
 /// <reference types="cypress" />
+
+import {
+  adminHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
 
 interface ApiResponse<T = any> {
   success: boolean
@@ -13,46 +19,32 @@ interface ApiResponse<T = any> {
   statusCode?: number
 }
 
-let userId = 0
-
 describe('[Composition] API Full CRUD + Auth Tests', () => {
-
-  // Auth migration: fresh disposable JWT user
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-      userToken = auth.token
-      userId = auth.id
-    })
-  })
-
   const modelName = 'composition'
-  const fallbackApiBase = 'https://kind-robots.vercel.app'
   const invalidToken = 'definitely-not-a-real-token'
-  const testUserId = 9
 
-  let apiBase = fallbackApiBase
-  let baseUrl = `${fallbackApiBase}/api/${modelName}s`
+  let apiBase = ''
+  let adminToken = ''
+  let baseUrl = ''
   let userToken = ''
-  let itemId: number
+  let userId = 0
+  let itemId: number | undefined
 
   const time = Date.now()
   const itemTitle = `COMPOSITION-${time}`
 
   before(() => {
-    cy.env(['API_BASE']).then((env) => {
-      apiBase = String(env.API_BASE || fallbackApiBase)
-      baseUrl = `${apiBase}/api/${modelName}s`
-})
-  })
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-    userToken = auth.token
+    getApiEnv().then((env) => {
+      apiBase = env.apiBase
+      adminToken = env.adminToken
+      baseUrl = `${apiBase}/${modelName}s`
+    })
+
+    createLoggedInTestUser({ fresh: true }).then((auth) => {
+      userToken = auth.token
+      userId = auth.id
     })
   })
-
-
-
-
 
   it('POST: rejects without auth', () => {
     cy.request<ApiResponse>({
@@ -62,7 +54,7 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
       body: {
         title: `Unauth-${itemTitle}`,
         characterBlurb: 'A ghost',
-        userId: testUserId,
+        userId,
       },
       failOnStatusCode: false,
     }).then((res) => {
@@ -82,7 +74,7 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
       body: {
         title: `Bad-${itemTitle}`,
         characterBlurb: 'A ghost',
-        userId: testUserId,
+        userId,
       },
       failOnStatusCode: false,
     }).then((res) => {
@@ -105,7 +97,7 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
         characterBlurb: 'A weary cartographer with ink-stained hands.',
         dreamBlurb: 'A floating market above the clouds.',
         isPublic: true,
-        userId: testUserId,
+        userId,
       },
     }).then((res) => {
       expect(res.status).to.eq(201)
@@ -117,6 +109,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('GET: fetches all public compositions', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse<any[]>>({ method: 'GET', url: baseUrl }).then(
       (res) => {
         expect(res.status).to.eq(200)
@@ -130,6 +124,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('GET: fetches by ID', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse>({
       method: 'GET',
       url: `${baseUrl}/${itemId}`,
@@ -141,6 +137,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('PATCH: rejects update without auth', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse>({
       method: 'PATCH',
       url: `${baseUrl}/${itemId}`,
@@ -153,6 +151,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('PATCH: updates with valid auth (saving synthesis output)', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse>({
       method: 'PATCH',
       url: `${baseUrl}/${itemId}`,
@@ -175,6 +175,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('DELETE: rejects without auth', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse>({
       method: 'DELETE',
       url: `${baseUrl}/${itemId}`,
@@ -186,6 +188,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('DELETE: hard deletes with valid auth', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse>({
       method: 'DELETE',
       url: `${baseUrl}/${itemId}`,
@@ -197,6 +201,8 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   it('GET: deleted record returns 404', () => {
+    expect(itemId).to.be.a('number')
+
     cy.request<ApiResponse>({
       method: 'GET',
       url: `${baseUrl}/${itemId}`,
@@ -209,12 +215,15 @@ describe('[Composition] API Full CRUD + Auth Tests', () => {
   })
 
   after(() => {
-    if (!itemId || !userToken) return
-    cy.request({
-      method: 'DELETE',
-      url: `${baseUrl}/${itemId}`,
-      headers: { Authorization: `Bearer ${userToken}` },
-      failOnStatusCode: false,
-    })
+    if (itemId && adminToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${baseUrl}/${itemId}`,
+        headers: adminHeaders(adminToken),
+        failOnStatusCode: false,
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, userId)
   })
 })

--- a/cypress/e2e/api/sheets.cy.ts
+++ b/cypress/e2e/api/sheets.cy.ts
@@ -1,6 +1,12 @@
-import { createLoggedInTestUser } from '../../support/api-auth'
 // /cypress/e2e/api/sheets.cy.ts
 /// <reference types="cypress" />
+
+import {
+  adminHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
 
 interface ApiResponse<T = any> {
   success: boolean
@@ -10,21 +16,14 @@ interface ApiResponse<T = any> {
 }
 
 describe('Sheets API CRUD + Auth Tests', () => {
-
-  // Auth migration: fresh disposable JWT user
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-      userToken = auth.token
-    })
-  })
-
-  const fallbackApiBase = 'https://kind-robots.vercel.app'
   const invalidToken = 'definitely-not-a-real-token'
 
-  let apiBase = fallbackApiBase
-  let sheetsUrl = `${fallbackApiBase}/api/sheets`
-  let dreamsUrl = `${fallbackApiBase}/api/dreams`
+  let apiBase = ''
+  let adminToken = ''
+  let sheetsUrl = ''
+  let dreamsUrl = ''
   let userToken = ''
+  let userId: number | undefined
   let dreamId = 0
   let pitchSheetId = 0
 
@@ -32,50 +31,48 @@ describe('Sheets API CRUD + Auth Tests', () => {
   const dreamTitle = `PitchSheet Cypress Dream ${time}`
 
   before(() => {
-    cy.env(['API_BASE']).then((env) => {
-      apiBase = String(env.API_BASE || fallbackApiBase)
-      sheetsUrl = `${apiBase}/api/sheets`
-      dreamsUrl = `${apiBase}/api/dreams`
-})
-  })
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-    userToken = auth.token
+    getApiEnv().then((env) => {
+      apiBase = env.apiBase
+      adminToken = env.adminToken
+      sheetsUrl = `${apiBase}/sheets`
+      dreamsUrl = `${apiBase}/dreams`
     })
-  })
 
+    createLoggedInTestUser({ fresh: true }).then((auth) => {
+      userToken = auth.token
+      userId = auth.id
+    })
 
+    cy.then(() => {
+      cy.request<ApiResponse>({
+        method: 'POST',
+        url: dreamsUrl,
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          title: dreamTitle,
+          slug: `pitchsheet-cypress-dream-${time}`,
+          dreamType: 'PITCH',
+          description: 'Temporary Dream created by the PitchSheet API Cypress test.',
+          pitch: 'A throwaway Dream used to verify PitchSheet backend behavior.',
+          flavorText: 'If you can read this in production, the cleanup goblin missed a spot.',
+          isPublic: true,
+          isActive: true,
+          isMature: false,
+          designer: 'cypress',
+        },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status, JSON.stringify(res.body)).to.eq(201)
+        expect(res.body.success).to.eq(true)
+        expect(res.body.data).to.have.property('id')
+        expect(res.body.data.title).to.eq(dreamTitle)
 
-
-
-  it('SETUP: creates a test Dream owned by the authenticated user', () => {
-    cy.request<ApiResponse>({
-      method: 'POST',
-      url: dreamsUrl,
-      headers: {
-        Authorization: `Bearer ${userToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        title: dreamTitle,
-        slug: `pitchsheet-cypress-dream-${time}`,
-        dreamType: 'PITCH',
-        description: 'Temporary Dream created by the PitchSheet API Cypress test.',
-        pitch: 'A throwaway Dream used to verify PitchSheet backend behavior.',
-        flavorText: 'If you can read this in production, the cleanup goblin missed a spot.',
-        isPublic: true,
-        isActive: true,
-        isMature: false,
-        designer: 'cypress',
-      },
-    }).then((res) => {
-      expect(res.status).to.eq(201)
-      expect(res.body.success).to.eq(true)
-      expect(res.body.data).to.have.property('id')
-      expect(res.body.data.title).to.eq(dreamTitle)
-
-      dreamId = res.body.data.id
-      expect(dreamId).to.be.a('number').and.to.be.greaterThan(0)
+        dreamId = res.body.data.id
+        expect(dreamId).to.be.a('number').and.to.be.greaterThan(0)
+      })
     })
   })
 
@@ -268,22 +265,24 @@ describe('Sheets API CRUD + Auth Tests', () => {
   })
 
   after(() => {
-    if (pitchSheetId && userToken) {
+    if (pitchSheetId && adminToken) {
       cy.request({
         method: 'DELETE',
         url: `${sheetsUrl}/${pitchSheetId}`,
-        headers: { Authorization: `Bearer ${userToken}` },
+        headers: adminHeaders(adminToken),
         failOnStatusCode: false,
       })
     }
 
-    if (dreamId && userToken) {
+    if (dreamId && adminToken) {
       cy.request({
         method: 'DELETE',
-        url: `${dreamsUrl}/${dreamId}`,
-        headers: { Authorization: `Bearer ${userToken}` },
+        url: `${dreamsUrl}/${dreamId}?hard=true`,
+        headers: adminHeaders(adminToken),
         failOnStatusCode: false,
       })
     }
+
+    deleteTestUser(apiBase, adminToken, userId)
   })
 })


### PR DESCRIPTION
## Summary
- Stabilizes API Cypress specs that create temporary records.
- Uses disposable test users in the updated specs.
- Cleans dependent records before cleaning the temporary user.
- Keeps route authorization assertions intact.

## Notes
- No `.http` files were changed.
- I did not run the suite while the live database schema update is pending.