### PR TITLE
global-ui/t-018: show per-milestone "N/M done" task count

### DIFF
--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -1595,6 +1595,13 @@
                     </p>
                     <p class="text-xs text-base-content/50">
                       weight {{ milestone.weight }}
+                      <span v-if="milestoneTaskCounts.get(milestone.id)?.total"
+                        >&middot;
+                        {{ milestoneTaskCounts.get(milestone.id)?.done }}/{{
+                          milestoneTaskCounts.get(milestone.id)?.total
+                        }}
+                        done</span
+                      >
                     </p>
                   </div>
                   <span
@@ -2722,6 +2729,22 @@ const doneTasksByMilestone = computed(() => {
     if (tasks.length) groups.push({ id: key || 'other', title: 'Other', tasks })
   }
   return groups
+})
+
+// Per-milestone "N/M done" counts (t-018), a side effect of the same
+// done/active split doneTasksByMilestone and activeTasks already compute.
+const milestoneTaskCounts = computed(() => {
+  const counts = new Map<string, { done: number; total: number }>()
+  const project = selectedProject.value
+  if (!project) return counts
+  for (const task of project.tasks) {
+    const key = task.milestone || ''
+    const entry = counts.get(key) ?? { done: 0, total: 0 }
+    entry.total += 1
+    if (task.status === 'done') entry.done += 1
+    counts.set(key, entry)
+  }
+  return counts
 })
 
 function priorityBadgeClass(priority: ProjectPriorityLevel): string {


### PR DESCRIPTION
### Task
global-ui/t-018: Show a per-milestone "N/M tasks done" count on the milestone cards (kind: software)

### What changed / what I produced
- `components/pages/conductor-page.vue`: added a `milestoneTaskCounts` computed (a `Map<milestoneId, {done, total}>`) built from `selectedProject.tasks`, alongside the existing `doneTasksByMilestone`/`activeTasks` split from t-015.
- Rendered "&middot; N/M done" next to each milestone card's weight label, so progress is visible without opening the collapsed completed-tasks disclosure or scrolling the task list.

### How I verified
- `npx eslint components/pages/conductor-page.vue` — clean
- `npx vue-tsc --noEmit` (full project) — 0 errors
- Confirmed the diff is scoped to exactly this change (reverted incidental prettier reformatting of unrelated pre-existing `ProjectPriorityLevel` union-type lines elsewhere in the file — the installed prettier version reformats those regardless of this change; verified the same reformatting already fires on the unmodified baseline file, so it's a pre-existing environment/version drift, not something this PR should fix).
- No dev-server/browser verification this session (no DB in this sandbox, same limitation t-012/t-015 already documented for this page).

### Stakes
reversible

### Flags for Reviewer
- Purely a computed + template addition; no prop/schema changes, no new data source.

### Kaizen suggestion
None filed this cycle — t-018 was itself a kaizen task from t-015.

### Notes for reviewer
Claimed via `claim_task.py` (reviewer/claude-conductor-hourly-20260716-t018) during this hour's autonomous conductor cycle, after merging the already-open conductor/t-052 PR (#631, all 20 checks green).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FRk98wD7drxDLZck2dGPY1)_