### PR TITLE
feat(art): navigable Hair Studio jobs + durable per-client history

### DIFF
--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -4,13 +4,10 @@
   enhance (any combination), and send it through the Kind Robots Kontext backend to
   get the same photo back with new hair.
 
-  Notes:
-  - Results are saved with isPublic: false on purpose. Client photos are private and
-    must NOT surface in public galleries or the memory-match game, even though they
-    are linked to the studio user. (Silas, 2026-07-09.)
-  - Generation runs async via artStore.generateArt; the rest of the app stays
-    navigable while a job is in flight. Durable per-client galleries + cross-page
-    background jobs are tracked in conductor superkate-hairstyle-ai t-007 / t-008.
+  Job state and past looks live in stylistStore, so a styling job keeps running (and
+  its result still lands) even if Superkate leaves the /stylist tab and comes back.
+  Results are saved private (isPublic:false) and tagged per client. See conductor
+  superkate-hairstyle-ai t-007 (navigable async) and t-008 (durable per-client gallery).
 -->
 <template>
   <section
@@ -22,8 +19,12 @@
       <span class="badge badge-primary badge-sm">Kontext</span>
       <span class="badge badge-ghost badge-sm">Private</span>
       <div class="flex-1" />
-      <span class="text-xs font-semibold text-base-content/50">
-        Superkate · surprise preview
+      <span
+        v-if="stylist.isBusy"
+        class="flex items-center gap-1 text-xs font-semibold text-primary"
+      >
+        <span class="loading loading-spinner loading-xs" />
+        {{ stylist.pendingCount }} styling…
       </span>
     </header>
 
@@ -169,52 +170,65 @@
     </div>
 
     <!-- Action -->
-    <div class="flex items-center gap-2">
-      <button
-        type="button"
-        class="btn btn-primary btn-sm flex-1"
-        :disabled="!canGenerate"
-        @click="runStylist"
-      >
-        <span v-if="isGenerating" class="loading loading-spinner loading-xs" />
-        <Icon v-else name="kind-icon:magic" class="h-4 w-4" />
-        {{ isGenerating ? 'Styling…' : 'Style it' }}
-      </button>
-    </div>
+    <button
+      type="button"
+      class="btn btn-primary btn-sm"
+      :disabled="!canGenerate"
+      @click="submit"
+    >
+      <Icon name="kind-icon:magic" class="h-4 w-4" />
+      Style it
+    </button>
 
-    <p v-if="isGenerating" class="text-center text-xs text-base-content/50">
-      This can take a minute or two — feel free to keep working, the result lands here when it's ready.
-    </p>
-    <p v-if="errorMessage" class="rounded-lg bg-error/10 p-2 text-xs font-semibold text-error">
-      {{ errorMessage }}
+    <p class="text-center text-xs text-base-content/50">
+      Styling takes a minute or two — you can keep working or switch tabs; results land below when ready.
     </p>
 
-    <!-- Results — per-client before/after -->
-    <div v-if="results.length" class="flex flex-col gap-2">
-      <span class="text-xs font-black text-base-content">Transformations</span>
+    <!-- This session's jobs -->
+    <div v-if="visibleJobs.length" class="flex flex-col gap-2">
+      <span class="text-xs font-black text-base-content">
+        {{ clientName.trim() ? `Styling ${clientName.trim()}` : 'This session' }}
+      </span>
       <div class="grid gap-3 sm:grid-cols-2">
         <article
-          v-for="result in results"
-          :key="result.id"
+          v-for="job in visibleJobs"
+          :key="job.id"
           class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
         >
           <div class="flex items-center gap-2 text-xs">
-            <span class="font-bold">{{ result.client || 'Unnamed client' }}</span>
-            <span v-if="result.pending" class="badge badge-warning badge-xs gap-1">
+            <span class="font-bold">{{ job.client || 'Unnamed client' }}</span>
+            <span v-if="job.status === 'pending'" class="badge badge-warning badge-xs gap-1">
               <span class="loading loading-spinner loading-xs" /> working
             </span>
-            <span v-else-if="result.failed" class="badge badge-error badge-xs">failed</span>
+            <span v-else-if="job.status === 'failed'" class="badge badge-error badge-xs">failed</span>
             <span v-else class="badge badge-success badge-xs">done</span>
+            <div class="flex-1" />
+            <button
+              v-if="job.status === 'failed'"
+              type="button"
+              class="btn btn-ghost btn-xs"
+              @click="stylist.retryJob(job.id)"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              class="btn btn-circle btn-ghost btn-xs"
+              title="Dismiss"
+              @click="stylist.dismissJob(job.id)"
+            >
+              <Icon name="mdi:close" class="h-3.5 w-3.5" />
+            </button>
           </div>
           <div class="grid grid-cols-2 gap-1">
             <figure class="flex flex-col gap-1">
-              <img :src="result.before" alt="Before" class="aspect-square w-full rounded-lg object-cover" />
+              <img :src="job.before" alt="Before" class="aspect-square w-full rounded-lg object-cover" />
               <figcaption class="text-center text-[10px] text-base-content/50">Before</figcaption>
             </figure>
             <figure class="flex flex-col gap-1">
               <img
-                v-if="result.after"
-                :src="result.after"
+                v-if="job.after"
+                :src="job.after"
                 alt="After"
                 class="aspect-square w-full rounded-lg object-cover"
               />
@@ -222,31 +236,71 @@
                 v-else
                 class="flex aspect-square w-full items-center justify-center rounded-lg bg-base-200"
               >
-                <span v-if="result.pending" class="loading loading-spinner text-primary" />
+                <span v-if="job.status === 'pending'" class="loading loading-spinner text-primary" />
                 <Icon v-else name="mdi:image-broken" class="h-6 w-6 text-base-content/30" />
               </div>
               <figcaption class="text-center text-[10px] text-base-content/50">After</figcaption>
             </figure>
           </div>
-          <p class="line-clamp-2 text-[10px] text-base-content/50" :title="result.prompt">
-            {{ result.prompt }}
+          <p v-if="job.error" class="text-[10px] font-semibold text-error">{{ job.error }}</p>
+          <p v-else class="line-clamp-2 text-[10px] text-base-content/50" :title="job.prompt">
+            {{ job.prompt }}
           </p>
         </article>
+      </div>
+    </div>
+
+    <!-- Durable per-client history -->
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-black text-base-content">
+          {{ clientName.trim() ? `Past looks for ${clientName.trim()}` : 'Past looks' }}
+        </span>
+        <span v-if="stylist.isLoadingHistory" class="loading loading-spinner loading-xs text-primary" />
+        <div class="flex-1" />
+        <button type="button" class="btn btn-ghost btn-xs" @click="stylist.loadHistory(true)">
+          Refresh
+        </button>
+      </div>
+      <p v-if="stylist.historyError" class="text-xs text-error">{{ stylist.historyError }}</p>
+      <p
+        v-else-if="!clientHistory.length && !stylist.isLoadingHistory"
+        class="text-xs text-base-content/40"
+      >
+        No saved looks yet{{ clientName.trim() ? ' for this client' : '' }}.
+      </p>
+      <div v-else class="grid grid-cols-3 gap-2 sm:grid-cols-4">
+        <figure
+          v-for="image in clientHistory"
+          :key="image.id"
+          class="flex flex-col gap-1"
+        >
+          <img
+            :src="historyImageSrc(image)"
+            :alt="`Look for ${clientFromDesigner(image.designer) || 'client'}`"
+            class="aspect-square w-full rounded-lg object-cover"
+          />
+          <figcaption
+            v-if="!clientName.trim()"
+            class="truncate text-center text-[10px] text-base-content/50"
+          >
+            {{ clientFromDesigner(image.designer) || 'client' }}
+          </figcaption>
+        </figure>
       </div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref } from 'vue'
-import { useArtStore } from '@/stores/artStore'
-import { useUserStore } from '@/stores/userStore'
-import { useServerStore } from '@/stores/serverStore'
-import type { Server } from '~/prisma/generated/prisma/client'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  useStylistStore,
+  clientFromDesigner,
+} from '@/stores/stylistStore'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
 
-const artStore = useArtStore()
-const userStore = useUserStore()
-const serverStore = useServerStore()
+const stylist = useStylistStore()
 
 const clientName = ref('')
 
@@ -266,33 +320,17 @@ const styleValue = ref('')
 const enhanceImage = ref(false)
 const extraNotes = ref('')
 
-const isGenerating = ref(false)
-const errorMessage = ref('')
-
-let resultSeq = 0
-type StylistResult = {
-  id: number
-  client: string
-  before: string
-  after: string | null
-  prompt: string
-  pending: boolean
-  failed: boolean
-}
-const results = ref<StylistResult[]>([])
-
-function patchResult(id: number, patch: Partial<StylistResult>) {
-  results.value = results.value.map((result) =>
-    result.id === id ? { ...result, ...patch } : result,
-  )
-}
-
 const hasAnyChange = computed(
   () => changeColor.value || changeStyle.value || enhanceImage.value,
 )
 
 const canGenerate = computed(
-  () => !isGenerating.value && !!sourceImageData.value && hasAnyChange.value,
+  () => !!sourceImageData.value && hasAnyChange.value,
+)
+
+const visibleJobs = computed(() => stylist.jobsForClient(clientName.value))
+const clientHistory = computed(() =>
+  stylist.historyForClient(clientName.value),
 )
 
 const changeSummary = computed(() => {
@@ -337,24 +375,21 @@ function buildPrompt(): string {
   return clauses.join('. ')
 }
 
-function isUsableKontextServer(
-  server: Server | null | undefined,
-): server is Server {
-  if (!server) return false
-  if (!server.isActive) return false
-  if (server.serverType !== 'COMFY') return false
-  return true
-}
-
-const kontextServer = computed<Server | null>(() => {
-  if (isUsableKontextServer(serverStore.activeArtServer)) {
-    return serverStore.activeArtServer
+function historyImageSrc(image: ArtImage): string {
+  const img = image as ArtImage & {
+    imageData?: string | null
+    thumbnailData?: string | null
+    imagePath?: string | null
+    path?: string | null
   }
-  const servers = Array.isArray(serverStore.servers)
-    ? (serverStore.servers as Server[])
-    : []
-  return servers.find(isUsableKontextServer) || null
-})
+  if (img.thumbnailData) {
+    return `data:image/${img.fileType || 'png'};base64,${img.thumbnailData}`
+  }
+  if (img.imageData) {
+    return `data:image/${img.fileType || 'png'};base64,${img.imageData}`
+  }
+  return img.imagePath || img.path || ''
+}
 
 function handleFileSelect(event: Event) {
   const input = event.target as HTMLInputElement
@@ -372,27 +407,22 @@ function processFile(file: File) {
   const reader = new FileReader()
   reader.onload = (event) => {
     sourceImageData.value = (event.target?.result as string) ?? null
-    errorMessage.value = ''
   }
   reader.readAsDataURL(file)
 }
 
 async function openCamera() {
   sourceTab.value = 'camera'
-  errorMessage.value = ''
   try {
     cameraStream = await navigator.mediaDevices.getUserMedia({
       video: { facingMode: 'user' },
       audio: false,
     })
     cameraActive.value = true
-    // Wait a tick for the <video> to render before binding the stream.
     await new Promise((resolve) => setTimeout(resolve, 0))
     if (videoEl.value) videoEl.value.srcObject = cameraStream
   } catch {
     cameraActive.value = false
-    errorMessage.value =
-      'Camera unavailable. You can upload a photo instead.'
     sourceTab.value = 'upload'
   }
 }
@@ -418,66 +448,20 @@ function closeCamera() {
 
 function clearSource() {
   sourceImageData.value = null
-  errorMessage.value = ''
 }
 
-async function runStylist() {
+function submit() {
   if (!sourceImageData.value || !hasAnyChange.value) return
-
-  errorMessage.value = ''
-  const prompt = buildPrompt()
-  const before = sourceImageData.value
-  const client = clientName.value.trim()
-  const base64Payload = before.includes(',') ? before.split(',')[1] : before
-
-  const entryId = ++resultSeq
-  const entry: StylistResult = {
-    id: entryId,
-    client,
-    before,
-    after: null,
-    prompt,
-    pending: true,
-    failed: false,
-  }
-  results.value = [entry, ...results.value]
-
-  isGenerating.value = true
-  try {
-    const result = await artStore.generateArt({
-      promptString: prompt,
-      userId: userStore.userId ?? undefined,
-      serverId: kontextServer.value?.id ?? null,
-      serverName: kontextServer.value?.title ?? null,
-      engine: 'kontext',
-      transport: 'backend',
-      // Client photos stay private — never public, never in the memory game.
-      isPublic: false,
-      isMature: false,
-      // Tag the owning client so a durable per-client gallery can group later.
-      designer: client ? `stylist:${client}` : 'stylist',
-      sourceImageBase64: base64Payload,
-    })
-
-    if (!result.success || !result.data) {
-      throw new Error(result.message || 'Styling failed.')
-    }
-
-    const image = result.data as { imageData?: string | null; fileType?: string | null }
-    patchResult(entryId, {
-      after: image.imageData
-        ? `data:image/${image.fileType || 'png'};base64,${image.imageData}`
-        : before,
-      pending: false,
-    })
-  } catch (error) {
-    patchResult(entryId, { pending: false, failed: true })
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Styling failed.'
-  } finally {
-    isGenerating.value = false
-  }
+  void stylist.runStylist({
+    client: clientName.value,
+    before: sourceImageData.value,
+    prompt: buildPrompt(),
+  })
 }
+
+onMounted(() => {
+  void stylist.loadHistory()
+})
 
 onBeforeUnmount(closeCamera)
 </script>

--- a/stores/stylistStore.ts
+++ b/stores/stylistStore.ts
@@ -58,6 +58,34 @@ function isStylistImage(image: ArtImage): boolean {
   return (image.designer ?? '').startsWith('stylist')
 }
 
+/** Turn a raw generation error into something Superkate can act on. */
+export function friendlyError(raw: string): string {
+  const message = (raw || '').toLowerCase()
+  if (
+    message.includes('mana') ||
+    message.includes('balance') ||
+    message.includes('insufficient') ||
+    message.includes('afford')
+  ) {
+    return 'Not enough mana to style this photo — top up and try again.'
+  }
+  if (message.includes('timed out') || message.includes('timeout')) {
+    return 'That took too long and timed out. Give it another try in a moment.'
+  }
+  if (
+    message.includes('no active image generation server') ||
+    message.includes('no art server') ||
+    message.includes('server selected') ||
+    message.includes('not active')
+  ) {
+    return 'No art server is responding right now. Check that a Comfy/Kontext server is active, then retry.'
+  }
+  if (message.includes('sign') || message.includes('account') || message.includes('auth')) {
+    return 'Please sign in to use Hair Studio, then try again.'
+  }
+  return raw || 'Styling failed. Please try again.'
+}
+
 export const useStylistStore = defineStore('stylistStore', () => {
   const artStore = useArtStore()
   const userStore = useUserStore()
@@ -170,7 +198,9 @@ export const useStylistStore = defineStore('stylistStore', () => {
     } catch (error) {
       patchJob(id, {
         status: 'failed',
-        error: error instanceof Error ? error.message : 'Styling failed.',
+        error: friendlyError(
+          error instanceof Error ? error.message : 'Styling failed.',
+        ),
       })
     }
 

--- a/stores/stylistStore.ts
+++ b/stores/stylistStore.ts
@@ -1,0 +1,243 @@
+// /stores/stylistStore.ts
+//
+// Hair Studio (Superkate) state. Lives at store level on purpose so a styling
+// job survives the user leaving and returning to the /stylist tab — the
+// component is just a view over this store. See conductor superkate-hairstyle-ai
+// t-007 (navigable async) and t-008 (durable per-client gallery).
+//
+// Client photos are always generated with isPublic:false and tagged
+// designer:"stylist:<client>", so results stay private (never in public
+// galleries or the memory-match game) and can be grouped per client later.
+
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import { useArtStore } from '@/stores/artStore'
+import { useUserStore } from '@/stores/userStore'
+import { useServerStore } from '@/stores/serverStore'
+import type { ArtImage, Server } from '~/prisma/generated/prisma/client'
+
+export const STYLIST_DESIGNER_PREFIX = 'stylist:'
+
+export type StylistJobStatus = 'pending' | 'done' | 'failed'
+
+export type StylistJob = {
+  id: number
+  client: string
+  before: string // data URL of the source photo (session-only)
+  after: string | null // data URL of the result
+  prompt: string
+  status: StylistJobStatus
+  error?: string
+  artImageId?: number
+  createdAt: number
+}
+
+export type StylistRunInput = {
+  client: string
+  before: string // data URL of the source photo
+  prompt: string
+}
+
+/** designer tag stored on each generated ArtImage for a given client. */
+export function stylistDesignerFor(client: string): string {
+  const trimmed = client.trim()
+  return trimmed ? `${STYLIST_DESIGNER_PREFIX}${trimmed}` : 'stylist'
+}
+
+/** The client name encoded in a stylist ArtImage's designer field, or ''. */
+export function clientFromDesigner(designer?: string | null): string {
+  if (!designer) return ''
+  if (designer === 'stylist') return ''
+  return designer.startsWith(STYLIST_DESIGNER_PREFIX)
+    ? designer.slice(STYLIST_DESIGNER_PREFIX.length)
+    : ''
+}
+
+function isStylistImage(image: ArtImage): boolean {
+  return (image.designer ?? '').startsWith('stylist')
+}
+
+export const useStylistStore = defineStore('stylistStore', () => {
+  const artStore = useArtStore()
+  const userStore = useUserStore()
+  const serverStore = useServerStore()
+
+  // Live jobs from this session (before/after both available in memory).
+  const jobs = ref<StylistJob[]>([])
+  // Durable results loaded from the user's saved private stylist images.
+  const history = ref<ArtImage[]>([])
+  const isLoadingHistory = ref(false)
+  const historyError = ref('')
+
+  let seq = 0
+
+  const pendingCount = computed(
+    () => jobs.value.filter((job) => job.status === 'pending').length,
+  )
+  const isBusy = computed(() => pendingCount.value > 0)
+
+  function isUsableKontextServer(
+    server: Server | null | undefined,
+  ): server is Server {
+    if (!server) return false
+    if (!server.isActive) return false
+    if (server.serverType !== 'COMFY') return false
+    return true
+  }
+
+  const kontextServer = computed<Server | null>(() => {
+    if (isUsableKontextServer(serverStore.activeArtServer)) {
+      return serverStore.activeArtServer
+    }
+    const servers = Array.isArray(serverStore.servers)
+      ? (serverStore.servers as Server[])
+      : []
+    return servers.find(isUsableKontextServer) || null
+  })
+
+  function jobsForClient(client: string): StylistJob[] {
+    const target = client.trim().toLowerCase()
+    if (!target) return jobs.value
+    return jobs.value.filter(
+      (job) => job.client.trim().toLowerCase() === target,
+    )
+  }
+
+  function historyForClient(client: string): ArtImage[] {
+    const target = client.trim().toLowerCase()
+    if (!target) return history.value
+    return history.value.filter(
+      (image) => clientFromDesigner(image.designer).toLowerCase() === target,
+    )
+  }
+
+  function patchJob(id: number, patch: Partial<StylistJob>) {
+    jobs.value = jobs.value.map((job) =>
+      job.id === id ? { ...job, ...patch } : job,
+    )
+  }
+
+  async function runStylist(input: StylistRunInput): Promise<number> {
+    const id = ++seq
+    const client = input.client.trim()
+    const before = input.before
+
+    jobs.value = [
+      {
+        id,
+        client,
+        before,
+        after: null,
+        prompt: input.prompt,
+        status: 'pending',
+        createdAt: Date.now(),
+      },
+      ...jobs.value,
+    ]
+
+    const base64Payload = before.includes(',')
+      ? (before.split(',')[1] ?? before)
+      : before
+
+    try {
+      const result = await artStore.generateArt({
+        promptString: input.prompt,
+        userId: userStore.userId ?? undefined,
+        serverId: kontextServer.value?.id ?? null,
+        serverName: kontextServer.value?.title ?? null,
+        engine: 'kontext',
+        transport: 'backend',
+        // Private: never public, never in the memory game.
+        isPublic: false,
+        isMature: false,
+        designer: stylistDesignerFor(client),
+        sourceImageBase64: base64Payload,
+      })
+
+      if (!result.success || !result.data) {
+        throw new Error(result.message || 'Styling failed.')
+      }
+
+      const image = result.data
+      const after = image.imageData
+        ? `data:image/${image.fileType || 'png'};base64,${image.imageData}`
+        : before
+
+      patchJob(id, { status: 'done', after, artImageId: image.id })
+      // Surface the new result in the durable history immediately.
+      history.value = [image, ...history.value.filter((i) => i.id !== image.id)]
+    } catch (error) {
+      patchJob(id, {
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Styling failed.',
+      })
+    }
+
+    return id
+  }
+
+  async function retryJob(id: number): Promise<number | null> {
+    const job = jobs.value.find((entry) => entry.id === id)
+    if (!job) return null
+    // Drop the failed job and re-run with the same inputs.
+    jobs.value = jobs.value.filter((entry) => entry.id !== id)
+    return runStylist({
+      client: job.client,
+      before: job.before,
+      prompt: job.prompt,
+    })
+  }
+
+  function dismissJob(id: number) {
+    jobs.value = jobs.value.filter((job) => job.id !== id)
+  }
+
+  /**
+   * Load the current user's saved stylist results (private) so past looks show
+   * across sessions. Idempotent-ish: pass force to refetch.
+   */
+  async function loadHistory(force = false): Promise<void> {
+    const userId = userStore.userId ?? userStore.user?.id ?? null
+    if (!userId) return
+    if (isLoadingHistory.value) return
+    if (history.value.length && !force) return
+
+    isLoadingHistory.value = true
+    historyError.value = ''
+    try {
+      const response = await performFetch<{ art: ArtImage[] }>(
+        `/api/art/user/${userId}`,
+        { method: 'GET' },
+        2,
+        20000,
+      )
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Could not load past looks.')
+      }
+      const art = Array.isArray(response.data.art) ? response.data.art : []
+      history.value = art.filter(isStylistImage)
+    } catch (error) {
+      historyError.value =
+        error instanceof Error ? error.message : 'Could not load past looks.'
+    } finally {
+      isLoadingHistory.value = false
+    }
+  }
+
+  return {
+    jobs,
+    history,
+    isLoadingHistory,
+    historyError,
+    pendingCount,
+    isBusy,
+    kontextServer,
+    jobsForClient,
+    historyForClient,
+    runStylist,
+    retryJob,
+    dismissJob,
+    loadHistory,
+  }
+})


### PR DESCRIPTION
Builds on the merged Hair Studio tab (#133). Delivers conductor `superkate-hairstyle-ai` **t-007** (navigable async) and a first cut of **t-008** (durable per-client gallery).

## The problem this solves
Before this, a styling job lived in the component's local state — leave the `/stylist` tab mid-render and the pending job (and its result) was lost. Kontext takes ~1–2 min, so "keep working while it renders" wasn't actually true.

## What changed
- **`stores/stylistStore.ts`** (new) — job state lives at store level, so a job keeps running and its result still lands even if the component unmounts (tab switch / navigation). Holds:
  - `jobs[]` (pending / done / failed, with retry + dismiss),
  - Kontext server resolution,
  - `runStylist()` — generates via `artStore.generateArt({ engine: 'kontext' })`, always `isPublic:false`, tagged `designer: "stylist:<client>"`,
  - `history[]` — the user's saved **private** stylist results loaded from `GET /api/art/user/:id` and filtered by the `stylist:` designer tag, grouped per client.
- **`components/art/stylist-manager.vue`** — now a thin view over the store: live jobs grid + a **"Past looks for &lt;client&gt;"** durable gallery (grouped by the client tag), retry/dismiss, and refresh. Form state stays local.

## Privacy (unchanged guarantee)
Every result is still saved `isPublic:false`, so nothing surfaces in public galleries or the memory-match game.

## Stakes
reversible

## ⚠️ Flags for reviewer (Silas)
- **Still unverified in a running app** — no `node_modules` / live Comfy server here, so no typecheck/lint/e2e. The store/component follow existing artStore + performFetch patterns, and I self-reviewed reactivity, but please run `/stylist` end-to-end.
- **t-008 is a first cut:** the durable gallery shows past *results* only. The *before* image isn't persisted across sessions yet (save-generated stores only the generated image). Full durable before/after would need to also save the source — flagged as a follow-up.
- `GET /api/art/user/:id` returns full image data (no thumbnail-only variant); fine for MVP volumes, a thumbnail endpoint is a later optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ)_