### PR TITLE
fix(todos): re-throw H3Errors so auth failures return correct HTTP st…

### DIFF
--- a/server/api/todos/[id].delete.ts
+++ b/server/api/todos/[id].delete.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/[id].delete.ts
-import { defineEventHandler, createError, getRouterParam } from 'h3'
+import { defineEventHandler, createError, getRouterParam, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -25,6 +25,7 @@ export default defineEventHandler(async (event) => {
 
     return { success: true, message: 'Todo deleted.' }
   } catch (error) {
+    if (error instanceof H3Error) throw error
     return errorHandler(error)
   }
 })

--- a/server/api/todos/[id].patch.ts
+++ b/server/api/todos/[id].patch.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/[id].patch.ts
-import { defineEventHandler, readBody, createError, getRouterParam } from 'h3'
+import { defineEventHandler, readBody, createError, getRouterParam, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -69,6 +69,7 @@ export default defineEventHandler(async (event) => {
 
     return { success: true, message: 'Todo updated.', data: updated }
   } catch (error) {
+    if (error instanceof H3Error) throw error
     return errorHandler(error)
   }
 })

--- a/server/api/todos/index.get.ts
+++ b/server/api/todos/index.get.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/index.get.ts
-import { defineEventHandler, getQuery } from 'h3'
+import { defineEventHandler, getQuery, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -39,6 +39,7 @@ export default defineEventHandler(async (event) => {
 
     return { success: true, data: sortTodos(todos) }
   } catch (error) {
+    if (error instanceof H3Error) throw error
     return errorHandler(error)
   }
 })

--- a/server/api/todos/index.post.ts
+++ b/server/api/todos/index.post.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/index.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { defineEventHandler, readBody, createError, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -53,6 +53,7 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = 201
     return { success: true, message: 'Todo created.', data: todo }
   } catch (error) {
+    if (error instanceof H3Error) throw error
     return errorHandler(error)
   }
 })


### PR DESCRIPTION
…atus codes

The try/catch in all todo handlers was swallowing createError H3Errors and passing them to errorHandler, which only returned the statusCode in the response body without setting the HTTP status. Re-throw H3Errors so H3 applies the correct status (401, 400, 404) automatically.


Claude-Session: https://claude.ai/code/session_017H4hHjEsdiXn1CoiEFjfEu