### PR TITLE
newsfeed/t-003: move settings-first homepage off root

### DIFF
--- a/components/home/home-feed-placeholder.vue
+++ b/components/home/home-feed-placeholder.vue
@@ -1,0 +1,57 @@
+<!-- /components/home/home-feed-placeholder.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col items-center justify-center gap-6 rounded-2xl border border-base-300 bg-base-200 p-8 text-center"
+  >
+    <div
+      class="flex h-16 w-16 items-center justify-center rounded-full bg-primary/15"
+    >
+      <Icon name="kind-icon:scroll" class="h-8 w-8 text-primary" />
+    </div>
+
+    <div class="flex max-w-md flex-col items-center gap-2">
+      <h1 class="text-xl font-black text-base-content">
+        {{ headline }}
+      </h1>
+      <p class="text-sm text-base-content/60">
+        The recommended newsfeed is on its way — AI news, activism, and the rest
+        of the swarm's activity, curated right here. Until it lands, here's
+        where to go next.
+      </p>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <NuxtLink
+        v-if="isLoggedIn"
+        to="/dashboard"
+        class="btn btn-primary rounded-xl px-6"
+      >
+        <Icon name="kind-icon:dashboard" class="size-4" />
+        Go to your Dashboard
+      </NuxtLink>
+
+      <NuxtLink v-else to="/login" class="btn btn-primary rounded-xl px-6">
+        <Icon name="kind-icon:login" class="size-4" />
+        Log In
+      </NuxtLink>
+
+      <NuxtLink to="/newsfeed" class="btn btn-ghost rounded-xl px-6">
+        <Icon name="kind-icon:news" class="size-4" />
+        Preview the Newsfeed Lab
+      </NuxtLink>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+
+const userStore = useUserStore()
+
+const isLoggedIn = computed(() => userStore.isLoggedIn)
+
+const headline = computed(() =>
+  isLoggedIn.value ? 'Welcome back' : 'Welcome, guest',
+)
+</script>

--- a/content/channels/home/dashboard.md
+++ b/content/channels/home/dashboard.md
@@ -2,8 +2,6 @@
 contentType: tab
 channelKey: home
 tabKey: dashboard
-dashboardKey: user
-dashboardTab: dashboard
 label: Dashboard
 title: Home Dashboard
 subtitle: Your Kind Robots activity at a glance

--- a/content/index.md
+++ b/content/index.md
@@ -11,11 +11,9 @@ amiTip: It was ready the moment we decided weird things should exist. Everything
 sort: highlight
 channelKey: home
 tabKey: dashboard
-dashboardKey: user
-dashboardTab: dashboard
 cards: navCards
-loadingMessage: Loading user dashboard
-refreshLabel: Refresh dashboard
+loadingMessage: Loading the homepage
+refreshLabel: Refresh
 ---
 
-:user-manager
+:home-feed-placeholder


### PR DESCRIPTION
### Task
conductor newsfeed/t-003: "Move homepage settings into a dedicated settings section" (kind: software)

### What changed / what I produced
- `content/index.md` (homepage, route `/`) no longer embeds `:user-manager` (the full settings/avatar/theme/friends/achievements/chats dashboard). It now renders a new lightweight `:home-feed-placeholder` component with a welcome message and a CTA to `/dashboard`.
- New `components/home/home-feed-placeholder.vue`: guest/logged-in aware welcome panel, links to `/dashboard` (or `/login` for guests) and `/newsfeed` (existing Newsfeed Lab stub).
- `content/channels/home/dashboard.md` (the "Home" channel's Dashboard nav-tab metadata entry, route `/`) drops its stale `dashboardKey: user` / `dashboardTab: dashboard` frontmatter, since route `/` no longer represents that tab's content.
- `content/dashboard.md` (route `/dashboard`) is untouched — it already rendered the identical `:user-manager` component, so all settings/avatar/theme/friends/achievements/chats functionality is preserved exactly where it already lived.

### How I verified
- Confirmed `/dashboard` already hosts the full `user-manager` dashboard (`content/dashboard.md`, pre-existing, unchanged) and that the header avatar widget (`components/user/user-picture.vue`) already links there — so settings stay discoverable without any homepage CTA.
- `npx vue-tsc --noEmit` — clean, no errors.
- `npx eslint components/home/home-feed-placeholder.vue` — clean.
- `npx prettier --check` on all touched files — clean (after `--write` on the new component).
- Tried to boot `nuxt dev` for a visual check, but both `/` and `/dashboard` rendered the stock "Welcome to Nuxt!" placeholder in this sandbox regardless of branch content — a pre-existing sandbox limitation (no real DB/session), not something introduced by this change. Could not get a real browser screenshot here; flagging per repo convention rather than claiming visual verification I didn't actually get.

### Stakes
reversible

### Flags for Reviewer
- I did not touch `dashboardConfigs.user` in `stores/helpers/dashboardHelper.ts` — all 6 of its tabs (`dashboard/avatars/friends/achievements/themes/chats`) already routed to `/dashboard`, so no change was needed there.
- Homepage content is intentionally a minimal placeholder, not the real feed — that's newsfeed/t-006 (depends on t-003 + t-005/feed pipeline, still `waiting`). This task's scope per its roadmap note was only "relocate settings off root," not build the feed.
- Could not visually verify in a browser (see above) — sandbox couldn't boot a working dev preview for either `/` or `/dashboard`, before or after this change.

### Kaizen suggestion
`components/conductor/newsfeed-page.vue` (the separate wonder/newsfeed pitch-status page) and `content/newsfeed.md`/`content/channels/lab/newsfeed.md` are already stubbed for the real feed (t-006/t-005). Once t-005's aggregation pipeline exists, t-006 should fork `components/dreams/dream-card.vue` into `FeedCard.vue` as the audit already recommended, and swap `home-feed-placeholder` for the real feed component in `content/index.md`.

### Notes for reviewer
Conductor task newsfeed/t-003 is claimed (`owner: worker`) as of this session; will flip to `status: review` and then `done` on merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxFeGzSTxoFrVpgFGRaPro)_