### PR TITLE
kind-robots/t-024: CI guard against Prisma.InputJsonValue casts

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Deploy-wait ancestry check contract
         run: npm run test:deploy-wait-ancestry
 
+      - name: Prisma JSON-cast contract
+        run: npm run test:no-prisma-json-cast
+
       - name: Challenge Center seed validation (dry run, no database)
         run: |
           npm run test:seed-challenges

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",
     "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
+    "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/utils/scripts/verifyNoPrismaJsonCast.ts
+++ b/utils/scripts/verifyNoPrismaJsonCast.ts
@@ -1,0 +1,107 @@
+// /utils/scripts/verifyNoPrismaJsonCast.ts
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Regression guard: 12 of the 19 TypeScript errors fixed in kind_robots PR
+// #295 were the same shape repeated across 10 files -- code casting a plain
+// JS object straight to Prisma.InputJsonValue and assigning it to a Prisma
+// field that is actually a String/@db.Text/@db.LongText column in
+// prisma/schema.prisma or prisma/model-builder.prisma (this repo deliberately
+// stores structured data as serialized JSON text rather than native Json
+// columns). Neither schema file declares a native `Json` column today, so
+// there is no legitimate call site for this cast anywhere in the codebase --
+// the correct pattern is normalizeJson/parseStoredJson
+// (server/api/model-builder/runs/index.ts) or a plain JSON.stringify. A new
+// call site typechecks fine locally and only breaks once vue-tsc runs
+// against the real generated Prisma types, so this catches it at contract-test
+// speed instead of waiting for that slower job.
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SCAN_EXTENSIONS = ['.ts', '.tsx', '.vue', '.js', '.mjs', '.cjs']
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.nuxt',
+  '.output',
+  '.vercel',
+  'node_modules',
+  'dist',
+  'coverage',
+  'cypress',
+  'prisma/generated',
+])
+// This file documents/references the exact string it scans for -- exclude it
+// from its own scan rather than obscuring the pattern to dodge a self-match.
+const EXCLUDED_FILES = new Set(['utils/scripts/verifyNoPrismaJsonCast.ts'])
+
+// Matches `as Prisma.InputJsonValue` and `as unknown as Prisma.InputJsonValue`.
+const BAD_CAST_PATTERN = /\bas\s+(?:unknown\s+as\s+)?Prisma\.InputJsonValue\b/
+
+function isExcluded(relativePath: string): boolean {
+  if (EXCLUDED_FILES.has(relativePath)) return true
+  return [...EXCLUDED_DIRECTORIES].some(
+    (excluded) =>
+      relativePath === excluded || relativePath.startsWith(`${excluded}/`),
+  )
+}
+
+function listSourceFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name)
+    const relativePath = relative(repositoryRoot, path)
+    if (isExcluded(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(path))
+      continue
+    }
+
+    if (entry.isFile() && SCAN_EXTENSIONS.some((ext) => path.endsWith(ext))) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function main(): void {
+  const files = listSourceFiles(repositoryRoot)
+  const errors: string[] = []
+
+  for (const file of files) {
+    const relativeFile = relative(repositoryRoot, file)
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/)
+
+    lines.forEach((line, index) => {
+      if (BAD_CAST_PATTERN.test(line)) {
+        errors.push(
+          `${relativeFile}:${index + 1}: casts to Prisma.InputJsonValue, but ` +
+            'no column in prisma/schema.prisma or prisma/model-builder.prisma ' +
+            'is a native Json column -- use normalizeJson/parseStoredJson ' +
+            '(server/api/model-builder/runs/index.ts) or JSON.stringify against ' +
+            'the String/@db.Text/@db.LongText column instead.',
+        )
+      }
+    })
+  }
+
+  if (errors.length) {
+    console.error(
+      `Prisma JSON-cast contract failed with ${errors.length} error(s):`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Prisma JSON-cast contract passed: ${files.length} source file(s) checked, ` +
+      'no Prisma.InputJsonValue casts found.',
+  )
+}
+
+main()


### PR DESCRIPTION
### Task
kind-robots/t-024: Add a lint/convention guard against casting objects to `Prisma.InputJsonValue` for String/LongText columns (kind: software)

### What changed / what I produced
- `utils/scripts/verifyNoPrismaJsonCast.ts`: recursively scans all `.ts`/`.tsx`/`.vue`/`.js`/`.mjs`/`.cjs` source files (excluding `node_modules`, `.nuxt`, `.output`, `.vercel`, `dist`, `coverage`, `cypress`, `prisma/generated`, and the checker script itself) for `as Prisma.InputJsonValue` / `as unknown as Prisma.InputJsonValue` call sites and fails with the exact file:line if any are found.
- Wired it up as `npm run test:no-prisma-json-cast` in `package.json`.
- Added it as a step ("Prisma JSON-cast contract") in `.github/workflows/contract-tests.yml`, alongside the other fast, DB-free contract checks.

### Why a flat grep instead of an eslint rule
Neither `prisma/schema.prisma` nor `prisma/model-builder.prisma` declares a single native `Json` column today — every structured field (`stageStatuses`, `pitch`, `fieldsDraft`, `promptDraft`, `previousPayload`, `nextPayload`, `usageInfo`, `sourceSnapshot`, `selections`, `ArtJob.payload`, etc.) is `String`/`String?`/`@db.Text`/`@db.LongText` storing serialized JSON. That means there is currently no legitimate call site for `Prisma.InputJsonValue` anywhere in this codebase, so the check can be an unconditional "this pattern should never appear" guard rather than a field-aware allow/deny list — simpler than an eslint rule and consistent with this repo's existing `verify*.ts` contract-check convention (e.g. `verifyWorkflowPaths.ts`, `verifyDeployWaitAncestry.ts`).

### How I verified
- `npx tsx utils/scripts/verifyNoPrismaJsonCast.ts` passes cleanly against the current tree (1056 source files checked, 0 hits).
- Sanity-checked detection by temporarily adding a fixture file with `as Prisma.InputJsonValue`, confirmed the script fails with the correct file:line and a non-zero exit code, then removed the fixture and re-confirmed a clean pass.
- Confirmed via `grep` that no current source file uses `Prisma.InputJsonValue`/`Prisma.JsonValue`/`Prisma.NullableJsonNullValueInput` anywhere (PR #295 already fixed the 12 known bad casts).

### Stakes
reversible

### Flags for Reviewer
- None — self-contained addition, no runtime behavior change, CI-only.

### Kaizen suggestion
kind-robots/t-031 (already filed, from t-027's kaizen) covers the narrower "diff-scoped, PR-time" version of this same idea for the `.exec(`/`.match(` capture-group pattern. A natural follow-up here would be extending *this* script's approach (or t-031's diff-scoped tooling once built) to also flag other Prisma "cast past the type system" footguns as they're discovered, rather than adding a new one-off script per pattern.

### Notes for reviewer
Closes kind-robots/t-024 in the conductor roadmap (roadmap.yaml update to follow in the conductor repo commit for this session).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XV3yJTSEy7t99V17v48ZSf)_