### PR TITLE
Polish startup animation sequence and loader layering

### DIFF
--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -63,11 +63,13 @@ const minimumSequenceComplete = ref(false)
 const logoLoaded = ref(false)
 const hiddenEmitted = ref(false)
 
-const FIRST_MESSAGE_MS = 850
-const SLOW_LOAD_MESSAGE_MS = 1500
+const FIRST_MESSAGE_MS = 950
+const EXTRA_MESSAGE_COUNT = 2
+const EXTRA_MESSAGE_MS = 1250
 const ROTATING_MESSAGE_MS = 1600
-const READY_HOLD_MS = 350
-const MIN_TOTAL_MS = 1800
+const READY_HOLD_MS = 450
+const MIN_TOTAL_MS =
+  FIRST_MESSAGE_MS + EXTRA_MESSAGE_COUNT * EXTRA_MESSAGE_MS + READY_HOLD_MS
 const OVERLAY_FADE_MS = 650
 
 const startTime = Date.now()
@@ -148,8 +150,14 @@ function handleTransitionEnd(event: TransitionEvent) {
 
 async function runVisualSequence() {
   await wait(FIRST_MESSAGE_MS)
-  if (destroyed) return
 
+  for (let index = 0; index < EXTRA_MESSAGE_COUNT; index += 1) {
+    if (destroyed) return
+    nextMessage()
+    await wait(EXTRA_MESSAGE_MS)
+  }
+
+  if (destroyed) return
   minimumSequenceComplete.value = true
 
   if (props.storesReady) {
@@ -157,10 +165,6 @@ async function runVisualSequence() {
     return
   }
 
-  await wait(SLOW_LOAD_MESSAGE_MS)
-  if (destroyed || props.storesReady || fadeOverlay.value) return
-
-  nextMessage()
   rotationIntervalId = setInterval(() => {
     if (destroyed) return
     nextMessage()
@@ -204,7 +208,7 @@ onBeforeUnmount(() => {
   display: grid;
   place-items: center;
   padding: 1rem;
-  background: #000;
+  background: transparent;
   opacity: 1;
   transition: opacity 650ms ease;
   pointer-events: auto;

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -5,13 +5,17 @@
       v-if="renderEffect && currentComponent"
       class="startup-animation"
       :class="{ 'startup-animation--fading': isFading }"
-      aria-hidden="true"
     >
       <component
         :is="currentComponent"
         :key="resolvedEffectId"
         class="startup-animation__effect"
+        aria-hidden="true"
       />
+
+      <div v-if="currentEffectLabel" class="startup-animation__label">
+        Animation: {{ currentEffectLabel }}
+      </div>
     </div>
   </Teleport>
 </template>
@@ -41,6 +45,16 @@ let fadeTimer: ReturnType<typeof setTimeout> | null = null
 const currentComponent = computed(() => {
   if (!resolvedEffectId.value) return null
   return getAnimationEffectComponent(resolvedEffectId.value)
+})
+
+const currentEffectLabel = computed(() => {
+  if (!resolvedEffectId.value) return ''
+
+  return (
+    animationStore.effects.find(
+      (effect) => effect.id === resolvedEffectId.value,
+    )?.label ?? resolvedEffectId.value
+  )
 })
 
 function clearFadeTimer(): void {
@@ -103,7 +117,7 @@ onBeforeUnmount(() => {
 .startup-animation {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: 49;
   overflow: hidden;
   pointer-events: none;
   opacity: 1;
@@ -121,5 +135,27 @@ onBeforeUnmount(() => {
   inset: 0;
   width: 100%;
   height: 100%;
+}
+
+.startup-animation__label {
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 100;
+  max-width: calc(100vw - 2rem);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 9999px;
+  padding: 0.45rem 0.8rem;
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(0.5rem);
 }
 </style>

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -119,6 +119,7 @@ onBeforeUnmount(() => {
   inset: 0;
   z-index: 49;
   overflow: hidden;
+  background: #000;
   pointer-events: none;
   opacity: 1;
   transition: opacity 650ms ease;


### PR DESCRIPTION
## What changed

- guarantee two rotating loading messages after `Building Kind Robots...` before the startup loader may fade
- extend the minimum visible boot sequence to roughly four seconds
- place startup animations below the loader foreground so the Kind Robots logo, spinner, and loading message remain visible
- give the startup animation layer its own black stage so sparse effects do not expose the already-rendered app
- make the loader foreground transparent so the selected animation remains visible beneath it
- add a bottom-left `Animation: {name}` badge during startup to identify effects that appear visually empty

## Why

The loader could finish as soon as stores were ready, which often ended the sequence before any extra loading copy appeared. Warp Drive also renders an opaque black canvas and the startup animation layer sat above the loader at `z-index: 100`, covering the logo and status message.

## Validation

- ✅ TypeScript Type Check
- ✅ Contract Tests
- ✅ branch contains only the loader timing and startup-layer changes

## Manual smoke checks

- [ ] confirm `Building Kind Robots...` is followed by two additional messages
- [ ] confirm Warp Drive remains behind the logo, spinner, and message
- [ ] confirm the bottom-left animation badge names the startup effect
- [ ] note the name of any effect with no visible startup motion
- [ ] confirm loader fade and startup-effect fade remain synchronized
