### PR TITLE
Fix SocialPost Cypress cascade

### DIFF
--- a/server/api/socials/index.post.ts
+++ b/server/api/socials/index.post.ts
@@ -22,6 +22,19 @@ type IncomingPost = {
   designer?: string | null
 }
 
+const serializeMediaUrls = (value: unknown): string | null => {
+  if (value == null) return null
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return JSON.stringify(value.filter((item): item is string => typeof item === 'string'))
+  }
+
+  throw createError({
+    statusCode: 400,
+    message: 'The "mediaUrls" field must be a string or an array of strings.',
+  })
+}
+
 export default defineEventHandler(async (event) => {
   const singularLabel = 'SocialPost'
   const pluralLabel = 'SocialPosts'
@@ -70,7 +83,7 @@ export default defineEventHandler(async (event) => {
       return {
         title,
         body: postBody,
-        mediaUrls: (mediaUrls as Prisma.InputJsonValue) ?? [],
+        mediaUrls: serializeMediaUrls(mediaUrls),
         isPublic: isPublic ?? false,
         isMature: isMature ?? false,
         audience: audience ?? ('SOCIAL' as PostAudience),
@@ -90,7 +103,6 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // Batch
     if (Array.isArray(body)) {
       const created = []
       const skipped: string[] = []
@@ -118,7 +130,6 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // Single
     const data = await prisma.socialPost.create({
       data: buildCreate(body),
       include: { targets: true },


### PR DESCRIPTION
## Root cause
The GitHub/Vercel Cypress run failed SocialPost creation because `mediaUrls` is a Prisma `String?`, while the route passed an array/JSON value directly. Prisma rejected the create, leaving `postId` undefined and causing the remaining SocialPost CRUD/publish tests to cascade.

## Change
- Accept `mediaUrls` as either a string or an array of strings.
- Serialize arrays to JSON before persistence.
- Preserve `null` when omitted.
- Return a clear 400 for unsupported values.

## Expected impact
Fixes the one SocialPost create failure and the 11 dependent `undefined` ID failures visible in the latest Cypress/Vercel runtime logs.

This PR is intentionally narrow so CI can validate the root fix independently.