### PR TITLE
ai-art-academy/t-010: make image-upload drop-zone keyboard-operable

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -14,6 +14,9 @@
 
     <!-- ── Drop zone ──────────────────────────────────────────────────── -->
     <div
+      role="button"
+      tabindex="0"
+      aria-label="Upload images"
       class="flex min-h-40 cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed transition-all duration-200"
       :class="
         isDragging
@@ -24,6 +27,7 @@
       @dragleave.prevent="isDragging = false"
       @drop.prevent="handleDrop"
       @click="fileInput?.click()"
+      @keydown.enter.space.prevent="fileInput?.click()"
     >
       <span
         class="flex h-14 w-14 items-center justify-center rounded-2xl border border-base-300 bg-base-200 transition-transform"


### PR DESCRIPTION
## Summary
- The Style Lab tab (`components/academy/academy-manager.vue`) renders `art-styler.vue` and `image-upload.vue` side by side, but only `art-styler.vue`'s upload drop-zone got the accessibility treatment in PR #371 (`role`, `tabindex`, `aria-label`, keyboard handler).
- `image-upload.vue`'s identical click-to-browse drop-zone had none of that — no `role`, no `tabindex`, no keyboard handler — so keyboard-only and screen-reader users could not reach or trigger the file picker at all in that panel.
- Mirrors the existing `art-styler.vue` pattern exactly: added `role="button"`, `tabindex="0"`, `aria-label="Upload images"`, and `@keydown.enter.space.prevent="fileInput?.click()"`.
- `image-upload.vue` is shared beyond Academy (bots, characters, rewards, scenarios, art-builder, art-manager, avatar-picker, user-dashboard) — the change is purely additive (new a11y attributes + a keyboard handler equivalent to the existing click handler), so it's safe everywhere it's used.

## Test plan
- [x] `npx eslint components/art/image-upload.vue` — clean
- [x] `npx prettier --check components/art/image-upload.vue` — clean
- [x] `npm run test` (`vue-tsc --noEmit`, full project) — clean, no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PibWQf9VCX54YHnbmGW5Mz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PibWQf9VCX54YHnbmGW5Mz)_