### PR TITLE
art: display folder-based collections in the gallery + sync them to saved collections (t-007)

### DIFF
--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -246,11 +246,32 @@
             class="badge badge-accent badge-sm shrink-0"
             >Unsorted</span
           >
+          <span
+            v-else-if="activeGroup.isFolder"
+            class="badge badge-outline badge-sm shrink-0"
+            >Folder</span
+          >
           <span class="badge badge-primary badge-sm shrink-0">{{
             filteredActiveImages.length
           }}</span>
           <button
-            class="btn btn-ghost btn-xs ml-auto rounded-lg"
+            v-if="activeGroup.isFolder"
+            class="btn btn-secondary btn-xs ml-auto rounded-lg"
+            type="button"
+            :disabled="isSyncingFolder"
+            title="Create a saved collection from this folder's images"
+            @click="syncActiveFolder"
+          >
+            <span
+              v-if="isSyncingFolder"
+              class="loading loading-spinner loading-xs"
+            />
+            <Icon v-else name="kind-icon:plus" class="h-3.5 w-3.5" />
+            Sync to collection
+          </button>
+          <button
+            class="btn btn-ghost btn-xs rounded-lg"
+            :class="{ 'ml-auto': !activeGroup.isFolder }"
             type="button"
             @click="clearActiveGroup"
           >
@@ -883,6 +904,9 @@ type GalleryGroup = {
   isPublic: boolean
   isMature: boolean
   isVirtual: boolean
+  // Folder-derived collection (public/images/{slug}/) not yet saved to the DB.
+  isFolder?: boolean
+  slug?: string | null
   images: ArtImage[]
   collection: GalleryCollection
 }
@@ -915,6 +939,7 @@ const hydratedImages = ref<Record<number, ArtImage>>({})
 const activeGroupKey = ref<string | null>(null)
 const selectedImageForOverlay = ref<ArtImage | null>(null)
 const viewSize = ref<ViewSize>('md')
+const isSyncingFolder = ref(false)
 
 // ── Grid classes ──────────────────────────────────────────────────────────────
 const folderGridClass = computed(() => {
@@ -988,6 +1013,7 @@ const collectionGroups = computed<GalleryGroup[]>(() => {
 
   return [
     ...groups,
+    ...folderGroups.value,
     {
       key: 'collection-unsorted',
       id: -1,
@@ -1001,6 +1027,84 @@ const collectionGroups = computed<GalleryGroup[]>(() => {
       collection: unassignedCollection,
     },
   ]
+})
+
+// ── Folder-derived collections ─────────────────────────────────────────────
+// A folder under public/images/ whose name matches a slug IS that slug's
+// collection. The store fetches these from /api/art/collection/folders; here
+// they become read-only gallery groups (skipping any slug that already exists
+// as a DB collection) with a "Sync to collection" action to materialize them.
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+// Deterministic negative id so synthetic folder images have a stable :key
+// across recomputes and never collide with real (positive) ArtImage ids.
+function hashSlug(slug: string): number {
+  let hash = 0
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) % 100000
+  }
+  return hash
+}
+
+function folderUrlToArtImage(
+  url: string,
+  slug: string,
+  index: number,
+): ArtImage {
+  return {
+    id: -(1_000_000 + hashSlug(slug) * 1000 + index),
+    imagePath: url,
+    path: url,
+    fileName: url.split('/').pop() || url,
+    isPublic: true,
+    isMature: false,
+    userId: currentUserId.value ?? null,
+  } as unknown as ArtImage
+}
+
+const folderGroups = computed<GalleryGroup[]>(() => {
+  const dbSlugs = new Set(
+    collectionStore.collections
+      .map((collection) => (collection.slug || '').toLowerCase())
+      .filter(Boolean),
+  )
+
+  return collectionStore.folderCollections
+    .filter((folder) => folder.slug && !dbSlugs.has(folder.slug.toLowerCase()))
+    .map((folder) => {
+      const title = labelFromSlug(folder.slug)
+      const images = folder.images.map((url, index) =>
+        folderUrlToArtImage(url, folder.slug, index),
+      )
+      const collection = makePseudoCollection({
+        id: -(2_000_000 + hashSlug(folder.slug)),
+        title,
+        description: `Folder collection from public/images/${folder.slug}/.`,
+        images,
+      })
+      return {
+        key: `folder-${folder.slug}`,
+        id: collection.id,
+        title,
+        description: 'Folder collection — not yet synced to a saved collection.',
+        userId: currentUserId.value ?? null,
+        isPublic: true,
+        isMature: false,
+        isVirtual: false,
+        isFolder: true,
+        slug: folder.slug,
+        images,
+        collection,
+      }
+    })
+    .sort((a, b) => a.title.localeCompare(b.title))
 })
 
 const visibleGroups = computed<GalleryGroup[]>(() => {
@@ -1160,6 +1264,7 @@ async function initializeGallery() {
 
   try {
     await fetchCollectionsSafely(false)
+    await fetchFolderCollectionsSafely()
 
     if (!props.dropdownMode) {
       await fetchArtImagesSafely()
@@ -1178,6 +1283,48 @@ async function initializeGallery() {
 async function fetchCollectionsSafely(force = false) {
   if (typeof collectionStore.fetchCollections !== 'function') return
   await collectionStore.fetchCollections(force)
+}
+
+async function fetchFolderCollectionsSafely() {
+  if (typeof collectionStore.fetchFolderCollections !== 'function') return
+  try {
+    await collectionStore.fetchFolderCollections(false)
+  } catch {
+    // Folder collections are a non-critical enhancement over the DB
+    // collections; a failure here must not break the gallery.
+  }
+}
+
+async function syncActiveFolder() {
+  const group = activeGroup.value
+  if (!group?.isFolder || !group.slug) return
+
+  isSyncingFolder.value = true
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    const result = await collectionStore.syncFolderCollection(group.slug)
+    successMessage.value = result.created
+      ? `Synced ${result.created} image(s) into "${group.slug}".`
+      : `"${group.slug}" is already up to date.`
+
+    // The folder is now a saved collection; jump to it (folderGroups drops it
+    // automatically now that a matching DB slug exists).
+    const synced = collectionStore.collections.find(
+      (collection) =>
+        (collection.slug || '').toLowerCase() === group.slug!.toLowerCase(),
+    )
+    activeGroupKey.value = synced ? `collection-${synced.id}` : null
+    await hydrateVisibleImages()
+  } catch (error) {
+    errorMessage.value = getErrorMessage(
+      error,
+      'Failed to sync folder collection.',
+    )
+  } finally {
+    isSyncingFolder.value = false
+  }
 }
 
 async function fetchArtImagesSafely(force = false) {

--- a/server/api/art/collection/folder/[slug].get.ts
+++ b/server/api/art/collection/folder/[slug].get.ts
@@ -1,129 +1,29 @@
 // /server/api/art/collection/folder/[slug].get.ts
 //
-// Folder-based art collection: every image in a slug's folder is part of
-// that slug's collection just by existing there. Conductor's image pipeline
-// maintains a gallery.json manifest per folder and a master
-// public/images/collections.json index (slug -> folder path).
-//
-// Placement convention (Silas, 2026-07-05): the canonical home is nested,
-// public/images/{context}/{slug}/ - context being the most relevant schema
-// or project - with flat public/images/{slug}/ still valid as the
-// degenerate case, and artcollections/{slug}/ as the legacy/unsorted
-// fallback. Resolution order here follows that: nested -> flat ->
-// artcollections. Filesystem is used when readable (dev); on Vercel the
-// public/ assets live on the CDN, so resolution falls back to the master
-// index + per-folder manifests over HTTP.
-import { promises as fs } from 'node:fs'
-import path from 'node:path'
+// Folder-based art collection: every image in a slug's folder is part of that
+// slug's collection just by existing there. Resolution (nested -> flat ->
+// artcollections, filesystem in dev, master-index + per-folder manifest on the
+// CDN) lives in ~/server/utils/folderCollections so this route, the
+// enumeration route, and the sync route all agree on what a folder holds.
 import { defineEventHandler, getRouterParam, getRequestURL, createError } from 'h3'
 import { errorHandler } from '~/server/utils/error'
-
-const IMAGE_EXTENSIONS = new Set(['.webp', '.png', '.jpg', '.jpeg', '.gif', '.svg'])
-
-function isImageFile(name: string): boolean {
-  const ext = name.toLowerCase().match(/\.[a-z0-9]+$/)?.[0] ?? ''
-  return IMAGE_EXTENSIONS.has(ext)
-}
-
-async function listImages(folder: string, urlPrefix: string): Promise<string[] | null> {
-  try {
-    const entries = await fs.readdir(folder, { withFileTypes: true })
-    const images = entries
-      .filter((entry) => entry.isFile() && isImageFile(entry.name))
-      .map((entry) => `${urlPrefix}/${entry.name}`)
-      .sort()
-    return images.length ? images : null
-  } catch {
-    return null
-  }
-}
-
-async function imagesFromFilesystem(slug: string): Promise<string[] | null> {
-  const imagesRoot = path.resolve(process.cwd(), 'public/images')
-
-  // 1. Nested: public/images/{context}/{slug}/
-  try {
-    const contexts = await fs.readdir(imagesRoot, { withFileTypes: true })
-    for (const ctx of contexts) {
-      if (!ctx.isDirectory() || ctx.name === slug || ctx.name === 'artcollections') continue
-      const nested = path.join(imagesRoot, ctx.name, slug)
-      const images = await listImages(nested, `/images/${ctx.name}/${slug}`)
-      if (images) return images
-    }
-  } catch {
-    return null // images root unreadable: CDN mode, use manifests
-  }
-
-  // 2. Flat: public/images/{slug}/
-  const flat = await listImages(path.join(imagesRoot, slug), `/images/${slug}`)
-  if (flat) return flat
-
-  // 3. Legacy/unsorted: public/images/artcollections/{slug}/
-  return listImages(
-    path.join(imagesRoot, 'artcollections', slug),
-    `/images/artcollections/${slug}`,
-  )
-}
-
-async function fetchJson(url: string): Promise<unknown | null> {
-  try {
-    const res = await fetch(url)
-    if (!res.ok) return null
-    return await res.json()
-  } catch {
-    return null
-  }
-}
-
-function stemsToUrls(stems: unknown, urlPrefix: string): string[] | null {
-  if (!Array.isArray(stems)) return null
-  const urls = stems
-    .filter((stem): stem is string => typeof stem === 'string' && stem.length > 0)
-    .map((stem) => (isImageFile(stem) ? `${urlPrefix}/${stem}` : `${urlPrefix}/${stem}.webp`))
-    .sort()
-  return urls.length ? urls : null
-}
-
-async function imagesFromManifest(slug: string, origin: string): Promise<string[] | null> {
-  // 1. Master index: public/images/collections.json -> { [slug]: "context/slug" | "slug" }
-  const index = await fetchJson(`${origin}/images/collections.json`)
-  if (index && typeof index === 'object' && !Array.isArray(index)) {
-    const folder = (index as Record<string, unknown>)[slug]
-    if (typeof folder === 'string' && /^[a-z0-9][a-z0-9_/-]*$/.test(folder)) {
-      const stems = await fetchJson(`${origin}/images/${folder}/gallery.json`)
-      const urls = stemsToUrls(stems, `/images/${folder}`)
-      if (urls) return urls
-    }
-  }
-
-  // 2. Flat per-folder manifest (pre-index deployments)
-  const flat = stemsToUrls(
-    await fetchJson(`${origin}/images/${slug}/gallery.json`),
-    `/images/${slug}`,
-  )
-  if (flat) return flat
-
-  // 3. Legacy artcollections manifest
-  return stemsToUrls(
-    await fetchJson(`${origin}/images/artcollections/${slug}/gallery.json`),
-    `/images/artcollections/${slug}`,
-  )
-}
+import {
+  resolveFolderImages,
+  SLUG_PATTERN,
+} from '~/server/utils/folderCollections'
 
 export default defineEventHandler(async (event) => {
   try {
-    const slug = String(getRouterParam(event, 'slug') || '').trim().toLowerCase()
+    const slug = String(getRouterParam(event, 'slug') || '')
+      .trim()
+      .toLowerCase()
 
-    if (!/^[a-z0-9][a-z0-9_-]*$/.test(slug)) {
+    if (!SLUG_PATTERN.test(slug)) {
       throw createError({ statusCode: 400, message: 'Invalid collection slug.' })
     }
 
-    let images = await imagesFromFilesystem(slug)
-
-    if (images === null) {
-      const origin = getRequestURL(event).origin
-      images = await imagesFromManifest(slug, origin)
-    }
+    const origin = getRequestURL(event).origin
+    const images = await resolveFolderImages(slug, origin)
 
     if (images === null) {
       throw createError({

--- a/server/api/art/collection/folder/[slug]/sync.post.ts
+++ b/server/api/art/collection/folder/[slug]/sync.post.ts
@@ -1,0 +1,142 @@
+// /server/api/art/collection/folder/[slug]/sync.post.ts
+//
+// Sync a folder into a real DB ArtCollection. A folder under public/images/
+// whose name matches a slug IS that slug's collection (Silas, 2026-07-04);
+// this endpoint materializes that: it ensures an ArtCollection exists at the
+// slug and creates a lightweight ArtImage row (imagePath -> the public URL,
+// no imageData) for every folder image not already linked, then connects them.
+//
+// Idempotent: re-syncing only adds images that appeared since last time; it
+// never duplicates an image already in the collection (dedup by imagePath).
+// Machine auth (JWT / user apiKey / beta admin) so both the browser gallery
+// and conductor automation can trigger it.
+import {
+  defineEventHandler,
+  getRouterParam,
+  getRequestURL,
+  createError,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import {
+  resolveFolderImages,
+  SLUG_PATTERN,
+} from '~/server/utils/folderCollections'
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function fileNameFromUrl(url: string): string {
+  const name = url.split('/').pop() || url
+  return name.slice(0, 764)
+}
+
+function fileTypeFromUrl(url: string): string {
+  return url.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] || 'png'
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+
+    const slug = String(getRouterParam(event, 'slug') || '')
+      .trim()
+      .toLowerCase()
+
+    if (!SLUG_PATTERN.test(slug)) {
+      throw createError({ statusCode: 400, message: 'Invalid collection slug.' })
+    }
+
+    const origin = getRequestURL(event).origin
+    const images = await resolveFolderImages(slug, origin)
+
+    if (images === null || images.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: `No folder collection found for "${slug}" - nothing to sync.`,
+      })
+    }
+
+    // Ensure the collection exists (keyed on the unique slug).
+    let collection = await prisma.artCollection.findUnique({
+      where: { slug },
+      select: { id: true, ArtImages: { select: { id: true, imagePath: true } } },
+    })
+
+    if (!collection) {
+      const created = await prisma.artCollection.create({
+        data: {
+          slug,
+          label: labelFromSlug(slug),
+          description: `Folder collection synced from public/images/ (${slug}).`,
+          userId: auth.user.id,
+          isPublic: true,
+        },
+        select: { id: true },
+      })
+      collection = { id: created.id, ArtImages: [] }
+    }
+
+    const existingPaths = new Set(
+      collection.ArtImages.map((image) => image.imagePath).filter(
+        (p): p is string => typeof p === 'string',
+      ),
+    )
+
+    const toCreate = images.filter((url) => !existingPaths.has(url))
+
+    let created = 0
+    for (const url of toCreate) {
+      const artImage = await prisma.artImage.create({
+        data: {
+          imagePath: url,
+          path: url.slice(0, 764),
+          fileName: fileNameFromUrl(url),
+          fileType: fileTypeFromUrl(url),
+          userId: auth.user.id,
+          isPublic: true,
+          designer: `folder-sync:${slug}`,
+        },
+        select: { id: true },
+      })
+
+      await prisma.artCollection.update({
+        where: { id: collection.id },
+        data: { ArtImages: { connect: { id: artImage.id } } },
+      })
+      created += 1
+    }
+
+    return {
+      success: true,
+      message: created
+        ? `Synced ${created} new image(s) into "${slug}".`
+        : `"${slug}" already up to date.`,
+      data: {
+        slug,
+        collectionId: collection.id,
+        total: images.length,
+        created,
+        alreadyPresent: images.length - toCreate.length,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to sync folder collection.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/art/collection/folder/collections.http
+++ b/server/api/art/collection/folder/collections.http
@@ -1,0 +1,54 @@
+@admintoken = {{$dotenv ADMIN_TOKEN}}
+@usertoken = {{$dotenv USER_TOKEN}}
+@host = https://kind-robots.vercel.app
+@slug = art-generator-connect
+
+// @ts-nocheck
+/* eslint-disable */
+// test-ignore
+
+// Folder-based art collection contract tests (art-generator-connect t-007).
+// A folder under public/images/ whose name matches a slug IS that slug's
+// collection. These routes list folder collections, read one, and sync a
+// folder into a saved DB ArtCollection. Run top to bottom.
+
+### 1. List all folder collections (public; expect data[] of {slug, count, preview, images})
+GET {{host}}/api/art/collection/folders
+
+###
+
+### 2. Read one folder collection's images (public; expect data.images[] of URLs)
+GET {{host}}/api/art/collection/folder/{{ slug }}
+
+###
+
+### 3. Sync the folder into a DB collection (auth; expect data.created + collectionId)
+###    First run materializes ArtImage rows; re-running returns created: 0.
+POST {{host}}/api/art/collection/folder/{{ slug }}/sync
+Authorization: Bearer {{ usertoken }}
+
+###
+
+### 4. Re-sync is idempotent (expect data.created = 0, alreadyPresent = total)
+POST {{host}}/api/art/collection/folder/{{ slug }}/sync
+Authorization: Bearer {{ usertoken }}
+
+###
+
+### 5. The synced collection now shows up among DB collections (find it by slug)
+GET {{host}}/api/art/collection?summary=true
+
+###
+
+### 6. Negative: read a slug with no folder (expect 404)
+GET {{host}}/api/art/collection/folder/definitely-not-a-real-slug-xyz
+
+###
+
+### 7. Negative: sync unauthenticated (expect 401)
+POST {{host}}/api/art/collection/folder/{{ slug }}/sync
+
+###
+
+### 8. Negative: invalid slug shape (expect 400)
+GET {{host}}/api/art/collection/folder/Not_A_Valid_Slug!

--- a/server/api/art/collection/folders.get.ts
+++ b/server/api/art/collection/folders.get.ts
@@ -1,0 +1,45 @@
+// /server/api/art/collection/folders.get.ts
+//
+// Enumerate every folder-based art collection the site can see: one entry per
+// slug that owns a folder of images under public/images/. This is the
+// "display collections by folders" surface - the gallery lists these
+// alongside the DB-backed ArtCollections, and offers a sync action
+// (POST .../folder/[slug]/sync) to promote a folder into a real collection.
+//
+// Public/read-only: folder contents are already public assets, so no auth is
+// required to list them (matching the single-slug folder route).
+import { defineEventHandler, getRequestURL } from 'h3'
+import { errorHandler } from '~/server/utils/error'
+import { listFolderCollections } from '~/server/utils/folderCollections'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const origin = getRequestURL(event).origin
+    const collections = await listFolderCollections(origin)
+
+    return {
+      success: true,
+      message: collections.length
+        ? `${collections.length} folder collection(s).`
+        : 'No folder collections found.',
+      data: collections.map((collection) => ({
+        slug: collection.slug,
+        images: collection.images,
+        count: collection.images.length,
+        preview: collection.images[0] ?? null,
+      })),
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to list folder collections.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/folderCollections.ts
+++ b/server/utils/folderCollections.ts
@@ -1,0 +1,233 @@
+// /server/utils/folderCollections.ts
+//
+// Folder-based art collections: every image sitting in a slug's folder under
+// public/images/ IS part of that slug's collection just by existing there
+// (Silas, 2026-07-04). Conductor's image pipeline maintains a gallery.json
+// manifest per folder and a master public/images/collections.json index
+// (slug -> folder path) so the collection can be resolved on Vercel, where
+// public/ lives on the CDN and the filesystem is not readable.
+//
+// Placement convention (Silas, 2026-07-05): the canonical home is nested,
+// public/images/{context}/{slug}/ - context being the most relevant schema or
+// project - with flat public/images/{slug}/ still valid as the degenerate
+// case, and artcollections/{slug}/ as the legacy/unsorted fallback. Both the
+// single-slug resolver and the enumeration below follow that order.
+//
+// Shared by GET /api/art/collection/folder/[slug], GET
+// /api/art/collection/folders, and POST /api/art/collection/folder/[slug]/sync
+// so all three agree on exactly what "the folder's images" means.
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+const IMAGE_EXTENSIONS = new Set([
+  '.webp',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+])
+
+export const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
+
+export type FolderCollection = {
+  slug: string
+  images: string[]
+}
+
+export function isImageFile(name: string): boolean {
+  const ext = name.toLowerCase().match(/\.[a-z0-9]+$/)?.[0] ?? ''
+  return IMAGE_EXTENSIONS.has(ext)
+}
+
+async function listImages(
+  folder: string,
+  urlPrefix: string,
+): Promise<string[] | null> {
+  try {
+    const entries = await fs.readdir(folder, { withFileTypes: true })
+    const images = entries
+      .filter((entry) => entry.isFile() && isImageFile(entry.name))
+      .map((entry) => `${urlPrefix}/${entry.name}`)
+      .sort()
+    return images.length ? images : null
+  } catch {
+    return null
+  }
+}
+
+async function imagesFromFilesystem(slug: string): Promise<string[] | null> {
+  const imagesRoot = path.resolve(process.cwd(), 'public/images')
+
+  // 1. Nested: public/images/{context}/{slug}/
+  try {
+    const contexts = await fs.readdir(imagesRoot, { withFileTypes: true })
+    for (const ctx of contexts) {
+      if (!ctx.isDirectory() || ctx.name === slug || ctx.name === 'artcollections')
+        continue
+      const nested = path.join(imagesRoot, ctx.name, slug)
+      const images = await listImages(nested, `/images/${ctx.name}/${slug}`)
+      if (images) return images
+    }
+  } catch {
+    return null // images root unreadable: CDN mode, use manifests
+  }
+
+  // 2. Flat: public/images/{slug}/
+  const flat = await listImages(path.join(imagesRoot, slug), `/images/${slug}`)
+  if (flat) return flat
+
+  // 3. Legacy/unsorted: public/images/artcollections/{slug}/
+  return listImages(
+    path.join(imagesRoot, 'artcollections', slug),
+    `/images/artcollections/${slug}`,
+  )
+}
+
+async function fetchJson(url: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) return null
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+function stemsToUrls(stems: unknown, urlPrefix: string): string[] | null {
+  if (!Array.isArray(stems)) return null
+  const urls = stems
+    .filter((stem): stem is string => typeof stem === 'string' && stem.length > 0)
+    .map((stem) =>
+      isImageFile(stem) ? `${urlPrefix}/${stem}` : `${urlPrefix}/${stem}.webp`,
+    )
+    .sort()
+  return urls.length ? urls : null
+}
+
+async function imagesFromManifest(
+  slug: string,
+  origin: string,
+): Promise<string[] | null> {
+  // 1. Master index: public/images/collections.json -> { [slug]: "context/slug" | "slug" }
+  const index = await readCollectionsIndex(origin)
+  const folder = index[slug]
+  if (typeof folder === 'string' && /^[a-z0-9][a-z0-9_/-]*$/.test(folder)) {
+    const stems = await fetchJson(`${origin}/images/${folder}/gallery.json`)
+    const urls = stemsToUrls(stems, `/images/${folder}`)
+    if (urls) return urls
+  }
+
+  // 2. Flat per-folder manifest (pre-index deployments)
+  const flat = stemsToUrls(
+    await fetchJson(`${origin}/images/${slug}/gallery.json`),
+    `/images/${slug}`,
+  )
+  if (flat) return flat
+
+  // 3. Legacy artcollections manifest
+  return stemsToUrls(
+    await fetchJson(`${origin}/images/artcollections/${slug}/gallery.json`),
+    `/images/artcollections/${slug}`,
+  )
+}
+
+/**
+ * Read the master slug -> folder index. Prefers the local filesystem (dev),
+ * falls back to fetching the CDN copy (Vercel). Returns {} when neither is
+ * available so callers can degrade gracefully.
+ */
+async function readCollectionsIndex(
+  origin: string,
+): Promise<Record<string, string>> {
+  const local = path.resolve(process.cwd(), 'public/images/collections.json')
+  try {
+    const raw = await fs.readFile(local, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>
+    }
+  } catch {
+    // not on disk (CDN mode) - fall through to HTTP
+  }
+
+  const remote = await fetchJson(`${origin}/images/collections.json`)
+  if (remote && typeof remote === 'object' && !Array.isArray(remote)) {
+    return remote as Record<string, string>
+  }
+  return {}
+}
+
+/**
+ * Resolve every image URL belonging to a slug's folder collection. Filesystem
+ * first (dev), master index + per-folder manifest second (CDN). Returns null
+ * when no folder collection exists for the slug.
+ */
+export async function resolveFolderImages(
+  slug: string,
+  origin: string,
+): Promise<string[] | null> {
+  const fromDisk = await imagesFromFilesystem(slug)
+  if (fromDisk !== null) return fromDisk
+  return imagesFromManifest(slug, origin)
+}
+
+/**
+ * Enumerate every folder collection the site can see. Slugs come from the
+ * master index (the reliable source on the CDN); a dev filesystem scan of
+ * public/images/ fills in any folders not yet indexed. Each returned
+ * collection carries its resolved image URLs.
+ */
+export async function listFolderCollections(
+  origin: string,
+): Promise<FolderCollection[]> {
+  const slugs = new Set<string>()
+
+  const index = await readCollectionsIndex(origin)
+  for (const key of Object.keys(index)) {
+    if (SLUG_PATTERN.test(key)) slugs.add(key)
+  }
+
+  // Dev fallback: pick up folders that hold images but aren't indexed yet.
+  const imagesRoot = path.resolve(process.cwd(), 'public/images')
+  try {
+    const contexts = await fs.readdir(imagesRoot, { withFileTypes: true })
+    for (const ctx of contexts) {
+      if (!ctx.isDirectory()) continue
+      if (ctx.name === 'artcollections') {
+        // legacy: artcollections/{slug}/
+        await addChildDirsAsSlugs(path.join(imagesRoot, ctx.name), slugs)
+        continue
+      }
+      // flat: {slug}/ (only if it directly holds images)
+      if (SLUG_PATTERN.test(ctx.name)) {
+        const direct = await listImages(path.join(imagesRoot, ctx.name), '')
+        if (direct) slugs.add(ctx.name)
+      }
+      // nested: {context}/{slug}/
+      await addChildDirsAsSlugs(path.join(imagesRoot, ctx.name), slugs)
+    }
+  } catch {
+    // images root unreadable (CDN mode): the index above is all we have.
+  }
+
+  const collections: FolderCollection[] = []
+  for (const slug of [...slugs].sort()) {
+    const images = await resolveFolderImages(slug, origin)
+    if (images && images.length) collections.push({ slug, images })
+  }
+  return collections
+}
+
+async function addChildDirsAsSlugs(dir: string, slugs: Set<string>) {
+  try {
+    const children = await fs.readdir(dir, { withFileTypes: true })
+    for (const child of children) {
+      if (child.isDirectory() && SLUG_PATTERN.test(child.name)) {
+        slugs.add(child.name)
+      }
+    }
+  } catch {
+    // not a directory / unreadable - ignore
+  }
+}

--- a/stores/collectionStore.ts
+++ b/stores/collectionStore.ts
@@ -42,10 +42,26 @@ type ArtWithRelations = ArtImage & {
   Server?: unknown
 }
 
+export type FolderCollectionSummary = {
+  slug: string
+  images: string[]
+  count: number
+  preview: string | null
+}
+
+export type FolderSyncResult = {
+  slug: string
+  collectionId: number
+  total: number
+  created: number
+  alreadyPresent: number
+}
+
 type CollectionState = {
   collections: ArtCollection[]
   currentCollection: ArtCollection | null
   autoSave: boolean
+  folderCollections: FolderCollectionSummary[]
 }
 
 type AddArtImageToCollectionInput = {
@@ -261,7 +277,10 @@ export const useCollectionStore = defineStore('collectionStore', () => {
     collections: [],
     currentCollection: null,
     autoSave: true,
+    folderCollections: [],
   })
+
+  const hasFetchedFolders = ref(false)
 
   const userStore = useUserStore()
   const artStore = useArtStore()
@@ -992,8 +1011,59 @@ export const useCollectionStore = defineStore('collectionStore', () => {
     fetchPromise.value = null
   }
 
+  /**
+   * Load the folder-based collections (public/images/{slug}/ folders) so the
+   * gallery can show them alongside the DB-backed ArtCollections. Cached after
+   * the first successful load; pass force to refetch.
+   */
+  async function fetchFolderCollections(
+    force = false,
+  ): Promise<FolderCollectionSummary[]> {
+    if (!force && hasFetchedFolders.value) return state.folderCollections
+
+    const response = await performFetch<FolderCollectionSummary[]>(
+      '/api/art/collection/folders',
+    )
+
+    if (!response.success || !Array.isArray(response.data)) {
+      throw new Error(
+        response.message || 'Failed to fetch folder collections',
+      )
+    }
+
+    state.folderCollections = response.data
+    hasFetchedFolders.value = true
+    return state.folderCollections
+  }
+
+  /**
+   * Promote a folder into a real DB ArtCollection: the server ensures a
+   * collection exists at the slug and materializes an ArtImage row per folder
+   * image. Idempotent. Refreshes both the DB collections (so the synced one
+   * appears as a normal collection) and the folder list (updated counts).
+   */
+  async function syncFolderCollection(
+    slug: string,
+  ): Promise<FolderSyncResult> {
+    const response = await performFetch<FolderSyncResult>(
+      `/api/art/collection/folder/${encodeURIComponent(slug)}/sync`,
+      { method: 'POST' },
+    )
+
+    if (!response.success || !response.data) {
+      throw new Error(response.message || `Failed to sync folder "${slug}"`)
+    }
+
+    await fetchCollections(true)
+    await fetchFolderCollections(true)
+    return response.data
+  }
+
   return {
     ...toRefs(state),
+
+    fetchFolderCollections,
+    syncFolderCollection,
 
     selectedCollectionIds,
     selectedCollections,


### PR DESCRIPTION
## Summary

A folder under `public/images/` whose name matches a slug **is** that slug's art collection (Silas, 2026-07-04). The derivation already existed server-side (`GET /api/art/collection/folder/[slug]`), but nothing consumed it and there was no way to promote a folder into a real `ArtCollection`. This wires both — display **and** sync.

Implements `art-generator-connect/t-007`, extended per Silas to include the sync action.

## Backend
- **`server/utils/folderCollections.ts`** — extracts the `nested → flat → artcollections` resolution (filesystem in dev; `collections.json` master index + per-folder `gallery.json` manifests on the CDN) into a shared util, and adds `listFolderCollections()` to enumerate every folder collection the site can see.
- **`GET /api/art/collection/folders`** — lists folder collections (`slug`, `images`, `count`, `preview`). Public/read-only, matching the single-slug route.
- **`POST /api/art/collection/folder/[slug]/sync`** — materializes a folder into a DB `ArtCollection`: ensures the slug's collection exists, creates a lightweight `ArtImage` (`imagePath` → the public URL, no `imageData`) per folder image not already linked, and connects them. **Idempotent** (dedup by `imagePath`). Machine auth (`requireMachineUser`) so both the browser gallery and conductor automation can trigger it.
- The single-slug route is refactored onto the shared util — **no behavior change**.

## Frontend
- **`collectionStore`** — `folderCollections` state + `fetchFolderCollections()` + `syncFolderCollection()` (refreshes DB + folder lists after a sync).
- **`art-gallery.vue`** — folder collections render as read-only groups alongside DB collections (skipping any slug already saved), each with a **"Sync to collection"** action. Synthetic folder images render straight from `imagePath`, so they never trigger a hydration fetch.

Adds `collections.http` mirroring the existing `queue.http` contract file.

## Test plan
⚠️ **Source-reviewed only — please let CI + a local run validate.** The conductor session where this was authored has no runnable kind_robots toolchain (`node_modules` absent), so I could not run `vue-tsc`, the linter, or the actual gallery. Statically verified: referenced symbols exist, auth matches the `requireMachineUser` pattern, Prisma writes match the schema, import aliases match repo convention, and the negative-id folder images bypass hydration via the existing `imagePath` guard in `shouldHydrateImage`.

- [ ] `npm run test` (vue-tsc)
- [ ] `npm run lint`
- [ ] Open the art manager → gallery: folder collections appear, "Sync to collection" creates a saved collection and jumps to it, re-sync is a no-op
- [ ] `collections.http` steps 1–8

## Known limits (v1)
- `ArtImage.imagePath` is the default `VARCHAR(191)`; real folder URLs are well under that, but a very deeply nested long slug could overflow.
- Sync creates rows sequentially (2 queries/image) and the list endpoint resolves all folders' images per call — fine for current folder counts, batchable later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011HYgpHpcrsDtjMYqtDLgUp)_