### PR TITLE
Reduce redundant Vercel build work

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:relay-agent-registry": "tsx utils/scripts/verifyRelayAgentRegistry.ts",
     "test:seed-challenges": "tsx scripts/seed_challenges.ts",
     "test:seed-contenders": "tsx scripts/seed_contenders.ts",
-    "vercel-build": "prisma generate && node scripts/prisma-migrate-deploy.mjs && node --max-old-space-size=8192 node_modules/.bin/nuxt build",
+    "vercel-build": "node scripts/vercel-build.mjs",
     "dev": "nuxt dev --host",
     "build": "nuxi prepare && prisma generate && nuxi build",
     "start": "nuxi start",

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,0 +1,41 @@
+// /scripts/vercel-build.mjs
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const binExtension = process.platform === 'win32' ? '.cmd' : ''
+const prismaBinary = path.resolve(`node_modules/.bin/prisma${binExtension}`)
+const nuxtBinary = path.resolve('node_modules/.bin/nuxt')
+
+function run(command, args, label) {
+  console.log(`[vercel-build] ${label}`)
+
+  const result = spawnSync(command, args, {
+    env: process.env,
+    stdio: 'inherit',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${label} exited with code ${result.status ?? 'unknown'}`)
+  }
+}
+
+const isVercelBuild = process.env.VERCEL === '1'
+const isProductionDeployment = process.env.VERCEL_ENV === 'production'
+
+run(prismaBinary, ['generate'], 'Generating Prisma client')
+
+if (!isVercelBuild || isProductionDeployment) {
+  run(process.execPath, ['scripts/prisma-migrate-deploy.mjs'], 'Applying production migrations')
+} else {
+  console.log(`[vercel-build] Skipping migrations for Vercel ${process.env.VERCEL_ENV || 'unknown'} deployment`)
+}
+
+run(
+  process.execPath,
+  ['--max-old-space-size=8192', nuxtBinary, 'build'],
+  'Building Nuxt application',
+)

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,75 @@
+// /scripts/vercel-ignore-build.mjs
+import { spawnSync } from 'node:child_process'
+
+const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA
+const currentSha = process.env.VERCEL_GIT_COMMIT_SHA
+
+const ignoredPrefixes = [
+  '.github/',
+  '.migration-backups/',
+  'artifacts/',
+  'cypress/',
+  'docs/',
+]
+
+const ignoredRootFiles = new Set([
+  'AGENTS.md',
+  'AI_README.md',
+  'CONTROL.md',
+  'README.md',
+])
+
+function continueBuild(reason) {
+  console.log(`[vercel-ignore] Build required: ${reason}`)
+  process.exit(1)
+}
+
+function ignoreBuild(reason) {
+  console.log(`[vercel-ignore] Build skipped: ${reason}`)
+  process.exit(0)
+}
+
+function isIgnoredPath(filePath) {
+  return (
+    ignoredRootFiles.has(filePath) ||
+    ignoredPrefixes.some((prefix) => filePath.startsWith(prefix)) ||
+    filePath.endsWith('.bak')
+  )
+}
+
+if (!previousSha || !currentSha) {
+  continueBuild('missing Vercel commit ancestry')
+}
+
+const diff = spawnSync(
+  'git',
+  ['diff', '--name-only', '--diff-filter=ACMRTUXB', previousSha, currentSha],
+  {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+)
+
+if (diff.status !== 0) {
+  const error = diff.stderr.trim() || `git diff exited with ${diff.status ?? 'unknown status'}`
+  continueBuild(error)
+}
+
+const changedFiles = diff.stdout
+  .split('\n')
+  .map((filePath) => filePath.trim())
+  .filter(Boolean)
+
+if (changedFiles.length === 0) {
+  continueBuild('no changed files were detected')
+}
+
+const deployableFiles = changedFiles.filter((filePath) => !isIgnoredPath(filePath))
+
+if (deployableFiles.length === 0) {
+  ignoreBuild(`${changedFiles.length} documentation, test, or report file(s) changed`)
+}
+
+const preview = deployableFiles.slice(0, 10).join(', ')
+const remainder = deployableFiles.length > 10 ? ` and ${deployableFiles.length - 10} more` : ''
+continueBuild(`${preview}${remainder}`)

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,13 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "regions": ["iad1"],
+  "ignoreCommand": "node scripts/vercel-ignore-build.mjs",
   "git": {
     "deploymentEnabled": {
       "claude/*": false,
-      "agent/*": false
+      "agent/*": false,
+      "worker/*": false,
+      "conductor/*": false
     }
   }
 }


### PR DESCRIPTION
## What changed

- disable automatic Vercel deployments for `worker/*` and `conductor/*` branches
- add a conservative ignored-build filter for docs, Cypress, reports, backups, and workflow-only commits
- keep runtime-affecting changes building by default
- run Prisma migrations only for Production deployments while still generating Prisma and building Nuxt for Previews

## Why

Recent deployment history showed heavy queue churn from automated branch pushes and repeated Preview migration checks against the production database. These changes remove redundant work without changing application runtime behavior.

## Validation

- `node --check scripts/vercel-ignore-build.mjs`
- `node --check scripts/vercel-build.mjs`
- temporary Git repository test confirmed docs-only changes exit `0` to skip and runtime changes exit `1` to build

## Follow-up

The larger remaining bottleneck is the multi-gigabyte image history. That should be handled as a separate staged migration with URL-preserving rewrites and rollback coverage.