### PR TITLE
mural: shrink muralStore + promote mural to canonical wonder tabs (engine steps 6–7)

### DIFF
--- a/content/mural.md
+++ b/content/mural.md
@@ -10,7 +10,7 @@ sort: wonder
 dottitip: "Can a coloring page become project management?"
 amitip: "Yes, but only if the paint swatches stop wandering off like tiny chromatic ferrets."
 dashboardKey: wonder
-dashboardTab: wonder-lab
+dashboardTab: mural
 cards: labCards
 loadingMessage: Loading mural studio...
 refreshLabel: Refresh Mural

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -999,6 +999,20 @@ export const dashboardConfigs = {
           'Control the screen-effect layer, including matrix rain, firefly drift, butterflies, and ambient theater.',
         route: '/screenfx',
       },
+      {
+        key: 'mural',
+        label: 'Mural',
+        icon: 'kind-icon:paintbrush',
+        title: 'Mural Color Studio',
+        summary:
+          'Color a paintable mural plan by section, shared color group, and saved paint swatch.',
+        image: tabImage('wonder', 'mural'),
+        flourish: '✺',
+        tagline: 'Paint inside the lines, then bend the lines politely.',
+        narrative:
+          'Color a simplified mural page, assign one paint ID across multiple sections, override individual shapes, and save the palette before the paint goblin eats the swatches.',
+        route: '/mural',
+      },
     ],
   },
 } as const satisfies Record<string, DashboardConfig>

--- a/stores/helpers/labCards.ts
+++ b/stores/helpers/labCards.ts
@@ -1,38 +1,25 @@
 // /stores/helpers/labCards.ts
-import { dashboardConfigs, getDashboardTabImagePath } from '@/stores/helpers/dashboardHelper'
-import { deriveNavCard, deriveNavCards } from '@/stores/helpers/tabsToCards'
-import type {
-  BuilderCard,
-  DashboardTabConfig,
-} from '@/stores/helpers/builderCards'
+//
+// Lab cards derive entirely from the canonical dashboardConfigs.wonder.tabs
+// registry (the temporary hand-rolled mural bridge was removed in the mural
+// engine migration, step 7). The mural tab routes to its own page, so its
+// card gets /mural as its path instead of the shared /wonderlab shell.
+import { dashboardConfigs } from '@/stores/helpers/dashboardHelper'
+import { deriveNavCard } from '@/stores/helpers/tabsToCards'
+import type { BuilderCard } from '@/stores/helpers/builderCards'
 
 export type LabCard = BuilderCard
 
-const muralTab = {
-  key: 'mural',
-  label: 'Mural',
-  icon: 'kind-icon:paintbrush',
-  title: 'Mural Color Studio',
-  summary:
-    'Color a paintable mural plan by section, shared color group, and saved paint swatch.',
-  image: getDashboardTabImagePath('wonder', 'mural'),
-  flourish: '✺',
-  tagline: 'Paint inside the lines, then bend the lines politely.',
-  narrative:
-    'Color a simplified mural page, assign one paint ID across multiple sections, override individual shapes, and save the palette before the paint goblin eats the swatches.',
-  route: '/mural',
-} as const satisfies DashboardTabConfig
-
-export const LAB_CARDS: LabCard[] = [
-  ...deriveNavCards(dashboardConfigs.wonder.tabs, {
-    path: '/wonderlab',
-    dashboardKey: 'wonder',
-    routeByTab: true,
-    imageDir: 'lab',
-  }),
-  deriveNavCard(muralTab, {
-    path: '/mural',
-    dashboardKey: 'wonder',
-    imageDir: 'lab',
-  }),
-]
+export const LAB_CARDS: LabCard[] = dashboardConfigs.wonder.tabs.map((tab) =>
+  deriveNavCard(
+    tab,
+    tab.key === 'mural'
+      ? { path: '/mural', dashboardKey: 'wonder', imageDir: 'lab' }
+      : {
+          path: '/wonderlab',
+          dashboardKey: 'wonder',
+          routeByTab: true,
+          imageDir: 'lab',
+        },
+  ),
+)

--- a/stores/muralStore.ts
+++ b/stores/muralStore.ts
@@ -1,33 +1,22 @@
 // /stores/muralStore.ts
-import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
-import type { ColoringPageDefinition } from '@/stores/helpers/coloring'
+//
+// Slimmed to the mural page-definition loader (shared coloring-engine
+// migration step 6, conductor coloring-book/docs/coloring-engine-spec.md).
+// The old useMuralStore Pinia store is gone: /mural runs on coloringStore
+// via ColoringCanvas, and legacy saved state migrates through
+// stores/helpers/muralMigration.ts. Geometry/palette live in
+// public/data/mural-design/mural-page.json; the inline constants below are
+// the fallback so /mural keeps working if the data file is missing.
+import { normalizeColorValue } from '@/stores/helpers/coloring'
+import type {
+  ColoringColor,
+  ColoringPageDefinition,
+  ColoringRegion,
+} from '@/stores/helpers/coloring'
 
-export interface MuralColor {
-  id: string
-  name: string
-  value: string
-}
+const MURAL_PAGE_URL = '/data/mural-design/mural-page.json'
 
-export interface MuralSection {
-  id: string
-  label: string
-  groupId: string
-  colorId: string
-  d: string
-}
-
-export interface MuralGroup {
-  id: string
-  label: string
-  sectionIds: string[]
-  colorId: string
-}
-
-const storageKey = 'kindRobotsMuralState'
-const isClient = typeof window !== 'undefined'
-
-const defaultColors: MuralColor[] = [
+const fallbackPalette: ColoringColor[] = [
   { id: 'wine-red', name: 'Wine Red', value: '#6f2746' },
   { id: 'leaf-yellow', name: 'Yellow Green', value: '#8aa63f' },
   { id: 'leaf-true', name: 'True Green', value: '#3f7f4a' },
@@ -43,201 +32,162 @@ const defaultColors: MuralColor[] = [
   { id: 'line-black', name: 'Linework Black', value: '#171312' },
 ]
 
-const defaultSections: MuralSection[] = [
+const fallbackRegions: ColoringRegion[] = [
   {
     id: 'background-sky',
     label: 'Wine sky',
-    groupId: 'background',
-    colorId: 'wine-red',
+    group: 'background',
+    defaultColorId: 'wine-red',
     d: 'M0 0H960V540H0Z',
   },
   {
     id: 'alien-ground',
     label: 'Alien garden ground',
-    groupId: 'foliage',
-    colorId: 'leaf-blue',
+    group: 'foliage',
+    defaultColorId: 'leaf-blue',
     d: 'M0 422C95 392 174 420 248 392C330 360 422 392 505 372C619 344 704 377 783 354C861 331 916 354 960 337V540H0Z',
   },
   {
     id: 'ivy-portal',
     label: 'Ivy portal',
-    groupId: 'foliage',
-    colorId: 'leaf-true',
+    group: 'foliage',
+    defaultColorId: 'leaf-true',
     d: 'M78 137C125 77 221 82 268 147C306 199 306 276 262 329C218 382 127 382 78 329C26 274 28 198 78 137Z',
   },
   {
     id: 'portal-glow',
     label: 'Portal glow',
-    groupId: 'portal',
-    colorId: 'leaf-yellow',
+    group: 'portal',
+    defaultColorId: 'leaf-yellow',
     d: 'M110 164C145 119 215 124 247 171C274 211 271 270 237 309C202 349 142 347 108 307C73 266 76 205 110 164Z',
   },
   {
     id: 'totoro-body',
     label: 'Hidden spirit body',
-    groupId: 'spirit',
-    colorId: 'robot-gray',
+    group: 'spirit',
+    defaultColorId: 'robot-gray',
     d: 'M151 203C155 162 213 158 224 202C242 207 254 228 249 252C244 287 218 316 184 316C149 316 123 288 118 253C115 229 129 207 151 203Z',
   },
   {
     id: 'totoro-belly',
     label: 'Spirit belly',
-    groupId: 'spirit',
-    colorId: 'soft-white',
+    group: 'spirit',
+    defaultColorId: 'soft-white',
     d: 'M151 257C160 235 210 235 220 257C226 276 211 297 185 299C158 297 145 276 151 257Z',
   },
   {
     id: 'catbus-body',
     label: 'Catbus body',
-    groupId: 'catbus',
-    colorId: 'catbus-orange',
+    group: 'catbus',
+    defaultColorId: 'catbus-orange',
     d: 'M527 219C584 148 763 143 838 215C890 265 874 341 804 363C713 391 589 374 530 328C495 300 497 257 527 219Z',
   },
   {
     id: 'catbus-roof',
     label: 'Catbus roof stripe',
-    groupId: 'catbus',
-    colorId: 'catbus-brown',
+    group: 'catbus',
+    defaultColorId: 'catbus-brown',
     d: 'M576 183C640 151 751 159 807 205C751 190 637 186 576 183Z',
   },
   {
     id: 'catbus-face',
     label: 'Catbus face',
-    groupId: 'catbus',
-    colorId: 'catbus-brown',
+    group: 'catbus',
+    defaultColorId: 'catbus-brown',
     d: 'M804 218C842 234 858 267 848 296C828 279 805 259 774 244C781 231 790 223 804 218Z',
   },
   {
     id: 'catbus-window-1',
     label: 'Window one',
-    groupId: 'windows',
-    colorId: 'window-teal',
+    group: 'windows',
+    defaultColorId: 'window-teal',
     d: 'M578 215H626C637 215 644 224 642 236L636 281H568L561 236C559 224 567 215 578 215Z',
   },
   {
     id: 'catbus-window-2',
     label: 'Window two',
-    groupId: 'windows',
-    colorId: 'window-teal',
+    group: 'windows',
+    defaultColorId: 'window-teal',
     d: 'M654 213H701C713 213 721 223 719 236L713 282H646L642 236C640 223 642 213 654 213Z',
   },
   {
     id: 'catbus-window-3',
     label: 'Window three',
-    groupId: 'windows',
-    colorId: 'window-teal',
+    group: 'windows',
+    defaultColorId: 'window-teal',
     d: 'M730 221H775C789 221 798 232 795 246L786 288H722L717 246C715 232 717 221 730 221Z',
   },
   {
     id: 'catbus-eye-left',
     label: 'Left Catbus eye',
-    groupId: 'catbus',
-    colorId: 'warm-yellow',
+    group: 'catbus',
+    defaultColorId: 'warm-yellow',
     d: 'M813 252C829 242 845 250 846 265C832 275 817 270 813 252Z',
   },
   {
     id: 'catbus-eye-right',
     label: 'Right Catbus eye',
-    groupId: 'catbus',
-    colorId: 'warm-yellow',
+    group: 'catbus',
+    defaultColorId: 'warm-yellow',
     d: 'M782 248C797 239 812 246 814 260C802 270 787 266 782 248Z',
   },
   {
     id: 'robot-left',
     label: 'Garden robot left',
-    groupId: 'robots',
-    colorId: 'robot-gray',
+    group: 'robots',
+    defaultColorId: 'robot-gray',
     d: 'M344 322H390V366H344ZM354 296H380V322H354ZM335 339H344V353H335ZM390 339H399V353H390Z',
   },
   {
     id: 'robot-right',
     label: 'Garden robot right',
-    groupId: 'robots',
-    colorId: 'robot-gray',
+    group: 'robots',
+    defaultColorId: 'robot-gray',
     d: 'M436 346H475V387H436ZM446 322H466V346H446ZM426 359H436V373H426ZM475 359H485V373H475Z',
   },
   {
     id: 'butterfly-one',
     label: 'Purple butterfly',
-    groupId: 'butterflies',
-    colorId: 'butterfly-purple',
+    group: 'butterflies',
+    defaultColorId: 'butterfly-purple',
     d: 'M348 151C321 122 302 154 326 174C300 197 331 220 352 186C376 220 408 197 379 174C405 151 377 122 348 151Z',
   },
   {
     id: 'butterfly-two',
     label: 'Violet butterfly',
-    groupId: 'butterflies',
-    colorId: 'butterfly-violet',
+    group: 'butterflies',
+    defaultColorId: 'butterfly-violet',
     d: 'M676 110C654 85 636 111 656 129C632 150 660 170 680 140C700 170 729 150 705 129C725 111 703 85 676 110Z',
   },
   {
     id: 'butterfly-three',
     label: 'Yellow butterfly',
-    groupId: 'butterflies',
-    colorId: 'warm-yellow',
+    group: 'butterflies',
+    defaultColorId: 'warm-yellow',
     d: 'M478 123C459 103 444 126 461 140C441 158 465 175 482 149C499 175 524 158 503 140C520 126 501 103 478 123Z',
   },
   {
     id: 'soot-sprites',
     label: 'Hidden soot sprites',
-    groupId: 'sprites',
-    colorId: 'line-black',
+    group: 'sprites',
+    defaultColorId: 'line-black',
     d: 'M289 387C289 374 309 374 309 387C309 400 289 400 289 387ZM873 395C873 382 893 382 893 395C893 408 873 408 873 395ZM405 415C405 403 423 403 423 415C423 427 405 427 405 415Z',
   },
 ]
 
-interface MuralStoredState {
-  colors?: MuralColor[]
-  sections?: MuralSection[]
-  activeColorId?: string
-  selectedSectionId?: string | null
-}
-
-// Geometry/palette now live in data (shared coloring-engine page format,
-// step 4 of the migration in conductor coloring-book/docs/coloring-engine-spec.md).
-// The inline constants above remain as the fallback so /mural keeps working
-// if the data file is missing or malformed.
-const MURAL_PAGE_URL = '/data/mural-design/mural-page.json'
-
-// Whisker/smile strokes, mirrored from mural-page.json's layers.decor for
-// the same-fallback reason as the geometry.
-let baseColors: MuralColor[] = defaultColors
-let baseSections: MuralSection[] = defaultSections
-let baseDecor =
+const fallbackDecor =
   'M139 211L156 226M215 211L199 226M169 274H201M592 300H777M565 358C576 386 612 386 621 361M677 365C687 392 725 392 734 364M784 358C793 382 829 382 837 357'
-let baseLoaded = false
 
-async function hydrateBaseFromPageData(): Promise<void> {
-  if (baseLoaded || !isClient) return
-  baseLoaded = true
-
-  try {
-    const page = await $fetch<ColoringPageDefinition>(MURAL_PAGE_URL)
-
-    if (!page?.regions?.length || !page.palette?.length) return
-
-    baseSections = page.regions.map((region) => ({
-      id: region.id,
-      label: region.label ?? region.id,
-      groupId: region.group ?? 'misc',
-      colorId: region.defaultColorId ?? 'soft-white',
-      d: region.d,
-    }))
-
-    baseColors = page.palette.map((color) => ({
-      id: color.id,
-      name: color.name,
-      value: normalizeColorValue(color.value),
-    }))
-
-    if (page.layers?.decor) {
-      baseDecor = page.layers.decor
-    }
-  } catch (error) {
-    console.warn(
-      '[muralStore] page data unavailable, using inline defaults:',
-      error,
-    )
+function fallbackDefinition(): ColoringPageDefinition {
+  return {
+    id: 'mural/fence-v1',
+    version: 1,
+    title: 'Fence Mural Color Studio',
+    viewBox: { width: 960, height: 540 },
+    mode: 'svg-regions',
+    layers: { decor: fallbackDecor },
+    regions: fallbackRegions.map((region) => ({ ...region })),
+    palette: fallbackPalette.map((color) => ({ ...color })),
   }
 }
 
@@ -245,292 +195,32 @@ let cachedPageDefinition: ColoringPageDefinition | null = null
 
 /**
  * The mural as a shared coloring-engine page definition. Prefers the data
- * file (step 4); falls back to the inline constants so /mural never breaks.
+ * file; falls back to the inline constants so /mural never breaks.
  */
 export async function loadMuralPageDefinition(): Promise<ColoringPageDefinition> {
   if (cachedPageDefinition) return cachedPageDefinition
 
-  await hydrateBaseFromPageData()
+  try {
+    const page = await $fetch<ColoringPageDefinition>(MURAL_PAGE_URL)
 
-  cachedPageDefinition = {
-    id: 'mural/fence-v1',
-    version: 1,
-    title: 'Fence Mural Color Studio',
-    viewBox: { width: 960, height: 540 },
-    mode: 'svg-regions',
-    layers: { decor: baseDecor },
-    regions: baseSections.map((section) => ({
-      id: section.id,
-      label: section.label,
-      group: section.groupId,
-      defaultColorId: section.colorId,
-      d: section.d,
-    })),
-    palette: baseColors.map((color) => ({ ...color })),
+    if (page?.regions?.length && page.palette?.length) {
+      cachedPageDefinition = {
+        ...page,
+        palette: page.palette.map((color) => ({
+          ...color,
+          value: normalizeColorValue(color.value),
+        })),
+      }
+
+      return cachedPageDefinition
+    }
+  } catch (error) {
+    console.warn(
+      '[muralStore] page data unavailable, using inline fallback:',
+      error,
+    )
   }
 
+  cachedPageDefinition = fallbackDefinition()
   return cachedPageDefinition
 }
-
-function safeReadState(): MuralStoredState | null {
-  if (!isClient) return null
-
-  try {
-    const raw = localStorage.getItem(storageKey)
-    if (!raw) return null
-    const parsed = JSON.parse(raw)
-    return parsed && typeof parsed === 'object' ? parsed : null
-  } catch {
-    return null
-  }
-}
-
-function safeWriteState(payload: MuralStoredState): void {
-  if (!isClient) return
-
-  try {
-    localStorage.setItem(storageKey, JSON.stringify(payload))
-  } catch {
-    // Quota/private-mode failures are non-fatal; coloring continues unsaved.
-  }
-}
-
-function normalizeColorValue(value: string): string {
-  const trimmed = value.trim()
-  return /^#[0-9a-f]{6}$/i.test(trimmed) ? trimmed : '#ffffff'
-}
-
-function makeColorId(name: string): string {
-  const slug =
-    name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '') || 'saved-color'
-
-  return `${slug}-${Date.now().toString(36)}`
-}
-
-export const useMuralStore = defineStore('muralStore', () => {
-  const colors = ref<MuralColor[]>(defaultColors.map((color) => ({ ...color })))
-  const sections = ref<MuralSection[]>(
-    defaultSections.map((section) => ({ ...section })),
-  )
-  const activeColorId = ref('leaf-true')
-  const selectedSectionId = ref<string | null>(defaultSections[0]?.id ?? null)
-  const initialized = ref(false)
-
-  const colorMap = computed(() => {
-    return new Map(colors.value.map((color) => [color.id, color]))
-  })
-
-  const activeColor = computed(() => {
-    return colorMap.value.get(activeColorId.value) ?? colors.value[0] ?? null
-  })
-
-  const selectedSection = computed(() => {
-    return (
-      sections.value.find(
-        (section) => section.id === selectedSectionId.value,
-      ) ?? null
-    )
-  })
-
-  const groups = computed<MuralGroup[]>(() => {
-    const groupOrder: string[] = []
-    const lookup = new Map<string, MuralSection[]>()
-
-    for (const section of sections.value) {
-      if (!lookup.has(section.groupId)) {
-        lookup.set(section.groupId, [])
-        groupOrder.push(section.groupId)
-      }
-
-      lookup.get(section.groupId)?.push(section)
-    }
-
-    return groupOrder.map((groupId) => {
-      const groupSections = lookup.get(groupId) ?? []
-      const firstColorId =
-        groupSections[0]?.colorId ?? colors.value[0]?.id ?? ''
-      const sameColor = groupSections.every(
-        (section) => section.colorId === firstColorId,
-      )
-
-      return {
-        id: groupId,
-        label: groupId
-          .split('-')
-          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-          .join(' '),
-        sectionIds: groupSections.map((section) => section.id),
-        colorId: sameColor ? firstColorId : 'mixed',
-      }
-    })
-  })
-
-  function getColorValue(colorId: string): string {
-    return colorMap.value.get(colorId)?.value ?? '#ffffff'
-  }
-
-  function sync(): void {
-    safeWriteState({
-      colors: colors.value,
-      sections: sections.value,
-      activeColorId: activeColorId.value,
-      selectedSectionId: selectedSectionId.value,
-    })
-  }
-
-  async function initialize(force = false): Promise<void> {
-    if (initialized.value && !force) return
-
-    await hydrateBaseFromPageData()
-
-    const saved = safeReadState()
-
-    if (saved?.colors?.length) {
-      colors.value = saved.colors.map((color) => ({
-        ...color,
-        value: normalizeColorValue(color.value),
-      }))
-    } else {
-      colors.value = baseColors.map((color) => ({ ...color }))
-    }
-
-    if (saved?.sections?.length) {
-      const savedSectionMap = new Map(
-        saved.sections.map((section) => [section.id, section]),
-      )
-
-      sections.value = baseSections.map((section) => {
-        const savedSection = savedSectionMap.get(section.id)
-
-        return {
-          ...section,
-          colorId: savedSection?.colorId ?? section.colorId,
-        }
-      })
-    } else {
-      sections.value = baseSections.map((section) => ({ ...section }))
-    }
-
-    if (saved?.activeColorId && colorMap.value.has(saved.activeColorId)) {
-      activeColorId.value = saved.activeColorId
-    }
-
-    if (
-      saved?.selectedSectionId &&
-      sections.value.some((section) => section.id === saved.selectedSectionId)
-    ) {
-      selectedSectionId.value = saved.selectedSectionId
-    }
-
-    initialized.value = true
-    sync()
-  }
-
-  function setActiveColor(colorId: string): void {
-    if (!colorMap.value.has(colorId)) return
-
-    activeColorId.value = colorId
-    sync()
-  }
-
-  function selectSection(sectionId: string): void {
-    if (!sections.value.some((section) => section.id === sectionId)) return
-
-    selectedSectionId.value = sectionId
-    sync()
-  }
-
-  function setSectionColor(
-    sectionId: string,
-    colorId = activeColorId.value,
-  ): void {
-    if (!colorMap.value.has(colorId)) return
-
-    sections.value = sections.value.map((section) =>
-      section.id === sectionId ? { ...section, colorId } : section,
-    )
-
-    selectedSectionId.value = sectionId
-    sync()
-  }
-
-  function setGroupColor(groupId: string, colorId = activeColorId.value): void {
-    if (!colorMap.value.has(colorId)) return
-
-    sections.value = sections.value.map((section) =>
-      section.groupId === groupId ? { ...section, colorId } : section,
-    )
-
-    sync()
-  }
-
-  function addSavedColor(name: string, value: string): void {
-    const trimmedName = name.trim() || 'Saved color'
-    const normalizedValue = normalizeColorValue(value)
-
-    const color: MuralColor = {
-      id: makeColorId(trimmedName),
-      name: trimmedName,
-      value: normalizedValue,
-    }
-
-    colors.value = [...colors.value, color]
-    activeColorId.value = color.id
-    sync()
-  }
-
-  function removeSavedColor(colorId: string): void {
-    if (colors.value.length <= 1) return
-
-    const fallbackColorId = colors.value.find(
-      (color) => color.id !== colorId,
-    )?.id
-    if (!fallbackColorId) return
-
-    colors.value = colors.value.filter((color) => color.id !== colorId)
-    sections.value = sections.value.map((section) =>
-      section.colorId === colorId
-        ? { ...section, colorId: fallbackColorId }
-        : section,
-    )
-
-    if (activeColorId.value === colorId) {
-      activeColorId.value = fallbackColorId
-    }
-
-    sync()
-  }
-
-  function resetMural(): void {
-    colors.value = baseColors.map((color) => ({ ...color }))
-    sections.value = baseSections.map((section) => ({ ...section }))
-    activeColorId.value = 'leaf-true'
-    selectedSectionId.value = baseSections[0]?.id ?? null
-    initialized.value = true
-    sync()
-  }
-
-  return {
-    colors,
-    sections,
-    activeColorId,
-    selectedSectionId,
-    initialized,
-    colorMap,
-    activeColor,
-    selectedSection,
-    groups,
-    getColorValue,
-    initialize,
-    setActiveColor,
-    selectSection,
-    setSectionColor,
-    setGroupColor,
-    addSavedColor,
-    removeSavedColor,
-    resetMural,
-  }
-})


### PR DESCRIPTION
### Task
coloring-book/t-017, steps 6 and 7 (kind: software) — low-risk cleanups now that step 5 (#148) is merged.

### What changed / what I produced
- **Step 6 — muralStore shrunk from 441 lines to a slim loader.** The `useMuralStore` Pinia store is deleted: `/mural` has run on `coloringStore` since #148 and grep confirms zero remaining consumers. What's left is `loadMuralPageDefinition()` — data file first, cached, with the full inline fallback definition (regions/palette/decor already in shared-engine shape) so a missing data file still renders the page.
- **Step 7 — mural is now a canonical wonder tab.** Registered in `dashboardConfigs.wonder.tabs` (route `/mural`, same copy as before); the temporary hand-rolled `muralTab` bridge in `labCards.ts` is deleted, and LAB_CARDS derive entirely from the canonical registry (the mural card keeps `/mural` as its path rather than the `/wonderlab` shell). `content/mural.md`'s `dashboardTab` hint updated `wonder-lab` → `mural` so the tab bar highlights Mural on its own page. This closes the cleanup item flagged in mural-design t-007's original notes.

### How I verified
- eslint + prettier + `npm test` (vue-tsc): clean, zero new errors.
- grep sweeps: no imports of `useMuralStore`, `MuralColor`/`MuralSection`/`MuralGroup`, or the deleted bridge helpers anywhere outside the slimmed module.
- The wonder tab bar now shows Mural everywhere wonder tabs render — expected and intentional (that's what canonical registration means); per-tab `route` handling mirrors the art channel's stylist tab, which already works this way.

### Stakes
reversible

### Flags for Reviewer
- The wonder dashboard gains a fourth tab; if the deployed WonderLab tab bar looks crowded on mobile, that's a styling follow-up, not a rollback reason.

### Kaizen suggestion
Step 8 (export-to-image) is the last t-017 item — after it lands, the engine-spec's migration section can be marked fully executed in conductor.

### Notes for reviewer
Overnight autonomous cycle 3 (scheduled check-in); Silas gave a mid-cycle "keep going."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB)_