### PR TITLE
Add bulk re-enqueue for failed ArtJobs

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -51,6 +51,18 @@
       </div>
 
       <div
+        v-if="bulkRetryMessage"
+        class="rounded-2xl border p-2 text-xs"
+        :class="
+          bulkRetryHasFailures
+            ? 'border-warning/40 bg-warning/10 text-warning'
+            : 'border-success/40 bg-success/10 text-success'
+        "
+      >
+        {{ bulkRetryMessage }}
+      </div>
+
+      <div
         v-if="stats?.oldestPending"
         class="rounded-2xl border border-warning/40 bg-warning/10 p-2 text-xs text-warning"
       >
@@ -152,7 +164,7 @@
 
       <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
         <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
             <h3 class="text-sm font-semibold">Queue</h3>
             <span
               v-if="(stats?.staleRunningCount ?? 0) > 0"
@@ -164,6 +176,20 @@
             <span class="text-[11px] text-base-content/50">
               {{ stats?.imagesCreatedInWindow ?? 0 }} imgs / {{ windowHours }}h
             </span>
+            <button
+              v-if="failedJobCount > 0"
+              type="button"
+              class="btn btn-error btn-xs rounded-2xl"
+              :disabled="artJobStore.reenqueueingFailedJobs"
+              :title="`Clone all ${failedJobCount} failed jobs into fresh pending attempts`"
+              @click="reenqueueAllFailed"
+            >
+              <span
+                v-if="artJobStore.reenqueueingFailedJobs"
+                class="loading loading-spinner loading-xs"
+              />
+              Re-enqueue all failed ({{ failedJobCount }})
+            </button>
             <button
               v-if="uncuratedJobs.length"
               type="button"
@@ -686,6 +712,8 @@ const selectedWindow = ref(24)
 const checkingServerId = ref<number | null>(null)
 const copiedJobId = ref<number | null>(null)
 const overwriteJob = ref<ArtJob | null>(null)
+const bulkRetryMessage = ref('')
+const bulkRetryHasFailures = ref(false)
 
 const statusFilters: (ArtJobStatus | 'ALL')[] = [
   'PENDING',
@@ -699,6 +727,7 @@ const statusFilters: (ArtJobStatus | 'ALL')[] = [
 const stats = computed(() => artJobStore.stats)
 const uptime = computed(() => artJobStore.uptime)
 const windowHours = computed(() => artJobStore.windowHours)
+const failedJobCount = computed(() => stats.value?.queueDepth.FAILED ?? 0)
 const isLoading = computed(
   () =>
     artJobStore.loadingStats ||
@@ -1192,6 +1221,30 @@ async function requestBulkCuration(): Promise<void> {
   } finally {
     bulkCurating.value = false
   }
+}
+
+async function reenqueueAllFailed(): Promise<void> {
+  const count = failedJobCount.value
+  if (!count || artJobStore.reenqueueingFailedJobs) return
+
+  const confirmed = window.confirm(
+    `Re-enqueue all ${count} failed art jobs as fresh outputs? The failed jobs and their errors will remain in history.`,
+  )
+  if (!confirmed) return
+
+  bulkRetryMessage.value = ''
+  bulkRetryHasFailures.value = false
+
+  const result = await artJobStore.reenqueueFailedJobs()
+  if (!result) return
+
+  bulkRetryHasFailures.value = result.failedCount > 0
+  bulkRetryMessage.value =
+    result.requestedCount === 0
+      ? 'No failed art jobs were found.'
+      : result.failedCount > 0
+        ? `Queued ${result.queuedCount} of ${result.requestedCount} failed jobs. ${result.failedCount} could not be queued.`
+        : `Re-enqueued all ${result.queuedCount} failed jobs as fresh outputs.`
 }
 
 function askToOverwrite(job: ArtJob): void {

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -23,89 +23,17 @@ import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import {
   decodeArtJobPayload,
-  parseArtJobPayload,
   serializeArtJobPayload,
-  type ArtJobPayloadRecord,
 } from '../../../../utils/artJobPayload'
-
-type RetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
+import {
+  ART_JOB_RETRY_MODES,
+  prepareArtJobRetryPayload,
+  type ArtJobRetryMode,
+} from '../../../../utils/artJobRetry'
 
 type ReenqueueBody = {
   mode?: string | null
   refreshSeed?: boolean
-}
-
-const RETRY_MODES = new Set<RetryMode>(['NEW_OUTPUT', 'OVERWRITE'])
-const SEED_KEYS = new Set(['seed', 'noise_seed'])
-
-function asRecord(value: unknown): ArtJobPayloadRecord {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
-  return value as ArtJobPayloadRecord
-}
-
-function nextSeed(): number {
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
-}
-
-function refreshConcreteSeeds(value: unknown, key = ''): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => refreshConcreteSeeds(item))
-  }
-
-  if (!value || typeof value !== 'object') {
-    if (SEED_KEYS.has(key)) {
-      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
-        return nextSeed()
-      }
-      if (
-        typeof value === 'string' &&
-        value.trim() &&
-        Number.isFinite(Number(value)) &&
-        Number(value) >= 0
-      ) {
-        return String(nextSeed())
-      }
-    }
-    return value
-  }
-
-  return Object.fromEntries(
-    Object.entries(value as ArtJobPayloadRecord).map(([childKey, child]) => [
-      childKey,
-      refreshConcreteSeeds(child, childKey),
-    ]),
-  )
-}
-
-function preparePayload(
-  rawPayload: unknown,
-  sourceJobId: number,
-  sourceArtImageId: number | null,
-  mode: RetryMode,
-  refreshSeed: boolean,
-): ArtJobPayloadRecord {
-  const cloned = structuredClone(parseArtJobPayload(rawPayload))
-  const previousRetry = asRecord(cloned.retry)
-  const rootJobId = Number(previousRetry.rootJobId) || sourceJobId
-
-  // A new render has not been curated yet. Keeping old feedback here would make
-  // the trainer believe the replacement pixels had already been reviewed.
-  delete cloned.curation
-
-  const generationPayload = refreshSeed
-    ? (refreshConcreteSeeds(cloned) as ArtJobPayloadRecord)
-    : cloned
-
-  generationPayload.retry = {
-    mode,
-    sourceJobId,
-    rootJobId,
-    targetArtImageId: mode === 'OVERWRITE' ? sourceArtImageId : null,
-    refreshSeed,
-    requestedAt: new Date().toISOString(),
-  }
-
-  return generationPayload
 }
 
 export default defineEventHandler(async (event) => {
@@ -126,10 +54,12 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = (await readBody(event).catch(() => null)) as ReenqueueBody | null
-    const mode = String(body?.mode || 'NEW_OUTPUT').toUpperCase() as RetryMode
+    const mode = String(
+      body?.mode || 'NEW_OUTPUT',
+    ).toUpperCase() as ArtJobRetryMode
     const refreshSeed = body?.refreshSeed !== false
 
-    if (!RETRY_MODES.has(mode)) {
+    if (!ART_JOB_RETRY_MODES.has(mode)) {
       throw createError({
         statusCode: 400,
         message: 'mode must be NEW_OUTPUT or OVERWRITE.',
@@ -164,7 +94,7 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    const payload = preparePayload(
+    const payload = prepareArtJobRetryPayload(
       source.payload,
       source.id,
       source.artImageId,

--- a/server/api/art/queue/reenqueue-failed.post.ts
+++ b/server/api/art/queue/reenqueue-failed.post.ts
@@ -1,0 +1,123 @@
+// /server/api/art/queue/reenqueue-failed.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '../../../utils/prisma'
+import { errorHandler } from '../../../utils/error'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { serializeArtJobPayload } from '../../../utils/artJobPayload'
+import { prepareArtJobRetryPayload } from '../../../utils/artJobRetry'
+
+type ReenqueueFailedBody = {
+  refreshSeed?: boolean
+}
+
+type FailedSourceJob = Awaited<
+  ReturnType<typeof prisma.artJob.findMany>
+>[number]
+
+const CREATE_CONCURRENCY = 10
+
+function createRetryJob(source: FailedSourceJob, refreshSeed: boolean) {
+  const payload = prepareArtJobRetryPayload(
+    source.payload,
+    source.id,
+    source.artImageId,
+    'NEW_OUTPUT',
+    refreshSeed,
+  )
+
+  return prisma.artJob.create({
+    data: {
+      engine: source.engine,
+      payload: serializeArtJobPayload(payload),
+      priority: source.priority,
+      projectSlug: source.projectSlug,
+      projectId: source.projectId,
+      userId: source.userId,
+    },
+    select: { id: true },
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to re-enqueue failed jobs.',
+      })
+    }
+
+    const body = (await readBody(event).catch(() => null)) as
+      | ReenqueueFailedBody
+      | null
+    const refreshSeed = body?.refreshSeed !== false
+
+    const sources = await prisma.artJob.findMany({
+      where: { status: 'FAILED' },
+      orderBy: { id: 'asc' },
+    })
+
+    const queuedSourceJobIds: number[] = []
+    const failedSourceJobIds: number[] = []
+    const createdJobIds: number[] = []
+
+    for (let index = 0; index < sources.length; index += CREATE_CONCURRENCY) {
+      const batch = sources.slice(index, index + CREATE_CONCURRENCY)
+      const results = await Promise.allSettled(
+        batch.map((source) => createRetryJob(source, refreshSeed)),
+      )
+
+      results.forEach((result, resultIndex) => {
+        const source = batch[resultIndex]
+        if (!source) return
+
+        if (result.status === 'fulfilled') {
+          queuedSourceJobIds.push(source.id)
+          createdJobIds.push(result.value.id)
+        } else {
+          failedSourceJobIds.push(source.id)
+        }
+      })
+    }
+
+    const queuedCount = queuedSourceJobIds.length
+    const failedCount = failedSourceJobIds.length
+    const requestedCount = sources.length
+
+    event.node.res.statusCode = queuedCount > 0 ? 201 : 200
+
+    return {
+      success: true,
+      message:
+        requestedCount === 0
+          ? 'No failed art jobs were found.'
+          : failedCount > 0
+            ? `Re-enqueued ${queuedCount} of ${requestedCount} failed art jobs. ${failedCount} could not be queued.`
+            : `Re-enqueued all ${queuedCount} failed art jobs as fresh outputs.`,
+      data: {
+        requestedCount,
+        queuedCount,
+        failedCount,
+        sourceJobIds: sources.map((source) => source.id),
+        queuedSourceJobIds,
+        failedSourceJobIds,
+        createdJobIds,
+        refreshSeed,
+      },
+      statusCode: event.node.res.statusCode,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to re-enqueue failed art jobs.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -1,0 +1,82 @@
+// /server/utils/artJobRetry.ts
+import {
+  parseArtJobPayload,
+  type ArtJobPayloadRecord,
+} from './artJobPayload'
+
+export type ArtJobRetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
+
+export const ART_JOB_RETRY_MODES = new Set<ArtJobRetryMode>([
+  'NEW_OUTPUT',
+  'OVERWRITE',
+])
+
+const SEED_KEYS = new Set(['seed', 'noise_seed'])
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+function nextSeed(): number {
+  return Math.floor(Math.random() * 1_000_000_000_000_000)
+}
+
+function refreshConcreteSeeds(value: unknown, key = ''): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => refreshConcreteSeeds(item))
+  }
+
+  if (!value || typeof value !== 'object') {
+    if (SEED_KEYS.has(key)) {
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+        return nextSeed()
+      }
+      if (
+        typeof value === 'string' &&
+        value.trim() &&
+        Number.isFinite(Number(value)) &&
+        Number(value) >= 0
+      ) {
+        return String(nextSeed())
+      }
+    }
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as ArtJobPayloadRecord).map(([childKey, child]) => [
+      childKey,
+      refreshConcreteSeeds(child, childKey),
+    ]),
+  )
+}
+
+export function prepareArtJobRetryPayload(
+  rawPayload: unknown,
+  sourceJobId: number,
+  sourceArtImageId: number | null,
+  mode: ArtJobRetryMode,
+  refreshSeed: boolean,
+): ArtJobPayloadRecord {
+  const cloned = structuredClone(parseArtJobPayload(rawPayload))
+  const previousRetry = asRecord(cloned.retry)
+  const rootJobId = Number(previousRetry.rootJobId) || sourceJobId
+
+  delete cloned.curation
+
+  const generationPayload = refreshSeed
+    ? (refreshConcreteSeeds(cloned) as ArtJobPayloadRecord)
+    : cloned
+
+  generationPayload.retry = {
+    mode,
+    sourceJobId,
+    rootJobId,
+    targetArtImageId: mode === 'OVERWRITE' ? sourceArtImageId : null,
+    refreshSeed,
+    requestedAt: new Date().toISOString(),
+  }
+
+  return generationPayload
+}

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -79,6 +79,17 @@ export type CurateRequestResult = {
   missing: number[]
 }
 
+export type BulkReenqueueResult = {
+  requestedCount: number
+  queuedCount: number
+  failedCount: number
+  sourceJobIds: number[]
+  queuedSourceJobIds: number[]
+  failedSourceJobIds: number[]
+  createdJobIds: number[]
+  refreshSeed: boolean
+}
+
 export type QueueStats = {
   windowHours: number
   since: string
@@ -143,6 +154,7 @@ type ArtJobState = {
   loadingJobs: boolean
   loadingTrainerJobs: boolean
   retryingJobIds: number[]
+  reenqueueingFailedJobs: boolean
   // Jobs with a curate-request POST in flight, and jobs a request has been queued
   // for this session (so the UI can show "Curation requested" before Conductor's
   // verdict lands in payload.curation.curator).
@@ -168,6 +180,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     loadingJobs: false,
     loadingTrainerJobs: false,
     retryingJobIds: [],
+    reenqueueingFailedJobs: false,
     curationRequestingIds: [],
     curationRequestedIds: [],
     error: null,
@@ -462,6 +475,32 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     }
   }
 
+  async function reenqueueFailedJobs(): Promise<BulkReenqueueResult | null> {
+    if (state.reenqueueingFailedJobs) return null
+    state.reenqueueingFailedJobs = true
+    state.error = null
+
+    try {
+      const res = await performFetch<BulkReenqueueResult>(
+        '/api/art/queue/reenqueue-failed',
+        {
+          method: 'POST',
+          body: JSON.stringify({ refreshSeed: true }),
+        },
+      )
+
+      if (res.success && res.data) {
+        await Promise.all([fetchJobs(), fetchStats(), fetchTrainerJobs()])
+        return res.data
+      }
+
+      state.error = res.message || 'Failed to re-enqueue failed jobs.'
+      return null
+    } finally {
+      state.reenqueueingFailedJobs = false
+    }
+  }
+
   async function refreshAll(): Promise<void> {
     state.error = null
     await Promise.all([
@@ -488,6 +527,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     requeueJob,
     cancelJob,
     reenqueueJob,
+    reenqueueFailedJobs,
     refreshAll,
     setWindow,
   }


### PR DESCRIPTION
## What changed

- adds an admin-only `POST /api/art/queue/reenqueue-failed` endpoint that selects every failed ArtJob server-side
- extracts retry payload cloning and seed refresh into a shared helper used by single and bulk retries
- adds a Pinia bulk action with double-submit protection and a single queue/stats refresh
- adds a count-aware **Re-enqueue all failed** button, explicit confirmation, spinner, and result banner
- preserves failed source jobs and their errors while creating fresh `PENDING` attempts with retry lineage
- reports requested, queued, failed, source, and created job IDs, including partial failures

## Validation

- TypeScript syntax transpilation passed for the new endpoint, helper, store, and Vue script block
- retry helper behavior check passed: source payload remains unchanged, curation is removed, concrete seeds refresh, and retry lineage is preserved
- branch diff is limited to the five intended files

Closes #365