### PR TITLE
fix(api): replace and clear character/scenario relationships

### DIFF
--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -1,5 +1,5 @@
 // /server/api/characters/[id].patch.ts
-import { defineEventHandler, createError, getRouterParam, readBody } from 'h3'
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
@@ -12,21 +12,46 @@ import {
 import type { Character, Prisma } from '~/prisma/generated/prisma/client'
 
 type CharacterPatchBody = Partial<Character> & {
-  rewardIds?: number[]
-  scenarioIds?: number[]
-  dreamIds?: number[]
+  rewardIds?: unknown
+  scenarioIds?: unknown
+  dreamIds?: unknown
 }
 
-function normalizeIdArray(value: unknown): number[] {
-  if (!Array.isArray(value)) return []
+function normalizePositiveIdArray(value: unknown, field: string): number[] {
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be an array of positive integer IDs.`,
+    })
+  }
 
-  return Array.from(
-    new Set(
-      value
-        .map((entry) => Number(entry))
-        .filter((entry) => Number.isInteger(entry) && entry > 0),
-    ),
-  )
+  const ids = value.map((entry) => Number(entry))
+
+  if (!ids.every((entry) => Number.isInteger(entry) && entry > 0)) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must contain only positive integer IDs.`,
+    })
+  }
+
+  return [...new Set(ids)]
+}
+
+function normalizeArtImageRelation(
+  value: unknown,
+): Prisma.ArtImageUpdateOneWithoutCharactersNestedInput {
+  if (value === null || value === '') return { disconnect: true }
+
+  const id = Number(value)
+
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'artImageId must be a positive integer or null when provided.',
+    })
+  }
+
+  return { connect: { id } }
 }
 
 function getStringOrUndefined(value: unknown): string | undefined {
@@ -44,12 +69,72 @@ function getBooleanOrUndefined(value: unknown): boolean | undefined {
 }
 
 function getNumberOrUndefined(value: unknown): number | undefined {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return undefined
+  }
+
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
 function hasUpdateData(data: Record<string, unknown>): boolean {
   return Object.values(data).some((value) => value !== undefined)
+}
+
+async function assertRelatedRecordsExist(options: {
+  rewardIds?: number[]
+  scenarioIds?: number[]
+  dreamIds?: number[]
+}) {
+  const { rewardIds, scenarioIds, dreamIds } = options
+
+  if (rewardIds?.length) {
+    const records = await prisma.reward.findMany({
+      where: { id: { in: rewardIds } },
+      select: { id: true },
+    })
+    const foundIds = new Set(records.map((record) => record.id))
+    const missingIds = rewardIds.filter((id) => !foundIds.has(id))
+
+    if (missingIds.length) {
+      throw createError({
+        statusCode: 404,
+        message: `Reward IDs not found: ${missingIds.join(', ')}.`,
+      })
+    }
+  }
+
+  if (scenarioIds?.length) {
+    const records = await prisma.scenario.findMany({
+      where: { id: { in: scenarioIds } },
+      select: { id: true },
+    })
+    const foundIds = new Set(records.map((record) => record.id))
+    const missingIds = scenarioIds.filter((id) => !foundIds.has(id))
+
+    if (missingIds.length) {
+      throw createError({
+        statusCode: 404,
+        message: `Scenario IDs not found: ${missingIds.join(', ')}.`,
+      })
+    }
+  }
+
+  if (dreamIds?.length) {
+    const records = await prisma.dream.findMany({
+      where: { id: { in: dreamIds } },
+      select: { id: true },
+    })
+    const foundIds = new Set(records.map((record) => record.id))
+    const missingIds = dreamIds.filter((id) => !foundIds.has(id))
+
+    if (missingIds.length) {
+      throw createError({
+        statusCode: 404,
+        message: `Dream IDs not found: ${missingIds.join(', ')}.`,
+      })
+    }
+  }
 }
 
 export default defineEventHandler(async (event) => {
@@ -152,15 +237,24 @@ export default defineEventHandler(async (event) => {
       nextSlug = await getUniqueCharacterSlug(
         prisma,
         nextName ?? existingCharacter.name,
-        {
-          excludeId: id,
-        },
+        { excludeId: id },
       )
     }
 
-    const rewardIds = normalizeIdArray(body.rewardIds)
-    const scenarioIds = normalizeIdArray(body.scenarioIds)
-    const dreamIds = normalizeIdArray(body.dreamIds)
+    const rewardIds =
+      'rewardIds' in body
+        ? normalizePositiveIdArray(body.rewardIds, 'rewardIds')
+        : undefined
+    const scenarioIds =
+      'scenarioIds' in body
+        ? normalizePositiveIdArray(body.scenarioIds, 'scenarioIds')
+        : undefined
+    const dreamIds =
+      'dreamIds' in body
+        ? normalizePositiveIdArray(body.dreamIds, 'dreamIds')
+        : undefined
+
+    await assertRelatedRecordsExist({ rewardIds, scenarioIds, dreamIds })
 
     const updateData: Prisma.CharacterUpdateInput = {
       name: nextName,
@@ -193,31 +287,28 @@ export default defineEventHandler(async (event) => {
       grace: body.grace,
       charm: body.charm,
       empathy: body.empathy,
+    }
 
-      ArtImage:
-        typeof body.artImageId === 'number'
-          ? { connect: { id: body.artImageId } }
-          : body.artImageId === null
-            ? { disconnect: true }
-            : undefined,
+    if ('artImageId' in body) {
+      updateData.ArtImage = normalizeArtImageRelation(body.artImageId)
+    }
 
-      Rewards: rewardIds.length
-        ? {
-            connect: rewardIds.map((rewardId) => ({ id: rewardId })),
-          }
-        : undefined,
+    if (rewardIds) {
+      updateData.Rewards = {
+        set: rewardIds.map((rewardId) => ({ id: rewardId })),
+      }
+    }
 
-      Scenarios: scenarioIds.length
-        ? {
-            connect: scenarioIds.map((scenarioId) => ({ id: scenarioId })),
-          }
-        : undefined,
+    if (scenarioIds) {
+      updateData.Scenarios = {
+        set: scenarioIds.map((scenarioId) => ({ id: scenarioId })),
+      }
+    }
 
-      Dreams: dreamIds.length
-        ? {
-            connect: dreamIds.map((dreamId) => ({ id: dreamId })),
-          }
-        : undefined,
+    if (dreamIds) {
+      updateData.Dreams = {
+        set: dreamIds.map((dreamId) => ({ id: dreamId })),
+      }
     }
 
     if (!hasUpdateData(updateData as Record<string, unknown>)) {

--- a/server/api/scenarios/[id].patch.ts
+++ b/server/api/scenarios/[id].patch.ts
@@ -1,11 +1,13 @@
 // /server/api/scenarios/[id].patch.ts
-import { defineEventHandler, createError, readBody } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { normalizeSlugInput } from '~/utils/slugify'
-import { Prisma } from '~/prisma/generated/prisma/client'
-import type { ScenarioOutputType } from '~/prisma/generated/prisma/client'
+import type {
+  Prisma,
+  ScenarioOutputType,
+} from '~/prisma/generated/prisma/client'
 
 type ScenarioPatchInput = {
   title?: unknown
@@ -127,7 +129,6 @@ function normalizeBoolean(value: unknown, field: string): boolean {
 
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase()
-
     if (normalized === 'true') return true
     if (normalized === 'false') return false
   }
@@ -157,8 +158,6 @@ function normalizeNullableInteger(
 }
 
 function normalizePositiveIdArray(value: unknown, field: string): number[] {
-  if (typeof value === 'undefined') return []
-
   if (!Array.isArray(value)) {
     throw createError({
       statusCode: 400,
@@ -189,12 +188,10 @@ function normalizeIntros(value: unknown): string {
 
   if (typeof value === 'string') {
     const trimmed = value.trim()
-
     if (!trimmed) return '[]'
 
     try {
       const parsed = JSON.parse(trimmed)
-
       if (Array.isArray(parsed)) {
         return JSON.stringify(
           parsed.map((entry) => String(entry).trim()).filter(Boolean),
@@ -222,11 +219,7 @@ function normalizeIntros(value: unknown): string {
 function normalizeArtImageRelation(
   value: unknown,
 ): Prisma.ArtImageUpdateOneWithoutScenariosNestedInput {
-  if (value === null || value === '') {
-    return {
-      disconnect: true,
-    }
-  }
+  if (value === null || value === '') return { disconnect: true }
 
   const id = Number(value)
 
@@ -237,27 +230,22 @@ function normalizeArtImageRelation(
     })
   }
 
-  return {
-    connect: {
-      id,
-    },
-  }
+  return { connect: { id } }
 }
 
 async function assertRelatedRecordsExist(options: {
-  characterIds: number[]
-  compositionIds: number[]
-  dreamIds: number[]
+  characterIds?: number[]
+  compositionIds?: number[]
+  dreamIds?: number[]
 }) {
   const { characterIds, compositionIds, dreamIds } = options
 
-  if (characterIds.length) {
-    const characters = await prisma.character.findMany({
+  if (characterIds?.length) {
+    const records = await prisma.character.findMany({
       where: { id: { in: characterIds } },
       select: { id: true },
     })
-
-    const foundIds = new Set(characters.map((character) => character.id))
+    const foundIds = new Set(records.map((record) => record.id))
     const missingIds = characterIds.filter((id) => !foundIds.has(id))
 
     if (missingIds.length) {
@@ -268,13 +256,12 @@ async function assertRelatedRecordsExist(options: {
     }
   }
 
-  if (compositionIds.length) {
-    const compositions = await prisma.composition.findMany({
+  if (compositionIds?.length) {
+    const records = await prisma.composition.findMany({
       where: { id: { in: compositionIds } },
       select: { id: true },
     })
-
-    const foundIds = new Set(compositions.map((composition) => composition.id))
+    const foundIds = new Set(records.map((record) => record.id))
     const missingIds = compositionIds.filter((id) => !foundIds.has(id))
 
     if (missingIds.length) {
@@ -285,13 +272,12 @@ async function assertRelatedRecordsExist(options: {
     }
   }
 
-  if (dreamIds.length) {
-    const dreams = await prisma.dream.findMany({
+  if (dreamIds?.length) {
+    const records = await prisma.dream.findMany({
       where: { id: { in: dreamIds } },
       select: { id: true },
     })
-
-    const foundIds = new Set(dreams.map((dream) => dream.id))
+    const foundIds = new Set(records.map((record) => record.id))
     const missingIds = dreamIds.filter((id) => !foundIds.has(id))
 
     if (missingIds.length) {
@@ -314,15 +300,8 @@ async function buildScenarioUpdateInput(
     data.description = normalizeString(body.description, 'description')
   }
   if ('intros' in body) data.intros = normalizeIntros(body.intros)
-
-  if ('outputType' in body) {
-    data.outputType = normalizeOutputType(body.outputType)
-  }
-
-  if ('cast' in body) {
-    data.cast = normalizeJsonString(body.cast, 'cast')
-  }
-
+  if ('outputType' in body) data.outputType = normalizeOutputType(body.outputType)
+  if ('cast' in body) data.cast = normalizeJsonString(body.cast, 'cast')
   if ('imagePath' in body) {
     data.imagePath = normalizeNullableString(body.imagePath, 'imagePath')
   }
@@ -362,15 +341,18 @@ async function buildScenarioUpdateInput(
     data.ArtImage = normalizeArtImageRelation(body.artImageId)
   }
 
-  const characterIds = normalizePositiveIdArray(
-    body.characterIds,
-    'characterIds',
-  )
-  const compositionIds = normalizePositiveIdArray(
-    body.compositionIds,
-    'compositionIds',
-  )
-  const dreamIds = normalizePositiveIdArray(body.dreamIds, 'dreamIds')
+  const characterIds =
+    'characterIds' in body
+      ? normalizePositiveIdArray(body.characterIds, 'characterIds')
+      : undefined
+  const compositionIds =
+    'compositionIds' in body
+      ? normalizePositiveIdArray(body.compositionIds, 'compositionIds')
+      : undefined
+  const dreamIds =
+    'dreamIds' in body
+      ? normalizePositiveIdArray(body.dreamIds, 'dreamIds')
+      : undefined
 
   await assertRelatedRecordsExist({
     characterIds,
@@ -378,21 +360,21 @@ async function buildScenarioUpdateInput(
     dreamIds,
   })
 
-  if (characterIds.length) {
+  if (characterIds) {
     data.Characters = {
-      connect: characterIds.map((id) => ({ id })),
+      set: characterIds.map((id) => ({ id })),
     }
   }
 
-  if (compositionIds.length) {
+  if (compositionIds) {
     data.Compositions = {
-      connect: compositionIds.map((id) => ({ id })),
+      set: compositionIds.map((id) => ({ id })),
     }
   }
 
-  if (dreamIds.length) {
+  if (dreamIds) {
     data.Dreams = {
-      connect: dreamIds.map((id) => ({ id })),
+      set: dreamIds.map((id) => ({ id })),
     }
   }
 


### PR DESCRIPTION
## What changed

- Treat supplied relationship ID arrays as replacement instructions instead of additive-only connects.
- Use Prisma `set` for Character rewards/scenarios/dreams and Scenario characters/compositions/dreams.
- Allow empty arrays to intentionally clear relationships.
- Validate supplied arrays and related record existence before updating.
- Preserve scalar updates, ownership checks, response shapes, and relation includes.

## Root cause

The PATCH routes normalized omitted relationship arrays and supplied empty arrays to the same `[]` value, then only generated Prisma update data when the arrays had entries. Requests such as `{ "characterIds": [] }` therefore produced no update fields and returned `No valid scenario fields provided for update`. Non-empty lists were also additive via `connect`, despite the API shape behaving like replacement fields.

## Context

The MariaDB text-protocol change restored stable execution, but the latest production run still reports the same deterministic set of 96 application failures. This PR addresses two recurring relationship-update failures independently of the database transport work.

## Validation

- Confirmed generated Prisma nested input type for Character art-image updates exists.
- Draft PR opened to trigger Vercel/CI static validation.
- Production Cypress should be rerun against the preview after deployment completes.