### PR TITLE
Extend Serendipity Voice view: theme control, art drafts, surprise-me

### DIFF
--- a/components/pages/serendipity-voice-page.vue
+++ b/components/pages/serendipity-voice-page.vue
@@ -164,6 +164,11 @@
           </ul>
         </div>
 
+        <div class="border-t border-base-300 pt-2">
+          <p class="text-xs font-bold uppercase text-base-content/60">Theme</p>
+          <p class="mt-1 text-sm font-semibold">{{ currentTheme }}</p>
+        </div>
+
         <div v-if="voice.lastAppliedText" class="text-xs text-success">
           Last applied: {{ voice.lastAppliedText }}
         </div>
@@ -177,6 +182,33 @@
         </p>
       </aside>
     </div>
+
+    <!-- Art drafts (surfaced from voice; never generated or published here) -->
+    <div
+      v-if="voice.artRequests.length > 0"
+      class="rounded-xl border border-base-300 bg-base-200/60 p-3"
+    >
+      <p class="mb-2 text-xs font-bold uppercase text-base-content/60">
+        Art drafts from voice ({{ voice.artRequests.length }})
+      </p>
+      <ul class="space-y-2">
+        <li
+          v-for="art in voice.artRequests"
+          :key="art.id"
+          class="rounded-lg border border-base-300 bg-base-100 p-2"
+        >
+          <p class="text-sm font-semibold">“{{ art.prompt }}”</p>
+          <p class="mt-0.5 text-xs text-base-content/60">
+            style: {{ art.style || '—' }} · size: {{ art.size || '—' }} ·
+            gallery: {{ art.gallery || '—' }}
+          </p>
+        </li>
+      </ul>
+      <p class="mt-2 text-[0.7rem] leading-snug text-base-content/50">
+        Drafts only — review here, then generate through the normal Kind Robots
+        art flow. Voice never generates or publishes images on its own.
+      </p>
+    </div>
   </section>
 </template>
 
@@ -187,9 +219,11 @@ import {
   type VoiceBusRole,
 } from '@/stores/serendipityVoiceStore'
 import { useAnimationStore } from '@/stores/animationStore'
+import { useThemeStore } from '@/stores/themeStore'
 
 const voice = useSerendipityVoiceStore()
 const animationStore = useAnimationStore()
+const themeStore = useThemeStore()
 
 const relayInput = ref(voice.relayBaseUrl)
 const utterance = ref('Serendipity, turn butterflies on')
@@ -197,11 +231,15 @@ const utterance = ref('Serendipity, turn butterflies on')
 const quickPhrases = [
   'Serendipity, turn butterflies on',
   'Serendipity, turn butterflies off',
-  'Serendipity, change the animation to fireflies',
+  'Serendipity, surprise me',
+  'Serendipity, set theme to synthwave',
+  'Serendipity, use the retro theme',
+  'Serendipity, generate art of a robot fox painting a portal',
   'Serendipity, turn off all animations',
 ]
 
 const activeEffects = computed(() => animationStore.screenEffects)
+const currentTheme = computed(() => themeStore.currentTheme)
 
 function roleClass(role: VoiceBusRole): string {
   if (role === 'voice') return 'bg-primary/20 text-primary'

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -15,6 +15,7 @@ import {
   type AnimationEffectId,
   type FxRegion,
 } from '@/stores/animationStore'
+import { useThemeStore } from '@/stores/themeStore'
 
 export type VoiceBusRole = 'voice' | 'view' | 'system'
 
@@ -28,12 +29,28 @@ export type VoiceBusMessage = {
 export type VoiceBusCommand = {
   id: number
   target: string
-  action: 'on' | 'off' | 'toggle' | 'clear'
+  action: 'on' | 'off' | 'toggle' | 'clear' | 'set' | 'draft'
   effect?: string
   effectId?: string
   surface?: string
+  theme?: string
+  prompt?: string
+  style?: string
+  size?: string
+  gallery?: string
   spokenText: string
   source: string
+  at: string
+}
+
+// An art draft surfaced on the view for review. Voice never generates or
+// publishes images — this is display + a manual handoff only.
+export type VoiceArtRequest = {
+  id: number
+  prompt: string
+  style?: string
+  size?: string
+  gallery?: string
   at: string
 }
 
@@ -46,6 +63,7 @@ export const useSerendipityVoiceStore = defineStore(
   'serendipityVoiceStore',
   () => {
     const animationStore = useAnimationStore()
+    const themeStore = useThemeStore()
 
     const relayBaseUrl = ref<string>(DEFAULT_RELAY_URL)
     const connected = ref(false)
@@ -54,6 +72,7 @@ export const useSerendipityVoiceStore = defineStore(
     const lastAppliedText = ref<string | null>(null)
 
     const messages = ref<VoiceBusMessage[]>([])
+    const artRequests = ref<VoiceArtRequest[]>([])
     const commandCursor = ref(0)
     const messageCursor = ref(0)
 
@@ -98,6 +117,13 @@ export const useSerendipityVoiceStore = defineStore(
       const slug = (command.effect ?? '').toLowerCase().trim()
       if (!slug) return null
 
+      // "surprise me" — pick a random generation-safe effect.
+      if (slug === 'surprise') {
+        const pool = animationStore.safeEffects
+        const pick = pool[Math.floor(Math.random() * pool.length)]
+        return pick ? pick.id : null
+      }
+
       const singular = slug.replace(/s$/, '')
       const match = animationStore.effects.find((effect) => {
         const id = effect.id.toLowerCase()
@@ -119,7 +145,53 @@ export const useSerendipityVoiceStore = defineStore(
         : 'page'
     }
 
+    function applyThemeCommand(command: VoiceBusCommand): void {
+      const theme = (command.theme ?? '').trim()
+      if (!theme) {
+        pushLocalMessage('system', 'Theme command had no theme name.')
+        return
+      }
+
+      void themeStore.setActiveTheme(theme).then((result) => {
+        if (result.success) {
+          lastAppliedText.value = `theme → ${theme}`
+          pushLocalMessage('system', `Applied: theme set to ${theme}.`)
+          void postAck(`Serendipity view: theme is now ${theme}.`)
+        } else {
+          const message = result.message ?? `Unknown theme "${theme}".`
+          lastError.value = message
+          pushLocalMessage('system', message)
+        }
+      })
+    }
+
+    function applyArtCommand(command: VoiceBusCommand): void {
+      // Draft only: surface the request for review. Never generate or publish.
+      const request: VoiceArtRequest = {
+        id: command.id,
+        prompt: command.prompt ?? command.spokenText,
+        at: command.at,
+      }
+      if (command.style) request.style = command.style
+      if (command.size) request.size = command.size
+      if (command.gallery) request.gallery = command.gallery
+
+      artRequests.value.push(request)
+      lastAppliedText.value = `art draft: ${request.prompt}`
+      pushLocalMessage('system', `Art draft received: ${request.prompt}`)
+    }
+
     function applyCommand(command: VoiceBusCommand): void {
+      if (command.target === 'theme') {
+        applyThemeCommand(command)
+        return
+      }
+
+      if (command.target === 'art') {
+        applyArtCommand(command)
+        return
+      }
+
       if (command.target !== 'animation') {
         pushLocalMessage(
           'system',
@@ -271,6 +343,7 @@ export const useSerendipityVoiceStore = defineStore(
       lastAppliedText,
       messages,
       recentMessages,
+      artRequests,
       setRelayBaseUrl,
       start,
       stop,


### PR DESCRIPTION
Broadens `serendipityVoiceStore` and the `/serendipity-voice` page to match the extended voice bridge.

## Changes
- **stores/serendipityVoiceStore.ts**: `applyCommand` dispatches by target (`animation | theme | art`). Theme commands call `themeStore.setActiveTheme`; art commands push a draft to a new `artRequests` list; "surprise" picks a random generation-safe effect. All reversible/client-side; art never generates.
- **components/pages/serendipity-voice-page.vue**: theme/surprise/art quick phrases, current-theme readout, and an art-drafts review panel.

## Verification
`npm run test` (vue-tsc), eslint, and prettier green; headless-browser proof of theme switch + art draft + "surprise" on top of butterflies, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_