### PR TITLE
ai-art-academy/t-010: fix stale century-span copy in Academy loading text

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -9,7 +9,7 @@
         <span class="loading loading-spinner loading-lg text-primary" />
         <p class="text-sm text-base-content/70">
           Dusting off the timeline, warming up the remix engine, and politely
-          waking five centuries of dead masters...
+          waking twenty-five centuries of dead masters...
         </p>
       </div>
     </div>

--- a/content/academy.md
+++ b/content/academy.md
@@ -2,7 +2,7 @@
 title: 'Art Academy'
 room: 'Art Academy'
 subtitle: 'Learn the styles. Meet the masters. Remix everything.'
-description: Explore twenty-five centuries of public-domain art history, then remix your own images in any style you learn — from Greek vases to De Stijl grids.
+description: Explore twenty-five centuries of public-domain art history, then remix your own images in any style you learn — from Greek vases to Bauhaus grids.
 image: 'background/artgallery.webp'
 icon: kind-icon:palette
 tooltip: Art history lessons with a remix button. The masters would approve. Probably.


### PR DESCRIPTION
## Summary
- `academy-manager.vue`'s loading spinner said "politely waking five centuries of dead masters" — stale copy from before the curriculum grew to 21 movements spanning ~25 centuries (Greek vase painting c. 600 BCE through Bauhaus 1919–1933).
- `content/academy.md`'s description said "from Greek vases to De Stijl grids" — Bauhaus (ends 1933) is now the chronologically last movement in `stores/seeds/academyStyles.ts`, after De Stijl (ends 1931).
- Both now match the already-correct "twenty-five centuries" copy in `academy-timeline.vue`'s header.

conductor/ai-art-academy/t-010 (recurring continuous-improvement pass), option (a) front-end polish.

## Test plan
- [x] `prettier --check` clean on both changed files
- [x] Copy-only change, no logic touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01RcmDmraLWUsGRDasdZPFHZ)_