### PR TITLE
model-builder/t-027 + t-029: quantity batch editor + tutorial section

### DIFF
--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -1,0 +1,254 @@
+<!-- /components/model-builder/model-builder-batch-editor.vue -->
+<!--
+  Batch editor for a quantity / expansion output (model-builder/t-027). A quantity
+  output produces N BuildItems sharing an outputKey; this panel edits them
+  together: automate a stage across all N, set one model field to the same value
+  on all N, approve/auto-build the whole group — and hands off single-item
+  fine-tuning to the existing item panel via the select-item event.
+-->
+<template>
+  <div
+    v-if="group"
+    class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
+  >
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-2">
+      <div>
+        <h4
+          class="flex items-center gap-1.5 text-sm font-black text-base-content"
+        >
+          <Icon name="kind-icon:layers" class="h-4 w-4 text-primary" />
+          Batch edit — {{ group.label }}
+        </h4>
+        <p class="mt-0.5 text-xs text-base-content/60">
+          {{ group.items.length }} {{ group.targetModel }} items · edit them
+          together, fine-tune any one below
+        </p>
+      </div>
+      <span
+        v-if="batching"
+        class="loading loading-dots loading-sm text-primary"
+      />
+    </div>
+
+    <!-- Automate the whole group -->
+    <section class="rounded-xl border border-base-300 bg-base-200 p-2.5">
+      <div class="mb-2 flex items-center justify-between gap-2">
+        <span
+          class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+        >
+          Automate all {{ group.items.length }}
+        </span>
+        <label
+          class="flex cursor-pointer items-center gap-1 text-[11px] text-base-content/60"
+        >
+          <input
+            v-model="onlyEmpty"
+            type="checkbox"
+            class="checkbox checkbox-xs"
+          />
+          Only empty
+        </label>
+      </div>
+      <div class="flex flex-wrap gap-1.5">
+        <button
+          type="button"
+          class="btn btn-xs rounded-lg"
+          :disabled="batching"
+          @click="draftAll('pitch')"
+        >
+          <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+          Draft pitches
+        </button>
+        <button
+          v-if="!isAsset"
+          type="button"
+          class="btn btn-xs rounded-lg"
+          :disabled="batching"
+          @click="draftAll('fields')"
+        >
+          <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+          Draft fields
+        </button>
+        <button
+          v-if="wantArt"
+          type="button"
+          class="btn btn-xs rounded-lg"
+          :disabled="batching"
+          @click="draftAll('artPrompt')"
+        >
+          <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+          Draft prompts
+        </button>
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost rounded-lg"
+          :disabled="batching"
+          @click="
+            store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')
+          "
+        >
+          <Icon name="kind-icon:check" class="h-3.5 w-3.5" />
+          Approve fields
+        </button>
+        <button
+          type="button"
+          class="btn btn-xs btn-primary rounded-lg"
+          :disabled="batching"
+          @click="store.batchAutoBuild(group.outputKey)"
+        >
+          <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
+          Auto-build group
+        </button>
+      </div>
+    </section>
+
+    <!-- Set one field to the same value on every item -->
+    <section
+      v-if="!isAsset && fields.length"
+      class="rounded-xl border border-base-300 bg-base-200 p-2.5"
+    >
+      <span
+        class="mb-2 block text-xs font-bold uppercase tracking-wide text-base-content/50"
+      >
+        Set a field on all {{ group.items.length }}
+      </span>
+      <div class="flex flex-col gap-1.5">
+        <div
+          v-for="field in fields"
+          :key="field.key"
+          class="flex items-center gap-2"
+        >
+          <span
+            class="w-24 shrink-0 truncate text-xs font-semibold text-base-content"
+            :title="field.label"
+          >
+            {{ field.label }}
+            <span v-if="field.required" class="text-error">*</span>
+          </span>
+          <select
+            v-if="field.choices"
+            v-model="batchValues[field.key]"
+            class="select select-bordered select-xs flex-1 bg-base-100"
+          >
+            <option value="">—</option>
+            <option
+              v-for="choice in field.choices"
+              :key="choice"
+              :value="choice"
+            >
+              {{ choice }}
+            </option>
+          </select>
+          <input
+            v-else
+            v-model="batchValues[field.key]"
+            type="text"
+            :placeholder="field.default || 'value for all'"
+            class="input input-bordered input-xs flex-1 bg-base-100"
+          />
+          <button
+            type="button"
+            class="btn btn-xs rounded-lg"
+            :disabled="batching || !batchValues[field.key]"
+            @click="applyField(field.key)"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Per-item fine-tune -->
+    <section class="rounded-xl border border-base-300 bg-base-200 p-2.5">
+      <span
+        class="mb-2 block text-xs font-bold uppercase tracking-wide text-base-content/50"
+      >
+        Fine-tune individual items
+      </span>
+      <ul class="flex flex-col gap-1">
+        <li
+          v-for="item in group.items"
+          :key="item.id"
+          class="flex items-center gap-2 rounded-lg bg-base-100 px-2 py-1"
+        >
+          <span
+            class="min-w-0 flex-1 truncate text-xs font-semibold text-base-content"
+          >
+            {{ item.label }}
+          </span>
+          <span class="badge badge-xs" :class="commitBadge(item)">
+            {{ itemStageSummary(item) }}
+          </span>
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost rounded-lg"
+            @click="emit('select-item', item.id)"
+          >
+            <Icon name="kind-icon:pencil" class="h-3 w-3" />
+            Edit
+          </button>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import { useModelBuilderStore } from '@/stores/modelBuilderStore'
+import type { BuildItem, DraftField } from '@/stores/modelBuilderStore'
+import { fieldSpecFor } from '@/stores/helpers/modelBuilderFields'
+
+const props = defineProps<{ outputKey: string }>()
+const emit = defineEmits<{ (e: 'select-item', itemId: string): void }>()
+
+const store = useModelBuilderStore()
+
+const group = computed(() =>
+  store.itemGroups.find((entry) => entry.outputKey === props.outputKey),
+)
+const batching = computed(() => store.batchingOutputKey === props.outputKey)
+const isAsset = computed(() => group.value?.action === 'ASSET_ONLY')
+const wantArt = computed(
+  () => store.includeArt && group.value?.generation === 'image',
+)
+const fields = computed(() =>
+  group.value ? fieldSpecFor(group.value.targetModel) : [],
+)
+
+const onlyEmpty = ref(false)
+const batchValues = reactive<Record<string, string>>({})
+
+async function draftAll(field: DraftField): Promise<void> {
+  if (!group.value) return
+  await store.batchDraftField(group.value.outputKey, field, {
+    onlyEmpty: onlyEmpty.value,
+  })
+}
+
+function applyField(key: string): void {
+  if (!group.value) return
+  const value = batchValues[key]
+  if (!value) return
+  store.batchSetField(group.value.outputKey, key, value)
+}
+
+function approvedCount(item: BuildItem): number {
+  return Object.values(item.stages).filter(
+    (stage) => stage.status === 'approved',
+  ).length
+}
+
+function itemStageSummary(item: BuildItem): string {
+  return item.stages.COMMIT.status === 'approved'
+    ? 'committed'
+    : `${approvedCount(item)}/4`
+}
+
+function commitBadge(item: BuildItem): string {
+  return item.stages.COMMIT.status === 'approved'
+    ? 'badge-success'
+    : 'badge-ghost'
+}
+</script>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -116,6 +116,13 @@
       </table>
     </div>
 
+    <!-- Batch editor for the selected item's quantity group -->
+    <model-builder-batch-editor
+      v-if="selectedItem && showBatch"
+      :output-key="selectedItem.outputKey"
+      @select-item="selectedItemId = $event"
+    />
+
     <!-- Selected item panel -->
     <model-builder-item-panel
       v-if="selectedItem"
@@ -192,6 +199,15 @@ const selectedItemId = ref<string>(run.value?.items[0]?.id ?? '')
 const selectedItem = computed(() =>
   run.value?.items.find((item) => item.id === selectedItemId.value),
 )
+
+// Show the batch editor when the selected item is part of a quantity/expansion
+// group (more than one item sharing its outputKey).
+const selectedGroup = computed(() =>
+  store.itemGroups.find(
+    (group) => group.outputKey === selectedItem.value?.outputKey,
+  ),
+)
+const showBatch = computed(() => (selectedGroup.value?.items.length ?? 0) > 1)
 
 function statusClass(status: StageStatus): string {
   switch (status) {

--- a/stores/helpers/modelBuilderFields.ts
+++ b/stores/helpers/modelBuilderFields.ts
@@ -153,3 +153,53 @@ export const CREATE_TARGETS: Record<string, SourceTypeKey> = {
   'expand-manager-bot': 'Bot',
   'expand-narrator-bot': 'Bot',
 }
+
+// --- FIELDS blob helpers ----------------------------------------------------
+// The FIELDS stage stores a "key: value" text blob (one field per line, the same
+// format defaultFieldsTemplate produces and the commit executor parses). These
+// helpers let the batch editor read and set individual fields across many items
+// without disturbing the other lines.
+
+export interface FieldLine {
+  key: string
+  value: string
+}
+
+export function parseFieldLines(blob: string): FieldLine[] {
+  return blob
+    .split('\n')
+    .map((line): FieldLine | null => {
+      const idx = line.indexOf(':')
+      if (idx === -1) return null
+      const key = line.slice(0, idx).trim()
+      if (!key) return null
+      return { key, value: line.slice(idx + 1).trim() }
+    })
+    .filter((line): line is FieldLine => line !== null)
+}
+
+// Read a single field's value from a FIELDS blob ('' if absent).
+export function readFieldLine(blob: string, key: string): string {
+  return parseFieldLines(blob).find((line) => line.key === key)?.value ?? ''
+}
+
+// Set (or append) a key's value in a FIELDS blob, preserving every other line and
+// its order. Appending drops a single trailing blank line first so the blob stays
+// tidy.
+export function setFieldLine(blob: string, key: string, value: string): string {
+  const lines = blob.split('\n')
+  let found = false
+  const next = lines.map((line) => {
+    const idx = line.indexOf(':')
+    if (idx === -1) return line
+    if (line.slice(0, idx).trim() !== key) return line
+    found = true
+    return `${key}: ${value}`
+  })
+  if (!found) {
+    const last = next[next.length - 1]
+    if (last !== undefined && last.trim() === '') next.pop()
+    next.push(`${key}: ${value}`)
+  }
+  return next.join('\n')
+}

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -354,6 +354,12 @@ export const tutorialChannels = {
         body: 'Move through a card-driven flow to create reusable building blocks from one place.',
         image: tutorialImage('builder', 'builder'),
       },
+      {
+        key: 'model-builder',
+        title: 'Model Builder',
+        body: 'Turn any record — Project, Character, Bot, Reward, Dream, Scenario, or Facet — into a resumable, gated build run: pick a recipe, draft fields and art, batch-edit quantity outputs, and commit upgraded or newly created records with full provenance.',
+        image: tutorialImage('builder', 'model-builder'),
+      },
     ],
   },
 

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -36,6 +36,7 @@ import {
   CREATE_TARGETS,
   defaultFieldsTemplate,
   fieldsBrief,
+  setFieldLine,
 } from '@/stores/helpers/modelBuilderFields'
 
 export type BuilderStep = 'source' | 'recipe' | 'run'
@@ -89,6 +90,18 @@ export interface BuildRun {
   items: BuildItem[]
 }
 
+// A quantity/expansion output's items, grouped for batch editing. Derived from
+// run.items by outputKey — the run model has no persisted group object.
+export interface BuildItemGroup {
+  outputKey: string
+  label: string
+  quantity: boolean
+  action: BuildAction
+  generation: GenerationKind
+  targetModel: SourceTypeKey
+  items: BuildItem[]
+}
+
 interface OutputSelection {
   on: boolean
   quantity: number
@@ -112,6 +125,7 @@ interface ModelBuilderState {
   committingItemId: string | null
   autoBuilding: boolean
   autoBuildingItemId: string | null
+  batchingOutputKey: string | null
   statusMessage: string
   statusTone: 'success' | 'error'
 }
@@ -295,6 +309,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     committingItemId: null,
     autoBuilding: false,
     autoBuildingItemId: null,
+    batchingOutputKey: null,
     statusMessage: '',
     statusTone: 'success',
   })
@@ -982,6 +997,136 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
+  // --- batch editing across a quantity output group -------------------------
+
+  // Group the run's items by outputKey so a quantity/expansion output (e.g. 10
+  // rewards) can be edited together. The group carries its target model so the
+  // editor can enumerate that model's fields (fieldSpecFor).
+  const itemGroups = computed<BuildItemGroup[]>(() => {
+    const run = state.run
+    if (!run) return []
+    const byKey = new Map<string, BuildItem[]>()
+    for (const item of run.items) {
+      const existing = byKey.get(item.outputKey)
+      if (existing) existing.push(item)
+      else byKey.set(item.outputKey, [item])
+    }
+    return [...byKey.entries()].flatMap(([outputKey, items]) => {
+      const first = items[0]
+      if (!first) return []
+      const config = recipeOutputs.value.find(
+        (output) => output.key === outputKey,
+      )
+      return [
+        {
+          outputKey,
+          label: config?.label ?? first.label,
+          quantity: config?.quantity ?? items.length > 1,
+          action: first.action,
+          generation: first.generation,
+          targetModel: resolveTargetModel(
+            first.action,
+            outputKey,
+            run.sourceType,
+          ),
+          items,
+        },
+      ]
+    })
+  })
+
+  function groupItems(outputKey: string): BuildItem[] {
+    return state.run?.items.filter((item) => item.outputKey === outputKey) ?? []
+  }
+
+  // AI-draft one field (pitch/fields/artPrompt) across every item in a group,
+  // sequentially so we don't hammer the text server. onlyEmpty skips items that
+  // already have hand-edited content.
+  async function batchDraftField(
+    outputKey: string,
+    field: DraftField,
+    opts?: { onlyEmpty?: boolean },
+  ): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    state.batchingOutputKey = outputKey
+    clearStatus()
+    let drafted = 0
+    try {
+      for (const item of items) {
+        const current =
+          field === 'pitch'
+            ? item.pitch
+            : field === 'fields'
+              ? item.fieldsDraft
+              : item.promptDraft
+        if (opts?.onlyEmpty && current.trim()) continue
+        const ok = await draftText(item.id, field)
+        if (ok) drafted++
+      }
+      const label = field === 'artPrompt' ? 'prompt' : field
+      setStatus('success', `Drafted ${label} for ${drafted}/${items.length} items.`)
+    } finally {
+      state.batchingOutputKey = null
+    }
+  }
+
+  // Set one model field to the same value on every item in a group (e.g. rarity =
+  // RARE across 10 rewards). Only rewrites items whose value actually changes.
+  function batchSetField(
+    outputKey: string,
+    fieldKey: string,
+    value: string,
+  ): void {
+    const items = groupItems(outputKey)
+    let changed = 0
+    for (const item of items) {
+      const next = setFieldLine(item.fieldsDraft, fieldKey, value)
+      if (next !== item.fieldsDraft) {
+        updateFields(item.id, next)
+        changed++
+      }
+    }
+    setStatus('success', `Set ${fieldKey} on ${changed}/${items.length} items.`)
+  }
+
+  // Approve a stage for every (unlocked) item in a group at once.
+  function batchApproveStage(outputKey: string, stageKey: BuildStageKey): void {
+    let approved = 0
+    for (const item of groupItems(outputKey)) {
+      if (item.stages[stageKey].status === 'locked') continue
+      approveStage(item.id, stageKey)
+      approved++
+    }
+    setStatus('success', `Approved ${stageKey} for ${approved} items.`)
+  }
+
+  // Auto-build (draft → generate → commit with defaults) every not-yet-committed
+  // item in a single group.
+  async function batchAutoBuild(outputKey: string): Promise<void> {
+    const items = groupItems(outputKey)
+    if (!items.length) return
+    state.batchingOutputKey = outputKey
+    clearStatus()
+    let committed = 0
+    try {
+      for (const item of items) {
+        if (item.stages.COMMIT.status === 'approved') {
+          committed++
+          continue
+        }
+        const ok = await autoBuildItem(item.id)
+        if (ok) committed++
+      }
+      setStatus(
+        'success',
+        `Auto-built ${committed}/${items.length} in this group.`,
+      )
+    } finally {
+      state.batchingOutputKey = null
+    }
+  }
+
   // --- persistence / resume -------------------------------------------------
 
   function setActiveRunId(id: number): void {
@@ -1129,6 +1274,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     selectedOutputCount,
     canStartRun,
     runProgress,
+    itemGroups,
     // display
     sourceLabel,
     // actions
@@ -1152,6 +1298,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     toggleIncludeArt,
     autoBuildItem,
     autoBuildRun,
+    batchDraftField,
+    batchSetField,
+    batchApproveStage,
+    batchAutoBuild,
     resumeRun,
     fetchRuns,
     openRun,


### PR DESCRIPTION
## What & why

Pushes **model-builder** toward finished with the no-DB-write ready tasks (the DB is write-locked, so the live-smoke t-022 and ArtJob t-025 tasks can't be exercised). 2 commits, 5 files, **+476** (all additive), vue-tsc green.

### t-027 — batch editor for quantity outputs
A quantity/expansion output (e.g. "10 rewards") produces N `BuildItem`s sharing an `outputKey`; until now they could only be edited one at a time. New `model-builder-batch-editor.vue` edits the whole group:
- **Automate all N** — batch-draft pitch / fields / art-prompt (with an "only empty" guard), approve the FIELDS stage, or auto-build the group.
- **Set a field on all N** — pick a model field (choice fields become a dropdown) and apply one value to every item, e.g. `rarity=RARE` across 10 rewards.
- **Fine-tune individually** — per-item rows hand off to the existing item panel via a `select-item` event.

Groups derive from `run.items` by `outputKey` (the run model has no group object); the target model's field list comes from `fieldSpecFor` (t-024). New store surface: `itemGroups` computed + `batchDraftField` / `batchSetField` / `batchApproveStage` / `batchAutoBuild`, each looping the existing per-item primitives. Added `parse`/`read`/`setFieldLine` helpers matching the FIELDS `key: value` blob the commit executor parses (t-028). Slots into `model-builder-progress-matrix.vue` above the single-item panel when the selected item is part of a quantity group.

### t-029 — Model Builder tutorial section
Added a `model-builder` section under the builder tutorial channel (`tutorialCards.ts`).

## Verification
- `vue-tsc --noEmit` — **0 errors**. ESLint clean on the new component. No new prettier issues (existing model-builder files were already prettier-dirty on main and have no lint CI gate; I left them untouched beyond my additions).
- Components stay presentational and route everything through `modelBuilderStore` (no direct API calls), per the project convention.

## Not verifiable here / deferred
- The batch AI-draft and auto-build call `/api/suggest` and the art/commit paths — those need a live text/art server + DB, so I couldn't exercise them end-to-end in the DB-less sandbox. The wiring is type-checked and loops the already-shipped, already-exercised per-item primitives.
- **t-029 remainder:** dashboard-tab + tutorial `.webp` art (needs the generation backend) and the PROJECT Dream `liveUrl` backfill (admin Placements button) stay open.
- **t-022 (live post-deploy smoke) and t-025 (ArtJob async art)** remain blocked — both need prod DB writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB9TYhcS9hmeVc6Hprr74M)_