### PR TITLE
global-ui/t-017 follow-up: wire honeydo-inbox navEntry now that t-014 landed

### DIFF
--- a/utils/dataSurfaceManifest.ts
+++ b/utils/dataSurfaceManifest.ts
@@ -5,9 +5,9 @@
 // Markdown page gets this check for free from verifyChannelContent.ts's
 // channelKey/tabKey frontmatter cross-reference -- but a data surface can
 // live entirely inside a Vue component's local tab state, with no Markdown
-// page at all, and slip past that file-scanning check silently. That is
-// exactly what happened to the honeydo inbox: todoStore.honeyDoTodos is
-// correctly global, but its only UI entry point was a HONEYDO tab buried
+// page at all, and slip past that file-scanning check silently. That is what
+// happened to the honeydo inbox until global-ui/t-014 landed: todoStore.honeyDoTodos
+// was correctly global, but its only UI entry point was a HONEYDO tab buried
 // inside conductor-page.vue's per-project detail view, with no top-level
 // destination -- caught only by a manual audit (NAVIGATION-MAP.md,
 // 2026-07-15), not CI. Mirrors the intent of PortOS's server/lib/navManifest.js.
@@ -33,7 +33,6 @@ export const DATA_SURFACES: DataSurfaceEntry[] = [
     id: 'honeydo-inbox',
     label: 'Global honeydo queue',
     dataSource: 'stores/todoStore.ts: todoStore.honeyDoTodos',
-    navEntry: null,
-    acknowledgedGap: 'global-ui/t-014',
+    navEntry: { channelKey: 'home', tabKey: 'for-you' },
   },
 ]


### PR DESCRIPTION
## Summary
- PR #338 (this cycle) seeded `utils/dataSurfaceManifest.ts`'s `honeydo-inbox` entry with `navEntry: null` + `acknowledgedGap: 'global-ui/t-014'`, since t-014 (the actual top-level nav fix) hadn't landed yet.
- t-014 merged in the same rotation cycle (PR #337, `home/for-you` tab + `for-you-manager.vue`), so the acknowledged gap is now stale.
- Updates the manifest entry to `navEntry: { channelKey: 'home', tabKey: 'for-you' }`, matching the real fix, so the contract reflects current reality instead of a resolved gap.

## Test plan
- [x] `npm run test:data-surface-manifest` passes, now reporting 1 wired / 0 acknowledged gaps
- [x] `npx vue-tsc --noEmit` — 0 errors
- [x] `npx eslint` / `npx prettier --check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNna1mfa1fRLKayhtvwAsy)_