### PR TITLE
fix(db): add DATABASE_SSL_REJECT_UNAUTHORIZED escape hatch

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -116,19 +116,48 @@ function readDatabaseSslCa(): string | undefined {
   return plain
 }
 
+// Escape hatch. Default true (verify the server cert's CA + identity). Set
+// DATABASE_SSL_REJECT_UNAUTHORIZED=false to keep the connection ENCRYPTED but
+// stop verifying the certificate — the temporary unblock when ProxySQL presents
+// a cert whose CA or SAN no longer matches (e.g. after a cert renewal, or when
+// connecting by IP to a cert issued for a hostname). This trades away MITM
+// protection on the DB link; treat it as a stopgap and re-enable verification
+// once the cert/CA is fixed.
+function readSslRejectUnauthorized(): boolean {
+  const raw = process.env.DATABASE_SSL_REJECT_UNAUTHORIZED?.trim().toLowerCase()
+  return raw !== 'false' && raw !== '0' && raw !== 'no'
+}
+
 function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
   const resolvedUrl = buildDatabaseUrl(url)
   const sslCa = readDatabaseSslCa()
+  const rejectUnauthorized = readSslRejectUnauthorized()
 
-  if (!sslCa) return resolvedUrl
+  // No CA and full verification requested → nothing to customize; hand the
+  // adapter the plain URL (unchanged default behavior).
+  if (!sslCa && rejectUnauthorized) return resolvedUrl
 
   const parsed = new URL(resolvedUrl)
   const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
-  const tlsOptions: TlsConnectionOptions = {
-    ca: sslCa,
-    rejectUnauthorized: true,
-    checkServerIdentity: (_connectorHostname, certificate) =>
-      checkServerIdentity(parsed.hostname, certificate),
+  const tlsOptions: TlsConnectionOptions = rejectUnauthorized
+    ? {
+        ca: sslCa,
+        rejectUnauthorized: true,
+        checkServerIdentity: (_connectorHostname, certificate) =>
+          checkServerIdentity(parsed.hostname, certificate),
+      }
+    : {
+        // Encrypted but unverified: no CA requirement, no identity check.
+        ...(sslCa ? { ca: sslCa } : {}),
+        rejectUnauthorized: false,
+      }
+
+  if (!rejectUnauthorized) {
+    console.warn(
+      '[prisma] DATABASE_SSL_REJECT_UNAUTHORIZED=false — TLS is on but the ' +
+        'database certificate is NOT being verified. Stopgap only; restore ' +
+        'verification once the ProxySQL cert/CA is fixed.',
+    )
   }
 
   return {


### PR DESCRIPTION
## Why

Live infra inspection ruled out capacity: ProxySQL's backend is `ONLINE` with `MaxConnUsed=0` and **zero client connections ever**, `stats_mysql_errors` is empty, and MariaDB shows only the monitor connected (`Threads_connected=2`, `Max_used_connections=4`). Both DB layers are healthy and idle — the app's connection to the ProxySQL frontend **hangs and never registers**, which points at a TLS trust failure rather than the wall being overwhelmed.

The app connects to ProxySQL by IP with `rejectUnauthorized: true` and a strict `checkServerIdentity`, so a certificate whose CA or SAN no longer matches (e.g. after the July 14 cert renewal, or a cert issued for `proxysql.cafepurr` rather than the IP) fails the handshake exactly this way.

## Change

Add `DATABASE_SSL_REJECT_UNAUTHORIZED` (`server/utils/prisma.ts`):
- Default (`true`): unchanged — full CA + identity verification.
- `false`: keep the connection **encrypted** but stop verifying the server certificate — the temporary unblock to restore service while the cert/CA is fixed. Works with or without a `DATABASE_SSL_CA` present, and logs a startup warning while active.

This trades away MITM protection on the DB link, so it's a stopgap: re-enable verification (unset the var) once ProxySQL's cert/CA is corrected.

## To activate
Set `DATABASE_SSL_REJECT_UNAUTHORIZED=false` in Vercel (production env) and redeploy.

## Follow-ups (not in this PR)
- Fix the ProxySQL cert: reissue with `IP:75.111.66.70` in the SAN, or update Vercel's `DATABASE_SSL_CA_BASE64` to the renewed CA, then unset this flag.
- Rotate the `apiKey` that reached log retention (from PR #270).

---
_Generated by [Claude Code](https://claude.ai/code/session_017XSvLKeQjytBSA53zyGDtS)_