### PR TITLE
fix: lazy-init Stripe clients

### DIFF
--- a/server/api/stripe/checkout.post.ts
+++ b/server/api/stripe/checkout.post.ts
@@ -5,7 +5,22 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { cartItems } from '@/stores/seeds/cartItems' // or move to server if needed
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
+let stripe: Stripe | null = null
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY
+
+  if (!secretKey) {
+    const error = new Error('Stripe secret key is not configured') as Error & {
+      statusCode: number
+    }
+    error.statusCode = 500
+    throw error
+  }
+
+  stripe ??= new Stripe(secretKey)
+  return stripe
+}
 
 export default defineEventHandler(async (event) => {
   try {
@@ -21,6 +36,7 @@ export default defineEventHandler(async (event) => {
     if (!user)
       return errorHandler({ message: 'User not found', statusCode: 404 })
 
+    const stripe = getStripeClient()
     const email = user.email || `user-${user.id}@kindrobots.org`
 
     const customerId =

--- a/server/api/stripe/subscribe.post.ts
+++ b/server/api/stripe/subscribe.post.ts
@@ -4,7 +4,22 @@ import Stripe from 'stripe'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
+let stripe: Stripe | null = null
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY
+
+  if (!secretKey) {
+    const error = new Error('Stripe secret key is not configured') as Error & {
+      statusCode: number
+    }
+    error.statusCode = 500
+    throw error
+  }
+
+  stripe ??= new Stripe(secretKey)
+  return stripe
+}
 
 export default defineEventHandler(async (event) => {
   try {
@@ -17,6 +32,7 @@ export default defineEventHandler(async (event) => {
     if (!user)
       return errorHandler({ message: 'User not found', statusCode: 404 })
 
+    const stripe = getStripeClient()
     const email = user.email || `user-${user.id}@kindrobots.org`
 
     const customerId =


### PR DESCRIPTION
### Task
kind-robots/t-009: Lazy-init the Stripe client in checkout/subscribe routes  (kind: software)

### What changed / what I produced
- Moved Stripe client construction out of module load for `server/api/stripe/checkout.post.ts`.
- Moved Stripe client construction out of module load for `server/api/stripe/subscribe.post.ts`.
- Added a lazy singleton helper in each route that throws a request-scoped 500 when `STRIPE_SECRET_KEY` is missing.

### How I verified
- Inspected both route files before and after the change through the GitHub connector.
- Could not run the local test suite because the execution sandbox cannot resolve `github.com` to clone the repo, so verification is limited to static review in the connector session.

### Stakes
reversible

### Flags for Reviewer
- Local tests were not runnable in this sandbox due network/DNS failure on `git clone`; please rely on CI for full validation.

### Kaizen suggestion
Add a tiny server-side Stripe helper module for lazy client creation so future Stripe routes do not duplicate env handling.

### Notes for reviewer
