### PR TITLE
Fix conductor gallery vertical scrolling

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -27,7 +27,24 @@ body,
   overflow-x: hidden;
 }
 
+section:has(img[src*="projects/images"]) .overflow-y-auto {
+  overflow-x: hidden;
+}
 
+section:has(img[src*="projects/images"]) .grid:has(> button[style*="aspect-ratio: 2/3"]),
+section:has(img[src*="projects/images"]) .grid:has(> div[style*="aspect-ratio: 2/3"]) {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+}
+
+section:has(img[src*="projects/images"]) .grid:has(> button[style*="aspect-ratio: 16/9"]),
+section:has(img[src*="projects/images"]) .grid:has(> div[style*="aspect-ratio: 16/9"]) {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+}
+
+section:has(img[src*="projects/images"]) .grid:has(> button > img[src*="-icon"]),
+section:has(img[src*="projects/images"]) .grid:has(> div > img[src*="-icon"]) {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 8rem), 1fr));
+}
 
 @layer base {
   body {

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -46,6 +46,33 @@ section:has(img[src*="projects/images"]) .grid:has(> div > img[src*="-icon"]) {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 8rem), 1fr));
 }
 
+section:has(div[class*="xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"]) {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+section:has(div[class*="xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"]) > div[class*="overflow-y-auto"] {
+  flex: 0 0 auto;
+  overflow-x: hidden;
+  overflow-y: visible;
+}
+
+section:has(div[class*="xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"]) div[class*="min-h-[180px]"][class*="rounded-2xl"] {
+  min-height: 7rem !important;
+}
+
+@media (min-width: 640px) {
+  section:has(div[class*="xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"]) div[class*="min-h-[180px]"][class*="rounded-2xl"] {
+    min-height: 8rem !important;
+  }
+}
+
+@media (min-width: 1280px) {
+  section:has(div[class*="xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"]) div[class*="min-h-[180px]"][class*="rounded-2xl"] {
+    min-height: 9rem !important;
+  }
+}
+
 @layer base {
   body {
     @apply text-sm md:text-base lg:text-lg xl:text-xl;

--- a/components/pages/conductor-art-gallery.vue
+++ b/components/pages/conductor-art-gallery.vue
@@ -1,25 +1,25 @@
 <!-- /components/pages/conductor-art-gallery.vue -->
 <template>
   <section
-    class="flex min-h-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="flex min-h-0 min-w-0 flex-col gap-3 overflow-x-hidden rounded-2xl border border-base-300 bg-base-100 p-4"
     @mouseenter="paused = true"
     @mouseleave="paused = false"
   >
-    <div class="flex items-center gap-2">
+    <div class="flex min-w-0 items-center gap-2">
       <Icon name="kind-icon:image" class="size-4 text-secondary" />
       <h4
-        class="text-xs font-bold uppercase tracking-wide text-base-content/60"
+        class="min-w-0 truncate text-xs font-bold uppercase tracking-wide text-base-content/60"
       >
         Inspiration Gallery
       </h4>
       <span
         v-if="matchedCollection"
-        class="badge badge-secondary badge-xs"
+        class="badge badge-secondary badge-xs shrink-0"
         :title="`Art collection: ${matchedCollection.label}`"
       >
         {{ collectionSlideCount }} from collection
       </span>
-      <span v-if="slides.length" class="ml-auto text-xs text-base-content/40">
+      <span v-if="slides.length" class="ml-auto shrink-0 text-xs text-base-content/40">
         {{ activeIndex + 1 }} / {{ slides.length }}
       </span>
     </div>
@@ -81,13 +81,13 @@
 
     <div
       v-if="slides.length > 1"
-      class="flex shrink-0 gap-1.5 overflow-x-auto pb-1"
+      class="flex shrink-0 flex-wrap justify-center gap-1.5 overflow-x-hidden pb-1"
     >
       <button
         v-for="(slide, index) in slides"
         :key="slide.src"
         type="button"
-        class="relative size-12 shrink-0 overflow-hidden rounded-lg border transition-all"
+        class="relative size-12 overflow-hidden rounded-lg border transition-all"
         :class="
           index === activeIndex
             ? 'border-primary ring-2 ring-primary/40'


### PR DESCRIPTION
## Summary
- Removes the horizontal thumbnail strip from the conductor inspiration gallery by wrapping thumbnails instead of scrolling sideways.
- Adds conductor-gallery CSS guardrails so project grids auto-fit available width and hide horizontal overflow while keeping vertical scroll.
- Compacts the project detail header and makes the project detail view use a single vertical scroll surface so the header scrolls with the rest of the project content.

## Notes
- Focused layout-only change. TypeScript check passed before the final CSS-only commit; the latest run is queued/running again for the new head.