### PR TITLE
fix(api): honor page/pageSize in GET /api/bots

### DIFF
--- a/server/api/bots/index.get.ts
+++ b/server/api/bots/index.get.ts
@@ -1,12 +1,15 @@
 // /server/api/bots/index.get.ts
-import { defineEventHandler } from 'h3'
+import { defineEventHandler, getQuery } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 
 export default defineEventHandler(async (event) => {
   try {
-    const page = Number(event.context.query?.page) || 1
-    const pageSize = Number(event.context.query?.pageSize) || 100
+    // event.context.query is never populated in Nitro, so page/pageSize were
+    // silently stuck at 1/100 — every caller got only the first 100 bots.
+    const query = getQuery(event)
+    const page = Number(query.page) || 1
+    const pageSize = Number(query.pageSize) || 100
 
     // Fetch bots with pagination
     const skip = (page - 1) * pageSize


### PR DESCRIPTION
### Task
Found during kind-robots/t-011's first live run: `GET /api/bots` ignores its paging params, capping every caller at the first 100 bots (kind: software)

### What changed / what I produced
- `server/api/bots/index.get.ts` reads `page`/`pageSize` via `getQuery(event)` instead of `event.context.query`, which Nitro never populates — so `page` was silently stuck at 1 and `pageSize` at 100 for every request, regardless of what the caller passed. The dreams endpoint already uses `getQuery`; this matches it.

### How I verified
- Grepped the server tree: this was the only `event.context.query` usage
- Checked callers: the lone app caller (`stores/helpers/botHelper.ts`) passes no params, so its behavior is unchanged (still defaults to page 1 / 100); the conductor reconcile script is the caller that needs working pagination

### Stakes
reversible

### Flags for Reviewer
- Side observation, not changed here: since the app's bot fetch defaults to the first 100 and there are 400+ bots, the bot gallery likely never shows the full roster. Worth a small follow-up task (paginate or raise the store's fetch size) if that's not intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XiYez6WVbMLN2GDMAV1rC

---
_Generated by [Claude Code](https://claude.ai/code/session_019XiYez6WVbMLN2GDMAV1rC)_