### PR TITLE
packmaker/t-008: test pack manifest validation

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Capture-group guard checker self-test
         run: npm run test:capture-group-guards-selftest
 
+      - name: Pack manifest validator self-test
+        run: npm run test:pack-manifest
+
       - name: mysql:// URL parser contract
         run: npm run test:parse-mysql-url
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:capture-group-guards": "tsx utils/scripts/verifyCaptureGroupGuards.ts",
     "test:capture-group-guards-selftest": "tsx utils/scripts/verifyCaptureGroupGuards.test.ts",
+    "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/utils/scripts/verifyPackManifest.test.ts
+++ b/utils/scripts/verifyPackManifest.test.ts
@@ -1,7 +1,42 @@
 // /utils/scripts/verifyPackManifest.test.ts
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
 
-import { validatePackManifest } from '../../stores/packStore.js'
+import ts from 'typescript'
+
+const storeSource = readFileSync(
+  new URL('../../stores/packStore.ts', import.meta.url),
+  'utf8',
+)
+const validatorStart = storeSource.indexOf('const ITEM_SHAPES')
+const validatorEnd = storeSource.indexOf('export const usePackStore')
+
+assert.ok(validatorStart >= 0, 'packStore.ts must define ITEM_SHAPES')
+assert.ok(validatorEnd > validatorStart, 'packStore.ts must export usePackStore')
+
+const validatorSource = storeSource
+  .slice(validatorStart, validatorEnd)
+  .replace('export function validatePackManifest', 'function validatePackManifest')
+
+const compiled = ts.transpileModule(
+  `${validatorSource}\nvalidationResult = validatePackManifest(input)`,
+  {
+    compilerOptions: {
+      module: ts.ModuleKind.None,
+      target: ts.ScriptTarget.ES2022,
+    },
+  },
+).outputText
+
+function validate(input: unknown): string | null {
+  const context: { input: unknown; validationResult: string | null } = {
+    input,
+    validationResult: null,
+  }
+  runInNewContext(compiled, context)
+  return context.validationResult
+}
 
 const validManifest = {
   schemaVersion: 1,
@@ -24,23 +59,17 @@ const validManifest = {
   ],
 }
 
-assert.equal(validatePackManifest(validManifest), null)
-
+assert.equal(validate(validManifest), null)
+assert.equal(validate({ ...validManifest, title: '' }), 'Pack "title" is required.')
 assert.equal(
-  validatePackManifest({ ...validManifest, title: '' }),
-  'Pack "title" is required.',
-)
-
-assert.equal(
-  validatePackManifest({
+  validate({
     ...validManifest,
     items: [{ ...validManifest.items[0], itemShape: 'invalid' }],
   }),
   'Item "test-location" has unknown itemShape "invalid".',
 )
-
 assert.equal(
-  validatePackManifest({
+  validate({
     ...validManifest,
     items: [{ ...validManifest.items[0], draftPayload: undefined }],
   }),
@@ -48,5 +77,5 @@ assert.equal(
 )
 
 console.log(
-  'Pack manifest validator verified: accepts schema-v1 input and rejects missing required fields, invalid item shapes, and items without draft payloads or references.',
+  'Pack manifest validator verified from packStore.ts source: accepts schema-v1 input and rejects missing required fields, invalid item shapes, and items without draft payloads or references.',
 )

--- a/utils/scripts/verifyPackManifest.test.ts
+++ b/utils/scripts/verifyPackManifest.test.ts
@@ -1,0 +1,52 @@
+// /utils/scripts/verifyPackManifest.test.ts
+import assert from 'node:assert/strict'
+
+import { validatePackManifest } from '../../stores/packStore.js'
+
+const validManifest = {
+  schemaVersion: 1,
+  id: 'test-pack',
+  title: 'Test Pack',
+  description: 'A focused manifest-validator fixture.',
+  owner: 'silas',
+  visibility: 'draft',
+  price: { hook: 'dlc' },
+  items: [
+    {
+      id: 'test-location',
+      type: 'location',
+      itemShape: 'dream',
+      draftPayload: {
+        title: 'Test Location',
+        description: 'A place used only by this regression test.',
+      },
+    },
+  ],
+}
+
+assert.equal(validatePackManifest(validManifest), null)
+
+assert.equal(
+  validatePackManifest({ ...validManifest, title: '' }),
+  'Pack "title" is required.',
+)
+
+assert.equal(
+  validatePackManifest({
+    ...validManifest,
+    items: [{ ...validManifest.items[0], itemShape: 'invalid' }],
+  }),
+  'Item "test-location" has unknown itemShape "invalid".',
+)
+
+assert.equal(
+  validatePackManifest({
+    ...validManifest,
+    items: [{ ...validManifest.items[0], draftPayload: undefined }],
+  }),
+  'Item "test-location" needs a draftPayload (or a refId).',
+)
+
+console.log(
+  'Pack manifest validator verified: accepts schema-v1 input and rejects missing required fields, invalid item shapes, and items without draft payloads or references.',
+)


### PR DESCRIPTION
### Task
packmaker/t-008: Add a unit test for packStore.ts's validatePackManifest

### What changed / what I produced
- Added `utils/scripts/verifyPackManifest.test.ts`, which reads and transpiles the actual validator block from `stores/packStore.ts` in a hermetic VM instead of duplicating its logic or booting the Nuxt/Pinia store runtime.
- Covered a valid schema-v1 manifest plus missing required title, invalid `itemShape`, and missing `draftPayload`/`refId` cases.
- Added `npm run test:pack-manifest` and wired it into the fast Contract Tests workflow.

### How I verified
- Compared `worker/packmaker-t-008` against current `main`: exactly three scoped files changed, with no production behavior changes.
- The first CI attempt correctly exposed that importing the store directly pulls in Nuxt aliases/runtime. The test was repaired on the same branch to execute the exact source validator in an isolated VM; no mocks or copied implementation.
- GitHub PR CI is the authoritative runtime verification gate.

### Stakes
reversible

### Flags for Reviewer
- No API, database, deployment, publishing, billing, or secret changes.
- The source-boundary assertions make the test fail clearly if the validator is moved, forcing the test to be updated rather than silently testing stale copied logic.

### Kaizen suggestion
Move `validatePackManifest` into a dependency-light manifest utility when another non-store caller needs it; this test demonstrates the coupling, but a production refactor is unnecessary for the current single-call-site task.