### PR TITLE
academy: add Neoclassicism to the academyStyles.ts front-end seed

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -207,6 +207,48 @@ export const academyStyles: AcademyStyle[] = [
     },
   },
   {
+    slug: 'neoclassicism',
+    name: 'Neoclassicism',
+    era: 'c. 1750–1830',
+    sortYear: 1750,
+    region: 'Europe',
+    keyIdeas:
+      'A deliberate correction after Rococo’s pastel frivolity: artists turned back to the "noble simplicity" of Greece and Rome, freshly fueled by the excavations at Pompeii and Herculaneum. Clear drawing over loose paint, moral seriousness over decoration, stoic self-sacrifice over romance — the art of the Enlightenment and the age of revolutions.',
+    recognitionCues: [
+      'Crisp, precise contours — line does the work, not visible brushwork',
+      'Cool, restrained color and even, theater-lit illumination (no Baroque murk)',
+      'Friezelike compositions: figures arranged shallowly, almost like a stage set',
+      'Classical props — togas, columns, Roman furniture, marble — used with intent',
+    ],
+    artists: [
+      {
+        name: 'Jacques-Louis David',
+        years: '1748–1825',
+        note: 'The movement’s central figure and eventual court painter to Napoleon; his Roman history paintings doubled as political manifestos.',
+      },
+      {
+        name: 'Jean-Auguste-Dominique Ingres',
+        years: '1780–1867',
+        note: 'David’s most brilliant pupil, who pushed line into near-abstraction.',
+      },
+      {
+        name: 'Antonio Canova',
+        years: '1757–1822',
+        note: 'The age’s greatest sculptor, whose marble figures combine antique cool with tender softness.',
+      },
+      {
+        name: 'Angelica Kauffman',
+        years: '1741–1807',
+        note: 'Swiss-born history painter and a founding member of Britain’s Royal Academy.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a Neoclassical oil painting: crisp linear contours, cool restrained color, smooth invisible brushwork, and a calm, stage-like classical composition',
+    },
+  },
+  {
     slug: 'ukiyo-e',
     name: 'Ukiyo-e',
     era: 'c. 1650–1900',


### PR DESCRIPTION
## Summary
- Conductor's `ai-art-academy` curriculum doc (`docs/curriculum-outline.md`) documents a 15th movement, Neoclassicism (slug `neoclassicism`, c. 1750–1830, David/Ingres/Canova/Kauffman), but the front-end style registry (`stores/seeds/academyStyles.ts`) only had the original 14 movements.
- Mirrors the new movement's slug/name/era/artist list/remix template into the seed file, matching the existing entry shape exactly (same pattern as PR #143's original 14 entries).
- Inserted between `baroque` and `ukiyo-e` to match the curriculum doc's ordering.

Tracks conductor `ai-art-academy/t-015` (kaizen follow-up from t-010's curriculum-expansion pass).

## Test plan
- [x] `npm run test` (project-wide `vue-tsc --noEmit`) — 19 pre-existing errors, none in the changed file (confirmed against a clean `origin/main` checkout, matching the count already tracked in `kind-robots/t-020`)
- [x] Manually verified brace balance and entry shape against sibling entries (`baroque`, `ukiyo-e`)
- [x] `academyStyles.length`-based UI consumers (`academy-remix.vue`) are dynamic, no hardcoded counts to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cQmmZwWimprFjoc1gftcB

---
_Generated by [Claude Code](https://claude.ai/code/session_012cQmmZwWimprFjoc1gftcB)_