### PR TITLE
feat: compact responsive breakpoints for card galleries

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -48,8 +48,8 @@
       <div
         v-if="showImage"
         :class="[
-          'relative min-h-0 w-full flex-1 overflow-hidden rounded-2xl border border-base-300 bg-base-300',
-          compact ? 'h-52' : 'h-80',
+          'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
+          compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
         ]"
       >
         <img
@@ -142,7 +142,10 @@
 
       <div
         v-else
-        class="flex min-h-56 flex-1 flex-col justify-end rounded-2xl border border-base-300 bg-linear-to-br from-primary/15 via-secondary/10 to-accent/15 p-3"
+        :class="[
+          'flex flex-col justify-end rounded-2xl border border-base-300 bg-linear-to-br from-primary/15 via-secondary/10 to-accent/15 p-3',
+          compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
+        ]"
       >
         <h2
           class="line-clamp-2 text-xl font-black leading-tight text-base-content"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -676,8 +676,8 @@ function handleBotDeleted(id: number) {
 <style scoped>
 .bot-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(160px, 100%), 1fr));
+  gap: 0.75rem;
 }
 
 .bot-row {
@@ -688,7 +688,7 @@ function handleBotDeleted(id: number) {
 }
 
 .bot-row > * {
-  min-width: min(240px, 85vw);
-  max-width: 360px;
+  min-width: min(200px, 80vw);
+  max-width: 280px;
 }
 </style>

--- a/components/builder/builder-card-grid.vue
+++ b/components/builder/builder-card-grid.vue
@@ -31,7 +31,7 @@
     <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
       <div
         v-if="store.visibleCards.length"
-        class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+        class="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
       >
         <builder-card
           v-for="card in store.visibleCards"

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -2,12 +2,12 @@
 <template>
   <button
     type="button"
-    class="group flex min-h-56 w-full flex-col overflow-hidden rounded-2xl border-2 bg-base-200 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg sm:min-h-60 lg:min-h-64 xl:flex-row"
+    class="group flex min-h-44 w-full flex-col overflow-hidden rounded-2xl border-2 bg-base-200 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg sm:min-h-52 md:min-h-56 xl:min-h-[8.5rem] xl:flex-row"
     :class="cardClass"
     @click="store.selectCard(card.key)"
   >
     <div
-      class="relative flex min-h-48 w-full shrink-0 items-center justify-center overflow-hidden bg-base-300 sm:min-h-56 lg:min-h-64 xl:min-h-full xl:w-2/5 xl:max-w-sm"
+      class="relative flex min-h-36 w-full shrink-0 items-center justify-center overflow-hidden bg-base-300 sm:min-h-44 md:min-h-52 xl:min-h-full xl:w-2/5 xl:max-w-[10rem]"
     >
       <img
         v-if="card.deckImage"
@@ -20,7 +20,7 @@
 
       <div
         v-else
-        class="flex h-full min-h-48 w-full items-center justify-center bg-base-300 sm:min-h-56 lg:min-h-64"
+        class="flex h-full w-full items-center justify-center bg-base-300"
       >
         <Icon
           :name="card.icon || 'kind-icon:cards'"
@@ -40,8 +40,8 @@
       </div>
     </div>
 
-    <div class="flex min-w-0 flex-1 flex-col gap-3 p-4 sm:p-5">
-      <div class="flex items-start justify-between gap-3">
+    <div class="flex min-w-0 flex-1 flex-col gap-2 p-3 xl:gap-1.5">
+      <div class="flex items-start justify-between gap-2">
         <div class="min-w-0">
           <p
             class="text-xs font-black uppercase tracking-widest text-primary/70"
@@ -49,34 +49,38 @@
             {{ card.label }}
           </p>
 
-          <h3 class="line-clamp-2 text-xl font-black leading-tight text-base-content">
+          <h3 class="line-clamp-2 text-lg font-black leading-tight text-base-content xl:text-sm">
             {{ card.title }}
           </h3>
         </div>
 
         <Icon
           :name="card.icon || 'kind-icon:cards'"
-          class="h-6 w-6 shrink-0 text-primary/70"
+          class="h-5 w-5 shrink-0 text-primary/70 xl:h-4 xl:w-4"
         />
       </div>
 
-      <div class="min-h-0 flex-1 space-y-2">
-        <p class="line-clamp-2 text-sm font-bold leading-snug text-secondary">
+      <div class="min-h-0 flex-1 space-y-1.5 xl:hidden">
+        <p class="line-clamp-1 text-sm font-bold leading-snug text-secondary">
           {{ card.tagline }}
         </p>
 
-        <p class="line-clamp-3 text-sm leading-relaxed text-base-content/60 sm:line-clamp-4">
+        <p class="line-clamp-2 text-sm leading-relaxed text-base-content/60">
           {{ card.narrative }}
         </p>
       </div>
 
-      <div class="mt-auto flex items-center justify-between gap-2 pt-2">
+      <p class="hidden line-clamp-2 text-xs leading-relaxed text-base-content/60 xl:block">
+        {{ card.tagline || card.narrative }}
+      </p>
+
+      <div class="mt-auto flex items-center justify-between gap-2 pt-1">
         <span class="text-xs font-bold text-base-content/40">
           {{ card.steps.length }} step{{ card.steps.length === 1 ? '' : 's' }}
         </span>
 
         <span
-          class="badge rounded-xl font-black"
+          class="badge badge-sm rounded-xl font-black"
           :class="isCompleted ? 'badge-success' : 'badge-primary badge-outline'"
         >
           {{ isCompleted ? 'done' : 'open' }}

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -45,8 +45,8 @@
     <div
       v-if="showImage"
       :class="[
-        'relative min-h-0 w-full flex-1 overflow-hidden rounded-2xl border border-base-300 bg-base-300',
-        compact ? 'h-52' : 'h-80',
+        'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
+        compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
       ]"
     >
       <img
@@ -117,7 +117,7 @@
 
     <div
       v-else
-      class="flex min-h-56 flex-1 flex-col justify-end rounded-2xl border border-base-300 bg-linear-to-br from-primary/15 via-secondary/10 to-accent/15 p-3"
+      :class="['flex flex-col justify-end rounded-2xl border border-base-300 bg-linear-to-br from-primary/15 via-secondary/10 to-accent/15 p-3', compact ? 'h-44 sm:h-48' : 'aspect-[2/3]']"
     >
       <h2
         class="line-clamp-2 text-xl font-black leading-tight text-base-content"

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -699,8 +699,8 @@ function handleCharacterDeleted(id: number) {
 <style scoped>
 .character-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr));
+  gap: 0.75rem;
 }
 
 .character-row {
@@ -711,7 +711,7 @@ function handleCharacterDeleted(id: number) {
 }
 
 .character-row > * {
-  min-width: min(240px, 85vw);
-  max-width: 360px;
+  min-width: min(200px, 80vw);
+  max-width: 280px;
 }
 </style>

--- a/components/composition/composition-gallery.vue
+++ b/components/composition/composition-gallery.vue
@@ -316,8 +316,8 @@ function handleDeleted(id: number) {
 <style scoped>
 .composition-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(200px, 100%), 1fr));
+  gap: 0.75rem;
 }
 .composition-row {
   display: flex;
@@ -326,7 +326,7 @@ function handleDeleted(id: number) {
   padding-bottom: 0.5rem;
 }
 .composition-row > * {
-  min-width: min(260px, 85vw);
-  max-width: 360px;
+  min-width: min(210px, 80vw);
+  max-width: 300px;
 }
 </style>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -658,8 +658,8 @@ function handleRewardDeleted(id: number) {
 <style scoped>
 .reward-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(160px, 100%), 1fr));
+  gap: 0.75rem;
 }
 
 .reward-row {
@@ -670,7 +670,7 @@ function handleRewardDeleted(id: number) {
 }
 
 .reward-row > * {
-  min-width: min(240px, 85vw);
-  max-width: 340px;
+  min-width: min(200px, 80vw);
+  max-width: 280px;
 }
 </style>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -538,8 +538,8 @@ function handleScenarioDeleted(id: number) {
 <style scoped>
 .scenario-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr));
+  gap: 0.75rem;
   align-items: start;
 }
 
@@ -553,15 +553,15 @@ function handleScenarioDeleted(id: number) {
 
 .scenario-row > * {
   scroll-snap-align: start;
-  min-width: min(220px, 70vw);
-  max-width: 280px;
+  min-width: min(180px, 70vw);
+  max-width: 240px;
   flex-shrink: 0;
 }
 
 .character-card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr));
+  gap: 0.75rem;
   align-items: stretch;
 }
 </style>


### PR DESCRIPTION
Inspired by game-library density: more columns at larger viewports, aspect-ratio images instead of fixed heights so cards scale naturally with column width.

- builder-card-grid: 1→2→3→4→5 cols across sm/md/xl/2xl
- builder-card: reduced min-heights, tighter padding/gaps at xl; long description collapses to single merged line at xl
- bot-card / character-card: swap h-52/h-80 for aspect-[2/3]; compact mode keeps fixed h-44/sm:h-48 for row scrollers
- bot-gallery: grid min 240px→160px (≈8 cols at 1280px vs ≈5)
- character-gallery: grid min 260px→180px, row max 360→280px
- scenario-gallery: grid min 240px→180px, inner character grid same
- composition-gallery: grid min 260px→200px
- reward-gallery: grid min 240px→160px
- All grids: gap 1rem→0.75rem for tighter density


Claude-Session: https://claude.ai/code/session_01DVnFjGDmpCBeHc311UsTYJ