### PR TITLE
Use vertical overflow in channel selector

### DIFF
--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -38,7 +38,7 @@
     <div tabindex="0" class="dropdown-content z-110 mt-2">
       <ul
         ref="channelMenu"
-        class="menu max-h-[min(38rem,calc(100dvh-5rem))] w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="menu max-h-[calc(100dvh-5rem)] w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
         @scroll="closeChannelTabs"
       >
         <li
@@ -106,7 +106,7 @@
       <ul
         v-if="expandedChannel"
         ref="channelFlyout"
-        class="channel-submenu menu absolute left-full z-120 ml-2 max-h-[min(32rem,calc(100dvh-5rem))] w-[min(22rem,calc(100vw-1rem))] overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl md:w-80"
+        class="channel-submenu menu absolute left-full z-120 ml-2 max-h-[calc(100dvh-5rem)] w-[min(22rem,calc(100vw-1rem))] overflow-x-hidden overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl md:w-80"
         :style="{ top: `${channelFlyoutTop}px` }"
         :aria-label="expandedChannel.label + ' tabs'"
       >


### PR DESCRIPTION
## What changed

- removes the fixed 38rem channel-list and 32rem tab-list height caps
- lets both menus use the available viewport height before scrolling
- explicitly hides horizontal overflow
- keeps vertical overflow on `auto`, so scrollbars appear only when content genuinely exceeds the viewport
- contains vertical overscroll inside each menu

## Why

The fixed height caps forced scrolling even on tall XL displays. Because only the y-axis was declared, small width overflow could also produce an awkward horizontal scrollbar.

## Impact

The channel selector remains a single vertical list with its right-side tab flyout. On larger screens it shows as much content as fits naturally; if the number of channels or tabs truly exceeds the viewport, only that list scrolls vertically.

## Validation

- one current-main commit
- one component changed
- two class-only edits
- branch is zero commits behind `main`
