### PR TITLE
revert(db): stop global Prisma reconnect from aborting transactions

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -14,7 +14,6 @@ type CircuitBreakerState = {
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
   prismaBreaker?: CircuitBreakerState
-  prismaReconnect?: Promise<void>
 }
 
 const databaseUrl = process.env.DATABASE_URL
@@ -210,8 +209,9 @@ const unavailableDatabaseMessages = [
 ]
 
 // Acquisition failures consume the full timeout, so keep that retry budget at
-// one. Closed pooled sockets fail immediately, but the MariaDB adapter can keep
-// returning the same poisoned pool unless Prisma explicitly reconnects first.
+// one. Closed pooled sockets fail immediately; with a two-slot pool, two fast
+// retries let the adapter discard both stale sockets and create a fresh third
+// connection attempt without extending an outage by several seconds.
 const unavailableRetryAttempts = readNonNegativeInteger(
   process.env.DATABASE_TRANSIENT_RETRY_ATTEMPTS,
   1,
@@ -310,33 +310,6 @@ const basePrisma =
   })
 globalForPrisma.prisma = basePrisma
 
-async function reconnectPrisma(): Promise<void> {
-  const activeReconnect = globalForPrisma.prismaReconnect
-  if (activeReconnect) {
-    await activeReconnect
-    return
-  }
-
-  const reconnect = (async () => {
-    console.warn('[prisma:stale-connection-reset]', {
-      action: 'disconnect-connect',
-    })
-    await basePrisma.$disconnect()
-    await basePrisma.$connect()
-    recordConnectionSuccess()
-  })()
-
-  globalForPrisma.prismaReconnect = reconnect
-
-  try {
-    await reconnect
-  } finally {
-    if (globalForPrisma.prismaReconnect === reconnect) {
-      delete globalForPrisma.prismaReconnect
-    }
-  }
-}
-
 export const prisma = basePrisma.$extends({
   name: 'transient-database-retry',
   query: {
@@ -379,11 +352,6 @@ export const prisma = basePrisma.$extends({
             waitMs,
             message: errorMessage(error),
           })
-
-          if (staleConnectionError) {
-            await reconnectPrisma()
-          }
-
           await delay(waitMs)
         }
       }

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -1,6 +1,5 @@
 // /utils/scripts/verifyDatabasePoolDefaults.ts
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import {
   DEFAULT_CONNECTION_LIMIT,
   SAFE_MINIMUM_CONNECTION_LIMIT,
@@ -17,23 +16,6 @@ assert.ok(
     'see server/utils/databasePoolDefaults.ts',
 )
 
-const prismaSource = readFileSync(
-  new URL('../../server/utils/prisma.ts', import.meta.url),
-  'utf8',
-)
-
-// Project Sync exposed that retrying the same Prisma query after ProxySQL closes
-// a warm socket can keep borrowing from the same poisoned pool. Guard the
-// disconnect/connect reset and its stale-error-only call site.
-assert.match(prismaSource, /prismaReconnect\?: Promise<void>/)
-assert.match(prismaSource, /await basePrisma\.\$disconnect\(\)/)
-assert.match(prismaSource, /await basePrisma\.\$connect\(\)/)
-assert.match(
-  prismaSource,
-  /if \(staleConnectionError\) \{\s+await reconnectPrisma\(\)/,
-)
-
 console.log(
-  `Database pool safeguards verified: connection limit ${DEFAULT_CONNECTION_LIMIT} >= ` +
-    `${SAFE_MINIMUM_CONNECTION_LIMIT}, stale connections trigger a single-flight reconnect.`,
+  `Database pool connection-limit fallback verified: ${DEFAULT_CONNECTION_LIMIT} >= ${SAFE_MINIMUM_CONNECTION_LIMIT}.`,
 )


### PR DESCRIPTION
## Why this rollback is urgent

Production validation of #320 showed the global `$disconnect()` / `$connect()` approach does not recover the retry closure: Project Sync still returned stale-connection 503s after both resets.

Worse, disconnecting the shared Prisma client interrupted unrelated concurrent Cypress transactions, producing `P2028 Transaction already closed` failures on `/api/art/image` and `/api/bots`.

## Change

This exactly restores the two files changed by #320 to their state at `38beaea7`:

- remove the shared-client reconnect promise and `$disconnect()` / `$connect()` calls
- remove the regression assertion that required that unsafe behavior

## Follow-up

The next fix must not mutate the shared Prisma client. The safer direction is an isolated fresh client for the Project Sync create fallback, or fixing the underlying MariaDB/ProxySQL stale-socket lifecycle at the adapter/proxy layer.