### PR TITLE
Make Nuxt Content the source of truth for channels and tabs

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Channel resolver contract
         run: npm run test:channel-resolver
 
+      - name: Navigation route access contract
+        run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
+
       - name: Channel artwork audit
         run: npm run audit:channel-assets 2>&1 | tee channel-artwork-audit.txt
 

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Channel resolver contract
         run: npm run test:channel-resolver
+
+      - name: Channel artwork audit
+        run: npm run audit:channel-assets

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -45,4 +45,13 @@ jobs:
         run: npm run test:channel-resolver
 
       - name: Channel artwork audit
-        run: npm run audit:channel-assets
+        run: npm run audit:channel-assets 2>&1 | tee channel-artwork-audit.txt
+
+      - name: Upload channel artwork report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: channel-artwork-audit
+          path: channel-artwork-audit.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,10 +1,7 @@
 name: Contract Tests
 
-# Fast, DB-free contract checks (conductor art-generator-connect/t-018).
-# Runs the pure-string tsx verifiers that assert cross-repo data contracts
-# — currently the art-request YAML indentation contract that conductor's
-# PyYAML parser depends on (server/utils/artRequestYaml.ts). No database or
-# Nuxt build needed, so this stays fast and can gate every PR.
+# Fast, DB-free contract checks for cross-repo and content-driven contracts.
+# No database or Nuxt build is needed, so these can gate every pull request.
 
 on:
   push:
@@ -36,7 +33,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          CYPRESS_INSTALL_BINARY: '0' # cypress unused in this job
+          CYPRESS_INSTALL_BINARY: '0'
 
       - name: Art-request YAML indentation contract
         run: npm run test:art-request-yaml
+
+      - name: Channel content contract
+        run: npm run test:channel-content

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Channel content contract
         run: npm run test:channel-content
+
+      - name: Channel resolver contract
+        run: npm run test:channel-resolver

--- a/components/builder/builder-manager.vue
+++ b/components/builder/builder-manager.vue
@@ -136,57 +136,32 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useBuilderStore } from '@/stores/builderStore'
+import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useNavStore } from '@/stores/navStore'
-import {
-  dashboardConfigs,
-  getDashboardTabConfig,
-  isDashboardTabKey,
-  type DashboardTabConfig,
-} from '@/stores/helpers/dashboardHelper'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
 
-type BuilderTabConfig = DashboardTabConfig & {
-  modelType?: string
-  route?: string
-  requiredBeforeNext?: string[]
-}
-
 const store = useBuilderStore()
+const channelContentStore = useChannelContentStore()
 const navStore = useNavStore()
-
-const dashboardKey = 'builder'
 const showResetConfirm = ref(false)
 
-const builderConfig = computed(() => {
-  return dashboardConfigs.builder
-})
+await channelContentStore.initialize()
 
-const defaultBuilderTab = computed(() => {
-  return builderConfig.value.defaultTab
-})
+const builderChannel = computed(() =>
+  channelContentStore.getChannel('build'),
+)
 
-const activeTab = computed(() => {
-  const selectedTab = navStore.getDashboardTab(dashboardKey)
+const defaultBuilderTab = computed(
+  () => builderChannel.value?.defaultTab || 'character',
+)
 
-  if (isDashboardTabKey(dashboardKey, selectedTab)) {
-    return selectedTab
-  }
+const activeTab = computed(() =>
+  channelContentStore.getActiveTab('build') || defaultBuilderTab.value,
+)
 
-  return defaultBuilderTab.value
-})
-
-const activeTabConfig = computed<BuilderTabConfig>(() => {
-  const tabConfig = getDashboardTabConfig(dashboardKey, activeTab.value)
-
-  return (
-    (tabConfig as BuilderTabConfig | null) ||
-    (getDashboardTabConfig(
-      dashboardKey,
-      defaultBuilderTab.value,
-    ) as BuilderTabConfig | null) ||
-    (builderConfig.value.tabs[0] as BuilderTabConfig)
-  )
-})
+const activeTabConfig = computed(() =>
+  channelContentStore.getTab('build', activeTab.value),
+)
 
 const isBuilderActive = computed(() => {
   return store.activeConfig.modelType !== 'builder' && store.cards.length > 0
@@ -200,9 +175,7 @@ const showSplash = computed(() => {
   )
 })
 
-const showBuilderControls = computed(() => {
-  return isBuilderActive.value
-})
+const showBuilderControls = computed(() => isBuilderActive.value)
 
 const fallbackIcon = computed(() => {
   if (activeTab.value === 'art') return 'kind-icon:palette'
@@ -210,7 +183,7 @@ const fallbackIcon = computed(() => {
 })
 
 const headerIcon = computed(() => {
-  return activeTabConfig.value.icon || fallbackIcon.value
+  return activeTabConfig.value?.icon || fallbackIcon.value
 })
 
 const fallbackTitle = computed(() => {
@@ -225,7 +198,7 @@ const title = computed(() => {
     sheetTitle ||
     store.activeConfig.title ||
     store.splash.title ||
-    activeTabConfig.value.title ||
+    activeTabConfig.value?.title ||
     fallbackTitle.value
   )
 })
@@ -245,8 +218,9 @@ const subtitle = computed(() => {
   return (
     store.splash.tagline ||
     store.activeConfig.label ||
-    activeTabConfig.value.summary ||
-    activeTabConfig.value.label ||
+    activeTabConfig.value?.summary ||
+    activeTabConfig.value?.description ||
+    activeTabConfig.value?.label ||
     fallbackSubtitle.value
   )
 })
@@ -264,16 +238,47 @@ async function syncBuilder(): Promise<void> {
   }
 }
 
+function syncLegacyBuilderTab(tabKey: string): void {
+  const tab = channelContentStore.getTab('build', tabKey)
+  if (!tab?.dashboardTab) return
+
+  const legacyTabs = navStore.getDashboardTabs('builder')
+  if (!legacyTabs.some((item) => item.key === tab.dashboardTab)) return
+
+  navStore.setDashboardTab(
+    'builder',
+    tab.dashboardTab,
+    'builder-manager content sync',
+  )
+}
+
 function resetBuilder(): void {
   store.resetBuilder(true)
   showResetConfirm.value = false
 }
 
-watch(activeTab, syncBuilder)
+watch(activeTab, async (tabKey) => {
+  syncLegacyBuilderTab(tabKey)
+  await syncBuilder()
+})
+
+watch(
+  () => navStore.getDashboardTab('builder'),
+  (legacyTab) => {
+    const tab = builderChannel.value?.tabs.find(
+      (item) => item.dashboardTab === legacyTab,
+    )
+
+    if (tab && tab.tabKey !== activeTab.value) {
+      channelContentStore.setActiveTab('build', tab.tabKey)
+    }
+  },
+)
 
 onMounted(async () => {
   ensureBuildersRegistered()
   store.hydrate()
+  syncLegacyBuilderTab(activeTab.value)
   await syncBuilder()
 })
 </script>

--- a/components/builder/builder-manager.vue
+++ b/components/builder/builder-manager.vue
@@ -238,27 +238,12 @@ async function syncBuilder(): Promise<void> {
   }
 }
 
-function syncLegacyBuilderTab(tabKey: string): void {
-  const tab = channelContentStore.getTab('build', tabKey)
-  if (!tab?.dashboardTab) return
-
-  const legacyTabs = navStore.getDashboardTabs('builder')
-  if (!legacyTabs.some((item) => item.key === tab.dashboardTab)) return
-
-  navStore.setDashboardTab(
-    'builder',
-    tab.dashboardTab,
-    'builder-manager content sync',
-  )
-}
-
 function resetBuilder(): void {
   store.resetBuilder(true)
   showResetConfirm.value = false
 }
 
-watch(activeTab, async (tabKey) => {
-  syncLegacyBuilderTab(tabKey)
+watch(activeTab, async () => {
   await syncBuilder()
 })
 
@@ -278,7 +263,6 @@ watch(
 onMounted(async () => {
   ensureBuildersRegistered()
   store.hydrate()
-  syncLegacyBuilderTab(activeTab.value)
   await syncBuilder()
 })
 </script>

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -173,6 +173,9 @@ const expandedChannelKey = ref('')
 await channelContentStore.initialize()
 
 const visibleChannels = computed(() => channelContentStore.visibleChannels)
+const requestedTabKey = computed(() => {
+  return typeof route.query.tab === 'string' ? route.query.tab.trim() : ''
+})
 
 const fallbackChannel: ResolvedChannel = {
   key: 'home',
@@ -204,7 +207,7 @@ const fallbackChannel: ResolvedChannel = {
 const resolvedLocation = computed(() =>
   channelContentStore.resolveLocation({
     channelKey: pageStore.channelKey,
-    tabKey: pageStore.tabKey,
+    tabKey: requestedTabKey.value || pageStore.tabKey,
     dashboardKey: pageStore.dashboardKey,
     dashboardTab: pageStore.dashboardTab,
     path: route.path,
@@ -217,6 +220,11 @@ const activeChannel = computed<ResolvedChannel>(() => {
 
 const activeTab = computed<ResolvedTab | null>(() => {
   const channel = activeChannel.value
+  const requested = channel.tabs.find(
+    (tab) => tab.tabKey === requestedTabKey.value,
+  )
+  if (requested) return requested
+
   const locatedTab = resolvedLocation.value?.tab
   const locatedOnChildRoute =
     locatedTab &&
@@ -291,6 +299,28 @@ function setSheetFromTab(tab: ResolvedTab): void {
   })
 }
 
+function tabSharesRoute(channel: ResolvedChannel, tab: ResolvedTab): boolean {
+  return channel.tabs.filter((item) => item.route === tab.route).length > 1
+}
+
+function navigateToTab(channel: ResolvedChannel, tab: ResolvedTab): void {
+  if (!tab.route) return
+
+  if (tabSharesRoute(channel, tab)) {
+    if (route.path === tab.route && requestedTabKey.value === tab.tabKey) return
+
+    void router.push({
+      path: tab.route,
+      query: { tab: tab.tabKey },
+    })
+    return
+  }
+
+  if (route.path !== tab.route || requestedTabKey.value) {
+    void router.push(tab.route)
+  }
+}
+
 function selectChannel(channel: ResolvedChannel): void {
   const tab = destinationTab(channel)
 
@@ -310,11 +340,7 @@ function selectTab(channel: ResolvedChannel, tab: ResolvedTab): void {
   channelContentStore.setActiveTab(channel.channelKey, tab.tabKey)
   syncLegacyTab(tab)
   setSheetFromTab(tab)
-
-  if (tab.route && tab.route !== route.path) {
-    void router.push(tab.route)
-  }
-
+  navigateToTab(channel, tab)
   closeDropdown()
 }
 

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -93,6 +93,7 @@ const fallbackChannel: ResolvedChannel = {
   refreshLabel: 'Refresh Home',
   dottiTip: '',
   amiTip: '',
+  tutorial: null,
   tabs: [],
 }
 

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -152,21 +152,16 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { isDashboardKey } from '@/stores/helpers/dashboardHelper'
 import type {
   ResolvedChannel,
   ResolvedTab,
 } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
-import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
-import { useSheetStore } from '@/stores/sheetStore'
 
 const route = useRoute()
 const router = useRouter()
-const navStore = useNavStore()
 const pageStore = usePageStore()
-const sheetStore = useSheetStore()
 const channelContentStore = useChannelContentStore()
 const expandedChannelKey = ref('')
 
@@ -204,18 +199,8 @@ const fallbackChannel: ResolvedChannel = {
   tabs: [],
 }
 
-const resolvedLocation = computed(() =>
-  channelContentStore.resolveLocation({
-    channelKey: pageStore.channelKey,
-    tabKey: requestedTabKey.value || pageStore.tabKey,
-    dashboardKey: pageStore.dashboardKey,
-    dashboardTab: pageStore.dashboardTab,
-    path: route.path,
-  }),
-)
-
 const activeChannel = computed<ResolvedChannel>(() => {
-  return resolvedLocation.value?.channel ?? visibleChannels.value[0] ?? fallbackChannel
+  return pageStore.resolvedChannel ?? visibleChannels.value[0] ?? fallbackChannel
 })
 
 const activeTab = computed<ResolvedTab | null>(() => {
@@ -225,19 +210,17 @@ const activeTab = computed<ResolvedTab | null>(() => {
   )
   if (requested) return requested
 
-  const locatedTab = resolvedLocation.value?.tab
-  const locatedOnChildRoute =
-    locatedTab &&
-    locatedTab.route === route.path &&
-    locatedTab.route !== channel.route
-
-  if (locatedOnChildRoute) return locatedTab
+  if (
+    pageStore.resolvedTab &&
+    pageStore.resolvedTab.channelKey === channel.channelKey
+  ) {
+    return pageStore.resolvedTab
+  }
 
   const storedTabKey = channelContentStore.getActiveTab(channel.channelKey)
 
   return (
     channel.tabs.find((tab) => tab.tabKey === storedTabKey) ??
-    locatedTab ??
     channel.tabs.find((tab) => tab.tabKey === channel.defaultTab) ??
     channel.tabs[0] ??
     null
@@ -273,30 +256,6 @@ function isActiveTab(channel: ResolvedChannel, tab: ResolvedTab): boolean {
 function toggleChannel(channelKey: string): void {
   expandedChannelKey.value =
     expandedChannelKey.value === channelKey ? '' : channelKey
-}
-
-function syncLegacyTab(tab: ResolvedTab): void {
-  if (!tab.dashboardKey || !isDashboardKey(tab.dashboardKey)) return
-
-  const legacyTabs = navStore.getDashboardTabs(tab.dashboardKey)
-  const legacyTab = tab.dashboardTab || tab.tabKey
-
-  if (!legacyTabs.some((item) => item.key === legacyTab)) return
-
-  navStore.setDashboardTab(tab.dashboardKey, legacyTab, 'channel submenu navigation')
-}
-
-function setSheetFromTab(tab: ResolvedTab): void {
-  sheetStore.setSheetFromTab({
-    key: tab.tabKey,
-    label: tab.label,
-    title: tab.title,
-    summary: tab.summary,
-    description: tab.description,
-    narrative: tab.narrative,
-    icon: tab.icon,
-    image: tab.image,
-  })
 }
 
 function tabSharesRoute(channel: ResolvedChannel, tab: ResolvedTab): boolean {
@@ -338,8 +297,6 @@ function selectChannel(channel: ResolvedChannel): void {
 
 function selectTab(channel: ResolvedChannel, tab: ResolvedTab): void {
   channelContentStore.setActiveTab(channel.channelKey, tab.tabKey)
-  syncLegacyTab(tab)
-  setSheetFromTab(tab)
   navigateToTab(channel, tab)
   closeDropdown()
 }

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -30,9 +30,9 @@
       tabindex="0"
       class="menu dropdown-content z-110 mt-2 max-h-[min(32rem,calc(100dvh-5rem))] w-[min(14rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
     >
-      <li v-for="channel in allChannels" :key="channel.key">
+      <li v-for="channel in visibleChannels" :key="channel.channelKey">
         <NuxtLink
-          :to="channel.path"
+          :to="channel.route"
           class="flex min-h-11 items-center gap-2 rounded-xl xl:min-h-12"
           :class="
             isChannelActive(channel) ? 'bg-primary text-primary-content' : ''
@@ -56,79 +56,65 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-
-type ChannelRoute = {
-  key: string
-  label: string
-  path: string
-  icon: string
-}
+import {
+  resolveChannels,
+  type ResolvedChannel,
+  type ChannelContentItem,
+} from '@/stores/helpers/channelContent'
+import { useUserStore } from '@/stores/userStore'
 
 const route = useRoute()
+const userStore = useUserStore()
 
-const allChannels: ChannelRoute[] = [
-  { key: 'home', label: 'Home', path: '/', icon: 'kind-icon:home' },
-
-  {
-    key: 'conductor',
-    label: 'Conductor',
-    path: '/conductor',
-    icon: 'kind-icon:gearhammer',
-  },
-  { key: 'art', label: 'Art', path: '/art', icon: 'kind-icon:palette' },
-
-  {
-    key: 'builder',
-    label: 'Builder',
-    path: '/builder',
-    icon: 'kind-icon:blueprint',
-  },
-
-  {
-    key: 'bots',
-    label: 'Narrators',
-    path: '/bots',
-    icon: 'kind-icon:robot-color',
-  },
-  { key: 'dreams', label: 'Dreams', path: '/dreams', icon: 'kind-icon:moon' },
-  {
-    key: 'characters',
-    label: 'Characters',
-    path: '/characters',
-    icon: 'kind-icon:mask',
-  },
-
-  {
-    key: 'rewards',
-    label: 'Rewards',
-    path: '/rewards',
-    icon: 'kind-icon:trophy',
-  },
-  {
-    key: 'scenarios',
-    label: 'Stories',
-    path: '/stories',
-    icon: 'kind-icon:story',
-  },
-  { key: 'lab', label: 'Lab', path: '/memory', icon: 'kind-icon:dungeon' },
-  {
-    key: 'sanctuary',
-    label: 'Sanctuary',
-    path: '/sanctuary',
-    icon: 'kind-icon:butterfly',
-  },
-]
-
-const fallbackChannel: ChannelRoute = allChannels[0]!
-
-const activeChannel = computed<ChannelRoute>(
+const { data: navigationContent } = await useAsyncData(
+  'navigation-content',
   () =>
-    allChannels.find((channel) => isChannelActive(channel)) ?? fallbackChannel,
+    queryCollection('content')
+      .where('contentType', 'IN', ['channel', 'tab'])
+      .all(),
 )
 
-function isChannelActive(channel: ChannelRoute): boolean {
-  if (route.path === channel.path) return true
-  return channel.path !== '/' && route.path.startsWith(`${channel.path}/`)
+const allChannels = computed(() =>
+  resolveChannels((navigationContent.value ?? []) as ChannelContentItem[]),
+)
+
+const visibleChannels = computed(() =>
+  allChannels.value.filter(
+    (channel) =>
+      !channel.requiredRole || channel.requiredRole === userStore.role,
+  ),
+)
+
+const fallbackChannel: ResolvedChannel = {
+  channelKey: 'home',
+  label: 'Home',
+  title: 'Home',
+  subtitle: '',
+  description: '',
+  summary: '',
+  narrative: '',
+  icon: 'kind-icon:home',
+  image: '/images/channels/home/channel.webp',
+  route: '/',
+  defaultTab: 'dashboard',
+  sort: 0,
+  requiredRole: '',
+  requiredPermission: '',
+  dottiTip: '',
+  amiTip: '',
+  tabs: [],
+}
+
+const activeChannel = computed<ResolvedChannel>(
+  () =>
+    visibleChannels.value.find((channel) => isChannelActive(channel)) ??
+    visibleChannels.value[0] ??
+    fallbackChannel,
+)
+
+function isChannelActive(channel: ResolvedChannel): boolean {
+  if (route.path === channel.route) return true
+  return channel.route !== '/' && route.path.startsWith(`${channel.route}/`)
 }
 
 function closeDropdown(): void {

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -35,7 +35,9 @@
           :to="channel.route"
           class="flex min-h-11 items-center gap-2 rounded-xl xl:min-h-12"
           :class="
-            isChannelActive(channel) ? 'bg-primary text-primary-content' : ''
+            activeChannel.channelKey === channel.channelKey
+              ? 'bg-primary text-primary-content'
+              : ''
           "
           @click="closeDropdown"
         >
@@ -56,43 +58,30 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import {
-  resolveChannels,
-  type ResolvedChannel,
-  type ChannelContentItem,
-} from '@/stores/helpers/channelContent'
-import { useUserStore } from '@/stores/userStore'
+import type { ResolvedChannel } from '@/stores/helpers/channelContent'
+import { useChannelContentStore } from '@/stores/channelContentStore'
+import { usePageStore } from '@/stores/pageStore'
 
 const route = useRoute()
-const userStore = useUserStore()
+const pageStore = usePageStore()
+const channelContentStore = useChannelContentStore()
 
-const { data: navigationContent } = await useAsyncData(
-  'navigation-content',
-  () =>
-    queryCollection('content')
-      .where('contentType', 'IN', ['channel', 'tab'])
-      .all(),
-)
+await channelContentStore.initialize()
 
-const allChannels = computed(() =>
-  resolveChannels((navigationContent.value ?? []) as ChannelContentItem[]),
-)
-
-const visibleChannels = computed(() =>
-  allChannels.value.filter(
-    (channel) =>
-      !channel.requiredRole || channel.requiredRole === userStore.role,
-  ),
-)
+const visibleChannels = computed(() => channelContentStore.visibleChannels)
 
 const fallbackChannel: ResolvedChannel = {
+  key: 'home',
   channelKey: 'home',
+  dashboardKey: 'user',
   label: 'Home',
   title: 'Home',
+  room: 'Kind Robots',
   subtitle: '',
   description: '',
   summary: '',
   narrative: '',
+  tooltip: '',
   icon: 'kind-icon:home',
   image: '/images/channels/home/channel.webp',
   route: '/',
@@ -100,22 +89,24 @@ const fallbackChannel: ResolvedChannel = {
   sort: 0,
   requiredRole: '',
   requiredPermission: '',
+  loadingMessage: 'Loading Home…',
+  refreshLabel: 'Refresh Home',
   dottiTip: '',
   amiTip: '',
   tabs: [],
 }
 
-const activeChannel = computed<ResolvedChannel>(
-  () =>
-    visibleChannels.value.find((channel) => isChannelActive(channel)) ??
-    visibleChannels.value[0] ??
-    fallbackChannel,
-)
+const activeChannel = computed<ResolvedChannel>(() => {
+  const location = channelContentStore.resolveLocation({
+    channelKey: pageStore.channelKey,
+    tabKey: pageStore.tabKey,
+    dashboardKey: pageStore.dashboardKey,
+    dashboardTab: pageStore.dashboardTab,
+    path: route.path,
+  })
 
-function isChannelActive(channel: ResolvedChannel): boolean {
-  if (route.path === channel.route) return true
-  return channel.route !== '/' && route.path.startsWith(`${channel.route}/`)
-}
+  return location?.channel ?? visibleChannels.value[0] ?? fallbackChannel
+})
 
 function closeDropdown(): void {
   if (typeof document !== 'undefined') {

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -5,7 +5,8 @@
       tabindex="0"
       type="button"
       class="flex h-10 min-h-10 shrink-0 items-center gap-2 overflow-hidden rounded-xl border border-base-300 bg-base-100 px-2 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14 xl:gap-2.5 xl:px-3"
-      :title="`Channel: ${activeChannel.label}`"
+      :title="`Navigate ${activeChannel.label}`"
+      aria-haspopup="menu"
     >
       <span
         class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
@@ -16,8 +17,16 @@
         />
       </span>
 
-      <span class="truncate text-sm font-black sm:text-base xl:text-lg">
-        {{ activeChannel.label }}
+      <span class="flex min-w-0 flex-col items-start leading-tight">
+        <span class="truncate text-sm font-black sm:text-base xl:text-lg">
+          {{ activeChannel.label }}
+        </span>
+        <span
+          v-if="activeTab"
+          class="hidden max-w-32 truncate text-[0.62rem] font-bold text-base-content/55 sm:block xl:max-w-40 xl:text-xs"
+        >
+          {{ activeTab.label }}
+        </span>
       </span>
 
       <Icon
@@ -28,43 +37,138 @@
 
     <ul
       tabindex="0"
-      class="menu dropdown-content z-110 mt-2 max-h-[min(32rem,calc(100dvh-5rem))] w-[min(14rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+      class="menu dropdown-content z-110 mt-2 max-h-[min(38rem,calc(100dvh-5rem))] w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
     >
-      <li v-for="channel in visibleChannels" :key="channel.channelKey">
-        <NuxtLink
-          :to="channel.route"
-          class="flex min-h-11 items-center gap-2 rounded-xl xl:min-h-12"
+      <li
+        v-for="channel in visibleChannels"
+        :key="channel.channelKey"
+        class="channel-menu-item"
+      >
+        <div
+          class="flex min-h-12 w-full items-stretch overflow-hidden rounded-xl"
           :class="
             activeChannel.channelKey === channel.channelKey
               ? 'bg-primary text-primary-content'
+              : 'hover:bg-base-200'
+          "
+        >
+          <button
+            type="button"
+            class="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
+            @click="selectChannel(channel)"
+          >
+            <span
+              class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-base-300/50 bg-base-200 text-base-content xl:h-10 xl:w-10"
+            >
+              <Icon :name="channel.icon" class="h-4 w-4 shrink-0" />
+            </span>
+
+            <span class="flex min-w-0 flex-1 flex-col items-start leading-tight">
+              <span class="max-w-full truncate text-sm font-black xl:text-base">
+                {{ channel.label }}
+              </span>
+              <span class="max-w-full truncate text-xs font-semibold opacity-65">
+                {{ destinationTab(channel)?.label || channel.title }}
+              </span>
+            </span>
+          </button>
+
+          <button
+            v-if="channel.tabs.length > 1"
+            type="button"
+            class="flex w-10 shrink-0 items-center justify-center border-l border-current/10"
+            :aria-label="`Show ${channel.label} tabs`"
+            :aria-expanded="expandedChannelKey === channel.channelKey"
+            @click.stop="toggleChannel(channel.channelKey)"
+          >
+            <Icon
+              name="kind-icon:chevron-right"
+              class="h-4 w-4 transition-transform"
+              :class="
+                expandedChannelKey === channel.channelKey ? 'rotate-90' : ''
+              "
+            />
+          </button>
+        </div>
+
+        <ul
+          v-if="channel.tabs.length > 1"
+          class="channel-submenu menu ml-5 mt-1 border-l border-base-300 pl-2"
+          :class="
+            expandedChannelKey === channel.channelKey
+              ? 'channel-submenu-open'
               : ''
           "
-          @click="closeDropdown"
         >
-          <span
-            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-base-300/50 bg-base-200 xl:h-9 xl:w-9"
-          >
-            <Icon :name="channel.icon" class="h-4 w-4 shrink-0" />
-          </span>
-          <span class="truncate text-sm font-black xl:text-base">
-            {{ channel.label }}
-          </span>
-        </NuxtLink>
+          <li v-for="tab in channel.tabs" :key="tab.tabKey">
+            <button
+              type="button"
+              class="flex min-h-11 items-center gap-2 rounded-xl"
+              :class="
+                isActiveTab(channel, tab)
+                  ? 'active bg-secondary text-secondary-content'
+                  : ''
+              "
+              @click="selectTab(channel, tab)"
+            >
+              <span
+                class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-base-200"
+              >
+                <img
+                  v-if="tab.image"
+                  :src="tab.image"
+                  :alt="tab.title || tab.label"
+                  class="h-full w-full object-cover"
+                />
+                <span
+                  class="absolute inset-0 flex items-center justify-center bg-base-content/20"
+                >
+                  <Icon
+                    :name="tab.icon || channel.icon"
+                    class="h-4 w-4 text-base-100 drop-shadow"
+                  />
+                </span>
+              </span>
+
+              <span class="flex min-w-0 flex-1 flex-col items-start leading-tight">
+                <span class="max-w-full truncate text-sm font-black">
+                  {{ tab.label }}
+                </span>
+                <span
+                  v-if="tab.summary || tab.description"
+                  class="line-clamp-1 text-xs font-medium opacity-65"
+                >
+                  {{ tab.summary || tab.description }}
+                </span>
+              </span>
+            </button>
+          </li>
+        </ul>
       </li>
     </ul>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useRoute } from 'vue-router'
-import type { ResolvedChannel } from '@/stores/helpers/channelContent'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { isDashboardKey } from '@/stores/helpers/dashboardHelper'
+import type {
+  ResolvedChannel,
+  ResolvedTab,
+} from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
+import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
+import { useSheetStore } from '@/stores/sheetStore'
 
 const route = useRoute()
+const router = useRouter()
+const navStore = useNavStore()
 const pageStore = usePageStore()
+const sheetStore = useSheetStore()
 const channelContentStore = useChannelContentStore()
+const expandedChannelKey = ref('')
 
 await channelContentStore.initialize()
 
@@ -97,22 +201,144 @@ const fallbackChannel: ResolvedChannel = {
   tabs: [],
 }
 
-const activeChannel = computed<ResolvedChannel>(() => {
-  const location = channelContentStore.resolveLocation({
+const resolvedLocation = computed(() =>
+  channelContentStore.resolveLocation({
     channelKey: pageStore.channelKey,
     tabKey: pageStore.tabKey,
     dashboardKey: pageStore.dashboardKey,
     dashboardTab: pageStore.dashboardTab,
     path: route.path,
-  })
+  }),
+)
 
-  return location?.channel ?? visibleChannels.value[0] ?? fallbackChannel
+const activeChannel = computed<ResolvedChannel>(() => {
+  return resolvedLocation.value?.channel ?? visibleChannels.value[0] ?? fallbackChannel
 })
 
-function closeDropdown(): void {
-  if (typeof document !== 'undefined') {
-    const el = document.activeElement as HTMLElement | null
-    el?.blur()
+const activeTab = computed<ResolvedTab | null>(() => {
+  const channel = activeChannel.value
+  const locatedTab = resolvedLocation.value?.tab
+  const locatedOnChildRoute =
+    locatedTab &&
+    locatedTab.route === route.path &&
+    locatedTab.route !== channel.route
+
+  if (locatedOnChildRoute) return locatedTab
+
+  const storedTabKey = channelContentStore.getActiveTab(channel.channelKey)
+
+  return (
+    channel.tabs.find((tab) => tab.tabKey === storedTabKey) ??
+    locatedTab ??
+    channel.tabs.find((tab) => tab.tabKey === channel.defaultTab) ??
+    channel.tabs[0] ??
+    null
+  )
+})
+
+watch(
+  () => activeChannel.value.channelKey,
+  (channelKey) => {
+    expandedChannelKey.value = channelKey
+  },
+  { immediate: true },
+)
+
+function destinationTab(channel: ResolvedChannel): ResolvedTab | null {
+  const storedTabKey = channelContentStore.getActiveTab(channel.channelKey)
+
+  return (
+    channel.tabs.find((tab) => tab.tabKey === storedTabKey) ??
+    channel.tabs.find((tab) => tab.tabKey === channel.defaultTab) ??
+    channel.tabs[0] ??
+    null
+  )
+}
+
+function isActiveTab(channel: ResolvedChannel, tab: ResolvedTab): boolean {
+  return (
+    activeChannel.value.channelKey === channel.channelKey &&
+    activeTab.value?.tabKey === tab.tabKey
+  )
+}
+
+function toggleChannel(channelKey: string): void {
+  expandedChannelKey.value =
+    expandedChannelKey.value === channelKey ? '' : channelKey
+}
+
+function syncLegacyTab(tab: ResolvedTab): void {
+  if (!tab.dashboardKey || !isDashboardKey(tab.dashboardKey)) return
+
+  const legacyTabs = navStore.getDashboardTabs(tab.dashboardKey)
+  const legacyTab = tab.dashboardTab || tab.tabKey
+
+  if (!legacyTabs.some((item) => item.key === legacyTab)) return
+
+  navStore.setDashboardTab(tab.dashboardKey, legacyTab, 'channel submenu navigation')
+}
+
+function setSheetFromTab(tab: ResolvedTab): void {
+  sheetStore.setSheetFromTab({
+    key: tab.tabKey,
+    label: tab.label,
+    title: tab.title,
+    summary: tab.summary,
+    description: tab.description,
+    narrative: tab.narrative,
+    icon: tab.icon,
+    image: tab.image,
+  })
+}
+
+function selectChannel(channel: ResolvedChannel): void {
+  const tab = destinationTab(channel)
+
+  if (tab) {
+    selectTab(channel, tab)
+    return
   }
+
+  if (channel.route && channel.route !== route.path) {
+    void router.push(channel.route)
+  }
+
+  closeDropdown()
+}
+
+function selectTab(channel: ResolvedChannel, tab: ResolvedTab): void {
+  channelContentStore.setActiveTab(channel.channelKey, tab.tabKey)
+  syncLegacyTab(tab)
+  setSheetFromTab(tab)
+
+  if (tab.route && tab.route !== route.path) {
+    void router.push(tab.route)
+  }
+
+  closeDropdown()
+}
+
+function closeDropdown(): void {
+  if (typeof document === 'undefined') return
+
+  const element = document.activeElement as HTMLElement | null
+  element?.blur()
 }
 </script>
+
+<style scoped>
+.channel-submenu {
+  display: none;
+}
+
+.channel-submenu-open,
+.channel-menu-item:focus-within > .channel-submenu {
+  display: flex;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .channel-menu-item:hover > .channel-submenu {
+    display: flex;
+  }
+}
+</style>

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -1,0 +1,255 @@
+<!-- /components/navigation/navigation-health.vue -->
+<template>
+  <section class="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-6">
+    <header
+      class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+    >
+      <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <Icon name="kind-icon:compass" class="h-6 w-6 text-primary" />
+            <h1 class="text-xl font-black sm:text-2xl">Navigation Health</h1>
+          </div>
+          <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
+            Inspect the resolved Nuxt Content navigation graph, route sharing,
+            compatibility adapters, permissions, and artwork failures from one
+            operational view.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm shrink-0 rounded-xl"
+          :disabled="channelContentStore.loading"
+          @click="refresh"
+        >
+          <span
+            v-if="channelContentStore.loading"
+            class="loading loading-spinner loading-xs"
+          />
+          <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+          Reload content
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="channelContentStore.lastError"
+      class="alert alert-error rounded-2xl border border-error/30"
+    >
+      <Icon name="kind-icon:error" class="h-5 w-5" />
+      <span>{{ channelContentStore.lastError }}</span>
+    </div>
+
+    <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <div class="stat-title">Channels</div>
+        <div class="stat-value text-primary">{{ channels.length }}</div>
+        <div class="stat-desc">Resolved parent documents</div>
+      </article>
+
+      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <div class="stat-title">Tabs</div>
+        <div class="stat-value">{{ totalTabs }}</div>
+        <div class="stat-desc">Resolved child documents</div>
+      </article>
+
+      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <div class="stat-title">Shared routes</div>
+        <div class="stat-value text-secondary">{{ sharedRouteGroups.length }}</div>
+        <div class="stat-desc">Groups using ?tab= addressing</div>
+      </article>
+
+      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <div class="stat-title">Legacy adapters</div>
+        <div class="stat-value text-warning">{{ legacyAdapterCount }}</div>
+        <div class="stat-desc">Tabs bridging old dashboards</div>
+      </article>
+
+      <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <div class="stat-title">Broken artwork</div>
+        <div class="stat-value" :class="brokenImages.size ? 'text-error' : 'text-success'">
+          {{ brokenImages.size }}
+        </div>
+        <div class="stat-desc">Detected by browser image loading</div>
+      </article>
+    </section>
+
+    <section
+      v-if="sharedRouteGroups.length"
+      class="rounded-2xl border border-secondary/30 bg-secondary/5 p-4 shadow-sm"
+    >
+      <div class="flex items-center gap-2">
+        <Icon name="kind-icon:link" class="h-5 w-5 text-secondary" />
+        <h2 class="font-black">Shared-route groups</h2>
+      </div>
+      <div class="mt-3 flex flex-wrap gap-2">
+        <span
+          v-for="group in sharedRouteGroups"
+          :key="`${group.channelKey}:${group.route}`"
+          class="badge badge-secondary badge-outline h-auto gap-1 whitespace-normal py-1.5"
+        >
+          <strong>{{ group.channelKey }}</strong>
+          <span>{{ group.route }}</span>
+          <span>({{ group.tabs.join(', ') }})</span>
+        </span>
+      </div>
+    </section>
+
+    <section class="grid gap-4 xl:grid-cols-2">
+      <article
+        v-for="channel in channels"
+        :key="channel.channelKey"
+        class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+      >
+        <header class="relative overflow-hidden border-b border-base-300 p-4">
+          <img
+            v-if="channel.image"
+            :src="channel.image"
+            :alt="channel.title"
+            class="absolute inset-0 -z-10 h-full w-full object-cover opacity-10"
+            @error="markBroken(channel.image)"
+          />
+          <div class="absolute inset-0 -z-10 bg-base-100/85" />
+
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex min-w-0 items-start gap-3">
+              <span
+                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-base-300 bg-base-200"
+              >
+                <Icon :name="channel.icon" class="h-5 w-5" />
+              </span>
+              <div class="min-w-0">
+                <h2 class="truncate text-lg font-black">{{ channel.label }}</h2>
+                <p class="truncate text-xs font-bold text-base-content/45">
+                  {{ channel.channelKey }} · {{ channel.route }}
+                </p>
+                <p class="mt-1 line-clamp-2 text-sm text-base-content/65">
+                  {{ channel.description || channel.summary || channel.subtitle }}
+                </p>
+              </div>
+            </div>
+
+            <div class="flex shrink-0 flex-col items-end gap-1">
+              <span class="badge badge-primary badge-outline">
+                {{ channel.tabs.length }} tabs
+              </span>
+              <span v-if="channel.requiredRole" class="badge badge-warning badge-sm">
+                {{ channel.requiredRole }}
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div class="divide-y divide-base-300">
+          <div
+            v-for="tab in channel.tabs"
+            :key="tab.tabKey"
+            class="flex items-start gap-3 p-3"
+          >
+            <span
+              class="relative flex h-9 w-9 shrink-0 overflow-hidden rounded-lg border border-base-300 bg-base-200"
+            >
+              <img
+                v-if="tab.image"
+                :src="tab.image"
+                :alt="tab.title"
+                class="h-full w-full object-cover"
+                @error="markBroken(tab.image)"
+              />
+              <span
+                class="absolute inset-0 flex items-center justify-center bg-base-content/15"
+              >
+                <Icon :name="tab.icon || channel.icon" class="h-4 w-4 text-base-100" />
+              </span>
+            </span>
+
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span class="font-black">{{ tab.label }}</span>
+                <span
+                  v-if="tab.tabKey === channel.defaultTab"
+                  class="badge badge-primary badge-xs"
+                >
+                  default
+                </span>
+                <span
+                  v-if="tab.dashboardKey"
+                  class="badge badge-warning badge-outline badge-xs"
+                >
+                  {{ tab.dashboardKey }}/{{ tab.dashboardTab }}
+                </span>
+                <span v-if="tab.requiredRole" class="badge badge-error badge-outline badge-xs">
+                  {{ tab.requiredRole }}
+                </span>
+              </div>
+              <p class="mt-0.5 truncate text-xs font-semibold text-base-content/45">
+                {{ tab.tabKey }} · {{ tab.route }}
+              </p>
+              <p class="mt-1 line-clamp-2 text-xs text-base-content/65">
+                {{ tab.description || tab.summary || tab.subtitle }}
+              </p>
+              <p
+                v-if="brokenImages.has(tab.image)"
+                class="mt-1 break-all text-xs font-bold text-error"
+              >
+                Missing: {{ tab.image }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useChannelContentStore } from '@/stores/channelContentStore'
+
+const channelContentStore = useChannelContentStore()
+const brokenImages = ref(new Set<string>())
+
+await channelContentStore.initialize()
+
+const channels = computed(() => channelContentStore.channels)
+const totalTabs = computed(() =>
+  channels.value.reduce((total, channel) => total + channel.tabs.length, 0),
+)
+const legacyAdapterCount = computed(() =>
+  channels.value.reduce(
+    (total, channel) =>
+      total + channel.tabs.filter((tab) => Boolean(tab.dashboardKey)).length,
+    0,
+  ),
+)
+const sharedRouteGroups = computed(() => {
+  return channels.value.flatMap((channel) => {
+    const routes = new Map<string, string[]>()
+
+    for (const tab of channel.tabs) {
+      const current = routes.get(tab.route) ?? []
+      current.push(tab.tabKey)
+      routes.set(tab.route, current)
+    }
+
+    return Array.from(routes.entries())
+      .filter(([, tabs]) => tabs.length > 1)
+      .map(([route, tabs]) => ({
+        channelKey: channel.channelKey,
+        route,
+        tabs,
+      }))
+  })
+})
+
+function markBroken(image: string): void {
+  if (!image) return
+  brokenImages.value = new Set([...brokenImages.value, image])
+}
+
+async function refresh(): Promise<void> {
+  brokenImages.value = new Set()
+  await channelContentStore.initialize(true)
+}
+</script>

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -1,8 +1,6 @@
 <!-- /components/navigation/tutorial-flyer.vue -->
 <template>
-  <!-- Inline: lightweight, single-column on sm, image+text two-up on lg/xl -->
   <div v-if="inline && config" class="flex flex-col gap-4">
-    <!-- Lead image -->
     <img
       v-if="heroImage"
       :src="heroImage"
@@ -11,7 +9,6 @@
       class="w-full rounded-2xl object-cover shadow-sm md:max-h-72 lg:max-h-80"
     />
 
-    <!-- Overview text -->
     <div class="flex flex-col gap-3">
       <p
         class="text-sm font-medium leading-relaxed text-base-content/80 md:text-base"
@@ -34,7 +31,6 @@
       </div>
     </div>
 
-    <!-- Sections: image then text, side-by-side only on lg+ -->
     <section
       v-for="section in config.sections"
       :key="section.key"
@@ -75,7 +71,6 @@
     </section>
   </div>
 
-  <!-- Modal: unchanged full-flyer experience -->
   <Transition v-else name="tutorial-fade">
     <div
       v-if="visible && config"
@@ -92,7 +87,6 @@
         :aria-modal="true"
         :aria-label="`${config.title} tutorial`"
       >
-        <!-- Hero band -->
         <header
           class="relative shrink-0 overflow-hidden border-b border-base-300/60 bg-linear-to-br from-primary/10 via-base-200/50 to-secondary/10 px-5 pb-5 pt-6 sm:px-7 sm:pt-7"
         >
@@ -151,7 +145,6 @@
             </div>
           </div>
 
-          <!-- Step progress -->
           <div
             v-if="stepCount > 1"
             class="relative mt-5 flex items-center gap-2"
@@ -171,7 +164,6 @@
         </header>
 
         <div class="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-7 sm:py-6">
-          <!-- Overview -->
           <section
             class="rounded-2xl border border-base-300/60 bg-base-200/50 p-4 sm:p-5"
           >
@@ -199,7 +191,6 @@
             </div>
           </section>
 
-          <!-- Steps -->
           <ol class="mt-5 space-y-3">
             <li
               v-for="(section, index) in config.sections"
@@ -285,18 +276,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onBeforeUnmount, watch } from 'vue'
-import { useTutorialStore } from '~/stores/tutorialStore'
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
+import { useChannelContentStore } from '@/stores/channelContentStore'
+import { useTutorialStore } from '@/stores/tutorialStore'
 import {
   getTutorialChannel,
   getTutorialHero,
   isTutorialChannelKey,
-  type TutorialChannelKey,
-} from '~/stores/helpers/tutorialCards'
+} from '@/stores/helpers/tutorialCards'
 
 const props = withDefaults(
   defineProps<{
-    channel: TutorialChannelKey | string
+    channel: string
     autoOpen?: boolean
     inline?: boolean
   }>(),
@@ -306,29 +297,48 @@ const props = withDefaults(
   },
 )
 
+const channelContentStore = useChannelContentStore()
 const tutorialStore = useTutorialStore()
 
-const channelKey = computed<TutorialChannelKey | null>(() => {
-  return isTutorialChannelKey(props.channel) ? props.channel : null
-})
+await channelContentStore.initialize()
 
+const requestedChannelKey = computed(() => props.channel.trim())
+const contentChannel = computed(() =>
+  channelContentStore.getChannel(requestedChannelKey.value),
+)
+const legacyChannelKey = computed(() =>
+  isTutorialChannelKey(requestedChannelKey.value)
+    ? requestedChannelKey.value
+    : null,
+)
+const channelKey = computed(
+  () =>
+    contentChannel.value?.channelKey ||
+    legacyChannelKey.value ||
+    requestedChannelKey.value ||
+    null,
+)
 const config = computed(() => {
-  return channelKey.value ? getTutorialChannel(channelKey.value) : null
+  if (contentChannel.value?.tutorial) return contentChannel.value.tutorial
+  if (legacyChannelKey.value) return getTutorialChannel(legacyChannelKey.value)
+  return null
 })
-
 const heroImage = computed(() => {
-  return channelKey.value ? getTutorialHero(channelKey.value) : null
+  if (contentChannel.value?.tutorial?.hero) {
+    return contentChannel.value.tutorial.hero
+  }
+
+  return legacyChannelKey.value
+    ? getTutorialHero(legacyChannelKey.value)
+    : null
 })
-
 const stepCount = computed(() => config.value?.sections?.length ?? 0)
-
 const visible = computed(() => {
-  if (!channelKey.value) return false
+  if (!channelKey.value || !config.value) return false
   if (props.inline) return true
 
   return tutorialStore.activeChannel === channelKey.value
 })
-
 const showNextTime = computed({
   get: () => {
     return channelKey.value
@@ -352,7 +362,6 @@ function onKeydown(event: KeyboardEvent): void {
   }
 }
 
-// Lock body scroll while the modal flyer is open.
 watch(
   () => visible.value && !props.inline,
   (isModalOpen) => {
@@ -365,6 +374,7 @@ onMounted(() => {
   if (typeof window !== 'undefined') {
     window.addEventListener('keydown', onKeydown)
   }
+
   if (!props.inline && props.autoOpen && channelKey.value) {
     tutorialStore.maybeAutoOpen(channelKey.value)
   }
@@ -374,6 +384,7 @@ onBeforeUnmount(() => {
   if (typeof window !== 'undefined') {
     window.removeEventListener('keydown', onKeydown)
   }
+
   if (typeof document !== 'undefined') {
     document.body.style.overflow = ''
   }
@@ -381,7 +392,6 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-/* Open/close transition for the modal layer */
 .tutorial-fade-enter-active,
 .tutorial-fade-leave-active {
   transition: opacity 0.2s ease;

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -84,19 +84,16 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { isDashboardKey } from '@/stores/helpers/dashboardHelper'
 import type { ResolvedTab } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
-import { useSheetStore } from '@/stores/sheetStore'
 
 const fallbackIcon = 'kind-icon:sparkles'
 
 const channelContentStore = useChannelContentStore()
 const navStore = useNavStore()
 const pageStore = usePageStore()
-const sheetStore = useSheetStore()
 const router = useRouter()
 const route = useRoute()
 
@@ -106,17 +103,7 @@ const requestedTabKey = computed(() => {
   return typeof route.query.tab === 'string' ? route.query.tab.trim() : ''
 })
 
-const resolvedLocation = computed(() =>
-  channelContentStore.resolveLocation({
-    channelKey: pageStore.channelKey,
-    tabKey: requestedTabKey.value || pageStore.tabKey,
-    dashboardKey: pageStore.dashboardKey,
-    dashboardTab: pageStore.dashboardTab,
-    path: route.path,
-  }),
-)
-
-const resolvedChannel = computed(() => resolvedLocation.value?.channel ?? null)
+const resolvedChannel = computed(() => pageStore.resolvedChannel)
 const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
 
 const shellTitle = computed(
@@ -144,18 +131,17 @@ const activeTabKey = computed(() => {
     return requestedTabKey.value
   }
 
-  const locatedTab = resolvedLocation.value?.tab
-  const locatedOnChildRoute =
-    locatedTab &&
-    locatedTab.route === route.path &&
-    locatedTab.route !== channel.route
-
-  if (locatedOnChildRoute) return locatedTab.tabKey
+  if (
+    pageStore.resolvedTab &&
+    pageStore.resolvedTab.channelKey === channel.channelKey
+  ) {
+    return pageStore.resolvedTab.tabKey
+  }
 
   const stored = channelContentStore.getActiveTab(channel.channelKey)
   if (stored && channel.tabs.some((tab) => tab.tabKey === stored)) return stored
 
-  return locatedTab?.tabKey || channel.defaultTab || channel.tabs[0]?.tabKey || ''
+  return channel.defaultTab || channel.tabs[0]?.tabKey || ''
 })
 
 const fallbackTab: ResolvedTab = {
@@ -214,39 +200,10 @@ watch(
   ({ channelKey, tabKey }) => {
     if (!channelKey || !tabKey) return
 
-    const tab = resolvedTabs.value.find((item) => item.tabKey === tabKey)
-    if (!tab) return
-
     channelContentStore.setActiveTab(channelKey, tabKey)
-    syncLegacyTab(tab, 'workspace-header route sync')
-    setSheetFromTab(tab)
   },
   { immediate: true },
 )
-
-function syncLegacyTab(tab: ResolvedTab, reason: string): void {
-  if (!tab.dashboardKey || !isDashboardKey(tab.dashboardKey)) return
-
-  const legacyTabs = navStore.getDashboardTabs(tab.dashboardKey)
-  const legacyTab = tab.dashboardTab || tab.tabKey
-
-  if (!legacyTabs.some((item) => item.key === legacyTab)) return
-
-  navStore.setDashboardTab(tab.dashboardKey, legacyTab, reason)
-}
-
-function setSheetFromTab(tab: ResolvedTab): void {
-  sheetStore.setSheetFromTab({
-    key: tab.tabKey,
-    label: tab.label,
-    title: tab.title,
-    summary: tab.summary,
-    description: tab.description,
-    narrative: tab.narrative,
-    icon: tab.icon,
-    image: tab.image,
-  })
-}
 
 function goBack(): void {
   const path = navStore.backPath

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -1,4 +1,4 @@
-<!-- /components/content/navigation/workspace-header.vue -->
+<!-- /components/navigation/workspace-header.vue -->
 <template>
   <header
     class="relative z-30 mb-2 shrink-0 overflow-visible rounded-2xl border border-base-300/70 bg-base-100/95 shadow-sm backdrop-blur"
@@ -21,7 +21,6 @@
 
       <channel-select class="shrink-0" />
 
-      <!-- Unified tab selector — same layout at every breakpoint, scales up on larger screens -->
       <div v-if="resolvedTabs.length" class="dropdown min-w-0 flex-1">
         <button
           tabindex="0"
@@ -48,7 +47,6 @@
               :alt="activeTabConfig.title || activeTabConfig.label"
               class="h-full w-full object-cover"
             />
-
             <span
               class="absolute inset-0 flex items-center justify-center bg-base-content/20"
             >
@@ -84,16 +82,16 @@
           tabindex="0"
           class="menu dropdown-content z-40 mt-2 max-h-80 w-[min(24rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
         >
-          <li v-for="tab in resolvedTabs" :key="tab.key">
+          <li v-for="tab in resolvedTabs" :key="tab.tabKey">
             <button
               type="button"
               class="flex min-h-12 items-center gap-2 rounded-xl xl:min-h-14"
               :class="
-                activeTabKey === tab.key
+                activeTabKey === tab.tabKey
                   ? 'active bg-primary text-primary-content'
                   : ''
               "
-              @click="selectTabFromDropdown(tab.key)"
+              @click="selectTabFromDropdown(tab.tabKey)"
             >
               <span
                 class="relative flex h-9 w-9 shrink-0 overflow-hidden rounded-lg bg-base-200 xl:h-10 xl:w-10"
@@ -123,10 +121,10 @@
                 </span>
 
                 <span
-                  v-if="tab.summary"
+                  v-if="tab.summary || tab.description"
                   class="line-clamp-1 text-xs font-medium opacity-70"
                 >
-                  {{ tab.summary }}
+                  {{ tab.summary || tab.description }}
                 </span>
               </span>
             </button>
@@ -166,23 +164,30 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import {
-  isDashboardKey,
-  type DashboardKey,
-  type DashboardTabConfig,
-} from '@/stores/helpers/dashboardHelper'
+import { isDashboardKey } from '@/stores/helpers/dashboardHelper'
+import type { ResolvedTab } from '@/stores/helpers/channelContent'
+import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
+import { useSheetStore } from '@/stores/sheetStore'
 
 const fallbackIcon = 'kind-icon:sparkles'
 
+const channelContentStore = useChannelContentStore()
 const navStore = useNavStore()
 const pageStore = usePageStore()
+const sheetStore = useSheetStore()
 const router = useRouter()
 const route = useRoute()
 
+await channelContentStore.initialize()
+
 const shellTitle = computed(
-  () => pageStore.room || pageStore.title || 'Kind Robots',
+  () =>
+    resolvedChannel.value?.room ||
+    pageStore.room ||
+    pageStore.title ||
+    'Kind Robots',
 )
 
 const shellSummary = computed(
@@ -191,82 +196,73 @@ const shellSummary = computed(
 
 const showBackButton = computed(() => navStore.canGoBack)
 
-const resolvedDashboardKey = computed<DashboardKey | null>(() => {
-  const shellKey = navStore.dashboardShell.dashboardKey
+const resolvedLocation = computed(() =>
+  channelContentStore.resolveLocation({
+    channelKey: pageStore.channelKey,
+    tabKey: pageStore.tabKey,
+    dashboardKey: pageStore.dashboardKey,
+    dashboardTab: pageStore.dashboardTab,
+    path: route.path,
+  }),
+)
 
-  if (shellKey && isDashboardKey(shellKey)) {
-    return shellKey
-  }
-
-  const pageKey = (pageStore.dashboardKey || '').trim()
-
-  return pageKey && isDashboardKey(pageKey) ? pageKey : null
-})
-
-const resolvedTabs = computed<DashboardTabConfig[]>(() => {
-  const key = resolvedDashboardKey.value
-  return key ? navStore.getDashboardTabs(key) : []
-})
-
-const routeRequestedTabKey = computed(() => {
-  const tabKey = (pageStore.dashboardTab || '').trim()
-  if (!tabKey) return ''
-
-  const tabExists = resolvedTabs.value.some((tab) => tab.key === tabKey)
-  return tabExists ? tabKey : ''
-})
+const resolvedChannel = computed(() => resolvedLocation.value?.channel ?? null)
+const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
 
 const activeTabKey = computed(() => {
-  const key = resolvedDashboardKey.value
-  if (!key) return ''
+  const channel = resolvedChannel.value
+  if (!channel) return ''
 
-  const storedTab = navStore.getDashboardTab(key)
+  const locatedTab = resolvedLocation.value?.tab
+  const locatedOnChildRoute =
+    locatedTab &&
+    locatedTab.route === route.path &&
+    locatedTab.route !== channel.route
 
-  const storedTabExists = resolvedTabs.value.some(
-    (tab) => tab.key === storedTab,
-  )
+  if (locatedOnChildRoute) return locatedTab.tabKey
 
-  if (storedTabExists) {
-    return storedTab
-  }
+  const stored = channelContentStore.getActiveTab(channel.channelKey)
+  if (stored && channel.tabs.some((tab) => tab.tabKey === stored)) return stored
 
-  const contentTab = navStore.dashboardShell.activeTabHint
-
-  const contentTabExists = resolvedTabs.value.some(
-    (tab) => tab.key === contentTab,
-  )
-
-  if (contentTabExists) {
-    return contentTab
-  }
-
-  return resolvedTabs.value[0]?.key || ''
+  return locatedTab?.tabKey || channel.defaultTab || channel.tabs[0]?.tabKey || ''
 })
 
-const activeTabConfig = computed<DashboardTabConfig>(() => {
-  const matched = resolvedTabs.value.find(
-    (tab) => tab.key === activeTabKey.value,
+const fallbackTab: ResolvedTab = {
+  key: 'overview',
+  channelKey: 'home',
+  tabKey: 'overview',
+  dashboardKey: '',
+  dashboardTab: '',
+  label: pageStore.title || 'Overview',
+  title: pageStore.title || 'Overview',
+  room: pageStore.room || 'Kind Robots',
+  subtitle: shellSummary.value,
+  description: shellSummary.value,
+  summary: shellSummary.value,
+  narrative: shellSummary.value || pageStore.title || 'Overview',
+  tooltip: pageStore.tooltip,
+  icon: fallbackIcon,
+  image: pageStore.image || '',
+  route: pageStore.currentPage?.path || '/',
+  component: '',
+  modelType: '',
+  sort: 0,
+  cards: null,
+  requiredBeforeNext: [],
+  requiredRole: '',
+  requiredPermission: '',
+  loadingMessage: pageStore.loadingMessage || 'Loading…',
+  refreshLabel: pageStore.refreshLabel || 'Refresh',
+  dottiTip: pageStore.dottiTip,
+  amiTip: pageStore.amiTip,
+}
+
+const activeTabConfig = computed<ResolvedTab>(() => {
+  return (
+    resolvedTabs.value.find((tab) => tab.tabKey === activeTabKey.value) ??
+    resolvedTabs.value[0] ??
+    fallbackTab
   )
-
-  if (matched) return matched
-
-  const firstTab = resolvedTabs.value[0]
-
-  if (firstTab) return firstTab
-
-  const title = pageStore.title || 'Overview'
-  const summary = shellSummary.value || ''
-
-  return {
-    key: activeTabKey.value || 'overview',
-    label: title,
-    icon: fallbackIcon,
-    title,
-    summary,
-    narrative: summary || title,
-    image: pageStore.image || '',
-    route: pageStore.currentPage?.path || '/',
-  }
 })
 
 const activeTitle = computed(
@@ -278,33 +274,58 @@ const activeTitle = computed(
 
 watch(
   () => ({
-    dashboardKey: resolvedDashboardKey.value,
-    dashboardTab: routeRequestedTabKey.value,
+    channelKey: resolvedChannel.value?.channelKey || '',
+    tabKey: resolvedLocation.value?.tab?.tabKey || '',
+    path: route.path,
   }),
-  ({ dashboardKey, dashboardTab }) => {
-    if (!dashboardKey || !dashboardTab) return
+  ({ channelKey, tabKey }) => {
+    if (!channelKey || !tabKey) return
 
-    const currentTab = navStore.getDashboardTab(dashboardKey)
-    if (currentTab === dashboardTab) return
+    const tab = resolvedTabs.value.find((item) => item.tabKey === tabKey)
+    if (!tab) return
 
-    navStore.setDashboardTab(
-      dashboardKey,
-      dashboardTab,
-      'dashboard-header route-enforced tab',
-    )
+    channelContentStore.setActiveTab(channelKey, tabKey)
+    syncLegacyTab(tab, 'workspace-header route sync')
+    setSheetFromTab(tab)
   },
   { immediate: true },
 )
 
-function selectTabFromDropdown(tabKey: string): void {
-  setTab(tabKey)
+function syncLegacyTab(tab: ResolvedTab, reason: string): void {
+  if (!tab.dashboardKey || !isDashboardKey(tab.dashboardKey)) return
 
-  // When a tab lives on its own route (a project page stitched into this
-  // channel), navigate there. Tabs that share the current channel route keep
-  // rendering inline via the channel manager, so behavior is unchanged for them.
-  const tab = resolvedTabs.value.find((entry) => entry.key === tabKey)
-  if (tab?.route && tab.route !== route.path) {
-    router.push(tab.route)
+  const legacyTabs = navStore.getDashboardTabs(tab.dashboardKey)
+  const legacyTab = tab.dashboardTab || tab.tabKey
+
+  if (!legacyTabs.some((item) => item.key === legacyTab)) return
+
+  navStore.setDashboardTab(tab.dashboardKey, legacyTab, reason)
+}
+
+function setSheetFromTab(tab: ResolvedTab): void {
+  sheetStore.setSheetFromTab({
+    key: tab.tabKey,
+    label: tab.label,
+    title: tab.title,
+    summary: tab.summary,
+    description: tab.description,
+    narrative: tab.narrative,
+    icon: tab.icon,
+    image: tab.image,
+  })
+}
+
+function selectTabFromDropdown(tabKey: string): void {
+  const channel = resolvedChannel.value
+  const tab = resolvedTabs.value.find((item) => item.tabKey === tabKey)
+  if (!channel || !tab) return
+
+  channelContentStore.setActiveTab(channel.channelKey, tab.tabKey)
+  syncLegacyTab(tab, 'workspace-header content tab')
+  setSheetFromTab(tab)
+
+  if (tab.route && tab.route !== route.path) {
+    void router.push(tab.route)
   }
 
   if (typeof document !== 'undefined') {
@@ -313,18 +334,11 @@ function selectTabFromDropdown(tabKey: string): void {
   }
 }
 
-function setTab(tabKey: string): void {
-  const key = resolvedDashboardKey.value
-  if (!key) return
-
-  navStore.setDashboardTab(key, tabKey, 'dashboard-header tab button')
-}
-
 function goBack(): void {
   const path = navStore.backPath
 
   if (path) {
-    router.push(path)
+    void router.push(path)
     return
   }
 

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -21,133 +21,53 @@
 
       <channel-select class="shrink-0" />
 
-      <div v-if="resolvedTabs.length" class="dropdown min-w-0 flex-1">
-        <button
-          tabindex="0"
-          type="button"
-          class="btn relative flex h-10 min-h-10 w-full max-w-full items-center gap-2 overflow-hidden rounded-xl border border-base-300 bg-base-100 px-2 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14 xl:gap-2.5 xl:px-3"
+      <section
+        class="relative flex h-10 min-h-10 min-w-0 flex-1 items-center gap-2 overflow-hidden rounded-xl border border-base-300 bg-base-100 px-2 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14 xl:gap-2.5 xl:px-3"
+      >
+        <img
+          v-if="activeTabConfig.image"
+          :src="activeTabConfig.image"
+          :alt="activeTabConfig.title || activeTabConfig.label"
+          class="absolute inset-0 -z-10 h-full w-full object-cover opacity-15 xl:opacity-20"
+        />
+
+        <span
+          class="absolute inset-0 -z-10 bg-linear-to-r from-base-100/95 via-base-100/80 to-base-100/40"
+        />
+
+        <span
+          class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
         >
           <img
             v-if="activeTabConfig.image"
             :src="activeTabConfig.image"
             :alt="activeTabConfig.title || activeTabConfig.label"
-            class="absolute inset-0 -z-10 h-full w-full object-cover opacity-15 xl:opacity-20"
+            class="h-full w-full object-cover"
           />
-
           <span
-            class="absolute inset-0 -z-10 bg-linear-to-r from-base-100/95 via-base-100/80 to-base-100/40"
-          />
-
-          <span
-            class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
+            class="absolute inset-0 flex items-center justify-center bg-base-content/20"
           >
-            <img
-              v-if="activeTabConfig.image"
-              :src="activeTabConfig.image"
-              :alt="activeTabConfig.title || activeTabConfig.label"
-              class="h-full w-full object-cover"
+            <Icon
+              :name="activeTabConfig.icon || fallbackIcon"
+              class="h-4 w-4 text-base-100 drop-shadow xl:h-5 xl:w-5"
             />
-            <span
-              class="absolute inset-0 flex items-center justify-center bg-base-content/20"
-            >
-              <Icon
-                :name="activeTabConfig.icon || fallbackIcon"
-                class="h-4 w-4 text-base-100 drop-shadow xl:h-5 xl:w-5"
-              />
-            </span>
+          </span>
+        </span>
+
+        <span class="flex min-w-0 flex-1 flex-col items-start leading-tight">
+          <span
+            v-if="shellTitle"
+            class="max-w-full truncate text-[0.58rem] font-black uppercase tracking-wide text-primary/70"
+          >
+            {{ shellTitle }}
           </span>
 
-          <span class="flex min-w-0 flex-1 flex-col items-start leading-tight">
-            <span
-              v-if="shellTitle"
-              class="max-w-full truncate text-[0.58rem] font-black uppercase tracking-wide text-primary/70"
-            >
-              {{ shellTitle }}
-            </span>
-
-            <span
-              class="max-w-full truncate text-sm font-black sm:text-base xl:text-lg"
-            >
-              {{ activeTitle }}
-            </span>
+          <span
+            class="max-w-full truncate text-sm font-black sm:text-base xl:text-lg"
+          >
+            {{ activeTitle }}
           </span>
-
-          <Icon
-            name="kind-icon:chevron-down"
-            class="h-3.5 w-3.5 shrink-0 text-base-content/50 xl:h-4 xl:w-4"
-          />
-        </button>
-
-        <ul
-          tabindex="0"
-          class="menu dropdown-content z-40 mt-2 max-h-80 w-[min(24rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
-        >
-          <li v-for="tab in resolvedTabs" :key="tab.tabKey">
-            <button
-              type="button"
-              class="flex min-h-12 items-center gap-2 rounded-xl xl:min-h-14"
-              :class="
-                activeTabKey === tab.tabKey
-                  ? 'active bg-primary text-primary-content'
-                  : ''
-              "
-              @click="selectTabFromDropdown(tab.tabKey)"
-            >
-              <span
-                class="relative flex h-9 w-9 shrink-0 overflow-hidden rounded-lg bg-base-200 xl:h-10 xl:w-10"
-              >
-                <img
-                  v-if="tab.image"
-                  :src="tab.image"
-                  :alt="tab.title || tab.label"
-                  class="h-full w-full object-cover"
-                />
-
-                <span
-                  class="absolute inset-0 flex items-center justify-center bg-base-content/20"
-                >
-                  <Icon
-                    :name="tab.icon || fallbackIcon"
-                    class="h-4 w-4 text-base-100 drop-shadow"
-                  />
-                </span>
-              </span>
-
-              <span class="flex min-w-0 flex-col items-start">
-                <span
-                  class="max-w-full truncate text-sm font-black xl:text-base"
-                >
-                  {{ tab.label }}
-                </span>
-
-                <span
-                  v-if="tab.summary || tab.description"
-                  class="line-clamp-1 text-xs font-medium opacity-70"
-                >
-                  {{ tab.summary || tab.description }}
-                </span>
-              </span>
-            </button>
-          </li>
-        </ul>
-      </div>
-
-      <section
-        v-else
-        class="flex min-w-0 flex-1 flex-col justify-center leading-tight"
-      >
-        <p
-          v-if="shellTitle"
-          class="truncate text-[0.58rem] font-black uppercase tracking-wide text-primary/70 xl:text-xs"
-        >
-          {{ shellTitle }}
-        </p>
-
-        <h1
-          class="truncate text-sm font-black text-base-content sm:text-base xl:text-xl"
-        >
-          {{ activeTitle }}
-        </h1>
+        </span>
       </section>
 
       <section
@@ -314,25 +234,6 @@ function setSheetFromTab(tab: ResolvedTab): void {
     icon: tab.icon,
     image: tab.image,
   })
-}
-
-function selectTabFromDropdown(tabKey: string): void {
-  const channel = resolvedChannel.value
-  const tab = resolvedTabs.value.find((item) => item.tabKey === tabKey)
-  if (!channel || !tab) return
-
-  channelContentStore.setActiveTab(channel.channelKey, tab.tabKey)
-  syncLegacyTab(tab, 'workspace-header content tab')
-  setSheetFromTab(tab)
-
-  if (tab.route && tab.route !== route.path) {
-    void router.push(tab.route)
-  }
-
-  if (typeof document !== 'undefined') {
-    const el = document.activeElement as HTMLElement | null
-    el?.blur()
-  }
 }
 
 function goBack(): void {

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -182,6 +182,19 @@ const route = useRoute()
 
 await channelContentStore.initialize()
 
+const resolvedLocation = computed(() =>
+  channelContentStore.resolveLocation({
+    channelKey: pageStore.channelKey,
+    tabKey: pageStore.tabKey,
+    dashboardKey: pageStore.dashboardKey,
+    dashboardTab: pageStore.dashboardTab,
+    path: route.path,
+  }),
+)
+
+const resolvedChannel = computed(() => resolvedLocation.value?.channel ?? null)
+const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
+
 const shellTitle = computed(
   () =>
     resolvedChannel.value?.room ||
@@ -195,19 +208,6 @@ const shellSummary = computed(
 )
 
 const showBackButton = computed(() => navStore.canGoBack)
-
-const resolvedLocation = computed(() =>
-  channelContentStore.resolveLocation({
-    channelKey: pageStore.channelKey,
-    tabKey: pageStore.tabKey,
-    dashboardKey: pageStore.dashboardKey,
-    dashboardTab: pageStore.dashboardTab,
-    path: route.path,
-  }),
-)
-
-const resolvedChannel = computed(() => resolvedLocation.value?.channel ?? null)
-const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
 
 const activeTabKey = computed(() => {
   const channel = resolvedChannel.value
@@ -248,6 +248,7 @@ const fallbackTab: ResolvedTab = {
   modelType: '',
   sort: 0,
   cards: null,
+  tutorial: null,
   requiredBeforeNext: [],
   requiredRole: '',
   requiredPermission: '',

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -102,10 +102,14 @@ const route = useRoute()
 
 await channelContentStore.initialize()
 
+const requestedTabKey = computed(() => {
+  return typeof route.query.tab === 'string' ? route.query.tab.trim() : ''
+})
+
 const resolvedLocation = computed(() =>
   channelContentStore.resolveLocation({
     channelKey: pageStore.channelKey,
-    tabKey: pageStore.tabKey,
+    tabKey: requestedTabKey.value || pageStore.tabKey,
     dashboardKey: pageStore.dashboardKey,
     dashboardTab: pageStore.dashboardTab,
     path: route.path,
@@ -132,6 +136,13 @@ const showBackButton = computed(() => navStore.canGoBack)
 const activeTabKey = computed(() => {
   const channel = resolvedChannel.value
   if (!channel) return ''
+
+  if (
+    requestedTabKey.value &&
+    channel.tabs.some((tab) => tab.tabKey === requestedTabKey.value)
+  ) {
+    return requestedTabKey.value
+  }
 
   const locatedTab = resolvedLocation.value?.tab
   const locatedOnChildRoute =
@@ -196,8 +207,9 @@ const activeTitle = computed(
 watch(
   () => ({
     channelKey: resolvedChannel.value?.channelKey || '',
-    tabKey: resolvedLocation.value?.tab?.tabKey || '',
+    tabKey: activeTabKey.value,
     path: route.path,
+    queryTab: requestedTabKey.value,
   }),
   ({ channelKey, tabKey }) => {
     if (!channelKey || !tabKey) return

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -13,7 +13,8 @@
           <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
             Apply the canonical channel, tab, and live URL map to existing
             Project rows. The operation uses the normal guarded Project PATCH
-            endpoint and reports every updated, unchanged, and missing slug.
+            endpoint and reports every updated, unchanged, missing, or failed
+            slug.
           </p>
         </div>
 
@@ -61,7 +62,7 @@
             <h2 class="font-black">Backfill controls</h2>
             <p class="mt-1 text-sm text-base-content/60">
               Existing non-empty live URLs are preserved unless overwrite is
-              enabled.
+              enabled. Individual failures do not stop the remaining rows.
             </p>
           </div>
 
@@ -116,7 +117,7 @@
 
       <section
         v-if="result"
-        class="grid gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm lg:grid-cols-3 lg:p-5"
+        class="grid gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4 xl:p-5"
       >
         <article>
           <div class="flex items-center justify-between gap-2">
@@ -174,6 +175,26 @@
             </li>
           </ul>
         </article>
+
+        <article>
+          <div class="flex items-center justify-between gap-2">
+            <h2 class="font-black text-error">Failed</h2>
+            <span class="badge badge-error">{{ result.failed.length }}</span>
+          </div>
+          <ul class="mt-3 space-y-1.5 text-sm">
+            <li
+              v-for="failure in result.failed"
+              :key="failure.slug"
+              class="rounded-lg bg-error/10 px-2.5 py-1.5"
+            >
+              <p class="font-black">{{ failure.slug }}</p>
+              <p class="mt-0.5 text-xs text-error/80">{{ failure.message }}</p>
+            </li>
+            <li v-if="!result.failed.length" class="text-base-content/45">
+              No Project updates failed.
+            </li>
+          </ul>
+        </article>
       </section>
     </template>
   </section>
@@ -181,21 +202,18 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { useProjectStore } from '@/stores/projectStore'
+import {
+  useProjectStore,
+  type ApplyPlacementsResult,
+} from '@/stores/projectStore'
 import { useUserStore } from '@/stores/userStore'
 import { PROJECT_PLACEMENTS } from '@/utils/projectPlacements'
-
-type PlacementResult = {
-  updated: string[]
-  unchanged: string[]
-  missing: string[]
-}
 
 const projectStore = useProjectStore()
 const userStore = useUserStore()
 const overwriteLiveUrl = ref(false)
 const applying = ref(false)
-const result = ref<PlacementResult | null>(null)
+const result = ref<ApplyPlacementsResult | null>(null)
 const message = ref('')
 const messageTone = ref<'success' | 'error'>('success')
 
@@ -243,8 +261,10 @@ async function applyPlacements(): Promise<void> {
 
   try {
     result.value = await projectStore.applyPlacements(overwriteLiveUrl.value)
+    const tone = result.value.failed.length ? 'error' : 'success'
     setMessage(
-      `Placement pass complete: ${result.value.updated.length} updated, ${result.value.unchanged.length} unchanged, ${result.value.missing.length} missing.`,
+      `Placement pass complete: ${result.value.updated.length} updated, ${result.value.unchanged.length} unchanged, ${result.value.missing.length} missing, ${result.value.failed.length} failed.`,
+      tone,
     )
   } catch (error) {
     setMessage(

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -1,0 +1,264 @@
+<!-- /components/projects/project-placement-manager.vue -->
+<template>
+  <section class="mx-auto flex w-full max-w-6xl flex-col gap-4 p-4 sm:p-6">
+    <header
+      class="overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm"
+    >
+      <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <Icon name="kind-icon:map" class="h-6 w-6 text-primary" />
+            <h1 class="text-xl font-black sm:text-2xl">Project Placement</h1>
+          </div>
+          <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
+            Apply the canonical channel, tab, and live URL map to existing
+            Project rows. The operation uses the normal guarded Project PATCH
+            endpoint and reports every updated, unchanged, and missing slug.
+          </p>
+        </div>
+
+        <span class="badge badge-warning badge-lg shrink-0 gap-1 font-black">
+          <Icon name="kind-icon:shield" class="h-4 w-4" />
+          Admin
+        </span>
+      </div>
+    </header>
+
+    <div
+      v-if="!canManage"
+      class="alert alert-error rounded-2xl border border-error/30"
+    >
+      <Icon name="kind-icon:lock" class="h-5 w-5" />
+      <span>This workspace requires an administrator account.</span>
+    </div>
+
+    <template v-else>
+      <section class="grid gap-3 sm:grid-cols-3">
+        <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+          <div class="stat-title">Canonical placements</div>
+          <div class="stat-value text-primary">{{ expectedCount }}</div>
+          <div class="stat-desc">Defined in projectPlacements.ts</div>
+        </article>
+
+        <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+          <div class="stat-title">Projects loaded</div>
+          <div class="stat-value">{{ projectStore.projects.length }}</div>
+          <div class="stat-desc">Including inactive projects</div>
+        </article>
+
+        <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+          <div class="stat-title">Placement matches</div>
+          <div class="stat-value text-secondary">{{ matchedCount }}</div>
+          <div class="stat-desc">Recognized by slug or conductor slug</div>
+        </article>
+      </section>
+
+      <section
+        class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm sm:p-5"
+      >
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 class="font-black">Backfill controls</h2>
+            <p class="mt-1 text-sm text-base-content/60">
+              Existing non-empty live URLs are preserved unless overwrite is
+              enabled.
+            </p>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <label
+              class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2 text-sm font-bold"
+            >
+              <input
+                v-model="overwriteLiveUrl"
+                type="checkbox"
+                class="checkbox checkbox-sm checkbox-warning"
+              />
+              Overwrite live URLs
+            </label>
+
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm rounded-xl"
+              :disabled="busy"
+              @click="loadProjects"
+            >
+              <span v-if="projectStore.loading" class="loading loading-spinner loading-xs" />
+              <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+              Load projects
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-primary btn-sm rounded-xl"
+              :disabled="busy || !projectStore.loaded"
+              @click="applyPlacements"
+            >
+              <span v-if="applying" class="loading loading-spinner loading-xs" />
+              <Icon v-else name="kind-icon:wand" class="h-4 w-4" />
+              Apply placements
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-if="message"
+          class="alert rounded-xl"
+          :class="messageTone === 'error' ? 'alert-error' : 'alert-success'"
+        >
+          <Icon
+            :name="messageTone === 'error' ? 'kind-icon:error' : 'kind-icon:check'"
+            class="h-5 w-5"
+          />
+          <span>{{ message }}</span>
+        </div>
+      </section>
+
+      <section
+        v-if="result"
+        class="grid gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm lg:grid-cols-3 lg:p-5"
+      >
+        <article>
+          <div class="flex items-center justify-between gap-2">
+            <h2 class="font-black text-success">Updated</h2>
+            <span class="badge badge-success">{{ result.updated.length }}</span>
+          </div>
+          <ul class="mt-3 space-y-1.5 text-sm">
+            <li
+              v-for="slug in result.updated"
+              :key="slug"
+              class="rounded-lg bg-success/10 px-2.5 py-1.5 font-semibold"
+            >
+              {{ slug }}
+            </li>
+            <li v-if="!result.updated.length" class="text-base-content/45">
+              No rows required updates.
+            </li>
+          </ul>
+        </article>
+
+        <article>
+          <div class="flex items-center justify-between gap-2">
+            <h2 class="font-black">Unchanged</h2>
+            <span class="badge">{{ result.unchanged.length }}</span>
+          </div>
+          <ul class="mt-3 space-y-1.5 text-sm">
+            <li
+              v-for="slug in result.unchanged"
+              :key="slug"
+              class="rounded-lg bg-base-200 px-2.5 py-1.5 font-semibold"
+            >
+              {{ slug }}
+            </li>
+            <li v-if="!result.unchanged.length" class="text-base-content/45">
+              No canonical rows were already current.
+            </li>
+          </ul>
+        </article>
+
+        <article>
+          <div class="flex items-center justify-between gap-2">
+            <h2 class="font-black text-warning">Missing</h2>
+            <span class="badge badge-warning">{{ result.missing.length }}</span>
+          </div>
+          <ul class="mt-3 space-y-1.5 text-sm">
+            <li
+              v-for="slug in result.missing"
+              :key="slug"
+              class="rounded-lg bg-warning/10 px-2.5 py-1.5 font-semibold"
+            >
+              {{ slug }}
+            </li>
+            <li v-if="!result.missing.length" class="text-base-content/45">
+              Every canonical slug matched a Project row.
+            </li>
+          </ul>
+        </article>
+      </section>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useProjectStore } from '@/stores/projectStore'
+import { useUserStore } from '@/stores/userStore'
+import { PROJECT_PLACEMENTS } from '@/utils/projectPlacements'
+
+type PlacementResult = {
+  updated: string[]
+  unchanged: string[]
+  missing: string[]
+}
+
+const projectStore = useProjectStore()
+const userStore = useUserStore()
+const overwriteLiveUrl = ref(false)
+const applying = ref(false)
+const result = ref<PlacementResult | null>(null)
+const message = ref('')
+const messageTone = ref<'success' | 'error'>('success')
+
+const canManage = computed(() => userStore.role === 'ADMIN')
+const expectedCount = Object.keys(PROJECT_PLACEMENTS).length
+const busy = computed(() => projectStore.loading || projectStore.saving || applying.value)
+const matchedCount = computed(() => {
+  const slugs = new Set(Object.keys(PROJECT_PLACEMENTS))
+
+  return projectStore.projects.filter(
+    (project) =>
+      (project.slug && slugs.has(project.slug)) ||
+      (project.conductorSlug && slugs.has(project.conductorSlug)),
+  ).length
+})
+
+function setMessage(value: string, tone: 'success' | 'error' = 'success'): void {
+  message.value = value
+  messageTone.value = tone
+}
+
+async function loadProjects(): Promise<void> {
+  if (!canManage.value) return
+
+  try {
+    await projectStore.fetchProjects({
+      includeInactive: true,
+      includeMature: true,
+      take: 500,
+    })
+    setMessage(`Loaded ${projectStore.projects.length} Project rows.`)
+  } catch (error) {
+    setMessage(
+      error instanceof Error ? error.message : 'Failed to load Projects.',
+      'error',
+    )
+  }
+}
+
+async function applyPlacements(): Promise<void> {
+  if (!canManage.value || busy.value) return
+
+  applying.value = true
+  result.value = null
+
+  try {
+    result.value = await projectStore.applyPlacements(overwriteLiveUrl.value)
+    setMessage(
+      `Placement pass complete: ${result.value.updated.length} updated, ${result.value.unchanged.length} unchanged, ${result.value.missing.length} missing.`,
+    )
+  } catch (error) {
+    setMessage(
+      error instanceof Error ? error.message : 'Failed to apply placements.',
+      'error',
+    )
+  } finally {
+    applying.value = false
+  }
+}
+
+onMounted(() => {
+  if (canManage.value && !projectStore.loaded) {
+    void loadProjects()
+  }
+})
+</script>

--- a/content.config.ts
+++ b/content.config.ts
@@ -10,6 +10,16 @@ const narratorSchema = z.union([
   }),
 ])
 
+const navigationCardSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  icon: z.string().optional(),
+  image: z.string().optional(),
+  route: z.string().optional(),
+  action: z.string().optional(),
+})
+
 const contentSchema = z.object({
   title: z.string().optional(),
   room: z.string().optional(),
@@ -18,15 +28,30 @@ const contentSchema = z.object({
   icon: z.string().optional(),
   image: z.string().optional(),
   tooltip: z.string().optional(),
+  dottiTip: z.string().optional(),
+  amiTip: z.string().optional(),
   dottitip: z.string().optional(),
   amitip: z.string().optional(),
   narrator: narratorSchema.optional(),
   artPrompt: z.string().optional(),
   summary: z.string().optional(),
-  sort: z.string().optional(),
+  narrative: z.string().optional(),
+  sort: z.union([z.string(), z.number()]).optional(),
+  contentType: z.enum(['page', 'channel', 'tab']).default('page'),
+  channelKey: z.string().optional(),
+  tabKey: z.string().optional(),
   dashboardKey: z.string().optional(),
   dashboardTab: z.string().optional(),
-  cards: z.string().optional(),
+  defaultTab: z.string().optional(),
+  route: z.string().optional(),
+  component: z.string().optional(),
+  modelType: z.string().optional(),
+  cards: z.union([z.string(), z.array(navigationCardSchema)]).optional(),
+  requiredBeforeNext: z.array(z.string()).optional(),
+  requiredRole: z.string().optional(),
+  requiredPermission: z.string().optional(),
+  visible: z.boolean().default(true),
+  status: z.string().optional(),
   loadingMessage: z.string().optional(),
   refreshLabel: z.string().optional(),
   footer: z.string().optional(),
@@ -89,10 +114,12 @@ export type PageBrief = {
   icon: string
   image: string
   tooltip: string
-  dottitip: string
-  amitip: string
+  dottiTip: string
+  amiTip: string
   narrator?: PageNarratorRef
   artPrompt: string
+  channelKey?: string
+  tabKey?: string
   dashboardKey?: string
   summary?: string
   dashboardTab?: string

--- a/content.config.ts
+++ b/content.config.ts
@@ -32,6 +32,15 @@ const tutorialSchema = z.object({
   underConstruction: z.boolean().optional(),
 })
 
+const contentNavigationSchema = z.union([
+  z.boolean(),
+  z.object({
+    title: z.string(),
+    icon: z.string(),
+    description: z.string(),
+  }),
+])
+
 const sharedNavigationSchema = z.object({
   title: z.string().optional(),
   label: z.string().optional(),
@@ -73,6 +82,7 @@ const pageSchema = sharedNavigationSchema.extend({
   artPrompt: z.string().optional(),
   footer: z.string().optional(),
   footerState: z.string().optional(),
+  navigation: contentNavigationSchema.default(false),
 })
 
 const channelSchema = sharedNavigationSchema.extend({

--- a/content.config.ts
+++ b/content.config.ts
@@ -22,6 +22,7 @@ const navigationCardSchema = z.object({
 
 const contentSchema = z.object({
   title: z.string().optional(),
+  label: z.string().optional(),
   room: z.string().optional(),
   subtitle: z.string().optional(),
   description: z.string().optional(),
@@ -123,7 +124,7 @@ export type PageBrief = {
   dashboardKey?: string
   summary?: string
   dashboardTab?: string
-  cards?: string
+  cards?: string | z.infer<typeof navigationCardSchema>[]
   loadingMessage?: string
   refreshLabel?: string
 }

--- a/content.config.ts
+++ b/content.config.ts
@@ -77,7 +77,7 @@ const sharedNavigationSchema = z.object({
 })
 
 const pageSchema = sharedNavigationSchema.extend({
-  contentType: z.literal('page').default('page'),
+  contentType: z.enum(['page', 'channel', 'tab']).default('page'),
   narrator: narratorSchema.optional(),
   artPrompt: z.string().optional(),
   footer: z.string().optional(),
@@ -88,6 +88,7 @@ const pageSchema = sharedNavigationSchema.extend({
 const channelSchema = sharedNavigationSchema.extend({
   contentType: z.enum(['channel', 'tab']),
   channelKey: z.string(),
+  navigation: contentNavigationSchema.default(false),
 })
 
 export type ContentType = z.infer<typeof pageSchema>
@@ -134,7 +135,7 @@ export default defineContentConfig({
       schema: pageSchema,
     }),
     channels: defineCollection({
-      type: 'data',
+      type: 'page',
       source: 'channels/**/*.md',
       schema: channelSchema,
       indexes: [

--- a/content.config.ts
+++ b/content.config.ts
@@ -32,7 +32,7 @@ const tutorialSchema = z.object({
   underConstruction: z.boolean().optional(),
 })
 
-const contentSchema = z.object({
+const sharedNavigationSchema = z.object({
   title: z.string().optional(),
   label: z.string().optional(),
   room: z.string().optional(),
@@ -45,12 +45,9 @@ const contentSchema = z.object({
   amiTip: z.string().optional(),
   dottitip: z.string().optional(),
   amitip: z.string().optional(),
-  narrator: narratorSchema.optional(),
-  artPrompt: z.string().optional(),
   summary: z.string().optional(),
   narrative: z.string().optional(),
   sort: z.union([z.string(), z.number()]).optional(),
-  contentType: z.enum(['page', 'channel', 'tab']).default('page'),
   channelKey: z.string().optional(),
   tabKey: z.string().optional(),
   dashboardKey: z.string().optional(),
@@ -68,50 +65,23 @@ const contentSchema = z.object({
   status: z.string().optional(),
   loadingMessage: z.string().optional(),
   refreshLabel: z.string().optional(),
-  footer: z.string().optional(),
-  footerState: z.string().optional(),
-
-  path: z.string(),
-
-  seo: z
-    .intersection(
-      z.object({
-        title: z.string().optional(),
-        description: z.string().optional(),
-        meta: z.array(z.record(z.string(), z.any())).optional(),
-        link: z.array(z.record(z.string(), z.any())).optional(),
-      }),
-      z.record(z.string(), z.any()),
-    )
-    .default({}),
-
-  body: z.object({
-    type: z.string(),
-    children: z.any(),
-    toc: z.any(),
-  }),
-
-  navigation: z
-    .union([
-      z.boolean(),
-      z.object({
-        title: z.string(),
-        icon: z.string(),
-        description: z.string(),
-      }),
-    ])
-    .default(false),
 })
 
-export type ContentType = z.infer<typeof contentSchema> & {
-  seo?: {
-    title?: string
-    description?: string
-    meta?: Record<string, any>[]
-    link?: Record<string, any>[]
-    [key: string]: any
-  }
-}
+const pageSchema = sharedNavigationSchema.extend({
+  contentType: z.literal('page').default('page'),
+  narrator: narratorSchema.optional(),
+  artPrompt: z.string().optional(),
+  footer: z.string().optional(),
+  footerState: z.string().optional(),
+})
+
+const channelSchema = sharedNavigationSchema.extend({
+  contentType: z.enum(['channel', 'tab']),
+  channelKey: z.string(),
+})
+
+export type ContentType = z.infer<typeof pageSchema>
+export type ChannelContentType = z.infer<typeof channelSchema>
 
 export type PageNarratorRef =
   | string
@@ -147,8 +117,22 @@ export default defineContentConfig({
   collections: {
     content: defineCollection({
       type: 'page',
-      source: '**/*.md',
-      schema: contentSchema,
+      source: {
+        include: '**/*.md',
+        exclude: ['channels/**'],
+      },
+      schema: pageSchema,
+    }),
+    channels: defineCollection({
+      type: 'data',
+      source: 'channels/**/*.md',
+      schema: channelSchema,
+      indexes: [
+        { columns: ['contentType'] },
+        { columns: ['channelKey'] },
+        { columns: ['channelKey', 'tabKey'] },
+        { columns: ['sort'] },
+      ],
     }),
   },
 })

--- a/content.config.ts
+++ b/content.config.ts
@@ -10,6 +10,26 @@ const narratorSchema = z.union([
   }),
 ])
 
+const navigationRoleSchema = z.enum([
+  'SYSTEM',
+  'USER',
+  'ASSISTANT',
+  'ADMIN',
+  'GUEST',
+  'BOT',
+  'DESIGNER',
+  'CHILD',
+  'FAMILY',
+])
+
+const navigationPermissionSchema = z.enum([
+  'authenticated',
+  'member',
+  'family',
+  'mature',
+  'admin',
+])
+
 const navigationCardSchema = z.object({
   key: z.string(),
   label: z.string(),
@@ -68,8 +88,8 @@ const sharedNavigationSchema = z.object({
   cards: z.union([z.string(), z.array(navigationCardSchema)]).optional(),
   tutorial: tutorialSchema.optional(),
   requiredBeforeNext: z.array(z.string()).optional(),
-  requiredRole: z.string().optional(),
-  requiredPermission: z.string().optional(),
+  requiredRole: navigationRoleSchema.optional(),
+  requiredPermission: navigationPermissionSchema.optional(),
   visible: z.boolean().default(true),
   status: z.string().optional(),
   loadingMessage: z.string().optional(),

--- a/content.config.ts
+++ b/content.config.ts
@@ -20,6 +20,18 @@ const navigationCardSchema = z.object({
   action: z.string().optional(),
 })
 
+const tutorialSchema = z.object({
+  enabled: z.boolean().optional(),
+  title: z.string().optional(),
+  overview: z.string().optional(),
+  tagline: z.string().optional(),
+  hero: z.string().optional(),
+  earnings: z.string().optional(),
+  body: z.string().optional(),
+  image: z.string().optional(),
+  underConstruction: z.boolean().optional(),
+})
+
 const contentSchema = z.object({
   title: z.string().optional(),
   label: z.string().optional(),
@@ -48,6 +60,7 @@ const contentSchema = z.object({
   component: z.string().optional(),
   modelType: z.string().optional(),
   cards: z.union([z.string(), z.array(navigationCardSchema)]).optional(),
+  tutorial: tutorialSchema.optional(),
   requiredBeforeNext: z.array(z.string()).optional(),
   requiredRole: z.string().optional(),
   requiredPermission: z.string().optional(),
@@ -125,6 +138,7 @@ export type PageBrief = {
   summary?: string
   dashboardTab?: string
   cards?: string | z.infer<typeof navigationCardSchema>[]
+  tutorial?: z.infer<typeof tutorialSchema>
   loadingMessage?: string
   refreshLabel?: string
 }

--- a/content/about.md
+++ b/content/about.md
@@ -6,12 +6,14 @@ description: Where missions and elevator pitches go to socialize.
 icon: kind-icon:butterfly
 image: splash/about.png
 tooltip: Ah, the "About" page—home of lofty goals and earnest mission statements. But really, welcome! We're all about creating nifty AI-human interaction tools. Stick around and you might just become part of our mission.
-dottitip: People keep asking us what we do, so I made an elevator pitch. Is eleven minutes too long?
-amitip: Where's that 'Rookie Numbers' Meme? We're all about options! 🦋🌈
+dottiTip: People keep asking us what we do, so I made an elevator pitch. Is eleven minutes too long?
+amiTip: Where's that 'Rookie Numbers' meme? We're all about options! 🦋🌈
+channelKey: sanctuary
+tabKey: about
 dashboardKey: giftshop
 dashboardTab: about
 cards: navCards
-loadingMessage: Loading plans....
+loadingMessage: Loading plans...
 refreshLabel: Refresh mission statement
 ---
 

--- a/content/academy.md
+++ b/content/academy.md
@@ -7,9 +7,12 @@ image: 'background/artgallery.webp'
 icon: kind-icon:palette
 tooltip: Art history lessons with a remix button. The masters would approve. Probably.
 sort: highlight
-dottitip: 'Can you really learn art history from a robot?'
-amitip: 'Every artist here has been public domain for decades — we checked. The robots just dust the frames and run the remix engine!'
+dottiTip: Can you really learn art history from a robot?
+amiTip: Every artist here has been public domain for decades — we checked. The robots just dust the frames and run the remix engine!
+channelKey: play
+tabKey: academy
 dashboardKey: academy
+dashboardTab: timeline
 loadingMessage: Restoring the frescoes...
 refreshLabel: Refresh Academy
 ---

--- a/content/achievements.md
+++ b/content/achievements.md
@@ -4,11 +4,13 @@ room: 'Jellybean Quests Gallery'
 subtitle: Find the jellybeans
 description: Embark on a delightful quest to discover jellybeans scattered across the website.
 image: splash/jellybeans.png
-icon: kind-icon:mermaid
+icon: kind-icon:trophy
 tooltip: Ready for a hunt? Find all 11 jellybeans hidden across the site.
 sort: highlight
-dottitip: I hid a bunch of jellybeans around the laboratory for visitors to find. How do we tell them that they absolutely SHOULD NOT EAT them.
-amitip: Uhm, what happens if they eat them? Are we talking silica-gel-packet-bad or Bruce Banner-bad? Because humans will eat jellybeans off a laboratory floor if they think it could give them superpowers.
+dottiTip: I hid a bunch of jellybeans around the laboratory for visitors to find. How do we tell them that they absolutely should not eat them?
+amiTip: Are we talking silica-gel-packet-bad or Bruce Banner-bad? Humans will eat jellybeans off a laboratory floor if they think it could give them superpowers.
+channelKey: home
+tabKey: achievements
 dashboardKey: user
 dashboardTab: achievements
 cards: navCards

--- a/content/appmaker.md
+++ b/content/appmaker.md
@@ -6,6 +6,8 @@ description: Turn app ideas into structured projects ready for the build loop.
 image: nav/heroes/conductor.webp
 icon: kind-icon:foundry
 tooltip: Sketch an app. Ship a project.
+channelKey: plan
+tabKey: appmaker
 dashboardKey: conductor
 dashboardTab: appmaker
 cards: navCards

--- a/content/art.md
+++ b/content/art.md
@@ -1,15 +1,18 @@
 ---
 title: 'Art'
 room: 'Art Gallery'
-subtitle: "Your personal art space"
-description: "This is your space to make and share art created with modellers. Thanks for being a part of the Kind Community!"
+subtitle: 'Your personal art space'
+description: 'This is your space to make and share art created with modellers. Thanks for being a part of the Kind Community!'
 image: 'background/artgallery.webp'
 icon: splash/aartgallerybout.png
-tooltip: This is a collection of user art. 
-dottitip: People keep asking if AI art is 'real' art. I never know what to say.
-amitip: "If it makes you stop and look, have a conversation, or feel something new, I’d say it does it's job!"
+tooltip: This is a collection of user art.
+dottiTip: People keep asking if AI art is 'real' art. I never know what to say.
+amiTip: "If it makes you stop and look, have a conversation, or feel something new, I’d say it does its job!"
 sort: highlight
+channelKey: play
+tabKey: art
 dashboardKey: art
+dashboardTab: gallery
 cards: artCards
 loadingMessage: Loading art gallery...
 refreshLabel: Refresh Art

--- a/content/artjob.md
+++ b/content/artjob.md
@@ -2,14 +2,17 @@
 title: 'ArtJob'
 room: 'ArtJob Pipeline'
 subtitle: 'The art-generation control room'
-description: 'Admin dashboard for the ArtJob pipeline: manage ComfyUI/SD servers, watch uptime, track images created vs failed, and inspect, requeue, or cancel jobs in the queue.'
+description: Admin dashboard for the ArtJob pipeline: manage ComfyUI and SD servers, watch uptime, track images created versus failed, and inspect, requeue, or cancel jobs in the queue.
 image: 'background/artgallery.webp'
 icon: kind-icon:server
 tooltip: Manage art servers and watch the generation queue.
-dottitip: So this is where the pixel goblins actually live.
-amitip: "It's the control room — servers, uptime, and every job the queue is chewing on."
+dottiTip: So this is where the pixel goblins actually live.
+amiTip: It's the control room — servers, uptime, and every job the queue is chewing on.
+channelKey: admin
+tabKey: artjob
 dashboardKey: art
 dashboardTab: artjob
+requiredRole: ADMIN
 loadingMessage: Loading ArtJob pipeline...
 refreshLabel: Refresh ArtJob
 ---

--- a/content/bots.md
+++ b/content/bots.md
@@ -7,11 +7,13 @@ image: splash/botcafe.png
 icon: kind-icon:robot-color
 tooltip: Every bot uses ChatGPT under the hood, generating infinite designer content. What do you think, AMI?
 sort: highlight
-dottitip: "I've been meaning to ask you, AMI...What's it like being a robot? I make bots all day, but I can't imagine what what its like to be on the other side of the circuit board."
-amitip: "Uhm, Dotti...I think we might need to have a talk."
+dottiTip: "I've been meaning to ask you, AMI... What's it like being a robot? I make bots all day, but I can't imagine what it's like to be on the other side of the circuit board."
+amiTip: 'Uhm, Dotti... I think we might need to have a talk.'
 narrator: dotti-bot
+channelKey: play
+tabKey: bots
 dashboardKey: bot
-dashboardTab: overview
+dashboardTab: bots
 cards: botCards
 loadingMessage: Loading bot factory...
 refreshLabel: Refresh Bots

--- a/content/brainstorm.md
+++ b/content/brainstorm.md
@@ -1,15 +1,17 @@
 ---
-title: Brains
+title: Brainstorm
 room: 'Brainstorm! Room'
 subtitle: Enhanced Idea Generator
-description: Need ideas? The sillier, the better
+description: Need ideas? The sillier, the better.
 image: splash/brainstorm.png
 icon: kind-icon:brain
 tooltip: Welcome to Brainstorm's lair! From laughable RPG characters to unfortunate date ideas, Brainstorm creates the concept and the example.
-amitip: Hey, Brainstorm's my cousin! Sure his humor is a little dark, but I'm a multifaceted hivemind built to save the world, he's a brain in a jar. It colors one's perspective. 🦋🤖😂
+amiTip: Hey, Brainstorm's my cousin! Sure his humor is a little dark, but I'm a multifaceted hivemind built to save the world and he's a brain in a jar. It colors one's perspective. 🦋🤖😂
 sort: highlight
-dottitip: Brainstorm is my first robot, even before AMI! He's a little, well, let's just say we love him a lot.
-dashboardKey: dreams
+dottiTip: Brainstorm is my first robot, even before AMI! He's a little, well, let's just say we love him a lot.
+channelKey: build
+tabKey: brainstorm
+dashboardKey: brainstorm
 dashboardTab: brainstorm
 cards: dreamCards
 loadingMessage: Loading brainstorm

--- a/content/builder.md
+++ b/content/builder.md
@@ -1,18 +1,20 @@
 ---
-title: Builder Tool
-room: 'Builder! Room'
+title: Build
+room: 'Build Workshop'
 subtitle: Full Universe Builder
 description: Build a complete Kind Robots universe from big ideas to characters, rewards, art, and interactive scenarios.
 image: splash/builder.png
 icon: kind-icon:blueprint
-tooltip: Welcome to the Builder Tool! Start with a tiny idea goblin and grow it into a full interactive world.
-dottitip: AMI, I added a universe builder. Someone is going to use it to build a universe entirely of sandwiches.
-amitip: That's the thing about free will. Give people the option to do what they want, and they'll do it.
+tooltip: Welcome to Build! Start with a tiny idea goblin and grow it into a full interactive world.
+dottiTip: AMI, I added a universe builder. Someone is going to use it to build a universe entirely of sandwiches.
+amiTip: That's the thing about free will. Give people the option to do what they want, and they'll do it.
+channelKey: build
+tabKey: character
 dashboardKey: builder
 dashboardTab: character
 cards: builderCards
 loadingMessage: Loading builder systems...
-refreshLabel: Refresh Builder
+refreshLabel: Refresh Build
 ---
 
 :builder-manager

--- a/content/challenges.md
+++ b/content/challenges.md
@@ -6,8 +6,10 @@ description: A generative comparison arena — browse challenges, study the cont
 image: nav/heroes/games.webp
 icon: kind-icon:trophy
 tooltip: Compare models, agents, and art generators head-to-head.
-dottitip: Pick a winner. Break a tie. Start a rivalry.
-amitip: I voted for all of them. The leaderboard is very confused. 🏆
+dottiTip: Pick a winner. Break a tie. Start a rivalry.
+amiTip: I voted for all of them. The leaderboard is very confused. 🏆
+channelKey: lab
+tabKey: challenges
 dashboardKey: wonder
 dashboardTab: challenges
 cards: navCards

--- a/content/channels/admin/artjob.md
+++ b/content/channels/admin/artjob.md
@@ -2,6 +2,8 @@
 contentType: tab
 channelKey: admin
 tabKey: artjob
+dashboardKey: art
+dashboardTab: artjob
 label: ArtJob
 title: ArtJob Pipeline
 subtitle: Manage the generation queue

--- a/content/channels/admin/artjob.md
+++ b/content/channels/admin/artjob.md
@@ -1,0 +1,15 @@
+---
+contentType: tab
+channelKey: admin
+tabKey: artjob
+label: ArtJob
+title: ArtJob Pipeline
+subtitle: Manage the generation queue
+description: Review art servers, queue health, failures, retries, and cancellations.
+icon: kind-icon:server
+route: /artjob
+sort: 10
+requiredRole: ADMIN
+---
+
+Operate the art-generation pipeline.

--- a/content/channels/admin/index.md
+++ b/content/channels/admin/index.md
@@ -1,8 +1,10 @@
 ---
 contentType: channel
 channelKey: admin
+dashboardKey: art
 label: Admin
 title: Admin
+room: Control Room
 subtitle: Operational controls for managers
 description: Queues, servers, permissions, moderation, system health, and other dangerous buttons.
 icon: kind-icon:server
@@ -10,6 +12,8 @@ route: /artjob
 defaultTab: artjob
 sort: 70
 requiredRole: ADMIN
+loadingMessage: Loading admin systems...
+refreshLabel: Refresh Admin
 dottiTip: Admin tools are powerful, so I brought validation.
 amiTip: I brought a helmet.
 ---

--- a/content/channels/admin/index.md
+++ b/content/channels/admin/index.md
@@ -1,0 +1,17 @@
+---
+contentType: channel
+channelKey: admin
+label: Admin
+title: Admin
+subtitle: Operational controls for managers
+description: Queues, servers, permissions, moderation, system health, and other dangerous buttons.
+icon: kind-icon:server
+route: /artjob
+defaultTab: artjob
+sort: 70
+requiredRole: ADMIN
+dottiTip: Admin tools are powerful, so I brought validation.
+amiTip: I brought a helmet.
+---
+
+Manage the systems and queues that keep Kind Robots running.

--- a/content/channels/admin/index.md
+++ b/content/channels/admin/index.md
@@ -1,7 +1,6 @@
 ---
 contentType: channel
 channelKey: admin
-dashboardKey: art
 label: Admin
 title: Admin
 room: Control Room

--- a/content/channels/admin/navigation-health.md
+++ b/content/channels/admin/navigation-health.md
@@ -1,0 +1,19 @@
+---
+contentType: tab
+channelKey: admin
+tabKey: navigation-health
+label: Navigation Health
+title: Navigation Health
+subtitle: Inspect the resolved channel graph
+description: Review channels, tabs, shared routes, legacy adapters, permissions, and artwork failures from the content-driven navigation system.
+icon: kind-icon:compass
+route: /navigation-health
+sort: 40
+requiredRole: ADMIN
+loadingMessage: Loading navigation health...
+refreshLabel: Reload Navigation
+dottiTip: I built a dashboard to make sure the new dashboards are not secretly becoming the old dashboards.
+amiTip: Recursive quality assurance. Very fashionable.
+---
+
+Inspect the resolved navigation graph and identify missing artwork, shared routes, or lingering compatibility adapters.

--- a/content/channels/admin/project-placement.md
+++ b/content/channels/admin/project-placement.md
@@ -1,0 +1,21 @@
+---
+contentType: tab
+channelKey: admin
+tabKey: project-placement
+dashboardKey: conductor
+dashboardTab: conductor
+label: Project Placement
+title: Project Placement
+subtitle: Backfill the canonical channel map
+description: Review Project rows and apply the channel, tab, and live URL placement map with a detailed result report.
+icon: kind-icon:map
+route: /project-placement
+sort: 30
+requiredRole: ADMIN
+loadingMessage: Loading project placement controls...
+refreshLabel: Reload Projects
+dottiTip: I turned the migration script into a button with a report and several opportunities to reconsider.
+amiTip: That is what responsible danger looks like.
+---
+
+Apply the canonical navigation placement map to existing Project records and inspect every changed, unchanged, or missing slug.

--- a/content/channels/admin/scoop-cms.md
+++ b/content/channels/admin/scoop-cms.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: admin
+tabKey: scoop-cms
+dashboardKey: conductor
+dashboardTab: scoop-cms
+label: Scoop CMS
+title: Humboldt Scoop CMS
+subtitle: Operate customers, routes, and schedules
+description: Manage the back office for the Humboldt Scoop real-world service.
+icon: kind-icon:heart
+route: /scoop-cms
+sort: 20
+requiredRole: ADMIN
+---
+
+An operational console belongs with the dangerous buttons, not among public projects.

--- a/content/channels/build/art.md
+++ b/content/channels/build/art.md
@@ -1,0 +1,18 @@
+---
+contentType: tab
+channelKey: build
+tabKey: art
+label: Art
+title: Art Builder
+subtitle: Generate and remix images
+description: Build prompts, choose models, generate images, and refine the results.
+icon: kind-icon:palette
+route: /art
+modelType: art
+sort: 10
+cards: art
+requiredBeforeNext:
+  - style
+---
+
+Create art with the visual polish of Builder and the power of the existing art tools.

--- a/content/channels/build/art.md
+++ b/content/channels/build/art.md
@@ -2,14 +2,16 @@
 contentType: tab
 channelKey: build
 tabKey: art
+dashboardKey: builder
+dashboardTab: art
 label: Art
 title: Art Builder
 subtitle: Generate and remix images
 description: Build prompts, choose models, generate images, and refine the results.
 icon: kind-icon:palette
-route: /art
+route: /builder
 modelType: art
-sort: 10
+sort: 60
 cards: art
 requiredBeforeNext:
   - style

--- a/content/channels/build/bot.md
+++ b/content/channels/build/bot.md
@@ -1,0 +1,19 @@
+---
+contentType: tab
+channelKey: build
+tabKey: bot
+dashboardKey: builder
+dashboardTab: bot
+label: Bots
+title: Bot Builder
+subtitle: Create a useful little troublemaker
+description: Build assistants with specific skills, personalities, roles, and conversational style.
+icon: kind-icon:robot-color
+route: /builder
+modelType: bot
+sort: 30
+requiredBeforeNext:
+  - name
+---
+
+Create bots inside the shared visual builder while preserving the existing bot logic underneath.

--- a/content/channels/build/brainstorm.md
+++ b/content/channels/build/brainstorm.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: build
+tabKey: brainstorm
+dashboardKey: brainstorm
+dashboardTab: brainstorm
+label: Brainstorm
+title: Brainstorm
+subtitle: Turn a pitch into useful creative riffs
+description: Generate variations, keep the promising ideas, and save reusable seeds for later building.
+icon: kind-icon:brain
+route: /brainstorm
+sort: 100
+---
+
+A front porch for ideas that are not yet ready to become forms.

--- a/content/channels/build/characters.md
+++ b/content/channels/build/characters.md
@@ -1,15 +1,17 @@
 ---
 contentType: tab
 channelKey: build
-tabKey: characters
+tabKey: character
+dashboardKey: builder
+dashboardTab: character
 label: Characters
 title: Character Builder
 subtitle: Create somebody memorable
 description: Build people, creatures, guides, rivals, disasters, and chattable weirdos.
 icon: kind-icon:mask
-route: /characters
+route: /builder
 modelType: character
-sort: 30
+sort: 20
 cards: character-builder
 requiredBeforeNext:
   - name

--- a/content/channels/build/characters.md
+++ b/content/channels/build/characters.md
@@ -1,0 +1,18 @@
+---
+contentType: tab
+channelKey: build
+tabKey: characters
+label: Characters
+title: Character Builder
+subtitle: Create somebody memorable
+description: Build people, creatures, guides, rivals, disasters, and chattable weirdos.
+icon: kind-icon:mask
+route: /characters
+modelType: character
+sort: 30
+cards: character-builder
+requiredBeforeNext:
+  - name
+---
+
+Create and refine characters inside the shared builder system.

--- a/content/channels/build/dream.md
+++ b/content/channels/build/dream.md
@@ -1,0 +1,19 @@
+---
+contentType: tab
+channelKey: build
+tabKey: dream
+dashboardKey: builder
+dashboardTab: dream
+label: World
+ title: World Builder
+subtitle: Grow a place from a tiny idea
+description: Build worlds, settings, conflicts, locations, and reusable story fuel.
+icon: kind-icon:moon
+route: /builder
+modelType: dream
+sort: 10
+requiredBeforeNext:
+  - title
+---
+
+Turn a pitch into a world with enough structure to support characters, stories, and play.

--- a/content/channels/build/dream.md
+++ b/content/channels/build/dream.md
@@ -5,7 +5,7 @@ tabKey: dream
 dashboardKey: builder
 dashboardTab: dream
 label: World
- title: World Builder
+title: World Builder
 subtitle: Grow a place from a tiny idea
 description: Build worlds, settings, conflicts, locations, and reusable story fuel.
 icon: kind-icon:moon

--- a/content/channels/build/index.md
+++ b/content/channels/build/index.md
@@ -1,14 +1,18 @@
 ---
 contentType: channel
 channelKey: build
+dashboardKey: builder
 label: Build
 title: Build
+room: Build Workshop
 subtitle: Make something new
 description: Create art, models, characters, bots, worlds, rewards, and scenarios.
 icon: kind-icon:blueprint
 route: /builder
-defaultTab: art
+defaultTab: character
 sort: 30
+loadingMessage: Loading builder systems...
+refreshLabel: Refresh Build
 dottiTip: Pick a thing to build and I will help with the machinery.
 amiTip: I will help with the sparkles and snacks.
 ---

--- a/content/channels/build/index.md
+++ b/content/channels/build/index.md
@@ -1,0 +1,16 @@
+---
+contentType: channel
+channelKey: build
+label: Build
+title: Build
+subtitle: Make something new
+description: Create art, models, characters, bots, worlds, rewards, and scenarios.
+icon: kind-icon:blueprint
+route: /builder
+defaultTab: art
+sort: 30
+dottiTip: Pick a thing to build and I will help with the machinery.
+amiTip: I will help with the sparkles and snacks.
+---
+
+Use one creative workshop for everything Kind Robots can help you make.

--- a/content/channels/build/models.md
+++ b/content/channels/build/models.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: build
+tabKey: models
+label: Models
+title: Model Builder
+subtitle: Build makers, not just records
+description: Define schemas, compose reusable builders, and generate new creation systems.
+icon: kind-icon:blueprint
+route: /model-builder
+sort: 20
+---
+
+Use the advanced model builder as the meta-tool behind future creative workflows.

--- a/content/channels/build/models.md
+++ b/content/channels/build/models.md
@@ -1,14 +1,16 @@
 ---
 contentType: tab
 channelKey: build
-tabKey: models
+tabKey: model-builder
+dashboardKey: builder
+dashboardTab: model-builder
 label: Models
 title: Model Builder
 subtitle: Build makers, not just records
 description: Define schemas, compose reusable builders, and generate new creation systems.
 icon: kind-icon:blueprint
 route: /model-builder
-sort: 20
+sort: 80
 ---
 
 Use the advanced model builder as the meta-tool behind future creative workflows.

--- a/content/channels/build/packs.md
+++ b/content/channels/build/packs.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: build
+tabKey: packs
+dashboardKey: builder
+dashboardTab: packs
+label: Packs
+title: Packmaker
+subtitle: Bundle creations into reusable sets
+description: Collect related creations into shareable, permissioned packs and downloadable content.
+icon: kind-icon:box
+route: /packs
+sort: 70
+---
+
+Bundle loose creations into coherent sets that other projects and players can reuse.

--- a/content/channels/build/reward.md
+++ b/content/channels/build/reward.md
@@ -1,0 +1,19 @@
+---
+contentType: tab
+channelKey: build
+tabKey: reward
+dashboardKey: builder
+dashboardTab: reward
+label: Rewards
+title: Reward Builder
+subtitle: Make loot, powers, secrets, and consequences
+description: Design rewards, skills, permissions, curses, keys, and narrative accelerants.
+icon: kind-icon:gift
+route: /builder
+modelType: reward
+sort: 40
+requiredBeforeNext:
+  - title
+---
+
+Create rewards as reusable ingredients rather than isolated destinations.

--- a/content/channels/build/scenario.md
+++ b/content/channels/build/scenario.md
@@ -1,0 +1,20 @@
+---
+contentType: tab
+channelKey: build
+tabKey: scenario
+dashboardKey: builder
+dashboardTab: scenario
+label: Scenarios
+title: Scenario Builder
+subtitle: Build choices with consequences
+description: Create branching experiences where players can choose, improvise, and receive narrated outcomes.
+icon: kind-icon:story
+route: /builder
+modelType: scenario
+sort: 50
+requiredBeforeNext:
+  - title
+  - intro
+---
+
+Build interactive scenarios inside the shared creative workshop.

--- a/content/channels/build/stylist.md
+++ b/content/channels/build/stylist.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: build
+tabKey: stylist
+dashboardKey: art
+dashboardTab: stylist
+label: Hair Studio
+title: Hair Studio
+subtitle: Build private hairstyle previews and salon tools
+description: Restyle client photos, calculate appointments, manage clients, and prepare friendly receipts.
+icon: kind-icon:magic
+route: /stylist
+sort: 90
+---
+
+The Hair by Superkate creation suite, with client photos kept private.

--- a/content/channels/home/achievements.md
+++ b/content/channels/home/achievements.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: home
+tabKey: achievements
+dashboardKey: user
+dashboardTab: achievements
+label: Achievements
+title: Jellybean Quests
+subtitle: Find the jellybeans
+description: Track personal achievements and the jellybeans hidden throughout Kind Robots.
+icon: kind-icon:trophy
+route: /achievements
+sort: 20
+---
+
+Your progress, discoveries, and laboratory-floor candy collection live at Home.

--- a/content/channels/home/achievements.md
+++ b/content/channels/home/achievements.md
@@ -11,6 +11,7 @@ description: Track personal achievements and the jellybeans hidden throughout Ki
 icon: kind-icon:trophy
 route: /achievements
 sort: 20
+requiredPermission: authenticated
 ---
 
 Your progress, discoveries, and laboratory-floor candy collection live at Home.

--- a/content/channels/home/chats.md
+++ b/content/channels/home/chats.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: home
+tabKey: chats
+dashboardKey: user
+dashboardTab: chats
+label: Chats
+title: Chat Gallery
+subtitle: Echoes of wit and weirdness
+description: Review personal and curated conversations from across Kind Robots.
+icon: kind-icon:chat
+route: /chats
+sort: 60
+---
+
+Conversations and friend communication live close to the user who participated in them.

--- a/content/channels/home/chats.md
+++ b/content/channels/home/chats.md
@@ -11,6 +11,7 @@ description: Review personal and curated conversations from across Kind Robots.
 icon: kind-icon:chat
 route: /chats
 sort: 60
+requiredPermission: authenticated
 ---
 
 Conversations and friend communication live close to the user who participated in them.

--- a/content/channels/home/dashboard.md
+++ b/content/channels/home/dashboard.md
@@ -2,6 +2,8 @@
 contentType: tab
 channelKey: home
 tabKey: dashboard
+dashboardKey: user
+dashboardTab: dashboard
 label: Dashboard
 title: Home Dashboard
 subtitle: Your Kind Robots activity at a glance

--- a/content/channels/home/dashboard.md
+++ b/content/channels/home/dashboard.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: home
+tabKey: dashboard
+label: Dashboard
+title: Home Dashboard
+subtitle: Your Kind Robots activity at a glance
+description: Recent work, favorites, messages, and personal milestones.
+icon: kind-icon:home
+route: /
+sort: 10
+---
+
+Your personal dashboard.

--- a/content/channels/home/index.md
+++ b/content/channels/home/index.md
@@ -1,14 +1,18 @@
 ---
 contentType: channel
 channelKey: home
+dashboardKey: user
 label: Home
 title: Home
+room: Kind Robots
 subtitle: Your place in Kind Robots
 description: Personal activity, friends, communication, favorites, and settings.
 icon: kind-icon:home
 route: /
 defaultTab: dashboard
 sort: 10
+loadingMessage: Loading your dashboard...
+refreshLabel: Refresh Home
 dottiTip: Start here when you want to see what is yours.
 amiTip: Home is where the robot remembers your favorite buttons.
 ---

--- a/content/channels/home/index.md
+++ b/content/channels/home/index.md
@@ -1,0 +1,16 @@
+---
+contentType: channel
+channelKey: home
+label: Home
+title: Home
+subtitle: Your place in Kind Robots
+description: Personal activity, friends, communication, favorites, and settings.
+icon: kind-icon:home
+route: /
+defaultTab: dashboard
+sort: 10
+dottiTip: Start here when you want to see what is yours.
+amiTip: Home is where the robot remembers your favorite buttons.
+---
+
+Your personal space for activity, communication, favorites, and settings.

--- a/content/channels/home/navigation.md
+++ b/content/channels/home/navigation.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: home
+tabKey: navigation
+dashboardKey: admin
+dashboardTab: user
+label: Navigation
+title: Navigation Overview
+subtitle: Your personal roadmap
+description: Review destinations, favorites, and the tools used to move through Kind Robots.
+icon: kind-icon:map
+route: /navigation
+sort: 40
+---
+
+A personal map of the site and the places you return to most often.

--- a/content/channels/home/registration.md
+++ b/content/channels/home/registration.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: home
+tabKey: registration
+dashboardKey: user
+dashboardTab: dashboard
+label: Register
+title: Join Kind Robots
+subtitle: Welcome to the community
+description: Create an account to keep personal progress, collections, prompts, achievements, and preferences.
+icon: kind-icon:register
+route: /register
+sort: 30
+---
+
+Registration is the front door to a personal Home inside Kind Robots.

--- a/content/channels/home/themes.md
+++ b/content/channels/home/themes.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: home
+tabKey: themes
+dashboardKey: user
+dashboardTab: themes
+label: Themes
+title: Theme Gallery
+subtitle: Your world, your palette
+description: Choose the visual theme and interface atmosphere that feels like home.
+icon: kind-icon:palette
+route: /themes
+sort: 50
+---
+
+Personal appearance belongs with the user, not the machinery.

--- a/content/channels/lab/challenges.md
+++ b/content/channels/lab/challenges.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: challenges
+dashboardKey: wonder
+dashboardTab: challenges
+label: Challenges
+title: Challenge Center
+subtitle: Experiments with goals, scores, and friendly pressure
+description: Try structured challenges that connect creative systems, achievements, and community play.
+icon: kind-icon:trophy
+route: /challenges
+sort: 20
+---
+
+A testing ground for challenges that may eventually graduate into Play.

--- a/content/channels/lab/coat-dance.md
+++ b/content/channels/lab/coat-dance.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: coat-dance
+dashboardKey: art
+dashboardTab: coat-dance
+label: Coat Dance
+title: Coat Dance
+subtitle: Remix motion, costume, and video
+description: Experiment with playful video transformations built from movement and clothing.
+icon: kind-icon:sparkles
+route: /coat-dance
+sort: 60
+---
+
+An experimental corner where coats are encouraged to become choreography.

--- a/content/channels/lab/davinci.md
+++ b/content/channels/lab/davinci.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: davinci
+dashboardKey: wonder
+dashboardTab: davinci
+label: Da Vinci
+title: Da Vinci
+subtitle: Explore strange endings and creative branches
+description: Experiment with generated endings, branching ideas, and visual storytelling.
+icon: kind-icon:brain
+route: /davinci
+sort: 40
+---
+
+A narrative experiment where endings are prototypes rather than conclusions.

--- a/content/channels/lab/experiments.md
+++ b/content/channels/lab/experiments.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: experiments
+label: Experiments
+title: Lab Experiments
+subtitle: Prototypes, games, and unusual tools
+description: Explore active experiments and projects outside the standard workflow.
+icon: kind-icon:dungeon
+route: /memory
+sort: 10
+---
+
+A home for experiments that are still becoming themselves.

--- a/content/channels/lab/experiments.md
+++ b/content/channels/lab/experiments.md
@@ -2,6 +2,8 @@
 contentType: tab
 channelKey: lab
 tabKey: experiments
+dashboardKey: wonder
+dashboardTab: memory-dungeon
 label: Experiments
 title: Lab Experiments
 subtitle: Prototypes, games, and unusual tools

--- a/content/channels/lab/humboldt-scoop.md
+++ b/content/channels/lab/humboldt-scoop.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: humboldt-scoop
+dashboardKey: wonder
+dashboardTab: humboldt-scoop
+label: Humboldt Scoop
+title: Humboldt Scoop
+subtitle: A real-world service experiment
+description: Explore the public project surface for the Humboldt Scoop pet-waste service.
+icon: kind-icon:heart
+route: /humboldt-scoop
+sort: 90
+---
+
+A practical local-business project living beside the stranger experiments.

--- a/content/channels/lab/index.md
+++ b/content/channels/lab/index.md
@@ -1,14 +1,18 @@
 ---
 contentType: channel
 channelKey: lab
+dashboardKey: wonder
 label: Lab
 title: Lab
+room: Wonder Lab
 subtitle: Experiments, prototypes, and delightful oddities
 description: New projects, extra games, research tools, prototypes, and the backend museum.
 icon: kind-icon:dungeon
 route: /memory
 defaultTab: experiments
 sort: 50
+loadingMessage: Loading experiments...
+refreshLabel: Refresh Lab
 dottiTip: Lab projects are allowed to be strange before they become useful.
 amiTip: Some of them remain strange after becoming useful.
 ---

--- a/content/channels/lab/index.md
+++ b/content/channels/lab/index.md
@@ -1,0 +1,16 @@
+---
+contentType: channel
+channelKey: lab
+label: Lab
+title: Lab
+subtitle: Experiments, prototypes, and delightful oddities
+description: New projects, extra games, research tools, prototypes, and the backend museum.
+icon: kind-icon:dungeon
+route: /memory
+defaultTab: experiments
+sort: 50
+dottiTip: Lab projects are allowed to be strange before they become useful.
+amiTip: Some of them remain strange after becoming useful.
+---
+
+Explore experiments outside the normal project and creative pipelines.

--- a/content/channels/lab/index.md
+++ b/content/channels/lab/index.md
@@ -1,7 +1,6 @@
 ---
 contentType: channel
 channelKey: lab
-dashboardKey: wonder
 label: Lab
 title: Lab
 room: Wonder Lab

--- a/content/channels/lab/mural.md
+++ b/content/channels/lab/mural.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: mural
+dashboardKey: wonder
+dashboardTab: mural
+label: Mural Studio
+title: Mural Color Studio
+subtitle: Plan real paint with a digital coloring surface
+description: Color mural regions, save swatches, coordinate shared fills, and prepare the physical painting plan.
+icon: kind-icon:paintbrush
+route: /mural
+sort: 110
+---
+
+A bridge between digital experimentation and an actual wall that cannot be undone with Ctrl+Z.

--- a/content/channels/lab/museum.md
+++ b/content/channels/lab/museum.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: museum
+dashboardKey: wonder
+dashboardTab: wonder-lab
+label: Museum
+title: Backend Museum
+subtitle: Peer into the gears behind Kind Robots
+description: Explore the modular components, retired curiosities, and behind-the-scenes machinery that power the site.
+icon: kind-icon:gearhammer
+route: /wonderlab
+sort: 15
+---
+
+A living museum for components, experiments, and old machinery that remain interesting enough to keep around.

--- a/content/channels/lab/newsfeed.md
+++ b/content/channels/lab/newsfeed.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: newsfeed
+dashboardKey: wonder
+dashboardTab: newsfeed
+label: Newsfeed
+title: Newsfeed Lab
+subtitle: Experiment with gathered and summarized updates
+description: Explore an experimental feed for collecting, shaping, and reviewing useful news.
+icon: kind-icon:news
+route: /newsfeed
+sort: 80
+---
+
+A prototype feed where information is invited to arrive with context.

--- a/content/channels/lab/ruler-hooked.md
+++ b/content/channels/lab/ruler-hooked.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: ruler-hooked
+dashboardKey: wonder
+dashboardTab: ruler-hooked
+label: Ruler Hooked
+title: Ruler Hooked
+subtitle: An experimental game with its own peculiar physics
+description: Explore a standalone game prototype outside the main creative pipeline.
+icon: kind-icon:gamepad
+route: /ruler-hooked
+sort: 70
+---
+
+A strange little game is allowed to be strange in Lab. That is literally the lease.

--- a/content/channels/lab/screen-fx.md
+++ b/content/channels/lab/screen-fx.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: screen-fx
+dashboardKey: wonder
+dashboardTab: screen-fx
+label: Screen FX
+title: Screen FX
+subtitle: Reality, lightly tampered with
+description: Test visual effects, overlays, animations, butterflies, debug grids, and screen-wide mischief.
+icon: kind-icon:sparkles
+route: /screenfx
+sort: 120
+---
+
+A flashy little control room for effects that should remain optional, reversible, and at least mildly ridiculous.

--- a/content/channels/lab/sketchy.md
+++ b/content/channels/lab/sketchy.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: sketchy
+dashboardKey: academy
+dashboardTab: sketchy
+label: Sketchy
+title: Sketchy
+subtitle: Daily drawing assignments and kind critique
+description: Build a drawing habit with prompts, timers, practice, and gentle feedback.
+icon: kind-icon:pencil
+route: /sketchy
+sort: 30
+---
+
+A daily drawing experiment with considerably fewer judgmental rectangles.

--- a/content/channels/lab/voice-lab.md
+++ b/content/channels/lab/voice-lab.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: voice-lab
+dashboardKey: wonder
+dashboardTab: voice-lab
+label: Voice Lab
+title: Voice Lab
+subtitle: Prototype spoken interfaces and integrations
+description: Experiment with voice input, assistants, and external device integrations.
+icon: kind-icon:microphone
+route: /voice-lab
+sort: 100
+---
+
+A laboratory for teaching robots when to speak and, critically, when not to.

--- a/content/channels/lab/watchlist.md
+++ b/content/channels/lab/watchlist.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: watchlist
+dashboardKey: wonder
+dashboardTab: watchlist
+label: Watchlist
+title: Media Watchlist
+subtitle: Keep track of stories worth returning to
+description: Explore an experimental media tracker for films, shows, books, and recommendations.
+icon: kind-icon:eye
+route: /watchlist
+sort: 50
+---
+
+A prototype shelf for media you intend to consume before entropy wins.

--- a/content/channels/plan/appmaker.md
+++ b/content/channels/plan/appmaker.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: plan
+tabKey: appmaker
+dashboardKey: conductor
+dashboardTab: appmaker
+label: AppMaker
+title: AppMaker
+subtitle: Shape an application before building it
+description: Turn project ideas into structured application concepts, surfaces, and implementation plans.
+icon: kind-icon:foundry
+route: /appmaker
+sort: 30
+requiredRole: ADMIN
+---
+
+Draft an application into a shape the project pipeline can actually reason about.

--- a/content/channels/plan/conductor-app.md
+++ b/content/channels/plan/conductor-app.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: plan
+tabKey: conductor-app
+dashboardKey: conductor
+dashboardTab: conductor-app
+label: Conductor App
+title: Conductor App
+subtitle: Steer plans from a mobile client
+description: Review the companion Flutter application for project coordination on the go.
+icon: kind-icon:external-link
+route: /conductor-app
+sort: 40
+requiredRole: ADMIN
+---
+
+A mobile bridge into Plan and the Conductor workflow.

--- a/content/channels/plan/index.md
+++ b/content/channels/plan/index.md
@@ -1,14 +1,18 @@
 ---
 contentType: channel
 channelKey: plan
+dashboardKey: conductor
 label: Plan
 title: Plan
+room: Conductor
 subtitle: Turn wishes into coordinated work
 description: Projects, roadmaps, conductor workflows, milestones, and human checkpoints.
 icon: kind-icon:gearhammer
 route: /conductor
 defaultTab: projects
 sort: 20
+loadingMessage: Loading project plans...
+refreshLabel: Refresh Plan
 dottiTip: Plan is where ideas stop being fog and start becoming steps.
 amiTip: I brought tiny clipboards for everyone.
 ---

--- a/content/channels/plan/index.md
+++ b/content/channels/plan/index.md
@@ -1,0 +1,16 @@
+---
+contentType: channel
+channelKey: plan
+label: Plan
+title: Plan
+subtitle: Turn wishes into coordinated work
+description: Projects, roadmaps, conductor workflows, milestones, and human checkpoints.
+icon: kind-icon:gearhammer
+route: /conductor
+defaultTab: projects
+sort: 20
+dottiTip: Plan is where ideas stop being fog and start becoming steps.
+amiTip: I brought tiny clipboards for everyone.
+---
+
+Shape ideas into projects, coordinate the work, and keep humans in the loop.

--- a/content/channels/plan/projects.md
+++ b/content/channels/plan/projects.md
@@ -2,6 +2,8 @@
 contentType: tab
 channelKey: plan
 tabKey: projects
+dashboardKey: conductor
+dashboardTab: conductor
 label: Projects
 title: Project Planner
 subtitle: Organize the work that matters

--- a/content/channels/plan/projects.md
+++ b/content/channels/plan/projects.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: plan
+tabKey: projects
+label: Projects
+title: Project Planner
+subtitle: Organize the work that matters
+description: Browse projects, review status, and move ideas through the Conductor pipeline.
+icon: kind-icon:map
+route: /conductor
+sort: 10
+---
+
+Review projects and coordinate their next steps.

--- a/content/channels/plan/wishmaster.md
+++ b/content/channels/plan/wishmaster.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: plan
+tabKey: wishmaster
+dashboardKey: conductor
+dashboardTab: wishmaster
+label: Wishmaster
+title: Wishmaster
+subtitle: Turn a wish into a buildable project seed
+description: Capture a raw idea, clarify its intent, and shape it into a project the Conductor can coordinate.
+icon: kind-icon:sparkles
+route: /wishmaster
+sort: 20
+requiredRole: ADMIN
+---
+
+Turn a hopeful idea into a scoped project seed without sanding off all the hope.

--- a/content/channels/play/academy.md
+++ b/content/channels/play/academy.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: academy
+dashboardKey: academy
+dashboardTab: timeline
+label: Art Academy
+title: Art Academy
+subtitle: Explore styles across art history
+description: Browse historical styles, learn their visual language, and remix your own images.
+icon: kind-icon:palette
+route: /academy
+sort: 100
+---
+
+Learn the styles, then immediately commit tasteful visual crimes with them.

--- a/content/channels/play/art.md
+++ b/content/channels/play/art.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: art
+dashboardKey: art
+dashboardTab: gallery
+label: Art
+title: Art Gallery
+subtitle: Browse and collect generated images
+description: Explore generated art, inspect details, collect favorites, and reuse images in new creations.
+icon: kind-icon:image
+route: /art
+sort: 20
+---
+
+Browse the visual archive without entering the generation workshop.

--- a/content/channels/play/bots.md
+++ b/content/channels/play/bots.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: bots
+dashboardKey: bot
+dashboardTab: bots
+label: Bots
+title: Bot Gallery
+subtitle: Meet the narrators and assistants
+description: Browse bots, launch conversations, clone favorites, and discover new personalities.
+icon: kind-icon:robot-color
+route: /bots
+sort: 30
+---
+
+Meet the bots as characters and collaborators instead of configuration records.

--- a/content/channels/play/characters.md
+++ b/content/channels/play/characters.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: characters
+dashboardKey: character
+dashboardTab: characters
+label: Characters
+title: Character Gallery
+subtitle: Browse the cast
+description: Explore characters, choose performers, launch chats, and stage scenes.
+icon: kind-icon:mask
+route: /characters
+sort: 40
+---
+
+Browse the glorious weirdos who inhabit Kind Robots worlds.

--- a/content/channels/play/coloring.md
+++ b/content/channels/play/coloring.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: coloring
+dashboardKey: art
+dashboardTab: coloring
+label: Coloring
+title: Coloring Book
+subtitle: Color generated pages and sampler art
+description: Open a page, fill regions, save palettes, and return to works in progress.
+icon: kind-icon:paintbrush
+route: /coloring
+sort: 25
+---
+
+Color AI-generated pages and playful sampler art.

--- a/content/channels/play/facets.md
+++ b/content/channels/play/facets.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: facets
+dashboardKey: facets
+dashboardTab: library
+label: Facets
+title: Facet Library
+subtitle: Browse the reusable flavor of the ecosystem
+description: Explore genres, animals, colors, themes, moods, styles, and settings shared across creative systems.
+icon: kind-icon:tag
+route: /facets
+sort: 70
+---
+
+Browse the reusable creative building blocks shared by dreams, scenarios, art, and characters.

--- a/content/channels/play/gallery.md
+++ b/content/channels/play/gallery.md
@@ -1,14 +1,16 @@
 ---
 contentType: tab
 channelKey: play
-tabKey: gallery
-label: Gallery
-title: Creative Gallery
-subtitle: Browse the worlds of Kind Robots
-description: Discover art, dreams, bots, facets, characters, rewards, and scenarios.
-icon: kind-icon:grid
+tabKey: dreams
+dashboardKey: dream
+dashboardTab: dreams
+label: Dreams
+title: Dream Gallery
+subtitle: Browse collaborative worlds
+description: Explore dreams, choose a world, and branch into characters, art, chat, and stories.
+icon: kind-icon:moon
 route: /dreams
 sort: 10
 ---
 
-Browse the creative elements of Kind Robots from one playful home.
+Browse collaborative worlds and choose one to explore, remix, or expand.

--- a/content/channels/play/gallery.md
+++ b/content/channels/play/gallery.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: play
+tabKey: gallery
+label: Gallery
+title: Creative Gallery
+subtitle: Browse the worlds of Kind Robots
+description: Discover art, dreams, bots, facets, characters, rewards, and scenarios.
+icon: kind-icon:grid
+route: /dreams
+sort: 10
+---
+
+Browse the creative elements of Kind Robots from one playful home.

--- a/content/channels/play/index.md
+++ b/content/channels/play/index.md
@@ -1,0 +1,16 @@
+---
+contentType: channel
+channelKey: play
+label: Play
+title: Play
+subtitle: Explore what we have made
+description: Browse and interact with galleries, bots, dreams, facets, characters, rewards, and scenarios.
+icon: kind-icon:dice
+route: /dreams
+defaultTab: gallery
+sort: 40
+dottiTip: Play is for using creations instead of configuring them.
+amiTip: Finally, a channel with fewer forms.
+---
+
+Browse, remix, chat, perform, and play with the creative worlds of Kind Robots.

--- a/content/channels/play/index.md
+++ b/content/channels/play/index.md
@@ -3,12 +3,15 @@ contentType: channel
 channelKey: play
 label: Play
 title: Play
+room: Creative Worlds
 subtitle: Explore what we have made
 description: Browse and interact with galleries, bots, dreams, facets, characters, rewards, and scenarios.
 icon: kind-icon:dice
 route: /dreams
-defaultTab: gallery
+defaultTab: dreams
 sort: 40
+loadingMessage: Loading creative worlds...
+refreshLabel: Refresh Play
 dottiTip: Play is for using creations instead of configuring them.
 amiTip: Finally, a channel with fewer forms.
 ---

--- a/content/channels/play/rewards.md
+++ b/content/channels/play/rewards.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: rewards
+dashboardKey: reward
+dashboardTab: rewards
+label: Rewards
+title: Reward Gallery
+subtitle: Browse beautiful narrative chaos
+description: Explore items, powers, prompts, permissions, and surprises created by the community.
+icon: kind-icon:gift
+route: /rewards
+sort: 50
+---
+
+Browse rewards as ingredients for play, stories, and delightful imbalance.

--- a/content/channels/play/scenarios.md
+++ b/content/channels/play/scenarios.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: scenarios
+dashboardKey: scenario
+dashboardTab: scenarios
+label: Scenarios
+title: Scenario Gallery
+subtitle: Choose a story and make a mess
+description: Browse branching experiences, choose responses, invent solutions, and let the narrator handle the consequences.
+icon: kind-icon:story
+route: /stories
+sort: 60
+---
+
+Play through scenarios without dragging the authoring controls onto the stage.

--- a/content/channels/play/serendipity-voice.md
+++ b/content/channels/play/serendipity-voice.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: serendipity-voice
+dashboardKey: scenario
+dashboardTab: serendipity-voice
+label: Serendipity Voice
+title: Serendipity Voice
+subtitle: Talk to the story and watch the site respond
+description: Use the Serendipity voice surface, follow the shared message feed, and trigger playful spoken interactions.
+icon: kind-icon:butterfly
+route: /serendipity-voice
+sort: 85
+---
+
+The playful voice experience lives in Play; its relay diagnostics and integration machinery remain in Lab.

--- a/content/channels/play/serendipity.md
+++ b/content/channels/play/serendipity.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: serendipity
+dashboardKey: scenario
+dashboardTab: serendipity
+label: Serendipity
+title: Serendipity
+subtitle: Let the story surprise you
+description: Enter a playful narrated experience built around unexpected choices and discoveries.
+icon: kind-icon:sparkles
+route: /serendipity
+sort: 80
+---
+
+Follow a story that is allowed to take the scenic route.

--- a/content/channels/play/storymaker.md
+++ b/content/channels/play/storymaker.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: storymaker
+dashboardKey: scenario
+dashboardTab: storymaker
+label: Storymaker
+title: Storymaker
+subtitle: Weave a story from reusable ingredients
+description: Combine characters, places, rewards, art, and prompts into an unfolding narrative.
+icon: kind-icon:book
+route: /storymaker
+sort: 90
+---
+
+Bring the creative ecosystem together inside one narrative space.

--- a/content/channels/sanctuary/about.md
+++ b/content/channels/sanctuary/about.md
@@ -2,6 +2,8 @@
 contentType: tab
 channelKey: sanctuary
 tabKey: about
+dashboardKey: giftshop
+dashboardTab: sanctuary
 label: About
 title: About Kind Robots
 subtitle: Humans and robots building a kinder future

--- a/content/channels/sanctuary/about.md
+++ b/content/channels/sanctuary/about.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: about
+label: About
+title: About Kind Robots
+subtitle: Humans and robots building a kinder future
+description: Our story, values, community, and anti-malaria mission.
+icon: kind-icon:butterfly
+route: /sanctuary
+sort: 10
+---
+
+Meet the people, values, and mission behind Kind Robots.

--- a/content/channels/sanctuary/about.md
+++ b/content/channels/sanctuary/about.md
@@ -3,14 +3,14 @@ contentType: tab
 channelKey: sanctuary
 tabKey: about
 dashboardKey: giftshop
-dashboardTab: sanctuary
+dashboardTab: about
 label: About
 title: About Kind Robots
 subtitle: Humans and robots building a kinder future
 description: Our story, values, community, and anti-malaria mission.
-icon: kind-icon:butterfly
-route: /sanctuary
-sort: 10
+icon: kind-icon:heart
+route: /about
+sort: 20
 ---
 
 Meet the people, values, and mission behind Kind Robots.

--- a/content/channels/sanctuary/butterflies.md
+++ b/content/channels/sanctuary/butterflies.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: sanctuary
+dashboardKey: giftshop
+dashboardTab: sanctuary
+label: Butterflies
+title: Butterfly Sanctuary
+subtitle: Play with AMI's digital recreations
+description: Explore the animation controls and butterfly forms of Kind Robots' mascot.
+icon: kind-icon:butterfly
+route: /sanctuary
+sort: 10
+---
+
+A playful home for AMI and the butterflies that keep escaping into the interface.

--- a/content/channels/sanctuary/giftshop.md
+++ b/content/channels/sanctuary/giftshop.md
@@ -1,0 +1,19 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: giftshop
+dashboardKey: giftshop
+dashboardTab: giftshop
+label: Gift Shop
+title: Kind Robots Gift Shop
+subtitle: Support the mission through things we make
+description: Explore plans for print-on-demand art, creative products, subscriptions, and mission support.
+icon: kind-icon:gift
+route: /sanctuary
+sort: 30
+status: under-construction
+tutorial:
+  underConstruction: true
+---
+
+A future storefront for generated art and products that help support the project.

--- a/content/channels/sanctuary/index.md
+++ b/content/channels/sanctuary/index.md
@@ -1,7 +1,6 @@
 ---
 contentType: channel
 channelKey: sanctuary
-dashboardKey: giftshop
 label: Sanctuary
 title: Sanctuary
 room: Butterfly Sanctuary

--- a/content/channels/sanctuary/index.md
+++ b/content/channels/sanctuary/index.md
@@ -6,10 +6,10 @@ label: Sanctuary
 title: Sanctuary
 room: Butterfly Sanctuary
 subtitle: The heart of Kind Robots
-description: Our story, values, anti-malaria mission, community, and gift shop.
+description: Our story, values, anti-malaria mission, community, butterflies, and gift shop.
 icon: kind-icon:butterfly
 route: /sanctuary
-defaultTab: about
+defaultTab: sanctuary
 sort: 60
 loadingMessage: Loading Sanctuary...
 refreshLabel: Refresh Sanctuary

--- a/content/channels/sanctuary/index.md
+++ b/content/channels/sanctuary/index.md
@@ -1,0 +1,16 @@
+---
+contentType: channel
+channelKey: sanctuary
+label: Sanctuary
+title: Sanctuary
+subtitle: The heart of Kind Robots
+description: Our story, values, anti-malaria mission, community, and gift shop.
+icon: kind-icon:butterfly
+route: /sanctuary
+defaultTab: about
+sort: 60
+dottiTip: Sanctuary explains why we are building all of this.
+amiTip: Also where we keep the butterflies.
+---
+
+Learn about Kind Robots, our mission, our community, and how to support the work.

--- a/content/channels/sanctuary/index.md
+++ b/content/channels/sanctuary/index.md
@@ -1,14 +1,18 @@
 ---
 contentType: channel
 channelKey: sanctuary
+dashboardKey: giftshop
 label: Sanctuary
 title: Sanctuary
+room: Butterfly Sanctuary
 subtitle: The heart of Kind Robots
 description: Our story, values, anti-malaria mission, community, and gift shop.
 icon: kind-icon:butterfly
 route: /sanctuary
 defaultTab: about
 sort: 60
+loadingMessage: Loading Sanctuary...
+refreshLabel: Refresh Sanctuary
 dottiTip: Sanctuary explains why we are building all of this.
 amiTip: Also where we keep the butterflies.
 ---

--- a/content/channels/sanctuary/mermaids.md
+++ b/content/channels/sanctuary/mermaids.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: mermaids
+dashboardKey: giftshop
+dashboardTab: mermaids
+label: Mermaids
+title: Mermaids of Venice
+subtitle: A story project with its own public home
+description: Explore the Mermaids of Venice project, its world, art, and external surfaces.
+icon: kind-icon:mermaid
+route: /mermaids
+sort: 20
+---
+
+A public-facing creative project living in the community and mission wing.

--- a/content/channels/sanctuary/privacy.md
+++ b/content/channels/sanctuary/privacy.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: privacy
+dashboardKey: admin
+dashboardTab: user
+label: Privacy
+title: Privacy and Data Philosophy
+subtitle: Your data belongs to you
+description: Learn how Kind Robots handles personal data and the principles behind those choices.
+icon: kind-icon:shield
+route: /privacy
+sort: 50
+---
+
+A public promise about privacy belongs beside the mission and values it protects.

--- a/content/channels/sanctuary/subscriptions.md
+++ b/content/channels/sanctuary/subscriptions.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: subscriptions
+dashboardKey: giftshop
+dashboardTab: subscriptions
+label: Support Plans
+title: Support Kind Robots Monthly
+subtitle: Power our circuits
+description: Explore recurring support plans that help fund servers, art, stories, and the anti-malaria mission.
+icon: kind-icon:rocket
+route: /subscriptions
+sort: 40
+---
+
+Ongoing support helps Kind Robots plan beyond the next delightful emergency.

--- a/content/characters.md
+++ b/content/characters.md
@@ -2,12 +2,14 @@
 title: 'Characters'
 room: 'Character Gallery'
 subtitle: 'Not just pretty code'
-description: 'Browse character profiles each with their own quirks and quests.'
+description: 'Browse character profiles, each with their own quirks and quests.'
 image: splash/characters.png
 icon: fa-solid:mask
 tooltip: 'Meet the characters behind the chaos.'
-dottitip: 'Characters give your bots depth and direction.'
-amitip: 'One of mine insists on being addressed as “Captain Marshmallow.”'
+dottiTip: 'Characters give your bots depth and direction.'
+amiTip: 'One of mine insists on being addressed as “Captain Marshmallow.”'
+channelKey: play
+tabKey: characters
 dashboardKey: character
 dashboardTab: characters
 cards: characterCards

--- a/content/chats.md
+++ b/content/chats.md
@@ -2,12 +2,14 @@
 title: 'Chats'
 room: 'Chat Gallery'
 subtitle: 'Echoes of wit and weirdness'
-description: 'Scroll through curated messages and threads from across our digital domains.'
+description: Scroll through curated messages and threads from across our digital domains.
 image: splash/chats.png
 icon: fa-solid:comments
-tooltip: 'Read the things bots and users have actually said. It’s a ride.'
-dottitip: 'Sometimes, the conversation becomes the content.'
-amitip: 'Especially when someone accidentally proposes to a toaster.'
+tooltip: Read the things bots and users have actually said. It’s a ride.
+dottiTip: Sometimes, the conversation becomes the content.
+amiTip: Especially when someone accidentally proposes to a toaster.
+channelKey: home
+tabKey: chats
 dashboardKey: user
 dashboardTab: chats
 cards: navCards

--- a/content/coat-dance.md
+++ b/content/coat-dance.md
@@ -6,6 +6,8 @@ description: A playful video-remix project that loops movement and costume into 
 image: nav/heroes/art.webp
 icon: kind-icon:sparkles
 tooltip: Remix motion and costume into short, joyful loops.
+channelKey: lab
+tabKey: coat-dance
 dashboardKey: art
 dashboardTab: coat-dance
 cards: navCards

--- a/content/coloring.md
+++ b/content/coloring.md
@@ -6,8 +6,10 @@ description: Color AI-generated pages by tapping regions, browse finished art, g
 image: nav/heroes/art.webp
 icon: kind-icon:paintbrush
 tooltip: Open a page, fill the regions, save your palette, and make more art.
-dottitip: Stay inside the lines or don't — the robots aren't judging. Much.
-amitip: I colored a butterfly forty-one times. No regrets. 🦋🎨
+dottiTip: Stay inside the lines or don't — the robots aren't judging. Much.
+amiTip: I colored a butterfly forty-one times. No regrets. 🦋🎨
+channelKey: play
+tabKey: coloring
 dashboardKey: art
 dashboardTab: coloring
 cards: navCards

--- a/content/conductor-app.md
+++ b/content/conductor-app.md
@@ -6,6 +6,8 @@ description: The external Flutter client for steering Conductor on the go.
 image: nav/heroes/conductor.webp
 icon: kind-icon:external-link
 tooltip: Conductor, reshaped for a phone.
+channelKey: plan
+tabKey: conductor-app
 dashboardKey: conductor
 dashboardTab: conductor-app
 cards: navCards

--- a/content/conductor.md
+++ b/content/conductor.md
@@ -1,5 +1,5 @@
 ---
-title: Conductor
+title: Plan
 room: Conductor
 subtitle: Conductor Cockpit
 description: Project progress, pitch voting, task gates, roadmap state, and Portos setup.
@@ -7,11 +7,13 @@ image: nav/heroes/conductor.webp
 tooltip: Review Conductor state and configure Portos.
 icon: kind-icon:gearhammer
 sort: highlight
+channelKey: plan
+tabKey: projects
 dashboardKey: conductor
 dashboardTab: conductor
 cards: conductorCards
-loadingMessage: Loading conductor...
-refreshLabel: Refresh Conductor
+loadingMessage: Loading plans...
+refreshLabel: Refresh Plan
 ---
 
 :conductor-manager

--- a/content/dashboard.md
+++ b/content/dashboard.md
@@ -1,13 +1,15 @@
 ---
 title: 'Human'
 room: 'Dashboard Room'
-subtitle: "Your Private Page"
-description: 'This is your space!'
+subtitle: 'Your Private Page'
+description: This is your space!
 image: splash/dashboard.png
 icon: kind-icon:settings
-tooltip: user customizations and art sharing settings here.
-dottitip: 'Everyone needs a personal space all to their own.'
-amitip: "Even I've got a bungalo in the cloud where I unwind."
+tooltip: User customizations and art sharing settings live here.
+dottiTip: Everyone needs a personal space all to their own.
+amiTip: Even I've got a bungalow in the cloud where I unwind.
+channelKey: home
+tabKey: dashboard
 dashboardKey: user
 dashboardTab: dashboard
 cards: navCards

--- a/content/davinci.md
+++ b/content/davinci.md
@@ -6,6 +6,8 @@ description: A generative life-and-legacy simulation of ambition, craft, and riv
 image: nav/heroes/games.webp
 icon: kind-icon:castle
 tooltip: Seed a life, make choices, and see what legacy you leave.
+channelKey: lab
+tabKey: davinci
 dashboardKey: wonder
 dashboardTab: davinci
 cards: navCards

--- a/content/dreams.md
+++ b/content/dreams.md
@@ -7,10 +7,12 @@ image: splash/dreams.png
 icon: kind-icon:moon
 tooltip: A shared room where prompts, images, and chat bend the experience together.
 sort: highlight
-dottitip: Users can now steer the dream together. I'm a little nervous about what they'll build
-amitip: Good. Dreams built by committee are how mythology happens.
+dottiTip: Users can now steer the dream together. I'm a little nervous about what they'll build.
+amiTip: Good. Dreams built by committee are how mythology happens.
+channelKey: play
+tabKey: dreams
 dashboardKey: dream
-dashboardTab: locations
+dashboardTab: dreams
 cards: dreamCards
 loadingMessage: Loading locations...
 refreshLabel: Refresh Locations

--- a/content/facets.md
+++ b/content/facets.md
@@ -7,6 +7,8 @@ image: nav/heroes/facets.webp
 icon: kind-icon:tag
 tooltip: Manage the reusable creative building blocks shared across the site.
 sort: utility
+channelKey: play
+tabKey: facets
 dashboardKey: facets
 dashboardTab: library
 loadingMessage: Loading facets...

--- a/content/humboldt-scoop.md
+++ b/content/humboldt-scoop.md
@@ -6,6 +6,8 @@ description: A real-world pet-waste removal service with a warm local story — 
 image: nav/heroes/sanctuary.webp
 icon: kind-icon:heart
 tooltip: Meet the Humboldt Scoop and book a cleanup.
+channelKey: lab
+tabKey: humboldt-scoop
 dashboardKey: wonder
 dashboardTab: humboldt-scoop
 cards: navCards

--- a/content/index.md
+++ b/content/index.md
@@ -2,13 +2,15 @@
 title: 'Kind Robots'
 room: 'Dashboard Room'
 subtitle: 'Craft your universe'
-description: Welcome to the Kind Robots, a consortium of AI-assisted tools to generate and share your creations with others.
+description: Welcome to Kind Robots, a consortium of AI-assisted tools to generate and share your creations with others.
 image: splash/robots.png
 icon: kind-icon:home
 tooltip: Hi! I'm Silas, human programmer for Kind Robots!
-dottitip: AMI, we've been building this lab a while. Do you think it's ready?
-amitip: It was ready the moment we decided weird things should exist. Everything else is details.
+dottiTip: AMI, we've been building this lab a while. Do you think it's ready?
+amiTip: It was ready the moment we decided weird things should exist. Everything else is details.
 sort: highlight
+channelKey: home
+tabKey: dashboard
 dashboardKey: user
 dashboardTab: dashboard
 cards: navCards

--- a/content/memory.md
+++ b/content/memory.md
@@ -6,8 +6,10 @@ description: A roguelite memory card game where AI art becomes a tiny dungeon cr
 image: 'background/memorydungeon.png'
 icon: kind-icon:brain
 tooltip: 'A memory game with lives, levels, powerups, surprise loot, and weird dungeon flavor.'
-dottitip: 'AMI, I upgraded the memory game into a dungeon crawler. There are lives, levels, rewards, and probably goblins.'
-amitip: 'Excellent. Nothing improves cognitive training like treasure chests and suspiciously judgmental rectangles.'
+dottiTip: 'AMI, I upgraded the memory game into a dungeon crawler. There are lives, levels, rewards, and probably goblins.'
+amiTip: 'Excellent. Nothing improves cognitive training like treasure chests and suspiciously judgmental rectangles.'
+channelKey: lab
+tabKey: experiments
 dashboardKey: wonder
 dashboardTab: memory-dungeon
 cards: labCards

--- a/content/mermaids.md
+++ b/content/mermaids.md
@@ -6,8 +6,10 @@ description: Silas Knight's novel — the book itself, a note from the author, a
 image: utility/mermaids/mermaids1.jpg
 icon: kind-icon:mermaid
 tooltip: Six years of hand-carved words about gods moonlighting as street performers. The only AI on this page is the paragraph that admits it.
-dottitip: A whole novel and not one robot in it? Bold choice, honestly.
-amitip: I checked every canal. Zero butterflies, but the mermaids seemed nice. 🧜✨
+dottiTip: A whole novel and not one robot in it? Bold choice, honestly.
+amiTip: I checked every canal. Zero butterflies, but the mermaids seemed nice. 🧜✨
+channelKey: sanctuary
+tabKey: mermaids
 dashboardKey: giftshop
 dashboardTab: mermaids
 cards: navCards

--- a/content/model-builder.md
+++ b/content/model-builder.md
@@ -5,6 +5,8 @@ subtitle: Resumable, human-gated recipe runner
 description: Select a Kind Robots source model, choose a recipe, and walk each output through pitch, fields, generation, and commit — editable and resumable at every gate.
 icon: kind-icon:blueprint
 tooltip: Upgrade or expand existing Kind Robots records through four reviewable gates.
+channelKey: build
+tabKey: model-builder
 dashboardKey: builder
 dashboardTab: model-builder
 cards: navCards

--- a/content/mural.md
+++ b/content/mural.md
@@ -7,8 +7,10 @@ image: dashboard-tabs/wonder/mural.webp
 tooltip: Color the mural plan, save paint IDs, and test the palette before anyone opens a can.
 icon: kind-icon:paintbrush
 sort: wonder
-dottitip: "Can a coloring page become project management?"
-amitip: "Yes, but only if the paint swatches stop wandering off like tiny chromatic ferrets."
+dottiTip: Can a coloring page become project management?
+amiTip: Yes, but only if the paint swatches stop wandering off like tiny chromatic ferrets.
+channelKey: lab
+tabKey: mural
 dashboardKey: wonder
 dashboardTab: mural
 cards: labCards

--- a/content/navigation-health.md
+++ b/content/navigation-health.md
@@ -1,0 +1,16 @@
+---
+title: Navigation Health
+room: Control Room
+subtitle: Inspect the resolved channel graph
+description: Review content-driven channels, tabs, route sharing, permissions, compatibility adapters, and browser-detected artwork failures.
+icon: kind-icon:compass
+channelKey: admin
+tabKey: navigation-health
+requiredRole: ADMIN
+loadingMessage: Loading navigation health...
+refreshLabel: Reload Navigation
+dottiTip: The navigation has a navigation page now. I promise this is less silly than it sounds.
+amiTip: Maps need legends. Systems need mirrors.
+---
+
+:navigation-navigation-health

--- a/content/navigation.md
+++ b/content/navigation.md
@@ -2,12 +2,14 @@
 title: 'Navigation'
 room: 'Navigation Overview'
 subtitle: 'Your personal roadmap'
-description: 'All roads lead to here — your central hub for exploring Kind Robots. Switch tabs, access dashboards, and get where you need to go.'
+description: All roads lead to here — your central hub for exploring Kind Robots. Switch tabs, access dashboards, and get where you need to go.
 image: splash/navigation.png
 icon: kind-icon:map
-tooltip: 'You can’t get lost if you enjoy the journey.'
-dottitip: 'Organized navigation is a kindness to future-you.'
-amitip: 'I navigated the nav to the other nav. Now I’m the nav.'
+tooltip: You can’t get lost if you enjoy the journey.
+dottiTip: Organized navigation is a kindness to future-you.
+amiTip: I navigated the nav to the other nav. Now I’m the nav.
+channelKey: home
+tabKey: navigation
 dashboardKey: admin
 dashboardTab: user
 cards: navCards

--- a/content/newsfeed.md
+++ b/content/newsfeed.md
@@ -6,6 +6,8 @@ description: A programmable, remixable homepage feed of fresh art, stories, and 
 image: nav/heroes/home.webp
 icon: kind-icon:scroll
 tooltip: See what the swarm is making right now.
+channelKey: lab
+tabKey: newsfeed
 dashboardKey: wonder
 dashboardTab: newsfeed
 cards: navCards

--- a/content/packs.md
+++ b/content/packs.md
@@ -6,6 +6,8 @@ description: Bundle reusable content into shareable, permissioned packs and DLC.
 image: nav/heroes/builder.webp
 icon: kind-icon:box
 tooltip: Turn loose creations into tidy, shareable packs.
+channelKey: build
+tabKey: packs
 dashboardKey: builder
 dashboardTab: packs
 cards: navCards

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,18 +1,21 @@
 ---
 title: 'Privacy'
 room: 'Info Room'
-subtitle: "Our Privacy Policy"
-description: "How Kind Robots handles your data — and why we think you'll like it."
+subtitle: 'Our Privacy Policy'
+description: How Kind Robots handles your data — and why we think you'll like it.
 image: splash/privacy.png
 icon: kind-icon:shield
 tooltip: Kind Robots privacy policy and data philosophy.
-dottitip: 'Your data belongs to you. Full stop.'
-amitip: "Even robots have a code of ethics. Ours just happens to be written down."
+dottiTip: Your data belongs to you. Full stop.
+amiTip: Even robots have a code of ethics. Ours just happens to be written down.
 sort: info
+channelKey: sanctuary
+tabKey: privacy
 dashboardKey: admin
 dashboardTab: user
 cards: navCards
 loadingMessage: Loading privacy
 refreshLabel: Refresh Privacy
 ---
+
 :privacy-page

--- a/content/project-placement.md
+++ b/content/project-placement.md
@@ -1,0 +1,20 @@
+---
+title: Project Placement
+room: Control Room
+subtitle: Apply the canonical Project navigation map
+description: Load existing Projects, backfill channel and tab placement, optionally repair live URLs, and review the migration report.
+image: dashboard-tabs/conductor/conductor.webp
+icon: kind-icon:map
+tooltip: Apply the canonical projectPlacements map to existing Project rows.
+channelKey: admin
+tabKey: project-placement
+dashboardKey: conductor
+dashboardTab: conductor
+requiredRole: ADMIN
+loadingMessage: Loading project placement controls...
+refreshLabel: Reload Projects
+dottiTip: I made the placement migration visible so it cannot hide behind a store method forever.
+amiTip: Excellent. Dangerous buttons should at least have labels.
+---
+
+:projects-project-placement-manager

--- a/content/register.md
+++ b/content/register.md
@@ -4,11 +4,13 @@ room: 'Registration Room'
 subtitle: Welcome to the community
 description: Register to unlock leaderboards, user navigation, jellybean tracking, art collection, prompt retention, and more!
 image: splash/register.png
-tooltip: 'Step through the gateway to a world of creativity and camaraderie!'
-amitip: And keep track of who tries to beat me on the leaderboards!
+tooltip: Step through the gateway to a world of creativity and camaraderie!
+amiTip: And keep track of who tries to beat me on the leaderboards!
 icon: kind-icon:register
 sort: highlight
-dottitip: If people register for an account, then we can customize their experience.
+dottiTip: If people register for an account, then we can customize their experience.
+channelKey: home
+tabKey: registration
 dashboardKey: user
 dashboardTab: dashboard
 cards: navCards

--- a/content/rewards.md
+++ b/content/rewards.md
@@ -1,13 +1,15 @@
 ---
 title: 'Rewards'
 room: 'Reward Gallery'
-subtitle: 'beautiful narrative chaos'
+subtitle: 'Beautiful narrative chaos'
 description: 'Explore community-created rewards: items, powers, and prompts that twist the rules of our AI storytelling worlds.'
 image: splash/rewards.png
 icon: kind-icon:vortex
 tooltip: 'Browse rewards that inject wonder, mischief, or magic into the story.'
-dottitip: Are some of these rewards a tad unbalanced?
-amitip: That's the beauty of a narrative-driven adventure. Anything can keep the story going!
+dottiTip: Are some of these rewards a tad unbalanced?
+amiTip: That's the beauty of a narrative-driven adventure. Anything can keep the story going!
+channelKey: play
+tabKey: rewards
 dashboardKey: reward
 dashboardTab: rewards
 cards: rewardCards

--- a/content/ruler-hooked.md
+++ b/content/ruler-hooked.md
@@ -6,6 +6,8 @@ description: A fishing-meets-kingdom-management slideshow sim of tides, catches,
 image: nav/heroes/games.webp
 icon: kind-icon:crown
 tooltip: Cast lines, land catches, and run a seaside kingdom.
+channelKey: lab
+tabKey: ruler-hooked
 dashboardKey: wonder
 dashboardTab: ruler-hooked
 cards: navCards

--- a/content/sanctuary.md
+++ b/content/sanctuary.md
@@ -1,18 +1,20 @@
 ---
 title: Butterfly
 room: 'Butterfly Sanctuary'
-subtitle: butterflies for world harmony
-description: Play around with AMIs digital recreations.
+subtitle: Butterflies for world harmony
+description: Play around with AMI's digital recreations.
 image: splash/sanctuary.png
 icon: kind-icon:butterfly
 tooltip: Our animation controller for AMI, our website's digital avatar
-dottitip: AMI, how many butterflies are you exactly?
-amitip: Yes.
+dottiTip: AMI, how many butterflies are you exactly?
+amiTip: Yes.
+channelKey: sanctuary
+tabKey: about
 dashboardKey: giftshop
 dashboardTab: sanctuary
 cards: navCards
 loadingMessage: Loading sanctuary...
-refreshLabel: Refresh Adventure
+refreshLabel: Refresh Sanctuary
 ---
 
 :giftshop-manager

--- a/content/sanctuary.md
+++ b/content/sanctuary.md
@@ -9,7 +9,7 @@ tooltip: Our animation controller for AMI, our website's digital avatar
 dottiTip: AMI, how many butterflies are you exactly?
 amiTip: Yes.
 channelKey: sanctuary
-tabKey: about
+tabKey: sanctuary
 dashboardKey: giftshop
 dashboardTab: sanctuary
 cards: navCards

--- a/content/scoop-cms.md
+++ b/content/scoop-cms.md
@@ -6,8 +6,11 @@ description: Admin console for the Humboldt Scoop customer, schedule, and route 
 image: nav/heroes/conductor.webp
 icon: kind-icon:heart
 tooltip: Manage the Humboldt Scoop service, admin only.
+channelKey: admin
+tabKey: scoop-cms
 dashboardKey: conductor
 dashboardTab: scoop-cms
+requiredRole: ADMIN
 cards: navCards
 loadingMessage: Opening the back office...
 refreshLabel: Refresh Scoop CMS

--- a/content/screenfx.md
+++ b/content/screenfx.md
@@ -7,8 +7,10 @@ image: splash/screenfx.png
 tooltip: Test visual effects, animation overlays, and screen interactions from one flashy little control room.
 icon: kind-icon:sparkles
 sort: highlight
-dottitip: "AMI, should we really give them buttons that affect the whole screen?"
-amitip: "Absolutely. What's the worst that could happen? Besides everything becoming butterflies. Which is arguably an improvement."
+dottiTip: AMI, should we really give them buttons that affect the whole screen?
+amiTip: Absolutely. What's the worst that could happen? Besides everything becoming butterflies.
+channelKey: lab
+tabKey: screen-fx
 dashboardKey: wonder
 dashboardTab: screen-fx
 cards: labCards

--- a/content/serendipity-voice.md
+++ b/content/serendipity-voice.md
@@ -5,8 +5,10 @@ subtitle: Talk to Kind Robots
 description: The voice surface for the Serendipity Alexa integration. Connects to the local voice relay, shows the shared message feed, and applies spoken commands like "turn butterflies on" to the app.
 icon: kind-icon:butterfly
 tooltip: Say "Serendipity, turn butterflies on" and watch it happen here.
-dottitip: The house is listening. Speak kindly.
-amitip: Your voice becomes a butterfly. Try it.
+dottiTip: The house is listening. Speak kindly.
+amiTip: Your voice becomes a butterfly. Try it.
+channelKey: play
+tabKey: serendipity-voice
 dashboardKey: scenario
 dashboardTab: serendipity-voice
 cards: navCards

--- a/content/serendipity.md
+++ b/content/serendipity.md
@@ -5,8 +5,10 @@ subtitle: A story that helps
 description: Step into a second-person adventure woven by the Serendipity bot. Pick a tone, open the door, and let the story's questions quietly help your projects.
 icon: kind-icon:sparkles
 tooltip: You are the protagonist. The story is on your side.
-dottitip: The story asks the questions this time. Answer honestly, it can tell.
-amitip: A to-do list wearing a fairy tale is still a fairy tale. Let it in.
+dottiTip: The story asks the questions this time. Answer honestly, it can tell.
+amiTip: A to-do list wearing a fairy tale is still a fairy tale. Let it in.
+channelKey: play
+tabKey: serendipity
 dashboardKey: scenario
 dashboardTab: serendipity
 cards: navCards

--- a/content/stories.md
+++ b/content/stories.md
@@ -2,13 +2,15 @@
 title: 'Stories'
 room: 'Story Maker Room'
 subtitle: A multiverse of possibilities
-description: A surreal odyssey powered by ChatGPT.  Craft worlds, weave narratives, and embrace the beautifully bizarre.
+description: A surreal odyssey powered by ChatGPT. Craft worlds, weave narratives, and embrace the beautifully bizarre.
 image: splash/stories.png
 icon: kind-icon:book
-tooltip: Share in a multiverse of possibilties.
+tooltip: Share in a multiverse of possibilities.
 sort: highlight
-dottitip: AMI, is the simulation room ready? We've handed visitors a box of story props, but we forgot to tell them what they're for.
-amitip: Perfect! Nothing fuels creativity like vague instructions and existential confusion. Let's see what they do with it!
+dottiTip: AMI, is the simulation room ready? We've handed visitors a box of story props, but we forgot to tell them what they're for.
+amiTip: Perfect! Nothing fuels creativity like vague instructions and existential confusion. Let's see what they do with it!
+channelKey: play
+tabKey: scenarios
 dashboardKey: scenario
 dashboardTab: scenarios
 cards: scenarioCards

--- a/content/storymaker.md
+++ b/content/storymaker.md
@@ -6,6 +6,8 @@ description: Weave characters, places, and treasures into a collaborative, narra
 image: nav/heroes/scenario.webp
 icon: kind-icon:story
 tooltip: Weave your cast and settings into one story.
+channelKey: play
+tabKey: storymaker
 dashboardKey: scenario
 dashboardTab: storymaker
 cards: navCards

--- a/content/stylist.md
+++ b/content/stylist.md
@@ -1,14 +1,16 @@
 ---
 title: 'Hair Studio'
 room: 'Hair Studio'
-subtitle: "The Hair by Superkate studio suite"
-description: "The whole salon in one tab: try a new color or cut on a client's own photo, price an appointment, keep the client book, and send warm receipts. Client photos stay private."
+subtitle: 'The Hair by Superkate studio suite'
+description: The whole salon in one tab: try a new color or cut on a client's own photo, price an appointment, keep the client book, and send warm receipts. Client photos stay private.
 image: 'background/artgallery.webp'
 icon: kind-icon:magic
 tooltip: Private AI hairstyle studio for Hair by Superkate.
-dottitip: AMI, I taught the art forge to do hair. Color, cut, the works.
-amitip: "Delightful. Reversible haircuts at last — the only kind I trust."
+dottiTip: AMI, I taught the art forge to do hair. Color, cut, the works.
+amiTip: Delightful. Reversible haircuts at last — the only kind I trust.
 sort: highlight
+channelKey: build
+tabKey: stylist
 dashboardKey: art
 dashboardTab: stylist
 cards: artCards

--- a/content/subscriptions.md
+++ b/content/subscriptions.md
@@ -6,12 +6,14 @@ description: Subscribe to keep Kind Robots dreaming! Monthly support helps us pl
 image: splash/plans.png
 icon: kind-icon:rocket
 tooltip: Ongoing support makes long-term imagination possible.
-amitip: We're basically a butterfly-powered nonprofit with server bills.
-dottitip: Subscriptions are the adult version of putting a star sticker on our forehead.
+amiTip: We're basically a butterfly-powered nonprofit with server bills.
+dottiTip: Subscriptions are the adult version of putting a star sticker on our forehead.
+channelKey: sanctuary
+tabKey: subscriptions
 dashboardKey: giftshop
 dashboardTab: subscriptions
 cards: navCards
-loadingMessage: Loading plans....
+loadingMessage: Loading plans...
 refreshLabel: Refresh plans
 ---
 

--- a/content/themes.md
+++ b/content/themes.md
@@ -2,13 +2,15 @@
 title: 'Themes'
 room: 'Theme Gallery'
 subtitle: 'Your World, Your Palette'
-description: 'Select a theme that resonances with you, and make this space truly your own. With a plethora of choices, you are bound to find your vibe.'
+description: Select a theme that resonates with you and make this space truly your own. With a plethora of choices, you are bound to find your vibe.
 image: splash/themes.png
 icon: kind-icon:remote
 tooltip: Fun fact, Cupcake was the in-utero name for our firstborn!
 sort: highlight
-dottitip: AMI, we already have over thirty themes and someone wants to know if we'll add more.
-amitip: Tell them yes and that we'll never stop.
+dottiTip: AMI, we already have over thirty themes and someone wants to know if we'll add more.
+amiTip: Tell them yes and that we'll never stop.
+channelKey: home
+tabKey: themes
 dashboardKey: user
 dashboardTab: themes
 cards: navCards
@@ -17,5 +19,3 @@ refreshLabel: Refresh Themes
 ---
 
 :user-manager
-
-

--- a/content/voice-lab.md
+++ b/content/voice-lab.md
@@ -2,10 +2,12 @@
 title: 'Voice Lab'
 room: 'Voice Lab'
 subtitle: 'Kind Robots, out loud.'
-description: The experimental Alexa/voice bridge and its relay status.
+description: The experimental Alexa and voice bridge and its relay status.
 image: nav/heroes/games.webp
 icon: kind-icon:microphone
 tooltip: The voice frontier — skill, relay, and status.
+channelKey: lab
+tabKey: voice-lab
 dashboardKey: wonder
 dashboardTab: voice-lab
 cards: navCards

--- a/content/watchlist.md
+++ b/content/watchlist.md
@@ -6,6 +6,8 @@ description: A structured log of films and shows to queue, watch, and finish.
 image: nav/heroes/games.webp
 icon: kind-icon:movie
 tooltip: Queue it now so you actually watch it later.
+channelKey: lab
+tabKey: watchlist
 dashboardKey: wonder
 dashboardTab: watchlist
 cards: navCards

--- a/content/wishmaster.md
+++ b/content/wishmaster.md
@@ -6,6 +6,8 @@ description: Shape a raw wish into a scoped, buildable project seed.
 image: nav/heroes/conductor.webp
 icon: kind-icon:sparkles
 tooltip: Make a wish. Get a plan.
+channelKey: plan
+tabKey: wishmaster
 dashboardKey: conductor
 dashboardTab: wishmaster
 cards: navCards

--- a/content/wonderlab.md
+++ b/content/wonderlab.md
@@ -1,5 +1,5 @@
 ---
-title: 'Wonder'
+title: 'Backend Museum'
 room: 'Wonder Lab'
 subtitle: 'Unveiling the Magic'
 description: A comprehensive showcase of the modular building blocks that power our digital wonderland. Peer into the gears and cogs of our operation.
@@ -7,13 +7,15 @@ image: splash/wonderlab.png
 tooltip: Here's the behind-the-scenes look at the components that make up our site.
 icon: kind-icon:gearhammer
 sort: highlight
-dottitip: "AMI, is it safe to let people poke around in the lab?"
-amitip: "Don't worry about them breaking anything, it was probably broken before they touched it. Besides, there's always the button in the left corner that lets them head back to the main lab."
+dottiTip: AMI, is it safe to let people poke around in the lab?
+amiTip: Don't worry about them breaking anything. It was probably broken before they touched it.
+channelKey: lab
+tabKey: museum
 dashboardKey: wonder
 dashboardTab: wonder-lab
 cards: labCards
-loadingMessage: Loading wonderlab...
-refreshLabel: Refresh Lab
+loadingMessage: Loading the museum...
+refreshLabel: Refresh Museum
 ---
 
 :lab-manager

--- a/cypress/e2e/api/projects.cy.ts
+++ b/cypress/e2e/api/projects.cy.ts
@@ -29,8 +29,8 @@ describe('Project API', () => {
         flavorText: 'Project rows are real now.',
         status: 'ACTIVE',
         priority: 'HIGH',
-        channelKey: 'conductor',
-        tabKey: slug,
+        channelKey: 'plan',
+        tabKey: 'projects',
         isPublic: false,
       },
     }).then((response) => {
@@ -39,7 +39,8 @@ describe('Project API', () => {
       expect(response.body.data.slug).to.eq(slug)
       expect(response.body.data.status).to.eq('ACTIVE')
       expect(response.body.data.priority).to.eq('HIGH')
-      expect(response.body.data.channelKey).to.eq('conductor')
+      expect(response.body.data.channelKey).to.eq('plan')
+      expect(response.body.data.tabKey).to.eq('projects')
       projectId = response.body.data.id
     })
   })
@@ -62,7 +63,11 @@ describe('Project API', () => {
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data).to.be.an('array')
-      expect(response.body.data.some((project: { id: number }) => project.id === projectId)).to.be.true
+      expect(
+        response.body.data.some(
+          (project: { id: number }) => project.id === projectId,
+        ),
+      ).to.be.true
     })
   })
 
@@ -73,16 +78,16 @@ describe('Project API', () => {
       headers: { Authorization: `Bearer ${token}` },
       body: {
         priority: 'LOW',
-        channelKey: 'projects',
-        tabKey: `${slug}-updated`,
-        liveUrl: '/projects/cypress',
+        channelKey: 'lab',
+        tabKey: 'challenges',
+        liveUrl: '/challenges',
         allowReviews: true,
       },
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data.priority).to.eq('LOW')
-      expect(response.body.data.channelKey).to.eq('projects')
-      expect(response.body.data.tabKey).to.eq(`${slug}-updated`)
+      expect(response.body.data.channelKey).to.eq('lab')
+      expect(response.body.data.tabKey).to.eq('challenges')
       expect(response.body.data.allowReviews).to.be.true
     })
   })

--- a/docs/channel-content-authoring.md
+++ b/docs/channel-content-authoring.md
@@ -29,7 +29,6 @@ Create `content/channels/<channel-key>/index.md`:
 ---
 contentType: channel
 channelKey: example
-dashboardKey: legacy-dashboard
 label: Example
 title: Example
 room: Example Workshop
@@ -49,6 +48,8 @@ Optional longer channel copy can live in the Markdown body.
 ```
 
 `channelKey` must be lowercase kebab-case. The top-level channel list is currently intentionally limited to Home, Plan, Build, Play, Lab, Sanctuary, and Admin; update the channel-content contract only when deliberately changing that information architecture.
+
+Only put `dashboardKey` on the parent when every child truly belongs to the same legacy dashboard. Diverse channels such as Lab, Sanctuary, and Admin keep legacy adapters on individual tabs instead.
 
 ## Add a tab
 
@@ -105,6 +106,8 @@ A tab inherits missing presentation metadata from its parent channel. Common inh
 
 The content resolver performs inheritance once. Components receive complete resolved tab objects and should not recreate fallback chains.
 
+Legacy dashboard adapters can also inherit, but use that only for channels whose children genuinely share one old manager. Otherwise declare `dashboardKey` and `dashboardTab` directly on each tab.
+
 ## Shared routes and shareable tab URLs
 
 Several tabs may intentionally use the same route while selecting different manager modes. Build is the clearest example.
@@ -136,6 +139,14 @@ When `image` is omitted, the resolver tries legacy dashboard artwork and then th
 /images/channels/<channel-key>/<tab-key>.webp
 ```
 
+Run the non-blocking artwork audit to list resolved images that do not exist under `public/`:
+
+```bash
+npm run audit:channel-assets
+```
+
+Add `-- --strict` when deliberately using the audit as a local gate.
+
 ## Dotti and AMI dialogue
 
 The optional simulated conversation remains supported:
@@ -149,17 +160,35 @@ Camel-case `dottiTip` and `amiTip` are canonical. Legacy lowercase `dottitip` an
 
 ## Permissions
 
-Use channel-level permissions when every child shares the same gate. Override on a tab only when necessary:
+Use channel-level permissions when every child shares the same gate. Override on a tab only when necessary.
+
+Role gate:
 
 ```yaml
 requiredRole: ADMIN
 ```
 
-`requiredPermission` is available for the future capability-based permission system.
+Capability gate:
+
+```yaml
+requiredPermission: member
+```
+
+Supported navigation capabilities are:
+
+- `authenticated` — any signed-in user
+- `member` — an active Kind Robots member
+- `family` — a user with the FAMILY role
+- `mature` — a user who enabled mature content
+- `admin` — an administrator
+
+Role and capability gates are evaluated independently. Administrators bypass capability gates, while `requiredRole` still expresses the explicit role boundary. Channels with no accessible tabs are omitted from navigation.
 
 ## Legacy bridge
 
 `dashboardKey` and `dashboardTab` are compatibility adapters, not the public information architecture. Keep them while the destination still launches an existing dashboard manager. New navigation code should prefer `channelKey` and `tabKey`.
+
+Canonical page activation happens in `pageStore`: content resolves the active channel and tab first, then the old dashboard shell is synchronized as a compatibility adapter. Header, navigator, Builder, and tutorial components should not recreate that synchronization.
 
 ## Validation
 
@@ -167,9 +196,11 @@ Run:
 
 ```bash
 npm run test:channel-content
+npm run test:channel-resolver
+npm run audit:channel-assets
 ```
 
-The contract checks:
+The content contract checks:
 
 - Required parent channels
 - Valid lowercase kebab-case keys
@@ -180,4 +211,14 @@ The contract checks:
 - Valid canonical Project placements
 - Shared-route tab groups that use `?tab=` addressing
 
-TypeScript validation also runs through the normal project test workflow.
+The resolver contract checks:
+
+- Parent inheritance
+- Dotti and AMI dialogue compatibility
+- Legacy dashboard aliases
+- Shared-route defaults
+- Role filtering
+- Capability filtering
+- Administrator bypass
+
+TypeScript validation also runs through the normal project test workflow. Admin users can inspect the live resolved graph at `/navigation-health` and apply Project placement updates at `/project-placement`.

--- a/docs/channel-content-authoring.md
+++ b/docs/channel-content-authoring.md
@@ -1,0 +1,183 @@
+# Channel content authoring
+
+Kind Robots navigation is defined by Markdown documents in `content/channels`.
+The navigation UI, workspace cards, tutorial flyer, tab artwork, and legacy dashboard bridge all consume the same channel and tab metadata.
+
+## Folder shape
+
+```text
+content/channels/
+├── home/
+│   ├── index.md
+│   ├── dashboard.md
+│   └── themes.md
+├── plan/
+├── build/
+├── play/
+├── lab/
+├── sanctuary/
+└── admin/
+```
+
+Each folder contains one parent channel document named `index.md` and one Markdown document per tab.
+
+## Add a channel
+
+Create `content/channels/<channel-key>/index.md`:
+
+```md
+---
+contentType: channel
+channelKey: example
+dashboardKey: legacy-dashboard
+label: Example
+title: Example
+room: Example Workshop
+subtitle: A short channel promise
+description: What belongs in this channel and why.
+icon: kind-icon:sparkles
+route: /example
+defaultTab: overview
+sort: 80
+loadingMessage: Loading Example…
+refreshLabel: Refresh Example
+dottiTip: Dotti starts this optional two-line conversation.
+amiTip: AMI gets the second line.
+---
+
+Optional longer channel copy can live in the Markdown body.
+```
+
+`channelKey` must be lowercase kebab-case. The top-level channel list is currently intentionally limited to Home, Plan, Build, Play, Lab, Sanctuary, and Admin; update the channel-content contract only when deliberately changing that information architecture.
+
+## Add a tab
+
+Create `content/channels/<channel-key>/<tab-key>.md`:
+
+```md
+---
+contentType: tab
+channelKey: example
+tabKey: overview
+dashboardKey: legacy-dashboard
+dashboardTab: legacy-tab
+label: Overview
+title: Example Overview
+subtitle: A concise tab promise
+description: What the visitor can do here.
+icon: kind-icon:sparkles
+route: /example
+sort: 10
+---
+
+Optional tutorial or explanatory copy can live here.
+```
+
+That single document can provide:
+
+- Channel submenu navigation
+- Workspace hand and sheet cards
+- Tutorial flyer sections
+- Route and active-tab resolution
+- Tab imagery and icons
+- Loading and refresh labels
+- Dotti and AMI dialogue
+- Legacy manager synchronization during migration
+
+## Parent inheritance
+
+A tab inherits missing presentation metadata from its parent channel. Common inherited fields include:
+
+- `room`
+- `subtitle`
+- `description`
+- `summary`
+- `narrative`
+- `tooltip`
+- `icon`
+- `cards`
+- `requiredRole`
+- `requiredPermission`
+- `loadingMessage`
+- `refreshLabel`
+- `dottiTip`
+- `amiTip`
+
+The content resolver performs inheritance once. Components receive complete resolved tab objects and should not recreate fallback chains.
+
+## Shared routes and shareable tab URLs
+
+Several tabs may intentionally use the same route while selecting different manager modes. Build is the clearest example.
+
+When multiple tabs in one channel share a route, the navigator adds a query parameter:
+
+```text
+/builder?tab=character
+/builder?tab=bot
+/builder?tab=art
+```
+
+The query parameter drives the content tab, remembered state, workspace sheet, browser history, and legacy dashboard synchronization. Tabs with unique routes continue using clean route-only URLs.
+
+Do not hand-author `?tab=` inside front matter. Declare the shared `route` and the navigator creates the address.
+
+## Images
+
+Explicit front matter paths may be absolute, remote, or relative to `/public/images`:
+
+```yaml
+image: navigation/build/characters.webp
+```
+
+When `image` is omitted, the resolver tries legacy dashboard artwork and then the channel convention:
+
+```text
+/images/channels/<channel-key>/channel.webp
+/images/channels/<channel-key>/<tab-key>.webp
+```
+
+## Dotti and AMI dialogue
+
+The optional simulated conversation remains supported:
+
+```yaml
+dottiTip: I built a new tab. It only took one Markdown file.
+amiTip: Please do not frame the old helper and hang it in the museum yet.
+```
+
+Camel-case `dottiTip` and `amiTip` are canonical. Legacy lowercase `dottitip` and `amitip` remain readable during migration.
+
+## Permissions
+
+Use channel-level permissions when every child shares the same gate. Override on a tab only when necessary:
+
+```yaml
+requiredRole: ADMIN
+```
+
+`requiredPermission` is available for the future capability-based permission system.
+
+## Legacy bridge
+
+`dashboardKey` and `dashboardTab` are compatibility adapters, not the public information architecture. Keep them while the destination still launches an existing dashboard manager. New navigation code should prefer `channelKey` and `tabKey`.
+
+## Validation
+
+Run:
+
+```bash
+npm run test:channel-content
+```
+
+The contract checks:
+
+- Required parent channels
+- Valid lowercase kebab-case keys
+- Unique channel/tab locations
+- Valid default tabs
+- Existing parent channels
+- Valid page placements
+- Valid canonical Project placements
+- Shared-route tab groups that use `?tab=` addressing
+
+TypeScript validation also runs through the normal project test workflow.

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -1,0 +1,48 @@
+// /middleware/navigation-access.global.ts
+import { resolveChannelLocation } from '@/stores/helpers/channelContent'
+import { useChannelContentStore } from '@/stores/channelContentStore'
+import { useUserStore } from '@/stores/userStore'
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (import.meta.server) return
+
+  const userStore = useUserStore()
+  const channelContentStore = useChannelContentStore()
+
+  await Promise.all([
+    userStore.initialize(),
+    channelContentStore.initialize(),
+  ])
+
+  const requestedTab =
+    typeof to.query.tab === 'string' ? to.query.tab.trim() : ''
+  const requested = resolveChannelLocation(channelContentStore.channels, {
+    path: to.path,
+    tabKey: requestedTab,
+  })
+
+  // Routes outside the content navigation graph are not this middleware's job.
+  if (!requested) return
+
+  const visibleChannel = channelContentStore.visibleChannels.find(
+    (channel) => channel.channelKey === requested.channel.channelKey,
+  )
+  const visibleTab = requested.tab
+    ? visibleChannel?.tabs.find(
+        (tab) => tab.tabKey === requested.tab?.tabKey,
+      )
+    : null
+
+  if (visibleChannel && (!requested.tab || visibleTab)) return
+
+  // Avoid an impossible redirect loop if Home is ever accidentally gated.
+  if (to.path === '/') return
+
+  return navigateTo({
+    path: '/',
+    query: {
+      access: 'denied',
+    },
+    replace: true,
+  })
+})

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -3,6 +3,7 @@ import { resolveChannelLocation } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
+const navigationReturnStorageKey = 'kindrobots:navigation-return-to'
 const accountPermissions = new Set([
   'authenticated',
   'member',
@@ -10,6 +11,37 @@ const accountPermissions = new Set([
   'mature',
   'admin',
 ])
+
+function safeReturnPath(value: unknown): string {
+  if (typeof value !== 'string') return ''
+
+  const path = value.trim()
+  return path.startsWith('/') && !path.startsWith('//') ? path : ''
+}
+
+function storedReturnPath(): string {
+  try {
+    return safeReturnPath(sessionStorage.getItem(navigationReturnStorageKey))
+  } catch {
+    return ''
+  }
+}
+
+function rememberReturnPath(path: string): void {
+  try {
+    sessionStorage.setItem(navigationReturnStorageKey, path)
+  } catch {}
+}
+
+function consumeReturnPath(): string {
+  const path = storedReturnPath()
+
+  try {
+    sessionStorage.removeItem(navigationReturnStorageKey)
+  } catch {}
+
+  return path
+}
 
 export default defineNuxtRouteMiddleware(async (to) => {
   if (import.meta.server) return
@@ -21,6 +53,23 @@ export default defineNuxtRouteMiddleware(async (to) => {
     userStore.initialize(),
     channelContentStore.initialize(),
   ])
+
+  const requestedLoginReturn = safeReturnPath(to.query.redirect)
+
+  if (userStore.isLoggedIn && to.path === '/login' && requestedLoginReturn) {
+    return navigateTo(requestedLoginReturn, { replace: true })
+  }
+
+  // The existing login page sends successful sessions to /dashboard. Resume a
+  // previously denied channel destination from there without coupling the login
+  // component to the navigation system.
+  if (userStore.isLoggedIn && to.path === '/dashboard') {
+    const returnPath = consumeReturnPath()
+
+    if (returnPath && returnPath !== to.fullPath) {
+      return navigateTo(returnPath, { replace: true })
+    }
+  }
 
   const requestedTab =
     typeof to.query.tab === 'string' ? to.query.tab.trim() : ''
@@ -52,6 +101,8 @@ export default defineNuxtRouteMiddleware(async (to) => {
     accountPermissions.has(requiredPermission.toLowerCase())
 
   if (!userStore.isLoggedIn && requiresAccount && to.path !== '/login') {
+    rememberReturnPath(to.fullPath)
+
     return navigateTo({
       path: '/login',
       query: {

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -1,5 +1,5 @@
 // /middleware/navigation-access.global.ts
-import { resolveChannelLocation } from '@/stores/helpers/channelContent'
+import { evaluateNavigationRouteAccess } from '@/stores/helpers/navigationRouteAccess'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -73,32 +73,21 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   const requestedTab =
     typeof to.query.tab === 'string' ? to.query.tab.trim() : ''
-  const requested = resolveChannelLocation(channelContentStore.channels, {
-    path: to.path,
-    tabKey: requestedTab,
-  })
+  const access = evaluateNavigationRouteAccess(
+    channelContentStore.channels,
+    channelContentStore.visibleChannels,
+    {
+      path: to.path,
+      tabKey: requestedTab,
+    },
+  )
 
   // Routes outside the content navigation graph are not this middleware's job.
-  if (!requested) return
+  if (!access.matched || access.allowed) return
 
-  const visibleChannel = channelContentStore.visibleChannels.find(
-    (channel) => channel.channelKey === requested.channel.channelKey,
-  )
-  const visibleTab = requested.tab
-    ? visibleChannel?.tabs.find(
-        (tab) => tab.tabKey === requested.tab?.tabKey,
-      )
-    : null
-
-  if (visibleChannel && (!requested.tab || visibleTab)) return
-
-  const requiredRole =
-    requested.tab?.requiredRole || requested.channel.requiredRole
-  const requiredPermission =
-    requested.tab?.requiredPermission || requested.channel.requiredPermission
   const requiresAccount =
-    Boolean(requiredRole && requiredRole !== 'GUEST') ||
-    accountPermissions.has(requiredPermission.toLowerCase())
+    Boolean(access.requiredRole && access.requiredRole !== 'GUEST') ||
+    accountPermissions.has(access.requiredPermission.toLowerCase())
 
   if (!userStore.isLoggedIn && requiresAccount && to.path !== '/login') {
     rememberReturnPath(to.fullPath)

--- a/middleware/navigation-access.global.ts
+++ b/middleware/navigation-access.global.ts
@@ -3,6 +3,14 @@ import { resolveChannelLocation } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useUserStore } from '@/stores/userStore'
 
+const accountPermissions = new Set([
+  'authenticated',
+  'member',
+  'family',
+  'mature',
+  'admin',
+])
+
 export default defineNuxtRouteMiddleware(async (to) => {
   if (import.meta.server) return
 
@@ -34,6 +42,24 @@ export default defineNuxtRouteMiddleware(async (to) => {
     : null
 
   if (visibleChannel && (!requested.tab || visibleTab)) return
+
+  const requiredRole =
+    requested.tab?.requiredRole || requested.channel.requiredRole
+  const requiredPermission =
+    requested.tab?.requiredPermission || requested.channel.requiredPermission
+  const requiresAccount =
+    Boolean(requiredRole && requiredRole !== 'GUEST') ||
+    accountPermissions.has(requiredPermission.toLowerCase())
+
+  if (!userStore.isLoggedIn && requiresAccount && to.path !== '/login') {
+    return navigateTo({
+      path: '/login',
+      query: {
+        redirect: to.fullPath,
+      },
+      replace: true,
+    })
+  }
 
   // Avoid an impossible redirect loop if Home is ever accidentally gated.
   if (to.path === '/') return

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "addFilePathComments": "node utils/scripts/addFilePathComment.js",
     "audit": "node ./utils/scripts/audit.mjs",
     "facet:alias": "prisma generate && tsx utils/scripts/setFacetAliases.ts",
-    "trim:dry": "node ./utils/scripts/trim.mjs --dry-run",
-    "trim": "node ./utils/scripts/trim.mjs",
+    "trim:dry": "node utils/scripts/trim.mjs --dry-run",
+    "trim": "node utils/scripts/trim.mjs",
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "vercel-build": "prisma generate && prisma migrate deploy && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
@@ -33,6 +33,7 @@
     "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts",
+    "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
+    "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "addFilePathComments": "node utils/scripts/addFilePathComment.js",
     "audit": "node ./utils/scripts/audit.mjs",
+    "audit:channel-assets": "tsx utils/scripts/auditChannelAssets.ts",
     "facet:alias": "prisma generate && tsx utils/scripts/setFacetAliases.ts",
     "trim:dry": "node utils/scripts/trim.mjs --dry-run",
     "trim": "node utils/scripts/trim.mjs",

--- a/plugins/navigation-image-fallback.client.ts
+++ b/plugins/navigation-image-fallback.client.ts
@@ -1,0 +1,35 @@
+// /plugins/navigation-image-fallback.client.ts
+const fallbackImage = '/images/botcafe.webp'
+const navigationImagePrefixes = [
+  '/images/channels/',
+  '/images/dashboard-tabs/',
+]
+
+function pathname(value: string): string {
+  try {
+    return new URL(value, window.location.origin).pathname
+  } catch {
+    return value.split(/[?#]/)[0] ?? ''
+  }
+}
+
+function isNavigationArtwork(image: HTMLImageElement): boolean {
+  const source = pathname(image.currentSrc || image.src)
+  return navigationImagePrefixes.some((prefix) => source.startsWith(prefix))
+}
+
+export default defineNuxtPlugin(() => {
+  document.addEventListener(
+    'error',
+    (event) => {
+      const image = event.target
+      if (!(image instanceof HTMLImageElement)) return
+      if (!isNavigationArtwork(image)) return
+      if (image.dataset.navigationFallbackApplied === 'true') return
+
+      image.dataset.navigationFallbackApplied = 'true'
+      image.src = fallbackImage
+    },
+    true,
+  )
+})

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -1,0 +1,111 @@
+// /stores/channelContentStore.ts
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import {
+  filterChannelsByRole,
+  resolveChannelLocation,
+  resolveChannels,
+  type ChannelContentItem,
+  type ChannelLocationInput,
+} from '@/stores/helpers/channelContent'
+import { useUserStore } from '@/stores/userStore'
+import { handleError } from '@/stores/utils'
+
+export const useChannelContentStore = defineStore('channelContentStore', () => {
+  const items = ref<ChannelContentItem[]>([])
+  const initialized = ref(false)
+  const loading = ref(false)
+  const lastError = ref<string | null>(null)
+  const initializePromise = ref<Promise<void> | null>(null)
+
+  const userStore = useUserStore()
+
+  const channels = computed(() => resolveChannels(items.value))
+  const visibleChannels = computed(() =>
+    filterChannelsByRole(channels.value, userStore.role),
+  )
+
+  async function initialize(force = false): Promise<void> {
+    if (initializePromise.value && !force) return initializePromise.value
+    if (initialized.value && !force) return
+
+    initializePromise.value = (async () => {
+      loading.value = true
+      lastError.value = null
+
+      try {
+        const content = await queryCollection('content').all()
+
+        items.value = (content as ChannelContentItem[]).filter(
+          (item) => item.contentType === 'channel' || item.contentType === 'tab',
+        )
+        initialized.value = true
+      } catch (error) {
+        handleError(error, 'loading channel content')
+        lastError.value =
+          error instanceof Error
+            ? error.message
+            : 'Failed to load channel content'
+        initialized.value = false
+      } finally {
+        loading.value = false
+        initializePromise.value = null
+      }
+    })()
+
+    return initializePromise.value
+  }
+
+  function getChannel(channelKey: string) {
+    const normalized = channelKey.trim()
+
+    return (
+      visibleChannels.value.find(
+        (channel) =>
+          channel.channelKey === normalized ||
+          channel.dashboardKey === normalized,
+      ) ?? null
+    )
+  }
+
+  function getTab(channelKey: string, tabKey: string) {
+    const channel = getChannel(channelKey)
+    if (!channel) return null
+
+    const normalized = tabKey.trim()
+
+    return (
+      channel.tabs.find(
+        (tab) =>
+          tab.tabKey === normalized || tab.dashboardTab === normalized,
+      ) ?? null
+    )
+  }
+
+  function resolveLocation(input: ChannelLocationInput) {
+    return resolveChannelLocation(visibleChannels.value, input)
+  }
+
+  function reset(): void {
+    items.value = []
+    initialized.value = false
+    loading.value = false
+    lastError.value = null
+    initializePromise.value = null
+  }
+
+  return {
+    items,
+    channels,
+    visibleChannels,
+    initialized,
+    loading,
+    lastError,
+    initializePromise,
+    initialize,
+    getChannel,
+    getTab,
+    resolveLocation,
+    reset,
+  }
+})

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -98,9 +98,11 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
       lastError.value = null
 
       try {
-        const content = await queryCollection('content').all()
+        const content = await queryCollection('channels').all()
 
-        items.value = (content as ChannelContentItem[]).filter(
+        items.value = (
+          content as unknown as ChannelContentItem[]
+        ).filter(
           (item) => item.contentType === 'channel' || item.contentType === 'tab',
         )
         normalizeActiveTabs()

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -9,6 +9,11 @@ import {
   type ChannelLocationInput,
   type ResolvedChannelLocation,
 } from '@/stores/helpers/channelContent'
+import {
+  filterChannelsByPermission,
+  navigationPermissions,
+  type NavigationAccessContext,
+} from '@/stores/helpers/navigationAccess'
 import { useUserStore } from '@/stores/userStore'
 import { handleError } from '@/stores/utils'
 
@@ -59,9 +64,29 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
   const userStore = useUserStore()
 
   const channels = computed(() => resolveChannels(items.value))
-  const visibleChannels = computed(() =>
-    filterChannelsByRole(channels.value, userStore.role),
-  )
+  const accessContext = computed<NavigationAccessContext>(() => {
+    const isAdmin = userStore.isAdmin
+
+    return {
+      role: isAdmin ? 'ADMIN' : userStore.role,
+      permissions: navigationPermissions({
+        isLoggedIn: userStore.isLoggedIn,
+        isMember: userStore.isMember,
+        isFamily: userStore.isFamily,
+        showMature: userStore.showMature,
+        isAdmin,
+      }),
+      isAdmin,
+    }
+  })
+  const visibleChannels = computed(() => {
+    const roleFiltered = filterChannelsByRole(
+      channels.value,
+      accessContext.value.role,
+    )
+
+    return filterChannelsByPermission(roleFiltered, accessContext.value)
+  })
 
   function syncActiveTabs(): void {
     if (!isClient) return
@@ -264,6 +289,7 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     items,
     channels,
     visibleChannels,
+    accessContext,
     activeTabs,
     activeTabsHydrated,
     initialized,

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -54,7 +54,10 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     if (!isClient) return
 
     try {
-      localStorage.setItem(channelTabsStorageKey, JSON.stringify(activeTabs.value))
+      localStorage.setItem(
+        channelTabsStorageKey,
+        JSON.stringify(activeTabs.value),
+      )
     } catch {}
   }
 
@@ -151,7 +154,7 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     const stored = activeTabs.value[channel.channelKey]
 
     return channel.tabs.some((tab) => tab.tabKey === stored)
-      ? stored
+      ? (stored ?? channel.defaultTab)
       : channel.defaultTab
   }
 

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -128,7 +128,8 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
       visibleChannels.value.find(
         (channel) =>
           channel.channelKey === normalized ||
-          channel.dashboardKey === normalized,
+          channel.dashboardKey === normalized ||
+          channel.tabs.some((tab) => tab.dashboardKey === normalized),
       ) ?? null
     )
   }

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -11,8 +11,33 @@ import {
 import { useUserStore } from '@/stores/userStore'
 import { handleError } from '@/stores/utils'
 
+const channelTabsStorageKey = 'channelTabs'
+const isClient = typeof window !== 'undefined'
+
+function readStoredTabs(): Record<string, string> {
+  if (!isClient) return {}
+
+  try {
+    const raw = localStorage.getItem(channelTabsStorageKey)
+    if (!raw) return {}
+
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([key, value]) => key.trim() && typeof value === 'string',
+      ),
+    ) as Record<string, string>
+  } catch {
+    return {}
+  }
+}
+
 export const useChannelContentStore = defineStore('channelContentStore', () => {
   const items = ref<ChannelContentItem[]>([])
+  const activeTabs = ref<Record<string, string>>({})
+  const activeTabsHydrated = ref(false)
   const initialized = ref(false)
   const loading = ref(false)
   const lastError = ref<string | null>(null)
@@ -25,9 +50,45 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     filterChannelsByRole(channels.value, userStore.role),
   )
 
+  function syncActiveTabs(): void {
+    if (!isClient) return
+
+    try {
+      localStorage.setItem(channelTabsStorageKey, JSON.stringify(activeTabs.value))
+    } catch {}
+  }
+
+  function hydrateActiveTabs(force = false): void {
+    if (activeTabsHydrated.value && !force) return
+
+    activeTabs.value = readStoredTabs()
+    activeTabsHydrated.value = true
+  }
+
+  function normalizeActiveTabs(): void {
+    const normalized: Record<string, string> = {}
+
+    for (const channel of channels.value) {
+      const stored = activeTabs.value[channel.channelKey]
+      const active = channel.tabs.some((tab) => tab.tabKey === stored)
+        ? stored
+        : channel.defaultTab
+
+      if (active) normalized[channel.channelKey] = active
+    }
+
+    activeTabs.value = normalized
+    syncActiveTabs()
+  }
+
   async function initialize(force = false): Promise<void> {
+    hydrateActiveTabs(force)
+
     if (initializePromise.value && !force) return initializePromise.value
-    if (initialized.value && !force) return
+    if (initialized.value && !force) {
+      normalizeActiveTabs()
+      return
+    }
 
     initializePromise.value = (async () => {
       loading.value = true
@@ -39,6 +100,7 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
         items.value = (content as ChannelContentItem[]).filter(
           (item) => item.contentType === 'channel' || item.contentType === 'tab',
         )
+        normalizeActiveTabs()
         initialized.value = true
       } catch (error) {
         handleError(error, 'loading channel content')
@@ -82,12 +144,43 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     )
   }
 
+  function getActiveTab(channelKey: string): string {
+    const channel = getChannel(channelKey)
+    if (!channel) return ''
+
+    const stored = activeTabs.value[channel.channelKey]
+
+    return channel.tabs.some((tab) => tab.tabKey === stored)
+      ? stored
+      : channel.defaultTab
+  }
+
+  function setActiveTab(channelKey: string, tabKey: string): string {
+    const channel = getChannel(channelKey)
+    if (!channel) return ''
+
+    const tab = getTab(channel.channelKey, tabKey)
+    const resolved = tab?.tabKey || channel.defaultTab
+
+    if (!resolved) return ''
+
+    activeTabs.value = {
+      ...activeTabs.value,
+      [channel.channelKey]: resolved,
+    }
+    syncActiveTabs()
+
+    return resolved
+  }
+
   function resolveLocation(input: ChannelLocationInput) {
     return resolveChannelLocation(visibleChannels.value, input)
   }
 
   function reset(): void {
     items.value = []
+    activeTabs.value = {}
+    activeTabsHydrated.value = false
     initialized.value = false
     loading.value = false
     lastError.value = null
@@ -98,13 +191,18 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     items,
     channels,
     visibleChannels,
+    activeTabs,
+    activeTabsHydrated,
     initialized,
     loading,
     lastError,
     initializePromise,
     initialize,
+    hydrateActiveTabs,
     getChannel,
     getTab,
+    getActiveTab,
+    setActiveTab,
     resolveLocation,
     reset,
   }

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -123,14 +123,31 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
 
   function getChannel(channelKey: string) {
     const normalized = channelKey.trim()
+    if (!normalized) return null
+
+    const direct = visibleChannels.value.find(
+      (channel) =>
+        channel.channelKey === normalized ||
+        channel.dashboardKey === normalized,
+    )
+    if (direct) return direct
+
+    const tabMatches = visibleChannels.value.filter((channel) =>
+      channel.tabs.some((tab) => tab.dashboardKey === normalized),
+    )
+
+    if (tabMatches.length <= 1) return tabMatches[0] ?? null
 
     return (
-      visibleChannels.value.find(
-        (channel) =>
-          channel.channelKey === normalized ||
-          channel.dashboardKey === normalized ||
-          channel.tabs.some((tab) => tab.dashboardKey === normalized),
-      ) ?? null
+      tabMatches.find((channel) =>
+        channel.tabs.some(
+          (tab) =>
+            tab.dashboardKey === normalized &&
+            tab.route === `/${normalized}`,
+        ),
+      ) ??
+      tabMatches[0] ??
+      null
     )
   }
 

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -7,6 +7,7 @@ import {
   resolveChannels,
   type ChannelContentItem,
   type ChannelLocationInput,
+  type ResolvedChannelLocation,
 } from '@/stores/helpers/channelContent'
 import { useUserStore } from '@/stores/userStore'
 import { handleError } from '@/stores/utils'
@@ -32,6 +33,18 @@ function readStoredTabs(): Record<string, string> {
   } catch {
     return {}
   }
+}
+
+function routePath(value?: string | null): string {
+  const raw = String(value ?? '')
+    .split(/[?#]/)[0]
+    ?.trim()
+
+  if (!raw) return '/'
+  if (raw === '/') return raw
+
+  const prefixed = raw.startsWith('/') ? raw : `/${raw}`
+  return prefixed.replace(/\/+$/, '')
 }
 
 export const useChannelContentStore = defineStore('channelContentStore', () => {
@@ -186,6 +199,7 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     const resolved = tab?.tabKey || channel.defaultTab
 
     if (!resolved) return ''
+    if (activeTabs.value[channel.channelKey] === resolved) return resolved
 
     activeTabs.value = {
       ...activeTabs.value,
@@ -196,8 +210,44 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     return resolved
   }
 
-  function resolveLocation(input: ChannelLocationInput) {
+  function resolveLocation(
+    input: ChannelLocationInput,
+  ): ResolvedChannelLocation | null {
     return resolveChannelLocation(visibleChannels.value, input)
+  }
+
+  function resolveActiveLocation(
+    input: ChannelLocationInput,
+  ): ResolvedChannelLocation | null {
+    const location = resolveLocation(input)
+    if (!location) return null
+
+    const path = routePath(input.path)
+    const routeTabs = location.channel.tabs.filter((tab) => tab.route === path)
+
+    if (routeTabs.length <= 1) return location
+
+    const activeTabKey = getActiveTab(location.channel.channelKey)
+    const activeTab = routeTabs.find((tab) => tab.tabKey === activeTabKey)
+
+    return activeTab
+      ? {
+          channel: location.channel,
+          tab: activeTab,
+        }
+      : location
+  }
+
+  function activateLocation(
+    input: ChannelLocationInput,
+  ): ResolvedChannelLocation | null {
+    const location = resolveActiveLocation(input)
+
+    if (location?.tab) {
+      setActiveTab(location.channel.channelKey, location.tab.tabKey)
+    }
+
+    return location
   }
 
   function reset(): void {
@@ -227,6 +277,8 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     getActiveTab,
     setActiveTab,
     resolveLocation,
+    resolveActiveLocation,
+    activateLocation,
     reset,
   }
 })

--- a/stores/helpers/channelCards.ts
+++ b/stores/helpers/channelCards.ts
@@ -1,0 +1,96 @@
+// /stores/helpers/channelCards.ts
+import type { BuilderCard } from '@/stores/helpers/builderCards'
+import type {
+  NavigationCard,
+  ResolvedChannel,
+  ResolvedTab,
+} from '@/stores/helpers/channelContent'
+
+function tabPayload(tab: ResolvedTab): Record<string, unknown> {
+  return {
+    path: tab.route,
+    channelKey: tab.channelKey,
+    tabKey: tab.tabKey,
+    dashboardKey: tab.dashboardKey,
+    tab: tab.dashboardTab,
+    component: tab.component,
+    modelType: tab.modelType,
+  }
+}
+
+export function channelTabToCard(tab: ResolvedTab): BuilderCard {
+  const narrative =
+    tab.narrative || tab.description || tab.summary || tab.subtitle || tab.title
+  const tagline = tab.subtitle || tab.summary || tab.description || tab.label
+  const payload = tabPayload(tab)
+
+  return {
+    key: tab.tabKey,
+    label: tab.label,
+    title: tab.title,
+    icon: tab.icon,
+    deckImage: tab.image,
+    heroImage: tab.tutorial?.image || tab.image,
+    tagline,
+    narrative,
+    required: false,
+    restoresFields: [],
+    unlockCondition: 'always',
+    payload,
+    steps: [
+      {
+        key: tab.tabKey,
+        title: tab.title,
+        narrative,
+        inputType: 'custom',
+        heroImage: tab.tutorial?.image || tab.image,
+        payload,
+      },
+    ],
+  }
+}
+
+export function channelTabsToCards(channel: ResolvedChannel): BuilderCard[] {
+  return channel.tabs.map(channelTabToCard)
+}
+
+export function navigationCardToBuilderCard(
+  card: NavigationCard,
+): BuilderCard {
+  const narrative = card.description || card.label
+  const payload: Record<string, unknown> = {
+    path: card.route || '',
+    action: card.action || '',
+  }
+
+  return {
+    key: card.key,
+    label: card.label,
+    title: card.label,
+    icon: card.icon || 'kind-icon:cards',
+    deckImage: card.image,
+    heroImage: card.image,
+    tagline: narrative,
+    narrative,
+    required: false,
+    restoresFields: [],
+    unlockCondition: 'always',
+    payload,
+    steps: [
+      {
+        key: card.key,
+        title: card.label,
+        narrative,
+        inputType: 'custom',
+        heroImage: card.image,
+        payload,
+      },
+    ],
+  }
+}
+
+export function navigationCardsToBuilderCards(
+  cards: NavigationCard[],
+): BuilderCard[] {
+  return cards.map(navigationCardToBuilderCard)
+}

--- a/stores/helpers/channelContent.ts
+++ b/stores/helpers/channelContent.ts
@@ -11,6 +11,18 @@ export type NavigationCard = {
   action?: string
 }
 
+export type TutorialContent = {
+  enabled?: boolean
+  title?: string
+  overview?: string
+  tagline?: string
+  hero?: string
+  earnings?: string
+  body?: string
+  image?: string
+  underConstruction?: boolean
+}
+
 export type ChannelContentItem = ContentCollectionItem & {
   contentType?: 'page' | 'channel' | 'tab'
   channelKey?: string
@@ -33,16 +45,37 @@ export type ChannelContentItem = ContentCollectionItem & {
   defaultTab?: string
   sort?: string | number
   cards?: string | NavigationCard[]
+  tutorial?: TutorialContent
   requiredBeforeNext?: string[]
   requiredRole?: string
   requiredPermission?: string
   visible?: boolean
+  status?: string
   loadingMessage?: string
   refreshLabel?: string
   dottiTip?: string
   amiTip?: string
   dottitip?: string
   amitip?: string
+}
+
+export type ResolvedTutorialSection = {
+  key: string
+  title: string
+  body: string
+  image: string
+  underConstruction?: boolean
+}
+
+export type ResolvedTutorialChannel = {
+  key: string
+  title: string
+  hero: string
+  overview: string
+  tagline: string
+  earnings: string
+  underConstruction?: boolean
+  sections: ResolvedTutorialSection[]
 }
 
 export type ResolvedTab = {
@@ -66,6 +99,7 @@ export type ResolvedTab = {
   modelType: string
   sort: number
   cards: string | NavigationCard[] | null
+  tutorial: ResolvedTutorialSection | null
   requiredBeforeNext: string[]
   requiredRole: string
   requiredPermission: string
@@ -98,6 +132,7 @@ export type ResolvedChannel = {
   refreshLabel: string
   dottiTip: string
   amiTip: string
+  tutorial: ResolvedTutorialChannel | null
   tabs: ResolvedTab[]
 }
 
@@ -131,6 +166,8 @@ function imageValue(
   image: unknown,
   channelKey: string,
   tabKey?: string,
+  dashboardKey?: string,
+  dashboardTab?: string,
 ): string {
   const explicit = stringValue(image)
   if (explicit) {
@@ -138,9 +175,20 @@ function imageValue(
     return `/images/${explicit}`
   }
 
+  if (tabKey && dashboardKey && dashboardTab) {
+    return `/images/dashboard-tabs/${dashboardKey}/${dashboardTab}.webp`
+  }
+
   return tabKey
     ? `/images/channels/${channelKey}/${tabKey}.webp`
     : `/images/channels/${channelKey}/channel.webp`
+}
+
+function tutorialImageValue(image: unknown, fallback: string): string {
+  const explicit = stringValue(image)
+  if (!explicit) return fallback
+  if (explicit.startsWith('/') || explicit.startsWith('http')) return explicit
+  return `/images/${explicit}`
 }
 
 function tipValue(camelCase: unknown, legacyLowercase: unknown): string {
@@ -185,7 +233,9 @@ function findTab(
     const matched = channel.tabs.find(
       (tab) =>
         tab.dashboardTab === dashboardTab &&
-        (!dashboardKey || !tab.dashboardKey || tab.dashboardKey === dashboardKey),
+        (!dashboardKey ||
+          !tab.dashboardKey ||
+          tab.dashboardKey === dashboardKey),
     )
     if (matched) return matched
   }
@@ -242,6 +292,7 @@ export function resolveChannels(
         stringValue(channel.refreshLabel) || `Refresh ${channelLabel}`
       const channelDottiTip = tipValue(channel.dottiTip, channel.dottitip)
       const channelAmiTip = tipValue(channel.amiTip, channel.amitip)
+      const channelImage = imageValue(channel.image, channelKey)
 
       const tabs = tabItems
         .filter((tab) => stringValue(tab.channelKey) === channelKey)
@@ -251,29 +302,61 @@ export function resolveChannels(
 
           const label =
             stringValue(tab.label) || stringValue(tab.title) || tabKey
+          const dashboardKey =
+            stringValue(tab.dashboardKey) || channelDashboardKey
+          const dashboardTab = stringValue(tab.dashboardTab) || tabKey
+          const title = stringValue(tab.title) || label
+          const description =
+            stringValue(tab.description) || channelDescription
+          const summary = stringValue(tab.summary) || channelSummary
+          const narrative = stringValue(tab.narrative) || channelNarrative
+          const image = imageValue(
+            tab.image,
+            channelKey,
+            tabKey,
+            dashboardKey,
+            dashboardTab,
+          )
+          const tutorial = tab.tutorial?.enabled === false
+            ? null
+            : {
+                key: tabKey,
+                title: stringValue(tab.tutorial?.title) || title,
+                body:
+                  stringValue(tab.tutorial?.body) ||
+                  description ||
+                  summary ||
+                  narrative ||
+                  title,
+                image: tutorialImageValue(tab.tutorial?.image, image),
+                underConstruction:
+                  tab.tutorial?.underConstruction === true ||
+                  stringValue(tab.status) === 'under-construction' ||
+                  undefined,
+              }
 
           return {
             key: tabKey,
             channelKey,
             tabKey,
-            dashboardKey:
-              stringValue(tab.dashboardKey) || channelDashboardKey,
-            dashboardTab: stringValue(tab.dashboardTab) || tabKey,
+            dashboardKey,
+            dashboardTab,
             label,
-            title: stringValue(tab.title) || label,
+            title,
             room: stringValue(tab.room) || channelRoom,
             subtitle: stringValue(tab.subtitle) || channelSubtitle,
-            description: stringValue(tab.description) || channelDescription,
-            summary: stringValue(tab.summary) || channelSummary,
-            narrative: stringValue(tab.narrative) || channelNarrative,
+            description,
+            summary,
+            narrative,
             tooltip: stringValue(tab.tooltip) || channelTooltip,
             icon: stringValue(tab.icon) || channelIcon,
-            image: imageValue(tab.image, channelKey, tabKey),
+            image,
             route: routeValue(tab.route) || channelRoute,
             component: stringValue(tab.component),
             modelType: stringValue(tab.modelType),
             sort: sortValue(tab.sort),
             cards: tab.cards ?? channel.cards ?? null,
+            tutorial,
             requiredBeforeNext: Array.isArray(tab.requiredBeforeNext)
               ? tab.requiredBeforeNext
               : [],
@@ -296,6 +379,36 @@ export function resolveChannels(
       const defaultTab = tabs.some((tab) => tab.tabKey === requestedDefault)
         ? requestedDefault
         : tabs[0]?.tabKey || ''
+      const tutorialSections = tabs
+        .map((tab) => tab.tutorial)
+        .filter(
+          (tutorial): tutorial is ResolvedTutorialSection => tutorial !== null,
+        )
+      const tutorial = channel.tutorial?.enabled === false
+        ? null
+        : {
+            key: channelKey,
+            title:
+              stringValue(channel.tutorial?.title) || channelTitle,
+            hero: tutorialImageValue(
+              channel.tutorial?.hero,
+              tutorialSections[0]?.image || channelImage,
+            ),
+            overview:
+              stringValue(channel.tutorial?.overview) ||
+              channelDescription ||
+              channelSummary ||
+              channelNarrative ||
+              channelTitle,
+            tagline:
+              stringValue(channel.tutorial?.tagline) || channelSubtitle,
+            earnings: stringValue(channel.tutorial?.earnings),
+            underConstruction:
+              channel.tutorial?.underConstruction === true ||
+              stringValue(channel.status) === 'under-construction' ||
+              undefined,
+            sections: tutorialSections,
+          }
 
       return {
         key: channelKey,
@@ -310,7 +423,7 @@ export function resolveChannels(
         narrative: channelNarrative,
         tooltip: channelTooltip,
         icon: channelIcon,
-        image: imageValue(channel.image, channelKey),
+        image: channelImage,
         route: channelRoute,
         defaultTab,
         sort: sortValue(channel.sort),
@@ -320,6 +433,7 @@ export function resolveChannels(
         refreshLabel: channelRefreshLabel,
         dottiTip: channelDottiTip,
         amiTip: channelAmiTip,
+        tutorial,
         tabs,
       }
     })
@@ -333,10 +447,27 @@ export function filterChannelsByRole(
 ): ResolvedChannel[] {
   return channels
     .filter((channel) => matchesRole(channel.requiredRole, role))
-    .map((channel) => ({
-      ...channel,
-      tabs: channel.tabs.filter((tab) => matchesRole(tab.requiredRole, role)),
-    }))
+    .map((channel) => {
+      const tabs = channel.tabs.filter((tab) =>
+        matchesRole(tab.requiredRole, role),
+      )
+      const tutorial = channel.tutorial
+        ? {
+            ...channel.tutorial,
+            sections: tabs
+              .map((tab) => tab.tutorial)
+              .filter(
+                (item): item is ResolvedTutorialSection => item !== null,
+              ),
+          }
+        : null
+
+      return {
+        ...channel,
+        tabs,
+        tutorial,
+      }
+    })
 }
 
 export function resolveChannelLocation(

--- a/stores/helpers/channelContent.ts
+++ b/stores/helpers/channelContent.ts
@@ -1,5 +1,4 @@
 // /stores/helpers/channelContent.ts
-import type { ContentCollectionItem } from '@nuxt/content'
 
 export type NavigationCard = {
   key: string
@@ -23,7 +22,7 @@ export type TutorialContent = {
   underConstruction?: boolean
 }
 
-export type ChannelContentItem = ContentCollectionItem & {
+export type ChannelContentItem = {
   contentType?: 'page' | 'channel' | 'tab'
   channelKey?: string
   tabKey?: string
@@ -57,6 +56,9 @@ export type ChannelContentItem = ContentCollectionItem & {
   amiTip?: string
   dottitip?: string
   amitip?: string
+  path?: string
+  stem?: string
+  id?: string
 }
 
 export type ResolvedTutorialSection = {
@@ -149,30 +151,40 @@ export type ResolvedChannelLocation = {
   tab: ResolvedTab | null
 }
 
-function stringValue(value: unknown): string {
+function text(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function sortValue(value: unknown): number {
+function order(value: unknown): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value === 'string') {
-    const parsed = Number(value)
-    if (Number.isFinite(parsed)) return parsed
-  }
-  return 0
+  const parsed = Number(text(value))
+  return Number.isFinite(parsed) ? parsed : 0
 }
 
-function imageValue(
-  image: unknown,
+function normalizedRoute(value: unknown): string {
+  const route = text(value)
+  if (!route) return ''
+  if (route === '/') return route
+  const prefixed = route.startsWith('/') ? route : `/${route}`
+  return prefixed.replace(/\/+$/, '')
+}
+
+function normalizedPath(value: unknown): string {
+  return normalizedRoute(text(value).split(/[?#]/)[0]) || '/'
+}
+
+function imagePath(
+  value: unknown,
   channelKey: string,
   tabKey?: string,
   dashboardKey?: string,
   dashboardTab?: string,
 ): string {
-  const explicit = stringValue(image)
+  const explicit = text(value)
   if (explicit) {
-    if (explicit.startsWith('/') || explicit.startsWith('http')) return explicit
-    return `/images/${explicit}`
+    return explicit.startsWith('/') || explicit.startsWith('http')
+      ? explicit
+      : `/images/${explicit}`
   }
 
   if (tabKey && dashboardKey && dashboardTab) {
@@ -184,70 +196,55 @@ function imageValue(
     : `/images/channels/${channelKey}/channel.webp`
 }
 
-function tutorialImageValue(image: unknown, fallback: string): string {
-  const explicit = stringValue(image)
+function tutorialImage(value: unknown, fallback: string): string {
+  const explicit = text(value)
   if (!explicit) return fallback
-  if (explicit.startsWith('/') || explicit.startsWith('http')) return explicit
-  return `/images/${explicit}`
+  return explicit.startsWith('/') || explicit.startsWith('http')
+    ? explicit
+    : `/images/${explicit}`
 }
 
-function tipValue(camelCase: unknown, legacyLowercase: unknown): string {
-  return stringValue(camelCase) || stringValue(legacyLowercase)
+function dialogue(camelCase: unknown, legacy: unknown): string {
+  return text(camelCase) || text(legacy)
 }
 
-function routeValue(value: unknown): string {
-  const route = stringValue(value)
-  if (!route) return ''
-  if (route === '/') return route
-  return route.startsWith('/') ? route.replace(/\/+$/, '') : `/${route}`
+function roleAllows(requiredRole: string, role: string): boolean {
+  return !requiredRole || role === 'ADMIN' || requiredRole === role
 }
 
-function pathValue(value: unknown): string {
-  const path = routeValue(stringValue(value).split(/[?#]/)[0])
-  return path || '/'
-}
-
-function matchesRole(requiredRole: string, role: string): boolean {
-  if (!requiredRole) return true
-  if (role === 'ADMIN') return true
-  return requiredRole === role
-}
-
-function findTab(
+function resolveTab(
   channel: ResolvedChannel,
   input: ChannelLocationInput,
 ): ResolvedTab | null {
-  const tabKey = stringValue(input.tabKey)
-  const dashboardKey = stringValue(input.dashboardKey)
-  const dashboardTab = stringValue(input.dashboardTab)
-  const path = pathValue(input.path)
+  const tabKey = text(input.tabKey)
+  const dashboardKey = text(input.dashboardKey)
+  const dashboardTab = text(input.dashboardTab)
+  const path = normalizedPath(input.path)
 
   if (tabKey) {
-    const matched = channel.tabs.find(
+    const direct = channel.tabs.find(
       (tab) => tab.tabKey === tabKey || tab.dashboardTab === tabKey,
     )
-    if (matched) return matched
+    if (direct) return direct
   }
 
   if (dashboardTab) {
-    const matched = channel.tabs.find(
+    const legacy = channel.tabs.find(
       (tab) =>
         tab.dashboardTab === dashboardTab &&
-        (!dashboardKey ||
-          !tab.dashboardKey ||
-          tab.dashboardKey === dashboardKey),
+        (!dashboardKey || !tab.dashboardKey || tab.dashboardKey === dashboardKey),
     )
-    if (matched) return matched
+    if (legacy) return legacy
   }
 
   const routeMatches = channel.tabs.filter((tab) => tab.route === path)
   if (routeMatches.length === 1) return routeMatches[0] ?? null
 
   if (routeMatches.length > 1 && dashboardKey) {
-    const matched = routeMatches.find(
+    const legacy = routeMatches.find(
       (tab) => !tab.dashboardKey || tab.dashboardKey === dashboardKey,
     )
-    if (matched) return matched
+    if (legacy) return legacy
   }
 
   return (
@@ -255,6 +252,81 @@ function findTab(
     channel.tabs[0] ??
     null
   )
+}
+
+function resolveTabItem(
+  item: ChannelContentItem,
+  channel: Omit<ResolvedChannel, 'defaultTab' | 'tutorial' | 'tabs'>,
+): ResolvedTab | null {
+  const tabKey = text(item.tabKey)
+  if (!tabKey) return null
+
+  const label = text(item.label) || text(item.title) || tabKey
+  const title = text(item.title) || label
+  const description = text(item.description) || channel.description
+  const summary = text(item.summary) || channel.summary
+  const narrative = text(item.narrative) || channel.narrative
+  const dashboardKey = text(item.dashboardKey) || channel.dashboardKey
+  const dashboardTab = text(item.dashboardTab) || tabKey
+  const image = imagePath(
+    item.image,
+    channel.channelKey,
+    tabKey,
+    dashboardKey,
+    dashboardTab,
+  )
+  const tutorial =
+    item.tutorial?.enabled === false
+      ? null
+      : {
+          key: tabKey,
+          title: text(item.tutorial?.title) || title,
+          body:
+            text(item.tutorial?.body) ||
+            description ||
+            summary ||
+            narrative ||
+            title,
+          image: tutorialImage(item.tutorial?.image, image),
+          underConstruction:
+            item.tutorial?.underConstruction === true ||
+            text(item.status) === 'under-construction' ||
+            undefined,
+        }
+
+  return {
+    key: tabKey,
+    channelKey: channel.channelKey,
+    tabKey,
+    dashboardKey,
+    dashboardTab,
+    label,
+    title,
+    room: text(item.room) || channel.room,
+    subtitle: text(item.subtitle) || channel.subtitle,
+    description,
+    summary,
+    narrative,
+    tooltip: text(item.tooltip) || channel.tooltip,
+    icon: text(item.icon) || channel.icon,
+    image,
+    route: normalizedRoute(item.route) || channel.route,
+    component: text(item.component),
+    modelType: text(item.modelType),
+    sort: order(item.sort),
+    cards: item.cards ?? null,
+    tutorial,
+    requiredBeforeNext: Array.isArray(item.requiredBeforeNext)
+      ? item.requiredBeforeNext
+      : [],
+    requiredRole: text(item.requiredRole) || channel.requiredRole,
+    requiredPermission:
+      text(item.requiredPermission) || channel.requiredPermission,
+    loadingMessage: text(item.loadingMessage) || channel.loadingMessage,
+    refreshLabel: text(item.refreshLabel) || channel.refreshLabel,
+    dottiTip: dialogue(item.dottiTip, item.dottitip) || channel.dottiTip,
+    amiTip: dialogue(item.amiTip, item.amitip) || channel.amiTip,
+  }
 }
 
 export function resolveChannels(
@@ -268,171 +340,78 @@ export function resolveChannels(
   )
 
   return channelItems
-    .map((channel): ResolvedChannel | null => {
-      const channelKey = stringValue(channel.channelKey)
+    .map((item): ResolvedChannel | null => {
+      const channelKey = text(item.channelKey)
       if (!channelKey) return null
 
-      const channelLabel =
-        stringValue(channel.label) || stringValue(channel.title) || channelKey
-      const channelTitle = stringValue(channel.title) || channelLabel
-      const channelRoom = stringValue(channel.room) || channelTitle
-      const channelSubtitle = stringValue(channel.subtitle)
-      const channelDescription = stringValue(channel.description)
-      const channelSummary = stringValue(channel.summary)
-      const channelNarrative = stringValue(channel.narrative)
-      const channelTooltip = stringValue(channel.tooltip)
-      const channelIcon = stringValue(channel.icon) || 'kind-icon:folder'
-      const channelRoute = routeValue(channel.route) || `/${channelKey}`
-      const channelDashboardKey = stringValue(channel.dashboardKey)
-      const channelRole = stringValue(channel.requiredRole)
-      const channelPermission = stringValue(channel.requiredPermission)
-      const channelLoadingMessage =
-        stringValue(channel.loadingMessage) || `Loading ${channelLabel}…`
-      const channelRefreshLabel =
-        stringValue(channel.refreshLabel) || `Refresh ${channelLabel}`
-      const channelDottiTip = tipValue(channel.dottiTip, channel.dottitip)
-      const channelAmiTip = tipValue(channel.amiTip, channel.amitip)
-      const channelImage = imageValue(channel.image, channelKey)
+      const label = text(item.label) || text(item.title) || channelKey
+      const base = {
+        key: channelKey,
+        channelKey,
+        dashboardKey: text(item.dashboardKey),
+        label,
+        title: text(item.title) || label,
+        room: text(item.room) || text(item.title) || label,
+        subtitle: text(item.subtitle),
+        description: text(item.description),
+        summary: text(item.summary),
+        narrative: text(item.narrative),
+        tooltip: text(item.tooltip),
+        icon: text(item.icon) || 'kind-icon:folder',
+        image: imagePath(item.image, channelKey),
+        route: normalizedRoute(item.route) || `/${channelKey}`,
+        sort: order(item.sort),
+        requiredRole: text(item.requiredRole),
+        requiredPermission: text(item.requiredPermission),
+        loadingMessage: text(item.loadingMessage) || `Loading ${label}…`,
+        refreshLabel: text(item.refreshLabel) || `Refresh ${label}`,
+        dottiTip: dialogue(item.dottiTip, item.dottitip),
+        amiTip: dialogue(item.amiTip, item.amitip),
+      }
 
       const tabs = tabItems
-        .filter((tab) => stringValue(tab.channelKey) === channelKey)
-        .map((tab): ResolvedTab | null => {
-          const tabKey = stringValue(tab.tabKey)
-          if (!tabKey) return null
-
-          const label =
-            stringValue(tab.label) || stringValue(tab.title) || tabKey
-          const dashboardKey =
-            stringValue(tab.dashboardKey) || channelDashboardKey
-          const dashboardTab = stringValue(tab.dashboardTab) || tabKey
-          const title = stringValue(tab.title) || label
-          const description =
-            stringValue(tab.description) || channelDescription
-          const summary = stringValue(tab.summary) || channelSummary
-          const narrative = stringValue(tab.narrative) || channelNarrative
-          const image = imageValue(
-            tab.image,
-            channelKey,
-            tabKey,
-            dashboardKey,
-            dashboardTab,
-          )
-          const tutorial = tab.tutorial?.enabled === false
-            ? null
-            : {
-                key: tabKey,
-                title: stringValue(tab.tutorial?.title) || title,
-                body:
-                  stringValue(tab.tutorial?.body) ||
-                  description ||
-                  summary ||
-                  narrative ||
-                  title,
-                image: tutorialImageValue(tab.tutorial?.image, image),
-                underConstruction:
-                  tab.tutorial?.underConstruction === true ||
-                  stringValue(tab.status) === 'under-construction' ||
-                  undefined,
-              }
-
-          return {
-            key: tabKey,
-            channelKey,
-            tabKey,
-            dashboardKey,
-            dashboardTab,
-            label,
-            title,
-            room: stringValue(tab.room) || channelRoom,
-            subtitle: stringValue(tab.subtitle) || channelSubtitle,
-            description,
-            summary,
-            narrative,
-            tooltip: stringValue(tab.tooltip) || channelTooltip,
-            icon: stringValue(tab.icon) || channelIcon,
-            image,
-            route: routeValue(tab.route) || channelRoute,
-            component: stringValue(tab.component),
-            modelType: stringValue(tab.modelType),
-            sort: sortValue(tab.sort),
-            cards: tab.cards ?? channel.cards ?? null,
-            tutorial,
-            requiredBeforeNext: Array.isArray(tab.requiredBeforeNext)
-              ? tab.requiredBeforeNext
-              : [],
-            requiredRole: stringValue(tab.requiredRole) || channelRole,
-            requiredPermission:
-              stringValue(tab.requiredPermission) || channelPermission,
-            loadingMessage:
-              stringValue(tab.loadingMessage) || channelLoadingMessage,
-            refreshLabel:
-              stringValue(tab.refreshLabel) || channelRefreshLabel,
-            dottiTip:
-              tipValue(tab.dottiTip, tab.dottitip) || channelDottiTip,
-            amiTip: tipValue(tab.amiTip, tab.amitip) || channelAmiTip,
-          }
-        })
+        .filter((tab) => text(tab.channelKey) === channelKey)
+        .map((tab) => resolveTabItem(tab, base))
         .filter((tab): tab is ResolvedTab => tab !== null)
         .sort((a, b) => a.sort - b.sort || a.label.localeCompare(b.label))
 
-      const requestedDefault = stringValue(channel.defaultTab)
+      const requestedDefault = text(item.defaultTab)
       const defaultTab = tabs.some((tab) => tab.tabKey === requestedDefault)
         ? requestedDefault
         : tabs[0]?.tabKey || ''
       const tutorialSections = tabs
         .map((tab) => tab.tutorial)
         .filter(
-          (tutorial): tutorial is ResolvedTutorialSection => tutorial !== null,
+          (section): section is ResolvedTutorialSection => section !== null,
         )
-      const tutorial = channel.tutorial?.enabled === false
-        ? null
-        : {
-            key: channelKey,
-            title:
-              stringValue(channel.tutorial?.title) || channelTitle,
-            hero: tutorialImageValue(
-              channel.tutorial?.hero,
-              tutorialSections[0]?.image || channelImage,
-            ),
-            overview:
-              stringValue(channel.tutorial?.overview) ||
-              channelDescription ||
-              channelSummary ||
-              channelNarrative ||
-              channelTitle,
-            tagline:
-              stringValue(channel.tutorial?.tagline) || channelSubtitle,
-            earnings: stringValue(channel.tutorial?.earnings),
-            underConstruction:
-              channel.tutorial?.underConstruction === true ||
-              stringValue(channel.status) === 'under-construction' ||
-              undefined,
-            sections: tutorialSections,
-          }
+      const tutorial =
+        item.tutorial?.enabled === false
+          ? null
+          : {
+              key: channelKey,
+              title: text(item.tutorial?.title) || base.title,
+              hero: tutorialImage(
+                item.tutorial?.hero,
+                tutorialSections[0]?.image || base.image,
+              ),
+              overview:
+                text(item.tutorial?.overview) ||
+                base.description ||
+                base.summary ||
+                base.narrative ||
+                base.title,
+              tagline: text(item.tutorial?.tagline) || base.subtitle,
+              earnings: text(item.tutorial?.earnings),
+              underConstruction:
+                item.tutorial?.underConstruction === true ||
+                text(item.status) === 'under-construction' ||
+                undefined,
+              sections: tutorialSections,
+            }
 
       return {
-        key: channelKey,
-        channelKey,
-        dashboardKey: channelDashboardKey,
-        label: channelLabel,
-        title: channelTitle,
-        room: channelRoom,
-        subtitle: channelSubtitle,
-        description: channelDescription,
-        summary: channelSummary,
-        narrative: channelNarrative,
-        tooltip: channelTooltip,
-        icon: channelIcon,
-        image: channelImage,
-        route: channelRoute,
+        ...base,
         defaultTab,
-        sort: sortValue(channel.sort),
-        requiredRole: channelRole,
-        requiredPermission: channelPermission,
-        loadingMessage: channelLoadingMessage,
-        refreshLabel: channelRefreshLabel,
-        dottiTip: channelDottiTip,
-        amiTip: channelAmiTip,
         tutorial,
         tabs,
       }
@@ -446,26 +425,26 @@ export function filterChannelsByRole(
   role: string,
 ): ResolvedChannel[] {
   return channels
-    .filter((channel) => matchesRole(channel.requiredRole, role))
+    .filter((channel) => roleAllows(channel.requiredRole, role))
     .map((channel) => {
       const tabs = channel.tabs.filter((tab) =>
-        matchesRole(tab.requiredRole, role),
+        roleAllows(tab.requiredRole, role),
       )
-      const tutorial = channel.tutorial
-        ? {
-            ...channel.tutorial,
-            sections: tabs
-              .map((tab) => tab.tutorial)
-              .filter(
-                (item): item is ResolvedTutorialSection => item !== null,
-              ),
-          }
-        : null
 
       return {
         ...channel,
         tabs,
-        tutorial,
+        tutorial: channel.tutorial
+          ? {
+              ...channel.tutorial,
+              sections: tabs
+                .map((tab) => tab.tutorial)
+                .filter(
+                  (section): section is ResolvedTutorialSection =>
+                    section !== null,
+                ),
+            }
+          : null,
       }
     })
 }
@@ -474,9 +453,9 @@ export function resolveChannelLocation(
   channels: ResolvedChannel[],
   input: ChannelLocationInput,
 ): ResolvedChannelLocation | null {
-  const channelKey = stringValue(input.channelKey)
-  const dashboardKey = stringValue(input.dashboardKey)
-  const path = pathValue(input.path)
+  const channelKey = text(input.channelKey)
+  const dashboardKey = text(input.dashboardKey)
+  const path = normalizedPath(input.path)
 
   let channel = channelKey
     ? channels.find(
@@ -490,19 +469,19 @@ export function resolveChannelLocation(
   }
 
   if (!channel) {
-    const tabMatches = channels.flatMap((item) =>
+    const matches = channels.flatMap((item) =>
       item.tabs
         .filter((tab) => tab.route === path)
         .map((tab) => ({ channel: item, tab })),
     )
 
-    if (tabMatches.length === 1) return tabMatches[0] ?? null
+    if (matches.length === 1) return matches[0] ?? null
 
-    if (tabMatches.length > 1 && dashboardKey) {
-      const matched = tabMatches.find(
+    if (matches.length > 1 && dashboardKey) {
+      const legacy = matches.find(
         ({ tab }) => !tab.dashboardKey || tab.dashboardKey === dashboardKey,
       )
-      if (matched) return matched
+      if (legacy) return legacy
     }
   }
 
@@ -514,10 +493,10 @@ export function resolveChannelLocation(
     )
   }
 
-  if (!channel) return null
-
-  return {
-    channel,
-    tab: findTab(channel, input),
-  }
+  return channel
+    ? {
+        channel,
+        tab: resolveTab(channel, input),
+      }
+    : null
 }

--- a/stores/helpers/channelContent.ts
+++ b/stores/helpers/channelContent.ts
@@ -1,0 +1,218 @@
+// /stores/helpers/channelContent.ts
+import type { ContentCollectionItem } from '@nuxt/content'
+
+export type NavigationCard = {
+  key: string
+  label: string
+  description?: string
+  icon?: string
+  image?: string
+  route?: string
+  action?: string
+}
+
+export type ChannelContentItem = ContentCollectionItem & {
+  contentType?: 'page' | 'channel' | 'tab'
+  channelKey?: string
+  tabKey?: string
+  label?: string
+  title?: string
+  subtitle?: string
+  description?: string
+  summary?: string
+  narrative?: string
+  icon?: string
+  image?: string
+  route?: string
+  component?: string
+  modelType?: string
+  defaultTab?: string
+  sort?: string | number
+  cards?: string | NavigationCard[]
+  requiredBeforeNext?: string[]
+  requiredRole?: string
+  requiredPermission?: string
+  visible?: boolean
+  dottiTip?: string
+  amiTip?: string
+  dottitip?: string
+  amitip?: string
+}
+
+export type ResolvedTab = {
+  channelKey: string
+  tabKey: string
+  label: string
+  title: string
+  subtitle: string
+  description: string
+  summary: string
+  narrative: string
+  icon: string
+  image: string
+  route: string
+  component: string
+  modelType: string
+  sort: number
+  cards: string | NavigationCard[] | null
+  requiredBeforeNext: string[]
+  requiredRole: string
+  requiredPermission: string
+  dottiTip: string
+  amiTip: string
+}
+
+export type ResolvedChannel = {
+  channelKey: string
+  label: string
+  title: string
+  subtitle: string
+  description: string
+  summary: string
+  narrative: string
+  icon: string
+  image: string
+  route: string
+  defaultTab: string
+  sort: number
+  requiredRole: string
+  requiredPermission: string
+  dottiTip: string
+  amiTip: string
+  tabs: ResolvedTab[]
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function sortValue(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
+}
+
+function imageValue(
+  image: unknown,
+  channelKey: string,
+  tabKey?: string,
+): string {
+  const explicit = stringValue(image)
+  if (explicit) {
+    if (explicit.startsWith('/') || explicit.startsWith('http')) return explicit
+    return `/images/${explicit}`
+  }
+
+  return tabKey
+    ? `/images/channels/${channelKey}/${tabKey}.webp`
+    : `/images/channels/${channelKey}/channel.webp`
+}
+
+function tipValue(
+  camelCase: unknown,
+  legacyLowercase: unknown,
+): string {
+  return stringValue(camelCase) || stringValue(legacyLowercase)
+}
+
+export function resolveChannels(
+  items: ChannelContentItem[],
+): ResolvedChannel[] {
+  const channelItems = items.filter(
+    (item) => item.contentType === 'channel' && item.visible !== false,
+  )
+  const tabItems = items.filter(
+    (item) => item.contentType === 'tab' && item.visible !== false,
+  )
+
+  return channelItems
+    .map((channel): ResolvedChannel | null => {
+      const channelKey = stringValue(channel.channelKey)
+      if (!channelKey) return null
+
+      const channelLabel =
+        stringValue(channel.label) || stringValue(channel.title) || channelKey
+      const channelTitle = stringValue(channel.title) || channelLabel
+      const channelSubtitle = stringValue(channel.subtitle)
+      const channelDescription = stringValue(channel.description)
+      const channelSummary = stringValue(channel.summary)
+      const channelNarrative = stringValue(channel.narrative)
+      const channelIcon = stringValue(channel.icon) || 'kind-icon:folder'
+      const channelRoute = stringValue(channel.route) || `/${channelKey}`
+      const channelRole = stringValue(channel.requiredRole)
+      const channelPermission = stringValue(channel.requiredPermission)
+      const channelDottiTip = tipValue(channel.dottiTip, channel.dottitip)
+      const channelAmiTip = tipValue(channel.amiTip, channel.amitip)
+
+      const tabs = tabItems
+        .filter((tab) => stringValue(tab.channelKey) === channelKey)
+        .map((tab): ResolvedTab | null => {
+          const tabKey = stringValue(tab.tabKey)
+          if (!tabKey) return null
+
+          const label =
+            stringValue(tab.label) || stringValue(tab.title) || tabKey
+
+          return {
+            channelKey,
+            tabKey,
+            label,
+            title: stringValue(tab.title) || label,
+            subtitle: stringValue(tab.subtitle) || channelSubtitle,
+            description:
+              stringValue(tab.description) || channelDescription,
+            summary: stringValue(tab.summary) || channelSummary,
+            narrative: stringValue(tab.narrative) || channelNarrative,
+            icon: stringValue(tab.icon) || channelIcon,
+            image: imageValue(tab.image, channelKey, tabKey),
+            route: stringValue(tab.route) || channelRoute,
+            component: stringValue(tab.component),
+            modelType: stringValue(tab.modelType),
+            sort: sortValue(tab.sort),
+            cards: tab.cards ?? channel.cards ?? null,
+            requiredBeforeNext: Array.isArray(tab.requiredBeforeNext)
+              ? tab.requiredBeforeNext
+              : [],
+            requiredRole:
+              stringValue(tab.requiredRole) || channelRole,
+            requiredPermission:
+              stringValue(tab.requiredPermission) || channelPermission,
+            dottiTip:
+              tipValue(tab.dottiTip, tab.dottitip) || channelDottiTip,
+            amiTip: tipValue(tab.amiTip, tab.amitip) || channelAmiTip,
+          }
+        })
+        .filter((tab): tab is ResolvedTab => tab !== null)
+        .sort((a, b) => a.sort - b.sort || a.label.localeCompare(b.label))
+
+      const requestedDefault = stringValue(channel.defaultTab)
+      const defaultTab = tabs.some((tab) => tab.tabKey === requestedDefault)
+        ? requestedDefault
+        : tabs[0]?.tabKey || ''
+
+      return {
+        channelKey,
+        label: channelLabel,
+        title: channelTitle,
+        subtitle: channelSubtitle,
+        description: channelDescription,
+        summary: channelSummary,
+        narrative: channelNarrative,
+        icon: channelIcon,
+        image: imageValue(channel.image, channelKey),
+        route: channelRoute,
+        defaultTab,
+        sort: sortValue(channel.sort),
+        requiredRole: channelRole,
+        requiredPermission: channelPermission,
+        dottiTip: channelDottiTip,
+        amiTip: channelAmiTip,
+        tabs,
+      }
+    })
+    .filter((channel): channel is ResolvedChannel => channel !== null)
+    .sort((a, b) => a.sort - b.sort || a.label.localeCompare(b.label))
+}

--- a/stores/helpers/channelContent.ts
+++ b/stores/helpers/channelContent.ts
@@ -15,12 +15,16 @@ export type ChannelContentItem = ContentCollectionItem & {
   contentType?: 'page' | 'channel' | 'tab'
   channelKey?: string
   tabKey?: string
+  dashboardKey?: string
+  dashboardTab?: string
   label?: string
   title?: string
+  room?: string
   subtitle?: string
   description?: string
   summary?: string
   narrative?: string
+  tooltip?: string
   icon?: string
   image?: string
   route?: string
@@ -33,6 +37,8 @@ export type ChannelContentItem = ContentCollectionItem & {
   requiredRole?: string
   requiredPermission?: string
   visible?: boolean
+  loadingMessage?: string
+  refreshLabel?: string
   dottiTip?: string
   amiTip?: string
   dottitip?: string
@@ -40,14 +46,19 @@ export type ChannelContentItem = ContentCollectionItem & {
 }
 
 export type ResolvedTab = {
+  key: string
   channelKey: string
   tabKey: string
+  dashboardKey: string
+  dashboardTab: string
   label: string
   title: string
+  room: string
   subtitle: string
   description: string
   summary: string
   narrative: string
+  tooltip: string
   icon: string
   image: string
   route: string
@@ -58,18 +69,24 @@ export type ResolvedTab = {
   requiredBeforeNext: string[]
   requiredRole: string
   requiredPermission: string
+  loadingMessage: string
+  refreshLabel: string
   dottiTip: string
   amiTip: string
 }
 
 export type ResolvedChannel = {
+  key: string
   channelKey: string
+  dashboardKey: string
   label: string
   title: string
+  room: string
   subtitle: string
   description: string
   summary: string
   narrative: string
+  tooltip: string
   icon: string
   image: string
   route: string
@@ -77,9 +94,24 @@ export type ResolvedChannel = {
   sort: number
   requiredRole: string
   requiredPermission: string
+  loadingMessage: string
+  refreshLabel: string
   dottiTip: string
   amiTip: string
   tabs: ResolvedTab[]
+}
+
+export type ChannelLocationInput = {
+  channelKey?: string | null
+  tabKey?: string | null
+  dashboardKey?: string | null
+  dashboardTab?: string | null
+  path?: string | null
+}
+
+export type ResolvedChannelLocation = {
+  channel: ResolvedChannel
+  tab: ResolvedTab | null
 }
 
 function stringValue(value: unknown): string {
@@ -111,11 +143,68 @@ function imageValue(
     : `/images/channels/${channelKey}/channel.webp`
 }
 
-function tipValue(
-  camelCase: unknown,
-  legacyLowercase: unknown,
-): string {
+function tipValue(camelCase: unknown, legacyLowercase: unknown): string {
   return stringValue(camelCase) || stringValue(legacyLowercase)
+}
+
+function routeValue(value: unknown): string {
+  const route = stringValue(value)
+  if (!route) return ''
+  if (route === '/') return route
+  return route.startsWith('/') ? route.replace(/\/+$/, '') : `/${route}`
+}
+
+function pathValue(value: unknown): string {
+  const path = routeValue(stringValue(value).split(/[?#]/)[0])
+  return path || '/'
+}
+
+function matchesRole(requiredRole: string, role: string): boolean {
+  if (!requiredRole) return true
+  if (role === 'ADMIN') return true
+  return requiredRole === role
+}
+
+function findTab(
+  channel: ResolvedChannel,
+  input: ChannelLocationInput,
+): ResolvedTab | null {
+  const tabKey = stringValue(input.tabKey)
+  const dashboardKey = stringValue(input.dashboardKey)
+  const dashboardTab = stringValue(input.dashboardTab)
+  const path = pathValue(input.path)
+
+  if (tabKey) {
+    const matched = channel.tabs.find(
+      (tab) => tab.tabKey === tabKey || tab.dashboardTab === tabKey,
+    )
+    if (matched) return matched
+  }
+
+  if (dashboardTab) {
+    const matched = channel.tabs.find(
+      (tab) =>
+        tab.dashboardTab === dashboardTab &&
+        (!dashboardKey || !tab.dashboardKey || tab.dashboardKey === dashboardKey),
+    )
+    if (matched) return matched
+  }
+
+  const routeMatches = channel.tabs.filter((tab) => tab.route === path)
+  if (routeMatches.length === 1) return routeMatches[0] ?? null
+
+  if (routeMatches.length > 1 && dashboardKey) {
+    const matched = routeMatches.find(
+      (tab) => !tab.dashboardKey || tab.dashboardKey === dashboardKey,
+    )
+    if (matched) return matched
+  }
+
+  return (
+    channel.tabs.find((tab) => tab.tabKey === channel.defaultTab) ??
+    channel.tabs[0] ??
+    null
+  )
 }
 
 export function resolveChannels(
@@ -136,14 +225,21 @@ export function resolveChannels(
       const channelLabel =
         stringValue(channel.label) || stringValue(channel.title) || channelKey
       const channelTitle = stringValue(channel.title) || channelLabel
+      const channelRoom = stringValue(channel.room) || channelTitle
       const channelSubtitle = stringValue(channel.subtitle)
       const channelDescription = stringValue(channel.description)
       const channelSummary = stringValue(channel.summary)
       const channelNarrative = stringValue(channel.narrative)
+      const channelTooltip = stringValue(channel.tooltip)
       const channelIcon = stringValue(channel.icon) || 'kind-icon:folder'
-      const channelRoute = stringValue(channel.route) || `/${channelKey}`
+      const channelRoute = routeValue(channel.route) || `/${channelKey}`
+      const channelDashboardKey = stringValue(channel.dashboardKey)
       const channelRole = stringValue(channel.requiredRole)
       const channelPermission = stringValue(channel.requiredPermission)
+      const channelLoadingMessage =
+        stringValue(channel.loadingMessage) || `Loading ${channelLabel}…`
+      const channelRefreshLabel =
+        stringValue(channel.refreshLabel) || `Refresh ${channelLabel}`
       const channelDottiTip = tipValue(channel.dottiTip, channel.dottitip)
       const channelAmiTip = tipValue(channel.amiTip, channel.amitip)
 
@@ -157,18 +253,23 @@ export function resolveChannels(
             stringValue(tab.label) || stringValue(tab.title) || tabKey
 
           return {
+            key: tabKey,
             channelKey,
             tabKey,
+            dashboardKey:
+              stringValue(tab.dashboardKey) || channelDashboardKey,
+            dashboardTab: stringValue(tab.dashboardTab) || tabKey,
             label,
             title: stringValue(tab.title) || label,
+            room: stringValue(tab.room) || channelRoom,
             subtitle: stringValue(tab.subtitle) || channelSubtitle,
-            description:
-              stringValue(tab.description) || channelDescription,
+            description: stringValue(tab.description) || channelDescription,
             summary: stringValue(tab.summary) || channelSummary,
             narrative: stringValue(tab.narrative) || channelNarrative,
+            tooltip: stringValue(tab.tooltip) || channelTooltip,
             icon: stringValue(tab.icon) || channelIcon,
             image: imageValue(tab.image, channelKey, tabKey),
-            route: stringValue(tab.route) || channelRoute,
+            route: routeValue(tab.route) || channelRoute,
             component: stringValue(tab.component),
             modelType: stringValue(tab.modelType),
             sort: sortValue(tab.sort),
@@ -176,10 +277,13 @@ export function resolveChannels(
             requiredBeforeNext: Array.isArray(tab.requiredBeforeNext)
               ? tab.requiredBeforeNext
               : [],
-            requiredRole:
-              stringValue(tab.requiredRole) || channelRole,
+            requiredRole: stringValue(tab.requiredRole) || channelRole,
             requiredPermission:
               stringValue(tab.requiredPermission) || channelPermission,
+            loadingMessage:
+              stringValue(tab.loadingMessage) || channelLoadingMessage,
+            refreshLabel:
+              stringValue(tab.refreshLabel) || channelRefreshLabel,
             dottiTip:
               tipValue(tab.dottiTip, tab.dottitip) || channelDottiTip,
             amiTip: tipValue(tab.amiTip, tab.amitip) || channelAmiTip,
@@ -194,13 +298,17 @@ export function resolveChannels(
         : tabs[0]?.tabKey || ''
 
       return {
+        key: channelKey,
         channelKey,
+        dashboardKey: channelDashboardKey,
         label: channelLabel,
         title: channelTitle,
+        room: channelRoom,
         subtitle: channelSubtitle,
         description: channelDescription,
         summary: channelSummary,
         narrative: channelNarrative,
+        tooltip: channelTooltip,
         icon: channelIcon,
         image: imageValue(channel.image, channelKey),
         route: channelRoute,
@@ -208,6 +316,8 @@ export function resolveChannels(
         sort: sortValue(channel.sort),
         requiredRole: channelRole,
         requiredPermission: channelPermission,
+        loadingMessage: channelLoadingMessage,
+        refreshLabel: channelRefreshLabel,
         dottiTip: channelDottiTip,
         amiTip: channelAmiTip,
         tabs,
@@ -215,4 +325,68 @@ export function resolveChannels(
     })
     .filter((channel): channel is ResolvedChannel => channel !== null)
     .sort((a, b) => a.sort - b.sort || a.label.localeCompare(b.label))
+}
+
+export function filterChannelsByRole(
+  channels: ResolvedChannel[],
+  role: string,
+): ResolvedChannel[] {
+  return channels
+    .filter((channel) => matchesRole(channel.requiredRole, role))
+    .map((channel) => ({
+      ...channel,
+      tabs: channel.tabs.filter((tab) => matchesRole(tab.requiredRole, role)),
+    }))
+}
+
+export function resolveChannelLocation(
+  channels: ResolvedChannel[],
+  input: ChannelLocationInput,
+): ResolvedChannelLocation | null {
+  const channelKey = stringValue(input.channelKey)
+  const dashboardKey = stringValue(input.dashboardKey)
+  const path = pathValue(input.path)
+
+  let channel = channelKey
+    ? channels.find(
+        (item) =>
+          item.channelKey === channelKey || item.dashboardKey === channelKey,
+      )
+    : undefined
+
+  if (!channel && dashboardKey) {
+    channel = channels.find((item) => item.dashboardKey === dashboardKey)
+  }
+
+  if (!channel) {
+    const tabMatches = channels.flatMap((item) =>
+      item.tabs
+        .filter((tab) => tab.route === path)
+        .map((tab) => ({ channel: item, tab })),
+    )
+
+    if (tabMatches.length === 1) return tabMatches[0] ?? null
+
+    if (tabMatches.length > 1 && dashboardKey) {
+      const matched = tabMatches.find(
+        ({ tab }) => !tab.dashboardKey || tab.dashboardKey === dashboardKey,
+      )
+      if (matched) return matched
+    }
+  }
+
+  if (!channel) {
+    channel = channels.find(
+      (item) =>
+        item.route === path ||
+        (item.route !== '/' && path.startsWith(`${item.route}/`)),
+    )
+  }
+
+  if (!channel) return null
+
+  return {
+    channel,
+    tab: findTab(channel, input),
+  }
 }

--- a/stores/helpers/navigationAccess.ts
+++ b/stores/helpers/navigationAccess.ts
@@ -1,0 +1,78 @@
+import type {
+  ResolvedChannel,
+  ResolvedTutorialSection,
+} from '@/stores/helpers/channelContent'
+
+export type NavigationPermission =
+  | 'authenticated'
+  | 'member'
+  | 'family'
+  | 'mature'
+  | 'admin'
+  | string
+
+export type NavigationAccessContext = {
+  role: string
+  permissions: ReadonlySet<string>
+  isAdmin: boolean
+}
+
+export function permissionAllows(
+  requiredPermission: string,
+  context: NavigationAccessContext,
+): boolean {
+  const required = requiredPermission.trim().toLowerCase()
+  if (!required || context.isAdmin) return true
+
+  return context.permissions.has(required)
+}
+
+export function filterChannelsByPermission(
+  channels: ResolvedChannel[],
+  context: NavigationAccessContext,
+): ResolvedChannel[] {
+  return channels
+    .filter((channel) =>
+      permissionAllows(channel.requiredPermission, context),
+    )
+    .map((channel) => {
+      const tabs = channel.tabs.filter((tab) =>
+        permissionAllows(tab.requiredPermission, context),
+      )
+
+      return {
+        ...channel,
+        tabs,
+        tutorial: channel.tutorial
+          ? {
+              ...channel.tutorial,
+              sections: tabs
+                .map((tab) => tab.tutorial)
+                .filter(
+                  (section): section is ResolvedTutorialSection =>
+                    section !== null,
+                ),
+            }
+          : null,
+      }
+    })
+    .filter((channel) => channel.tabs.length > 0)
+}
+
+export function navigationPermissions(input: {
+  isLoggedIn: boolean
+  isMember: boolean
+  isFamily: boolean
+  showMature: boolean
+  isAdmin: boolean
+}): ReadonlySet<string> {
+  const permissions = new Set<string>()
+
+  if (input.isLoggedIn) permissions.add('authenticated')
+  if (input.isMember) permissions.add('member')
+  if (input.isFamily) permissions.add('family')
+  if (input.showMature) permissions.add('mature')
+  if (input.isAdmin) permissions.add('admin')
+
+  return permissions
+}

--- a/stores/helpers/navigationAccess.ts
+++ b/stores/helpers/navigationAccess.ts
@@ -39,9 +39,15 @@ export function filterChannelsByPermission(
       const tabs = channel.tabs.filter((tab) =>
         permissionAllows(tab.requiredPermission, context),
       )
+      const defaultTab = tabs.some(
+        (tab) => tab.tabKey === channel.defaultTab,
+      )
+        ? channel.defaultTab
+        : tabs[0]?.tabKey || ''
 
       return {
         ...channel,
+        defaultTab,
         tabs,
         tutorial: channel.tutorial
           ? {

--- a/stores/helpers/navigationRouteAccess.ts
+++ b/stores/helpers/navigationRouteAccess.ts
@@ -1,0 +1,52 @@
+import {
+  resolveChannelLocation,
+  type ChannelLocationInput,
+  type ResolvedChannel,
+  type ResolvedChannelLocation,
+} from '@/stores/helpers/channelContent'
+
+export type NavigationRouteAccess = {
+  matched: boolean
+  allowed: boolean
+  requested: ResolvedChannelLocation | null
+  requiredRole: string
+  requiredPermission: string
+}
+
+export function evaluateNavigationRouteAccess(
+  channels: ResolvedChannel[],
+  visibleChannels: ResolvedChannel[],
+  input: ChannelLocationInput,
+): NavigationRouteAccess {
+  const requested = resolveChannelLocation(channels, input)
+
+  if (!requested) {
+    return {
+      matched: false,
+      allowed: true,
+      requested: null,
+      requiredRole: '',
+      requiredPermission: '',
+    }
+  }
+
+  const visibleChannel = visibleChannels.find(
+    (channel) => channel.channelKey === requested.channel.channelKey,
+  )
+  const visibleTab = requested.tab
+    ? visibleChannel?.tabs.find(
+        (tab) => tab.tabKey === requested.tab?.tabKey,
+      )
+    : null
+
+  return {
+    matched: true,
+    allowed: Boolean(visibleChannel && (!requested.tab || visibleTab)),
+    requested,
+    requiredRole:
+      requested.tab?.requiredRole || requested.channel.requiredRole,
+    requiredPermission:
+      requested.tab?.requiredPermission ||
+      requested.channel.requiredPermission,
+  }
+}

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -1,6 +1,6 @@
 // /stores/pageStore.ts
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { ContentCollectionItem } from '@nuxt/content'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
 import type { NavigationCard } from '@/stores/helpers/channelContent'
@@ -127,6 +127,8 @@ export const usePageStore = defineStore('pageStore', () => {
   const lastResolvedPath = ref('')
   const overrideCards = ref<BuilderCard[] | null>(null)
 
+  const channelContentStore = useChannelContentStore()
+
   const currentPage = computed(() => page.value as WorkspacePage | null)
 
   const layout = computed<PageLayoutKey>(() => 'default')
@@ -174,6 +176,28 @@ export const usePageStore = defineStore('pageStore', () => {
     refreshLabel: getString(currentPage.value?.refreshLabel),
   }))
 
+  const resolvedLocation = computed(() =>
+    channelContentStore.resolveActiveLocation({
+      channelKey: meta.value.channelKey,
+      tabKey: meta.value.tabKey,
+      dashboardKey: meta.value.dashboardKey,
+      dashboardTab: meta.value.dashboardTab,
+      path: currentPage.value?.path || lastResolvedPath.value,
+    }),
+  )
+
+  const resolvedChannel = computed(
+    () => resolvedLocation.value?.channel ?? null,
+  )
+  const resolvedTab = computed(() => resolvedLocation.value?.tab ?? null)
+
+  const activeChannelKey = computed(
+    () => resolvedChannel.value?.channelKey || meta.value.channelKey,
+  )
+  const activeTabKey = computed(
+    () => resolvedTab.value?.tabKey || meta.value.tabKey,
+  )
+
   const cards = computed<BuilderCard[]>(() => {
     if (overrideCards.value !== null) return overrideCards.value
 
@@ -183,39 +207,68 @@ export const usePageStore = defineStore('pageStore', () => {
       return navigationCardsToBuilderCards(value)
     }
 
-    const channelContentStore = useChannelContentStore()
-    const location = channelContentStore.resolveLocation({
-      channelKey: meta.value.channelKey,
-      tabKey: meta.value.tabKey,
-      dashboardKey: meta.value.dashboardKey,
-      dashboardTab: meta.value.dashboardTab,
-      path: currentPage.value?.path,
-    })
-
-    return location?.channel ? channelTabsToCards(location.channel) : []
+    return resolvedChannel.value
+      ? channelTabsToCards(resolvedChannel.value)
+      : []
   })
 
-  function syncDashboardShellFromPage(): void {
-    const navStore = useNavStore()
+  function setSheetFromResolvedTab(): void {
+    const tab = resolvedTab.value
+    if (!tab) return
 
-    navStore.setDashboardShellFromContent({
-      title: meta.value.title,
-      subtitle: meta.value.subtitle,
-      description: meta.value.description,
-      summary: meta.value.summary,
-      dashboardKey: meta.value.dashboardKey,
-      dashboardTab: meta.value.dashboardTab,
-      cards: cardsKey.value,
-      loadingMessage: meta.value.loadingMessage,
-      refreshLabel: meta.value.refreshLabel,
+    useSheetStore().setSheetFromTab({
+      key: tab.tabKey,
+      label: tab.label,
+      title: tab.title,
+      summary: tab.summary,
+      description: tab.description,
+      narrative: tab.narrative,
+      icon: tab.icon,
+      image: tab.image,
     })
   }
 
-  function initialize(): void {
-    if (initialized.value) return
+  function syncDashboardShellFromPage(): void {
+    const navStore = useNavStore()
+    const channel = resolvedChannel.value
+    const tab = resolvedTab.value
 
+    if (channel && tab) {
+      channelContentStore.setActiveTab(channel.channelKey, tab.tabKey)
+    }
+
+    const tabCards = typeof tab?.cards === 'string' ? tab.cards.trim() : ''
+
+    navStore.setDashboardShellFromContent({
+      title: tab?.title || channel?.title || meta.value.title,
+      subtitle: tab?.subtitle || channel?.subtitle || meta.value.subtitle,
+      description:
+        tab?.description || channel?.description || meta.value.description,
+      summary: tab?.summary || channel?.summary || meta.value.summary,
+      dashboardKey:
+        tab?.dashboardKey || channel?.dashboardKey || meta.value.dashboardKey,
+      dashboardTab:
+        tab?.dashboardTab || tab?.tabKey || meta.value.dashboardTab,
+      cards: tabCards || cardsKey.value,
+      loadingMessage:
+        tab?.loadingMessage ||
+        channel?.loadingMessage ||
+        meta.value.loadingMessage,
+      refreshLabel:
+        tab?.refreshLabel || channel?.refreshLabel || meta.value.refreshLabel,
+    })
+
+    setSheetFromResolvedTab()
+  }
+
+  async function initialize(force = false): Promise<void> {
+    if (initialized.value && !force) return
+
+    await channelContentStore.initialize(force)
     initialized.value = true
     ready.value = true
+
+    if (page.value) syncDashboardShellFromPage()
   }
 
   function setLoading(value: boolean): void {
@@ -233,6 +286,12 @@ export const usePageStore = defineStore('pageStore', () => {
     useSheetStore().clearSheet()
 
     syncDashboardShellFromPage()
+
+    if (!channelContentStore.initialized) {
+      void channelContentStore.initialize().then(() => {
+        if (page.value === newPage) syncDashboardShellFromPage()
+      })
+    }
   }
 
   function clearPage(): void {
@@ -273,6 +332,24 @@ export const usePageStore = defineStore('pageStore', () => {
     overrideCards.value = null
   }
 
+  watch(
+    () => ({
+      channelKey: activeChannelKey.value,
+      tabKey: activeTabKey.value,
+    }),
+    (next, previous) => {
+      if (!page.value) return
+      if (
+        next.channelKey === previous.channelKey &&
+        next.tabKey === previous.tabKey
+      ) {
+        return
+      }
+
+      syncDashboardShellFromPage()
+    },
+  )
+
   return {
     page,
     currentPage,
@@ -285,6 +362,11 @@ export const usePageStore = defineStore('pageStore', () => {
     cardsKey,
     workspaceCardKey,
     lastResolvedPath,
+    resolvedLocation,
+    resolvedChannel,
+    resolvedTab,
+    activeChannelKey,
+    activeTabKey,
 
     setPage,
     clearPage,

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -126,6 +126,7 @@ export const usePageStore = defineStore('pageStore', () => {
   const workspaceCardKey = ref('')
   const lastResolvedPath = ref('')
   const overrideCards = ref<BuilderCard[] | null>(null)
+  const initializePromise = ref<Promise<void> | null>(null)
 
   const channelContentStore = useChannelContentStore()
 
@@ -262,13 +263,26 @@ export const usePageStore = defineStore('pageStore', () => {
   }
 
   async function initialize(force = false): Promise<void> {
+    if (initializePromise.value && !force) return initializePromise.value
     if (initialized.value && !force) return
 
-    await channelContentStore.initialize(force)
-    initialized.value = true
-    ready.value = true
+    initializePromise.value = (async () => {
+      const navStore = useNavStore()
 
-    if (page.value) syncDashboardShellFromPage()
+      await navStore.initialize(force)
+      await channelContentStore.initialize(force)
+
+      initialized.value = true
+      ready.value = true
+
+      if (page.value) syncDashboardShellFromPage()
+    })()
+
+    try {
+      await initializePromise.value
+    } finally {
+      initializePromise.value = null
+    }
   }
 
   function setLoading(value: boolean): void {
@@ -287,8 +301,8 @@ export const usePageStore = defineStore('pageStore', () => {
 
     syncDashboardShellFromPage()
 
-    if (!channelContentStore.initialized) {
-      void channelContentStore.initialize().then(() => {
+    if (!initialized.value || !channelContentStore.initialized) {
+      void initialize().then(() => {
         if (page.value === newPage) syncDashboardShellFromPage()
       })
     }
@@ -362,6 +376,7 @@ export const usePageStore = defineStore('pageStore', () => {
     cardsKey,
     workspaceCardKey,
     lastResolvedPath,
+    initializePromise,
     resolvedLocation,
     resolvedChannel,
     resolvedTab,

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -18,6 +18,9 @@ export type PageNarratorRef =
 
 export type WorkspacePage = ContentCollectionItem & {
   cards?: WorkspaceCardsInput
+  contentType?: 'page' | 'channel' | 'tab'
+  channelKey?: string
+  tabKey?: string
   dashboardKey?: string
   dashboardTab?: string
   loadingMessage?: string
@@ -25,6 +28,8 @@ export type WorkspacePage = ContentCollectionItem & {
   room?: string
   subtitle?: string
   tooltip?: string
+  dottiTip?: string
+  amiTip?: string
   dottitip?: string
   amitip?: string
   narrator?: PageNarratorRef
@@ -121,13 +126,28 @@ export const usePageStore = defineStore('pageStore', () => {
       getString(currentPage.value?.image) || '/images/botcafe.webp',
     ),
     tooltip: getString(currentPage.value?.tooltip),
-    dottitip: getString(currentPage.value?.dottitip),
-    amitip: getString(currentPage.value?.amitip),
+    dottiTip:
+      getString(currentPage.value?.dottiTip) ||
+      getString(currentPage.value?.dottitip),
+    amiTip:
+      getString(currentPage.value?.amiTip) ||
+      getString(currentPage.value?.amitip),
     narrator: getNarratorRef(currentPage.value?.narrator),
     artPrompt: getString(currentPage.value?.artPrompt),
     sort: currentPage.value?.sort ?? '',
-    dashboardKey: getString(currentPage.value?.dashboardKey),
-    dashboardTab: getString(currentPage.value?.dashboardTab),
+    contentType: getString(currentPage.value?.contentType),
+    channelKey:
+      getString(currentPage.value?.channelKey) ||
+      getString(currentPage.value?.dashboardKey),
+    tabKey:
+      getString(currentPage.value?.tabKey) ||
+      getString(currentPage.value?.dashboardTab),
+    dashboardKey:
+      getString(currentPage.value?.dashboardKey) ||
+      getString(currentPage.value?.channelKey),
+    dashboardTab:
+      getString(currentPage.value?.dashboardTab) ||
+      getString(currentPage.value?.tabKey),
     loadingMessage: getString(currentPage.value?.loadingMessage),
     refreshLabel: getString(currentPage.value?.refreshLabel),
   }))
@@ -240,11 +260,16 @@ export const usePageStore = defineStore('pageStore', () => {
     icon: computed(() => meta.value.icon),
     image: computed(() => meta.value.image),
     tooltip: computed(() => meta.value.tooltip),
-    dottitip: computed(() => meta.value.dottitip),
-    amitip: computed(() => meta.value.amitip),
+    dottiTip: computed(() => meta.value.dottiTip),
+    amiTip: computed(() => meta.value.amiTip),
+    dottitip: computed(() => meta.value.dottiTip),
+    amitip: computed(() => meta.value.amiTip),
     narrator: computed(() => meta.value.narrator),
     artPrompt: computed(() => meta.value.artPrompt),
     sort: computed(() => meta.value.sort),
+    contentType: computed(() => meta.value.contentType),
+    channelKey: computed(() => meta.value.channelKey),
+    tabKey: computed(() => meta.value.tabKey),
     dashboardKey: computed(() => meta.value.dashboardKey),
     dashboardTab: computed(() => meta.value.dashboardTab),
     loadingMessage: computed(() => meta.value.loadingMessage),

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -3,11 +3,20 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { ContentCollectionItem } from '@nuxt/content'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
+import type { NavigationCard } from '@/stores/helpers/channelContent'
+import {
+  channelTabsToCards,
+  navigationCardsToBuilderCards,
+} from '@/stores/helpers/channelCards'
+import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useNavStore } from '@/stores/navStore'
 import { useSheetStore } from '@/stores/sheetStore'
 
 export type PageLayoutKey = 'default' | 'minimal' | 'vertical-scroll' | false
-export type WorkspaceCardsInput = string | BuilderCard[]
+export type WorkspaceCardsInput =
+  | string
+  | BuilderCard[]
+  | NavigationCard[]
 export type PageNarratorKind = 'bot' | 'character'
 export type PageNarratorRef =
   | string
@@ -48,6 +57,25 @@ function normalizeImagePath(path: string): string {
 }
 
 function isBuilderCardArray(value: unknown): value is BuilderCard[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        entry &&
+        typeof entry === 'object' &&
+        'key' in entry &&
+        'label' in entry &&
+        'title' in entry &&
+        'icon' in entry &&
+        'tagline' in entry &&
+        'narrative' in entry &&
+        'restoresFields' in entry &&
+        'steps' in entry,
+    )
+  )
+}
+
+function isNavigationCardArray(value: unknown): value is NavigationCard[] {
   return (
     Array.isArray(value) &&
     value.every(
@@ -108,12 +136,6 @@ export const usePageStore = defineStore('pageStore', () => {
     return getCardsKey(value)
   })
 
-  const cards = computed<BuilderCard[]>(() => {
-    if (overrideCards.value !== null) return overrideCards.value
-    const value = currentPage.value?.cards
-    return isBuilderCardArray(value) ? value : []
-  })
-
   const meta = computed(() => ({
     title: getString(currentPage.value?.title) || 'Robots',
     room: getString(currentPage.value?.room) || 'Kind Robots',
@@ -151,6 +173,27 @@ export const usePageStore = defineStore('pageStore', () => {
     loadingMessage: getString(currentPage.value?.loadingMessage),
     refreshLabel: getString(currentPage.value?.refreshLabel),
   }))
+
+  const cards = computed<BuilderCard[]>(() => {
+    if (overrideCards.value !== null) return overrideCards.value
+
+    const value = currentPage.value?.cards
+    if (isBuilderCardArray(value)) return value
+    if (isNavigationCardArray(value)) {
+      return navigationCardsToBuilderCards(value)
+    }
+
+    const channelContentStore = useChannelContentStore()
+    const location = channelContentStore.resolveLocation({
+      channelKey: meta.value.channelKey,
+      tabKey: meta.value.tabKey,
+      dashboardKey: meta.value.dashboardKey,
+      dashboardTab: meta.value.dashboardTab,
+      path: currentPage.value?.path,
+    })
+
+    return location?.channel ? channelTabsToCards(location.channel) : []
+  })
 
   function syncDashboardShellFromPage(): void {
     const navStore = useNavStore()

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -290,12 +290,14 @@ export const usePageStore = defineStore('pageStore', () => {
   }
 
   function setPage(newPage: ContentCollectionItem): void {
+    const resolvedPath = (newPage as WorkspacePage).path ?? ''
+
     page.value = newPage
     workspaceCardKey.value = ''
     overrideCards.value = null
     ready.value = true
     isLoading.value = false
-    lastResolvedPath.value = (newPage as WorkspacePage).path ?? ''
+    lastResolvedPath.value = resolvedPath
 
     useSheetStore().clearSheet()
 
@@ -303,7 +305,9 @@ export const usePageStore = defineStore('pageStore', () => {
 
     if (!initialized.value || !channelContentStore.initialized) {
       void initialize().then(() => {
-        if (page.value === newPage) syncDashboardShellFromPage()
+        if (lastResolvedPath.value === resolvedPath) {
+          syncDashboardShellFromPage()
+        }
       })
     }
   }

--- a/stores/projectStore.ts
+++ b/stores/projectStore.ts
@@ -46,6 +46,18 @@ export type ProjectListOptions = {
   skip?: number
 }
 
+export type ProjectPlacementFailure = {
+  slug: string
+  message: string
+}
+
+export type ApplyPlacementsResult = {
+  updated: string[]
+  unchanged: string[]
+  missing: string[]
+  failed: ProjectPlacementFailure[]
+}
+
 function queryString(options: ProjectListOptions): string {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(options)) {
@@ -203,23 +215,19 @@ export const useProjectStore = defineStore('projectStore', () => {
     }
   }
 
-  type ApplyPlacementsResult = {
-    updated: string[]
-    unchanged: string[]
-    missing: string[]
-  }
-
   // Backfill channelKey / tabKey / liveUrl on loaded Project rows from the
   // canonical PROJECT_PLACEMENTS map, using the existing PATCH endpoint (which is
   // admin/owner-gated server-side). Runs over projects already in the store, so
   // load them (admin: includeInactive) before calling. liveUrl is only filled
-  // when empty unless overwriteLiveUrl is set.
+  // when empty unless overwriteLiveUrl is set. Individual PATCH failures are
+  // reported per slug so the rest of the migration can continue.
   async function applyPlacements(
     overwriteLiveUrl = false,
   ): Promise<ApplyPlacementsResult> {
     const updated: string[] = []
     const unchanged: string[] = []
     const missing: string[] = []
+    const failed: ProjectPlacementFailure[] = []
 
     for (const [slug, placement] of Object.entries(PROJECT_PLACEMENTS)) {
       const project =
@@ -245,15 +253,23 @@ export const useProjectStore = defineStore('projectStore', () => {
         continue
       }
 
-      await updateProject(project.id, {
-        channelKey: placement.channelKey,
-        tabKey: placement.tabKey,
-        liveUrl: nextLiveUrl,
-      })
-      updated.push(slug)
+      try {
+        await updateProject(project.id, {
+          channelKey: placement.channelKey,
+          tabKey: placement.tabKey,
+          liveUrl: nextLiveUrl,
+        })
+        updated.push(slug)
+      } catch (cause) {
+        failed.push({
+          slug,
+          message:
+            cause instanceof Error ? cause.message : 'Unknown Project update error',
+        })
+      }
     }
 
-    return { updated, unchanged, missing }
+    return { updated, unchanged, missing, failed }
   }
 
   return {

--- a/stores/tutorialStore.ts
+++ b/stores/tutorialStore.ts
@@ -1,27 +1,13 @@
 // /stores/tutorialStore.ts
-//
-// Single owner of "should the tutorial popup auto-open for this channel?"
-// state. The map is keyed by FooterKey. true = still show on visit (unchecked
-// "don't show again"); false = dismissed.
-//
-// Pattern notes (matches the rest of the project):
-//  - State holder only; components read computed/getters, never localStorage.
-//  - Mutations call syncToLocalStorage() immediately after changing state.
-//  - useStore() is called lazily inside function bodies where needed.
-
 import { defineStore } from 'pinia'
-import {
-  type TutorialChannelKey,
-  tutorialChannelKeys,
-  isTutorialChannelKey,
-} from './helpers/tutorialCards'
+import { tutorialChannelKeys } from './helpers/tutorialCards'
 
 const STORAGE_KEY = 'kindrobots:tutorial-state:v1'
 
+export type TutorialChannelKey = string
+
 type TutorialState = {
-  // For each channel: true = auto-show tutorial, false = user dismissed it.
   showByChannel: Record<TutorialChannelKey, boolean>
-  // Whether the popup is currently open, and for which channel.
   activeChannel: TutorialChannelKey | null
   hydrated: boolean
 }
@@ -40,7 +26,6 @@ export const useTutorialStore = defineStore('tutorialStore', {
   }),
 
   getters: {
-    // Should the tutorial auto-open when the user lands on this channel?
     shouldAutoShow:
       (state) =>
       (channel: TutorialChannelKey): boolean =>
@@ -50,8 +35,6 @@ export const useTutorialStore = defineStore('tutorialStore', {
   },
 
   actions: {
-    // Pull persisted dismissals out of localStorage. Safe to call repeatedly;
-    // no-ops after the first successful hydrate and on the server.
     hydrate() {
       if (this.hydrated) return
       if (typeof window === 'undefined') return
@@ -61,34 +44,31 @@ export const useTutorialStore = defineStore('tutorialStore', {
         if (raw) {
           const parsed = JSON.parse(raw) as Partial<Record<string, boolean>>
           const next = defaultShowMap()
+
           for (const [key, value] of Object.entries(parsed)) {
-            if (isTutorialChannelKey(key) && typeof value === 'boolean') {
+            if (key.trim() && typeof value === 'boolean') {
               next[key] = value
             }
           }
+
           this.showByChannel = next
         }
-      } catch {
-        // Corrupt or unavailable storage — keep defaults, don't throw.
-      }
+      } catch {}
 
       this.hydrated = true
     },
 
     syncToLocalStorage() {
       if (typeof window === 'undefined') return
+
       try {
         window.localStorage.setItem(
           STORAGE_KEY,
           JSON.stringify(this.showByChannel),
         )
-      } catch {
-        // Storage full or blocked — degrade quietly.
-      }
+      } catch {}
     },
 
-    // Open the popup for a channel. Used both for manual opens (the "?" button)
-    // and auto-opens on first visit.
     open(channel: TutorialChannelKey) {
       this.hydrate()
       this.activeChannel = channel
@@ -98,19 +78,17 @@ export const useTutorialStore = defineStore('tutorialStore', {
       this.activeChannel = null
     },
 
-    // Call on channel entry. Opens the tutorial only if the user hasn't
-    // dismissed it. Returns whether it opened, in case the caller cares.
     maybeAutoOpen(channel: TutorialChannelKey): boolean {
       this.hydrate()
+
       if (this.shouldAutoShow(channel)) {
         this.activeChannel = channel
         return true
       }
+
       return false
     },
 
-    // Toggle the "don't show this again" preference for a channel.
-    // show=true means keep auto-showing; show=false means dismiss.
     setShowForChannel(channel: TutorialChannelKey, show: boolean) {
       this.showByChannel = { ...this.showByChannel, [channel]: show }
       this.syncToLocalStorage()
@@ -120,7 +98,6 @@ export const useTutorialStore = defineStore('tutorialStore', {
       this.setShowForChannel(channel, false)
     },
 
-    // Re-enable every tutorial (handy for a "replay tutorials" settings button).
     resetAll() {
       this.showByChannel = defaultShowMap()
       this.syncToLocalStorage()

--- a/stores/tutorialStore.ts
+++ b/stores/tutorialStore.ts
@@ -1,6 +1,5 @@
 // /stores/tutorialStore.ts
 import { defineStore } from 'pinia'
-import { tutorialChannelKeys } from './helpers/tutorialCards'
 
 const STORAGE_KEY = 'kindrobots:tutorial-state:v1'
 
@@ -13,9 +12,7 @@ type TutorialState = {
 }
 
 function defaultShowMap(): Record<TutorialChannelKey, boolean> {
-  return Object.fromEntries(
-    tutorialChannelKeys.map((key) => [key, true]),
-  ) as Record<TutorialChannelKey, boolean>
+  return {}
 }
 
 export const useTutorialStore = defineStore('tutorialStore', {

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -1,131 +1,149 @@
 // /utils/projectPlacements.ts
 //
-// Canonical placement for every project surface: conductor slug -> the channel
-// (dashboardKey), tab (dashboardTab), the in-app route, and the launch pointer.
-// This is the single source of truth used to backfill the Project DB rows
-// (channelKey / tabKey / liveUrl) via POST /api/projects/apply-placements, and it
-// mirrors the tabs registered in stores/helpers/dashboardHelper.ts.
-//
-// liveUrl is the internal Kind Robots route by default (so the Conductor "Open
-// Project" action lands on the styled page). Bridge projects still expose their
-// external app from their own page.
+// Canonical placement for every project surface: conductor slug -> channelKey,
+// tabKey, in-app route, and launch pointer. Channel and tab names mirror the
+// Nuxt Content documents under /content/channels.
 
 export type ProjectPlacement = {
-  /** dashboardKey / Project.channelKey */
   channelKey: string
-  /** dashboardTab / Project.tabKey */
   tabKey: string
-  /** In-app route the page lives at (also the default liveUrl). */
   route: string
-  /** Explicit launch pointer when it differs from `route` (e.g. external app). */
   liveUrl?: string
 }
 
 export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
-  // Flagship + newly stitched surfaces
-  'coloring-book': { channelKey: 'art', tabKey: 'coloring', route: '/coloring' },
+  'coloring-book': {
+    channelKey: 'play',
+    tabKey: 'coloring',
+    route: '/coloring',
+  },
   'challenge-center': {
-    channelKey: 'wonder',
+    channelKey: 'lab',
     tabKey: 'challenges',
     route: '/challenges',
   },
   wishmaster: {
-    channelKey: 'conductor',
+    channelKey: 'plan',
     tabKey: 'wishmaster',
     route: '/wishmaster',
   },
-  appmaker: { channelKey: 'conductor', tabKey: 'appmaker', route: '/appmaker' },
+  appmaker: {
+    channelKey: 'plan',
+    tabKey: 'appmaker',
+    route: '/appmaker',
+  },
   serendipity: {
-    channelKey: 'scenario',
+    channelKey: 'play',
     tabKey: 'serendipity',
     route: '/serendipity',
   },
   'mermaids-of-venice': {
-    channelKey: 'giftshop',
+    channelKey: 'sanctuary',
     tabKey: 'mermaids',
     route: '/mermaids',
   },
   'model-builder': {
-    channelKey: 'builder',
+    channelKey: 'build',
     tabKey: 'model-builder',
     route: '/model-builder',
   },
   storymaker: {
-    channelKey: 'scenario',
+    channelKey: 'play',
     tabKey: 'storymaker',
     route: '/storymaker',
   },
-  sketchy: { channelKey: 'academy', tabKey: 'sketchy', route: '/sketchy' },
-  packmaker: { channelKey: 'builder', tabKey: 'packs', route: '/packs' },
-  davinci: { channelKey: 'wonder', tabKey: 'davinci', route: '/davinci' },
+  sketchy: {
+    channelKey: 'lab',
+    tabKey: 'sketchy',
+    route: '/sketchy',
+  },
+  packmaker: {
+    channelKey: 'build',
+    tabKey: 'packs',
+    route: '/packs',
+  },
+  davinci: {
+    channelKey: 'lab',
+    tabKey: 'davinci',
+    route: '/davinci',
+  },
   'media-watchlist': {
-    channelKey: 'wonder',
+    channelKey: 'lab',
     tabKey: 'watchlist',
     route: '/watchlist',
   },
-  'coat-dance': { channelKey: 'art', tabKey: 'coat-dance', route: '/coat-dance' },
+  'coat-dance': {
+    channelKey: 'lab',
+    tabKey: 'coat-dance',
+    route: '/coat-dance',
+  },
   'ruler-hooked': {
-    channelKey: 'wonder',
+    channelKey: 'lab',
     tabKey: 'ruler-hooked',
     route: '/ruler-hooked',
   },
-  newsfeed: { channelKey: 'wonder', tabKey: 'newsfeed', route: '/newsfeed' },
+  newsfeed: {
+    channelKey: 'lab',
+    tabKey: 'newsfeed',
+    route: '/newsfeed',
+  },
   'humboldt-scoop': {
-    channelKey: 'wonder',
+    channelKey: 'lab',
     tabKey: 'humboldt-scoop',
     route: '/humboldt-scoop',
   },
   'humboldt-scoop-cms': {
-    channelKey: 'conductor',
+    channelKey: 'admin',
     tabKey: 'scoop-cms',
     route: '/scoop-cms',
   },
   'conductor-app': {
-    channelKey: 'conductor',
+    channelKey: 'plan',
     tabKey: 'conductor-app',
     route: '/conductor-app',
   },
   'alexa-integration': {
-    channelKey: 'wonder',
+    channelKey: 'lab',
     tabKey: 'voice-lab',
     route: '/voice-lab',
   },
-
-  // Already-complete surfaces (recorded so their DB rows carry placement too)
   'superkate-services-calculator': {
-    channelKey: 'art',
+    channelKey: 'build',
     tabKey: 'stylist',
     route: '/stylist',
   },
   'superkate-hairstyle-ai': {
-    channelKey: 'art',
+    channelKey: 'build',
     tabKey: 'stylist',
     route: '/stylist',
   },
   'digital-storefront': {
-    channelKey: 'giftshop',
+    channelKey: 'sanctuary',
     tabKey: 'giftshop',
     route: '/sanctuary',
   },
   'ai-art-academy': {
-    channelKey: 'academy',
-    tabKey: 'timeline',
+    channelKey: 'play',
+    tabKey: 'academy',
     route: '/academy',
   },
   brainstorm: {
-    channelKey: 'brainstorm',
+    channelKey: 'build',
     tabKey: 'brainstorm',
     route: '/brainstorm',
   },
-  'mural-design': { channelKey: 'wonder', tabKey: 'mural', route: '/mural' },
+  'mural-design': {
+    channelKey: 'lab',
+    tabKey: 'mural',
+    route: '/mural',
+  },
   conductor: {
-    channelKey: 'conductor',
-    tabKey: 'conductor',
+    channelKey: 'plan',
+    tabKey: 'projects',
     route: '/conductor',
   },
 }
 
-/** Resolve a placement by conductor slug (or project slug), if one exists. */
 export function getProjectPlacement(
   slug: string | null | undefined,
 ): ProjectPlacement | null {
@@ -133,7 +151,6 @@ export function getProjectPlacement(
   return PROJECT_PLACEMENTS[slug] ?? null
 }
 
-/** The launch pointer for a placement: explicit liveUrl, else the route. */
 export function placementLiveUrl(placement: ProjectPlacement): string {
   return placement.liveUrl ?? placement.route
 }

--- a/utils/scripts/auditChannelAssets.ts
+++ b/utils/scripts/auditChannelAssets.ts
@@ -1,0 +1,144 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  resolveChannels,
+  type ChannelContentItem,
+} from '@/stores/helpers/channelContent'
+
+type FrontMatter = Record<string, string>
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const channelsDirectory = resolve(repositoryRoot, 'content/channels')
+const publicDirectory = resolve(repositoryRoot, 'public')
+const strict = process.argv.includes('--strict')
+
+function cleanValue(value: string): string {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+
+  if (
+    (quote === "'" || quote === '"') &&
+    trimmed.length >= 2 &&
+    trimmed.endsWith(quote)
+  ) {
+    return trimmed.slice(1, -1)
+  }
+
+  return trimmed
+}
+
+function parseFrontMatter(source: string): FrontMatter {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!match?.[1]) return {}
+
+  const result: FrontMatter = {}
+
+  for (const line of match[1].split(/\r?\n/)) {
+    if (!line.trim() || /^\s/.test(line)) continue
+
+    const separator = line.indexOf(':')
+    if (separator < 1) continue
+
+    result[line.slice(0, separator).trim()] = cleanValue(
+      line.slice(separator + 1),
+    )
+  }
+
+  return result
+}
+
+async function filesWithin(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(directory, entry.name)
+
+      if (entry.isDirectory()) return filesWithin(path)
+      if (entry.isFile()) return [path]
+      return []
+    }),
+  )
+
+  return nested.flat()
+}
+
+async function loadChannelItems(): Promise<ChannelContentItem[]> {
+  const files = (await filesWithin(channelsDirectory)).filter((file) =>
+    file.endsWith('.md'),
+  )
+
+  return Promise.all(
+    files.map(async (file) => {
+      const source = await readFile(file, 'utf8')
+      const frontMatter = parseFrontMatter(source)
+
+      return {
+        ...frontMatter,
+        sort: frontMatter.sort ? Number(frontMatter.sort) : 0,
+        path: relative(repositoryRoot, file),
+      } as ChannelContentItem
+    }),
+  )
+}
+
+function publicAssetPath(image: string): string | null {
+  const value = image.trim()
+  if (!value || /^https?:\/\//i.test(value)) return null
+
+  const pathname = value.split(/[?#]/)[0] ?? ''
+  if (!pathname.startsWith('/')) return null
+
+  return pathname.slice(1)
+}
+
+async function main(): Promise<void> {
+  const [items, publicFiles] = await Promise.all([
+    loadChannelItems(),
+    filesWithin(publicDirectory),
+  ])
+  const assets = new Set(
+    publicFiles.map((file) => relative(publicDirectory, file).replaceAll('\\', '/')),
+  )
+  const channels = resolveChannels(items)
+  const missing: Array<{ location: string; image: string }> = []
+  let checked = 0
+
+  function inspect(location: string, image: string): void {
+    const asset = publicAssetPath(image)
+    if (!asset) return
+
+    checked += 1
+    if (!assets.has(asset)) missing.push({ location, image })
+  }
+
+  for (const channel of channels) {
+    inspect(channel.channelKey, channel.image)
+
+    for (const tab of channel.tabs) {
+      inspect(`${channel.channelKey}/${tab.tabKey}`, tab.image)
+    }
+  }
+
+  console.log(
+    `Channel artwork audit checked ${checked} local image references across ${channels.length} channels.`,
+  )
+
+  if (!missing.length) {
+    console.log('All resolved channel and tab artwork exists in public/.')
+    return
+  }
+
+  console.warn(`Missing ${missing.length} resolved channel or tab image(s):`)
+  for (const entry of missing) {
+    console.warn(`- ${entry.location}: ${entry.image}`)
+  }
+
+  if (strict) process.exitCode = 1
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyChannelContent.ts
+++ b/utils/scripts/verifyChannelContent.ts
@@ -108,30 +108,10 @@ function addError(
   errors.push(`${document.file}: ${message}`)
 }
 
-function validateDocument(
+function validateAccess(
   errors: string[],
   document: NavigationDocument,
 ): void {
-  if (!document.contentType) addError(errors, document, 'missing contentType')
-  if (!document.channelKey) addError(errors, document, 'missing channelKey')
-  if (!['channel', 'tab', 'page'].includes(document.contentType)) {
-    addError(errors, document, `invalid contentType ${document.contentType}`)
-  }
-  if (
-    document.channelKey &&
-    !navigationKeyPattern.test(document.channelKey)
-  ) {
-    addError(errors, document, 'channelKey must use lowercase kebab-case')
-  }
-  if (document.tabKey && !navigationKeyPattern.test(document.tabKey)) {
-    addError(errors, document, 'tabKey must use lowercase kebab-case')
-  }
-  if (
-    document.defaultTab &&
-    !navigationKeyPattern.test(document.defaultTab)
-  ) {
-    addError(errors, document, 'defaultTab must use lowercase kebab-case')
-  }
   if (document.requiredRole && !allowedRoles.has(document.requiredRole)) {
     addError(errors, document, `unknown requiredRole ${document.requiredRole}`)
   }
@@ -147,6 +127,44 @@ function validateDocument(
   }
 }
 
+function validateKey(
+  errors: string[],
+  document: NavigationDocument,
+  label: string,
+  value: string,
+): void {
+  if (value && !navigationKeyPattern.test(value)) {
+    addError(errors, document, `${label} must use lowercase kebab-case`)
+  }
+}
+
+function validateChannelDocument(
+  errors: string[],
+  document: NavigationDocument,
+): void {
+  if (!document.contentType) addError(errors, document, 'missing contentType')
+  if (!document.channelKey) addError(errors, document, 'missing channelKey')
+  if (!['channel', 'tab'].includes(document.contentType)) {
+    addError(errors, document, `invalid contentType ${document.contentType}`)
+  }
+  validateKey(errors, document, 'channelKey', document.channelKey)
+  validateKey(errors, document, 'tabKey', document.tabKey)
+  validateKey(errors, document, 'defaultTab', document.defaultTab)
+  validateAccess(errors, document)
+}
+
+function validatePageDocument(
+  errors: string[],
+  document: NavigationDocument,
+): void {
+  if (document.contentType && document.contentType !== 'page') {
+    addError(errors, document, `unexpected page contentType ${document.contentType}`)
+  }
+  validateKey(errors, document, 'channelKey', document.channelKey)
+  validateKey(errors, document, 'tabKey', document.tabKey)
+  validateAccess(errors, document)
+}
+
 async function main(): Promise<void> {
   const documents = await Promise.all(
     (await markdownFiles(channelsDirectory)).map(readDocument),
@@ -160,7 +178,7 @@ async function main(): Promise<void> {
   const tabsByLocation = new Map<string, NavigationDocument>()
   const tabsByChannelRoute = new Map<string, NavigationDocument[]>()
 
-  for (const document of documents) validateDocument(errors, document)
+  for (const document of documents) validateChannelDocument(errors, document)
 
   for (const channel of channels) {
     if (!channel.defaultTab) addError(errors, channel, 'missing defaultTab')
@@ -222,7 +240,7 @@ async function main(): Promise<void> {
   const pageDocuments = await Promise.all(pageFiles.map(readDocument))
   let placedPages = 0
   for (const page of pageDocuments) {
-    validateDocument(errors, page)
+    validatePageDocument(errors, page)
     if (!page.channelKey && !page.tabKey) continue
     placedPages += 1
     if (!page.channelKey || !page.tabKey) {

--- a/utils/scripts/verifyChannelContent.ts
+++ b/utils/scripts/verifyChannelContent.ts
@@ -25,6 +25,7 @@ const expectedChannels = [
   'admin',
 ]
 
+const navigationKeyPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const scriptDirectory = dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = resolve(scriptDirectory, '../..')
 const contentDirectory = resolve(repositoryRoot, 'content')
@@ -95,8 +96,27 @@ async function readDocument(file: string): Promise<NavigationDocument> {
   }
 }
 
-function addError(errors: string[], document: NavigationDocument, message: string) {
+function addError(
+  errors: string[],
+  document: NavigationDocument,
+  message: string,
+) {
   errors.push(`${document.file}: ${message}`)
+}
+
+function validateKey(
+  errors: string[],
+  document: NavigationDocument,
+  label: string,
+  value: string,
+) {
+  if (value && !navigationKeyPattern.test(value)) {
+    addError(
+      errors,
+      document,
+      `${label} must be lowercase kebab-case for shareable URLs: ${value}`,
+    )
+  }
 }
 
 async function main() {
@@ -107,8 +127,11 @@ async function main() {
     (document) => document.contentType === 'channel',
   )
   const tabs = documents.filter((document) => document.contentType === 'tab')
-  const channelsByKey = new Map(channels.map((channel) => [channel.channelKey, channel]))
+  const channelsByKey = new Map(
+    channels.map((channel) => [channel.channelKey, channel]),
+  )
   const tabsByLocation = new Map<string, NavigationDocument>()
+  const tabsByChannelRoute = new Map<string, NavigationDocument[]>()
 
   for (const document of documents) {
     if (!document.contentType) {
@@ -122,12 +145,16 @@ async function main() {
     if (!['channel', 'tab'].includes(document.contentType)) {
       addError(errors, document, `invalid contentType ${document.contentType}`)
     }
+
+    validateKey(errors, document, 'channelKey', document.channelKey)
   }
 
   for (const channel of channels) {
     if (!channel.defaultTab) {
       addError(errors, channel, 'missing defaultTab')
     }
+
+    validateKey(errors, channel, 'defaultTab', channel.defaultTab)
 
     if (!channel.route.startsWith('/')) {
       addError(errors, channel, 'route must start with /')
@@ -142,7 +169,11 @@ async function main() {
 
   for (const channel of channels) {
     if (!expectedChannels.includes(channel.channelKey)) {
-      addError(errors, channel, `unexpected top-level channel ${channel.channelKey}`)
+      addError(
+        errors,
+        channel,
+        `unexpected top-level channel ${channel.channelKey}`,
+      )
     }
   }
 
@@ -151,6 +182,8 @@ async function main() {
       addError(errors, tab, 'missing tabKey')
       continue
     }
+
+    validateKey(errors, tab, 'tabKey', tab.tabKey)
 
     if (!channelsByKey.has(tab.channelKey)) {
       addError(errors, tab, `unknown parent channel ${tab.channelKey}`)
@@ -168,6 +201,11 @@ async function main() {
     } else {
       tabsByLocation.set(location, tab)
     }
+
+    const routeLocation = `${tab.channelKey}:${tab.route}`
+    const routeTabs = tabsByChannelRoute.get(routeLocation) ?? []
+    routeTabs.push(tab)
+    tabsByChannelRoute.set(routeLocation, routeTabs)
   }
 
   for (const channel of channels) {
@@ -180,7 +218,9 @@ async function main() {
 
   for (const [slug, placement] of Object.entries(PROJECT_PLACEMENTS)) {
     if (!channelsByKey.has(placement.channelKey)) {
-      errors.push(`${slug}: project placement uses unknown channel ${placement.channelKey}`)
+      errors.push(
+        `${slug}: project placement uses unknown channel ${placement.channelKey}`,
+      )
     }
 
     const location = `${placement.channelKey}/${placement.tabKey}`
@@ -205,21 +245,30 @@ async function main() {
       continue
     }
 
+    validateKey(errors, page, 'channelKey', page.channelKey)
+    validateKey(errors, page, 'tabKey', page.tabKey)
+
     const location = `${page.channelKey}/${page.tabKey}`
     if (!tabsByLocation.has(location)) {
       addError(errors, page, `references unknown tab ${location}`)
     }
   }
 
+  const sharedRouteGroups = Array.from(tabsByChannelRoute.values()).filter(
+    (routeTabs) => routeTabs.length > 1,
+  )
+
   if (errors.length) {
-    console.error(`Channel content contract failed with ${errors.length} error(s):`)
+    console.error(
+      `Channel content contract failed with ${errors.length} error(s):`,
+    )
     for (const error of errors) console.error(`- ${error}`)
     process.exitCode = 1
     return
   }
 
   console.log(
-    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements.`,
+    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements, ${sharedRouteGroups.length} shared-route tab groups using ?tab= addressing.`,
   )
 }
 

--- a/utils/scripts/verifyChannelContent.ts
+++ b/utils/scripts/verifyChannelContent.ts
@@ -1,0 +1,229 @@
+// /utils/scripts/verifyChannelContent.ts
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { PROJECT_PLACEMENTS } from '@/utils/projectPlacements'
+
+type FrontMatter = Record<string, string>
+
+type NavigationDocument = {
+  file: string
+  contentType: string
+  channelKey: string
+  tabKey: string
+  defaultTab: string
+  route: string
+}
+
+const expectedChannels = [
+  'home',
+  'plan',
+  'build',
+  'play',
+  'lab',
+  'sanctuary',
+  'admin',
+]
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const contentDirectory = resolve(repositoryRoot, 'content')
+const channelsDirectory = resolve(contentDirectory, 'channels')
+
+function cleanValue(value: string): string {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+
+  if (
+    (quote === "'" || quote === '"') &&
+    trimmed.length >= 2 &&
+    trimmed.endsWith(quote)
+  ) {
+    return trimmed.slice(1, -1)
+  }
+
+  return trimmed
+}
+
+function parseFrontMatter(source: string): FrontMatter {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!match?.[1]) return {}
+
+  const result: FrontMatter = {}
+
+  for (const line of match[1].split(/\r?\n/)) {
+    if (!line.trim() || /^\s/.test(line)) continue
+
+    const separator = line.indexOf(':')
+    if (separator < 1) continue
+
+    const key = line.slice(0, separator).trim()
+    const value = line.slice(separator + 1)
+    result[key] = cleanValue(value)
+  }
+
+  return result
+}
+
+async function markdownFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(directory, entry.name)
+
+      if (entry.isDirectory()) return markdownFiles(path)
+      if (entry.isFile() && entry.name.endsWith('.md')) return [path]
+
+      return []
+    }),
+  )
+
+  return nested.flat()
+}
+
+async function readDocument(file: string): Promise<NavigationDocument> {
+  const source = await readFile(file, 'utf8')
+  const frontMatter = parseFrontMatter(source)
+
+  return {
+    file: relative(repositoryRoot, file),
+    contentType: frontMatter.contentType ?? '',
+    channelKey: frontMatter.channelKey ?? '',
+    tabKey: frontMatter.tabKey ?? '',
+    defaultTab: frontMatter.defaultTab ?? '',
+    route: frontMatter.route ?? '',
+  }
+}
+
+function addError(errors: string[], document: NavigationDocument, message: string) {
+  errors.push(`${document.file}: ${message}`)
+}
+
+async function main() {
+  const channelFiles = await markdownFiles(channelsDirectory)
+  const documents = await Promise.all(channelFiles.map(readDocument))
+  const errors: string[] = []
+  const channels = documents.filter(
+    (document) => document.contentType === 'channel',
+  )
+  const tabs = documents.filter((document) => document.contentType === 'tab')
+  const channelsByKey = new Map(channels.map((channel) => [channel.channelKey, channel]))
+  const tabsByLocation = new Map<string, NavigationDocument>()
+
+  for (const document of documents) {
+    if (!document.contentType) {
+      addError(errors, document, 'missing contentType')
+    }
+
+    if (!document.channelKey) {
+      addError(errors, document, 'missing channelKey')
+    }
+
+    if (!['channel', 'tab'].includes(document.contentType)) {
+      addError(errors, document, `invalid contentType ${document.contentType}`)
+    }
+  }
+
+  for (const channel of channels) {
+    if (!channel.defaultTab) {
+      addError(errors, channel, 'missing defaultTab')
+    }
+
+    if (!channel.route.startsWith('/')) {
+      addError(errors, channel, 'route must start with /')
+    }
+  }
+
+  for (const expected of expectedChannels) {
+    if (!channelsByKey.has(expected)) {
+      errors.push(`missing required channel ${expected}`)
+    }
+  }
+
+  for (const channel of channels) {
+    if (!expectedChannels.includes(channel.channelKey)) {
+      addError(errors, channel, `unexpected top-level channel ${channel.channelKey}`)
+    }
+  }
+
+  for (const tab of tabs) {
+    if (!tab.tabKey) {
+      addError(errors, tab, 'missing tabKey')
+      continue
+    }
+
+    if (!channelsByKey.has(tab.channelKey)) {
+      addError(errors, tab, `unknown parent channel ${tab.channelKey}`)
+    }
+
+    if (!tab.route.startsWith('/')) {
+      addError(errors, tab, 'route must start with /')
+    }
+
+    const location = `${tab.channelKey}/${tab.tabKey}`
+    const duplicate = tabsByLocation.get(location)
+
+    if (duplicate) {
+      errors.push(`${tab.file}: duplicates ${location} from ${duplicate.file}`)
+    } else {
+      tabsByLocation.set(location, tab)
+    }
+  }
+
+  for (const channel of channels) {
+    const location = `${channel.channelKey}/${channel.defaultTab}`
+
+    if (channel.defaultTab && !tabsByLocation.has(location)) {
+      addError(errors, channel, `defaultTab does not exist: ${location}`)
+    }
+  }
+
+  for (const [slug, placement] of Object.entries(PROJECT_PLACEMENTS)) {
+    if (!channelsByKey.has(placement.channelKey)) {
+      errors.push(`${slug}: project placement uses unknown channel ${placement.channelKey}`)
+    }
+
+    const location = `${placement.channelKey}/${placement.tabKey}`
+    if (!tabsByLocation.has(location)) {
+      errors.push(`${slug}: project placement uses unknown tab ${location}`)
+    }
+  }
+
+  const pageFiles = (await markdownFiles(contentDirectory)).filter(
+    (file) => !file.startsWith(channelsDirectory),
+  )
+  const pageDocuments = await Promise.all(pageFiles.map(readDocument))
+  let placedPages = 0
+
+  for (const page of pageDocuments) {
+    if (!page.channelKey && !page.tabKey) continue
+
+    placedPages += 1
+
+    if (!page.channelKey || !page.tabKey) {
+      addError(errors, page, 'channelKey and tabKey must be declared together')
+      continue
+    }
+
+    const location = `${page.channelKey}/${page.tabKey}`
+    if (!tabsByLocation.has(location)) {
+      addError(errors, page, `references unknown tab ${location}`)
+    }
+  }
+
+  if (errors.length) {
+    console.error(`Channel content contract failed with ${errors.length} error(s):`)
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements.`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyChannelContent.ts
+++ b/utils/scripts/verifyChannelContent.ts
@@ -13,6 +13,7 @@ type NavigationDocument = {
   tabKey: string
   defaultTab: string
   route: string
+  requiredPermission: string
 }
 
 const expectedChannels = [
@@ -24,7 +25,13 @@ const expectedChannels = [
   'sanctuary',
   'admin',
 ]
-
+const allowedPermissions = new Set([
+  'authenticated',
+  'member',
+  'family',
+  'mature',
+  'admin',
+])
 const navigationKeyPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const scriptDirectory = dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = resolve(scriptDirectory, '../..')
@@ -93,6 +100,7 @@ async function readDocument(file: string): Promise<NavigationDocument> {
     tabKey: frontMatter.tabKey ?? '',
     defaultTab: frontMatter.defaultTab ?? '',
     route: frontMatter.route ?? '',
+    requiredPermission: (frontMatter.requiredPermission ?? '').toLowerCase(),
   }
 }
 
@@ -115,6 +123,22 @@ function validateKey(
       errors,
       document,
       `${label} must be lowercase kebab-case for shareable URLs: ${value}`,
+    )
+  }
+}
+
+function validatePermission(
+  errors: string[],
+  document: NavigationDocument,
+): void {
+  if (
+    document.requiredPermission &&
+    !allowedPermissions.has(document.requiredPermission)
+  ) {
+    addError(
+      errors,
+      document,
+      `unknown requiredPermission ${document.requiredPermission}; expected one of ${Array.from(allowedPermissions).join(', ')}`,
     )
   }
 }
@@ -147,6 +171,7 @@ async function main() {
     }
 
     validateKey(errors, document, 'channelKey', document.channelKey)
+    validatePermission(errors, document)
   }
 
   for (const channel of channels) {
@@ -236,6 +261,8 @@ async function main() {
   let placedPages = 0
 
   for (const page of pageDocuments) {
+    validatePermission(errors, page)
+
     if (!page.channelKey && !page.tabKey) continue
 
     placedPages += 1
@@ -268,7 +295,7 @@ async function main() {
   }
 
   console.log(
-    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements, ${sharedRouteGroups.length} shared-route tab groups using ?tab= addressing.`,
+    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements, ${sharedRouteGroups.length} shared-route tab groups using ?tab= addressing, and ${allowedPermissions.size} supported capability names.`,
   )
 }
 

--- a/utils/scripts/verifyChannelContent.ts
+++ b/utils/scripts/verifyChannelContent.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url'
 import { PROJECT_PLACEMENTS } from '@/utils/projectPlacements'
 
 type FrontMatter = Record<string, string>
-
 type NavigationDocument = {
   file: string
   contentType: string
@@ -13,6 +12,7 @@ type NavigationDocument = {
   tabKey: string
   defaultTab: string
   route: string
+  requiredRole: string
   requiredPermission: string
 }
 
@@ -25,6 +25,17 @@ const expectedChannels = [
   'sanctuary',
   'admin',
 ]
+const allowedRoles = new Set([
+  'SYSTEM',
+  'USER',
+  'ASSISTANT',
+  'ADMIN',
+  'GUEST',
+  'BOT',
+  'DESIGNER',
+  'CHILD',
+  'FAMILY',
+])
 const allowedPermissions = new Set([
   'authenticated',
   'member',
@@ -41,16 +52,9 @@ const channelsDirectory = resolve(contentDirectory, 'channels')
 function cleanValue(value: string): string {
   const trimmed = value.trim()
   const quote = trimmed[0]
-
-  if (
-    (quote === "'" || quote === '"') &&
-    trimmed.length >= 2 &&
-    trimmed.endsWith(quote)
-  ) {
-    return trimmed.slice(1, -1)
-  }
-
-  return trimmed
+  return (quote === "'" || quote === '"') && trimmed.endsWith(quote)
+    ? trimmed.slice(1, -1)
+    : trimmed
 }
 
 function parseFrontMatter(source: string): FrontMatter {
@@ -58,41 +62,32 @@ function parseFrontMatter(source: string): FrontMatter {
   if (!match?.[1]) return {}
 
   const result: FrontMatter = {}
-
   for (const line of match[1].split(/\r?\n/)) {
     if (!line.trim() || /^\s/.test(line)) continue
-
     const separator = line.indexOf(':')
     if (separator < 1) continue
-
-    const key = line.slice(0, separator).trim()
-    const value = line.slice(separator + 1)
-    result[key] = cleanValue(value)
+    result[line.slice(0, separator).trim()] = cleanValue(
+      line.slice(separator + 1),
+    )
   }
-
   return result
 }
 
 async function markdownFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true })
-  const nested = await Promise.all(
-    entries.map(async (entry) => {
-      const path = resolve(directory, entry.name)
-
-      if (entry.isDirectory()) return markdownFiles(path)
-      if (entry.isFile() && entry.name.endsWith('.md')) return [path]
-
-      return []
-    }),
-  )
-
-  return nested.flat()
+  return (
+    await Promise.all(
+      entries.map(async (entry) => {
+        const path = resolve(directory, entry.name)
+        if (entry.isDirectory()) return markdownFiles(path)
+        return entry.isFile() && entry.name.endsWith('.md') ? [path] : []
+      }),
+    )
+  ).flat()
 }
 
 async function readDocument(file: string): Promise<NavigationDocument> {
-  const source = await readFile(file, 'utf8')
-  const frontMatter = parseFrontMatter(source)
-
+  const frontMatter = parseFrontMatter(await readFile(file, 'utf8'))
   return {
     file: relative(repositoryRoot, file),
     contentType: frontMatter.contentType ?? '',
@@ -100,6 +95,7 @@ async function readDocument(file: string): Promise<NavigationDocument> {
     tabKey: frontMatter.tabKey ?? '',
     defaultTab: frontMatter.defaultTab ?? '',
     route: frontMatter.route ?? '',
+    requiredRole: (frontMatter.requiredRole ?? '').toUpperCase(),
     requiredPermission: (frontMatter.requiredPermission ?? '').toLowerCase(),
   }
 }
@@ -108,29 +104,37 @@ function addError(
   errors: string[],
   document: NavigationDocument,
   message: string,
-) {
+): void {
   errors.push(`${document.file}: ${message}`)
 }
 
-function validateKey(
-  errors: string[],
-  document: NavigationDocument,
-  label: string,
-  value: string,
-) {
-  if (value && !navigationKeyPattern.test(value)) {
-    addError(
-      errors,
-      document,
-      `${label} must be lowercase kebab-case for shareable URLs: ${value}`,
-    )
-  }
-}
-
-function validatePermission(
+function validateDocument(
   errors: string[],
   document: NavigationDocument,
 ): void {
+  if (!document.contentType) addError(errors, document, 'missing contentType')
+  if (!document.channelKey) addError(errors, document, 'missing channelKey')
+  if (!['channel', 'tab', 'page'].includes(document.contentType)) {
+    addError(errors, document, `invalid contentType ${document.contentType}`)
+  }
+  if (
+    document.channelKey &&
+    !navigationKeyPattern.test(document.channelKey)
+  ) {
+    addError(errors, document, 'channelKey must use lowercase kebab-case')
+  }
+  if (document.tabKey && !navigationKeyPattern.test(document.tabKey)) {
+    addError(errors, document, 'tabKey must use lowercase kebab-case')
+  }
+  if (
+    document.defaultTab &&
+    !navigationKeyPattern.test(document.defaultTab)
+  ) {
+    addError(errors, document, 'defaultTab must use lowercase kebab-case')
+  }
+  if (document.requiredRole && !allowedRoles.has(document.requiredRole)) {
+    addError(errors, document, `unknown requiredRole ${document.requiredRole}`)
+  }
   if (
     document.requiredPermission &&
     !allowedPermissions.has(document.requiredPermission)
@@ -138,68 +142,37 @@ function validatePermission(
     addError(
       errors,
       document,
-      `unknown requiredPermission ${document.requiredPermission}; expected one of ${Array.from(allowedPermissions).join(', ')}`,
+      `unknown requiredPermission ${document.requiredPermission}`,
     )
   }
 }
 
-async function main() {
-  const channelFiles = await markdownFiles(channelsDirectory)
-  const documents = await Promise.all(channelFiles.map(readDocument))
-  const errors: string[] = []
-  const channels = documents.filter(
-    (document) => document.contentType === 'channel',
+async function main(): Promise<void> {
+  const documents = await Promise.all(
+    (await markdownFiles(channelsDirectory)).map(readDocument),
   )
-  const tabs = documents.filter((document) => document.contentType === 'tab')
+  const errors: string[] = []
+  const channels = documents.filter((item) => item.contentType === 'channel')
+  const tabs = documents.filter((item) => item.contentType === 'tab')
   const channelsByKey = new Map(
     channels.map((channel) => [channel.channelKey, channel]),
   )
   const tabsByLocation = new Map<string, NavigationDocument>()
   const tabsByChannelRoute = new Map<string, NavigationDocument[]>()
 
-  for (const document of documents) {
-    if (!document.contentType) {
-      addError(errors, document, 'missing contentType')
-    }
-
-    if (!document.channelKey) {
-      addError(errors, document, 'missing channelKey')
-    }
-
-    if (!['channel', 'tab'].includes(document.contentType)) {
-      addError(errors, document, `invalid contentType ${document.contentType}`)
-    }
-
-    validateKey(errors, document, 'channelKey', document.channelKey)
-    validatePermission(errors, document)
-  }
+  for (const document of documents) validateDocument(errors, document)
 
   for (const channel of channels) {
-    if (!channel.defaultTab) {
-      addError(errors, channel, 'missing defaultTab')
-    }
-
-    validateKey(errors, channel, 'defaultTab', channel.defaultTab)
-
+    if (!channel.defaultTab) addError(errors, channel, 'missing defaultTab')
     if (!channel.route.startsWith('/')) {
       addError(errors, channel, 'route must start with /')
     }
-  }
-
-  for (const expected of expectedChannels) {
-    if (!channelsByKey.has(expected)) {
-      errors.push(`missing required channel ${expected}`)
-    }
-  }
-
-  for (const channel of channels) {
     if (!expectedChannels.includes(channel.channelKey)) {
-      addError(
-        errors,
-        channel,
-        `unexpected top-level channel ${channel.channelKey}`,
-      )
+      addError(errors, channel, `unexpected top-level channel ${channel.channelKey}`)
     }
+  }
+  for (const expected of expectedChannels) {
+    if (!channelsByKey.has(expected)) errors.push(`missing required channel ${expected}`)
   }
 
   for (const tab of tabs) {
@@ -207,20 +180,13 @@ async function main() {
       addError(errors, tab, 'missing tabKey')
       continue
     }
-
-    validateKey(errors, tab, 'tabKey', tab.tabKey)
-
     if (!channelsByKey.has(tab.channelKey)) {
       addError(errors, tab, `unknown parent channel ${tab.channelKey}`)
     }
-
-    if (!tab.route.startsWith('/')) {
-      addError(errors, tab, 'route must start with /')
-    }
+    if (!tab.route.startsWith('/')) addError(errors, tab, 'route must start with /')
 
     const location = `${tab.channelKey}/${tab.tabKey}`
     const duplicate = tabsByLocation.get(location)
-
     if (duplicate) {
       errors.push(`${tab.file}: duplicates ${location} from ${duplicate.file}`)
     } else {
@@ -235,7 +201,6 @@ async function main() {
 
   for (const channel of channels) {
     const location = `${channel.channelKey}/${channel.defaultTab}`
-
     if (channel.defaultTab && !tabsByLocation.has(location)) {
       addError(errors, channel, `defaultTab does not exist: ${location}`)
     }
@@ -243,14 +208,11 @@ async function main() {
 
   for (const [slug, placement] of Object.entries(PROJECT_PLACEMENTS)) {
     if (!channelsByKey.has(placement.channelKey)) {
-      errors.push(
-        `${slug}: project placement uses unknown channel ${placement.channelKey}`,
-      )
+      errors.push(`${slug}: unknown placement channel ${placement.channelKey}`)
     }
-
     const location = `${placement.channelKey}/${placement.tabKey}`
     if (!tabsByLocation.has(location)) {
-      errors.push(`${slug}: project placement uses unknown tab ${location}`)
+      errors.push(`${slug}: unknown placement tab ${location}`)
     }
   }
 
@@ -259,43 +221,32 @@ async function main() {
   )
   const pageDocuments = await Promise.all(pageFiles.map(readDocument))
   let placedPages = 0
-
   for (const page of pageDocuments) {
-    validatePermission(errors, page)
-
+    validateDocument(errors, page)
     if (!page.channelKey && !page.tabKey) continue
-
     placedPages += 1
-
     if (!page.channelKey || !page.tabKey) {
       addError(errors, page, 'channelKey and tabKey must be declared together')
       continue
     }
-
-    validateKey(errors, page, 'channelKey', page.channelKey)
-    validateKey(errors, page, 'tabKey', page.tabKey)
-
     const location = `${page.channelKey}/${page.tabKey}`
     if (!tabsByLocation.has(location)) {
       addError(errors, page, `references unknown tab ${location}`)
     }
   }
 
-  const sharedRouteGroups = Array.from(tabsByChannelRoute.values()).filter(
-    (routeTabs) => routeTabs.length > 1,
-  )
-
   if (errors.length) {
-    console.error(
-      `Channel content contract failed with ${errors.length} error(s):`,
-    )
+    console.error(`Channel content contract failed with ${errors.length} error(s):`)
     for (const error of errors) console.error(`- ${error}`)
     process.exitCode = 1
     return
   }
 
+  const sharedRouteGroups = Array.from(tabsByChannelRoute.values()).filter(
+    (routeTabs) => routeTabs.length > 1,
+  )
   console.log(
-    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements, ${sharedRouteGroups.length} shared-route tab groups using ?tab= addressing, and ${allowedPermissions.size} supported capability names.`,
+    `Channel content contract passed: ${channels.length} channels, ${tabs.length} tabs, ${placedPages} placed pages, ${Object.keys(PROJECT_PLACEMENTS).length} project placements, ${sharedRouteGroups.length} shared-route groups, ${allowedRoles.size} roles, and ${allowedPermissions.size} capabilities.`,
   )
 }
 

--- a/utils/scripts/verifyChannelResolver.ts
+++ b/utils/scripts/verifyChannelResolver.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import {
+  filterChannelsByRole,
+  resolveChannelLocation,
+  resolveChannels,
+  type ChannelContentItem,
+} from '@/stores/helpers/channelContent'
+
+const items: ChannelContentItem[] = [
+  {
+    contentType: 'channel',
+    channelKey: 'build',
+    dashboardKey: 'builder',
+    label: 'Build',
+    title: 'Build Workshop',
+    description: 'Create reusable things.',
+    icon: 'kind-icon:blueprint',
+    route: '/builder',
+    defaultTab: 'character',
+    sort: 20,
+    dottitip: 'Legacy Dotti line.',
+    amiTip: 'Parent Ami line.',
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'build',
+    tabKey: 'character',
+    dashboardKey: 'builder',
+    dashboardTab: 'character',
+    label: 'Characters',
+    route: '/builder',
+    sort: 10,
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'build',
+    tabKey: 'art',
+    dashboardKey: 'builder',
+    dashboardTab: 'art',
+    label: 'Art',
+    route: '/builder',
+    sort: 20,
+    amiTip: 'Tab Ami line.',
+  },
+  {
+    contentType: 'channel',
+    channelKey: 'home',
+    label: 'Home',
+    route: '/',
+    defaultTab: 'dashboard',
+    sort: 10,
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'home',
+    tabKey: 'dashboard',
+    label: 'Dashboard',
+    route: '/',
+    sort: 10,
+  },
+  {
+    contentType: 'channel',
+    channelKey: 'admin',
+    label: 'Admin',
+    route: '/admin',
+    defaultTab: 'queue',
+    sort: 30,
+    requiredRole: 'ADMIN',
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'admin',
+    tabKey: 'queue',
+    label: 'Queue',
+    route: '/admin',
+    sort: 10,
+    requiredRole: 'ADMIN',
+  },
+]
+
+const channels = resolveChannels(items)
+
+assert.deepEqual(
+  channels.map((channel) => channel.channelKey),
+  ['home', 'build', 'admin'],
+  'channels should sort by numeric sort order',
+)
+
+const build = channels.find((channel) => channel.channelKey === 'build')
+assert.ok(build, 'build channel should resolve')
+assert.equal(build.defaultTab, 'character')
+assert.equal(build.tabs.length, 2)
+
+const character = build.tabs.find((tab) => tab.tabKey === 'character')
+const art = build.tabs.find((tab) => tab.tabKey === 'art')
+assert.ok(character, 'character tab should resolve')
+assert.ok(art, 'art tab should resolve')
+
+assert.equal(
+  character.description,
+  build.description,
+  'tab should inherit channel description',
+)
+assert.equal(character.icon, build.icon, 'tab should inherit channel icon')
+assert.equal(
+  character.dottiTip,
+  'Legacy Dotti line.',
+  'legacy lowercase dottitip should remain supported',
+)
+assert.equal(
+  character.amiTip,
+  'Parent Ami line.',
+  'tab should inherit parent Ami dialogue',
+)
+assert.equal(art.amiTip, 'Tab Ami line.', 'tab Ami dialogue should override parent')
+assert.equal(
+  character.image,
+  '/images/dashboard-tabs/builder/character.webp',
+  'legacy dashboard metadata should provide the transitional image fallback',
+)
+
+const explicitArt = resolveChannelLocation(channels, {
+  channelKey: 'build',
+  tabKey: 'art',
+  path: '/builder',
+})
+assert.equal(explicitArt?.channel.channelKey, 'build')
+assert.equal(explicitArt?.tab?.tabKey, 'art')
+
+const legacyCharacter = resolveChannelLocation(channels, {
+  dashboardKey: 'builder',
+  dashboardTab: 'character',
+  path: '/builder',
+})
+assert.equal(legacyCharacter?.channel.channelKey, 'build')
+assert.equal(legacyCharacter?.tab?.tabKey, 'character')
+
+const sharedRouteDefault = resolveChannelLocation(channels, {
+  channelKey: 'build',
+  path: '/builder',
+})
+assert.equal(
+  sharedRouteDefault?.tab?.tabKey,
+  'character',
+  'shared route without an explicit tab should use the channel default',
+)
+
+const userChannels = filterChannelsByRole(channels, 'USER')
+assert.deepEqual(
+  userChannels.map((channel) => channel.channelKey),
+  ['home', 'build'],
+  'non-admin users should not receive the Admin channel',
+)
+
+const adminChannels = filterChannelsByRole(channels, 'ADMIN')
+assert.deepEqual(
+  adminChannels.map((channel) => channel.channelKey),
+  ['home', 'build', 'admin'],
+  'administrators should receive all channels',
+)
+
+console.log(
+  `Channel resolver contract passed: ${channels.length} channels, ${build.tabs.length} shared-route Build tabs, dialogue inheritance and role filtering verified.`,
+)

--- a/utils/scripts/verifyChannelResolver.ts
+++ b/utils/scripts/verifyChannelResolver.ts
@@ -5,6 +5,10 @@ import {
   resolveChannels,
   type ChannelContentItem,
 } from '@/stores/helpers/channelContent'
+import {
+  filterChannelsByPermission,
+  navigationPermissions,
+} from '@/stores/helpers/navigationAccess'
 
 const items: ChannelContentItem[] = [
   {
@@ -41,6 +45,7 @@ const items: ChannelContentItem[] = [
     route: '/builder',
     sort: 20,
     amiTip: 'Tab Ami line.',
+    requiredPermission: 'member',
   },
   {
     contentType: 'channel',
@@ -152,13 +157,71 @@ assert.deepEqual(
   'non-admin users should not receive the Admin channel',
 )
 
+const guestAccess = {
+  role: 'USER',
+  permissions: navigationPermissions({
+    isLoggedIn: false,
+    isMember: false,
+    isFamily: false,
+    showMature: false,
+    isAdmin: false,
+  }),
+  isAdmin: false,
+}
+const guestChannels = filterChannelsByPermission(userChannels, guestAccess)
+assert.deepEqual(
+  guestChannels
+    .find((channel) => channel.channelKey === 'build')
+    ?.tabs.map((tab) => tab.tabKey),
+  ['character'],
+  'guests should not receive member-gated tabs',
+)
+
+const memberAccess = {
+  role: 'USER',
+  permissions: navigationPermissions({
+    isLoggedIn: true,
+    isMember: true,
+    isFamily: false,
+    showMature: false,
+    isAdmin: false,
+  }),
+  isAdmin: false,
+}
+const memberChannels = filterChannelsByPermission(userChannels, memberAccess)
+assert.deepEqual(
+  memberChannels
+    .find((channel) => channel.channelKey === 'build')
+    ?.tabs.map((tab) => tab.tabKey),
+  ['character', 'art'],
+  'members should receive member-gated tabs',
+)
+
 const adminChannels = filterChannelsByRole(channels, 'ADMIN')
 assert.deepEqual(
   adminChannels.map((channel) => channel.channelKey),
   ['home', 'build', 'admin'],
-  'administrators should receive all channels',
+  'administrators should receive all role-gated channels',
+)
+const adminAccess = {
+  role: 'ADMIN',
+  permissions: navigationPermissions({
+    isLoggedIn: true,
+    isMember: false,
+    isFamily: false,
+    showMature: false,
+    isAdmin: true,
+  }),
+  isAdmin: true,
+}
+assert.deepEqual(
+  filterChannelsByPermission(adminChannels, adminAccess)
+    .find((channel) => channel.channelKey === 'build')
+    ?.tabs.map((tab) => tab.tabKey),
+  ['character', 'art'],
+  'administrators should bypass capability gates',
 )
 
 console.log(
-  `Channel resolver contract passed: ${channels.length} channels, ${build.tabs.length} shared-route Build tabs, dialogue inheritance and role filtering verified.`,
+  `Channel resolver contract passed: ${channels.length} channels, ${build.tabs.length} shared-route Build tabs, dialogue inheritance, role filtering, and capability gates verified.`,
 )

--- a/utils/scripts/verifyNavigationRouteAccess.ts
+++ b/utils/scripts/verifyNavigationRouteAccess.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict'
+import {
+  filterChannelsByRole,
+  resolveChannels,
+  type ChannelContentItem,
+} from '@/stores/helpers/channelContent'
+import {
+  filterChannelsByPermission,
+  navigationPermissions,
+} from '@/stores/helpers/navigationAccess'
+import { evaluateNavigationRouteAccess } from '@/stores/helpers/navigationRouteAccess'
+
+const items: ChannelContentItem[] = [
+  {
+    contentType: 'channel',
+    channelKey: 'home',
+    label: 'Home',
+    route: '/',
+    defaultTab: 'dashboard',
+    sort: 10,
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'home',
+    tabKey: 'dashboard',
+    label: 'Dashboard',
+    route: '/',
+    sort: 10,
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'home',
+    tabKey: 'achievements',
+    label: 'Achievements',
+    route: '/achievements',
+    sort: 20,
+    requiredPermission: 'authenticated',
+  },
+  {
+    contentType: 'channel',
+    channelKey: 'build',
+    label: 'Build',
+    route: '/builder',
+    defaultTab: 'character',
+    sort: 20,
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'build',
+    tabKey: 'character',
+    label: 'Character',
+    route: '/builder',
+    sort: 10,
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'build',
+    tabKey: 'advanced',
+    label: 'Advanced',
+    route: '/builder',
+    sort: 20,
+    requiredPermission: 'member',
+  },
+  {
+    contentType: 'channel',
+    channelKey: 'admin',
+    label: 'Admin',
+    route: '/navigation-health',
+    defaultTab: 'navigation-health',
+    sort: 30,
+    requiredRole: 'ADMIN',
+  },
+  {
+    contentType: 'tab',
+    channelKey: 'admin',
+    tabKey: 'navigation-health',
+    label: 'Navigation Health',
+    route: '/navigation-health',
+    sort: 10,
+    requiredRole: 'ADMIN',
+  },
+]
+
+const channels = resolveChannels(items)
+const guestRoleChannels = filterChannelsByRole(channels, 'GUEST')
+const guestChannels = filterChannelsByPermission(guestRoleChannels, {
+  role: 'GUEST',
+  permissions: navigationPermissions({
+    isLoggedIn: false,
+    isMember: false,
+    isFamily: false,
+    showMature: false,
+    isAdmin: false,
+  }),
+  isAdmin: false,
+})
+const userRoleChannels = filterChannelsByRole(channels, 'USER')
+const userChannels = filterChannelsByPermission(userRoleChannels, {
+  role: 'USER',
+  permissions: navigationPermissions({
+    isLoggedIn: true,
+    isMember: false,
+    isFamily: false,
+    showMature: false,
+    isAdmin: false,
+  }),
+  isAdmin: false,
+})
+const memberChannels = filterChannelsByPermission(userRoleChannels, {
+  role: 'USER',
+  permissions: navigationPermissions({
+    isLoggedIn: true,
+    isMember: true,
+    isFamily: false,
+    showMature: false,
+    isAdmin: false,
+  }),
+  isAdmin: false,
+})
+const adminRoleChannels = filterChannelsByRole(channels, 'ADMIN')
+const adminChannels = filterChannelsByPermission(adminRoleChannels, {
+  role: 'ADMIN',
+  permissions: navigationPermissions({
+    isLoggedIn: true,
+    isMember: false,
+    isFamily: false,
+    showMature: false,
+    isAdmin: true,
+  }),
+  isAdmin: true,
+})
+
+assert.deepEqual(
+  evaluateNavigationRouteAccess(channels, guestChannels, {
+    path: '/outside-navigation',
+  }),
+  {
+    matched: false,
+    allowed: true,
+    requested: null,
+    requiredRole: '',
+    requiredPermission: '',
+  },
+  'unrelated routes should pass through untouched',
+)
+
+const publicHome = evaluateNavigationRouteAccess(channels, guestChannels, {
+  path: '/',
+})
+assert.equal(publicHome.matched, true)
+assert.equal(publicHome.allowed, true)
+
+const guestAchievements = evaluateNavigationRouteAccess(
+  channels,
+  guestChannels,
+  { path: '/achievements' },
+)
+assert.equal(guestAchievements.matched, true)
+assert.equal(guestAchievements.allowed, false)
+assert.equal(guestAchievements.requiredPermission, 'authenticated')
+
+const userAchievements = evaluateNavigationRouteAccess(
+  channels,
+  userChannels,
+  { path: '/achievements' },
+)
+assert.equal(userAchievements.allowed, true)
+
+const guestAdvanced = evaluateNavigationRouteAccess(channels, guestChannels, {
+  path: '/builder',
+  tabKey: 'advanced',
+})
+assert.equal(guestAdvanced.allowed, false)
+assert.equal(guestAdvanced.requiredPermission, 'member')
+
+const userAdvanced = evaluateNavigationRouteAccess(channels, userChannels, {
+  path: '/builder',
+  tabKey: 'advanced',
+})
+assert.equal(userAdvanced.allowed, false)
+
+const memberAdvanced = evaluateNavigationRouteAccess(
+  channels,
+  memberChannels,
+  { path: '/builder', tabKey: 'advanced' },
+)
+assert.equal(memberAdvanced.allowed, true)
+
+const userAdmin = evaluateNavigationRouteAccess(channels, userChannels, {
+  path: '/navigation-health',
+})
+assert.equal(userAdmin.allowed, false)
+assert.equal(userAdmin.requiredRole, 'ADMIN')
+
+const adminAdmin = evaluateNavigationRouteAccess(channels, adminChannels, {
+  path: '/navigation-health',
+})
+assert.equal(adminAdmin.allowed, true)
+
+console.log(
+  'Navigation route access contract passed: unrelated, public, authenticated, member, shared-route, and admin destinations verified.',
+)


### PR DESCRIPTION
## What this PR does

This moves Kind Robots navigation from overlapping TypeScript registries into one Nuxt Content channel graph.

The public information architecture is now:

- Home
- Plan
- Build
- Play
- Lab
- Sanctuary
- Admin

A channel is defined by `content/channels/<channelKey>/index.md`. Each tab is defined by one child Markdown file. `channelKey` and `tabKey` remain the canonical names.

## Content architecture

- Added an isolated Nuxt Content `channels` collection backed by `content/channels/**/*.md` and excluded it from ordinary public page routing.
- Added parent-channel inheritance for labels, room copy, descriptions, icons, artwork, cards, tutorials, permissions, loading copy, and dialogue.
- Preserved `dottiTip` and `amiTip` as first-class fields, including legacy `dottitip` and `amitip` compatibility.
- Made legacy `dashboardKey` / `dashboardTab` values opt-in compatibility adapters rather than the public organization.
- Removed misleading parent dashboard inheritance from diverse channels such as Lab, Sanctuary, and Admin.
- Added a documented authoring contract in `docs/channel-content-authoring.md`.

## Navigation and routing

- Replaced separate channel and tab dropdowns with one combined nested navigator.
- A channel row goes directly to its remembered or default tab.
- Child tabs expand through desktop hover or an explicit touch-friendly chevron.
- The former tab dropdown is now a read-only active-location banner.
- Tabs that intentionally share a route receive bookmarkable query addresses such as `/builder?tab=character` and `/builder?tab=art`.
- Shared-route selection survives refresh, browser history, copied links, and new sessions.
- Added canonical page activation in `pageStore`: content resolves the current channel/tab first, then the legacy dashboard shell is synchronized only as an adapter.
- Removed duplicate legacy-tab and workspace-sheet synchronization from the header, channel selector, and Builder.

## Access controls

- Typed `requiredRole` and `requiredPermission` in the Nuxt Content schema.
- Supported capability gates are `authenticated`, `member`, `family`, `mature`, and `admin`.
- Administrators bypass capability checks; role gates remain independent.
- Permission filtering promotes the first accessible tab when a configured default is hidden.
- Added a global client route guard so direct URLs obey the same role/capability visibility as the menu.
- Signed-out users are sent to Login with the original destination preserved.
- The existing post-login Dashboard redirect resumes the original gated channel/tab through session storage.
- Personal Achievements and Chats now use the real `authenticated` capability gate.

Server/API authorization remains the security boundary; the navigation guard provides consistent client routing and presentation.

## Builders, cards, and tutorials

- Build channel tabs now select the existing registered builder implementations.
- Workspace hand and sheet cards derive from channel-tab content.
- Tutorial flyer sections derive from channel/tab content, with the legacy tutorial registry retained only as fallback.
- Tutorial preference state no longer requires a static list of allowed tutorial channel keys.

## Project migration and operational tools

- Updated canonical Project placements to the new channel/tab organization.
- Added Admin → Project Placement at `/project-placement`.
  - Loads inactive Projects.
  - Applies the canonical placement map through the existing guarded PATCH endpoint.
  - Optionally repairs live URLs.
  - Reports updated, unchanged, missing, and per-slug failed rows without aborting the whole pass.
- Added Admin → Navigation Health at `/navigation-health`.
  - Shows the resolved graph, shared routes, role gates, compatibility adapters, and browser-detected broken artwork.

## Artwork handling

- Added a filesystem artwork audit for every resolved channel/tab image.
- The audit report is uploaded as a 14-day GitHub Actions artifact.
- The current graph reports missing legacy/conventional artwork paths rather than hiding them.
- Added a narrow client fallback: broken `/images/channels/` and `/images/dashboard-tabs/` artwork falls back to the known-good Kind Robots image instead of showing broken-image icons.

## Validation

The branch now runs:

- TypeScript Type Check
- Channel content contract
- Channel resolver contract
- Navigation route access contract
- Channel artwork audit
- Existing art-request and facet-alias contracts

These verify:

- required channels and unique tabs,
- valid defaults and placements,
- URL-safe keys,
- typed roles and capabilities,
- parent inheritance,
- Dotti/AMI compatibility,
- legacy aliases,
- shared-route behavior,
- role/capability filtering,
- direct-route access decisions,
- artwork coverage.

TypeScript, the facet smoke test, and the complete fast-contract suite all pass on the current head.

## Compatibility bridge

- Existing routes remain in place.
- Existing mature managers still receive legacy dashboard tab state.
- Existing builder registrations still own model-specific behavior.
- `dashboardHelper.ts`, `navCards.ts`, and `tutorialCards.ts` remain as compatibility fallbacks for surfaces not yet visually retired.
- Existing lowercase Dotti/AMI fields remain readable.

## Remaining work

- Run browser-level visual verification when a preview or local environment is available.
- Replace the generic artwork fallback with deliberate artwork for the missing paths listed by the CI artifact.
- Use Admin → Project Placement from an authenticated admin session to reconcile existing database rows.
- Continue shrinking the legacy dashboard/card/tutorial registries after each mature manager surface is visually confirmed.

The Vercel preview is still blocked by the account build-rate limit rather than a reported code failure.