### PR TITLE
ai-art-academy/t-010: restore focus after closing an expanded lesson

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -37,7 +37,7 @@
     <academy-style-detail
       v-if="expandedStyle"
       :lesson="expandedStyle"
-      @close="expandedSlug = null"
+      @close="closeStyle"
       @remix="emit('remix', $event)"
     />
 
@@ -50,6 +50,7 @@
       <button
         v-for="style in filteredStyles"
         :key="style.slug"
+        :ref="(el) => setGridRef(style.slug, el)"
         type="button"
         class="group flex flex-col gap-2 rounded-2xl border-2 p-4 text-left transition-all duration-150"
         :class="
@@ -99,7 +100,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, type ComponentPublicInstance } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import type { AcademyStyle } from '@/stores/seeds/academyStyles'
 
@@ -111,6 +112,31 @@ const academyStore = useAcademyStore()
 
 const searchQuery = ref('')
 const expandedSlug = ref<string | null>(null)
+
+// The grid button stays mounted while its detail panel is open, but the
+// panel's own close button unmounts (v-if) the instant it's clicked — the
+// browser drops focus to <body> with nothing to restore it. Track each
+// grid button so we can return focus to it after closing.
+const gridRefs = new Map<string, HTMLButtonElement>()
+
+function setGridRef(
+  slug: string,
+  el: Element | ComponentPublicInstance | null,
+) {
+  if (el instanceof HTMLButtonElement) {
+    gridRefs.set(slug, el)
+  } else {
+    gridRefs.delete(slug)
+  }
+}
+
+function closeStyle() {
+  const slug = expandedSlug.value
+  expandedSlug.value = null
+  nextTick(() => {
+    if (slug) gridRefs.get(slug)?.focus()
+  })
+}
 
 const expandedStyle = computed<AcademyStyle | null>(() => {
   if (!expandedSlug.value) return null

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -54,6 +54,7 @@
 
         <button
           v-if="expandedSlug !== style.slug"
+          :ref="(el) => setToggleRef(style.slug, el)"
           type="button"
           class="group flex w-full flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
           aria-expanded="false"
@@ -88,7 +89,7 @@
         <academy-style-detail
           v-else
           :lesson="style"
-          @close="expandedSlug = null"
+          @close="closeLesson(style.slug)"
           @remix="emit('remix', $event)"
         />
       </li>
@@ -97,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { nextTick, ref, type ComponentPublicInstance } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 
 const emit = defineEmits<{
@@ -107,4 +108,28 @@ const emit = defineEmits<{
 const academyStore = useAcademyStore()
 
 const expandedSlug = ref<string | null>(null)
+
+// Collapsing an expanded lesson unmounts its close button (v-if/v-else swap
+// with the toggle button), so the browser drops focus to <body> with no
+// fix — keyboard/screen-reader users lose their place in the timeline.
+// Track each toggle button so we can restore focus to it after closing.
+const toggleRefs = new Map<string, HTMLButtonElement>()
+
+function setToggleRef(
+  slug: string,
+  el: Element | ComponentPublicInstance | null,
+) {
+  if (el instanceof HTMLButtonElement) {
+    toggleRefs.set(slug, el)
+  } else {
+    toggleRefs.delete(slug)
+  }
+}
+
+function closeLesson(slug: string) {
+  expandedSlug.value = null
+  nextTick(() => {
+    toggleRefs.get(slug)?.focus()
+  })
+}
 </script>


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass — option (a) front-end polish (kind: software)

### What changed / what I produced
- `components/academy/academy-timeline.vue`: the toggle button and `academy-style-detail` swap via `v-if`/`v-else`, so closing an expanded lesson unmounts its close button with no `ref`/`focus()` call anywhere to recover focus — keyboard/screen-reader users dropped to `<body>` and had to re-tab from the top of the page. Added a `toggleRefs` map keyed by slug and a `closeLesson()` helper that refocuses the original toggle button after `nextTick`.
- `components/academy/academy-styles-browser.vue`: same underlying problem — the grid button stays mounted, but the detail panel's own close button unmounts on click with nothing to restore focus. Added a matching `gridRefs` map and `closeStyle()` helper.

### How I verified
- `npx eslint` on both files: clean
- `npx prettier --check`: clean
- Full-project `npm run test` (`vue-tsc --noEmit`): 0 errors

### Stakes
reversible

### Flags for Reviewer
- None — scoped to the two files that own the expand/collapse focus lifecycle; `academy-remix.vue` renders `academy-style-detail` with `showClose=false` so it's unaffected.

### Kaizen suggestion
`academy-style-detail.vue`'s `tryItFailureFallbackNote` (lines ~225-235) is now dead in practice — all 23 seed entries in `stores/seeds/academyStyles.ts` define `failureMode`, so the fallback computed never triggers. Worth pruning or confirming intent in a future cycle rather than carrying unreachable code.

### Notes for reviewer
Continuous-improvement checklist rotation: previous `t-010` cycle ran lane 4 (curriculum depth), so this cycle picked lane 1 (front-end polish) per the round-robin.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145aTfXikFq5aKmsALGEYBY)_