### PR TITLE
Rescue challenge-center contenders migration (t-002)

### DIFF
--- a/docs/challenge-center-t-002-schema-patch.md
+++ b/docs/challenge-center-t-002-schema-patch.md
@@ -1,0 +1,111 @@
+# Challenge Center t-002 schema patch handoff
+
+This connector run could create the additive migration file, but it could not safely replace the full `prisma/schema.prisma` through the contents API without a patch-capable checkout. Apply the schema changes below in the same PR before merging or regenerate them with Prisma from the migration.
+
+## Intended branch
+
+`worker/challenge-center-t-002`
+
+## Migration already added
+
+`prisma/migrations/20260706121000_add_challenge_contenders/migration.sql`
+
+The migration:
+
+- Creates `Contender` with `slug`, `name`, `kind`, provider/model/generator metadata, nullable `avatarImageId`, `defaultSettings`, `description`, and `isActive`.
+- Adds `contenderId`, `variantKey`, `promptUsed`, `settings`, and `randomSelections` to `ChallengeSubmission`.
+- Makes `ChallengeSubmission.botId` nullable instead of dropping it.
+- Replaces the old unique `(challengeId, botId)` index with `(challengeId, contenderId, variantKey)`.
+- Adds only indexes and foreign keys, plus one `DROP INDEX`; it does not drop tables, columns, or data.
+
+## Required schema.prisma patch
+
+Add a relation from `ArtImage` to contenders near the existing challenge relations:
+
+```prisma
+  Contenders           Contender[]
+```
+
+Add the Contender model near the Challenge Center section:
+
+```prisma
+enum ContenderKind {
+  AGENT_STACK
+  LLM_MODEL
+  ART_GENERATOR
+}
+
+model Contender {
+  id              Int           @id @default(autoincrement())
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime?     @default(now()) @updatedAt
+  slug            String        @unique @db.VarChar(255)
+  name            String        @db.VarChar(255)
+  kind            ContenderKind
+  provider        String?       @db.VarChar(128)
+  model           String?       @db.VarChar(255)
+  generator       String?       @db.VarChar(128)
+  defaultSettings Json?
+  description     String?       @db.Text
+  avatarImageId   Int?
+  isActive        Boolean       @default(true)
+
+  AvatarImage ArtImage?             @relation(fields: [avatarImageId], references: [id])
+  Submissions ChallengeSubmission[]
+
+  @@index([kind])
+  @@index([provider])
+  @@index([model])
+  @@index([generator])
+  @@index([isActive])
+  @@index([avatarImageId], map: "Contender_avatarImageId_fkey")
+}
+```
+
+Update `ChallengeSubmission`:
+
+```prisma
+model ChallengeSubmission {
+  id               Int                       @id @default(autoincrement())
+  createdAt        DateTime                  @default(now())
+  updatedAt        DateTime?                 @default(now()) @updatedAt
+  challengeId      Int
+  botId            Int?
+  contenderId      Int?
+  variantKey       String                    @default("default") @db.VarChar(128)
+  promptUsed       String?                   @db.Text
+  settings         Json?
+  randomSelections Json?
+  agentModel       String?                   @db.VarChar(256)
+  outputText       String?                   @db.Text
+  artImageId       Int?
+  characterId      Int?
+  scenarioId       Int?
+  status           ChallengeSubmissionStatus @default(READY)
+  Challenge        Challenge                 @relation(fields: [challengeId], references: [id])
+  Bot              Bot?                      @relation(fields: [botId], references: [id])
+  Contender        Contender?                @relation(fields: [contenderId], references: [id])
+  ArtImage         ArtImage?                 @relation(fields: [artImageId], references: [id])
+  Character        Character?                @relation(fields: [characterId], references: [id])
+  Scenario         Scenario?                 @relation(fields: [scenarioId], references: [id])
+  Reactions        Reaction[]
+
+  @@unique([challengeId, contenderId, variantKey])
+  @@index([botId], map: "ChallengeSubmission_botId_fkey")
+  @@index([contenderId], map: "ChallengeSubmission_contenderId_fkey")
+  @@index([artImageId], map: "ChallengeSubmission_artImageId_fkey")
+  @@index([characterId], map: "ChallengeSubmission_characterId_fkey")
+  @@index([scenarioId], map: "ChallengeSubmission_scenarioId_fkey")
+}
+```
+
+## Verification still needed
+
+Run from a real checkout:
+
+```bash
+npx prisma validate
+npx prisma generate
+```
+
+Then inspect the generated migration if regenerated. It must remain additive except for the `DROP INDEX` index swap; no `DROP TABLE`, `DROP COLUMN`, or data rewrite should appear.

--- a/prisma/migrations/20260706121000_add_challenge_contenders/migration.sql
+++ b/prisma/migrations/20260706121000_add_challenge_contenders/migration.sql
@@ -1,0 +1,52 @@
+-- CreateEnum is represented as an inline MySQL ENUM on Contender.kind.
+-- This migration is intentionally additive except for the unique-index swap on ChallengeSubmission.
+
+-- CreateTable
+CREATE TABLE `Contender` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `slug` VARCHAR(255) NOT NULL,
+    `name` VARCHAR(255) NOT NULL,
+    `kind` ENUM('AGENT_STACK', 'LLM_MODEL', 'ART_GENERATOR') NOT NULL,
+    `provider` VARCHAR(128) NULL,
+    `model` VARCHAR(255) NULL,
+    `generator` VARCHAR(128) NULL,
+    `defaultSettings` JSON NULL,
+    `description` TEXT NULL,
+    `avatarImageId` INTEGER NULL,
+    `isActive` BOOLEAN NOT NULL DEFAULT true,
+
+    UNIQUE INDEX `Contender_slug_key`(`slug`),
+    INDEX `Contender_kind_idx`(`kind`),
+    INDEX `Contender_provider_idx`(`provider`),
+    INDEX `Contender_model_idx`(`model`),
+    INDEX `Contender_generator_idx`(`generator`),
+    INDEX `Contender_isActive_idx`(`isActive`),
+    INDEX `Contender_avatarImageId_fkey`(`avatarImageId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AlterTable
+ALTER TABLE `ChallengeSubmission`
+    ADD COLUMN `contenderId` INTEGER NULL,
+    ADD COLUMN `variantKey` VARCHAR(128) NOT NULL DEFAULT 'default',
+    ADD COLUMN `promptUsed` TEXT NULL,
+    ADD COLUMN `settings` JSON NULL,
+    ADD COLUMN `randomSelections` JSON NULL,
+    MODIFY `botId` INTEGER NULL;
+
+-- DropIndex
+DROP INDEX `ChallengeSubmission_challengeId_botId_key` ON `ChallengeSubmission`;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `ChallengeSubmission_challengeId_contenderId_variantKey_key` ON `ChallengeSubmission`(`challengeId`, `contenderId`, `variantKey`);
+
+-- CreateIndex
+CREATE INDEX `ChallengeSubmission_contenderId_fkey` ON `ChallengeSubmission`(`contenderId`);
+
+-- AddForeignKey
+ALTER TABLE `Contender` ADD CONSTRAINT `Contender_avatarImageId_fkey` FOREIGN KEY (`avatarImageId`) REFERENCES `ArtImage`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ChallengeSubmission` ADD CONSTRAINT `ChallengeSubmission_contenderId_fkey` FOREIGN KEY (`contenderId`) REFERENCES `Contender`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model ArtImage {
   Prompts              Prompt[]
   Reactions            Reaction[]
   ChallengeSubmissions ChallengeSubmission[]
+  Contenders           Contender[]
   Resources            Resource[]            @relation("ResourcePreviewImage")
   LoraResources        Resource[]            @relation("ArtImageLoraResources")
   Rewards              Reward[]
@@ -1693,30 +1694,69 @@ model Challenge {
 }
 
 model ChallengeSubmission {
-  id          Int                       @id @default(autoincrement())
-  createdAt   DateTime                  @default(now())
-  updatedAt   DateTime?                 @default(now()) @updatedAt
-  challengeId Int
-  botId       Int
-  agentModel  String?                   @db.VarChar(256)
-  outputText  String?                   @db.Text
-  artImageId  Int?
-  characterId Int?
-  scenarioId  Int?
-  status      ChallengeSubmissionStatus @default(READY)
-  Challenge   Challenge                 @relation(fields: [challengeId], references: [id])
-  Bot         Bot                       @relation(fields: [botId], references: [id])
-  ArtImage    ArtImage?                 @relation(fields: [artImageId], references: [id])
-  Character   Character?                @relation(fields: [characterId], references: [id])
-  Scenario    Scenario?                 @relation(fields: [scenarioId], references: [id])
-  Reactions   Reaction[]
+  id               Int                       @id @default(autoincrement())
+  createdAt        DateTime                  @default(now())
+  updatedAt        DateTime?                 @default(now()) @updatedAt
+  challengeId      Int
+  botId            Int?
+  contenderId      Int?
+  variantKey       String                    @default("default") @db.VarChar(128)
+  promptUsed       String?                   @db.Text
+  settings         Json?
+  randomSelections Json?
+  agentModel       String?                   @db.VarChar(256)
+  outputText       String?                   @db.Text
+  artImageId       Int?
+  characterId      Int?
+  scenarioId       Int?
+  status           ChallengeSubmissionStatus @default(READY)
+  Challenge        Challenge                 @relation(fields: [challengeId], references: [id])
+  Bot              Bot?                      @relation(fields: [botId], references: [id])
+  Contender        Contender?                @relation(fields: [contenderId], references: [id])
+  ArtImage         ArtImage?                 @relation(fields: [artImageId], references: [id])
+  Character        Character?                @relation(fields: [characterId], references: [id])
+  Scenario         Scenario?                 @relation(fields: [scenarioId], references: [id])
+  Reactions        Reaction[]
 
-  // One submission per agent per challenge.
-  @@unique([challengeId, botId])
+  // One submission per contender variant per challenge.
+  @@unique([challengeId, contenderId, variantKey])
   @@index([botId], map: "ChallengeSubmission_botId_fkey")
+  @@index([contenderId], map: "ChallengeSubmission_contenderId_fkey")
   @@index([artImageId], map: "ChallengeSubmission_artImageId_fkey")
   @@index([characterId], map: "ChallengeSubmission_characterId_fkey")
   @@index([scenarioId], map: "ChallengeSubmission_scenarioId_fkey")
+}
+
+enum ContenderKind {
+  AGENT_STACK
+  LLM_MODEL
+  ART_GENERATOR
+}
+
+model Contender {
+  id              Int           @id @default(autoincrement())
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime?     @default(now()) @updatedAt
+  slug            String        @unique @db.VarChar(255)
+  name            String        @db.VarChar(255)
+  kind            ContenderKind
+  provider        String?       @db.VarChar(128)
+  model           String?       @db.VarChar(255)
+  generator       String?       @db.VarChar(128)
+  defaultSettings Json?
+  description     String?       @db.Text
+  avatarImageId   Int?
+  isActive        Boolean       @default(true)
+
+  AvatarImage ArtImage?             @relation(fields: [avatarImageId], references: [id])
+  Submissions ChallengeSubmission[]
+
+  @@index([kind])
+  @@index([provider])
+  @@index([model])
+  @@index([generator])
+  @@index([isActive])
+  @@index([avatarImageId], map: "Contender_avatarImageId_fkey")
 }
 
 // ── Da Vinci (da-vinci project) ──────────────────────────────────────────────────


### PR DESCRIPTION
## What

Recovers the challenge-**contenders** work that was stranded on the stale `worker/challenge-center-t-002` branch. That branch had fallen so far behind `main` it could no longer be merged without reverting ~150 files of newer work, so this rebuilds it cleanly on current `main`.

- **`prisma/migrations/20260706121000_add_challenge_contenders/migration.sql`** (verbatim from the original branch): creates the `Contender` table; adds `contenderId`, `variantKey`, `promptUsed`, `settings`, `randomSelections` to `ChallengeSubmission`; makes `botId` nullable; swaps the `(challengeId, botId)` unique index for `(challengeId, contenderId, variantKey)`. Additive except that one index swap — no `DROP TABLE`/`DROP COLUMN`/data rewrite.
- **`prisma/schema.prisma`**: applies the schema patch the original handoff doc specified (the connector run at the time couldn't write `schema.prisma`) — `ContenderKind` enum, `Contender` model, `ArtImage.Contenders` back-relation, and the `ChallengeSubmission` field/relation/index updates. Current `main`'s `ChallengeSubmission` matched the doc's pre-image exactly, so the patch applies cleanly.
- **`docs/challenge-center-t-002-schema-patch.md`**: the original handoff notes.

## ⚠️ Before merge

This offline environment can't install the pinned Prisma CLI, so validation is deferred to a real checkout (exactly as the handoff doc instructs):

```bash
npx prisma validate
npx prisma generate
```

Once this lands, the old `worker/challenge-center-t-002` branch can be deleted (recovery SHA `1cfce4a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3SPBKJU2kRUKHM4thnAFS)_