### PR TITLE
ci: add Cypress API test workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,70 @@
+name: Cypress Tests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      wait_seconds:
+        description: 'Seconds to wait for Vercel deploy before running tests'
+        required: false
+        default: '90'
+
+concurrency:
+  group: cypress-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cypress:
+    name: API Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Give Vercel time to finish deploying the new commit before tests hit it.
+      # On manual dispatch you can override this; on push to main 90s is usually enough.
+      - name: Wait for Vercel deploy
+        run: |
+          WAIT="${{ github.event.inputs.wait_seconds || '90' }}"
+          echo "Waiting ${WAIT}s for Vercel to finish deploying..."
+          sleep "$WAIT"
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          install: false  # already installed above
+          browser: chrome
+          record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
+        env:
+          CYPRESS_BASE_API_URL: https://kind-robots.vercel.app/api
+          CYPRESS_BETA_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          CYPRESS_API_KEY: ${{ secrets.CYPRESS_API_KEY }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      - name: Upload Cypress screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          if-no-files-found: ignore
+
+      - name: Upload Cypress videos
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          if-no-files-found: ignore


### PR DESCRIPTION
Runs the full Cypress suite against the live Vercel deployment on every push to main and on manual dispatch.

- Waits 90s post-push for Vercel to finish deploying before tests run (overridable via workflow_dispatch input)
- Injects BETA_ADMIN_TOKEN and API_KEY from GitHub Secrets so the seed user provisioning and admin-gated cleanup routes work in CI
- Uses cypress-io/github-action v6 with chrome; records to Cypress Cloud when CYPRESS_RECORD_KEY secret is present
- Uploads screenshots (on failure) and videos (always) as artifacts
- concurrency group cancels stale runs on rapid successive pushes