### PR TITLE
authGuard: a bad JWT must not block apiKey / admin-token fallbacks

### DIFF
--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -58,7 +58,22 @@ async function getUserById(id: number): Promise<AuthUser | null> {
 async function validateJwtAuth(token: string): Promise<AuthGuardResult | null> {
   if (!token) return null
 
-  const verification = await verifyJwtToken(token)
+  // Only attempt JWT verification on a JWT-shaped token (header.payload.sig).
+  // A user apiKey or beta-admin token is not a JWT; running it through the JWT
+  // verifier just logs a noisy "Operation failed" and — critically — must not
+  // prevent the apiKey/beta-admin fallbacks in requireMachineUser from running.
+  if (token.split('.').length !== 3) return null
+
+  // An expired or otherwise invalid JWT is NOT fatal here: it simply means "not
+  // authenticated via JWT". Swallow any throw so requireMachineUser can fall
+  // through to the apiKey / beta-admin token instead of surfacing a 500/JWT
+  // error to a machine caller that also holds a valid long-lived credential.
+  let verification: Awaited<ReturnType<typeof verifyJwtToken>>
+  try {
+    verification = await verifyJwtToken(token)
+  } catch {
+    return null
+  }
 
   if (!verification.success || !verification.userId) return null
 


### PR DESCRIPTION
## The bug

`requireMachineUser` is meant to accept **any** of: a session JWT, a long-lived user **apiKey**, or the **beta-admin token** — trying them in that order. But `validateJwtAuth` ran *every* bearer token through the JWT verifier. So:

- An **expired JWT** (the home relay's token) threw / short-circuited before the apiKey/admin fallbacks ran.
- A **valid apiKey sent as `Authorization: Bearer`** got fed to the JWT verifier too, and a verifier throw could stop the chain before `validateUserApiKeyAuth` was reached — so a caller with a genuinely valid apiKey still got rejected.

That's why the relay's `queue/claim` **and** the new `folders/sync` failed with `Operation failed: JWTExpired` even when a valid credential was in hand.

## Fix

`validateJwtAuth` now:
1. Only attempts verification on a **JWT-shaped** token (`header.payload.sig` — three dot-segments). A non-JWT apiKey/admin token skips the JWT path entirely.
2. **Swallows any verify error** (expired/invalid) and returns `null`, so `requireMachineUser` cleanly falls through to the apiKey and beta-admin credentials.

Net: machine callers (home relay, conductor scripts, folders-sync) authenticating with an apiKey or the admin token now work, expired JWTs degrade to a clean 401 instead of a 500, and the noisy `Operation failed: JWTExpired` logs from expired session tokens go quiet. The valid-session-JWT happy path is unchanged (a real JWT is 3-part and verifies).

## Verification

`npm test` (nuxi prepare + vue-tsc `--noEmit`) clean; eslint clean on `authGuard.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_