### PR TITLE
docs(sample): generation framework for primary content objects

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -12,6 +12,12 @@ the canonical recipe for both humans and agents — including the rule that a
 new *channel* requires Silas's explicit approval. The channel checklist
 below is kept in sync with it for use during the model loop.
 
+**Generating instances** of the existing models (bots, dreams, characters,
+rewards, scenarios, narration threads, expression media, pitch sheets) —
+whether by hand or by agent — follows the spec sheets in
+**[`generation/`](./generation/README.md)**. Every generation is presumed
+to include its art.
+
 **Naming contract** (keep all five consistent or nothing lines up):
 
 | Thing | Convention | For Sample |

--- a/sample/generation/README.md
+++ b/sample/generation/README.md
@@ -1,0 +1,71 @@
+# Generation framework — auto-creating Kind Robots objects
+
+Spec sheets for the primary objects that agents (or Silas) may generate
+automatically, grounded in `prisma/schema.prisma`. Each sheet says what a
+finished, shippable object looks like: required fields, house voice, the
+art it is presumed to include, file conventions, and the endpoint that
+accepts it. `sample/README.md` covers wiring a NEW model; this folder
+covers generating INSTANCES of the models we already have.
+
+## The specs
+
+| Object | Spec | Variants |
+| --- | --- | --- |
+| Bot | [`bots.md`](./bots.md) | NARRATOR (dreams), PROMPTBOT (bots), MANAGER (projects) |
+| Dream | [`dreams.md`](./dreams.md) | LOCATION, GENRE (a.k.a. vibe), PROJECT (+ full enum) |
+| Character | [`characters.md`](./characters.md) | includes portrait + expression art |
+| Reward | [`rewards.md`](./rewards.md) | by `rewardType` and `rarity` |
+| Scenario | [`scenarios.md`](./scenarios.md) | by `outputType` |
+| Narration threads | [`threads.md`](./threads.md) | NarratorTopic + NarratorThread |
+| Expression media | [`expressions.md`](./expressions.md) | 10 emotions + 10 actions, stills/video/transitions |
+| PitchSheet | [`pitchsheets.md`](./pitchsheets.md) | includes artist mockup |
+
+## Universal rules (apply to every generated object)
+
+1. **Art is presumed.** Every generation includes its desired art, not just
+   text. At minimum, fill `artPrompt` on the object (house style: subject,
+   staging, "adult animated cartoon style", palette, "crisp clean
+   linework, no text"); then either generate the image through the art
+   pipeline or queue it in conductor's `projects/art-prompts.yaml`. Never
+   ship an object with an empty `artPrompt` — that image can then never be
+   regenerated. Missing image files never block: the UI falls back to
+   placeholders.
+2. **Standard art sizes:** icon 256×256, card 512×768, hero 1280×720,
+   avatars and expression stills square (1:1). All webp.
+3. **Provenance.** Set `creationSource: 'AI'` where the field exists
+   (Dream, Prompt), set `designer` to the generating agent/pipeline name,
+   and keep the prompt/model/seed metadata needed to recreate or delete
+   the image (AGENTS.md generated-art rule).
+4. **Flags.** `isPublic: true`, `isActive: true`, `isMature: false` unless
+   the content genuinely warrants otherwise. Mature content must be
+   flagged, never smuggled.
+5. **Ownership.** System-generated canon uses `userId: 1` and
+   `designer: 'silasfelinus'` (matching existing seeds); user-requested
+   generations belong to the requesting user. Guest/system fallback id
+   is `10`.
+6. **Slugs.** Lowercase kebab, globally unique per model. A slug is also a
+   folder name: an object's inspiration set lives at
+   `public/images/{slug}/` (or `public/images/artcollections/{slug}/` for
+   dream parity collections), tracked by a `gallery.json` manifest — the
+   folder IS the ArtCollection.
+7. **Inspiration sets.** When generating multiple candidate images for one
+   object (portrait options, expression candidates, mockup variants), put
+   them in the slug's inspiration folder as
+   `{slug}-inspiration-{n}.webp` and promote the winner to the canonical
+   path. This is how characters can be handed avatar/expression options
+   instead of a single take.
+8. **Endpoints.** All writes go through the API (never raw SQL):
+   single-object `index.post.ts`, bulk `batch.post.ts` with
+   `created/skipped/failed` and 207 on partial success. The expression and
+   thread batch endpoints accept `dryRun: true` — use it to validate a
+   payload before writing. Auth via `validateApiKey` (`KR_API_TOKEN` for
+   agents).
+9. **Never overwrite silently.** Batch endpoints upsert by slug/unique
+   key; if a generation would replace an existing image file, the old file
+   moves to the slug's inspiration folder first (conductor
+   `distribute_images.py` behavior — mirror it when writing files
+   directly).
+10. **Voice.** Kind Robots copy is playful, kind, and specific — see any
+    `narrative:` in `stores/helpers/dashboardHelper.ts` or the narrator
+    seeds in `stores/seeds/narrators.ts` for register. Generated text that
+    reads like beige LLM filler gets rejected in review.

--- a/sample/generation/bots.md
+++ b/sample/generation/bots.md
@@ -1,0 +1,64 @@
+# Generating Bots
+
+Model: `Bot` (`prisma/schema.prisma`). Endpoints: `POST /api/bots`,
+`POST /api/bots/batch` (upsert by slug), seeds via
+`POST /api/bots/seed`. Live reference: `stores/seeds/narrators.ts`.
+
+## The three flavors
+
+`BotType` is a free string in the schema; these are the canonical values.
+(Legacy rows also contain `'assistant'` — the add-bot form default. Do not
+generate new ones.)
+
+| BotType | Belongs to | Job |
+| --- | --- | --- |
+| `NARRATOR` | a Dream (LOCATION/GENRE) | Framing voice of the dream — narrates in third person, never acts in-scene. Drives stories, forges scenarios/characters/rewards for its home dream. |
+| `PROMPTBOT` | the Bots channel | A standalone prompt-centric assistant: one strong `prompt`, a personality, chat-first. |
+| `MANAGER` | a PROJECT dream | Project-facing steward for a conductor project — reports status, frames the roadmap, talks waypoints and gates. Same framing-device stance as narrators. |
+
+NARRATORs and MANAGERs get the full expression set (10 emotions + 10
+actions — see `expressions.md`). PROMPTBOTs need an avatar; expressions
+are optional polish.
+
+## Field spec
+
+Required by schema: `BotType`, `name`, `botIntro`, `userIntro`, `prompt`.
+
+| Field | Fill with |
+| --- | --- |
+| `name`, `slug` | Character name; slug is the kebab of it (`brass-lampkeeper`) |
+| `subtitle` | 'Narrator of {Dream}' / 'Manager of {Project}' / role line |
+| `description` | 1–2 sentence identity ("You are {name}, …") |
+| `botIntro` | Identity + role + stance. Narrators/managers: state "You are a NARRATOR: a framing device… never a character inside the story." |
+| `narrativeVoice` | `VOICE:` register notes + `SAMPLE:` one in-voice paragraph |
+| `forgeIntro` | `FORGE:` in-voice offer to generate more content |
+| `userIntro` | Pipe-delimited starter prompts ("Tell me a story… \| Generate 6 scenarios. \| …") |
+| `prompt` | Core behavior instruction (≤764 chars) |
+| `theme` | A DaisyUI theme name matching the vibe (`garden`, `dracula`, …) |
+| `personality` | 3–5 comma-separated traits |
+| `modules` | Capabilities list (`'Narrator, DreamForge, Scenario, Character, Reward, Dream'`) |
+| `tagline` | One short in-voice line |
+| `artPrompt` | Full avatar prompt, house style (see README rule 1) |
+| `avatarImage` | `/images/bots/{slug}.webp` |
+| `Dreams` | `{ connect: [{ id }] }` to the home dream (narrators/managers) |
+| `userId`, `designer` | Per README rule 5; `canDelete: false` for canon bots |
+
+## Art set
+
+| Asset | Path | Notes |
+| --- | --- | --- |
+| Avatar (identity anchor) | `public/images/bots/{slug}.webp` | square; also referenced by `avatarImage` |
+| Avatar (picker copy) | `public/images/bots/avatars/{slug}.webp` | same art; the avatar-picker folder |
+| Expression set | `public/images/bots/expressions/{slug}/{key}_01.webp` | 20 files — see `expressions.md` |
+| Inspiration set (optional) | `public/images/{slug}/{slug}-inspiration-{n}.webp` | candidate takes before promoting one |
+
+## Checklist
+
+1. Write the bot row (fields above) — batch endpoint for sets.
+2. Generate avatar art from `artPrompt`; save to both avatar paths.
+3. NARRATOR/MANAGER: generate the 20-expression set and register
+   ExpressionMedia rows (`expressions.md`).
+4. Narration-capable bots: add NarratorThread rows per topic
+   (`threads.md`).
+5. Verify: bot appears in the gallery, avatar renders, and
+   `/api/narrators/{type}/{slug}` returns it with expressions attached.

--- a/sample/generation/characters.md
+++ b/sample/generation/characters.md
@@ -1,0 +1,53 @@
+# Generating Characters
+
+Model: `Character`. Endpoints: `POST /api/characters`,
+`POST /api/characters/batch`, LLM-assisted `server/api/characters/generate.ts`.
+
+Characters are in-story people/creatures — unlike bots they act INSIDE
+scenes. A character can still chat (via `Chats`) and can carry its own
+expression media set.
+
+## Field spec
+
+Required: `name`. Always set: `slug`, `species`, `class`, `genre`,
+`personality`, `backstory`, `drive`, `quirks`, `artPrompt`.
+
+| Field | Fill with |
+| --- | --- |
+| `name`, `slug`, `honorific`, `title`, `role` | Identity; honorific defaults to `adventurer` |
+| `species`, `class`, `gender`, `alignment`, `genre` | Casting sheet — mix humans, robots, creatures, and originals (inclusive by default) |
+| `personality`, `quirks`, `drive`, `backstory` | The playable core: how they talk, what's odd about them, what they want, where they came from |
+| `presentation` | Visual description referenced by art prompts |
+| `charm/empathy/grace/luck/might/wits` | `Rarity` enum stats (`COMMON`→`MYTHIC`); default COMMON, spike 1–2 to fit concept |
+| `experience`, `level` | 0 / 1 for fresh characters |
+| `artPrompt` | Portrait prompt built from `presentation`, house style |
+| `userId`, `designer` | README rule 5 |
+
+Connect at generation time when part of a set: `Dreams` (home world),
+`Scenarios` (cast membership — also mirror into `Scenario.cast` Json),
+`Rewards` (signature items).
+
+## Art set — characters get multiple art, by design
+
+| Asset | Path / field | Notes |
+| --- | --- | --- |
+| Primary portrait | `public/images/characters/{slug}.webp`, referenced by `imagePath` (and/or `artImageId`) | the identity anchor |
+| Portrait inspiration set | `public/images/{slug}/{slug}-inspiration-{n}.webp` | 3+ candidate takes; promote the winner; the folder is the character's ArtCollection |
+| Expression set (optional but desired) | `public/images/characters/expressions/{slug}/{key}_01.webp` | mirrors the bot convention (`bots/expressions/…`); register via `ExpressionMedia.characterId` — see `expressions.md` |
+
+The inspiration set is what lets a character be *given* avatar
+expressions later: generate candidates into the slug folder, then an
+expression pass edits the chosen portrait per key. Keep every
+expression's `artPrompt` anchored to the same `presentation` text so the
+face stays consistent across all 20.
+
+## Checklist
+
+1. Write the character row (batch for casts).
+2. Generate portrait candidates into the inspiration folder; promote one
+   to the canonical portrait path.
+3. Optional expression pass: 10 emotions + 10 actions from the promoted
+   portrait (`expressions.md`), rows keyed by `characterId`.
+4. Verify: gallery card renders, portrait resolves, stats display, and
+   mature-gating behaves (`isMature` rows hidden unless
+   `userStore.showMature`).

--- a/sample/generation/dreams.md
+++ b/sample/generation/dreams.md
@@ -1,0 +1,58 @@
+# Generating Dreams
+
+Model: `Dream`. Endpoints: `POST /api/dreams`, `POST /api/dreams/batch`.
+Helper: `stores/helpers/dreamHelper.ts` (`parseDreamType` maps legacy
+names — `VIBE` → `GENRE`, `DREAM` → `LOCATION`).
+
+## The flavors
+
+`dreamType` enum: `ART, BRAINSTORM, PROMPTBOT, NARRATOR, CHARACTER,
+PROJECT, REWARD, SCENARIO, LOCATION, PITCH, GENRE, WISH` (default
+`PITCH`). The three agents generate most often:
+
+| dreamType | What it is | Extra obligations |
+| --- | --- | --- |
+| `LOCATION` | A place/world — the home of a narrator, cast, and stories | Gets a NARRATOR bot (`bots.md`) and usually an art collection |
+| `GENRE` | A vibe/aesthetic that other dreams can inherit ("vibe" in older docs) | Link related dreams via `DreamRelation` (`IS_A`, `INSPIRED_BY`) |
+| `PROJECT` | A conductor project mirror (`Dream.slug === projects/<slug>` dir name) | Fill the project block; gets a MANAGER bot; conductor sync owns creation — don't invent PROJECT dreams outside that flow |
+
+## Field spec
+
+Required: `title`. Always set: `slug`, `dreamType`, `description`,
+`pitch`, `artPrompt`, `creationSource: 'AI'`.
+
+| Field | Fill with |
+| --- | --- |
+| `title`, `slug` | Evocative title; kebab slug |
+| `pitch` | The 1–3 sentence hook (the elevator version) |
+| `description` | The expanded version — setting, vibe, conflicts, story fuel |
+| `flavorText` | One quotable in-world line (≤512) |
+| `examples` | Optional riffs/story seeds (LongText) |
+| `artPrompt` | Hero/card prompt, house style |
+| `icon` | `kind-icon:*` name |
+| `designer`, `userId` | README rule 5 |
+
+Project block (PROJECT only): `projectStatus` (`ACTIVE/PAUSED/DONE/
+ARCHIVED/BRAINSTORM`), `priority` (`LOW/NORMAL/HIGH`), `goal` (what 100%
+looks like, concretely), `waypoints` (pipe-delimited steps; `✓ ` prefix =
+done, `~ ` = in progress), `repoUrl`, `liveUrl`.
+
+Relations worth setting at generation time: `ArtImage`/`artImageId`
+(primary image), `artCollectionId` (primary collection), `Characters`,
+`Bots`, `Rewards`, `Scenarios` connects when generating a themed set, and
+`DreamRelation` edges (`IS_A`, `APPEARS_IN`, `RELATED`, `INSPIRED_BY`)
+instead of duplicating lore across rows.
+
+## Art set
+
+| Asset | Path / field | Notes |
+| --- | --- | --- |
+| Card | `cardPath` (512×768) | portrait key art |
+| Hero | `heroPath` (1280×720) | banner |
+| Primary image | `imagePath` / `artImageId` | the one image if only one exists |
+| Art collection | `public/images/artcollections/{slug}/` | `{slug}-inspiration-{n}.webp` + `gallery.json`; set `artCollectionId` |
+
+A generated LOCATION ships as a bundle: the dream row + card/hero art +
+its NARRATOR bot + (optionally) starter scenarios, characters, and
+rewards connected to it. A PROJECT dream additionally gets a PitchSheet
+(`pitchsheets.md`).

--- a/sample/generation/expressions.md
+++ b/sample/generation/expressions.md
@@ -1,0 +1,75 @@
+# Generating Expression Media
+
+Models: `ExpressionMedia` (+ `ExpressionTransition`). Endpoints:
+`POST /api/bots/expressions`, `POST /api/bots/transitions` (batch
+upserts, CHUNK_SIZE 25, accept `dryRun: true`). Video generation via
+`server/api/comfy/ltx/` (image2Video / FLF2V).
+
+One row per (owner, expressionKey), where the owner is a Bot OR a
+Character. `NEUTRAL` is the canonical generated avatar; the owner's
+`artImageId` portrait stays the identity anchor.
+
+## The canonical set — 20 per owner
+
+Every NARRATOR and MANAGER bot gets the full set; characters get it when
+promoted to chat/stage use. From the `Expression` enum:
+
+- **10 emotions** (`kind: EMOTION`, face-only edits, body/framing locked):
+  `NEUTRAL, JOYFUL, SORROWFUL, AFRAID, DISGUSTED, ENRAGED, SURPRISED,
+  ANXIOUS, PROUD, LOVING`
+- **10 actions** (`kind: ACTION`, pose/state edits):
+  `LAUGHING, CRYING, SLEEPING, THINKING, SHRUGGING, WINKING, FACEPALMING,
+  CHEERING, WHISPERING, SHOUTING`
+- `CUSTOM` is the escape hatch for freeform actions (`expressionKey` is
+  then a freeform slug like `backflip`).
+
+## Field spec
+
+| Field | Fill with |
+| --- | --- |
+| `expression`, `kind` | Enum value + EMOTION/ACTION |
+| `expressionKey` | Lowercase enum name (`"laughing"`) or custom slug — always set, matches the filename |
+| `botId` XOR `characterId` | The owner |
+| `imagePath` | Still: see file convention below |
+| `videoPath` | Optional looping reaction clip (animated webp/mp4) |
+| `label`, `emoticon` | Display name + emoji |
+| `message`, `additionalPhrases` | Optional in-voice line(s) the owner can say when striking this expression |
+| `artPrompt` | The edit prompt used — REQUIRED for regeneration |
+| `designer` | README rule 5 |
+
+## File conventions
+
+| Owner | Path |
+| --- | --- |
+| Bot stills | `public/images/bots/expressions/{slug}/{key}_01.webp` |
+| Character stills | `public/images/characters/expressions/{slug}/{key}_01.webp` (mirror of the bot convention) |
+| Reaction videos | same folder, `{key}_loop.webp` |
+| Transitions | same folder, `{from}_to_{to}.webp` |
+
+`{key}` is the lowercase `expressionKey`; `_01` allows numbered variants —
+extra takes stay in the folder as `_02`, `_03` (the row points at the
+promoted one). Square (1:1), consistent framing across the whole set.
+
+**Consistency rule:** all 20 stills derive from the owner's promoted
+portrait with the same `presentation`/identity language in every
+`artPrompt`. EMOTION edits change the face only; ACTION edits may change
+pose. A set where the character drifts between takes is a failed set.
+
+## ExpressionTransition (optional polish)
+
+Directed clips `fromKey -> toKey` for the same owner (`videoPath`,
+`fps` 16, unique per (owner, fromKey, toKey)). The frontend falls back to
+the static still when no transition row exists, so generate transitions
+lazily — the high-value pairs are `neutral -> *` and `* -> neutral`.
+
+## Checklist
+
+1. Generate the 20 stills from the promoted portrait into the owner's
+   expressions folder.
+2. `dryRun: true` the batch to `/api/bots/expressions`; then write rows
+   with `imagePath`, `label`, `emoticon`, `message`, and `artPrompt`.
+3. Do NOT create an ArtImage row per expression — `imagePath` on the
+   ExpressionMedia row is enough; `artImageId` is reserved for stills
+   that need full ArtImage provenance (the NEUTRAL avatar, typically).
+4. Verify: the narrator screen swaps expressions, and unknown keys fall
+   back to NEUTRAL.

--- a/sample/generation/pitchsheets.md
+++ b/sample/generation/pitchsheets.md
@@ -1,0 +1,53 @@
+# Generating PitchSheets
+
+Model: `PitchSheet` — exactly one per Dream (`dreamId` unique, cascade
+delete). Endpoints: `POST /api/sheets`, `POST /api/sheets/batch`,
+`GET /api/sheets/by-dream/…`.
+
+A PitchSheet is the presentation layer for a dream — the one-screen
+sales card with a hook, three highlights, three detail blocks, and an
+**artist mockup**. Every PROJECT dream (and any pitch going to Silas)
+deserves one.
+
+## Field spec
+
+Required: `dreamId`, `title`.
+
+| Field | Fill with |
+| --- | --- |
+| `layoutKey` | `'pitch-card'` (default) unless a new layout exists |
+| `title`, `subtitle` | Usually the dream's title + a positioning line |
+| `hook` | One irresistible sentence (≤512) |
+| `pitch` | The full pitch paragraph(s) |
+| `highlight{1..3}Label/Value/Icon` | Three stat-style selling points — short label, short value, `kind-icon:*` icon |
+| `detail{1..3}Label/Body` | Three expandable sections (e.g. The Idea / Why It Works / First Steps) |
+| `imagePath` / `artImageId` | **The artist mockup** — see below |
+| `icon`, `colorTheme` | `kind-icon:*` + a DaisyUI theme name matching the vibe |
+| `extraData` | Json overflow for layout-specific extras |
+| `userId`, `designer`, flags | README rules 4–5 |
+
+## The artist mockup
+
+Every generated PitchSheet includes one mockup image: a "what this would
+feel like shipped" illustration — key screen, poster, or product shot
+energy, NOT a UI wireframe with readable text (house rule: no readable
+text in generated art).
+
+| Asset | Path | Notes |
+| --- | --- | --- |
+| Mockup | `public/images/sheets/{dream-slug}-mockup.webp` (1280×720) | referenced by `imagePath` |
+| Mockup variants | `public/images/{dream-slug}/{dream-slug}-inspiration-{n}.webp` | candidate takes; promote one |
+
+(`images/sheets/` is the prescribed convention for new mockups; existing
+sheets sometimes point elsewhere via `imagePath` — the field, not the
+folder, is authoritative.)
+
+## Checklist
+
+1. Confirm the dream exists and has no sheet (`dreamId` is unique —
+   batch upserts by it).
+2. Write the sheet: hook + 3 highlights + 3 details, all in-voice.
+3. Generate the mockup from a prompt anchored to the dream's `artPrompt`
+   and set `imagePath`.
+4. Verify: the sheet renders in the pitch layout with icons, theme, and
+   mockup resolving.

--- a/sample/generation/rewards.md
+++ b/sample/generation/rewards.md
@@ -1,0 +1,44 @@
+# Generating Rewards
+
+Model: `Reward`. Endpoints: `POST /api/rewards`, `POST /api/rewards/batch`,
+`GET /api/rewards/random`.
+
+Rewards are narrative accelerants: loot, powers, skills, secrets, pets,
+curses, keys, plot grenades. They get played into scenarios and attached
+to characters and dreams.
+
+## Field spec
+
+Required: `name`. Always set: `slug`, `description`, `flavorText`,
+`effect`, `rarity`, `rewardType`, `icon`, `artPrompt`.
+
+| Field | Fill with |
+| --- | --- |
+| `name`, `slug` | Punchy item name; kebab slug |
+| `rewardType` | `SKILL / ITEM / POWER / PET / MAGIC / FAVOR` |
+| `rarity` | `COMMON / UNCOMMON / RARE / EPIC / LEGENDARY / MYTHIC` — skew common; legendaries are earned |
+| `flavorText` | One quotable line (≤512) — the card text |
+| `effect` | What it mechanically/narratively DOES when played into a scene |
+| `description` | Longer lore |
+| `collection` | Set name when generating themed batches (e.g. a dream's loot table) |
+| `icon` | `kind-icon:*` name |
+| `artPrompt` | Item-card prompt, house style |
+| `userId`, `designer` | README rule 5 |
+
+Connect when generating themed sets: `Dreams` (the loot's home world),
+`Characters` (signature owner).
+
+## Art set
+
+| Asset | Path / field | Notes |
+| --- | --- | --- |
+| Card image | `imagePath` / `artImageId` (512×768) | one per reward |
+| Collection folder | `public/images/rewards/{collection-slug}/` | themed batches share a folder; ArtCollection rows use `parentFolder: 'rewards'` |
+
+## Checklist
+
+1. Batch-write the reward rows (a themed set is 5–12 rewards spanning
+   rarities and types).
+2. Generate one card image per reward from `artPrompt`.
+3. Verify: rewards render in the gallery, rarity/type filters catch
+   them, and `random.get` can serve them.

--- a/sample/generation/scenarios.md
+++ b/sample/generation/scenarios.md
@@ -1,0 +1,43 @@
+# Generating Scenarios
+
+Model: `Scenario`. Endpoints: `POST /api/scenarios`,
+`PATCH /api/scenarios/batch`. Parser: `stores/helpers/scenarioHelper.ts`.
+
+Scenarios are playable story settings: the user picks an intro, then
+continues via skill checks, inventory, rewards, or custom prompts while
+the narrator turns choices into consequences.
+
+## Field spec
+
+Required: `title`, `description`, `intros`, `userId`.
+
+| Field | Fill with |
+| --- | --- |
+| `title`, `slug` | Adventure title; kebab slug |
+| `description` | Player-facing setup — where you are, what's at stake |
+| `intros` | **JSON string array.** Each entry is one opening, formatted `"TITLE IN CAPS: opening scene text…"` (see `splitIntro`). 3–6 intros per scenario. Newline-delimited text is tolerated by the parser; JSON array is canonical. |
+| `locations` | Named places within the scenario |
+| `genres` | Comma-separated genre tags |
+| `inspirations` | Source vibes ("Treasure Planet by way of…") |
+| `secretNotes` | GM-only twists the narrator may deploy — never shown to players |
+| `cast` | Json of featured characters; also `Characters` connect |
+| `difficulty`, `tier`, `group` | Optional tuning knobs |
+| `outputType` | `STORY` (default) — or `ART / CHARACTER / REWARD / DREAM / SCENARIO / MIXED` when playing it is meant to *produce* another object |
+| `artPrompt` | Key-art prompt, house style |
+| `designer` | README rule 5 |
+
+Connect: `Dreams` (home world), `Characters` (cast).
+
+## Art set
+
+| Asset | Path / field | Notes |
+| --- | --- | --- |
+| Key art | `imagePath` / `artImageId` (512×768 card or 1280×720 hero) | one per scenario |
+
+## Checklist
+
+1. Write the scenario with 3–6 titled intros as a JSON array string.
+2. Connect the home dream and any cast characters (mirror into `cast`).
+3. Generate key art from `artPrompt`.
+4. Verify: intros parse (`parseScenarioIntros`), choice selector shows
+   them, and the scenario is playable end-to-end in `/stories`.

--- a/sample/generation/threads.md
+++ b/sample/generation/threads.md
@@ -1,0 +1,54 @@
+# Generating Narration Threads
+
+Models: `NarratorTopic` + `NarratorThread`. Endpoints:
+`POST /api/bots/topics`, `POST /api/bots/threads` (both batch upserts,
+CHUNK_SIZE 25, accept `dryRun: true`). Read side:
+`GET /api/narrators/{type}/{slug}`.
+
+Topics are the shared conversation menu (one row per subject, reused
+across all narrators). Threads are one narrator's take on one topic —
+unique per `(botId, topicId)`.
+
+## NarratorTopic field spec
+
+Required: `slug`, `title`, `prompt`.
+
+| Field | Fill with |
+| --- | --- |
+| `slug`, `title`, `subtitle` | Topic identity (`storytime`, "Story Time", …) |
+| `description` | What this conversation mode is |
+| `icon` | `kind-icon:*` name |
+| `prompt` | System-flavored guidance for ANY narrator running this topic |
+| `sampleUserPrompt` | Example user opener |
+| `sortOrder` | Menu position |
+
+Topics are near-canon: prefer reusing existing topics over minting new
+ones. A new topic changes every narrator's menu — check with Silas first.
+
+## NarratorThread field spec
+
+Required: `botId` (or `botName` — the endpoint resolves it), `topicId`,
+`openingText`.
+
+| Field | Fill with |
+| --- | --- |
+| `title` | Optional thread title; falls back to topic title |
+| `openingText` | The narrator's in-voice opener for this topic — written in that bot's `narrativeVoice`, not generic |
+| `guidance` | Topic-specific steering for the LLM, layered on the bot's `botIntro` |
+| `starterPrompts` | Json array of `{ label, prompt, action, path?, flavor?, key?, screen? }` — the suggestion chips |
+| `sortOrder`, `isActive` | Menu position / soft delete |
+
+## Art
+
+Threads have no art of their own — the owning bot's avatar and
+expression set carry the visuals. Generating threads for a bot therefore
+presumes the bot already satisfies `bots.md` (avatar + expressions).
+
+## Checklist
+
+1. `dryRun: true` the batch first; fix `skipped/failed` rows.
+2. One thread per (narrator × topic) that narrator should offer —
+   a full menu is every active topic, each with a distinct in-voice
+   `openingText`.
+3. Verify: `/api/narrators/{type}/{slug}` returns the threads and the
+   narrator screen shows the topic menu.


### PR DESCRIPTION
### Task
Silas-directed (session): generation spec sheets for the objects that get created automatically — bots, dreams, characters, rewards, scenarios, narration threads, expression media, pitch sheets (kind: software/docs). Follow-up to #137.

### What changed / what I produced
- `sample/generation/README.md` — index + universal rules: art is presumed on every generation (artPrompt always filled), standard sizes (icon 256, card 512×768, hero 1280×720, square avatars/expressions), provenance (`creationSource: 'AI'`, designer, prompt metadata), slug-is-a-folder inspiration sets with `{slug}-inspiration-{n}.webp`, batch-API-first with `dryRun`, never-overwrite-silently
- `sample/generation/bots.md` — the three flavors: **NARRATOR** (voice of a dream), **PROMPTBOT** (standalone assistant), **MANAGER** (voice of a PROJECT dream; new canonical BotType value); field spec from the narrator seeds pattern (botIntro stance, narrativeVoice VOICE:+SAMPLE:, forgeIntro, pipe-delimited userIntro); avatar + expression-set art obligations
- `sample/generation/dreams.md` — LOCATION / GENRE (vibe) / PROJECT flavors, project block (goal, waypoints with ✓/~ prefixes), DreamRelation edges, card/hero/collection art
- `sample/generation/characters.md` — full casting sheet incl. Rarity stats; multi-art by design: portrait inspiration set → promoted portrait → optional 20-expression set keyed by characterId
- `sample/generation/rewards.md`, `scenarios.md` (intros = JSON string array of `"TITLE: text"`, per `scenarioHelper.ts`), `threads.md` (NarratorTopic near-canon, threads per bot×topic with in-voice openers)
- `sample/generation/expressions.md` — the 10 emotions + 10 actions, `{key}_01.webp` file convention (bots existing, characters mirrored), identity-consistency rule, ExpressionTransition as lazy polish, and the no-ArtImage-row-per-expression rule
- `sample/generation/pitchsheets.md` — one per dream, hook + 3 highlights + 3 details + **artist mockup** (1280×720, no readable text) at `images/sheets/{dream-slug}-mockup.webp`
- `sample/README.md` — pointer to the new folder

### How I verified
- Field specs read directly from `prisma/schema.prisma` (Bot, Dream, Character, Reward, Scenario, NarratorTopic/Thread, ExpressionMedia/Transition, PitchSheet)
- Conventions confirmed against live code: `stores/seeds/narrators.ts`, `stores/helpers/dreamHelper.ts` (VIBE→GENRE), `scenarioHelper.ts`, `server/api/bots/expressions.post.ts` (dryRun, CHUNK_SIZE), `server/api/narrators/[type]/[slug].get.ts`, and existing files under `public/images/bots/expressions/{slug}/`
- Docs-only change

### Stakes
reversible

### Flags for Reviewer
- `MANAGER` BotType and the character expressions folder (`characters/expressions/{slug}/`) are prescribed conventions — they don't exist in data yet, marked as such in the docs
- `images/sheets/` mockup path is a prescribed convention; existing sheets point wherever their `imagePath` says

### Notes for reviewer
Companion conductor PR adds the policy layer `projects/kind-robots/GENERATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XiYez6WVbMLN2GDMAV1rC

---
_Generated by [Claude Code](https://claude.ai/code/session_019XiYez6WVbMLN2GDMAV1rC)_