### PR TITLE
feat: persist pitch votes to conductor repo via API

### DIFF
--- a/server/api/conductor/pitch-vote.post.ts
+++ b/server/api/conductor/pitch-vote.post.ts
@@ -1,0 +1,31 @@
+import { conductorGet, conductorPut } from '~/server/utils/conductor-github'
+
+type PitchVote = 'approved' | 'passed'
+
+export default defineEventHandler(async (event) => {
+  const { slug, vote } = await readBody<{ slug: string; vote: PitchVote }>(event)
+
+  if (!slug?.trim()) {
+    throw createError({ statusCode: 400, statusMessage: 'slug is required' })
+  }
+  if (vote !== 'approved' && vote !== 'passed') {
+    throw createError({ statusCode: 400, statusMessage: 'vote must be "approved" or "passed"' })
+  }
+
+  const path = `pitches/${slug}.md`
+  const file = await conductorGet(path)
+
+  if (!file) {
+    throw createError({ statusCode: 404, statusMessage: `Pitch not found: ${slug}` })
+  }
+
+  const updated = file.content.replace(/^status:.*$/m, `status: ${vote}`)
+
+  if (updated === file.content) {
+    return { success: true, changed: false, path }
+  }
+
+  await conductorPut(path, updated, `vote: ${vote} ${slug}`, file.sha)
+
+  return { success: true, changed: true, path }
+})

--- a/stores/conductorStore.ts
+++ b/stores/conductorStore.ts
@@ -62,7 +62,9 @@ export const useConductorStore = defineStore('conductor', () => {
     }
   }
 
-  // ── Pitch votes (localStorage-backed) ─────────────────────────────────────
+  // ── Pitch votes ───────────────────────────────────────────────────────────
+  // Stored in localStorage for instant UI feedback; each vote is also
+  // persisted to the conductor repo via the pitch-vote API so agents see it.
   const votedPitches = ref<Record<string, PitchVote>>(
     lsGet<Record<string, PitchVote>>(VOTE_KEY) ?? {},
   )
@@ -74,13 +76,19 @@ export const useConductorStore = defineStore('conductor', () => {
   function voteOnPitch(slug: string, choice: PitchVote): void {
     votedPitches.value = { ...votedPitches.value, [slug]: choice }
     lsSet(VOTE_KEY, votedPitches.value)
+    $fetch('/api/conductor/pitch-vote', {
+      method: 'POST',
+      body: { slug, vote: choice },
+    }).catch((err) => {
+      console.error('[conductor] pitch vote failed to persist to repo:', err)
+    })
   }
 
   function clearVote(slug: string): void {
     const next = { ...votedPitches.value }
     delete next[slug]
     votedPitches.value = next
-    lsSet(VOTE_KEY, votedPitches.value)
+    lsSet(VOTE_KEY, next)
   }
 
   // ── Project priorities (localStorage-backed, synced to API) ───────────────


### PR DESCRIPTION
Adds POST /api/conductor/pitch-vote that reads the pitch file from the conductor repo, rewrites its status line, and commits it back via conductorPut. Updates conductorStore.voteOnPitch to call this endpoint alongside the existing localStorage write, so votes survive page reloads and are visible to agents.