### PR TITLE
global-ui/t-012 + t-022: migrate callouts onto kr-note + extract shared leaderboard-table

### DIFF
--- a/components/achievements/leaderboard-table.vue
+++ b/components/achievements/leaderboard-table.vue
@@ -1,0 +1,43 @@
+<!-- /components/achievements/leaderboard-table.vue -->
+<template>
+  <table
+    class="table-auto w-full border-collapse rounded-lg border border-base-300"
+  >
+    <thead>
+      <tr class="bg-base-200">
+        <th class="border border-base-300 px-4 py-2">Rank</th>
+        <th class="border border-base-300 px-4 py-2">Username</th>
+        <th class="border border-base-300 px-4 py-2">{{ scoreLabel }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(row, index) in rows" :key="row.id" class="hover:bg-base-100">
+        <td class="border border-base-300 px-4 py-2 text-center">
+          {{ index + 1 }}
+        </td>
+        <td class="border border-base-300 px-4 py-2">{{ row.username }}</td>
+        <td class="border border-base-300 px-4 py-2 text-center">
+          {{ row[scoreKey] ?? 'N/A' }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+// Shared presentational leaderboard table used by both click-leaderboard.vue
+// and match-leaderboard.vue so the rank/username/record markup can't drift
+// apart (global-ui/t-022, following the honeydo-card pattern from t-020).
+interface LeaderboardRow {
+  id: number
+  username: string
+  clickRecord?: number
+  matchRecord?: number
+}
+
+defineProps<{
+  rows: LeaderboardRow[]
+  scoreLabel: string
+  scoreKey: 'clickRecord' | 'matchRecord'
+}>()
+</script>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -15,7 +15,7 @@
 
     <div
       v-if="mode === 'edit' && !botStore.currentBot"
-      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+      class="kr-note kr-note-warning"
     >
       Select a bot before editing.
     </div>
@@ -435,19 +435,15 @@
 
       <div
         v-if="botStore.lastError"
-        class="rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error"
+        class="kr-note kr-note-error"
       >
         {{ botStore.lastError }}
       </div>
 
       <div
         v-if="statusMessage"
-        class="rounded-2xl border p-3 text-sm"
-        :class="
-          statusTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        class="kr-note"
+        :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}
       </div>

--- a/components/bots/bot-interact.vue
+++ b/components/bots/bot-interact.vue
@@ -18,12 +18,8 @@
 
     <div
       v-if="statusMessage"
-      class="rounded-2xl border p-3 text-sm"
-      :class="
-        statusTone === 'error'
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'border-success/40 bg-success/10 text-success'
-      "
+      class="kr-note"
+      :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
     >
       {{ statusMessage }}
     </div>
@@ -95,10 +91,7 @@
             </div>
           </div>
 
-          <div
-            v-else
-            class="flex flex-col gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
-          >
+          <div v-else class="kr-note kr-note-warning flex flex-col gap-3">
             <p class="font-bold">No bot selected.</p>
 
             <bot-gallery
@@ -378,8 +371,7 @@
 
           <pre
             class="max-h-full overflow-auto whitespace-pre-wrap rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
-            >{{ promptPreview }}</pre
-          >
+            >{{ promptPreview }}</pre>
         </section>
       </aside>
     </section>

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -15,7 +15,7 @@
 
     <div
       v-if="mode === 'edit' && !promptStore.selectedPrompt"
-      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+      class="kr-note kr-note-warning"
     >
       Select a prompt before editing.
     </div>
@@ -260,21 +260,14 @@
         </div>
       </section>
 
-      <div
-        v-if="promptStore.lastError"
-        class="rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error"
-      >
+      <div v-if="promptStore.lastError" class="kr-note kr-note-error">
         {{ promptStore.lastError }}
       </div>
 
       <div
         v-if="statusMessage"
-        class="rounded-2xl border p-3 text-sm"
-        :class="
-          statusTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        class="kr-note"
+        :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}
       </div>
@@ -547,7 +540,6 @@ function handleKeepFieldChange(field: string) {
     useGenerated[field] = false
   }
 }
-
 
 function seedPrompt() {
   promptStore.setPromptForm({

--- a/components/characters/character-interact.vue
+++ b/components/characters/character-interact.vue
@@ -5,12 +5,8 @@
   >
     <div
       v-if="statusMessage"
-      class="rounded-2xl border p-3 text-sm"
-      :class="
-        statusTone === 'error'
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'border-success/40 bg-success/10 text-success'
-      "
+      class="kr-note"
+      :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
     >
       {{ statusMessage }}
     </div>
@@ -67,7 +63,7 @@
 
           <div
             v-else
-            class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm text-warning"
+            class="kr-note kr-note-warning"
           >
             No character selected. Return to the gallery and pick a beautiful
             little problem.

--- a/components/composition/add-composition.vue
+++ b/components/composition/add-composition.vue
@@ -10,7 +10,7 @@
 
     <div
       v-if="mode === 'edit' && !compositionStore.selected"
-      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+      class="kr-note kr-note-warning"
     >
       Select a composition before editing.
     </div>
@@ -236,11 +236,7 @@
       <div
         v-if="statusMessage"
         class="rounded-2xl border p-3 text-sm"
-        :class="
-          statusTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}
       </div>

--- a/components/composition/composition-interact.vue
+++ b/components/composition/composition-interact.vue
@@ -23,12 +23,8 @@
 
     <div
       v-if="statusMessage"
-      class="rounded-2xl border p-3 text-sm"
-      :class="
-        statusTone === 'error'
-          ? 'border-error/40 bg-error/10 text-error'
-          : 'border-success/40 bg-success/10 text-success'
-      "
+      class="kr-note"
+      :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
     >
       {{ statusMessage }}
     </div>
@@ -113,8 +109,7 @@
             <pre
               v-if="synthesisPrompt"
               class="whitespace-pre-wrap rounded-2xl bg-base-300 p-3 text-sm leading-relaxed text-base-content/80"
-              >{{ synthesisPrompt }}</pre
-            >
+              >{{ synthesisPrompt }}</pre>
             <div
               v-else
               class="flex min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 p-4 text-center text-sm text-base-content/50"

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -40,10 +40,8 @@
         <div class="min-h-0 flex-1 space-y-4 overflow-y-auto p-3 sm:p-4">
           <div
             v-if="statusMessage"
-            class="rounded-2xl border p-3 text-sm font-bold"
-            :class="statusTone === 'success'
-              ? 'border-success/40 bg-success/10 text-success'
-              : 'border-error/40 bg-error/10 text-error'"
+            class="kr-note"
+            :class="statusTone === 'success' ? 'kr-note-success' : 'kr-note-error'"
           >
             {{ statusMessage }}
           </div>

--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -2,32 +2,11 @@
 <template>
   <div class="p-4">
     <h1 class="text-xl font-bold mb-4">Global Leaderboard</h1>
-    <table
-      class="table-auto w-full border-collapse border border-gray-300 rounded-lg"
-    >
-      <thead>
-        <tr class="bg-gray-200">
-          <th class="px-4 py-2 border border-gray-300">Rank</th>
-          <th class="px-4 py-2 border border-gray-300">Username</th>
-          <th class="px-4 py-2 border border-gray-300">Click Record</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          v-for="(user, index) in leaderboard"
-          :key="user.id"
-          class="hover:bg-gray-100"
-        >
-          <td class="px-4 py-2 border border-gray-300 text-center">
-            {{ index + 1 }}
-          </td>
-          <td class="px-4 py-2 border border-gray-300">{{ user.username }}</td>
-          <td class="px-4 py-2 border border-gray-300 text-center">
-            {{ user.clickRecord ?? 'N/A' }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <leaderboard-table
+      :rows="leaderboard"
+      score-label="Click Record"
+      score-key="clickRecord"
+    />
   </div>
 </template>
 

--- a/components/pages/match-leaderboard.vue
+++ b/components/pages/match-leaderboard.vue
@@ -16,34 +16,11 @@
       class="rounded-2xl border p-3 m-3 mt-4 bg-base-300 text-center transition-all duration-300"
     >
       <h1 class="text-xl font-bold mb-4">Global Match Leaderboard</h1>
-      <table
-        class="table-auto w-full border-collapse border border-gray-300 rounded-lg"
-      >
-        <thead>
-          <tr class="bg-gray-200">
-            <th class="px-4 py-2 border border-gray-300">Rank</th>
-            <th class="px-4 py-2 border border-gray-300">Username</th>
-            <th class="px-4 py-2 border border-gray-300">Match Record</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="(user, index) in leaderboard"
-            :key="user.id"
-            class="hover:bg-gray-100"
-          >
-            <td class="px-4 py-2 border border-gray-300 text-center">
-              {{ index + 1 }}
-            </td>
-            <td class="px-4 py-2 border border-gray-300">
-              {{ user.username }}
-            </td>
-            <td class="px-4 py-2 border border-gray-300 text-center">
-              {{ user.matchRecord ?? 'N/A' }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <leaderboard-table
+        :rows="leaderboard"
+        score-label="Match Record"
+        score-key="matchRecord"
+      />
     </div>
   </div>
 </template>

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -15,7 +15,7 @@
 
     <div
       v-if="mode === 'edit' && !rewardStore.selectedReward"
-      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+      class="kr-note kr-note-warning"
     >
       Select a reward before editing.
     </div>
@@ -229,11 +229,7 @@
       <div
         v-if="statusMessage"
         class="rounded-2xl border p-3 text-sm"
-        :class="
-          statusTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}
       </div>
@@ -278,7 +274,11 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useArtStore } from '@/stores/artStore'
 import { useChoiceStore } from '@/stores/choiceStore'
-import { useRewardStore, type Rarity, type RewardType } from '@/stores/rewardStore'
+import {
+  useRewardStore,
+  type Rarity,
+  type RewardType,
+} from '@/stores/rewardStore'
 import { useUploadStore } from '@/stores/uploadStore'
 
 const props = withDefaults(

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -15,7 +15,7 @@
 
     <div
       v-if="mode === 'edit' && !scenarioStore.selectedScenario"
-      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+      class="kr-note kr-note-warning"
     >
       Select a scenario before editing.
     </div>
@@ -249,12 +249,8 @@
 
       <div
         v-if="statusMessage"
-        class="rounded-2xl border p-3 text-sm"
-        :class="
-          statusTone === 'error'
-            ? 'border-error/40 bg-error/10 text-error'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        class="kr-note"
+        :class="statusTone === 'error' ? 'kr-note-error' : 'kr-note-success'"
       >
         {{ statusMessage }}
       </div>

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -27,11 +27,7 @@
       </button>
     </div>
 
-    <div
-      v-if="message"
-      class="rounded-2xl border p-3 text-sm"
-      :class="messageClass"
-    >
+    <div v-if="message" class="kr-note" :class="messageClass">
       {{ message }}
     </div>
 
@@ -248,14 +244,7 @@ type ResourceType =
   | 'API'
 
 type SupportedServer =
-  | 'SDXL'
-  | 'SD15'
-  | 'FLUX'
-  | 'KONTEXT'
-  | 'COMFY'
-  | 'A1111'
-  | 'OPENAI'
-  | 'OTHER'
+  'SDXL' | 'SD15' | 'FLUX' | 'KONTEXT' | 'COMFY' | 'A1111' | 'OPENAI' | 'OTHER'
 
 type AddCheckpointForm = {
   name: string
@@ -316,14 +305,14 @@ const canSubmit = computed(() => {
 
 const messageClass = computed(() => {
   if (messageType.value === 'success') {
-    return 'border-success/40 bg-success/10 text-success'
+    return 'kr-note-success'
   }
 
   if (messageType.value === 'error') {
-    return 'border-error/40 bg-error/10 text-error'
+    return 'kr-note-error'
   }
 
-  return 'border-info/40 bg-info/10 text-info'
+  return 'kr-note-info'
 })
 
 function cleanOptional(value: string) {

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -481,6 +481,13 @@
             </tbody>
           </table>
         </div>
+        <div class="kr-panel-flat overflow-x-auto">
+          <leaderboard-table
+            :rows="sampleLeaderboard"
+            score-label="Click Record"
+            score-key="clickRecord"
+          />
+        </div>
       </section>
 
       <!-- Progress & loaders -->
@@ -546,6 +553,12 @@ const sections = [
   { id: 'nav', label: 'Nav' },
   { id: 'data', label: 'Data' },
   { id: 'progress', label: 'Progress' },
+]
+
+const sampleLeaderboard = [
+  { id: 1, username: 'kindrobot', clickRecord: 9001 },
+  { id: 2, username: 'silas', clickRecord: 742 },
+  { id: 3, username: 'amibot', clickRecord: 128 },
 ]
 
 const tokens = [

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -16,7 +16,7 @@
 
     <div
       v-if="!userStore.isLoggedIn || userStore.isGuest"
-      class="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm font-semibold text-warning"
+      class="kr-note kr-note-warning"
     >
       Sign in to manage your account settings.
     </div>
@@ -25,7 +25,7 @@
       <!-- Query-string banners (from email links) -->
       <div
         v-if="banner"
-        class="rounded-2xl border p-3 text-sm font-semibold"
+        class="kr-note"
         :class="banner.ok ? okClass : errClass"
       >
         {{ banner.text }}
@@ -302,8 +302,8 @@ const userStore = useUserStore()
 const account = useAccountStore()
 const route = useRoute()
 
-const okClass = 'border-success/40 bg-success/10 text-success'
-const errClass = 'border-error/40 bg-error/10 text-error'
+const okClass = 'kr-note-success'
+const errClass = 'kr-note-error'
 
 // ── Email / password state ──────────────────────────────────────────────────
 const userEmail = computed(() => userStore.user?.email ?? '')


### PR DESCRIPTION
## What & why

Design-system consolidation for **global-ui** (conductor tasks **t-012** and **t-022**) — DB-free front-end work chosen deliberately while the prod DB is write-locked (kind-robots/t-022). Migrates hand-rolled surfaces onto the canonical `.kr-*` classes shipped by t-011/t-013, and extracts the one duplicated item-card t-022's audit found.

3 clean commits, 15 files, **+107 / −145** — pure presentational class swaps + one component extraction. No logic, type, store, or data-source changes.

### 1. `t-012` — callouts onto `.kr-note-*` (11 files)
Hand-rolled status callouts (`border-{status}/40 bg-{status}/10 text-{status}` + static/ternary/computed variants) → canonical `.kr-note` + `.kr-note-{info,success,warning,error}`:
- **add-\* forms:** add-bot, add-character, add-scenario, add-reward, add-checkpoint, add-composition
- **interact + settings:** character/bot/composition-interact, server-selector, account-settings

Most sites lacked `text-sm font-semibold`, so they adopt the canonical treatment (the point of t-012). `account-settings` was already byte-canonical, so its swap is visually identical.

### 2. `t-022` — shared `leaderboard-table.vue` (4 files)
`click-leaderboard.vue` and `match-leaderboard.vue` rendered an identical rank/username/record table differing only in the score column. Extracted `components/achievements/leaderboard-table.vue` (props `rows`, `scoreLabel`, `scoreKey`) and rewired both callers — same drift-prevention pattern t-020 applied to `honeydo-card`. Off-theme `gray-*` → theme-aware `base-*` tokens. Added a live example to the `/ui` data gallery.

## Verification
- `npm run test` (vue-tsc `--noEmit`) — **exit 0, green** locally.
- Prettier-clean; no new eslint errors (there is no lint CI gate; typecheck is the gate).
- `/ui` gallery renders the canonical `.kr-note-*` + the new leaderboard **without a DB** (static route).

## Needs a preview-deploy eyeball (the human-in-the-loop step)
Class swaps are visually verifiable headlessly only via `/ui`; the **data pages behind auth** (add-\* dialogs, interact views, `account-settings`, the real leaderboards) want a per-surface visual check on a preview deploy, since the sandbox has no DB.

## Deliberately deferred (documented, not done here)
- **Art surfaces** (`artjob-manager.vue`, `stylist-relay-status.vue`) — full-height flex containers / dense `p-2 text-xs` chips where `.kr-note` (which bakes `p-4 text-sm font-semibold`) is a poor fit.
- **`/30`-opacity notices with no text color** (composition-interact narrative panel, server-selector info panel) — would gain colored text.
- **stage-manager** rounded-full status pills — not inline notes.
- **Generic-panel migration (t-012 remainder)** and **code-library computed maps** — untouched; want the preview-driven pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9TYhcS9hmeVc6Hprr74M)_