### PR TITLE
Run Prisma migrations through verified ProxySQL TLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "trim": "node utils/scripts/trim.mjs",
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
-    "vercel-build": "prisma generate && prisma migrate deploy && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
+    "vercel-build": "prisma generate && node scripts/prisma-migrate-deploy.mjs && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
     "dev": "nuxt dev --host",
     "build": "nuxi prepare && prisma generate && nuxi build",
     "start": "nuxi start",

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -1,0 +1,122 @@
+// /scripts/prisma-migrate-deploy.mjs
+import { X509Certificate } from 'node:crypto'
+import { writeFile, unlink } from 'node:fs/promises'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import mariadb from 'mariadb'
+
+const databaseUrl = process.env.DATABASE_URL
+const caFilePath = '/tmp/kindrobots-proxysql-ca.pem'
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is missing')
+}
+
+function readDatabaseSslCa() {
+  const encoded = process.env.DATABASE_SSL_CA_BASE64?.replace(/\s+/g, '')
+  if (encoded) {
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8').trim()
+    if (!decoded.includes('BEGIN CERTIFICATE')) {
+      throw new Error('DATABASE_SSL_CA_BASE64 does not decode to a PEM certificate')
+    }
+    return decoded
+  }
+
+  const plain = process.env.DATABASE_SSL_CA?.replace(/\\n/g, '\n').trim()
+  return plain || undefined
+}
+
+function runPrismaMigrate(url) {
+  const prismaBinary = path.resolve('node_modules/.bin/prisma')
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(prismaBinary, ['migrate', 'deploy'], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        DATABASE_URL: url,
+      },
+    })
+
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(
+        new Error(
+          signal
+            ? `prisma migrate deploy terminated by ${signal}`
+            : `prisma migrate deploy exited with code ${code ?? 'unknown'}`,
+        ),
+      )
+    })
+  })
+}
+
+async function verifyTlsConnection(parsedUrl, sslCa) {
+  let connection
+
+  try {
+    connection = await mariadb.createConnection({
+      host: parsedUrl.hostname,
+      port: Number.parseInt(parsedUrl.port || '3306', 10),
+      user: decodeURIComponent(parsedUrl.username),
+      password: decodeURIComponent(parsedUrl.password),
+      database: decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, '')),
+      connectTimeout: 5_000,
+      ssl: {
+        ca: sslCa,
+        rejectUnauthorized: true,
+      },
+    })
+
+    await connection.query('SELECT 1 AS tls_connection_ok')
+    console.log('[database] Verified TLS connection to ProxySQL before migration.')
+  } finally {
+    await connection?.end()
+  }
+}
+
+async function main() {
+  const sslCa = readDatabaseSslCa()
+
+  if (!sslCa) {
+    console.warn(
+      '[database] No custom CA configured; running Prisma Migrate with DATABASE_URL unchanged.',
+    )
+    await runPrismaMigrate(databaseUrl)
+    return
+  }
+
+  let certificate
+  try {
+    certificate = new X509Certificate(sslCa)
+  } catch (error) {
+    throw new Error('Configured database CA is not a valid X.509 certificate', {
+      cause: error,
+    })
+  }
+
+  console.log(
+    `[database] Loaded ProxySQL CA subject=${certificate.subject} fingerprint=${certificate.fingerprint256} validTo=${certificate.validTo}`,
+  )
+
+  await writeFile(caFilePath, `${sslCa}\n`, { mode: 0o600 })
+
+  try {
+    const parsedUrl = new URL(databaseUrl)
+    await verifyTlsConnection(parsedUrl, sslCa)
+
+    parsedUrl.searchParams.set('sslcert', caFilePath)
+    parsedUrl.searchParams.set('sslaccept', 'strict')
+
+    await runPrismaMigrate(parsedUrl.toString())
+  } finally {
+    await unlink(caFilePath).catch(() => undefined)
+  }
+}
+
+await main()


### PR DESCRIPTION
## What changed

- Replaced the direct `prisma migrate deploy` Vercel build step with a TLS-aware migration runner.
- Decodes and validates `DATABASE_SSL_CA_BASE64` or `DATABASE_SSL_CA` as an X.509 certificate.
- Performs a verified MariaDB TLS preflight using the same host, credentials, database, and CA as the application.
- Writes the CA to a temporary file and adds Prisma's documented `sslcert` and `sslaccept=strict` URL parameters for `prisma migrate deploy`.
- Logs only safe certificate metadata and connection status; credentials and CA contents are never printed.

## Root cause

ProxySQL now requires SSL for `kindrobot`, but Prisma Migrate reads only `DATABASE_URL` from `prisma.config.ts`. The runtime MariaDB adapter knew about `DATABASE_SSL_CA_BASE64`; the Prisma CLI did not, so new Vercel deployments failed with P1000 before Nuxt could build.

## Expected diagnostic value

The next Vercel build will distinguish malformed/missing CA data, certificate validation problems, TLS reachability, and Prisma migration errors instead of collapsing everything into an authentication failure.