### PR TITLE
Fix missing-image reporter source selection

### DIFF
--- a/plugins/missing-image-reporter.client.ts
+++ b/plugins/missing-image-reporter.client.ts
@@ -24,7 +24,11 @@ function cleanString(value: unknown): string {
 }
 
 function imageSource(img: HTMLImageElement): string {
-  return cleanString(img.currentSrc) || cleanString(img.src) || cleanString(img.getAttribute('src'))
+  return (
+    cleanString(img.getAttribute('src')) ||
+    cleanString(img.currentSrc) ||
+    cleanString(img.src)
+  )
 }
 
 function hasImageExtension(src: string): boolean {


### PR DESCRIPTION
### Task
Fix the missing-image smoke test where `/api/conductor/art-request` could receive an optimized/transformed image URL and reject it with a 400.

### What changed
- Updated `plugins/missing-image-reporter.client.ts` so `imageSource()` prefers the original `<img src>` attribute before `currentSrc` or resolved `img.src`.
- This keeps reports like `/images/dev/conductor-missing-image-pipeline-test-card.webp` clean when they reach the server route.

### How to test
1. Deploy this patch.
2. Log into Kind Robots as an admin.
3. Visit `/dev/missing-image-test`.
4. In DevTools, confirm `/api/conductor/art-request` receives the plain missing image path rather than an `/_ipx/...` URL.
5. Confirm Conductor receives a pending request under `projects/art-prompts.yaml` → `requests:`.

### Stakes
reversible