### PR TITLE
feat: snapshot fallback hydration for bot/prompt/theme stores (phase 2)

### DIFF
--- a/.github/workflows/fallback-snapshot.yml
+++ b/.github/workflows/fallback-snapshot.yml
@@ -34,6 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # prisma.config.ts resolves DATABASE_URL at config-load time, so every
+      # prisma-adjacent step needs it — not just the snapshot script.
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,8 +58,6 @@ jobs:
 
       - name: Write fallback snapshots
         run: npx tsx utils/scripts/snapshotFallback.ts
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Commit snapshots if changed
         run: |

--- a/stores/botStore.ts
+++ b/stores/botStore.ts
@@ -12,6 +12,7 @@ import {
   seedBotsHelper,
 } from './helpers/botHelper'
 import { performFetch, handleError } from './utils'
+import { loadSnapshot, markSnapshotActive } from './helpers/snapshotLoader'
 import { useServerStore } from './serverStore'
 import { useUserStore } from './userStore'
 
@@ -119,6 +120,9 @@ export const useBotStore = defineStore('botStore', () => {
   const isInitializing = ref(false)
   const isSaving = ref(false)
   const lastError = ref<string | null>(null)
+  // True while the list is showing nightly snapshot rows instead of live
+  // data (fresh visit with the database unreachable). Cleared by fetchBots.
+  const usingSnapshot = ref(false)
 
   const pendingLaunchMessage = ref('')
 
@@ -465,6 +469,19 @@ export const useBotStore = defineStore('botStore', () => {
 
         hydrateFromLocalStorage()
 
+        // First visit (or cleared storage): paint from the nightly snapshot
+        // so the page has real bots even if the database is down. The next
+        // successful fetchBots replaces these rows and clears the flag.
+        if (bots.value.length === 0) {
+          const snapshotRows = await loadSnapshot<Bot>('bots')
+
+          if (snapshotRows.length && bots.value.length === 0) {
+            bots.value = snapshotRows.slice().sort(sortBots)
+            usingSnapshot.value = true
+            markSnapshotActive('bots', true)
+          }
+        }
+
         if (options.initializeServerStore === true) {
           await serverStore.initialize({
             fetchRemote: true,
@@ -517,6 +534,8 @@ export const useBotStore = defineStore('botStore', () => {
         if (response.success && Array.isArray(response.data)) {
           bots.value = response.data.slice().sort(sortBots)
           isLoaded.value = true
+          usingSnapshot.value = false
+          markSnapshotActive('bots', false)
           persist()
 
           return bots.value
@@ -909,6 +928,7 @@ export const useBotStore = defineStore('botStore', () => {
     isLoaded,
     isInitialized,
     isInitializing,
+    usingSnapshot,
     lastError,
     error,
     pendingLaunchMessage,

--- a/stores/helpers/snapshotLoader.ts
+++ b/stores/helpers/snapshotLoader.ts
@@ -1,0 +1,51 @@
+// /stores/helpers/snapshotLoader.ts
+// Loads the nightly public-content snapshots in stores/fallback/*.json
+// (written by utils/scripts/snapshotFallback.ts via the fallback-snapshot
+// Action) so stores can render real content while the database is down —
+// the conductorStore fallback pattern, generalized.
+//
+// import.meta.glob keeps the build green before the first snapshot exists
+// and code-splits each file so a store only downloads its own model.
+import { ref } from 'vue'
+
+export type SnapshotFile<T> = {
+  model: string
+  rowCount: number
+  cap: number
+  rows: T[]
+}
+
+const modules = import.meta.glob('../fallback/*.json', {
+  import: 'default',
+}) as Record<string, () => Promise<SnapshotFile<unknown>>>
+
+// Models currently rendering snapshot rows instead of live data. UI (e.g.
+// the conductor page) can watch this to surface a "degraded mode" notice.
+export const snapshotActiveModels = ref<string[]>([])
+
+export function markSnapshotActive(model: string, active: boolean): void {
+  const list = snapshotActiveModels.value
+  const has = list.includes(model)
+
+  if (active && !has) {
+    snapshotActiveModels.value = [...list, model]
+  } else if (!active && has) {
+    snapshotActiveModels.value = list.filter((m) => m !== model)
+  }
+}
+
+// Returns [] when the snapshot doesn't exist yet, fails to parse, or when
+// called during SSR (module-level degraded state must stay per-client).
+export async function loadSnapshot<T>(model: string): Promise<T[]> {
+  if (import.meta.server) return []
+
+  const loader = modules[`../fallback/${model}.json`]
+  if (!loader) return []
+
+  try {
+    const snapshot = (await loader()) as SnapshotFile<T>
+    return Array.isArray(snapshot?.rows) ? snapshot.rows : []
+  } catch {
+    return []
+  }
+}

--- a/stores/promptStore.ts
+++ b/stores/promptStore.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { ArtImage, Prompt } from '~/prisma/generated/prisma/client'
 import { performFetch, handleError } from './utils'
+import { loadSnapshot, markSnapshotActive } from './helpers/snapshotLoader'
 import { useUserStore } from './userStore'
 import {
   validatePromptString,
@@ -132,6 +133,9 @@ export const usePromptStore = defineStore('promptStore', () => {
   const isSaving = ref(false)
   const isGeneratingFields = ref(false)
   const lastError = ref<string | null>(null)
+  // True while the list is showing nightly snapshot rows instead of live
+  // data (fresh visit with the database unreachable). Cleared by fetchPrompts.
+  const usingSnapshot = ref(false)
 
   const initializePromise = ref<Promise<void> | null>(null)
   const fetchPromise = ref<Promise<Prompt[]> | null>(null)
@@ -377,6 +381,19 @@ export const usePromptStore = defineStore('promptStore', () => {
 
         loadFromLocalStorage()
 
+        // First visit (or cleared storage): paint from the nightly snapshot
+        // so the page has real prompts even if the database is down. The
+        // next successful fetchPrompts replaces these rows and clears the flag.
+        if (prompts.value.length === 0) {
+          const snapshotRows = await loadSnapshot<Prompt>('prompts')
+
+          if (snapshotRows.length && prompts.value.length === 0) {
+            prompts.value = snapshotRows.slice().sort(sortPrompts)
+            usingSnapshot.value = true
+            markSnapshotActive('prompts', true)
+          }
+        }
+
         if (options.fetchRemote) {
           await fetchPrompts(Boolean(options.force))
         }
@@ -420,6 +437,8 @@ export const usePromptStore = defineStore('promptStore', () => {
 
         prompts.value = response.data.slice().sort(sortPrompts)
         hasLoaded.value = true
+        usingSnapshot.value = false
+        markSnapshotActive('prompts', false)
         syncToLocalStorage()
 
         return prompts.value
@@ -797,7 +816,9 @@ export const usePromptStore = defineStore('promptStore', () => {
     return result.success
   }
 
-  async function promoteToDream(promptId?: number): Promise<PromptMutationResult> {
+  async function promoteToDream(
+    promptId?: number,
+  ): Promise<PromptMutationResult> {
     const id = promptId ?? selectedPrompt.value?.id
 
     if (!id) {
@@ -1038,6 +1059,7 @@ export const usePromptStore = defineStore('promptStore', () => {
     loading,
     isSaving,
     isGeneratingFields,
+    usingSnapshot,
     lastError,
     initializePromise,
     fetchPromise,

--- a/stores/themeStore.ts
+++ b/stores/themeStore.ts
@@ -2,6 +2,10 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch, nextTick } from 'vue'
 import { performFetch, handleError } from '@/stores/utils'
+import {
+  loadSnapshot,
+  markSnapshotActive,
+} from '@/stores/helpers/snapshotLoader'
 import { useUserStore } from '@/stores/userStore'
 import { useErrorStore, ErrorType } from '@/stores/errorStore'
 import type { Theme } from '~/prisma/generated/prisma/client'
@@ -121,6 +125,9 @@ export const useThemeStore = defineStore('themeStore', () => {
   const initializing = ref(false)
   const loadingThemes = ref(false)
   const lastError = ref<string | null>(null)
+  // True while sharedThemes holds nightly snapshot rows because the live
+  // fetch failed (database down). Cleared by the next successful getThemes.
+  const usingSnapshot = ref(false)
 
   const initializePromise = ref<Promise<void> | null>(null)
   const getThemesPromise = ref<Promise<Theme[]> | null>(null)
@@ -377,6 +384,8 @@ export const useThemeStore = defineStore('themeStore', () => {
 
         if (success && data?.themes) {
           sharedThemes.value = data.themes
+          usingSnapshot.value = false
+          markSnapshotActive('themes', false)
           return sharedThemes.value
         }
 
@@ -384,6 +393,21 @@ export const useThemeStore = defineStore('themeStore', () => {
       } catch (error) {
         handleError(error, 'getThemes')
         setLastError(error, 'Failed to fetch themes')
+
+        // Database unreachable and nothing loaded yet: fall back to the
+        // nightly snapshot so theme pickers still have real content.
+        // getThemes' cache guard checks sharedThemes.length, so snapshot
+        // rows must only land here (after a failure), never before a fetch.
+        if (sharedThemes.value.length === 0) {
+          const snapshotRows = await loadSnapshot<Theme>('themes')
+
+          if (snapshotRows.length && sharedThemes.value.length === 0) {
+            sharedThemes.value = snapshotRows
+            usingSnapshot.value = true
+            markSnapshotActive('themes', true)
+          }
+        }
+
         return sharedThemes.value
       } finally {
         loadingThemes.value = false
@@ -571,6 +595,7 @@ export const useThemeStore = defineStore('themeStore', () => {
     initialized,
     initializing,
     loadingThemes,
+    usingSnapshot,
     lastError,
     initializePromise,
     toggleMenu,


### PR DESCRIPTION
- stores/helpers/snapshotLoader.ts: loadSnapshot() reads the nightly stores/fallback/*.json via import.meta.glob (build stays green before the first snapshot exists; each model code-splits separately), plus a shared snapshotActiveModels registry so UI can surface degraded mode
- botStore/promptStore: on a fresh visit with empty localStorage, paint from the snapshot immediately; the next successful fetch replaces the rows and clears the usingSnapshot flag
- themeStore: hydrate from snapshot only after a failed getThemes (its cache guard keys off sharedThemes.length, so pre-filling would skip the live fetch permanently)
- workflow: move DATABASE_URL to job level — prisma.config.ts resolves it at config-load time, so 'prisma generate' needs it too (fixes the first run's failure)


Claude-Session: https://claude.ai/code/session_01UXXxE52z4WmxjKeFTjegJc