### PR TITLE
coloring: export-to-image for both page modes (engine step 8)

### DIFF
--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -135,6 +135,20 @@
           <button
             type="button"
             class="btn btn-ghost btn-sm rounded-2xl"
+            title="Download your colored page as a PNG image"
+            :disabled="isExporting"
+            @click="saveImage"
+          >
+            <span
+              v-if="isExporting"
+              class="loading loading-spinner loading-xs"
+            />
+            <Icon v-else name="kind-icon:image" class="h-4 w-4" />
+            Save image
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-2xl"
             title="Download your color assignments as JSON"
             @click="downloadAssignments"
           >
@@ -148,6 +162,7 @@
         class="grid min-h-0 gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(220px,280px)]"
       >
         <coloring-canvas
+          ref="canvasRef"
           :page="openDefinition"
           :fills="coloringStore.currentPage?.fills ?? {}"
           :fill-ops="coloringStore.currentPage?.fillOps ?? []"
@@ -244,6 +259,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useColoringStore } from '@/stores/coloringStore'
 import { BLANK_COLOR_ID } from '@/stores/helpers/coloring'
+import { downloadPageBlob } from '@/stores/helpers/coloringExport'
 import type {
   ColoringPageDefinition,
   ColoringSetManifest,
@@ -261,6 +277,8 @@ const sets = ref<ColoringSetManifest[]>([])
 const loadError = ref('')
 const openDefinition = ref<ColoringPageDefinition | null>(null)
 const newColorValue = ref('#e05c5c')
+const canvasRef = ref<{ exportImage: () => Promise<Blob> } | null>(null)
+const isExporting = ref(false)
 
 const groupNames = computed<string[]>(() => {
   const regions = openDefinition.value?.regions ?? []
@@ -325,6 +343,22 @@ function onFillRequest(coords: { x: number; y: number }) {
 
 function addCustomColor() {
   coloringStore.addColor('My Color', newColorValue.value)
+}
+
+async function saveImage() {
+  if (!canvasRef.value || isExporting.value) return
+
+  isExporting.value = true
+
+  try {
+    const blob = await canvasRef.value.exportImage()
+    downloadPageBlob(blob, openDefinition.value?.id ?? 'coloring')
+  } catch (error) {
+    loadError.value =
+      error instanceof Error ? error.message : 'Image export failed.'
+  } finally {
+    isExporting.value = false
+  }
 }
 
 function downloadAssignments() {

--- a/components/coloring/coloring-canvas.vue
+++ b/components/coloring/coloring-canvas.vue
@@ -107,6 +107,10 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { BLANK_COLOR_VALUE } from '@/stores/helpers/coloring'
+import {
+  exportRasterCanvasToBlob,
+  exportSvgPageToBlob,
+} from '@/stores/helpers/coloringExport'
 import { floodFillRgba, hexToRgb } from '@/stores/helpers/floodFill'
 import type {
   ColoringFillOp,
@@ -251,6 +255,23 @@ watch(
 onMounted(() => {
   loadRasterBase()
 })
+
+/** Renders the current page state to a PNG blob (engine-spec section 2.5). */
+async function exportImage(): Promise<Blob> {
+  if (props.page.mode === 'raster-flood') {
+    const canvas = rasterCanvas.value
+    if (!canvas || !rasterReady.value) {
+      throw new Error('Page is still loading')
+    }
+    return exportRasterCanvasToBlob(canvas, props.page.layers.lineArt)
+  }
+
+  return exportSvgPageToBlob(props.page, props.fills, props.paletteResolver, {
+    strokeWidth: props.strokeWidth,
+  })
+}
+
+defineExpose({ exportImage })
 
 const selectedRegions = computed<ColoringRegion[]>(() => {
   if (!props.selectedRegionIds?.length) return []

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -40,6 +40,21 @@
             Reset
           </button>
 
+          <button
+            class="btn btn-sm btn-ghost rounded-xl"
+            type="button"
+            title="Download the colored mural plan as a PNG image"
+            :disabled="isExporting || !pageDefinition"
+            @click="saveImage"
+          >
+            <span
+              v-if="isExporting"
+              class="loading loading-spinner loading-xs"
+            />
+            <Icon v-else name="kind-icon:image" class="h-4 w-4" />
+            Save image
+          </button>
+
           <div
             class="rounded-2xl border border-base-300 bg-base-200 px-3 py-2 text-sm"
           >
@@ -167,6 +182,7 @@
           class="rounded-2xl border border-base-300 bg-base-200 p-3 shadow-inner"
         >
           <coloring-canvas
+            ref="canvasRef"
             :page="pageDefinition"
             :fills="coloringStore.currentPage?.fills ?? {}"
             :selected-region-ids="
@@ -303,6 +319,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useColoringStore } from '@/stores/coloringStore'
 import { loadMuralPageDefinition } from '@/stores/muralStore'
+import { downloadPageBlob } from '@/stores/helpers/coloringExport'
 import { runMuralMigration } from '@/stores/helpers/muralMigration'
 import type {
   ColoringPageDefinition,
@@ -321,6 +338,8 @@ const coloringStore = useColoringStore()
 const pageDefinition = ref<ColoringPageDefinition | null>(null)
 const newColorName = ref('')
 const newColorValue = ref('#55a9b5')
+const canvasRef = ref<{ exportImage: () => Promise<Blob> } | null>(null)
+const isExporting = ref(false)
 
 const activeColorId = computed(
   () => coloringStore.currentPage?.activeColorId ?? null,
@@ -396,6 +415,21 @@ function paintSection(sectionId: string): void {
 function addColor(): void {
   coloringStore.addColor(newColorName.value, newColorValue.value)
   newColorName.value = ''
+}
+
+async function saveImage(): Promise<void> {
+  if (!canvasRef.value || isExporting.value) return
+
+  isExporting.value = true
+
+  try {
+    const blob = await canvasRef.value.exportImage()
+    downloadPageBlob(blob, pageDefinition.value?.id ?? 'mural')
+  } catch (error) {
+    console.warn('[mural] image export failed:', error)
+  } finally {
+    isExporting.value = false
+  }
 }
 
 onMounted(async () => {

--- a/stores/helpers/coloringExport.ts
+++ b/stores/helpers/coloringExport.ts
@@ -1,0 +1,187 @@
+// /stores/helpers/coloringExport.ts
+//
+// Export-to-image for coloring pages, per coloring-engine-spec.md section
+// 2.5. The SVG markup builder is pure (Node-testable); only the blob
+// rasterization touches the DOM.
+
+import { BLANK_COLOR_VALUE } from '@/stores/helpers/coloring'
+import type { ColoringPageDefinition } from '@/stores/helpers/coloring'
+
+function escapeAttr(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+/**
+ * Builds standalone SVG markup for an svg-regions page: white paper,
+ * optional underlay image, filled region paths, decor strokes, optional
+ * lineArt image on top. Image hrefs should already be data URIs when the
+ * output must rasterize offline (see inlineImageAsDataUri).
+ */
+export function buildColoringSvgMarkup(
+  def: ColoringPageDefinition,
+  fills: Record<string, string>,
+  resolveColor: (colorId: string) => string,
+  options: { strokeWidth?: number; imageHrefs?: Record<string, string> } = {},
+): string {
+  const { width, height } = def.viewBox
+  const strokeWidth = options.strokeWidth ?? 3
+  const hrefs = options.imageHrefs ?? {}
+
+  const parts: string[] = [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">`,
+    `<rect width="${width}" height="${height}" fill="#ffffff"/>`,
+  ]
+
+  const underlay = hrefs.underlay ?? def.layers.underlay
+  if (underlay) {
+    parts.push(
+      `<image href="${escapeAttr(underlay)}" x="0" y="0" width="${width}" height="${height}"/>`,
+    )
+  }
+
+  for (const region of def.regions ?? []) {
+    const colorId = fills[region.id]
+    const fill = colorId ? resolveColor(colorId) : BLANK_COLOR_VALUE
+
+    parts.push(
+      `<path d="${escapeAttr(region.d)}" fill="${escapeAttr(fill)}" stroke="#171312" stroke-width="${strokeWidth}" stroke-linejoin="round"/>`,
+    )
+  }
+
+  if (def.layers.decor) {
+    parts.push(
+      `<path d="${escapeAttr(def.layers.decor)}" fill="none" stroke="#171312" stroke-width="4" stroke-linecap="round"/>`,
+    )
+  }
+
+  const lineArt = hrefs.lineArt ?? def.layers.lineArt
+  if (lineArt) {
+    parts.push(
+      `<image href="${escapeAttr(lineArt)}" x="0" y="0" width="${width}" height="${height}"/>`,
+    )
+  }
+
+  parts.push('</svg>')
+  return parts.join('')
+}
+
+/** Fetches an asset and returns it as a data URI (for offline-safe SVG rasterization). */
+export async function inlineImageAsDataUri(src: string): Promise<string> {
+  const response = await fetch(src)
+  const blob = await response.blob()
+
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error(`Could not inline ${src}`))
+    reader.readAsDataURL(blob)
+  })
+}
+
+/**
+ * Rasterizes an svg-regions page to a PNG blob at export scale.
+ * Shareable-quality only — print masters come from the generation pipeline.
+ */
+export async function exportSvgPageToBlob(
+  def: ColoringPageDefinition,
+  fills: Record<string, string>,
+  resolveColor: (colorId: string) => string,
+  options: { scale?: number; strokeWidth?: number } = {},
+): Promise<Blob> {
+  const scale = options.scale ?? 2
+
+  const imageHrefs: Record<string, string> = {}
+  if (def.layers.underlay) {
+    imageHrefs.underlay = await inlineImageAsDataUri(def.layers.underlay)
+  }
+  if (def.layers.lineArt) {
+    imageHrefs.lineArt = await inlineImageAsDataUri(def.layers.lineArt)
+  }
+
+  const markup = buildColoringSvgMarkup(def, fills, resolveColor, {
+    strokeWidth: options.strokeWidth,
+    imageHrefs,
+  })
+
+  const svgBlob = new Blob([markup], { type: 'image/svg+xml' })
+  const url = URL.createObjectURL(svgBlob)
+
+  try {
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image()
+      el.onload = () => resolve(el)
+      el.onerror = () => reject(new Error('Could not render page SVG'))
+      el.src = url
+    })
+
+    const canvas = document.createElement('canvas')
+    canvas.width = def.viewBox.width * scale
+    canvas.height = def.viewBox.height * scale
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Canvas 2D unavailable')
+
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Export failed'))),
+        'image/png',
+      )
+    })
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+/**
+ * Rasterizes a raster-flood page: the working canvas already is the image;
+ * composite the optional lineArt layer above and export.
+ */
+export async function exportRasterCanvasToBlob(
+  workingCanvas: HTMLCanvasElement,
+  lineArtSrc?: string,
+): Promise<Blob> {
+  const canvas = document.createElement('canvas')
+  canvas.width = workingCanvas.width
+  canvas.height = workingCanvas.height
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D unavailable')
+
+  ctx.drawImage(workingCanvas, 0, 0)
+
+  if (lineArtSrc) {
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image()
+      el.crossOrigin = 'anonymous'
+      el.onload = () => resolve(el)
+      el.onerror = () => reject(new Error('Could not load line art'))
+      el.src = lineArtSrc
+    })
+
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
+  }
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('Export failed'))),
+      'image/png',
+    )
+  })
+}
+
+/** Triggers a browser download for an exported page blob. */
+export function downloadPageBlob(blob: Blob, pageId: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+
+  link.href = url
+  link.download = `${pageId.replace('/', '-')}.png`
+  link.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
### Task
coloring-book/t-017, step 8 — the final mural-migration item (kind: software)

### What changed / what I produced
- **`stores/helpers/coloringExport.ts`** — `buildColoringSvgMarkup` (pure and Node-testable: white paper, optional underlay, filled region paths, decor strokes, optional lineArt), `inlineImageAsDataUri` for offline-safe rasterization, `exportSvgPageToBlob` (offscreen canvas at 2× viewBox scale → PNG; print masters still come from the generation pipeline, per spec), `exportRasterCanvasToBlob` (working canvas + lineArt composite), and `downloadPageBlob`.
- **ColoringCanvas** exposes `exportImage()` covering both svg-regions and raster-flood modes.
- **Save-image buttons** in the mural header and the coloring book toolbar, with busy states. The coloring book keeps its assignment-JSON "Save file" alongside.

### How I verified
- 12-case Node run of the SVG builder against the **real** mural page definition: all 20 regions + decor emitted, default/override/custom/blank fill resolution, stroke width honored, attribute escaping, balanced markup — plus a strict `xml.etree` parse of the emitted document.
- eslint + prettier + `npm test` (vue-tsc): clean, zero new errors.
- The blob/canvas rasterization path is DOM-only, so it's type-checked rather than executed; the markup it feeds the canvas is the verified part.

### Stakes
reversible

### Flags for Reviewer
- With this, **t-017 is complete** — the engine-spec's 10-step migration section is fully executed (steps 1–3 in #144, 4 in #147, 5 in #148, 6–7 in #149, 8 here; step 9 raster mode landed early in #146; step 10 was the #144 surface).

### Kaizen suggestion
The export helper is the natural home for a future "share to gallery" action (upload the blob via artStore instead of downloading).

### Notes for reviewer
Cycle 4 work pulled forward at Silas's "keep going."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB)_