### PR TITLE
Polish conductor project galleries

### DIFF
--- a/components/pages/conductor-manager.vue
+++ b/components/pages/conductor-manager.vue
@@ -1,14 +1,21 @@
 <template>
   <WishmasterPage v-if="pageStore.workspaceCardKey === 'wishmaster'" />
   <PortosPage v-else-if="pageStore.workspaceCardKey === 'portos'" />
+  <ConductorOverviewGalleryPage v-else-if="showConductorGallery" />
   <ConductorPage v-else />
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import ConductorOverviewGalleryPage from '@/components/pages/conductor-overview-gallery-page.vue'
 import ConductorPage from '@/components/pages/conductor-page.vue'
 import PortosPage from '@/components/pages/portos-page.vue'
 import WishmasterPage from '@/components/pages/wishmaster-page.vue'
 import { usePageStore } from '@/stores/pageStore'
 
 const pageStore = usePageStore()
+
+const showConductorGallery = computed(() => {
+  return !pageStore.workspaceCardKey || pageStore.workspaceCardKey === 'overview'
+})
 </script>

--- a/components/pages/conductor-overview-gallery-page.vue
+++ b/components/pages/conductor-overview-gallery-page.vue
@@ -1,0 +1,905 @@
+<!-- /components/pages/conductor-overview-gallery-page.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
+  >
+    <header
+      class="shrink-0 overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+    >
+      <div class="relative isolate">
+        <div
+          class="absolute inset-0 bg-linear-to-br from-primary/10 via-secondary/5 to-accent/10"
+        />
+
+        <div class="relative flex flex-col gap-3 p-3 sm:p-4">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0">
+              <p
+                class="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-primary/70"
+              >
+                <Icon name="kind-icon:gearhammer" class="h-4 w-4" />
+                {{ userStore.isAdmin ? 'Conductor workspace' : 'Project gallery' }}
+              </p>
+
+              <h1
+                class="mt-1 text-2xl font-black leading-tight text-base-content sm:text-3xl"
+              >
+                Production-grade project galleries
+              </h1>
+
+              <p
+                class="mt-1 max-w-3xl text-sm font-medium leading-relaxed text-base-content/65"
+              >
+                Swap from image-first cards to text-first lists without losing
+                context. Tiny goblin UX crime scene: cleaned.
+              </p>
+            </div>
+
+            <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+              <button
+                v-if="userStore.isAdmin"
+                type="button"
+                class="btn btn-primary btn-sm rounded-2xl text-white"
+                @click="startProjectDream"
+              >
+                <Icon name="kind-icon:plus" class="h-4 w-4" />
+                New project
+              </button>
+
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm rounded-2xl"
+                :disabled="isLoading"
+                @click="refreshGallery"
+              >
+                <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+                <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              v-for="mode in galleryModeOptions"
+              :key="mode.value"
+              type="button"
+              class="btn btn-sm rounded-2xl"
+              :class="modeButtonClass(mode.value)"
+              :title="mode.label"
+              @click="projectGalleryMode = mode.value"
+            >
+              <Icon :name="mode.icon" class="h-4 w-4" />
+              <span class="font-black">{{ mode.abbr }}</span>
+              <span class="hidden text-xs font-semibold sm:inline">
+                {{ mode.label }}
+              </span>
+            </button>
+
+            <span class="ml-auto badge badge-primary badge-lg rounded-2xl">
+              {{ galleryItems.length }} project{{ galleryItems.length === 1 ? '' : 's' }}
+            </span>
+
+            <button
+              v-if="userStore.isAdmin"
+              type="button"
+              class="btn btn-outline btn-sm rounded-2xl"
+              @click="goToTasks"
+            >
+              <Icon name="kind-icon:check" class="h-4 w-4" />
+              Tasks
+              <span
+                v-if="todoStore.openTodos.length"
+                class="badge badge-warning badge-sm"
+              >
+                {{ todoStore.openTodos.length }}
+              </span>
+            </button>
+
+            <button
+              v-if="userStore.isAdmin && brainstormCount"
+              type="button"
+              class="btn btn-secondary btn-sm rounded-2xl"
+              @click="goToBrainstorm"
+            >
+              <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+              Brainstorm
+              <span class="badge badge-sm">{{ brainstormCount }}</span>
+            </button>
+          </div>
+
+          <div class="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+            <div class="rounded-2xl border border-base-300 bg-base-200/70 p-3">
+              <p class="font-black text-base-content/40">Visible</p>
+              <p class="mt-1 text-xl font-black text-primary">
+                {{ galleryItems.length }}
+              </p>
+            </div>
+
+            <div class="rounded-2xl border border-base-300 bg-base-200/70 p-3">
+              <p class="font-black text-base-content/40">Need human</p>
+              <p class="mt-1 text-xl font-black text-accent">
+                {{ humanQueueCount }}
+              </p>
+            </div>
+
+            <div class="rounded-2xl border border-base-300 bg-base-200/70 p-3">
+              <p class="font-black text-base-content/40">Blocked</p>
+              <p class="mt-1 text-xl font-black text-error">
+                {{ blockedQueueCount }}
+              </p>
+            </div>
+
+            <div class="rounded-2xl border border-base-300 bg-base-200/70 p-3">
+              <p class="font-black text-base-content/40">Avg progress</p>
+              <p class="mt-1 text-xl font-black text-info">
+                {{ averageProgress }}%
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main
+      class="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-3"
+    >
+      <div
+        v-if="isLoading && !galleryItems.length"
+        class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+      >
+        <div
+          v-for="n in 6"
+          :key="n"
+          class="h-72 animate-pulse rounded-2xl bg-base-200"
+        />
+      </div>
+
+      <div
+        v-else-if="errorMessage"
+        class="flex min-h-64 flex-col items-center justify-center gap-3 rounded-2xl border border-error/30 bg-error/10 p-6 text-center text-error"
+      >
+        <Icon name="kind-icon:warning" class="h-10 w-10" />
+        <p class="max-w-xl font-bold">{{ errorMessage }}</p>
+
+        <button
+          type="button"
+          class="btn btn-error btn-sm rounded-2xl"
+          @click="refreshGallery"
+        >
+          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          Try again
+        </button>
+      </div>
+
+      <div
+        v-else-if="!galleryItems.length"
+        class="flex min-h-64 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+      >
+        <Icon name="kind-icon:cards" class="h-12 w-12 text-primary/50" />
+        <p class="text-lg font-black">No projects found.</p>
+        <p class="max-w-lg text-sm text-base-content/55">
+          Fetch project Dreams or sync the Conductor roadmap, then the gallery
+          will show up with actual drip.
+        </p>
+      </div>
+
+      <section
+        v-else-if="projectGalleryMode === 'cards'"
+        class="project-card-scroll flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4"
+      >
+        <button
+          v-for="item in galleryItems"
+          :key="item.slug"
+          type="button"
+          class="group relative min-h-[28rem] min-w-[82vw] snap-start overflow-hidden rounded-2xl border border-base-300 bg-base-200 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-xl sm:min-w-[22rem] md:min-w-[24rem] lg:min-w-[26rem]"
+          @click="openProject(item)"
+        >
+          <img
+            :src="item.cardPath"
+            :alt="item.title"
+            class="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105"
+          />
+
+          <div
+            class="absolute inset-0 bg-linear-to-t from-base-300 via-base-300/40 to-transparent"
+          />
+
+          <div class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-3">
+            <span
+              class="badge badge-sm rounded-2xl font-black"
+              :class="priorityBadgeClass(item.priority)"
+            >
+              {{ item.priority }}
+            </span>
+
+            <span v-if="item.blocked" class="badge badge-error badge-sm rounded-2xl">
+              {{ item.blocked }} blocked
+            </span>
+            <span
+              v-else-if="item.needsHuman"
+              class="badge badge-accent badge-sm rounded-2xl"
+            >
+              {{ item.needsHuman }} need you
+            </span>
+          </div>
+
+          <div class="absolute inset-x-0 bottom-0 flex flex-col gap-3 p-4">
+            <div class="flex items-end gap-3">
+              <img
+                :src="item.iconPath"
+                alt=""
+                class="h-12 w-12 shrink-0 rounded-2xl border border-base-100/30 object-cover shadow"
+              />
+
+              <div class="min-w-0">
+                <p
+                  class="line-clamp-2 text-2xl font-black leading-none text-base-content drop-shadow"
+                >
+                  {{ item.title }}
+                </p>
+                <p class="mt-1 line-clamp-2 text-sm font-semibold leading-snug text-base-content/70">
+                  {{ item.flavor }}
+                </p>
+              </div>
+            </div>
+
+            <div
+              class="rounded-2xl border border-base-content/10 bg-base-100/80 p-3 shadow-sm backdrop-blur"
+            >
+              <div
+                class="flex items-center justify-between gap-3 text-xs font-black uppercase tracking-widest text-base-content/45"
+              >
+                <span>{{ item.kindLabel }}</span>
+                <span>{{ item.progress }}%</span>
+              </div>
+
+              <div class="mt-2 h-2 overflow-hidden rounded-full bg-base-content/15">
+                <div
+                  class="h-full rounded-full transition-all"
+                  :class="kindProgressClass(item.kind)"
+                  :style="{ width: `${item.progress}%` }"
+                />
+              </div>
+            </div>
+          </div>
+        </button>
+      </section>
+
+      <section
+        v-else-if="projectGalleryMode === 'heroes'"
+        class="grid gap-4 lg:grid-cols-2"
+      >
+        <button
+          v-for="item in galleryItems"
+          :key="item.slug"
+          type="button"
+          class="group relative min-h-72 overflow-hidden rounded-2xl border border-base-300 bg-base-200 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          @click="openProject(item)"
+        >
+          <img
+            :src="item.heroPath"
+            :alt="item.title"
+            class="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105"
+          />
+
+          <div
+            class="absolute inset-0 bg-linear-to-t from-base-300 via-base-300/45 to-transparent"
+          />
+
+          <div class="absolute inset-x-0 bottom-0 p-4 transition-all duration-300">
+            <div class="flex items-end gap-3">
+              <img
+                :src="item.iconPath"
+                alt=""
+                class="h-12 w-12 rounded-2xl border border-base-100/40 object-cover shadow"
+              />
+
+              <div class="min-w-0">
+                <p class="text-2xl font-black leading-tight text-base-content drop-shadow">
+                  {{ item.title }}
+                </p>
+                <p class="line-clamp-2 text-sm font-semibold text-base-content/65">
+                  {{ item.flavor }}
+                </p>
+              </div>
+            </div>
+
+            <div
+              class="mt-3 max-h-0 overflow-hidden rounded-2xl border border-base-content/10 bg-base-100/85 opacity-0 shadow-sm backdrop-blur transition-all duration-300 group-hover:max-h-72 group-hover:p-3 group-hover:opacity-100 group-focus-visible:max-h-72 group-focus-visible:p-3 group-focus-visible:opacity-100"
+            >
+              <p class="line-clamp-4 text-sm font-semibold leading-relaxed text-base-content/75">
+                {{ item.details }}
+              </p>
+
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span
+                  class="badge badge-sm rounded-2xl"
+                  :class="priorityBadgeClass(item.priority)"
+                >
+                  {{ item.priority }}
+                </span>
+                <span class="badge badge-info badge-sm rounded-2xl">
+                  {{ item.progress }}% progress
+                </span>
+                <span
+                  v-if="item.needsHuman"
+                  class="badge badge-accent badge-sm rounded-2xl"
+                >
+                  {{ item.needsHuman }} human gate
+                </span>
+                <span
+                  v-if="item.blocked"
+                  class="badge badge-error badge-sm rounded-2xl"
+                >
+                  {{ item.blocked }} blocked
+                </span>
+                <span
+                  v-if="item.liveUrl"
+                  class="badge badge-outline badge-sm rounded-2xl"
+                >
+                  Live
+                </span>
+                <span
+                  v-if="item.repoUrl"
+                  class="badge badge-outline badge-sm rounded-2xl"
+                >
+                  Repo
+                </span>
+              </div>
+            </div>
+          </div>
+        </button>
+      </section>
+
+      <section
+        v-else-if="projectGalleryMode === 'icons'"
+        class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      >
+        <button
+          v-for="item in galleryItems"
+          :key="item.slug"
+          type="button"
+          class="group flex h-full flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:bg-base-100 hover:shadow-lg"
+          @click="openProject(item)"
+        >
+          <div class="flex items-start gap-3">
+            <img
+              :src="item.iconPath"
+              :alt="item.title"
+              class="h-16 w-16 shrink-0 rounded-2xl border border-base-300 object-cover shadow-sm transition group-hover:scale-105"
+            />
+
+            <div class="min-w-0 flex-1">
+              <p class="line-clamp-2 text-lg font-black leading-tight">
+                {{ item.title }}
+              </p>
+              <p class="mt-1 text-xs font-bold uppercase tracking-widest text-base-content/40">
+                {{ item.kindLabel }}
+              </p>
+            </div>
+          </div>
+
+          <p class="line-clamp-3 text-sm font-semibold leading-relaxed text-base-content/70">
+            {{ item.details }}
+          </p>
+
+          <div class="mt-auto flex flex-wrap gap-1.5">
+            <span
+              class="badge badge-sm rounded-2xl"
+              :class="priorityBadgeClass(item.priority)"
+            >
+              {{ item.priority }}
+            </span>
+            <span class="badge badge-ghost badge-sm rounded-2xl">
+              {{ item.status }}
+            </span>
+            <span v-if="item.totalTasks" class="badge badge-info badge-sm rounded-2xl">
+              {{ item.totalTasks }} tasks
+            </span>
+            <span
+              v-if="item.needsHuman"
+              class="badge badge-accent badge-sm rounded-2xl"
+            >
+              {{ item.needsHuman }} need you
+            </span>
+          </div>
+
+          <div class="h-2 overflow-hidden rounded-full bg-base-content/10">
+            <div
+              class="h-full rounded-full transition-all"
+              :class="kindProgressClass(item.kind)"
+              :style="{ width: `${item.progress}%` }"
+            />
+          </div>
+        </button>
+      </section>
+
+      <section v-else class="flex flex-col gap-3">
+        <button
+          v-for="item in galleryItems"
+          :key="item.slug"
+          type="button"
+          class="group grid gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 text-left shadow-sm transition-all hover:border-primary/50 hover:bg-base-100 hover:shadow-md md:grid-cols-[11rem_1fr_auto]"
+          @click="openProject(item)"
+        >
+          <div class="relative min-h-36 overflow-hidden rounded-2xl bg-base-300 md:min-h-full">
+            <img
+              :src="item.heroPath"
+              :alt="item.title"
+              class="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105"
+            />
+
+            <div class="absolute inset-0 bg-linear-to-t from-base-300/80 to-transparent" />
+
+            <img
+              :src="item.iconPath"
+              alt=""
+              class="absolute bottom-3 left-3 h-12 w-12 rounded-2xl border border-base-100/30 object-cover shadow"
+            />
+          </div>
+
+          <div class="min-w-0 py-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span
+                class="badge badge-sm rounded-2xl"
+                :class="priorityBadgeClass(item.priority)"
+              >
+                {{ item.priority }}
+              </span>
+              <span class="badge badge-ghost badge-sm rounded-2xl">
+                {{ item.kindLabel }}
+              </span>
+              <span v-if="item.status" class="badge badge-outline badge-sm rounded-2xl">
+                {{ item.status }}
+              </span>
+            </div>
+
+            <h2 class="mt-2 text-xl font-black leading-tight sm:text-2xl">
+              {{ item.title }}
+            </h2>
+            <p class="mt-1 text-sm font-bold text-primary/80">
+              {{ item.flavor }}
+            </p>
+            <p class="mt-2 line-clamp-3 text-sm leading-relaxed text-base-content/70">
+              {{ item.details }}
+            </p>
+            <p
+              v-if="item.notes"
+              class="mt-2 line-clamp-2 rounded-2xl border border-info/20 bg-info/5 px-3 py-2 text-xs font-semibold text-info/80"
+            >
+              {{ item.notes }}
+            </p>
+          </div>
+
+          <aside
+            class="flex flex-row flex-wrap items-end gap-2 md:w-36 md:flex-col md:flex-nowrap md:items-stretch"
+          >
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3 text-center">
+              <p class="text-2xl font-black text-primary">{{ item.progress }}%</p>
+              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                progress
+              </p>
+            </div>
+
+            <div class="grid flex-1 grid-cols-3 gap-2 text-center md:w-full">
+              <div class="rounded-xl bg-base-100 p-2">
+                <p class="font-black text-success">{{ item.done }}</p>
+                <p class="text-[0.65rem] text-base-content/40">done</p>
+              </div>
+              <div class="rounded-xl bg-base-100 p-2">
+                <p class="font-black text-accent">{{ item.needsHuman }}</p>
+                <p class="text-[0.65rem] text-base-content/40">you</p>
+              </div>
+              <div class="rounded-xl bg-base-100 p-2">
+                <p class="font-black text-error">{{ item.blocked }}</p>
+                <p class="text-[0.65rem] text-base-content/40">block</p>
+              </div>
+            </div>
+          </aside>
+        </button>
+      </section>
+    </main>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type { ConductorProject } from '@/server/api/conductor/projects.get'
+import { useConductorStore, type DreamPriority } from '@/stores/conductorStore'
+import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
+import { useNavStore } from '@/stores/navStore'
+import { usePageStore } from '@/stores/pageStore'
+import { useTodoStore } from '@/stores/todoStore'
+import { useUserStore } from '@/stores/userStore'
+import type { BuilderCard } from '@/stores/helpers/builderCards'
+
+const CONDUCTOR_IMG_BASE =
+  'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
+
+type GalleryMode = 'cards' | 'heroes' | 'icons' | 'list'
+
+type GalleryOption = {
+  value: GalleryMode
+  label: string
+  abbr: string
+  icon: string
+}
+
+type ProjectGalleryItem = {
+  slug: string
+  title: string
+  flavor: string
+  details: string
+  notes: string
+  kind: string
+  kindLabel: string
+  status: string
+  priority: DreamPriority
+  progress: number
+  blocked: number
+  needsHuman: number
+  ready: number
+  review: number
+  done: number
+  totalTasks: number
+  dreamId: number | null
+  iconPath: string
+  cardPath: string
+  heroPath: string
+  liveUrl: string
+  repoUrl: string
+}
+
+const galleryModeOptions: GalleryOption[] = [
+  { value: 'cards', label: 'Cards', abbr: 'C', icon: 'kind-icon:cards' },
+  { value: 'heroes', label: 'Heroes', abbr: 'H', icon: 'kind-icon:image' },
+  { value: 'icons', label: 'Icons', abbr: 'I', icon: 'kind-icon:cards' },
+  { value: 'list', label: 'List', abbr: 'L', icon: 'kind-icon:document' },
+]
+
+const conductorStore = useConductorStore()
+const dreamStore = useDreamStore()
+const navStore = useNavStore()
+const pageStore = usePageStore()
+const todoStore = useTodoStore()
+const userStore = useUserStore()
+
+const projectGalleryMode = ref<GalleryMode>('cards')
+
+const isLoading = computed(() => conductorStore.pending || dreamStore.loading)
+const errorMessage = computed(() => conductorStore.error || dreamStore.error || '')
+const brainstormCount = computed(
+  () => conductorStore.pendingPitches.length + brainstormProjects.value.length,
+)
+
+const activeProjects = computed(() => {
+  return conductorStore.projects.filter((project) => {
+    return projectDreamForSlug(project.slug)?.projectStatus !== 'BRAINSTORM'
+  })
+})
+
+const brainstormProjects = computed(() => {
+  return conductorStore.projects.filter((project) => {
+    return projectDreamForSlug(project.slug)?.projectStatus === 'BRAINSTORM'
+  })
+})
+
+const sortedActiveProjects = computed(() => {
+  const order: Record<DreamPriority, number> = { HIGH: 0, NORMAL: 1, LOW: 2 }
+
+  return [...activeProjects.value].sort((a, b) => {
+    const aPriority = conductorStore.getProjectPriority(projectDreamForSlug(a.slug)?.id)
+    const bPriority = conductorStore.getProjectPriority(projectDreamForSlug(b.slug)?.id)
+
+    return (order[aPriority] ?? 1) - (order[bPriority] ?? 1)
+  })
+})
+
+const adminItems = computed<ProjectGalleryItem[]>(() => {
+  return sortedActiveProjects.value.map((project) => itemFromProject(project))
+})
+
+const publicItems = computed<ProjectGalleryItem[]>(() => {
+  return [...dreamStore.publicProjectDreams]
+    .sort((a, b) => getDreamTitle(a).localeCompare(getDreamTitle(b)))
+    .map((dream) => itemFromDream(dream))
+})
+
+const galleryItems = computed(() => {
+  return userStore.isAdmin ? adminItems.value : publicItems.value
+})
+
+const humanQueueCount = computed(() =>
+  galleryItems.value.reduce((sum, item) => sum + item.needsHuman, 0),
+)
+
+const blockedQueueCount = computed(() =>
+  galleryItems.value.reduce((sum, item) => sum + item.blocked, 0),
+)
+
+const averageProgress = computed(() => {
+  if (!galleryItems.value.length) return 0
+
+  const total = galleryItems.value.reduce((sum, item) => sum + item.progress, 0)
+  return Math.round(total / galleryItems.value.length)
+})
+
+const workspaceCards = computed<BuilderCard[]>(() => {
+  const cards: BuilderCard[] = [
+    makeCard(
+      'overview',
+      'Overview',
+      'kind-icon:gearhammer',
+      '/images/projects/overview-card.webp',
+    ),
+  ]
+
+  if (userStore.isAdmin) {
+    cards.push(
+      makeCard(
+        'tasks',
+        todoStore.openTodos.length
+          ? `Tasks (${todoStore.openTodos.length})`
+          : 'Tasks',
+        'kind-icon:check',
+        '/images/projects/tasks-card.webp',
+      ),
+    )
+
+    if (brainstormCount.value) {
+      cards.push(
+        makeCard(
+          'brainstorm',
+          `Brainstorm (${brainstormCount.value})`,
+          'kind-icon:sparkles',
+          '/images/projects/brainstorm-card.webp',
+        ),
+      )
+    }
+  }
+
+  for (const item of galleryItems.value) {
+    cards.push(makeCard(item.slug, item.title, kindIcon(item.kind), item.cardPath))
+  }
+
+  return cards
+})
+
+watch(
+  workspaceCards,
+  (cards) => {
+    if (!cards.length) return
+
+    pageStore.setCards(cards)
+    if (!pageStore.workspaceCardKey) pageStore.setWorkspaceCardKey('overview')
+  },
+  { immediate: true },
+)
+
+watch(projectGalleryMode, (mode) => {
+  if (!import.meta.client) return
+
+  localStorage.setItem('conductor-gallery-mode', mode)
+})
+
+onMounted(async () => {
+  if (import.meta.client) {
+    const saved = localStorage.getItem('conductor-gallery-mode') as GalleryMode | null
+    if (saved && galleryModeOptions.some((mode) => mode.value === saved)) {
+      projectGalleryMode.value = saved
+    }
+  }
+
+  await ensureData()
+})
+
+async function ensureData(force = false) {
+  if (userStore.isAdmin) {
+    await Promise.all([
+      conductorStore.fetchProjects(force),
+      dreamStore.fetchDreams({ dreamType: 'PROJECT' }),
+      todoStore.hasLoaded ? todoStore.fetchTodos(force) : Promise.resolve(),
+    ])
+    return
+  }
+
+  if (force || !dreamStore.hasLoaded || !dreamStore.publicProjectDreams.length) {
+    await dreamStore.fetchDreams({ dreamType: 'PROJECT' })
+  }
+}
+
+async function refreshGallery() {
+  await ensureData(true)
+}
+
+function makeCard(
+  key: string,
+  label: string,
+  icon: string,
+  deckImage?: string,
+): BuilderCard {
+  return {
+    key,
+    label,
+    title: label,
+    icon,
+    tagline: '',
+    narrative: '',
+    restoresFields: [],
+    steps: [],
+    deckImage,
+    payload: {},
+  }
+}
+
+function projectDreamForSlug(slug: string) {
+  return dreamStore.projectDreams.find((dream) => dream.slug === slug) ?? null
+}
+
+function itemFromProject(project: ConductorProject): ProjectGalleryItem {
+  const dream = projectDreamForSlug(project.slug)
+  const priority = conductorStore.getProjectPriority(dream?.id)
+  const counts = taskCounts(project)
+  const details =
+    dream?.description ||
+    dream?.pitch ||
+    project.notesFromSilas ||
+    `${project.name || project.slug} has ${project.tasks.length} tracked tasks across ${project.milestones.length} milestones.`
+
+  return {
+    slug: project.slug,
+    title: project.name || getDreamTitle(dream) || project.slug,
+    flavor: dream?.flavorText || project.notesFromSilas || 'Active Kind Robots project.',
+    details,
+    notes: project.notesFromSilas || '',
+    kind: project.kind || 'project',
+    kindLabel: formatKind(project.kind),
+    status: dream?.projectStatus || 'ACTIVE',
+    priority,
+    progress: Number.isFinite(project.progress) ? project.progress : 0,
+    blocked: counts.blocked,
+    needsHuman: counts.needsHuman,
+    ready: counts.ready,
+    review: counts.review,
+    done: counts.done,
+    totalTasks: project.tasks.length,
+    dreamId: dream?.id ?? null,
+    iconPath:
+      dream?.imagePath ||
+      project.imagePath ||
+      `${CONDUCTOR_IMG_BASE}/${project.slug}-icon.webp`,
+    cardPath:
+      dream?.cardPath ||
+      project.cardPath ||
+      `${CONDUCTOR_IMG_BASE}/${project.slug}-card.webp`,
+    heroPath:
+      dream?.heroPath ||
+      project.heroPath ||
+      `${CONDUCTOR_IMG_BASE}/${project.slug}-hero.webp`,
+    liveUrl: dream?.liveUrl || '',
+    repoUrl: dream?.repoUrl || '',
+  }
+}
+
+function itemFromDream(dream: DreamWithRelations): ProjectGalleryItem {
+  return {
+    slug: dream.slug || `dream-${dream.id}`,
+    title: getDreamTitle(dream),
+    flavor: dream.flavorText || dream.pitch || 'Public project from Kind Robots.',
+    details:
+      dream.description ||
+      dream.pitch ||
+      dream.artPrompt ||
+      dream.flavorText ||
+      'This project is waiting for a richer public description.',
+    notes: '',
+    kind: 'project',
+    kindLabel: 'Project',
+    status: dream.projectStatus || (dream.isActive ? 'ACTIVE' : 'ARCHIVED'),
+    priority: 'NORMAL',
+    progress: dream.projectStatus === 'DONE' ? 100 : 0,
+    blocked: 0,
+    needsHuman: 0,
+    ready: 0,
+    review: 0,
+    done: dream.projectStatus === 'DONE' ? 1 : 0,
+    totalTasks: 0,
+    dreamId: dream.id,
+    iconPath: dream.imagePath || `${CONDUCTOR_IMG_BASE}/${dream.slug}-icon.webp`,
+    cardPath: dream.cardPath || `${CONDUCTOR_IMG_BASE}/${dream.slug}-card.webp`,
+    heroPath: dream.heroPath || `${CONDUCTOR_IMG_BASE}/${dream.slug}-hero.webp`,
+    liveUrl: dream.liveUrl || '',
+    repoUrl: dream.repoUrl || '',
+  }
+}
+
+function taskCounts(project: ConductorProject) {
+  const counts = {
+    blocked: 0,
+    needsHuman: 0,
+    ready: 0,
+    review: 0,
+    done: 0,
+  }
+
+  for (const task of project.tasks) {
+    if (task.status === 'blocked') counts.blocked++
+    if (task.status === 'needs-human') counts.needsHuman++
+    if (task.status === 'ready') counts.ready++
+    if (task.status === 'review') counts.review++
+    if (task.status === 'done') counts.done++
+  }
+
+  return counts
+}
+
+async function openProject(item: ProjectGalleryItem) {
+  if (item.dreamId) await dreamStore.selectDreamById(item.dreamId)
+
+  if (userStore.isAdmin) {
+    pageStore.setWorkspaceCardKey(item.slug)
+    return
+  }
+
+  if (item.liveUrl && import.meta.client) {
+    window.open(item.liveUrl, '_blank', 'noopener,noreferrer')
+  }
+}
+
+function startProjectDream() {
+  dreamStore.startAddingDream({
+    dreamType: 'PROJECT',
+    isPublic: true,
+    isActive: true,
+    userId: userStore.userId ?? userStore.user?.id ?? undefined,
+    designer: userStore.username || 'Kind Designer',
+  })
+  navStore.setDashboardTab?.('dream', 'dreammaker')
+}
+
+function goToTasks() {
+  pageStore.setWorkspaceCardKey('tasks')
+}
+
+function goToBrainstorm() {
+  pageStore.setWorkspaceCardKey('brainstorm')
+}
+
+function modeButtonClass(mode: GalleryMode) {
+  return projectGalleryMode.value === mode ? 'btn-primary text-white' : 'btn-ghost'
+}
+
+function priorityBadgeClass(priority: DreamPriority): string {
+  if (priority === 'HIGH') return 'badge-error'
+  if (priority === 'LOW') return 'badge-ghost'
+  return 'badge-warning'
+}
+
+function kindIcon(kind: string) {
+  if (kind === 'software') return 'kind-icon:code'
+  if (kind === 'proposal') return 'kind-icon:sparkles'
+  return 'kind-icon:document'
+}
+
+function kindProgressClass(kind: string) {
+  if (kind === 'software') return 'bg-primary'
+  if (kind === 'proposal') return 'bg-info'
+  return 'bg-secondary'
+}
+
+function formatKind(kind: string) {
+  return String(kind || 'project')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function getDreamTitle(dream?: DreamWithRelations | null) {
+  return dream?.title || dream?.slug || ''
+}
+</script>
+
+<style scoped>
+.project-card-scroll {
+  scrollbar-width: thin;
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds a dedicated `ConductorOverviewGalleryPage` for the workspace project gallery.
- Makes card mode a single-row horizontal scroll with snap sizing and mobile-friendly card widths.
- Upgrades hero mode with hover/focus dream detail reveal instead of only the image/title overlay.
- Makes icon and list modes much richer by default with descriptions, status, priority, progress, task counts, blocked/human-gate signals, and project notes.
- Routes only the Conductor overview state through the new gallery page so the existing detail/tasks/brainstorm workflows stay on the current `ConductorPage`.

## Notes

This intentionally avoids direct frontend API calls and uses the existing stores for project, dream, todo, nav, user, and page state. I did not run the local test suite from the connector environment.