### PR TITLE
newsfeed/t-003: move homepage settings into dedicated /dashboard section

### DIFF
--- a/components/pages/home-feed.vue
+++ b/components/pages/home-feed.vue
@@ -1,0 +1,87 @@
+<!-- /components/pages/home-feed.vue -->
+<template>
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto overscroll-contain p-3 sm:p-4"
+  >
+    <header
+      class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+    >
+      <div class="min-w-0">
+        <h1 class="text-xl font-black text-base-content">
+          {{ welcomeMessage }}
+        </h1>
+        <p class="text-xs text-base-content/55">
+          Your recommended newsfeed is being built. Here's a preview of what's
+          coming.
+        </p>
+      </div>
+
+      <NuxtLink to="/dashboard" class="btn btn-outline btn-sm rounded-xl">
+        <Icon name="kind-icon:dashboard" class="size-4" />
+        Account &amp; settings
+      </NuxtLink>
+    </header>
+
+    <div
+      v-if="previewFeeds.length"
+      class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+    >
+      <div
+        v-for="feed in previewFeeds"
+        :key="feed.slug"
+        class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-100 p-4"
+      >
+        <div class="flex items-center gap-2">
+          <span
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/12 text-primary"
+          >
+            <Icon :name="feed.icon" class="size-4" />
+          </span>
+          <h2 class="min-w-0 truncate text-sm font-black text-base-content">
+            {{ feed.title }}
+          </h2>
+          <span class="badge badge-ghost badge-sm ml-auto shrink-0">
+            Coming soon
+          </span>
+        </div>
+
+        <p class="text-xs text-base-content/60">
+          {{ feed.description }}
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="flex min-h-48 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+    >
+      <Icon name="kind-icon:sparkles" class="size-8 text-base-content/35" />
+      <p class="text-sm font-semibold text-base-content/55">
+        No feeds enabled yet — recommended feeds will appear here.
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { useFeedPreferenceStore } from '@/stores/feedPreferenceStore'
+
+const userStore = useUserStore()
+const feedPreferenceStore = useFeedPreferenceStore()
+
+const isGuest = computed(() => userStore.isGuest)
+
+const welcomeMessage = computed(() => {
+  return isGuest.value
+    ? 'Welcome, mysterious traveller'
+    : `Welcome back, ${userStore.user?.username || 'traveller'}`
+})
+
+const previewFeeds = computed(() => feedPreferenceStore.enabledFeeds)
+
+onMounted(() => {
+  feedPreferenceStore.hydrate()
+})
+</script>

--- a/content/index.md
+++ b/content/index.md
@@ -18,4 +18,4 @@ loadingMessage: Loading user dashboard
 refreshLabel: Refresh dashboard
 ---
 
-:user-manager
+:home-feed


### PR DESCRIPTION
### Task
newsfeed/t-003: Move homepage settings into a dedicated settings section (kind: software)

### What changed / what I produced
- `content/index.md` (homepage, route `/`) rendered the same `:user-manager` settings shell as `content/dashboard.md` (route `/dashboard`) — account settings genuinely lived on the homepage.
- Added `components/pages/home-feed.vue`: a lightweight placeholder for the homepage — welcome header, preview cards for the six recommended feed presets already defined in `stores/helpers/newsfeed.ts` (t-004), a "Coming soon" badge per card, and a link into `/dashboard` for account & settings.
- Swapped `content/index.md`'s body from `:user-manager` to `:home-feed`.
- `content/dashboard.md` (route `/dashboard`, already registered as the target route for every `user` dashboard tab in `stores/helpers/dashboardHelper.ts`) is unchanged — all existing settings/avatar/friends/achievements/themes/chats controls remain reachable there exactly as before.

### How I verified
- `npx eslint components/pages/home-feed.vue` — clean.
- `npx prettier --check components/pages/home-feed.vue` — clean.
- `npm run test` (nuxi prepare + vue-tsc --noEmit, full project) — 0 errors.
- Started `npm run dev` and loaded `/` and `/dashboard` in a headless browser. The page shell loaded but this sandbox has no live database (dummy `DATABASE_URL`), so the app's global `kind-loader` store-initialization overlay never clears and blocks visual confirmation of the rendered component tree — a sandbox limitation, not something introduced by this change (same class of constraint as documented DB/egress limitations elsewhere in this repo's session notes). Static verification (types, lint, format) is clean.

### Stakes
reversible

### Flags for Reviewer
- Could not get a real screenshot of the rendered homepage due to the sandbox's lack of DB connectivity (`kind-loader` overlay never resolves). Worth a quick eyeball on a real preview/staging deploy before considering this fully visually verified.
- `home-feed.vue` is intentionally minimal (static preview cards, no live data) since real aggregation/rendering is t-005/t-006, still `ready`/`waiting`. This task's scope is only the homepage/settings relocation.

### Kaizen suggestion
Add a `DATABASE_URL`-free / mock-store dev mode (or a documented seed script) so future sessions can get a real rendered screenshot of homepage/dashboard changes in this sandbox instead of hitting the `kind-loader` initialization gate.

### Notes for reviewer
conductor roadmap task `newsfeed/t-003` will be set to `status: review` then `status: done` after this merges (conductor session on `claude/zealous-euler-3pifs9`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KhcLc8sKXrios83CjkvrdF)_