### PR TITLE
fix(art): Hair Studio tab renders inline + Art channel remembers its tab

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -80,6 +80,15 @@
     </section>
 
     <section
+      v-else-if="activeTab === 'stylist'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <stylist-manager class="min-h-full w-full" />
+      </div>
+    </section>
+
+    <section
       v-else-if="activeTab === 'art-test'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
     >
@@ -117,6 +126,7 @@ type ArtTab =
   | 'gallery'
   | 'checkpoints'
   | 'styler'
+  | 'stylist'
   | 'workbench'
   | 'art-test'
 
@@ -136,6 +146,7 @@ const validTabs: LegacyArtTab[] = [
   'gallery',
   'checkpoints',
   'styler',
+  'stylist',
   'workbench',
   'art-test',
 ]

--- a/content/art.md
+++ b/content/art.md
@@ -10,7 +10,6 @@ dottitip: People keep asking if AI art is 'real' art. I never know what to say.
 amitip: "If it makes you stop and look, have a conversation, or feel something new, I’d say it does it's job!"
 sort: highlight
 dashboardKey: art
-dashboardTab: generate
 cards: artCards
 loadingMessage: Loading art gallery...
 refreshLabel: Refresh Art

--- a/stores/navStore.ts
+++ b/stores/navStore.ts
@@ -378,7 +378,15 @@ export const useNavStore = defineStore('navStore', () => {
 
   function setDashboardShellFromContent(input: ContentDashboardInput): void {
     const dashboardKey = inferDashboardKeyFromContent(input)
-    const activeTabHint = resolveDashboardTab(dashboardKey, input.dashboardTab)
+    // A page that names one of this dashboard's real tabs IS that tab
+    // (e.g. /stylist -> art/stylist), so enforce it. A page without a valid
+    // tab hint is a channel landing page — keep the visitor's remembered tab
+    // instead of resetting to the dashboard default.
+    const requestedTab = (input.dashboardTab ?? '').trim()
+    const activeTabHint =
+      requestedTab && isDashboardTabKey(dashboardKey, requestedTab)
+        ? requestedTab
+        : getDashboardTab(dashboardKey)
     const resolvedTab = setDashboardTab(
       dashboardKey,
       activeTabHint,


### PR DESCRIPTION
Fixes the two dashboard bugs Silas reported after running Hair Studio live.

## Bug 1 — clicking the Hair Studio tab kept showing the image generator
The dashboard header's tab buttons only set the stored tab (`setTab` → `setDashboardTab`) — they never navigate. On `/art`, `art-manager` renders the active tab internally, and its `validTabs` didn't include `stylist`, so the active tab fell back to `generate`.

**Fix:** `art-manager.vue` now knows the `stylist` tab and renders `<stylist-manager />` inline, exactly like every other art tab.

## Bug 2 — returning to the Art channel forgot the remembered tab
`content/art.md` declared `dashboardTab: generate` — a **valid** art tab — so every visit to `/art` force-reset the art dashboard's remembered tab (via `setDashboardShellFromContent` and the header's route-enforced watch). Other channels' landing pages carry non-tab hints (e.g. `bots.md` → `overview`, not a real bot tab), which is why only Art misbehaved.

**Fix (two parts):**
- `navStore.setDashboardShellFromContent` now enforces the frontmatter tab only when it names a **real tab of that dashboard** (page-as-tab identity, e.g. `/stylist` → art/stylist, `/memory` → wonder/memory-dungeon — those keep working exactly as before). Otherwise the page is a channel landing page and the visitor's **remembered tab is preserved**.
- `content/art.md` no longer pins `dashboardTab`, making `/art` a true landing page.

Expected behavior after this: pick Hair Studio → it renders in place; hop to Rewards and back to Art → you're still on Hair Studio (or whatever tab you left).

## ⚠️ Note on the diff size
`stores/navStore.ts` and `components/art/art-manager.vue` show whole-file diffs because they were stored with CRLF line endings while `.gitattributes` declares `* text=auto eol=lf` — this push normalizes them to LF (the repo's declared policy). Review with whitespace hidden (`?w=1` or the gear → "Hide whitespace") to see the real ~15-line change. The git relay's push path was down this session, so these commits went up via the GitHub API, which applied the normalization.

## Stakes
reversible — UI/state logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ)_