### PR TITLE
One-tap "Make coloring page" on gallery image cards

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -538,8 +538,19 @@ const props = withDefaults(
     showClose?: boolean
     /** Preselect a style by its key (slug/loraPath/label) — e.g. Academy lesson CTA. */
     selectedStyleKey?: string | null
+    /**
+     * Preselect a gallery ArtImage as the source by id — e.g. the "Make
+     * coloring page" one-tap from an image card. Loaded on mount.
+     */
+    sourceImageId?: number | null
   }>(),
-  { serverId: null, styles: null, showClose: true, selectedStyleKey: null },
+  {
+    serverId: null,
+    styles: null,
+    showClose: true,
+    selectedStyleKey: null,
+    sourceImageId: null,
+  },
 )
 
 const emit = defineEmits<{
@@ -1270,8 +1281,51 @@ watch(
   { immediate: true },
 )
 
+// Preselect a gallery image passed by id (e.g. the "Make coloring page" deep
+// link). We only need the thumbnail for the preview here — runStyleTransfer
+// lazily fetches the full imageData when the user generates.
+async function applySourceImageId(
+  id: number | null | undefined,
+): Promise<void> {
+  if (!id || id <= 0) return
+
+  uploadedImageData.value = null
+  resultImage.value = null
+
+  try {
+    const fetched = await artStore.getArtImageById(id, {
+      includeImageData: false,
+      includeThumbnailData: true,
+    })
+
+    if (!fetched) return
+
+    const hydrated = fetched as ArtImage & { thumbnailData?: string | null }
+
+    if (hydrated.thumbnailData) {
+      galleryThumbs.value = {
+        ...galleryThumbs.value,
+        [id]: `data:image/${hydrated.fileType || 'png'};base64,${hydrated.thumbnailData}`,
+      }
+    }
+
+    selectedSourceImage.value = fetched
+    sourceTab.value = 'gallery'
+  } catch {
+    // Non-fatal: the user can still pick a source manually.
+  }
+}
+
+watch(
+  () => props.sourceImageId,
+  (id) => {
+    void applySourceImageId(id)
+  },
+)
+
 onMounted(() => {
   void hydrateFromResourceStore()
+  void applySourceImageId(props.sourceImageId)
 })
 </script>
 

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -22,6 +22,16 @@
       </button>
 
       <button
+        v-if="showActions && allowColoringPage && (selected || compact)"
+        class="rounded-full bg-base-100 p-2 text-accent shadow transition hover:bg-accent hover:text-accent-content"
+        type="button"
+        title="Make coloring page"
+        @click.stop="makeColoringPage"
+      >
+        <Icon name="kind-icon:paintbrush" class="h-4 w-4" />
+      </button>
+
+      <button
         v-if="
           showActions &&
           allowCopyPrompt &&
@@ -325,6 +335,7 @@ const props = withDefaults(
     allowEdit?: boolean
     allowDelete?: boolean
     allowCopyPrompt?: boolean
+    allowColoringPage?: boolean
     autoLoadImage?: boolean
     fallbackImage?: string
   }>(),
@@ -345,6 +356,7 @@ const props = withDefaults(
     allowEdit: true,
     allowDelete: true,
     allowCopyPrompt: true,
+    allowColoringPage: true,
     autoLoadImage: true,
     fallbackImage: '/images/backtree.webp',
   },
@@ -383,6 +395,12 @@ const appUrl = computed(() => {
 })
 
 const displayImage = computed(() => localImage.value || props.artImage)
+
+// One-tap deep link to the Coloring Page Maker with this image preselected as
+// the source (art-styler reads ?imageId and loads it).
+function makeColoringPage() {
+  void navigateTo(`/coloring-page?imageId=${displayImage.value.id}`)
+}
 
 const cardTitle = computed(
   () =>

--- a/pages/coloring-page.vue
+++ b/pages/coloring-page.vue
@@ -25,10 +25,30 @@
       </p>
     </header>
 
-    <art-styler :styles="COLORING_STYLES" :show-close="false" />
+    <art-styler
+      :styles="COLORING_STYLES"
+      :source-image-id="sourceImageId"
+      selected-style-key="coloring-page"
+      :show-close="false"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from '#app'
 import { COLORING_STYLES } from '@/stores/helpers/styleHelper'
+
+const route = useRoute()
+
+// Deep link from a gallery image card: /coloring-page?imageId=123 lands here
+// with that image already loaded as the source and "Coloring Page" preselected,
+// so it's one tap to generate.
+const sourceImageId = computed<number | null>(() => {
+  const raw = Array.isArray(route.query.imageId)
+    ? route.query.imageId[0]
+    : route.query.imageId
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : null
+})
 </script>


### PR DESCRIPTION
## What

Adds a paintbrush **"Make coloring page"** action to every gallery image card. One tap deep-links to the Coloring Page Maker with that image already loaded as the source and the *Coloring Page* style preselected — so any existing render is one tap and one generate away from a printable coloring page.

## Changes

- **`components/art/image-card.vue`** — new action button (gated by `allowColoringPage`, default on, shown like Edit/Delete) → `navigateTo('/coloring-page?imageId=<id>')`.
- **`components/art/art-styler.vue`** — new `sourceImageId` prop: on mount it loads that ArtImage as the source (thumbnail for the preview; full image data is still fetched lazily at generate time, so no heavy payload up front).
- **`pages/coloring-page.vue`** — reads `?imageId` from the query, passes it through, and preselects the `coloring-page` style so the deep link lands ready to generate.

## Why

Follows up the Coloring Page Maker (#243). The dedicated tab is the front door; this makes the feature *ambient* — you can turn anything in your gallery into a coloring page without hunting for the tool. Builds on the existing art-styler → `generateArt({ engine: 'kontext' })` pipeline, no new endpoint.

## Verification

- `npm test` (nuxi prepare + vue-tsc `--noEmit`) — clean.
- ESLint + Prettier — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FBAnTBhEfFpbpKnaLirsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018FBAnTBhEfFpbpKnaLirsZ)_