### PR TITLE
Restore animations to the global top layer

### DIFF
--- a/components/screenfx/animation-layer.vue
+++ b/components/screenfx/animation-layer.vue
@@ -1,10 +1,24 @@
-<!-- /components/content/animation/animation-layer.vue -->
+<!-- /components/screenfx/animation-layer.vue -->
 <template>
   <Teleport to="body">
     <Transition name="animation-layer-fade">
       <div
+        v-if="animationStore.isActive && activeComponent"
+        class="animation-effect-layer"
+        aria-hidden="true"
+      >
+        <component
+          :is="activeComponent"
+          :key="animationStore.activeEffectId"
+          class="animation-effect-layer__effect"
+        />
+      </div>
+    </Transition>
+
+    <Transition name="animation-layer-fade">
+      <div
         v-if="animationStore.isActive"
-        class="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex justify-center px-4"
+        class="animation-status-layer pointer-events-none flex justify-center px-4"
         aria-live="polite"
       >
         <div
@@ -29,16 +43,56 @@
 </template>
 
 <script setup lang="ts">
-// /components/content/animation/animation-layer.vue
-// The generation effect itself now renders through <fx-region /> surfaces
-// inside the header, sheet, page, and hand. This layer is only the status
-// pill and effect controls.
-import { useAnimationStore } from '@/stores/animationStore'
+import { computed, resolveComponent } from 'vue'
+import {
+  getAnimationComponentName,
+  useAnimationStore,
+  type AnimationEffectId,
+} from '@/stores/animationStore'
 
 const animationStore = useAnimationStore()
+
+const componentsMap = new Map<
+  AnimationEffectId,
+  ReturnType<typeof resolveComponent>
+>(
+  animationStore.effects.map((effect) => [
+    effect.id,
+    resolveComponent(getAnimationComponentName(effect.id)),
+  ]),
+)
+
+const activeComponent = computed(() => {
+  const effectId = animationStore.activeEffectId
+  if (!effectId) return null
+  return componentsMap.get(effectId) || null
+})
 </script>
 
 <style scoped>
+.animation-effect-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  overflow: hidden;
+  pointer-events: none;
+  isolation: isolate;
+}
+
+.animation-effect-layer__effect {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.animation-status-layer {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 1rem;
+  z-index: 90;
+}
+
 .animation-layer-fade-enter-active,
 .animation-layer-fade-leave-active {
   transition:

--- a/components/screenfx/animation-tester.vue
+++ b/components/screenfx/animation-tester.vue
@@ -1,13 +1,13 @@
-<!-- /components/content/screenfx/animation-tester.vue -->
+<!-- /components/screenfx/animation-tester.vue -->
 <template>
   <div
-    class="animation-tester-container bg-base-200 p-8 rounded-lg max-w-lg mx-auto"
+    class="animation-tester-container mx-auto max-w-lg rounded-2xl bg-base-200 p-8"
   >
-    <h2 class="text-4xl font-bold mb-6 text-primary">Animation Tester</h2>
+    <h2 class="mb-6 text-4xl font-bold text-primary">Animation Tester</h2>
 
-    <div class="text-lg mb-4 font-bold text-info">
+    <div class="mb-4 text-lg font-bold text-info">
       Current Animation:
-      <span v-if="isAnimating">{{ currentAnimationLabel }}</span>
+      <span v-if="animationStore.isActive">{{ currentAnimationLabel }}</span>
       <span v-else>None</span>
     </div>
 
@@ -18,10 +18,11 @@
         class="btn text-white"
         :class="{
           'bg-secondary hover:bg-secondary-focus':
-            currentAnimation !== effect.id,
+            animationStore.activeEffectId !== effect.id,
           'bg-primary hover:bg-primary-focus':
-            currentAnimation === effect.id && isAnimating,
+            animationStore.activeEffectId === effect.id && animationStore.isActive,
         }"
+        type="button"
         @click="startAnimation(effect.id)"
       >
         Start {{ effect.label }} Animation
@@ -30,7 +31,8 @@
 
     <div class="mt-6">
       <button
-        class="btn bg-accent hover:bg-accent-focus text-white"
+        class="btn bg-accent text-white hover:bg-accent-focus"
+        type="button"
         @click="startRandomAnimation"
       >
         Start Random Animation
@@ -39,96 +41,56 @@
 
     <div class="mt-6">
       <button
-        class="btn bg-error hover:bg-error-focus text-white"
-        @click="stopAnimation"
+        class="btn bg-error text-white hover:bg-error-focus"
+        type="button"
+        @click="animationStore.stop()"
       >
         Stop Animation
       </button>
-    </div>
-
-    <div v-if="errorMessage" class="mt-6 text-error text-lg font-semibold">
-      {{ errorMessage }}
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
-import { useDisplayStore } from '@/stores/displayStore'
-import { useErrorStore, ErrorType } from '@/stores/errorStore'
-import type { EffectId } from '@/stores/displayStore'
+import { computed } from 'vue'
+import {
+  useAnimationStore,
+  type AnimationEffectId,
+} from '@/stores/animationStore'
 
-const displayStore = useDisplayStore()
-const errorStore = useErrorStore()
+const animationStore = useAnimationStore()
 
-const errorMessage = ref<string | null>(null)
+const effects = computed(() => animationStore.safeEffects)
 
-const effects = ref<Array<{ id: EffectId; label: string }>>([
-  { id: 'bubble-effect', label: 'Bubble Fiesta' },
-  { id: 'fizzy-bubbles', label: 'Fizzy Lifting' },
-  { id: 'rain-effect', label: 'Rainmaker' },
-  { id: 'butterfly-animation', label: 'Butterfly Scouts' },
-])
-
-const isAnimating = computed(() => displayStore.isAnimating)
-const currentAnimation = computed(() => displayStore.currentAnimation)
 const currentAnimationLabel = computed(() => {
-  const effect = effects.value.find((e) => e.id === currentAnimation.value)
-  return effect ? effect.label : 'None'
+  return animationStore.activeEffect?.label || 'None'
 })
 
-watch(
-  () => errorStore.getError,
-  (newError) => {
-    if (newError) {
-      errorMessage.value = `Error: ${newError}`
-    } else {
-      errorMessage.value = null
-    }
-  },
-)
+function startAnimation(effectId: AnimationEffectId): void {
+  const effect = effects.value.find((entry) => entry.id === effectId)
+  if (!effect) return
 
-const startAnimation = (animationId: EffectId) => {
-  try {
-    displayStore.toggleAnimationById(animationId)
-  } catch (error) {
-    reportError('Failed to start the animation', error)
-  }
+  animationStore.start({
+    effectId,
+    message: `${effect.label} test`,
+    durationMs: null,
+  })
 }
 
-const startRandomAnimation = () => {
-  try {
-    displayStore.toggleRandomAnimation()
-  } catch (error) {
-    reportError('Failed to start a random animation', error)
-  }
-}
+function startRandomAnimation(): void {
+  const available = effects.value
+  if (!available.length) return
 
-const stopAnimation = () => {
-  try {
-    displayStore.stopAnimation()
-  } catch (error) {
-    reportError('Failed to stop the animation', error)
-  }
-}
+  const effect = available[Math.floor(Math.random() * available.length)]
+  if (!effect) return
 
-const reportError = (contextMessage: string, error: unknown) => {
-  const message = error instanceof Error ? error.message : 'Unknown error'
-  errorStore.setError(ErrorType.GENERAL_ERROR, `${contextMessage}: ${message}`)
+  startAnimation(effect.id)
 }
 </script>
 
 <style scoped>
 .animation-tester-container {
-  padding: 2rem;
-  background-color: var(--bg-base-200);
-  border-radius: 0.5rem;
   max-width: 400px;
-  margin: auto;
-}
-
-.text-error {
-  color: var(--error);
 }
 
 .btn {

--- a/components/screenfx/fx-region.vue
+++ b/components/screenfx/fx-region.vue
@@ -65,33 +65,19 @@ interface SurfaceEntry {
 }
 
 function entriesForPlacement(placement: FxPlacement): SurfaceEntry[] {
+  if (!animationStore.screenSurfaces[props.region][placement]) return []
+
   const entries: SurfaceEntry[] = []
   const seen = new Set<AnimationEffectId>()
 
-  if (animationStore.screenSurfaces[props.region][placement]) {
-    animationStore.screenEffects.forEach((effect) => {
-      const component = componentsMap.get(effect.id)
+  animationStore.screenEffects.forEach((effect) => {
+    const component = componentsMap.get(effect.id)
 
-      if (!component || seen.has(effect.id)) return
+    if (!component || seen.has(effect.id)) return
 
-      seen.add(effect.id)
-      entries.push({ key: `fx-${effect.id}`, id: effect.id, component })
-    })
-  }
-
-  const generationActive =
-    animationStore.isActive &&
-    animationStore.activeEffectId &&
-    animationStore.generationSurfaces[props.region][placement]
-
-  if (generationActive && animationStore.activeEffectId) {
-    const id = animationStore.activeEffectId
-    const component = componentsMap.get(id)
-
-    if (component && !seen.has(id)) {
-      entries.push({ key: `gen-${id}`, id, component })
-    }
-  }
+    seen.add(effect.id)
+    entries.push({ key: `fx-${effect.id}`, id: effect.id, component })
+  })
 
   return entries
 }

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -33,6 +33,8 @@ import {
 import { useAnimationPreferenceStore } from '@/stores/animationPreferenceStore'
 import { useButterflyStore } from '@/stores/butterflyStore'
 
+defineOptions({ inheritAttrs: false })
+
 const animationStore = useAnimationStore()
 const preferenceStore = useAnimationPreferenceStore()
 const butterflyStore = useButterflyStore()

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -1,17 +1,19 @@
 <!-- /components/screenfx/startup-animation.vue -->
 <template>
-  <div
-    v-if="renderEffect && currentComponent"
-    class="startup-animation"
-    :class="{ 'startup-animation--fading': isFading }"
-    aria-hidden="true"
-  >
-    <component
-      :is="currentComponent"
-      :key="resolvedEffectId"
-      class="startup-animation__effect"
-    />
-  </div>
+  <Teleport to="body">
+    <div
+      v-if="renderEffect && currentComponent"
+      class="startup-animation"
+      :class="{ 'startup-animation--fading': isFading }"
+      aria-hidden="true"
+    >
+      <component
+        :is="currentComponent"
+        :key="resolvedEffectId"
+        class="startup-animation__effect"
+      />
+    </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -115,13 +117,12 @@ onBeforeUnmount(() => {
 .startup-animation {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 100;
   overflow: hidden;
   pointer-events: none;
   opacity: 1;
   transition: opacity 650ms ease;
-  transform: translateZ(0);
-  contain: layout paint style;
+  isolation: isolate;
   will-change: opacity;
 }
 


### PR DESCRIPTION
## What broke
There were two separate regressions:

1. Animation previews and generation effects were routed through `<fx-region>` containers inside the workspace. Those containers sit inside header/page/sheet/hand stacking contexts, so even a local `z-index: 50` could not rise above the loader, narrator, footer, or other app chrome.
2. `animation-tester.vue` was still driving the retired `displayStore` animation state. Nothing renders that state anymore, so its buttons changed state without producing an effect.

Startup rendering also depended on wrapper fallthrough classes rather than owning a guaranteed viewport layer.

## Fix
- Render the active preview/generation effect once through the body-teleported `animation-layer`.
- Give the effect and status controls explicit global z-index layers.
- Stop duplicating active generation effects through regional `<fx-region>` surfaces; those remain responsible for persistent Screen FX placement only.
- Teleport the startup animation directly to `body` and pin it above the loader/app chrome.
- Route the Animation Tester through the centralized animation catalog/store and remove its orphaned `bubble-effect` legacy path.

## Expected behavior
- Startup animation is visible during boot.
- Animation Preferences → Preview renders across the viewport above workspace chrome.
- Animation Tester buttons render the selected live catalog effect.
- Art-generation effects use the same global layer.
- Persistent Screen FX still clip correctly when assigned to header/sheet/page/hand.

## Verification
- Branch is based on current `main` (`51dec65`).
- Vercel preview/type-build checks are running.

The change is isolated to Screen FX components and does not touch database or error-reporting code.