### PR TITLE
kind-robots/t-026: fix facet-alias-smoke.yml dead migration reference

### DIFF
--- a/.github/workflows/facet-alias-smoke.yml
+++ b/.github/workflows/facet-alias-smoke.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - prisma.config.ts
       - prisma/facet-alias.prisma
-      - prisma/migrations/20260711021500_add_facet_aliases/migration.sql
+      - prisma/migrations/00000000000000_squashed/migration.sql
+      - .github/workflows/fixtures/facet-alias-schema.sql
       - utils/facetAliases.ts
       - utils/scripts/setFacetAliases.ts
       - utils/scripts/verifyFacetAliases.ts
@@ -20,7 +21,8 @@ on:
     paths:
       - prisma.config.ts
       - prisma/facet-alias.prisma
-      - prisma/migrations/20260711021500_add_facet_aliases/migration.sql
+      - prisma/migrations/00000000000000_squashed/migration.sql
+      - .github/workflows/fixtures/facet-alias-schema.sql
       - utils/facetAliases.ts
       - utils/scripts/setFacetAliases.ts
       - utils/scripts/verifyFacetAliases.ts
@@ -91,8 +93,8 @@ jobs:
           INSERT INTO `Facet` (`slug`) VALUES ('cowcore'), ('weird-core');
           SQL
 
-      - name: Execute Facet alias migration
-        run: mariadb --host=127.0.0.1 --port=3306 --user=root --password=root kindrobots < prisma/migrations/20260711021500_add_facet_aliases/migration.sql
+      - name: Create FacetAlias table + constraints
+        run: mariadb --host=127.0.0.1 --port=3306 --user=root --password=root kindrobots < .github/workflows/fixtures/facet-alias-schema.sql
 
       - name: Verify canonical aliases and constraints
         run: |

--- a/.github/workflows/fixtures/facet-alias-schema.sql
+++ b/.github/workflows/fixtures/facet-alias-schema.sql
@@ -1,0 +1,44 @@
+-- Standalone fixture for facet-alias-smoke.yml.
+-- Mirrors the FacetAlias table + FK exactly as defined in
+-- prisma/migrations/00000000000000_squashed/migration.sql, since the original
+-- standalone migration (20260711021500_add_facet_aliases) was folded into that
+-- squash and no longer exists as its own file. Keep this in sync if FacetAlias's
+-- shape changes in the squashed migration.
+CREATE TABLE `FacetAlias` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `facetId` INTEGER NOT NULL,
+    `alias` VARCHAR(255) NOT NULL,
+    `lookupKey` VARCHAR(255) NOT NULL,
+    `isCanonical` BOOLEAN NOT NULL DEFAULT false,
+    `isActive` BOOLEAN NOT NULL DEFAULT true,
+
+    UNIQUE INDEX `FacetAlias_lookupKey_key`(`lookupKey`),
+    INDEX `FacetAlias_facetId_idx`(`facetId`),
+    INDEX `FacetAlias_isActive_idx`(`isActive`),
+    UNIQUE INDEX `FacetAlias_facetId_alias_key`(`facetId`, `alias`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `FacetAlias` ADD CONSTRAINT `FacetAlias_facetId_fkey` FOREIGN KEY (`facetId`) REFERENCES `Facet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+INSERT INTO `FacetAlias` (
+  `facetId`,
+  `alias`,
+  `lookupKey`,
+  `isCanonical`,
+  `isActive`,
+  `createdAt`,
+  `updatedAt`
+)
+SELECT
+  `id`,
+  `slug`,
+  LOWER(REPLACE(REPLACE(REPLACE(`slug`, '-', ''), '_', ''), ' ', '')),
+  true,
+  true,
+  CURRENT_TIMESTAMP(3),
+  CURRENT_TIMESTAMP(3)
+FROM `Facet`
+WHERE `slug` IS NOT NULL AND `slug` <> '';


### PR DESCRIPTION
## Summary
- `facet-alias-smoke.yml`'s path triggers and its "Execute Facet alias migration" step referenced `prisma/migrations/20260711021500_add_facet_aliases/migration.sql`, which no longer exists after the Prisma migration squash (`main` now only has `00000000000000_squashed`). Any PR touching `package.json` (or the workflow's other path triggers) was failing this check regardless of the actual change.
- Added `.github/workflows/fixtures/facet-alias-schema.sql`, a standalone fixture that recreates the `FacetAlias` table, its `facetId` FK, and the canonical-alias seed (`INSERT ... SELECT` from `Facet`) exactly as the deleted migration did.
- Updated the workflow's path triggers and migration step to point at the fixture (and at `prisma/migrations/00000000000000_squashed/migration.sql` in place of the dead path).

## Context
Conductor task: `kind-robots/t-026` (kaizen from `t-025`, kind_robots PR #299). Confirmed via the GitHub API that the deleted migration path is genuinely absent from `main`, not a stale local checkout.

## Test plan
- [x] Confirmed no other file in the repo still references the deleted migration path (`grep -rn "20260711021500_add_facet_aliases"` → no hits)
- [ ] CI run of `facet-alias-smoke.yml` on this PR passes end-to-end (table creation via fixture, canonical-alias seed count, FK constraint check, duplicate-lookupKey rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194yLdr7UMCJT7cocsXXmbv


---
_Generated by [Claude Code](https://claude.ai/code/session_0194yLdr7UMCJT7cocsXXmbv)_