### PR TITLE
Authenticate facet alias-resolution lookups in cypress spec

### DIFF
--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -52,13 +52,16 @@ describe('Dream and Scenario Facet assignments', () => {
     ]
 
     keys.forEach((key) => {
-      cy.request(`${apiBase}/facets/${encodeURIComponent(key)}`).then(
-        (response) => {
-          expect(response.status).to.eq(200)
-          expect(response.body.success).to.be.true
-          expect(response.body.data.id).to.eq(facetId)
-        },
-      )
+      // The Facet is created isPublic: false, so lookups must authenticate
+      // as its owner or the visibility check answers 404.
+      cy.request({
+        url: `${apiBase}/facets/${encodeURIComponent(key)}`,
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body.success).to.be.true
+        expect(response.body.data.id).to.eq(facetId)
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Last remaining cypress failure on main. The `facet-assignments` spec creates its Facet with `isPublic: false`, so the unauthenticated GET-by-alias requests were correctly answered 404 by the visibility check once the #181 route-param fix landed (they previously failed earlier, at the 400 stage, which masked this). The alias-resolution test now sends the owner's token like every other request in the spec.

With this, the post-merge cypress run against production should be fully green (was 5 failures before tonight → 1 after #181 → 0 expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJDLHUXkYX2EXi1bU8jxoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJDLHUXkYX2EXi1bU8jxoL)_