### PR TITLE
packmaker: pack editor — rename, hand-build, and LLM-scaffold packs (conductor packmaker/t-009)

### DIFF
--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -26,14 +26,28 @@
           </p>
         </div>
       </div>
-      <button
-        class="btn btn-ghost btn-xs rounded-xl"
-        @click="showImport = !showImport"
-      >
-        <Icon name="kind-icon:plus" class="size-3.5" />
-        Load manifest JSON
-      </button>
+      <div class="flex items-center gap-1.5">
+        <button class="btn btn-primary btn-xs rounded-xl" @click="openNewPack">
+          <Icon name="kind-icon:plus" class="size-3.5" />
+          New pack
+        </button>
+        <button
+          class="btn btn-ghost btn-xs rounded-xl"
+          @click="showImport = !showImport"
+        >
+          Load manifest JSON
+        </button>
+      </div>
     </div>
+
+    <!-- Pack editor: hand-build, LLM-scaffold, or edit/rename a pack -->
+    <PackmakerPackEditor
+      v-if="editorMode"
+      :key="editorMode === 'edit' ? `edit-${selectedPackId}` : 'new'"
+      :pack="editorMode === 'edit' ? selectedPack : null"
+      @close="editorMode = null"
+      @saved="onEditorSaved"
+    />
 
     <!-- Paste-a-manifest for the NEXT pack -->
     <div v-if="showImport" class="flex flex-col gap-2">
@@ -93,6 +107,14 @@
           "
           >{{ packStore.packBuildStatus(selectedPack.id) }}</span
         >
+        <button
+          class="btn btn-ghost btn-xs rounded-xl"
+          title="Rename the pack or edit its manifest entries"
+          @click="editorMode = 'edit'"
+        >
+          <Icon name="kind-icon:pencil" class="size-3.5" />
+          Edit / rename
+        </button>
         <p class="w-full text-sm leading-relaxed text-base-content/70">
           {{ selectedPack.description }}
         </p>
@@ -226,6 +248,7 @@ const userStore = useUserStore()
 const packStore = usePackStore()
 
 const selectedPackId = ref<string>('')
+const editorMode = ref<'new' | 'edit' | null>(null)
 const showImport = ref(false)
 const importText = ref('')
 const importMessage = ref('')
@@ -300,6 +323,15 @@ function statusLabel(status: PackItemBuildStatus): string {
     default:
       return status
   }
+}
+
+function openNewPack(): void {
+  editorMode.value = editorMode.value === 'new' ? null : 'new'
+}
+
+function onEditorSaved(packId: string): void {
+  selectedPackId.value = packId
+  editorMode.value = null
 }
 
 function onImport(): void {

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -1,0 +1,348 @@
+<!-- /components/conductor/packmaker-pack-editor.vue -->
+<!--
+  Pack editor (conductor packmaker/t-009). Builds or edits a pack manifest:
+  either hand-set some or all entries, or describe the pack in a sentence and
+  let the LLM draft a full scaffold (via /api/suggest, 'packmaker' sheet) to
+  review and adjust before saving. Saving only writes the local draft manifest
+  (packStore.savePackManifest) — items are generated later, one by one, from
+  the generator panel; nothing here touches the database.
+-->
+<template>
+  <div
+    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200/40 p-4"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <h4 class="text-sm font-black text-base-content">
+        {{ editingExisting ? `Edit pack: ${draft.title}` : 'New pack' }}
+      </h4>
+      <button class="btn btn-ghost btn-xs rounded-xl" @click="emit('close')">
+        Close
+      </button>
+    </div>
+
+    <!-- LLM scaffold -->
+    <div
+      class="flex flex-col gap-2 rounded-xl border border-secondary/30 bg-base-100 p-3"
+    >
+      <label class="text-xs font-bold text-base-content/70">
+        Describe the pack and let the model draft a scaffold
+      </label>
+      <textarea
+        v-model="scaffoldPrompt"
+        rows="2"
+        class="textarea textarea-bordered w-full text-sm"
+        placeholder="e.g. A noir detective pack set in a rain-soaked coastal city — moody locations, morally grey characters"
+      />
+      <div class="flex items-center gap-2">
+        <button
+          class="btn btn-secondary btn-xs rounded-xl"
+          :disabled="scaffolding"
+          @click="onScaffold"
+        >
+          <span v-if="scaffolding" class="loading loading-spinner loading-xs" />
+          Generate scaffold
+        </button>
+        <span
+          v-if="scaffoldMessage"
+          class="text-xs font-semibold"
+          :class="scaffoldOk ? 'text-success' : 'text-error'"
+          >{{ scaffoldMessage }}</span
+        >
+      </div>
+      <p class="text-xs text-base-content/40">
+        The draft loads below for review — nothing is saved or generated until
+        you say so.
+      </p>
+    </div>
+
+    <!-- Pack fields -->
+    <div class="grid gap-2 sm:grid-cols-2">
+      <label class="form-control">
+        <span class="label-text text-xs font-bold">Title</span>
+        <input
+          v-model="draft.title"
+          type="text"
+          class="input input-bordered input-sm"
+          @input="syncIdFromTitle"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs font-bold">Id (slug)</span>
+        <input
+          v-model="draft.id"
+          type="text"
+          class="input input-bordered input-sm font-mono"
+          :disabled="editingExisting"
+          @input="idTouched = true"
+        />
+      </label>
+      <label class="form-control sm:col-span-2">
+        <span class="label-text text-xs font-bold">Description</span>
+        <textarea
+          v-model="draft.description"
+          rows="2"
+          class="textarea textarea-bordered textarea-sm"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs font-bold">Price hook</span>
+        <select
+          v-model="draft.price.hook"
+          class="select select-bordered select-sm"
+        >
+          <option value="free">free</option>
+          <option value="one-time">one-time</option>
+          <option value="dlc">dlc</option>
+        </select>
+      </label>
+    </div>
+
+    <!-- Items -->
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <span class="text-xs font-bold text-base-content/70"
+          >Items ({{ draft.items.length }})</span
+        >
+        <button class="btn btn-ghost btn-xs rounded-xl" @click="addItem">
+          <Icon name="kind-icon:plus" class="size-3.5" />
+          Add item
+        </button>
+      </div>
+
+      <details
+        v-for="(item, index) in draft.items"
+        :key="index"
+        class="rounded-xl border border-base-300 bg-base-100"
+      >
+        <summary
+          class="flex cursor-pointer flex-wrap items-center gap-2 px-3 py-2"
+        >
+          <span class="badge badge-xs rounded-lg badge-ghost">{{
+            item.type
+          }}</span>
+          <span class="text-sm font-bold">{{
+            item.draftPayload.title || item.id || `item ${index + 1}`
+          }}</span>
+          <button
+            class="btn btn-ghost btn-xs ml-auto rounded-lg text-error"
+            title="Remove this item"
+            @click.prevent="draft.items.splice(index, 1)"
+          >
+            Remove
+          </button>
+        </summary>
+        <div class="grid gap-2 p-3 pt-1 sm:grid-cols-2">
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Type</span>
+            <select
+              v-model="item.type"
+              class="select select-bordered select-sm"
+              @change="item.itemShape = defaultShapeFor(item.type)"
+            >
+              <option value="location">location</option>
+              <option value="genre">genre</option>
+              <option value="character">character</option>
+              <option value="reward">reward</option>
+            </select>
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Shape</span>
+            <select
+              v-model="item.itemShape"
+              class="select select-bordered select-sm"
+            >
+              <option
+                v-for="shape in shapesFor(item.type)"
+                :key="shape"
+                :value="shape"
+              >
+                {{ shape }}
+              </option>
+            </select>
+          </label>
+          <label class="form-control sm:col-span-2">
+            <span class="label-text text-xs font-bold">Title</span>
+            <input
+              v-model="item.draftPayload.title"
+              type="text"
+              class="input input-bordered input-sm"
+              @input="item.id = slugify(item.draftPayload.title)"
+            />
+          </label>
+          <label class="form-control sm:col-span-2">
+            <span class="label-text text-xs font-bold">Description</span>
+            <textarea
+              v-model="item.draftPayload.description"
+              rows="2"
+              class="textarea textarea-bordered textarea-sm"
+            />
+          </label>
+          <label class="form-control sm:col-span-2">
+            <span class="label-text text-xs font-bold">Art prompt</span>
+            <textarea
+              v-model="item.draftPayload.artPrompt"
+              rows="2"
+              class="textarea textarea-bordered textarea-sm"
+            />
+          </label>
+          <label class="form-control sm:col-span-2">
+            <span class="label-text text-xs font-bold"
+              >Text generation prompt</span
+            >
+            <textarea
+              v-model="item.draftPayload.generationPrompt"
+              rows="2"
+              class="textarea textarea-bordered textarea-sm"
+            />
+          </label>
+        </div>
+      </details>
+    </div>
+
+    <!-- Save -->
+    <div class="flex items-center gap-2">
+      <button class="btn btn-primary btn-sm rounded-2xl" @click="onSave">
+        {{ editingExisting ? 'Save changes' : 'Create pack' }}
+      </button>
+      <span
+        v-if="saveMessage"
+        class="text-xs font-semibold"
+        :class="saveOk ? 'text-success' : 'text-error'"
+        >{{ saveMessage }}</span
+      >
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import { usePackStore } from '@/stores/packStore'
+import { slugify } from '@/utils/slugify'
+import type {
+  PackItemShape,
+  PackItemType,
+  PackManifest,
+  PackManifestItem,
+} from '@/stores/seeds/packManifests'
+
+const props = defineProps<{
+  /** Pack to edit; omit to start a fresh manifest. */
+  pack?: PackManifest | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+  /** Fired with the saved pack's id so the parent can select it. */
+  saved: [packId: string]
+}>()
+
+const packStore = usePackStore()
+
+const editingExisting = ref(Boolean(props.pack))
+const idTouched = ref(false)
+
+function emptyItem(): PackManifestItem {
+  return {
+    id: '',
+    type: 'location',
+    itemShape: 'dream',
+    draftPayload: {
+      title: '',
+      description: '',
+      generationPrompt: '',
+      artPrompt: '',
+    },
+  }
+}
+
+function emptyDraft(): PackManifest {
+  return {
+    schemaVersion: 1,
+    id: '',
+    title: '',
+    description: '',
+    owner: 'silas',
+    visibility: 'draft',
+    price: { hook: 'free' },
+    items: [emptyItem()],
+  }
+}
+
+// Deep-copy so edits never mutate the seed/imported manifest until save.
+const draft = reactive<PackManifest>(
+  props.pack
+    ? (JSON.parse(JSON.stringify(props.pack)) as PackManifest)
+    : emptyDraft(),
+)
+
+const scaffoldPrompt = ref('')
+const scaffolding = ref(false)
+const scaffoldMessage = ref('')
+const scaffoldOk = ref(false)
+const saveMessage = ref('')
+const saveOk = ref(false)
+
+function defaultShapeFor(type: PackItemType): PackItemShape {
+  switch (type) {
+    case 'location':
+      return 'dream'
+    case 'genre':
+      return 'facet'
+    case 'character':
+      return 'character'
+    case 'reward':
+      return 'reward'
+  }
+}
+
+// Characters may be lore-only Dreams; other types have one canonical shape.
+function shapesFor(type: PackItemType): PackItemShape[] {
+  return type === 'character' ? ['character', 'dream'] : [defaultShapeFor(type)]
+}
+
+function syncIdFromTitle(): void {
+  if (!editingExisting.value && !idTouched.value) {
+    draft.id = slugify(draft.title)
+  }
+}
+
+function addItem(): void {
+  draft.items.push(emptyItem())
+}
+
+async function onScaffold(): Promise<void> {
+  scaffolding.value = true
+  scaffoldMessage.value = ''
+  try {
+    const result = await packStore.generatePackScaffold(scaffoldPrompt.value)
+    scaffoldOk.value = result.success
+    if (!result.success) {
+      scaffoldMessage.value = result.message
+      return
+    }
+    Object.assign(draft, result.manifest)
+    idTouched.value = true
+    scaffoldMessage.value = `Drafted "${result.manifest.title}" — review and adjust below.`
+  } finally {
+    scaffolding.value = false
+  }
+}
+
+function onSave(): void {
+  // Backfill item ids from titles so hand-built entries validate.
+  for (const item of draft.items) {
+    if (!item.id && item.draftPayload.title) {
+      item.id = slugify(item.draftPayload.title)
+    }
+  }
+  if (!editingExisting.value) {
+    draft.id = draft.id || slugify(draft.title)
+  }
+  const result = packStore.savePackManifest(
+    JSON.parse(JSON.stringify(draft)) as PackManifest,
+  )
+  saveOk.value = result.success
+  saveMessage.value = result.message
+  if (result.success) emit('saved', draft.id)
+}
+</script>

--- a/server/api/suggest.post.ts
+++ b/server/api/suggest.post.ts
@@ -33,7 +33,7 @@ function getSuggestServerId(server: unknown): number | null {
 
 export default defineEventHandler(async (event) => {
   try {
-const body = await readBody<SuggestRequestBody>(event)
+    const body = await readBody<SuggestRequestBody>(event)
 
     const field = body?.field ?? ''
     const stepKey = body?.stepKey ?? body?.field ?? ''
@@ -68,11 +68,18 @@ const body = await readBody<SuggestRequestBody>(event)
       context,
     })
 
+    // Caller-requested completion budget, clamped so a bad request can't ask
+    // for an unbounded generation. Mana cost is estimated from the same value.
+    const maxTokens = Math.min(
+      Math.max(Math.trunc(body.maxTokens ?? body.max_tokens ?? 512), 64),
+      8192,
+    )
+
     const gate = await manaGate(event, {
       kind: 'text',
       estCostUsd: estimateTextCostUsd({
         model,
-        maxTokens: body.maxTokens ?? body.max_tokens ?? 512,
+        maxTokens,
       }),
       serverId: getSuggestServerId(server),
     })
@@ -89,13 +96,17 @@ const body = await readBody<SuggestRequestBody>(event)
     const value = await callSuggestProvider(systemPrompt, userPrompt, {
       provider,
       model,
+      maxTokens,
       apiKey:
         provider === 'anthropic'
           ? str(config.anthropicApiKey)
           : str(config.openaiApiKey),
       baseUrl:
         provider === 'ollama'
-          ? str(server?.baseUrl, str(config.ollamaBaseUrl, 'http://localhost:11434'))
+          ? str(
+              server?.baseUrl,
+              str(config.ollamaBaseUrl, 'http://localhost:11434'),
+            )
           : provider === 'openai_compatible'
             ? str(server?.baseUrl, 'http://localhost:1234')
             : undefined,

--- a/server/utils/suggest/sheets/index.ts
+++ b/server/utils/suggest/sheets/index.ts
@@ -6,6 +6,7 @@ import scenarioSuggest from './scenarioSuggest'
 import rewardSuggest from './rewardSuggest'
 import dreamSuggest from './dreamSuggest'
 import modelBuilderSuggest from './modelBuilderSuggest'
+import packmakerSuggest from './packmakerSuggest'
 import type { SuggestSheet } from '../suggestTypes'
 
 export const suggestSheets = [
@@ -16,4 +17,5 @@ export const suggestSheets = [
   rewardSuggest,
   dreamSuggest,
   modelBuilderSuggest,
+  packmakerSuggest,
 ] satisfies SuggestSheet[]

--- a/server/utils/suggest/sheets/packmakerSuggest.ts
+++ b/server/utils/suggest/sheets/packmakerSuggest.ts
@@ -1,0 +1,67 @@
+// /server/utils/suggest/sheets/packmakerSuggest.ts
+import type { SuggestSheet } from '../suggestTypes'
+
+// Packmaker scaffold sheet (conductor packmaker/t-009): given a general theme
+// prompt from the admin panel, draft a complete schemaVersion-1 pack manifest
+// as strict JSON. The client (stores/packStore.ts generatePackScaffold) parses
+// and validates the result with validatePackManifest before anything is saved,
+// so a malformed generation fails safely at the review step — nothing here
+// writes to the database.
+
+const packmakerSuggest: SuggestSheet = {
+  builder: 'packmaker',
+  label: 'Packmaker',
+  systemPrompt: `You are the Packmaker scaffold assistant for Kind Robots.
+You draft complete content-pack manifests as STRICT JSON matching this exact shape:
+
+{
+  "schemaVersion": 1,
+  "id": "<kebab-case-slug-of-title>",
+  "title": "<pack title>",
+  "description": "<1-2 sentence pack summary>",
+  "owner": "silas",
+  "visibility": "draft",
+  "price": { "hook": "free" },
+  "items": [
+    {
+      "id": "<kebab-case-slug>",
+      "type": "location" | "genre" | "character" | "reward",
+      "itemShape": "dream" | "facet" | "character" | "reward",
+      "draftPayload": {
+        "title": "<item title>",
+        "description": "<1-2 evocative sentences>",
+        "generationPrompt": "<prompt for regenerating this item's text>",
+        "artPrompt": "<visual prompt for this item's art>"
+      },
+      "notes": "<one line on the item's role in the pack>"
+    }
+  ]
+}
+
+Rules:
+- Return ONLY the JSON object. No prose, no markdown fences, no comments.
+- Default composition unless the user asks otherwise: 2 locations, 2 genres,
+  4 characters, 3 rewards (11 items). Honor any counts or types the user
+  specifies instead.
+- itemShape mapping: location -> "dream", genre -> "facet", reward -> "reward",
+  character -> "character" (use "dream" for a character only if the user asks
+  for lore-only characters without stat blocks).
+- Pack title: exactly two words, no alliteration between them (house naming
+  rule) unless the user supplies a title themselves.
+- price.hook is "free" unless the user says the pack is paid DLC ("dlc") or a
+  one-time purchase ("one-time"). visibility is always "draft".
+- Keep every item on one coherent theme; tie each reward conceptually to one
+  of the pack's characters; give the two genres contrasting tones.
+- artPrompts describe a single illustrated image (subject, mood, palette,
+  style); generationPrompts say what text to write, for which model shape,
+  and the target length.`,
+  contextKeys: ['prompt'],
+  fieldPrompts: {
+    manifest:
+      'Generate a complete pack manifest as strict JSON for the theme ' +
+      'described in the context. Follow the composition and naming rules ' +
+      'from the system prompt exactly.',
+  },
+}
+
+export default packmakerSuggest

--- a/server/utils/suggest/suggestProviders.ts
+++ b/server/utils/suggest/suggestProviders.ts
@@ -75,7 +75,7 @@ async function callAnthropic(
     },
     body: JSON.stringify({
       model: options.model,
-      max_tokens: 512,
+      max_tokens: options.maxTokens ?? 512,
       stream: false,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }],
@@ -121,7 +121,7 @@ async function callOpenAI(
     },
     body: JSON.stringify({
       model: options.model,
-      max_tokens: 512,
+      max_tokens: options.maxTokens ?? 512,
       stream: false,
       temperature: 0.7,
       messages: [
@@ -164,7 +164,7 @@ async function callOllama(
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
-      options: { num_predict: 512 },
+      options: { num_predict: options.maxTokens ?? 512 },
     }),
   })
 

--- a/server/utils/suggest/suggestTypes.ts
+++ b/server/utils/suggest/suggestTypes.ts
@@ -1,5 +1,6 @@
 // /server/utils/suggest/suggestTypes.ts
-export type SuggestProvider = 'anthropic' | 'openai' | 'openai_compatible' | 'ollama'
+export type SuggestProvider =
+  'anthropic' | 'openai' | 'openai_compatible' | 'ollama'
 
 export type SuggestBuilder = string
 
@@ -41,7 +42,10 @@ export type SuggestSheet = {
   contextKeys?: string[]
   fieldPrompts?: Record<string, string>
   stepPrompts?: Record<string, string>
-  buildContext?: (context: Record<string, unknown>, body: SuggestBody) => string[]
+  buildContext?: (
+    context: Record<string, unknown>,
+    body: SuggestBody,
+  ) => string[]
   buildInstruction?: (body: SuggestBody) => string | null
 }
 
@@ -59,4 +63,6 @@ export type SuggestProviderOptions = {
   apiKey?: string
   baseUrl?: string
   endpointPath?: string
+  /** Completion budget; providers fall back to 512 when unset. */
+  maxTokens?: number
 }

--- a/stores/packStore.ts
+++ b/stores/packStore.ts
@@ -25,6 +25,7 @@ import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { performFetch } from '@/stores/utils'
 import { useArtStore } from '@/stores/artStore'
+import { useServerStore } from '@/stores/serverStore'
 import {
   seedPackManifests,
   type PackManifest,
@@ -226,6 +227,130 @@ export const usePackStore = defineStore('packStore', () => {
       (m) => m.id !== packId,
     )
     persist()
+  }
+
+  /**
+   * Validate and upsert a manifest into the editable (imported) set. Seed
+   * packs are copy-on-write: saving under a seed's id overrides the seed copy
+   * without touching the shipped data, and build state keyed by pack id
+   * carries over untouched.
+   */
+  function savePackManifest(manifest: PackManifest): {
+    success: boolean
+    message: string
+  } {
+    const problem = validatePackManifest(manifest)
+    if (problem) return { success: false, message: problem }
+    importedManifests.value = [
+      ...importedManifests.value.filter((m) => m.id !== manifest.id),
+      manifest,
+    ]
+    persist()
+    return { success: true, message: `Saved pack "${manifest.title}".` }
+  }
+
+  /** Rename a pack (seed or imported) — copy-on-write, id stays stable. */
+  function renamePack(
+    packId: string,
+    newTitle: string,
+  ): { success: boolean; message: string } {
+    const title = newTitle.trim()
+    if (!title) return { success: false, message: 'Title cannot be empty.' }
+    const pack = packById(packId)
+    if (!pack) return { success: false, message: 'Unknown pack.' }
+    return savePackManifest({ ...pack, title })
+  }
+
+  function uniquePackId(baseId: string): string {
+    const taken = new Set(manifests.value.map((m) => m.id))
+    if (!taken.has(baseId)) return baseId
+    let n = 2
+    while (taken.has(`${baseId}-${n}`)) n += 1
+    return `${baseId}-${n}`
+  }
+
+  /**
+   * Ask the LLM for a full manifest scaffold from a general theme prompt, via
+   * the existing /api/suggest pipeline (registered 'packmaker' sheet). The
+   * result is parsed and schema-validated but NOT saved — the caller loads it
+   * into the editor for review first.
+   */
+  async function generatePackScaffold(
+    prompt: string,
+  ): Promise<
+    | { success: true; manifest: PackManifest }
+    | { success: false; message: string }
+  > {
+    const theme = prompt.trim()
+    if (!theme) {
+      return { success: false, message: 'Describe the pack you want first.' }
+    }
+
+    const serverStore = useServerStore()
+    const activeServer = serverStore.activeTextServer
+    const serverSnapshot = activeServer
+      ? {
+          serverType: activeServer.serverType ?? null,
+          baseUrl: activeServer.baseUrl ?? null,
+          endpointPath: activeServer.endpointPath ?? null,
+          model: activeServer.model ?? null,
+        }
+      : undefined
+
+    const response = await performFetch<{ value: string }>(
+      '/api/suggest',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          builder: 'packmaker',
+          server: serverSnapshot,
+          field: 'manifest',
+          context: { prompt: theme },
+          maxTokens: 6000,
+        }),
+      },
+      1,
+      120_000,
+    )
+
+    if (!response.success || !response.data?.value) {
+      return {
+        success: false,
+        message: response.message || 'The model returned nothing useful.',
+      }
+    }
+
+    // Tolerate markdown fences or stray prose around the JSON object.
+    const raw = response.data.value
+    const start = raw.indexOf('{')
+    const end = raw.lastIndexOf('}')
+    if (start === -1 || end <= start) {
+      return { success: false, message: 'The model did not return JSON.' }
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw.slice(start, end + 1))
+    } catch {
+      return {
+        success: false,
+        message: 'The generated manifest was not valid JSON — try again.',
+      }
+    }
+
+    const problem = validatePackManifest(parsed)
+    if (problem) {
+      return {
+        success: false,
+        message: `The generated manifest failed validation (${problem}) — try again.`,
+      }
+    }
+
+    const manifest = parsed as PackManifest
+    return {
+      success: true,
+      manifest: { ...manifest, id: uniquePackId(manifest.id) },
+    }
   }
 
   /**
@@ -456,6 +581,10 @@ export const usePackStore = defineStore('packStore', () => {
     initialize,
     importManifest,
     removeImportedManifest,
+    savePackManifest,
+    renamePack,
+    uniquePackId,
+    generatePackScaffold,
     createItemRecord,
     generateItemArt,
     resetItem,


### PR DESCRIPTION
### Task
packmaker/t-009: Pack editor — rename packs, hand-build new packs, LLM scaffold from a prompt  (kind: software, cross-repo; Silas in-session direction 2026-07-17)

### What changed / what I produced
- `components/conductor/packmaker-pack-editor.vue` — editor hosted in the admin panel, for a new pack or an existing one (rename via the title field): pack-level fields (title/id/description/price hook), per-item add/edit/remove with type→shape defaults (character may opt into lore-only `dream` shape), and an LLM scaffold section: describe the pack in a sentence, get a full draft manifest loaded into the editor for review — nothing saves until "Create pack".
- `stores/packStore.ts` — `savePackManifest` (validated copy-on-write upsert; saving over a seed pack overrides it without touching shipped data, build state carries over), `renamePack`, `uniquePackId`, and `generatePackScaffold` which calls `/api/suggest` (builder `packmaker`, `maxTokens: 6000`), parses fence-tolerant JSON, and schema-validates before returning.
- `server/utils/suggest/sheets/packmakerSuggest.ts` (+ registry entry) — strict-JSON manifest scaffold sheet: default 2 locations / 2 genres / 4 characters / 3 rewards, two-word no-alliteration pack titles (house rule), itemShape mapping, draft-only visibility.
- Suggest pipeline fix, benefits every builder: the endpoint accepted `maxTokens` but all three providers hardcoded 512. Providers now honor `options.maxTokens` (endpoint clamps to 64–8192; the mana estimate uses the same clamped value, so cost and generation stay aligned).
- `packmaker-admin-panel.vue` — "New pack" and "Edit / rename" buttons wiring the editor in.

### How I verified
- `npm run test` (vue-tsc --noEmit): exit 0
- `npm run test:pack-manifest` (t-008's validator contract test): pass
- eslint on all changed files: clean; prettier --check: clean
- Live LLM round-trip not exercisable from this sandbox (no backend/API keys) — the scaffold path degrades safely: parse/validation failures surface as an error message and nothing is saved.

### Stakes
reversible

### Flags for Reviewer
- The maxTokens provider fix changes behavior for existing suggest callers only if they already pass `maxTokens` (none besides the mana estimator used it before; default stays 512).
- Scaffold output quality is untested against a live model; the sheet + client-side validation bound the blast radius to "try again."

### Kaizen suggestion
`generatePackScaffold`'s JSON-extraction/validation path (fence stripping, brace slicing, invalid-JSON and schema-fail messages) is pure logic that could join the `test:pack-manifest` contract test.

### Notes for reviewer
Manifest saves are local drafts (localStorage) feeding the existing t-004 generator flow; releasing packs stays human-gated as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVJ36q7qGLZwVceJmpvy1n)_