### PR TITLE
Fix Screen FX component rendering

### DIFF
--- a/components/screenfx/animation-layer.vue
+++ b/components/screenfx/animation-layer.vue
@@ -43,29 +43,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, resolveComponent } from 'vue'
-import {
-  getAnimationComponentName,
-  type AnimationEffectId,
-} from '@/stores/animationCatalog'
+import { computed } from 'vue'
+import { getAnimationEffectComponent } from '@/components/screenfx/effect-component-registry'
 import { useAnimationStore } from '@/stores/animationStore'
 
 const animationStore = useAnimationStore()
 
-const componentsMap = new Map<
-  AnimationEffectId,
-  ReturnType<typeof resolveComponent>
->(
-  animationStore.effects.map((effect) => [
-    effect.id,
-    resolveComponent(getAnimationComponentName(effect.id)),
-  ]),
-)
-
 const activeComponent = computed(() => {
   const effectId = animationStore.activeEffectId
   if (!effectId) return null
-  return componentsMap.get(effectId) || null
+  return getAnimationEffectComponent(effectId)
 })
 </script>
 

--- a/components/screenfx/effect-component-registry.ts
+++ b/components/screenfx/effect-component-registry.ts
@@ -1,6 +1,9 @@
 // /components/screenfx/effect-component-registry.ts
 import { defineAsyncComponent, type Component } from 'vue'
-import type { AnimationEffectId } from '@/stores/animationCatalog'
+import {
+  getAnimationComponentName,
+  type AnimationEffectId,
+} from '@/stores/animationCatalog'
 
 type EffectModule = {
   default: Component
@@ -9,13 +12,31 @@ type EffectModule = {
 const effectModules = import.meta.glob<EffectModule>('./*.vue')
 const componentCache = new Map<AnimationEffectId, Component>()
 
+function pascalFromPath(path: string): string {
+  const filename = path.split('/').at(-1)?.replace(/\.vue$/, '') ?? ''
+
+  return filename
+    .split(/[-_.]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join('')
+}
+
+const effectLoaders = new Map(
+  Object.entries(effectModules).map(([path, loader]) => [
+    pascalFromPath(path),
+    loader,
+  ]),
+)
+
 export function getAnimationEffectComponent(
   effectId: AnimationEffectId,
 ): Component | null {
   const cached = componentCache.get(effectId)
   if (cached) return cached
 
-  const loader = effectModules[`./${effectId}.vue`]
+  const componentName = getAnimationComponentName(effectId).replace(/^Lazy/, '')
+  const loader = effectLoaders.get(componentName)
   if (!loader) return null
 
   const component = defineAsyncComponent(async () => {

--- a/components/screenfx/effect-component-registry.ts
+++ b/components/screenfx/effect-component-registry.ts
@@ -1,0 +1,28 @@
+// /components/screenfx/effect-component-registry.ts
+import { defineAsyncComponent, type Component } from 'vue'
+import type { AnimationEffectId } from '@/stores/animationCatalog'
+
+type EffectModule = {
+  default: Component
+}
+
+const effectModules = import.meta.glob<EffectModule>('./*.vue')
+const componentCache = new Map<AnimationEffectId, Component>()
+
+export function getAnimationEffectComponent(
+  effectId: AnimationEffectId,
+): Component | null {
+  const cached = componentCache.get(effectId)
+  if (cached) return cached
+
+  const loader = effectModules[`./${effectId}.vue`]
+  if (!loader) return null
+
+  const component = defineAsyncComponent(async () => {
+    const module = await loader()
+    return module.default
+  })
+
+  componentCache.set(effectId, component)
+  return component
+}

--- a/components/screenfx/fx-region.vue
+++ b/components/screenfx/fx-region.vue
@@ -27,12 +27,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, resolveComponent } from 'vue'
-import {
-  getAnimationComponentName,
-  type AnimationEffectId,
-  type FxRegion,
-} from '@/stores/animationCatalog'
+import { computed, onMounted, ref, type Component } from 'vue'
+import { getAnimationEffectComponent } from '@/components/screenfx/effect-component-registry'
+import type { AnimationEffectId, FxRegion } from '@/stores/animationCatalog'
 import {
   useAnimationStore,
   type FxPlacement,
@@ -50,20 +47,10 @@ onMounted(() => {
   isMounted.value = true
 })
 
-const componentsMap = new Map<
-  AnimationEffectId,
-  ReturnType<typeof resolveComponent>
->(
-  animationStore.effects.map((effect) => [
-    effect.id,
-    resolveComponent(getAnimationComponentName(effect.id)),
-  ]),
-)
-
 interface SurfaceEntry {
   key: string
   id: AnimationEffectId
-  component: ReturnType<typeof resolveComponent>
+  component: Component
 }
 
 function entriesForPlacement(placement: FxPlacement): SurfaceEntry[] {
@@ -73,7 +60,7 @@ function entriesForPlacement(placement: FxPlacement): SurfaceEntry[] {
   const seen = new Set<AnimationEffectId>()
 
   animationStore.screenEffects.forEach((effect) => {
-    const component = componentsMap.get(effect.id)
+    const component = getAnimationEffectComponent(effect.id)
 
     if (!component || seen.has(effect.id)) return
 

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -17,18 +17,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  resolveComponent,
-  watch,
-} from 'vue'
-import {
-  getAnimationComponentName,
-  type AnimationEffectId,
-} from '@/stores/animationCatalog'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { getAnimationEffectComponent } from '@/components/screenfx/effect-component-registry'
+import type { AnimationEffectId } from '@/stores/animationCatalog'
 import { useAnimationStore } from '@/stores/animationStore'
 import { useAnimationPreferenceStore } from '@/stores/animationPreferenceStore'
 import { useButterflyStore } from '@/stores/butterflyStore'
@@ -47,19 +38,9 @@ const FADE_MS = 650
 
 let fadeTimer: ReturnType<typeof setTimeout> | null = null
 
-const componentsMap = new Map<
-  AnimationEffectId,
-  ReturnType<typeof resolveComponent>
->(
-  animationStore.effects.map((effect) => [
-    effect.id,
-    resolveComponent(getAnimationComponentName(effect.id)),
-  ]),
-)
-
 const currentComponent = computed(() => {
   if (!resolvedEffectId.value) return null
-  return componentsMap.get(resolvedEffectId.value) || null
+  return getAnimationEffectComponent(resolvedEffectId.value)
 })
 
 function clearFadeTimer(): void {
@@ -72,7 +53,10 @@ function selectEffect(): void {
   preferenceStore.initialize()
 
   const availableIds = animationStore.safeEffects
-    .filter((effect) => !effect.blocksInput && componentsMap.has(effect.id))
+    .filter(
+      (effect) =>
+        !effect.blocksInput && Boolean(getAnimationEffectComponent(effect.id)),
+    )
     .map((effect) => effect.id)
 
   resolvedEffectId.value = preferenceStore.resolveStartupEffect(availableIds)

--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -69,6 +69,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { useComponentStore } from '@/stores/componentStore'
 import { useNavStore } from '@/stores/navStore'
 
@@ -82,6 +83,7 @@ const dashboardKey = 'wonder' as const
 const fallbackTab: LabTab = 'memory-dungeon'
 const validTabs: LabTab[] = ['memory-dungeon', 'wonder-lab', 'screen-fx']
 
+const route = useRoute()
 const navStore = useNavStore()
 const componentStore = useComponentStore()
 
@@ -89,6 +91,9 @@ const isLoading = ref(false)
 const managerError = ref<string | null>(null)
 
 const activeTab = computed<LabTab>(() => {
+  const routePath = route.path.replace(/\/+$/, '') || '/'
+  if (routePath === '/screenfx') return 'screen-fx'
+
   const selectedTab = navStore.getDashboardTab(dashboardKey)
 
   if (validTabs.includes(selectedTab as LabTab)) {


### PR DESCRIPTION
## What changed

- replace runtime `resolveComponent('Lazy…')` lookups with a Vite-bundled Screen FX component registry
- mirror Nuxt's filename normalization so hyphen, underscore, and dotted effect filenames all resolve correctly
- use the shared registry for persistent surface effects, the global generation layer, and startup animations
- cache async component wrappers so repeated toggles reuse the same component definition
- make direct `/screenfx` loads render the Screen FX tab before remembered WonderLab fallback state

## Why

All three animation paths depended on Nuxt exposing dynamically constructed `Lazy…` component names at runtime. When that registration is unavailable, the store still marks effects active but Vue has no concrete component to render, producing the all-effects-invisible failure.

Production SSR also rendered Memory Dungeon on `/screenfx` because `lab-manager` consulted the default dashboard tab before client-side page state synchronized.

## Validation

- ✅ TypeScript Type Check
- ✅ Contract Tests
- ✅ direct `/screenfx` route selects `screen-fx` synchronously
- ✅ all rendering paths resolve from one statically discoverable `import.meta.glob('./*.vue')` registry
- ✅ branch is based on current `main` with no unrelated changes

## Manual smoke checks

- [ ] direct-load `/screenfx` and confirm the controls render immediately
- [ ] toggle multiple Screen FX effects on the page/front surface
- [ ] switch page placement between behind/front/off
- [ ] trigger a generation animation and confirm the full-screen layer appears
- [ ] confirm startup animation still fades cleanly
