### PR TITLE
feat: merge todos into Wishmaster wishes

### DIFF
--- a/components/pages/wishmaster-page.vue
+++ b/components/pages/wishmaster-page.vue
@@ -1,0 +1,88 @@
+<template>
+  <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4">
+    <header class="flex items-start gap-3">
+      <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary">
+        <Icon name="kind-icon:wand" class="size-6" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <p class="text-xs font-bold uppercase tracking-wide text-primary/70">Wishmaster</p>
+        <h2 class="text-2xl font-black leading-tight">One-shot wishes</h2>
+        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+          Wishmaster treats a wish as the lightweight Todo-shaped request: scoped, prioritized, and tracked until it is fulfilled. Projects stay reserved for infrastructure-heavy systems.
+        </p>
+      </div>
+    </header>
+
+    <div class="grid gap-3 md:grid-cols-3">
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="text-xs font-bold uppercase tracking-wide text-base-content/40">Open wishes</p>
+        <p class="mt-2 text-3xl font-black text-primary">{{ todoStore.openWishes.length }}</p>
+        <p class="mt-1 text-xs leading-relaxed text-base-content/60">Single-shot requests waiting for an agent or human to make them real.</p>
+      </article>
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="text-xs font-bold uppercase tracking-wide text-base-content/40">Fulfilled</p>
+        <p class="mt-2 text-3xl font-black text-success">{{ todoStore.doneWishes.length }}</p>
+        <p class="mt-1 text-xs leading-relaxed text-base-content/60">Wishes that reached DONE without needing a whole project shell.</p>
+      </article>
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <p class="text-xs font-bold uppercase tracking-wide text-base-content/40">Archived</p>
+        <p class="mt-2 text-3xl font-black text-base-content/40">{{ todoStore.archivedWishes.length }}</p>
+        <p class="mt-1 text-xs leading-relaxed text-base-content/60">Completed or retired requests kept out of the active queue.</p>
+      </article>
+    </div>
+
+    <div class="grid gap-3 md:grid-cols-2">
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <h3 class="font-bold">What belongs here</h3>
+        <p class="mt-2 text-sm leading-relaxed text-base-content/70">
+          Use a wish for a bounded request: fix a bug, make one asset batch, draft one thing, generate a pitch batch, or ask an agent to perform one clear cycle.
+        </p>
+      </article>
+      <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <h3 class="font-bold">What becomes a project</h3>
+        <p class="mt-2 text-sm leading-relaxed text-base-content/70">
+          Promote the work to a project only when it needs durable infrastructure: roadmap, milestones, dependencies, art assets, public surface, or repeated agent cycles.
+        </p>
+      </article>
+    </div>
+
+    <div class="space-y-2">
+      <div class="flex items-center justify-between gap-2">
+        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/50">Recent wishes</h3>
+        <span v-if="todoStore.loading" class="loading loading-spinner loading-xs text-primary" />
+      </div>
+      <article
+        v-for="wish in recentWishes"
+        :key="wish.id"
+        class="rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+      >
+        <div class="flex items-start gap-3">
+          <Icon :name="wish.status === 'DONE' ? 'kind-icon:check-circle' : 'kind-icon:sparkles'" class="mt-0.5 size-4 shrink-0" :class="wish.status === 'DONE' ? 'text-success' : 'text-primary'" />
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-bold">{{ wish.title }}</p>
+            <p class="mt-1 text-xs text-base-content/50">{{ wishLabel(wish) }} · {{ wish.priority.toLowerCase() }}</p>
+            <p v-if="wish.description" class="mt-2 line-clamp-2 text-xs leading-relaxed text-base-content/60">{{ wish.description }}</p>
+          </div>
+          <span class="badge badge-xs shrink-0" :class="wish.status === 'DONE' ? 'badge-success' : 'badge-primary'">{{ wish.status }}</span>
+        </div>
+      </article>
+      <p v-if="!todoStore.loading && !recentWishes.length" class="rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6 text-center text-sm text-base-content/50">
+        No wishes yet. The goblin inbox is weirdly peaceful.
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useTodoStore } from '@/stores/todoStore'
+import { wishLabel } from '@/stores/helpers/wishmaster'
+
+const todoStore = useTodoStore()
+
+const recentWishes = computed(() => todoStore.wishes.slice(0, 8))
+
+onMounted(() => {
+  if (!todoStore.hasLoaded) todoStore.fetchTodos(true)
+})
+</script>

--- a/stores/helpers/conductorTabs.ts
+++ b/stores/helpers/conductorTabs.ts
@@ -26,7 +26,7 @@ export const conductorTabs = [
     icon: 'kind-icon:wand',
     title: 'Wishmaster Wishes',
     summary: 'Treat one-shot Todo requests as wishes without pretending each one is a full project.',
-    image: '/images/dashboard-tabs/conductor/wishmaster.webp',
+    image: '/images/dashboard-tabs/conductor/conductor.webp',
     flourish: '✦',
     tagline: 'A wish is the single-shot request; a project is the infrastructure machine.',
     narrative:

--- a/stores/helpers/conductorTabs.ts
+++ b/stores/helpers/conductorTabs.ts
@@ -21,6 +21,20 @@ export const conductorTabs = [
     requiredRole: 'ADMIN',
   },
   {
+    key: 'wishmaster',
+    label: 'Wishmaster',
+    icon: 'kind-icon:wand',
+    title: 'Wishmaster Wishes',
+    summary: 'Treat one-shot Todo requests as wishes without pretending each one is a full project.',
+    image: '/images/dashboard-tabs/conductor/wishmaster.webp',
+    flourish: '✦',
+    tagline: 'A wish is the single-shot request; a project is the infrastructure machine.',
+    narrative:
+      'Wishmaster turns lightweight requests into agent-ready wishes: scoped, prioritized, tracked until done, and only promoted into project infrastructure when the request actually needs a larger system.',
+    route: '/conductor',
+    requiredRole: 'ADMIN',
+  },
+  {
     key: 'portos',
     label: 'Portos',
     icon: 'kind-icon:server',

--- a/stores/helpers/navCards.ts
+++ b/stores/helpers/navCards.ts
@@ -31,9 +31,9 @@ export const CONDUCTOR_NAV_CARD: NavCard = {
   flourish: '⚙',
   deckImage: getNavThumbImagePath('conductor'),
   heroImage: getNavHeroImagePath('conductor'),
-  tagline: 'Steer agents, review work, and configure Portos.',
+  tagline: 'Steer agents, review work, make wishes, and configure Portos.',
   narrative:
-    'Open the Conductor cockpit: project progress, pitches awaiting your vote, task gates, roadmap state, Portos setup, and the pieces that need a human with a clipboard.',
+    'Open the Conductor cockpit: project progress, Wishmaster one-shot requests, pitches awaiting your vote, task gates, roadmap state, Portos setup, and the pieces that need a human with a clipboard.',
   required: false,
   restoresFields: [],
   unlockCondition: 'always',
@@ -47,7 +47,7 @@ export const CONDUCTOR_NAV_CARD: NavCard = {
       key: 'conductor',
       title: 'Conductor',
       narrative:
-        'Steer the agent loop, review project state, configure Portos, and decide what deserves human approval next.',
+        'Steer the agent loop, review project state, make one-shot Wishmaster requests, configure Portos, and decide what deserves human approval next.',
       inputType: 'custom',
       payload: {
         path: '/conductor',

--- a/stores/helpers/wishmaster.ts
+++ b/stores/helpers/wishmaster.ts
@@ -1,0 +1,55 @@
+// /stores/helpers/wishmaster.ts
+import type { Todo, TodoCreate, TodoPriority } from '@/stores/todoStore'
+
+export const WISHMASTER_PROJECT_SLUG = 'wishmaster'
+export const WISHMASTER_WISH_CATEGORY = 'AGENT' as const
+export const WISHMASTER_DEFAULT_ICON = 'kind-icon:wand' as const
+
+export type WishStatus = Todo['status']
+export type WishPriority = TodoPriority
+export type WishTodo = Todo & { category: typeof WISHMASTER_WISH_CATEGORY }
+export type WishCreate = Omit<TodoCreate, 'category'> & {
+  projectSlug?: string | null
+}
+
+function cleanText(value?: string | null): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function withProjectContext(description?: string | null, projectSlug?: string | null): string | null {
+  const body = cleanText(description)
+  const project = cleanText(projectSlug)
+
+  if (!project) return body
+  if (!body) return `Project: ${project}`
+  if (body.toLowerCase().includes(`project: ${project.toLowerCase()}`)) return body
+
+  return `${body}\n\nProject: ${project}`
+}
+
+export function isWishTodo(todo: Todo): todo is WishTodo {
+  return !todo.category || todo.category === WISHMASTER_WISH_CATEGORY
+}
+
+export function makeWishTodo(data: WishCreate): TodoCreate {
+  return {
+    title: data.title,
+    description: withProjectContext(data.description, data.projectSlug),
+    priority: data.priority ?? 'NORMAL',
+    category: WISHMASTER_WISH_CATEGORY,
+    dueDate: data.dueDate ?? null,
+    icon: data.icon ?? WISHMASTER_DEFAULT_ICON,
+    imagePath: data.imagePath ?? null,
+  }
+}
+
+export function wishLabel(todo: Todo): string {
+  return todo.status === 'DONE' ? 'Fulfilled wish' : 'Open wish'
+}
+
+export function wishNarrative(todo: Todo): string {
+  const priority = todo.priority.toLowerCase()
+  const status = todo.status.toLowerCase()
+  return `${todo.title} is a ${priority}-priority ${status} Wishmaster request.`
+}

--- a/stores/todoStore.ts
+++ b/stores/todoStore.ts
@@ -1,6 +1,7 @@
 // /stores/todoStore.ts
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { isWishTodo, makeWishTodo, type WishCreate, type WishTodo } from '@/stores/helpers/wishmaster'
 import { performFetch, handleError } from './utils'
 
 export type TodoStatus = 'OPEN' | 'DONE' | 'ARCHIVED'
@@ -43,6 +44,9 @@ export type TodoUpdate = {
   imagePath?: string | null
 }
 
+export type Wish = WishTodo
+export type WishUpdate = TodoUpdate
+
 export const useTodoStore = defineStore('todoStore', () => {
   const todos = ref<Todo[]>([])
   const loading = ref(false)
@@ -67,6 +71,19 @@ export const useTodoStore = defineStore('todoStore', () => {
   )
   const honeyDoTodos = computed(() =>
     openTodos.value.filter((t) => t.category === 'HONEYDO'),
+  )
+
+  const wishes = computed(() =>
+    todos.value.filter(isWishTodo),
+  )
+  const openWishes = computed(() =>
+    openTodos.value.filter(isWishTodo),
+  )
+  const doneWishes = computed(() =>
+    doneTodos.value.filter(isWishTodo),
+  )
+  const archivedWishes = computed(() =>
+    archivedTodos.value.filter(isWishTodo),
   )
 
   async function fetchTodos(includeArchived = false): Promise<void> {
@@ -121,6 +138,11 @@ export const useTodoStore = defineStore('todoStore', () => {
     }
   }
 
+  async function createWish(data: WishCreate): Promise<Wish | null> {
+    const todo = await createTodo(makeWishTodo(data))
+    return todo && isWishTodo(todo) ? todo : null
+  }
+
   async function updateTodo(id: number, data: TodoUpdate): Promise<boolean> {
     lastError.value = null
 
@@ -145,6 +167,10 @@ export const useTodoStore = defineStore('todoStore', () => {
       console.error('updateTodo failed:', error)
       return false
     }
+  }
+
+  async function updateWish(id: number, data: WishUpdate): Promise<boolean> {
+    return updateTodo(id, { ...data, category: 'AGENT' })
   }
 
   async function deleteTodo(id: number): Promise<boolean> {
@@ -180,6 +206,18 @@ export const useTodoStore = defineStore('todoStore', () => {
     return updateTodo(id, { status: 'ARCHIVED' })
   }
 
+  async function completeWish(todo: Wish): Promise<boolean> {
+    return updateTodo(todo.id, { status: 'DONE' })
+  }
+
+  async function archiveWish(id: number): Promise<boolean> {
+    return archiveTodo(id)
+  }
+
+  async function deleteWish(id: number): Promise<boolean> {
+    return deleteTodo(id)
+  }
+
   return {
     todos,
     loading,
@@ -191,11 +229,20 @@ export const useTodoStore = defineStore('todoStore', () => {
     agentTodos,
     kaizenTodos,
     honeyDoTodos,
+    wishes,
+    openWishes,
+    doneWishes,
+    archivedWishes,
     fetchTodos,
     createTodo,
+    createWish,
     updateTodo,
+    updateWish,
     deleteTodo,
     toggleDone,
     archiveTodo,
+    completeWish,
+    archiveWish,
+    deleteWish,
   }
 })


### PR DESCRIPTION
### What changed
- Added Wishmaster helper semantics on top of the existing Todo object so one-shot requests can be treated as wishes without a schema migration.
- Exposed wish aliases in `todoStore`: `wishes`, `openWishes`, `doneWishes`, `createWish`, `completeWish`, etc.
- Added a Wishmaster Conductor tab entry modeled after the PortOS placeholder pattern.
- Added a lightweight `wishmaster-page.vue` surface that explains the project-vs-wish split and reads wish counts through the store.
- Updated the Conductor nav copy to mention Wishmaster requests.

### Why this shape
A project needs infrastructure: roadmap, milestones, dependencies, art, repeated cycles. A wish is the lightweight Todo-shaped one-shot request: scoped, prioritized, tracked until done. This keeps existing `/api/todos` compatibility while giving Wishmaster a stronger domain surface.

### Verification
- Confirmed repo state was clean before starting: `main` default, write access, no open PRs.
- Compared branch against `main`: 5 changed files, 2 added files, branch is ahead-only and not behind.
- Could not run local TypeScript/Cypress in this connector session; changes were kept TypeScript-only and additive.