### PR TITLE
kind-robots/t-030: widen workflow-path check to extension-less refs

### DIFF
--- a/utils/scripts/verifyWorkflowPaths.ts
+++ b/utils/scripts/verifyWorkflowPaths.ts
@@ -22,6 +22,9 @@ const ALLOWLIST_PREFIXES = [
   // davinci-seed-verify.yml checks out silasfelinus/conductor into this path
   // and runs its generator script from there -- not part of this repo tree.
   'conductor-src/',
+  // Build output, never checked into git -- whether it exists depends on
+  // whether a prior step in the same job ran an install, not on repo state.
+  'node_modules/',
 ]
 
 // `run:` steps are shell, not YAML -- we don't parse them, we scan for
@@ -46,6 +49,35 @@ const runStepTokenPattern = new RegExp(
   `[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+\\.(?:${RUN_STEP_EXTENSIONS.join('|')})\\b`,
   'g',
 )
+
+// Extension-less directory references (e.g. `git diff --quiet -- stores/fallback`).
+// Deliberately narrower than the extension-based pattern above -- bare
+// `word/word` tokens collide with a lot of non-path shell content (git refs,
+// npm builtin module specifiers, prose, /dev/null, CIDR ranges like
+// 100.64.0.0/10). To keep the false-positive rate down without a full shell
+// parser:
+//   - every segment must be lowercase (repo directories are lowercase; this
+//     alone rules out prose like "Codespaces/Dependabot" in echoed strings
+//     and GitHub Actions context expressions)
+//   - a segment may start with a single leading dot (`.bin`, `.github`) but
+//     is otherwise dot-free
+//   - the match can't be immediately preceded or followed by another
+//     path/token character (`\b` alone doesn't cover this: "." and "/" are
+//     both non-word, so `\b` happily anchors mid-token, e.g. inside
+//     "100.64.0.0/10" or right after the "/" in "/dev/null") -- these
+//     explicit lookaround checks are what actually keeps this pattern from
+//     matching a fragment of a longer non-path token, or a fragment of a
+//     path the extension-based pattern above already owns
+const bareSegment = String.raw`\.?[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?`
+const bareTokenPattern = new RegExp(
+  `(?<![a-zA-Z0-9._/-])${bareSegment}(?:/${bareSegment})+(?![a-zA-Z0-9._-])`,
+  'g',
+)
+
+// Bare tokens sit inside shell, so `require('dns/promises')` / `from
+// 'stream/promises'` / `import('node:fs/promises')` read as path-shaped
+// text even though they're Node module specifiers, not repo paths.
+const importSpecifierContext = /(?:\brequire\(\s*|\bfrom\s+|\bimport\(\s*)['"]$/
 
 function listWorkflowFiles(): string[] {
   return readdirSync(workflowsDirectory)
@@ -95,12 +127,24 @@ function extractRunStepPaths(lines: string[], file: string): PathHit[] {
       hits.push({ file, path: match[0], source: 'run step' })
     }
   }
+  // Bare tokens run over whole shell lines, so (unlike the extension pattern
+  // above) a `#` comment line reads as path-shaped text too easily -- skip
+  // it outright rather than trying to strip inline comments from arbitrary
+  // shell.
+  const scanBare = (text: string) => {
+    if (text.trim().startsWith('#')) return
+    for (const match of text.matchAll(bareTokenPattern)) {
+      if (importSpecifierContext.test(text.slice(0, match.index))) continue
+      hits.push({ file, path: match[0], source: 'run step' })
+    }
+  }
 
   for (const [i, line] of lines.entries()) {
     const inline = line.match(/^(\s*)run:\s*(.+)$/)
     const inlineValue = inline?.[2] ?? ''
     if (inline && !/^[|>][-+]?$/.test(inlineValue.trim())) {
       scan(inlineValue)
+      scanBare(inlineValue)
       continue
     }
     const block = line.match(/^(\s*)run:\s*[|>][-+]?\s*$/)
@@ -110,6 +154,7 @@ function extractRunStepPaths(lines: string[], file: string): PathHit[] {
       if (!next.trim()) continue
       if (indentOf(next) <= keyIndent) break
       scan(next)
+      scanBare(next)
     }
   }
   return hits


### PR DESCRIPTION
### Task
kind-robots/t-030: Widen the workflow-path-reference check to catch extension-less directory references (kind: software)

### What changed / what I produced
- `utils/scripts/verifyWorkflowPaths.ts`: added a second, narrower token pattern that catches bare `word/word` references in `run:` steps (e.g. `git diff --quiet -- stores/fallback`), which the existing extension-gated pattern never flagged.
- Added `node_modules/` to `ALLOWLIST_PREFIXES` (build output, existence depends on install state, not repo state).
- The new pattern uses explicit lookaround guards instead of `\b` (which anchors mid-token on `.`/`/`) plus a `require('...')`/`from '...'`/`import('...')` context check, specifically to avoid false positives on: `/dev/null`, CIDR notation (`100.64.0.0/10`), Node builtin subpath specifiers (`dns/promises`), shell comments, and fragments of paths the existing extension-based pattern already owns.

### How I verified
- Ran the widened check against the real `.github/workflows/*.yml` (7 files): passes cleanly, 35 path references checked (up from the extension-only baseline).
- Iterated against every real false positive the naive first version produced (`/dev/null`, `100.64/10`, `dns/promises`, `scripts/cleanup-test-users.mjs` truncation, `${BASE_URL}/api/version`, `.github/workflows/fixtures/...`) until the check passed clean on `main`'s actual workflow files — not asserted, actually run.
- Sanity-checked detection still works: temporarily renamed `stores/fallback` to a typo in `fallback-snapshot.yml`, confirmed the check fails with the expected error, then reverted.
- `npx eslint utils/scripts/verifyWorkflowPaths.ts` — clean.
- `npx prettier --check utils/scripts/verifyWorkflowPaths.ts` — clean.
- Full project `vue-tsc --noEmit` (after `nuxi prepare` + `fix-nuxt-tsconfig.mjs`) — 0 errors.
- `npm run test:workflow-paths` (the actual CI script) — passes.

### Stakes
reversible

### Flags for Reviewer
- None — self-contained, single-file, no runtime/behavior change outside this one verify script.

### Kaizen suggestion
The new bare-token pattern requires every path segment to be lowercase, which is a deliberate (and currently sufficient) heuristic to reject prose like "Codespaces/Dependabot" in echoed strings. If a future legitimate extension-less path with an uppercase segment needs checking, that'll need a small design update rather than just loosening the case rule — flag it as a new task rather than special-casing in this file, per the file's own "add an allowlist entry when a real false positive shows up" philosophy.

### Notes for reviewer
This is an autonomous hourly cycle (no separate Worker session this run) — claimed via `claim_task.py` as `owner=reviewer`, implemented and self-verified directly. Will self-merge as reversible/scoped/verified software work per AGENTS.md, then mark the conductor roadmap task `done`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaYCzsZBjknY9TnfPrbmAz)_