### PR TITLE
fix(db): contain poisoned adapter pools with one-shot clients

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -20,11 +20,17 @@ type CircuitBreakerState = {
   openUntil: number
 }
 
+type DatabasePoolOverrides = {
+  connectionLimit?: number
+  idleTimeout?: number
+  minimumIdle?: number
+  minDelayValidation?: number
+}
+
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
   prismaBreaker?: CircuitBreakerState
-  prismaRecovery?: Promise<PrismaClient>
-  prismaGeneration?: number
+  prismaAdapterPoisoned?: boolean
 }
 
 const configuredDatabaseUrl = process.env.DATABASE_URL
@@ -148,14 +154,14 @@ function readDatabaseUseTextProtocol(): boolean {
   return raw !== 'false' && raw !== '0' && raw !== 'no'
 }
 
-function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
+function buildDatabaseConfig(
+  url: string,
+  overrides: DatabasePoolOverrides = {},
+): PrismaMariaDbPoolConfig {
   const resolvedUrl = buildDatabaseUrl(url)
+  const parsed = new URL(resolvedUrl)
   const sslCa = readDatabaseSslCa()
   const rejectUnauthorized = readSslRejectUnauthorized()
-
-  if (!sslCa && rejectUnauthorized) return resolvedUrl
-
-  const parsed = new URL(resolvedUrl)
   const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
   const tlsOptions: TlsConnectionOptions = rejectUnauthorized
     ? {
@@ -189,23 +195,31 @@ function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
       parsed.searchParams.get('acquireTimeout') ?? undefined,
       DEFAULT_ACQUIRE_TIMEOUT_MS,
     ),
-    connectionLimit: readPositiveInteger(
-      parsed.searchParams.get('connectionLimit') ?? undefined,
-      DEFAULT_CONNECTION_LIMIT,
-    ),
-    minDelayValidation: readNonNegativeInteger(
-      parsed.searchParams.get('minDelayValidation') ?? undefined,
-      0,
-    ),
-    idleTimeout: readPositiveInteger(
-      parsed.searchParams.get('idleTimeout') ?? undefined,
-      DEFAULT_IDLE_TIMEOUT_SECONDS,
-    ),
-    minimumIdle: readNonNegativeInteger(
-      parsed.searchParams.get('minimumIdle') ?? undefined,
-      DEFAULT_MINIMUM_IDLE,
-    ),
-    ssl: tlsOptions,
+    connectionLimit:
+      overrides.connectionLimit ??
+      readPositiveInteger(
+        parsed.searchParams.get('connectionLimit') ?? undefined,
+        DEFAULT_CONNECTION_LIMIT,
+      ),
+    minDelayValidation:
+      overrides.minDelayValidation ??
+      readNonNegativeInteger(
+        parsed.searchParams.get('minDelayValidation') ?? undefined,
+        0,
+      ),
+    idleTimeout:
+      overrides.idleTimeout ??
+      readPositiveInteger(
+        parsed.searchParams.get('idleTimeout') ?? undefined,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+      ),
+    minimumIdle:
+      overrides.minimumIdle ??
+      readNonNegativeInteger(
+        parsed.searchParams.get('minimumIdle') ?? undefined,
+        DEFAULT_MINIMUM_IDLE,
+      ),
+    ...(sslCa || !rejectUnauthorized ? { ssl: tlsOptions } : {}),
   }
 
   Object.assign(poolConfig, {
@@ -230,10 +244,6 @@ const unavailableDatabaseMessages = [
 const unavailableRetryAttempts = readNonNegativeInteger(
   process.env.DATABASE_TRANSIENT_RETRY_ATTEMPTS,
   1,
-)
-const staleConnectionRetryAttempts = readNonNegativeInteger(
-  process.env.DATABASE_STALE_CONNECTION_RETRY_ATTEMPTS,
-  2,
 )
 const transientRetryDelayMs = readPositiveInteger(
   process.env.DATABASE_TRANSIENT_RETRY_DELAY_MS,
@@ -306,25 +316,19 @@ function isAvailabilityError(error: unknown): boolean {
   return messageMatches(error, unavailableDatabaseMessages)
 }
 
-function retryLimitFor(error: unknown): number {
-  if (isStaleDatabaseConnectionError(error)) {
-    return staleConnectionRetryAttempts
-  }
-
-  if (isAvailabilityError(error)) return unavailableRetryAttempts
-  return 0
-}
-
 const delay = (milliseconds: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
 
 const useTextProtocol = readDatabaseUseTextProtocol()
 
-function createBasePrismaClient(): PrismaClient {
+function createPrismaClient(
+  poolOverrides: DatabasePoolOverrides = {},
+): PrismaClient {
   return new PrismaClient({
-    adapter: new PrismaMariaDb(buildDatabaseConfig(databaseUrl), {
-      useTextProtocol,
-    }),
+    adapter: new PrismaMariaDb(
+      buildDatabaseConfig(databaseUrl, poolOverrides),
+      { useTextProtocol },
+    ),
   })
 }
 
@@ -337,7 +341,10 @@ async function replayPrismaOperation(
   const delegateName = `${model.charAt(0).toLowerCase()}${model.slice(1)}`
   const delegate = (client as unknown as Record<string, unknown>)[delegateName]
 
-  if (!delegate || (typeof delegate !== 'object' && typeof delegate !== 'function')) {
+  if (
+    !delegate ||
+    (typeof delegate !== 'object' && typeof delegate !== 'function')
+  ) {
     throw new Error(`Unable to replay Prisma operation for model ${model}.`)
   }
 
@@ -352,45 +359,50 @@ async function replayPrismaOperation(
   ).call(delegate, args)
 }
 
-let activeBasePrisma = globalForPrisma.prisma ?? createBasePrismaClient()
-globalForPrisma.prisma = activeBasePrisma
+const oneShotPoolOverrides: DatabasePoolOverrides = {
+  connectionLimit: 1,
+  minimumIdle: 0,
+  idleTimeout: 1,
+  minDelayValidation: 0,
+}
 
-type RetryingPrismaClient = ReturnType<typeof extendPrismaClient>
-let activePrisma: RetryingPrismaClient
+async function runOneShotPrismaOperation(
+  model: string,
+  operation: string,
+  args: unknown,
+  reason: string,
+): Promise<unknown> {
+  const oneShotPrisma = createPrismaClient(oneShotPoolOverrides)
 
-async function recyclePrismaClient(reason: string): Promise<PrismaClient> {
-  const existingRecovery = globalForPrisma.prismaRecovery
-  if (existingRecovery) return await existingRecovery
-
-  const recovery = (async () => {
-    const replacement = createBasePrismaClient()
-    await replacement.$connect()
-
-    activeBasePrisma = replacement
-    globalForPrisma.prisma = replacement
-    activePrisma = extendPrismaClient(replacement)
-    globalForPrisma.prismaGeneration =
-      (globalForPrisma.prismaGeneration ?? 0) + 1
-
-    console.warn('[prisma:client-recycled]', {
-      generation: globalForPrisma.prismaGeneration,
-      reason,
-      mode: useTextProtocol ? 'text-query' : 'binary-execute',
-    })
-
-    return replacement
-  })()
-
-  globalForPrisma.prismaRecovery = recovery
+  console.warn('[prisma:one-shot-fallback]', {
+    model,
+    operation,
+    reason,
+    mode: useTextProtocol ? 'text-query' : 'binary-execute',
+  })
 
   try {
-    return await recovery
+    const result = await replayPrismaOperation(
+      oneShotPrisma,
+      model,
+      operation,
+      args,
+    )
+    recordConnectionSuccess()
+    return result
   } finally {
-    if (globalForPrisma.prismaRecovery === recovery) {
-      globalForPrisma.prismaRecovery = undefined
-    }
+    await oneShotPrisma.$disconnect().catch((disconnectError: unknown) => {
+      console.warn('[prisma:one-shot-disconnect-failed]', {
+        model,
+        operation,
+        message: errorMessage(disconnectError),
+      })
+    })
   }
 }
+
+const basePrisma = globalForPrisma.prisma ?? createPrismaClient()
+globalForPrisma.prisma = basePrisma
 
 function extendPrismaClient(client: PrismaClient) {
   return client.$extends({
@@ -401,26 +413,57 @@ function extendPrismaClient(client: PrismaClient) {
           throw new Error(CIRCUIT_OPEN_MESSAGE)
         }
 
-        let execute = () => query(args)
+        const transactionActive = transactionContext.getStore() === true
+
+        if (
+          globalForPrisma.prismaAdapterPoisoned &&
+          model &&
+          !transactionActive
+        ) {
+          return (await runOneShotPrismaOperation(
+            model,
+            operation,
+            args,
+            'shared adapter already marked poisoned',
+          )) as ReturnType<typeof query>
+        }
 
         for (let attempt = 0; ; attempt += 1) {
           try {
-            const result = await execute()
+            const result = await query(args)
             recordConnectionSuccess()
             return result
           } catch (error: unknown) {
             const availabilityError = isAvailabilityError(error)
             const staleConnectionError = isStaleDatabaseConnectionError(error)
-            const retryLimit = retryLimitFor(error)
 
-            if (availabilityError) {
-              recordAvailabilityFailure()
+            if (staleConnectionError) {
+              globalForPrisma.prismaAdapterPoisoned = true
+
+              console.warn('[prisma:adapter-poisoned]', {
+                model: model ?? 'raw',
+                operation,
+                transactionActive,
+                message: errorMessage(error),
+              })
+
+              if (!model || transactionActive) throw error
+
+              return (await runOneShotPrismaOperation(
+                model,
+                operation,
+                args,
+                `${model}.${operation}: ${errorMessage(error)}`,
+              )) as ReturnType<typeof query>
             }
 
+            if (!availabilityError) throw error
+
+            recordAvailabilityFailure()
+
             if (
-              (!availabilityError && !staleConnectionError) ||
-              attempt >= retryLimit ||
-              (availabilityError && circuitIsOpen())
+              attempt >= unavailableRetryAttempts ||
+              circuitIsOpen()
             ) {
               throw error
             }
@@ -431,32 +474,14 @@ function extendPrismaClient(client: PrismaClient) {
             console.warn('[prisma:transient-retry]', {
               model: model ?? 'raw',
               operation,
-              kind: staleConnectionError ? 'stale-connection' : 'unavailable',
+              kind: 'unavailable',
               retry: retryNumber,
-              maxRetries: retryLimit,
+              maxRetries: unavailableRetryAttempts,
               waitMs,
               message: errorMessage(error),
             })
 
             await delay(waitMs)
-
-            if (staleConnectionError && model) {
-              const replacement = await recyclePrismaClient(
-                `${model}.${operation}: ${errorMessage(error)}`,
-              )
-
-              if (transactionContext.getStore()) {
-                throw error
-              }
-
-              execute = (() =>
-                replayPrismaOperation(
-                  replacement,
-                  model,
-                  operation,
-                  args,
-                ) as ReturnType<typeof query>) as typeof execute
-            }
           }
         }
       },
@@ -464,11 +489,12 @@ function extendPrismaClient(client: PrismaClient) {
   })
 }
 
-activePrisma = extendPrismaClient(activeBasePrisma)
+type RetryingPrismaClient = ReturnType<typeof extendPrismaClient>
+const activePrisma = extendPrismaClient(basePrisma)
 
 console.info('[prisma] MariaDB protocol mode', {
   mode: useTextProtocol ? 'text-query' : 'binary-execute',
-  generation: globalForPrisma.prismaGeneration ?? 0,
+  oneShotFallback: globalForPrisma.prismaAdapterPoisoned ?? false,
 })
 
 export const prisma = new Proxy({} as RetryingPrismaClient, {

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -16,7 +16,7 @@ import {
 // - retiring every idle connection after 15 seconds leaves warm Vercel instances
 //   reusing or recreating unhealthy ProxySQL sockets during sustained API tests
 // - the adapter's binary execute() path can retain a closed command channel
-// - retrying through the same poisoned client repeats the same stale-socket error
+// - replacement adapter pools can immediately inherit the same poisoned state
 assert.ok(
   DEFAULT_CONNECTION_LIMIT >= SAFE_MINIMUM_CONNECTION_LIMIT,
   `DEFAULT_CONNECTION_LIMIT (${DEFAULT_CONNECTION_LIMIT}) must be >= ` +
@@ -67,42 +67,48 @@ assert.doesNotMatch(prismaSource, /DATABASE_MINIMUM_IDLE,\s*0/)
 assert.match(prismaSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
 assert.match(
   prismaSource,
-  /new PrismaMariaDb\(buildDatabaseConfig\(databaseUrl\),\s*\{\s*useTextProtocol/,
+  /new PrismaMariaDb\(\s*buildDatabaseConfig\(databaseUrl, poolOverrides\)/,
 )
 assert.match(
   prismaSource,
   /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
 )
 
-// A stale socket poisons the adapter client that owns its pool. Recovery must
-// connect a replacement client, atomically redirect future calls, and replay the
-// failed model operation through that replacement instead of calling the stale
-// query closure again. Concurrent failures share one recovery promise.
-assert.match(prismaSource, /globalForPrisma\.prismaRecovery/)
-assert.match(prismaSource, /await replacement\.\$connect\(\)/)
-assert.match(
-  prismaSource,
-  /activePrisma = extendPrismaClient\(replacement\)/,
-)
+// Production proved that replacement shared pools can fail immediately while a
+// direct single-use MariaDB connection succeeds on the same warm instance. Once
+// the shared adapter emits the stale-channel error, future non-transaction model
+// operations must bypass it through a single-use Prisma client with no idle
+// connections and disconnect that isolated client after the operation.
+assert.match(prismaSource, /prismaAdapterPoisoned\?: boolean/)
+assert.match(prismaSource, /globalForPrisma\.prismaAdapterPoisoned = true/)
+assert.match(prismaSource, /\[prisma:adapter-poisoned\]/)
+assert.match(prismaSource, /\[prisma:one-shot-fallback\]/)
+assert.match(prismaSource, /const oneShotPoolOverrides/)
+assert.match(prismaSource, /connectionLimit:\s*1/)
+assert.match(prismaSource, /minimumIdle:\s*0/)
+assert.match(prismaSource, /idleTimeout:\s*1/)
+assert.match(prismaSource, /await oneShotPrisma\.\$disconnect\(\)/)
 assert.match(prismaSource, /replayPrismaOperation/)
 assert.match(prismaSource, /new Proxy\(\{\} as RetryingPrismaClient/)
+assert.doesNotMatch(prismaSource, /prismaRecovery/)
+assert.doesNotMatch(prismaSource, /\[prisma:client-recycled\]/)
 
-// Recovery may replace the client during an active transaction, but the failed
-// statement must not be replayed outside that transaction. Transaction callers
-// are tracked through the stable proxy and receive the original error so Prisma
-// can roll back the transaction normally.
+// A failed statement inside an explicit transaction must never be replayed on a
+// one-shot client outside that transaction. Transaction callers are tracked
+// through the stable proxy and receive the original error so Prisma rolls back.
 assert.match(prismaSource, /new AsyncLocalStorage<boolean>\(\)/)
 assert.match(prismaSource, /property === '\$transaction'/)
 assert.match(prismaSource, /transactionContext\.run\(true/)
-assert.match(prismaSource, /transactionContext\.getStore\(\)/)
+assert.match(prismaSource, /const transactionActive =/)
+assert.match(prismaSource, /if \(!model \|\| transactionActive\) throw error/)
 
-// Never disconnect the shared or retired client during request recovery. Other
-// requests may still be completing transactions against it.
-assert.doesNotMatch(prismaSource, /\.\$disconnect\(\)/)
-assert.doesNotMatch(prismaSource, /createIsolatedPrismaClient/)
+// The shared client itself must never be disconnected during request recovery;
+// only the explicitly isolated one-shot client may be closed.
+assert.doesNotMatch(prismaSource, /basePrisma\.\$disconnect\(\)/)
+assert.doesNotMatch(prismaSource, /activePrisma\.\$disconnect\(\)/)
 
-// Project Sync keeps its direct MariaDB fallback as a route-specific final
-// safety net when adapter recovery cannot complete.
+// Project Sync retains its direct MariaDB fallback as an independent control and
+// final route-specific safety net.
 assert.match(
   directProbeSource,
   /export async function createDatabaseDirectConnection\(\)/,
@@ -123,5 +129,5 @@ console.log(
     `connect=${DEFAULT_CONNECT_TIMEOUT_MS}ms, acquire=${DEFAULT_ACQUIRE_TIMEOUT_MS}ms, ` +
     `idle=${DEFAULT_IDLE_TIMEOUT_SECONDS}s, minimumIdle=${DEFAULT_MINIMUM_IDLE}, ` +
     `ping=${DEFAULT_PING_TIMEOUT_MS}ms; Prisma uses MariaDB text protocol and ` +
-    'recycles poisoned clients without replaying outside active transactions.',
+    'contains poisoned warm instances with transaction-safe one-shot clients.',
 )


### PR DESCRIPTION
## Production evidence

The merged client-recycling fix is active in production, but the authenticated Cypress run still reports the same 96 failures. Runtime logs from deployment `dpl_AAmXpxiQFA1wTLe7wUZ1bdfNLS6P` show:

- `[prisma:client-recycled]` fired 46 times in one run.
- Every freshly connected replacement client failed its first model command with `Cannot execute new commands: connection closed`.
- On the same poisoned warm instance, the route-specific direct MariaDB Project fallback completed two writes with HTTP 201.

That isolates the failure to the long-lived Prisma MariaDB adapter pool lifecycle on a warm Vercel instance. The database, credentials, TLS connection, ProxySQL path, and direct connector writes were still healthy.

## Change

- Stop creating replacement shared pools after a stale command-channel error.
- Mark the warm instance's shared Prisma adapter as poisoned after the first stale error.
- Replay that failed non-transaction model operation through a single-use Prisma client.
- Route later non-transaction model operations on the poisoned instance directly through single-use clients.
- Configure each one-shot client with `connectionLimit: 1`, `minimumIdle: 0`, and no retained warm connection, then disconnect it after the operation.
- Preserve the normal shared pool and availability retry behavior on healthy instances.
- Preserve explicit transaction rollback semantics: transaction statements are never replayed outside their transaction.
- Retain the direct Project fallback as an independent control and final route-specific safety net.

## Tradeoff

The containment path is intentionally slower because it opens and closes an adapter client per model operation. It only activates after a warm instance has demonstrated that its shared adapter pool is unusable. Correctness beats repeatedly returning 96 identical 503s.

## Validation plan

- Contract Tests and TypeScript Type Check must pass.
- After deployment, rerun the authenticated Cypress suite.
- Expected runtime signal: one `[prisma:adapter-poisoned]`, followed by `[prisma:one-shot-fallback]` operations that succeed instead of repeated `[prisma:client-recycled]` generations.
- If one-shot adapter operations still fail while direct MariaDB succeeds, the next step is removing the Prisma MariaDB adapter from this topology rather than adding more pool recovery logic.