### PR TITLE
Verify DB pool TLS by CA only, matching the working direct probe

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -1,10 +1,7 @@
 // /server/utils/prisma.ts
 import { PrismaClient } from '~/prisma/generated/prisma/client'
 import { PrismaMariaDb } from '@prisma/adapter-mariadb'
-import {
-  checkServerIdentity,
-  type ConnectionOptions as TlsConnectionOptions,
-} from 'node:tls'
+import { type ConnectionOptions as TlsConnectionOptions } from 'node:tls'
 import { DEFAULT_CONNECTION_LIMIT } from './databasePoolDefaults'
 
 type PrismaMariaDbConfig = ConstructorParameters<typeof PrismaMariaDb>[0]
@@ -139,12 +136,20 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
 
   const parsed = new URL(resolvedUrl)
   const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
+  // Verify the CA chain only — do NOT enforce a hostname/SAN match. This mirrors
+  // the direct probe (server/utils/databaseDirectProbe.ts), which connects fine
+  // with verification ON. A previous custom checkServerIdentity() pinned the cert
+  // to the DATABASE_URL hostname; the ProxySQL frontend cert does not carry that
+  // exact host in its SANs, so every *pooled* connection failed verification
+  // while the (CA-only) direct probe succeeded — forcing the
+  // DATABASE_SSL_REJECT_UNAUTHORIZED=false stopgap. CA-only keeps the link
+  // encrypted and CA-trusted so verification can stay enabled. To restore
+  // hostname pinning, reissue the ProxySQL cert with the DATABASE_URL host in its
+  // SANs and add the check back.
   const tlsOptions: TlsConnectionOptions = rejectUnauthorized
     ? {
         ca: sslCa,
         rejectUnauthorized: true,
-        checkServerIdentity: (_connectorHostname, certificate) =>
-          checkServerIdentity(parsed.hostname, certificate),
       }
     : {
         // Encrypted but unverified: no CA requirement, no identity check.


### PR DESCRIPTION
## Root cause (the recurring "we fixed it, then it came back" outage)

The Prisma pool's TLS config wrapped a **custom `checkServerIdentity()`** that pinned the server cert to the `DATABASE_URL` hostname:

```ts
checkServerIdentity: (_connectorHostname, certificate) =>
  checkServerIdentity(parsed.hostname, certificate)
```

The **direct probe** (`server/utils/databaseDirectProbe.ts`) does **not** do this — it verifies the **CA chain only**. The ProxySQL frontend cert on Alexandria does not carry the exact `DATABASE_URL` host in its SANs, so with `DATABASE_SSL_REJECT_UNAUTHORIZED` unset (verification ON):

- every **pooled** connection failed hostname/SAN verification → `pool timeout … active=0 idle=0`, 503 on all DB-backed routes;
- the **CA-only direct probe** connected fine → `/api/health/database-direct` returned 200 in the same seconds.

That asymmetry is exactly what we saw in production, and it's why the only relief was setting `DATABASE_SSL_REJECT_UNAUTHORIZED=false` — which disables that check — and why the outage returned each time verification was re-enabled.

Server-side was ruled out along the way: ProxySQL healthy (`ConnUsed=0/40`, `ConnPool_get_conn_failure=0`), MariaDB `Threads_connected=6/100`. Client pool size (2→10) and acquire timeout (3s→8s) made no difference. The `humboldtscoops` auth errors in the ProxySQL log are an unrelated tenant, not this app.

## Change

Drop the custom identity check so the pool verifies the **CA chain only**, exactly like the direct probe. The link stays **encrypted and CA-trusted**, so `rejectUnauthorized: true` (verification) can remain enabled **without** the outage — breaking the disable/re-enable cycle.

One file, `server/utils/prisma.ts` (+11 / −6): removes the `checkServerIdentity` import and the custom callback; the CA + `rejectUnauthorized` verification stays.

## After merge + deploy

You can **unset `DATABASE_SSL_REJECT_UNAUTHORIZED`** (re-enable full verification) and it should stay healthy. Your current `=false` stopgap restores the site immediately in the meantime; this makes it durable.

## Security note / alternative

This drops hostname/SAN pinning (matching the direct probe's existing posture) while keeping encryption + CA trust. To restore strict hostname pinning instead, reissue the ProxySQL frontend cert with the exact `DATABASE_URL` host in its SANs and re-add the check — happy to do that variant if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0176BnHSf19S1rtftUDs1iut)_