### PR TITLE
global-ui/t-017: data-surface manifest so undiscoverable surfaces fail CI

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Channel resolver contract
         run: npm run test:channel-resolver
 
+      - name: Data surface manifest contract
+        run: npm run test:data-surface-manifest
+
       - name: Database pool defaults contract
         run: npm run test:database-pool-defaults
 

--- a/docs/channel-content-authoring.md
+++ b/docs/channel-content-authoring.md
@@ -190,6 +190,29 @@ Role and capability gates are evaluated independently. Administrators bypass cap
 
 Canonical page activation happens in `pageStore`: content resolves the active channel and tab first, then the old dashboard shell is synchronized as a compatibility adapter. Header, navigator, Builder, and tutorial components should not recreate that synchronization.
 
+## Data surfaces without a content page
+
+Not every navigable thing is a Markdown page. A store-backed surface (the honeydo
+inbox, for example) can live entirely inside a component's local tab state, with
+no `content/` file for `verifyChannelContent.ts` to scan — so it can go
+undiscoverable with nothing failing CI. Register any such surface in
+`utils/dataSurfaceManifest.ts`'s `DATA_SURFACES` array:
+
+```ts
+{
+  id: 'my-surface',
+  label: 'What a human would call it',
+  dataSource: 'stores/myStore.ts: myStore.someGlobalList',
+  navEntry: { channelKey: 'plan', tabKey: 'my-tab' }, // or null while unwired
+  acknowledgedGap: 'project/t-XXX', // required when navEntry is null
+}
+```
+
+`npm run test:data-surface-manifest` fails the build if an entry has neither a
+`navEntry` that resolves to a real tab, nor an `acknowledgedGap` — a new
+data surface can never land silently undiscoverable, and an existing gap stays
+visible in CI until the tracked task actually wires it up.
+
 ## Validation
 
 Run:
@@ -197,6 +220,7 @@ Run:
 ```bash
 npm run test:channel-content
 npm run test:channel-resolver
+npm run test:data-surface-manifest
 npm run audit:channel-assets
 ```
 
@@ -220,5 +244,11 @@ The resolver contract checks:
 - Role filtering
 - Capability filtering
 - Administrator bypass
+
+The data surface manifest contract checks:
+
+- Every registered surface has a unique id
+- Every registered surface has a resolvable `navEntry` or an `acknowledgedGap`
+- Any `navEntry` actually points at a real channel/tab
 
 TypeScript validation also runs through the normal project test workflow. Admin users can inspect the live resolved graph at `/navigation-health` and apply Project placement updates at `/project-placement`.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
+    "test:data-surface-manifest": "tsx utils/scripts/verifyDataSurfaceManifest.ts",
     "test:animation-catalog": "tsx utils/scripts/verifyAnimationCatalog.ts",
     "test:database-pool-defaults": "tsx utils/scripts/verifyDatabasePoolDefaults.ts",
     "test:academy-style-detail-callers": "tsx utils/scripts/verifyAcademyStyleDetailCallers.ts",

--- a/utils/dataSurfaceManifest.ts
+++ b/utils/dataSurfaceManifest.ts
@@ -1,0 +1,39 @@
+// /utils/dataSurfaceManifest.ts
+//
+// Registry of application data surfaces that must be reachable from a
+// top-level nav destination (a channel/tab in content/channels). A content
+// Markdown page gets this check for free from verifyChannelContent.ts's
+// channelKey/tabKey frontmatter cross-reference -- but a data surface can
+// live entirely inside a Vue component's local tab state, with no Markdown
+// page at all, and slip past that file-scanning check silently. That is
+// exactly what happened to the honeydo inbox: todoStore.honeyDoTodos is
+// correctly global, but its only UI entry point was a HONEYDO tab buried
+// inside conductor-page.vue's per-project detail view, with no top-level
+// destination -- caught only by a manual audit (NAVIGATION-MAP.md,
+// 2026-07-15), not CI. Mirrors the intent of PortOS's server/lib/navManifest.js.
+//
+// Add an entry here whenever you introduce a data source a user should be
+// able to reach without already knowing which project/page it is tucked
+// inside. Wire `navEntry` once it has a real top-level channel/tab; leave it
+// `null` with an `acknowledgedGap` pointing at the tracking task while the
+// work is in flight -- that is the only way an unwired surface passes the
+// contract in utils/scripts/verifyDataSurfaceManifest.ts, so a gap can never
+// land silently.
+
+export type DataSurfaceEntry = {
+  id: string
+  label: string
+  dataSource: string
+  navEntry: { channelKey: string; tabKey: string } | null
+  acknowledgedGap?: string
+}
+
+export const DATA_SURFACES: DataSurfaceEntry[] = [
+  {
+    id: 'honeydo-inbox',
+    label: 'Global honeydo queue',
+    dataSource: 'stores/todoStore.ts: todoStore.honeyDoTodos',
+    navEntry: null,
+    acknowledgedGap: 'global-ui/t-014',
+  },
+]

--- a/utils/scripts/verifyDataSurfaceManifest.ts
+++ b/utils/scripts/verifyDataSurfaceManifest.ts
@@ -1,0 +1,118 @@
+// /utils/scripts/verifyDataSurfaceManifest.ts
+//
+// Contract test for utils/dataSurfaceManifest.ts: every registered data
+// surface must either resolve to a real top-level channel/tab, or carry an
+// explicit acknowledgedGap pointing at the roadmap task tracking the fix.
+// A surface with neither fails CI -- the manifest can only ever record a
+// gap, never hide one. See dataSurfaceManifest.ts for the full rationale.
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DATA_SURFACES } from '@/utils/dataSurfaceManifest'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const channelsDirectory = resolve(repositoryRoot, 'content/channels')
+
+function cleanValue(value: string): string {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+  return (quote === "'" || quote === '"') && trimmed.endsWith(quote)
+    ? trimmed.slice(1, -1)
+    : trimmed
+}
+
+function parseFrontMatter(source: string): Record<string, string> {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!match?.[1]) return {}
+
+  const result: Record<string, string> = {}
+  for (const line of match[1].split(/\r?\n/)) {
+    if (!line.trim() || /^\s/.test(line)) continue
+    const separator = line.indexOf(':')
+    if (separator < 1) continue
+    result[line.slice(0, separator).trim()] = cleanValue(
+      line.slice(separator + 1),
+    )
+  }
+  return result
+}
+
+async function markdownFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  return (
+    await Promise.all(
+      entries.map(async (entry) => {
+        const path = resolve(directory, entry.name)
+        if (entry.isDirectory()) return markdownFiles(path)
+        return entry.isFile() && entry.name.endsWith('.md') ? [path] : []
+      }),
+    )
+  ).flat()
+}
+
+async function loadTabLocations(): Promise<Set<string>> {
+  const files = await markdownFiles(channelsDirectory)
+  const locations = new Set<string>()
+  for (const file of files) {
+    const frontMatter = parseFrontMatter(await readFile(file, 'utf8'))
+    if (frontMatter.contentType !== 'tab') continue
+    if (!frontMatter.channelKey || !frontMatter.tabKey) continue
+    locations.add(`${frontMatter.channelKey}/${frontMatter.tabKey}`)
+  }
+  return locations
+}
+
+async function main(): Promise<void> {
+  const errors: string[] = []
+  const seenIds = new Set<string>()
+
+  for (const surface of DATA_SURFACES) {
+    if (!surface.id) {
+      errors.push('data surface entry missing id')
+      continue
+    }
+    if (seenIds.has(surface.id)) {
+      errors.push(`duplicate data surface id ${surface.id}`)
+    }
+    seenIds.add(surface.id)
+
+    if (!surface.navEntry && !surface.acknowledgedGap) {
+      errors.push(
+        `${surface.id}: has no navEntry and no acknowledgedGap -- wire a top-level ` +
+          'channel/tab or acknowledge the gap with a tracking task id',
+      )
+    }
+  }
+
+  const tabLocations = await loadTabLocations()
+  for (const surface of DATA_SURFACES) {
+    if (!surface.navEntry) continue
+    const location = `${surface.navEntry.channelKey}/${surface.navEntry.tabKey}`
+    if (!tabLocations.has(location)) {
+      errors.push(`${surface.id}: navEntry references unknown tab ${location}`)
+    }
+  }
+
+  if (errors.length) {
+    console.error(
+      `Data surface manifest contract failed with ${errors.length} error(s):`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  const wired = DATA_SURFACES.filter((surface) => surface.navEntry).length
+  const acknowledged = DATA_SURFACES.filter(
+    (surface) => surface.acknowledgedGap,
+  ).length
+  console.log(
+    `Data surface manifest contract passed: ${DATA_SURFACES.length} surface(s), ${wired} wired, ${acknowledged} acknowledged gap(s).`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- Kaizen from t-005's navigation audit (`NAVIGATION-MAP.md`): the honeydo inbox has correct, already-global data (`todoStore.honeyDoTodos`) but no top-level nav entry — a gap only caught by manual audit, not CI, because it has no Markdown page for `verifyChannelContent.ts` to scan in the first place.
- Adds `utils/dataSurfaceManifest.ts`, a PortOS `navManifest.js`-style registry of data surfaces that must be reachable from a top-level nav destination, and `utils/scripts/verifyDataSurfaceManifest.ts`, a CI contract that fails if an entry has neither a `navEntry` resolving to a real channel/tab nor an explicit `acknowledgedGap` pointing at a tracking task.
- Seeds the manifest with the honeydo-inbox gap, acknowledged against `global-ui/t-014` (currently in progress) so this doesn't fail CI on an already-tracked, in-flight fix — but any *new* undiscoverable surface added without wiring or acknowledgment will fail the build.
- Wires the new contract into `package.json` (`test:data-surface-manifest`) and `.github/workflows/contract-tests.yml`, and documents the convention in `docs/channel-content-authoring.md`.

## Test plan
- [x] `npm run test:data-surface-manifest` passes against the current manifest
- [x] Manually verified the contract fails when an entry has neither `navEntry` nor `acknowledgedGap`
- [x] `npm run test:channel-content` and `npm run test:channel-resolver` still pass (no regression)
- [x] `npx vue-tsc --noEmit` — 0 errors
- [x] `npx eslint` / `npx prettier --check` clean on all changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNna1mfa1fRLKayhtvwAsy)_