### PR TITLE
Model Builder: run-history panel (t-021)

### DIFF
--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -36,7 +36,17 @@
 
       <button
         type="button"
-        class="btn btn-xs btn-ghost ml-auto h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-error"
+        class="btn btn-xs btn-ghost ml-auto h-7 min-h-7 rounded-xl px-2"
+        :class="showHistory ? 'text-primary' : 'text-base-content/60 hover:text-primary'"
+        @click="showHistory = !showHistory"
+      >
+        <Icon name="kind-icon:clock" class="h-3.5 w-3.5" />
+        <span class="hidden sm:inline">History</span>
+      </button>
+
+      <button
+        type="button"
+        class="btn btn-xs btn-ghost h-7 min-h-7 rounded-xl px-2 text-base-content/60 hover:text-error"
         @click="store.resetAll()"
       >
         <Icon name="kind-icon:trash" class="h-3.5 w-3.5" />
@@ -59,18 +69,25 @@
     </Transition>
 
     <main class="flex min-h-0 flex-1 flex-col overflow-y-auto p-2 sm:p-3">
-      <model-builder-source-picker v-if="store.step === 'source'" />
-      <model-builder-recipe-selector v-else-if="store.step === 'recipe'" />
-      <model-builder-progress-matrix v-else-if="store.step === 'run'" />
+      <model-builder-run-history
+        v-if="showHistory"
+        @close="showHistory = false"
+      />
+      <template v-else>
+        <model-builder-source-picker v-if="store.step === 'source'" />
+        <model-builder-recipe-selector v-else-if="store.step === 'recipe'" />
+        <model-builder-progress-matrix v-else-if="store.step === 'run'" />
+      </template>
     </main>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useModelBuilderStore } from '@/stores/modelBuilderStore'
 
 const store = useModelBuilderStore()
+const showHistory = ref(false)
 
 const crumbs = computed(() => [
   { step: 'source' as const, label: 'Source', enabled: true },

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -1,0 +1,133 @@
+<!-- /components/model-builder/model-builder-run-history.vue -->
+<template>
+  <div class="flex min-h-0 flex-1 flex-col gap-3">
+    <div class="flex items-start justify-between gap-2">
+      <div>
+        <h3 class="text-base font-black text-base-content">Run history</h3>
+        <p class="mt-1 text-xs text-base-content/60">
+          Your recent Model Builder runs. Reopen one to keep working, or cancel
+          what you no longer need.
+        </p>
+      </div>
+      <div class="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost rounded-xl text-base-content/60"
+          :disabled="store.loadingRuns"
+          @click="store.fetchRuns()"
+        >
+          <Icon name="kind-icon:refresh" class="h-3.5 w-3.5" />
+          Refresh
+        </button>
+        <button
+          type="button"
+          class="btn btn-xs btn-primary rounded-xl"
+          @click="startNew"
+        >
+          <Icon name="kind-icon:add" class="h-3.5 w-3.5" />
+          New run
+        </button>
+      </div>
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto">
+      <div
+        v-if="store.loadingRuns"
+        class="flex h-full min-h-32 items-center justify-center gap-2 text-sm text-base-content/60"
+      >
+        <span class="loading loading-dots loading-md" />
+        Loading runs…
+      </div>
+
+      <div
+        v-else-if="!store.runs.length"
+        class="flex h-full min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center text-sm text-base-content/50"
+      >
+        <Icon name="kind-icon:blueprint" class="h-8 w-8 text-primary/50" />
+        No runs yet — start one from a source model.
+      </div>
+
+      <div v-else class="space-y-2">
+        <div
+          v-for="run in store.runs"
+          :key="run.id"
+          class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 transition hover:border-primary/50"
+          :class="run.id === store.run?.id ? 'border-primary/60 bg-primary/5' : ''"
+        >
+          <Icon :name="sourceIcon(run)" class="h-5 w-5 shrink-0 text-primary" />
+
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-1.5">
+              <span class="truncate text-sm font-bold text-base-content">
+                {{ run.sourceLabel || `#${run.sourceId}` }}
+              </span>
+              <span class="badge badge-xs badge-ghost">{{ run.sourceType }}</span>
+            </div>
+            <div class="flex items-center gap-2 text-xs text-base-content/55">
+              <span>{{ recipeLabel(run) }}</span>
+              <span class="text-base-content/30">·</span>
+              <span>{{ progress(run) }} committed</span>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost shrink-0 rounded-lg text-error/70 hover:text-error"
+            title="Cancel run"
+            @click="store.cancelRun(run.id)"
+          >
+            <Icon name="kind-icon:trash" class="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            class="btn btn-xs btn-primary shrink-0 rounded-lg"
+            @click="open(run.id)"
+          >
+            Open
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import type { BuildRun } from '@/stores/modelBuilderStore'
+import { getRecipe, getSourceType } from '@/stores/helpers/modelBuilderRecipes'
+
+const emit = defineEmits<{ close: [] }>()
+const store = useModelBuilderStore()
+
+function recipeLabel(run: BuildRun): string {
+  return getRecipe(run.recipeKey)?.label ?? run.recipeKey
+}
+
+function sourceIcon(run: BuildRun): string {
+  return getSourceType(run.sourceType)?.icon ?? 'kind-icon:blueprint'
+}
+
+function progress(run: BuildRun): string {
+  const total = run.items.length
+  const committed = run.items.filter(
+    (item) => item.stages.COMMIT?.status === 'approved',
+  ).length
+  return `${committed}/${total}`
+}
+
+async function open(runId: string): Promise<void> {
+  await store.openRun(runId)
+  emit('close')
+}
+
+function startNew(): void {
+  store.resetRun()
+  store.goToStep('source')
+  emit('close')
+}
+
+onMounted(() => {
+  store.fetchRuns()
+})
+</script>

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -96,6 +96,8 @@ interface ModelBuilderState {
   recipeKey: RecipeKey | null
   selections: Record<string, OutputSelection>
   run: BuildRun | null
+  runs: BuildRun[]
+  loadingRuns: boolean
   startingRun: boolean
   generatingItemId: string | null
   statusMessage: string
@@ -260,6 +262,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     recipeKey: null,
     selections: {},
     run: null,
+    runs: [],
+    loadingRuns: false,
     startingRun: false,
     generatingItemId: null,
     statusMessage: '',
@@ -843,6 +847,77 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
+  // --- run history ----------------------------------------------------------
+
+  async function fetchRuns(): Promise<void> {
+    state.loadingRuns = true
+    try {
+      const response = await performFetch<ServerRun[]>(
+        '/api/model-builder/runs?take=50',
+      )
+      if (response.success && Array.isArray(response.data)) {
+        state.runs = response.data.map(adaptRun)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to load run history.')
+      }
+    } catch (error) {
+      handleError(error, 'loading run history')
+    } finally {
+      state.loadingRuns = false
+    }
+  }
+
+  async function openRun(runId: string): Promise<void> {
+    const cached = state.runs.find((entry) => entry.id === runId)
+    if (cached) {
+      state.run = cached
+      state.sourceType = cached.sourceType
+      state.recipeKey = cached.recipeKey
+      state.step = 'run'
+      setActiveRunId(Number(runId))
+      return
+    }
+
+    try {
+      const response = await performFetch<ServerRun>(
+        `/api/model-builder/runs/${runId}`,
+      )
+      if (response.success && response.data) {
+        state.run = adaptRun(response.data)
+        state.sourceType = state.run.sourceType
+        state.recipeKey = state.run.recipeKey
+        state.step = 'run'
+        setActiveRunId(response.data.id)
+      } else if (!response.success) {
+        setStatus('error', response.message || 'Failed to open run.')
+      }
+    } catch (error) {
+      handleError(error, 'opening build run')
+    }
+  }
+
+  async function cancelRun(runId: string): Promise<void> {
+    try {
+      const response = await performFetch(
+        `/api/model-builder/runs/${runId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'CANCELLED' }),
+        },
+      )
+      if (!response.success) {
+        setStatus('error', response.message || 'Failed to cancel run.')
+        return
+      }
+      state.runs = state.runs.filter((entry) => entry.id !== runId)
+      if (state.run?.id === runId) resetRun()
+      setStatus('success', 'Run cancelled.')
+    } catch (error) {
+      handleError(error, 'cancelling build run')
+    }
+  }
+
   function goToStep(step: BuilderStep): void {
     state.step = step
   }
@@ -899,6 +974,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     previewCommit,
     approveCommit,
     resumeRun,
+    fetchRuns,
+    openRun,
+    cancelRun,
     goToStep,
     resetRun,
     resetAll,


### PR DESCRIPTION
## What & why

Now that Model Builder runs persist (#188), surface them. A **History** toggle in the manager opens a panel listing the user's recent runs with source, recipe, and committed/total progress — reopen one back into the progress matrix, cancel one, or start a new run.

## Changes
- `modelBuilderStore`: `runs`/`loadingRuns` state + `fetchRuns` (GET `/api/model-builder/runs`), `openRun`, `cancelRun` (PATCH status `CANCELLED`).
- `components/model-builder/model-builder-run-history.vue`: the list panel.
- `model-builder-manager.vue`: History toggle + conditional render.

**Front-end only — no schema, no new endpoints** (reuses the run APIs from #188).

## Verification
CI: whole-project `vue-tsc` + Vercel preview. Post-merge: open `/model-builder`, hit History, confirm past runs list and reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_