### PR TITLE
fix: resolve remaining pre-existing TypeScript errors on main (19 -> 0)

### DIFF
--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -394,7 +394,7 @@ function jobImageDiag(job: ArtJobRecord): string {
 }
 
 function jobPrompt(job: ArtJobRecord): string {
-  const payload = job.payload || {}
+  const payload: Record<string, unknown> = job.payload || {}
   for (const key of ['promptString', 'artPrompt', 'prompt']) {
     const value = payload[key]
     if (typeof value === 'string' && value.trim()) return value.trim()

--- a/components/screenfx/animation-tester.vue
+++ b/components/screenfx/animation-tester.vue
@@ -53,10 +53,8 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import {
-  useAnimationStore,
-  type AnimationEffectId,
-} from '@/stores/animationStore'
+import { useAnimationStore } from '@/stores/animationStore'
+import type { AnimationEffectId } from '@/stores/animationCatalog'
 
 const animationStore = useAnimationStore()
 

--- a/components/screenfx/screen-fx.vue
+++ b/components/screenfx/screen-fx.vue
@@ -159,10 +159,9 @@
 import { ref } from 'vue'
 import {
   useAnimationStore,
-  type AnimationEffectId,
-  type FxRegion,
   type FxPlacementState,
 } from '@/stores/animationStore'
+import type { AnimationEffectId, FxRegion } from '@/stores/animationCatalog'
 
 const animationStore = useAnimationStore()
 

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -45,7 +45,6 @@ import {
   WAN_DEFAULT_DURATION,
   WAN_DEFAULT_FRAME_RATE,
 } from '../comfy/wan/utils/imageToVideoWorkflow'
-import type { Prisma } from '~/prisma/generated/prisma/client'
 
 // The queueable engines. `openai` is handled synchronously elsewhere.
 // `ltx` and `wan` are image-to-video engines (media: 'video').
@@ -195,7 +194,7 @@ export default defineEventHandler(async (event) => {
     const job = await prisma.artJob.create({
       data: {
         engine: jobEngine,
-        payload: payload as unknown as Prisma.InputJsonValue,
+        payload: JSON.stringify(payload),
         priority,
         projectSlug,
         userId: gate.user.id,

--- a/server/api/art/image/index.get.ts
+++ b/server/api/art/image/index.get.ts
@@ -108,7 +108,7 @@ function buildArtImageWhere({
 
 function buildArtImageSelect(
   query: Record<string, QueryValue>,
-): Prisma.ArtImageSelect {
+): Prisma.Args<typeof prisma.artImage, 'findMany'>['select'] {
   const includeImageData = readBoolean(query.includeImageData, false)
   const includeThumbnailData = readBoolean(query.includeThumbnailData, false)
   const includeTags = readBoolean(query.includeTags, false)

--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -1,6 +1,6 @@
 // /server/api/model-builder/items/[id].patch.ts
 import { defineEventHandler, readBody } from 'h3'
-import { Prisma } from '~/prisma/generated/prisma/client'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
@@ -55,8 +55,9 @@ export default defineEventHandler(async (event) => {
     const body = await readBody<ItemPatchBody>(event)
     const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
 
-    if (body.stageStatuses !== undefined && typeof body.stageStatuses === 'object' && body.stageStatuses !== null) {
-      data.stageStatuses = body.stageStatuses as Prisma.InputJsonValue
+    if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
+      const stageStatuses = normalizeJson(body.stageStatuses)
+      if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
     }
     if (body.pitch !== undefined) data.pitch = normalizeText(body.pitch)
     if (body.fieldsDraft !== undefined)
@@ -90,20 +91,20 @@ export default defineEventHandler(async (event) => {
     const reason =
       typeof body.reason === 'string' ? body.reason.slice(0, 255) : null
 
-    const previousPayload = {
+    const previousPayload = JSON.stringify({
       pitch: existing.pitch,
       fieldsDraft: existing.fieldsDraft,
       promptDraft: existing.promptDraft,
       stageStatuses: existing.stageStatuses,
       relationshipDraft: existing.relationshipDraft,
-    } as unknown as Prisma.InputJsonValue
-    const nextPayload = {
+    })
+    const nextPayload = JSON.stringify({
       pitch: data.pitch ?? existing.pitch,
       fieldsDraft: data.fieldsDraft ?? existing.fieldsDraft,
       promptDraft: data.promptDraft ?? existing.promptDraft,
       stageStatuses: data.stageStatuses ?? existing.stageStatuses,
       relationshipDraft: data.relationshipDraft ?? existing.relationshipDraft,
-    } as unknown as Prisma.InputJsonValue
+    })
 
     const item = await prisma.$transaction(async (tx) => {
       if (contentChanged) {

--- a/server/api/model-builder/items/[id]/artifacts.post.ts
+++ b/server/api/model-builder/items/[id]/artifacts.post.ts
@@ -1,6 +1,5 @@
 // /server/api/model-builder/items/[id]/artifacts.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
-import { Prisma } from '~/prisma/generated/prisma/client'
 import type { ModelBuildReviewState } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
@@ -80,7 +79,7 @@ export default defineEventHandler(async (event) => {
         height: int(body.height),
         workflow:
           body.workflow && typeof body.workflow === 'object'
-            ? (body.workflow as Prisma.InputJsonValue)
+            ? JSON.stringify(body.workflow)
             : undefined,
         format: str(body.format, 32),
         artImageId: normalizeNullableId(body.artImageId) ?? null,
@@ -91,7 +90,7 @@ export default defineEventHandler(async (event) => {
           : 'PENDING',
         usageInfo:
           body.usageInfo && typeof body.usageInfo === 'object'
-            ? (body.usageInfo as Prisma.InputJsonValue)
+            ? JSON.stringify(body.usageInfo)
             : undefined,
       },
     })

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -19,12 +19,20 @@
 // fields it owns (the single text field plus the model's known field spec).
 
 import { createError, defineEventHandler, readBody } from 'h3'
-import type { Rarity, RewardType, DreamType, FacetKind, Prisma  } from '~/prisma/generated/prisma/client'
+import type { Rarity, RewardType, DreamType, FacetKind } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
-import { assertRunAccess, getItemId } from '../../runs/index'
+import { assertRunAccess, getItemId, parseStoredJson } from '../../runs/index'
 import { CREATE_TARGETS, fieldSpecFor } from '~/stores/helpers/modelBuilderFields'
+
+// prisma is $extends()-wrapped (see server/utils/prisma.ts), so its
+// $transaction callback's tx param has extended InternalArgs that don't
+// structurally match the plain Prisma.TransactionClient type. Derive the
+// type from the actual instance instead of the generated default.
+type TransactionClient = Parameters<
+  Parameters<typeof prisma.$transaction>[0]
+>[0]
 
 type SourceType =
   | 'Project'
@@ -359,7 +367,7 @@ async function updateText(
 // with the single text field plus any known columns from the structured FIELDS
 // draft. Returns its id.
 async function createRecord(
-  tx: Prisma.TransactionClient,
+  tx: TransactionClient,
   type: SourceType,
   name: string,
   text: string,
@@ -438,7 +446,7 @@ async function createRecord(
 // Link a newly created target back to its source via the known relation.
 // Returns true if a link was written, false if the pair has no known relation.
 async function linkSourceToTarget(
-  tx: Prisma.TransactionClient,
+  tx: TransactionClient,
   sourceType: SourceType,
   sourceId: number,
   targetType: SourceType,
@@ -667,10 +675,11 @@ export default defineEventHandler(async (event) => {
     }
 
     // Record the commit on the item (COMMIT stage + target) so it survives resume.
-    const stages =
-      item.stageStatuses && typeof item.stageStatuses === 'object'
-        ? { ...(item.stageStatuses as Record<string, unknown>) }
-        : {}
+    // stageStatuses is stored as serialized JSON text (see prisma/model-builder.prisma).
+    const stages = parseStoredJson<Record<string, unknown>>(
+      item.stageStatuses,
+      {},
+    )
     stages.COMMIT = {
       status: 'approved',
       note: `Committed → ${target.type} #${target.id}${target.created ? (target.linked ? ' (created + linked)' : ' (created)') : ''}`,
@@ -681,7 +690,7 @@ export default defineEventHandler(async (event) => {
       data: {
         targetType: target.type,
         targetId: target.id,
-        stageStatuses: stages as unknown as Prisma.InputJsonValue,
+        stageStatuses: JSON.stringify(stages),
       },
       include: {
         Artifacts: { orderBy: { id: 'asc' } },

--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -1,6 +1,5 @@
 // /server/api/model-builder/runs/index.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
-import { Prisma } from '~/prisma/generated/prisma/client'
 import type { ModelBuildAction } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
@@ -78,10 +77,11 @@ export default defineEventHandler(async (event) => {
       const action = actions.has(item.action as ModelBuildAction)
         ? (item.action as ModelBuildAction)
         : 'ASSET_ONLY'
-      const stageStatuses =
+      const stageStatuses = JSON.stringify(
         item.stageStatuses && typeof item.stageStatuses === 'object'
-          ? (item.stageStatuses as Prisma.InputJsonValue)
-          : ({} as Prisma.InputJsonValue)
+          ? item.stageStatuses
+          : {},
+      )
 
       const text = (value: unknown): string | null =>
         typeof value === 'string' && value.trim() ? value : null
@@ -116,7 +116,7 @@ export default defineEventHandler(async (event) => {
             : null,
         sourceSnapshot:
           body.sourceSnapshot && typeof body.sourceSnapshot === 'object'
-            ? (body.sourceSnapshot as Prisma.InputJsonValue)
+            ? JSON.stringify(body.sourceSnapshot)
             : undefined,
         recipeKey,
         recipeVersion:
@@ -125,7 +125,7 @@ export default defineEventHandler(async (event) => {
             : null,
         selections:
           body.selections && typeof body.selections === 'object'
-            ? (body.selections as Prisma.InputJsonValue)
+            ? JSON.stringify(body.selections)
             : undefined,
         Items: { create: items },
       },

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -10,11 +10,8 @@
 // Commands only toggle reversible visual effects; nothing is written or spent.
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
-import {
-  useAnimationStore,
-  type AnimationEffectId,
-  type FxRegion,
-} from '@/stores/animationStore'
+import { useAnimationStore } from '@/stores/animationStore'
+import type { AnimationEffectId, FxRegion } from '@/stores/animationCatalog'
 import { useThemeStore } from '@/stores/themeStore'
 
 export type VoiceBusRole = 'voice' | 'view' | 'system'


### PR DESCRIPTION
### Task
conductor/kind-robots/t-020: Fix pre-existing TypeScript errors breaking main's TypeScript CI check (kind: software)

### What changed / what I produced
Grouped by root cause:
- **animationStore.ts** imported `AnimationEffectId`/`FxRegion` as types from `animationCatalog.ts` but never re-exported them; three consumers (`animation-tester.vue`, `screen-fx.vue`, `serendipityVoiceStore.ts`) imported them from `animationStore` anyway. Pointed those imports at `animationCatalog` directly (a re-export shim would create an ambiguous duplicate for Nuxt's auto-import scanner — confirmed via a `WARN Duplicated imports` that appeared and was removed).
- **artjob-feedback-manager.vue**: `job.payload || {}` widened the indexed value's type to `ArtJobPayload | {}`, and `{}` has no index signature (TS7053). Annotated the local as `Record<string, unknown>`.
- **server/api/art/image/index.get.ts**: `buildArtImageSelect()` was typed with plain `Prisma.ArtImageSelect`, but `prisma` is a `$extends()`-wrapped client with different `InternalArgs`, so TS blew its comparison depth (TS2321 "Excessive stack depth"). Derived the select type from the actual instance via `Prisma.Args<typeof prisma.artImage, 'findMany'>['select']`.
- **model-builder JSON-ish columns** (`ModelBuildItem.stageStatuses/pitch/fieldsDraft/promptDraft`, `ModelBuildRevision.previousPayload/nextPayload`, `ModelBuildArtifact.workflow/usageInfo`, `ModelBuildRun.sourceSnapshot/selections`, `ArtJob.payload`) are all `String`/`LongText` columns in `prisma/model-builder.prisma` and `prisma/schema.prisma`, not native `Json` columns. Several call sites cast JS objects straight to `Prisma.InputJsonValue` instead of serializing, which never matched the generated `String` field types (TS2322/TS2345). Serialized with `JSON.stringify` (or the existing `normalizeJson` helper) at every call site.
- **commit.post.ts** also read `item.stageStatuses` back out with a `typeof === 'object'` check that's always false for a string column — silently dropping prior stage statuses on every commit. Fixed with the existing `parseStoredJson` helper instead of the dead branch.
- **createRecord/linkSourceToTarget** declared `tx: Prisma.TransactionClient` (the default-args shape) but only ever receive the extended client's transaction type from `prisma.$transaction()`. Derived a local `TransactionClient` type from the actual `prisma.$transaction` signature instead.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — 19 errors → 0, exit code 0 (needed a dummy `DATABASE_URL` for `prisma generate`/config load; no live DB connection required for typechecking).
- `npx eslint` on every touched file — clean, except one pre-existing, unrelated `includeTags` unused-var warning in `image/index.get.ts` confirmed present before this change via `git stash`.
- `npx prettier --check` on every touched file — the 6 pre-existing formatting warnings were confirmed present before this change too (same `git stash` check); this PR introduces no new formatting drift.

### Stakes
reversible

### Flags for Reviewer
- Left the pre-existing `includeTags` unused-var lint error and the 6 pre-existing prettier formatting warnings alone — out of scope for this task (fixing the TS-error CI check specifically), confirmed unrelated to this diff.
- The `commit.post.ts` `stageStatuses` read bug (silently dropping prior stage statuses) was a real, separate correctness bug hiding behind the type error, not just a type annotation fix — flagging in case it warrants extra scrutiny.

### Kaizen suggestion
Add a lightweight repo convention/lint rule (or a short note in a CLAUDE.md-style doc) flagging that any Prisma field of DB type `String`/`LongText` storing serialized structured data should go through `JSON.stringify`/`normalizeJson`/`parseStoredJson` at its call sites rather than `as Prisma.InputJsonValue` — that mismatch was the root cause of 12 of the 19 errors here and is easy to reintroduce next time a call site is added.

### Notes for reviewer
Diff is small and mechanical (10 files, +42/-40) — no behavior changes intended except the `commit.post.ts` stageStatuses read fix noted above, which restores previously-dropped data.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdUTrP6TTZBhfzGHDCGdds)_