### PR TITLE
subscribe.post.ts: require authenticated user instead of trusting client-supplied userId

### DIFF
--- a/server/api/stripe/subscribe.post.ts
+++ b/server/api/stripe/subscribe.post.ts
@@ -1,8 +1,9 @@
 // /server/api/stripe/subscribe.post.ts
-import { defineEventHandler, readBody } from 'h3'
+import { defineEventHandler } from 'h3'
 import Stripe from 'stripe'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
 
 let stripe: Stripe | null = null
 
@@ -23,14 +24,7 @@ function getStripeClient() {
 
 export default defineEventHandler(async (event) => {
   try {
-    const { userId } = await readBody<{ userId: number }>(event)
-
-    if (!userId)
-      return errorHandler({ message: 'No user ID provided', statusCode: 400 })
-
-    const user = await prisma.user.findUnique({ where: { id: userId } })
-    if (!user)
-      return errorHandler({ message: 'User not found', statusCode: 404 })
+    const { user } = await requireApiUser(event)
 
     const stripe = getStripeClient()
     const email = user.email || `user-${user.id}@kindrobots.org`
@@ -40,7 +34,7 @@ export default defineEventHandler(async (event) => {
 
     if (!user.stripeCustomerId) {
       await prisma.user.update({
-        where: { id: userId },
+        where: { id: user.id },
         data: { stripeCustomerId: customerId },
       })
     }


### PR DESCRIPTION
### Task
digital-storefront/t-024 (conductor): `subscribe.post.ts` require authenticated user instead of trusting client-supplied userId (kind: software)

### What changed / what I produced
- `server/api/stripe/subscribe.post.ts` no longer reads `userId` from the request body and looks the user up unauthenticated. It now calls `requireApiUser(event)` (same helper `cancel-subscription.post.ts` already uses) to derive the user from the caller's auth token, and uses that user's `id`/`email`/`stripeCustomerId` throughout.
- Removed the now-unused `readBody` import and the manual "no user id" / "user not found" branches (401 is handled by `requireApiUser` itself).

### Why
Kaizen from t-013's close: the endpoint trusted a client-supplied `userId` with no auth check, so any caller could pass an arbitrary id and start a Stripe subscription checkout (and silently attach a `stripeCustomerId` to) someone else's account.

### How I verified
- Confirmed `cartStore.ts`'s `performFetch` already attaches the caller's bearer token automatically (same as the existing `cancelSubscription()` call, which never needed to pass a userId), so no client change is required.
- `npx eslint server/api/stripe/subscribe.post.ts` — 1 pre-existing `no-explicit-any` error on the catch block, confirmed present before this change too (out of scope for this fix).
- `vue-tsc --noEmit` full project typecheck — exits 0, no new errors.

### Stakes
reversible

### Notes for reviewer
Scoped to the one file the task named. Left the client (`stores/cartStore.ts` / `subscription-manager.vue`) sending an unused `userId` field as-is since it's harmless and out of scope for this fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_013nv9QhfSUGpHQGHhafC4Qb)_