### PR TITLE
feat(conductor-page): show task notes, stakes, deps, approval, timest…

### DIFF
--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -804,6 +804,14 @@
                         <span v-if="task.owner">&middot; {{ task.owner }}</span>
                         <span v-if="task.passes > 0" class="text-warning">&middot; pass {{ task.passes }}/3</span>
                       </div>
+                      <div class="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+                        <span v-if="task.stakes && task.stakes !== 'reversible'" class="badge badge-xs" :class="stakesBadgeClass(task.stakes)">{{ task.stakes }}</span>
+                        <span v-if="task.dependsOn" class="text-base-content/30">depends: {{ Array.isArray(task.dependsOn) ? task.dependsOn.join(', ') : task.dependsOn }}</span>
+                        <span v-if="task.gateHuman && task.approvedByHuman" class="text-success">✓ approved</span>
+                        <span v-if="task.gateHuman && !task.approvedByHuman" class="text-accent/70">awaiting approval</span>
+                        <span v-if="task.updated" class="ml-auto text-base-content/25">{{ relativeTime(task.updated) }}</span>
+                      </div>
+                      <p v-if="task.note" class="mt-1.5 line-clamp-3 text-xs leading-relaxed text-base-content/50">{{ task.note }}</p>
                     </div>
                     <span class="badge badge-sm shrink-0" :class="taskBadgeClass(task.status)">{{ task.status }}</span>
                   </div>
@@ -1341,6 +1349,26 @@ function taskBadgeClass(status: string) {
     ready: 'badge-info', waiting: 'badge-ghost', blocked: 'badge-error', 'needs-human': 'badge-accent',
   }
   return map[status] ?? 'badge-ghost'
+}
+function stakesBadgeClass(stakes: string): string {
+  if (stakes === 'irreversible') return 'badge-error'
+  if (stakes === 'outward-facing') return 'badge-warning'
+  if (stakes === 'needs-human') return 'badge-accent'
+  return 'badge-ghost'
+}
+function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return ''
+  const ms = Date.now() - new Date(iso).getTime()
+  const s = Math.round(ms / 1000)
+  if (s < 60) return 'just now'
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.round(h / 24)
+  if (d < 30) return `${d}d ago`
+  const mo = Math.round(d / 30)
+  return `${mo}mo ago`
 }
 function taskIcon(status: string) {
   const map: Record<string, string> = {

--- a/server/api/conductor/projects.get.ts
+++ b/server/api/conductor/projects.get.ts
@@ -24,6 +24,10 @@ export interface ConductorTask {
   passes: number
   stakes?: string
   gateHuman: boolean
+  note?: string
+  dependsOn?: string | string[] | null
+  approvedByHuman?: boolean
+  updated?: string | null
 }
 
 export interface ConductorProjectAssets {
@@ -164,15 +168,42 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
         i++
         while (i < lines.length && /^    /.test(lines[i]!)) {
           const tline = lines[i]!
-          if (/^    \w+:\s*[>|]/.test(tline)) {
+          // Block scalar (note: > or note: |) — capture content instead of skipping
+          const blockScalarMatch = tline.match(/^    ([\w-]+):\s*[>|]\s*$/)
+          if (blockScalarMatch) {
+            const rawKey = blockScalarMatch[1]!
+            const camelKey = rawKey.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
             i++
-            while (i < lines.length && /^      /.test(lines[i]!)) i++
+            const buf: string[] = []
+            while (i < lines.length && /^      /.test(lines[i]!)) {
+              buf.push(lines[i]!.replace(/^      /, '').trimEnd())
+              i++
+            }
+            t[camelKey] = buf.join(' ').trim()
+            continue
+          }
+          // Block sequence for depends_on: followed by - items
+          if (/^    depends_on:\s*$/.test(tline)) {
+            i++
+            const items: string[] = []
+            while (i < lines.length && /^      - /.test(lines[i]!)) {
+              items.push(lines[i]!.replace(/^      - /, '').trim())
+              i++
+            }
+            t['dependsOn'] = items
             continue
           }
           parseKV(tline.trim(), t)
           i++
         }
         if (t['id']) {
+          const rawDependsOn = t['dependsOn'] ?? t['depends_on']
+          const dependsOn: string | string[] | null =
+            Array.isArray(rawDependsOn)
+              ? rawDependsOn
+              : typeof rawDependsOn === 'string' && rawDependsOn
+                ? rawDependsOn
+                : null
           result.tasks.push({
             id: t['id'] as string,
             milestone: (t['milestone'] as string) || '',
@@ -181,7 +212,11 @@ function parseRoadmapYaml(text: string): Omit<ConductorProject, 'slug' | 'progre
             owner: t['owner'] === 'null' || t['owner'] == null ? null : (t['owner'] as string),
             passes: Number(t['passes']) || 0,
             stakes: t['stakes'] as string | undefined,
-            gateHuman: t['gate_human'] === 'true' || t['gate_human'] === true,
+            gateHuman: t['gateHuman'] === 'true' || t['gateHuman'] === true || t['gate_human'] === 'true' || t['gate_human'] === true,
+            note: t['note'] as string | undefined,
+            dependsOn,
+            approvedByHuman: t['approvedByHuman'] === 'true' || t['approvedByHuman'] === true || t['approved_by_human'] === 'true' || t['approved_by_human'] === true,
+            updated: (t['updated'] as string | null | undefined) ?? null,
           })
         }
       }


### PR DESCRIPTION
…amps

Implements kind-robots t-005, t-006, t-007:

t-005: Task card note display
  Adds a line-clamped (3-line) note text below the task metadata row,
  showing the full task note field which was already returned by the API
  but never surfaced in the UI. Critical for Silas to see FOR SILAS /
  TO APPROVE instructions without opening the raw roadmap file.

t-006: Stakes, depends_on, approved_by_human in task cards
  Extends ConductorTask type with note, dependsOn, approvedByHuman,
  updated. Fixes the parser in projects.get.ts to capture block scalars
  (note: >) instead of silently skipping them, and to parse depends_on
  as either a string or a list. Adds color-coded stakes badge, dependency
  display, and approval status indicator to the task metadata row.

t-007: Relative timestamp on task cards
  Adds a relativeTime() helper (e.g. "3d ago", "2h ago") and renders
  the task.updated field in a muted right-aligned position. Lets Silas
  spot stale claimed tasks at a glance.


Claude-Session: https://claude.ai/code/session_01LXzi99MQtsfrxKwqAm46mU