### PR TITLE
Reach the database over Tailscale in the snapshot workflow

### DIFF
--- a/.github/workflows/fallback-snapshot.yml
+++ b/.github/workflows/fallback-snapshot.yml
@@ -253,9 +253,12 @@ jobs:
           db_and_query="${rest#*/}"
           DB_NAME="${db_and_query%%\?*}"
 
+          # --column-statistics=0: the runner's MySQL 8 mysqldump queries
+          # information_schema.COLUMN_STATISTICS, which MariaDB doesn't have.
           mysqldump \
             --host="$DB_HOST" --port="$DB_PORT" --user="$DB_USER" \
             --single-transaction --skip-lock-tables --routines --triggers \
+            --column-statistics=0 \
             "$DB_NAME" \
             | gzip \
             | openssl enc -aes-256-cbc -pbkdf2 -pass env:BACKUP_PASSPHRASE \

--- a/.github/workflows/fallback-snapshot.yml
+++ b/.github/workflows/fallback-snapshot.yml
@@ -127,10 +127,19 @@ jobs:
               setTimeout(() => done('TIMEOUT'), 12000)
             })
           ;(async () => {
-            for (const [label, fn] of [['A', () => dns.resolve4(host)], ['AAAA', () => dns.resolve6(host)]]) {
-              try { console.log(label, 'records:', (await fn()).length) }
-              catch (e) { console.log(label, 'lookup error:', e.code) }
+            // Booleans only — enough to tell "still pointing at the public
+            // host" apart from "tailnet address but the node is unreachable".
+            console.log('host is a .ts.net MagicDNS name:', host.endsWith('.ts.net'))
+            const inCgnat = (ip) => {
+              const [a, b] = ip.split('.').map(Number)
+              return a === 100 && b >= 64 && b <= 127
             }
+            try {
+              const addrs = await dns.resolve4(host)
+              console.log('A records:', addrs.length, '| all tailnet (100.64/10):', addrs.every(inCgnat))
+            } catch (e) { console.log('A lookup error:', e.code) }
+            try { console.log('AAAA records:', (await dns.resolve6(host)).length) }
+            catch (e) { console.log('AAAA lookup error:', e.code) }
             await probe({ family: 4 }, 'connect ipv4:')
             await probe({ family: 6 }, 'connect ipv6:')
             await probe({}, 'connect default:')
@@ -148,6 +157,14 @@ jobs:
           DB_HOST="${hostport%%:*}"
           DB_PORT="${hostport#*:}"
           [ "$DB_PORT" = "$DB_HOST" ] && DB_PORT=3306
+          if command -v tailscale >/dev/null 2>&1; then
+            if tailscale ping -c 2 --timeout 3s "$DB_HOST" >/dev/null 2>&1; then
+              echo "tailscale ping: ok"
+            else
+              echo "tailscale ping: fail (host is not a reachable tailnet node)"
+            fi
+          fi
+
           if mysql --connect-timeout=12 -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -e 'SELECT 1' >/dev/null 2>&1; then
             echo "mysql CLI: ok"
           else

--- a/.github/workflows/fallback-snapshot.yml
+++ b/.github/workflows/fallback-snapshot.yml
@@ -12,11 +12,25 @@ name: Nightly fallback snapshot & backup
 #     passphrase secret is missing: artifacts on a public repo are
 #     downloadable by anyone, so a plaintext dump must never be uploaded.
 #
+# The database lives on a home Unraid box that is not reachable from
+# GitHub-hosted runner IPs, so both jobs join the Tailscale tailnet as an
+# ephemeral node for the duration of the run and reach MariaDB over it.
+#
 # Required secrets (repository Actions secrets: Settings → Secrets and
 # variables → Actions → New repository secret):
-#   DATABASE_URL       mysql://user:pass@host:port/db (must accept
-#                      connections from GitHub-hosted runners)
-#   BACKUP_PASSPHRASE  symmetric key for the encrypted dump
+#   DATABASE_URL         mysql://user:pass@host:port/db — host must be the
+#                        Unraid machine's tailnet address (MagicDNS name or
+#                        100.x.y.z IP), NOT its public hostname
+#   BACKUP_PASSPHRASE    symmetric key for the encrypted dump
+#   TS_OAUTH_CLIENT_ID   Tailscale OAuth client (scope: Auth Keys, with
+#   TS_OAUTH_SECRET      tag:ci) — admin console → Settings → OAuth clients.
+#                        The tailnet ACL must define the tag, e.g.
+#                        "tagOwners": { "tag:ci": ["autogroup:admin"] }
+#
+# MariaDB must also accept tailnet connections: the container's 3306 mapped
+# on the Unraid host is reachable at the host's tailnet IP as long as
+# Tailscale runs on the host; the DB user's allowed host must cover the
+# tailnet source (e.g. '%' or '100.64.0.0/10' addresses).
 #
 # Restore a dump:
 #   openssl enc -d -aes-256-cbc -pbkdf2 -in dump.sql.gz.enc -pass env:BACKUP_PASSPHRASE | gunzip | mysql ...
@@ -40,10 +54,17 @@ jobs:
       # prisma-adjacent step needs it — not just the snapshot script.
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
-      - name: Require DATABASE_URL secret
+      - name: Require secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         run: |
           if [ -z "$DATABASE_URL" ]; then
             echo "::error::DATABASE_URL is empty. Add it as a REPOSITORY ACTIONS SECRET: repo Settings → Secrets and variables → Actions → 'New repository secret'. (Vercel env vars, .env files, Codespaces/Dependabot secrets, and Actions *variables* do not resolve here.)"
+            exit 1
+          fi
+          if [ -z "$TS_OAUTH_CLIENT_ID" ] || [ -z "$TS_OAUTH_SECRET" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. Create a Tailscale OAuth client (admin console → Settings → OAuth clients, scope 'Auth Keys' with tag:ci) and add both as repository Actions secrets."
             exit 1
           fi
 
@@ -64,6 +85,16 @@ jobs:
 
       - name: Generate Prisma client
         run: npx prisma generate
+
+      # Join the tailnet as an ephemeral node (auto-removed after the run).
+      # Placed after the npm/prisma steps so the tailnet session stays as
+      # short as possible — only the probe and snapshot steps need it.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       # Diagnoses connectivity without leaking infrastructure into public
       # logs: prints only record counts, error codes, and timings — never the
@@ -159,6 +190,14 @@ jobs:
           else
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Connect to Tailscale
+        if: steps.gate.outputs.enabled == 'true'
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Install mysql client
         if: steps.gate.outputs.enabled == 'true'

--- a/.github/workflows/fallback-snapshot.yml
+++ b/.github/workflows/fallback-snapshot.yml
@@ -163,6 +163,15 @@ jobs:
             else
               echo "tailscale ping: fail (host is not a reachable tailnet node)"
             fi
+            # Counts and booleans only: is the DB host even a peer in the
+            # tailnet this runner joined, and does Tailscale think it is
+            # online? Distinguishes wrong-tailnet/wrong-IP from node-offline.
+            tailscale status --json | jq --arg h "$DB_HOST" '
+              {
+                "tailnet peers": (.Peer | length),
+                "db host is a peer": ([.Peer[]? | select((.TailscaleIPs[]? == $h) or (.DNSName | startswith($h + ".")))] | length > 0),
+                "peer reports online": ([.Peer[]? | select((.TailscaleIPs[]? == $h) or (.DNSName | startswith($h + ".")))] | first | .Online)
+              }'
           fi
 
           if mysql --connect-timeout=12 -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -e 'SELECT 1' >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Rescues four unmerged commits stranded on this branch after PR #83 was squash-merged (rebased cleanly onto current main during branch cleanup). They continue the nightly fallback-snapshot work: GitHub-hosted runners can't reach the home Unraid database directly, so the workflow joins the Tailscale tailnet as an ephemeral node for the run.

## Changes (all in `.github/workflows/fallback-snapshot.yml`)
- Join the tailnet via `tailscale/github-action` in both jobs, using new `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` secrets (fail-fast check included, mirroring the existing `DATABASE_URL` guard)
- Connectivity probe now distinguishes wrong-host from unreachable-tailnet-node and reports tailnet peer visibility for the DB host
- Disable `column-statistics` in mysqldump for MariaDB compatibility
- Documented the required secrets and the MariaDB tailnet-access prerequisites in the workflow header

## Setup needed before this works
1. Tailscale OAuth client (admin console → Settings → OAuth clients, scope Auth Keys with `tag:ci`; ACL must define the tag)
2. Add `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` as repository Actions secrets
3. `DATABASE_URL` host must be the Unraid machine's tailnet address

## Stakes
reversible (workflow-only; runs nightly or on manual dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eNwntztDC8krFfb1dDVDe

---
_Generated by [Claude Code](https://claude.ai/code/session_018eNwntztDC8krFfb1dDVDe)_