### PR TITLE
feat(stylist): live queue state on job tiles + photo downscaling + CI typecheck fix

### DIFF
--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -210,6 +210,14 @@
       <span class="text-xs font-black text-base-content">
         {{ clientName.trim() ? `Styling ${clientName.trim()}` : 'This session' }}
       </span>
+      <p
+        v-if="hasStalledQueue"
+        class="rounded-lg bg-warning/10 p-2 text-xs text-warning"
+      >
+        A job has been waiting over a minute without the studio engine picking
+        it up — the home relay is probably offline or needs its update. The job
+        stays queued and finishes once the engine is back.
+      </p>
       <div class="grid gap-3 sm:grid-cols-2">
         <article
           v-for="job in visibleJobs"
@@ -218,8 +226,18 @@
         >
           <div class="flex items-center gap-2 text-xs">
             <span class="font-bold">{{ job.client || 'Unnamed client' }}</span>
-            <span v-if="job.status === 'pending'" class="badge badge-warning badge-xs gap-1">
-              <span class="loading loading-spinner loading-xs" /> working
+            <span
+              v-if="job.status === 'pending'"
+              class="badge badge-xs gap-1"
+              :class="job.queueState === 'rendering' ? 'badge-info' : 'badge-warning'"
+              :title="
+                job.queueState === 'rendering'
+                  ? 'The studio engine is painting'
+                  : 'Waiting for the studio engine to pick this up'
+              "
+            >
+              <span class="loading loading-spinner loading-xs" />
+              {{ job.queueState === 'rendering' ? 'rendering' : 'queued' }}
             </span>
             <span v-else-if="job.status === 'failed'" class="badge badge-error badge-xs">failed</span>
             <span v-else class="badge badge-success badge-xs">done</span>
@@ -388,6 +406,21 @@ const isFirstRun = computed(
     !stylist.isLoadingHistory,
 )
 
+// Ticks every 10s so the stalled-queue warning can appear without a reload.
+const now = ref(Date.now())
+let nowTimer: ReturnType<typeof setInterval> | null = null
+
+const STALL_AFTER_MS = 60_000
+
+const hasStalledQueue = computed(() =>
+  visibleJobs.value.some(
+    (job) =>
+      job.status === 'pending' &&
+      job.queueState !== 'rendering' &&
+      now.value - job.createdAt > STALL_AFTER_MS,
+  ),
+)
+
 // Past-looks compare state: imageId → currently showing the before photo.
 const comparing = ref<Record<number, boolean>>({})
 
@@ -468,10 +501,45 @@ function handleDrop(event: DragEvent) {
   if (file && file.type.startsWith('image/')) processFile(file)
 }
 
+// Downscale to the working size before anything leaves the device: Kontext
+// renders at ~1024px anyway, and a raw phone photo as base64 (5-10MB+) can
+// exceed the deployed backend's request-size limit at enqueue time.
+const MAX_PHOTO_DIMENSION = 1280
+
+function downscalePhoto(dataUrl: string): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image()
+
+    img.onload = () => {
+      const scale = Math.min(
+        1,
+        MAX_PHOTO_DIMENSION / Math.max(img.width, img.height),
+      )
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.max(1, Math.round(img.width * scale))
+      canvas.height = Math.max(1, Math.round(img.height * scale))
+
+      const ctx = canvas.getContext('2d')
+
+      if (!ctx) {
+        resolve(dataUrl)
+        return
+      }
+
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+      resolve(canvas.toDataURL('image/jpeg', 0.9))
+    }
+
+    img.onerror = () => resolve(dataUrl)
+    img.src = dataUrl
+  })
+}
+
 function processFile(file: File) {
   const reader = new FileReader()
-  reader.onload = (event) => {
-    sourceImageData.value = (event.target?.result as string) ?? null
+  reader.onload = async (event) => {
+    const raw = (event.target?.result as string) ?? null
+    sourceImageData.value = raw ? await downscalePhoto(raw) : null
   }
   reader.readAsDataURL(file)
 }
@@ -495,13 +563,16 @@ async function openCamera() {
 function capturePhoto() {
   const video = videoEl.value
   if (!video) return
+  const width = video.videoWidth || 768
+  const height = video.videoHeight || 768
+  const scale = Math.min(1, MAX_PHOTO_DIMENSION / Math.max(width, height))
   const canvas = document.createElement('canvas')
-  canvas.width = video.videoWidth || 768
-  canvas.height = video.videoHeight || 768
+  canvas.width = Math.max(1, Math.round(width * scale))
+  canvas.height = Math.max(1, Math.round(height * scale))
   const ctx = canvas.getContext('2d')
   if (!ctx) return
   ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
-  sourceImageData.value = canvas.toDataURL('image/png')
+  sourceImageData.value = canvas.toDataURL('image/jpeg', 0.9)
   closeCamera()
 }
 
@@ -527,7 +598,13 @@ function submit() {
 
 onMounted(() => {
   void stylist.loadHistory()
+  nowTimer = setInterval(() => {
+    now.value = Date.now()
+  }, 10_000)
 })
 
-onBeforeUnmount(closeCamera)
+onBeforeUnmount(() => {
+  closeCamera()
+  if (nowTimer) clearInterval(nowTimer)
+})
 </script>

--- a/server/api/comfy/kontext/enqueue.post.ts
+++ b/server/api/comfy/kontext/enqueue.post.ts
@@ -85,30 +85,33 @@ export default defineEventHandler(async (event) => {
       denoise: body.denoise,
       filenamePrefix: body.filenamePrefix || 'kindrobots_kontext_queue',
     })
-const payload = {
-  workflow,
-  promptString: prompt,
-  images: [
-    {
-      name: imageName,
-      imageData,
-    },
-  ],
-  save: {
-    isPublic: body.isPublic ?? false,
-    isMature: body.isMature ?? false,
-    designer: body.designer?.trim() || null,
-  },
-} satisfies Prisma.InputJsonValue
+    // ComfyWorkflow's index signature doesn't structurally satisfy
+    // Prisma.InputJsonValue, so cast at the boundary (same pattern as
+    // /api/art/queue/index.post.ts). The shape is plain JSON.
+    const payload = {
+      workflow,
+      promptString: prompt,
+      images: [
+        {
+          name: imageName,
+          imageData,
+        },
+      ],
+      save: {
+        isPublic: body.isPublic ?? false,
+        isMature: body.isMature ?? false,
+        designer: body.designer?.trim() || null,
+      },
+    }
 
-const job = await prisma.artJob.create({
-  data: {
-    engine: 'COMFY',
-    priority: Number.isInteger(body.priority) ? Number(body.priority) : 5,
-    userId: gate.user.id,
-    payload,
-  },
-})
+    const job = await prisma.artJob.create({
+      data: {
+        engine: 'COMFY',
+        priority: Number.isInteger(body.priority) ? Number(body.priority) : 5,
+        userId: gate.user.id,
+        payload: payload as unknown as Prisma.InputJsonValue,
+      },
+    })
 
     const { balance } = await gate.commit(`kontext-queue:${job.id}`)
 

--- a/stores/stylistStore.ts
+++ b/stores/stylistStore.ts
@@ -27,6 +27,10 @@ export type StylistJob = {
   after: string | null // data URL of the result
   prompt: string
   status: StylistJobStatus
+  // Live queue detail while pending: 'queued' = waiting for the home studio
+  // engine to claim it (if this persists, the relay is offline/out of date);
+  // 'rendering' = an engine claimed it and is working.
+  queueState?: 'queued' | 'rendering'
   error?: string
   artImageId?: number
   createdAt: number
@@ -177,7 +181,10 @@ export const useStylistStore = defineStore('stylistStore', () => {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
-  async function waitForQueuedJob(jobId: number): Promise<QueuedArtJob> {
+  async function waitForQueuedJob(
+    jobId: number,
+    localJobId: number,
+  ): Promise<QueuedArtJob> {
     const startedAt = Date.now()
 
     while (Date.now() - startedAt < QUEUE_TIMEOUT_MS) {
@@ -194,11 +201,20 @@ export const useStylistStore = defineStore('stylistStore', () => {
         return job
       }
 
+      // Mirror the queue state onto the tile so "was it ever claimed?" is
+      // answerable from the UI: stuck at "queued" = the home relay is
+      // offline or running a pre-handshake script; "rendering" = claimed.
+      if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
+        patchJob(localJobId, {
+          queueState: job.status === 'RUNNING' ? 'rendering' : 'queued',
+        })
+      }
+
       await sleep(QUEUE_POLL_MS)
     }
 
     throw new Error(
-      'Styling timed out. The studio queue may be catching up — check Past looks in a few minutes.',
+      'Still waiting on the studio engine. The job stays queued and will land in Past looks once the engine catches up — no need to resubmit.',
     )
   }
 
@@ -244,7 +260,7 @@ export const useStylistStore = defineStore('stylistStore', () => {
         throw new Error(enqueue.message || 'Could not queue the styling job.')
       }
 
-      const finished = await waitForQueuedJob(enqueue.data.jobId)
+      const finished = await waitForQueuedJob(enqueue.data.jobId, id)
 
       if (finished.status !== 'DONE' || !finished.artImageId) {
         throw new Error(finished.error || 'Styling failed.')


### PR DESCRIPTION
Overnight triage & hardening after the first live styling stalled ("adds as an art job, never completes").

## Diagnosis of last night's stall (see morning checklist below)
The job being created but never finishing is exactly what the claim guard produces when the relay runs a pre-handshake script: kind_robots (#141, merged 08:47) only hands image jobs to agents declaring `supportsInputImages`, but that declaration shipped in conductor **#326, merged 08:53** — most likely *after* the relay was pulled/restarted. The stalled job is safe: it stays PENDING and completes on its own once the updated relay starts.

## What this PR adds
- **Live queue state on job tiles** — pending tiles now show **`queued`** (amber: waiting for the home studio engine) vs **`rendering`** (blue: an engine claimed it), so "did the relay ever pick it up?" is answerable from the UI with no pm2 access. A warning banner appears if a job sits unclaimed for over a minute, and the poll-timeout message now says the job stays queued (no resubmit needed).
- **Client-side photo downscaling** (max 1280px, JPEG q0.9) on both upload and camera capture — Kontext renders ~1024px anyway, and a raw phone photo as base64 (5–10MB+) risks the deployed backend's request-size limit at enqueue.
- **CI fix:** the `satisfies Prisma.InputJsonValue` refactor on main's `enqueue.post.ts` doesn't compile (ComfyWorkflow's index signature) — full-repo typecheck was red. Cast at the boundary instead, matching `/api/art/queue/index.post.ts`. Runtime was never affected (builds don't typecheck).

## ✅ Verification
Full `vue-tsc` typecheck passes (it was failing on main before the fix here); eslint clean on touched files.

## ☀️ Morning checklist for the stalled job
1. On the home server: `cd conductor && git pull` (must include #326) → `pm2 restart kr-relay`.
2. Watch `pm2 logs kr-relay` — the stalled job should be claimed within ~10s (`uploaded input image kr_kontext_queue_…`).
3. On `/stylist`, the finished look appears in Past looks (the original tile timed out client-side, but the artwork still lands).
4. If it *still* sits at `queued` after this PR deploys: the relay's claim isn't sending `supportsInputImages` — check `git log -1 ops/home-server/relay_agent.py` in the home checkout.

## Stakes
reversible — UI/store polish + type-level fix; no API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uzd8ngDjf9hcDdQ51UKJGQ)_