### PR TITLE
fix: save-generated accepts machine auth (JWT, user apiKey, or admin token)

### DIFF
--- a/server/api/art/save-generated.post.ts
+++ b/server/api/art/save-generated.post.ts
@@ -2,6 +2,7 @@
 import { defineEventHandler, readBody, createError } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
+import { requireMachineUser } from '../../utils/authGuard'
 import { saveImage } from '../../utils/saveImage'
 import {
   type RequestData,
@@ -42,33 +43,15 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const authorizationHeader = event.node.req.headers.authorization
-
-    if (!authorizationHeader?.startsWith('Bearer ')) {
-      throw createError({
-        statusCode: 401,
-        message: 'Authorization token required in the format "Bearer <token>".',
-      })
-    }
-
-    const token = authorizationHeader.split(' ')[1] ?? ''
-
-    const user = await prisma.user.findFirst({
-      where: {
-        apiKey: token,
-      },
-      select: {
-        id: true,
-        karma: true,
-        preferredArtServerId: true,
-      },
-    })
-
-    if (!user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired authorization token.',
-      })
+    // Machine-auth parity with the ArtJob queue endpoints (t-011): accept a
+    // session JWT, a user apiKey, or the beta admin token. This endpoint
+    // previously accepted only a user apiKey, which stranded the relay agent
+    // at the final upload hop when it authenticated with the admin token.
+    const auth = await requireMachineUser(event)
+    const user = {
+      id: auth.user.id,
+      karma: auth.user.karma,
+      preferredArtServerId: auth.user.preferredArtServerId,
     }
 
     if (user.id !== requestData.userId) {


### PR DESCRIPTION
### Task
art-generator-connect: relay jobs render successfully but fail the final upload hop — ArtJob queue job 1 died with `save-generated failed: HTTP 401` after 3 attempts. (kind: software)

### What changed / what I produced
- `save-generated.post.ts`: replaced the inline user-apiKey-only lookup with the shared `requireMachineUser` guard (JWT, user apiKey, or beta admin token) — the same auth the queue endpoints already use (t-011). The userId-must-match-token-user check is unchanged, as is everything downstream.

### How I verified
- eslint clean; `tsc --noEmit` (server tsconfig) reports nothing for this file.
- Root cause confirmed live: claim/complete succeeded with the admin token (requireMachineUser) while save-generated 401'd the identical token; the failing job's error field names this exact hop.

### Stakes
reversible (single endpoint auth widened to match established parity; JWT and apiKey callers unaffected)

### Flags for Reviewer
- Same auth-surface consideration as PR #90's t-011: the beta admin token can now upload images via this endpoint (subject to the existing userId match check). It already had full queue control.

### Kaizen suggestion
Sweep the remaining art endpoints with bespoke inline apiKey checks (`/api/art/generate`, textGate consumers) onto `requireMachineUser` so auth behavior is uniform and defined in one place.

### Notes for reviewer
Silas can also work around without this merge by using his user apiKey as `KR_RELAY_TOKEN` — this PR just makes the admin token work uniformly across the pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_017HNj3jchdznYLCk6hrG2zA)_