### PR TITLE
docs(sample): new-section framework for pages, tabs, and channels

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -6,6 +6,12 @@ model, updated to match the site's current patterns and commented at the
 points you change when copying. Read this sheet for the loop; read the
 files for the details.
 
+Adding a new **page, tab, or channel** (rather than a data model) has its
+own step-by-step framework: **[`new-section.md`](./new-section.md)**. It is
+the canonical recipe for both humans and agents — including the rule that a
+new *channel* requires Silas's explicit approval. The channel checklist
+below is kept in sync with it for use during the model loop.
+
 **Naming contract** (keep all five consistent or nothing lines up):
 
 | Thing | Convention | For Sample |
@@ -69,6 +75,10 @@ Component filenames must be globally unique — Nuxt registers by filename
    (`createLoggedInTestUser`, `bearerHeaders`, …), not hand-rolled tokens.
 
 ## Adding a new channel
+
+**Gate:** a new channel requires Silas's explicit approval — agents treat
+it as a hard `needs-human`. New tabs and pages inside existing channels are
+normal reversible work (see `new-section.md`).
 
 The nav system is mostly derived from one registry:
 `dashboardConfigs.footer.tabs` in `stores/helpers/dashboardHelper.ts` IS the

--- a/sample/new-section.md
+++ b/sample/new-section.md
@@ -1,0 +1,190 @@
+# New section framework — page, tab, or channel
+
+The one process for adding a new section to Kind Robots, whether Silas does
+it by hand or an agent does it for a project task. `sample/README.md` covers
+adding a new *model* (schema → API → store); this sheet covers adding a new
+*place in the app*. The two compose: a new model usually lands inside a new
+tab or channel described here.
+
+## Vocabulary
+
+- **Page** — a Nuxt Content markdown file in `content/`. The filename IS the
+  route (`content/stylist.md` → `/stylist`). Every page is a single-word
+  `title.md` whose body is one line: the `:title-manager` component
+  directive. All visible UI lives in the component, never in the markdown.
+- **Tab** — one entry inside an existing channel's config in
+  `stores/helpers/dashboardHelper.ts` (`dashboardConfigs.{channel}.tabs[]`).
+  The channel's manager component renders it dynamically.
+- **Channel** — a top-level key in `dashboardConfigs` with its own tab list,
+  footer entry, nav card, tutorial channel, route, and image set.
+
+## Permission gates
+
+| Adding a… | Who can approve it |
+| --- | --- |
+| Page | normal reversible work — no gate |
+| Tab in an existing channel | normal reversible work — no gate |
+| **Channel** | **Silas only.** Agents treat a new channel as a hard `needs-human` in the conductor loop; do not create one without his explicit approval in the task or session. |
+
+## Which recipe do I need?
+
+- New UI inside an existing channel's flow → **Recipe B (tab)**. Add a page
+  too (Recipe A) only if it deserves its own route (like `/stylist`).
+- New standalone route that maps onto an existing channel/tab → **Recipe A
+  (page)** only.
+- A genuinely new top-level area → **Recipe C (channel)**, which includes
+  A and B for its tabs. Get Silas's sign-off first.
+
+---
+
+## Recipe A — new page
+
+1. Create `content/{title}.md` — single word, lowercase; the filename is the
+   route. Copy this frontmatter (fields are validated by
+   `content.config.ts`; anything else is dead weight):
+
+   ```md
+   ---
+   title: 'Title'
+   room: 'Room Name'
+   subtitle: 'One-line hook'
+   description: 'What the visitor can do here, in a sentence or two.'
+   image: 'nav/heroes/{channel}.webp'
+   icon: kind-icon:sparkles
+   tooltip: One-line hover text.
+   dottitip: Dotti's quip about the page.
+   amitip: "AMI's reply."
+   sort: highlight
+   dashboardKey: {channel}     # must exist in dashboardConfigs
+   dashboardTab: {tab}         # must exist in that channel's tabs
+   cards: navCards
+   loadingMessage: Loading {title}...
+   refreshLabel: Refresh {title}
+   ---
+
+   :{title}-manager
+   ```
+
+2. The body is exactly one directive: `:{title}-manager`, the page's
+   primary component. Create it at `components/{domain}/{title}-manager.vue`.
+   Component filenames must be globally unique (Nuxt registers by filename;
+   folders are organizational only).
+3. `dashboardKey`/`dashboardTab` must pass `validateDashboardPair` in
+   `dashboardHelper.ts` — point them at the channel and tab this page
+   belongs to.
+
+Live examples: `content/stylist.md` (`:stylist-manager`, a tab of the art
+channel with its own route), `content/mural.md` (`:mural-manager`).
+
+## Recipe B — new tab in an existing channel
+
+For tab `{tab}` in channel `{channel}`:
+
+1. **dashboardHelper** — add an entry to
+   `dashboardConfigs.{channel}.tabs[]` in
+   `stores/helpers/dashboardHelper.ts`:
+
+   ```ts
+   {
+     key: '{tab}',
+     label: 'Label',
+     icon: 'kind-icon:sparkles',
+     title: 'Tab Title',
+     summary: 'One-line summary shown on the tab card.',
+     image: tabImage('{channel}', '{tab}'),
+     narrative:
+       'A sentence or two of voice-y description for the dashboard card.',
+     route: '/{channel-route}',   // or the tab's own route if it has a page
+   },
+   ```
+
+   Add `requiredRole: 'ADMIN'` for admin-only tabs.
+2. **tutorialCards** — add a matching section to
+   `tutorialChannels.{channel}.sections[]` in
+   `stores/helpers/tutorialCards.ts`:
+
+   ```ts
+   {
+     key: '{tab}',
+     title: 'Tab Title',
+     body: 'What the user does here, tutorial voice.',
+     image: tutorialImage('{channel}', '{tab}'),
+   },
+   ```
+
+3. **Images** — two files, named by key:
+   - `public/images/dashboard-tabs/{channel}/{tab}.webp` (dashboard card)
+   - `public/images/tutorials/{channel}/{tab}.webp` (tutorial section)
+
+   The same art committed to both paths is fine.
+4. **Component** — the channel's manager picks up the tab automatically via
+   `getDashboardTabs('{channel}')`; wire the tab key to your new component
+   inside that manager.
+5. Optional: give the tab its own route with Recipe A (set the tab's
+   `route:` to the new page).
+
+## Recipe C — new channel (Silas approval required)
+
+For channel `{channel}` at route `/{channel}` — everything in one registry
+file plus a page, a manager, and images. `dashboardConfigs.footer.tabs` in
+`dashboardHelper.ts` IS the channel list; nav cards derive from it, so you
+do **not** hand-edit `navCards.ts` (its lone hand-written card is conductor,
+which sits outside the footer).
+
+1. `stores/helpers/dashboardHelper.ts` → `dashboardConfigs.footer.tabs[]` —
+   the channel's footer/nav entry: `key`, `label`, `icon`, `title`,
+   `summary`, `image: getNavHeroImagePath('{channel}')`, `flourish`,
+   `tagline`, `narrative`, `route: '/{channel}'`.
+2. Same file → `dashboardConfigs.{channel}` — the channel's own config:
+   `{ key, label, defaultTab, tabs: [...] }`, one Recipe-B entry per tab.
+3. Same file → `footerDashboardMap` — add `'{channel}': '{channel}'`.
+   **Compile-enforced**: missing entry fails `tsc`.
+4. `stores/helpers/tutorialCards.ts` → `tutorialChannels.{channel}` — the
+   channel tutorial: `key`, `title`, `tagline`, `overview`, one section per
+   tab (Recipe B step 2). **Compile-enforced.** Add the key to
+   `EARNING_CHANNELS` if creators earn from it; standalone channels that
+   aren't footer keys go in `ExtraTutorialKey` (see `mural`).
+5. `content/{channel}.md` — the channel page (Recipe A) with
+   `dashboardKey: {channel}` and `dashboardTab: {defaultTab}`.
+6. `components/{channel}/{channel}-manager.vue` — the primary component.
+   A channel manager is a tab switcher: it reads
+   `getDashboardTabs('{channel}')` (or `getVisibleDashboardTabs` for
+   role-gated tabs) and dynamically renders the right tab's component —
+   it does not re-implement the children. `sample/sample-manager.vue.txt`
+   is the template.
+7. `components/navigation/channel-select.vue` → `allChannels[]` — add
+   `{ key, label, path: '/{channel}', icon }`. **Hand-maintained and fails
+   silently** — forget it and the channel never appears in the header
+   dropdown. Check it last.
+
+Steps 3 and 4 fail the build if skipped; step 7 does not.
+
+### Channel image checklist
+
+All under `public/images/`; filenames must match the keys exactly.
+
+| Image | Path |
+| --- | --- |
+| Channel hero (nav deck + footer) | `nav/heroes/{channel}.webp` |
+| Channel card/thumb | `nav/thumbs/{channel}.webp` |
+| Tutorial hero | `tutorials/{channel}/hero.webp` |
+| Dashboard tab (one per tab) | `dashboard-tabs/{channel}/{tab}.webp` |
+| Tutorial section (one per tab) | `tutorials/{channel}/{tab}.webp` |
+
+The tutorial hero is a separate file by default; it only reuses other art
+if you explicitly set `hero:` on the tutorial channel entry. The `icon`
+fields are Iconify `kind-icon:*` names, not files.
+
+Net for a two-tab channel: 3 code files (`dashboardHelper.ts`,
+`tutorialCards.ts`, `channel-select.vue`) + 1 content page + 1 manager
+component + 9 images.
+
+## Verifying
+
+- `npx nuxt typecheck` (or the project's `tsc` script) — catches a missing
+  `footerDashboardMap` or `tutorialChannels` entry.
+- Load the page: the frontmatter's `dashboardKey`/`dashboardTab` pair is
+  validated by `validateDashboardPair`; an invalid pair logs the expected
+  keys.
+- Check the header channel dropdown and the footer nav for the new entry —
+  the dropdown (`channel-select.vue`) is the piece nothing enforces.


### PR DESCRIPTION
### Task
Silas-directed (session): consistent step-by-step process for adding a new page, tab, or channel (kind: software/docs)

### What changed / what I produced
- `sample/new-section.md` — the canonical framework: vocabulary (page / tab / channel), permission gates (new **channel** requires Silas's explicit approval; tabs and pages are normal reversible work), and three recipes with copy-paste templates:
  - **Recipe A (page):** single-word `content/{title}.md` (filename IS the route), frontmatter template validated by `content.config.ts`, body is exactly `:{title}-manager`
  - **Recipe B (tab):** entry in `dashboardConfigs.{channel}.tabs[]` + matching `tutorialChannels.{channel}.sections[]` entry + image pair (`dashboard-tabs/{channel}/{tab}.webp`, `tutorials/{channel}/{tab}.webp`)
  - **Recipe C (channel):** footer entry, own dashboard config, `footerDashboardMap`, tutorial channel, content page, `{channel}-manager` tab switcher via `getDashboardTabs`, `channel-select.vue` (the silent-failure step), and the 5-image checklist including `tutorials/{channel}/hero.webp` and `nav/heroes|thumbs/{channel}.webp`
- `sample/README.md` — points at the new framework as canonical and states the channel-approval gate above the existing channel checklist

### How I verified
- All paths, registry names, and helpers cross-checked against `stores/helpers/dashboardHelper.ts`, `tutorialCards.ts`, `navCards.ts`, `channel-select.vue`, `content.config.ts`, and live examples (`content/stylist.md`, `content/mural.md`)
- Docs-only change; no code touched, nothing to typecheck

### Stakes
reversible

### Notes for reviewer
Companion conductor PR adds the policy-layer doc `projects/kind-robots/SECTIONS.md` that defers to this framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XiYez6WVbMLN2GDMAV1rC

---
_Generated by [Claude Code](https://claude.ai/code/session_019XiYez6WVbMLN2GDMAV1rC)_