### PR TITLE
Turn finished ArtJobs into the art trainer

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -117,7 +117,16 @@
       v-else-if="activeTab === 'artjob'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
     >
-      <artjob-manager class="h-full min-h-0 flex-1 overflow-hidden" />
+      <div
+        class="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-y-auto 2xl:grid 2xl:grid-cols-[minmax(0,1.45fr)_minmax(360px,0.55fr)] 2xl:overflow-hidden"
+      >
+        <artjob-manager
+          class="min-h-[720px] overflow-hidden 2xl:min-h-0"
+        />
+        <artjob-feedback-manager
+          class="min-h-[560px] overflow-hidden 2xl:min-h-0"
+        />
+      </div>
     </section>
 
     <div

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -1,0 +1,371 @@
+<!-- /components/art/artjob-feedback-manager.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+  >
+    <div class="border-b border-base-300 p-3">
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <div class="flex items-center gap-2">
+            <h3 class="text-sm font-semibold">Art trainer</h3>
+            <span class="badge badge-primary badge-sm rounded-2xl">
+              {{ pendingCount }} waiting
+            </span>
+          </div>
+          <p class="mt-1 text-xs text-base-content/60">
+            Conductor curates finished jobs. Your verdict becomes training context
+            for its next pass.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-2xl"
+          :disabled="artJobStore.loadingTrainerJobs"
+          @click="artJobStore.fetchTrainerJobs()"
+        >
+          <span
+            v-if="artJobStore.loadingTrainerJobs"
+            class="loading loading-spinner loading-xs"
+          />
+          Refresh
+        </button>
+      </div>
+
+      <div class="mt-3 flex flex-wrap gap-1">
+        <button
+          v-for="option in reviewModes"
+          :key="option.value"
+          type="button"
+          class="btn btn-xs rounded-2xl"
+          :class="reviewMode === option.value ? 'btn-primary' : 'btn-ghost'"
+          @click="reviewMode = option.value"
+        >
+          {{ option.label }}
+          <span class="ml-1 font-mono opacity-70">
+            {{ modeCount(option.value) }}
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+      <div v-if="visibleJobs.length" class="flex flex-col gap-3">
+        <article
+          v-for="job in visibleJobs"
+          :key="job.id"
+          class="rounded-2xl border border-base-300 bg-base-200/30 p-3"
+        >
+          <div class="flex gap-3">
+            <a
+              v-if="jobImageSrc(job)"
+              :href="jobImageSrc(job)"
+              target="_blank"
+              rel="noopener"
+              class="shrink-0"
+            >
+              <img
+                :src="jobImageSrc(job)"
+                class="h-28 w-24 rounded-2xl border border-base-300 object-cover"
+                alt="curated generated art"
+              />
+            </a>
+            <div
+              v-else
+              class="flex h-28 w-24 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-2 text-center text-[10px] uppercase tracking-wide text-base-content/40"
+            >
+              Loading art
+            </div>
+
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span class="font-mono text-xs font-semibold">#{{ job.id }}</span>
+                <span
+                  class="badge badge-sm rounded-2xl"
+                  :class="verdictClass(curatorFeedback(job)?.verdict)"
+                >
+                  {{ curatorFeedback(job)?.verdict || 'CURATED' }}
+                </span>
+                <span
+                  v-if="curatorFeedback(job)?.score !== null"
+                  class="badge badge-outline badge-sm rounded-2xl"
+                >
+                  {{ curatorFeedback(job)?.score }}/100
+                </span>
+                <span
+                  v-if="job.projectSlug"
+                  class="badge badge-secondary badge-sm rounded-2xl"
+                >
+                  {{ job.projectSlug }}
+                </span>
+              </div>
+
+              <p class="mt-2 line-clamp-4 text-xs leading-relaxed">
+                {{ jobPrompt(job) || 'Prompt unavailable for this legacy job.' }}
+              </p>
+            </div>
+          </div>
+
+          <div
+            class="mt-3 rounded-2xl border border-info/30 bg-info/10 p-3 text-xs"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <span class="font-semibold">Conductor's read</span>
+              <span class="text-[10px] text-base-content/50">
+                {{ formatDate(curatorFeedback(job)?.createdAt) }}
+              </span>
+            </div>
+            <p
+              v-if="curatorFeedback(job)?.summary"
+              class="mt-1 leading-relaxed"
+            >
+              {{ curatorFeedback(job)?.summary }}
+            </p>
+            <ul
+              v-if="curatorFeedback(job)?.reasons.length"
+              class="mt-2 list-inside list-disc space-y-1 text-base-content/70"
+            >
+              <li
+                v-for="reason in curatorFeedback(job)?.reasons"
+                :key="reason"
+              >
+                {{ reason }}
+              </li>
+            </ul>
+          </div>
+
+          <div class="mt-3">
+            <div
+              class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50"
+            >
+              What should the trainer remember?
+            </div>
+            <div class="mt-2 flex flex-wrap gap-1">
+              <button
+                v-for="tag in feedbackTags"
+                :key="tag.value"
+                type="button"
+                class="btn btn-xs h-auto min-h-7 rounded-2xl py-1"
+                :class="hasTag(job.id, tag.value) ? 'btn-secondary' : 'btn-ghost'"
+                @click="toggleTag(job.id, tag.value)"
+              >
+                {{ tag.label }}
+              </button>
+            </div>
+
+            <textarea
+              v-model="notesByJob[job.id]"
+              class="textarea textarea-bordered mt-2 min-h-20 w-full rounded-2xl text-xs"
+              placeholder="What worked, what failed, or how the next prompt should change…"
+            />
+          </div>
+
+          <div class="mt-3 grid grid-cols-3 gap-2">
+            <button
+              type="button"
+              class="btn btn-success btn-sm rounded-2xl"
+              :disabled="isSaving(job.id)"
+              @click="saveFeedback(job, 'PROMOTE')"
+            >
+              Promote
+            </button>
+            <button
+              type="button"
+              class="btn btn-warning btn-sm rounded-2xl"
+              :disabled="isSaving(job.id)"
+              @click="saveFeedback(job, 'REVISE')"
+            >
+              Revise
+            </button>
+            <button
+              type="button"
+              class="btn btn-error btn-sm rounded-2xl"
+              :disabled="isSaving(job.id)"
+              @click="saveFeedback(job, 'REJECT')"
+            >
+              Reject
+            </button>
+          </div>
+
+          <div
+            v-if="humanFeedback(job)"
+            class="mt-3 rounded-2xl border border-success/30 bg-success/10 p-2 text-xs"
+          >
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="font-semibold">Your saved verdict</span>
+              <span
+                class="badge badge-sm rounded-2xl"
+                :class="verdictClass(humanFeedback(job)?.verdict)"
+              >
+                {{ humanFeedback(job)?.verdict }}
+              </span>
+              <span class="text-[10px] text-base-content/50">
+                {{ formatDate(humanFeedback(job)?.createdAt) }}
+              </span>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <div
+        v-else
+        class="flex min-h-56 items-center justify-center rounded-2xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+      >
+        <span v-if="artJobStore.loadingTrainerJobs">Loading curated jobs…</span>
+        <span v-else-if="reviewMode === 'pending'">
+          Nothing is waiting for feedback. Tiny victory parade. 🎉
+        </span>
+        <span v-else>No curated jobs match this filter.</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import {
+  useArtJobStore,
+  type ArtFeedbackVerdict,
+  type ArtJobFeedback,
+  type ArtJobRecord,
+} from '@/stores/artJobStore'
+
+type ReviewMode = 'pending' | 'reviewed' | 'all'
+
+const artJobStore = useArtJobStore()
+const reviewMode = ref<ReviewMode>('pending')
+const savingIds = ref<number[]>([])
+const notesByJob = reactive<Record<number, string>>({})
+const tagsByJob = reactive<Record<number, string[]>>({})
+
+const reviewModes: Array<{ value: ReviewMode; label: string }> = [
+  { value: 'pending', label: 'Needs feedback' },
+  { value: 'reviewed', label: 'Reviewed' },
+  { value: 'all', label: 'All curated' },
+]
+
+const feedbackTags = [
+  { value: 'prompt-fit', label: 'Prompt fit' },
+  { value: 'composition', label: 'Composition' },
+  { value: 'palette', label: 'Palette' },
+  { value: 'lighting', label: 'Lighting' },
+  { value: 'story', label: 'Story' },
+  { value: 'anatomy', label: 'Anatomy' },
+  { value: 'generic', label: 'Too generic' },
+  { value: 'text', label: 'Text / watermark' },
+  { value: 'collage', label: 'Collage' },
+  { value: 'line-art', label: 'Line art' },
+  { value: 'too-pretty', label: 'Beautified away' },
+]
+
+const pendingJobs = computed(() => {
+  return artJobStore.trainerJobs.filter((job) => !humanFeedback(job))
+})
+
+const reviewedJobs = computed(() => {
+  return artJobStore.trainerJobs.filter((job) => Boolean(humanFeedback(job)))
+})
+
+const pendingCount = computed(() => pendingJobs.value.length)
+
+const visibleJobs = computed(() => {
+  if (reviewMode.value === 'pending') return pendingJobs.value
+  if (reviewMode.value === 'reviewed') return reviewedJobs.value
+  return artJobStore.trainerJobs
+})
+
+watch(
+  () => artJobStore.trainerJobs,
+  (jobs) => {
+    for (const job of jobs) {
+      const human = humanFeedback(job)
+      if (!(job.id in notesByJob)) notesByJob[job.id] = human?.summary || ''
+      if (!(job.id in tagsByJob)) tagsByJob[job.id] = [...(human?.tags || [])]
+    }
+  },
+  { deep: true, immediate: true },
+)
+
+function modeCount(mode: ReviewMode): number {
+  if (mode === 'pending') return pendingJobs.value.length
+  if (mode === 'reviewed') return reviewedJobs.value.length
+  return artJobStore.trainerJobs.length
+}
+
+function curation(job: ArtJobRecord) {
+  return job.payload?.curation || {}
+}
+
+function curatorFeedback(job: ArtJobRecord): ArtJobFeedback | undefined {
+  return curation(job).curator
+}
+
+function humanFeedback(job: ArtJobRecord): ArtJobFeedback | undefined {
+  return curation(job).human
+}
+
+function jobImageSrc(job: ArtJobRecord): string {
+  if (typeof job.artImageId !== 'number') return ''
+  return artJobStore.imageSrcById[job.artImageId] || ''
+}
+
+function jobPrompt(job: ArtJobRecord): string {
+  const payload = job.payload || {}
+  for (const key of ['promptString', 'artPrompt', 'prompt']) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function verdictClass(verdict?: ArtFeedbackVerdict): string {
+  if (verdict === 'PROMOTE') return 'badge-success'
+  if (verdict === 'REVISE') return 'badge-warning'
+  if (verdict === 'REJECT') return 'badge-error'
+  return 'badge-ghost'
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return ''
+  return new Date(value).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function hasTag(jobId: number, tag: string): boolean {
+  return tagsByJob[jobId]?.includes(tag) || false
+}
+
+function toggleTag(jobId: number, tag: string): void {
+  const tags = tagsByJob[jobId] || []
+  tagsByJob[jobId] = tags.includes(tag)
+    ? tags.filter((value) => value !== tag)
+    : [...tags, tag]
+}
+
+function isSaving(jobId: number): boolean {
+  return savingIds.value.includes(jobId)
+}
+
+async function saveFeedback(
+  job: ArtJobRecord,
+  verdict: ArtFeedbackVerdict,
+): Promise<void> {
+  if (isSaving(job.id)) return
+  savingIds.value = [...savingIds.value, job.id]
+
+  try {
+    await artJobStore.submitFeedback(job.id, {
+      source: 'HUMAN',
+      verdict,
+      summary: notesByJob[job.id]?.trim() || null,
+      tags: tagsByJob[job.id] || [],
+      rubricKey: 'silas-art-trainer-v1',
+    })
+  } finally {
+    savingIds.value = savingIds.value.filter((id) => id !== job.id)
+  }
+}
+</script>

--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -1,11 +1,4 @@
 <!-- /components/art/artjob-manager.vue -->
-<!--
-  Admin-only ArtJob dashboard (the "artjob" tab under the "art" channel).
-  Surfaces the ArtJob pipeline: server management, ComfyUI/SD uptime, image
-  create/fail stats, the job queue, and errors. Every data call hits an
-  admin-guarded endpoint, so a non-admin sees nothing useful — but we also gate
-  the whole surface client-side for a clean message.
--->
 <template>
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
     <div
@@ -19,12 +12,12 @@
       v-else
       class="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain p-3"
     >
-      <!-- Header / controls -->
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 class="text-lg font-semibold">ArtJob Pipeline</h2>
           <p class="text-xs text-base-content/60">
-            Queue, servers, uptime & errors over the last {{ windowHours }}h.
+            Queue, creative briefs, servers, uptime & errors over the last
+            {{ windowHours }}h.
           </p>
         </div>
         <div class="flex items-center gap-2">
@@ -67,7 +60,6 @@
         KR_BASE_URL).
       </div>
 
-      <!-- Servers + Uptime -->
       <div class="grid gap-3 lg:grid-cols-2">
         <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
           <h3 class="mb-2 text-sm font-semibold">Servers</h3>
@@ -83,12 +75,12 @@
                 </div>
                 <div class="text-[11px] text-base-content/60">
                   {{ server.serverType }} ·
-                  <span :class="statusClass(server.lastStatus)">{{
-                    server.lastStatus
-                  }}</span>
+                  <span :class="statusClass(server.lastStatus)">
+                    {{ server.lastStatus }}
+                  </span>
                   <span v-if="server.lastCheckedAt">
-                    · {{ formatTime(server.lastCheckedAt) }}</span
-                  >
+                    · {{ formatTime(server.lastCheckedAt) }}
+                  </span>
                 </div>
               </div>
               <div class="flex shrink-0 items-center gap-1">
@@ -130,23 +122,25 @@
                   <span
                     v-if="srv.avgLatencyMs !== null"
                     class="text-base-content/50"
-                    >· {{ srv.avgLatencyMs }}ms</span
                   >
+                    · {{ srv.avgLatencyMs }}ms
+                  </span>
                 </span>
               </div>
               <div class="flex h-4 items-end gap-px overflow-hidden">
                 <span
-                  v-for="(s, i) in srv.samples"
-                  :key="i"
+                  v-for="(sample, index) in srv.samples"
+                  :key="index"
                   class="h-full flex-1"
-                  :class="s.ok ? 'bg-success' : 'bg-error'"
-                  :title="`${s.status} @ ${formatTime(s.checkedAt)}`"
+                  :class="sample.ok ? 'bg-success' : 'bg-error'"
+                  :title="`${sample.status} @ ${formatTime(sample.checkedAt)}`"
                 />
                 <span
                   v-if="!srv.samples.length"
                   class="text-[11px] text-base-content/40"
-                  >no samples yet — relay heartbeat not reporting</span
                 >
+                  no samples yet — relay heartbeat not reporting
+                </span>
               </div>
             </div>
             <p v-if="!uptime.length" class="text-xs text-base-content/50">
@@ -156,9 +150,8 @@
         </div>
       </div>
 
-      <!-- Queue -->
       <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
-        <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
           <div class="flex items-center gap-2">
             <h3 class="text-sm font-semibold">Queue</h3>
             <span
@@ -174,116 +167,283 @@
           </div>
           <div class="flex flex-wrap gap-1">
             <button
-              v-for="f in statusFilters"
-              :key="f"
+              v-for="filter in statusFilters"
+              :key="filter"
               type="button"
               class="btn btn-xs rounded-2xl"
               :class="
-                artJobStore.jobStatusFilter === f ? 'btn-primary' : 'btn-ghost'
+                artJobStore.jobStatusFilter === filter
+                  ? 'btn-primary'
+                  : 'btn-ghost'
               "
-              @click="artJobStore.fetchJobs(f)"
+              @click="artJobStore.fetchJobs(filter)"
             >
-              {{ f }}
-              <span class="ml-1 font-mono opacity-70">{{
-                statusCount(f)
-              }}</span>
+              {{ filter }}
+              <span class="ml-1 font-mono opacity-70">
+                {{ statusCount(filter) }}
+              </span>
             </button>
           </div>
         </div>
 
-        <div class="overflow-x-auto">
-          <table class="table table-sm">
-            <thead>
-              <tr class="text-[11px]">
-                <th>#</th>
-                <th>Art</th>
-                <th>Engine</th>
-                <th>Status</th>
-                <th>Att</th>
-                <th>Claimed by</th>
-                <th>Error</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="job in artJobStore.jobs" :key="job.id" class="text-xs">
-                <td>{{ job.id }}</td>
-                <td>
-                  <a
-                    v-if="jobImageSrc(job)"
-                    :href="jobImageSrc(job)"
-                    target="_blank"
-                    rel="noopener"
-                    :title="`ArtImage ${job.artImageId}`"
+        <div class="grid gap-3 xl:grid-cols-2">
+          <article
+            v-for="job in artJobStore.jobs"
+            :key="job.id"
+            class="flex min-w-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/30 p-3"
+          >
+            <div class="flex min-w-0 gap-3">
+              <a
+                v-if="jobImageSrc(job)"
+                :href="jobImageSrc(job)"
+                target="_blank"
+                rel="noopener"
+                :title="`Open ArtImage ${job.artImageId}`"
+                class="shrink-0"
+              >
+                <img
+                  :src="jobImageSrc(job)"
+                  class="h-24 w-20 rounded-2xl border border-base-300 object-cover sm:h-28 sm:w-24"
+                  alt="generated art"
+                />
+              </a>
+              <div
+                v-else
+                class="flex h-24 w-20 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 text-center text-[10px] font-semibold uppercase tracking-wide text-base-content/40 sm:h-28 sm:w-24"
+              >
+                {{ jobPlaceholder(job) }}
+              </div>
+
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-1.5">
+                  <span class="font-mono text-xs font-semibold"
+                    >#{{ job.id }}</span
                   >
-                    <img
-                      :src="jobImageSrc(job)"
-                      class="h-10 w-10 rounded-md object-cover"
-                      alt="generated art"
-                    />
-                  </a>
-                  <span
-                    v-else-if="job.status === 'DONE'"
-                    class="text-base-content/40"
-                    >—</span
-                  >
-                </td>
-                <td>{{ job.engine }}</td>
-                <td>
                   <span
                     class="badge badge-xs rounded-2xl"
                     :class="jobStatusClass(job.status)"
-                    >{{ job.status }}</span
                   >
-                </td>
-                <td>{{ job.attempts }}</td>
-                <td class="max-w-[120px] truncate">
-                  {{ job.claimedBy || '—' }}
-                </td>
-                <td
-                  class="max-w-[220px] truncate text-error"
-                  :title="job.error || ''"
+                    {{ job.status }}
+                  </span>
+                  <span class="badge badge-outline badge-xs rounded-2xl">
+                    {{ job.engine }}
+                  </span>
+                  <span
+                    v-if="job.projectSlug"
+                    class="badge badge-secondary badge-xs rounded-2xl"
+                  >
+                    {{ job.projectSlug }}
+                  </span>
+                </div>
+
+                <p
+                  class="mt-2 whitespace-pre-wrap break-words text-sm font-medium leading-relaxed"
                 >
-                  {{ job.error || '' }}
-                </td>
-                <td class="whitespace-nowrap">
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-xs rounded-2xl"
-                    title="Clone into a fresh job"
-                    @click="artJobStore.reenqueueJob(job.id)"
+                  {{
+                    jobPrompt(job) || 'Prompt unavailable for this legacy job.'
+                  }}
+                </p>
+
+                <div class="mt-2 flex flex-wrap gap-1">
+                  <span
+                    v-for="chip in jobSummaryChips(job)"
+                    :key="chip"
+                    class="badge badge-ghost badge-sm rounded-2xl text-[10px]"
                   >
-                    Re-run
-                  </button>
-                  <button
-                    v-if="job.status !== 'DONE'"
-                    type="button"
-                    class="btn btn-ghost btn-xs rounded-2xl"
-                    title="Reset this job to PENDING"
-                    @click="artJobStore.requeueJob(job.id)"
+                    {{ chip }}
+                  </span>
+                </div>
+
+                <p class="mt-2 text-[11px] text-base-content/60">
+                  {{ jobDestination(job) }} · queued
+                  {{ formatAgeFrom(job.createdAt) }} ago
+                </p>
+              </div>
+
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs shrink-0 rounded-2xl"
+                :disabled="!jobPrompt(job)"
+                @click="copyPrompt(job)"
+              >
+                {{ copiedJobId === job.id ? 'Copied' : 'Copy' }}
+              </button>
+            </div>
+
+            <div
+              v-if="job.error"
+              class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
+            >
+              {{ job.error }}
+            </div>
+
+            <details class="rounded-2xl border border-base-300 bg-base-100">
+              <summary
+                class="cursor-pointer select-none px-3 py-2 text-xs font-semibold"
+              >
+                Full creative brief & routing
+              </summary>
+              <div class="flex flex-col gap-3 border-t border-base-300 p-3">
+                <div>
+                  <div
+                    class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50"
                   >
-                    Requeue
-                  </button>
-                  <button
-                    v-if="job.status !== 'DONE' && job.status !== 'CANCELLED'"
-                    type="button"
-                    class="btn btn-ghost btn-xs rounded-2xl text-error"
-                    @click="artJobStore.cancelJob(job.id)"
+                    Prompt
+                  </div>
+                  <p
+                    class="mt-1 whitespace-pre-wrap break-words text-sm leading-relaxed"
                   >
-                    Cancel
-                  </button>
-                </td>
-              </tr>
-              <tr v-if="!artJobStore.jobs.length">
-                <td
-                  colspan="8"
-                  class="text-center text-xs text-base-content/50"
+                    {{ jobPrompt(job) || 'Prompt unavailable.' }}
+                  </p>
+                </div>
+
+                <div v-if="jobNegativePrompt(job)">
+                  <div
+                    class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50"
+                  >
+                    Negative prompt
+                  </div>
+                  <p
+                    class="mt-1 whitespace-pre-wrap break-words text-xs text-base-content/70"
+                  >
+                    {{ jobNegativePrompt(job) }}
+                  </p>
+                </div>
+
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <div class="rounded-xl bg-base-200/60 p-2">
+                    <div
+                      class="text-[10px] uppercase tracking-wide text-base-content/50"
+                    >
+                      Destination
+                    </div>
+                    <div class="mt-1 text-xs font-medium">
+                      {{ jobDestination(job) }}
+                    </div>
+                  </div>
+                  <div class="rounded-xl bg-base-200/60 p-2">
+                    <div
+                      class="text-[10px] uppercase tracking-wide text-base-content/50"
+                    >
+                      Output
+                    </div>
+                    <div class="mt-1 text-xs font-medium">
+                      {{ jobOutput(job) }}
+                    </div>
+                  </div>
+                  <div class="rounded-xl bg-base-200/60 p-2">
+                    <div
+                      class="text-[10px] uppercase tracking-wide text-base-content/50"
+                    >
+                      Created
+                    </div>
+                    <div class="mt-1 text-xs font-medium">
+                      {{ formatDateTime(job.createdAt) }}
+                    </div>
+                  </div>
+                  <div class="rounded-xl bg-base-200/60 p-2">
+                    <div
+                      class="text-[10px] uppercase tracking-wide text-base-content/50"
+                    >
+                      Relay
+                    </div>
+                    <div class="mt-1 text-xs font-medium">
+                      {{ job.claimedBy || 'Waiting for a relay' }}
+                      <span v-if="job.claimedAt">
+                        · {{ formatDateTime(job.claimedAt) }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div v-if="jobSettings(job).length">
+                  <div
+                    class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50"
+                  >
+                    Generation settings
+                  </div>
+                  <div class="mt-1 flex flex-wrap gap-1">
+                    <span
+                      v-for="setting in jobSettings(job)"
+                      :key="`${setting.label}:${setting.value}`"
+                      class="badge badge-outline badge-sm h-auto min-h-6 rounded-2xl py-1 text-[10px]"
+                    >
+                      {{ setting.label }}: {{ setting.value }}
+                    </span>
+                  </div>
+                </div>
+
+                <div v-if="jobSourceImages(job).length">
+                  <div
+                    class="text-[10px] font-semibold uppercase tracking-wide text-base-content/50"
+                  >
+                    Source / guide images
+                  </div>
+                  <div class="mt-2 flex flex-wrap gap-2">
+                    <a
+                      v-for="source in jobSourceImages(job)"
+                      :key="source.name"
+                      :href="source.src"
+                      target="_blank"
+                      rel="noopener"
+                      class="group"
+                    >
+                      <img
+                        :src="source.src"
+                        :alt="source.name"
+                        class="h-24 w-20 rounded-xl border border-base-300 object-cover transition-transform group-hover:scale-105"
+                      />
+                      <div
+                        class="mt-1 max-w-20 truncate text-[10px] text-base-content/50"
+                      >
+                        {{ source.name }}
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </details>
+
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div class="text-[11px] text-base-content/50">
+                Attempt {{ job.attempts }} · priority {{ job.priority }}
+              </div>
+              <div class="flex flex-wrap gap-1">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs rounded-2xl"
+                  title="Clone into a fresh job"
+                  @click="artJobStore.reenqueueJob(job.id)"
                 >
-                  No {{ artJobStore.jobStatusFilter }} jobs.
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  Re-run
+                </button>
+                <button
+                  v-if="job.status !== 'DONE'"
+                  type="button"
+                  class="btn btn-ghost btn-xs rounded-2xl"
+                  title="Reset this job to PENDING"
+                  @click="artJobStore.requeueJob(job.id)"
+                >
+                  Requeue
+                </button>
+                <button
+                  v-if="job.status !== 'DONE' && job.status !== 'CANCELLED'"
+                  type="button"
+                  class="btn btn-ghost btn-xs rounded-2xl text-error"
+                  @click="artJobStore.cancelJob(job.id)"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </article>
+
+          <div
+            v-if="!artJobStore.jobs.length"
+            class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-xs text-base-content/50 xl:col-span-2"
+          >
+            No {{ artJobStore.jobStatusFilter }} jobs.
+          </div>
         </div>
       </div>
     </div>
@@ -292,9 +452,14 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import type { ArtJob } from '~/prisma/generated/prisma/client'
 import { useArtJobStore, type ArtJobStatus } from '@/stores/artJobStore'
 import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
+
+type JsonRecord = Record<string, unknown>
+type JobSetting = { label: string; value: string }
+type SourceImage = { name: string; src: string }
 
 const artJobStore = useArtJobStore()
 const serverStore = useServerStore()
@@ -302,6 +467,7 @@ const userStore = useUserStore()
 
 const selectedWindow = ref(24)
 const checkingServerId = ref<number | null>(null)
+const copiedJobId = ref<number | null>(null)
 
 const statusFilters: (ArtJobStatus | 'ALL')[] = [
   'PENDING',
@@ -322,11 +488,246 @@ const isLoading = computed(
     artJobStore.loadingJobs,
 )
 
-// Count shown on each queue filter toggle. ALL sums every status.
+function asRecord(value: unknown): JsonRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as JsonRecord
+}
+
+function scalarToString(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  if (typeof value === 'boolean') return value ? 'yes' : 'no'
+  return ''
+}
+
+function payloadRecord(job: ArtJob): JsonRecord {
+  return asRecord(job.payload) ?? {}
+}
+
+function directScalar(record: JsonRecord, keys: string[]): string {
+  for (const key of keys) {
+    const value = scalarToString(record[key])
+    if (value) return value
+  }
+  return ''
+}
+
+function nestedScalar(value: unknown, keys: string[], depth = 0): string {
+  if (depth > 5 || value === null || value === undefined) return ''
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = nestedScalar(item, keys, depth + 1)
+      if (found) return found
+    }
+    return ''
+  }
+
+  const record = asRecord(value)
+  if (!record) return ''
+
+  const direct = directScalar(record, keys)
+  if (direct) return direct
+
+  for (const [key, child] of Object.entries(record)) {
+    if (
+      key === 'imageData' ||
+      key === 'sourceImageBase64' ||
+      key === 'firstImageBase64' ||
+      key === 'secondImageBase64'
+    ) {
+      continue
+    }
+
+    const found = nestedScalar(child, keys, depth + 1)
+    if (found) return found
+  }
+
+  return ''
+}
+
+function payloadScalar(job: ArtJob, keys: string[]): string {
+  const payload = payloadRecord(job)
+  return directScalar(payload, keys) || nestedScalar(payload.workflow, keys)
+}
+
+function workflowPrompt(job: ArtJob, kind: 'positive' | 'negative'): string {
+  const workflow = asRecord(payloadRecord(job).workflow)
+  if (!workflow) return ''
+
+  for (const value of Object.values(workflow)) {
+    const node = asRecord(value)
+    if (!node) continue
+
+    const classType = directScalar(node, ['class_type']).toLowerCase()
+    if (!classType.includes('cliptextencode')) continue
+
+    const inputs = asRecord(node.inputs)
+    if (!inputs) continue
+
+    const meta = asRecord(node._meta) ?? {}
+    const title = directScalar(meta, ['title']).toLowerCase()
+    const isNegative = `${title} ${classType}`.includes('negative')
+
+    if (kind === 'negative' && !isNegative) continue
+    if (kind === 'positive' && isNegative) continue
+
+    const text = directScalar(inputs, ['text', 'clip_l', 't5xxl'])
+    if (text) return text
+  }
+
+  return ''
+}
+
+function jobPrompt(job: ArtJob): string {
+  const payload = payloadRecord(job)
+  return (
+    directScalar(payload, [
+      'promptString',
+      'artPrompt',
+      'positivePrompt',
+      'prompt',
+    ]) || workflowPrompt(job, 'positive')
+  )
+}
+
+function jobNegativePrompt(job: ArtJob): string {
+  const payload = payloadRecord(job)
+  return (
+    directScalar(payload, ['negativePrompt', 'negative_prompt', 'negative']) ||
+    workflowPrompt(job, 'negative')
+  )
+}
+
+function jobDimensions(job: ArtJob): string {
+  const width = payloadScalar(job, ['width'])
+  const height = payloadScalar(job, ['height'])
+  return width && height ? `${width}×${height}` : ''
+}
+
+function jobModel(job: ArtJob): string {
+  return payloadScalar(job, ['checkpoint', 'ckpt_name', 'model_name', 'model'])
+}
+
+function jobSaveRecord(job: ArtJob): JsonRecord {
+  return asRecord(payloadRecord(job).save) ?? {}
+}
+
+function jobDestination(job: ArtJob): string {
+  const save = jobSaveRecord(job)
+  const designer = directScalar(save, ['designer'])
+  const hasSaveSettings = Object.keys(save).length > 0
+  const visibility = save.isPublic === false ? 'private' : 'public'
+  const maturity = save.isMature === true ? 'mature' : 'general'
+  const saveLabel = hasSaveSettings
+    ? `${visibility}/${maturity}`
+    : 'save defaults'
+  const target = job.projectSlug
+    ? `project ${job.projectSlug}`
+    : 'default art gallery'
+  const result = job.artImageId ? ` · ArtImage #${job.artImageId}` : ''
+  const credit = designer ? ` · ${designer}` : ''
+  return `${target}${result} · ${saveLabel}${credit}`
+}
+
+function jobOutput(job: ArtJob): string {
+  const dimensions = jobDimensions(job) || 'engine default size'
+  if (job.artImageId) return `${dimensions} · ArtImage #${job.artImageId}`
+  if (job.status === 'DONE') return `${dimensions} · output record missing`
+  return `${dimensions} · awaiting generated output`
+}
+
+function jobSummaryChips(job: ArtJob): string[] {
+  const dimensions = jobDimensions(job)
+  const model = jobModel(job)
+  const sampler = payloadScalar(job, ['sampler', 'sampler_name'])
+  const steps = payloadScalar(job, ['steps'])
+  const seed = payloadScalar(job, ['seed', 'noise_seed'])
+
+  const chips = [
+    dimensions,
+    model,
+    sampler,
+    steps ? `${steps} steps` : '',
+    seed ? `seed ${seed}` : '',
+  ]
+
+  return chips.filter((chip): chip is string => Boolean(chip)).slice(0, 6)
+}
+
+function jobSettings(job: ArtJob): JobSetting[] {
+  const settings: Array<[string, string]> = [
+    ['Size', jobDimensions(job)],
+    ['Model', jobModel(job)],
+    ['Sampler', payloadScalar(job, ['sampler', 'sampler_name'])],
+    ['Scheduler', payloadScalar(job, ['scheduler'])],
+    ['Steps', payloadScalar(job, ['steps'])],
+    ['CFG', payloadScalar(job, ['cfg', 'cfg_scale'])],
+    ['Guidance', payloadScalar(job, ['guidance'])],
+    ['Denoise', payloadScalar(job, ['denoise'])],
+    ['Seed', payloadScalar(job, ['seed', 'noise_seed'])],
+    ['Checkpoint', payloadScalar(job, ['checkpoint', 'ckpt_name'])],
+  ]
+
+  const seen = new Set<string>()
+  return settings
+    .filter(([, value]) => Boolean(value))
+    .filter(([label, value]) => {
+      const key = `${label}:${value}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .map(([label, value]) => ({ label, value }))
+}
+
+function normalizeImageData(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const raw = value.trim()
+  if (!raw) return ''
+  if (raw.startsWith('data:image/') || raw.startsWith('http')) return raw
+  return `data:image/png;base64,${raw}`
+}
+
+function jobSourceImages(job: ArtJob): SourceImage[] {
+  const payload = payloadRecord(job)
+  const sources: SourceImage[] = []
+  const images = Array.isArray(payload.images) ? payload.images : []
+
+  for (const [index, image] of images.entries()) {
+    const record = asRecord(image)
+    if (!record) continue
+    const src = normalizeImageData(record.imageData)
+    if (!src) continue
+    sources.push({
+      name: directScalar(record, ['name']) || `source-${index + 1}`,
+      src,
+    })
+  }
+
+  const directImages: Array<[string, unknown]> = [
+    ['source image', payload.sourceImageBase64],
+    ['first frame', payload.firstImageBase64],
+    ['last frame', payload.secondImageBase64],
+  ]
+
+  for (const [name, value] of directImages) {
+    const src = normalizeImageData(value)
+    if (src) sources.push({ name, src })
+  }
+
+  const unique = new Map<string, SourceImage>()
+  for (const source of sources) {
+    if (!unique.has(source.src)) unique.set(source.src, source)
+  }
+
+  return [...unique.values()].slice(0, 3)
+}
+
 function statusCount(filter: ArtJobStatus | 'ALL'): number {
   const depth = stats.value?.queueDepth ?? {}
   if (filter === 'ALL') {
-    return Object.values(depth).reduce((a, b) => a + b, 0)
+    return Object.values(depth).reduce((total, count) => total + count, 0)
   }
   return depth[filter] ?? 0
 }
@@ -351,6 +752,14 @@ function jobStatusClass(status: string): string {
   return 'badge-warning'
 }
 
+function jobPlaceholder(job: ArtJob): string {
+  if (job.status === 'DONE') return 'No image'
+  if (job.status === 'FAILED') return 'Failed'
+  if (job.status === 'CANCELLED') return 'Cancelled'
+  if (job.status === 'RUNNING') return 'Rendering'
+  return 'Queued'
+}
+
 function uptimeClass(pct: number | null): string {
   if (pct === null) return 'text-base-content/50'
   if (pct >= 99) return 'text-success'
@@ -365,15 +774,47 @@ function formatAge(seconds: number): string {
   return `${Math.round(seconds / 86400)}d`
 }
 
+function formatAgeFrom(value: string | Date | null): string {
+  if (!value) return 'unknown'
+  const timestamp = new Date(value).getTime()
+  if (!Number.isFinite(timestamp)) return 'unknown'
+  return formatAge(Math.max(0, Math.round((Date.now() - timestamp) / 1000)))
+}
+
 function formatTime(value: string | Date | null): string {
   if (!value) return ''
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return ''
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDateTime(value: string | Date | null): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return '—'
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+async function copyPrompt(job: ArtJob): Promise<void> {
+  const prompt = jobPrompt(job)
+  if (!prompt || !navigator.clipboard) return
+
   try {
-    return new Date(value).toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-    })
+    await navigator.clipboard.writeText(prompt)
+    copiedJobId.value = job.id
+    window.setTimeout(() => {
+      if (copiedJobId.value === job.id) copiedJobId.value = null
+    }, 1600)
   } catch {
-    return ''
+    copiedJobId.value = null
   }
 }
 
@@ -381,7 +822,6 @@ async function checkHealth(id: number): Promise<void> {
   checkingServerId.value = id
   try {
     await serverStore.testServerHealth(id)
-    // The health check writes a ServerHealthCheck row; refresh the chart.
     await Promise.all([
       artJobStore.fetchUptime(),
       serverStore.initialize({ force: true, fetchRemote: true }),

--- a/server/api/art/queue/[id]/feedback.post.ts
+++ b/server/api/art/queue/[id]/feedback.post.ts
@@ -1,0 +1,179 @@
+// /server/api/art/queue/[id]/feedback.post.ts
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+} from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { requireMachineUser } from '../../../../utils/authGuard'
+
+type FeedbackSource = 'CURATOR' | 'HUMAN'
+type FeedbackVerdict = 'PROMOTE' | 'REVISE' | 'REJECT'
+
+type FeedbackRequestBody = {
+  source?: string | null
+  verdict?: string | null
+  score?: number | null
+  summary?: string | null
+  reasons?: unknown
+  tags?: unknown
+  rubricKey?: string | null
+}
+
+type FeedbackRecord = {
+  source: FeedbackSource
+  verdict: FeedbackVerdict
+  score: number | null
+  summary: string | null
+  reasons: string[]
+  tags: string[]
+  rubricKey: string | null
+  createdAt: string
+  userId: number | null
+}
+
+const SOURCES = new Set<FeedbackSource>(['CURATOR', 'HUMAN'])
+const VERDICTS = new Set<FeedbackVerdict>(['PROMOTE', 'REVISE', 'REJECT'])
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+function sanitizeList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim().slice(0, 240))
+    .filter(Boolean)
+    .slice(0, 24)
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+    const id = Number(getRouterParam(event, 'id'))
+
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid job id.' })
+    }
+
+    const body = (await readBody(event)) as FeedbackRequestBody | null
+    const source = String(body?.source || '').toUpperCase() as FeedbackSource
+    const verdict = String(body?.verdict || '').toUpperCase() as FeedbackVerdict
+
+    if (!SOURCES.has(source)) {
+      throw createError({
+        statusCode: 400,
+        message: 'source must be CURATOR or HUMAN.',
+      })
+    }
+
+    if (!VERDICTS.has(verdict)) {
+      throw createError({
+        statusCode: 400,
+        message: 'verdict must be PROMOTE, REVISE, or REJECT.',
+      })
+    }
+
+    if (source === 'HUMAN' && !auth.isAdmin) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to submit human art feedback.',
+      })
+    }
+
+    if (source === 'CURATOR' && !auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin or server credentials required for curator feedback.',
+      })
+    }
+
+    const score = body?.score === null || body?.score === undefined
+      ? null
+      : Number(body.score)
+
+    if (score !== null && (!Number.isFinite(score) || score < 0 || score > 100)) {
+      throw createError({
+        statusCode: 400,
+        message: 'score must be between 0 and 100.',
+      })
+    }
+
+    const job = await prisma.artJob.findUnique({ where: { id } })
+
+    if (!job) {
+      throw createError({ statusCode: 404, message: `Job ${id} not found.` })
+    }
+
+    if (job.status !== 'DONE' || !job.artImageId) {
+      throw createError({
+        statusCode: 409,
+        message: 'Only completed jobs with an ArtImage can receive feedback.',
+      })
+    }
+
+    const payload = asRecord(job.payload)
+    const curation = asRecord(payload.curation)
+    const history = Array.isArray(curation.history)
+      ? curation.history.filter((item) => item && typeof item === 'object')
+      : []
+
+    const feedback: FeedbackRecord = {
+      source,
+      verdict,
+      score: score === null ? null : Math.round(score),
+      summary:
+        typeof body?.summary === 'string'
+          ? body.summary.trim().slice(0, 4000) || null
+          : null,
+      reasons: sanitizeList(body?.reasons),
+      tags: sanitizeList(body?.tags),
+      rubricKey:
+        typeof body?.rubricKey === 'string'
+          ? body.rubricKey.trim().slice(0, 128) || null
+          : null,
+      createdAt: new Date().toISOString(),
+      userId: auth.user?.id ?? null,
+    }
+
+    const key = source === 'CURATOR' ? 'curator' : 'human'
+    const nextPayload = {
+      ...payload,
+      curation: {
+        ...curation,
+        [key]: feedback,
+        history: [...history, feedback].slice(-50),
+      },
+    }
+
+    const updated = await prisma.artJob.update({
+      where: { id },
+      data: {
+        payload: nextPayload as Prisma.InputJsonValue,
+      },
+    })
+
+    return {
+      success: true,
+      message: `${source === 'CURATOR' ? 'Curator' : 'Human'} feedback saved for job ${id}.`,
+      data: { job: updated },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to save art feedback.',
+      statusCode,
+    }
+  }
+})

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -1,7 +1,11 @@
 // /stores/artJobStore.ts
 import { defineStore } from 'pinia'
 import { reactive, toRefs } from 'vue'
-import type { ArtImage, ArtJob } from '~/prisma/generated/prisma/client'
+import type {
+  ArtImage,
+  ArtJob,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
 
 export type ArtJobStatus =
@@ -14,7 +18,7 @@ export type ArtJobStatus =
 export type ArtFeedbackSource = 'CURATOR' | 'HUMAN'
 export type ArtFeedbackVerdict = 'PROMOTE' | 'REVISE' | 'REJECT'
 
-export type ArtJobFeedback = {
+export type ArtJobFeedback = Prisma.JsonObject & {
   source: ArtFeedbackSource
   verdict: ArtFeedbackVerdict
   score: number | null
@@ -26,13 +30,13 @@ export type ArtJobFeedback = {
   userId: number | null
 }
 
-export type ArtJobCuration = {
+export type ArtJobCuration = Prisma.JsonObject & {
   curator?: ArtJobFeedback
   human?: ArtJobFeedback
   history?: ArtJobFeedback[]
 }
 
-export type ArtJobPayload = Record<string, unknown> & {
+export type ArtJobPayload = Prisma.JsonObject & {
   curation?: ArtJobCuration
 }
 

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -1,10 +1,4 @@
 // /stores/artJobStore.ts
-//
-// Admin-only store backing the ArtJob dashboard (the "artjob" tab under the
-// "art" channel). Fetches pipeline stats, ComfyUI/SD uptime, and the job queue
-// from the admin-guarded endpoints, and exposes requeue/cancel actions. Every
-// call hits an endpoint guarded by requireAdminApiUser / admin-or-serverKey, so
-// a non-admin simply gets empty data.
 import { defineStore } from 'pinia'
 import { reactive, toRefs } from 'vue'
 import type { ArtImage, ArtJob } from '~/prisma/generated/prisma/client'
@@ -16,6 +10,45 @@ export type ArtJobStatus =
   | 'DONE'
   | 'FAILED'
   | 'CANCELLED'
+
+export type ArtFeedbackSource = 'CURATOR' | 'HUMAN'
+export type ArtFeedbackVerdict = 'PROMOTE' | 'REVISE' | 'REJECT'
+
+export type ArtJobFeedback = {
+  source: ArtFeedbackSource
+  verdict: ArtFeedbackVerdict
+  score: number | null
+  summary: string | null
+  reasons: string[]
+  tags: string[]
+  rubricKey: string | null
+  createdAt: string
+  userId: number | null
+}
+
+export type ArtJobCuration = {
+  curator?: ArtJobFeedback
+  human?: ArtJobFeedback
+  history?: ArtJobFeedback[]
+}
+
+export type ArtJobPayload = Record<string, unknown> & {
+  curation?: ArtJobCuration
+}
+
+export type ArtJobRecord = Omit<ArtJob, 'payload'> & {
+  payload: ArtJobPayload
+}
+
+export type SubmitArtFeedbackInput = {
+  source: ArtFeedbackSource
+  verdict: ArtFeedbackVerdict
+  score?: number | null
+  summary?: string | null
+  reasons?: string[]
+  tags?: string[]
+  rubricKey?: string | null
+}
 
 export type QueueStats = {
   windowHours: number
@@ -69,31 +102,32 @@ export type ServerUptime = {
 type ArtJobState = {
   stats: QueueStats | null
   uptime: ServerUptime[]
-  jobs: ArtJob[]
-  // Displayable src (data URL or /images path) for a finished job's ArtImage,
-  // keyed by artImageId — so the DONE tab can show the generated art.
+  jobs: ArtJobRecord[]
+  trainerJobs: ArtJobRecord[]
   imageSrcById: Record<number, string>
   jobStatusFilter: ArtJobStatus | 'ALL'
   loadingStats: boolean
   loadingUptime: boolean
   loadingJobs: boolean
+  loadingTrainerJobs: boolean
   error: string | null
   windowHours: number
 }
 
-// How many finished jobs to pull image data for at once (base64 is heavy).
-const MAX_JOB_IMAGES = 48
+const MAX_JOB_IMAGES = 72
 
 export const useArtJobStore = defineStore('artJobStore', () => {
   const state = reactive<ArtJobState>({
     stats: null,
     uptime: [],
     jobs: [],
+    trainerJobs: [],
     imageSrcById: {},
     jobStatusFilter: 'PENDING',
     loadingStats: false,
     loadingUptime: false,
     loadingJobs: false,
+    loadingTrainerJobs: false,
     error: null,
     windowHours: 24,
   })
@@ -137,7 +171,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     state.loadingJobs = true
     try {
       const query = status === 'ALL' ? '' : `?status=${status}`
-      const res = await performFetch<{ jobs: ArtJob[] }>(
+      const res = await performFetch<{ jobs: ArtJobRecord[] }>(
         `/api/art/queue${query}${status === 'ALL' ? '?' : '&'}limit=100`,
       )
       if (res.success && res.data) {
@@ -151,9 +185,25 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     }
   }
 
-  // Turn a finished job's ArtImage into a browser-displayable src: prefer the
-  // base64 imageData (how the relay stores results) as a data URL, else a
-  // normalized /images path.
+  async function fetchTrainerJobs(): Promise<void> {
+    state.loadingTrainerJobs = true
+    try {
+      const res = await performFetch<{ jobs: ArtJobRecord[] }>(
+        '/api/art/queue?status=DONE&limit=200',
+      )
+      if (res.success && res.data) {
+        state.trainerJobs = res.data.jobs.filter((job) => {
+          return Boolean(job.payload?.curation?.curator)
+        })
+        void loadJobImages()
+      } else if (!res.success) {
+        state.error = res.message || 'Failed to load curated jobs.'
+      }
+    } finally {
+      state.loadingTrainerJobs = false
+    }
+  }
+
   function artImageToSrc(image: ArtImage | null | undefined): string {
     if (!image) return ''
     const raw = (image.imageData || '').trim()
@@ -171,13 +221,13 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     return ''
   }
 
-  // Load the generated art for the currently-shown finished jobs so the DONE
-  // tab can render thumbnails. Bounded by MAX_JOB_IMAGES since imageData is
-  // heavy; skips ids already loaded.
   async function loadJobImages(): Promise<void> {
-    const ids = state.jobs
-      .filter((j) => j.status === 'DONE' && typeof j.artImageId === 'number')
-      .map((j) => j.artImageId as number)
+    const ids = [...state.jobs, ...state.trainerJobs]
+      .filter((job) => {
+        return job.status === 'DONE' && typeof job.artImageId === 'number'
+      })
+      .map((job) => job.artImageId as number)
+      .filter((id, index, all) => all.indexOf(id) === index)
       .filter((id) => !(id in state.imageSrcById))
       .slice(0, MAX_JOB_IMAGES)
 
@@ -198,13 +248,44 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     )
   }
 
+  function replaceJob(updated: ArtJobRecord): void {
+    const jobIndex = state.jobs.findIndex((job) => job.id === updated.id)
+    if (jobIndex >= 0) state.jobs[jobIndex] = updated
+
+    const trainerIndex = state.trainerJobs.findIndex(
+      (job) => job.id === updated.id,
+    )
+    if (trainerIndex >= 0) state.trainerJobs[trainerIndex] = updated
+  }
+
+  async function submitFeedback(
+    id: number,
+    input: SubmitArtFeedbackInput,
+  ): Promise<boolean> {
+    const res = await performFetch<{ job: ArtJobRecord }>(
+      `/api/art/queue/${id}/feedback`,
+      {
+        method: 'POST',
+        body: JSON.stringify(input),
+      },
+    )
+
+    if (res.success && res.data?.job) {
+      replaceJob(res.data.job)
+      return true
+    }
+
+    state.error = res.message || `Failed to save feedback for job ${id}.`
+    return false
+  }
+
   async function requeueJob(id: number): Promise<boolean> {
     const res = await performFetch(`/api/art/queue/${id}/requeue`, {
       method: 'POST',
       body: JSON.stringify({}),
     })
     if (res.success) {
-      await Promise.all([fetchJobs(), fetchStats()])
+      await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
       return true
     }
     state.error = res.message || `Failed to requeue job ${id}.`
@@ -217,21 +298,20 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       body: JSON.stringify({}),
     })
     if (res.success) {
-      await Promise.all([fetchJobs(), fetchStats()])
+      await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
       return true
     }
     state.error = res.message || `Failed to cancel job ${id}.`
     return false
   }
 
-  // Re-run: clone the job into a fresh PENDING job (works on DONE too).
   async function reenqueueJob(id: number): Promise<number | null> {
-    const res = await performFetch<{ job: ArtJob }>(
+    const res = await performFetch<{ job: ArtJobRecord }>(
       `/api/art/queue/${id}/reenqueue`,
       { method: 'POST', body: JSON.stringify({}) },
     )
     if (res.success && res.data?.job) {
-      await Promise.all([fetchJobs(), fetchStats()])
+      await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
       return res.data.job.id
     }
     state.error = res.message || `Failed to re-enqueue job ${id}.`
@@ -240,7 +320,12 @@ export const useArtJobStore = defineStore('artJobStore', () => {
 
   async function refreshAll(): Promise<void> {
     state.error = null
-    await Promise.all([fetchStats(), fetchUptime(), fetchJobs()])
+    await Promise.all([
+      fetchStats(),
+      fetchUptime(),
+      fetchJobs(),
+      fetchTrainerJobs(),
+    ])
   }
 
   function setWindow(hours: number): void {
@@ -252,6 +337,8 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     fetchStats,
     fetchUptime,
     fetchJobs,
+    fetchTrainerJobs,
+    submitFeedback,
     requeueJob,
     cancelJob,
     reenqueueJob,


### PR DESCRIPTION
## What changed

### ArtJob queue
- Replaced the horizontally scrolling queue table with responsive job cards.
- Shows the positive prompt on every pending, running, failed, cancelled, and completed job.
- Adds an expandable creative brief with the full prompt, negative prompt, destination, output record, relay claim, timestamps, generation settings, and source/guide images.
- Falls back to extracting prompts from Comfy workflow nodes for legacy jobs.

### Reusable trainer loop
- Added `POST /api/art/queue/:id/feedback` for durable CURATOR and HUMAN verdicts on completed jobs.
- Feedback stays inside the ArtJob payload beside the prompt, project, generation settings, and ArtImage id; each update also appends to a bounded history.
- Added an Art trainer panel on the existing ArtJob tab—no new one-purpose page.
- Shows Conductor's score, verdict, summary, and reasons for curated finished jobs.
- Adds Promote / Revise / Reject controls, free-text guidance, and structured tags for prompt fit, composition, palette, lighting, story, anatomy, generic output, text/watermarks, collage, line art, and beautified-away character details.
- Separates Needs feedback, Reviewed, and All curated queues.
- Extends the Pinia store with trainer-job loading, image hydration, and feedback submission; components do not call APIs directly.

## Why

Conductor already vision-scores generated art, but the human review step was stranded in curated GitHub lists. ArtJob is already the durable source of truth for the prompt, render, destination, and output, so it should also carry the curator result and Silas's response. This makes the finished queue the reusable trainer surface and gives future curation passes structured positive and negative examples.

## Conductor integration

Paired with `silasfelinus/conductor#496`, which:
- curates unscored DONE ArtJobs,
- writes the curator verdict back through the new endpoint,
- and uses recent human-labeled ArtJobs as visual few-shot examples on later passes.

## Validation

- **GitHub TypeScript Type Check passed.**
- **GitHub Contract Tests passed.**
- The change is additive and requires no database migration; curation metadata is stored in the existing ArtJob JSON payload.
- Vercel preview did not run because the account hit its build-rate limit; GitHub reports the rate-limit upgrade URL rather than a code/build diagnostic.