### PR TITLE
Separate Cypress traffic from production errors

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -98,6 +98,8 @@ jobs:
           CYPRESS_API_KEY: ${{ secrets.CYPRESS_API_KEY }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_TIMING_LOG: '1'
+          CYPRESS_SYNTHETIC_SOURCE: github-actions-cypress
+          CYPRESS_SYNTHETIC_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Upload Cypress diagnostic reports
         if: always()

--- a/cypress/e2e/api/art.cy.ts
+++ b/cypress/e2e/api/art.cy.ts
@@ -139,7 +139,6 @@ describe('ArtImage Management API Tests', () => {
       url: artGenerateUrl,
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
         Authorization: `Bearer ${invalidToken}`,
       },
       body: {
@@ -164,7 +163,6 @@ describe('ArtImage Management API Tests', () => {
       url: artGenerateUrl,
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
         Authorization: `Bearer ${userToken}`,
       },
       timeout: 120000,
@@ -177,7 +175,7 @@ describe('ArtImage Management API Tests', () => {
         cfg: 3,
         cfgHalf: false,
         seed: -1,
-        userId: adminUserId,
+        userId,
         serverId: lolaTestServerId,
         checkpoint: 'realcartoonPony_v1.safetensors',
         sampler: 'Euler',
@@ -209,7 +207,6 @@ describe('ArtImage Management API Tests', () => {
       url: `${artImageUrl}/${fixtureArtImageId}`,
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
         Authorization: `Bearer ${userToken}`,
       },
       failOnStatusCode: false,
@@ -354,7 +351,6 @@ describe('ArtImage Management API Tests', () => {
       url: `${artImageUrl}/${fixtureArtImageId}`,
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': apiKey,
         Authorization: `Bearer ${userToken}`,
       },
       failOnStatusCode: false,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -9,6 +9,66 @@ export type CleanupRequest = {
   expectedStatuses?: number[]
 }
 
+type RequestOptionsLike = Record<string, unknown> & {
+  headers?: Record<string, string>
+}
+
+type CurrentTestLike = {
+  title?: string
+  titlePath?: string[]
+}
+
+const httpMethods = new Set([
+  'CONNECT',
+  'DELETE',
+  'GET',
+  'HEAD',
+  'OPTIONS',
+  'PATCH',
+  'POST',
+  'PUT',
+  'TRACE',
+])
+
+const cleanHeaderValue = (value: unknown, maxLength = 220) =>
+  String(value ?? '')
+    .replace(/[^\x20-\x7E]/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+
+const syntheticTestHeaders = () => {
+  const currentTest = Cypress.currentTest as CurrentTestLike | undefined
+  const titlePath = Array.isArray(currentTest?.titlePath)
+    ? currentTest.titlePath.join(' > ')
+    : currentTest?.title
+
+  const headers: Record<string, string> = {
+    'x-kindrobots-test-source': cleanHeaderValue(
+      Cypress.env('SYNTHETIC_SOURCE') || 'cypress',
+    ),
+    'x-kindrobots-test-run-id': cleanHeaderValue(
+      Cypress.env('SYNTHETIC_RUN_ID') || 'local-cypress',
+    ),
+    'x-kindrobots-test-spec': cleanHeaderValue(
+      Cypress.spec.relative || Cypress.spec.name || 'unknown-spec',
+    ),
+  }
+
+  if (titlePath) {
+    headers['x-kindrobots-test-name'] = cleanHeaderValue(titlePath)
+  }
+
+  return headers
+}
+
+const withSyntheticHeaders = (options: RequestOptionsLike) => ({
+  ...options,
+  headers: {
+    ...(options.headers || {}),
+    ...syntheticTestHeaders(),
+  },
+})
+
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -16,6 +76,45 @@ declare global {
     }
   }
 }
+
+// cy.request runs from Cypress's Node process, so browser interceptors cannot tag
+// it. Overwrite every supported request overload to add searchable synthetic-test
+// metadata to production requests without changing individual specs.
+;(Cypress.Commands.overwrite as any)(
+  'request',
+  (originalFn: (...args: any[]) => unknown, ...args: any[]) => {
+    const [first, second, third] = args
+
+    if (first && typeof first === 'object' && !Array.isArray(first)) {
+      return originalFn(withSyntheticHeaders(first as RequestOptionsLike))
+    }
+
+    if (
+      typeof first === 'string' &&
+      typeof second === 'string' &&
+      httpMethods.has(first.toUpperCase())
+    ) {
+      return originalFn(
+        withSyntheticHeaders({
+          method: first,
+          url: second,
+          ...(third === undefined ? {} : { body: third }),
+        }),
+      )
+    }
+
+    if (typeof first === 'string') {
+      return originalFn(
+        withSyntheticHeaders({
+          url: first,
+          ...(second === undefined ? {} : { body: second }),
+        }),
+      )
+    }
+
+    return originalFn(...args)
+  },
+)
 
 Cypress.Commands.add('registerApiCleanup', (request: CleanupRequest) => {
   return cy.task('cypressCleanup:register', request, { log: false })

--- a/cypress/support/cypress-seed/api-seed-node.ts
+++ b/cypress/support/cypress-seed/api-seed-node.ts
@@ -34,6 +34,7 @@ const defaultApiBase = 'https://kind-robots.vercel.app/api'
 const defaultTestPassword = 'testtest12'
 const seedDir = path.resolve('.cypress-cache')
 const seedFile = path.join(seedDir, 'api-seed.json')
+const localSyntheticRunId = `local-node-${Date.now()}-${process.pid}`
 
 let memorySeed: CypressApiSeedState | undefined
 
@@ -42,12 +43,29 @@ const positiveNumber = (value: unknown): number | undefined => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
+const cleanHeaderValue = (value: unknown, maxLength = 220) =>
+  String(value ?? '')
+    .replace(/[^\x20-\x7E]/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+
+const syntheticHeaders = (spec = 'cypress-seed') => ({
+  'x-kindrobots-test-source': cleanHeaderValue(
+    process.env.CYPRESS_SYNTHETIC_SOURCE || 'cypress-node',
+  ),
+  'x-kindrobots-test-run-id': cleanHeaderValue(
+    process.env.CYPRESS_SYNTHETIC_RUN_ID || localSyntheticRunId,
+  ),
+  'x-kindrobots-test-spec': cleanHeaderValue(spec),
+})
+
 const jsonRequest = async <T = unknown>(url: string, init: RequestInit = {}) => {
   const response = await fetch(url, {
     ...init,
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      ...syntheticHeaders(),
       ...(init.headers || {}),
     },
   })
@@ -79,7 +97,10 @@ const extractUserId = (body: ApiResponse<Record<string, unknown>>) => {
 }
 
 const extractToken = (body: ApiResponse) => {
-  const data = body.data && typeof body.data === 'object' ? body.data as Record<string, unknown> : {}
+  const data =
+    body.data && typeof body.data === 'object'
+      ? (body.data as Record<string, unknown>)
+      : {}
   const token = String(data.token || body.token || body.user?.token || '')
 
   if (!token || token.length < 20) {
@@ -90,10 +111,19 @@ const extractToken = (body: ApiResponse) => {
 }
 
 const resolveApiBase = (env: Record<string, unknown>) =>
-  String(process.env.BASE_API_URL || env.BASE_API_URL || defaultApiBase).replace(/\/+$/, '')
+  String(process.env.BASE_API_URL || env.BASE_API_URL || defaultApiBase).replace(
+    /\/+$/,
+    '',
+  )
 
 const resolveAdminKey = (env: Record<string, unknown>) =>
-  String(process.env.BETA_ADMIN_TOKEN || process.env.API_KEY || env.BETA_ADMIN_TOKEN || env.API_KEY || '')
+  String(
+    process.env.BETA_ADMIN_TOKEN ||
+      process.env.API_KEY ||
+      env.BETA_ADMIN_TOKEN ||
+      env.API_KEY ||
+      '',
+  )
 
 const makeSeedUser = async (
   apiBase: string,
@@ -105,16 +135,21 @@ const makeSeedUser = async (
   const email = `${username}@example.com`
   const password = defaultTestPassword
 
-  const register = await jsonRequest<Record<string, unknown>>(`${apiBase}/users/register`, {
-    method: 'POST',
-    headers: {
-      'x-api-key': adminKey,
+  const register = await jsonRequest<Record<string, unknown>>(
+    `${apiBase}/users/register`,
+    {
+      method: 'POST',
+      headers: {
+        'x-api-key': adminKey,
+      },
+      body: JSON.stringify({ username, email, password }),
     },
-    body: JSON.stringify({ username, email, password }),
-  })
+  )
 
   if (![200, 201].includes(register.status)) {
-    throw new Error(`Seed user register failed for ${role}: ${register.status} ${JSON.stringify(register.body)}`)
+    throw new Error(
+      `Seed user register failed for ${role}: ${register.status} ${JSON.stringify(register.body)}`,
+    )
   }
 
   const id = extractUserId(register.body)
@@ -125,7 +160,9 @@ const makeSeedUser = async (
   })
 
   if (login.status !== 200 || login.body.success === false) {
-    throw new Error(`Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)}`)
+    throw new Error(
+      `Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)}`,
+    )
   }
 
   const token = extractToken(login.body)
@@ -188,7 +225,12 @@ export const ensureCypressApiSeed = async (env: Record<string, unknown>) => {
   return seed
 }
 
-export const isSeedUserId = async (env: Record<string, unknown>, userId: number) => {
+export const isSeedUserId = async (
+  env: Record<string, unknown>,
+  userId: number,
+) => {
   const seed = await ensureCypressApiSeed(env)
-  return [seed.user.id, seed.secondUser.id, seed.thirdUser.id].includes(Number(userId))
+  return [seed.user.id, seed.secondUser.id, seed.thirdUser.id].includes(
+    Number(userId),
+  )
 }

--- a/server/middleware/00.synthetic-test.ts
+++ b/server/middleware/00.synthetic-test.ts
@@ -1,0 +1,39 @@
+import {
+  defineEventHandler,
+  getHeader,
+  getRequestURL,
+  setResponseHeader,
+} from 'h3'
+
+const clean = (value: string | undefined, maxLength = 220) =>
+  String(value || '')
+    .replace(/[^\x20-\x7E]/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+
+export default defineEventHandler((event) => {
+  const source = clean(getHeader(event, 'x-kindrobots-test-source'))
+  if (!source) return
+
+  const runId = clean(getHeader(event, 'x-kindrobots-test-run-id'))
+  const spec = clean(getHeader(event, 'x-kindrobots-test-spec'))
+  const test = clean(getHeader(event, 'x-kindrobots-test-name'))
+
+  setResponseHeader(event, 'x-kindrobots-synthetic-test', 'true')
+  if (runId) setResponseHeader(event, 'x-kindrobots-test-run-id', runId)
+
+  event.node.res.once('finish', () => {
+    const statusCode = event.node.res.statusCode
+    if (statusCode < 400) return
+
+    console.info('[synthetic-test-request]', {
+      source,
+      runId: runId || 'unknown',
+      spec: spec || 'unknown',
+      test: test || 'unknown',
+      method: event.method,
+      path: getRequestURL(event).pathname,
+      statusCode,
+    })
+  })
+})

--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -13,85 +13,119 @@ export type ErrorHandlerOutput = {
   statusCode?: number
 }
 
-function logError(error: ErrorHandlerInput): void {
-  if (error instanceof Prisma.PrismaClientKnownRequestError) {
-    console.error('Operation failed:', {
-      name: error.name,
-      code: error.code,
-      message: error.message,
-    })
+const transientDatabaseMessages = [
+  'Cannot execute new commands: connection closed',
+  'pool timeout: failed to retrieve a connection from pool',
+  'Max connect timeout reached',
+]
+
+const authenticationErrorCodes = new Set([
+  'ERR_JWT_EXPIRED',
+  'ERR_JWS_INVALID',
+  'ERR_JWT_CLAIM_VALIDATION_FAILED',
+  'ERR_JWT_INVALID',
+])
+
+function errorCode(error: ErrorHandlerInput): string | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined
+
+  return typeof error.code === 'string' ? error.code : undefined
+}
+
+function errorMessage(error: ErrorHandlerInput): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String(error.message)
+  }
+
+  return 'Unknown error'
+}
+
+function isTransientDatabaseError(error: ErrorHandlerInput): boolean {
+  const message = errorMessage(error)
+  return transientDatabaseMessages.some((candidate) => message.includes(candidate))
+}
+
+function isAuthenticationError(error: ErrorHandlerInput): boolean {
+  const code = errorCode(error)
+  if (code && authenticationErrorCodes.has(code)) return true
+
+  const message = errorMessage(error)
+  return [
+    'Authentication required',
+    'Invalid API Key',
+    'Authorization token is required',
+    'Invalid or expired token',
+  ].some((candidate) => message.includes(candidate))
+}
+
+function logError(error: ErrorHandlerInput, statusCode: number): void {
+  const payload = {
+    name: error instanceof Error ? error.name : typeof error,
+    code: errorCode(error),
+    message: errorMessage(error),
+    statusCode,
+  }
+
+  // 4xx responses are handled client rejections, not server incidents. Keeping
+  // them at warning level prevents expected auth/validation probes from flooding
+  // Vercel's runtime error clusters while preserving them in searchable logs.
+  if (statusCode < 500) {
+    console.warn('Operation rejected:', payload)
     return
   }
 
-  if (error instanceof Error) {
-    const customError = error as CustomError
-
-    console.error('Operation failed:', {
-      name: error.name,
-      code: customError.code,
-      message: error.message,
-      statusCode: customError.statusCode,
-    })
-    return
-  }
-
-  console.error('Operation failed:', {
-    type: typeof error,
-    message: typeof error === 'string' ? error : 'Unknown error',
-  })
+  console.error('Operation failed:', payload)
 }
 
 export function errorHandler(error: ErrorHandlerInput): ErrorHandlerOutput {
-  logError(error)
+  let result: ErrorHandlerOutput
 
   if (!error) {
-    return {
+    result = {
+      success: false,
+      message: 'An unknown error occurred.',
+      statusCode: 500,
+    }
+  } else if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    result = handlePrismaError(error)
+  } else if (isTransientDatabaseError(error)) {
+    result = {
+      success: false,
+      message: 'Database connection was temporarily unavailable.',
+      statusCode: 503,
+    }
+  } else if (isAuthenticationError(error)) {
+    result = {
+      success: false,
+      message: errorMessage(error),
+      statusCode: 401,
+    }
+  } else if (error instanceof Error) {
+    const customError = error as CustomError
+    result = {
+      success: false,
+      message: error.message,
+      statusCode: customError.statusCode || 400,
+    }
+  } else if (typeof error === 'string') {
+    result = {
+      success: false,
+      message: error,
+      statusCode: 400,
+    }
+  } else {
+    result = {
       success: false,
       message: 'An unknown error occurred.',
       statusCode: 500,
     }
   }
 
-  if (error instanceof Prisma.PrismaClientKnownRequestError) {
-    return handlePrismaError(error)
-  }
-
-  if (error instanceof Error) {
-    const customError = error as CustomError
-    const statusCode = customError.statusCode || 400
-
-    if (
-      error.message.includes('Authentication required') ||
-      error.message.includes('Invalid API Key') ||
-      error.message.includes('Authorization token is required')
-    ) {
-      return {
-        success: false,
-        message: error.message,
-        statusCode: 401,
-      }
-    }
-
-    return {
-      success: false,
-      message: error.message,
-      statusCode,
-    }
-  }
-
-  if (typeof error === 'string') {
-    return {
-      success: false,
-      message: error,
-      statusCode: 400,
-    }
-  }
-
-  return {
-    success: false,
-    message: 'An unknown error occurred.',
-    statusCode: 500,
-  }
+  logError(error, result.statusCode || 500)
+  return result
 }
 
 function handlePrismaError(

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -52,6 +52,14 @@ function buildDatabaseUrl(url: string): string {
     process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
     0,
   )
+  const idleTimeout = readPositiveInteger(
+    process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
+    30,
+  )
+  const minimumIdle = readNonNegativeInteger(
+    process.env.DATABASE_MINIMUM_IDLE,
+    0,
+  )
 
   if (!parsed.searchParams.has('connectTimeout')) {
     parsed.searchParams.set('connectTimeout', String(connectTimeout))
@@ -67,6 +75,17 @@ function buildDatabaseUrl(url: string): string {
 
   if (!parsed.searchParams.has('minDelayValidation')) {
     parsed.searchParams.set('minDelayValidation', String(minDelayValidation))
+  }
+
+  // The MariaDB connector defaults minimumIdle to connectionLimit and keeps
+  // those idle sockets for 30 minutes. That is a poor fit for reused Vercel
+  // functions because a warm instance can retain a full pool of dead sockets.
+  if (!parsed.searchParams.has('idleTimeout')) {
+    parsed.searchParams.set('idleTimeout', String(idleTimeout))
+  }
+
+  if (!parsed.searchParams.has('minimumIdle')) {
+    parsed.searchParams.set('minimumIdle', String(minimumIdle))
   }
 
   return parsed.toString()
@@ -98,7 +117,6 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
 
   const parsed = new URL(resolvedUrl)
   const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
-
   const tlsOptions: TlsConnectionOptions = {
     ca: sslCa,
     rejectUnauthorized: true,
@@ -128,6 +146,14 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
       parsed.searchParams.get('minDelayValidation') ?? undefined,
       0,
     ),
+    idleTimeout: readPositiveInteger(
+      parsed.searchParams.get('idleTimeout') ?? undefined,
+      30,
+    ),
+    minimumIdle: readNonNegativeInteger(
+      parsed.searchParams.get('minimumIdle') ?? undefined,
+      0,
+    ),
     ssl: tlsOptions,
   }
 }
@@ -140,7 +166,7 @@ const retryableDatabaseMessages = [
 
 const transientRetryAttempts = readNonNegativeInteger(
   process.env.DATABASE_TRANSIENT_RETRY_ATTEMPTS,
-  2,
+  5,
 )
 const transientRetryDelayMs = readPositiveInteger(
   process.env.DATABASE_TRANSIENT_RETRY_DELAY_MS,
@@ -170,7 +196,6 @@ const basePrisma =
   new PrismaClient({
     adapter: new PrismaMariaDb(buildDatabaseConfig(databaseUrl)),
   })
-
 globalForPrisma.prisma = basePrisma
 
 export const prisma = basePrisma.$extends({


### PR DESCRIPTION
## Summary

- Tag Cypress requests with run, spec, and test metadata.
- Add searchable synthetic-test log records for non-success responses.
- Log handled 4xx responses as warnings while preserving server failures as errors.
- Return 503 for exhausted transient database disconnects.
- Recycle idle MariaDB pool connections in serverless runtimes and increase bounded retries.
- Correct Art tests that mixed two authentication mechanisms.

## Evidence

The latest run showed repeated database connection failures on valid Bot, Character, and Chat creation after all configured retries. Dependent tests then failed because their fixture IDs were never created.

## Validation

The latest preview was blocked before build by Vercel's build-rate limit, not by a compiler or application error.