### PR TITLE
Model Builder: expose /model-builder in the nav (t-019)

### DIFF
--- a/stores/seeds/smartIcons.json
+++ b/stores/seeds/smartIcons.json
@@ -236,5 +236,19 @@
     "description": "Here's the behind-the-scenes look at the components that make up our site.",
     "category": "ami",
     "modelType": "ami"
+  },
+  {
+    "title": "Model Builder",
+    "type": "directory",
+    "userId": 10,
+    "designer": "content-seeder",
+    "icon": "kind-icon:blueprint",
+    "label": "Model Builder Room",
+    "link": "/model-builder",
+    "component": "builder-nav",
+    "isPublic": true,
+    "description": "Upgrade or expand existing Kind Robots records through four reviewable gates.",
+    "category": "model",
+    "modelType": "builder"
   }
 ]


### PR DESCRIPTION
Adds the Model Builder to the site navigation (t-019).

Appends a `type: directory` SmartIcon (`link: /model-builder`, `kind-icon:blueprint`, label "Model Builder Room") to `stores/seeds/smartIcons.json` — the seed `navStore` imports directly as its offline fallback — mirroring the `/art` entry exactly. The existing `content/model-builder.md` already carries the `icon:`/`title:`/`room:` frontmatter the `generatesmart` generator needs, so it also registers through that path once the icon DB is reseeded.

Content-only seed change; no code paths touched.

## Verification
CI: `vue-tsc` + Vercel preview. Post-merge: the Model Builder room appears in the directory nav at `/model-builder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_