### PR TITLE
fix: restore production database pool capacity

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -52,7 +52,7 @@ function buildDatabaseUrl(url: string): string {
   )
   const connectionLimit = readPositiveInteger(
     process.env.DATABASE_CONNECTION_LIMIT,
-    2,
+    10,
   )
   const minDelayValidation = readNonNegativeInteger(
     process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
@@ -175,7 +175,7 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     ),
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
-      2,
+      10,
     ),
     minDelayValidation: readNonNegativeInteger(
       parsed.searchParams.get('minDelayValidation') ?? undefined,


### PR DESCRIPTION
## Conductor task
`kind-robots/t-022` — production DB connection-pool exhaustion.

## Root cause
Production deployments are `READY`, and a direct MariaDB probe succeeds, but every Prisma-backed route is returning 503 with:

`pool timeout: failed to retrieve a connection from pool after 3000ms (pool connections: active=0 idle=0 limit=2)`

The current `server/utils/prisma.ts` has regressed both default pool limits from 10 back to 2. Commit `e2caf03d` previously fixed this exact regression after it pool-starved production and Cypress; the newer pool lifecycle/circuit-breaker work accidentally reintroduced the unsafe fallback.

## Change
Restore the `DATABASE_CONNECTION_LIMIT` fallback to 10 in both configuration paths:
- URL query-parameter configuration
- explicit TLS/object configuration

An explicit `DATABASE_CONNECTION_LIMIT` environment value still overrides the fallback.

## Verification
- Diff is one file, 2 additions / 2 deletions.
- Live direct DB probe: 200, successful connection.
- Live pooled DB probe before this fix: 503 at the 3000ms acquire timeout, reporting `limit=2`.
- Historical commit `e2caf03d` documents and fixes the identical failure mode with the identical 2 → 10 change.

## Stakes
Reversible application configuration. No schema, migration, credentials, DNS, or database-side changes.