### PR TITLE
feat: global-ui task surfaces, honeydo inbox, kaizen prompts, feature wishlist

### DIFF
--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -819,6 +819,165 @@
               </div>
             </div>
           </div>
+
+          <!-- PROJECT TASK CREATION (t-002) -->
+          <div v-if="linkedDream" class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4">
+            <h4 class="mb-3 text-xs font-bold uppercase tracking-wide text-base-content/50">Add Task to This Project</h4>
+            <form class="space-y-2" @submit.prevent="submitProjectTask">
+              <input
+                v-model="projectTaskTitle"
+                type="text"
+                placeholder="What needs doing?"
+                class="input input-bordered w-full rounded-xl text-sm"
+                :disabled="projectTaskSubmitting"
+              />
+              <textarea
+                v-model="projectTaskDescription"
+                placeholder="Optional context..."
+                class="textarea textarea-bordered w-full rounded-xl text-sm"
+                rows="2"
+                :disabled="projectTaskSubmitting"
+              />
+              <div class="flex flex-wrap items-center gap-2">
+                <select v-model="projectTaskCategory" class="select select-bordered select-sm rounded-xl">
+                  <option value="AGENT">🤖 Agent Task</option>
+                  <option value="KAIZEN">✨ Kaizen</option>
+                  <option value="HONEYDO">🍯 Honey Do</option>
+                  <option value="DESIRED_FEATURE">⭐ Feature Idea</option>
+                </select>
+                <select v-model="projectTaskPriority" class="select select-bordered select-sm rounded-xl">
+                  <option value="HIGH">🔴 High</option>
+                  <option value="NORMAL">🟡 Normal</option>
+                  <option value="LOW">🟢 Low</option>
+                </select>
+                <button
+                  type="submit"
+                  class="btn btn-primary btn-sm ml-auto rounded-xl"
+                  :disabled="!projectTaskTitle.trim() || projectTaskSubmitting"
+                >
+                  <span v-if="projectTaskSubmitting" class="loading loading-spinner loading-xs" />
+                  Add Task
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <!-- KAIZEN + POLISH PROMPT (t-004, t-006) -->
+          <div v-if="linkedDream" class="shrink-0 space-y-3 rounded-2xl border border-secondary/30 bg-secondary/5 p-4">
+            <div class="flex items-center gap-2">
+              <Icon name="kind-icon:sparkles" class="size-4 text-secondary" />
+              <h4 class="text-xs font-bold uppercase tracking-wide text-secondary/70">Kaizen — Improvements</h4>
+            </div>
+            <div v-if="projectKaizens.length" class="space-y-2">
+              <div
+                v-for="kaizen in projectKaizens"
+                :key="kaizen.id"
+                class="flex items-start gap-2 rounded-xl border border-secondary/20 bg-base-100 px-3 py-2"
+              >
+                <Icon name="kind-icon:sparkles" class="mt-0.5 size-3.5 shrink-0 text-secondary/50" />
+                <div class="min-w-0 flex-1">
+                  <p class="text-sm leading-snug">{{ kaizen.title }}</p>
+                  <p v-if="kaizen.description" class="mt-0.5 text-xs text-base-content/50">{{ kaizen.description }}</p>
+                </div>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs rounded-lg text-success"
+                  :disabled="todoStore.loading"
+                  @click="todoStore.updateTodo(kaizen.id, { status: 'DONE' })"
+                >done</button>
+              </div>
+            </div>
+            <p v-else class="text-xs text-base-content/40">No active kaizens for this project.</p>
+            <form class="flex flex-col gap-2" @submit.prevent="submitPolishPrompt">
+              <label class="label py-0"><span class="label-text text-xs font-semibold text-secondary/80">How can I make this look better?</span></label>
+              <div class="flex gap-2">
+                <input
+                  v-model="polishPrompt"
+                  type="text"
+                  placeholder="Any visual or UX idea for this project..."
+                  class="input input-bordered input-sm flex-1 rounded-xl text-sm"
+                  :disabled="polishSubmitting"
+                />
+                <button
+                  type="submit"
+                  class="btn btn-secondary btn-sm rounded-xl"
+                  :disabled="!polishPrompt.trim() || polishSubmitting"
+                >
+                  <span v-if="polishSubmitting" class="loading loading-spinner loading-xs" />
+                  <Icon v-else name="kind-icon:sparkles" class="size-3.5" />
+                </button>
+              </div>
+              <p v-if="polishMessage" class="text-xs text-success">{{ polishMessage }}</p>
+            </form>
+          </div>
+
+          <!-- DESIRED FEATURES (t-007) -->
+          <div v-if="linkedDream" class="shrink-0 space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
+            <div class="flex items-center gap-2">
+              <Icon name="kind-icon:check" class="size-4 text-primary" />
+              <h4 class="text-xs font-bold uppercase tracking-wide text-base-content/50">Feature Wishlist</h4>
+            </div>
+            <div v-if="projectFeatures.length" class="space-y-1.5">
+              <div
+                v-for="(feature, idx) in projectFeatures"
+                :key="feature.id"
+                class="group flex items-center gap-2 rounded-xl border px-3 py-2 transition-colors"
+                :class="feature.status === 'ARCHIVED' ? 'border-base-300/50 bg-base-200/50 opacity-50' : 'border-base-300 bg-base-200'"
+              >
+                <div class="flex shrink-0 flex-col">
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs h-4 min-h-0 rounded px-1 py-0 opacity-40 hover:opacity-100 disabled:opacity-20"
+                    :disabled="idx === 0 || todoStore.loading"
+                    @click="moveFeatureUp(idx)"
+                  >▲</button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs h-4 min-h-0 rounded px-1 py-0 opacity-40 hover:opacity-100 disabled:opacity-20"
+                    :disabled="idx === projectFeatures.length - 1 || todoStore.loading"
+                    @click="moveFeatureDown(idx)"
+                  >▼</button>
+                </div>
+                <p
+                  class="min-w-0 flex-1 text-sm leading-snug"
+                  :class="feature.status === 'ARCHIVED' ? 'line-through text-base-content/40' : ''"
+                >{{ feature.title }}</p>
+                <div v-if="feature.status !== 'ARCHIVED'" class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs rounded-lg text-xs text-primary"
+                    :disabled="todoStore.loading"
+                    @click="promoteFeatureToTask(feature.id)"
+                  >→ task</button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs rounded-lg text-xs text-base-content/30"
+                    :disabled="todoStore.loading"
+                    @click="retireFeature(feature.id)"
+                  >retire</button>
+                </div>
+              </div>
+            </div>
+            <p v-else class="text-xs text-base-content/40">No feature ideas yet.</p>
+            <form class="flex gap-2" @submit.prevent="addDesiredFeature">
+              <input
+                v-model="newFeatureTitle"
+                type="text"
+                placeholder="New feature idea..."
+                class="input input-bordered input-sm flex-1 rounded-xl text-sm"
+                :disabled="newFeatureSubmitting"
+              />
+              <button
+                type="submit"
+                class="btn btn-outline btn-sm rounded-xl"
+                :disabled="!newFeatureTitle.trim() || newFeatureSubmitting"
+              >
+                <span v-if="newFeatureSubmitting" class="loading loading-spinner loading-xs" />
+                Add
+              </button>
+            </form>
+          </div>
+
         </div>
       </div>
     </template>
@@ -1400,5 +1559,123 @@ function milestoneBadgeClass(status: string) {
   if (status === 'done') return 'badge-success'
   if (status === 'in-progress') return 'badge-warning'
   return 'badge-ghost'
+}
+
+// Project-scoped task creation (t-002)
+const projectTaskTitle = ref('')
+const projectTaskDescription = ref('')
+const projectTaskCategory = ref<TodoCategory>('AGENT')
+const projectTaskPriority = ref<DreamPriority>('NORMAL')
+const projectTaskSubmitting = ref(false)
+
+// Kaizen / polish prompt (t-004, t-006)
+const polishPrompt = ref('')
+const polishSubmitting = ref(false)
+const polishMessage = ref('')
+
+// Desired features (t-007)
+const newFeatureTitle = ref('')
+const newFeatureSubmitting = ref(false)
+
+const projectKaizens = computed(() => {
+  if (!linkedDream.value) return []
+  const dreamId = linkedDream.value.id
+  return todoStore.openTodos.filter((t) => t.dreamId === dreamId && t.category === 'KAIZEN')
+})
+
+const projectFeatures = computed(() => {
+  if (!linkedDream.value) return []
+  const dreamId = linkedDream.value.id
+  return [...todoStore.todos.filter((t) => t.dreamId === dreamId && t.category === 'DESIRED_FEATURE')]
+    .sort((a, b) => (a.order ?? 9999) - (b.order ?? 9999))
+})
+
+watch(linkedDream, async (dream) => {
+  if (dream?.id) await todoStore.fetchDreamTodos(dream.id)
+}, { immediate: true })
+
+async function submitProjectTask() {
+  if (!linkedDream.value || !projectTaskTitle.value.trim()) return
+  projectTaskSubmitting.value = true
+  try {
+    await todoStore.createTodo({
+      title: projectTaskTitle.value.trim(),
+      description: projectTaskDescription.value.trim() || null,
+      category: projectTaskCategory.value,
+      priority: projectTaskPriority.value,
+      dreamId: linkedDream.value.id,
+    })
+    projectTaskTitle.value = ''
+    projectTaskDescription.value = ''
+    projectTaskCategory.value = 'AGENT'
+    projectTaskPriority.value = 'NORMAL'
+  } finally {
+    projectTaskSubmitting.value = false
+  }
+}
+
+async function submitPolishPrompt() {
+  if (!linkedDream.value || !polishPrompt.value.trim()) return
+  polishSubmitting.value = true
+  polishMessage.value = ''
+  try {
+    await todoStore.createTodo({
+      title: polishPrompt.value.trim(),
+      category: 'KAIZEN',
+      priority: 'NORMAL',
+      dreamId: linkedDream.value.id,
+    })
+    polishPrompt.value = ''
+    polishMessage.value = 'Kaizen logged!'
+    setTimeout(() => { polishMessage.value = '' }, 3000)
+  } finally {
+    polishSubmitting.value = false
+  }
+}
+
+async function addDesiredFeature() {
+  if (!linkedDream.value || !newFeatureTitle.value.trim()) return
+  newFeatureSubmitting.value = true
+  try {
+    await todoStore.createTodo({
+      title: newFeatureTitle.value.trim(),
+      category: 'DESIRED_FEATURE',
+      priority: 'NORMAL',
+      dreamId: linkedDream.value.id,
+      order: projectFeatures.value.length,
+    })
+    newFeatureTitle.value = ''
+    await todoStore.fetchDreamTodos(linkedDream.value.id)
+  } finally {
+    newFeatureSubmitting.value = false
+  }
+}
+
+async function promoteFeatureToTask(featureId: number) {
+  await todoStore.updateTodo(featureId, { category: 'AGENT' })
+}
+
+async function retireFeature(featureId: number) {
+  await todoStore.updateTodo(featureId, { status: 'ARCHIVED' })
+}
+
+async function moveFeatureUp(index: number) {
+  const features = projectFeatures.value
+  if (index === 0) return
+  await Promise.all([
+    todoStore.updateTodo(features[index].id, { order: index - 1 }),
+    todoStore.updateTodo(features[index - 1].id, { order: index }),
+  ])
+  if (linkedDream.value) await todoStore.fetchDreamTodos(linkedDream.value.id)
+}
+
+async function moveFeatureDown(index: number) {
+  const features = projectFeatures.value
+  if (index >= features.length - 1) return
+  await Promise.all([
+    todoStore.updateTodo(features[index].id, { order: index + 1 }),
+    todoStore.updateTodo(features[index + 1].id, { order: index }),
+  ])
+  if (linkedDream.value) await todoStore.fetchDreamTodos(linkedDream.value.id)
 }
 </script>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -453,6 +453,13 @@
             </div>
           </div>
 
+          <!-- Honeydo inbox context banner (t-003) -->
+          <div v-if="taskTab === 'HONEYDO' && todoFilter === 'OPEN'" class="rounded-2xl border border-accent/20 bg-accent/5 px-4 py-3">
+            <p class="text-xs font-semibold text-accent/80">🍯 Honey-Do Queue</p>
+            <p class="mt-0.5 text-xs text-base-content/50">Action items your AI assigned to you. These help your projects along — check them off as you go.</p>
+            <p v-if="highPriorityHoneyDos > 0" class="mt-1 text-xs font-semibold text-error">{{ highPriorityHoneyDos }} high-priority item{{ highPriorityHoneyDos > 1 ? 's' : '' }} need your attention.</p>
+          </div>
+
           <div class="space-y-2">
             <template v-if="todoStore.loading && !filteredTodos.length">
               <div v-for="n in 3" :key="n" class="h-16 animate-pulse rounded-2xl border border-base-300 bg-base-200" />
@@ -460,8 +467,12 @@
             <div
               v-for="todo in filteredTodos"
               :key="todo.id"
-              class="flex flex-col gap-1 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 transition-colors"
-              :class="todo.status === 'DONE' ? 'opacity-60' : ''"
+              class="flex flex-col gap-1 rounded-2xl border px-4 py-3 transition-colors"
+              :class="[
+                todo.status === 'DONE' ? 'opacity-60 border-base-300 bg-base-100' :
+                (todo.category === 'HONEYDO' && todo.priority === 'HIGH') ? 'border-error/30 bg-error/5' :
+                'border-base-300 bg-base-100'
+              ]"
             >
               <div class="flex items-center gap-3">
                 <button
@@ -502,9 +513,14 @@
               </div>
               <p v-if="todo.description" class="ml-8 text-xs leading-relaxed text-base-content/50">{{ todo.description }}</p>
             </div>
-            <p v-if="!todoStore.loading && !filteredTodos.length" class="py-6 text-center text-sm text-base-content/50">
-              No {{ todoFilter.toLowerCase() }} tasks.
-            </p>
+            <div v-if="!todoStore.loading && !filteredTodos.length" class="py-8 text-center">
+              <template v-if="taskTab === 'HONEYDO' && todoFilter === 'OPEN'">
+                <Icon name="kind-icon:check-circle" class="mx-auto mb-2 size-8 text-success/40" />
+                <p class="text-sm font-semibold text-base-content/50">No honey-dos right now.</p>
+                <p class="mt-1 text-xs text-base-content/30">When your AI assigns you an action item, it shows up here.</p>
+              </template>
+              <p v-else class="text-sm text-base-content/50">No {{ todoFilter.toLowerCase() }} tasks.</p>
+            </div>
           </div>
         </div>
 
@@ -1132,6 +1148,10 @@ const filteredTodos = computed(() => {
     default:        return todoStore.agentTodos
   }
 })
+
+const highPriorityHoneyDos = computed(() =>
+  todoStore.honeyDoTodos.filter((t) => t.priority === 'HIGH').length,
+)
 
 const allPitchesVoted = computed(() =>
   allPitches.value.length > 0 &&

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -399,6 +399,7 @@ model Dream {
   Bots            Bot[]
 
   PitchSheet PitchSheet?
+  Todos      Todo[]
 
   RelationsFrom DreamRelation[] @relation("DreamRelationFrom") // edges where this dream is the subject
   RelationsTo   DreamRelation[] @relation("DreamRelationTo") // edges where this dream is the object
@@ -1489,6 +1490,7 @@ enum TodoCategory {
   AGENT
   KAIZEN
   HONEYDO
+  DESIRED_FEATURE
 }
 
 model Todo {
@@ -1504,8 +1506,12 @@ model Todo {
   icon        String?      @db.VarChar(128)
   imagePath   String?      @db.VarChar(764)
   userId      Int?         @default(1)
+  dreamId     Int?         // project scope: links to a PROJECT Dream
+  order       Int?         // display order within category (used by DESIRED_FEATURE)
+  Dream       Dream?       @relation(fields: [dreamId], references: [id], onDelete: SetNull)
 
   @@index([userId])
+  @@index([dreamId])
 }
 
 enum ArtStatus {

--- a/server/api/prompts/[id]/bounty/claim.post.ts
+++ b/server/api/prompts/[id]/bounty/claim.post.ts
@@ -1,0 +1,54 @@
+// POST /api/prompts/:id/bounty/claim
+// Lets an authenticated user claim an open bounty prompt.
+import { createError, defineEventHandler } from 'h3'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { validateApiKey } from '../../../../utils/validateKey'
+import { awardKarma } from '../../../../utils/karma'
+import { BountyStatus } from '~/prisma/generated/prisma/client'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid prompt ID.' })
+    }
+
+    const { isValid, user } = await validateApiKey(event)
+    if (!isValid || !user) {
+      throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
+    }
+
+    const prompt = await prisma.prompt.findUnique({ where: { id } })
+    if (!prompt) {
+      throw createError({ statusCode: 404, message: 'Prompt not found.' })
+    }
+    if (!prompt.isBounty) {
+      throw createError({ statusCode: 400, message: 'Prompt is not a bounty.' })
+    }
+    if (prompt.bountyStatus !== BountyStatus.OPEN) {
+      throw createError({ statusCode: 409, message: `Bounty is not open (status: ${prompt.bountyStatus}).` })
+    }
+    if (prompt.userId === user.id) {
+      throw createError({ statusCode: 400, message: 'Cannot claim your own bounty.' })
+    }
+
+    const updated = await prisma.prompt.update({
+      where: { id },
+      data: {
+        bountyStatus: BountyStatus.CLAIMED,
+        claimerId: user.id,
+      },
+    })
+
+    // Award karma to claimer — gated by KARMA_LIVE; amounts need Silas sign-off before going live
+    awardKarma({ userId: user.id, reason: 'BOUNTY_CLAIMED', refId: String(id) }).catch(() => {})
+
+    event.node.res.statusCode = 200
+    return { success: true, message: 'Bounty claimed.', data: updated }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to claim bounty.' }
+  }
+})

--- a/server/api/prompts/[id]/bounty/fulfill.post.ts
+++ b/server/api/prompts/[id]/bounty/fulfill.post.ts
@@ -1,0 +1,95 @@
+// POST /api/prompts/:id/bounty/fulfill
+// Marks a claimed (or open) bounty as fulfilled; awards mana to claimer and poster from house pool.
+// IMPORTANT: Mana amounts below are placeholder drafts — Silas must approve before KARMA_LIVE is enabled.
+import { createError, defineEventHandler } from 'h3'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { validateApiKey } from '../../../../utils/validateKey'
+import { userIsAdmin } from '../../../../utils/authUser'
+import { awardKarma } from '../../../../utils/karma'
+import { applyMana } from '../../../../utils/mana'
+import { BountyStatus } from '~/prisma/generated/prisma/client'
+
+// Draft placeholder amounts — needs Silas sign-off before KARMA_LIVE = true
+const BOUNTY_MANA_FULFILLER = 50  // mana to the person who delivered
+const BOUNTY_MANA_POSTER = 25     // mana returned to the bounty poster as a thank-you from the house
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid prompt ID.' })
+    }
+
+    const { isValid, user } = await validateApiKey(event)
+    if (!isValid || !user) {
+      throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
+    }
+
+    const prompt = await prisma.prompt.findUnique({ where: { id } })
+    if (!prompt) {
+      throw createError({ statusCode: 404, message: 'Prompt not found.' })
+    }
+    if (!prompt.isBounty) {
+      throw createError({ statusCode: 400, message: 'Prompt is not a bounty.' })
+    }
+    if (
+      prompt.bountyStatus !== BountyStatus.CLAIMED &&
+      prompt.bountyStatus !== BountyStatus.OPEN
+    ) {
+      throw createError({
+        statusCode: 409,
+        message: `Bounty cannot be fulfilled (status: ${prompt.bountyStatus}).`,
+      })
+    }
+
+    // Claimer, original poster, or admin may fulfill
+    const isAuthorized =
+      user.id === prompt.claimerId ||
+      user.id === prompt.userId ||
+      userIsAdmin(user)
+    if (!isAuthorized) {
+      throw createError({
+        statusCode: 403,
+        message: 'Only the claimer, poster, or an admin may fulfill this bounty.',
+      })
+    }
+
+    const fulfillerId = prompt.claimerId ?? user.id
+    const posterId = prompt.userId
+    const refId = String(id)
+
+    const updated = await prisma.prompt.update({
+      where: { id },
+      data: { bountyStatus: BountyStatus.FULFILLED },
+    })
+
+    // Award mana + karma to fulfiller (fire-and-forget; gated by KARMA_LIVE)
+    applyMana({
+      userId: fulfillerId,
+      amount: BOUNTY_MANA_FULFILLER,
+      reason: 'BOUNTY_REWARD',
+      refId,
+      note: 'bounty fulfilled — house award',
+    }).catch(() => {})
+    awardKarma({ userId: fulfillerId, reason: 'BOUNTY_FULFILLED', refId }).catch(() => {})
+
+    // Return mana to poster as house reward for posting a helpful bounty
+    if (posterId && posterId !== fulfillerId) {
+      applyMana({
+        userId: posterId,
+        amount: BOUNTY_MANA_POSTER,
+        reason: 'BOUNTY_REWARD',
+        refId,
+        note: 'bounty poster reward — house award',
+      }).catch(() => {})
+    }
+
+    event.node.res.statusCode = 200
+    return { success: true, message: 'Bounty fulfilled.', data: updated }
+  } catch (error) {
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
+    return { success: false, message: message || 'Failed to fulfill bounty.' }
+  }
+})

--- a/server/api/reactions/index.post.ts
+++ b/server/api/reactions/index.post.ts
@@ -186,6 +186,39 @@ function buildTargetWhere(
   return { [expectedField]: expectedId }
 }
 
+async function getContentOwnerId(
+  category: Reaction_reactionCategory,
+  targets: ReturnType<typeof getTargetFields>,
+): Promise<number | null> {
+  const expectedField = getExpectedTargetField(category)
+  if (!expectedField) return null
+  const targetId = targets[expectedField]
+  if (!targetId) return null
+  // Component model has no userId field
+  if (expectedField === 'componentId') return null
+
+  const modelMap: Record<string, { findUnique: (args: unknown) => Promise<unknown> }> = {
+    artImageId: prisma.artImage,
+    artCollectionId: prisma.artCollection,
+    botId: prisma.bot,
+    characterId: prisma.character,
+    chatId: prisma.chat,
+    compositionId: prisma.composition,
+    dreamId: prisma.dream,
+    promptId: prisma.prompt,
+    resourceId: prisma.resource,
+    rewardId: prisma.reward,
+    scenarioId: prisma.scenario,
+    themeId: prisma.theme,
+  }
+
+  const model = modelMap[expectedField]
+  if (!model) return null
+
+  const result = await model.findUnique({ where: { id: targetId }, select: { userId: true } }) as { userId?: number | null } | null
+  return result?.userId ?? null
+}
+
 async function assertReactionTargetExists(
   category: Reaction_reactionCategory,
   targets: ReturnType<typeof getTargetFields>,
@@ -273,6 +306,12 @@ export default defineEventHandler(async (event) => {
 
     if (!existingReaction) {
       awardKarma({ userId: user.id, reason: 'REACTION_GIVEN', refId: String(data.id) }).catch(() => {})
+      // Award content owner for receiving a reaction (fire-and-forget; gated by KARMA_LIVE)
+      getContentOwnerId(reactionCategory, targets).then((ownerId) => {
+        if (ownerId && ownerId !== user.id) {
+          awardKarma({ userId: ownerId, reason: 'REACTION_RECEIVED', refId: String(data.id) }).catch(() => {})
+        }
+      }).catch(() => {})
     }
 
     event.node.res.statusCode = existingReaction ? 200 : 201

--- a/server/api/todos/[id].patch.ts
+++ b/server/api/todos/[id].patch.ts
@@ -10,10 +10,11 @@ type TodoPatchBody = {
   description?: string | null
   status?: 'OPEN' | 'DONE' | 'ARCHIVED'
   priority?: 'LOW' | 'NORMAL' | 'HIGH'
-  category?: 'AGENT' | 'KAIZEN' | 'HONEYDO'
+  category?: 'AGENT' | 'KAIZEN' | 'HONEYDO' | 'DESIRED_FEATURE'
   dueDate?: string | null
   icon?: string | null
   imagePath?: string | null
+  order?: number | null
 }
 
 export default defineEventHandler(async (event) => {
@@ -47,12 +48,13 @@ export default defineEventHandler(async (event) => {
     const priority = ['LOW', 'NORMAL', 'HIGH'].includes(body.priority ?? '')
       ? body.priority!
       : current.priority
-    const category = ['AGENT', 'KAIZEN', 'HONEYDO'].includes(body.category ?? '')
+    const category = ['AGENT', 'KAIZEN', 'HONEYDO', 'DESIRED_FEATURE'].includes(body.category ?? '')
       ? body.category!
       : (current.category ?? 'AGENT')
     const dueDate = 'dueDate' in body ? (body.dueDate ?? null) : current.dueDate
     const icon = 'icon' in body ? (body.icon ?? null) : current.icon
     const imagePath = 'imagePath' in body ? (body.imagePath ?? null) : current.imagePath
+    const order = 'order' in body ? (body.order ?? null) : (current as Todo & { order?: number | null }).order ?? null
 
     await prisma.$executeRaw`
       UPDATE \`Todo\` SET
@@ -64,6 +66,7 @@ export default defineEventHandler(async (event) => {
         dueDate     = ${dueDate},
         icon        = ${icon},
         imagePath   = ${imagePath},
+        \`order\`   = ${order},
         updatedAt   = NOW(3)
       WHERE id = ${id} AND userId = ${userId}
     `

--- a/server/api/todos/dream/[dreamId].get.ts
+++ b/server/api/todos/dream/[dreamId].get.ts
@@ -1,0 +1,31 @@
+// GET /api/todos/dream/:dreamId
+// Returns all todos scoped to a specific dream/project, ordered for display.
+import { defineEventHandler, createError, H3Error } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { requireApiUser } from '@/server/utils/authGuard'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireApiUser(event)
+
+    const dreamId = Number(event.context.params?.dreamId)
+    if (!Number.isInteger(dreamId) || dreamId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid dreamId.' })
+    }
+
+    const todos = await prisma.todo.findMany({
+      where: { dreamId },
+      orderBy: [
+        { order: 'asc' },
+        { priority: 'asc' },
+        { createdAt: 'desc' },
+      ],
+    })
+
+    return { success: true, data: todos }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/todos/index.post.ts
+++ b/server/api/todos/index.post.ts
@@ -5,7 +5,7 @@ import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 
 const todoPriorities = ['LOW', 'NORMAL', 'HIGH'] as const
-const todoCategories = ['AGENT', 'KAIZEN', 'HONEYDO'] as const
+const todoCategories = ['AGENT', 'KAIZEN', 'HONEYDO', 'DESIRED_FEATURE'] as const
 
 type TodoPriorityValue = (typeof todoPriorities)[number]
 type TodoCategoryValue = (typeof todoCategories)[number]
@@ -18,6 +18,8 @@ type TodoCreateBody = {
   dueDate?: string | null
   icon?: string | null
   imagePath?: string | null
+  dreamId?: number | null
+  order?: number | null
 }
 
 function normalizeDueDate(value?: string | null): Date | null {
@@ -56,6 +58,10 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'title is required' })
     }
 
+    const dreamId = body.dreamId && Number.isInteger(body.dreamId) && body.dreamId > 0
+      ? body.dreamId : null
+    const order = body.order != null && Number.isInteger(body.order) ? body.order : null
+
     const todo = await prisma.todo.create({
       data: {
         title,
@@ -67,6 +73,8 @@ export default defineEventHandler(async (event) => {
         icon: body.icon ?? null,
         imagePath: body.imagePath ?? null,
         userId,
+        dreamId,
+        order,
       },
     })
 

--- a/stores/todoStore.ts
+++ b/stores/todoStore.ts
@@ -5,7 +5,7 @@ import { performFetch, handleError } from './utils'
 
 export type TodoStatus = 'OPEN' | 'DONE' | 'ARCHIVED'
 export type TodoPriority = 'LOW' | 'NORMAL' | 'HIGH'
-export type TodoCategory = 'AGENT' | 'KAIZEN' | 'HONEYDO'
+export type TodoCategory = 'AGENT' | 'KAIZEN' | 'HONEYDO' | 'DESIRED_FEATURE'
 
 export interface Todo {
   id: number
@@ -20,6 +20,8 @@ export interface Todo {
   icon: string | null
   imagePath: string | null
   userId: number | null
+  dreamId: number | null   // project scope (PROJECT Dream)
+  order: number | null     // display order (DESIRED_FEATURE)
 }
 
 export type TodoCreate = {
@@ -30,6 +32,8 @@ export type TodoCreate = {
   dueDate?: string | null
   icon?: string | null
   imagePath?: string | null
+  dreamId?: number | null
+  order?: number | null
 }
 
 export type TodoUpdate = {
@@ -41,6 +45,8 @@ export type TodoUpdate = {
   dueDate?: string | null
   icon?: string | null
   imagePath?: string | null
+  dreamId?: number | null
+  order?: number | null
 }
 
 export const useTodoStore = defineStore('todoStore', () => {
@@ -68,6 +74,37 @@ export const useTodoStore = defineStore('todoStore', () => {
   const honeyDoTodos = computed(() =>
     openTodos.value.filter((t) => t.category === 'HONEYDO'),
   )
+
+  function dreamKaizens(dreamId: number) {
+    return computed(() =>
+      openTodos.value.filter((t) => t.dreamId === dreamId && t.category === 'KAIZEN'),
+    )
+  }
+
+  function dreamFeatures(dreamId: number) {
+    return computed(() =>
+      todos.value
+        .filter((t) => t.dreamId === dreamId && t.category === 'DESIRED_FEATURE')
+        .sort((a, b) => (a.order ?? 9999) - (b.order ?? 9999)),
+    )
+  }
+
+  async function fetchDreamTodos(dreamId: number): Promise<void> {
+    loading.value = true
+    lastError.value = null
+    try {
+      const res = await performFetch<Todo[]>(`/api/todos/dream/${dreamId}`)
+      if (!res.success || !res.data) throw new Error(res.message || 'Failed to fetch dream todos')
+      // Merge into main list (replace existing dream-scoped entries, keep others)
+      const others = todos.value.filter((t) => t.dreamId !== dreamId)
+      todos.value = [...others, ...res.data]
+    } catch (error) {
+      handleError(error, 'fetchDreamTodos')
+      lastError.value = error instanceof Error ? error.message : 'Failed to fetch dream todos'
+    } finally {
+      loading.value = false
+    }
+  }
 
   async function fetchTodos(includeArchived = false): Promise<void> {
     loading.value = true
@@ -191,7 +228,10 @@ export const useTodoStore = defineStore('todoStore', () => {
     agentTodos,
     kaizenTodos,
     honeyDoTodos,
+    dreamKaizens,
+    dreamFeatures,
     fetchTodos,
+    fetchDreamTodos,
     createTodo,
     updateTodo,
     deleteTodo,


### PR DESCRIPTION
## Summary

- **Project task creation form (t-002)** — added to `conductor-page.vue` project detail view; supports all four categories (AGENT, KAIZEN, HONEYDO, DESIRED_FEATURE) and priority; routes through `todoStore.createTodo()` with `dreamId`; shows new task immediately in the relevant list
- **Honeydo inbox context banner (t-003)** — added to the HONEYDO tab in tasks view; explains what honeydos are, shows high-priority count alert, friendly empty state when queue is clear
- **Kaizen section + polish prompt (t-004, t-006)** — added to project detail view; shows existing dream-scoped KAIZEN todos with a "done" button; "How can I make this look better?" input submits as a KAIZEN todo scoped to the current dream
- **Feature wishlist (t-007)** — DESIRED_FEATURE todos for the current dream, sortable with up/down buttons (swap `order` values), "→ task" promotes to AGENT category, "retire" archives with strikethrough
- **DESIRED_FEATURE backend support (t-008)** — added `DESIRED_FEATURE` to `TodoCategory` enum, `dreamId` and `order` fields to `Todo` model; new `GET /api/todos/dream/:dreamId` route; `todoStore.ts` updated with `dreamKaizens()`, `dreamFeatures()`, `fetchDreamTodos()`
- **Engagement karma wiring** — `REACTION_RECEIVED` karma event + bounty claim/fulfill API

## Before this goes live

`prisma migrate dev` must be run to apply the `dreamId` and `order` fields to the DB. The UI sections are wired to the store correctly but will return empty until the migration runs.

## What was NOT changed

- No real user data, addresses, gate codes, payment info, or auth credentials committed
- KARMA_LIVE remains false — all karma amounts are still gated pending Silas sign-off
- Seed/dummy data only throughout

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXzi99MQtsfrxKwqAm46mU)_