### PR TITLE
Fix bot roster capped at first 100 bots

### DIFF
--- a/stores/botStore.ts
+++ b/stores/botStore.ts
@@ -10,6 +10,7 @@ import {
   getBotById,
   botImage,
   seedBotsHelper,
+  fetchAllBots,
 } from './helpers/botHelper'
 import { performFetch, handleError } from './utils'
 import { loadSnapshot, markSnapshotActive } from './helpers/snapshotLoader'
@@ -529,19 +530,15 @@ export const useBotStore = defineStore('botStore', () => {
       try {
         clearError()
 
-        const response = await performFetch<Bot[]>('/api/bots')
+        const fetched = await fetchAllBots()
 
-        if (response.success && Array.isArray(response.data)) {
-          bots.value = response.data.slice().sort(sortBots)
-          isLoaded.value = true
-          usingSnapshot.value = false
-          markSnapshotActive('bots', false)
-          persist()
+        bots.value = fetched.slice().sort(sortBots)
+        isLoaded.value = true
+        usingSnapshot.value = false
+        markSnapshotActive('bots', false)
+        persist()
 
-          return bots.value
-        }
-
-        throw new Error(response.message || 'Failed to fetch bots')
+        return bots.value
       } catch (error: unknown) {
         handleError(error, 'fetching bots')
         setLastError(error, 'Failed to fetch bots')

--- a/stores/helpers/botHelper.ts
+++ b/stores/helpers/botHelper.ts
@@ -119,3 +119,28 @@ export async function botImage(bot: Bot): Promise<string> {
 export async function seedBotsHelper(): Promise<Partial<BotPayload>[]> {
   return botData as Partial<BotPayload>[]
 }
+
+const BOT_FETCH_PAGE_SIZE = 200
+const BOT_FETCH_MAX_PAGES = 50
+
+export async function fetchAllBots(): Promise<Bot[]> {
+  const allBots: Bot[] = []
+
+  for (let page = 1; page <= BOT_FETCH_MAX_PAGES; page++) {
+    const response = await performFetch<Bot[]>(
+      `/api/bots?page=${page}&pageSize=${BOT_FETCH_PAGE_SIZE}`,
+    )
+
+    if (!response.success || !Array.isArray(response.data)) {
+      throw new Error(response.message || 'Failed to fetch bots')
+    }
+
+    allBots.push(...response.data)
+
+    if (response.data.length < BOT_FETCH_PAGE_SIZE) {
+      break
+    }
+  }
+
+  return allBots
+}


### PR DESCRIPTION
## Summary
- `GET /api/bots` honors `page`/`pageSize` (default `pageSize: 100`), but `botStore.ts`'s `fetchBots()` called it with no query params, so with 400+ bots in the database only the first 100 ever loaded into the app-wide bot store/gallery.
- Added `fetchAllBots()` in `stores/helpers/botHelper.ts`, which pages through `/api/bots` in batches of 200 and accumulates until a short page confirms the end (bounded at 50 pages as a safety cap).
- `botStore.ts`'s `fetchBots()` now calls `fetchAllBots()` instead of a single unpaginated request.

Kaizen from kind_robots PR #152 / conductor `kind-robots/t-013`.

## Test plan
- [x] `npx eslint stores/helpers/botHelper.ts stores/botStore.ts` — no new errors (4 pre-existing errors elsewhere in `botStore.ts`, confirmed unchanged via `git stash`)
- [x] `npx prettier --check` on both files — clean
- [x] Full `vue-tsc --noEmit` project typecheck — zero errors touching either changed file (all remaining errors are pre-existing, unrelated `InputJsonValue`/animation-store issues tracked in `kind-robots/t-020`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdZddNXi53iBVBuKogf556

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdZddNXi53iBVBuKogf556)_