### PR TITLE
Accept stored user API keys across shared API auth guards

### DIFF
--- a/cypress/e2e/api/api-key-auth.cy.ts
+++ b/cypress/e2e/api/api-key-auth.cy.ts
@@ -11,10 +11,21 @@ type CypressApiKeyEnv = {
   BASE_API_URL?: string
 }
 
+type CurrentUserResponse = {
+  success: boolean
+  data?: {
+    id?: number
+    Role?: string
+    isAdmin?: boolean
+    authKind?: string
+  }
+}
+
 describe('Stored user API key authentication', () => {
   let apiBase = defaultApiBase
   let userApiKey = ''
   let adminApiKey = ''
+  let userId = 0
 
   before(() => {
     cy.env([
@@ -32,25 +43,51 @@ describe('Stored user API key authentication', () => {
         adminApiKey,
         'CYPRESS_BETA_ADMIN_TOKEN or CYPRESS_ADMIN_TOKEN admin apiKey',
       ).to.not.be.empty
+
+      return cy
+        .request<CurrentUserResponse>({
+          url: `${apiBase}/users/me`,
+          headers: apiKeyHeaders(userApiKey),
+          failOnStatusCode: false,
+        })
+        .then((response) => {
+          expect(response.status, JSON.stringify(response.body)).to.eq(200)
+          userId = Number(response.body.data?.id || 0)
+          expect(userId, 'test-user id').to.be.greaterThan(0)
+        })
     })
   })
 
   it('accepts a normal user apiKey through x-api-key', () => {
-    cy.request({
-      url: `${apiBase}/projects?mine=true&includeInactive=true`,
+    cy.request<CurrentUserResponse>({
+      url: `${apiBase}/users/me`,
       headers: apiKeyHeaders(userApiKey),
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status, JSON.stringify(response.body)).to.eq(200)
       expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
-      expect(response.body.data).to.be.an('array')
+      expect(response.body.data?.id).to.eq(userId)
+      expect(response.body.data?.authKind).to.eq('user-api-key')
+      expect(response.body.data?.isAdmin).to.eq(false)
     })
   })
 
   it('accepts a normal user apiKey through Bearer authentication', () => {
-    cy.request({
-      url: `${apiBase}/projects?mine=true&includeInactive=true`,
+    cy.request<CurrentUserResponse>({
+      url: `${apiBase}/users/me`,
       headers: bearerHeaders(userApiKey),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.data?.id).to.eq(userId)
+      expect(response.body.data?.authKind).to.eq('user-api-key')
+    })
+  })
+
+  it('accepts the same apiKey in legacy validateApiKey routes', () => {
+    cy.request({
+      url: `${apiBase}/mana/${userId}`,
+      headers: apiKeyHeaders(userApiKey),
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status, JSON.stringify(response.body)).to.eq(200)
@@ -82,12 +119,11 @@ describe('Stored user API key authentication', () => {
 
   it('rejects an unknown apiKey', () => {
     cy.request({
-      url: `${apiBase}/projects?mine=true`,
+      url: `${apiBase}/users/me`,
       headers: apiKeyHeaders('invalid-cypress-api-key'),
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status, JSON.stringify(response.body)).to.eq(401)
-      expect(response.body.success, JSON.stringify(response.body)).to.eq(false)
     })
   })
 })

--- a/cypress/e2e/api/api-key-auth.cy.ts
+++ b/cypress/e2e/api/api-key-auth.cy.ts
@@ -1,0 +1,93 @@
+import {
+  apiKeyHeaders,
+  bearerHeaders,
+  defaultApiBase,
+} from '../../support/api-auth'
+
+type CypressApiKeyEnv = {
+  API_KEY?: string
+  BETA_ADMIN_TOKEN?: string
+  ADMIN_TOKEN?: string
+  BASE_API_URL?: string
+}
+
+describe('Stored user API key authentication', () => {
+  let apiBase = defaultApiBase
+  let userApiKey = ''
+  let adminApiKey = ''
+
+  before(() => {
+    cy.env([
+      'API_KEY',
+      'BETA_ADMIN_TOKEN',
+      'ADMIN_TOKEN',
+      'BASE_API_URL',
+    ]).then((env: CypressApiKeyEnv) => {
+      apiBase = String(env.BASE_API_URL || defaultApiBase).replace(/\/+$/, '')
+      userApiKey = String(env.API_KEY || '')
+      adminApiKey = String(env.ADMIN_TOKEN || env.BETA_ADMIN_TOKEN || '')
+
+      expect(userApiKey, 'CYPRESS_API_KEY user apiKey').to.not.be.empty
+      expect(
+        adminApiKey,
+        'CYPRESS_BETA_ADMIN_TOKEN or CYPRESS_ADMIN_TOKEN admin apiKey',
+      ).to.not.be.empty
+    })
+  })
+
+  it('accepts a normal user apiKey through x-api-key', () => {
+    cy.request({
+      url: `${apiBase}/projects?mine=true&includeInactive=true`,
+      headers: apiKeyHeaders(userApiKey),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+      expect(response.body.data).to.be.an('array')
+    })
+  })
+
+  it('accepts a normal user apiKey through Bearer authentication', () => {
+    cy.request({
+      url: `${apiBase}/projects?mine=true&includeInactive=true`,
+      headers: bearerHeaders(userApiKey),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+    })
+  })
+
+  it('does not elevate a normal user apiKey to admin', () => {
+    cy.request({
+      url: `${apiBase}/server/uptime?window=1&samples=1`,
+      headers: apiKeyHeaders(userApiKey),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(403)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(false)
+    })
+  })
+
+  it('derives admin authority from the admin account apiKey', () => {
+    cy.request({
+      url: `${apiBase}/server/uptime?window=1&samples=1`,
+      headers: apiKeyHeaders(adminApiKey),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+    })
+  })
+
+  it('rejects an unknown apiKey', () => {
+    cy.request({
+      url: `${apiBase}/projects?mine=true`,
+      headers: apiKeyHeaders('invalid-cypress-api-key'),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(401)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(false)
+    })
+  })
+})

--- a/cypress/support/api-auth.ts
+++ b/cypress/support/api-auth.ts
@@ -60,14 +60,16 @@ export const bearerHeaders = (token: string) => ({
 
 export const invalidBearerHeaders = () => bearerHeaders('invalid-cypress-token')
 
-export const adminHeaders = (token: string) => ({
+export const apiKeyHeaders = (token: string) => ({
   ...jsonHeaders(),
-  [adminTokenHeaderName]: token,
-  [betaAdminTokenHeaderName]: token,
   [apiKeyHeaderName]: token,
 })
 
-export const apiKeyHeaders = (token: string) => adminHeaders(token)
+export const adminHeaders = (token: string) => ({
+  ...apiKeyHeaders(token),
+  [adminTokenHeaderName]: token,
+  [betaAdminTokenHeaderName]: token,
+})
 
 const bodyNumber = (value: unknown): number | undefined => {
   const parsed = Number(value)

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -22,6 +22,10 @@ function readBearerToken(event: H3Event): string {
     .trim()
 }
 
+function readUserApiKey(event: H3Event): string {
+  return (getHeader(event, 'x-api-key') || readBearerToken(event)).trim()
+}
+
 function readBetaAdminToken(event: H3Event): string {
   return (
     getHeader(event, 'x-beta-admin-token') ||
@@ -58,16 +62,8 @@ async function getUserById(id: number): Promise<AuthUser | null> {
 async function validateJwtAuth(token: string): Promise<AuthGuardResult | null> {
   if (!token) return null
 
-  // Only attempt JWT verification on a JWT-shaped token (header.payload.sig).
-  // A user apiKey or beta-admin token is not a JWT; running it through the JWT
-  // verifier just logs a noisy "Operation failed" and — critically — must not
-  // prevent the apiKey/beta-admin fallbacks in requireMachineUser from running.
   if (token.split('.').length !== 3) return null
 
-  // An expired or otherwise invalid JWT is NOT fatal here: it simply means "not
-  // authenticated via JWT". Swallow any throw so requireMachineUser can fall
-  // through to the apiKey / beta-admin token instead of surfacing a 500/JWT
-  // error to a machine caller that also holds a valid long-lived credential.
   let verification: Awaited<ReturnType<typeof verifyJwtToken>>
   try {
     verification = await verifyJwtToken(token)
@@ -131,26 +127,20 @@ async function validateUserApiKeyAuth(
 export async function getOptionalApiUser(
   event: H3Event,
 ): Promise<AuthGuardResult | null> {
-  const token = readBearerToken(event)
+  const bearerToken = readBearerToken(event)
+  const userApiKey = readUserApiKey(event)
 
-  return (await validateJwtAuth(token)) ?? (await validateBetaAdminAuth(event))
+  return (
+    (await validateJwtAuth(bearerToken)) ??
+    (await validateUserApiKeyAuth(userApiKey)) ??
+    (await validateBetaAdminAuth(event))
+  )
 }
 
-/**
- * Machine-friendly variant of requireApiUser: accepts a session JWT, a
- * long-lived user apiKey (parity with /api/art/generate and textGate), or
- * the beta admin token. For automation callers (conductor scripts, the home
- * relay agent) that hold static credentials rather than browser sessions.
- */
 export async function requireMachineUser(
   event: H3Event,
 ): Promise<AuthGuardResult> {
-  const token = readBearerToken(event)
-
-  const auth =
-    (await validateJwtAuth(token)) ??
-    (await validateUserApiKeyAuth(token)) ??
-    (await validateBetaAdminAuth(event))
+  const auth = await getOptionalApiUser(event)
 
   if (!auth) {
     throw createError({

--- a/server/utils/validateKey.ts
+++ b/server/utils/validateKey.ts
@@ -7,7 +7,7 @@ import { userIsAdmin } from './authUser'
 export type ValidateResult = {
   isValid: boolean
   user?: { id: number; Role: string }
-  kind?: 'jwt' | 'beta-admin-token' | 'server'
+  kind?: 'jwt' | 'user-api-key' | 'beta-admin-token' | 'server'
 }
 
 const config = useRuntimeConfig()
@@ -23,10 +23,10 @@ function cleanToken(value?: string | null): string {
 
 function readRequestToken(event: H3Event): string {
   return cleanToken(
-    getHeader(event, 'authorization') ||
+    getHeader(event, 'x-api-key') ||
       getHeader(event, 'x-beta-admin-token') ||
       getHeader(event, 'x-admin-token') ||
-      getHeader(event, 'x-api-key'),
+      getHeader(event, 'authorization'),
   )
 }
 
@@ -62,20 +62,43 @@ async function getAuthUser(id: number) {
 async function validateJwtString(
   token: string,
 ): Promise<ValidateResult | null> {
+  if (!token || token.split('.').length !== 3) return null
+
+  try {
+    const verification = await verifyJwtToken(token)
+
+    if (!verification.success || !verification.userId) return null
+
+    const user = await getAuthUser(verification.userId)
+
+    if (!user) return null
+
+    return {
+      isValid: true,
+      user: { id: user.id, Role: user.Role },
+      kind: 'jwt',
+    }
+  } catch {
+    return null
+  }
+}
+
+async function validateUserApiKeyString(
+  token: string,
+): Promise<ValidateResult | null> {
   if (!token) return null
 
-  const verification = await verifyJwtToken(token)
+  const user = await prisma.user.findFirst({
+    where: { apiKey: token },
+    select: { id: true, Role: true, isActive: true },
+  })
 
-  if (!verification.success || !verification.userId) return null
-
-  const user = await getAuthUser(verification.userId)
-
-  if (!user) return null
+  if (!user || !user.isActive) return null
 
   return {
     isValid: true,
     user: { id: user.id, Role: user.Role },
-    kind: 'jwt',
+    kind: 'user-api-key',
   }
 }
 
@@ -103,8 +126,9 @@ export async function validateApiKeyString(
   const clean = cleanToken(token)
 
   return (
-    (await validateBetaAdminString(clean)) ??
-    (await validateJwtString(clean)) ?? {
+    (await validateJwtString(clean)) ??
+    (await validateUserApiKeyString(clean)) ??
+    (await validateBetaAdminString(clean)) ?? {
       isValid: false,
     }
   )


### PR DESCRIPTION
## Why

The Cypress repository secrets now contain real `User.apiKey` values:

- `CYPRESS_API_KEY` → a normal test-user account apiKey
- `CYPRESS_BETA_ADMIN_TOKEN` → Silas's admin-account apiKey

Those values are intentionally not JWTs and are not the configured global beta-admin secret.

The backend currently accepts a stored user apiKey only in `requireMachineUser()` and only when it arrives as `Authorization: Bearer`. Most application endpoints use `requireApiUser()`, while Cypress admin helpers send the credential as `x-api-key`. That leaves valid database-backed apiKeys rejected or misclassified.

## Fix

- Read stored user apiKeys from `x-api-key`, falling back to `Authorization: Bearer`.
- Resolve user apiKeys in `getOptionalApiUser()`, so `requireApiUser()`, `requireMachineUser()`, and `requireAdminApiUser()` share one credential contract.
- Derive permissions from the matched user's actual database role. A normal account apiKey remains non-admin; an admin account apiKey satisfies admin guards.
- Preserve compatibility with session JWTs and the configured legacy beta-admin token.
- Make Cypress `apiKeyHeaders()` send only the actual API-key header; `adminHeaders()` retains legacy admin headers while also sending `x-api-key`.

## Contract coverage

New production Cypress coverage verifies:

- normal user apiKey through `x-api-key`
- normal user apiKey through Bearer
- normal user apiKey receives 403 from an admin-only endpoint
- admin account apiKey receives 200 from the same endpoint
- unknown apiKey receives 401

No secret rename is required for this repair. The existing GitHub secret names remain backward-compatible labels; their values are treated as account apiKeys.