### PR TITLE
Academy: make art-styler upload drop-zone keyboard accessible

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -112,6 +112,9 @@
           @change="handleFileSelect"
         />
         <div
+          role="button"
+          tabindex="0"
+          aria-label="Upload a source image"
           class="flex min-h-28 cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed transition-all duration-200"
           :class="
             isDragging
@@ -122,6 +125,7 @@
           @dragleave.prevent="isDragging = false"
           @drop.prevent="handleDrop"
           @click="fileInput?.click()"
+          @keydown.enter.space.prevent="fileInput?.click()"
         >
           <span
             class="flex h-10 w-10 items-center justify-center rounded-xl border border-base-300 bg-base-200 transition-transform"
@@ -156,6 +160,7 @@
             type="search"
             class="min-w-0 flex-1 bg-transparent"
             placeholder="Search images…"
+            aria-label="Search my images"
           />
         </label>
 


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor roadmap): Academy continuous-improvement pass — this cycle's lane: (1) front-end polish.

### What changed / what I produced
- `components/art/art-styler.vue`: the source-image upload drop-zone was a bare clickable `<div>` with no `role`, `tabindex`, or keydown handler — the actual `<input type="file">` it targets is `class="hidden"` and out of tab order, so keyboard-only users had no way to reach or trigger the file picker. Added `role="button"`, `tabindex="0"`, `aria-label="Upload a source image"`, and an `@keydown.enter.space` handler that mirrors the existing `@click` handler.
- Added `aria-label="Search my images"` to the gallery-search input in the same file, matching the convention `academy-styles-browser.vue` already uses on its own search box (this input's accessible name previously depended entirely on its placeholder, which disappears once text is typed).

Both surfaces are embedded directly in the Academy Remix Studio via `academy-remix.vue`, so this is a real accessibility fix on a primary Academy interaction path (not a cosmetic-only change), and `art-styler.vue` is shared more broadly (e.g. the Academy Style Lab tab), so the fix benefits every consumer.

### How I verified
- `npx eslint components/art/art-styler.vue` — clean
- `npx prettier --check components/art/art-styler.vue` — clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — exits 0, no new errors
- Did not exercise live in a browser (this sandbox has no reachable local DB for the app's SSR/API routes) — flagging for a manual keyboard/screen-reader click-through.

### Stakes
reversible

### Flags for Reviewer
- Not manually verified in a browser with a screen reader — typecheck/lint only, per this repo's usual conductor-session verification pattern.

### Kaizen suggestion
The same "bare clickable div, no keyboard affordance" pattern is worth a quick grep across the rest of the app (`components/**/*.vue` for `@click=` on a non-`<button>`/non-`<a>` element with no `role`/`tabindex` sibling) — this file had it, there may be others.

### Notes for reviewer
Found via a targeted accessibility sweep of the Academy front-end surfaces during this cycle's continuous-improvement pass (conductor `ai-art-academy/t-010`, recurring task).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ScK3vD1iF5g1V5QD5rCEsZ)_