### PR TITLE
Model Builder: front-end scaffold + AI-drafting (resumable gated recipe runner)

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -34,7 +34,20 @@
         :disabled="!isEditable('PITCH')"
         @change="store.updatePitch(item.id, pitch)"
       />
-      <div class="mt-1.5 flex justify-end gap-1.5">
+      <div class="mt-1.5 flex items-center justify-end gap-1.5">
+        <button
+          v-if="isEditable('PITCH')"
+          type="button"
+          class="btn btn-xs btn-ghost mr-auto gap-1 rounded-lg text-secondary"
+          :disabled="isDrafting('pitch')"
+          @click="draft('pitch')"
+        >
+          <span v-if="isDrafting('pitch')" class="loading loading-dots loading-xs" />
+          <template v-else>
+            <Icon name="kind-icon:magic" class="h-3.5 w-3.5" />
+            Draft with AI
+          </template>
+        </button>
         <button
           v-if="item.stages.PITCH.status === 'approved'"
           type="button"
@@ -64,9 +77,24 @@
           {{ item.stages.FIELDS_AND_PROMPTS.status }}
         </span>
       </div>
-      <label class="mb-0.5 block text-[10px] uppercase text-base-content/40">
-        Proposed fields / relationships
-      </label>
+      <div class="mb-0.5 flex items-center justify-between">
+        <label class="block text-[10px] uppercase text-base-content/40">
+          Proposed fields / relationships
+        </label>
+        <button
+          v-if="isEditable('FIELDS_AND_PROMPTS')"
+          type="button"
+          class="btn btn-ghost btn-xs h-5 min-h-5 gap-1 rounded-md px-1.5 text-[10px] text-secondary"
+          :disabled="isDrafting('fields')"
+          @click="draft('fields')"
+        >
+          <span v-if="isDrafting('fields')" class="loading loading-dots loading-xs" />
+          <template v-else>
+            <Icon name="kind-icon:magic" class="h-3 w-3" />
+            Draft
+          </template>
+        </button>
+      </div>
       <textarea
         v-model="fields"
         rows="2"
@@ -75,9 +103,24 @@
         :disabled="!isEditable('FIELDS_AND_PROMPTS')"
         @change="store.updateFields(item.id, fields)"
       />
-      <label class="mb-0.5 block text-[10px] uppercase text-base-content/40">
-        Generation prompt
-      </label>
+      <div class="mb-0.5 flex items-center justify-between">
+        <label class="block text-[10px] uppercase text-base-content/40">
+          Generation prompt
+        </label>
+        <button
+          v-if="isEditable('FIELDS_AND_PROMPTS')"
+          type="button"
+          class="btn btn-ghost btn-xs h-5 min-h-5 gap-1 rounded-md px-1.5 text-[10px] text-secondary"
+          :disabled="isDrafting('artPrompt')"
+          @click="draft('artPrompt')"
+        >
+          <span v-if="isDrafting('artPrompt')" class="loading loading-dots loading-xs" />
+          <template v-else>
+            <Icon name="kind-icon:magic" class="h-3 w-3" />
+            Draft
+          </template>
+        </button>
+      </div>
       <textarea
         v-model="prompt"
         rows="2"
@@ -223,8 +266,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import type { DraftField } from '@/stores/modelBuilderStore'
 import type { BuildStageKey } from '@/stores/helpers/modelBuilderRecipes'
 
 const props = defineProps<{ itemId: string }>()
@@ -238,7 +282,29 @@ const pitch = ref(item.value?.pitch ?? '')
 const fields = ref(item.value?.fieldsDraft ?? '')
 const prompt = ref(item.value?.promptDraft ?? '')
 
+// Keep the textareas in sync when the store's draft fields change under us —
+// e.g. an AI draft writes into the item.
+watch(
+  () => [item.value?.pitch, item.value?.fieldsDraft, item.value?.promptDraft],
+  () => {
+    pitch.value = item.value?.pitch ?? ''
+    fields.value = item.value?.fieldsDraft ?? ''
+    prompt.value = item.value?.promptDraft ?? ''
+  },
+)
+
 const isGenerating = computed(() => store.generatingItemId === props.itemId)
+
+function isDrafting(field: DraftField): boolean {
+  return (
+    store.draftingField?.itemId === props.itemId &&
+    store.draftingField?.field === field
+  )
+}
+
+function draft(field: DraftField): void {
+  store.draftText(props.itemId, field)
+}
 
 const preview = computed(() => store.previewCommit(props.itemId))
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -1,0 +1,287 @@
+<!-- /components/model-builder/model-builder-item-panel.vue -->
+<template>
+  <div
+    v-if="item"
+    class="flex min-h-0 flex-1 flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-3"
+  >
+    <div class="flex items-center gap-2">
+      <h4 class="text-sm font-black text-base-content">{{ item.label }}</h4>
+      <span class="badge badge-sm badge-ghost">{{ item.action }}</span>
+      <span class="badge badge-sm badge-ghost">{{ item.generation }}</span>
+    </div>
+
+    <p
+      v-if="item.error"
+      class="rounded-lg bg-error/10 px-2 py-1 text-xs font-semibold text-error"
+    >
+      {{ item.error }}
+    </p>
+
+    <!-- Stage: PITCH -->
+    <section class="rounded-xl border border-base-300 p-2.5">
+      <div class="mb-1.5 flex items-center gap-2">
+        <Icon name="kind-icon:lightbulb" class="h-4 w-4 text-primary" />
+        <span class="text-xs font-bold uppercase tracking-wide">Pitch</span>
+        <span class="badge badge-xs ml-auto" :class="badgeFor('PITCH')">
+          {{ item.stages.PITCH.status }}
+        </span>
+      </div>
+      <textarea
+        v-model="pitch"
+        rows="2"
+        class="textarea textarea-bordered w-full rounded-xl text-sm"
+        placeholder="Why this output exists and what it should convey…"
+        :disabled="!isEditable('PITCH')"
+        @change="store.updatePitch(item.id, pitch)"
+      />
+      <div class="mt-1.5 flex justify-end gap-1.5">
+        <button
+          v-if="item.stages.PITCH.status === 'approved'"
+          type="button"
+          class="btn btn-xs btn-ghost rounded-lg"
+          @click="store.reopenStage(item.id, 'PITCH')"
+        >
+          Edit
+        </button>
+        <button
+          v-else
+          type="button"
+          class="btn btn-xs btn-primary rounded-lg"
+          :disabled="isLocked('PITCH') || !pitch.trim()"
+          @click="approve('PITCH')"
+        >
+          Approve pitch
+        </button>
+      </div>
+    </section>
+
+    <!-- Stage: FIELDS_AND_PROMPTS -->
+    <section class="rounded-xl border border-base-300 p-2.5">
+      <div class="mb-1.5 flex items-center gap-2">
+        <Icon name="kind-icon:list" class="h-4 w-4 text-primary" />
+        <span class="text-xs font-bold uppercase tracking-wide">Fields &amp; Prompts</span>
+        <span class="badge badge-xs ml-auto" :class="badgeFor('FIELDS_AND_PROMPTS')">
+          {{ item.stages.FIELDS_AND_PROMPTS.status }}
+        </span>
+      </div>
+      <label class="mb-0.5 block text-[10px] uppercase text-base-content/40">
+        Proposed fields / relationships
+      </label>
+      <textarea
+        v-model="fields"
+        rows="2"
+        class="textarea textarea-bordered mb-1.5 w-full rounded-xl text-sm"
+        placeholder="Schema fields and relationships to write on commit…"
+        :disabled="!isEditable('FIELDS_AND_PROMPTS')"
+        @change="store.updateFields(item.id, fields)"
+      />
+      <label class="mb-0.5 block text-[10px] uppercase text-base-content/40">
+        Generation prompt
+      </label>
+      <textarea
+        v-model="prompt"
+        rows="2"
+        class="textarea textarea-bordered w-full rounded-xl text-sm"
+        placeholder="The prompt used to generate this asset…"
+        :disabled="!isEditable('FIELDS_AND_PROMPTS')"
+        @change="store.updatePrompt(item.id, prompt)"
+      />
+      <div class="mt-1.5 flex justify-end gap-1.5">
+        <button
+          v-if="item.stages.FIELDS_AND_PROMPTS.status === 'approved'"
+          type="button"
+          class="btn btn-xs btn-ghost rounded-lg"
+          @click="store.reopenStage(item.id, 'FIELDS_AND_PROMPTS')"
+        >
+          Edit
+        </button>
+        <button
+          v-else
+          type="button"
+          class="btn btn-xs btn-primary rounded-lg"
+          :disabled="isLocked('FIELDS_AND_PROMPTS')"
+          @click="approve('FIELDS_AND_PROMPTS')"
+        >
+          Approve fields &amp; prompts
+        </button>
+      </div>
+    </section>
+
+    <!-- Stage: GENERATE_ASSETS -->
+    <section class="rounded-xl border border-base-300 p-2.5">
+      <div class="mb-1.5 flex items-center gap-2">
+        <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary" />
+        <span class="text-xs font-bold uppercase tracking-wide">Generate Assets</span>
+        <span class="badge badge-xs ml-auto" :class="badgeFor('GENERATE_ASSETS')">
+          {{ item.stages.GENERATE_ASSETS.status }}
+        </span>
+      </div>
+
+      <div
+        v-if="item.generation !== 'image'"
+        class="rounded-lg bg-base-200 px-2 py-1.5 text-xs text-base-content/55"
+      >
+        {{ item.generation }} generation is defined in the recipe but not yet
+        wired into this front-end slice — image outputs run through the live art
+        generator below.
+      </div>
+
+      <template v-else>
+        <div
+          v-if="item.imagePath"
+          class="mb-1.5 overflow-hidden rounded-xl border border-base-300"
+        >
+          <img
+            :src="item.imagePath"
+            :alt="item.label"
+            class="max-h-48 w-full object-contain bg-base-200"
+          />
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-sm btn-primary w-full rounded-xl"
+          :disabled="!isEditable('GENERATE_ASSETS') || isGenerating"
+          @click="store.generateItemAsset(item.id)"
+        >
+          <span v-if="isGenerating" class="loading loading-dots loading-sm" />
+          <template v-else>
+            <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+            {{ item.imagePath ? 'Regenerate candidate' : 'Generate candidate' }}
+          </template>
+        </button>
+      </template>
+
+      <div
+        v-if="item.stages.GENERATE_ASSETS.status !== 'locked'"
+        class="mt-1.5 flex justify-end gap-1.5"
+      >
+        <button
+          v-if="item.stages.GENERATE_ASSETS.status === 'approved'"
+          type="button"
+          class="btn btn-xs btn-ghost rounded-lg"
+          @click="store.reopenStage(item.id, 'GENERATE_ASSETS')"
+        >
+          Edit
+        </button>
+        <button
+          v-else
+          type="button"
+          class="btn btn-xs btn-primary rounded-lg"
+          :disabled="!canApproveAssets"
+          @click="approve('GENERATE_ASSETS')"
+        >
+          Keep this asset
+        </button>
+      </div>
+    </section>
+
+    <!-- Stage: COMMIT -->
+    <section class="rounded-xl border border-base-300 p-2.5">
+      <div class="mb-1.5 flex items-center gap-2">
+        <Icon name="kind-icon:check" class="h-4 w-4 text-primary" />
+        <span class="text-xs font-bold uppercase tracking-wide">Commit</span>
+        <span class="badge badge-xs ml-auto" :class="badgeFor('COMMIT')">
+          {{ item.stages.COMMIT.status }}
+        </span>
+      </div>
+
+      <div
+        v-if="preview"
+        class="space-y-1 rounded-lg bg-base-200 p-2 text-xs text-base-content/70"
+      >
+        <div>
+          <span class="font-bold text-base-content">{{ preview.action }}</span>
+          → {{ preview.targetType }}
+        </div>
+        <div>{{ preview.summary }}</div>
+        <div v-if="preview.fields" class="whitespace-pre-wrap">
+          <span class="text-base-content/40">fields:</span> {{ preview.fields }}
+        </div>
+        <div v-if="preview.artImageId" class="text-base-content/40">
+          artImageId: {{ preview.artImageId }}
+        </div>
+      </div>
+
+      <p class="mt-1 text-[10px] leading-snug text-base-content/40">
+        The durable create / update / link / promote runs through the model APIs
+        in a later gated milestone. Approving here records the final diff only.
+      </p>
+
+      <div class="mt-1.5 flex justify-end">
+        <button
+          type="button"
+          class="btn btn-xs btn-success rounded-lg"
+          :disabled="isLocked('COMMIT') || item.stages.COMMIT.status === 'approved'"
+          @click="store.approveCommit(item.id)"
+        >
+          {{ item.stages.COMMIT.status === 'approved' ? 'Approved' : 'Approve commit' }}
+        </button>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import type { BuildStageKey } from '@/stores/helpers/modelBuilderRecipes'
+
+const props = defineProps<{ itemId: string }>()
+const store = useModelBuilderStore()
+
+const item = computed(() => store.run?.items.find((i) => i.id === props.itemId))
+
+// Local drafts (the parent keys this component by item id, so init-from-item is
+// safe — a different row remounts the panel).
+const pitch = ref(item.value?.pitch ?? '')
+const fields = ref(item.value?.fieldsDraft ?? '')
+const prompt = ref(item.value?.promptDraft ?? '')
+
+const isGenerating = computed(() => store.generatingItemId === props.itemId)
+
+const preview = computed(() => store.previewCommit(props.itemId))
+
+const canApproveAssets = computed(() => {
+  if (!item.value) return false
+  if (isLocked('GENERATE_ASSETS')) return false
+  // For image outputs, require a generated candidate first.
+  if (item.value.generation === 'image') return Boolean(item.value.artImageId)
+  return true
+})
+
+function isLocked(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'locked'
+}
+
+// A stage's inputs are editable while it is workable. An approved stage locks
+// behind its "Edit" button (which reopens it and stales downstream); a locked
+// stage waits on its prerequisite.
+function isEditable(stage: BuildStageKey): boolean {
+  const status = item.value?.stages[stage].status
+  return status === 'ready' || status === 'stale' || status === 'rejected'
+}
+
+function approve(stage: BuildStageKey): void {
+  store.approveStage(props.itemId, stage)
+}
+
+function badgeFor(stage: BuildStageKey): string {
+  const status = item.value?.stages[stage].status
+  switch (status) {
+    case 'approved':
+      return 'badge-success'
+    case 'ready':
+      return 'badge-primary'
+    case 'in-progress':
+      return 'badge-info'
+    case 'rejected':
+      return 'badge-error'
+    case 'stale':
+      return 'badge-warning'
+    default:
+      return 'badge-ghost'
+  }
+}
+</script>

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -1,0 +1,101 @@
+<!-- /components/model-builder/model-builder-manager.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 max-h-full w-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+  >
+    <header
+      class="flex h-10 shrink-0 items-center gap-2 border-b border-base-300 bg-base-100 px-2 sm:px-3"
+    >
+      <Icon name="kind-icon:blueprint" class="h-4 w-4 shrink-0 text-primary" />
+
+      <h2
+        class="truncate text-sm font-black leading-none text-base-content sm:text-base"
+      >
+        Model Builder
+      </h2>
+
+      <nav class="ml-2 hidden min-w-0 flex-1 items-center gap-1 sm:flex">
+        <button
+          v-for="(crumb, index) in crumbs"
+          :key="crumb.step"
+          type="button"
+          class="btn btn-xs h-7 min-h-7 rounded-xl px-2 text-xs font-semibold"
+          :class="
+            store.step === crumb.step
+              ? 'btn-primary'
+              : crumb.enabled
+                ? 'btn-ghost text-base-content/60'
+                : 'btn-ghost text-base-content/30 pointer-events-none'
+          "
+          @click="crumb.enabled && store.goToStep(crumb.step)"
+        >
+          <span class="opacity-50">{{ index + 1 }}.</span>
+          {{ crumb.label }}
+        </button>
+      </nav>
+
+      <button
+        type="button"
+        class="btn btn-xs btn-ghost ml-auto h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-error"
+        @click="store.resetAll()"
+      >
+        <Icon name="kind-icon:trash" class="h-3.5 w-3.5" />
+        <span class="hidden sm:inline">Reset</span>
+      </button>
+    </header>
+
+    <Transition name="mb-feedback">
+      <div
+        v-if="store.statusMessage"
+        class="shrink-0 border-b px-3 py-1 text-xs font-semibold"
+        :class="
+          store.statusTone === 'error'
+            ? 'border-error/30 bg-error/10 text-error'
+            : 'border-success/30 bg-success/10 text-success'
+        "
+      >
+        {{ store.statusMessage }}
+      </div>
+    </Transition>
+
+    <main class="flex min-h-0 flex-1 flex-col overflow-y-auto p-2 sm:p-3">
+      <model-builder-source-picker v-if="store.step === 'source'" />
+      <model-builder-recipe-selector v-else-if="store.step === 'recipe'" />
+      <model-builder-progress-matrix v-else-if="store.step === 'run'" />
+    </main>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+
+const store = useModelBuilderStore()
+
+const crumbs = computed(() => [
+  { step: 'source' as const, label: 'Source', enabled: true },
+  {
+    step: 'recipe' as const,
+    label: 'Recipe',
+    enabled: Boolean(store.selectedSource),
+  },
+  { step: 'run' as const, label: 'Run', enabled: Boolean(store.run) },
+])
+
+onMounted(() => {
+  store.resumeRun()
+})
+</script>
+
+<style scoped>
+.mb-feedback-enter-active,
+.mb-feedback-leave-active {
+  transition: all 180ms ease;
+}
+
+.mb-feedback-enter-from,
+.mb-feedback-leave-to {
+  opacity: 0;
+  transform: translateY(-0.5rem);
+}
+</style>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -1,0 +1,134 @@
+<!-- /components/model-builder/model-builder-progress-matrix.vue -->
+<template>
+  <div class="flex min-h-0 flex-1 flex-col gap-3">
+    <div class="flex items-start justify-between gap-2">
+      <div>
+        <h3 class="text-base font-black text-base-content">3. Build run</h3>
+        <p class="mt-1 text-xs text-base-content/60">
+          <span class="font-bold text-base-content">{{ run?.sourceLabel }}</span>
+          · {{ recipeLabel }} ·
+          {{ store.runProgress.committed }}/{{ store.runProgress.total }} committed
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-xs btn-ghost shrink-0 rounded-xl text-base-content/60"
+        @click="store.resetRun()"
+      >
+        <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+        New run
+      </button>
+    </div>
+
+    <!-- Stage matrix -->
+    <div class="overflow-x-auto rounded-2xl border border-base-300 bg-base-100">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th class="text-xs">Item</th>
+            <th
+              v-for="stage in stages"
+              :key="stage.key"
+              class="text-center text-xs"
+            >
+              {{ stage.short }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="item in run?.items"
+            :key="item.id"
+            class="cursor-pointer transition"
+            :class="item.id === selectedItemId ? 'bg-primary/10' : 'hover:bg-base-200'"
+            @click="selectedItemId = item.id"
+          >
+            <td class="max-w-[10rem] truncate text-xs font-semibold">
+              {{ item.label }}
+            </td>
+            <td
+              v-for="stage in stages"
+              :key="stage.key"
+              class="text-center"
+            >
+              <span
+                class="inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px]"
+                :class="statusClass(item.stages[stage.key].status)"
+                :title="item.stages[stage.key].status"
+              >
+                <Icon :name="statusIcon(item.stages[stage.key].status)" class="h-3 w-3" />
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Selected item panel -->
+    <model-builder-item-panel
+      v-if="selectedItem"
+      :key="selectedItem.id"
+      :item-id="selectedItem.id"
+    />
+    <div
+      v-else
+      class="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/50"
+    >
+      Select a row to work through its stages.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import { BUILD_STAGES, getRecipe } from '@/stores/helpers/modelBuilderRecipes'
+import type { StageStatus } from '@/stores/modelBuilderStore'
+
+const store = useModelBuilderStore()
+const stages = BUILD_STAGES
+
+const run = computed(() => store.run)
+const recipeLabel = computed(() =>
+  run.value ? getRecipe(run.value.recipeKey)?.label : '',
+)
+
+const selectedItemId = ref<string>(run.value?.items[0]?.id ?? '')
+const selectedItem = computed(() =>
+  run.value?.items.find((item) => item.id === selectedItemId.value),
+)
+
+function statusClass(status: StageStatus): string {
+  switch (status) {
+    case 'approved':
+      return 'bg-success/20 text-success'
+    case 'ready':
+      return 'bg-primary/20 text-primary'
+    case 'in-progress':
+      return 'bg-info/20 text-info animate-pulse'
+    case 'rejected':
+      return 'bg-error/20 text-error'
+    case 'stale':
+      return 'bg-warning/20 text-warning'
+    default:
+      return 'bg-base-300 text-base-content/40'
+  }
+}
+
+function statusIcon(status: StageStatus): string {
+  switch (status) {
+    case 'approved':
+      return 'kind-icon:check'
+    case 'ready':
+      return 'kind-icon:pencil'
+    case 'in-progress':
+      return 'kind-icon:loading'
+    case 'rejected':
+      return 'kind-icon:x'
+    case 'stale':
+      return 'kind-icon:refresh'
+    default:
+      return 'kind-icon:lock'
+  }
+}
+</script>

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -1,0 +1,155 @@
+<!-- /components/model-builder/model-builder-recipe-selector.vue -->
+<template>
+  <div class="flex min-h-0 flex-1 flex-col gap-3">
+    <div class="flex items-start justify-between gap-2">
+      <div>
+        <h3 class="text-base font-black text-base-content">
+          2. Choose a recipe &amp; outputs
+        </h3>
+        <p class="mt-1 text-xs text-base-content/60">
+          Building from
+          <span class="font-bold text-base-content">{{ sourceLabel }}</span>
+          <span class="text-base-content/40"> ({{ store.sourceType }})</span>.
+          Defaults are a convenience — toggle whatever you want.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-xs btn-ghost shrink-0 rounded-xl text-base-content/60"
+        @click="store.goToStep('source')"
+      >
+        <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+        Change source
+      </button>
+    </div>
+
+    <!-- Recipe chips -->
+    <div class="flex flex-wrap gap-1.5">
+      <button
+        v-for="recipe in recipes"
+        :key="recipe.key"
+        type="button"
+        class="btn btn-sm h-auto min-h-9 flex-col items-start gap-0 rounded-xl px-3 py-1.5 text-left"
+        :class="
+          store.recipeKey === recipe.key
+            ? 'btn-primary'
+            : 'btn-ghost border border-base-300'
+        "
+        @click="store.selectRecipe(recipe.key)"
+      >
+        <span class="flex items-center gap-1.5 text-xs font-bold">
+          <Icon :name="recipe.icon" class="h-4 w-4" />
+          {{ recipe.label }}
+        </span>
+      </button>
+    </div>
+
+    <p
+      v-if="store.selectedRecipe"
+      class="rounded-xl bg-base-100 px-3 py-2 text-xs text-base-content/60"
+    >
+      {{ store.selectedRecipe.summary }}
+    </p>
+
+    <!-- Outputs -->
+    <div class="min-h-0 flex-1 space-y-1.5 overflow-y-auto">
+      <label
+        v-for="output in store.recipeOutputs"
+        :key="output.key"
+        class="flex cursor-pointer items-center gap-3 rounded-xl border border-base-300 bg-base-100 p-2.5 transition hover:border-primary/50"
+        :class="store.selections[output.key]?.on ? 'border-primary/60 bg-primary/5' : ''"
+      >
+        <input
+          type="checkbox"
+          class="checkbox checkbox-sm checkbox-primary"
+          :checked="store.selections[output.key]?.on"
+          @change="store.toggleOutput(output.key)"
+        />
+
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-1.5">
+            <span class="truncate text-sm font-bold text-base-content">
+              {{ output.label }}
+            </span>
+            <span class="badge badge-xs badge-ghost">{{ output.generation }}</span>
+            <span v-if="output.size" class="text-[10px] text-base-content/40">
+              {{ output.size }}
+            </span>
+          </div>
+          <p class="truncate text-xs text-base-content/50">
+            {{ output.description }}
+          </p>
+        </div>
+
+        <div
+          v-if="output.quantity && store.selections[output.key]?.on"
+          class="flex shrink-0 items-center gap-1"
+          @click.prevent
+        >
+          <span class="text-[10px] uppercase text-base-content/40">qty</span>
+          <input
+            type="number"
+            min="1"
+            max="12"
+            class="input input-xs input-bordered w-14 rounded-lg text-center"
+            :value="store.selections[output.key]?.quantity"
+            @input="onQuantity(output.key, $event)"
+          />
+        </div>
+
+        <span
+          class="badge badge-sm shrink-0"
+          :class="actionBadge(output.action)"
+        >
+          {{ output.action }}
+        </span>
+      </label>
+    </div>
+
+    <!-- Footer -->
+    <div
+      class="flex shrink-0 items-center justify-between gap-2 border-t border-base-300 pt-2"
+    >
+      <span class="text-xs text-base-content/60">
+        {{ store.selectedOutputCount }} output{{ store.selectedOutputCount === 1 ? '' : 's' }} selected
+      </span>
+      <button
+        type="button"
+        class="btn btn-primary btn-sm rounded-xl"
+        :disabled="!store.canStartRun"
+        @click="store.startRun()"
+      >
+        <Icon name="kind-icon:play" class="h-4 w-4" />
+        Start build run
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import {
+  getRecipesForSource,
+  type BuildAction,
+} from '@/stores/helpers/modelBuilderRecipes'
+
+const store = useModelBuilderStore()
+
+const recipes = computed(() =>
+  store.sourceType ? getRecipesForSource(store.sourceType) : [],
+)
+
+const sourceLabel = computed(() => store.sourceLabel(store.selectedSource))
+
+function onQuantity(key: string, event: Event): void {
+  const value = Number((event.target as HTMLInputElement).value)
+  store.setOutputQuantity(key, value)
+}
+
+function actionBadge(action: BuildAction): string {
+  if (action === 'CREATE') return 'badge-secondary'
+  if (action === 'UPDATE') return 'badge-accent'
+  return 'badge-ghost'
+}
+</script>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -1,0 +1,118 @@
+<!-- /components/model-builder/model-builder-source-picker.vue -->
+<template>
+  <div class="flex min-h-0 flex-1 flex-col gap-3">
+    <div>
+      <h3 class="text-base font-black text-base-content">1. Pick a source model</h3>
+      <p class="mt-1 text-xs text-base-content/60">
+        Choose the existing record to upgrade or expand from. Every run keeps a
+        snapshot of this source.
+      </p>
+    </div>
+
+    <!-- Source type tabs -->
+    <div class="flex flex-wrap gap-1.5">
+      <button
+        v-for="type in sourceTypes"
+        :key="type.key"
+        type="button"
+        class="btn btn-sm h-9 min-h-9 gap-1.5 rounded-xl px-3 text-xs font-bold"
+        :class="
+          store.sourceType === type.key
+            ? 'btn-primary'
+            : 'btn-ghost border border-base-300 text-base-content/70'
+        "
+        @click="store.selectSourceType(type.key)"
+      >
+        <Icon :name="type.icon" class="h-4 w-4" />
+        {{ type.label }}
+      </button>
+    </div>
+
+    <p
+      v-if="activeType"
+      class="rounded-xl bg-base-100 px-3 py-2 text-xs text-base-content/60"
+    >
+      {{ activeType.blurb }}
+    </p>
+
+    <!-- Records -->
+    <div class="min-h-0 flex-1">
+      <div
+        v-if="!store.sourceType"
+        class="flex h-full min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/50"
+      >
+        Select a source type above to load records.
+      </div>
+
+      <div
+        v-else-if="store.loadingSources"
+        class="flex h-full min-h-32 items-center justify-center gap-2 text-sm text-base-content/60"
+      >
+        <span class="loading loading-dots loading-md" />
+        Loading {{ activeType?.plural.toLowerCase() }}…
+      </div>
+
+      <div
+        v-else-if="store.sourcesError"
+        class="flex h-full min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-error/30 bg-error/5 p-6 text-center text-sm text-error"
+      >
+        <Icon name="kind-icon:warning" class="h-6 w-6" />
+        {{ store.sourcesError }}
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost mt-1 rounded-xl"
+          @click="store.loadSources()"
+        >
+          Retry
+        </button>
+      </div>
+
+      <div
+        v-else
+        class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3"
+      >
+        <button
+          v-for="record in store.sources"
+          :key="record.id"
+          type="button"
+          class="flex flex-col items-start gap-0.5 rounded-2xl border border-base-300 bg-base-100 p-3 text-left transition hover:border-primary hover:bg-base-200"
+          @click="store.selectSource(record)"
+        >
+          <span class="truncate text-sm font-bold text-base-content">
+            {{ store.sourceLabel(record) }}
+          </span>
+          <span
+            v-if="subtitle(record)"
+            class="line-clamp-2 text-xs text-base-content/55"
+          >
+            {{ subtitle(record) }}
+          </span>
+          <span class="mt-1 text-[10px] uppercase tracking-wide text-base-content/35">
+            #{{ record.id }}
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import type { SourceRecord } from '@/stores/modelBuilderStore'
+import { SOURCE_TYPES, getSourceType } from '@/stores/helpers/modelBuilderRecipes'
+
+const store = useModelBuilderStore()
+const sourceTypes = SOURCE_TYPES
+
+const activeType = computed(() =>
+  store.sourceType ? getSourceType(store.sourceType) : undefined,
+)
+
+function subtitle(record: SourceRecord): string {
+  const field = activeType.value?.subtitleField
+  if (!field) return ''
+  const value = record[field]
+  return typeof value === 'string' ? value : ''
+}
+</script>

--- a/content/model-builder.md
+++ b/content/model-builder.md
@@ -1,0 +1,12 @@
+---
+title: Model Builder
+room: 'Model Builder Room'
+subtitle: Resumable, human-gated recipe runner
+description: Select a Kind Robots source model, choose a recipe, and walk each output through pitch, fields, generation, and commit — editable and resumable at every gate.
+icon: kind-icon:blueprint
+tooltip: Upgrade or expand existing Kind Robots records through four reviewable gates.
+loadingMessage: Loading Model Builder…
+refreshLabel: Refresh
+---
+
+:model-builder-manager

--- a/stores/helpers/modelBuilderRecipes.ts
+++ b/stores/helpers/modelBuilderRecipes.ts
@@ -1,0 +1,341 @@
+// /stores/helpers/modelBuilderRecipes.ts
+//
+// Static catalog for the Model Builder: the four gated stages, the supported
+// source types, the recipe matrix, and the selectable output catalog. This is
+// the front-end grounding for the conductor `model-builder` project brief —
+// durable orchestration records live server-side in a later milestone; here we
+// describe what a run may contain so the UI can drive it.
+
+export type BuildStageKey =
+  | 'PITCH'
+  | 'FIELDS_AND_PROMPTS'
+  | 'GENERATE_ASSETS'
+  | 'COMMIT'
+
+export interface BuildStageConfig {
+  key: BuildStageKey
+  label: string
+  short: string
+  description: string
+  icon: string
+}
+
+// Ordered — an item advances through these and no later stage may bypass an
+// unapproved prerequisite (enforced in the store).
+export const BUILD_STAGES: BuildStageConfig[] = [
+  {
+    key: 'PITCH',
+    label: 'Pitch',
+    short: 'Pitch',
+    description: 'Review the idea and intent for this output before any fields or assets exist.',
+    icon: 'kind-icon:lightbulb',
+  },
+  {
+    key: 'FIELDS_AND_PROMPTS',
+    label: 'Fields & Prompts',
+    short: 'Fields',
+    description: 'Review proposed schema fields, relationships, and generation prompts.',
+    icon: 'kind-icon:list',
+  },
+  {
+    key: 'GENERATE_ASSETS',
+    label: 'Generate Assets',
+    short: 'Assets',
+    description: 'Generate candidate images or media and pick the ones to keep.',
+    icon: 'kind-icon:sparkles',
+  },
+  {
+    key: 'COMMIT',
+    label: 'Commit',
+    short: 'Commit',
+    description: 'Review the final diff and create, update, link, or promote only approved work.',
+    icon: 'kind-icon:check',
+  },
+]
+
+export type SourceTypeKey =
+  | 'Project'
+  | 'Character'
+  | 'Bot'
+  | 'Facet'
+  | 'Dream'
+  | 'Reward'
+  | 'Scenario'
+
+export interface SourceTypeConfig {
+  key: SourceTypeKey
+  label: string
+  plural: string
+  icon: string
+  // List endpoint that returns { success, data: Record[] }.
+  endpoint: string
+  // Field used for the primary display name on each record.
+  titleField: string
+  // Optional secondary display field.
+  subtitleField?: string
+  defaultRecipe: RecipeKey
+  recipes: RecipeKey[]
+  blurb: string
+}
+
+export type RecipeKey =
+  | 'marketing-deck'
+  | 'character-deck'
+  | 'reward-deck'
+  | 'art-upgrade'
+  | 'relationship-expansion'
+
+export interface RecipeConfig {
+  key: RecipeKey
+  label: string
+  icon: string
+  summary: string
+  sourceTypes: SourceTypeKey[]
+}
+
+export type BuildAction = 'CREATE' | 'UPDATE' | 'ASSET_ONLY'
+export type GenerationKind = 'image' | 'text' | 'video' | 'three-d' | 'plan'
+
+export interface BuildOutputConfig {
+  key: string
+  label: string
+  recipe: RecipeKey
+  action: BuildAction
+  generation: GenerationKind
+  description: string
+  // Standard target dimensions for image outputs, when fixed.
+  size?: string
+  // Whether the user picks a quantity (batch / expansion outputs).
+  quantity?: boolean
+  // Suggested art engine hint for image outputs, passed to the art generator.
+  engine?: 'a1111' | 'comfy' | 'flux' | 'kontext' | 'openai'
+  // Selected by default when the recipe is chosen.
+  defaultOn?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Source type configuration — maps each supported model to its list endpoint,
+// display fields, and eligible recipes (from the brief's recipe matrix).
+// ---------------------------------------------------------------------------
+
+export const SOURCE_TYPES: SourceTypeConfig[] = [
+  {
+    key: 'Project',
+    label: 'Project',
+    plural: 'Projects',
+    icon: 'kind-icon:blueprint',
+    endpoint: '/api/projects',
+    titleField: 'title',
+    subtitleField: 'description',
+    defaultRecipe: 'marketing-deck',
+    recipes: ['marketing-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Marketing decks, a manager bot, or an art upgrade for a project.',
+  },
+  {
+    key: 'Character',
+    label: 'Character',
+    plural: 'Characters',
+    icon: 'kind-icon:user',
+    endpoint: '/api/characters',
+    titleField: 'name',
+    subtitleField: 'class',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Full character deck, signature rewards, or an art upgrade.',
+  },
+  {
+    key: 'Bot',
+    label: 'Bot',
+    plural: 'Bots',
+    icon: 'kind-icon:robot',
+    endpoint: '/api/bots',
+    titleField: 'name',
+    subtitleField: 'botType',
+    defaultRecipe: 'character-deck',
+    recipes: ['character-deck', 'art-upgrade'],
+    blurb: 'Character deck with expressions, transitions, and an art upgrade.',
+  },
+  {
+    key: 'Facet',
+    label: 'Facet',
+    plural: 'Facets',
+    icon: 'kind-icon:gem',
+    endpoint: '/api/facets',
+    titleField: 'title',
+    subtitleField: 'kind',
+    defaultRecipe: 'art-upgrade',
+    recipes: ['art-upgrade', 'relationship-expansion'],
+    blurb: 'Art upgrade, or expand into fitting dreams, characters, or rewards.',
+  },
+  {
+    key: 'Dream',
+    label: 'Dream',
+    plural: 'Dreams',
+    icon: 'kind-icon:cloud',
+    endpoint: '/api/dreams',
+    titleField: 'title',
+    subtitleField: 'dreamType',
+    defaultRecipe: 'art-upgrade',
+    recipes: ['art-upgrade', 'relationship-expansion'],
+    blurb: 'Art upgrade, or expand into characters, rewards, scenarios, or a narrator bot.',
+  },
+  {
+    key: 'Reward',
+    label: 'Reward',
+    plural: 'Rewards',
+    icon: 'kind-icon:trophy',
+    endpoint: '/api/rewards',
+    titleField: 'name',
+    subtitleField: 'rewardType',
+    defaultRecipe: 'reward-deck',
+    recipes: ['reward-deck', 'art-upgrade', 'relationship-expansion'],
+    blurb: 'Reward deck with type-aware art and optional 3D reference.',
+  },
+  {
+    key: 'Scenario',
+    label: 'Scenario',
+    plural: 'Scenarios',
+    icon: 'kind-icon:map',
+    endpoint: '/api/scenarios',
+    titleField: 'title',
+    subtitleField: 'difficulty',
+    defaultRecipe: 'art-upgrade',
+    recipes: ['art-upgrade', 'relationship-expansion'],
+    blurb: 'Art upgrade, or expand into cast characters and rewards.',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Recipes — versioned presets of eligible outputs. Defaults are conveniences,
+// never mandatory bundles: the user may remove all defaults and request one.
+// ---------------------------------------------------------------------------
+
+export const RECIPES: RecipeConfig[] = [
+  {
+    key: 'marketing-deck',
+    label: 'Marketing Deck',
+    icon: 'kind-icon:megaphone',
+    summary: 'A launch package for a project — cards, signage, mockups, ads, and a plan.',
+    sourceTypes: ['Project'],
+  },
+  {
+    key: 'character-deck',
+    label: 'Character Deck',
+    icon: 'kind-icon:user',
+    summary: 'Identity, canonical portrait, icon/card/hero, and an expression subset.',
+    sourceTypes: ['Character', 'Bot'],
+  },
+  {
+    key: 'reward-deck',
+    label: 'Reward Deck',
+    icon: 'kind-icon:trophy',
+    summary: 'Reward fields, art, collection placement, and optional 3D reference.',
+    sourceTypes: ['Reward'],
+  },
+  {
+    key: 'art-upgrade',
+    label: 'Art Upgrade',
+    icon: 'kind-icon:palette-color',
+    summary: 'Only the assets valid for this model: primary image, icon, card, hero, and repair.',
+    sourceTypes: ['Project', 'Character', 'Bot', 'Facet', 'Dream', 'Reward', 'Scenario'],
+  },
+  {
+    key: 'relationship-expansion',
+    label: 'Relationship Expansion',
+    icon: 'kind-icon:link',
+    summary: 'Create related records — each child is an independently gated build item.',
+    sourceTypes: ['Project', 'Character', 'Facet', 'Dream', 'Scenario', 'Reward'],
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Output catalog — the selectable outputs per recipe. Each has a stable key,
+// an action, a generation kind, and (for images) a target size.
+// ---------------------------------------------------------------------------
+
+export const OUTPUT_CATALOG: BuildOutputConfig[] = [
+  // Marketing Deck (Project) --------------------------------------------------
+  { key: 'business-card', label: 'Business card', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Front/back business card concept.', defaultOn: true },
+  { key: 'logo-application', label: 'Logo application sheet', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Existing logo applied across surfaces.' },
+  { key: 'lawn-sign', label: 'Lawn sign', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Yard/lawn sign concept.' },
+  { key: 'banner', label: 'Banner', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', size: '1280×720', description: 'Wide banner concept.' },
+  { key: 'flyer', label: 'Flyer', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Single-page promotional flyer.' },
+  { key: 'website-mockup', label: 'Website mockup board', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Landing page mockup board.', defaultOn: true },
+  { key: 'app-mockup', label: 'App mockup board', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'App screen mockup board.' },
+  { key: 'photo-shoot-plan', label: 'Photo-shoot plan', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'plan', description: 'Shot list and plan for a photo shoot.' },
+  { key: 'video-shot-list', label: 'Video shot list', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'plan', description: 'Shot list for a video shoot.' },
+  { key: 'static-ads', label: 'Static ad concepts', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Static ad posters and concepts.' },
+  { key: 'commercial-treatment', label: 'Video commercial treatment', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'plan', description: 'Treatment for a video commercial.' },
+  { key: 'storyboard', label: 'Storyboard', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Panel storyboard for the commercial.' },
+  { key: 'launch-plan', label: 'Week-by-week launch plan', recipe: 'marketing-deck', action: 'ASSET_ONLY', generation: 'plan', description: 'Weekly launch schedule.', defaultOn: true },
+
+  // Character Deck (Character / Bot) -----------------------------------------
+  { key: 'identity-pitch', label: 'Identity pitch', recipe: 'character-deck', action: 'UPDATE', generation: 'text', description: 'Identity and field pitch for the character.', defaultOn: true },
+  { key: 'field-proposal', label: 'Schema field proposal', recipe: 'character-deck', action: 'UPDATE', generation: 'text', description: 'Proposed schema fields to fill or refine.', defaultOn: true },
+  { key: 'canonical-avatar', label: 'Canonical avatar (NEUTRAL)', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', size: 'square', description: 'Promoted neutral avatar — canonical identity anchor.', defaultOn: true },
+  { key: 'portrait-candidates', label: 'Portrait candidates', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', size: 'square', description: 'Candidate portraits to pick a canonical from.' },
+  { key: 'icon', label: 'Icon', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', size: '256×256', description: 'Square icon.' },
+  { key: 'card', label: 'Card', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', size: '512×768', description: 'Portrait card.' },
+  { key: 'hero', label: 'Hero shot', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', size: '1280×720', description: 'Wide hero action shot.' },
+  { key: 'expression-subset', label: 'Expression subset', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', size: 'square', quantity: true, description: 'A small ExpressionMedia emotion/action subset — proven on a subset before the full set.' },
+  { key: 'model-sheet', label: 'Cutout / model-sheet reference', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'image', description: 'Transparent cutout or model-sheet reference.' },
+  { key: 'three-d-reference', label: '3D reference / model', recipe: 'character-deck', action: 'ASSET_ONLY', generation: 'three-d', description: 'Optional 3D reference output (Hunyuan3D).' },
+
+  // Reward Deck (Reward) ------------------------------------------------------
+  { key: 'reward-fields', label: 'Reward fields', recipe: 'reward-deck', action: 'UPDATE', generation: 'text', description: 'Reward field proposal.', defaultOn: true },
+  { key: 'reward-icon', label: 'Icon', recipe: 'reward-deck', action: 'ASSET_ONLY', generation: 'image', size: '256×256', description: 'Reward icon.', defaultOn: true },
+  { key: 'reward-card', label: 'Card', recipe: 'reward-deck', action: 'ASSET_ONLY', generation: 'image', size: '512×768', description: 'Reward card.' },
+  { key: 'reward-hero', label: 'Hero / use scene', recipe: 'reward-deck', action: 'ASSET_ONLY', generation: 'image', size: '1280×720', description: 'Hero or in-use scene.' },
+  { key: 'collection-placement', label: 'Collection placement', recipe: 'reward-deck', action: 'UPDATE', generation: 'text', description: 'Suggested ArtCollection placement.' },
+  { key: 'reward-relationships', label: 'Relationship proposals', recipe: 'reward-deck', action: 'UPDATE', generation: 'text', description: 'Owner-character or scenario-use pitches.' },
+  { key: 'reward-3d', label: '3D reference / print path', recipe: 'reward-deck', action: 'ASSET_ONLY', generation: 'three-d', description: 'ITEM: 3D reference and printable-model path (separate STL stages).' },
+
+  // Art Upgrade (any) ---------------------------------------------------------
+  { key: 'primary-image', label: 'Primary image', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', description: 'Primary image for the model.', defaultOn: true },
+  { key: 'upgrade-icon', label: 'Icon', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', size: '256×256', description: 'Square icon.' },
+  { key: 'upgrade-card', label: 'Card', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', size: '512×768', description: 'Portrait card.' },
+  { key: 'upgrade-hero', label: 'Hero', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', size: '1280×720', description: 'Wide hero banner.' },
+  { key: 'key-scene', label: 'Key scene', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', description: 'A signature scene image.' },
+  { key: 'inspiration-set', label: 'Inspiration set / ArtCollection', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', quantity: true, description: 'A set of inspiration candidates for the collection.' },
+  { key: 'missing-asset-repair', label: 'Missing-asset repair', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', description: 'Fill only the assets this model is missing.' },
+
+  // Relationship Expansion ----------------------------------------------------
+  { key: 'expand-characters', label: 'Characters', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting characters, each an independent build item.' },
+  { key: 'expand-rewards', label: 'Rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting rewards.' },
+  { key: 'expand-scenarios', label: 'Scenarios', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting scenarios.' },
+  { key: 'expand-narrator-bot', label: 'Narrator bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'Optional narrator bot for a dream.' },
+  { key: 'expand-manager-bot', label: 'Manager bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'Optional manager bot for a project.' },
+  { key: 'expand-signature-rewards', label: 'Signature rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Signature rewards for a character.' },
+]
+
+// ---------------------------------------------------------------------------
+// Lookups
+// ---------------------------------------------------------------------------
+
+export function getSourceType(key: SourceTypeKey): SourceTypeConfig | undefined {
+  return SOURCE_TYPES.find((source) => source.key === key)
+}
+
+export function getRecipe(key: RecipeKey): RecipeConfig | undefined {
+  return RECIPES.find((recipe) => recipe.key === key)
+}
+
+export function getRecipesForSource(sourceKey: SourceTypeKey): RecipeConfig[] {
+  const source = getSourceType(sourceKey)
+  if (!source) return []
+  return source.recipes
+    .map((recipeKey) => getRecipe(recipeKey))
+    .filter((recipe): recipe is RecipeConfig => Boolean(recipe))
+}
+
+export function getOutputsForRecipe(recipeKey: RecipeKey): BuildOutputConfig[] {
+  return OUTPUT_CATALOG.filter((output) => output.recipe === recipeKey)
+}
+
+export function getOutput(key: string): BuildOutputConfig | undefined {
+  return OUTPUT_CATALOG.find((output) => output.key === key)
+}
+
+export function getStage(key: BuildStageKey): BuildStageConfig | undefined {
+  return BUILD_STAGES.find((stage) => stage.key === key)
+}

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1,0 +1,600 @@
+// /stores/modelBuilderStore.ts
+//
+// Model Builder — a resumable, human-gated recipe runner for Kind Robots
+// records. A user selects a source model, a recipe, and individual outputs;
+// each output becomes a BuildItem that advances through PITCH,
+// FIELDS_AND_PROMPTS, GENERATE_ASSETS, and COMMIT. Users may edit, approve,
+// reject, rerun, or resume at any stage; editing upstream work marks
+// downstream work stale without deleting it.
+//
+// This front-end slice keeps run state on the client (localStorage) for resume
+// and reuses the existing art generator for GENERATE_ASSETS. Durable
+// server-side BuildRun/BuildItem persistence and the idempotent final COMMIT
+// write are a later, human-gated milestone (see conductor model-builder
+// roadmap t-004 / t-013 / t-014); COMMIT here produces a preview diff only and
+// never silently rewrites a canonical model.
+
+import { defineStore } from 'pinia'
+import { computed, reactive, toRefs } from 'vue'
+import { performFetch, handleError } from '@/stores/utils'
+import { useArtStore } from '@/stores/artStore'
+import {
+  BUILD_STAGES,
+  getOutput,
+  getOutputsForRecipe,
+  getRecipe,
+  getSourceType,
+  type BuildAction,
+  type BuildOutputConfig,
+  type BuildStageKey,
+  type GenerationKind,
+  type RecipeKey,
+  type SourceTypeKey,
+} from '@/stores/helpers/modelBuilderRecipes'
+
+export type BuilderStep = 'source' | 'recipe' | 'run'
+
+export type StageStatus =
+  | 'locked' // a prerequisite stage is not yet approved
+  | 'ready' // workable now
+  | 'in-progress' // generation running
+  | 'approved' // user approved this stage
+  | 'rejected' // user rejected — needs a redo
+  | 'stale' // an upstream edit invalidated this stage
+
+export interface StageState {
+  status: StageStatus
+  note?: string
+}
+
+// A single record loaded from a source-type list endpoint. Kept loose — the
+// UI only needs an id and a couple of display fields.
+export interface SourceRecord {
+  id: number
+  [key: string]: unknown
+}
+
+export interface BuildItem {
+  id: string // stable within a run: `${outputKey}#${quantityIndex}`
+  outputKey: string
+  label: string
+  action: BuildAction
+  generation: GenerationKind
+  quantityIndex: number
+  stages: Record<BuildStageKey, StageState>
+  pitch: string
+  fieldsDraft: string
+  promptDraft: string
+  artImageId: number | null
+  imagePath: string | null
+  error: string | null
+}
+
+export interface BuildRun {
+  id: string
+  createdAt: string
+  sourceType: SourceTypeKey
+  sourceId: number
+  sourceLabel: string
+  recipeKey: RecipeKey
+  items: BuildItem[]
+}
+
+interface OutputSelection {
+  on: boolean
+  quantity: number
+}
+
+interface ModelBuilderState {
+  step: BuilderStep
+  sourceType: SourceTypeKey | null
+  sources: SourceRecord[]
+  loadingSources: boolean
+  sourcesError: string
+  selectedSource: SourceRecord | null
+  recipeKey: RecipeKey | null
+  selections: Record<string, OutputSelection>
+  run: BuildRun | null
+  generatingItemId: string | null
+  statusMessage: string
+  statusTone: 'success' | 'error'
+}
+
+const isClient = typeof window !== 'undefined'
+const runStorageKey = 'modelBuilder:run'
+const MAX_BATCH = 12
+
+function safeGet(key: string): string | null {
+  if (!isClient) return null
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  if (!isClient) return
+  try {
+    localStorage.setItem(key, value)
+  } catch {}
+}
+
+function safeRemove(key: string): void {
+  if (!isClient) return
+  try {
+    localStorage.removeItem(key)
+  } catch {}
+}
+
+function makeRunId(sourceType: SourceTypeKey, sourceId: number): string {
+  // No Math.random / Date.now dependency for the id core so a resumed run keeps
+  // a stable identity; createdAt carries the timestamp separately.
+  return `${sourceType.toLowerCase()}-${sourceId}-${BUILD_STAGES.length}`
+}
+
+// Initial stage map: PITCH is workable, the rest are locked behind it.
+function freshStages(): Record<BuildStageKey, StageState> {
+  const stages = {} as Record<BuildStageKey, StageState>
+  BUILD_STAGES.forEach((stage, index) => {
+    stages[stage.key] = { status: index === 0 ? 'ready' : 'locked' }
+  })
+  return stages
+}
+
+function stageIndex(key: BuildStageKey): number {
+  return BUILD_STAGES.findIndex((stage) => stage.key === key)
+}
+
+// Turn a catalog size ('256×256', '512×768', 'square', undefined) into pixel
+// dimensions for the art generator.
+function sizeToDimensions(size?: string): { width: number; height: number } {
+  if (!size || size === 'square') return { width: 1024, height: 1024 }
+  const match = size.match(/(\d+)\s*[×x]\s*(\d+)/)
+  if (!match) return { width: 1024, height: 1024 }
+  return { width: Number(match[1]), height: Number(match[2]) }
+}
+
+export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
+  const state = reactive<ModelBuilderState>({
+    step: 'source',
+    sourceType: null,
+    sources: [],
+    loadingSources: false,
+    sourcesError: '',
+    selectedSource: null,
+    recipeKey: null,
+    selections: {},
+    run: null,
+    generatingItemId: null,
+    statusMessage: '',
+    statusTone: 'success',
+  })
+
+  // --- display helpers ------------------------------------------------------
+
+  function sourceLabel(record: SourceRecord | null): string {
+    if (!record) return ''
+    const config = state.sourceType ? getSourceType(state.sourceType) : undefined
+    const field = config?.titleField ?? 'title'
+    const value = record[field] ?? record.title ?? record.name ?? record.slug
+    return typeof value === 'string' && value.trim()
+      ? value
+      : `#${record.id}`
+  }
+
+  const selectedRecipe = computed(() =>
+    state.recipeKey ? getRecipe(state.recipeKey) : undefined,
+  )
+
+  const recipeOutputs = computed<BuildOutputConfig[]>(() =>
+    state.recipeKey ? getOutputsForRecipe(state.recipeKey) : [],
+  )
+
+  const selectedOutputCount = computed(
+    () =>
+      Object.values(state.selections).filter((selection) => selection.on)
+        .length,
+  )
+
+  const canStartRun = computed(
+    () => Boolean(state.selectedSource && state.recipeKey && selectedOutputCount.value > 0),
+  )
+
+  const runProgress = computed(() => {
+    if (!state.run) return { total: 0, committed: 0 }
+    const total = state.run.items.length
+    const committed = state.run.items.filter(
+      (item) => item.stages.COMMIT.status === 'approved',
+    ).length
+    return { total, committed }
+  })
+
+  function setStatus(tone: 'success' | 'error', message: string): void {
+    state.statusTone = tone
+    state.statusMessage = message
+  }
+
+  function clearStatus(): void {
+    state.statusMessage = ''
+  }
+
+  // --- step 1: source type + records ---------------------------------------
+
+  async function selectSourceType(key: SourceTypeKey): Promise<void> {
+    if (state.sourceType === key && state.sources.length) return
+    state.sourceType = key
+    state.selectedSource = null
+    state.recipeKey = null
+    state.selections = {}
+    await loadSources()
+  }
+
+  async function loadSources(): Promise<void> {
+    const config = state.sourceType ? getSourceType(state.sourceType) : undefined
+    if (!config) return
+
+    state.loadingSources = true
+    state.sourcesError = ''
+
+    try {
+      const response = await performFetch<SourceRecord[]>(config.endpoint)
+      if (!response.success || !Array.isArray(response.data)) {
+        throw new Error(response.message || `Failed to load ${config.plural}.`)
+      }
+      state.sources = response.data
+      if (!state.sources.length) {
+        state.sourcesError = `No ${config.plural.toLowerCase()} available to build from.`
+      }
+    } catch (error) {
+      handleError(error, `loading ${config.plural.toLowerCase()}`)
+      state.sourcesError =
+        error instanceof Error ? error.message : `Failed to load ${config.plural}.`
+      state.sources = []
+    } finally {
+      state.loadingSources = false
+    }
+  }
+
+  function selectSource(record: SourceRecord): void {
+    state.selectedSource = record
+    const config = state.sourceType ? getSourceType(state.sourceType) : undefined
+    if (config) selectRecipe(config.defaultRecipe)
+    state.step = 'recipe'
+  }
+
+  // --- step 2: recipe + outputs --------------------------------------------
+
+  function selectRecipe(key: RecipeKey): void {
+    state.recipeKey = key
+    const selections: Record<string, OutputSelection> = {}
+    for (const output of getOutputsForRecipe(key)) {
+      selections[output.key] = {
+        on: Boolean(output.defaultOn),
+        quantity: output.quantity ? 3 : 1,
+      }
+    }
+    state.selections = selections
+  }
+
+  function toggleOutput(key: string): void {
+    const selection = state.selections[key]
+    if (!selection) return
+    selection.on = !selection.on
+  }
+
+  function setOutputQuantity(key: string, quantity: number): void {
+    const selection = state.selections[key]
+    if (!selection) return
+    selection.quantity = Math.max(1, Math.min(MAX_BATCH, Math.floor(quantity) || 1))
+  }
+
+  // --- step 3: build run + gated stage advancement -------------------------
+
+  function startRun(): void {
+    if (!state.selectedSource || !state.sourceType || !state.recipeKey) return
+
+    const items: BuildItem[] = []
+    for (const output of recipeOutputs.value) {
+      const selection = state.selections[output.key]
+      if (!selection?.on) continue
+
+      const count = output.quantity ? selection.quantity : 1
+      for (let index = 0; index < count; index++) {
+        items.push({
+          id: `${output.key}#${index}`,
+          outputKey: output.key,
+          label: count > 1 ? `${output.label} ${index + 1}` : output.label,
+          action: output.action,
+          generation: output.generation,
+          quantityIndex: index,
+          stages: freshStages(),
+          pitch: '',
+          fieldsDraft: '',
+          promptDraft: '',
+          artImageId: null,
+          imagePath: null,
+          error: null,
+        })
+      }
+    }
+
+    state.run = {
+      id: makeRunId(state.sourceType, state.selectedSource.id),
+      createdAt: nowIso(),
+      sourceType: state.sourceType,
+      sourceId: state.selectedSource.id,
+      sourceLabel: sourceLabel(state.selectedSource),
+      recipeKey: state.recipeKey,
+      items,
+    }
+    state.step = 'run'
+    persistRun()
+    setStatus('success', `Started a ${getRecipe(state.recipeKey)?.label} run with ${items.length} item${items.length === 1 ? '' : 's'}.`)
+  }
+
+  function findItem(itemId: string): BuildItem | undefined {
+    return state.run?.items.find((item) => item.id === itemId)
+  }
+
+  // Stale-invalidation: editing an upstream stage marks every downstream stage
+  // stale (unless still locked). Commit is always downstream of everything.
+  function markDownstreamStale(item: BuildItem, fromStage: BuildStageKey): void {
+    const from = stageIndex(fromStage)
+    BUILD_STAGES.forEach((stage, index) => {
+      if (index <= from) return
+      const current = item.stages[stage.key].status
+      if (current === 'approved' || current === 'ready' || current === 'in-progress') {
+        item.stages[stage.key] = { status: 'stale' }
+      }
+    })
+  }
+
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+    // Unlock the next stage.
+    const next = BUILD_STAGES[stageIndex(stageKey) + 1]
+    if (next && item.stages[next.key].status === 'locked') {
+      item.stages[next.key] = { status: 'ready' }
+    }
+    persistRun()
+  }
+
+  function rejectStage(itemId: string, stageKey: BuildStageKey, note?: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'rejected', note }
+    markDownstreamStale(item, stageKey)
+    persistRun()
+  }
+
+  // Reopen a stale/approved stage for editing and invalidate downstream.
+  function reopenStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'ready' }
+    markDownstreamStale(item, stageKey)
+    persistRun()
+  }
+
+  function updatePitch(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.pitch = value
+    markDownstreamStale(item, 'PITCH')
+    persistRun()
+  }
+
+  function updateFields(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.fieldsDraft = value
+    markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
+    persistRun()
+  }
+
+  function updatePrompt(itemId: string, value: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.promptDraft = value
+    markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
+    persistRun()
+  }
+
+  // --- GENERATE_ASSETS: reuse the existing art generator --------------------
+
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    if (item.generation !== 'image') {
+      // Non-image generation kinds (text, plan, video, 3d) are described in the
+      // brief but not wired into this front-end slice yet.
+      item.error = `${item.generation} generation is not wired into the front-end slice yet.`
+      item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+      setStatus('error', item.error)
+      return false
+    }
+
+    const prompt = item.promptDraft.trim() || item.pitch.trim()
+    if (!prompt) {
+      item.error = 'Add a prompt in Fields & Prompts before generating.'
+      setStatus('error', item.error)
+      return false
+    }
+
+    const output = getOutput(item.outputKey)
+    const { width, height } = sizeToDimensions(output?.size)
+    const artStore = useArtStore()
+
+    state.generatingItemId = item.id
+    item.error = null
+    item.stages.GENERATE_ASSETS = { status: 'in-progress' }
+    clearStatus()
+
+    try {
+      await artStore.prepareArtGenerator()
+
+      const result = await artStore.generateCurrentArt({
+        promptString: prompt,
+        title: `${state.run.sourceLabel} — ${item.label}`,
+        width,
+        height,
+        engine: output?.engine,
+        isPublic: false,
+      })
+
+      if (!result.success || !result.data) {
+        throw new Error(result.message || 'Generation failed.')
+      }
+
+      const image = result.data as { id: number; imagePath?: string | null }
+      item.artImageId = image.id
+      item.imagePath = image.imagePath ?? null
+      item.stages.GENERATE_ASSETS = { status: 'ready' }
+      setStatus('success', `Generated a candidate for ${item.label}.`)
+      persistRun()
+      return true
+    } catch (error) {
+      handleError(error, 'generating model builder asset')
+      item.error = error instanceof Error ? error.message : 'Generation failed.'
+      item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+      setStatus('error', item.error)
+      return false
+    } finally {
+      state.generatingItemId = null
+    }
+  }
+
+  // --- COMMIT: preview only (durable write is a gated backend milestone) ----
+
+  interface CommitPreview {
+    itemId: string
+    action: BuildAction
+    targetType: SourceTypeKey | 'ArtImage'
+    summary: string
+    fields: string
+    artImageId: number | null
+  }
+
+  function previewCommit(itemId: string): CommitPreview | null {
+    const item = findItem(itemId)
+    if (!item || !state.run) return null
+    return {
+      itemId: item.id,
+      action: item.action,
+      targetType: item.action === 'ASSET_ONLY' ? 'ArtImage' : state.run.sourceType,
+      summary:
+        item.action === 'ASSET_ONLY'
+          ? `Promote generated asset for ${item.label} to ${state.run.sourceLabel}.`
+          : `${item.action} ${state.run.sourceType} from ${item.label}.`,
+      fields: item.fieldsDraft,
+      artImageId: item.artImageId,
+    }
+  }
+
+  // Records the user's approval of the final diff. The actual durable create /
+  // update / link / promote happens through model APIs in a later gated
+  // milestone — this scaffold only marks the item as approved-for-commit.
+  function approveCommit(itemId: string): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages.COMMIT = {
+      status: 'approved',
+      note: 'Approved for commit — durable write pending backend execution.',
+    }
+    persistRun()
+    setStatus('success', `${item.label} approved for commit.`)
+  }
+
+  // --- persistence / resume -------------------------------------------------
+
+  function persistRun(): void {
+    if (!state.run) {
+      safeRemove(runStorageKey)
+      return
+    }
+    safeSet(runStorageKey, JSON.stringify(state.run))
+  }
+
+  function resumeRun(): void {
+    const raw = safeGet(runStorageKey)
+    if (!raw) return
+    try {
+      const parsed = JSON.parse(raw) as BuildRun
+      if (parsed && Array.isArray(parsed.items)) {
+        state.run = parsed
+        state.sourceType = parsed.sourceType
+        state.recipeKey = parsed.recipeKey
+        state.step = 'run'
+      }
+    } catch {
+      safeRemove(runStorageKey)
+    }
+  }
+
+  function goToStep(step: BuilderStep): void {
+    state.step = step
+  }
+
+  function resetRun(): void {
+    state.run = null
+    state.step = state.selectedSource ? 'recipe' : 'source'
+    safeRemove(runStorageKey)
+    clearStatus()
+  }
+
+  function resetAll(): void {
+    state.step = 'source'
+    state.sourceType = null
+    state.sources = []
+    state.selectedSource = null
+    state.recipeKey = null
+    state.selections = {}
+    state.run = null
+    state.generatingItemId = null
+    safeRemove(runStorageKey)
+    clearStatus()
+  }
+
+  return {
+    ...toRefs(state),
+    // computed
+    selectedRecipe,
+    recipeOutputs,
+    selectedOutputCount,
+    canStartRun,
+    runProgress,
+    // display
+    sourceLabel,
+    // actions
+    selectSourceType,
+    loadSources,
+    selectSource,
+    selectRecipe,
+    toggleOutput,
+    setOutputQuantity,
+    startRun,
+    approveStage,
+    rejectStage,
+    reopenStage,
+    updatePitch,
+    updateFields,
+    updatePrompt,
+    generateItemAsset,
+    previewCommit,
+    approveCommit,
+    resumeRun,
+    goToStep,
+    resetRun,
+    resetAll,
+    setStatus,
+    clearStatus,
+  }
+})
+
+function nowIso(): string {
+  return new Date().toISOString()
+}

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -15,9 +15,10 @@
 // never silently rewrites a canonical model.
 
 import { defineStore } from 'pinia'
-import { computed, reactive, toRefs } from 'vue'
+import { computed, reactive, ref, toRefs } from 'vue'
 import { performFetch, handleError } from '@/stores/utils'
 import { useArtStore } from '@/stores/artStore'
+import { useServerStore } from '@/stores/serverStore'
 import {
   BUILD_STAGES,
   getOutput,
@@ -104,6 +105,19 @@ const isClient = typeof window !== 'undefined'
 const runStorageKey = 'modelBuilder:run'
 const MAX_BATCH = 12
 
+// Which draft field an AI suggestion targets. `artPrompt` matches the /api/suggest
+// convention used by the art generator.
+export type DraftField = 'pitch' | 'fields' | 'artPrompt'
+
+const DRAFT_INSTRUCTIONS: Record<DraftField, string> = {
+  pitch:
+    'Write a concise 2-3 sentence pitch describing why this output exists for the source record and what it should convey. Return only the pitch text.',
+  fields:
+    'Propose the concrete schema fields and relationships this output should write, as short "field: value" lines grounded in the source record. Return only the field list.',
+  artPrompt:
+    'Write a single vivid image-generation prompt for this output, grounded in the source record. Comma-separated descriptors, no preamble. Return only the prompt.',
+}
+
 function safeGet(key: string): string | null {
   if (!isClient) return null
   try {
@@ -170,6 +184,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     statusMessage: '',
     statusTone: 'success',
   })
+
+  // Per-button spinner state for AI drafting: which item/field is in flight.
+  const draftingField = ref<{ itemId: string; field: DraftField } | null>(null)
 
   // --- display helpers ------------------------------------------------------
 
@@ -403,6 +420,97 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     persistRun()
   }
 
+  // --- AI drafting: reuse the existing /api/suggest text generator -----------
+
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    const serverStore = useServerStore()
+    const activeServer = serverStore.activeTextServer
+    const serverSnapshot = activeServer
+      ? {
+          serverType: activeServer.serverType ?? null,
+          baseUrl: activeServer.baseUrl ?? null,
+          endpointPath: activeServer.endpointPath ?? null,
+          model: activeServer.model ?? null,
+        }
+      : undefined
+
+    const current =
+      field === 'pitch'
+        ? item.pitch
+        : field === 'fields'
+          ? item.fieldsDraft
+          : item.promptDraft
+
+    draftingField.value = { itemId, field }
+    clearStatus()
+
+    try {
+      const result = await performFetch<{ value: string }>(
+        '/api/suggest',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            builder: 'model-builder',
+            server: serverSnapshot,
+            field,
+            stepKey: field,
+            current,
+            context: {
+              sourceType: state.run.sourceType,
+              sourceLabel: state.run.sourceLabel,
+              recipe: state.run.recipeKey,
+              output: item.outputKey,
+              itemLabel: item.label,
+              action: item.action,
+              pitch: item.pitch,
+              fields: item.fieldsDraft,
+              source: state.selectedSource ?? undefined,
+            },
+            extra: {
+              instruction: instruction || DRAFT_INSTRUCTIONS[field],
+              sourceLabel: state.run.sourceLabel,
+            },
+          }),
+        },
+        2,
+        60_000,
+      )
+
+      if (!result.success || !result.data?.value) {
+        throw new Error(result.message || 'The model returned nothing useful.')
+      }
+
+      const value = result.data.value.trim()
+      // Route through the manual-edit setters so downstream stages stale exactly
+      // as they would on a hand edit.
+      if (field === 'pitch') updatePitch(itemId, value)
+      else if (field === 'fields') updateFields(itemId, value)
+      else updatePrompt(itemId, value)
+
+      setStatus(
+        'success',
+        `Drafted ${field === 'artPrompt' ? 'prompt' : field} for ${item.label}.`,
+      )
+      return true
+    } catch (error) {
+      handleError(error, 'drafting model builder text')
+      const message =
+        error instanceof Error ? error.message : 'Draft request failed.'
+      setStatus('error', message)
+      return false
+    } finally {
+      draftingField.value = null
+    }
+  }
+
   // --- GENERATE_ASSETS: reuse the existing art generator --------------------
 
   async function generateItemAsset(itemId: string): Promise<boolean> {
@@ -561,6 +669,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   return {
     ...toRefs(state),
+    draftingField,
     // computed
     selectedRecipe,
     recipeOutputs,
@@ -583,6 +692,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     updatePitch,
     updateFields,
     updatePrompt,
+    draftText,
     generateItemAsset,
     previewCommit,
     approveCommit,


### PR DESCRIPTION
## What & why

Stands up the front end for the conductor **model-builder** project: a resumable, human-gated recipe runner for existing Kind Robots records. Route: **`/model-builder`**. Advances roadmap m1 (concrete recipe catalog) and m2 (front-end workflow); first slice of t-005/t-014.

A run selects a **source model** → a **recipe** → individual **outputs**, and each output becomes a Build Item that walks four reviewable gates:

1. **PITCH** → 2. **FIELDS_AND_PROMPTS** → 3. **GENERATE_ASSETS** → 4. **COMMIT**

Editing an upstream gate stales everything downstream (revisions preserved, not deleted). Runs persist to `localStorage` and resume on reload.

## What's wired
- **Source picker** loads live records from `/api/{projects,characters,bots,facets,dreams,rewards,scenarios}`.
- **AI-drafting** — "Draft with AI" on pitch / field-proposal / prompt, reusing the existing `/api/suggest` text pipeline (mirrors `builderStore.callSuggest`), client-side only.
- **GENERATE_ASSETS** runs **live** through the existing art generator (`artStore.generateCurrentArt`) — image outputs produce a real `ArtImage` candidate (private).

## Files
- `stores/helpers/modelBuilderRecipes.ts` — typed stage/source/recipe/output catalog (from the project brief matrix).
- `stores/modelBuilderStore.ts` — run/item/stage state, gated advancement + stale-invalidation, `draftText` (suggest), `generateItemAsset` (art), localStorage resume.
- `components/model-builder/*` — manager shell, source picker, recipe/output selector, progress matrix, four-gate item editor.
- `content/model-builder.md` — the route.

## Deliberate boundaries (no risk on merge)
- **No Prisma/schema/migration.** Run state is client-side; durable `ModelBuildRun` persistence is the deferred follow-up (roadmap t-004). Merge-to-main's `prisma migrate deploy` is a **no-op** here.
- **COMMIT is preview-only** — records the final diff; the durable create/update/link/promote stays behind the existing human gate (t-013/t-015).
- Only image generation is wired; text/plan/video/3D outputs are catalogued and gated but show a "not wired yet" note.

## Verification
- Relies on this PR's CI: whole-project `vue-tsc` (typecheck workflow) + the Vercel preview build. I could not run the toolchain locally (no `node_modules`/generated Prisma client in the authoring environment), so those checks are the gate.
- Icon names validated against `assets/icons/*`; component names checked against the global `pathPrefix: false` config; source list endpoints confirmed to return `{ success, data: [...] }`.
- Note: eslint/prettier are not in CI and weren't run locally — style was matched by hand.

Reversible, scoped, additive UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_