### PR TITLE
feat(conductor): surface aggregate N/M tasks-done badge on project gallery cards

### DIFF
--- a/components/pages/conductor-overview-gallery-page.vue
+++ b/components/pages/conductor-overview-gallery-page.vue
@@ -246,6 +246,9 @@
                 class="flex items-center justify-between gap-3 text-xs font-black uppercase tracking-widest text-base-content/45"
               >
                 <span>{{ item.kindLabel }}</span>
+                <span v-if="item.totalTasks"
+                  >{{ item.done }}/{{ item.totalTasks }} done</span
+                >
                 <span>{{ item.progress }}%</span>
               </div>
 
@@ -328,6 +331,12 @@
                   {{ item.progress }}% progress
                 </span>
                 <span
+                  v-if="item.totalTasks"
+                  class="badge badge-success badge-sm rounded-2xl"
+                >
+                  {{ item.done }}/{{ item.totalTasks }} done
+                </span>
+                <span
                   v-if="item.needsHuman"
                   class="badge badge-accent badge-sm rounded-2xl"
                 >
@@ -407,7 +416,7 @@
               v-if="item.totalTasks"
               class="badge badge-info badge-sm rounded-2xl"
             >
-              {{ item.totalTasks }} tasks
+              {{ item.done }}/{{ item.totalTasks }} done
             </span>
             <span
               v-if="item.needsHuman"
@@ -511,7 +520,9 @@
 
             <div class="grid flex-1 grid-cols-3 gap-2 text-center md:w-full">
               <div class="rounded-xl bg-base-100 p-2">
-                <p class="font-black text-success">{{ item.done }}</p>
+                <p class="font-black text-success">
+                  {{ item.done }}/{{ item.totalTasks }}
+                </p>
                 <p class="text-[0.65rem] text-base-content/40">done</p>
               </div>
               <div class="rounded-xl bg-base-100 p-2">


### PR DESCRIPTION
### Task
global-ui/t-019: Surface an aggregate "N/M tasks done" count on the top-level project card, before opening the project. (kind: software)

### What changed / what I produced
- `components/pages/conductor-overview-gallery-page.vue`: added a `{{ item.done }}/{{ item.totalTasks }} done` badge to all 4 gallery layout modes (`cards`, `heroes`, `icons`, `list`) — the view a user sees before opening a specific project.
  - `list` mode already showed a bare `item.done` count; added the `/totalTasks` denominator.
  - `icons` mode's `{{ item.totalTasks }} tasks` badge became `{{ item.done }}/{{ item.totalTasks }} done` (same badge slot, strictly more informative).
  - `cards`/`heroes` modes got a new badge alongside the existing progress bar/percentage, guarded with `v-if="item.totalTasks"` matching the existing pattern.
- No API, store, or Prisma changes — `item.done`/`item.totalTasks` were already computed by `taskCounts()`/`itemFromProject()` for the per-milestone "N/M done" feature (t-018, PR #316); this task just surfaces the same already-available fields one level up, before a project is opened.

### How I verified
- `npx eslint components/pages/conductor-overview-gallery-page.vue` — clean.
- `npx vue-tsc --noEmit` (full project) — 0 errors.
- `npx prettier --check` — clean on all touched lines (two pre-existing unrelated lines elsewhere in the file remain non-conformant from before this change; left untouched rather than reformatting unrelated code).
- Could not exercise live in a browser (no dev server/DB in this sandbox) — the change is template-only against already-computed, already-tested fields.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`itemFromProjectRecord()`'s fallback path (non-admin users whose project has no matching `conductorStore` entry by `conductorSlug`) approximates `done`/`totalTasks` from DB `Todo` counts, not real conductor task counts — could show a misleading ratio in that edge case. Not fixed here (out of this task's scope, and the `v-if="item.totalTasks"` guard already hides the badge when that fallback yields 0).

### Notes for reviewer
Self-reviewed within the same autonomous cycle (no separate Worker/Reviewer split available this run).


---
_Generated by [Claude Code](https://claude.ai/code/session_016bPRe9ypPcqwMbfYNNtNfN)_