### PR TITLE
packmaker: admin pack generator view (conductor packmaker/t-004)

### DIFF
--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -1,0 +1,342 @@
+<!-- /components/conductor/packmaker-admin-panel.vue -->
+<!--
+  Packmaker admin generator (conductor packmaker/t-004). Admin-only: renders
+  nothing for everyone else. Loads a pack manifest (seeded launch packs or
+  pasted JSON), runs generation per item through the existing pipelines via
+  packStore, shows per-item progress, and marks a fully-generated pack ready.
+  Releasing a pack (making items public / storefront wiring) is deliberately
+  NOT a button here — that step stays human-gated.
+-->
+<template>
+  <section
+    v-if="userStore.isAdmin"
+    class="flex flex-col gap-4 rounded-3xl border border-warning/40 bg-base-100 p-5 shadow-sm"
+  >
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex items-center gap-2">
+        <span
+          class="flex size-9 items-center justify-center rounded-xl bg-warning/15 text-warning"
+        >
+          <Icon name="kind-icon:box" class="size-5" />
+        </span>
+        <div>
+          <h3 class="text-base font-black text-base-content">Pack Generator</h3>
+          <p class="text-xs font-semibold text-base-content/50">
+            Admin only — items are created private until release is approved
+          </p>
+        </div>
+      </div>
+      <button
+        class="btn btn-ghost btn-xs rounded-xl"
+        @click="showImport = !showImport"
+      >
+        <Icon name="kind-icon:plus" class="size-3.5" />
+        Load manifest JSON
+      </button>
+    </div>
+
+    <!-- Paste-a-manifest for the NEXT pack -->
+    <div v-if="showImport" class="flex flex-col gap-2">
+      <textarea
+        v-model="importText"
+        rows="6"
+        class="textarea textarea-bordered w-full font-mono text-xs"
+        placeholder='{"schemaVersion": 1, "id": "my-pack", "title": "My Pack", "visibility": "draft", "price": {"hook": "free"}, "items": [...]}'
+      />
+      <div class="flex items-center gap-2">
+        <button class="btn btn-primary btn-sm rounded-xl" @click="onImport">
+          Import pack
+        </button>
+        <span
+          v-if="importMessage"
+          class="text-xs font-semibold"
+          :class="importOk ? 'text-success' : 'text-error'"
+          >{{ importMessage }}</span
+        >
+      </div>
+    </div>
+
+    <!-- Pack selector -->
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="pack in packStore.manifests"
+        :key="pack.id"
+        class="btn btn-sm rounded-2xl"
+        :class="
+          pack.id === selectedPackId
+            ? 'btn-primary'
+            : 'btn-ghost border border-base-300'
+        "
+        @click="selectedPackId = pack.id"
+      >
+        {{ pack.title }}
+        <span class="badge badge-xs" :class="progressBadgeClass(pack.id)">
+          {{ packStore.packProgress(pack.id).done }}/{{
+            packStore.packProgress(pack.id).total
+          }}
+        </span>
+      </button>
+    </div>
+
+    <template v-if="selectedPack">
+      <!-- Pack header -->
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="badge badge-outline badge-sm rounded-xl">{{
+          selectedPack.price.hook
+        }}</span>
+        <span
+          class="badge badge-sm rounded-xl"
+          :class="
+            packStore.packBuildStatus(selectedPack.id) === 'ready'
+              ? 'badge-success'
+              : 'badge-ghost'
+          "
+          >{{ packStore.packBuildStatus(selectedPack.id) }}</span
+        >
+        <p class="w-full text-sm leading-relaxed text-base-content/70">
+          {{ selectedPack.description }}
+        </p>
+      </div>
+
+      <!-- Item table -->
+      <div class="flex flex-col gap-2">
+        <article
+          v-for="item in selectedPack.items"
+          :key="item.id"
+          class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span
+                class="badge badge-xs rounded-lg"
+                :class="typeBadge(item.type)"
+              >
+                {{ item.type }}
+              </span>
+              <span class="truncate text-sm font-bold text-base-content">
+                {{ item.draftPayload?.title || item.id }}
+              </span>
+              <span
+                class="badge badge-xs rounded-lg"
+                :class="statusBadge(stateFor(item.id).status)"
+              >
+                {{ statusLabel(stateFor(item.id).status) }}
+              </span>
+              <span
+                v-if="stateFor(item.id).refId"
+                class="text-xs font-mono text-base-content/50"
+                >#{{ stateFor(item.id).refId }}</span
+              >
+            </div>
+            <p class="mt-1 line-clamp-2 text-xs text-base-content/60">
+              {{ item.draftPayload?.description }}
+            </p>
+            <p
+              v-if="stateFor(item.id).error"
+              class="mt-1 text-xs font-semibold text-error"
+            >
+              {{ stateFor(item.id).error }}
+            </p>
+          </div>
+          <div class="flex shrink-0 items-center gap-1.5">
+            <button
+              v-if="!stateFor(item.id).refId"
+              class="btn btn-primary btn-xs rounded-xl"
+              :disabled="isBusy(item.id)"
+              @click="onCreate(item.id)"
+            >
+              <span
+                v-if="stateFor(item.id).status === 'creating'"
+                class="loading loading-spinner loading-xs"
+              />
+              Create record
+            </button>
+            <button
+              v-if="stateFor(item.id).refId && !stateFor(item.id).artImageId"
+              class="btn btn-secondary btn-xs rounded-xl"
+              :disabled="isBusy(item.id)"
+              @click="onArt(item.id)"
+            >
+              <span
+                v-if="stateFor(item.id).status === 'generating-art'"
+                class="loading loading-spinner loading-xs"
+              />
+              Generate art
+            </button>
+            <button
+              v-if="stateFor(item.id).refId"
+              class="btn btn-ghost btn-xs rounded-xl"
+              :disabled="isBusy(item.id)"
+              title="Forget the local link and start this item over as a fresh row"
+              @click="packStore.resetItem(selectedPack.id, item.id)"
+            >
+              <Icon name="kind-icon:refresh" class="size-3.5" />
+            </button>
+          </div>
+        </article>
+      </div>
+
+      <!-- Pack-level actions -->
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          class="btn btn-outline btn-sm rounded-2xl"
+          :disabled="anyBusy"
+          @click="onGenerateAll"
+        >
+          <Icon name="kind-icon:sparkles" class="size-4" />
+          Create all remaining records
+        </button>
+        <button
+          v-if="packStore.packBuildStatus(selectedPack.id) !== 'ready'"
+          class="btn btn-success btn-sm rounded-2xl"
+          :disabled="!packStore.isPackComplete(selectedPack.id)"
+          @click="onMarkReady"
+        >
+          <Icon name="kind-icon:check" class="size-4" />
+          Mark pack ready
+        </button>
+        <button
+          v-else
+          class="btn btn-ghost btn-sm rounded-2xl"
+          @click="packStore.markPackDraft(selectedPack.id)"
+        >
+          Back to draft
+        </button>
+        <span
+          v-if="actionMessage"
+          class="text-xs font-semibold text-base-content/60"
+          >{{ actionMessage }}</span
+        >
+      </div>
+      <p class="text-xs text-base-content/40">
+        Ready is local bookkeeping. Making pack items public and wiring the
+        storefront remain separate, human-approved steps.
+      </p>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { usePackStore, type PackItemBuildStatus } from '@/stores/packStore'
+import type { PackItemType } from '@/stores/seeds/packManifests'
+
+const userStore = useUserStore()
+const packStore = usePackStore()
+
+const selectedPackId = ref<string>('')
+const showImport = ref(false)
+const importText = ref('')
+const importMessage = ref('')
+const importOk = ref(false)
+const actionMessage = ref('')
+
+onMounted(() => {
+  packStore.initialize()
+  const firstPack = packStore.manifests[0]
+  if (!selectedPackId.value && firstPack) {
+    selectedPackId.value = firstPack.id
+  }
+})
+
+const selectedPack = computed(
+  () => packStore.packById(selectedPackId.value) || null,
+)
+
+function stateFor(itemId: string) {
+  return packStore.itemState(selectedPackId.value, itemId)
+}
+
+function isBusy(itemId: string): boolean {
+  const status = stateFor(itemId).status
+  return status === 'creating' || status === 'generating-art'
+}
+
+const anyBusy = computed(
+  () => selectedPack.value?.items.some((item) => isBusy(item.id)) ?? false,
+)
+
+function progressBadgeClass(packId: string): string {
+  const { done, total } = packStore.packProgress(packId)
+  if (total > 0 && done === total) return 'badge-success'
+  if (done > 0) return 'badge-warning'
+  return 'badge-ghost'
+}
+
+function typeBadge(type: PackItemType): string {
+  switch (type) {
+    case 'location':
+      return 'badge-info'
+    case 'genre':
+      return 'badge-secondary'
+    case 'character':
+      return 'badge-primary'
+    case 'reward':
+      return 'badge-accent'
+  }
+}
+
+function statusBadge(status: PackItemBuildStatus): string {
+  switch (status) {
+    case 'complete':
+      return 'badge-success'
+    case 'created':
+      return 'badge-info'
+    case 'creating':
+    case 'generating-art':
+      return 'badge-warning'
+    case 'error':
+      return 'badge-error'
+    default:
+      return 'badge-ghost'
+  }
+}
+
+function statusLabel(status: PackItemBuildStatus): string {
+  switch (status) {
+    case 'generating-art':
+      return 'rendering'
+    default:
+      return status
+  }
+}
+
+function onImport(): void {
+  const result = packStore.importManifest(importText.value)
+  importOk.value = result.success
+  importMessage.value = result.message
+  if (result.success) {
+    importText.value = ''
+    showImport.value = false
+  }
+}
+
+async function onCreate(itemId: string): Promise<void> {
+  const result = await packStore.createItemRecord(selectedPackId.value, itemId)
+  actionMessage.value = result.message
+}
+
+async function onArt(itemId: string): Promise<void> {
+  const result = await packStore.generateItemArt(selectedPackId.value, itemId)
+  actionMessage.value = result.message
+}
+
+// Sequential on purpose: one shared generation backend, no reason to slam it.
+async function onGenerateAll(): Promise<void> {
+  const pack = selectedPack.value
+  if (!pack) return
+  for (const item of pack.items) {
+    if (!stateFor(item.id).refId) {
+      const result = await packStore.createItemRecord(pack.id, item.id)
+      actionMessage.value = result.message
+      if (!result.success) break
+    }
+  }
+}
+
+function onMarkReady(): void {
+  const result = packStore.markPackReady(selectedPackId.value)
+  actionMessage.value = result.message
+}
+</script>

--- a/components/conductor/packmaker-page.vue
+++ b/components/conductor/packmaker-page.vue
@@ -1,6 +1,10 @@
 <!-- /components/conductor/packmaker-page.vue -->
 <template>
-  <ProjectFrontPage slug="packmaker" :fallback="config" />
+  <ProjectFrontPage slug="packmaker" :fallback="config">
+    <template #interactive>
+      <PackmakerAdminPanel />
+    </template>
+  </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">

--- a/stores/packStore.ts
+++ b/stores/packStore.ts
@@ -1,0 +1,465 @@
+// /stores/packStore.ts
+//
+// Packmaker admin generator state (conductor project: packmaker, task t-004).
+// Drives pack manifests (stores/seeds/packManifests.ts + admin-pasted JSON)
+// through the EXISTING kind_robots creation pipelines, one item at a time:
+//
+//   dream item     → POST /api/dreams      (dreamType LOCATION/CHARACTER)
+//   facet item     → POST /api/facets      (kind GENRE)
+//   character item → POST /api/characters
+//   reward item    → POST /api/rewards     (rewardType ITEM)
+//   item art       → artStore.generateArt() then PATCH artImageId onto the row
+//
+// No new generation logic, model routing, or backend surface is added here
+// (packmaker SPEC.md §2, BOUNDARY.md). Every row is created isPublic: false —
+// the interim all-or-nothing privacy rule from SPEC.md §4. "Ready" is a local
+// bookkeeping flag meaning "all items generated"; actually releasing a pack
+// (flipping isPublic / storefront wiring) stays a separately-gated human step
+// and is intentionally NOT implemented by this store.
+//
+// Build progress (which manifest item became which row) persists in
+// localStorage so re-running or resuming a pack is cheap — the whole point of
+// t-004 is making the NEXT pack cheap to produce.
+
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import { performFetch } from '@/stores/utils'
+import { useArtStore } from '@/stores/artStore'
+import {
+  seedPackManifests,
+  type PackManifest,
+  type PackManifestItem,
+  type PackItemShape,
+} from '@/stores/seeds/packManifests'
+
+export type PackItemBuildStatus =
+  'draft' | 'creating' | 'created' | 'generating-art' | 'complete' | 'error'
+
+export interface PackItemBuildState {
+  status: PackItemBuildStatus
+  refId: number | null
+  artImageId: number | null
+  error: string | null
+}
+
+export type PackBuildStatus = 'draft' | 'ready'
+
+const BUILD_STATE_KEY = 'packmaker-build-state'
+const IMPORTED_MANIFESTS_KEY = 'packmaker-imported-manifests'
+const PACK_STATUS_KEY = 'packmaker-pack-status'
+
+const ITEM_SHAPES: PackItemShape[] = ['dream', 'facet', 'character', 'reward']
+const ITEM_TYPES = ['location', 'genre', 'character', 'reward']
+const PRICE_HOOKS = ['free', 'one-time', 'dlc']
+
+function defaultItemState(): PackItemBuildState {
+  return { status: 'draft', refId: null, artImageId: null, error: null }
+}
+
+/**
+ * Validate a parsed JSON value against the schemaVersion 1 manifest shape
+ * (conductor projects/packmaker/packs/SCHEMA.md). Returns an error string, or
+ * null when the manifest is usable.
+ */
+export function validatePackManifest(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return 'Manifest must be a JSON object.'
+  }
+  const pack = value as Record<string, unknown>
+  if (pack.schemaVersion !== 1) return 'schemaVersion must be 1.'
+  if (typeof pack.id !== 'string' || !pack.id.trim()) {
+    return 'Pack "id" is required.'
+  }
+  if (typeof pack.title !== 'string' || !pack.title.trim()) {
+    return 'Pack "title" is required.'
+  }
+  if (pack.visibility !== 'draft' && pack.visibility !== 'released') {
+    return 'visibility must be "draft" or "released".'
+  }
+  const price = pack.price as Record<string, unknown> | undefined
+  if (!price || !PRICE_HOOKS.includes(String(price.hook))) {
+    return 'price.hook must be free, one-time, or dlc.'
+  }
+  if (!Array.isArray(pack.items) || pack.items.length === 0) {
+    return 'Pack must contain at least one item.'
+  }
+  for (const [index, raw] of pack.items.entries()) {
+    if (!raw || typeof raw !== 'object')
+      return `Item ${index} must be an object.`
+    const item = raw as Record<string, unknown>
+    if (typeof item.id !== 'string' || !item.id.trim()) {
+      return `Item ${index} is missing "id".`
+    }
+    if (!ITEM_TYPES.includes(String(item.type))) {
+      return `Item "${item.id}" has unknown type "${item.type}".`
+    }
+    if (!ITEM_SHAPES.includes(item.itemShape as PackItemShape)) {
+      return `Item "${item.id}" has unknown itemShape "${item.itemShape}".`
+    }
+    const payload = item.draftPayload as Record<string, unknown> | undefined
+    if (!item.refId && !payload) {
+      return `Item "${item.id}" needs a draftPayload (or a refId).`
+    }
+    if (payload) {
+      for (const field of ['title', 'description'] as const) {
+        if (typeof payload[field] !== 'string' || !payload[field]) {
+          return `Item "${item.id}" draftPayload is missing "${field}".`
+        }
+      }
+    }
+  }
+  return null
+}
+
+export const usePackStore = defineStore('packStore', () => {
+  const importedManifests = ref<PackManifest[]>([])
+  const buildState = ref<Record<string, Record<string, PackItemBuildState>>>({})
+  const packStatus = ref<Record<string, PackBuildStatus>>({})
+  const isInitialized = ref(false)
+
+  const manifests = computed<PackManifest[]>(() => {
+    const importedIds = new Set(importedManifests.value.map((m) => m.id))
+    // An imported manifest with a seed's id overrides the seed copy.
+    return [
+      ...seedPackManifests.filter((m) => !importedIds.has(m.id)),
+      ...importedManifests.value,
+    ]
+  })
+
+  function packById(packId: string): PackManifest | null {
+    return manifests.value.find((m) => m.id === packId) || null
+  }
+
+  function itemState(packId: string, itemId: string): PackItemBuildState {
+    return buildState.value[packId]?.[itemId] || defaultItemState()
+  }
+
+  function packBuildStatus(packId: string): PackBuildStatus {
+    return packStatus.value[packId] || 'draft'
+  }
+
+  function packProgress(packId: string): { done: number; total: number } {
+    const pack = packById(packId)
+    if (!pack) return { done: 0, total: 0 }
+    const done = pack.items.filter(
+      (item) => itemState(packId, item.id).refId !== null,
+    ).length
+    return { done, total: pack.items.length }
+  }
+
+  function isPackComplete(packId: string): boolean {
+    const { done, total } = packProgress(packId)
+    return total > 0 && done === total
+  }
+
+  function initialize(): void {
+    if (isInitialized.value || !import.meta.client) return
+    try {
+      const storedBuild = localStorage.getItem(BUILD_STATE_KEY)
+      if (storedBuild) buildState.value = JSON.parse(storedBuild)
+      const storedImports = localStorage.getItem(IMPORTED_MANIFESTS_KEY)
+      if (storedImports) importedManifests.value = JSON.parse(storedImports)
+      const storedStatus = localStorage.getItem(PACK_STATUS_KEY)
+      if (storedStatus) packStatus.value = JSON.parse(storedStatus)
+    } catch {
+      // Corrupt local state falls back to a clean slate; the database rows
+      // themselves are untouched.
+      buildState.value = {}
+      importedManifests.value = []
+      packStatus.value = {}
+    }
+    isInitialized.value = true
+  }
+
+  function persist(): void {
+    if (!import.meta.client) return
+    try {
+      localStorage.setItem(BUILD_STATE_KEY, JSON.stringify(buildState.value))
+      localStorage.setItem(
+        IMPORTED_MANIFESTS_KEY,
+        JSON.stringify(importedManifests.value),
+      )
+      localStorage.setItem(PACK_STATUS_KEY, JSON.stringify(packStatus.value))
+    } catch {
+      // Storage quota/private-mode failures only lose resume convenience.
+    }
+  }
+
+  function setItemState(
+    packId: string,
+    itemId: string,
+    updates: Partial<PackItemBuildState>,
+  ): void {
+    const packBucket = { ...(buildState.value[packId] || {}) }
+    packBucket[itemId] = {
+      ...(packBucket[itemId] || defaultItemState()),
+      ...updates,
+    }
+    buildState.value = { ...buildState.value, [packId]: packBucket }
+    persist()
+  }
+
+  /** Paste-a-manifest path for future packs: JSON with the schema v1 shape. */
+  function importManifest(rawJson: string): {
+    success: boolean
+    message: string
+  } {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(rawJson)
+    } catch {
+      return { success: false, message: 'Manifest is not valid JSON.' }
+    }
+    const problem = validatePackManifest(parsed)
+    if (problem) return { success: false, message: problem }
+    const manifest = parsed as PackManifest
+    importedManifests.value = [
+      ...importedManifests.value.filter((m) => m.id !== manifest.id),
+      manifest,
+    ]
+    persist()
+    return { success: true, message: `Loaded pack "${manifest.title}".` }
+  }
+
+  function removeImportedManifest(packId: string): void {
+    importedManifests.value = importedManifests.value.filter(
+      (m) => m.id !== packId,
+    )
+    persist()
+  }
+
+  /**
+   * Materialize one manifest item as a real database row through the model's
+   * existing create endpoint. Always isPublic: false (SPEC.md §4 interim rule).
+   */
+  async function createItemRecord(
+    packId: string,
+    itemId: string,
+  ): Promise<{ success: boolean; message: string }> {
+    const pack = packById(packId)
+    const item = pack?.items.find((entry) => entry.id === itemId)
+    if (!pack || !item) {
+      return { success: false, message: 'Unknown pack or item.' }
+    }
+    const payload = item.draftPayload
+    if (!payload) {
+      return {
+        success: false,
+        message: `Item "${itemId}" has no draftPayload.`,
+      }
+    }
+
+    setItemState(packId, itemId, { status: 'creating', error: null })
+
+    const { url, body } = buildCreateRequest(item)
+    const response = await performFetch<{ id: number }>(url, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+
+    if (!response.success || !response.data?.id) {
+      const message = response.message || 'Create request failed.'
+      setItemState(packId, itemId, { status: 'error', error: message })
+      return { success: false, message }
+    }
+
+    setItemState(packId, itemId, {
+      status: 'created',
+      refId: response.data.id,
+      error: null,
+    })
+    return {
+      success: true,
+      message: `Created ${item.itemShape} #${response.data.id} for "${payload.title}".`,
+    }
+  }
+
+  function buildCreateRequest(item: PackManifestItem): {
+    url: string
+    body: Record<string, unknown>
+  } {
+    const payload = item.draftPayload!
+    const shared = {
+      description: payload.description,
+      artPrompt: payload.artPrompt,
+      isPublic: false,
+      isMature: false,
+      designer: 'packmaker',
+    }
+    switch (item.itemShape) {
+      case 'dream':
+        return {
+          url: '/api/dreams',
+          body: {
+            ...shared,
+            title: payload.title,
+            dreamType: item.type === 'character' ? 'CHARACTER' : 'LOCATION',
+          },
+        }
+      case 'facet':
+        return {
+          url: '/api/facets',
+          body: { ...shared, title: payload.title, kind: 'GENRE' },
+        }
+      case 'character':
+        return {
+          url: '/api/characters',
+          body: {
+            name: payload.title,
+            backstory: payload.description,
+            artPrompt: payload.artPrompt,
+            isPublic: false,
+            isMature: false,
+            designer: 'packmaker',
+          },
+        }
+      case 'reward':
+        return {
+          url: '/api/rewards',
+          body: { ...shared, name: payload.title, rewardType: 'ITEM' },
+        }
+    }
+  }
+
+  /**
+   * Generate art for an already-created item through the shared art pipeline,
+   * then attach the finished ArtImage to the row. Requires the record first so
+   * there is always something to attach the image to.
+   */
+  async function generateItemArt(
+    packId: string,
+    itemId: string,
+  ): Promise<{ success: boolean; message: string }> {
+    const pack = packById(packId)
+    const item = pack?.items.find((entry) => entry.id === itemId)
+    if (!pack || !item?.draftPayload) {
+      return { success: false, message: 'Unknown pack or item.' }
+    }
+    const state = itemState(packId, itemId)
+    if (!state.refId) {
+      return {
+        success: false,
+        message: 'Create the item record before generating its art.',
+      }
+    }
+
+    setItemState(packId, itemId, { status: 'generating-art', error: null })
+
+    const artStore = useArtStore()
+    const result = await artStore.generateArt({
+      promptString: item.draftPayload.artPrompt,
+      title: item.draftPayload.title,
+      designer: 'packmaker',
+      isPublic: false,
+      isMature: false,
+    })
+
+    if (!result.success || !result.data?.id) {
+      const message = result.message || 'Art generation failed.'
+      setItemState(packId, itemId, { status: 'error', error: message })
+      return { success: false, message }
+    }
+
+    const patch = await performFetch(
+      `${patchBase(item.itemShape)}/${state.refId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ artImageId: result.data.id }),
+      },
+    )
+
+    if (!patch.success) {
+      const message =
+        patch.message ||
+        `Art image ${result.data.id} rendered but could not be attached.`
+      setItemState(packId, itemId, {
+        status: 'error',
+        artImageId: result.data.id,
+        error: message,
+      })
+      return { success: false, message }
+    }
+
+    setItemState(packId, itemId, {
+      status: 'complete',
+      artImageId: result.data.id,
+      error: null,
+    })
+    return {
+      success: true,
+      message: `Art attached to ${item.itemShape} #${state.refId}.`,
+    }
+  }
+
+  function patchBase(shape: PackItemShape): string {
+    switch (shape) {
+      case 'dream':
+        return '/api/dreams'
+      case 'facet':
+        return '/api/facets'
+      case 'character':
+        return '/api/characters'
+      case 'reward':
+        return '/api/rewards'
+    }
+  }
+
+  /** Forget the local link so the item can be re-generated as a fresh row. */
+  function resetItem(packId: string, itemId: string): void {
+    setItemState(packId, itemId, defaultItemState())
+    if (packStatus.value[packId] === 'ready') {
+      packStatus.value = { ...packStatus.value, [packId]: 'draft' }
+      persist()
+    }
+  }
+
+  /**
+   * Local bookkeeping only: all items generated, pack is ready for the (still
+   * human-gated) release step. Does NOT flip isPublic or touch the storefront.
+   */
+  function markPackReady(packId: string): {
+    success: boolean
+    message: string
+  } {
+    if (!isPackComplete(packId)) {
+      return {
+        success: false,
+        message: 'Every item needs a generated record first.',
+      }
+    }
+    packStatus.value = { ...packStatus.value, [packId]: 'ready' }
+    persist()
+    return {
+      success: true,
+      message:
+        'Pack marked ready. Releasing it (making items public / storefront wiring) stays a separate human-approved step.',
+    }
+  }
+
+  function markPackDraft(packId: string): void {
+    packStatus.value = { ...packStatus.value, [packId]: 'draft' }
+    persist()
+  }
+
+  return {
+    manifests,
+    importedManifests,
+    buildState,
+    isInitialized,
+
+    packById,
+    itemState,
+    packBuildStatus,
+    packProgress,
+    isPackComplete,
+
+    initialize,
+    importManifest,
+    removeImportedManifest,
+    createItemRecord,
+    generateItemArt,
+    resetItem,
+    markPackReady,
+    markPackDraft,
+  }
+})

--- a/stores/seeds/packManifests.ts
+++ b/stores/seeds/packManifests.ts
@@ -1,0 +1,419 @@
+// /stores/seeds/packManifests.ts
+//
+// Packmaker manifest seed — the front-end copy of the approved launch-pack
+// manifests (conductor project: packmaker, tasks t-003/t-004). The canonical
+// source of truth is conductor's projects/packmaker/packs/*.yaml (schemaVersion
+// 1, see SCHEMA.md there); this file mirrors those approved drafts as typed
+// data so the admin generator view can run without a conductor round-trip or a
+// YAML dependency. New packs can also be pasted into the admin panel as JSON
+// with this same shape — see stores/packStore.ts.
+//
+// Nothing here touches the database. Every item is a draft payload only;
+// generation happens item-by-item from the admin panel through the existing
+// dreams/facets/characters/rewards + art pipelines, always with
+// isPublic: false until the pack is released (interim rule per packmaker
+// SPEC.md §4, pending kind-robots t-008's sharing/ACL design).
+
+export type PackItemType = 'location' | 'genre' | 'character' | 'reward'
+
+/** Which kind_robots model a pack item materializes into. */
+export type PackItemShape = 'dream' | 'facet' | 'character' | 'reward'
+
+export type PackVisibility = 'draft' | 'released'
+
+export type PackPriceHook = 'free' | 'one-time' | 'dlc'
+
+export interface PackItemDraftPayload {
+  title: string
+  description: string
+  /** Prompt for regenerating the item's text through the chat pipeline. */
+  generationPrompt: string
+  /** Prompt for the item's art through the art pipeline. */
+  artPrompt: string
+}
+
+export interface PackManifestItem {
+  id: string
+  type: PackItemType
+  itemShape: PackItemShape
+  draftPayload: PackItemDraftPayload
+  /** Set once the item has been generated into a real database row. */
+  refId?: number | null
+  notes?: string
+}
+
+export interface PackManifest {
+  schemaVersion: 1
+  id: string
+  title: string
+  description: string
+  owner: string
+  visibility: PackVisibility
+  price: { hook: PackPriceHook }
+  items: PackManifestItem[]
+}
+
+const uncannyValor: PackManifest = {
+  schemaVersion: 1,
+  id: 'uncanny-valor',
+  title: 'Uncanny Valor',
+  description:
+    'A street-level superhero launch pack: two home-turf locations, two tonal genres, four powered cast members with distinct origin flavors, and three signature gear rewards tied to those characters.',
+  owner: 'silas',
+  visibility: 'draft',
+  price: { hook: 'dlc' },
+  items: [
+    {
+      id: 'ironclad-skyport',
+      type: 'location',
+      itemShape: 'dream',
+      draftPayload: {
+        title: 'Ironclad Skyport',
+        description:
+          'A retrofitted cargo-blimp dock hovering above the old industrial district, now serving as an unofficial hero headquarters — half landing pad, half squat, entirely held together by donated parts and stubbornness.',
+        generationPrompt:
+          'Write a short evocative location description (80-120 words) for Ironclad Skyport, a retrofitted cargo-blimp dock turned makeshift superhero headquarters above an industrial district, for use as a kind_robots Dream (dreamType: LOCATION) description. Emphasize scrappy, held-together-by-hand engineering over polished tech.',
+        artPrompt:
+          'A weathered airship dock bristling with mismatched antennas and patched gas envelopes, floating above smokestacks at dusk, warm window light, painterly comic-inspired illustration.',
+      },
+      notes: "Home base location; anchors the pack's street-level tone.",
+    },
+    {
+      id: 'sublevel-nine',
+      type: 'location',
+      itemShape: 'dream',
+      draftPayload: {
+        title: 'Sublevel Nine',
+        description:
+          "A decommissioned subway level converted into a containment wing for the city's stranger problems — part holding cell, part evidence locker for things that don't fit in either category.",
+        generationPrompt:
+          'Write a short evocative location description (80-120 words) for Sublevel Nine, a decommissioned subway level repurposed as a containment and evidence facility for superhuman incidents, for use as a kind_robots Dream (dreamType: LOCATION) description. Favor an uneasy, institutional-but-improvised tone over high-tech polish.',
+        artPrompt:
+          'A disused subway platform lined with reinforced cell doors and hand-labeled evidence crates, flickering fluorescent light, muted teal and rust color palette, moody illustration.',
+      },
+      notes: 'Secondary location; source of complication-driven plot hooks.',
+    },
+    {
+      id: 'grounded-heroics',
+      type: 'genre',
+      itemShape: 'facet',
+      draftPayload: {
+        title: 'Grounded Heroics',
+        description:
+          'Personal-stakes superhero stories about rent, relationships, and showing up for your neighborhood — powers are a complication, not a solution.',
+        generationPrompt:
+          'Write a one-sentence flavor description for a "Grounded Heroics" genre Facet (kind: GENRE), emphasizing personal, street-level stakes over cosmic spectacle.',
+        artPrompt:
+          'Abstract genre icon: a cracked shield overlapping a house key, muted urban color palette, flat illustration style.',
+      },
+      notes: "Default tonal register for this pack's characters and locations.",
+    },
+    {
+      id: 'bombastic-showdown',
+      type: 'genre',
+      itemShape: 'facet',
+      draftPayload: {
+        title: 'Bombastic Showdown',
+        description:
+          'Over-the-top set-piece battles where the skyline is the stakes and subtlety took the week off.',
+        generationPrompt:
+          'Write a one-sentence flavor description for a "Bombastic Showdown" genre Facet (kind: GENRE), emphasizing large-scale, high-energy superhero battles.',
+        artPrompt:
+          'Abstract genre icon: a lightning bolt shattering a city skyline silhouette, saturated primary colors, flat illustration style.',
+      },
+      notes: 'Escalation-flavored counterpart to Grounded Heroics.',
+    },
+    {
+      id: 'volta-ferrin',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Volta Ferrin',
+        description:
+          "A former power-plant engineer who survived a grid-failure accident as a living lightning conduit — now moonlights as backup muscle while trying to keep her old crew's lights on.",
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Volta Ferrin, a former power-plant engineer turned living lightning conduit, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. blunt, protective, exhausted).",
+        artPrompt:
+          'Portrait of a wiry woman in a work jumpsuit crackling with faint blue-white electricity along her arms, safety goggles pushed up on her forehead, industrial backdrop, character concept art.',
+      },
+      notes:
+        "Power source ties directly to Ironclad Skyport's improvised tech.",
+    },
+    {
+      id: 'greyline',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Greyline',
+        description:
+          'A disgraced ex-cop who can turn intangible for short bursts, now working the same streets from the other side of the badge — equal parts penance and unfinished business.',
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Greyline, a disgraced ex-police officer with short-burst intangibility, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. guarded, methodical, self-doubting).",
+        artPrompt:
+          'Portrait of a lean figure in a faded grey coat partially phasing into translucency at the edges, city alley backdrop at night, noir-tinged character concept art.',
+      },
+      notes: "Best paired narratively with Sublevel Nine's containment cases.",
+    },
+    {
+      id: 'bastion-ruk',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Bastion Ruk',
+        description:
+          'A gentle giant with near-total invulnerability, drawn to the team less for the fighting and more for the excuse to keep helping people move apartments.',
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Bastion Ruk, an invulnerable strongman with a gentle disposition, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. patient, soft-spoken, fiercely loyal).",
+        artPrompt:
+          'Portrait of a towering broad-shouldered man with weathered stone-grey skin texture, work gloves, a warm easy smile, soft daylight, character concept art.',
+      },
+      notes: 'Tonal anchor toward Grounded Heroics.',
+    },
+    {
+      id: 'echo-vance',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Echo Vance',
+        description:
+          "A former touring musician whose voice can now shatter glass or calm a crowd, depending on which show they're putting on that night.",
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Echo Vance, a former musician with sound-manipulation powers, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. theatrical, restless, secretly anxious about losing their old life).",
+        artPrompt:
+          'Portrait of a stylish androgynous performer with visible sound-wave motifs rippling from their hands, stage lighting, character concept art.',
+      },
+      notes: 'Bombastic Showdown-leaning character; pairs with big set pieces.',
+    },
+    {
+      id: 'ferrin-coil',
+      type: 'reward',
+      itemShape: 'reward',
+      draftPayload: {
+        title: 'Ferrin Coil',
+        description:
+          "A palm-sized capacitor coil, cool to the touch until it isn't — stores a single stored jolt of borrowed current for later use.",
+        generationPrompt:
+          'Write flavor text (2-3 sentences) for a kind_robots Reward named "Ferrin Coil" (rewardType: ITEM), themed around stored electrical power and improvised engineering, connected to Volta Ferrin.',
+        artPrompt:
+          'A small copper-wound coil device with a faint blue glow at its core, item-icon style, soft studio lighting.',
+      },
+      notes:
+        'Linked conceptually to volta-ferrin; no DreamToReward relation until locations are generated.',
+    },
+    {
+      id: 'greylines-badge',
+      type: 'reward',
+      itemShape: 'reward',
+      draftPayload: {
+        title: "Greyline's Badge",
+        description:
+          'A tarnished precinct badge, edges gone faintly translucent — carrying it seems to make its bearer a little harder to notice.',
+        generationPrompt:
+          'Write flavor text (2-3 sentences) for a kind_robots Reward named "Greyline\'s Badge" (rewardType: ITEM), themed around quiet watchfulness and unfinished justice, connected to Greyline.',
+        artPrompt:
+          'A worn silver police badge with edges dissolving into faint mist, item-icon style, cool blue-grey lighting.',
+      },
+      notes: 'Linked conceptually to greyline.',
+    },
+    {
+      id: 'bastions-core-fragment',
+      type: 'reward',
+      itemShape: 'reward',
+      draftPayload: {
+        title: "Bastion's Core Fragment",
+        description:
+          "A fist-sized shard of stone-grey material, warm as skin — said to lend its bearer a measure of Bastion's steadiness under pressure.",
+        generationPrompt:
+          'Write flavor text (2-3 sentences) for a kind_robots Reward named "Bastion\'s Core Fragment" (rewardType: ITEM), themed around steadiness and quiet endurance, connected to Bastion Ruk.',
+        artPrompt:
+          'A rough-hewn grey stone shard with faint warm inner light along its cracks, item-icon style, soft studio lighting.',
+      },
+      notes: 'Linked conceptually to bastion-ruk.',
+    },
+  ],
+}
+
+const arcaneWhimsy: PackManifest = {
+  schemaVersion: 1,
+  id: 'arcane-whimsy',
+  title: 'Arcane Whimsy',
+  description:
+    'A cozy-to-eerie magic launch pack: a hidden market and a moonlit observatory as home locations, two tonal genres spanning whimsical and wyrd, four spellcasting cast members, and three enchanted-item rewards tied to those characters.',
+  owner: 'silas',
+  visibility: 'draft',
+  price: { hook: 'dlc' },
+  items: [
+    {
+      id: 'bramblewick-market',
+      type: 'location',
+      itemShape: 'dream',
+      draftPayload: {
+        title: 'The Bramblewick Market',
+        description:
+          "A hidden bazaar that only opens on foggy mornings, tucked between two buildings that don't quite touch — stalls sell talking teapots, secondhand luck, and directions to places that no longer exist.",
+        generationPrompt:
+          'Write a short evocative location description (80-120 words) for The Bramblewick Market, a hidden bazaar that only appears on foggy mornings between two buildings, for use as a kind_robots Dream (dreamType: LOCATION) description. Favor a cozy, whimsical tone with a light undercurrent of the uncanny.',
+        artPrompt:
+          'A narrow cobblestone alley market strung with lanterns and fabric canopies, stalls overflowing with curious trinkets, soft fog, warm painterly fantasy illustration.',
+      },
+      notes: "Home base location; anchors the pack's cozy-conjuring tone.",
+    },
+    {
+      id: 'hollow-moon-observatory',
+      type: 'location',
+      itemShape: 'dream',
+      draftPayload: {
+        title: 'Hollow Moon Observatory',
+        description:
+          "A cliffside spellcasting academy built around a telescope that hasn't pointed at a real star in decades — its lenses show somewhere else entirely, and the faculty have opinions about where.",
+        generationPrompt:
+          'Write a short evocative location description (80-120 words) for Hollow Moon Observatory, a cliffside magic academy whose central telescope shows an uncanny otherworld instead of the sky, for use as a kind_robots Dream (dreamType: LOCATION) description. Favor an eerie, wyrd tone appropriate for a higher-stakes counterpart to a cozy market.',
+        artPrompt:
+          'A stone observatory perched on a moonlit sea cliff, an oversized brass telescope aimed at a swirling violet aperture instead of the stars, atmospheric fantasy illustration.',
+      },
+      notes:
+        'Secondary location; source of higher-stakes, Wyrd Peril plot hooks.',
+    },
+    {
+      id: 'cozy-conjuring',
+      type: 'genre',
+      itemShape: 'facet',
+      draftPayload: {
+        title: 'Cozy Conjuring',
+        description:
+          'Low-stakes, slice-of-life magic stories about tea, mending charms, and small kindnesses done with a wand.',
+        generationPrompt:
+          'Write a one-sentence flavor description for a "Cozy Conjuring" genre Facet (kind: GENRE), emphasizing gentle, low-stakes, slice-of-life magic.',
+        artPrompt:
+          'Abstract genre icon: a teacup with a swirl of sparkling steam shaped like a small star, warm pastel palette, flat illustration style.',
+      },
+      notes:
+        "Default tonal register for this pack's lighter characters and market location.",
+    },
+    {
+      id: 'wyrd-peril',
+      type: 'genre',
+      itemShape: 'facet',
+      draftPayload: {
+        title: 'Wyrd Peril',
+        description:
+          'Eerie, fae-touched danger where the rules of magic bend and the bill always comes due, one way or another.',
+        generationPrompt:
+          'Write a one-sentence flavor description for a "Wyrd Peril" genre Facet (kind: GENRE), emphasizing eerie, higher-stakes fae-touched danger.',
+        artPrompt:
+          'Abstract genre icon: a crescent moon cracked open with thorned vines spilling out, deep violet and black palette, flat illustration style.',
+      },
+      notes: 'Escalation-flavored counterpart to Cozy Conjuring.',
+    },
+    {
+      id: 'marigold-thistlewick',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Marigold Thistlewick',
+        description:
+          'A hedge witch who brews potions out of a market stall, more interested in fixing small everyday problems than in grand magic — though the grand magic keeps finding her anyway.',
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Marigold Thistlewick, a hedge witch and potion brewer working out of a market stall, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. practical, warm, quietly stubborn).",
+        artPrompt:
+          'Portrait of a middle-aged woman in a patched apron surrounded by floating bottles and dried herbs, warm lantern light, character concept art.',
+      },
+      notes: 'Anchors Bramblewick Market and the Cozy Conjuring tone.',
+    },
+    {
+      id: 'corvid-nightshade',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Corvid Nightshade',
+        description:
+          'An illusionist bonded to a raven familiar who may or may not be the one actually in charge — their tricks are gorgeous, unsettling, and never quite what they first appear to be.',
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Corvid Nightshade, a raven-familiar-bonded illusionist, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. sly, theatrical, hard to pin down).",
+        artPrompt:
+          'Portrait of a slender figure in a feathered cloak with a raven perched on one shoulder, faint illusory duplicates shimmering at the edges, moody violet lighting, character concept art.',
+      },
+      notes:
+        'Wyrd Peril-leaning character; pairs with Hollow Moon Observatory.',
+    },
+    {
+      id: 'pell-wickstone',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'Pell Wickstone',
+        description:
+          'An apprentice enchanter at Hollow Moon who is earnest, clumsy, and one accidental miscast away from a very interesting afternoon — beloved by the market stallholders for the same reason the faculty find them exhausting.',
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for Pell Wickstone, a well-meaning but clumsy apprentice enchanter, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. eager, accident-prone, kind).",
+        artPrompt:
+          'Portrait of a young apprentice in an ill-fitting robe with singed sleeve cuffs, sparks fizzling from an overloaded wand, sheepish expression, character concept art.',
+      },
+      notes:
+        'Bridges both locations; comic relief with real stakes underneath.',
+    },
+    {
+      id: 'hollow-warden',
+      type: 'character',
+      itemShape: 'character',
+      draftPayload: {
+        title: 'The Hollow Warden',
+        description:
+          "An ancient moss-covered golem that has guarded the observatory's telescope for longer than anyone living can account for — slow to speak, slower to trust, and the only one who remembers what the telescope used to point at.",
+        generationPrompt:
+          "Write a short character backstory (100-150 words) for The Hollow Warden, an ancient moss-covered golem guardian of a magical observatory, for use as a kind_robots Character row's flavor text. Suggest a class/species and a short list of notable traits (e.g. ancient, taciturn, unexpectedly gentle).",
+        artPrompt:
+          'Portrait of a massive stone golem overgrown with moss and small flowering vines, glowing faint violet runes across its chest, moonlit cliff backdrop, character concept art.',
+      },
+      notes:
+        'Wyrd Peril anchor character tied directly to Hollow Moon Observatory.',
+    },
+    {
+      id: 'thistlewicks-ledger',
+      type: 'reward',
+      itemShape: 'reward',
+      draftPayload: {
+        title: "Thistlewick's Ledger",
+        description:
+          'A small leather-bound recipe book whose pages rearrange themselves to show whichever potion its holder needs most, whether they asked for it or not.',
+        generationPrompt:
+          'Write flavor text (2-3 sentences) for a kind_robots Reward named "Thistlewick\'s Ledger" (rewardType: ITEM), themed around practical potion-craft and quiet helpfulness, connected to Marigold Thistlewick.',
+        artPrompt:
+          'A worn leather recipe book with a pressed flower bookmark and faint golden text shimmering across an open page, item-icon style, warm lighting.',
+      },
+      notes: 'Linked conceptually to marigold-thistlewick.',
+    },
+    {
+      id: 'nightshade-feather',
+      type: 'reward',
+      itemShape: 'reward',
+      draftPayload: {
+        title: 'Nightshade Feather',
+        description:
+          'A single raven feather that shivers faintly when an illusion is nearby — tucked in a pocket, it has a habit of making its bearer just slightly harder to look directly at.',
+        generationPrompt:
+          'Write flavor text (2-3 sentences) for a kind_robots Reward named "Nightshade Feather" (rewardType: ITEM), themed around illusion and misdirection, connected to Corvid Nightshade.',
+        artPrompt:
+          'A single glossy black feather with a faint violet shimmer along its edge, item-icon style, moody lighting.',
+      },
+      notes: 'Linked conceptually to corvid-nightshade.',
+    },
+    {
+      id: 'wardens-lichen-cloak',
+      type: 'reward',
+      itemShape: 'reward',
+      draftPayload: {
+        title: "Warden's Lichen Cloak",
+        description:
+          'A cloak woven from moss and lichen scraped from an ancient guardian — heavier than it looks, and it seems to steady the nerves of whoever wears it near something uncanny.',
+        generationPrompt:
+          'Write flavor text (2-3 sentences) for a kind_robots Reward named "Warden\'s Lichen Cloak" (rewardType: ITEM), themed around ancient steadiness and quiet protection, connected to The Hollow Warden.',
+        artPrompt:
+          'A heavy moss-green cloak textured with small lichen patches and faint glowing rune-threads along the hem, item-icon style, soft moonlit lighting.',
+      },
+      notes: 'Linked conceptually to hollow-warden.',
+    },
+  ],
+}
+
+export const seedPackManifests: PackManifest[] = [uncannyValor, arcaneWhimsy]


### PR DESCRIPTION
### Task
packmaker/t-004: Build the pack generator admin view in kind_robots  (kind: software, cross-repo — task state lives in the conductor roadmap)

### What changed / what I produced
- `stores/seeds/packManifests.ts` — typed front-end copies of the two approved launch-pack manifests (Uncanny Valor, Arcane Whimsy). Canonical source remains conductor `projects/packmaker/packs/*.yaml` (schemaVersion 1); this mirrors them so the admin view needs no conductor round-trip and no YAML dependency.
- `stores/packStore.ts` — Pinia store that materializes manifest items through the **existing** create pipelines (`POST /api/dreams|facets|characters|rewards`) and generates item art via `artStore.generateArt()` then PATCHes `artImageId` onto the row. Every row is created `isPublic: false` per SPEC.md §4's interim privacy rule. Build state (item → refId/artImageId) persists in localStorage so packs are resumable/re-runnable; includes JSON manifest import with schema-v1 validation so the NEXT pack is cheap — the point of t-004.
- `components/conductor/packmaker-admin-panel.vue` — admin-only panel (`v-if="userStore.isAdmin"`, renders nothing otherwise): pack selector with progress badges, per-item create/generate-art/reset, create-all-remaining, paste-a-manifest, and a local "mark pack ready" flag.
- `components/conductor/packmaker-page.vue` — mounts the panel in `ProjectFrontPage`'s `#interactive` slot (admin view and user view share the /packs page, per SPEC.md §3).

### How I verified
- `npm run test` (vue-tsc --noEmit): exit 0
- `npx eslint` on all four files: clean
- `npx prettier --check`: clean
- API field mapping checked against the live routes/schema: `DreamType.LOCATION/CHARACTER`, `FacetKind.GENRE`, `RewardType.ITEM`, `Character.name/backstory`, and confirmed all four `[id].patch` routes accept `artImageId`.
- No runtime drive: generation needs the live backend + admin auth, unavailable in this sandbox — flagged below.

### Stakes
reversible

### Flags for Reviewer
- Could not exercise generation end-to-end from the sandbox (no live DB/relay/admin token); verification is typecheck/lint plus field-mapping audit against the server routes.
- "Mark pack ready" is deliberately local bookkeeping only. Releasing a pack (flipping `isPublic`, storefront wiring) is NOT implemented — human-gated pending kind-robots t-008 and digital-storefront t-017.
- SPEC.md §7's open "Pack Prisma model" question: this PR sticks with manifests + localStorage rather than proposing schema; if Silas wants server-side pack CRUD, that's a follow-up pitch.

### Kaizen suggestion
Add a small Vitest-style unit test for `validatePackManifest` (pure function, no DOM/backend needed) so manifest-schema drift between conductor SCHEMA.md and the front-end validator gets caught automatically.

### Notes for reviewer
The seed file is large but pure data — a faithful transcription of the two approved YAML manifests, reviewed against the originals line-by-line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVJ36q7qGLZwVceJmpvy1n)_