### PR TITLE
Model Builder: model-aware fields + grounded drafting (t-024)

### DIFF
--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -16,6 +16,9 @@ type RunItemInput = {
   generation?: unknown
   quantityIndex?: unknown
   stageStatuses?: unknown
+  pitch?: unknown
+  fieldsDraft?: unknown
+  promptDraft?: unknown
 }
 
 type RunCreateBody = {
@@ -80,6 +83,9 @@ export default defineEventHandler(async (event) => {
           ? (item.stageStatuses as Prisma.InputJsonValue)
           : ({} as Prisma.InputJsonValue)
 
+      const text = (value: unknown): string | null =>
+        typeof value === 'string' && value.trim() ? value : null
+
       return {
         outputKey,
         label:
@@ -92,6 +98,9 @@ export default defineEventHandler(async (event) => {
             ? Number(item.quantityIndex)
             : 0,
         stageStatuses,
+        pitch: text(item.pitch),
+        fieldsDraft: text(item.fieldsDraft),
+        promptDraft: text(item.promptDraft),
       }
     })
 

--- a/server/utils/suggest/sheets/modelBuilderSuggest.ts
+++ b/server/utils/suggest/sheets/modelBuilderSuggest.ts
@@ -22,6 +22,8 @@ function buildSourceContext(context: Record<string, unknown>): string[] {
   push('Output', context.output)
   push('Item', context.itemLabel)
   push('Action', context.action)
+  push('Target model', context.targetModel)
+  push('Fields to fill', context.expectedFields)
 
   const source =
     context.source && typeof context.source === 'object'
@@ -86,7 +88,7 @@ Rules:
     pitch:
       'Write a concise 2–3 sentence pitch for this output — why it exists for the source record and what it should convey. Ground it in the source canon.',
     fields:
-      'Propose the concrete schema fields and relationships this output should write, as short "field: value" lines that fit the source model and stay true to its canon.',
+      'Fill in the target model as concrete "field: value" lines, one per line, using every field in "Fields to fill" (respect required fields and pick a valid option for choice fields). Invent a specific, characterful record grounded in the source canon — real names and effects, not vague summaries.',
     artPrompt:
       'Write a single vivid image-generation prompt for this output, grounded in the source record\'s look and canon. Comma-separated descriptors, no sentences.',
   },

--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -1,0 +1,143 @@
+// /stores/helpers/modelBuilderFields.ts
+//
+// Per-model field knowledge for the Model Builder: what fields each target model
+// needs, which are required, sensible defaults, and choice pools. Grounded in the
+// Prisma schema + the existing builder card configs (registerBuilderStore /
+// *Cards). Used to auto-fill the FIELDS stage and to ground AI drafting so a
+// created record comes out complete and specific (a Reward gets a real
+// type/rarity/effect) instead of a generic sentence.
+
+import type { SourceTypeKey } from '@/stores/helpers/modelBuilderRecipes'
+
+export interface ModelFieldSpec {
+  key: string
+  label: string
+  required?: boolean
+  default?: string
+  choices?: string[]
+  // Longer free-text fields the AI should write prose for.
+  prose?: boolean
+}
+
+const RARITY = ['COMMON', 'UNCOMMON', 'RARE', 'EPIC', 'LEGENDARY', 'MYTHIC']
+const REWARD_TYPES = ['ITEM', 'PET', 'SKILL', 'POWER', 'MAGIC', 'FAVOR']
+const BOT_TYPES = ['CHATBOT', 'PROMPTBOT', 'ARTBOT']
+const DREAM_TYPES = [
+  'ART',
+  'BRAINSTORM',
+  'CHARACTER',
+  'REWARD',
+  'SCENARIO',
+  'LOCATION',
+  'PITCH',
+  'WISH',
+]
+
+// Keyed by the model type (matches SourceTypeKey / the CREATE target types).
+export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
+  Character: [
+    { key: 'name', label: 'Name', required: true },
+    { key: 'class', label: 'Class' },
+    { key: 'species', label: 'Species' },
+    { key: 'honorific', label: 'Honorific', default: 'adventurer' },
+    { key: 'personality', label: 'Personality', prose: true },
+    { key: 'backstory', label: 'Backstory', prose: true },
+    { key: 'quirks', label: 'Quirks', prose: true },
+    { key: 'charm', label: 'Charm', default: 'COMMON', choices: RARITY },
+    { key: 'empathy', label: 'Empathy', default: 'COMMON', choices: RARITY },
+    { key: 'grace', label: 'Grace', default: 'COMMON', choices: RARITY },
+    { key: 'luck', label: 'Luck', default: 'COMMON', choices: RARITY },
+    { key: 'might', label: 'Might', default: 'COMMON', choices: RARITY },
+    { key: 'wits', label: 'Wits', default: 'COMMON', choices: RARITY },
+  ],
+  Bot: [
+    { key: 'name', label: 'Name', required: true },
+    { key: 'botType', label: 'Bot type', default: 'CHATBOT', choices: BOT_TYPES },
+    { key: 'subtitle', label: 'Subtitle' },
+    { key: 'description', label: 'Description', prose: true },
+    { key: 'personality', label: 'Personality' },
+    { key: 'botIntro', label: 'Bot intro', prose: true },
+    { key: 'userIntro', label: 'User intro', prose: true },
+    { key: 'prompt', label: 'System prompt', prose: true },
+  ],
+  Reward: [
+    { key: 'name', label: 'Name', required: true },
+    { key: 'rewardType', label: 'Type', required: true, default: 'ITEM', choices: REWARD_TYPES },
+    { key: 'rarity', label: 'Rarity', default: 'COMMON', choices: RARITY },
+    { key: 'effect', label: 'Effect', required: true, prose: true },
+    { key: 'description', label: 'Description', prose: true },
+    { key: 'flavorText', label: 'Flavor text', prose: true },
+    { key: 'collection', label: 'Collection' },
+  ],
+  Dream: [
+    { key: 'title', label: 'Title', required: true },
+    { key: 'dreamType', label: 'Type', default: 'PITCH', choices: DREAM_TYPES },
+    { key: 'pitch', label: 'Pitch', prose: true },
+    { key: 'description', label: 'Description', prose: true },
+    { key: 'flavorText', label: 'Flavor text', prose: true },
+    { key: 'examples', label: 'Examples (pipe-separated)' },
+  ],
+  Scenario: [
+    { key: 'title', label: 'Title', required: true },
+    { key: 'description', label: 'Description', required: true, prose: true },
+    { key: 'intros', label: 'Intros', required: true, prose: true },
+    { key: 'difficulty', label: 'Difficulty' },
+    { key: 'locations', label: 'Locations' },
+    { key: 'inspirations', label: 'Inspirations' },
+  ],
+  Project: [
+    { key: 'title', label: 'Title', required: true },
+    { key: 'description', label: 'Description', prose: true },
+    { key: 'pitch', label: 'Pitch', prose: true },
+    { key: 'goal', label: 'Goal', prose: true },
+  ],
+  Facet: [
+    { key: 'title', label: 'Title', required: true },
+    { key: 'kind', label: 'Kind', default: 'OTHER' },
+    { key: 'description', label: 'Description', prose: true },
+    { key: 'examples', label: 'Examples' },
+  ],
+}
+
+export function fieldSpecFor(modelType: string): ModelFieldSpec[] {
+  return MODEL_FIELDS[modelType] ?? []
+}
+
+// A pre-filled "key: value" skeleton for the FIELDS stage — required fields and
+// any with a default, so the editor starts populated rather than blank. The user
+// fills the rest (or AI-drafts them), and can toggle in optional fields.
+export function defaultFieldsTemplate(modelType: string): string {
+  const spec = fieldSpecFor(modelType)
+  if (!spec.length) return ''
+  return spec
+    .filter((field) => field.required || field.default)
+    .map((field) => `${field.key}: ${field.default ?? ''}`)
+    .join('\n')
+}
+
+// A compact human/LLM-readable description of the target model's fields, fed into
+// the draft context so a generated record is complete and uses valid choices.
+export function fieldsBrief(modelType: string): string {
+  const spec = fieldSpecFor(modelType)
+  if (!spec.length) return ''
+  return spec
+    .map((field) => {
+      const parts = [field.key]
+      if (field.required) parts.push('(required)')
+      if (field.choices) parts.push(`one of: ${field.choices.join('/')}`)
+      else if (field.default) parts.push(`default ${field.default}`)
+      return parts.join(' ')
+    })
+    .join('; ')
+}
+
+// Which model a build item ultimately writes to. CREATE items target the mapped
+// expansion type; UPDATE/ASSET_ONLY items target the run's source model.
+export const CREATE_TARGETS: Record<string, SourceTypeKey> = {
+  'expand-characters': 'Character',
+  'expand-signature-rewards': 'Reward',
+  'expand-rewards': 'Reward',
+  'expand-scenarios': 'Scenario',
+  'expand-manager-bot': 'Bot',
+  'expand-narrator-bot': 'Bot',
+}

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -32,6 +32,11 @@ import {
   type RecipeKey,
   type SourceTypeKey,
 } from '@/stores/helpers/modelBuilderRecipes'
+import {
+  CREATE_TARGETS,
+  defaultFieldsTemplate,
+  fieldsBrief,
+} from '@/stores/helpers/modelBuilderFields'
 
 export type BuilderStep = 'source' | 'recipe' | 'run'
 
@@ -206,6 +211,17 @@ function normalizeStages(raw: unknown): Record<BuildStageKey, StageState> {
 
 function stageIndex(key: BuildStageKey): number {
   return BUILD_STAGES.findIndex((stage) => stage.key === key)
+}
+
+// Which model an item ultimately writes to: CREATE items target the mapped
+// expansion type; UPDATE/ASSET_ONLY items target the run's source model.
+function resolveTargetModel(
+  action: BuildAction,
+  outputKey: string,
+  sourceType: SourceTypeKey,
+): SourceTypeKey {
+  if (action === 'CREATE') return CREATE_TARGETS[outputKey] ?? sourceType
+  return sourceType
 }
 
 // Turn a catalog size ('256×256', '512×768', 'square', undefined) into pixel
@@ -413,10 +429,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       return
     }
 
+    const runSourceType = state.sourceType
     const itemsPayload: Array<Record<string, unknown>> = []
     for (const output of recipeOutputs.value) {
       const selection = state.selections[output.key]
       if (!selection?.on) continue
+
+      // Model-aware pre-fill: CREATE/UPDATE items start with the target model's
+      // required/defaulted fields as a skeleton, so FIELDS isn't a blank box.
+      const targetModel = resolveTargetModel(
+        output.action,
+        output.key,
+        runSourceType,
+      )
+      const fieldsDraft =
+        output.action === 'ASSET_ONLY' ? '' : defaultFieldsTemplate(targetModel)
 
       const count = output.quantity ? selection.quantity : 1
       for (let index = 0; index < count; index++) {
@@ -427,6 +454,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           generation: output.generation,
           quantityIndex: index,
           stageStatuses: freshStages(),
+          fieldsDraft,
         })
       }
     }
@@ -593,6 +621,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const item = findItem(itemId)
     if (!item || !state.run) return false
 
+    const targetModel = resolveTargetModel(
+      item.action,
+      item.outputKey,
+      state.run.sourceType,
+    )
+
     const serverStore = useServerStore()
     const activeServer = serverStore.activeTextServer
     const serverSnapshot = activeServer
@@ -633,6 +667,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
               output: item.outputKey,
               itemLabel: item.label,
               action: item.action,
+              targetModel,
+              expectedFields: fieldsBrief(targetModel),
               pitch: item.pitch,
               fields: item.fieldsDraft,
               source: state.selectedSource ?? undefined,


### PR DESCRIPTION
Fixes the bland-draft problem (the reward that came back as "enhance the project…") by making the builder know each model's fields.

- **`stores/helpers/modelBuilderFields.ts`** — per-model field spec (required/optional, defaults, choice pools for Rarity/RewardType/BotType/DreamType) grounded in the schema + builder card configs. The single source of field truth for the Model Builder.
- **Store** — CREATE/UPDATE items start with the target model's required/defaulted fields **pre-filled** (FIELDS isn't a blank box); the create route accepts per-item `pitch`/`fieldsDraft`/`promptDraft`; `draftText` passes the **target model + its field brief** into the suggest context.
- **Suggest sheet** — surfaces "Target model" + "Fields to fill" and instructs the model to produce a **full, specific record** (a Reward gets name/type/rarity/effect) using valid choices.

**Scoped deliberately:** this makes the *drafts* rich and correct. Persisting those drafted `field: value` lines as real DB columns on commit is a tracked follow-up (t-028) — it's a prod-write I don't want to ship untested overnight. No schema.

## Verification
CI: `vue-tsc` + Vercel preview. Post-merge: drafting fields for a Reward returns a complete record with a real type/rarity/effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_