### PR TITLE
WonderLab: route authority and narratorSlug support

### DIFF
--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -80,7 +80,7 @@ import ScreenFx from '@/components/screenfx/screen-fx.vue'
 type LabTab = 'memory-dungeon' | 'wonder-lab' | 'screen-fx'
 
 const dashboardKey = 'wonder' as const
-const fallbackTab: LabTab = 'memory-dungeon'
+const fallbackTab: LabTab = 'wonder-lab'
 const validTabs: LabTab[] = ['memory-dungeon', 'wonder-lab', 'screen-fx']
 
 const route = useRoute()
@@ -92,6 +92,11 @@ const managerError = ref<string | null>(null)
 
 const activeTab = computed<LabTab>(() => {
   const routePath = route.path.replace(/\/+$/, '') || '/'
+
+  // Explicit routes are authoritative. Remembered dashboard state is only a
+  // fallback for embedded/global Lab surfaces and must never hijack a URL.
+  if (routePath === '/wonderlab') return 'wonder-lab'
+  if (routePath === '/memory') return 'memory-dungeon'
   if (routePath === '/screenfx') return 'screen-fx'
 
   const selectedTab = navStore.getDashboardTab(dashboardKey)

--- a/content.config.ts
+++ b/content.config.ts
@@ -72,6 +72,9 @@ const sharedNavigationSchema = z.object({
   tooltip: z.string().optional(),
   dottiTip: z.string().optional(),
   amiTip: z.string().optional(),
+  // Simple author-facing narrator selector. The page loader normalizes this
+  // into the richer `narrator` reference used by the narrator system.
+  narratorSlug: z.string().optional(),
   // NOTE: SQLite column names are case-insensitive, so a lowercase `dottitip`/
   // `amitip` field here collides with `dottiTip`/`amiTip` above and makes the
   // collection's CREATE TABLE fail ("duplicate column name"), which leaves the
@@ -134,6 +137,7 @@ export type PageBrief = {
   tooltip: string
   dottiTip: string
   amiTip: string
+  narratorSlug?: string
   narrator?: PageNarratorRef
   artPrompt: string
   channelKey?: string

--- a/content/wonderlab.md
+++ b/content/wonderlab.md
@@ -9,11 +9,11 @@ icon: kind-icon:gearhammer
 sort: highlight
 dottiTip: AMI, is it safe to let people poke around in the lab?
 amiTip: Don't worry about them breaking anything. It was probably broken before they touched it.
+narratorSlug: the-real-princess_donut
 channelKey: lab
 tabKey: museum
 dashboardKey: wonder
 dashboardTab: wonder-lab
-requiredRole: ADMIN
 cards: labCards
 loadingMessage: Loading the museum...
 refreshLabel: Refresh Museum

--- a/content/wonderlab.md
+++ b/content/wonderlab.md
@@ -9,7 +9,6 @@ icon: kind-icon:gearhammer
 sort: highlight
 dottiTip: AMI, is it safe to let people poke around in the lab?
 amiTip: Don't worry about them breaking anything. It was probably broken before they touched it.
-narratorSlug: the-real-princess_donut
 channelKey: lab
 tabKey: museum
 dashboardKey: wonder

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -63,6 +63,11 @@ type PagePayload = {
   page: ContentCollectionItem | null
 }
 
+type NarratedContentPage = ContentCollectionItem & {
+  narrator?: unknown
+  narratorSlug?: unknown
+}
+
 const route = useRoute()
 const pageStore = usePageStore()
 
@@ -116,11 +121,35 @@ const hasResolvedCurrentPath = computed(() => {
   return pagePayload.value?.path === contentPath.value
 })
 
+function normalizePageNarrator(
+  page: ContentCollectionItem | null,
+): ContentCollectionItem | null {
+  if (!page) return null
+
+  const narratedPage = page as NarratedContentPage
+  if (narratedPage.narrator) return page
+
+  const narratorSlug =
+    typeof narratedPage.narratorSlug === 'string'
+      ? narratedPage.narratorSlug.trim()
+      : ''
+
+  if (!narratorSlug) return page
+
+  return {
+    ...page,
+    narrator: {
+      type: 'bot',
+      slug: narratorSlug,
+    },
+  } as ContentCollectionItem
+}
+
 const activePage = computed(() => {
   if (isLoginPath.value) return null
   if (!hasResolvedCurrentPath.value) return null
 
-  return pagePayload.value?.page ?? null
+  return normalizePageNarrator(pagePayload.value?.page ?? null)
 })
 
 const isPageLoading = computed(() => {


### PR DESCRIPTION
## What changed

- Adds optional `narratorSlug` to shared Nuxt Content front matter.
- Normalizes `narratorSlug` into the existing bot narrator reference at page load time while preserving the richer `narrator` field as an override.
- Removes the ADMIN-only restriction from `/wonderlab`.
- Makes explicit routes authoritative:
  - `/wonderlab` -> component museum
  - `/memory` -> Memory Match Dungeon
  - `/screenfx` -> Screen FX
- Changes the non-route Lab fallback from Memory to WonderLab.

## Why

WonderLab was being hijacked by remembered dashboard state and rendering Memory Match Dungeon. This makes the URL authoritative and restores Lab as a generally available surface. The content metadata addition establishes a reusable page-level narrator convention without assigning a specific narrator to WonderLab yet.

## Scope correction

Princess Donut is not created, assigned, or referenced by this PR. Future personality-authored museum commentary will use Kind Robots' existing first-party bots and characters and is deferred pending further voice/personality work.

## Follow-up

This is the first implementation slice of #381. The remaining component registry, double-load cleanup, preview fixtures, schema migration, museum UI, and normal Reaction display work remain tracked there.

Closes part of #381.