### PR TITLE
serendipity/t-005: weave real tasks into story questions (read-only)

### DIFF
--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -1,8 +1,10 @@
 <!-- /components/pages/serendipity-page.vue -->
-<!-- Serendipity (serendipity/t-002..t-004): themed intro with a Dreams-fed
-     theme picker + the full story weaving loop on chat streams (momentum,
-     answer-steered beats, gentle finale). Task weaving arrives with t-005.
-     Read-only — no writes to todos or roadmaps. -->
+<!-- Serendipity (serendipity/t-002..t-005): themed intro with a Dreams-fed
+     theme picker, the full story weaving loop on chat streams (momentum,
+     answer-steered beats, gentle finale), and real-task weaving: HONEYDO
+     todos and needs-human conductor tasks surface as in-world questions.
+     Read-only — answers are captured for review, never written back
+     (t-006 gates write-back behind human approval). -->
 <template>
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4"
@@ -163,6 +165,28 @@
         Gathering places and story grammars from your Dreams…
       </p>
 
+      <label class="form-control w-full max-w-md">
+        <div class="label py-1">
+          <span class="label-text text-xs font-bold uppercase tracking-wide">
+            Project (optional — lets the story help for real)
+          </span>
+        </div>
+        <select
+          v-model="selectedProjectSlug"
+          class="select select-bordered w-full rounded-xl"
+          :disabled="store.isWeaving"
+        >
+          <option value="">A story just for me</option>
+          <option
+            v-for="project in conductorStore.projects"
+            :key="project.slug"
+            :value="project.slug"
+          >
+            {{ project.name || project.slug }}
+          </option>
+        </select>
+      </label>
+
       <label class="form-control w-full">
         <div class="label py-1">
           <span class="label-text text-xs font-bold uppercase tracking-wide">
@@ -250,6 +274,37 @@
           </span>
         </div>
 
+        <div
+          v-if="store.currentHookContext && store.awaitingAnswer"
+          class="flex items-start gap-2 rounded-2xl border border-info/30 bg-info/5 p-3"
+        >
+          <Icon
+            name="kind-icon:alert"
+            class="mt-0.5 size-4 shrink-0 text-info"
+          />
+          <div class="min-w-0 flex-1 text-xs leading-relaxed">
+            <p class="font-bold text-info">
+              This question is really about:
+              <span class="font-normal text-base-content/80">{{
+                store.currentHookContext.title
+              }}</span>
+              <span
+                class="badge badge-info badge-outline badge-xs ml-1 align-middle"
+              >
+                {{
+                  store.currentHookContext.kind === 'honeydo'
+                    ? 'honey-do'
+                    : 'needs a human'
+                }}
+              </span>
+            </p>
+            <p class="mt-0.5 text-base-content/50">
+              Your answer is kept for review — nothing is marked done or
+              approved by the story.
+            </p>
+          </div>
+        </div>
+
         <p v-if="store.errorMessage" class="text-xs text-error">
           {{ store.errorMessage }}
         </p>
@@ -294,6 +349,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useConductorStore } from '@/stores/conductorStore'
 import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
 import {
   SERENDIPITY_TONES,
@@ -303,11 +359,13 @@ import {
 } from '@/stores/serendipityStore'
 
 const store = useSerendipityStore()
+const conductorStore = useConductorStore()
 const dreamStore = useDreamStore()
 
 const selectedTone = ref<SerendipityTone>('cozy')
 const selectedLocationSlug = ref<string | null>(null)
 const selectedGenreSlug = ref<string | null>(null)
+const selectedProjectSlug = ref('')
 const vibeInput = ref('')
 const answerInput = ref('')
 
@@ -373,6 +431,7 @@ async function begin(surprise: boolean) {
     surprise,
     location,
     genre,
+    projectSlug: selectedProjectSlug.value || undefined,
   })
 }
 
@@ -396,5 +455,6 @@ onMounted(() => {
   ) {
     dreamStore.fetchDreams({ limit: 200 })
   }
+  void store.loadRealSurfaces()
 })
 </script>

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -6,6 +6,9 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { useChatStore } from '@/stores/chatStore'
+import { useConductorStore } from '@/stores/conductorStore'
+import { useDreamStore } from '@/stores/dreamStore'
+import { useTodoStore } from '@/stores/todoStore'
 import { useUserStore } from '@/stores/userStore'
 
 export type SerendipityTone =
@@ -34,6 +37,19 @@ export type SerendipityIngredient = {
   title: string
   description?: string | null
   flavorText?: string | null
+}
+
+// A real action surface the story can weave into a question (t-005).
+// Read-only: hooks are surfaced and phrased in-world; answers are captured
+// on the beat and never written back to todos or roadmaps here (t-006 gates
+// write-back behind human approval).
+export type SerendipityRealHook = {
+  kind: 'honeydo' | 'needs-human'
+  title: string
+  detail?: string | null
+  todoId?: number
+  conductorTaskId?: string
+  projectSlug: string
 }
 
 export type SerendipityQuestion = {
@@ -128,6 +144,9 @@ function extractQuestion(narrative: string): string {
 
 export const useSerendipityStore = defineStore('serendipityStore', () => {
   const chatStore = useChatStore()
+  const conductorStore = useConductorStore()
+  const dreamStore = useDreamStore()
+  const todoStore = useTodoStore()
   const userStore = useUserStore()
 
   const session = ref<SerendipitySession | null>(null)
@@ -159,6 +178,109 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
   )
 
   const isComplete = computed(() => session.value?.status === 'complete')
+
+  // ── Real-world hooks (t-005, read-only) ────────────────────────────────
+  // Hooks already woven into this session's beats are excluded via the
+  // todoId/conductorTaskId stamped on each beat's question.
+  const usedHookKeys = computed(() => {
+    const keys = new Set<string>()
+    for (const beat of session.value?.beats ?? []) {
+      if (beat.question.todoId != null) keys.add(`todo:${beat.question.todoId}`)
+      if (beat.question.conductorTaskId)
+        keys.add(`task:${beat.question.conductorTaskId}`)
+    }
+    return keys
+  })
+
+  const projectDreamId = computed(() => {
+    const slug = session.value?.projectSlug
+    if (!slug) return null
+    const dream = dreamStore.dreams.find(
+      (entry) => entry.dreamType === 'PROJECT' && entry.slug === slug,
+    )
+    return dream?.id ?? null
+  })
+
+  const availableHooks = computed<SerendipityRealHook[]>(() => {
+    const slug = session.value?.projectSlug
+    if (!slug) return []
+    const hooks: SerendipityRealHook[] = []
+    for (const todo of todoStore.honeyDoTodos) {
+      // Project-scoped honeydos first-class; unscoped ones ride along.
+      if (todo.dreamId != null && todo.dreamId !== projectDreamId.value)
+        continue
+      if (usedHookKeys.value.has(`todo:${todo.id}`)) continue
+      hooks.push({
+        kind: 'honeydo',
+        title: todo.title,
+        detail: todo.description ?? null,
+        todoId: todo.id,
+        projectSlug: slug,
+      })
+    }
+    const project = conductorStore.projects.find((entry) => entry.slug === slug)
+    for (const task of project?.tasks ?? []) {
+      if (task.status !== 'needs-human') continue
+      if (usedHookKeys.value.has(`task:${task.id}`)) continue
+      hooks.push({
+        kind: 'needs-human',
+        title: task.title,
+        detail: task.note ?? null,
+        conductorTaskId: task.id,
+        projectSlug: slug,
+      })
+    }
+    return hooks
+  })
+
+  function nextHook(): SerendipityRealHook | null {
+    return availableHooks.value[0] ?? null
+  }
+
+  // The brief's guardrail: always show the real task/todo context near a
+  // woven question. Resolves the current beat's ids back to display titles.
+  const currentHookContext = computed(() => {
+    const question = currentBeat.value?.question
+    if (!question || question.realWorldKind === 'preference') return null
+    if (question.todoId != null) {
+      const todo = todoStore.todos.find((entry) => entry.id === question.todoId)
+      return {
+        kind: question.realWorldKind,
+        title: todo?.title ?? 'a real to-do',
+      }
+    }
+    if (question.conductorTaskId) {
+      const project = conductorStore.projects.find(
+        (entry) => entry.slug === question.projectSlug,
+      )
+      const task = project?.tasks.find(
+        (entry) => entry.id === question.conductorTaskId,
+      )
+      return {
+        kind: question.realWorldKind,
+        title: task?.title ?? 'a real decision',
+      }
+    }
+    return null
+  })
+
+  async function loadRealSurfaces(): Promise<void> {
+    await Promise.all([
+      todoStore.hasLoaded ? Promise.resolve() : todoStore.fetchTodos(),
+      conductorStore.hasLoaded
+        ? Promise.resolve()
+        : conductorStore.fetchProjects(),
+    ])
+  }
+
+  function hookInstruction(hook: SerendipityRealHook): string {
+    const surface =
+      hook.kind === 'honeydo'
+        ? 'a small real to-do the protagonist can help with'
+        : "a real decision that is waiting on the protagonist's judgment"
+    const detail = hook.detail ? ` Context: ${hook.detail}` : ''
+    return `This beat's question must, in-world, present ${surface}. The real item is: "${hook.title}".${detail} Summarize the real decision plainly inside the story's voice — no jargon, no task ids — and frame it so the protagonist can answer in a sentence or two. Do not imply anything is approved or done by their answer.`
+  }
 
   const canClose = computed(() => {
     const active = session.value
@@ -231,10 +353,11 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
     return parts.join(' ')
   }
 
-  function buildOpeningPrompt(): string {
+  function buildOpeningPrompt(hook: SerendipityRealHook | null = null): string {
+    const hookPart = hook ? `\n\n${hookInstruction(hook)}` : ''
     return `${PERSONA}
 
-${buildSeedDescription()}
+${buildSeedDescription()}${hookPart}
 
 Write the opening scene: set the place, invite the protagonist in, and end with one question.`
   }
@@ -292,13 +415,17 @@ Write the opening scene: set the place, invite the protagonist in, and end with 
     ].join('\n\n')
   }
 
-  function buildNextBeatPrompt(answerText: string): string {
+  function buildNextBeatPrompt(
+    answerText: string,
+    hook: SerendipityRealHook | null = null,
+  ): string {
     const beatCount = session.value?.beats.length ?? 0
+    const hookPart = hook ? `\n\n${hookInstruction(hook)}` : ''
     return `${PERSONA}
 
 ${buildSeedDescription()}
 
-${beatPhaseGuidance(beatCount)}
+${beatPhaseGuidance(beatCount)}${hookPart}
 
 The story so far:
 ${buildRecap()}
@@ -321,7 +448,11 @@ the threads gently, give the protagonist a small gift to carry out of the
 story, and end with warmth. This is the finale — do NOT end with a question.`
   }
 
-  async function weaveBeat(prompt: string, closing = false): Promise<boolean> {
+  async function weaveBeat(
+    prompt: string,
+    closing = false,
+    hook: SerendipityRealHook | null = null,
+  ): Promise<boolean> {
     if (!session.value) return false
     isWeaving.value = true
     errorMessage.value = ''
@@ -347,8 +478,10 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
         narrative,
         question: {
           prompt: closing ? '' : extractQuestion(narrative),
-          realWorldKind: 'preference',
+          realWorldKind: hook?.kind ?? 'preference',
           projectSlug: session.value.projectSlug,
+          todoId: hook?.todoId,
+          conductorTaskId: hook?.conductorTaskId,
         },
         createdAt: nowIso(),
       }
@@ -399,7 +532,8 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
       updatedAt: nowIso(),
     }
     saveToLocalStorage()
-    return await weaveBeat(buildOpeningPrompt())
+    const hook = nextHook()
+    return await weaveBeat(buildOpeningPrompt(hook), false, hook)
   }
 
   async function answerCurrentBeat(text: string): Promise<boolean> {
@@ -410,11 +544,17 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
     beat.answer = {
       text: trimmed,
       capturedAt: nowIso(),
-      writeBackStatus: 'not-applicable',
+      // Answers to real hooks are held for human review (t-006 gates the
+      // actual write-back); pure preference answers need no write path.
+      writeBackStatus:
+        beat.question.realWorldKind === 'preference'
+          ? 'not-applicable'
+          : 'pending-human-gate',
     }
     session.value.updatedAt = nowIso()
     saveToLocalStorage()
-    return await weaveBeat(buildNextBeatPrompt(trimmed))
+    const hook = nextHook()
+    return await weaveBeat(buildNextBeatPrompt(trimmed, hook), false, hook)
   }
 
   async function closeStory(): Promise<boolean> {
@@ -431,6 +571,9 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
     awaitingAnswer,
     isComplete,
     canClose,
+    availableHooks,
+    currentHookContext,
+    loadRealSurfaces,
     restoreFromLocalStorage,
     resetSession,
     beginStory,


### PR DESCRIPTION
### Task
serendipity/t-005: Weave real tasks into story questions (kind: software) — continuing Silas's directed worker pass

### What changed / what I produced
- **Project selector** on the intro screen ("A story just for me" default), fed from `conductorStore.projects`
- **Real hooks**: with a project chosen, each beat weaves one real item as its in-world question — open **HONEYDO todos** (project-scoped via the PROJECT dream's id per the slug-parity rule, unscoped ones ride along) and **needs-human conductor tasks** for that project. Hooks already asked are excluded via the ids stamped on each beat's question
- **The brief's guardrail honored**: an info card next to the answer box shows "This question is really about: <real item>" with a honey-do / needs-a-human badge and the reassurance that nothing is marked done or approved by answering
- **Read-only capture**: answers to woven hooks get `writeBackStatus: 'pending-human-gate'`; preference answers stay `'not-applicable'`. No writes to todos or roadmaps anywhere
- Prompt instruction tells the engine to present the real decision plainly in the story's voice — no jargon, no task ids, no implying approval

### How I verified
- `vue-tsc --noEmit` full project: clean; eslint + prettier: clean
- The Vercel preview with a project selected (and open honeydos/needs-human gates on it) is the real test drive

### Stakes
reversible

### Kaizen suggestion
Session answers with `pending-human-gate` now accumulate silently in localStorage — t-006's design should start from a review surface that lists them (pairs naturally with t-010's finale recap).

### Notes for reviewer
This completes milestone m4's read-only half. t-006 (write-back) is human-gated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7)_