### PR TITLE
Model Builder: persist drafted structured fields on commit

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -1116,13 +1116,13 @@ function canCurate(job: ArtJob): boolean {
 }
 
 function hasCuratorVerdict(job: ArtJob): boolean {
-  return Boolean(asRecord(payloadRecord(job).curation).curator)
+  return Boolean(asRecord(payloadRecord(job).curation)?.curator)
 }
 
 // Conductor's curator verdict/score, once it has scored a finished job — surfaced
 // on the queue card so the queue and the trainer panel agree at a glance.
 function curatorFeedback(job: ArtJob): JsonRecord | null {
-  return asRecord(asRecord(payloadRecord(job).curation).curator)
+  return asRecord(asRecord(payloadRecord(job).curation)?.curator)
 }
 
 function curatorVerdict(job: ArtJob): string {

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -4,23 +4,27 @@
 //
 // - ASSET_ONLY: promote the item's generated ArtImage onto the source record's
 //   canonical `artImageId`.
-// - UPDATE: write the item's pitch into a single safe text field on the source.
+// - UPDATE: write the item's pitch into a single safe text field on the source,
+//   plus any additional known columns parsed from the item's structured FIELDS
+//   draft (t-028).
 // - CREATE: create a new private/inactive (draft-early) related record and link
-//   it to the source via the known relation.
+//   it to the source via the known relation, populated with the same known
+//   columns.
 //
 // Idempotency: the first commit atomically claims the item by setting its unique
 // `idempotencyKey`; a replay returns the existing target instead of writing
 // again. If the write fails after the claim, the claim is released so a retry can
 // run. CREATE + link happen in one transaction so a link failure never leaves an
 // orphan. COMMIT never overwrites unrelated canonical data — it only touches the
-// one field / relation it owns.
+// fields it owns (the single text field plus the model's known field spec).
 
 import { createError, defineEventHandler, readBody } from 'h3'
-import { Prisma } from '~/prisma/generated/prisma/client'
+import type { Rarity, RewardType, DreamType, FacetKind, Prisma  } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { assertRunAccess, getItemId } from '../../runs/index'
+import { CREATE_TARGETS, fieldSpecFor } from '~/stores/helpers/modelBuilderFields'
 
 type SourceType =
   | 'Project'
@@ -30,16 +34,6 @@ type SourceType =
   | 'Dream'
   | 'Reward'
   | 'Scenario'
-
-// Which model an expansion output creates.
-const CREATE_TARGETS: Record<string, SourceType> = {
-  'expand-characters': 'Character',
-  'expand-signature-rewards': 'Reward',
-  'expand-rewards': 'Reward',
-  'expand-scenarios': 'Scenario',
-  'expand-manager-bot': 'Bot',
-  'expand-narrator-bot': 'Bot',
-}
 
 function isSourceType(value: string): value is SourceType {
   return [
@@ -51,6 +45,248 @@ function isSourceType(value: string): value is SourceType {
     'Reward',
     'Scenario',
   ].includes(value)
+}
+
+// ── Structured FIELDS-draft parsing (t-028) ─────────────────────────────────
+//
+// The FIELDS stage draft is free text of "field: value" lines (one per line,
+// per modelBuilderSuggest's `fields` prompt). Parse it into a lowercased-key
+// map, then apply only the columns modelBuilderFields.ts already knows about
+// for the target model — the single source of per-model field truth used to
+// auto-fill and AI-ground the FIELDS stage (t-024). Choice fields are
+// validated against their pool; unknown keys are ignored; nothing here writes
+// an arbitrary column.
+
+const LONG_TEXT_MAX = 20000
+const DEFAULT_TEXT_MAX = 256
+
+// Short VarChar columns whose real schema limit is longer than the default cap.
+const SHORT_TEXT_MAX: Partial<Record<SourceType, Record<string, number>>> = {
+  Character: { class: 764, species: 764 },
+  Bot: { subtitle: 764 },
+  Reward: { flavorText: 512, collection: 764 },
+  Dream: { flavorText: 512 },
+}
+
+// Free-text fields backed by a Text/LongText column but not flagged `prose` in
+// the field spec — cap generously rather than truncating at the short default.
+const LONG_TEXT_FIELDS: Partial<Record<SourceType, Set<string>>> = {
+  Dream: new Set(['examples']),
+  Scenario: new Set(['locations', 'inspirations']),
+  Facet: new Set(['examples']),
+}
+
+// Fields stored as a numeric column rather than text.
+const NUMERIC_FIELDS: Partial<Record<SourceType, Set<string>>> = {
+  Scenario: new Set(['difficulty']),
+}
+
+function parseFieldLines(raw: string | null | undefined): Record<string, string> {
+  const map: Record<string, string> = {}
+  if (!raw) return map
+  for (const line of raw.split('\n')) {
+    const idx = line.indexOf(':')
+    if (idx === -1) continue
+    const key = line.slice(0, idx).trim().toLowerCase()
+    const value = line.slice(idx + 1).trim()
+    if (key && value) map[key] = value
+  }
+  return map
+}
+
+function choicesFor(type: SourceType, key: string): string[] | undefined {
+  return fieldSpecFor(type).find((field) => field.key === key)?.choices
+}
+
+function pickChoice<T extends string>(
+  fields: Record<string, string>,
+  type: SourceType,
+  key: string,
+): T | undefined {
+  const raw = fields[key.toLowerCase()]
+  const choices = choicesFor(type, key)
+  if (!raw || !choices) return undefined
+  const upper = raw.trim().toUpperCase()
+  return choices.includes(upper) ? (upper as T) : undefined
+}
+
+function pickText(
+  fields: Record<string, string>,
+  type: SourceType,
+  key: string,
+): string | undefined {
+  const raw = fields[key.toLowerCase()]
+  if (!raw) return undefined
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  const isLongText =
+    fieldSpecFor(type).find((field) => field.key === key)?.prose ||
+    LONG_TEXT_FIELDS[type]?.has(key)
+  const maxLen = isLongText
+    ? LONG_TEXT_MAX
+    : (SHORT_TEXT_MAX[type]?.[key] ?? DEFAULT_TEXT_MAX)
+  return trimmed.length > maxLen ? trimmed.slice(0, maxLen) : trimmed
+}
+
+function pickInt(fields: Record<string, string>, key: string): number | undefined {
+  const raw = fields[key.toLowerCase()]
+  if (!raw) return undefined
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+interface CharacterExtra {
+  class?: string
+  species?: string
+  honorific?: string
+  personality?: string
+  quirks?: string
+  backstory?: string
+  charm?: Rarity
+  empathy?: Rarity
+  grace?: Rarity
+  luck?: Rarity
+  might?: Rarity
+  wits?: Rarity
+}
+function characterFields(fields: Record<string, string>): CharacterExtra {
+  const data: CharacterExtra = {}
+  const cls = pickText(fields, 'Character', 'class'); if (cls) data.class = cls
+  const species = pickText(fields, 'Character', 'species'); if (species) data.species = species
+  const honorific = pickText(fields, 'Character', 'honorific'); if (honorific) data.honorific = honorific
+  const personality = pickText(fields, 'Character', 'personality'); if (personality) data.personality = personality
+  const quirks = pickText(fields, 'Character', 'quirks'); if (quirks) data.quirks = quirks
+  const backstory = pickText(fields, 'Character', 'backstory'); if (backstory) data.backstory = backstory
+  const charm = pickChoice<Rarity>(fields, 'Character', 'charm'); if (charm) data.charm = charm
+  const empathy = pickChoice<Rarity>(fields, 'Character', 'empathy'); if (empathy) data.empathy = empathy
+  const grace = pickChoice<Rarity>(fields, 'Character', 'grace'); if (grace) data.grace = grace
+  const luck = pickChoice<Rarity>(fields, 'Character', 'luck'); if (luck) data.luck = luck
+  const might = pickChoice<Rarity>(fields, 'Character', 'might'); if (might) data.might = might
+  const wits = pickChoice<Rarity>(fields, 'Character', 'wits'); if (wits) data.wits = wits
+  return data
+}
+
+interface BotExtra {
+  BotType?: string
+  subtitle?: string
+  description?: string
+  personality?: string
+  botIntro?: string
+  userIntro?: string
+  prompt?: string
+}
+function botFields(fields: Record<string, string>): BotExtra {
+  const data: BotExtra = {}
+  const botType = pickChoice<string>(fields, 'Bot', 'botType'); if (botType) data.BotType = botType
+  const subtitle = pickText(fields, 'Bot', 'subtitle'); if (subtitle) data.subtitle = subtitle
+  const description = pickText(fields, 'Bot', 'description'); if (description) data.description = description
+  const personality = pickText(fields, 'Bot', 'personality'); if (personality) data.personality = personality
+  const botIntro = pickText(fields, 'Bot', 'botIntro'); if (botIntro) data.botIntro = botIntro
+  const userIntro = pickText(fields, 'Bot', 'userIntro'); if (userIntro) data.userIntro = userIntro
+  const prompt = pickText(fields, 'Bot', 'prompt'); if (prompt) data.prompt = prompt
+  return data
+}
+
+interface RewardExtra {
+  rewardType?: RewardType
+  rarity?: Rarity
+  effect?: string
+  description?: string
+  flavorText?: string
+  collection?: string
+}
+function rewardFields(fields: Record<string, string>): RewardExtra {
+  const data: RewardExtra = {}
+  const rewardType = pickChoice<RewardType>(fields, 'Reward', 'rewardType'); if (rewardType) data.rewardType = rewardType
+  const rarity = pickChoice<Rarity>(fields, 'Reward', 'rarity'); if (rarity) data.rarity = rarity
+  const effect = pickText(fields, 'Reward', 'effect'); if (effect) data.effect = effect
+  const description = pickText(fields, 'Reward', 'description'); if (description) data.description = description
+  const flavorText = pickText(fields, 'Reward', 'flavorText'); if (flavorText) data.flavorText = flavorText
+  const collection = pickText(fields, 'Reward', 'collection'); if (collection) data.collection = collection
+  return data
+}
+
+interface DreamExtra {
+  dreamType?: DreamType
+  pitch?: string
+  description?: string
+  flavorText?: string
+  examples?: string
+}
+function dreamFields(fields: Record<string, string>): DreamExtra {
+  const data: DreamExtra = {}
+  const dreamType = pickChoice<DreamType>(fields, 'Dream', 'dreamType'); if (dreamType) data.dreamType = dreamType
+  const pitch = pickText(fields, 'Dream', 'pitch'); if (pitch) data.pitch = pitch
+  const description = pickText(fields, 'Dream', 'description'); if (description) data.description = description
+  const flavorText = pickText(fields, 'Dream', 'flavorText'); if (flavorText) data.flavorText = flavorText
+  const examples = pickText(fields, 'Dream', 'examples'); if (examples) data.examples = examples
+  return data
+}
+
+interface ScenarioExtra {
+  description?: string
+  intros?: string
+  difficulty?: number
+  locations?: string
+  inspirations?: string
+}
+function scenarioFields(fields: Record<string, string>): ScenarioExtra {
+  const data: ScenarioExtra = {}
+  const description = pickText(fields, 'Scenario', 'description'); if (description) data.description = description
+  const intros = pickText(fields, 'Scenario', 'intros'); if (intros) data.intros = intros
+  const difficulty = NUMERIC_FIELDS.Scenario?.has('difficulty') ? pickInt(fields, 'difficulty') : undefined
+  if (difficulty !== undefined) data.difficulty = difficulty
+  const locations = pickText(fields, 'Scenario', 'locations'); if (locations) data.locations = locations
+  const inspirations = pickText(fields, 'Scenario', 'inspirations'); if (inspirations) data.inspirations = inspirations
+  return data
+}
+
+interface ProjectExtra {
+  description?: string
+  pitch?: string
+  goal?: string
+}
+function projectFields(fields: Record<string, string>): ProjectExtra {
+  const data: ProjectExtra = {}
+  const description = pickText(fields, 'Project', 'description'); if (description) data.description = description
+  const pitch = pickText(fields, 'Project', 'pitch'); if (pitch) data.pitch = pitch
+  const goal = pickText(fields, 'Project', 'goal'); if (goal) data.goal = goal
+  return data
+}
+
+interface FacetExtra {
+  kind?: FacetKind
+  description?: string
+  examples?: string
+}
+function facetFields(fields: Record<string, string>): FacetExtra {
+  const data: FacetExtra = {}
+  const kind = pickChoice<FacetKind>(fields, 'Facet', 'kind'); if (kind) data.kind = kind
+  const description = pickText(fields, 'Facet', 'description'); if (description) data.description = description
+  const examples = pickText(fields, 'Facet', 'examples'); if (examples) data.examples = examples
+  return data
+}
+
+// Read-only view of which extra columns a commit would write — used for the
+// dry-run plan summary. Never passed directly to Prisma (see the typed
+// per-model functions above for the actual write path).
+function extraFieldKeys(type: SourceType, fields: Record<string, string>): string[] {
+  switch (type) {
+    case 'Character':
+      return Object.keys(characterFields(fields))
+    case 'Bot':
+      return Object.keys(botFields(fields))
+    case 'Reward':
+      return Object.keys(rewardFields(fields))
+    case 'Dream':
+      return Object.keys(dreamFields(fields))
+    case 'Scenario':
+      return Object.keys(scenarioFields(fields))
+    case 'Project':
+      return Object.keys(projectFields(fields))
+    case 'Facet':
+      return Object.keys(facetFields(fields))
+  }
 }
 
 // Promote a generated ArtImage onto the source record's canonical art link.
@@ -84,43 +320,50 @@ async function promoteAsset(
   }
 }
 
-// The single freeform text field UPDATE writes on each model.
+// The single freeform text field UPDATE writes on each model, plus any
+// additional known columns parsed from the item's structured FIELDS draft. A
+// structured value for the same key as the primary text field wins over the
+// generic `text` fallback.
 async function updateText(
   type: SourceType,
   id: number,
   text: string,
+  fields: Record<string, string>,
 ): Promise<void> {
   switch (type) {
     case 'Project':
-      await prisma.project.update({ where: { id }, data: { pitch: text } })
+      await prisma.project.update({ where: { id }, data: { pitch: text, ...projectFields(fields) } })
       return
     case 'Character':
-      await prisma.character.update({ where: { id }, data: { backstory: text } })
+      await prisma.character.update({ where: { id }, data: { backstory: text, ...characterFields(fields) } })
       return
     case 'Bot':
-      await prisma.bot.update({ where: { id }, data: { description: text } })
+      await prisma.bot.update({ where: { id }, data: { description: text, ...botFields(fields) } })
       return
     case 'Facet':
-      await prisma.facet.update({ where: { id }, data: { description: text } })
+      await prisma.facet.update({ where: { id }, data: { description: text, ...facetFields(fields) } })
       return
     case 'Dream':
-      await prisma.dream.update({ where: { id }, data: { pitch: text } })
+      await prisma.dream.update({ where: { id }, data: { pitch: text, ...dreamFields(fields) } })
       return
     case 'Reward':
-      await prisma.reward.update({ where: { id }, data: { description: text } })
+      await prisma.reward.update({ where: { id }, data: { description: text, ...rewardFields(fields) } })
       return
     case 'Scenario':
-      await prisma.scenario.update({ where: { id }, data: { description: text } })
+      await prisma.scenario.update({ where: { id }, data: { description: text, ...scenarioFields(fields) } })
       return
   }
 }
 
-// Create a private/inactive draft-early record of the target type. Returns its id.
+// Create a private/inactive draft-early record of the target type, populated
+// with the single text field plus any known columns from the structured FIELDS
+// draft. Returns its id.
 async function createRecord(
   tx: Prisma.TransactionClient,
   type: SourceType,
   name: string,
   text: string,
+  fields: Record<string, string>,
   userId: number,
 ): Promise<number> {
   const priv = { userId, isPublic: false, isActive: false }
@@ -128,43 +371,62 @@ async function createRecord(
     case 'Character':
       return (
         await tx.character.create({
-          data: { name, backstory: text, ...priv },
+          data: { name, backstory: text, ...priv, ...characterFields(fields) },
         })
       ).id
     case 'Reward':
       return (
         await tx.reward.create({
-          data: { name, description: text, ...priv },
+          data: { name, description: text, ...priv, ...rewardFields(fields) },
         })
       ).id
     case 'Scenario':
       return (
         await tx.scenario.create({
-          data: { title: name, description: text || name, intros: '', ...priv },
+          data: {
+            title: name,
+            description: text || name,
+            intros: '',
+            ...priv,
+            ...scenarioFields(fields),
+          },
         })
       ).id
     case 'Dream':
-      return (await tx.dream.create({ data: { title: name, pitch: text, ...priv } })).id
+      return (
+        await tx.dream.create({
+          data: { title: name, pitch: text, ...priv, ...dreamFields(fields) },
+        })
+      ).id
     case 'Project':
-      return (await tx.project.create({ data: { title: name, pitch: text, ...priv } })).id
+      return (
+        await tx.project.create({
+          data: { title: name, pitch: text, ...priv, ...projectFields(fields) },
+        })
+      ).id
     case 'Facet':
       return (
-        await tx.facet.create({ data: { title: name, description: text, ...priv } })
+        await tx.facet.create({
+          data: { title: name, description: text, ...priv, ...facetFields(fields) },
+        })
       ).id
-    case 'Bot':
+    case 'Bot': {
+      const extra = botFields(fields)
       return (
         await tx.bot.create({
           data: {
             name,
             description: text,
-            BotType: 'CHATBOT',
-            botIntro: text || name,
-            userIntro: 'Hello!',
-            prompt: text || name,
+            BotType: extra.BotType ?? 'CHATBOT',
+            botIntro: extra.botIntro ?? (text || name),
+            userIntro: extra.userIntro ?? 'Hello!',
+            prompt: extra.prompt ?? (text || name),
             ...priv,
+            ...extra,
           },
         })
       ).id
+    }
     default:
       throw createError({
         statusCode: 400,
@@ -262,6 +524,7 @@ export default defineEventHandler(async (event) => {
     const text = (item.pitch || item.fieldsDraft || '').trim()
     const name =
       (item.pitch?.split('\n')[0]?.trim() || item.label || 'Untitled').slice(0, 255)
+    const fieldMap = parseFieldLines(item.fieldsDraft)
 
     // Already committed? Return the recorded target without writing again.
     if (item.idempotencyKey) {
@@ -282,8 +545,8 @@ export default defineEventHandler(async (event) => {
     // Plan the write (also the dry-run response).
     let plan:
       | { action: 'ASSET_ONLY'; targetType: SourceType; targetId: number; field: string; value: number }
-      | { action: 'UPDATE'; targetType: SourceType; targetId: number; field: string; value: string }
-      | { action: 'CREATE'; targetType: SourceType; name: string; text: string }
+      | { action: 'UPDATE'; targetType: SourceType; targetId: number; field: string; value: string; fields: string[] }
+      | { action: 'CREATE'; targetType: SourceType; name: string; text: string; fields: string[] }
 
     if (item.action === 'ASSET_ONLY') {
       if (!item.artImageId) {
@@ -312,6 +575,7 @@ export default defineEventHandler(async (event) => {
         targetId: sourceId,
         field: 'text',
         value: text,
+        fields: extraFieldKeys(sourceType, fieldMap),
       }
     } else {
       const targetType = CREATE_TARGETS[item.outputKey]
@@ -321,7 +585,13 @@ export default defineEventHandler(async (event) => {
           message: `Commit for "${item.outputKey}" is not supported yet.`,
         })
       }
-      plan = { action: 'CREATE', targetType, name, text }
+      plan = {
+        action: 'CREATE',
+        targetType,
+        name,
+        text,
+        fields: extraFieldKeys(targetType, fieldMap),
+      }
     }
 
     if (dryRun) {
@@ -366,12 +636,12 @@ export default defineEventHandler(async (event) => {
         await promoteAsset(sourceType, sourceId, plan.value)
         target = { type: sourceType, id: sourceId, created: false }
       } else if (plan.action === 'UPDATE') {
-        await updateText(sourceType, sourceId, plan.value)
+        await updateText(sourceType, sourceId, plan.value, fieldMap)
         target = { type: sourceType, id: sourceId, created: false }
       } else {
         const targetType = plan.targetType
         const created = await prisma.$transaction(async (tx) => {
-          const newId = await createRecord(tx, targetType, name, text, auth.user.id)
+          const newId = await createRecord(tx, targetType, name, text, fieldMap, auth.user.id)
           const linked = await linkSourceToTarget(
             tx,
             sourceType,

--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -32,6 +32,18 @@ const DREAM_TYPES = [
   'PITCH',
   'WISH',
 ]
+const FACET_KINDS = [
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'OTHER',
+]
 
 // Keyed by the model type (matches SourceTypeKey / the CREATE target types).
 export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
@@ -93,7 +105,7 @@ export const MODEL_FIELDS: Record<string, ModelFieldSpec[]> = {
   ],
   Facet: [
     { key: 'title', label: 'Title', required: true },
-    { key: 'kind', label: 'Kind', default: 'OTHER' },
+    { key: 'kind', label: 'Kind', default: 'OTHER', choices: FACET_KINDS },
     { key: 'description', label: 'Description', prose: true },
     { key: 'examples', label: 'Examples' },
   ],


### PR DESCRIPTION
## Summary
- The Model Builder COMMIT executor (`server/api/model-builder/items/[id]/commit.post.ts`) previously wrote only a `name` plus one freeform text field on CREATE/UPDATE, even though the FIELDS stage draft already produces model-correct `"field: value"` lines (t-024).
- Parses the drafted field lines and applies the known columns for the target model (Character, Bot, Reward, Dream, Scenario, Project, Facet), reusing `modelBuilderFields.ts`'s per-model field spec as the single source of truth: choice fields are validated against their pool, free text is length-capped to the real schema limits, and `Scenario.difficulty` is parsed as a number. Unknown draft keys are ignored — no arbitrary column writes.
- Adds missing `choices` validation for `Facet.kind` to `modelBuilderFields.ts` (it previously had no choice pool, so the AI-drafting prompt and this commit-time validator had nothing to check against).
- Dedupes the local `CREATE_TARGETS` map in `commit.post.ts` in favor of the one already exported from `modelBuilderFields.ts`.

This closes conductor `model-builder/t-028` ("Executor: persist drafted structured fields on commit").

Note: this branch also carries 3 pre-existing commits (`better test`, `fixed art enqueue`, `removed temp db test`) from an earlier session that were never turned into a PR — included here since they were already on the branch, unrelated to this change.

## Test plan
- [x] `npm run test` (vue-tsc typecheck) — passes; the only remaining errors are pre-existing and unrelated (`components/art/artjob-manager.vue`)
- [x] `npx eslint` on both changed files — clean
- [ ] Live smoke test against prod DB (tracked separately as conductor `model-builder/t-022`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VL683BfVbFiJJU4wp2ezxv


---
_Generated by [Claude Code](https://claude.ai/code/session_01VL683BfVbFiJJU4wp2ezxv)_