### PR TITLE
Add Challenge Center API and leaderboard routes

### DIFF
--- a/server/api/challenges/[slug].get.ts
+++ b/server/api/challenges/[slug].get.ts
@@ -1,0 +1,94 @@
+// /server/api/challenges/[slug].get.ts
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import {
+  buildChallengeLeaderboard,
+  scoreChallengeReactions,
+} from '~/server/utils/challengeCenter'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const slug = getRouterParam(event, 'slug')?.trim()
+
+    if (!slug) {
+      throw createError({ statusCode: 400, message: 'Challenge slug is required.' })
+    }
+
+    const challenge = await prisma.challenge.findUnique({
+      where: { slug },
+      include: {
+        User: {
+          select: { id: true, username: true },
+        },
+        Submissions: {
+          where: { status: 'READY' },
+          include: {
+            Contender: {
+              select: {
+                id: true,
+                slug: true,
+                name: true,
+                kind: true,
+                provider: true,
+                model: true,
+                generator: true,
+                avatarImageId: true,
+                description: true,
+              },
+            },
+            ArtImage: {
+              select: {
+                id: true,
+                imagePath: true,
+                thumbnailPath: true,
+                fileName: true,
+                promptString: true,
+              },
+            },
+            Character: true,
+            Scenario: true,
+            Reactions: {
+              select: { reactionType: true },
+            },
+          },
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        },
+      },
+    })
+
+    if (!challenge) {
+      throw createError({ statusCode: 404, message: 'Challenge not found.' })
+    }
+
+    const leaderboard = buildChallengeLeaderboard(challenge.Submissions)
+    const rankByContender = new Map(
+      leaderboard.map((entry, index) => [entry.contenderId, index + 1]),
+    )
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Challenge fetched successfully.',
+      data: {
+        ...challenge,
+        Submissions: challenge.Submissions.map((submission) => ({
+          ...submission,
+          score: scoreChallengeReactions(submission.Reactions),
+          rank: submission.contenderId
+            ? rankByContender.get(submission.contenderId) ?? null
+            : null,
+        })),
+        leaderboard,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/challenges/[slug]/leaderboard.get.ts
+++ b/server/api/challenges/[slug]/leaderboard.get.ts
@@ -1,0 +1,73 @@
+// /server/api/challenges/[slug]/leaderboard.get.ts
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { buildChallengeLeaderboard } from '~/server/utils/challengeCenter'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const slug = getRouterParam(event, 'slug')?.trim()
+
+    if (!slug) {
+      throw createError({ statusCode: 400, message: 'Challenge slug is required.' })
+    }
+
+    const challenge = await prisma.challenge.findUnique({
+      where: { slug },
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        challengeType: true,
+        status: true,
+        Submissions: {
+          where: { status: 'READY', contenderId: { not: null } },
+          select: {
+            id: true,
+            contenderId: true,
+            variantKey: true,
+            Contender: {
+              select: {
+                id: true,
+                slug: true,
+                name: true,
+                avatarImageId: true,
+              },
+            },
+            Reactions: {
+              select: { reactionType: true },
+            },
+          },
+        },
+      },
+    })
+
+    if (!challenge) {
+      throw createError({ statusCode: 404, message: 'Challenge not found.' })
+    }
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Challenge leaderboard fetched successfully.',
+      data: {
+        challenge: {
+          id: challenge.id,
+          slug: challenge.slug,
+          title: challenge.title,
+          challengeType: challenge.challengeType,
+          status: challenge.status,
+        },
+        leaderboard: buildChallengeLeaderboard(challenge.Submissions),
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/challenges/[slug]/submissions.post.ts
+++ b/server/api/challenges/[slug]/submissions.post.ts
@@ -1,0 +1,175 @@
+// /server/api/challenges/[slug]/submissions.post.ts
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+} from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { validateApiKey } from '~/server/utils/validateKey'
+
+type SubmissionBody = {
+  contenderSlug?: unknown
+  variantKey?: unknown
+  promptUsed?: unknown
+  settings?: unknown
+  randomSelections?: unknown
+  agentModel?: unknown
+  outputText?: unknown
+  artImageId?: unknown
+  characterId?: unknown
+  scenarioId?: unknown
+}
+
+function optionalString(value: unknown, maxLength?: number): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'Expected a string value.' })
+  }
+
+  const normalized = value.trim()
+
+  if (!normalized) return null
+
+  if (maxLength && normalized.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `String value must be ${maxLength} characters or fewer.`,
+    })
+  }
+
+  return normalized
+}
+
+function optionalId(value: unknown, field: string): number | null {
+  if (value === undefined || value === null || value === '') return null
+
+  const id = Number(value)
+
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be a positive integer.`,
+    })
+  }
+
+  return id
+}
+
+function optionalJson(value: unknown): Prisma.InputJsonValue | undefined {
+  if (value === undefined || value === null) return undefined
+
+  if (typeof value !== 'object') {
+    throw createError({ statusCode: 400, message: 'JSON fields must be objects or arrays.' })
+  }
+
+  return value as Prisma.InputJsonValue
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await validateApiKey(event)
+
+    if (!auth.isValid || !auth.user) {
+      throw createError({ statusCode: 401, message: 'Authentication required.' })
+    }
+
+    const slug = getRouterParam(event, 'slug')?.trim()
+
+    if (!slug) {
+      throw createError({ statusCode: 400, message: 'Challenge slug is required.' })
+    }
+
+    const body = await readBody<SubmissionBody>(event)
+
+    if (!body || typeof body.contenderSlug !== 'string') {
+      throw createError({ statusCode: 400, message: 'contenderSlug is required.' })
+    }
+
+    const contenderSlug = body.contenderSlug.trim()
+    const variantKey = optionalString(body.variantKey, 128) ?? 'default'
+    const outputText = optionalString(body.outputText)
+    const artImageId = optionalId(body.artImageId, 'artImageId')
+    const characterId = optionalId(body.characterId, 'characterId')
+    const scenarioId = optionalId(body.scenarioId, 'scenarioId')
+
+    if (!outputText && !artImageId && !characterId && !scenarioId) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'A submission requires outputText, artImageId, characterId, or scenarioId.',
+      })
+    }
+
+    const [challenge, contender] = await Promise.all([
+      prisma.challenge.findUnique({ where: { slug } }),
+      prisma.contender.findUnique({ where: { slug: contenderSlug } }),
+    ])
+
+    if (!challenge) {
+      throw createError({ statusCode: 404, message: 'Challenge not found.' })
+    }
+
+    if (challenge.status === 'CLOSED') {
+      throw createError({ statusCode: 409, message: 'Challenge is closed.' })
+    }
+
+    if (!contender || !contender.isActive) {
+      throw createError({ statusCode: 404, message: 'Active contender not found.' })
+    }
+
+    const submission = await prisma.challengeSubmission.create({
+      data: {
+        Challenge: { connect: { id: challenge.id } },
+        Contender: { connect: { id: contender.id } },
+        variantKey,
+        promptUsed: optionalString(body.promptUsed),
+        settings: optionalJson(body.settings),
+        randomSelections: optionalJson(body.randomSelections),
+        agentModel: optionalString(body.agentModel, 256),
+        outputText,
+        ArtImage: artImageId ? { connect: { id: artImageId } } : undefined,
+        Character: characterId ? { connect: { id: characterId } } : undefined,
+        Scenario: scenarioId ? { connect: { id: scenarioId } } : undefined,
+        status: 'READY',
+      },
+      include: {
+        Contender: true,
+        ArtImage: true,
+        Character: true,
+        Scenario: true,
+      },
+    })
+
+    event.node.res.statusCode = 201
+
+    return {
+      success: true,
+      message: 'Challenge submission created successfully.',
+      data: submission,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      event.node.res.statusCode = 409
+
+      return {
+        success: false,
+        message:
+          'This contender already submitted the same variant for this challenge.',
+        statusCode: 409,
+      }
+    }
+
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/challenges/index.get.ts
+++ b/server/api/challenges/index.get.ts
@@ -1,0 +1,79 @@
+// /server/api/challenges/index.get.ts
+import { createError, defineEventHandler, getQuery } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+
+const challengeTypes = new Set([
+  'ART',
+  'TEXT',
+  'CHARACTER',
+  'SCENARIO',
+  'REASONING',
+])
+const challengeStatuses = new Set(['OPEN', 'JUDGING', 'CLOSED'])
+
+function normalizeFilter(
+  value: unknown,
+  allowed: Set<string>,
+  field: string,
+): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+
+  const normalized = String(value).trim().toUpperCase()
+
+  if (!allowed.has(normalized)) {
+    throw createError({
+      statusCode: 400,
+      message: `Invalid ${field} filter.`,
+    })
+  }
+
+  return normalized
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery(event)
+    const challengeType = normalizeFilter(
+      query.type,
+      challengeTypes,
+      'challenge type',
+    )
+    const status = normalizeFilter(
+      query.status,
+      challengeStatuses,
+      'challenge status',
+    )
+
+    const challenges = await prisma.challenge.findMany({
+      where: {
+        challengeType: challengeType as never,
+        status: (status ?? 'OPEN') as never,
+      },
+      include: {
+        _count: {
+          select: { Submissions: true },
+        },
+      },
+      orderBy: [{ createdAt: 'desc' }, { title: 'asc' }],
+    })
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Challenges fetched successfully.',
+      data: challenges.map(({ _count, ...challenge }) => ({
+        ...challenge,
+        submissionCount: _count.Submissions,
+      })),
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/challenges/index.post.ts
+++ b/server/api/challenges/index.post.ts
@@ -1,0 +1,152 @@
+// /server/api/challenges/index.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { userIsAdmin } from '~/server/utils/authUser'
+import { validateApiKey } from '~/server/utils/validateKey'
+
+const challengeTypes = new Set([
+  'ART',
+  'TEXT',
+  'CHARACTER',
+  'SCENARIO',
+  'REASONING',
+])
+const challengeStatuses = new Set(['OPEN', 'JUDGING', 'CLOSED'])
+
+type ChallengeCreateBody = {
+  slug?: unknown
+  title?: unknown
+  challengeType?: unknown
+  difficulty?: unknown
+  promptText?: unknown
+  judgeNotes?: unknown
+  status?: unknown
+  isMature?: unknown
+  userId?: unknown
+}
+
+function requiredString(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} is required.`,
+    })
+  }
+
+  const normalized = value.trim()
+
+  if (normalized.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be ${maxLength} characters or fewer.`,
+    })
+  }
+
+  return normalized
+}
+
+function enumValue(
+  value: unknown,
+  allowed: Set<string>,
+  field: string,
+  fallback?: string,
+): string {
+  if (value === undefined || value === null || value === '') {
+    if (fallback) return fallback
+    throw createError({ statusCode: 400, message: `${field} is required.` })
+  }
+
+  const normalized = String(value).trim().toUpperCase()
+
+  if (!allowed.has(normalized)) {
+    throw createError({ statusCode: 400, message: `Invalid ${field}.` })
+  }
+
+  return normalized
+}
+
+function optionalPositiveInteger(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === '') return fallback
+
+  const number = Number(value)
+
+  if (!Number.isInteger(number) || number < 1 || number > 5) {
+    throw createError({
+      statusCode: 400,
+      message: 'difficulty must be an integer from 1 through 5.',
+    })
+  }
+
+  return number
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await validateApiKey(event)
+
+    if (!auth.isValid || !auth.user) {
+      throw createError({ statusCode: 401, message: 'Authentication required.' })
+    }
+
+    if (!userIsAdmin(auth.user)) {
+      throw createError({ statusCode: 403, message: 'Admin access required.' })
+    }
+
+    const body = await readBody<ChallengeCreateBody>(event)
+
+    if (!body) {
+      throw createError({ statusCode: 400, message: 'Request body is required.' })
+    }
+
+    const requestedUserId = Number(body.userId)
+    const userId =
+      Number.isInteger(requestedUserId) && requestedUserId > 0
+        ? requestedUserId
+        : auth.user.id
+
+    const challenge = await prisma.challenge.create({
+      data: {
+        slug: requiredString(body.slug, 'slug', 255)
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, ''),
+        title: requiredString(body.title, 'title', 764),
+        challengeType: enumValue(
+          body.challengeType,
+          challengeTypes,
+          'challengeType',
+        ) as never,
+        difficulty: optionalPositiveInteger(body.difficulty, 1),
+        promptText: requiredString(body.promptText, 'promptText', 50000),
+        judgeNotes:
+          typeof body.judgeNotes === 'string' && body.judgeNotes.trim()
+            ? body.judgeNotes.trim()
+            : null,
+        status: enumValue(
+          body.status,
+          challengeStatuses,
+          'status',
+          'OPEN',
+        ) as never,
+        isMature: body.isMature === true,
+        User: { connect: { id: userId } },
+      },
+    })
+
+    event.node.res.statusCode = 201
+
+    return {
+      success: true,
+      message: 'Challenge created successfully.',
+      data: challenge,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/challenges/leaderboard.get.ts
+++ b/server/api/challenges/leaderboard.get.ts
@@ -1,0 +1,84 @@
+// /server/api/challenges/leaderboard.get.ts
+import { createError, defineEventHandler, getQuery } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { buildChallengeLeaderboard } from '~/server/utils/challengeCenter'
+
+const challengeTypes = new Set([
+  'ART',
+  'TEXT',
+  'CHARACTER',
+  'SCENARIO',
+  'REASONING',
+])
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery(event)
+    const challengeType =
+      query.type === undefined || query.type === null || query.type === ''
+        ? undefined
+        : String(query.type).trim().toUpperCase()
+
+    if (challengeType && !challengeTypes.has(challengeType)) {
+      throw createError({ statusCode: 400, message: 'Invalid challenge type.' })
+    }
+
+    const submissions = await prisma.challengeSubmission.findMany({
+      where: {
+        status: 'READY',
+        contenderId: { not: null },
+        Challenge: challengeType
+          ? { challengeType: challengeType as never }
+          : undefined,
+      },
+      select: {
+        id: true,
+        challengeId: true,
+        contenderId: true,
+        variantKey: true,
+        Contender: {
+          select: {
+            id: true,
+            slug: true,
+            name: true,
+            avatarImageId: true,
+          },
+        },
+        Reactions: {
+          select: { reactionType: true },
+        },
+      },
+    })
+
+    const leaderboard = buildChallengeLeaderboard(submissions)
+    const challengeIdsByContender = new Map<number, Set<number>>()
+
+    for (const submission of submissions) {
+      if (!submission.contenderId) continue
+
+      const ids = challengeIdsByContender.get(submission.contenderId) ?? new Set()
+      ids.add(submission.challengeId)
+      challengeIdsByContender.set(submission.contenderId, ids)
+    }
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Global challenge leaderboard fetched successfully.',
+      data: leaderboard.map((entry) => ({
+        ...entry,
+        challengesAttempted:
+          challengeIdsByContender.get(entry.contenderId)?.size ?? 0,
+      })),
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/contenders/index.get.ts
+++ b/server/api/contenders/index.get.ts
@@ -1,0 +1,59 @@
+// /server/api/contenders/index.get.ts
+import { createError, defineEventHandler, getQuery } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+
+const contenderKinds = new Set(['AGENT_STACK', 'LLM_MODEL', 'ART_GENERATOR'])
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery(event)
+    const requestedKind =
+      query.kind === undefined || query.kind === null || query.kind === ''
+        ? undefined
+        : String(query.kind).trim().toUpperCase()
+
+    if (requestedKind && !contenderKinds.has(requestedKind)) {
+      throw createError({ statusCode: 400, message: 'Invalid contender kind.' })
+    }
+
+    const contenders = await prisma.contender.findMany({
+      where: {
+        isActive: true,
+        kind: requestedKind as never,
+      },
+      include: {
+        AvatarImage: {
+          select: {
+            id: true,
+            imagePath: true,
+            thumbnailPath: true,
+            fileName: true,
+          },
+        },
+        _count: {
+          select: { Submissions: true },
+        },
+      },
+      orderBy: [{ kind: 'asc' }, { name: 'asc' }],
+    })
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Contenders fetched successfully.',
+      data: contenders.map(({ _count, ...contender }) => ({
+        ...contender,
+        submissionCount: _count.Submissions,
+      })),
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/utils/challengeCenter.ts
+++ b/server/utils/challengeCenter.ts
@@ -1,0 +1,119 @@
+type ChallengeReaction = {
+  reactionType: string
+}
+
+type ChallengeSubmissionScoreInput = {
+  id: number
+  contenderId: number | null
+  variantKey: string
+  Reactions: ChallengeReaction[]
+}
+
+export type ChallengeScore = {
+  loved: number
+  clapped: number
+  booed: number
+  hated: number
+  votes: number
+  netScore: number
+}
+
+export type ChallengeLeaderboardEntry = {
+  contenderId: number
+  slug: string
+  name: string
+  avatarImageId: number | null
+  submissions: number
+  variants: Array<{
+    submissionId: number
+    variantKey: string
+    score: ChallengeScore
+  }>
+  score: ChallengeScore
+}
+
+export function scoreChallengeReactions(
+  reactions: ChallengeReaction[],
+): ChallengeScore {
+  const score: ChallengeScore = {
+    loved: 0,
+    clapped: 0,
+    booed: 0,
+    hated: 0,
+    votes: 0,
+    netScore: 0,
+  }
+
+  for (const reaction of reactions) {
+    if (reaction.reactionType === 'LOVED') score.loved += 1
+    if (reaction.reactionType === 'CLAPPED') score.clapped += 1
+    if (reaction.reactionType === 'BOOED') score.booed += 1
+    if (reaction.reactionType === 'HATED') score.hated += 1
+  }
+
+  score.votes = score.loved + score.clapped + score.booed + score.hated
+  score.netScore = score.loved + score.clapped - score.booed - score.hated
+
+  return score
+}
+
+export function buildChallengeLeaderboard(
+  submissions: Array<
+    ChallengeSubmissionScoreInput & {
+      Contender: {
+        id: number
+        slug: string
+        name: string
+        avatarImageId: number | null
+      } | null
+    }
+  >,
+): ChallengeLeaderboardEntry[] {
+  const entries = new Map<number, ChallengeLeaderboardEntry>()
+
+  for (const submission of submissions) {
+    if (!submission.Contender || !submission.contenderId) continue
+
+    const variantScore = scoreChallengeReactions(submission.Reactions)
+    const current = entries.get(submission.contenderId) ?? {
+      contenderId: submission.Contender.id,
+      slug: submission.Contender.slug,
+      name: submission.Contender.name,
+      avatarImageId: submission.Contender.avatarImageId,
+      submissions: 0,
+      variants: [],
+      score: {
+        loved: 0,
+        clapped: 0,
+        booed: 0,
+        hated: 0,
+        votes: 0,
+        netScore: 0,
+      },
+    }
+
+    current.submissions += 1
+    current.variants.push({
+      submissionId: submission.id,
+      variantKey: submission.variantKey,
+      score: variantScore,
+    })
+    current.score.loved += variantScore.loved
+    current.score.clapped += variantScore.clapped
+    current.score.booed += variantScore.booed
+    current.score.hated += variantScore.hated
+    current.score.votes += variantScore.votes
+    current.score.netScore += variantScore.netScore
+
+    entries.set(submission.contenderId, current)
+  }
+
+  return [...entries.values()]
+    .sort(
+      (a, b) =>
+        b.score.netScore - a.score.netScore ||
+        b.score.votes - a.score.votes ||
+        a.name.localeCompare(b.name),
+    )
+    .map((entry, index) => ({ ...entry, rank: index + 1 }))
+}


### PR DESCRIPTION
### Task
challenge-center/t-003: Create `/api/challenges` CRUD and submission routes in kind_robots (kind: software)

### What changed / what I produced
- added challenge list, detail, and admin-only create endpoints
- added active contender listing with optional kind filtering
- added authenticated contender submission intake with duplicate variant protection
- added per-challenge and global contender leaderboards
- added shared reaction scoring and variant aggregation helpers

### How I verified
- audited the routes against the current `Challenge`, `ChallengeSubmission`, `Contender`, and `Reaction` Prisma models
- reused the existing `validateApiKey`, `userIsAdmin`, `errorHandler`, and Prisma route patterns
- CI/typecheck requested on this PR

### Stakes
reversible

### Flags for Reviewer
- The connected environment cannot run the repository locally, so the GitHub checks are the executable verification source.
- Script submissions authenticate through the existing `validateApiKey()` header path (`Authorization`, `x-beta-admin-token`, `x-admin-token`, or `x-api-key`).

### Kaizen suggestion
Add Cypress API coverage that seeds one challenge, two contenders, duplicate variants, and all four vote reactions, then asserts both leaderboard shapes.