### PR TITLE
Add direct runtime database diagnostics

### DIFF
--- a/server/api/health/database-direct.get.ts
+++ b/server/api/health/database-direct.get.ts
@@ -1,0 +1,19 @@
+import { defineEventHandler, setResponseHeader } from 'h3'
+import { probeDatabaseDirect } from '~/server/utils/databaseDirectProbe'
+
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'Cache-Control', 'no-store')
+
+  const result = await probeDatabaseDirect()
+  const statusCode = result.success ? 200 : 503
+  event.node.res.statusCode = statusCode
+
+  return {
+    success: result.success,
+    message: result.success
+      ? 'Direct database connection succeeded.'
+      : 'Direct database connection failed.',
+    data: result,
+    statusCode,
+  }
+})

--- a/server/utils/databaseDirectProbe.ts
+++ b/server/utils/databaseDirectProbe.ts
@@ -1,0 +1,116 @@
+import mariadb from 'mariadb'
+
+type ConnectorError = Error & {
+  code?: string | number
+  errno?: string | number
+  sqlState?: string
+  fatal?: boolean
+}
+
+export type DirectDatabaseProbeResult = {
+  success: boolean
+  latencyMs: number
+  code: string | null
+}
+
+function readDatabaseSslCa(): string | undefined {
+  const encoded = process.env.DATABASE_SSL_CA_BASE64?.replace(/\s+/g, '')
+  if (encoded) {
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8').trim()
+    return decoded.includes('BEGIN CERTIFICATE') ? decoded : undefined
+  }
+
+  return process.env.DATABASE_SSL_CA?.replace(/\\n/g, '\n').trim() || undefined
+}
+
+function rejectUnauthorized(): boolean {
+  const value = process.env.DATABASE_SSL_REJECT_UNAUTHORIZED
+    ?.trim()
+    .toLowerCase()
+  return value !== 'false' && value !== '0' && value !== 'no'
+}
+
+function errorCode(error: ConnectorError): string | null {
+  const value = error.code ?? error.errno ?? error.sqlState
+  return value == null ? null : String(value)
+}
+
+function sanitizedMessage(error: ConnectorError, parsed: URL): string {
+  let message = error.message || String(error)
+
+  for (const secret of [
+    decodeURIComponent(parsed.password),
+    decodeURIComponent(parsed.username),
+  ]) {
+    if (secret) message = message.replaceAll(secret, '[redacted]')
+  }
+
+  if (parsed.hostname) {
+    message = message.replaceAll(parsed.hostname, '[database-host]')
+  }
+
+  return message
+}
+
+export async function probeDatabaseDirect(): Promise<DirectDatabaseProbeResult> {
+  const startedAt = Date.now()
+  const databaseUrl = process.env.DATABASE_URL
+
+  if (!databaseUrl) {
+    return {
+      success: false,
+      latencyMs: Date.now() - startedAt,
+      code: 'DATABASE_URL_MISSING',
+    }
+  }
+
+  const parsed = new URL(databaseUrl)
+  const sslCa = readDatabaseSslCa()
+  let connection: Awaited<ReturnType<typeof mariadb.createConnection>> | null =
+    null
+
+  try {
+    connection = await mariadb.createConnection({
+      host: parsed.hostname,
+      port: Number.parseInt(parsed.port || '3306', 10),
+      user: decodeURIComponent(parsed.username),
+      password: decodeURIComponent(parsed.password),
+      database: decodeURIComponent(parsed.pathname.replace(/^\/+/, '')),
+      connectTimeout: 5_000,
+      ...(sslCa
+        ? {
+            ssl: {
+              ca: sslCa,
+              rejectUnauthorized: rejectUnauthorized(),
+            },
+          }
+        : {}),
+    })
+
+    await connection.query('SELECT 1 AS direct_probe_ok')
+
+    return {
+      success: true,
+      latencyMs: Date.now() - startedAt,
+      code: null,
+    }
+  } catch (unknownError: unknown) {
+    const error = unknownError as ConnectorError
+    const code = errorCode(error)
+
+    console.error('[database:direct-probe]', {
+      name: error.name,
+      code,
+      fatal: error.fatal ?? null,
+      message: sanitizedMessage(error, parsed),
+    })
+
+    return {
+      success: false,
+      latencyMs: Date.now() - startedAt,
+      code,
+    }
+  } finally {
+    await connection?.end().catch(() => undefined)
+  }
+}


### PR DESCRIPTION
Add a separate `/api/health/database-direct` endpoint that bypasses the Prisma pool and performs one direct MariaDB TLS connection.

The public response contains only success, latency, and connector error code. Detailed connector errors are sanitized before logging so credentials and the database hostname are not exposed.

This distinguishes an adapter-pool defect from runtime network/TLS/auth failure while leaving the existing health endpoint unchanged.