### PR TITLE
serendipity/t-006: per-item Apply write-back for story answers

### DIFF
--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -1,10 +1,11 @@
 <!-- /components/pages/serendipity-page.vue -->
-<!-- Serendipity (serendipity/t-002..t-005): themed intro with a Dreams-fed
+<!-- Serendipity (serendipity/t-002..t-006): themed intro with a Dreams-fed
      theme picker, the full story weaving loop on chat streams (momentum,
-     answer-steered beats, gentle finale), and real-task weaving: HONEYDO
-     todos and needs-human conductor tasks surface as in-world questions.
-     Read-only — answers are captured for review, never written back
-     (t-006 gates write-back behind human approval). -->
+     answer-steered beats, gentle finale), real-task weaving (HONEYDO todos
+     and needs-human conductor tasks as in-world questions), and the Story
+     ledger's per-item Apply write-back (t-006 wiring approved by Silas
+     2026-07-03): honey-dos are marked done, needs-human decisions become
+     AGENT todos. The app never edits conductor roadmap YAML. -->
 <template>
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4"
@@ -325,7 +326,9 @@
           >
             <div class="mb-2 flex items-center gap-2">
               <Icon name="kind-icon:stars" class="size-4 text-secondary" />
-              <h3 class="text-xs font-bold uppercase tracking-wide text-secondary">
+              <h3
+                class="text-xs font-bold uppercase tracking-wide text-secondary"
+              >
                 What the story learned
               </h3>
             </div>
@@ -342,7 +345,7 @@
           </div>
         </div>
 
-        <!-- Story ledger: t-006 write-back demo, dry-run only -->
+        <!-- Story ledger: t-006, approved wiring — explicit per-item Apply -->
         <div
           v-if="store.pendingWriteBacks.length"
           class="space-y-2 rounded-2xl border border-warning/30 bg-warning/5 p-4"
@@ -350,32 +353,56 @@
           <div class="flex items-center gap-2">
             <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
             <h3 class="text-xs font-bold uppercase tracking-wide text-warning">
-              Story ledger — answers waiting on the human gate
+              Story ledger — answers the story collected
             </h3>
           </div>
           <p class="text-[0.7rem] leading-relaxed text-base-content/50">
-            The story collected these while you played. Nothing below has been
-            written anywhere — write-back ships only after Silas approves the
-            wiring (serendipity/t-006). This panel is the demo of that flow.
+            Nothing is written automatically. Apply an answer to make it real;
+            until then it just waits here.
           </p>
           <article
             v-for="item in store.pendingWriteBacks"
             :key="item.beatId"
             class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
           >
-            <p class="font-bold">
-              {{ item.title }}
-              <span
-                class="badge badge-warning badge-outline badge-xs ml-1 align-middle"
-              >
-                {{ item.kind === 'honeydo' ? 'honey-do' : 'needs a human' }}
-              </span>
-            </p>
-            <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
-            <p class="mt-1 text-base-content/50">
-              <span class="font-semibold">Dry run:</span>
-              {{ item.proposedWrite }}
-            </p>
+            <div class="flex items-start gap-2">
+              <div class="min-w-0 flex-1">
+                <p class="font-bold">
+                  {{ item.title }}
+                  <span
+                    class="badge badge-warning badge-outline badge-xs ml-1 align-middle"
+                  >
+                    {{ item.kind === 'honeydo' ? 'honey-do' : 'needs a human' }}
+                  </span>
+                </p>
+                <p class="mt-1 text-base-content/70">“{{ item.answer }}”</p>
+                <p class="mt-1 text-base-content/50">
+                  <span class="font-semibold">Apply will:</span>
+                  {{ item.proposedWrite }}
+                </p>
+              </div>
+              <div class="shrink-0">
+                <span
+                  v-if="item.status === 'written'"
+                  class="badge badge-success badge-sm rounded-xl"
+                >
+                  written
+                </span>
+                <button
+                  v-else
+                  type="button"
+                  class="btn btn-warning btn-xs rounded-xl"
+                  :disabled="item.status === 'queued'"
+                  @click="store.applyWriteBack(item.beatId)"
+                >
+                  <span
+                    v-if="item.status === 'queued'"
+                    class="loading loading-spinner loading-xs"
+                  />
+                  <template v-else>Apply</template>
+                </button>
+              </div>
+            </div>
           </article>
         </div>
       </div>
@@ -455,8 +482,10 @@ const sessionRecap = computed(() => {
   const items: { label: string; value: string }[] = [
     { label: 'Tone', value: active.seed.tone },
   ]
-  if (active.location) items.push({ label: 'Place', value: active.location.title })
-  if (active.genre) items.push({ label: 'Story grammar', value: active.genre.title })
+  if (active.location)
+    items.push({ label: 'Place', value: active.location.title })
+  if (active.genre)
+    items.push({ label: 'Story grammar', value: active.genre.title })
   if (active.seed.vibeTags.length) {
     items.push({ label: 'Vibes', value: active.seed.vibeTags.join(', ') })
   }

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -268,10 +268,11 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
     resolveQuestionContext(currentBeat.value?.question),
   )
 
-  // ── Story ledger (t-006 demo, dry-run only) ────────────────────────────
-  // Every captured answer that is waiting on the human gate, with the write
-  // that WOULD happen once Silas approves the wiring. No write path exists
-  // in this build — the ledger is the demo of the flow.
+  // ── Story ledger (t-006, wiring approved by Silas 2026-07-03) ──────────
+  // Every captured hook answer with its write-back state. Writes happen only
+  // through the explicit per-item Apply action below — never automatically
+  // on answering — per the approved design in conductor
+  // projects/serendipity/docs/write-back-design.md.
   const pendingWriteBacks = computed(() => {
     const items: {
       beatId: string
@@ -279,10 +280,11 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
       title: string
       answer: string
       proposedWrite: string
+      status: SerendipityAnswer['writeBackStatus']
     }[] = []
     for (const beat of session.value?.beats ?? []) {
       const question = beat.question
-      if (!beat.answer || beat.answer.writeBackStatus !== 'pending-human-gate')
+      if (!beat.answer || beat.answer.writeBackStatus === 'not-applicable')
         continue
       if (
         question.realWorldKind !== 'honeydo' &&
@@ -297,12 +299,67 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
         answer: beat.answer.text,
         proposedWrite:
           question.realWorldKind === 'honeydo'
-            ? `Would mark honey-do #${question.todoId} done, with this answer attached as the note.`
-            : `Would record this decision on conductor task ${question.conductorTaskId} as a new AGENT todo for review — the roadmap itself is only ever edited by Silas or the agents in conductor.`,
+            ? `Marks honey-do #${question.todoId} done, with this answer attached as the note.`
+            : `Records this decision on conductor task ${question.conductorTaskId} as a new AGENT todo for review — the roadmap itself is only ever edited by Silas or the agents in conductor.`,
+        status: beat.answer.writeBackStatus,
       })
     }
     return items
   })
+
+  // Applies one captured answer to the real world (t-006 approved wiring).
+  async function applyWriteBack(beatId: string): Promise<boolean> {
+    const beat = session.value?.beats.find((entry) => entry.id === beatId)
+    if (
+      !session.value ||
+      !beat?.answer ||
+      beat.answer.writeBackStatus !== 'pending-human-gate'
+    )
+      return false
+    const question = beat.question
+    beat.answer.writeBackStatus = 'queued'
+    saveToLocalStorage()
+    try {
+      let ok = false
+      if (question.realWorldKind === 'honeydo' && question.todoId != null) {
+        const todo = todoStore.todos.find(
+          (entry) => entry.id === question.todoId,
+        )
+        const note = `Story answer (serendipity): ${beat.answer.text}`
+        ok = await todoStore.updateTodo(question.todoId, {
+          status: 'DONE',
+          description: todo?.description
+            ? `${todo.description}\n\n${note}`
+            : note,
+        })
+      } else if (
+        question.realWorldKind === 'needs-human' &&
+        question.conductorTaskId
+      ) {
+        const context = resolveQuestionContext(question)
+        const created = await todoStore.createTodo({
+          title: `Story decision on ${question.projectSlug}/${question.conductorTaskId}: ${beat.answer.text.slice(0, 80)}`,
+          description: `Captured by Serendipity for conductor task ${question.projectSlug}/${question.conductorTaskId} ("${context?.title ?? ''}").\n\nProtagonist's answer: ${beat.answer.text}\n\nThe conductor task stays needs-human until Silas edits the roadmap.`,
+          category: 'AGENT',
+          dreamId: projectDreamId.value,
+        })
+        ok = created !== null
+      }
+      beat.answer.writeBackStatus = ok ? 'written' : 'pending-human-gate'
+      if (!ok)
+        errorMessage.value =
+          'The write did not land — it stays in the ledger to retry.'
+      session.value.updatedAt = nowIso()
+      saveToLocalStorage()
+      return ok
+    } catch (error) {
+      beat.answer.writeBackStatus = 'pending-human-gate'
+      errorMessage.value =
+        error instanceof Error ? error.message : 'The write did not land.'
+      saveToLocalStorage()
+      return false
+    }
+  }
 
   async function loadRealSurfaces(): Promise<void> {
     await Promise.all([
@@ -614,6 +671,7 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
     availableHooks,
     currentHookContext,
     pendingWriteBacks,
+    applyWriteBack,
     loadRealSurfaces,
     restoreFromLocalStorage,
     resetSession,


### PR DESCRIPTION
### Task
serendipity/t-006: Write story answers back to task progress — **implementation of the wiring Silas approved** (design: conductor `projects/serendipity/docs/write-back-design.md`; approval recorded on the roadmap task)

### What changed / what I produced
- The Story ledger now shows every hook answer with its live `writeBackStatus` and an explicit **per-item Apply button** — writes never happen automatically on answering
- **Honey-do answers** → `PATCH` the todo to `DONE` via `todoStore.updateTodo`, with the protagonist's answer appended to the todo description as `"Story answer (serendipity): …"`
- **Needs-human conductor task decisions** → `todoStore.createTodo` creates an AGENT todo (scoped to the project's dream) carrying the task id and full answer; the roadmap YAML is never touched and the conductor task stays `needs-human` until Silas edits it — exactly as designed
- Status walks `pending-human-gate → queued → written`; failures roll back to pending with an error message so nothing is silently lost; applied items show a `written` badge

### How I verified
- `vue-tsc --noEmit` full project: clean; eslint + prettier: clean
- End-to-end write verification needs a live backend session: on the preview/production, answer a woven question, hit Apply, and confirm the todo flips DONE (or the AGENT todo appears) in the Todos surface

### Stakes
reversible (todos can be flipped back to OPEN in one tap; AGENT todos can be deleted)

### Notes for reviewer
This completes t-006's implementation per the approved design. t-007 (polish + first full playthrough with report) is the last roadmap task and unblocks when t-006 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3z9Eytw5tYUbEAJ3xyfQ7)_