### PR TITLE
cypress: wait for the pushed commit to go live before testing production

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,10 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      wait_seconds:
-        description: 'Seconds to wait for Vercel deploy before running tests'
+      max_wait_seconds:
+        description: 'Max seconds to wait for the pushed commit to go live on Vercel before running tests'
         required: false
-        default: '90'
+        default: '600'
 
 concurrency:
   group: cypress-${{ github.ref }}
@@ -33,18 +33,39 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Give Vercel time to finish deploying the new commit before tests hit it.
-      # On manual dispatch you can override this; on push to main 90s is usually enough.
-      - name: Wait for Vercel deploy
+      # Wait for Vercel to finish deploying THIS commit before tests hit production.
+      # A blind sleep used to race the deploy: `vercel-build` runs `prisma migrate
+      # deploy` during the build, so there is a window where the schema has already
+      # changed but the previous serverless functions are still being served. Tests
+      # landing in that window hit a code/DB mismatch (e.g. the subFolder ->
+      # parentFolder rename returned 500s). Instead, poll /api/version until
+      # production reports the pushed commit as live, then run.
+      - name: Wait for deploy to go live
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+          TARGET_SHA: ${{ github.sha }}
+          MAX_WAIT: ${{ github.event.inputs.max_wait_seconds || '600' }}
         run: |
-          WAIT="${{ github.event.inputs.wait_seconds || '90' }}"
-          echo "Waiting ${WAIT}s for Vercel to finish deploying..."
-          sleep "$WAIT"
+          echo "Waiting up to ${MAX_WAIT}s for production to serve ${TARGET_SHA}..."
+          deadline=$(( $(date +%s) + MAX_WAIT ))
+          live=""
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            body="$(curl -sf --max-time 15 "${BASE_URL}/api/version" || true)"
+            live="$(printf '%s' "$body" | jq -r '.data.commit // empty' 2>/dev/null || true)"
+            if [ -n "$live" ] && [ "$live" = "$TARGET_SHA" ]; then
+              echo "Production is serving ${live} — deploy is live."
+              exit 0
+            fi
+            echo "  not live yet (serving: ${live:-unknown}); retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Production did not serve ${TARGET_SHA} within ${MAX_WAIT}s (last seen: ${live:-unknown})."
+          exit 1
 
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:
-          install: false  # already installed above
+          install: false # already installed above
           browser: chrome
           record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
         env:

--- a/server/api/version.get.ts
+++ b/server/api/version.get.ts
@@ -1,0 +1,28 @@
+// /server/api/version.get.ts
+// Public, read-only build-identity endpoint. Reports the git commit this
+// deployment was built from so CI (and humans) can confirm which build is
+// actually live before exercising the rest of the API. Vercel injects the
+// VERCEL_GIT_* system environment variables at build and runtime.
+//
+// The Cypress workflow polls this after a push to main and only starts the API
+// suite once `data.commit` matches the pushed SHA. That closes the race where
+// `prisma migrate deploy` (run during `vercel-build`) has already changed the
+// schema but the previous serverless functions are still being served — the
+// window that made the subFolder -> parentFolder rename fail against production.
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => {
+  const commit =
+    process.env.VERCEL_GIT_COMMIT_SHA || process.env.COMMIT_SHA || null
+
+  return {
+    success: true,
+    message: 'ok',
+    data: {
+      commit,
+      ref: process.env.VERCEL_GIT_COMMIT_REF || null,
+      environment: process.env.VERCEL_ENV || process.env.NODE_ENV || null,
+      deploymentId: process.env.VERCEL_DEPLOYMENT_ID || null,
+    },
+  }
+})


### PR DESCRIPTION
## What was failing

The latest `Cypress Tests` run on `main` (commit #126, `subFolder` → `parentFolder` rename) failed with **13 failures**: all 12 `api/artcollection.cy.ts` tests plus the one `api/relationships.cy.ts` test (which also creates an ArtCollection mid-chain). The exact error from production:

```
Database operation failed: Invalid `prisma.artCollection.create()` invocation:
The column `ArtCollection.subFolder` does not exist in the current database.
```

## Root cause — a deploy-timing race, not a code bug

The suite runs against live production (`https://kind-robots.vercel.app`) right after a push, with a fixed `sleep 90` beforehand. But `vercel-build` runs `prisma migrate deploy` **during** the build, so there is a window where the schema has already been migrated (column renamed to `parentFolder`) while the **previous** serverless functions — still querying `subFolder` — are being served. The 90s sleep landed inside that window, so `POST /api/art/collection` returned 500 and every test depending on a created collection cascaded to failure.

Re-running the workflow against now-fully-live production passes with 0 failures (all 296 tests green), confirming the code and migration are correct and the failure was purely the deploy race.

## The fix

- **`server/api/version.get.ts`** — a public, read-only endpoint returning the deployment's `VERCEL_GIT_COMMIT_SHA` (plus ref/environment).
- **`.github/workflows/cypress.yml`** — replace the blind `sleep 90` with a poll of `/api/version` that waits until production reports the pushed commit as live before starting the suite (bounded by `max_wait_seconds`, default 600s; fails clearly on timeout).

Tests now begin only once the new build is actually serving, so the migrate-before-swap window can no longer produce false failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012N3gzZd8NEMWqpGAdjkrJb)_