### PR TITLE
Academy: simplify remix selection state, widen style search, add a11y hints

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -36,8 +36,8 @@
 
       <aside class="flex min-h-0 flex-col gap-3">
         <academy-style-detail
-          v-if="contextStyle"
-          :lesson="contextStyle"
+          v-if="academyStore.selectedStyle"
+          :lesson="academyStore.selectedStyle"
           :show-close="false"
           @remix="() => {}"
         />
@@ -61,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import type { AcademyStyle } from '@/stores/seeds/academyStyles'
 import type { StyleEntry } from '@/stores/helpers/styleHelper'
@@ -69,20 +69,8 @@ import type { ArtImage } from '~/prisma/generated/prisma/client'
 
 const academyStore = useAcademyStore()
 
-const activeStyleSlug = ref<string | null>(
-  academyStore.selectedStyleSlug ?? null,
-)
-
 const remixStyles = computed<StyleEntry[]>(() => {
   return academyStore.timeline.map((style) => academyStyleToEntry(style))
-})
-
-const contextStyle = computed<AcademyStyle | null>(() => {
-  if (!activeStyleSlug.value) return null
-  return (
-    academyStore.styles.find((style) => style.slug === activeStyleSlug.value) ??
-    null
-  )
 })
 
 function academyStyleToEntry(style: AcademyStyle): StyleEntry {
@@ -98,13 +86,12 @@ function academyStyleToEntry(style: AcademyStyle): StyleEntry {
 }
 
 function onStyleSelected(entry: StyleEntry | null) {
-  activeStyleSlug.value = entry?.slug ?? null
   academyStore.selectStyle(entry?.slug ?? null)
 }
 
 function onGenerated(_image: ArtImage) {
-  if (activeStyleSlug.value) {
-    academyStore.markStyleRemixed(activeStyleSlug.value)
+  if (academyStore.selectedStyleSlug) {
+    academyStore.markStyleRemixed(academyStore.selectedStyleSlug)
   }
 }
 </script>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -29,6 +29,7 @@
           type="search"
           class="min-w-0 flex-1 bg-transparent"
           placeholder="Search styles…"
+          aria-label="Search Academy styles"
         />
       </label>
     </header>
@@ -56,6 +57,7 @@
             ? 'border-primary shadow-md shadow-primary/20'
             : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
         "
+        :aria-expanded="expandedSlug === style.slug"
         @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
       >
         <div class="flex items-center justify-between gap-2">
@@ -129,6 +131,7 @@ const filteredStyles = computed<AcademyStyle[]>(() => {
       style.era,
       style.region,
       style.keyIdeas,
+      ...style.recognitionCues,
       ...style.artists.map((artist) => artist.name),
     ]
       .join(' ')

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -56,6 +56,7 @@
           v-if="expandedSlug !== style.slug"
           type="button"
           class="group flex w-full flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
+          aria-expanded="false"
           @click="expandedSlug = style.slug"
         >
           <span class="text-xl leading-none">🏛️</span>


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor): continuous improvement pass, option (a) front-end style/polish pass on the Academy surface. (kind: software)

### What changed
- `academy-remix.vue`: removed a local `activeStyleSlug` ref that duplicated `academyStore.selectedStyleSlug` — the two were kept in sync by hand across `onStyleSelected`/`onGenerated`, but the store already exposes `selectedStyle` for direct lookup. The component now reads the store directly, removing the redundant state.
- `academy-styles-browser.vue`: the search box only matched `name`/`era`/`region`/`keyIdeas`/artist names — not the `recognitionCues` shown on every card, so searching a visible cue term (e.g. "impasto") returned nothing. Added `recognitionCues` to the match fields. Also added `aria-label` on the search input and `aria-expanded` on the style-card toggle buttons.
- `academy-timeline.vue`: added `aria-expanded="false"` to the collapsed lesson toggle buttons to match.

### How I verified
- `npx eslint` on the three changed files — clean.
- `npx prettier --check` on the three changed files — clean.
- Full `vue-tsc --noEmit` run — 82 pre-existing errors (matches the kind-robots/t-020 baseline), zero new errors in the changed files.

### Stakes
reversible

### Notes for reviewer
This is conductor's `ai-art-academy` project (autonomous: true). The project's other `ready` tasks (t-004 prompt/LoRA eval, t-009 art generation) need a `KR_API_TOKEN`-bearing session against the generation backend, and t-008/t-013 need outbound access to museum/Wikimedia hosts to download provenance-tracked images — both are blocked in this sandbox (confirmed via the agent proxy status: policy-denied CONNECT to `metmuseum.org`/`upload.wikimedia.org`). This polish pass (t-010, the recurring "never idle" task) needed neither, so it's the piece that could actually land this cycle.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011oREd62E1YY2g13UHp5Utv

---
_Generated by [Claude Code](https://claude.ai/code/session_011oREd62E1YY2g13UHp5Utv)_