### PR TITLE
t-015 auth sweep + t-014 queue contract tests

### DIFF
--- a/server/api/art/generate.post.ts
+++ b/server/api/art/generate.post.ts
@@ -1,5 +1,7 @@
 // /server/api/art/generate.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
+import type { H3Event } from 'h3'
+import { requireMachineUser } from '../../utils/authGuard'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { saveImage } from '../../utils/saveImage'
@@ -90,9 +92,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const user = await getAuthenticatedUser(
-      event.node.req.headers.authorization,
-    )
+    const user = await getAuthenticatedUser(event)
     const requestedUserId = requestData.userId ?? user.id
 
     if (user.id !== requestedUserId) {
@@ -249,36 +249,17 @@ export default defineEventHandler(async (event) => {
 })
 
 async function getAuthenticatedUser(
-  authorizationHeader: string | undefined,
+  event: H3Event,
 ): Promise<AuthenticatedUser> {
-  if (!authorizationHeader?.startsWith('Bearer ')) {
-    throw createError({
-      statusCode: 401,
-      message: 'Authorization token required in the format "Bearer <token>".',
-    })
+  // t-015: shared machine auth (session JWT, user apiKey, or beta admin
+  // token) via requireMachineUser, replacing the inline apiKey-only lookup.
+  const { user } = await requireMachineUser(event)
+
+  return {
+    id: user.id,
+    karma: user.karma,
+    preferredArtServerId: user.preferredArtServerId,
   }
-
-  const token = authorizationHeader.split(' ')[1] ?? ''
-
-  const user = await prisma.user.findFirst({
-    where: {
-      apiKey: token,
-    },
-    select: {
-      id: true,
-      karma: true,
-      preferredArtServerId: true,
-    },
-  })
-
-  if (!user) {
-    throw createError({
-      statusCode: 401,
-      message: 'Invalid or expired authorization token.',
-    })
-  }
-
-  return user
 }
 
 function assertA1111Server(server: Server): void {

--- a/server/api/art/queue/queue.http
+++ b/server/api/art/queue/queue.http
@@ -1,0 +1,117 @@
+@admintoken = {{$dotenv ADMIN_TOKEN}}
+@usertoken = {{$dotenv USER_TOKEN}}
+@host = https://kind-robots.vercel.app
+
+// @ts-nocheck
+/* eslint-disable */
+// test-ignore
+
+// ArtJob queue contract tests (art-generator-connect t-014).
+// Lifecycle: enqueue -> claim -> complete -> poll. Run top to bottom.
+// The claim/complete steps need admin credentials; enqueue/poll work with
+// any authenticated user (own jobs only).
+
+### 1. Enqueue an A1111 job (expect 201, data.job.status = PENDING)
+POST {{host}}/api/art/queue
+Content-Type: application/json
+Authorization: Bearer {{ admintoken }}
+
+{
+  "engine": "A1111",
+  "payload": {
+    "promptString": "contract test - a tiny robot inspecting a queue",
+    "width": 512,
+    "height": 512,
+    "steps": 8
+  },
+  "projectSlug": "art-generator-connect"
+}
+
+###
+
+### 2. List queue (expect the new job PENDING; admin sees all users' jobs)
+GET {{host}}/api/art/queue?status=PENDING&limit=10
+Authorization: Bearer {{ admintoken }}
+
+###
+
+### 3. Claim the next runnable job (expect data.job RUNNING with claimedBy;
+###    re-run immediately: expect "No runnable jobs." - claims are atomic)
+POST {{host}}/api/art/queue/claim
+Content-Type: application/json
+Authorization: Bearer {{ admintoken }}
+
+{
+  "agentId": "http-contract-test",
+  "engines": ["A1111"]
+}
+
+###
+
+### 4. Poll the job by id (replace 1; expect RUNNING after step 3)
+GET {{host}}/api/art/queue/1
+Authorization: Bearer {{ admintoken }}
+
+###
+
+### 5a. Complete the claimed job successfully (replace ids; artImageId must
+###     reference a real ArtImage, e.g. from /api/art/save-generated)
+POST {{host}}/api/art/queue/1/complete
+Content-Type: application/json
+Authorization: Bearer {{ admintoken }}
+
+{
+  "success": true,
+  "artImageId": 4032
+}
+
+###
+
+### 5b. OR report failure (job returns to PENDING until attempts hit 3 -> FAILED)
+POST {{host}}/api/art/queue/1/complete
+Content-Type: application/json
+Authorization: Bearer {{ admintoken }}
+
+{
+  "success": false,
+  "error": "contract test failure path"
+}
+
+###
+
+### 6. Negative: enqueue without payload (expect 400)
+POST {{host}}/api/art/queue
+Content-Type: application/json
+Authorization: Bearer {{ admintoken }}
+
+{
+  "engine": "A1111"
+}
+
+###
+
+### 7. Negative: claim with a non-admin user token (expect 403)
+POST {{host}}/api/art/queue/claim
+Content-Type: application/json
+Authorization: Bearer {{ usertoken }}
+
+{
+  "agentId": "http-contract-test"
+}
+
+###
+
+### 8. Negative: complete a job that is not RUNNING (expect 409)
+POST {{host}}/api/art/queue/1/complete
+Content-Type: application/json
+Authorization: Bearer {{ admintoken }}
+
+{
+  "success": true,
+  "artImageId": 4032
+}
+
+###
+
+### 9. Negative: unauthenticated list (expect 401)
+GET {{host}}/api/art/queue

--- a/server/api/chats/openai/images/generate.post.ts
+++ b/server/api/chats/openai/images/generate.post.ts
@@ -1,5 +1,6 @@
 // /server/api/openai/images/generate.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
+import { requireMachineUser } from '../../../../utils/authGuard'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from './../../../../utils/error'
 import { saveImage } from '../../../../utils/saveImage'
@@ -49,32 +50,9 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const authorizationHeader = event.node.req.headers.authorization
-
-    if (!authorizationHeader?.startsWith('Bearer ')) {
-      throw createError({
-        statusCode: 401,
-        message: 'Authorization token required in the format "Bearer <token>".',
-      })
-    }
-
-    const token = authorizationHeader.split(' ')[1] ?? ''
-
-    const user = await prisma.user.findFirst({
-      where: {
-        apiKey: token,
-      },
-      select: {
-        id: true,
-      },
-    })
-
-    if (!user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired authorization token.',
-      })
-    }
+    // t-015: shared machine auth (session JWT, user apiKey, or beta admin
+    // token) via requireMachineUser, replacing the inline apiKey-only lookup.
+    const { user } = await requireMachineUser(event)
 
     if (user.id !== requestData.userId) {
       throw createError({

--- a/server/api/comfy/characterSheet.post.ts
+++ b/server/api/comfy/characterSheet.post.ts
@@ -97,33 +97,9 @@ export default defineEventHandler(async (event) => {
       serverId: body.serverId ?? null,
     })
 
-    const authorizationHeader = event.node.req.headers.authorization
-
-    if (!authorizationHeader?.startsWith('Bearer ')) {
-      throw createError({
-        statusCode: 401,
-        message:
-          'Authorization token is required in the format "Bearer <token>".',
-      })
-    }
-
-    const token = authorizationHeader.split(' ')[1] ?? ''
-
-    const user = await prisma.user.findFirst({
-      where: {
-        apiKey: token,
-      },
-      select: {
-        id: true,
-      },
-    })
-
-    if (!user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired authorization token.',
-      })
-    }
+    // t-015: the former inline apiKey-only lookup here was redundant - this
+    // route authenticates via authAndGate (comfyGate) below, which accepts
+    // machine auth (JWT, user apiKey, or beta admin token) since t-011.
 
     const server = await resolveServer({
       userId: gate.user.id,

--- a/server/api/comfy/hunyuan3d.post.ts
+++ b/server/api/comfy/hunyuan3d.post.ts
@@ -88,33 +88,9 @@ export default defineEventHandler(async (event) => {
       serverId: body.serverId ?? null,
     })
 
-    const authorizationHeader = event.node.req.headers.authorization
-
-    if (!authorizationHeader?.startsWith('Bearer ')) {
-      throw createError({
-        statusCode: 401,
-        message:
-          'Authorization token is required in the format "Bearer <token>".',
-      })
-    }
-
-    const token = authorizationHeader.split(' ')[1] ?? ''
-
-    const user = await prisma.user.findFirst({
-      where: {
-        apiKey: token,
-      },
-      select: {
-        id: true,
-      },
-    })
-
-    if (!user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired authorization token.',
-      })
-    }
+    // t-015: the former inline apiKey-only lookup here was redundant - this
+    // route authenticates via authAndGate (comfyGate) below, which accepts
+    // machine auth (JWT, user apiKey, or beta admin token) since t-011.
 
     if (!body.imageData?.trim()) {
       throw createError({

--- a/server/api/comfy/ltx/image2Video.post.ts
+++ b/server/api/comfy/ltx/image2Video.post.ts
@@ -85,33 +85,9 @@ export default defineEventHandler(async (event) => {
       serverId: body.serverId ?? null,
     })
 
-    const authorizationHeader = event.node.req.headers.authorization
-
-    if (!authorizationHeader?.startsWith('Bearer ')) {
-      throw createError({
-        statusCode: 401,
-        message:
-          'Authorization token is required in the format "Bearer <token>".',
-      })
-    }
-
-    const token = authorizationHeader.split(' ')[1] ?? ''
-
-    const user = await prisma.user.findFirst({
-      where: {
-        apiKey: token,
-      },
-      select: {
-        id: true,
-      },
-    })
-
-    if (!user) {
-      throw createError({
-        statusCode: 401,
-        message: 'Invalid or expired authorization token.',
-      })
-    }
+    // t-015: the former inline apiKey-only lookup here was redundant - this
+    // route authenticates via authAndGate (comfyGate) below, which accepts
+    // machine auth (JWT, user apiKey, or beta admin token) since t-011.
 
     const server = await resolveServer({
       userId: gate.user.id,

--- a/server/utils/textGate.ts
+++ b/server/utils/textGate.ts
@@ -1,8 +1,7 @@
 // /server/utils/textGate.ts
 import type { H3Event } from 'h3'
-import { createError } from 'h3'
-import prisma from './prisma'
 import { manaGate } from './manaGate'
+import { requireMachineUser } from './authGuard'
 
 type TextGateInput = {
   model?: string | null
@@ -27,33 +26,10 @@ export async function authAndTextGate(
   event: H3Event,
   input: TextGateInput = {},
 ): Promise<TextGateResult> {
-  const authorizationHeader = event.node.req.headers.authorization
-
-  if (!authorizationHeader?.startsWith('Bearer ')) {
-    throw createError({
-      statusCode: 401,
-      message:
-        'Authorization token is required in the format "Bearer <token>".',
-    })
-  }
-
-  const token = authorizationHeader.split(' ')[1] ?? ''
-
-  const user = await prisma.user.findFirst({
-    where: {
-      apiKey: token,
-    },
-    select: {
-      id: true,
-    },
-  })
-
-  if (!user) {
-    throw createError({
-      statusCode: 401,
-      message: 'Invalid or expired authorization token.',
-    })
-  }
+  // t-015: shared machine auth (session JWT, user apiKey, or beta admin
+  // token) via requireMachineUser, replacing the inline apiKey-only lookup.
+  // Mirrors comfyGate.authAndGate.
+  const { user } = await requireMachineUser(event)
 
   const gate = await manaGate(event, {
     kind: 'text',
@@ -66,7 +42,7 @@ export async function authAndTextGate(
   })
 
   return {
-    user,
+    user: { id: user.id },
     cost: gate.cost,
     free: gate.free,
     commit: gate.commit,


### PR DESCRIPTION
### Task
art-generator-connect/t-015 + t-014 (Silas-directed night session, 2026-07-06). (kind: software)

### What changed / what I produced
**t-015 — machine-auth sweep** (the auth drift class that stranded relay job 1):
- `art/generate`: `getAuthenticatedUser` now takes the event and delegates to `requireMachineUser` (JWT / user apiKey / beta admin token).
- `chats/openai/images/generate`: same swap at the endpoint.
- `textGate.authAndTextGate`: same swap — now mirrors `comfyGate.authAndGate`.
- `comfy/characterSheet`, `comfy/hunyuan3d`, `comfy/ltx/image2Video`: their inline apiKey lookups were **redundant second auths** (each route also gates via `authAndGate`, machine-auth-capable since t-011) — removed rather than replaced.

**t-014 — contract tests**: `server/api/art/queue/queue.http` covering enqueue → list → atomic claim → poll → complete (success + failure), plus negatives (400 no payload, 403 non-admin claim, 409 complete non-RUNNING, 401 unauthenticated). Follows the dreams next-to-endpoint .http convention; force-added past the global `*.http` ignore like the four existing tracked files.

### How I verified
- eslint clean on every touched file (one pre-existing `negativePrompt` unused-var in characterSheet predates this PR — verified against main — and is untouched).
- `tsc --noEmit` (server tsconfig): no errors in any touched file.
- The .http file's expected statuses were written from the queue endpoints' actual code paths.

### Stakes
reversible (auth widening matches the already-merged #90/#96 precedent exactly; .http file is inert documentation/testing)

### Flags for Reviewer
- The three comfy routes previously demanded an apiKey inline AND a JWT via authAndGate on the same header — mutually unsatisfiable before t-011, meaning those routes were likely broken for API callers. Removing the redundant check is strictly a fix, but worth knowing.

### Kaizen suggestion
The negativePrompt unused-var in characterSheet (pre-existing) suggests a quick lint-debt pass over `server/api/comfy/` — one small task.

### Notes for reviewer
Merging on Silas's live direction once CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_017HNj3jchdznYLCk6hrG2zA)_