### PR TITLE
WonderLab: safe server-side component reconciliation

### DIFF
--- a/components/wonderlab/component-sync.vue
+++ b/components/wonderlab/component-sync.vue
@@ -1,62 +1,335 @@
-<!-- /components/content/wonderlab/component-sync.vue -->
-// /components/content/wonderlab/component-sync.vue
+<!-- /components/wonderlab/component-sync.vue -->
 <template>
-  <div class="flex flex-col items-center p-4 bg-base-200 rounded-lg shadow-md">
-    <h2 class="text-lg font-bold mb-4">Component Sync</h2>
-    <button class="btn btn-primary" :disabled="isSyncing" @click="handleSync">
-      {{ isSyncing ? 'Syncing...' : 'Sync Components' }}
-    </button>
-    <p v-if="progressMessage" class="mt-4 text-info">{{ progressMessage }}</p>
-    <p v-if="syncMessage" class="mt-4 text-success">{{ syncMessage }}</p>
-    <p v-if="syncError" class="mt-4 text-error">{{ syncError }}</p>
-  </div>
+  <section class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-lg">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          Admin Tool
+        </p>
+        <h2 class="mt-1 text-xl font-black">Component Reconciliation</h2>
+        <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
+          Compare the generated WonderLab manifest with the database before
+          applying changes. Unmatched database records are reported but never
+          deleted.
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn btn-outline btn-sm rounded-xl"
+          :disabled="isBusy"
+          @click="runDryRun"
+        >
+          <span v-if="isDryRunning" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:search" class="size-4" />
+          Dry Run
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-primary btn-sm rounded-xl"
+          :disabled="!canApply || isBusy"
+          @click="applyPlan"
+        >
+          <span v-if="isApplying" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:check" class="size-4" />
+          Apply Safe Changes
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="mt-4 rounded-2xl border border-info/30 bg-info/10 px-4 py-3 text-sm text-info-content"
+    >
+      Apply creates missing records and updates component names or folders. It
+      does not delete records, remove reactions, or mark missing components as
+      broken.
+    </div>
+
+    <div
+      v-if="errorMessage"
+      class="mt-4 rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div
+      v-if="successMessage"
+      class="mt-4 rounded-2xl border border-success/40 bg-success/10 p-4 text-sm text-success"
+    >
+      {{ successMessage }}
+    </div>
+
+    <template v-if="result">
+      <div class="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+        <article
+          v-for="metric in summaryMetrics"
+          :key="metric.label"
+          class="rounded-2xl border border-base-300 bg-base-200/60 p-3"
+        >
+          <p class="text-xs font-bold uppercase tracking-wide text-base-content/50">
+            {{ metric.label }}
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ metric.value }}</p>
+        </article>
+      </div>
+
+      <p class="mt-3 text-xs text-base-content/50">
+        Manifest generated {{ formatDate(result.manifest.generatedAt) }} with
+        {{ result.manifest.count }} entries.
+      </p>
+
+      <section
+        v-if="result.plan.conflicts.length"
+        class="mt-4 rounded-2xl border border-error/40 bg-error/5 p-4"
+      >
+        <h3 class="font-black text-error">Naming conflicts block apply</h3>
+        <div class="mt-3 grid gap-3">
+          <article
+            v-for="conflict in result.plan.conflicts"
+            :key="conflict.key"
+            class="rounded-xl border border-error/25 bg-base-100 p-3"
+          >
+            <p class="font-mono text-xs font-bold text-error">
+              {{ conflict.key }}
+            </p>
+            <p class="mt-1 text-sm">{{ conflict.componentNames.join(', ') }}</p>
+            <p class="mt-2 text-xs leading-relaxed text-base-content/60">
+              {{ conflict.reason }}
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <details
+        v-if="result.plan.creates.length"
+        class="mt-4 rounded-2xl border border-base-300 bg-base-200/35 p-4"
+      >
+        <summary class="cursor-pointer font-black">
+          New records ({{ result.plan.creates.length }})
+        </summary>
+        <ul class="mt-3 grid gap-1 text-sm">
+          <li
+            v-for="action in result.plan.creates.slice(0, 50)"
+            :key="action.componentName"
+            class="font-mono text-xs"
+          >
+            {{ action.changes.folderName }}/{{ action.componentName }}
+          </li>
+        </ul>
+      </details>
+
+      <details
+        v-if="result.plan.updates.length"
+        class="mt-3 rounded-2xl border border-base-300 bg-base-200/35 p-4"
+      >
+        <summary class="cursor-pointer font-black">
+          Updates ({{ result.plan.updates.length }})
+        </summary>
+        <div class="mt-3 grid gap-2">
+          <article
+            v-for="action in result.plan.updates.slice(0, 50)"
+            :key="`${action.existingId}-${action.componentName}`"
+            class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs"
+          >
+            <p class="font-mono font-bold">{{ action.componentName }}</p>
+            <p class="mt-1 text-base-content/60">
+              {{ formatChanges(action.changes) }}
+            </p>
+          </article>
+        </div>
+      </details>
+
+      <details
+        v-if="result.plan.missingFromManifest.length"
+        class="mt-3 rounded-2xl border border-warning/40 bg-warning/5 p-4"
+      >
+        <summary class="cursor-pointer font-black text-warning-content">
+          Missing from manifest ({{ result.plan.missingFromManifest.length }})
+        </summary>
+        <p class="mt-2 text-xs leading-relaxed text-base-content/60">
+          These records remain untouched so notes, status, artwork, and reactions
+          are preserved for review.
+        </p>
+        <ul class="mt-3 grid gap-1 text-sm">
+          <li
+            v-for="component in result.plan.missingFromManifest.slice(0, 50)"
+            :key="component.id"
+            class="font-mono text-xs"
+          >
+            {{ component.folderName }}/{{ component.componentName }}
+          </li>
+        </ul>
+      </details>
+    </template>
+  </section>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useComponentStore } from '@/stores/componentStore'
+import { computed, ref } from 'vue'
+import { performFetch } from '@/stores/utils'
 
-const componentStore = useComponentStore()
-const isSyncing = ref(false)
-const progressMessage = ref('')
-const syncMessage = ref('')
-const syncError = ref('')
+type WonderLabManifest = {
+  version: number
+  generatedAt: string
+  componentRoot: string
+  count: number
+  entries: unknown[]
+}
 
-const handleSync = async () => {
-  isSyncing.value = true
-  syncMessage.value = ''
-  syncError.value = ''
-  progressMessage.value = 'Initializing sync...'
+type ReconcileAction = {
+  kind: 'create' | 'update'
+  componentName: string
+  existingId?: number
+  changes: Record<string, string>
+}
 
-  try {
-    await componentStore.syncComponents((progress: string) => {
-      console.log('[ComponentSync] Progress:', progress)
-      progressMessage.value = progress
-    })
-    syncMessage.value = 'Components synced successfully!'
-  } catch (error) {
-    console.error('[ComponentSync] Sync error:', error)
-    syncError.value =
-      error instanceof Error
-        ? error.message
-        : typeof error === 'string'
-          ? error
-          : 'An unexpected error occurred during the sync process.'
-  } finally {
-    isSyncing.value = false
-    progressMessage.value = ''
+type ReconcileConflict = {
+  key: string
+  componentNames: string[]
+  reason: string
+}
+
+type MissingComponent = {
+  id: number
+  componentName: string
+  folderName: string
+}
+
+type ReconcileResult = {
+  mode: 'dry-run' | 'apply'
+  applied: boolean
+  manifest: {
+    version: number
+    generatedAt: string
+    count: number
+  }
+  summary: {
+    creates: number
+    updates: number
+    unchanged: number
+    missingFromManifest: number
+    conflicts: number
+  }
+  plan: {
+    creates: ReconcileAction[]
+    updates: ReconcileAction[]
+    unchanged: string[]
+    missingFromManifest: MissingComponent[]
+    conflicts: ReconcileConflict[]
   }
 }
-</script>
 
-<style scoped>
-.text-info {
-  color: var(--color-info);
+const manifest = ref<WonderLabManifest | null>(null)
+const result = ref<ReconcileResult | null>(null)
+const isDryRunning = ref(false)
+const isApplying = ref(false)
+const errorMessage = ref('')
+const successMessage = ref('')
+
+const isBusy = computed(() => isDryRunning.value || isApplying.value)
+const canApply = computed(
+  () =>
+    result.value?.mode === 'dry-run' &&
+    result.value.summary.conflicts === 0 &&
+    Boolean(manifest.value),
+)
+
+const summaryMetrics = computed(() => {
+  const summary = result.value?.summary
+  if (!summary) return []
+
+  return [
+    { label: 'Create', value: summary.creates },
+    { label: 'Update', value: summary.updates },
+    { label: 'Unchanged', value: summary.unchanged },
+    { label: 'Missing', value: summary.missingFromManifest },
+    { label: 'Conflicts', value: summary.conflicts },
+  ]
+})
+
+async function loadManifest(): Promise<WonderLabManifest> {
+  const response = await fetch('/wonderlab-components.json', {
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error('The generated WonderLab component manifest is unavailable.')
+  }
+
+  const data = (await response.json()) as WonderLabManifest
+  if (!Array.isArray(data.entries)) {
+    throw new Error('The WonderLab component manifest has an invalid format.')
+  }
+
+  return data
 }
-.text-success {
-  color: var(--color-success);
+
+async function reconcile(mode: 'dry-run' | 'apply'): Promise<void> {
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  const activeManifest =
+    mode === 'apply' && manifest.value ? manifest.value : await loadManifest()
+  manifest.value = activeManifest
+
+  const response = await performFetch<ReconcileResult>(
+    '/api/components/reconcile',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        mode,
+        manifest: activeManifest,
+      }),
+    },
+  )
+
+  if (!response.success || !response.data) {
+    throw new Error(response.message || 'Component reconciliation failed.')
+  }
+
+  result.value = response.data
+  successMessage.value = response.message
 }
-.text-error {
-  color: var(--color-error);
+
+async function runDryRun(): Promise<void> {
+  isDryRunning.value = true
+
+  try {
+    await reconcile('dry-run')
+  } catch (error) {
+    result.value = null
+    manifest.value = null
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Component dry run failed.'
+  } finally {
+    isDryRunning.value = false
+  }
 }
-</style>
+
+async function applyPlan(): Promise<void> {
+  if (!canApply.value) return
+  isApplying.value = true
+
+  try {
+    await reconcile('apply')
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Component reconciliation failed.'
+  } finally {
+    isApplying.value = false
+  }
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+function formatChanges(changes: Record<string, string>): string {
+  return Object.entries(changes)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(' · ')
+}
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -120,16 +120,18 @@ export default defineNuxtConfig({
 
   hooks: {
     'build:before': async () => {
-      if (process.env.NODE_ENV !== 'development') {
-        console.log('Skipping component JSON generation in production mode.')
-        return
-      }
-      const { execSync } = await import('node:child_process')
+      const { execFileSync } = await import('node:child_process')
+
       try {
-        const out = execSync('node utils/scripts/create-component-json.mjs')
-        console.log(out.toString())
-      } catch (err) {
-        console.error('Failed to generate components JSON:', err)
+        const output = execFileSync(
+          process.execPath,
+          ['utils/scripts/create-component-json.mjs'],
+          { encoding: 'utf8' },
+        )
+        console.log(output.trim())
+      } catch (error) {
+        console.error('Failed to generate WonderLab component manifest:', error)
+        throw error
       }
     },
   },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
+    "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
+    "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/server/api/components/reconcile.post.ts
+++ b/server/api/components/reconcile.post.ts
@@ -1,0 +1,149 @@
+// /server/api/components/reconcile.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '../../utils/error'
+import { requireAdminApiUser } from '../../utils/authGuard'
+import {
+  buildComponentReconcilePlan,
+  parseWonderLabManifest,
+} from '../../utils/wonderlabComponentReconcile'
+
+ type ReconcileMode = 'dry-run' | 'apply'
+
+ type ReconcileRequestBody = {
+  mode?: ReconcileMode
+  manifest?: unknown
+}
+
+function parseMode(value: unknown): ReconcileMode {
+  if (value === undefined || value === 'dry-run') return 'dry-run'
+  if (value === 'apply') return 'apply'
+
+  throw createError({
+    statusCode: 400,
+    message: 'Reconciliation mode must be "dry-run" or "apply".',
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const body = await readBody<ReconcileRequestBody>(event)
+    const mode = parseMode(body?.mode)
+
+    let manifest
+    try {
+      manifest = parseWonderLabManifest(body?.manifest)
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message:
+          error instanceof Error ? error.message : 'Invalid component manifest.',
+      })
+    }
+
+    const existingComponents = await prisma.component.findMany({
+      orderBy: { id: 'asc' },
+    })
+    const plan = buildComponentReconcilePlan(manifest, existingComponents)
+
+    if (mode === 'apply' && plan.conflicts.length) {
+      throw createError({
+        statusCode: 409,
+        message:
+          'Component reconciliation has naming conflicts. Review the dry-run result before applying.',
+        data: {
+          conflicts: plan.conflicts,
+        },
+      })
+    }
+
+    let applied = false
+
+    if (mode === 'apply') {
+      await prisma.$transaction(async (tx) => {
+        for (const action of plan.updates) {
+          if (!action.existingId) continue
+
+          await tx.component.update({
+            where: { id: action.existingId },
+            data: {
+              componentName: action.changes.componentName,
+              folderName: action.changes.folderName,
+              updatedAt: new Date(),
+            },
+          })
+        }
+
+        for (const action of plan.creates) {
+          await tx.component.create({
+            data: {
+              componentName: action.componentName,
+              folderName: action.changes.folderName || 'root',
+              title: action.componentName,
+              notes: null,
+              isWorking: false,
+              underConstruction: false,
+              isBroken: false,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          })
+        }
+      })
+
+      applied = true
+    }
+
+    const summary = {
+      creates: plan.creates.length,
+      updates: plan.updates.length,
+      unchanged: plan.unchanged.length,
+      missingFromManifest: plan.missingFromManifest.length,
+      conflicts: plan.conflicts.length,
+    }
+
+    return {
+      success: true,
+      message:
+        mode === 'apply'
+          ? 'Component reconciliation applied without deleting unmatched records.'
+          : 'Component reconciliation dry run complete. No database records were changed.',
+      data: {
+        mode,
+        applied,
+        requestedBy: {
+          id: auth.user.id,
+          username: auth.user.username,
+        },
+        manifest: {
+          version: manifest.version,
+          generatedAt: manifest.generatedAt,
+          count: manifest.count,
+        },
+        summary,
+        plan: {
+          creates: plan.creates,
+          updates: plan.updates,
+          unchanged: plan.unchanged,
+          missingFromManifest: plan.missingFromManifest,
+          conflicts: plan.conflicts,
+        },
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to reconcile WonderLab components.',
+      data:
+        error && typeof error === 'object' && 'data' in error
+          ? (error as { data?: unknown }).data
+          : null,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/wonderlabComponentReconcile.ts
+++ b/server/utils/wonderlabComponentReconcile.ts
@@ -1,0 +1,247 @@
+// /server/utils/wonderlabComponentReconcile.ts
+import type { Component } from '~/prisma/generated/prisma/client'
+
+export type WonderLabManifestEntry = {
+  sourceKey: string
+  sourcePath: string
+  sourceHash: string
+  componentName: string
+  slug: string
+  folderName: string
+}
+
+export type WonderLabManifest = {
+  version: number
+  generatedAt: string
+  componentRoot: string
+  count: number
+  entries: WonderLabManifestEntry[]
+}
+
+export type ComponentReconcileAction = {
+  kind: 'create' | 'update'
+  componentName: string
+  existingId?: number
+  changes: Record<string, string>
+}
+
+export type ComponentReconcileConflict = {
+  key: string
+  componentNames: string[]
+  reason: string
+}
+
+export type ComponentReconcilePlan = {
+  creates: ComponentReconcileAction[]
+  updates: ComponentReconcileAction[]
+  unchanged: string[]
+  missingFromManifest: Array<
+    Pick<Component, 'id' | 'componentName' | 'folderName'>
+  >
+  conflicts: ComponentReconcileConflict[]
+  matchedComponentIds: number[]
+}
+
+const MAX_MANIFEST_ENTRIES = 5000
+
+export function normalizeComponentName(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Manifest entry field "${field}" must be a non-empty string.`)
+  }
+
+  return value.trim()
+}
+
+export function parseWonderLabManifest(value: unknown): WonderLabManifest {
+  if (!value || typeof value !== 'object') {
+    throw new Error('A WonderLab component manifest is required.')
+  }
+
+  const input = value as Partial<WonderLabManifest>
+  if (input.version !== 1) {
+    throw new Error(
+      `Unsupported WonderLab manifest version: ${String(input.version)}.`,
+    )
+  }
+
+  if (!Array.isArray(input.entries)) {
+    throw new Error('Manifest entries must be an array.')
+  }
+
+  if (input.entries.length > MAX_MANIFEST_ENTRIES) {
+    throw new Error(
+      `Manifest exceeds the ${MAX_MANIFEST_ENTRIES} entry safety limit.`,
+    )
+  }
+
+  const entries = input.entries.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`Manifest entry ${index} must be an object.`)
+    }
+
+    const record = entry as Partial<WonderLabManifestEntry>
+    return {
+      sourceKey: requireString(
+        record.sourceKey,
+        `entries[${index}].sourceKey`,
+      ),
+      sourcePath: requireString(
+        record.sourcePath,
+        `entries[${index}].sourcePath`,
+      ),
+      sourceHash: requireString(
+        record.sourceHash,
+        `entries[${index}].sourceHash`,
+      ),
+      componentName: requireString(
+        record.componentName,
+        `entries[${index}].componentName`,
+      ),
+      slug: requireString(record.slug, `entries[${index}].slug`),
+      folderName: requireString(
+        record.folderName,
+        `entries[${index}].folderName`,
+      ),
+    }
+  })
+
+  if (typeof input.count === 'number' && input.count !== entries.length) {
+    throw new Error(
+      `Manifest count mismatch: declared ${input.count}, received ${entries.length}.`,
+    )
+  }
+
+  return {
+    version: 1,
+    generatedAt:
+      typeof input.generatedAt === 'string'
+        ? input.generatedAt
+        : new Date(0).toISOString(),
+    componentRoot:
+      typeof input.componentRoot === 'string' && input.componentRoot.trim()
+        ? input.componentRoot.trim()
+        : 'components',
+    count: entries.length,
+    entries,
+  }
+}
+
+export function buildComponentReconcilePlan(
+  manifest: WonderLabManifest,
+  existingComponents: Component[],
+): ComponentReconcilePlan {
+  const conflicts: ComponentReconcileConflict[] = []
+  const creates: ComponentReconcileAction[] = []
+  const updates: ComponentReconcileAction[] = []
+  const unchanged: string[] = []
+  const matchedComponentIds = new Set<number>()
+
+  const manifestByNormalizedName = new Map<string, WonderLabManifestEntry[]>()
+  for (const entry of manifest.entries) {
+    const key = normalizeComponentName(entry.componentName)
+    const group = manifestByNormalizedName.get(key) ?? []
+    group.push(entry)
+    manifestByNormalizedName.set(key, group)
+  }
+
+  for (const [key, entries] of manifestByNormalizedName) {
+    if (entries.length > 1) {
+      conflicts.push({
+        key,
+        componentNames: entries.map((entry) => entry.componentName),
+        reason:
+          'Multiple source components normalize to the same database component name. A source-path schema migration is required before these can be reconciled safely.',
+      })
+    }
+  }
+
+  const databaseByNormalizedName = new Map<string, Component[]>()
+  for (const component of existingComponents) {
+    const key = normalizeComponentName(component.componentName)
+    const group = databaseByNormalizedName.get(key) ?? []
+    group.push(component)
+    databaseByNormalizedName.set(key, group)
+  }
+
+  for (const [key, components] of databaseByNormalizedName) {
+    if (components.length > 1) {
+      conflicts.push({
+        key,
+        componentNames: components.map((component) => component.componentName),
+        reason:
+          'Multiple database rows normalize to the same component name. Resolve the duplicate before applying reconciliation.',
+      })
+    }
+  }
+
+  const blockedKeys = new Set(conflicts.map((conflict) => conflict.key))
+
+  for (const entry of manifest.entries) {
+    const normalizedName = normalizeComponentName(entry.componentName)
+    if (blockedKeys.has(normalizedName)) continue
+
+    const exact = existingComponents.find(
+      (component) => component.componentName === entry.componentName,
+    )
+    const normalizedMatches = databaseByNormalizedName.get(normalizedName) ?? []
+    const existing = exact ?? normalizedMatches[0]
+
+    if (!existing) {
+      creates.push({
+        kind: 'create',
+        componentName: entry.componentName,
+        changes: {
+          folderName: entry.folderName,
+        },
+      })
+      continue
+    }
+
+    matchedComponentIds.add(existing.id)
+
+    const changes: Record<string, string> = {}
+    if (existing.componentName !== entry.componentName) {
+      changes.componentName = entry.componentName
+    }
+    if (existing.folderName !== entry.folderName) {
+      changes.folderName = entry.folderName
+    }
+
+    if (Object.keys(changes).length) {
+      updates.push({
+        kind: 'update',
+        componentName: entry.componentName,
+        existingId: existing.id,
+        changes,
+      })
+    } else {
+      unchanged.push(entry.componentName)
+    }
+  }
+
+  const missingFromManifest = existingComponents
+    .filter((component) => !matchedComponentIds.has(component.id))
+    .map(({ id, componentName, folderName }) => ({
+      id,
+      componentName,
+      folderName,
+    }))
+
+  return {
+    creates,
+    updates,
+    unchanged,
+    missingFromManifest,
+    conflicts,
+    matchedComponentIds: [...matchedComponentIds],
+  }
+}

--- a/stores/componentStore.ts
+++ b/stores/componentStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { Component } from '~/prisma/generated/prisma/client'
 import {
   fetchComponentById as helperFetch,
@@ -14,12 +14,6 @@ import {
   loadSnapshot,
   markSnapshotActive,
 } from '@/stores/helpers/snapshotLoader'
-import { useErrorStore, ErrorType } from '@/stores/errorStore'
-
-interface Folder {
-  folderName: string
-  components: string[]
-}
 
 export const useComponentStore = defineStore('componentStore', () => {
   const components = ref<Component[]>([])
@@ -35,6 +29,7 @@ export const useComponentStore = defineStore('componentStore', () => {
 
   async function initialize() {
     if (isInitialized.value) return
+
     try {
       // performFetch (not raw fetch) so a dead DB trips the shared circuit
       // breaker instead of hanging every page that lists components.
@@ -79,9 +74,9 @@ export const useComponentStore = defineStore('componentStore', () => {
   }
 
   async function fetchComponentById(id: number) {
-    const comp = await helperFetch(id)
-    if (comp) selectedComponent.value = comp
-    return comp
+    const component = await helperFetch(id)
+    if (component) selectedComponent.value = component
+    return component
   }
 
   async function createComponent(component: Component) {
@@ -92,9 +87,7 @@ export const useComponentStore = defineStore('componentStore', () => {
 
   async function updateComponent(component: Component) {
     const updated = await helperUpdate(component)
-    const index = components.value.findIndex(
-      (c: { id: any }) => c.id === component.id,
-    )
+    const index = components.value.findIndex((entry) => entry.id === component.id)
     if (index !== -1) components.value[index] = updated
     return updated
   }
@@ -102,9 +95,7 @@ export const useComponentStore = defineStore('componentStore', () => {
   async function deleteComponent(id: number) {
     const success = await helperDelete(id)
     if (success) {
-      components.value = components.value.filter(
-        (c: { id: number }) => c.id !== id,
-      )
+      components.value = components.value.filter((entry) => entry.id !== id)
     }
     return success
   }
@@ -120,143 +111,15 @@ export const useComponentStore = defineStore('componentStore', () => {
     action: 'create' | 'update',
   ) {
     const result = await helperCreateOrUpdate(component, action)
+
     if (action === 'create') {
       components.value.push(result)
     } else {
-      const index = components.value.findIndex(
-        (c: { id: any }) => c.id === result.id,
-      )
+      const index = components.value.findIndex((entry) => entry.id === result.id)
       if (index !== -1) components.value[index] = result
     }
+
     return result
-  }
-
-  async function syncComponents(progressCallback?: (msg: string) => void) {
-    const errorStore = useErrorStore()
-
-    return errorStore.handleError(
-      async () => {
-        const log = (msg: string) => {
-          console.log(`[SyncComponents] ${msg}`)
-          if (progressCallback) progressCallback(msg)
-        }
-
-        log('Fetching components.json...')
-        const response = await fetch('/components.json')
-        if (!response.ok) throw new Error('Failed to fetch components.json')
-        const folderData: Folder[] = await response.json()
-
-        if (!Array.isArray(folderData)) {
-          throw new Error(
-            'Invalid data format: components.json must be an array',
-          )
-        }
-
-        log('Fetched components.json.')
-        log('Fetching existing components from the API...')
-        const apiData = await performFetch<Component[]>('/api/components')
-        if (!apiData.success || !Array.isArray(apiData.data)) {
-          throw new Error('Invalid API response: expected data array')
-        }
-
-        const apiComponents: Component[] = apiData.data
-        const matchedComponentIds = new Set<number>()
-
-        const normalize = (str: string) =>
-          str
-            .replace(/([a-z])([A-Z])/g, '$1-$2')
-            .replace(/[\s_]+/g, '-')
-            .toLowerCase()
-
-        for (const folder of folderData) {
-          for (const name of folder.components) {
-            const normalizedName = normalize(name)
-
-            const existing = apiComponents.find(
-              (c) => normalize(c.componentName) === normalizedName,
-            )
-            const directMatch = apiComponents.find(
-              (c) => c.componentName === name,
-            )
-
-            if (existing) {
-              if (directMatch && directMatch.id !== existing.id) {
-                log(`Merging "${existing.componentName}" into "${name}"`)
-
-                const patchRes = await performFetch<Component>(
-                  `/api/components/${directMatch.id}`,
-                  {
-                    method: 'PATCH',
-                    body: JSON.stringify({
-                      folderName: folder.folderName,
-                      updatedAt: new Date(),
-                    }),
-                  },
-                )
-
-                if (!patchRes.success)
-                  throw new Error(
-                    `Failed to update folderName: ${patchRes.message}`,
-                  )
-
-                matchedComponentIds.add(directMatch.id)
-                await deleteComponent(existing.id)
-                log(`Deleted duplicate "${existing.componentName}"`)
-              } else {
-                const patchRes = await performFetch<Component>(
-                  `/api/components/${existing.id}`,
-                  {
-                    method: 'PATCH',
-                    body: JSON.stringify({
-                      componentName: name,
-                      folderName: folder.folderName,
-                      updatedAt: new Date(),
-                    }),
-                  },
-                )
-
-                if (!patchRes.success)
-                  throw new Error(
-                    `Failed to update ${name}: ${patchRes.message}`,
-                  )
-
-                matchedComponentIds.add(existing.id)
-                log(`Updated: ${name}`)
-              }
-            } else {
-              const newComp: Omit<Component, 'id'> = {
-                componentName: name,
-                folderName: folder.folderName,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                isWorking: true,
-                underConstruction: false,
-                isBroken: false,
-                title: null,
-                notes: null,
-                artImageId: null,
-              }
-
-              const created = await createComponent(newComp as Component)
-              matchedComponentIds.add(created.id)
-              log(`Created: ${name}`)
-            }
-          }
-        }
-
-        const stale = apiComponents.filter(
-          (c) => !matchedComponentIds.has(c.id),
-        )
-        for (const comp of stale) {
-          log(`Deleting unmatched: ${comp.componentName}`)
-          await deleteComponent(comp.id)
-        }
-
-        log('Component sync complete.')
-      },
-      ErrorType.GENERAL_ERROR,
-      'Error syncing components',
-    )
   }
 
   return {
@@ -279,7 +142,6 @@ export const useComponentStore = defineStore('componentStore', () => {
     deleteComponent,
     findComponentByName,
     createOrUpdateComponent,
-    syncComponents,
   }
 })
 

--- a/utils/scripts/create-component-json.mjs
+++ b/utils/scripts/create-component-json.mjs
@@ -1,32 +1,118 @@
-// create-component-json.ts
-import { promises as fs } from 'fs'
-import path from 'path'
+// /utils/scripts/create-component-json.mjs
+import { createHash } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
-async function generateComponentJSON() {
-  try {
-    const componentPath = path.resolve(process.cwd(), 'components/')
-    const folderNames = await fs.readdir(componentPath)
-    const folders = []
+const ROOT = process.cwd()
+const COMPONENT_ROOT = path.resolve(ROOT, 'components')
+const LEGACY_OUTPUT = path.resolve(ROOT, 'public/components.json')
+const MANIFEST_OUTPUT = path.resolve(ROOT, 'public/wonderlab-components.json')
 
-    for (const folderName of folderNames) {
-      const folderPath = path.join(componentPath, folderName)
-      const stat = await fs.stat(folderPath)
+const ignoredSegments = new Set(['abandonware', '__tests__', '__fixtures__'])
 
-      if (stat.isDirectory()) {
-        const componentFiles = await fs.readdir(folderPath)
-        const components = componentFiles
-          .filter((file) => file.endsWith('.vue'))
-          .map((file) => file.replace('.vue', ''))
-        folders.push({ folderName, components })
-      }
+function toPosix(value) {
+  return value.split(path.sep).join('/')
+}
+
+function toSlug(value) {
+  return value
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+function shouldIgnore(relativePath) {
+  const segments = toPosix(relativePath).split('/')
+  return segments.some((segment) => ignoredSegments.has(segment))
+}
+
+async function collectVueFiles(directory, files = []) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = path.relative(COMPONENT_ROOT, absolutePath)
+
+    if (shouldIgnore(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      await collectVueFiles(absolutePath, files)
+      continue
     }
 
-    const outputPath = path.resolve(process.cwd(), 'public/components.json')
-    await fs.writeFile(outputPath, JSON.stringify(folders, null, 2))
-    console.log('Component JSON generated successfully:', outputPath)
-  } catch (error) {
-    console.error('Failed to generate component JSON:', error)
+    if (entry.isFile() && entry.name.endsWith('.vue')) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+async function buildManifestEntry(absolutePath) {
+  const relativePath = toPosix(path.relative(COMPONENT_ROOT, absolutePath))
+  const sourcePath = `components/${relativePath}`
+  const folderName = toPosix(path.dirname(relativePath))
+  const componentName = path.basename(relativePath, '.vue')
+  const source = await fs.readFile(absolutePath)
+  const sourceHash = createHash('sha256').update(source).digest('hex')
+
+  return {
+    sourceKey: sourcePath.toLowerCase(),
+    sourcePath,
+    sourceHash,
+    componentName,
+    slug: toSlug(relativePath),
+    folderName: folderName === '.' ? 'root' : folderName,
   }
 }
 
-generateComponentJSON()
+function buildLegacyFolders(entries) {
+  const folders = new Map()
+
+  for (const entry of entries) {
+    const names = folders.get(entry.folderName) ?? []
+    names.push(entry.componentName)
+    folders.set(entry.folderName, names)
+  }
+
+  return [...folders.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([folderName, components]) => ({
+      folderName,
+      components: components.sort((left, right) => left.localeCompare(right)),
+    }))
+}
+
+async function generateComponentManifest() {
+  const files = await collectVueFiles(COMPONENT_ROOT)
+  const entries = await Promise.all(files.map(buildManifestEntry))
+  entries.sort((left, right) => left.sourcePath.localeCompare(right.sourcePath))
+
+  const manifest = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    componentRoot: 'components',
+    count: entries.length,
+    entries,
+  }
+
+  await fs.mkdir(path.dirname(MANIFEST_OUTPUT), { recursive: true })
+  await Promise.all([
+    fs.writeFile(MANIFEST_OUTPUT, `${JSON.stringify(manifest, null, 2)}\n`),
+    fs.writeFile(
+      LEGACY_OUTPUT,
+      `${JSON.stringify(buildLegacyFolders(entries), null, 2)}\n`,
+    ),
+  ])
+
+  console.log(
+    `Generated ${entries.length} WonderLab component entries at ${path.relative(ROOT, MANIFEST_OUTPUT)}.`,
+  )
+}
+
+generateComponentManifest().catch((error) => {
+  console.error('Failed to generate WonderLab component manifest:', error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyWonderLabReconcile.ts
+++ b/utils/scripts/verifyWonderLabReconcile.ts
@@ -1,0 +1,105 @@
+// /utils/scripts/verifyWonderLabReconcile.ts
+import assert from 'node:assert/strict'
+import type { Component } from '~/prisma/generated/prisma/client'
+import {
+  buildComponentReconcilePlan,
+  parseWonderLabManifest,
+  type WonderLabManifest,
+} from '@/server/utils/wonderlabComponentReconcile'
+
+function component(
+  id: number,
+  componentName: string,
+  folderName: string,
+): Component {
+  return {
+    id,
+    componentName,
+    folderName,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    isWorking: false,
+    underConstruction: false,
+    isBroken: false,
+    title: componentName,
+    notes: null,
+    artImageId: null,
+  }
+}
+
+function manifest(
+  entries: WonderLabManifest['entries'],
+): WonderLabManifest {
+  return {
+    version: 1,
+    generatedAt: '2026-07-18T00:00:00.000Z',
+    componentRoot: 'components',
+    count: entries.length,
+    entries,
+  }
+}
+
+function entry(componentName: string, folderName: string) {
+  const sourcePath = `components/${folderName}/${componentName}.vue`
+
+  return {
+    sourceKey: sourcePath.toLowerCase(),
+    sourcePath,
+    sourceHash: 'a'.repeat(64),
+    componentName,
+    slug: `${folderName}-${componentName}`.toLowerCase(),
+    folderName,
+  }
+}
+
+const safePlan = buildComponentReconcilePlan(
+  manifest([entry('ExistingCard', 'cards'), entry('NewPanel', 'panels')]),
+  [
+    component(1, 'ExistingCard', 'legacy'),
+    component(2, 'RetiredWidget', 'legacy'),
+  ],
+)
+
+assert.equal(safePlan.updates.length, 1)
+assert.deepEqual(safePlan.updates[0]?.changes, { folderName: 'cards' })
+assert.equal(safePlan.creates.length, 1)
+assert.equal(safePlan.creates[0]?.componentName, 'NewPanel')
+assert.deepEqual(
+  safePlan.missingFromManifest.map((item) => item.componentName),
+  ['RetiredWidget'],
+  'Unmatched database records must be reported rather than deleted.',
+)
+assert.equal(safePlan.conflicts.length, 0)
+
+const renamePlan = buildComponentReconcilePlan(
+  manifest([entry('NarratorCard', 'navigation')]),
+  [component(3, 'narrator-card', 'legacy')],
+)
+
+assert.equal(renamePlan.updates.length, 1)
+assert.deepEqual(renamePlan.updates[0]?.changes, {
+  componentName: 'NarratorCard',
+  folderName: 'navigation',
+})
+
+const conflictPlan = buildComponentReconcilePlan(
+  manifest([
+    entry('StatusBadge', 'one'),
+    entry('status-badge', 'two'),
+  ]),
+  [],
+)
+
+assert.equal(conflictPlan.conflicts.length, 1)
+assert.equal(conflictPlan.creates.length, 0)
+
+assert.throws(
+  () =>
+    parseWonderLabManifest({
+      ...manifest([entry('Counted', 'cards')]),
+      count: 2,
+    }),
+  /count mismatch/i,
+)
+
+console.log('WonderLab component reconciliation verification passed.')


### PR DESCRIPTION
## What changed

- Adds an admin-only `POST /api/components/reconcile` endpoint using the existing `requireAdminApiUser` guard.
- Supports two explicit modes:
  - `dry-run` plans changes without mutating the database.
  - `apply` runs the reviewed plan in a transaction.
- Validates the generated WonderLab manifest and rejects malformed or oversized payloads.
- Detects normalized-name conflicts in both source and database records and blocks apply until they are resolved.
- Creates newly discovered records as unreviewed in the current schema (`isWorking`, `underConstruction`, and `isBroken` are all false).
- Updates only component names and folder locations while preserving titles, notes, artwork, status, and reactions.
- Reports records missing from the manifest but never deletes or reclassifies them.
- Replaces the old one-click browser sync with a two-step admin UI showing creates, updates, unchanged records, conflicts, and missing records.
- Removes the destructive `syncComponents()` method from the Pinia store entirely.
- Adds `npm run test:wonderlab-reconcile` for planner safety coverage.

## Safety properties

- No automatic deletes.
- No automatic broken/retired classification.
- Apply is blocked by naming ambiguity.
- Dry-run uses the same server-side planner as apply.
- The reviewed manifest is reused for apply rather than silently fetching a different inventory.
- Database writes happen transactionally.

## Stack

This PR is stacked on #388 (`feat/wonderlab-component-manifest`) because it consumes the recursive generated manifest introduced there.

It supersedes the temporary paused-state UI in #389 once this stack is ready to merge.

Part of #381.