### PR TITLE
academy: add Bauhaus to academyStyles.ts front-end seed

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -546,6 +546,43 @@ export const academyStyles: AcademyStyle[] = [
         'Convert this image into a De Stijl composition: bold black grid lines on white, rectangles of pure primary red yellow and blue, strict horizontal and vertical geometry, balanced asymmetry',
     },
   },
+  {
+    slug: 'bauhaus',
+    name: 'Bauhaus',
+    era: '1919–1933',
+    sortYear: 1919,
+    region: 'Germany',
+    keyIdeas:
+      'Painting, craft, and design as one discipline: "form follows function," taught through hands-on workshops and a shared foundational visual vocabulary. Kandinsky and Klee both taught the school\'s first-year "form" class, codifying geometric shape and color into symbolic language — a direct continuation of De Stijl\'s flat grids, until the Nazi government forced the school to close in 1933 and its faculty scattered its style worldwide.',
+    recognitionCues: [
+      'Pure geometric forms — circles, triangles, squares — as a symbolic color-form vocabulary',
+      'Bold primary and secondary color fields crossed by black grid lines or diagonals',
+      'Whimsical, sign-like pictograms layered over precise geometric grids',
+      'Camera-less "photograms" — ghostly silhouettes on light-sensitive paper',
+    ],
+    artists: [
+      {
+        name: 'Wassily Kandinsky',
+        years: '1866–1944',
+        note: 'Led the Bauhaus\'s foundational "form" class, teaching that geometric shapes and colors carry specific emotional meaning.',
+      },
+      {
+        name: 'Paul Klee',
+        years: '1879–1940',
+        note: 'Filled private notebooks with pedagogical diagrams; his paintings mix childlike pictograms with dry, precise geometry.',
+      },
+      {
+        name: 'László Moholy-Nagy',
+        years: '1895–1946',
+        note: 'Ran the metal workshop and pioneered the photogram, treating light itself as an art medium.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a Bauhaus-school geometric abstraction: pure circles, triangles, and squares in bold primary colors on a flat plane, precise linework, no realistic shading',
+    },
+  },
 ]
 
 export const academyStylesBySlug: Record<string, AcademyStyle> =


### PR DESCRIPTION
### Task
ai-art-academy/t-018: kind_robots — add Bauhaus to the academyStyles.ts front-end seed (kind: software)

### What changed / what I produced
- Added a `bauhaus` entry to `stores/seeds/academyStyles.ts` (era `1919–1933`, region Germany), inserted after `de-stijl` to match curriculum ordering — mirrors the shape of every other entry (keyIdeas, recognitionCues, artists, remix template).
- Artists: Wassily Kandinsky (1866–1944), Paul Klee (1879–1940), László Moholy-Nagy (1895–1946) — all safely public domain per PUBLIC-DOMAIN-POLICY.md's death-year rule.
- Content sourced directly from conductor's `projects/ai-art-academy/docs/curriculum-outline.md` §16 (Bauhaus), added in an earlier cycle (conductor `ai-art-academy/t-010`, 2026-07-16 RAN note) — recognition cues, artist bios, and remix_hint copied verbatim from that verified source rather than re-derived.

### How I verified
- `npx prettier --check stores/seeds/academyStyles.ts` — clean.
- Full project `npm run test` (`vue-tsc --noEmit`) — exit 0, zero errors.
- No dedicated test references `academyStyles.ts` directly (checked via grep); this is a pure additive data entry matching the existing 15-entry array shape exactly.

### Stakes
reversible

### Notes for reviewer
Companion conductor task: `ai-art-academy/t-018`, claimed this cycle (session `claude-burst-hourly-20260716-0200`). Will set the conductor roadmap task to `done` once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiGEPKYxWh5Wi7SccrE1PR)_