### PR TITLE
Make Cypress cleanup zero-leak

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Wait for Vercel to finish deploying THIS commit before tests hit production.
-      # A blind sleep used to race the deploy: `vercel-build` runs `prisma migrate
-      # deploy` during the build, so there is a window where the schema has already
-      # changed but the previous serverless functions are still being served. Tests
-      # landing in that window hit a code/DB mismatch (e.g. the subFolder ->
-      # parentFolder rename returned 500s). Instead, poll /api/version until
-      # production reports the pushed commit as live, then run.
       - name: Wait for deploy to go live
         env:
           BASE_URL: https://kind-robots.vercel.app
@@ -89,7 +82,7 @@ jobs:
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:
-          install: false # already installed above
+          install: false
           browser: chrome
           record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
         env:
@@ -101,6 +94,10 @@ jobs:
           CYPRESS_SYNTHETIC_SOURCE: github-actions-cypress
           CYPRESS_SYNTHETIC_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
+      - name: Verify Cypress cleanup
+        if: always()
+        run: node scripts/verify-cypress-cleanup.mjs
+
       - name: Upload Cypress diagnostic reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -109,6 +106,7 @@ jobs:
           path: |
             .cypress-cache/timing-latest.json
             .cypress-cache/seed-cleanup-latest.json
+            .cypress-cache/orphan-user-sweep-latest.json
           if-no-files-found: warn
 
       - name: Upload Cypress screenshots on failure

--- a/cypress/support/api-auth.ts
+++ b/cypress/support/api-auth.ts
@@ -31,13 +31,7 @@ export type TestUserAuth = {
 export type TestUserRole = 'primary' | 'second' | 'third'
 
 export type CreateLoggedInTestUserOptions = {
-  /**
-   * Use a brand-new disposable remote user instead of the shared per-run seed user.
-   * Keep this for tests that are specifically about registration, deletion, or hard
-   * ownership isolation. Most API specs should use the shared seed for speed.
-   */
   fresh?: boolean
-  /** Pick a stable seed user. When omitted, the primary seed user is used. */
   role?: TestUserRole
 }
 
@@ -83,31 +77,24 @@ const seedUserForRole = (seed: {
 }, role?: TestUserRole) => {
   if (role === 'second') return seed.secondUser
   if (role === 'third') return seed.thirdUser
-
   return seed.user
 }
 
-export const resetSeedUserCursor = () => {
-  // Backward-compatible no-op. Seed users no longer rotate by default.
-}
+export const resetSeedUserCursor = () => {}
 
 export const getApiEnv = () =>
   cy.env(['API_KEY', 'BETA_ADMIN_TOKEN', 'ADMIN_TOKEN', 'BASE_API_URL']).then((env: CypressApiEnv) => {
     const apiBase = String(env.BASE_API_URL || defaultApiBase).replace(/\/+$/, '')
     const adminToken = String(env.ADMIN_TOKEN || env.BETA_ADMIN_TOKEN || env.API_KEY || '')
-
     expect(apiBase, 'api base').to.be.a('string').and.not.be.empty
     expect(adminToken, 'ADMIN_TOKEN, BETA_ADMIN_TOKEN, or API_KEY').to.be.a('string').and.not.be.empty
-
     return { apiBase, adminToken }
   })
 
 export const extractToken = (body: ApiResponse): string => {
   const data = body.data && typeof body.data === 'object' ? dataFromBody(body) : {}
   const token = String(data.token || body.token || body.user?.token || '')
-
   expect(token, 'login token').to.be.a('string').and.have.length.greaterThan(20)
-
   return token
 }
 
@@ -116,9 +103,7 @@ const dataFromBody = (body: ApiResponse) => body.data as Record<string, unknown>
 export const extractUserId = (body: ApiResponse<RegisterUserData>): number => {
   const data = body.data && typeof body.data === 'object' ? body.data : {}
   const id = bodyNumber(body.user?.id) || bodyNumber(data.id)
-
   expect(id, 'registered user id').to.be.a('number')
-
   return id as number
 }
 
@@ -136,79 +121,61 @@ export const createFreshLoggedInTestUser = () =>
     const email = `${username}@example.com`
     const password = defaultTestPassword
 
-    return cy
-      .request<ApiResponse<RegisterUserData>>({
-        method: 'POST',
-        url: `${apiBase}/users/register`,
+    return cy.request<ApiResponse<RegisterUserData>>({
+      method: 'POST',
+      url: `${apiBase}/users/register`,
+      headers: adminHeaders(adminToken),
+      body: { username, email, password },
+      failOnStatusCode: false,
+    }).then((registerResponse) => {
+      expect(registerResponse.status, JSON.stringify(registerResponse.body)).to.be.oneOf([200, 201])
+      const id = extractUserId(registerResponse.body)
+
+      // Register immediately after creation. This survives a spec-level failure because
+      // the Node-side after:run cleanup owns the request independently of Mocha hooks.
+      cy.task('cypressCleanup:register', {
+        label: `fresh Cypress user ${id}`,
+        method: 'DELETE',
+        url: `${apiBase}/users/${id}`,
         headers: adminHeaders(adminToken),
-        body: {
-          username,
-          email,
-          password,
-        },
+        expectedStatuses: [200, 202, 204, 404],
+      }, { log: false })
+
+      return cy.request<ApiResponse>({
+        method: 'POST',
+        url: `${apiBase}/auth/login`,
+        headers: jsonHeaders(),
+        body: { username, password },
         failOnStatusCode: false,
+      }).then((loginResponse) => {
+        expect(loginResponse.status, JSON.stringify(loginResponse.body)).to.eq(200)
+        expect(loginResponse.body.success, JSON.stringify(loginResponse.body)).to.eq(true)
+        const token = extractToken(loginResponse.body)
+        return { id, username, email, password, token } satisfies TestUserAuth
       })
-      .then((registerResponse) => {
-        expect(registerResponse.status, JSON.stringify(registerResponse.body)).to.be.oneOf([200, 201])
-
-        const id = extractUserId(registerResponse.body)
-
-        return cy
-          .request<ApiResponse>({
-            method: 'POST',
-            url: `${apiBase}/auth/login`,
-            headers: jsonHeaders(),
-            body: {
-              username,
-              password,
-            },
-            failOnStatusCode: false,
-          })
-          .then((loginResponse) => {
-            expect(loginResponse.status, JSON.stringify(loginResponse.body)).to.eq(200)
-            expect(loginResponse.body.success, JSON.stringify(loginResponse.body)).to.eq(true)
-
-            const token = extractToken(loginResponse.body)
-
-            return {
-              id,
-              username,
-              email,
-              password,
-              token,
-            } satisfies TestUserAuth
-          })
-      })
+    })
   })
 
 export const createLoggedInTestUser = (options: CreateLoggedInTestUserOptions = {}) => {
   if (options.fresh) return createFreshLoggedInTestUser()
-
   return getSeedTestUser(options.role)
 }
 
 export const deleteTestUser = (apiBase: string, adminToken: string, userId?: number) => {
-  if (!userId) {
-    return cy.wrap(null)
-  }
+  if (!userId) return cy.wrap(null)
 
   return cy.task<boolean>('cypressSeed:isSeedUser', userId).then((isSeedUser) => {
     if (isSeedUser) return null
-
-    return cy
-      .request({
-        method: 'DELETE',
-        url: `${apiBase}/users/${userId}`,
-        headers: adminHeaders(adminToken),
-        failOnStatusCode: false,
-      })
-      .then((response) => {
-        // Cleanup must actually clean up: a leaked test user is a real
-        // failure, not something to swallow silently.
-        expect(
-          response.status,
-          `delete test user ${userId}: ${JSON.stringify(response.body)}`,
-        ).to.be.oneOf([200, 404])
-      })
+    return cy.request({
+      method: 'DELETE',
+      url: `${apiBase}/users/${userId}`,
+      headers: adminHeaders(adminToken),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(
+        response.status,
+        `delete test user ${userId}: ${JSON.stringify(response.body)}`,
+      ).to.be.oneOf([200, 404])
+    })
   })
 }

--- a/cypress/support/cypress-seed/api-seed-node.ts
+++ b/cypress/support/cypress-seed/api-seed-node.ts
@@ -24,17 +24,24 @@ type ApiResponse<T = unknown> = {
   message?: string
   data?: T
   token?: string
-  user?: {
-    id?: number
-    token?: string
-  }
+  user?: { id?: number; token?: string }
+}
+
+type ListedUser = {
+  id?: number
+  username?: string | null
+  email?: string | null
+  createdAt?: string | null
+  Role?: string | null
 }
 
 const defaultApiBase = 'https://kind-robots.vercel.app/api'
 const defaultTestPassword = 'testtest12'
 const seedDir = path.resolve('.cypress-cache')
 const seedFile = path.join(seedDir, 'api-seed.json')
+const orphanReportFile = path.join(seedDir, 'orphan-user-sweep-latest.json')
 const localSyntheticRunId = `local-node-${Date.now()}-${process.pid}`
+const defaultOrphanAgeMs = 2 * 60 * 60 * 1000
 
 let memorySeed: CypressApiSeedState | undefined
 
@@ -44,10 +51,7 @@ const positiveNumber = (value: unknown): number | undefined => {
 }
 
 const cleanHeaderValue = (value: unknown, maxLength = 220) =>
-  String(value ?? '')
-    .replace(/[^\x20-\x7E]/g, ' ')
-    .trim()
-    .slice(0, maxLength)
+  String(value ?? '').replace(/[^\x20-\x7E]/g, ' ').trim().slice(0, maxLength)
 
 const syntheticHeaders = (spec = 'cypress-seed') => ({
   'x-kindrobots-test-source': cleanHeaderValue(
@@ -59,62 +63,47 @@ const syntheticHeaders = (spec = 'cypress-seed') => ({
   'x-kindrobots-test-spec': cleanHeaderValue(spec),
 })
 
-const jsonRequest = async <T = unknown>(url: string, init: RequestInit = {}) => {
+const jsonRequest = async <T = unknown>(url: string, init: RequestInit = {}, spec = 'cypress-seed') => {
   const response = await fetch(url, {
     ...init,
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      ...syntheticHeaders(),
+      ...syntheticHeaders(spec),
       ...(init.headers || {}),
     },
   })
 
   const text = await response.text()
   let body: ApiResponse<T>
-
   try {
     body = text ? JSON.parse(text) : {}
   } catch {
     body = { success: false, message: text }
   }
-
-  return {
-    status: response.status,
-    body,
-  }
+  return { status: response.status, body }
 }
 
 const extractUserId = (body: ApiResponse<Record<string, unknown>>) => {
   const data = body.data && typeof body.data === 'object' ? body.data : {}
   const id = positiveNumber(body.user?.id) || positiveNumber(data.id)
-
-  if (!id) {
-    throw new Error(`Unable to extract user id: ${JSON.stringify(body)}`)
-  }
-
+  if (!id) throw new Error(`Unable to extract user id: ${JSON.stringify(body)}`)
   return id
 }
 
 const extractToken = (body: ApiResponse) => {
-  const data =
-    body.data && typeof body.data === 'object'
-      ? (body.data as Record<string, unknown>)
-      : {}
+  const data = body.data && typeof body.data === 'object'
+    ? (body.data as Record<string, unknown>)
+    : {}
   const token = String(data.token || body.token || body.user?.token || '')
-
   if (!token || token.length < 20) {
     throw new Error(`Unable to extract login token: ${JSON.stringify(body)}`)
   }
-
   return token
 }
 
 const resolveApiBase = (env: Record<string, unknown>) =>
-  String(process.env.BASE_API_URL || env.BASE_API_URL || defaultApiBase).replace(
-    /\/+$/,
-    '',
-  )
+  String(process.env.BASE_API_URL || env.BASE_API_URL || defaultApiBase).replace(/\/+$/, '')
 
 const resolveAdminKey = (env: Record<string, unknown>) =>
   String(
@@ -124,6 +113,78 @@ const resolveAdminKey = (env: Record<string, unknown>) =>
       env.API_KEY ||
       '',
   )
+
+const adminHeaders = (adminKey: string) => ({
+  'x-api-key': adminKey,
+  'x-beta-admin-token': adminKey,
+})
+
+const isCypressUser = (user: ListedUser) => {
+  const username = String(user.username || '')
+  const email = String(user.email || '')
+  return /^cypress-(?:user|target|third)-/i.test(username) ||
+    /^cypress-user-/i.test(username) ||
+    /@example\.com$/i.test(email) && /^cypress-/i.test(email)
+}
+
+const userAgeMs = (user: ListedUser) => {
+  const created = Date.parse(String(user.createdAt || ''))
+  return Number.isFinite(created) ? Date.now() - created : Number.POSITIVE_INFINITY
+}
+
+export const sweepStaleCypressUsers = async (env: Record<string, unknown>) => {
+  const apiBase = resolveApiBase(env)
+  const adminKey = resolveAdminKey(env)
+  if (!adminKey) throw new Error('Cypress orphan sweep requires API_KEY or BETA_ADMIN_TOKEN.')
+
+  const configuredAge = Number(
+    process.env.CYPRESS_ORPHAN_MAX_AGE_MS || env.CYPRESS_ORPHAN_MAX_AGE_MS,
+  )
+  const maxAgeMs = Number.isFinite(configuredAge) && configuredAge >= 0
+    ? configuredAge
+    : defaultOrphanAgeMs
+
+  const listed = await jsonRequest<ListedUser[]>(
+    `${apiBase}/users`,
+    { headers: adminHeaders(adminKey) },
+    'cypress-orphan-sweep',
+  )
+  const rawUsers = Array.isArray(listed.body.data) ? listed.body.data : []
+  const candidates = rawUsers.filter((user) =>
+    isCypressUser(user) && user.Role !== 'ADMIN' && userAgeMs(user) >= maxAgeMs,
+  )
+
+  const results: unknown[] = []
+  for (const user of candidates) {
+    const id = positiveNumber(user.id)
+    if (!id) continue
+    const deleted = await jsonRequest(
+      `${apiBase}/users/${id}`,
+      { method: 'DELETE', headers: adminHeaders(adminKey) },
+      'cypress-orphan-sweep',
+    )
+    results.push({
+      id,
+      username: user.username,
+      ageMs: userAgeMs(user),
+      status: deleted.status,
+      ok: [200, 202, 204, 404].includes(deleted.status),
+      body: deleted.body,
+    })
+  }
+
+  fs.mkdirSync(seedDir, { recursive: true })
+  fs.writeFileSync(
+    orphanReportFile,
+    `${JSON.stringify({ createdAt: new Date().toISOString(), maxAgeMs, candidates: candidates.length, results }, null, 2)}\n`,
+  )
+
+  const failures = results.filter((item: any) => !item.ok)
+  if (failures.length > 0) {
+    throw new Error(`Failed to remove ${failures.length} abandoned Cypress users: ${JSON.stringify(failures)}`)
+  }
+  return results
+}
 
 const makeSeedUser = async (
   apiBase: string,
@@ -135,44 +196,35 @@ const makeSeedUser = async (
   const email = `${username}@example.com`
   const password = defaultTestPassword
 
-  const register = await jsonRequest<Record<string, unknown>>(
-    `${apiBase}/users/register`,
-    {
-      method: 'POST',
-      headers: {
-        'x-api-key': adminKey,
-      },
-      body: JSON.stringify({ username, email, password }),
-    },
-  )
-
+  const register = await jsonRequest<Record<string, unknown>>(`${apiBase}/users/register`, {
+    method: 'POST',
+    headers: { 'x-api-key': adminKey },
+    body: JSON.stringify({ username, email, password }),
+  })
   if (![200, 201].includes(register.status)) {
-    throw new Error(
-      `Seed user register failed for ${role}: ${register.status} ${JSON.stringify(register.body)}`,
-    )
+    throw new Error(`Seed user register failed for ${role}: ${register.status} ${JSON.stringify(register.body)}`)
   }
 
   const id = extractUserId(register.body)
-
   const login = await jsonRequest(`${apiBase}/auth/login`, {
     method: 'POST',
     body: JSON.stringify({ username, password }),
   })
-
   if (login.status !== 200 || login.body.success === false) {
-    throw new Error(
-      `Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)}`,
+    // Registration succeeded but login failed. Remove the partial user immediately.
+    await jsonRequest(
+      `${apiBase}/users/${id}`,
+      { method: 'DELETE', headers: adminHeaders(adminKey) },
+      'cypress-seed-rollback',
     )
+    throw new Error(`Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)}`)
   }
 
-  const token = extractToken(login.body)
-
-  return { id, username, email, password, token }
+  return { id, username, email, password, token: extractToken(login.body) }
 }
 
 const readSeed = (): CypressApiSeedState | undefined => {
   if (!fs.existsSync(seedFile)) return undefined
-
   try {
     return JSON.parse(fs.readFileSync(seedFile, 'utf8')) as CypressApiSeedState
   } catch {
@@ -195,42 +247,48 @@ export const ensureCypressApiSeed = async (env: Record<string, unknown>) => {
 
   const apiBase = resolveApiBase(env)
   const adminKey = resolveAdminKey(env)
+  if (!adminKey) throw new Error('Cypress API seed requires API_KEY or BETA_ADMIN_TOKEN.')
 
-  if (!adminKey) {
-    throw new Error('Cypress API seed requires API_KEY or BETA_ADMIN_TOKEN.')
-  }
+  await sweepStaleCypressUsers(env)
 
   const cached = readSeed()
-
   if (cached?.apiBase === apiBase && cached?.adminKey === adminKey) {
     memorySeed = cached
     return cached
   }
 
   const runId = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
+  const created: CypressApiSeedUser[] = []
+  try {
+    created.push(await makeSeedUser(apiBase, adminKey, runId, 'user'))
+    created.push(await makeSeedUser(apiBase, adminKey, runId, 'target'))
+    created.push(await makeSeedUser(apiBase, adminKey, runId, 'third'))
+  } catch (error) {
+    for (const user of created.reverse()) {
+      await jsonRequest(
+        `${apiBase}/users/${user.id}`,
+        { method: 'DELETE', headers: adminHeaders(adminKey) },
+        'cypress-seed-rollback',
+      )
+    }
+    throw error
+  }
 
   const seed: CypressApiSeedState = {
     runId,
     apiBase,
     adminKey,
-    user: await makeSeedUser(apiBase, adminKey, runId, 'user'),
-    secondUser: await makeSeedUser(apiBase, adminKey, runId, 'target'),
-    thirdUser: await makeSeedUser(apiBase, adminKey, runId, 'third'),
+    user: created[0]!,
+    secondUser: created[1]!,
+    thirdUser: created[2]!,
     fixtures: {},
   }
-
   writeSeed(seed)
   memorySeed = seed
-
   return seed
 }
 
-export const isSeedUserId = async (
-  env: Record<string, unknown>,
-  userId: number,
-) => {
+export const isSeedUserId = async (env: Record<string, unknown>, userId: number) => {
   const seed = await ensureCypressApiSeed(env)
-  return [seed.user.id, seed.secondUser.id, seed.thirdUser.id].includes(
-    Number(userId),
-  )
+  return [seed.user.id, seed.secondUser.id, seed.thirdUser.id].includes(Number(userId))
 }

--- a/scripts/verify-cypress-cleanup.mjs
+++ b/scripts/verify-cypress-cleanup.mjs
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const cleanupFile = path.resolve('.cypress-cache/seed-cleanup-latest.json')
+const orphanFile = path.resolve('.cypress-cache/orphan-user-sweep-latest.json')
+
+const readJson = (file) => {
+  if (!fs.existsSync(file)) {
+    throw new Error(`Missing Cypress cleanup report: ${file}`)
+  }
+  return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+const cleanup = readJson(cleanupFile)
+const orphan = readJson(orphanFile)
+const failures = []
+
+for (const entry of Array.isArray(cleanup) ? cleanup : []) {
+  if (entry?.ok === false) failures.push({ source: path.basename(cleanupFile), entry })
+}
+for (const entry of Array.isArray(orphan?.results) ? orphan.results : []) {
+  if (entry?.ok === false) failures.push({ source: path.basename(orphanFile), entry })
+}
+
+if (failures.length > 0) {
+  console.error(`Cypress cleanup leaked ${failures.length} item(s).`)
+  console.error(JSON.stringify(failures, null, 2))
+  process.exit(1)
+}
+
+console.log(
+  `Cypress cleanup verified: ${Array.isArray(cleanup) ? cleanup.length : 0} cleanup result(s), ` +
+    `${Number(orphan?.candidates || 0)} stale user candidate(s).`,
+)

--- a/server/utils/userPurge.ts
+++ b/server/utils/userPurge.ts
@@ -3,14 +3,8 @@ import prisma from './prisma'
 
 export type UserPurgeCounts = Record<string, number>
 
-// Deletes a user together with their owned content. Since the explicit
-// onDelete pass, the schema itself no longer blocks user deletion: content
-// relations (ArtCollection, Code, Dream, ...) orphan via SET NULL and
-// user-scoped rows (reactions, ledgers, relations, referrals) cascade. This
-// helper exists so an account wipe removes the content outright instead of
-// stranding orphans — that orphan pile-up is exactly the test-fixture bloat
-// this was built to stop. The explicit deletes on cascading tables are
-// redundant with the DB but kept for the per-table counts they report.
+// Delete the account and the content it owns instead of relying on SET NULL,
+// which turns disposable Cypress fixtures into permanent orphan records.
 export async function deleteUserWithOwnedData(
   userId: number,
 ): Promise<UserPurgeCounts> {
@@ -35,8 +29,6 @@ export async function deleteUserWithOwnedData(
       )
       track('reactions', await tx.reaction.deleteMany({ where: { userId } }))
 
-      // ChallengeSubmission -> Challenge is RESTRICT: clear submissions on the
-      // user's challenges before the challenges themselves.
       const challenges = await tx.challenge.findMany({
         where: { userId },
         select: { id: true },
@@ -45,11 +37,16 @@ export async function deleteUserWithOwnedData(
         track(
           'challengeSubmissions',
           await tx.challengeSubmission.deleteMany({
-            where: { challengeId: { in: challenges.map((c) => c.id) } },
+            where: { challengeId: { in: challenges.map((challenge) => challenge.id) } },
           }),
         )
       }
       track('challenges', await tx.challenge.deleteMany({ where: { userId } }))
+
+      // Delete dependent conversational rows before their bots.
+      track('chats', await tx.chat.deleteMany({ where: { userId } }))
+      track('bots', await tx.bot.deleteMany({ where: { userId } }))
+      track('rewards', await tx.reward.deleteMany({ where: { userId } }))
 
       track(
         'artCollections',
@@ -65,7 +62,12 @@ export async function deleteUserWithOwnedData(
         'socialPosts',
         await tx.socialPost.deleteMany({ where: { userId } }),
       )
+
+      // ArtImages may reference prompts and servers, so remove them first.
       track('artImages', await tx.artImage.deleteMany({ where: { userId } }))
+      track('prompts', await tx.prompt.deleteMany({ where: { userId } }))
+      track('servers', await tx.server.deleteMany({ where: { userId } }))
+
       track(
         'manaTransactions',
         await tx.manaTransaction.deleteMany({ where: { userId } }),
@@ -80,7 +82,6 @@ export async function deleteUserWithOwnedData(
       )
 
       await tx.user.delete({ where: { id: userId } })
-
       return counts
     },
     { timeout: 30000 },


### PR DESCRIPTION
Registers fresh test users for runner-owned cleanup, sweeps abandoned Cypress users before each run, rolls back partial seed creation, expands user-owned data purge, and fails CI when cleanup reports a leak. Draft until the exact-head preview validates the Prisma delegates; Vercel currently reports a build-rate-limit failure before build.