### PR TITLE
kind-robots/t-034: fix mid-token anchoring gap in verifyWorkflowPaths.ts

### DIFF
--- a/utils/scripts/verifyWorkflowPaths.ts
+++ b/utils/scripts/verifyWorkflowPaths.ts
@@ -45,8 +45,18 @@ const RUN_STEP_EXTENSIONS = [
   'yaml',
   'prisma',
 ]
+// Anchored the same way as bareTokenPattern below: plain `\b` only checks a
+// word/non-word transition, and `.`/`/`/`@` are all non-word, so it happily
+// anchors mid-token -- e.g. against a `curl`'d install-script URL like
+// `https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh` or an
+// absolute toolcache path like `/opt/hostedtoolcache/node/20.11.0/x64/bin/
+// activate.sh`, the un-anchored version below matched the domain/path as if
+// it were a repo-relative file reference. The lookarounds require the match
+// not be immediately preceded/followed by another path/token/version-pin
+// character, so it can't start partway through a longer non-repo token (a
+// URL host, a CDN path like `some-package@1.2.3/dist/index.js`, etc.).
 const runStepTokenPattern = new RegExp(
-  `[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+\\.(?:${RUN_STEP_EXTENSIONS.join('|')})\\b`,
+  `(?<![A-Za-z0-9._/@-])[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+\\.(?:${RUN_STEP_EXTENSIONS.join('|')})(?![A-Za-z0-9._-])`,
   'g',
 )
 


### PR DESCRIPTION
## Summary
- Audits `utils/scripts/verifyWorkflowPaths.ts`'s extension-based `runStepTokenPattern` for the same `\b` mid-token anchoring gap t-030 found and fixed in the bare-token pattern (kind_robots PR #312).
- Confirmed the gap is real here too: the un-anchored regex matched install-script URLs (e.g. `https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh`) and absolute toolcache paths (e.g. `/opt/hostedtoolcache/node/20.11.0/x64/bin/activate.sh`) as if they were repo-relative file references, since domain/host segments fit the same `[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+` shape as a real path.
- Applied the same lookaround anchoring technique t-030 used, plus excluding a leading `@` so CDN/registry version-pin paths (`some-package@1.2.3/dist/index.js`) don't false-positive either.

## Verification
- Ran the fixed pattern against all 7 real workflow files: identical match set before/after — this is a pure robustness fix, no live false positive exists in the current workflows today (matches the task's "low urgency" framing).
- Manually injected an adversarial `curl .../install.sh` URL line into a `run: |` block — correctly ignored (no false positive).
- Manually injected a genuinely dead path reference (`scripts/definitely-not-a-real-file.js`) into the same block — still correctly caught and flagged.
- `npm run test:workflow-paths` passes (7 workflow files, 35 path references checked).
- `vue-tsc --noEmit`, `eslint`, and `prettier --check` all clean on the changed file.

## Stakes
Reversible — a regex-only change to a CI contract-check script, no runtime/app behavior touched.

Task: kind-robots/t-034 (conductor roadmap), kaizen from t-030.

Claude-Session: https://claude.ai/code/session_01VVFWHvFnZsV3W6gQjYpi1A

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVFWHvFnZsV3W6gQjYpi1A)_