### PR TITLE
api: add DreamRelation REST endpoint (create/list/delete dream graph edges)

### DIFF
--- a/server/api/dream-relations/[id].delete.ts
+++ b/server/api/dream-relations/[id].delete.ts
@@ -1,0 +1,52 @@
+// DELETE /api/dream-relations/:id — remove a DreamRelation edge.
+import { defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { assertDreamAccess } from '~/server/api/dreams/index'
+import { getDreamRelationId } from './index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getDreamRelationId(event.context.params?.id)
+    const auth = await requireApiUser(event)
+
+    const existing = await prisma.dreamRelation.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        FromDream: { select: { id: true, userId: true, isPublic: true } },
+      },
+    })
+    if (!existing) {
+      event.node.res.statusCode = 404
+      return {
+        success: false,
+        message: 'Dream relation not found.',
+        statusCode: 404,
+      }
+    }
+
+    assertDreamAccess({
+      dream: existing.FromDream,
+      userId: auth.user.id,
+      userRole: auth.user.Role,
+      action: 'mutate',
+    })
+
+    await prisma.dreamRelation.delete({ where: { id } })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Dream relation deleted successfully.',
+      data: { id },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/dream-relations/index.get.ts
+++ b/server/api/dream-relations/index.get.ts
@@ -1,0 +1,62 @@
+// GET /api/dream-relations — list DreamRelation edges, optionally filtered.
+// Query: dreamId (either side), fromDreamId, toDreamId, relationType.
+import { defineEventHandler, getQuery } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { dreamRelationSelect, parseDreamRelationType } from './index'
+
+type DreamRelationListQuery = {
+  dreamId?: string
+  fromDreamId?: string
+  toDreamId?: string
+  relationType?: string
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireApiUser(event)
+    const query = getQuery<DreamRelationListQuery>(event)
+
+    const and: Prisma.DreamRelationWhereInput[] = []
+
+    const dreamId = Number(query.dreamId)
+    if (Number.isInteger(dreamId) && dreamId > 0) {
+      and.push({ OR: [{ fromDreamId: dreamId }, { toDreamId: dreamId }] })
+    }
+
+    const fromDreamId = Number(query.fromDreamId)
+    if (Number.isInteger(fromDreamId) && fromDreamId > 0) {
+      and.push({ fromDreamId })
+    }
+
+    const toDreamId = Number(query.toDreamId)
+    if (Number.isInteger(toDreamId) && toDreamId > 0) {
+      and.push({ toDreamId })
+    }
+
+    const relationType = parseDreamRelationType(query.relationType)
+    if (relationType) and.push({ relationType })
+
+    const relations = await prisma.dreamRelation.findMany({
+      where: and.length ? { AND: and } : undefined,
+      select: dreamRelationSelect,
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Dream relations fetched successfully.',
+      data: relations,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/dream-relations/index.post.ts
+++ b/server/api/dream-relations/index.post.ts
@@ -1,0 +1,111 @@
+// POST /api/dream-relations — create (or update the note on) a DreamRelation edge.
+// Body: { fromDreamId, toDreamId, relationType?, note? }
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { assertDreamAccess } from '~/server/api/dreams/index'
+import {
+  dreamRelationSelect,
+  dreamRelationTypes,
+  parseDreamRelationType,
+} from './index'
+
+type DreamRelationCreateBody = {
+  fromDreamId?: unknown
+  toDreamId?: unknown
+  relationType?: unknown
+  note?: unknown
+}
+
+function requiredDreamId(value: unknown, field: string): number {
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `"${field}" must be a positive integer.`,
+    })
+  }
+  return id
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = await readBody<DreamRelationCreateBody>(event)
+
+    const fromDreamId = requiredDreamId(body.fromDreamId, 'fromDreamId')
+    const toDreamId = requiredDreamId(body.toDreamId, 'toDreamId')
+    if (fromDreamId === toDreamId) {
+      throw createError({
+        statusCode: 400,
+        message: 'fromDreamId and toDreamId must be different Dreams.',
+      })
+    }
+
+    const relationType = body.relationType
+      ? parseDreamRelationType(body.relationType)
+      : 'RELATED'
+    if (!relationType) {
+      throw createError({
+        statusCode: 400,
+        message: `"relationType" must be one of: ${dreamRelationTypes.join(', ')}.`,
+      })
+    }
+
+    const note =
+      typeof body.note === 'string' && body.note.trim()
+        ? body.note.trim().slice(0, 512)
+        : null
+
+    const [fromDream, toDream] = await Promise.all([
+      prisma.dream.findUnique({
+        where: { id: fromDreamId },
+        select: { id: true, userId: true, isPublic: true },
+      }),
+      prisma.dream.findUnique({
+        where: { id: toDreamId },
+        select: { id: true },
+      }),
+    ])
+    if (!fromDream) {
+      throw createError({ statusCode: 404, message: 'fromDreamId not found.' })
+    }
+    if (!toDream) {
+      throw createError({ statusCode: 404, message: 'toDreamId not found.' })
+    }
+
+    assertDreamAccess({
+      dream: fromDream,
+      userId: auth.user.id,
+      userRole: auth.user.Role,
+      action: 'mutate',
+    })
+
+    const relation = await prisma.dreamRelation.upsert({
+      where: {
+        fromDreamId_toDreamId_relationType: {
+          fromDreamId,
+          toDreamId,
+          relationType,
+        },
+      },
+      create: { fromDreamId, toDreamId, relationType, note },
+      update: { note },
+      select: dreamRelationSelect,
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: 'Dream relation created successfully.',
+      data: relation,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/dream-relations/index.ts
+++ b/server/api/dream-relations/index.ts
@@ -1,0 +1,43 @@
+// /server/api/dream-relations/index.ts — shared helpers for the DreamRelation REST surface.
+import { createError } from 'h3'
+import type { DreamRelationType } from '~/prisma/generated/prisma/client'
+
+export const dreamRelationTypes: DreamRelationType[] = [
+  'IS_A',
+  'APPEARS_IN',
+  'CONTAINS',
+  'RELATED',
+  'INSPIRED_BY',
+]
+
+export function parseDreamRelationType(
+  value: unknown,
+): DreamRelationType | null {
+  return typeof value === 'string' &&
+    dreamRelationTypes.includes(value as DreamRelationType)
+    ? (value as DreamRelationType)
+    : null
+}
+
+export const dreamRelationSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  fromDreamId: true,
+  toDreamId: true,
+  relationType: true,
+  note: true,
+}
+
+export function getDreamRelationId(idParam: unknown): number {
+  const id = Number(idParam)
+
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid DreamRelation ID. It must be a positive integer.',
+    })
+  }
+
+  return id
+}


### PR DESCRIPTION
### Task
kind-robots/t-017: Add a DreamRelation REST endpoint (create/list dream graph edges) (kind: software)

### What changed / what I produced
- `server/api/dream-relations/index.ts` — shared `dreamRelationTypes`/`parseDreamRelationType`/`dreamRelationSelect`/`getDreamRelationId` helpers.
- `server/api/dream-relations/index.get.ts` — list edges, filterable by `dreamId` (either side), `fromDreamId`, `toDreamId`, `relationType`.
- `server/api/dream-relations/index.post.ts` — create/upsert an edge (`fromDreamId`, `toDreamId`, `relationType?` default `RELATED`, `note?`). Validates both Dreams exist, rejects self-edges, gates on `assertDreamAccess` mutate (owner or admin) against the `fromDream`.
- `server/api/dream-relations/[id].delete.ts` — delete an edge, same access gate.
- All three `requireApiUser`-gated per the task note, following the `model-builder/runs` and `dreams/facets` endpoint patterns already in the codebase (same `errorHandler`/status-code shape).
- Extended conductor's `scripts/build_dream_records.py` (companion repo) to call the new endpoint: world (PITCH) `RELATED` to the GENRE Dream, world `CONTAINS` each LOCATION Dream, and each LOCATION `RELATED` to the GENRE Dream — closing the "KNOWN GAP" the daily-dream builder's docstring called out.

### How I verified
- `npx prisma generate` (dummy `DATABASE_URL`, no schema changes — reused the existing `DreamRelation` model and its `fromDreamId_toDreamId_relationType` unique constraint, confirmed the generated name against the sibling `UserRelation` `userId_relatedUserId_type` constraint).
- `vue-tsc --noEmit`: 0 new errors. Full run still shows the same 19 pre-existing errors tracked at kind-robots/t-020 (byte-diffed the error list before/after — no `dream-relations` files appear).
- `npx eslint server/api/dream-relations` — clean, 0 warnings.
- `npm run test:channel-content` and `npm run test:channel-resolver` — both pass (unrelated to this change, ran as a sanity check).
- Could not exercise the endpoint live end-to-end (no `KR_API_TOKEN`/DB in this sandbox), so I unit-exercised the conductor script change directly: monkeypatched `kr_call` to return incrementing ids and confirmed the three relation POSTs fire with the correct `fromDreamId`/`toDreamId`/`relationType` payloads for a synthetic 1-world/2-location proposal (world→genre RELATED, world→each location CONTAINS, each location→genre RELATED). A real dry-run (`kr_call`'s built-in dry-run returns `{"id": 0}`, which is falsy) correctly no-ops the relation calls, matching the existing `link_ids` falsy-zero convention already used elsewhere in that script for character/narrator/reward links.

### Stakes
reversible

### Flags for Reviewer
- No live-DB verification was possible in this sandbox (no `KR_API_TOKEN`). The endpoint code closely mirrors two other tested-and-merged endpoint families in this repo (`model-builder/runs/*` and `dreams/[id]/facets.*`), so the risk is low, but a live smoke test (`POST /api/dream-relations` with two real Dream ids) would be good before the next daily-dream build cycle relies on it.
- `POST` upserts on the unique triple `(fromDreamId, toDreamId, relationType)` rather than erroring on a duplicate — chosen so a re-run of the dream-cycle builder for the same day doesn't fail on already-created edges; only the `note` is updated on a repeat call.

### Kaizen suggestion
`kind-robots/t-020` (19 pre-existing TypeScript errors) and `t-021` (Channel content contract — already resolved, no action needed) remain the two open CI-signal threads; consider giving `t-020` a dedicated pass since it's been sitting at 19 for a few cycles now.

### Notes for reviewer
Companion conductor-repo change (`scripts/build_dream_records.py`) ships in the same session's conductor PR, not this one, per the cross-repo task convention in `AGENTS.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jtug71Sd7Bg9VyfHMnhN5h)_