### PR TITLE
global-ui/t-024: guard misleading done/totalTasks fallback badge

### DIFF
--- a/components/pages/conductor-overview-gallery-page.vue
+++ b/components/pages/conductor-overview-gallery-page.vue
@@ -246,7 +246,7 @@
                 class="flex items-center justify-between gap-3 text-xs font-black uppercase tracking-widest text-base-content/45"
               >
                 <span>{{ item.kindLabel }}</span>
-                <span v-if="item.totalTasks"
+                <span v-if="item.hasConductorTaskCounts && item.totalTasks"
                   >{{ item.done }}/{{ item.totalTasks }} done</span
                 >
                 <span>{{ item.progress }}%</span>
@@ -331,7 +331,7 @@
                   {{ item.progress }}% progress
                 </span>
                 <span
-                  v-if="item.totalTasks"
+                  v-if="item.hasConductorTaskCounts && item.totalTasks"
                   class="badge badge-success badge-sm rounded-2xl"
                 >
                   {{ item.done }}/{{ item.totalTasks }} done
@@ -413,7 +413,7 @@
               {{ item.status }}
             </span>
             <span
-              v-if="item.totalTasks"
+              v-if="item.hasConductorTaskCounts && item.totalTasks"
               class="badge badge-info badge-sm rounded-2xl"
             >
               {{ item.done }}/{{ item.totalTasks }} done
@@ -521,7 +521,11 @@
             <div class="grid flex-1 grid-cols-3 gap-2 text-center md:w-full">
               <div class="rounded-xl bg-base-100 p-2">
                 <p class="font-black text-success">
-                  {{ item.done }}/{{ item.totalTasks }}
+                  {{
+                    item.hasConductorTaskCounts
+                      ? `${item.done}/${item.totalTasks}`
+                      : '—'
+                  }}
                 </p>
                 <p class="text-[0.65rem] text-base-content/40">done</p>
               </div>
@@ -585,6 +589,7 @@ type ProjectGalleryItem = {
   review: number
   done: number
   totalTasks: number
+  hasConductorTaskCounts: boolean
   projectId: number | null
   iconPath: string
   cardPath: string
@@ -843,6 +848,7 @@ function itemFromProject(project: ConductorProject): ProjectGalleryItem {
     review: counts.review,
     done: counts.done,
     totalTasks: project.tasks.length,
+    hasConductorTaskCounts: true,
     projectId: record?.id ?? null,
     iconPath:
       record?.imagePath ||
@@ -889,6 +895,7 @@ function itemFromProjectRecord(
     review: 0,
     done: record.status === 'DONE' ? 1 : 0,
     totalTasks: record._count?.Todos ?? 0,
+    hasConductorTaskCounts: false,
     projectId: record.id,
     iconPath:
       record.imagePath || `${CONDUCTOR_IMG_BASE}/${record.slug}-icon.webp`,


### PR DESCRIPTION
## Summary
- Fixes conductor/`global-ui/t-024`: `conductor-overview-gallery-page.vue`'s `itemFromProjectRecord()` fallback path approximates `done`/`totalTasks` from DB `Todo` counts (not real conductor task counts), but rendered the same "N/M done" badge as the conductor-sourced `itemFromProject()` path — producing a plausible-looking but semantically wrong ratio for public/non-admin gallery items with no matching conductor project.
- Adds a `hasConductorTaskCounts: boolean` field to `ProjectGalleryItem`, `true` only from `itemFromProject()`, `false` from the `itemFromProjectRecord()` fallback branch.
- Gates the badge in all three grid/card view modes on `item.hasConductorTaskCounts && item.totalTasks`, and replaces the unguarded raw `{{ item.done }}/{{ item.totalTasks }}` in the list view with a `—` placeholder when the counts aren't conductor-sourced.

## Test plan
- [x] `npx eslint components/pages/conductor-overview-gallery-page.vue` — clean
- [x] `npx vue-tsc --noEmit` (full project) — 0 errors
- [ ] Preview-deploy eyeball on `/overview` gallery in all four view modes (cards/heroes/icons/list), for both admin and public users — sandbox has no DB so this couldn't be visually verified headlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoP7o46FNZerGCqnfXUXHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoP7o46FNZerGCqnfXUXHN)_