### PR TITLE
global-ui/t-014: top-level "For You" honeydo inbox nav entry

### DIFF
--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -1,0 +1,154 @@
+<!-- /components/pages/for-you-manager.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden p-1.5 sm:p-2.5"
+  >
+    <div class="rounded-2xl border border-accent/20 bg-accent/5 px-4 py-3">
+      <p class="text-xs font-semibold text-accent/80">🍯 For You</p>
+      <p class="mt-0.5 text-xs text-base-content/50">
+        Action items your AI assigned to you. These help your projects along —
+        check them off as you go.
+      </p>
+      <p
+        v-if="highPriorityCount > 0"
+        class="mt-1 text-xs font-semibold text-error"
+      >
+        {{ highPriorityCount }} high-priority item{{
+          highPriorityCount > 1 ? 's' : ''
+        }}
+        need your attention.
+      </p>
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+      <div class="space-y-2">
+        <template v-if="todoStore.loading && !todoStore.honeyDoTodos.length">
+          <div
+            v-for="n in 3"
+            :key="n"
+            class="h-16 animate-pulse rounded-2xl border border-base-300 bg-base-200"
+          />
+        </template>
+
+        <div
+          v-for="todo in todoStore.honeyDoTodos"
+          :key="todo.id"
+          class="flex flex-col gap-1 rounded-2xl border px-4 py-3 transition-colors"
+          :class="
+            todo.priority === 'HIGH'
+              ? 'border-error/30 bg-error/5'
+              : 'border-base-300 bg-base-100'
+          "
+        >
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              class="shrink-0 text-base-content/30 transition-colors hover:text-success"
+              title="Mark complete"
+              @click="todoStore.toggleDone(todo)"
+            >
+              <Icon name="kind-icon:circle" class="size-5" />
+            </button>
+            <span class="min-w-0 flex-1 truncate text-sm font-medium">{{
+              todo.title
+            }}</span>
+            <span
+              v-if="todo.priority === 'HIGH'"
+              class="badge badge-error badge-xs shrink-0"
+              >🔴 high</span
+            >
+            <span
+              v-else-if="todo.priority === 'LOW'"
+              class="badge badge-ghost badge-xs shrink-0"
+              >🟢 low</span
+            >
+            <span class="shrink-0 text-xs text-base-content/40">{{
+              relativeTime(todo.createdAt)
+            }}</span>
+          </div>
+          <p
+            v-if="todo.description"
+            class="ml-8 text-xs leading-relaxed text-base-content/50"
+          >
+            {{ todo.description }}
+          </p>
+          <button
+            v-if="relatedProject(todo)"
+            type="button"
+            class="ml-8 self-start text-xs text-info hover:underline"
+            @click="viewProject(relatedProject(todo)!)"
+          >
+            View
+            {{
+              relatedProject(todo)!.title || relatedProject(todo)!.slug
+            }}&nbsp;→
+          </button>
+        </div>
+
+        <div
+          v-if="!todoStore.loading && !todoStore.honeyDoTodos.length"
+          class="py-8 text-center"
+        >
+          <Icon
+            name="kind-icon:check-circle"
+            class="mx-auto mb-2 size-8 text-success/40"
+          />
+          <p class="text-sm font-semibold text-base-content/50">
+            Nothing needs your attention right now.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useTodoStore, type Todo } from '@/stores/todoStore'
+import {
+  useProjectStore,
+  type ProjectWithRelations,
+} from '@/stores/projectStore'
+import { usePageStore } from '@/stores/pageStore'
+
+const todoStore = useTodoStore()
+const projectStore = useProjectStore()
+const pageStore = usePageStore()
+
+const highPriorityCount = computed(
+  () =>
+    todoStore.honeyDoTodos.filter((todo) => todo.priority === 'HIGH').length,
+)
+
+function relatedProject(todo: Todo): ProjectWithRelations | null {
+  if (!todo.projectId) return null
+  return (
+    projectStore.projects.find((project) => project.id === todo.projectId) ??
+    null
+  )
+}
+
+function viewProject(project: ProjectWithRelations) {
+  if (!project.slug) return
+  pageStore.setWorkspaceCardKey(project.slug)
+  navigateTo('/conductor')
+}
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const minutes = Math.round(diffMs / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.round(days / 30)
+  return `${months}mo ago`
+}
+
+onMounted(() => {
+  if (!todoStore.hasLoaded) void todoStore.fetchTodos()
+  if (!projectStore.loaded) void projectStore.fetchProjects()
+})
+</script>

--- a/content/channels/home/for-you.md
+++ b/content/channels/home/for-you.md
@@ -1,0 +1,15 @@
+---
+contentType: tab
+channelKey: home
+tabKey: for-you
+label: For You
+title: For You
+subtitle: Your action queue
+description: Things your AI has flagged that need your attention, across every project.
+icon: kind-icon:checklist
+route: /for-you
+sort: 15
+requiredPermission: authenticated
+---
+
+Your honey-do queue — action items your AI assigned to you — lives here, independent of any single project.

--- a/content/for-you.md
+++ b/content/for-you.md
@@ -1,0 +1,14 @@
+---
+title: 'For You'
+room: 'For You'
+subtitle: 'Your action queue'
+description: Things your AI has flagged that need your attention, across every project.
+icon: kind-icon:checklist
+tooltip: Action items your AI assigned to you, in one place.
+channelKey: home
+tabKey: for-you
+loadingMessage: Loading your action queue...
+refreshLabel: Refresh
+---
+
+:for-you-manager


### PR DESCRIPTION
## Task
global-ui/t-014: Give the honeydo queue a top-level nav "For You" inbox, not just a project-page tab (kind: software)

## What changed / what I produced
- `content/channels/home/for-you.md`: nav-metadata entry (the `channels` content collection) registering a "For You" tab under the Home channel dropdown, `route: /for-you`, `sort: 15` (right after Dashboard).
- `content/for-you.md`: the actual routable page (the `content` collection, excludes `channels/**`), body `:for-you-manager`.
- `components/pages/for-you-manager.vue`: new standalone component reading `todoStore.honeyDoTodos` directly — no project context required, matching the task's premise that the data is already global. Styled after the existing HONEYDO tab's card/banner/empty-state in `conductor-page.vue`, plus two things `TASK-SURFACE-SPEC.md` §3 calls for that the original tab never implemented:
  - a relative timestamp per item ("Nm/h/d/mo ago")
  - a "View `<project>`" link, resolved via `todo.projectId` → `projectStore.projects`, that calls `pageStore.setWorkspaceCardKey(project.slug)` + `navigateTo('/conductor')` to jump straight to that project's Conductor detail view (the spec's "related project" language predates the Dream→Dream/Project/Facet split; `projectId` is the current equivalent).
  - Empty state copy matches the spec's exact text ("Nothing needs your attention right now.") rather than the existing tab's slightly different wording.

Deliberately left `conductor-page.vue`'s existing HONEYDO tab untouched — it keeps working standalone. De-duplicating the two card markups into one shared component is a reasonable follow-up (noted as this PR's kaizen suggestion) but felt like unnecessary risk to an unrelated, working AGENT/KAIZEN/HONEYDO tri-tab system for this pass.

## How I verified
- `npx prettier --write` on all three new files: clean.
- `npx eslint` on the new `.vue` file: 0 errors (the two `.md` files aren't covered by the eslint config, expected).
- Full project `vue-tsc --noEmit` (`npm test`): 0 errors.
- Booted the dev server (`npm run dev`) and confirmed Nuxt Content parsed all 137 content files including the 2 new ones with zero schema violations (`[@nuxt/content] Processed 3 collections and 137 files ... 0 cached, 137 parsed`), confirming both files validate against `content.config.ts`'s `pageSchema`/`channelSchema`.
- Could **not** verify the live rendered page end-to-end: this sandbox has no `DATABASE_URL` configured, so any route hits a 500 ("DATABASE_URL is missing") before the SPA can render — a pre-existing sandbox limitation unrelated to this change (confirmed it's not page-specific: the same 500 appears for any route in this environment).

## Stakes
reversible

## Flags for Reviewer
- Couldn't do a real click-through in this sandbox (no DB). Worth a quick manual check in an environment with `DATABASE_URL` set — especially the "View project" link (`pageStore.setWorkspaceCardKey` + `navigateTo('/conductor')`) and that honeydo items actually disappear from the list on "mark complete" (they do structurally: `toggleDone` sets `status: DONE`, and `honeyDoTodos` filters to `status === 'OPEN'`, same mechanism the existing tab already relies on).
- Content collection oddity worth knowing (not touched here): `content/dashboard.md`/`achievements.md`/etc. (flat, real pages) and `content/channels/home/dashboard.md`/`achievements.md`/etc. (nav-metadata only) both declare the same `tabKey`s — they're two different Nuxt Content collections (`content` excludes `channels/**`; `channels` sources only `channels/**`), so this isn't a duplication bug, just non-obvious. Followed that existing split pattern exactly for the new "for-you" tabKey.

## Kaizen suggestion
Extract the honeydo item card (checkbox toggle, title, priority badge, description) out of `conductor-page.vue`'s tri-tab list into a small shared component (e.g. `components/tasks/honeydo-card.vue`) used by both the Conductor TASKS→HONEYDO tab and this new page, so the two surfaces can't visually drift apart over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FmfUbxxAu3jSKXjxbfezNx)_