### PR TITLE
Integrate Facets into Dream and Scenario editors

### DIFF
--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -184,6 +184,13 @@
             </label>
           </div>
 
+          <FacetPicker
+            v-model="facetIds"
+            owner-type="dream"
+            :owner-id="dreamStore.dreamForm.id ?? null"
+            label="Dream Facets"
+          />
+
           <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
             <div class="flex flex-wrap items-center justify-between gap-2">
               <div>
@@ -368,8 +375,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useDreamStore } from '@/stores/dreamStore'
+import { useFacetStore } from '@/stores/facetStore'
 import { useNavStore } from '@/stores/navStore'
 
 const emit = defineEmits<{
@@ -378,7 +386,9 @@ const emit = defineEmits<{
 }>()
 
 const dreamStore = useDreamStore()
+const facetStore = useFacetStore()
 const navStore = useNavStore()
+const facetIds = ref<number[]>([])
 
 const canSave = computed(() => {
   return Boolean(
@@ -508,16 +518,19 @@ function copyPitchToArtPrompt() {
 }
 
 function clearForm() {
+  facetIds.value = []
   dreamStore.startAddingDream()
 }
 
 async function saveDream() {
+  const wasCreating = !dreamStore.dreamForm.id
   const result = await dreamStore.saveDream()
 
   if (!result.success || !result.data?.id) return
 
+  await facetStore.setDreamFacets(result.data.id, facetIds.value)
   emit('saved', result.data.id)
-  if (!dreamStore.dreamForm.id) emit('created', result.data.id)
+  if (wasCreating) emit('created', result.data.id)
 
   await dreamStore.selectDreamById(result.data.id)
   navStore.setDashboardTab?.('dream', 'interact')

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -1,0 +1,277 @@
+<!-- /components/facets/facet-picker.vue -->
+<template>
+  <section class="space-y-3 rounded-2xl border border-base-300 bg-base-100 p-4">
+    <div class="flex flex-wrap items-center gap-2">
+      <Icon name="kind-icon:tag" class="size-4 text-secondary" />
+      <div class="min-w-0 flex-1">
+        <h3 class="text-sm font-bold">{{ label }}</h3>
+        <p class="text-xs text-base-content/50">
+          Reusable flavor shared by Dreams and Scenarios. Aliases resolve to one
+          canonical Facet.
+        </p>
+      </div>
+      <span v-if="saving || loadingAssignments" class="loading loading-spinner loading-xs" />
+      <span class="badge badge-ghost badge-sm">{{ selectedFacets.length }}</span>
+    </div>
+
+    <div v-if="selectedFacets.length" class="flex flex-wrap gap-2">
+      <button
+        v-for="facet in selectedFacets"
+        :key="facet.id"
+        type="button"
+        class="badge badge-secondary badge-lg gap-1 rounded-xl"
+        :title="facetTitle(facet)"
+        :disabled="saving"
+        @click="removeFacet(facet.id)"
+      >
+        <span>{{ facet.title }}</span>
+        <span class="text-secondary-content/60">×</span>
+      </button>
+    </div>
+
+    <div class="relative">
+      <input
+        v-model="search"
+        type="search"
+        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        placeholder="Search title, slug, or alias — try cow, cows, cowCore..."
+        @focus="showResults = true"
+      />
+
+      <div
+        v-if="showResults && search.trim()"
+        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
+      >
+        <button
+          v-for="facet in searchResults"
+          :key="facet.id"
+          type="button"
+          class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left hover:bg-base-200 disabled:opacity-40"
+          :disabled="selectedIds.has(facet.id) || saving"
+          @click="addFacet(facet.id)"
+        >
+          <span class="badge badge-outline badge-xs shrink-0">{{ kindLabel(facet.kind) }}</span>
+          <span class="min-w-0 flex-1">
+            <span class="block truncate text-sm font-semibold">{{ facet.title }}</span>
+            <span class="block truncate text-xs text-base-content/40">
+              {{ facet.aliases.join(' · ') }}
+            </span>
+          </span>
+          <Icon name="kind-icon:plus" class="size-3.5 shrink-0" />
+        </button>
+
+        <p v-if="!searchResults.length" class="px-3 py-3 text-xs text-base-content/40">
+          No matching Facet. Create one below.
+        </p>
+      </div>
+    </div>
+
+    <details class="rounded-xl border border-base-300 bg-base-200/60">
+      <summary class="cursor-pointer px-3 py-2 text-xs font-bold text-base-content/60">
+        Create a new Facet
+      </summary>
+      <div class="grid gap-2 border-t border-base-300 p-3 sm:grid-cols-2">
+        <input
+          v-model="newTitle"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="Canonical title, e.g. CowCore"
+        />
+        <select v-model="newKind" class="select select-bordered select-sm rounded-xl">
+          <option v-for="kind in facetKinds" :key="kind" :value="kind">
+            {{ kindLabel(kind) }}
+          </option>
+        </select>
+        <input
+          v-model="newAliases"
+          type="text"
+          class="input input-bordered input-sm rounded-xl sm:col-span-2"
+          placeholder="Aliases separated by commas, e.g. cow, cows"
+        />
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm rounded-xl sm:col-span-2"
+          :disabled="!newTitle.trim() || facetStore.saving"
+          @click="createAndAddFacet"
+        >
+          <span v-if="facetStore.saving" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:plus" class="size-3.5" />
+          Create and attach
+        </button>
+      </div>
+    </details>
+
+    <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import type { FacetKind } from '~/prisma/generated/prisma/client'
+import {
+  useFacetStore,
+  type FacetWithAliases,
+} from '@/stores/facetStore'
+import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: number[]
+    ownerType: 'dream' | 'scenario'
+    ownerId?: number | null
+    label?: string
+  }>(),
+  {
+    ownerId: null,
+    label: 'Facets',
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number[]]
+}>()
+
+const facetStore = useFacetStore()
+const search = ref('')
+const showResults = ref(false)
+const loadingAssignments = ref(false)
+const errorMessage = ref('')
+const newTitle = ref('')
+const newAliases = ref('')
+const newKind = ref<FacetKind>('OTHER')
+
+const facetKinds: FacetKind[] = [
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'OTHER',
+]
+
+const saving = computed(() => facetStore.saving)
+const selectedIds = computed(() => new Set(props.modelValue))
+const selectedFacets = computed(() =>
+  props.modelValue
+    .map((id) => facetStore.facets.find((facet) => facet.id === id))
+    .filter((facet): facet is FacetWithAliases => Boolean(facet)),
+)
+
+const searchResults = computed(() => {
+  const needle = normalizeFacetLookupKey(search.value)
+  if (!needle) return []
+
+  return facetStore.activeFacets
+    .filter((facet) => {
+      const values = [facet.title, facet.slug, ...facet.aliases]
+      return values.some((value) =>
+        normalizeFacetLookupKey(value || '').includes(needle),
+      )
+    })
+    .slice(0, 30)
+})
+
+onMounted(async () => {
+  try {
+    if (!facetStore.loaded) await facetStore.fetchFacets()
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facets could not be loaded.'
+  }
+})
+
+watch(
+  () => [props.ownerType, props.ownerId] as const,
+  async ([ownerType, ownerId]) => {
+    if (!ownerId || ownerId <= 0) return
+    loadingAssignments.value = true
+    errorMessage.value = ''
+    try {
+      const facets =
+        ownerType === 'dream'
+          ? await facetStore.fetchDreamFacets(ownerId)
+          : await facetStore.fetchScenarioFacets(ownerId)
+      emit(
+        'update:modelValue',
+        facets.map((facet) => facet.id),
+      )
+    } catch (error) {
+      errorMessage.value =
+        error instanceof Error
+          ? error.message
+          : 'Assigned Facets could not be loaded.'
+    } finally {
+      loadingAssignments.value = false
+    }
+  },
+  { immediate: true },
+)
+
+function kindLabel(kind: FacetKind): string {
+  return kind
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function facetTitle(facet: FacetWithAliases): string {
+  return `${kindLabel(facet.kind)} · ${facet.aliases.join(', ')}`
+}
+
+async function persist(next: number[]) {
+  emit('update:modelValue', next)
+  if (!props.ownerId || props.ownerId <= 0) return
+
+  errorMessage.value = ''
+  try {
+    if (props.ownerType === 'dream') {
+      await facetStore.setDreamFacets(props.ownerId, next)
+    } else {
+      await facetStore.setScenarioFacets(props.ownerId, next)
+    }
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facets could not be saved.'
+  }
+}
+
+async function addFacet(facetId: number) {
+  if (selectedIds.value.has(facetId)) return
+  await persist([...props.modelValue, facetId])
+  search.value = ''
+  showResults.value = false
+}
+
+async function removeFacet(facetId: number) {
+  await persist(props.modelValue.filter((id) => id !== facetId))
+}
+
+async function createAndAddFacet() {
+  const title = newTitle.value.trim()
+  if (!title) return
+
+  errorMessage.value = ''
+  try {
+    const facet = await facetStore.createFacet({
+      title,
+      kind: newKind.value,
+      aliases: newAliases.value
+        .split(',')
+        .map((alias) => alias.trim())
+        .filter(Boolean),
+      isPublic: true,
+    })
+    await addFacet(facet.id)
+    newTitle.value = ''
+    newAliases.value = ''
+    newKind.value = 'OTHER'
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facet could not be created.'
+  }
+}
+</script>

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -72,11 +72,12 @@
       </section>
 
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div class="rounded-2xl border border-base-300 bg-base-100 p-4">
-          <h2 class="mb-3 text-lg font-bold text-base-content">Genres</h2>
-
-          <choice-manager label="genre" model="Scenario" />
-        </div>
+        <FacetPicker
+          v-model="facetIds"
+          owner-type="scenario"
+          :owner-id="scenarioStore.scenarioForm.id ?? null"
+          label="Scenario Facets"
+        />
 
         <label
           class="form-control rounded-2xl border border-base-300 bg-base-100 p-4"
@@ -91,6 +92,21 @@
             class="textarea textarea-bordered min-h-28 w-full bg-base-200"
           />
         </label>
+
+        <details
+          class="rounded-2xl border border-base-300 bg-base-100 p-4 lg:col-span-2"
+        >
+          <summary class="cursor-pointer text-sm font-bold text-base-content/60">
+            Legacy genre compatibility
+          </summary>
+          <p class="mt-2 text-xs text-base-content/50">
+            Existing Genre Dream links remain available during the Facet migration.
+            New reusable genre data should be added as Facets above.
+          </p>
+          <div class="mt-3">
+            <choice-manager label="genre" model="Scenario" />
+          </div>
+        </details>
       </section>
 
       <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
@@ -282,6 +298,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useArtStore } from '@/stores/artStore'
 import { useChoiceStore } from '@/stores/choiceStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
+import { useFacetStore } from '@/stores/facetStore'
 import { useUploadStore } from '@/stores/uploadStore'
 import { useUserStore } from '@/stores/userStore'
 import { useDreamStore } from '@/stores/dreamStore'
@@ -302,6 +319,7 @@ const emit = defineEmits<{
 const artStore = useArtStore()
 const choiceStore = useChoiceStore()
 const scenarioStore = useScenarioStore()
+const facetStore = useFacetStore()
 const uploadStore = useUploadStore()
 const userStore = useUserStore()
 const dreamStore = useDreamStore()
@@ -313,6 +331,7 @@ const introPrompt = ref('')
 const statusMessage = ref('')
 const statusTone = ref<'success' | 'error'>('success')
 const uploadedPreviewImage = ref<string | null>(null)
+const facetIds = ref<number[]>([])
 
 const defaultPlaceholder = '/images/scenarios/space.webp'
 
@@ -428,6 +447,7 @@ async function prepareForm() {
 
 function resetForAdd() {
   scenarioStore.deselectScenario()
+  facetIds.value = []
 
   scenarioStore.scenarioForm = {
     title: '',
@@ -451,6 +471,7 @@ function resetForAdd() {
 
 function resetFromSelected() {
   if (!scenarioStore.selectedScenario) return
+  facetIds.value = []
 
   scenarioStore.scenarioForm = scenarioStore.toScenarioForm(
     scenarioStore.selectedScenario,
@@ -628,6 +649,10 @@ async function saveScenario() {
 
     const savedScenarioId =
       scenarioStore.selectedScenario?.id ?? scenarioStore.scenarioForm.id
+
+    if (savedScenarioId) {
+      await facetStore.setScenarioFacets(savedScenarioId, facetIds.value)
+    }
 
     if (selectedDream?.id && savedScenarioId) {
       const dreamResult = await dreamStore.setDreamScenario(savedScenarioId)

--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -1,0 +1,187 @@
+// /cypress/e2e/api/facet-assignments.cy.ts
+import { createLoggedInTestUser } from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+describe('Dream and Scenario Facet assignments', () => {
+  const apiBase = 'https://kind-robots.vercel.app/api'
+  const stamp = Date.now()
+  const facetSlug = `cowcore-${stamp}`
+  const cowAlias = `cow-${stamp}`
+  const cowsAlias = `cows-${stamp}`
+  let token = ''
+  let facetId = 0
+  let dreamId = 0
+  let scenarioId = 0
+
+  before(() => {
+    createLoggedInTestUser().then((auth) => {
+      token = auth.token
+    })
+  })
+
+  it('creates one canonical Facet with singular and plural aliases', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        title: `CowCore ${stamp}`,
+        slug: facetSlug,
+        kind: 'CORE',
+        aliases: [cowAlias, cowsAlias],
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      expect(response.body.success).to.be.true
+      expect(response.body.data.aliases).to.include(facetSlug)
+      expect(response.body.data.aliases).to.include(cowAlias)
+      expect(response.body.data.aliases).to.include(cowsAlias)
+      facetId = response.body.data.id
+    })
+  })
+
+  it('resolves canonical formatting variants and explicit aliases to one Facet', () => {
+    const keys = [
+      facetSlug,
+      `cowCore ${stamp}`,
+      `cow-core-${stamp}`,
+      cowAlias,
+      cowsAlias,
+    ]
+
+    keys.forEach((key) => {
+      cy.request(`${apiBase}/facets/${encodeURIComponent(key)}`).then(
+        (response) => {
+          expect(response.status).to.eq(200)
+          expect(response.body.success).to.be.true
+          expect(response.body.data.id).to.eq(facetId)
+        },
+      )
+    })
+  })
+
+  it('assigns the Facet to a Dream through an alias key', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/dreams`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        title: `Facet Dream ${stamp}`,
+        dreamType: 'PITCH',
+        description: 'Dream Facet assignment coverage.',
+        isPublic: false,
+        createCollection: false,
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      dreamId = response.body.data.id
+    })
+
+    cy.request({
+      method: 'PUT',
+      url: `${apiBase}/dreams/${dreamId}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { facetKeys: [cowAlias] },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data).to.have.length(1)
+      expect(response.body.data[0].id).to.eq(facetId)
+    })
+
+    cy.request({
+      url: `${apiBase}/dreams/${dreamId}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data.map((facet: { id: number }) => facet.id)).to.deep.eq([
+        facetId,
+      ])
+    })
+  })
+
+  it('assigns the same Facet to a Scenario through the plural alias', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/scenarios`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        title: `Facet Scenario ${stamp}`,
+        description: 'Scenario Facet assignment coverage.',
+        intros: [],
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      scenarioId = response.body.data.id
+    })
+
+    cy.request({
+      method: 'PUT',
+      url: `${apiBase}/scenarios/${scenarioId}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { facetKeys: [cowsAlias] },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data).to.have.length(1)
+      expect(response.body.data[0].id).to.eq(facetId)
+    })
+
+    cy.request({
+      url: `${apiBase}/scenarios/${scenarioId}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data[0].id).to.eq(facetId)
+    })
+  })
+
+  it('uses exact-set semantics when a Facet is removed', () => {
+    cy.request({
+      method: 'PUT',
+      url: `${apiBase}/dreams/${dreamId}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { facetIds: [] },
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.data).to.deep.eq([])
+    })
+
+    cy.request({
+      url: `${apiBase}/dreams/${dreamId}/facets`,
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((response) => {
+      expect(response.body.data).to.deep.eq([])
+    })
+  })
+
+  after(() => {
+    if (dreamId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${apiBase}/dreams/${dreamId}`,
+        headers: { Authorization: `Bearer ${token}` },
+        failOnStatusCode: false,
+      })
+    }
+
+    if (scenarioId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${apiBase}/scenarios/${scenarioId}`,
+        headers: { Authorization: `Bearer ${token}` },
+        failOnStatusCode: false,
+      })
+    }
+
+    if (facetId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${apiBase}/facets/${facetId}`,
+        headers: { Authorization: `Bearer ${token}` },
+        failOnStatusCode: false,
+      })
+    }
+  })
+})

--- a/server/api/dreams/[id]/facets.get.ts
+++ b/server/api/dreams/[id]/facets.get.ts
@@ -1,0 +1,47 @@
+// GET /api/dreams/:id/facets
+import { createError, defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { getOptionalApiUser } from '~/server/utils/authGuard'
+import { loadFacetSummaries } from '~/server/utils/facetAssignments'
+import { assertDreamAccess } from '~/server/api/dreams/index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Dream ID.' })
+    }
+
+    const [dream, auth] = await Promise.all([
+      prisma.dream.findUnique({
+        where: { id },
+        select: { id: true, userId: true, isPublic: true },
+      }),
+      getOptionalApiUser(event),
+    ])
+
+    if (!dream) {
+      throw createError({ statusCode: 404, message: 'Dream not found.' })
+    }
+
+    assertDreamAccess({
+      dream,
+      userId: auth?.user.id,
+      userRole: auth?.user.Role,
+      action: 'view',
+    })
+
+    const links = await prisma.dreamFacet.findMany({
+      where: { dreamId: id },
+      select: { facetId: true },
+    })
+
+    return {
+      success: true,
+      data: await loadFacetSummaries(links.map((link) => link.facetId)),
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})

--- a/server/api/dreams/[id]/facets.put.ts
+++ b/server/api/dreams/[id]/facets.put.ts
@@ -1,0 +1,69 @@
+// PUT /api/dreams/:id/facets
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  parseFacetSelectionBody,
+  resolveFacetSelection,
+} from '~/server/utils/facetAssignments'
+import { assertDreamAccess } from '~/server/api/dreams/index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Dream ID.' })
+    }
+
+    const auth = await requireApiUser(event)
+    const dream = await prisma.dream.findUnique({
+      where: { id },
+      select: { id: true, userId: true, isPublic: true },
+    })
+
+    if (!dream) {
+      throw createError({ statusCode: 404, message: 'Dream not found.' })
+    }
+
+    assertDreamAccess({
+      dream,
+      userId: auth.user.id,
+      userRole: auth.user.Role,
+      action: 'mutate',
+    })
+
+    const selection = parseFacetSelectionBody(await readBody(event))
+    const facets = await resolveFacetSelection({
+      ...selection,
+      userId: auth.user.id,
+      isAdmin: auth.isAdmin,
+    })
+    const facetIds = facets.map((facet) => facet.id)
+
+    await prisma.$transaction(async (tx) => {
+      await tx.dreamFacet.deleteMany({
+        where: facetIds.length
+          ? { dreamId: id, facetId: { notIn: facetIds } }
+          : { dreamId: id },
+      })
+
+      if (facetIds.length) {
+        await tx.dreamFacet.createMany({
+          data: facetIds.map((facetId) => ({ dreamId: id, facetId })),
+          skipDuplicates: true,
+        })
+      }
+    })
+
+    return {
+      success: true,
+      message: 'Dream Facets updated.',
+      data: facets,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/facets/[id].delete.ts
+++ b/server/api/facets/[id].delete.ts
@@ -1,0 +1,58 @@
+// DELETE /api/facets/:id
+import { createError, defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  facetSummarySelect,
+  hydrateFacetSummaries,
+} from '~/server/utils/facetAssignments'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Facet ID.' })
+    }
+
+    const auth = await requireApiUser(event)
+    const existing = await prisma.facet.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    })
+
+    if (!existing) {
+      throw createError({ statusCode: 404, message: 'Facet not found.' })
+    }
+
+    if (!auth.isAdmin && existing.userId !== auth.user.id) {
+      throw createError({
+        statusCode: 403,
+        message: 'You do not have permission to archive this Facet.',
+      })
+    }
+
+    const facet = await prisma.$transaction(async (tx) => {
+      await tx.facetAlias.updateMany({
+        where: { facetId: id },
+        data: { isActive: false },
+      })
+      return tx.facet.update({
+        where: { id },
+        data: { isActive: false },
+        select: facetSummarySelect,
+      })
+    })
+
+    const [data] = await hydrateFacetSummaries([facet])
+    return {
+      success: true,
+      message: 'Facet archived successfully.',
+      data,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/facets/[key].get.ts
+++ b/server/api/facets/[key].get.ts
@@ -1,6 +1,7 @@
 // /server/api/facets/[key].get.ts
 import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { errorHandler } from '~/server/utils/error'
+import { getOptionalApiUser } from '~/server/utils/authGuard'
 import { resolveFacetAlias } from '~/server/utils/facetAliases'
 
 export default defineEventHandler(async (event) => {
@@ -8,13 +9,35 @@ export default defineEventHandler(async (event) => {
     const requested = getRouterParam(event, 'key')?.trim()
 
     if (!requested) {
-      throw createError({ statusCode: 400, message: 'Facet slug or alias is required.' })
+      throw createError({
+        statusCode: 400,
+        message: 'Facet slug or alias is required.',
+      })
     }
 
-    const resolved = await resolveFacetAlias(requested)
+    const [resolved, auth] = await Promise.all([
+      resolveFacetAlias(requested),
+      getOptionalApiUser(event),
+    ])
 
-    if (!resolved) {
+    if (!resolved || !resolved.facet.isActive) {
       throw createError({ statusCode: 404, message: 'Facet not found.' })
+    }
+
+    const isOwner =
+      Boolean(auth?.user.id) && resolved.facet.userId === auth?.user.id
+    const canView =
+      auth?.isAdmin ||
+      isOwner ||
+      (resolved.facet.isPublic && !resolved.facet.isMature)
+
+    if (!canView) {
+      throw createError({
+        statusCode: auth ? 403 : 404,
+        message: auth
+          ? 'You do not have permission to view this Facet.'
+          : 'Facet not found.',
+      })
     }
 
     event.node.res.statusCode = 200

--- a/server/api/facets/index.get.ts
+++ b/server/api/facets/index.get.ts
@@ -1,0 +1,105 @@
+// GET /api/facets
+import { defineEventHandler, getQuery } from 'h3'
+import type { FacetKind, Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { getOptionalApiUser } from '~/server/utils/authGuard'
+import {
+  facetKinds,
+  facetSummarySelect,
+  hydrateFacetSummaries,
+} from '~/server/utils/facetAssignments'
+import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+
+type FacetListQuery = {
+  search?: string
+  kind?: string
+  includeInactive?: string
+  includeMature?: string
+  mine?: string
+  take?: string
+  skip?: string
+}
+
+function toBoolean(value: unknown): boolean {
+  return value === true || value === 'true' || value === '1'
+}
+
+function toPositiveInt(value: unknown, fallback: number, max: number): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) return fallback
+  return Math.min(parsed, max)
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery<FacetListQuery>(event)
+    const auth = await getOptionalApiUser(event)
+    const userId = auth?.user.id ?? null
+    const isAdmin = auth?.isAdmin ?? false
+    const includeInactive = isAdmin && toBoolean(query.includeInactive)
+    const includeMature = isAdmin && toBoolean(query.includeMature)
+    const mine = toBoolean(query.mine)
+    const take = Math.max(1, toPositiveInt(query.take, 100, 250))
+    const skip = toPositiveInt(query.skip, 0, 100000)
+    const search = typeof query.search === 'string' ? query.search.trim() : ''
+    const kind = facetKinds.includes(query.kind as FacetKind)
+      ? (query.kind as FacetKind)
+      : null
+
+    const andFilters: Prisma.FacetWhereInput[] = []
+    if (!includeInactive) andFilters.push({ isActive: true })
+    if (!includeMature) andFilters.push({ isMature: false })
+
+    if (mine) {
+      andFilters.push(userId ? { userId } : { id: -1 })
+    } else if (!isAdmin) {
+      andFilters.push(
+        userId
+          ? { OR: [{ isPublic: true }, { userId }] }
+          : { isPublic: true },
+      )
+    }
+
+    if (kind) andFilters.push({ kind })
+
+    if (search) {
+      const lookupKey = normalizeFacetLookupKey(search)
+      const aliasMatches = lookupKey
+        ? await prisma.facetAlias.findMany({
+            where: {
+              isActive: true,
+              lookupKey: { contains: lookupKey },
+            },
+            select: { facetId: true },
+            take: 250,
+          })
+        : []
+
+      andFilters.push({
+        OR: [
+          { title: { contains: search } },
+          { slug: { contains: search } },
+          { description: { contains: search } },
+          { id: { in: aliasMatches.map((alias) => alias.facetId) } },
+        ],
+      })
+    }
+
+    const facets = await prisma.facet.findMany({
+      where: andFilters.length ? { AND: andFilters } : undefined,
+      orderBy: [{ kind: 'asc' }, { title: 'asc' }],
+      take,
+      skip,
+      select: facetSummarySelect,
+    })
+
+    return {
+      success: true,
+      data: await hydrateFacetSummaries(facets),
+      count: facets.length,
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})

--- a/server/api/facets/index.post.ts
+++ b/server/api/facets/index.post.ts
@@ -1,0 +1,175 @@
+// POST /api/facets
+import { createError, defineEventHandler, readBody } from 'h3'
+import type {
+  CreationSource,
+  FacetKind,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  facetKinds,
+  facetSummarySelect,
+  hydrateFacetSummaries,
+} from '~/server/utils/facetAssignments'
+import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+
+type FacetCreateBody = {
+  title?: unknown
+  slug?: unknown
+  kind?: unknown
+  description?: unknown
+  flavorText?: unknown
+  examples?: unknown
+  artPrompt?: unknown
+  imagePath?: unknown
+  cardPath?: unknown
+  heroPath?: unknown
+  icon?: unknown
+  designer?: unknown
+  creationSource?: unknown
+  artImageId?: unknown
+  artCollectionId?: unknown
+  isPublic?: unknown
+  isMature?: unknown
+  aliases?: unknown
+}
+
+const creationSources: CreationSource[] = [
+  'HUMAN',
+  'AI',
+  'HYBRID',
+  'UPLOAD',
+  'UNKNOWN',
+]
+
+function optionalText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function positiveId(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function facetSlug(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function normalizeAliases(value: unknown): string[] {
+  const entries = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : []
+
+  const aliases = entries
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter(Boolean)
+
+  const byLookupKey = new Map<string, string>()
+  for (const alias of aliases) {
+    const lookupKey = normalizeFacetLookupKey(alias)
+    if (lookupKey && !byLookupKey.has(lookupKey)) byLookupKey.set(lookupKey, alias)
+  }
+
+  return Array.from(byLookupKey.values())
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = await readBody<FacetCreateBody>(event)
+    const title = optionalText(body.title)
+
+    if (!title) {
+      throw createError({ statusCode: 400, message: 'Facet title is required.' })
+    }
+
+    const slug = facetSlug(body.slug || title)
+    if (!slug) {
+      throw createError({ statusCode: 400, message: 'Facet slug is required.' })
+    }
+
+    const kind = facetKinds.includes(body.kind as FacetKind)
+      ? (body.kind as FacetKind)
+      : 'OTHER'
+    const creationSource = creationSources.includes(
+      body.creationSource as CreationSource,
+    )
+      ? (body.creationSource as CreationSource)
+      : 'HUMAN'
+
+    const explicitAliases = normalizeAliases(body.aliases)
+    const aliasesByKey = new Map<string, { alias: string; isCanonical: boolean }>()
+    const canonicalKey = normalizeFacetLookupKey(slug)
+    aliasesByKey.set(canonicalKey, { alias: slug, isCanonical: true })
+
+    for (const alias of explicitAliases) {
+      const lookupKey = normalizeFacetLookupKey(alias)
+      if (!lookupKey || lookupKey === canonicalKey) continue
+      aliasesByKey.set(lookupKey, { alias, isCanonical: false })
+    }
+
+    const created = await prisma.$transaction(async (tx) => {
+      const data: Prisma.FacetUncheckedCreateInput = {
+        title,
+        slug,
+        kind,
+        description: optionalText(body.description),
+        flavorText: optionalText(body.flavorText),
+        examples: optionalText(body.examples),
+        artPrompt: optionalText(body.artPrompt),
+        imagePath: optionalText(body.imagePath),
+        cardPath: optionalText(body.cardPath),
+        heroPath: optionalText(body.heroPath),
+        icon: optionalText(body.icon),
+        designer: optionalText(body.designer),
+        creationSource,
+        userId: auth.user.id,
+        artImageId: positiveId(body.artImageId),
+        artCollectionId: positiveId(body.artCollectionId),
+        isPublic: body.isPublic !== false,
+        isMature: body.isMature === true,
+        isActive: true,
+      }
+
+      const facet = await tx.facet.create({
+        data,
+        select: facetSummarySelect,
+      })
+
+      await tx.facetAlias.createMany({
+        data: Array.from(aliasesByKey.entries()).map(
+          ([lookupKey, alias]) => ({
+            facetId: facet.id,
+            alias: alias.alias,
+            lookupKey,
+            isCanonical: alias.isCanonical,
+            isActive: true,
+          }),
+        ),
+      })
+
+      return facet
+    })
+
+    const [facet] = await hydrateFacetSummaries([created])
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: 'Facet created successfully.',
+      data: facet,
+      statusCode: 201,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/scenarios/[id]/facets.get.ts
+++ b/server/api/scenarios/[id]/facets.get.ts
@@ -1,0 +1,51 @@
+// GET /api/scenarios/:id/facets
+import { createError, defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { getOptionalApiUser } from '~/server/utils/authGuard'
+import { loadFacetSummaries } from '~/server/utils/facetAssignments'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Scenario ID.' })
+    }
+
+    const [scenario, auth] = await Promise.all([
+      prisma.scenario.findUnique({
+        where: { id },
+        select: { id: true, userId: true, isPublic: true },
+      }),
+      getOptionalApiUser(event),
+    ])
+
+    if (!scenario) {
+      throw createError({ statusCode: 404, message: 'Scenario not found.' })
+    }
+
+    const canView =
+      scenario.isPublic ||
+      auth?.isAdmin ||
+      (auth?.user.id && scenario.userId === auth.user.id)
+
+    if (!canView) {
+      throw createError({
+        statusCode: auth ? 403 : 401,
+        message: 'You do not have permission to view this Scenario.',
+      })
+    }
+
+    const links = await prisma.scenarioFacet.findMany({
+      where: { scenarioId: id },
+      select: { facetId: true },
+    })
+
+    return {
+      success: true,
+      data: await loadFacetSummaries(links.map((link) => link.facetId)),
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})

--- a/server/api/scenarios/[id]/facets.put.ts
+++ b/server/api/scenarios/[id]/facets.put.ts
@@ -1,0 +1,68 @@
+// PUT /api/scenarios/:id/facets
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  parseFacetSelectionBody,
+  resolveFacetSelection,
+} from '~/server/utils/facetAssignments'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Scenario ID.' })
+    }
+
+    const auth = await requireApiUser(event)
+    const scenario = await prisma.scenario.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    })
+
+    if (!scenario) {
+      throw createError({ statusCode: 404, message: 'Scenario not found.' })
+    }
+
+    if (!auth.isAdmin && scenario.userId !== auth.user.id) {
+      throw createError({
+        statusCode: 403,
+        message: 'You do not have permission to update this Scenario.',
+      })
+    }
+
+    const selection = parseFacetSelectionBody(await readBody(event))
+    const facets = await resolveFacetSelection({
+      ...selection,
+      userId: auth.user.id,
+      isAdmin: auth.isAdmin,
+    })
+    const facetIds = facets.map((facet) => facet.id)
+
+    await prisma.$transaction(async (tx) => {
+      await tx.scenarioFacet.deleteMany({
+        where: facetIds.length
+          ? { scenarioId: id, facetId: { notIn: facetIds } }
+          : { scenarioId: id },
+      })
+
+      if (facetIds.length) {
+        await tx.scenarioFacet.createMany({
+          data: facetIds.map((facetId) => ({ scenarioId: id, facetId })),
+          skipDuplicates: true,
+        })
+      }
+    })
+
+    return {
+      success: true,
+      message: 'Scenario Facets updated.',
+      data: facets,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/utils/facetAssignments.ts
+++ b/server/utils/facetAssignments.ts
@@ -1,0 +1,209 @@
+// /server/utils/facetAssignments.ts
+import { createError } from 'h3'
+import type { Facet, FacetKind, Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { resolveFacetAlias } from '~/server/utils/facetAliases'
+
+export type FacetSummary = Pick<
+  Facet,
+  | 'id'
+  | 'title'
+  | 'slug'
+  | 'kind'
+  | 'description'
+  | 'flavorText'
+  | 'imagePath'
+  | 'icon'
+  | 'userId'
+  | 'isPublic'
+  | 'isMature'
+  | 'isActive'
+> & {
+  aliases: string[]
+}
+
+export const facetKinds: FacetKind[] = [
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'OTHER',
+]
+
+export const facetSummarySelect = {
+  id: true,
+  title: true,
+  slug: true,
+  kind: true,
+  description: true,
+  flavorText: true,
+  imagePath: true,
+  icon: true,
+  userId: true,
+  isPublic: true,
+  isMature: true,
+  isActive: true,
+} satisfies Prisma.FacetSelect
+
+type RawFacetSummary = Prisma.FacetGetPayload<{
+  select: typeof facetSummarySelect
+}>
+
+function normalizePositiveIds(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+
+  return Array.from(
+    new Set(
+      value
+        .map((entry) => Number(entry))
+        .filter((id) => Number.isInteger(id) && id > 0),
+    ),
+  )
+}
+
+function normalizeKeys(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  return Array.from(
+    new Set(
+      value
+        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+        .filter(Boolean),
+    ),
+  )
+}
+
+export async function hydrateFacetSummaries(
+  facets: RawFacetSummary[],
+): Promise<FacetSummary[]> {
+  if (!facets.length) return []
+
+  const aliases = await prisma.facetAlias.findMany({
+    where: {
+      facetId: { in: facets.map((facet) => facet.id) },
+      isActive: true,
+    },
+    orderBy: [{ isCanonical: 'desc' }, { alias: 'asc' }],
+    select: {
+      facetId: true,
+      alias: true,
+    },
+  })
+
+  const aliasesByFacet = new Map<number, string[]>()
+  for (const alias of aliases) {
+    const entries = aliasesByFacet.get(alias.facetId) ?? []
+    entries.push(alias.alias)
+    aliasesByFacet.set(alias.facetId, entries)
+  }
+
+  return facets.map((facet) => ({
+    ...facet,
+    aliases: aliasesByFacet.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
+  }))
+}
+
+export async function loadFacetSummaries(
+  facetIds: number[],
+): Promise<FacetSummary[]> {
+  if (!facetIds.length) return []
+
+  const facets = await prisma.facet.findMany({
+    where: {
+      id: { in: facetIds },
+      isActive: true,
+    },
+    orderBy: [{ kind: 'asc' }, { title: 'asc' }],
+    select: facetSummarySelect,
+  })
+
+  return hydrateFacetSummaries(facets)
+}
+
+export async function resolveFacetSelection(options: {
+  facetIds?: unknown
+  facetKeys?: unknown
+  userId: number
+  isAdmin: boolean
+}): Promise<FacetSummary[]> {
+  const requestedIds = normalizePositiveIds(options.facetIds)
+  const requestedKeys = normalizeKeys(options.facetKeys)
+
+  const resolvedKeyIds: number[] = []
+  for (const key of requestedKeys) {
+    const resolved = await resolveFacetAlias(key)
+    if (!resolved) {
+      throw createError({
+        statusCode: 404,
+        message: `Facet not found for key: ${key}.`,
+      })
+    }
+    resolvedKeyIds.push(resolved.facet.id)
+  }
+
+  const facetIds = Array.from(new Set([...requestedIds, ...resolvedKeyIds]))
+  if (!facetIds.length) return []
+
+  const facets = await prisma.facet.findMany({
+    where: {
+      id: { in: facetIds },
+      isActive: true,
+    },
+    select: facetSummarySelect,
+  })
+
+  const foundIds = new Set(facets.map((facet) => facet.id))
+  const missingIds = facetIds.filter((id) => !foundIds.has(id))
+  if (missingIds.length) {
+    throw createError({
+      statusCode: 404,
+      message: `Facet IDs not found or inactive: ${missingIds.join(', ')}.`,
+    })
+  }
+
+  const forbidden = options.isAdmin
+    ? []
+    : facets.filter(
+        (facet) => !facet.isPublic && facet.userId !== options.userId,
+      )
+
+  if (forbidden.length) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach Facet IDs: ${forbidden
+        .map((facet) => facet.id)
+        .join(', ')}.`,
+    })
+  }
+
+  return hydrateFacetSummaries(
+    facets.sort((a, b) =>
+      a.kind === b.kind
+        ? a.title.localeCompare(b.title)
+        : a.kind.localeCompare(b.kind),
+    ),
+  )
+}
+
+export function parseFacetSelectionBody(body: unknown): {
+  facetIds: unknown
+  facetKeys: unknown
+} {
+  if (!body || typeof body !== 'object') {
+    throw createError({
+      statusCode: 400,
+      message: 'Facet assignment body must be an object.',
+    })
+  }
+
+  const record = body as Record<string, unknown>
+  return {
+    facetIds: record.facetIds,
+    facetKeys: record.facetKeys,
+  }
+}

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -1,0 +1,254 @@
+// /stores/facetStore.ts
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import type { Facet, FacetKind } from '~/prisma/generated/prisma/client'
+import { performFetch } from '@/stores/utils'
+import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+
+export type FacetWithAliases = Pick<
+  Facet,
+  | 'id'
+  | 'title'
+  | 'slug'
+  | 'kind'
+  | 'description'
+  | 'flavorText'
+  | 'imagePath'
+  | 'icon'
+  | 'userId'
+  | 'isPublic'
+  | 'isMature'
+  | 'isActive'
+> & {
+  aliases: string[]
+}
+
+export type FacetListOptions = {
+  search?: string
+  kind?: FacetKind
+  includeInactive?: boolean
+  includeMature?: boolean
+  mine?: boolean
+  take?: number
+  skip?: number
+}
+
+export type FacetCreateInput = {
+  title: string
+  slug?: string
+  kind?: FacetKind
+  description?: string | null
+  flavorText?: string | null
+  imagePath?: string | null
+  icon?: string | null
+  aliases?: string[]
+  isPublic?: boolean
+  isMature?: boolean
+}
+
+type ApiResult<T> = {
+  success: boolean
+  data?: T
+  message?: string
+}
+
+function toQuery(options: FacetListOptions): string {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(options)) {
+    if (value === undefined || value === null || value === '') continue
+    query.set(key, String(value))
+  }
+  const result = query.toString()
+  return result ? `?${result}` : ''
+}
+
+export const useFacetStore = defineStore('facetStore', () => {
+  const facets = ref<FacetWithAliases[]>([])
+  const loading = ref(false)
+  const saving = ref(false)
+  const loaded = ref(false)
+  const error = ref<string | null>(null)
+  const dreamFacetIds = ref<Record<number, number[]>>({})
+  const scenarioFacetIds = ref<Record<number, number[]>>({})
+
+  const activeFacets = computed(() =>
+    facets.value.filter((facet) => facet.isActive),
+  )
+
+  const facetsByLookupKey = computed(() => {
+    const index = new Map<string, FacetWithAliases>()
+    for (const facet of facets.value) {
+      const keys = [facet.slug, facet.title, ...facet.aliases]
+      for (const key of keys) {
+        const lookupKey = normalizeFacetLookupKey(key || '')
+        if (lookupKey) index.set(lookupKey, facet)
+      }
+    }
+    return index
+  })
+
+  function facetForKey(value?: string | null): FacetWithAliases | null {
+    const lookupKey = normalizeFacetLookupKey(value || '')
+    return lookupKey ? facetsByLookupKey.value.get(lookupKey) ?? null : null
+  }
+
+  function upsertFacet(facet: FacetWithAliases): FacetWithAliases {
+    const index = facets.value.findIndex((entry) => entry.id === facet.id)
+    if (index >= 0) facets.value[index] = facet
+    else facets.value.push(facet)
+    facets.value.sort((a, b) =>
+      a.kind === b.kind
+        ? a.title.localeCompare(b.title)
+        : a.kind.localeCompare(b.kind),
+    )
+    return facet
+  }
+
+  async function fetchFacets(
+    options: FacetListOptions = {},
+  ): Promise<FacetWithAliases[]> {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await performFetch<FacetWithAliases[]>(
+        `/api/facets${toQuery(options)}`,
+      )
+      if (!response.success) {
+        throw new Error(response.message || 'Failed to fetch Facets.')
+      }
+      facets.value = response.data ?? []
+      loaded.value = true
+      return facets.value
+    } catch (cause) {
+      error.value = cause instanceof Error ? cause.message : String(cause)
+      throw cause
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function resolveFacet(key: string): Promise<FacetWithAliases> {
+    const existing = facetForKey(key)
+    if (existing) return existing
+
+    const response = await performFetch<FacetWithAliases>(
+      `/api/facets/${encodeURIComponent(key)}`,
+    )
+    if (!response.success || !response.data) {
+      throw new Error(response.message || `Facet not found: ${key}.`)
+    }
+    return upsertFacet(response.data)
+  }
+
+  async function createFacet(
+    input: FacetCreateInput,
+  ): Promise<FacetWithAliases> {
+    saving.value = true
+    error.value = null
+    try {
+      const response = await performFetch<FacetWithAliases>('/api/facets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to create Facet.')
+      }
+      return upsertFacet(response.data)
+    } catch (cause) {
+      error.value = cause instanceof Error ? cause.message : String(cause)
+      throw cause
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function fetchOwnerFacets(
+    ownerType: 'dream' | 'scenario',
+    ownerId: number,
+  ): Promise<FacetWithAliases[]> {
+    const response = await performFetch<FacetWithAliases[]>(
+      `/api/${ownerType === 'dream' ? 'dreams' : 'scenarios'}/${ownerId}/facets`,
+    )
+    if (!response.success) {
+      throw new Error(response.message || 'Failed to fetch assigned Facets.')
+    }
+
+    const assigned = response.data ?? []
+    for (const facet of assigned) upsertFacet(facet)
+    const ids = assigned.map((facet) => facet.id)
+    if (ownerType === 'dream') dreamFacetIds.value[ownerId] = ids
+    else scenarioFacetIds.value[ownerId] = ids
+    return assigned
+  }
+
+  async function setOwnerFacets(
+    ownerType: 'dream' | 'scenario',
+    ownerId: number,
+    facetIds: number[],
+  ): Promise<FacetWithAliases[]> {
+    saving.value = true
+    error.value = null
+    try {
+      const response = await performFetch<FacetWithAliases[]>(
+        `/api/${ownerType === 'dream' ? 'dreams' : 'scenarios'}/${ownerId}/facets`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ facetIds }),
+        },
+      )
+      if (!response.success) {
+        throw new Error(response.message || 'Failed to update Facets.')
+      }
+
+      const assigned = response.data ?? []
+      for (const facet of assigned) upsertFacet(facet)
+      const ids = assigned.map((facet) => facet.id)
+      if (ownerType === 'dream') dreamFacetIds.value[ownerId] = ids
+      else scenarioFacetIds.value[ownerId] = ids
+      return assigned
+    } catch (cause) {
+      error.value = cause instanceof Error ? cause.message : String(cause)
+      throw cause
+    } finally {
+      saving.value = false
+    }
+  }
+
+  function fetchDreamFacets(dreamId: number) {
+    return fetchOwnerFacets('dream', dreamId)
+  }
+
+  function setDreamFacets(dreamId: number, facetIds: number[]) {
+    return setOwnerFacets('dream', dreamId, facetIds)
+  }
+
+  function fetchScenarioFacets(scenarioId: number) {
+    return fetchOwnerFacets('scenario', scenarioId)
+  }
+
+  function setScenarioFacets(scenarioId: number, facetIds: number[]) {
+    return setOwnerFacets('scenario', scenarioId, facetIds)
+  }
+
+  return {
+    facets,
+    loading,
+    saving,
+    loaded,
+    error,
+    dreamFacetIds,
+    scenarioFacetIds,
+    activeFacets,
+    facetsByLookupKey,
+    facetForKey,
+    fetchFacets,
+    resolveFacet,
+    createFacet,
+    fetchDreamFacets,
+    setDreamFacets,
+    fetchScenarioFacets,
+    setScenarioFacets,
+  }
+})


### PR DESCRIPTION
## In progress

This PR completes the first usable Dream/Scenario Facet slice:

- alias-aware Facet list and creation APIs
- soft Facet archival for test and lifecycle cleanup
- exact-set DreamFacet and ScenarioFacet APIs accepting IDs or alias keys
- ownership and visibility checks for Facet attachment
- shared Pinia `facetStore`
- reusable Facet picker with alias search and inline creation
- Dreammaker and Scenario editor integration
- legacy Scenario Genre chooser retained in a compatibility panel
- Cypress coverage for canonical formatting variants, aliases, Dream assignment, Scenario assignment, exact removal, and cleanup

The editor changes are being applied through a strict transformer and validated with Prisma generation plus the repository Vue/TypeScript check before temporary workflow files are removed.