### PR TITLE
Optimize Flux model defaults for better image quality

### DIFF
--- a/server/api/comfy/flux/generate.post.ts
+++ b/server/api/comfy/flux/generate.post.ts
@@ -65,12 +65,19 @@ type ComfyImageOutput = {
 const defaultTimeoutMs = 180_000
 const pollIntervalMs = 1_500
 
+// Flux is trained at ~1 megapixel. Rendering below that (the old 1024x512 =
+// 0.5MP letterbox) is the #1 cause of cramped, distorted, low-detail output.
+// Default to the native 1MP square; callers can still pass any dimensions
+// (use proper 1MP buckets for other aspect ratios, e.g. 1216x832 for 3:2,
+// 1344x768 for 16:9, 832x1216 for a portrait card).
 const DEFAULT_FLUX_DEV_WIDTH = 1024
-const DEFAULT_FLUX_DEV_HEIGHT = 512
+const DEFAULT_FLUX_DEV_HEIGHT = 1024
 const DEFAULT_FLUX_SCHNELL_WIDTH = 1024
-const DEFAULT_FLUX_SCHNELL_HEIGHT = 512
+const DEFAULT_FLUX_SCHNELL_HEIGHT = 1024
 const DEFAULT_FLUX_SAMPLER = 'euler'
-const DEFAULT_FLUX_SCHEDULER = 'normal'
+// `beta` resolves Flux's flow-matching noise schedule far better than the
+// SD-era `normal` scheduler — crisper detail and cleaner composition.
+const DEFAULT_FLUX_SCHEDULER = 'beta'
 const DEFAULT_DENOISE = 1
 
 const defaultPrompt =
@@ -82,7 +89,9 @@ const fluxModelByVariant = {
     filenamePrefix: 'kindrobots_flux_dev',
     defaultSteps: 30,
     defaultCfg: 1,
-    defaultGuidance: 4,
+    // 3.5 is Flux-dev's aesthetic sweet spot; higher (4+) starts to "burn"
+    // contrast and over-bake detail on general/illustrative prompts.
+    defaultGuidance: 3.5,
   },
   schnell: {
     unetName: 'flux1-schnell-Q8_0.gguf',


### PR DESCRIPTION
## Summary
Updated default parameters for Flux image generation to improve output quality and align with the model's training specifications.

## Key Changes
- **Image dimensions**: Changed default resolution from 1024x512 (0.5MP) to 1024x1024 (1MP) for both Flux Dev and Schnell variants
  - Flux is trained at ~1 megapixel, and rendering below that causes cramped, distorted, low-detail output
  - Added guidance on proper 1MP bucket dimensions for other aspect ratios (e.g., 1216x832 for 3:2, 1344x768 for 16:9)

- **Scheduler**: Changed default from `normal` to `beta` for Flux Dev
  - The `beta` scheduler better resolves Flux's flow-matching noise schedule, resulting in crisper detail and cleaner composition compared to the SD-era `normal` scheduler

- **Guidance scale**: Reduced Flux Dev default from 4.0 to 3.5
  - 3.5 is the aesthetic sweet spot for Flux Dev; higher values (4+) cause contrast to "burn" and over-bake detail on general/illustrative prompts

## Implementation Details
All changes are configuration constants with detailed inline comments explaining the rationale behind each adjustment. These defaults can still be overridden by callers passing custom parameters.

https://claude.ai/code/session_01H3SPBKJU2kRUKHM4thnAFS