### PR TITLE
fix(db): fail fast on pool starvation + stop leaking secrets in logs

### DIFF
--- a/server/api/auth/google/callback.ts
+++ b/server/api/auth/google/callback.ts
@@ -1,6 +1,7 @@
 import { defineEventHandler, getQuery, sendRedirect, createError } from 'h3'
 import prisma from '../../../utils/prisma'
 import { createToken } from '..'
+import { logSafeError } from '../../../utils/error'
 
 interface GoogleTokenResponse {
   access_token: string
@@ -89,7 +90,7 @@ export default defineEventHandler(async (event) => {
 
     return sendRedirect(event, redirectTarget)
   } catch (error) {
-    console.error('[Google Callback] ❌ Fatal error:', error)
+    logSafeError('[Google Callback] ❌ Fatal error:', error)
     throw createError({ statusCode: 500, message: 'Internal Server Error' })
   }
 })

--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,6 +1,7 @@
 // server/api/auth/login.post.ts
 import { defineEventHandler, readBody, sendError, setCookie } from 'h3'
 import { validateUserCredentials } from '.'
+import { logSafeError } from '../../utils/error'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -35,7 +36,7 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = 401
     return { success: false, message: 'Invalid credentials' }
   } catch (error: unknown) {
-    console.error('Error during login:', error)
+    logSafeError('Error during login:', error)
     const errorMessage =
       error instanceof Error ? error.message : 'Unknown error occurred'
     return sendError(event, new Error(errorMessage))

--- a/server/api/users/register.post.ts
+++ b/server/api/users/register.post.ts
@@ -41,7 +41,10 @@ export default defineEventHandler(async (event) => {
 
     // If the star formation (user creation) is successful, we celebrate with a warm welcome
     if (result.success && result.user) {
-      console.log('🌟 A new star is born in our user universe:', result)
+      console.log('🌟 A new star is born in our user universe:', {
+        id: result.user.id,
+        username: result.user.username,
+      })
 
       // Auto-send the inbox welcome message. Non-fatal: a failure here
       // should never block a successful registration.

--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -43,6 +43,34 @@ function errorMessage(error: ErrorHandlerInput): string {
   return 'Unknown error'
 }
 
+// Secrets must never reach the logs. Old 360-day JWTs were minted carrying the
+// user's apiKey in their payload, and `jose` attaches that decoded payload to
+// JWTExpired/JWTClaimValidationFailed errors — so logging a raw auth error (or
+// a full user row) leaks the key into Vercel's log retention. We scrub both the
+// obvious token shapes and any long hex secret before anything is logged.
+const JWT_LIKE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
+const LONG_HEX_SECRET = /\b[A-Fa-f0-9]{32,}\b/g
+const SENSITIVE_KEY_VALUE =
+  /("?\b(?:api_?key|password|token|secret|authorization|jwt|session)\b"?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,}]+)/gi
+
+export function sanitizeLogMessage(message: string): string {
+  return message
+    .replace(JWT_LIKE, '[REDACTED_JWT]')
+    .replace(SENSITIVE_KEY_VALUE, '$1[REDACTED]')
+    .replace(LONG_HEX_SECRET, '[REDACTED]')
+}
+
+// Log an error safely from anywhere (auth handlers, callbacks, stream pumps).
+// Never pass the raw error object to console — that is what serializes a jose
+// error's `.payload` (with the apiKey) into the log line.
+export function logSafeError(context: string, error: ErrorHandlerInput): void {
+  console.error(context, {
+    name: error instanceof Error ? error.name : typeof error,
+    code: errorCode(error),
+    message: sanitizeLogMessage(errorMessage(error)),
+  })
+}
+
 function isTransientDatabaseError(error: ErrorHandlerInput): boolean {
   const message = errorMessage(error)
   return transientDatabaseMessages.some((candidate) => message.includes(candidate))
@@ -65,7 +93,7 @@ function logError(error: ErrorHandlerInput, statusCode: number): void {
   const payload = {
     name: error instanceof Error ? error.name : typeof error,
     code: errorCode(error),
-    message: errorMessage(error),
+    message: sanitizeLogMessage(errorMessage(error)),
     statusCode,
   }
 

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -8,8 +8,14 @@ import {
 
 type PrismaMariaDbConfig = ConstructorParameters<typeof PrismaMariaDb>[0]
 
+type CircuitBreakerState = {
+  failures: number
+  openUntil: number
+}
+
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
+  prismaBreaker?: CircuitBreakerState
 }
 
 const databaseUrl = process.env.DATABASE_URL
@@ -38,11 +44,11 @@ function buildDatabaseUrl(url: string): string {
   const parsed = new URL(url)
   const connectTimeout = readPositiveInteger(
     process.env.DATABASE_CONNECT_TIMEOUT_MS,
-    5_000,
+    3_000,
   )
   const acquireTimeout = readPositiveInteger(
     process.env.DATABASE_ACQUIRE_TIMEOUT_MS,
-    6_000,
+    3_000,
   )
   const connectionLimit = readPositiveInteger(
     process.env.DATABASE_CONNECTION_LIMIT,
@@ -133,11 +139,11 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     database,
     connectTimeout: readPositiveInteger(
       parsed.searchParams.get('connectTimeout') ?? undefined,
-      5_000,
+      3_000,
     ),
     acquireTimeout: readPositiveInteger(
       parsed.searchParams.get('acquireTimeout') ?? undefined,
-      6_000,
+      3_000,
     ),
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
@@ -168,14 +174,68 @@ const retryableDatabaseMessages = [
 // A pool acquisition can consume the full acquireTimeout. Keep the default
 // retry budget within the serverless function deadline instead of allowing the
 // platform to terminate the request before errorHandler can return a 503.
+// One retry, not two: when the wall is down every attempt burns the full
+// acquireTimeout, and a 3x retry turned a single dead request into ~18s of held
+// serverless concurrency — which is what produced the 504 gateway timeouts.
 const transientRetryAttempts = readNonNegativeInteger(
   process.env.DATABASE_TRANSIENT_RETRY_ATTEMPTS,
-  2,
+  1,
 )
 const transientRetryDelayMs = readPositiveInteger(
   process.env.DATABASE_TRANSIENT_RETRY_DELAY_MS,
   100,
 )
+
+// Circuit breaker. When the pool cannot hand out a connection (ProxySQL/MariaDB
+// saturated or unreachable), every request otherwise waits the full
+// acquireTimeout before failing. After `breakerThreshold` consecutive connection
+// failures we "open" the breaker for `breakerCooldownMs` and fail fast — freeing
+// serverless slots (no more 504 pile-up) and letting the wall recover instead of
+// being hammered by retries. State is per warm instance, held on globalThis so it
+// survives across invocations on a reused Lambda.
+const breakerThreshold = readPositiveInteger(
+  process.env.DATABASE_BREAKER_THRESHOLD,
+  5,
+)
+const breakerCooldownMs = readPositiveInteger(
+  process.env.DATABASE_BREAKER_COOLDOWN_MS,
+  10_000,
+)
+
+const breaker: CircuitBreakerState =
+  globalForPrisma.prismaBreaker ?? { failures: 0, openUntil: 0 }
+globalForPrisma.prismaBreaker = breaker
+
+// Message is intentionally one the errorHandler classifies as a transient DB
+// error, so a fast-failed request still returns a clean 503 (not a 500).
+const CIRCUIT_OPEN_MESSAGE =
+  'pool timeout: failed to retrieve a connection from pool (circuit open)'
+
+function circuitIsOpen(): boolean {
+  if (breaker.openUntil === 0) return false
+
+  if (Date.now() >= breaker.openUntil) {
+    // Cooldown elapsed: half-open. Allow the next request through as a probe;
+    // recordSuccess/recordFailure below will close it or re-open it.
+    breaker.openUntil = 0
+    breaker.failures = breakerThreshold - 1
+    return false
+  }
+
+  return true
+}
+
+function recordConnectionSuccess(): void {
+  breaker.failures = 0
+  breaker.openUntil = 0
+}
+
+function recordConnectionFailure(): void {
+  breaker.failures += 1
+  if (breaker.failures >= breakerThreshold) {
+    breaker.openUntil = Date.now() + breakerCooldownMs
+  }
+}
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
@@ -206,13 +266,26 @@ export const prisma = basePrisma.$extends({
   name: 'transient-database-retry',
   query: {
     async $allOperations({ model, operation, args, query }) {
+      // Fail fast while the breaker is open instead of blocking on the pool.
+      if (circuitIsOpen()) {
+        throw new Error(CIRCUIT_OPEN_MESSAGE)
+      }
+
       for (let attempt = 0; ; attempt += 1) {
         try {
-          return await query(args)
+          const result = await query(args)
+          recordConnectionSuccess()
+          return result
         } catch (error: unknown) {
+          const retryable = isRetryableDatabaseError(error)
+          if (retryable) {
+            recordConnectionFailure()
+          }
+
           if (
-            !isRetryableDatabaseError(error) ||
-            attempt >= transientRetryAttempts
+            !retryable ||
+            attempt >= transientRetryAttempts ||
+            circuitIsOpen()
           ) {
             throw error
           }


### PR DESCRIPTION
## Why

Production is returning more 503/504 than 200 (48h: 242× 503, 113× 504, 90× 200). Every failure is a Prisma pool timeout with `active=0 idle=0` — the app cannot get a connection through the ProxySQL layer, so each request blocks the full `acquireTimeout`, and the 2× transient retry stretched a single dead request to ~18s, blowing past Vercel's function deadline and producing the 504 gateway timeouts.

The root fix is ProxySQL/MariaDB capacity (being investigated on the infra side). These are the **app-side mitigations** so a degraded wall stops cascading into a full outage — and a fix for secrets leaking into logs found along the way.

## Changes

**Fail fast on pool starvation** (`server/utils/prisma.ts`)
- connect/acquire timeouts `5s/6s → 3s`, transient retries `2 → 1`: a dead DB fails in ~6s instead of ~18s, freeing serverless concurrency and killing the 504 pile-up.
- Per-instance **circuit breaker**: after 5 consecutive connection failures, open for 10s and fail fast with a clean 503 instead of hammering the wall; half-opens with a single probe after cooldown. All values env-overridable (`DATABASE_BREAKER_THRESHOLD`, `DATABASE_BREAKER_COOLDOWN_MS`, `DATABASE_ACQUIRE_TIMEOUT_MS`, `DATABASE_CONNECT_TIMEOUT_MS`, `DATABASE_TRANSIENT_RETRY_ATTEMPTS`).

**Stop secrets reaching the logs**
- `jose` attaches the decoded JWT payload to `JWTExpired` errors, and old 360-day tokens were minted carrying the user's `apiKey` — logging a raw auth error leaked it into log retention. Add `sanitizeLogMessage()` + `logSafeError()` (`server/utils/error.ts`) and route auth error logs (`login.post.ts`, `google/callback.ts`) through them.
- Harden the central `logError` to scrub JWTs and long hex secrets from messages.
- `register.post.ts` logged the full new-user row (apiKey + password hash) on signup → now logs only `id` + `username`.

## Follow-ups (not in this PR)
- Infra: inspect ProxySQL `stats_mysql_connection_pool` / MariaDB `max_connections` — the `active=0` stall points at the backend pool being saturated, shunned, or a TLS/cert mismatch from the July 14 cert renewal.
- Rotate the `apiKey` that already reached log retention.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XSvLKeQjytBSA53zyGDtS)_