### PR TITLE
Add Comfy direct smoke endpoints

### DIFF
--- a/server/api/comfy/test/generate.post.ts
+++ b/server/api/comfy/test/generate.post.ts
@@ -1,17 +1,23 @@
 // /server/api/comfy/test/generate.post.ts
-import { createError, defineEventHandler, getRequestHeaders, readBody } from 'h3'
-import type { Server } from '~/prisma/generated/prisma/client'
+//
+// Automated smoke test for ComfyUI art generation. Talks to the Comfy server
+// DIRECTLY (via comfyTestClient) with a minimal flux-schnell workflow, so it:
+//   - charges NO mana (does not route through /api/comfy/flux/generate)
+//   - authenticates ONCE (requireMachineUser), no internal self-HTTP hop
+//   - needs NO checkpoint (flux loads a GGUF unet, not an SDXL checkpoint)
+// Safe to run repeatedly / in CI.
+import { createError, defineEventHandler, readBody } from 'h3'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
 import { resolveServer } from '../../../utils/serverResolver'
-import { resolveCheckpointResource } from '../../art/utils/checkpointResource'
+import {
+  assertComfyServer,
+  runComfySmokeGeneration,
+} from '../../../utils/comfyTestClient'
 
 type ComfyDirectGenerateRequest = {
   serverId?: number | null
   serverName?: string | null
-  checkpointId?: number | null
-  checkpointResourceId?: number | null
-  resourceId?: number | null
   prompt?: string | null
   negativePrompt?: string | null
   width?: number | null
@@ -20,46 +26,21 @@ type ComfyDirectGenerateRequest = {
   cfg?: number | null
   guidance?: number | null
   seed?: number | null
-  wildcardSeed?: number | null
   sampler?: string | null
   scheduler?: string | null
   denoise?: number | null
   timeoutMs?: number | null
-  variant?: 'dev' | 'schnell' | null
-}
-
-type ComfyFluxGenerateResponse = {
-  success: boolean
-  message?: string
-  statusCode?: number
-  promptId?: string
-  imageData?: string
-  filename?: string
-  mimeType?: string
-  variant?: string
-  serverId?: number
-  serverName?: string
-  baseUrl?: string
-  mana?: unknown
 }
 
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody<ComfyDirectGenerateRequest>(event)
     const prompt = body.prompt?.trim()
-    const checkpointId = resolveCheckpointId(body)
 
     if (!prompt) {
       throw createError({
         statusCode: 400,
         message: 'Missing required field: "prompt".',
-      })
-    }
-
-    if (!checkpointId) {
-      throw createError({
-        statusCode: 400,
-        message: 'Missing required field: "checkpointId".',
       })
     }
 
@@ -73,53 +54,40 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const checkpoint = await resolveCheckpointResource({
-      requestData: { checkpointResourceId: checkpointId },
+    const result = await runComfySmokeGeneration({
       server,
+      prompt,
+      negativePrompt: body.negativePrompt ?? '',
+      width: body.width ?? 512,
+      height: body.height ?? 512,
+      steps: body.steps ?? 8,
+      cfg: body.cfg ?? 1,
+      guidance: body.guidance ?? 4,
+      seed: body.seed ?? -1,
+      sampler: body.sampler ?? 'euler',
+      scheduler: body.scheduler ?? 'normal',
+      denoise: body.denoise ?? 1,
+      timeoutMs: body.timeoutMs ?? 180_000,
     })
 
-    const response = await $fetch<ComfyFluxGenerateResponse>(
-      '/api/comfy/flux/generate',
-      {
-        method: 'POST',
-        headers: forwardAuthHeaders(getRequestHeaders(event)),
-        body: {
-          variant: body.variant === 'dev' ? 'dev' : 'schnell',
-          serverId: server.id,
-          prompt,
-          negativePrompt: body.negativePrompt ?? '',
-          width: body.width ?? 512,
-          height: body.height ?? 512,
-          steps: body.steps ?? 8,
-          cfg: body.cfg ?? 1,
-          guidance: body.guidance ?? 4,
-          seed: body.seed ?? -1,
-          wildcardSeed: body.wildcardSeed ?? -1,
-          sampler: body.sampler ?? 'euler',
-          scheduler: body.scheduler ?? 'normal',
-          denoise: body.denoise ?? 1,
-          timeoutMs: body.timeoutMs ?? 180_000,
-        },
-      },
-    )
-
-    if (!response.success) {
-      event.node.res.statusCode = response.statusCode || 502
-
-      return {
-        ...response,
-        status: 'error',
-        checkpointId,
-        checkpoint: checkpoint.checkpoint,
-      }
-    }
-
     return {
-      ...response,
-      status: 'done',
-      checkpointId,
-      checkpoint: checkpoint.checkpoint,
-      mimeType: response.imageData?.match(/^data:([^;]+);base64,/)?.[1] ?? null,
+      success: true,
+      message: 'Comfy smoke image generated successfully (no mana charged).',
+      data: {
+        status: 'done',
+        promptId: result.promptId,
+        queuePosition: result.queuePosition,
+        imageData: result.imageData,
+        filename: result.filename,
+        subfolder: result.subfolder,
+        type: result.type,
+        mimeType:
+          result.imageData.match(/^data:([^;]+);base64,/)?.[1] ?? null,
+        serverId: server.id,
+        serverName: server.title,
+        baseUrl: result.baseUrl,
+      },
+      statusCode: 200,
     }
   } catch (error: unknown) {
     const handledError = errorHandler(error)
@@ -127,70 +95,8 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: false,
-      status: 'error',
       statusCode: handledError.statusCode || 500,
       message: handledError.message || 'Failed to generate Comfy test image.',
     }
   }
 })
-
-function resolveCheckpointId(body: ComfyDirectGenerateRequest): number | null {
-  return (
-    normalizeId(body.checkpointId) ??
-    normalizeId(body.checkpointResourceId) ??
-    normalizeId(body.resourceId)
-  )
-}
-
-function normalizeId(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
-    return value
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number(value)
-    if (Number.isInteger(parsed) && parsed > 0) return parsed
-  }
-
-  return null
-}
-
-function assertComfyServer(server: Server): void {
-  if (!server.isActive) {
-    throw createError({
-      statusCode: 400,
-      message: `Server "${server.title}" is not active.`,
-    })
-  }
-
-  if (server.serverType !== 'COMFY') {
-    throw createError({
-      statusCode: 400,
-      message: `Server "${server.title}" is ${server.serverType}. This route only supports Comfy servers.`,
-    })
-  }
-}
-
-function forwardAuthHeaders(
-  headers: ReturnType<typeof getRequestHeaders>,
-): HeadersInit {
-  const forwardedHeaders: Record<string, string> = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  }
-
-  for (const key of [
-    'authorization',
-    'x-beta-admin-token',
-    'x-admin-token',
-    'x-api-key',
-  ]) {
-    const value = headers[key]
-
-    if (typeof value === 'string' && value.trim()) {
-      forwardedHeaders[key] = value
-    }
-  }
-
-  return forwardedHeaders
-}

--- a/server/api/comfy/test/generate.post.ts
+++ b/server/api/comfy/test/generate.post.ts
@@ -1,0 +1,196 @@
+// /server/api/comfy/test/generate.post.ts
+import { createError, defineEventHandler, getRequestHeaders, readBody } from 'h3'
+import type { Server } from '~/prisma/generated/prisma/client'
+import { errorHandler } from '../../../utils/error'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { resolveServer } from '../../../utils/serverResolver'
+import { resolveCheckpointResource } from '../../art/utils/checkpointResource'
+
+type ComfyDirectGenerateRequest = {
+  serverId?: number | null
+  serverName?: string | null
+  checkpointId?: number | null
+  checkpointResourceId?: number | null
+  resourceId?: number | null
+  prompt?: string | null
+  negativePrompt?: string | null
+  width?: number | null
+  height?: number | null
+  steps?: number | null
+  cfg?: number | null
+  guidance?: number | null
+  seed?: number | null
+  wildcardSeed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  denoise?: number | null
+  timeoutMs?: number | null
+  variant?: 'dev' | 'schnell' | null
+}
+
+type ComfyFluxGenerateResponse = {
+  success: boolean
+  message?: string
+  statusCode?: number
+  promptId?: string
+  imageData?: string
+  filename?: string
+  mimeType?: string
+  variant?: string
+  serverId?: number
+  serverName?: string
+  baseUrl?: string
+  mana?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody<ComfyDirectGenerateRequest>(event)
+    const prompt = body.prompt?.trim()
+    const checkpointId = resolveCheckpointId(body)
+
+    if (!prompt) {
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required field: "prompt".',
+      })
+    }
+
+    if (!checkpointId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required field: "checkpointId".',
+      })
+    }
+
+    const auth = await requireMachineUser(event)
+    const server = await resolveServer({
+      userId: auth.user.id,
+      serverId: body.serverId ?? null,
+      serverName: body.serverName ?? null,
+      capability: 'comfy',
+    })
+
+    assertComfyServer(server)
+
+    const checkpoint = await resolveCheckpointResource({
+      requestData: { checkpointResourceId: checkpointId },
+      server,
+    })
+
+    const response = await $fetch<ComfyFluxGenerateResponse>(
+      '/api/comfy/flux/generate',
+      {
+        method: 'POST',
+        headers: forwardAuthHeaders(getRequestHeaders(event)),
+        body: {
+          variant: body.variant === 'dev' ? 'dev' : 'schnell',
+          serverId: server.id,
+          prompt,
+          negativePrompt: body.negativePrompt ?? '',
+          width: body.width ?? 512,
+          height: body.height ?? 512,
+          steps: body.steps ?? 8,
+          cfg: body.cfg ?? 1,
+          guidance: body.guidance ?? 4,
+          seed: body.seed ?? -1,
+          wildcardSeed: body.wildcardSeed ?? -1,
+          sampler: body.sampler ?? 'euler',
+          scheduler: body.scheduler ?? 'normal',
+          denoise: body.denoise ?? 1,
+          timeoutMs: body.timeoutMs ?? 180_000,
+        },
+      },
+    )
+
+    if (!response.success) {
+      event.node.res.statusCode = response.statusCode || 502
+
+      return {
+        ...response,
+        status: 'error',
+        checkpointId,
+        checkpoint: checkpoint.checkpoint,
+      }
+    }
+
+    return {
+      ...response,
+      status: 'done',
+      checkpointId,
+      checkpoint: checkpoint.checkpoint,
+      mimeType: response.imageData?.match(/^data:([^;]+);base64,/)?.[1] ?? null,
+    }
+  } catch (error: unknown) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+
+    return {
+      success: false,
+      status: 'error',
+      statusCode: handledError.statusCode || 500,
+      message: handledError.message || 'Failed to generate Comfy test image.',
+    }
+  }
+})
+
+function resolveCheckpointId(body: ComfyDirectGenerateRequest): number | null {
+  return (
+    normalizeId(body.checkpointId) ??
+    normalizeId(body.checkpointResourceId) ??
+    normalizeId(body.resourceId)
+  )
+}
+
+function normalizeId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+
+  return null
+}
+
+function assertComfyServer(server: Server): void {
+  if (!server.isActive) {
+    throw createError({
+      statusCode: 400,
+      message: `Server "${server.title}" is not active.`,
+    })
+  }
+
+  if (server.serverType !== 'COMFY') {
+    throw createError({
+      statusCode: 400,
+      message: `Server "${server.title}" is ${server.serverType}. This route only supports Comfy servers.`,
+    })
+  }
+}
+
+function forwardAuthHeaders(
+  headers: ReturnType<typeof getRequestHeaders>,
+): HeadersInit {
+  const forwardedHeaders: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  }
+
+  for (const key of [
+    'authorization',
+    'x-beta-admin-token',
+    'x-admin-token',
+    'x-api-key',
+  ]) {
+    const value = headers[key]
+
+    if (typeof value === 'string' && value.trim()) {
+      forwardedHeaders[key] = value
+    }
+  }
+
+  return forwardedHeaders
+}

--- a/server/api/comfy/test/info.get.ts
+++ b/server/api/comfy/test/info.get.ts
@@ -1,17 +1,24 @@
 // /server/api/comfy/test/info.get.ts
+//
+// Smoke probe of a Comfy server's own HTTP API (system_stats / queue).
+// Auth once via requireMachineUser; no checkpoint (flux uses no checkpoint,
+// and probing server info never needed one). Shares the Comfy client helpers
+// with the generate smoke route.
 import { createError, defineEventHandler, getQuery } from 'h3'
-import type { Server } from '~/prisma/generated/prisma/client'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
-import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
-import { resolveCheckpointResource } from '../../art/utils/checkpointResource'
+import { resolveServer } from '../../../utils/serverResolver'
+import {
+  assertComfyServer,
+  fetchComfyInfo,
+  getComfyBaseUrl,
+} from '../../../utils/comfyTestClient'
 
 type ComfyInfoTarget = 'system' | 'queue'
 
 type ComfyInfoQuery = {
   serverId?: string
   serverName?: string
-  checkpointId?: string
   target?: string
 }
 
@@ -20,7 +27,6 @@ export default defineEventHandler(async (event) => {
     const query = getQuery(event) as ComfyInfoQuery
     const auth = await requireMachineUser(event)
     const serverId = normalizeId(query.serverId)
-    const checkpointId = normalizeId(query.checkpointId)
     const target = normalizeTarget(query.target)
 
     const server = await resolveServer({
@@ -32,13 +38,6 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    if (checkpointId) {
-      await resolveCheckpointResource({
-        requestData: { checkpointResourceId: checkpointId },
-        server,
-      })
-    }
-
     const baseUrl = getComfyBaseUrl(server)
     const data = await fetchComfyInfo(baseUrl, target)
 
@@ -47,10 +46,10 @@ export default defineEventHandler(async (event) => {
       message: `Comfy ${target} info fetched successfully.`,
       data,
       target,
-      checkpointId,
       serverId: server.id,
       serverName: server.title,
       baseUrl,
+      statusCode: 200,
     }
   } catch (error: unknown) {
     const handledError = errorHandler(error)
@@ -84,108 +83,4 @@ function normalizeId(value: unknown): number | null {
   }
 
   return null
-}
-
-function assertComfyServer(server: Server): void {
-  if (!server.isActive) {
-    throw createError({
-      statusCode: 400,
-      message: `Server "${server.title}" is not active.`,
-    })
-  }
-
-  if (server.serverType !== 'COMFY') {
-    throw createError({
-      statusCode: 400,
-      message: `Server "${server.title}" is ${server.serverType}. This route only supports Comfy servers.`,
-    })
-  }
-}
-
-function getComfyBaseUrl(server: Server): string {
-  const endpoint = getServerEndpoint(server)
-  const trimmed = endpoint.replace(/\/+$/, '')
-
-  if (trimmed.endsWith('/prompt')) {
-    return trimmed.replace(/\/prompt$/, '')
-  }
-
-  if (trimmed.endsWith('/api/prompt')) {
-    return trimmed.replace(/\/api\/prompt$/, '')
-  }
-
-  return trimmed
-}
-
-async function fetchComfyInfo(
-  baseUrl: string,
-  target: ComfyInfoTarget,
-): Promise<unknown> {
-  const path = target === 'system' ? 'system_stats' : 'queue'
-  const response = await fetch(`${baseUrl}/${path}`, {
-    method: 'GET',
-    headers: getComfyHeaders(),
-  })
-
-  if (!response.ok) {
-    const details = await readResponseDetails(response)
-
-    throw createError({
-      statusCode: 502,
-      message: `Comfy ${target} info failed: ${response.status} ${
-        response.statusText
-      }${details ? ` - ${details}` : ''}`,
-    })
-  }
-
-  return await response.json()
-}
-
-function getComfyHeaders(): HeadersInit {
-  const headers: Record<string, string> = {
-    Accept: 'application/json, image/*, */*',
-  }
-
-  const token = process.env.ART_SERVER_PROXY_TOKEN || ''
-
-  if (token) {
-    headers['X-Kindrobots-Server-Token'] = token
-  }
-
-  return headers
-}
-
-async function readResponseDetails(response: Response): Promise<string> {
-  try {
-    const contentType = response.headers.get('content-type') || ''
-
-    if (contentType.includes('application/json')) {
-      return stringifyServerError(await response.json())
-    }
-
-    return await response.text()
-  } catch {
-    return response.statusText
-  }
-}
-
-function stringifyServerError(errorData: unknown): string {
-  if (!errorData) return ''
-
-  if (typeof errorData === 'string') return errorData
-
-  if (typeof errorData === 'object') {
-    const data = errorData as Record<string, unknown>
-    const message = data.message
-    const error = data.error
-    const detail = data.detail
-
-    if (typeof error === 'string') return error
-    if (typeof message === 'string') return message
-    if (typeof detail === 'string') return detail
-
-    return JSON.stringify(data)
-  }
-
-  return String(errorData)
 }

--- a/server/api/comfy/test/info.get.ts
+++ b/server/api/comfy/test/info.get.ts
@@ -1,0 +1,191 @@
+// /server/api/comfy/test/info.get.ts
+import { createError, defineEventHandler, getQuery } from 'h3'
+import type { Server } from '~/prisma/generated/prisma/client'
+import { errorHandler } from '../../../utils/error'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
+import { resolveCheckpointResource } from '../../art/utils/checkpointResource'
+
+type ComfyInfoTarget = 'system' | 'queue'
+
+type ComfyInfoQuery = {
+  serverId?: string
+  serverName?: string
+  checkpointId?: string
+  target?: string
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery(event) as ComfyInfoQuery
+    const auth = await requireMachineUser(event)
+    const serverId = normalizeId(query.serverId)
+    const checkpointId = normalizeId(query.checkpointId)
+    const target = normalizeTarget(query.target)
+
+    const server = await resolveServer({
+      userId: auth.user.id,
+      serverId,
+      serverName: query.serverName ?? null,
+      capability: 'comfy',
+    })
+
+    assertComfyServer(server)
+
+    if (checkpointId) {
+      await resolveCheckpointResource({
+        requestData: { checkpointResourceId: checkpointId },
+        server,
+      })
+    }
+
+    const baseUrl = getComfyBaseUrl(server)
+    const data = await fetchComfyInfo(baseUrl, target)
+
+    return {
+      success: true,
+      message: `Comfy ${target} info fetched successfully.`,
+      data,
+      target,
+      checkpointId,
+      serverId: server.id,
+      serverName: server.title,
+      baseUrl,
+    }
+  } catch (error: unknown) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+
+    return {
+      success: false,
+      statusCode: handledError.statusCode || 500,
+      message: handledError.message || 'Failed to fetch Comfy test info.',
+    }
+  }
+})
+
+function normalizeTarget(target?: string | null): ComfyInfoTarget {
+  if (target === 'queue' || target === 'system') return target
+
+  throw createError({
+    statusCode: 400,
+    message: 'Invalid target. Use "system" or "queue".',
+  })
+}
+
+function normalizeId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+
+  return null
+}
+
+function assertComfyServer(server: Server): void {
+  if (!server.isActive) {
+    throw createError({
+      statusCode: 400,
+      message: `Server "${server.title}" is not active.`,
+    })
+  }
+
+  if (server.serverType !== 'COMFY') {
+    throw createError({
+      statusCode: 400,
+      message: `Server "${server.title}" is ${server.serverType}. This route only supports Comfy servers.`,
+    })
+  }
+}
+
+function getComfyBaseUrl(server: Server): string {
+  const endpoint = getServerEndpoint(server)
+  const trimmed = endpoint.replace(/\/+$/, '')
+
+  if (trimmed.endsWith('/prompt')) {
+    return trimmed.replace(/\/prompt$/, '')
+  }
+
+  if (trimmed.endsWith('/api/prompt')) {
+    return trimmed.replace(/\/api\/prompt$/, '')
+  }
+
+  return trimmed
+}
+
+async function fetchComfyInfo(
+  baseUrl: string,
+  target: ComfyInfoTarget,
+): Promise<unknown> {
+  const path = target === 'system' ? 'system_stats' : 'queue'
+  const response = await fetch(`${baseUrl}/${path}`, {
+    method: 'GET',
+    headers: getComfyHeaders(),
+  })
+
+  if (!response.ok) {
+    const details = await readResponseDetails(response)
+
+    throw createError({
+      statusCode: 502,
+      message: `Comfy ${target} info failed: ${response.status} ${
+        response.statusText
+      }${details ? ` - ${details}` : ''}`,
+    })
+  }
+
+  return await response.json()
+}
+
+function getComfyHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, image/*, */*',
+  }
+
+  const token = process.env.ART_SERVER_PROXY_TOKEN || ''
+
+  if (token) {
+    headers['X-Kindrobots-Server-Token'] = token
+  }
+
+  return headers
+}
+
+async function readResponseDetails(response: Response): Promise<string> {
+  try {
+    const contentType = response.headers.get('content-type') || ''
+
+    if (contentType.includes('application/json')) {
+      return stringifyServerError(await response.json())
+    }
+
+    return await response.text()
+  } catch {
+    return response.statusText
+  }
+}
+
+function stringifyServerError(errorData: unknown): string {
+  if (!errorData) return ''
+
+  if (typeof errorData === 'string') return errorData
+
+  if (typeof errorData === 'object') {
+    const data = errorData as Record<string, unknown>
+    const message = data.message
+    const error = data.error
+    const detail = data.detail
+
+    if (typeof error === 'string') return error
+    if (typeof message === 'string') return message
+    if (typeof detail === 'string') return detail
+
+    return JSON.stringify(data)
+  }
+
+  return String(errorData)
+}

--- a/server/utils/comfyTestClient.ts
+++ b/server/utils/comfyTestClient.ts
@@ -1,0 +1,478 @@
+// /server/utils/comfyTestClient.ts
+//
+// Direct ComfyUI client for the automated smoke test (server/api/comfy/test/*).
+//
+// Why this exists separately from flux/generate.post.ts: the smoke test must be
+// safe to run repeatedly (CI) WITHOUT charging mana and WITHOUT double-auth over
+// an internal HTTP hop. So instead of forwarding to /api/comfy/flux/generate
+// (which runs authAndGate -> manaGate and costs currency), the smoke endpoint
+// talks to the Comfy server directly with a minimal, known-good flux-schnell
+// workflow. The call sequence (POST /prompt -> poll /history -> GET /view) and
+// the workflow shape mirror flux/generate.post.ts exactly; this module is kept
+// standalone so the production route stays untouched.
+import { createError } from 'h3'
+import type { Server } from '~/prisma/generated/prisma/client'
+import { getServerEndpoint } from './serverResolver'
+
+export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
+
+type ComfyWorkflowNode = {
+  class_type?: string
+  inputs?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+type ComfyPromptResponse = {
+  prompt_id?: string
+  number?: number
+  node_errors?: unknown
+}
+
+type ComfyHistoryResponse = Record<string, ComfyHistoryEntry>
+
+type ComfyHistoryEntry = {
+  outputs?: Record<string, ComfyOutputNode>
+  status?: {
+    status_str?: string
+    completed?: boolean
+    messages?: unknown[]
+  }
+}
+
+type ComfyOutputNode = {
+  images?: ComfyImageOutput[]
+  gifs?: ComfyImageOutput[]
+}
+
+type ComfyImageOutput = {
+  filename?: string
+  subfolder?: string
+  type?: string
+}
+
+export type ComfySmokeResult = {
+  promptId: string
+  queuePosition: number | null
+  imageData: string
+  filename: string
+  subfolder: string
+  type: string
+  baseUrl: string
+}
+
+// flux schnell: fast (8 steps), no checkpoint — it loads a GGUF unet, not an
+// SDXL checkpoint. This is the smoke default and keeps runs cheap.
+const SMOKE_UNET_NAME = 'flux1-schnell-Q8_0.gguf'
+const SMOKE_FILENAME_PREFIX = 'kindrobots_comfy_smoke'
+const DEFAULT_TIMEOUT_MS = 180_000
+const POLL_INTERVAL_MS = 1_500
+
+export function assertComfyServer(server: Server): void {
+  if (!server.isActive) {
+    throw createError({
+      statusCode: 400,
+      message: `Server "${server.title}" is not active.`,
+    })
+  }
+
+  if (server.serverType !== 'COMFY') {
+    throw createError({
+      statusCode: 400,
+      message: `Server "${server.title}" is ${server.serverType}. This route only supports Comfy servers.`,
+    })
+  }
+}
+
+export function getComfyBaseUrl(server: Server): string {
+  const endpoint = getServerEndpoint(server)
+  const trimmed = endpoint.replace(/\/+$/, '')
+
+  if (trimmed.endsWith('/prompt')) {
+    return trimmed.replace(/\/prompt$/, '')
+  }
+
+  if (trimmed.endsWith('/api/prompt')) {
+    return trimmed.replace(/\/api\/prompt$/, '')
+  }
+
+  return trimmed
+}
+
+export function getComfyHeaders(includeJson = true): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, image/*, */*',
+  }
+
+  const token = process.env.ART_SERVER_PROXY_TOKEN || ''
+
+  if (token) {
+    headers['X-Kindrobots-Server-Token'] = token
+  }
+
+  if (includeJson) {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  return headers
+}
+
+/**
+ * Fetch a Comfy info endpoint (system_stats or queue) and return parsed JSON.
+ * Shared by the smoke info route.
+ */
+export async function fetchComfyInfo(
+  baseUrl: string,
+  target: 'system' | 'queue',
+): Promise<unknown> {
+  const path = target === 'system' ? 'system_stats' : 'queue'
+  const response = await fetch(`${baseUrl}/${path}`, {
+    method: 'GET',
+    headers: getComfyHeaders(false),
+  })
+
+  if (!response.ok) {
+    const details = await readResponseDetails(response)
+    throw createError({
+      statusCode: 502,
+      message: `Comfy ${target} info failed: ${response.status} ${response.statusText}${
+        details ? ` - ${details}` : ''
+      }`,
+    })
+  }
+
+  return await response.json()
+}
+
+/**
+ * Run one flux-schnell generation directly against the Comfy server. No mana,
+ * no internal HTTP hop. Returns the image as a data URL plus metadata.
+ */
+export async function runComfySmokeGeneration(input: {
+  server: Server
+  prompt: string
+  negativePrompt?: string
+  width?: number
+  height?: number
+  steps?: number
+  cfg?: number
+  guidance?: number
+  seed?: number
+  sampler?: string
+  scheduler?: string
+  denoise?: number
+  timeoutMs?: number
+}): Promise<ComfySmokeResult> {
+  const baseUrl = getComfyBaseUrl(input.server)
+  const workflow = buildSchnellSmokeWorkflow({
+    prompt: input.prompt,
+    negativePrompt: input.negativePrompt ?? '',
+    width: input.width ?? 512,
+    height: input.height ?? 512,
+    steps: input.steps ?? 8,
+    cfg: input.cfg ?? 1,
+    guidance: input.guidance ?? 4,
+    seed: input.seed ?? -1,
+    sampler: input.sampler ?? 'euler',
+    scheduler: input.scheduler ?? 'normal',
+    denoise: input.denoise ?? 1,
+  })
+
+  const clientId = crypto.randomUUID()
+  const promptResponse = await postComfyPrompt(baseUrl, workflow, clientId)
+
+  if (!promptResponse.prompt_id) {
+    throw createError({
+      statusCode: 502,
+      message: `Comfy did not return a prompt_id.${
+        promptResponse.node_errors
+          ? ` Node errors: ${stringifyServerError(promptResponse.node_errors)}`
+          : ''
+      }`,
+    })
+  }
+
+  const historyEntry = await waitForComfyHistory({
+    baseUrl,
+    promptId: promptResponse.prompt_id,
+    timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  })
+
+  const imageOutput = getFirstComfyImage(historyEntry)
+
+  if (!imageOutput?.filename) {
+    throw createError({
+      statusCode: 502,
+      message: 'Comfy completed but returned no image output.',
+    })
+  }
+
+  const imageData = await fetchComfyImageAsDataUrl(baseUrl, imageOutput)
+
+  return {
+    promptId: promptResponse.prompt_id,
+    queuePosition: promptResponse.number ?? null,
+    imageData,
+    filename: imageOutput.filename,
+    subfolder: imageOutput.subfolder ?? '',
+    type: imageOutput.type ?? 'output',
+    baseUrl,
+  }
+}
+
+function buildSchnellSmokeWorkflow(input: {
+  prompt: string
+  negativePrompt: string
+  width: number
+  height: number
+  steps: number
+  cfg: number
+  guidance: number
+  seed: number
+  sampler: string
+  scheduler: string
+  denoise: number
+}): ComfyWorkflow {
+  const samplerSeed = resolveSeed(input.seed)
+  const wildcardSeed = resolveSeed(-1)
+  const prompt = input.prompt.trim() || 'a friendly test robot, clean concept art'
+
+  return {
+    '4': {
+      inputs: {
+        clip_name1: 'umt5_xxl_fp8_e4m3fn_scaled.safetensors',
+        clip_name2: 'clip_l.safetensors',
+        type: 'flux',
+        device: 'default',
+      },
+      class_type: 'DualCLIPLoader',
+      _meta: { title: 'DualCLIPLoader' },
+    },
+    '6': {
+      inputs: { width: input.width, height: input.height, batch_size: 1 },
+      class_type: 'EmptyLatentImage',
+      _meta: { title: 'Empty Latent Image' },
+    },
+    '7': {
+      inputs: { samples: ['52', 0], vae: ['8', 0] },
+      class_type: 'VAEDecode',
+      _meta: { title: 'VAE Decode' },
+    },
+    '8': {
+      inputs: { vae_name: 'ae.safetensors' },
+      class_type: 'VAELoader',
+      _meta: { title: 'Load VAE' },
+    },
+    '24': {
+      inputs: { unet_name: SMOKE_UNET_NAME },
+      class_type: 'UnetLoaderGGUF',
+      _meta: { title: 'Unet Loader (GGUF)' },
+    },
+    '46': {
+      inputs: { guidance: input.guidance, conditioning: ['59', 2] },
+      class_type: 'FluxGuidance',
+      _meta: { title: 'FluxGuidance' },
+    },
+    '52': {
+      inputs: {
+        seed: samplerSeed,
+        steps: input.steps,
+        cfg: input.cfg,
+        sampler_name: input.sampler,
+        scheduler: input.scheduler,
+        denoise: input.denoise,
+        model: ['59', 0],
+        positive: ['46', 0],
+        negative: ['46', 0],
+        latent_image: ['6', 0],
+      },
+      class_type: 'KSampler',
+      _meta: { title: 'KSampler' },
+    },
+    '57': {
+      inputs: { filename_prefix: SMOKE_FILENAME_PREFIX, images: ['7', 0] },
+      class_type: 'SaveImage',
+      _meta: { title: 'Save Image' },
+    },
+    '59': {
+      inputs: {
+        wildcard_text: prompt,
+        populated_text: prompt,
+        mode: 'populate',
+        'Select to add LoRA': 'Select the LoRA to add to the text',
+        'Select to add Wildcard': 'Select the Wildcard to add to the text',
+        seed: wildcardSeed,
+        model: ['24', 0],
+        clip: ['4', 0],
+      },
+      class_type: 'ImpactWildcardEncode',
+      _meta: { title: 'ImpactWildcardEncode' },
+    },
+  }
+}
+
+async function postComfyPrompt(
+  baseUrl: string,
+  workflow: ComfyWorkflow,
+  clientId: string,
+): Promise<ComfyPromptResponse> {
+  const response = await fetch(`${baseUrl}/prompt`, {
+    method: 'POST',
+    headers: getComfyHeaders(),
+    body: JSON.stringify({ prompt: workflow, client_id: clientId }),
+  })
+
+  if (!response.ok) {
+    const details = await readResponseDetails(response)
+    throw createError({
+      statusCode: 502,
+      message: `Comfy prompt failed: ${response.status} ${response.statusText}${
+        details ? ` - ${details}` : ''
+      }`,
+    })
+  }
+
+  return await response.json()
+}
+
+async function waitForComfyHistory(input: {
+  baseUrl: string
+  promptId: string
+  timeoutMs: number
+}): Promise<ComfyHistoryEntry> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < input.timeoutMs) {
+    const response = await fetch(`${input.baseUrl}/history/${input.promptId}`, {
+      method: 'GET',
+      headers: getComfyHeaders(),
+    })
+
+    if (!response.ok) {
+      const details = await readResponseDetails(response)
+      throw createError({
+        statusCode: 502,
+        message: `Comfy history failed: ${response.status} ${response.statusText}${
+          details ? ` - ${details}` : ''
+        }`,
+      })
+    }
+
+    const history = (await response.json()) as ComfyHistoryResponse
+    const entry = history[input.promptId]
+
+    if (entry?.outputs && Object.keys(entry.outputs).length) {
+      return entry
+    }
+
+    if (entry?.status?.status_str === 'error') {
+      throw createError({
+        statusCode: 502,
+        message: `Comfy workflow failed: ${stringifyServerError(entry)}`,
+      })
+    }
+
+    await sleep(POLL_INTERVAL_MS)
+  }
+
+  throw createError({
+    statusCode: 504,
+    message: `Comfy generation timed out after ${input.timeoutMs}ms.`,
+  })
+}
+
+function getFirstComfyImage(
+  historyEntry: ComfyHistoryEntry,
+): ComfyImageOutput | null {
+  const outputs = Object.values(historyEntry.outputs || {})
+
+  for (const output of outputs) {
+    const image = output.images?.find((entry) => entry.filename)
+    if (image) return image
+  }
+
+  for (const output of outputs) {
+    const gif = output.gifs?.find((entry) => entry.filename)
+    if (gif) return gif
+  }
+
+  return null
+}
+
+async function fetchComfyImageAsDataUrl(
+  baseUrl: string,
+  image: ComfyImageOutput,
+): Promise<string> {
+  const params = new URLSearchParams({
+    filename: image.filename || '',
+    subfolder: image.subfolder || '',
+    type: image.type || 'output',
+  })
+
+  const response = await fetch(`${baseUrl}/view?${params.toString()}`, {
+    method: 'GET',
+    headers: getComfyHeaders(false),
+  })
+
+  if (!response.ok) {
+    const details = await readResponseDetails(response)
+    throw createError({
+      statusCode: 502,
+      message: `Comfy image fetch failed: ${response.status} ${response.statusText}${
+        details ? ` - ${details}` : ''
+      }`,
+    })
+  }
+
+  const contentType = response.headers.get('content-type') || 'image/png'
+  const arrayBuffer = await response.arrayBuffer()
+  const base64 = Buffer.from(arrayBuffer).toString('base64')
+
+  return `data:${contentType};base64,${base64}`
+}
+
+async function readResponseDetails(response: Response): Promise<string> {
+  try {
+    const contentType = response.headers.get('content-type') || ''
+
+    if (contentType.includes('application/json')) {
+      return stringifyServerError(await response.json())
+    }
+
+    return await response.text()
+  } catch {
+    return response.statusText
+  }
+}
+
+function resolveSeed(seed?: number | null): number {
+  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
+    return Math.floor(seed)
+  }
+
+  return Math.floor(Math.random() * 1_000_000_000_000_000)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function stringifyServerError(errorData: unknown): string {
+  if (!errorData) return ''
+
+  if (typeof errorData === 'string') return errorData
+
+  if (typeof errorData === 'object') {
+    const data = errorData as Record<string, unknown>
+    const message = data.message
+    const error = data.error
+    const detail = data.detail
+
+    if (typeof error === 'string') return error
+    if (typeof message === 'string') return message
+    if (typeof detail === 'string') return detail
+
+    return JSON.stringify(data)
+  }
+
+  return String(errorData)
+}

--- a/utils/scripts/test-comfy-direct.mjs
+++ b/utils/scripts/test-comfy-direct.mjs
@@ -1,17 +1,34 @@
 // /utils/scripts/test-comfy-direct.mjs
+//
+// Automated smoke test for ComfyUI art generation. Calls the two test
+// endpoints in sequence: info (system_stats + queue) then a direct generate.
+// No mana is charged and no checkpoint is needed (flux loads a GGUF unet).
+//
+// Env:
+//   COMFY_TEST_AUTH_TOKEN   required — machine auth (user apiKey or admin token)
+//   COMFY_TEST_SERVER_ID    optional — target a specific Comfy server by id;
+//                           if unset, the server is resolved by capability
+//   COMFY_TEST_API_BASE     optional — default https://kind-robots.vercel.app
 
 const apiBase = (process.env.COMFY_TEST_API_BASE || 'https://kind-robots.vercel.app').replace(/\/+$/, '')
 const authToken = process.env.COMFY_TEST_AUTH_TOKEN || ''
-const serverId = Number(process.env.COMFY_TEST_SERVER_ID || 25)
-const checkpointId = Number(process.env.COMFY_TEST_CHECKPOINT_ID || 0)
+const serverIdRaw = process.env.COMFY_TEST_SERVER_ID
 
 if (!authToken) {
   throw new Error('Missing COMFY_TEST_AUTH_TOKEN')
 }
 
-if (!serverId || !checkpointId) {
-  throw new Error('Missing COMFY_TEST_SERVER_ID or COMFY_TEST_CHECKPOINT_ID')
+// Server id is optional: when unset, the API resolves a comfy server by
+// capability. When set, it must be a positive integer (no invented defaults).
+let serverId = null
+if (serverIdRaw !== undefined && serverIdRaw !== '') {
+  serverId = Number(serverIdRaw)
+  if (!Number.isInteger(serverId) || serverId <= 0) {
+    throw new Error(`COMFY_TEST_SERVER_ID must be a positive integer, got "${serverIdRaw}"`)
+  }
 }
+
+const serverQuery = serverId ? `&serverId=${serverId}` : ''
 
 const headers = {
   Authorization: `Bearer ${authToken}`,
@@ -39,17 +56,16 @@ async function request(path, options = {}) {
   return body
 }
 
-const system = await request(`/api/comfy/test/info?serverId=${serverId}&target=system`)
+const system = await request(`/api/comfy/test/info?target=system${serverQuery}`)
 console.log('system ok', { serverId: system.serverId, serverName: system.serverName })
 
-const queue = await request(`/api/comfy/test/info?serverId=${serverId}&checkpointId=${checkpointId}&target=queue`)
-console.log('queue ok', { checkpointId: queue.checkpointId })
+const queue = await request(`/api/comfy/test/info?target=queue${serverQuery}`)
+console.log('queue ok', { serverId: queue.serverId, serverName: queue.serverName })
 
 const generated = await request('/api/comfy/test/generate', {
   method: 'POST',
   body: JSON.stringify({
-    serverId,
-    checkpointId,
+    ...(serverId ? { serverId } : {}),
     prompt: 'friendly robot painter in a bright futuristic studio, colorful polished concept art, crisp details, clean composition',
     width: 512,
     height: 512,
@@ -57,13 +73,13 @@ const generated = await request('/api/comfy/test/generate', {
     cfg: 1,
     guidance: 4,
     timeoutMs: 180000,
-    variant: 'schnell',
   }),
 })
 
+const data = generated.data || {}
 console.log('generate ok', {
-  promptId: generated.promptId,
-  filename: generated.filename,
-  mimeType: generated.mimeType,
-  imageDataPrefix: generated.imageData?.slice(0, 32),
+  promptId: data.promptId,
+  filename: data.filename,
+  mimeType: data.mimeType,
+  imageDataPrefix: data.imageData?.slice(0, 32),
 })

--- a/utils/scripts/test-comfy-direct.mjs
+++ b/utils/scripts/test-comfy-direct.mjs
@@ -1,0 +1,69 @@
+// /utils/scripts/test-comfy-direct.mjs
+
+const apiBase = (process.env.COMFY_TEST_API_BASE || 'https://kind-robots.vercel.app').replace(/\/+$/, '')
+const authToken = process.env.COMFY_TEST_AUTH_TOKEN || ''
+const serverId = Number(process.env.COMFY_TEST_SERVER_ID || 25)
+const checkpointId = Number(process.env.COMFY_TEST_CHECKPOINT_ID || 0)
+
+if (!authToken) {
+  throw new Error('Missing COMFY_TEST_AUTH_TOKEN')
+}
+
+if (!serverId || !checkpointId) {
+  throw new Error('Missing COMFY_TEST_SERVER_ID or COMFY_TEST_CHECKPOINT_ID')
+}
+
+const headers = {
+  Authorization: `Bearer ${authToken}`,
+}
+
+const jsonHeaders = {
+  ...headers,
+  'Content-Type': 'application/json',
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${apiBase}${path}`, {
+    ...options,
+    headers: {
+      ...(options.body ? jsonHeaders : headers),
+      ...(options.headers || {}),
+    },
+  })
+  const body = await response.json().catch(() => null)
+
+  if (!response.ok || body?.success === false) {
+    throw new Error(`${path} failed: ${response.status} ${JSON.stringify(body)}`)
+  }
+
+  return body
+}
+
+const system = await request(`/api/comfy/test/info?serverId=${serverId}&target=system`)
+console.log('system ok', { serverId: system.serverId, serverName: system.serverName })
+
+const queue = await request(`/api/comfy/test/info?serverId=${serverId}&checkpointId=${checkpointId}&target=queue`)
+console.log('queue ok', { checkpointId: queue.checkpointId })
+
+const generated = await request('/api/comfy/test/generate', {
+  method: 'POST',
+  body: JSON.stringify({
+    serverId,
+    checkpointId,
+    prompt: 'friendly robot painter in a bright futuristic studio, colorful polished concept art, crisp details, clean composition',
+    width: 512,
+    height: 512,
+    steps: 8,
+    cfg: 1,
+    guidance: 4,
+    timeoutMs: 180000,
+    variant: 'schnell',
+  }),
+})
+
+console.log('generate ok', {
+  promptId: generated.promptId,
+  filename: generated.filename,
+  mimeType: generated.mimeType,
+  imageDataPrefix: generated.imageData?.slice(0, 32),
+})


### PR DESCRIPTION
## Summary
- add `/api/comfy/test/info` for authenticated Comfy `system_stats` and `queue` smoke checks
- add `/api/comfy/test/generate` to validate a checkpoint, submit a small Flux Schnell image job, and return `imageData`
- add `utils/scripts/test-comfy-direct.mjs` so Stage 1 can be run from a machine with the production token/env

## How to test
```bash
COMFY_TEST_AUTH_TOKEN="..." \
COMFY_TEST_API_BASE="https://kind-robots.vercel.app" \
COMFY_TEST_SERVER_ID="25" \
COMFY_TEST_CHECKPOINT_ID="<flux checkpoint resource id>" \
node utils/scripts/test-comfy-direct.mjs
```

Expected output:
- `system ok`
- `queue ok`
- `generate ok` with a `promptId`, filename, MIME type, and data URL prefix

## Notes
- The existing Cypress spec at `cypress/e2e/api/comfy.cy.ts` is still `describe.skip(...)`; I attempted to convert it to an opt-in test, but the connector blocked that file update. This PR leaves the runnable smoke coverage in the standalone script instead.
- Stage 2 quality work should focus on reusable prompt presets, width/height defaults, seed capture, negative prompt defaults, and model-specific quality profiles.