### PR TITLE
Fix channel tab flyout overlap

### DIFF
--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -106,7 +106,7 @@
       <ul
         v-if="expandedChannel"
         ref="channelFlyout"
-        class="channel-submenu menu absolute left-0 z-120 max-h-[min(32rem,calc(100dvh-5rem))] w-[min(22rem,calc(100vw-1rem))] overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl md:left-[calc(100%+0.5rem)] md:w-80"
+        class="channel-submenu menu absolute left-full z-120 ml-2 max-h-[min(32rem,calc(100dvh-5rem))] w-[min(22rem,calc(100vw-1rem))] overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl md:w-80"
         :style="{ top: `${channelFlyoutTop}px` }"
         :aria-label="expandedChannel.label + ' tabs'"
       >


### PR DESCRIPTION
## What changed

- anchors the tab flyout at `left-full` with a fixed gap from the channel menu
- removes the narrow-screen `left-0` overlay behavior

## Root cause

The merged flyout used `left-0` as its base position and only moved right at the `md` breakpoint. At narrower rendered widths, the tab menu was therefore placed directly over the channel menu.

## Impact

Tab menus now consistently open beyond the right edge of the channel list without changing or covering the channel menu layout.

## Validation

- one-line class correction in `components/navigation/channel-select.vue`
- branch is one commit ahead of `main` with no unrelated changes
