### PR TITLE
Route Project writes away from Dream

### DIFF
--- a/cypress/e2e/api/project-write-boundary.cy.ts
+++ b/cypress/e2e/api/project-write-boundary.cy.ts
@@ -1,0 +1,95 @@
+// /cypress/e2e/api/project-write-boundary.cy.ts
+import { createLoggedInTestUser } from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+describe('Project write boundary', () => {
+  const apiBase = 'https://kind-robots.vercel.app/api'
+  const stamp = Date.now()
+  const slug = `cypress-project-boundary-${stamp}`
+  let token = ''
+  let projectId = 0
+
+  before(() => {
+    createLoggedInTestUser().then((auth) => {
+      token = auth.token
+    })
+  })
+
+  it('rejects Project creation through the single Dream endpoint', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/dreams`,
+      failOnStatusCode: false,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        title: `Wrong Project Route ${stamp}`,
+        slug: `${slug}-single`,
+        dreamType: 'PROJECT',
+        description: 'This must not create a Project-shaped Dream.',
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(409)
+      expect(response.body.success).to.be.false
+      expect(response.body.data).to.eq(null)
+      expect(response.body.message).to.contain('/api/projects')
+    })
+  })
+
+  it('rejects Project creation through the Dream batch endpoint', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/dreams/batch`,
+      failOnStatusCode: false,
+      headers: { Authorization: `Bearer ${token}` },
+      body: [
+        {
+          title: `Wrong Batch Project Route ${stamp}`,
+          slug: `${slug}-batch`,
+          dreamType: 'PROJECT',
+          description: 'Batch imports must use the Project API too.',
+        },
+      ],
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.be.false
+      expect(response.body.count).to.eq(0)
+      expect(response.body.errors).to.have.length(1)
+      expect(response.body.errors[0].statusCode).to.eq(409)
+      expect(response.body.errors[0].message).to.contain('/api/projects')
+    })
+  })
+
+  it('creates the same concept through the first-class Project endpoint', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/projects`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        title: `Correct Project Route ${stamp}`,
+        slug,
+        conductorSlug: slug,
+        description: 'Created through the first-class Project API.',
+        status: 'BRAINSTORM',
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      expect(response.body.success).to.be.true
+      expect(response.body.data.slug).to.eq(slug)
+      expect(response.body.data.status).to.eq('BRAINSTORM')
+      projectId = response.body.data.id
+    })
+  })
+
+  after(() => {
+    if (!projectId) return
+
+    cy.request({
+      method: 'DELETE',
+      url: `${apiBase}/projects/${projectId}`,
+      headers: { Authorization: `Bearer ${token}` },
+      failOnStatusCode: false,
+    })
+  })
+})

--- a/server/api/appmaker/apps.get.ts
+++ b/server/api/appmaker/apps.get.ts
@@ -1,6 +1,6 @@
 // GET /api/appmaker/apps — the AppMaker inventory (appmaker/t-004).
 // scaffolded: slugs with a workspace folder at apps/<slug>/ in the conductor repo.
-// pending:    open scaffold-request todos whose folder hasn't landed yet.
+// pending:    open scaffold-request Todos whose folder hasn't landed yet.
 import { defineEventHandler, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
@@ -22,7 +22,12 @@ export default defineEventHandler(async () => {
         category: 'AGENT',
         title: { startsWith: "Scaffold new app '" },
       },
-      select: { title: true, dreamId: true, createdAt: true },
+      select: {
+        title: true,
+        projectId: true,
+        dreamId: true,
+        createdAt: true,
+      },
       orderBy: { createdAt: 'desc' },
     })
 
@@ -30,7 +35,12 @@ export default defineEventHandler(async () => {
       .map((todo) => {
         const slug = SCAFFOLD_TITLE_RE.exec(todo.title)?.[1]
         return slug
-          ? { slug, dreamId: todo.dreamId, requestedAt: todo.createdAt }
+          ? {
+              slug,
+              projectId: todo.projectId,
+              dreamId: todo.dreamId,
+              requestedAt: todo.createdAt,
+            }
           : null
       })
       .filter((item): item is NonNullable<typeof item> => item !== null)

--- a/server/api/appmaker/scaffold-request.post.ts
+++ b/server/api/appmaker/scaffold-request.post.ts
@@ -1,8 +1,7 @@
 // POST /api/appmaker/scaffold-request — self-serve app creation (appmaker/t-004).
-// Creates the PROJECT Dream (slug parity) owned by the requesting user, then
-// files an AGENT todo under the worker account so the next Worker cycle runs
-// scripts/new_app.py. Server-side caps apply; no admin gate by design
-// (Silas, 2026-07-02: build the self-serve end state).
+// Creates the first-class Project owned by the requesting user, then files an
+// AGENT Todo under the worker account so the next Worker cycle runs
+// scripts/new_app.py. Server-side caps apply; no admin gate by design.
 import { defineEventHandler, readBody, createError, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
@@ -50,57 +49,73 @@ export default defineEventHandler(async (event) => {
     }
 
     const description = body.description?.trim() || null
+    const [existingProject, existingDream] = await Promise.all([
+      prisma.project.findFirst({
+        where: { OR: [{ slug }, { conductorSlug: slug }] },
+        select: { id: true },
+      }),
+      prisma.dream.findUnique({
+        where: { slug },
+        select: { id: true },
+      }),
+    ])
 
-    const existing = await prisma.dream.findUnique({
-      where: { slug },
-      select: { id: true },
-    })
-    if (existing) {
+    if (existingProject || existingDream) {
       throw createError({ statusCode: 409, message: `Slug '${slug}' is already taken.` })
     }
 
     const isAdmin = user.Role === 'ADMIN' || user.id === 1
     await enforceProjectCap({ userId: user.id, userRole: user.Role, isAdmin })
 
-    const dream = await prisma.dream.create({
-      data: {
-        title,
-        slug,
-        description,
-        dreamType: 'PROJECT',
-        projectStatus: 'ACTIVE',
-        userId: user.id,
-        isPublic: true,
-      },
-    })
-
-    // The Worker only reads its own todo queue (fetch_todos.py runs with the
-    // worker account's token), so the request is filed there — not under the
-    // requesting user.
     const scaffoldCommand =
       `python scripts/new_app.py ${slug} --title "${title}"` +
       (description ? ` --description "${description.replace(/"/g, "'")}"` : '')
 
-    const todo = await prisma.todo.create({
-      data: {
-        title: `Scaffold new app '${slug}' with scripts/new_app.py`,
-        description: [
-          `AppMaker self-serve request from user ${user.id}.`,
-          `Run: ${scaffoldCommand}`,
-          `Dream ${dream.id} already exists (slug parity) — do not create another.`,
-        ].join('\n'),
-        status: 'OPEN',
-        priority: 'NORMAL',
-        category: 'AGENT',
-        userId: getWorkerUserId(),
-        dreamId: dream.id,
-      },
+    const { project, todo } = await prisma.$transaction(async (tx) => {
+      const project = await tx.project.create({
+        data: {
+          title,
+          slug,
+          conductorSlug: slug,
+          description,
+          status: 'ACTIVE',
+          priority: 'NORMAL',
+          userId: user.id,
+          isPublic: true,
+          isActive: true,
+        },
+      })
+
+      // The Worker only reads its own Todo queue, so the request is filed under
+      // the worker account while remaining scoped to the requester's Project.
+      const todo = await tx.todo.create({
+        data: {
+          title: `Scaffold new app '${slug}' with scripts/new_app.py`,
+          description: [
+            `AppMaker self-serve request from user ${user.id}.`,
+            `Run: ${scaffoldCommand}`,
+            `Project ${project.id} already exists (slug parity) — do not create another.`,
+          ].join('\n'),
+          status: 'OPEN',
+          priority: 'NORMAL',
+          category: 'AGENT',
+          userId: getWorkerUserId(),
+          projectId: project.id,
+        },
+      })
+
+      return { project, todo }
     })
 
     event.node.res.statusCode = 201
     return {
       success: true,
-      data: { dreamId: dream.id, slug, todoId: todo.id },
+      data: {
+        projectId: project.id,
+        dreamId: null,
+        slug,
+        todoId: todo.id,
+      },
     }
   } catch (error) {
     if (error instanceof H3Error) throw error

--- a/server/api/dreams/index.post.ts
+++ b/server/api/dreams/index.post.ts
@@ -3,7 +3,6 @@ import { defineEventHandler, readBody, createError } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
-import { enforceProjectCap } from '@/server/utils/projectCap'
 import type {
   CreationSource,
   DreamType,
@@ -66,8 +65,10 @@ export default defineEventHandler(async (event) => {
 
     const dreamTypeNormalized = normalizeDreamType(body.dreamType)
     if (dreamTypeNormalized === 'PROJECT') {
-      const isAdmin = user.Role === 'ADMIN' || user.id === 1
-      await enforceProjectCap({ userId: user.id, userRole: user.Role, isAdmin })
+      throw createError({
+        statusCode: 409,
+        message: 'Projects must be created through /api/projects, not /api/dreams.',
+      })
     }
 
     const userRecord = await prisma.user.findUnique({

--- a/server/api/dreams/index.ts
+++ b/server/api/dreams/index.ts
@@ -362,9 +362,18 @@ export function normalizeOptionalText(
 }
 
 export function normalizeDreamType(value: unknown): DreamType {
-  return dreamTypes.includes(value as DreamType)
+  const normalized = dreamTypes.includes(value as DreamType)
     ? (value as DreamType)
     : 'PITCH'
+
+  if (normalized === 'PROJECT') {
+    throw createError({
+      statusCode: 409,
+      message: 'Projects must be created through /api/projects, not /api/dreams.',
+    })
+  }
+
+  return normalized
 }
 
 export function parseDreamType(value: unknown): DreamType | null {

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -4,6 +4,7 @@ import type { Prisma, ProjectPriority, ProjectStatus } from '~/prisma/generated/
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
+import { enforceProjectCap } from '~/server/utils/projectCap'
 import {
   assertProjectAccess,
   getProjectId,
@@ -16,6 +17,10 @@ import {
 } from './index'
 
 type ProjectPatchBody = Record<string, unknown>
+
+function countsTowardProjectCap(status: ProjectStatus, isActive: boolean) {
+  return isActive && (status === 'ACTIVE' || status === 'PAUSED')
+}
 
 export default defineEventHandler(async (event) => {
   try {
@@ -30,6 +35,23 @@ export default defineEventHandler(async (event) => {
     assertProjectAccess(existing, auth.user)
     const body = await readBody<ProjectPatchBody>(event)
     const data: Prisma.ProjectUncheckedUpdateInput = {}
+
+    const nextStatus = projectStatuses.has(body.status as ProjectStatus)
+      ? (body.status as ProjectStatus)
+      : existing.status
+    const nextIsActive =
+      typeof body.isActive === 'boolean' ? body.isActive : existing.isActive
+
+    if (
+      !countsTowardProjectCap(existing.status, existing.isActive) &&
+      countsTowardProjectCap(nextStatus, nextIsActive)
+    ) {
+      await enforceProjectCap({
+        userId: auth.user.id,
+        userRole: auth.user.Role,
+        isAdmin: auth.isAdmin || auth.user.id === 1,
+      })
+    }
 
     if (body.title !== undefined) data.title = normalizeOptionalText(body.title) ?? existing.title
     if (body.slug !== undefined) data.slug = normalizeSlug(body.slug)

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -4,6 +4,7 @@ import type { ProjectPriority, ProjectStatus } from '~/prisma/generated/prisma/c
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
+import { enforceProjectCap } from '~/server/utils/projectCap'
 import {
   normalizeNullableId,
   normalizeOptionalText,
@@ -59,6 +60,14 @@ export default defineEventHandler(async (event) => {
     const priority = projectPriorities.has(body.priority as ProjectPriority)
       ? (body.priority as ProjectPriority)
       : 'NORMAL'
+
+    if (status === 'ACTIVE' || status === 'PAUSED') {
+      await enforceProjectCap({
+        userId: auth.user.id,
+        userRole: auth.user.Role,
+        isAdmin: auth.isAdmin || auth.user.id === 1,
+      })
+    }
 
     const project = await prisma.project.create({
       data: {

--- a/server/utils/projectCap.ts
+++ b/server/utils/projectCap.ts
@@ -28,11 +28,11 @@ export async function enforceProjectCap(input: {
 
   if (isMemberActive) return
 
-  const activeCount = await prisma.dream.count({
+  const activeCount = await prisma.project.count({
     where: {
       userId: input.userId,
-      dreamType: 'PROJECT',
-      projectStatus: { in: ['ACTIVE', 'PAUSED'] },
+      status: { in: ['ACTIVE', 'PAUSED'] },
+      isActive: true,
     },
   })
 


### PR DESCRIPTION
## What changed

- project caps now count first-class `Project` rows
- `/api/projects` enforces the cap for ACTIVE and PAUSED creation
- AppMaker creates a Project and Project-scoped worker Todo transactionally
- AppMaker pending responses expose `projectId` while retaining nullable `dreamId` compatibility
- `/api/dreams` rejects new `PROJECT` rows and directs callers to `/api/projects`
- Dream batch imports reject Project-shaped entries through the shared write normalizer
- legacy Project Dreams remain readable during the parity period
- Cypress covers single and batch Dream rejection plus successful Project creation

## Safety

This does not delete or modify existing legacy Project Dream rows. It only closes new Project-as-Dream write paths.