### PR TITLE
Restore production database connectivity

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -52,14 +52,6 @@ function buildDatabaseUrl(url: string): string {
     process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
     0,
   )
-  const idleTimeout = readPositiveInteger(
-    process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
-    30,
-  )
-  const minimumIdle = readNonNegativeInteger(
-    process.env.DATABASE_MINIMUM_IDLE,
-    0,
-  )
 
   if (!parsed.searchParams.has('connectTimeout')) {
     parsed.searchParams.set('connectTimeout', String(connectTimeout))
@@ -75,18 +67,6 @@ function buildDatabaseUrl(url: string): string {
 
   if (!parsed.searchParams.has('minDelayValidation')) {
     parsed.searchParams.set('minDelayValidation', String(minDelayValidation))
-  }
-
-  // Every warm Vercel function has its own pool. A default pool of ten lets a
-  // small traffic burst multiply into hundreds of database sockets. Keep the
-  // pool elastic and small; all values remain overridable through environment
-  // variables for non-serverless deployments.
-  if (!parsed.searchParams.has('idleTimeout')) {
-    parsed.searchParams.set('idleTimeout', String(idleTimeout))
-  }
-
-  if (!parsed.searchParams.has('minimumIdle')) {
-    parsed.searchParams.set('minimumIdle', String(minimumIdle))
   }
 
   return parsed.toString()
@@ -145,14 +125,6 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     ),
     minDelayValidation: readNonNegativeInteger(
       parsed.searchParams.get('minDelayValidation') ?? undefined,
-      0,
-    ),
-    idleTimeout: readPositiveInteger(
-      parsed.searchParams.get('idleTimeout') ?? undefined,
-      30,
-    ),
-    minimumIdle: readNonNegativeInteger(
-      parsed.searchParams.get('minimumIdle') ?? undefined,
       0,
     ),
     ssl: tlsOptions,

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["iad1"],
   "git": {
     "deploymentEnabled": {
       "claude/*": false,


### PR DESCRIPTION
## Incident

Production deployment `dpl_7rDbosokgfVp1fciKvTFh8qqHGm4` cannot establish even one MariaDB connection. Runtime logs consistently show `active=0 idle=0`, so this is connection creation failure rather than local pool exhaustion.

The same deployment successfully verified a TLS connection to ProxySQL and ran Prisma migrations from Vercel's `iad1` build machine, while the deployed functions execute in `sfo1` and fail every database-backed request.

## Emergency recovery

- Run Vercel functions in `iad1`, matching the environment where ProxySQL TLS connectivity was proven during the build.
- Remove the recently-added `minimumIdle` and `idleTimeout` options from the Prisma MariaDB adapter configuration, restoring its pre-incident initialization behavior.
- Keep the bounded serverless settings already deployed: connection limit 2, six-second acquisition timeout, and two transient retries.

## Verification after merge

1. Confirm the production deployment reports region `iad1`.
2. Run `curl -i https://kind-robots.vercel.app/api/health/database` until it returns HTTP 200 and `success: true`.
3. Pull `main` locally before rerunning Cypress so the targeted nonblocking cleanup helper is present.

This branch does not receive a preview deployment because `agent/*` deployments are intentionally disabled in `vercel.json`; production health is therefore the decisive validation.