### PR TITLE
challenge-center: faceted leaderboards (model/generator/kind/provider) + per-variant winner

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
+    "test:challenge-center": "tsx utils/scripts/verifyChallengeCenter.ts",
     "vercel-build": "prisma generate && node scripts/prisma-migrate-deploy.mjs && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
     "dev": "nuxt dev --host",
     "build": "nuxi prepare && prisma generate && nuxi build",

--- a/pages/challenges/[slug].vue
+++ b/pages/challenges/[slug].vue
@@ -34,7 +34,10 @@
         <Icon name="kind-icon:warning" class="mx-auto size-10 text-error" />
         <h1 class="mt-3 text-xl font-black">Arena unavailable</h1>
         <p class="mt-2 text-sm text-base-content/65">{{ errorMessage }}</p>
-        <button class="btn btn-error btn-sm mt-5 rounded-xl" @click="loadChallenge">
+        <button
+          class="btn btn-error btn-sm mt-5 rounded-xl"
+          @click="loadChallenge"
+        >
           Try again
         </button>
       </div>
@@ -53,7 +56,9 @@
             class="pointer-events-none absolute -bottom-24 -left-16 size-64 rounded-full border-[40px] border-secondary/10"
           />
 
-          <div class="relative grid gap-6 lg:grid-cols-[1fr_auto] lg:items-start">
+          <div
+            class="relative grid gap-6 lg:grid-cols-[1fr_auto] lg:items-start"
+          >
             <div>
               <div class="flex flex-wrap items-center gap-2">
                 <span class="badge badge-primary rounded-lg font-black">
@@ -77,7 +82,9 @@
               >
                 {{ challenge.title }}
               </h1>
-              <p class="mt-5 max-w-4xl text-base leading-relaxed text-base-content/75">
+              <p
+                class="mt-5 max-w-4xl text-base leading-relaxed text-base-content/75"
+              >
                 {{ challenge.promptText }}
               </p>
 
@@ -99,7 +106,9 @@
             <div
               class="grid min-w-40 place-items-center rounded-3xl border border-primary/20 bg-base-100/75 p-5 text-center shadow-lg backdrop-blur"
             >
-              <span class="text-xs font-black uppercase tracking-[0.2em] text-base-content/45">
+              <span
+                class="text-xs font-black uppercase tracking-[0.2em] text-base-content/45"
+              >
                 Difficulty
               </span>
               <span
@@ -110,9 +119,12 @@
                   v-for="star in 5"
                   :key="star"
                   :class="star > challenge.difficulty ? 'opacity-20' : ''"
-                >★</span>
+                  >★</span
+                >
               </span>
-              <span class="mt-3 text-5xl font-black italic text-primary">VS</span>
+              <span class="mt-3 text-5xl font-black italic text-primary"
+                >VS</span
+              >
             </div>
           </div>
         </header>
@@ -123,8 +135,8 @@
         >
           <Icon name="kind-icon:warning" class="size-5" />
           <span>
-            Browse freely, but sign in before voting. Each account gets exactly one
-            current vote per submission.
+            Browse freely, but sign in before voting. Each account gets exactly
+            one current vote per submission.
           </span>
         </div>
 
@@ -134,7 +146,9 @@
           :class="voteStatus === 'error' ? 'alert-error' : 'alert-success'"
         >
           <Icon
-            :name="voteStatus === 'error' ? 'kind-icon:warning' : 'kind-icon:check'"
+            :name="
+              voteStatus === 'error' ? 'kind-icon:warning' : 'kind-icon:check'
+            "
             class="size-5"
           />
           <span>{{ voteMessage }}</span>
@@ -157,7 +171,9 @@
               v-for="submission in challenge.Submissions"
               :key="submission.id"
               class="group relative flex min-w-0 flex-col overflow-hidden rounded-3xl border bg-base-100 shadow-lg transition hover:-translate-y-1 hover:shadow-2xl"
-              :class="submission.rank === 1 ? 'border-warning/60' : 'border-base-300'"
+              :class="
+                submission.rank === 1 ? 'border-warning/60' : 'border-base-300'
+              "
             >
               <div
                 class="h-1.5 bg-gradient-to-r from-primary via-secondary to-accent"
@@ -175,12 +191,21 @@
                     <span
                       v-if="submission.rank"
                       class="badge rounded-lg font-black"
-                      :class="submission.rank === 1 ? 'badge-warning' : 'badge-ghost'"
+                      :class="
+                        submission.rank === 1 ? 'badge-warning' : 'badge-ghost'
+                      "
                     >
                       #{{ submission.rank }}
                     </span>
                     <span class="badge badge-outline badge-sm rounded-lg">
                       {{ submission.variantKey }}
+                    </span>
+                    <span
+                      v-if="submission.isBestVariant"
+                      class="badge badge-secondary badge-sm rounded-lg font-black"
+                      title="Top-scoring prompt variant from this contender in this challenge"
+                    >
+                      Best variant
                     </span>
                   </div>
                   <h2 class="mt-2 truncate text-xl font-black uppercase">
@@ -205,7 +230,9 @@
                 </div>
               </header>
 
-              <div class="flex-1 border-y border-base-300 bg-base-200/35 p-4 sm:p-5">
+              <div
+                class="flex-1 border-y border-base-300 bg-base-200/35 p-4 sm:p-5"
+              >
                 <img
                   v-if="submission.ArtImage && artImageUrl(submission.ArtImage)"
                   :src="artImageUrl(submission.ArtImage)"
@@ -217,7 +244,9 @@
                   v-else-if="submission.Character"
                   class="rounded-2xl border border-primary/20 bg-primary/5 p-5"
                 >
-                  <p class="text-xs font-black uppercase tracking-[0.2em] text-primary">
+                  <p
+                    class="text-xs font-black uppercase tracking-[0.2em] text-primary"
+                  >
                     Character entry
                   </p>
                   <h3 class="mt-2 text-2xl font-black">
@@ -234,7 +263,9 @@
                   v-else-if="submission.Scenario"
                   class="rounded-2xl border border-secondary/20 bg-secondary/5 p-5"
                 >
-                  <p class="text-xs font-black uppercase tracking-[0.2em] text-secondary">
+                  <p
+                    class="text-xs font-black uppercase tracking-[0.2em] text-secondary"
+                  >
                     Scenario entry
                   </p>
                   <h3 class="mt-2 text-2xl font-black">
@@ -253,7 +284,9 @@
                 >
                   <p
                     class="whitespace-pre-line text-sm leading-relaxed"
-                    :class="expandedIds.has(submission.id) ? '' : 'line-clamp-[12]'"
+                    :class="
+                      expandedIds.has(submission.id) ? '' : 'line-clamp-[12]'
+                    "
                   >
                     {{ submission.outputText }}
                   </p>
@@ -291,6 +324,26 @@
                     class="collapse-content whitespace-pre-line text-xs text-base-content/65"
                   >
                     {{ submission.promptUsed }}
+                  </div>
+                </details>
+
+                <details
+                  v-if="randomSelectionsList(submission).length"
+                  class="collapse collapse-arrow mt-3 rounded-2xl border border-base-300 bg-base-100"
+                >
+                  <summary
+                    class="collapse-title min-h-0 py-3 text-xs font-black uppercase tracking-wider"
+                  >
+                    Random rolls used
+                  </summary>
+                  <div class="collapse-content flex flex-wrap gap-2 text-xs">
+                    <span
+                      v-for="[key, value] in randomSelectionsList(submission)"
+                      :key="key"
+                      class="badge badge-ghost rounded-lg"
+                    >
+                      {{ key }}: {{ value }}
+                    </span>
                   </div>
                 </details>
               </div>
@@ -360,10 +413,16 @@
           v-else
           class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
         >
-          <Icon name="kind-icon:trophy" class="mx-auto size-12 text-primary/40" />
-          <h2 class="mt-4 text-2xl font-black uppercase">Waiting for contenders</h2>
+          <Icon
+            name="kind-icon:trophy"
+            class="mx-auto size-12 text-primary/40"
+          />
+          <h2 class="mt-4 text-2xl font-black uppercase">
+            Waiting for contenders
+          </h2>
           <p class="mx-auto mt-2 max-w-xl text-sm text-base-content/60">
-            The challenge is live, but no ready submissions have entered the arena yet.
+            The challenge is live, but no ready submissions have entered the
+            arena yet.
           </p>
         </section>
 
@@ -373,10 +432,14 @@
         >
           <div class="flex flex-wrap items-end justify-between gap-3">
             <div>
-              <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
+              <p
+                class="text-xs font-black uppercase tracking-[0.25em] text-primary"
+              >
                 Live scorecard
               </p>
-              <h2 class="mt-1 text-2xl font-black uppercase">Challenge rankings</h2>
+              <h2 class="mt-1 text-2xl font-black uppercase">
+                Challenge rankings
+              </h2>
             </div>
             <NuxtLink
               to="/challenges/leaderboard"
@@ -405,7 +468,9 @@
                   {{ entry.score.votes }} votes
                 </p>
               </div>
-              <span class="hidden text-xs font-bold text-base-content/45 sm:inline">
+              <span
+                class="hidden text-xs font-bold text-base-content/45 sm:inline"
+              >
                 ♥ {{ entry.score.loved }} · 👏 {{ entry.score.clapped }} · 👎
                 {{ entry.score.booed }} · ✕ {{ entry.score.hated }}
               </span>
@@ -471,6 +536,7 @@ type ChallengeSubmission = {
   contenderId: number | null
   variantKey: string
   promptUsed: string | null
+  randomSelections: Record<string, string> | null
   outputText: string | null
   Contender: Contender | null
   ArtImage: ArtImagePreview | null
@@ -478,6 +544,8 @@ type ChallengeSubmission = {
   Scenario: LinkedEntity | null
   score: ChallengeScore
   rank: number | null
+  variantRank: number | null
+  isBestVariant: boolean
   myReaction: ReactionType | null
 }
 
@@ -552,7 +620,19 @@ function contenderInitial(submission: ChallengeSubmission) {
 function contenderSubtitle(submission: ChallengeSubmission) {
   const contender = submission.Contender
   if (!contender) return 'Unregistered contender'
-  return contender.model || contender.generator || contender.provider || contender.kind
+  return (
+    contender.model ||
+    contender.generator ||
+    contender.provider ||
+    contender.kind
+  )
+}
+
+function randomSelectionsList(
+  submission: ChallengeSubmission,
+): Array<[string, string]> {
+  if (!submission.randomSelections) return []
+  return Object.entries(submission.randomSelections)
 }
 
 function artImageUrl(image: ArtImagePreview) {
@@ -648,7 +728,9 @@ async function vote(submissionId: number, reactionType: ReactionType) {
   } catch (error: unknown) {
     voteStatus.value = 'error'
     voteMessage.value =
-      error instanceof Error ? error.message : 'Your vote could not be recorded.'
+      error instanceof Error
+        ? error.message
+        : 'Your vote could not be recorded.'
   } finally {
     votingSubmissionId.value = null
     pendingReaction.value = null

--- a/pages/challenges/leaderboard.vue
+++ b/pages/challenges/leaderboard.vue
@@ -27,33 +27,49 @@
         <div
           class="pointer-events-none absolute -right-20 -top-24 size-72 rounded-full border-[44px] border-warning/10"
         />
-        <div class="relative grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center">
+        <div
+          class="relative grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center"
+        >
           <div>
-            <p class="text-xs font-black uppercase tracking-[0.3em] text-warning">
+            <p
+              class="text-xs font-black uppercase tracking-[0.3em] text-warning"
+            >
               Championship standings
             </p>
-            <h1 class="mt-2 text-4xl font-black uppercase leading-none sm:text-6xl">
+            <h1
+              class="mt-2 text-4xl font-black uppercase leading-none sm:text-6xl"
+            >
               Hall of contenders
             </h1>
             <p class="mt-4 max-w-3xl text-base text-base-content/70">
-              Every reaction counts. Compare total score, victories, and win rate across the whole arena or inside one challenge division.
+              Every reaction counts. Compare total score, victories, and win
+              rate across the whole arena or inside one challenge division.
             </p>
           </div>
           <div
             class="grid size-36 place-items-center rounded-full border-8 border-warning/30 bg-base-100/80 text-center shadow-2xl backdrop-blur"
           >
             <div>
-              <Icon name="kind-icon:trophy" class="mx-auto size-10 text-warning" />
-              <p class="mt-1 text-xs font-black uppercase tracking-widest">Champion</p>
+              <Icon
+                name="kind-icon:trophy"
+                class="mx-auto size-10 text-warning"
+              />
+              <p class="mt-1 text-xs font-black uppercase tracking-widest">
+                Champion
+              </p>
             </div>
           </div>
         </div>
       </header>
 
-      <section class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-lg sm:p-6">
+      <section
+        class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-lg sm:p-6"
+      >
         <div class="flex flex-wrap items-end justify-between gap-4">
           <fieldset>
-            <legend class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/45">
+            <legend
+              class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/45"
+            >
               Weight class
             </legend>
             <div class="flex flex-wrap gap-2">
@@ -62,7 +78,11 @@
                 :key="option.value"
                 type="button"
                 class="btn btn-sm rounded-xl"
-                :class="typeFilter === option.value ? 'btn-primary' : 'btn-ghost border border-base-300'"
+                :class="
+                  typeFilter === option.value
+                    ? 'btn-primary'
+                    : 'btn-ghost border border-base-300'
+                "
                 @click="selectType(option.value)"
               >
                 {{ option.label }}
@@ -70,8 +90,38 @@
             </div>
           </fieldset>
           <p class="text-xs font-bold text-base-content/45">
-            {{ leaderboard.length }} ranked contenders
+            {{ leaderboard.length }} ranked
+            {{
+              facetFilter === 'contender'
+                ? 'contenders'
+                : facetLabel(facetFilter) + ' groups'
+            }}
           </p>
+        </div>
+        <div class="mt-4 border-t border-base-300 pt-4">
+          <fieldset>
+            <legend
+              class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/45"
+            >
+              Comparison axis
+            </legend>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="option in facetOptions"
+                :key="option.value"
+                type="button"
+                class="btn btn-sm rounded-xl"
+                :class="
+                  facetFilter === option.value
+                    ? 'btn-secondary'
+                    : 'btn-ghost border border-base-300'
+                "
+                @click="selectFacet(option.value)"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </fieldset>
         </div>
       </section>
 
@@ -95,50 +145,84 @@
         <div class="grid gap-4 md:grid-cols-3">
           <article
             v-for="entry in podium"
-            :key="entry.contenderId"
+            :key="entry.key"
             class="relative overflow-hidden rounded-3xl border bg-base-100 p-5 text-center shadow-xl"
-            :class="entry.rank === 1 ? 'border-warning/60 md:-translate-y-3' : 'border-base-300'"
+            :class="
+              entry.rank === 1
+                ? 'border-warning/60 md:-translate-y-3'
+                : 'border-base-300'
+            "
           >
             <div
               class="absolute inset-x-0 top-0 h-2 bg-gradient-to-r from-primary via-warning to-secondary"
               :class="entry.rank === 1 ? 'opacity-100' : 'opacity-45'"
             />
-            <div class="mx-auto mt-3 grid size-20 place-items-center rounded-full border-4 border-base-100 bg-primary/10 text-3xl font-black text-primary shadow-lg">
+            <div
+              class="mx-auto mt-3 grid size-20 place-items-center rounded-full border-4 border-base-100 bg-primary/10 text-3xl font-black text-primary shadow-lg"
+            >
               {{ entry.name.slice(0, 1).toUpperCase() }}
             </div>
-            <span class="badge mt-4 rounded-lg font-black" :class="entry.rank === 1 ? 'badge-warning' : 'badge-ghost'">
+            <span
+              class="badge mt-4 rounded-lg font-black"
+              :class="entry.rank === 1 ? 'badge-warning' : 'badge-ghost'"
+            >
               #{{ entry.rank }}
             </span>
             <h2 class="mt-3 text-xl font-black uppercase">{{ entry.name }}</h2>
-            <p class="mt-1 text-xs font-bold text-base-content/45">{{ entry.slug }}</p>
-            <p class="mt-5 text-5xl font-black" :class="scoreClass(entry.score.netScore)">
+            <p class="mt-1 text-xs font-bold text-base-content/45">
+              {{ entry.subtitle }}
+            </p>
+            <p
+              class="mt-5 text-5xl font-black"
+              :class="scoreClass(entry.score.netScore)"
+            >
               {{ signedScore(entry.score.netScore) }}
             </p>
-            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">total score</p>
+            <p
+              class="text-xs font-black uppercase tracking-widest text-base-content/40"
+            >
+              total score
+            </p>
             <div class="mt-5 grid grid-cols-3 gap-2 text-sm">
               <div class="rounded-xl bg-base-200 p-3">
-                <strong class="block text-lg">{{ entry.challengesAttempted }}</strong>
-                <span class="text-[0.65rem] uppercase text-base-content/45">fights</span>
+                <strong class="block text-lg">{{
+                  entry.challengesAttempted
+                }}</strong>
+                <span class="text-[0.65rem] uppercase text-base-content/45"
+                  >fights</span
+                >
               </div>
               <div class="rounded-xl bg-warning/10 p-3">
                 <strong class="block text-lg">{{ entry.challengesWon }}</strong>
-                <span class="text-[0.65rem] uppercase text-base-content/45">wins</span>
+                <span class="text-[0.65rem] uppercase text-base-content/45"
+                  >wins</span
+                >
               </div>
               <div class="rounded-xl bg-primary/10 p-3">
                 <strong class="block text-lg">{{ entry.winRate }}%</strong>
-                <span class="text-[0.65rem] uppercase text-base-content/45">rate</span>
+                <span class="text-[0.65rem] uppercase text-base-content/45"
+                  >rate</span
+                >
               </div>
             </div>
           </article>
         </div>
 
-        <div class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg">
+        <div
+          class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg"
+        >
           <div class="overflow-x-auto">
             <table class="table">
               <thead class="bg-base-200/70 text-xs uppercase tracking-wider">
                 <tr>
                   <th>Rank</th>
-                  <th>Contender</th>
+                  <th>
+                    {{
+                      facetFilter === 'contender'
+                        ? 'Contender'
+                        : facetLabel(facetFilter)
+                    }}
+                  </th>
                   <th class="text-right">Fights</th>
                   <th class="text-right">Wins</th>
                   <th class="text-right">Win rate</th>
@@ -147,24 +231,43 @@
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="entry in leaderboard" :key="entry.contenderId" class="hover">
-                  <td><span class="badge badge-ghost rounded-lg font-black">#{{ entry.rank }}</span></td>
+                <tr
+                  v-for="entry in normalizedLeaderboard"
+                  :key="entry.key"
+                  class="hover"
+                >
+                  <td>
+                    <span class="badge badge-ghost rounded-lg font-black"
+                      >#{{ entry.rank }}</span
+                    >
+                  </td>
                   <td>
                     <div class="flex items-center gap-3">
-                      <div class="grid size-10 place-items-center rounded-xl bg-primary/10 font-black text-primary">
+                      <div
+                        class="grid size-10 place-items-center rounded-xl bg-primary/10 font-black text-primary"
+                      >
                         {{ entry.name.slice(0, 1).toUpperCase() }}
                       </div>
                       <div>
                         <p class="font-black">{{ entry.name }}</p>
-                        <p class="text-xs text-base-content/45">{{ entry.slug }}</p>
+                        <p class="text-xs text-base-content/45">
+                          {{ entry.subtitle }}
+                        </p>
                       </div>
                     </div>
                   </td>
-                  <td class="text-right font-bold">{{ entry.challengesAttempted }}</td>
-                  <td class="text-right font-bold">{{ entry.challengesWon }}</td>
+                  <td class="text-right font-bold">
+                    {{ entry.challengesAttempted }}
+                  </td>
+                  <td class="text-right font-bold">
+                    {{ entry.challengesWon }}
+                  </td>
                   <td class="text-right font-bold">{{ entry.winRate }}%</td>
                   <td class="text-right font-bold">{{ entry.score.votes }}</td>
-                  <td class="text-right text-lg font-black" :class="scoreClass(entry.score.netScore)">
+                  <td
+                    class="text-right text-lg font-black"
+                    :class="scoreClass(entry.score.netScore)"
+                  >
                     {{ signedScore(entry.score.netScore) }}
                   </td>
                 </tr>
@@ -178,7 +281,10 @@
         v-else-if="!loading"
         class="rounded-3xl border border-dashed border-base-300 bg-base-100 p-10 text-center"
       >
-        <Icon name="kind-icon:trophy" class="mx-auto size-12 text-base-content/25" />
+        <Icon
+          name="kind-icon:trophy"
+          class="mx-auto size-12 text-base-content/25"
+        />
         <h2 class="mt-4 text-xl font-black">No rankings yet</h2>
         <p class="mt-2 text-sm text-base-content/55">
           This division needs scored submissions before a champion can emerge.
@@ -189,9 +295,16 @@
 </template>
 
 <script setup lang="ts">
-type ChallengeType = '' | 'ART' | 'TEXT' | 'CHARACTER' | 'SCENARIO' | 'REASONING'
+type ChallengeType =
+  | ''
+  | 'ART'
+  | 'TEXT'
+  | 'CHARACTER'
+  | 'SCENARIO'
+  | 'REASONING'
+type Facet = 'contender' | 'kind' | 'provider' | 'model' | 'generator'
 
-type LeaderboardEntry = {
+type ContenderLeaderboardEntry = {
   contenderId: number
   slug: string
   name: string
@@ -205,10 +318,34 @@ type LeaderboardEntry = {
   }
 }
 
+type FacetLeaderboardEntry = {
+  value: string
+  contenderSlugs: string[]
+  rank: number
+  challengesAttempted: number
+  challengesWon: number
+  winRate: number
+  score: {
+    votes: number
+    netScore: number
+  }
+}
+
 type LeaderboardResponse = {
   success: boolean
   message: string
-  data?: LeaderboardEntry[]
+  data?: Array<ContenderLeaderboardEntry | FacetLeaderboardEntry>
+}
+
+type DisplayEntry = {
+  key: string
+  name: string
+  subtitle: string
+  rank: number
+  challengesAttempted: number
+  challengesWon: number
+  winRate: number
+  score: { votes: number; netScore: number }
 }
 
 const typeOptions: Array<{ label: string; value: ChallengeType }> = [
@@ -220,11 +357,63 @@ const typeOptions: Array<{ label: string; value: ChallengeType }> = [
   { label: 'Reasoning', value: 'REASONING' },
 ]
 
+const facetOptions: Array<{ label: string; value: Facet }> = [
+  { label: 'By contender', value: 'contender' },
+  { label: 'By model', value: 'model' },
+  { label: 'By generator', value: 'generator' },
+  { label: 'By provider', value: 'provider' },
+  { label: 'By kind', value: 'kind' },
+]
+
 const typeFilter = ref<ChallengeType>('')
-const leaderboard = ref<LeaderboardEntry[]>([])
+const facetFilter = ref<Facet>('contender')
+const leaderboard = ref<
+  Array<ContenderLeaderboardEntry | FacetLeaderboardEntry>
+>([])
 const loading = ref(false)
 const errorMessage = ref('')
-const podium = computed(() => leaderboard.value.slice(0, 3))
+
+function isContenderEntry(
+  entry: ContenderLeaderboardEntry | FacetLeaderboardEntry,
+): entry is ContenderLeaderboardEntry {
+  return 'contenderId' in entry
+}
+
+function facetLabel(facet: Facet): string {
+  return (
+    facetOptions
+      .find((option) => option.value === facet)
+      ?.label.replace('By ', '') ?? facet
+  )
+}
+
+const normalizedLeaderboard = computed<DisplayEntry[]>(() =>
+  leaderboard.value.map((entry) =>
+    isContenderEntry(entry)
+      ? {
+          key: `contender-${entry.contenderId}`,
+          name: entry.name,
+          subtitle: entry.slug,
+          rank: entry.rank,
+          challengesAttempted: entry.challengesAttempted,
+          challengesWon: entry.challengesWon,
+          winRate: entry.winRate,
+          score: entry.score,
+        }
+      : {
+          key: `facet-${entry.value}`,
+          name: entry.value,
+          subtitle: `${entry.contenderSlugs.length} ${entry.contenderSlugs.length === 1 ? 'contender' : 'contenders'}`,
+          rank: entry.rank,
+          challengesAttempted: entry.challengesAttempted,
+          challengesWon: entry.challengesWon,
+          winRate: entry.winRate,
+          score: entry.score,
+        },
+  ),
+)
+
+const podium = computed(() => normalizedLeaderboard.value.slice(0, 3))
 
 function signedScore(value: number): string {
   return value > 0 ? `+${value}` : String(value)
@@ -241,9 +430,16 @@ async function loadLeaderboard(): Promise<void> {
   errorMessage.value = ''
 
   try {
-    const response = await $fetch<LeaderboardResponse>('/api/challenges/leaderboard', {
-      query: typeFilter.value ? { type: typeFilter.value } : undefined,
-    })
+    const query: Record<string, string> = {}
+    if (typeFilter.value) query.type = typeFilter.value
+    if (facetFilter.value !== 'contender') query.facet = facetFilter.value
+
+    const response = await $fetch<LeaderboardResponse>(
+      '/api/challenges/leaderboard',
+      {
+        query: Object.keys(query).length ? query : undefined,
+      },
+    )
 
     if (!response.success) {
       throw new Error(response.message || 'Leaderboard fetch failed')
@@ -251,7 +447,8 @@ async function loadLeaderboard(): Promise<void> {
 
     leaderboard.value = response.data ?? []
   } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : 'Leaderboard fetch failed'
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Leaderboard fetch failed'
   } finally {
     loading.value = false
   }
@@ -260,6 +457,12 @@ async function loadLeaderboard(): Promise<void> {
 function selectType(value: ChallengeType): void {
   if (typeFilter.value === value) return
   typeFilter.value = value
+  void loadLeaderboard()
+}
+
+function selectFacet(value: Facet): void {
+  if (facetFilter.value === value) return
+  facetFilter.value = value
   void loadLeaderboard()
 }
 

--- a/server/api/challenges/[slug].get.ts
+++ b/server/api/challenges/[slug].get.ts
@@ -13,7 +13,10 @@ export default defineEventHandler(async (event) => {
     const slug = getRouterParam(event, 'slug')?.trim()
 
     if (!slug) {
-      throw createError({ statusCode: 400, message: 'Challenge slug is required.' })
+      throw createError({
+        statusCode: 400,
+        message: 'Challenge slug is required.',
+      })
     }
 
     const auth = await validateApiKey(event)
@@ -69,6 +72,19 @@ export default defineEventHandler(async (event) => {
     const rankByContender = new Map(
       leaderboard.map((entry, index) => [entry.contenderId, index + 1]),
     )
+    const variantInfoBySubmission = new Map(
+      leaderboard.flatMap((entry) =>
+        entry.variants.map((variant) => [
+          variant.submissionId,
+          {
+            variantRank: variant.rank,
+            isBestVariant:
+              entry.bestVariantKey !== null &&
+              variant.variantKey === entry.bestVariantKey,
+          },
+        ]),
+      ),
+    )
 
     event.node.res.statusCode = 200
 
@@ -79,16 +95,19 @@ export default defineEventHandler(async (event) => {
         ...challenge,
         Submissions: challenge.Submissions.map((submission) => {
           const { Reactions, ...submissionData } = submission
+          const variantInfo = variantInfoBySubmission.get(submission.id)
 
           return {
             ...submissionData,
             score: scoreChallengeReactions(Reactions),
             rank: submission.contenderId
-              ? rankByContender.get(submission.contenderId) ?? null
+              ? (rankByContender.get(submission.contenderId) ?? null)
               : null,
+            variantRank: variantInfo?.variantRank ?? null,
+            isBestVariant: variantInfo?.isBestVariant ?? false,
             myReaction: currentUserId
-              ? Reactions.find((reaction) => reaction.userId === currentUserId)
-                  ?.reactionType ?? null
+              ? (Reactions.find((reaction) => reaction.userId === currentUserId)
+                  ?.reactionType ?? null)
               : null,
           }
         }),

--- a/server/api/challenges/[slug]/leaderboard.get.ts
+++ b/server/api/challenges/[slug]/leaderboard.get.ts
@@ -9,7 +9,10 @@ export default defineEventHandler(async (event) => {
     const slug = getRouterParam(event, 'slug')?.trim()
 
     if (!slug) {
-      throw createError({ statusCode: 400, message: 'Challenge slug is required.' })
+      throw createError({
+        statusCode: 400,
+        message: 'Challenge slug is required.',
+      })
     }
 
     const challenge = await prisma.challenge.findUnique({
@@ -26,6 +29,8 @@ export default defineEventHandler(async (event) => {
             id: true,
             contenderId: true,
             variantKey: true,
+            promptUsed: true,
+            randomSelections: true,
             Contender: {
               select: {
                 id: true,

--- a/server/api/challenges/leaderboard.get.ts
+++ b/server/api/challenges/leaderboard.get.ts
@@ -2,7 +2,11 @@
 import { createError, defineEventHandler, getQuery } from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
-import { buildChallengeLeaderboard } from '~/server/utils/challengeCenter'
+import {
+  buildChallengeLeaderboard,
+  buildFacetLeaderboard,
+  type ContenderFacetKey,
+} from '~/server/utils/challengeCenter'
 
 const challengeTypes = new Set([
   'ART',
@@ -10,6 +14,13 @@ const challengeTypes = new Set([
   'CHARACTER',
   'SCENARIO',
   'REASONING',
+])
+
+const facetKeys = new Set<ContenderFacetKey>([
+  'kind',
+  'provider',
+  'model',
+  'generator',
 ])
 
 export default defineEventHandler(async (event) => {
@@ -23,6 +34,25 @@ export default defineEventHandler(async (event) => {
     if (challengeType && !challengeTypes.has(challengeType)) {
       throw createError({ statusCode: 400, message: 'Invalid challenge type.' })
     }
+
+    const rawFacet =
+      query.facet === undefined || query.facet === null || query.facet === ''
+        ? 'contender'
+        : String(query.facet).trim().toLowerCase()
+
+    if (
+      rawFacet !== 'contender' &&
+      !facetKeys.has(rawFacet as ContenderFacetKey)
+    ) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Invalid facet. Use contender, kind, provider, model, or generator.',
+      })
+    }
+
+    const facet =
+      rawFacet === 'contender' ? null : (rawFacet as ContenderFacetKey)
 
     const submissions = await prisma.challengeSubmission.findMany({
       where: {
@@ -43,6 +73,10 @@ export default defineEventHandler(async (event) => {
             slug: true,
             name: true,
             avatarImageId: true,
+            kind: true,
+            provider: true,
+            model: true,
+            generator: true,
           },
         },
         Reactions: {
@@ -51,21 +85,81 @@ export default defineEventHandler(async (event) => {
       },
     })
 
+    const submissionsByChallenge = new Map<number, typeof submissions>()
+    for (const submission of submissions) {
+      const challengeSubmissions =
+        submissionsByChallenge.get(submission.challengeId) ?? []
+      challengeSubmissions.push(submission)
+      submissionsByChallenge.set(submission.challengeId, challengeSubmissions)
+    }
+
+    event.node.res.statusCode = 200
+
+    if (facet) {
+      const leaderboard = buildFacetLeaderboard(submissions, facet)
+      const challengeIdsByValue = new Map<string, Set<number>>()
+      const winsByValue = new Map<string, number>()
+
+      for (const submission of submissions) {
+        const value = submission.Contender?.[facet]
+        if (!value) continue
+
+        const ids = challengeIdsByValue.get(value) ?? new Set()
+        ids.add(submission.challengeId)
+        challengeIdsByValue.set(value, ids)
+      }
+
+      for (const challengeSubmissions of submissionsByChallenge.values()) {
+        const challengeLeaders = buildFacetLeaderboard(
+          challengeSubmissions,
+          facet,
+        )
+        const winningScore = challengeLeaders[0]?.score.netScore
+        if (winningScore === undefined) continue
+
+        for (const leader of challengeLeaders) {
+          if (leader.score.netScore !== winningScore) break
+          winsByValue.set(
+            leader.value,
+            (winsByValue.get(leader.value) ?? 0) + 1,
+          )
+        }
+      }
+
+      return {
+        success: true,
+        message: `Challenge leaderboard by ${facet} fetched successfully.`,
+        facet,
+        data: leaderboard.map((entry) => {
+          const challengesAttempted =
+            challengeIdsByValue.get(entry.value)?.size ?? 0
+          const challengesWon = winsByValue.get(entry.value) ?? 0
+
+          return {
+            ...entry,
+            challengesAttempted,
+            challengesWon,
+            winRate:
+              challengesAttempted > 0
+                ? Math.round((challengesWon / challengesAttempted) * 1000) / 10
+                : 0,
+          }
+        }),
+        statusCode: 200,
+      }
+    }
+
     const leaderboard = buildChallengeLeaderboard(submissions)
     const challengeIdsByContender = new Map<number, Set<number>>()
     const winsByContender = new Map<number, number>()
-    const submissionsByChallenge = new Map<number, typeof submissions>()
 
     for (const submission of submissions) {
       if (!submission.contenderId) continue
 
-      const ids = challengeIdsByContender.get(submission.contenderId) ?? new Set()
+      const ids =
+        challengeIdsByContender.get(submission.contenderId) ?? new Set()
       ids.add(submission.challengeId)
       challengeIdsByContender.set(submission.contenderId, ids)
-
-      const challengeSubmissions = submissionsByChallenge.get(submission.challengeId) ?? []
-      challengeSubmissions.push(submission)
-      submissionsByChallenge.set(submission.challengeId, challengeSubmissions)
     }
 
     for (const challengeSubmissions of submissionsByChallenge.values()) {
@@ -82,11 +176,10 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    event.node.res.statusCode = 200
-
     return {
       success: true,
       message: 'Global challenge leaderboard fetched successfully.',
+      facet: 'contender',
       data: leaderboard.map((entry) => {
         const challengesAttempted =
           challengeIdsByContender.get(entry.contenderId)?.size ?? 0

--- a/server/utils/challengeCenter.ts
+++ b/server/utils/challengeCenter.ts
@@ -6,6 +6,8 @@ type ChallengeSubmissionScoreInput = {
   id: number
   contenderId: number | null
   variantKey: string
+  promptUsed?: string | null
+  randomSelections?: unknown
   Reactions: ChallengeReaction[]
 }
 
@@ -27,9 +29,37 @@ export type ChallengeLeaderboardEntry = {
   variants: Array<{
     submissionId: number
     variantKey: string
+    promptUsed: string | null
+    randomSelections: unknown
+    rank: number
     score: ChallengeScore
   }>
+  bestVariantKey: string | null
   score: ChallengeScore
+}
+
+/** The Contender fields that facet grouping can key on. */
+export type ContenderFacetKey = 'kind' | 'provider' | 'model' | 'generator'
+
+export type FacetLeaderboardEntry = {
+  facet: ContenderFacetKey
+  value: string
+  contenderSlugs: string[]
+  submissions: number
+  score: ChallengeScore
+  rank: number
+}
+
+type FacetSubmissionInput = {
+  contenderId: number | null
+  Reactions: ChallengeReaction[]
+  Contender: {
+    slug: string
+    kind: string
+    provider: string | null
+    model: string | null
+    generator: string | null
+  } | null
 }
 
 export function scoreChallengeReactions(
@@ -82,6 +112,7 @@ export function buildChallengeLeaderboard(
       avatarImageId: submission.Contender.avatarImageId,
       submissions: 0,
       variants: [],
+      bestVariantKey: null,
       score: {
         loved: 0,
         clapped: 0,
@@ -96,6 +127,9 @@ export function buildChallengeLeaderboard(
     current.variants.push({
       submissionId: submission.id,
       variantKey: submission.variantKey,
+      promptUsed: submission.promptUsed ?? null,
+      randomSelections: submission.randomSelections ?? null,
+      rank: 0,
       score: variantScore,
     })
     current.score.loved += variantScore.loved
@@ -108,6 +142,20 @@ export function buildChallengeLeaderboard(
     entries.set(submission.contenderId, current)
   }
 
+  for (const entry of entries.values()) {
+    entry.variants.sort(
+      (a, b) =>
+        b.score.netScore - a.score.netScore ||
+        b.score.votes - a.score.votes ||
+        a.variantKey.localeCompare(b.variantKey),
+    )
+    entry.variants.forEach((variant, index) => {
+      variant.rank = index + 1
+    })
+    entry.bestVariantKey =
+      entry.variants.length > 1 ? entry.variants[0]!.variantKey : null
+  }
+
   return [...entries.values()]
     .sort(
       (a, b) =>
@@ -116,4 +164,71 @@ export function buildChallengeLeaderboard(
         a.name.localeCompare(b.name),
     )
     .map((entry, index) => ({ ...entry, rank: index + 1 }))
+}
+
+/**
+ * Groups submissions by a Contender facet (kind/provider/model/generator)
+ * instead of by individual contender, so e.g. "all Comfy-backed art
+ * generators" or "all Claude models" can be ranked as one weight class.
+ * Submissions from a contender that doesn't declare the requested facet
+ * are skipped (there's nothing meaningful to group them under).
+ */
+export function buildFacetLeaderboard(
+  submissions: FacetSubmissionInput[],
+  facet: ContenderFacetKey,
+): FacetLeaderboardEntry[] {
+  const entries = new Map<
+    string,
+    FacetLeaderboardEntry & { contenderSlugSet: Set<string> }
+  >()
+
+  for (const submission of submissions) {
+    if (!submission.Contender) continue
+
+    const rawValue = submission.Contender[facet]
+    const value = rawValue && String(rawValue).trim() ? String(rawValue) : null
+    if (!value) continue
+
+    const variantScore = scoreChallengeReactions(submission.Reactions)
+    const current = entries.get(value) ?? {
+      facet,
+      value,
+      contenderSlugs: [],
+      contenderSlugSet: new Set<string>(),
+      submissions: 0,
+      score: {
+        loved: 0,
+        clapped: 0,
+        booed: 0,
+        hated: 0,
+        votes: 0,
+        netScore: 0,
+      },
+      rank: 0,
+    }
+
+    current.submissions += 1
+    current.contenderSlugSet.add(submission.Contender.slug)
+    current.score.loved += variantScore.loved
+    current.score.clapped += variantScore.clapped
+    current.score.booed += variantScore.booed
+    current.score.hated += variantScore.hated
+    current.score.votes += variantScore.votes
+    current.score.netScore += variantScore.netScore
+
+    entries.set(value, current)
+  }
+
+  return [...entries.values()]
+    .sort(
+      (a, b) =>
+        b.score.netScore - a.score.netScore ||
+        b.score.votes - a.score.votes ||
+        a.value.localeCompare(b.value),
+    )
+    .map(({ contenderSlugSet, ...entry }, index) => ({
+      ...entry,
+      contenderSlugs: [...contenderSlugSet].sort(),
+      rank: index + 1,
+    }))
 }

--- a/utils/scripts/verifyChallengeCenter.ts
+++ b/utils/scripts/verifyChallengeCenter.ts
@@ -1,0 +1,177 @@
+// /utils/scripts/verifyChallengeCenter.ts
+import assert from 'node:assert/strict'
+import {
+  buildChallengeLeaderboard,
+  buildFacetLeaderboard,
+  scoreChallengeReactions,
+} from '../../server/utils/challengeCenter'
+
+// scoreChallengeReactions
+assert.deepEqual(
+  scoreChallengeReactions([
+    { reactionType: 'LOVED' },
+    { reactionType: 'LOVED' },
+    { reactionType: 'CLAPPED' },
+    { reactionType: 'BOOED' },
+    { reactionType: 'HATED' },
+  ]),
+  { loved: 2, clapped: 1, booed: 1, hated: 1, votes: 5, netScore: 1 },
+)
+
+// buildChallengeLeaderboard — single-variant contenders rank by netScore
+const claude = {
+  id: 1,
+  slug: 'conductor-claude',
+  name: 'Conductor (Claude)',
+  avatarImageId: null,
+}
+const gpt = {
+  id: 2,
+  slug: 'openai-gpt',
+  name: 'OpenAI GPT',
+  avatarImageId: null,
+}
+
+const singleVariantBoard = buildChallengeLeaderboard([
+  {
+    id: 101,
+    contenderId: 1,
+    variantKey: 'default',
+    Contender: claude,
+    Reactions: [{ reactionType: 'LOVED' }, { reactionType: 'CLAPPED' }],
+  },
+  {
+    id: 102,
+    contenderId: 2,
+    variantKey: 'default',
+    Contender: gpt,
+    Reactions: [{ reactionType: 'BOOED' }],
+  },
+])
+
+assert.equal(singleVariantBoard.length, 2)
+assert.equal(singleVariantBoard[0]!.contenderId, 1)
+assert.equal(singleVariantBoard[0]!.score.netScore, 2)
+assert.equal(
+  singleVariantBoard[0]!.bestVariantKey,
+  null,
+  'a single variant has no "best" to call out',
+)
+assert.equal(singleVariantBoard[0]!.variants[0]!.rank, 1)
+
+// buildChallengeLeaderboard — multi-variant contender surfaces the winning
+// variant plus its promptUsed/randomSelections for the comparison to teach something
+const multiVariantBoard = buildChallengeLeaderboard([
+  {
+    id: 201,
+    contenderId: 1,
+    variantKey: 'random-1',
+    promptUsed: 'A fierce fox guards a tower.',
+    randomSelections: { adjective: 'fierce', animal: 'fox' },
+    Contender: claude,
+    Reactions: [{ reactionType: 'HATED' }],
+  },
+  {
+    id: 202,
+    contenderId: 1,
+    variantKey: 'random-2',
+    promptUsed: 'A gentle owl guards a tower.',
+    randomSelections: { adjective: 'gentle', animal: 'owl' },
+    Contender: claude,
+    Reactions: [
+      { reactionType: 'LOVED' },
+      { reactionType: 'LOVED' },
+      { reactionType: 'CLAPPED' },
+    ],
+  },
+])
+
+assert.equal(multiVariantBoard.length, 1)
+const entry = multiVariantBoard[0]!
+assert.equal(entry.bestVariantKey, 'random-2')
+assert.equal(entry.variants[0]!.variantKey, 'random-2')
+assert.equal(entry.variants[0]!.rank, 1)
+assert.equal(entry.variants[0]!.promptUsed, 'A gentle owl guards a tower.')
+assert.deepEqual(entry.variants[0]!.randomSelections, {
+  adjective: 'gentle',
+  animal: 'owl',
+})
+assert.equal(entry.variants[1]!.variantKey, 'random-1')
+assert.equal(entry.variants[1]!.rank, 2)
+assert.equal(
+  entry.score.netScore,
+  2,
+  'contender score aggregates across both variants',
+)
+
+// buildFacetLeaderboard — groups across contenders sharing a facet value
+const claudeFable = {
+  slug: 'claude-fable',
+  kind: 'LLM_MODEL',
+  provider: 'anthropic',
+  model: 'claude-fable-5',
+  generator: null,
+}
+const claudeOpus = {
+  slug: 'claude-opus',
+  kind: 'LLM_MODEL',
+  provider: 'anthropic',
+  model: 'claude-opus-4-8',
+  generator: null,
+}
+const openaiGpt = {
+  slug: 'openai-gpt',
+  kind: 'LLM_MODEL',
+  provider: 'openai',
+  model: 'gpt-5',
+  generator: null,
+}
+
+const byProvider = buildFacetLeaderboard(
+  [
+    {
+      contenderId: 10,
+      Contender: claudeFable,
+      Reactions: [{ reactionType: 'LOVED' }],
+    },
+    {
+      contenderId: 11,
+      Contender: claudeOpus,
+      Reactions: [{ reactionType: 'LOVED' }, { reactionType: 'CLAPPED' }],
+    },
+    {
+      contenderId: 12,
+      Contender: openaiGpt,
+      Reactions: [{ reactionType: 'BOOED' }],
+    },
+  ],
+  'provider',
+)
+
+assert.equal(byProvider.length, 2)
+assert.equal(byProvider[0]!.value, 'anthropic')
+assert.equal(
+  byProvider[0]!.score.netScore,
+  3,
+  'anthropic aggregates fable + opus',
+)
+assert.deepEqual(byProvider[0]!.contenderSlugs, ['claude-fable', 'claude-opus'])
+assert.equal(byProvider[0]!.rank, 1)
+assert.equal(byProvider[1]!.value, 'openai')
+assert.equal(byProvider[1]!.score.netScore, -1)
+
+// A contender missing the requested facet (null generator) is excluded, not
+// silently grouped under "null" — nothing meaningful to show for that weight class.
+const byGenerator = buildFacetLeaderboard(
+  [
+    {
+      contenderId: 10,
+      Contender: claudeFable,
+      Reactions: [{ reactionType: 'LOVED' }],
+    },
+  ],
+  'generator',
+)
+assert.equal(byGenerator.length, 0)
+
+console.log('Challenge Center leaderboard/facet logic verified.')


### PR DESCRIPTION
### Task
conductor `challenge-center/t-015`: Faceted leaderboards: rank by model, generator, and prompt strategy (kind: software)

### What changed
- `server/utils/challengeCenter.ts`: new `buildFacetLeaderboard()` groups scored submissions by a Contender facet (`kind` | `provider` | `model` | `generator`) instead of by individual contender, so e.g. all Comfy-backed art generators or all Claude models rank as one weight class. Contenders that don't declare the requested facet are excluded rather than silently bucketed under "unknown". Also extended `buildChallengeLeaderboard()`'s per-contender `variants[]` with `promptUsed`, `randomSelections`, and a within-contender `rank`, plus a `bestVariantKey` on the entry — surfaces which prompt variant actually won when one contender enters a challenge multiple times.
- `server/api/challenges/leaderboard.get.ts`: new `facet` query param (`contender` default, or `kind`/`provider`/`model`/`generator`) branches to the facet-grouped leaderboard, with matching `challengesAttempted`/`challengesWon`/`winRate` computed per facet value the same way it's computed per contender today.
- `server/api/challenges/[slug].get.ts`: each submission now carries `variantRank` and `isBestVariant` (derived from the per-challenge leaderboard's variant ranking), so the arena page can flag the winning variant.
- `server/api/challenges/[slug]/leaderboard.get.ts`: select `promptUsed`/`randomSelections` for parity.
- `pages/challenges/leaderboard.vue`: new "Comparison axis" selector (By contender / model / generator / provider / kind) alongside the existing weight-class (challenge type) filter. Podium and table now render a normalized shape so both contender rows and facet rows share the same UI.
- `pages/challenges/[slug].vue`: submission cards show a "Best variant" badge when they're the top-scoring prompt variant for their contender, and a "Random rolls used" collapse rendering `randomSelections` key→value pairs (existing "Exact prompt used" collapse for `promptUsed` was already there).
- `utils/scripts/verifyChallengeCenter.ts` (new, wired as `npm run test:challenge-center`): assert-based tests for `scoreChallengeReactions`, `buildChallengeLeaderboard` (single- and multi-variant contenders, `bestVariantKey`, variant rank/promptUsed/randomSelections), and `buildFacetLeaderboard` (grouping across contenders sharing a facet, missing-facet exclusion).

### How I verified
- `npx tsx utils/scripts/verifyChallengeCenter.ts` — new suite passes.
- `npx tsx utils/scripts/verifyPromptVariants.ts` — unaffected suite still passes.
- `npm run test` (project-wide `vue-tsc --noEmit`) — no new errors; the two pre-existing errors on `main` (`server/api/art/image/index.get.ts`, `server/api/model-builder/items/[id]/commit.post.ts`, tracked in conductor `kind-robots/t-020`) are unchanged.
- `npx eslint` and `npx prettier --check` on all changed files — clean.

### Stakes
reversible

### Flags for Reviewer
- No schema changes — this is query-level grouping over existing `Contender` fields (`kind`/`provider`/`model`/`generator`) per the task note.
- The facet leaderboard's `challengesAttempted`/`challengesWon`/`winRate` are computed per facet *value*, not per contender, so e.g. "anthropic" attempted/won counts aggregate across every Anthropic-backed contender's challenges.

### Kaizen suggestion
`buildChallengeLeaderboard` and `buildFacetLeaderboard` in `server/utils/challengeCenter.ts` now share a lot of accumulate/sort/rank shape but are implemented as two separate loops. A future pass could factor out a generic `groupAndRank(submissions, keyOf, labelOf)` helper — not done here to keep this PR's diff scoped to the task.

### Notes for reviewer
Closes conductor `challenge-center/t-015`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UukqfuRhB7H8xWtjdC9MRq)_