### PR TITLE
Verify and remove Project Facet migration smoke workflow

### DIFF
--- a/.github/workflows/project-facet-migration-smoke.yml
+++ b/.github/workflows/project-facet-migration-smoke.yml
@@ -1,10 +1,8 @@
 name: Project and Facet Migration Smoke Test
 
 on:
-  push:
+  pull_request:
     branches: [main]
-    paths:
-      - .github/workflows/project-facet-migration-smoke.yml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Purpose

Run the additive Project/Facet migration against a disposable MariaDB database built from the immediate pre-change Prisma schema.

## Verification

The workflow downloads only the historical schema and merged migration, creates the old database shape, executes the SQL verbatim, and asserts the new core tables plus the exclusive PitchSheet owner constraint.

## Cleanup

After the smoke test passes, this workflow will be deleted before the PR is merged. This PR should contain no durable application change.