### PR TITLE
mana: manaGate.commit now writes ManaTransaction ledger rows (t-012 part 1)

### DIFF
--- a/server/utils/manaGate.ts
+++ b/server/utils/manaGate.ts
@@ -2,6 +2,8 @@
 import { createError, type H3Event } from 'h3'
 import prisma from './prisma'
 import { requireApiUser } from './authGuard'
+import { applyMana } from './mana'
+import type { ManaReason } from './mana'
 
 type ManaGateKind = 'text' | 'art' | 'video' | 'model' | 'free'
 
@@ -27,6 +29,15 @@ type ManaGateResult = {
 }
 
 const MANA_PER_USD = 1000
+
+// video/model spends land under GENERATION_ART until the enum grows
+// dedicated reasons (additive migration — separate task).
+const REASON_BY_KIND: Record<Exclude<ManaGateKind, 'free'>, ManaReason> = {
+  text: 'GENERATION_TEXT',
+  art: 'GENERATION_ART',
+  video: 'GENERATION_ART',
+  model: 'GENERATION_ART',
+}
 
 export async function manaGate(
   event: H3Event,
@@ -79,29 +90,26 @@ export async function manaGate(
     user,
     cost,
     free,
-    commit: async (_refId: string, _providerCostUsd?: number) => {
+    commit: async (refId: string, providerCostUsd?: number) => {
       if (cost <= 0) {
         return {
           balance,
         }
       }
 
-      const updated = await prisma.user.update({
-        where: {
-          id: user.id,
-        },
-        data: {
-          mana: {
-            decrement: cost,
-          },
-        },
-        select: {
-          mana: true,
-        },
+      // Atomic debit + ManaTransaction ledger row (applyMana re-checks the
+      // balance inside the transaction, closing the check-then-spend race).
+      const result = await applyMana({
+        userId: user.id,
+        amount: -cost,
+        reason:
+          input.kind === 'free' ? 'ADJUSTMENT' : REASON_BY_KIND[input.kind],
+        refId,
+        costUsd: providerCostUsd ?? input.estCostUsd,
       })
 
       return {
-        balance: updated.mana ?? 0,
+        balance: result.balance,
       }
     },
   }


### PR DESCRIPTION
### Task
kind-robots/t-012, part 1 ONLY — ledger writes; no webhook, no Stripe, no schema changes (kind: software)

### What changed / what I produced
- `manaGate.commit()` now delegates to the existing `applyMana` helper instead of a bare `prisma.user.update` decrement. Every paid generation now produces a **ManaTransaction ledger row** (amount, reason, balanceAfter snapshot, refId, cost) in the same atomic transaction as the debit — which also closes the check-then-spend race, since `applyMana` re-validates the balance inside the transaction.
- Reason mapping: `text` → `GENERATION_TEXT`, `art`/`video`/`model` → `GENERATION_ART` (dedicated enum values would need an additive migration — left as a follow-up note, not done here).
- The previously-ignored `commit(refId, providerCostUsd)` arguments are now used; all 13 gate call sites already pass refIds (e.g. `sdxl:<artId>`), so statements are traceable immediately.

### How I verified
- eslint + prettier + `npm test` (vue-tsc): clean, zero new errors.
- Enum values checked against `prisma/schema.prisma`; `applyMana`'s transaction/ledger behavior read line-by-line; call sites spot-checked for refId format.
- Not exercised against a live DB in this environment — `applyMana` is the same code path the daily refill and signup bonus already use in production.

### Stakes
reversible

### Flags for Reviewer
- The `/api/mana/[id]` statement endpoint will now actually show generation debits — previously it could only ever show credits/refills.
- Pushed via the GitHub API on a fresh branch (`claude/mana-ledger-t012-part1`) because the session's git proxy was returning 500s on push; the change is this single file.

### Kaizen suggestion
t-012 part 2 (test-mode Stripe webhook crediting PURCHASE transactions) is now a clean follow-up since the ledger side is proven.

### Notes for reviewer
Continuation of the rush session at Silas's "keep going."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Hfd7baT5WXFAk5AJ7YmB)_