### PR TITLE
ci: Contract Tests workflow — run art-request YAML verifier on every PR (t-018)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,0 +1,42 @@
+name: Contract Tests
+
+# Fast, DB-free contract checks (conductor art-generator-connect/t-018).
+# Runs the pure-string tsx verifiers that assert cross-repo data contracts
+# — currently the art-request YAML indentation contract that conductor's
+# PyYAML parser depends on (server/utils/artRequestYaml.ts). No database or
+# Nuxt build needed, so this stays fast and can gate every PR.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: contract-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-tests:
+    name: Contract verifiers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0' # cypress unused in this job
+
+      - name: Art-request YAML indentation contract
+        run: npm run test:art-request-yaml


### PR DESCRIPTION
### Task
art-generator-connect/t-018: run the tsx contract verifiers in a kind_robots CI job (kind: software) — kaizen from the t-008 merge (PR #108).

### What changed
- Added `.github/workflows/contract-tests.yml` — a lean, DB-free GitHub Actions job that runs `npm run test:art-request-yaml` on every push to `main`, every PR into `main`, and on manual dispatch.
- The verifier is pure string assertions over `server/utils/artRequestYaml.ts` (no database, no Nuxt build), so the job stays fast and can gate every PR. Mirrors the existing `typecheck.yml` structure (checkout → setup-node 24 → `npm ci` → run script), with `CYPRESS_INSTALL_BINARY=0` since cypress is unused here.

### Why
The column-0 `art-prompts.yaml` indentation contract (kind_robots PR #84's silent-stall bug) now has a verifier, but until now it only ran on demand. This makes the contract self-enforcing so a future edit that breaks conductor's YAML parser fails CI here instead of silently stalling the missing-image pipeline downstream.

### How I verified
- `yaml.safe_load` on the workflow file — valid.
- The verifier logic itself was validated green via a plain-node mirror when it landed in #108 (this environment has no `node_modules`); the new job runs the same `npm run test:art-request-yaml`, which will execute for real on this PR.

### Stakes
reversible (additive CI workflow only; no app code or schema change)

### Kaizen suggestion
Once a scratch-DB step is worth the cost, fold the davinci seed verifier into this same workflow (or a matrix) so all cross-repo contract checks live in one place.

### Notes for reviewer
Additive workflow only. Self-validating — the new "Contract verifiers" check running green on this PR is the proof. Safe to squash-merge once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwG3kgeME1XN8kC4MqknKZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwG3kgeME1XN8kC4MqknKZ)_