### PR TITLE
Retry transient Cypress seed failures safely

### DIFF
--- a/cypress/support/cypress-seed/api-seed-node.ts
+++ b/cypress/support/cypress-seed/api-seed-node.ts
@@ -25,6 +25,21 @@ type ApiResponse<T = unknown> = {
   data?: T
   token?: string
   user?: { id?: number; token?: string }
+  error?: unknown
+}
+
+type ApiAttempt = {
+  attempt: number
+  status?: number
+  retryable: boolean
+  message?: string
+  error?: string
+}
+
+type JsonRequestResult<T = unknown> = {
+  status: number
+  body: ApiResponse<T>
+  attempts: ApiAttempt[]
 }
 
 type ListedUser = {
@@ -42,6 +57,8 @@ const seedFile = path.join(seedDir, 'api-seed.json')
 const orphanReportFile = path.join(seedDir, 'orphan-user-sweep-latest.json')
 const localSyntheticRunId = `local-node-${Date.now()}-${process.pid}`
 const defaultOrphanAgeMs = 2 * 60 * 60 * 1000
+const defaultRequestAttempts = 5
+const retryableStatuses = new Set([408, 425, 429, 500, 502, 503, 504])
 
 let memorySeed: CypressApiSeedState | undefined
 
@@ -63,25 +80,94 @@ const syntheticHeaders = (spec = 'cypress-seed') => ({
   'x-kindrobots-test-spec': cleanHeaderValue(spec),
 })
 
-const jsonRequest = async <T = unknown>(url: string, init: RequestInit = {}, spec = 'cypress-seed') => {
-  const response = await fetch(url, {
-    ...init,
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      ...syntheticHeaders(spec),
-      ...(init.headers || {}),
-    },
-  })
+const requestAttemptLimit = () => {
+  const configured = positiveNumber(process.env.CYPRESS_HTTP_MAX_ATTEMPTS)
+  return configured ? Math.max(1, Math.min(10, Math.floor(configured))) : defaultRequestAttempts
+}
 
-  const text = await response.text()
-  let body: ApiResponse<T>
+const retryDelayMs = (attempt: number) => Math.min(500 * 2 ** Math.max(0, attempt - 1), 4000)
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const responseMessage = (body: ApiResponse) => {
+  if (body.message) return body.message
+  if (body.error === undefined) return undefined
+
+  if (typeof body.error === 'string') return body.error
   try {
-    body = text ? JSON.parse(text) : {}
+    return JSON.stringify(body.error)
   } catch {
-    body = { success: false, message: text }
+    return String(body.error)
   }
-  return { status: response.status, body }
+}
+
+const jsonRequest = async <T = unknown>(
+  url: string,
+  init: RequestInit = {},
+  spec = 'cypress-seed',
+): Promise<JsonRequestResult<T>> => {
+  const attempts: ApiAttempt[] = []
+  const maxAttempts = requestAttemptLimit()
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...syntheticHeaders(spec),
+          ...(init.headers || {}),
+        },
+      })
+
+      const text = await response.text()
+      let body: ApiResponse<T>
+      try {
+        body = text ? JSON.parse(text) : {}
+      } catch {
+        body = { success: false, message: text }
+      }
+
+      const retryable = retryableStatuses.has(response.status)
+      attempts.push({
+        attempt,
+        status: response.status,
+        retryable,
+        message: responseMessage(body),
+      })
+
+      if (!retryable || attempt === maxAttempts) {
+        return { status: response.status, body, attempts }
+      }
+
+      const delayMs = retryDelayMs(attempt)
+      console.warn(
+        `[cypress-seed] transient HTTP ${response.status} for ${spec}; ` +
+          `retrying ${attempt + 1}/${maxAttempts} in ${delayMs}ms`,
+      )
+      await wait(delayMs)
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      attempts.push({ attempt, retryable: true, error: errorMessage })
+
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `Cypress seed request failed after ${maxAttempts} attempts: ` +
+            `${init.method || 'GET'} ${url} ${JSON.stringify(attempts)}`,
+        )
+      }
+
+      const delayMs = retryDelayMs(attempt)
+      console.warn(
+        `[cypress-seed] transient fetch error for ${spec}: ${errorMessage}; ` +
+          `retrying ${attempt + 1}/${maxAttempts} in ${delayMs}ms`,
+      )
+      await wait(delayMs)
+    }
+  }
+
+  throw new Error(`Cypress seed request exhausted without a result: ${init.method || 'GET'} ${url}`)
 }
 
 const extractUserId = (body: ApiResponse<Record<string, unknown>>) => {
@@ -132,7 +218,54 @@ const userAgeMs = (user: ListedUser) => {
   return Number.isFinite(created) ? Date.now() - created : Number.POSITIVE_INFINITY
 }
 
-export const sweepStaleCypressUsers = async (env: Record<string, unknown>) => {
+const listedUsersFromResponse = (response: JsonRequestResult<ListedUser[]>) => {
+  if (response.status !== 200 || response.body.success === false) {
+    throw new Error(
+      `Unable to list Cypress users: ${response.status} ` +
+        `${JSON.stringify(response.body)} attempts=${JSON.stringify(response.attempts)}`,
+    )
+  }
+  return Array.isArray(response.body.data) ? response.body.data : []
+}
+
+const findUserIdByUsername = async (
+  apiBase: string,
+  adminKey: string,
+  username: string,
+): Promise<number | undefined> => {
+  const listed = await jsonRequest<ListedUser[]>(
+    `${apiBase}/users`,
+    { headers: adminHeaders(adminKey) },
+    'cypress-seed-user-lookup',
+  )
+  const users = listedUsersFromResponse(listed)
+  return positiveNumber(users.find((user) => user.username === username)?.id)
+}
+
+const deleteSeedUserById = async (
+  apiBase: string,
+  adminKey: string,
+  id: number,
+  spec = 'cypress-seed-rollback',
+) => {
+  const deleted = await jsonRequest(
+    `${apiBase}/users/${id}`,
+    { method: 'DELETE', headers: adminHeaders(adminKey) },
+    spec,
+  )
+  if (![200, 202, 204, 404].includes(deleted.status)) {
+    throw new Error(
+      `Seed user rollback failed for ${id}: ${deleted.status} ` +
+        `${JSON.stringify(deleted.body)} attempts=${JSON.stringify(deleted.attempts)}`,
+    )
+  }
+  return deleted
+}
+
+export const sweepStaleCypressUsers = async (
+  env: Record<string, unknown>,
+  excludedUserIds: number[] = [],
+) => {
   const apiBase = resolveApiBase(env)
   const adminKey = resolveAdminKey(env)
   if (!adminKey) throw new Error('Cypress orphan sweep requires API_KEY or BETA_ADMIN_TOKEN.')
@@ -143,16 +276,24 @@ export const sweepStaleCypressUsers = async (env: Record<string, unknown>) => {
   const maxAgeMs = Number.isFinite(configuredAge) && configuredAge >= 0
     ? configuredAge
     : defaultOrphanAgeMs
+  const excludedIds = new Set(excludedUserIds.map(Number))
 
   const listed = await jsonRequest<ListedUser[]>(
     `${apiBase}/users`,
     { headers: adminHeaders(adminKey) },
     'cypress-orphan-sweep',
   )
-  const rawUsers = Array.isArray(listed.body.data) ? listed.body.data : []
-  const candidates = rawUsers.filter((user) =>
-    isCypressUser(user) && user.Role !== 'ADMIN' && userAgeMs(user) >= maxAgeMs,
-  )
+  const rawUsers = listedUsersFromResponse(listed)
+  const candidates = rawUsers.filter((user) => {
+    const id = positiveNumber(user.id)
+    return Boolean(
+      id &&
+      !excludedIds.has(id) &&
+      isCypressUser(user) &&
+      user.Role !== 'ADMIN' &&
+      userAgeMs(user) >= maxAgeMs,
+    )
+  })
 
   const results: unknown[] = []
   for (const user of candidates) {
@@ -170,6 +311,7 @@ export const sweepStaleCypressUsers = async (env: Record<string, unknown>) => {
       status: deleted.status,
       ok: [200, 202, 204, 404].includes(deleted.status),
       body: deleted.body,
+      attempts: deleted.attempts,
     })
   }
 
@@ -201,26 +343,52 @@ const makeSeedUser = async (
     headers: { 'x-api-key': adminKey },
     body: JSON.stringify({ username, email, password }),
   })
-  if (![200, 201].includes(register.status)) {
-    throw new Error(`Seed user register failed for ${role}: ${register.status} ${JSON.stringify(register.body)}`)
+
+  const registrationSucceeded = [200, 201].includes(register.status)
+  const registrationAmbiguous = register.status === 409 ||
+    register.attempts.some((attempt) => attempt.retryable)
+
+  if (!registrationSucceeded && !registrationAmbiguous) {
+    throw new Error(
+      `Seed user register failed for ${role}: ${register.status} ` +
+        `${JSON.stringify(register.body)} attempts=${JSON.stringify(register.attempts)}`,
+    )
   }
 
-  const id = extractUserId(register.body)
-  const login = await jsonRequest(`${apiBase}/auth/login`, {
+  let id = registrationSucceeded ? extractUserId(register.body) : undefined
+
+  const login = await jsonRequest<Record<string, unknown>>(`${apiBase}/auth/login`, {
     method: 'POST',
     body: JSON.stringify({ username, password }),
   })
-  if (login.status !== 200 || login.body.success === false) {
-    // Registration succeeded but login failed. Remove the partial user immediately.
-    await jsonRequest(
-      `${apiBase}/users/${id}`,
-      { method: 'DELETE', headers: adminHeaders(adminKey) },
-      'cypress-seed-rollback',
-    )
-    throw new Error(`Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)}`)
+
+  if (login.status === 200 && login.body.success !== false) {
+    if (!id) {
+      id = extractUserId(login.body)
+      console.warn(
+        `[cypress-seed] recovered ${role} user ${id} after ambiguous registration ` +
+          `(final status ${register.status})`,
+      )
+    }
+    return { id, username, email, password, token: extractToken(login.body) }
   }
 
-  return { id, username, email, password, token: extractToken(login.body) }
+  try {
+    id = id || await findUserIdByUsername(apiBase, adminKey, username)
+    if (id) await deleteSeedUserById(apiBase, adminKey, id)
+  } catch (rollbackError) {
+    throw new Error(
+      `Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)} ` +
+        `loginAttempts=${JSON.stringify(login.attempts)}; rollback also failed: ` +
+        `${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+    )
+  }
+
+  throw new Error(
+    `Seed user login failed for ${role}: ${login.status} ${JSON.stringify(login.body)} ` +
+      `registerAttempts=${JSON.stringify(register.attempts)} ` +
+      `loginAttempts=${JSON.stringify(login.attempts)}`,
+  )
 }
 
 const readSeed = (): CypressApiSeedState | undefined => {
@@ -249,12 +417,19 @@ export const ensureCypressApiSeed = async (env: Record<string, unknown>) => {
   const adminKey = resolveAdminKey(env)
   if (!adminKey) throw new Error('Cypress API seed requires API_KEY or BETA_ADMIN_TOKEN.')
 
-  await sweepStaleCypressUsers(env)
-
   const cached = readSeed()
-  if (cached?.apiBase === apiBase && cached?.adminKey === adminKey) {
-    memorySeed = cached
-    return cached
+  const reusableCache = cached?.apiBase === apiBase && cached?.adminKey === adminKey
+    ? cached
+    : undefined
+  const cachedUserIds = reusableCache
+    ? [reusableCache.user.id, reusableCache.secondUser.id, reusableCache.thirdUser.id]
+    : []
+
+  await sweepStaleCypressUsers(env, cachedUserIds)
+
+  if (reusableCache) {
+    memorySeed = reusableCache
+    return reusableCache
   }
 
   const runId = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
@@ -264,11 +439,20 @@ export const ensureCypressApiSeed = async (env: Record<string, unknown>) => {
     created.push(await makeSeedUser(apiBase, adminKey, runId, 'target'))
     created.push(await makeSeedUser(apiBase, adminKey, runId, 'third'))
   } catch (error) {
+    const rollbackFailures: string[] = []
     for (const user of created.reverse()) {
-      await jsonRequest(
-        `${apiBase}/users/${user.id}`,
-        { method: 'DELETE', headers: adminHeaders(adminKey) },
-        'cypress-seed-rollback',
+      try {
+        await deleteSeedUserById(apiBase, adminKey, user.id)
+      } catch (rollbackError) {
+        rollbackFailures.push(
+          rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+        )
+      }
+    }
+    if (rollbackFailures.length > 0) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; ` +
+          `seed rollback failures=${JSON.stringify(rollbackFailures)}`,
       )
     }
     throw error


### PR DESCRIPTION
Fixes the before:run failure caused by transient Vercel 504 responses during disposable-user registration. Node-side seed and cleanup requests now retry retryable HTTP/network failures with bounded exponential backoff and retain an attempt trace. Registration handles the ambiguous case where Vercel returns 504 after committing the user: the harness logs into the uniquely named account and recovers its ID rather than leaking it or failing on a later 409. User listing and rollback deletion now validate responses and use the same retry behavior.

The exact-head Vercel preview is currently blocked before build by the account build-rate limit, so this remains draft until local TypeScript/Cypress validation or a completed preview confirms it.