### PR TITLE
Remove duplicate animation auto-imports

### DIFF
--- a/components/screenfx/animation-layer.vue
+++ b/components/screenfx/animation-layer.vue
@@ -46,9 +46,9 @@
 import { computed, resolveComponent } from 'vue'
 import {
   getAnimationComponentName,
-  useAnimationStore,
   type AnimationEffectId,
-} from '@/stores/animationStore'
+} from '@/stores/animationCatalog'
+import { useAnimationStore } from '@/stores/animationStore'
 
 const animationStore = useAnimationStore()
 

--- a/components/screenfx/fx-region.vue
+++ b/components/screenfx/fx-region.vue
@@ -30,10 +30,12 @@
 import { computed, onMounted, ref, resolveComponent } from 'vue'
 import {
   getAnimationComponentName,
-  useAnimationStore,
   type AnimationEffectId,
-  type FxPlacement,
   type FxRegion,
+} from '@/stores/animationCatalog'
+import {
+  useAnimationStore,
+  type FxPlacement,
 } from '@/stores/animationStore'
 
 const props = defineProps<{

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -27,9 +27,9 @@ import {
 } from 'vue'
 import {
   getAnimationComponentName,
-  useAnimationStore,
   type AnimationEffectId,
-} from '@/stores/animationStore'
+} from '@/stores/animationCatalog'
+import { useAnimationStore } from '@/stores/animationStore'
 import { useAnimationPreferenceStore } from '@/stores/animationPreferenceStore'
 import { useButterflyStore } from '@/stores/butterflyStore'
 

--- a/stores/animationPreferenceStore.ts
+++ b/stores/animationPreferenceStore.ts
@@ -1,7 +1,10 @@
 // /stores/animationPreferenceStore.ts
 import { defineStore } from 'pinia'
 import { computed, reactive, ref } from 'vue'
-import { isAnimationEffectId, type AnimationEffectId } from './animationStore'
+import {
+  isAnimationEffectId,
+  type AnimationEffectId,
+} from './animationCatalog'
 
 export type StartupAnimationChoice = AnimationEffectId | 'random' | 'none'
 

--- a/stores/animationStore.ts
+++ b/stores/animationStore.ts
@@ -8,12 +8,10 @@ import {
   type FxRegion,
 } from './animationCatalog'
 
-export {
-  getAnimationComponentName,
-  isAnimationEffectId,
-  type AnimationEffect,
-  type AnimationEffectId,
-  type FxRegion,
+export type {
+  AnimationEffect,
+  AnimationEffectId,
+  FxRegion,
 } from './animationCatalog'
 
 export type FxPlacement = 'behind' | 'front'


### PR DESCRIPTION
## What changed

- keep `getAnimationComponentName` and `isAnimationEffectId` owned by `animationCatalog.ts`
- stop re-exporting those runtime helpers from `animationStore.ts`
- import catalog helpers directly in the animation layer, FX region, startup animation, and preference store
- preserve the store's type re-exports for existing type consumers

## Root cause

Nuxt scans both files in `stores/` for auto-importable runtime exports. Re-exporting the catalog helpers from the store registered each helper twice, so Nuxt ignored one source and emitted duplicate-import warnings during `nuxi prepare` and production builds.

## Expected result

`nuxi prepare` should no longer report duplicated imports for `getAnimationComponentName` or `isAnimationEffectId`. Animation behavior is unchanged.