### PR TITLE
Adapt startup butterflies to device performance

### DIFF
--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -3,6 +3,8 @@
     <loading-messages
       v-if="showOverlay"
       :stores-ready="storesReady"
+      @covered="handleOverlayCovered"
+      @hiding="handleOverlayHiding"
       @hidden="handleOverlayHidden"
     />
   </div>
@@ -34,6 +36,7 @@ import { useNavStore } from '@/stores/navStore'
 import { useServerStore } from '@/stores/serverStore'
 import { useCheckpointStore } from '@/stores/checkpointStore'
 import { useThemeStore } from '@/stores/themeStore'
+import { useButterflyStore } from '@/stores/butterflyStore'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
 
 const errorStore = useErrorStore()
@@ -59,6 +62,7 @@ const componentStore = useComponentStore()
 const randomStore = useRandomStore()
 const navStore = useNavStore()
 const themeStore = useThemeStore()
+const butterflyStore = useButterflyStore()
 
 const emit = defineEmits<{
   covered: []
@@ -77,6 +81,10 @@ function handleOverlayCovered() {
   emit('covered')
 }
 
+function handleOverlayHiding() {
+  butterflyStore.setShowSwarm(false)
+}
+
 function emitReadyOnce() {
   if (pageReadyEmitted.value) return
   pageReadyEmitted.value = true
@@ -89,8 +97,6 @@ function handleOverlayHidden() {
   emitReadyOnce()
 }
 
-// Run a batch of store inits in parallel. allSettled (not all) so one
-// rejecting store never aborts its siblings or the rest of the boot.
 async function runWave(
   label: string,
   tasks: Array<Promise<unknown> | void | undefined>,
@@ -117,8 +123,6 @@ async function runWave(
 }
 
 async function initializeServerAndCheckpoints() {
-  // Servers must fully load before checkpoints can resolve their active server.
-  // This is the single place both are initialized — galleries must not re-fetch.
   await errorStore.handleError(
     async () => {
       if (
@@ -133,7 +137,6 @@ async function initializeServerAndCheckpoints() {
     'Error initializing server store',
   )
 
-  // Checkpoints depend on servers being present so they can resolve activeArtServer.
   await errorStore.handleError(
     async () => {
       checkpointStore.initialize()
@@ -145,8 +148,6 @@ async function initializeServerAndCheckpoints() {
 
 async function initializeStores() {
   try {
-    // Synchronous, order-independent: only touches the module-level builder
-    // registry. Done first so any builder UI in the first paint has configs.
     ensureBuildersRegistered()
 
     if (!displayStore.isInitialized) {
@@ -157,8 +158,6 @@ async function initializeStores() {
       )
     }
 
-    // First wave: user identity (session-restore from stored token) and UI
-    // chrome. Everything downstream depends on these.
     await runWave('identity + chrome', [
       userStore.initialize?.(),
       pageStore.initialize?.(),
@@ -169,17 +168,14 @@ async function initializeStores() {
       themeStore.initialize({ fetchShared: true }),
     ])
 
-    // Servers + checkpoints are sequential: checkpoints need a loaded server array.
     await initializeServerAndCheckpoints()
 
-    // Second wave: content stores that may reference servers but don't block server init.
     await runWave('content stores', [
       artStore.initialize?.(),
       botStore.initialize?.(),
       chatStore.initialize?.(),
     ])
 
-    // Third wave: everything else.
     await runWave('remaining stores', [
       characterStore.initialize?.(),
       promptStore.initialize?.(),

--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -97,6 +97,8 @@ function handleOverlayHidden() {
   emitReadyOnce()
 }
 
+// Run a batch of store inits in parallel. allSettled (not all) so one
+// rejecting store never aborts its siblings or the rest of the boot.
 async function runWave(
   label: string,
   tasks: Array<Promise<unknown> | void | undefined>,
@@ -123,6 +125,8 @@ async function runWave(
 }
 
 async function initializeServerAndCheckpoints() {
+  // Servers must fully load before checkpoints can resolve their active server.
+  // This is the single place both are initialized — galleries must not re-fetch.
   await errorStore.handleError(
     async () => {
       if (
@@ -137,6 +141,7 @@ async function initializeServerAndCheckpoints() {
     'Error initializing server store',
   )
 
+  // Checkpoints depend on servers being present so they can resolve activeArtServer.
   await errorStore.handleError(
     async () => {
       checkpointStore.initialize()
@@ -148,6 +153,8 @@ async function initializeServerAndCheckpoints() {
 
 async function initializeStores() {
   try {
+    // Synchronous, order-independent: only touches the module-level builder
+    // registry. Done first so any builder UI in the first paint has configs.
     ensureBuildersRegistered()
 
     if (!displayStore.isInitialized) {
@@ -158,6 +165,8 @@ async function initializeStores() {
       )
     }
 
+    // First wave: user identity (session-restore from stored token) and UI
+    // chrome. Everything downstream depends on these.
     await runWave('identity + chrome', [
       userStore.initialize?.(),
       pageStore.initialize?.(),
@@ -168,14 +177,17 @@ async function initializeStores() {
       themeStore.initialize({ fetchShared: true }),
     ])
 
+    // Servers + checkpoints are sequential: checkpoints need a loaded server array.
     await initializeServerAndCheckpoints()
 
+    // Second wave: content stores that may reference servers but don't block server init.
     await runWave('content stores', [
       artStore.initialize?.(),
       botStore.initialize?.(),
       chatStore.initialize?.(),
     ])
 
+    // Third wave: everything else.
     await runWave('remaining stores', [
       characterStore.initialize?.(),
       promptStore.initialize?.(),

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -5,23 +5,44 @@
     :class="{ 'loading-overlay--fade': fadeOverlay }"
     @transitionend="handleTransitionEnd"
   >
-    <Icon name="kind-icon:bubble-loading" class="bubble-loader" />
-    <transition name="loader-message" mode="out-in">
-      <div :key="messageKey" class="loading-message">
-        {{ currentMessage }}
-      </div>
-    </transition>
+    <NuxtImg
+      src="/images/kindlogo_new.webp"
+      alt="Kind Robots"
+      class="loading-logo"
+      :width="320"
+      :height="320"
+      format="webp"
+      :quality="72"
+      preload
+      loading="eager"
+      fetchpriority="high"
+      decoding="async"
+    />
+
+    <div class="loading-status">
+      <Icon name="kind-icon:bubble-loading" class="bubble-loader" />
+
+      <transition name="loader-message" mode="out-in">
+        <div
+          :key="messageKey"
+          class="loading-message"
+          aria-live="polite"
+        >
+          {{ currentMessage }}
+        </div>
+      </transition>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// /components/content/story/loading-messages.vue
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useLoadStore } from '../../stores/loadStore'
 
 const props = defineProps<{ storesReady: boolean }>()
 const emit = defineEmits<{
   covered: []
+  hiding: []
   hidden: []
 }>()
 
@@ -32,12 +53,12 @@ const messageKey = ref(0)
 const fadeOverlay = ref(false)
 const minimumSequenceComplete = ref(false)
 
-const FIRST_MESSAGE_MS = 1100
-const SECOND_MESSAGE_LEAD_MS = 900
-const ROTATING_MESSAGE_MS = 1300
-const READY_HOLD_MS = 700
-const MIN_TOTAL_MS = 2600
-const OVERLAY_FADE_MS = 950
+const FIRST_MESSAGE_MS = 850
+const SLOW_LOAD_MESSAGE_MS = 1500
+const ROTATING_MESSAGE_MS = 1600
+const READY_HOLD_MS = 250
+const MIN_TOTAL_MS = 1650
+const OVERLAY_FADE_MS = 650
 
 const startTime = Date.now()
 
@@ -72,7 +93,9 @@ function clearRotation() {
 function doFade() {
   if (destroyed || fadeOverlay.value) return
 
+  clearRotation()
   loadStore.revealDesktop()
+  emit('hiding')
   fadeOverlay.value = true
 
   if (fallbackFadeTimeoutId) {
@@ -110,11 +133,6 @@ async function runVisualSequence() {
   await wait(FIRST_MESSAGE_MS)
   if (destroyed) return
 
-  nextMessage()
-
-  await wait(SECOND_MESSAGE_LEAD_MS)
-  if (destroyed) return
-
   minimumSequenceComplete.value = true
 
   if (props.storesReady) {
@@ -122,6 +140,10 @@ async function runVisualSequence() {
     return
   }
 
+  await wait(SLOW_LOAD_MESSAGE_MS)
+  if (destroyed || props.storesReady || fadeOverlay.value) return
+
+  nextMessage()
   rotationIntervalId = setInterval(() => {
     if (destroyed) return
     nextMessage()
@@ -174,10 +196,11 @@ onBeforeUnmount(() => {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 1.25rem;
+  gap: 0.75rem;
+  padding: 1.5rem;
   background: #000;
   opacity: 1;
-  transition: opacity 0.95s ease;
+  transition: opacity 0.65s ease;
   pointer-events: auto;
   contain: layout paint style;
   will-change: opacity;
@@ -188,39 +211,53 @@ onBeforeUnmount(() => {
   pointer-events: none;
 }
 
+.loading-logo {
+  width: clamp(9rem, 24vw, 14rem);
+  height: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 0.9rem 1.8rem rgba(255, 255, 255, 0.16));
+}
+
+.loading-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .loading-message {
   max-width: min(90vw, 44rem);
-  min-height: 4.5rem;
+  min-height: 3.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.85rem 1.35rem;
-  background: rgba(0, 0, 0, 0.85);
+  padding: 0.65rem 1.2rem;
+  background: rgba(0, 0, 0, 0.78);
   color: #ffffff;
-  font-size: clamp(1.1rem, 2vw, 2rem);
+  font-size: clamp(1.05rem, 2vw, 1.75rem);
   font-weight: 700;
   text-align: center;
-  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.42);
   will-change: transform, opacity;
   transform: translateZ(0);
 }
 
 .bubble-loader {
-  font-size: clamp(4rem, 10vw, 6rem);
+  font-size: clamp(2.5rem, 6vw, 4rem);
   color: #ffffff;
-  filter: drop-shadow(0 0 0.75rem rgba(255, 255, 255, 0.25));
+  filter: drop-shadow(0 0 0.75rem rgba(255, 255, 255, 0.22));
 }
 
 .loader-message-enter-active,
 .loader-message-leave-active {
   transition:
-    opacity 0.24s ease,
-    transform 0.24s ease;
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .loader-message-enter-from,
 .loader-message-leave-to {
   opacity: 0;
-  transform: translateY(6px);
+  transform: translateY(5px);
 }
 </style>

--- a/components/screenfx/butterfly-animation.vue
+++ b/components/screenfx/butterfly-animation.vue
@@ -1,27 +1,405 @@
 <!-- /components/content/screenfx/butterfly-animation.vue -->
 <template>
   <div
-    class="pointer-events-none fixed inset-0 z-50 h-dvh w-dvw overflow-hidden"
+    ref="stage"
+    class="butterfly-animation pointer-events-none fixed inset-0 z-50 h-dvh w-dvw overflow-hidden"
+    :class="`butterfly-animation--${profile.name}`"
+    :data-butterfly-quality="profile.name"
+    aria-hidden="true"
   >
-    <ami-butterfly
-      v-for="i in butterflyCount"
-      :key="i"
-      class="pointer-events-none"
-    />
+    <div
+      v-for="butterfly in butterflies"
+      :key="butterfly.id"
+      class="butterfly"
+    >
+      <div class="left-wing" :style="butterfly.wingStyle" />
+      <div class="right-wing" :style="butterfly.wingStyle" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
+import type { CSSProperties } from 'vue'
+import { useButterflyStore } from '@/stores/butterflyStore'
 
-const butterflyCount = ref(20)
+type PerformanceProfileName = 'off' | 'low' | 'balanced' | 'high' | 'ultra'
+
+interface PerformanceProfile {
+  name: PerformanceProfileName
+  count: number
+  fps: number
+  size: number
+  speed: number
+}
+
+interface ButterflyParticle {
+  id: number
+  x: number
+  y: number
+  angle: number
+  speed: number
+  turnRate: number
+  phase: number
+  bob: number
+  scale: number
+  wingStyle: CSSProperties
+}
+
+interface NavigatorConnectionHints {
+  saveData?: boolean
+  effectiveType?: string
+}
+
+interface NavigatorPerformanceHints extends Navigator {
+  deviceMemory?: number
+  connection?: NavigatorConnectionHints
+}
+
+const PROFILES: Record<PerformanceProfileName, PerformanceProfile> = {
+  off: { name: 'off', count: 0, fps: 0, size: 0, speed: 0 },
+  low: { name: 'low', count: 5, fps: 24, size: 1.2, speed: 0.68 },
+  balanced: { name: 'balanced', count: 24, fps: 30, size: 0.82, speed: 0.86 },
+  high: { name: 'high', count: 56, fps: 45, size: 0.58, speed: 1 },
+  ultra: { name: 'ultra', count: 100, fps: 60, size: 0.42, speed: 1.08 },
+}
+
+const PROFILE_ORDER: PerformanceProfileName[] = [
+  'off',
+  'low',
+  'balanced',
+  'high',
+  'ultra',
+]
+
+const butterflyStore = useButterflyStore()
+const stage = ref<HTMLElement | null>(null)
+const profile = ref<PerformanceProfile>(PROFILES.balanced)
+const butterflies = shallowRef<ButterflyParticle[]>([])
+
+let butterflyElements: HTMLElement[] = []
+let animationFrameId: number | null = null
+let lastAnimationTime = 0
+let lastRafTime = 0
+let viewportWidth = 0
+let viewportHeight = 0
+let frameSamples: number[] = []
+let hasBenchmarked = false
+let rebuilding = false
+
+function randomRange(min: number, max: number): number {
+  return Math.random() * (max - min) + min
+}
+
+function detectPerformanceProfile(): PerformanceProfileName {
+  const navigatorHints = navigator as NavigatorPerformanceHints
+  const connection = navigatorHints.connection
+  const cores = navigatorHints.hardwareConcurrency || 0
+  const memory = navigatorHints.deviceMemory
+  const reducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)',
+  ).matches
+
+  if (reducedMotion || connection?.saveData) return 'off'
+  if (connection?.effectiveType === 'slow-2g') return 'off'
+  if (cores > 0 && cores <= 2 && (memory === undefined || memory <= 2)) {
+    return 'off'
+  }
+
+  let score = 2
+
+  if (cores >= 12) score += 2
+  else if (cores >= 8) score += 1
+  else if (cores > 0 && cores <= 4) score -= 1
+
+  if (memory !== undefined) {
+    if (memory >= 8) score += 1
+    else if (memory <= 2) score -= 2
+    else if (memory <= 4) score -= 1
+  }
+
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
+  const pixelLoad = window.innerWidth * window.innerHeight * pixelRatio ** 2
+
+  if (pixelLoad >= 16_000_000) score -= 2
+  else if (pixelLoad >= 8_000_000) score -= 1
+
+  if (connection?.effectiveType === '2g') score -= 1
+
+  if (score >= 5) return 'ultra'
+  if (score >= 3) return 'high'
+  if (score >= 2) return 'balanced'
+  return 'low'
+}
+
+function createParticle(
+  index: number,
+  activeProfile: PerformanceProfile,
+): ButterflyParticle {
+  const primaryColor = butterflyStore.randomColor()
+  const secondaryColor =
+    Math.random() > 0.5
+      ? butterflyStore.complementaryColor(primaryColor)
+      : butterflyStore.analogousColor(primaryColor)
+  const wingSpeed = Math.round(randomRange(360, 680))
+
+  return {
+    id: index,
+    x: randomRange(0, viewportWidth),
+    y: randomRange(0, viewportHeight),
+    angle: randomRange(0, Math.PI * 2),
+    speed: randomRange(24, 58) * activeProfile.speed,
+    turnRate: randomRange(0.3, 0.9),
+    phase: randomRange(0, Math.PI * 2),
+    bob: randomRange(5, 14),
+    scale: activeProfile.size * randomRange(0.72, 1.18),
+    wingStyle: {
+      background: `radial-gradient(circle at 30% 28%, ${primaryColor}, ${secondaryColor} 76%)`,
+      animationDuration: `${wingSpeed}ms`,
+    },
+  }
+}
+
+function syncViewport(): void {
+  viewportWidth = window.innerWidth
+  viewportHeight = window.innerHeight
+}
+
+function cacheButterflyElements(): void {
+  butterflyElements = stage.value
+    ? Array.from(stage.value.querySelectorAll<HTMLElement>('.butterfly'))
+    : []
+}
+
+function stopAnimation(): void {
+  if (animationFrameId === null) return
+  cancelAnimationFrame(animationFrameId)
+  animationFrameId = null
+}
+
+function resetFrameTiming(): void {
+  lastAnimationTime = 0
+  lastRafTime = 0
+}
+
+function benchmarkFrame(rawDelta: number): number {
+  if (hasBenchmarked || rawDelta <= 0 || rawDelta >= 250) return 0
+
+  frameSamples.push(rawDelta)
+  if (frameSamples.length < 45) return 0
+
+  hasBenchmarked = true
+
+  const average =
+    frameSamples.reduce((total, delta) => total + delta, 0) /
+    frameSamples.length
+  const slowRatio =
+    frameSamples.filter((delta) => delta > 24).length / frameSamples.length
+
+  frameSamples = []
+
+  if (average > 34 || slowRatio > 0.4) return 2
+  if (average > 23 || slowRatio > 0.18) return 1
+  return 0
+}
+
+function getDowngradedProfile(steps: number): PerformanceProfileName {
+  const currentIndex = PROFILE_ORDER.indexOf(profile.value.name)
+  return PROFILE_ORDER[Math.max(0, currentIndex - steps)] || 'off'
+}
+
+async function applyProfile(name: PerformanceProfileName): Promise<void> {
+  if (profile.value.name === name && butterflies.value.length) return
+
+  rebuilding = true
+  stopAnimation()
+  profile.value = PROFILES[name]
+  butterflies.value = Array.from({ length: profile.value.count }, (_, index) =>
+    createParticle(index, profile.value),
+  )
+
+  await nextTick()
+  cacheButterflyElements()
+  updateParticles(performance.now(), 0)
+  resetFrameTiming()
+  rebuilding = false
+  startAnimation()
+}
+
+function updateParticles(now: number, deltaSeconds: number): void {
+  const margin = 80
+
+  for (let index = 0; index < butterflies.value.length; index += 1) {
+    const butterfly = butterflies.value[index]
+    const element = butterflyElements[index]
+    if (!butterfly || !element) continue
+
+    const wander = Math.sin(now * 0.00042 + butterfly.phase)
+    butterfly.angle += wander * butterfly.turnRate * deltaSeconds
+    butterfly.x += Math.cos(butterfly.angle) * butterfly.speed * deltaSeconds
+    butterfly.y +=
+      Math.sin(butterfly.angle) * butterfly.speed * deltaSeconds +
+      Math.sin(now * 0.0012 + butterfly.phase) *
+        butterfly.bob *
+        deltaSeconds
+
+    if (butterfly.x < -margin) butterfly.x = viewportWidth + margin
+    if (butterfly.x > viewportWidth + margin) butterfly.x = -margin
+    if (butterfly.y < -margin) butterfly.y = viewportHeight + margin
+    if (butterfly.y > viewportHeight + margin) butterfly.y = -margin
+
+    const heading = (butterfly.angle * 180) / Math.PI + 90
+    const tilt = Math.cos(butterfly.angle) >= 0 ? 118 : 32
+
+    element.style.transform = `translate3d(${butterfly.x}px, ${butterfly.y}px, 0) rotateZ(${heading}deg) rotate3d(1, 0.5, 0, ${tilt}deg) scale(${butterfly.scale})`
+  }
+}
+
+function animate(now: number): void {
+  animationFrameId = null
+
+  if (rebuilding || document.hidden || profile.value.count === 0) return
+
+  const rawDelta = lastRafTime ? now - lastRafTime : 0
+  lastRafTime = now
+
+  const downgradeSteps = benchmarkFrame(rawDelta)
+  if (downgradeSteps > 0) {
+    void applyProfile(getDowngradedProfile(downgradeSteps))
+    return
+  }
+
+  const frameInterval = 1000 / profile.value.fps
+  const elapsed = lastAnimationTime ? now - lastAnimationTime : frameInterval
+
+  if (elapsed >= frameInterval) {
+    const deltaSeconds = Math.min(elapsed, 50) / 1000
+    lastAnimationTime = now - (elapsed % frameInterval)
+    updateParticles(now, deltaSeconds)
+  }
+
+  animationFrameId = requestAnimationFrame(animate)
+}
+
+function startAnimation(): void {
+  if (
+    animationFrameId !== null ||
+    rebuilding ||
+    document.hidden ||
+    profile.value.count === 0
+  ) {
+    return
+  }
+
+  animationFrameId = requestAnimationFrame(animate)
+}
+
+function handleVisibilityChange(): void {
+  if (document.hidden) {
+    stopAnimation()
+    return
+  }
+
+  resetFrameTiming()
+  startAnimation()
+}
+
+onMounted(async () => {
+  syncViewport()
+  await applyProfile(detectPerformanceProfile())
+
+  window.addEventListener('resize', syncViewport, { passive: true })
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+})
+
+onBeforeUnmount(() => {
+  stopAnimation()
+  window.removeEventListener('resize', syncViewport)
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+})
 </script>
+
 <style scoped>
-.loading-overlay {
-  position: fixed;
-  top: 0;
+@keyframes flutter-left {
+  0%,
+  100% {
+    transform: rotateY(18deg);
+  }
+
+  50% {
+    transform: rotateY(72deg);
+  }
+}
+
+@keyframes flutter-right {
+  0%,
+  100% {
+    transform: rotateY(-18deg);
+  }
+
+  50% {
+    transform: rotateY(-72deg);
+  }
+}
+
+.butterfly-animation {
+  contain: strict;
+  transform: translateZ(0);
+}
+
+.butterfly {
+  position: absolute;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  top: 0;
+  width: 70px;
+  height: 70px;
+  opacity: 0.74;
+  pointer-events: none;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  contain: layout paint style;
+  will-change: transform;
+}
+
+.left-wing,
+.right-wing {
+  position: absolute;
+  top: 12px;
+  width: 28px;
+  height: 42px;
+  border-radius: 72% 42% 68% 38%;
+  opacity: 0.78;
+  backface-visibility: hidden;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  will-change: transform;
+}
+
+.left-wing {
+  left: 7px;
+  transform-origin: 100% 52%;
+  animation-name: flutter-left;
+}
+
+.right-wing {
+  left: 35px;
+  border-radius: 42% 72% 38% 68%;
+  transform-origin: 0 52%;
+  animation-name: flutter-right;
+}
+
+.butterfly-animation--low .left-wing,
+.butterfly-animation--low .right-wing {
+  animation-timing-function: steps(4, end);
+}
+
+.butterfly-animation--ultra .butterfly {
+  opacity: 0.68;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .butterfly {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
## What changed

- traced the startup path from `app.vue` through `kind-loader`, `loading-messages`, `butterfly-layer`, and the legacy `butterfly-animation` variant
- replaced the hard-coded 20 `ami-butterfly` instances with one shared animation loop and adaptive profiles:
  - off: 0 butterflies
  - low: 5 larger butterflies at 24 fps
  - balanced: 24 butterflies at 30 fps
  - high: 56 smaller butterflies at 45 fps
  - ultra: 100 small butterflies at 60 fps
- selects the initial profile from reduced-motion, data-saver, network hints, logical CPU count, device memory when available, and display pixel load
- samples real animation-frame timing after launch and only downgrades when the browser is struggling
- forwards the loader `covered` event so the black boot curtain no longer hides the loader for up to 1.5 seconds
- fades the butterfly swarm when the loading overlay starts fading
- adds `kindlogo_new.webp` above the loading message through `NuxtImg`, generating an optimized 320×320 WebP instead of shipping a second hand-maintained logo file
- reduces the fast-path loader from roughly 3.65 seconds to roughly 2.3 seconds and removes the mandatory second message; additional messages only appear on genuinely slow loads

## Why

The current startup implementation always creates 20 independent Vue components, each with its own `requestAnimationFrame` loop and resize listener. That is simultaneously underwhelming on capable desktops and disproportionately expensive on weaker devices.

## Validation

- reviewed the complete branch diff against `main`
- confirmed `@nuxt/image` is enabled in `nuxt.config.ts`
- confirmed the existing loader event path and butterfly store exit behavior
- local typecheck/build could not be run in this environment because the GitHub CLI and repository checkout/toolchain are unavailable; CI should run the repository checks on this draft PR
