### PR TITLE
ArtJob dashboard: re-enqueue + show generated art; fix dashboard tab image crop

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -197,6 +197,7 @@
             <thead>
               <tr class="text-[11px]">
                 <th>#</th>
+                <th>Art</th>
                 <th>Engine</th>
                 <th>Status</th>
                 <th>Att</th>
@@ -208,6 +209,26 @@
             <tbody>
               <tr v-for="job in artJobStore.jobs" :key="job.id" class="text-xs">
                 <td>{{ job.id }}</td>
+                <td>
+                  <a
+                    v-if="jobImageSrc(job)"
+                    :href="jobImageSrc(job)"
+                    target="_blank"
+                    rel="noopener"
+                    :title="`ArtImage ${job.artImageId}`"
+                  >
+                    <img
+                      :src="jobImageSrc(job)"
+                      class="h-10 w-10 rounded-md object-cover"
+                      alt="generated art"
+                    />
+                  </a>
+                  <span
+                    v-else-if="job.status === 'DONE'"
+                    class="text-base-content/40"
+                    >—</span
+                  >
+                </td>
                 <td>{{ job.engine }}</td>
                 <td>
                   <span
@@ -228,9 +249,18 @@
                 </td>
                 <td class="whitespace-nowrap">
                   <button
+                    type="button"
+                    class="btn btn-ghost btn-xs rounded-2xl"
+                    title="Clone into a fresh job"
+                    @click="artJobStore.reenqueueJob(job.id)"
+                  >
+                    Re-run
+                  </button>
+                  <button
                     v-if="job.status !== 'DONE'"
                     type="button"
                     class="btn btn-ghost btn-xs rounded-2xl"
+                    title="Reset this job to PENDING"
                     @click="artJobStore.requeueJob(job.id)"
                   >
                     Requeue
@@ -247,7 +277,7 @@
               </tr>
               <tr v-if="!artJobStore.jobs.length">
                 <td
-                  colspan="7"
+                  colspan="8"
                   class="text-center text-xs text-base-content/50"
                 >
                   No {{ artJobStore.jobStatusFilter }} jobs.
@@ -318,6 +348,11 @@ function statusClass(status: string): string {
   if (status === 'OFFLINE') return 'text-error'
   if (status === 'DEGRADED') return 'text-warning'
   return 'text-base-content/50'
+}
+
+function jobImageSrc(job: { artImageId?: number | null }): string {
+  if (typeof job.artImageId !== 'number') return ''
+  return artJobStore.imageSrcById[job.artImageId] || ''
 }
 
 function jobStatusClass(status: string): string {

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -4,12 +4,15 @@
     <div
       class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
     >
-      <div class="relative aspect-4/3 overflow-hidden bg-base-300">
+      <div
+        class="relative overflow-hidden bg-base-300"
+        :class="{ 'aspect-4/3': !imagePath }"
+      >
         <img
           v-if="imagePath"
           :src="imagePath"
           :alt="title"
-          class="h-full w-full object-cover transition-transform duration-500 hover:scale-105"
+          class="block h-auto w-full transition-transform duration-500 hover:scale-105"
         />
 
         <div

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -1,0 +1,72 @@
+// /server/api/art/queue/[id]/reenqueue.post.ts
+//
+// Admin action: re-run a job by cloning it into a fresh PENDING ArtJob. Unlike
+// requeue (which resets a stuck/failed job in place), this works on ANY job —
+// including DONE — and never touches the original record, so its history and
+// resulting ArtImage stay intact. Used by the dashboard's "Re-run" button to
+// regenerate from a finished job.
+//
+// Admin/server credentials only.
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { requireMachineUser } from '../../../../utils/authGuard'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to re-enqueue jobs.',
+      })
+    }
+
+    const id = Number(getRouterParam(event, 'id'))
+
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid job id.' })
+    }
+
+    const source = await prisma.artJob.findUnique({ where: { id } })
+
+    if (!source) {
+      throw createError({ statusCode: 404, message: `Job ${id} not found.` })
+    }
+
+    // Clone the generation spec into a brand-new PENDING job. Preserve the
+    // original owner/project so the regenerated ArtImage lands the same way.
+    const job = await prisma.artJob.create({
+      data: {
+        engine: source.engine,
+        payload: source.payload as Prisma.InputJsonValue,
+        priority: source.priority,
+        projectSlug: source.projectSlug,
+        projectId: source.projectId,
+        userId: source.userId,
+      },
+    })
+
+    event.node.res.statusCode = 201
+
+    return {
+      success: true,
+      message: `Re-enqueued job ${id} as new job ${job.id}.`,
+      data: { job, sourceJobId: id },
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to re-enqueue art job.',
+      statusCode,
+    }
+  }
+})

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -7,7 +7,7 @@
 // a non-admin simply gets empty data.
 import { defineStore } from 'pinia'
 import { reactive, toRefs } from 'vue'
-import type { ArtJob } from '~/prisma/generated/prisma/client'
+import type { ArtImage, ArtJob } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
 
 export type ArtJobStatus =
@@ -70,6 +70,9 @@ type ArtJobState = {
   stats: QueueStats | null
   uptime: ServerUptime[]
   jobs: ArtJob[]
+  // Displayable src (data URL or /images path) for a finished job's ArtImage,
+  // keyed by artImageId — so the DONE tab can show the generated art.
+  imageSrcById: Record<number, string>
   jobStatusFilter: ArtJobStatus | 'ALL'
   loadingStats: boolean
   loadingUptime: boolean
@@ -78,11 +81,15 @@ type ArtJobState = {
   windowHours: number
 }
 
+// How many finished jobs to pull image data for at once (base64 is heavy).
+const MAX_JOB_IMAGES = 48
+
 export const useArtJobStore = defineStore('artJobStore', () => {
   const state = reactive<ArtJobState>({
     stats: null,
     uptime: [],
     jobs: [],
+    imageSrcById: {},
     jobStatusFilter: 'PENDING',
     loadingStats: false,
     loadingUptime: false,
@@ -135,12 +142,60 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       )
       if (res.success && res.data) {
         state.jobs = res.data.jobs
+        void loadJobImages()
       } else if (!res.success) {
         state.error = res.message || 'Failed to load jobs.'
       }
     } finally {
       state.loadingJobs = false
     }
+  }
+
+  // Turn a finished job's ArtImage into a browser-displayable src: prefer the
+  // base64 imageData (how the relay stores results) as a data URL, else a
+  // normalized /images path.
+  function artImageToSrc(image: ArtImage | null | undefined): string {
+    if (!image) return ''
+    const raw = (image.imageData || '').trim()
+    if (raw) {
+      if (raw.startsWith('data:image/')) return raw
+      if (!raw.startsWith('/') && !raw.startsWith('http')) {
+        return `data:image/${image.fileType || 'png'};base64,${raw}`
+      }
+    }
+    const path = (image.imagePath || image.path || '').trim()
+    if (!path) return ''
+    if (path.startsWith('http') || path.startsWith('data:')) return path
+    if (path.startsWith('/images/')) return path
+    if (path.startsWith('images/')) return `/${path}`
+    return ''
+  }
+
+  // Load the generated art for the currently-shown finished jobs so the DONE
+  // tab can render thumbnails. Bounded by MAX_JOB_IMAGES since imageData is
+  // heavy; skips ids already loaded.
+  async function loadJobImages(): Promise<void> {
+    const ids = state.jobs
+      .filter((j) => j.status === 'DONE' && typeof j.artImageId === 'number')
+      .map((j) => j.artImageId as number)
+      .filter((id) => !(id in state.imageSrcById))
+      .slice(0, MAX_JOB_IMAGES)
+
+    if (!ids.length) return
+
+    await Promise.all(
+      ids.map(async (id) => {
+        const res = await performFetch<ArtImage>(
+          `/api/art/image/${id}?includeImageData=true`,
+          { method: 'GET' },
+          1,
+          30_000,
+        )
+        if (res.success && res.data) {
+          state.imageSrcById[id] = artImageToSrc(res.data)
+        }
+      }),
+    )
   }
 
   async function requeueJob(id: number): Promise<boolean> {
@@ -169,6 +224,20 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     return false
   }
 
+  // Re-run: clone the job into a fresh PENDING job (works on DONE too).
+  async function reenqueueJob(id: number): Promise<number | null> {
+    const res = await performFetch<{ job: ArtJob }>(
+      `/api/art/queue/${id}/reenqueue`,
+      { method: 'POST', body: JSON.stringify({}) },
+    )
+    if (res.success && res.data?.job) {
+      await Promise.all([fetchJobs(), fetchStats()])
+      return res.data.job.id
+    }
+    state.error = res.message || `Failed to re-enqueue job ${id}.`
+    return null
+  }
+
   async function refreshAll(): Promise<void> {
     state.error = null
     await Promise.all([fetchStats(), fetchUptime(), fetchJobs()])
@@ -185,6 +254,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     fetchJobs,
     requeueJob,
     cancelJob,
+    reenqueueJob,
     refreshAll,
     setWindow,
   }


### PR DESCRIPTION
## ArtJob dashboard

- **Re-run action** — `POST /api/art/queue/[id]/reenqueue` clones a job's engine/payload/project/owner into a fresh PENDING job. Unlike **Requeue** (reset-in-place, non-DONE only), this works on **any** job including DONE, and leaves the original record + its ArtImage intact. Added a "Re-run" button to every queue row.
- **See generated art in the DONE tab** — the store now loads each finished job's ArtImage (base64 `imageData`, bounded to 48) and the queue table shows a thumbnail linking to the full image.

## Dashboard tab image crop fix

`workspace-sheet.vue` locked the tab portrait to `aspect-4/3` + `object-cover`, cropping every tab image — obvious on the ArtJob card because its text got cut off. Now renders the image at **100% width, natural height** (no crop); the 4:3 box is kept only for the no-image placeholder.

Verified: `nuxi typecheck` clean; changed files pass prettier + eslint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014sBtYxdew9nvBzMaVFbnY2)_