### PR TITLE
Fix butterfly proportions and unlock desktop performance

### DIFF
--- a/components/screenfx/butterfly-animation.vue
+++ b/components/screenfx/butterfly-animation.vue
@@ -58,10 +58,10 @@ interface NavigatorPerformanceHints extends Navigator {
 
 const PROFILES: Record<PerformanceProfileName, PerformanceProfile> = {
   off: { name: 'off', count: 0, fps: 0, size: 0, speed: 0 },
-  low: { name: 'low', count: 6, fps: 24, size: 0.96, speed: 0.72 },
-  balanced: { name: 'balanced', count: 18, fps: 30, size: 0.84, speed: 0.88 },
-  high: { name: 'high', count: 32, fps: 45, size: 0.74, speed: 1 },
-  ultra: { name: 'ultra', count: 48, fps: 60, size: 0.66, speed: 1.06 },
+  low: { name: 'low', count: 8, fps: 30, size: 0.94, speed: 0.78 },
+  balanced: { name: 'balanced', count: 28, fps: 60, size: 0.82, speed: 0.94 },
+  high: { name: 'high', count: 52, fps: 60, size: 0.72, speed: 1.05 },
+  ultra: { name: 'ultra', count: 76, fps: 60, size: 0.64, speed: 1.12 }
 }
 
 const PROFILE_ORDER: PerformanceProfileName[] = [
@@ -69,13 +69,16 @@ const PROFILE_ORDER: PerformanceProfileName[] = [
   'low',
   'balanced',
   'high',
-  'ultra',
+  'ultra'
 ]
 
-const QUALITY_STORAGE_KEY = 'kind-loader-butterfly-quality'
 const SAMPLE_SIZE = 30
-const PROFILE_CHANGE_COOLDOWN_MS = 350
-const BUTTERFLY_HALF_SIZE = 35
+const PROFILE_CHANGE_COOLDOWN_MS = 450
+const STARTUP_GRACE_MS = 650
+const BAD_WINDOWS_BEFORE_DOWNGRADE = 2
+const HEALTHY_WINDOWS_BEFORE_UPGRADE = 2
+const BUTTERFLY_HALF_WIDTH = 32
+const BUTTERFLY_HALF_HEIGHT = 29
 
 const butterflyStore = useButterflyStore()
 const stage = ref<HTMLElement | null>(null)
@@ -88,12 +91,14 @@ let resizeTimeoutId: number | null = null
 let lastAnimationTime = 0
 let lastRafTime = 0
 let lastProfileChangeAt = 0
+let animationStartedAt = 0
 let viewportWidth = 0
 let viewportHeight = 0
 let frameSamples: number[] = []
 let healthySampleWindows = 0
+let badSampleWindows = 0
 let rebuilding = false
-let profileCeiling: PerformanceProfileName = 'balanced'
+let hardwareCeiling: PerformanceProfileName = 'balanced'
 
 function randomRange(min: number, max: number): number {
   return Math.random() * (max - min) + min
@@ -103,46 +108,23 @@ function profileIndex(name: PerformanceProfileName): number {
   return PROFILE_ORDER.indexOf(name)
 }
 
-function isPerformanceProfileName(
-  value: string | null,
-): value is PerformanceProfileName {
-  return value !== null && PROFILE_ORDER.includes(value as PerformanceProfileName)
-}
-
 function clampProfileToCeiling(
   name: PerformanceProfileName,
-  ceiling: PerformanceProfileName,
+  ceiling: PerformanceProfileName
 ): PerformanceProfileName {
   return PROFILE_ORDER[Math.min(profileIndex(name), profileIndex(ceiling))] || 'off'
 }
 
 function shiftProfile(
   name: PerformanceProfileName,
-  steps: number,
+  steps: number
 ): PerformanceProfileName {
   const nextIndex = Math.min(
     PROFILE_ORDER.length - 1,
-    Math.max(0, profileIndex(name) + steps),
+    Math.max(0, profileIndex(name) + steps)
   )
 
   return PROFILE_ORDER[nextIndex] || 'off'
-}
-
-function readStoredProfileLimit(): PerformanceProfileName | null {
-  try {
-    const stored = window.sessionStorage.getItem(QUALITY_STORAGE_KEY)
-    return isPerformanceProfileName(stored) ? stored : null
-  } catch {
-    return null
-  }
-}
-
-function storeProfileLimit(name: PerformanceProfileName): void {
-  try {
-    window.sessionStorage.setItem(QUALITY_STORAGE_KEY, name)
-  } catch {
-    return
-  }
 }
 
 function detectPerformanceProfile(): PerformanceProfileName {
@@ -151,19 +133,20 @@ function detectPerformanceProfile(): PerformanceProfileName {
   const cores = navigatorHints.hardwareConcurrency || 0
   const memory = navigatorHints.deviceMemory
   const reducedMotion = window.matchMedia(
-    '(prefers-reduced-motion: reduce)',
+    '(prefers-reduced-motion: reduce)'
   ).matches
 
   if (reducedMotion || connection?.saveData) return 'off'
   if (connection?.effectiveType === 'slow-2g') return 'off'
   if (cores > 0 && cores <= 2 && (memory === undefined || memory <= 2)) {
-    return 'off'
+    return 'low'
   }
 
   let score = 2
 
-  if (cores >= 12) score += 1
-  else if (cores >= 8) score += 1
+  if (cores >= 12) score += 3
+  else if (cores >= 8) score += 2
+  else if (cores >= 6) score += 1
   else if (cores > 0 && cores <= 4) score -= 1
 
   if (memory !== undefined) {
@@ -172,59 +155,53 @@ function detectPerformanceProfile(): PerformanceProfileName {
     else if (memory <= 4) score -= 1
   }
 
-  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
-  const pixelLoad = window.innerWidth * window.innerHeight * pixelRatio ** 2
+  const cssPixelArea = window.innerWidth * window.innerHeight
+  const pixelRatioCost = Math.min(Math.max(window.devicePixelRatio || 1, 1), 1.5)
+  const renderLoad = cssPixelArea * pixelRatioCost
 
-  if (pixelLoad >= 12_000_000) score -= 2
-  else if (pixelLoad >= 6_000_000) score -= 1
+  if (renderLoad >= 20_000_000) score -= 2
+  else if (renderLoad >= 12_000_000) score -= 1
 
   if (connection?.effectiveType === '2g') score -= 1
 
-  let detected: PerformanceProfileName
-
-  if (score >= 4) detected = 'ultra'
-  else if (score >= 3) detected = 'high'
-  else if (score >= 2) detected = 'balanced'
-  else detected = 'low'
-
-  const storedLimit = readStoredProfileLimit()
-  return storedLimit
-    ? clampProfileToCeiling(detected, storedLimit)
-    : detected
+  if (score >= 5) return 'ultra'
+  if (score >= 3) return 'high'
+  if (score >= 2) return 'balanced'
+  return 'low'
 }
 
-function getWarmupProfile(
-  ceiling: PerformanceProfileName,
+function getStartupProfile(
+  ceiling: PerformanceProfileName
 ): PerformanceProfileName {
-  if (ceiling === 'off' || ceiling === 'low') return ceiling
-  return clampProfileToCeiling('balanced', ceiling)
+  if (ceiling === 'ultra') return 'high'
+  return ceiling
 }
 
 function createParticle(
   index: number,
-  activeProfile: PerformanceProfile,
+  activeProfile: PerformanceProfile
 ): ButterflyParticle {
   const primaryColor = butterflyStore.randomColor()
   const secondaryColor =
     Math.random() > 0.5
       ? butterflyStore.complementaryColor(primaryColor)
       : butterflyStore.analogousColor(primaryColor)
-  const wingSpeed = Math.round(randomRange(480, 780))
+  const wingSpeed = Math.round(randomRange(320, 560))
 
   return {
     id: index,
     x: randomRange(0, viewportWidth),
     y: randomRange(0, viewportHeight),
     angle: randomRange(0, Math.PI * 2),
-    speed: randomRange(24, 58) * activeProfile.speed,
-    turnRate: randomRange(0.3, 0.9),
+    speed: randomRange(26, 62) * activeProfile.speed,
+    turnRate: randomRange(0.28, 0.78),
     phase: randomRange(0, Math.PI * 2),
-    bob: randomRange(5, 14),
-    scale: activeProfile.size * randomRange(0.78, 1.16),
+    bob: randomRange(4, 11),
+    scale: activeProfile.size * randomRange(0.8, 1.14),
     wingStyle: {
-      background: `radial-gradient(circle at 30% 28%, ${primaryColor}, ${secondaryColor} 76%)`,
-      animationDuration: `${wingSpeed}ms`,
-    },
+      background: `radial-gradient(ellipse at 30% 30%, ${primaryColor}, ${secondaryColor} 78%)`,
+      animationDuration: `${wingSpeed}ms`
+    }
   }
 }
 
@@ -250,6 +227,7 @@ function resetFrameTiming(): void {
   lastRafTime = 0
   frameSamples = []
   healthySampleWindows = 0
+  badSampleWindows = 0
 }
 
 function getPercentile(samples: number[], percentile: number): number {
@@ -258,7 +236,7 @@ function getPercentile(samples: number[], percentile: number): number {
   const ordered = [...samples].sort((a, b) => a - b)
   const index = Math.min(
     ordered.length - 1,
-    Math.floor(ordered.length * percentile),
+    Math.floor(ordered.length * percentile)
   )
 
   return ordered[index] || 0
@@ -266,15 +244,21 @@ function getPercentile(samples: number[], percentile: number): number {
 
 function samplePerformance(rawDelta: number, now: number): number {
   if (rawDelta <= 0) return 0
+  if (now - animationStartedAt < STARTUP_GRACE_MS) return 0
   if (now - lastProfileChangeAt < PROFILE_CHANGE_COOLDOWN_MS) return 0
 
   if (rawDelta >= 180) {
     frameSamples = []
     healthySampleWindows = 0
+    badSampleWindows += 1
+
+    if (badSampleWindows < BAD_WINDOWS_BEFORE_DOWNGRADE) return 0
+
+    badSampleWindows = 0
     return -1
   }
 
-  frameSamples.push(Math.min(rawDelta, 180))
+  frameSamples.push(rawDelta)
   if (frameSamples.length < SAMPLE_SIZE) return 0
 
   const samples = frameSamples
@@ -284,35 +268,35 @@ function samplePerformance(rawDelta: number, now: number): number {
   const average =
     samples.reduce((total, delta) => total + delta, 0) / samples.length
   const p90 = getPercentile(samples, 0.9)
-  const slowRatio =
-    samples.filter((delta) => delta > currentBudget * 1.45).length /
-    samples.length
-  const severeRatio =
-    samples.filter((delta) => delta > currentBudget * 2.2).length /
+  const longFrameRatio =
+    samples.filter((delta) => delta > currentBudget * 1.8).length /
     samples.length
 
-  if (
-    severeRatio > 0.12 ||
-    average > currentBudget * 1.75 ||
-    p90 > currentBudget * 2.4
-  ) {
-    healthySampleWindows = 0
-    return -2
-  }
+  const severe =
+    average > currentBudget * 1.9 ||
+    p90 > currentBudget * 2.4 ||
+    longFrameRatio > 0.18
+  const struggling =
+    average > currentBudget * 1.45 ||
+    p90 > currentBudget * 1.85 ||
+    longFrameRatio > 0.1
 
-  if (
-    slowRatio > 0.22 ||
-    average > currentBudget * 1.28 ||
-    p90 > currentBudget * 1.7
-  ) {
+  if (severe || struggling) {
     healthySampleWindows = 0
+    badSampleWindows += severe ? 2 : 1
+
+    if (badSampleWindows < BAD_WINDOWS_BEFORE_DOWNGRADE) return 0
+
+    badSampleWindows = 0
     return -1
   }
+
+  badSampleWindows = 0
 
   const nextProfileName = shiftProfile(profile.value.name, 1)
   if (
     nextProfileName === profile.value.name ||
-    profileIndex(nextProfileName) > profileIndex(profileCeiling)
+    profileIndex(nextProfileName) > profileIndex(hardwareCeiling)
   ) {
     healthySampleWindows = 0
     return 0
@@ -320,7 +304,9 @@ function samplePerformance(rawDelta: number, now: number): number {
 
   const nextBudget = 1000 / PROFILES[nextProfileName].fps
   const canSustainNextProfile =
-    average <= nextBudget * 1.08 && p90 <= nextBudget * 1.3
+    average <= nextBudget * 1.2 &&
+    p90 <= nextBudget * 1.55 &&
+    longFrameRatio <= 0.04
 
   if (!canSustainNextProfile) {
     healthySampleWindows = 0
@@ -328,7 +314,7 @@ function samplePerformance(rawDelta: number, now: number): number {
   }
 
   healthySampleWindows += 1
-  if (healthySampleWindows < 1) return 0
+  if (healthySampleWindows < HEALTHY_WINDOWS_BEFORE_UPGRADE) return 0
 
   healthySampleWindows = 0
   return 1
@@ -348,8 +334,7 @@ async function applyProfile(name: PerformanceProfileName): Promise<void> {
   stopAnimation()
 
   const previousProfile = profile.value
-  const previousParticles = butterflies.value
-  const retainedParticles = previousParticles.slice(0, nextProfile.count)
+  const retainedParticles = butterflies.value.slice(0, nextProfile.count)
 
   if (
     retainedParticles.length &&
@@ -387,18 +372,15 @@ async function applyProfile(name: PerformanceProfileName): Promise<void> {
   startAnimation()
 }
 
-function lowerAndLockProfile(steps: number): void {
-  const nextProfileName = shiftProfile(profile.value.name, -Math.abs(steps))
-  profileCeiling = clampProfileToCeiling(profileCeiling, nextProfileName)
-  storeProfileLimit(profileCeiling)
-  void applyProfile(nextProfileName)
+function lowerProfile(): void {
+  if (profile.value.name === 'off' || profile.value.name === 'low') return
+  void applyProfile(shiftProfile(profile.value.name, -1))
 }
 
-function raiseProfile(steps: number): void {
-  const requestedProfile = shiftProfile(profile.value.name, Math.abs(steps))
+function raiseProfile(): void {
   const nextProfileName = clampProfileToCeiling(
-    requestedProfile,
-    profileCeiling,
+    shiftProfile(profile.value.name, 1),
+    hardwareCeiling
   )
 
   if (nextProfileName === profile.value.name) return
@@ -406,19 +388,19 @@ function raiseProfile(steps: number): void {
 }
 
 function updateParticles(now: number, deltaSeconds: number): void {
-  const margin = 80
+  const margin = 72
 
   for (let index = 0; index < butterflies.value.length; index += 1) {
     const butterfly = butterflies.value[index]
     const element = butterflyElements[index]
     if (!butterfly || !element) continue
 
-    const wander = Math.sin(now * 0.00042 + butterfly.phase)
+    const wander = Math.sin(now * 0.00038 + butterfly.phase)
     butterfly.angle += wander * butterfly.turnRate * deltaSeconds
     butterfly.x += Math.cos(butterfly.angle) * butterfly.speed * deltaSeconds
     butterfly.y +=
       Math.sin(butterfly.angle) * butterfly.speed * deltaSeconds +
-      Math.sin(now * 0.0012 + butterfly.phase) *
+      Math.sin(now * 0.0011 + butterfly.phase) *
         butterfly.bob *
         deltaSeconds
 
@@ -428,10 +410,10 @@ function updateParticles(now: number, deltaSeconds: number): void {
     if (butterfly.y > viewportHeight + margin) butterfly.y = -margin
 
     const heading = (butterfly.angle * 180) / Math.PI + 90
-    const pitch = 48 + Math.sin(now * 0.0007 + butterfly.phase) * 6
-    const bank = Math.sin(now * 0.001 + butterfly.phase) * 10
+    const pitch = 30 + Math.sin(now * 0.00065 + butterfly.phase) * 4
+    const bank = Math.sin(now * 0.0009 + butterfly.phase) * 6
 
-    element.style.transform = `translate3d(${butterfly.x - BUTTERFLY_HALF_SIZE}px, ${butterfly.y - BUTTERFLY_HALF_SIZE}px, 0) rotateZ(${heading}deg) rotateX(${pitch}deg) rotateY(${bank}deg) scale(${butterfly.scale})`
+    element.style.transform = `translate3d(${butterfly.x - BUTTERFLY_HALF_WIDTH}px, ${butterfly.y - BUTTERFLY_HALF_HEIGHT}px, 0) rotateZ(${heading}deg) rotateX(${pitch}deg) rotateY(${bank}deg) scale(${butterfly.scale})`
   }
 }
 
@@ -446,22 +428,28 @@ function animate(now: number): void {
   const profileAdjustment = samplePerformance(rawDelta, now)
 
   if (profileAdjustment < 0) {
-    lowerAndLockProfile(Math.abs(profileAdjustment))
+    lowerProfile()
     return
   }
 
   if (profileAdjustment > 0) {
-    raiseProfile(profileAdjustment)
+    raiseProfile()
     return
   }
 
-  const frameInterval = 1000 / profile.value.fps
-  const elapsed = lastAnimationTime ? now - lastAnimationTime : frameInterval
-
-  if (elapsed >= frameInterval) {
-    const deltaSeconds = Math.min(elapsed, 50) / 1000
-    lastAnimationTime = now - (elapsed % frameInterval)
+  if (profile.value.fps >= 55) {
+    const deltaSeconds = Math.min(rawDelta || 1000 / 60, 34) / 1000
+    lastAnimationTime = now
     updateParticles(now, deltaSeconds)
+  } else {
+    const frameInterval = 1000 / profile.value.fps
+    const elapsed = lastAnimationTime ? now - lastAnimationTime : frameInterval
+
+    if (elapsed >= frameInterval) {
+      const deltaSeconds = Math.min(elapsed, 50) / 1000
+      lastAnimationTime = now - (elapsed % frameInterval)
+      updateParticles(now, deltaSeconds)
+    }
   }
 
   animationFrameId = requestAnimationFrame(animate)
@@ -487,6 +475,7 @@ function handleVisibilityChange(): void {
   }
 
   resetFrameTiming()
+  animationStartedAt = performance.now()
   startAnimation()
 }
 
@@ -499,23 +488,19 @@ function handleResize(): void {
 
   resizeTimeoutId = window.setTimeout(() => {
     resizeTimeoutId = null
-    const detectedCeiling = detectPerformanceProfile()
+    hardwareCeiling = detectPerformanceProfile()
 
-    if (profileIndex(detectedCeiling) >= profileIndex(profileCeiling)) return
-
-    profileCeiling = detectedCeiling
-    storeProfileLimit(profileCeiling)
-
-    if (profileIndex(profile.value.name) > profileIndex(profileCeiling)) {
-      void applyProfile(profileCeiling)
+    if (profileIndex(profile.value.name) > profileIndex(hardwareCeiling)) {
+      void applyProfile(hardwareCeiling)
     }
   }, 150)
 }
 
 onMounted(async () => {
   syncViewport()
-  profileCeiling = detectPerformanceProfile()
-  await applyProfile(getWarmupProfile(profileCeiling))
+  hardwareCeiling = detectPerformanceProfile()
+  animationStartedAt = performance.now()
+  await applyProfile(getStartupProfile(hardwareCeiling))
 
   window.addEventListener('resize', handleResize, { passive: true })
   document.addEventListener('visibilitychange', handleVisibilityChange)
@@ -538,27 +523,28 @@ onBeforeUnmount(() => {
 @keyframes flutter-left {
   0%,
   100% {
-    transform: rotateY(16deg);
+    transform: rotateY(10deg);
   }
 
   50% {
-    transform: rotateY(66deg);
+    transform: rotateY(64deg);
   }
 }
 
 @keyframes flutter-right {
   0%,
   100% {
-    transform: rotateY(-16deg);
+    transform: rotateY(-10deg);
   }
 
   50% {
-    transform: rotateY(-66deg);
+    transform: rotateY(-64deg);
   }
 }
 
 .butterfly-animation {
   contain: strict;
+  perspective: 900px;
   transform: translateZ(0);
 }
 
@@ -566,46 +552,59 @@ onBeforeUnmount(() => {
   position: absolute;
   left: 0;
   top: 0;
-  width: 70px;
-  height: 70px;
-  opacity: 0.74;
+  width: 64px;
+  height: 58px;
+  opacity: 0.76;
   pointer-events: none;
   transform-origin: center;
   transform-style: preserve-3d;
-  backface-visibility: visible;
   contain: layout paint style;
   will-change: transform;
+}
+
+.butterfly::after {
+  position: absolute;
+  top: 17px;
+  left: 30px;
+  z-index: 2;
+  width: 4px;
+  height: 25px;
+  border-radius: 999px;
+  background: rgba(12, 12, 18, 0.78);
+  content: '';
+  transform: translateZ(1px);
 }
 
 .left-wing,
 .right-wing {
   position: absolute;
-  top: 12px;
-  width: 28px;
-  height: 42px;
-  border-radius: 72% 42% 68% 38%;
-  opacity: 0.78;
-  backface-visibility: visible;
+  top: 11px;
+  width: 29px;
+  height: 32px;
+  opacity: 0.82;
+  backface-visibility: hidden;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
+  animation-fill-mode: both;
   will-change: transform;
 }
 
 .left-wing {
-  left: 7px;
+  left: 3px;
+  border-radius: 72% 34% 62% 42% / 58% 42% 64% 38%;
   transform-origin: 100% 52%;
   animation-name: flutter-left;
 }
 
 .right-wing {
-  left: 35px;
-  border-radius: 42% 72% 38% 68%;
+  left: 32px;
+  border-radius: 34% 72% 42% 62% / 42% 58% 38% 64%;
   transform-origin: 0 52%;
   animation-name: flutter-right;
 }
 
 .butterfly-animation--ultra .butterfly {
-  opacity: 0.68;
+  opacity: 0.7;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What changed

- shortens the wing geometry from 28×42 to 29×32 so the butterflies are wider and less stretched
- adds a small central body and reduces the 3D pitch/bank distortion
- raises quality tiers to 8 / 28 / 52 / 76 butterflies
- runs balanced, high, and ultra motion directly on every animation frame at 60 FPS instead of using a timing gate that could skip alternating frames
- stops squaring `devicePixelRatio` when estimating display load, which was heavily penalizing 4K/high-DPI desktop machines
- gives 8–12+ core desktops substantially more weight in initial quality selection
- starts ultra-capable systems at high (52 butterflies) and upgrades to ultra after healthy frame samples
- removes the session-wide cached downgrade so one busy startup cannot permanently trap the browser at 18 butterflies / 30 FPS
- requires repeated poor performance before stepping down and allows recovery back toward the hardware ceiling

## Root causes

The previous detector treated display cost as `width × height × DPR²`. A 4K desktop at DPR 2 therefore appeared to have more than 33 million pixels of load and could be classified as balanced despite strong CPU and memory signals. Balanced was also explicitly capped at 18 butterflies and 30 FPS.

The 60 FPS profiles used an elapsed-time gate against a fractional 16.67 ms interval. On a 60 Hz display, normal requestAnimationFrame timestamps can land fractionally below that threshold, causing visible skipped-frame cadence even when the machine is healthy.

## Verification

- branch is one commit ahead of current `main`
- only `components/screenfx/butterfly-animation.vue` changed
- extracted TypeScript passes `tsc --strict --target ES2023` with Vue/store declarations stubbed
- full Nuxt typecheck and preview remain CI verification surfaces
