### PR TITLE
fix(api): accept admin/api-key auth on relations + reactions (Cypress)

### DIFF
--- a/server/api/reactions/[id].delete.ts
+++ b/server/api/reactions/[id].delete.ts
@@ -2,6 +2,7 @@
 import { defineEventHandler, createError } from 'h3'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
 import prisma from '../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
@@ -38,7 +39,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (reaction.userId !== user.id) {
+    if (reaction.userId !== user.id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to delete this reaction.',

--- a/server/api/reactions/[id].patch.ts
+++ b/server/api/reactions/[id].patch.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
 import type { Reaction } from '~/prisma/generated/prisma/client'
 
 export default defineEventHandler(async (event) => {
@@ -50,7 +51,7 @@ export default defineEventHandler(async (event) => {
         message: 'Reaction not found.',
       })
     }
-    if (existingReaction.userId !== userId) {
+    if (existingReaction.userId !== userId && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to update this reaction.',

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,24 +1,14 @@
 // /server/utils/auth.ts
-import { getHeader, type H3Event } from 'h3'
-import { verifyJwtToken } from '../api/auth'
+import { type H3Event } from 'h3'
+import { getOptionalApiUser } from './authGuard'
 
-function readBearerToken(event: H3Event): string {
-  const authorization = getHeader(event, 'authorization') ?? ''
-
-  return authorization
-    .trim()
-    .replace(/^Bearer\s+/i, '')
-    .trim()
-}
-
+// Resolve the acting user for endpoints that only need the caller's id.
+// Delegates to the canonical auth resolver so these routes accept the same
+// credentials as the rest of the API — a JWT, a user API key, or the
+// beta-admin token — instead of JWTs only. (Previously JWT-only, which made
+// admin/api-key callers to /api/relations fail with "Not authenticated.")
 export async function getCurrentUserId(event: H3Event): Promise<number | null> {
-  const token = readBearerToken(event)
+  const auth = await getOptionalApiUser(event)
 
-  if (!token) return null
-
-  const verification = await verifyJwtToken(token)
-
-  if (!verification.success || !verification.userId) return null
-
-  return verification.userId
+  return auth?.user.id ?? null
 }


### PR DESCRIPTION
## Summary

Investigated the recent burst of Cypress API failures. The run during the database outage showed **96 failing tests across 16 specs**, but the run after the DB came back healthy narrowed it to just **2 specs / 7 tests** — the rest were transient `503 "Database connection was temporarily unavailable."` errors and their cascades (a create 503s, so dependent GET/PATCH/DELETE on the now-missing id fail too). Those resolve on their own with the DB up.

The two specs that **kept failing with a healthy database** were genuine auth gaps, and this PR fixes them:

### `friendships.cy.ts` — 6 failing
`/api/relations` authenticates via `getCurrentUserId`, which only accepted **JWTs**. The suite's "second user" is the admin identity, and it carries the **beta-admin token** (not a JWT), so every relation request made as that user returned `401 "Not authenticated."` (The first user is a JWT-backed seed user, so its requests already passed — which is why only the multi-user lifecycle tests failed.)

`getCurrentUserId` now delegates to the canonical `getOptionalApiUser` resolver in `authGuard`, so relations accept the same credentials as the rest of the API (JWT, user API key, or beta-admin token). `getCurrentUserId` is used **only** by the four `/api/relations` endpoints, so the blast radius is contained. The beta-admin token resolves to the same `betaAdminUserId` that `/users/me` (used by the seed) returns, so ids stay consistent.

### `reactions.cy.ts` — 1 failing
`DELETE /api/reactions/:id` (and `PATCH`) only allowed an exact owner match. The suite deletes with the admin `x-api-key`, which `validateApiKey` resolves to the admin user (not the reaction's owner), so the owner check `403`'d. Both handlers now grant an admin override (`&& !userIsAdmin(user)`), matching the existing pattern in `art/image`, `users`, etc.

## Changes
- `server/utils/auth.ts` — `getCurrentUserId` routes through `getOptionalApiUser` (accepts JWT / user API key / beta-admin token).
- `server/api/reactions/[id].delete.ts` — admin override on ownership check.
- `server/api/reactions/[id].patch.ts` — admin override on ownership check (consistency; prevents the same latent gap).

## Verification
- Behavior traced through CI logs from both the DB-down run (run 7796) and the DB-healthy run (run 7798, `2 of 33 failed`).
- Cypress runs against the live Vercel deployment, so the suite self-verifies on the merge-to-`main` push once the new code deploys.
- CI `TypeScript Type Check` runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rg7wrjgMg4kpkUykXR5ft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rg7wrjgMg4kpkUykXR5ft)_