### PR TITLE
Bulk folder-collection sync: orphan folders → DB collections

### DIFF
--- a/server/api/art/collection/folder/[slug]/sync.post.ts
+++ b/server/api/art/collection/folder/[slug]/sync.post.ts
@@ -16,38 +16,13 @@ import {
   getRequestURL,
   createError,
 } from 'h3'
-import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireMachineUser } from '~/server/utils/authGuard'
+import { SLUG_PATTERN } from '~/server/utils/folderCollections'
 import {
-  resolveFolderImages,
-  SLUG_PATTERN,
-} from '~/server/utils/folderCollections'
-
-// ArtImage.imagePath is the default VarChar(191) (unlike `path`/`fileName`,
-// which are VarChar(764)). A deeply-nested long slug URL can exceed 191 chars
-// and would throw on insert, failing the whole sync. We guard by skipping any
-// URL that would overflow and reporting it, rather than crashing (t-017).
-// Permanent fix is to widen the column to VarChar(764); until that migration
-// lands, this keeps the endpoint safe.
-const MAX_IMAGE_PATH = 191
-
-function labelFromSlug(slug: string): string {
-  return slug
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-}
-
-function fileNameFromUrl(url: string): string {
-  const name = url.split('/').pop() || url
-  return name.slice(0, 764)
-}
-
-function fileTypeFromUrl(url: string): string {
-  return url.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] || 'png'
-}
+  syncFolderCollection,
+  MAX_IMAGE_PATH,
+} from '~/server/utils/syncFolderCollection'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -62,75 +37,16 @@ export default defineEventHandler(async (event) => {
     }
 
     const origin = getRequestURL(event).origin
-    const images = await resolveFolderImages(slug, origin)
+    const result = await syncFolderCollection(slug, origin, auth.user.id)
 
-    if (images === null || images.length === 0) {
+    if (!result) {
       throw createError({
         statusCode: 404,
         message: `No folder collection found for "${slug}" - nothing to sync.`,
       })
     }
 
-    // Ensure the collection exists (keyed on the unique slug).
-    let collection = await prisma.artCollection.findUnique({
-      where: { slug },
-      select: { id: true, ArtImages: { select: { id: true, imagePath: true } } },
-    })
-
-    if (!collection) {
-      const created = await prisma.artCollection.create({
-        data: {
-          slug,
-          label: labelFromSlug(slug),
-          description: `Folder collection synced from public/images/ (${slug}).`,
-          userId: auth.user.id,
-          isPublic: true,
-        },
-        select: { id: true },
-      })
-      collection = { id: created.id, ArtImages: [] }
-    }
-
-    const existingPaths = new Set(
-      collection.ArtImages.map((image) => image.imagePath).filter(
-        (p): p is string => typeof p === 'string',
-      ),
-    )
-
-    const toCreate = images.filter((url) => !existingPaths.has(url))
-
-    // Split off any URL that would overflow ArtImage.imagePath (VarChar(191))
-    // so a single pathological path can't fail the whole batch insert.
-    const toCreateSafe = toCreate.filter((url) => url.length <= MAX_IMAGE_PATH)
-    const skipped = toCreate.length - toCreateSafe.length
-    if (skipped > 0) {
-      console.warn(
-        `[folder-sync:${slug}] skipped ${skipped} image(s) whose imagePath exceeds ${MAX_IMAGE_PATH} chars.`,
-      )
-    }
-
-    // Batch: create every new ArtImage and connect it to the collection in a
-    // single nested write, instead of 2 queries per image in a loop.
-    if (toCreateSafe.length > 0) {
-      await prisma.artCollection.update({
-        where: { id: collection.id },
-        data: {
-          ArtImages: {
-            create: toCreateSafe.map((url) => ({
-              imagePath: url,
-              path: url.slice(0, 764),
-              fileName: fileNameFromUrl(url),
-              fileType: fileTypeFromUrl(url),
-              userId: auth.user.id,
-              isPublic: true,
-              designer: `folder-sync:${slug}`,
-            })),
-          },
-        },
-      })
-    }
-
-    const created = toCreateSafe.length
+    const { created, skipped } = result
 
     return {
       success: true,
@@ -139,14 +55,7 @@ export default defineEventHandler(async (event) => {
         : skipped
           ? `"${slug}": nothing synced; ${skipped} image path(s) exceed the ${MAX_IMAGE_PATH}-char limit.`
           : `"${slug}" already up to date.`,
-      data: {
-        slug,
-        collectionId: collection.id,
-        total: images.length,
-        created,
-        alreadyPresent: images.length - toCreate.length,
-        skipped,
-      },
+      data: result,
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/server/api/art/collection/folders/sync.post.ts
+++ b/server/api/art/collection/folders/sync.post.ts
@@ -1,0 +1,90 @@
+// /server/api/art/collection/folders/sync.post.ts
+//
+// Bulk parity: ensure EVERY folder under public/images/ has a real DB
+// ArtCollection. Enumerates listFolderCollections() and syncs each folder,
+// creating any missing collection at its slug and linking new images. This is
+// the one-shot that brings orphan folders (e.g. `comfy`, freshly-generated
+// batches) into the DB so they show up on every collection surface, not just
+// the folder-aware gallery.
+//
+// Idempotent — safe to run repeatedly; re-running only adds new images and
+// never duplicates a collection (keyed on the unique slug). Machine auth
+// (JWT / user apiKey / beta admin) so the browser and conductor automation can
+// both trigger it, e.g. right after the art pipeline commits new folders.
+//
+// Reuses the exact per-slug routine (syncFolderCollection) so the single-slug
+// and bulk endpoints can never drift apart. Folders are synced sequentially to
+// stay gentle on the DB connection pool.
+import { defineEventHandler, getRequestURL } from 'h3'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import { listFolderCollections } from '~/server/utils/folderCollections'
+import {
+  syncFolderCollection,
+  type FolderSyncResult,
+} from '~/server/utils/syncFolderCollection'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+    const origin = getRequestURL(event).origin
+
+    const folders = await listFolderCollections(origin)
+
+    const results: FolderSyncResult[] = []
+    const failures: { slug: string; error: string }[] = []
+    let createdCollections = 0
+    let createdImages = 0
+    let skipped = 0
+
+    for (const folder of folders) {
+      try {
+        // Pass the already-resolved images so we don't re-list every folder.
+        const result = await syncFolderCollection(
+          folder.slug,
+          origin,
+          auth.user.id,
+          folder.images,
+        )
+        if (!result) continue
+        results.push(result)
+        if (result.createdCollection) createdCollections += 1
+        createdImages += result.created
+        skipped += result.skipped
+      } catch (err) {
+        // One bad folder shouldn't abort the whole sweep — record and continue.
+        failures.push({
+          slug: folder.slug,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
+    return {
+      success: true,
+      message: `Synced ${results.length} folder(s): ${createdCollections} new collection(s), ${createdImages} new image(s)${
+        skipped ? `, ${skipped} over-long path(s) skipped` : ''
+      }${failures.length ? `, ${failures.length} failed` : ''}.`,
+      data: {
+        folders: results.length,
+        createdCollections,
+        createdImages,
+        skipped,
+        failures,
+        results,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to sync folder collections.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/syncFolderCollection.ts
+++ b/server/utils/syncFolderCollection.ts
@@ -1,0 +1,135 @@
+// /server/utils/syncFolderCollection.ts
+//
+// Shared "materialize a folder into a real DB ArtCollection" routine, used by
+// both POST /api/art/collection/folder/[slug]/sync (one slug) and
+// POST /api/art/collection/folders/sync (every folder at once). A folder under
+// public/images/ whose name matches a slug IS that slug's collection
+// (Silas, 2026-07-04); this ensures the ArtCollection row exists at that slug
+// and creates a lightweight ArtImage row (imagePath -> the public URL, no
+// imageData) for every folder image not already linked.
+//
+// Idempotent and keyed on the unique slug: re-running only adds images that
+// appeared since last time, never duplicates an image (dedup by imagePath), and
+// never creates a second collection for the same folder.
+import prisma from '~/server/utils/prisma'
+import { resolveFolderImages } from './folderCollections'
+
+// ArtImage.imagePath is the default VarChar(191) (unlike `path`/`fileName`,
+// which are VarChar(764)). A deeply-nested long slug URL can exceed 191 chars
+// and would throw on insert, failing the whole sync. We guard by skipping any
+// URL that would overflow and reporting it, rather than crashing (t-017).
+export const MAX_IMAGE_PATH = 191
+
+export type FolderSyncResult = {
+  slug: string
+  collectionId: number
+  total: number
+  created: number
+  alreadyPresent: number
+  skipped: number
+  createdCollection: boolean
+}
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function fileNameFromUrl(url: string): string {
+  const name = url.split('/').pop() || url
+  return name.slice(0, 764)
+}
+
+function fileTypeFromUrl(url: string): string {
+  return url.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] || 'png'
+}
+
+/**
+ * Ensure the folder collection for `slug` exists in the DB and its images are
+ * linked. Returns null when the folder has no images (nothing to sync). Pass
+ * `preresolvedImages` to skip a re-fetch when the caller already listed them
+ * (the bulk endpoint gets them for free from listFolderCollections).
+ */
+export async function syncFolderCollection(
+  slug: string,
+  origin: string,
+  userId: number,
+  preresolvedImages?: string[],
+): Promise<FolderSyncResult | null> {
+  const images = preresolvedImages ?? (await resolveFolderImages(slug, origin))
+  if (!images || images.length === 0) return null
+
+  // Ensure the collection exists (keyed on the unique slug).
+  let collection = await prisma.artCollection.findUnique({
+    where: { slug },
+    select: { id: true, ArtImages: { select: { id: true, imagePath: true } } },
+  })
+
+  let createdCollection = false
+  if (!collection) {
+    const created = await prisma.artCollection.create({
+      data: {
+        slug,
+        label: labelFromSlug(slug),
+        description: `Folder collection synced from public/images/ (${slug}).`,
+        userId,
+        isPublic: true,
+      },
+      select: { id: true },
+    })
+    collection = { id: created.id, ArtImages: [] }
+    createdCollection = true
+  }
+
+  const existingPaths = new Set(
+    collection.ArtImages.map((image) => image.imagePath).filter(
+      (p): p is string => typeof p === 'string',
+    ),
+  )
+
+  const toCreate = images.filter((url) => !existingPaths.has(url))
+
+  // Split off any URL that would overflow ArtImage.imagePath (VarChar(191)) so
+  // a single pathological path can't fail the whole batch insert.
+  const toCreateSafe = toCreate.filter((url) => url.length <= MAX_IMAGE_PATH)
+  const skipped = toCreate.length - toCreateSafe.length
+  if (skipped > 0) {
+    console.warn(
+      `[folder-sync:${slug}] skipped ${skipped} image(s) whose imagePath exceeds ${MAX_IMAGE_PATH} chars.`,
+    )
+  }
+
+  // Batch: create every new ArtImage and connect it to the collection in a
+  // single nested write, instead of 2 queries per image in a loop.
+  if (toCreateSafe.length > 0) {
+    await prisma.artCollection.update({
+      where: { id: collection.id },
+      data: {
+        ArtImages: {
+          create: toCreateSafe.map((url) => ({
+            imagePath: url,
+            path: url.slice(0, 764),
+            fileName: fileNameFromUrl(url),
+            fileType: fileTypeFromUrl(url),
+            userId,
+            isPublic: true,
+            designer: `folder-sync:${slug}`,
+          })),
+        },
+      },
+    })
+  }
+
+  return {
+    slug,
+    collectionId: collection.id,
+    total: images.length,
+    created: toCreateSafe.length,
+    alreadyPresent: images.length - toCreate.length,
+    skipped,
+    createdCollection,
+  }
+}

--- a/stores/collectionStore.ts
+++ b/stores/collectionStore.ts
@@ -55,6 +55,17 @@ export type FolderSyncResult = {
   total: number
   created: number
   alreadyPresent: number
+  skipped: number
+  createdCollection: boolean
+}
+
+export type FolderSyncAllResult = {
+  folders: number
+  createdCollections: number
+  createdImages: number
+  skipped: number
+  failures: { slug: string; error: string }[]
+  results: FolderSyncResult[]
 }
 
 type CollectionState = {
@@ -1059,11 +1070,34 @@ export const useCollectionStore = defineStore('collectionStore', () => {
     return response.data
   }
 
+  /**
+   * Bulk parity: ensure every folder under public/images/ has a real DB
+   * ArtCollection. Creates missing collections and links new images, then
+   * refreshes the DB + folder lists so orphan folders (e.g. `comfy`, freshly
+   * generated batches) appear as normal collections on every surface.
+   * Idempotent.
+   */
+  async function syncAllFolderCollections(): Promise<FolderSyncAllResult> {
+    const response = await performFetch<FolderSyncAllResult>(
+      '/api/art/collection/folders/sync',
+      { method: 'POST' },
+    )
+
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Failed to sync folder collections')
+    }
+
+    await fetchCollections(true)
+    await fetchFolderCollections(true)
+    return response.data
+  }
+
   return {
     ...toRefs(state),
 
     fetchFolderCollections,
     syncFolderCollection,
+    syncAllFolderCollections,
 
     selectedCollectionIds,
     selectedCollections,


### PR DESCRIPTION
## Why

Folders under `public/images/` only show up in the collection list if there's a matching DB `ArtCollection` row (or, for the folder-aware `art-gallery.vue`, an entry in `collections.json`). Freshly-generated folders like `comfy` have neither, so they're invisible on most surfaces. There was a per-slug sync but no way to reconcile everything at once.

## What

- **`POST /api/art/collection/folders/sync`** (new): enumerates `listFolderCollections()` and ensures every folder has a real `ArtCollection` at its slug, linking any new images. Machine-auth, idempotent, folders synced sequentially (gentle on the DB pool). Returns a summary: `{ folders, createdCollections, createdImages, skipped, failures, results }`. One bad folder is recorded in `failures` and doesn't abort the sweep.
- **`server/utils/syncFolderCollection.ts`** (new): the per-slug materialize-a-folder routine extracted from `folder/[slug]/sync.post.ts`, so the single-slug and bulk endpoints share one implementation and can't drift. Keeps the VarChar(191) `imagePath` guard.
- **`folder/[slug]/sync.post.ts`**: refactored to call the shared helper (same behavior + response, now also reports `skipped`/`createdCollection`).
- **`collectionStore.ts`**: `syncAllFolderCollections()` action + `FolderSyncAllResult` type (and filled in the `skipped`/`createdCollection` fields the server already returns).

## Running it

One call brings the whole gallery into parity (admin/machine token):

```bash
curl -s -X POST https://<kind-robots-host>/api/art/collection/folders/sync \
  -H "Authorization: Bearer $KR_API_TOKEN"
```

Or from the app: `collectionStore.syncAllFolderCollections()`. Safe to re-run; the conductor art pipeline can call it after committing new folders to keep parity automatic.

## Verification

`npm test` (nuxi prepare + vue-tsc `--noEmit`) clean; eslint clean on all new files (the 4 pre-existing `collectionStore.ts` lint errors are unrelated and predate this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_