### PR TITLE
Add Facet Library manager and art-facet linking

### DIFF
--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -471,6 +471,13 @@
                 </div>
               </div>
             </div>
+            <!-- Facets -->
+            <FacetPicker
+              v-model="artFacetIds"
+              owner-type="artImage"
+              :owner-id="currentArtImage?.id ?? null"
+              label="Facets"
+            />
             <!-- Remix -->
             <div class="rounded-2xl border border-primary/30 bg-primary/10 p-3">
               <div class="mb-2 flex items-center justify-between gap-2">
@@ -532,6 +539,7 @@ const collectionSearch = ref('')
 const statusMessage = ref('')
 const statusTone = ref<'success' | 'error'>('success')
 const remixPrompt = ref('')
+const artFacetIds = ref<number[]>([])
 const deleteArmed = ref(false)
 const isDeleting = ref(false)
 const isSettingAvatar = ref(false)

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -1,0 +1,420 @@
+<!-- /components/facets/facet-manager.vue -->
+<template>
+  <section class="mx-auto w-full max-w-6xl space-y-4 p-4">
+    <header
+      class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
+    >
+      <Icon name="kind-icon:tag" class="size-6 text-secondary" />
+      <div class="min-w-0 flex-1">
+        <h1 class="text-xl font-black">Facet Library</h1>
+        <p class="text-sm text-base-content/60">
+          The reusable flavor shared by Dreams, Scenarios, and Art. Aliases
+          resolve to one canonical Facet.
+        </p>
+      </div>
+      <span
+        v-if="facetStore.loading"
+        class="loading loading-spinner loading-sm"
+      />
+      <span class="badge badge-ghost">{{ filteredFacets.length }} shown</span>
+    </header>
+
+    <div class="flex flex-wrap items-center gap-2">
+      <input
+        v-model="search"
+        type="search"
+        class="input input-bordered input-sm w-full max-w-xs rounded-xl bg-base-200"
+        placeholder="Search title, slug, or alias..."
+      />
+      <div class="flex flex-wrap gap-1">
+        <button
+          type="button"
+          class="btn btn-xs rounded-xl"
+          :class="kindFilter === null ? 'btn-secondary' : 'btn-ghost'"
+          @click="kindFilter = null"
+        >
+          All
+        </button>
+        <button
+          v-for="kind in facetKinds"
+          :key="kind"
+          type="button"
+          class="btn btn-xs rounded-xl"
+          :class="kindFilter === kind ? 'btn-secondary' : 'btn-ghost'"
+          @click="kindFilter = kindFilter === kind ? null : kind"
+        >
+          {{ kindLabel(kind) }}
+          <span class="opacity-50">{{ kindCounts[kind] || 0 }}</span>
+        </button>
+      </div>
+      <label
+        class="ml-auto flex items-center gap-2 text-xs text-base-content/60"
+      >
+        <input
+          v-model="showArchived"
+          type="checkbox"
+          class="toggle toggle-secondary toggle-xs"
+        />
+        Show archived
+      </label>
+    </div>
+
+    <details
+      class="rounded-2xl border border-base-300 bg-base-100"
+      :open="createOpen"
+    >
+      <summary
+        class="cursor-pointer px-4 py-3 text-sm font-bold text-base-content/70"
+        @click.prevent="createOpen = !createOpen"
+      >
+        + Create a new Facet
+      </summary>
+      <div class="grid gap-2 border-t border-base-300 p-4 sm:grid-cols-2">
+        <input
+          v-model="newTitle"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="Canonical title, e.g. CowCore"
+        />
+        <select
+          v-model="newKind"
+          class="select select-bordered select-sm rounded-xl"
+        >
+          <option v-for="kind in facetKinds" :key="kind" :value="kind">
+            {{ kindLabel(kind) }}
+          </option>
+        </select>
+        <input
+          v-model="newAliases"
+          type="text"
+          class="input input-bordered input-sm rounded-xl sm:col-span-2"
+          placeholder="Aliases separated by commas, e.g. cow, cows"
+        />
+        <textarea
+          v-model="newDescription"
+          class="textarea textarea-bordered min-h-16 rounded-xl sm:col-span-2"
+          placeholder="What this facet means (optional)..."
+        />
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm rounded-xl sm:col-span-2"
+          :disabled="!newTitle.trim() || facetStore.saving"
+          @click="createFacet"
+        >
+          <span
+            v-if="facetStore.saving"
+            class="loading loading-spinner loading-xs"
+          />
+          <Icon v-else name="kind-icon:plus" class="size-3.5" />
+          Create Facet
+        </button>
+      </div>
+    </details>
+
+    <p v-if="errorMessage" class="text-sm text-error">{{ errorMessage }}</p>
+
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+      <article
+        v-for="facet in filteredFacets"
+        :key="facet.id"
+        class="rounded-2xl border bg-base-100 p-4 transition-all"
+        :class="[
+          facet.isActive ? 'border-base-300' : 'border-error/40 opacity-60',
+          editingId === facet.id ? 'ring-2 ring-secondary/60' : '',
+        ]"
+      >
+        <div class="flex items-start justify-between gap-2">
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="badge badge-outline badge-xs shrink-0">
+                {{ kindLabel(facet.kind) }}
+              </span>
+              <span v-if="!facet.isActive" class="badge badge-error badge-xs">
+                archived
+              </span>
+              <span v-if="!facet.isPublic" class="badge badge-ghost badge-xs">
+                private
+              </span>
+            </div>
+            <h2 class="mt-1 truncate text-base font-bold">{{ facet.title }}</h2>
+            <p class="truncate text-xs text-base-content/40">
+              {{ facet.aliases.join(' · ') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-xl"
+            @click="toggleEdit(facet)"
+          >
+            <Icon
+              :name="
+                editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'
+              "
+              class="size-4"
+            />
+          </button>
+        </div>
+
+        <p
+          v-if="facet.description && editingId !== facet.id"
+          class="mt-2 line-clamp-3 text-xs text-base-content/60"
+        >
+          {{ facet.description }}
+        </p>
+
+        <div v-if="editingId === facet.id" class="mt-3 space-y-2">
+          <input
+            v-model="editForm.title"
+            type="text"
+            class="input input-bordered input-sm w-full rounded-xl"
+            placeholder="Title"
+          />
+          <select
+            v-model="editForm.kind"
+            class="select select-bordered select-sm w-full rounded-xl"
+          >
+            <option v-for="kind in facetKinds" :key="kind" :value="kind">
+              {{ kindLabel(kind) }}
+            </option>
+          </select>
+          <input
+            v-model="editForm.aliases"
+            type="text"
+            class="input input-bordered input-sm w-full rounded-xl"
+            placeholder="Aliases, comma separated"
+          />
+          <textarea
+            v-model="editForm.description"
+            class="textarea textarea-bordered min-h-16 w-full rounded-xl"
+            placeholder="Description"
+          />
+          <div class="flex items-center gap-3 text-xs">
+            <label class="flex items-center gap-1">
+              <input
+                v-model="editForm.isPublic"
+                type="checkbox"
+                class="toggle toggle-secondary toggle-xs"
+              />
+              Public
+            </label>
+            <label class="flex items-center gap-1">
+              <input
+                v-model="editForm.isMature"
+                type="checkbox"
+                class="toggle toggle-warning toggle-xs"
+              />
+              Mature
+            </label>
+          </div>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="btn btn-secondary btn-sm flex-1 rounded-xl"
+              :disabled="!editForm.title.trim() || facetStore.saving"
+              @click="saveEdit(facet.id)"
+            >
+              <span
+                v-if="facetStore.saving"
+                class="loading loading-spinner loading-xs"
+              />
+              Save
+            </button>
+            <button
+              v-if="facet.isActive"
+              type="button"
+              class="btn btn-outline btn-error btn-sm rounded-xl"
+              :disabled="facetStore.saving"
+              @click="archive(facet.id)"
+            >
+              Archive
+            </button>
+            <button
+              v-else
+              type="button"
+              class="btn btn-outline btn-sm rounded-xl"
+              :disabled="facetStore.saving"
+              @click="restore(facet.id)"
+            >
+              Restore
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <p
+      v-if="!facetStore.loading && !filteredFacets.length"
+      class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50"
+    >
+      No facets match. Create one above to start the library.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import type { FacetKind } from '~/prisma/generated/prisma/client'
+import { useFacetStore, type FacetWithAliases } from '@/stores/facetStore'
+import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+
+const facetStore = useFacetStore()
+
+const search = ref('')
+const kindFilter = ref<FacetKind | null>(null)
+const showArchived = ref(false)
+const errorMessage = ref('')
+const editingId = ref<number | null>(null)
+const createOpen = ref(false)
+
+const newTitle = ref('')
+const newKind = ref<FacetKind>('OTHER')
+const newAliases = ref('')
+const newDescription = ref('')
+
+const editForm = reactive({
+  title: '',
+  kind: 'OTHER' as FacetKind,
+  aliases: '',
+  description: '',
+  isPublic: true,
+  isMature: false,
+})
+
+const facetKinds: FacetKind[] = [
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'OTHER',
+]
+
+const visibleFacets = computed(() =>
+  showArchived.value ? facetStore.facets : facetStore.activeFacets,
+)
+
+const kindCounts = computed(() => {
+  const counts: Partial<Record<FacetKind, number>> = {}
+  for (const facet of visibleFacets.value) {
+    counts[facet.kind] = (counts[facet.kind] || 0) + 1
+  }
+  return counts
+})
+
+const filteredFacets = computed(() => {
+  const needle = normalizeFacetLookupKey(search.value)
+  return visibleFacets.value.filter((facet) => {
+    if (kindFilter.value && facet.kind !== kindFilter.value) return false
+    if (!needle) return true
+    const values = [facet.title, facet.slug, ...facet.aliases]
+    return values.some((value) =>
+      normalizeFacetLookupKey(value || '').includes(needle),
+    )
+  })
+})
+
+onMounted(async () => {
+  try {
+    await facetStore.fetchFacets({ includeInactive: true })
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facets could not be loaded.'
+  }
+})
+
+function kindLabel(kind: FacetKind): string {
+  return kind
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function splitAliases(value: string): string[] {
+  return value
+    .split(',')
+    .map((alias) => alias.trim())
+    .filter(Boolean)
+}
+
+function toggleEdit(facet: FacetWithAliases) {
+  if (editingId.value === facet.id) {
+    editingId.value = null
+    return
+  }
+  editingId.value = facet.id
+  editForm.title = facet.title
+  editForm.kind = facet.kind
+  // The canonical slug leads the alias list; only the extra aliases are editable.
+  editForm.aliases = facet.aliases
+    .filter((alias) => alias !== facet.slug)
+    .join(', ')
+  editForm.description = facet.description || ''
+  editForm.isPublic = facet.isPublic
+  editForm.isMature = facet.isMature
+}
+
+async function createFacet() {
+  errorMessage.value = ''
+  try {
+    await facetStore.createFacet({
+      title: newTitle.value.trim(),
+      kind: newKind.value,
+      aliases: splitAliases(newAliases.value),
+      description: newDescription.value.trim() || null,
+      isPublic: true,
+    })
+    newTitle.value = ''
+    newAliases.value = ''
+    newDescription.value = ''
+    newKind.value = 'OTHER'
+    createOpen.value = false
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facet could not be created.'
+  }
+}
+
+async function saveEdit(id: number) {
+  errorMessage.value = ''
+  try {
+    await facetStore.updateFacet(id, {
+      title: editForm.title.trim(),
+      kind: editForm.kind,
+      aliases: splitAliases(editForm.aliases),
+      description: editForm.description.trim() || null,
+      isPublic: editForm.isPublic,
+      isMature: editForm.isMature,
+    })
+    editingId.value = null
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facet could not be saved.'
+  }
+}
+
+async function archive(id: number) {
+  errorMessage.value = ''
+  try {
+    await facetStore.archiveFacet(id)
+    editingId.value = null
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facet could not be archived.'
+  }
+}
+
+async function restore(id: number) {
+  errorMessage.value = ''
+  try {
+    await facetStore.updateFacet(id, { isActive: true })
+    editingId.value = null
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facet could not be restored.'
+  }
+}
+</script>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -6,12 +6,17 @@
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-bold">{{ label }}</h3>
         <p class="text-xs text-base-content/50">
-          Reusable flavor shared by Dreams and Scenarios. Aliases resolve to one
-          canonical Facet.
+          Reusable flavor shared by Dreams, Scenarios, and Art. Aliases resolve
+          to one canonical Facet.
         </p>
       </div>
-      <span v-if="saving || loadingAssignments" class="loading loading-spinner loading-xs" />
-      <span class="badge badge-ghost badge-sm">{{ selectedFacets.length }}</span>
+      <span
+        v-if="saving || loadingAssignments"
+        class="loading loading-spinner loading-xs"
+      />
+      <span class="badge badge-ghost badge-sm">{{
+        selectedFacets.length
+      }}</span>
     </div>
 
     <div v-if="selectedFacets.length" class="flex flex-wrap gap-2">
@@ -50,9 +55,13 @@
           :disabled="selectedIds.has(facet.id) || saving"
           @click="addFacet(facet.id)"
         >
-          <span class="badge badge-outline badge-xs shrink-0">{{ kindLabel(facet.kind) }}</span>
+          <span class="badge badge-outline badge-xs shrink-0">{{
+            kindLabel(facet.kind)
+          }}</span>
           <span class="min-w-0 flex-1">
-            <span class="block truncate text-sm font-semibold">{{ facet.title }}</span>
+            <span class="block truncate text-sm font-semibold">{{
+              facet.title
+            }}</span>
             <span class="block truncate text-xs text-base-content/40">
               {{ facet.aliases.join(' · ') }}
             </span>
@@ -60,14 +69,19 @@
           <Icon name="kind-icon:plus" class="size-3.5 shrink-0" />
         </button>
 
-        <p v-if="!searchResults.length" class="px-3 py-3 text-xs text-base-content/40">
+        <p
+          v-if="!searchResults.length"
+          class="px-3 py-3 text-xs text-base-content/40"
+        >
           No matching Facet. Create one below.
         </p>
       </div>
     </div>
 
     <details class="rounded-xl border border-base-300 bg-base-200/60">
-      <summary class="cursor-pointer px-3 py-2 text-xs font-bold text-base-content/60">
+      <summary
+        class="cursor-pointer px-3 py-2 text-xs font-bold text-base-content/60"
+      >
         Create a new Facet
       </summary>
       <div class="grid gap-2 border-t border-base-300 p-3 sm:grid-cols-2">
@@ -77,7 +91,10 @@
           class="input input-bordered input-sm rounded-xl"
           placeholder="Canonical title, e.g. CowCore"
         />
-        <select v-model="newKind" class="select select-bordered select-sm rounded-xl">
+        <select
+          v-model="newKind"
+          class="select select-bordered select-sm rounded-xl"
+        >
           <option v-for="kind in facetKinds" :key="kind" :value="kind">
             {{ kindLabel(kind) }}
           </option>
@@ -94,7 +111,10 @@
           :disabled="!newTitle.trim() || facetStore.saving"
           @click="createAndAddFacet"
         >
-          <span v-if="facetStore.saving" class="loading loading-spinner loading-xs" />
+          <span
+            v-if="facetStore.saving"
+            class="loading loading-spinner loading-xs"
+          />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create and attach
         </button>
@@ -110,6 +130,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import type { FacetKind } from '~/prisma/generated/prisma/client'
 import {
   useFacetStore,
+  type FacetOwnerType,
   type FacetWithAliases,
 } from '@/stores/facetStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
@@ -117,7 +138,7 @@ import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 const props = withDefaults(
   defineProps<{
     modelValue: number[]
-    ownerType: 'dream' | 'scenario'
+    ownerType: FacetOwnerType
     ownerId?: number | null
     label?: string
   }>(),
@@ -191,10 +212,7 @@ watch(
     loadingAssignments.value = true
     errorMessage.value = ''
     try {
-      const facets =
-        ownerType === 'dream'
-          ? await facetStore.fetchDreamFacets(ownerId)
-          : await facetStore.fetchScenarioFacets(ownerId)
+      const facets = await facetStore.fetchOwnerFacets(ownerType, ownerId)
       emit(
         'update:modelValue',
         facets.map((facet) => facet.id),
@@ -228,11 +246,7 @@ async function persist(next: number[]) {
 
   errorMessage.value = ''
   try {
-    if (props.ownerType === 'dream') {
-      await facetStore.setDreamFacets(props.ownerId, next)
-    } else {
-      await facetStore.setScenarioFacets(props.ownerId, next)
-    }
+    await facetStore.setOwnerFacets(props.ownerType, props.ownerId, next)
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : 'Facets could not be saved.'

--- a/content/facets.md
+++ b/content/facets.md
@@ -1,0 +1,16 @@
+---
+title: Facets
+room: 'Facet Library'
+subtitle: The reusable flavor of the ecosystem
+description: Browse and refine the genres, animals, colors, themes, moods, styles, and settings that Dreams, Scenarios, and Art share.
+image: nav/heroes/facets.webp
+icon: kind-icon:tag
+tooltip: Manage the reusable creative building blocks shared across the site.
+sort: utility
+dashboardKey: facets
+dashboardTab: library
+loadingMessage: Loading facets...
+refreshLabel: Refresh Facets
+---
+
+:facet-manager

--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -13,6 +13,7 @@ describe('Dream and Scenario Facet assignments', () => {
   let facetId = 0
   let dreamId = 0
   let scenarioId = 0
+  let artImageId = 0
 
   before(() => {
     createLoggedInTestUser().then((auth) => {
@@ -197,6 +198,54 @@ describe('Dream and Scenario Facet assignments', () => {
     })
   })
 
+  it('assigns the Facet to an ArtImage and reads it back', () => {
+    cy.request({
+      method: 'POST',
+      url: `${apiBase}/art/image`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        promptString: `facet assignment fixture ${stamp}`,
+        path: ' ',
+        imagePath: 'justfortesting',
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201)
+      artImageId = response.body.data.id
+
+      cy.request({
+        method: 'PUT',
+        url: `${apiBase}/art/image/${artImageId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { facetIds: [facetId] },
+      }).then((putResponse) => {
+        expect(putResponse.status).to.eq(200)
+        expect(putResponse.body.success).to.be.true
+        expect(putResponse.body.data).to.have.length(1)
+        expect(putResponse.body.data[0].id).to.eq(facetId)
+      })
+
+      cy.request({
+        url: `${apiBase}/art/image/${artImageId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((getResponse) => {
+        expect(getResponse.status).to.eq(200)
+        expect(getResponse.body.data).to.have.length(1)
+        expect(getResponse.body.data[0].id).to.eq(facetId)
+      })
+
+      // Exact-set semantics: an empty set clears the link.
+      cy.request({
+        method: 'PUT',
+        url: `${apiBase}/art/image/${artImageId}/facets`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { facetIds: [] },
+      }).then((clearResponse) => {
+        expect(clearResponse.status).to.eq(200)
+        expect(clearResponse.body.data).to.deep.eq([])
+      })
+    })
+  })
+
   it('updates the Facet in place and keeps alias resolution consistent', () => {
     const bovineAlias = `bovine-${stamp}`
 
@@ -252,6 +301,15 @@ describe('Dream and Scenario Facet assignments', () => {
       cy.request({
         method: 'DELETE',
         url: `${apiBase}/scenarios/${scenarioId}`,
+        headers: { Authorization: `Bearer ${token}` },
+        failOnStatusCode: false,
+      })
+    }
+
+    if (artImageId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${apiBase}/art/image/${artImageId}`,
         headers: { Authorization: `Bearer ${token}` },
         failOnStatusCode: false,
       })

--- a/server/api/art/image/[id]/facets.get.ts
+++ b/server/api/art/image/[id]/facets.get.ts
@@ -1,0 +1,54 @@
+// GET /api/art/image/:id/facets
+import { createError, defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { getOptionalApiUser } from '~/server/utils/authGuard'
+import { loadFacetSummaries } from '~/server/utils/facetAssignments'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid ArtImage ID.' })
+    }
+
+    const [image, auth] = await Promise.all([
+      prisma.artImage.findUnique({
+        where: { id },
+        select: { id: true, userId: true, isPublic: true, isMature: true },
+      }),
+      getOptionalApiUser(event),
+    ])
+
+    if (!image) {
+      throw createError({ statusCode: 404, message: 'ArtImage not found.' })
+    }
+
+    const isOwner = Boolean(auth?.user.id) && image.userId === auth?.user.id
+    const canView =
+      auth?.isAdmin || isOwner || (image.isPublic && !image.isMature)
+
+    if (!canView) {
+      throw createError({
+        statusCode: auth ? 403 : 404,
+        message: auth
+          ? 'You do not have permission to view this ArtImage.'
+          : 'ArtImage not found.',
+      })
+    }
+
+    const links = await prisma.facetArtImage.findMany({
+      where: { artImageId: id },
+      select: { facetId: true },
+    })
+
+    return {
+      success: true,
+      data: await loadFacetSummaries(links.map((link) => link.facetId)),
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/art/image/[id]/facets.put.ts
+++ b/server/api/art/image/[id]/facets.put.ts
@@ -1,0 +1,70 @@
+// PUT /api/art/image/:id/facets
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import {
+  parseFacetSelectionBody,
+  resolveFacetSelection,
+} from '~/server/utils/facetAssignments'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid ArtImage ID.' })
+    }
+
+    // Machine auth (JWT / user apiKey / beta-admin) for parity with the rest
+    // of the art API — automation that can PATCH an image can also facet it.
+    const auth = await requireMachineUser(event)
+    const image = await prisma.artImage.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    })
+
+    if (!image) {
+      throw createError({ statusCode: 404, message: 'ArtImage not found.' })
+    }
+
+    if (!auth.isAdmin && image.userId !== auth.user.id) {
+      throw createError({
+        statusCode: 403,
+        message: 'You do not have permission to edit this ArtImage.',
+      })
+    }
+
+    const selection = parseFacetSelectionBody(await readBody(event))
+    const facets = await resolveFacetSelection({
+      ...selection,
+      userId: auth.user.id,
+      isAdmin: auth.isAdmin,
+    })
+    const facetIds = facets.map((facet) => facet.id)
+
+    await prisma.$transaction(async (tx) => {
+      await tx.facetArtImage.deleteMany({
+        where: facetIds.length
+          ? { artImageId: id, facetId: { notIn: facetIds } }
+          : { artImageId: id },
+      })
+
+      if (facetIds.length) {
+        await tx.facetArtImage.createMany({
+          data: facetIds.map((facetId) => ({ artImageId: id, facetId })),
+          skipDuplicates: true,
+        })
+      }
+    })
+
+    return {
+      success: true,
+      message: 'ArtImage Facets updated.',
+      data: facets,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/facets/[id].patch.ts
+++ b/server/api/facets/[id].patch.ts
@@ -130,6 +130,15 @@ export default defineEventHandler(async (event) => {
       body.aliases !== undefined ? normalizeAliases(body.aliases) : null
 
     const updated = await prisma.$transaction(async (tx) => {
+      // Restoring an archived Facet must also revive its aliases — archive
+      // (DELETE) deactivates them all, which would leave lookups dead.
+      if (body.isActive === true) {
+        await tx.facetAlias.updateMany({
+          where: { facetId: id },
+          data: { isActive: true },
+        })
+      }
+
       if (nextSlug && nextSlug !== existing.slug) {
         const lookupKey = normalizeFacetLookupKey(nextSlug)
         const taken = await tx.facetAlias.findUnique({

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -50,6 +50,8 @@ export type FacetUpdateInput = Partial<FacetCreateInput> & {
   isActive?: boolean
 }
 
+export type FacetOwnerType = 'dream' | 'scenario' | 'artImage'
+
 function toQuery(options: FacetListOptions): string {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(options)) {
@@ -68,6 +70,7 @@ export const useFacetStore = defineStore('facetStore', () => {
   const error = ref<string | null>(null)
   const dreamFacetIds = ref<Record<number, number[]>>({})
   const scenarioFacetIds = ref<Record<number, number[]>>({})
+  const artImageFacetIds = ref<Record<number, number[]>>({})
 
   const activeFacets = computed(() =>
     facets.value.filter((facet) => facet.isActive),
@@ -208,12 +211,24 @@ export const useFacetStore = defineStore('facetStore', () => {
     }
   }
 
+  const ownerFacetEndpoints: Record<FacetOwnerType, (id: number) => string> = {
+    dream: (id) => `/api/dreams/${id}/facets`,
+    scenario: (id) => `/api/scenarios/${id}/facets`,
+    artImage: (id) => `/api/art/image/${id}/facets`,
+  }
+
+  function ownerFacetIndex(ownerType: FacetOwnerType) {
+    if (ownerType === 'dream') return dreamFacetIds
+    if (ownerType === 'scenario') return scenarioFacetIds
+    return artImageFacetIds
+  }
+
   async function fetchOwnerFacets(
-    ownerType: 'dream' | 'scenario',
+    ownerType: FacetOwnerType,
     ownerId: number,
   ): Promise<FacetWithAliases[]> {
     const response = await performFetch<FacetWithAliases[]>(
-      `/api/${ownerType === 'dream' ? 'dreams' : 'scenarios'}/${ownerId}/facets`,
+      ownerFacetEndpoints[ownerType](ownerId),
     )
     if (!response.success) {
       throw new Error(response.message || 'Failed to fetch assigned Facets.')
@@ -221,14 +236,14 @@ export const useFacetStore = defineStore('facetStore', () => {
 
     const assigned = response.data ?? []
     for (const facet of assigned) upsertFacet(facet)
-    const ids = assigned.map((facet) => facet.id)
-    if (ownerType === 'dream') dreamFacetIds.value[ownerId] = ids
-    else scenarioFacetIds.value[ownerId] = ids
+    ownerFacetIndex(ownerType).value[ownerId] = assigned.map(
+      (facet) => facet.id,
+    )
     return assigned
   }
 
   async function setOwnerFacets(
-    ownerType: 'dream' | 'scenario',
+    ownerType: FacetOwnerType,
     ownerId: number,
     facetIds: number[],
   ): Promise<FacetWithAliases[]> {
@@ -236,7 +251,7 @@ export const useFacetStore = defineStore('facetStore', () => {
     error.value = null
     try {
       const response = await performFetch<FacetWithAliases[]>(
-        `/api/${ownerType === 'dream' ? 'dreams' : 'scenarios'}/${ownerId}/facets`,
+        ownerFacetEndpoints[ownerType](ownerId),
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
@@ -249,9 +264,9 @@ export const useFacetStore = defineStore('facetStore', () => {
 
       const assigned = response.data ?? []
       for (const facet of assigned) upsertFacet(facet)
-      const ids = assigned.map((facet) => facet.id)
-      if (ownerType === 'dream') dreamFacetIds.value[ownerId] = ids
-      else scenarioFacetIds.value[ownerId] = ids
+      ownerFacetIndex(ownerType).value[ownerId] = assigned.map(
+        (facet) => facet.id,
+      )
       return assigned
     } catch (cause) {
       error.value = cause instanceof Error ? cause.message : String(cause)
@@ -277,6 +292,14 @@ export const useFacetStore = defineStore('facetStore', () => {
     return setOwnerFacets('scenario', scenarioId, facetIds)
   }
 
+  function fetchArtImageFacets(artImageId: number) {
+    return fetchOwnerFacets('artImage', artImageId)
+  }
+
+  function setArtImageFacets(artImageId: number, facetIds: number[]) {
+    return setOwnerFacets('artImage', artImageId, facetIds)
+  }
+
   return {
     facets,
     loading,
@@ -285,6 +308,7 @@ export const useFacetStore = defineStore('facetStore', () => {
     error,
     dreamFacetIds,
     scenarioFacetIds,
+    artImageFacetIds,
     activeFacets,
     facetsByLookupKey,
     facetForKey,
@@ -293,9 +317,13 @@ export const useFacetStore = defineStore('facetStore', () => {
     createFacet,
     updateFacet,
     archiveFacet,
+    fetchOwnerFacets,
+    setOwnerFacets,
     fetchDreamFacets,
     setDreamFacets,
     fetchScenarioFacets,
     setScenarioFacets,
+    fetchArtImageFacets,
+    setArtImageFacets,
   }
 })

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -523,6 +523,26 @@ export const dashboardConfigs = {
     ],
   },
 
+  facets: {
+    key: 'facets',
+    label: 'Facets',
+    defaultTab: 'library',
+    tabs: [
+      {
+        key: 'library',
+        label: 'Library',
+        icon: 'kind-icon:tag',
+        title: 'Facet Library',
+        summary:
+          'Browse, edit, and organize the reusable flavor of the ecosystem.',
+        image: tabImage('facets', 'library'),
+        narrative:
+          'Facets are the small reusable building blocks — genres, animals, colors, themes, cores, moods, styles, settings, and art direction — that Dreams, Scenarios, and Art share. Browse the library, refine titles and aliases, and keep the flavor vocabulary tidy.',
+        route: '/facets',
+      },
+    ],
+  },
+
   footer: {
     key: 'footer',
     label: 'Footer',


### PR DESCRIPTION
### Task
Build out the Facet surface — the remaining coverage gap called out as the kaizen on #183 (no standalone Facet management UI; art editors not facet-wired).

### What changed
**Art ↔ Facet linking (new backend + wiring)**
- `GET`/`PUT /api/art/image/[id]/facets` backed by the previously unused `FacetArtImage` join table, mirroring the dream/scenario assignment routes. PUT uses machine auth (JWT / user apiKey / beta-admin) for parity with the rest of the art API; exact-set semantics (empty array clears).
- `facetStore`: refactored the two owner ternaries into a generic `fetchOwnerFacets`/`setOwnerFacets` + endpoint map, added an `artImage` owner type and `artImageFacetIds` index. `FacetPicker` now accepts any `FacetOwnerType` (no more hardcoded dream/scenario switches) and is embedded in `art-interact.vue`'s edit panel alongside Collections and Remix.

**Facet Library (new management surface)**
- `components/facets/facet-manager.vue`: search, kind filters with live counts, create, inline edit (title / kind / aliases / description / public / mature), archive, and restore.
- `content/facets.md` (`:facet-manager`) + a `facets` block in `dashboardConfigs` register it as its own room at `/facets`, following the same MDC + dashboard-registry convention as the other manager surfaces.

**Fix surfaced while building**
- `PATCH /api/facets/[id]` now reactivates a facet's aliases when `isActive: true` is set — archive (DELETE) deactivates all aliases, so a restore without this left the facet's lookups dead.

### How I verified
- Full `vue-tsc` typecheck (`npm run test`): clean, exit 0.
- `eslint` on all changed files: clean.
- Prettier applied.
- Cypress: added art-image facet assignment coverage (assign → read back → clear) to the `facet-assignments` spec; runs against prod in CI like the sibling cases.

### Stakes
reversible

### Flags for Reviewer
- The `facets` dashboard tab references `public/images/dashboard-tabs/facets/library.webp` and `public/images/nav/heroes/facets.webp`, which don't exist yet — both fall back to the existing coming-soon/placeholder handling, same as any new room before its art lands. An ART-PROMPTS entry for facet room art would be a natural follow-up.
- `facet-manager` calls `fetchFacets({ includeInactive: true })`; that flag is admin-gated server-side, so non-admins simply get active facets and the "Show archived" toggle is a no-op for them. Fine for now (management is an admin-ish surface); a role gate on the tab could be added if you want it hidden entirely.

### Kaizen suggestion
Generate the facet room art (nav hero + library tab) via the art pipeline, and consider a compact facet chip display on `image-card.vue` so facets show on gallery cards, not just in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMDJqoU9grXmbuwXa8mzVv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMDJqoU9grXmbuwXa8mzVv)_