### PR TITLE
Stop Cypress test users and friend requests from leaking

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -149,6 +149,14 @@ jobs:
           sleep 5
           run_pool_round 3
 
+      - name: Remove stale Cypress users
+        env:
+          CYPRESS_BASE_API_URL: https://kind-robots.vercel.app/api
+          CYPRESS_BETA_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          CYPRESS_API_KEY: ${{ secrets.CYPRESS_API_KEY }}
+          CYPRESS_CLEANUP_PHASE: before-run
+        run: node scripts/cleanup-cypress-users.mjs
+
       - name: Run Cypress tests
         id: cypress
         uses: cypress-io/github-action@v6
@@ -164,6 +172,15 @@ jobs:
           CYPRESS_TIMING_LOG: '1'
           CYPRESS_SYNTHETIC_SOURCE: github-actions-cypress
           CYPRESS_SYNTHETIC_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Remove Cypress users after run
+        if: always() && steps.cypress.outcome != 'skipped'
+        env:
+          CYPRESS_BASE_API_URL: https://kind-robots.vercel.app/api
+          CYPRESS_BETA_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          CYPRESS_API_KEY: ${{ secrets.CYPRESS_API_KEY }}
+          CYPRESS_CLEANUP_PHASE: after-run
+        run: node scripts/cleanup-cypress-users.mjs
 
       - name: Verify Cypress cleanup
         # Only meaningful when Cypress actually ran. When an earlier gate (deploy
@@ -181,6 +198,7 @@ jobs:
             .cypress-cache/timing-latest.json
             .cypress-cache/seed-cleanup-latest.json
             .cypress-cache/orphan-user-sweep-latest.json
+            .cypress-cache/user-cleanup-*.json
           if-no-files-found: warn
 
       - name: Upload Cypress screenshots on failure

--- a/cypress/support/api-auth.ts
+++ b/cypress/support/api-auth.ts
@@ -33,7 +33,7 @@ export type TestUserRole = 'primary' | 'second'
 export type CreateLoggedInTestUserOptions = {
   /** @deprecated The suite now reuses run-scoped identities. */
   fresh?: boolean
-  /** `second` resolves to the existing administrator; it creates no user. */
+  /** `second` creates an isolated disposable account for relationship tests. */
   role?: TestUserRole
 }
 
@@ -105,13 +105,13 @@ export const extractUserId = (body: ApiResponse<RegisterUserData>): number => {
   return id as number
 }
 
-export const getSeedTestUser = (role: TestUserRole = 'primary') =>
+export const getSeedTestUser = () =>
   cy
     .task<{
       user: TestUserAuth
       secondUser: TestUserAuth
     }>('cypressSeed:get')
-    .then((seed) => (role === 'second' ? seed.secondUser : seed.user))
+    .then((seed) => seed.user)
 
 // Kept as an explicit escape hatch for a future test that truly requires an
 // isolated account. Normal specs must call createLoggedInTestUser().
@@ -173,7 +173,10 @@ export const createFreshLoggedInTestUser = () =>
 
 export const createLoggedInTestUser = (
   options: CreateLoggedInTestUserOptions = {},
-) => getSeedTestUser(options.role || 'primary')
+) =>
+  options.role === 'second'
+    ? createFreshLoggedInTestUser()
+    : getSeedTestUser()
 
 export const deleteTestUser = (
   apiBase: string,

--- a/scripts/cleanup-cypress-users.mjs
+++ b/scripts/cleanup-cypress-users.mjs
@@ -1,0 +1,133 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const apiBase = String(
+  process.env.CYPRESS_BASE_API_URL ||
+    process.env.BASE_API_URL ||
+    'https://kind-robots.vercel.app/api',
+).replace(/\/+$/, '')
+
+const adminToken = String(
+  process.env.CYPRESS_ADMIN_TOKEN ||
+    process.env.CYPRESS_BETA_ADMIN_TOKEN ||
+    process.env.CYPRESS_API_KEY ||
+    process.env.ADMIN_TOKEN ||
+    process.env.BETA_ADMIN_TOKEN ||
+    process.env.API_KEY ||
+    '',
+).trim()
+
+const phase = String(process.env.CYPRESS_CLEANUP_PHASE || 'manual')
+  .trim()
+  .replace(/[^a-z0-9_-]+/gi, '-')
+  .toLowerCase()
+const maxBatches = 100
+const reportDir = path.resolve('.cypress-cache')
+const reportFile = path.join(reportDir, `user-cleanup-${phase}.json`)
+const attempts = []
+
+const report = {
+  createdAt: new Date().toISOString(),
+  phase,
+  apiBase,
+  ok: false,
+  deleted: 0,
+  remaining: null,
+  attempts,
+}
+
+const writeReport = () => {
+  fs.mkdirSync(reportDir, { recursive: true })
+  fs.writeFileSync(reportFile, `${JSON.stringify(report, null, 2)}\n`)
+}
+
+try {
+  if (!adminToken) {
+    throw new Error(
+      'Cypress user cleanup requires CYPRESS_BETA_ADMIN_TOKEN or CYPRESS_API_KEY.',
+    )
+  }
+
+  for (let batch = 1; batch <= maxBatches; batch += 1) {
+    const response = await fetch(`${apiBase}/users/cypress-cleanup`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'x-api-key': adminToken,
+        'x-admin-token': adminToken,
+        'x-beta-admin-token': adminToken,
+      },
+      body: JSON.stringify({ maxAgeMs: 0, limit: 10 }),
+    })
+
+    const text = await response.text()
+    let body
+    try {
+      body = text ? JSON.parse(text) : {}
+    } catch {
+      body = { success: false, message: text }
+    }
+
+    const deleted = Array.isArray(body?.data?.deleted) ? body.data.deleted : []
+    const failed = Array.isArray(body?.data?.failed) ? body.data.failed : []
+    const remaining = Number(body?.data?.remaining)
+
+    attempts.push({
+      batch,
+      status: response.status,
+      success: body?.success,
+      deleted,
+      failed,
+      remaining: Number.isFinite(remaining) ? remaining : null,
+      message: body?.message,
+    })
+    report.deleted += deleted.length
+    report.remaining = Number.isFinite(remaining) ? remaining : null
+
+    if (![200, 207].includes(response.status) || body?.success === false) {
+      throw new Error(
+        `Cypress cleanup batch ${batch} failed: HTTP ${response.status} ${JSON.stringify(body)}`,
+      )
+    }
+
+    if (failed.length > 0) {
+      throw new Error(
+        `Cypress cleanup batch ${batch} could not delete ${failed.length} user(s): ${JSON.stringify(failed)}`,
+      )
+    }
+
+    if (!Number.isFinite(remaining)) {
+      throw new Error(
+        `Cypress cleanup batch ${batch} returned no remaining-user count: ${JSON.stringify(body)}`,
+      )
+    }
+
+    if (remaining === 0) {
+      report.ok = true
+      console.log(
+        `Cypress user cleanup (${phase}) removed ${report.deleted} user(s); none remain.`,
+      )
+      break
+    }
+
+    if (deleted.length === 0) {
+      throw new Error(
+        `Cypress cleanup made no progress with ${remaining} user(s) remaining.`,
+      )
+    }
+  }
+
+  if (!report.ok) {
+    throw new Error(
+      `Cypress cleanup exceeded ${maxBatches} batches with ${report.remaining ?? 'unknown'} user(s) remaining.`,
+    )
+  }
+} catch (error) {
+  report.error = error instanceof Error ? error.message : String(error)
+  console.error(report.error)
+  process.exitCode = 1
+} finally {
+  writeReport()
+  console.log(`Cypress cleanup report: ${reportFile}`)
+}

--- a/scripts/verify-cypress-cleanup.mjs
+++ b/scripts/verify-cypress-cleanup.mjs
@@ -33,8 +33,25 @@ const failures = []
 for (const entry of Array.isArray(cleanup) ? cleanup : []) {
   if (entry?.ok === false) failures.push({ source: path.basename(cleanupFile), entry })
 }
-for (const entry of Array.isArray(orphan?.results) ? orphan.results : []) {
-  if (entry?.ok === false) failures.push({ source: path.basename(orphanFile), entry })
+
+if (orphan?.ok === false && orphan?.skipped !== true) {
+  failures.push({ source: path.basename(orphanFile), entry: orphan })
+}
+
+const orphanFailed = Array.isArray(orphan?.data?.failed) ? orphan.data.failed : []
+if (orphanFailed.length > 0) {
+  failures.push({
+    source: path.basename(orphanFile),
+    entry: { failed: orphanFailed },
+  })
+}
+
+const orphanRemaining = Number(orphan?.data?.remaining)
+if (Number.isFinite(orphanRemaining) && orphanRemaining > 0) {
+  failures.push({
+    source: path.basename(orphanFile),
+    entry: { remaining: orphanRemaining },
+  })
 }
 
 if (failures.length > 0) {
@@ -45,5 +62,5 @@ if (failures.length > 0) {
 
 console.log(
   `Cypress cleanup verified: ${Array.isArray(cleanup) ? cleanup.length : 0} cleanup result(s), ` +
-    `${Number(orphan?.candidates || 0)} stale user candidate(s).`,
+    `${Number(orphan?.data?.deleted?.length || 0)} stale user(s) removed.`,
 )


### PR DESCRIPTION
## What changed

- friendship tests now use a disposable second account instead of the real administrator account
- added a deterministic admin cleanup script that purges every `cypress-*` user in batches
- run that purge before Cypress starts and again after Cypress finishes or fails
- upload the cleanup reports with the existing Cypress diagnostics
- fixed cleanup verification to read the actual orphan-sweep report shape and detect failures or remaining users

## Root cause

The friendship suite used the existing admin as its second identity, so any interrupted teardown left real friend requests in the admin inbox. Rapid pushes also cancel older Cypress workflows; canceled runs can skip Cypress's `after:run` hook. The fallback orphan sweep waited two hours, removed at most ten users per pass, and its verifier looked for fields that the report does not contain.

## Expected impact

Normal and failed runs remove test accounts immediately. A canceled run may not execute its final step, but the next run purges all pre-existing Cypress accounts before creating a new test user. Friendship requests now stay entirely between disposable test users.

## Validation

- reviewed the branch diff against current `main`
- cleanup script uses the existing admin-only `/api/users/cypress-cleanup` endpoint, loops until `remaining` is zero, and fails on partial cleanup
- no production user naming patterns are accepted by the endpoint; deletion remains restricted to `cypress-*` accounts
