### PR TITLE
ArtJob trainer: request curation from the front end + curator verdict badges

### DIFF
--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -208,12 +208,30 @@
 
       <div
         v-else
-        class="flex min-h-56 items-center justify-center rounded-2xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+        class="flex min-h-56 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
       >
         <span v-if="artJobStore.loadingTrainerJobs">Loading curated jobs…</span>
-        <span v-else-if="reviewMode === 'pending'">
-          Nothing is waiting for feedback. Tiny victory parade. 🎉
-        </span>
+        <template v-else-if="reviewMode === 'pending'">
+          <span>
+            Nothing is waiting for feedback. Ask Conductor to curate the day's
+            finished art and it'll show up here.
+          </span>
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm rounded-2xl"
+            :disabled="requestingCuration"
+            @click="requestCuration"
+          >
+            <span
+              v-if="requestingCuration"
+              class="loading loading-spinner loading-xs"
+            />
+            Request Conductor curation
+          </button>
+          <span v-if="curationNote" class="text-xs text-base-content/60">
+            {{ curationNote }}
+          </span>
+        </template>
         <span v-else>No curated jobs match this filter.</span>
       </div>
     </div>
@@ -234,6 +252,8 @@ type ReviewMode = 'pending' | 'reviewed' | 'all'
 const artJobStore = useArtJobStore()
 const reviewMode = ref<ReviewMode>('pending')
 const savingIds = ref<number[]>([])
+const requestingCuration = ref(false)
+const curationNote = ref('')
 const notesByJob = reactive<Record<number, string>>({})
 const tagsByJob = reactive<Record<number, string[]>>({})
 
@@ -366,6 +386,28 @@ async function saveFeedback(
     })
   } finally {
     savingIds.value = savingIds.value.filter((id) => id !== job.id)
+  }
+}
+
+async function requestCuration(): Promise<void> {
+  if (requestingCuration.value) return
+  requestingCuration.value = true
+  curationNote.value = ''
+  try {
+    const result = await artJobStore.requestWindowCuration()
+    if (!result) {
+      curationNote.value =
+        'No finished art in this window to curate yet — generate some first.'
+      return
+    }
+    const queued = result.requested.length + result.alreadyQueued.length
+    curationNote.value = result.requested.length
+      ? `Queued ${result.requested.length} job(s) for Conductor. Verdicts appear here after the next sweep.`
+      : queued
+        ? 'Already queued — waiting on Conductor to curate.'
+        : 'No eligible finished jobs to curate in this window.'
+  } finally {
+    requestingCuration.value = false
   }
 }
 </script>

--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -261,6 +261,24 @@
                         : 'new attempt'
                     }}
                   </span>
+                  <span
+                    v-if="curatorVerdict(job)"
+                    class="badge badge-xs rounded-2xl"
+                    :class="curatorBadgeClass(job)"
+                    :title="`Conductor curated this job${
+                      curatorScore(job) !== null
+                        ? ` — ${curatorScore(job)}/100`
+                        : ''
+                    }`"
+                  >
+                    curator: {{ curatorVerdict(job)?.toLowerCase() }}
+                    <span
+                      v-if="curatorScore(job) !== null"
+                      class="ml-1 font-mono opacity-80"
+                    >
+                      {{ curatorScore(job) }}
+                    </span>
+                  </span>
                 </div>
 
                 <p
@@ -1026,6 +1044,30 @@ function canCurate(job: ArtJob): boolean {
 
 function hasCuratorVerdict(job: ArtJob): boolean {
   return Boolean(asRecord(payloadRecord(job).curation).curator)
+}
+
+// Conductor's curator verdict/score, once it has scored a finished job — surfaced
+// on the queue card so the queue and the trainer panel agree at a glance.
+function curatorFeedback(job: ArtJob): JsonRecord | null {
+  return asRecord(asRecord(payloadRecord(job).curation).curator)
+}
+
+function curatorVerdict(job: ArtJob): string {
+  const verdict = curatorFeedback(job)?.verdict
+  return typeof verdict === 'string' ? verdict.toUpperCase() : ''
+}
+
+function curatorScore(job: ArtJob): number | null {
+  const score = curatorFeedback(job)?.score
+  return typeof score === 'number' ? score : null
+}
+
+function curatorBadgeClass(job: ArtJob): string {
+  const verdict = curatorVerdict(job)
+  if (verdict === 'PROMOTE') return 'badge-success'
+  if (verdict === 'REVISE') return 'badge-warning'
+  if (verdict === 'REJECT') return 'badge-error'
+  return 'badge-ghost'
 }
 
 function curationRequested(job: ArtJob): boolean {

--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -164,6 +164,20 @@
             <span class="text-[11px] text-base-content/50">
               {{ stats?.imagesCreatedInWindow ?? 0 }} imgs / {{ windowHours }}h
             </span>
+            <button
+              v-if="uncuratedJobs.length"
+              type="button"
+              class="btn btn-secondary btn-xs rounded-2xl"
+              :disabled="bulkCurating"
+              :title="`Ask Conductor to curate ${uncuratedJobs.length} finished job(s) shown here`"
+              @click="requestBulkCuration"
+            >
+              <span
+                v-if="bulkCurating"
+                class="loading loading-spinner loading-xs"
+              />
+              Curate finished ({{ uncuratedJobs.length }})
+            </button>
           </div>
           <div class="flex flex-wrap gap-1">
             <button
@@ -493,6 +507,25 @@
                     </li>
                   </ul>
                 </details>
+                <button
+                  v-if="canCurate(job)"
+                  type="button"
+                  class="btn btn-ghost btn-xs rounded-2xl"
+                  :class="curationRequested(job) ? 'text-success' : ''"
+                  :disabled="isRequestingCuration(job.id) || curationRequested(job)"
+                  :title="
+                    curationRequested(job)
+                      ? 'Conductor has this job queued for curation'
+                      : 'Ask Conductor to score this finished render and add a curator verdict'
+                  "
+                  @click="requestCuration(job)"
+                >
+                  <span
+                    v-if="isRequestingCuration(job.id)"
+                    class="loading loading-spinner loading-xs"
+                  />
+                  {{ curationRequested(job) ? 'Curation requested' : 'Request curation' }}
+                </button>
                 <button
                   v-if="job.status !== 'DONE'"
                   type="button"
@@ -983,6 +1016,52 @@ function isRetrying(jobId: number): boolean {
 
 async function retryJob(job: ArtJob, mode: ArtJobRetryMode): Promise<void> {
   await artJobStore.reenqueueJob(job.id, mode)
+}
+
+// Only finished jobs with a generated ArtImage can be curated (the curator scores
+// the rendered pixels) — same gate the feedback endpoint enforces.
+function canCurate(job: ArtJob): boolean {
+  return job.status === 'DONE' && typeof job.artImageId === 'number'
+}
+
+function hasCuratorVerdict(job: ArtJob): boolean {
+  return Boolean(asRecord(payloadRecord(job).curation).curator)
+}
+
+function curationRequested(job: ArtJob): boolean {
+  return (
+    hasCuratorVerdict(job) ||
+    artJobStore.curationRequestedIds.includes(job.id)
+  )
+}
+
+function isRequestingCuration(jobId: number): boolean {
+  return artJobStore.curationRequestingIds.includes(jobId)
+}
+
+// Curatable jobs currently loaded that Conductor has not already curated or been
+// asked to curate — the bulk button's target set.
+const uncuratedJobs = computed(() =>
+  artJobStore.jobs.filter(
+    (job) => canCurate(job) && !curationRequested(job),
+  ),
+)
+
+const bulkCurating = ref(false)
+
+async function requestCuration(job: ArtJob): Promise<void> {
+  await artJobStore.requestCuration(job.id)
+}
+
+async function requestBulkCuration(): Promise<void> {
+  const ids = uncuratedJobs.value.map((job) => job.id)
+  if (!ids.length) return
+  bulkCurating.value = true
+  try {
+    await artJobStore.requestCuration(ids)
+  } finally {
+    bulkCurating.value = false
+  }
 }
 
 function askToOverwrite(job: ArtJob): void {

--- a/server/api/conductor/curate-request.post.ts
+++ b/server/api/conductor/curate-request.post.ts
@@ -1,0 +1,204 @@
+// /server/api/conductor/curate-request.post.ts
+//
+// Front-end → Conductor bridge for the ArtJob "Art trainer" panel. An admin picks
+// finished ArtJob(s) in the queue and asks Conductor to curate them; this appends a
+// request to conductor's projects/curation/requests.yaml (via the shared GitHub
+// helpers). The conductor sweep (scripts/curate_art.py --requests) drains that file:
+// it runs the vision assessor on each ArtImage and POSTs source=CURATOR feedback back
+// to POST /api/art/queue/<job_id>/feedback, which fills the trainer panel.
+//
+// Mirrors the auth + GitHub-write pattern of api/conductor/art-request.post.ts.
+import { defineEventHandler, readBody, createError } from 'h3'
+import type { ArtJob } from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { userIsAdmin } from '@/server/utils/authUser'
+import { validateApiKey } from '@/server/utils/validateKey'
+import { conductorGet, conductorPut } from '@/server/utils/conductor-github'
+import {
+  type CurationRequestEntry,
+  appendCurationRequest,
+  CURATION_REQUESTS_SEED,
+} from '@/server/utils/curationRequestYaml'
+
+const REQUESTS_PATH = 'projects/curation/requests.yaml'
+const REQUEST_SOURCE = 'kind-robots-artjob-trainer'
+
+type CurateRequestBody = {
+  jobId?: number | string
+  jobIds?: Array<number | string>
+  window?: number | string
+  note?: string
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function toPositiveInt(value: unknown): number | null {
+  const num = Number(value)
+  return Number.isInteger(num) && num > 0 ? num : null
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+// Same prompt precedence the trainer/queue components use, so the queued request
+// carries a human-readable brief for Conductor's curation log.
+function jobPrompt(job: ArtJob): string {
+  const payload = asRecord(job.payload)
+  for (const key of ['promptString', 'artPrompt', 'positivePrompt', 'prompt']) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function hasCuratorVerdict(job: ArtJob): boolean {
+  const curation = asRecord(asRecord(job.payload).curation)
+  return Boolean(curation.curator)
+}
+
+async function resolveJobIds(body: CurateRequestBody): Promise<number[]> {
+  const explicit = new Set<number>()
+  const single = toPositiveInt(body.jobId)
+  if (single) explicit.add(single)
+  if (Array.isArray(body.jobIds)) {
+    for (const raw of body.jobIds) {
+      const id = toPositiveInt(raw)
+      if (id) explicit.add(id)
+    }
+  }
+  if (explicit.size) return [...explicit]
+
+  // Window fallback: every DONE job with an ArtImage finished within N hours that
+  // Conductor has not already curated.
+  const windowHours = toPositiveInt(body.window)
+  if (windowHours) {
+    const since = new Date(Date.now() - windowHours * 3600 * 1000)
+    const jobs = await prisma.artJob.findMany({
+      where: {
+        status: 'DONE',
+        artImageId: { not: null },
+        updatedAt: { gte: since },
+      },
+      orderBy: { id: 'desc' },
+      take: 200,
+    })
+    return jobs.filter((job) => !hasCuratorVerdict(job)).map((job) => job.id)
+  }
+
+  return []
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const { isValid, user } = await validateApiKey(event)
+    if (!isValid || !user) {
+      throw createError({ statusCode: 401, message: 'Invalid or expired token.' })
+    }
+    if (!userIsAdmin(user)) {
+      throw createError({ statusCode: 403, message: 'Admin access required.' })
+    }
+
+    const body = await readBody<CurateRequestBody>(event).catch(
+      () => ({}) as CurateRequestBody,
+    )
+    const note = cleanString(body.note).slice(0, 2000)
+
+    const jobIds = await resolveJobIds(body)
+    if (!jobIds.length) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Provide a jobId, a jobIds array, or a window (hours) of finished jobs to curate.',
+      })
+    }
+
+    const jobs = await prisma.artJob.findMany({
+      where: { id: { in: jobIds } },
+    })
+    const foundIds = new Set(jobs.map((job) => job.id))
+    const missing = jobIds.filter((id) => !foundIds.has(id))
+
+    // Only DONE jobs with an ArtImage can be curated (same gate as feedback.post.ts).
+    const eligible = jobs.filter(
+      (job) => job.status === 'DONE' && typeof job.artImageId === 'number',
+    )
+    const ineligible = jobs
+      .filter((job) => !eligible.includes(job))
+      .map((job) => job.id)
+
+    if (!eligible.length) {
+      throw createError({
+        statusCode: 409,
+        message:
+          'No eligible jobs: curation needs completed jobs (status DONE) with a generated ArtImage.',
+      })
+    }
+
+    const requestedAt = new Date().toISOString()
+    const entries: CurationRequestEntry[] = eligible.map((job) => ({
+      id: `curate-${job.id}`,
+      source: REQUEST_SOURCE,
+      status: 'pending',
+      job_id: job.id,
+      art_image_id: job.artImageId as number,
+      project_slug: cleanString(job.projectSlug),
+      prompt: jobPrompt(job),
+      note,
+      requested_at: requestedAt,
+    }))
+
+    // Load the queue once, append every new entry, write one commit. A missing file
+    // is created from the documented seed.
+    const existing = await conductorGet(REQUESTS_PATH)
+    const before = existing?.content ?? CURATION_REQUESTS_SEED
+    let next = before
+    const created: number[] = []
+    for (const entry of entries) {
+      const merged = appendCurationRequest(next, entry)
+      if (merged !== next) {
+        created.push(entry.job_id)
+        next = merged
+      }
+    }
+
+    if (next !== before || !existing) {
+      const message = created.length
+        ? `curation: request ${created.map((id) => `job ${id}`).join(', ')}`
+        : `curation: initialize ${REQUESTS_PATH}`
+      await conductorPut(REQUESTS_PATH, next, message, existing?.sha)
+    }
+
+    const alreadyQueued = eligible
+      .map((job) => job.id)
+      .filter((id) => !created.includes(id))
+
+    event.node.res.statusCode = created.length ? 201 : 200
+    return {
+      success: true,
+      message: created.length
+        ? `Queued ${created.length} job(s) for Conductor curation.`
+        : 'All selected jobs were already queued for curation.',
+      data: {
+        requested: created,
+        alreadyQueued,
+        ineligible,
+        missing,
+      },
+      statusCode: created.length ? 201 : 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to create Conductor curation request.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/curationRequestYaml.ts
+++ b/server/utils/curationRequestYaml.ts
@@ -1,0 +1,108 @@
+// /server/utils/curationRequestYaml.ts
+//
+// Pure, dependency-free rendering of Conductor art-curation requests into the
+// block-sequence YAML style that conductor's projects/curation/requests.yaml uses.
+//
+// Extracted from api/conductor/curate-request.post.ts (mirroring artRequestYaml.ts)
+// so the indentation contract can be reasoned about without pulling in h3, prisma,
+// or the rest of the Nuxt server runtime.
+//
+// THE CONTRACT: every request is a block-sequence item whose `- ` marker sits at
+// COLUMN 0 and whose continuation keys are indented exactly 2 spaces. conductor's
+// PyYAML parser (scripts/curate_art.py --requests) rejects mixed indentation, so
+// this is the same silent-stall guard artRequestYaml.ts protects against.
+
+export type CurationRequestEntry = {
+  id: string
+  source: string
+  status: 'pending'
+  job_id: number
+  art_image_id: number
+  project_slug: string
+  prompt: string
+  note: string
+  requested_at: string
+}
+
+function yamlQuoted(value: string): string {
+  return JSON.stringify(value)
+}
+
+function yamlFolded(key: string, value: string, indent = '    '): string {
+  const clean = value.replace(/\r/g, '').replace(/\n+/g, ' ').trim()
+  if (!clean) return `${key}: ""`
+  return `${key}: >\n${indent}${clean}`
+}
+
+// Entries sit at column 0 to match the `requests:` block-sequence style; mixed
+// indentation breaks conductor's parser.
+export function renderCurationEntry(entry: CurationRequestEntry): string {
+  const lines = [
+    `- id: ${yamlQuoted(entry.id)}`,
+    `  source: ${yamlQuoted(entry.source)}`,
+    `  status: ${yamlQuoted(entry.status)}`,
+    `  job_id: ${entry.job_id}`,
+    `  art_image_id: ${entry.art_image_id}`,
+  ]
+
+  if (entry.project_slug) {
+    lines.push(`  project_slug: ${yamlQuoted(entry.project_slug)}`)
+  }
+  if (entry.note) lines.push(`  note: ${yamlQuoted(entry.note)}`)
+  lines.push(`  requested_at: ${yamlQuoted(entry.requested_at)}`)
+  lines.push(`  ${yamlFolded('prompt', entry.prompt, '    ')}`)
+
+  return lines.join('\n')
+}
+
+// A request is "already queued" if the same job_id (the dedupe key) is present as
+// a pending or in-flight entry. A `done`/`error` line still counts as queued so we
+// don't re-request a job Conductor has already curated in this file's history;
+// re-curation is an explicit re-run on the conductor side, not a duplicate append.
+export function curationAlreadyQueued(
+  content: string,
+  entry: CurationRequestEntry,
+): boolean {
+  const idHit = new RegExp(`\\bid:\\s*"?${escapeRegExp(entry.id)}"?`).test(
+    content,
+  )
+  const jobHit = new RegExp(`\\bjob_id:\\s*${entry.job_id}\\b`).test(content)
+  return idHit || jobHit
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function appendCurationRequest(
+  content: string,
+  entry: CurationRequestEntry,
+): string {
+  if (curationAlreadyQueued(content, entry)) return content
+
+  const serialized = renderCurationEntry(entry)
+  const trimmed = content.trimEnd()
+
+  if (/^requests:\s*\[\]\s*$/m.test(trimmed)) {
+    return `${trimmed.replace(
+      /^requests:\s*\[\]\s*$/m,
+      `requests:\n${serialized}`,
+    )}\n`
+  }
+
+  if (/^requests:\s*$/m.test(trimmed)) {
+    return `${trimmed}\n${serialized}\n`
+  }
+
+  return `${trimmed}\n\nrequests:\n${serialized}\n`
+}
+
+// Seed body written when the queue file does not yet exist in conductor.
+export const CURATION_REQUESTS_SEED = `# projects/curation/requests.yaml
+#
+# Front-end-submitted art-curation requests (kind_robots ArtJob trainer →
+# Conductor). scripts/curate_art.py --requests drains this: for each pending
+# entry it runs the vision assessor on the ArtImage and POSTs source=CURATOR
+# feedback to POST /api/art/queue/<job_id>/feedback, then flips the entry to done.
+requests: []
+`

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -67,6 +67,13 @@ export type SubmitArtFeedbackInput = {
   rubricKey?: string | null
 }
 
+export type CurateRequestResult = {
+  requested: number[]
+  alreadyQueued: number[]
+  ineligible: number[]
+  missing: number[]
+}
+
 export type QueueStats = {
   windowHours: number
   since: string
@@ -128,6 +135,11 @@ type ArtJobState = {
   loadingJobs: boolean
   loadingTrainerJobs: boolean
   retryingJobIds: number[]
+  // Jobs with a curate-request POST in flight, and jobs a request has been queued
+  // for this session (so the UI can show "Curation requested" before Conductor's
+  // verdict lands in payload.curation.curator).
+  curationRequestingIds: number[]
+  curationRequestedIds: number[]
   error: string | null
   windowHours: number
 }
@@ -147,6 +159,8 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     loadingJobs: false,
     loadingTrainerJobs: false,
     retryingJobIds: [],
+    curationRequestingIds: [],
+    curationRequestedIds: [],
     error: null,
     windowHours: 24,
   })
@@ -322,6 +336,71 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     return false
   }
 
+  // Ask Conductor to curate finished ArtJob(s). Accepts one id or a batch; the
+  // bridge (POST /api/conductor/curate-request) queues them in conductor's
+  // projects/curation/requests.yaml. Conductor's sweep then POSTs source=CURATOR
+  // feedback back, which surfaces in the trainer panel.
+  async function requestCuration(
+    jobIds: number | number[],
+    note?: string,
+  ): Promise<CurateRequestResult | null> {
+    const ids = (Array.isArray(jobIds) ? jobIds : [jobIds]).filter(
+      (id): id is number => Number.isInteger(id) && id > 0,
+    )
+    if (!ids.length) return null
+
+    const inFlight = ids.filter((id) => !state.curationRequestingIds.includes(id))
+    if (!inFlight.length) return null
+    state.curationRequestingIds = [...state.curationRequestingIds, ...inFlight]
+
+    try {
+      const payload =
+        inFlight.length === 1
+          ? { jobId: inFlight[0], note }
+          : { jobIds: inFlight, note }
+      const res = await performFetch<CurateRequestResult>(
+        '/api/conductor/curate-request',
+        { method: 'POST', body: JSON.stringify(payload) },
+      )
+
+      if (res.success && res.data) {
+        const queued = [...res.data.requested, ...res.data.alreadyQueued]
+        const merged = new Set([...state.curationRequestedIds, ...queued])
+        state.curationRequestedIds = [...merged]
+        return res.data
+      }
+
+      state.error = res.message || 'Failed to request curation.'
+      return null
+    } finally {
+      state.curationRequestingIds = state.curationRequestingIds.filter(
+        (id) => !inFlight.includes(id),
+      )
+    }
+  }
+
+  // Trainer empty-state CTA: ask Conductor to curate every uncurated finished job
+  // in the current window (the bridge selects them server-side). Returns how many
+  // were newly queued.
+  async function requestWindowCuration(
+    windowHours: number = state.windowHours,
+    note?: string,
+  ): Promise<CurateRequestResult | null> {
+    const res = await performFetch<CurateRequestResult>(
+      '/api/conductor/curate-request',
+      { method: 'POST', body: JSON.stringify({ window: windowHours, note }) },
+    )
+    if (res.success && res.data) {
+      const queued = [...res.data.requested, ...res.data.alreadyQueued]
+      state.curationRequestedIds = [
+        ...new Set([...state.curationRequestedIds, ...queued]),
+      ]
+      return res.data
+    }
+    state.error = res.message || 'Failed to request curation.'
+    return null
+  }
+
   async function requeueJob(id: number): Promise<boolean> {
     const res = await performFetch(`/api/art/queue/${id}/requeue`, {
       method: 'POST',
@@ -400,6 +479,8 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     fetchJobs,
     fetchTrainerJobs,
     submitFeedback,
+    requestCuration,
+    requestWindowCuration,
     requeueJob,
     cancelJob,
     reenqueueJob,


### PR DESCRIPTION
## Why

The merged trainer panel only showed jobs Conductor had already curated, but nothing on the site could *request* curation — so the panel stayed empty. This is the front-end half of closing that loop.

## What changed (2 commits, +560)

- **`server/api/conductor/curate-request.post.ts`** (new) — admin-gated bridge; appends a request to conductor's `projects/curation/requests.yaml` via the shared GitHub helpers (`conductorGet`/`conductorPut`), mirroring the `art-request.post.ts` pattern. One commit per batch, dedupe by `job_id`, optimistic SHA.
- **`server/utils/curationRequestYaml.ts`** (new) — the column-0 block-sequence contract (`id/source/status/job_id/art_image_id/project_slug/requested_at/prompt`) + `curationAlreadyQueued` dedupe. Field names match conductor's reader exactly.
- **`stores/artJobStore.ts`** — `requestCuration` / `requestWindowCuration` actions + `curationRequesting` / `RequestedIds` state.
- **`components/art/artjob-manager.vue`** — per-job "Request curation" on DONE cards + a bulk "Curate finished" header button.
- **`components/art/artjob-feedback-manager.vue`** — trainer empty-state CTA, and the curator verdict/score badge surfaced on the queue cards.

## The loop

Admin clicks **Request curation** → this bridge queues it in conductor's `requests.yaml` → conductor's hourly sweep (`curate_art.py --requests`) scores it and POSTs a `CURATOR` verdict back to `/api/art/queue/<id>/feedback` → the trainer panel (Promote/Revise/Reject) and the queue-card badge fill in.

Pairs with the conductor PR (the `--requests` drain).

## Verification
- Merges clean into current `main`.
- The YAML contract round-trips in PyYAML and matches the conductor reader.
- No `node_modules` this session, so the Vue/TS was checked statically, not via `vue-tsc` — worth a CI run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dXcqHkffMLemew8294gcR

---
_Generated by [Claude Code](https://claude.ai/code/session_013dXcqHkffMLemew8294gcR)_