### PR TITLE
challenge-center: validate seed catalogs in CI without a database

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Navigation route access contract
         run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
 
+      - name: Challenge Center seed validation (dry run, no database)
+        run: |
+          npm run test:seed-challenges
+          npm run test:seed-contenders
+
       - name: Channel artwork audit
         run: npm run audit:channel-assets 2>&1 | tee channel-artwork-audit.txt
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
     "test:challenge-center": "tsx utils/scripts/verifyChallengeCenter.ts",
+    "test:seed-challenges": "tsx scripts/seed_challenges.ts",
+    "test:seed-contenders": "tsx scripts/seed_contenders.ts",
     "vercel-build": "prisma generate && node scripts/prisma-migrate-deploy.mjs && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
     "dev": "nuxt dev --host",
     "build": "nuxi prepare && prisma generate && nuxi build",


### PR DESCRIPTION
## Summary

Kaizen from conductor `challenge-center/t-018` (Worker's suggestion on kind_robots PR #199): add a CI check that runs the Challenge Center seed scripts in validation-only mode so a malformed seed catalog (bad enum value, missing required field, duplicate slug, wrong type coverage) fails CI before merge instead of only being caught by manual review.

- `scripts/seed_challenges.ts` and `scripts/seed_contenders.ts` already validate their catalogs (`validateChallengeSeeds`/`validateContenderSeeds`) and skip all Prisma/DB work unless run with `--write` — so running them plain is already a pure, DB-free dry run.
- Added `test:seed-challenges` / `test:seed-contenders` npm scripts as explicit, discoverable aliases for that dry-run mode.
- Wired both into `.github/workflows/contract-tests.yml`, which already documents itself as "Fast, DB-free contract checks... can gate every pull request" — the natural home for this check, no new workflow needed.

## Verification

- Ran both scripts locally with no `DATABASE_URL` set: both validate and print a preview table, exit 0, no DB touched.
- Confirmed the failure path: temporarily fed `validateChallengeSeeds` a duplicate-slug/short catalog and confirmed it throws (`main()`'s `.catch` sets `process.exitCode = 1`), so CI will actually fail on a broken catalog.
- `npx prettier --check package.json .github/workflows/contract-tests.yml` — clean.
- Confirmed `prisma/generated/prisma/client` is checked into the repo, so no `prisma generate` step is needed before these run in CI.

## Out of scope

`utils/scripts/seedDaVinciEndings.ts` (mentioned in the original kaizen note as a script following "the same pattern") takes a required JSONL/JSON file argument rather than an embedded catalog, so it can't dry-run standalone the same way. It already has its own nightly DB-backed regression job (`davinci-seed-verify.yml`) that generates real fixture data via conductor's generator; extending this fast, file-free contract-tests job to cover it would need a checked-in fixture and is a larger change than this task's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyUnFs7jdftvK56r9XF6yK


---
_Generated by [Claude Code](https://claude.ai/code/session_01XyUnFs7jdftvK56r9XF6yK)_