### PR TITLE
Add canonical .kr-note status-callout classes + gallery section

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -146,6 +146,33 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-100;
   }
 
+  /*
+   * Status callouts — inline tinted notices (the most-repeated surface in
+   * the app, previously written by hand with drifting opacities like
+   * border-info/30 vs /40 and bg-info/5 vs /10 vs /15). Canonical form:
+   * border-{status}/40 + bg-{status}/10 + text-{status}. Use .kr-note with
+   * one modifier. For a loud, full-width banner prefer DaisyUI `alert`.
+   */
+  .kr-note {
+    @apply rounded-2xl border p-4 text-sm font-semibold;
+  }
+
+  .kr-note-info {
+    @apply border-info/40 bg-info/10 text-info;
+  }
+
+  .kr-note-success {
+    @apply border-success/40 bg-success/10 text-success;
+  }
+
+  .kr-note-warning {
+    @apply border-warning/40 bg-warning/10 text-warning;
+  }
+
+  .kr-note-error {
+    @apply border-error/40 bg-error/10 text-error;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -147,6 +147,12 @@
                   >— flat surface for lists</span
                 >
               </li>
+              <li>
+                <code>.kr-note-*</code>
+                <span class="font-sans opacity-70"
+                  >— status callouts (see below)</span
+                >
+              </li>
             </ul>
             <p class="text-smart-caption opacity-60">
               Defined in <code class="font-mono">assets/css/tailwind.css</code>.
@@ -273,6 +279,28 @@
           </div>
           <div class="alert alert-error">
             <span>Something went wrong. Try again.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Callouts: canonical status-tint notices -->
+      <section id="callouts" class="scroll-mt-32 kr-section">
+        <SectionHeading
+          title="Callouts"
+          hint="Inline tinted notices via .kr-note + a status modifier. Use these instead of hand-writing border-{status}/40 bg-{status}/10 per component. For a loud full-width banner, prefer the DaisyUI alert above."
+        />
+        <div class="grid gap-3 sm:grid-cols-2">
+          <div class="kr-note kr-note-info">
+            .kr-note-info — informational aside
+          </div>
+          <div class="kr-note kr-note-success">
+            .kr-note-success — positive confirmation
+          </div>
+          <div class="kr-note kr-note-warning">
+            .kr-note-warning — needs attention
+          </div>
+          <div class="kr-note kr-note-error">
+            .kr-note-error — something failed
           </div>
         </div>
       </section>
@@ -512,6 +540,7 @@ const sections = [
   { id: 'buttons', label: 'Buttons' },
   { id: 'badges', label: 'Badges' },
   { id: 'alerts', label: 'Alerts' },
+  { id: 'callouts', label: 'Callouts' },
   { id: 'cards', label: 'Cards' },
   { id: 'forms', label: 'Forms' },
   { id: 'nav', label: 'Nav' },


### PR DESCRIPTION
## What & why

Follows the `/ui` style plan (t-011) with the highest-value *safe* consistency win from a codebase audit.

An audit of the 283 components found that most high-traffic surfaces are **intentionally bespoke** (the workspace header is translucent `bg-base-100/95` + `backdrop-blur` chrome; `login-page` is glassmorphism; the "generic" panels are mostly dashed-border empty-states) — so blindly migrating them onto `.kr-panel` would *regress* crafted UI. The one genuinely mechanical inconsistency is **status-tint callouts**: 100+ hand-written notices with drifting opacities (`border-info/30` vs `/40`, `bg-info/5` vs `/10` vs `/15`, likewise success/warning/error).

## Change

- Add canonical `.kr-note` + `.kr-note-{info,success,warning,error}` classes to `assets/css/tailwind.css` — `border-{status}/40 + bg-{status}/10 + text-{status}`, one source of truth for inline tinted notices.
- Add a **Callouts** section to the `/ui` gallery documenting them (nav entry + Conventions reference included), noting: prefer DaisyUI `alert` for loud full-width banners, `.kr-note` for inline notices.

Additive only — no existing component markup changed, so zero regression risk. Migrating the 100+ existing usages onto `.kr-note-*` is the incremental follow-up (global-ui t-012), which needs per-surface verification in a preview deploy.

## Verification

- `/ui` renders HTTP 200; new Callouts section verified across themes (emerald, synthwave) via headless Chromium screenshots.
- `prettier` + `eslint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZdq7USxPx2j6dmkEd6QP9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZdq7USxPx2j6dmkEd6QP9)_