### PR TITLE
animation-manager/t-010: register bubble-effect in the animation catalog

### DIFF
--- a/stores/animationCatalog.ts
+++ b/stores/animationCatalog.ts
@@ -116,6 +116,16 @@ export const ANIMATION_EFFECTS = [
     preferredSurface: 'fullscreen',
   },
   {
+    id: 'bubble-effect',
+    label: 'Soap Bubbles',
+    reveal: 'Bubbles!',
+    icon: 'kind-icon:bubbles',
+    tooltip: 'Colorful bubbles drift up and pop 🫧',
+    color: '#67e8f9',
+    generationSafe: true,
+    preferredSurface: 'fullscreen',
+  },
+  {
     id: 'ripple-effect',
     label: 'Ripple',
     reveal: 'Still waters',


### PR DESCRIPTION
## Summary
- `stores/displayStore.ts`'s legacy `EffectId` list (and `animation-loader.vue`'s own `effectMap`) have always included `'bubble-effect'`, and `components/screenfx/bubble-effect.vue` is a real, working, visually distinct effect (colorful SVG bubbles with random per-bubble color + pop animation, vs. `fizzy-bubbles`' white glow) — it was just never added to `stores/animationCatalog.ts`, the single source of truth since t-003.
- That meant `animationStore`'s `pickRandomEffect()`/toggle paths could never actually select it, even though the loader was already fully wired to render it — a dead, unreachable mapping.
- Registers `bubble-effect` alongside `fizzy-bubbles` as a `generationSafe`, `fullscreen` effect using the existing `assets/icons/bubbles.svg` icon (`kind-icon:bubbles`).

Conductor task: `animation-manager/t-010`. This resolves option (a) from the task note (register properly, since the effect is worth keeping) rather than (b) (retiring the legacy path) — the component is a legitimate, working, distinct effect already wired into the centralized loader.

## Test plan
- [x] `npm run test:animation-catalog` — passes clean, now reports 30 effects (was 29), unique ids, all screenfx components resolved
- [x] `npm run test` (`vue-tsc --noEmit`) — passes clean, no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014YtUr7rF9WhhoeiF7J7aLR)_