### PR TITLE
ci(cypress): accept a superseding commit as a live deploy

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -39,20 +39,38 @@ jobs:
           TARGET_SHA: ${{ github.sha }}
           MAX_WAIT: ${{ github.event.inputs.max_wait_seconds || '1200' }}
         run: |
-          echo "Waiting up to ${MAX_WAIT}s for production to serve ${TARGET_SHA}..."
+          echo "Waiting up to ${MAX_WAIT}s for production to serve ${TARGET_SHA} (or a commit that supersedes it)..."
           deadline=$(( $(date +%s) + MAX_WAIT ))
           live=""
           while [ "$(date +%s)" -lt "$deadline" ]; do
             body="$(curl -sf --max-time 15 "${BASE_URL}/api/version" || true)"
             live="$(printf '%s' "$body" | jq -r '.data.commit // empty' 2>/dev/null || true)"
-            if [ -n "$live" ] && [ "$live" = "$TARGET_SHA" ]; then
-              echo "Production is serving ${live} — deploy is live."
-              exit 0
+            if [ -n "$live" ]; then
+              if [ "$live" = "$TARGET_SHA" ]; then
+                echo "Production is serving ${live} — deploy is live."
+                exit 0
+              fi
+              # A burst of several merges within a short window can land newer
+              # commits on main before this run's own deploy goes live, so an
+              # already-superseded TARGET_SHA never becomes the exact `live`
+              # value. If the live commit already contains TARGET_SHA (i.e.
+              # TARGET_SHA is one of its ancestors), this deploy's changes are
+              # live too via that superseding commit -- not a failure. Only
+              # deepen the (shallow) checkout when ancestry needs checking, so
+              # the common exact-match case stays fast.
+              if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+                git fetch --quiet --depth=200 origin main 2>/dev/null || true
+              fi
+              if git cat-file -e "${live}^{commit}" 2>/dev/null \
+                && git merge-base --is-ancestor "$TARGET_SHA" "$live" 2>/dev/null; then
+                echo "Production is serving ${live}, a newer commit that already includes ${TARGET_SHA} — deploy is live (superseded)."
+                exit 0
+              fi
             fi
             echo "  not live yet (serving: ${live:-unknown}); retrying in 10s..."
             sleep 10
           done
-          echo "::error::Production did not serve ${TARGET_SHA} within ${MAX_WAIT}s (last seen: ${live:-unknown})."
+          echo "::error::Production did not serve ${TARGET_SHA} (or a superseding commit) within ${MAX_WAIT}s (last seen: ${live:-unknown})."
           exit 1
 
       - name: Verify database readiness


### PR DESCRIPTION
## Summary
- `.github/workflows/cypress.yml`'s deploy-wait step polled `/api/version` for an *exact* match on `TARGET_SHA`, timing out at 600s (now configurable, default 1200s) if production never served that exact commit.
- During a burst of several merges within 1-2 hours (e.g. PR #238-#242), Vercel starts a new production build for each new `main` commit before the previous one finishes. By the time any single build would go live, a newer commit has already superseded it — production stays pinned on an older SHA and the exact-match poll fails red even though nothing is actually broken (each commit's own build was still queued/building).
- Fix: when the live commit doesn't exactly match `TARGET_SHA`, check whether `TARGET_SHA` is a git ancestor of the live commit. If so, the live commit already contains `TARGET_SHA`'s changes (a "superseded but correct" state) and the wait succeeds instead of timing out. The shallow checkout is only deepened (`--depth=200`) when this ancestry check is actually needed, so the common exact-match case stays fast.

This is conductor `kind-robots/t-018` (found during a Reviewer sweep 2026-07-14, root-caused and documented there; not urgent since it self-resolves once merge bursts settle, but flakes CI red during any future rapid-merge session).

## Test plan
- [x] `.github/workflows/cypress.yml` parses as valid YAML.
- [x] Verified the new ancestry-check shell logic in isolated scratch git repos simulating both the shallow-checkout "superseded" case (commit accepted) and a non-superseding sibling-branch commit (correctly rejected).
- [ ] Live verification requires an actual merge-burst Vercel deploy race, which can't be reproduced outside CI — the next time this scenario occurs the workflow run will confirm behavior end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vov3WyjVX673po7g1nX2Nq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vov3WyjVX673po7g1nX2Nq)_