### PR TITLE
Hair Studio: preserve-original weight, real negative prompt, mask-ready Kontext graph

### DIFF
--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -178,6 +178,64 @@
       </p>
     </div>
 
+    <!-- How much to keep them looking like themselves -->
+    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
+      <div class="flex items-center justify-between">
+        <span class="text-xs font-black text-base-content">How much should it still look like them?</span>
+        <span class="text-xs font-bold text-primary">{{ preserveLabel }}</span>
+      </div>
+      <input
+        v-model.number="preserveStrength"
+        type="range"
+        min="0"
+        max="0.8"
+        step="0.05"
+        class="range range-primary range-xs"
+      />
+      <div class="flex justify-between text-[10px] text-base-content/50">
+        <span>Bolder change</span>
+        <span>Keep it them</span>
+      </div>
+      <label class="flex items-start gap-2 pt-1">
+        <input v-model="protectIdentity" type="checkbox" class="checkbox checkbox-xs checkbox-primary mt-0.5" />
+        <span class="text-xs text-base-content/70">
+          Extra-protect the face &amp; identity (a little slower — guards against turning
+          them into someone else)
+        </span>
+      </label>
+      <button
+        type="button"
+        class="text-left text-[11px] text-base-content/50 underline"
+        @click="advancedOpen = !advancedOpen"
+      >
+        {{ advancedOpen ? 'Hide' : 'Show' }} advanced settings
+      </button>
+      <div v-if="advancedOpen" class="grid grid-cols-2 gap-2">
+        <label class="flex flex-col gap-1">
+          <span class="text-[10px] font-bold text-base-content/60">Prompt strength (guidance)</span>
+          <input
+            v-model.number="guidanceValue"
+            type="number"
+            min="1"
+            max="6"
+            step="0.5"
+            class="input input-xs input-bordered w-full"
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="text-[10px] font-bold text-base-content/60">Steps</span>
+          <input
+            v-model.number="stepsValue"
+            type="number"
+            min="8"
+            max="40"
+            step="1"
+            class="input input-xs input-bordered w-full"
+          />
+        </label>
+      </div>
+    </div>
+
     <!-- Action -->
     <button
       type="button"
@@ -380,6 +438,27 @@ const changeStyle = ref(false)
 const styleValue = ref('')
 const enhanceImage = ref(false)
 const extraNotes = ref('')
+
+// Identity/quality controls. preserveStrength is the "weight from the original
+// picture": 0 fully reimagines (legacy Kontext), higher keeps the client's own
+// face/framing. Defaults lean toward preservation — the studio's complaint was
+// over-modification. All are live-tunable per render.
+const preserveStrength = ref(0.3)
+const protectIdentity = ref(false)
+const advancedOpen = ref(false)
+const guidanceValue = ref(2.5)
+const stepsValue = ref(20)
+
+const IDENTITY_NEGATIVE =
+  'different person, changed facial features, changed identity, distorted face, ' +
+  'deformed, disfigured, extra fingers, plastic skin, over-smoothed skin, ' +
+  'lowres, blurry, watermark, text'
+
+const preserveLabel = computed(() => {
+  if (preserveStrength.value <= 0.1) return 'Bold'
+  if (preserveStrength.value >= 0.5) return 'Very close'
+  return 'Balanced'
+})
 
 const hasAnyChange = computed(
   () => changeColor.value || changeStyle.value || enhanceImage.value,
@@ -593,6 +672,10 @@ function submit() {
     clientId: bookClient.value?.id ?? null,
     before: sourceImageData.value,
     prompt: buildPrompt(),
+    originalWeight: preserveStrength.value,
+    guidance: guidanceValue.value,
+    steps: stepsValue.value,
+    ...(protectIdentity.value ? { negativePrompt: IDENTITY_NEGATIVE } : {}),
   })
 }
 

--- a/server/api/comfy/kontext/enqueue.post.ts
+++ b/server/api/comfy/kontext/enqueue.post.ts
@@ -32,6 +32,13 @@ type KontextEnqueueRequest = {
   sampler?: string | null
   scheduler?: string | null
   denoise?: number | null
+  // 0..1, how much of the original photo to preserve (see workflow.ts).
+  originalWeight?: number | null
+  // Optional real negative prompt (+ cfg) — enables the CFGGuider path.
+  negativePrompt?: string | null
+  cfg?: number | null
+  // Optional hair/region mask as a data URL (white = change, black = keep).
+  maskData?: string | null
   isPublic?: boolean | null
   isMature?: boolean | null
   designer?: string | null
@@ -72,6 +79,13 @@ export default defineEventHandler(async (event) => {
     const extension = getKontextImageExtension(imageData)
     const imageName = `kr_kontext_queue_${Date.now()}_${crypto.randomUUID()}.${extension}`
 
+    // Optional hair/region mask travels as a second input image the relay
+    // uploads to Comfy's input folder alongside the source photo.
+    const maskData = body.maskData?.trim() || ''
+    const maskName = maskData
+      ? `kr_kontext_mask_${Date.now()}_${crypto.randomUUID()}.${getKontextImageExtension(maskData)}`
+      : ''
+
     const workflow = buildKontextWorkflow({
       prompt,
       imageName,
@@ -83,6 +97,10 @@ export default defineEventHandler(async (event) => {
       sampler: body.sampler,
       scheduler: body.scheduler,
       denoise: body.denoise,
+      originalWeight: body.originalWeight,
+      negativePrompt: body.negativePrompt,
+      cfg: body.cfg,
+      maskName: maskName || null,
       filenamePrefix: body.filenamePrefix || 'kindrobots_kontext_queue',
     })
     // ComfyWorkflow's index signature doesn't structurally satisfy
@@ -96,6 +114,7 @@ export default defineEventHandler(async (event) => {
           name: imageName,
           imageData,
         },
+        ...(maskName ? [{ name: maskName, imageData: maskData }] : []),
       ],
       save: {
         isPublic: body.isPublic ?? false,

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -24,6 +24,25 @@ export type KontextWorkflowInput = {
   scheduler?: string | null
   denoise?: number | null
   filenamePrefix?: string | null
+  // How much of the ORIGINAL photo to preserve, 0..1. 0 = full reimagine from
+  // an empty latent (the legacy Kontext behavior); higher values initialise the
+  // sampler from the encoded source photo at a reduced denoise, so the person's
+  // face, body, and background survive — this is the "weight from the original
+  // picture" control. It also makes the output follow the source's aspect ratio
+  // instead of a forced 1024x1024 square. Ignored (treated as full denoise) when
+  // a mask is supplied, where the mask alone decides what changes.
+  originalWeight?: number | null
+  // Optional real negative prompt. When set, the graph swaps BasicGuider for
+  // CFGGuider (cfg > 1) so the negative actually constrains the result — Flux
+  // ignores negatives on the default cfg=1 path. Left empty keeps the cheaper
+  // single-pass BasicGuider path unchanged.
+  negativePrompt?: string | null
+  cfg?: number | null
+  // Optional hair/region mask (uploaded as a separate input image, white =
+  // change, black = keep). When set, only the masked region is repainted via
+  // SetLatentNoiseMask over the source-init latent — everything else is locked
+  // to the original. Core ComfyUI nodes only (LoadImageMask/SetLatentNoiseMask).
+  maskName?: string | null
 }
 
 export const DEFAULT_KONTEXT_WIDTH = 1024
@@ -33,6 +52,12 @@ export const DEFAULT_KONTEXT_GUIDANCE = 2.5
 export const DEFAULT_KONTEXT_SAMPLER = 'res_multistep'
 export const DEFAULT_KONTEXT_SCHEDULER = 'sgm_uniform'
 export const DEFAULT_KONTEXT_DENOISE = 1
+// cfg used only on the CFGGuider (real-negative) path; the default BasicGuider
+// path is effectively cfg=1. Flux stays coherent at a low positive cfg.
+export const DEFAULT_KONTEXT_CFG = 2.5
+// Minimum denoise floor so a very high originalWeight still leaves the model
+// enough budget to actually apply the requested change.
+const MIN_IMG2IMG_DENOISE = 0.15
 
 function resolveSeed(seed?: number | null): number {
   if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
@@ -42,6 +67,10 @@ function resolveSeed(seed?: number | null): number {
   return Math.floor(Math.random() * 1_000_000_000_000_000)
 }
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
 export function buildKontextWorkflow(
   input: KontextWorkflowInput,
 ): ComfyWorkflow {
@@ -49,26 +78,37 @@ export function buildKontextWorkflow(
   const height = input.height ?? DEFAULT_KONTEXT_HEIGHT
   const seed = resolveSeed(input.seed)
 
-  return {
+  const negativePrompt = input.negativePrompt?.trim() || ''
+  const useNegative = negativePrompt.length > 0
+  const maskName = input.maskName?.trim() || ''
+  const useMask = maskName.length > 0
+  const originalWeight =
+    typeof input.originalWeight === 'number' && Number.isFinite(input.originalWeight)
+      ? clamp(input.originalWeight, 0, 1)
+      : 0
+  // Init from the encoded source when preserving the original or when masking
+  // (a mask needs a base latent to protect). Otherwise start from empty latent.
+  const useImg2Img = originalWeight > 0 || useMask
+
+  // With an img2img init, denoise sets how much of the original survives:
+  // denoise = 1 - originalWeight (floored). Masking with no weight keeps full
+  // denoise so the masked region is fully restyled while the rest is locked.
+  const denoise = useImg2Img
+    ? originalWeight > 0
+      ? clamp(1 - originalWeight, MIN_IMG2IMG_DENOISE, 1)
+      : (input.denoise ?? DEFAULT_KONTEXT_DENOISE)
+    : (input.denoise ?? DEFAULT_KONTEXT_DENOISE)
+
+  const workflow: ComfyWorkflow = {
     '6': {
-      inputs: {
-        text: input.prompt,
-        clip: ['11', 0],
-      },
+      inputs: { text: input.prompt, clip: ['11', 0] },
       class_type: 'CLIPTextEncode',
-      _meta: {
-        title: 'CLIP Text Encode (Positive Prompt)',
-      },
+      _meta: { title: 'CLIP Text Encode (Positive Prompt)' },
     },
     '8': {
-      inputs: {
-        samples: ['13', 0],
-        vae: ['10', 0],
-      },
+      inputs: { samples: ['13', 0], vae: ['10', 0] },
       class_type: 'VAEDecode',
-      _meta: {
-        title: 'VAE Decode',
-      },
+      _meta: { title: 'VAE Decode' },
     },
     '9': {
       inputs: {
@@ -76,18 +116,12 @@ export function buildKontextWorkflow(
         images: ['8', 0],
       },
       class_type: 'SaveImage',
-      _meta: {
-        title: 'Save Image',
-      },
+      _meta: { title: 'Save Image' },
     },
     '10': {
-      inputs: {
-        vae_name: 'ae.safetensors',
-      },
+      inputs: { vae_name: 'ae.safetensors' },
       class_type: 'VAELoader',
-      _meta: {
-        title: 'Load VAE',
-      },
+      _meta: { title: 'Load VAE' },
     },
     '11': {
       inputs: {
@@ -97,9 +131,7 @@ export function buildKontextWorkflow(
         device: 'default',
       },
       class_type: 'DualCLIPLoader',
-      _meta: {
-        title: 'DualCLIPLoader',
-      },
+      _meta: { title: 'DualCLIPLoader' },
     },
     '13': {
       inputs: {
@@ -107,52 +139,38 @@ export function buildKontextWorkflow(
         guider: ['22', 0],
         sampler: ['60', 0],
         sigmas: ['17', 0],
+        // latent_image is patched below depending on img2img/mask.
         latent_image: ['27', 0],
       },
       class_type: 'SamplerCustomAdvanced',
-      _meta: {
-        title: 'SamplerCustomAdvanced',
-      },
+      _meta: { title: 'SamplerCustomAdvanced' },
     },
     '16': {
-      inputs: {
-        sampler_name: input.sampler ?? DEFAULT_KONTEXT_SAMPLER,
-      },
+      inputs: { sampler_name: input.sampler ?? DEFAULT_KONTEXT_SAMPLER },
       class_type: 'KSamplerSelect',
-      _meta: {
-        title: 'KSamplerSelect',
-      },
+      _meta: { title: 'KSamplerSelect' },
     },
     '17': {
       inputs: {
         scheduler: input.scheduler ?? DEFAULT_KONTEXT_SCHEDULER,
         steps: input.steps ?? DEFAULT_KONTEXT_STEPS,
-        denoise: input.denoise ?? DEFAULT_KONTEXT_DENOISE,
+        denoise,
         model: ['30', 0],
       },
       class_type: 'BasicScheduler',
-      _meta: {
-        title: 'BasicScheduler',
-      },
+      _meta: { title: 'BasicScheduler' },
     },
+    // 22 is the guider — BasicGuider by default; replaced with CFGGuider below
+    // when a real negative prompt is supplied.
     '22': {
-      inputs: {
-        model: ['30', 0],
-        conditioning: ['42', 0],
-      },
+      inputs: { model: ['30', 0], conditioning: ['42', 0] },
       class_type: 'BasicGuider',
-      _meta: {
-        title: 'BasicGuider',
-      },
+      _meta: { title: 'BasicGuider' },
     },
     '25': {
-      inputs: {
-        noise_seed: seed,
-      },
+      inputs: { noise_seed: seed },
       class_type: 'RandomNoise',
-      _meta: {
-        title: 'RandomNoise',
-      },
+      _meta: { title: 'RandomNoise' },
     },
     '26': {
       inputs: {
@@ -160,20 +178,12 @@ export function buildKontextWorkflow(
         conditioning: ['6', 0],
       },
       class_type: 'FluxGuidance',
-      _meta: {
-        title: 'FluxGuidance',
-      },
+      _meta: { title: 'FluxGuidance' },
     },
     '27': {
-      inputs: {
-        width,
-        height,
-        batch_size: 1,
-      },
+      inputs: { width, height, batch_size: 1 },
       class_type: 'EmptySD3LatentImage',
-      _meta: {
-        title: 'EmptySD3LatentImage',
-      },
+      _meta: { title: 'EmptySD3LatentImage' },
     },
     '30': {
       inputs: {
@@ -184,56 +194,32 @@ export function buildKontextWorkflow(
         model: ['59', 0],
       },
       class_type: 'ModelSamplingFlux',
-      _meta: {
-        title: 'ModelSamplingFlux',
-      },
+      _meta: { title: 'ModelSamplingFlux' },
     },
     '39': {
-      inputs: {
-        pixels: ['40', 0],
-        vae: ['10', 0],
-      },
+      inputs: { pixels: ['40', 0], vae: ['10', 0] },
       class_type: 'VAEEncode',
-      _meta: {
-        title: 'VAE Encode',
-      },
+      _meta: { title: 'VAE Encode' },
     },
     '40': {
-      inputs: {
-        image: ['41', 0],
-      },
+      inputs: { image: ['41', 0] },
       class_type: 'FluxKontextImageScale',
-      _meta: {
-        title: 'FluxKontextImageScale',
-      },
+      _meta: { title: 'FluxKontextImageScale' },
     },
     '41': {
-      inputs: {
-        image: input.imageName,
-      },
+      inputs: { image: input.imageName },
       class_type: 'LoadImage',
-      _meta: {
-        title: 'Load Image',
-      },
+      _meta: { title: 'Load Image' },
     },
     '42': {
-      inputs: {
-        conditioning: ['26', 0],
-        latent: ['39', 0],
-      },
+      inputs: { conditioning: ['26', 0], latent: ['39', 0] },
       class_type: 'ReferenceLatent',
-      _meta: {
-        title: 'ReferenceLatent',
-      },
+      _meta: { title: 'ReferenceLatent' },
     },
     '59': {
-      inputs: {
-        unet_name: 'flux1-kontext-dev-Q5_K_M.gguf',
-      },
+      inputs: { unet_name: 'flux1-kontext-dev-Q5_K_M.gguf' },
       class_type: 'UnetLoaderGGUF',
-      _meta: {
-        title: 'Unet Loader (GGUF)',
-      },
+      _meta: { title: 'Unet Loader (GGUF)' },
     },
     '60': {
       inputs: {
@@ -250,11 +236,52 @@ export function buildKontextWorkflow(
         sampler: ['16', 0],
       },
       class_type: 'DetailDaemonSamplerNode',
-      _meta: {
-        title: 'Detail Daemon Sampler',
-      },
+      _meta: { title: 'Detail Daemon Sampler' },
     },
   }
+
+  // --- img2img init: start from the encoded source photo (node 39) so the
+  //     person and framing survive, instead of the empty latent (node 27). ---
+  let latentRef: [string, number] = useImg2Img ? ['39', 0] : ['27', 0]
+
+  // --- optional hair/region mask: only the white area of the mask is denoised,
+  //     the rest is locked to the source latent. ---
+  if (useMask) {
+    workflow['70'] = {
+      inputs: { image: maskName, channel: 'red' },
+      class_type: 'LoadImageMask',
+      _meta: { title: 'Load Hair Mask' },
+    }
+    workflow['71'] = {
+      inputs: { samples: ['39', 0], mask: ['70', 0] },
+      class_type: 'SetLatentNoiseMask',
+      _meta: { title: 'Set Latent Noise Mask (hair only)' },
+    }
+    latentRef = ['71', 0]
+  }
+
+  ;(workflow['13'].inputs as Record<string, unknown>).latent_image = latentRef
+
+  // --- real negative prompt via CFGGuider (Flux ignores negatives at cfg=1) ---
+  if (useNegative) {
+    workflow['7'] = {
+      inputs: { text: negativePrompt, clip: ['11', 0] },
+      class_type: 'CLIPTextEncode',
+      _meta: { title: 'CLIP Text Encode (Negative Prompt)' },
+    }
+    workflow['22'] = {
+      inputs: {
+        model: ['30', 0],
+        positive: ['42', 0],
+        negative: ['7', 0],
+        cfg: input.cfg ?? DEFAULT_KONTEXT_CFG,
+      },
+      class_type: 'CFGGuider',
+      _meta: { title: 'CFGGuider' },
+    }
+  }
+
+  return workflow
 }
 
 export function getKontextImageExtension(imageData: string): string {

--- a/stores/stylistStore.ts
+++ b/stores/stylistStore.ts
@@ -41,6 +41,17 @@ export type StylistRunInput = {
   clientId?: number | null // StylistClient id from the synced book, if known
   before: string // data URL of the source photo
   prompt: string
+  // Generation controls (all optional; omitted keys use the backend defaults).
+  // originalWeight 0..1 = how much of the client's own photo to preserve (face,
+  // identity, framing). negativePrompt enables the real-negative CFGGuider path.
+  // maskData is a hair/region mask data URL (white = change, black = keep).
+  originalWeight?: number
+  negativePrompt?: string
+  cfg?: number
+  guidance?: number
+  steps?: number
+  seed?: number
+  maskData?: string
 }
 
 /**
@@ -244,6 +255,17 @@ export const useStylistStore = defineStore('stylistStore', () => {
           body: JSON.stringify({
             prompt: input.prompt,
             imageData: before,
+            // Identity/quality controls — only sent when set so the backend
+            // defaults still apply to an untouched request.
+            ...(input.originalWeight !== undefined
+              ? { originalWeight: input.originalWeight }
+              : {}),
+            ...(input.negativePrompt ? { negativePrompt: input.negativePrompt } : {}),
+            ...(input.cfg !== undefined ? { cfg: input.cfg } : {}),
+            ...(input.guidance !== undefined ? { guidance: input.guidance } : {}),
+            ...(input.steps !== undefined ? { steps: input.steps } : {}),
+            ...(input.seed !== undefined ? { seed: input.seed } : {}),
+            ...(input.maskData ? { maskData: input.maskData } : {}),
             // Private: never public, never in the memory game.
             isPublic: false,
             isMature: false,


### PR DESCRIPTION
## Why

The Hair Studio / Kontext styler over-modifies — it repaints the whole frame at full denoise from an empty latent (source only enters as `ReferenceLatent` conditioning), with no adjustable fidelity, a forced 1024×1024 square output, and no working negative prompt. That produces the "turned me into a different person / glamour shot" and gibberish results. See conductor `IMAGE-GEN-QUALITY-REVIEW.md` §3.

## What changed

All using core / confirmed-installed ComfyUI nodes only:

**`server/api/comfy/kontext/utils/workflow.ts`**
- **`originalWeight` (0..1)** — img2img init from the encoded source photo at `denoise = 1 − originalWeight`, so the person's face, identity, and framing survive, and the output follows the source aspect ratio instead of a forced square. This is the "weight from the original picture" control.
- **`negativePrompt` + `cfg`** — swaps `BasicGuider` for `CFGGuider` so a real negative actually constrains the result (Flux ignores negatives at `cfg=1`). Opt-in; the default single-pass path is unchanged.
- **`maskName`** — optional `LoadImageMask` + `SetLatentNoiseMask` over the source-init latent so only the masked (hair) region is repainted. The mask rides as a second input image the relay already uploads.

**Wiring**
- `enqueue.post.ts` accepts `originalWeight`/`negativePrompt`/`cfg`/`maskData` and uploads an optional mask image.
- `stylistStore.ts` threads the controls through (only sent when set).
- `stylist-restyle.vue` adds a live "how much should it still look like them?" strength slider (defaults toward preservation), an opt-in extra-protect toggle, and advanced guidance/steps.

## Note on the mask
The mask **path** is shipped and ready, but nothing generates a hair mask yet (no segmentation node on the ComfyUI box, no client-side seg lib). The identity fix that works today is `originalWeight`; true hair-only masking needs a mask source — filed as conductor superkate `t-018`.

## Verification
- `workflow.ts` typechecks clean under `tsc --strict --skipLibCheck`.
- The store / enqueue / `.vue` edits are additive and reviewed, but not runtime-verified here (no local Nuxt build or live Comfy box). Default preserve strength (0.3) and the negative wording want one live tuning run on the studio box — conductor superkate `t-019`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dXcqHkffMLemew8294gcR

---
_Generated by [Claude Code](https://claude.ai/code/session_013dXcqHkffMLemew8294gcR)_