### PR TITLE
challenge-center/t-014: prompt-variant generator using random lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "trim": "node utils/scripts/trim.mjs",
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
+    "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
     "vercel-build": "prisma generate && node scripts/prisma-migrate-deploy.mjs && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
     "dev": "nuxt dev --host",
     "build": "nuxi prepare && prisma generate && nuxi build",

--- a/server/api/challenges/variants.post.ts
+++ b/server/api/challenges/variants.post.ts
@@ -1,0 +1,111 @@
+// /server/api/challenges/variants.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { validateApiKey } from '~/server/utils/validateKey'
+import {
+  basicSinglePools,
+  dreamToRandomListItem,
+} from '@/stores/helpers/randomHelper'
+import {
+  generatePromptVariants,
+  extractPlaceholderKeys,
+  normalizeVariantKey,
+} from '~/server/utils/promptVariants'
+
+type VariantsBody = {
+  basePrompt?: unknown
+  count?: unknown
+}
+
+const MAX_VARIANT_COUNT = 50
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await validateApiKey(event)
+
+    if (!auth.isValid || !auth.user) {
+      throw createError({
+        statusCode: 401,
+        message: 'Authentication required.',
+      })
+    }
+
+    const body = await readBody<VariantsBody>(event)
+
+    if (
+      !body ||
+      typeof body.basePrompt !== 'string' ||
+      !body.basePrompt.trim()
+    ) {
+      throw createError({ statusCode: 400, message: 'basePrompt is required.' })
+    }
+
+    const count = Number(body.count ?? 1)
+
+    if (!Number.isInteger(count) || count < 1 || count > MAX_VARIANT_COUNT) {
+      throw createError({
+        statusCode: 400,
+        message: `count must be an integer between 1 and ${MAX_VARIANT_COUNT}.`,
+      })
+    }
+
+    const basePrompt = body.basePrompt.trim()
+    const keys = extractPlaceholderKeys(basePrompt)
+
+    if (keys.length === 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'basePrompt must contain at least one {{placeholder}}.',
+      })
+    }
+
+    const builtInPools = new Map(
+      basicSinglePools.map((pool) => [
+        normalizeVariantKey(pool.key),
+        [...pool.values],
+      ]),
+    )
+
+    const customKeys = keys.filter((key) => !builtInPools.has(key))
+
+    const randomListPools = new Map<string, string[]>()
+
+    if (customKeys.length > 0) {
+      const dreams = await prisma.dream.findMany({
+        where: {
+          // RANDOMLIST is a virtual/legacy dream type stored as BRAINSTORM in the DB
+          // (see LEGACY_DREAM_TYPE_MAP in stores/helpers/dreamHelper.ts).
+          dreamType: 'BRAINSTORM',
+          isActive: true,
+          OR: [{ isPublic: true }, { userId: auth.user.id }],
+        },
+        orderBy: { updatedAt: 'asc' },
+      })
+
+      for (const dream of dreams) {
+        const item = dreamToRandomListItem(dream)
+        randomListPools.set(normalizeVariantKey(item.title), item.content)
+      }
+    }
+
+    const variants = generatePromptVariants(
+      basePrompt,
+      count,
+      (key) => builtInPools.get(key) ?? randomListPools.get(key),
+    )
+
+    return {
+      success: true,
+      message: 'Prompt variants generated successfully.',
+      data: { basePrompt, count, variants },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/utils/promptVariants.ts
+++ b/server/utils/promptVariants.ts
@@ -1,0 +1,90 @@
+// /server/utils/promptVariants.ts
+
+export type PromptVariant = {
+  variantKey: string
+  promptUsed: string
+  randomSelections: Record<string, string>
+}
+
+export type VariantPoolProvider = (key: string) => string[] | undefined
+
+const PLACEHOLDER_PATTERN = /\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/g
+
+/** Normalizes a placeholder key or a random-list title for matching: lowercase, letters/digits only. */
+export function normalizeVariantKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+/** Extracts the distinct `{{key}}` placeholder keys from a base prompt, normalized and de-duplicated. */
+export function extractPlaceholderKeys(basePrompt: string): string[] {
+  const keys = new Set<string>()
+  for (const match of basePrompt.matchAll(PLACEHOLDER_PATTERN)) {
+    keys.add(normalizeVariantKey(match[1]!))
+  }
+  return [...keys]
+}
+
+function defaultPickRandom(values: string[]): string {
+  return values[Math.floor(Math.random() * values.length)]!
+}
+
+function substitutePlaceholder(
+  prompt: string,
+  key: string,
+  value: string,
+): string {
+  const pattern = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'gi')
+  return prompt.replace(pattern, value)
+}
+
+/**
+ * Generates `count` concrete prompt variants from a base prompt containing `{{key}}`
+ * placeholders, substituting each occurrence from the pool `getPool(key)` returns.
+ * Every variant records its `randomSelections` map so the roll is auditable and
+ * reproducible, not a mystery substitution (challenge-center/t-014).
+ */
+export function generatePromptVariants(
+  basePrompt: string,
+  count: number,
+  getPool: VariantPoolProvider,
+  pickRandom: (values: string[]) => string = defaultPickRandom,
+): PromptVariant[] {
+  const trimmed = basePrompt.trim()
+  if (!trimmed) {
+    throw new Error('basePrompt must be a non-empty string.')
+  }
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error('count must be a positive integer.')
+  }
+
+  const keys = extractPlaceholderKeys(trimmed)
+  if (keys.length === 0) {
+    throw new Error('basePrompt must contain at least one {{placeholder}}.')
+  }
+
+  const pools = new Map<string, string[]>()
+  for (const key of keys) {
+    const values = getPool(key)
+    if (!values || values.length === 0) {
+      throw new Error(`No random pool found for placeholder "${key}".`)
+    }
+    pools.set(key, values)
+  }
+
+  const variants: PromptVariant[] = []
+  for (let i = 1; i <= count; i++) {
+    const randomSelections: Record<string, string> = {}
+    let promptUsed = trimmed
+    for (const key of keys) {
+      const value = pickRandom(pools.get(key)!)
+      randomSelections[key] = value
+      promptUsed = substitutePlaceholder(promptUsed, key, value)
+    }
+    variants.push({ variantKey: `random-${i}`, promptUsed, randomSelections })
+  }
+
+  return variants
+}

--- a/utils/scripts/verifyPromptVariants.ts
+++ b/utils/scripts/verifyPromptVariants.ts
@@ -1,0 +1,74 @@
+// /utils/scripts/verifyPromptVariants.ts
+import assert from 'node:assert/strict'
+import {
+  extractPlaceholderKeys,
+  generatePromptVariants,
+  normalizeVariantKey,
+} from '../../server/utils/promptVariants'
+
+// normalizeVariantKey
+assert.equal(normalizeVariantKey('Sci-Fi Weapons'), 'scifiweapons')
+assert.equal(normalizeVariantKey('  Adjective  '), 'adjective')
+assert.equal(normalizeVariantKey('cow_core'), 'cowcore')
+
+// extractPlaceholderKeys
+assert.deepEqual(
+  extractPlaceholderKeys('A {{adjective}} {{animal}} in a {{adjective}} hat'),
+  ['adjective', 'animal'],
+)
+assert.deepEqual(extractPlaceholderKeys('{{ Sci-Fi_Weapons }}'), [
+  'scifiweapons',
+])
+assert.deepEqual(extractPlaceholderKeys('no placeholders here'), [])
+
+// generatePromptVariants — validation
+assert.throws(
+  () => generatePromptVariants('', 3, () => ['a']),
+  /non-empty string/,
+)
+assert.throws(
+  () => generatePromptVariants('a {{x}} prompt', 0, () => ['a']),
+  /positive integer/,
+)
+assert.throws(
+  () => generatePromptVariants('no placeholders', 3, () => ['a']),
+  /at least one/,
+)
+assert.throws(
+  () => generatePromptVariants('a {{missing}} prompt', 3, () => undefined),
+  /No random pool found for placeholder "missing"/,
+)
+
+// generatePromptVariants — deterministic pickRandom, always first pool element
+const pools: Record<string, string[]> = {
+  adjective: ['fierce', 'gentle'],
+  animal: ['fox', 'owl'],
+}
+const variants = generatePromptVariants(
+  'A {{adjective}} {{animal}} guards a {{adjective}} tower.',
+  3,
+  (key) => pools[key],
+  (values) => values[0]!,
+)
+
+assert.equal(variants.length, 3)
+for (let i = 0; i < variants.length; i++) {
+  assert.equal(variants[i]!.variantKey, `random-${i + 1}`)
+  assert.equal(variants[i]!.promptUsed, 'A fierce fox guards a fierce tower.')
+  assert.deepEqual(variants[i]!.randomSelections, {
+    adjective: 'fierce',
+    animal: 'fox',
+  })
+}
+
+// Case-insensitive / whitespace-tolerant placeholder matching, and repeated keys
+// all resolve to the same rolled value within one variant.
+const singleVariant = generatePromptVariants(
+  '{{ Animal }} meets {{animal}} meets {{ANIMAL}}',
+  1,
+  () => ['owl'],
+)
+assert.equal(singleVariant[0]!.promptUsed, 'owl meets owl meets owl')
+assert.deepEqual(singleVariant[0]!.randomSelections, { animal: 'owl' })
+
+console.log('Prompt variant generation verified.')


### PR DESCRIPTION
## Summary
- Adds `server/utils/promptVariants.ts` (`generatePromptVariants`), a pure resolver that expands a base prompt's `{{key}}` placeholders into N concrete variants, substituting from a supplied pool provider. Every variant carries its `randomSelections` map so rolls stay auditable/reproducible.
- Adds `POST /api/challenges/variants`, which wires the resolver to the built-in `randomHelper.ts` pools (adjective, animal, species, ...) and, for placeholder keys that aren't built-in, a Prisma lookup of RANDOMLIST dreams (stored as `dreamType: BRAINSTORM`, per `LEGACY_DREAM_TYPE_MAP`) visible to the requesting user (public or own), matched by normalized title.
- Adds `utils/scripts/verifyPromptVariants.ts` (assert-based, matches the existing `verifyFacetAliases.ts` convention) and wires it up as `npm run test:prompt-variants`.

This implements conductor `challenge-center/t-014`: the conductor matchup runner (`t-013`) can consume this endpoint to enter one contender N times with `variantKey` `"random-1"`.."random-N"`, each backed by an auditable `randomSelections` map for storage on the submission (`t-002`).

## Test plan
- [x] `npx tsx utils/scripts/verifyPromptVariants.ts` — passes
- [x] `npm test` (vue-tsc `--noEmit`) — no new errors; the 3 pre-existing errors are in unrelated files (`server/api/art/image/index.get.ts`, `server/api/model-builder/items/[id]/commit.post.ts`) untouched by this PR
- [x] `npx eslint` on the changed files — clean
- [x] `npx prettier --check` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GA2PsSkNQkkL6JAm8nCfvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GA2PsSkNQkkL6JAm8nCfvZ)_