### PR TITLE
kind-robots/t-023: hermetic regression test for deploy-wait ancestry check

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Workflow path references contract
         run: npm run test:workflow-paths
 
+      - name: Deploy-wait ancestry check contract
+        run: npm run test:deploy-wait-ancestry
+
       - name: Challenge Center seed validation (dry run, no database)
         run: |
           npm run test:seed-challenges

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -61,8 +61,7 @@ jobs:
               if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
                 git fetch --quiet --depth=200 origin main 2>/dev/null || true
               fi
-              if git cat-file -e "${live}^{commit}" 2>/dev/null \
-                && git merge-base --is-ancestor "$TARGET_SHA" "$live" 2>/dev/null; then
+              if bash scripts/check-deploy-ancestry.sh "$TARGET_SHA" "$live" 2>/dev/null; then
                 echo "Production is serving ${live}, a newer commit that already includes ${TARGET_SHA} — deploy is live (superseded)."
                 exit 0
               fi

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:database-pool-defaults": "tsx utils/scripts/verifyDatabasePoolDefaults.ts",
     "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",
     "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
+    "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/scripts/check-deploy-ancestry.sh
+++ b/scripts/check-deploy-ancestry.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# scripts/check-deploy-ancestry.sh <target_sha> <live_sha>
+#
+# Shared by .github/workflows/cypress.yml's "Wait for deploy to go live" step
+# and utils/scripts/verifyDeployWaitAncestry.ts's regression test, so a future
+# edit to this ancestry check is exercised by both the real deploy-wait loop
+# and a hermetic CI test -- not just re-verified by hand in scratch repos
+# (see kind-robots/t-018 and t-023 in conductor's roadmap.yaml).
+#
+# Exits 0 (accept) when <live_sha> is a commit this checkout knows about and
+# that already contains <target_sha> as an ancestor -- i.e. TARGET_SHA's
+# changes are live via a newer, superseding commit. Exits 1 (reject)
+# otherwise, including when <live_sha> isn't a commit this checkout has seen.
+#
+# Callers are responsible for fetching/deepening the checkout first so
+# <live_sha> is resolvable when it should be -- this script does no network
+# I/O, which is what keeps it hermetic and fast to test.
+set -euo pipefail
+
+target_sha="$1"
+live_sha="$2"
+
+git cat-file -e "${live_sha}^{commit}" 2>/dev/null \
+  && git merge-base --is-ancestor "$target_sha" "$live_sha"

--- a/utils/scripts/verifyDeployWaitAncestry.ts
+++ b/utils/scripts/verifyDeployWaitAncestry.ts
@@ -1,0 +1,107 @@
+// /utils/scripts/verifyDeployWaitAncestry.ts
+//
+// Regression test for scripts/check-deploy-ancestry.sh -- the ancestry check
+// shared by .github/workflows/cypress.yml's "Wait for deploy to go live"
+// step. That step accepts a deploy as live either when the served commit
+// exactly matches the pushed commit, or when the served commit is a *newer*
+// commit that already contains the pushed commit as an ancestor (a burst of
+// merges can supersede TARGET_SHA before its own deploy finishes).
+//
+// Before this test existed, that accept/reject logic was only ever verified
+// by hand against scratch git repos (see kind-robots/t-018 in conductor's
+// roadmap.yaml). This exercises the exact same script -- not a
+// reimplementation -- against the accept path (superseding commit), the
+// reject path (non-superseding sibling-branch commit), and the
+// unknown-commit edge case, entirely in a hermetic temp git repo with no
+// network calls.
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const ancestryScript = join(repositoryRoot, 'scripts/check-deploy-ancestry.sh')
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+function commit(cwd: string, message: string): string {
+  git(cwd, 'commit', '--allow-empty', '-m', message)
+  return git(cwd, 'rev-parse', 'HEAD')
+}
+
+/** Runs the shared ancestry script; returns true (accept) / false (reject). */
+function checkAncestry(cwd: string, targetSha: string, liveSha: string): boolean {
+  try {
+    execFileSync('bash', [ancestryScript, targetSha, liveSha], {
+      cwd,
+      stdio: 'pipe',
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Fork two branches from one shared root commit so "sibling, not an
+// ancestor" and "descendant, an ancestor" relationships are both
+// unambiguous to build.
+const repo = mkdtempSync(join(tmpdir(), 'deploy-wait-ancestry-'))
+
+try {
+  git(repo, 'init', '--quiet', '--initial-branch=main')
+  git(repo, 'config', 'user.email', 'test@example.com')
+  git(repo, 'config', 'user.name', 'Deploy Wait Ancestry Test')
+
+  const root = commit(repo, 'shared root')
+
+  // Accept path: TARGET_SHA is an ancestor of a later "live" commit on the
+  // same line of history -- this deploy's changes are live via a
+  // superseding commit.
+  const targetSha = commit(repo, 'target commit (this is TARGET_SHA)')
+  const supersedingLiveSha = commit(repo, 'superseding commit (this is "live")')
+  assert.equal(
+    checkAncestry(repo, targetSha, supersedingLiveSha),
+    true,
+    `expected TARGET_SHA ${targetSha} to be accepted as an ancestor of superseding commit ${supersedingLiveSha}`,
+  )
+
+  // Exact match trivially satisfies "is an ancestor of itself" too.
+  assert.equal(
+    checkAncestry(repo, targetSha, targetSha),
+    true,
+    `expected TARGET_SHA ${targetSha} to be accepted against itself`,
+  )
+
+  // Reject path: "live" is a sibling-branch commit forked from the same
+  // root but does NOT contain TARGET_SHA -- must not be accepted, even
+  // though both commits exist in the checkout.
+  git(repo, 'checkout', '--quiet', '-b', 'sibling-branch', root)
+  const siblingLiveSha = commit(repo, 'sibling commit (this is "live", not a descendant)')
+  assert.equal(
+    checkAncestry(repo, targetSha, siblingLiveSha),
+    false,
+    `expected TARGET_SHA ${targetSha} to be REJECTED against sibling-branch commit ${siblingLiveSha} (no ancestor relationship)`,
+  )
+
+  // Unknown-commit edge case: "live" isn't a commit this checkout has ever
+  // seen (e.g. an ancestry-deepening fetch didn't reach far enough). Must
+  // reject rather than throw an uncaught error.
+  const unknownSha = '0'.repeat(40)
+  assert.equal(
+    checkAncestry(repo, targetSha, unknownSha),
+    false,
+    `expected an unknown live commit (${unknownSha}) to be REJECTED, not accepted or crash`,
+  )
+
+  console.log(
+    'Deploy-wait ancestry check verified: accepts superseding commits, ' +
+      'rejects sibling-branch commits and unknown commits.',
+  )
+} finally {
+  rmSync(repo, { recursive: true, force: true })
+}


### PR DESCRIPTION
### Task
kind-robots/t-023: Automate the deploy-wait ancestry-check verification t-018 did manually in scratch git repos (kind: software)

### What changed / what I produced
- `scripts/check-deploy-ancestry.sh` — extracted the accept/reject ancestry check (the two-line `git cat-file -e` + `git merge-base --is-ancestor` condition) out of `.github/workflows/cypress.yml`'s "Wait for deploy to go live" step into a small, hermetic, no-network shared script.
- `.github/workflows/cypress.yml` — the deploy-wait step now calls this shared script instead of inlining the check, so the workflow and the regression test run byte-identical logic (a future edit to the check is automatically exercised by the test, not just re-verified by hand).
- `utils/scripts/verifyDeployWaitAncestry.ts` — new regression test, following this repo's existing `verify*.ts` convention (see `test:workflow-paths`, `test:database-pool-defaults`, etc.). Builds a hermetic temp git repo and asserts:
  - accept path: TARGET_SHA is an ancestor of a later superseding "live" commit
  - accept path: TARGET_SHA matches "live" exactly (ancestor-of-itself)
  - reject path: "live" is a sibling-branch commit forked from the same root, not a descendant
  - reject path: "live" is an unknown commit the checkout has never seen
- `package.json` — added `test:deploy-wait-ancestry` script.
- `.github/workflows/contract-tests.yml` — wired the new test in as a CI step alongside the other contract tests.

### How I verified
- `npm run test:deploy-wait-ancestry` — passes, prints the confirmation line for all four scenarios.
- `npm test` (nuxi prepare + vue-tsc --noEmit) — 0 TypeScript errors.
- `bash -n scripts/check-deploy-ancestry.sh` — shell syntax OK (no shellcheck available in this sandbox).
- Validated both edited workflow YAML files parse with `yaml.safe_load`.
- Confirmed the extracted script preserves the original step's exact behavior: same two commands, same 2>/dev/null suppression on the outer `if`, only the "which shallow-fetch happened first" logic (still inline, since it's the network-touching part and out of scope for a hermetic test) is unchanged.

### Stakes
reversible

### Flags for Reviewer
- I split the ancestry check into its own script rather than writing a test that re-implements the same bash inline, so the test can never drift from production behavior — this is a slightly larger diff than a pure test-only change, but keeps the workflow and the test provably in sync per the task's own goal ("so future edits to this step are regression-tested instead of re-verified by hand").
- No shellcheck available in this sandbox to lint the new .sh file; relied on `bash -n` plus the passing regression test itself.

### Kaizen suggestion
`scripts/check-deploy-ancestry.sh` is now a second hermetic shell script in the repo (alongside `scripts/verify-cypress-cleanup.mjs` etc.) — if more workflow steps grow inline bash worth regression-testing, consider a `scripts/lib/` convention doc so future tasks don't have to rediscover this pattern from scratch each time.

### Notes for reviewer
Conductor task: kind-robots/t-023 (claimed reviewer/claude-burst-hourly-20260716-0849-manual, autonomous hourly cycle).


---
_Generated by [Claude Code](https://claude.ai/code/session_01N11xCJMqg7nHGcytheG7Tx)_