### PR TITLE
Consolidate art generation onto the durable ArtJob queue

### DIFF
--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -50,7 +50,7 @@
       >
         <span v-if="artStore.isGenerating" class="flex items-center gap-2">
           <span class="loading loading-dots loading-sm" />
-          {{ busyLabel }}
+          {{ busyText }}
         </span>
 
         <span v-else class="flex items-center gap-2">
@@ -162,6 +162,15 @@ const serverChoice = ref<ServerChoice>('default')
 const resultImage = computed(
   () => artStore.lastGeneratedArtImage || artStore.currentArtImage || null,
 )
+
+// While a generation is in flight it now goes through the durable ArtJob
+// queue: reflect whether the job is waiting for the relay ("Queued…") or
+// actively rendering ("Rendering…"). Falls back to the caller's busyLabel.
+const busyText = computed(() => {
+  if (artStore.queueState === 'queued') return 'Queued…'
+  if (artStore.queueState === 'rendering') return 'Rendering…'
+  return props.busyLabel
+})
 
 const serverOptions = computed<Server[]>(() => {
   return Array.isArray(artStore.generationServers)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postinstall": "nuxi prepare",
     "snapshot:fallback": "tsx utils/scripts/snapshotFallback.ts",
     "backfill:slugs": "tsx utils/scripts/backfillSlugs.ts",
+    "migrate:art-jobs": "tsx utils/scripts/migratePromptsToArtJobs.ts",
     "characters:repair": "tsx utils/scripts/repairCharacterSlugs.mjs",
     "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1014,7 +1014,11 @@ model Prompt {
   isActive       Boolean        @default(true)
   artPrompt      String?        @db.Text
   imagePath      String?        @db.VarChar(764)
-  // Art queue fields
+  // DEPRECATED art queue fields — superseded by the durable ArtJob model.
+  // Generation now flows through ArtJob (see /api/art/enqueue + the relay);
+  // these columns are no longer written. Pending rows were migrated to ArtJob
+  // by utils/scripts/migratePromptsToArtJobs.ts. Kept for history until a
+  // follow-up migration drops them (and the ArtStatus enum).
   serverId       Int?
   artStatus      ArtStatus?
   batchId        String?
@@ -1903,6 +1907,9 @@ model Todo {
   @@index([projectId])
 }
 
+/// DEPRECATED — legacy state machine for the bolted-on Prompt art queue.
+/// Superseded by ArtJobStatus on the durable ArtJob model. Retained only until
+/// the Prompt.artStatus column is dropped in a follow-up migration.
 enum ArtStatus {
   PENDING
   QUEUED

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -1,0 +1,298 @@
+// /server/api/art/enqueue.post.ts
+//
+// High-level, engine-dispatching enqueue endpoint. This is the single surface
+// the browser art flow (stores/artStore.ts) posts to: it charges mana, builds
+// the correct ArtJob payload for the requested engine, and creates a durable
+// ArtJob. The home relay agent then claims the job outward, renders it against
+// local A1111/Comfy, uploads via /api/art/save-generated, and completes it —
+// so generation works even though the deployed backend cannot reach the home
+// GPU box. Poll /api/art/queue/:id until DONE, then load the ArtImage.
+//
+// Distinct from POST /api/art/queue (the low-level producer surface used by
+// conductor scripts with pre-built payloads and no mana gate). Browser/billed
+// work must go through here so mana is charged exactly once, at enqueue time.
+//
+// The payload carries a `save` block (isPublic/isMature/designer); the complete
+// endpoint applies it plus ownership by the enqueuing user to the uploaded
+// ArtImage, since the relay uploads as its own machine user.
+//
+// OpenAI is intentionally NOT handled here — the backend reaches OpenAI
+// directly (no relay needed), so the browser keeps calling the synchronous
+// /api/chats/openai/images/generate for that engine.
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '../../utils/error'
+import { authAndGate } from '../../utils/comfyGate'
+import { buildDefaultComfyWorkflow } from '../comfy/sdxl/utils/workflow'
+import { buildFluxWorkflowFromRequest } from '../comfy/flux/utils/workflow'
+import {
+  buildKontextWorkflow,
+  getKontextImageExtension,
+} from '../comfy/kontext/utils/workflow'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+// The queueable engines. `openai` is handled synchronously elsewhere.
+type EnqueueEngine = 'a1111' | 'comfy' | 'flux' | 'kontext'
+
+// GenerateArtData-shaped body (a superset; only the fields used per engine are
+// read). Mirrors stores/artStore.ts GenerateArtData.
+type ArtEnqueueRequest = {
+  engine?: string | null
+  promptString?: string | null
+  prompt?: string | null
+  artPrompt?: string | null
+  negativePrompt?: string | null
+  checkpoint?: string | null
+  sampler?: string | null
+  scheduler?: string | null
+  steps?: number | null
+  cfg?: number | null
+  cfgHalf?: boolean | null
+  guidance?: number | null
+  denoise?: number | null
+  seed?: number | null
+  width?: number | null
+  height?: number | null
+  variant?: 'dev' | 'schnell' | null
+  designer?: string | null
+  isPublic?: boolean | null
+  isMature?: boolean | null
+  serverId?: number | null
+  serverName?: string | null
+  projectSlug?: string | null
+  priority?: number | null
+  // Kontext (image-to-image) source.
+  sourceImageBase64?: string | null
+}
+
+// ComfyEngine used by the mana gate — a1111 shares comfy's base 2D cost.
+const GATE_ENGINE: Record<EnqueueEngine, 'comfy' | 'flux' | 'kontext'> = {
+  a1111: 'comfy',
+  comfy: 'comfy',
+  flux: 'flux',
+  kontext: 'kontext',
+}
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
+
+function normalizeEngine(value: unknown): EnqueueEngine {
+  const engine = String(value || 'a1111').toLowerCase()
+
+  if (
+    engine === 'a1111' ||
+    engine === 'comfy' ||
+    engine === 'flux' ||
+    engine === 'kontext'
+  ) {
+    return engine
+  }
+
+  throw createError({
+    statusCode: 400,
+    message:
+      engine === 'openai'
+        ? 'OpenAI generation is synchronous; call /api/chats/openai/images/generate instead of enqueuing.'
+        : `Unsupported enqueue engine "${engine}". Use a1111, comfy, flux, or kontext.`,
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = (await readBody(event)) as ArtEnqueueRequest | null
+
+    const engine = normalizeEngine(body?.engine)
+
+    const promptString = (
+      body?.promptString ||
+      body?.artPrompt ||
+      body?.prompt ||
+      ''
+    ).trim()
+
+    if (!promptString) {
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required field: "promptString".',
+      })
+    }
+
+    const gate = await authAndGate(event, {
+      engine: GATE_ENGINE[engine],
+      steps: body?.steps ?? null,
+      width: body?.width ?? null,
+      height: body?.height ?? null,
+      serverId: body?.serverId ?? null,
+    })
+
+    const projectSlug = body?.projectSlug?.trim().toLowerCase() || null
+
+    if (projectSlug && !SLUG_PATTERN.test(projectSlug)) {
+      throw createError({ statusCode: 400, message: 'Invalid projectSlug.' })
+    }
+
+    const priority = Number.isInteger(body?.priority)
+      ? Number(body?.priority)
+      : 0
+
+    const save = {
+      isPublic: body?.isPublic ?? true,
+      isMature: body?.isMature ?? false,
+      designer: body?.designer?.trim() || null,
+    }
+
+    const { jobEngine, payload } = buildJobPayload(engine, {
+      body: body ?? {},
+      promptString,
+      save,
+    })
+
+    const job = await prisma.artJob.create({
+      data: {
+        engine: jobEngine,
+        payload: payload as unknown as Prisma.InputJsonValue,
+        priority,
+        projectSlug,
+        userId: gate.user.id,
+      },
+    })
+
+    const { balance } = await gate.commit(`art-enqueue:${job.id}`)
+
+    event.node.res.statusCode = 201
+
+    return {
+      success: true,
+      message: 'Art job queued. Poll /api/art/queue/:id until DONE.',
+      statusCode: 201,
+      data: {
+        jobId: job.id,
+        status: job.status,
+        mana: { balance, charged: gate.cost },
+      },
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to queue art job.',
+      statusCode,
+    }
+  }
+})
+
+type SaveBlock = {
+  isPublic: boolean
+  isMature: boolean
+  designer: string | null
+}
+
+// Build the ArtJob engine + payload for the resolved generation engine. A1111
+// jobs carry raw txt2img params; Comfy-family jobs carry a prebuilt workflow.
+function buildJobPayload(
+  engine: EnqueueEngine,
+  ctx: { body: ArtEnqueueRequest; promptString: string; save: SaveBlock },
+): { jobEngine: 'A1111' | 'COMFY'; payload: Record<string, unknown> } {
+  const { body, promptString, save } = ctx
+
+  if (engine === 'a1111') {
+    return {
+      jobEngine: 'A1111',
+      payload: {
+        promptString,
+        negativePrompt: body.negativePrompt ?? '',
+        steps: body.steps ?? null,
+        cfg: body.cfg ?? null,
+        cfgHalf: body.cfgHalf ?? false,
+        width: body.width ?? null,
+        height: body.height ?? null,
+        sampler: body.sampler ?? null,
+        seed: body.seed ?? null,
+        checkpoint: body.checkpoint ?? null,
+        save,
+      },
+    }
+  }
+
+  if (engine === 'flux') {
+    const { workflow } = buildFluxWorkflowFromRequest({
+      variant: body.variant ?? null,
+      prompt: promptString,
+      negativePrompt: body.negativePrompt ?? null,
+      width: body.width ?? null,
+      height: body.height ?? null,
+      steps: body.steps ?? null,
+      cfg: body.cfg ?? null,
+      guidance: body.guidance ?? null,
+      seed: body.seed ?? null,
+      sampler: body.sampler ?? null,
+      scheduler: body.scheduler ?? null,
+      denoise: body.denoise ?? null,
+    })
+
+    return {
+      jobEngine: 'COMFY',
+      payload: { workflow, promptString, save },
+    }
+  }
+
+  if (engine === 'kontext') {
+    const imageData = body.sourceImageBase64?.trim()
+
+    if (!imageData) {
+      throw createError({
+        statusCode: 400,
+        message: 'Kontext generation requires "sourceImageBase64".',
+      })
+    }
+
+    const normalizedImageData = imageData.startsWith('data:image/')
+      ? imageData
+      : `data:image/png;base64,${imageData}`
+
+    const extension = getKontextImageExtension(normalizedImageData)
+    const imageName = `kr_kontext_queue_${crypto.randomUUID()}.${extension}`
+
+    const workflow = buildKontextWorkflow({
+      prompt: promptString,
+      imageName,
+      width: body.width ?? null,
+      height: body.height ?? null,
+      steps: body.steps ?? null,
+      guidance: body.guidance ?? null,
+      seed: body.seed ?? null,
+      sampler: body.sampler ?? null,
+      scheduler: body.scheduler ?? null,
+      denoise: body.denoise ?? null,
+    })
+
+    return {
+      jobEngine: 'COMFY',
+      payload: {
+        workflow,
+        promptString,
+        images: [{ name: imageName, imageData: normalizedImageData }],
+        save,
+      },
+    }
+  }
+
+  // comfy (default SDXL/SD graph)
+  const workflow = buildDefaultComfyWorkflow({
+    prompt: promptString,
+    negativePrompt: body.negativePrompt ?? '',
+    cfgValue: body.cfg ?? 3,
+    seed: body.seed ?? null,
+    steps: body.steps ?? undefined,
+    checkpoint: body.checkpoint ?? null,
+    sampler: body.sampler ?? null,
+  })
+
+  return {
+    jobEngine: 'COMFY',
+    payload: { workflow, promptString, save },
+  }
+}

--- a/server/api/art/generate.post.ts
+++ b/server/api/art/generate.post.ts
@@ -1,4 +1,11 @@
 // /server/api/art/generate.post.ts
+//
+// Direct/relay-only synchronous A1111 txt2img render. This dials the render
+// server inline and returns a finished ArtImage, so it only works from a
+// caller that can reach the GPU box (the home relay agent, or an on-tailnet
+// tool). The browser art flow no longer calls this — it enqueues via
+// /api/art/enqueue and the relay drains the queue. Kept as the relay's
+// execution surface; do not wire new browser callers to it.
 import { createError, defineEventHandler, readBody } from 'h3'
 import type { H3Event } from 'h3'
 import { requireMachineUser } from '../../utils/authGuard'

--- a/server/api/comfy/flux/generate.post.ts
+++ b/server/api/comfy/flux/generate.post.ts
@@ -1,11 +1,19 @@
 // /server/api/comfy/flux/generate.post.ts
+//
+// Direct/relay-only synchronous Flux render. Dials the Comfy server inline, so
+// it only works from a caller on the home tailnet (relay agent or on-box tool).
+// The browser enqueues via /api/art/enqueue instead (engine "flux"), which
+// reuses this route's workflow builder (./utils/workflow.ts).
 import { createError, defineEventHandler, readBody } from 'h3'
 import type { Server } from '~/prisma/generated/prisma/client'
 import { errorHandler } from '../../../utils/error'
 import { getServerEndpoint, resolveServer } from '../../../utils/serverResolver'
 import { authAndGate } from '../../../utils/comfyGate'
-
-type FluxVariant = 'dev' | 'schnell'
+import {
+  buildFluxWorkflowFromRequest,
+  type ComfyWorkflow,
+  type FluxVariant,
+} from './utils/workflow'
 
 type FluxGenerateRequest = {
   variant?: FluxVariant | null
@@ -24,14 +32,6 @@ type FluxGenerateRequest = {
   scheduler?: string | null
   denoise?: number | null
   timeoutMs?: number | null
-}
-
-type ComfyWorkflow = Record<string, ComfyWorkflowNode>
-
-type ComfyWorkflowNode = {
-  class_type?: string
-  inputs?: Record<string, unknown>
-  _meta?: Record<string, unknown>
 }
 
 type ComfyPromptResponse = {
@@ -65,43 +65,6 @@ type ComfyImageOutput = {
 const defaultTimeoutMs = 180_000
 const pollIntervalMs = 1_500
 
-// Flux is trained at ~1 megapixel. Rendering below that (the old 1024x512 =
-// 0.5MP letterbox) is the #1 cause of cramped, distorted, low-detail output.
-// Default to the native 1MP square; callers can still pass any dimensions
-// (use proper 1MP buckets for other aspect ratios, e.g. 1216x832 for 3:2,
-// 1344x768 for 16:9, 832x1216 for a portrait card).
-const DEFAULT_FLUX_DEV_WIDTH = 1024
-const DEFAULT_FLUX_DEV_HEIGHT = 1024
-const DEFAULT_FLUX_SCHNELL_WIDTH = 1024
-const DEFAULT_FLUX_SCHNELL_HEIGHT = 1024
-const DEFAULT_FLUX_SAMPLER = 'euler'
-// `beta` resolves Flux's flow-matching noise schedule far better than the
-// SD-era `normal` scheduler — crisper detail and cleaner composition.
-const DEFAULT_FLUX_SCHEDULER = 'beta'
-const DEFAULT_DENOISE = 1
-
-const defaultPrompt =
-  'an evil magician, holding a magic wand, the magic wand creates the big words:"FLUX GGUF 🔥" appear, professional cartoon movie cover, epic scenery, eyes looking straight, ultra detailed, best movie effects, best quality, ultra professional, magic particles, colorful, midjourneyv6.1, detailmaximizer'
-
-const fluxModelByVariant = {
-  dev: {
-    unetName: 'flux1-dev-Q8_0.gguf',
-    filenamePrefix: 'kindrobots_flux_dev',
-    defaultSteps: 30,
-    defaultCfg: 1,
-    // 3.5 is Flux-dev's aesthetic sweet spot; higher (4+) starts to "burn"
-    // contrast and over-bake detail on general/illustrative prompts.
-    defaultGuidance: 3.5,
-  },
-  schnell: {
-    unetName: 'flux1-schnell-Q8_0.gguf',
-    filenamePrefix: 'kindrobots_flux_schnell',
-    defaultSteps: 8,
-    defaultCfg: 1,
-    defaultGuidance: 4,
-  },
-} as const
-
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody<FluxGenerateRequest>(event)
@@ -123,35 +86,9 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const variant = body.variant === 'schnell' ? 'schnell' : 'dev'
-    const fluxConfig = fluxModelByVariant[variant]
     const baseUrl = getComfyBaseUrl(server)
-    const prompt = body.prompt?.trim() || defaultPrompt
 
-    const workflow = buildFluxWorkflow({
-      prompt,
-      negativePrompt: body.negativePrompt ?? '',
-      width:
-        body.width ??
-        (variant === 'schnell'
-          ? DEFAULT_FLUX_SCHNELL_WIDTH
-          : DEFAULT_FLUX_DEV_WIDTH),
-      height:
-        body.height ??
-        (variant === 'schnell'
-          ? DEFAULT_FLUX_SCHNELL_HEIGHT
-          : DEFAULT_FLUX_DEV_HEIGHT),
-      steps: body.steps ?? fluxConfig.defaultSteps,
-      cfg: body.cfg ?? fluxConfig.defaultCfg,
-      guidance: body.guidance ?? fluxConfig.defaultGuidance,
-      seed: body.seed ?? -1,
-      wildcardSeed: body.wildcardSeed ?? -1,
-      sampler: body.sampler ?? DEFAULT_FLUX_SAMPLER,
-      scheduler: body.scheduler ?? DEFAULT_FLUX_SCHEDULER,
-      denoise: body.denoise ?? DEFAULT_DENOISE,
-      unetName: fluxConfig.unetName,
-      filenamePrefix: fluxConfig.filenamePrefix,
-    })
+    const { workflow, variant } = buildFluxWorkflowFromRequest(body)
 
     const clientId = crypto.randomUUID()
     const promptResponse = await postComfyPrompt(baseUrl, workflow, clientId)
@@ -214,135 +151,6 @@ export default defineEventHandler(async (event) => {
     }
   }
 })
-
-function buildFluxWorkflow(input: {
-  prompt: string
-  negativePrompt: string
-  width: number
-  height: number
-  steps: number
-  cfg: number
-  guidance: number
-  seed: number
-  wildcardSeed: number
-  sampler: string
-  scheduler: string
-  denoise: number
-  unetName: string
-  filenamePrefix: string
-}): ComfyWorkflow {
-  const samplerSeed = resolveSeed(input.seed)
-  const wildcardSeed = resolveSeed(input.wildcardSeed)
-  const prompt = input.prompt.trim() || defaultPrompt
-
-  return {
-    '4': {
-      inputs: {
-        clip_name1: 'umt5_xxl_fp8_e4m3fn_scaled.safetensors',
-        clip_name2: 'clip_l.safetensors',
-        type: 'flux',
-        device: 'default',
-      },
-      class_type: 'DualCLIPLoader',
-      _meta: {
-        title: 'DualCLIPLoader',
-      },
-    },
-    '6': {
-      inputs: {
-        width: input.width,
-        height: input.height,
-        batch_size: 1,
-      },
-      class_type: 'EmptyLatentImage',
-      _meta: {
-        title: 'Empty Latent Image',
-      },
-    },
-    '7': {
-      inputs: {
-        samples: ['52', 0],
-        vae: ['8', 0],
-      },
-      class_type: 'VAEDecode',
-      _meta: {
-        title: 'VAE Decode',
-      },
-    },
-    '8': {
-      inputs: {
-        vae_name: 'ae.safetensors',
-      },
-      class_type: 'VAELoader',
-      _meta: {
-        title: 'Load VAE',
-      },
-    },
-    '24': {
-      inputs: {
-        unet_name: input.unetName,
-      },
-      class_type: 'UnetLoaderGGUF',
-      _meta: {
-        title: 'Unet Loader (GGUF)',
-      },
-    },
-    '46': {
-      inputs: {
-        guidance: input.guidance,
-        conditioning: ['59', 2],
-      },
-      class_type: 'FluxGuidance',
-      _meta: {
-        title: 'FluxGuidance',
-      },
-    },
-    '52': {
-      inputs: {
-        seed: samplerSeed,
-        steps: input.steps,
-        cfg: input.cfg,
-        sampler_name: input.sampler,
-        scheduler: input.scheduler,
-        denoise: input.denoise,
-        model: ['59', 0],
-        positive: ['46', 0],
-        negative: ['46', 0],
-        latent_image: ['6', 0],
-      },
-      class_type: 'KSampler',
-      _meta: {
-        title: 'KSampler',
-      },
-    },
-    '57': {
-      inputs: {
-        filename_prefix: input.filenamePrefix,
-        images: ['7', 0],
-      },
-      class_type: 'SaveImage',
-      _meta: {
-        title: 'Save Image',
-      },
-    },
-    '59': {
-      inputs: {
-        wildcard_text: prompt,
-        populated_text: prompt,
-        mode: 'populate',
-        'Select to add LoRA': 'Select the LoRA to add to the text',
-        'Select to add Wildcard': 'Select the Wildcard to add to the text',
-        seed: wildcardSeed,
-        model: ['24', 0],
-        clip: ['4', 0],
-      },
-      class_type: 'ImpactWildcardEncode',
-      _meta: {
-        title: 'ImpactWildcardEncode',
-      },
-    },
-  }
-}
 
 function assertComfyServer(server: Server): void {
   if (!server.isActive) {
@@ -531,14 +339,6 @@ async function readResponseDetails(response: Response): Promise<string> {
   } catch {
     return response.statusText
   }
-}
-
-function resolveSeed(seed?: number | null): number {
-  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
-    return Math.floor(seed)
-  }
-
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
 }
 
 function sleep(ms: number): Promise<void> {

--- a/server/api/comfy/flux/utils/workflow.ts
+++ b/server/api/comfy/flux/utils/workflow.ts
@@ -1,0 +1,239 @@
+// /server/api/comfy/flux/utils/workflow.ts
+//
+// Shared Flux (GGUF) workflow builder. Extracted from ../generate.post.ts so
+// both the direct/relay render route and the queue-based enqueue endpoint
+// (/api/art/enqueue) build the exact same Comfy graph. The direct route keeps
+// the networking/polling; this module owns only the workflow shape + defaults.
+
+export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
+
+export type ComfyWorkflowNode = {
+  class_type?: string
+  inputs?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+export type FluxVariant = 'dev' | 'schnell'
+
+// Flux is trained at ~1 megapixel. Rendering below that (the old 1024x512 =
+// 0.5MP letterbox) is the #1 cause of cramped, distorted, low-detail output.
+// Default to the native 1MP square; callers can still pass any dimensions
+// (use proper 1MP buckets for other aspect ratios, e.g. 1216x832 for 3:2,
+// 1344x768 for 16:9, 832x1216 for a portrait card).
+export const DEFAULT_FLUX_DEV_WIDTH = 1024
+export const DEFAULT_FLUX_DEV_HEIGHT = 1024
+export const DEFAULT_FLUX_SCHNELL_WIDTH = 1024
+export const DEFAULT_FLUX_SCHNELL_HEIGHT = 1024
+export const DEFAULT_FLUX_SAMPLER = 'euler'
+// `beta` resolves Flux's flow-matching noise schedule far better than the
+// SD-era `normal` scheduler — crisper detail and cleaner composition.
+export const DEFAULT_FLUX_SCHEDULER = 'beta'
+export const DEFAULT_FLUX_DENOISE = 1
+
+export const defaultFluxPrompt =
+  'an evil magician, holding a magic wand, the magic wand creates the big words:"FLUX GGUF 🔥" appear, professional cartoon movie cover, epic scenery, eyes looking straight, ultra detailed, best movie effects, best quality, ultra professional, magic particles, colorful, midjourneyv6.1, detailmaximizer'
+
+export const fluxModelByVariant = {
+  dev: {
+    unetName: 'flux1-dev-Q8_0.gguf',
+    filenamePrefix: 'kindrobots_flux_dev',
+    defaultSteps: 30,
+    defaultCfg: 1,
+    // 3.5 is Flux-dev's aesthetic sweet spot; higher (4+) starts to "burn"
+    // contrast and over-bake detail on general/illustrative prompts.
+    defaultGuidance: 3.5,
+  },
+  schnell: {
+    unetName: 'flux1-schnell-Q8_0.gguf',
+    filenamePrefix: 'kindrobots_flux_schnell',
+    defaultSteps: 8,
+    defaultCfg: 1,
+    defaultGuidance: 4,
+  },
+} as const
+
+export function resolveFluxSeed(seed?: number | null): number {
+  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
+    return Math.floor(seed)
+  }
+
+  return Math.floor(Math.random() * 1_000_000_000_000_000)
+}
+
+export function buildFluxWorkflow(input: {
+  prompt: string
+  negativePrompt: string
+  width: number
+  height: number
+  steps: number
+  cfg: number
+  guidance: number
+  seed: number
+  wildcardSeed: number
+  sampler: string
+  scheduler: string
+  denoise: number
+  unetName: string
+  filenamePrefix: string
+}): ComfyWorkflow {
+  const samplerSeed = resolveFluxSeed(input.seed)
+  const wildcardSeed = resolveFluxSeed(input.wildcardSeed)
+  const prompt = input.prompt.trim() || defaultFluxPrompt
+
+  return {
+    '4': {
+      inputs: {
+        clip_name1: 'umt5_xxl_fp8_e4m3fn_scaled.safetensors',
+        clip_name2: 'clip_l.safetensors',
+        type: 'flux',
+        device: 'default',
+      },
+      class_type: 'DualCLIPLoader',
+      _meta: {
+        title: 'DualCLIPLoader',
+      },
+    },
+    '6': {
+      inputs: {
+        width: input.width,
+        height: input.height,
+        batch_size: 1,
+      },
+      class_type: 'EmptyLatentImage',
+      _meta: {
+        title: 'Empty Latent Image',
+      },
+    },
+    '7': {
+      inputs: {
+        samples: ['52', 0],
+        vae: ['8', 0],
+      },
+      class_type: 'VAEDecode',
+      _meta: {
+        title: 'VAE Decode',
+      },
+    },
+    '8': {
+      inputs: {
+        vae_name: 'ae.safetensors',
+      },
+      class_type: 'VAELoader',
+      _meta: {
+        title: 'Load VAE',
+      },
+    },
+    '24': {
+      inputs: {
+        unet_name: input.unetName,
+      },
+      class_type: 'UnetLoaderGGUF',
+      _meta: {
+        title: 'Unet Loader (GGUF)',
+      },
+    },
+    '46': {
+      inputs: {
+        guidance: input.guidance,
+        conditioning: ['59', 2],
+      },
+      class_type: 'FluxGuidance',
+      _meta: {
+        title: 'FluxGuidance',
+      },
+    },
+    '52': {
+      inputs: {
+        seed: samplerSeed,
+        steps: input.steps,
+        cfg: input.cfg,
+        sampler_name: input.sampler,
+        scheduler: input.scheduler,
+        denoise: input.denoise,
+        model: ['59', 0],
+        positive: ['46', 0],
+        negative: ['46', 0],
+        latent_image: ['6', 0],
+      },
+      class_type: 'KSampler',
+      _meta: {
+        title: 'KSampler',
+      },
+    },
+    '57': {
+      inputs: {
+        filename_prefix: input.filenamePrefix,
+        images: ['7', 0],
+      },
+      class_type: 'SaveImage',
+      _meta: {
+        title: 'Save Image',
+      },
+    },
+    '59': {
+      inputs: {
+        wildcard_text: prompt,
+        populated_text: prompt,
+        mode: 'populate',
+        'Select to add LoRA': 'Select the LoRA to add to the text',
+        'Select to add Wildcard': 'Select the Wildcard to add to the text',
+        seed: wildcardSeed,
+        model: ['24', 0],
+        clip: ['4', 0],
+      },
+      class_type: 'ImpactWildcardEncode',
+      _meta: {
+        title: 'ImpactWildcardEncode',
+      },
+    },
+  }
+}
+
+// Resolve variant defaults + build the workflow from a loose request shape.
+// Shared by the direct route and the enqueue endpoint so both pick identical
+// models, sizes, and sampling for a given variant.
+export function buildFluxWorkflowFromRequest(input: {
+  variant?: FluxVariant | null
+  prompt?: string | null
+  negativePrompt?: string | null
+  width?: number | null
+  height?: number | null
+  steps?: number | null
+  cfg?: number | null
+  guidance?: number | null
+  seed?: number | null
+  wildcardSeed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  denoise?: number | null
+}): { workflow: ComfyWorkflow; variant: FluxVariant } {
+  const variant: FluxVariant = input.variant === 'schnell' ? 'schnell' : 'dev'
+  const fluxConfig = fluxModelByVariant[variant]
+
+  const workflow = buildFluxWorkflow({
+    prompt: input.prompt?.trim() || defaultFluxPrompt,
+    negativePrompt: input.negativePrompt ?? '',
+    width:
+      input.width ??
+      (variant === 'schnell'
+        ? DEFAULT_FLUX_SCHNELL_WIDTH
+        : DEFAULT_FLUX_DEV_WIDTH),
+    height:
+      input.height ??
+      (variant === 'schnell'
+        ? DEFAULT_FLUX_SCHNELL_HEIGHT
+        : DEFAULT_FLUX_DEV_HEIGHT),
+    steps: input.steps ?? fluxConfig.defaultSteps,
+    cfg: input.cfg ?? fluxConfig.defaultCfg,
+    guidance: input.guidance ?? fluxConfig.defaultGuidance,
+    seed: input.seed ?? -1,
+    wildcardSeed: input.wildcardSeed ?? -1,
+    sampler: input.sampler ?? DEFAULT_FLUX_SAMPLER,
+    scheduler: input.scheduler ?? DEFAULT_FLUX_SCHEDULER,
+    denoise: input.denoise ?? DEFAULT_FLUX_DENOISE,
+    unetName: fluxConfig.unetName,
+    filenamePrefix: fluxConfig.filenamePrefix,
+  })
+
+  return { workflow, variant }
+}

--- a/server/api/comfy/kontext/generate.post.ts
+++ b/server/api/comfy/kontext/generate.post.ts
@@ -1,4 +1,9 @@
 // /server/api/comfy/kontext/generate.post.ts
+//
+// Direct/relay-only synchronous Flux Kontext render. Dials the Comfy server
+// inline, so it only works from a caller on the home tailnet. The browser
+// enqueues via /api/art/enqueue (engine "kontext"), which reuses the shared
+// Kontext workflow builder (./utils/workflow.ts).
 import { createError, defineEventHandler, readBody } from 'h3'
 import type { Server } from '~/prisma/generated/prisma/client'
 import { errorHandler } from '../../../utils/error'

--- a/server/api/comfy/sdxl/generate.post.ts
+++ b/server/api/comfy/sdxl/generate.post.ts
@@ -1,4 +1,9 @@
 // /server/api/comfy/sdxl/generate.post.ts
+//
+// Direct/relay-only synchronous Comfy (SDXL/SD) render. Dials the Comfy server
+// inline, so it only works from a caller on the home tailnet (relay agent or
+// on-box tool). The browser enqueues via /api/art/enqueue instead (engine
+// "comfy"), which reuses this route's workflow builder (./utils/workflow.ts).
 import { defineEventHandler, readBody, createError } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
@@ -20,6 +25,11 @@ import {
 import { manaGate } from '../../../utils/manaGate'
 import { estimateArtCostUsd } from '../../../utils/manaCost'
 import { requireApiUser } from '../../../utils/authGuard'
+import {
+  buildDefaultComfyWorkflow,
+  patchComfyWorkflow,
+  type ComfyWorkflow,
+} from './utils/workflow'
 
 type ComfyGenerateRequestData = RequestData &
   CheckpointResourceRequestData & {
@@ -28,14 +38,6 @@ type ComfyGenerateRequestData = RequestData &
     workflow?: ComfyWorkflow | null
     workflowJson?: ComfyWorkflow | null
   }
-
-type ComfyWorkflow = Record<string, ComfyWorkflowNode>
-
-type ComfyWorkflowNode = {
-  class_type?: string
-  inputs?: Record<string, unknown>
-  _meta?: Record<string, unknown>
-}
 
 type ComfyPromptResponse = {
   prompt_id?: string
@@ -466,181 +468,6 @@ async function fetchComfyImageAsBase64(
 
   const arrayBuffer = await response.arrayBuffer()
   return Buffer.from(arrayBuffer).toString('base64')
-}
-
-function patchComfyWorkflow(
-  workflow: ComfyWorkflow,
-  input: Omit<GenerateComfyImageInput, 'server' | 'workflow'>,
-): void {
-  const positiveText = input.prompt
-  const negativeText = input.negativePrompt || ''
-  const seed = input.seed ?? -1
-  const steps = input.steps ?? 20
-  const cfg = input.cfgValue || 3
-  const sampler = normalizeComfySampler(input.sampler)
-  const checkpoint = input.checkpoint || ''
-
-  for (const node of Object.values(workflow)) {
-    if (!node?.inputs) continue
-
-    const classType = node.class_type || ''
-    const title = getNodeTitle(node)
-
-    if (classType === 'CheckpointLoaderSimple' && checkpoint) {
-      assignIfKeyExists(node.inputs, 'ckpt_name', checkpoint)
-    }
-
-    if (classType === 'KSampler') {
-      assignIfKeyExists(node.inputs, 'seed', seed)
-      assignIfKeyExists(node.inputs, 'steps', steps)
-      assignIfKeyExists(node.inputs, 'cfg', cfg)
-      assignIfKeyExists(node.inputs, 'sampler_name', sampler)
-    }
-
-    if (classType === 'CLIPTextEncode') {
-      const label = `${title} ${JSON.stringify(node.inputs)}`.toLowerCase()
-
-      if (label.includes('negative')) {
-        assignIfKeyExists(node.inputs, 'text', negativeText)
-      } else if (label.includes('positive') || label.includes('prompt')) {
-        assignIfKeyExists(node.inputs, 'text', positiveText)
-      }
-    }
-
-    if (classType === 'CLIPTextEncodeFlux') {
-      const label = `${title} ${JSON.stringify(node.inputs)}`.toLowerCase()
-
-      if (label.includes('negative')) {
-        assignIfKeyExists(node.inputs, 'clip_l', negativeText)
-        assignIfKeyExists(node.inputs, 't5xxl', negativeText)
-      } else {
-        assignIfKeyExists(node.inputs, 'clip_l', positiveText)
-        assignIfKeyExists(node.inputs, 't5xxl', positiveText)
-      }
-    }
-
-    if ('noise_seed' in node.inputs) {
-      node.inputs.noise_seed = seed
-    }
-
-    if ('guidance' in node.inputs) {
-      node.inputs.guidance = cfg
-    }
-
-    if ('denoise' in node.inputs && typeof node.inputs.denoise !== 'number') {
-      node.inputs.denoise = 1
-    }
-  }
-}
-
-function buildDefaultComfyWorkflow({
-  prompt,
-  negativePrompt,
-  cfgValue,
-  seed,
-  steps,
-  checkpoint,
-  sampler,
-}: Omit<GenerateComfyImageInput, 'server' | 'workflow'>): ComfyWorkflow {
-  return {
-    '1': {
-      class_type: 'CheckpointLoaderSimple',
-      inputs: {
-        ckpt_name: checkpoint || 'v1-5-pruned-emaonly.safetensors',
-      },
-    },
-    '2': {
-      class_type: 'CLIPTextEncode',
-      inputs: {
-        text: prompt,
-        clip: ['1', 1],
-      },
-      _meta: {
-        title: 'Positive Prompt',
-      },
-    },
-    '3': {
-      class_type: 'CLIPTextEncode',
-      inputs: {
-        text: negativePrompt || '',
-        clip: ['1', 1],
-      },
-      _meta: {
-        title: 'Negative Prompt',
-      },
-    },
-    '4': {
-      class_type: 'EmptyLatentImage',
-      inputs: {
-        width: 1024,
-        height: 1024,
-        batch_size: 1,
-      },
-    },
-    '5': {
-      class_type: 'KSampler',
-      inputs: {
-        seed: seed ?? -1,
-        steps: steps ?? 20,
-        cfg: cfgValue || 3,
-        sampler_name: normalizeComfySampler(sampler),
-        scheduler: 'normal',
-        denoise: 1,
-        model: ['1', 0],
-        positive: ['2', 0],
-        negative: ['3', 0],
-        latent_image: ['4', 0],
-      },
-    },
-    '6': {
-      class_type: 'VAEDecode',
-      inputs: {
-        samples: ['5', 0],
-        vae: ['1', 2],
-      },
-    },
-    '7': {
-      class_type: 'SaveImage',
-      inputs: {
-        filename_prefix: 'kindrobots',
-        images: ['6', 0],
-      },
-    },
-  }
-}
-
-function normalizeComfySampler(sampler?: string | null): string {
-  const value = sampler?.trim()
-
-  if (!value) return 'euler'
-
-  const lookup: Record<string, string> = {
-    'Euler a': 'euler_ancestral',
-    Euler: 'euler',
-    LMS: 'lms',
-    Heun: 'heun',
-    DPM2: 'dpm_2',
-    'DPM2 a': 'dpm_2_ancestral',
-    DDIM: 'ddim',
-  }
-
-  return lookup[value] || value
-}
-
-function getNodeTitle(node: ComfyWorkflowNode): string {
-  const title = node._meta?.title
-
-  return typeof title === 'string' ? title : ''
-}
-
-function assignIfKeyExists(
-  inputs: Record<string, unknown>,
-  key: string,
-  value: unknown,
-): void {
-  if (key in inputs) {
-    inputs[key] = value
-  }
 }
 
 function getComfyHeaders(includeJson = true): HeadersInit {

--- a/server/api/comfy/sdxl/utils/workflow.ts
+++ b/server/api/comfy/sdxl/utils/workflow.ts
@@ -1,0 +1,203 @@
+// /server/api/comfy/sdxl/utils/workflow.ts
+//
+// Shared default SDXL/Comfy workflow builder + patcher. Extracted from
+// ../generate.post.ts so both the direct/relay render route and the
+// queue-based enqueue endpoint (/api/art/enqueue) build the same Comfy graph
+// and apply prompt/seed/sampler overrides identically.
+
+export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
+
+export type ComfyWorkflowNode = {
+  class_type?: string
+  inputs?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+// The generation params the builder/patcher consume (the direct route's
+// GenerateComfyImageInput minus the transport-only server/workflow fields).
+export type ComfyWorkflowInput = {
+  prompt: string
+  cfgValue: number
+  negativePrompt?: string
+  seed?: number | null
+  steps?: number
+  checkpoint?: string | null
+  sampler?: string | null
+}
+
+export function normalizeComfySampler(sampler?: string | null): string {
+  const value = sampler?.trim()
+
+  if (!value) return 'euler'
+
+  const lookup: Record<string, string> = {
+    'Euler a': 'euler_ancestral',
+    Euler: 'euler',
+    LMS: 'lms',
+    Heun: 'heun',
+    DPM2: 'dpm_2',
+    'DPM2 a': 'dpm_2_ancestral',
+    DDIM: 'ddim',
+  }
+
+  return lookup[value] || value
+}
+
+function getNodeTitle(node: ComfyWorkflowNode): string {
+  const title = node._meta?.title
+
+  return typeof title === 'string' ? title : ''
+}
+
+function assignIfKeyExists(
+  inputs: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (key in inputs) {
+    inputs[key] = value
+  }
+}
+
+// Apply the request's prompt/seed/steps/cfg/sampler/checkpoint onto a
+// caller-supplied Comfy workflow, matching nodes by class_type + title.
+export function patchComfyWorkflow(
+  workflow: ComfyWorkflow,
+  input: ComfyWorkflowInput,
+): void {
+  const positiveText = input.prompt
+  const negativeText = input.negativePrompt || ''
+  const seed = input.seed ?? -1
+  const steps = input.steps ?? 20
+  const cfg = input.cfgValue || 3
+  const sampler = normalizeComfySampler(input.sampler)
+  const checkpoint = input.checkpoint || ''
+
+  for (const node of Object.values(workflow)) {
+    if (!node?.inputs) continue
+
+    const classType = node.class_type || ''
+    const title = getNodeTitle(node)
+
+    if (classType === 'CheckpointLoaderSimple' && checkpoint) {
+      assignIfKeyExists(node.inputs, 'ckpt_name', checkpoint)
+    }
+
+    if (classType === 'KSampler') {
+      assignIfKeyExists(node.inputs, 'seed', seed)
+      assignIfKeyExists(node.inputs, 'steps', steps)
+      assignIfKeyExists(node.inputs, 'cfg', cfg)
+      assignIfKeyExists(node.inputs, 'sampler_name', sampler)
+    }
+
+    if (classType === 'CLIPTextEncode') {
+      const label = `${title} ${JSON.stringify(node.inputs)}`.toLowerCase()
+
+      if (label.includes('negative')) {
+        assignIfKeyExists(node.inputs, 'text', negativeText)
+      } else if (label.includes('positive') || label.includes('prompt')) {
+        assignIfKeyExists(node.inputs, 'text', positiveText)
+      }
+    }
+
+    if (classType === 'CLIPTextEncodeFlux') {
+      const label = `${title} ${JSON.stringify(node.inputs)}`.toLowerCase()
+
+      if (label.includes('negative')) {
+        assignIfKeyExists(node.inputs, 'clip_l', negativeText)
+        assignIfKeyExists(node.inputs, 't5xxl', negativeText)
+      } else {
+        assignIfKeyExists(node.inputs, 'clip_l', positiveText)
+        assignIfKeyExists(node.inputs, 't5xxl', positiveText)
+      }
+    }
+
+    if ('noise_seed' in node.inputs) {
+      node.inputs.noise_seed = seed
+    }
+
+    if ('guidance' in node.inputs) {
+      node.inputs.guidance = cfg
+    }
+
+    if ('denoise' in node.inputs && typeof node.inputs.denoise !== 'number') {
+      node.inputs.denoise = 1
+    }
+  }
+}
+
+export function buildDefaultComfyWorkflow({
+  prompt,
+  negativePrompt,
+  cfgValue,
+  seed,
+  steps,
+  checkpoint,
+  sampler,
+}: ComfyWorkflowInput): ComfyWorkflow {
+  return {
+    '1': {
+      class_type: 'CheckpointLoaderSimple',
+      inputs: {
+        ckpt_name: checkpoint || 'v1-5-pruned-emaonly.safetensors',
+      },
+    },
+    '2': {
+      class_type: 'CLIPTextEncode',
+      inputs: {
+        text: prompt,
+        clip: ['1', 1],
+      },
+      _meta: {
+        title: 'Positive Prompt',
+      },
+    },
+    '3': {
+      class_type: 'CLIPTextEncode',
+      inputs: {
+        text: negativePrompt || '',
+        clip: ['1', 1],
+      },
+      _meta: {
+        title: 'Negative Prompt',
+      },
+    },
+    '4': {
+      class_type: 'EmptyLatentImage',
+      inputs: {
+        width: 1024,
+        height: 1024,
+        batch_size: 1,
+      },
+    },
+    '5': {
+      class_type: 'KSampler',
+      inputs: {
+        seed: seed ?? -1,
+        steps: steps ?? 20,
+        cfg: cfgValue || 3,
+        sampler_name: normalizeComfySampler(sampler),
+        scheduler: 'normal',
+        denoise: 1,
+        model: ['1', 0],
+        positive: ['2', 0],
+        negative: ['3', 0],
+        latent_image: ['4', 0],
+      },
+    },
+    '6': {
+      class_type: 'VAEDecode',
+      inputs: {
+        samples: ['5', 0],
+        vae: ['1', 2],
+      },
+    },
+    '7': {
+      class_type: 'SaveImage',
+      inputs: {
+        filename_prefix: 'kindrobots',
+        images: ['6', 0],
+      },
+    },
+  }
+}

--- a/server/api/prompts/generate.post.ts
+++ b/server/api/prompts/generate.post.ts
@@ -1,4 +1,12 @@
 // /server/api/prompts/generate.post.ts
+//
+// DEPRECATED — legacy synchronous "art_prompts" driver. Takes a promptId and
+// walks the bolted-on Prompt.artStatus state machine (QUEUED → GENERATING →
+// DONE) while dialing the render server inline. It is superseded by the durable
+// ArtJob queue: producers now enqueue via /api/art/enqueue (or the conductor
+// scripts) and the home relay renders. Kept only until the Prompt.artStatus
+// columns are dropped; do not wire new callers to it. Pending Prompt rows are
+// migrated to ArtJob by utils/scripts/migratePromptsToArtJobs.ts.
 import { defineEventHandler, readBody, createError } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -215,6 +215,9 @@ type ArtStoreState = {
   generationMessageTone: 'success' | 'error'
   lastGeneratedArtImage: ArtImage | null
   selectedGenerationCollectionId: number | null
+  // Async ArtJob queue state for the in-flight generation (enqueue → poll).
+  queueState: 'queued' | 'rendering' | null
+  currentJobId: number | null
 }
 
 const isClient = typeof window !== 'undefined'
@@ -328,6 +331,8 @@ export const useArtStore = defineStore('artStore', () => {
     generationMessageTone: 'success',
     lastGeneratedArtImage: null,
     selectedGenerationCollectionId: null,
+    queueState: null,
+    currentJobId: null,
     artForm: {
       promptString: '',
       negativePrompt: '',
@@ -1871,33 +1876,6 @@ export const useArtStore = defineStore('artStore', () => {
     return String(errorData)
   }
 
-  async function generateComfyImageFromBrowserServer(
-    server: Server,
-    data: GenerateArtData,
-  ): Promise<string> {
-    throw new Error(
-      `Browser Comfy generation is not wired yet for "${server.title}".`,
-    )
-  }
-
-  async function generateFluxImageFromBrowserServer(
-    server: Server,
-    data: GenerateArtData,
-  ): Promise<string> {
-    throw new Error(
-      `Browser Flux generation is not wired yet for "${server.title}".`,
-    )
-  }
-
-  async function generateKontextImageFromBrowserServer(
-    server: Server,
-    data: GenerateArtData,
-  ): Promise<string> {
-    throw new Error(
-      `Browser Kontext generation is not wired yet for "${server.title}".`,
-    )
-  }
-
   async function saveBrowserGeneratedArtImage(
     data: GenerateArtData & { imageBase64: string },
   ): Promise<ArtImage> {
@@ -1919,56 +1897,6 @@ export const useArtStore = defineStore('artStore', () => {
     }
 
     return response.data
-  }
-
-  async function generateBrowserArtImage(
-    server: Server,
-    data: GenerateArtData,
-    engine: ArtImageGenerationEngine,
-  ): Promise<ArtImage> {
-    if (engine === 'a1111') {
-      const imageBase64 = await generateImageFromBrowserServer(server, data)
-
-      return await saveBrowserGeneratedArtImage({
-        ...data,
-        imageBase64,
-      })
-    }
-
-    if (engine === 'comfy') {
-      const imageBase64 = await generateComfyImageFromBrowserServer(
-        server,
-        data,
-      )
-
-      return await saveBrowserGeneratedArtImage({
-        ...data,
-        imageBase64,
-      })
-    }
-
-    if (engine === 'flux') {
-      const imageBase64 = await generateFluxImageFromBrowserServer(server, data)
-
-      return await saveBrowserGeneratedArtImage({
-        ...data,
-        imageBase64,
-      })
-    }
-
-    if (engine === 'kontext') {
-      const imageBase64 = await generateKontextImageFromBrowserServer(
-        server,
-        data,
-      )
-
-      return await saveBrowserGeneratedArtImage({
-        ...data,
-        imageBase64,
-      })
-    }
-
-    throw new Error(`Unsupported browser generation engine: ${engine}`)
   }
 
   function getBackendArtImageGenerationEndpoint(
@@ -2102,6 +2030,117 @@ export const useArtStore = defineStore('artStore', () => {
     }
 
     return response.data
+  }
+
+  // ---------------------------------------------------------------------------
+  // Durable ArtJob queue path (the default for every engine except OpenAI).
+  // Enqueue via /api/art/enqueue, poll /api/art/queue/:id until the home relay
+  // renders + completes the job, then load the resulting ArtImage. Mirrors the
+  // pattern in stores/stylistStore.ts.
+  // ---------------------------------------------------------------------------
+  const ART_QUEUE_POLL_MS = 5_000
+  const ART_QUEUE_TIMEOUT_MS = 10 * 60_000
+
+  type QueuedArtJob = {
+    id: number
+    status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
+    artImageId?: number | null
+    error?: string | null
+  }
+
+  function queueSleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  async function enqueueArtJob(
+    data: GenerateArtData,
+    engine: ArtImageGenerationEngine,
+  ): Promise<number> {
+    const response = await performFetch<{ jobId: number; status: string }>(
+      '/api/art/enqueue',
+      {
+        method: 'POST',
+        body: JSON.stringify({ ...data, engine }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+      2,
+      60_000,
+    )
+
+    if (!response.success || !response.data?.jobId) {
+      throw new Error(response.message || 'Failed to queue art job.')
+    }
+
+    return response.data.jobId
+  }
+
+  async function waitForQueuedArtJob(jobId: number): Promise<QueuedArtJob> {
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < ART_QUEUE_TIMEOUT_MS) {
+      const response = await performFetch<{ job: QueuedArtJob }>(
+        `/api/art/queue/${jobId}`,
+        { method: 'GET' },
+        2,
+        20_000,
+      )
+
+      const job = response.success ? response.data?.job : null
+
+      if (
+        job?.status === 'DONE' ||
+        job?.status === 'FAILED' ||
+        job?.status === 'CANCELLED'
+      ) {
+        return job
+      }
+
+      // Surface "queued" vs "rendering" so the button can tell whether the
+      // home relay has claimed the job yet.
+      if (job?.status === 'PENDING' || job?.status === 'RUNNING') {
+        state.queueState = job.status === 'RUNNING' ? 'rendering' : 'queued'
+      }
+
+      await queueSleep(ART_QUEUE_POLL_MS)
+    }
+
+    throw new Error(
+      'The studio engine is still catching up. The job stays queued and its image will appear once the engine finishes — no need to resubmit.',
+    )
+  }
+
+  // Enqueue an ArtJob, wait for the relay to render it, then load the finished
+  // ArtImage (with image data) so callers get the same ArtImage the synchronous
+  // path used to return inline.
+  async function enqueueAndRenderArtImage(
+    data: GenerateArtData,
+    engine: ArtImageGenerationEngine,
+  ): Promise<ArtImage> {
+    state.queueState = 'queued'
+
+    const jobId = await enqueueArtJob(data, engine)
+    state.currentJobId = jobId
+
+    const job = await waitForQueuedArtJob(jobId)
+
+    if (job.status !== 'DONE' || !job.artImageId) {
+      throw new Error(
+        job.error || `Art job ${jobId} ${job.status.toLowerCase()}.`,
+      )
+    }
+
+    const image = await getArtImageById(job.artImageId, {
+      force: true,
+      includeImageData: true,
+    })
+
+    if (!image) {
+      throw new Error(
+        `Art job ${jobId} finished but its image (${job.artImageId}) could not be loaded.`,
+      )
+    }
+
+    return image
   }
 
   async function ensureCollectionsReady(): Promise<void> {
@@ -2297,40 +2336,22 @@ export const useArtStore = defineStore('artStore', () => {
           }
         : data
 
+      // Hosted Kontext (no explicit server): enqueue an image-to-image job so
+      // the home relay renders it, same as every other engine.
       if (resolvedData.engine === 'kontext' && !server) {
         const dataWithHostedKontext: GenerateArtData = {
           ...data,
           serverId: null,
           serverName: null,
           engine: 'kontext',
-          transport: 'backend',
         }
 
-        const image = await generateBackendArtImage(
+        const image = await enqueueAndRenderArtImage(
           dataWithHostedKontext,
           'kontext',
         )
 
-        addOrUpdateArtImages([image])
-
-        state.generatedArtImages = mergeUniqueArtImages(
-          state.generatedArtImages,
-          [image],
-        )
-
-        state.currentArtImage = image
-        state.lastGeneratedArtImage = image
-
-        await addGeneratedArtImageToCollections(
-          image,
-          dataWithHostedKontext.userId || 10,
-          dataWithHostedKontext.artCollectionId,
-        )
-
-        setGenerationMessage(
-          'success',
-          'Image created and added to collections.',
-        )
+        await applyGeneratedArtImage(image, dataWithHostedKontext)
 
         return {
           success: true,
@@ -2348,36 +2369,16 @@ export const useArtStore = defineStore('artStore', () => {
       const dataWithServer: GenerateArtData = {
         ...resolvedData,
         engine: route.engine,
-        transport:
-          route.engine === 'comfy' ||
-          route.engine === 'flux' ||
-          route.engine === 'kontext'
-            ? 'backend'
-            : route.transport,
       }
 
+      // OpenAI runs on the backend directly (no home relay needed), so it stays
+      // synchronous. Every other engine goes through the durable ArtJob queue.
       const image =
-        dataWithServer.transport === 'browser'
-          ? await generateBrowserArtImage(server, dataWithServer, route.engine)
-          : await generateBackendArtImage(dataWithServer, route.engine)
+        route.engine === 'openai'
+          ? await generateBackendArtImage(dataWithServer, 'openai')
+          : await enqueueAndRenderArtImage(dataWithServer, route.engine)
 
-      addOrUpdateArtImages([image])
-
-      state.generatedArtImages = mergeUniqueArtImages(
-        state.generatedArtImages,
-        [image],
-      )
-
-      state.currentArtImage = image
-      state.lastGeneratedArtImage = image
-
-      await addGeneratedArtImageToCollections(
-        image,
-        dataWithServer.userId || 10,
-        dataWithServer.artCollectionId,
-      )
-
-      setGenerationMessage('success', 'Image created and added to collections.')
+      await applyGeneratedArtImage(image, dataWithServer)
 
       return {
         success: true,
@@ -2399,8 +2400,34 @@ export const useArtStore = defineStore('artStore', () => {
     } finally {
       state.loading = false
       state.isGenerating = false
+      state.queueState = null
+      state.currentJobId = null
       animationStore.stop()
     }
+  }
+
+  // Shared tail for a freshly generated image: cache it, track it as the
+  // latest generation, and link it into the selected collections.
+  async function applyGeneratedArtImage(
+    image: ArtImage,
+    data: GenerateArtData,
+  ): Promise<void> {
+    addOrUpdateArtImages([image])
+
+    state.generatedArtImages = mergeUniqueArtImages(state.generatedArtImages, [
+      image,
+    ])
+
+    state.currentArtImage = image
+    state.lastGeneratedArtImage = image
+
+    await addGeneratedArtImageToCollections(
+      image,
+      data.userId || 10,
+      data.artCollectionId,
+    )
+
+    setGenerationMessage('success', 'Image created and added to collections.')
   }
 
   function resetInitialization(): void {

--- a/utils/scripts/migratePromptsToArtJobs.ts
+++ b/utils/scripts/migratePromptsToArtJobs.ts
@@ -1,0 +1,126 @@
+// utils/scripts/migratePromptsToArtJobs.ts
+//
+// One-time migration: convert pending legacy "art_prompts" work — Prompt rows
+// still sitting in the bolted-on art queue (artStatus PENDING/QUEUED/GENERATING
+// with no finished image) — into durable ArtJob rows, so the home relay drains
+// them like everything else. Consolidates onto ArtJob as the single source of
+// truth (see /api/art/enqueue).
+//
+// Each migrated Prompt gets:
+//   - a new ArtJob (engine A1111, payload built from artPrompt/prompt + imagePath)
+//   - artStatus cleared to null so it is not double-processed by the deprecated
+//     /api/prompts/generate driver.
+//
+// Usage (tsx, matching backfillSlugs.ts — the repo is ESM):
+//   npm run migrate:art-jobs            # dry run (default)
+//   npm run migrate:art-jobs -- --write # apply
+
+import 'dotenv/config'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
+
+const WRITE = process.argv.includes('--write')
+
+// Prompt.userId is optional (default 1); ArtJob.userId is required.
+const FALLBACK_USER_ID = 1
+
+// Live (unfinished) legacy queue states worth migrating.
+const PENDING_STATES = ['PENDING', 'QUEUED', 'GENERATING'] as const
+
+async function main() {
+  const prompts = await prisma.prompt.findMany({
+    where: {
+      artStatus: { in: [...PENDING_STATES] },
+      artImageId: null,
+    },
+    select: {
+      id: true,
+      userId: true,
+      prompt: true,
+      artPrompt: true,
+      imagePath: true,
+      isPublic: true,
+      isMature: true,
+      artStatus: true,
+    },
+  })
+
+  if (!prompts.length) {
+    console.log('No pending Prompt art-queue rows to migrate.')
+    return
+  }
+
+  for (const p of prompts) {
+    const promptString = (p.artPrompt ?? p.prompt ?? '').trim()
+    console.log(
+      `Prompt #${p.id} [${p.artStatus}] → ArtJob (user ${p.userId ?? FALLBACK_USER_ID})` +
+        `  "${promptString.slice(0, 60)}"`,
+    )
+  }
+
+  if (!WRITE) {
+    console.log(
+      `\nDry run: ${prompts.length} Prompt row(s) would become ArtJob(s). Re-run with --write to apply.`,
+    )
+    return
+  }
+
+  let migrated = 0
+  let skipped = 0
+
+  for (const p of prompts) {
+    const promptString = (p.artPrompt ?? p.prompt ?? '').trim()
+
+    if (!promptString) {
+      // Nothing to render — just clear the stale queue state.
+      await prisma.prompt.update({
+        where: { id: p.id },
+        data: { artStatus: null },
+      })
+      skipped++
+      continue
+    }
+
+    // Migrate + clear atomically so a row is never both queued and pending.
+    await prisma.$transaction([
+      prisma.artJob.create({
+        data: {
+          engine: 'A1111',
+          userId: p.userId ?? FALLBACK_USER_ID,
+          payload: {
+            promptString,
+            imagePath: p.imagePath ?? null,
+            migratedFromPromptId: p.id,
+            save: {
+              isPublic: p.isPublic,
+              isMature: p.isMature,
+              designer: null,
+            },
+          },
+        },
+      }),
+      prisma.prompt.update({
+        where: { id: p.id },
+        data: { artStatus: null },
+      }),
+    ])
+
+    migrated++
+  }
+
+  console.log(
+    `\nMigrated ${migrated} Prompt row(s) into ArtJob; cleared ${skipped} empty row(s).`,
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())


### PR DESCRIPTION
## Why

Art generation ran through **three overlapping mechanisms**: the legacy `Prompt.artStatus` queue ("art_prompts"), the synchronous `/api/art/generate` + `/api/comfy/*/generate` endpoints the Generate button called inline ("art generate"), and the durable `ArtJob` queue ("art jobs"). The synchronous paths break whenever the deployed backend can't reach the home GPU box. This makes **`ArtJob` the single source of truth** — the browser always enqueues a durable job and polls for completion.

## Server

- **New `/api/art/enqueue`** — the single browser surface: charges mana once, builds the correct `ArtJob` payload per engine (A1111 raw params; Comfy/flux/kontext prebuilt workflows) with a `save` block for ownership/visibility, then creates the job. Distinct from the low-level `/api/art/queue` producer surface (used by conductor scripts, no mana gate).
- **Extracted** the flux + sdxl Comfy workflow builders into shared utils (`server/api/comfy/{flux,sdxl}/utils/workflow.ts`) so the enqueue path and the direct render routes build identical graphs; repointed the `generate.post.ts` handlers at them (no behavior change).
- **Annotated** the synchronous render endpoints as direct/relay-only and marked `/api/prompts/generate` (the legacy `Prompt.artStatus` driver) deprecated.
- **Deprecated** the `Prompt` art-queue columns and the `ArtStatus` enum in `schema.prisma` (comment-only; column drop is a follow-up migration).

## Client

- `artStore.generateArt` now enqueues via `/api/art/enqueue`, polls `/api/art/queue/:id` (`queued → rendering`), then loads the finished `ArtImage`. **OpenAI stays synchronous** (backend reaches it directly, no relay). Adds `queueState`/`currentJobId` state; `generate-button.vue` reflects "Queued…/Rendering…". Removes the now-dead browser-render dispatch.

## Migration

- `npm run migrate:art-jobs` (`utils/scripts/migratePromptsToArtJobs.ts`): converts pending `Prompt` art-queue rows into `ArtJob` rows and clears the source. Dry-run by default; `--write` to apply.

## Behavior change

In-app generation is now **asynchronous** — the home relay must be running for images to land (the button sits at "Queued…" if it's offline and resumes when it returns).

## Verification

- `nuxi typecheck` passes clean (0 errors); new files pass prettier + eslint. Pre-existing lint/prettier debt in untouched files was left alone.
- The app can't be driven end-to-end without a DB/relay, so runtime confirmation of the enqueue→render loop is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014sBtYxdew9nvBzMaVFbnY2)_