### PR TITLE
Fix dead front page: remove case-insensitive content-column collision

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -72,8 +72,11 @@ const sharedNavigationSchema = z.object({
   tooltip: z.string().optional(),
   dottiTip: z.string().optional(),
   amiTip: z.string().optional(),
-  dottitip: z.string().optional(),
-  amitip: z.string().optional(),
+  // NOTE: SQLite column names are case-insensitive, so a lowercase `dottitip`/
+  // `amitip` field here collides with `dottiTip`/`amiTip` above and makes the
+  // collection's CREATE TABLE fail ("duplicate column name"), which leaves the
+  // content tables uncreated and 500s every page. Keep a single canonical
+  // camelCase key; legacy lowercase frontmatter is normalized in content files.
   summary: z.string().optional(),
   narrative: z.string().optional(),
   sort: z.union([z.string(), z.number()]).optional(),

--- a/content/button.md
+++ b/content/button.md
@@ -7,8 +7,8 @@ image: splash/button.png
 icon: kind-icon:button
 tooltip: This started as a morning coding exercise but has evolved into an leadboard race.
 sort: highlight
-dottitip: AMI! I made a button and a sign to not press it and and visitors started pressing it. Why are people like this?
-amitip: Maybe they're jellybean hunters? But in that case, they should definitely stop around 100 times or so.
+dottiTip: AMI! I made a button and a sign to not press it and and visitors started pressing it. Why are people like this?
+amiTip: Maybe they're jellybean hunters? But in that case, they should definitely stop around 100 times or so.
 ---
 
 :lab-manager

--- a/content/error.md
+++ b/content/error.md
@@ -6,8 +6,8 @@ description: "We couldn’t find the page you were looking for. It might have be
 image: splash/error.png
 icon: kind-icon:error
 tooltip: This page doesn't exist, but you're still in good company.
-dottitip: "Looks like someone misplaced a link."
-amitip: "Or maybe this is a secret room… with no walls!"
+dottiTip: "Looks like someone misplaced a link."
+amiTip: "Or maybe this is a secret room… with no walls!"
 sort: error
 ---
 

--- a/content/forum.md
+++ b/content/forum.md
@@ -6,8 +6,8 @@ description: 'Welcome to the Kind Robots Forum — a freeform chat space for use
 image: splash/forum.png
 icon: kind-icon:forum
 tooltip: 'Jump into the conversation and let your ideas unfold.'
-dottitip: 'Threads help us track the chaos. Use them wisely.'
-amitip: 'I replied to a reply but someone already replied to their reply. Was that wrong?'
+dottiTip: 'Threads help us track the chaos. Use them wisely.'
+amiTip: 'I replied to a reply but someone already replied to their reply. Was that wrong?'
 sort: highlight
 ---
 

--- a/content/icons.md
+++ b/content/icons.md
@@ -6,8 +6,8 @@ description: 'Customize your smart bar.'
 image: splash/icons.png
 icon: fa-solid:icons
 tooltip: 'See all icons available to personalize your Kind Robots experience.'
-dottitip: AMI, how many icons is too many icons?
-amitip: The correct number of icons is 'yes.'
+dottiTip: AMI, how many icons is too many icons?
+amiTip: The correct number of icons is 'yes.'
 sort: gallery
 ---
 

--- a/content/login.md
+++ b/content/login.md
@@ -6,8 +6,8 @@ description: 'Login to get access to our suite of AI-enhanced tools.'
 image: splash/login.png
 icon: kind-icon:settings
 tooltip: "login and registration link here"
-dottitip: 'Before you log in, you must solve a puzzle. One of us only lies, and—'
-amitip: "We're kidding! We do the normal username-and-password thing here. No riddles required."
+dottiTip: 'Before you log in, you must solve a puzzle. One of us only lies, and—'
+amiTip: "We're kidding! We do the normal username-and-password thing here. No riddles required."
 sort: highlight
 loadingMessage: Loading login
 refreshLabel: Refresh login

--- a/content/servers.md
+++ b/content/servers.md
@@ -5,8 +5,8 @@ description: 'Add, edit, test, and select art, text, and workflow servers.'
 image: splash/servers.png
 icon: kind-icon:server
 tooltip: 'Manage your custom and official servers.'
-dottitip: 'A good server page is like a switchboard for chaos.'
-amitip: 'I like a dropdown full of possibilities and only mild danger.'
+dottiTip: 'A good server page is like a switchboard for chaos.'
+amiTip: 'I like a dropdown full of possibilities and only mild danger.'
 sort: highlight
 ---
 

--- a/content/sheets.md
+++ b/content/sheets.md
@@ -9,8 +9,8 @@ layout: 'default'
 icon: kind-icon:file-sparkles
 category: dreams
 tooltip: 'View PitchSheets for Dreams.'
-dottitip: 'A good pitch turns a database row into a dare.'
-amitip: 'I like the ones with butterflies. This is not a conflict of interest.'
+dottiTip: 'A good pitch turns a database row into a dare.'
+amiTip: 'I like the ones with butterflies. This is not a conflict of interest.'
 sort: highlight
 navComponent: 'dream-nav'
 ---

--- a/content/stages.md
+++ b/content/stages.md
@@ -6,8 +6,8 @@ description: 'Create scenes between 1 or more Performers'
 image: stage/splash.webp
 icon: fa-solid:mask
 tooltip: 'Meet the characters behind the chaos.'
-dottitip: I setup a stage for the bots to perform, and it's now devolved into utter chaos!
-amitip: You know what they say, You can't make a Hamlet without breaking some legs.
+dottiTip: I setup a stage for the bots to perform, and it's now devolved into utter chaos!
+amiTip: You know what they say, You can't make a Hamlet without breaking some legs.
 dashboardKey: character
 dashboardTab: stage
 cards: navCards

--- a/content/ui.md
+++ b/content/ui.md
@@ -7,8 +7,8 @@ image: splash/dashboard.png
 icon: kind-icon:settings
 tooltip: The living style guide. Pick a theme, screenshot it, iterate in code.
 sort: highlight
-dottitip: AMI! I want everything to match. Where do I even start?
-amitip: Right here. Pick a token, pick a container class, and let the theme do the rest. Consistency is just choosing the same names twice.
+dottiTip: AMI! I want everything to match. Where do I even start?
+amiTip: Right here. Pick a token, pick a container class, and let the theme do the rest. Consistency is just choosing the same names twice.
 ---
 
 :ui-gallery


### PR DESCRIPTION
## What was broken

The production front page (and every SSR page) was returning **500** — nothing rendered. Vercel runtime logs showed a flood of:

```
H3Error: no such table: _content_content
H3Error: no such table: _content_channels
```

on every `GET /`. The `Cypress Tests` CI job was red because its smoke spec just visits the live site (`kind-robots.vercel.app/`) and the page 500s.

## Root cause

The Vercel **build logs** revealed the real error, right after `[@nuxt/content] Processed 3 collections`:

```
[error] [unhandledRejection] duplicate column name: amitip
[error] [unhandledRejection] no such table: _content_content   (×100+)
```

`content.config.ts`'s `sharedNavigationSchema` declared **both** `dottiTip`/`amiTip` (camelCase) **and** `dottitip`/`amitip` (lowercase). SQLite column names are **case-insensitive**, so the collection's `CREATE TABLE` threw `duplicate column name: amitip`. That aborted table creation, so `_content_content` and `_content_channels` never existed at runtime. Since PR #212 moved navigation, tabs, and the home page (`content/index.md` → `:user-manager`) onto Nuxt Content SSR, every page depends on those tables — hence the blank/500 front end.

The lowercase keys pre-dated #212; #212 added the camelCase versions alongside them, creating the collision.

## The fix

- **`content.config.ts`**: remove the duplicate lowercase `dottitip`/`amitip` schema keys (with a comment explaining the SQLite case-insensitivity trap). Keep the canonical camelCase columns already used by components, stores, and 42 content files.
- **`content/*.md`** (9 legacy files): normalize lowercase `dottitip`/`amitip` frontmatter → `dottiTip`/`amiTip` so no narrator tips are lost.

## Verification

Ran a local production build (`nuxi build`):
- `[@nuxt/content] ✔ Processed 3 collections and 122 files` with **zero** `duplicate column` / `no such table` errors (previously 100+).
- Client built ✓, server built ✓.
- The only remaining local build error is `DATABASE_URL is missing` in the prerender step — a sandbox-only limitation (no DB); on Vercel `DATABASE_URL` is configured and that step passes.

Once merged and deployed, the content tables will be created at build time and the front page will render again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bxuehfk2LkyFPTdVrcYt1S)_