### PR TITLE
Daily Dream page + fix broken POST /api/sheets

### DIFF
--- a/components/pages/daily-dream-page.vue
+++ b/components/pages/daily-dream-page.vue
@@ -1,0 +1,229 @@
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl bg-base-300 p-4"
+  >
+    <!-- Loading / empty states -->
+    <div v-if="loading" class="flex items-center justify-center py-16">
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </div>
+
+    <div
+      v-else-if="!groups.length"
+      class="flex flex-col items-center gap-2 rounded-2xl bg-base-100 p-10 text-center"
+    >
+      <Icon name="kind-icon:moon" class="h-10 w-10 text-primary opacity-70" />
+      <h2 class="text-xl font-bold">No daily dream yet</h2>
+      <p class="max-w-md text-sm opacity-70">
+        Conductor proposes a new starter dream each morning and builds it the
+        next day — the first one will appear here once its records land.
+      </p>
+    </div>
+
+    <template v-else>
+      <!-- Header: the active dream -->
+      <header
+        class="flex flex-col gap-2 rounded-2xl bg-base-100 p-4 md:flex-row md:items-center md:justify-between"
+      >
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 text-sm text-primary">
+            <Icon name="kind-icon:moon" class="h-5 w-5" />
+            <span class="font-semibold uppercase tracking-wide">Daily Dream</span>
+            <span v-if="active?.date" class="badge badge-ghost badge-sm">{{
+              active.date
+            }}</span>
+          </div>
+          <h1 class="truncate text-2xl font-black md:text-3xl">
+            {{ activeTitle }}
+          </h1>
+          <p v-if="activeIdea" class="mt-1 max-w-3xl text-sm opacity-80">
+            {{ activeIdea }}
+          </p>
+        </div>
+
+        <div class="flex shrink-0 flex-wrap items-center gap-2">
+          <a
+            v-if="editLink"
+            :href="editLink"
+            target="_blank"
+            rel="noopener"
+            class="btn btn-primary btn-sm"
+          >
+            <Icon name="kind-icon:message-square-magic" class="h-4 w-4" />
+            Comment / edit this dream
+          </a>
+          <select
+            v-if="groups.length > 1"
+            v-model="selectedSlug"
+            class="select select-bordered select-sm"
+            aria-label="Choose a dream day"
+          >
+            <option v-for="g in groups" :key="g.slug" :value="g.slug">
+              {{ g.date }} — {{ g.title }}
+            </option>
+          </select>
+        </div>
+      </header>
+
+      <!-- The cast: real pitch cards -->
+      <div class="flex flex-wrap items-stretch justify-center gap-4">
+        <dream-pitch-sheet
+          v-for="sheet in activeSheets"
+          :key="sheet.id"
+          :dream="dreamShim(sheet)"
+          :sheet="sheet"
+          variant="card"
+          :auto-load="false"
+          :allow-ensure="false"
+          :allow-edit="false"
+          :allow-actions="false"
+        />
+      </div>
+
+      <!-- Art strip: attached images at a glance -->
+      <div v-if="artImages.length" class="rounded-2xl bg-base-100 p-4">
+        <h2 class="mb-2 flex items-center gap-2 text-lg font-bold">
+          <Icon name="kind-icon:palette" class="h-5 w-5 text-primary" />
+          Dream art
+        </h2>
+        <div class="flex flex-wrap gap-3">
+          <img
+            v-for="img in artImages"
+            :key="img.src"
+            :src="img.src"
+            :alt="img.alt"
+            loading="lazy"
+            class="h-40 rounded-xl border border-base-200 object-cover"
+          />
+        </div>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+// /daily-dream — the rolling daily-dream showcase. Conductor's dream-cycle
+// pipeline creates one starter dream per day (2 locations, 3 characters, a
+// narrator bot, 2 rewards) as real records with PitchSheets tagged
+// extraData.dreamCycle; this page groups those sheets by dream and renders
+// the actual dream-pitch-sheet cards.
+import { computed, onMounted, ref, watch } from 'vue'
+import {
+  useSheetStore,
+  type SheetDream,
+  type SheetWithDream,
+} from '@/stores/sheetStore'
+
+const sheetStore = useSheetStore()
+const loading = ref(true)
+const selectedSlug = ref<string>('')
+
+interface DreamCycleMeta {
+  dreamCycle?: string
+  proposalDate?: string
+  elementType?: string
+  element?: string
+}
+
+function metaOf(sheet: SheetWithDream): DreamCycleMeta {
+  const extra = sheet.extraData
+  if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
+    return extra as DreamCycleMeta
+  }
+  return {}
+}
+
+const cycleSheets = computed(() =>
+  sheetStore.sheets.filter((s) => Boolean(metaOf(s).dreamCycle)),
+)
+
+interface DreamGroup {
+  slug: string
+  date: string
+  title: string
+  sheets: SheetWithDream[]
+}
+
+const ELEMENT_ORDER = ['PITCH', 'LOCATION', 'CHARACTER', 'NARRATOR', 'REWARD', 'SCENARIO']
+
+const groups = computed<DreamGroup[]>(() => {
+  const bySlug = new Map<string, DreamGroup>()
+  for (const sheet of cycleSheets.value) {
+    const meta = metaOf(sheet)
+    const slug = meta.dreamCycle as string
+    let group = bySlug.get(slug)
+    if (!group) {
+      group = { slug, date: meta.proposalDate || '', title: '', sheets: [] }
+      bySlug.set(slug, group)
+    }
+    group.sheets.push(sheet)
+    if (meta.proposalDate && meta.proposalDate > group.date) {
+      group.date = meta.proposalDate
+    }
+    if (metaOf(sheet).elementType === 'PITCH' && sheet.title) {
+      group.title = sheet.title
+    }
+  }
+  const list = [...bySlug.values()]
+  for (const g of list) {
+    if (!g.title) {
+      g.title = g.slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    }
+    g.sheets.sort(
+      (a, b) =>
+        ELEMENT_ORDER.indexOf(metaOf(a).elementType || 'PITCH') -
+        ELEMENT_ORDER.indexOf(metaOf(b).elementType || 'PITCH'),
+    )
+  }
+  return list.sort((a, b) => (b.date || '').localeCompare(a.date || ''))
+})
+
+const active = computed(
+  () =>
+    groups.value.find((g) => g.slug === selectedSlug.value) || groups.value[0],
+)
+const activeSheets = computed(() => active.value?.sheets ?? [])
+const pitchSheet = computed(() =>
+  activeSheets.value.find((s) => metaOf(s).elementType === 'PITCH'),
+)
+const activeTitle = computed(() => active.value?.title || 'Daily Dream')
+const activeIdea = computed(
+  () => pitchSheet.value?.pitch || pitchSheet.value?.hook || '',
+)
+
+// Comment/edit link → the conductor backlog file's Notes-from-Silas section.
+const editLink = computed(() => {
+  const g = active.value
+  if (!g?.date || !g.slug) return ''
+  return `https://github.com/silasfelinus/conductor/blob/main/projects/dream-cycle/backlog/${g.date}-${g.slug}.md#notes-from-silas`
+})
+
+const artImages = computed(() =>
+  activeSheets.value
+    .filter((s) => s.imagePath)
+    .map((s) => ({ src: s.imagePath as string, alt: s.title || 'Dream art' })),
+)
+
+function dreamShim(sheet: SheetWithDream): { id: number; dreamType: SheetDream['dreamType'] } {
+  // dream-pitch-sheet themes by dream.dreamType; feed it the element type so
+  // location/character/narrator/reward cards get their real theming even when
+  // the sheet isn't attached to a Dream row.
+  return {
+    id: sheet.dreamId ?? 0,
+    dreamType: (metaOf(sheet).elementType || 'PITCH') as SheetDream['dreamType'],
+  }
+}
+
+watch(groups, (list) => {
+  if (list.length && !list.some((g) => g.slug === selectedSlug.value)) {
+    selectedSlug.value = list[0].slug
+  }
+})
+
+onMounted(async () => {
+  try {
+    await sheetStore.fetchSheets()
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/content/channels/play/daily-dream.md
+++ b/content/channels/play/daily-dream.md
@@ -1,0 +1,14 @@
+---
+contentType: tab
+channelKey: play
+tabKey: daily-dream
+label: Daily Dream
+title: Daily Dream
+subtitle: Today's starter dream
+description: The rolling daily dream — Conductor proposes a new world each morning and builds it into characters, locations, rewards, and a narrator.
+icon: kind-icon:moon
+route: /daily-dream
+sort: 12
+---
+
+Meet today's freshly built dream: its locations, cast, narrator, and rewards.

--- a/content/daily-dream.md
+++ b/content/daily-dream.md
@@ -1,0 +1,17 @@
+---
+title: Daily Dream
+room: 'Dream Deck'
+subtitle: Today's starter dream, freshly built
+description: Every morning Conductor proposes a starter dream — two locations, three characters, a narrator, and two rewards — and builds it the next day. Meet today's world.
+icon: kind-icon:moon
+tooltip: The rolling daily dream — a new world every day, pitch cards and all.
+sort: highlight
+dottiTip: A whole new world arrives every morning. I alphabetize them so they don't wander off.
+amiTip: The dreams are daily. The consequences are permanent.
+channelKey: play
+tabKey: daily-dream
+loadingMessage: Waking today's dream...
+refreshLabel: Refresh Dream
+---
+
+:daily-dream-page

--- a/server/api/sheets/index.post.ts
+++ b/server/api/sheets/index.post.ts
@@ -1,64 +1,119 @@
-// /server/api/sheets/[id].get.ts
-import { defineEventHandler, createError } from 'h3'
+// /server/api/sheets/index.post.ts
+import { defineEventHandler, createError, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
-import { validateApiKey } from '@/server/utils/validateKey'
+import { requireApiUser } from '@/server/utils/authGuard'
+import { buildPitchSheetFromDream } from '@/server/utils/pitchSheets/defaults'
+import { sanitizePitchSheetPayload } from '@/server/utils/pitchSheets/payload'
+
+const artImageSelect = {
+  select: {
+    id: true,
+    imagePath: true,
+    thumbnailData: true,
+    fileName: true,
+    fileType: true,
+  },
+} as const
 
 export default defineEventHandler(async (event) => {
-  let id = 0
-
   try {
-    id = Number(event.context.params?.id)
-    if (Number.isNaN(id) || id <= 0) {
-      throw createError({ statusCode: 400, message: 'Invalid PitchSheet ID. Must be a positive integer.' })
+    const { user } = await requireApiUser(event)
+
+    const body = await readBody<Record<string, unknown>>(event).catch(
+      () => ({}),
+    )
+    const overrides = sanitizePitchSheetPayload(body || {})
+    const dreamId =
+      body && body.dreamId != null ? Number(body.dreamId) : undefined
+
+    // Dream-attached create: verify + delegate to the dream-derived defaults
+    // (same behavior as POST /api/sheets/by-dream/{dreamId}).
+    if (dreamId !== undefined) {
+      if (Number.isNaN(dreamId) || dreamId <= 0) {
+        throw createError({
+          statusCode: 400,
+          message: 'Invalid dreamId. Must be a positive integer.',
+        })
+      }
+
+      const dream = await prisma.dream.findUnique({ where: { id: dreamId } })
+      if (!dream) {
+        throw createError({
+          statusCode: 404,
+          message: `Dream with ID ${dreamId} not found.`,
+        })
+      }
+      if (dream.userId !== user.id && user.Role !== 'ADMIN') {
+        throw createError({
+          statusCode: 403,
+          message: `You are not authorized to create a PitchSheet for Dream ${dreamId}.`,
+        })
+      }
+
+      const existing = await prisma.pitchSheet.findUnique({
+        where: { dreamId },
+        include: { Dream: true, ArtImage: artImageSelect },
+      })
+      if (existing) {
+        event.node.res.statusCode = 200
+        return {
+          success: true,
+          message: 'PitchSheet already exists for this Dream.',
+          data: existing,
+          statusCode: 200,
+        }
+      }
+
+      const created = await prisma.pitchSheet.create({
+        data: buildPitchSheetFromDream(dream, user.id, overrides),
+        include: { Dream: true, ArtImage: artImageSelect },
+      })
+
+      event.node.res.statusCode = 201
+      return {
+        success: true,
+        message: 'PitchSheet created successfully.',
+        data: created,
+        statusCode: 201,
+      }
     }
 
-    const { isValid, user } = await validateApiKey(event)
-    const data = await prisma.pitchSheet.findUnique({
-      where: { id },
-      include: {
-        Dream: true,
-        Project: true,
-        ArtImage: {
-          select: {
-            id: true,
-            imagePath: true,
-            thumbnailData: true,
-            fileName: true,
-            fileType: true,
-          },
-        },
+    // Standalone create (no dream): title is the only required field.
+    const title = typeof overrides.title === 'string' ? overrides.title.trim() : ''
+    if (!title) {
+      throw createError({
+        statusCode: 400,
+        message: 'A "title" is required to create a PitchSheet without a dreamId.',
+      })
+    }
+
+    const created = await prisma.pitchSheet.create({
+      data: {
+        ...overrides,
+        title,
+        layoutKey:
+          typeof overrides.layoutKey === 'string' && overrides.layoutKey
+            ? overrides.layoutKey
+            : 'pitch-card',
+        userId: user.id,
       },
+      include: { Dream: true, ArtImage: artImageSelect },
     })
 
-    if (!data) {
-      throw createError({ statusCode: 404, message: `PitchSheet with ID ${id} not found.` })
-    }
-
-    const isOwner =
-      data.userId === user?.id ||
-      data.Dream?.userId === user?.id ||
-      data.Project?.userId === user?.id
-    const canView =
-      data.isPublic &&
-      (data.Dream?.isPublic ?? data.Project?.isPublic ?? false)
-    if (!canView && (!isValid || !user || (user.Role !== 'ADMIN' && !isOwner))) {
-      throw createError({ statusCode: 403, message: 'You are not authorized to view this PitchSheet.' })
-    }
-
-    event.node.res.statusCode = 200
+    event.node.res.statusCode = 201
     return {
       success: true,
-      message: 'PitchSheet fetched successfully.',
-      data,
-      statusCode: 200,
+      message: 'PitchSheet created successfully.',
+      data: created,
+      statusCode: 201,
     }
   } catch (error) {
     const handled = errorHandler(error)
     event.node.res.statusCode = handled.statusCode || 500
     return {
       success: false,
-      message: handled.message || `Failed to fetch PitchSheet with ID ${id}.`,
+      message: handled.message || 'Failed to create PitchSheet.',
       data: null,
       statusCode: event.node.res.statusCode,
     }


### PR DESCRIPTION
## What this does

Two pieces from the rolling daily-dream pipeline (conductor PR silasfelinus/conductor#487):

### 1. `/daily-dream` page — real pitch cards for the daily dream

Conductor's dream-cycle pipeline proposes one starter dream each morning (2 locations, 3 characters, a narrator bot, 2 rewards — one SKILL, one ITEM) and builds it the next day into real records with PitchSheets tagged `extraData.dreamCycle`. This page renders them:

- `components/pages/daily-dream-page.vue` — fetches sheets via `useSheetStore().fetchSheets()`, filters `extraData.dreamCycle`, groups by dream (newest `proposalDate` first), and renders the **real `dream-pitch-sheet` cards** with per-type theming (via an `{id, dreamType}` dream shim; sheets passed directly, no refetch). Includes a day-picker for previous dreams, an attached-art strip, and a **"Comment / edit this dream"** button linking to the conductor backlog file's Notes-from-Silas section.
- `content/daily-dream.md` — the content-driven route (`:daily-dream-page`).
- `content/channels/play/daily-dream.md` — Play channel nav tab (sort 12).

The conductor daily digest email links here as "View the Daily Dream page".

### 2. Fix `POST /api/sheets` (conductor kind-robots/t-016)

`server/api/sheets/index.post.ts` was a mis-copied GET-by-id handler (header comment read `[id].get.ts`; it did `prisma.pitchSheet.findUnique` on `event.context.params.id`) — on the collection route `params.id` is undefined, so **every POST /api/sheets returned 400 and never created anything**.

Replaced with a real create handler mirroring `sheets/by-dream/[dreamId].post.ts`:
- `requireApiUser`; body filtered through `sanitizePitchSheetPayload`
- optional `dreamId`: verifies the Dream + ownership/admin, idempotently returns an existing sheet (dreamId is `@unique`), else creates via `buildPitchSheetFromDream`
- standalone (no dreamId): requires `title`, attributes to the authenticated user
- house `{success, message, data, statusCode}` envelope, 201

## Notes for review
- No schema changes; no new dependencies; page is public (no auth-gate frontmatter), matching `/dreams`.
- The page renders an empty-state until the first dream's records land, so merging before the pipeline runs is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQvC7yeFDrY6fEj87XAUdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQvC7yeFDrY6fEj87XAUdE)_