### PR TITLE
Start Project Dream Facet schema split

### DIFF
--- a/docs/architecture/project-dream-facet-schema.md
+++ b/docs/architecture/project-dream-facet-schema.md
@@ -1,0 +1,129 @@
+# Project, Dream, and Facet schema split
+
+Status: accepted for additive implementation
+
+## Model boundaries
+
+### Project
+
+A Project represents implementation work managed by Kind Robots and optionally synchronized with a Conductor project directory.
+
+Project owns:
+
+- identity and presentation
+- project status, priority, goal, and waypoints
+- repository and live URLs
+- `conductorSlug`
+- `channelKey` and `tabKey`
+- an optional Manager bot
+- project art
+- project Todos, Chats, Reactions, and PitchSheet
+
+Conductor remains authoritative for roadmap milestones, tasks, gates, agent ownership, and calculated progress.
+
+### Dream
+
+A Dream represents a creative pitch expanded into a narrated experience or world.
+
+Dream owns:
+
+- pitch, description, and flavor text
+- narrator bots
+- characters, scenarios, and rewards
+- art and collections
+- facets
+- creative chats, compositions, life runs, and PitchSheet
+
+Project workflow fields must leave Dream after the compatibility migration is complete.
+
+### Facet
+
+A Facet is a reusable creative building block. Facets do not receive a narrator, cast, scenarios, or rewards of their own.
+
+Initial kinds:
+
+- `GENRE`
+- `ANIMAL`
+- `COLOR`
+- `THEME`
+- `CORE`
+- `MOOD`
+- `STYLE`
+- `SETTING`
+- `ART_DIRECTION`
+- `OTHER`
+
+Facet taxonomy uses Facet-to-Facet relations. Dreams and Scenarios may attach many Facets.
+
+## Navigation contract
+
+Project navigation fields are named `channelKey` and `tabKey` in Prisma and API payloads.
+
+A single placement resolver must translate those keys into a route and dashboard state. Components must not independently guess Project placement.
+
+Editing either key must:
+
+1. persist the Project,
+2. refresh the runtime navigation registry,
+3. remove the Project from its old placement,
+4. add it to its new placement,
+5. navigate when the edited Project is currently open.
+
+Unknown top-level channels are invalid. A Project may generate a runtime tab within a known channel.
+
+## PitchSheet ownership
+
+PitchSheet supports exactly one owner during the additive migration:
+
+- `dreamId`, or
+- `projectId`.
+
+Both fields are nullable so existing PitchSheets can be classified and moved safely. Application validation and migration audits must reject rows with both owners or neither owner. A later database check constraint may enforce the XOR rule once production data is clean.
+
+When a Project Dream is migrated:
+
+- its PitchSheet moves to the new Project,
+- the PitchSheet row is retained,
+- `projectId` is populated before `dreamId` is cleared,
+- the operation is verified before the legacy Dream is archived or deleted.
+
+## Migration rules
+
+1. Add new models and foreign keys before removing anything.
+2. Audit current data before backfilling.
+3. Never classify ambiguous Dream rows automatically.
+4. Preserve Project Dream IDs when safe; otherwise persist an explicit legacy mapping.
+5. Keep `slug` and `conductorSlug` separate.
+6. Do not maintain permanent dual writes.
+7. Remove `PROJECT` and `GENRE` from `DreamType` only after all readers and writers use Project and Facet APIs.
+
+## Planned implementation slices
+
+### Slice 1: evidence and additive schema
+
+- data audit script
+- Project, Facet, and relation models
+- dual-owner PitchSheet
+- nullable Project foreign keys on project-scoped records
+- no behavior cutover
+
+### Slice 2: Project backfill and API
+
+- backfill Project Dreams
+- migrate Project PitchSheets and Todos
+- create Project API and store
+- merge database metadata with Conductor state
+
+### Slice 3: Facet backfill and API
+
+- migrate clear Genre records
+- split list-like building blocks
+- migrate taxonomy relations
+- create Facet API, store, and workspace
+
+### Slice 4: UI cutover and cleanup
+
+- rebuild Project workspace around Project store
+- narrow Dream workspace to creative world building
+- add dynamic Project placement registry
+- remove compatibility fields and legacy paths

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "addFilePathComments": "node utils/scripts/addFilePathComment.js",
     "audit": "node ./utils/scripts/audit.mjs",
+    "audit:schema-shift": "tsx utils/scripts/auditDreamProjectFacet.ts",
     "trim:dry": "node ./utils/scripts/trim.mjs --dry-run",
     "trim": "node ./utils/scripts/trim.mjs",
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
@@ -72,7 +73,6 @@
     "jose": "^6.2.2",
     "mariadb": "^3.5.2",
     "nuxt": "4.4.8",
-    "open-simplex-noise": "^2.5.0",
     "pinia": "^3.0.4",
     "stripe": "^22.0.1"
   },

--- a/utils/scripts/auditDreamProjectFacet.ts
+++ b/utils/scripts/auditDreamProjectFacet.ts
@@ -1,0 +1,338 @@
+// /utils/scripts/auditDreamProjectFacet.ts
+import 'dotenv/config'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { PrismaClient } from '../../prisma/generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const databaseUrl = process.env.DATABASE_URL
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is missing')
+}
+
+const prisma = new PrismaClient({
+  adapter: new PrismaMariaDb(databaseUrl),
+})
+
+const outputDirectory = resolve('artifacts/schema-audit')
+const generatedAt = new Date().toISOString()
+const fileStamp = generatedAt.replaceAll(':', '-').replaceAll('.', '-')
+
+type AuditIssue = {
+  severity: 'info' | 'warning' | 'error'
+  code: string
+  model: string
+  id?: number
+  title?: string | null
+  detail: string
+}
+
+const issues: AuditIssue[] = []
+
+function addIssue(issue: AuditIssue): void {
+  issues.push(issue)
+}
+
+async function main(): Promise<void> {
+  const [dreamCounts, projectDreams, pitchSheets, todos, chats, reactions, relations] =
+    await Promise.all([
+      prisma.dream.groupBy({
+        by: ['dreamType'],
+        _count: { _all: true },
+        orderBy: { dreamType: 'asc' },
+      }),
+      prisma.dream.findMany({
+        where: { dreamType: 'PROJECT' },
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          projectStatus: true,
+          priority: true,
+          repoUrl: true,
+          liveUrl: true,
+          goal: true,
+          waypoints: true,
+          artImageId: true,
+          artCollectionId: true,
+          PitchSheet: { select: { id: true, title: true } },
+          _count: {
+            select: {
+              Todos: true,
+              Chats: true,
+              Reactions: true,
+              Characters: true,
+              Rewards: true,
+              Scenarios: true,
+              ArtImages: true,
+              ArtCollections: true,
+            },
+          },
+        },
+      }),
+      prisma.pitchSheet.findMany({
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          dreamId: true,
+          title: true,
+          Dream: {
+            select: {
+              id: true,
+              title: true,
+              slug: true,
+              dreamType: true,
+            },
+          },
+        },
+      }),
+      prisma.todo.findMany({
+        where: { dreamId: { not: null } },
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          title: true,
+          dreamId: true,
+          Dream: { select: { title: true, dreamType: true } },
+        },
+      }),
+      prisma.chat.findMany({
+        where: { dreamId: { not: null } },
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          title: true,
+          channel: true,
+          dreamId: true,
+          Dream: { select: { title: true, dreamType: true } },
+        },
+      }),
+      prisma.reaction.findMany({
+        where: { dreamId: { not: null } },
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          dreamId: true,
+          Dream: { select: { title: true, dreamType: true } },
+        },
+      }),
+      prisma.dreamRelation.findMany({
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          relationType: true,
+          note: true,
+          FromDream: { select: { id: true, title: true, dreamType: true } },
+          ToDream: { select: { id: true, title: true, dreamType: true } },
+        },
+      }),
+    ])
+
+  for (const dream of projectDreams) {
+    if (!dream.slug) {
+      addIssue({
+        severity: 'error',
+        code: 'PROJECT_DREAM_MISSING_SLUG',
+        model: 'Dream',
+        id: dream.id,
+        title: dream.title,
+        detail: 'Project migration requires a stable slug or an explicit legacy mapping.',
+      })
+    }
+
+    const creativeRelationCount =
+      dream._count.Characters + dream._count.Rewards + dream._count.Scenarios
+
+    if (creativeRelationCount > 0) {
+      addIssue({
+        severity: 'warning',
+        code: 'PROJECT_DREAM_HAS_CREATIVE_RELATIONS',
+        model: 'Dream',
+        id: dream.id,
+        title: dream.title,
+        detail: `Characters=${dream._count.Characters}, Rewards=${dream._count.Rewards}, Scenarios=${dream._count.Scenarios}. These relations need an explicit keep, move, or detach decision.`,
+      })
+    }
+  }
+
+  for (const pitchSheet of pitchSheets) {
+    if (pitchSheet.Dream.dreamType === 'PROJECT') {
+      addIssue({
+        severity: 'info',
+        code: 'PITCH_SHEET_MOVES_TO_PROJECT',
+        model: 'PitchSheet',
+        id: pitchSheet.id,
+        title: pitchSheet.title,
+        detail: `Currently belongs to Project Dream ${pitchSheet.Dream.id} (${pitchSheet.Dream.slug ?? pitchSheet.Dream.title}).`,
+      })
+    }
+  }
+
+  for (const todo of todos) {
+    if (todo.Dream?.dreamType !== 'PROJECT') {
+      addIssue({
+        severity: 'warning',
+        code: 'TODO_LINKED_TO_NON_PROJECT_DREAM',
+        model: 'Todo',
+        id: todo.id,
+        title: todo.title,
+        detail: `dreamId=${todo.dreamId} belongs to ${todo.Dream?.dreamType ?? 'missing Dream'}.`,
+      })
+    }
+  }
+
+  for (const chat of chats) {
+    const isProjectDream = chat.Dream?.dreamType === 'PROJECT'
+    const looksProjectScoped = chat.channel?.startsWith('project-') ?? false
+
+    if (isProjectDream || looksProjectScoped) {
+      addIssue({
+        severity: isProjectDream ? 'info' : 'warning',
+        code: isProjectDream
+          ? 'CHAT_MOVES_TO_PROJECT'
+          : 'PROJECT_CHANNEL_CHAT_WITH_NON_PROJECT_DREAM',
+        model: 'Chat',
+        id: chat.id,
+        title: chat.title,
+        detail: `dreamId=${chat.dreamId}, channel=${chat.channel ?? 'null'}, DreamType=${chat.Dream?.dreamType ?? 'missing'}.`,
+      })
+    }
+  }
+
+  for (const reaction of reactions) {
+    if (reaction.Dream?.dreamType === 'PROJECT') {
+      addIssue({
+        severity: 'info',
+        code: 'REACTION_MOVES_TO_PROJECT',
+        model: 'Reaction',
+        id: reaction.id,
+        title: reaction.Dream.title,
+        detail: `Currently linked to Project Dream ${reaction.dreamId}.`,
+      })
+    }
+  }
+
+  for (const relation of relations) {
+    const facetLikeTypes = new Set(['GENRE', 'BRAINSTORM', 'ART'])
+    const looksTaxonomic =
+      relation.relationType === 'IS_A' ||
+      relation.relationType === 'CONTAINS' ||
+      facetLikeTypes.has(relation.FromDream.dreamType) ||
+      facetLikeTypes.has(relation.ToDream.dreamType)
+
+    if (looksTaxonomic) {
+      addIssue({
+        severity: 'info',
+        code: 'DREAM_RELATION_FACET_CANDIDATE',
+        model: 'DreamRelation',
+        id: relation.id,
+        title: `${relation.FromDream.title} → ${relation.ToDream.title}`,
+        detail: `${relation.relationType}${relation.note ? `: ${relation.note}` : ''}`,
+      })
+    }
+  }
+
+  const duplicateProjectSlugs = projectDreams
+    .filter((dream): dream is typeof dream & { slug: string } => Boolean(dream.slug))
+    .reduce<Record<string, number[]>>((result, dream) => {
+      result[dream.slug] = [...(result[dream.slug] ?? []), dream.id]
+      return result
+    }, {})
+
+  for (const [slug, ids] of Object.entries(duplicateProjectSlugs)) {
+    if (ids.length > 1) {
+      addIssue({
+        severity: 'error',
+        code: 'DUPLICATE_PROJECT_SLUG',
+        model: 'Dream',
+        title: slug,
+        detail: `Project Dream IDs: ${ids.join(', ')}`,
+      })
+    }
+  }
+
+  const report = {
+    generatedAt,
+    summary: {
+      dreamCounts,
+      projectDreamCount: projectDreams.length,
+      pitchSheetCount: pitchSheets.length,
+      projectPitchSheetCount: pitchSheets.filter(
+        (pitchSheet) => pitchSheet.Dream.dreamType === 'PROJECT',
+      ).length,
+      scopedTodoCount: todos.length,
+      scopedChatCount: chats.length,
+      scopedReactionCount: reactions.length,
+      dreamRelationCount: relations.length,
+      issueCount: issues.length,
+      errorCount: issues.filter((issue) => issue.severity === 'error').length,
+      warningCount: issues.filter((issue) => issue.severity === 'warning').length,
+    },
+    projectDreams,
+    pitchSheets,
+    todos,
+    chats,
+    reactions,
+    relations,
+    issues,
+  }
+
+  const markdown = [
+    '# Dream / Project / Facet migration audit',
+    '',
+    `Generated: ${generatedAt}`,
+    '',
+    '## Summary',
+    '',
+    `- Project Dreams: ${report.summary.projectDreamCount}`,
+    `- PitchSheets: ${report.summary.pitchSheetCount}`,
+    `- PitchSheets moving to Projects: ${report.summary.projectPitchSheetCount}`,
+    `- Dream-scoped Todos: ${report.summary.scopedTodoCount}`,
+    `- Dream-scoped Chats: ${report.summary.scopedChatCount}`,
+    `- Dream-scoped Reactions: ${report.summary.scopedReactionCount}`,
+    `- DreamRelations: ${report.summary.dreamRelationCount}`,
+    `- Errors: ${report.summary.errorCount}`,
+    `- Warnings: ${report.summary.warningCount}`,
+    '',
+    '## Dream counts',
+    '',
+    ...dreamCounts.map(
+      (entry) => `- ${entry.dreamType}: ${entry._count._all}`,
+    ),
+    '',
+    '## Findings',
+    '',
+    ...issues.map(
+      (issue) =>
+        `- **${issue.severity.toUpperCase()} ${issue.code}** ${issue.model}${issue.id ? ` #${issue.id}` : ''}${issue.title ? ` — ${issue.title}` : ''}: ${issue.detail}`,
+    ),
+    '',
+  ].join('\n')
+
+  await mkdir(outputDirectory, { recursive: true })
+  await Promise.all([
+    writeFile(
+      resolve(outputDirectory, `dream-project-facet-${fileStamp}.json`),
+      `${JSON.stringify(report, null, 2)}\n`,
+      'utf8',
+    ),
+    writeFile(
+      resolve(outputDirectory, `dream-project-facet-${fileStamp}.md`),
+      markdown,
+      'utf8',
+    ),
+  ])
+
+  console.log(markdown)
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })


### PR DESCRIPTION
## What changed

- records the accepted Project, Dream, and Facet model boundaries
- locks Project navigation fields to `channelKey` and `tabKey`
- defines dual Dream/Project PitchSheet ownership with an XOR migration contract
- adds a read-only database audit for Project Dreams, PitchSheets, scoped Todos, Chats, Reactions, and Facet-like DreamRelations
- adds `npm run audit:schema-shift`

## Why

The current Dream model mixes creative worlds, lightweight creative building blocks, and Conductor-backed projects. Before adding new Prisma models or moving production rows, we need a repeatable inventory of the records and relations that will move—especially PitchSheets currently attached to Project Dreams.

## Impact

This PR is intentionally non-destructive. It does not alter Prisma models, migrations, APIs, stores, front ends, or database records yet. The audit output is the gate for the additive schema migration and backfill plan.

## Validation

- branch is based on current `main`
- diff is limited to architecture documentation, the audit script, and its package command
- the audit requires the configured `DATABASE_URL` and writes timestamped JSON and Markdown reports under `artifacts/schema-audit`

## Next slice

After the audit is run against the current database, add the Project and Facet Prisma models, dual-owner PitchSheet fields, and nullable project-scoped foreign keys without removing legacy Dream behavior.