### PR TITLE
Fix Code graph storage mismatch

### DIFF
--- a/server/api/code/[id].patch.ts
+++ b/server/api/code/[id].patch.ts
@@ -11,21 +11,35 @@ type CodePatchBody = Partial<
     | 'title'
     | 'description'
     | 'icon'
-    | 'graph'
     | 'isPublic'
     | 'isOfficial'
   >
->
+> & {
+  graph?: unknown
+}
 
-function normalizeGraph(graph: unknown): Prisma.InputJsonValue {
-  if (!graph || typeof graph !== 'object') {
+function normalizeGraph(graph: unknown): string {
+  let parsed = graph
+
+  if (typeof graph === 'string') {
+    try {
+      parsed = JSON.parse(graph)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: 'The graph field must contain valid JSON.',
+      })
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw createError({
       statusCode: 400,
       message: 'A valid graph object is required.',
     })
   }
 
-  return graph as Prisma.InputJsonValue
+  return typeof graph === 'string' ? graph : JSON.stringify(parsed)
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/code/index.post.ts
+++ b/server/api/code/index.post.ts
@@ -11,22 +11,36 @@ type CodeCreateBody = Partial<
     | 'title'
     | 'description'
     | 'icon'
-    | 'graph'
     | 'isPublic'
     | 'isOfficial'
     | 'isActive'
   >
->
+> & {
+  graph?: unknown
+}
 
-function normalizeGraph(graph: unknown): Prisma.InputJsonValue {
-  if (!graph || typeof graph !== 'object') {
+function normalizeGraph(graph: unknown): string {
+  let parsed = graph
+
+  if (typeof graph === 'string') {
+    try {
+      parsed = JSON.parse(graph)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: 'The graph field must contain valid JSON.',
+      })
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw createError({
       statusCode: 400,
       message: 'A valid graph object is required.',
     })
   }
 
-  return graph as Prisma.InputJsonValue
+  return typeof graph === 'string' ? graph : JSON.stringify(parsed)
 }
 
 export default defineEventHandler(async (event) => {


### PR DESCRIPTION
The Code create and update routes were passing graph objects into a required string column. This serializes validated graph objects before persistence and accepts already-serialized JSON. It should remove the initial Code create failure and its dependent zero-ID failures.