### PR TITLE
Fix inspiration/collection slugs to match their folder (parity)

### DIFF
--- a/server/api/dreams/batch.post.ts
+++ b/server/api/dreams/batch.post.ts
@@ -246,20 +246,36 @@ async function createDreamFromInput(
   const shouldCreateCollection = body.createCollection !== false
 
   if (shouldCreateCollection && !artCollectionId) {
-    const collection = await prisma.artCollection.create({
-      data: {
-        label: `${title} Inspiration`,
-        description: `Card, icon, hero, screenshots, mockups, and inspiration art for ${title}. Drop additional files into public/images/artcollections/${slug}/ and attach matching ArtImage rows to keep this collection in parity with the filesystem.`,
-        imagePath: collectionImagePath(slug, 'card'),
-        artPrompt: normalizeOptionalText(body.artPrompt) ?? null,
-        userId,
-        username: sender,
-        isPublic,
-        isMature,
-      },
-    })
+    // Give the collection the SAME slug as its folder
+    // (public/images/artcollections/{slug}/) so it stays in parity with the
+    // filesystem and folder-sync reuses it instead of creating a duplicate.
+    // Previously slug was left null and later backfilled from the label
+    // ("Sketchy Inspiration" -> "sketchy-inspiration"), which broke the
+    // folder<->collection match. If a collection already claims this slug,
+    // reuse it rather than colliding on the unique slug.
+    const existingBySlug = slug
+      ? await prisma.artCollection.findUnique({ where: { slug }, select: { id: true } })
+      : null
 
-    artCollectionId = collection.id
+    if (existingBySlug) {
+      artCollectionId = existingBySlug.id
+    } else {
+      const collection = await prisma.artCollection.create({
+        data: {
+          ...(slug ? { slug } : {}),
+          label: `${title} Inspiration`,
+          description: `Card, icon, hero, screenshots, mockups, and inspiration art for ${title}. Drop additional files into public/images/artcollections/${slug}/ and attach matching ArtImage rows to keep this collection in parity with the filesystem.`,
+          imagePath: collectionImagePath(slug, 'card'),
+          artPrompt: normalizeOptionalText(body.artPrompt) ?? null,
+          userId,
+          username: sender,
+          isPublic,
+          isMature,
+        },
+      })
+
+      artCollectionId = collection.id
+    }
   }
 
   const scenarioIds = normalizeScenarioIds(body)

--- a/server/api/dreams/index.post.ts
+++ b/server/api/dreams/index.post.ts
@@ -88,18 +88,30 @@ export default defineEventHandler(async (event) => {
     let artCollectionId = normalizeNullableId(body.artCollectionId)
 
     if (body.createCollection && !artCollectionId) {
-      const collection = await prisma.artCollection.create({
-        data: {
-          label: `${title} Collection`,
-          description: `Curated art for ${title}`,
-          userId: user.id,
-          username: sender,
-          isPublic,
-          isMature,
-        },
-      })
+      // Set slug = the dream slug so the collection matches its folder and
+      // folder-sync reuses it (see batch.post.ts). Never leave slug null to be
+      // backfilled from the label. Reuse an existing collection on this slug.
+      const existingBySlug = slug
+        ? await prisma.artCollection.findUnique({ where: { slug }, select: { id: true } })
+        : null
 
-      artCollectionId = collection.id
+      if (existingBySlug) {
+        artCollectionId = existingBySlug.id
+      } else {
+        const collection = await prisma.artCollection.create({
+          data: {
+            ...(slug ? { slug } : {}),
+            label: `${title} Collection`,
+            description: `Curated art for ${title}`,
+            userId: user.id,
+            username: sender,
+            isPublic,
+            isMature,
+          },
+        })
+
+        artCollectionId = collection.id
+      }
     }
 
     const scenarioIds = normalizeScenarioIds(body)

--- a/utils/scripts/backfillSlugs.ts
+++ b/utils/scripts/backfillSlugs.ts
@@ -43,10 +43,30 @@ function isGeneratedLabel(label: string): boolean {
   return GENERATED_LABEL_PATTERNS.some((pattern) => pattern.test(label.trim()))
 }
 
+// The folder collection convention is that slug === the folder name under
+// public/images/. imagePath points at a file in that folder, so the folder
+// (the last directory segment) is the authoritative slug — NOT the label.
+// Deriving from the label appended " Inspiration"/" Collection" and produced
+// mismatches like "sketchy-inspiration" for a folder named "sketchy".
+function folderSlugFromImagePath(imagePath: string | null): string | null {
+  if (!imagePath) return null
+  const parts = imagePath.split('/').filter(Boolean)
+  // Drop a trailing filename (has an extension) to land on its folder.
+  if (parts.length && /\.[a-z0-9]+$/i.test(parts[parts.length - 1] ?? '')) parts.pop()
+  const last = parts[parts.length - 1]
+  return last && /^[a-z0-9][a-z0-9_-]*$/.test(last) ? last : null
+}
+
+// Fallback when there's no usable imagePath: slugify the label but strip the
+// auto-appended collection suffix so it still matches the intended folder.
+function slugFromLabel(label: string): string {
+  return slugify(label).replace(/-(inspiration|collection)$/i, '')
+}
+
 async function planArtCollections(taken: Set<string>): Promise<Plan[]> {
   const rows = await prisma.artCollection.findMany({
     where: { slug: null },
-    select: { id: true, userId: true, label: true },
+    select: { id: true, userId: true, label: true, imagePath: true },
     orderBy: { id: 'asc' },
   })
 
@@ -59,7 +79,10 @@ async function planArtCollections(taken: Set<string>): Promise<Plan[]> {
     const generated = isGeneratedLabel(label)
     if (generated && !ALL_COLLECTIONS) continue
 
-    const slug = generated ? `${slugify(label)}-u${row.userId}` : slugify(label)
+    // Prefer the folder (imagePath) as the slug source; fall back to the label
+    // with the collection suffix stripped.
+    const base = folderSlugFromImagePath(row.imagePath) || slugFromLabel(label)
+    const slug = generated ? `${base}-u${row.userId}` : base
 
     if (!slug || taken.has(slug)) continue
     taken.add(slug)


### PR DESCRIPTION
## The bug

Art collections auto-created for Dreams/inspiration were saved with **no `slug`**. The one-time slug backfill then derived the slug from the **label** — and the label is `"${title} Inspiration"` — so `slugify("Sketchy Inspiration")` → **`sketchy-inspiration`**, which never matches the actual folder `public/images/artcollections/sketchy/`. Result: the collection and its folder don't line up, and folder-sync creates a *second* collection at the real slug.

## Fix (root cause, prevents recurrence)

- **`server/api/dreams/batch.post.ts`** & **`server/api/dreams/index.post.ts`**: set `slug = <dream slug>` at creation time (e.g. `sketchy`), so the collection matches its folder from birth. If a collection already claims that slug, reuse it instead of colliding on the unique constraint. Slug is never left null to be mis-backfilled.
- **`utils/scripts/backfillSlugs.ts`**: derive the ArtCollection slug from the **folder in `imagePath`** (the authoritative source per the folder-collection convention), falling back to the label with a trailing `-inspiration`/`-collection` stripped. So even if it's ever run again, it produces `sketchy`, not `sketchy-inspiration`.

Existing mismatched rows are being cleaned up manually (only a handful); this stops new ones from being created.

## Verification

`npm test` (nuxi prepare + vue-tsc `--noEmit`) passes clean; eslint clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_