### PR TITLE
fix: add missing Todo columns migration and run migrations on Vercel …

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "trim:dry": "node ./utils/scripts/trim.mjs --dry-run",
     "trim": "node ./utils/scripts/trim.mjs",
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
-    "vercel-build": "prisma generate && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
+    "vercel-build": "prisma generate && prisma migrate deploy && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
     "dev": "nuxt dev --host",
     "build": "nuxi prepare && prisma generate && nuxi build",
     "start": "nuxi start",

--- a/prisma/migrations/20260630020000_add_todo_dream_order/migration.sql
+++ b/prisma/migrations/20260630020000_add_todo_dream_order/migration.sql
@@ -1,0 +1,16 @@
+-- Add dreamId and order columns that were missing from the readd_todo_with_category migration.
+-- Add DESIRED_FEATURE to TodoCategory enum to match the Prisma schema.
+
+ALTER TABLE `Todo`
+  ADD COLUMN `dreamId` INTEGER NULL,
+  ADD COLUMN `order` INTEGER NULL;
+
+ALTER TABLE `Todo`
+  MODIFY COLUMN `category` ENUM('AGENT', 'KAIZEN', 'HONEYDO', 'DESIRED_FEATURE') NOT NULL DEFAULT 'AGENT';
+
+CREATE INDEX `Todo_dreamId_idx` ON `Todo`(`dreamId`);
+
+ALTER TABLE `Todo`
+  ADD CONSTRAINT `Todo_dreamId_fkey`
+  FOREIGN KEY (`dreamId`) REFERENCES `Dream`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
…deploy

The Todo table was missing `dreamId` and `order` columns (and the `DESIRED_FEATURE` category enum value) because the readd_todo_with_category migration created the table without them. This caused the POST /api/todos endpoint to fail at runtime with an unknown column error, breaking 11/18 Cypress tests that depend on creating a todo first.

Changes:
- Add migration 20260630020000_add_todo_dream_order that adds the dreamId/order columns, DESIRED_FEATURE enum value, dreamId index, and foreign key to Dream.id
- Add `prisma migrate deploy` to vercel-build so pending migrations are applied on every Vercel deployment