### PR TITLE
Restore the ArtJob payload contract

### DIFF
--- a/server/api/art/queue/[id].get.ts
+++ b/server/api/art/queue/[id].get.ts
@@ -7,6 +7,7 @@ import { createError, defineEventHandler, getRouterParam } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
+import { decodeArtJobPayload } from '../../../utils/artJobPayload'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -17,14 +18,14 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Invalid job id.' })
     }
 
-    const job = await prisma.artJob.findUnique({ where: { id } })
+    const storedJob = await prisma.artJob.findUnique({ where: { id } })
 
-    if (!job) {
+    if (!storedJob) {
       throw createError({ statusCode: 404, message: `Job ${id} not found.` })
     }
 
     if (
-      job.userId !== auth.user.id &&
+      storedJob.userId !== auth.user.id &&
       !auth.isAdmin &&
       !auth.isServerKey
     ) {
@@ -34,7 +35,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: `Job ${id}.`,
-      data: { job },
+      data: { job: decodeArtJobPayload(storedJob) },
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -13,6 +13,12 @@ import type {
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
+import {
+  decodeArtJobPayload,
+  parseArtJobPayload,
+  serializeArtJobPayload,
+  type ArtJobPayloadRecord,
+} from '../../../../utils/artJobPayload'
 
 const MAX_ATTEMPTS = 3
 
@@ -38,7 +44,7 @@ function asRecord(value: unknown): JsonRecord {
 }
 
 function readRetry(payload: unknown): RetryMetadata | null {
-  const retry = asRecord(asRecord(payload).retry)
+  const retry = asRecord(parseArtJobPayload(payload).retry)
   const mode = String(retry.mode || '').toUpperCase()
   if (mode !== 'NEW_OUTPUT' && mode !== 'OVERWRITE') return null
 
@@ -63,7 +69,7 @@ function readSavePolicy(payload: unknown): {
   isMature?: boolean
   designer?: string
 } {
-  const save = asRecord(asRecord(payload).save)
+  const save = asRecord(parseArtJobPayload(payload).save)
   return {
     ...(typeof save.isPublic === 'boolean'
       ? { isPublic: save.isPublic }
@@ -152,17 +158,17 @@ function replacementData(
 }
 
 function completedPayload(
-  payload: Prisma.JsonValue,
+  payload: unknown,
   archivedArtImageId: number,
-): Prisma.InputJsonValue {
-  const next = JSON.parse(JSON.stringify(payload ?? {})) as JsonRecord
+): ArtJobPayloadRecord {
+  const next = structuredClone(parseArtJobPayload(payload))
   const retry = asRecord(next.retry)
   next.retry = {
     ...retry,
     archivedArtImageId,
     completedAt: new Date().toISOString(),
   }
-  return next as Prisma.InputJsonValue
+  return next
 }
 
 export default defineEventHandler(async (event) => {
@@ -286,7 +292,9 @@ export default defineEventHandler(async (event) => {
               status: 'DONE',
               artImageId: targetArtImageId,
               error: null,
-              payload: completedPayload(job.payload, archived.id),
+              payload: serializeArtJobPayload(
+                completedPayload(job.payload, archived.id),
+              ),
             },
           })
 
@@ -338,7 +346,7 @@ export default defineEventHandler(async (event) => {
           ? `Job ${id} replaced ArtImage ${replacedArtImageId}; prior render archived as ArtImage ${archivedArtImageId}.`
           : `Job ${id} → ${updated.status}.`,
       data: {
-        job: updated,
+        job: decodeArtJobPayload(updated),
         replacedArtImageId,
         archivedArtImageId,
       },

--- a/server/api/art/queue/[id]/feedback.post.ts
+++ b/server/api/art/queue/[id]/feedback.post.ts
@@ -5,10 +5,14 @@ import {
   getRouterParam,
   readBody,
 } from 'h3'
-import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
+import {
+  decodeArtJobPayload,
+  parseArtJobPayload,
+  serializeArtJobPayload,
+} from '../../../../utils/artJobPayload'
 
 type FeedbackSource = 'CURATOR' | 'HUMAN'
 type FeedbackVerdict = 'PROMOTE' | 'REVISE' | 'REJECT'
@@ -93,9 +97,10 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const score = body?.score === null || body?.score === undefined
-      ? null
-      : Number(body.score)
+    const score =
+      body?.score === null || body?.score === undefined
+        ? null
+        : Number(body.score)
 
     if (score !== null && (!Number.isFinite(score) || score < 0 || score > 100)) {
       throw createError({
@@ -117,7 +122,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const payload = asRecord(job.payload)
+    const payload = parseArtJobPayload(job.payload)
     const curation = asRecord(payload.curation)
     const history = Array.isArray(curation.history)
       ? curation.history.filter((item) => item && typeof item === 'object')
@@ -154,14 +159,14 @@ export default defineEventHandler(async (event) => {
     const updated = await prisma.artJob.update({
       where: { id },
       data: {
-        payload: nextPayload as Prisma.InputJsonValue,
+        payload: serializeArtJobPayload(nextPayload),
       },
     })
 
     return {
       success: true,
       message: `${source === 'CURATOR' ? 'Curator' : 'Human'} feedback saved for job ${id}.`,
-      data: { job: updated },
+      data: { job: decodeArtJobPayload(updated) },
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -18,10 +18,15 @@ import {
   getRouterParam,
   readBody,
 } from 'h3'
-import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
+import {
+  decodeArtJobPayload,
+  parseArtJobPayload,
+  serializeArtJobPayload,
+  type ArtJobPayloadRecord,
+} from '../../../../utils/artJobPayload'
 
 type RetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
 
@@ -30,14 +35,12 @@ type ReenqueueBody = {
   refreshSeed?: boolean
 }
 
-type JsonRecord = Record<string, unknown>
-
 const RETRY_MODES = new Set<RetryMode>(['NEW_OUTPUT', 'OVERWRITE'])
 const SEED_KEYS = new Set(['seed', 'noise_seed'])
 
-function asRecord(value: unknown): JsonRecord {
+function asRecord(value: unknown): ArtJobPayloadRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
-  return value as JsonRecord
+  return value as ArtJobPayloadRecord
 }
 
 function nextSeed(): number {
@@ -67,7 +70,7 @@ function refreshConcreteSeeds(value: unknown, key = ''): unknown {
   }
 
   return Object.fromEntries(
-    Object.entries(value as JsonRecord).map(([childKey, child]) => [
+    Object.entries(value as ArtJobPayloadRecord).map(([childKey, child]) => [
       childKey,
       refreshConcreteSeeds(child, childKey),
     ]),
@@ -75,13 +78,13 @@ function refreshConcreteSeeds(value: unknown, key = ''): unknown {
 }
 
 function preparePayload(
-  rawPayload: Prisma.JsonValue,
+  rawPayload: unknown,
   sourceJobId: number,
   sourceArtImageId: number | null,
   mode: RetryMode,
   refreshSeed: boolean,
-): Prisma.InputJsonValue {
-  const cloned = JSON.parse(JSON.stringify(rawPayload ?? {})) as JsonRecord
+): ArtJobPayloadRecord {
+  const cloned = structuredClone(parseArtJobPayload(rawPayload))
   const previousRetry = asRecord(cloned.retry)
   const rootJobId = Number(previousRetry.rootJobId) || sourceJobId
 
@@ -90,7 +93,7 @@ function preparePayload(
   delete cloned.curation
 
   const generationPayload = refreshSeed
-    ? (refreshConcreteSeeds(cloned) as JsonRecord)
+    ? (refreshConcreteSeeds(cloned) as ArtJobPayloadRecord)
     : cloned
 
   generationPayload.retry = {
@@ -102,7 +105,7 @@ function preparePayload(
     requestedAt: new Date().toISOString(),
   }
 
-  return generationPayload as Prisma.InputJsonValue
+  return generationPayload
 }
 
 export default defineEventHandler(async (event) => {
@@ -172,7 +175,7 @@ export default defineEventHandler(async (event) => {
     const job = await prisma.artJob.create({
       data: {
         engine: source.engine,
-        payload,
+        payload: serializeArtJobPayload(payload),
         priority: source.priority,
         projectSlug: source.projectSlug,
         projectId: source.projectId,
@@ -189,7 +192,7 @@ export default defineEventHandler(async (event) => {
           ? `Queued job ${job.id} to replace ArtImage ${source.artImageId}.`
           : `Re-enqueued job ${id} as new-output job ${job.id}.`,
       data: {
-        job,
+        job: decodeArtJobPayload(job),
         sourceJobId: id,
         mode,
         targetArtImageId: mode === 'OVERWRITE' ? source.artImageId : null,

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -13,6 +13,10 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
+import {
+  decodeArtJobPayload,
+  parseArtJobPayload,
+} from '../../../utils/artJobPayload'
 
 const STALE_CLAIM_MINUTES = 15
 const MAX_ATTEMPTS = 3
@@ -44,8 +48,11 @@ export default defineEventHandler(async (event) => {
     const claimedBy = body?.agentId?.trim().slice(0, 255) || 'relay'
 
     const engines = (body?.engines || ['A1111', 'COMFY'])
-      .map((e) => String(e).toUpperCase())
-      .filter((e) => e === 'A1111' || e === 'COMFY') as ('A1111' | 'COMFY')[]
+      .map((engine) => String(engine).toUpperCase())
+      .filter((engine) => engine === 'A1111' || engine === 'COMFY') as (
+      | 'A1111'
+      | 'COMFY'
+    )[]
 
     if (!engines.length) {
       throw createError({ statusCode: 400, message: 'No valid engines given.' })
@@ -97,9 +104,9 @@ export default defineEventHandler(async (event) => {
         }
       }
 
-      const payload = candidate.payload as { images?: unknown } | null
+      const payload = parseArtJobPayload(candidate.payload)
       const needsInputImages =
-        Array.isArray(payload?.images) && payload.images.length > 0
+        Array.isArray(payload.images) && payload.images.length > 0
 
       if (needsInputImages && !supportsInputImages) {
         // Leave the job for an image-capable agent instead of failing it.
@@ -129,7 +136,7 @@ export default defineEventHandler(async (event) => {
         return {
           success: true,
           message: 'Job claimed.',
-          data: { job },
+          data: { job: job ? decodeArtJobPayload(job) : null },
           statusCode: 200,
         }
       }

--- a/server/api/art/queue/index.get.ts
+++ b/server/api/art/queue/index.get.ts
@@ -8,6 +8,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
+import { decodeArtJobPayload } from '../../../utils/artJobPayload'
 
 const STATUSES = new Set(['PENDING', 'RUNNING', 'DONE', 'FAILED', 'CANCELLED'])
 
@@ -39,11 +40,12 @@ export default defineEventHandler(async (event) => {
 
     const take = Math.min(Math.max(Number(query.limit) || 50, 1), 200)
 
-    const jobs = await prisma.artJob.findMany({
+    const storedJobs = await prisma.artJob.findMany({
       where,
       orderBy: [{ id: 'desc' }],
       take,
     })
+    const jobs = storedJobs.map(decodeArtJobPayload)
 
     return {
       success: true,

--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -8,6 +8,10 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
+import {
+  decodeArtJobPayload,
+  serializeArtJobPayload,
+} from '../../../utils/artJobPayload'
 
 const ENGINES = new Set(['A1111', 'COMFY'])
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
@@ -54,7 +58,7 @@ export default defineEventHandler(async (event) => {
     const job = await prisma.artJob.create({
       data: {
         engine: engine as 'A1111' | 'COMFY',
-        payload: payload as object,
+        payload: serializeArtJobPayload(payload),
         priority,
         projectSlug,
         userId: auth.user.id,
@@ -66,7 +70,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: 'Art job queued.',
-      data: { job },
+      data: { job: decodeArtJobPayload(job) },
       statusCode: 201,
     }
   } catch (error: unknown) {

--- a/server/api/comfy/kontext/enqueue.post.ts
+++ b/server/api/comfy/kontext/enqueue.post.ts
@@ -19,7 +19,7 @@ import {
   buildKontextWorkflow,
   getKontextImageExtension,
 } from './utils/workflow'
-import type { Prisma } from '~/prisma/generated/prisma/client'
+import { serializeArtJobPayload } from '../../../utils/artJobPayload'
 
 type KontextEnqueueRequest = {
   prompt?: string | null
@@ -103,9 +103,7 @@ export default defineEventHandler(async (event) => {
       maskName: maskName || null,
       filenamePrefix: body.filenamePrefix || 'kindrobots_kontext_queue',
     })
-    // ComfyWorkflow's index signature doesn't structurally satisfy
-    // Prisma.InputJsonValue, so cast at the boundary (same pattern as
-    // /api/art/queue/index.post.ts). The shape is plain JSON.
+
     const payload = {
       workflow,
       promptString: prompt,
@@ -128,7 +126,7 @@ export default defineEventHandler(async (event) => {
         engine: 'COMFY',
         priority: Number.isInteger(body.priority) ? Number(body.priority) : 5,
         userId: gate.user.id,
-        payload: payload as unknown as Prisma.InputJsonValue,
+        payload: serializeArtJobPayload(payload),
       },
     })
 

--- a/server/utils/artJobPayload.ts
+++ b/server/utils/artJobPayload.ts
@@ -1,0 +1,40 @@
+import type { ArtJob } from '~/prisma/generated/prisma/client'
+
+export type ArtJobPayloadRecord = Record<string, unknown>
+
+export type DecodedArtJob<T extends Pick<ArtJob, 'payload'>> = Omit<
+  T,
+  'payload'
+> & {
+  payload: ArtJobPayloadRecord
+}
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+export function parseArtJobPayload(value: unknown): ArtJobPayloadRecord {
+  if (typeof value === 'string') {
+    try {
+      return asRecord(JSON.parse(value))
+    } catch {
+      return {}
+    }
+  }
+
+  return asRecord(value)
+}
+
+export function serializeArtJobPayload(value: unknown): string {
+  return JSON.stringify(parseArtJobPayload(value))
+}
+
+export function decodeArtJobPayload<T extends Pick<ArtJob, 'payload'>>(
+  job: T,
+): DecodedArtJob<T> {
+  return {
+    ...job,
+    payload: parseArtJobPayload(job.payload),
+  }
+}

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -55,7 +55,10 @@ export type ArtJobPayload = Prisma.JsonObject & {
   retry?: ArtJobRetry
 }
 
-export type ArtJobRecord = Omit<ArtJob, 'payload'> & {
+// The database column is string-backed, while queue API responses decode that
+// JSON for consumers. Intersect with the Prisma model so transport records stay
+// assignable anywhere that only needs the regular ArtJob scalar fields.
+export type ArtJobRecord = ArtJob & {
   payload: ArtJobPayload
 }
 


### PR DESCRIPTION
ArtJob payloads are stored in a Prisma String column but were being written and read as JSON objects throughout the queue stack.

This change adds one shared payload serializer/parser and applies it across queue list, poll, claim, feedback, low-level enqueue, retry, completion, and Kontext enqueue. API consumers continue receiving decoded payload objects while Prisma receives canonical JSON strings.

It also aligns the UI transport type with decoded queue records, addressing the 41 repeated artjob-manager type errors. Runtime fixes include preserving retry/curation metadata and correctly detecting jobs with input images before relay claim.