### PR TITLE
Bound ArtImage dynamic select typing

### DIFF
--- a/server/api/art/image/[id].get.ts
+++ b/server/api/art/image/[id].get.ts
@@ -22,6 +22,14 @@ type AccessContext = {
   isAuthenticated: boolean
 }
 
+type ReadableArtImage = Pick<ArtImage, 'userId' | 'isPublic' | 'isMature'> &
+  Record<string, unknown>
+
+type FindSelectedArtImage = (args: {
+  where: { id: number }
+  select: Prisma.ArtImageSelect
+}) => Promise<ReadableArtImage | null>
+
 function readBoolean(value: unknown, fallback = false): boolean {
   if (Array.isArray(value)) return readBoolean(value[0], fallback)
   if (value == null) return fallback
@@ -155,7 +163,11 @@ export default defineEventHandler(async (event) => {
     const access = await getAccessContext(event)
     const select = buildArtImageSelect(query)
 
-    const data = await prisma.artImage.findUnique({
+    // Prisma's extended-client generic can exceed TypeScript's comparison depth
+    // when a runtime-built select is passed directly. The query contract is
+    // intentionally bounded here to the access fields plus the selected record.
+    const findSelected = prisma.artImage.findUnique as unknown as FindSelectedArtImage
+    const data = await findSelected({
       where: { id },
       select,
     })


### PR DESCRIPTION
Wrap the extended Prisma ArtImage findUnique delegate in a narrow local query contract. This avoids TypeScript's excessive generic comparison depth while preserving the runtime-built select, lightweight response behavior, and existing access checks.