### PR TITLE
art image PATCH: unify auth with the read endpoints (requireMachineUser)

### DIFF
--- a/server/api/art/image/[id].patch.ts
+++ b/server/api/art/image/[id].patch.ts
@@ -3,14 +3,7 @@ import { defineEventHandler, createError, readBody, type H3Event } from 'h3'
 import type { ArtImage, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
-import { validateApiKey } from '../../../utils/validateKey'
-
-type ValidatedUser = {
-  id?: number | null
-  Role?: string | null
-  role?: string | null
-  isAdmin?: boolean | null
-}
+import { requireMachineUser } from '../../../utils/authGuard'
 
 type PatchUser = {
   id: number
@@ -54,28 +47,14 @@ const ART_IMAGE_PATCH_FIELDS = new Set<
   'serverUrl',
 ])
 
-function isAdminUser(user: ValidatedUser | null | undefined): boolean {
-  if (!user) return false
-
-  const role = String(user.Role || user.role || '').toLowerCase()
-
-  return Boolean(user.isAdmin || role === 'admin' || role === 'system')
-}
-
 async function requirePatchUser(event: H3Event): Promise<PatchUser> {
-  const auth = await validateApiKey(event)
-  const user = auth.user as ValidatedUser | null | undefined
-
-  if (!auth.isValid || typeof user?.id !== 'number') {
-    throw createError({
-      statusCode: 401,
-      message: 'Valid authorization token required.',
-    })
-  }
+  // Same machine auth as the rest of the art API (JWT / user apiKey /
+  // beta-admin token) so a token that can READ can also WRITE. Throws 401.
+  const auth = await requireMachineUser(event)
 
   return {
-    id: Number(user.id),
-    isAdmin: isAdminUser(user),
+    id: auth.user.id,
+    isAdmin: auth.isAdmin,
   }
 }
 


### PR DESCRIPTION
## Bug (hit during the live migration)

`GET /api/art/image/needs-work` uses `requireMachineUser` (accepts JWT / user apiKey / beta-admin token), but `PATCH /api/art/image/[id]` used `validateApiKey` — a stricter guard that **rejected the same machine/beta-admin token**. So the relay parity job could *read* the work list but every write returned `401 Valid authorization token required`.

## Fix

`requirePatchUser` now uses `requireMachineUser`, so any token that can read can also write. Ownership rules unchanged (admins patch any image; non-admins only their own). Removed the now-unused `validateApiKey`/`ValidatedUser`/`isAdminUser` locals.

## Verification

`npm test` (nuxi prepare + vue-tsc) clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_