### PR TITLE
Model Builder: auto-build "just create it" + art toggle (t-026)

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -8,6 +8,19 @@
       <h4 class="text-sm font-black text-base-content">{{ item.label }}</h4>
       <span class="badge badge-sm badge-ghost">{{ item.action }}</span>
       <span class="badge badge-sm badge-ghost">{{ item.generation }}</span>
+      <button
+        type="button"
+        class="btn btn-xs btn-ghost ml-auto gap-1 rounded-lg text-primary"
+        :disabled="isAutoBuilding"
+        title="Draft, generate, and commit this item automatically"
+        @click="store.autoBuildItem(item.id)"
+      >
+        <span v-if="isAutoBuilding" class="loading loading-dots loading-xs" />
+        <template v-else>
+          <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
+          Auto
+        </template>
+      </button>
     </div>
 
     <p
@@ -309,6 +322,7 @@ watch(
 
 const isGenerating = computed(() => store.generatingItemId === props.itemId)
 const isCommitting = computed(() => store.committingItemId === props.itemId)
+const isAutoBuilding = computed(() => store.autoBuildingItemId === props.itemId)
 
 function isDrafting(field: DraftField): boolean {
   return (

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -10,14 +10,29 @@
           {{ store.runProgress.committed }}/{{ store.runProgress.total }} committed
         </p>
       </div>
-      <button
-        type="button"
-        class="btn btn-xs btn-ghost shrink-0 rounded-xl text-base-content/60"
-        @click="store.resetRun()"
-      >
-        <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
-        New run
-      </button>
+      <div class="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          class="btn btn-xs btn-primary rounded-xl"
+          :disabled="store.autoBuilding"
+          title="Draft, generate, and commit every item automatically"
+          @click="store.autoBuildRun()"
+        >
+          <span v-if="store.autoBuilding" class="loading loading-dots loading-xs" />
+          <template v-else>
+            <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
+            Auto-build all
+          </template>
+        </button>
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost rounded-xl text-base-content/60"
+          @click="store.resetRun()"
+        >
+          <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+          New run
+        </button>
+      </div>
     </div>
 
     <!-- Source context: what we already have on the record we're building from -->

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -108,11 +108,24 @@
 
     <!-- Footer -->
     <div
-      class="flex shrink-0 items-center justify-between gap-2 border-t border-base-300 pt-2"
+      class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-base-300 pt-2"
     >
-      <span class="text-xs text-base-content/60">
-        {{ store.selectedOutputCount }} output{{ store.selectedOutputCount === 1 ? '' : 's' }} selected
-      </span>
+      <div class="flex items-center gap-3">
+        <span class="text-xs text-base-content/60">
+          {{ store.selectedOutputCount }} output{{ store.selectedOutputCount === 1 ? '' : 's' }} selected
+        </span>
+        <label
+          class="flex cursor-pointer items-center gap-1.5 text-xs text-base-content/70"
+        >
+          <input
+            type="checkbox"
+            class="checkbox checkbox-xs checkbox-primary"
+            :checked="store.includeArt"
+            @change="onIncludeArt($event)"
+          />
+          Include art
+        </label>
+      </div>
       <button
         type="button"
         class="btn btn-primary btn-sm rounded-xl"
@@ -145,6 +158,10 @@ const sourceLabel = computed(() => store.sourceLabel(store.selectedSource))
 function onQuantity(key: string, event: Event): void {
   const value = Number((event.target as HTMLInputElement).value)
   store.setOutputQuantity(key, value)
+}
+
+function onIncludeArt(event: Event): void {
+  store.toggleIncludeArt((event.target as HTMLInputElement).checked)
 }
 
 function actionBadge(action: BuildAction): string {

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -107,8 +107,11 @@ interface ModelBuilderState {
   runs: BuildRun[]
   loadingRuns: boolean
   startingRun: boolean
+  includeArt: boolean
   generatingItemId: string | null
   committingItemId: string | null
+  autoBuilding: boolean
+  autoBuildingItemId: string | null
   statusMessage: string
   statusTone: 'success' | 'error'
 }
@@ -287,8 +290,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     runs: [],
     loadingRuns: false,
     startingRun: false,
+    includeArt: true,
     generatingItemId: null,
     committingItemId: null,
+    autoBuilding: false,
+    autoBuildingItemId: null,
     statusMessage: '',
     statusTone: 'success',
   })
@@ -895,6 +901,87 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
+  // --- auto-build: walk an item (or the whole run) to completion ------------
+
+  function toggleIncludeArt(value?: boolean): void {
+    state.includeArt = typeof value === 'boolean' ? value : !state.includeArt
+  }
+
+  // Run one item through every gate automatically with sensible defaults: draft
+  // what's empty, generate art only when wanted, and commit. "Create directly"
+  // for CREATE/UPDATE items when art is off. Returns whether it committed.
+  async function autoBuildItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    const isAsset = item.action === 'ASSET_ONLY'
+    const wantArt = state.includeArt && item.generation === 'image'
+
+    // An ASSET_ONLY item is nothing but its art — can't auto-build without it.
+    if (isAsset && !wantArt) {
+      setStatus(
+        'error',
+        `${item.label} is asset-only — enable art to auto-build it.`,
+      )
+      return false
+    }
+
+    state.autoBuildingItemId = item.id
+    try {
+      if (item.stages.PITCH.status !== 'approved') {
+        if (!item.pitch.trim()) await draftText(itemId, 'pitch')
+        approveStage(itemId, 'PITCH')
+      }
+
+      if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
+        if (!isAsset) await draftText(itemId, 'fields')
+        if (wantArt) await draftText(itemId, 'artPrompt')
+        approveStage(itemId, 'FIELDS_AND_PROMPTS')
+      }
+
+      if (item.stages.GENERATE_ASSETS.status !== 'approved') {
+        if (wantArt) {
+          const generated = await generateItemAsset(itemId)
+          if (!generated) return false
+        }
+        approveStage(itemId, 'GENERATE_ASSETS')
+      }
+
+      if (item.stages.COMMIT.status !== 'approved') {
+        return await commitItem(itemId)
+      }
+      return true
+    } finally {
+      state.autoBuildingItemId = null
+    }
+  }
+
+  // Auto-build every not-yet-committed item in the run, in order.
+  async function autoBuildRun(): Promise<void> {
+    if (!state.run || state.autoBuilding) return
+    state.autoBuilding = true
+    clearStatus()
+
+    const items = [...state.run.items]
+    let committed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          continue
+        }
+        const ok = await autoBuildItem(item.id)
+        if (ok) committed++
+      }
+      setStatus(
+        'success',
+        `Auto-build finished: ${committed}/${items.length} committed.`,
+      )
+    } finally {
+      state.autoBuilding = false
+    }
+  }
+
   // --- persistence / resume -------------------------------------------------
 
   function setActiveRunId(id: number): void {
@@ -1062,6 +1149,9 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     generateItemAsset,
     previewCommit,
     commitItem,
+    toggleIncludeArt,
+    autoBuildItem,
+    autoBuildRun,
     resumeRun,
     fetchRuns,
     openRun,


### PR DESCRIPTION
The "let me just create the objects/art directly without walking every gate" flow you asked for.

- **Store** — an `includeArt` run toggle (off = create records only, faster), plus `autoBuildItem` / `autoBuildRun`: each walks an item through **every gate automatically** with defaults — draft what's empty, generate art only when wanted (skipped for text CREATE items and when the toggle is off), then commit. ASSET_ONLY items are pure art, so they're skipped when art is off.
- **UI** — "Include art" checkbox in the recipe selector; **"Auto-build all"** in the run header; a per-item **"Auto"** button. Spinners via `autoBuilding`/`autoBuildingItemId`.

Reuses the existing gate actions (draft → approve → generate → commit) and the idempotent executor, so it's safe and re-runnable. No new backend, no schema.

## Verification
CI: `vue-tsc` + Vercel preview. Post-merge: with "Include art" off, "Auto-build all" creates the records directly; with it on, it also generates and promotes art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbhpteYPDaPKFUxiimztF)_