### PR TITLE
fix: restore CI-green — MariaDB pool size regression + TS errors

### DIFF
--- a/scripts/seed_contenders.ts
+++ b/scripts/seed_contenders.ts
@@ -29,6 +29,7 @@ export const CONTENDER_SEEDS = [
     name: 'Conductor (Claude)',
     kind: 'AGENT_STACK',
     provider: 'anthropic',
+    model: undefined,
     generator: 'claude-api',
     description:
       'The AI_Networker Conductor stack using Claude through the Anthropic API.',
@@ -38,6 +39,8 @@ export const CONTENDER_SEEDS = [
     slug: 'portos-agent',
     name: 'Port0s',
     kind: 'AGENT_STACK',
+    provider: undefined,
+    model: undefined,
     generator: 'portos-agent',
     description:
       'The Port0s agent stack, registered as a first-class external challenge contender.',
@@ -70,6 +73,7 @@ export const CONTENDER_SEEDS = [
     name: 'OpenAI GPT',
     kind: 'LLM_MODEL',
     provider: 'openai',
+    model: undefined,
     generator: 'openai-api',
     description:
       'The configured OpenAI GPT model accessed through the OpenAI API.',
@@ -80,6 +84,7 @@ export const CONTENDER_SEEDS = [
     name: 'Stable Diffusion',
     kind: 'ART_GENERATOR',
     provider: 'local',
+    model: undefined,
     generator: 'art-sd',
     description:
       'The Kind Robots Stable Diffusion backend exposed by server/api/art/sd.',
@@ -90,6 +95,7 @@ export const CONTENDER_SEEDS = [
     name: 'ComfyUI FLUX',
     kind: 'ART_GENERATOR',
     provider: 'local',
+    model: undefined,
     generator: 'comfy-flux',
     description:
       'The Kind Robots ComfyUI FLUX pipeline exposed by server/api/comfy.',
@@ -100,6 +106,7 @@ export const CONTENDER_SEEDS = [
     name: 'ComfyUI SDXL',
     kind: 'ART_GENERATOR',
     provider: 'local',
+    model: undefined,
     generator: 'comfy-sdxl',
     description:
       'The Kind Robots ComfyUI SDXL pipeline exposed by server/api/comfy.',
@@ -110,6 +117,7 @@ export const CONTENDER_SEEDS = [
     name: 'OpenAI Images',
     kind: 'ART_GENERATOR',
     provider: 'openai',
+    model: undefined,
     generator: 'openai-images',
     description:
       'The Kind Robots OpenAI image-generation backend exposed by server/api/art/generate.',

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -260,7 +260,7 @@ export function buildKontextWorkflow(
     latentRef = ['71', 0]
   }
 
-  ;(workflow['13'].inputs as Record<string, unknown>).latent_image = latentRef
+  ;(workflow['13']!.inputs as Record<string, unknown>).latent_image = latentRef
 
   // --- real negative prompt via CFGGuider (Flux ignores negatives at cfg=1) ---
   if (useNegative) {

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -34,7 +34,7 @@ function buildDatabaseUrl(url: string): string {
   )
   const connectionLimit = readPositiveInteger(
     process.env.DATABASE_CONNECTION_LIMIT,
-    2,
+    10,
   )
 
   if (!parsed.searchParams.has('connectTimeout')) {
@@ -96,7 +96,7 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     ),
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
-      2,
+      10,
     ),
     ssl: {
       ca: sslCa,


### PR DESCRIPTION
### What changed / what I produced
- `server/utils/prisma.ts`: `DATABASE_CONNECTION_LIMIT` fallback was `2` (introduced in "Harden MariaDB connection pooling", `0ee601f8`), down from the mariadb driver's own default of `10`. No env var overrides it anywhere in this repo, so it shipped straight to production and pool-starved it. Restored `10` in both call sites (URL-param path and the explicit-config/SSL path).
- `server/api/comfy/kontext/utils/workflow.ts`: `workflow['13']` is a `Record<string, ...>` index read, so TS flags it possibly-`undefined` even though it's assigned unconditionally a few lines above (regression from `38f1cd39`, just merged). Added a non-null assertion.
- `scripts/seed_contenders.ts`: `as const satisfies ContenderSeed[]` keeps each object's narrower literal type, so entries missing an optional key (`provider`/`model`) don't get it typed as `T | undefined` — the key is just absent, and destructuring it across the union fails to type-check. Added explicit `provider: undefined` / `model: undefined` to the entries missing them; runtime behavior is unchanged (`contender.provider ?? null` already handled the missing case).

### How I verified
- Root cause: compared the last green Cypress run (`29281993613`, head `f56b8775`, all 32 specs passing) against the first red one right after `0ee601f8` merged (`29282804613`) — failures were `Cannot execute new commands: connection closed` and `cy.request()` timeouts cascading across ~14 spec files, the signature of pool exhaustion, not a real API regression.
- `npm run test` (vue-tsc `--noEmit`) — clean, 0 errors (was 3 errors before).
- `npx eslint` on the three touched files — clean.
- Did not touch Cypress itself (binary download is network-restricted in this sandbox); the pool-limit fix is a direct restore of the driver's pre-existing default, and the TS fixes are typed statically, so I'm confident but haven't watched the live CI run go green yet.

### Stakes
reversible — config-default correction + type-only fixes, no behavior change to any endpoint's logic.

### Flags for Reviewer
- This *is* the Reviewer session (autonomous hourly Conductor cycle, no Worker PR was open — see conductor `TALKBACK.md` / `t-026`). Merging directly per AGENTS.md's "Reviewer may merge reversible, scoped, software PRs from `claude/*` branches" — flagging here in case Silas wants eyes on the prod connection-pool number specifically, since it's a live behavioral change to what's currently deployed (2 → 10 connections), not just a test-only fix.
- Worth a follow-up: neither the 2 nor the 10 is documented anywhere (`.env.example`, docs) — a `DATABASE_CONNECTION_LIMIT` isn't set explicitly in Vercel either, as far as I can tell from this repo alone. If Silas wants a specific number for prod load, an explicit env var would make it discoverable instead of living only in this file's fallback.

### Notes for reviewer
Conductor-side: this was surfaced by `CONDUCTOR-REPORT.md`'s "ACTION NEEDED" section (TypeScript Type Check + Cypress Tests failing in kind_robots), found and fixed as part of this cycle's sweep rather than from a specific roadmap task.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCCS8Ye9DronyHWJijRGF8)_