### PR TITLE
serendipity/t-006: story ledger — write-back demo (dry-run, human-gated)

### DIFF
--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -318,6 +318,43 @@
             This story is complete. Open another door whenever you like.
           </p>
         </div>
+
+        <!-- Story ledger: t-006 write-back demo, dry-run only -->
+        <div
+          v-if="store.pendingWriteBacks.length"
+          class="space-y-2 rounded-2xl border border-warning/30 bg-warning/5 p-4"
+        >
+          <div class="flex items-center gap-2">
+            <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
+            <h3 class="text-xs font-bold uppercase tracking-wide text-warning">
+              Story ledger — answers waiting on the human gate
+            </h3>
+          </div>
+          <p class="text-[0.7rem] leading-relaxed text-base-content/50">
+            The story collected these while you played. Nothing below has been
+            written anywhere — write-back ships only after Silas approves the
+            wiring (serendipity/t-006). This panel is the demo of that flow.
+          </p>
+          <article
+            v-for="item in store.pendingWriteBacks"
+            :key="item.beatId"
+            class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
+          >
+            <p class="font-bold">
+              {{ item.title }}
+              <span
+                class="badge badge-warning badge-outline badge-xs ml-1 align-middle"
+              >
+                {{ item.kind === 'honeydo' ? 'honey-do' : 'needs a human' }}
+              </span>
+            </p>
+            <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
+            <p class="mt-1 text-base-content/50">
+              <span class="font-semibold">Dry run:</span>
+              {{ item.proposedWrite }}
+            </p>
+          </article>
+        </div>
       </div>
 
       <form

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -237,10 +237,8 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
     return availableHooks.value[0] ?? null
   }
 
-  // The brief's guardrail: always show the real task/todo context near a
-  // woven question. Resolves the current beat's ids back to display titles.
-  const currentHookContext = computed(() => {
-    const question = currentBeat.value?.question
+  // Resolves a woven question's ids back to a display title.
+  function resolveQuestionContext(question: SerendipityQuestion | undefined) {
     if (!question || question.realWorldKind === 'preference') return null
     if (question.todoId != null) {
       const todo = todoStore.todos.find((entry) => entry.id === question.todoId)
@@ -262,6 +260,48 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
       }
     }
     return null
+  }
+
+  // The brief's guardrail: always show the real task/todo context near a
+  // woven question.
+  const currentHookContext = computed(() =>
+    resolveQuestionContext(currentBeat.value?.question),
+  )
+
+  // ── Story ledger (t-006 demo, dry-run only) ────────────────────────────
+  // Every captured answer that is waiting on the human gate, with the write
+  // that WOULD happen once Silas approves the wiring. No write path exists
+  // in this build — the ledger is the demo of the flow.
+  const pendingWriteBacks = computed(() => {
+    const items: {
+      beatId: string
+      kind: 'honeydo' | 'needs-human'
+      title: string
+      answer: string
+      proposedWrite: string
+    }[] = []
+    for (const beat of session.value?.beats ?? []) {
+      const question = beat.question
+      if (!beat.answer || beat.answer.writeBackStatus !== 'pending-human-gate')
+        continue
+      if (
+        question.realWorldKind !== 'honeydo' &&
+        question.realWorldKind !== 'needs-human'
+      )
+        continue
+      const context = resolveQuestionContext(question)
+      items.push({
+        beatId: beat.id,
+        kind: question.realWorldKind,
+        title: context?.title ?? 'a real item',
+        answer: beat.answer.text,
+        proposedWrite:
+          question.realWorldKind === 'honeydo'
+            ? `Would mark honey-do #${question.todoId} done, with this answer attached as the note.`
+            : `Would record this decision on conductor task ${question.conductorTaskId} as a new AGENT todo for review — the roadmap itself is only ever edited by Silas or the agents in conductor.`,
+      })
+    }
+    return items
   })
 
   async function loadRealSurfaces(): Promise<void> {
@@ -573,6 +613,7 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
     canClose,
     availableHooks,
     currentHookContext,
+    pendingWriteBacks,
     loadRealSurfaces,
     restoreFromLocalStorage,
     resetSession,


### PR DESCRIPTION
### Task
serendipity/t-006: Write story answers back to task progress — **the human-gated design/demo half**. Per the roadmap note, the wiring design is demoed first; nothing goes live until Silas approves.

### What changed / what I produced
- **Story ledger panel**: whenever a session holds answers at `pending-human-gate`, the panel lists each one — real item, badge, the protagonist's answer verbatim, and a **dry-run line stating the exact write that would happen** once approved:
  - honey-do → mark the todo done with the answer attached as its note
  - needs-human conductor task → record the decision as a new AGENT todo for review (the roadmap YAML itself stays edited only by Silas/agents in conductor — the app never touches it)
- Explicit in-UI language that nothing has been written anywhere and write-back ships only after t-006 approval
- Refactored the hook-context resolver so the question card and the ledger share it

### How I verified
- `vue-tsc --noEmit` full project: clean; eslint + prettier: clean
- Demo drive: on the Vercel preview, start a story with a project that has open honeydos or needs-human gates, answer a woven question, and the ledger appears with the dry-run writes

### Stakes
reversible (demo only — no write path exists in this build)

### Flags for Reviewer
- **This PR is safe to merge** (it writes nothing), but t-006 itself stays `needs-human`: approving the task means approving the wiring design described above, which unblocks implementing the real writes
- The companion design doc lands in conductor at `projects/serendipity/docs/write-back-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7)_