### PR TITLE
Hotfix: restore the working MariaDB pool configuration

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -22,14 +22,6 @@ function readPositiveInteger(
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-function readNonNegativeInteger(
-  value: string | undefined,
-  fallback: number,
-): number {
-  const parsed = Number.parseInt(value ?? '', 10)
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
-}
-
 function buildDatabaseUrl(url: string): string {
   const parsed = new URL(url)
   const connectTimeout = readPositiveInteger(
@@ -42,15 +34,7 @@ function buildDatabaseUrl(url: string): string {
   )
   const connectionLimit = readPositiveInteger(
     process.env.DATABASE_CONNECTION_LIMIT,
-    2,
-  )
-  const minimumIdle = readNonNegativeInteger(
-    process.env.DATABASE_MINIMUM_IDLE,
-    0,
-  )
-  const idleTimeout = readPositiveInteger(
-    process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
-    30,
+    10,
   )
 
   if (!parsed.searchParams.has('connectTimeout')) {
@@ -63,14 +47,6 @@ function buildDatabaseUrl(url: string): string {
 
   if (!parsed.searchParams.has('connectionLimit')) {
     parsed.searchParams.set('connectionLimit', String(connectionLimit))
-  }
-
-  if (!parsed.searchParams.has('minimumIdle')) {
-    parsed.searchParams.set('minimumIdle', String(minimumIdle))
-  }
-
-  if (!parsed.searchParams.has('idleTimeout')) {
-    parsed.searchParams.set('idleTimeout', String(idleTimeout))
   }
 
   return parsed.toString()
@@ -120,15 +96,7 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     ),
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
-      2,
-    ),
-    minimumIdle: readNonNegativeInteger(
-      parsed.searchParams.get('minimumIdle') ?? undefined,
-      0,
-    ),
-    idleTimeout: readPositiveInteger(
-      parsed.searchParams.get('idleTimeout') ?? undefined,
-      30,
+      10,
     ),
     ssl: {
       ca: sslCa,


### PR DESCRIPTION
## Summary
- restore the MariaDB adapter pool configuration that is proven healthy on existing preview and production deployments
- keep the new `/api/health/database` readiness endpoint and Cypress preflight from #225
- keep the Conductor no-op sync reduction from silasfelinus/conductor#489

## Why
Post-merge production verification isolated a regression in #225's pool change:
- deployment `dpl_6nPr4dbQaALJNp5FgThnUszXmeqa` (limit=2, minimumIdle=0) consistently returns pool timeouts with active=0/idle=0
- the historical limit=2 deployment has the same cold-connection failure pattern
- older preview and production deployments using the restored configuration both return 200 from `/api/themes`
- the production migration runner also connected successfully, so TLS credentials and the upstream database are available

This hotfix reverts only `server/utils/prisma.ts` to the known-good pool behavior (default connectionLimit=10, driver-managed idle settings). The health gate remains so CI will fail clearly at readiness if connectivity regresses instead of cascading into dozens of endpoint failures.

## Verification
- exact known-good `server/utils/prisma.ts` blob restored from production commit `98fb8e0182eec688cd7e5f16e1dcf3c8eeae36fa`
- Vercel preview should be exercised at `/api/health/database` and `/api/themes` before merge