### PR TITLE
global-ui/t-020: extract shared honeydo-card component

### DIFF
--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -890,96 +890,99 @@
                 class="h-16 animate-pulse rounded-2xl border border-base-300 bg-base-200"
               />
             </template>
-            <div
-              v-for="todo in filteredTodos"
-              :key="todo.id"
-              class="flex flex-col gap-1 rounded-2xl border px-4 py-3 transition-colors"
-              :class="[
-                todo.status === 'DONE'
-                  ? 'opacity-60 border-base-300 bg-base-100'
-                  : todo.category === 'HONEYDO' && todo.priority === 'HIGH'
-                    ? 'border-error/30 bg-error/5'
+            <template v-for="todo in filteredTodos" :key="todo.id">
+              <honeydo-card
+                v-if="todo.category === 'HONEYDO'"
+                :todo="todo"
+                :show-relative-time="false"
+                :show-category-badge="todoFilter !== 'OPEN'"
+                show-archive-action
+                show-delete-action
+                @toggle-done="todoStore.toggleDone(todo)"
+                @archive="todoStore.archiveTodo(todo.id)"
+                @delete="todoStore.deleteTodo(todo.id)"
+              />
+              <div
+                v-else
+                class="flex flex-col gap-1 rounded-2xl border px-4 py-3 transition-colors"
+                :class="[
+                  todo.status === 'DONE'
+                    ? 'opacity-60 border-base-300 bg-base-100'
                     : 'border-base-300 bg-base-100',
-              ]"
-            >
-              <div class="flex items-center gap-3">
-                <button
-                  type="button"
-                  class="shrink-0 transition-colors"
-                  :class="
-                    todo.status === 'DONE'
-                      ? 'text-success'
-                      : 'text-base-content/30 hover:text-success'
-                  "
-                  @click="todoStore.toggleDone(todo)"
-                >
-                  <Icon
-                    :name="
-                      todo.status === 'DONE'
-                        ? 'kind-icon:check-circle'
-                        : 'kind-icon:circle'
-                    "
-                    class="size-5"
-                  />
-                </button>
-                <span
-                  class="min-w-0 flex-1 truncate text-sm font-medium"
-                  :class="
-                    todo.status === 'DONE'
-                      ? 'line-through text-base-content/40'
-                      : ''
-                  "
-                  >{{ todo.title }}</span
-                >
-                <span
-                  v-if="todo.priority === 'HIGH'"
-                  class="badge badge-error badge-xs shrink-0"
-                  >🔴 high</span
-                >
-                <span
-                  v-else-if="todo.priority === 'LOW'"
-                  class="badge badge-ghost badge-xs shrink-0"
-                  >🟢 low</span
-                >
-                <span
-                  v-if="todoFilter !== 'OPEN' && todo.category === 'KAIZEN'"
-                  class="badge badge-secondary badge-xs shrink-0"
-                  >✨ kaizen</span
-                >
-                <span
-                  v-else-if="
-                    todoFilter !== 'OPEN' && todo.category === 'HONEYDO'
-                  "
-                  class="badge badge-accent badge-xs shrink-0"
-                  >🍯 honey do</span
-                >
-                <div class="flex shrink-0 gap-1">
-                  <button
-                    v-if="todo.status !== 'ARCHIVED'"
-                    type="button"
-                    class="btn btn-ghost btn-xs rounded-lg text-base-content/30 hover:text-base-content"
-                    title="Archive"
-                    @click="todoStore.archiveTodo(todo.id)"
-                  >
-                    <Icon name="kind-icon:archive" class="size-3" />
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-xs rounded-lg text-base-content/20 hover:text-error"
-                    title="Delete"
-                    @click="todoStore.deleteTodo(todo.id)"
-                  >
-                    <Icon name="kind-icon:x" class="size-3" />
-                  </button>
-                </div>
-              </div>
-              <p
-                v-if="todo.description"
-                class="ml-8 text-xs leading-relaxed text-base-content/50"
+                ]"
               >
-                {{ todo.description }}
-              </p>
-            </div>
+                <div class="flex items-center gap-3">
+                  <button
+                    type="button"
+                    class="shrink-0 transition-colors"
+                    :class="
+                      todo.status === 'DONE'
+                        ? 'text-success'
+                        : 'text-base-content/30 hover:text-success'
+                    "
+                    @click="todoStore.toggleDone(todo)"
+                  >
+                    <Icon
+                      :name="
+                        todo.status === 'DONE'
+                          ? 'kind-icon:check-circle'
+                          : 'kind-icon:circle'
+                      "
+                      class="size-5"
+                    />
+                  </button>
+                  <span
+                    class="min-w-0 flex-1 truncate text-sm font-medium"
+                    :class="
+                      todo.status === 'DONE'
+                        ? 'line-through text-base-content/40'
+                        : ''
+                    "
+                    >{{ todo.title }}</span
+                  >
+                  <span
+                    v-if="todo.priority === 'HIGH'"
+                    class="badge badge-error badge-xs shrink-0"
+                    >🔴 high</span
+                  >
+                  <span
+                    v-else-if="todo.priority === 'LOW'"
+                    class="badge badge-ghost badge-xs shrink-0"
+                    >🟢 low</span
+                  >
+                  <span
+                    v-if="todoFilter !== 'OPEN' && todo.category === 'KAIZEN'"
+                    class="badge badge-secondary badge-xs shrink-0"
+                    >✨ kaizen</span
+                  >
+                  <div class="flex shrink-0 gap-1">
+                    <button
+                      v-if="todo.status !== 'ARCHIVED'"
+                      type="button"
+                      class="btn btn-ghost btn-xs rounded-lg text-base-content/30 hover:text-base-content"
+                      title="Archive"
+                      @click="todoStore.archiveTodo(todo.id)"
+                    >
+                      <Icon name="kind-icon:archive" class="size-3" />
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs rounded-lg text-base-content/20 hover:text-error"
+                      title="Delete"
+                      @click="todoStore.deleteTodo(todo.id)"
+                    >
+                      <Icon name="kind-icon:x" class="size-3" />
+                    </button>
+                  </div>
+                </div>
+                <p
+                  v-if="todo.description"
+                  class="ml-8 text-xs leading-relaxed text-base-content/50"
+                >
+                  {{ todo.description }}
+                </p>
+              </div>
+            </template>
             <div
               v-if="!todoStore.loading && !filteredTodos.length"
               class="py-8 text-center"

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -30,60 +30,14 @@
           />
         </template>
 
-        <div
+        <honeydo-card
           v-for="todo in todoStore.honeyDoTodos"
           :key="todo.id"
-          class="flex flex-col gap-1 rounded-2xl border px-4 py-3 transition-colors"
-          :class="
-            todo.priority === 'HIGH'
-              ? 'border-error/30 bg-error/5'
-              : 'border-base-300 bg-base-100'
-          "
-        >
-          <div class="flex items-center gap-3">
-            <button
-              type="button"
-              class="shrink-0 text-base-content/30 transition-colors hover:text-success"
-              title="Mark complete"
-              @click="todoStore.toggleDone(todo)"
-            >
-              <Icon name="kind-icon:circle" class="size-5" />
-            </button>
-            <span class="min-w-0 flex-1 truncate text-sm font-medium">{{
-              todo.title
-            }}</span>
-            <span
-              v-if="todo.priority === 'HIGH'"
-              class="badge badge-error badge-xs shrink-0"
-              >🔴 high</span
-            >
-            <span
-              v-else-if="todo.priority === 'LOW'"
-              class="badge badge-ghost badge-xs shrink-0"
-              >🟢 low</span
-            >
-            <span class="shrink-0 text-xs text-base-content/40">{{
-              relativeTime(todo.createdAt)
-            }}</span>
-          </div>
-          <p
-            v-if="todo.description"
-            class="ml-8 text-xs leading-relaxed text-base-content/50"
-          >
-            {{ todo.description }}
-          </p>
-          <button
-            v-if="relatedProject(todo)"
-            type="button"
-            class="ml-8 self-start text-xs text-info hover:underline"
-            @click="viewProject(relatedProject(todo)!)"
-          >
-            View
-            {{
-              relatedProject(todo)!.title || relatedProject(todo)!.slug
-            }}&nbsp;→
-          </button>
-        </div>
+          :todo="todo"
+          :project="relatedProject(todo)"
+          @toggle-done="todoStore.toggleDone(todo)"
+          @view-project="viewProject"
+        />
 
         <div
           v-if="!todoStore.loading && !todoStore.honeyDoTodos.length"
@@ -132,19 +86,6 @@ function viewProject(project: ProjectWithRelations) {
   if (!project.slug) return
   pageStore.setWorkspaceCardKey(project.slug)
   navigateTo('/conductor')
-}
-
-function relativeTime(iso: string): string {
-  const diffMs = Date.now() - new Date(iso).getTime()
-  const minutes = Math.round(diffMs / 60000)
-  if (minutes < 1) return 'just now'
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.round(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.round(hours / 24)
-  if (days < 30) return `${days}d ago`
-  const months = Math.round(days / 30)
-  return `${months}mo ago`
 }
 
 onMounted(() => {

--- a/components/tasks/honeydo-card.vue
+++ b/components/tasks/honeydo-card.vue
@@ -1,0 +1,151 @@
+<!-- /components/tasks/honeydo-card.vue -->
+<!--
+  Shared honey-do item card (checkbox toggle, title, priority badge,
+  description, relative timestamp, "View project" link). Used by both the
+  Conductor HONEYDO tab (components/pages/conductor-page.vue) and the
+  top-level For You page (components/pages/for-you-manager.vue) so the two
+  surfaces can't silently drift apart when a badge or action is added.
+  Purely presentational -- callers own the todoStore/projectStore calls and
+  handle emitted events.
+-->
+<template>
+  <div
+    class="flex flex-col gap-1 rounded-2xl border px-4 py-3 transition-colors"
+    :class="cardClass"
+  >
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        class="shrink-0 transition-colors"
+        :class="
+          isDone
+            ? 'text-success'
+            : 'text-base-content/30 hover:text-success'
+        "
+        title="Mark complete"
+        @click="emit('toggle-done')"
+      >
+        <Icon
+          :name="isDone ? 'kind-icon:check-circle' : 'kind-icon:circle'"
+          class="size-5"
+        />
+      </button>
+      <span
+        class="min-w-0 flex-1 truncate text-sm font-medium"
+        :class="isDone ? 'line-through text-base-content/40' : ''"
+        >{{ todo.title }}</span
+      >
+      <span
+        v-if="todo.priority === 'HIGH'"
+        class="badge badge-error badge-xs shrink-0"
+        >🔴 high</span
+      >
+      <span
+        v-else-if="todo.priority === 'LOW'"
+        class="badge badge-ghost badge-xs shrink-0"
+        >🟢 low</span
+      >
+      <span
+        v-if="showCategoryBadge"
+        class="badge badge-accent badge-xs shrink-0"
+        >🍯 honey do</span
+      >
+      <span
+        v-if="showRelativeTime"
+        class="shrink-0 text-xs text-base-content/40"
+        >{{ relativeTime(todo.createdAt) }}</span
+      >
+      <div
+        v-if="showArchiveAction || showDeleteAction"
+        class="flex shrink-0 gap-1"
+      >
+        <button
+          v-if="showArchiveAction && todo.status !== 'ARCHIVED'"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-lg text-base-content/30 hover:text-base-content"
+          title="Archive"
+          @click="emit('archive')"
+        >
+          <Icon name="kind-icon:archive" class="size-3" />
+        </button>
+        <button
+          v-if="showDeleteAction"
+          type="button"
+          class="btn btn-ghost btn-xs rounded-lg text-base-content/20 hover:text-error"
+          title="Delete"
+          @click="emit('delete')"
+        >
+          <Icon name="kind-icon:x" class="size-3" />
+        </button>
+      </div>
+    </div>
+    <p
+      v-if="todo.description"
+      class="ml-8 text-xs leading-relaxed text-base-content/50"
+    >
+      {{ todo.description }}
+    </p>
+    <button
+      v-if="project"
+      type="button"
+      class="ml-8 self-start text-xs text-info hover:underline"
+      @click="emit('view-project', project)"
+    >
+      View {{ project.title || project.slug }}&nbsp;→
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Todo } from '@/stores/todoStore'
+import type { ProjectWithRelations } from '@/stores/projectStore'
+
+const props = withDefaults(
+  defineProps<{
+    todo: Todo
+    project?: ProjectWithRelations | null
+    showRelativeTime?: boolean
+    showCategoryBadge?: boolean
+    showArchiveAction?: boolean
+    showDeleteAction?: boolean
+  }>(),
+  {
+    project: null,
+    showRelativeTime: true,
+    showCategoryBadge: false,
+    showArchiveAction: false,
+    showDeleteAction: false,
+  },
+)
+
+const emit = defineEmits<{
+  'toggle-done': []
+  archive: []
+  delete: []
+  'view-project': [project: ProjectWithRelations]
+}>()
+
+const isDone = computed(() => props.todo.status === 'DONE')
+
+const cardClass = computed(() =>
+  isDone.value
+    ? 'opacity-60 border-base-300 bg-base-100'
+    : props.todo.priority === 'HIGH'
+      ? 'border-error/30 bg-error/5'
+      : 'border-base-300 bg-base-100',
+)
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const minutes = Math.round(diffMs / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.round(days / 30)
+  return `${months}mo ago`
+}
+</script>


### PR DESCRIPTION
## Summary
- Conductor's HONEYDO tab (`components/pages/conductor-page.vue`) and the top-level For You page (`components/pages/for-you-manager.vue`) each maintained a separate copy of the honey-do item card — and they'd already drifted: only `for-you-manager.vue` had the relative timestamp and "View project" link.
- Extracted `components/tasks/honeydo-card.vue` as a presentational shared component (`todo`/`project` props, `toggle-done`/`archive`/`delete`/`view-project` emits) used by both surfaces.
- `conductor-page.vue`'s HONEYDO-category items now render `honeydo-card` with its archive/delete actions and (in non-OPEN filters) category badge. Non-HONEYDO items (KAIZEN) keep their existing inline markup unchanged — this refactor is scoped to the honey-do card only.

Closes conductor roadmap task `global-ui/t-020` (kaizen from `global-ui/t-014`, kind_robots PR #337).

## Test plan
- [x] `npx eslint components/tasks/honeydo-card.vue components/pages/for-you-manager.vue components/pages/conductor-page.vue` — clean
- [x] `npx vue-tsc --noEmit` — 0 errors (exit 0)
- [ ] Manual verification in a live dev environment (no DB/dev server available in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcEUTgvaWxxkXtcCMA3DfV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcEUTgvaWxxkXtcCMA3DfV)_