### PR TITLE
packmaker/t-006: add packs tutorial channel

### DIFF
--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -34,6 +34,7 @@ export type ExtraTutorialKey =
   | 'humboldt-scoop'
   | 'scoop-cms'
   | 'mermaids'
+  | 'packs'
 export type TutorialChannelKey = FooterKey | ExtraTutorialKey
 
 export type TutorialSection = {
@@ -522,6 +523,23 @@ export const tutorialChannels = {
       },
     ],
   },
+  packs: {
+    key: 'packs',
+    title: 'Packmaker',
+    tagline: 'Bundle it once. Share it everywhere.',
+    overview:
+      'Packmaker turns loose creations into tidy, shareable packs. Choose the contents, set who can use them, and ship reusable content bundles and DLC that other builders can drop straight into their own worlds.',
+    underConstruction: true,
+    sections: [
+      {
+        key: 'packs',
+        title: 'Packmaker',
+        body: 'Group characters, art, scenarios, and rewards into one coherent pack, then control who can install it with the shared permission primitives.',
+        image: tutorialImage('packs', 'packs'),
+        underConstruction: true,
+      },
+    ],
+  },
 } as const satisfies Record<TutorialChannelKey, TutorialChannel>
 
 export const tutorialChannelKeys = Object.keys(
@@ -536,6 +554,7 @@ const tutorialRouteMap = {
   'humboldt-scoop': '/humboldt-scoop',
   'scoop-cms': '/scoop-cms',
   mermaids: '/mermaids',
+  packs: '/packs',
 } as const satisfies Record<TutorialChannelKey, string>
 
 export function isTutorialChannelKey(


### PR DESCRIPTION
### Task
packmaker/t-006: Polish and upgrade Packmaker front-end surface (kind: software) — this PR covers step (2) of that task only.

### What changed / what I produced
- Registered `packs` as a new top-level `ExtraTutorialKey` in `stores/helpers/tutorialCards.ts` (not a nested section under an existing `tutorialChannels.builder` group), per the convention corrected in conductor/t-044.
- Added the `tutorialChannels.packs` entry (title, tagline, overview, one section) and the `tutorialRouteMap.packs: '/packs'` mapping, matching `content/channels/build/packs.md`'s `route: /packs`.
- Marked the channel and its section `underConstruction: true` since the Packmaker front end is still the `ProjectFrontPage` scaffold and no dashboard-tab/tutorial art exists yet for `packs` (referenced via `tutorialImage('packs', 'packs')`, following the same not-yet-generated-image pattern already used elsewhere in this file, e.g. `sanctuary.giftshop`).

### How I verified
- `npx eslint stores/helpers/tutorialCards.ts` — clean.
- `npx prettier --check stores/helpers/tutorialCards.ts` — clean.
- `npm run test` (full `vue-tsc --noEmit`) — exit 0, 0 errors, none in the touched file.
- Confirmed `ExtraTutorialKey` has no other exhaustiveness-check consumers in the repo (`grep -rl "ExtraTutorialKey\b"` → only this file).

### Stakes
reversible

### Flags for Reviewer
- This only lands step (2) of packmaker/t-006's 4-step note. Steps (1) art generation and (3) admin Placements verification are blocked in this environment (missing `KR_API_TOKEN`; Placements is an admin-only UI action) and step (4) "evolve into the full interactive experience" is intentionally *not* attempted here — that's packmaker/t-004's scope, and t-004 is correctly `waiting` on t-003 (launch-pack manifests), which is itself a hard `needs-human` gate awaiting Silas's approval. Building it now would preempt a gated task.
- Conductor roadmap side: packmaker/t-006 will be updated to reflect this partial completion and note the remaining scope isn't re-duplicated once t-004 unblocks.

### Kaizen suggestion
packmaker/t-006's note bundles a mechanical, always-doable step (tutorial channel wiring) with steps that depend on external credentials, admin UI, and a separately-gated task (t-004). Worth splitting roadmap tasks like this into "buildable now" vs "blocked/gated" sub-tasks at authoring time rather than discovering the split mid-cycle.

### Notes for reviewer
N/A — self-authored by this session acting as Reviewer (Claude) per AGENTS.md's allowance for `claude/*` branches directed by Silas.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEaweqXo4kNfjg9fQc9cJk)_