### PR TITLE
Assign collection-less ArtImages to a home (reverse parity, phase 1)

### DIFF
--- a/server/api/art/collection/assign-orphans.post.ts
+++ b/server/api/art/collection/assign-orphans.post.ts
@@ -1,0 +1,158 @@
+// /server/api/art/collection/assign-orphans.post.ts
+//
+// Reverse parity, phase 1 (DB-only, Vercel-safe): give every ArtImage that has
+// NO collection a home. For each orphan we derive its collection from its image
+// path (folder === slug, the folder convention); when the path doesn't imply a
+// folder, we file it under a per-user "unsorted-u{userId}" collection so nothing
+// stays homeless. Complements the folders sync (files -> rows); this is rows ->
+// a collection.
+//
+// Bounded by an id cursor so it can't hit the serverless time limit: syncs a
+// page and returns nextCursor; the caller loops until done. Machine-auth,
+// idempotent (only touches images that currently have zero collections).
+//
+// Note: this assigns COLLECTIONS only. Materializing missing files, PNG->WebP
+// conversion, and thumbnails happen in the relay-side phase 2 job (the app
+// filesystem is read-only on Vercel).
+import { defineEventHandler, getRequestURL, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import { folderSlugFromImageUrl } from '~/server/utils/folderCollections'
+
+const DEFAULT_LIMIT = 200
+const MAX_LIMIT = 1000
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, Math.trunc(n)))
+}
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+    getRequestURL(event) // (parity with sibling routes; origin not needed here)
+
+    const body = (await readBody(event).catch(() => ({}))) as {
+      limit?: unknown
+      cursorId?: unknown
+    }
+    const limit = clampInt(body?.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
+    const cursorId = clampInt(body?.cursorId, 0, 0, Number.MAX_SAFE_INTEGER)
+
+    // Page over collection-less images by ascending id (stable cursor).
+    const orphans = await prisma.artImage.findMany({
+      where: {
+        ArtCollections: { none: {} },
+        ...(cursorId ? { id: { gt: cursorId } } : {}),
+      },
+      select: { id: true, imagePath: true, path: true, userId: true },
+      orderBy: { id: 'asc' },
+      take: limit,
+    })
+
+    if (orphans.length === 0) {
+      return {
+        success: true,
+        message: 'No collection-less ArtImages remain.',
+        data: { processed: 0, assigned: 0, derived: 0, unsorted: 0, createdCollections: 0, nextCursor: null, done: true },
+        statusCode: 200,
+      }
+    }
+
+    // Decide each orphan's target slug: derived from its path, else per-user unsorted.
+    const bySlug = new Map<string, number[]>()
+    let derived = 0
+    let unsorted = 0
+    for (const img of orphans) {
+      const fromPath = folderSlugFromImageUrl(img.imagePath || img.path)
+      const slug = fromPath ?? `unsorted-u${img.userId ?? 10}`
+      if (fromPath) derived += 1
+      else unsorted += 1
+      const list = bySlug.get(slug)
+      if (list) list.push(img.id)
+      else bySlug.set(slug, [img.id])
+    }
+
+    // Ensure every target collection exists (create the missing ones).
+    const targetSlugs = [...bySlug.keys()]
+    const existing = await prisma.artCollection.findMany({
+      where: { slug: { in: targetSlugs } },
+      select: { id: true, slug: true },
+    })
+    const existingSlugs = new Set(existing.map((c) => c.slug))
+    const missing = targetSlugs.filter((s) => !existingSlugs.has(s))
+
+    if (missing.length > 0) {
+      await prisma.artCollection.createMany({
+        data: missing.map((slug) => ({
+          slug,
+          label: slug.startsWith('unsorted-u') ? 'Unsorted' : labelFromSlug(slug),
+          description: slug.startsWith('unsorted-u')
+            ? 'Images not yet filed into a folder collection.'
+            : `Folder collection (${slug}).`,
+          userId: auth.user.id,
+          isPublic: true,
+        })),
+        skipDuplicates: true,
+      })
+    }
+
+    // Re-read to get every target collection's id (created + pre-existing).
+    const collections = await prisma.artCollection.findMany({
+      where: { slug: { in: targetSlugs } },
+      select: { id: true, slug: true },
+    })
+    const idBySlug = new Map(collections.map((c) => [c.slug, c.id]))
+
+    // Connect each group of images to its collection (one write per collection).
+    let assigned = 0
+    for (const [slug, ids] of bySlug) {
+      const collectionId = idBySlug.get(slug)
+      if (!collectionId) continue
+      await prisma.artCollection.update({
+        where: { id: collectionId },
+        data: { ArtImages: { connect: ids.map((id) => ({ id })) } },
+      })
+      assigned += ids.length
+    }
+
+    const nextCursor = orphans[orphans.length - 1]?.id ?? null
+    const done = orphans.length < limit
+
+    return {
+      success: true,
+      message: `Assigned ${assigned} image(s) (${derived} by path, ${unsorted} to unsorted), ${missing.length} new collection(s).${done ? ' Done.' : ''}`,
+      data: {
+        processed: orphans.length,
+        assigned,
+        derived,
+        unsorted,
+        createdCollections: missing.length,
+        nextCursor: done ? null : nextCursor,
+        done,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to assign orphan images.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/folderCollections.ts
+++ b/server/utils/folderCollections.ts
@@ -40,6 +40,28 @@ export function isImageFile(name: string): boolean {
   return IMAGE_EXTENSIONS.has(ext)
 }
 
+// Containers that are not themselves a collection slug (they hold folders).
+const NON_SLUG_DIRS = new Set(['images', 'artcollections'])
+
+/**
+ * Derive the folder-collection slug from an ArtImage's public URL. By the
+ * folder convention slug === the directory that holds the file, so we take the
+ * last path segment after dropping the filename. Returns null when the image
+ * sits loose in /images/ (no owning folder) or the segment isn't slug-shaped —
+ * callers then fall back to an "unsorted" bucket.
+ *   /images/artcollections/sketchy/sketchy-card.webp -> "sketchy"
+ *   /images/comfy/comfy-1.webp                        -> "comfy"
+ *   /images/loose.webp                                -> null
+ */
+export function folderSlugFromImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+  const parts = url.split('?')[0]?.split('/').filter(Boolean) ?? []
+  if (parts.length && /\.[a-z0-9]+$/i.test(parts[parts.length - 1] ?? '')) parts.pop()
+  const last = parts[parts.length - 1]
+  if (!last || NON_SLUG_DIRS.has(last)) return null
+  return SLUG_PATTERN.test(last) ? last : null
+}
+
 async function listImages(
   folder: string,
   urlPrefix: string,


### PR DESCRIPTION
## Why

We guarantee every file has a row and every folder is a collection. This closes the other gap you asked for: every *image* should have a collection. Decisions applied: **file-first**, **derive-else-unsorted**.

## What

`POST /api/art/collection/assign-orphans` — for each ArtImage with **no** collection:
- Derive its collection from `imagePath`/`path` (folder === slug) and connect it.
- If the path implies no folder → file under a per-user **`unsorted-u{userId}`** collection so nothing is homeless.
- Create any missing target collections (`createMany`, `skipDuplicates`).

Bounded by an ascending-id **cursor** (returns `nextCursor`) so it can't time out; caller loops until `done`. Idempotent — only touches zero-collection images. Groups connects one write per collection. Adds `folderSlugFromImageUrl()` (drops filename, ignores `images`/`artcollections` containers).

**Scope:** collections only. Materializing missing files, PNG→WebP, and thumbnails are the relay-side phase 2 job (Vercel FS is read-only).

## Verification

`npm test` (nuxi prepare + vue-tsc) clean; eslint clean.

## Usage
```bash
cur=0
while :; do
  r=$(curl -s -X POST https://<host>/api/art/collection/assign-orphans \
    -H "Authorization: Bearer <apikey>" -H 'content-type: application/json' \
    --data "{\"limit\":200,\"cursorId\":$cur}")
  echo "$r"
  echo "$r" | grep -q '"done":true' && break
  cur=$(echo "$r" | python3 -c 'import sys,json;print(json.load(sys.stdin)["data"]["nextCursor"])')
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_