### PR TITLE
fix: update art.cy generate auth contract

### DIFF
--- a/cypress/e2e/api/art.cy.ts
+++ b/cypress/e2e/api/art.cy.ts
@@ -110,13 +110,12 @@ describe('ArtImage Management API Tests', () => {
     deleteTestUser(apiRoot, adminToken, userId)
   })
 
-  it('should not allow generating an ArtImage without a bearer token', () => {
+  it('should not allow generating an ArtImage without machine auth', () => {
     cy.request({
       method: 'POST',
       url: artGenerateUrl,
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
       },
       body: {
         promptString: 'A sunset over the ocean',
@@ -130,7 +129,7 @@ describe('ArtImage Management API Tests', () => {
     }).then((response) => {
       expect(response.status).to.eq(401)
       expect(response.body.success).to.be.false
-      expect(response.body.message).to.match(/authorization|bearer/i)
+      expect(response.body.message).to.match(/authorization|token|auth/i)
     })
   })
 


### PR DESCRIPTION
### What changed
- Updated `cypress/e2e/api/art.cy.ts` so the negative `art/generate` auth test no longer sends `x-api-key`.
- Renamed the test to match the shared auth contract.
- Adjusted the expected auth error wording regex.

### Why
The recent `art/generate` auth sweep made API key auth valid for the endpoint. The old negative test still sent an API key, so it was no longer testing an unauthenticated request.

### Verification
- Compared branch against `main`: one file only, 5 changed lines.
- CI should verify the Cypress spec.