### PR TITLE
WonderLab: recursive component manifest foundation

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -120,16 +120,18 @@ export default defineNuxtConfig({
 
   hooks: {
     'build:before': async () => {
-      if (process.env.NODE_ENV !== 'development') {
-        console.log('Skipping component JSON generation in production mode.')
-        return
-      }
-      const { execSync } = await import('node:child_process')
+      const { execFileSync } = await import('node:child_process')
+
       try {
-        const out = execSync('node utils/scripts/create-component-json.mjs')
-        console.log(out.toString())
-      } catch (err) {
-        console.error('Failed to generate components JSON:', err)
+        const output = execFileSync(
+          process.execPath,
+          ['utils/scripts/create-component-json.mjs'],
+          { encoding: 'utf8' },
+        )
+        console.log(output.trim())
+      } catch (error) {
+        console.error('Failed to generate WonderLab component manifest:', error)
+        throw error
       }
     },
   },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
+    "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/utils/scripts/create-component-json.mjs
+++ b/utils/scripts/create-component-json.mjs
@@ -1,32 +1,118 @@
-// create-component-json.ts
-import { promises as fs } from 'fs'
-import path from 'path'
+// /utils/scripts/create-component-json.mjs
+import { createHash } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
-async function generateComponentJSON() {
-  try {
-    const componentPath = path.resolve(process.cwd(), 'components/')
-    const folderNames = await fs.readdir(componentPath)
-    const folders = []
+const ROOT = process.cwd()
+const COMPONENT_ROOT = path.resolve(ROOT, 'components')
+const LEGACY_OUTPUT = path.resolve(ROOT, 'public/components.json')
+const MANIFEST_OUTPUT = path.resolve(ROOT, 'public/wonderlab-components.json')
 
-    for (const folderName of folderNames) {
-      const folderPath = path.join(componentPath, folderName)
-      const stat = await fs.stat(folderPath)
+const ignoredSegments = new Set(['abandonware', '__tests__', '__fixtures__'])
 
-      if (stat.isDirectory()) {
-        const componentFiles = await fs.readdir(folderPath)
-        const components = componentFiles
-          .filter((file) => file.endsWith('.vue'))
-          .map((file) => file.replace('.vue', ''))
-        folders.push({ folderName, components })
-      }
+function toPosix(value) {
+  return value.split(path.sep).join('/')
+}
+
+function toSlug(value) {
+  return value
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+function shouldIgnore(relativePath) {
+  const segments = toPosix(relativePath).split('/')
+  return segments.some((segment) => ignoredSegments.has(segment))
+}
+
+async function collectVueFiles(directory, files = []) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = path.relative(COMPONENT_ROOT, absolutePath)
+
+    if (shouldIgnore(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      await collectVueFiles(absolutePath, files)
+      continue
     }
 
-    const outputPath = path.resolve(process.cwd(), 'public/components.json')
-    await fs.writeFile(outputPath, JSON.stringify(folders, null, 2))
-    console.log('Component JSON generated successfully:', outputPath)
-  } catch (error) {
-    console.error('Failed to generate component JSON:', error)
+    if (entry.isFile() && entry.name.endsWith('.vue')) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+async function buildManifestEntry(absolutePath) {
+  const relativePath = toPosix(path.relative(COMPONENT_ROOT, absolutePath))
+  const sourcePath = `components/${relativePath}`
+  const folderName = toPosix(path.dirname(relativePath))
+  const componentName = path.basename(relativePath, '.vue')
+  const source = await fs.readFile(absolutePath)
+  const sourceHash = createHash('sha256').update(source).digest('hex')
+
+  return {
+    sourceKey: sourcePath.toLowerCase(),
+    sourcePath,
+    sourceHash,
+    componentName,
+    slug: toSlug(relativePath),
+    folderName: folderName === '.' ? 'root' : folderName,
   }
 }
 
-generateComponentJSON()
+function buildLegacyFolders(entries) {
+  const folders = new Map()
+
+  for (const entry of entries) {
+    const names = folders.get(entry.folderName) ?? []
+    names.push(entry.componentName)
+    folders.set(entry.folderName, names)
+  }
+
+  return [...folders.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([folderName, components]) => ({
+      folderName,
+      components: components.sort((left, right) => left.localeCompare(right)),
+    }))
+}
+
+async function generateComponentManifest() {
+  const files = await collectVueFiles(COMPONENT_ROOT)
+  const entries = await Promise.all(files.map(buildManifestEntry))
+  entries.sort((left, right) => left.sourcePath.localeCompare(right.sourcePath))
+
+  const manifest = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    componentRoot: 'components',
+    count: entries.length,
+    entries,
+  }
+
+  await fs.mkdir(path.dirname(MANIFEST_OUTPUT), { recursive: true })
+  await Promise.all([
+    fs.writeFile(MANIFEST_OUTPUT, `${JSON.stringify(manifest, null, 2)}\n`),
+    fs.writeFile(
+      LEGACY_OUTPUT,
+      `${JSON.stringify(buildLegacyFolders(entries), null, 2)}\n`,
+    ),
+  ])
+
+  console.log(
+    `Generated ${entries.length} WonderLab component entries at ${path.relative(ROOT, MANIFEST_OUTPUT)}.`,
+  )
+}
+
+generateComponentManifest().catch((error) => {
+  console.error('Failed to generate WonderLab component manifest:', error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What changed

- Replaces the shallow one-folder component scan with recursive discovery across `components/**/*.vue`.
- Excludes `abandonware`, `__tests__`, and `__fixtures__` paths.
- Generates a detailed `public/wonderlab-components.json` manifest with stable source keys, source paths, SHA-256 source hashes, normalized slugs, nested folder names, and component names.
- Continues generating the legacy `public/components.json` shape for compatibility with the existing museum while the sync layer is migrated.
- Runs manifest generation in development and production builds instead of silently skipping production.
- Fails the build if manifest generation fails rather than deploying stale inventory.
- Adds `npm run components:manifest` for explicit local/CI generation.

## Why

The existing WonderLab inventory only saw Vue files one directory below `/components`, while the preview renderer already used recursive discovery. That created two incompatible inventories and made nested components invisible to database sync. This establishes one recursive, deterministic source inventory without yet changing the database schema or preview harness.

## Safety

This PR does not delete or reconcile database rows. The legacy file remains temporarily so the existing UI keeps working. The next slice will move reconciliation server-side and remove the current destructive client behavior.

Part of #381.