### PR TITLE
Add Serendipity Voice view: Echo-driven front-end animation control

### DIFF
--- a/components/pages/serendipity-voice-page.vue
+++ b/components/pages/serendipity-voice-page.vue
@@ -1,0 +1,238 @@
+<!-- /components/pages/serendipity-voice-page.vue -->
+<!--
+  Serendipity Voice — the Kind Robots front end for the Alexa voice surface.
+  It connects to the local serendipity-voice relay, shows the shared message
+  feed, and applies spoken commands to the app. Say "Serendipity, turn
+  butterflies on" to your Echo (or use the simulate box below) and the butterfly
+  animation turns on right here via animationStore + the app-wide fx-region.
+-->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4 md:p-6"
+    data-animation-surface
+  >
+    <header class="flex flex-wrap items-center justify-between gap-3">
+      <div class="flex items-center gap-3">
+        <span
+          class="grid h-12 w-12 place-items-center rounded-2xl bg-primary/15 text-primary"
+        >
+          <Icon name="kind-icon:butterfly" class="h-7 w-7" />
+        </span>
+        <div>
+          <h1 class="text-2xl font-black tracking-tight">Serendipity Voice</h1>
+          <p class="text-sm text-base-content/60">
+            Talk to Kind Robots through your Amazon Echo.
+          </p>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <span
+          class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wide"
+          :class="
+            voice.connected
+              ? 'bg-success/20 text-success'
+              : 'bg-error/15 text-error'
+          "
+        >
+          <span
+            class="h-2 w-2 rounded-full"
+            :class="voice.connected ? 'bg-success' : 'bg-error'"
+          />
+          {{ voice.connected ? 'Relay connected' : 'Relay offline' }}
+        </span>
+        <button
+          class="btn btn-sm"
+          :class="voice.polling ? 'btn-warning' : 'btn-primary'"
+          type="button"
+          @click="toggleConnection"
+        >
+          {{ voice.polling ? 'Disconnect' : 'Connect' }}
+        </button>
+      </div>
+    </header>
+
+    <!-- Relay endpoint -->
+    <div
+      class="flex flex-wrap items-end gap-3 rounded-xl border border-base-300 bg-base-200/60 p-3"
+    >
+      <label class="flex-1">
+        <span
+          class="mb-1 block text-xs font-bold uppercase text-base-content/60"
+        >
+          Relay URL
+        </span>
+        <input
+          v-model="relayInput"
+          class="input input-bordered input-sm w-full"
+          placeholder="http://localhost:4173"
+          @change="saveRelay"
+        />
+      </label>
+      <p class="text-xs text-base-content/50">
+        The serendipity-voice dev server (npm run dev:web).
+      </p>
+    </div>
+
+    <!-- Simulate an Echo utterance -->
+    <div class="rounded-xl border border-base-300 bg-base-200/60 p-3">
+      <p class="mb-2 text-xs font-bold uppercase text-base-content/60">
+        Speak to Serendipity (or simulate)
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="phrase in quickPhrases"
+          :key="phrase"
+          class="btn btn-xs btn-outline"
+          type="button"
+          @click="send(phrase)"
+        >
+          {{ phrase }}
+        </button>
+      </div>
+      <form class="mt-3 flex gap-2" @submit.prevent="send(utterance)">
+        <input
+          v-model="utterance"
+          class="input input-bordered input-sm flex-1"
+          placeholder="Serendipity, turn butterflies on"
+        />
+        <button class="btn btn-sm btn-primary" type="submit">Send</button>
+      </form>
+    </div>
+
+    <div class="grid flex-1 gap-4 md:grid-cols-[1fr,16rem]">
+      <!-- Message feed -->
+      <div
+        class="flex min-h-48 flex-col rounded-xl border border-base-300 bg-base-100"
+      >
+        <div
+          class="border-b border-base-300 px-3 py-2 text-xs font-bold uppercase text-base-content/60"
+        >
+          Message feed
+        </div>
+        <div class="flex flex-1 flex-col gap-2 overflow-y-auto p-3">
+          <p
+            v-if="voice.recentMessages.length === 0"
+            class="text-sm text-base-content/50"
+          >
+            Waiting for messages. Connect the relay, then say “Serendipity, turn
+            butterflies on.”
+          </p>
+          <div
+            v-for="message in voice.recentMessages"
+            :key="message.id"
+            class="flex items-start gap-2"
+          >
+            <span
+              class="mt-0.5 rounded-full px-2 py-0.5 text-[0.65rem] font-black uppercase"
+              :class="roleClass(message.role)"
+            >
+              {{ message.role }}
+            </span>
+            <span class="text-sm text-base-content/90">{{ message.text }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Live animation state -->
+      <aside
+        class="flex flex-col gap-3 rounded-xl border border-base-300 bg-base-200/60 p-3"
+      >
+        <div>
+          <p class="text-xs font-bold uppercase text-base-content/60">
+            Active animations
+          </p>
+          <p
+            v-if="activeEffects.length === 0"
+            class="mt-1 text-sm text-base-content/50"
+          >
+            None running.
+          </p>
+          <ul v-else class="mt-1 space-y-1">
+            <li
+              v-for="effect in activeEffects"
+              :key="effect.id"
+              class="flex items-center gap-2 text-sm font-semibold"
+            >
+              <Icon
+                :name="effect.icon"
+                class="h-4 w-4"
+                :style="{ color: effect.color }"
+              />
+              {{ effect.label }}
+            </li>
+          </ul>
+        </div>
+
+        <div v-if="voice.lastAppliedText" class="text-xs text-success">
+          Last applied: {{ voice.lastAppliedText }}
+        </div>
+        <div v-if="voice.lastError" class="text-xs text-error">
+          {{ voice.lastError }}
+        </div>
+
+        <p class="mt-auto text-[0.7rem] leading-snug text-base-content/50">
+          Effects render app-wide through fx-region, so butterflies appear over
+          this page the moment the command lands.
+        </p>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  useSerendipityVoiceStore,
+  type VoiceBusRole,
+} from '@/stores/serendipityVoiceStore'
+import { useAnimationStore } from '@/stores/animationStore'
+
+const voice = useSerendipityVoiceStore()
+const animationStore = useAnimationStore()
+
+const relayInput = ref(voice.relayBaseUrl)
+const utterance = ref('Serendipity, turn butterflies on')
+
+const quickPhrases = [
+  'Serendipity, turn butterflies on',
+  'Serendipity, turn butterflies off',
+  'Serendipity, change the animation to fireflies',
+  'Serendipity, turn off all animations',
+]
+
+const activeEffects = computed(() => animationStore.screenEffects)
+
+function roleClass(role: VoiceBusRole): string {
+  if (role === 'voice') return 'bg-primary/20 text-primary'
+  if (role === 'view') return 'bg-info/20 text-info'
+  return 'bg-base-300 text-base-content/70'
+}
+
+function toggleConnection(): void {
+  if (voice.polling) voice.stop()
+  else voice.start()
+}
+
+function saveRelay(): void {
+  voice.setRelayBaseUrl(relayInput.value)
+  relayInput.value = voice.relayBaseUrl
+  if (voice.polling) {
+    voice.stop()
+    voice.start()
+  }
+}
+
+function send(text: string): void {
+  void voice.sendVoiceText(text)
+}
+
+onMounted(() => {
+  voice.start()
+  relayInput.value = voice.relayBaseUrl
+})
+
+onBeforeUnmount(() => {
+  voice.stop()
+})
+</script>

--- a/content/serendipity-voice.md
+++ b/content/serendipity-voice.md
@@ -1,0 +1,12 @@
+---
+title: Serendipity Voice
+room: Story Door
+subtitle: Talk to Kind Robots
+description: The voice surface for the Serendipity Alexa integration. Connects to the local voice relay, shows the shared message feed, and applies spoken commands like "turn butterflies on" to the app.
+icon: kind-icon:butterfly
+tooltip: Say "Serendipity, turn butterflies on" and watch it happen here.
+dottitip: The house is listening. Speak kindly.
+amitip: Your voice becomes a butterfly. Try it.
+---
+
+:serendipity-voice-page

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -1,0 +1,282 @@
+// /stores/serendipityVoiceStore.ts
+// Serendipity Voice bridge (alexa-integration surface).
+// Connects the Kind Robots front end to the local serendipity-voice relay
+// (silasfelinus/serendipity-voice). It polls the relay for front-end commands
+// spoken through Alexa ("Serendipity, turn butterflies on") and applies them to
+// the app — starting with the animation surface via animationStore. It also
+// mirrors the shared message feed so both sides of the conversation are visible.
+//
+// Local-first and read-safe: the relay is an in-memory dev seam on localhost.
+// Commands only toggle reversible visual effects; nothing is written or spent.
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import {
+  useAnimationStore,
+  type AnimationEffectId,
+  type FxRegion,
+} from '@/stores/animationStore'
+
+export type VoiceBusRole = 'voice' | 'view' | 'system'
+
+export type VoiceBusMessage = {
+  id: number
+  role: VoiceBusRole
+  text: string
+  at: string
+}
+
+export type VoiceBusCommand = {
+  id: number
+  target: string
+  action: 'on' | 'off' | 'toggle' | 'clear'
+  effect?: string
+  effectId?: string
+  surface?: string
+  spokenText: string
+  source: string
+  at: string
+}
+
+const DEFAULT_RELAY_URL = 'http://localhost:4173'
+const RELAY_URL_KEY = 'serendipity-voice-relay'
+const POLL_INTERVAL_MS = 1200
+const FX_REGIONS: FxRegion[] = ['header', 'sheet', 'page', 'hand']
+
+export const useSerendipityVoiceStore = defineStore(
+  'serendipityVoiceStore',
+  () => {
+    const animationStore = useAnimationStore()
+
+    const relayBaseUrl = ref<string>(DEFAULT_RELAY_URL)
+    const connected = ref(false)
+    const polling = ref(false)
+    const lastError = ref<string | null>(null)
+    const lastAppliedText = ref<string | null>(null)
+
+    const messages = ref<VoiceBusMessage[]>([])
+    const commandCursor = ref(0)
+    const messageCursor = ref(0)
+
+    const pollTimer = ref<ReturnType<typeof setInterval> | null>(null)
+
+    const recentMessages = computed(() => messages.value.slice(-40))
+
+    function isClient(): boolean {
+      return typeof window !== 'undefined'
+    }
+
+    function loadRelayUrl(): void {
+      if (!isClient()) return
+      const saved = window.localStorage.getItem(RELAY_URL_KEY)
+      if (saved) relayBaseUrl.value = saved
+    }
+
+    function setRelayBaseUrl(url: string): void {
+      relayBaseUrl.value = url.trim().replace(/\/+$/, '') || DEFAULT_RELAY_URL
+      if (isClient())
+        window.localStorage.setItem(RELAY_URL_KEY, relayBaseUrl.value)
+    }
+
+    function pushLocalMessage(role: VoiceBusRole, text: string): void {
+      // Local-only feed entries (for example an applied-effect note) get a
+      // negative id so they never collide with server-assigned ids.
+      const id = -(messages.value.length + 1)
+      messages.value.push({ id, role, text, at: new Date().toISOString() })
+    }
+
+    // Map a spoken effect ("butterflies") to a real Kind Robots effect id. Prefer
+    // the id the voice runtime guessed; otherwise resolve by id/label substring so
+    // an unknown alias still has a chance to land on the right effect.
+    function resolveEffectId(
+      command: VoiceBusCommand,
+    ): AnimationEffectId | null {
+      const byId = animationStore.effects.find(
+        (effect) => effect.id === command.effectId,
+      )
+      if (byId) return byId.id
+
+      const slug = (command.effect ?? '').toLowerCase().trim()
+      if (!slug) return null
+
+      const singular = slug.replace(/s$/, '')
+      const match = animationStore.effects.find((effect) => {
+        const id = effect.id.toLowerCase()
+        const label = effect.label.toLowerCase()
+        return (
+          id.includes(slug) ||
+          label.includes(slug) ||
+          id.includes(singular) ||
+          label.includes(singular)
+        )
+      })
+
+      return match ? match.id : null
+    }
+
+    function normalizeRegion(surface?: string): FxRegion {
+      return FX_REGIONS.includes(surface as FxRegion)
+        ? (surface as FxRegion)
+        : 'page'
+    }
+
+    function applyCommand(command: VoiceBusCommand): void {
+      if (command.target !== 'animation') {
+        pushLocalMessage(
+          'system',
+          `Ignored unsupported command target: ${command.target}`,
+        )
+        return
+      }
+
+      if (command.action === 'clear') {
+        animationStore.clearScreenEffects()
+        lastAppliedText.value = 'Cleared all animations'
+        pushLocalMessage('system', 'Applied: cleared all animations.')
+        void postAck('Serendipity view: cleared all animations.')
+        return
+      }
+
+      const effectId = resolveEffectId(command)
+      if (!effectId) {
+        const message = `Could not match animation "${command.effect ?? command.effectId ?? 'unknown'}".`
+        lastError.value = message
+        pushLocalMessage('system', message)
+        return
+      }
+
+      const active = animationStore.isScreenEffectActive(effectId)
+      if (command.action === 'on' && !active)
+        animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'off' && active)
+        animationStore.toggleScreenEffect(effectId)
+      else if (command.action === 'toggle')
+        animationStore.toggleScreenEffect(effectId)
+
+      if (command.action !== 'off') {
+        animationStore.setSurfacePlacement(
+          normalizeRegion(command.surface),
+          'front',
+        )
+      }
+
+      const verb =
+        command.action === 'off'
+          ? 'off'
+          : command.action === 'toggle'
+            ? 'toggled'
+            : 'on'
+      lastAppliedText.value = `${effectId} ${verb}`
+      pushLocalMessage('system', `Applied: ${effectId} ${verb}.`)
+      void postAck(`Serendipity view: ${effectId} is now ${verb}.`)
+    }
+
+    async function pollOnce(): Promise<void> {
+      if (!isClient()) return
+
+      try {
+        const [commandsRes, messagesRes] = await Promise.all([
+          fetch(
+            `${relayBaseUrl.value}/api/commands?since=${commandCursor.value}`,
+          ),
+          fetch(
+            `${relayBaseUrl.value}/api/messages?since=${messageCursor.value}`,
+          ),
+        ])
+
+        if (!commandsRes.ok || !messagesRes.ok) {
+          throw new Error(
+            `Relay responded ${commandsRes.status}/${messagesRes.status}`,
+          )
+        }
+
+        const commandsData = (await commandsRes.json()) as {
+          commands: VoiceBusCommand[]
+          cursor: number
+        }
+        const messagesData = (await messagesRes.json()) as {
+          messages: VoiceBusMessage[]
+          cursor: number
+        }
+
+        for (const message of messagesData.messages)
+          messages.value.push(message)
+        messageCursor.value = messagesData.cursor
+
+        for (const command of commandsData.commands) applyCommand(command)
+        commandCursor.value = commandsData.cursor
+
+        connected.value = true
+        lastError.value = null
+      } catch (error) {
+        connected.value = false
+        lastError.value =
+          error instanceof Error ? error.message : 'Relay poll failed'
+      }
+    }
+
+    function start(): void {
+      if (!isClient() || polling.value) return
+      loadRelayUrl()
+      polling.value = true
+      void pollOnce()
+      pollTimer.value = setInterval(() => void pollOnce(), POLL_INTERVAL_MS)
+    }
+
+    function stop(): void {
+      polling.value = false
+      connected.value = false
+      if (pollTimer.value) {
+        clearInterval(pollTimer.value)
+        pollTimer.value = null
+      }
+    }
+
+    // Simulate an Echo utterance from the page: routes through the same relay
+    // dispatcher the Alexa endpoint uses, so testing needs no physical device.
+    async function sendVoiceText(text: string): Promise<void> {
+      if (!isClient() || !text.trim()) return
+
+      try {
+        const response = await fetch(`${relayBaseUrl.value}/api/handle`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ text }),
+        })
+        if (!response.ok) throw new Error(`Relay responded ${response.status}`)
+        lastError.value = null
+        await pollOnce()
+      } catch (error) {
+        lastError.value = error instanceof Error ? error.message : 'Send failed'
+      }
+    }
+
+    async function postAck(text: string): Promise<void> {
+      if (!isClient()) return
+      try {
+        await fetch(`${relayBaseUrl.value}/api/messages`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ role: 'view', text }),
+        })
+      } catch {
+        // Acknowledgements are best-effort; a failed ack must not break the view.
+      }
+    }
+
+    return {
+      relayBaseUrl,
+      connected,
+      polling,
+      lastError,
+      lastAppliedText,
+      messages,
+      recentMessages,
+      setRelayBaseUrl,
+      start,
+      stop,
+      pollOnce,
+      sendVoiceText,
+      applyCommand,
+    }
+  },
+)


### PR DESCRIPTION
Adds the Kind Robots side of the Serendipity voice bridge. The new **`/serendipity-voice`** page connects to the local serendipity-voice relay, shows the shared message feed, and applies spoken commands to the app. Saying "Serendipity, turn butterflies on" toggles the butterfly screen animation via `animationStore` (rendered app-wide through `fx-region`).

## Changes
- **stores/serendipityVoiceStore.ts**: polls the relay for commands + messages, resolves spoken effect names to real effect ids, drives `animationStore.toggleScreenEffect` / `setSurfacePlacement`. Client-only, best-effort acks; no data writes.
- **components/pages/serendipity-voice-page.vue**: the view (connection status, relay URL, simulate box, live message feed, active-animation panel).
- **content/serendipity-voice.md**: routes the page at `/serendipity-voice`.

## Verification
`npm run test` (vue-tsc), eslint, and prettier all green. End-to-end butterfly toggle confirmed against the live relay (0 → 20 → 0, no console errors). The `animationStore` path it drives is the same one `screen-fx.vue` uses.

## Safety
Toggles reversible visual effects only — no data writes, publishing, or spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_