### PR TITLE
Open finished ArtJob images in an in-app preview

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -116,6 +116,7 @@
     <section
       v-else-if="activeTab === 'artjob'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+      @click.capture="handleArtJobImageClick"
     >
       <div
         class="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-y-auto 2xl:grid 2xl:grid-cols-[minmax(0,1.45fr)_minmax(360px,0.55fr)] 2xl:overflow-hidden"
@@ -135,6 +136,45 @@
     >
       Unknown image tab: {{ activeTab }}
     </div>
+
+    <dialog
+      ref="artPreviewDialog"
+      class="modal"
+      @click.self="closeArtPreview"
+      @close="clearArtPreview"
+    >
+      <div
+        class="modal-box flex h-[92vh] w-[96vw] max-w-7xl flex-col rounded-2xl border border-base-300 bg-base-100 p-3"
+      >
+        <div class="flex items-center justify-between gap-3 px-1 pb-3">
+          <div class="min-w-0">
+            <h3 class="truncate text-sm font-semibold">{{ artPreviewTitle }}</h3>
+            <p class="text-[11px] text-base-content/50">
+              Finished ArtJob preview
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-circle btn-ghost btn-sm"
+            aria-label="Close art preview"
+            @click="closeArtPreview"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div
+          class="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-2xl bg-base-200/60 p-2"
+        >
+          <img
+            v-if="artPreviewSrc"
+            :src="artPreviewSrc"
+            class="max-h-full max-w-full rounded-2xl object-contain"
+            :alt="artPreviewTitle"
+          />
+        </div>
+      </div>
+    </dialog>
   </section>
 </template>
 
@@ -182,6 +222,9 @@ const validTabs: LegacyArtTab[] = [
 
 const isLoadingManager = ref(false)
 const managerError = ref<string | null>(null)
+const artPreviewDialog = ref<HTMLDialogElement | null>(null)
+const artPreviewSrc = ref('')
+const artPreviewTitle = ref('Generated art')
 
 const dashboardKey = computed(() => {
   return navStore.dashboardShell.dashboardKey || defaultDashboardKey
@@ -232,6 +275,33 @@ async function loadManagerData(force = false) {
 
 async function refreshManagerData() {
   await loadManagerData(true)
+}
+
+function handleArtJobImageClick(event: MouseEvent): void {
+  const target = event.target
+  if (!(target instanceof Element)) return
+
+  const anchor = target.closest('a[href^="data:image/"]')
+  if (!(anchor instanceof HTMLAnchorElement)) return
+
+  const src = anchor.getAttribute('href') || ''
+  if (!src) return
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  artPreviewSrc.value = src
+  artPreviewTitle.value = anchor.title || 'Generated art'
+  artPreviewDialog.value?.showModal()
+}
+
+function closeArtPreview(): void {
+  artPreviewDialog.value?.close()
+}
+
+function clearArtPreview(): void {
+  artPreviewSrc.value = ''
+  artPreviewTitle.value = 'Generated art'
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## What changed

- Intercepts generated-image clicks inside the existing ArtJob queue and trainer surfaces.
- Opens base64-backed ArtImages in a large in-app modal instead of navigating the browser to a `data:image/...;base64,...` URL.
- Keeps normal HTTP/path-backed image links behaving normally.
- Supports both the finished queue cards and curated trainer cards without duplicating preview state in both child components.

## Why

Finished ArtJobs are commonly hydrated from `ArtImage.imageData`, so their thumbnail source is a data URI. Sending that URI to a new browser tab can produce a blank page or hit browser URL/document limits. The data URI is valid as an `<img>` source and should stay inside the application UI.

## Validation

- Scoped to `components/art/art-manager.vue`.
- No API, schema, or store changes.
- The preview closes by button, dialog close, or backdrop click.