### PR TITLE
Treat Kind Guest as unauthenticated

### DIFF
--- a/components/navigation/login-switcher.vue
+++ b/components/navigation/login-switcher.vue
@@ -7,8 +7,8 @@
       type="button"
       class="login-switcher-avatar btn btn-ghost relative shrink-0 overflow-hidden rounded-full border border-base-300 bg-base-100 p-0"
       :class="store.isOpen ? 'ring-2 ring-primary' : ''"
-      title="Switch account"
-      aria-label="Switch account"
+      :title="accountMenuLabel"
+      :aria-label="accountMenuLabel"
       :aria-expanded="store.isOpen"
       @click.stop="store.toggle"
     >
@@ -37,12 +37,15 @@
 
         <div class="min-w-0 flex-1">
           <p class="truncate text-sm font-black text-base-content">
-            {{ userStore.username }}
+            {{ userStore.isLoggedIn ? userStore.username : 'Guest' }}
           </p>
 
           <p class="truncate text-xs text-base-content/60">
-            {{ userStore.role }} ·
-            {{ userStore.isLoggedIn ? 'Logged in' : 'Guest mode' }}
+            {{
+              userStore.isLoggedIn
+                ? `${userStore.role} · Logged in`
+                : 'Not logged in'
+            }}
           </p>
         </div>
       </header>
@@ -67,11 +70,11 @@
           type="button"
           class="flex w-full items-center gap-3 rounded-2xl border p-2 text-left transition hover:bg-base-200"
           :class="
-            account.userId === userStore.userId
+            account.userId === currentUserId
               ? 'border-primary bg-primary/10'
               : 'border-base-300 bg-base-100'
           "
-          :disabled="store.isSwitching || account.userId === userStore.userId"
+          :disabled="store.isSwitching || account.userId === currentUserId"
           @click="store.switchToAccount(account.userId)"
         >
           <img
@@ -91,7 +94,7 @@
           </span>
 
           <Icon
-            v-if="account.userId === userStore.userId"
+            v-if="account.userId === currentUserId"
             name="kind-icon:check"
             class="h-4 w-4 text-success"
           />
@@ -106,7 +109,10 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-2 gap-2">
+      <div
+        v-if="userStore.isLoggedIn"
+        class="grid grid-cols-2 gap-2"
+      >
         <button
           type="button"
           class="btn btn-sm rounded-2xl"
@@ -126,7 +132,18 @@
         </button>
       </div>
 
+      <NuxtLink
+        v-else
+        to="/login"
+        class="btn btn-primary btn-sm rounded-2xl"
+        @click="store.close"
+      >
+        <Icon name="kind-icon:login" class="h-4 w-4" />
+        Log in
+      </NuxtLink>
+
       <button
+        v-if="userStore.isLoggedIn"
         type="button"
         class="btn btn-sm btn-ghost rounded-2xl text-error"
         @click="logout"
@@ -139,7 +156,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useLoginManagerStore } from '@/stores/loginStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -147,6 +164,12 @@ const store = useLoginManagerStore()
 const userStore = useUserStore()
 const menuRef = ref<HTMLElement | null>(null)
 const fallbackAvatar = '/images/kindart.webp'
+const currentUserId = computed(() => {
+  return userStore.isLoggedIn ? (userStore.user?.id ?? null) : null
+})
+const accountMenuLabel = computed(() => {
+  return userStore.isLoggedIn ? 'Switch account' : 'Log in or switch account'
+})
 
 function handlePointerDown(event: PointerEvent) {
   if (!store.isOpen) {
@@ -162,24 +185,26 @@ function captureCurrent() {
   store.captureCurrentSession()
 }
 
-function addAccount() {
+async function addAccount(): Promise<void> {
   store.close()
   userStore.logout()
+  await navigateTo('/login')
 }
 
 function logout() {
   store.close()
   userStore.logout()
+  store.clearActiveSession()
 }
 
-watch(
-  () => userStore.userId,
-  (newId) => {
-    if (newId) {
-      store.captureCurrentSession()
-    }
-  },
-)
+watch(currentUserId, (newId) => {
+  if (newId) {
+    store.captureCurrentSession()
+    return
+  }
+
+  store.clearActiveSession()
+})
 
 onMounted(() => {
   store.initialize()

--- a/stores/loginStore.ts
+++ b/stores/loginStore.ts
@@ -53,8 +53,10 @@ function parseAccounts(value: string | null): ManagedLogin[] {
         typeof account === 'object' &&
         account !== null &&
         typeof account.userId === 'number' &&
+        account.userId !== 10 &&
         typeof account.username === 'string' &&
-        typeof account.token === 'string'
+        typeof account.token === 'string' &&
+        account.token.trim().length > 0
       )
     })
   } catch {
@@ -78,6 +80,9 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
   const lastError = ref<string | null>(null)
 
   const userStore = useUserStore()
+  const currentUserId = computed(() => {
+    return userStore.isLoggedIn ? (userStore.user?.id ?? null) : null
+  })
 
   const activeAccount = computed(() => {
     return accounts.value.find((account) => account.userId === activeUserId.value) ?? null
@@ -85,7 +90,7 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
 
   const otherAccounts = computed(() => {
     return accounts.value
-      .filter((account) => account.userId !== userStore.userId)
+      .filter((account) => account.userId !== currentUserId.value)
       .sort((a, b) => b.lastUsedAt.localeCompare(a.lastUsedAt))
   })
 
@@ -106,12 +111,14 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
   function initialize() {
     accounts.value = parseAccounts(getFromLocalStorage(loginStorageKey))
 
-    const storedActiveId = Number(getFromLocalStorage(activeLoginStorageKey))
-    activeUserId.value = Number.isFinite(storedActiveId) ? storedActiveId : null
+    activeUserId.value = currentUserId.value
 
-    if (userStore.user && userStore.token) {
+    if (currentUserId.value && userStore.token) {
       captureCurrentSession()
+      return
     }
+
+    persist()
   }
 
   function open() {
@@ -127,23 +134,25 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
   }
 
   function captureCurrentSession(relationship: LoginRelationship = 'testing') {
-    if (!userStore.user || !userStore.token || userStore.user.id === 10) {
+    const currentUser = userStore.user
+
+    if (!userStore.isLoggedIn || !currentUser || !userStore.token) {
       return
     }
 
     const now = new Date().toISOString()
     const existing = accounts.value.find(
-      (account) => account.userId === userStore.user?.id,
+      (account) => account.userId === currentUser.id,
     )
 
     const managedLogin: ManagedLogin = {
-      userId: userStore.user.id,
-      username: userStore.user.username,
-      role: userStore.user.Role ?? 'USER',
+      userId: currentUser.id,
+      username: currentUser.username,
+      role: currentUser.Role ?? 'USER',
       token: userStore.token,
       googleToken: userStore.googleToken,
-      avatarImage: userStore.user.avatarImage,
-      artImageId: userStore.user.artImageId,
+      avatarImage: currentUser.avatarImage,
+      artImageId: currentUser.artImageId,
       label: existing?.label,
       relationship: existing?.relationship ?? relationship,
       lastUsedAt: now,
@@ -179,7 +188,11 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
         force: true,
       })
 
-      if (!userStore.user || userStore.user.id !== account.userId) {
+      if (
+        !userStore.isLoggedIn ||
+        !userStore.user ||
+        userStore.user.id !== account.userId
+      ) {
         throw new Error('That saved login is no longer valid.')
       }
 
@@ -235,9 +248,14 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
     accounts.value = accounts.value.filter((account) => account.userId !== userId)
 
     if (activeUserId.value === userId) {
-      activeUserId.value = userStore.user?.id ?? null
+      activeUserId.value = currentUserId.value
     }
 
+    persist()
+  }
+
+  function clearActiveSession() {
+    activeUserId.value = null
     persist()
   }
 
@@ -267,6 +285,7 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
     updateAccountRelationship,
     updateAccountLabel,
     removeAccount,
+    clearActiveSession,
     clearSavedAccounts,
   }
 })

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -459,6 +459,11 @@ export const useUserStore = defineStore('userStore', () => {
         })
 
         if (res.success && res.data) {
+          if (res.data.id === 10) {
+            lastError.value = 'Guest sessions are not authenticated.'
+            return 'invalid'
+          }
+
           await setUser(res.data)
 
           if (stayLoggedIn.value && token.value) {
@@ -686,8 +691,11 @@ export const useUserStore = defineStore('userStore', () => {
 
       const loginData = normalizeLoginData(res.data)
 
-      if (!loginData.user?.id) {
-        const message = 'Login response did not include a valid user.'
+      if (!loginData.user?.id || loginData.user.id === 10) {
+        const message =
+          loginData.user?.id === 10
+            ? 'Kind Guest is not a login account.'
+            : 'Login response did not include a valid user.'
         handleError(new Error(message), 'login')
         lastError.value = message
         return { success: false, message }


### PR DESCRIPTION
## What changed

- shows a real `/login` action in the account switcher whenever there is no authenticated user
- hides Save, Add, and Logout Current actions from guest sessions
- keys account highlighting and session capture to a real authenticated user instead of the legacy `userId ?? 10` fallback
- removes legacy user 10 entries from saved login storage
- clears the active managed-login state when the user logs out
- rejects user 10 during token validation and direct login

## Root cause

The global user store still exposes user ID 10 as a compatibility fallback for anonymous content ownership. The account switcher used that fallback as though it were an active authentication identity, and its Logout Current button was rendered unconditionally.

## Impact

Logging out now immediately produces a guest state with a genuine Log In link. Kind Guest can no longer be captured, restored, highlighted, or validated as a logged-in account.

The content/generation fallback remains untouched for now because it has many non-auth consumers; this change isolates it from authentication rather than breaking those workflows.

## Validation

- branch is current with `main` and zero commits behind
- changed only the user store, managed-login store, and account-switcher component
- verified guest ID filtering, invalid-session handling, logout cleanup, and conditional login/logout rendering
- full TypeScript and browser checks are delegated to GitHub CI
