### PR TITLE
schema: explicit onDelete rules — orphan content, cascade user-scoped rows

### DIFF
--- a/prisma/migrations/20260710200000_explicit_user_ondelete_rules/migration.sql
+++ b/prisma/migrations/20260710200000_explicit_user_ondelete_rules/migration.sql
@@ -1,0 +1,111 @@
+-- DropForeignKey
+ALTER TABLE `ArtCollection` DROP FOREIGN KEY `ArtCollection_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Character` DROP FOREIGN KEY `Character_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Code` DROP FOREIGN KEY `Code_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Dream` DROP FOREIGN KEY `Dream_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `ManaTransaction` DROP FOREIGN KEY `ManaTransaction_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `MilestoneRecord` DROP FOREIGN KEY `MilestoneRecord_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Reaction` DROP FOREIGN KEY `Reaction_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Scenario` DROP FOREIGN KEY `Scenario_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `SocialPost` DROP FOREIGN KEY `SocialPost_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `KarmaTransaction` DROP FOREIGN KEY `KarmaTransaction_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Referral` DROP FOREIGN KEY `Referral_referrerId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Referral` DROP FOREIGN KEY `Referral_referredId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `UserRelation` DROP FOREIGN KEY `UserRelation_userId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `UserRelation` DROP FOREIGN KEY `UserRelation_relatedUserId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `Challenge` DROP FOREIGN KEY `Challenge_userId_fkey`;
+
+-- AlterTable
+ALTER TABLE `ArtCollection` MODIFY `userId` INTEGER NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE `Character` MODIFY `userId` INTEGER NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE `Code` MODIFY `userId` INTEGER NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE `Dream` MODIFY `userId` INTEGER NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE `Scenario` MODIFY `userId` INTEGER NULL;
+
+-- AlterTable
+ALTER TABLE `SocialPost` MODIFY `userId` INTEGER NULL;
+
+-- AlterTable
+ALTER TABLE `Challenge` MODIFY `userId` INTEGER NULL DEFAULT 10;
+
+-- AddForeignKey
+ALTER TABLE `ArtCollection` ADD CONSTRAINT `ArtCollection_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Character` ADD CONSTRAINT `Character_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Code` ADD CONSTRAINT `Code_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Dream` ADD CONSTRAINT `Dream_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ManaTransaction` ADD CONSTRAINT `ManaTransaction_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `MilestoneRecord` ADD CONSTRAINT `MilestoneRecord_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Reaction` ADD CONSTRAINT `Reaction_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Scenario` ADD CONSTRAINT `Scenario_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `SocialPost` ADD CONSTRAINT `SocialPost_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `KarmaTransaction` ADD CONSTRAINT `KarmaTransaction_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Referral` ADD CONSTRAINT `Referral_referrerId_fkey` FOREIGN KEY (`referrerId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Referral` ADD CONSTRAINT `Referral_referredId_fkey` FOREIGN KEY (`referredId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserRelation` ADD CONSTRAINT `UserRelation_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserRelation` ADD CONSTRAINT `UserRelation_relatedUserId_fkey` FOREIGN KEY (`relatedUserId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Challenge` ADD CONSTRAINT `Challenge_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,7 +51,7 @@ model ArtImage {
   CheckpointResource Resource?        @relation("ArtImageCheckpointResource", fields: [checkpointResourceId], references: [id])
   Server             Server?          @relation("ArtImageGeneratorServer", fields: [serverId], references: [id])
 
-  User                 User?                 @relation("ArtImageCreator", fields: [userId], references: [id])
+  User                 User?                 @relation("ArtImageCreator", fields: [userId], references: [id], onDelete: SetNull)
   Bots                 Bot[]
   Characters           Character[]
   Chats                Chat[]
@@ -86,7 +86,7 @@ model ArtCollection {
   id            Int        @id @default(autoincrement())
   createdAt     DateTime   @default(now())
   updatedAt     DateTime?  @default(now()) @updatedAt
-  userId        Int        @default(10)
+  userId        Int?       @default(10)
   label         String?
   slug          String?    @unique @db.VarChar(255)
   // Parent path under public/images/ that contains this collection's folder, so
@@ -102,7 +102,7 @@ model ArtCollection {
   username      String?
   isActive      Boolean    @default(true)
   artPrompt     String?    @db.Text
-  User          User       @relation(fields: [userId], references: [id])
+  User          User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
   DreamsPrimary Dream[]    @relation("DreamPrimaryArtCollection")
   Dreams        Dream[]    @relation("DreamToArtCollection")
   Reactions     Reaction[]
@@ -148,7 +148,7 @@ model Bot {
   artPrompt            String?                @db.Text
   ArtImage             ArtImage?              @relation(fields: [artImageId], references: [id])
   Server               Server?                @relation(fields: [serverId], references: [id])
-  User                 User?                  @relation(fields: [userId], references: [id])
+  User                 User?                  @relation(fields: [userId], references: [id], onDelete: SetNull)
   chatBorderImage      String?                @db.VarChar(764)
   NarratorThreads      NarratorThread[]
   Chats                Chat[]
@@ -184,7 +184,7 @@ model Character {
   genre                String?                @db.VarChar(256)
   artImageId           Int?
   isPublic             Boolean                @default(true)
-  userId               Int                    @default(10)
+  userId               Int?                   @default(10)
   artPrompt            String?                @db.Text
   honorific            String?                @default("adventurer") @db.VarChar(256)
   imagePath            String?                @db.VarChar(764)
@@ -203,7 +203,7 @@ model Character {
   wits                 Rarity                 @default(COMMON)
   gender               String?                @db.VarChar(256)
   ArtImage             ArtImage?              @relation(fields: [artImageId], references: [id])
-  User                 User                   @relation(fields: [userId], references: [id])
+  User                 User?                  @relation(fields: [userId], references: [id], onDelete: SetNull)
   Chats                Chat[]
   Reactions            Reaction[]
   ChallengeSubmissions ChallengeSubmission[]
@@ -261,7 +261,7 @@ model Chat {
   Dream           Dream?     @relation(fields: [dreamId], references: [id])
   Prompt          Prompt?    @relation(fields: [promptId], references: [id])
   Server          Server?    @relation(fields: [serverId], references: [id])
-  User            User?      @relation(fields: [userId], references: [id])
+  User            User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
   Reactions       Reaction[]
 
   LifeChoices LifeChoice[]
@@ -282,7 +282,7 @@ model Code {
   id          Int      @id @default(autoincrement())
   createdAt   DateTime @default(now())
   updatedAt   DateTime @default(now()) @updatedAt
-  userId      Int      @default(10)
+  userId      Int?     @default(10)
   title       String
   description String?  @db.Text
   icon        String?
@@ -291,7 +291,7 @@ model Code {
   isOfficial  Boolean  @default(false)
   isActive    Boolean  @default(true)
   isMature    Boolean  @default(false)
-  User        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  User        User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([userId])
   @@index([isPublic])
@@ -359,7 +359,7 @@ model Composition {
   bountyId       Int? // Prompt id of the bounty this wish settles against (plain column by design)
   // ── Relations ───────────────────────────────────────────────────────────────────────────────────────────
   userId         Int?
-  User           User?             @relation(fields: [userId], references: [id])
+  User           User?             @relation(fields: [userId], references: [id], onDelete: SetNull)
   artImageId     Int?              @unique
   ArtImage       ArtImage?         @relation(fields: [artImageId], references: [id])
   outputDreamId  Int?              @unique // the Dream this wish spawned (distinct from ingredient dreamId)
@@ -412,7 +412,7 @@ model Dream {
   designer          String?         @db.VarChar(256)
   creationSource    CreationSource  @default(HUMAN)
   // ── Flags ──────────────────────────────────────────────────────────────────────────────────
-  userId            Int             @default(10)
+  userId            Int?            @default(10)
   isPublic          Boolean         @default(true)
   isMature          Boolean         @default(false)
   isActive          Boolean         @default(true)
@@ -420,7 +420,7 @@ model Dream {
   artImageId        Int?
   artCollectionId   Int?
   // ── Relations ───────────────────────────────────────────────────────────────────────────────────────────
-  User              User            @relation(fields: [userId], references: [id])
+  User              User?           @relation(fields: [userId], references: [id], onDelete: SetNull)
   ArtImage          ArtImage?       @relation("DreamPrimaryArtImage", fields: [artImageId], references: [id])
   ArtCollection     ArtCollection?  @relation("DreamPrimaryArtCollection", fields: [artCollectionId], references: [id])
   Scenarios         Scenario[]      @relation("DreamToScenario")
@@ -606,7 +606,7 @@ model Log {
   timestamp DateTime @db.DateTime(0)
   username  String?  @db.VarChar(764)
   userId    Int?
-  User      User?    @relation(fields: [userId], references: [id])
+  User      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([userId], map: "Log_userId_fkey")
 }
@@ -666,7 +666,7 @@ model ManaTransaction {
   provider     String? // "openai" | "anthropic" | "local" | "byok"
   costUsd      Float? // real/estimated cost for reconciliation
   reversedById Int? // points at the txn that reversed this one
-  User         User       @relation(fields: [userId], references: [id])
+  User         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
 }
@@ -681,7 +681,7 @@ model MilestoneRecord {
   userId      Int
   isConfirmed Boolean   @default(false)
   Milestones  Milestone @relation(fields: [milestoneId], references: [id])
-  User        User      @relation(fields: [userId], references: [id])
+  User        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   LifeAchievementUnlocks LifeAchievementUnlock[]
 
@@ -777,7 +777,7 @@ model PitchSheet {
   extraData Json?
 
   userId Int?
-  User   User? @relation(fields: [userId], references: [id])
+  User   User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   isPublic Boolean @default(true)
   isActive Boolean @default(true)
@@ -824,9 +824,9 @@ model Prompt {
   Chats          Chat[]
   ArtImage       ArtImage?      @relation(fields: [artImageId], references: [id])
   Bot            Bot?           @relation(fields: [botId], references: [id])
-  User           User?          @relation("PromptUser", fields: [userId], references: [id])
+  User           User?          @relation("PromptUser", fields: [userId], references: [id], onDelete: SetNull)
   Server         Server?        @relation("PromptServer", fields: [serverId], references: [id])
-  Claimer        User?          @relation("PromptClaimer", fields: [claimerId], references: [id])
+  Claimer        User?          @relation("PromptClaimer", fields: [claimerId], references: [id], onDelete: SetNull)
   Reactions      Reaction[]
 
   @@index([userId], map: "Prompt_userId_fkey")
@@ -876,7 +876,7 @@ model Reaction {
   Scenario              Scenario?                 @relation(fields: [scenarioId], references: [id])
   Theme                 Theme?                    @relation(fields: [themeId], references: [id])
   ChallengeSubmission   ChallengeSubmission?      @relation(fields: [challengeSubmissionId], references: [id])
-  User                  User                      @relation(fields: [userId], references: [id])
+  User                  User                      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   // One reaction per user per challenge submission: legitimate one-user-one-vote.
   // MySQL permits multiple NULLs here, so other reaction categories are unaffected.
@@ -927,7 +927,7 @@ model Resource {
   UsedInImages    ArtImage[]      @relation("ArtImageLoraResources")
   Reactions       Reaction[]
   ArtImage        ArtImage?       @relation("ResourcePreviewImage", fields: [artImageId], references: [id])
-  User            User?           @relation(fields: [userId], references: [id])
+  User            User?           @relation(fields: [userId], references: [id], onDelete: SetNull)
   Servers         Server[]        @relation("ResourceToServer")
 
   @@index([userId], map: "Resource_userId_fkey")
@@ -960,7 +960,7 @@ model Reward {
   isActive     Boolean       @default(true)
   Reactions    Reaction[]
   ArtImage     ArtImage?     @relation(fields: [artImageId], references: [id])
-  User         User?         @relation(fields: [userId], references: [id])
+  User         User?         @relation(fields: [userId], references: [id], onDelete: SetNull)
   Characters   Character[]   @relation("CharacterToReward")
   Dreams       Dream[]       @relation("DreamToReward")
   Compositions Composition[]
@@ -981,7 +981,7 @@ model Scenario {
   slug                 String?               @unique @db.VarChar(255)
   description          String                @db.Text
   intros               String                @db.Text
-  userId               Int
+  userId               Int?
   artImageId           Int?
   imagePath            String?
   locations            String?               @db.Text
@@ -1000,7 +1000,7 @@ model Scenario {
   Reactions            Reaction[]
   ChallengeSubmissions ChallengeSubmission[]
   ArtImage             ArtImage?             @relation(fields: [artImageId], references: [id])
-  User                 User                  @relation(fields: [userId], references: [id])
+  User                 User?                 @relation(fields: [userId], references: [id], onDelete: SetNull)
   Characters           Character[]           @relation("CharacterToScenario")
   Compositions         Composition[]
   outputType           ScenarioOutputType    @default(STORY)
@@ -1095,7 +1095,7 @@ model SmartIcon {
   category    String?   @db.VarChar(255)
   modelType   String?   @db.VarChar(255)
   isMature    Boolean   @default(false)
-  User        User?     @relation(fields: [userId], references: [id])
+  User        User?     @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([userId], map: "SmartIcon_userId_fkey")
 }
@@ -1148,8 +1148,8 @@ model SocialPost {
   sourceId    Int?
   scheduledAt DateTime?
   isPublic    Boolean        @default(false)
-  userId      Int
-  User        User           @relation(fields: [userId], references: [id])
+  userId      Int?
+  User        User?          @relation(fields: [userId], references: [id], onDelete: SetNull)
   targets     SocialTarget[]
   isActive    Boolean        @default(true)
   isMature    Boolean        @default(false)
@@ -1191,7 +1191,7 @@ model Theme {
   isActive    Boolean    @default(true)
   artPrompt   String?    @db.Text
   Reactions   Reaction[]
-  user        User?      @relation(fields: [userId], references: [id])
+  user        User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([userId], map: "Theme_userId_fkey")
 }
@@ -1391,7 +1391,7 @@ model KarmaTransaction {
   balanceAfter Int
   refId        String?
   note         String?     @db.Text
-  User         User        @relation(fields: [userId], references: [id])
+  User         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
 }
@@ -1404,8 +1404,8 @@ model Referral {
   referredId Int      @unique
   codeUsed   String?  @db.VarChar(64)
   cutRate    Float    @default(0.05)
-  Referrer   User     @relation("ReferralsMade", fields: [referrerId], references: [id])
-  Referred   User     @relation("ReferredBy", fields: [referredId], references: [id])
+  Referrer   User     @relation("ReferralsMade", fields: [referrerId], references: [id], onDelete: Cascade)
+  Referred   User     @relation("ReferredBy", fields: [referredId], references: [id], onDelete: Cascade)
 
   @@index([referrerId])
 }
@@ -1440,8 +1440,8 @@ model UserRelation {
   note          String?        @db.Text
   pairId        Int?
 
-  User        User @relation("UserRelationOwner", fields: [userId], references: [id])
-  RelatedUser User @relation("UserRelationTarget", fields: [relatedUserId], references: [id])
+  User        User @relation("UserRelationOwner", fields: [userId], references: [id], onDelete: Cascade)
+  RelatedUser User @relation("UserRelationTarget", fields: [relatedUserId], references: [id], onDelete: Cascade)
 
   // Prevents duplicate links of the same type between the same ordered pair.
   // A user can both FRIEND and (later) BLOCK someone — different type, allowed.
@@ -1735,8 +1735,8 @@ model Challenge {
   judgeNotes    String?               @db.Text
   status        ChallengeStatus       @default(OPEN)
   isMature      Boolean               @default(false)
-  userId        Int                   @default(10)
-  User          User                  @relation(fields: [userId], references: [id])
+  userId        Int?                  @default(10)
+  User          User?                 @relation(fields: [userId], references: [id], onDelete: SetNull)
   Submissions   ChallengeSubmission[]
 
   @@index([userId], map: "Challenge_userId_fkey")

--- a/server/api/dreams/index.ts
+++ b/server/api/dreams/index.ts
@@ -11,7 +11,8 @@ export type DreamAccessAction = 'view' | 'chat' | 'mutate'
 
 type DreamAccessInput = {
   dream: {
-    userId: number
+    // null = orphaned (owner deleted): public dreams stay viewable, only admins mutate
+    userId: number | null
     isPublic: boolean
   }
   userId?: number | null

--- a/server/utils/characterSlug.ts
+++ b/server/utils/characterSlug.ts
@@ -71,7 +71,7 @@ export async function getUniqueCharacterSlug(
 
 export async function findCharacterNameDuplicate(
   client: any,
-  userId: number,
+  userId: number | null,
   name: string,
   excludeId?: number,
 ): Promise<CharacterSlugRow | null> {

--- a/server/utils/userPurge.ts
+++ b/server/utils/userPurge.ts
@@ -3,15 +3,14 @@ import prisma from './prisma'
 
 export type UserPurgeCounts = Record<string, number>
 
-// Deletes a user together with every owned row that would otherwise block the
-// delete. Required relations with no explicit onDelete rule (ArtCollection,
-// Character, Dream, Scenario, SocialPost, Challenge, Reaction, UserRelation,
-// Referral, ManaTransaction, KarmaTransaction, MilestoneRecord) default to
-// ON DELETE RESTRICT in MySQL, so a user who still owns any of those rows can
-// never be deleted — that is how residual test fixtures piled up ~1000
-// undeletable cypress users. ArtImages are optional (SET NULL) and would not
-// block, but they are deleted too so an account wipe doesn't strand orphaned
-// image rows.
+// Deletes a user together with their owned content. Since the explicit
+// onDelete pass, the schema itself no longer blocks user deletion: content
+// relations (ArtCollection, Code, Dream, ...) orphan via SET NULL and
+// user-scoped rows (reactions, ledgers, relations, referrals) cascade. This
+// helper exists so an account wipe removes the content outright instead of
+// stranding orphans — that orphan pile-up is exactly the test-fixture bloat
+// this was built to stop. The explicit deletes on cascading tables are
+// redundant with the DB but kept for the per-table counts they report.
 export async function deleteUserWithOwnedData(
   userId: number,
 ): Promise<UserPurgeCounts> {
@@ -56,6 +55,7 @@ export async function deleteUserWithOwnedData(
         'artCollections',
         await tx.artCollection.deleteMany({ where: { userId } }),
       )
+      track('codes', await tx.code.deleteMany({ where: { userId } }))
       track('dreams', await tx.dream.deleteMany({ where: { userId } }))
       track('characters', await tx.character.deleteMany({ where: { userId } }))
       track('scenarios', await tx.scenario.deleteMany({ where: { userId } }))


### PR DESCRIPTION
### Task
Follow-up to #153, directed by Silas: make delete behavior explicit in the schema, preferring **orphaning over cascade** for content. (kind: software + migration)

### What changed
Every relation pointing at `User` now declares its `onDelete` behavior instead of silently defaulting to `RESTRICT` (the root cause of undeletable users):

**Orphan — `SET NULL`, `userId` becomes nullable** (creative content survives its creator):
ArtCollection, Character, **Code** (switched from Cascade), Dream, Scenario, SocialPost, Challenge. The already-optional content relations (ArtImage, Bot, Chat, Composition, Log, PitchSheet, Prompt, Resource, Reward, SmartIcon, Theme) get their implicit SetNull written out explicitly — zero DB change for those.

**Cascade** — only rows semantically dead without their user: Reaction (an orphaned vote skews ratings), ManaTransaction + KarmaTransaction (ledger rows of nobody), MilestoneRecord, UserRelation, Referral. Server, StylistClient/Appointment, ArtJob, LifeRun already cascaded deliberately (private config/queues/progress) and are unchanged.

**userPurge** still explicitly deletes content on account wipe — now including Code, which no longer cascades — so test-user cleanup removes assets rather than stranding orphans. The schema rules are the safety net for every other delete path.

**Type fallout** (all of it): `DreamAccessInput.dream.userId` and `findCharacterNameDuplicate`'s `userId` widened to `number | null`. Orphaned dreams stay viewable when public and only admins can mutate them, which is the semantics we want.

### Migration audit (`20260710200000_explicit_user_ondelete_rules`)
37 statements, generated offline with `prisma migrate diff --script`:
- 15 × `DROP FOREIGN KEY` immediately re-added as → 15 × `ADD CONSTRAINT` with the new `ON DELETE` action (pure constraint swaps)
- 7 × `MODIFY userId INTEGER NULL` (keeping existing `DEFAULT 10` where present)
- **No DROP of tables/columns/data, no data rewrites.** Nullable-widening is metadata-only in MySQL 8.

### How I verified
- `prisma validate` passes; `prisma generate` + full `vue-tsc` typecheck passes.
- eslint/prettier clean on touched files (the two `no-explicit-any` errors + format warning in `characterSlug.ts` pre-exist on main, confirmed via stash).
- No live DB available in the session sandbox, so the migration SQL is verified by construction (offline diff) + line-by-line audit above.

### Stakes
reversible code / **prod-deploying migration on merge** — flagging for your explicit nod rather than self-merging, since `MODIFY COLUMN` sits outside the "additive-only" auto-merge list even though it's data-preserving. Say the word and I'll merge.

### Kaizen suggestion
The purge list in `userPurge.ts` and the schema rules are now two views of one policy — a small unit check that walks the DMMF and asserts every User relation has an explicit onDelete would prevent drift permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2V9FYENKhQW4gNGmXMvyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2V9FYENKhQW4gNGmXMvyB)_