### PR TITLE
Fix TypeScript errors on main

### DIFF
--- a/components/pages/daily-dream-page.vue
+++ b/components/pages/daily-dream-page.vue
@@ -214,8 +214,9 @@ function dreamShim(sheet: SheetWithDream): { id: number; dreamType: SheetDream['
 }
 
 watch(groups, (list) => {
-  if (list.length && !list.some((g) => g.slug === selectedSlug.value)) {
-    selectedSlug.value = list[0].slug
+  const first = list[0]
+  if (first && !list.some((g) => g.slug === selectedSlug.value)) {
+    selectedSlug.value = first.slug
   }
 })
 

--- a/server/api/sheets/index.post.ts
+++ b/server/api/sheets/index.post.ts
@@ -20,12 +20,12 @@ export default defineEventHandler(async (event) => {
   try {
     const { user } = await requireApiUser(event)
 
-    const body = await readBody<Record<string, unknown>>(event).catch(
-      () => ({}),
-    )
-    const overrides = sanitizePitchSheetPayload(body || {})
+    const body: Record<string, unknown> = await readBody<
+      Record<string, unknown>
+    >(event).catch(() => ({}))
+    const overrides = sanitizePitchSheetPayload(body)
     const dreamId =
-      body && body.dreamId != null ? Number(body.dreamId) : undefined
+      body.dreamId != null ? Number(body.dreamId) : undefined
 
     // Dream-attached create: verify + delegate to the dream-derived defaults
     // (same behavior as POST /api/sheets/by-dream/{dreamId}).


### PR DESCRIPTION
## Summary

- narrow the first Daily Dream group before reading its slug
- keep the sheets POST body typed as `Record<string, unknown>`
- remove now-redundant nullable-body checks

## Why

The latest main TypeScript workflow reports:

- `components/pages/daily-dream-page.vue(218,26): TS2532`
- two `TS2339` errors for `body.dreamId` in `server/api/sheets/index.post.ts`

These changes are type-safety fixes only; runtime behavior is unchanged.

## Verification

GitHub TypeScript and contract checks will run on this PR.