### PR TITLE
Validate MariaDB connections before pooled reuse

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -22,6 +22,14 @@ function readPositiveInteger(
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+function readNonNegativeInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
 function buildDatabaseUrl(url: string): string {
   const parsed = new URL(url)
   const connectTimeout = readPositiveInteger(
@@ -36,6 +44,10 @@ function buildDatabaseUrl(url: string): string {
     process.env.DATABASE_CONNECTION_LIMIT,
     10,
   )
+  const minDelayValidation = readNonNegativeInteger(
+    process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
+    0,
+  )
 
   if (!parsed.searchParams.has('connectTimeout')) {
     parsed.searchParams.set('connectTimeout', String(connectTimeout))
@@ -47,6 +59,16 @@ function buildDatabaseUrl(url: string): string {
 
   if (!parsed.searchParams.has('connectionLimit')) {
     parsed.searchParams.set('connectionLimit', String(connectionLimit))
+  }
+
+  // ProxySQL can close a socket between rapid borrows. Validate every
+  // connection before use so stale sockets are discarded before Prisma sends
+  // a command. Set DATABASE_MIN_DELAY_VALIDATION_MS to relax this if needed.
+  if (!parsed.searchParams.has('minDelayValidation')) {
+    parsed.searchParams.set(
+      'minDelayValidation',
+      String(minDelayValidation),
+    )
   }
 
   return parsed.toString()
@@ -97,6 +119,10 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
       10,
+    ),
+    minDelayValidation: readNonNegativeInteger(
+      parsed.searchParams.get('minDelayValidation') ?? undefined,
+      0,
     ),
     ssl: {
       ca: sslCa,


### PR DESCRIPTION
## Summary
- keep the proven MariaDB pool size restored by #227
- set `minDelayValidation=0` so the connector validates every pooled connection before Prisma uses it
- allow an environment override with `DATABASE_MIN_DELAY_VALIDATION_MS`

## Why
The post-merge Cypress run passed the database readiness gate, then produced 17 `Cannot execute new commands: connection closed` failures across write-heavy API routes. There were no new `Max connect timeout reached` errors.

MariaDB Connector/Node.js defaults `minDelayValidation` to 500 ms, which intentionally skips connection validation when a socket is borrowed again quickly. ProxySQL can close a socket inside that window under test load, so Prisma receives a stale connection. Setting the documented option to 0 validates on every borrow and lets the pool discard/reconnect stale sockets before a command is sent.

Official option documentation: https://mariadb.com/docs/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api

## Verification plan
- TypeScript and contract checks
- preview database health probe
- parallel preview API requests
- after merge, three consecutive Production health checks and the full push-triggered Cypress run