### PR TITLE
fix: test users now actually delete — admin cleanup + owned-data purge

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -213,7 +213,9 @@ const deleteSeedUser = async (apiBase: string, adminKey: string, user: SeedUser)
     label: `seed user ${user.id}`,
     userId: user.id,
     status: response.status,
-    ok: [200, 202, 204, 401, 403, 404].includes(response.status),
+    // 401/403 used to count as "ok", which hid the fact that seed users were
+    // never actually deleted. Only success or already-gone counts now.
+    ok: [200, 202, 204, 404].includes(response.status),
     body: await parseResponseBody(response),
   }
 }
@@ -230,7 +232,7 @@ const runCleanupRequest = async (request: CleanupRequest) => {
     },
     body: request.body === undefined ? undefined : JSON.stringify(request.body),
   })
-  const expectedStatuses = request.expectedStatuses || [200, 202, 204, 401, 403, 404]
+  const expectedStatuses = request.expectedStatuses || [200, 202, 204, 404]
 
   return {
     label: request.label,
@@ -491,7 +493,7 @@ export default defineConfig({
           if (!cleanupRequests.some((item) => cleanupKey(item) === key)) {
             cleanupRequests.push({
               method: 'DELETE',
-              expectedStatuses: [200, 202, 204, 401, 403, 404],
+              expectedStatuses: [200, 202, 204, 404],
               ...request,
             })
           }

--- a/cypress/support/api-auth.ts
+++ b/cypress/support/api-auth.ts
@@ -193,11 +193,20 @@ export const deleteTestUser = (apiBase: string, adminToken: string, userId?: num
   return cy.task<boolean>('cypressSeed:isSeedUser', userId).then((isSeedUser) => {
     if (isSeedUser) return null
 
-    return cy.request({
-      method: 'DELETE',
-      url: `${apiBase}/users/${userId}`,
-      headers: adminHeaders(adminToken),
-      failOnStatusCode: false,
-    })
+    return cy
+      .request({
+        method: 'DELETE',
+        url: `${apiBase}/users/${userId}`,
+        headers: adminHeaders(adminToken),
+        failOnStatusCode: false,
+      })
+      .then((response) => {
+        // Cleanup must actually clean up: a leaked test user is a real
+        // failure, not something to swallow silently.
+        expect(
+          response.status,
+          `delete test user ${userId}: ${JSON.stringify(response.body)}`,
+        ).to.be.oneOf([200, 404])
+      })
   })
 }

--- a/scripts/cleanup-test-users.mjs
+++ b/scripts/cleanup-test-users.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// scripts/cleanup-test-users.mjs
+//
+// One-time (or occasional) sweep for leaked cypress/test users. These piled up
+// because DELETE /api/users/:id only allowed self-deletion (admin cleanup got
+// a silent 403) and because residual owned rows (art collections, ledger rows,
+// reactions, ...) RESTRICT the delete. Both are fixed server-side; this script
+// clears the backlog through the fixed endpoint, one user at a time.
+//
+// DRY RUN by default — prints what it would delete. Pass --delete to execute.
+//
+// Usage:
+//   BASE_API_URL=https://kind-robots.vercel.app/api ADMIN_TOKEN=... \
+//     node scripts/cleanup-test-users.mjs [--delete] [--limit N]
+//
+// Env: BASE_API_URL (default https://kind-robots.vercel.app/api)
+//      ADMIN_TOKEN or BETA_ADMIN_TOKEN or API_KEY (required)
+
+const apiBase = String(
+  process.env.BASE_API_URL || 'https://kind-robots.vercel.app/api',
+).replace(/\/+$/, '')
+
+const adminToken = String(
+  process.env.ADMIN_TOKEN ||
+    process.env.BETA_ADMIN_TOKEN ||
+    process.env.API_KEY ||
+    '',
+)
+
+const doDelete = process.argv.includes('--delete')
+const limitFlagIndex = process.argv.indexOf('--limit')
+const limit =
+  limitFlagIndex !== -1 ? Number(process.argv[limitFlagIndex + 1]) : Infinity
+
+// Usernames produced by the cypress suites:
+//   cypress-user-<ts>-<rand>          (createFreshLoggedInTestUser)
+//   cypress-primary|second|third-<id> (per-run seed users)
+//   testuser<ts>                      (users.cy.ts registration spec)
+const testUserPattern = /^(cypress-(user|primary|second|third)-|testuser\d+$)/i
+
+// Never touch admins or low-id system accounts (id 10 is the default owner
+// for orphaned content) no matter what their username looks like.
+const isProtected = (user) =>
+  user.id <= 10 || String(user.Role || '').toUpperCase() === 'ADMIN'
+
+const headers = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+  'x-beta-admin-token': adminToken,
+  'x-admin-token': adminToken,
+  'x-api-key': adminToken,
+}
+
+const readJson = async (response) => {
+  const text = await response.text()
+  try {
+    return text ? JSON.parse(text) : {}
+  } catch {
+    return { message: text }
+  }
+}
+
+const main = async () => {
+  if (!adminToken) {
+    console.error('Missing ADMIN_TOKEN / BETA_ADMIN_TOKEN / API_KEY env var.')
+    process.exit(1)
+  }
+
+  const listResponse = await fetch(`${apiBase}/users`, { headers })
+  const listBody = await readJson(listResponse)
+
+  if (!listResponse.ok || !Array.isArray(listBody?.data)) {
+    console.error(`Failed to list users: ${listResponse.status}`, listBody)
+    process.exit(1)
+  }
+
+  const candidates = listBody.data
+    .filter(
+      (user) =>
+        Number.isInteger(user?.id) && typeof user?.username === 'string',
+    )
+    .filter((user) => testUserPattern.test(user.username))
+    .filter((user) => !isProtected(user))
+    .slice(0, Number.isFinite(limit) && limit > 0 ? limit : undefined)
+
+  console.log(
+    `${listBody.data.length} users total, ${candidates.length} matching test-user patterns${
+      doDelete ? '' : ' (dry run — pass --delete to remove them)'
+    }`,
+  )
+
+  let deleted = 0
+  let failed = 0
+
+  for (const user of candidates) {
+    if (!doDelete) {
+      console.log(
+        `  would delete ${user.id} ${user.username} (created ${user.createdAt})`,
+      )
+      continue
+    }
+
+    const response = await fetch(`${apiBase}/users/${user.id}`, {
+      method: 'DELETE',
+      headers,
+    })
+    const body = await readJson(response)
+
+    if (response.ok && body?.success) {
+      deleted += 1
+      const purged = body?.data?.purged
+      const purgedNote =
+        purged && Object.keys(purged).length > 0
+          ? ` purged=${JSON.stringify(purged)}`
+          : ''
+      console.log(`  deleted ${user.id} ${user.username}${purgedNote}`)
+    } else {
+      failed += 1
+      console.error(
+        `  FAILED ${user.id} ${user.username}: ${response.status} ${body?.message || ''}`,
+      )
+    }
+  }
+
+  if (doDelete) {
+    console.log(`Done: ${deleted} deleted, ${failed} failed.`)
+    if (failed > 0) process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/server/api/users/[id].delete.ts
+++ b/server/api/users/[id].delete.ts
@@ -3,6 +3,8 @@ import { defineEventHandler, createError } from 'h3'
 import { errorHandler } from '../../utils/error'
 import prisma from '../../utils/prisma'
 import { validateApiKey } from '../../utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
+import { deleteUserWithOwnedData } from '../../utils/userPurge'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -15,39 +17,51 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Validate API key using the utility function
+    // A user may delete themselves; an admin (or the beta admin token) may
+    // delete any non-admin account. This is what lets test cleanup, which
+    // authenticates with the admin token, actually remove disposable users.
     const { isValid, user } = await validateApiKey(event)
     const requestingUserId = user?.id
+    const isSelf = requestingUserId === targetUserId
+    const isAdmin = Boolean(
+      user && userIsAdmin({ id: user.id, Role: user.Role }),
+    )
 
-    // Check if the API key is valid and if the requesting user matches the target user
-    if (!isValid || requestingUserId !== targetUserId) {
+    if (!isValid || (!isSelf && !isAdmin)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to delete this user.',
       })
     }
 
-    // Verify the target user exists before attempting deletion
-    const userExists = await prisma.user.findUnique({
+    const targetUser = await prisma.user.findUnique({
       where: { id: targetUserId },
-      select: { id: true },
+      select: { id: true, Role: true },
     })
 
-    if (!userExists) {
+    if (!targetUser) {
       throw createError({
         statusCode: 404,
         message: `User with ID ${targetUserId} not found.`,
       })
     }
 
-    // Attempt to delete the user
-    await prisma.user.delete({ where: { id: targetUserId } })
+    if (!isSelf && userIsAdmin(targetUser)) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin accounts can only be deleted by themselves.',
+      })
+    }
 
-    // Successful deletion response
+    // Delete the user plus every owned row that would otherwise RESTRICT the
+    // delete (collections, ledger rows, reactions, relations, ...).
+    const purged = await deleteUserWithOwnedData(targetUserId)
+
     event.node.res.statusCode = 200
     return {
       success: true,
       message: `User with ID ${targetUserId} successfully deleted.`,
+      data: { purged },
     }
   } catch (error: unknown) {
     const handledError = errorHandler(error)

--- a/server/utils/userPurge.ts
+++ b/server/utils/userPurge.ts
@@ -1,0 +1,86 @@
+// /server/utils/userPurge.ts
+import prisma from './prisma'
+
+export type UserPurgeCounts = Record<string, number>
+
+// Deletes a user together with every owned row that would otherwise block the
+// delete. Required relations with no explicit onDelete rule (ArtCollection,
+// Character, Dream, Scenario, SocialPost, Challenge, Reaction, UserRelation,
+// Referral, ManaTransaction, KarmaTransaction, MilestoneRecord) default to
+// ON DELETE RESTRICT in MySQL, so a user who still owns any of those rows can
+// never be deleted — that is how residual test fixtures piled up ~1000
+// undeletable cypress users. ArtImages are optional (SET NULL) and would not
+// block, but they are deleted too so an account wipe doesn't strand orphaned
+// image rows.
+export async function deleteUserWithOwnedData(
+  userId: number,
+): Promise<UserPurgeCounts> {
+  return prisma.$transaction(
+    async (tx) => {
+      const counts: UserPurgeCounts = {}
+      const track = (label: string, result: { count: number }) => {
+        if (result.count > 0) counts[label] = result.count
+      }
+
+      track(
+        'userRelations',
+        await tx.userRelation.deleteMany({
+          where: { OR: [{ userId }, { relatedUserId: userId }] },
+        }),
+      )
+      track(
+        'referrals',
+        await tx.referral.deleteMany({
+          where: { OR: [{ referrerId: userId }, { referredId: userId }] },
+        }),
+      )
+      track('reactions', await tx.reaction.deleteMany({ where: { userId } }))
+
+      // ChallengeSubmission -> Challenge is RESTRICT: clear submissions on the
+      // user's challenges before the challenges themselves.
+      const challenges = await tx.challenge.findMany({
+        where: { userId },
+        select: { id: true },
+      })
+      if (challenges.length > 0) {
+        track(
+          'challengeSubmissions',
+          await tx.challengeSubmission.deleteMany({
+            where: { challengeId: { in: challenges.map((c) => c.id) } },
+          }),
+        )
+      }
+      track('challenges', await tx.challenge.deleteMany({ where: { userId } }))
+
+      track(
+        'artCollections',
+        await tx.artCollection.deleteMany({ where: { userId } }),
+      )
+      track('dreams', await tx.dream.deleteMany({ where: { userId } }))
+      track('characters', await tx.character.deleteMany({ where: { userId } }))
+      track('scenarios', await tx.scenario.deleteMany({ where: { userId } }))
+      track(
+        'socialPosts',
+        await tx.socialPost.deleteMany({ where: { userId } }),
+      )
+      track('artImages', await tx.artImage.deleteMany({ where: { userId } }))
+      track(
+        'manaTransactions',
+        await tx.manaTransaction.deleteMany({ where: { userId } }),
+      )
+      track(
+        'karmaTransactions',
+        await tx.karmaTransaction.deleteMany({ where: { userId } }),
+      )
+      track(
+        'milestoneRecords',
+        await tx.milestoneRecord.deleteMany({ where: { userId } }),
+      )
+
+      await tx.user.delete({ where: { id: userId } })
+
+      return counts
+    },
+    { timeout: 30000 },
+  )
+}


### PR DESCRIPTION
### Task
Silas-directed session task: test users and their art/code assets weren't deleting, leaving ~1000 undeletable cypress users in the database. (kind: software)

### What changed
Three stacked root causes, all fixed:

1. **`DELETE /api/users/:id` only allowed self-deletion.** Every test-cleanup path (`deleteTestUser`, `deleteSeedUser`) authenticates with the admin token, which resolves to the beta-admin user — so cleanup got a 403 on every call. The endpoint now also allows admins (or the beta admin token) to delete **non-admin** users; admins can only ever delete themselves.
2. **Cleanup treated 401/403 as success.** `cypress.config.ts` counted them as "ok" and `deleteTestUser` swallowed all failures, so the leak was invisible. 401/403 no longer count, and `deleteTestUser` now asserts the delete landed (200/404).
3. **Residual owned rows made users permanently undeletable.** A dozen required relations (ArtCollection, Character, Dream, Scenario, SocialPost, Challenge, Reaction, UserRelation, Referral, ManaTransaction, KarmaTransaction, MilestoneRecord) have no `onDelete` rule → MySQL `RESTRICT`. New `server/utils/userPurge.ts` deletes those rows (plus the user's ArtImages, so wipes don't strand orphans) in one transaction before deleting the user, and the endpoint returns per-table purge counts. Note: the new mana ledger (PR #151) would have made this worse — every debit is now a RESTRICT row.

Also adds `scripts/cleanup-test-users.mjs` to clear the existing backlog: **dry-run by default**, `--delete` to execute, only touches usernames matching cypress/test patterns, never touches ADMIN-role accounts or ids ≤ 10, exits non-zero if any delete fails.

### How I verified
- `npm run test` (vue-tsc typecheck) passes; eslint + prettier clean on all touched files (two pre-existing chai-expression lint errors in `api-auth.ts` left as-is).
- Cleanup script exercised end-to-end against a local mock API: dry-run deletes nothing; delete-run skips admin/system/trap accounts, reports per-user purge counts, and exits 1 on a simulated failure.
- Could not hit the live API from the session sandbox (network policy blocks the host), so the endpoint change itself is verified by review + types only.

### Stakes
reversible (code only, no migration; deletion stays gated behind self-auth or the admin token)

### Flags for Reviewer
- Merging deploys to prod: the endpoint's behavior changes from "delete bare user row" to "delete user + owned rows". That is what account deletion should mean here, but worth a conscious nod.
- The purge list is hand-maintained; if a future model adds a required `User` relation without `onDelete`, deletes will 500 again (now loudly, not silently). A schema pass adding explicit `onDelete` rules would remove that drift risk.

### After merge + deploy (runbook for Silas)
```
BASE_API_URL=https://kind-robots.vercel.app/api ADMIN_TOKEN=<token> node scripts/cleanup-test-users.mjs           # dry run, prints candidates
BASE_API_URL=https://kind-robots.vercel.app/api ADMIN_TOKEN=<token> node scripts/cleanup-test-users.mjs --delete  # clears the backlog
```

### Kaizen suggestion
Add explicit `onDelete` rules to the schema (Cascade for owned content, SetNull where orphaning is intended) so user deletion is enforced by the database instead of a hand-maintained purge list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2V9FYENKhQW4gNGmXMvyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2V9FYENKhQW4gNGmXMvyB)_