### PR TITLE
Revert one-shot Prisma fallback (#336, #339) — restores user registration

### DIFF
--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -20,17 +20,11 @@ type CircuitBreakerState = {
   openUntil: number
 }
 
-type DatabasePoolOverrides = {
-  connectionLimit?: number
-  idleTimeout?: number
-  minimumIdle?: number
-  minDelayValidation?: number
-}
-
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
   prismaBreaker?: CircuitBreakerState
-  prismaAdapterPoisoned?: boolean
+  prismaRecovery?: Promise<PrismaClient>
+  prismaGeneration?: number
 }
 
 const configuredDatabaseUrl = process.env.DATABASE_URL
@@ -154,14 +148,14 @@ function readDatabaseUseTextProtocol(): boolean {
   return raw !== 'false' && raw !== '0' && raw !== 'no'
 }
 
-function buildDatabaseConfig(
-  url: string,
-  overrides: DatabasePoolOverrides = {},
-): PrismaMariaDbPoolConfig {
+function buildDatabaseConfig(url: string): PrismaMariaDbConfig {
   const resolvedUrl = buildDatabaseUrl(url)
-  const parsed = new URL(resolvedUrl)
   const sslCa = readDatabaseSslCa()
   const rejectUnauthorized = readSslRejectUnauthorized()
+
+  if (!sslCa && rejectUnauthorized) return resolvedUrl
+
+  const parsed = new URL(resolvedUrl)
   const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
   const tlsOptions: TlsConnectionOptions = rejectUnauthorized
     ? {
@@ -195,31 +189,23 @@ function buildDatabaseConfig(
       parsed.searchParams.get('acquireTimeout') ?? undefined,
       DEFAULT_ACQUIRE_TIMEOUT_MS,
     ),
-    connectionLimit:
-      overrides.connectionLimit ??
-      readPositiveInteger(
-        parsed.searchParams.get('connectionLimit') ?? undefined,
-        DEFAULT_CONNECTION_LIMIT,
-      ),
-    minDelayValidation:
-      overrides.minDelayValidation ??
-      readNonNegativeInteger(
-        parsed.searchParams.get('minDelayValidation') ?? undefined,
-        0,
-      ),
-    idleTimeout:
-      overrides.idleTimeout ??
-      readPositiveInteger(
-        parsed.searchParams.get('idleTimeout') ?? undefined,
-        DEFAULT_IDLE_TIMEOUT_SECONDS,
-      ),
-    minimumIdle:
-      overrides.minimumIdle ??
-      readNonNegativeInteger(
-        parsed.searchParams.get('minimumIdle') ?? undefined,
-        DEFAULT_MINIMUM_IDLE,
-      ),
-    ...(sslCa || !rejectUnauthorized ? { ssl: tlsOptions } : {}),
+    connectionLimit: readPositiveInteger(
+      parsed.searchParams.get('connectionLimit') ?? undefined,
+      DEFAULT_CONNECTION_LIMIT,
+    ),
+    minDelayValidation: readNonNegativeInteger(
+      parsed.searchParams.get('minDelayValidation') ?? undefined,
+      0,
+    ),
+    idleTimeout: readPositiveInteger(
+      parsed.searchParams.get('idleTimeout') ?? undefined,
+      DEFAULT_IDLE_TIMEOUT_SECONDS,
+    ),
+    minimumIdle: readNonNegativeInteger(
+      parsed.searchParams.get('minimumIdle') ?? undefined,
+      DEFAULT_MINIMUM_IDLE,
+    ),
+    ssl: tlsOptions,
   }
 
   Object.assign(poolConfig, {
@@ -244,6 +230,10 @@ const unavailableDatabaseMessages = [
 const unavailableRetryAttempts = readNonNegativeInteger(
   process.env.DATABASE_TRANSIENT_RETRY_ATTEMPTS,
   1,
+)
+const staleConnectionRetryAttempts = readNonNegativeInteger(
+  process.env.DATABASE_STALE_CONNECTION_RETRY_ATTEMPTS,
+  2,
 )
 const transientRetryDelayMs = readPositiveInteger(
   process.env.DATABASE_TRANSIENT_RETRY_DELAY_MS,
@@ -316,19 +306,25 @@ function isAvailabilityError(error: unknown): boolean {
   return messageMatches(error, unavailableDatabaseMessages)
 }
 
+function retryLimitFor(error: unknown): number {
+  if (isStaleDatabaseConnectionError(error)) {
+    return staleConnectionRetryAttempts
+  }
+
+  if (isAvailabilityError(error)) return unavailableRetryAttempts
+  return 0
+}
+
 const delay = (milliseconds: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
 
 const useTextProtocol = readDatabaseUseTextProtocol()
 
-function createPrismaClient(
-  poolOverrides: DatabasePoolOverrides = {},
-): PrismaClient {
+function createBasePrismaClient(): PrismaClient {
   return new PrismaClient({
-    adapter: new PrismaMariaDb(
-      buildDatabaseConfig(databaseUrl, poolOverrides),
-      { useTextProtocol },
-    ),
+    adapter: new PrismaMariaDb(buildDatabaseConfig(databaseUrl), {
+      useTextProtocol,
+    }),
   })
 }
 
@@ -341,10 +337,7 @@ async function replayPrismaOperation(
   const delegateName = `${model.charAt(0).toLowerCase()}${model.slice(1)}`
   const delegate = (client as unknown as Record<string, unknown>)[delegateName]
 
-  if (
-    !delegate ||
-    (typeof delegate !== 'object' && typeof delegate !== 'function')
-  ) {
+  if (!delegate || (typeof delegate !== 'object' && typeof delegate !== 'function')) {
     throw new Error(`Unable to replay Prisma operation for model ${model}.`)
   }
 
@@ -359,50 +352,45 @@ async function replayPrismaOperation(
   ).call(delegate, args)
 }
 
-const oneShotPoolOverrides: DatabasePoolOverrides = {
-  connectionLimit: 1,
-  minimumIdle: 0,
-  idleTimeout: 1,
-  minDelayValidation: 0,
-}
+let activeBasePrisma = globalForPrisma.prisma ?? createBasePrismaClient()
+globalForPrisma.prisma = activeBasePrisma
 
-async function runOneShotPrismaOperation(
-  model: string,
-  operation: string,
-  args: unknown,
-  reason: string,
-): Promise<unknown> {
-  const oneShotPrisma = createPrismaClient(oneShotPoolOverrides)
+type RetryingPrismaClient = ReturnType<typeof extendPrismaClient>
+let activePrisma: RetryingPrismaClient
 
-  console.warn('[prisma:one-shot-fallback]', {
-    model,
-    operation,
-    reason,
-    mode: useTextProtocol ? 'text-query' : 'binary-execute',
-  })
+async function recyclePrismaClient(reason: string): Promise<PrismaClient> {
+  const existingRecovery = globalForPrisma.prismaRecovery
+  if (existingRecovery) return await existingRecovery
+
+  const recovery = (async () => {
+    const replacement = createBasePrismaClient()
+    await replacement.$connect()
+
+    activeBasePrisma = replacement
+    globalForPrisma.prisma = replacement
+    activePrisma = extendPrismaClient(replacement)
+    globalForPrisma.prismaGeneration =
+      (globalForPrisma.prismaGeneration ?? 0) + 1
+
+    console.warn('[prisma:client-recycled]', {
+      generation: globalForPrisma.prismaGeneration,
+      reason,
+      mode: useTextProtocol ? 'text-query' : 'binary-execute',
+    })
+
+    return replacement
+  })()
+
+  globalForPrisma.prismaRecovery = recovery
 
   try {
-    const result = await replayPrismaOperation(
-      oneShotPrisma,
-      model,
-      operation,
-      args,
-    )
-    recordConnectionSuccess()
-    return result
+    return await recovery
   } finally {
-    await oneShotPrisma.$disconnect().catch((disconnectError: unknown) => {
-      console.warn('[prisma:one-shot-disconnect-failed]', {
-        model,
-        operation,
-        message: errorMessage(disconnectError),
-      })
-    })
+    if (globalForPrisma.prismaRecovery === recovery) {
+      globalForPrisma.prismaRecovery = undefined
+    }
   }
 }
-
-const basePrisma = globalForPrisma.prisma ?? createPrismaClient()
-globalForPrisma.prisma = basePrisma
 
 function extendPrismaClient(client: PrismaClient) {
   return client.$extends({
@@ -413,57 +401,26 @@ function extendPrismaClient(client: PrismaClient) {
           throw new Error(CIRCUIT_OPEN_MESSAGE)
         }
 
-        const transactionActive = transactionContext.getStore() === true
-
-        if (
-          globalForPrisma.prismaAdapterPoisoned &&
-          model &&
-          !transactionActive
-        ) {
-          return (await runOneShotPrismaOperation(
-            model,
-            operation,
-            args,
-            'shared adapter already marked poisoned',
-          )) as ReturnType<typeof query>
-        }
+        let execute = () => query(args)
 
         for (let attempt = 0; ; attempt += 1) {
           try {
-            const result = await query(args)
+            const result = await execute()
             recordConnectionSuccess()
             return result
           } catch (error: unknown) {
             const availabilityError = isAvailabilityError(error)
             const staleConnectionError = isStaleDatabaseConnectionError(error)
+            const retryLimit = retryLimitFor(error)
 
-            if (staleConnectionError) {
-              globalForPrisma.prismaAdapterPoisoned = true
-
-              console.warn('[prisma:adapter-poisoned]', {
-                model: model ?? 'raw',
-                operation,
-                transactionActive,
-                message: errorMessage(error),
-              })
-
-              if (!model || transactionActive) throw error
-
-              return (await runOneShotPrismaOperation(
-                model,
-                operation,
-                args,
-                `${model}.${operation}: ${errorMessage(error)}`,
-              )) as ReturnType<typeof query>
+            if (availabilityError) {
+              recordAvailabilityFailure()
             }
 
-            if (!availabilityError) throw error
-
-            recordAvailabilityFailure()
-
             if (
-              attempt >= unavailableRetryAttempts ||
-              circuitIsOpen()
+              (!availabilityError && !staleConnectionError) ||
+              attempt >= retryLimit ||
+              (availabilityError && circuitIsOpen())
             ) {
               throw error
             }
@@ -474,14 +431,32 @@ function extendPrismaClient(client: PrismaClient) {
             console.warn('[prisma:transient-retry]', {
               model: model ?? 'raw',
               operation,
-              kind: 'unavailable',
+              kind: staleConnectionError ? 'stale-connection' : 'unavailable',
               retry: retryNumber,
-              maxRetries: unavailableRetryAttempts,
+              maxRetries: retryLimit,
               waitMs,
               message: errorMessage(error),
             })
 
             await delay(waitMs)
+
+            if (staleConnectionError && model) {
+              const replacement = await recyclePrismaClient(
+                `${model}.${operation}: ${errorMessage(error)}`,
+              )
+
+              if (transactionContext.getStore()) {
+                throw error
+              }
+
+              execute = (() =>
+                replayPrismaOperation(
+                  replacement,
+                  model,
+                  operation,
+                  args,
+                ) as ReturnType<typeof query>) as typeof execute
+            }
           }
         }
       },
@@ -489,12 +464,11 @@ function extendPrismaClient(client: PrismaClient) {
   })
 }
 
-type RetryingPrismaClient = ReturnType<typeof extendPrismaClient>
-const activePrisma = extendPrismaClient(basePrisma)
+activePrisma = extendPrismaClient(activeBasePrisma)
 
 console.info('[prisma] MariaDB protocol mode', {
   mode: useTextProtocol ? 'text-query' : 'binary-execute',
-  oneShotFallback: globalForPrisma.prismaAdapterPoisoned ?? false,
+  generation: globalForPrisma.prismaGeneration ?? 0,
 })
 
 export const prisma = new Proxy({} as RetryingPrismaClient, {

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -31,7 +31,6 @@ const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient
   prismaBreaker?: CircuitBreakerState
   prismaAdapterPoisoned?: boolean
-  prismaOneShotQueue?: Promise<void>
 }
 
 const configuredDatabaseUrl = process.env.DATABASE_URL
@@ -57,6 +56,68 @@ function readNonNegativeInteger(
 ): number {
   const parsed = Number.parseInt(value ?? '', 10)
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+function buildDatabaseUrl(url: string): string {
+  const parsed = new URL(url)
+  const connectTimeout = readPositiveInteger(
+    process.env.DATABASE_CONNECT_TIMEOUT_MS,
+    DEFAULT_CONNECT_TIMEOUT_MS,
+  )
+  const acquireTimeout = readPositiveInteger(
+    process.env.DATABASE_ACQUIRE_TIMEOUT_MS,
+    DEFAULT_ACQUIRE_TIMEOUT_MS,
+  )
+  const connectionLimit = readPositiveInteger(
+    process.env.DATABASE_CONNECTION_LIMIT,
+    DEFAULT_CONNECTION_LIMIT,
+  )
+  const minDelayValidation = readNonNegativeInteger(
+    process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
+    0,
+  )
+  const idleTimeout = readPositiveInteger(
+    process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
+    DEFAULT_IDLE_TIMEOUT_SECONDS,
+  )
+  const minimumIdle = readNonNegativeInteger(
+    process.env.DATABASE_MINIMUM_IDLE,
+    DEFAULT_MINIMUM_IDLE,
+  )
+  const pingTimeout = readPositiveInteger(
+    process.env.DATABASE_PING_TIMEOUT_MS,
+    DEFAULT_PING_TIMEOUT_MS,
+  )
+
+  if (!parsed.searchParams.has('connectTimeout')) {
+    parsed.searchParams.set('connectTimeout', String(connectTimeout))
+  }
+
+  if (!parsed.searchParams.has('acquireTimeout')) {
+    parsed.searchParams.set('acquireTimeout', String(acquireTimeout))
+  }
+
+  if (!parsed.searchParams.has('connectionLimit')) {
+    parsed.searchParams.set('connectionLimit', String(connectionLimit))
+  }
+
+  if (!parsed.searchParams.has('minDelayValidation')) {
+    parsed.searchParams.set('minDelayValidation', String(minDelayValidation))
+  }
+
+  if (!parsed.searchParams.has('idleTimeout')) {
+    parsed.searchParams.set('idleTimeout', String(idleTimeout))
+  }
+
+  if (!parsed.searchParams.has('minimumIdle')) {
+    parsed.searchParams.set('minimumIdle', String(minimumIdle))
+  }
+
+  if (!parsed.searchParams.has('pingTimeout')) {
+    parsed.searchParams.set('pingTimeout', String(pingTimeout))
+  }
+
+  return parsed.toString()
 }
 
 function readDatabaseSslCa(): string | undefined {
@@ -97,20 +158,11 @@ function buildDatabaseConfig(
   url: string,
   overrides: DatabasePoolOverrides = {},
 ): PrismaMariaDbPoolConfig {
-  const parsed = new URL(url)
+  const resolvedUrl = buildDatabaseUrl(url)
+  const parsed = new URL(resolvedUrl)
   const sslCa = readDatabaseSslCa()
   const rejectUnauthorized = readSslRejectUnauthorized()
   const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ''))
-  const connectTimeout = readPositiveInteger(
-    parsed.searchParams.get('connectTimeout') ??
-      process.env.DATABASE_CONNECT_TIMEOUT_MS,
-    DEFAULT_CONNECT_TIMEOUT_MS,
-  )
-  const acquireTimeout = readPositiveInteger(
-    parsed.searchParams.get('acquireTimeout') ??
-      process.env.DATABASE_ACQUIRE_TIMEOUT_MS,
-    DEFAULT_ACQUIRE_TIMEOUT_MS,
-  )
   const tlsOptions: TlsConnectionOptions = rejectUnauthorized
     ? {
         ca: sslCa,
@@ -135,34 +187,36 @@ function buildDatabaseConfig(
     user: decodeURIComponent(parsed.username),
     password: decodeURIComponent(parsed.password),
     database,
-    connectTimeout,
-    acquireTimeout,
+    connectTimeout: readPositiveInteger(
+      parsed.searchParams.get('connectTimeout') ?? undefined,
+      DEFAULT_CONNECT_TIMEOUT_MS,
+    ),
+    acquireTimeout: readPositiveInteger(
+      parsed.searchParams.get('acquireTimeout') ?? undefined,
+      DEFAULT_ACQUIRE_TIMEOUT_MS,
+    ),
     connectionLimit:
       overrides.connectionLimit ??
       readPositiveInteger(
-        parsed.searchParams.get('connectionLimit') ??
-          process.env.DATABASE_CONNECTION_LIMIT,
+        parsed.searchParams.get('connectionLimit') ?? undefined,
         DEFAULT_CONNECTION_LIMIT,
       ),
     minDelayValidation:
       overrides.minDelayValidation ??
       readNonNegativeInteger(
-        parsed.searchParams.get('minDelayValidation') ??
-          process.env.DATABASE_MIN_DELAY_VALIDATION_MS,
+        parsed.searchParams.get('minDelayValidation') ?? undefined,
         0,
       ),
     idleTimeout:
       overrides.idleTimeout ??
       readPositiveInteger(
-        parsed.searchParams.get('idleTimeout') ??
-          process.env.DATABASE_IDLE_TIMEOUT_SECONDS,
+        parsed.searchParams.get('idleTimeout') ?? undefined,
         DEFAULT_IDLE_TIMEOUT_SECONDS,
       ),
     minimumIdle:
       overrides.minimumIdle ??
       readNonNegativeInteger(
-        parsed.searchParams.get('minimumIdle') ??
-          process.env.DATABASE_MINIMUM_IDLE,
+        parsed.searchParams.get('minimumIdle') ?? undefined,
         DEFAULT_MINIMUM_IDLE,
       ),
     ...(sslCa || !rejectUnauthorized ? { ssl: tlsOptions } : {}),
@@ -170,11 +224,9 @@ function buildDatabaseConfig(
 
   Object.assign(poolConfig, {
     pingTimeout: readPositiveInteger(
-      parsed.searchParams.get('pingTimeout') ??
-        process.env.DATABASE_PING_TIMEOUT_MS,
+      parsed.searchParams.get('pingTimeout') ?? undefined,
       DEFAULT_PING_TIMEOUT_MS,
     ),
-    initializationTimeout: acquireTimeout,
   })
 
   return poolConfig
@@ -309,33 +361,9 @@ async function replayPrismaOperation(
 
 const oneShotPoolOverrides: DatabasePoolOverrides = {
   connectionLimit: 1,
-  minimumIdle: 1,
-  idleTimeout: 30,
-  minDelayValidation: 500,
-}
-
-async function serializeOneShotOperation<T>(
-  operation: () => Promise<T>,
-): Promise<T> {
-  const previous = globalForPrisma.prismaOneShotQueue ?? Promise.resolve()
-  let release!: () => void
-  const gate = new Promise<void>((resolve) => {
-    release = resolve
-  })
-  const current = previous.catch(() => undefined).then(() => gate)
-
-  globalForPrisma.prismaOneShotQueue = current
-  await previous.catch(() => undefined)
-
-  try {
-    return await operation()
-  } finally {
-    release()
-
-    if (globalForPrisma.prismaOneShotQueue === current) {
-      globalForPrisma.prismaOneShotQueue = undefined
-    }
-  }
+  minimumIdle: 0,
+  idleTimeout: 1,
+  minDelayValidation: 0,
 }
 
 async function runOneShotPrismaOperation(
@@ -344,43 +372,33 @@ async function runOneShotPrismaOperation(
   args: unknown,
   reason: string,
 ): Promise<unknown> {
-  return serializeOneShotOperation(async () => {
-    const oneShotPrisma = createPrismaClient(oneShotPoolOverrides)
+  const oneShotPrisma = createPrismaClient(oneShotPoolOverrides)
 
-    console.warn('[prisma:one-shot-fallback]', {
+  console.warn('[prisma:one-shot-fallback]', {
+    model,
+    operation,
+    reason,
+    mode: useTextProtocol ? 'text-query' : 'binary-execute',
+  })
+
+  try {
+    const result = await replayPrismaOperation(
+      oneShotPrisma,
       model,
       operation,
-      reason,
-      mode: useTextProtocol ? 'text-query' : 'binary-execute',
+      args,
+    )
+    recordConnectionSuccess()
+    return result
+  } finally {
+    await oneShotPrisma.$disconnect().catch((disconnectError: unknown) => {
+      console.warn('[prisma:one-shot-disconnect-failed]', {
+        model,
+        operation,
+        message: errorMessage(disconnectError),
+      })
     })
-
-    try {
-      await oneShotPrisma.$connect()
-      await oneShotPrisma.$queryRawUnsafe('SELECT 1 AS prisma_one_shot_ready')
-
-      console.warn('[prisma:one-shot-ready]', {
-        model,
-        operation,
-      })
-
-      const result = await replayPrismaOperation(
-        oneShotPrisma,
-        model,
-        operation,
-        args,
-      )
-      recordConnectionSuccess()
-      return result
-    } finally {
-      await oneShotPrisma.$disconnect().catch((disconnectError: unknown) => {
-        console.warn('[prisma:one-shot-disconnect-failed]', {
-          model,
-          operation,
-          message: errorMessage(disconnectError),
-        })
-      })
-    }
-  })
+  }
 }
 
 const basePrisma = globalForPrisma.prisma ?? createPrismaClient()
@@ -391,6 +409,10 @@ function extendPrismaClient(client: PrismaClient) {
     name: 'transient-database-retry',
     query: {
       async $allOperations({ model, operation, args, query }) {
+        if (circuitIsOpen()) {
+          throw new Error(CIRCUIT_OPEN_MESSAGE)
+        }
+
         const transactionActive = transactionContext.getStore() === true
 
         if (
@@ -404,10 +426,6 @@ function extendPrismaClient(client: PrismaClient) {
             args,
             'shared adapter already marked poisoned',
           )) as ReturnType<typeof query>
-        }
-
-        if (circuitIsOpen()) {
-          throw new Error(CIRCUIT_OPEN_MESSAGE)
         }
 
         for (let attempt = 0; ; attempt += 1) {

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -16,7 +16,7 @@ import {
 // - retiring every idle connection after 15 seconds leaves warm Vercel instances
 //   reusing or recreating unhealthy ProxySQL sockets during sustained API tests
 // - the adapter's binary execute() path can retain a closed command channel
-// - replacement adapter pools can immediately inherit the same poisoned state
+// - retrying through the same poisoned client repeats the same stale-socket error
 assert.ok(
   DEFAULT_CONNECTION_LIMIT >= SAFE_MINIMUM_CONNECTION_LIMIT,
   `DEFAULT_CONNECTION_LIMIT (${DEFAULT_CONNECTION_LIMIT}) must be >= ` +
@@ -67,48 +67,42 @@ assert.doesNotMatch(prismaSource, /DATABASE_MINIMUM_IDLE,\s*0/)
 assert.match(prismaSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
 assert.match(
   prismaSource,
-  /new PrismaMariaDb\(\s*buildDatabaseConfig\(databaseUrl, poolOverrides\)/,
+  /new PrismaMariaDb\(buildDatabaseConfig\(databaseUrl\),\s*\{\s*useTextProtocol/,
 )
 assert.match(
   prismaSource,
   /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
 )
 
-// Production proved that replacement shared pools can fail immediately while a
-// direct single-use MariaDB connection succeeds on the same warm instance. Once
-// the shared adapter emits the stale-channel error, future non-transaction model
-// operations must bypass it through a single-use Prisma client with no idle
-// connections and disconnect that isolated client after the operation.
-assert.match(prismaSource, /prismaAdapterPoisoned\?: boolean/)
-assert.match(prismaSource, /globalForPrisma\.prismaAdapterPoisoned = true/)
-assert.match(prismaSource, /\[prisma:adapter-poisoned\]/)
-assert.match(prismaSource, /\[prisma:one-shot-fallback\]/)
-assert.match(prismaSource, /const oneShotPoolOverrides/)
-assert.match(prismaSource, /connectionLimit:\s*1/)
-assert.match(prismaSource, /minimumIdle:\s*0/)
-assert.match(prismaSource, /idleTimeout:\s*1/)
-assert.match(prismaSource, /await oneShotPrisma\.\$disconnect\(\)/)
+// A stale socket poisons the adapter client that owns its pool. Recovery must
+// connect a replacement client, atomically redirect future calls, and replay the
+// failed model operation through that replacement instead of calling the stale
+// query closure again. Concurrent failures share one recovery promise.
+assert.match(prismaSource, /globalForPrisma\.prismaRecovery/)
+assert.match(prismaSource, /await replacement\.\$connect\(\)/)
+assert.match(
+  prismaSource,
+  /activePrisma = extendPrismaClient\(replacement\)/,
+)
 assert.match(prismaSource, /replayPrismaOperation/)
 assert.match(prismaSource, /new Proxy\(\{\} as RetryingPrismaClient/)
-assert.doesNotMatch(prismaSource, /prismaRecovery/)
-assert.doesNotMatch(prismaSource, /\[prisma:client-recycled\]/)
 
-// A failed statement inside an explicit transaction must never be replayed on a
-// one-shot client outside that transaction. Transaction callers are tracked
-// through the stable proxy and receive the original error so Prisma rolls back.
+// Recovery may replace the client during an active transaction, but the failed
+// statement must not be replayed outside that transaction. Transaction callers
+// are tracked through the stable proxy and receive the original error so Prisma
+// can roll back the transaction normally.
 assert.match(prismaSource, /new AsyncLocalStorage<boolean>\(\)/)
 assert.match(prismaSource, /property === '\$transaction'/)
 assert.match(prismaSource, /transactionContext\.run\(true/)
-assert.match(prismaSource, /const transactionActive =/)
-assert.match(prismaSource, /if \(!model \|\| transactionActive\) throw error/)
+assert.match(prismaSource, /transactionContext\.getStore\(\)/)
 
-// The shared client itself must never be disconnected during request recovery;
-// only the explicitly isolated one-shot client may be closed.
-assert.doesNotMatch(prismaSource, /basePrisma\.\$disconnect\(\)/)
-assert.doesNotMatch(prismaSource, /activePrisma\.\$disconnect\(\)/)
+// Never disconnect the shared or retired client during request recovery. Other
+// requests may still be completing transactions against it.
+assert.doesNotMatch(prismaSource, /\.\$disconnect\(\)/)
+assert.doesNotMatch(prismaSource, /createIsolatedPrismaClient/)
 
-// Project Sync retains its direct MariaDB fallback as an independent control and
-// final route-specific safety net.
+// Project Sync keeps its direct MariaDB fallback as a route-specific final
+// safety net when adapter recovery cannot complete.
 assert.match(
   directProbeSource,
   /export async function createDatabaseDirectConnection\(\)/,
@@ -129,5 +123,5 @@ console.log(
     `connect=${DEFAULT_CONNECT_TIMEOUT_MS}ms, acquire=${DEFAULT_ACQUIRE_TIMEOUT_MS}ms, ` +
     `idle=${DEFAULT_IDLE_TIMEOUT_SECONDS}s, minimumIdle=${DEFAULT_MINIMUM_IDLE}, ` +
     `ping=${DEFAULT_PING_TIMEOUT_MS}ms; Prisma uses MariaDB text protocol and ` +
-    'contains poisoned warm instances with transaction-safe one-shot clients.',
+    'recycles poisoned clients without replaying outside active transactions.',
 )

--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -14,9 +14,9 @@ import {
 // Regression guards for the production pool failure modes:
 // - too few connections starve every DB-backed route
 // - retiring every idle connection after 15 seconds leaves warm Vercel instances
-//   reusing unhealthy ProxySQL sockets during sustained API tests
+//   reusing or recreating unhealthy ProxySQL sockets during sustained API tests
 // - the adapter's binary execute() path can retain a closed command channel
-// - a fallback pool with minimumIdle=0 never established a connection and timed out
+// - replacement adapter pools can immediately inherit the same poisoned state
 assert.ok(
   DEFAULT_CONNECTION_LIMIT >= SAFE_MINIMUM_CONNECTION_LIMIT,
   `DEFAULT_CONNECTION_LIMIT (${DEFAULT_CONNECTION_LIMIT}) must be >= ` +
@@ -60,7 +60,6 @@ const projectCreateSource = readFileSync(
 
 assert.match(prismaSource, /process\.env\.DATABASE_PING_TIMEOUT_MS/)
 assert.match(prismaSource, /pingTimeout:\s*readPositiveInteger/)
-assert.match(prismaSource, /initializationTimeout:\s*acquireTimeout/)
 assert.match(prismaSource, /DEFAULT_IDLE_TIMEOUT_SECONDS/)
 assert.match(prismaSource, /DEFAULT_MINIMUM_IDLE/)
 assert.doesNotMatch(prismaSource, /DATABASE_IDLE_TIMEOUT_SECONDS,\s*15/)
@@ -75,33 +74,24 @@ assert.match(
   /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
 )
 
-// Once the shared adapter emits the stale-channel error, future non-transaction
-// model operations bypass it through an initialized, single-connection client.
-// Fallback operations are serialized so background heartbeat/queue traffic cannot
-// create a connection storm on the same warm Vercel instance.
+// Production proved that replacement shared pools can fail immediately while a
+// direct single-use MariaDB connection succeeds on the same warm instance. Once
+// the shared adapter emits the stale-channel error, future non-transaction model
+// operations must bypass it through a single-use Prisma client with no idle
+// connections and disconnect that isolated client after the operation.
 assert.match(prismaSource, /prismaAdapterPoisoned\?: boolean/)
-assert.match(prismaSource, /prismaOneShotQueue\?: Promise<void>/)
 assert.match(prismaSource, /globalForPrisma\.prismaAdapterPoisoned = true/)
 assert.match(prismaSource, /\[prisma:adapter-poisoned\]/)
 assert.match(prismaSource, /\[prisma:one-shot-fallback\]/)
-assert.match(prismaSource, /\[prisma:one-shot-ready\]/)
 assert.match(prismaSource, /const oneShotPoolOverrides/)
 assert.match(prismaSource, /connectionLimit:\s*1/)
-assert.match(prismaSource, /minimumIdle:\s*1/)
-assert.match(prismaSource, /idleTimeout:\s*30/)
-assert.match(prismaSource, /minDelayValidation:\s*500/)
-assert.match(prismaSource, /serializeOneShotOperation/)
-assert.match(prismaSource, /await oneShotPrisma\.\$connect\(\)/)
-assert.match(
-  prismaSource,
-  /await oneShotPrisma\.\$queryRawUnsafe\('SELECT 1 AS prisma_one_shot_ready'\)/,
-)
+assert.match(prismaSource, /minimumIdle:\s*0/)
+assert.match(prismaSource, /idleTimeout:\s*1/)
 assert.match(prismaSource, /await oneShotPrisma\.\$disconnect\(\)/)
 assert.match(prismaSource, /replayPrismaOperation/)
 assert.match(prismaSource, /new Proxy\(\{\} as RetryingPrismaClient/)
 assert.doesNotMatch(prismaSource, /prismaRecovery/)
 assert.doesNotMatch(prismaSource, /\[prisma:client-recycled\]/)
-assert.doesNotMatch(prismaSource, /minimumIdle:\s*0/)
 
 // A failed statement inside an explicit transaction must never be replayed on a
 // one-shot client outside that transaction. Transaction callers are tracked
@@ -139,5 +129,5 @@ console.log(
     `connect=${DEFAULT_CONNECT_TIMEOUT_MS}ms, acquire=${DEFAULT_ACQUIRE_TIMEOUT_MS}ms, ` +
     `idle=${DEFAULT_IDLE_TIMEOUT_SECONDS}s, minimumIdle=${DEFAULT_MINIMUM_IDLE}, ` +
     `ping=${DEFAULT_PING_TIMEOUT_MS}ms; Prisma uses MariaDB text protocol and ` +
-    'contains poisoned warm instances with initialized serialized one-shot clients.',
+    'contains poisoned warm instances with transaction-safe one-shot clients.',
 )


### PR DESCRIPTION
Reverts #336 and its follow-up #339 (the one-shot / poisoned-adapter fallback mechanism).

## Why

Since `dpl_81JDWEPrgN6QxA4bAVNV2i743LTk` deployed, **`POST /api/users/register` fails 100% of the time** — the incident escalated from "some tables can't write" (#324) to "new users can't sign up." Verified live 5/5 attempts, ~20s latency each.

Mechanism of the regression (full analysis in [#324 comment](https://github.com/silasfelinus/kind_robots/issues/324#issuecomment-4998711780)):

1. Any stale-connection error sets `globalForPrisma.prismaAdapterPoisoned = true` — permanently; nothing resets it for the life of the warm instance.
2. A background client (userId 3937) retry-loops `POST /api/dreams` every ~1.5s and always fails with that error, so every warm instance is poisoned within seconds of booting.
3. Once poisoned, every model operation — reads included — creates a fresh one-connection PrismaClient per query; those pools time out before opening a socket (`pool timeout ... active=0 idle=0 limit=1`), which is the exact failure mode #324 already documented as disproved for #322.

## What this restores

`server/utils/prisma.ts` and `utils/scripts/verifyDatabasePoolDefaults.ts` return **byte-for-byte** to their state at `545dbb9` (the #334-era code deployed as `dpl_F5tTp9ewwNJe9DhZG8RgeB7afVZW`), under which registration, reads, and non-affected-table writes were verified working earlier tonight. The underlying per-table create failures (#324) remain open and are being isolated via `scripts/db-write-repro.mjs` on branch `claude/kind-robots-db-errors-b0bcuv`.

## Verification

- `git diff 545dbb9 HEAD -- server/utils/prisma.ts utils/scripts/verifyDatabasePoolDefaults.ts` → empty
- After merge+deploy: `node scripts/db-write-smoke.mjs` (from the db-errors branch) should show the `user write (register)` and `control write (todos)` probes passing again, with only the `canary write (rewards)` probe still failing per #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WiGtSg2iCYS6rSXr1jfFa

---
_Generated by [Claude Code](https://claude.ai/code/session_013WiGtSg2iCYS6rSXr1jfFa)_