### PR TITLE
mural: move geometry/palette to data with inline fallback (engine step 4)

### DIFF
--- a/public/data/mural-design/mural-page.json
+++ b/public/data/mural-design/mural-page.json
@@ -1,0 +1,229 @@
+{
+  "id": "mural/fence-v1",
+  "version": 1,
+  "title": "Fence Mural Color Studio",
+  "viewBox": {
+    "width": 960,
+    "height": 540
+  },
+  "mode": "svg-regions",
+  "layers": {
+    "decor": "M139 211L156 226M215 211L199 226M169 274H201M592 300H777M565 358C576 386 612 386 621 361M677 365C687 392 725 392 734 364M784 358C793 382 829 382 837 357"
+  },
+  "regions": [
+    {
+      "id": "background-sky",
+      "label": "Wine sky",
+      "group": "background",
+      "defaultColorId": "wine-red",
+      "d": "M0 0H960V540H0Z"
+    },
+    {
+      "id": "alien-ground",
+      "label": "Alien garden ground",
+      "group": "foliage",
+      "defaultColorId": "leaf-blue",
+      "d": "M0 422C95 392 174 420 248 392C330 360 422 392 505 372C619 344 704 377 783 354C861 331 916 354 960 337V540H0Z"
+    },
+    {
+      "id": "ivy-portal",
+      "label": "Ivy portal",
+      "group": "foliage",
+      "defaultColorId": "leaf-true",
+      "d": "M78 137C125 77 221 82 268 147C306 199 306 276 262 329C218 382 127 382 78 329C26 274 28 198 78 137Z"
+    },
+    {
+      "id": "portal-glow",
+      "label": "Portal glow",
+      "group": "portal",
+      "defaultColorId": "leaf-yellow",
+      "d": "M110 164C145 119 215 124 247 171C274 211 271 270 237 309C202 349 142 347 108 307C73 266 76 205 110 164Z"
+    },
+    {
+      "id": "totoro-body",
+      "label": "Hidden spirit body",
+      "group": "spirit",
+      "defaultColorId": "robot-gray",
+      "d": "M151 203C155 162 213 158 224 202C242 207 254 228 249 252C244 287 218 316 184 316C149 316 123 288 118 253C115 229 129 207 151 203Z"
+    },
+    {
+      "id": "totoro-belly",
+      "label": "Spirit belly",
+      "group": "spirit",
+      "defaultColorId": "soft-white",
+      "d": "M151 257C160 235 210 235 220 257C226 276 211 297 185 299C158 297 145 276 151 257Z"
+    },
+    {
+      "id": "catbus-body",
+      "label": "Catbus body",
+      "group": "catbus",
+      "defaultColorId": "catbus-orange",
+      "d": "M527 219C584 148 763 143 838 215C890 265 874 341 804 363C713 391 589 374 530 328C495 300 497 257 527 219Z"
+    },
+    {
+      "id": "catbus-roof",
+      "label": "Catbus roof stripe",
+      "group": "catbus",
+      "defaultColorId": "catbus-brown",
+      "d": "M576 183C640 151 751 159 807 205C751 190 637 186 576 183Z"
+    },
+    {
+      "id": "catbus-face",
+      "label": "Catbus face",
+      "group": "catbus",
+      "defaultColorId": "catbus-brown",
+      "d": "M804 218C842 234 858 267 848 296C828 279 805 259 774 244C781 231 790 223 804 218Z"
+    },
+    {
+      "id": "catbus-window-1",
+      "label": "Window one",
+      "group": "windows",
+      "defaultColorId": "window-teal",
+      "d": "M578 215H626C637 215 644 224 642 236L636 281H568L561 236C559 224 567 215 578 215Z"
+    },
+    {
+      "id": "catbus-window-2",
+      "label": "Window two",
+      "group": "windows",
+      "defaultColorId": "window-teal",
+      "d": "M654 213H701C713 213 721 223 719 236L713 282H646L642 236C640 223 642 213 654 213Z"
+    },
+    {
+      "id": "catbus-window-3",
+      "label": "Window three",
+      "group": "windows",
+      "defaultColorId": "window-teal",
+      "d": "M730 221H775C789 221 798 232 795 246L786 288H722L717 246C715 232 717 221 730 221Z"
+    },
+    {
+      "id": "catbus-eye-left",
+      "label": "Left Catbus eye",
+      "group": "catbus",
+      "defaultColorId": "warm-yellow",
+      "d": "M813 252C829 242 845 250 846 265C832 275 817 270 813 252Z"
+    },
+    {
+      "id": "catbus-eye-right",
+      "label": "Right Catbus eye",
+      "group": "catbus",
+      "defaultColorId": "warm-yellow",
+      "d": "M782 248C797 239 812 246 814 260C802 270 787 266 782 248Z"
+    },
+    {
+      "id": "robot-left",
+      "label": "Garden robot left",
+      "group": "robots",
+      "defaultColorId": "robot-gray",
+      "d": "M344 322H390V366H344ZM354 296H380V322H354ZM335 339H344V353H335ZM390 339H399V353H390Z"
+    },
+    {
+      "id": "robot-right",
+      "label": "Garden robot right",
+      "group": "robots",
+      "defaultColorId": "robot-gray",
+      "d": "M436 346H475V387H436ZM446 322H466V346H446ZM426 359H436V373H426ZM475 359H485V373H475Z"
+    },
+    {
+      "id": "butterfly-one",
+      "label": "Purple butterfly",
+      "group": "butterflies",
+      "defaultColorId": "butterfly-purple",
+      "d": "M348 151C321 122 302 154 326 174C300 197 331 220 352 186C376 220 408 197 379 174C405 151 377 122 348 151Z"
+    },
+    {
+      "id": "butterfly-two",
+      "label": "Violet butterfly",
+      "group": "butterflies",
+      "defaultColorId": "butterfly-violet",
+      "d": "M676 110C654 85 636 111 656 129C632 150 660 170 680 140C700 170 729 150 705 129C725 111 703 85 676 110Z"
+    },
+    {
+      "id": "butterfly-three",
+      "label": "Yellow butterfly",
+      "group": "butterflies",
+      "defaultColorId": "warm-yellow",
+      "d": "M478 123C459 103 444 126 461 140C441 158 465 175 482 149C499 175 524 158 503 140C520 126 501 103 478 123Z"
+    },
+    {
+      "id": "soot-sprites",
+      "label": "Hidden soot sprites",
+      "group": "sprites",
+      "defaultColorId": "line-black",
+      "d": "M289 387C289 374 309 374 309 387C309 400 289 400 289 387ZM873 395C873 382 893 382 893 395C893 408 873 408 873 395ZM405 415C405 403 423 403 423 415C423 427 405 427 405 415Z"
+    }
+  ],
+  "palette": [
+    {
+      "id": "wine-red",
+      "name": "Wine Red",
+      "value": "#6f2746"
+    },
+    {
+      "id": "leaf-yellow",
+      "name": "Yellow Green",
+      "value": "#8aa63f"
+    },
+    {
+      "id": "leaf-true",
+      "name": "True Green",
+      "value": "#3f7f4a"
+    },
+    {
+      "id": "leaf-blue",
+      "name": "Blue Green",
+      "value": "#2f7c74"
+    },
+    {
+      "id": "catbus-orange",
+      "name": "Catbus Orange",
+      "value": "#d87428"
+    },
+    {
+      "id": "catbus-brown",
+      "name": "Catbus Brown",
+      "value": "#7b4b2a"
+    },
+    {
+      "id": "window-teal",
+      "name": "Window Teal",
+      "value": "#55a9b5"
+    },
+    {
+      "id": "butterfly-purple",
+      "name": "Butterfly Purple",
+      "value": "#7d4dc2"
+    },
+    {
+      "id": "butterfly-violet",
+      "name": "Butterfly Violet",
+      "value": "#a05dc8"
+    },
+    {
+      "id": "warm-yellow",
+      "name": "Warm Yellow",
+      "value": "#f5c451"
+    },
+    {
+      "id": "soft-white",
+      "name": "Soft White",
+      "value": "#f0ead9"
+    },
+    {
+      "id": "robot-gray",
+      "name": "Robot Gray",
+      "value": "#9aa0a6"
+    },
+    {
+      "id": "line-black",
+      "name": "Linework Black",
+      "value": "#171312"
+    }
+  ],
+  "metadata": {
+    "sourceImage": "projects/mural-design/firstdraft.jpg (conductor)",
+    "prompt": "hand-authored placeholder geometry (mural t-007 scaffold); real fence-only assets arrive via mural-design t-002",
+    "model": "none (hand-authored SVG)",
+    "generatedAt": "2026-07-10T14:10:00Z",
+    "printMaster": null
+  }
+}

--- a/stores/muralStore.ts
+++ b/stores/muralStore.ts
@@ -1,6 +1,7 @@
 // /stores/muralStore.ts
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import type { ColoringPageDefinition } from '@/stores/helpers/coloring'
 
 export interface MuralColor {
   id: string
@@ -192,6 +193,46 @@ interface MuralStoredState {
   selectedSectionId?: string | null
 }
 
+// Geometry/palette now live in data (shared coloring-engine page format,
+// step 4 of the migration in conductor coloring-book/docs/coloring-engine-spec.md).
+// The inline constants above remain as the fallback so /mural keeps working
+// if the data file is missing or malformed.
+const MURAL_PAGE_URL = '/data/mural-design/mural-page.json'
+
+let baseColors: MuralColor[] = defaultColors
+let baseSections: MuralSection[] = defaultSections
+let baseLoaded = false
+
+async function hydrateBaseFromPageData(): Promise<void> {
+  if (baseLoaded || !isClient) return
+  baseLoaded = true
+
+  try {
+    const page = await $fetch<ColoringPageDefinition>(MURAL_PAGE_URL)
+
+    if (!page?.regions?.length || !page.palette?.length) return
+
+    baseSections = page.regions.map((region) => ({
+      id: region.id,
+      label: region.label ?? region.id,
+      groupId: region.group ?? 'misc',
+      colorId: region.defaultColorId ?? 'soft-white',
+      d: region.d,
+    }))
+
+    baseColors = page.palette.map((color) => ({
+      id: color.id,
+      name: color.name,
+      value: normalizeColorValue(color.value),
+    }))
+  } catch (error) {
+    console.warn(
+      '[muralStore] page data unavailable, using inline defaults:',
+      error,
+    )
+  }
+}
+
 function safeReadState(): MuralStoredState | null {
   if (!isClient) return null
 
@@ -210,7 +251,9 @@ function safeWriteState(payload: MuralStoredState): void {
 
   try {
     localStorage.setItem(storageKey, JSON.stringify(payload))
-  } catch {}
+  } catch {
+    // Quota/private-mode failures are non-fatal; coloring continues unsaved.
+  }
 }
 
 function normalizeColorValue(value: string): string {
@@ -247,8 +290,9 @@ export const useMuralStore = defineStore('muralStore', () => {
 
   const selectedSection = computed(() => {
     return (
-      sections.value.find((section) => section.id === selectedSectionId.value) ??
-      null
+      sections.value.find(
+        (section) => section.id === selectedSectionId.value,
+      ) ?? null
     )
   })
 
@@ -267,7 +311,8 @@ export const useMuralStore = defineStore('muralStore', () => {
 
     return groupOrder.map((groupId) => {
       const groupSections = lookup.get(groupId) ?? []
-      const firstColorId = groupSections[0]?.colorId ?? colors.value[0]?.id ?? ''
+      const firstColorId =
+        groupSections[0]?.colorId ?? colors.value[0]?.id ?? ''
       const sameColor = groupSections.every(
         (section) => section.colorId === firstColorId,
       )
@@ -297,8 +342,10 @@ export const useMuralStore = defineStore('muralStore', () => {
     })
   }
 
-  function initialize(force = false): void {
+  async function initialize(force = false): Promise<void> {
     if (initialized.value && !force) return
+
+    await hydrateBaseFromPageData()
 
     const saved = safeReadState()
 
@@ -307,6 +354,8 @@ export const useMuralStore = defineStore('muralStore', () => {
         ...color,
         value: normalizeColorValue(color.value),
       }))
+    } else {
+      colors.value = baseColors.map((color) => ({ ...color }))
     }
 
     if (saved?.sections?.length) {
@@ -314,7 +363,7 @@ export const useMuralStore = defineStore('muralStore', () => {
         saved.sections.map((section) => [section.id, section]),
       )
 
-      sections.value = defaultSections.map((section) => {
+      sections.value = baseSections.map((section) => {
         const savedSection = savedSectionMap.get(section.id)
 
         return {
@@ -322,6 +371,8 @@ export const useMuralStore = defineStore('muralStore', () => {
           colorId: savedSection?.colorId ?? section.colorId,
         }
       })
+    } else {
+      sections.value = baseSections.map((section) => ({ ...section }))
     }
 
     if (saved?.activeColorId && colorMap.value.has(saved.activeColorId)) {
@@ -353,7 +404,10 @@ export const useMuralStore = defineStore('muralStore', () => {
     sync()
   }
 
-  function setSectionColor(sectionId: string, colorId = activeColorId.value): void {
+  function setSectionColor(
+    sectionId: string,
+    colorId = activeColorId.value,
+  ): void {
     if (!colorMap.value.has(colorId)) return
 
     sections.value = sections.value.map((section) =>
@@ -392,7 +446,9 @@ export const useMuralStore = defineStore('muralStore', () => {
   function removeSavedColor(colorId: string): void {
     if (colors.value.length <= 1) return
 
-    const fallbackColorId = colors.value.find((color) => color.id !== colorId)?.id
+    const fallbackColorId = colors.value.find(
+      (color) => color.id !== colorId,
+    )?.id
     if (!fallbackColorId) return
 
     colors.value = colors.value.filter((color) => color.id !== colorId)
@@ -410,10 +466,10 @@ export const useMuralStore = defineStore('muralStore', () => {
   }
 
   function resetMural(): void {
-    colors.value = defaultColors.map((color) => ({ ...color }))
-    sections.value = defaultSections.map((section) => ({ ...section }))
+    colors.value = baseColors.map((color) => ({ ...color }))
+    sections.value = baseSections.map((section) => ({ ...section }))
     activeColorId.value = 'leaf-true'
-    selectedSectionId.value = defaultSections[0]?.id ?? null
+    selectedSectionId.value = baseSections[0]?.id ?? null
     initialized.value = true
     sync()
   }


### PR DESCRIPTION
### Task
coloring-book/t-017, step 4 ONLY (kind: software) — the first of the small `/mural` migration PRs.

### What changed / what I produced
- **`public/data/mural-design/mural-page.json`** — the fence mural expressed as a shared-engine `ColoringPageDefinition` (page id `mural/fence-v1`): all 20 section regions, the 13-color palette, and the whisker/smile strokes as `layers.decor`. Generated **directly from muralStore's inline constants** by a script that parses the store source, so the data file cannot drift from the code at creation time.
- **`muralStore`** — `initialize()` now hydrates its base geometry/palette from that data file and falls back to the inline constants if the file is missing or malformed; `resetMural()` resets to the same base. `initialize` became async; its only caller is a fire-and-forget `onMounted` in mural-manager, unchanged.
- Also fixed a pre-existing empty-catch lint error in this file.

### How I verified
- JSON validated: 20 regions, 13 colors, region ids/paths byte-derived from the inline defaults — **zero behavior change** on `/mural` by construction.
- eslint + prettier clean; `npm test` (vue-tsc) zero new errors.
- The fallback path is the previous behavior verbatim, so a 404 on the data file reproduces today's page exactly.

### Stakes
reversible — revert = delete the JSON + restore the sync initialize.

### Flags for Reviewer
- Step 5 (swapping mural-manager's inline SVG for ColoringCanvas + the localStorage migration shim) is deliberately NOT in this PR — it's the only step with user-visible risk and gets its own review.

### Kaizen suggestion
The JSON-from-source generator pattern (parse the store, emit the data file) would also keep the sampler set's manifests honest if pages are ever authored in code first.

### Notes for reviewer
Overnight autonomous cycle 1 (scheduled check-in). This is the step that lets mural-design t-002's real fence-only assets replace placeholder geometry later with no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB)_