### PR TITLE
Add first-class Project API, store, and Cypress coverage

### DIFF
--- a/cypress/e2e/api/projects.cy.ts
+++ b/cypress/e2e/api/projects.cy.ts
@@ -1,0 +1,101 @@
+// /cypress/e2e/api/projects.cy.ts
+import { createLoggedInTestUser } from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+describe('Project API', () => {
+  const baseUrl = 'https://kind-robots.vercel.app/api/projects'
+  const stamp = Date.now()
+  const slug = `cypress-project-${stamp}`
+  let token = ''
+  let projectId = 0
+
+  before(() => {
+    createLoggedInTestUser().then((auth) => {
+      token = auth.token
+    })
+  })
+
+  it('creates a first-class Project instead of a Project Dream', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        title: `Cypress Project ${stamp}`,
+        slug,
+        conductorSlug: slug,
+        description: 'Created by the Project API cutover test.',
+        flavorText: 'Project rows are real now.',
+        status: 'ACTIVE',
+        priority: 'HIGH',
+        channelKey: 'conductor',
+        tabKey: slug,
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      expect(response.body.success).to.be.true
+      expect(response.body.data.slug).to.eq(slug)
+      expect(response.body.data.status).to.eq('ACTIVE')
+      expect(response.body.data.priority).to.eq('HIGH')
+      expect(response.body.data.channelKey).to.eq('conductor')
+      projectId = response.body.data.id
+    })
+  })
+
+  it('retrieves the same Project by slug', () => {
+    cy.request({
+      url: `${baseUrl}/${slug}`,
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data.id).to.eq(projectId)
+      expect(response.body.data.conductorSlug).to.eq(slug)
+    })
+  })
+
+  it('lists the authenticated user Projects', () => {
+    cy.request({
+      url: `${baseUrl}?mine=true&includeInactive=true`,
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data).to.be.an('array')
+      expect(response.body.data.some((project: { id: number }) => project.id === projectId)).to.be.true
+    })
+  })
+
+  it('updates placement and presentation fields', () => {
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${projectId}`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        priority: 'LOW',
+        channelKey: 'projects',
+        tabKey: `${slug}-updated`,
+        liveUrl: '/projects/cypress',
+        allowReviews: true,
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data.priority).to.eq('LOW')
+      expect(response.body.data.channelKey).to.eq('projects')
+      expect(response.body.data.tabKey).to.eq(`${slug}-updated`)
+      expect(response.body.data.allowReviews).to.be.true
+    })
+  })
+
+  it('archives instead of destructively deleting the Project', () => {
+    cy.request({
+      method: 'DELETE',
+      url: `${baseUrl}/${projectId}`,
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data.isActive).to.be.false
+      expect(response.body.data.status).to.eq('ARCHIVED')
+    })
+  })
+})

--- a/server/api/projects/[id].delete.ts
+++ b/server/api/projects/[id].delete.ts
@@ -1,0 +1,39 @@
+// /server/api/projects/[id].delete.ts
+import { defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { assertProjectAccess, getProjectId, projectInclude } from './index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getProjectId(event)
+    const auth = await requireApiUser(event)
+    const existing = await prisma.project.findUnique({ where: { id } })
+
+    if (!existing) {
+      event.node.res.statusCode = 404
+      return { success: false, message: 'Project not found.', statusCode: 404 }
+    }
+
+    assertProjectAccess(existing, auth.user)
+    const project = await prisma.project.update({
+      where: { id },
+      data: { isActive: false, status: 'ARCHIVED' },
+      include: projectInclude,
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Project archived successfully.',
+      data: project,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
 
     assertProjectAccess(existing, auth.user)
     const body = await readBody<ProjectPatchBody>(event)
-    const data: Prisma.ProjectUpdateInput = {}
+    const data: Prisma.ProjectUncheckedUpdateInput = {}
 
     if (body.title !== undefined) data.title = normalizeOptionalText(body.title) ?? existing.title
     if (body.slug !== undefined) data.slug = normalizeSlug(body.slug)

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -1,0 +1,70 @@
+// /server/api/projects/[id].patch.ts
+import { defineEventHandler, readBody } from 'h3'
+import type { Prisma, ProjectPriority, ProjectStatus } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  assertProjectAccess,
+  getProjectId,
+  normalizeNullableId,
+  normalizeOptionalText,
+  normalizeSlug,
+  projectInclude,
+  projectPriorities,
+  projectStatuses,
+} from './index'
+
+type ProjectPatchBody = Record<string, unknown>
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getProjectId(event)
+    const auth = await requireApiUser(event)
+    const existing = await prisma.project.findUnique({ where: { id } })
+    if (!existing) {
+      event.node.res.statusCode = 404
+      return { success: false, message: 'Project not found.', statusCode: 404 }
+    }
+
+    assertProjectAccess(existing, auth.user)
+    const body = await readBody<ProjectPatchBody>(event)
+    const data: Prisma.ProjectUpdateInput = {}
+
+    if (body.title !== undefined) data.title = normalizeOptionalText(body.title) ?? existing.title
+    if (body.slug !== undefined) data.slug = normalizeSlug(body.slug)
+    if (body.description !== undefined) data.description = normalizeOptionalText(body.description)
+    if (body.flavorText !== undefined) data.flavorText = normalizeOptionalText(body.flavorText)
+    if (body.goal !== undefined) data.goal = normalizeOptionalText(body.goal)
+    if (body.waypoints !== undefined) data.waypoints = normalizeOptionalText(body.waypoints)
+    if (body.conductorSlug !== undefined) data.conductorSlug = normalizeSlug(body.conductorSlug)
+    if (body.repoUrl !== undefined) data.repoUrl = normalizeOptionalText(body.repoUrl)
+    if (body.liveUrl !== undefined) data.liveUrl = normalizeOptionalText(body.liveUrl)
+    if (body.channelKey !== undefined) data.channelKey = normalizeOptionalText(body.channelKey)
+    if (body.tabKey !== undefined) data.tabKey = normalizeOptionalText(body.tabKey)
+    if (body.highlightImage !== undefined) data.highlightImage = normalizeOptionalText(body.highlightImage)
+    if (body.icon !== undefined) data.icon = normalizeOptionalText(body.icon)
+    if (body.imagePath !== undefined) data.imagePath = normalizeOptionalText(body.imagePath)
+    if (body.cardPath !== undefined) data.cardPath = normalizeOptionalText(body.cardPath)
+    if (body.heroPath !== undefined) data.heroPath = normalizeOptionalText(body.heroPath)
+    if (body.designer !== undefined) data.designer = normalizeOptionalText(body.designer)
+    if (body.managerBotId !== undefined) data.managerBotId = normalizeNullableId(body.managerBotId)
+    if (body.artImageId !== undefined) data.artImageId = normalizeNullableId(body.artImageId)
+    if (body.artCollectionId !== undefined) data.artCollectionId = normalizeNullableId(body.artCollectionId)
+    if (typeof body.allowReviews === 'boolean') data.allowReviews = body.allowReviews
+    if (typeof body.isPublic === 'boolean') data.isPublic = body.isPublic
+    if (typeof body.isMature === 'boolean') data.isMature = body.isMature
+    if (typeof body.isActive === 'boolean') data.isActive = body.isActive
+    if (projectStatuses.has(body.status as ProjectStatus)) data.status = body.status as ProjectStatus
+    if (projectPriorities.has(body.priority as ProjectPriority)) data.priority = body.priority as ProjectPriority
+
+    const project = await prisma.project.update({ where: { id }, data, include: projectInclude })
+    event.node.res.statusCode = 200
+    return { success: true, message: 'Project updated successfully.', data: project, statusCode: 200 }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/projects/[key].get.ts
+++ b/server/api/projects/[key].get.ts
@@ -1,0 +1,47 @@
+// /server/api/projects/[key].get.ts
+import { createError, defineEventHandler, getHeader, getRouterParam } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { validateApiKey } from '~/server/utils/validateKey'
+import { projectInclude } from './index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const key = getRouterParam(event, 'key')?.trim()
+    if (!key) throw createError({ statusCode: 400, message: 'Project ID or slug is required.' })
+
+    const id = Number(key)
+    const project = await prisma.project.findFirst({
+      where: Number.isInteger(id) && id > 0
+        ? { id }
+        : { OR: [{ slug: key }, { conductorSlug: key }] },
+      include: projectInclude,
+    })
+
+    if (!project) throw createError({ statusCode: 404, message: 'Project not found.' })
+
+    let userId: number | null = null
+    let isAdmin = false
+    if (getHeader(event, 'authorization')?.startsWith('Bearer ')) {
+      try {
+        const auth = await validateApiKey(event)
+        if (auth.isValid && auth.user) {
+          userId = auth.user.id
+          isAdmin = auth.user.Role === 'ADMIN'
+        }
+      } catch {}
+    }
+
+    if ((!project.isActive || !project.isPublic || project.isMature) && !isAdmin && project.userId !== userId) {
+      throw createError({ statusCode: 403, message: 'You do not have permission to view this Project.' })
+    }
+
+    event.node.res.statusCode = 200
+    return { success: true, message: 'Project fetched successfully.', data: project, statusCode: 200 }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/projects/index.get.ts
+++ b/server/api/projects/index.get.ts
@@ -1,0 +1,107 @@
+// /server/api/projects/index.get.ts
+import { defineEventHandler, getHeader, getQuery } from 'h3'
+import type { Prisma, ProjectPriority, ProjectStatus } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { validateApiKey } from '~/server/utils/validateKey'
+import { projectInclude, projectPriorities, projectStatuses } from './index'
+
+type ProjectListQuery = {
+  take?: string
+  skip?: string
+  includeMature?: string
+  includeInactive?: string
+  mine?: string
+  search?: string
+  status?: string
+  priority?: string
+  channelKey?: string
+}
+
+function numberParam(value: unknown, fallback: number, max: number): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) return fallback
+  return Math.min(parsed, max)
+}
+
+function booleanParam(value: unknown): boolean {
+  return value === true || value === 'true' || value === '1'
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery<ProjectListQuery>(event)
+    const authorization = getHeader(event, 'authorization')
+    let userId: number | null = null
+    let isAdmin = false
+
+    if (authorization?.startsWith('Bearer ')) {
+      try {
+        const auth = await validateApiKey(event)
+        if (auth.isValid && auth.user) {
+          userId = auth.user.id
+          isAdmin = auth.user.Role === 'ADMIN'
+        }
+      } catch {
+        userId = null
+        isAdmin = false
+      }
+    }
+
+    const and: Prisma.ProjectWhereInput[] = []
+    const includeInactive = booleanParam(query.includeInactive)
+    const includeMature = booleanParam(query.includeMature)
+    const mine = booleanParam(query.mine)
+    const search = typeof query.search === 'string' ? query.search.trim() : ''
+    const status = projectStatuses.has(query.status as ProjectStatus)
+      ? (query.status as ProjectStatus)
+      : undefined
+    const priority = projectPriorities.has(query.priority as ProjectPriority)
+      ? (query.priority as ProjectPriority)
+      : undefined
+
+    if (!includeInactive) and.push({ isActive: true })
+    if (!includeMature && !isAdmin) and.push({ isMature: false })
+
+    if (mine) {
+      and.push(userId ? { userId } : { id: -1 })
+    } else if (!isAdmin) {
+      and.push(userId ? { OR: [{ isPublic: true }, { userId }] } : { isPublic: true })
+    }
+
+    if (status) and.push({ status })
+    if (priority) and.push({ priority })
+    if (query.channelKey) and.push({ channelKey: query.channelKey })
+    if (search) {
+      and.push({
+        OR: [
+          { title: { contains: search } },
+          { slug: { contains: search } },
+          { conductorSlug: { contains: search } },
+          { description: { contains: search } },
+        ],
+      })
+    }
+
+    const projects = await prisma.project.findMany({
+      where: and.length ? { AND: and } : undefined,
+      include: projectInclude,
+      orderBy: [{ priority: 'desc' }, { updatedAt: 'desc' }, { title: 'asc' }],
+      take: numberParam(query.take, 100, 250),
+      skip: numberParam(query.skip, 0, 100000),
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Projects fetched successfully.',
+      data: projects,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -1,0 +1,107 @@
+// /server/api/projects/index.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import type { ProjectPriority, ProjectStatus } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  normalizeNullableId,
+  normalizeOptionalText,
+  normalizeSlug,
+  projectInclude,
+  projectPriorities,
+  projectStatuses,
+} from './index'
+
+type ProjectCreateBody = {
+  title?: unknown
+  slug?: unknown
+  description?: unknown
+  flavorText?: unknown
+  goal?: unknown
+  waypoints?: unknown
+  status?: unknown
+  priority?: unknown
+  conductorSlug?: unknown
+  repoUrl?: unknown
+  liveUrl?: unknown
+  channelKey?: unknown
+  tabKey?: unknown
+  allowReviews?: unknown
+  highlightImage?: unknown
+  icon?: unknown
+  imagePath?: unknown
+  cardPath?: unknown
+  heroPath?: unknown
+  designer?: unknown
+  managerBotId?: unknown
+  artImageId?: unknown
+  artCollectionId?: unknown
+  isPublic?: unknown
+  isMature?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = await readBody<ProjectCreateBody>(event)
+    const title = normalizeOptionalText(body?.title)
+
+    if (!title) {
+      throw createError({ statusCode: 400, message: 'Project title is required.' })
+    }
+
+    const slug = normalizeSlug(body.slug ?? title)
+    const status = projectStatuses.has(body.status as ProjectStatus)
+      ? (body.status as ProjectStatus)
+      : 'BRAINSTORM'
+    const priority = projectPriorities.has(body.priority as ProjectPriority)
+      ? (body.priority as ProjectPriority)
+      : 'NORMAL'
+
+    const project = await prisma.project.create({
+      data: {
+        title,
+        slug,
+        description: normalizeOptionalText(body.description),
+        flavorText: normalizeOptionalText(body.flavorText),
+        goal: normalizeOptionalText(body.goal),
+        waypoints: normalizeOptionalText(body.waypoints),
+        status,
+        priority,
+        conductorSlug: normalizeSlug(body.conductorSlug ?? slug),
+        repoUrl: normalizeOptionalText(body.repoUrl),
+        liveUrl: normalizeOptionalText(body.liveUrl),
+        channelKey: normalizeOptionalText(body.channelKey),
+        tabKey: normalizeOptionalText(body.tabKey),
+        allowReviews: body.allowReviews === true,
+        highlightImage: normalizeOptionalText(body.highlightImage),
+        icon: normalizeOptionalText(body.icon),
+        imagePath: normalizeOptionalText(body.imagePath),
+        cardPath: normalizeOptionalText(body.cardPath),
+        heroPath: normalizeOptionalText(body.heroPath),
+        designer: normalizeOptionalText(body.designer),
+        managerBotId: normalizeNullableId(body.managerBotId),
+        artImageId: normalizeNullableId(body.artImageId),
+        artCollectionId: normalizeNullableId(body.artCollectionId),
+        isPublic: body.isPublic !== false,
+        isMature: body.isMature === true,
+        userId: auth.user.id,
+      },
+      include: projectInclude,
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: 'Project created successfully.',
+      data: project,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/projects/index.ts
+++ b/server/api/projects/index.ts
@@ -1,0 +1,113 @@
+// /server/api/projects/index.ts
+import { createError, getRouterParam } from 'h3'
+import type { H3Event } from 'h3'
+import type { Prisma, ProjectPriority, ProjectStatus } from '~/prisma/generated/prisma/client'
+
+export const projectStatuses = new Set<ProjectStatus>([
+  'ACTIVE',
+  'PAUSED',
+  'DONE',
+  'ARCHIVED',
+  'BRAINSTORM',
+])
+
+export const projectPriorities = new Set<ProjectPriority>(['LOW', 'NORMAL', 'HIGH'])
+
+export const projectInclude = {
+  Manager: {
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      avatarImage: true,
+      imagePath: true,
+    },
+  },
+  ArtImage: {
+    select: {
+      id: true,
+      imagePath: true,
+      thumbnailPath: true,
+      fileName: true,
+    },
+  },
+  ArtCollection: {
+    select: {
+      id: true,
+      label: true,
+      imagePath: true,
+    },
+  },
+  PitchSheet: {
+    select: {
+      id: true,
+      title: true,
+      subtitle: true,
+      hook: true,
+      imagePath: true,
+      artImageId: true,
+      isActive: true,
+      isPublic: true,
+    },
+  },
+  _count: {
+    select: {
+      Chats: true,
+      Todos: true,
+      Reactions: true,
+      ArtJobs: true,
+      ArtImageLinks: true,
+      ArtCollectionLinks: true,
+    },
+  },
+} satisfies Prisma.ProjectInclude
+
+export function getProjectId(event: H3Event): number {
+  const value = Number(getRouterParam(event, 'id'))
+  if (!Number.isInteger(value) || value <= 0) {
+    throw createError({ statusCode: 400, message: 'A valid Project ID is required.' })
+  }
+  return value
+}
+
+export function normalizeOptionalText(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'Expected a text value.' })
+  }
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+export function normalizeSlug(value: unknown): string | null | undefined {
+  const text = normalizeOptionalText(value)
+  if (text === undefined || text === null) return text
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  if (!slug) {
+    throw createError({ statusCode: 400, message: 'Project slug must contain letters or numbers.' })
+  }
+  return slug
+}
+
+export function normalizeNullableId(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'Expected a positive integer ID.' })
+  }
+  return id
+}
+
+export function assertProjectAccess(
+  project: { userId: number },
+  user: { id: number; Role?: string | null },
+): void {
+  if (user.Role !== 'ADMIN' && project.userId !== user.id) {
+    throw createError({ statusCode: 403, message: 'You do not have permission to modify this Project.' })
+  }
+}

--- a/stores/projectStore.ts
+++ b/stores/projectStore.ts
@@ -1,0 +1,192 @@
+// /stores/projectStore.ts
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import type {
+  ArtCollection,
+  ArtImage,
+  Bot,
+  PitchSheet,
+  Project,
+} from '~/prisma/generated/prisma/client'
+import { performFetch } from '@/stores/utils'
+
+export type ProjectWithRelations = Project & {
+  Manager?: Pick<Bot, 'id' | 'name' | 'slug' | 'avatarImage' | 'imagePath'> | null
+  ArtImage?: Partial<ArtImage> | null
+  ArtCollection?: Partial<ArtCollection> | null
+  PitchSheet?: Partial<PitchSheet> | null
+  _count?: {
+    Chats?: number
+    Todos?: number
+    Reactions?: number
+    ArtJobs?: number
+    ArtImageLinks?: number
+    ArtCollectionLinks?: number
+  }
+}
+
+export type ProjectListOptions = {
+  mine?: boolean
+  includeInactive?: boolean
+  includeMature?: boolean
+  status?: Project['status']
+  priority?: Project['priority']
+  channelKey?: string
+  search?: string
+  take?: number
+  skip?: number
+}
+
+type ApiResult<T> = {
+  success: boolean
+  data?: T
+  message?: string
+}
+
+function queryString(options: ProjectListOptions): string {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(options)) {
+    if (value === undefined || value === null || value === '') continue
+    query.set(key, String(value))
+  }
+  const value = query.toString()
+  return value ? `?${value}` : ''
+}
+
+export const useProjectStore = defineStore('projectStore', () => {
+  const projects = ref<ProjectWithRelations[]>([])
+  const selectedProject = ref<ProjectWithRelations | null>(null)
+  const loading = ref(false)
+  const saving = ref(false)
+  const loaded = ref(false)
+  const error = ref<string | null>(null)
+
+  const activeProjects = computed(() =>
+    projects.value.filter((project) => project.isActive && project.status !== 'ARCHIVED'),
+  )
+  const publicProjects = computed(() =>
+    activeProjects.value.filter((project) => project.isPublic && !project.isMature),
+  )
+  const projectsBySlug = computed(
+    () => new Map(projects.value.flatMap((project) => (project.slug ? [[project.slug, project]] : []))),
+  )
+
+  function projectForSlug(slug?: string | null): ProjectWithRelations | null {
+    if (!slug) return null
+    return projectsBySlug.value.get(slug) ?? null
+  }
+
+  function replaceProject(project: ProjectWithRelations): ProjectWithRelations {
+    const index = projects.value.findIndex((entry) => entry.id === project.id)
+    if (index >= 0) projects.value[index] = project
+    else projects.value.unshift(project)
+    if (selectedProject.value?.id === project.id) selectedProject.value = project
+    return project
+  }
+
+  async function fetchProjects(options: ProjectListOptions = {}): Promise<ProjectWithRelations[]> {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await performFetch<ProjectWithRelations[]>(
+        `/api/projects${queryString(options)}`,
+      )
+      if (!response.success) throw new Error(response.message || 'Failed to fetch Projects.')
+      projects.value = response.data ?? []
+      loaded.value = true
+      return projects.value
+    } catch (cause) {
+      error.value = cause instanceof Error ? cause.message : String(cause)
+      throw cause
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchProject(key: number | string): Promise<ProjectWithRelations> {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await performFetch<ProjectWithRelations>(`/api/projects/${key}`)
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Project not found.')
+      }
+      selectedProject.value = replaceProject(response.data)
+      return response.data
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createProject(
+    input: Partial<Project> & Pick<Project, 'title'>,
+  ): Promise<ProjectWithRelations> {
+    saving.value = true
+    try {
+      const response = await performFetch<ProjectWithRelations>('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to create Project.')
+      }
+      return replaceProject(response.data)
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function updateProject(
+    id: number,
+    input: Partial<Project>,
+  ): Promise<ProjectWithRelations> {
+    saving.value = true
+    try {
+      const response = await performFetch<ProjectWithRelations>(`/api/projects/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to update Project.')
+      }
+      return replaceProject(response.data)
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function archiveProject(id: number): Promise<ProjectWithRelations> {
+    saving.value = true
+    try {
+      const response = await performFetch<ProjectWithRelations>(`/api/projects/${id}`, {
+        method: 'DELETE',
+      })
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to archive Project.')
+      }
+      return replaceProject(response.data)
+    } finally {
+      saving.value = false
+    }
+  }
+
+  return {
+    projects,
+    selectedProject,
+    loading,
+    saving,
+    loaded,
+    error,
+    activeProjects,
+    publicProjects,
+    projectsBySlug,
+    projectForSlug,
+    fetchProjects,
+    fetchProject,
+    createProject,
+    updateProject,
+    archiveProject,
+  }
+})


### PR DESCRIPTION
## What changed

- adds first-class Project CRUD routes under `/api/projects`
- supports list filters, ID/slug/conductorSlug lookup, authenticated creation, owner/admin updates, and non-destructive archival
- returns manager, primary art, PitchSheet, and relation counts with Project responses
- adds a dedicated Pinia `projectStore` with fetch, create, update, archive, slug lookup, and public/active projections
- adds Cypress API coverage proving Projects are created, retrieved, listed, updated, and archived as Project rows

## Why

The Project / Dream / Facet schema and production backfill are complete, but the application still uses Project-shaped Dreams. This starts the actual application cutover by establishing the API and store contracts the existing Conductor UI can move onto.

## Compatibility

- does not delete or rewrite legacy Project Dreams
- does not change current Dream routes or `dreamStore`
- archival is soft (`isActive=false`, `status=ARCHIVED`)
- the next slice can wire Conductor components to `projectStore` while retaining temporary Dream fallback for legacy-only fields

## Validation

- existing TypeScript and contract checks will run on the PR
- Cypress spec follows the repository's disposable authenticated-user pattern
