### PR TITLE
Project placements: backfill channelKey / tabKey / liveUrl

### DIFF
--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -186,6 +186,30 @@
         >
       </template>
 
+      <!-- Backfill channelKey / tabKey / liveUrl on project rows (admin) -->
+      <template v-if="userStore.isAdmin && viewMode === 'overview'">
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs gap-1 rounded-lg border border-base-300"
+          :disabled="applyingPlacements"
+          title="Backfill channelKey / tabKey / liveUrl on project rows from the canonical placement map"
+          @click="applyPlacementsAction"
+        >
+          <span
+            v-if="applyingPlacements"
+            class="loading loading-spinner loading-xs"
+          />
+          <Icon v-else name="kind-icon:link" class="size-3" />
+          Placements
+        </button>
+        <span
+          v-if="placementsMessage"
+          class="text-xs"
+          :class="placementsError ? 'text-error' : 'text-success'"
+          >{{ placementsMessage }}</span
+        >
+      </template>
+
       <!-- Kaizen philosophy popup -->
       <KaizenPopup />
 
@@ -1932,6 +1956,10 @@ import { usePageStore } from '@/stores/pageStore'
 import { useTodoStore } from '@/stores/todoStore'
 import type { TodoCategory } from '@/stores/todoStore'
 import { useConductorStore } from '@/stores/conductorStore'
+import {
+  getProjectPlacement,
+  placementLiveUrl,
+} from '~/utils/projectPlacements'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
 import ConductorArtGallery from '@/components/pages/conductor-art-gallery.vue'
 import ConductorProjectChat from '@/components/pages/conductor-project-chat.vue'
@@ -1980,6 +2008,10 @@ const projectGalleryMode = ref<GalleryMode>('cards')
 const syncingMissing = ref(false)
 const syncMessage = ref('')
 const syncError = ref(false)
+
+const applyingPlacements = ref(false)
+const placementsMessage = ref('')
+const placementsError = ref(false)
 
 const showNewProjectForm = ref(false)
 const newProjectTitle = ref('')
@@ -2393,6 +2425,7 @@ async function syncMissingProjects() {
       const project = conductorStore.projects.find(
         (entry) => entry.slug === slug,
       )
+      const placement = getProjectPlacement(slug)
       await projectStore.createProject({
         title: project?.name || slug,
         slug,
@@ -2400,6 +2433,14 @@ async function syncMissingProjects() {
         imagePath: `${CONDUCTOR_IMG_BASE}/${slug}-icon.webp`,
         cardPath: `${CONDUCTOR_IMG_BASE}/${slug}-card.webp`,
         heroPath: `${CONDUCTOR_IMG_BASE}/${slug}-hero.webp`,
+        // Seed navigation placement from the canonical map when we know it.
+        ...(placement
+          ? {
+              channelKey: placement.channelKey,
+              tabKey: placement.tabKey,
+              liveUrl: placementLiveUrl(placement),
+            }
+          : {}),
         isPublic: true,
         isMature: false,
         isActive: true,
@@ -2415,6 +2456,27 @@ async function syncMissingProjects() {
     syncMessage.value = 'Sync failed'
   } finally {
     syncingMissing.value = false
+  }
+}
+
+async function applyPlacementsAction() {
+  applyingPlacements.value = true
+  placementsMessage.value = ''
+  placementsError.value = false
+  try {
+    const result = await projectStore.applyPlacements()
+    placementsMessage.value = `Placements: ${result.updated.length} set, ${result.unchanged.length} current${
+      result.missing.length ? `, ${result.missing.length} not synced` : ''
+    }`
+    setTimeout(() => {
+      placementsMessage.value = ''
+    }, 6000)
+  } catch (error) {
+    placementsError.value = true
+    placementsMessage.value =
+      error instanceof Error ? error.message : 'Failed to apply placements'
+  } finally {
+    applyingPlacements.value = false
   }
 }
 

--- a/stores/projectStore.ts
+++ b/stores/projectStore.ts
@@ -9,6 +9,10 @@ import type {
   Project,
 } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
+import {
+  PROJECT_PLACEMENTS,
+  placementLiveUrl,
+} from '~/utils/projectPlacements'
 
 export type ProjectWithRelations = Project & {
   Manager?: Pick<
@@ -199,6 +203,59 @@ export const useProjectStore = defineStore('projectStore', () => {
     }
   }
 
+  type ApplyPlacementsResult = {
+    updated: string[]
+    unchanged: string[]
+    missing: string[]
+  }
+
+  // Backfill channelKey / tabKey / liveUrl on loaded Project rows from the
+  // canonical PROJECT_PLACEMENTS map, using the existing PATCH endpoint (which is
+  // admin/owner-gated server-side). Runs over projects already in the store, so
+  // load them (admin: includeInactive) before calling. liveUrl is only filled
+  // when empty unless overwriteLiveUrl is set.
+  async function applyPlacements(
+    overwriteLiveUrl = false,
+  ): Promise<ApplyPlacementsResult> {
+    const updated: string[] = []
+    const unchanged: string[] = []
+    const missing: string[] = []
+
+    for (const [slug, placement] of Object.entries(PROJECT_PLACEMENTS)) {
+      const project =
+        projectForSlug(slug) ??
+        projects.value.find((entry) => entry.conductorSlug === slug) ??
+        null
+      if (!project) {
+        missing.push(slug)
+        continue
+      }
+
+      const nextLiveUrl =
+        overwriteLiveUrl || !project.liveUrl
+          ? placementLiveUrl(placement)
+          : project.liveUrl
+
+      if (
+        project.channelKey === placement.channelKey &&
+        project.tabKey === placement.tabKey &&
+        project.liveUrl === nextLiveUrl
+      ) {
+        unchanged.push(slug)
+        continue
+      }
+
+      await updateProject(project.id, {
+        channelKey: placement.channelKey,
+        tabKey: placement.tabKey,
+        liveUrl: nextLiveUrl,
+      })
+      updated.push(slug)
+    }
+
+    return { updated, unchanged, missing }
+  }
+
   return {
     projects,
     selectedProject,
@@ -215,5 +272,6 @@ export const useProjectStore = defineStore('projectStore', () => {
     createProject,
     updateProject,
     archiveProject,
+    applyPlacements,
   }
 })

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -1,0 +1,139 @@
+// /utils/projectPlacements.ts
+//
+// Canonical placement for every project surface: conductor slug -> the channel
+// (dashboardKey), tab (dashboardTab), the in-app route, and the launch pointer.
+// This is the single source of truth used to backfill the Project DB rows
+// (channelKey / tabKey / liveUrl) via POST /api/projects/apply-placements, and it
+// mirrors the tabs registered in stores/helpers/dashboardHelper.ts.
+//
+// liveUrl is the internal Kind Robots route by default (so the Conductor "Open
+// Project" action lands on the styled page). Bridge projects still expose their
+// external app from their own page.
+
+export type ProjectPlacement = {
+  /** dashboardKey / Project.channelKey */
+  channelKey: string
+  /** dashboardTab / Project.tabKey */
+  tabKey: string
+  /** In-app route the page lives at (also the default liveUrl). */
+  route: string
+  /** Explicit launch pointer when it differs from `route` (e.g. external app). */
+  liveUrl?: string
+}
+
+export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
+  // Flagship + newly stitched surfaces
+  'coloring-book': { channelKey: 'art', tabKey: 'coloring', route: '/coloring' },
+  'challenge-center': {
+    channelKey: 'wonder',
+    tabKey: 'challenges',
+    route: '/challenges',
+  },
+  wishmaster: {
+    channelKey: 'conductor',
+    tabKey: 'wishmaster',
+    route: '/wishmaster',
+  },
+  appmaker: { channelKey: 'conductor', tabKey: 'appmaker', route: '/appmaker' },
+  serendipity: {
+    channelKey: 'scenario',
+    tabKey: 'serendipity',
+    route: '/serendipity',
+  },
+  'mermaids-of-venice': {
+    channelKey: 'giftshop',
+    tabKey: 'mermaids',
+    route: '/mermaids',
+  },
+  'model-builder': {
+    channelKey: 'builder',
+    tabKey: 'model-builder',
+    route: '/model-builder',
+  },
+  storymaker: {
+    channelKey: 'scenario',
+    tabKey: 'storymaker',
+    route: '/storymaker',
+  },
+  sketchy: { channelKey: 'academy', tabKey: 'sketchy', route: '/sketchy' },
+  packmaker: { channelKey: 'builder', tabKey: 'packs', route: '/packs' },
+  davinci: { channelKey: 'wonder', tabKey: 'davinci', route: '/davinci' },
+  'media-watchlist': {
+    channelKey: 'wonder',
+    tabKey: 'watchlist',
+    route: '/watchlist',
+  },
+  'coat-dance': { channelKey: 'art', tabKey: 'coat-dance', route: '/coat-dance' },
+  'ruler-hooked': {
+    channelKey: 'wonder',
+    tabKey: 'ruler-hooked',
+    route: '/ruler-hooked',
+  },
+  newsfeed: { channelKey: 'wonder', tabKey: 'newsfeed', route: '/newsfeed' },
+  'humboldt-scoop': {
+    channelKey: 'wonder',
+    tabKey: 'humboldt-scoop',
+    route: '/humboldt-scoop',
+  },
+  'humboldt-scoop-cms': {
+    channelKey: 'conductor',
+    tabKey: 'scoop-cms',
+    route: '/scoop-cms',
+  },
+  'conductor-app': {
+    channelKey: 'conductor',
+    tabKey: 'conductor-app',
+    route: '/conductor-app',
+  },
+  'alexa-integration': {
+    channelKey: 'wonder',
+    tabKey: 'voice-lab',
+    route: '/voice-lab',
+  },
+
+  // Already-complete surfaces (recorded so their DB rows carry placement too)
+  'superkate-services-calculator': {
+    channelKey: 'art',
+    tabKey: 'stylist',
+    route: '/stylist',
+  },
+  'superkate-hairstyle-ai': {
+    channelKey: 'art',
+    tabKey: 'stylist',
+    route: '/stylist',
+  },
+  'digital-storefront': {
+    channelKey: 'giftshop',
+    tabKey: 'giftshop',
+    route: '/sanctuary',
+  },
+  'ai-art-academy': {
+    channelKey: 'academy',
+    tabKey: 'timeline',
+    route: '/academy',
+  },
+  brainstorm: {
+    channelKey: 'brainstorm',
+    tabKey: 'brainstorm',
+    route: '/brainstorm',
+  },
+  'mural-design': { channelKey: 'wonder', tabKey: 'mural', route: '/mural' },
+  conductor: {
+    channelKey: 'conductor',
+    tabKey: 'conductor',
+    route: '/conductor',
+  },
+}
+
+/** Resolve a placement by conductor slug (or project slug), if one exists. */
+export function getProjectPlacement(
+  slug: string | null | undefined,
+): ProjectPlacement | null {
+  if (!slug) return null
+  return PROJECT_PLACEMENTS[slug] ?? null
+}
+
+/** The launch pointer for a placement: explicit liveUrl, else the route. */
+export function placementLiveUrl(placement: ProjectPlacement): string {
+  return placement.liveUrl ?? placement.route
+}


### PR DESCRIPTION
## What & why

Follow-up to #204. The project front pages exist, but the `Project` DB rows still lack `channelKey` / `tabKey` / `liveUrl`, so the Conductor "Open Project" action and any placement-aware code can't resolve them. This adds the tooling to backfill them (the production DB isn't reachable from CI, so this ships as an admin-triggered action rather than a migration).

## Changes

- **`utils/projectPlacements.ts`** — canonical map: conductor slug → `{ channelKey, tabKey, route, liveUrl? }` for every project surface (mirrors `dashboardConfigs`). Single source of truth.
- **`projectStore.applyPlacements()`** — backfills `channelKey` / `tabKey` / `liveUrl` onto loaded Project rows via the existing admin/owner-gated `PATCH /api/projects/:id`. `liveUrl` is only filled when empty (won't clobber a hand-set launch URL). Idempotent.
  - Deliberately **client-side** (loops the map, reuses the PATCH route) rather than a new endpoint: adding a server route expanded Nitro's typed-`$fetch` route union and tipped `conductorStore`'s `$fetch<ConductorData>` over the type-instantiation recursion limit. No new route = no regression.
- **`conductor-page.vue`** — admin **"Placements"** button in the overview bar to run it, with a result summary.
- **`syncMissingProjects`** now seeds `channelKey` / `tabKey` / `liveUrl` from the map when it first creates a project row.

## How to apply (Silas)

Open `/conductor` as admin → click **Placements**. It patches every project that's loaded in the store and reports `N set / N current / N not synced`.

## Verification

- `vue-tsc --noEmit`: **0 errors** (confirmed the route-removal resolves the `conductorStore` deep-instantiation errors).
- `eslint`: clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLcMVq3HG5PYr4sdLhBZjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLcMVq3HG5PYr4sdLhBZjU)_