### PR TITLE
feat: add Serendipity finale recap

### DIFF
--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -311,12 +311,35 @@
 
         <div
           v-if="store.isComplete"
-          class="rounded-2xl border border-secondary/30 bg-secondary/5 p-4 text-center"
+          class="space-y-3 rounded-2xl border border-secondary/30 bg-secondary/5 p-4"
         >
-          <p class="text-sm font-bold text-secondary">The End</p>
-          <p class="mt-1 text-xs text-base-content/60">
-            This story is complete. Open another door whenever you like.
-          </p>
+          <div class="text-center">
+            <p class="text-sm font-bold text-secondary">The End</p>
+            <p class="mt-1 text-xs text-base-content/60">
+              This story is complete. Open another door whenever you like.
+            </p>
+          </div>
+          <div
+            v-if="sessionRecap.length"
+            class="rounded-2xl border border-base-300 bg-base-100 p-3 text-left"
+          >
+            <div class="mb-2 flex items-center gap-2">
+              <Icon name="kind-icon:stars" class="size-4 text-secondary" />
+              <h3 class="text-xs font-bold uppercase tracking-wide text-secondary">
+                What the story learned
+              </h3>
+            </div>
+            <dl class="grid gap-2 text-xs leading-relaxed sm:grid-cols-2">
+              <div
+                v-for="item in sessionRecap"
+                :key="item.label"
+                class="rounded-xl border border-base-300 bg-base-200/50 p-2"
+              >
+                <dt class="font-bold text-base-content/70">{{ item.label }}</dt>
+                <dd class="mt-0.5 text-base-content/60">{{ item.value }}</dd>
+              </div>
+            </dl>
+          </div>
         </div>
 
         <!-- Story ledger: t-006 write-back demo, dry-run only -->
@@ -416,6 +439,41 @@ const genreDreams = computed(() =>
     (dream) => dream.dreamType === 'GENRE' && dream.isActive && dream.slug,
   ),
 )
+
+const sessionRecap = computed(() => {
+  const active = store.session
+  if (!active || active.status !== 'complete') return []
+  const answeredBeats = active.beats.filter((beat) => beat.answer?.text)
+  const preferenceAnswers = answeredBeats
+    .filter((beat) => beat.question.realWorldKind === 'preference')
+    .map((beat) => beat.answer?.text.trim())
+    .filter(Boolean)
+    .slice(0, 3)
+  const realThreadCount = answeredBeats.filter(
+    (beat) => beat.question.realWorldKind !== 'preference',
+  ).length
+  const items: { label: string; value: string }[] = [
+    { label: 'Tone', value: active.seed.tone },
+  ]
+  if (active.location) items.push({ label: 'Place', value: active.location.title })
+  if (active.genre) items.push({ label: 'Story grammar', value: active.genre.title })
+  if (active.seed.vibeTags.length) {
+    items.push({ label: 'Vibes', value: active.seed.vibeTags.join(', ') })
+  }
+  if (preferenceAnswers.length) {
+    items.push({
+      label: 'Preference clues',
+      value: preferenceAnswers.join(' • '),
+    })
+  }
+  if (realThreadCount) {
+    items.push({
+      label: 'Real-world threads',
+      value: `${realThreadCount} answer${realThreadCount === 1 ? '' : 's'} held for review`,
+    })
+  }
+  return items
+})
 
 function toIngredient(
   dream: DreamWithRelations | undefined,


### PR DESCRIPTION
### Task
serendipity/t-010: Surface a session recap at the finale (kind: software)

### What changed / what I produced
- Added a "What the story learned" recap card to the completed Serendipity finale state.
- Summarizes selected tone, place, story grammar, vibe tags, preference answers, and any real-world threads held for review.
- Kept the change UI/store-local only; no backend writes, roadmap writes, Todo writes, deploys, or publish actions.

### How I verified
- Read the existing Serendipity component and store surfaces.
- Kept all data derived from existing `store.session` and existing answer metadata.
- Did not run local tests; connector-only run has no local checkout/runtime.

### Stakes
reversible

### Flags for Reviewer
- This PR is in `silasfelinus/kind_robots` because the Serendipity implementation lives there, while the roadmap task is tracked in `silasfelinus/conductor`.
- The conductor roadmap claim/status update was blocked by the connector safety filter before this PR could be opened.
- I avoided touching the gated write-back path; the recap only displays local session-derived information.

### Kaizen suggestion
Move the finale recap derivation into `serendipityStore` as a typed computed export once the streaming-store helper safety issue is cleared.

### Notes for reviewer
