### PR TITLE
Add database write reproduction and smoke test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "trim:dry": "node utils/scripts/trim.mjs --dry-run",
     "trim": "node utils/scripts/trim.mjs",
     "test": "nuxi prepare && node utils/scripts/fix-nuxt-tsconfig.mjs && node --max-old-space-size=8192 ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json",
+    "test:db-writes": "node scripts/db-write-smoke.mjs",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
     "test:challenge-center": "tsx utils/scripts/verifyChallengeCenter.ts",

--- a/scripts/db-write-repro.mjs
+++ b/scripts/db-write-repro.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// scripts/db-write-repro.mjs
+//
+// Minimal reproduction harness for issue #324: deterministic per-table create
+// failures ("Cannot execute new commands: connection closed") where the INSERT
+// succeeds server-side but the connection is destroyed before COMMIT.
+//
+// Run this ON ALEXANDRIA (LAN access to ProxySQL + MariaDB) from a kind_robots
+// checkout (the generated Prisma client is committed, so no generate step):
+//
+//   npm ci --ignore-scripts          # one-time; skips nuxi postinstall
+//
+//   # via ProxySQL (the failing production path):
+//   DATABASE_URL='mysql://kindrobot:<pw>@127.0.0.1:5544/kindblank_fresh' \
+//     node scripts/db-write-repro.mjs
+//
+//   # direct to MariaDB (bypasses ProxySQL — the discriminating run):
+//   DATABASE_URL='mysql://kindrobot:<pw>@<mariadb-ip>:3306/kindblank_fresh' \
+//     node scripts/db-write-repro.mjs
+//
+// Each run exercises text AND binary protocol, with and without include, on a
+// control table (Todo — passes in prod) and two failing tables (Chat, Reward).
+// Connector-level trace logging captures the FIRST internal error before the
+// generic "Cannot execute new commands" surfaces. All created rows are deleted;
+// on failure the row never commits, so nothing persists either way.
+
+import { PrismaClient } from '../prisma/generated/prisma/client.js'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) {
+  console.error('DATABASE_URL is required')
+  process.exit(1)
+}
+
+const stamp = Date.now()
+const results = []
+
+function buildAdapter(useTextProtocol) {
+  const parsed = new URL(databaseUrl)
+  return new PrismaMariaDb(
+    {
+      host: parsed.hostname,
+      port: Number(parsed.port || 3306),
+      user: decodeURIComponent(parsed.username),
+      password: decodeURIComponent(parsed.password),
+      database: parsed.pathname.replace(/^\/+/, ''),
+      connectionLimit: 5,
+      connectTimeout: 5000,
+      acquireTimeout: 10000,
+      trace: true,
+      // Surface every connector-level error with its ORIGINAL message/stack —
+      // this is the evidence the production logs never show.
+      logger: {
+        error: (err) => console.error('  [connector:error]', err?.message, err?.cause?.message ?? ''),
+        warning: (msg) => console.error('  [connector:warn]', msg),
+      },
+    },
+    { useTextProtocol },
+  )
+}
+
+async function attempt(label, fn, cleanup) {
+  const t0 = Date.now()
+  try {
+    const created = await fn()
+    const ms = Date.now() - t0
+    try {
+      await cleanup(created)
+    } catch (cleanupError) {
+      console.error(`  [cleanup-failed] ${label}: ${cleanupError.message}`)
+    }
+    results.push({ label, ok: true, ms })
+    console.log(`  PASS ${label} (${ms}ms, id=${created.id})`)
+  } catch (error) {
+    const ms = Date.now() - t0
+    results.push({ label, ok: false, ms, error: error.message?.split('\n')[0] })
+    console.log(`  FAIL ${label} (${ms}ms): ${error.message?.split('\n')[0]}`)
+  }
+}
+
+// Any real user id works for the FK; user 10 is the schema-wide default owner.
+const USER_ID = Number(process.env.REPRO_USER_ID || 10)
+
+async function runMatrixCell(useTextProtocol, withInclude) {
+  const mode = `${useTextProtocol ? 'text' : 'binary'}/${withInclude ? 'include' : 'plain'}`
+  console.log(`\n=== protocol=${useTextProtocol ? 'TEXT' : 'BINARY'} include=${withInclude} ===`)
+
+  const prisma = new PrismaClient({ adapter: buildAdapter(useTextProtocol) })
+
+  const rewardInclude = withInclude
+    ? {
+        include: {
+          ArtImage: true,
+          Characters: true,
+          Dreams: true,
+          Compositions: true,
+          Reactions: true,
+          User: { select: { id: true, username: true } },
+        },
+      }
+    : {}
+
+  await attempt(
+    `todo.create [${mode}] (control — passes in prod)`,
+    () => prisma.todo.create({ data: { title: `repro-${stamp}`, userId: USER_ID } }),
+    (row) => prisma.todo.delete({ where: { id: row.id } }),
+  )
+
+  await attempt(
+    `chat.create [${mode}] (fails in prod)`,
+    () =>
+      prisma.chat.create({
+        data: {
+          type: 'ToBot',
+          sender: 'db-write-repro',
+          content: `repro-${stamp}`,
+          User: { connect: { id: USER_ID } },
+        },
+      }),
+    (row) => prisma.chat.delete({ where: { id: row.id } }),
+  )
+
+  await attempt(
+    `reward.create [${mode}] (fails in prod)`,
+    () =>
+      prisma.reward.create({
+        data: {
+          name: 'db-write-repro',
+          slug: `repro-${stamp}-${mode.replace(/\W/g, '-')}`,
+          rewardType: 'ITEM',
+          rarity: 'COMMON',
+          User: { connect: { id: USER_ID } },
+        },
+        ...rewardInclude,
+      }),
+    (row) => prisma.reward.delete({ where: { id: row.id } }),
+  )
+
+  await prisma.$disconnect().catch(() => {})
+}
+
+console.log(`db-write-repro against ${new URL(databaseUrl).host}`)
+
+for (const useTextProtocol of [true, false]) {
+  for (const withInclude of [true, false]) {
+    await runMatrixCell(useTextProtocol, withInclude)
+  }
+}
+
+console.log('\n=== SUMMARY ===')
+for (const r of results) {
+  console.log(`${r.ok ? 'PASS' : 'FAIL'}  ${r.label}${r.ok ? '' : `  — ${r.error}`}`)
+}
+
+const failed = results.filter((r) => !r.ok)
+console.log(
+  failed.length === 0
+    ? '\nAll cells passed. If production still fails, the difference is the ' +
+        'network path (Vercel→ProxySQL TLS) — rerun with the TLS options from ' +
+        'server/utils/prisma.ts.'
+    : `\n${failed.length} cell(s) failed. If the direct-to-MariaDB run also fails, ` +
+        'this is a pure driver/adapter bug (check prisma/prisma and ' +
+        'mariadb-connector-nodejs upstream issues, bisect mariadb 3.4.x vs 3.5.3). ' +
+        'If only the ProxySQL run fails, capture the wire difference around the ' +
+        'last statement before the connection is destroyed.',
+)

--- a/scripts/db-write-smoke.mjs
+++ b/scripts/db-write-smoke.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// scripts/db-write-smoke.mjs
+//
+// Fast database-write canary for issue #324 — one write to a currently-failing
+// table (Reward) and one control write (Todo), via the live API. Runs anywhere
+// with network access in ~15s: no Cypress, no Cypress Cloud, no DB credentials.
+//
+//   node scripts/db-write-smoke.mjs
+//   BASE_API_URL=https://preview-url.vercel.app/api node scripts/db-write-smoke.mjs
+//
+// Exit code 0 = both writes committed (bug fixed / healthy).
+// Exit code 1 = the failing-table write still 503s (bug present) or the
+//               control write broke (wider outage).
+//
+// Creates a throwaway `cypress-user-smoke-*` account and deletes it (plus all
+// fixtures) at the end; the name matches the existing cypress cleanup sweeps,
+// so leaked fixtures are removed by the janitor even if this script dies.
+
+const apiBase = String(
+  process.env.BASE_API_URL || 'https://kind-robots.vercel.app/api',
+).replace(/\/+$/, '')
+
+const stamp = `${Date.now()}`
+const username = `cypress-user-smoke-${stamp}`
+const password = 'testtest12'
+const jsonHeaders = { Accept: 'application/json', 'Content-Type': 'application/json' }
+
+const call = async (method, path, body, token) => {
+  const startedAt = Date.now()
+  const response = await fetch(`${apiBase}${path}`, {
+    method,
+    headers: {
+      ...jsonHeaders,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  let parsed = null
+  try {
+    parsed = await response.json()
+  } catch {
+    // non-JSON body; status is enough
+  }
+  return { status: response.status, ms: Date.now() - startedAt, body: parsed }
+}
+
+const failures = []
+const report = (label, ok, detail) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}  ${detail}`)
+  if (!ok) failures.push(label)
+}
+
+// --- probe 0: user write (register doubles as the User-table write probe) -----
+const registered = await call('POST', '/users/register', {
+  username,
+  email: `${username}@example.com`,
+  password,
+})
+const userId = registered.body?.user?.id
+report(
+  'user write      (POST /users/register)',
+  Boolean(userId),
+  `${registered.status} in ${registered.ms}ms${
+    userId ? '' : ` — ${registered.body?.message || 'no user id returned'}`
+  }`,
+)
+if (!userId) {
+  console.error(
+    '\ndb-write smoke FAILED: cannot register a probe user, so the ' +
+      'authenticated probes were skipped. See issue #324.',
+  )
+  process.exit(1)
+}
+
+const login = await call('POST', '/auth/login', { username, password })
+const token = login.body?.data?.token || login.body?.token
+if (!token) {
+  console.error(`setup failed: login returned ${login.status}`)
+  await call('DELETE', `/users/${userId}`, undefined, token)
+  process.exit(1)
+}
+
+// --- the two probes ----------------------------------------------------------
+const todo = await call('POST', '/todos', { title: `smoke ${stamp}` }, token)
+report(
+  'control write   (POST /todos)  ',
+  todo.status === 201 && todo.body?.data?.id,
+  `${todo.status} in ${todo.ms}ms`,
+)
+
+const reward = await call(
+  'POST',
+  '/rewards',
+  {
+    name: 'Cypress Smoke Reward',
+    slug: `cypress-smoke-${stamp}`,
+    rewardType: 'ITEM',
+    rarity: 'COMMON',
+  },
+  token,
+)
+report(
+  'canary write    (POST /rewards)',
+  [200, 201].includes(reward.status) && reward.body?.data?.id,
+  `${reward.status} in ${reward.ms}ms${
+    reward.status === 503 ? ` — ${reward.body?.message || 'unavailable'}` : ''
+  }`,
+)
+
+// --- cleanup (best-effort; user purge removes owned rows regardless) ----------
+if (todo.body?.data?.id) {
+  await call('DELETE', `/todos/${todo.body.data.id}`, undefined, token)
+}
+if (reward.body?.data?.id) {
+  await call('DELETE', `/rewards/${reward.body.data.id}`, undefined, token)
+}
+const removal = await call('DELETE', `/users/${userId}`, undefined, token)
+if (![200, 202, 204].includes(removal.status)) {
+  console.warn(
+    `cleanup warning: DELETE /users/${userId} returned ${removal.status} ` +
+      '(the cypress-user janitor will sweep it)',
+  )
+}
+
+// --- verdict -------------------------------------------------------------------
+if (failures.length > 0) {
+  console.error(`\ndb-write smoke FAILED (${failures.length}/3): see issue #324`)
+  process.exit(1)
+}
+console.log('\ndb-write smoke passed: failing-table and control writes both commit.')


### PR DESCRIPTION
## Summary
Add two diagnostic scripts to help investigate and monitor issue #324, a deterministic per-table database write failure where INSERTs succeed server-side but connections are destroyed before COMMIT.

## Key Changes
- **`scripts/db-write-repro.mjs`**: Minimal reproduction harness for issue #324
  - Tests both text and binary protocols with/without query includes
  - Exercises control table (Todo — passes in prod) and failing tables (Chat, Reward)
  - Captures connector-level trace logging to surface original errors before generic "Cannot execute new commands" message
  - Supports testing via ProxySQL (production path) or direct MariaDB connection
  - Cleans up all created rows on completion
  - Includes detailed instructions for running on Alexandria with LAN access

- **`scripts/db-write-smoke.mjs`**: Fast canary test for issue #324 via live API
  - Runs anywhere with network access in ~15s (no Cypress, no DB credentials)
  - Creates throwaway test user and performs one control write (Todo) and one failing-table write (Reward)
  - Supports custom API base URL via `BASE_API_URL` environment variable
  - Exit code 0 = both writes committed (bug fixed), exit code 1 = failure detected
  - Cleans up test fixtures automatically (compatible with existing cypress cleanup sweeps)

- **`package.json`**: Added npm scripts for the new diagnostic tools

## Implementation Details
- Both scripts use the live Prisma client and MariaDB adapter
- `db-write-repro.mjs` includes comprehensive logging with connector-level error capture to distinguish between driver bugs, adapter issues, and network path problems
- `db-write-smoke.mjs` provides quick health checks suitable for CI/CD pipelines and preview deployments
- Scripts include detailed diagnostic output to help narrow down whether failures are driver-level, adapter-level, or network-path-specific

https://claude.ai/code/session_013WiGtSg2iCYS6rSXr1jfFa