### PR TITLE
Model Builder: durable run persistence (schema + APIs + store)

### DIFF
--- a/prisma/migrations/20260712120000_add_model_builder_tables/migration.sql
+++ b/prisma/migrations/20260712120000_add_model_builder_tables/migration.sql
@@ -1,0 +1,110 @@
+-- Model Builder durable orchestration tables.
+--
+-- Additive only: four new CREATE TABLEs plus the internal run -> item ->
+-- artifact/revision foreign keys (cascade on delete). No existing table is
+-- altered or dropped. External references (userId, sourceId, artImageId,
+-- targetId) are plain scalar columns with no foreign key — ownership is
+-- enforced in the API layer — so these tables stay self-contained.
+
+-- CreateTable
+CREATE TABLE `ModelBuildRun` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `status` ENUM('DRAFT', 'ACTIVE', 'COMPLETED', 'CANCELLED') NOT NULL DEFAULT 'DRAFT',
+    `userId` INTEGER NULL DEFAULT 10,
+    `sourceType` VARCHAR(64) NOT NULL,
+    `sourceId` INTEGER NOT NULL,
+    `sourceLabel` VARCHAR(255) NULL,
+    `sourceSnapshot` JSON NULL,
+    `recipeKey` VARCHAR(64) NOT NULL,
+    `recipeVersion` VARCHAR(32) NULL,
+    `selections` JSON NULL,
+    `usageInfo` JSON NULL,
+    `cancelledAt` DATETIME(3) NULL,
+
+    INDEX `ModelBuildRun_userId_idx`(`userId`),
+    INDEX `ModelBuildRun_status_idx`(`status`),
+    INDEX `ModelBuildRun_sourceType_sourceId_idx`(`sourceType`, `sourceId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ModelBuildItem` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `runId` INTEGER NOT NULL,
+    `outputKey` VARCHAR(64) NOT NULL,
+    `label` VARCHAR(255) NULL,
+    `action` ENUM('CREATE', 'UPDATE', 'ASSET_ONLY') NOT NULL DEFAULT 'ASSET_ONLY',
+    `generation` VARCHAR(32) NOT NULL,
+    `quantityIndex` INTEGER NOT NULL DEFAULT 0,
+    `targetType` VARCHAR(64) NULL,
+    `targetId` INTEGER NULL,
+    `stageStatuses` JSON NOT NULL,
+    `pitch` TEXT NULL,
+    `fieldsDraft` TEXT NULL,
+    `promptDraft` TEXT NULL,
+    `relationshipDraft` JSON NULL,
+    `staleReason` VARCHAR(255) NULL,
+    `error` TEXT NULL,
+    `idempotencyKey` VARCHAR(191) NULL,
+    `artImageId` INTEGER NULL,
+
+    UNIQUE INDEX `ModelBuildItem_idempotencyKey_key`(`idempotencyKey`),
+    INDEX `ModelBuildItem_runId_idx`(`runId`),
+    INDEX `ModelBuildItem_targetType_targetId_idx`(`targetType`, `targetId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ModelBuildArtifact` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `itemId` INTEGER NOT NULL,
+    `kind` VARCHAR(64) NOT NULL,
+    `provider` VARCHAR(64) NULL,
+    `model` VARCHAR(191) NULL,
+    `seed` VARCHAR(64) NULL,
+    `prompt` TEXT NULL,
+    `negativePrompt` TEXT NULL,
+    `width` INTEGER NULL,
+    `height` INTEGER NULL,
+    `workflow` JSON NULL,
+    `format` VARCHAR(32) NULL,
+    `artImageId` INTEGER NULL,
+    `draftPath` TEXT NULL,
+    `promotedPath` TEXT NULL,
+    `reviewState` ENUM('PENDING', 'APPROVED', 'REJECTED') NOT NULL DEFAULT 'PENDING',
+    `usageInfo` JSON NULL,
+
+    INDEX `ModelBuildArtifact_itemId_idx`(`itemId`),
+    INDEX `ModelBuildArtifact_reviewState_idx`(`reviewState`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ModelBuildRevision` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `itemId` INTEGER NOT NULL,
+    `stage` VARCHAR(48) NOT NULL,
+    `previousPayload` JSON NULL,
+    `nextPayload` JSON NULL,
+    `actor` VARCHAR(191) NULL,
+    `reason` VARCHAR(255) NULL,
+
+    INDEX `ModelBuildRevision_itemId_idx`(`itemId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `ModelBuildItem` ADD CONSTRAINT `ModelBuildItem_runId_fkey` FOREIGN KEY (`runId`) REFERENCES `ModelBuildRun`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ModelBuildArtifact` ADD CONSTRAINT `ModelBuildArtifact_itemId_fkey` FOREIGN KEY (`itemId`) REFERENCES `ModelBuildItem`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ModelBuildRevision` ADD CONSTRAINT `ModelBuildRevision_itemId_fkey` FOREIGN KEY (`itemId`) REFERENCES `ModelBuildItem`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/model-builder.prisma
+++ b/prisma/model-builder.prisma
@@ -1,0 +1,157 @@
+// Model Builder — durable orchestration tables.
+//
+// A resumable, human-gated recipe run over an existing Kind Robots record. The
+// run holds a snapshot of its source and a set of build items; each item walks
+// the four gates (PITCH, FIELDS_AND_PROMPTS, GENERATE_ASSETS, COMMIT) and
+// carries its own artifacts and revision history. These tables ORCHESTRATE work
+// — they never replace the canonical domain models.
+//
+// External references (userId, sourceId, artImageId, targetId) are stored as
+// plain scalar Int columns rather than Prisma relations, so these tables stay
+// self-contained and additive (no reverse-relation edits to User/ArtImage). The
+// only foreign keys are the internal run -> item -> artifact/revision chain,
+// which cascades on delete. Ownership is enforced in the API layer via userId.
+
+enum ModelBuildStatus {
+  DRAFT
+  ACTIVE
+  COMPLETED
+  CANCELLED
+}
+
+enum ModelBuildAction {
+  CREATE
+  UPDATE
+  ASSET_ONLY
+}
+
+enum ModelBuildReviewState {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+/// One resumable Model Builder run: a source record, a chosen recipe, and the
+/// build items produced from the selected outputs. `sourceSnapshot` freezes the
+/// source at run start so later drift is detectable; `selections`/`usage` are
+/// free-form JSON. `sourceType`/`recipeKey` are catalog keys (VarChar, not
+/// enums) so evolving the front-end recipe catalog needs no migration.
+model ModelBuildRun {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @default(now()) @updatedAt
+
+  status ModelBuildStatus @default(DRAFT)
+
+  userId Int? @default(10)
+
+  sourceType     String  @db.VarChar(64)
+  sourceId       Int
+  sourceLabel    String? @db.VarChar(255)
+  sourceSnapshot Json?
+
+  recipeKey     String  @db.VarChar(64)
+  recipeVersion String? @db.VarChar(32)
+  selections    Json?
+  usageInfo     Json?
+
+  cancelledAt DateTime?
+
+  Items ModelBuildItem[]
+
+  @@index([userId])
+  @@index([status])
+  @@index([sourceType, sourceId])
+}
+
+/// One requested output within a run. `stageStatuses` is the four-gate map
+/// ({ PITCH: { status, note }, ... }); `pitch`/`fieldsDraft`/`promptDraft` are
+/// the editable drafts; `targetType`/`targetId` point at a durable target row
+/// for CREATE/UPDATE actions (draft-early or final). `idempotencyKey` guards the
+/// eventual final commit against duplicate writes.
+model ModelBuildItem {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @default(now()) @updatedAt
+
+  runId Int
+  Run   ModelBuildRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  outputKey     String           @db.VarChar(64)
+  label         String?          @db.VarChar(255)
+  action        ModelBuildAction @default(ASSET_ONLY)
+  generation    String           @db.VarChar(32)
+  quantityIndex Int              @default(0)
+
+  targetType String? @db.VarChar(64)
+  targetId   Int?
+
+  stageStatuses     Json
+  pitch             String? @db.Text
+  fieldsDraft       String? @db.Text
+  promptDraft       String? @db.Text
+  relationshipDraft Json?
+
+  staleReason    String? @db.VarChar(255)
+  error          String? @db.Text
+  idempotencyKey String? @unique @db.VarChar(191)
+
+  artImageId Int?
+
+  Artifacts ModelBuildArtifact[]
+  Revisions ModelBuildRevision[]
+
+  @@index([runId])
+  @@index([targetType, targetId])
+}
+
+/// A generated or assembled output for an item, with provenance. Draft outputs
+/// live at `draftPath`; canonical promotion (a later gated step) sets
+/// `promotedPath` and `reviewState`. `artImageId` links a persisted ArtImage.
+model ModelBuildArtifact {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @default(now()) @updatedAt
+
+  itemId Int
+  Item   ModelBuildItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+
+  kind           String  @db.VarChar(64)
+  provider       String? @db.VarChar(64)
+  model          String? @db.VarChar(191)
+  seed           String? @db.VarChar(64)
+  prompt         String? @db.Text
+  negativePrompt String? @db.Text
+  width          Int?
+  height         Int?
+  workflow       Json?
+  format         String? @db.VarChar(32)
+
+  artImageId   Int?
+  draftPath    String? @db.Text
+  promotedPath String? @db.Text
+
+  reviewState ModelBuildReviewState @default(PENDING)
+  usageInfo   Json?
+
+  @@index([itemId])
+  @@index([reviewState])
+}
+
+/// Append-only revision history for an item stage. Editing an upstream stage
+/// records the previous and next payloads so nothing is silently lost.
+model ModelBuildRevision {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+
+  itemId Int
+  Item   ModelBuildItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+
+  stage           String  @db.VarChar(48)
+  previousPayload Json?
+  nextPayload     Json?
+  actor           String? @db.VarChar(191)
+  reason          String? @db.VarChar(255)
+
+  @@index([itemId])
+}

--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -1,0 +1,141 @@
+// /server/api/model-builder/items/[id].patch.ts
+import { defineEventHandler, readBody } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  assertRunAccess,
+  getItemId,
+  normalizeJson,
+  normalizeNullableId,
+  normalizeText,
+} from '../runs/index'
+
+const itemInclude = {
+  Artifacts: { orderBy: { id: 'asc' } },
+  Revisions: { orderBy: { id: 'asc' } },
+} satisfies Prisma.ModelBuildItemInclude
+
+type ItemPatchBody = {
+  stageStatuses?: unknown
+  pitch?: unknown
+  fieldsDraft?: unknown
+  promptDraft?: unknown
+  relationshipDraft?: unknown
+  staleReason?: unknown
+  error?: unknown
+  artImageId?: unknown
+  targetType?: unknown
+  targetId?: unknown
+  // Revision metadata (optional):
+  stage?: unknown
+  reason?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getItemId(event)
+    const auth = await requireApiUser(event)
+
+    const existing = await prisma.modelBuildItem.findUnique({
+      where: { id },
+      include: { Run: { select: { userId: true } } },
+    })
+    if (!existing) {
+      event.node.res.statusCode = 404
+      return {
+        success: false,
+        message: 'Build item not found.',
+        statusCode: 404,
+      }
+    }
+    assertRunAccess(existing.Run, auth.user)
+
+    const body = await readBody<ItemPatchBody>(event)
+    const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
+
+    if (body.stageStatuses !== undefined && typeof body.stageStatuses === 'object' && body.stageStatuses !== null) {
+      data.stageStatuses = body.stageStatuses as Prisma.InputJsonValue
+    }
+    if (body.pitch !== undefined) data.pitch = normalizeText(body.pitch)
+    if (body.fieldsDraft !== undefined)
+      data.fieldsDraft = normalizeText(body.fieldsDraft)
+    if (body.promptDraft !== undefined)
+      data.promptDraft = normalizeText(body.promptDraft)
+    const relationshipDraft = normalizeJson(body.relationshipDraft)
+    if (relationshipDraft !== undefined)
+      data.relationshipDraft = relationshipDraft
+    if (body.staleReason !== undefined)
+      data.staleReason = normalizeText(body.staleReason)
+    if (body.error !== undefined) data.error = normalizeText(body.error)
+    if (body.artImageId !== undefined)
+      data.artImageId = normalizeNullableId(body.artImageId)
+    if (body.targetType !== undefined)
+      data.targetType = normalizeText(body.targetType)
+    if (body.targetId !== undefined)
+      data.targetId = normalizeNullableId(body.targetId)
+
+    // Record a revision whenever editable draft content changes, so upstream
+    // edits are never silently lost. Stage-status transitions (approve/reject/
+    // stale) are frequent and not themselves revisions.
+    const contentChanged =
+      body.pitch !== undefined ||
+      body.fieldsDraft !== undefined ||
+      body.promptDraft !== undefined ||
+      body.relationshipDraft !== undefined
+
+    const stageLabel =
+      typeof body.stage === 'string' ? body.stage.slice(0, 48) : 'EDIT'
+    const reason =
+      typeof body.reason === 'string' ? body.reason.slice(0, 255) : null
+
+    const previousPayload = {
+      pitch: existing.pitch,
+      fieldsDraft: existing.fieldsDraft,
+      promptDraft: existing.promptDraft,
+      stageStatuses: existing.stageStatuses,
+      relationshipDraft: existing.relationshipDraft,
+    } as unknown as Prisma.InputJsonValue
+    const nextPayload = {
+      pitch: data.pitch ?? existing.pitch,
+      fieldsDraft: data.fieldsDraft ?? existing.fieldsDraft,
+      promptDraft: data.promptDraft ?? existing.promptDraft,
+      stageStatuses: data.stageStatuses ?? existing.stageStatuses,
+      relationshipDraft: data.relationshipDraft ?? existing.relationshipDraft,
+    } as unknown as Prisma.InputJsonValue
+
+    const item = await prisma.$transaction(async (tx) => {
+      if (contentChanged) {
+        await tx.modelBuildRevision.create({
+          data: {
+            itemId: id,
+            stage: stageLabel,
+            reason,
+            actor: auth.user.username ?? String(auth.user.id),
+            previousPayload,
+            nextPayload,
+          },
+        })
+      }
+      return tx.modelBuildItem.update({
+        where: { id },
+        data,
+        include: itemInclude,
+      })
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Build item updated successfully.',
+      data: item,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/items/[id]/artifacts.post.ts
+++ b/server/api/model-builder/items/[id]/artifacts.post.ts
@@ -1,0 +1,112 @@
+// /server/api/model-builder/items/[id]/artifacts.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import type { ModelBuildReviewState } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { assertRunAccess, getItemId, normalizeNullableId } from '../../runs/index'
+
+const reviewStates = new Set<ModelBuildReviewState>([
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+])
+
+type ArtifactBody = {
+  kind?: unknown
+  provider?: unknown
+  model?: unknown
+  seed?: unknown
+  prompt?: unknown
+  negativePrompt?: unknown
+  width?: unknown
+  height?: unknown
+  workflow?: unknown
+  format?: unknown
+  artImageId?: unknown
+  draftPath?: unknown
+  promotedPath?: unknown
+  reviewState?: unknown
+  usageInfo?: unknown
+}
+
+function str(value: unknown, max: number): string | null {
+  return typeof value === 'string' ? value.slice(0, max) : null
+}
+
+function int(value: unknown): number | null {
+  const n = Number(value)
+  return Number.isInteger(n) ? n : null
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const itemId = getItemId(event)
+    const auth = await requireApiUser(event)
+
+    const item = await prisma.modelBuildItem.findUnique({
+      where: { id: itemId },
+      include: { Run: { select: { userId: true } } },
+    })
+    if (!item) {
+      event.node.res.statusCode = 404
+      return {
+        success: false,
+        message: 'Build item not found.',
+        statusCode: 404,
+      }
+    }
+    assertRunAccess(item.Run, auth.user)
+
+    const body = await readBody<ArtifactBody>(event)
+    if (typeof body.kind !== 'string' || !body.kind.trim()) {
+      throw createError({
+        statusCode: 400,
+        message: 'Artifact "kind" is required.',
+      })
+    }
+
+    const artifact = await prisma.modelBuildArtifact.create({
+      data: {
+        itemId,
+        kind: body.kind.slice(0, 64),
+        provider: str(body.provider, 64),
+        model: str(body.model, 191),
+        seed: str(body.seed, 64),
+        prompt: str(body.prompt, 20000),
+        negativePrompt: str(body.negativePrompt, 20000),
+        width: int(body.width),
+        height: int(body.height),
+        workflow:
+          body.workflow && typeof body.workflow === 'object'
+            ? (body.workflow as Prisma.InputJsonValue)
+            : undefined,
+        format: str(body.format, 32),
+        artImageId: normalizeNullableId(body.artImageId) ?? null,
+        draftPath: str(body.draftPath, 20000),
+        promotedPath: str(body.promotedPath, 20000),
+        reviewState: reviewStates.has(body.reviewState as ModelBuildReviewState)
+          ? (body.reviewState as ModelBuildReviewState)
+          : 'PENDING',
+        usageInfo:
+          body.usageInfo && typeof body.usageInfo === 'object'
+            ? (body.usageInfo as Prisma.InputJsonValue)
+            : undefined,
+      },
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: 'Artifact recorded successfully.',
+      data: artifact,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/runs/[id].delete.ts
+++ b/server/api/model-builder/runs/[id].delete.ts
@@ -1,0 +1,40 @@
+// /server/api/model-builder/runs/[id].delete.ts
+import { defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { assertRunAccess, getRunId } from './index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getRunId(event)
+    const auth = await requireApiUser(event)
+
+    const existing = await prisma.modelBuildRun.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    })
+    if (!existing) {
+      event.node.res.statusCode = 404
+      return { success: false, message: 'Build run not found.', statusCode: 404 }
+    }
+    assertRunAccess(existing, auth.user)
+
+    // Hard delete — items, artifacts, and revisions cascade. Build runs are
+    // disposable scratch state, not canonical records.
+    await prisma.modelBuildRun.delete({ where: { id } })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Build run deleted successfully.',
+      data: { id },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/runs/[id].get.ts
+++ b/server/api/model-builder/runs/[id].get.ts
@@ -1,0 +1,38 @@
+// /server/api/model-builder/runs/[id].get.ts
+import { defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { assertRunAccess, getRunId, runInclude } from './index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getRunId(event)
+    const auth = await requireApiUser(event)
+
+    const run = await prisma.modelBuildRun.findUnique({
+      where: { id },
+      include: runInclude,
+    })
+
+    if (!run) {
+      event.node.res.statusCode = 404
+      return { success: false, message: 'Build run not found.', statusCode: 404 }
+    }
+
+    assertRunAccess(run, auth.user)
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Build run fetched successfully.',
+      data: run,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/runs/[id].patch.ts
+++ b/server/api/model-builder/runs/[id].patch.ts
@@ -1,0 +1,75 @@
+// /server/api/model-builder/runs/[id].patch.ts
+import { defineEventHandler, readBody } from 'h3'
+import type {
+  ModelBuildStatus,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  assertRunAccess,
+  getRunId,
+  modelBuildStatuses,
+  normalizeJson,
+  normalizeText,
+  runInclude,
+} from './index'
+
+type RunPatchBody = {
+  status?: unknown
+  sourceLabel?: unknown
+  selections?: unknown
+  usageInfo?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getRunId(event)
+    const auth = await requireApiUser(event)
+
+    const existing = await prisma.modelBuildRun.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    })
+    if (!existing) {
+      event.node.res.statusCode = 404
+      return { success: false, message: 'Build run not found.', statusCode: 404 }
+    }
+    assertRunAccess(existing, auth.user)
+
+    const body = await readBody<RunPatchBody>(event)
+    const data: Prisma.ModelBuildRunUncheckedUpdateInput = {}
+
+    if (modelBuildStatuses.has(body.status as ModelBuildStatus)) {
+      const status = body.status as ModelBuildStatus
+      data.status = status
+      if (status === 'CANCELLED') data.cancelledAt = new Date()
+    }
+    if (body.sourceLabel !== undefined)
+      data.sourceLabel = normalizeText(body.sourceLabel)
+    const selections = normalizeJson(body.selections)
+    if (selections !== undefined) data.selections = selections
+    const usageInfo = normalizeJson(body.usageInfo)
+    if (usageInfo !== undefined) data.usageInfo = usageInfo
+
+    const run = await prisma.modelBuildRun.update({
+      where: { id },
+      data,
+      include: runInclude,
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Build run updated successfully.',
+      data: run,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/runs/index.get.ts
+++ b/server/api/model-builder/runs/index.get.ts
@@ -1,0 +1,56 @@
+// /server/api/model-builder/runs/index.get.ts
+import { defineEventHandler, getQuery } from 'h3'
+import type {
+  ModelBuildStatus,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { modelBuildStatuses, runInclude } from './index'
+
+type RunListQuery = {
+  status?: string
+  includeCancelled?: string
+  take?: string
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const query = getQuery<RunListQuery>(event)
+
+    const and: Prisma.ModelBuildRunWhereInput[] = [{ userId: auth.user.id }]
+
+    if (modelBuildStatuses.has(query.status as ModelBuildStatus)) {
+      and.push({ status: query.status as ModelBuildStatus })
+    } else if (query.includeCancelled !== 'true') {
+      and.push({ status: { not: 'CANCELLED' } })
+    }
+
+    const take = Math.min(
+      Math.max(Number(query.take) || 25, 1),
+      100,
+    )
+
+    const runs = await prisma.modelBuildRun.findMany({
+      where: { AND: and },
+      include: runInclude,
+      orderBy: { updatedAt: 'desc' },
+      take,
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Build runs fetched successfully.',
+      data: runs,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -1,0 +1,139 @@
+// /server/api/model-builder/runs/index.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import type { ModelBuildAction } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { runInclude } from './index'
+
+const actions = new Set<ModelBuildAction>(['CREATE', 'UPDATE', 'ASSET_ONLY'])
+
+type RunItemInput = {
+  outputKey?: unknown
+  label?: unknown
+  action?: unknown
+  generation?: unknown
+  quantityIndex?: unknown
+  stageStatuses?: unknown
+}
+
+type RunCreateBody = {
+  sourceType?: unknown
+  sourceId?: unknown
+  sourceLabel?: unknown
+  sourceSnapshot?: unknown
+  recipeKey?: unknown
+  recipeVersion?: unknown
+  selections?: unknown
+  items?: unknown
+}
+
+function requiredString(value: unknown, field: string, max: number): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw createError({ statusCode: 400, message: `"${field}" is required.` })
+  }
+  if (value.length > max) {
+    throw createError({
+      statusCode: 400,
+      message: `"${field}" must be ${max} characters or fewer.`,
+    })
+  }
+  return value.trim()
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = await readBody<RunCreateBody>(event)
+
+    const sourceType = requiredString(body.sourceType, 'sourceType', 64)
+    const recipeKey = requiredString(body.recipeKey, 'recipeKey', 64)
+
+    const sourceId = Number(body.sourceId)
+    if (!Number.isInteger(sourceId) || sourceId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'A valid sourceId is required.',
+      })
+    }
+
+    if (!Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'At least one build item is required.',
+      })
+    }
+
+    const items = (body.items as RunItemInput[]).map((item, index) => {
+      const outputKey = requiredString(item.outputKey, `items[${index}].outputKey`, 64)
+      const generation = requiredString(
+        item.generation,
+        `items[${index}].generation`,
+        32,
+      )
+      const action = actions.has(item.action as ModelBuildAction)
+        ? (item.action as ModelBuildAction)
+        : 'ASSET_ONLY'
+      const stageStatuses =
+        item.stageStatuses && typeof item.stageStatuses === 'object'
+          ? (item.stageStatuses as Prisma.InputJsonValue)
+          : ({} as Prisma.InputJsonValue)
+
+      return {
+        outputKey,
+        label:
+          typeof item.label === 'string' ? item.label.slice(0, 255) : null,
+        action,
+        generation,
+        quantityIndex:
+          Number.isInteger(Number(item.quantityIndex)) &&
+          Number(item.quantityIndex) >= 0
+            ? Number(item.quantityIndex)
+            : 0,
+        stageStatuses,
+      }
+    })
+
+    const run = await prisma.modelBuildRun.create({
+      data: {
+        userId: auth.user.id,
+        status: 'ACTIVE',
+        sourceType,
+        sourceId,
+        sourceLabel:
+          typeof body.sourceLabel === 'string'
+            ? body.sourceLabel.slice(0, 255)
+            : null,
+        sourceSnapshot:
+          body.sourceSnapshot && typeof body.sourceSnapshot === 'object'
+            ? (body.sourceSnapshot as Prisma.InputJsonValue)
+            : undefined,
+        recipeKey,
+        recipeVersion:
+          typeof body.recipeVersion === 'string'
+            ? body.recipeVersion.slice(0, 32)
+            : null,
+        selections:
+          body.selections && typeof body.selections === 'object'
+            ? (body.selections as Prisma.InputJsonValue)
+            : undefined,
+        Items: { create: items },
+      },
+      include: runInclude,
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: 'Build run created successfully.',
+      data: run,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -1,0 +1,90 @@
+// /server/api/model-builder/runs/index.ts
+import { createError, getRouterParam } from 'h3'
+import type { H3Event } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import type { ModelBuildStatus } from '~/prisma/generated/prisma/client'
+
+export const modelBuildStatuses = new Set<ModelBuildStatus>([
+  'DRAFT',
+  'ACTIVE',
+  'COMPLETED',
+  'CANCELLED',
+])
+
+// Full run graph: items with their artifacts and revisions, in stable order.
+export const runInclude = {
+  Items: {
+    orderBy: { id: 'asc' },
+    include: {
+      Artifacts: { orderBy: { id: 'asc' } },
+      Revisions: { orderBy: { id: 'asc' } },
+    },
+  },
+} satisfies Prisma.ModelBuildRunInclude
+
+export function getRunId(event: H3Event): number {
+  const value = Number(getRouterParam(event, 'id'))
+  if (!Number.isInteger(value) || value <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid build run ID is required.',
+    })
+  }
+  return value
+}
+
+export function getItemId(event: H3Event): number {
+  const value = Number(getRouterParam(event, 'id'))
+  if (!Number.isInteger(value) || value <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid build item ID is required.',
+    })
+  }
+  return value
+}
+
+// A run (or a run reached via one of its items) may only be modified by its
+// owner or an admin. A null userId means the owner was deleted — admins only.
+export function assertRunAccess(
+  run: { userId: number | null },
+  user: { id: number; Role?: string | null },
+): void {
+  if (user.Role !== 'ADMIN' && run.userId !== user.id) {
+    throw createError({
+      statusCode: 403,
+      message: 'You do not have permission to modify this build run.',
+    })
+  }
+}
+
+export function normalizeText(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'Expected a text value.' })
+  }
+  return value
+}
+
+export function normalizeNullableId(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'Expected a positive integer ID.',
+    })
+  }
+  return id
+}
+
+// JSON columns use the tri-state undefined (leave) / null (clear) / value.
+export function normalizeJson(
+  value: unknown,
+): Prisma.InputJsonValue | typeof Prisma.JsonNull | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return Prisma.JsonNull
+  return value as Prisma.InputJsonValue
+}

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -7,12 +7,12 @@
 // reject, rerun, or resume at any stage; editing upstream work marks
 // downstream work stale without deleting it.
 //
-// This front-end slice keeps run state on the client (localStorage) for resume
-// and reuses the existing art generator for GENERATE_ASSETS. Durable
-// server-side BuildRun/BuildItem persistence and the idempotent final COMMIT
-// write are a later, human-gated milestone (see conductor model-builder
-// roadmap t-004 / t-013 / t-014); COMMIT here produces a preview diff only and
-// never silently rewrites a canonical model.
+// Run state is DURABLE: runs, items, artifacts, and revisions persist through
+// the /api/model-builder endpoints so a run resumes across devices and
+// sessions. The store mutates local state optimistically, then persists in the
+// background. GENERATE_ASSETS reuses the existing art generator; COMMIT is still
+// preview-only — the durable create/update/link/promote is a later gated
+// milestone (roadmap t-013/t-015) and never silently rewrites a canonical model.
 
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, toRefs } from 'vue'
@@ -56,7 +56,7 @@ export interface SourceRecord {
 }
 
 export interface BuildItem {
-  id: string // stable within a run: `${outputKey}#${quantityIndex}`
+  id: string // durable server id (as a string, for keying)
   outputKey: string
   label: string
   action: BuildAction
@@ -96,13 +96,49 @@ interface ModelBuilderState {
   recipeKey: RecipeKey | null
   selections: Record<string, OutputSelection>
   run: BuildRun | null
+  startingRun: boolean
   generatingItemId: string | null
   statusMessage: string
   statusTone: 'success' | 'error'
 }
 
+// --- server record shapes (loose — only the fields we read) ----------------
+
+interface ServerArtifact {
+  id: number
+  draftPath?: string | null
+  promotedPath?: string | null
+  artImageId?: number | null
+}
+
+interface ServerItem {
+  id: number
+  outputKey: string
+  label: string | null
+  action: BuildAction
+  generation: string
+  quantityIndex: number
+  stageStatuses: unknown
+  pitch: string | null
+  fieldsDraft: string | null
+  promptDraft: string | null
+  artImageId: number | null
+  error: string | null
+  Artifacts?: ServerArtifact[]
+}
+
+interface ServerRun {
+  id: number
+  createdAt: string
+  sourceType: string
+  sourceId: number
+  sourceLabel: string | null
+  recipeKey: string
+  Items: ServerItem[]
+}
+
 const isClient = typeof window !== 'undefined'
-const runStorageKey = 'modelBuilder:run'
+const runIdKey = 'modelBuilder:runId'
 const MAX_BATCH = 12
 
 // Which draft field an AI suggestion targets. `artPrompt` matches the /api/suggest
@@ -141,18 +177,28 @@ function safeRemove(key: string): void {
   } catch {}
 }
 
-function makeRunId(sourceType: SourceTypeKey, sourceId: number): string {
-  // No Math.random / Date.now dependency for the id core so a resumed run keeps
-  // a stable identity; createdAt carries the timestamp separately.
-  return `${sourceType.toLowerCase()}-${sourceId}-${BUILD_STAGES.length}`
-}
-
 // Initial stage map: PITCH is workable, the rest are locked behind it.
 function freshStages(): Record<BuildStageKey, StageState> {
   const stages = {} as Record<BuildStageKey, StageState>
   BUILD_STAGES.forEach((stage, index) => {
     stages[stage.key] = { status: index === 0 ? 'ready' : 'locked' }
   })
+  return stages
+}
+
+// Coerce a persisted stageStatuses JSON blob back into a complete stage map,
+// filling any missing gate with a locked default.
+function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
+  const stages = freshStages()
+  if (raw && typeof raw === 'object') {
+    const source = raw as Record<string, StageState>
+    for (const stage of BUILD_STAGES) {
+      const value = source[stage.key]
+      if (value && typeof value.status === 'string') {
+        stages[stage.key] = { status: value.status, note: value.note }
+      }
+    }
+  }
   return stages
 }
 
@@ -169,6 +215,40 @@ function sizeToDimensions(size?: string): { width: number; height: number } {
   return { width: Number(match[1]), height: Number(match[2]) }
 }
 
+function adaptItem(server: ServerItem): BuildItem {
+  const artifact =
+    server.Artifacts && server.Artifacts.length
+      ? server.Artifacts[server.Artifacts.length - 1]
+      : null
+  return {
+    id: String(server.id),
+    outputKey: server.outputKey,
+    label: server.label ?? server.outputKey,
+    action: server.action,
+    generation: server.generation as GenerationKind,
+    quantityIndex: server.quantityIndex,
+    stages: normalizeStages(server.stageStatuses),
+    pitch: server.pitch ?? '',
+    fieldsDraft: server.fieldsDraft ?? '',
+    promptDraft: server.promptDraft ?? '',
+    artImageId: server.artImageId ?? null,
+    imagePath: artifact?.promotedPath ?? artifact?.draftPath ?? null,
+    error: server.error ?? null,
+  }
+}
+
+function adaptRun(server: ServerRun): BuildRun {
+  return {
+    id: String(server.id),
+    createdAt: server.createdAt,
+    sourceType: server.sourceType as SourceTypeKey,
+    sourceId: server.sourceId,
+    sourceLabel: server.sourceLabel ?? '',
+    recipeKey: server.recipeKey as RecipeKey,
+    items: Array.isArray(server.Items) ? server.Items.map(adaptItem) : [],
+  }
+}
+
 export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   const state = reactive<ModelBuilderState>({
     step: 'source',
@@ -180,6 +260,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     recipeKey: null,
     selections: {},
     run: null,
+    startingRun: false,
     generatingItemId: null,
     statusMessage: '',
     statusTone: 'success',
@@ -195,9 +276,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const config = state.sourceType ? getSourceType(state.sourceType) : undefined
     const field = config?.titleField ?? 'title'
     const value = record[field] ?? record.title ?? record.name ?? record.slug
-    return typeof value === 'string' && value.trim()
-      ? value
-      : `#${record.id}`
+    return typeof value === 'string' && value.trim() ? value : `#${record.id}`
   }
 
   const selectedRecipe = computed(() =>
@@ -210,12 +289,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   const selectedOutputCount = computed(
     () =>
-      Object.values(state.selections).filter((selection) => selection.on)
-        .length,
+      Object.values(state.selections).filter((selection) => selection.on).length,
   )
 
   const canStartRun = computed(
-    () => Boolean(state.selectedSource && state.recipeKey && selectedOutputCount.value > 0),
+    () =>
+      Boolean(
+        state.selectedSource &&
+          state.recipeKey &&
+          selectedOutputCount.value > 0 &&
+          !state.startingRun,
+      ),
   )
 
   const runProgress = computed(() => {
@@ -306,52 +390,101 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     selection.quantity = Math.max(1, Math.min(MAX_BATCH, Math.floor(quantity) || 1))
   }
 
-  // --- step 3: build run + gated stage advancement -------------------------
+  // --- step 3: create the durable run --------------------------------------
 
-  function startRun(): void {
-    if (!state.selectedSource || !state.sourceType || !state.recipeKey) return
+  async function startRun(): Promise<void> {
+    if (
+      !state.selectedSource ||
+      !state.sourceType ||
+      !state.recipeKey ||
+      state.startingRun
+    ) {
+      return
+    }
 
-    const items: BuildItem[] = []
+    const itemsPayload: Array<Record<string, unknown>> = []
     for (const output of recipeOutputs.value) {
       const selection = state.selections[output.key]
       if (!selection?.on) continue
 
       const count = output.quantity ? selection.quantity : 1
       for (let index = 0; index < count; index++) {
-        items.push({
-          id: `${output.key}#${index}`,
+        itemsPayload.push({
           outputKey: output.key,
           label: count > 1 ? `${output.label} ${index + 1}` : output.label,
           action: output.action,
           generation: output.generation,
           quantityIndex: index,
-          stages: freshStages(),
-          pitch: '',
-          fieldsDraft: '',
-          promptDraft: '',
-          artImageId: null,
-          imagePath: null,
-          error: null,
+          stageStatuses: freshStages(),
         })
       }
     }
 
-    state.run = {
-      id: makeRunId(state.sourceType, state.selectedSource.id),
-      createdAt: nowIso(),
-      sourceType: state.sourceType,
-      sourceId: state.selectedSource.id,
-      sourceLabel: sourceLabel(state.selectedSource),
-      recipeKey: state.recipeKey,
-      items,
+    if (!itemsPayload.length) return
+
+    state.startingRun = true
+    clearStatus()
+
+    try {
+      const response = await performFetch<ServerRun>('/api/model-builder/runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceType: state.sourceType,
+          sourceId: state.selectedSource.id,
+          sourceLabel: sourceLabel(state.selectedSource),
+          sourceSnapshot: state.selectedSource,
+          recipeKey: state.recipeKey,
+          selections: state.selections,
+          items: itemsPayload,
+        }),
+      })
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to start build run.')
+      }
+
+      state.run = adaptRun(response.data)
+      setActiveRunId(response.data.id)
+      state.step = 'run'
+      setStatus(
+        'success',
+        `Started a ${getRecipe(state.recipeKey)?.label} run with ${state.run.items.length} item${state.run.items.length === 1 ? '' : 's'}.`,
+      )
+    } catch (error) {
+      handleError(error, 'starting build run')
+      setStatus(
+        'error',
+        error instanceof Error ? error.message : 'Failed to start build run.',
+      )
+    } finally {
+      state.startingRun = false
     }
-    state.step = 'run'
-    persistRun()
-    setStatus('success', `Started a ${getRecipe(state.recipeKey)?.label} run with ${items.length} item${items.length === 1 ? '' : 's'}.`)
   }
 
   function findItem(itemId: string): BuildItem | undefined {
     return state.run?.items.find((item) => item.id === itemId)
+  }
+
+  // Background persistence of a single item. Callers mutate local state first
+  // (optimistic) and pass only the changed fields; a draft change also carries
+  // stage metadata so the server records a revision.
+  function pushItem(
+    item: BuildItem,
+    payload: Record<string, unknown>,
+    meta?: { stage?: string; reason?: string },
+  ): void {
+    performFetch(`/api/model-builder/items/${item.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...payload, ...meta }),
+    })
+      .then((response) => {
+        if (!response.success) {
+          setStatus('error', response.message || 'Failed to save changes.')
+        }
+      })
+      .catch((error) => handleError(error, 'saving build item'))
   }
 
   // Stale-invalidation: editing an upstream stage marks every downstream stage
@@ -361,7 +494,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     BUILD_STAGES.forEach((stage, index) => {
       if (index <= from) return
       const current = item.stages[stage.key].status
-      if (current === 'approved' || current === 'ready' || current === 'in-progress') {
+      if (
+        current === 'approved' ||
+        current === 'ready' ||
+        current === 'in-progress'
+      ) {
         item.stages[stage.key] = { status: 'stale' }
       }
     })
@@ -371,20 +508,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const item = findItem(itemId)
     if (!item) return
     item.stages[stageKey] = { status: 'approved' }
-    // Unlock the next stage.
     const next = BUILD_STAGES[stageIndex(stageKey) + 1]
     if (next && item.stages[next.key].status === 'locked') {
       item.stages[next.key] = { status: 'ready' }
     }
-    persistRun()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
   }
 
-  function rejectStage(itemId: string, stageKey: BuildStageKey, note?: string): void {
+  function rejectStage(
+    itemId: string,
+    stageKey: BuildStageKey,
+    note?: string,
+  ): void {
     const item = findItem(itemId)
     if (!item) return
     item.stages[stageKey] = { status: 'rejected', note }
     markDownstreamStale(item, stageKey)
-    persistRun()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
   }
 
   // Reopen a stale/approved stage for editing and invalidate downstream.
@@ -393,7 +533,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!item) return
     item.stages[stageKey] = { status: 'ready' }
     markDownstreamStale(item, stageKey)
-    persistRun()
+    pushItem(item, { stageStatuses: item.stages }, { stage: stageKey })
   }
 
   function updatePitch(itemId: string, value: string): void {
@@ -401,7 +541,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!item) return
     item.pitch = value
     markDownstreamStale(item, 'PITCH')
-    persistRun()
+    pushItem(
+      item,
+      { stageStatuses: item.stages, pitch: item.pitch },
+      { stage: 'PITCH', reason: 'edited pitch' },
+    )
   }
 
   function updateFields(itemId: string, value: string): void {
@@ -409,7 +553,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!item) return
     item.fieldsDraft = value
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
-    persistRun()
+    pushItem(
+      item,
+      { stageStatuses: item.stages, fieldsDraft: item.fieldsDraft },
+      { stage: 'FIELDS_AND_PROMPTS', reason: 'edited fields' },
+    )
   }
 
   function updatePrompt(itemId: string, value: string): void {
@@ -417,7 +565,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     if (!item) return
     item.promptDraft = value
     markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
-    persistRun()
+    pushItem(
+      item,
+      { stageStatuses: item.stages, promptDraft: item.promptDraft },
+      { stage: 'FIELDS_AND_PROMPTS', reason: 'edited prompt' },
+    )
   }
 
   // --- AI drafting: reuse the existing /api/suggest text generator -----------
@@ -489,8 +641,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       }
 
       const value = result.data.value.trim()
-      // Route through the manual-edit setters so downstream stages stale exactly
-      // as they would on a hand edit.
+      // Route through the manual-edit setters so downstream stages stale and the
+      // draft persists exactly as on a hand edit.
       if (field === 'pitch') updatePitch(itemId, value)
       else if (field === 'fields') updateFields(itemId, value)
       else updatePrompt(itemId, value)
@@ -513,13 +665,40 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // --- GENERATE_ASSETS: reuse the existing art generator --------------------
 
+  async function recordArtifact(
+    item: BuildItem,
+    image: { id: number; imagePath?: string | null },
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+  ): Promise<void> {
+    try {
+      await performFetch(`/api/model-builder/items/${item.id}/artifacts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          kind: 'image',
+          provider: output?.engine ?? null,
+          prompt,
+          width: dims.width,
+          height: dims.height,
+          artImageId: image.id,
+          draftPath: image.imagePath ?? null,
+          reviewState: 'PENDING',
+        }),
+      })
+    } catch (error) {
+      handleError(error, 'recording build artifact')
+    }
+  }
+
   async function generateItemAsset(itemId: string): Promise<boolean> {
     const item = findItem(itemId)
     if (!item || !state.run) return false
 
     if (item.generation !== 'image') {
-      // Non-image generation kinds (text, plan, video, 3d) are described in the
-      // brief but not wired into this front-end slice yet.
+      // Non-image generation kinds (text, plan, video, 3d) are catalogued but
+      // not wired into this slice yet.
       item.error = `${item.generation} generation is not wired into the front-end slice yet.`
       item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
       setStatus('error', item.error)
@@ -534,7 +713,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
 
     const output = getOutput(item.outputKey)
-    const { width, height } = sizeToDimensions(output?.size)
+    const dims = sizeToDimensions(output?.size)
     const artStore = useArtStore()
 
     state.generatingItemId = item.id
@@ -548,8 +727,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const result = await artStore.generateCurrentArt({
         promptString: prompt,
         title: `${state.run.sourceLabel} — ${item.label}`,
-        width,
-        height,
+        width: dims.width,
+        height: dims.height,
         engine: output?.engine,
         isPublic: false,
       })
@@ -562,8 +741,14 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null
       item.stages.GENERATE_ASSETS = { status: 'ready' }
+
+      await recordArtifact(item, image, output, prompt, dims)
+      pushItem(item, {
+        stageStatuses: item.stages,
+        artImageId: item.artImageId,
+      })
+
       setStatus('success', `Generated a candidate for ${item.label}.`)
-      persistRun()
       return true
     } catch (error) {
       handleError(error, 'generating model builder asset')
@@ -603,9 +788,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
-  // Records the user's approval of the final diff. The actual durable create /
-  // update / link / promote happens through model APIs in a later gated
-  // milestone — this scaffold only marks the item as approved-for-commit.
+  // Records the user's approval of the final diff. The durable create / update /
+  // link / promote happens through model APIs in a later gated milestone — this
+  // only marks the item approved-for-commit (persisted so it survives resume).
   function approveCommit(itemId: string): void {
     const item = findItem(itemId)
     if (!item) return
@@ -613,33 +798,48 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       status: 'approved',
       note: 'Approved for commit — durable write pending backend execution.',
     }
-    persistRun()
+    pushItem(item, { stageStatuses: item.stages }, { stage: 'COMMIT' })
     setStatus('success', `${item.label} approved for commit.`)
   }
 
   // --- persistence / resume -------------------------------------------------
 
-  function persistRun(): void {
-    if (!state.run) {
-      safeRemove(runStorageKey)
-      return
-    }
-    safeSet(runStorageKey, JSON.stringify(state.run))
+  function setActiveRunId(id: number): void {
+    safeSet(runIdKey, String(id))
   }
 
-  function resumeRun(): void {
-    const raw = safeGet(runStorageKey)
-    if (!raw) return
+  // Resume the most recent run: the remembered run id if still present, else the
+  // newest non-cancelled run for this user. Silent on failure (e.g. signed out).
+  async function resumeRun(): Promise<void> {
     try {
-      const parsed = JSON.parse(raw) as BuildRun
-      if (parsed && Array.isArray(parsed.items)) {
-        state.run = parsed
-        state.sourceType = parsed.sourceType
-        state.recipeKey = parsed.recipeKey
+      const remembered = safeGet(runIdKey)
+      let data: ServerRun | undefined
+
+      if (remembered) {
+        const response = await performFetch<ServerRun>(
+          `/api/model-builder/runs/${remembered}`,
+        )
+        if (response.success && response.data) data = response.data
+      }
+
+      if (!data) {
+        const response = await performFetch<ServerRun[]>(
+          '/api/model-builder/runs?take=1',
+        )
+        if (response.success && Array.isArray(response.data) && response.data.length) {
+          data = response.data[0]
+        }
+      }
+
+      if (data) {
+        state.run = adaptRun(data)
+        state.sourceType = data.sourceType as SourceTypeKey
+        state.recipeKey = data.recipeKey as RecipeKey
         state.step = 'run'
+        setActiveRunId(data.id)
       }
     } catch {
-      safeRemove(runStorageKey)
+      // Not signed in, or no runs yet — start fresh at the source picker.
     }
   }
 
@@ -647,10 +847,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.step = step
   }
 
+  // Leave this run behind (its server record and history remain) and start a new
+  // one. Does not delete the durable run.
   function resetRun(): void {
     state.run = null
     state.step = state.selectedSource ? 'recipe' : 'source'
-    safeRemove(runStorageKey)
+    safeRemove(runIdKey)
     clearStatus()
   }
 
@@ -663,7 +865,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.selections = {}
     state.run = null
     state.generatingItemId = null
-    safeRemove(runStorageKey)
+    safeRemove(runIdKey)
     clearStatus()
   }
 
@@ -704,7 +906,3 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     clearStatus,
   }
 })
-
-function nowIso(): string {
-  return new Date().toISOString()
-}


### PR DESCRIPTION
## What & why

Model Builder runs currently live only in `localStorage` — they can't resume across devices/sessions and leave no server record of items, artifacts, or revisions. This lands **t-004**: durable, resumable run persistence.

## Schema (additive — no existing table touched)
`prisma/model-builder.prisma` + migration `20260712120000_add_model_builder_tables`:
- **ModelBuildRun** → **ModelBuildItem** → **ModelBuildArtifact** / **ModelBuildRevision** (+ `ModelBuildStatus`/`ModelBuildAction`/`ModelBuildReviewState` enums).
- External references (`userId`, `sourceId`, `artImageId`, `targetId`) are **plain scalar `Int` columns, no FK** — so the tables stay self-contained and require no reverse-relation edits to `User`/`ArtImage`. The only foreign keys are the internal run→item→artifact/revision chain, which **cascades on delete**.
- Migration is **four `CREATE TABLE`s + the internal cascade FKs only** — additive, `prisma migrate deploy`-safe.

## API (`server/api/model-builder/*`)
Mirrors the `server/api/projects` idioms exactly — `requireApiUser`, owner/admin guard (`assertRunAccess`), `{ success, data, message }` envelope, `errorHandler`, `Prisma.InputJsonValue`/`Prisma.JsonNull` tri-state for JSON columns:
- `runs/` — list (mine) · create (run + nested items in one call) · get · patch (status/cancel) · delete (cascade).
- `items/[id]` PATCH — stage + draft updates, **auto-appending a `ModelBuildRevision`** when draft content changes.
- `items/[id]/artifacts` POST — record a generated artifact with provenance.

## Store
`modelBuilderStore` now mutates locally (optimistic) then persists in the background: `startRun` POSTs a durable run, `resumeRun` rehydrates the remembered or newest non-cancelled run, stage/draft edits PATCH the item, and generate records an artifact. The `BuildRun`/`BuildItem` in-memory shapes are unchanged, so the components need **no structural change**.

## Boundaries
- COMMIT stays **preview-only** — the durable canonical create/update/link/promote is still gated (t-013/t-015).
- Merge runs `prisma migrate deploy` against prod; the migration is additive-only (`CREATE TABLE`), audited line-by-line.

## Verification
- **Pre-merge (CI):** `prisma generate` validates the new schema; whole-project `vue-tsc` typechecks the routes + rewritten store against the generated client; Vercel preview build runs `nuxt build`. I could not run the toolchain locally (no `node_modules`/generated client), so these are the gate.
- **Post-merge (manual, against prod):** create a run in the UI → reload → confirm it resumes from the server; generate an asset → confirm the artifact row; confirm a second session sees the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_