### PR TITLE
feat(conductor): LLM-powered contextual art prompt generation for missing images

### DIFF
--- a/server/api/conductor/art-request.post.ts
+++ b/server/api/conductor/art-request.post.ts
@@ -5,6 +5,7 @@ import { defineEventHandler, readBody, createError } from 'h3'
 import { errorHandler } from '@/server/utils/error'
 import { userIsAdmin } from '@/server/utils/authUser'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { buildContextualArtPrompt } from '@/server/utils/conductorArtPrompt'
 
 const GITHUB_API = 'https://api.github.com'
 const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
@@ -31,6 +32,11 @@ type MissingArtRequestBody = {
   variant?: string
   size?: string
   prompt?: string
+  pageTitle?: string
+  pageDescription?: string
+  nearestHeading?: string
+  nearbyText?: string
+  imageClass?: string
 }
 
 type GitHubFile = {
@@ -264,7 +270,7 @@ function yamlFolded(key: string, value: string, indent = '    '): string {
   return `${key}: >\n${indent}${clean}`
 }
 
-function buildPrompt(body: MissingArtRequestBody, target: ImageTarget): string {
+function buildFallbackPrompt(body: MissingArtRequestBody, target: ImageTarget): string {
   const explicit = cleanString(body.prompt)
   if (explicit) return explicit
 
@@ -285,13 +291,15 @@ function buildPrompt(body: MissingArtRequestBody, target: ImageTarget): string {
   return `polished web illustration for ${label}, clear subject, cohesive Kind Robots visual style, no text`
 }
 
-function buildEntry(body: MissingArtRequestBody, target: ImageTarget): ArtQueueEntry {
+async function buildEntry(body: MissingArtRequestBody, target: ImageTarget): Promise<ArtQueueEntry> {
   const repoName = target.targetRepo.split('/').pop() ?? 'repo'
   const hash = createHash('sha1')
     .update(`${target.targetRepo}:${target.imagePath}:${target.sourceUrl}`)
     .digest('hex')
     .slice(0, 8)
   const id = `${slugify(`${repoName}-${target.slug}-${target.variant}`)}-${hash}`
+  const fallbackPrompt = buildFallbackPrompt(body, target)
+  const prompt = await buildContextualArtPrompt(body, target, fallbackPrompt)
 
   return {
     id,
@@ -304,7 +312,7 @@ function buildEntry(body: MissingArtRequestBody, target: ImageTarget): ArtQueueE
     variant: target.variant,
     size: target.size,
     label: cleanString(body.alt || body.label) || titleFromSlug(target.slug),
-    prompt: buildPrompt(body, target),
+    prompt,
   }
 }
 
@@ -420,7 +428,7 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    const entry = buildEntry(body, target)
+    const entry = await buildEntry(body, target)
     const result = await updateConductorQueue(entry, token)
 
     event.node.res.statusCode = result.created ? 201 : 200

--- a/server/utils/conductorArtPrompt.ts
+++ b/server/utils/conductorArtPrompt.ts
@@ -1,0 +1,168 @@
+type ArtPromptTarget = {
+  sourceUrl: string
+  targetRepo: string
+  targetRef: string
+  imagePath: string
+  publicPath: string
+  variant: string
+  size: string
+  slug: string
+}
+
+type ArtPromptRequestBody = {
+  pageUrl?: string
+  alt?: string
+  label?: string
+  prompt?: string
+  pageTitle?: string
+  pageDescription?: string
+  nearestHeading?: string
+  nearbyText?: string
+  imageClass?: string
+}
+
+type OpenAITextContent = {
+  type?: string
+  text?: string
+}
+
+type OpenAIOutputItem = {
+  type?: string
+  content?: OpenAITextContent[]
+}
+
+type OpenAIResponse = {
+  output_text?: string
+  output?: OpenAIOutputItem[]
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function compact(value: string, maxLength = 1200): string {
+  const clean = value.replace(/\s+/g, ' ').trim()
+  if (clean.length <= maxLength) return clean
+  return `${clean.slice(0, maxLength - 1).trim()}…`
+}
+
+function openAiKey(): string {
+  return String(process.env.OPENAI_API_KEY || '').trim()
+}
+
+function openAiModel(): string {
+  return String(
+    process.env.OPENAI_ART_PROMPT_MODEL ||
+      process.env.OPENAI_MODEL ||
+      'gpt-5.5-mini',
+  ).trim()
+}
+
+function responseText(data: OpenAIResponse): string {
+  const direct = cleanString(data.output_text)
+  if (direct) return direct
+
+  for (const item of data.output ?? []) {
+    for (const part of item.content ?? []) {
+      if (part.type === 'output_text' || part.text) {
+        const text = cleanString(part.text)
+        if (text) return text
+      }
+    }
+  }
+
+  return ''
+}
+
+function sanitizePrompt(value: string): string {
+  return compact(
+    value
+      .replace(/^```[a-z]*\s*/i, '')
+      .replace(/```$/i, '')
+      .replace(/^prompt\s*:\s*/i, '')
+      .trim(),
+    900,
+  )
+}
+
+function promptContext(body: ArtPromptRequestBody, target: ArtPromptTarget): string {
+  const context = {
+    requestedAsset: {
+      imagePath: target.imagePath,
+      publicPath: target.publicPath,
+      sourceUrl: target.sourceUrl,
+      targetRepo: target.targetRepo,
+      variant: target.variant,
+      size: target.size,
+      slug: target.slug,
+    },
+    pageContext: {
+      pageUrl: cleanString(body.pageUrl),
+      pageTitle: cleanString(body.pageTitle),
+      pageDescription: cleanString(body.pageDescription),
+      nearestHeading: cleanString(body.nearestHeading),
+      nearbyText: cleanString(body.nearbyText),
+    },
+    imageContext: {
+      alt: cleanString(body.alt),
+      label: cleanString(body.label),
+      className: cleanString(body.imageClass),
+    },
+  }
+
+  return JSON.stringify(context, null, 2)
+}
+
+export async function buildContextualArtPrompt(
+  body: ArtPromptRequestBody,
+  target: ArtPromptTarget,
+  fallbackPrompt: string,
+): Promise<string> {
+  const explicit = cleanString(body.prompt)
+  if (explicit) return explicit
+
+  const token = openAiKey()
+  if (!token) return fallbackPrompt
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: openAiModel(),
+        instructions: [
+          'You write production-ready image generation prompts for the Kind Robots website.',
+          'Infer what missing web artwork should be from the asset path, page URL, image label, and page context.',
+          'Return one vivid prompt only. No markdown, no JSON, no quotes.',
+          'Always include the intended composition, mood, subject matter, style direction, and "no text".',
+          'Respect the requested variant: icon is square and simple, card is 2:3 portrait, hero is 16:9 landscape.',
+          'Avoid copyrighted characters, logos, brands, text in the image, and vague filler.',
+        ].join(' '),
+        input: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: `Create the best image prompt for this missing asset.\n\n${promptContext(body, target)}`,
+              },
+            ],
+          },
+        ],
+        max_output_tokens: 260,
+      }),
+    })
+
+    if (!res.ok) return fallbackPrompt
+
+    const data = (await res.json()) as OpenAIResponse
+    const generated = sanitizePrompt(responseText(data))
+
+    return generated || fallbackPrompt
+  } catch {
+    return fallbackPrompt
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `server/utils/conductorArtPrompt.ts` — a utility that calls the OpenAI Responses API to generate a vivid, context-aware image generation prompt for a missing asset, using page URL, page title, nearby text, alt text, image class, and asset path as context
- Upgrades `server/api/conductor/art-request.post.ts` to call `buildContextualArtPrompt` instead of the old static fallback, so queued art requests in `conductor/projects/art-prompts.yaml` get richer, more specific prompts automatically
- Falls back gracefully to the rule-based prompt if `OPENAI_API_KEY` is absent or the call fails
- Prompt model is configurable via `OPENAI_ART_PROMPT_MODEL` (defaults to `gpt-5.5-mini`)
- Endpoint remains admin-only

## Test plan

- [ ] Missing image request without `OPENAI_API_KEY` set still queues a valid fallback prompt
- [ ] With a valid key, the queued prompt reflects page context (title, nearby text, etc.)
- [ ] Icon / card / hero variants generate appropriately shaped prompts
- [ ] Duplicate image paths are not re-queued
- [ ] Non-admin requests still return 403

---
_Generated by [Claude Code](https://claude.ai/code/session_019H1fEQk6GMydnmURw6dMpZ)_