### PR TITLE
feat: idempotent Da Vinci ending seed importer (davinci/t-008)

### DIFF
--- a/docs/notes/davinci-ending-seed.md
+++ b/docs/notes/davinci-ending-seed.md
@@ -1,0 +1,47 @@
+# Da Vinci ending seed importer
+
+Populates the 1024 deterministic Da Vinci ending records from the conductor
+generator output. Source of truth for the payload shape lives in the conductor
+repo: `scripts/generate_davinci_endings.py` and
+`projects/davinci/docs/ending-seed-and-art-flow.md`.
+
+## Generate the seed file (conductor repo)
+
+```bash
+python scripts/generate_davinci_endings.py --format jsonl --output tmp/davinci-endings.jsonl
+```
+
+JSON (`--format json`) works too — the importer accepts both.
+
+## Import (this repo)
+
+```bash
+npm run seed:davinci -- path/to/davinci-endings.jsonl            # dry run
+npm run seed:davinci -- path/to/davinci-endings.jsonl --write    # apply
+```
+
+Requires `DATABASE_URL`. The importer is idempotent — safe to re-run; counts
+do not grow on repeat runs.
+
+## What it writes
+
+Per ending payload:
+
+- **Milestone** upserted by `triggerCode` (`davinci-ending-{outcomeKey}`),
+  non-repeatable, active, with icon/imagePath as path strings and the art
+  prompt stored for the future local generator pipeline.
+- **LifeEnding** upserted by `outcomeKey`, linked to the Milestone via
+  `milestoneId`.
+- **LifeAchievement** matched by `conditionKey` (`ending:{outcomeKey}`),
+  type `ENDING`, linked to both the Milestone and the LifeEnding.
+
+## What it deliberately does NOT do
+
+- No `ArtImage` rows are created. `iconArtImageId`, `heroArtImageId`, and
+  `artImageId` stay null until the local generator pipeline produces real
+  files — icon and hero images exist only as path strings for now.
+- No art generation jobs are enqueued.
+- No `LifeAchievementUnlock` rows. Note for the future unlock endpoint:
+  MySQL treats NULLs as distinct in the `(userId, achievementId, lifeRunId)`
+  unique constraint, so global unlocks (null `lifeRunId`) need an explicit
+  API-layer duplicate guard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1514,6 +1514,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1536,6 +1537,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1558,6 +1560,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1574,6 +1577,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1590,6 +1594,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1606,6 +1611,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1622,6 +1628,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1638,6 +1645,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1654,6 +1662,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1670,6 +1679,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1686,6 +1696,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1702,6 +1713,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1718,6 +1730,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1740,6 +1753,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1762,6 +1776,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1784,6 +1799,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1806,6 +1822,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1828,6 +1845,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1850,6 +1868,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1872,6 +1891,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1894,6 +1914,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1913,6 +1934,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1932,6 +1954,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1951,6 +1974,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2279,11 +2303,33 @@
         }
       }
     },
+    "node_modules/@nuxt/cli/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@nuxt/content": {
       "version": "3.14.0",
@@ -9892,6 +9938,23 @@
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/crossws": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.9.tgz",
+      "integrity": "sha512-iWx+1OMSG2aOHpjyf9AESOzkwsVdS49cXM9dVrI2PDhxU5l2RIWE/KG56gk4BbAnsMoycvniJ9OnOxO9LRzHVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postinstall": "nuxi prepare",
     "snapshot:fallback": "tsx utils/scripts/snapshotFallback.ts",
     "backfill:slugs": "tsx utils/scripts/backfillSlugs.ts",
+    "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/utils/scripts/seedDaVinciEndings.ts
+++ b/utils/scripts/seedDaVinciEndings.ts
@@ -1,0 +1,258 @@
+// utils/scripts/seedDaVinciEndings.ts
+//
+// Idempotent importer for the deterministic Da Vinci ending seed data produced
+// by conductor's scripts/generate_davinci_endings.py (JSON or JSONL).
+//
+// For each of the 1024 ending payloads it upserts:
+//   - Milestone        by triggerCode  (davinci-ending-{outcomeKey})
+//   - LifeEnding       by outcomeKey   (linked to the Milestone)
+//   - LifeAchievement  by conditionKey (ending:{outcomeKey}, linked to both)
+//
+// It NEVER creates ArtImage rows and never touches iconArtImageId /
+// heroArtImageId / artImageId — icon and hero images are seeded as path
+// strings only, until the local generator pipeline produces real files.
+//
+// Usage (tsx, not ts-node — the repo is ESM and ts-node can't resolve the
+// generated client's extensionless imports under Node's ESM loader):
+//   npm run seed:davinci -- tmp/davinci-endings.jsonl            # dry run (default)
+//   npm run seed:davinci -- tmp/davinci-endings.jsonl --write    # apply
+
+import 'dotenv/config'
+import { readFileSync } from 'node:fs'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import type { Prisma } from './../../prisma/generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
+
+const WRITE = process.argv.includes('--write')
+const filePath = ((): string => {
+  const arg = process.argv.slice(2).find((a) => !a.startsWith('--'))
+  if (!arg) {
+    throw new Error(
+      'Usage: npm run seed:davinci -- <path/to/davinci-endings.json|jsonl> [--write]',
+    )
+  }
+  return arg
+})()
+
+const VICTORY_TYPES = ['VICTORY', 'FAILURE', 'MIXED', 'SECRET'] as const
+type VictoryType = (typeof VICTORY_TYPES)[number]
+
+interface EndingPayload {
+  title: string
+  slug: string
+  outcomeKey: string
+  summary: string
+  victoryType: VictoryType
+  icon: string
+  heroImage: string
+  artPrompt: string
+  metadata: Prisma.InputJsonValue
+  milestone: {
+    label: string
+    message: string
+    icon: string
+    triggerCode: string
+    tooltip: string
+    isActive: boolean
+    isRepeatable: boolean
+    imagePath: string
+    artPrompt: string
+  }
+  achievement: {
+    title: string
+    slug: string
+    achievementType: string
+    conditionKey: string
+    description: string
+    icon: string
+    imagePath: string
+    artPrompt: string
+  }
+}
+
+function parseEndings(raw: string): EndingPayload[] {
+  const trimmed = raw.trim()
+  // Whole-file JSON: either {"endings": [...]} or a bare array.
+  if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) return parsed
+      if (Array.isArray(parsed.endings)) return parsed.endings
+    } catch {
+      // fall through to JSONL
+    }
+  }
+  return trimmed
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line)
+      } catch {
+        throw new Error(`Invalid JSONL at line ${index + 1}`)
+      }
+    })
+}
+
+function validate(ending: EndingPayload, index: number): void {
+  const where = `ending #${index} (${ending.outcomeKey ?? 'missing outcomeKey'})`
+  if (!/^[01]{10}$/.test(ending.outcomeKey ?? '')) {
+    throw new Error(`${where}: outcomeKey must be a 10-bit binary string`)
+  }
+  if (!ending.title || !ending.slug || !ending.summary) {
+    throw new Error(`${where}: title, slug, and summary are required`)
+  }
+  if (!VICTORY_TYPES.includes(ending.victoryType)) {
+    throw new Error(
+      `${where}: victoryType "${ending.victoryType}" is not valid`,
+    )
+  }
+  if (ending.milestone?.triggerCode !== `davinci-ending-${ending.outcomeKey}`) {
+    throw new Error(`${where}: milestone.triggerCode does not match outcomeKey`)
+  }
+  if (ending.achievement?.conditionKey !== `ending:${ending.outcomeKey}`) {
+    throw new Error(
+      `${where}: achievement.conditionKey does not match outcomeKey`,
+    )
+  }
+  if (ending.achievement.achievementType !== 'ENDING') {
+    throw new Error(`${where}: achievement.achievementType must be ENDING`)
+  }
+}
+
+async function importEnding(ending: EndingPayload) {
+  const m = ending.milestone
+  const milestoneData = {
+    label: m.label,
+    message: m.message,
+    icon: m.icon,
+    tooltip: m.tooltip,
+    isActive: m.isActive ?? true,
+    isRepeatable: m.isRepeatable ?? false,
+    imagePath: m.imagePath,
+    artPrompt: m.artPrompt,
+  }
+  const milestone = await prisma.milestone.upsert({
+    where: { triggerCode: m.triggerCode },
+    update: milestoneData,
+    create: { ...milestoneData, triggerCode: m.triggerCode },
+  })
+
+  const endingData = {
+    title: ending.title,
+    slug: ending.slug,
+    summary: ending.summary,
+    victoryType: ending.victoryType,
+    icon: ending.icon,
+    heroImage: ending.heroImage,
+    artPrompt: ending.artPrompt,
+    metadata: ending.metadata,
+    milestoneId: milestone.id,
+    isActive: true,
+  }
+  const lifeEnding = await prisma.lifeEnding.upsert({
+    where: { outcomeKey: ending.outcomeKey },
+    update: endingData,
+    create: { ...endingData, outcomeKey: ending.outcomeKey },
+  })
+
+  const a = ending.achievement
+  const achievementData = {
+    title: a.title,
+    slug: a.slug,
+    achievementType: 'ENDING' as const,
+    conditionKey: a.conditionKey,
+    description: a.description,
+    icon: a.icon,
+    imagePath: a.imagePath,
+    // LifeAchievement has no artPrompt column — the prompt lives on the
+    // linked Milestone and LifeEnding rows.
+    metadata: ending.metadata,
+    milestoneId: milestone.id,
+    endingId: lifeEnding.id,
+    isActive: true,
+  }
+  // conditionKey is derived from outcomeKey and stable across regenerations,
+  // while the slug embeds the (theoretically tunable) title — so match on
+  // conditionKey first to avoid duplicating achievements if titles ever shift.
+  const existing = await prisma.lifeAchievement.findFirst({
+    where: { conditionKey: a.conditionKey },
+    select: { id: true },
+  })
+  if (existing) {
+    await prisma.lifeAchievement.update({
+      where: { id: existing.id },
+      data: achievementData,
+    })
+  } else {
+    await prisma.lifeAchievement.create({ data: achievementData })
+  }
+}
+
+async function main() {
+  const endings = parseEndings(readFileSync(filePath, 'utf-8'))
+  console.log(`Parsed ${endings.length} ending payloads from ${filePath}`)
+  endings.forEach(validate)
+
+  const outcomeKeys = endings.map((ending) => ending.outcomeKey)
+  if (new Set(outcomeKeys).size !== outcomeKeys.length) {
+    throw new Error('Duplicate outcomeKeys in seed file')
+  }
+
+  const [existingMilestones, existingEndings, existingAchievements] =
+    await Promise.all([
+      prisma.milestone.count({
+        where: { triggerCode: { startsWith: 'davinci-ending-' } },
+      }),
+      prisma.lifeEnding.count({
+        where: { outcomeKey: { in: outcomeKeys } },
+      }),
+      prisma.lifeAchievement.count({
+        where: { conditionKey: { in: outcomeKeys.map((k) => `ending:${k}`) } },
+      }),
+    ])
+  console.log(
+    `Existing: ${existingMilestones} milestones, ${existingEndings} endings, ${existingAchievements} achievements`,
+  )
+
+  if (!WRITE) {
+    console.log(
+      `[dry run] Would upsert ${endings.length} milestones, endings, and achievements. Re-run with --write to apply.`,
+    )
+    return
+  }
+
+  let done = 0
+  for (const ending of endings) {
+    await importEnding(ending)
+    done += 1
+    if (done % 128 === 0) console.log(`  ...${done}/${endings.length}`)
+  }
+
+  const [milestones, lifeEndings, achievements] = await Promise.all([
+    prisma.milestone.count({
+      where: { triggerCode: { startsWith: 'davinci-ending-' } },
+    }),
+    prisma.lifeEnding.count({
+      where: { outcomeKey: { in: outcomeKeys } },
+    }),
+    prisma.lifeAchievement.count({
+      where: { conditionKey: { in: outcomeKeys.map((k) => `ending:${k}`) } },
+    }),
+  ])
+  console.log(
+    `Done. Totals now: ${milestones} davinci-ending milestones, ${lifeEndings} LifeEndings, ${achievements} ENDING achievements.`,
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())


### PR DESCRIPTION
### Task
davinci/t-008: Build Da Vinci seed importer in kind_robots (kind: software)

### What changed
- `utils/scripts/seedDaVinciEndings.ts` + `npm run seed:davinci` — idempotent importer for the deterministic conductor generator output (`scripts/generate_davinci_endings.py`, JSON or JSONL). Per ending it upserts **Milestone** by `triggerCode` (`davinci-ending-{outcomeKey}`), **LifeEnding** by `outcomeKey` (linked via `milestoneId`), and **LifeAchievement** matched by `conditionKey` (`ending:{outcomeKey}`, linked via `milestoneId` + `endingId`). Dry run by default; `--write` applies.
- `docs/notes/davinci-ending-seed.md` — usage + what the importer deliberately does not do.
- `package-lock.json` — repairs pre-existing lock drift on main (`npm ci` failed: missing nested `cac`/`commander`/`crossws` entries). Additive-only, no version changes to direct deps.

### Deliberate exclusions (per task boundaries)
- No `ArtImage` rows; `iconArtImageId` / `heroArtImageId` / `artImageId` stay null. Icon and hero images are seeded as **path strings only** until the local generator pipeline produces real files.
- No art jobs enqueued, no user-facing changes, no unlock rows.

### How I verified
- Ran the importer end-to-end against a throwaway local MariaDB with the schema applied via `prisma db push`: **1024 Milestones** (`davinci-ending-*`), **1024 LifeEndings**, **1024 LifeAchievements**, zero rows missing `milestoneId`/`endingId` links, zero `ArtImage` rows, victory distribution SECRET 96 / VICTORY 43 / FAILURE 56 / MIXED 829.
- Re-ran with `--write` twice more: counts unchanged (idempotent). Also verified it absorbs a partially-imported database correctly.
- Verified both JSON and JSONL input formats parse.
- `npm run test` (vue-tsc) passes with 0 errors; eslint + prettier clean on the new files.

### Stakes
reversible — additive script + docs; no live data touched by merging.

### Flags for Reviewer
- The task mapping asked for `artPrompt` on LifeAchievement, but the migrated schema has no such column — the prompt lives on the linked Milestone and LifeEnding rows instead (noted in the script).
- Spec suggested `utils/scripts/seedDaVinciEndings.mjs`; shipped as `.ts` + tsx instead because the generated Prisma client is TypeScript and `.mjs` cannot import it (same reasoning documented in `backfillSlugs.ts`).
- Achievements are matched on `conditionKey` (stable, derived from outcomeKey) rather than slug, so future title/slug tuning in the generator can't duplicate rows.

### Notes for reviewer
Conductor roadmap updated on the same-named branch: t-008 → done, t-009 (minimal ending resolution API) → ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL77tR4AopDKKYxzC9hU1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL77tR4AopDKKYxzC9hU1S)_