### PR TITLE
academy: hide redundant remix CTA in the Remix Studio detail panel

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -39,7 +39,7 @@
           v-if="academyStore.selectedStyle"
           :lesson="academyStore.selectedStyle"
           :show-close="false"
-          @remix="() => {}"
+          :show-remix-button="false"
         />
 
         <div

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -84,7 +84,7 @@
       </div>
     </div>
 
-    <footer class="flex flex-wrap items-center gap-2">
+    <footer v-if="showRemixButton" class="flex flex-wrap items-center gap-2">
       <button
         type="button"
         class="btn btn-primary flex-1 rounded-2xl font-black shadow-lg shadow-primary/20 hover:-translate-y-0.5 hover:shadow-primary/30 active:translate-y-0"
@@ -106,8 +106,9 @@ const props = withDefaults(
   defineProps<{
     lesson: AcademyStyle
     showClose?: boolean
+    showRemixButton?: boolean
   }>(),
-  { showClose: true },
+  { showClose: true, showRemixButton: true },
 )
 
 const emit = defineEmits<{


### PR DESCRIPTION
### Task
conductor/ai-art-academy t-010: Academy continuous improvement pass (recurring), option (a) front-end style/polish pass. (kind: software)

### What changed / what I produced
- `components/academy/academy-style-detail.vue`: added a `showRemixButton` prop (default `true`) that gates the "Remix an image in {style}" footer button.
- `components/academy/academy-remix.vue`: passes `:show-remix-button="false"` and drops the `@remix="() => {}"` no-op handler.

Context: `academy-style-detail` is reused in three places. In `academy-styles-browser.vue` and `academy-timeline.vue` its footer "Remix" button correctly navigates to the Remix Studio tab. But `academy-remix.vue` renders the same component *inside* the Remix Studio itself (as the side panel showing the selected style's lesson) — there, clicking "Remix an image in {style}" did nothing (it was already wired to a no-op), which reads as a dead/broken button. Hiding it in that one context removes the confusing dead click without touching the two contexts where it's a real CTA.

### How I verified
- `npx eslint components/academy/academy-style-detail.vue components/academy/academy-remix.vue` — clean.
- `npx prettier --check` on both files — clean.
- Full `vue-tsc --noEmit` project typecheck — 0 errors (ran `npm run test`'s typecheck step directly; no pre-existing baseline to compare against since this run reported zero errors overall).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`academy-style-detail.vue`'s three call sites (`academy-styles-browser.vue`, `academy-timeline.vue`, `academy-remix.vue`) each pass a different subset of `show-close`/`show-remix-button`/`@remix` — worth a short comment atop the component listing the three usage contexts so a future prop addition doesn't miss one silently.

### Notes for reviewer
Conductor roadmap task `ai-art-academy/t-010` (recurring, never reaches `done`) will be updated in the companion conductor PR to log this cycle's run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpGqkw4SQCgjnTHKkvJwAS)_