### PR TITLE
fix: guard DATABASE_CONNECTION_LIMIT fallback against regressing below a safe minimum

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Channel resolver contract
         run: npm run test:channel-resolver
 
+      - name: Database pool defaults contract
+        run: npm run test:database-pool-defaults
+
       - name: Navigation route access contract
         run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:animation-catalog": "tsx utils/scripts/verifyAnimationCatalog.ts",
+    "test:database-pool-defaults": "tsx utils/scripts/verifyDatabasePoolDefaults.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/server/utils/databasePoolDefaults.ts
+++ b/server/utils/databasePoolDefaults.ts
@@ -1,0 +1,20 @@
+// /server/utils/databasePoolDefaults.ts
+// The DATABASE_CONNECTION_LIMIT fallback has regressed from 10 down to 2 twice
+// (historical commit e2caf03d, then again in kind_robots PR #296) — each time a
+// full production outage, every DB-backed API route 503ing with
+// "pool timeout ... (pool connections: active=0 idle=0 limit=2)" once the
+// two-connection pool starved. server/utils/prisma.ts imports
+// DEFAULT_CONNECTION_LIMIT from here instead of hardcoding the fallback so a
+// future edit can't silently reintroduce an unsafe value without either
+// changing this file (visible in review) or failing the guard below and
+// utils/scripts/verifyDatabasePoolDefaults.ts in CI.
+export const SAFE_MINIMUM_CONNECTION_LIMIT = 8
+export const DEFAULT_CONNECTION_LIMIT = 10
+
+if (DEFAULT_CONNECTION_LIMIT < SAFE_MINIMUM_CONNECTION_LIMIT) {
+  throw new Error(
+    `DEFAULT_CONNECTION_LIMIT (${DEFAULT_CONNECTION_LIMIT}) is below the safe ` +
+      `minimum (${SAFE_MINIMUM_CONNECTION_LIMIT}) in server/utils/databasePoolDefaults.ts — ` +
+      'this fallback has caused two production outages, see the file header before lowering it.',
+  )
+}

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -5,6 +5,7 @@ import {
   checkServerIdentity,
   type ConnectionOptions as TlsConnectionOptions,
 } from 'node:tls'
+import { DEFAULT_CONNECTION_LIMIT } from './databasePoolDefaults'
 
 type PrismaMariaDbConfig = ConstructorParameters<typeof PrismaMariaDb>[0]
 
@@ -52,7 +53,7 @@ function buildDatabaseUrl(url: string): string {
   )
   const connectionLimit = readPositiveInteger(
     process.env.DATABASE_CONNECTION_LIMIT,
-    10,
+    DEFAULT_CONNECTION_LIMIT,
   )
   const minDelayValidation = readNonNegativeInteger(
     process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
@@ -175,7 +176,7 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
     ),
     connectionLimit: readPositiveInteger(
       parsed.searchParams.get('connectionLimit') ?? undefined,
-      10,
+      DEFAULT_CONNECTION_LIMIT,
     ),
     minDelayValidation: readNonNegativeInteger(
       parsed.searchParams.get('minDelayValidation') ?? undefined,
@@ -231,8 +232,10 @@ const breakerCooldownMs = readPositiveInteger(
   10_000,
 )
 
-const breaker: CircuitBreakerState =
-  globalForPrisma.prismaBreaker ?? { failures: 0, openUntil: 0 }
+const breaker: CircuitBreakerState = globalForPrisma.prismaBreaker ?? {
+  failures: 0,
+  openUntil: 0,
+}
 globalForPrisma.prismaBreaker = breaker
 
 const CIRCUIT_OPEN_MESSAGE =

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -1,0 +1,21 @@
+// /utils/scripts/verifyDatabasePoolDefaults.ts
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_CONNECTION_LIMIT,
+  SAFE_MINIMUM_CONNECTION_LIMIT,
+} from './../../server/utils/databasePoolDefaults'
+
+// Regression guard: this fallback has silently dropped from 10 to 2 twice
+// (e2caf03d, then kind_robots PR #296), each time causing a full production
+// outage (every DB-backed route 503ing on pool exhaustion). Fail CI loudly
+// instead of waiting for the next outage to notice.
+assert.ok(
+  DEFAULT_CONNECTION_LIMIT >= SAFE_MINIMUM_CONNECTION_LIMIT,
+  `DEFAULT_CONNECTION_LIMIT (${DEFAULT_CONNECTION_LIMIT}) must be >= ` +
+    `SAFE_MINIMUM_CONNECTION_LIMIT (${SAFE_MINIMUM_CONNECTION_LIMIT}) — ` +
+    'see server/utils/databasePoolDefaults.ts',
+)
+
+console.log(
+  `Database pool connection-limit fallback verified: ${DEFAULT_CONNECTION_LIMIT} >= ${SAFE_MINIMUM_CONNECTION_LIMIT}.`,
+)


### PR DESCRIPTION
### Task
kind-robots/t-025: Guard against DATABASE_CONNECTION_LIMIT fallback regressing below a safe minimum in server/utils/prisma.ts (kind: software)

### What changed / what I produced
- New `server/utils/databasePoolDefaults.ts` exporting `DEFAULT_CONNECTION_LIMIT` (10) and `SAFE_MINIMUM_CONNECTION_LIMIT` (8), with a throw-at-import guard if the default ever drops below the minimum.
- `server/utils/prisma.ts` now imports `DEFAULT_CONNECTION_LIMIT` instead of hardcoding `10` in its two fallback spots (`buildDatabaseUrl` and `buildDatabaseConfig`).
- New `utils/scripts/verifyDatabasePoolDefaults.ts` (following the existing `verifyFacetAliases.ts`-style convention) asserting the default stays >= the safe minimum.
- Wired the new script into `package.json` (`test:database-pool-defaults`) and the DB-free `Contract Tests` CI workflow (`.github/workflows/contract-tests.yml`), so a regression fails CI instead of waiting for the next production outage.

### Why
This fallback has silently regressed from 10 down to 2 twice — historical commit `e2caf03d`, then again in PR #296 — each time causing a full production outage (every DB-backed API route 503ing on `pool timeout ... (pool connections: active=0 idle=0 limit=2)`). There was no guard stopping a third regression.

### How I verified
- `npx eslint` on all touched/new files — clean
- `npx prettier --check` on all touched/new files — clean
- `npm run test:database-pool-defaults` — passes (10 >= 8)
- Sanity-checked the guard itself actually fires: temporarily set `DEFAULT_CONNECTION_LIMIT = 2` and confirmed both the import-time throw and the verify script fail loudly, then restored it
- Full `vue-tsc --noEmit` type check — zero errors

### Stakes
reversible

### Flags for Reviewer
- This session's local git checkout of this branch had diverged from the true GitHub `main` (stale/desynced local proxy mirror), so this PR was built and pushed directly via the GitHub API against real `main` (SHA `414f33da`) rather than a local `git push`, after confirming the three touched files matched real `main` byte-for-byte before editing.

### Kaizen suggestion
The same regression-guard pattern (extract a safety-critical fallback constant into its own file with an import-time assertion, contract-test wired into CI) could be applied to the other hardcoded pool/timeout defaults in `buildDatabaseUrl`/`buildDatabaseConfig` (`connectTimeout`, `acquireTimeout`, `idleTimeout`) if any of those ever show a similar regression history.

### Notes for reviewer
Conductor roadmap task kind-robots/t-025 claimed by `worker/claude-burst-20260715-2007`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145FhKthroW5Ht9a6kfRffH)_