### PR TITLE
Fix cascading Cypress failures from database connection fan-out

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -62,6 +62,30 @@ jobs:
           echo "::error::Production did not serve ${TARGET_SHA} within ${MAX_WAIT}s (last seen: ${live:-unknown})."
           exit 1
 
+      - name: Verify database readiness
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+        run: |
+          echo "Waiting for three consecutive database health checks..."
+          deadline=$(( $(date +%s) + 180 ))
+          consecutive=0
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            body="$(curl -sf --max-time 15 "${BASE_URL}/api/health/database" || true)"
+            if printf '%s' "$body" | jq -e '.success == true and .statusCode == 200' >/dev/null 2>&1; then
+              consecutive=$(( consecutive + 1 ))
+              echo "  database healthy (${consecutive}/3)"
+              if [ "$consecutive" -ge 3 ]; then
+                exit 0
+              fi
+            else
+              consecutive=0
+              echo "  database unavailable; retrying in 5s..."
+            fi
+            sleep 5
+          done
+          echo "::error::Database did not remain healthy for three consecutive checks."
+          exit 1
+
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:

--- a/server/api/health/database.get.ts
+++ b/server/api/health/database.get.ts
@@ -1,0 +1,31 @@
+// /server/api/health/database.get.ts
+import { defineEventHandler, setResponseHeader } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+
+export default defineEventHandler(async (event) => {
+  const startedAt = Date.now()
+  setResponseHeader(event, 'Cache-Control', 'no-store')
+
+  try {
+    await prisma.$queryRaw<Array<{ ok: number }>>`SELECT 1 AS ok`
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Database is reachable.',
+      data: { latencyMs: Date.now() - startedAt },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    errorHandler(error)
+    event.node.res.statusCode = 503
+
+    return {
+      success: false,
+      message: 'Database is unavailable.',
+      data: { latencyMs: Date.now() - startedAt },
+      statusCode: 503,
+    }
+  }
+})

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -22,6 +22,14 @@ function readPositiveInteger(
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+function readNonNegativeInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
 function buildDatabaseUrl(url: string): string {
   const parsed = new URL(url)
   const connectTimeout = readPositiveInteger(
@@ -34,7 +42,15 @@ function buildDatabaseUrl(url: string): string {
   )
   const connectionLimit = readPositiveInteger(
     process.env.DATABASE_CONNECTION_LIMIT,
-    10,
+    2,
+  )
+  const minimumIdle = readNonNegativeInteger(
+    process.env.DATABASE_MINIMUM_IDLE,
+    0,
+  )
+  const idleTimeout = readPositiveInteger(
+    process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
+    30,
   )
 
   if (!parsed.searchParams.has('connectTimeout')) {
@@ -47,6 +63,14 @@ function buildDatabaseUrl(url: string): string {
 
   if (!parsed.searchParams.has('connectionLimit')) {
     parsed.searchParams.set('connectionLimit', String(connectionLimit))
+  }
+
+  if (!parsed.searchParams.has('minimumIdle')) {
+    parsed.searchParams.set('minimumIdle', String(minimumIdle))
+  }
+
+  if (!parsed.searchParams.has('idleTimeout')) {
+    parsed.searchParams.set('idleTimeout', String(idleTimeout))
   }
 
   return parsed.toString()
@@ -96,7 +120,15 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     ),
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
-      10,
+      2,
+    ),
+    minimumIdle: readNonNegativeInteger(
+      parsed.searchParams.get('minimumIdle') ?? undefined,
+      0,
+    ),
+    idleTimeout: readPositiveInteger(
+      parsed.searchParams.get('idleTimeout') ?? undefined,
+      30,
     ),
     ssl: {
       ca: sslCa,


### PR DESCRIPTION
## What changed

- Bound each MariaDB pool to 2 connections, with zero minimum idle and 30-second idle retirement.
- Added a no-cache `/api/health/database` readiness endpoint backed by `SELECT 1`.
- Gated Cypress on three consecutive healthy database checks after the target deployment goes live.

## Root cause

Vercel logs during the 90-failure run showed ProxySQL hostgroup 10 connection timeouts and closed MariaDB connections across the same routes Cypress reported. The prior pool-size fix raised the default to 10 but did not address serverless pool fan-out or long-lived idle connections.

## Verification

- Reviewed the complete three-file diff against current `main`.
- Confirmed explicit DATABASE_URL pool parameters and environment overrides still take precedence.
- GitHub/Vercel checks and the post-merge production Cypress run are the runtime verification gates.

## Stakes

Reversible runtime configuration and CI diagnostics. No schema or data changes.