### PR TITLE
Add Animation Manager registry and Bioluminescent Tide

### DIFF
--- a/components/screenfx/bioluminescent-tide.vue
+++ b/components/screenfx/bioluminescent-tide.vue
@@ -1,0 +1,407 @@
+<!-- /components/screenfx/bioluminescent-tide.vue -->
+<template>
+  <canvas ref="canvasRef" class="bioluminescent-tide" />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+interface Lantern {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  radius: number
+  hue: number
+  phase: number
+  depth: number
+}
+
+interface Ripple {
+  x: number
+  y: number
+  radius: number
+  alpha: number
+  speed: number
+  hue: number
+}
+
+interface PointerState {
+  x: number
+  y: number
+  active: boolean
+  lastWakeAt: number
+}
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+
+let animationFrameId: number | null = null
+let resizeObserver: ResizeObserver | null = null
+let motionQuery: MediaQueryList | null = null
+let context: CanvasRenderingContext2D | null = null
+let width = 1
+let height = 1
+let previousTimestamp = 0
+let reducedMotion = false
+
+const lanterns: Lantern[] = []
+const ripples: Ripple[] = []
+const pointer: PointerState = {
+  x: 0,
+  y: 0,
+  active: false,
+  lastWakeAt: 0,
+}
+
+function randomBetween(min: number, max: number): number {
+  return min + Math.random() * (max - min)
+}
+
+function lanternCount(): number {
+  if (reducedMotion) return 12
+  return Math.round(Math.min(44, Math.max(20, (width * height) / 42000)))
+}
+
+function createLantern(): Lantern {
+  const depth = randomBetween(0.45, 1)
+
+  return {
+    x: Math.random() * width,
+    y: Math.random() * height,
+    vx: randomBetween(-0.08, 0.08) * depth,
+    vy: randomBetween(-0.12, -0.025) * depth,
+    radius: randomBetween(5, 12) * depth,
+    hue: randomBetween(162, 204),
+    phase: Math.random() * Math.PI * 2,
+    depth,
+  }
+}
+
+function seedLanterns(): void {
+  const count = lanternCount()
+
+  while (lanterns.length < count) lanterns.push(createLantern())
+  if (lanterns.length > count) lanterns.splice(count)
+}
+
+function canvasPoint(clientX: number, clientY: number): { x: number; y: number } | null {
+  const canvas = canvasRef.value
+  if (!canvas) return null
+
+  const rect = canvas.getBoundingClientRect()
+  const x = clientX - rect.left
+  const y = clientY - rect.top
+
+  if (x < 0 || y < 0 || x > rect.width || y > rect.height) return null
+  return { x, y }
+}
+
+function addRipple(
+  x: number,
+  y: number,
+  strength = 1,
+  hue = randomBetween(168, 206),
+): void {
+  ripples.push({
+    x,
+    y,
+    radius: 3,
+    alpha: 0.34 * strength,
+    speed: 0.72 + strength * 0.46,
+    hue,
+  })
+
+  if (ripples.length > 10) ripples.shift()
+}
+
+function handlePointerMove(event: PointerEvent): void {
+  const point = canvasPoint(event.clientX, event.clientY)
+
+  if (!point) {
+    pointer.active = false
+    return
+  }
+
+  pointer.x = point.x
+  pointer.y = point.y
+  pointer.active = true
+
+  const now = performance.now()
+  if (!reducedMotion && now - pointer.lastWakeAt > 115) {
+    addRipple(point.x, point.y, 0.42, 182)
+    pointer.lastWakeAt = now
+  }
+}
+
+function handlePointerDown(event: PointerEvent): void {
+  const point = canvasPoint(event.clientX, event.clientY)
+  if (!point) return
+
+  addRipple(point.x, point.y, 1.25)
+}
+
+function resizeCanvas(): void {
+  const canvas = canvasRef.value
+  if (!canvas || !context) return
+
+  const rect = canvas.getBoundingClientRect()
+  const nextWidth = Math.max(1, rect.width)
+  const nextHeight = Math.max(1, rect.height)
+  const scaleX = nextWidth / width
+  const scaleY = nextHeight / height
+
+  width = nextWidth
+  height = nextHeight
+
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
+  canvas.width = Math.round(width * pixelRatio)
+  canvas.height = Math.round(height * pixelRatio)
+  context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0)
+
+  lanterns.forEach((lantern) => {
+    lantern.x *= scaleX
+    lantern.y *= scaleY
+  })
+
+  seedLanterns()
+}
+
+function drawTideBands(timestamp: number): void {
+  if (!context) return
+
+  context.save()
+  context.globalCompositeOperation = 'lighter'
+  context.lineCap = 'round'
+
+  const bandCount = reducedMotion ? 2 : 4
+
+  for (let band = 0; band < bandCount; band += 1) {
+    const baseline = height * (0.18 + band * 0.21)
+    const amplitude = 9 + band * 4
+    const speed = timestamp * (0.00012 + band * 0.000025)
+
+    context.beginPath()
+
+    for (let x = -40; x <= width + 40; x += 28) {
+      const y =
+        baseline +
+        Math.sin(x * 0.009 + speed + band * 1.7) * amplitude +
+        Math.cos(x * 0.0035 - speed * 0.72) * 6
+
+      if (x === -40) context.moveTo(x, y)
+      else context.lineTo(x, y)
+    }
+
+    context.strokeStyle = `hsla(${176 + band * 8}, 92%, 68%, ${
+      0.035 + band * 0.008
+    })`
+    context.lineWidth = 12 + band * 5
+    context.stroke()
+  }
+
+  context.restore()
+}
+
+function updateLantern(lantern: Lantern, delta: number, timestamp: number): void {
+  const driftScale = reducedMotion ? 0.22 : 1
+  const pulse = Math.sin(timestamp * 0.0012 + lantern.phase)
+
+  lantern.vx += Math.sin(timestamp * 0.00022 + lantern.phase) * 0.0008 * delta
+  lantern.vy += Math.cos(timestamp * 0.00018 + lantern.phase) * 0.00035 * delta
+
+  if (pointer.active) {
+    const dx = pointer.x - lantern.x
+    const dy = pointer.y - lantern.y
+    const distance = Math.hypot(dx, dy)
+
+    if (distance > 0 && distance < 220) {
+      const influence = (1 - distance / 220) * 0.0045 * lantern.depth
+      lantern.vx += (-dy / distance) * influence * delta
+      lantern.vy += (dx / distance) * influence * delta
+      lantern.vx += (dx / distance) * influence * 0.28 * delta
+      lantern.vy += (dy / distance) * influence * 0.28 * delta
+    }
+  }
+
+  lantern.vx *= 0.997
+  lantern.vy *= 0.998
+  lantern.x += lantern.vx * delta * driftScale
+  lantern.y += lantern.vy * delta * driftScale
+
+  const margin = lantern.radius * 5
+
+  if (lantern.x < -margin) lantern.x = width + margin
+  if (lantern.x > width + margin) lantern.x = -margin
+  if (lantern.y < -margin) lantern.y = height + margin
+  if (lantern.y > height + margin) lantern.y = -margin
+
+  drawLantern(lantern, pulse)
+}
+
+function drawLantern(lantern: Lantern, pulse: number): void {
+  if (!context) return
+
+  const radius = lantern.radius * (1 + pulse * 0.12)
+  const glowRadius = radius * 4.2
+  const alpha = 0.24 + lantern.depth * 0.28
+
+  context.save()
+  context.globalCompositeOperation = 'lighter'
+
+  const glow = context.createRadialGradient(
+    lantern.x,
+    lantern.y,
+    0,
+    lantern.x,
+    lantern.y,
+    glowRadius,
+  )
+  glow.addColorStop(0, `hsla(${lantern.hue}, 100%, 78%, ${alpha})`)
+  glow.addColorStop(0.28, `hsla(${lantern.hue + 12}, 95%, 62%, ${alpha * 0.44})`)
+  glow.addColorStop(1, `hsla(${lantern.hue + 24}, 90%, 52%, 0)`)
+
+  context.fillStyle = glow
+  context.beginPath()
+  context.arc(lantern.x, lantern.y, glowRadius, 0, Math.PI * 2)
+  context.fill()
+
+  context.fillStyle = `hsla(${lantern.hue}, 100%, 86%, ${0.42 + lantern.depth * 0.35})`
+  context.beginPath()
+  context.ellipse(
+    lantern.x,
+    lantern.y,
+    radius * 0.9,
+    radius * 0.62,
+    Math.sin(lantern.phase) * 0.18,
+    0,
+    Math.PI * 2,
+  )
+  context.fill()
+
+  context.lineCap = 'round'
+  context.lineWidth = Math.max(0.55, lantern.depth)
+
+  for (let tendril = -1; tendril <= 1; tendril += 1) {
+    const startX = lantern.x + tendril * radius * 0.32
+    const startY = lantern.y + radius * 0.45
+    const sway = Math.sin(lantern.phase + tendril + performance.now() * 0.0011)
+
+    context.beginPath()
+    context.moveTo(startX, startY)
+    context.quadraticCurveTo(
+      startX + sway * radius * 0.9,
+      startY + radius * 1.35,
+      startX - sway * radius * 0.45,
+      startY + radius * 2.25,
+    )
+    context.strokeStyle = `hsla(${lantern.hue + 18}, 96%, 72%, ${
+      0.12 + lantern.depth * 0.22
+    })`
+    context.stroke()
+  }
+
+  context.restore()
+}
+
+function drawRipples(delta: number): void {
+  if (!context) return
+
+  context.save()
+  context.globalCompositeOperation = 'lighter'
+
+  for (let index = ripples.length - 1; index >= 0; index -= 1) {
+    const ripple = ripples[index]
+    if (!ripple) continue
+
+    ripple.radius += ripple.speed * delta
+    ripple.alpha *= Math.pow(0.986, delta)
+
+    context.beginPath()
+    context.arc(ripple.x, ripple.y, ripple.radius, 0, Math.PI * 2)
+    context.strokeStyle = `hsla(${ripple.hue}, 100%, 76%, ${ripple.alpha})`
+    context.lineWidth = Math.max(0.7, 2.4 - ripple.radius * 0.008)
+    context.stroke()
+
+    if (ripple.alpha < 0.012 || ripple.radius > Math.max(width, height) * 0.7) {
+      ripples.splice(index, 1)
+    }
+  }
+
+  context.restore()
+}
+
+function renderFrame(timestamp: number): void {
+  if (!context) return
+
+  const elapsed = previousTimestamp ? timestamp - previousTimestamp : 16.67
+  previousTimestamp = timestamp
+  const delta = Math.min(2.2, Math.max(0.35, elapsed / 16.67))
+
+  context.clearRect(0, 0, width, height)
+  drawTideBands(timestamp)
+  lanterns.forEach((lantern) => updateLantern(lantern, delta, timestamp))
+  drawRipples(delta)
+
+  animationFrameId = window.requestAnimationFrame(renderFrame)
+}
+
+function handleMotionPreference(event: MediaQueryListEvent): void {
+  reducedMotion = event.matches
+  seedLanterns()
+}
+
+onMounted(() => {
+  const canvas = canvasRef.value
+  if (!canvas) return
+
+  context = canvas.getContext('2d', { alpha: true })
+  if (!context) return
+
+  motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+  reducedMotion = motionQuery.matches
+  motionQuery.addEventListener('change', handleMotionPreference)
+
+  resizeObserver = new ResizeObserver(resizeCanvas)
+  resizeObserver.observe(canvas)
+  resizeCanvas()
+
+  window.addEventListener('pointermove', handlePointerMove, { passive: true })
+  window.addEventListener('pointerdown', handlePointerDown, { passive: true })
+
+  animationFrameId = window.requestAnimationFrame(renderFrame)
+})
+
+onBeforeUnmount(() => {
+  if (animationFrameId !== null) {
+    window.cancelAnimationFrame(animationFrameId)
+  }
+
+  resizeObserver?.disconnect()
+  motionQuery?.removeEventListener('change', handleMotionPreference)
+  window.removeEventListener('pointermove', handlePointerMove)
+  window.removeEventListener('pointerdown', handlePointerDown)
+
+  animationFrameId = null
+  resizeObserver = null
+  motionQuery = null
+  context = null
+})
+</script>
+
+<style scoped>
+.bioluminescent-tide {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0.92;
+  transform: translateZ(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bioluminescent-tide {
+    opacity: 0.62;
+  }
+}
+</style>

--- a/components/screenfx/fx-region.vue
+++ b/components/screenfx/fx-region.vue
@@ -1,4 +1,4 @@
-<!-- /components/content/screenfx/fx-region.vue -->
+<!-- /components/screenfx/fx-region.vue -->
 <template>
   <div
     v-if="isMounted && behindEntries.length"
@@ -29,6 +29,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, resolveComponent } from 'vue'
 import {
+  getAnimationComponentName,
   useAnimationStore,
   type AnimationEffectId,
   type FxPlacement,
@@ -47,40 +48,15 @@ onMounted(() => {
   isMounted.value = true
 })
 
-type ComponentMap = Record<
+const componentsMap = new Map<
   AnimationEffectId,
   ReturnType<typeof resolveComponent>
->
-
-const componentsMap: ComponentMap = {
-  'starfield-effect': resolveComponent('LazyStarfieldEffect'),
-  'constellation-effect': resolveComponent('LazyConstellationEffect'),
-  'wishing-stars': resolveComponent('LazyWishingStars'),
-  'orbit-effect': resolveComponent('LazyOrbitEffect'),
-  'butterfly-animation': resolveComponent('LazyButterflyAnimation'),
-  'firefly-effect': resolveComponent('LazyFireflyEffect'),
-  'rain-effect': resolveComponent('LazyRainEffect'),
-  'snow-effect': resolveComponent('LazySnowEffect'),
-  'floating-hearts': resolveComponent('LazyFloatingHearts'),
-  'fizzy-bubbles': resolveComponent('LazyFizzyBubbles'),
-  'ripple-effect': resolveComponent('LazyRippleEffect'),
-  'fireworks-effect': resolveComponent('LazyFireworksEffect'),
-  'lightning-effect': resolveComponent('LazyLightningEffect'),
-  'fire-effect': resolveComponent('LazyFireEffect'),
-  'glitch-effect': resolveComponent('LazyGlitchEffect'),
-  'kaleidoscope-effect': resolveComponent('LazyKaleidoscopeEffect'),
-  'plasma-effect': resolveComponent('LazyPlasmaEffect'),
-  'nyan-trail': resolveComponent('LazyNyanTrail'),
-  'matrix-rain': resolveComponent('LazyMatrixRain'),
-  'pixel-rain': resolveComponent('LazyPixelRain'),
-  'pixel-explosion': resolveComponent('LazyPixelExplosion'),
-  'wandering-creatures': resolveComponent('LazyWanderingCreatures'),
-  'toaster-effect': resolveComponent('LazyToasterEffect'),
-  'ascii-aquarium': resolveComponent('LazyAsciiAquarium'),
-  'pacbot-effect': resolveComponent('LazyPacbotEffect'),
-  'pocket-gremlin': resolveComponent('LazyPocketGremlin'),
-  'siege-engine': resolveComponent('LazySiegeEngine'),
-}
+>(
+  animationStore.effects.map((effect) => [
+    effect.id,
+    resolveComponent(getAnimationComponentName(effect.id)),
+  ]),
+)
 
 interface SurfaceEntry {
   key: string
@@ -94,7 +70,7 @@ function entriesForPlacement(placement: FxPlacement): SurfaceEntry[] {
 
   if (animationStore.screenSurfaces[props.region][placement]) {
     animationStore.screenEffects.forEach((effect) => {
-      const component = componentsMap[effect.id]
+      const component = componentsMap.get(effect.id)
 
       if (!component || seen.has(effect.id)) return
 
@@ -110,7 +86,7 @@ function entriesForPlacement(placement: FxPlacement): SurfaceEntry[] {
 
   if (generationActive && animationStore.activeEffectId) {
     const id = animationStore.activeEffectId
-    const component = componentsMap[id]
+    const component = componentsMap.get(id)
 
     if (component && !seen.has(id)) {
       entries.push({ key: `gen-${id}`, id, component })
@@ -138,19 +114,10 @@ const frontInteractive = computed(() => {
   overflow: hidden;
   border-radius: inherit;
   pointer-events: none;
-
-  /* Traps position: fixed effect children inside the region and clips them */
   transform: translateZ(0);
   contain: layout paint;
 }
 
-/*
- * Paints above the region's own background but below its normal-flow content.
- * The region's content children all carry z-index >= 1 (z-10, z-70, etc.),
- * so a z-index of 0 here sits above the opaque region background and below
- * that content. A negative z-index would hide behind the background and
- * render the effect invisible.
- */
 .fx-surface--behind {
   z-index: 0;
 }

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -23,7 +23,11 @@ import {
   resolveComponent,
   watch,
 } from 'vue'
-import { useAnimationStore, type AnimationEffectId } from '@/stores/animationStore'
+import {
+  getAnimationComponentName,
+  useAnimationStore,
+  type AnimationEffectId,
+} from '@/stores/animationStore'
 import { useAnimationPreferenceStore } from '@/stores/animationPreferenceStore'
 import { useButterflyStore } from '@/stores/butterflyStore'
 
@@ -39,41 +43,19 @@ const FADE_MS = 650
 
 let fadeTimer: ReturnType<typeof setTimeout> | null = null
 
-const componentsMap: Partial<
-  Record<AnimationEffectId, ReturnType<typeof resolveComponent>>
-> = {
-  'starfield-effect': resolveComponent('LazyStarfieldEffect'),
-  'constellation-effect': resolveComponent('LazyConstellationEffect'),
-  'wishing-stars': resolveComponent('LazyWishingStars'),
-  'orbit-effect': resolveComponent('LazyOrbitEffect'),
-  'butterfly-animation': resolveComponent('LazyButterflyAnimation'),
-  'firefly-effect': resolveComponent('LazyFireflyEffect'),
-  'rain-effect': resolveComponent('LazyRainEffect'),
-  'snow-effect': resolveComponent('LazySnowEffect'),
-  'floating-hearts': resolveComponent('LazyFloatingHearts'),
-  'fizzy-bubbles': resolveComponent('LazyFizzyBubbles'),
-  'ripple-effect': resolveComponent('LazyRippleEffect'),
-  'fireworks-effect': resolveComponent('LazyFireworksEffect'),
-  'lightning-effect': resolveComponent('LazyLightningEffect'),
-  'fire-effect': resolveComponent('LazyFireEffect'),
-  'glitch-effect': resolveComponent('LazyGlitchEffect'),
-  'kaleidoscope-effect': resolveComponent('LazyKaleidoscopeEffect'),
-  'plasma-effect': resolveComponent('LazyPlasmaEffect'),
-  'nyan-trail': resolveComponent('LazyNyanTrail'),
-  'matrix-rain': resolveComponent('LazyMatrixRain'),
-  'pixel-rain': resolveComponent('LazyPixelRain'),
-  'pixel-explosion': resolveComponent('LazyPixelExplosion'),
-  'wandering-creatures': resolveComponent('LazyWanderingCreatures'),
-  'toaster-effect': resolveComponent('LazyToasterEffect'),
-  'ascii-aquarium': resolveComponent('LazyAsciiAquarium'),
-  'pacbot-effect': resolveComponent('LazyPacbotEffect'),
-  'pocket-gremlin': resolveComponent('LazyPocketGremlin'),
-  'siege-engine': resolveComponent('LazySiegeEngine'),
-}
+const componentsMap = new Map<
+  AnimationEffectId,
+  ReturnType<typeof resolveComponent>
+>(
+  animationStore.effects.map((effect) => [
+    effect.id,
+    resolveComponent(getAnimationComponentName(effect.id)),
+  ]),
+)
 
 const currentComponent = computed(() => {
   if (!resolvedEffectId.value) return null
-  return componentsMap[resolvedEffectId.value] || null
+  return componentsMap.get(resolvedEffectId.value) || null
 })
 
 function clearFadeTimer(): void {
@@ -86,9 +68,7 @@ function selectEffect(): void {
   preferenceStore.initialize()
 
   const availableIds = animationStore.safeEffects
-    .filter(
-      (effect) => !effect.blocksInput && componentsMap[effect.id] !== undefined,
-    )
+    .filter((effect) => !effect.blocksInput && componentsMap.has(effect.id))
     .map((effect) => effect.id)
 
   resolvedEffectId.value = preferenceStore.resolveStartupEffect(availableIds)

--- a/stores/animationCatalog.ts
+++ b/stores/animationCatalog.ts
@@ -1,0 +1,326 @@
+// /stores/animationCatalog.ts
+
+export type FxRegion = 'header' | 'sheet' | 'page' | 'hand'
+
+interface AnimationEffectDefinition {
+  id: string
+  label: string
+  reveal: string
+  icon: string
+  tooltip: string
+  color: string
+  generationSafe: boolean
+  blocksInput?: boolean
+  preferredSurface?: FxRegion | 'fullscreen'
+}
+
+export const ANIMATION_EFFECTS = [
+  {
+    id: 'starfield-effect',
+    label: 'Warp Drive',
+    reveal: 'Hyperspace!',
+    icon: 'kind-icon:star',
+    tooltip: 'Punch it, Chewie ✨',
+    color: '#6366f1',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'constellation-effect',
+    label: 'Constellation',
+    reveal: 'Star map',
+    icon: 'kind-icon:sparkle',
+    tooltip: 'Drifting stars connect into patterns 🔭',
+    color: '#60a5fa',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'wishing-stars',
+    label: 'Wishing Stars',
+    reveal: '✨ Wish granted',
+    icon: 'kind-icon:star',
+    tooltip: 'Shooting stars streak across the sky 🌠',
+    color: '#fbbf24',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'orbit-effect',
+    label: 'Orrery',
+    reveal: 'Solar system',
+    icon: 'kind-icon:orbit',
+    tooltip: 'Glowing orbs trace orbital paths 🪐',
+    color: '#a855f7',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'butterfly-animation',
+    label: 'Butterfly Scouts',
+    reveal: 'Happy butterflies',
+    icon: 'kind-icon:butterfly',
+    tooltip: 'Release AMI into the world 🦋',
+    color: '#e879f9',
+    generationSafe: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'firefly-effect',
+    label: 'Fireflies',
+    reveal: 'Golden hour',
+    icon: 'kind-icon:sparkle',
+    tooltip: 'Organic warm glow drifting through the dark 🌿',
+    color: '#f59e0b',
+    generationSafe: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'rain-effect',
+    label: 'Rainmaker',
+    reveal: 'Just a drizzle',
+    icon: 'kind-icon:raindrop',
+    tooltip: "Rain doesn't have to be sad 🌧️",
+    color: '#7ba7c0',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'snow-effect',
+    label: 'Snow Globe',
+    reveal: 'Cozy ❄️',
+    icon: 'kind-icon:snowflake',
+    tooltip: 'Soft particle snowfall ❄️',
+    color: '#93c5fd',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'floating-hearts',
+    label: 'Love Bomb',
+    reveal: 'So much love',
+    icon: 'kind-icon:heart',
+    tooltip: 'Click anywhere to burst 💖',
+    color: '#f43f5e',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'fizzy-bubbles',
+    label: 'Fizzy Lifting',
+    reveal: 'Carbonation!',
+    icon: 'kind-icon:soda',
+    tooltip: 'Float away with fizzy bubbles 🍾',
+    color: '#38bdf8',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'ripple-effect',
+    label: 'Ripple',
+    reveal: 'Still waters',
+    icon: 'kind-icon:raindrop',
+    tooltip: 'Move your cursor to ripple the surface 💧',
+    color: '#0ea5e9',
+    generationSafe: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'bioluminescent-tide',
+    label: 'Bioluminescent Tide',
+    reveal: 'The deep is awake',
+    icon: 'kind-icon:wave',
+    tooltip: 'Drifting lantern life follows your wake; click for a tide pulse 🌊',
+    color: '#2dd4bf',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'fireworks-effect',
+    label: 'Fireworks',
+    reveal: '🎆 Celebration!',
+    icon: 'kind-icon:sparkle',
+    tooltip: 'Click anywhere to fire 🎆',
+    color: '#ef4444',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'lightning-effect',
+    label: 'Storm Caller',
+    reveal: 'Feel the power',
+    icon: 'kind-icon:lightning',
+    tooltip: 'Recursive arc strikes from the sky ⚡',
+    color: '#eab308',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'fire-effect',
+    label: 'Wildfire',
+    reveal: 'Everything is fine',
+    icon: 'kind-icon:flame',
+    tooltip: 'This is fine 🔥',
+    color: '#ea580c',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'glitch-effect',
+    label: 'Glitch',
+    reveal: 'ERR_404',
+    icon: 'kind-icon:lightning',
+    tooltip: 'Signal corruption detected 📺',
+    color: '#7c3aed',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'kaleidoscope-effect',
+    label: 'Kaleidoscope',
+    reveal: 'Infinite mirror',
+    icon: 'kind-icon:gem',
+    tooltip: 'Sacred geometry in motion 🔮',
+    color: '#9333ea',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'plasma-effect',
+    label: 'Plasma',
+    reveal: 'Sine wave soup',
+    icon: 'kind-icon:wave',
+    tooltip: 'Summed sine waves, After Dark plasma 🌊',
+    color: '#8b5cf6',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'nyan-trail',
+    label: 'Nyan Trail',
+    reveal: 'Nyan nyan nyan',
+    icon: 'kind-icon:rainbow',
+    tooltip: 'Rainbow particle trail follows your cursor 🌈',
+    color: '#ec4899',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'matrix-rain',
+    label: 'Matrix Rain',
+    reveal: 'There is no spoon',
+    icon: 'kind-icon:code',
+    tooltip: 'Follow the white rabbit 🐇',
+    color: '#22c55e',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'pixel-rain',
+    label: 'Pixel Rain',
+    reveal: "It's raining bits",
+    icon: 'kind-icon:pixel',
+    tooltip: 'Retro pixel blocks fall and pile up 🕹️',
+    color: '#06b6d4',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'pixel-explosion',
+    label: 'Pixel Smash',
+    reveal: 'Everything is pixels',
+    icon: 'kind-icon:pixel',
+    tooltip: 'Click anything to shatter it into pixels 💥',
+    color: '#dc2626',
+    generationSafe: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'wandering-creatures',
+    label: 'Creatures',
+    reveal: 'They live here now',
+    icon: 'kind-icon:butterfly',
+    tooltip: 'Critters with distinct personalities roam the screen 🐾',
+    color: '#10b981',
+    generationSafe: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'toaster-effect',
+    label: 'Flying Toasters',
+    reveal: 'Toast incoming!',
+    icon: 'kind-icon:toast',
+    tooltip: 'After Dark tribute, the original screensaver 🍞',
+    color: '#f97316',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
+    id: 'ascii-aquarium',
+    label: 'Aquarium',
+    reveal: 'Glub glub',
+    icon: 'kind-icon:fish',
+    tooltip: 'Click to feed, Move cursor to spook 🐠',
+    color: '#06b6d4',
+    generationSafe: false,
+    blocksInput: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'pacbot-effect',
+    label: 'Pac-Bot',
+    reveal: 'Nom nom nom',
+    icon: 'kind-icon:robot',
+    tooltip: 'Move to leave crumbs, Click for power, Dbl-click for crumb storm 🤖',
+    color: '#eab308',
+    generationSafe: false,
+    blocksInput: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'pocket-gremlin',
+    label: 'Gremlin',
+    reveal: 'beep?',
+    icon: 'kind-icon:ghost',
+    tooltip: 'Click it to pet it, Ignore it at your peril 👾',
+    color: '#a78bfa',
+    generationSafe: false,
+    blocksInput: true,
+    preferredSurface: 'page',
+  },
+  {
+    id: 'siege-engine',
+    label: 'Siege Engine',
+    reveal: 'FIRE!!!',
+    icon: 'kind-icon:flame',
+    tooltip: 'Hold to charge, Release to launch 🪨',
+    color: '#b45309',
+    generationSafe: false,
+    blocksInput: true,
+    preferredSurface: 'page',
+  },
+] as const satisfies readonly AnimationEffectDefinition[]
+
+export type AnimationEffectId = (typeof ANIMATION_EFFECTS)[number]['id']
+
+export type AnimationEffect = Omit<AnimationEffectDefinition, 'id'> & {
+  id: AnimationEffectId
+}
+
+export const animationEffects: readonly AnimationEffect[] = ANIMATION_EFFECTS
+
+export function isAnimationEffectId(value: unknown): value is AnimationEffectId {
+  return (
+    typeof value === 'string' &&
+    animationEffects.some((effect) => effect.id === value)
+  )
+}
+
+export function getAnimationComponentName(id: AnimationEffectId): string {
+  const pascalName = id
+    .split('-')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join('')
+
+  return `Lazy${pascalName}`
+}

--- a/stores/animationStore.ts
+++ b/stores/animationStore.ts
@@ -1,54 +1,26 @@
 // /stores/animationStore.ts
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, toRefs } from 'vue'
+import {
+  animationEffects,
+  type AnimationEffect,
+  type AnimationEffectId,
+  type FxRegion,
+} from './animationCatalog'
 
-export type FxRegion = 'header' | 'sheet' | 'page' | 'hand'
+export {
+  getAnimationComponentName,
+  isAnimationEffectId,
+  type AnimationEffect,
+  type AnimationEffectId,
+  type FxRegion,
+} from './animationCatalog'
+
 export type FxPlacement = 'behind' | 'front'
 export type FxPlacementState = 'off' | FxPlacement
 export type FxSurfaceMap = Record<FxRegion, Record<FxPlacement, boolean>>
 
 export const FX_REGIONS: FxRegion[] = ['header', 'sheet', 'page', 'hand']
-
-export type AnimationEffectId =
-  | 'starfield-effect'
-  | 'constellation-effect'
-  | 'wishing-stars'
-  | 'orbit-effect'
-  | 'butterfly-animation'
-  | 'firefly-effect'
-  | 'rain-effect'
-  | 'snow-effect'
-  | 'fizzy-bubbles'
-  | 'ripple-effect'
-  | 'floating-hearts'
-  | 'plasma-effect'
-  | 'pixel-rain'
-  | 'matrix-rain'
-  | 'glitch-effect'
-  | 'kaleidoscope-effect'
-  | 'toaster-effect'
-  | 'fireworks-effect'
-  | 'lightning-effect'
-  | 'fire-effect'
-  | 'nyan-trail'
-  | 'pixel-explosion'
-  | 'wandering-creatures'
-  | 'ascii-aquarium'
-  | 'pacbot-effect'
-  | 'pocket-gremlin'
-  | 'siege-engine'
-
-export interface AnimationEffect {
-  id: AnimationEffectId
-  label: string
-  reveal: string
-  icon: string
-  tooltip: string
-  color: string
-  generationSafe: boolean
-  blocksInput?: boolean
-  preferredSurface?: FxRegion | 'fullscreen'
-}
 
 export interface AnimationLayerOptions {
   effectId?: AnimationEffectId
@@ -98,295 +70,8 @@ function mergeSurfaces(
   return merged
 }
 
-const allEffects: AnimationEffect[] = [
-  {
-    id: 'starfield-effect',
-    label: 'Warp Drive',
-    reveal: 'Hyperspace!',
-    icon: 'kind-icon:star',
-    tooltip: 'Punch it, Chewie ✨',
-    color: '#6366f1',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'constellation-effect',
-    label: 'Constellation',
-    reveal: 'Star map',
-    icon: 'kind-icon:sparkle',
-    tooltip: 'Drifting stars connect into patterns 🔭',
-    color: '#60a5fa',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'wishing-stars',
-    label: 'Wishing Stars',
-    reveal: '✨ Wish granted',
-    icon: 'kind-icon:star',
-    tooltip: 'Shooting stars streak across the sky 🌠',
-    color: '#fbbf24',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'orbit-effect',
-    label: 'Orrery',
-    reveal: 'Solar system',
-    icon: 'kind-icon:orbit',
-    tooltip: 'Glowing orbs trace orbital paths 🪐',
-    color: '#a855f7',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'butterfly-animation',
-    label: 'Butterfly Scouts',
-    reveal: 'Happy butterflies',
-    icon: 'kind-icon:butterfly',
-    tooltip: 'Release AMI into the world 🦋',
-    color: '#e879f9',
-    generationSafe: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'firefly-effect',
-    label: 'Fireflies',
-    reveal: 'Golden hour',
-    icon: 'kind-icon:sparkle',
-    tooltip: 'Organic warm glow drifting through the dark 🌿',
-    color: '#f59e0b',
-    generationSafe: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'rain-effect',
-    label: 'Rainmaker',
-    reveal: 'Just a drizzle',
-    icon: 'kind-icon:raindrop',
-    tooltip: "Rain doesn't have to be sad 🌧️",
-    color: '#7ba7c0',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'snow-effect',
-    label: 'Snow Globe',
-    reveal: 'Cozy ❄️',
-    icon: 'kind-icon:snowflake',
-    tooltip: 'Soft particle snowfall ❄️',
-    color: '#93c5fd',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'floating-hearts',
-    label: 'Love Bomb',
-    reveal: 'So much love',
-    icon: 'kind-icon:heart',
-    tooltip: 'Click anywhere to burst 💖',
-    color: '#f43f5e',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'fizzy-bubbles',
-    label: 'Fizzy Lifting',
-    reveal: 'Carbonation!',
-    icon: 'kind-icon:soda',
-    tooltip: 'Float away with fizzy bubbles 🍾',
-    color: '#38bdf8',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'ripple-effect',
-    label: 'Ripple',
-    reveal: 'Still waters',
-    icon: 'kind-icon:raindrop',
-    tooltip: 'Move your cursor to ripple the surface 💧',
-    color: '#0ea5e9',
-    generationSafe: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'fireworks-effect',
-    label: 'Fireworks',
-    reveal: '🎆 Celebration!',
-    icon: 'kind-icon:sparkle',
-    tooltip: 'Click anywhere to fire 🎆',
-    color: '#ef4444',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'lightning-effect',
-    label: 'Storm Caller',
-    reveal: 'Feel the power',
-    icon: 'kind-icon:lightning',
-    tooltip: 'Recursive arc strikes from the sky ⚡',
-    color: '#eab308',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'fire-effect',
-    label: 'Wildfire',
-    reveal: 'Everything is fine',
-    icon: 'kind-icon:flame',
-    tooltip: 'This is fine 🔥',
-    color: '#ea580c',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'glitch-effect',
-    label: 'Glitch',
-    reveal: 'ERR_404',
-    icon: 'kind-icon:lightning',
-    tooltip: 'Signal corruption detected 📺',
-    color: '#7c3aed',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'kaleidoscope-effect',
-    label: 'Kaleidoscope',
-    reveal: 'Infinite mirror',
-    icon: 'kind-icon:gem',
-    tooltip: 'Sacred geometry in motion 🔮',
-    color: '#9333ea',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'plasma-effect',
-    label: 'Plasma',
-    reveal: 'Sine wave soup',
-    icon: 'kind-icon:wave',
-    tooltip: 'Summed sine waves, After Dark plasma 🌊',
-    color: '#8b5cf6',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'nyan-trail',
-    label: 'Nyan Trail',
-    reveal: 'Nyan nyan nyan',
-    icon: 'kind-icon:rainbow',
-    tooltip: 'Rainbow particle trail follows your cursor 🌈',
-    color: '#ec4899',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'matrix-rain',
-    label: 'Matrix Rain',
-    reveal: 'There is no spoon',
-    icon: 'kind-icon:code',
-    tooltip: 'Follow the white rabbit 🐇',
-    color: '#22c55e',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'pixel-rain',
-    label: 'Pixel Rain',
-    reveal: "It's raining bits",
-    icon: 'kind-icon:pixel',
-    tooltip: 'Retro pixel blocks fall and pile up 🕹️',
-    color: '#06b6d4',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'pixel-explosion',
-    label: 'Pixel Smash',
-    reveal: 'Everything is pixels',
-    icon: 'kind-icon:pixel',
-    tooltip: 'Click anything to shatter it into pixels 💥',
-    color: '#dc2626',
-    generationSafe: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'wandering-creatures',
-    label: 'Creatures',
-    reveal: 'They live here now',
-    icon: 'kind-icon:butterfly',
-    tooltip: 'Critters with distinct personalities roam the screen 🐾',
-    color: '#10b981',
-    generationSafe: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'toaster-effect',
-    label: 'Flying Toasters',
-    reveal: 'Toast incoming!',
-    icon: 'kind-icon:toast',
-    tooltip: 'After Dark tribute, the original screensaver 🍞',
-    color: '#f97316',
-    generationSafe: true,
-    preferredSurface: 'fullscreen',
-  },
-  {
-    id: 'ascii-aquarium',
-    label: 'Aquarium',
-    reveal: 'Glub glub',
-    icon: 'kind-icon:fish',
-    tooltip: 'Click to feed, Move cursor to spook 🐠',
-    color: '#06b6d4',
-    generationSafe: false,
-    blocksInput: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'pacbot-effect',
-    label: 'Pac-Bot',
-    reveal: 'Nom nom nom',
-    icon: 'kind-icon:robot',
-    tooltip:
-      'Move to leave crumbs, Click for power, Dbl-click for crumb storm 🤖',
-    color: '#eab308',
-    generationSafe: false,
-    blocksInput: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'pocket-gremlin',
-    label: 'Gremlin',
-    reveal: 'beep?',
-    icon: 'kind-icon:ghost',
-    tooltip: 'Click it to pet it, Ignore it at your peril 👾',
-    color: '#a78bfa',
-    generationSafe: false,
-    blocksInput: true,
-    preferredSurface: 'page',
-  },
-  {
-    id: 'siege-engine',
-    label: 'Siege Engine',
-    reveal: 'FIRE!!!',
-    icon: 'kind-icon:flame',
-    tooltip: 'Hold to charge, Release to launch 🪨',
-    color: '#b45309',
-    generationSafe: false,
-    blocksInput: true,
-    preferredSurface: 'page',
-  },
-]
-
-export function isAnimationEffectId(
-  value: unknown,
-): value is AnimationEffectId {
-  return (
-    typeof value === 'string' &&
-    allEffects.some((effect) => effect.id === value)
-  )
-}
-
 function pickRandomEffect(): AnimationEffectId {
-  const safeEffects = allEffects.filter((effect) => effect.generationSafe)
+  const safeEffects = animationEffects.filter((effect) => effect.generationSafe)
   const index = Math.floor(Math.random() * safeEffects.length)
   return safeEffects[index]?.id || 'starfield-effect'
 }
@@ -420,7 +105,7 @@ export const useAnimationStore = defineStore('animationStore', () => {
     screenSurfaces: defaultScreenSurfaces(),
   })
 
-  const effects = computed(() => allEffects)
+  const effects = computed(() => animationEffects)
 
   const safeEffects = computed(() => {
     return effects.value.filter((effect) => effect.generationSafe)
@@ -495,8 +180,6 @@ export const useAnimationStore = defineStore('animationStore', () => {
     region: FxRegion,
     placement: FxPlacementState,
   ): void {
-    // Placements are mutually exclusive per region: setting one clears the
-    // other, and 'off' clears both.
     state.screenSurfaces[region] = {
       behind: placement === 'behind',
       front: placement === 'front',


### PR DESCRIPTION
## What changed
- centralizes Screen FX and startup wallpaper registration in `stores/animationCatalog.ts`
- derives animation IDs from the catalog and resolves Nuxt lazy components by filename convention
- removes duplicated component maps from `fx-region.vue` and `startup-animation.vue`
- adds **Bioluminescent Tide**, a passive canvas wallpaper with cursor wake and click ripples that never captures page input
- respects `prefers-reduced-motion`, caps device pixel ratio, observes its rendered surface, and cleans up animation/listener resources

## Why
Future Worker cycles can add one animation component plus one catalog entry and have it appear in Screen FX, random startup wallpapers, and explicit startup preferences automatically.

## Verification
- TypeScript Type Check: passed
- Contract Tests: passed
- repository diff reviewed for catalog parity with all existing effects
- effect is `generationSafe: true`, non-blocking, and therefore eligible for random startup selection
- Vercel preview deployment queued from the PR branch

## Flags for Reviewer
The animation is deliberately transparent and surface-relative so it works both as a full-screen startup wallpaper and inside clipped Screen FX regions. Optional interaction is observed from `window` without preventing or intercepting the underlying click.