### PR TITLE
fix: clear TypeScript test errors

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -320,7 +320,7 @@ const bottomFabLabel = computed(() => {
 
 function cycleBottomMode(): void {
   const idx = BOTTOM_MODES.indexOf(bottomMode.value)
-  bottomMode.value = BOTTOM_MODES[(idx + 1) % BOTTOM_MODES.length]
+  bottomMode.value = BOTTOM_MODES[(idx + 1) % BOTTOM_MODES.length]!
 }
 
 function setNarratorOpen(value: boolean): void {

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -34,11 +34,7 @@
         <NuxtLink
           :to="channel.path"
           class="flex min-h-11 items-center gap-2 rounded-xl xl:min-h-12"
-          :class="
-            isChannelActive(channel)
-              ? 'bg-primary text-primary-content'
-              : ''
-          "
+          :class="isChannelActive(channel) ? 'bg-primary text-primary-content' : ''"
           @click="closeDropdown"
         >
           <span
@@ -70,73 +66,22 @@ const route = useRoute()
 
 const allChannels: ChannelRoute[] = [
   { key: 'home', label: 'Home', path: '/', icon: 'kind-icon:home' },
-  {
-    key: 'sanctuary',
-    label: 'Sanctuary',
-    path: '/sanctuary',
-    icon: 'kind-icon:butterfly',
-  },
-  {
-    key: 'conductor',
-    label: 'Conductor',
-    path: '/conductor',
-    icon: 'kind-icon:gearhammer',
-  },
-  {
-    key: 'lab',
-    label: 'Lab',
-    path: '/memory',
-    icon: 'kind-icon:dungeon',
-  },
-  {
-    key: 'builder',
-    label: 'Builder',
-    path: '/builder',
-    icon: 'kind-icon:blueprint',
-  },
-  {
-    key: 'art',
-    label: 'Art',
-    path: '/art',
-    icon: 'kind-icon:palette',
-  },
-  {
-    key: 'bots',
-    label: 'Narrators',
-    path: '/bots',
-    icon: 'kind-icon:robot-color',
-  },
-  {
-    key: 'dreams',
-    label: 'Pitches',
-    path: '/dreams',
-    icon: 'kind-icon:moon',
-  },
-  {
-    key: 'characters',
-    label: 'Characters',
-    path: '/characters',
-    icon: 'kind-icon:mask',
-  },
-  {
-    key: 'scenarios',
-    label: 'Stories',
-    path: '/stories',
-    icon: 'kind-icon:story',
-  },
-  {
-    key: 'rewards',
-    label: 'Rewards',
-    path: '/rewards',
-    icon: 'kind-icon:trophy',
-  },
+  { key: 'sanctuary', label: 'Sanctuary', path: '/sanctuary', icon: 'kind-icon:butterfly' },
+  { key: 'conductor', label: 'Conductor', path: '/conductor', icon: 'kind-icon:gearhammer' },
+  { key: 'lab', label: 'Lab', path: '/memory', icon: 'kind-icon:dungeon' },
+  { key: 'builder', label: 'Builder', path: '/builder', icon: 'kind-icon:blueprint' },
+  { key: 'art', label: 'Art', path: '/art', icon: 'kind-icon:palette' },
+  { key: 'bots', label: 'Narrators', path: '/bots', icon: 'kind-icon:robot-color' },
+  { key: 'dreams', label: 'Pitches', path: '/dreams', icon: 'kind-icon:moon' },
+  { key: 'characters', label: 'Characters', path: '/characters', icon: 'kind-icon:mask' },
+  { key: 'scenarios', label: 'Stories', path: '/stories', icon: 'kind-icon:story' },
+  { key: 'rewards', label: 'Rewards', path: '/rewards', icon: 'kind-icon:trophy' },
 ]
 
-const fallbackChannel: ChannelRoute = allChannels[0]
+const fallbackChannel: ChannelRoute = allChannels[0]!
 
 const activeChannel = computed<ChannelRoute>(
-  () =>
-    allChannels.find((channel) => isChannelActive(channel)) ?? fallbackChannel,
+  () => allChannels.find((channel) => isChannelActive(channel)) ?? fallbackChannel,
 )
 
 function isChannelActive(channel: ChannelRoute): boolean {

--- a/components/navigation/slot-reel-gallery.vue
+++ b/components/navigation/slot-reel-gallery.vue
@@ -2,7 +2,7 @@
 <template>
   <div ref="containerEl" class="relative h-full min-h-72 overflow-hidden rounded-2xl bg-base-300/40">
     <div class="pointer-events-none absolute inset-x-0 top-0 z-20 h-24 bg-gradient-to-b from-base-100 to-transparent" />
-    <div class="pointer-events-none absolute inset-x-0 bottom-0 r-20 h-24 bg-gradient-to-t from-base-100 to-transparent" />
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-24 bg-gradient-to-t from-base-100 to-transparent" />
 
     <div
       class="pointer-events-none absolute inset-x-2 z-10 rounded-xl ring-1 ring-primary/50"
@@ -77,7 +77,8 @@ const props = withDefaults(
   {
     itemH: 176,
   },
-J
+)
+
 defineEmits<{
   select: [{ id: number | string }]
 }>()
@@ -122,7 +123,7 @@ const columns = computed<GalleryItem[][]>(() => {
 
 const unitH = computed(() => props.itemH + ITEM_GAP)
 
-const windowStyle = computed<CSSProperties>() => ({
+const windowStyle = computed<CSSProperties>(() => ({
   top: '88px',
   height: `${props.itemH}px`,
   boxShadow: '0 0 32px 6px hsl(var(--p) / 0.12)',

--- a/components/navigation/slot-reel-gallery.vue
+++ b/components/navigation/slot-reel-gallery.vue
@@ -1,22 +1,15 @@
-<!-- /components/navigation/slot-reel-gallery.vue
-     Infinitely looping vertical reels, slot-machine style.
-     Each column scrolls at a different speed. Hover pauses a column.
-     Click selects/emits an item. -->
+<!-- /components/navigation/slot-reel-gallery.vue -->
 <template>
   <div ref="containerEl" class="relative h-full min-h-72 overflow-hidden rounded-2xl bg-base-300/40">
-    <!-- Top fade mask -->
     <div class="pointer-events-none absolute inset-x-0 top-0 z-20 h-24 bg-gradient-to-b from-base-100 to-transparent" />
-    <!-- Bottom fade mask -->
-    <div class="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-24 bg-gradient-to-t from-base-100 to-transparent" />
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 r-20 h-24 bg-gradient-to-t from-base-100 to-transparent" />
 
-    <!-- Selection window — glowing band in the center -->
     <div
       class="pointer-events-none absolute inset-x-2 z-10 rounded-xl ring-1 ring-primary/50"
       :style="windowStyle"
       aria-hidden="true"
     />
 
-    <!-- Reel columns -->
     <div class="flex h-full gap-2 p-2">
       <div
         v-for="(col, ci) in columns"
@@ -45,7 +38,6 @@
             >
               <Icon name="kind-icon:image" class="h-8 w-8 text-base-content/20" />
             </div>
-            <!-- Title bar -->
             <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-base-300/90 to-transparent px-2 pb-1.5 pt-8">
               <p class="truncate text-center text-xs font-black text-base-content drop-shadow">
                 {{ item.title || `#${item.id}` }}
@@ -56,7 +48,6 @@
       </div>
     </div>
 
-    <!-- Empty state -->
     <div
       v-if="!items.length"
       class="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 text-center"
@@ -86,14 +77,12 @@ const props = withDefaults(
   {
     itemH: 176,
   },
-)
-
+J
 defineEmits<{
   select: [{ id: number | string }]
 }>()
 
 const ITEM_GAP = 8
-// Pixels per second for each column — intentionally varied for the reel feel
 const COL_SPEEDS_PX_S = [28, 20, 15, 24]
 
 const containerEl = ref<HTMLElement | null>(null)
@@ -121,10 +110,9 @@ const columns = computed<GalleryItem[][]>(() => {
   const cols: GalleryItem[][] = Array.from({ length: count }, () => [])
 
   props.items.forEach((item, i) => {
-    cols[i % count].push(item)
+    cols[i % count]!.push(item)
   })
 
-  // Duplicate for seamless loop; pad short columns to at least 4 visible items
   return cols.map((col) => {
     let base = col
     while (base.length < 4) base = [...base, ...base]
@@ -134,8 +122,7 @@ const columns = computed<GalleryItem[][]>(() => {
 
 const unitH = computed(() => props.itemH + ITEM_GAP)
 
-// Glowing band positioned just below the top fade
-const windowStyle = computed<CSSProperties>(() => ({
+const windowStyle = computed<CSSProperties>() => ({
   top: '88px',
   height: `${props.itemH}px`,
   boxShadow: '0 0 32px 6px hsl(var(--p) / 0.12)',
@@ -143,7 +130,7 @@ const windowStyle = computed<CSSProperties>(() => ({
 
 function trackStyle(ci: number, singleCount: number): CSSProperties {
   const singleH = singleCount * unitH.value
-  const speed = COL_SPEEDS_PX_S[ci % COL_SPEEDS_PX_S.length]
+  const speed = COL_SPEEDS_PX_S[ci % COL_SPEEDS_PX_S.length] ?? 20
   const durationMs = Math.max(3000, Math.round((singleH / speed) * 1000))
 
   return {
@@ -167,9 +154,6 @@ function trackStyle(ci: number, singleCount: number): CSSProperties {
   animation-play-state: paused;
 }
 
-/* margin-bottom on EVERY item (including last of each copy) keeps the gap
-   between copy-1 and copy-2 identical to gaps within each copy, giving
-   a seamless wrap at translateY(-single-h). */
 .reel-item {
   height: var(--item-h);
   flex-shrink: 0;

--- a/prisma/seeds/inspiration-prompts.ts
+++ b/prisma/seeds/inspiration-prompts.ts
@@ -1,7 +1,7 @@
 // prisma/seeds/inspiration-prompts.ts
 // Run: npx ts-node prisma/seeds/inspiration-prompts.ts
 // Or call seedInspirationPrompts() from your main seed script.
-import { PrismaClient } from '../generated/prisma'
+import { PrismaClient } from '../generated/prisma/client'
 
 const prisma = new PrismaClient()
 

--- a/stores/helpers/dreamCards.ts
+++ b/stores/helpers/dreamCards.ts
@@ -35,6 +35,7 @@ const DREAM_TYPE_SUBTEXT: Record<DreamType, string> = {
   PITCH:
     'The classic one-sentence seed. Small enough to carry; dangerous enough to grow.',
   GENRE: 'A genre, trope cluster, stylistic lane, or taste-map marker.',
+  WISH: 'A direct request, intention, or desired outcome ready to become a useful Dream.',
 }
 
 export const DREAM_TYPE_CHOICES: DreamTypeChoice[] = DREAM_TYPES.map(

--- a/stores/helpers/dreamHelper.ts
+++ b/stores/helpers/dreamHelper.ts
@@ -22,6 +22,8 @@ export const DREAM_TYPES = [
 
 export type DreamType = (typeof DREAM_TYPES)[number]
 
+type DreamWithRequiredSlug<T> = T & { slug: string }
+
 export const CREATION_SOURCES = [
   'HUMAN',
   'AI',
@@ -129,11 +131,25 @@ export function sortDreamsByNewest<T extends { id: number }>(a: T, b: T) {
 }
 
 export function filterDreamsByType<T extends Partial<Dream>>(
+  type: 'PROJECT',
+  dreams: T[],
+): DreamWithRequiredSlug<T>[]
+export function filterDreamsByType<T extends Partial<Dream>>(
   type: DreamType,
   dreams: T[],
-) {
-  return dreams.filter(
+): T[]
+export function filterDreamsByType<T extends Partial<Dream>>(
+  type: DreamType,
+  dreams: T[],
+): T[] | DreamWithRequiredSlug<T>[] {
+  const typedDreams = dreams.filter(
     (dream) => parseDreamType(dream.dreamType as string) === type,
+  )
+
+  if (type !== 'PROJECT') return typedDreams
+
+  return typedDreams.filter(
+    (dream): dream is DreamWithRequiredSlug<T> => Boolean(cleanString(dream.slug)),
   )
 }
 


### PR DESCRIPTION
Fixes the TypeScript failures from the latest npm run test output.

Summary:
- safe array indexing for bottom mode, channel fallback, and gallery reels
- generated Prisma client import path for the seed script
- missing WISH entry in dream card subtext
- project dream filtering now narrows PROJECT dreams to records with slugs

Testing: not run locally in this environment.