### PR TITLE
ai-art-academy/t-010: expose aria-pressed on source-tab switchers

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -38,6 +38,7 @@
                 ? 'bg-primary text-primary-content'
                 : 'bg-base-100 text-base-content/60 hover:bg-base-200'
             "
+            :aria-pressed="sourceTab === 'upload'"
             @click="sourceTab = 'upload'"
           >
             Upload
@@ -50,6 +51,7 @@
                 ? 'bg-primary text-primary-content'
                 : 'bg-base-100 text-base-content/60 hover:bg-base-200'
             "
+            :aria-pressed="sourceTab === 'gallery'"
             @click="sourceTab = 'gallery'"
           >
             Gallery
@@ -62,6 +64,7 @@
                 ? 'bg-primary text-primary-content'
                 : 'bg-base-100 text-base-content/60 hover:bg-base-200'
             "
+            :aria-pressed="sourceTab === 'starters'"
             @click="sourceTab = 'starters'"
           >
             Starters

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -61,6 +61,7 @@
             type="button"
             class="px-2.5 py-1 font-bold transition"
             :class="sourceTab === 'upload' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
+            :aria-pressed="sourceTab === 'upload'"
             @click="sourceTab = 'upload'"
           >
             Upload
@@ -69,6 +70,7 @@
             type="button"
             class="px-2.5 py-1 font-bold transition"
             :class="sourceTab === 'camera' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
+            :aria-pressed="sourceTab === 'camera'"
             @click="openCamera"
           >
             Camera


### PR DESCRIPTION
## Summary
- `ai-art-academy/t-010` continuous-improvement cycle, lane 1 (front-end polish) — rotated to this lane after lane 1 (PRs #383, #385) then lane 2 (roadmap accuracy, PR #769) ran the previous two cycles; lane 3 (inspiration/preview assets) is currently blocked (no style-preview thumbnails have landed via the art-prompts.yaml pipeline yet — see `ai-art-academy/t-019`), so per the checklist's "blocker discipline" this cycle rotated to lane 1 instead.
- `components/art/art-styler.vue`: the Source Image sub-tab switcher (Upload / Gallery / Starters) conveyed its selected state only via a CSS background-color swap — no `aria-pressed`, unlike the same file's category filter chips and style-grid buttons which already expose it (from PR #385). Screen-reader users had no indication of which sub-tab was active.
- `components/art/stylist-restyle.vue` (Superkate Hair Studio): found the identical gap on its own Upload/Camera source-tab switcher while checking for sibling components with the same pattern (per the precedent set by PR #383's `image-upload.vue` twin-fix). Same trivial, additive fix.
- Both fixes mirror the existing `:aria-pressed="..."` convention already used elsewhere in `art-styler.vue` — no new pattern introduced.

## Test plan
- [x] `npx eslint components/art/art-styler.vue components/art/stylist-restyle.vue` — clean
- [x] `npx prettier --check` on the same files — `stylist-restyle.vue` reports pre-existing formatting drift unrelated to this change (confirmed via `git stash` that the same warning exists on `main` before this diff); not touched, since CI does not gate on lint/prettier and a full-file reformat would bloat this diff far beyond the accessibility fix.
- [x] `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — exit 0, no type errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjLeXjyh5kQbAQPMNfxgME)_