### PR TITLE
docs: salvage model schema and backend sweep notes

### DIFF
--- a/docs/model-and-channel-patterns.md
+++ b/docs/model-and-channel-patterns.md
@@ -1,0 +1,127 @@
+# Model and channel implementation patterns
+
+Salvaged from stale branch `claude/model-schema-docs-samples-m5d0jq` and rewritten as documentation rather than live sample code.
+
+Use this as a checklist when adding a new content model or user-facing channel. Verify current files before applying; this doc intentionally avoids copying the stale branch's sample route/component implementations.
+
+## Naming contract
+
+Keep these names aligned or routing, stores, and generated UI will drift.
+
+| Thing | Convention | Example |
+| --- | --- | --- |
+| Prisma model | singular PascalCase | `Sample` |
+| API route | lowercase plural | `/api/samples`, `server/api/samples/` |
+| Store | `stores/<x>Store.ts`, `use<X>Store` | `stores/sampleStore.ts`, `useSampleStore` |
+| Components | domain folder, kebab-case filenames | `components/sample/sample-manager.vue` |
+| Content page | route markdown | `content/samples.md` → `/samples` |
+
+Component filenames must remain globally unique because Nuxt component registration can ignore path prefixes. Treat folders as organization, not namespace safety.
+
+## Adding a new model
+
+1. Add the Prisma model block to `prisma/schema.prisma`.
+2. Add required back-relations on `User` and any linked model such as `ArtImage`.
+3. Create an additive migration and generate Prisma types.
+4. Add server routes under `server/api/<plural>/` using the current canonical route patterns.
+5. Add a Pinia store based on the current canonical store pattern.
+6. Add components and a content page only after the data layer is stable.
+7. Add tests for API ownership/auth, batch behavior, and basic store transformations.
+
+Migration rules:
+
+- Additive-only migrations: create tables, add columns, add indexes, add constraints.
+- Never edit, rename, or delete a migration that may already be applied anywhere.
+- Never run `prisma migrate reset` unless Silas explicitly orders it in the current session.
+- Import Prisma client/types from `~/prisma/generated/prisma/client`, not `@prisma/client`.
+
+## Baseline Prisma model shape
+
+For user-generated content models, start with this structure and adjust deliberately:
+
+```prisma
+model Sample {
+  id          Int       @id @default(autoincrement())
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime? @default(now()) @updatedAt
+
+  title       String    @db.VarChar(764)
+  description String?   @db.Text
+  label       String?   @db.VarChar(255)
+
+  isPublic    Boolean   @default(true)
+  isMature    Boolean   @default(false)
+
+  type        String?   @db.VarChar(128)
+  designer    String?   @default("system") @db.VarChar(255)
+
+  userId      Int?
+  User        User?     @relation(fields: [userId], references: [id])
+
+  imageId     Int?      @unique
+  Image       ArtImage? @relation(fields: [imageId], references: [id])
+
+  @@index([userId])
+  @@index([type])
+}
+```
+
+If `User` or `ArtImage` relations are used, remember the back-relation or `prisma validate` will fail.
+
+## API route expectations
+
+New model routes should follow current house patterns rather than copying old samples blindly:
+
+- Use `validateApiKey` or the current auth helper for writes.
+- Derive `userId` from auth unless a trusted server/admin key is explicitly allowed to act on behalf of another user.
+- Enforce ownership checks for user-owned records.
+- Allow admin bypass through the current shared helper, not ad hoc comparisons.
+- Guard update payload fields explicitly; never pass raw `readBody()` straight into `prisma.update`.
+- Return the standard `{ success, message, data, statusCode }` envelope.
+- Use batch result envelopes with `created`, `skipped`, and `failed`; return 207 on partial success when applicable.
+- Make delete behavior explicit. If the route says delete, hard delete unless a product requirement says otherwise.
+
+## Store expectations
+
+Stores should follow the current canonical pattern, not a one-off fetch wrapper:
+
+- Use the shared fetch helper so auth headers, timeout, and circuit breaker behavior are preserved.
+- Merge remote rows by id instead of clobbering local state.
+- Deduplicate concurrent initialization/fetch requests.
+- Expose consistent loading, initialized, and error state.
+- Keep SSR-safe `localStorage` access guarded.
+- Add snapshot fallback only for content that benefits from offline/bootstrap display.
+- Keep transform helpers like `toPayload`, `toForm`, and default form builders close to the store.
+
+## Adding a new channel
+
+The nav system is mostly derived from registries. For a new channel `x` at route `/x` with tabs `t1` and `t2`, verify each of these:
+
+1. `stores/helpers/dashboardHelper.ts` → `dashboardConfigs.footer.tabs[]`: add `key`, `label`, `icon`, `title`, `summary`, `image`, `flourish`, `tagline`, `narrative`, and `route`.
+2. Same file → `dashboardConfigs.x`: define `{ key, label, defaultTab, tabs: [...] }` with one tab entry per tab.
+3. Same file → `footerDashboardMap`: add `x: 'x'`; this should be compile-enforced.
+4. `stores/helpers/tutorialCards.ts` → `tutorialChannels`: add one tutorial section per tab; add the key to `EARNING_CHANNELS` if creators earn from it.
+5. `content/x.md`: add the page with `dashboardKey: x` and `dashboardTab: <defaultTab>`.
+6. Manager component: render tabs from `getDashboardTabs('x')` rather than hard-coding menus.
+7. `components/navigation/channel-select.vue`: update `allChannels[]`; this may fail silently if forgotten.
+
+## Channel image checklist
+
+All paths are under `public/images/` unless the current project has moved to a newer collection pipeline.
+
+| Image | Path |
+| --- | --- |
+| Channel hero | `nav/heroes/{channel}.webp` |
+| Channel card/thumb | `nav/thumbs/{channel}.webp` |
+| Dashboard tab | `dashboard-tabs/{channel}/{tab}.webp` |
+| Tutorial section | `tutorials/{channel}/{tab}.webp` |
+| Tutorial hero | `tutorials/{channel}/hero.webp` |
+
+The channel icon should be an Iconify name such as `kind-icon:*`, not an image file.
+
+## Gotchas
+
+- `performFetch` injects `Content-Type` and bearer authorization automatically; avoid redundant manual headers unless the current helper requires them.
+- Guest/system user id has historically been `10`; verify before hard-coding.
+- `validateApiKey` returns auth kind information such as JWT, admin token, or server key; use it to control allowed impersonation.
+- Mature content should be gated in gallery/list views, usually with `userStore.showMature` plus admin bypass.

--- a/docs/notes/backend-sweep-2026-07-05.md
+++ b/docs/notes/backend-sweep-2026-07-05.md
@@ -1,0 +1,69 @@
+# Backend sweep — stores & endpoints drift audit (2026-07-05)
+
+Salvaged documentation from stale branch `claude/model-schema-docs-samples-m5d0jq`.
+
+This note records a read-only audit of Pinia stores and server API endpoints. Treat the findings as triage leads, not as proof that each issue is still current; verify every listed file against current `main` before fixing.
+
+## Security flags to verify first
+
+The stale branch identified these unauthenticated or under-authorized mutating endpoints as highest priority review targets:
+
+- `server/api/milestones/updateClickRecord.put.ts`
+- `server/api/milestones/updateMatchRecord.put.ts`
+- `server/api/milestones/[id].patch.ts`
+- `server/api/milestones/[id].delete.ts`
+- `server/api/milestones/index.post.ts`
+- `server/api/milestones/records/[id].patch.ts`
+- `server/api/components/[id].delete.ts`
+- `server/api/components/[id].patch.ts`
+- `server/api/components/index.post.ts`
+- `server/api/components/name/[name].patch.ts`
+- `server/api/stripe/checkout.post.ts`
+- `server/api/stripe/subscribe.post.ts`
+- `server/api/art/upload.post.ts`
+- `server/api/bots/seed.post.ts`
+- `server/api/art/sd/setModel.post.ts`
+
+Do not batch-fix these blindly. Verify each route on current `main`, then file or implement scoped security tasks with ownership/auth expectations called out explicitly.
+
+## Other endpoint drift to verify
+
+- Raw `readBody` values passed into Prisma updates can create mass-assignment risk. Verify prompt, icon, reaction, milestone, and component patch routes.
+- Error bodies returned without setting HTTP status can make failures look like HTTP 200. Verify `server/api/logs/[id].delete.ts`.
+- Some reaction patch routes may have double-nested `data` payloads.
+- Some route comments may still reference old paths or old model names.
+- Admin-check style may drift between `Role === 'ADMIN'`, `id === 1`, and `userIsAdmin()`.
+- Response envelope shape may drift across older routes.
+- Batch endpoints may not consistently return `created/skipped/failed` with 207 on partial success.
+
+## Store drift to verify
+
+The stale audit flagged these patterns:
+
+- Fetch paths that overwrite local collections instead of merging by id.
+- Stores that lack request dedupe for `initialize()` or fetch methods.
+- Stores that bypass `performFetch`, losing auth injection, timeout, and circuit-breaker behavior.
+- Stores with no consistent `error` / `setError` / `clearError` shape.
+- Content-heavy stores with no snapshot fallback.
+
+Priority candidates from the stale branch were:
+
+1. `codeStore`
+2. `compositionStore`
+3. `socialStore`
+4. `componentStore`
+5. `dreamStore`
+6. `userStore`
+7. `milestoneStore`
+8. `chatStore`
+9. `sheetStore`
+10. `todoStore`
+11. `serverStore`
+12. `manaStore`
+
+## Suggested salvage path
+
+1. Verify the security endpoints against current `main` first.
+2. Turn confirmed security findings into separate tasks or PRs.
+3. Batch shared store-pattern fixes only when the pattern and tests are current.
+4. Keep this note as triage context; do not treat it as current truth without re-checking.


### PR DESCRIPTION
### Task
Salvage useful documentation from stale branch `claude/model-schema-docs-samples-m5d0jq` without merging stale sample route/component rewrites.

### What changed / what I produced
- Added `docs/notes/backend-sweep-2026-07-05.md` as a triage note, clearly marked as stale-branch context that must be verified against current `main`.
- Added `docs/model-and-channel-patterns.md` with the reusable model/channel checklist, Prisma baseline shape, route expectations, store expectations, and channel image checklist.
- Deliberately did **not** copy `sample/*.ts`, Vue sample text files, Cypress sample rewrites, or any other stale implementation files.

### How I verified
- Fetched both new docs files from `worker/salvage-model-schema-docs` and confirmed they are documentation-only.
- Compared the stale branch earlier and confirmed it was diverged from `main`; this PR avoids those stale code rewrites.

### Stakes
reversible

### Flags for Reviewer
- The backend sweep note contains security-sensitive triage leads, but this PR does not change runtime behavior or claim the findings are still current. It explicitly says to verify against current `main` before fixing.
- I accidentally created then removed a temporary `_tmp_should_not_create.md` file on `main` during tool use. The temp file was removed immediately; this PR does not depend on that mistake.

### Kaizen suggestion
Add a branch-prune checklist for stale Claude/Codex branches: compare against `main`, salvage docs only when useful, then delete the stale branch after the salvage PR merges.