### PR TITLE
fix(projects): bypass stale Prisma pool with direct MariaDB upsert

### DIFF
--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -5,10 +5,8 @@ import type {
   ProjectPriority,
   ProjectStatus,
 } from '~/prisma/generated/prisma/client'
-import prisma, {
-  createIsolatedPrismaClient,
-  isStaleDatabaseConnectionError,
-} from '~/server/utils/prisma'
+import prisma, { isStaleDatabaseConnectionError } from '~/server/utils/prisma'
+import { upsertProjectDirect } from '~/server/utils/projectDirectWrite'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { enforceProjectCap } from '~/server/utils/projectCap'
@@ -51,7 +49,7 @@ type ProjectCreateBody = {
   isMature?: unknown
 }
 
-async function createProjectWithIsolatedFallback(
+async function createProjectWithDirectFallback(
   data: Prisma.ProjectUncheckedCreateInput,
   conductorSlug: string,
 ) {
@@ -63,32 +61,11 @@ async function createProjectWithIsolatedFallback(
   } catch (error: unknown) {
     if (!isStaleDatabaseConnectionError(error)) throw error
 
-    const isolatedPrisma = createIsolatedPrismaClient()
-    console.warn('[project-sync:isolated-prisma-fallback]', {
+    console.warn('[project-sync:direct-mariadb-fallback]', {
       conductorSlug,
       action: 'upsert',
     })
-
-    try {
-      return await isolatedPrisma.project.upsert({
-        where: { conductorSlug },
-        create: data,
-        update: data,
-        include: projectInclude,
-      })
-    } finally {
-      try {
-        await isolatedPrisma.$disconnect()
-      } catch (disconnectError: unknown) {
-        console.warn('[project-sync:isolated-prisma-disconnect-failed]', {
-          conductorSlug,
-          message:
-            disconnectError instanceof Error
-              ? disconnectError.message
-              : String(disconnectError),
-        })
-      }
-    }
+    return upsertProjectDirect(data, conductorSlug)
   }
 }
 
@@ -166,7 +143,7 @@ export default defineEventHandler(async (event) => {
       userId: auth.user.id,
     } satisfies Prisma.ProjectUncheckedCreateInput
 
-    const project = await createProjectWithIsolatedFallback(
+    const project = await createProjectWithDirectFallback(
       projectData,
       conductorSlug,
     )

--- a/server/utils/databaseDirectProbe.ts
+++ b/server/utils/databaseDirectProbe.ts
@@ -7,6 +7,10 @@ type ConnectorError = Error & {
   fatal?: boolean
 }
 
+export type DirectDatabaseConnection = Awaited<
+  ReturnType<typeof mariadb.createConnection>
+>
+
 export type DirectDatabaseProbeResult = {
   success: boolean
   latencyMs: number
@@ -52,6 +56,35 @@ function sanitizedMessage(error: ConnectorError, parsed: URL): string {
   return message
 }
 
+export async function createDatabaseDirectConnection(): Promise<DirectDatabaseConnection> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    throw Object.assign(new Error('DATABASE_URL is missing'), {
+      code: 'DATABASE_URL_MISSING',
+    })
+  }
+
+  const parsed = new URL(databaseUrl)
+  const sslCa = readDatabaseSslCa()
+
+  return mariadb.createConnection({
+    host: parsed.hostname,
+    port: Number.parseInt(parsed.port || '3306', 10),
+    user: decodeURIComponent(parsed.username),
+    password: decodeURIComponent(parsed.password),
+    database: decodeURIComponent(parsed.pathname.replace(/^\/+/, '')),
+    connectTimeout: 5_000,
+    ...(sslCa
+      ? {
+          ssl: {
+            ca: sslCa,
+            rejectUnauthorized: rejectUnauthorized(),
+          },
+        }
+      : {}),
+  })
+}
+
 export async function probeDatabaseDirect(): Promise<DirectDatabaseProbeResult> {
   const startedAt = Date.now()
   const databaseUrl = process.env.DATABASE_URL
@@ -65,28 +98,10 @@ export async function probeDatabaseDirect(): Promise<DirectDatabaseProbeResult> 
   }
 
   const parsed = new URL(databaseUrl)
-  const sslCa = readDatabaseSslCa()
-  let connection: Awaited<ReturnType<typeof mariadb.createConnection>> | null =
-    null
+  let connection: DirectDatabaseConnection | null = null
 
   try {
-    connection = await mariadb.createConnection({
-      host: parsed.hostname,
-      port: Number.parseInt(parsed.port || '3306', 10),
-      user: decodeURIComponent(parsed.username),
-      password: decodeURIComponent(parsed.password),
-      database: decodeURIComponent(parsed.pathname.replace(/^\/+/, '')),
-      connectTimeout: 5_000,
-      ...(sslCa
-        ? {
-            ssl: {
-              ca: sslCa,
-              rejectUnauthorized: rejectUnauthorized(),
-            },
-          }
-        : {}),
-    })
-
+    connection = await createDatabaseDirectConnection()
     await connection.query('SELECT 1 AS direct_probe_ok')
 
     return {

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -199,13 +199,6 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
   }
 }
 
-function buildIsolatedDatabaseConfig(url: string): PrismaMariaDbConfig {
-  const parsed = new URL(buildDatabaseUrl(url))
-  parsed.searchParams.set('connectionLimit', '1')
-  parsed.searchParams.set('minimumIdle', '0')
-  return buildDatabaseConfig(parsed.toString())
-}
-
 const staleConnectionMessages = [
   'Cannot execute new commands: connection closed',
 ]
@@ -311,12 +304,6 @@ function retryLimitFor(error: unknown): number {
 
 const delay = (milliseconds: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
-
-export function createIsolatedPrismaClient(): PrismaClient {
-  return new PrismaClient({
-    adapter: new PrismaMariaDb(buildIsolatedDatabaseConfig(databaseUrl!)),
-  })
-}
 
 const basePrisma =
   globalForPrisma.prisma ??

--- a/server/utils/projectDirectWrite.ts
+++ b/server/utils/projectDirectWrite.ts
@@ -1,0 +1,150 @@
+// /server/utils/projectDirectWrite.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import { createDatabaseDirectConnection } from './databaseDirectProbe'
+
+const projectWriteColumns = [
+  'title',
+  'slug',
+  'description',
+  'pitch',
+  'flavorText',
+  'goal',
+  'status',
+  'priority',
+  'conductorSlug',
+  'lastSyncedAt',
+  'repoUrl',
+  'liveUrl',
+  'channelKey',
+  'tabKey',
+  'allowReviews',
+  'highlightImage',
+  'icon',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'designer',
+  'managerBotId',
+  'artImageId',
+  'artCollectionId',
+  'isPublic',
+  'isMature',
+  'userId',
+] as const satisfies readonly (keyof Prisma.ProjectUncheckedCreateInput)[]
+
+const projectSelectColumns = [
+  'id',
+  'createdAt',
+  'updatedAt',
+  'title',
+  'slug',
+  'description',
+  'pitch',
+  'flavorText',
+  'goal',
+  'status',
+  'priority',
+  'conductorSlug',
+  'repoUrl',
+  'liveUrl',
+  'channelKey',
+  'tabKey',
+  'lastSyncedAt',
+  'allowReviews',
+  'highlightImage',
+  'icon',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'designer',
+  'creationSource',
+  'userId',
+  'managerBotId',
+  'artImageId',
+  'artCollectionId',
+  'isPublic',
+  'isMature',
+  'isActive',
+] as const
+
+function databaseValue(value: unknown): unknown {
+  return value === undefined ? null : value
+}
+
+function booleanValue(value: unknown): boolean {
+  return value === true || value === 1 || value === '1'
+}
+
+export async function upsertProjectDirect(
+  data: Prisma.ProjectUncheckedCreateInput,
+  conductorSlug: string,
+) {
+  const connection = await createDatabaseDirectConnection()
+
+  try {
+    const quotedColumns = projectWriteColumns
+      .map((column) => `\`${column}\``)
+      .join(', ')
+    const placeholders = projectWriteColumns.map(() => '?').join(', ')
+    const updates = projectWriteColumns
+      .map((column) => `\`${column}\` = VALUES(\`${column}\`)`)
+      .join(', ')
+    const values = projectWriteColumns.map((column) =>
+      databaseValue(data[column]),
+    )
+
+    await connection.query(
+      `INSERT INTO \`Project\` (${quotedColumns}) ` +
+        `VALUES (${placeholders}) ` +
+        `ON DUPLICATE KEY UPDATE ${updates}, ` +
+        '`updatedAt` = CURRENT_TIMESTAMP(3)',
+      values,
+    )
+
+    const selectedColumns = projectSelectColumns
+      .map((column) => `\`${column}\``)
+      .join(', ')
+    const rows = (await connection.query(
+      `SELECT ${selectedColumns} FROM \`Project\` ` +
+        'WHERE `conductorSlug` = ? LIMIT 1',
+      [conductorSlug],
+    )) as Array<Record<string, unknown>>
+    const project = rows[0]
+
+    if (!project) {
+      throw new Error(
+        `Direct Project upsert completed but ${conductorSlug} was not found.`,
+      )
+    }
+
+    return {
+      ...project,
+      allowReviews: booleanValue(project.allowReviews),
+      isPublic: booleanValue(project.isPublic),
+      isMature: booleanValue(project.isMature),
+      isActive: booleanValue(project.isActive),
+      Manager: null,
+      ArtImage: null,
+      ArtCollection: null,
+      PitchSheet: null,
+      _count: {
+        Chats: 0,
+        Todos: 0,
+        Reactions: 0,
+        ArtJobs: 0,
+        ArtImageLinks: 0,
+        ArtCollectionLinks: 0,
+      },
+    }
+  } finally {
+    await connection.end().catch((disconnectError: unknown) => {
+      console.warn('[project-sync:direct-mariadb-disconnect-failed]', {
+        conductorSlug,
+        message:
+          disconnectError instanceof Error
+            ? disconnectError.message
+            : String(disconnectError),
+      })
+    })
+  }
+}

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -21,31 +21,41 @@ const prismaSource = readFileSync(
   new URL('../../server/utils/prisma.ts', import.meta.url),
   'utf8',
 )
+const directProbeSource = readFileSync(
+  new URL('../../server/utils/databaseDirectProbe.ts', import.meta.url),
+  'utf8',
+)
+const directProjectSource = readFileSync(
+  new URL('../../server/utils/projectDirectWrite.ts', import.meta.url),
+  'utf8',
+)
 const projectCreateSource = readFileSync(
   new URL('../../server/api/projects/index.post.ts', import.meta.url),
   'utf8',
 )
 
 // Project Sync can encounter a stale socket retained by a warm Vercel instance.
-// Recovery must use a fresh one-connection client and must never disconnect the
-// shared Prisma client, which would abort unrelated in-flight transactions.
-assert.match(
-  prismaSource,
-  /export function createIsolatedPrismaClient\(\): PrismaClient/,
-)
-assert.match(prismaSource, /searchParams\.set\('connectionLimit', '1'\)/)
+// Recovery must bypass the Prisma adapter pool through the same direct MariaDB
+// connection path used by the production database probe. It must never
+// disconnect the shared Prisma client, which aborts unrelated transactions.
 assert.doesNotMatch(prismaSource, /basePrisma\.\$disconnect\(\)/)
+assert.doesNotMatch(prismaSource, /createIsolatedPrismaClient/)
+assert.match(
+  directProbeSource,
+  /export async function createDatabaseDirectConnection\(\)/,
+)
+assert.match(directProjectSource, /ON DUPLICATE KEY UPDATE/)
+assert.match(directProjectSource, /await connection\.end\(\)/)
 assert.match(
   projectCreateSource,
   /if \(!isStaleDatabaseConnectionError\(error\)\) throw error/,
 )
 assert.match(
   projectCreateSource,
-  /isolatedPrisma\.project\.upsert\([\s\S]*where: \{ conductorSlug \}/,
+  /return upsertProjectDirect\(data, conductorSlug\)/,
 )
-assert.match(projectCreateSource, /await isolatedPrisma\.\$disconnect\(\)/)
 
 console.log(
   `Database pool safeguards verified: connection limit ${DEFAULT_CONNECTION_LIMIT} >= ` +
-    `${SAFE_MINIMUM_CONNECTION_LIMIT}; stale Project creates use an isolated client.`,
+    `${SAFE_MINIMUM_CONNECTION_LIMIT}; stale Project creates bypass Prisma through direct MariaDB.`,
 )


### PR DESCRIPTION
## Production finding

#322 removed the dangerous shared-client reset and correctly isolated stale Project creates. The live Project Sync rerun proved a second adapter-level failure: each brand-new one-connection `PrismaMariaDb` pool timed out with `active=0 idle=0 limit=1` before opening a socket.

Meanwhile unrelated production routes continued succeeding, and Kind Robots already has a direct MariaDB connection path used by its database probe and build preflight.

## Fix

- Export the existing verified direct MariaDB connection factory from `databaseDirectProbe.ts`.
- On the exact stale Prisma socket signature only, perform the Project write through a direct single connection instead of another Prisma adapter pool.
- Use parameterized `INSERT ... ON DUPLICATE KEY UPDATE`, keyed by unique `conductorSlug`, preserving idempotency if the original create committed ambiguously.
- Select and return the newly created Project shape after the write.
- Always close only the direct connection.
- Remove the failed isolated-Prisma factory; never disconnect the shared Prisma client.

## Safety

- Normal Project creates still use Prisma and the existing include shape.
- The direct path runs only after the shared Prisma retry wrapper exhausts the exact `Cannot execute new commands: connection closed` error.
- SQL identifiers are static and all values are parameterized.
- The Project model guarantees unique `conductorSlug`.

## Regression guard

The database contract asserts:

- shared `basePrisma` is never disconnected
- the failed isolated-Prisma factory does not return
- direct connection creation is exported from the verified probe path
- fallback SQL remains idempotent and closes its connection
- `POST /api/projects` invokes the direct fallback only after stale classification

## Validation plan

1. TypeScript and Contract Tests.
2. Vercel preview build and database TLS preflight.
3. Merge and wait for production READY.
4. Rerun Project Sync run `29526629136` and verify `kindrobots-unraid` is created without 503s.