### PR TITLE
fix(db): recycle poisoned Prisma pool before stale retries

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -14,6 +14,7 @@ type CircuitBreakerState = {
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
   prismaBreaker?: CircuitBreakerState
+  prismaReconnect?: Promise<void>
 }
 
 const databaseUrl = process.env.DATABASE_URL
@@ -209,9 +210,8 @@ const unavailableDatabaseMessages = [
 ]
 
 // Acquisition failures consume the full timeout, so keep that retry budget at
-// one. Closed pooled sockets fail immediately; with a two-slot pool, two fast
-// retries let the adapter discard both stale sockets and create a fresh third
-// connection attempt without extending an outage by several seconds.
+// one. Closed pooled sockets fail immediately, but the MariaDB adapter can keep
+// returning the same poisoned pool unless Prisma explicitly reconnects first.
 const unavailableRetryAttempts = readNonNegativeInteger(
   process.env.DATABASE_TRANSIENT_RETRY_ATTEMPTS,
   1,
@@ -310,6 +310,33 @@ const basePrisma =
   })
 globalForPrisma.prisma = basePrisma
 
+async function reconnectPrisma(): Promise<void> {
+  const activeReconnect = globalForPrisma.prismaReconnect
+  if (activeReconnect) {
+    await activeReconnect
+    return
+  }
+
+  const reconnect = (async () => {
+    console.warn('[prisma:stale-connection-reset]', {
+      action: 'disconnect-connect',
+    })
+    await basePrisma.$disconnect()
+    await basePrisma.$connect()
+    recordConnectionSuccess()
+  })()
+
+  globalForPrisma.prismaReconnect = reconnect
+
+  try {
+    await reconnect
+  } finally {
+    if (globalForPrisma.prismaReconnect === reconnect) {
+      delete globalForPrisma.prismaReconnect
+    }
+  }
+}
+
 export const prisma = basePrisma.$extends({
   name: 'transient-database-retry',
   query: {
@@ -352,6 +379,11 @@ export const prisma = basePrisma.$extends({
             waitMs,
             message: errorMessage(error),
           })
+
+          if (staleConnectionError) {
+            await reconnectPrisma()
+          }
+
           await delay(waitMs)
         }
       }

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -1,5 +1,6 @@
 // /utils/scripts/verifyDatabasePoolDefaults.ts
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   DEFAULT_CONNECTION_LIMIT,
   SAFE_MINIMUM_CONNECTION_LIMIT,
@@ -16,6 +17,23 @@ assert.ok(
     'see server/utils/databasePoolDefaults.ts',
 )
 
+const prismaSource = readFileSync(
+  new URL('../../server/utils/prisma.ts', import.meta.url),
+  'utf8',
+)
+
+// Project Sync exposed that retrying the same Prisma query after ProxySQL closes
+// a warm socket can keep borrowing from the same poisoned pool. Guard the
+// disconnect/connect reset and its stale-error-only call site.
+assert.match(prismaSource, /prismaReconnect\?: Promise<void>/)
+assert.match(prismaSource, /await basePrisma\.\$disconnect\(\)/)
+assert.match(prismaSource, /await basePrisma\.\$connect\(\)/)
+assert.match(
+  prismaSource,
+  /if \(staleConnectionError\) \{\s+await reconnectPrisma\(\)/,
+)
+
 console.log(
-  `Database pool connection-limit fallback verified: ${DEFAULT_CONNECTION_LIMIT} >= ${SAFE_MINIMUM_CONNECTION_LIMIT}.`,
+  `Database pool safeguards verified: connection limit ${DEFAULT_CONNECTION_LIMIT} >= ` +
+    `${SAFE_MINIMUM_CONNECTION_LIMIT}, stale connections trigger a single-flight reconnect.`,
 )


### PR DESCRIPTION
## Incident

The Conductor Project Sync run began failing at 2026-07-16 18:51 UTC. Vercel recorded at least 40 failed `POST /api/projects` requests through 19:02 UTC. Every request failed with `DriverAdapterError: Cannot execute new commands: connection closed`, including both existing transient retries, and returned 503.

All sampled 503s in that window were Project creates from the sync—not a broad application outage. Normal production traffic remained mostly healthy, so this is narrower than the earlier full database outage: a warm Vercel instance can retain a poisoned MariaDB/ProxySQL pool, and repeating `query(args)` does not force that pool to recover.

## Fix

- Add a single-flight Prisma reconnect for stale-connection errors.
- Explicitly `$disconnect()` and `$connect()` the base client before retrying the failed operation.
- Keep pool-acquisition failures, retry budgets, and the existing circuit breaker behavior unchanged.
- Add a regression guard to the existing database-pool contract test so the reconnect path cannot silently disappear.

## Safety

The reconnect only runs for the exact stale-socket signature `Cannot execute new commands: connection closed`. Concurrent stale failures in the same warm instance share one reconnect promise instead of racing multiple pool resets.

## Verification

- Branch is exactly two commits ahead of `main` and changes only:
  - `server/utils/prisma.ts`
  - `utils/scripts/verifyDatabasePoolDefaults.ts`
- CI and the Vercel preview should validate TypeScript, contract checks, and deployment behavior.

## Follow-up

After this reaches production, rerun Project Sync and confirm the stale-connection retry logs include one `prisma:stale-connection-reset` event followed by successful project writes.