### PR TITLE
coloring-book: add a second page set and dynamic set discovery

### DIFF
--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -266,9 +266,10 @@ import type {
   ColoringSetPageRef,
 } from '@/stores/helpers/coloring'
 
-// v1 static registry of shipped sets; generated sets append here (or a
-// directory index replaces this) as coloring-book t-006/t-007 land.
-const SET_SLUGS = ['sampler']
+// Sets are discovered from data/coloring-book/sets/index.json so new sets
+// (coloring-book t-006/t-007 and beyond) can ship without a code change.
+// Falls back to the sampler alone if the index is missing or malformed.
+const FALLBACK_SET_SLUGS = ['sampler']
 const DATA_BASE = '/data/coloring-book/sets'
 
 const coloringStore = useColoringStore()
@@ -295,12 +296,24 @@ function isInProgress(setSlug: string, pageId: string): boolean {
   return coloringStore.inProgressPageIds.includes(`${setSlug}/${pageId}`)
 }
 
+async function loadSetSlugs(): Promise<string[]> {
+  try {
+    const index = await $fetch<{ sets: string[] }>(`${DATA_BASE}/index.json`)
+    return Array.isArray(index?.sets) && index.sets.length
+      ? index.sets
+      : FALLBACK_SET_SLUGS
+  } catch {
+    return FALLBACK_SET_SLUGS
+  }
+}
+
 async function loadSets() {
   loadError.value = ''
 
   try {
+    const slugs = await loadSetSlugs()
     const loaded = await Promise.all(
-      SET_SLUGS.map((slug) =>
+      slugs.map((slug) =>
         $fetch<ColoringSetManifest>(`${DATA_BASE}/${slug}/manifest.json`),
       ),
     )

--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -209,7 +209,7 @@ const config: ProjectFrontConfig = {
   deliverables: {
     done: [
       'Shared coloring engine (region + flood fill, undo, palette, export)',
-      'Sampler set live; Mural runs on the same engine',
+      'Sampler and Cozy Corner sets live; Mural runs on the same engine',
     ],
     next: [
       'Generated Kind Robots and Monster Recast books',

--- a/public/data/coloring-book/sets/cozy-corner/manifest.json
+++ b/public/data/coloring-book/sets/cozy-corner/manifest.json
@@ -1,0 +1,33 @@
+{
+  "slug": "cozy-corner",
+  "title": "Cozy Corner",
+  "description": "Two hand-drawn cozy-corner pages that prove out multi-set support while the Kind Robots and Monster Recast books are in production.",
+  "rating": "all-ages",
+  "pages": [
+    {
+      "id": "cozy-corner-p01",
+      "title": "Sleepy Cat",
+      "file": "pages/cozy-corner-p01.json"
+    },
+    {
+      "id": "cozy-corner-p02",
+      "title": "Potted Plant Shelf",
+      "file": "pages/cozy-corner-p02.json"
+    }
+  ],
+  "attribution": [
+    {
+      "pageId": "cozy-corner-p01",
+      "source": "hand-authored SVG (conductor coloring-book t-020)",
+      "note": "second demo set proving the library scales past a single hardcoded slug"
+    },
+    {
+      "pageId": "cozy-corner-p02",
+      "source": "hand-authored SVG (conductor coloring-book t-020)",
+      "note": "second demo set proving the library scales past a single hardcoded slug"
+    }
+  ],
+  "access": {
+    "tier": "free"
+  }
+}

--- a/public/data/coloring-book/sets/cozy-corner/pages/cozy-corner-p01.json
+++ b/public/data/coloring-book/sets/cozy-corner/pages/cozy-corner-p01.json
@@ -1,0 +1,123 @@
+{
+  "id": "cozy-corner/cozy-corner-p01",
+  "version": 1,
+  "title": "Sleepy Cat",
+  "viewBox": { "width": 1700, "height": 2200 },
+  "mode": "svg-regions",
+  "layers": {
+    "decor": "M1150 340V760 M940 550H1360 M560 1290 Q580 1300 600 1290 M640 1290 Q660 1300 680 1290 M480 1330H420 M480 1345H410 M480 1360H420 M760 1330H820 M760 1345H830 M760 1360H820"
+  },
+  "regions": [
+    {
+      "id": "wall",
+      "label": "Wall",
+      "group": "background",
+      "d": "M0 0H1700V1500H0Z"
+    },
+    {
+      "id": "floor",
+      "label": "Floor",
+      "group": "background",
+      "d": "M0 1500 C400 1460 1300 1540 1700 1490 V2200 H0 Z"
+    },
+    {
+      "id": "window-frame",
+      "label": "Window frame",
+      "group": "window",
+      "d": "M960 300 H1300 Q1400 300 1400 400 V700 Q1400 800 1300 800 H960 Q860 800 860 700 V400 Q860 300 960 300 Z"
+    },
+    {
+      "id": "window-glass",
+      "label": "Window glass",
+      "group": "window",
+      "d": "M940 340 H1360 V760 H940 Z"
+    },
+    {
+      "id": "moon",
+      "label": "Moon",
+      "group": "window",
+      "d": "M1200 420 A50 50 0 1 1 1300 420 A50 50 0 1 1 1200 420 Z"
+    },
+    {
+      "id": "cushion",
+      "label": "Cushion",
+      "d": "M400 1650 A300 150 0 1 1 1000 1650 A300 150 0 1 1 400 1650 Z"
+    },
+    {
+      "id": "cat-tail",
+      "label": "Cat tail",
+      "group": "cat",
+      "d": "M960 1500 C1050 1600 1000 1780 850 1800 C700 1820 550 1780 500 1700 C620 1750 780 1740 870 1650 C930 1600 950 1550 960 1500 Z"
+    },
+    {
+      "id": "cat-body",
+      "label": "Cat body",
+      "group": "cat",
+      "d": "M440 1450 A260 220 0 1 1 960 1450 A260 220 0 1 1 440 1450 Z"
+    },
+    {
+      "id": "cat-head",
+      "label": "Cat head",
+      "group": "cat",
+      "d": "M470 1280 A150 150 0 1 1 770 1280 A150 150 0 1 1 470 1280 Z"
+    },
+    {
+      "id": "ear-left",
+      "label": "Left ear",
+      "group": "cat",
+      "d": "M540 1170 L580 1060 L640 1185 Z"
+    },
+    {
+      "id": "ear-right",
+      "label": "Right ear",
+      "group": "cat",
+      "d": "M600 1185 L660 1060 L700 1170 Z"
+    },
+    {
+      "id": "inner-ear-left",
+      "label": "Left inner ear",
+      "d": "M555 1155 L580 1090 L615 1165 Z"
+    },
+    {
+      "id": "inner-ear-right",
+      "label": "Right inner ear",
+      "d": "M615 1165 L655 1090 L680 1155 Z"
+    },
+    {
+      "id": "nose",
+      "label": "Nose",
+      "d": "M600 1330 L640 1330 L620 1360 Z"
+    },
+    {
+      "id": "pot",
+      "label": "Plant pot",
+      "group": "plant",
+      "d": "M150 1900 H350 L320 2050 H180 Z"
+    },
+    {
+      "id": "leaves",
+      "label": "Plant leaves",
+      "group": "plant",
+      "d": "M180 1900 C120 1780 180 1700 250 1750 C260 1650 350 1650 340 1750 C400 1700 440 1800 380 1900 Z"
+    }
+  ],
+  "palette": [
+    { "id": "wall-cream", "name": "Wall Cream", "value": "#f3e6d8" },
+    { "id": "floor-wood", "name": "Floor Wood", "value": "#c8935a" },
+    { "id": "frame-brown", "name": "Frame Brown", "value": "#7a5230" },
+    { "id": "glass-night", "name": "Night Glass", "value": "#2b3a67" },
+    { "id": "moon-yellow", "name": "Moon Yellow", "value": "#f5e396" },
+    { "id": "cushion-plum", "name": "Cushion Plum", "value": "#b06a8f" },
+    { "id": "cat-orange", "name": "Cat Orange", "value": "#e08a3c" },
+    { "id": "ear-pink", "name": "Ear Pink", "value": "#e58fb1" },
+    { "id": "pot-terracotta", "name": "Pot Terracotta", "value": "#c1592f" },
+    { "id": "leaf-green", "name": "Leaf Green", "value": "#4c8c4a" }
+  ],
+  "metadata": {
+    "sourceImage": null,
+    "prompt": "hand-authored placeholder cozy-corner page",
+    "model": "none (hand-authored SVG)",
+    "generatedAt": "2026-07-15T00:00:00Z",
+    "printMaster": null
+  }
+}

--- a/public/data/coloring-book/sets/cozy-corner/pages/cozy-corner-p02.json
+++ b/public/data/coloring-book/sets/cozy-corner/pages/cozy-corner-p02.json
@@ -1,0 +1,90 @@
+{
+  "id": "cozy-corner/cozy-corner-p02",
+  "version": 1,
+  "title": "Potted Plant Shelf",
+  "viewBox": { "width": 1700, "height": 2200 },
+  "mode": "svg-regions",
+  "layers": {
+    "decor": "M850 1420 C840 1300 845 1180 850 1080 M780 1350 C760 1280 770 1200 800 1150 M920 1350 C940 1280 930 1200 900 1150"
+  },
+  "regions": [
+    {
+      "id": "wall",
+      "label": "Wall",
+      "group": "background",
+      "d": "M0 0H1700V1500H0Z"
+    },
+    {
+      "id": "floor",
+      "label": "Floor",
+      "group": "background",
+      "d": "M0 1500 C400 1460 1300 1540 1700 1490 V2200 H0 Z"
+    },
+    {
+      "id": "sun",
+      "label": "Sun",
+      "d": "M140 300 A110 110 0 1 1 360 300 A110 110 0 1 1 140 300 Z"
+    },
+    {
+      "id": "shelf",
+      "label": "Shelf",
+      "d": "M200 1600 H1500 Q1520 1600 1520 1620 V1660 Q1520 1680 1500 1680 H200 Q180 1680 180 1660 V1620 Q180 1600 200 1600 Z"
+    },
+    {
+      "id": "bracket-left",
+      "label": "Left bracket",
+      "d": "M260 1680 L260 1780 L340 1680 Z"
+    },
+    {
+      "id": "bracket-right",
+      "label": "Right bracket",
+      "d": "M1360 1680 L1440 1680 L1360 1780 Z"
+    },
+    {
+      "id": "pot",
+      "label": "Plant pot",
+      "group": "plant",
+      "d": "M650 1450 H1050 L1000 1600 H700 Z"
+    },
+    {
+      "id": "pot-rim",
+      "label": "Pot rim",
+      "group": "plant",
+      "d": "M630 1420 H1070 V1460 H630 Z"
+    },
+    {
+      "id": "leaf-left",
+      "label": "Left leaf",
+      "group": "plant",
+      "d": "M850 1420 C700 1350 650 1180 750 1080 C830 1200 850 1320 850 1420 Z"
+    },
+    {
+      "id": "leaf-center",
+      "label": "Center leaf",
+      "group": "plant",
+      "d": "M820 1420 C800 1250 810 1080 850 950 C890 1080 900 1250 880 1420 Z"
+    },
+    {
+      "id": "leaf-right",
+      "label": "Right leaf",
+      "group": "plant",
+      "d": "M850 1420 C1000 1350 1050 1180 950 1080 C870 1200 850 1320 850 1420 Z"
+    }
+  ],
+  "palette": [
+    { "id": "wall-cream", "name": "Wall Cream", "value": "#f3e6d8" },
+    { "id": "floor-wood", "name": "Floor Wood", "value": "#c8935a" },
+    { "id": "sun-yellow", "name": "Sun Yellow", "value": "#f5c451" },
+    { "id": "shelf-brown", "name": "Shelf Brown", "value": "#7a5230" },
+    { "id": "pot-terracotta", "name": "Pot Terracotta", "value": "#c1592f" },
+    { "id": "leaf-green", "name": "Leaf Green", "value": "#4c8c4a" },
+    { "id": "leaf-green-light", "name": "Leaf Green Light", "value": "#7fb56a" }
+  ],
+  "metadata": {
+    "sourceImage": null,
+    "prompt": "hand-authored placeholder cozy-corner page",
+    "model": "none (hand-authored SVG)",
+    "generatedAt": "2026-07-15T00:00:00Z",
+    "printMaster": null
+  }
+}

--- a/public/data/coloring-book/sets/index.json
+++ b/public/data/coloring-book/sets/index.json
@@ -1,0 +1,3 @@
+{
+  "sets": ["sampler", "cozy-corner"]
+}


### PR DESCRIPTION
## Summary
- `coloring-book-manager.vue` hardcoded `SET_SLUGS = ['sampler']`, so the library could never grow past the sampler without a code change (conductor `coloring-book/t-020`, filed as the kaizen follow-up from t-019).
- Adds `public/data/coloring-book/sets/index.json` and a `loadSetSlugs()` helper that fetches it, falling back to `['sampler']` if the index is missing or malformed — new sets (t-006 Kind Robots, t-007 Monster Recast, and beyond) can ship by adding a manifest + index entry, no component change needed.
- Adds a second hand-authored demo set, **Cozy Corner** (`Sleepy Cat` + `Potted Plant Shelf`), in the same `svg-regions` style as the existing sampler pages, so the multi-set path is proven end-to-end today rather than only in theory.
- Updates the front page's "done" deliverables copy to reflect two live sets.

## Test plan
- [x] Validated all new/changed JSON (`index.json`, `cozy-corner/manifest.json`, both page definitions) parses and matches the existing `ColoringSetManifest`/`ColoringPageDefinition` shapes (`stores/helpers/coloring.ts`).
- [x] Hand-checked every new SVG region `d` path against the closed-path patterns already used in `sampler-p01.json`/`sampler-p02.json` (paired arc/line commands, explicit `Z` close).
- [ ] Could not run `vue-tsc`/`eslint`/Cypress locally in this sandbox (no `node_modules` installed); relying on CI for the full check — please flag if anything red comes back.
- Manual verification: open `/coloring-book` (or wherever `coloring-book-manager.vue` mounts), confirm both "Starter Sampler" and "Cozy Corner" sets render in the library grid, and that both new pages open and fill correctly in the Color tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg7Q9GDNpLFW6AqSXn2td7)_