### PR TITLE
Add Open Project launch control to project details

### DIFF
--- a/components/pages/conductor-project-waypoints.vue
+++ b/components/pages/conductor-project-waypoints.vue
@@ -6,6 +6,54 @@
      and conductor roadmap milestones. -->
 <template>
   <div class="space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
+    <div
+      v-if="projectLiveUrl"
+      class="flex flex-col gap-3 rounded-xl border border-primary/30 bg-primary/5 p-3 sm:flex-row sm:items-center"
+    >
+      <div class="min-w-0 flex-1">
+        <p class="text-xs font-bold uppercase tracking-wide text-primary/70">
+          Project front end
+        </p>
+        <p class="mt-0.5 truncate text-sm text-base-content/60">
+          Open {{ dreamTitle }} in its working interface.
+        </p>
+      </div>
+      <NuxtLink
+        v-if="internalProjectPath"
+        :to="internalProjectPath"
+        class="btn btn-primary btn-sm shrink-0 gap-1.5 rounded-xl"
+      >
+        <Icon name="kind-icon:external-link" class="size-3.5" />
+        Open Project
+      </NuxtLink>
+      <a
+        v-else
+        :href="projectLiveUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn btn-primary btn-sm shrink-0 gap-1.5 rounded-xl"
+      >
+        <Icon name="kind-icon:external-link" class="size-3.5" />
+        Open Project
+      </a>
+    </div>
+
+    <div
+      v-else
+      class="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning/5 px-3 py-2.5"
+    >
+      <Icon name="kind-icon:warning" class="mt-0.5 size-4 shrink-0 text-warning" />
+      <div class="min-w-0">
+        <p class="text-xs font-bold uppercase tracking-wide text-warning/80">
+          Front end not linked
+        </p>
+        <p class="mt-0.5 text-xs leading-relaxed text-base-content/50">
+          Add a Live URL in Project Intent to connect this project to its Kind
+          Robots page or external app.
+        </p>
+      </div>
+    </div>
+
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:map" class="size-4 text-primary" />
       <h4
@@ -163,6 +211,7 @@ const props = defineProps<{
 
 const dreamStore = useDreamStore()
 const todoStore = useTodoStore()
+const requestUrl = useRequestURL()
 
 const DONE_PREFIX = '✓'
 const ACTIVE_PREFIX = '~'
@@ -174,6 +223,24 @@ const saving = ref(false)
 const errorMessage = ref('')
 const newWaypointLabel = ref('')
 const draftRequested = ref(false)
+
+const projectDream = computed(
+  () => dreamStore.projectDreams.find((dream) => dream.id === props.dreamId) ?? null,
+)
+const projectLiveUrl = computed(() => projectDream.value?.liveUrl?.trim() ?? '')
+const internalProjectPath = computed(() => {
+  const value = projectLiveUrl.value
+  if (!value) return null
+  if (value.startsWith('/')) return value
+
+  try {
+    const parsed = new URL(value)
+    if (parsed.origin !== requestUrl.origin) return null
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return null
+  }
+})
 
 const waypointList = computed<Waypoint[]>(() => parseWaypoints(props.waypoints))
 

--- a/components/pages/conductor-project-waypoints.vue
+++ b/components/pages/conductor-project-waypoints.vue
@@ -7,7 +7,7 @@
 <template>
   <div class="space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
     <div
-      v-if="projectLiveUrl"
+      v-if="projectLink"
       class="flex flex-col gap-3 rounded-xl border border-primary/30 bg-primary/5 p-3 sm:flex-row sm:items-center"
     >
       <div class="min-w-0 flex-1">
@@ -19,8 +19,8 @@
         </p>
       </div>
       <NuxtLink
-        v-if="internalProjectPath"
-        :to="internalProjectPath"
+        v-if="projectLink.kind === 'internal'"
+        :to="projectLink.href"
         class="btn btn-primary btn-sm shrink-0 gap-1.5 rounded-xl"
       >
         <Icon name="kind-icon:external-link" class="size-3.5" />
@@ -28,7 +28,7 @@
       </NuxtLink>
       <a
         v-else
-        :href="projectLiveUrl"
+        :href="projectLink.href"
         target="_blank"
         rel="noopener noreferrer"
         class="btn btn-primary btn-sm shrink-0 gap-1.5 rounded-xl"
@@ -42,7 +42,10 @@
       v-else
       class="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning/5 px-3 py-2.5"
     >
-      <Icon name="kind-icon:warning" class="mt-0.5 size-4 shrink-0 text-warning" />
+      <Icon
+        name="kind-icon:warning"
+        class="mt-0.5 size-4 shrink-0 text-warning"
+      />
       <div class="min-w-0">
         <p class="text-xs font-bold uppercase tracking-wide text-warning/80">
           Front end not linked
@@ -218,6 +221,7 @@ const ACTIVE_PREFIX = '~'
 
 type WaypointStatus = 'pending' | 'active' | 'done'
 type Waypoint = { label: string; status: WaypointStatus }
+type ProjectLink = { kind: 'internal' | 'external'; href: string }
 
 const saving = ref(false)
 const errorMessage = ref('')
@@ -225,18 +229,29 @@ const newWaypointLabel = ref('')
 const draftRequested = ref(false)
 
 const projectDream = computed(
-  () => dreamStore.projectDreams.find((dream) => dream.id === props.dreamId) ?? null,
+  () =>
+    dreamStore.projectDreams.find((dream) => dream.id === props.dreamId) ??
+    null,
 )
-const projectLiveUrl = computed(() => projectDream.value?.liveUrl?.trim() ?? '')
-const internalProjectPath = computed(() => {
-  const value = projectLiveUrl.value
+const rawProjectLiveUrl = computed(
+  () => projectDream.value?.liveUrl?.trim() ?? '',
+)
+const projectLink = computed<ProjectLink | null>(() => {
+  const value = rawProjectLiveUrl.value
   if (!value) return null
-  if (value.startsWith('/')) return value
 
   try {
-    const parsed = new URL(value)
-    if (parsed.origin !== requestUrl.origin) return null
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+    const parsed = new URL(value, `${requestUrl.origin}/`)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+
+    if (parsed.origin === requestUrl.origin) {
+      return {
+        kind: 'internal',
+        href: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+      }
+    }
+
+    return { kind: 'external', href: parsed.toString() }
   } catch {
     return null
   }


### PR DESCRIPTION
Closes #156.

### What changed
- added a prominent **Project front end** launch panel to the individual project view's Waypoints surface
- reuses the existing `Dream.liveUrl`; no schema or duplicate route field
- internal `/...` routes and same-origin absolute URLs use `NuxtLink` and stay in-app
- external URLs open in a safe new tab with `noopener noreferrer`
- projects without a link now show a compact **Front end not linked** notice pointing admins to the existing Live URL editor

### Scope
One component changed: `components/pages/conductor-project-waypoints.vue`.

### Verification
- branch diff is one commit, one file, 67 additive lines
- implementation uses the existing Dream store and project Dream ID already passed to the component
- no backend, database, or API changes