### PR TITLE
serendipity/t-004: complete the story weaving loop

### DIFF
--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -1,7 +1,7 @@
 <!-- /components/pages/serendipity-page.vue -->
-<!-- Serendipity (serendipity/t-002 + t-003): themed intro with a Dreams-fed
-     theme picker (LOCATION and GENRE dreams as story ingredients) + streamed
-     story loop on chat streams. Task weaving arrives with t-005.
+<!-- Serendipity (serendipity/t-002..t-004): themed intro with a Dreams-fed
+     theme picker + the full story weaving loop on chat streams (momentum,
+     answer-steered beats, gentle finale). Task weaving arrives with t-005.
      Read-only — no writes to todos or roadmaps. -->
 <template>
   <section
@@ -25,15 +25,24 @@
           the protagonist.
         </p>
       </div>
-      <button
-        v-if="store.session"
-        type="button"
-        class="btn btn-ghost btn-sm rounded-xl"
-        :disabled="store.isWeaving"
-        @click="startOver"
-      >
-        <Icon name="kind-icon:wand" class="size-4" /> New story
-      </button>
+      <div v-if="store.session" class="flex shrink-0 gap-2">
+        <button
+          v-if="store.canClose"
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl"
+          @click="store.closeStory()"
+        >
+          <Icon name="kind-icon:moon" class="size-4" /> Bring it to a close
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl"
+          :disabled="store.isWeaving"
+          @click="startOver"
+        >
+          <Icon name="kind-icon:wand" class="size-4" /> New story
+        </button>
+      </div>
     </header>
 
     <!-- Intro screen -->
@@ -244,9 +253,20 @@
         <p v-if="store.errorMessage" class="text-xs text-error">
           {{ store.errorMessage }}
         </p>
+
+        <div
+          v-if="store.isComplete"
+          class="rounded-2xl border border-secondary/30 bg-secondary/5 p-4 text-center"
+        >
+          <p class="text-sm font-bold text-secondary">The End</p>
+          <p class="mt-1 text-xs text-base-content/60">
+            This story is complete. Open another door whenever you like.
+          </p>
+        </div>
       </div>
 
       <form
+        v-if="!store.isComplete"
         class="flex items-end gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3"
         @submit.prevent="submitAnswer"
       >

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -1,5 +1,5 @@
 // /stores/serendipityStore.ts
-// Serendipity story sessions (serendipity/t-002 scaffold).
+// Serendipity story sessions (serendipity/t-002..t-004).
 // App-owned session state per the approved experience brief:
 // conductor projects/serendipity/docs/serendipity-experience.md.
 // Read-only against real task state — no writes to todos or roadmaps here.
@@ -151,9 +151,24 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
   const awaitingAnswer = computed(
     () =>
       Boolean(
-        session.value && currentBeat.value && !currentBeat.value.answer,
+        session.value &&
+        session.value.status === 'active' &&
+        currentBeat.value &&
+        !currentBeat.value.answer,
       ) && !isWeaving.value,
   )
+
+  const isComplete = computed(() => session.value?.status === 'complete')
+
+  const canClose = computed(() => {
+    const active = session.value
+    return Boolean(
+      active &&
+      active.status === 'active' &&
+      active.beats.length >= 2 &&
+      !isWeaving.value,
+    )
+  })
 
   function saveToLocalStorage() {
     if (typeof localStorage === 'undefined') return
@@ -224,29 +239,89 @@ ${buildSeedDescription()}
 Write the opening scene: set the place, invite the protagonist in, and end with one question.`
   }
 
-  function buildNextBeatPrompt(answerText: string): string {
+  // Momentum guidance: the story should feel like it is going somewhere.
+  function beatPhaseGuidance(beatCount: number): string {
+    if (beatCount <= 1) {
+      return 'The story is young — widen the world a little and build momentum.'
+    }
+    if (beatCount <= 3) {
+      return 'The story is rising — raise what is at stake for the protagonist, gently.'
+    }
+    if (beatCount <= 5) {
+      return 'The story is deep — start braiding earlier threads and answers back in.'
+    }
+    return 'The story is long and rich — begin bending toward a resolution the protagonist can feel coming.'
+  }
+
+  // Keep prompts bounded on long stories: full text for the opening scene and
+  // the most recent beats, one-line question/answer pairs for the middle.
+  const RECAP_FULL_BEATS = 4
+
+  function buildRecap(): string {
     const beats = session.value?.beats ?? []
-    const recap = beats
+    if (beats.length <= RECAP_FULL_BEATS + 1) {
+      return beats
+        .map((beat) => {
+          const answer = beat.answer
+            ? `\nThe protagonist answered: ${beat.answer.text}`
+            : ''
+          return `${beat.narrative}${answer}`
+        })
+        .join('\n\n')
+    }
+    const opening = beats[0]
+    const middle = beats.slice(1, -RECAP_FULL_BEATS)
+    const recent = beats.slice(-RECAP_FULL_BEATS)
+    const middleLines = middle
       .map((beat) => {
-        const answer = beat.answer
-          ? `\nThe protagonist answered: ${beat.answer.text}`
-          : ''
-        return `${beat.narrative}${answer}`
+        const answer = beat.answer ? ` They answered: ${beat.answer.text}` : ''
+        return `- The story asked: ${beat.question.prompt}${answer}`
       })
-      .join('\n\n')
+      .join('\n')
+    return [
+      `How it began:\n${opening?.narrative ?? ''}`,
+      `What happened along the way:\n${middleLines}`,
+      recent
+        .map((beat) => {
+          const answer = beat.answer
+            ? `\nThe protagonist answered: ${beat.answer.text}`
+            : ''
+          return `${beat.narrative}${answer}`
+        })
+        .join('\n\n'),
+    ].join('\n\n')
+  }
+
+  function buildNextBeatPrompt(answerText: string): string {
+    const beatCount = session.value?.beats.length ?? 0
     return `${PERSONA}
 
 ${buildSeedDescription()}
 
+${beatPhaseGuidance(beatCount)}
+
 The story so far:
-${recap}
+${buildRecap()}
 
 The protagonist just answered: ${answerText}
 
 Continue the story with the next beat, honoring their answer, and end with one new question.`
   }
 
-  async function weaveBeat(prompt: string): Promise<boolean> {
+  function buildClosingPrompt(): string {
+    return `${PERSONA}
+
+${buildSeedDescription()}
+
+The story so far:
+${buildRecap()}
+
+The protagonist is ready for the story to end. Write the final beat: resolve
+the threads gently, give the protagonist a small gift to carry out of the
+story, and end with warmth. This is the finale — do NOT end with a question.`
+  }
+
+  async function weaveBeat(prompt: string, closing = false): Promise<boolean> {
     if (!session.value) return false
     isWeaving.value = true
     errorMessage.value = ''
@@ -271,12 +346,13 @@ Continue the story with the next beat, honoring their answer, and end with one n
         sessionId: session.value.id,
         narrative,
         question: {
-          prompt: extractQuestion(narrative),
+          prompt: closing ? '' : extractQuestion(narrative),
           realWorldKind: 'preference',
           projectSlug: session.value.projectSlug,
         },
         createdAt: nowIso(),
       }
+      if (closing) session.value.status = 'complete'
       session.value.beats.push(beat)
       session.value.updatedAt = nowIso()
       saveToLocalStorage()
@@ -329,7 +405,8 @@ Continue the story with the next beat, honoring their answer, and end with one n
   async function answerCurrentBeat(text: string): Promise<boolean> {
     const beat = currentBeat.value
     const trimmed = text.trim()
-    if (!session.value || !beat || beat.answer || !trimmed) return false
+    if (!awaitingAnswer.value || !session.value || !beat || !trimmed)
+      return false
     beat.answer = {
       text: trimmed,
       capturedAt: nowIso(),
@@ -340,6 +417,11 @@ Continue the story with the next beat, honoring their answer, and end with one n
     return await weaveBeat(buildNextBeatPrompt(trimmed))
   }
 
+  async function closeStory(): Promise<boolean> {
+    if (!canClose.value) return false
+    return await weaveBeat(buildClosingPrompt(), true)
+  }
+
   return {
     session,
     isWeaving,
@@ -347,9 +429,12 @@ Continue the story with the next beat, honoring their answer, and end with one n
     streamingText,
     currentBeat,
     awaitingAnswer,
+    isComplete,
+    canClose,
     restoreFromLocalStorage,
     resetSession,
     beginStory,
     answerCurrentBeat,
+    closeStory,
   }
 })


### PR DESCRIPTION
### Task
serendipity/t-004: Implement the story weaving loop (kind: software) — continuing Silas's directed worker pass

### What changed / what I produced
- **Momentum:** each beat's prompt now carries phase guidance keyed to beat count (young → rising → deep → bending toward resolution), so stories build instead of meandering
- **Bounded recaps:** long stories no longer grow prompts without limit — full text for the opening scene and the four most recent beats, one-line question/answer pairs for the middle
- **A real ending:** "Bring it to a close" (available from beat 2) weaves a warm finale beat with no question, sets the session to `complete`, hides the answer box, and shows "The End" card; New story remains one tap away
- Answer-steered beats and localStorage resume were already in from t-002 and are unchanged

### How I verified
- `vue-tsc --noEmit` full project: clean; eslint + prettier: clean
- Vercel preview on this PR is the place to play a full story through to its finale

### Stakes
reversible

### Kaizen suggestion
The finale would be a natural moment to surface a session recap ("what the story learned about your preferences") — groundwork for t-005's task weaving.

### Notes for reviewer
Scope stops at t-004: no task integration (t-005) and no write-back (t-006, human-gated). The store's public shape gained `isComplete`, `canClose`, and `closeStory()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7)_