### PR TITLE
Rename Humboldt Scoop CMS conductor card

### DIFF
--- a/stores/helpers/conductorCards.ts
+++ b/stores/helpers/conductorCards.ts
@@ -66,8 +66,8 @@ export const CONDUCTOR_CARDS: ConductorCard[] = [
     restoresFields: [],
   },
   {
-    key: 'humboldt-poop-scoop-cms',
-    label: 'Poop Scoop CMS',
+    key: 'humboldt-scoop-cms',
+    label: 'Humboldt Scoop CMS',
     title: 'Customer Management',
     icon: 'kind-icon:toolbox',
     tagline: 'Simple self-hostable CMS',
@@ -77,9 +77,9 @@ export const CONDUCTOR_CARDS: ConductorCard[] = [
     taskStatus: 'ready',
     priority: 2,
     narrative:
-      'Building the customer-management tool for the poop-scoop business. Simple and self-hostable with dummy data only until approved.',
+      'Building the customer-management tool for Humboldt Scoop. Simple and self-hostable with dummy data only until approved.',
     description:
-      'Building the customer-management tool for the poop-scoop business. Simple and self-hostable with dummy data only until approved.',
+      'Building the customer-management tool for Humboldt Scoop. Simple and self-hostable with dummy data only until approved.',
     steps: [],
     restoresFields: [],
   },


### PR DESCRIPTION
### Task
Rename the Kind Robots conductor card key/name to `humboldt-scoop-cms`.

### What changed / what I produced
- Updated `stores/helpers/conductorCards.ts`:
  - `key: 'humboldt-scoop-cms'`
  - label/title copy now says `Humboldt Scoop CMS` / `Customer Management`
  - narrative/description now references Humboldt Scoop directly.

### How I verified
- Searched the repo for the old slug.
- Confirmed `public/images/projects/heroes` was not found in this repository through the GitHub connector.

### Stakes
reversible

### Notes for reviewer
Silas mentioned local image files under `kind_robots/public/images/projects/heroes`, but that path was not present in the GitHub repo from this connector. I only updated the tracked card helper here.