### PR TITLE
Remove retired Aurora animation references

### DIFF
--- a/components/screenfx/fx-region.vue
+++ b/components/screenfx/fx-region.vue
@@ -53,7 +53,6 @@ type ComponentMap = Record<
 >
 
 const componentsMap: ComponentMap = {
-  'aurora-effect': resolveComponent('LazyAuroraEffect'),
   'starfield-effect': resolveComponent('LazyStarfieldEffect'),
   'constellation-effect': resolveComponent('LazyConstellationEffect'),
   'wishing-stars': resolveComponent('LazyWishingStars'),

--- a/public/components.json
+++ b/public/components.json
@@ -278,7 +278,6 @@
       "animation-loader",
       "animation-tester",
       "ascii-aquarium",
-      "aurora-effect",
       "bubble-effect",
       "butterfly-animation",
       "constellation-effect",

--- a/stores/animationPreferenceStore.ts
+++ b/stores/animationPreferenceStore.ts
@@ -1,7 +1,7 @@
 // /stores/animationPreferenceStore.ts
 import { defineStore } from 'pinia'
 import { computed, reactive, ref } from 'vue'
-import type { AnimationEffectId } from './animationStore'
+import { isAnimationEffectId, type AnimationEffectId } from './animationStore'
 
 export type StartupAnimationChoice = AnimationEffectId | 'random' | 'none'
 
@@ -45,6 +45,14 @@ function clamp(value: unknown, min: number, max: number, fallback: number): numb
   return Math.min(max, Math.max(min, parsed))
 }
 
+function sanitizeStartupEffect(value: unknown): StartupAnimationChoice {
+  if (value === 'random' || value === 'none' || isAnimationEffectId(value)) {
+    return value
+  }
+
+  return DEFAULT_PREFERENCES.startupEffect
+}
+
 function sanitizePreferences(value: unknown): AnimationPreferences {
   const source: Partial<AnimationPreferences> =
     value && typeof value === 'object'
@@ -56,10 +64,7 @@ function sanitizePreferences(value: unknown): AnimationPreferences {
       : {}
 
   return {
-    startupEffect:
-      typeof source.startupEffect === 'string'
-        ? (source.startupEffect as StartupAnimationChoice)
-        : DEFAULT_PREFERENCES.startupEffect,
+    startupEffect: sanitizeStartupEffect(source.startupEffect),
     butterflies: {
       adaptive:
         typeof butterflies.adaptive === 'boolean'
@@ -163,7 +168,7 @@ export const useAnimationPreferenceStore = defineStore(
     }
 
     function setStartupEffect(value: StartupAnimationChoice): void {
-      preferences.startupEffect = value
+      preferences.startupEffect = sanitizeStartupEffect(value)
       persist()
     }
 

--- a/stores/animationStore.ts
+++ b/stores/animationStore.ts
@@ -10,7 +10,6 @@ export type FxSurfaceMap = Record<FxRegion, Record<FxPlacement, boolean>>
 export const FX_REGIONS: FxRegion[] = ['header', 'sheet', 'page', 'hand']
 
 export type AnimationEffectId =
-  | 'aurora-effect'
   | 'starfield-effect'
   | 'constellation-effect'
   | 'wishing-stars'
@@ -100,16 +99,6 @@ function mergeSurfaces(
 }
 
 const allEffects: AnimationEffect[] = [
-  {
-    id: 'aurora-effect',
-    label: 'Aurora',
-    reveal: 'Borealis!',
-    icon: 'kind-icon:rainbow',
-    tooltip: 'Northern lights drift across the sky 🌌',
-    color: '#14b8a6',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
   {
     id: 'starfield-effect',
     label: 'Warp Drive',
@@ -386,6 +375,15 @@ const allEffects: AnimationEffect[] = [
     preferredSurface: 'page',
   },
 ]
+
+export function isAnimationEffectId(
+  value: unknown,
+): value is AnimationEffectId {
+  return (
+    typeof value === 'string' &&
+    allEffects.some((effect) => effect.id === value)
+  )
+}
 
 function pickRandomEffect(): AnimationEffectId {
   const safeEffects = allEffects.filter((effect) => effect.generationSafe)

--- a/stores/helpers/narratorHelper.ts
+++ b/stores/helpers/narratorHelper.ts
@@ -302,8 +302,6 @@ export const narratorLoreTopics: NarratorLoreTopic[] = [
 // Kept as a lightweight name→id lookup so the Narrator can resolve
 // "make it rain" → 'rain-effect' without importing the full store.
 export const narratorAnimationAliases: Record<string, string> = {
-  aurora: 'aurora-effect',
-  borealis: 'aurora-effect',
   warp: 'starfield-effect',
   hyperspace: 'starfield-effect',
   stars: 'starfield-effect',


### PR DESCRIPTION
## What changed

- removes `aurora-effect` from the animation ID type and effect catalog
- removes the dead renderer mapping to the deleted Aurora component
- removes Aurora and Borealis narrator aliases
- removes the stale component-index entry
- validates persisted startup preferences against the live effect catalog
- resets retired or unknown stored effects to Butterfly Scouts and persists the repaired preference

## Root cause

The Aurora component was deleted, but its catalog metadata and aliases remained. The startup preference sanitizer also accepted any string, allowing old local storage to keep selecting a retired effect.

## Impact

Aurora no longer appears in user animation preferences, random selection, narrator commands, renderer lookup, or component discovery. Existing browsers that stored Aurora automatically migrate to the default startup animation.

## Validation

- branch is zero commits behind `main`
- confirmed `aurora-effect` is absent from all modified runtime catalogs
- confirmed startup preferences no longer use an unchecked string cast
- full TypeScript and browser checks are delegated to GitHub CI
