### PR TITLE
academy: AI Art Academy — timeline, style gallery, remix studio, style lab

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -1,0 +1,153 @@
+<!-- /components/academy/academy-manager.vue -->
+<template>
+  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <div
+      v-if="isLoadingManager"
+      class="flex h-full min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6"
+    >
+      <div class="flex flex-col items-center gap-3 text-center">
+        <span class="loading loading-spinner loading-lg text-primary" />
+        <p class="text-sm text-base-content/70">
+          Dusting off the timeline, warming up the remix engine, and politely
+          waking five centuries of dead masters...
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-else-if="managerError"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
+    >
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <span>{{ managerError }}</span>
+        <button
+          type="button"
+          class="btn btn-error btn-sm rounded-2xl"
+          @click="loadManagerData(true)"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+
+    <section
+      v-else-if="activeTab === 'timeline'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <academy-timeline class="min-h-full w-full" @remix="goToRemix" />
+      </div>
+    </section>
+
+    <section
+      v-else-if="activeTab === 'styles'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <academy-styles-browser class="min-h-full w-full" @remix="goToRemix" />
+      </div>
+    </section>
+
+    <section
+      v-else-if="activeTab === 'remix'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <academy-remix class="min-h-full w-full" />
+      </div>
+    </section>
+
+    <section
+      v-else-if="activeTab === 'stylelab'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <div
+          class="grid min-h-full gap-3 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]"
+        >
+          <art-styler class="min-h-0" :show-close="false" />
+
+          <image-upload class="min-h-0" :show-model-connect="false" />
+        </div>
+      </div>
+    </section>
+
+    <div
+      v-else
+      class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+    >
+      Unknown academy tab: {{ activeTab }}
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useAcademyStore } from '@/stores/academyStore'
+import { useArtStore } from '@/stores/artStore'
+import { useNavStore } from '@/stores/navStore'
+import { useServerStore } from '@/stores/serverStore'
+
+type AcademyTab = 'timeline' | 'styles' | 'remix' | 'stylelab'
+
+const academyStore = useAcademyStore()
+const artStore = useArtStore()
+const navStore = useNavStore()
+const serverStore = useServerStore()
+
+const defaultDashboardKey = 'academy'
+const defaultTab: AcademyTab = 'timeline'
+
+const validTabs: AcademyTab[] = ['timeline', 'styles', 'remix', 'stylelab']
+
+const isLoadingManager = ref(false)
+const managerError = ref<string | null>(null)
+
+const dashboardKey = computed(() => {
+  return navStore.dashboardShell.dashboardKey || defaultDashboardKey
+})
+
+const activeTab = computed<AcademyTab>(() => {
+  const selectedTab = navStore.getDashboardTab(dashboardKey.value)
+
+  if (!validTabs.includes(selectedTab as AcademyTab)) {
+    return defaultTab
+  }
+
+  return selectedTab as AcademyTab
+})
+
+function goToRemix(styleSlug: string) {
+  academyStore.selectStyle(styleSlug)
+  navStore.setDashboardTab(dashboardKey.value, 'remix', 'academy remix CTA')
+}
+
+async function loadManagerData(force = false) {
+  isLoadingManager.value = true
+  managerError.value = null
+
+  try {
+    await Promise.all([
+      ...(force || !serverStore.hasLoaded
+        ? [serverStore.initialize({ force, fetchRemote: true })]
+        : []),
+      artStore.initialize({
+        force,
+        fetchRemote: true,
+        hydrateImages: false,
+        initializeServerStore: false,
+      }),
+    ])
+  } catch (error) {
+    managerError.value =
+      error instanceof Error ? error.message : 'Failed to load the Academy.'
+  } finally {
+    isLoadingManager.value = false
+  }
+}
+
+onMounted(() => {
+  academyStore.hydrate()
+  void loadManagerData()
+})
+</script>

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -1,0 +1,110 @@
+<!-- /components/academy/academy-remix.vue -->
+<template>
+  <section class="flex flex-col gap-3">
+    <header
+      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+    >
+      <div class="flex flex-col gap-1">
+        <h2
+          class="flex items-center gap-2 text-base font-black text-base-content"
+        >
+          <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
+          Remix Studio
+        </h2>
+        <p class="text-sm text-base-content/70">
+          Pick a historical style, bring an image — yours or from the gallery —
+          and let the Kontext engine repaint it the way the masters would have.
+        </p>
+      </div>
+      <span class="badge badge-ghost badge-sm">
+        {{ academyStore.stylesRemixedCount }}/{{ academyStore.styles.length }}
+        styles remixed
+      </span>
+    </header>
+
+    <div
+      class="grid min-h-0 gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]"
+    >
+      <art-styler
+        class="min-h-0"
+        :styles="remixStyles"
+        :selected-style-key="academyStore.selectedStyleSlug"
+        :show-close="false"
+        @style-selected="onStyleSelected"
+        @generated="onGenerated"
+      />
+
+      <aside class="flex min-h-0 flex-col gap-3">
+        <academy-style-detail
+          v-if="contextStyle"
+          :lesson="contextStyle"
+          :show-close="false"
+          @remix="() => {}"
+        />
+
+        <div
+          v-else
+          class="flex min-h-40 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6 text-center"
+        >
+          <span class="text-3xl">🏛️</span>
+          <p class="text-sm font-semibold text-base-content/60">
+            Select a style to see its story
+          </p>
+          <p class="text-xs text-base-content/40">
+            Every remix comes with a free history lesson. We're sneaky like
+            that.
+          </p>
+        </div>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useAcademyStore } from '@/stores/academyStore'
+import type { AcademyStyle } from '@/stores/seeds/academyStyles'
+import type { StyleEntry } from '@/stores/helpers/styleHelper'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+
+const academyStore = useAcademyStore()
+
+const activeStyleSlug = ref<string | null>(
+  academyStore.selectedStyleSlug ?? null,
+)
+
+const remixStyles = computed<StyleEntry[]>(() => {
+  return academyStore.timeline.map((style) => academyStyleToEntry(style))
+})
+
+const contextStyle = computed<AcademyStyle | null>(() => {
+  if (!activeStyleSlug.value) return null
+  return (
+    academyStore.styles.find((style) => style.slug === activeStyleSlug.value) ??
+    null
+  )
+})
+
+function academyStyleToEntry(style: AcademyStyle): StyleEntry {
+  return {
+    slug: style.slug,
+    label: style.name,
+    category: 'History',
+    triggerPhrase: style.remix.template,
+    loraPath: style.remix.loraPath,
+    loraWeight: style.remix.loraWeight,
+    previewImageSrc: style.previewImageSrc,
+  }
+}
+
+function onStyleSelected(entry: StyleEntry | null) {
+  activeStyleSlug.value = entry?.slug ?? null
+  academyStore.selectStyle(entry?.slug ?? null)
+}
+
+function onGenerated(_image: ArtImage) {
+  if (activeStyleSlug.value) {
+    academyStore.markStyleRemixed(activeStyleSlug.value)
+  }
+}
+</script>

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -1,0 +1,127 @@
+<!-- /components/academy/academy-style-detail.vue -->
+<template>
+  <article
+    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
+  >
+    <header class="flex flex-wrap items-start justify-between gap-2">
+      <div class="flex min-w-0 flex-col gap-1">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-2xl leading-none">🏛️</span>
+          <h3 class="text-lg font-black text-base-content">
+            {{ lesson.name }}
+          </h3>
+          <span class="badge badge-primary badge-sm font-bold">
+            {{ lesson.era }}
+          </span>
+          <span class="badge badge-ghost badge-sm">{{ lesson.region }}</span>
+        </div>
+        <p
+          v-if="isViewed"
+          class="flex items-center gap-1 text-xs font-semibold text-success"
+        >
+          <Icon name="kind-icon:check" class="h-3.5 w-3.5" />
+          Lesson explored
+        </p>
+      </div>
+
+      <button
+        v-if="showClose"
+        type="button"
+        class="btn btn-circle btn-ghost btn-sm"
+        title="Close lesson"
+        @click="emit('close')"
+      >
+        <Icon name="mdi:close" class="h-4 w-4" />
+      </button>
+    </header>
+
+    <p class="text-sm leading-relaxed text-base-content/80">
+      {{ lesson.keyIdeas }}
+    </p>
+
+    <div class="rounded-xl border border-base-300 bg-base-200/60 p-3">
+      <p
+        class="mb-2 flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
+      >
+        <Icon name="kind-icon:search" class="h-3.5 w-3.5" />
+        How to spot it
+      </p>
+      <ul class="flex flex-col gap-1.5">
+        <li
+          v-for="cue in lesson.recognitionCues"
+          :key="cue"
+          class="flex items-start gap-2 text-sm text-base-content/80"
+        >
+          <span class="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+          {{ cue }}
+        </li>
+      </ul>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <p
+        class="flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-base-content/60"
+      >
+        <Icon name="kind-icon:user" class="h-3.5 w-3.5" />
+        Meet the masters
+      </p>
+      <div class="grid gap-2 sm:grid-cols-2">
+        <div
+          v-for="artist in lesson.artists"
+          :key="artist.name"
+          class="rounded-xl border border-base-300 bg-base-200/40 px-3 py-2"
+        >
+          <p class="text-sm font-bold text-base-content">
+            {{ artist.name }}
+            <span class="ml-1 text-xs font-normal text-base-content/50">
+              {{ artist.years }}
+            </span>
+          </p>
+          <p class="text-xs leading-relaxed text-base-content/70">
+            {{ artist.note }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <footer class="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        class="btn btn-primary flex-1 rounded-2xl font-black shadow-lg shadow-primary/20 hover:-translate-y-0.5 hover:shadow-primary/30 active:translate-y-0"
+        @click="emit('remix', lesson.slug)"
+      >
+        <Icon name="kind-icon:magic" class="h-5 w-5" />
+        Remix an image in {{ lesson.name }}
+      </button>
+    </footer>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useAcademyStore } from '@/stores/academyStore'
+import type { AcademyStyle } from '@/stores/seeds/academyStyles'
+
+const props = withDefaults(
+  defineProps<{
+    lesson: AcademyStyle
+    showClose?: boolean
+  }>(),
+  { showClose: true },
+)
+
+const emit = defineEmits<{
+  remix: [styleSlug: string]
+  close: []
+}>()
+
+const academyStore = useAcademyStore()
+
+const isViewed = computed(() => {
+  return academyStore.viewedLessons.includes(props.lesson.slug)
+})
+
+onMounted(() => {
+  academyStore.markLessonViewed(props.lesson.slug)
+})
+</script>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -1,0 +1,139 @@
+<!-- /components/academy/academy-styles-browser.vue -->
+<template>
+  <section class="flex flex-col gap-4">
+    <header
+      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+    >
+      <div class="flex flex-col gap-1">
+        <h2
+          class="flex items-center gap-2 text-base font-black text-base-content"
+        >
+          <Icon name="kind-icon:palette" class="h-5 w-5 text-primary" />
+          Style Gallery
+        </h2>
+        <p class="text-sm text-base-content/70">
+          Every style the Academy teaches. Open a lesson, learn to spot it, then
+          remix your own image in it.
+        </p>
+      </div>
+
+      <label
+        class="input input-bordered input-sm flex items-center gap-1.5 bg-base-100"
+      >
+        <Icon
+          name="kind-icon:search"
+          class="h-3.5 w-3.5 shrink-0 text-base-content/40"
+        />
+        <input
+          v-model="searchQuery"
+          type="search"
+          class="min-w-0 flex-1 bg-transparent"
+          placeholder="Search styles…"
+        />
+      </label>
+    </header>
+
+    <academy-style-detail
+      v-if="expandedStyle"
+      :lesson="expandedStyle"
+      @close="expandedSlug = null"
+      @remix="emit('remix', $event)"
+    />
+
+    <div
+      class="grid gap-3"
+      style="
+        grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
+      "
+    >
+      <button
+        v-for="style in filteredStyles"
+        :key="style.slug"
+        type="button"
+        class="group flex flex-col gap-2 rounded-2xl border-2 p-4 text-left transition-all duration-150"
+        :class="
+          expandedSlug === style.slug
+            ? 'border-primary shadow-md shadow-primary/20'
+            : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
+        "
+        @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
+      >
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-2xl leading-none">🏛️</span>
+          <Icon
+            v-if="academyStore.viewedLessons.includes(style.slug)"
+            name="kind-icon:check"
+            class="h-4 w-4 text-success"
+            title="Lesson explored"
+          />
+        </div>
+        <div class="flex flex-col">
+          <span
+            class="text-sm font-black text-base-content group-hover:text-primary"
+          >
+            {{ style.name }}
+          </span>
+          <span class="text-xs text-base-content/50">
+            {{ style.era }} · {{ style.region }}
+          </span>
+        </div>
+        <p class="line-clamp-2 text-xs leading-relaxed text-base-content/60">
+          {{ style.keyIdeas }}
+        </p>
+      </button>
+    </div>
+
+    <div
+      v-if="!filteredStyles.length"
+      class="flex min-h-28 flex-col items-center justify-center rounded-2xl border border-base-300 bg-base-200/60 text-center"
+    >
+      <Icon name="kind-icon:search" class="h-8 w-8 text-base-content/20" />
+      <p class="mt-1 text-xs text-base-content/40">
+        No styles match "{{ searchQuery }}" — history is long, but not that
+        long.
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useAcademyStore } from '@/stores/academyStore'
+import type { AcademyStyle } from '@/stores/seeds/academyStyles'
+
+const emit = defineEmits<{
+  remix: [styleSlug: string]
+}>()
+
+const academyStore = useAcademyStore()
+
+const searchQuery = ref('')
+const expandedSlug = ref<string | null>(null)
+
+const expandedStyle = computed<AcademyStyle | null>(() => {
+  if (!expandedSlug.value) return null
+  return (
+    academyStore.styles.find((style) => style.slug === expandedSlug.value) ??
+    null
+  )
+})
+
+const filteredStyles = computed<AcademyStyle[]>(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  if (!query) return academyStore.timeline
+
+  return academyStore.timeline.filter((style) => {
+    return [
+      style.name,
+      style.era,
+      style.region,
+      style.keyIdeas,
+      ...style.artists.map((artist) => artist.name),
+    ]
+      .join(' ')
+      .toLowerCase()
+      .includes(query)
+  })
+})
+</script>

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -1,0 +1,109 @@
+<!-- /components/academy/academy-timeline.vue -->
+<template>
+  <section class="flex flex-col gap-4">
+    <header
+      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+    >
+      <div class="flex flex-col gap-1">
+        <h2
+          class="flex items-center gap-2 text-base font-black text-base-content"
+        >
+          <Icon name="kind-icon:map" class="h-5 w-5 text-primary" />
+          The Art History Timeline
+        </h2>
+        <p class="text-sm text-base-content/70">
+          Twenty-five centuries of style, all public domain, all remixable. Pick
+          an era and see what the masters were up to.
+        </p>
+      </div>
+      <div
+        class="flex items-center gap-2 text-xs font-semibold text-base-content/60"
+      >
+        <span class="badge badge-ghost badge-sm">
+          {{ academyStore.lessonsViewedCount }}/{{
+            academyStore.timeline.length
+          }}
+          lessons explored
+        </span>
+        <span class="badge badge-ghost badge-sm">
+          {{ academyStore.stylesRemixedCount }} styles remixed
+        </span>
+      </div>
+    </header>
+
+    <ol class="relative flex flex-col gap-3 pl-6">
+      <div
+        class="absolute bottom-4 left-2 top-4 w-0.5 rounded-full bg-linear-to-b from-primary/60 via-secondary/40 to-primary/10"
+      />
+
+      <li
+        v-for="style in academyStore.timeline"
+        :key="style.slug"
+        class="relative"
+      >
+        <span
+          class="absolute -left-[1.35rem] top-5 h-3 w-3 rounded-full border-2 transition-colors"
+          :class="
+            expandedSlug === style.slug
+              ? 'border-primary bg-primary'
+              : academyStore.viewedLessons.includes(style.slug)
+                ? 'border-primary bg-base-100'
+                : 'border-base-300 bg-base-100'
+          "
+        />
+
+        <button
+          v-if="expandedSlug !== style.slug"
+          type="button"
+          class="group flex w-full flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
+          @click="expandedSlug = style.slug"
+        >
+          <span class="text-xl leading-none">🏛️</span>
+          <span class="flex min-w-0 flex-1 flex-col">
+            <span class="flex flex-wrap items-baseline gap-2">
+              <span
+                class="text-sm font-black text-base-content group-hover:text-primary"
+              >
+                {{ style.name }}
+              </span>
+              <span class="text-xs text-base-content/50">{{ style.era }}</span>
+            </span>
+            <span class="truncate text-xs text-base-content/60">
+              {{ style.recognitionCues[0] }}
+            </span>
+          </span>
+          <Icon
+            v-if="academyStore.viewedLessons.includes(style.slug)"
+            name="kind-icon:check"
+            class="h-4 w-4 shrink-0 text-success"
+            title="Lesson explored"
+          />
+          <Icon
+            name="mdi:chevron-down"
+            class="h-4 w-4 shrink-0 text-base-content/40 group-hover:text-primary"
+          />
+        </button>
+
+        <academy-style-detail
+          v-else
+          :lesson="style"
+          @close="expandedSlug = null"
+          @remix="emit('remix', $event)"
+        />
+      </li>
+    </ol>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useAcademyStore } from '@/stores/academyStore'
+
+const emit = defineEmits<{
+  remix: [styleSlug: string]
+}>()
+
+const academyStore = useAcademyStore()
+
+const expandedSlug = ref<string | null>(null)
+</script>

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -10,6 +10,7 @@
         <span class="badge badge-primary badge-sm">Kontext</span>
       </div>
       <button
+        v-if="showClose"
         type="button"
         class="btn btn-circle btn-ghost btn-sm"
         title="Close"
@@ -308,11 +309,11 @@
     >
       <button
         v-for="style in filteredStyles"
-        :key="style.loraPath"
+        :key="styleKey(style)"
         type="button"
         class="group relative flex flex-col items-center gap-1.5 overflow-hidden rounded-2xl border-2 p-0 text-center transition-all duration-150"
         :class="
-          selectedStyle?.loraPath === style.loraPath
+          isSelectedStyle(style)
             ? 'border-primary shadow-md shadow-primary/20'
             : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
         "
@@ -351,11 +352,7 @@
         <div
           v-else
           class="flex w-full flex-col items-center gap-1.5 px-2 py-3"
-          :class="
-            selectedStyle?.loraPath === style.loraPath
-              ? 'bg-primary/10'
-              : 'bg-base-100'
-          "
+          :class="isSelectedStyle(style) ? 'bg-primary/10' : 'bg-base-100'"
         >
           <span class="text-xl leading-none">
             {{ CATEGORY_ICONS[style.category] }}
@@ -363,7 +360,7 @@
           <span
             class="text-xs font-bold leading-tight"
             :class="
-              selectedStyle?.loraPath === style.loraPath
+              isSelectedStyle(style)
                 ? 'text-primary'
                 : 'text-base-content/80 group-hover:text-primary'
             "
@@ -374,7 +371,7 @@
 
         <Transition name="pop">
           <div
-            v-if="selectedStyle?.loraPath === style.loraPath"
+            v-if="isSelectedStyle(style)"
             class="absolute right-1.5 top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-primary"
           >
             <Icon name="mdi:check" class="h-3 w-3 text-primary-content" />
@@ -400,14 +397,18 @@
           <Icon name="kind-icon:edit" class="h-4 w-4 text-primary" />
           <span class="text-xs font-black text-base-content">Prompt</span>
           <span class="ml-auto text-xs text-base-content/40">
-            LoRA trigger auto-prepended
+            {{
+              selectedStyle?.loraPath
+                ? 'LoRA trigger auto-prepended'
+                : 'Style instruction auto-prepended'
+            }}
           </span>
         </div>
 
         <div
           class="rounded-lg border border-base-300 bg-base-200 px-3 py-2 font-mono text-xs text-base-content/60"
         >
-          <span class="text-warning">
+          <span v-if="buildLoraReference(selectedStyle)" class="text-warning">
             {{ buildLoraReference(selectedStyle) }}
           </span>
           <span class="text-primary"> {{ selectedStyle.triggerPhrase }}</span>
@@ -517,18 +518,33 @@ import { useArtStore } from '@/stores/artStore'
 import { useResourceStore } from '@/stores/resourceStore'
 import { useUserStore } from '@/stores/userStore'
 import { useServerStore } from '@/stores/serverStore'
+import {
+  STYLE_CATEGORY_ICONS,
+  styleEntryKey,
+} from '@/stores/helpers/styleHelper'
+import type { StyleCategory, StyleEntry } from '@/stores/helpers/styleHelper'
 import type { ArtImage, Server } from '~/prisma/generated/prisma/client'
 
 const props = withDefaults(
   defineProps<{
     serverId?: number | null
+    /**
+     * External style list (e.g. the AI Art Academy registry). When provided,
+     * it replaces the builtin styles and resource-DB hydration is skipped.
+     */
+    styles?: StyleEntry[] | null
+    /** Hide the close button when embedded as a full tab rather than a panel. */
+    showClose?: boolean
+    /** Preselect a style by its key (slug/loraPath/label) — e.g. Academy lesson CTA. */
+    selectedStyleKey?: string | null
   }>(),
-  { serverId: null },
+  { serverId: null, styles: null, showClose: true, selectedStyleKey: null },
 )
 
 const emit = defineEmits<{
   generated: [image: ArtImage]
   close: []
+  styleSelected: [style: StyleEntry | null]
 }>()
 
 const artStore = useArtStore()
@@ -536,36 +552,8 @@ const resourceStore = useResourceStore()
 const userStore = useUserStore()
 const serverStore = useServerStore()
 
-type StyleCategory =
-  | 'Painterly'
-  | 'Illustration'
-  | 'Cartoon'
-  | 'Anime'
-  | 'Trippy'
-  | '3D/Craft'
-  | 'Realism'
-  | 'Ink'
-
-interface StyleEntry {
-  loraPath: string
-  loraWeight: number
-  triggerPhrase: string
-  label: string
-  category: StyleCategory
-  previewImageSrc?: string
-  resourceId?: number
-}
-
-const CATEGORY_ICONS: Record<StyleCategory, string> = {
-  Painterly: '🎨',
-  Illustration: '✏️',
-  Cartoon: '🎬',
-  Anime: '⛩️',
-  Trippy: '🌈',
-  '3D/Craft': '🏺',
-  Realism: '📸',
-  Ink: '🖋️',
-}
+const CATEGORY_ICONS = STYLE_CATEGORY_ICONS
+const styleKey = styleEntryKey
 
 const BUILTIN_STYLES: StyleEntry[] = [
   {
@@ -749,7 +737,9 @@ const BUILTIN_STYLES: StyleEntry[] = [
   },
 ]
 
-const styles = ref<StyleEntry[]>([...BUILTIN_STYLES])
+const styles = ref<StyleEntry[]>(
+  props.styles?.length ? [...props.styles] : [...BUILTIN_STYLES],
+)
 const selectedStyle = ref<StyleEntry | null>(null)
 const activeCategory = ref<StyleCategory | null>(null)
 const extraPrompt = ref('')
@@ -1023,15 +1013,22 @@ async function hydrateGalleryThumbs() {
 }
 
 function buildLoraReference(style: StyleEntry): string {
-  return `<lora:${style.loraPath}:${style.loraWeight}>`
+  if (!style.loraPath) return ''
+  return `<lora:${style.loraPath}:${style.loraWeight ?? 1}>`
+}
+
+function isSelectedStyle(style: StyleEntry): boolean {
+  return (
+    !!selectedStyle.value && styleKey(selectedStyle.value) === styleKey(style)
+  )
 }
 
 function selectStyle(style: StyleEntry) {
-  selectedStyle.value =
-    selectedStyle.value?.loraPath === style.loraPath ? null : { ...style }
+  selectedStyle.value = isSelectedStyle(style) ? null : { ...style }
   errorMessage.value = ''
   successMessage.value = ''
   resultImage.value = null
+  emit('styleSelected', selectedStyle.value)
 }
 
 function clearSelection() {
@@ -1040,9 +1037,13 @@ function clearSelection() {
   errorMessage.value = ''
   successMessage.value = ''
   resultImage.value = null
+  emit('styleSelected', null)
 }
 
 async function hydrateFromResourceStore(): Promise<void> {
+  // External registries (e.g. Academy) own their style list entirely.
+  if (props.styles?.length) return
+
   try {
     if (!resourceStore.hasLoaded) {
       await resourceStore.getResources()
@@ -1059,11 +1060,15 @@ async function hydrateFromResourceStore(): Promise<void> {
 
     if (!dbLoras.length) return
 
-    const builtinPaths = new Set(styles.value.map((style) => style.loraPath))
+    const builtinPaths = new Set(
+      styles.value
+        .map((style) => style.loraPath)
+        .filter((path): path is string => !!path),
+    )
 
     const updated = styles.value.map((style) => {
       const stem =
-        style.loraPath.split('/').pop()?.replace('.safetensors', '') || ''
+        style.loraPath?.split('/').pop()?.replace('.safetensors', '') || ''
 
       const match = dbLoras.find((resource) => {
         return (
@@ -1126,7 +1131,9 @@ async function runStyleTransfer(): Promise<void> {
     const loraRef = buildLoraReference(style)
 
     const promptString = [
-      `${loraRef} ${style.triggerPhrase}`.trim(),
+      loraRef
+        ? `${loraRef} ${style.triggerPhrase}`.trim()
+        : style.triggerPhrase,
       extraPrompt.value.trim(),
     ]
       .filter(Boolean)
@@ -1222,6 +1229,43 @@ watch(sourceTab, async (tab) => {
 watch(gallerySearch, () => {
   void hydrateGalleryThumbs()
 })
+
+watch(
+  () => props.styles,
+  (next) => {
+    if (next?.length) {
+      styles.value = [...next]
+
+      if (
+        selectedStyle.value &&
+        !next.some((style) => isSelectedStyle(style))
+      ) {
+        selectedStyle.value = null
+        emit('styleSelected', null)
+      }
+    }
+  },
+  { deep: true },
+)
+
+watch(
+  () => props.selectedStyleKey,
+  (key) => {
+    if (!key) return
+    if (selectedStyle.value && styleKey(selectedStyle.value) === key) return
+
+    const match = styles.value.find((style) => styleKey(style) === key)
+
+    if (match) {
+      selectedStyle.value = { ...match }
+      errorMessage.value = ''
+      successMessage.value = ''
+      resultImage.value = null
+      emit('styleSelected', selectedStyle.value)
+    }
+  },
+  { immediate: true },
+)
 
 onMounted(() => {
   void hydrateFromResourceStore()

--- a/content/academy.md
+++ b/content/academy.md
@@ -1,0 +1,17 @@
+---
+title: 'Art Academy'
+room: 'Art Academy'
+subtitle: 'Learn the styles. Meet the masters. Remix everything.'
+description: Explore twenty-five centuries of public-domain art history, then remix your own images in any style you learn — from Greek vases to De Stijl grids.
+image: 'background/artgallery.webp'
+icon: kind-icon:palette
+tooltip: Art history lessons with a remix button. The masters would approve. Probably.
+sort: highlight
+dottitip: 'Can you really learn art history from a robot?'
+amitip: 'Every artist here has been public domain for decades — we checked. The robots just dust the frames and run the remix engine!'
+dashboardKey: academy
+loadingMessage: Restoring the frescoes...
+refreshLabel: Refresh Academy
+---
+
+:academy-manager

--- a/stores/academyStore.ts
+++ b/stores/academyStore.ts
@@ -1,0 +1,123 @@
+// /stores/academyStore.ts
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import {
+  academyStyles,
+  academyStylesBySlug,
+  academyTimeline,
+} from '@/stores/seeds/academyStyles'
+import type { AcademyStyle } from '@/stores/seeds/academyStyles'
+
+const storageKey = 'kindRobotsAcademyState'
+const isClient = typeof window !== 'undefined'
+
+interface AcademyPersistedState {
+  viewedLessons: string[]
+  remixedStyles: string[]
+  selectedStyleSlug: string | null
+}
+
+export const useAcademyStore = defineStore('academyStore', () => {
+  const selectedStyleSlug = ref<string | null>(null)
+  const viewedLessons = ref<string[]>([])
+  const remixedStyles = ref<string[]>([])
+  const hasHydrated = ref(false)
+
+  const styles = computed<AcademyStyle[]>(() => academyStyles)
+  const timeline = computed<AcademyStyle[]>(() => academyTimeline)
+
+  const selectedStyle = computed<AcademyStyle | null>(() => {
+    if (!selectedStyleSlug.value) return null
+    return academyStylesBySlug[selectedStyleSlug.value] ?? null
+  })
+
+  const lessonsViewedCount = computed(() => viewedLessons.value.length)
+  const stylesRemixedCount = computed(() => remixedStyles.value.length)
+
+  function hydrate() {
+    if (!isClient || hasHydrated.value) return
+    hasHydrated.value = true
+
+    try {
+      const raw = localStorage.getItem(storageKey)
+      if (!raw) return
+
+      const parsed = JSON.parse(raw) as Partial<AcademyPersistedState>
+
+      if (Array.isArray(parsed.viewedLessons)) {
+        viewedLessons.value = parsed.viewedLessons.filter(
+          (slug): slug is string =>
+            typeof slug === 'string' && slug in academyStylesBySlug,
+        )
+      }
+
+      if (Array.isArray(parsed.remixedStyles)) {
+        remixedStyles.value = parsed.remixedStyles.filter(
+          (slug): slug is string =>
+            typeof slug === 'string' && slug in academyStylesBySlug,
+        )
+      }
+
+      if (
+        typeof parsed.selectedStyleSlug === 'string' &&
+        parsed.selectedStyleSlug in academyStylesBySlug
+      ) {
+        selectedStyleSlug.value = parsed.selectedStyleSlug
+      }
+    } catch (error) {
+      console.warn('[academyStore] hydrate failed:', error)
+    }
+  }
+
+  function persist() {
+    if (!isClient) return
+
+    const payload: AcademyPersistedState = {
+      viewedLessons: viewedLessons.value,
+      remixedStyles: remixedStyles.value,
+      selectedStyleSlug: selectedStyleSlug.value,
+    }
+
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(payload))
+    } catch (error) {
+      console.warn('[academyStore] persist failed:', error)
+    }
+  }
+
+  function selectStyle(slug: string | null) {
+    selectedStyleSlug.value = slug && slug in academyStylesBySlug ? slug : null
+    persist()
+  }
+
+  function markLessonViewed(slug: string) {
+    if (!(slug in academyStylesBySlug)) return
+    if (!viewedLessons.value.includes(slug)) {
+      viewedLessons.value = [...viewedLessons.value, slug]
+      persist()
+    }
+  }
+
+  function markStyleRemixed(slug: string) {
+    if (!(slug in academyStylesBySlug)) return
+    if (!remixedStyles.value.includes(slug)) {
+      remixedStyles.value = [...remixedStyles.value, slug]
+      persist()
+    }
+  }
+
+  return {
+    styles,
+    timeline,
+    selectedStyleSlug,
+    selectedStyle,
+    viewedLessons,
+    remixedStyles,
+    lessonsViewedCount,
+    stylesRemixedCount,
+    hydrate,
+    selectStyle,
+    markLessonViewed,
+    markStyleRemixed,
+  }
+})

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -119,7 +119,7 @@ export const dashboardConfigs = {
           'The Hair by Superkate suite: AI restyles, appointment calculator, clients, and receipts.',
         image: tabImage('art', 'stylist'),
         narrative:
-          'The whole salon in one tab: try a new color or cut on a client\'s own photo, price an appointment (rate × time + products), keep the client book, and send warm receipts. Client photos stay private — never public, never in the memory game.',
+          "The whole salon in one tab: try a new color or cut on a client's own photo, price an appointment (rate × time + products), keep the client book, and send warm receipts. Client photos stay private — never public, never in the memory game.",
         route: '/stylist',
       },
       {
@@ -145,6 +145,61 @@ export const dashboardConfigs = {
         narrative:
           'Test image generators directly with quick prompts, fast iteration, and a healthy distrust of default settings.',
         route: '/wonderlab',
+      },
+    ],
+  },
+
+  academy: {
+    key: 'academy',
+    label: 'Art Academy',
+    defaultTab: 'timeline',
+    tabs: [
+      {
+        key: 'timeline',
+        label: 'Timeline',
+        icon: 'kind-icon:map',
+        title: 'Art History Timeline',
+        summary:
+          'Walk twenty-five centuries of art history, one style at a time.',
+        image: tabImage('academy', 'timeline'),
+        narrative:
+          'Walk the timeline from Greek vases to De Stijl grids, meet the long-departed masters, and learn why every era thought the previous one was doing it wrong.',
+        route: '/academy',
+      },
+      {
+        key: 'styles',
+        label: 'Styles',
+        icon: 'kind-icon:palette',
+        title: 'Style Gallery',
+        summary:
+          'Browse every style the Academy teaches and learn to spot each one.',
+        image: tabImage('academy', 'styles'),
+        narrative:
+          'Browse the full public-domain style catalog, learn the recognition cues, and start seeing brushstrokes everywhere you look. We apologize in advance.',
+        route: '/academy',
+      },
+      {
+        key: 'remix',
+        label: 'Remix Studio',
+        icon: 'kind-icon:magic',
+        title: 'Remix Studio',
+        summary:
+          'Remix your own image in any historical style you just learned.',
+        image: tabImage('academy', 'remix'),
+        narrative:
+          'Bring your own image or pick one from the gallery, choose a historical style, and let the Kontext engine repaint it the way the masters would have — history lesson included at no extra charge.',
+        route: '/academy',
+      },
+      {
+        key: 'stylelab',
+        label: 'Style Lab',
+        icon: 'kind-icon:paintbrush',
+        title: 'Style Lab',
+        summary: 'Free-play style transfer with the full experimental catalog.',
+        image: tabImage('art', 'styler'), // shared with the art styler tab
+        narrative:
+          'The free-play corner of the Academy: remix images with the full experimental style catalog, no curriculum, no quiz, just tasteful visual crimes.',
+        route: '/academy',
       },
     ],
   },

--- a/stores/helpers/styleHelper.ts
+++ b/stores/helpers/styleHelper.ts
@@ -1,0 +1,49 @@
+// /stores/helpers/styleHelper.ts
+//
+// Shared style-transfer types used by art-styler.vue and the AI Art
+// Academy surfaces. Lives outside the SFC because <script setup>
+// cannot re-export types.
+
+export type StyleCategory =
+  | 'Painterly'
+  | 'Illustration'
+  | 'Cartoon'
+  | 'Anime'
+  | 'Trippy'
+  | '3D/Craft'
+  | 'Realism'
+  | 'Ink'
+  | 'History'
+
+export interface StyleEntry {
+  /**
+   * LoRA reference on the art server. Optional: prompt-mode styles
+   * (e.g. Academy historical styles) rely on base-model knowledge and
+   * carry only a triggerPhrase.
+   */
+  loraPath?: string
+  loraWeight?: number
+  triggerPhrase: string
+  label: string
+  category: StyleCategory
+  /** Stable identity for external registries; falls back to loraPath/label. */
+  slug?: string
+  previewImageSrc?: string
+  resourceId?: number
+}
+
+export const STYLE_CATEGORY_ICONS: Record<StyleCategory, string> = {
+  Painterly: '🎨',
+  Illustration: '✏️',
+  Cartoon: '🎬',
+  Anime: '⛩️',
+  Trippy: '🌈',
+  '3D/Craft': '🏺',
+  Realism: '📸',
+  Ink: '🖋️',
+  History: '🏛️',
+}
+
+export function styleEntryKey(style: StyleEntry): string {
+  return style.slug ?? style.loraPath ?? style.label
+}

--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -1,0 +1,514 @@
+// /stores/seeds/academyStyles.ts
+//
+// AI Art Academy style registry — the canonical front-end seed for the
+// Academy curriculum (conductor project: ai-art-academy).
+//
+// ETHICAL BOUNDARY (do not relax): entries reference art MOVEMENTS and
+// long-dead public-domain artists only. No living artists, no active
+// brands or studios. Living-creator styles stay in the free-play Style
+// Lab (art-styler builtin list) and are never presented as curriculum.
+//
+// remix.mode:
+//   'prompt' — FLUX Kontext base-model knowledge, no LoRA required.
+//   'lora'   — requires the named LoRA on the art server.
+//   'hybrid' — LoRA plus a rich prompt template.
+// Prompt-mode is the default: canonical historical styles are the best
+// case for model knowledge. LoRA upgrades land via the conductor
+// style-lora-registry evaluation (ai-art-academy t-003/t-004).
+
+export interface AcademyArtist {
+  name: string
+  years: string
+  note: string
+}
+
+export interface AcademyRemixConfig {
+  mode: 'prompt' | 'lora' | 'hybrid'
+  /** Kontext instruction; art-styler uses this as the trigger phrase. */
+  template: string
+  loraPath?: string
+  loraWeight?: number
+}
+
+export interface AcademyStyle {
+  slug: string
+  name: string
+  era: string
+  /** Rough start year, used to order the timeline. */
+  sortYear: number
+  region: string
+  keyIdeas: string
+  recognitionCues: string[]
+  artists: AcademyArtist[]
+  remix: AcademyRemixConfig
+  /** Optional preview image under /images/academy/styles/{slug}.webp */
+  previewImageSrc?: string
+}
+
+export const academyStyles: AcademyStyle[] = [
+  {
+    slug: 'greek-vase-painting',
+    name: 'Greek Vase Painting',
+    era: 'c. 600–300 BCE',
+    sortYear: -600,
+    region: 'Ancient Greece',
+    keyIdeas:
+      'Storytelling wrapped around everyday objects: gods, athletes, and heroes rendered in bold silhouette on clay. Black-figure and later red-figure techniques turned pottery into a portable gallery, and the strict two-tone palette forced artists to say everything with contour and gesture.',
+    recognitionCues: [
+      'Terracotta orange and glossy black, almost nothing else',
+      'Figures in confident profile with strong silhouettes',
+      'Ornamental key-pattern (meander) borders',
+      'Flat space — no shadows, no horizon, no perspective',
+    ],
+    artists: [
+      {
+        name: 'Exekias',
+        years: 'active c. 545–530 BCE',
+        note: 'Master of black-figure amphorae; his Ajax and Achilles playing dice is antiquity’s quiet masterpiece.',
+      },
+      {
+        name: 'The Berlin Painter',
+        years: 'active c. 500–460 BCE',
+        note: 'Red-figure virtuoso known for single glowing figures floating on black.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Convert this image into an ancient Greek vase painting: terracotta orange and black two-tone palette, figures in flat profile silhouette, glossy ceramic texture, meander key-pattern border',
+    },
+  },
+  {
+    slug: 'byzantine-mosaic',
+    name: 'Byzantine Mosaic',
+    era: 'c. 500–1200',
+    sortYear: 500,
+    region: 'Eastern Mediterranean',
+    keyIdeas:
+      'Images built from thousands of glass and gold tesserae, designed to shimmer in candlelight. Byzantine artists cared about presence, not realism — flattened figures with huge eyes gaze straight at you from fields of gold that stand in for heaven itself.',
+    recognitionCues: [
+      'Gold background filling all empty space',
+      'Visible tile grid — the image is made of tiny squares',
+      'Frontal, elongated figures with large solemn eyes',
+      'Jewel-tone blues, greens, and reds outlined in dark tiles',
+    ],
+    artists: [
+      {
+        name: 'The Ravenna mosaicists',
+        years: '6th century',
+        note: 'The anonymous workshops of San Vitale set the gold standard — literally — for the next six hundred years.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Convert this image into a Byzantine mosaic: composed of small visible glass tesserae tiles, shimmering gold background, flattened frontal figures, jewel-tone colors with dark tile outlines',
+    },
+  },
+  {
+    slug: 'illuminated-manuscript',
+    name: 'Illuminated Manuscript',
+    era: 'c. 700–1500',
+    sortYear: 700,
+    region: 'Medieval Europe',
+    keyIdeas:
+      'Books as treasure: monks and workshop artists decorated hand-copied pages with gold leaf, impossible knotwork, and tiny worlds curling through the margins. Every inch of vellum was an invitation to ornament, from dragon-tailed initials to snails jousting with knights.',
+    recognitionCues: [
+      'Flat gold-leaf accents that catch the light',
+      'Elaborate decorated initial letters and dense borders',
+      'Bright mineral pigments — lapis blue, vermilion red',
+      'Charming, slightly stiff figures with expressive hands',
+    ],
+    artists: [
+      {
+        name: 'The Limbourg Brothers',
+        years: 'c. 1385–1416',
+        note: 'Their Très Riches Heures calendar pages are the most famous manuscript paintings ever made.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Convert this image into a medieval illuminated manuscript illustration: flat gold leaf accents, lapis blue and vermilion mineral pigments, ornate decorated border with knotwork, parchment texture',
+    },
+  },
+  {
+    slug: 'renaissance',
+    name: 'Renaissance',
+    era: 'c. 1400–1600',
+    sortYear: 1400,
+    region: 'Italy & Northern Europe',
+    keyIdeas:
+      'The rediscovery of perspective, anatomy, and the individual. Renaissance painters built pictures like architects — vanishing points, balanced triangles, sfumato haze — and made human faces worth studying for their own sake.',
+    recognitionCues: [
+      'Convincing depth with linear perspective',
+      'Balanced, often triangular compositions',
+      'Soft sfumato shading on skin and fabric',
+      'Classical architecture and drapery everywhere',
+    ],
+    artists: [
+      {
+        name: 'Leonardo da Vinci',
+        years: '1452–1519',
+        note: 'Painter-scientist whose sfumato and curiosity defined the era.',
+      },
+      {
+        name: 'Sandro Botticelli',
+        years: 'c. 1445–1510',
+        note: 'Linear grace and mythological dreamscapes like the Birth of Venus.',
+      },
+      {
+        name: 'Raphael',
+        years: '1483–1520',
+        note: 'The great harmonizer — clarity, sweetness, and perfect composition.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as an Italian Renaissance oil painting: balanced classical composition, soft sfumato shading, warm earth-tone glazes, subtle linear perspective depth',
+    },
+  },
+  {
+    slug: 'baroque',
+    name: 'Baroque',
+    era: 'c. 1600–1750',
+    sortYear: 1600,
+    region: 'Europe',
+    keyIdeas:
+      'Drama as doctrine. Baroque painters aimed the spotlight, cranked the contrast, and froze stories at their most theatrical instant — a technique called chiaroscuro, where figures blaze out of near-black shadow.',
+    recognitionCues: [
+      'Extreme light-dark contrast (chiaroscuro / tenebrism)',
+      'Diagonal, swirling compositions full of motion',
+      'Rich velvety darks with candlelit skin tones',
+      'Caught-in-the-act storytelling moments',
+    ],
+    artists: [
+      {
+        name: 'Caravaggio',
+        years: '1571–1610',
+        note: 'Invented the spotlight three centuries before electricity.',
+      },
+      {
+        name: 'Rembrandt van Rijn',
+        years: '1606–1669',
+        note: 'Turned chiaroscuro inward — light as psychology.',
+      },
+      {
+        name: 'Artemisia Gentileschi',
+        years: '1593–c. 1656',
+        note: 'Fierce, virtuosic drama from the era’s greatest woman painter.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a Baroque oil painting with dramatic chiaroscuro: a single strong light source, deep near-black shadows, rich warm tones, theatrical composition',
+    },
+  },
+  {
+    slug: 'ukiyo-e',
+    name: 'Ukiyo-e',
+    era: 'c. 1650–1900',
+    sortYear: 1650,
+    region: 'Edo-period Japan',
+    keyIdeas:
+      'Pictures of the floating world: woodblock prints of actors, landscapes, and great waves, made to be affordable and everywhere. Flat color planes, confident outlines, and daring crops later electrified European painters when the prints reached Paris.',
+    recognitionCues: [
+      'Flat areas of color with crisp woodblock outlines',
+      'Bold asymmetric crops and high vantage points',
+      'Visible paper tone and subtle printing gradients (bokashi)',
+      'Nature motifs: waves, blossoms, rain, Mount Fuji',
+    ],
+    artists: [
+      {
+        name: 'Katsushika Hokusai',
+        years: '1760–1849',
+        note: 'The Great Wave is the most reproduced image in art history.',
+      },
+      {
+        name: 'Utagawa Hiroshige',
+        years: '1797–1858',
+        note: 'Poet of rain, snow, and the road to Kyoto.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Convert this image into a Japanese ukiyo-e woodblock print: flat color planes, crisp dark outlines, visible paper texture, subtle bokashi color gradients, Edo-period print aesthetic',
+    },
+  },
+  {
+    slug: 'romanticism',
+    name: 'Romanticism',
+    era: 'c. 1780–1850',
+    sortYear: 1780,
+    region: 'Europe',
+    keyIdeas:
+      'Feeling over formula. Romantic painters chased awe — storm-wrecked ships, mountain mists, lone figures dwarfed by the sublime — insisting that emotion and imagination were as true as any measurement.',
+    recognitionCues: [
+      'Dramatic weather and vast landscapes',
+      'Tiny human figures against overwhelming nature',
+      'Turbulent brushwork and glowing atmospheric light',
+      'Moody palettes — storm grays, sunset golds',
+    ],
+    artists: [
+      {
+        name: 'Caspar David Friedrich',
+        years: '1774–1840',
+        note: 'The wanderer above the sea of fog, and every album cover since.',
+      },
+      {
+        name: 'J.M.W. Turner',
+        years: '1775–1851',
+        note: 'Dissolved ships and sunsets into pure luminous weather.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a Romantic era landscape painting: sublime dramatic atmosphere, glowing turbulent sky, misty depth, small figures dwarfed by vast nature, expressive brushwork',
+    },
+  },
+  {
+    slug: 'realism',
+    name: 'Realism',
+    era: 'c. 1840–1880',
+    sortYear: 1840,
+    region: 'France',
+    keyIdeas:
+      'Paint what is actually there. Realists turned from gods and storms to gleaners, stone breakers, and ordinary rooms, arguing that honest observation of working life deserved the grandest canvases.',
+    recognitionCues: [
+      'Everyday subjects treated with monumental seriousness',
+      'Earthy, restrained palettes and natural light',
+      'Solid, unidealized figures with real weight',
+      'No mythology, no melodrama — dignity in the ordinary',
+    ],
+    artists: [
+      {
+        name: 'Gustave Courbet',
+        years: '1819–1877',
+        note: '"Show me an angel and I will paint one" — the movement’s manifesto in a sentence.',
+      },
+      {
+        name: 'Jean-François Millet',
+        years: '1814–1875',
+        note: 'Gave farm labor the gravity of scripture.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a 19th century French Realist oil painting: earthy restrained palette, natural light, solid unidealized forms, honest observational detail',
+    },
+  },
+  {
+    slug: 'impressionism',
+    name: 'Impressionism',
+    era: 'c. 1860–1890',
+    sortYear: 1860,
+    region: 'France',
+    keyIdeas:
+      'Painting the light instead of the thing. Impressionists worked outdoors, fast, in broken dabs of unmixed color, catching how a haystack or a river actually looks in one fleeting moment of sun.',
+    recognitionCues: [
+      'Short broken brushstrokes you can see individually',
+      'Sunlit palettes — lavender shadows, no true black',
+      'Everyday leisure scenes: gardens, rivers, cafés',
+      'Edges dissolve; the image sharpens at a distance',
+    ],
+    artists: [
+      {
+        name: 'Claude Monet',
+        years: '1840–1926',
+        note: 'Painted the same haystacks and lilies until light itself was the subject.',
+      },
+      {
+        name: 'Berthe Morisot',
+        years: '1841–1895',
+        note: 'Feather-light brushwork and intimate modern life.',
+      },
+      {
+        name: 'Pierre-Auguste Renoir',
+        years: '1841–1919',
+        note: 'Dappled sunlight on dancing crowds.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a French Impressionist oil painting: visible broken brushstrokes, sunlit color with lavender shadows and no pure black, soft dissolved edges, plein-air freshness',
+    },
+  },
+  {
+    slug: 'post-impressionism',
+    name: 'Post-Impressionism',
+    era: 'c. 1885–1910',
+    sortYear: 1885,
+    region: 'France & beyond',
+    keyIdeas:
+      'Impressionism’s children went separate, radical ways: Van Gogh bent color and stroke to emotion, Seurat rebuilt light from scientific dots, Cézanne carved nature into planes that would later crack open into Cubism.',
+    recognitionCues: [
+      'Expressive, directional brushstrokes (swirls, dots, dashes)',
+      'Color chosen for feeling, not accuracy',
+      'Strong outlines and flattened, patterned space',
+      'Thick visible paint texture (impasto)',
+    ],
+    artists: [
+      {
+        name: 'Vincent van Gogh',
+        years: '1853–1890',
+        note: 'Starry swirls and sunflowers — emotion made visible in paint.',
+      },
+      {
+        name: 'Georges Seurat',
+        years: '1859–1891',
+        note: 'Pointillism: light assembled from thousands of pure-color dots.',
+      },
+      {
+        name: 'Paul Cézanne',
+        years: '1839–1906',
+        note: 'The bridge from Impressionism to everything modern.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a Post-Impressionist painting in the manner of Van Gogh: swirling directional impasto brushstrokes, intense emotional color, bold outlines, thick visible paint texture',
+    },
+  },
+  {
+    slug: 'art-nouveau',
+    name: 'Art Nouveau',
+    era: 'c. 1890–1910',
+    sortYear: 1890,
+    region: 'Europe',
+    keyIdeas:
+      'Nature as ornament, everywhere. Art Nouveau wrapped posters, jewelry, and whole buildings in whiplash curves, flowing hair, and flattened decorative frames — fine art and design refusing to stay in separate rooms.',
+    recognitionCues: [
+      'Sinuous whiplash curves and flowing organic lines',
+      'Flat decorative color inside strong contours',
+      'Ornamental frames, halos, and botanical borders',
+      'Elegant figures with cascading hair',
+    ],
+    artists: [
+      {
+        name: 'Alphonse Mucha',
+        years: '1860–1939',
+        note: 'His poster goddesses defined the look of an era.',
+      },
+      {
+        name: 'Gustav Klimt',
+        years: '1862–1918',
+        note: 'Gold-leaf patterns swallowing tender figures.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Convert this image into an Art Nouveau poster illustration: sinuous whiplash curves, flat decorative color within elegant dark contours, ornamental botanical border, muted harmonious palette',
+    },
+  },
+  {
+    slug: 'expressionism',
+    name: 'Expressionism',
+    era: 'c. 1905–1930',
+    sortYear: 1905,
+    region: 'Germany & Northern Europe',
+    keyIdeas:
+      'Truth through distortion. Expressionists jangled color and warped form until the canvas felt the way the world felt — anxious, electric, alive — trading optical accuracy for raw psychological voltage.',
+    recognitionCues: [
+      'Clashing, non-natural color (green faces, red skies)',
+      'Jagged, angular distortion of figures and space',
+      'Rough, urgent brushwork or woodcut-style marks',
+      'Emotional intensity over polish',
+    ],
+    artists: [
+      {
+        name: 'Edvard Munch',
+        years: '1863–1944',
+        note: 'The Scream — anxiety’s official portrait.',
+      },
+      {
+        name: 'Ernst Ludwig Kirchner',
+        years: '1880–1938',
+        note: 'Electric city streets in acid pinks and greens.',
+      },
+      {
+        name: 'Franz Marc',
+        years: '1880–1916',
+        note: 'Blue horses and yellow cows — animals as pure feeling.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a German Expressionist painting: clashing non-natural colors, jagged angular distortion, rough urgent brushwork, intense psychological mood',
+    },
+  },
+  {
+    slug: 'cubism',
+    name: 'Cubism',
+    era: 'c. 1907–1920',
+    sortYear: 1907,
+    region: 'Paris',
+    keyIdeas:
+      'Why paint one viewpoint when you can paint them all at once? Cubists shattered subjects into facets and reassembled them, showing a guitar’s front, side, and soul on a single flat surface.',
+    recognitionCues: [
+      'Fractured geometric facets and overlapping planes',
+      'Multiple viewpoints of one subject simultaneously',
+      'Muted early palettes: ochres, grays, browns',
+      'Still-life props — guitars, bottles, newspapers',
+    ],
+    artists: [
+      {
+        name: 'Juan Gris',
+        years: '1887–1927',
+        note: 'The clearest, most elegant architect of the Cubist grid.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as an analytical Cubist painting: subject fractured into overlapping geometric facets, multiple viewpoints at once, muted ochre gray and brown palette, flattened shallow space',
+    },
+  },
+  {
+    slug: 'de-stijl',
+    name: 'De Stijl',
+    era: 'c. 1917–1931',
+    sortYear: 1917,
+    region: 'Netherlands',
+    keyIdeas:
+      'Art reduced to its purest ingredients: straight lines, right angles, and primary colors. De Stijl believed a universal visual harmony could rebuild a world shaken by war — one perfect grid at a time.',
+    recognitionCues: [
+      'Black grid lines on white',
+      'Rectangles of pure red, yellow, and blue only',
+      'Strict horizontals and verticals — no curves, no diagonals',
+      'Asymmetric but perfectly balanced layouts',
+    ],
+    artists: [
+      {
+        name: 'Piet Mondrian',
+        years: '1872–1944',
+        note: 'Reduced trees to grids and grids to jazz.',
+      },
+      {
+        name: 'Theo van Doesburg',
+        years: '1883–1931',
+        note: 'The movement’s tireless organizer and provocateur.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Convert this image into a De Stijl composition: bold black grid lines on white, rectangles of pure primary red yellow and blue, strict horizontal and vertical geometry, balanced asymmetry',
+    },
+  },
+]
+
+export const academyStylesBySlug: Record<string, AcademyStyle> =
+  Object.fromEntries(academyStyles.map((style) => [style.slug, style]))
+
+export const academyTimeline: AcademyStyle[] = [...academyStyles].sort(
+  (a, b) => a.sortYear - b.sortYear,
+)


### PR DESCRIPTION
### Task
ai-art-academy/t-007 (+ groundwork for t-008): scaffold the Academy front end wrapping art-styler (kind: software)

### What changed / what I produced
- **`/academy` page** (content/academy.md + `dashboardConfigs.academy`) with four tabs: **Timeline** (chronological art-history walk, expandable lessons), **Styles** (searchable style gallery), **Remix Studio** (registry-driven Kontext remixing with a lesson panel beside the styler), **Style Lab** (the existing free-play art-styler + image upload, unchanged).
- **`stores/seeds/academyStyles.ts`** — the curriculum registry: 14 movements (Greek vase painting → De Stijl), each with era, key ideas, recognition cues, dead-master bios, and a prompt-mode Kontext remix template. Public-domain boundary enforced in data: every named artist died 1953 or earlier (Cubism ships with Juan Gris, not Picasso/Braque, who are inside the 70-year window). Slugs match `projects/ai-art-academy/docs/curriculum-outline.md` in conductor.
- **`stores/academyStore.ts`** — selected style + lessons-viewed/styles-remixed progress, localStorage-persisted (mural-store pattern).
- **`art-styler.vue` extensions** (Silas granted standing authority for this project): optional `styles` prop for external registries, prompt-mode entries (`loraPath` now optional — prompt-only styles send just the instruction, no `<lora:…>` ref), stable `slug`-based style keys, `styleSelected` emit, `selectedStyleKey` preselect, `showClose` prop. **Builtin styler behavior is unchanged** — same styles, same LoRA prompt assembly, resource-DB hydration skipped only when an external list is provided.
- **`stores/helpers/styleHelper.ts`** — shared StyleEntry/StyleCategory types + key helper (script-setup can't export types).

### How I verified
- `eslint` clean and `prettier --check` clean on all touched files.
- Full `npm test` (vue-tsc): zero new errors — the single remaining error (`server/api/comfy/kontext/enqueue.post.ts` TS2322) reproduces on a clean stash of main, pre-existing.
- Fixed during self-review: the lesson-detail component originally declared a `style` prop, which Vue reserves as a fallthrough attribute — renamed to `lesson`.
- Not verified live: no dev server/DB in this environment; generation path unchanged from the shipped styler flow.

### Stakes
reversible

### Flags for Reviewer
- Academy tab images (`/images/dashboard-tabs/academy/{timeline,styles,remix}.webp`) don't exist yet — requests queued conductor-side; Style Lab reuses the existing art/styler tab image.
- t-008 follow-up: lesson example-work strips (needs the starter-image library downloads) and LoRA-mode upgrades pending the t-004 evaluation.

### Kaizen suggestion
Add a tiny unit test (or storybook fixture) exercising art-styler prompt assembly for lora-mode vs prompt-mode entries, so future styler refactors can't silently break either path.

### Notes for reviewer
First deliverable of the autonomous-initiative test project. Conductor roadmap statuses updated in the companion conductor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB)_