### PR TITLE
fix(security): require admin auth on conductor write endpoints, scope…

### DIFF
--- a/server/api/conductor/inbox.post.ts
+++ b/server/api/conductor/inbox.post.ts
@@ -1,7 +1,10 @@
 import { defineEventHandler, readBody, createError } from 'h3'
 import { conductorGet, conductorPut } from '~/server/utils/conductor-github'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
 
 export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+
   const body = await readBody(event)
   const message = String(body?.message ?? '').trim()
   if (!message) throw createError({ statusCode: 400, message: 'message required' })

--- a/server/api/conductor/message.post.ts
+++ b/server/api/conductor/message.post.ts
@@ -1,6 +1,9 @@
 import { conductorPut } from '~/server/utils/conductor-github'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
 
 export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+
   const { message, project } = await readBody<{ message: string; project?: string }>(event)
 
   if (!message?.trim()) {

--- a/server/api/conductor/overrides.post.ts
+++ b/server/api/conductor/overrides.post.ts
@@ -1,4 +1,5 @@
 import { conductorGet, conductorPut } from '~/server/utils/conductor-github'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
 
 const VALID_STATUSES = ['active', 'paused', 'retired', 'finished'] as const
 const VALID_PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const
@@ -15,6 +16,8 @@ interface OverrideEntry {
 }
 
 export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+
   const body = await readBody<Record<string, OverrideEntry>>(event)
 
   const lines = [

--- a/server/api/conductor/pitch-vote.post.ts
+++ b/server/api/conductor/pitch-vote.post.ts
@@ -1,8 +1,11 @@
 import { conductorGet, conductorPut } from '~/server/utils/conductor-github'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
 
 type PitchVote = 'approved' | 'passed'
 
 export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+
   const { slug, vote } = await readBody<{ slug: string; vote: PitchVote }>(event)
 
   if (!slug?.trim()) {

--- a/server/api/conductor/pitch.post.ts
+++ b/server/api/conductor/pitch.post.ts
@@ -1,6 +1,9 @@
 import { conductorPut } from '~/server/utils/conductor-github'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
 
 export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+
   const { title, summary, target, effort, why, firstTask } = await readBody<{
     title: string
     summary: string

--- a/server/api/todos/dream/[dreamId].get.ts
+++ b/server/api/todos/dream/[dreamId].get.ts
@@ -7,7 +7,7 @@ import { requireApiUser } from '@/server/utils/authGuard'
 
 export default defineEventHandler(async (event) => {
   try {
-    await requireApiUser(event)
+    const auth = await requireApiUser(event)
 
     const dreamId = Number(event.context.params?.dreamId)
     if (!Number.isInteger(dreamId) || dreamId <= 0) {
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const todos = await prisma.todo.findMany({
-      where: { dreamId },
+      where: { dreamId, userId: auth.user.id },
       orderBy: [
         { order: 'asc' },
         { priority: 'asc' },

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -112,3 +112,18 @@ export async function requireApiUser(event: H3Event): Promise<AuthGuardResult> {
 
   return auth
 }
+
+export async function requireAdminApiUser(
+  event: H3Event,
+): Promise<AuthGuardResult> {
+  const auth = await requireApiUser(event)
+
+  if (!auth.isAdmin) {
+    throw createError({
+      statusCode: 403,
+      message: 'Admin access required.',
+    })
+  }
+
+  return auth
+}

--- a/stores/conductorStore.ts
+++ b/stores/conductorStore.ts
@@ -10,6 +10,7 @@ import type {
   ConductorPitch,
 } from '@/server/api/conductor/projects.get'
 import { CONDUCTOR_CARDS } from '@/stores/helpers/conductorCards'
+import { performFetch } from '@/stores/utils'
 
 export type DreamPriority = 'LOW' | 'NORMAL' | 'HIGH'
 export type PitchVote = 'approved' | 'passed'
@@ -116,9 +117,10 @@ export const useConductorStore = defineStore('conductor', () => {
   function voteOnPitch(slug: string, choice: PitchVote): void {
     votedPitches.value = { ...votedPitches.value, [slug]: choice }
     lsSet(VOTE_KEY, votedPitches.value)
-    $fetch('/api/conductor/pitch-vote', {
+    // pitch-vote is admin-gated server-side; send the signed-in user's JWT.
+    performFetch('/api/conductor/pitch-vote', {
       method: 'POST',
-      body: { slug, vote: choice },
+      body: JSON.stringify({ slug, vote: choice }),
     }).catch((err) => {
       console.error('[conductor] pitch vote failed to persist to repo:', err)
     })


### PR DESCRIPTION
… dream todos to caller

- New requireAdminApiUser guard in authGuard (JWT admin or beta-admin token)
- Gate POST /api/conductor/{pitch,pitch-vote,inbox,message,overrides} — these previously accepted anonymous writes to the conductor repo
- GET /api/todos/dream/[dreamId] now returns only the caller's todos
- conductorStore.voteOnPitch sends the user's JWT via performFetch


Claude-Session: https://claude.ai/code/session_01HueWkK45Gb292q8f8XWYPc