### PR TITLE
Improve session resilience during server outages

### DIFF
--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -313,9 +313,15 @@ export const useChatStore = defineStore('chatStore', () => {
     }
 
     if (userStore.token) {
-      const tokenIsValid = await userStore.validateAndFetchUserData()
+      const validation = await userStore.validateAndFetchUserData()
 
-      if (tokenIsValid) return
+      if (validation === 'valid') return
+
+      if (validation === 'unavailable') {
+        throw new Error(
+          'The sign-in service is unreachable right now. Please try again in a moment.',
+        )
+      }
 
       userStore.logout()
     }

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -33,6 +33,11 @@ type InitializeOptions = {
   force?: boolean
 }
 
+// 'invalid' means the server definitively rejected the token; 'unavailable'
+// means we couldn't get an answer (timeout, network, database down). Only
+// 'invalid' may cost the user their stored session.
+type TokenValidation = 'valid' | 'invalid' | 'unavailable'
+
 const fallbackAvatar = '/images/kindart.webp'
 
 function stableStringify(value: unknown): string {
@@ -81,7 +86,7 @@ export const useUserStore = defineStore('userStore', () => {
   const initialized = ref(false)
 
   const initializePromise = ref<Promise<void> | null>(null)
-  const validatePromise = ref<Promise<boolean> | null>(null)
+  const validatePromise = ref<Promise<TokenValidation> | null>(null)
   const fetchUsersPromise = ref<Promise<User[]> | null>(null)
   const patchUserPromise = ref<Promise<User | null> | null>(null)
   const queuedUserPatch = ref<UserPatch>({})
@@ -95,12 +100,15 @@ export const useUserStore = defineStore('userStore', () => {
   const karma = computed(() => user.value?.karma ?? 1000)
   const mana = computed(() => user.value?.mana ?? 0)
   const role = computed(() => user.value?.Role ?? 'USER')
-  const isAdmin = computed(() => user.value?.Role === 'ADMIN' || user.value?.id === 1)
+  const isAdmin = computed(
+    () => user.value?.Role === 'ADMIN' || user.value?.id === 1,
+  )
   const isFamily = computed(() => user.value?.Role === 'FAMILY')
   const isMember = computed(
     () =>
       user.value?.isMember === true &&
-      (!user.value?.memberUntil || new Date(user.value.memberUntil) > new Date()),
+      (!user.value?.memberUntil ||
+        new Date(user.value.memberUntil) > new Date()),
   )
   const avatarImage = computed(() => user.value?.avatarImage ?? 'default')
   const apiKey = computed(() => user.value?.apiKey ?? null)
@@ -396,11 +404,19 @@ export const useUserStore = defineStore('userStore', () => {
 
         token.value = tokenToUse
 
-        const success = await validateAndFetchUserData()
+        const validation = await validateAndFetchUserData()
 
-        if (!success) {
+        if (validation === 'invalid') {
           clearAuthStorage()
           resetSessionState(false)
+          initialized.value = true
+          return
+        }
+
+        if (validation === 'unavailable') {
+          // Server or database is unreachable — keep the stored token so the
+          // session survives the outage. The user browses as a guest until a
+          // later validateAndFetchUserData call succeeds.
           initialized.value = true
           return
         }
@@ -425,9 +441,9 @@ export const useUserStore = defineStore('userStore', () => {
     return initializePromise.value
   }
 
-  async function validateAndFetchUserData(): Promise<boolean> {
+  async function validateAndFetchUserData(): Promise<TokenValidation> {
     if (!token.value) {
-      return false
+      return 'invalid'
     }
 
     if (validatePromise.value) {
@@ -450,15 +466,23 @@ export const useUserStore = defineStore('userStore', () => {
           }
 
           lastError.value = null
-          return true
+          return 'valid'
         }
 
         lastError.value = res.message || 'Invalid token'
-        return false
+
+        // 400/401/403/404 are definitive rejections. Timeouts (408), server
+        // errors (5xx), and circuit-breaker skips (503) are outages — the
+        // token may still be perfectly good.
+        const status = res.status ?? 0
+        const definitivelyRejected =
+          status >= 400 && status < 500 && status !== 408
+
+        return definitivelyRejected ? 'invalid' : 'unavailable'
       } catch (error) {
         handleError(error, 'validateAndFetchUserData')
         lastError.value = 'Validation error'
-        return false
+        return 'unavailable'
       } finally {
         validatePromise.value = null
       }

--- a/stores/utils.ts
+++ b/stores/utils.ts
@@ -3,6 +3,33 @@ import { useUserStore } from '~/stores/userStore'
 import { useErrorStore, ErrorType } from '~/stores/errorStore'
 import type { ApiResponse } from '~/types/api'
 
+// Circuit breaker: after several consecutive transport-level failures
+// (timeouts, refused connections — not HTTP error responses), stop hammering
+// the API for a cool-off window so a dead database doesn't turn every page
+// into a pile of 10-second hangs. Client-only; server module state is shared
+// across requests and must not be poisoned by one bad render.
+const CIRCUIT_THRESHOLD = 3
+const CIRCUIT_COOLDOWN_MS = 30_000
+let consecutiveTransportFailures = 0
+let circuitOpenUntil = 0
+
+function circuitIsOpen(): boolean {
+  return import.meta.client && Date.now() < circuitOpenUntil
+}
+
+function recordTransportFailure(): void {
+  if (!import.meta.client) return
+  consecutiveTransportFailures += 1
+  if (consecutiveTransportFailures >= CIRCUIT_THRESHOLD) {
+    circuitOpenUntil = Date.now() + CIRCUIT_COOLDOWN_MS
+  }
+}
+
+function recordTransportSuccess(): void {
+  consecutiveTransportFailures = 0
+  circuitOpenUntil = 0
+}
+
 export async function performFetch<T = unknown>(
   url: string,
   options: RequestInit = {},
@@ -25,6 +52,14 @@ export async function performFetch<T = unknown>(
 
   if (token && !normalizedHeaders.has('Authorization')) {
     normalizedHeaders.set('Authorization', `Bearer ${token}`)
+  }
+
+  if (circuitIsOpen()) {
+    return {
+      success: false,
+      status: 503,
+      message: `Skipped ${url}: API unreachable, cooling off before retrying`,
+    }
   }
 
   const maxAttempts = Math.max(1, retries)
@@ -61,16 +96,27 @@ export async function performFetch<T = unknown>(
           ? (parsedBody as Record<string, unknown>)
           : {}
 
+      // Reaching the server at all closes the circuit, even on an HTTP error.
+      recordTransportSuccess()
+
+      // Many endpoints follow the app convention of replying HTTP 200 with
+      // { success: false, statusCode } in the body — honor both fields so a
+      // body-level failure is never reported as a successful fetch.
+      const bodySuccess =
+        typeof body.success === 'boolean' ? body.success : true
+      const effectiveStatus =
+        typeof body.statusCode === 'number' ? body.statusCode : res.status
+
       return {
-        success: res.ok,
-        status: res.status,
+        success: res.ok && bodySuccess,
+        status: effectiveStatus,
         data: (body.data ?? parsedBody) as T,
         message:
           typeof body.message === 'string'
             ? body.message
-            : res.ok
+            : res.ok && bodySuccess
               ? 'Request completed successfully'
-              : `Request failed with status ${res.status}`,
+              : `Request failed with status ${effectiveStatus}`,
         user: body.user as ApiResponse<T>['user'],
         token: typeof body.token === 'string' ? body.token : undefined,
         usernames: Array.isArray(body.usernames)
@@ -84,6 +130,8 @@ export async function performFetch<T = unknown>(
       const isLastAttempt = attempt >= maxAttempts
 
       if (isLastAttempt || isAbortError) {
+        recordTransportFailure()
+
         const message = isAbortError
           ? `Request timed out after ${timeout}ms`
           : err instanceof Error


### PR DESCRIPTION
## Summary
This PR enhances session handling to distinguish between definitive token rejections and temporary server unavailability, allowing users to maintain their stored sessions during outages while still clearing invalid tokens.

## Key Changes

- **Token validation states**: Introduced `TokenValidation` type with three states (`'valid'`, `'invalid'`, `'unavailable'`) to differentiate between:
  - Definitive rejections (4xx errors excluding 408)
  - Temporary unavailability (5xx, 408, network failures)
  - Valid tokens

- **Outage resilience**: Modified `initialize()` to preserve stored tokens when validation returns `'unavailable'`, allowing users to browse as guests until the server recovers, rather than clearing their session

- **Circuit breaker pattern**: Added client-side circuit breaker in `utils.ts` to prevent hammering a dead API:
  - Tracks consecutive transport-level failures (timeouts, connection refused)
  - Opens circuit after 3 failures, returning 503 for 30 seconds
  - Resets on successful requests
  - Only active on client-side to avoid poisoning server module state

- **Updated validation logic**: `validateAndFetchUserData()` now returns `TokenValidation` instead of boolean, with HTTP status inspection to determine if rejection is permanent or temporary

- **Chat store compatibility**: Updated `chatStore.ts` to handle the new validation return type

## Implementation Details

The circuit breaker prevents cascading failures by short-circuiting requests when the backend is unreachable, reducing unnecessary network overhead and improving perceived performance during outages. The distinction between invalid and unavailable tokens ensures users don't lose their session due to temporary infrastructure issues while still protecting against compromised or expired tokens.

https://claude.ai/code/session_01UXXxE52z4WmxjKeFTjegJc