### PR TITLE
Ruler Hooked PoC — deterministic engine foundation (conductor ruler-hooked/t-007)

### DIFF
--- a/types/ruler-hooked.ts
+++ b/types/ruler-hooked.ts
@@ -1,0 +1,301 @@
+// types/ruler-hooked.ts
+//
+// Type contracts for "The Ruler is Hooked" — the offline-first slideshow
+// fishing/kingdom PoC (conductor ruler-hooked/t-007). These mirror the merged
+// design specs in the conductor repo:
+//   projects/ruler-hooked/docs/{data-model.md, compositing.md, decks.md}
+//
+// Everything here is framework-free (no Vue/Nuxt/Prisma imports) so the pure
+// engine in utils/rulerHooked/* can be type-checked and reasoned about in
+// isolation, and ports cleanly to a future Unreal build (unreal-migration.md).
+// The vocabulary intentionally matches the kind_robots models it can sync to:
+// LifeRun (status/seed), Reward (rewardType/rarity), Rarity.
+
+// --- shared enums (mirror kind_robots prisma enums) -------------------------
+
+export type LifeRunStatus = 'ACTIVE' | 'COMPLETE' | 'ABANDONED'
+export type RewardType = 'SKILL' | 'ITEM' | 'POWER' | 'PET' | 'MAGIC' | 'FAVOR'
+export type Rarity =
+  | 'COMMON'
+  | 'UNCOMMON'
+  | 'RARE'
+  | 'EPIC'
+  | 'LEGENDARY'
+  | 'MYTHIC'
+
+// --- regions / compositing (compositing.md) ---------------------------------
+
+/** Canonical region keys, back-to-front z-order (compositing.md §1). */
+export const REGION_KEYS = [
+  'sky',
+  'far_shore',
+  'treeline',
+  'village_edge',
+  'castle_grounds',
+  'lake',
+  'near_bank',
+  'ruler',
+  'fx',
+] as const
+export type RegionKey = (typeof REGION_KEYS)[number]
+
+/** Cosmetic time-of-day cycle positions (compositing.md §4). Settle: day/night;
+ *  transient "treats": dawn/golden/dusk. Never gates content. */
+export const TIME_KEYS = ['day', 'night', 'dawn', 'golden', 'dusk'] as const
+export type TimeKey = (typeof TIME_KEYS)[number]
+
+/** A region's visual state is authored content — a plain string key. */
+export type RegionState = string
+
+/** One region's definition in the regions manifest (compositing.md §2). */
+export interface RegionDef {
+  z: number
+  /** If ramp-driven: which slider axis selects the state, over an ordered ramp. */
+  driver?: { slider: AxisKey; ramp: RegionState[] }
+  states: RegionState[]
+  /** Times this region actually authors (for the asset fallback ladder). */
+  times?: TimeKey[]
+}
+
+export interface RegionsManifest {
+  regions: Record<RegionKey, RegionDef>
+}
+
+// --- kingdom health (data-model.md §4) --------------------------------------
+
+/** Canonical continuous axes, each 0..100. */
+export const AXIS_KEYS = [
+  'nature',
+  'prosperity',
+  'treasury',
+  'joy',
+  'order',
+] as const
+export type AxisKey = (typeof AXIS_KEYS)[number]
+
+export type KingdomHealth = Record<AxisKey, number>
+
+// --- decks / cards / effects (decks.md) -------------------------------------
+
+export type CardKind = 'interrupt' | 'arc-step' | 'ambient' | 'finale'
+
+/** Numeric comparators used by triggers (decks.md §3). */
+export interface NumericPredicate {
+  gte?: number
+  gt?: number
+  lte?: number
+  lt?: number
+  eq?: number
+  neq?: number
+}
+
+/** A trigger clause: numeric predicates over sliders/counters, plus set
+ *  membership over flags/rewards/cardsSeen. */
+export interface TriggerClause {
+  sliders?: Partial<Record<AxisKey, NumericPredicate>>
+  counters?: Record<string, NumericPredicate>
+  flags?: string[]
+  rewards?: string[]
+  cardsSeen?: string[]
+}
+
+export interface Trigger {
+  minTurn?: number
+  maxTurn?: number
+  requires?: TriggerClause
+  forbids?: TriggerClause
+  /** Min turns since this card last fired (turns, never wall-clock). */
+  cooldown?: number
+  weightBonus?: { when: TriggerClause; add: number }
+  /** Probability [0..1] gate for arc starts / occasional cards. */
+  chance?: number
+}
+
+/** The closed effects grammar (decks.md §6) — the ONLY way content mutates save. */
+export interface Effect {
+  /** Additive deltas to kingdomHealth (clamped 0..100). */
+  sliders?: Partial<Record<AxisKey, number>>
+  /** Additive deltas to discrete counters. */
+  counters?: Record<string, number>
+  /** Pin a region's visual state (compositing.md §3). */
+  regionOverride?: Partial<Record<RegionKey, RegionState>>
+  flags?: { set?: string[]; clear?: string[] }
+  /** Grant Rewards by slug. */
+  grant?: { reward: string }[]
+  /** Remove Rewards by slug. */
+  revoke?: string[]
+  /** Arc control. */
+  arc?: { start?: string; advance?: string; complete?: string }
+  /** finale choices only: set save.endingKey + status COMPLETE. */
+  ending?: string
+  /** Return this card to the draw bag (the mandatory defer path). */
+  requeue?: boolean
+}
+
+export interface Choice {
+  id: string
+  text: string
+  effects?: Effect
+  result?: string
+  requeue?: boolean
+}
+
+export interface Card {
+  id: string
+  deck?: string
+  kind: CardKind
+  weight?: number
+  once?: boolean
+  narratorId?: string | number
+  characters?: string[] // Character slugs
+  title: string
+  body?: string
+  art?: string
+  trigger?: Trigger
+  choices: Choice[]
+}
+
+export interface Deck {
+  id: string
+  title?: string
+  description?: string
+  cards: Card[]
+}
+
+export interface ArcStepRef {
+  id: string
+}
+
+export interface Arc {
+  id: string
+  title?: string
+  characters?: string[]
+  start?: { trigger?: Trigger }
+  steps: Card[]
+}
+
+/** Ending catalog entry (mirrors LifeEnding: outcomeKey/victoryType). */
+export type VictoryType = 'VICTORY' | 'FAILURE' | 'MIXED' | 'SECRET'
+export interface Ending {
+  outcomeKey: string
+  victoryType: VictoryType
+  title: string
+  body?: string
+  trigger?: Trigger
+}
+
+// --- content bundle (data-model.md §6) --------------------------------------
+
+export interface CharacterRef {
+  slug: string
+  name: string
+  honorific?: string
+  alignment?: string
+  role?: string
+  drive?: string
+  quirks?: string
+}
+
+export interface RewardRef {
+  slug: string
+  name: string
+  rewardType: RewardType
+  rarity: Rarity
+  effect?: string
+  description?: string
+}
+
+export interface ContentBundle {
+  contentVersion: string
+  regions: RegionsManifest
+  decks: Deck[]
+  arcs: Arc[]
+  characters: CharacterRef[]
+  rewards: RewardRef[]
+  endings: Ending[]
+}
+
+// --- the save document (data-model.md §3) -----------------------------------
+
+export interface InventoryReward {
+  slug: string
+  rarity: Rarity
+  effect?: string
+}
+
+export interface ChoiceLogEntry {
+  turn: number
+  cardId: string
+  prompt: string
+  choiceText: string
+  effects: Effect
+  resultText?: string
+}
+
+export interface ArcState {
+  step: string
+  flags: Record<string, boolean>
+}
+
+export interface DeckState {
+  seenCardIds: string[]
+  activeArcs: Record<string, ArcState>
+  cooldowns: Record<string, number> // turns remaining
+  drawBag: string[]
+}
+
+export interface RunSave {
+  schemaVersion: number
+  saveId: string
+  name: string
+  dreamSlug: string
+  contentVersion: string
+  seed: string
+  status: LifeRunStatus
+  ruler: {
+    name: string
+    honorific?: string
+    characterSlug?: string
+    cosmetics?: Record<string, unknown>
+  }
+  turnCount: number
+  cyclePosition: number
+  kingdomHealth: KingdomHealth
+  counters: Record<string, number>
+  regionStates: Partial<Record<RegionKey, RegionState>>
+  regionOverrides: Partial<Record<RegionKey, RegionState>>
+  deckState: DeckState
+  inventory: { skills: InventoryReward[]; items: InventoryReward[] }
+  choiceLog: ChoiceLogEntry[]
+  flags: Record<string, boolean>
+  endingKey: string | null
+  createdAt: string // display metadata only — never read by game logic
+  updatedAt: string
+}
+
+// --- save index / slots (data-model.md §2.2) --------------------------------
+
+export interface SaveSlotMeta {
+  saveId: string
+  name: string
+  rulerName: string
+  createdAt: string
+  updatedAt: string
+  turnCount: number
+  status: LifeRunStatus
+  kingdomHealth: KingdomHealth
+}
+
+export interface SaveIndex {
+  schemaVersion: number
+  activeSaveId: string | null
+  slots: SaveSlotMeta[]
+}
+
+// --- compositor output (compositing.md §3) ----------------------------------
+
+export interface SceneState {
+  regionStates: Partial<Record<RegionKey, RegionState>>
+  time: TimeKey
+  fx: string[]
+}

--- a/types/ruler-hooked.ts
+++ b/types/ruler-hooked.ts
@@ -58,7 +58,8 @@ export interface RegionDef {
 }
 
 export interface RegionsManifest {
-  regions: Record<RegionKey, RegionDef>
+  // Partial: a theme/biome need not define every region (compositing.md §1).
+  regions: Partial<Record<RegionKey, RegionDef>>
 }
 
 // --- kingdom health (data-model.md §4) --------------------------------------

--- a/utils/rulerHooked/applyEffects.ts
+++ b/utils/rulerHooked/applyEffects.ts
@@ -1,0 +1,109 @@
+// utils/rulerHooked/applyEffects.ts
+//
+// The pure effects reducer (decks.md §6, data-model.md §8). The ONLY way content
+// mutates a save. Additive + clamped for sliders/counters (mirrors the davinci
+// server reducer server/utils/davinci.ts), never absolute, so effects compose and
+// stay legible. Deterministic and side-effect-free: returns a new RunSave, never
+// mutates the input, and records the applied effect into choiceLog as the audit
+// trail (so a run reconstructs even if the card's authored effects later change).
+
+import type { AxisKey, Card, Choice, Effect, RunSave } from '~/types/ruler-hooked'
+import { AXIS_KEYS } from '~/types/ruler-hooked'
+
+const clamp = (n: number, lo = 0, hi = 100): number =>
+  Math.max(lo, Math.min(hi, n))
+
+/** Deep-ish clone of a RunSave (plain JSON data — safe to structuredClone-lite). */
+export function cloneSave(save: RunSave): RunSave {
+  return JSON.parse(JSON.stringify(save)) as RunSave
+}
+
+function isAxis(key: string): key is AxisKey {
+  return (AXIS_KEYS as readonly string[]).includes(key)
+}
+
+/** Apply one Effect to a save in place (caller owns the clone). */
+export function applyEffect(save: RunSave, effect: Effect): void {
+  if (effect.sliders) {
+    for (const [axis, delta] of Object.entries(effect.sliders)) {
+      if (delta == null || !isAxis(axis)) continue
+      save.kingdomHealth[axis] = clamp((save.kingdomHealth[axis] ?? 0) + delta)
+    }
+  }
+  if (effect.counters) {
+    for (const [key, delta] of Object.entries(effect.counters)) {
+      if (delta == null) continue
+      save.counters[key] = (save.counters[key] ?? 0) + delta
+    }
+  }
+  if (effect.regionOverride) {
+    for (const [region, state] of Object.entries(effect.regionOverride)) {
+      if (state == null) continue
+      ;(save.regionOverrides as Record<string, string>)[region] = state
+    }
+  }
+  if (effect.flags) {
+    for (const f of effect.flags.set ?? []) save.flags[f] = true
+    for (const f of effect.flags.clear ?? []) save.flags[f] = false
+  }
+  if (effect.grant) {
+    for (const g of effect.grant) {
+      const bucket = save.inventory.items // default; caller may re-bucket by RewardType
+      if (!bucket.some((r) => r.slug === g.reward)) {
+        bucket.push({ slug: g.reward, rarity: 'COMMON' })
+      }
+    }
+  }
+  if (effect.revoke) {
+    save.inventory.items = save.inventory.items.filter(
+      (r) => !effect.revoke!.includes(r.slug),
+    )
+    save.inventory.skills = save.inventory.skills.filter(
+      (r) => !effect.revoke!.includes(r.slug),
+    )
+  }
+  if (effect.arc) {
+    const { start, advance, complete } = effect.arc
+    if (start && !save.deckState.activeArcs[start]) {
+      save.deckState.activeArcs[start] = { step: '', flags: {} }
+    }
+    if (advance) {
+      // advance names the NEXT step id; find the owning arc and set its step.
+      for (const arcId of Object.keys(save.deckState.activeArcs)) {
+        save.deckState.activeArcs[arcId].step = advance
+      }
+    }
+    if (complete) delete save.deckState.activeArcs[complete]
+  }
+  if (effect.ending) {
+    save.endingKey = effect.ending
+    save.status = 'COMPLETE'
+  }
+}
+
+/**
+ * Resolve a player's choice on a card: apply its effects, append the choiceLog
+ * entry, and return a new save. Pure — the input save is never mutated.
+ */
+export function resolveChoice(
+  save: RunSave,
+  card: Card,
+  choice: Choice,
+): RunSave {
+  const next = cloneSave(save)
+  const effect: Effect = choice.effects ?? {}
+  applyEffect(next, effect)
+  next.choiceLog.push({
+    turn: next.turnCount,
+    cardId: card.id,
+    prompt: card.title,
+    choiceText: choice.text,
+    effects: effect,
+    resultText: choice.result,
+  })
+  if (!next.deckState.seenCardIds.includes(card.id)) {
+    next.deckState.seenCardIds.push(card.id)
+  }
+  next.updatedAt = save.updatedAt // stamped by the caller/store, not game logic
+  return next
+}

--- a/utils/rulerHooked/compositor.ts
+++ b/utils/rulerHooked/compositor.ts
@@ -1,0 +1,98 @@
+// utils/rulerHooked/compositor.ts
+//
+// The scene compositor (compositing.md §3–§5). Pure function of the save:
+//   - resolveScene(save, manifest) → the committed visual state per region + the
+//     time-of-day, deterministic so the same save always renders the same frame.
+//   - rampState() maps a slider value to a region state by even thresholding.
+//   - cyclePosition() advances a cosmetic day/night cycle by TURNS, never a clock.
+//   - assetPath() resolves {region}-{state}-{time} with the graceful fallback
+//     ladder (compositing.md §4.2) so the variant matrix never has to be exhaustive.
+
+import type {
+  RegionKey,
+  RegionState,
+  RegionsManifest,
+  RunSave,
+  SceneState,
+  TimeKey,
+} from '~/types/ruler-hooked'
+
+/** Even-threshold a 0..100 slider value across an ordered ramp (compositing.md §3). */
+export function rampState(value: number, ramp: RegionState[]): RegionState {
+  if (ramp.length === 0) return ''
+  const band = 100 / ramp.length
+  const idx = Math.max(0, Math.min(ramp.length - 1, Math.floor(value / band)))
+  return ramp[idx]
+}
+
+/**
+ * A cosmetic cycle position derived from turnCount. Pure presentation — NOTHING
+ * keys off it (data-model.md time pillar). Sequence: day → golden → dusk → night
+ * → dawn → (day). Treats (golden/dawn/dusk) occupy one step each.
+ */
+const CYCLE: TimeKey[] = ['day', 'golden', 'dusk', 'night', 'dawn']
+export function cyclePosition(turnCount: number): number {
+  return ((turnCount % CYCLE.length) + CYCLE.length) % CYCLE.length
+}
+export function cycleTime(turnCount: number): TimeKey {
+  return CYCLE[cyclePosition(turnCount)]
+}
+
+/**
+ * Resolve the committed scene: each region's state = its event override (if pinned)
+ * else its ramp state from the driver slider; plus the time and any active fx.
+ */
+export function resolveScene(
+  save: RunSave,
+  manifest: RegionsManifest,
+): SceneState {
+  const regionStates: Partial<Record<RegionKey, RegionState>> = {}
+  for (const key of Object.keys(manifest.regions) as RegionKey[]) {
+    const def = manifest.regions[key]
+    const override = save.regionOverrides[key]
+    if (override !== undefined) {
+      regionStates[key] = override
+    } else if (def.driver) {
+      const val = save.kingdomHealth[def.driver.slider] ?? 0
+      regionStates[key] = rampState(val, def.driver.ramp)
+    } else if (def.states.length > 0) {
+      // single/first-state region (e.g. sky/lake are time-led)
+      regionStates[key] = save.regionStates[key] ?? def.states[0]
+    }
+  }
+  const fx: string[] = []
+  return { regionStates, time: cycleTime(save.turnCount), fx }
+}
+
+/**
+ * Asset filename for a resolved (region, state, time), following the naming
+ * contract {region}-{state}[-{time}].webp (compositing.md §4.3). Returns the
+ * ordered fallback candidates (exact → settle-neighbour → base) so the caller's
+ * <img> onError ladder can degrade gracefully instead of showing a hole.
+ */
+const SETTLE: Record<TimeKey, TimeKey> = {
+  day: 'day',
+  night: 'night',
+  dawn: 'day',
+  golden: 'day',
+  dusk: 'night',
+}
+export function assetCandidates(
+  region: RegionKey,
+  state: RegionState | undefined,
+  time: TimeKey,
+  dir = '/images/ruler-hooked',
+): string[] {
+  const base = state ? `${region}-${state}` : `${region}`
+  const settle = SETTLE[time]
+  const names = [
+    `${base}-${time}`, // exact
+    `${base}-${settle}`, // treat → nearest settle
+    base, // time-agnostic
+  ]
+  // de-dupe while preserving order
+  const seen = new Set<string>()
+  return names
+    .filter((n) => (seen.has(n) ? false : (seen.add(n), true)))
+    .map((n) => `${dir}/${n}.webp`)
+}

--- a/utils/rulerHooked/compositor.ts
+++ b/utils/rulerHooked/compositor.ts
@@ -49,6 +49,7 @@ export function resolveScene(
   const regionStates: Partial<Record<RegionKey, RegionState>> = {}
   for (const key of Object.keys(manifest.regions) as RegionKey[]) {
     const def = manifest.regions[key]
+    if (!def) continue
     const override = save.regionOverrides[key]
     if (override !== undefined) {
       regionStates[key] = override

--- a/utils/rulerHooked/engine.selftest.ts
+++ b/utils/rulerHooked/engine.selftest.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import { makeRng, hashSeed } from '~/utils/rulerHooked/seed'
+import { applyEffect, resolveChoice, cloneSave } from '~/utils/rulerHooked/applyEffects'
+import { triggerHolds, effectiveWeight } from '~/utils/rulerHooked/triggers'
+import { rampState, resolveScene, cycleTime, assetCandidates } from '~/utils/rulerHooked/compositor'
+import { eligiblePool, weightedPick, selectCard, tickCooldowns } from '~/utils/rulerHooked/select'
+import type { Card, RegionsManifest, RunSave } from '~/types/ruler-hooked'
+
+function baseSave(): RunSave {
+  return {
+    schemaVersion: 3, saveId: 'sv_test', name: 'Test', dreamSlug: 'ruler-hooked',
+    contentVersion: '2026.07', seed: 'mo-4820', status: 'ACTIVE',
+    ruler: { name: 'Mo', honorific: 'Queen' },
+    turnCount: 5, cyclePosition: 0,
+    kingdomHealth: { nature: 90, prosperity: 40, treasury: 55, joy: 72, order: 48 },
+    counters: { fishCaught: 3, warlockFavors: 0 },
+    regionStates: {}, regionOverrides: {},
+    deckState: { seenCardIds: [], activeArcs: {}, cooldowns: {}, drawBag: [] },
+    inventory: { skills: [], items: [] },
+    choiceLog: [], flags: {}, endingKey: null,
+    createdAt: 'x', updatedAt: 'x',
+  }
+}
+
+// 1. RNG determinism + resume
+{
+  assert.equal(hashSeed('mo'), hashSeed('mo'), 'hash stable')
+  const a = makeRng('mo-4820'); const b = makeRng('mo-4820')
+  const seqA = [a.next(), a.next(), a.next()]
+  const seqB = [b.next(), b.next(), b.next()]
+  assert.deepEqual(seqA, seqB, 'same seed -> same sequence')
+  const c = makeRng('mo-4820'); c.next()
+  const resumed = makeRng(0, c.state()) // resume from mid-stream state
+  assert.equal(resumed.next(), a === b ? c.next() : c.next(), 'state resume continues stream')
+  assert.notDeepEqual(makeRng('other').next(), seqA[0], 'different seed differs')
+}
+
+// 2. Reducer: additive + clamp, flags, override, ending, purity
+{
+  const s = baseSave()
+  applyEffect(s, { sliders: { nature: +20, prosperity: -6 }, counters: { warlockFavors: +1 },
+    flags: { set: ['metWarlock'] }, regionOverride: { far_shore: 'industrial' } })
+  assert.equal(s.kingdomHealth.nature, 100, 'nature 90+20 clamps to 100')
+  assert.equal(s.kingdomHealth.prosperity, 34, 'prosperity 40-6=34')
+  assert.equal(s.counters.warlockFavors, 1, 'counter incremented')
+  assert.equal(s.flags.metWarlock, true, 'flag set')
+  assert.equal(s.regionOverrides.far_shore, 'industrial', 'region pinned')
+
+  const before = baseSave()
+  const card: Card = { id: 'warlock-druid-north', kind: 'interrupt', title: 'North Woods',
+    choices: [{ id: 'develop', text: 'Build', effects: { sliders: { nature: -20 }, ending: undefined } }] }
+  const after = resolveChoice(before, card, card.choices[0])
+  assert.equal(before.kingdomHealth.nature, 90, 'input save NOT mutated (purity)')
+  assert.equal(after.kingdomHealth.nature, 70, 'choice applied on clone')
+  assert.equal(after.choiceLog.length, 1, 'choiceLog appended')
+  assert.equal(after.choiceLog[0].cardId, 'warlock-druid-north')
+  assert.ok(after.deckState.seenCardIds.includes('warlock-druid-north'), 'card marked seen')
+
+  const fin = cloneSave(baseSave())
+  applyEffect(fin, { ending: 'druid-utopia' })
+  assert.equal(fin.status, 'COMPLETE', 'ending sets COMPLETE')
+  assert.equal(fin.endingKey, 'druid-utopia')
+}
+
+// 3. Triggers
+{
+  const s = baseSave()
+  assert.equal(triggerHolds(s, { minTurn: 3, requires: { sliders: { nature: { gte: 30 } } } }), true)
+  assert.equal(triggerHolds(s, { minTurn: 99 }), false, 'minTurn gates on turnCount')
+  s.flags.northWoodsSettled = true
+  assert.equal(triggerHolds(s, { forbids: { flags: ['northWoodsSettled'] } }), false, 'forbids blocks')
+  assert.equal(effectiveWeight(s, { weightBonus: { when: { sliders: { joy: { gte: 70 } } }, add: 4 } }, 1), 5)
+}
+
+// 4. Compositor
+{
+  assert.equal(rampState(0, ['wild', 'tended', 'logged', 'overbuilt']), 'wild')
+  assert.equal(rampState(60, ['wild', 'tended', 'logged', 'overbuilt']), 'logged')
+  assert.equal(rampState(100, ['wild', 'tended', 'logged', 'overbuilt']), 'overbuilt')
+  const manifest: RegionsManifest = { regions: {
+    treeline: { z: 2, driver: { slider: 'nature', ramp: ['wild', 'tended', 'logged', 'overbuilt'] }, states: [] },
+    far_shore: { z: 1, states: ['pristine', 'industrial'] },
+  } }
+  const s = baseSave(); s.regionOverrides.far_shore = 'industrial'
+  const scene = resolveScene(s, manifest)
+  assert.equal(scene.regionStates.treeline, 'overbuilt', 'nature 90 -> overbuilt via ramp')
+  assert.equal(scene.regionStates.far_shore, 'industrial', 'override wins over anything')
+  assert.equal(cycleTime(0), 'day'); assert.equal(cycleTime(3), 'night')
+  const cands = assetCandidates('treeline', 'wild', 'golden')
+  assert.deepEqual(cands, [
+    '/images/ruler-hooked/treeline-wild-golden.webp',
+    '/images/ruler-hooked/treeline-wild-day.webp',
+    '/images/ruler-hooked/treeline-wild.webp',
+  ], 'golden falls back to day settle then base')
+}
+
+// 5. Selection determinism + gating
+{
+  const cards: Card[] = [
+    { id: 'a', kind: 'interrupt', title: 'A', weight: 1, choices: [] },
+    { id: 'b', kind: 'interrupt', title: 'B', weight: 3, choices: [] },
+    { id: 'arc', kind: 'arc-step', title: 'Arc', choices: [] },
+    { id: 'once', kind: 'ambient', title: 'Once', once: true, choices: [] },
+  ]
+  const s = baseSave()
+  const pool = eligiblePool(s, cards)
+  assert.ok(!pool.some((c) => c.kind === 'arc-step'), 'arc-step excluded from free draw')
+  s.deckState.seenCardIds.push('once')
+  assert.ok(!eligiblePool(s, cards).some((c) => c.id === 'once'), 'once+seen excluded')
+  s.deckState.cooldowns.a = 2
+  assert.ok(!eligiblePool(s, cards).some((c) => c.id === 'a'), 'cooldown excluded')
+  tickCooldowns(s); assert.equal(s.deckState.cooldowns.a, 1, 'cooldown ticks down')
+
+  // deterministic pick: same seed -> same choice
+  const p1 = weightedPick(baseSave(), cards.filter((c) => c.kind === 'interrupt'), makeRng('seedX'))
+  const p2 = weightedPick(baseSave(), cards.filter((c) => c.kind === 'interrupt'), makeRng('seedX'))
+  assert.equal(p1?.id, p2?.id, 'weightedPick deterministic per seed')
+  const s2 = baseSave()
+  const r1 = selectCard(s2, cards, makeRng('t5'))
+  const r2 = selectCard(s2, cards, makeRng('t5'))
+  assert.equal(r1?.id ?? null, r2?.id ?? null, 'selectCard deterministic per seed (replay==reload)')
+}
+
+console.log('ruler-hooked engine self-test: ALL PASS')

--- a/utils/rulerHooked/seed.ts
+++ b/utils/rulerHooked/seed.ts
@@ -1,0 +1,51 @@
+// utils/rulerHooked/seed.ts
+//
+// Deterministic RNG for "The Ruler is Hooked" (data-model.md §0.5). A save's
+// `seed` + its choiceLog fully reconstruct a run, and the compositor is a pure
+// function of the save — so replay and reload always match. This is the single
+// interface all randomness goes through (`nextRandom(stream)`), which is what
+// makes the Unreal port a one-file swap to FRandomStream (unreal-migration.md §7).
+//
+// Framework-free, no imports.
+
+export interface RngStream {
+  /** Next float in [0, 1). Mutates the stream's internal state. */
+  next(): number
+  /** Integer in [0, n). */
+  int(n: number): number
+  /** Current 32-bit state — serialize alongside the save to resume mid-run. */
+  state(): number
+}
+
+/** FNV-1a 32-bit hash of a string → a stable numeric seed. */
+export function hashSeed(seed: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    // 32-bit FNV prime multiply
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/** mulberry32 — small, fast, well-distributed 32-bit PRNG. */
+export function makeRng(seed: string | number, startState?: number): RngStream {
+  let s =
+    startState !== undefined
+      ? startState >>> 0
+      : typeof seed === 'number'
+        ? seed >>> 0
+        : hashSeed(seed)
+  const next = (): number => {
+    s = (s + 0x6d2b79f5) >>> 0
+    let t = s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+  return {
+    next,
+    int: (n: number) => Math.floor(next() * Math.max(1, n)),
+    state: () => s >>> 0,
+  }
+}

--- a/utils/rulerHooked/select.ts
+++ b/utils/rulerHooked/select.ts
@@ -1,0 +1,63 @@
+// utils/rulerHooked/select.ts
+//
+// The seeded card-selection engine (decks.md §5). Deterministic given the save's
+// RNG stream, so "replay variety" and "reload parity" are the same mechanism.
+// Pure over (save, cards, rng); rng is advanced as draws are made.
+
+import type { Card, RunSave } from '~/types/ruler-hooked'
+import type { RngStream } from './seed'
+import { effectiveWeight, triggerHolds } from './triggers'
+
+/** Cards eligible to fire this turn: trigger holds, not on cooldown, and — if
+ *  `once` — not already seen. Arc-step cards are excluded (they fire via arcs). */
+export function eligiblePool(save: RunSave, cards: Card[]): Card[] {
+  const seen = new Set(save.deckState.seenCardIds)
+  return cards.filter((c) => {
+    if (c.kind === 'arc-step') return false
+    if (c.once && seen.has(c.id)) return false
+    if ((save.deckState.cooldowns[c.id] ?? 0) > 0) return false
+    return triggerHolds(save, c.trigger)
+  })
+}
+
+/** Seeded weighted pick from a non-empty pool. Returns null for an empty pool. */
+export function weightedPick(
+  save: RunSave,
+  pool: Card[],
+  rng: RngStream,
+): Card | null {
+  if (pool.length === 0) return null
+  const weights = pool.map((c) => effectiveWeight(save, c.trigger, c.weight ?? 1))
+  const total = weights.reduce((a, b) => a + b, 0)
+  if (total <= 0) return null
+  let roll = rng.next() * total
+  for (let i = 0; i < pool.length; i++) {
+    roll -= weights[i]
+    if (roll < 0) return pool[i]
+  }
+  return pool[pool.length - 1]
+}
+
+/**
+ * Decide the card that fires this turn (or null for a pure-fishing turn).
+ * `interruptChance` in [0,1] gates whether an interrupt is attempted at all.
+ * Arc advancement is handled by the caller (it needs the arc catalog); this
+ * function covers the free-draw interrupt/ambient path.
+ */
+export function selectCard(
+  save: RunSave,
+  cards: Card[],
+  rng: RngStream,
+  interruptChance = 0.5,
+): Card | null {
+  if (rng.next() >= interruptChance) return null
+  const pool = eligiblePool(save, cards)
+  return weightedPick(save, pool, rng)
+}
+
+/** Decrement all per-card cooldowns by one turn (never below zero). */
+export function tickCooldowns(save: RunSave): void {
+  for (const id of Object.keys(save.deckState.cooldowns)) {
+    save.deckState.cooldowns[id] = Math.max(0, save.deckState.cooldowns[id] - 1)
+  }
+}

--- a/utils/rulerHooked/triggers.ts
+++ b/utils/rulerHooked/triggers.ts
@@ -1,0 +1,105 @@
+// utils/rulerHooked/triggers.ts
+//
+// The closed trigger predicate evaluator (decks.md §3). Pure over a RunSave, with
+// NO wall-clock input — turns only. Deliberately small and inspectable: numeric
+// comparators over sliders/counters, set membership over flags/rewards/cardsSeen.
+// `chance` is NOT evaluated here (it's a seeded roll owned by selection).
+
+import type {
+  NumericPredicate,
+  RunSave,
+  Trigger,
+  TriggerClause,
+} from '~/types/ruler-hooked'
+
+export function numericHolds(value: number, pred: NumericPredicate): boolean {
+  if (pred.gte !== undefined && !(value >= pred.gte)) return false
+  if (pred.gt !== undefined && !(value > pred.gt)) return false
+  if (pred.lte !== undefined && !(value <= pred.lte)) return false
+  if (pred.lt !== undefined && !(value < pred.lt)) return false
+  if (pred.eq !== undefined && !(value === pred.eq)) return false
+  if (pred.neq !== undefined && !(value !== pred.neq)) return false
+  return true
+}
+
+function ownedRewards(save: RunSave): Set<string> {
+  const s = new Set<string>()
+  for (const r of save.inventory.skills) s.add(r.slug)
+  for (const r of save.inventory.items) s.add(r.slug)
+  return s
+}
+
+/** True if EVERY condition in the clause holds against the save. */
+export function clauseHolds(save: RunSave, clause: TriggerClause): boolean {
+  if (clause.sliders) {
+    for (const [axis, pred] of Object.entries(clause.sliders)) {
+      if (!pred) continue
+      if (!numericHolds(save.kingdomHealth[axis as never] ?? 0, pred)) return false
+    }
+  }
+  if (clause.counters) {
+    for (const [key, pred] of Object.entries(clause.counters)) {
+      if (!numericHolds(save.counters[key] ?? 0, pred)) return false
+    }
+  }
+  if (clause.flags) {
+    for (const f of clause.flags) if (!save.flags[f]) return false
+  }
+  if (clause.rewards) {
+    const owned = ownedRewards(save)
+    for (const r of clause.rewards) if (!owned.has(r)) return false
+  }
+  if (clause.cardsSeen) {
+    const seen = new Set(save.deckState.seenCardIds)
+    for (const c of clause.cardsSeen) if (!seen.has(c)) return false
+  }
+  return true
+}
+
+/** True if ANY condition in the clause holds (used for `forbids`). */
+export function clauseTouches(save: RunSave, clause: TriggerClause): boolean {
+  if (clause.flags) {
+    for (const f of clause.flags) if (save.flags[f]) return true
+  }
+  if (clause.cardsSeen) {
+    const seen = new Set(save.deckState.seenCardIds)
+    for (const c of clause.cardsSeen) if (seen.has(c)) return true
+  }
+  if (clause.rewards) {
+    const owned = ownedRewards(save)
+    for (const r of clause.rewards) if (owned.has(r)) return true
+  }
+  if (clause.sliders) {
+    for (const [axis, pred] of Object.entries(clause.sliders)) {
+      if (pred && numericHolds(save.kingdomHealth[axis as never] ?? 0, pred)) return true
+    }
+  }
+  if (clause.counters) {
+    for (const [key, pred] of Object.entries(clause.counters)) {
+      if (numericHolds(save.counters[key] ?? 0, pred)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Whether a trigger is currently satisfied (ignoring `chance`, and ignoring the
+ * per-card cooldown which selection tracks separately via deckState.cooldowns).
+ */
+export function triggerHolds(save: RunSave, trigger?: Trigger): boolean {
+  if (!trigger) return true
+  if (trigger.minTurn !== undefined && save.turnCount < trigger.minTurn) return false
+  if (trigger.maxTurn !== undefined && save.turnCount > trigger.maxTurn) return false
+  if (trigger.requires && !clauseHolds(save, trigger.requires)) return false
+  if (trigger.forbids && clauseTouches(save, trigger.forbids)) return false
+  return true
+}
+
+/** Effective draw weight including any satisfied situational bonus (decks.md §5). */
+export function effectiveWeight(save: RunSave, trigger?: Trigger, base = 1): number {
+  let w = base
+  if (trigger?.weightBonus && clauseHolds(save, trigger.weightBonus.when)) {
+    w += trigger.weightBonus.add
+  }
+  return Math.max(0, w)
+}


### PR DESCRIPTION
### Task
Cross-repo: conductor **ruler-hooked/t-007** — build the offline slideshow fishing/kingdom PoC. This PR lands **Phase 1 (the foundation)**: the pure, framework-free game engine + type contracts. The Vue play-screen (store + components + content bundle) is Phase 2, tracked as conductor t-012.

### What changed / what I produced (all new, self-contained)
- `types/ruler-hooked.ts` — framework-free interfaces mirroring the merged conductor design specs (`data-model.md` / `compositing.md` / `decks.md`): `RunSave`, `SaveIndex`, `SceneState`, `RegionsManifest`, `Card`/`Deck`/`Arc`/`Effect`/`Trigger`, `ContentBundle`, `Ending`. Vocabulary matches the kind_robots models it can sync to (`LifeRunStatus`, `RewardType`, `Rarity`).
- `utils/rulerHooked/`:
  - `seed.ts` — mulberry32 RNG behind one `RngStream` interface (deterministic; a future Unreal port swaps to `FRandomStream`).
  - `applyEffects.ts` — the pure, additive-and-clamped effects reducer + `resolveChoice` (appends the audit `choiceLog`, never mutates the input). Mirrors the server-side `server/utils/davinci.ts` additive pattern.
  - `triggers.ts` — the closed predicate evaluator (numeric comparators + set membership; **no wall-clock input**, turns only) + `effectiveWeight`.
  - `compositor.ts` — `resolveScene` (ramp-from-slider + event override), turn-driven `cycleTime`, and the `{region}-{state}-{time}` asset fallback ladder.
  - `select.ts` — seeded eligible-pool + weighted pick; deterministic so replay == reload.
  - `engine.selftest.ts` — runtime assertions (run via `npx tsx`).

Nothing existing is touched; these are all additive new files under `types/` and `utils/rulerHooked/`. No routes, components, stores, or server code change in this PR.

### How I verified
- **Strict isolated typecheck** (`tsc --noEmit`, `strict: true`, bundler resolution matching this repo's tsconfig) over `types/ruler-hooked.ts` + `utils/rulerHooked/*.ts` → **exit 0, no errors**. This caught a real design bug mid-review — `RegionsManifest.regions` is now `Partial<Record<RegionKey, RegionDef>>` (a biome needn't define every region) with a guard in `resolveScene`.
- **Runtime self-test** (`engine.selftest.ts` via tsx) → **ALL PASS**: RNG determinism + mid-stream resume; reducer additive/clamp/purity; `ending → COMPLETE`; trigger requires/forbids/weightBonus; ramp + override compositing; asset fallback (golden → day-settle → base); seeded selection gating (arc-step/once/cooldown exclusion; deterministic pick).

### Flags for Reviewer
- **The full `npm run test` (vue-tsc) gate was NOT run in-session:** the kind_robots toolchain (`nuxi prepare` + `vue-tsc --max-old-space-size=8192`) OOM-restarts this sandbox. These modules are pure, framework-free TypeScript with no Nuxt globals, verified in isolation under strict mode instead. **Please let CI run the full vue-tsc pass to confirm** — I expect green, but couldn't self-run the repo's exact gate.
- `engine.selftest.ts` is committed for reproducibility; it's a `tsx` script, not part of the vue-tsc-only `npm run test`. Run it with `npx tsx utils/rulerHooked/engine.selftest.ts`.
- Grounded in the reuse map from recon: the reducer mirrors `server/utils/davinci.ts`; Phase 2 will use the `stores/compositionStore.ts` localStorage helpers, `swipe-deck.vue` / `single-slider.vue`, and the `ruler-hooked-page.vue` `#interactive` slot.

### Stakes
reversible (additive new modules; not imported by any live route yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Rmy2RDNY4S5469y6fGf94

---
_Generated by [Claude Code](https://claude.ai/code/session_017Rmy2RDNY4S5469y6fGf94)_