### PR TITLE
kind-robots/t-028: add CI check for dead workflow path references

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Navigation route access contract
         run: npx tsx utils/scripts/verifyNavigationRouteAccess.ts
 
+      - name: Workflow path references contract
+        run: npm run test:workflow-paths
+
       - name: Challenge Center seed validation (dry run, no database)
         run: |
           npm run test:seed-challenges

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:animation-catalog": "tsx utils/scripts/verifyAnimationCatalog.ts",
     "test:database-pool-defaults": "tsx utils/scripts/verifyDatabasePoolDefaults.ts",
     "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",
+    "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/utils/scripts/verifyWorkflowPaths.ts
+++ b/utils/scripts/verifyWorkflowPaths.ts
@@ -1,0 +1,174 @@
+// /utils/scripts/verifyWorkflowPaths.ts
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+type PathHit = {
+  file: string
+  path: string
+  source: 'trigger paths' | 'run step'
+}
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const workflowsDirectory = resolve(repositoryRoot, '.github/workflows')
+
+// Heuristic only -- these hits are known-good non-repo paths (another repo's
+// checkout, or a path only known to exist once a build step has generated
+// it) rather than dead references. Add an exact string or path prefix here
+// when a new false positive shows up; do not loosen the extraction regexes
+// to "fix" it.
+const ALLOWLIST_PREFIXES = [
+  // davinci-seed-verify.yml checks out silasfelinus/conductor into this path
+  // and runs its generator script from there -- not part of this repo tree.
+  'conductor-src/',
+]
+
+// `run:` steps are shell, not YAML -- we don't parse them, we scan for
+// tokens that look like repo-relative file paths. Restricting to a known
+// extension list keeps this from matching command names, flags, or output
+// files that don't exist until the step itself creates them.
+const RUN_STEP_EXTENSIONS = [
+  'ts',
+  'tsx',
+  'js',
+  'mjs',
+  'cjs',
+  'py',
+  'sql',
+  'sh',
+  'json',
+  'yml',
+  'yaml',
+  'prisma',
+]
+const runStepTokenPattern = new RegExp(
+  `[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+\\.(?:${RUN_STEP_EXTENSIONS.join('|')})\\b`,
+  'g',
+)
+
+function listWorkflowFiles(): string[] {
+  return readdirSync(workflowsDirectory)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .sort()
+    .map((name) => join(workflowsDirectory, name))
+}
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+  return (quote === "'" || quote === '"') && trimmed.endsWith(quote)
+    ? trimmed.slice(1, -1)
+    : trimmed
+}
+
+// Collects `- entry` list items nested under a `paths:` / `paths-ignore:`
+// trigger key (indentation-based, not a full YAML parse -- these lists are
+// always simple string arrays in our workflows).
+function extractTriggerPaths(lines: string[], file: string): PathHit[] {
+  const hits: PathHit[] = []
+  for (const [i, line] of lines.entries()) {
+    const keyMatch = line.match(/^(\s*)(?:paths|paths-ignore):\s*$/)
+    if (!keyMatch) continue
+    const keyIndent = (keyMatch[1] ?? '').length
+    for (const next of lines.slice(i + 1)) {
+      if (!next.trim()) continue
+      if (indentOf(next) <= keyIndent) break
+      const item = next.match(/^\s*-\s*(.+?)\s*$/)
+      if (!item) break
+      hits.push({ file, path: unquote(item[1] ?? ''), source: 'trigger paths' })
+    }
+  }
+  return hits
+}
+
+// Scans `run:` step bodies (inline `run: cmd` or block-scalar `run: |`) for
+// path-like tokens. Does not attempt to parse shell syntax.
+function extractRunStepPaths(lines: string[], file: string): PathHit[] {
+  const hits: PathHit[] = []
+  const scan = (text: string) => {
+    for (const match of text.matchAll(runStepTokenPattern)) {
+      hits.push({ file, path: match[0], source: 'run step' })
+    }
+  }
+
+  for (const [i, line] of lines.entries()) {
+    const inline = line.match(/^(\s*)run:\s*(.+)$/)
+    const inlineValue = inline?.[2] ?? ''
+    if (inline && !/^[|>][-+]?$/.test(inlineValue.trim())) {
+      scan(inlineValue)
+      continue
+    }
+    const block = line.match(/^(\s*)run:\s*[|>][-+]?\s*$/)
+    if (!block) continue
+    const keyIndent = (block[1] ?? '').length
+    for (const next of lines.slice(i + 1)) {
+      if (!next.trim()) continue
+      if (indentOf(next) <= keyIndent) break
+      scan(next)
+    }
+  }
+  return hits
+}
+
+function isAllowlisted(path: string): boolean {
+  return ALLOWLIST_PREFIXES.some((prefix) => path.startsWith(prefix))
+}
+
+// Trigger-path entries may be globs (e.g. `server/api/facets/**`); check
+// existence of the concrete directory/file prefix before the first `*`.
+function resolvableTarget(path: string): string | null {
+  const starIndex = path.indexOf('*')
+  if (starIndex === -1) return path
+  const prefix = path.slice(0, starIndex).replace(/\/+$/, '')
+  return prefix.length > 0 ? prefix : null
+}
+
+async function main(): Promise<void> {
+  const files = listWorkflowFiles()
+  const errors: string[] = []
+  let checked = 0
+
+  for (const file of files) {
+    const relativeFile = file.slice(repositoryRoot.length + 1)
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/)
+    const hits = [
+      ...extractTriggerPaths(lines, relativeFile),
+      ...extractRunStepPaths(lines, relativeFile),
+    ]
+
+    for (const hit of hits) {
+      if (isAllowlisted(hit.path)) continue
+      const target = resolvableTarget(hit.path)
+      if (target === null) continue // bare glob like `*.ts` -- nothing concrete to check
+      checked += 1
+      if (!existsSync(resolve(repositoryRoot, target))) {
+        errors.push(
+          `${hit.file}: ${hit.source} references missing path "${hit.path}"`,
+        )
+      }
+    }
+  }
+
+  if (errors.length) {
+    console.error(
+      `Workflow path references contract failed with ${errors.length} error(s):`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Workflow path references contract passed: ${files.length} workflow file(s), ${checked} path reference(s) checked.`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
### Task
kind-robots/t-028: Add a CI check that every file path referenced by a `.github/workflows/*.yml` step or path-trigger actually exists in the repo (kind: software)

### What changed / what I produced
- `utils/scripts/verifyWorkflowPaths.ts`: scans every `.github/workflows/*.yml` for (a) `paths:`/`paths-ignore:` trigger list entries and (b) path-like tokens (extension-allowlisted: ts/tsx/js/mjs/cjs/py/sql/sh/json/yml/yaml/prisma) inside `run:` step bodies (inline and block-scalar), then fails if any resolve to a path that doesn't exist in the repo tree. Globs (`server/api/facets/**`) are resolved to their concrete prefix before the first `*`.
- Added `"test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts"` to `package.json`, following the existing `verifyChannelContent.ts`-style convention used by the other contract checks.
- Wired it into the existing **Contract Tests** job (`.github/workflows/contract-tests.yml`) as a new step, rather than a standalone workflow, per the task note.
- A small allowlist (`ALLOWLIST_PREFIXES`) covers one known non-repo false positive: `davinci-seed-verify.yml` checks out `silasfelinus/conductor` into `conductor-src/` and runs a script from there.

### How I verified
- Ran the script against the current repo: passes (7 workflow files, 29 path references checked).
- Simulated the exact regression class this guards against (renamed `utils/facetAliases.ts`, then separately the `.github/workflows/fixtures/facet-alias-schema.sql` fixture referenced from a `run:` step) — the script correctly fails both times with the missing path named; restored both files and re-confirmed a clean pass afterward.
- `npx eslint utils/scripts/verifyWorkflowPaths.ts` — clean.
- `npx prettier --check` — clean (ran `--write` once to match repo style).
- Full project typecheck (`npm run test`, i.e. `vue-tsc --noEmit`) — 0 errors. (First pass had 12 `noUncheckedIndexedAccess` errors from unguarded array/regex-capture indexing — the same bug class t-027 was filed for — fixed by switching to `Array.prototype.entries()`/`slice()` iteration and `?? ''` fallbacks on capture groups.)
- Ran the other five Contract Tests job steps directly (`test:art-request-yaml`, `test:channel-content`, `test:channel-resolver`, `test:database-pool-defaults`, `test:academy-style-detail-callers`, `verifyNavigationRouteAccess.ts`) — all still pass, confirming no regression from the new step or the `npm ci` this required.

### Stakes
reversible

### Flags for Reviewer
- None — self-contained addition, no cross-repo or external-egress dependency.

### Kaizen suggestion
The extension-based heuristic in `run:` steps won't catch extension-less path references (e.g. `git diff --quiet -- stores/fallback`). If a future incident involves a dead directory reference without a file extension, consider widening the heuristic to also match bare `word/word` tokens gated by `existsSync` on the parent directory — but that has a much higher false-positive rate (matches npm script names like `test:foo`, glob-like args, etc.) so I deliberately kept the extension gate for this pass.

### Notes for reviewer
This closes out kind-robots' `t-028` roadmap task (conductor repo). No conductor code changes in this PR — roadmap status update will follow in a separate conductor-repo commit per the cross-repo task convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGPP8fAJEy3mebCBvb9irA)_