### PR TITLE
ai-art-academy/t-010: expose aria-pressed on Remix Studio selectable-button grids

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -179,6 +179,7 @@
                 : 'border-transparent hover:border-primary/50'
             "
             :title="image.fileName || `Image #${image.id}`"
+            :aria-pressed="selectedSourceImage?.id === image.id"
             @click="selectGalleryImage(image)"
           >
             <img
@@ -241,6 +242,7 @@
             "
             :disabled="isLoadingStarterImage"
             :title="`${entry.workTitle} — ${entry.artist}`"
+            :aria-pressed="selectedStarterFile === entry.file"
             @click="selectStarterEntry(entry)"
           >
             <img
@@ -368,6 +370,7 @@
             ? 'badge-primary border-primary font-bold'
             : 'badge-ghost border-base-300 hover:border-primary/40 hover:text-primary'
         "
+        :aria-pressed="activeCategory === cat"
         @click="activeCategory = activeCategory === cat ? null : cat"
       >
         <span class="mr-1">{{ CATEGORY_ICONS[cat] }}</span>
@@ -392,6 +395,7 @@
             : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
         "
         :title="style.triggerPhrase"
+        :aria-pressed="isSelectedStyle(style)"
         @click="selectStyle(style)"
       >
         <div


### PR DESCRIPTION
## Summary
- `art-styler.vue` powers the Remix Studio surface used by both `academy-remix.vue` and the Academy Manager's Style Lab tab. Its four selectable-button grids (gallery images, starter images, category filters, and the style picker) signaled selection state only visually (border/checkmark swap) with no `aria-pressed`, so screen-reader users tabbing through — especially the style picker, the primary control for every Remix flow — got no indication of what's currently selected.
- This is an outlier against the codebase's own established convention for selectable-card grids: `card-picker.vue` and `avatar-picker.vue` already set `aria-pressed` on their equivalent buttons.
- Added `:aria-pressed` bound to each grid's existing selected-state boolean (`selectedSourceImage?.id === image.id`, `selectedStarterFile === entry.file`, `activeCategory === cat`, `isSelectedStyle(style)`) — no new logic, just exposing state that already drives the visual class.

## Test plan
- [x] `npx eslint components/art/art-styler.vue` — clean
- [x] `npx prettier --check components/art/art-styler.vue` — clean
- [x] `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — exit 0, no new errors


---
_Generated by [Claude Code](https://claude.ai/code/session_011GAtZErKRDj3jJnuMhc76M)_