### PR TITLE
mural: swap inline SVG for ColoringCanvas + coloringStore (engine step 5)

### DIFF
--- a/components/coloring/coloring-canvas.vue
+++ b/components/coloring/coloring-canvas.vue
@@ -22,7 +22,7 @@
       :d="region.d"
       :fill="fillFor(region.id)"
       stroke="#171312"
-      stroke-width="3"
+      :stroke-width="strokeWidth"
       stroke-linejoin="round"
       :class="interactive ? 'cursor-pointer transition-opacity' : ''"
       :opacity="
@@ -123,10 +123,17 @@ const props = withDefaults(
     fillOps?: ColoringFillOp[]
     selectedRegionIds?: string[]
     interactive?: boolean
+    /** Region outline width (svg mode); the mural uses heavier linework. */
+    strokeWidth?: number
     /** Resolves a colorId to a hex value (store-owned palette lookup). */
     paletteResolver: (colorId: string) => string
   }>(),
-  { fillOps: () => [], selectedRegionIds: () => [], interactive: true },
+  {
+    fillOps: () => [],
+    selectedRegionIds: () => [],
+    interactive: true,
+    strokeWidth: 3,
+  },
 )
 
 const emit = defineEmits<{

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -1,9 +1,9 @@
 <template>
   <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden">
-    <header
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4"
-    >
-      <div class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+    <header class="shrink-0 rounded-2xl border border-base-300 bg-base-100 p-4">
+      <div
+        class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between"
+      >
         <div class="flex items-center gap-3">
           <div
             class="flex h-14 w-14 items-center justify-center rounded-2xl border-2 border-primary bg-primary/10"
@@ -12,9 +12,7 @@
           </div>
 
           <div class="min-w-0">
-            <h1 class="text-2xl font-black text-primary">
-              Mural Color Studio
-            </h1>
+            <h1 class="text-2xl font-black text-primary">Mural Color Studio</h1>
 
             <p class="mt-1 max-w-3xl text-sm text-base-content/65">
               Color the mural plan by section, fill whole groups with one saved
@@ -27,7 +25,16 @@
           <button
             class="btn btn-sm btn-ghost rounded-xl"
             type="button"
-            @click="muralStore.resetMural"
+            @click="coloringStore.undo()"
+          >
+            <Icon name="mdi:undo" class="h-4 w-4" />
+            Undo
+          </button>
+
+          <button
+            class="btn btn-sm btn-ghost rounded-xl"
+            type="button"
+            @click="coloringStore.resetPage()"
           >
             <Icon name="kind-icon:refresh" class="h-4 w-4" />
             Reset
@@ -45,7 +52,15 @@
       </div>
     </header>
 
+    <div
+      v-if="!pageDefinition"
+      class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+    >
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </div>
+
     <section
+      v-else
       class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-[minmax(280px,360px)_minmax(0,1fr)_minmax(280px,360px)]"
     >
       <aside
@@ -61,11 +76,11 @@
         <div class="min-h-0 flex-1 overflow-y-auto p-3">
           <div class="grid gap-2">
             <div
-              v-for="color in muralStore.colors"
+              v-for="color in coloringStore.currentPalette"
               :key="color.id"
               class="grid grid-cols-[minmax(0,1fr)_auto] gap-2 rounded-2xl border p-2 transition"
               :class="
-                muralStore.activeColorId === color.id
+                activeColorId === color.id
                   ? 'border-primary bg-primary/10 text-primary'
                   : 'border-base-300 bg-base-200'
               "
@@ -73,7 +88,7 @@
               <button
                 class="flex min-w-0 items-center gap-3 rounded-xl p-1 text-left hover:bg-base-100/60"
                 type="button"
-                @click="muralStore.setActiveColor(color.id)"
+                @click="coloringStore.setActiveColor(color.id)"
               >
                 <span
                   class="h-8 w-8 shrink-0 rounded-xl border border-base-300 shadow-inner"
@@ -92,8 +107,13 @@
               <button
                 class="btn btn-ghost btn-xs self-center rounded-xl"
                 type="button"
-                :disabled="muralStore.colors.length <= 1"
-                @click="muralStore.removeSavedColor(color.id)"
+                :disabled="!isCustomColor(color.id)"
+                :title="
+                  isCustomColor(color.id)
+                    ? 'Remove saved color'
+                    : 'Base palette colors stay available'
+                "
+                @click="coloringStore.removeColor(color.id)"
               >
                 <Icon name="kind-icon:trash" class="h-4 w-4" />
               </button>
@@ -129,7 +149,10 @@
               />
             </div>
 
-            <button class="btn btn-sm btn-primary rounded-xl text-white" type="submit">
+            <button
+              class="btn btn-sm btn-primary rounded-xl text-white"
+              type="submit"
+            >
               <Icon name="kind-icon:plus" class="h-4 w-4" />
               Save Color
             </button>
@@ -143,76 +166,49 @@
         <div
           class="rounded-2xl border border-base-300 bg-base-200 p-3 shadow-inner"
         >
-          <svg
-            class="h-auto w-full rounded-2xl bg-base-100"
-            viewBox="0 0 960 540"
-            role="img"
-            aria-labelledby="mural-title mural-description"
-          >
-            <title id="mural-title">Paintable fence mural coloring plan</title>
-            <desc id="mural-description">
-              A simplified mural with a portal spirit, catbus, robots,
-              butterflies, soot sprites, and grouped colorable sections.
-            </desc>
-
-            <path
-              v-for="section in muralStore.sections"
-              :key="section.id"
-              :d="section.d"
-              :fill="muralStore.getColorValue(section.colorId)"
-              :stroke="
-                section.id === muralStore.selectedSectionId
-                  ? activeColor?.value || '#171312'
-                  : '#171312'
-              "
-              :stroke-width="section.id === muralStore.selectedSectionId ? 8 : 5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="cursor-pointer transition hover:brightness-110"
-              :class="
-                section.id === muralStore.selectedSectionId
-                  ? 'drop-shadow-lg'
-                  : ''
-              "
-              @click="paintSection(section.id)"
-            />
-
-            <path
-              d="M139 211L156 226M215 211L199 226M169 274H201M592 300H777M565 358C576 386 612 386 621 361M677 365C687 392 725 392 734 364M784 358C793 382 829 382 837 357"
-              fill="none"
-              stroke="#171312"
-              stroke-width="6"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
+          <coloring-canvas
+            :page="pageDefinition"
+            :fills="coloringStore.currentPage?.fills ?? {}"
+            :selected-region-ids="
+              coloringStore.currentPage?.selectedRegionIds ?? []
+            "
+            :stroke-width="5"
+            :palette-resolver="coloringStore.resolveColorValue"
+            @region-click="paintSection"
+          />
         </div>
 
         <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
           <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
-            <p class="text-xs font-bold uppercase tracking-wide text-base-content/45">
+            <p
+              class="text-xs font-bold uppercase tracking-wide text-base-content/45"
+            >
               Sections
             </p>
             <p class="mt-1 text-3xl font-black text-primary">
-              {{ muralStore.sections.length }}
+              {{ pageDefinition.regions?.length ?? 0 }}
             </p>
           </div>
 
           <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
-            <p class="text-xs font-bold uppercase tracking-wide text-base-content/45">
+            <p
+              class="text-xs font-bold uppercase tracking-wide text-base-content/45"
+            >
               Groups
             </p>
             <p class="mt-1 text-3xl font-black text-secondary">
-              {{ muralStore.groups.length }}
+              {{ groups.length }}
             </p>
           </div>
 
           <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
-            <p class="text-xs font-bold uppercase tracking-wide text-base-content/45">
+            <p
+              class="text-xs font-bold uppercase tracking-wide text-base-content/45"
+            >
               Saved colors
             </p>
             <p class="mt-1 text-3xl font-black text-accent">
-              {{ muralStore.colors.length }}
+              {{ coloringStore.currentPalette.length }}
             </p>
           </div>
         </div>
@@ -234,20 +230,22 @@
             v-if="selectedSection"
             class="mb-3 rounded-2xl border border-primary/30 bg-primary/10 p-3"
           >
-            <p class="text-xs font-bold uppercase tracking-wide text-primary/70">
+            <p
+              class="text-xs font-bold uppercase tracking-wide text-primary/70"
+            >
               Selected section
             </p>
             <h3 class="mt-1 text-lg font-black text-primary">
               {{ selectedSection.label }}
             </h3>
             <p class="mt-1 text-sm text-base-content/65">
-              Group: {{ groupLabel(selectedSection.groupId) }}
+              Group: {{ groupLabel(selectedSection.group) }}
             </p>
 
             <button
               class="btn btn-sm btn-primary mt-3 rounded-xl text-white"
               type="button"
-              @click="muralStore.setSectionColor(selectedSection.id)"
+              @click="coloringStore.paintRegion(selectedSection.id)"
             >
               Paint selected with active color
             </button>
@@ -255,7 +253,7 @@
 
           <div class="grid gap-3">
             <article
-              v-for="group in muralStore.groups"
+              v-for="group in groups"
               :key="group.id"
               class="rounded-2xl border border-base-300 bg-base-200 p-3"
             >
@@ -263,15 +261,15 @@
                 <div>
                   <h3 class="font-black">{{ group.label }}</h3>
                   <p class="mt-1 text-xs text-base-content/55">
-                    {{ group.sectionIds.length }} sections ·
-                    {{ group.colorId === 'mixed' ? 'mixed colors' : 'one color' }}
+                    {{ group.sections.length }} sections ·
+                    {{ group.mixed ? 'mixed colors' : 'one color' }}
                   </p>
                 </div>
 
                 <button
                   class="btn btn-xs btn-secondary rounded-xl text-white"
                   type="button"
-                  @click="muralStore.setGroupColor(group.id)"
+                  @click="coloringStore.paintGroup(group.id)"
                 >
                   Fill group
                 </button>
@@ -279,16 +277,16 @@
 
               <div class="mt-3 flex flex-wrap gap-2">
                 <button
-                  v-for="section in sectionsForGroup(group.id)"
+                  v-for="section in group.sections"
                   :key="section.id"
                   class="badge cursor-pointer border transition"
                   :class="
-                    section.id === muralStore.selectedSectionId
+                    selectedSectionId === section.id
                       ? 'badge-primary'
                       : 'badge-ghost hover:badge-outline'
                   "
                   type="button"
-                  @click="muralStore.selectSection(section.id)"
+                  @click="coloringStore.selectRegion(section.id)"
                 >
                   {{ section.label }}
                 </button>
@@ -303,36 +301,110 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { useMuralStore, type MuralSection } from '@/stores/muralStore'
+import { useColoringStore } from '@/stores/coloringStore'
+import { loadMuralPageDefinition } from '@/stores/muralStore'
+import { runMuralMigration } from '@/stores/helpers/muralMigration'
+import type {
+  ColoringPageDefinition,
+  ColoringRegion,
+} from '@/stores/helpers/coloring'
 
-const muralStore = useMuralStore()
+interface MuralGroupView {
+  id: string
+  label: string
+  sections: ColoringRegion[]
+  mixed: boolean
+}
 
+const coloringStore = useColoringStore()
+
+const pageDefinition = ref<ColoringPageDefinition | null>(null)
 const newColorName = ref('')
 const newColorValue = ref('#55a9b5')
 
-const activeColor = computed(() => muralStore.activeColor)
-const selectedSection = computed(() => muralStore.selectedSection)
+const activeColorId = computed(
+  () => coloringStore.currentPage?.activeColorId ?? null,
+)
+
+const activeColor = computed(() => {
+  return (
+    coloringStore.currentPalette.find(
+      (color) => color.id === activeColorId.value,
+    ) ?? null
+  )
+})
+
+const selectedSectionId = computed(
+  () => coloringStore.currentPage?.selectedRegionIds[0] ?? null,
+)
+
+const selectedSection = computed<ColoringRegion | null>(() => {
+  if (!selectedSectionId.value) return null
+  return (
+    pageDefinition.value?.regions?.find(
+      (region) => region.id === selectedSectionId.value,
+    ) ?? null
+  )
+})
+
+const groups = computed<MuralGroupView[]>(() => {
+  const regions = pageDefinition.value?.regions ?? []
+  const fills = coloringStore.currentPage?.fills ?? {}
+  const order: string[] = []
+  const lookup = new Map<string, ColoringRegion[]>()
+
+  for (const region of regions) {
+    const groupId = region.group ?? 'misc'
+
+    if (!lookup.has(groupId)) {
+      lookup.set(groupId, [])
+      order.push(groupId)
+    }
+
+    lookup.get(groupId)?.push(region)
+  }
+
+  return order.map((groupId) => {
+    const sections = lookup.get(groupId) ?? []
+    const firstFill = sections[0] ? fills[sections[0].id] : undefined
+
+    return {
+      id: groupId,
+      label: groupLabel(groupId),
+      sections,
+      mixed: sections.some((section) => fills[section.id] !== firstFill),
+    }
+  })
+})
+
+function groupLabel(groupId: string | undefined): string {
+  return (groupId ?? 'misc')
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function isCustomColor(colorId: string): boolean {
+  return !pageDefinition.value?.palette.some((color) => color.id === colorId)
+}
 
 function paintSection(sectionId: string): void {
-  muralStore.setSectionColor(sectionId)
-}
-
-function sectionsForGroup(groupId: string): MuralSection[] {
-  return muralStore.sections.filter((section) => section.groupId === groupId)
-}
-
-function groupLabel(groupId: string): string {
-  return (
-    muralStore.groups.find((group) => group.id === groupId)?.label ?? groupId
-  )
+  coloringStore.paintRegion(sectionId)
+  coloringStore.selectRegion(sectionId)
 }
 
 function addColor(): void {
-  muralStore.addSavedColor(newColorName.value, newColorValue.value)
+  coloringStore.addColor(newColorName.value, newColorValue.value)
   newColorName.value = ''
 }
 
-onMounted(() => {
-  muralStore.initialize()
+onMounted(async () => {
+  const definition = await loadMuralPageDefinition()
+
+  // One-time legacy kindRobotsMuralState translation (old key left in place).
+  runMuralMigration(definition)
+
+  coloringStore.openPage(definition)
+  pageDefinition.value = definition
 })
 </script>

--- a/stores/helpers/muralMigration.ts
+++ b/stores/helpers/muralMigration.ts
@@ -1,0 +1,112 @@
+// /stores/helpers/muralMigration.ts
+//
+// One-time translation of the legacy mural color-studio state
+// (localStorage key 'kindRobotsMuralState') into the shared coloring-engine
+// per-page format, per coloring-engine-spec.md section 2.4. The legacy key
+// is left in place for one release so rollback stays safe.
+
+import {
+  coloringStorageKey,
+  isColoringClient,
+  normalizeColorValue,
+  safeReadJson,
+  safeWriteJson,
+} from '@/stores/helpers/coloring'
+import type {
+  ColoringColor,
+  ColoringPageDefinition,
+} from '@/stores/helpers/coloring'
+
+export const LEGACY_MURAL_STORAGE_KEY = 'kindRobotsMuralState'
+
+/** Minimal shape of the legacy muralStore blob (decoupled from muralStore). */
+export interface LegacyMuralState {
+  colors?: Array<{ id: string; name: string; value: string }>
+  sections?: Array<{ id: string; colorId: string }>
+  activeColorId?: string
+}
+
+export interface MigratedColoringState {
+  fills: Record<string, string>
+  customColors: ColoringColor[]
+  activeColorId?: string
+  updatedAt: string
+}
+
+/**
+ * Pure translation: legacy blob + page definition → per-page coloring state.
+ * Returns null when the legacy blob holds nothing usable. Notes:
+ * - fills carry over only for regions that still exist in the definition and
+ *   whose color id is known (page palette or migrated custom color).
+ * - custom colors are legacy colors whose id is not in the page palette.
+ * - legacy deletions of base palette colors are not preserved — the page
+ *   palette is authoritative in the shared engine.
+ */
+export function translateLegacyMuralState(
+  legacy: LegacyMuralState | null,
+  def: ColoringPageDefinition,
+  now: string,
+): MigratedColoringState | null {
+  if (!legacy || (!legacy.sections?.length && !legacy.colors?.length)) {
+    return null
+  }
+
+  const paletteIds = new Set(def.palette.map((color) => color.id))
+
+  const customColors: ColoringColor[] = (legacy.colors ?? [])
+    .filter((color) => color?.id && !paletteIds.has(color.id))
+    .map((color) => ({
+      id: color.id,
+      name: color.name || 'Saved color',
+      value: normalizeColorValue(color.value ?? ''),
+    }))
+
+  const knownColorIds = new Set([
+    ...paletteIds,
+    ...customColors.map((color) => color.id),
+  ])
+
+  const regionIds = new Set((def.regions ?? []).map((region) => region.id))
+  const fills: Record<string, string> = {}
+
+  for (const section of legacy.sections ?? []) {
+    if (
+      section?.id &&
+      regionIds.has(section.id) &&
+      section.colorId &&
+      knownColorIds.has(section.colorId)
+    ) {
+      fills[section.id] = section.colorId
+    }
+  }
+
+  const activeColorId =
+    legacy.activeColorId && knownColorIds.has(legacy.activeColorId)
+      ? legacy.activeColorId
+      : undefined
+
+  return { fills, customColors, activeColorId, updatedAt: now }
+}
+
+/**
+ * Browser wrapper: migrate once, only when the new per-page key does not
+ * exist yet. Leaves the legacy key untouched.
+ */
+export function runMuralMigration(def: ColoringPageDefinition): boolean {
+  if (!isColoringClient) return false
+
+  const targetKey = coloringStorageKey(def.id)
+  if (localStorage.getItem(targetKey) !== null) return false
+
+  const legacy = safeReadJson<LegacyMuralState>(LEGACY_MURAL_STORAGE_KEY)
+  const migrated = translateLegacyMuralState(
+    legacy,
+    def,
+    new Date().toISOString(),
+  )
+
+  if (!migrated) return false
+
+  safeWriteJson(targetKey, migrated)
+  return true
+}

--- a/stores/muralStore.ts
+++ b/stores/muralStore.ts
@@ -199,8 +199,12 @@ interface MuralStoredState {
 // if the data file is missing or malformed.
 const MURAL_PAGE_URL = '/data/mural-design/mural-page.json'
 
+// Whisker/smile strokes, mirrored from mural-page.json's layers.decor for
+// the same-fallback reason as the geometry.
 let baseColors: MuralColor[] = defaultColors
 let baseSections: MuralSection[] = defaultSections
+let baseDecor =
+  'M139 211L156 226M215 211L199 226M169 274H201M592 300H777M565 358C576 386 612 386 621 361M677 365C687 392 725 392 734 364M784 358C793 382 829 382 837 357'
 let baseLoaded = false
 
 async function hydrateBaseFromPageData(): Promise<void> {
@@ -225,12 +229,47 @@ async function hydrateBaseFromPageData(): Promise<void> {
       name: color.name,
       value: normalizeColorValue(color.value),
     }))
+
+    if (page.layers?.decor) {
+      baseDecor = page.layers.decor
+    }
   } catch (error) {
     console.warn(
       '[muralStore] page data unavailable, using inline defaults:',
       error,
     )
   }
+}
+
+let cachedPageDefinition: ColoringPageDefinition | null = null
+
+/**
+ * The mural as a shared coloring-engine page definition. Prefers the data
+ * file (step 4); falls back to the inline constants so /mural never breaks.
+ */
+export async function loadMuralPageDefinition(): Promise<ColoringPageDefinition> {
+  if (cachedPageDefinition) return cachedPageDefinition
+
+  await hydrateBaseFromPageData()
+
+  cachedPageDefinition = {
+    id: 'mural/fence-v1',
+    version: 1,
+    title: 'Fence Mural Color Studio',
+    viewBox: { width: 960, height: 540 },
+    mode: 'svg-regions',
+    layers: { decor: baseDecor },
+    regions: baseSections.map((section) => ({
+      id: section.id,
+      label: section.label,
+      group: section.groupId,
+      defaultColorId: section.colorId,
+      d: section.d,
+    })),
+    palette: baseColors.map((color) => ({ ...color })),
+  }
+
+  return cachedPageDefinition
 }
 
 function safeReadState(): MuralStoredState | null {


### PR DESCRIPTION
### Task
coloring-book/t-017, step 5 ONLY (kind: software) — **this is the one user-visible-risk step** of the `/mural` migration, deliberately shipped alone.

### What changed / what I produced
- **mural-manager.vue** renders through the shared `ColoringCanvas` driven by `coloringStore`; the page definition comes from step 4's data file (`loadMuralPageDefinition()`, inline fallback intact). All chrome preserved: saved-colors sidebar, group fills, per-section overrides, selected-section panel, stats tiles, reset — **plus Undo**, which the mural never had before.
- **`stores/helpers/muralMigration.ts`** — the one-time `kindRobotsMuralState` → `kindRobots:coloring:mural/fence-v1` shim, written as a pure function plus a thin browser wrapper. Legacy key stays in place for one release, so rollback is safe: revert this PR and the old page reads its old state unchanged.
- **muralStore** exports `loadMuralPageDefinition()`; nothing else touched — the store is now consumer-free and gets shrunk in step 6.
- **ColoringCanvas** gains an optional `strokeWidth` prop (mural keeps its heavier 5px lines).

### Intentional behavior deltas (please eyeball on the deployed page)
1. Selection highlight is now a dashed primary ring instead of an active-color stroke.
2. Base palette colors can't be deleted anymore (page palette is authoritative; the shim does not preserve legacy deletions of base colors).
3. Reset clears fills but keeps saved custom colors.

### How I verified
- **12-case Node run of the pure shim against the real page definition**: custom colors extracted (base colors not duplicated), fills carried for surviving regions, ghost regions and unknown color ids dropped, bad hex normalized, unknown activeColorId dropped, empty/null legacy no-ops.
- eslint + prettier + `npm test` (vue-tsc) clean, zero new errors.
- grep confirms no other `useMuralStore` consumers, so the swap is contained to this page.
- Not driven in a live browser (no dev DB in this environment) — the deltas above are the review checklist for the deployed page.

### Stakes
reversible — single-revert rollback; legacy storage untouched.

### Flags for Reviewer
- If the deployed `/mural` looks wrong in any way, revert this PR alone; steps 4 and earlier are independent.

### Kaizen suggestion
Step 6 (shrink muralStore to nothing or a thin wrapper) is now trivial and should land while this context is fresh.

### Notes for reviewer
Overnight autonomous cycle 2 (scheduled check-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB)_