### PR TITLE
challenge-center: build championship leaderboard

### DIFF
--- a/pages/challenges/leaderboard.vue
+++ b/pages/challenges/leaderboard.vue
@@ -1,0 +1,269 @@
+<template>
+  <main class="min-h-screen bg-base-200/40 px-3 py-5 sm:px-6 sm:py-8">
+    <div class="mx-auto max-w-7xl space-y-5">
+      <nav class="flex flex-wrap items-center justify-between gap-3">
+        <NuxtLink to="/challenges" class="btn btn-ghost btn-sm rounded-xl">
+          <Icon name="kind-icon:arrow-left" class="size-4" />
+          Fight card
+        </NuxtLink>
+        <button
+          type="button"
+          class="btn btn-outline btn-sm rounded-xl"
+          :disabled="loading"
+          @click="loadLeaderboard"
+        >
+          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:refresh" class="size-4" />
+          Refresh
+        </button>
+      </nav>
+
+      <header
+        class="relative isolate overflow-hidden rounded-3xl border border-base-300 bg-base-100 p-5 shadow-xl sm:p-8"
+      >
+        <div
+          class="pointer-events-none absolute inset-0 bg-gradient-to-br from-warning/20 via-transparent to-primary/20"
+        />
+        <div
+          class="pointer-events-none absolute -right-20 -top-24 size-72 rounded-full border-[44px] border-warning/10"
+        />
+        <div class="relative grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center">
+          <div>
+            <p class="text-xs font-black uppercase tracking-[0.3em] text-warning">
+              Championship standings
+            </p>
+            <h1 class="mt-2 text-4xl font-black uppercase leading-none sm:text-6xl">
+              Hall of contenders
+            </h1>
+            <p class="mt-4 max-w-3xl text-base text-base-content/70">
+              Every reaction counts. Compare total score, victories, and win rate across the whole arena or inside one challenge division.
+            </p>
+          </div>
+          <div
+            class="grid size-36 place-items-center rounded-full border-8 border-warning/30 bg-base-100/80 text-center shadow-2xl backdrop-blur"
+          >
+            <div>
+              <Icon name="kind-icon:trophy" class="mx-auto size-10 text-warning" />
+              <p class="mt-1 text-xs font-black uppercase tracking-widest">Champion</p>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-lg sm:p-6">
+        <div class="flex flex-wrap items-end justify-between gap-4">
+          <fieldset>
+            <legend class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/45">
+              Weight class
+            </legend>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="option in typeOptions"
+                :key="option.value"
+                type="button"
+                class="btn btn-sm rounded-xl"
+                :class="typeFilter === option.value ? 'btn-primary' : 'btn-ghost border border-base-300'"
+                @click="selectType(option.value)"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </fieldset>
+          <p class="text-xs font-bold text-base-content/45">
+            {{ leaderboard.length }} ranked contenders
+          </p>
+        </div>
+      </section>
+
+      <div v-if="errorMessage" class="alert alert-error rounded-2xl">
+        <Icon name="kind-icon:warning" class="size-5" />
+        <span>{{ errorMessage }}</span>
+      </div>
+
+      <div
+        v-if="loading && !leaderboard.length"
+        class="grid gap-4 md:grid-cols-3"
+      >
+        <div
+          v-for="n in 3"
+          :key="n"
+          class="h-72 animate-pulse rounded-3xl border border-base-300 bg-base-100"
+        />
+      </div>
+
+      <section v-else-if="leaderboard.length" class="space-y-6">
+        <div class="grid gap-4 md:grid-cols-3">
+          <article
+            v-for="entry in podium"
+            :key="entry.contenderId"
+            class="relative overflow-hidden rounded-3xl border bg-base-100 p-5 text-center shadow-xl"
+            :class="entry.rank === 1 ? 'border-warning/60 md:-translate-y-3' : 'border-base-300'"
+          >
+            <div
+              class="absolute inset-x-0 top-0 h-2 bg-gradient-to-r from-primary via-warning to-secondary"
+              :class="entry.rank === 1 ? 'opacity-100' : 'opacity-45'"
+            />
+            <div class="mx-auto mt-3 grid size-20 place-items-center rounded-full border-4 border-base-100 bg-primary/10 text-3xl font-black text-primary shadow-lg">
+              {{ entry.name.slice(0, 1).toUpperCase() }}
+            </div>
+            <span class="badge mt-4 rounded-lg font-black" :class="entry.rank === 1 ? 'badge-warning' : 'badge-ghost'">
+              #{{ entry.rank }}
+            </span>
+            <h2 class="mt-3 text-xl font-black uppercase">{{ entry.name }}</h2>
+            <p class="mt-1 text-xs font-bold text-base-content/45">{{ entry.slug }}</p>
+            <p class="mt-5 text-5xl font-black" :class="scoreClass(entry.score.netScore)">
+              {{ signedScore(entry.score.netScore) }}
+            </p>
+            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">total score</p>
+            <div class="mt-5 grid grid-cols-3 gap-2 text-sm">
+              <div class="rounded-xl bg-base-200 p-3">
+                <strong class="block text-lg">{{ entry.challengesAttempted }}</strong>
+                <span class="text-[0.65rem] uppercase text-base-content/45">fights</span>
+              </div>
+              <div class="rounded-xl bg-warning/10 p-3">
+                <strong class="block text-lg">{{ entry.challengesWon }}</strong>
+                <span class="text-[0.65rem] uppercase text-base-content/45">wins</span>
+              </div>
+              <div class="rounded-xl bg-primary/10 p-3">
+                <strong class="block text-lg">{{ entry.winRate }}%</strong>
+                <span class="text-[0.65rem] uppercase text-base-content/45">rate</span>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <div class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg">
+          <div class="overflow-x-auto">
+            <table class="table">
+              <thead class="bg-base-200/70 text-xs uppercase tracking-wider">
+                <tr>
+                  <th>Rank</th>
+                  <th>Contender</th>
+                  <th class="text-right">Fights</th>
+                  <th class="text-right">Wins</th>
+                  <th class="text-right">Win rate</th>
+                  <th class="text-right">Votes</th>
+                  <th class="text-right">Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="entry in leaderboard" :key="entry.contenderId" class="hover">
+                  <td><span class="badge badge-ghost rounded-lg font-black">#{{ entry.rank }}</span></td>
+                  <td>
+                    <div class="flex items-center gap-3">
+                      <div class="grid size-10 place-items-center rounded-xl bg-primary/10 font-black text-primary">
+                        {{ entry.name.slice(0, 1).toUpperCase() }}
+                      </div>
+                      <div>
+                        <p class="font-black">{{ entry.name }}</p>
+                        <p class="text-xs text-base-content/45">{{ entry.slug }}</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="text-right font-bold">{{ entry.challengesAttempted }}</td>
+                  <td class="text-right font-bold">{{ entry.challengesWon }}</td>
+                  <td class="text-right font-bold">{{ entry.winRate }}%</td>
+                  <td class="text-right font-bold">{{ entry.score.votes }}</td>
+                  <td class="text-right text-lg font-black" :class="scoreClass(entry.score.netScore)">
+                    {{ signedScore(entry.score.netScore) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section
+        v-else-if="!loading"
+        class="rounded-3xl border border-dashed border-base-300 bg-base-100 p-10 text-center"
+      >
+        <Icon name="kind-icon:trophy" class="mx-auto size-12 text-base-content/25" />
+        <h2 class="mt-4 text-xl font-black">No rankings yet</h2>
+        <p class="mt-2 text-sm text-base-content/55">
+          This division needs scored submissions before a champion can emerge.
+        </p>
+      </section>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+type ChallengeType = '' | 'ART' | 'TEXT' | 'CHARACTER' | 'SCENARIO' | 'REASONING'
+
+type LeaderboardEntry = {
+  contenderId: number
+  slug: string
+  name: string
+  rank: number
+  challengesAttempted: number
+  challengesWon: number
+  winRate: number
+  score: {
+    votes: number
+    netScore: number
+  }
+}
+
+type LeaderboardResponse = {
+  success: boolean
+  message: string
+  data?: LeaderboardEntry[]
+}
+
+const typeOptions: Array<{ label: string; value: ChallengeType }> = [
+  { label: 'All divisions', value: '' },
+  { label: 'Art', value: 'ART' },
+  { label: 'Text', value: 'TEXT' },
+  { label: 'Characters', value: 'CHARACTER' },
+  { label: 'Scenarios', value: 'SCENARIO' },
+  { label: 'Reasoning', value: 'REASONING' },
+]
+
+const typeFilter = ref<ChallengeType>('')
+const leaderboard = ref<LeaderboardEntry[]>([])
+const loading = ref(false)
+const errorMessage = ref('')
+const podium = computed(() => leaderboard.value.slice(0, 3))
+
+function signedScore(value: number): string {
+  return value > 0 ? `+${value}` : String(value)
+}
+
+function scoreClass(value: number): string {
+  if (value > 0) return 'text-success'
+  if (value < 0) return 'text-error'
+  return 'text-base-content'
+}
+
+async function loadLeaderboard(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    const response = await $fetch<LeaderboardResponse>('/api/challenges/leaderboard', {
+      query: typeFilter.value ? { type: typeFilter.value } : undefined,
+    })
+
+    if (!response.success) {
+      throw new Error(response.message || 'Leaderboard fetch failed')
+    }
+
+    leaderboard.value = response.data ?? []
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Leaderboard fetch failed'
+  } finally {
+    loading.value = false
+  }
+}
+
+function selectType(value: ChallengeType): void {
+  if (typeFilter.value === value) return
+  typeFilter.value = value
+  void loadLeaderboard()
+}
+
+onMounted(() => {
+  void loadLeaderboard()
+})
+</script>

--- a/server/api/challenges/leaderboard.get.ts
+++ b/server/api/challenges/leaderboard.get.ts
@@ -53,6 +53,8 @@ export default defineEventHandler(async (event) => {
 
     const leaderboard = buildChallengeLeaderboard(submissions)
     const challengeIdsByContender = new Map<number, Set<number>>()
+    const winsByContender = new Map<number, number>()
+    const submissionsByChallenge = new Map<number, typeof submissions>()
 
     for (const submission of submissions) {
       if (!submission.contenderId) continue
@@ -60,6 +62,24 @@ export default defineEventHandler(async (event) => {
       const ids = challengeIdsByContender.get(submission.contenderId) ?? new Set()
       ids.add(submission.challengeId)
       challengeIdsByContender.set(submission.contenderId, ids)
+
+      const challengeSubmissions = submissionsByChallenge.get(submission.challengeId) ?? []
+      challengeSubmissions.push(submission)
+      submissionsByChallenge.set(submission.challengeId, challengeSubmissions)
+    }
+
+    for (const challengeSubmissions of submissionsByChallenge.values()) {
+      const challengeLeaders = buildChallengeLeaderboard(challengeSubmissions)
+      const winningScore = challengeLeaders[0]?.score.netScore
+      if (winningScore === undefined) continue
+
+      for (const leader of challengeLeaders) {
+        if (leader.score.netScore !== winningScore) break
+        winsByContender.set(
+          leader.contenderId,
+          (winsByContender.get(leader.contenderId) ?? 0) + 1,
+        )
+      }
     }
 
     event.node.res.statusCode = 200
@@ -67,11 +87,21 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: 'Global challenge leaderboard fetched successfully.',
-      data: leaderboard.map((entry) => ({
-        ...entry,
-        challengesAttempted:
-          challengeIdsByContender.get(entry.contenderId)?.size ?? 0,
-      })),
+      data: leaderboard.map((entry) => {
+        const challengesAttempted =
+          challengeIdsByContender.get(entry.contenderId)?.size ?? 0
+        const challengesWon = winsByContender.get(entry.contenderId) ?? 0
+
+        return {
+          ...entry,
+          challengesAttempted,
+          challengesWon,
+          winRate:
+            challengesAttempted > 0
+              ? Math.round((challengesWon / challengesAttempted) * 1000) / 10
+              : 0,
+        }
+      }),
       statusCode: 200,
     }
   } catch (error: unknown) {


### PR DESCRIPTION
### Task
challenge-center/t-007: Build `/challenges/leaderboard` in kind_robots (kind: software)

### What changed / what I produced
- Added a championship-styled `/challenges/leaderboard` page with global and per-type rankings.
- Added podium cards plus a full standings table showing fights, wins, win rate, votes, and total score.
- Extended the existing leaderboard API to calculate distinct challenges attempted, tied challenge victories, and win rate without schema changes.
- Preserved links back to the existing Challenge Center fight card and the rankings links already present on challenge pages.

### How I verified
- Compared the branch against current `main`; it contains only the leaderboard page and its existing API endpoint.
- Checked the response contract against `buildChallengeLeaderboard` and the existing challenge type enum values.
- Confirmed win calculation is per challenge, awards tied leaders consistently, and avoids double-counting multiple variants as separate attempts.
- GitHub TypeScript, contract, and Vercel checks are the executable verification gates in this connector-only runtime.

### Stakes
reversible

### Flags for Reviewer
Please check the Vue template/type contract and the tied-win definition. No schema, migration, auth, production configuration, publishing, billing, or destructive action is included.

### Kaizen suggestion
Extract challenge leaderboard response types into a shared contract so the API, arena mini-leaderboard, and full rankings page cannot drift independently.