### PR TITLE
academy: document academy-style-detail.vue's three usage contexts

### DIFF
--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -98,6 +98,13 @@
 </template>
 
 <script setup lang="ts">
+// Reused in three contexts, each passing a different showClose/showRemixButton
+// subset — check all three before changing a prop's default or meaning:
+//   - academy-timeline.vue: default props (close+remix shown), expanded list item
+//   - academy-styles-browser.vue: default props (close+remix shown), grid detail panel
+//   - academy-remix.vue: showClose=false, showRemixButton=false — read-only style
+//     summary in the Remix Studio sidebar, where remixing is already the page's
+//     primary action (a stray showRemixButton no-op button here was PR #301's bug)
 import { computed, onMounted } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import type { AcademyStyle } from '@/stores/seeds/academyStyles'


### PR DESCRIPTION
## Summary
- Adds a short comment atop `academy-style-detail.vue`'s script block listing the three call sites that reuse it (`academy-timeline.vue`, `academy-styles-browser.vue`, `academy-remix.vue`) and the `showClose`/`showRemixButton` subset each one passes.
- Kaizen task from `ai-art-academy/t-010`'s cycle (kind_robots PR #301, merged): that PR fixed a `showRemixButton` no-op-handler bug that happened precisely because a new prop's meaning wasn't obvious from the component alone. This is docs-only — no behavior change.

Conductor task: `ai-art-academy/t-016` (claimed by worker, session `claude-burst-20260715-2300`).

## Test plan
- [x] Read-only diff (comment addition only, no logic touched)
- [x] Verified all three call sites (`academy-timeline.vue`, `academy-styles-browser.vue`, `academy-remix.vue`) via grep to confirm the documented prop usage matches reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjqNYrgMcaVUdbX8Sbmzin)_