### PR TITLE
Give the video generator its own Art dashboard tab

### DIFF
--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -170,6 +170,19 @@ export const dashboardConfigs = {
         route: '/coat-dance',
       },
       {
+        key: 'video',
+        label: 'Video',
+        icon: 'kind-icon:video',
+        title: 'Video Generator',
+        summary: 'Animate a still into a short looping clip with LTX or WAN.',
+        image: tabImage('art', 'video'),
+        flourish: '✨',
+        tagline: 'Turn a single frame into motion.',
+        narrative:
+          'Feed in a still (start with Use logo), add a motion prompt, pick LTX or WAN, set the seconds and fps, and queue an image-to-video job on the art box. The finished clip loops right on the page — perfect for launch gifs and endless randomized variants.',
+        route: '/video-generator',
+      },
+      {
         key: 'artjob',
         label: 'ArtJob',
         icon: 'kind-icon:server',


### PR DESCRIPTION
## What

Adds a **Video** tab to the Art dashboard (`stores/helpers/dashboardHelper.ts`) routing to `/video-generator`, so the video generator is clickable from the nav instead of only reachable by typing the URL.

Placed next to **Coat Dance** (the other video tool) and before the admin-only **ArtJob** tab. Uses `kind-icon:video` (verified present in `assets/icons/video.svg`).

## Why

The video-generator page shipped in #213 with **no nav entry at all** — no `definePageMeta`, not referenced by any dashboard/nav helper — so it was orphaned behind a hand-typed URL. This wires it in the same way the other standalone-route art tools (Hair Studio → `/stylist`, Coat Dance → `/coat-dance`, ArtJob → `/artjob`) are.

## Floating-page audit (while I was in here)

Silas asked if anything else is "available but not in the system." Findings:

- **`pages/image-editor.vue`** — a real 86-line "Image Editor" feature with **zero references anywhere** in the app. Genuinely floating, reachable only via `/image-editor`. Not touched here; flagging it. Happy to give it a tab too (Art dashboard) if you want it surfaced, or retire it if it's abandonware.
- Everything else checks out: the other ~58 routes are Nuxt Content pages served through the `[...slug]` catch-all and are linked from menus/dashboards. My first-pass diff flagged a few (forum, sheets, chats, achievements…) but on closer look they all have real links elsewhere — not floating.

## Verification

- `npm test` (nuxi prepare + vue-tsc `--noEmit`) — passes clean.
- ESLint + Prettier — clean.
- Tab image `dashboard-tabs/art/video.webp` isn't created yet, so the tab card art will be a placeholder until that asset lands (same follow-up bucket #212 tracks for other tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FBAnTBhEfFpbpKnaLirsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018FBAnTBhEfFpbpKnaLirsZ)_