### PR TITLE
art image GET: optional ?includeCollections

### DIFF
--- a/server/api/art/image/[id].get.ts
+++ b/server/api/art/image/[id].get.ts
@@ -102,7 +102,7 @@ function buildArtImageSelect(
 ): Prisma.ArtImageSelect {
   const includeImageData = readBoolean(query.includeImageData, false)
   const includeThumbnailData = readBoolean(query.includeThumbnailData, false)
-  const includeTags = readBoolean(query.includeTags, false)
+  const includeCollections = readBoolean(query.includeCollections, false)
 
   return {
     id: true,
@@ -114,6 +114,7 @@ function buildArtImageSelect(
     imagePath: true,
     path: true,
     promptString: true,
+    artPrompt: true,
     negativePrompt: true,
     checkpoint: true,
     checkpointResourceId: true,
@@ -131,6 +132,11 @@ function buildArtImageSelect(
     serverUrl: true,
     imageData: includeImageData,
     thumbnailData: includeThumbnailData,
+    // Lightweight collection info (id/slug/label) for tools that name files by
+    // collection. Off by default to keep the payload small.
+    ArtCollections: includeCollections
+      ? { select: { id: true, slug: true, label: true } }
+      : false,
   }
 }
 


### PR DESCRIPTION
## Why

The parity migration should name materialized files after the image's collection (`{slug}-inspiration-{id}`), which means the single-image GET needs to return the image's collection.

## What

`GET /api/art/image/[id]?includeCollections=true` now returns `ArtCollections { id, slug, label }`. Off by default (small payload). Also added `artPrompt` to the select for a naming fallback.

## Verification

`npm test` (nuxi prepare + vue-tsc) clean; eslint clean.

Pairs with the conductor `parity_migrate.py` naming update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R

---
_Generated by [Claude Code](https://claude.ai/code/session_011ca3tfgDiYrs7BimzQ3c2R)_