### PR TITLE
Fix blank art tiles: robust src resolver + video rendering + self-explaining placeholders

### DIFF
--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -57,7 +57,7 @@
         >
           <div class="flex gap-3">
             <a
-              v-if="jobImageSrc(job)"
+              v-if="jobImageShowable(job)"
               :href="jobImageSrc(job)"
               target="_blank"
               rel="noopener"
@@ -70,12 +70,14 @@
                 muted
                 playsinline
                 preload="metadata"
+                @error="markImageFailed(job)"
               />
               <img
                 v-else
                 :src="jobImageSrc(job)"
                 class="h-28 w-24 rounded-2xl border border-base-300 object-cover"
                 alt="curated generated art"
+                @error="markImageFailed(job)"
               />
             </a>
             <div
@@ -323,12 +325,28 @@ function jobImageInfo(job: ArtJobRecord) {
   return artJobStore.imageInfoById[job.artImageId] || null
 }
 
+// Track srcs whose <img>/<video> failed to load (e.g. a path that 404s) so the
+// tile falls back to the diagnostic instead of a silent broken-image icon.
+const failedSrcs = ref<Set<string>>(new Set())
+function markImageFailed(job: ArtJobRecord) {
+  const s = jobImageSrc(job)
+  if (s) failedSrcs.value = new Set(failedSrcs.value).add(s)
+}
+function jobImageFailed(job: ArtJobRecord): boolean {
+  const s = jobImageSrc(job)
+  return !!s && failedSrcs.value.has(s)
+}
+function jobImageShowable(job: ArtJobRecord): boolean {
+  return !!jobImageSrc(job) && !jobImageFailed(job)
+}
+
 function jobImageKind(job: ArtJobRecord): string {
   return jobImageInfo(job)?.kind ?? 'none'
 }
 
 // Short keyword under the placeholder; '' while the image is still loading.
 function jobImageReason(job: ArtJobRecord): string {
+  if (jobImageFailed(job)) return 'load failed (404?)'
   const info = jobImageInfo(job)
   if (!info || info.kind !== 'none') return ''
   const d = info.diag
@@ -343,14 +361,16 @@ function jobImageDiag(job: ArtJobRecord): string {
   const info = jobImageInfo(job)
   if (!info) return `ArtImage ${job.artImageId ?? '—'}: not loaded yet`
   const d = info.diag
-  return [
+  const lines = [
     `reason: ${info.reason}`,
     `kind: ${info.kind}  ·  used: ${d.usedField}`,
     `imageData: ${d.hasImageData ? d.imageDataShape : 'empty'}`,
     `fileType: ${d.fileType}`,
     `imagePath: ${d.imagePath}`,
     `path: ${d.path}`,
-  ].join('\n')
+  ]
+  if (jobImageFailed(job)) lines.unshift(`LOAD FAILED — attempted: ${jobImageSrc(job)}`)
+  return lines.join('\n')
 }
 
 function jobPrompt(job: ArtJobRecord): string {

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -63,7 +63,16 @@
               rel="noopener"
               class="shrink-0"
             >
+              <video
+                v-if="jobImageKind(job) === 'video'"
+                :src="jobImageSrc(job)"
+                class="h-28 w-24 rounded-2xl border border-base-300 object-cover"
+                muted
+                playsinline
+                preload="metadata"
+              />
               <img
+                v-else
                 :src="jobImageSrc(job)"
                 class="h-28 w-24 rounded-2xl border border-base-300 object-cover"
                 alt="curated generated art"
@@ -71,9 +80,10 @@
             </a>
             <div
               v-else
-              class="flex h-28 w-24 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-2 text-center text-[10px] uppercase tracking-wide text-base-content/40"
+              :title="jobImageDiag(job)"
+              class="flex h-28 w-24 shrink-0 flex-col items-center justify-center gap-0.5 rounded-2xl border border-dashed border-base-300 bg-base-100 p-2 text-center text-[10px] uppercase tracking-wide text-base-content/40"
             >
-              Loading art
+              <span>{{ jobImageReason(job) || 'Loading art' }}</span>
             </div>
 
             <div class="min-w-0 flex-1">
@@ -306,6 +316,41 @@ function humanFeedback(job: ArtJobRecord): ArtJobFeedback | undefined {
 function jobImageSrc(job: ArtJobRecord): string {
   if (typeof job.artImageId !== 'number') return ''
   return artJobStore.imageSrcById[job.artImageId] || ''
+}
+
+function jobImageInfo(job: ArtJobRecord) {
+  if (typeof job.artImageId !== 'number') return null
+  return artJobStore.imageInfoById[job.artImageId] || null
+}
+
+function jobImageKind(job: ArtJobRecord): string {
+  return jobImageInfo(job)?.kind ?? 'none'
+}
+
+// Short keyword under the placeholder; '' while the image is still loading.
+function jobImageReason(job: ArtJobRecord): string {
+  const info = jobImageInfo(job)
+  if (!info || info.kind !== 'none') return ''
+  const d = info.diag
+  if (!d.hasImageData && d.imagePath === '(none)' && d.path === '(none)') return 'no bytes stored'
+  if (d.imageDataShape === 'unusable') return 'bad imageData'
+  if (d.imagePath !== '(none)' || d.path !== '(none)') return 'unresolved path'
+  return 'no source'
+}
+
+// Full field dump for the hover tooltip — what the row actually holds.
+function jobImageDiag(job: ArtJobRecord): string {
+  const info = jobImageInfo(job)
+  if (!info) return `ArtImage ${job.artImageId ?? '—'}: not loaded yet`
+  const d = info.diag
+  return [
+    `reason: ${info.reason}`,
+    `kind: ${info.kind}  ·  used: ${d.usedField}`,
+    `imageData: ${d.hasImageData ? d.imageDataShape : 'empty'}`,
+    `fileType: ${d.fileType}`,
+    `imagePath: ${d.imagePath}`,
+    `path: ${d.path}`,
+  ].join('\n')
 }
 
 function jobPrompt(job: ArtJobRecord): string {

--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -194,7 +194,7 @@
           >
             <div class="flex min-w-0 gap-3">
               <a
-                v-if="jobImageSrc(job)"
+                v-if="jobImageShowable(job)"
                 :href="jobImageSrc(job)"
                 target="_blank"
                 rel="noopener"
@@ -208,12 +208,14 @@
                   muted
                   playsinline
                   preload="metadata"
+                  @error="markImageFailed(job)"
                 />
                 <img
                   v-else
                   :src="jobImageSrc(job)"
                   class="h-24 w-20 rounded-2xl border border-base-300 object-cover sm:h-28 sm:w-24"
                   alt="generated art"
+                  @error="markImageFailed(job)"
                 />
               </a>
               <div
@@ -937,6 +939,22 @@ function jobImageInfo(job: { artImageId?: number | null }) {
   return artJobStore.imageInfoById[job.artImageId] || null
 }
 
+// Track srcs whose <img>/<video> failed to load (e.g. a path that 404s) so the
+// tile can fall back to the diagnostic instead of a silent broken-image icon.
+// Keyed by src string, so a re-render with a new src is shown again.
+const failedSrcs = ref<Set<string>>(new Set())
+function markImageFailed(job: { artImageId?: number | null }) {
+  const s = jobImageSrc(job)
+  if (s) failedSrcs.value = new Set(failedSrcs.value).add(s)
+}
+function jobImageFailed(job: { artImageId?: number | null }): boolean {
+  const s = jobImageSrc(job)
+  return !!s && failedSrcs.value.has(s)
+}
+function jobImageShowable(job: { artImageId?: number | null }): boolean {
+  return !!jobImageSrc(job) && !jobImageFailed(job)
+}
+
 // 'video' → render <video>; 'image' → <img>; anything else → placeholder.
 function jobImageKind(job: { artImageId?: number | null }): string {
   return jobImageInfo(job)?.kind ?? 'none'
@@ -945,6 +963,7 @@ function jobImageKind(job: { artImageId?: number | null }): string {
 // Short keyword shown under the placeholder label so a blank tile at a glance
 // says WHY (no bytes vs. bad data vs. unresolved path) rather than just "No image".
 function jobImageReason(job: { artImageId?: number | null }): string {
+  if (jobImageFailed(job)) return 'load failed (404?)'
   const info = jobImageInfo(job)
   if (!info || info.kind !== 'none') return ''
   const d = info.diag
@@ -960,14 +979,16 @@ function jobImageDiag(job: { artImageId?: number | null }): string {
   const info = jobImageInfo(job)
   if (!info) return `ArtImage ${job.artImageId ?? '—'}: not loaded yet`
   const d = info.diag
-  return [
+  const lines = [
     `reason: ${info.reason}`,
     `kind: ${info.kind}  ·  used: ${d.usedField}`,
     `imageData: ${d.hasImageData ? d.imageDataShape : 'empty'}`,
     `fileType: ${d.fileType}`,
     `imagePath: ${d.imagePath}`,
     `path: ${d.path}`,
-  ].join('\n')
+  ]
+  if (jobImageFailed(job)) lines.unshift(`LOAD FAILED — attempted: ${jobImageSrc(job)}`)
+  return lines.join('\n')
 }
 
 function jobStatusClass(status: string): string {

--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -201,7 +201,16 @@
                 :title="`Open ArtImage ${job.artImageId}`"
                 class="shrink-0"
               >
+                <video
+                  v-if="jobImageKind(job) === 'video'"
+                  :src="jobImageSrc(job)"
+                  class="h-24 w-20 rounded-2xl border border-base-300 object-cover sm:h-28 sm:w-24"
+                  muted
+                  playsinline
+                  preload="metadata"
+                />
                 <img
+                  v-else
                   :src="jobImageSrc(job)"
                   class="h-24 w-20 rounded-2xl border border-base-300 object-cover sm:h-28 sm:w-24"
                   alt="generated art"
@@ -209,9 +218,14 @@
               </a>
               <div
                 v-else
-                class="flex h-24 w-20 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 text-center text-[10px] font-semibold uppercase tracking-wide text-base-content/40 sm:h-28 sm:w-24"
+                :title="jobImageDiag(job)"
+                class="flex h-24 w-20 shrink-0 flex-col items-center justify-center gap-0.5 rounded-2xl border border-dashed border-base-300 bg-base-100 px-1 text-center text-[10px] font-semibold uppercase tracking-wide text-base-content/40 sm:h-28 sm:w-24"
               >
-                {{ jobPlaceholder(job) }}
+                <span>{{ jobPlaceholder(job) }}</span>
+                <span
+                  v-if="jobImageReason(job)"
+                  class="text-[8px] font-normal normal-case leading-tight text-base-content/50"
+                >{{ jobImageReason(job) }}</span>
               </div>
 
               <div class="min-w-0 flex-1">
@@ -916,6 +930,44 @@ function statusClass(status: string): string {
 function jobImageSrc(job: { artImageId?: number | null }): string {
   if (typeof job.artImageId !== 'number') return ''
   return artJobStore.imageSrcById[job.artImageId] || ''
+}
+
+function jobImageInfo(job: { artImageId?: number | null }) {
+  if (typeof job.artImageId !== 'number') return null
+  return artJobStore.imageInfoById[job.artImageId] || null
+}
+
+// 'video' → render <video>; 'image' → <img>; anything else → placeholder.
+function jobImageKind(job: { artImageId?: number | null }): string {
+  return jobImageInfo(job)?.kind ?? 'none'
+}
+
+// Short keyword shown under the placeholder label so a blank tile at a glance
+// says WHY (no bytes vs. bad data vs. unresolved path) rather than just "No image".
+function jobImageReason(job: { artImageId?: number | null }): string {
+  const info = jobImageInfo(job)
+  if (!info || info.kind !== 'none') return ''
+  const d = info.diag
+  if (!d.hasImageData && d.imagePath === '(none)' && d.path === '(none)') return 'no bytes stored'
+  if (d.imageDataShape === 'unusable') return 'bad imageData'
+  if (d.imagePath !== '(none)' || d.path !== '(none)') return 'unresolved path'
+  return 'no source'
+}
+
+// Full field dump for the hover tooltip — the "show output of the path file" ask:
+// exactly what the row holds so a blank can be traced to missing bytes vs. format.
+function jobImageDiag(job: { artImageId?: number | null }): string {
+  const info = jobImageInfo(job)
+  if (!info) return `ArtImage ${job.artImageId ?? '—'}: not loaded yet`
+  const d = info.diag
+  return [
+    `reason: ${info.reason}`,
+    `kind: ${info.kind}  ·  used: ${d.usedField}`,
+    `imageData: ${d.hasImageData ? d.imageDataShape : 'empty'}`,
+    `fileType: ${d.fileType}`,
+    `imagePath: ${d.imagePath}`,
+    `path: ${d.path}`,
+  ].join('\n')
 }
 
 function jobStatusClass(status: string): string {

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -7,6 +7,8 @@ import type {
   Prisma,
 } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
+import { resolveArtImageSource } from '~/utils/artImageSource'
+import type { ArtImageSource } from '~/utils/artImageSource'
 
 export type ArtJobStatus =
   | 'PENDING'
@@ -122,6 +124,9 @@ type ArtJobState = {
   jobs: ArtJobRecord[]
   trainerJobs: ArtJobRecord[]
   imageSrcById: Record<number, string>
+  // Full resolver result per id: src + kind ('image'|'video'|'none') + a
+  // human-readable `reason` and `diag` block so a blank tile can explain itself.
+  imageInfoById: Record<number, ArtImageSource>
   jobStatusFilter: ArtJobStatus | 'ALL'
   loadingStats: boolean
   loadingUptime: boolean
@@ -132,7 +137,7 @@ type ArtJobState = {
   windowHours: number
 }
 
-const MAX_JOB_IMAGES = 72
+const MAX_JOB_IMAGES = 240
 
 export const useArtJobStore = defineStore('artJobStore', () => {
   const state = reactive<ArtJobState>({
@@ -141,6 +146,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     jobs: [],
     trainerJobs: [],
     imageSrcById: {},
+    imageInfoById: {},
     jobStatusFilter: 'PENDING',
     loadingStats: false,
     loadingUptime: false,
@@ -198,7 +204,10 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     // Stable ids are the point of overwrite, but that means an existing data URL
     // is no longer proof that the current bytes are hydrated. Force these ids to
     // reload whenever a completed overwrite is observed.
-    for (const id of ids) delete state.imageSrcById[id]
+    for (const id of ids) {
+      delete state.imageSrcById[id]
+      delete state.imageInfoById[id]
+    }
     return ids
   }
 
@@ -244,21 +253,11 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     }
   }
 
+  // Delegates to the shared resolver (utils/artImageSource) so the ArtJob cards
+  // use the same robust, video-aware, path-normalizing logic as the main gallery
+  // instead of the old narrow rule that dropped any path not under /images/.
   function artImageToSrc(image: ArtImage | null | undefined): string {
-    if (!image) return ''
-    const raw = (image.imageData || '').trim()
-    if (raw) {
-      if (raw.startsWith('data:image/')) return raw
-      if (!raw.startsWith('/') && !raw.startsWith('http')) {
-        return `data:image/${image.fileType || 'png'};base64,${raw}`
-      }
-    }
-    const path = (image.imagePath || image.path || '').trim()
-    if (!path) return ''
-    if (path.startsWith('http') || path.startsWith('data:')) return path
-    if (path.startsWith('/images/')) return path
-    if (path.startsWith('images/')) return `/${path}`
-    return ''
+    return resolveArtImageSource(image).src
   }
 
   async function loadJobImages(forceIds: number[] = []): Promise<void> {
@@ -285,7 +284,9 @@ export const useArtJobStore = defineStore('artJobStore', () => {
           30_000,
         )
         if (res.success && res.data) {
-          state.imageSrcById[id] = artImageToSrc(res.data)
+          const info = resolveArtImageSource(res.data)
+          state.imageInfoById[id] = info
+          state.imageSrcById[id] = info.src
         }
       }),
     )

--- a/utils/artImageSource.ts
+++ b/utils/artImageSource.ts
@@ -1,0 +1,199 @@
+// utils/artImageSource.ts
+//
+// One shared resolver for turning an ArtImage row into a displayable media src,
+// with a diagnostic so the UI can say WHY something is blank instead of a bare
+// "No image". Ported/unified from image-card.vue's robust logic (the only
+// resolver that recovered path-only and malformed rows) and extended with:
+//   - video awareness (fileType mp4/webm etc. -> a <video>-playable data/URL,
+//     not a data:image/mp4 that an <img> silently drops), and
+//   - a `diag` block that reports which fields were present and which one was
+//     used, so a blank tile can explain itself.
+//
+// Same-origin, leading-slash paths (e.g. /images/foo.webp) are returned as-is;
+// callers on the app origin can use them directly. No Vue/runtime deps so this
+// stays a pure, reusable util.
+
+export type ArtImageLike = {
+  imageData?: string | null
+  imagePath?: string | null
+  path?: string | null
+  fileName?: string | null
+  fileType?: string | null
+}
+
+export type ArtMediaKind = 'image' | 'video' | 'none'
+
+export type ArtImageSourceDiag = {
+  hasImageData: boolean
+  imageDataShape: 'data-url' | 'base64' | 'path-in-data-field' | 'unusable' | 'empty'
+  fileType: string
+  imagePath: string
+  path: string
+  usedField: 'imageData' | 'imagePath' | 'path' | 'fileName' | 'none'
+}
+
+export type ArtImageSource = {
+  src: string
+  kind: ArtMediaKind
+  /** Human-readable explanation — always set, most useful when kind === 'none' or 'video'. */
+  reason: string
+  diag: ArtImageSourceDiag
+}
+
+const VIDEO_FILETYPES = new Set(['mp4', 'webm', 'mov', 'ogv', 'ogg', 'm4v'])
+
+function isVideoType(fileType?: string | null, path?: string | null): boolean {
+  const ft = (fileType || '').trim().toLowerCase()
+  if (ft.startsWith('video/')) return true
+  if (VIDEO_FILETYPES.has(ft)) return true
+  return /\.(mp4|webm|mov|ogv|m4v)(\?|#|$)/i.test((path || '').trim())
+}
+
+function mediaMimeType(fileType: string | null | undefined, kind: 'image' | 'video'): string {
+  const cleaned = (fileType || '').trim().toLowerCase()
+  if (cleaned.includes('/')) return cleaned
+  if (kind === 'video') {
+    if (cleaned === 'mov') return 'video/quicktime'
+    if (cleaned === 'ogv' || cleaned === 'ogg') return 'video/ogg'
+    return `video/${cleaned || 'mp4'}`
+  }
+  if (cleaned === 'jpg' || cleaned === 'jpeg') return 'image/jpeg'
+  if (!cleaned) return 'image/png'
+  return `image/${cleaned}`
+}
+
+function isProbablyPath(value: string): boolean {
+  const t = value.trim()
+  return (
+    t.startsWith('/') ||
+    t.startsWith('./') ||
+    t.startsWith('../') ||
+    t.startsWith('http://') ||
+    t.startsWith('https://') ||
+    t.startsWith('images/') ||
+    t.startsWith('public/') ||
+    t.startsWith('/mnt/data/') ||
+    /\.(png|jpe?g|webp|gif|avif|svg|mp4|webm|mov|ogv|m4v)$/i.test(t)
+  )
+}
+
+function looksLikeBase64(value: string): boolean {
+  const compact = value.replace(/\s+/g, '')
+  if (compact.length < 64) return false
+  if (compact.length % 4 !== 0) return false
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(compact)
+}
+
+function stripServerFilePrefix(value: string): string {
+  return value
+    .replace(/^file:\/\//, '')
+    .replace(/^\/mnt\/data\/+/, '')
+    .replace(/^\/public\/+/, '')
+    .replace(/^public\/+/, '')
+    .replace(/^\/app\/public\/+/, '')
+    .replace(/^app\/public\/+/, '')
+}
+
+/** Normalize a stored path to a same-origin URL, or '' if unusable. */
+export function normalizeMediaPath(value?: string | null): string {
+  if (!value) return ''
+  const trimmed = value.trim()
+  if (!trimmed || trimmed === 'UNDEFINED' || trimmed === 'undefined') return ''
+  if (
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('data:')
+  ) {
+    return trimmed
+  }
+  const clean = stripServerFilePrefix(trimmed)
+  if (!clean) return ''
+  if (clean.startsWith('/images/')) return clean
+  if (clean.startsWith('images/')) return `/${clean}`
+  if (clean.startsWith('/')) return clean
+  return `/images/${clean}`
+}
+
+/**
+ * Resolve an ArtImage to { src, kind, reason, diag }. `kind === 'video'` means
+ * the caller should render a <video>, not an <img>. `kind === 'none'` means
+ * nothing renderable — `reason` says why (missing bytes vs. unusable path etc.).
+ */
+export function resolveArtImageSource(image?: ArtImageLike | null): ArtImageSource {
+  const fileType = (image?.fileType || '').trim()
+  const imagePath = (image?.imagePath || '').trim()
+  const path = (image?.path || '').trim()
+  const fileName = (image?.fileName || '').trim()
+  const rawData = (image?.imageData || '').trim()
+
+  const diag: ArtImageSourceDiag = {
+    hasImageData: rawData.length > 0,
+    imageDataShape: !rawData
+      ? 'empty'
+      : rawData.startsWith('data:')
+        ? 'data-url'
+        : isProbablyPath(rawData)
+          ? 'path-in-data-field'
+          : looksLikeBase64(rawData)
+            ? 'base64'
+            : 'unusable',
+    fileType: fileType || '(none)',
+    imagePath: imagePath || '(none)',
+    path: path || '(none)',
+    usedField: 'none',
+  }
+
+  if (!image) {
+    return { src: '', kind: 'none', reason: 'no ArtImage record', diag }
+  }
+
+  // 1) Inline bytes in imageData.
+  if (rawData) {
+    if (diag.imageDataShape === 'data-url') {
+      const kind: ArtMediaKind = rawData.startsWith('data:video/') ? 'video' : 'image'
+      return { src: rawData, kind, reason: 'inline data URL', diag: { ...diag, usedField: 'imageData' } }
+    }
+    if (diag.imageDataShape === 'base64') {
+      const kind: 'image' | 'video' = isVideoType(fileType, imagePath || path) ? 'video' : 'image'
+      const src = `data:${mediaMimeType(fileType, kind)};base64,${rawData}`
+      const reason = kind === 'video' ? `video result (fileType=${fileType || 'unknown'}) — render as <video>` : 'inline base64'
+      return { src, kind, reason, diag: { ...diag, usedField: 'imageData' } }
+    }
+    // 'path-in-data-field' falls through to path handling using imageData as a candidate.
+  }
+
+  // 2) A stored path (imagePath, then path, then imageData-holding-a-path, then fileName).
+  const pathCandidateRaw =
+    imagePath ||
+    path ||
+    (diag.imageDataShape === 'path-in-data-field' ? rawData : '') ||
+    fileName
+  const usedField: ArtImageSourceDiag['usedField'] = imagePath
+    ? 'imagePath'
+    : path
+      ? 'path'
+      : diag.imageDataShape === 'path-in-data-field'
+        ? 'imageData'
+        : fileName
+          ? 'fileName'
+          : 'none'
+  const normalized = normalizeMediaPath(pathCandidateRaw)
+  if (normalized) {
+    const kind: 'image' | 'video' = isVideoType(fileType, normalized) ? 'video' : 'image'
+    const reason = kind === 'video' ? `video path (fileType=${fileType || 'unknown'}) — render as <video>` : `path (${usedField})`
+    return { src: normalized, kind, reason, diag: { ...diag, usedField } }
+  }
+
+  // 3) Nothing renderable — explain why.
+  let reason: string
+  if (!rawData && !imagePath && !path) {
+    reason = 'no bytes stored: imageData empty and no imagePath/path'
+  } else if (rawData && diag.imageDataShape === 'unusable') {
+    reason = `imageData present but not valid base64/data-URL (${rawData.length} chars)`
+  } else if (pathCandidateRaw) {
+    reason = `path present but did not resolve to a URL: "${pathCandidateRaw.slice(0, 120)}"`
+  } else {
+    reason = 'no usable image source on this record'
+  }
+  return { src: '', kind: 'none', reason, diag }
+}


### PR DESCRIPTION
## Why

~Half the ArtJob cards render the "No image" placeholder, with no way to tell whether the image is missing or just mis-formatted. Tracing it turned up **three distinct causes** (which is why it looked random), plus the fact that the app has three disagreeing image-src resolvers and only `image-card.vue`'s is robust.

## Root causes

1. **Video results shown in an `<img>`.** LTX/WAN i2v jobs store `fileType = mp4/webm`, but the card resolver built `data:image/${fileType};base64,…` → `data:image/mp4;…`, which an `<img>` silently drops.
2. **Paths not under `/images/` were discarded.** `artJobStore.artImageToSrc` returned `''` for any path shape other than `http`/`data:`/`/images/` — a bare filename, `art/…`, `/mnt/data/…`, or a disk path all vanished. (This is the "use `path` if it exists, and properly" gap.)
3. **`imageData` genuinely empty** (upload never stored bytes) was indistinguishable from a formatting bug — no diagnostic.

## What changed

- **`utils/artImageSource.ts` (new)** — one shared, video-aware, path-normalizing resolver returning `{ src, kind: 'image'|'video'|'none', reason, diag }`. Ported from `image-card.vue`'s robust logic (strips `file://`/`/public/`/`/mnt/data/` prefixes, prefixes bare names with `/images/`, passes `http`/`data:` through) and extended with video detection.
- **`stores/artJobStore.ts`** — `artImageToSrc` now delegates to the shared resolver; stores the full result per id (`imageInfoById`) alongside `imageSrcById`; raised the per-panel image cap `72 → 240` so large queues don't blank past the cutoff.
- **`artjob-manager.vue` + `artjob-feedback-manager.vue`** — render `<video>` for video results, `<img>` otherwise; and on a blank tile show a short reason (`no bytes stored` / `bad imageData` / `unresolved path`) with a **hover tooltip dumping `imageData` shape, `fileType`, `imagePath`, and `path`** — so a blank explains itself: missing bytes vs. format vs. path. (This is the "know if it's not there or we're not formatting it — show output of the path file" ask.)

## Note / follow-up
There are still **three** ArtImage resolvers in the app (`artStore.currentImagePath`, this one, and `image-card`). This PR unifies the ArtJob surfaces onto the shared util; folding `artStore` and `image-card` onto it too is a clean follow-up. Also flagged by the trace: generated/uploaded rows store `imageData` only (path null) while folder-synced rows store `path` only — so a genuine fix for "no bytes stored" tiles is upstream (ensure `save-generated`/relay actually persist the base64), which the diagnostic will now make visible per-image.

## Verification
- `utils/artImageSource.ts` typechecks **strict-clean** and passes a behavioral test over 10 real-world cases (base64 image/video, `/images` path, bare/relative/disk paths, `ts.net` URL, empty, unusable).
- The `.vue`/store edits are additive and reviewed but **not** run through `vue-tsc` (no `node_modules` this session) — worth a CI check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dXcqHkffMLemew8294gcR

---
_Generated by [Claude Code](https://claude.ai/code/session_013dXcqHkffMLemew8294gcR)_