### PR TITLE
fix: pass MariaDB adapter to PrismaClient in inspiration-prompts seed

### DIFF
--- a/prisma/seeds/inspiration-prompts.ts
+++ b/prisma/seeds/inspiration-prompts.ts
@@ -2,8 +2,12 @@
 // Run: npx ts-node prisma/seeds/inspiration-prompts.ts
 // Or call seedInspirationPrompts() from your main seed script.
 import { PrismaClient } from '../generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 
-const prisma = new PrismaClient()
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
 
 interface InspirationEntry {
   imagePath: string


### PR DESCRIPTION
## What failed

TypeScript CI on main has been red since the `generate` commit (SHA `456a1ab7`, 2026-06-30T23:34Z):

```
prisma/seeds/inspiration-prompts.ts(6,16): error TS2554: Expected 1 arguments, but got 0.
```

The generated `PrismaClient` (custom output path) requires an adapter argument — calling it bare with `new PrismaClient()` satisfies the old default client interface but not the generated one.

## Root cause

`prisma/seeds/inspiration-prompts.ts` was written against the standard PrismaClient signature. After `prisma generate` produced a client with a custom output path (`../generated/prisma/client`), that client requires an adapter to be passed explicitly — same as `server/utils/prisma.ts` already does.

## What changed

`prisma/seeds/inspiration-prompts.ts` — 8 lines:
- Import `PrismaMariaDb` from `@prisma/adapter-mariadb`
- Read `DATABASE_URL` from env (throws early if missing)
- Construct `new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })` — mirroring the pattern in `server/utils/prisma.ts`

## Stakes

`reversible` — seed file only, no schema or migration changes, no production data touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REiMjK3LgUZZdYL2BAZfiW)_