### PR TITLE
feat: add slot-reel, hero-showcase, and swipe-deck gallery views

### DIFF
--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -63,11 +63,14 @@
         <select
           v-if="showControls"
           v-model="layoutMode"
-          class="select select-bordered select-sm h-9 w-24 shrink-0 rounded-2xl bg-base-200"
+          class="select select-bordered select-sm h-9 w-28 shrink-0 rounded-2xl bg-base-200"
           aria-label="Dream gallery layout"
         >
           <option value="grid">Grid</option>
           <option value="row">Row</option>
+          <option value="reel">Reel</option>
+          <option value="hero">Hero</option>
+          <option value="swipe">Swipe</option>
         </select>
 
         <button
@@ -320,12 +323,13 @@
 
       <div v-else class="flex flex-col gap-3">
         <dream-sheet-toolbar
-          v-if="showSheetToolbar"
+          v-if="showSheetToolbar && isClassicLayout"
           :dreams="filteredDreams"
           :auto-refresh="autoLoadSheets"
         />
 
-        <div :class="layoutClass">
+        <!-- Classic grid / row views -->
+        <div v-if="isClassicLayout" :class="layoutClass">
           <dream-card
             v-for="dream in filteredDreams"
             :key="dream.id"
@@ -349,6 +353,22 @@
             @delete="handleDreamDeleted"
           />
         </div>
+
+        <slot-reel-gallery
+          v-if="layoutMode === 'reel'"
+          :items="showcaseItems"
+          @select="({ id }) => selectDreamAndOpen(Number(id))"
+        />
+        <hero-showcase
+          v-if="layoutMode === 'hero'"
+          :items="showcaseItems"
+          @select="({ id }) => selectDreamAndOpen(Number(id))"
+        />
+        <swipe-deck
+          v-if="layoutMode === 'swipe'"
+          :items="showcaseItems"
+          @select="({ id }) => selectDreamAndOpen(Number(id))"
+        />
       </div>
     </section>
   </section>
@@ -437,7 +457,9 @@ const searchQuery = ref('')
 const showMineOnly = ref(false)
 const showArchived = ref(false)
 const isLoading = ref(false)
-const layoutMode = ref<'grid' | 'row'>(props.variant === 'row' ? 'row' : 'grid')
+const layoutMode = ref<'grid' | 'row' | 'reel' | 'hero' | 'swipe'>(
+  props.variant === 'row' ? 'row' : 'grid',
+)
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
 
@@ -454,11 +476,24 @@ const isCompact = computed(() => {
   return props.compact || props.variant === 'row' || isDropdownMode.value
 })
 
+const isClassicLayout = computed(
+  () => layoutMode.value === 'grid' || layoutMode.value === 'row',
+)
+
 const layoutClass = computed(() => {
   return layoutMode.value === 'row' || props.variant === 'row'
     ? 'dream-row'
     : 'dream-grid'
 })
+
+const showcaseItems = computed(() =>
+  filteredDreams.value.map((dream) => ({
+    id: dream.id,
+    title: getDreamTitle(dream),
+    imagePath: previewImage(dream),
+    description: getDreamDescription(dream),
+  })),
+)
 
 const currentUserId = computed(() => {
   return userStore.userId ?? userStore.user?.id ?? null

--- a/components/navigation/hero-showcase.vue
+++ b/components/navigation/hero-showcase.vue
@@ -1,0 +1,265 @@
+<!-- /components/navigation/hero-showcase.vue
+     Cinematic hero card carousel. Full-bleed image with crossfade, auto-advance
+     progress bar, prev/next navigation, dot indicators, and a rich description panel. -->
+<template>
+  <div
+    class="flex h-full min-h-80 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+    @mouseenter="isPaused = true"
+    @mouseleave="isPaused = false"
+  >
+    <!-- ── Hero image ───────────────────────────────────────────────── -->
+    <div class="relative min-h-0 flex-1 overflow-hidden bg-base-300">
+      <!-- Crossfade: both old and new images are absolute, overlapping during transition -->
+      <Transition name="hero-xfade">
+        <img
+          v-if="currentItem.imagePath"
+          :key="currentItem.id"
+          :src="currentItem.imagePath"
+          :alt="currentItem.title"
+          class="absolute inset-0 h-full w-full object-cover"
+        />
+        <div
+          v-else
+          :key="`ph-${currentItem.id}`"
+          class="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-primary/15 via-secondary/10 to-accent/10"
+        >
+          <Icon name="kind-icon:image" class="h-20 w-20 text-base-content/15" />
+        </div>
+      </Transition>
+
+      <!-- Cinematic gradient overlay -->
+      <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-100 via-base-100/10 to-transparent" />
+
+      <!-- Prev button -->
+      <button
+        v-if="items.length > 1"
+        type="button"
+        class="absolute left-3 top-1/2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-base-100/80 shadow backdrop-blur transition hover:bg-base-100 hover:shadow-md"
+        aria-label="Previous"
+        @click="prev"
+      >
+        <Icon name="kind-icon:chevron-left" class="h-5 w-5 text-base-content" />
+      </button>
+
+      <!-- Next button -->
+      <button
+        v-if="items.length > 1"
+        type="button"
+        class="absolute right-3 top-1/2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-base-100/80 shadow backdrop-blur transition hover:bg-base-100 hover:shadow-md"
+        aria-label="Next"
+        @click="next"
+      >
+        <Icon name="kind-icon:chevron-right" class="h-5 w-5 text-base-content" />
+      </button>
+
+      <!-- Auto-advance progress bar -->
+      <div v-if="items.length > 1" class="absolute inset-x-0 bottom-0 z-10 h-0.5 bg-base-300/30">
+        <div
+          class="progress-fill h-full bg-primary"
+          :key="progressKey"
+          :class="{ 'animation-paused': isPaused }"
+          :style="{ '--interval': `${intervalMs}ms` }"
+        />
+      </div>
+    </div>
+
+    <!-- ── Description panel ────────────────────────────────────────── -->
+    <div class="shrink-0 p-4 sm:p-5">
+      <!-- Dot navigation + counter -->
+      <div v-if="items.length > 1" class="mb-3 flex items-center gap-2">
+        <div class="flex items-center gap-1.5">
+          <button
+            v-for="(_, i) in items"
+            :key="i"
+            type="button"
+            class="h-1.5 rounded-full bg-base-300 transition-all hover:bg-primary/60"
+            :class="i === currentIndex ? 'w-6 bg-primary' : 'w-1.5'"
+            :aria-label="`Go to item ${i + 1}`"
+            @click="goTo(i)"
+          />
+        </div>
+        <span class="ml-auto text-xs tabular-nums text-base-content/35">
+          {{ currentIndex + 1 }}&thinsp;/&thinsp;{{ items.length }}
+        </span>
+      </div>
+
+      <!-- Title + description with slide-up transition -->
+      <Transition name="desc-slide" mode="out-in">
+        <div :key="currentItem.id" class="flex flex-col gap-2">
+          <h2 class="text-2xl font-black leading-tight tracking-tight text-base-content sm:text-3xl">
+            {{ currentItem.title }}
+          </h2>
+          <p
+            v-if="currentItem.description"
+            class="line-clamp-3 text-sm leading-relaxed text-base-content/65 sm:text-base"
+          >
+            {{ currentItem.description }}
+          </p>
+        </div>
+      </Transition>
+
+      <button
+        type="button"
+        class="btn btn-primary btn-sm mt-3 rounded-xl gap-1.5"
+        @click="$emit('select', { id: currentItem.id })"
+      >
+        <Icon name="kind-icon:arrow-right" class="h-4 w-4" />
+        Open
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+interface GalleryItem {
+  id: number | string
+  title: string
+  imagePath: string
+  description: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    items: GalleryItem[]
+    intervalMs?: number
+  }>(),
+  {
+    intervalMs: 5000,
+  },
+)
+
+defineEmits<{
+  select: [{ id: number | string }]
+}>()
+
+const currentIndex = ref(0)
+const isPaused = ref(false)
+const progressKey = ref(0)
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+const currentItem = computed(
+  () => props.items[currentIndex.value] ?? props.items[0] ?? { id: 0, title: '', imagePath: '', description: '' },
+)
+
+function mod(n: number, m: number) {
+  return ((n % m) + m) % m
+}
+
+function goTo(i: number) {
+  if (!props.items.length) return
+  currentIndex.value = mod(i, props.items.length)
+  progressKey.value++
+  restartInterval()
+}
+
+function next() {
+  goTo(currentIndex.value + 1)
+}
+
+function prev() {
+  goTo(currentIndex.value - 1)
+}
+
+function restartInterval() {
+  if (intervalId) clearInterval(intervalId)
+  if (props.items.length <= 1) return
+
+  intervalId = setInterval(() => {
+    if (!isPaused.value) next()
+  }, props.intervalMs)
+}
+
+onMounted(() => {
+  restartInterval()
+})
+
+onBeforeUnmount(() => {
+  if (intervalId) clearInterval(intervalId)
+})
+
+watch(
+  () => props.items,
+  () => {
+    currentIndex.value = 0
+    progressKey.value++
+    restartInterval()
+  },
+)
+</script>
+
+<style scoped>
+/* ── Crossfade transition ──────────────────────────────────────────── */
+.hero-xfade-enter-active,
+.hero-xfade-leave-active {
+  position: absolute;
+  inset: 0;
+  transition: opacity 0.55s ease;
+}
+
+.hero-xfade-enter-active {
+  z-index: 1;
+}
+
+.hero-xfade-leave-active {
+  z-index: 0;
+}
+
+.hero-xfade-enter-from,
+.hero-xfade-leave-to {
+  opacity: 0;
+}
+
+/* ── Description slide-up ─────────────────────────────────────────── */
+.desc-slide-enter-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.desc-slide-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.desc-slide-leave-active {
+  /* Instant removal; the entering version slides in over the gap */
+  transition: none;
+  opacity: 0;
+}
+
+/* ── Auto-advance progress bar ────────────────────────────────────── */
+.progress-fill {
+  width: 0;
+  animation: progress-expand var(--interval) linear forwards;
+  transform-origin: left;
+}
+
+.progress-fill.animation-paused {
+  animation-play-state: paused;
+}
+
+@keyframes progress-expand {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-xfade-enter-active,
+  .hero-xfade-leave-active {
+    transition: none;
+  }
+
+  .desc-slide-enter-active {
+    transition: none;
+  }
+
+  .progress-fill {
+    animation: none;
+    width: 100%;
+  }
+}
+</style>

--- a/components/navigation/slot-reel-gallery.vue
+++ b/components/navigation/slot-reel-gallery.vue
@@ -1,0 +1,193 @@
+<!-- /components/navigation/slot-reel-gallery.vue
+     Infinitely looping vertical reels, slot-machine style.
+     Each column scrolls at a different speed. Hover pauses a column.
+     Click selects/emits an item. -->
+<template>
+  <div ref="containerEl" class="relative h-full min-h-72 overflow-hidden rounded-2xl bg-base-300/40">
+    <!-- Top fade mask -->
+    <div class="pointer-events-none absolute inset-x-0 top-0 z-20 h-24 bg-gradient-to-b from-base-100 to-transparent" />
+    <!-- Bottom fade mask -->
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-24 bg-gradient-to-t from-base-100 to-transparent" />
+
+    <!-- Selection window — glowing band in the center -->
+    <div
+      class="pointer-events-none absolute inset-x-2 z-10 rounded-xl ring-1 ring-primary/50"
+      :style="windowStyle"
+      aria-hidden="true"
+    />
+
+    <!-- Reel columns -->
+    <div class="flex h-full gap-2 p-2">
+      <div
+        v-for="(col, ci) in columns"
+        :key="ci"
+        class="relative min-w-0 flex-1 overflow-hidden"
+        @mouseenter="pausedCol = ci"
+        @mouseleave="pausedCol = -1"
+      >
+        <div class="reel-track" :class="{ 'reel-paused': pausedCol === ci }" :style="trackStyle(ci, col.length / 2)">
+          <div
+            v-for="(item, ii) in col"
+            :key="`${ci}-${ii}-${item.id}`"
+            class="reel-item group relative w-full cursor-pointer overflow-hidden rounded-xl border border-base-300/50 bg-base-200 transition-all hover:border-primary/70 hover:shadow-lg hover:shadow-primary/10"
+            @click="$emit('select', { id: item.id })"
+          >
+            <img
+              v-if="item.imagePath"
+              :src="item.imagePath"
+              :alt="item.title"
+              class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
+              loading="lazy"
+            />
+            <div
+              v-else
+              class="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/10 to-secondary/10"
+            >
+              <Icon name="kind-icon:image" class="h-8 w-8 text-base-content/20" />
+            </div>
+            <!-- Title bar -->
+            <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-base-300/90 to-transparent px-2 pb-1.5 pt-8">
+              <p class="truncate text-center text-xs font-black text-base-content drop-shadow">
+                {{ item.title || `#${item.id}` }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-if="!items.length"
+      class="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 text-center"
+    >
+      <Icon name="kind-icon:gallery" class="h-14 w-14 text-base-content/20" />
+      <p class="text-sm font-black text-base-content/40">Nothing in the reel yet.</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import type { CSSProperties } from 'vue'
+
+interface GalleryItem {
+  id: number | string
+  title: string
+  imagePath: string
+  description: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    items: GalleryItem[]
+    itemH?: number
+  }>(),
+  {
+    itemH: 176,
+  },
+)
+
+defineEmits<{
+  select: [{ id: number | string }]
+}>()
+
+const ITEM_GAP = 8
+// Pixels per second for each column — intentionally varied for the reel feel
+const COL_SPEEDS_PX_S = [28, 20, 15, 24]
+
+const containerEl = ref<HTMLElement | null>(null)
+const pausedCol = ref(-1)
+const effectiveColCount = ref(3)
+
+function updateColCount() {
+  if (!import.meta.client) return
+  const w = containerEl.value?.clientWidth ?? window.innerWidth
+  effectiveColCount.value = w < 480 ? 2 : 3
+}
+
+onMounted(() => {
+  updateColCount()
+  window.addEventListener('resize', updateColCount)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateColCount)
+})
+
+const columns = computed<GalleryItem[][]>(() => {
+  if (!props.items.length) return []
+  const count = Math.min(effectiveColCount.value, props.items.length)
+  const cols: GalleryItem[][] = Array.from({ length: count }, () => [])
+
+  props.items.forEach((item, i) => {
+    cols[i % count].push(item)
+  })
+
+  // Duplicate for seamless loop; pad short columns to at least 4 visible items
+  return cols.map((col) => {
+    let base = col
+    while (base.length < 4) base = [...base, ...base]
+    return [...base, ...base]
+  })
+})
+
+const unitH = computed(() => props.itemH + ITEM_GAP)
+
+// Glowing band positioned just below the top fade
+const windowStyle = computed<CSSProperties>(() => ({
+  top: '88px',
+  height: `${props.itemH}px`,
+  boxShadow: '0 0 32px 6px hsl(var(--p) / 0.12)',
+}))
+
+function trackStyle(ci: number, singleCount: number): CSSProperties {
+  const singleH = singleCount * unitH.value
+  const speed = COL_SPEEDS_PX_S[ci % COL_SPEEDS_PX_S.length]
+  const durationMs = Math.max(3000, Math.round((singleH / speed) * 1000))
+
+  return {
+    '--item-h': `${props.itemH}px`,
+    '--item-gap': `${ITEM_GAP}px`,
+    '--single-h': `${singleH}px`,
+    '--reel-duration': `${durationMs}ms`,
+  } as CSSProperties
+}
+</script>
+
+<style scoped>
+.reel-track {
+  display: flex;
+  flex-direction: column;
+  will-change: transform;
+  animation: reel-scroll-up var(--reel-duration) linear infinite;
+}
+
+.reel-track.reel-paused {
+  animation-play-state: paused;
+}
+
+/* margin-bottom on EVERY item (including last of each copy) keeps the gap
+   between copy-1 and copy-2 identical to gaps within each copy, giving
+   a seamless wrap at translateY(-single-h). */
+.reel-item {
+  height: var(--item-h);
+  flex-shrink: 0;
+  margin-bottom: var(--item-gap);
+}
+
+@keyframes reel-scroll-up {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(calc(-1 * var(--single-h)));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reel-track {
+    animation: none;
+  }
+}
+</style>

--- a/components/navigation/swipe-deck.vue
+++ b/components/navigation/swipe-deck.vue
@@ -1,0 +1,328 @@
+<!-- /components/navigation/swipe-deck.vue
+     Tinder-style art-first swipe deck. Art fills the card in portrait orientation.
+     Drag/swipe right = select, left = skip. Touch and mouse pointer events both work.
+     Cards behind the active one are visible as a depth stack. -->
+<template>
+  <div class="flex h-full min-h-[32rem] flex-col items-center gap-4 overflow-hidden rounded-2xl bg-base-300/40 p-4 sm:p-6">
+    <!-- ── Card stack ────────────────────────────────────────────────── -->
+    <div class="relative flex w-full max-w-xs flex-1 items-center justify-center sm:max-w-sm">
+      <!-- Depth cards — purely visual, show next items -->
+      <template v-for="depth in [2, 1]" :key="depth">
+        <div
+          v-if="peekItem(depth)"
+          class="absolute w-full overflow-hidden rounded-2xl border border-base-300 bg-base-200 shadow"
+          :style="depthCardStyle(depth)"
+          aria-hidden="true"
+        >
+          <div class="aspect-[3/4] w-full overflow-hidden">
+            <img
+              v-if="peekItem(depth)?.imagePath"
+              :src="peekItem(depth)!.imagePath"
+              :alt="peekItem(depth)!.title"
+              class="h-full w-full object-cover"
+              loading="lazy"
+            />
+            <div v-else class="flex h-full items-center justify-center bg-base-300">
+              <Icon name="kind-icon:image" class="h-10 w-10 text-base-content/15" />
+            </div>
+          </div>
+          <div class="p-3">
+            <p class="truncate text-sm font-black text-base-content/30">{{ peekItem(depth)?.title }}</p>
+          </div>
+        </div>
+      </template>
+
+      <!-- Active card -->
+      <div
+        v-if="currentItem"
+        ref="cardEl"
+        class="relative w-full cursor-grab select-none overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-xl active:cursor-grabbing"
+        :style="activeCardStyle"
+        @pointerdown.prevent="onPointerDown"
+        @pointermove="onPointerMove"
+        @pointerup="onPointerUp"
+        @pointercancel="onPointerUp"
+      >
+        <!-- LIKE indicator (right swipe) -->
+        <div
+          class="absolute left-4 top-4 z-10 rounded-xl border-2 border-success px-3 py-1 text-lg font-black uppercase text-success transition-opacity duration-75"
+          :style="{ opacity: likeOpacity }"
+          aria-hidden="true"
+        >
+          Like
+        </div>
+        <!-- NOPE indicator (left swipe) -->
+        <div
+          class="absolute right-4 top-4 z-10 rounded-xl border-2 border-error px-3 py-1 text-lg font-black uppercase text-error transition-opacity duration-75"
+          :style="{ opacity: nopeOpacity }"
+          aria-hidden="true"
+        >
+          Nope
+        </div>
+
+        <!-- Art (portrait orientation) -->
+        <div class="relative aspect-[3/4] w-full overflow-hidden bg-base-300">
+          <img
+            v-if="currentItem.imagePath"
+            :src="currentItem.imagePath"
+            :alt="currentItem.title"
+            class="h-full w-full object-cover"
+            draggable="false"
+            loading="eager"
+          />
+          <div
+            v-else
+            class="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/15 via-secondary/10 to-accent/10"
+          >
+            <Icon name="kind-icon:image" class="h-20 w-20 text-base-content/15" />
+          </div>
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-100 via-transparent to-transparent" />
+        </div>
+
+        <!-- Info panel -->
+        <div class="p-4">
+          <h3 class="text-xl font-black leading-tight text-base-content">
+            {{ currentItem.title }}
+          </h3>
+          <p v-if="currentItem.description" class="mt-1 line-clamp-2 text-sm text-base-content/65">
+            {{ currentItem.description }}
+          </p>
+          <!-- Deck position hint -->
+          <p class="mt-2 text-xs font-semibold tabular-nums text-base-content/30">
+            {{ deckPosition }}
+          </p>
+        </div>
+      </div>
+
+      <!-- All-done state -->
+      <div
+        v-else
+        class="flex flex-col items-center gap-4 py-12 text-center"
+      >
+        <Icon name="kind-icon:sparkles" class="h-16 w-16 text-primary/40" />
+        <p class="text-lg font-black text-base-content/60">Deck complete!</p>
+        <p class="text-sm text-base-content/40">You've seen everything in this stack.</p>
+        <button type="button" class="btn btn-primary btn-sm rounded-xl" @click="reset">
+          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          Reset deck
+        </button>
+      </div>
+    </div>
+
+    <!-- ── Action buttons ────────────────────────────────────────────── -->
+    <div v-if="currentItem" class="flex shrink-0 items-center gap-5">
+      <!-- Skip -->
+      <button
+        type="button"
+        class="flex h-14 w-14 items-center justify-center rounded-full border-2 border-error/40 bg-base-100 shadow transition hover:border-error hover:bg-error/10 hover:shadow-md"
+        aria-label="Skip"
+        @click="swipeLeft"
+      >
+        <Icon name="kind-icon:x" class="h-6 w-6 text-error" />
+      </button>
+
+      <!-- Info / open -->
+      <button
+        type="button"
+        class="flex h-10 w-10 items-center justify-center rounded-full border border-base-300 bg-base-100 shadow transition hover:border-primary/60 hover:bg-primary/10"
+        aria-label="Open"
+        @click="onInfoClick"
+      >
+        <Icon name="kind-icon:info" class="h-5 w-5 text-base-content/60" />
+      </button>
+
+      <!-- Select / like -->
+      <button
+        type="button"
+        class="flex h-14 w-14 items-center justify-center rounded-full border-2 border-success/40 bg-base-100 shadow transition hover:border-success hover:bg-success/10 hover:shadow-md"
+        aria-label="Select"
+        @click="swipeRight"
+      >
+        <Icon name="kind-icon:check" class="h-6 w-6 text-success" />
+      </button>
+    </div>
+
+    <!-- Mini dot progress (capped at 12 dots) -->
+    <div v-if="items.length > 1 && currentItem" class="flex shrink-0 items-center gap-1">
+      <template v-if="items.length <= 12">
+        <div
+          v-for="(_, i) in items"
+          :key="i"
+          class="rounded-full bg-base-300 transition-all"
+          :class="
+            i < swipedCount
+              ? 'h-1.5 w-1.5 bg-primary/40'
+              : i === swipedCount
+                ? 'h-1.5 w-3 bg-primary'
+                : 'h-1.5 w-1.5'
+          "
+        />
+      </template>
+      <span v-else class="text-xs tabular-nums text-base-content/35">
+        {{ swipedCount + 1 }}&thinsp;/&thinsp;{{ items.length }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { CSSProperties } from 'vue'
+
+interface GalleryItem {
+  id: number | string
+  title: string
+  imagePath: string
+  description: string
+}
+
+const props = defineProps<{
+  items: GalleryItem[]
+}>()
+
+const emit = defineEmits<{
+  select: [{ id: number | string }]
+}>()
+
+// ── State ─────────────────────────────────────────────────────────────
+const swipedCount = ref(0)
+const dragX = ref(0)
+const isDragging = ref(false)
+const isFlying = ref(false)
+const flyDir = ref<'left' | 'right' | null>(null)
+const cardEl = ref<HTMLElement | null>(null)
+
+let pointerId = -1
+let startX = 0
+
+// ── Derived ───────────────────────────────────────────────────────────
+const currentItem = computed<GalleryItem | null>(
+  () => props.items[swipedCount.value] ?? null,
+)
+
+const deckPosition = computed(() => {
+  const remaining = props.items.length - swipedCount.value
+  return remaining <= 1 ? 'Last one!' : `${remaining} in stack`
+})
+
+function peekItem(depth: number): GalleryItem | null {
+  return props.items[swipedCount.value + depth] ?? null
+}
+
+// ── Gesture constants ─────────────────────────────────────────────────
+const SWIPE_THRESHOLD = 80
+const FLY_X = 600
+const FLY_DURATION_MS = 320
+
+// ── Card styles ───────────────────────────────────────────────────────
+const activeCardStyle = computed<CSSProperties>(() => {
+  if (isFlying.value) {
+    const rotation = flyDir.value === 'right' ? 22 : -22
+    return {
+      transform: `translateX(${flyDir.value === 'right' ? FLY_X : -FLY_X}px) rotate(${rotation}deg)`,
+      transition: `transform ${FLY_DURATION_MS}ms cubic-bezier(0.2, 0.0, 1.0, 1.0)`,
+      zIndex: 3,
+    }
+  }
+
+  if (isDragging.value) {
+    const rotation = dragX.value * 0.04
+    return {
+      transform: `translateX(${dragX.value}px) rotate(${rotation}deg)`,
+      transition: 'none',
+      zIndex: 3,
+    }
+  }
+
+  return {
+    transform: 'translateX(0) rotate(0deg)',
+    transition: 'transform 0.28s cubic-bezier(0.17, 0.67, 0.46, 1.0)',
+    zIndex: 3,
+  }
+})
+
+function depthCardStyle(depth: number): CSSProperties {
+  // As drag progresses, depth cards shift toward their promoted position
+  const progress = Math.min(1, Math.abs(dragX.value) / SWIPE_THRESHOLD)
+  const targetScale = depth === 1 ? 1.0 : 0.95
+  const restScale = depth === 1 ? 0.95 : 0.90
+  const scale = restScale + (targetScale - restScale) * progress
+  const translateY = depth === 1 ? `${8 - 8 * progress}px` : `${16 - 16 * progress}px`
+
+  return {
+    transform: `scale(${scale}) translateY(${translateY})`,
+    zIndex: 3 - depth,
+    transition: isDragging.value ? 'none' : 'transform 0.28s ease',
+  }
+}
+
+// ── Indicators ────────────────────────────────────────────────────────
+const likeOpacity = computed(() => Math.max(0, Math.min(1, dragX.value / SWIPE_THRESHOLD)))
+const nopeOpacity = computed(() => Math.max(0, Math.min(1, -dragX.value / SWIPE_THRESHOLD)))
+
+// ── Pointer handlers ──────────────────────────────────────────────────
+function onPointerDown(e: PointerEvent) {
+  if (isFlying.value || !currentItem.value) return
+  const el = e.currentTarget as HTMLElement
+  el.setPointerCapture(e.pointerId)
+  pointerId = e.pointerId
+  startX = e.clientX
+  dragX.value = 0
+  isDragging.value = true
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (!isDragging.value || e.pointerId !== pointerId) return
+  dragX.value = e.clientX - startX
+}
+
+function onPointerUp(e: PointerEvent) {
+  if (!isDragging.value || e.pointerId !== pointerId) return
+  isDragging.value = false
+
+  if (dragX.value > SWIPE_THRESHOLD) {
+    swipeRight()
+  } else if (dragX.value < -SWIPE_THRESHOLD) {
+    swipeLeft()
+  } else {
+    dragX.value = 0
+  }
+}
+
+// ── Actions ───────────────────────────────────────────────────────────
+function flyOff(dir: 'left' | 'right', andSelect = false) {
+  if (isFlying.value || !currentItem.value) return
+  if (andSelect) emit('select', { id: currentItem.value.id })
+  flyDir.value = dir
+  isFlying.value = true
+  dragX.value = 0
+
+  setTimeout(() => {
+    swipedCount.value++
+    isFlying.value = false
+    flyDir.value = null
+    dragX.value = 0
+  }, FLY_DURATION_MS)
+}
+
+function swipeLeft() {
+  flyOff('left', false)
+}
+
+function swipeRight() {
+  flyOff('right', true)
+}
+
+function onInfoClick() {
+  if (currentItem.value) emit('select', { id: currentItem.value.id })
+  flyOff('right', false)
+}
+
+function reset() {
+  swipedCount.value = 0
+  dragX.value = 0
+  isDragging.value = false
+  isFlying.value = false
+  flyDir.value = null
+}
+</script>


### PR DESCRIPTION
Three new visually distinct gallery modes accessible via the dream gallery layout selector (alongside the existing Grid and Row views):

- slot-reel-gallery: Three columns of infinitely looping vertical reels at staggered speeds (28/20/15 px/s). Hover pauses a column; click selects the dream. Gradient masks and a glowing selection window give a slot-machine vibe. Collapses to 2 columns on mobile.

- hero-showcase: Full-bleed crossfade carousel with a cinematic gradient overlay, auto-advance progress bar (pauses on hover), prev/next arrow nav, dot indicators, and a description panel with slide-up transition. Select button opens the dream directly.

- swipe-deck: Art-first portrait card stack. Drag/swipe right to select, left to skip. Shows 2 depth cards behind the active one that animate toward the camera as you drag. Like/Nope indicators fade in proportionally to drag distance. Touch + mouse pointer events. Deck-complete state with reset. Mini dot progress strip.

Integration: dream-gallery.vue gains a 5-option layout selector (Grid, Row, Reel, Hero, Swipe) and a `showcaseItems` computed that maps `filteredDreams` to the generic `GalleryItem` shape consumed by the new components.


Claude-Session: https://claude.ai/code/session_016v1gDo9kkztYpckEsqc4qX