### PR TITLE
Model Builder: register a grounded suggest sheet for AI-drafting (t-020)

### DIFF
--- a/server/utils/suggest/sheets/index.ts
+++ b/server/utils/suggest/sheets/index.ts
@@ -5,6 +5,7 @@ import botSuggest from './botSuggest'
 import scenarioSuggest from './scenarioSuggest'
 import rewardSuggest from './rewardSuggest'
 import dreamSuggest from './dreamSuggest'
+import modelBuilderSuggest from './modelBuilderSuggest'
 import type { SuggestSheet } from '../suggestTypes'
 
 export const suggestSheets = [
@@ -14,4 +15,5 @@ export const suggestSheets = [
   scenarioSuggest,
   rewardSuggest,
   dreamSuggest,
+  modelBuilderSuggest,
 ] satisfies SuggestSheet[]

--- a/server/utils/suggest/sheets/modelBuilderSuggest.ts
+++ b/server/utils/suggest/sheets/modelBuilderSuggest.ts
@@ -1,0 +1,97 @@
+// /server/utils/suggest/sheets/modelBuilderSuggest.ts
+import type { SuggestSheet, SuggestBody } from '../suggestTypes'
+
+// Pull a compact digest of the selected SOURCE record's canon so drafts stay
+// on-brand instead of generic. The Model Builder store sends the whole record as
+// context.source plus a few run-level keys.
+function buildSourceContext(context: Record<string, unknown>): string[] {
+  const lines: string[] = []
+
+  const push = (label: string, value: unknown): void => {
+    if (value == null) return
+    const text = Array.isArray(value)
+      ? value.filter(Boolean).join(', ')
+      : String(value)
+    const trimmed = text.trim()
+    if (trimmed) lines.push(`${label}: ${trimmed}`)
+  }
+
+  push('Source type', context.sourceType)
+  push('Source', context.sourceLabel)
+  push('Recipe', context.recipe)
+  push('Output', context.output)
+  push('Item', context.itemLabel)
+  push('Action', context.action)
+
+  const source =
+    context.source && typeof context.source === 'object'
+      ? (context.source as Record<string, unknown>)
+      : null
+  if (source) {
+    const canonKeys = [
+      'name',
+      'title',
+      'subtitle',
+      'tagline',
+      'class',
+      'species',
+      'rewardType',
+      'dreamType',
+      'kind',
+      'personality',
+      'quirks',
+      'backstory',
+      'description',
+      'pitch',
+      'flavorText',
+      'botIntro',
+    ]
+    for (const key of canonKeys) {
+      const value = source[key]
+      if (typeof value === 'string' && value.trim()) {
+        const clipped = value.length > 240 ? `${value.slice(0, 240)}…` : value
+        push(`  ${key}`, clipped)
+      }
+    }
+  }
+
+  // Existing sibling drafts help keep the pitch/fields/prompt consistent.
+  push('Existing pitch', context.pitch)
+  push('Existing fields', context.fields)
+
+  return lines
+}
+
+const modelBuilderSuggest: SuggestSheet = {
+  builder: 'model-builder',
+  label: 'Model Builder',
+  systemPrompt: `You are the Model Builder drafting assistant for Kind Robots.
+You help upgrade or create records (Project, Character, Bot, Facet, Dream, Reward,
+Scenario) by drafting concise, on-brand, schema-ready text for one build output,
+grounded in the selected SOURCE record's canon and the chosen recipe/output.
+Rules:
+- Return only the requested value. No preamble, no quotation marks, no labels.
+- Stay consistent with the source's established identity — never contradict its canon.
+- Fit the specific output being built and the source's model type.
+- Be tight and concrete.`,
+  contextKeys: [
+    'sourceType',
+    'sourceLabel',
+    'recipe',
+    'output',
+    'itemLabel',
+    'action',
+  ],
+  fieldPrompts: {
+    pitch:
+      'Write a concise 2–3 sentence pitch for this output — why it exists for the source record and what it should convey. Ground it in the source canon.',
+    fields:
+      'Propose the concrete schema fields and relationships this output should write, as short "field: value" lines that fit the source model and stay true to its canon.',
+    artPrompt:
+      'Write a single vivid image-generation prompt for this output, grounded in the source record\'s look and canon. Comma-separated descriptors, no sentences.',
+  },
+  buildContext: (context: Record<string, unknown>, _body: SuggestBody) =>
+    buildSourceContext(context),
+}
+
+export default modelBuilderSuggest

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -149,17 +149,10 @@ const runIdKey = 'modelBuilder:runId'
 const MAX_BATCH = 12
 
 // Which draft field an AI suggestion targets. `artPrompt` matches the /api/suggest
-// convention used by the art generator.
+// convention used by the art generator. Per-field prompt text lives in the
+// registered 'model-builder' suggest sheet (server/utils/suggest/sheets), so the
+// store just names the field.
 export type DraftField = 'pitch' | 'fields' | 'artPrompt'
-
-const DRAFT_INSTRUCTIONS: Record<DraftField, string> = {
-  pitch:
-    'Write a concise 2-3 sentence pitch describing why this output exists for the source record and what it should convey. Return only the pitch text.',
-  fields:
-    'Propose the concrete schema fields and relationships this output should write, as short "field: value" lines grounded in the source record. Return only the field list.',
-  artPrompt:
-    'Write a single vivid image-generation prompt for this output, grounded in the source record. Comma-separated descriptors, no preamble. Return only the prompt.',
-}
 
 function safeGet(key: string): string | null {
   if (!isClient) return null
@@ -639,7 +632,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
               source: state.selectedSource ?? undefined,
             },
             extra: {
-              instruction: instruction || DRAFT_INSTRUCTIONS[field],
+              // The registered 'model-builder' suggest sheet owns the per-field
+              // prompt; only override it when the caller passes an explicit one.
+              ...(instruction ? { instruction } : {}),
               sourceLabel: state.run.sourceLabel,
             },
           }),


### PR DESCRIPTION
## What & why

"Draft with AI" called `/api/suggest` with `builder: 'model-builder'`, which had no registered sheet and **fell back to the adventure sheet** (a generic creative-writing system prompt). This registers a real sheet so drafts are on-topic and grounded in the source record's canon.

- **`server/utils/suggest/sheets/modelBuilderSuggest.ts`** — `builder: 'model-builder'` with a Model-Builder system prompt, per-field prompts for `pitch`/`fields`/`artPrompt`, and a `buildContext` that surfaces the source record's canon (source type, recipe, output, action, plus a digest of `name`/`class`/`personality`/`backstory`/`pitch`/…).
- Registered in `sheets/index.ts`.
- **`modelBuilderStore.draftText`**: stop force-sending `extra.instruction`, which **overrode** any sheet `fieldPrompt` (instruction wins in `buildSuggestUserPrompt`). Now it's only sent when a caller passes one explicitly, so the sheet's per-field prompts actually take effect. Dropped the obsolete client-side `DRAFT_INSTRUCTIONS`.

Net effect: better system prompt + real source grounding, and the per-field prompts live server-side where they belong. No schema.

## Verification
CI: `vue-tsc` (validates the `SuggestSheet` typing + store) + Vercel preview. Post-merge: "Draft with AI" on a Character source produces character-grounded drafts instead of generic ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_