### PR TITLE
serendipity/t-003: theme picker from LOCATION and GENRE dreams

### DIFF
--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -1,7 +1,8 @@
 <!-- /components/pages/serendipity-page.vue -->
-<!-- Serendipity scaffold (serendipity/t-002): themed intro + streamed story
-     loop on chat streams. Theme picker from Dreams arrives with t-003;
-     task weaving with t-005. Read-only — no writes to todos or roadmaps. -->
+<!-- Serendipity (serendipity/t-002 + t-003): themed intro with a Dreams-fed
+     theme picker (LOCATION and GENRE dreams as story ingredients) + streamed
+     story loop on chat streams. Task weaving arrives with t-005.
+     Read-only — no writes to todos or roadmaps. -->
 <template>
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4"
@@ -61,6 +62,98 @@
         </button>
       </div>
 
+      <div v-if="locationDreams.length" class="space-y-2">
+        <div class="flex items-center gap-2">
+          <span
+            class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+          >
+            Place
+          </span>
+          <span class="text-[0.7rem] text-base-content/40">
+            from your LOCATION dreams
+          </span>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :class="
+              !selectedLocationSlug
+                ? 'btn-secondary'
+                : 'btn-ghost border border-base-300'
+            "
+            @click="selectedLocationSlug = null"
+          >
+            Anywhere
+          </button>
+          <button
+            v-for="dream in locationDreams"
+            :key="dream.slug ?? dream.id"
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :class="
+              dream.slug === selectedLocationSlug
+                ? 'btn-secondary'
+                : 'btn-ghost border border-base-300'
+            "
+            :title="dream.flavorText ?? dream.description ?? undefined"
+            @click="selectedLocationSlug = dream.slug"
+          >
+            {{ dream.title }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="genreDreams.length" class="space-y-2">
+        <div class="flex items-center gap-2">
+          <span
+            class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+          >
+            Story grammar
+          </span>
+          <span class="text-[0.7rem] text-base-content/40">
+            from your GENRE dreams
+          </span>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :class="
+              !selectedGenreSlug
+                ? 'btn-secondary'
+                : 'btn-ghost border border-base-300'
+            "
+            @click="selectedGenreSlug = null"
+          >
+            Any tale
+          </button>
+          <button
+            v-for="dream in genreDreams"
+            :key="dream.slug ?? dream.id"
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :class="
+              dream.slug === selectedGenreSlug
+                ? 'btn-secondary'
+                : 'btn-ghost border border-base-300'
+            "
+            :title="dream.flavorText ?? dream.description ?? undefined"
+            @click="selectedGenreSlug = dream.slug"
+          >
+            {{ dream.title }}
+          </button>
+        </div>
+      </div>
+
+      <p
+        v-if="dreamStore.loading"
+        class="flex items-center gap-2 text-xs text-base-content/50"
+      >
+        <span class="loading loading-spinner loading-xs" />
+        Gathering places and story grammars from your Dreams…
+      </p>
+
       <label class="form-control w-full">
         <div class="label py-1">
           <span class="label-text text-xs font-bold uppercase tracking-wide">
@@ -103,8 +196,13 @@
         >
           <Icon name="kind-icon:wand" class="size-4" /> Surprise me
         </button>
-        <p class="text-xs text-base-content/50">
-          Soon: pick places and genres from your Dreams.
+        <p
+          v-if="
+            !locationDreams.length && !genreDreams.length && !dreamStore.loading
+          "
+          class="text-xs text-base-content/50"
+        >
+          Add LOCATION or GENRE dreams to unlock places and story grammars.
         </p>
       </div>
     </div>
@@ -175,18 +273,51 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
 import {
   SERENDIPITY_TONES,
   useSerendipityStore,
+  type SerendipityIngredient,
   type SerendipityTone,
 } from '@/stores/serendipityStore'
 
 const store = useSerendipityStore()
+const dreamStore = useDreamStore()
 
 const selectedTone = ref<SerendipityTone>('cozy')
+const selectedLocationSlug = ref<string | null>(null)
+const selectedGenreSlug = ref<string | null>(null)
 const vibeInput = ref('')
 const answerInput = ref('')
+
+const locationDreams = computed(() =>
+  dreamStore.dreams.filter(
+    (dream) => dream.dreamType === 'LOCATION' && dream.isActive && dream.slug,
+  ),
+)
+const genreDreams = computed(() =>
+  dreamStore.dreams.filter(
+    (dream) => dream.dreamType === 'GENRE' && dream.isActive && dream.slug,
+  ),
+)
+
+function toIngredient(
+  dream: DreamWithRelations | undefined,
+): SerendipityIngredient | undefined {
+  if (!dream?.slug) return undefined
+  return {
+    slug: dream.slug,
+    title: dream.title,
+    description: dream.description,
+    flavorText: dream.flavorText,
+  }
+}
+
+function pickRandom<T>(items: T[]): T | undefined {
+  if (!items.length) return undefined
+  return items[Math.floor(Math.random() * items.length)]
+}
 
 function parseVibes(): string[] {
   return vibeInput.value
@@ -202,7 +333,27 @@ async function begin(surprise: boolean) {
         Math.floor(Math.random() * SERENDIPITY_TONES.length)
       ] ?? 'surprising')
     : selectedTone.value
-  await store.beginStory({ tone, vibeTags: parseVibes(), surprise })
+  const location = surprise
+    ? toIngredient(pickRandom(locationDreams.value))
+    : toIngredient(
+        locationDreams.value.find(
+          (dream) => dream.slug === selectedLocationSlug.value,
+        ),
+      )
+  const genre = surprise
+    ? toIngredient(pickRandom(genreDreams.value))
+    : toIngredient(
+        genreDreams.value.find(
+          (dream) => dream.slug === selectedGenreSlug.value,
+        ),
+      )
+  await store.beginStory({
+    tone,
+    vibeTags: parseVibes(),
+    surprise,
+    location,
+    genre,
+  })
 }
 
 async function submitAnswer() {
@@ -219,5 +370,11 @@ function startOver() {
 
 onMounted(() => {
   store.restoreFromLocalStorage()
+  if (
+    !dreamStore.hasLoaded ||
+    (!locationDreams.value.length && !genreDreams.value.length)
+  ) {
+    dreamStore.fetchDreams({ limit: 200 })
+  }
 })
 </script>

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -26,6 +26,16 @@ export type SerendipityStorySeed = {
   surprise: boolean
 }
 
+// A pickable story ingredient sourced from a LOCATION or GENRE Dream.
+// The seed references Dreams by slug; the ingredient carries the display
+// text the prompt needs so the engine never re-reads the Dream record.
+export type SerendipityIngredient = {
+  slug: string
+  title: string
+  description?: string | null
+  flavorText?: string | null
+}
+
 export type SerendipityQuestion = {
   prompt: string
   realWorldKind:
@@ -65,6 +75,8 @@ export type SerendipitySession = {
   userId: number
   projectSlug?: string
   seed: SerendipityStorySeed
+  location?: SerendipityIngredient
+  genre?: SerendipityIngredient
   beats: SerendipityBeat[]
   status: 'draft' | 'active' | 'paused' | 'complete'
   createdAt: string
@@ -170,14 +182,33 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
     saveToLocalStorage()
   }
 
-  function buildSeedDescription(seed: SerendipityStorySeed): string {
+  function describeIngredient(ingredient: SerendipityIngredient): string {
+    return [ingredient.title, ingredient.description, ingredient.flavorText]
+      .filter(Boolean)
+      .join(' — ')
+  }
+
+  function buildSeedDescription(): string {
+    const active = session.value
+    if (!active) return ''
+    const seed = active.seed
     const parts = [`The story's tone is ${seed.tone}.`]
+    if (active.location) {
+      parts.push(
+        `The story is set in this place (make it vivid, stay true to it): ${describeIngredient(active.location)}.`,
+      )
+    }
+    if (active.genre) {
+      parts.push(
+        `Tell it in this story grammar, honoring its pacing and tropes: ${describeIngredient(active.genre)}.`,
+      )
+    }
     if (seed.vibeTags.length) {
       parts.push(
         `Let these vibe words color the texture (tone guidance, not plot instructions): ${seed.vibeTags.join(', ')}.`,
       )
     }
-    if (seed.surprise) {
+    if (seed.surprise && !active.location && !active.genre) {
       parts.push(
         'The protagonist asked to be surprised — pick the setting and story grammar yourself, something unexpected but compatible.',
       )
@@ -185,10 +216,10 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
     return parts.join(' ')
   }
 
-  function buildOpeningPrompt(seed: SerendipityStorySeed): string {
+  function buildOpeningPrompt(): string {
     return `${PERSONA}
 
-${buildSeedDescription(seed)}
+${buildSeedDescription()}
 
 Write the opening scene: set the place, invite the protagonist in, and end with one question.`
   }
@@ -205,7 +236,7 @@ Write the opening scene: set the place, invite the protagonist in, and end with 
       .join('\n\n')
     return `${PERSONA}
 
-${buildSeedDescription(session.value!.seed)}
+${buildSeedDescription()}
 
 The story so far:
 ${recap}
@@ -267,10 +298,14 @@ Continue the story with the next beat, honoring their answer, and end with one n
     vibeTags?: string[]
     projectSlug?: string
     surprise?: boolean
+    location?: SerendipityIngredient
+    genre?: SerendipityIngredient
   }): Promise<boolean> {
     const seed: SerendipityStorySeed = {
       userId: userStore.userId ?? userStore.user?.id ?? 10,
       projectSlug: input.projectSlug,
+      locationDreamSlug: input.location?.slug,
+      genreDreamSlug: input.genre?.slug,
       vibeTags: input.vibeTags ?? [],
       tone: input.tone,
       surprise: input.surprise ?? false,
@@ -280,13 +315,15 @@ Continue the story with the next beat, honoring their answer, and end with one n
       userId: seed.userId,
       projectSlug: seed.projectSlug,
       seed,
+      location: input.location,
+      genre: input.genre,
       beats: [],
       status: 'active',
       createdAt: nowIso(),
       updatedAt: nowIso(),
     }
     saveToLocalStorage()
-    return await weaveBeat(buildOpeningPrompt(seed))
+    return await weaveBeat(buildOpeningPrompt())
   }
 
   async function answerCurrentBeat(text: string): Promise<boolean> {


### PR DESCRIPTION
### Task
serendipity/t-003: Build theme picker from dream vibes, locations, and genres (kind: software) — continuing Silas's directed worker pass

### What changed / what I produced
- Intro screen now surfaces active **LOCATION dreams as pickable places** and **GENRE dreams as story grammars** (chip pickers with flavor text on hover, "Anywhere"/"Any tale" defaults)
- A choice produces the story seed per the brief's contract: `locationDreamSlug`/`genreDreamSlug` on the seed, with a new `SerendipityIngredient` type carrying the display text (title/description/flavorText) on the session so prompts stay self-contained
- Prompt building weaves the chosen place and grammar into every beat ("set in this place… tell it in this story grammar…")
- **"Surprise me" now rolls real Dreams**: random location + random genre + random tone
- Graceful fallback: with no LOCATION/GENRE dreams, the page works exactly as t-002 shipped it (tone-only), with a hint to add such dreams

### How I verified
- `vue-tsc --noEmit` full project: clean; eslint + prettier: clean
- Live streaming against a text server not exercised in this environment — the Vercel preview is the place to roll a themed story

### Stakes
reversible

### Kaizen suggestion
LOCATION/GENRE dreams would shine with a small seed set — a content task to author ~5 starter locations and ~5 genres would make the picker (and surprise roll) immediately delightful.

### Notes for reviewer
Dreams are fetched with the store's existing `fetchDreams({ limit: 200 })` on mount only when not already loaded. No schema changes, no writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7)_