### PR TITLE
fix(db): use MariaDB text protocol through ProxySQL

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -141,6 +141,17 @@ function readSslRejectUnauthorized(): boolean {
   return raw !== 'false' && raw !== '0' && raw !== 'no'
 }
 
+// Prisma's MariaDB adapter uses the binary execute() protocol by default. Under
+// sustained Vercel traffic through ProxySQL, that path repeatedly retained a
+// connection whose command channel was already closed, while the connector's
+// query() path remained healthy for direct probes and fallback writes. Default
+// to the adapter's supported text protocol for this topology. Set
+// DATABASE_USE_TEXT_PROTOCOL=false to restore the binary protocol quickly.
+function readDatabaseUseTextProtocol(): boolean {
+  const raw = process.env.DATABASE_USE_TEXT_PROTOCOL?.trim().toLowerCase()
+  return raw !== 'false' && raw !== '0' && raw !== 'no'
+}
+
 function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
   const resolvedUrl = buildDatabaseUrl(url)
   const sslCa = readDatabaseSslCa()
@@ -334,10 +345,17 @@ function retryLimitFor(error: unknown): number {
 const delay = (milliseconds: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
 
+const useTextProtocol = readDatabaseUseTextProtocol()
+console.info('[prisma] MariaDB protocol mode', {
+  mode: useTextProtocol ? 'text-query' : 'binary-execute',
+})
+
 const basePrisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    adapter: new PrismaMariaDb(buildDatabaseConfig(databaseUrl)),
+    adapter: new PrismaMariaDb(buildDatabaseConfig(databaseUrl), {
+      useTextProtocol,
+    }),
   })
 globalForPrisma.prisma = basePrisma
 

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -11,10 +11,12 @@ import {
   SAFE_MINIMUM_CONNECTION_LIMIT,
 } from './../../server/utils/databasePoolDefaults'
 
-// Regression guards for the two production pool failure modes:
+// Regression guards for the production pool failure modes:
 // - too few connections starve every DB-backed route
 // - retiring every idle connection after 15 seconds leaves warm Vercel instances
 //   reusing or recreating unhealthy ProxySQL sockets during sustained API tests
+// - the adapter's binary execute() path can retain a closed command channel
+//   through ProxySQL even while the connector's text query() path stays healthy
 assert.ok(
   DEFAULT_CONNECTION_LIMIT >= SAFE_MINIMUM_CONNECTION_LIMIT,
   `DEFAULT_CONNECTION_LIMIT (${DEFAULT_CONNECTION_LIMIT}) must be >= ` +
@@ -62,6 +64,15 @@ assert.match(prismaSource, /DEFAULT_IDLE_TIMEOUT_SECONDS/)
 assert.match(prismaSource, /DEFAULT_MINIMUM_IDLE/)
 assert.doesNotMatch(prismaSource, /DATABASE_IDLE_TIMEOUT_SECONDS,\s*15/)
 assert.doesNotMatch(prismaSource, /DATABASE_MINIMUM_IDLE,\s*0/)
+assert.match(prismaSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
+assert.match(
+  prismaSource,
+  /new PrismaMariaDb\(buildDatabaseConfig\(databaseUrl\),\s*\{\s*useTextProtocol/,
+)
+assert.match(
+  prismaSource,
+  /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
+)
 
 // Project Sync can encounter a stale socket retained by a warm Vercel instance.
 // Recovery must bypass the Prisma adapter pool through the same direct MariaDB
@@ -88,5 +99,6 @@ console.log(
   `Database pool safeguards verified: limit=${DEFAULT_CONNECTION_LIMIT}, ` +
     `connect=${DEFAULT_CONNECT_TIMEOUT_MS}ms, acquire=${DEFAULT_ACQUIRE_TIMEOUT_MS}ms, ` +
     `idle=${DEFAULT_IDLE_TIMEOUT_SECONDS}s, minimumIdle=${DEFAULT_MINIMUM_IDLE}, ` +
-    `ping=${DEFAULT_PING_TIMEOUT_MS}ms; stale Project creates bypass Prisma through direct MariaDB.`,
+    `ping=${DEFAULT_PING_TIMEOUT_MS}ms; Prisma defaults to MariaDB text protocol through ProxySQL; ` +
+    'stale Project creates bypass Prisma through direct MariaDB.',
 )


### PR DESCRIPTION
## Production finding

PR #325 improved pool startup and passed the new concurrent/post-idle readiness gate, but the production Cypress run still produced `DriverAdapterError: Cannot execute new commands: connection closed` across unrelated Prisma creates.

The installed `@prisma/adapter-mariadb` 7.8 implementation uses the binary `execute()` protocol for ordinary operations by default. Its supported `useTextProtocol` option switches those operations to the connector's `query()` path. During this incident, direct `mariadb` queries through the same TLS/ProxySQL route remained healthy while Prisma's binary adapter operations repeatedly retained a closed command channel.

## Change

- Default `PrismaMariaDb` to `useTextProtocol: true`.
- Add `DATABASE_USE_TEXT_PROTOCOL=false` as a rapid rollback switch to restore binary `execute()` behavior.
- Log the active protocol mode on process initialization without exposing connection details.
- Extend the database contract guard so the ProxySQL text-protocol setting cannot silently disappear.
- Keep the pool lifecycle safeguards from #325 unchanged.

## Safety

- This uses a public adapter option present in the installed Prisma 7.8 source.
- Parameters remain handled by the MariaDB connector; this does not interpolate SQL.
- Prisma transactions already use the connector's text `query()` path internally.
- No shared Prisma disconnect/reconnect is introduced.

## Validation

- Contract Tests: passed
- TypeScript Type Check: passed
- Vercel preview build: completed successfully
- Preview database TLS preflight: passed
- Preview migration check against `acrocatranch.com:5544/kindblank_fresh`: passed; no pending migrations
- Preview runtime logged `MariaDB protocol mode { mode: 'text-query' }`
- Preview pooled health: HTTP 200 on cold request and after crossing the former 15-second idle window
- Preview direct health: HTTP 200

## Remaining proof

The decisive validation is sustained authenticated CRUD traffic. Keep this PR unmerged until review; after merge, the production Cypress suite should be watched specifically for recurrence of `Cannot execute new commands: connection closed`.
