### PR TITLE
folders sync: paginate to avoid FUNCTION_INVOCATION_TIMEOUT

### DIFF
--- a/server/api/art/collection/folders/sync.post.ts
+++ b/server/api/art/collection/folders/sync.post.ts
@@ -1,35 +1,49 @@
 // /server/api/art/collection/folders/sync.post.ts
 //
-// Bulk parity: ensure EVERY folder under public/images/ has a real DB
-// ArtCollection. Enumerates listFolderCollections() and syncs each folder,
-// creating any missing collection at its slug and linking new images. This is
-// the one-shot that brings orphan folders (e.g. `comfy`, freshly-generated
-// batches) into the DB so they show up on every collection surface, not just
-// the folder-aware gallery.
+// Bulk parity: ensure folders under public/images/ have real DB
+// ArtCollections. A full site can have hundreds of folders, and resolving every
+// folder's manifest + writing images in ONE serverless invocation blows the
+// function time limit (FUNCTION_INVOCATION_TIMEOUT). So this endpoint works in
+// bounded PAGES: it lists slugs cheaply (no per-folder image resolution up
+// front), then syncs a slice [offset, offset+limit) and returns `nextOffset` so
+// the caller loops until done. Each call stays comfortably under the timeout.
 //
-// Idempotent — safe to run repeatedly; re-running only adds new images and
-// never duplicates a collection (keyed on the unique slug). Machine auth
-// (JWT / user apiKey / beta admin) so the browser and conductor automation can
-// both trigger it, e.g. right after the art pipeline commits new folders.
-//
-// Reuses the exact per-slug routine (syncFolderCollection) so the single-slug
-// and bulk endpoints can never drift apart. Folders are synced sequentially to
-// stay gentle on the DB connection pool.
-import { defineEventHandler, getRequestURL } from 'h3'
+// Body (all optional): { limit?: number, offset?: number }.
+// Idempotent, machine-auth. Reuses the per-slug routine (syncFolderCollection).
+import { defineEventHandler, getRequestURL, readBody } from 'h3'
 import { errorHandler } from '~/server/utils/error'
 import { requireMachineUser } from '~/server/utils/authGuard'
-import { listFolderCollections } from '~/server/utils/folderCollections'
+import { listFolderSlugs } from '~/server/utils/folderCollections'
 import {
   syncFolderCollection,
   type FolderSyncResult,
 } from '~/server/utils/syncFolderCollection'
+
+// Folders processed per call. Kept modest so one page (its manifest fetches +
+// DB writes) finishes well inside the serverless time budget.
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 50
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, Math.trunc(n)))
+}
 
 export default defineEventHandler(async (event) => {
   try {
     const auth = await requireMachineUser(event)
     const origin = getRequestURL(event).origin
 
-    const folders = await listFolderCollections(origin)
+    const body = (await readBody(event).catch(() => ({}))) as {
+      limit?: unknown
+      offset?: unknown
+    }
+    const limit = clampInt(body?.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
+    const offset = clampInt(body?.offset, 0, 0, Number.MAX_SAFE_INTEGER)
+
+    const slugs = await listFolderSlugs(origin)
+    const slice = slugs.slice(offset, offset + limit)
 
     const results: FolderSyncResult[] = []
     const failures: { slug: string; error: string }[] = []
@@ -37,36 +51,37 @@ export default defineEventHandler(async (event) => {
     let createdImages = 0
     let skipped = 0
 
-    for (const folder of folders) {
+    for (const slug of slice) {
       try {
-        // Pass the already-resolved images so we don't re-list every folder.
-        const result = await syncFolderCollection(
-          folder.slug,
-          origin,
-          auth.user.id,
-          folder.images,
-        )
+        const result = await syncFolderCollection(slug, origin, auth.user.id)
         if (!result) continue
         results.push(result)
         if (result.createdCollection) createdCollections += 1
         createdImages += result.created
         skipped += result.skipped
       } catch (err) {
-        // One bad folder shouldn't abort the whole sweep — record and continue.
+        // One bad folder shouldn't abort the page — record and continue.
         failures.push({
-          slug: folder.slug,
+          slug,
           error: err instanceof Error ? err.message : String(err),
         })
       }
     }
 
+    const nextOffset = offset + slice.length
+    const done = nextOffset >= slugs.length
+
     return {
       success: true,
-      message: `Synced ${results.length} folder(s): ${createdCollections} new collection(s), ${createdImages} new image(s)${
+      message: `Page ${offset}-${nextOffset} of ${slugs.length} folder(s): ${createdCollections} new collection(s), ${createdImages} new image(s)${
         skipped ? `, ${skipped} over-long path(s) skipped` : ''
-      }${failures.length ? `, ${failures.length} failed` : ''}.`,
+      }${failures.length ? `, ${failures.length} failed` : ''}.${done ? ' Done.' : ''}`,
       data: {
-        folders: results.length,
+        totalFolders: slugs.length,
+        offset,
+        processed: slice.length,
+        nextOffset: done ? null : nextOffset,
+        done,
         createdCollections,
         createdImages,
         skipped,

--- a/server/utils/folderCollections.ts
+++ b/server/utils/folderCollections.ts
@@ -173,14 +173,12 @@ export async function resolveFolderImages(
 }
 
 /**
- * Enumerate every folder collection the site can see. Slugs come from the
- * master index (the reliable source on the CDN); a dev filesystem scan of
- * public/images/ fills in any folders not yet indexed. Each returned
- * collection carries its resolved image URLs.
+ * Enumerate every folder slug the site can see WITHOUT resolving its images.
+ * Cheap: one master-index read plus a dev filesystem scan. Callers that need
+ * images resolve them per-slug (so large sites can page instead of resolving
+ * every folder's manifest in one shot — which times out on serverless).
  */
-export async function listFolderCollections(
-  origin: string,
-): Promise<FolderCollection[]> {
+export async function listFolderSlugs(origin: string): Promise<string[]> {
   const slugs = new Set<string>()
 
   const index = await readCollectionsIndex(origin)
@@ -211,8 +209,23 @@ export async function listFolderCollections(
     // images root unreadable (CDN mode): the index above is all we have.
   }
 
+  return [...slugs].sort()
+}
+
+/**
+ * Enumerate every folder collection the site can see, WITH resolved image URLs.
+ * Slugs come from listFolderSlugs; each folder's images are resolved from the
+ * filesystem (dev) or master index + manifest (CDN). Note: this resolves every
+ * folder's manifest, so it is O(folders) network calls — fine for listing, but
+ * bulk mutations should page over listFolderSlugs instead.
+ */
+export async function listFolderCollections(
+  origin: string,
+): Promise<FolderCollection[]> {
+  const slugs = await listFolderSlugs(origin)
+
   const collections: FolderCollection[] = []
-  for (const slug of [...slugs].sort()) {
+  for (const slug of slugs) {
     const images = await resolveFolderImages(slug, origin)
     if (images && images.length) collections.push({ slug, images })
   }

--- a/stores/collectionStore.ts
+++ b/stores/collectionStore.ts
@@ -59,13 +59,28 @@ export type FolderSyncResult = {
   createdCollection: boolean
 }
 
-export type FolderSyncAllResult = {
-  folders: number
+// One page of the bulk folder sync (the endpoint works in bounded pages so it
+// can't time out on serverless).
+export type FolderSyncPage = {
+  totalFolders: number
+  offset: number
+  processed: number
+  nextOffset: number | null
+  done: boolean
   createdCollections: number
   createdImages: number
   skipped: number
   failures: { slug: string; error: string }[]
   results: FolderSyncResult[]
+}
+
+// Aggregate result after paging through every folder.
+export type FolderSyncAllResult = {
+  totalFolders: number
+  createdCollections: number
+  createdImages: number
+  skipped: number
+  failures: { slug: string; error: string }[]
 }
 
 type CollectionState = {
@@ -1077,19 +1092,46 @@ export const useCollectionStore = defineStore('collectionStore', () => {
    * generated batches) appear as normal collections on every surface.
    * Idempotent.
    */
-  async function syncAllFolderCollections(): Promise<FolderSyncAllResult> {
-    const response = await performFetch<FolderSyncAllResult>(
-      '/api/art/collection/folders/sync',
-      { method: 'POST' },
-    )
+  async function syncAllFolderCollections(
+    limit = 20,
+  ): Promise<FolderSyncAllResult> {
+    const totals: FolderSyncAllResult = {
+      totalFolders: 0,
+      createdCollections: 0,
+      createdImages: 0,
+      skipped: 0,
+      failures: [],
+    }
 
-    if (!response.success || !response.data) {
-      throw new Error(response.message || 'Failed to sync folder collections')
+    // Page until the server reports done. The endpoint bounds each call so it
+    // can't hit the serverless time limit; we drive the loop from here.
+    let offset = 0
+    // Hard stop well above any realistic folder count, so a server bug can't
+    // spin this forever.
+    for (let guard = 0; guard < 1000; guard += 1) {
+      const response = await performFetch<FolderSyncPage>(
+        '/api/art/collection/folders/sync',
+        { method: 'POST', body: JSON.stringify({ limit, offset }) },
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to sync folder collections')
+      }
+
+      const page = response.data
+      totals.totalFolders = page.totalFolders
+      totals.createdCollections += page.createdCollections
+      totals.createdImages += page.createdImages
+      totals.skipped += page.skipped
+      totals.failures.push(...page.failures)
+
+      if (page.done || page.nextOffset === null) break
+      offset = page.nextOffset
     }
 
     await fetchCollections(true)
     await fetchFolderCollections(true)
-    return response.data
+    return totals
   }
 
   return {


### PR DESCRIPTION
## The bug

`POST /api/art/collection/folders/sync` resolved every folder's manifest (an HTTP call per folder on the CDN) and wrote images for all ~125 folders in a single request → Vercel `FUNCTION_INVOCATION_TIMEOUT`.

## Fix — bounded pages

- **`listFolderSlugs()`** (new, in `folderCollections.ts`): enumerates folder slugs cheaply from the master index + dev fs scan, **without** resolving each folder's images. `listFolderCollections()` now builds on it (unchanged behavior).
- **`folders/sync.post.ts`**: accepts `{ limit?, offset? }` (default 20, max 50), syncs the slice `[offset, offset+limit)`, and returns `{ totalFolders, processed, nextOffset, done, … }`. Each call stays well under the serverless time budget.
- **`collectionStore.syncAllFolderCollections()`**: drives the loop — pages until `done`, aggregating totals — so one call from the UI still syncs everything. Has a 1000-iteration guard against a runaway server response.

Per-slug sync and the auth path are untouched.

## Verification

`npm test` (nuxi prepare + vue-tsc `--noEmit`) clean; eslint clean on the new/changed files (the 4 pre-existing `collectionStore.ts` lint errors are unrelated).

## Usage

Manual paging (each call is fast):
```bash
curl -s -X POST https://<host>/api/art/collection/folders/sync \
  -H "x-admin-token: <admin token>" -H 'content-type: application/json' \
  --data '{"limit":20,"offset":0}'
# repeat with offset = the returned nextOffset until "done": true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_