### PR TITLE
digital-storefront/t-014: Against Malaria giving page

### DIFF
--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -76,6 +76,31 @@
           </div>
         </div>
 
+        <div
+          class="flex flex-col items-start gap-3 rounded-2xl border border-primary/30 bg-primary/10 p-4 text-sm text-primary-content sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div class="flex items-start gap-3">
+            <Icon name="kind-icon:hand-heart" class="mt-1 h-5 w-5 shrink-0" />
+
+            <div class="space-y-1">
+              <p class="font-black">Skip the shop, give directly</p>
+
+              <p>
+                Every net purchased through the Against Malaria Foundation saves
+                lives. We never touch the money.
+              </p>
+            </div>
+          </div>
+
+          <NuxtLink
+            to="/giving"
+            class="btn btn-primary btn-sm shrink-0 rounded-2xl"
+          >
+            <Icon name="kind-icon:gift" class="h-4 w-4" />
+            Give directly
+          </NuxtLink>
+        </div>
+
         <div class="grid gap-3 xl:grid-cols-2">
           <article
             v-for="item in showcaseItems"

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -1,0 +1,126 @@
+<!-- /components/content/pages/giving-page.vue -->
+<template>
+  <div class="mx-auto max-w-4xl space-y-6 px-4 py-2 sm:px-6 lg:px-8">
+    <div
+      class="rounded-2xl border border-primary/30 bg-primary/10 p-6 text-center shadow-sm sm:p-10"
+    >
+      <Icon
+        name="kind-icon:hand-heart"
+        class="mx-auto h-12 w-12 text-primary"
+      />
+
+      <h1 class="mt-4 text-3xl font-black text-base-content sm:text-4xl">
+        Give Directly. We Never Touch It.
+      </h1>
+
+      <p class="mx-auto mt-3 max-w-2xl text-base-content/75">
+        Kind Robots supports the
+        <strong>Against Malaria Foundation</strong> — every dollar buys
+        insecticide-treated bed nets that prevent malaria. Donations go straight
+        to AMF; we are not a middleman and never see a cent of it.
+      </p>
+
+      <a
+        href="https://www.againstmalaria.com/amibot"
+        target="_blank"
+        rel="noopener"
+        class="btn btn-primary btn-lg mt-6 rounded-2xl"
+      >
+        <Icon name="kind-icon:gift" class="h-5 w-5" />
+        Donate at againstmalaria.com/amibot
+      </a>
+
+      <p class="mt-2 text-xs text-base-content/50">
+        Opens the Against Malaria Foundation's official fundraiser page in a new
+        tab.
+      </p>
+    </div>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+      <div class="rounded-2xl border border-base-300 bg-base-100 p-5 shadow-sm">
+        <Icon name="kind-icon:heart" class="h-6 w-6 text-secondary" />
+
+        <h2 class="mt-2 text-lg font-black text-base-content">Why AMF?</h2>
+
+        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+          {{ trivia }}
+        </p>
+      </div>
+
+      <div class="rounded-2xl border border-base-300 bg-base-100 p-5 shadow-sm">
+        <Icon name="kind-icon:cart" class="h-6 w-6 text-secondary" />
+
+        <h2 class="mt-2 text-lg font-black text-base-content">
+          Prefer It On Your Receipt?
+        </h2>
+
+        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+          As a convenience, you can add a $1 net donation to your Kind Robots
+          cart alongside anything else you're picking up — it still routes 100%
+          to AMF. The direct link above is the fastest way to give.
+        </p>
+
+        <button
+          type="button"
+          class="btn btn-outline btn-sm mt-4 rounded-2xl"
+          :disabled="!donationItem"
+          @click="addDonationToCart"
+        >
+          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          Add $1 net donation to cart
+        </button>
+
+        <p v-if="added" class="mt-2 text-xs font-semibold text-success">
+          Added — thank you! Check the cart to review.
+        </p>
+      </div>
+    </div>
+
+    <div
+      class="rounded-2xl border border-info/30 bg-info/10 p-4 text-center text-sm text-info-content"
+    >
+      <p>{{ plea }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useCartStore } from '@/stores/cartStore'
+import { cartItems } from '@/stores/seeds/cartItems'
+import { malariaTrivia } from '@/utils/messages/MalariaTrivia'
+import { sponsorPlea } from '@/utils/messages/sponsorPlea'
+
+const cartStore = useCartStore()
+const added = ref(false)
+
+const donationItem = computed(() =>
+  cartItems.find((item) => item.type === 'donation'),
+)
+
+const trivia = computed(() => {
+  const pool = malariaTrivia
+  return pool[Math.floor(Math.random() * pool.length)]
+})
+
+const plea = computed(() => {
+  const pool = sponsorPlea
+  return pool[Math.floor(Math.random() * pool.length)]
+})
+
+function addDonationToCart() {
+  const item = donationItem.value
+  if (!item) return
+
+  cartStore.addItem({
+    type: item.type,
+    artImageId: 0,
+    imageUrl: item.image,
+    quantity: 1,
+    price: item.price,
+    notes: item.label,
+  })
+
+  added.value = true
+}
+</script>

--- a/content/channels/sanctuary/giving.md
+++ b/content/channels/sanctuary/giving.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: sanctuary
+tabKey: giving
+dashboardKey: giftshop
+dashboardTab: giving
+label: Giving
+title: Give Directly to Against Malaria
+subtitle: We never touch the money
+description: A dedicated page whose primary call to action sends you straight to AMF's fundraiser — no middleman.
+icon: kind-icon:hand-heart
+route: /giving
+sort: 45
+---
+
+Donate directly at the Against Malaria Foundation's fundraiser page. 100% goes to AMF.

--- a/content/giving.md
+++ b/content/giving.md
@@ -1,0 +1,19 @@
+---
+title: 'Giving'
+room: 'Giving Room'
+subtitle: 'Direct to the Against Malaria Foundation'
+description: Donate straight to AMF — nets that save lives, no middleman.
+icon: kind-icon:hand-heart
+image: splash/about.png
+tooltip: We keep this simple on purpose. Every dollar you send goes to AMF, not through us.
+dottiTip: I checked the math three times. $2 really does buy a bed net.
+amiTip: The swarm does not touch the money. We just point the way. 🦋💙
+channelKey: sanctuary
+tabKey: giving
+dashboardKey: giftshop
+dashboardTab: giving
+loadingMessage: Loading giving page...
+refreshLabel: Refresh giving page
+---
+
+:giving-page

--- a/public/components.json
+++ b/public/components.json
@@ -1,5 +1,26 @@
 [
   {
+    "folderName": "academy",
+    "components": [
+      "academy-manager",
+      "academy-remix",
+      "academy-style-detail",
+      "academy-styles-browser",
+      "academy-timeline"
+    ]
+  },
+  {
+    "folderName": "achievements",
+    "components": [
+      "achievement-gallery",
+      "achievement-leaderboard",
+      "achievement-popup",
+      "earned-achievement-card",
+      "locked-achievements",
+      "unearned-achievement-card"
+    ]
+  },
+  {
     "folderName": "admin",
     "components": [
       "error-popup",
@@ -21,12 +42,20 @@
       "art-reactions",
       "art-styler",
       "art-test",
+      "artjob-feedback-manager",
+      "artjob-manager",
       "collection-card",
       "collection-picker",
       "generate-button",
       "image-card",
       "image-upload",
-      "list-manager"
+      "list-manager",
+      "stylist-calculator",
+      "stylist-clients",
+      "stylist-history",
+      "stylist-manager",
+      "stylist-restyle",
+      "stylist-settings"
     ]
   },
   {
@@ -122,6 +151,14 @@
     ]
   },
   {
+    "folderName": "coloring",
+    "components": [
+      "coloring-book-manager",
+      "coloring-book-page",
+      "coloring-canvas"
+    ]
+  },
+  {
     "folderName": "composition",
     "components": [
       "add-composition",
@@ -129,6 +166,28 @@
       "composition-gallery",
       "composition-interact",
       "composition-manager"
+    ]
+  },
+  {
+    "folderName": "conductor",
+    "components": [
+      "challenge-center-page",
+      "coat-dance-page",
+      "conductor-app-page",
+      "davinci-page",
+      "humboldt-scoop-page",
+      "newsfeed-page",
+      "packmaker-page",
+      "project-deliverables-panel",
+      "project-front-page",
+      "project-gallery-strip",
+      "project-pitch-board",
+      "ruler-hooked-page",
+      "scoop-cms-page",
+      "sketchy-page",
+      "storymaker-page",
+      "voice-lab-page",
+      "watchlist-page"
     ]
   },
   {
@@ -146,8 +205,14 @@
       "dream-pitch-sheet",
       "dream-relationship-gallery",
       "dream-sheet-toolbar",
-      "dream-workspace",
-      "project-card"
+      "dream-workspace"
+    ]
+  },
+  {
+    "folderName": "facets",
+    "components": [
+      "facet-manager",
+      "facet-picker"
     ]
   },
   {
@@ -184,14 +249,14 @@
     ]
   },
   {
-    "folderName": "achievements",
+    "folderName": "model-builder",
     "components": [
-      "earned-achievement-card",
-      "locked-achievements",
-      "achievement-gallery",
-      "achievement-leaderboard",
-      "achievement-popup",
-      "unearned-achievement-card"
+      "model-builder-item-panel",
+      "model-builder-manager",
+      "model-builder-progress-matrix",
+      "model-builder-recipe-selector",
+      "model-builder-run-history",
+      "model-builder-source-picker"
     ]
   },
   {
@@ -204,6 +269,8 @@
       "login-switcher",
       "mana-widget",
       "narrator-chat",
+      "navigation-health",
+      "notification-bell",
       "page-image",
       "server-selector",
       "slot-reel-gallery",
@@ -226,7 +293,10 @@
       "conductor-manager",
       "conductor-overview-gallery-page",
       "conductor-page",
+      "conductor-pitch-manager",
       "conductor-project-chat",
+      "daily-dream-page",
+      "giving-page",
       "kaizen-popup",
       "kind-prompts",
       "match-leaderboard",
@@ -237,11 +307,18 @@
       "rebel-button",
       "registration-form",
       "serendipity-page",
+      "serendipity-voice-page",
       "social-page",
       "sponsor-page",
       "super-form",
       "welcome-page",
       "wishmaster-page"
+    ]
+  },
+  {
+    "folderName": "projects",
+    "components": [
+      "project-placement-manager"
     ]
   },
   {
@@ -276,8 +353,10 @@
       "animation-interact",
       "animation-layer",
       "animation-loader",
+      "animation-selector",
       "animation-tester",
       "ascii-aquarium",
+      "bioluminescent-tide",
       "bubble-effect",
       "butterfly-animation",
       "constellation-effect",
@@ -290,6 +369,7 @@
       "fx-clear-all",
       "fx-region",
       "glitch-effect",
+      "gravity-garden",
       "kaleidoscope-effect",
       "lava-lamp",
       "lightning-effect",
@@ -308,6 +388,7 @@
       "smudge-effect",
       "snow-effect",
       "starfield-effect",
+      "startup-animation",
       "talking-butterflies",
       "toaster-effect",
       "wandering-creatures",
@@ -350,8 +431,16 @@
     ]
   },
   {
+    "folderName": "ui",
+    "components": [
+      "section-heading",
+      "ui-gallery"
+    ]
+  },
+  {
     "folderName": "user",
     "components": [
+      "account-settings",
       "avatar-image",
       "avatar-picker",
       "cache-clear",
@@ -360,15 +449,19 @@
       "chat-view",
       "forum-thread",
       "friend-gallery",
+      "friends-panel",
       "google-login",
       "login-form",
       "login-page",
       "login-persister",
+      "messenger",
+      "password-reset",
       "registration-page",
       "user-avatar",
       "user-builder",
       "user-dashboard",
       "user-galleries",
+      "user-manager-directory",
       "user-manager",
       "user-panel",
       "user-picture"
@@ -383,6 +476,7 @@
       "lab-gallery",
       "lab-interact",
       "lab-manager",
+      "mural-manager",
       "new-eyeball",
       "reactable-card",
       "reaction-card"


### PR DESCRIPTION
## Summary
- New dedicated `/giving` page (`content/giving.md` + `components/pages/giving-page.vue`) whose primary call to action links directly to https://www.againstmalaria.com/amibot — Kind Robots never touches the donation money.
- The existing `$1 Donation to Against Malaria` cart item (`stores/seeds/cartItems.ts`) remains available as a secondary convenience, wired via the existing `cartStore.addItem` action (no new payment code).
- Adds a sidebar/channel nav entry (`content/channels/sanctuary/giving.md`) so the page is discoverable, and a "Give directly" CTA banner in `giftshop-interact.vue` linking to the new page.
- `public/components.json` regenerated to register the new `giving-page` component.

Closes conductor roadmap task `digital-storefront/t-014` (content + layout only, no payment code changes, per task scope).

## Verification
- `npx eslint` and `npx prettier --check` clean on all changed source files.
- `npx vue-tsc --noEmit` shows no new errors introduced by this change (pre-existing unrelated errors elsewhere in the repo untouched).
- Started the dev server locally (temporary local MySQL-shaped env stand-in was not available, so `DATABASE_URL`/`JWT_SECRET` were set to dummy local values purely to get past module-level env checks) and confirmed via curl that `GET /giving` returns `HTTP 200` and renders the expected headline ("Give Directly. We Never Touch It.") and the direct `href="https://www.againstmalaria.com/amibot"` link.
- Did not click-verify the new "Give directly" CTA banner inside `giftshop-interact.vue` in a real browser (no Playwright/Cypress harness readily wired up in this sandbox for an authenticated dashboard route) — it's straightforward template markup reusing already-imported `NuxtLink`/`Icon`, verified by lint + typecheck only.

## Flags for Reviewer
- No account creation, no live payment code changes, no spend — matches the task's hard-rule boundaries.
- `public/components.json` diff is an auto-generated artifact (adds the new component to the registry); the existing pre-change version already fails `prettier --check` on `main`, so that's pre-existing drift, not introduced here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lg7tmNmoLDvPcF8T69ApHm)_