### PR TITLE
fix(projects): isolate stale Project Sync recovery

### DIFF
--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -1,10 +1,14 @@
 // /server/api/projects/index.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
 import type {
+  Prisma,
   ProjectPriority,
   ProjectStatus,
 } from '~/prisma/generated/prisma/client'
-import prisma from '~/server/utils/prisma'
+import prisma, {
+  createIsolatedPrismaClient,
+  isStaleDatabaseConnectionError,
+} from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { enforceProjectCap } from '~/server/utils/projectCap'
@@ -47,6 +51,47 @@ type ProjectCreateBody = {
   isMature?: unknown
 }
 
+async function createProjectWithIsolatedFallback(
+  data: Prisma.ProjectUncheckedCreateInput,
+  conductorSlug: string,
+) {
+  try {
+    return await prisma.project.create({
+      data,
+      include: projectInclude,
+    })
+  } catch (error: unknown) {
+    if (!isStaleDatabaseConnectionError(error)) throw error
+
+    const isolatedPrisma = createIsolatedPrismaClient()
+    console.warn('[project-sync:isolated-prisma-fallback]', {
+      conductorSlug,
+      action: 'upsert',
+    })
+
+    try {
+      return await isolatedPrisma.project.upsert({
+        where: { conductorSlug },
+        create: data,
+        update: data,
+        include: projectInclude,
+      })
+    } finally {
+      try {
+        await isolatedPrisma.$disconnect()
+      } catch (disconnectError: unknown) {
+        console.warn('[project-sync:isolated-prisma-disconnect-failed]', {
+          conductorSlug,
+          message:
+            disconnectError instanceof Error
+              ? disconnectError.message
+              : String(disconnectError),
+        })
+      }
+    }
+  }
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const auth = await requireApiUser(event)
@@ -61,6 +106,21 @@ export default defineEventHandler(async (event) => {
     }
 
     const slug = normalizeSlug(body.slug ?? title)
+    if (!slug) {
+      throw createError({
+        statusCode: 400,
+        message: 'Project slug is required.',
+      })
+    }
+
+    const conductorSlug = normalizeSlug(body.conductorSlug ?? slug)
+    if (!conductorSlug) {
+      throw createError({
+        statusCode: 400,
+        message: 'Conductor slug is required.',
+      })
+    }
+
     const status = projectStatuses.has(body.status as ProjectStatus)
       ? (body.status as ProjectStatus)
       : 'BRAINSTORM'
@@ -76,38 +136,40 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const project = await prisma.project.create({
-      data: {
-        title,
-        slug,
-        description: normalizeOptionalText(body.description),
-        pitch: normalizeOptionalText(body.pitch),
-        flavorText: normalizeOptionalText(body.flavorText),
-        goal: normalizeOptionalText(body.goal),
-        status,
-        priority,
-        conductorSlug: normalizeSlug(body.conductorSlug ?? slug),
-        lastSyncedAt: normalizeNullableDateTime(body.lastSyncedAt),
-        repoUrl: normalizeOptionalText(body.repoUrl),
-        liveUrl: normalizeOptionalText(body.liveUrl),
-        channelKey: normalizeOptionalText(body.channelKey),
-        tabKey: normalizeOptionalText(body.tabKey),
-        allowReviews: body.allowReviews === true,
-        highlightImage: normalizeOptionalText(body.highlightImage),
-        icon: normalizeOptionalText(body.icon),
-        imagePath: normalizeOptionalText(body.imagePath),
-        cardPath: normalizeOptionalText(body.cardPath),
-        heroPath: normalizeOptionalText(body.heroPath),
-        designer: normalizeOptionalText(body.designer),
-        managerBotId: normalizeNullableId(body.managerBotId),
-        artImageId: normalizeNullableId(body.artImageId),
-        artCollectionId: normalizeNullableId(body.artCollectionId),
-        isPublic: body.isPublic !== false,
-        isMature: body.isMature === true,
-        userId: auth.user.id,
-      },
-      include: projectInclude,
-    })
+    const projectData = {
+      title,
+      slug,
+      description: normalizeOptionalText(body.description),
+      pitch: normalizeOptionalText(body.pitch),
+      flavorText: normalizeOptionalText(body.flavorText),
+      goal: normalizeOptionalText(body.goal),
+      status,
+      priority,
+      conductorSlug,
+      lastSyncedAt: normalizeNullableDateTime(body.lastSyncedAt),
+      repoUrl: normalizeOptionalText(body.repoUrl),
+      liveUrl: normalizeOptionalText(body.liveUrl),
+      channelKey: normalizeOptionalText(body.channelKey),
+      tabKey: normalizeOptionalText(body.tabKey),
+      allowReviews: body.allowReviews === true,
+      highlightImage: normalizeOptionalText(body.highlightImage),
+      icon: normalizeOptionalText(body.icon),
+      imagePath: normalizeOptionalText(body.imagePath),
+      cardPath: normalizeOptionalText(body.cardPath),
+      heroPath: normalizeOptionalText(body.heroPath),
+      designer: normalizeOptionalText(body.designer),
+      managerBotId: normalizeNullableId(body.managerBotId),
+      artImageId: normalizeNullableId(body.artImageId),
+      artCollectionId: normalizeNullableId(body.artCollectionId),
+      isPublic: body.isPublic !== false,
+      isMature: body.isMature === true,
+      userId: auth.user.id,
+    } satisfies Prisma.ProjectUncheckedCreateInput
+
+    const project = await createProjectWithIsolatedFallback(
+      projectData,
+      conductorSlug,
+    )
 
     event.node.res.statusCode = 201
     return {

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -199,6 +199,13 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
   }
 }
 
+function buildIsolatedDatabaseConfig(url: string): PrismaMariaDbConfig {
+  const parsed = new URL(buildDatabaseUrl(url))
+  parsed.searchParams.set('connectionLimit', '1')
+  parsed.searchParams.set('minimumIdle', '0')
+  return buildDatabaseConfig(parsed.toString())
+}
+
 const staleConnectionMessages = [
   'Cannot execute new commands: connection closed',
 ]
@@ -286,7 +293,7 @@ function messageMatches(error: unknown, candidates: string[]): boolean {
   return candidates.some((candidate) => message.includes(candidate))
 }
 
-function isStaleConnectionError(error: unknown): boolean {
+export function isStaleDatabaseConnectionError(error: unknown): boolean {
   return messageMatches(error, staleConnectionMessages)
 }
 
@@ -295,13 +302,21 @@ function isAvailabilityError(error: unknown): boolean {
 }
 
 function retryLimitFor(error: unknown): number {
-  if (isStaleConnectionError(error)) return staleConnectionRetryAttempts
+  if (isStaleDatabaseConnectionError(error)) {
+    return staleConnectionRetryAttempts
+  }
   if (isAvailabilityError(error)) return unavailableRetryAttempts
   return 0
 }
 
 const delay = (milliseconds: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
+
+export function createIsolatedPrismaClient(): PrismaClient {
+  return new PrismaClient({
+    adapter: new PrismaMariaDb(buildIsolatedDatabaseConfig(databaseUrl)),
+  })
+}
 
 const basePrisma =
   globalForPrisma.prisma ??
@@ -326,7 +341,7 @@ export const prisma = basePrisma.$extends({
           return result
         } catch (error: unknown) {
           const availabilityError = isAvailabilityError(error)
-          const staleConnectionError = isStaleConnectionError(error)
+          const staleConnectionError = isStaleDatabaseConnectionError(error)
           const retryLimit = retryLimitFor(error)
 
           if (availabilityError) {

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -314,7 +314,7 @@ const delay = (milliseconds: number) =>
 
 export function createIsolatedPrismaClient(): PrismaClient {
   return new PrismaClient({
-    adapter: new PrismaMariaDb(buildIsolatedDatabaseConfig(databaseUrl)),
+    adapter: new PrismaMariaDb(buildIsolatedDatabaseConfig(databaseUrl!)),
   })
 }
 

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -1,5 +1,6 @@
 // /utils/scripts/verifyDatabasePoolDefaults.ts
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   DEFAULT_CONNECTION_LIMIT,
   SAFE_MINIMUM_CONNECTION_LIMIT,
@@ -16,6 +17,35 @@ assert.ok(
     'see server/utils/databasePoolDefaults.ts',
 )
 
+const prismaSource = readFileSync(
+  new URL('../../server/utils/prisma.ts', import.meta.url),
+  'utf8',
+)
+const projectCreateSource = readFileSync(
+  new URL('../../server/api/projects/index.post.ts', import.meta.url),
+  'utf8',
+)
+
+// Project Sync can encounter a stale socket retained by a warm Vercel instance.
+// Recovery must use a fresh one-connection client and must never disconnect the
+// shared Prisma client, which would abort unrelated in-flight transactions.
+assert.match(
+  prismaSource,
+  /export function createIsolatedPrismaClient\(\): PrismaClient/,
+)
+assert.match(prismaSource, /searchParams\.set\('connectionLimit', '1'\)/)
+assert.doesNotMatch(prismaSource, /basePrisma\.\$disconnect\(\)/)
+assert.match(
+  projectCreateSource,
+  /if \(!isStaleDatabaseConnectionError\(error\)\) throw error/,
+)
+assert.match(
+  projectCreateSource,
+  /isolatedPrisma\.project\.upsert\([\s\S]*where: \{ conductorSlug \}/,
+)
+assert.match(projectCreateSource, /await isolatedPrisma\.\$disconnect\(\)/)
+
 console.log(
-  `Database pool connection-limit fallback verified: ${DEFAULT_CONNECTION_LIMIT} >= ${SAFE_MINIMUM_CONNECTION_LIMIT}.`,
+  `Database pool safeguards verified: connection limit ${DEFAULT_CONNECTION_LIMIT} >= ` +
+    `${SAFE_MINIMUM_CONNECTION_LIMIT}; stale Project creates use an isolated client.`,
 )


### PR DESCRIPTION
## Incident

Project Sync repeatedly fails `POST /api/projects` with `Cannot execute new commands: connection closed` when a warm Vercel instance retains a stale MariaDB/ProxySQL socket.

The first attempted repair in #320 globally disconnected the shared Prisma client. Production validation proved that approach unsafe: it did not recover the bound retry query and it aborted unrelated in-flight transactions with `P2028`. #321 restored the previous behavior.

## Fix

- Export a factory for a short-lived Prisma client with a one-connection pool.
- Expose the exact stale-connection classifier already used by the shared retry wrapper.
- In `POST /api/projects`, fall back only after the shared client exhausts retries with that exact stale-socket error.
- Perform the fallback as an isolated `upsert` keyed by unique `conductorSlug`.
- Disconnect only the isolated client; the shared application client remains untouched.

## Why upsert

The original create may theoretically commit before the driver reports a closed connection. `conductorSlug` is unique and always normalized for Project creates, so the isolated retry is idempotent rather than risking a duplicate row.

## Regression guard

The existing database-pool contract now asserts:

- the isolated client is limited to one connection
- Project recovery uses isolated `upsert`
- the shared `basePrisma` is never disconnected
- the isolated client is cleaned up

## Validation plan

1. TypeScript Type Check and Contract Tests.
2. Vercel preview build, including database TLS preflight and migration check.
3. Merge and wait for the production alias to point at this commit.
4. Rerun failed Conductor Project Sync run `29526629136` and inspect both Actions and Vercel runtime logs.