### PR TITLE
ai-art-academy/t-031: add Suprematism to academyStyles.ts

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -1098,6 +1098,35 @@ export const academyStyles: AcademyStyle[] = [
     },
   },
   {
+    slug: 'suprematism',
+    name: 'Suprematism',
+    era: '1913–1919',
+    sortYear: 1913,
+    region: 'Russia',
+    keyIdeas:
+      'Kazimir Malevich pushed abstraction as far as it would go: not reducing a subject to shapes, but throwing the subject away entirely. He called it Suprematism — "the supremacy of pure feeling" over the depiction of objects — and within a few years was floating clusters of squares, bars, and circles across bare white canvases, as if geometry itself had come unmoored from gravity.',
+    recognitionCues: [
+      'A small number of flat, hard-edged geometric shapes — squares, rectangles, circles, bars',
+      'Shapes float freely, tilted off the horizontal/vertical axis, with no ground line, horizon, or perspective',
+      'A plain white or near-white background used as infinite, weightless space',
+      'Black, red, and white as the dominant palette; total absence of recognizable objects, figures, or texture',
+    ],
+    artists: [
+      {
+        name: 'Kazimir Malevich',
+        years: '1879–1935',
+        note: 'Founder and sole originator of Suprematism; unveiled the style at the 1915 "Last Futurist Exhibition 0,10" in Petrograd.',
+      },
+    ],
+    failureMode:
+      "The most radically non-representational style in the curriculum — a faithful remix discards the source photo's content entirely, even more so than De Stijl; treat it as translating a photo's mood into pure geometry, not preserving anything recognizable",
+    remix: {
+      mode: 'prompt',
+      template:
+        'Reduce this image to a Suprematist composition: a small number of flat geometric shapes — squares, circles, bars — in black, red, and a few pure colors, floating freely against a plain white ground, no outline or perspective, pure weightless geometry',
+    },
+  },
+  {
     slug: 'de-stijl',
     name: 'De Stijl',
     era: 'c. 1917–1931',


### PR DESCRIPTION
### Task
ai-art-academy/t-031: kind_robots: add Suprematism to the academyStyles.ts front-end seed (kind: software)

### What changed / what I produced
- Added a `suprematism` entry to `stores/seeds/academyStyles.ts` (slug, name, era, sortYear, region, keyIdeas, recognitionCues, artists, failureMode, remix template), inserted before `de-stijl`/`bauhaus` per its 1913 sortYear (chronologically earlier than both).
- Content sourced verbatim from conductor's `projects/ai-art-academy/docs/curriculum-outline.md` §22 (Suprematism, Kazimir Malevich, 1913-1919) — no new facts invented. Mirrors the pattern used by t-015 (Neoclassicism) and t-018 (Bauhaus).
- `exampleWorks` intentionally omitted this pass (matches t-018/t-020's initial landing — example-work images are a separate follow-up, per the `t-013`-style pattern).

### How I verified
- `npx prettier --write` then `--check` on the changed file: clean.
- `npx eslint stores/seeds/academyStyles.ts`: 0 errors.
- Full-project `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`): exit 0, no TypeScript errors.

### Stakes
reversible

### Kaizen suggestion
Once a Suprematism preview thumbnail lands (already queued in conductor's `art-prompts.yaml` this same cycle), a follow-up task can set `previewImageSrc` alongside the rest of t-019's batch.

### Notes for reviewer
conductor task: ai-art-academy/t-031, claimed by session `claude-conductor-hourly-20260718T0048Z`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZbR9CU4VxaQShRwcrT85R)_