### PR TITLE
Fix production 400s on Facet/Project slug GETs and facet-assignment spec ordering

### DIFF
--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -79,21 +79,27 @@ describe('Dream and Scenario Facet assignments', () => {
       dreamId = response.body.data.id
     })
 
-    cy.request({
-      method: 'PUT',
-      url: `${apiBase}/dreams/${dreamId}/facets`,
-      headers: { Authorization: `Bearer ${token}` },
-      body: { facetKeys: [cowAlias] },
-    }).then((response) => {
+    // dreamId is only set inside the .then above, so every dependent URL must
+    // be built lazily (inside its own .then) rather than at enqueue time.
+    cy.then(() =>
+      cy.request({
+        method: 'PUT',
+        url: `${apiBase}/dreams/${dreamId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { facetKeys: [cowAlias] },
+      }),
+    ).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data).to.have.length(1)
       expect(response.body.data[0].id).to.eq(facetId)
     })
 
-    cy.request({
-      url: `${apiBase}/dreams/${dreamId}/facets`,
-      headers: { Authorization: `Bearer ${token}` },
-    }).then((response) => {
+    cy.then(() =>
+      cy.request({
+        url: `${apiBase}/dreams/${dreamId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    ).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data.map((facet: { id: number }) => facet.id)).to.deep.eq([
         facetId,
@@ -117,29 +123,37 @@ describe('Dream and Scenario Facet assignments', () => {
       scenarioId = response.body.data.id
     })
 
-    cy.request({
-      method: 'PUT',
-      url: `${apiBase}/scenarios/${scenarioId}/facets`,
-      headers: { Authorization: `Bearer ${token}` },
-      body: { facetKeys: [cowsAlias] },
-    }).then((response) => {
+    // Same lazy-URL rule as the Dream test: scenarioId is assigned in the
+    // .then above, after this test body has already enqueued its commands.
+    cy.then(() =>
+      cy.request({
+        method: 'PUT',
+        url: `${apiBase}/scenarios/${scenarioId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { facetKeys: [cowsAlias] },
+      }),
+    ).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data).to.have.length(1)
       expect(response.body.data[0].id).to.eq(facetId)
     })
 
-    cy.request({
-      url: `${apiBase}/scenarios/${scenarioId}/facets`,
-      headers: { Authorization: `Bearer ${token}` },
-    }).then((response) => {
+    cy.then(() =>
+      cy.request({
+        url: `${apiBase}/scenarios/${scenarioId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    ).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data[0].id).to.eq(facetId)
     })
 
-    cy.request({
-      url: `${apiBase}/scenarios/${scenarioId}`,
-      headers: { Authorization: `Bearer ${token}` },
-    }).then((response) => {
+    cy.then(() =>
+      cy.request({
+        url: `${apiBase}/scenarios/${scenarioId}`,
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    ).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data.Facets).to.have.length(1)
       expect(response.body.data.Facets[0].id).to.eq(facetId)

--- a/server/api/facets/[id].get.ts
+++ b/server/api/facets/[id].get.ts
@@ -1,4 +1,4 @@
-// /server/api/facets/[key].get.ts
+// /server/api/facets/[id].get.ts
 import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { errorHandler } from '~/server/utils/error'
 import { getOptionalApiUser } from '~/server/utils/authGuard'
@@ -6,7 +6,7 @@ import { resolveFacetAlias } from '~/server/utils/facetAliases'
 
 export default defineEventHandler(async (event) => {
   try {
-    const requested = getRouterParam(event, 'key')?.trim()
+    const requested = getRouterParam(event, 'id')?.trim()
 
     if (!requested) {
       throw createError({

--- a/server/api/projects/[id].get.ts
+++ b/server/api/projects/[id].get.ts
@@ -1,4 +1,4 @@
-// /server/api/projects/[key].get.ts
+// /server/api/projects/[id].get.ts
 import { createError, defineEventHandler, getHeader, getRouterParam } from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
@@ -7,7 +7,7 @@ import { projectInclude } from './index'
 
 export default defineEventHandler(async (event) => {
   try {
-    const key = getRouterParam(event, 'key')?.trim()
+    const key = getRouterParam(event, 'id')?.trim()
     if (!key) throw createError({ statusCode: 400, message: 'Project ID or slug is required.' })
 
     const id = Number(key)


### PR DESCRIPTION
## Summary

The post-#180 cypress run against production showed zero migration regressions — the 5 failures (3 in `facet-assignments`, 1 in `project-workspace`, 1 in `projects`) were pre-existing, and shared two root causes:

- **Nitro param-name conflict**: `server/api/facets/[key].get.ts` and `server/api/projects/[key].get.ts` sat beside sibling `[id].*` handlers on the same dynamic segment. The deployed router registers one param name per segment, so `getRouterParam(event, 'key')` returned `undefined` in production and every GET-by-slug/alias answered 400 ("Facet slug or alias is required." / "Project ID or slug is required."). Both files are renamed to `[id].get.ts` and read the `id` param — the handlers already accept id-or-slug, so behavior is unchanged where it worked and fixed where it didn't.
- **Cypress enqueue-time interpolation**: `facet-assignments.cy.ts` built dependent URLs with `${dreamId}`/`${scenarioId}` before the create response assigned them, producing `PUT /api/dreams/0/facets`. Dependent requests now build URLs lazily inside `cy.then()`.

## Validation

- eslint: the one remaining error in `projects/[id].get.ts` (empty block) pre-exists on main; prettier warnings on both touched files also reproduce on main unchanged
- the next cypress run on main (post-deploy) should clear all three failing specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJDLHUXkYX2EXi1bU8jxoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJDLHUXkYX2EXi1bU8jxoL)_