### PR TITLE
Route image requests to self-hosted media origin

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,13 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "regions": ["iad1"],
   "ignoreCommand": "node scripts/vercel-ignore-build.mjs",
+  "redirects": [
+    {
+      "source": "/images/:path*",
+      "destination": "https://media.acrocatranch.com/images/:path*",
+      "permanent": false
+    }
+  ],
   "git": {
     "deploymentEnabled": {
       "claude/*": false,


### PR DESCRIPTION
Adds a temporary Vercel redirect for `/images/:path*` to `https://media.acrocatranch.com/images/:path*`.

This keeps application/database paths unchanged while moving image delivery off the Vercel deployment. The redirect is intentionally temporary (`307`) for the initial cutover so rollback remains immediate.

Cutover gates before merge:
- final rsync dry-run reports no pending source changes
- representative media URLs return 200 from the origin
- direct-write relay remains healthy

No tracked images are removed in this PR.