### PR TITLE
Add legacy-dream archive/delete cleanup workflow

### DIFF
--- a/.github/workflows/legacy-dream-cleanup.yml
+++ b/.github/workflows/legacy-dream-cleanup.yml
@@ -1,0 +1,113 @@
+# One-shot migration helper (Dream → Project/Facet migration, phase 4).
+# Audits the remaining legacy PROJECT/GENRE dreams, archives them to
+# archives/legacy-dreams/legacy-dreams.json, and — only when the `delete`
+# input is true — removes the rows so the enum-dropping schema migration
+# can deploy. Delete this workflow once the legacy rows are gone.
+#
+# Connectivity mirrors fallback-snapshot.yml: the database lives on a home
+# Unraid box reachable only over Tailscale, so the job joins the tailnet as
+# an ephemeral node. Required repository Actions secrets: DATABASE_URL
+# (tailnet host), TS_OAUTH_CLIENT_ID, TS_OAUTH_SECRET.
+#
+# Run order:
+#   1. dispatch with delete=false — review the audit artifacts and the
+#      committed archive diff
+#   2. dispatch with delete=true  — re-archives, deletes, verifies zero remain
+name: Legacy Dream Cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      delete:
+        description: 'Actually delete legacy dreams (false = audit + archive only)'
+        required: false
+        default: 'false'
+
+concurrency:
+  group: legacy-dream-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - name: Require secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL repository Actions secret is empty."
+            exit 1
+          fi
+          if [ -z "$TS_OAUTH_CLIENT_ID" ] || [ -z "$TS_OAUTH_SECRET" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      # Join the tailnet as an ephemeral node (auto-removed after the run),
+      # after the npm/prisma steps so the tailnet session stays short.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Genre/Facet relation audit
+        run: npx tsx utils/scripts/auditLegacyGenreDreamRelations.ts --output=artifacts/legacy-dream-cleanup/genre-relations.json
+
+      # Exits non-zero unless every legacy dream is cleanup-ready (Project/
+      # Facet parity holds and no unmigrated relations remain), which blocks
+      # the archive/delete steps below.
+      - name: Project/Facet parity gate
+        run: npx tsx utils/scripts/verifyProjectDreamFacetParity.ts --output=artifacts/legacy-dream-cleanup/parity.json
+
+      - name: Archive legacy dreams (and delete if requested)
+        run: |
+          ARGS=""
+          if [ "${{ inputs.delete }}" = "true" ]; then ARGS="--delete"; fi
+          npx tsx utils/scripts/archiveLegacyDreams.ts $ARGS
+
+      - name: Upload audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: legacy-dream-cleanup-${{ github.run_id }}
+          path: |
+            artifacts/legacy-dream-cleanup/
+            archives/legacy-dreams/
+          retention-days: 90
+
+      - name: Commit archive if changed
+        if: github.ref == 'refs/heads/main'
+        run: |
+          if [ -z "$(git status --porcelain archives/legacy-dreams)" ]; then
+            echo "No archive changes."
+            exit 0
+          fi
+          git config user.name "kind-robots-snapshot[bot]"
+          git config user.email "snapshot-bot@users.noreply.github.com"
+          git add archives/legacy-dreams
+          git commit -m "chore: archive legacy PROJECT/GENRE dreams before deletion"
+          git push origin main

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ kindblank_*.sql
 /artifacts/schema-backfill/
 /artifacts/schema-parity/
 /artifacts/genre-facet-audit/
+/artifacts/legacy-dream-cleanup/

--- a/utils/scripts/archiveLegacyDreams.ts
+++ b/utils/scripts/archiveLegacyDreams.ts
@@ -1,0 +1,125 @@
+// utils/scripts/archiveLegacyDreams.ts
+//
+// Final step of the Dream → Project/Facet migration (phase 4): archive the
+// remaining legacy PROJECT/GENRE dreams to a committed JSON file, then —
+// only with --delete — remove the rows so the enum-dropping migration can
+// deploy. Dry (archive-only) by default.
+//
+// Usage:
+//   npx tsx utils/scripts/archiveLegacyDreams.ts [--delete] [--output=path]
+//
+// Run the relation audit (auditLegacyGenreDreamRelations.ts) and the parity
+// verifier (verifyProjectDreamFacetParity.ts) first; the cleanup workflow
+// gates on both before this script ever runs with --delete.
+import 'dotenv/config'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
+const generatedAt = new Date().toISOString()
+const outputArg = process.argv.find((argument) =>
+  argument.startsWith('--output='),
+)
+const outputPath = resolve(
+  outputArg?.slice('--output='.length) ||
+    'archives/legacy-dreams/legacy-dreams.json',
+)
+const doDelete = process.argv.includes('--delete')
+
+const LEGACY_TYPES = ['PROJECT', 'GENRE'] as const
+
+async function main() {
+  const dreams = await prisma.dream.findMany({
+    where: { dreamType: { in: [...LEGACY_TYPES] } },
+    orderBy: { id: 'asc' },
+    include: {
+      Scenarios: { select: { id: true } },
+      FacetLinks: { select: { facetId: true } },
+      Reactions: { select: { id: true } },
+      Compositions: { select: { id: true } },
+      SourceComposition: { select: { id: true } },
+      Chats: { select: { id: true } },
+      ArtImages: { select: { id: true } },
+      ArtCollections: { select: { id: true } },
+      Characters: { select: { id: true } },
+      Rewards: { select: { id: true } },
+      Bots: { select: { id: true } },
+      PitchSheet: { select: { id: true, projectId: true } },
+      Todos: { select: { id: true, projectId: true } },
+      RelationsFrom: {
+        select: { id: true, toDreamId: true, relationType: true, note: true },
+      },
+      RelationsTo: {
+        select: { id: true, fromDreamId: true, relationType: true, note: true },
+      },
+      LifeRuns: { select: { id: true } },
+    },
+  })
+
+  const counts = {
+    total: dreams.length,
+    project: dreams.filter((dream) => dream.dreamType === 'PROJECT').length,
+    genre: dreams.filter((dream) => dream.dreamType === 'GENRE').length,
+  }
+
+  const archive = {
+    generatedAt,
+    note:
+      'Archival copy of the legacy PROJECT/GENRE dreams taken immediately ' +
+      'before their deletion. Live data moved to the Project and Facet ' +
+      'models (kind_robots PRs #172/#173 and follow-ups).',
+    counts,
+    dreams,
+  }
+
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${JSON.stringify(archive, null, 2)}\n`, 'utf8')
+  console.error(
+    `Archived ${counts.total} legacy dreams (${counts.project} PROJECT, ${counts.genre} GENRE) to ${outputPath}`,
+  )
+
+  if (!doDelete) {
+    console.error('Dry run — pass --delete to remove the archived rows.')
+    return
+  }
+
+  const failures: { id: number; title: string; error: string }[] = []
+  let deleted = 0
+  for (const dream of dreams) {
+    try {
+      await prisma.dream.delete({ where: { id: dream.id } })
+      deleted += 1
+    } catch (error) {
+      failures.push({
+        id: dream.id,
+        title: dream.title,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const remaining = await prisma.dream.count({
+    where: { dreamType: { in: [...LEGACY_TYPES] } },
+  })
+  console.error(
+    `Deleted ${deleted}/${dreams.length}; ${remaining} legacy dreams remain.`,
+  )
+  if (failures.length > 0) {
+    console.error(JSON.stringify(failures, null, 2))
+    process.exitCode = 1
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })


### PR DESCRIPTION
## Summary

Phase 4 of the Dream → Project/Facet migration. Before the schema migration that drops `PROJECT`/`GENRE` from `DreamType` can deploy (`vercel-build` runs `prisma migrate deploy`), the 29 PROJECT + 20 GENRE dream rows must be archived and removed from production. The dev sandbox cannot reach the database, so this ships a one-shot `workflow_dispatch` job that does it from Actions.

- new `utils/scripts/archiveLegacyDreams.ts`: archives every legacy PROJECT/GENRE dream (all scalars + relation IDs) to `archives/legacy-dreams/legacy-dreams.json`; dry by default, `--delete` removes the rows per-dream with per-row failure reporting and a remaining-count check
- new `.github/workflows/legacy-dream-cleanup.yml`: joins the tailnet (same pattern as `fallback-snapshot.yml`), runs the genre relation audit and the Project/Facet parity verifier as hard gates, archives, optionally deletes, uploads audit artifacts, and commits the archive on main
- `.gitignore`: ignore the new local audit artifact dir

## Run order

1. dispatch with `delete=false` — review audit artifacts and the committed archive
2. dispatch with `delete=true` — re-archives, deletes, verifies zero legacy dreams remain

The workflow (and script) are meant to be deleted in the follow-up compat-removal PR once the rows are gone.

## Validation

- eslint + prettier clean on the new files
- standalone strict `tsc --noEmit` on the script passes
- parity verifier exits non-zero unless `cleanupReady`, so the delete step cannot run against unmigrated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJDLHUXkYX2EXi1bU8jxoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJDLHUXkYX2EXi1bU8jxoL)_