### PR TITLE
academy: add caller-doc regression guard for academy-style-detail.vue

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Database pool defaults contract
         run: npm run test:database-pool-defaults
 
+      - name: Academy style-detail caller-doc contract
+        run: npm run test:academy-style-detail-callers
+
       - name: Navigation route access contract
         run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:animation-catalog": "tsx utils/scripts/verifyAnimationCatalog.ts",
     "test:database-pool-defaults": "tsx utils/scripts/verifyDatabasePoolDefaults.ts",
+    "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/utils/scripts/verifyAcademyStyleDetailCallers.ts
+++ b/utils/scripts/verifyAcademyStyleDetailCallers.ts
@@ -52,7 +52,8 @@ function findDocumentedCallers(): Set<string> {
   const lineRegex = /^\/\/\s+-\s+([\w-]+\.vue):/gm
   let match: RegExpExecArray | null
   while ((match = lineRegex.exec(contents)) !== null) {
-    documented.add(match[1])
+    const filename = match[1]
+    if (filename) documented.add(filename)
   }
   return documented
 }

--- a/utils/scripts/verifyAcademyStyleDetailCallers.ts
+++ b/utils/scripts/verifyAcademyStyleDetailCallers.ts
@@ -1,0 +1,89 @@
+// /utils/scripts/verifyAcademyStyleDetailCallers.ts
+//
+// Regression guard for ai-art-academy/t-017 (kaizen from t-016): academy-style-detail.vue
+// carries a hand-written comment atop its <script setup> listing every call site and the
+// showClose/showRemixButton subset each one passes. A hand-written comment can silently go
+// stale the same way an undocumented prop did before (PR #301 fixed a showRemixButton
+// no-op-handler bug caused exactly by a caller's expectations not being obvious from the
+// component alone). This script fails CI when a new file uses academy-style-detail.vue
+// without a matching entry in that comment, or when a documented entry no longer exists.
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const COMPONENT_PATH = path.resolve('components/academy/academy-style-detail.vue')
+const SEARCH_ROOTS = ['components', 'pages', 'layouts']
+const SKIP_DIRS = new Set(['node_modules', '.nuxt', '.output', '.git', 'dist', 'coverage'])
+const USAGE_PATTERN = /<academy-style-detail\b|<AcademyStyleDetail\b/
+
+function walkVueFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue
+    const fullPath = path.join(dir, entry)
+    const stat = fs.statSync(fullPath)
+    if (stat.isDirectory()) {
+      walkVueFiles(fullPath, out)
+    } else if (entry.endsWith('.vue')) {
+      out.push(fullPath)
+    }
+  }
+  return out
+}
+
+function findActualCallers(): Set<string> {
+  const callers = new Set<string>()
+  for (const root of SEARCH_ROOTS) {
+    const dir = path.resolve(root)
+    if (!fs.existsSync(dir)) continue
+    for (const filePath of walkVueFiles(dir)) {
+      if (path.resolve(filePath) === COMPONENT_PATH) continue
+      const contents = fs.readFileSync(filePath, 'utf8')
+      if (USAGE_PATTERN.test(contents)) {
+        callers.add(path.basename(filePath))
+      }
+    }
+  }
+  return callers
+}
+
+function findDocumentedCallers(): Set<string> {
+  const contents = fs.readFileSync(COMPONENT_PATH, 'utf8')
+  const documented = new Set<string>()
+  const lineRegex = /^\/\/\s+-\s+([\w-]+\.vue):/gm
+  let match: RegExpExecArray | null
+  while ((match = lineRegex.exec(contents)) !== null) {
+    documented.add(match[1])
+  }
+  return documented
+}
+
+const actualCallers = findActualCallers()
+const documentedCallers = findDocumentedCallers()
+
+assert.ok(
+  documentedCallers.size > 0,
+  'academy-style-detail.vue is missing its usage-context comment (expected lines like ' +
+    '"//   - some-caller.vue: ..." atop the <script setup> block) — see t-016/t-017.',
+)
+
+const undocumented = [...actualCallers].filter((file) => !documentedCallers.has(file))
+assert.deepEqual(
+  undocumented,
+  [],
+  `academy-style-detail.vue has undocumented caller(s): ${undocumented.join(', ')}. ` +
+    'Add an entry to the usage-context comment atop academy-style-detail.vue\'s ' +
+    '<script setup> block describing the showClose/showRemixButton subset this caller passes.',
+)
+
+const stale = [...documentedCallers].filter((file) => !actualCallers.has(file))
+assert.deepEqual(
+  stale,
+  [],
+  `academy-style-detail.vue's usage-context comment documents caller(s) that no longer use ` +
+    `it: ${stale.join(', ')}. Remove the stale entry from the comment.`,
+)
+
+console.log(
+  `academy-style-detail.vue usage-context comment verified: ${actualCallers.size} caller(s) ` +
+    `match the documented list (${[...documentedCallers].sort().join(', ')}).`,
+)


### PR DESCRIPTION
## Summary
- Adds `utils/scripts/verifyAcademyStyleDetailCallers.ts`, a contract-test script that scans `components/`, `pages/`, and `layouts/` for any file using `academy-style-detail.vue` and asserts every caller is listed in the usage-context comment added atop the component's `<script setup>` block in PR #302 — and vice versa, catching stale documented entries too.
- Wires it in as `npm run test:academy-style-detail-callers` and a new step in `.github/workflows/contract-tests.yml` ("Academy style-detail caller-doc contract").
- Kaizen from `ai-art-academy/t-016` (conductor task `t-017`): a hand-written doc comment can silently drift the same way an undocumented prop caused PR #301's `showRemixButton` no-op bug. This makes drift a CI failure instead of a future bug report.

Conductor task: `ai-art-academy/t-017` (claimed by worker, session `claude-burst-20260715-2300`).

## Test plan
- [x] `npx tsx utils/scripts/verifyAcademyStyleDetailCallers.ts` passes against the current three documented callers (`academy-timeline.vue`, `academy-styles-browser.vue`, `academy-remix.vue`)
- [x] Manually verified the failure path: added a temporary fake `.vue` file using the component without a doc entry, confirmed the script throws an `AssertionError` naming it, then removed the temp file and re-confirmed a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjqNYrgMcaVUdbX8Sbmzin)_