### PR TITLE
Route local image writers to self-hosted media root

### DIFF
--- a/docs/self-hosted-media.md
+++ b/docs/self-hosted-media.md
@@ -1,0 +1,107 @@
+# Self-hosted image storage
+
+Kind Robots keeps `/images/...` as its stable public URL contract while the
+underlying files live outside the Git repository.
+
+## Current infrastructure
+
+- Public origin: `https://media.acrocatranch.com/images/...`
+- Unraid filesystem root: `/mnt/user/pc/kindrobots/images`
+- Windows share: `Z:\kindrobots\images`
+- WSL mount: `/mnt/z/kindrobots/images`
+- Nginx container: `media`
+
+The Nginx container mounts the Unraid image root read-only and Traefik exposes
+it publicly. Application writers use the filesystem path; browsers use the
+stable `/images/...` path.
+
+## Local environment
+
+For development and maintenance commands running inside WSL, add this to the
+local `.env` file:
+
+```dotenv
+IMAGES_PATH=/mnt/z/kindrobots/images
+```
+
+For commands running directly in Windows, use a Windows path instead:
+
+```dotenv
+IMAGES_PATH=Z:\kindrobots\images
+```
+
+Do not set `IMAGES_PATH` on Vercel. Vercel cannot write to the Unraid share.
+Production upload behavior remains database-backed until a separate authenticated
+media-ingest path is deliberately introduced.
+
+When `IMAGES_PATH` is absent, the application falls back to `public/images`, so
+existing checkouts continue to work.
+
+## Live migration sync
+
+During cutover, keep copying repository images to Unraid without deleting files
+that exist only on Unraid:
+
+```bash
+rsync -rv \
+  --size-only \
+  --info=progress2 \
+  --no-owner \
+  --no-group \
+  --no-perms \
+  --no-times \
+  --omit-dir-times \
+  public/images/ \
+  /mnt/z/kindrobots/images/
+```
+
+Never add `--delete` during migration. Unraid becomes the canonical store and
+may contain new files that are not present in the repository.
+
+A safe comparison pass is:
+
+```bash
+rsync -rvin \
+  --size-only \
+  --no-owner \
+  --no-group \
+  --no-perms \
+  --no-times \
+  --omit-dir-times \
+  public/images/ \
+  /mnt/z/kindrobots/images/
+```
+
+## Verification
+
+Confirm the media origin and the Unraid file contain identical bytes:
+
+```bash
+curl -fsSL \
+  https://media.acrocatranch.com/images/kindlogo_new.webp \
+  -o /tmp/kindlogo_new.webp
+
+sha256sum \
+  /mnt/user/pc/kindrobots/images/kindlogo_new.webp \
+  /tmp/kindlogo_new.webp
+```
+
+Normal media should return a one-hour migration cache, while collection
+manifests use a 60-second cache:
+
+```bash
+curl -sSI https://media.acrocatranch.com/images/kindlogo_new.webp
+curl -sSI https://media.acrocatranch.com/images/collections.json
+curl -sSI https://media.acrocatranch.com/images/generated/gallery.json
+```
+
+## Cutover order
+
+1. Set `IMAGES_PATH` locally and restart writers.
+2. Create one new test image and confirm it lands on Unraid and is public.
+3. Run the final incremental rsync without `--delete`.
+4. Add the Vercel `/images/:path*` redirect to the media origin.
+5. Verify the deployed application and folder manifests.
+6. Stop committing new image binaries.
+7. Remove the tracked image tree in a separate change.
+8. Rewrite Git history only after all working copies and automation are ready.

--- a/scripts/generate_achievement_art.ts
+++ b/scripts/generate_achievement_art.ts
@@ -4,7 +4,8 @@
 // Achievement that has an `artPrompt` but no `imagePath`, it:
 //   1. generates an image from the prompt via the site's OpenAI image pipeline
 //      (server/utils/openAIImageGenerator.ts),
-//   2. downloads the result to public/images/achievements/<triggerCode>.png,
+//   2. downloads the result to images/achievements/<triggerCode>.png under the
+//      configured IMAGES_PATH (default: public/images),
 //   3. creates an ArtImage row and points the Achievement at it
 //      (imagePath + artImageId).
 //
@@ -27,10 +28,11 @@ import { dirname, resolve } from 'node:path'
 import { PrismaClient } from '../prisma/generated/prisma/client'
 import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 import { generateImageWithOpenAI } from '../server/utils/openAIImageGenerator'
+import { getImageStorageRoot } from '../server/utils/imageStorageRoot'
 import { slugify } from '../utils/slugify'
 
-const PUBLIC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'public')
-const ART_SUBDIR = 'images/achievements'
+const IMAGE_ROOT = getImageStorageRoot()
+const ART_SUBDIR = 'achievements'
 // Achievements seeded by the seed script share userId 10 (guest) as owner, the
 // same default ArtImage.userId uses elsewhere.
 const SEED_USER_ID = 10
@@ -41,9 +43,9 @@ function createSeedPrismaClient(): PrismaClient {
   return new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
 }
 
-async function downloadToPublic(url: string, slug: string): Promise<string> {
+async function downloadToImageStorage(url: string, slug: string): Promise<string> {
   const relPath = `${ART_SUBDIR}/${slug}.png`
-  const absPath = resolve(PUBLIC_DIR, relPath)
+  const absPath = resolve(IMAGE_ROOT, relPath)
   await mkdir(dirname(absPath), { recursive: true })
 
   const res = await fetch(url)
@@ -51,8 +53,8 @@ async function downloadToPublic(url: string, slug: string): Promise<string> {
   const bytes = Buffer.from(await res.arrayBuffer())
   await writeFile(absPath, bytes)
 
-  // Paths served by Nuxt are absolute from /public.
-  return `/${relPath}`
+  // Public paths remain stable regardless of the filesystem backing store.
+  return `/images/${relPath}`
 }
 
 async function main() {
@@ -89,7 +91,7 @@ async function main() {
           achievement.artPrompt as string,
           'achievement-seeder',
         )
-        const imagePath = await downloadToPublic(url, slug)
+        const imagePath = await downloadToImageStorage(url, slug)
 
         const artImage = await prisma.artImage.create({
           data: {

--- a/server/utils/UploadArtImage.ts
+++ b/server/utils/UploadArtImage.ts
@@ -1,9 +1,10 @@
 // /server/api/utils/UploadArtImage.ts
-import path from 'path'
-import fs from 'fs/promises'
+import path from 'node:path'
+import fs from 'node:fs/promises'
 import prisma from '~/server/utils/prisma'
 import type { ArtImage, Prisma } from '~/prisma/generated/prisma/client'
 import { errorHandler } from './error'
+import { getImageStorageRoot } from './imageStorageRoot'
 
 export type UploadedImageFile = {
   data: Buffer
@@ -161,7 +162,7 @@ export async function uploadArtImage(
     let savedImagePath = cleanText(input.imagePath)
 
     if (process.env.APP_ENV !== 'production') {
-      const imageRoot = process.env.IMAGES_PATH || './public/images'
+      const imageRoot = getImageStorageRoot()
       const dirPath = path.join(imageRoot, safeGalleryName)
       const filePath = path.join(dirPath, finalFileName)
 

--- a/server/utils/folderCollections.ts
+++ b/server/utils/folderCollections.ts
@@ -1,23 +1,24 @@
 // /server/utils/folderCollections.ts
 //
 // Folder-based art collections: every image sitting in a slug's folder under
-// public/images/ IS part of that slug's collection just by existing there
-// (Silas, 2026-07-04). Conductor's image pipeline maintains a gallery.json
-// manifest per folder and a master public/images/collections.json index
-// (slug -> folder path) so the collection can be resolved on Vercel, where
-// public/ lives on the CDN and the filesystem is not readable.
+// the configured image storage root IS part of that slug's collection just by
+// existing there (Silas, 2026-07-04). Conductor's image pipeline maintains a
+// gallery.json manifest per folder and a master collections.json index
+// (slug -> folder path) so the collection can be resolved when the filesystem
+// is not readable by the deployed application.
 //
 // Placement convention (Silas, 2026-07-05): the canonical home is nested,
-// public/images/{context}/{slug}/ - context being the most relevant schema or
-// project - with flat public/images/{slug}/ still valid as the degenerate
-// case, and artcollections/{slug}/ as the legacy/unsorted fallback. Both the
-// single-slug resolver and the enumeration below follow that order.
+// images/{context}/{slug}/ - context being the most relevant schema or project -
+// with flat images/{slug}/ still valid as the degenerate case, and
+// artcollections/{slug}/ as the legacy/unsorted fallback. Both the single-slug
+// resolver and the enumeration below follow that order.
 //
 // Shared by GET /api/art/collection/folder/[slug], GET
 // /api/art/collection/folders, and POST /api/art/collection/folder/[slug]/sync
 // so all three agree on exactly what "the folder's images" means.
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { getImageStorageRoot } from './imageStorageRoot'
 
 const IMAGE_EXTENSIONS = new Set([
   '.webp',
@@ -47,7 +48,7 @@ const NON_SLUG_DIRS = new Set(['images', 'artcollections'])
  * Split an ArtImage's public URL into its folder collection {slug, parentFolder}.
  * By the folder convention slug === the directory that holds the file (the leaf,
  * which is the collection's unique key); parentFolder is everything before it under
- * public/images/ (null when top-level). Returns null when the image sits loose
+ * the image root (null when top-level). Returns null when the image sits loose
  * in /images/ or the leaf isn't slug-shaped — callers fall back to "unsorted".
  *   /images/artcollections/sketchy/sketchy-card.webp -> { slug: "sketchy", parentFolder: "artcollections" }
  *   /images/rewards/duct-tape/x.webp                 -> { slug: "duct-tape", parentFolder: "rewards" }
@@ -90,9 +91,9 @@ async function listImages(
 }
 
 async function imagesFromFilesystem(slug: string): Promise<string[] | null> {
-  const imagesRoot = path.resolve(process.cwd(), 'public/images')
+  const imagesRoot = getImageStorageRoot()
 
-  // 1. Nested: public/images/{context}/{slug}/
+  // 1. Nested: images/{context}/{slug}/
   try {
     const contexts = await fs.readdir(imagesRoot, { withFileTypes: true })
     for (const ctx of contexts) {
@@ -106,11 +107,11 @@ async function imagesFromFilesystem(slug: string): Promise<string[] | null> {
     return null // images root unreadable: CDN mode, use manifests
   }
 
-  // 2. Flat: public/images/{slug}/
+  // 2. Flat: images/{slug}/
   const flat = await listImages(path.join(imagesRoot, slug), `/images/${slug}`)
   if (flat) return flat
 
-  // 3. Legacy/unsorted: public/images/artcollections/{slug}/
+  // 3. Legacy/unsorted: images/artcollections/{slug}/
   return listImages(
     path.join(imagesRoot, 'artcollections', slug),
     `/images/artcollections/${slug}`,
@@ -142,7 +143,7 @@ async function imagesFromManifest(
   slug: string,
   origin: string,
 ): Promise<string[] | null> {
-  // 1. Master index: public/images/collections.json -> { [slug]: "context/slug" | "slug" }
+  // 1. Master index: /images/collections.json -> { [slug]: "context/slug" | "slug" }
   const index = await readCollectionsIndex(origin)
   const folder = index[slug]
   if (typeof folder === 'string' && /^[a-z0-9][a-z0-9_/-]*$/.test(folder)) {
@@ -166,14 +167,14 @@ async function imagesFromManifest(
 }
 
 /**
- * Read the master slug -> folder index. Prefers the local filesystem (dev),
- * falls back to fetching the CDN copy (Vercel). Returns {} when neither is
- * available so callers can degrade gracefully.
+ * Read the master slug -> folder index. Prefers the configured local image root,
+ * falls back to fetching the deployed copy. Returns {} when neither is available
+ * so callers can degrade gracefully.
  */
 async function readCollectionsIndex(
   origin: string,
 ): Promise<Record<string, string>> {
-  const local = path.resolve(process.cwd(), 'public/images/collections.json')
+  const local = path.join(getImageStorageRoot(), 'collections.json')
   try {
     const raw = await fs.readFile(local, 'utf8')
     const parsed = JSON.parse(raw)
@@ -220,7 +221,7 @@ export async function listFolderSlugs(origin: string): Promise<string[]> {
   }
 
   // Dev fallback: pick up folders that hold images but aren't indexed yet.
-  const imagesRoot = path.resolve(process.cwd(), 'public/images')
+  const imagesRoot = getImageStorageRoot()
   try {
     const contexts = await fs.readdir(imagesRoot, { withFileTypes: true })
     for (const ctx of contexts) {

--- a/server/utils/imageStorageRoot.ts
+++ b/server/utils/imageStorageRoot.ts
@@ -1,0 +1,18 @@
+// /server/utils/imageStorageRoot.ts
+import path from 'node:path'
+
+/**
+ * Filesystem root that backs the public `/images/...` namespace during local
+ * development and maintenance scripts.
+ *
+ * Defaults to the repository's `public/images` directory so existing setups
+ * keep working. Set IMAGES_PATH to an external mounted directory (for example
+ * `/mnt/z/kindrobots/images` in WSL) to write and discover images outside Git.
+ */
+export function getImageStorageRoot(): string {
+  const configuredRoot = process.env.IMAGES_PATH?.trim()
+
+  return configuredRoot
+    ? path.resolve(configuredRoot)
+    : path.resolve(process.cwd(), 'public/images')
+}

--- a/server/utils/saveImage.ts
+++ b/server/utils/saveImage.ts
@@ -1,7 +1,8 @@
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from './error'
-import path from 'path'
-import fs from 'fs/promises'
+import { getImageStorageRoot } from './imageStorageRoot'
+import path from 'node:path'
+import fs from 'node:fs/promises'
 
 export async function saveImage(
   base64Image: string,
@@ -23,9 +24,9 @@ export async function saveImage(
       },
     })
 
-    // Optionally save to the local filesystem in development
+    // Optionally save to the configured local filesystem in development.
     if (!isProduction) {
-      const dirPath = path.join(process.env.IMAGES_PATH || './public/images')
+      const dirPath = getImageStorageRoot()
       const filePath = path.join(dirPath, fileName)
 
       // Ensure the gallery directory exists


### PR DESCRIPTION
## What changed

- add one shared `getImageStorageRoot()` resolver controlled by `IMAGES_PATH`
- preserve `public/images` as the default for existing checkouts
- route local upload helpers through the configured root
- make folder collection discovery and `collections.json` reads follow the configured root
- make the achievement art generator write to the configured root while retaining `/images/...` database paths
- document the verified self-hosted paths and live cutover sequence

## Current infrastructure

- public origin: `https://media.acrocatranch.com/images/...`
- Unraid root: `/mnt/user/pc/kindrobots/images`
- WSL root: `/mnt/z/kindrobots/images`
- Nginx container: `media`

## Why

New art must begin landing outside Git before the final incremental rsync and Vercel redirect. The application URL contract remains `/images/...`; only the local filesystem backing store changes.

## Safety boundaries

- no Vercel redirect is activated
- no tracked images are removed
- no history is rewritten
- no paid or external storage dependency is added
- Vercel is explicitly not configured with `IMAGES_PATH`

## Local validation

Set this in the WSL development environment and restart the relevant writer:

```dotenv
IMAGES_PATH=/mnt/z/kindrobots/images
```

Then create one new test image and confirm it appears both at the Unraid path and through `media.acrocatranch.com`.
