### PR TITLE
kind-robots/t-012 follow-up: mount credit-purchase.vue, fix dead-end redirect

### DIFF
--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -55,9 +55,25 @@
 
       <section
         v-else-if="activeTab === 'mana'"
-        class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+        class="flex h-full min-h-0 flex-1 flex-col gap-6 overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-4"
       >
-        <mana-wallet class="h-full min-h-0 flex-1 overflow-hidden" />
+        <div
+          v-if="manaTopupNotice"
+          class="rounded-xl border p-3 text-center text-sm font-medium"
+          :class="
+            manaTopupNotice === 'success'
+              ? 'border-success/40 bg-success/10 text-success'
+              : 'border-warning/40 bg-warning/10 text-warning'
+          "
+        >
+          {{
+            manaTopupNotice === 'success'
+              ? '⚡ Mana top-up complete — your balance updates below.'
+              : 'Mana top-up cancelled. No charge was made.'
+          }}
+        </div>
+        <mana-wallet />
+        <credit-purchase />
         <subscription-manager />
       </section>
 
@@ -114,9 +130,12 @@ const dashboardConfig = dashboardConfigs[defaultDashboardKey]
 const cartStore = useCartStore()
 const navStore = useNavStore()
 const userStore = useUserStore()
+const route = useRoute()
+const router = useRouter()
 
 const isLoadingManager = ref(false)
 const managerError = ref<string | null>(null)
+const manaTopupNotice = ref<'success' | 'cancelled' | null>(null)
 
 const dashboardKey = computed(() => {
   return navStore.dashboardShell.dashboardKey || defaultDashboardKey
@@ -162,6 +181,15 @@ const swarmMemo = computed(() => {
 
 onMounted(async () => {
   await refreshManagerData()
+
+  const topupQuery = route.query.manaTopup
+  if (topupQuery === 'success' || topupQuery === 'cancelled') {
+    manaTopupNotice.value = topupQuery
+    setTab('mana')
+    const { manaTopup: _drop, ...restQuery } = route.query
+    router.replace({ query: restQuery })
+    return
+  }
 
   if (!isDashboardTabKey(defaultDashboardKey, storedTab.value)) {
     setTab(dashboardConfig.defaultTab)

--- a/server/api/stripe/topup.post.ts
+++ b/server/api/stripe/topup.post.ts
@@ -77,8 +77,8 @@ export default defineEventHandler(async (event) => {
         userId: String(user.id),
         manaAmount: String(manaAmount),
       },
-      success_url: `${process.env.BASE_URL}/shop/success`,
-      cancel_url: `${process.env.BASE_URL}/shop/cancel`,
+      success_url: `${process.env.BASE_URL}/sanctuary?manaTopup=success`,
+      cancel_url: `${process.env.BASE_URL}/sanctuary?manaTopup=cancelled`,
     })
 
     response = {


### PR DESCRIPTION
## Summary

PR #345 (merged earlier this cycle) built the full mana top-up flow — `server/api/stripe/topup.post.ts`, `server/api/stripe/webhook.post.ts`, `cartStore.topup()` — but left two loose ends:

- `credit-purchase.vue` was never mounted anywhere reachable in the app.
- Its Stripe success/cancel redirects point at `/shop/success` / `/shop/cancel`, routes that don't exist.

This PR closes both gaps:

- Mounts `<credit-purchase />` in `giftshop-manager.vue`'s "mana" tab, alongside `mana-wallet` and `subscription-manager`.
- Points `topup.post.ts`'s `success_url`/`cancel_url` at `/sanctuary?manaTopup=<state>` — a route that already exists and is already the tab's canonical URL.
- `giftshop-manager.vue` reads that query param on mount, switches to the mana tab, shows a one-time success/cancelled banner, then strips the query param.
- Widened the mana tab's container from `overflow-hidden` to `overflow-y-auto` since it now stacks three components instead of one.

## Test plan

- [x] `eslint` on changed files — clean (the one reported error, `swarmMemo` unused-var, is pre-existing on `main` and unrelated to this diff — confirmed via `git stash` + re-run)
- [x] `prettier --check` — clean
- [x] Full-project `vue-tsc --noEmit` — 0 errors
- [ ] Live Stripe test-mode round trip — not run (no MySQL/Stripe test keys available in this sandbox); same gap noted on the parent PR's own verification

Cross-repo tracking: conductor `kind-robots/t-012` and `digital-storefront/t-012`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1iVNDsFKrZc3WXxQYcQ6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1iVNDsFKrZc3WXxQYcQ6H)_