### PR TITLE
Model Builder: source thumbnails + run source-context panel

### DIFF
--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -20,6 +20,43 @@
       </button>
     </div>
 
+    <!-- Source context: what we already have on the record we're building from -->
+    <div
+      v-if="source"
+      class="flex items-start gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
+    >
+      <div
+        class="grid h-16 w-16 shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
+      >
+        <img
+          v-if="sourceImage"
+          :src="sourceImage"
+          :alt="run?.sourceLabel"
+          class="h-full w-full object-cover"
+          loading="lazy"
+        />
+        <Icon v-else name="kind-icon:blueprint" class="h-6 w-6 text-base-content/30" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-1.5">
+          <span class="truncate text-sm font-bold text-base-content">
+            {{ run?.sourceLabel }}
+          </span>
+          <span class="badge badge-xs badge-ghost">{{ run?.sourceType }}</span>
+          <span class="text-[10px] text-base-content/35">#{{ run?.sourceId }}</span>
+        </div>
+        <p
+          v-if="sourceBlurb"
+          class="mt-0.5 line-clamp-3 text-xs leading-snug text-base-content/60"
+        >
+          {{ sourceBlurb }}
+        </p>
+        <p v-else class="mt-0.5 text-xs italic text-base-content/40">
+          No description on this record yet.
+        </p>
+      </div>
+    </div>
+
     <!-- Stage matrix -->
     <div class="overflow-x-auto rounded-2xl border border-base-300 bg-base-100">
       <table class="table table-sm">
@@ -92,6 +129,49 @@ const run = computed(() => store.run)
 const recipeLabel = computed(() =>
   run.value ? getRecipe(run.value.recipeKey)?.label : '',
 )
+
+// The source record we're building from — snapshot survives resume; fall back to
+// the freshly-picked record.
+const source = computed<Record<string, unknown> | null>(
+  () => run.value?.sourceSnapshot ?? store.selectedSource ?? null,
+)
+
+function str(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  return typeof value === 'string' ? value : ''
+}
+
+const sourceImage = computed(() => {
+  const record = source.value
+  if (!record) return ''
+  const art = record.ArtImage as
+    | { thumbnailPath?: string; imagePath?: string }
+    | undefined
+  return (
+    str(record, 'imagePath') ||
+    str(record, 'avatarImage') ||
+    art?.thumbnailPath ||
+    art?.imagePath ||
+    ''
+  )
+})
+
+const sourceBlurb = computed(() => {
+  const record = source.value
+  if (!record) return ''
+  for (const key of [
+    'description',
+    'pitch',
+    'backstory',
+    'flavorText',
+    'botIntro',
+    'subtitle',
+  ]) {
+    const value = str(record, key)
+    if (value.trim()) return value
+  }
+  return ''
+})
 
 const selectedItemId = ref<string>(run.value?.items[0]?.id ?? '')
 const selectedItem = computed(() =>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -75,21 +75,40 @@
           v-for="record in store.sources"
           :key="record.id"
           type="button"
-          class="flex flex-col items-start gap-0.5 rounded-2xl border border-base-300 bg-base-100 p-3 text-left transition hover:border-primary hover:bg-base-200"
+          class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-2.5 text-left transition hover:border-primary hover:bg-base-200"
           @click="store.selectSource(record)"
         >
-          <span class="truncate text-sm font-bold text-base-content">
-            {{ store.sourceLabel(record) }}
-          </span>
-          <span
-            v-if="subtitle(record)"
-            class="line-clamp-2 text-xs text-base-content/55"
+          <div
+            class="grid h-12 w-12 shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
           >
-            {{ subtitle(record) }}
-          </span>
-          <span class="mt-1 text-[10px] uppercase tracking-wide text-base-content/35">
-            #{{ record.id }}
-          </span>
+            <img
+              v-if="recordImage(record)"
+              :src="recordImage(record)"
+              :alt="store.sourceLabel(record)"
+              class="h-full w-full object-cover"
+              loading="lazy"
+            />
+            <Icon
+              v-else
+              :name="activeType?.icon || 'kind-icon:blueprint'"
+              class="h-5 w-5 text-base-content/30"
+            />
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <span class="block truncate text-sm font-bold text-base-content">
+              {{ store.sourceLabel(record) }}
+            </span>
+            <span
+              v-if="subtitle(record)"
+              class="line-clamp-2 text-xs text-base-content/55"
+            >
+              {{ subtitle(record) }}
+            </span>
+            <span class="text-[10px] uppercase tracking-wide text-base-content/35">
+              #{{ record.id }}
+            </span>
+          </div>
         </button>
       </div>
     </div>
@@ -114,5 +133,18 @@ function subtitle(record: SourceRecord): string {
   if (!field) return ''
   const value = record[field]
   return typeof value === 'string' ? value : ''
+}
+
+// Resolve a record's existing art for the source thumbnail, checking the common
+// direct fields then the linked ArtImage.
+function recordImage(record: SourceRecord): string {
+  const art = record.ArtImage as { thumbnailPath?: string; imagePath?: string } | undefined
+  const candidate =
+    (record.imagePath as string) ||
+    (record.avatarImage as string) ||
+    art?.thumbnailPath ||
+    art?.imagePath ||
+    ''
+  return typeof candidate === 'string' ? candidate : ''
 }
 </script>

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -79,6 +79,7 @@ export interface BuildRun {
   sourceType: SourceTypeKey
   sourceId: number
   sourceLabel: string
+  sourceSnapshot: Record<string, unknown> | null
   recipeKey: RecipeKey
   items: BuildItem[]
 }
@@ -140,6 +141,7 @@ interface ServerRun {
   sourceType: string
   sourceId: number
   sourceLabel: string | null
+  sourceSnapshot: unknown
   recipeKey: string
   Items: ServerItem[]
 }
@@ -246,6 +248,10 @@ function adaptRun(server: ServerRun): BuildRun {
     sourceType: server.sourceType as SourceTypeKey,
     sourceId: server.sourceId,
     sourceLabel: server.sourceLabel ?? '',
+    sourceSnapshot:
+      server.sourceSnapshot && typeof server.sourceSnapshot === 'object'
+        ? (server.sourceSnapshot as Record<string, unknown>)
+        : null,
     recipeKey: server.recipeKey as RecipeKey,
     items: Array.isArray(server.Items) ? server.Items.map(adaptItem) : [],
   }


### PR DESCRIPTION
Two usage-driven UX wins from live testing:

- **Source picker thumbnails** — each record now shows its existing art (`imagePath` / `avatarImage` / linked `ArtImage`), with an icon fallback, so you can recognize what you're building from.
- **Run source-context card** — the build-run view shows the source record's art plus its description/pitch/backstory, so you can see *what you already have* before generating. Sourced from the run's server-side `sourceSnapshot` (so it survives resume/other devices), with the freshly-picked record as fallback. Plumbed `sourceSnapshot` through `BuildRun`/`adaptRun`.

Additive UI; no schema.

## Verification
CI: `vue-tsc` + Vercel preview. Post-merge: source cards show art; the run header shows the source record's art + description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_