### PR TITLE
feat(mana): Stripe webhook credits mana top-ups (test mode)

### DIFF
--- a/components/giftshop/credit-purchase.vue
+++ b/components/giftshop/credit-purchase.vue
@@ -1,52 +1,58 @@
-<!-- /components/content/story/credit-purchase.vue -->
+<!-- /components/giftshop/credit-purchase.vue -->
 <template>
   <div class="p-6 bg-base-200 rounded-2xl shadow-md text-center">
-    <h2 class="text-2xl font-bold text-primary mb-4">Buy Credits</h2>
+    <h2 class="text-2xl font-bold text-primary mb-4">Buy Mana</h2>
     <p class="mb-6 text-lg text-gray-500">
-      Purchase credits to generate more AI-powered stories.
+      Top up your mana balance to generate more AI-powered content.
     </p>
 
     <!-- Pricing Options -->
     <div class="grid gap-4 sm:grid-cols-3">
       <button
-        v-for="option in creditOptions"
-        :key="option.amount"
-        class="p-4 border rounded-xl hover:bg-base-300 transition"
-        @click="purchaseCredits(option.amount, option.price)"
+        v-for="tier in manaTopupTiers"
+        :key="tier.id"
+        class="p-4 border rounded-xl hover:bg-base-300 transition disabled:opacity-50"
+        :disabled="loading"
+        @click="purchaseMana(tier.id)"
       >
-        <p class="text-xl font-semibold">{{ option.amount }} Credits</p>
-        <p class="text-lg text-success font-bold">${{ option.price }}</p>
+        <p class="text-xl font-semibold">{{ tier.label }}</p>
+        <p class="text-lg text-success font-bold">${{ tier.priceUsd }}</p>
       </button>
     </div>
 
     <!-- Payment Processing Status -->
-    <div v-if="loading" class="mt-6 text-warning">Processing payment...</div>
+    <div v-if="loading" class="mt-6 text-warning">
+      Redirecting to checkout...
+    </div>
+    <div v-if="error" class="mt-6 text-error">{{ error }}</div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue'
+import { useCartStore } from '@/stores/cartStore'
 
+const cartStore = useCartStore()
 const loading = ref(false)
+const error = ref('')
 
-// Credit Purchase Options
-const creditOptions = [
-  { amount: 50, price: 5 },
-  { amount: 200, price: 18 },
-  { amount: 500, price: 40 },
+// Mirrors the trusted server-side tiers in server/api/stripe/topup.post.ts —
+// the server re-validates tierId and prices; this list is display-only.
+const manaTopupTiers = [
+  { id: 'small', label: 'Small mana top-up', priceUsd: 5 },
+  { id: 'medium', label: 'Medium mana top-up', priceUsd: 10 },
+  { id: 'large', label: 'Large mana top-up', priceUsd: 25 },
 ]
 
-// Simulated Purchase Function
-const purchaseCredits = async (amount: number, price: number) => {
+const purchaseMana = async (tierId: string) => {
   loading.value = true
+  error.value = ''
   try {
-    // Simulate API call or Stripe payment
-    await new Promise((resolve) => setTimeout(resolve, 2000)) // Fake delay
-    alert(`Successfully purchased ${amount} credits for $${price}`)
-    // Here, you'd update the store with the new credits
-  } catch (error) {
-    console.error('Payment failed:', error)
-    alert('Payment failed. Please try again.')
+    const result = await cartStore.topup(tierId)
+    if (!result.success) {
+      error.value = result.message || 'Mana top-up failed. Please try again.'
+    }
+    // On success, cartStore.topup redirects the browser to Stripe Checkout.
   } finally {
     loading.value = false
   }

--- a/server/api/stripe/topup.post.ts
+++ b/server/api/stripe/topup.post.ts
@@ -1,0 +1,101 @@
+// /server/api/stripe/topup.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import Stripe from 'stripe'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { usdToMana } from '~/server/utils/mana'
+
+let stripe: Stripe | null = null
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY
+
+  if (!secretKey) {
+    throw createError({
+      statusCode: 500,
+      message: 'Stripe secret key is not configured',
+    })
+  }
+
+  stripe ??= new Stripe(secretKey)
+  return stripe
+}
+
+// Trusted server-side tiers — client only ever sends a tier id, never a price,
+// so a tampered request body can't buy mana below its real USD cost.
+export const MANA_TOPUP_TIERS = [
+  { id: 'small', priceUsd: 5, label: 'Small mana top-up' },
+  { id: 'medium', priceUsd: 10, label: 'Medium mana top-up' },
+  { id: 'large', priceUsd: 25, label: 'Large mana top-up' },
+] as const
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const { user } = await requireApiUser(event)
+    const { tierId } = await readBody<{ tierId: string }>(event)
+
+    const tier = MANA_TOPUP_TIERS.find((t) => t.id === tierId)
+    if (!tier)
+      throw createError({ statusCode: 400, message: 'Invalid top-up tier' })
+
+    const stripe = getStripeClient()
+    const email = user.email || `user-${user.id}@kindrobots.org`
+
+    const customerId =
+      user.stripeCustomerId ?? (await stripe.customers.create({ email })).id
+
+    if (!user.stripeCustomerId) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { stripeCustomerId: customerId },
+      })
+    }
+
+    const manaAmount = usdToMana(tier.priceUsd)
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      customer: customerId,
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: tier.label,
+              description: `${manaAmount} mana`,
+            },
+            unit_amount: Math.round(tier.priceUsd * 100), // cents
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: {
+        kind: 'mana_topup',
+        userId: String(user.id),
+        manaAmount: String(manaAmount),
+      },
+      success_url: `${process.env.BASE_URL}/shop/success`,
+      cancel_url: `${process.env.BASE_URL}/shop/cancel`,
+    })
+
+    response = {
+      success: true,
+      url: session.url,
+      message: '🧾 Mana top-up checkout ready',
+    }
+    event.node.res.statusCode = 200
+  } catch (error: unknown) {
+    console.error('🔥 Stripe Top-up Error:', error)
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message: handledError.message || '😵 Mana top-up checkout failed',
+    }
+  }
+
+  return response
+})

--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -1,0 +1,117 @@
+// /server/api/stripe/webhook.post.ts
+import { createError, defineEventHandler, getHeader, readRawBody } from 'h3'
+import Stripe from 'stripe'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { applyMana } from '~/server/utils/mana'
+
+let stripe: Stripe | null = null
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY
+
+  if (!secretKey) {
+    throw createError({
+      statusCode: 500,
+      message: 'Stripe secret key is not configured',
+    })
+  }
+
+  stripe ??= new Stripe(secretKey)
+  return stripe
+}
+
+// Stripe's signature verification IS the auth for this route — the caller is
+// Stripe itself, not a logged-in user, so no validateApiKey/requireApiUser guard.
+async function handleManaTopup(session: Stripe.Checkout.Session) {
+  const userId = Number(session.metadata?.userId)
+  const manaAmount = Number(session.metadata?.manaAmount)
+
+  if (
+    !Number.isInteger(userId) ||
+    userId <= 0 ||
+    !Number.isInteger(manaAmount) ||
+    manaAmount <= 0
+  ) {
+    console.error(
+      `⚠️ Stripe webhook: mana_topup session ${session.id} has invalid metadata`,
+    )
+    return
+  }
+
+  // Idempotency: Stripe can redeliver the same event id on retry. Guard against
+  // double-crediting by checking whether this session was already fulfilled.
+  const existing = await prisma.manaTransaction.findFirst({
+    where: { refId: session.id, reason: 'PURCHASE' },
+  })
+  if (existing) {
+    console.log(
+      `💤 Stripe webhook: session ${session.id} already credited, skipping`,
+    )
+    return
+  }
+
+  await applyMana({
+    userId,
+    amount: manaAmount,
+    reason: 'PURCHASE',
+    refId: session.id,
+    provider: 'stripe',
+    costUsd: (session.amount_total ?? 0) / 100,
+    note: 'Mana top-up via Stripe checkout',
+  })
+
+  console.log(
+    `💰 Credited ${manaAmount} mana to user ${userId} (session ${session.id})`,
+  )
+}
+
+export default defineEventHandler(async (event) => {
+  let response
+
+  try {
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+    if (!webhookSecret) {
+      throw createError({
+        statusCode: 500,
+        message: 'Stripe webhook secret is not configured',
+      })
+    }
+
+    const signature = getHeader(event, 'stripe-signature')
+    const rawBody = await readRawBody(event)
+
+    if (!signature || !rawBody)
+      throw createError({
+        statusCode: 400,
+        message: 'Missing Stripe signature or body',
+      })
+
+    const stripe = getStripeClient()
+    const stripeEvent = stripe.webhooks.constructEvent(
+      rawBody,
+      signature,
+      webhookSecret,
+    )
+
+    if (stripeEvent.type === 'checkout.session.completed') {
+      const session = stripeEvent.data.object as Stripe.Checkout.Session
+      if (session.metadata?.kind === 'mana_topup') {
+        await handleManaTopup(session)
+      }
+    }
+
+    response = { received: true }
+    event.node.res.statusCode = 200
+  } catch (error: unknown) {
+    console.error('🔥 Stripe Webhook Error:', error)
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 400
+    response = {
+      success: false,
+      message: handledError.message || '😵 Stripe webhook handling failed',
+    }
+  }
+
+  return response
+})

--- a/stores/cartStore.ts
+++ b/stores/cartStore.ts
@@ -91,6 +91,7 @@ export const useCartStore = defineStore('cartStore', () => {
   const initializePromise = ref<Promise<void> | null>(null)
   const checkoutPromise = ref<Promise<CartCheckoutResult> | null>(null)
   const subscribePromise = ref<Promise<CartCheckoutResult> | null>(null)
+  const topupPromise = ref<Promise<CartCheckoutResult> | null>(null)
   const hydrating = ref(false)
 
   const totalPrice = computed(() =>
@@ -350,6 +351,55 @@ export const useCartStore = defineStore('cartStore', () => {
     return subscribePromise.value
   }
 
+  async function topup(tierId: string): Promise<CartCheckoutResult> {
+    if (topupPromise.value) return topupPromise.value
+
+    topupPromise.value = (async () => {
+      try {
+        loading.value = true
+        clearError()
+
+        const result = await performFetch<{ url: string }>(
+          '/api/stripe/topup',
+          {
+            method: 'POST',
+            body: JSON.stringify({ tierId }),
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
+
+        if (!result.success || !result.data?.url) {
+          throw new Error(result.message || 'Mana top-up checkout failed.')
+        }
+
+        if (isClient) {
+          window.location.href = result.data.url
+        }
+
+        return {
+          success: true,
+          url: result.data.url,
+        }
+      } catch (error) {
+        handleError(error, 'topup')
+        setLastError(error, 'Mana top-up failed. Try again later.')
+
+        return {
+          success: false,
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Mana top-up failed. Try again later.',
+        }
+      } finally {
+        loading.value = false
+        topupPromise.value = null
+      }
+    })()
+
+    return topupPromise.value
+  }
+
   async function cancelSubscription(
     userId: number,
   ): Promise<CartCheckoutResult> {
@@ -381,6 +431,7 @@ export const useCartStore = defineStore('cartStore', () => {
     initializePromise.value = null
     checkoutPromise.value = null
     subscribePromise.value = null
+    topupPromise.value = null
     lastError.value = null
   }
 
@@ -398,6 +449,7 @@ export const useCartStore = defineStore('cartStore', () => {
     initializePromise,
     checkoutPromise,
     subscribePromise,
+    topupPromise,
 
     totalItems,
     totalPrice,
@@ -417,6 +469,7 @@ export const useCartStore = defineStore('cartStore', () => {
     loadFromLocalStorage,
     checkout,
     subscribe,
+    topup,
     cancelSubscription,
   }
 })


### PR DESCRIPTION
### Task
kind-robots/t-012 (parts 2+3): test-mode Stripe webhook crediting mana + wire credit-purchase.vue to a real checkout flow. (kind: software)

Part 1 (manaGate ledger writes) shipped earlier as PR #151. This finishes the purchase side: a Stripe webhook now actually credits mana, and the client purchase UI drives a real Checkout Session instead of a fake `alert()`. This is the same underlying feature digital-storefront/t-012 (mana top-ups) needs — landing it here unblocks that task too rather than duplicating the work.

### What changed / what I produced
- `server/api/stripe/topup.post.ts` — new route. Auth-gated (`requireApiUser`), takes a `tierId` and looks it up against a small trusted server-side tier list (`MANA_TOPUP_TIERS`: $5/$10/$25 — client never sends a price, so a tampered request can't buy mana below its real cost). Creates/reuses the user's `stripeCustomerId`, creates a Checkout Session (`mode: 'payment'`) with `metadata: { kind: 'mana_topup', userId, manaAmount }`, mana amount derived via the existing `usdToMana()` peg helper.
- `server/api/stripe/webhook.post.ts` — new route. Verifies the Stripe signature (`stripe.webhooks.constructEvent` against the raw body + `STRIPE_WEBHOOK_SECRET`) — signature verification is the auth for this route, so no user auth guard. On `checkout.session.completed` with `metadata.kind === 'mana_topup'`, credits mana via the existing `applyMana()` util (atomic debit/credit + `ManaTransaction` ledger row). Idempotent: checks for an existing `ManaTransaction` with `refId = session.id` before crediting, so a Stripe retry-delivery of the same event can't double-credit.
- `stores/cartStore.ts` — added a `topup(tierId)` action mirroring the existing `checkout()`/`subscribe()` pattern (dedup via a promise ref, redirects to the returned Stripe URL on success).
- `components/giftshop/credit-purchase.vue` — replaced the mocked `setTimeout` + `alert()` flow with a real call to `cartStore.topup()`, using the same three tier ids/prices as the server (display-only; server re-validates).

No Prisma schema changes — `ManaTransaction`/`ManaReason.PURCHASE`/`User.stripeCustomerId` already existed and are unused-until-now, per the task's own note.

### How I verified
- `npx eslint` clean on all four touched/new files.
- `npx prettier --check` clean on all four files.
- Full-project `npx vue-tsc --noEmit` (the repo's `npm test`): 0 errors.
- Could not exercise live in a browser (no dev server/DB/Stripe test keys in this sandbox) — no automated tests exist yet for the Stripe routes to run either.

### Stakes
reversible (test mode only; no live Stripe products/webhooks touched; no schema migration)

### Flags for Reviewer
- Live activation (real `STRIPE_WEBHOOK_SECRET` registered on a live Stripe webhook endpoint, going from test to live keys) stays a separate hard `needs-human` per digital-storefront's standing rule — this PR only wires the code path.
- `credit-purchase.vue` isn't mounted on any page currently (grepped for both the filename and `<CreditPurchase>`/`<GiftshopCreditPurchase>` usage — none found). Making its real flow correct was the task's explicit scope; wiring it into a page (e.g. `/subscriptions`, which `mana-wallet.vue` already links to for "top up") is a natural follow-up but is its own scope decision, so I didn't fold it in here.
- Noticed `server/api/stripe/checkout.post.ts` and `subscribe.post.ts` call `errorHandler({ error, message, statusCode })` (object form), but `errorHandler`'s actual signature only takes the raw error and derives message/statusCode from it — so those two custom fields are silently dropped at runtime in both existing routes. I did NOT touch those files (out of scope), but I used the correct, dominant `errorHandler(error)` pattern (283 other call sites) in both my new routes instead of copying the broken one. Worth a follow-up task to fix the two pre-existing call sites.

### Kaizen suggestion
File a task to fix `checkout.post.ts`/`subscribe.post.ts`'s `errorHandler({...})` object-form calls (see "Flags for Reviewer" above) — they currently return a generic "An unknown error occurred" (500) on every failure instead of their intended custom message/statusCode, which would confuse anyone debugging a failed Stripe checkout.

### Notes for reviewer
Conductor roadmap: kind-robots/t-012 → `done` and digital-storefront/t-012's note updated to point at this PR as the shared foundation, in a companion conductor PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFyV3wCtnR2FBGiVRknc9M)_