### PR TITLE
Add new-output and overwrite modes for ArtJob retries

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -216,9 +216,7 @@
 
               <div class="min-w-0 flex-1">
                 <div class="flex flex-wrap items-center gap-1.5">
-                  <span class="font-mono text-xs font-semibold"
-                    >#{{ job.id }}</span
-                  >
+                  <span class="font-mono text-xs font-semibold">#{{ job.id }}</span>
                   <span
                     class="badge badge-xs rounded-2xl"
                     :class="jobStatusClass(job.status)"
@@ -234,14 +232,27 @@
                   >
                     {{ job.projectSlug }}
                   </span>
+                  <span
+                    v-if="jobRetryMode(job)"
+                    class="badge badge-xs rounded-2xl"
+                    :class="
+                      jobRetryMode(job) === 'OVERWRITE'
+                        ? 'badge-warning'
+                        : 'badge-info'
+                    "
+                  >
+                    {{
+                      jobRetryMode(job) === 'OVERWRITE'
+                        ? 'replace asset'
+                        : 'new attempt'
+                    }}
+                  </span>
                 </div>
 
                 <p
                   class="mt-2 whitespace-pre-wrap break-words text-sm font-medium leading-relaxed"
                 >
-                  {{
-                    jobPrompt(job) || 'Prompt unavailable for this legacy job.'
-                  }}
+                  {{ jobPrompt(job) || 'Prompt unavailable for this legacy job.' }}
                 </p>
 
                 <div class="mt-2 flex flex-wrap gap-1">
@@ -275,6 +286,21 @@
               class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
             >
               {{ job.error }}
+            </div>
+
+            <div
+              v-if="jobRetryMode(job)"
+              class="rounded-2xl border border-info/30 bg-info/10 p-2 text-xs"
+            >
+              <span v-if="jobRetryMode(job) === 'OVERWRITE'">
+                This attempt will replace ArtImage #{{ jobRetryTarget(job) }} while
+                preserving that canonical id. The prior render will be archived
+                for job/trainer history.
+              </span>
+              <span v-else>
+                This is a fresh output derived from job #{{ jobRetrySource(job) }}.
+                It will create a separate ArtImage.
+              </span>
             </div>
 
             <details class="rounded-2xl border border-base-300 bg-base-100">
@@ -354,6 +380,19 @@
                       </span>
                     </div>
                   </div>
+                  <div
+                    v-if="jobRetryMode(job)"
+                    class="rounded-xl bg-base-200/60 p-2 sm:col-span-2"
+                  >
+                    <div
+                      class="text-[10px] uppercase tracking-wide text-base-content/50"
+                    >
+                      Retry lineage
+                    </div>
+                    <div class="mt-1 text-xs font-medium">
+                      {{ retryLineage(job) }}
+                    </div>
+                  </div>
                 </div>
 
                 <div v-if="jobSettings(job).length">
@@ -408,23 +447,60 @@
               <div class="text-[11px] text-base-content/50">
                 Attempt {{ job.attempts }} · priority {{ job.priority }}
               </div>
-              <div class="flex flex-wrap gap-1">
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-xs rounded-2xl"
-                  title="Clone into a fresh job"
-                  @click="artJobStore.reenqueueJob(job.id)"
-                >
-                  Re-run
-                </button>
+              <div class="flex flex-wrap items-center gap-1">
+                <details class="dropdown dropdown-end">
+                  <summary
+                    class="btn btn-ghost btn-xs rounded-2xl"
+                    :class="{ 'btn-disabled': isRetrying(job.id) }"
+                  >
+                    <span
+                      v-if="isRetrying(job.id)"
+                      class="loading loading-spinner loading-xs"
+                    />
+                    Try again
+                  </summary>
+                  <ul
+                    class="menu dropdown-content z-30 mt-1 w-72 rounded-2xl border border-base-300 bg-base-100 p-2 text-xs shadow-xl"
+                  >
+                    <li>
+                      <button
+                        type="button"
+                        :disabled="isRetrying(job.id)"
+                        @click="retryJob(job, 'NEW_OUTPUT')"
+                      >
+                        <span>
+                          <strong>Make a new output</strong>
+                          <span class="block text-[11px] opacity-60">
+                            Fresh seed, separate ArtImage, original stays intact.
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                    <li v-if="job.status === 'DONE' && job.artImageId">
+                      <button
+                        type="button"
+                        class="text-warning"
+                        :disabled="isRetrying(job.id)"
+                        @click="askToOverwrite(job)"
+                      >
+                        <span>
+                          <strong>Replace ArtImage #{{ job.artImageId }}</strong>
+                          <span class="block text-[11px] opacity-70">
+                            Keep the id and links; archive the current render.
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                  </ul>
+                </details>
                 <button
                   v-if="job.status !== 'DONE'"
                   type="button"
                   class="btn btn-ghost btn-xs rounded-2xl"
-                  title="Reset this job to PENDING"
+                  title="Reset this same job to PENDING after a failure or stale claim"
                   @click="artJobStore.requeueJob(job.id)"
                 >
-                  Requeue
+                  Resume job
                 </button>
                 <button
                   v-if="job.status !== 'DONE' && job.status !== 'CANCELLED'"
@@ -447,13 +523,71 @@
         </div>
       </div>
     </div>
+
+    <div
+      v-if="overwriteJob"
+      class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="overwrite-art-title"
+      @click.self="overwriteJob = null"
+    >
+      <div
+        class="w-full max-w-lg rounded-3xl border border-warning/40 bg-base-100 p-5 shadow-2xl"
+      >
+        <h3 id="overwrite-art-title" class="text-lg font-semibold">
+          Replace ArtImage #{{ overwriteJob.artImageId }}?
+        </h3>
+        <p class="mt-2 text-sm leading-relaxed text-base-content/70">
+          The server will generate a fresh attempt and keep this ArtImage id, so
+          every Dream, Bot, Reward, collection, or other record linked to it sees
+          the replacement. The current pixels are archived under a new ArtImage id
+          and historical ArtJobs keep pointing to that archived render.
+        </p>
+        <div class="mt-3 rounded-2xl bg-base-200 p-3 text-xs">
+          <div class="font-semibold">Prompt</div>
+          <p class="mt-1 line-clamp-4 whitespace-pre-wrap">
+            {{ jobPrompt(overwriteJob) || 'Prompt unavailable.' }}
+          </p>
+        </div>
+        <p class="mt-3 text-xs text-base-content/60">
+          Concrete seeds are refreshed automatically so this is a real new attempt,
+          not a byte-for-byte rerun.
+        </p>
+        <div class="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-2xl"
+            @click="overwriteJob = null"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn btn-warning btn-sm rounded-2xl"
+            :disabled="isRetrying(overwriteJob.id)"
+            @click="confirmOverwrite"
+          >
+            <span
+              v-if="isRetrying(overwriteJob.id)"
+              class="loading loading-spinner loading-xs"
+            />
+            Generate and replace
+          </button>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import type { ArtJob } from '~/prisma/generated/prisma/client'
-import { useArtJobStore, type ArtJobStatus } from '@/stores/artJobStore'
+import {
+  useArtJobStore,
+  type ArtJobRetryMode,
+  type ArtJobStatus,
+} from '@/stores/artJobStore'
 import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -468,6 +602,7 @@ const userStore = useUserStore()
 const selectedWindow = ref(24)
 const checkingServerId = ref<number | null>(null)
 const copiedJobId = ref<number | null>(null)
+const overwriteJob = ref<ArtJob | null>(null)
 
 const statusFilters: (ArtJobStatus | 'ALL')[] = [
   'PENDING',
@@ -502,6 +637,10 @@ function scalarToString(value: unknown): string {
 
 function payloadRecord(job: ArtJob): JsonRecord {
   return asRecord(job.payload) ?? {}
+}
+
+function retryRecord(job: ArtJob): JsonRecord {
+  return asRecord(payloadRecord(job).retry) ?? {}
 }
 
 function directScalar(record: JsonRecord, keys: string[]): string {
@@ -635,6 +774,41 @@ function jobOutput(job: ArtJob): string {
   if (job.artImageId) return `${dimensions} · ArtImage #${job.artImageId}`
   if (job.status === 'DONE') return `${dimensions} · output record missing`
   return `${dimensions} · awaiting generated output`
+}
+
+function jobRetryMode(job: ArtJob): ArtJobRetryMode | null {
+  const mode = directScalar(retryRecord(job), ['mode']).toUpperCase()
+  return mode === 'NEW_OUTPUT' || mode === 'OVERWRITE' ? mode : null
+}
+
+function jobRetrySource(job: ArtJob): number | null {
+  const value = Number(retryRecord(job).sourceJobId)
+  return Number.isInteger(value) && value > 0 ? value : null
+}
+
+function jobRetryTarget(job: ArtJob): number | null {
+  const value = Number(retryRecord(job).targetArtImageId)
+  return Number.isInteger(value) && value > 0 ? value : null
+}
+
+function retryLineage(job: ArtJob): string {
+  const retry = retryRecord(job)
+  const mode = jobRetryMode(job)
+  const source = jobRetrySource(job)
+  const root = Number(retry.rootJobId)
+  const target = jobRetryTarget(job)
+  const archived = Number(retry.archivedArtImageId)
+  const parts = [
+    mode === 'OVERWRITE' ? 'replace canonical asset' : 'create new output',
+    source ? `source job #${source}` : '',
+    Number.isInteger(root) && root > 0 ? `root job #${root}` : '',
+    target ? `target ArtImage #${target}` : '',
+    Number.isInteger(archived) && archived > 0
+      ? `prior render archived as ArtImage #${archived}`
+      : '',
+    retry.refreshSeed === true ? 'fresh seeds' : '',
+  ]
+  return parts.filter(Boolean).join(' · ')
 }
 
 function jobSummaryChips(job: ArtJob): string[] {
@@ -801,6 +975,25 @@ function formatDateTime(value: string | Date | null): string {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+function isRetrying(jobId: number): boolean {
+  return artJobStore.retryingJobIds.includes(jobId)
+}
+
+async function retryJob(job: ArtJob, mode: ArtJobRetryMode): Promise<void> {
+  await artJobStore.reenqueueJob(job.id, mode)
+}
+
+function askToOverwrite(job: ArtJob): void {
+  overwriteJob.value = job
+}
+
+async function confirmOverwrite(): Promise<void> {
+  const job = overwriteJob.value
+  if (!job) return
+  const queued = await artJobStore.reenqueueJob(job.id, 'OVERWRITE')
+  if (queued) overwriteJob.value = null
 }
 
 async function copyPrompt(job: ArtJob): Promise<void> {

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -1,11 +1,15 @@
 // /server/api/art/queue/[id]/complete.post.ts
 //
-// The relay agent reports a claimed job's outcome. On success it has already
-// uploaded the image via /api/art/save-generated and passes the resulting
-// artImageId here. On failure the job returns to PENDING for another try,
-// or lands at FAILED once attempts are exhausted (attempts increment at
-// claim time). Admin/server credentials only, matching claim.
+// The relay reports a claimed job's outcome after uploading the rendered bytes
+// through /api/art/save-generated. Normal jobs keep that uploaded ArtImage.
+// OVERWRITE retries use it as a temporary staging row: completion snapshots the
+// old canonical ArtImage for historical ArtJobs, copies the fresh render into
+// the canonical row, and deletes the temporary upload in one transaction.
 import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import type {
+  ArtImage,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
@@ -16,6 +20,149 @@ type CompleteRequestBody = {
   success?: boolean
   artImageId?: number | null
   error?: string | null
+}
+
+type RetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
+type JsonRecord = Record<string, unknown>
+
+type RetryMetadata = {
+  mode: RetryMode
+  sourceJobId: number | null
+  rootJobId: number | null
+  targetArtImageId: number | null
+}
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
+
+function readRetry(payload: unknown): RetryMetadata | null {
+  const retry = asRecord(asRecord(payload).retry)
+  const mode = String(retry.mode || '').toUpperCase()
+  if (mode !== 'NEW_OUTPUT' && mode !== 'OVERWRITE') return null
+
+  const sourceJobId = Number(retry.sourceJobId)
+  const rootJobId = Number(retry.rootJobId)
+  const targetArtImageId = Number(retry.targetArtImageId)
+
+  return {
+    mode,
+    sourceJobId:
+      Number.isInteger(sourceJobId) && sourceJobId > 0 ? sourceJobId : null,
+    rootJobId: Number.isInteger(rootJobId) && rootJobId > 0 ? rootJobId : null,
+    targetArtImageId:
+      Number.isInteger(targetArtImageId) && targetArtImageId > 0
+        ? targetArtImageId
+        : null,
+  }
+}
+
+function readSavePolicy(payload: unknown): {
+  isPublic?: boolean
+  isMature?: boolean
+  designer?: string
+} {
+  const save = asRecord(asRecord(payload).save)
+  return {
+    ...(typeof save.isPublic === 'boolean'
+      ? { isPublic: save.isPublic }
+      : {}),
+    ...(typeof save.isMature === 'boolean'
+      ? { isMature: save.isMature }
+      : {}),
+    ...(typeof save.designer === 'string' && save.designer.trim()
+      ? { designer: save.designer.trim() }
+      : {}),
+  }
+}
+
+function snapshotData(image: ArtImage): Prisma.ArtImageUncheckedCreateInput {
+  return {
+    imageData: image.imageData,
+    userId: image.userId,
+    fileName: `${image.fileName || `ArtImage-${image.id}`}-revision-${Date.now()}`,
+    fileType: image.fileType,
+    cfg: image.cfg,
+    cfgHalf: image.cfgHalf,
+    checkpoint: image.checkpoint,
+    checkpointResourceId: image.checkpointResourceId,
+    designer: image.designer,
+    genres: image.genres,
+    // Revision rows are historical render snapshots, not another canonical file
+    // placement. Keep their bytes and generation metadata but avoid duplicating
+    // path claims that still belong to the stable target ArtImage.
+    imagePath: null,
+    heroPath: null,
+    cardPath: null,
+    iconPath: null,
+    thumbnailPath: null,
+    heroData: null,
+    cardData: null,
+    iconData: null,
+    thumbnailData: null,
+    isMature: image.isMature,
+    isPublic: image.isPublic,
+    isActive: image.isActive,
+    negativePrompt: image.negativePrompt,
+    path: null,
+    promptString: image.promptString,
+    sampler: image.sampler,
+    seed: image.seed,
+    serverId: image.serverId,
+    serverName: image.serverName,
+    serverUrl: image.serverUrl,
+    steps: image.steps,
+    artPrompt: image.artPrompt,
+  }
+}
+
+function replacementData(
+  staged: ArtImage,
+  userId: number,
+  savePolicy: ReturnType<typeof readSavePolicy>,
+): Prisma.ArtImageUncheckedUpdateInput {
+  return {
+    imageData: staged.imageData,
+    fileName: staged.fileName,
+    fileType: staged.fileType,
+    cfg: staged.cfg,
+    cfgHalf: staged.cfgHalf,
+    checkpoint: staged.checkpoint,
+    checkpointResourceId: staged.checkpointResourceId,
+    designer: savePolicy.designer ?? staged.designer,
+    genres: staged.genres,
+    negativePrompt: staged.negativePrompt,
+    promptString: staged.promptString,
+    sampler: staged.sampler,
+    seed: staged.seed,
+    serverId: staged.serverId,
+    serverName: staged.serverName,
+    serverUrl: staged.serverUrl,
+    steps: staged.steps,
+    artPrompt: staged.artPrompt,
+    userId,
+    ...(typeof savePolicy.isPublic === 'boolean'
+      ? { isPublic: savePolicy.isPublic }
+      : {}),
+    ...(typeof savePolicy.isMature === 'boolean'
+      ? { isMature: savePolicy.isMature }
+      : {}),
+  }
+}
+
+function completedPayload(
+  payload: Prisma.JsonValue,
+  archivedArtImageId: number,
+): Prisma.InputJsonValue {
+  const next = JSON.parse(JSON.stringify(payload ?? {})) as JsonRecord
+  const retry = asRecord(next.retry)
+  next.retry = {
+    ...retry,
+    archivedArtImageId,
+    completedAt: new Date().toISOString(),
+  }
+  return next as Prisma.InputJsonValue
 }
 
 export default defineEventHandler(async (event) => {
@@ -58,11 +205,13 @@ export default defineEventHandler(async (event) => {
     }
 
     let updated
+    let archivedArtImageId: number | null = null
+    let replacedArtImageId: number | null = null
 
     if (body.success) {
-      const artImageId = Number(body.artImageId)
+      const uploadedArtImageId = Number(body.artImageId)
 
-      if (!Number.isInteger(artImageId) || artImageId <= 0) {
+      if (!Number.isInteger(uploadedArtImageId) || uploadedArtImageId <= 0) {
         throw createError({
           statusCode: 400,
           message:
@@ -70,39 +219,100 @@ export default defineEventHandler(async (event) => {
         })
       }
 
-      updated = await prisma.artJob.update({
-        where: { id },
-        data: { status: 'DONE', artImageId, error: null },
-      })
+      const retry = readRetry(job.payload)
+      const savePolicy = readSavePolicy(job.payload)
 
-      // Jobs enqueued on behalf of a browser user (e.g. kontext enqueue) carry
-      // a `save` block. The relay uploads as its own machine user, so apply
-      // ownership + visibility policy here, where admin auth already holds.
-      // Legacy jobs without `save` are untouched.
-      const payload = job.payload as { save?: unknown } | null
-      const save =
-        payload && typeof payload.save === 'object' && payload.save
-          ? (payload.save as {
-              isPublic?: unknown
-              isMature?: unknown
-              designer?: unknown
+      if (retry?.mode === 'OVERWRITE') {
+        const targetArtImageId = retry.targetArtImageId
+
+        if (!targetArtImageId) {
+          throw createError({
+            statusCode: 409,
+            message: 'Overwrite retry is missing targetArtImageId.',
+          })
+        }
+
+        if (targetArtImageId === uploadedArtImageId) {
+          throw createError({
+            statusCode: 409,
+            message: 'Overwrite upload must use a temporary ArtImage row.',
+          })
+        }
+
+        const result = await prisma.$transaction(async (tx) => {
+          const [target, staged] = await Promise.all([
+            tx.artImage.findUnique({ where: { id: targetArtImageId } }),
+            tx.artImage.findUnique({ where: { id: uploadedArtImageId } }),
+          ])
+
+          if (!target) {
+            throw createError({
+              statusCode: 409,
+              message: `Overwrite target ArtImage ${targetArtImageId} no longer exists.`,
             })
-          : null
+          }
 
-      if (save) {
+          if (!staged) {
+            throw createError({
+              statusCode: 409,
+              message: `Uploaded ArtImage ${uploadedArtImageId} no longer exists.`,
+            })
+          }
+
+          const archived = await tx.artImage.create({
+            data: snapshotData(target),
+          })
+
+          // ArtJobs are historical render records. Move every prior job that
+          // referenced the canonical id onto the archived snapshot before the
+          // canonical row is replaced, keeping trainer feedback tied to its
+          // original pixels.
+          await tx.artJob.updateMany({
+            where: {
+              artImageId: targetArtImageId,
+              id: { not: id },
+            },
+            data: { artImageId: archived.id },
+          })
+
+          await tx.artImage.update({
+            where: { id: targetArtImageId },
+            data: replacementData(staged, job.userId, savePolicy),
+          })
+
+          const completed = await tx.artJob.update({
+            where: { id },
+            data: {
+              status: 'DONE',
+              artImageId: targetArtImageId,
+              error: null,
+              payload: completedPayload(job.payload, archived.id),
+            },
+          })
+
+          await tx.artImage.delete({ where: { id: uploadedArtImageId } })
+
+          return { completed, archivedId: archived.id }
+        })
+
+        updated = result.completed
+        archivedArtImageId = result.archivedId
+        replacedArtImageId = targetArtImageId
+      } else {
+        updated = await prisma.artJob.update({
+          where: { id },
+          data: {
+            status: 'DONE',
+            artImageId: uploadedArtImageId,
+            error: null,
+          },
+        })
+
         await prisma.artImage.update({
-          where: { id: artImageId },
+          where: { id: uploadedArtImageId },
           data: {
             userId: job.userId,
-            ...(typeof save.isPublic === 'boolean'
-              ? { isPublic: save.isPublic }
-              : {}),
-            ...(typeof save.isMature === 'boolean'
-              ? { isMature: save.isMature }
-              : {}),
-            ...(typeof save.designer === 'string' && save.designer.trim()
-              ? { designer: save.designer.trim() }
-              : {}),
+            ...savePolicy,
           },
         })
       }
@@ -123,8 +333,15 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      message: `Job ${id} → ${updated.status}.`,
-      data: { job: updated },
+      message:
+        replacedArtImageId && archivedArtImageId
+          ? `Job ${id} replaced ArtImage ${replacedArtImageId}; prior render archived as ArtImage ${archivedArtImageId}.`
+          : `Job ${id} → ${updated.status}.`,
+      data: {
+        job: updated,
+        replacedArtImageId,
+        archivedArtImageId,
+      },
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -1,17 +1,109 @@
 // /server/api/art/queue/[id]/reenqueue.post.ts
 //
-// Admin action: re-run a job by cloning it into a fresh PENDING ArtJob. Unlike
-// requeue (which resets a stuck/failed job in place), this works on ANY job —
-// including DONE — and never touches the original record, so its history and
-// resulting ArtImage stay intact. Used by the dashboard's "Re-run" button to
-// regenerate from a finished job.
+// Admin action: re-run any ArtJob by cloning its generation spec into a fresh
+// PENDING job. Two explicit intents are supported:
 //
-// Admin/server credentials only.
-import { createError, defineEventHandler, getRouterParam } from 'h3'
+// - NEW_OUTPUT: keep the source ArtImage intact and create another ArtImage.
+// - OVERWRITE: render into a temporary ArtImage, then atomically replace the
+//   source ArtImage's pixels/metadata at completion while preserving its id and
+//   every Dream/Bot/Reward/etc. relation that points at it.
+//
+// Retry metadata lives in payload.retry so the relay remains generic and the UI
+// can explain ancestry. Curator/human feedback is deliberately not copied to the
+// fresh attempt, and concrete generation seeds are refreshed by default so a
+// Comfy retry does not reproduce the exact same pixels.
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+} from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
-import type { Prisma } from '~/prisma/generated/prisma/client'
+
+type RetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
+
+type ReenqueueBody = {
+  mode?: string | null
+  refreshSeed?: boolean
+}
+
+type JsonRecord = Record<string, unknown>
+
+const RETRY_MODES = new Set<RetryMode>(['NEW_OUTPUT', 'OVERWRITE'])
+const SEED_KEYS = new Set(['seed', 'noise_seed'])
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
+
+function nextSeed(): number {
+  return Math.floor(Math.random() * 1_000_000_000_000_000)
+}
+
+function refreshConcreteSeeds(value: unknown, key = ''): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => refreshConcreteSeeds(item))
+  }
+
+  if (!value || typeof value !== 'object') {
+    if (SEED_KEYS.has(key)) {
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+        return nextSeed()
+      }
+      if (
+        typeof value === 'string' &&
+        value.trim() &&
+        Number.isFinite(Number(value)) &&
+        Number(value) >= 0
+      ) {
+        return String(nextSeed())
+      }
+    }
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as JsonRecord).map(([childKey, child]) => [
+      childKey,
+      refreshConcreteSeeds(child, childKey),
+    ]),
+  )
+}
+
+function preparePayload(
+  rawPayload: Prisma.JsonValue,
+  sourceJobId: number,
+  sourceArtImageId: number | null,
+  mode: RetryMode,
+  refreshSeed: boolean,
+): Prisma.InputJsonValue {
+  const cloned = JSON.parse(JSON.stringify(rawPayload ?? {})) as JsonRecord
+  const previousRetry = asRecord(cloned.retry)
+  const rootJobId = Number(previousRetry.rootJobId) || sourceJobId
+
+  // A new render has not been curated yet. Keeping old feedback here would make
+  // the trainer believe the replacement pixels had already been reviewed.
+  delete cloned.curation
+
+  const generationPayload = refreshSeed
+    ? (refreshConcreteSeeds(cloned) as JsonRecord)
+    : cloned
+
+  generationPayload.retry = {
+    mode,
+    sourceJobId,
+    rootJobId,
+    targetArtImageId: mode === 'OVERWRITE' ? sourceArtImageId : null,
+    refreshSeed,
+    requestedAt: new Date().toISOString(),
+  }
+
+  return generationPayload as Prisma.InputJsonValue
+}
 
 export default defineEventHandler(async (event) => {
   try {
@@ -30,18 +122,57 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Invalid job id.' })
     }
 
+    const body = (await readBody(event).catch(() => null)) as ReenqueueBody | null
+    const mode = String(body?.mode || 'NEW_OUTPUT').toUpperCase() as RetryMode
+    const refreshSeed = body?.refreshSeed !== false
+
+    if (!RETRY_MODES.has(mode)) {
+      throw createError({
+        statusCode: 400,
+        message: 'mode must be NEW_OUTPUT or OVERWRITE.',
+      })
+    }
+
     const source = await prisma.artJob.findUnique({ where: { id } })
 
     if (!source) {
       throw createError({ statusCode: 404, message: `Job ${id} not found.` })
     }
 
-    // Clone the generation spec into a brand-new PENDING job. Preserve the
-    // original owner/project so the regenerated ArtImage lands the same way.
+    if (mode === 'OVERWRITE') {
+      if (source.status !== 'DONE' || !source.artImageId) {
+        throw createError({
+          statusCode: 409,
+          message:
+            'Overwrite retries require a completed source job with an ArtImage.',
+        })
+      }
+
+      const target = await prisma.artImage.findUnique({
+        where: { id: source.artImageId },
+        select: { id: true },
+      })
+
+      if (!target) {
+        throw createError({
+          statusCode: 409,
+          message: `ArtImage ${source.artImageId} no longer exists.`,
+        })
+      }
+    }
+
+    const payload = preparePayload(
+      source.payload,
+      source.id,
+      source.artImageId,
+      mode,
+      refreshSeed,
+    )
+
     const job = await prisma.artJob.create({
       data: {
         engine: source.engine,
-        payload: source.payload as Prisma.InputJsonValue,
+        payload,
         priority: source.priority,
         projectSlug: source.projectSlug,
         projectId: source.projectId,
@@ -53,8 +184,16 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      message: `Re-enqueued job ${id} as new job ${job.id}.`,
-      data: { job, sourceJobId: id },
+      message:
+        mode === 'OVERWRITE'
+          ? `Queued job ${job.id} to replace ArtImage ${source.artImageId}.`
+          : `Re-enqueued job ${id} as new-output job ${job.id}.`,
+      data: {
+        job,
+        sourceJobId: id,
+        mode,
+        targetArtImageId: mode === 'OVERWRITE' ? source.artImageId : null,
+      },
       statusCode: 201,
     }
   } catch (error: unknown) {

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -15,6 +15,7 @@ export type ArtJobStatus =
   | 'FAILED'
   | 'CANCELLED'
 
+export type ArtJobRetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
 export type ArtFeedbackSource = 'CURATOR' | 'HUMAN'
 export type ArtFeedbackVerdict = 'PROMOTE' | 'REVISE' | 'REJECT'
 
@@ -36,8 +37,20 @@ export type ArtJobCuration = Prisma.JsonObject & {
   history?: ArtJobFeedback[]
 }
 
+export type ArtJobRetry = Prisma.JsonObject & {
+  mode?: ArtJobRetryMode
+  sourceJobId?: number | null
+  rootJobId?: number | null
+  targetArtImageId?: number | null
+  archivedArtImageId?: number | null
+  refreshSeed?: boolean
+  requestedAt?: string
+  completedAt?: string
+}
+
 export type ArtJobPayload = Prisma.JsonObject & {
   curation?: ArtJobCuration
+  retry?: ArtJobRetry
 }
 
 export type ArtJobRecord = Omit<ArtJob, 'payload'> & {
@@ -114,6 +127,7 @@ type ArtJobState = {
   loadingUptime: boolean
   loadingJobs: boolean
   loadingTrainerJobs: boolean
+  retryingJobIds: number[]
   error: string | null
   windowHours: number
 }
@@ -132,6 +146,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     loadingUptime: false,
     loadingJobs: false,
     loadingTrainerJobs: false,
+    retryingJobIds: [],
     error: null,
     windowHours: 24,
   })
@@ -309,17 +324,43 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     return false
   }
 
-  async function reenqueueJob(id: number): Promise<number | null> {
-    const res = await performFetch<{ job: ArtJobRecord }>(
-      `/api/art/queue/${id}/reenqueue`,
-      { method: 'POST', body: JSON.stringify({}) },
-    )
-    if (res.success && res.data?.job) {
-      await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
-      return res.data.job.id
+  async function reenqueueJob(
+    id: number,
+    mode: ArtJobRetryMode = 'NEW_OUTPUT',
+  ): Promise<number | null> {
+    if (state.retryingJobIds.includes(id)) return null
+    state.retryingJobIds = [...state.retryingJobIds, id]
+
+    try {
+      const res = await performFetch<{
+        job: ArtJobRecord
+        mode: ArtJobRetryMode
+        targetArtImageId: number | null
+      }>(`/api/art/queue/${id}/reenqueue`, {
+        method: 'POST',
+        body: JSON.stringify({ mode, refreshSeed: true }),
+      })
+
+      if (res.success && res.data?.job) {
+        if (
+          mode === 'OVERWRITE' &&
+          typeof res.data.targetArtImageId === 'number'
+        ) {
+          // The canonical id stays stable, so explicitly evict the old data URL;
+          // otherwise loadJobImages correctly assumes it is already hydrated.
+          delete state.imageSrcById[res.data.targetArtImageId]
+        }
+        await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+        return res.data.job.id
+      }
+
+      state.error = res.message || `Failed to re-enqueue job ${id}.`
+      return null
+    } finally {
+      state.retryingJobIds = state.retryingJobIds.filter(
+        (jobId) => jobId !== id,
+      )
     }
-    state.error = res.message || `Failed to re-enqueue job ${id}.`
-    return null
   }
 
   async function refreshAll(): Promise<void> {

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -183,6 +183,25 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     }
   }
 
+  function completedOverwriteIds(jobs: ArtJobRecord[]): number[] {
+    const ids = jobs
+      .filter((job) => {
+        return (
+          job.status === 'DONE' &&
+          job.payload?.retry?.mode === 'OVERWRITE' &&
+          typeof job.artImageId === 'number'
+        )
+      })
+      .map((job) => job.artImageId as number)
+      .filter((id, index, all) => all.indexOf(id) === index)
+
+    // Stable ids are the point of overwrite, but that means an existing data URL
+    // is no longer proof that the current bytes are hydrated. Force these ids to
+    // reload whenever a completed overwrite is observed.
+    for (const id of ids) delete state.imageSrcById[id]
+    return ids
+  }
+
   async function fetchJobs(
     status: ArtJobStatus | 'ALL' = state.jobStatusFilter,
   ): Promise<void> {
@@ -194,8 +213,9 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         `/api/art/queue${query}${status === 'ALL' ? '?' : '&'}limit=100`,
       )
       if (res.success && res.data) {
+        const forceImageIds = completedOverwriteIds(res.data.jobs)
         state.jobs = res.data.jobs
-        void loadJobImages()
+        void loadJobImages(forceImageIds)
       } else if (!res.success) {
         state.error = res.message || 'Failed to load jobs.'
       }
@@ -211,10 +231,11 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         '/api/art/queue?status=DONE&limit=200',
       )
       if (res.success && res.data) {
+        const forceImageIds = completedOverwriteIds(res.data.jobs)
         state.trainerJobs = res.data.jobs.filter((job) => {
           return Boolean(job.payload?.curation?.curator)
         })
-        void loadJobImages()
+        void loadJobImages(forceImageIds)
       } else if (!res.success) {
         state.error = res.message || 'Failed to load curated jobs.'
       }
@@ -240,14 +261,17 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     return ''
   }
 
-  async function loadJobImages(): Promise<void> {
-    const ids = [...state.jobs, ...state.trainerJobs]
-      .filter((job) => {
-        return job.status === 'DONE' && typeof job.artImageId === 'number'
-      })
-      .map((job) => job.artImageId as number)
+  async function loadJobImages(forceIds: number[] = []): Promise<void> {
+    const ids = [
+      ...forceIds,
+      ...[...state.jobs, ...state.trainerJobs]
+        .filter((job) => {
+          return job.status === 'DONE' && typeof job.artImageId === 'number'
+        })
+        .map((job) => job.artImageId as number),
+    ]
       .filter((id, index, all) => all.indexOf(id) === index)
-      .filter((id) => !(id in state.imageSrcById))
+      .filter((id) => forceIds.includes(id) || !(id in state.imageSrcById))
       .slice(0, MAX_JOB_IMAGES)
 
     if (!ids.length) return
@@ -342,14 +366,6 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       })
 
       if (res.success && res.data?.job) {
-        if (
-          mode === 'OVERWRITE' &&
-          typeof res.data.targetArtImageId === 'number'
-        ) {
-          // The canonical id stays stable, so explicitly evict the old data URL;
-          // otherwise loadJobImages correctly assumes it is already hydrated.
-          delete state.imageSrcById[res.data.targetArtImageId]
-        }
         await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
         return res.data.job.id
       }


### PR DESCRIPTION
## What changed

- Replaced the ambiguous finished-job **Re-run** action with an explicit **Try again** menu:
  - **Make a new output** creates a separate ArtImage.
  - **Replace ArtImage #…** keeps the canonical ArtImage id and all Dream/Bot/Reward/etc. links.
- Added an overwrite confirmation explaining stable references and archived history.
- Retry jobs carry structured ancestry in `payload.retry` (`mode`, source/root job ids, target ArtImage id, timestamps, refreshed-seed flag).
- Concrete `seed` / `noise_seed` values are refreshed by default, including seeds nested inside Comfy workflows, so retrying actually produces a fresh attempt.
- Curator/human feedback is removed from the fresh retry payload rather than incorrectly applying the prior verdict to new pixels.
- Overwrite completion is transactional:
  1. snapshot the current canonical ArtImage into a detached historical ArtImage,
  2. repoint prior ArtJobs to that snapshot so prompts and trainer feedback remain tied to the old pixels,
  3. copy the new render into the canonical ArtImage row,
  4. complete the retry job against the canonical id,
  5. delete the temporary uploaded ArtImage.
- Completed overwrite ids are force-refetched so the browser cannot keep displaying stale base64 data under the stable ArtImage id.
- Existing **Requeue** semantics are clarified in the UI as **Resume job** for failed/stale in-place jobs; it remains distinct from creating a new attempt.

## Why

A retry can mean either “show me another candidate” or “fix the asset already linked throughout the site.” Those intents need different identity behavior. Keeping overwrite transactional preserves stable content links without corrupting ArtJob/trainer history.

## Data model

No schema migration is required. Retry ancestry and archived-output ids use the existing ArtJob JSON payload, while prior pixels are preserved as ordinary detached ArtImage rows.

## Relay integration

Paired with `silasfelinus/conductor#501`, which uses the final canonical ArtImage id returned by completion for local-copy naming and logs after overwrite retries.

## Validation

- **GitHub TypeScript Type Check passed.**
- **GitHub Contract Tests passed.**
- Paired Conductor **Worker PR CI passed.**
- Paired Conductor **Security Audit passed.**
- Vercel preview did not run because the account hit its build-rate limit; the status points to the rate-limit upgrade page rather than a code/build diagnostic.