### PR TITLE
Fix ArtJob maintenance script payloads

### DIFF
--- a/utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts
+++ b/utils/scripts/enqueueTwistedFairyTalesArtPrompts.ts
@@ -8,7 +8,6 @@
 //   npm run seed:twisted-fairy-tales -- --write # create missing ArtJob rows
 
 import 'dotenv/config'
-import type { Prisma } from './../../prisma/generated/prisma/client'
 import prisma from './../../server/utils/prisma'
 import { twistedFairyTalesArtPrompts } from './../../stores/seeds/twistedFairyTalesArtPrompts'
 
@@ -17,11 +16,13 @@ const USER_ID = Number(process.env.ART_SEED_USER_ID || 1)
 const PROJECT_SLUG = 'twisted-fairy-tales'
 const PRIORITY = 10
 
-function requestIdFromPayload(payload: Prisma.JsonValue): string | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload))
+function requestIdFromPayload(payload: string): string | null {
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>
+    return typeof parsed.requestId === 'string' ? parsed.requestId : null
+  } catch {
     return null
-  const requestId = (payload as Record<string, Prisma.JsonValue>).requestId
-  return typeof requestId === 'string' ? requestId : null
+  }
 }
 
 async function main() {
@@ -92,7 +93,7 @@ async function main() {
           priority: PRIORITY,
           projectSlug: PROJECT_SLUG,
           userId: USER_ID,
-          payload: {
+          payload: JSON.stringify({
             requestId: entry.requestId,
             number: entry.number,
             title: entry.title,
@@ -108,7 +109,7 @@ async function main() {
               isMature: true,
               designer: 'Kind Robots / Twisted Fairy Tales',
             },
-          } as Prisma.InputJsonValue,
+          }),
         },
       }),
     ),

--- a/utils/scripts/migratePromptsToArtJobs.ts
+++ b/utils/scripts/migratePromptsToArtJobs.ts
@@ -55,10 +55,10 @@ async function main() {
     return
   }
 
-  for (const p of prompts) {
-    const promptString = (p.artPrompt ?? p.prompt ?? '').trim()
+  for (const prompt of prompts) {
+    const promptString = (prompt.artPrompt ?? prompt.prompt ?? '').trim()
     console.log(
-      `Prompt #${p.id} [${p.artStatus}] → ArtJob (user ${p.userId ?? FALLBACK_USER_ID})` +
+      `Prompt #${prompt.id} [${prompt.artStatus}] → ArtJob (user ${prompt.userId ?? FALLBACK_USER_ID})` +
         `  "${promptString.slice(0, 60)}"`,
     )
   }
@@ -73,13 +73,13 @@ async function main() {
   let migrated = 0
   let skipped = 0
 
-  for (const p of prompts) {
-    const promptString = (p.artPrompt ?? p.prompt ?? '').trim()
+  for (const prompt of prompts) {
+    const promptString = (prompt.artPrompt ?? prompt.prompt ?? '').trim()
 
     if (!promptString) {
       // Nothing to render — just clear the stale queue state.
       await prisma.prompt.update({
-        where: { id: p.id },
+        where: { id: prompt.id },
         data: { artStatus: null },
       })
       skipped++
@@ -91,21 +91,21 @@ async function main() {
       prisma.artJob.create({
         data: {
           engine: 'A1111',
-          userId: p.userId ?? FALLBACK_USER_ID,
-          payload: {
+          userId: prompt.userId ?? FALLBACK_USER_ID,
+          payload: JSON.stringify({
             promptString,
-            imagePath: p.imagePath ?? null,
-            migratedFromPromptId: p.id,
+            imagePath: prompt.imagePath ?? null,
+            migratedFromPromptId: prompt.id,
             save: {
-              isPublic: p.isPublic,
-              isMature: p.isMature,
+              isPublic: prompt.isPublic,
+              isMature: prompt.isMature,
               designer: null,
             },
-          },
+          }),
         },
       }),
       prisma.prompt.update({
-        where: { id: p.id },
+        where: { id: prompt.id },
         data: { artStatus: null },
       }),
     ])


### PR DESCRIPTION
Update the Twisted Fairy Tales enqueue and legacy Prompt migration scripts for the string-backed ArtJob payload column. Existing payloads are parsed for lookup and new payloads are JSON-stringified before Prisma writes.