### PR TITLE
coloring-book/t-019: add tutorial card for the Coloring Book art section

### DIFF
--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -275,6 +275,12 @@ export const tutorialChannels = {
         body: 'The admin control room for art generation: manage ComfyUI/SD servers, watch uptime, track images created vs failed, and inspect, requeue, or cancel jobs in the queue.',
         image: tutorialImage('art', 'artjob'),
       },
+      {
+        key: 'coloring',
+        title: 'Coloring Book',
+        body: 'Pick a page from a set, tap a region to fill it, and group-fill matching sections with one color. Switch to a custom shade any time, undo mistakes, and save your progress or export a finished page as an image — it all saves itself as you go.',
+        image: tutorialImage('art', 'coloring'),
+      },
     ],
   },
 


### PR DESCRIPTION
### Task
coloring-book/t-019 (conductor roadmap): Polish and upgrade Coloring Book front-end surface (kind: software)

### What changed
- Added a `coloring` entry to `tutorialChannels.art.sections` in `stores/helpers/tutorialCards.ts`, describing the shipped coloring engine (region/group fill, custom colors, undo, save/export) — matches the shape of sibling sections exactly (`generate`, `gallery`, `styler`, `stylist`, `workbench`, `artjob`).
- Image asset (`public/images/tutorials/art/coloring.webp`) is queued in the conductor art-request pipeline (`projects/art-prompts.yaml`) rather than faked — no `KR_API_TOKEN` available this session to generate it live. `tutorialImage('art', 'coloring')` will resolve correctly once that file lands.

### How I verified
- Reviewed the diff against every sibling entry in `art.sections` for shape parity.
- Confirmed via repo research that `dashboardConfigs.art.tabs` already registers the `coloring` tab and `PROJECT_PLACEMENTS['coloring-book']` already resolves `/coloring` correctly (no code change needed there).
- Could not run `eslint`/`vue-tsc` locally (`.nuxt/eslint.config.mjs` missing — needs `nuxt prepare`); change is a same-shape object literal addition with no new imports or types, low risk.

### Stakes
reversible

### Notes for reviewer
This is a small slice of conductor coloring-book/t-019. The task's other sub-items:
- Missing dashboard-tab/tutorial art (`coloring.webp`, `coloring-page.webp`) — queued in conductor's `art-prompts.yaml` `requests:` list for a future generation pass.
- "Evolve the placeholder scaffold page into the full interactive experience" — research showed the core coloring engine (store/canvas/manager: region+flood fill, undo, palette, export) is already functionally complete; the actual thin spots are the Generate/Proposals/Prompts sub-tabs (generic pitch boards) and only one page set (`sampler`) existing. Filing that as a separate follow-up task in the conductor roadmap rather than expanding this PR's scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_013VmqUsb8CVG3Dy89z1iqaZ)_