### PR TITLE
feat(art): Hair Studio via ArtJob queue (prod fix) + full Superkate suite on /stylist

### DIFF
--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -1,0 +1,211 @@
+<!-- /components/art/stylist-calculator.vue -->
+<!--
+  Superkate services calculator (web replica). Core formula from the
+  calculator SPEC: hourly rate x time spent + product cost = total.
+  Time is hours/minutes with preset chips; product cost defaults to $0.00.
+-->
+<template>
+  <section
+    class="stylist-calculator flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
+  >
+    <header class="flex items-center gap-2">
+      <Icon name="kind-icon:sparkles" class="h-5 w-5 text-primary" />
+      <h2 class="text-base font-black text-base-content">New Appointment</h2>
+    </header>
+
+    <div class="grid gap-3 sm:grid-cols-2">
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Client</span>
+        <input
+          v-model="clientName"
+          type="text"
+          list="calculator-client-suggestions"
+          placeholder="Client name"
+          class="input input-sm input-bordered w-full"
+        />
+        <datalist id="calculator-client-suggestions">
+          <option
+            v-for="customer in superkate.sortedCustomers"
+            :key="customer.id"
+            :value="customer.name"
+          />
+        </datalist>
+      </label>
+
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Date</span>
+        <input v-model="date" type="date" class="input input-sm input-bordered w-full" />
+      </label>
+
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Hourly rate ($)</span>
+        <input
+          v-model.number="hourlyRate"
+          type="number"
+          min="0"
+          step="5"
+          class="input input-sm input-bordered w-full"
+        />
+      </label>
+
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Product cost ($, optional)</span>
+        <input
+          v-model.number="productCost"
+          type="number"
+          min="0"
+          step="1"
+          class="input input-sm input-bordered w-full"
+        />
+      </label>
+    </div>
+
+    <!-- Time spent -->
+    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
+      <span class="text-xs font-black text-base-content">Time spent</span>
+      <div class="flex flex-wrap gap-1">
+        <button
+          v-for="chip in TIME_CHIPS"
+          :key="chip.minutes"
+          type="button"
+          class="btn btn-xs rounded-lg"
+          :class="totalMinutes === chip.minutes ? 'btn-primary' : 'btn-ghost border border-base-300'"
+          @click="setMinutes(chip.minutes)"
+        >
+          {{ chip.label }}
+        </button>
+      </div>
+      <div class="flex items-center gap-2">
+        <label class="flex items-center gap-1 text-xs">
+          <input
+            v-model.number="hours"
+            type="number"
+            min="0"
+            max="12"
+            class="input input-xs input-bordered w-16"
+          />
+          hours
+        </label>
+        <label class="flex items-center gap-1 text-xs">
+          <input
+            v-model.number="minutes"
+            type="number"
+            min="0"
+            max="59"
+            step="5"
+            class="input input-xs input-bordered w-16"
+          />
+          minutes
+        </label>
+      </div>
+    </div>
+
+    <!-- Live total -->
+    <div class="flex items-center justify-between rounded-xl bg-primary/10 p-3">
+      <span class="text-xs text-base-content/70">
+        {{ formatCents(hourlyRateCents) }}/hr × {{ formatMinutes(totalMinutes) }} +
+        {{ formatCents(productCostCents) }} products
+      </span>
+      <span class="text-lg font-black text-primary">{{ formatCents(totalCents) }}</span>
+    </div>
+
+    <button
+      type="button"
+      class="btn btn-primary btn-sm"
+      :disabled="!canSave"
+      @click="save"
+    >
+      Save appointment
+    </button>
+
+    <!-- Receipt for the just-saved appointment -->
+    <div
+      v-if="savedAppointment"
+      class="flex flex-col gap-2 rounded-xl border border-success/40 bg-success/5 p-3"
+    >
+      <span class="text-xs font-black text-success">Saved! Receipt preview</span>
+      <pre class="whitespace-pre-wrap rounded-lg bg-base-100 p-2 text-xs">{{
+        superkate.receiptText(savedAppointment)
+      }}</pre>
+      <a
+        :href="superkate.receiptMailto(savedAppointment)"
+        class="btn btn-outline btn-sm"
+      >
+        <Icon name="mdi:email-outline" class="h-4 w-4" />
+        Open receipt email
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  useSuperkateStore,
+  computeTotalCents,
+  formatCents,
+  formatMinutes,
+  type SuperkateAppointment,
+} from '@/stores/superkateStore'
+
+const superkate = useSuperkateStore()
+
+const TIME_CHIPS = [
+  { label: '30m', minutes: 30 },
+  { label: '45m', minutes: 45 },
+  { label: '1h', minutes: 60 },
+  { label: '1h 30m', minutes: 90 },
+  { label: '2h', minutes: 120 },
+  { label: '2h 30m', minutes: 150 },
+  { label: '3h', minutes: 180 },
+]
+
+const clientName = ref('')
+const date = ref(new Date().toISOString().slice(0, 10))
+const hourlyRate = ref<number>(0)
+const productCost = ref<number>(0)
+const hours = ref<number>(1)
+const minutes = ref<number>(0)
+
+const savedAppointment = ref<SuperkateAppointment | null>(null)
+
+const totalMinutes = computed(
+  () => Math.max(0, hours.value || 0) * 60 + Math.max(0, minutes.value || 0),
+)
+const hourlyRateCents = computed(() =>
+  Math.round(Math.max(0, hourlyRate.value || 0) * 100),
+)
+const productCostCents = computed(() =>
+  Math.round(Math.max(0, productCost.value || 0) * 100),
+)
+const totalCents = computed(() =>
+  computeTotalCents(hourlyRateCents.value, totalMinutes.value, productCostCents.value),
+)
+
+const canSave = computed(
+  () =>
+    !!clientName.value.trim() &&
+    !!date.value &&
+    hourlyRateCents.value > 0 &&
+    totalMinutes.value > 0,
+)
+
+function setMinutes(total: number) {
+  hours.value = Math.floor(total / 60)
+  minutes.value = total % 60
+}
+
+function save() {
+  const appointment = superkate.saveAppointment({
+    clientName: clientName.value,
+    date: date.value,
+    hourlyRateCents: hourlyRateCents.value,
+    minutes: totalMinutes.value,
+    productCostCents: productCostCents.value,
+  })
+
+  if (appointment) {
+    savedAppointment.value = appointment
+  }
+}
+</script>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -1,0 +1,134 @@
+<!-- /components/art/stylist-clients.vue -->
+<!--
+  Superkate client database (web replica): add/edit/delete customers with an
+  optional email for receipt prefill. Deleting a client keeps appointment
+  history (client name snapshot) per the calculator spec's delete-detach rule.
+-->
+<template>
+  <section
+    class="stylist-clients flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
+  >
+    <header class="flex items-center gap-2">
+      <Icon name="kind-icon:heart" class="h-5 w-5 text-primary" />
+      <h2 class="text-base font-black text-base-content">Clients</h2>
+      <span class="badge badge-ghost badge-sm">{{ superkate.sortedCustomers.length }}</span>
+    </header>
+
+    <!-- Add / edit form -->
+    <form
+      class="flex flex-wrap items-end gap-2 rounded-xl border border-base-300 bg-base-100 p-3"
+      @submit.prevent="save"
+    >
+      <label class="flex min-w-40 flex-1 flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Name</span>
+        <input
+          v-model="name"
+          type="text"
+          placeholder="Client name"
+          class="input input-sm input-bordered w-full"
+        />
+      </label>
+      <label class="flex min-w-40 flex-1 flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Email (optional)</span>
+        <input
+          v-model="email"
+          type="email"
+          placeholder="For receipt prefill"
+          class="input input-sm input-bordered w-full"
+        />
+      </label>
+      <button type="submit" class="btn btn-primary btn-sm" :disabled="!name.trim()">
+        {{ editingId ? 'Update' : 'Add client' }}
+      </button>
+      <button
+        v-if="editingId"
+        type="button"
+        class="btn btn-ghost btn-sm"
+        @click="resetForm"
+      >
+        Cancel
+      </button>
+    </form>
+
+    <p v-if="!superkate.sortedCustomers.length" class="text-xs text-base-content/40">
+      No clients yet — add one above, or save an appointment and the client is created
+      automatically.
+    </p>
+
+    <ul v-else class="flex flex-col gap-2">
+      <li
+        v-for="customer in superkate.sortedCustomers"
+        :key="customer.id"
+        class="flex flex-wrap items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
+      >
+        <div class="flex min-w-0 flex-1 flex-col">
+          <span class="truncate text-sm font-bold">{{ customer.name }}</span>
+          <span class="truncate text-xs text-base-content/50">
+            {{ customer.email || 'no email' }} ·
+            {{ superkate.appointmentsForCustomer(customer.id).length }} appointments
+          </span>
+        </div>
+        <button type="button" class="btn btn-ghost btn-xs" @click="edit(customer)">
+          Edit
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs text-error"
+          @click="confirmRemove(customer)"
+        >
+          Delete
+        </button>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  useSuperkateStore,
+  type SuperkateCustomer,
+} from '@/stores/superkateStore'
+
+const superkate = useSuperkateStore()
+
+const name = ref('')
+const email = ref('')
+const editingId = ref<number | null>(null)
+
+function resetForm() {
+  name.value = ''
+  email.value = ''
+  editingId.value = null
+}
+
+function edit(customer: SuperkateCustomer) {
+  editingId.value = customer.id
+  name.value = customer.name
+  email.value = customer.email
+}
+
+function save() {
+  if (!name.value.trim()) return
+  superkate.saveCustomer({
+    id: editingId.value,
+    name: name.value,
+    email: email.value,
+  })
+  resetForm()
+}
+
+function confirmRemove(customer: SuperkateCustomer) {
+  const ok =
+    typeof window === 'undefined'
+      ? false
+      : window.confirm(
+          `Delete ${customer.name}? Their appointment history keeps its name, but the profile and email are removed.`,
+        )
+
+  if (ok) {
+    superkate.removeCustomer(customer.id)
+    if (editingId.value === customer.id) resetForm()
+  }
+}
+</script>

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -1,0 +1,127 @@
+<!-- /components/art/stylist-history.vue -->
+<!--
+  Superkate appointment history (web replica): search by client name, filter
+  by date, review totals, and open the warm receipt email for any appointment.
+-->
+<template>
+  <section
+    class="stylist-history flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
+  >
+    <header class="flex items-center gap-2">
+      <Icon name="kind-icon:book" class="h-5 w-5 text-primary" />
+      <h2 class="text-base font-black text-base-content">Appointments</h2>
+      <span class="badge badge-ghost badge-sm">{{ results.length }}</span>
+    </header>
+
+    <div class="flex flex-wrap gap-2">
+      <input
+        v-model="query"
+        type="text"
+        placeholder="Search by client"
+        class="input input-sm input-bordered min-w-40 flex-1"
+      />
+      <input v-model="date" type="date" class="input input-sm input-bordered" />
+      <button
+        v-if="query || date"
+        type="button"
+        class="btn btn-ghost btn-sm"
+        @click="clearFilters"
+      >
+        Clear
+      </button>
+    </div>
+
+    <p v-if="!results.length" class="text-xs text-base-content/40">
+      {{
+        superkate.sortedAppointments.length
+          ? 'No appointments match those filters.'
+          : 'No appointments saved yet — the Calculator tab creates them.'
+      }}
+    </p>
+
+    <ul v-else class="flex flex-col gap-2">
+      <li
+        v-for="appointment in results"
+        :key="appointment.id"
+        class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
+      >
+        <div class="flex flex-wrap items-center gap-2">
+          <div class="flex min-w-0 flex-1 flex-col">
+            <span class="truncate text-sm font-bold">{{ appointment.clientName }}</span>
+            <span class="text-xs text-base-content/50">
+              {{ appointment.date }} · {{ formatCents(appointment.hourlyRateCents) }}/hr ×
+              {{ formatMinutes(appointment.minutes) }} +
+              {{ formatCents(appointment.productCostCents) }}
+            </span>
+          </div>
+          <span class="text-base font-black text-primary">
+            {{ formatCents(appointment.totalCents) }}
+          </span>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs"
+            @click="toggleReceipt(appointment.id)"
+          >
+            Receipt
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs text-error"
+            @click="confirmRemove(appointment)"
+          >
+            Delete
+          </button>
+        </div>
+
+        <div
+          v-if="openReceiptId === appointment.id"
+          class="flex flex-col gap-2 rounded-lg bg-base-200 p-2"
+        >
+          <pre class="whitespace-pre-wrap text-xs">{{ superkate.receiptText(appointment) }}</pre>
+          <a :href="superkate.receiptMailto(appointment)" class="btn btn-outline btn-xs">
+            <Icon name="mdi:email-outline" class="h-4 w-4" />
+            Open receipt email
+          </a>
+        </div>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  useSuperkateStore,
+  formatCents,
+  formatMinutes,
+  type SuperkateAppointment,
+} from '@/stores/superkateStore'
+
+const superkate = useSuperkateStore()
+
+const query = ref('')
+const date = ref('')
+const openReceiptId = ref<number | null>(null)
+
+const results = computed(() => superkate.searchAppointments(query.value, date.value))
+
+function clearFilters() {
+  query.value = ''
+  date.value = ''
+}
+
+function toggleReceipt(id: number) {
+  openReceiptId.value = openReceiptId.value === id ? null : id
+}
+
+function confirmRemove(appointment: SuperkateAppointment) {
+  const ok =
+    typeof window === 'undefined'
+      ? false
+      : window.confirm(
+          `Delete the ${appointment.date} appointment for ${appointment.clientName}?`,
+        )
+
+  if (ok) superkate.removeAppointment(appointment.id)
+}
+</script>

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -1,467 +1,65 @@
 <!-- /components/art/stylist-manager.vue -->
 <!--
-  Hair Studio (Superkate) — upload or snap a client photo, choose color / style /
-  enhance (any combination), and send it through the Kind Robots Kontext backend to
-  get the same photo back with new hair.
-
-  Job state and past looks live in stylistStore, so a styling job keeps running (and
-  its result still lands) even if Superkate leaves the /stylist tab and comes back.
-  Results are saved private (isPublic:false) and tagged per client. See conductor
-  superkate-hairstyle-ai t-007 (navigable async) and t-008 (durable per-client gallery).
+  Hair by Superkate suite (/stylist) — a web replica of the whole Superkate app
+  (conductor superkate-hairstyle-ai t-015), not just the hair restyler:
+  Calculator | Clients | History | Hair Studio. Data lives in superkateStore
+  (localStorage-persisted mock; KR-model-backed sync is a follow-up).
 -->
 <template>
-  <section
-    class="stylist-manager flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
-    <header class="flex items-center gap-2">
-      <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
-      <h2 class="text-base font-black text-base-content">Hair Studio</h2>
-      <span class="badge badge-primary badge-sm">Kontext</span>
-      <span class="badge badge-ghost badge-sm">Private</span>
+  <section class="stylist-suite flex h-full min-h-0 w-full flex-col gap-3">
+    <nav
+      class="flex flex-wrap items-center gap-1 rounded-2xl border border-base-300 bg-base-200 p-2"
+    >
+      <Icon name="kind-icon:magic" class="ml-1 h-5 w-5 text-primary" />
+      <span class="mr-2 text-sm font-black text-base-content">
+        {{ superkate.settings.salonName }}
+      </span>
+      <button
+        v-for="view in views"
+        :key="view.key"
+        type="button"
+        class="btn btn-sm rounded-xl"
+        :class="superkate.activeView === view.key ? 'btn-primary' : 'btn-ghost'"
+        @click="superkate.activeView = view.key"
+      >
+        <Icon :name="view.icon" class="h-4 w-4" />
+        {{ view.label }}
+      </button>
       <div class="flex-1" />
       <span
         v-if="stylist.isBusy"
-        class="flex items-center gap-1 text-xs font-semibold text-primary"
+        class="mr-1 flex items-center gap-1 text-xs font-semibold text-primary"
       >
         <span class="loading loading-spinner loading-xs" />
-        {{ stylist.pendingCount }} styling…
+        styling
       </span>
-    </header>
+    </nav>
 
-    <!-- Client -->
-    <div class="rounded-xl border border-base-300 bg-base-100 p-3">
-      <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Client</span>
-        <input
-          v-model="clientName"
-          type="text"
-          placeholder="Whose hair are we styling?"
-          class="input input-sm input-bordered w-full"
-        />
-      </label>
-    </div>
-
-    <!-- Source image -->
-    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
-      <div class="flex items-center gap-2">
-        <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-black text-base-content">Client Photo</span>
-        <div class="flex-1" />
-        <div class="flex overflow-hidden rounded-lg border border-base-300 text-xs">
-          <button
-            type="button"
-            class="px-2.5 py-1 font-bold transition"
-            :class="sourceTab === 'upload' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
-            @click="sourceTab = 'upload'"
-          >
-            Upload
-          </button>
-          <button
-            type="button"
-            class="px-2.5 py-1 font-bold transition"
-            :class="sourceTab === 'camera' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
-            @click="openCamera"
-          >
-            Camera
-          </button>
-        </div>
-      </div>
-
-      <!-- Upload -->
-      <div
-        v-show="sourceTab === 'upload' && !sourceImageData"
-        class="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed p-6 text-center text-xs transition"
-        :class="isDragging ? 'border-primary bg-primary/5' : 'border-base-300 hover:border-primary/60'"
-        @click="fileInput?.click()"
-        @dragover.prevent="isDragging = true"
-        @dragleave.prevent="isDragging = false"
-        @drop.prevent="handleDrop"
-      >
-        <Icon name="kind-icon:upload" class="h-6 w-6 text-base-content/50" />
-        <span class="font-bold text-base-content/70">Drop a photo or click to browse</span>
-        <input
-          ref="fileInput"
-          type="file"
-          accept="image/*"
-          class="hidden"
-          @change="handleFileSelect"
-        />
-      </div>
-
-      <!-- Camera -->
-      <div v-show="sourceTab === 'camera' && cameraActive" class="flex flex-col items-center gap-2">
-        <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
-        <video ref="videoEl" autoplay playsinline class="max-h-64 w-full rounded-lg bg-black object-contain" />
-        <div class="flex gap-2">
-          <button type="button" class="btn btn-primary btn-sm" @click="capturePhoto">
-            <Icon name="kind-icon:camera" class="h-4 w-4" /> Capture
-          </button>
-          <button type="button" class="btn btn-ghost btn-sm" @click="closeCamera">Cancel</button>
-        </div>
-      </div>
-
-      <!-- Preview -->
-      <div v-if="sourceImageData" class="relative">
-        <img :src="sourceImageData" alt="Client photo" class="max-h-64 w-full rounded-lg object-contain" />
-        <button
-          type="button"
-          class="btn btn-circle btn-error btn-xs absolute right-2 top-2"
-          title="Remove photo"
-          @click="clearSource"
-        >
-          <Icon name="mdi:close" class="h-4 w-4" />
-        </button>
-      </div>
-    </div>
-
-    <!-- What to change -->
-    <div class="flex flex-col gap-3 rounded-xl border border-base-300 bg-base-100 p-3">
-      <span class="text-xs font-black text-base-content">What are we changing?</span>
-
-      <label class="flex items-start gap-2">
-        <input v-model="changeColor" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
-        <div class="flex flex-1 flex-col gap-1">
-          <span class="text-sm font-bold">Change color</span>
-          <input
-            v-model="colorValue"
-            :disabled="!changeColor"
-            type="text"
-            placeholder="e.g. warm copper, ash blonde, deep violet"
-            class="input input-xs input-bordered w-full"
-          />
-        </div>
-      </label>
-
-      <label class="flex items-start gap-2">
-        <input v-model="changeStyle" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
-        <div class="flex flex-1 flex-col gap-1">
-          <span class="text-sm font-bold">Change style</span>
-          <input
-            v-model="styleValue"
-            :disabled="!changeStyle"
-            type="text"
-            placeholder="e.g. shoulder-length curtain bangs, sleek bob, beachy waves"
-            class="input input-xs input-bordered w-full"
-          />
-        </div>
-      </label>
-
-      <label class="flex items-start gap-2">
-        <input v-model="enhanceImage" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
-        <div class="flex flex-1 flex-col gap-1">
-          <span class="text-sm font-bold">Improve the overall image</span>
-          <span class="text-xs text-base-content/50">Cleaner lighting, sharper detail — face and identity kept.</span>
-        </div>
-      </label>
-
-      <label class="flex flex-col gap-1">
-        <span class="text-xs font-bold text-base-content/70">Extra notes (optional)</span>
-        <input
-          v-model="extraNotes"
-          type="text"
-          placeholder="Anything else Superkate wants to try"
-          class="input input-xs input-bordered w-full"
-        />
-      </label>
-
-      <p v-if="changeSummary" class="rounded-lg bg-base-200 p-2 text-xs text-base-content/70">
-        {{ changeSummary }}
-      </p>
-    </div>
-
-    <!-- Action -->
-    <button
-      type="button"
-      class="btn btn-primary btn-sm"
-      :disabled="!canGenerate"
-      @click="submit"
-    >
-      <Icon name="kind-icon:magic" class="h-4 w-4" />
-      Style it
-    </button>
-
-    <p class="text-center text-xs text-base-content/50">
-      Styling takes a minute or two — you can keep working or switch tabs; results land below when ready.
-    </p>
-
-    <!-- This session's jobs -->
-    <div v-if="visibleJobs.length" class="flex flex-col gap-2">
-      <span class="text-xs font-black text-base-content">
-        {{ clientName.trim() ? `Styling ${clientName.trim()}` : 'This session' }}
-      </span>
-      <div class="grid gap-3 sm:grid-cols-2">
-        <article
-          v-for="job in visibleJobs"
-          :key="job.id"
-          class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
-        >
-          <div class="flex items-center gap-2 text-xs">
-            <span class="font-bold">{{ job.client || 'Unnamed client' }}</span>
-            <span v-if="job.status === 'pending'" class="badge badge-warning badge-xs gap-1">
-              <span class="loading loading-spinner loading-xs" /> working
-            </span>
-            <span v-else-if="job.status === 'failed'" class="badge badge-error badge-xs">failed</span>
-            <span v-else class="badge badge-success badge-xs">done</span>
-            <div class="flex-1" />
-            <button
-              v-if="job.status === 'failed'"
-              type="button"
-              class="btn btn-ghost btn-xs"
-              @click="stylist.retryJob(job.id)"
-            >
-              Retry
-            </button>
-            <button
-              type="button"
-              class="btn btn-circle btn-ghost btn-xs"
-              title="Dismiss"
-              @click="stylist.dismissJob(job.id)"
-            >
-              <Icon name="mdi:close" class="h-3.5 w-3.5" />
-            </button>
-          </div>
-          <div class="grid grid-cols-2 gap-1">
-            <figure class="flex flex-col gap-1">
-              <img :src="job.before" alt="Before" class="aspect-square w-full rounded-lg object-cover" />
-              <figcaption class="text-center text-[10px] text-base-content/50">Before</figcaption>
-            </figure>
-            <figure class="flex flex-col gap-1">
-              <img
-                v-if="job.after"
-                :src="job.after"
-                alt="After"
-                class="aspect-square w-full rounded-lg object-cover"
-              />
-              <div
-                v-else
-                class="flex aspect-square w-full items-center justify-center rounded-lg bg-base-200"
-              >
-                <span v-if="job.status === 'pending'" class="loading loading-spinner text-primary" />
-                <Icon v-else name="mdi:image-broken" class="h-6 w-6 text-base-content/30" />
-              </div>
-              <figcaption class="text-center text-[10px] text-base-content/50">After</figcaption>
-            </figure>
-          </div>
-          <p v-if="job.error" class="text-[10px] font-semibold text-error">{{ job.error }}</p>
-          <p v-else class="line-clamp-2 text-[10px] text-base-content/50" :title="job.prompt">
-            {{ job.prompt }}
-          </p>
-        </article>
-      </div>
-    </div>
-
-    <!-- Durable per-client history -->
-    <div class="flex flex-col gap-2">
-      <div class="flex items-center gap-2">
-        <span class="text-xs font-black text-base-content">
-          {{ clientName.trim() ? `Past looks for ${clientName.trim()}` : 'Past looks' }}
-        </span>
-        <span v-if="stylist.isLoadingHistory" class="loading loading-spinner loading-xs text-primary" />
-        <div class="flex-1" />
-        <button type="button" class="btn btn-ghost btn-xs" @click="stylist.loadHistory(true)">
-          Refresh
-        </button>
-      </div>
-      <p v-if="stylist.historyError" class="text-xs text-error">{{ stylist.historyError }}</p>
-      <p
-        v-else-if="!clientHistory.length && !stylist.isLoadingHistory"
-        class="text-xs text-base-content/40"
-      >
-        No saved looks yet{{ clientName.trim() ? ' for this client' : '' }}.
-      </p>
-      <div v-else class="grid grid-cols-3 gap-2 sm:grid-cols-4">
-        <figure
-          v-for="image in clientHistory"
-          :key="image.id"
-          class="flex flex-col gap-1"
-        >
-          <img
-            :src="historyImageSrc(image)"
-            :alt="`Look for ${clientFromDesigner(image.designer) || 'client'}`"
-            class="aspect-square w-full rounded-lg object-cover"
-          />
-          <figcaption
-            v-if="!clientName.trim()"
-            class="truncate text-center text-[10px] text-base-content/50"
-          >
-            {{ clientFromDesigner(image.designer) || 'client' }}
-          </figcaption>
-        </figure>
-      </div>
+    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+      <stylist-calculator v-if="superkate.activeView === 'calculator'" />
+      <stylist-clients v-else-if="superkate.activeView === 'clients'" />
+      <stylist-history v-else-if="superkate.activeView === 'history'" />
+      <stylist-restyle v-else />
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import {
-  useStylistStore,
-  clientFromDesigner,
-} from '@/stores/stylistStore'
-import type { ArtImage } from '~/prisma/generated/prisma/client'
+import { onMounted } from 'vue'
+import { useStylistStore } from '@/stores/stylistStore'
+import { useSuperkateStore } from '@/stores/superkateStore'
 
 const stylist = useStylistStore()
+const superkate = useSuperkateStore()
 
-const clientName = ref('')
-
-const sourceTab = ref<'upload' | 'camera'>('upload')
-const sourceImageData = ref<string | null>(null)
-const fileInput = ref<HTMLInputElement | null>(null)
-const isDragging = ref(false)
-
-const videoEl = ref<HTMLVideoElement | null>(null)
-const cameraActive = ref(false)
-let cameraStream: MediaStream | null = null
-
-const changeColor = ref(false)
-const colorValue = ref('')
-const changeStyle = ref(false)
-const styleValue = ref('')
-const enhanceImage = ref(false)
-const extraNotes = ref('')
-
-const hasAnyChange = computed(
-  () => changeColor.value || changeStyle.value || enhanceImage.value,
-)
-
-const canGenerate = computed(
-  () => !!sourceImageData.value && hasAnyChange.value,
-)
-
-const visibleJobs = computed(() => stylist.jobsForClient(clientName.value))
-const clientHistory = computed(() =>
-  stylist.historyForClient(clientName.value),
-)
-
-const changeSummary = computed(() => {
-  const parts: string[] = []
-  if (changeColor.value)
-    parts.push(colorValue.value.trim() ? `color → ${colorValue.value.trim()}` : 'new color')
-  if (changeStyle.value)
-    parts.push(styleValue.value.trim() ? `style → ${styleValue.value.trim()}` : 'new style')
-  if (enhanceImage.value) parts.push('image cleanup')
-  if (!parts.length) return ''
-  return `We'll ${parts.join(', ')} — keeping the same face and person.`
-})
-
-function buildPrompt(): string {
-  const clauses: string[] = []
-
-  if (changeColor.value) {
-    clauses.push(
-      colorValue.value.trim()
-        ? `change the hair color to ${colorValue.value.trim()}`
-        : 'give the hair a flattering new color',
-    )
-  }
-  if (changeStyle.value) {
-    clauses.push(
-      styleValue.value.trim()
-        ? `restyle the hair as ${styleValue.value.trim()}`
-        : 'give a fresh, flattering new hairstyle',
-    )
-  }
-  if (enhanceImage.value) {
-    clauses.push('improve the overall photo quality, lighting, and sharpness')
-  }
-  if (extraNotes.value.trim()) {
-    clauses.push(extraNotes.value.trim())
-  }
-
-  clauses.push(
-    'keep the same person, same face and identity, natural photorealistic result',
-  )
-
-  return clauses.join('. ')
-}
-
-function historyImageSrc(image: ArtImage): string {
-  const img = image as ArtImage & {
-    imageData?: string | null
-    thumbnailData?: string | null
-    imagePath?: string | null
-    path?: string | null
-  }
-  if (img.thumbnailData) {
-    return `data:image/${img.fileType || 'png'};base64,${img.thumbnailData}`
-  }
-  if (img.imageData) {
-    return `data:image/${img.fileType || 'png'};base64,${img.imageData}`
-  }
-  return img.imagePath || img.path || ''
-}
-
-function handleFileSelect(event: Event) {
-  const input = event.target as HTMLInputElement
-  if (input.files?.[0]) processFile(input.files[0])
-  if (fileInput.value) fileInput.value.value = ''
-}
-
-function handleDrop(event: DragEvent) {
-  isDragging.value = false
-  const file = event.dataTransfer?.files?.[0]
-  if (file && file.type.startsWith('image/')) processFile(file)
-}
-
-function processFile(file: File) {
-  const reader = new FileReader()
-  reader.onload = (event) => {
-    sourceImageData.value = (event.target?.result as string) ?? null
-  }
-  reader.readAsDataURL(file)
-}
-
-async function openCamera() {
-  sourceTab.value = 'camera'
-  try {
-    cameraStream = await navigator.mediaDevices.getUserMedia({
-      video: { facingMode: 'user' },
-      audio: false,
-    })
-    cameraActive.value = true
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    if (videoEl.value) videoEl.value.srcObject = cameraStream
-  } catch {
-    cameraActive.value = false
-    sourceTab.value = 'upload'
-  }
-}
-
-function capturePhoto() {
-  const video = videoEl.value
-  if (!video) return
-  const canvas = document.createElement('canvas')
-  canvas.width = video.videoWidth || 768
-  canvas.height = video.videoHeight || 768
-  const ctx = canvas.getContext('2d')
-  if (!ctx) return
-  ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
-  sourceImageData.value = canvas.toDataURL('image/png')
-  closeCamera()
-}
-
-function closeCamera() {
-  cameraStream?.getTracks().forEach((track) => track.stop())
-  cameraStream = null
-  cameraActive.value = false
-}
-
-function clearSource() {
-  sourceImageData.value = null
-}
-
-function submit() {
-  if (!sourceImageData.value || !hasAnyChange.value) return
-  void stylist.runStylist({
-    client: clientName.value,
-    before: sourceImageData.value,
-    prompt: buildPrompt(),
-  })
-}
+const views = [
+  { key: 'studio', label: 'Hair Studio', icon: 'kind-icon:magic' },
+  { key: 'calculator', label: 'Calculator', icon: 'kind-icon:sparkles' },
+  { key: 'clients', label: 'Clients', icon: 'kind-icon:heart' },
+  { key: 'history', label: 'History', icon: 'kind-icon:book' },
+] as const
 
 onMounted(() => {
-  void stylist.loadHistory()
+  superkate.hydrate()
 })
-
-onBeforeUnmount(closeCamera)
 </script>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -1,0 +1,478 @@
+<!-- /components/art/stylist-restyle.vue -->
+<!--
+  Hair Studio restyler (Superkate) — upload or snap a client photo, choose color /
+  style / enhance (any combination), and send it through the Kind Robots Kontext
+  queue to get the same photo back with new hair. Hosted inside the /stylist suite
+  (stylist-manager.vue) alongside the calculator, clients, and history views.
+
+  Job state and past looks live in stylistStore, so a styling job keeps running (and
+  its result still lands) even if Superkate leaves the /stylist tab and comes back.
+  Results are saved private (isPublic:false) and tagged per client. See conductor
+  superkate-hairstyle-ai t-007 (navigable async) and t-008 (durable per-client gallery).
+-->
+<template>
+  <section
+    class="stylist-restyle flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
+  >
+    <header class="flex items-center gap-2">
+      <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
+      <h2 class="text-base font-black text-base-content">Hair Studio</h2>
+      <span class="badge badge-primary badge-sm">Kontext</span>
+      <span class="badge badge-ghost badge-sm">Private</span>
+      <div class="flex-1" />
+      <span
+        v-if="stylist.isBusy"
+        class="flex items-center gap-1 text-xs font-semibold text-primary"
+      >
+        <span class="loading loading-spinner loading-xs" />
+        {{ stylist.pendingCount }} styling…
+      </span>
+    </header>
+
+    <!-- Client -->
+    <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-black text-base-content">Client</span>
+        <input
+          v-model="clientName"
+          type="text"
+          list="stylist-client-suggestions"
+          placeholder="Whose hair are we styling?"
+          class="input input-sm input-bordered w-full"
+        />
+        <datalist id="stylist-client-suggestions">
+          <option
+            v-for="customer in superkate.sortedCustomers"
+            :key="customer.id"
+            :value="customer.name"
+          />
+        </datalist>
+      </label>
+    </div>
+
+    <!-- Source image -->
+    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
+      <div class="flex items-center gap-2">
+        <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
+        <span class="text-xs font-black text-base-content">Client Photo</span>
+        <div class="flex-1" />
+        <div class="flex overflow-hidden rounded-lg border border-base-300 text-xs">
+          <button
+            type="button"
+            class="px-2.5 py-1 font-bold transition"
+            :class="sourceTab === 'upload' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
+            @click="sourceTab = 'upload'"
+          >
+            Upload
+          </button>
+          <button
+            type="button"
+            class="px-2.5 py-1 font-bold transition"
+            :class="sourceTab === 'camera' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
+            @click="openCamera"
+          >
+            Camera
+          </button>
+        </div>
+      </div>
+
+      <!-- Upload -->
+      <div
+        v-show="sourceTab === 'upload' && !sourceImageData"
+        class="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed p-6 text-center text-xs transition"
+        :class="isDragging ? 'border-primary bg-primary/5' : 'border-base-300 hover:border-primary/60'"
+        @click="fileInput?.click()"
+        @dragover.prevent="isDragging = true"
+        @dragleave.prevent="isDragging = false"
+        @drop.prevent="handleDrop"
+      >
+        <Icon name="kind-icon:upload" class="h-6 w-6 text-base-content/50" />
+        <span class="font-bold text-base-content/70">Drop a photo or click to browse</span>
+        <input
+          ref="fileInput"
+          type="file"
+          accept="image/*"
+          class="hidden"
+          @change="handleFileSelect"
+        />
+      </div>
+
+      <!-- Camera -->
+      <div v-show="sourceTab === 'camera' && cameraActive" class="flex flex-col items-center gap-2">
+        <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
+        <video ref="videoEl" autoplay playsinline class="max-h-64 w-full rounded-lg bg-black object-contain" />
+        <div class="flex gap-2">
+          <button type="button" class="btn btn-primary btn-sm" @click="capturePhoto">
+            <Icon name="kind-icon:camera" class="h-4 w-4" /> Capture
+          </button>
+          <button type="button" class="btn btn-ghost btn-sm" @click="closeCamera">Cancel</button>
+        </div>
+      </div>
+
+      <!-- Preview -->
+      <div v-if="sourceImageData" class="relative">
+        <img :src="sourceImageData" alt="Client photo" class="max-h-64 w-full rounded-lg object-contain" />
+        <button
+          type="button"
+          class="btn btn-circle btn-error btn-xs absolute right-2 top-2"
+          title="Remove photo"
+          @click="clearSource"
+        >
+          <Icon name="mdi:close" class="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+
+    <!-- What to change -->
+    <div class="flex flex-col gap-3 rounded-xl border border-base-300 bg-base-100 p-3">
+      <span class="text-xs font-black text-base-content">What are we changing?</span>
+
+      <label class="flex items-start gap-2">
+        <input v-model="changeColor" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
+        <div class="flex flex-1 flex-col gap-1">
+          <span class="text-sm font-bold">Change color</span>
+          <input
+            v-model="colorValue"
+            :disabled="!changeColor"
+            type="text"
+            placeholder="e.g. warm copper, ash blonde, deep violet"
+            class="input input-xs input-bordered w-full"
+          />
+        </div>
+      </label>
+
+      <label class="flex items-start gap-2">
+        <input v-model="changeStyle" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
+        <div class="flex flex-1 flex-col gap-1">
+          <span class="text-sm font-bold">Change style</span>
+          <input
+            v-model="styleValue"
+            :disabled="!changeStyle"
+            type="text"
+            placeholder="e.g. shoulder-length curtain bangs, sleek bob, beachy waves"
+            class="input input-xs input-bordered w-full"
+          />
+        </div>
+      </label>
+
+      <label class="flex items-start gap-2">
+        <input v-model="enhanceImage" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
+        <div class="flex flex-1 flex-col gap-1">
+          <span class="text-sm font-bold">Improve the overall image</span>
+          <span class="text-xs text-base-content/50">Cleaner lighting, sharper detail — face and identity kept.</span>
+        </div>
+      </label>
+
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-bold text-base-content/70">Extra notes (optional)</span>
+        <input
+          v-model="extraNotes"
+          type="text"
+          placeholder="Anything else Superkate wants to try"
+          class="input input-xs input-bordered w-full"
+        />
+      </label>
+
+      <p v-if="changeSummary" class="rounded-lg bg-base-200 p-2 text-xs text-base-content/70">
+        {{ changeSummary }}
+      </p>
+    </div>
+
+    <!-- Action -->
+    <button
+      type="button"
+      class="btn btn-primary btn-sm"
+      :disabled="!canGenerate"
+      @click="submit"
+    >
+      <Icon name="kind-icon:magic" class="h-4 w-4" />
+      Style it
+    </button>
+
+    <p class="text-center text-xs text-base-content/50">
+      Styling takes a minute or two — you can keep working or switch tabs; results land below when ready.
+    </p>
+
+    <!-- This session's jobs -->
+    <div v-if="visibleJobs.length" class="flex flex-col gap-2">
+      <span class="text-xs font-black text-base-content">
+        {{ clientName.trim() ? `Styling ${clientName.trim()}` : 'This session' }}
+      </span>
+      <div class="grid gap-3 sm:grid-cols-2">
+        <article
+          v-for="job in visibleJobs"
+          :key="job.id"
+          class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
+        >
+          <div class="flex items-center gap-2 text-xs">
+            <span class="font-bold">{{ job.client || 'Unnamed client' }}</span>
+            <span v-if="job.status === 'pending'" class="badge badge-warning badge-xs gap-1">
+              <span class="loading loading-spinner loading-xs" /> working
+            </span>
+            <span v-else-if="job.status === 'failed'" class="badge badge-error badge-xs">failed</span>
+            <span v-else class="badge badge-success badge-xs">done</span>
+            <div class="flex-1" />
+            <button
+              v-if="job.status === 'failed'"
+              type="button"
+              class="btn btn-ghost btn-xs"
+              @click="stylist.retryJob(job.id)"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              class="btn btn-circle btn-ghost btn-xs"
+              title="Dismiss"
+              @click="stylist.dismissJob(job.id)"
+            >
+              <Icon name="mdi:close" class="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <div class="grid grid-cols-2 gap-1">
+            <figure class="flex flex-col gap-1">
+              <img :src="job.before" alt="Before" class="aspect-square w-full rounded-lg object-cover" />
+              <figcaption class="text-center text-[10px] text-base-content/50">Before</figcaption>
+            </figure>
+            <figure class="flex flex-col gap-1">
+              <img
+                v-if="job.after"
+                :src="job.after"
+                alt="After"
+                class="aspect-square w-full rounded-lg object-cover"
+              />
+              <div
+                v-else
+                class="flex aspect-square w-full items-center justify-center rounded-lg bg-base-200"
+              >
+                <span v-if="job.status === 'pending'" class="loading loading-spinner text-primary" />
+                <Icon v-else name="mdi:image-broken" class="h-6 w-6 text-base-content/30" />
+              </div>
+              <figcaption class="text-center text-[10px] text-base-content/50">After</figcaption>
+            </figure>
+          </div>
+          <p v-if="job.error" class="text-[10px] font-semibold text-error">{{ job.error }}</p>
+          <p v-else class="line-clamp-2 text-[10px] text-base-content/50" :title="job.prompt">
+            {{ job.prompt }}
+          </p>
+        </article>
+      </div>
+    </div>
+
+    <!-- Durable per-client history -->
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-black text-base-content">
+          {{ clientName.trim() ? `Past looks for ${clientName.trim()}` : 'Past looks' }}
+        </span>
+        <span v-if="stylist.isLoadingHistory" class="loading loading-spinner loading-xs text-primary" />
+        <div class="flex-1" />
+        <button type="button" class="btn btn-ghost btn-xs" @click="stylist.loadHistory(true)">
+          Refresh
+        </button>
+      </div>
+      <p v-if="stylist.historyError" class="text-xs text-error">{{ stylist.historyError }}</p>
+      <p
+        v-else-if="!clientHistory.length && !stylist.isLoadingHistory"
+        class="text-xs text-base-content/40"
+      >
+        No saved looks yet{{ clientName.trim() ? ' for this client' : '' }}.
+      </p>
+      <div v-else class="grid grid-cols-3 gap-2 sm:grid-cols-4">
+        <figure
+          v-for="image in clientHistory"
+          :key="image.id"
+          class="flex flex-col gap-1"
+        >
+          <img
+            :src="historyImageSrc(image)"
+            :alt="`Look for ${clientFromDesigner(image.designer) || 'client'}`"
+            class="aspect-square w-full rounded-lg object-cover"
+          />
+          <figcaption
+            v-if="!clientName.trim()"
+            class="truncate text-center text-[10px] text-base-content/50"
+          >
+            {{ clientFromDesigner(image.designer) || 'client' }}
+          </figcaption>
+        </figure>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  useStylistStore,
+  clientFromDesigner,
+} from '@/stores/stylistStore'
+import { useSuperkateStore } from '@/stores/superkateStore'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+
+const stylist = useStylistStore()
+const superkate = useSuperkateStore()
+
+const clientName = ref('')
+
+const sourceTab = ref<'upload' | 'camera'>('upload')
+const sourceImageData = ref<string | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+const isDragging = ref(false)
+
+const videoEl = ref<HTMLVideoElement | null>(null)
+const cameraActive = ref(false)
+let cameraStream: MediaStream | null = null
+
+const changeColor = ref(false)
+const colorValue = ref('')
+const changeStyle = ref(false)
+const styleValue = ref('')
+const enhanceImage = ref(false)
+const extraNotes = ref('')
+
+const hasAnyChange = computed(
+  () => changeColor.value || changeStyle.value || enhanceImage.value,
+)
+
+const canGenerate = computed(
+  () => !!sourceImageData.value && hasAnyChange.value,
+)
+
+const visibleJobs = computed(() => stylist.jobsForClient(clientName.value))
+const clientHistory = computed(() =>
+  stylist.historyForClient(clientName.value),
+)
+
+const changeSummary = computed(() => {
+  const parts: string[] = []
+  if (changeColor.value)
+    parts.push(colorValue.value.trim() ? `color → ${colorValue.value.trim()}` : 'new color')
+  if (changeStyle.value)
+    parts.push(styleValue.value.trim() ? `style → ${styleValue.value.trim()}` : 'new style')
+  if (enhanceImage.value) parts.push('image cleanup')
+  if (!parts.length) return ''
+  return `We'll ${parts.join(', ')} — keeping the same face and person.`
+})
+
+function buildPrompt(): string {
+  const clauses: string[] = []
+
+  if (changeColor.value) {
+    clauses.push(
+      colorValue.value.trim()
+        ? `change the hair color to ${colorValue.value.trim()}`
+        : 'give the hair a flattering new color',
+    )
+  }
+  if (changeStyle.value) {
+    clauses.push(
+      styleValue.value.trim()
+        ? `restyle the hair as ${styleValue.value.trim()}`
+        : 'give a fresh, flattering new hairstyle',
+    )
+  }
+  if (enhanceImage.value) {
+    clauses.push('improve the overall photo quality, lighting, and sharpness')
+  }
+  if (extraNotes.value.trim()) {
+    clauses.push(extraNotes.value.trim())
+  }
+
+  clauses.push(
+    'keep the same person, same face and identity, natural photorealistic result',
+  )
+
+  return clauses.join('. ')
+}
+
+function historyImageSrc(image: ArtImage): string {
+  const img = image as ArtImage & {
+    imageData?: string | null
+    thumbnailData?: string | null
+    imagePath?: string | null
+    path?: string | null
+  }
+  if (img.thumbnailData) {
+    return `data:image/${img.fileType || 'png'};base64,${img.thumbnailData}`
+  }
+  if (img.imageData) {
+    return `data:image/${img.fileType || 'png'};base64,${img.imageData}`
+  }
+  return img.imagePath || img.path || ''
+}
+
+function handleFileSelect(event: Event) {
+  const input = event.target as HTMLInputElement
+  if (input.files?.[0]) processFile(input.files[0])
+  if (fileInput.value) fileInput.value.value = ''
+}
+
+function handleDrop(event: DragEvent) {
+  isDragging.value = false
+  const file = event.dataTransfer?.files?.[0]
+  if (file && file.type.startsWith('image/')) processFile(file)
+}
+
+function processFile(file: File) {
+  const reader = new FileReader()
+  reader.onload = (event) => {
+    sourceImageData.value = (event.target?.result as string) ?? null
+  }
+  reader.readAsDataURL(file)
+}
+
+async function openCamera() {
+  sourceTab.value = 'camera'
+  try {
+    cameraStream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: 'user' },
+      audio: false,
+    })
+    cameraActive.value = true
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    if (videoEl.value) videoEl.value.srcObject = cameraStream
+  } catch {
+    cameraActive.value = false
+    sourceTab.value = 'upload'
+  }
+}
+
+function capturePhoto() {
+  const video = videoEl.value
+  if (!video) return
+  const canvas = document.createElement('canvas')
+  canvas.width = video.videoWidth || 768
+  canvas.height = video.videoHeight || 768
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+  sourceImageData.value = canvas.toDataURL('image/png')
+  closeCamera()
+}
+
+function closeCamera() {
+  cameraStream?.getTracks().forEach((track) => track.stop())
+  cameraStream = null
+  cameraActive.value = false
+}
+
+function clearSource() {
+  sourceImageData.value = null
+}
+
+function submit() {
+  if (!sourceImageData.value || !hasAnyChange.value) return
+  void stylist.runStylist({
+    client: clientName.value,
+    before: sourceImageData.value,
+    prompt: buildPrompt(),
+  })
+}
+
+onMounted(() => {
+  void stylist.loadHistory()
+})
+
+onBeforeUnmount(closeCamera)
+</script>

--- a/content/stylist.md
+++ b/content/stylist.md
@@ -1,8 +1,8 @@
 ---
 title: 'Hair Studio'
 room: 'Hair Studio'
-subtitle: "Try the look before the scissors"
-description: "Upload or snap a client photo, pick a new color, style, or an overall cleanup, and see it on their own face in a minute or two. Client photos stay private."
+subtitle: "The Hair by Superkate studio suite"
+description: "The whole salon in one tab: try a new color or cut on a client's own photo, price an appointment, keep the client book, and send warm receipts. Client photos stay private."
 image: 'background/artgallery.webp'
 icon: kind-icon:magic
 tooltip: Private AI hairstyle studio for Hair by Superkate.

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -74,6 +74,38 @@ export default defineEventHandler(async (event) => {
         where: { id },
         data: { status: 'DONE', artImageId, error: null },
       })
+
+      // Jobs enqueued on behalf of a browser user (e.g. kontext enqueue) carry
+      // a `save` block. The relay uploads as its own machine user, so apply
+      // ownership + visibility policy here, where admin auth already holds.
+      // Legacy jobs without `save` are untouched.
+      const payload = job.payload as { save?: unknown } | null
+      const save =
+        payload && typeof payload.save === 'object' && payload.save
+          ? (payload.save as {
+              isPublic?: unknown
+              isMature?: unknown
+              designer?: unknown
+            })
+          : null
+
+      if (save) {
+        await prisma.artImage.update({
+          where: { id: artImageId },
+          data: {
+            userId: job.userId,
+            ...(typeof save.isPublic === 'boolean'
+              ? { isPublic: save.isPublic }
+              : {}),
+            ...(typeof save.isMature === 'boolean'
+              ? { isMature: save.isMature }
+              : {}),
+            ...(typeof save.designer === 'string' && save.designer.trim()
+              ? { designer: save.designer.trim() }
+              : {}),
+          },
+        })
+      }
     } else {
       const message = String(body.error || 'Generation failed.').slice(0, 4000)
       const exhausted = job.attempts >= MAX_ATTEMPTS

--- a/server/api/comfy/kontext/enqueue.post.ts
+++ b/server/api/comfy/kontext/enqueue.post.ts
@@ -1,0 +1,136 @@
+// /server/api/comfy/kontext/enqueue.post.ts
+//
+// Queue-based Flux Kontext generation. The direct route (generate.post.ts)
+// dials the Comfy server from this backend, which fails in production: the
+// deployed backend is not on the home tailnet (ENOTFOUND on ts.net names).
+// This route instead enqueues a durable ArtJob that the home relay agent
+// (conductor ops/home-server/relay_agent.py) claims outward, runs against
+// its local Comfy, uploads via save-generated, and completes. Poll the job
+// at /api/art/queue/:id until DONE, then load the ArtImage by artImageId.
+//
+// The job payload carries a `save` block (isPublic/isMature/designer). The
+// complete endpoint applies it — plus ownership by the enqueuing user — to
+// the uploaded ArtImage, since the relay uploads as its own machine user.
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '../../../utils/prisma'
+import { errorHandler } from '../../../utils/error'
+import { authAndGate } from '../../../utils/comfyGate'
+import {
+  buildKontextWorkflow,
+  getKontextImageExtension,
+} from './utils/workflow'
+
+type KontextEnqueueRequest = {
+  prompt?: string | null
+  imageData?: string | null
+  width?: number | null
+  height?: number | null
+  steps?: number | null
+  guidance?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  denoise?: number | null
+  isPublic?: boolean | null
+  isMature?: boolean | null
+  designer?: string | null
+  filenamePrefix?: string | null
+  priority?: number | null
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody<KontextEnqueueRequest>(event)
+
+    const gate = await authAndGate(event, {
+      engine: 'kontext',
+      steps: body.steps,
+      width: body.width,
+      height: body.height,
+      serverId: null,
+    })
+
+    const prompt = body.prompt?.trim()
+
+    if (!prompt) {
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required field: prompt.',
+      })
+    }
+
+    const imageData = body.imageData?.trim()
+
+    if (!imageData) {
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required field: imageData.',
+      })
+    }
+
+    const extension = getKontextImageExtension(imageData)
+    const imageName = `kr_kontext_queue_${Date.now()}_${crypto.randomUUID()}.${extension}`
+
+    const workflow = buildKontextWorkflow({
+      prompt,
+      imageName,
+      width: body.width,
+      height: body.height,
+      steps: body.steps,
+      guidance: body.guidance,
+      seed: body.seed,
+      sampler: body.sampler,
+      scheduler: body.scheduler,
+      denoise: body.denoise,
+      filenamePrefix: body.filenamePrefix || 'kindrobots_kontext_queue',
+    })
+
+    const job = await prisma.artJob.create({
+      data: {
+        engine: 'COMFY',
+        priority: Number.isInteger(body.priority) ? Number(body.priority) : 5,
+        userId: gate.user.id,
+        payload: {
+          workflow,
+          promptString: prompt,
+          images: [
+            {
+              name: imageName,
+              imageData,
+            },
+          ],
+          save: {
+            isPublic: body.isPublic ?? false,
+            isMature: body.isMature ?? false,
+            designer: body.designer?.trim() || null,
+          },
+        },
+      },
+    })
+
+    const { balance } = await gate.commit(`kontext-queue:${job.id}`)
+
+    return {
+      success: true,
+      message: 'Kontext job queued. Poll /api/art/queue/:id until DONE.',
+      statusCode: 201,
+      data: {
+        jobId: job.id,
+        status: job.status,
+        mana: {
+          balance,
+          charged: gate.cost,
+        },
+      },
+    }
+  } catch (error: unknown) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+
+    return {
+      success: false,
+      statusCode: handledError.statusCode || 500,
+      message: handledError.message || 'Failed to queue Kontext job.',
+    }
+  }
+})

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -1,0 +1,270 @@
+// /server/api/comfy/kontext/utils/workflow.ts
+//
+// Shared Flux Kontext workflow builder for the queue-based generation path.
+// Mirrors the graph in ../generate.post.ts (kept private there); the direct
+// route and this builder should be deduped in a later pass.
+
+export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
+
+export type ComfyWorkflowNode = {
+  class_type?: string
+  inputs?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+export type KontextWorkflowInput = {
+  prompt: string
+  imageName: string
+  width?: number | null
+  height?: number | null
+  steps?: number | null
+  guidance?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  denoise?: number | null
+  filenamePrefix?: string | null
+}
+
+export const DEFAULT_KONTEXT_WIDTH = 1024
+export const DEFAULT_KONTEXT_HEIGHT = 1024
+export const DEFAULT_KONTEXT_STEPS = 20
+export const DEFAULT_KONTEXT_GUIDANCE = 2.5
+export const DEFAULT_KONTEXT_SAMPLER = 'res_multistep'
+export const DEFAULT_KONTEXT_SCHEDULER = 'sgm_uniform'
+export const DEFAULT_KONTEXT_DENOISE = 1
+
+function resolveSeed(seed?: number | null): number {
+  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
+    return Math.floor(seed)
+  }
+
+  return Math.floor(Math.random() * 1_000_000_000_000_000)
+}
+
+export function buildKontextWorkflow(
+  input: KontextWorkflowInput,
+): ComfyWorkflow {
+  const width = input.width ?? DEFAULT_KONTEXT_WIDTH
+  const height = input.height ?? DEFAULT_KONTEXT_HEIGHT
+  const seed = resolveSeed(input.seed)
+
+  return {
+    '6': {
+      inputs: {
+        text: input.prompt,
+        clip: ['11', 0],
+      },
+      class_type: 'CLIPTextEncode',
+      _meta: {
+        title: 'CLIP Text Encode (Positive Prompt)',
+      },
+    },
+    '8': {
+      inputs: {
+        samples: ['13', 0],
+        vae: ['10', 0],
+      },
+      class_type: 'VAEDecode',
+      _meta: {
+        title: 'VAE Decode',
+      },
+    },
+    '9': {
+      inputs: {
+        filename_prefix: input.filenamePrefix || 'kindrobots_kontext_queue',
+        images: ['8', 0],
+      },
+      class_type: 'SaveImage',
+      _meta: {
+        title: 'Save Image',
+      },
+    },
+    '10': {
+      inputs: {
+        vae_name: 'ae.safetensors',
+      },
+      class_type: 'VAELoader',
+      _meta: {
+        title: 'Load VAE',
+      },
+    },
+    '11': {
+      inputs: {
+        clip_name1: 't5xxl_fp8_e4m3fn_scaled.safetensors',
+        clip_name2: 'clip_l.safetensors',
+        type: 'flux',
+        device: 'default',
+      },
+      class_type: 'DualCLIPLoader',
+      _meta: {
+        title: 'DualCLIPLoader',
+      },
+    },
+    '13': {
+      inputs: {
+        noise: ['25', 0],
+        guider: ['22', 0],
+        sampler: ['60', 0],
+        sigmas: ['17', 0],
+        latent_image: ['27', 0],
+      },
+      class_type: 'SamplerCustomAdvanced',
+      _meta: {
+        title: 'SamplerCustomAdvanced',
+      },
+    },
+    '16': {
+      inputs: {
+        sampler_name: input.sampler ?? DEFAULT_KONTEXT_SAMPLER,
+      },
+      class_type: 'KSamplerSelect',
+      _meta: {
+        title: 'KSamplerSelect',
+      },
+    },
+    '17': {
+      inputs: {
+        scheduler: input.scheduler ?? DEFAULT_KONTEXT_SCHEDULER,
+        steps: input.steps ?? DEFAULT_KONTEXT_STEPS,
+        denoise: input.denoise ?? DEFAULT_KONTEXT_DENOISE,
+        model: ['30', 0],
+      },
+      class_type: 'BasicScheduler',
+      _meta: {
+        title: 'BasicScheduler',
+      },
+    },
+    '22': {
+      inputs: {
+        model: ['30', 0],
+        conditioning: ['42', 0],
+      },
+      class_type: 'BasicGuider',
+      _meta: {
+        title: 'BasicGuider',
+      },
+    },
+    '25': {
+      inputs: {
+        noise_seed: seed,
+      },
+      class_type: 'RandomNoise',
+      _meta: {
+        title: 'RandomNoise',
+      },
+    },
+    '26': {
+      inputs: {
+        guidance: input.guidance ?? DEFAULT_KONTEXT_GUIDANCE,
+        conditioning: ['6', 0],
+      },
+      class_type: 'FluxGuidance',
+      _meta: {
+        title: 'FluxGuidance',
+      },
+    },
+    '27': {
+      inputs: {
+        width,
+        height,
+        batch_size: 1,
+      },
+      class_type: 'EmptySD3LatentImage',
+      _meta: {
+        title: 'EmptySD3LatentImage',
+      },
+    },
+    '30': {
+      inputs: {
+        max_shift: 1.15,
+        base_shift: 0.5,
+        width,
+        height,
+        model: ['59', 0],
+      },
+      class_type: 'ModelSamplingFlux',
+      _meta: {
+        title: 'ModelSamplingFlux',
+      },
+    },
+    '39': {
+      inputs: {
+        pixels: ['40', 0],
+        vae: ['10', 0],
+      },
+      class_type: 'VAEEncode',
+      _meta: {
+        title: 'VAE Encode',
+      },
+    },
+    '40': {
+      inputs: {
+        image: ['41', 0],
+      },
+      class_type: 'FluxKontextImageScale',
+      _meta: {
+        title: 'FluxKontextImageScale',
+      },
+    },
+    '41': {
+      inputs: {
+        image: input.imageName,
+      },
+      class_type: 'LoadImage',
+      _meta: {
+        title: 'Load Image',
+      },
+    },
+    '42': {
+      inputs: {
+        conditioning: ['26', 0],
+        latent: ['39', 0],
+      },
+      class_type: 'ReferenceLatent',
+      _meta: {
+        title: 'ReferenceLatent',
+      },
+    },
+    '59': {
+      inputs: {
+        unet_name: 'flux1-kontext-dev-Q5_K_M.gguf',
+      },
+      class_type: 'UnetLoaderGGUF',
+      _meta: {
+        title: 'Unet Loader (GGUF)',
+      },
+    },
+    '60': {
+      inputs: {
+        detail_amount: 0.06,
+        start: 0.3,
+        end: 0.7,
+        bias: 0.5,
+        exponent: 1,
+        start_offset: 0,
+        end_offset: 0,
+        fade: 0,
+        smooth: true,
+        cfg_scale_override: 0,
+        sampler: ['16', 0],
+      },
+      class_type: 'DetailDaemonSamplerNode',
+      _meta: {
+        title: 'Detail Daemon Sampler',
+      },
+    },
+  }
+}
+
+export function getKontextImageExtension(imageData: string): string {
+  const match = imageData
+    .trim()
+    .match(/^data:image\/([a-zA-Z0-9.+-]+);base64,/)
+  const subtype = (match?.[1] || 'png').toLowerCase()
+
+  if (subtype.includes('jpeg') || subtype.includes('jpg')) return 'jpg'
+  if (subtype.includes('webp')) return 'webp'
+
+  return 'png'
+}

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -115,10 +115,11 @@ export const dashboardConfigs = {
         label: 'Hair Studio',
         icon: 'kind-icon:magic',
         title: 'Hair Studio',
-        summary: 'Upload a client photo and try a new hair color, cut, or cleanup.',
+        summary:
+          'The Hair by Superkate suite: AI restyles, appointment calculator, clients, and receipts.',
         image: tabImage('art', 'stylist'),
         narrative:
-          'Upload or snap a client photo, pick a new color, style, or overall cleanup, and see it on their own face in a minute or two. Client photos stay private — never public, never in the memory game.',
+          'The whole salon in one tab: try a new color or cut on a client\'s own photo, price an appointment (rate × time + products), keep the client book, and send warm receipts. Client photos stay private — never public, never in the memory game.',
         route: '/stylist',
       },
       {

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -259,7 +259,7 @@ export const tutorialChannels = {
       {
         key: 'stylist',
         title: 'Hair Studio',
-        body: 'Upload or snap a client photo, choose a new hair color, a new style, or an overall image cleanup (any combination), and get the same photo back with the new look through the Kontext backend. Client photos are kept private — they never appear in public galleries or the memory game.',
+        body: 'The Hair by Superkate suite: upload or snap a client photo and try a new color, style, or cleanup on their own face; price appointments with the services calculator (rate × time + products); keep the client book; and send warm receipts. Client photos are kept private — they never appear in public galleries or the memory game.',
         image: tutorialImage('art', 'stylist'),
       },
       {

--- a/stores/stylistStore.ts
+++ b/stores/stylistStore.ts
@@ -14,8 +14,7 @@ import { computed, ref } from 'vue'
 import { performFetch } from '@/stores/utils'
 import { useArtStore } from '@/stores/artStore'
 import { useUserStore } from '@/stores/userStore'
-import { useServerStore } from '@/stores/serverStore'
-import type { ArtImage, Server } from '~/prisma/generated/prisma/client'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
 
 export const STYLIST_DESIGNER_PREFIX = 'stylist:'
 
@@ -89,7 +88,6 @@ export function friendlyError(raw: string): string {
 export const useStylistStore = defineStore('stylistStore', () => {
   const artStore = useArtStore()
   const userStore = useUserStore()
-  const serverStore = useServerStore()
 
   // Live jobs from this session (before/after both available in memory).
   const jobs = ref<StylistJob[]>([])
@@ -104,25 +102,6 @@ export const useStylistStore = defineStore('stylistStore', () => {
     () => jobs.value.filter((job) => job.status === 'pending').length,
   )
   const isBusy = computed(() => pendingCount.value > 0)
-
-  function isUsableKontextServer(
-    server: Server | null | undefined,
-  ): server is Server {
-    if (!server) return false
-    if (!server.isActive) return false
-    if (server.serverType !== 'COMFY') return false
-    return true
-  }
-
-  const kontextServer = computed<Server | null>(() => {
-    if (isUsableKontextServer(serverStore.activeArtServer)) {
-      return serverStore.activeArtServer
-    }
-    const servers = Array.isArray(serverStore.servers)
-      ? (serverStore.servers as Server[])
-      : []
-    return servers.find(isUsableKontextServer) || null
-  })
 
   function jobsForClient(client: string): StylistJob[] {
     const target = client.trim().toLowerCase()
@@ -146,6 +125,49 @@ export const useStylistStore = defineStore('stylistStore', () => {
     )
   }
 
+  // Generation goes through the durable ArtJob queue, NOT the direct
+  // /api/comfy/kontext/generate route: the deployed backend is not on the
+  // home tailnet, so dialing the Comfy server from it fails (ENOTFOUND on
+  // ts.net names). The home relay agent claims queued jobs outward instead.
+  const QUEUE_POLL_MS = 5_000
+  const QUEUE_TIMEOUT_MS = 10 * 60_000
+
+  type QueuedArtJob = {
+    id: number
+    status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED'
+    artImageId?: number | null
+    error?: string | null
+  }
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  async function waitForQueuedJob(jobId: number): Promise<QueuedArtJob> {
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < QUEUE_TIMEOUT_MS) {
+      const response = await performFetch<{ job: QueuedArtJob }>(
+        `/api/art/queue/${jobId}`,
+        { method: 'GET' },
+        2,
+        20_000,
+      )
+
+      const job = response.success ? response.data?.job : null
+
+      if (job?.status === 'DONE' || job?.status === 'FAILED') {
+        return job
+      }
+
+      await sleep(QUEUE_POLL_MS)
+    }
+
+    throw new Error(
+      'Styling timed out. The studio queue may be catching up — check Past looks in a few minutes.',
+    )
+  }
+
   async function runStylist(input: StylistRunInput): Promise<number> {
     const id = ++seq
     const client = input.client.trim()
@@ -164,30 +186,45 @@ export const useStylistStore = defineStore('stylistStore', () => {
       ...jobs.value,
     ]
 
-    const base64Payload = before.includes(',')
-      ? (before.split(',')[1] ?? before)
-      : before
-
     try {
-      const result = await artStore.generateArt({
-        promptString: input.prompt,
-        userId: userStore.userId ?? undefined,
-        serverId: kontextServer.value?.id ?? null,
-        serverName: kontextServer.value?.title ?? null,
-        engine: 'kontext',
-        transport: 'backend',
-        // Private: never public, never in the memory game.
-        isPublic: false,
-        isMature: false,
-        designer: stylistDesignerFor(client),
-        sourceImageBase64: base64Payload,
-      })
+      const enqueue = await performFetch<{ jobId: number }>(
+        '/api/comfy/kontext/enqueue',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            prompt: input.prompt,
+            imageData: before,
+            // Private: never public, never in the memory game.
+            isPublic: false,
+            isMature: false,
+            designer: stylistDesignerFor(client),
+            filenamePrefix: 'kindrobots_stylist',
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        },
+        2,
+        60_000,
+      )
 
-      if (!result.success || !result.data) {
-        throw new Error(result.message || 'Styling failed.')
+      if (!enqueue.success || !enqueue.data?.jobId) {
+        throw new Error(enqueue.message || 'Could not queue the styling job.')
       }
 
-      const image = result.data
+      const finished = await waitForQueuedJob(enqueue.data.jobId)
+
+      if (finished.status !== 'DONE' || !finished.artImageId) {
+        throw new Error(finished.error || 'Styling failed.')
+      }
+
+      const image = (await artStore.getArtImageById(finished.artImageId, {
+        includeImageData: true,
+        includeThumbnailData: true,
+      })) as (ArtImage & { imageData?: string | null }) | null
+
+      if (!image) {
+        throw new Error('Styled image could not be loaded.')
+      }
+
       const after = image.imageData
         ? `data:image/${image.fileType || 'png'};base64,${image.imageData}`
         : before
@@ -262,7 +299,6 @@ export const useStylistStore = defineStore('stylistStore', () => {
     historyError,
     pendingCount,
     isBusy,
-    kontextServer,
     jobsForClient,
     historyForClient,
     runStylist,

--- a/stores/superkateStore.ts
+++ b/stores/superkateStore.ts
@@ -1,0 +1,323 @@
+// /stores/superkateStore.ts
+//
+// Web replica of the Hair by Superkate services app (conductor project
+// superkate-hairstyle-ai t-015): customers, appointments, and receipt
+// settings backing the /stylist suite (Calculator | Clients | History |
+// Hair Studio). Kind Robots is the backend of record eventually; this store
+// is the approved "easy mock" — persisted to localStorage so Superkate's
+// data survives reloads on her device. KR-model-backed sync is a follow-up.
+//
+// Core formula (calculator SPEC): hourly rate x time spent + product cost.
+
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export type SuperkateCustomer = {
+  id: number
+  name: string
+  email: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type SuperkateAppointment = {
+  id: number
+  customerId: number | null
+  clientName: string
+  date: string // YYYY-MM-DD
+  hourlyRateCents: number
+  minutes: number
+  productCostCents: number
+  totalCents: number
+  createdAt: string
+}
+
+export type SuperkateSettings = {
+  salonName: string
+  bookingLink: string
+  replyContact: string
+}
+
+const STORAGE_KEY = 'superkateSuite'
+
+const DEFAULT_SETTINGS: SuperkateSettings = {
+  salonName: 'Hair by Superkate',
+  bookingLink: 'https://hairbysuperkate.glossgenius.com/',
+  replyContact: 'hairbysuperkate@gmail.com',
+}
+
+export function computeTotalCents(
+  hourlyRateCents: number,
+  minutes: number,
+  productCostCents: number,
+): number {
+  const rate = Math.max(0, Math.round(hourlyRateCents))
+  const time = Math.max(0, Math.round(minutes))
+  const product = Math.max(0, Math.round(productCostCents))
+
+  return Math.round((rate * time) / 60) + product
+}
+
+export function formatCents(cents: number): string {
+  return `$${(Math.max(0, Math.round(cents)) / 100).toFixed(2)}`
+}
+
+export function formatMinutes(minutes: number): string {
+  const total = Math.max(0, Math.round(minutes))
+  const hours = Math.floor(total / 60)
+  const rest = total % 60
+
+  if (!hours) return `${rest}m`
+  if (!rest) return `${hours}h`
+
+  return `${hours}h ${rest}m`
+}
+
+export const useSuperkateStore = defineStore('superkateStore', () => {
+  const customers = ref<SuperkateCustomer[]>([])
+  const appointments = ref<SuperkateAppointment[]>([])
+  const settings = ref<SuperkateSettings>({ ...DEFAULT_SETTINGS })
+  const hydrated = ref(false)
+
+  // Which suite view is open on /stylist. Store-level so it survives
+  // leaving and returning to the page, matching the dashboard-tab fix.
+  const activeView = ref<'studio' | 'calculator' | 'clients' | 'history'>(
+    'studio',
+  )
+
+  const isClient = typeof window !== 'undefined'
+
+  function persist(): void {
+    if (!isClient) return
+
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          customers: customers.value,
+          appointments: appointments.value,
+          settings: settings.value,
+        }),
+      )
+    } catch {}
+  }
+
+  function hydrate(force = false): void {
+    if (!isClient) return
+    if (hydrated.value && !force) return
+
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      const parsed = raw ? JSON.parse(raw) : null
+
+      if (parsed && typeof parsed === 'object') {
+        if (Array.isArray(parsed.customers)) customers.value = parsed.customers
+        if (Array.isArray(parsed.appointments))
+          appointments.value = parsed.appointments
+        if (parsed.settings && typeof parsed.settings === 'object') {
+          settings.value = { ...DEFAULT_SETTINGS, ...parsed.settings }
+        }
+      }
+    } catch {}
+
+    hydrated.value = true
+  }
+
+  function nextId(rows: Array<{ id: number }>): number {
+    return rows.reduce((max, row) => Math.max(max, row.id), 0) + 1
+  }
+
+  const sortedCustomers = computed(() =>
+    [...customers.value].sort((a, b) => a.name.localeCompare(b.name)),
+  )
+
+  const sortedAppointments = computed(() =>
+    [...appointments.value].sort(
+      (a, b) => b.date.localeCompare(a.date) || b.id - a.id,
+    ),
+  )
+
+  function customerByName(name: string): SuperkateCustomer | null {
+    const target = name.trim().toLowerCase()
+    if (!target) return null
+
+    return (
+      customers.value.find(
+        (customer) => customer.name.trim().toLowerCase() === target,
+      ) ?? null
+    )
+  }
+
+  function saveCustomer(input: {
+    id?: number | null
+    name: string
+    email?: string | null
+  }): SuperkateCustomer | null {
+    const name = input.name.trim()
+    if (!name) return null
+
+    const now = new Date().toISOString()
+    const email = (input.email ?? '').trim()
+
+    if (input.id) {
+      let updated: SuperkateCustomer | null = null
+
+      customers.value = customers.value.map((customer) => {
+        if (customer.id !== input.id) return customer
+        updated = { ...customer, name, email, updatedAt: now }
+        return updated
+      })
+
+      persist()
+      return updated
+    }
+
+    const existing = customerByName(name)
+
+    if (existing) {
+      return saveCustomer({ id: existing.id, name, email: email || existing.email })
+    }
+
+    const customer: SuperkateCustomer = {
+      id: nextId(customers.value),
+      name,
+      email,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    customers.value = [...customers.value, customer]
+    persist()
+    return customer
+  }
+
+  function removeCustomer(id: number): void {
+    customers.value = customers.value.filter((customer) => customer.id !== id)
+    // Appointment history keeps its client name snapshot after the linked
+    // customer is deleted (delete-detach invariant from the calculator spec).
+    appointments.value = appointments.value.map((appointment) =>
+      appointment.customerId === id
+        ? { ...appointment, customerId: null }
+        : appointment,
+    )
+    persist()
+  }
+
+  function saveAppointment(input: {
+    clientName: string
+    date: string
+    hourlyRateCents: number
+    minutes: number
+    productCostCents: number
+  }): SuperkateAppointment | null {
+    const clientName = input.clientName.trim()
+    if (!clientName || !input.date) return null
+
+    const customer = customerByName(clientName) ?? saveCustomer({ name: clientName })
+
+    const appointment: SuperkateAppointment = {
+      id: nextId(appointments.value),
+      customerId: customer?.id ?? null,
+      clientName,
+      date: input.date,
+      hourlyRateCents: Math.max(0, Math.round(input.hourlyRateCents)),
+      minutes: Math.max(0, Math.round(input.minutes)),
+      productCostCents: Math.max(0, Math.round(input.productCostCents)),
+      totalCents: computeTotalCents(
+        input.hourlyRateCents,
+        input.minutes,
+        input.productCostCents,
+      ),
+      createdAt: new Date().toISOString(),
+    }
+
+    appointments.value = [...appointments.value, appointment]
+    persist()
+    return appointment
+  }
+
+  function removeAppointment(id: number): void {
+    appointments.value = appointments.value.filter(
+      (appointment) => appointment.id !== id,
+    )
+    persist()
+  }
+
+  function appointmentsForCustomer(customerId: number): SuperkateAppointment[] {
+    return sortedAppointments.value.filter(
+      (appointment) => appointment.customerId === customerId,
+    )
+  }
+
+  function searchAppointments(query: string, date: string): SuperkateAppointment[] {
+    const target = query.trim().toLowerCase()
+
+    return sortedAppointments.value.filter((appointment) => {
+      if (date && appointment.date !== date) return false
+      if (target && !appointment.clientName.toLowerCase().includes(target))
+        return false
+      return true
+    })
+  }
+
+  function updateSettings(patch: Partial<SuperkateSettings>): void {
+    settings.value = { ...settings.value, ...patch }
+    persist()
+  }
+
+  function receiptText(appointment: SuperkateAppointment): string {
+    const rate = formatCents(appointment.hourlyRateCents)
+    const time = formatMinutes(appointment.minutes)
+    const product = formatCents(appointment.productCostCents)
+    const total = formatCents(appointment.totalCents)
+
+    return [
+      `Hi ${appointment.clientName}!`,
+      '',
+      `Thank you so much for visiting ${settings.value.salonName} on ${appointment.date}.`,
+      '',
+      `${rate}/hr x ${time} + ${product} products = ${total}`,
+      '',
+      settings.value.salonName,
+      settings.value.bookingLink,
+      settings.value.replyContact,
+      'Superkate loves you!',
+    ].join('\n')
+  }
+
+  function receiptMailto(appointment: SuperkateAppointment): string {
+    const customer = appointment.customerId
+      ? customers.value.find((entry) => entry.id === appointment.customerId)
+      : null
+    const to = customer?.email || ''
+    const subject = encodeURIComponent(
+      `Your ${settings.value.salonName} receipt — ${appointment.date}`,
+    )
+    const body = encodeURIComponent(receiptText(appointment))
+
+    return `mailto:${to}?subject=${subject}&body=${body}`
+  }
+
+  return {
+    customers,
+    appointments,
+    settings,
+    hydrated,
+    activeView,
+
+    sortedCustomers,
+    sortedAppointments,
+
+    hydrate,
+    customerByName,
+    saveCustomer,
+    removeCustomer,
+    saveAppointment,
+    removeAppointment,
+    appointmentsForCustomer,
+    searchAppointments,
+    updateSettings,
+    receiptText,
+    receiptMailto,
+  }
+})


### PR DESCRIPTION
Two deliverables on this branch — the production generation fix and the full-app replica Silas asked for.

## Part 1 — Fix the prod ENOTFOUND: generate via the ArtJob queue

**Root cause of `ENOTFOUND ferngrotto.foxhound-chicken.ts.net`:** the direct route dials the Comfy server from the deployed backend, which isn't on the home tailnet. The **durable ArtJob queue** is the working production path — the home relay agent (`conductor ops/home-server/relay_agent.py`) claims jobs **outward**, no inbound connection needed.

- **`server/api/comfy/kontext/enqueue.post.ts`** (new) — same auth/mana gate as the direct route (charged at enqueue), builds the Kontext workflow, creates an ArtJob carrying `{workflow, images:[{name,imageData}], promptString, save:{isPublic,isMature,designer}}`.
- **`server/api/comfy/kontext/utils/workflow.ts`** (new) — shared workflow builder (mirrors `generate.post.ts`; dedup later).
- **`server/api/art/queue/[id]/complete.post.ts`** — on success applies the job's `save` block **and ownership by the enqueuing user** to the uploaded ArtImage (the relay uploads as its machine user; `save-generated` rejects foreign userIds). Keeps stylist photos **`isPublic:false`** and in Superkate's history. Legacy jobs untouched.
- **`stores/stylistStore.ts`** — enqueue + poll `/api/art/queue/:id` (5s / 10-min cap), then load the finished image. Jobs still survive navigation.

**Companion (required):** conductor PR #320 adds input-image upload to `relay_agent.py` (multipart to ComfyUI's `input` folder) so `LoadImage` finds the client photo. **Restart the home relay agent with the updated script before testing.**

## Part 2 — Full Superkate app replica on `/stylist`

Per Silas: the Hair Studio page hosts the whole app, not just the restyler. New suite shell with **Hair Studio | Calculator | Clients | History**:

- **`stores/superkateStore.ts`** — localStorage-persisted mock backend (KR-model sync is the follow-up): customers, appointments, receipt settings. Core formula `rate × time + products` in cents; warm receipt text with the configurable contact block (`Hair by Superkate` / glossgenius link / reply email) and **"Superkate loves you!"**; `mailto:` composer with client-email prefill; delete-detach invariant (history keeps the client name after a profile delete).
- **`stylist-manager.vue`** — suite shell (view choice survives navigation); **`stylist-restyle.vue`** — the restyler, moved, now suggesting clients from the client book; **`stylist-calculator.vue`** — hours/minutes preset chips, optional product cost, live total, save + receipt; **`stylist-clients.vue`** — client book; **`stylist-history.vue`** — search by client/date, totals, receipts.
- Page/dashboard/tutorial copy updated for the suite.

## Verify end-to-end
1. Merge this + conductor #320; restart the relay agent.
2. `/stylist` → Hair Studio → upload → Style it → job goes PENDING → RUNNING → DONE; After image appears; result is private + owned by you.
3. Calculator → save an appointment → appears in History + client auto-created in Clients; receipt email opens prefilled.

## Stakes
reversible — the direct kontext route is untouched (still useful on-tailnet/local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ