### PR TITLE
WonderLab: normalize Component status before schema migration

### DIFF
--- a/components/wonderlab/component-card.vue
+++ b/components/wonderlab/component-card.vue
@@ -1,4 +1,4 @@
-<!-- /components/content/wonderlab/component-card.vue -->
+<!-- /components/wonderlab/component-card.vue -->
 <template>
   <reactable-card
     :selected="activeSelected"
@@ -76,22 +76,8 @@
     </p>
 
     <div v-if="showStatus" class="flex flex-wrap gap-2">
-      <span
-        class="badge badge-sm"
-        :class="component.isWorking ? 'badge-success' : 'badge-ghost'"
-      >
-        {{ component.isWorking ? 'Working' : 'Not verified' }}
-      </span>
-
-      <span
-        v-if="component.underConstruction"
-        class="badge badge-warning badge-sm"
-      >
-        Building
-      </span>
-
-      <span v-if="component.isBroken" class="badge badge-error badge-sm">
-        Broken
+      <span class="badge badge-sm" :class="statusBadgeClass">
+        {{ statusLabel }}
       </span>
 
       <span v-if="component.artImageId" class="badge badge-primary badge-sm">
@@ -158,10 +144,13 @@
 </template>
 
 <script setup lang="ts">
-// /components/content/wonderlab/component-card.vue
 import { computed } from 'vue'
 import type { KindComponent as Component } from '@/stores/componentStore'
 import { useComponentStore } from '@/stores/componentStore'
+import {
+  getLegacyComponentStatus,
+  type LegacyComponentStatus,
+} from '@/utils/wonderlab/componentStatus'
 
 const props = withDefaults(
   defineProps<{
@@ -215,44 +204,69 @@ const componentTitle = computed(() => {
   )
 })
 
-const statusLabel = computed(() => {
-  if (props.component.isBroken) return 'Broken'
-  if (props.component.underConstruction) return 'Building'
-  if (props.component.isWorking) return 'Working'
+const componentStatus = computed(() =>
+  getLegacyComponentStatus(props.component),
+)
 
-  return 'Unverified'
-})
+const statusLabels: Record<LegacyComponentStatus, string> = {
+  UNREVIEWED: 'Unreviewed',
+  WORKING: 'Working',
+  UNDER_CONSTRUCTION: 'Building',
+  BROKEN: 'Broken',
+}
+
+const statusLabel = computed(() => statusLabels[componentStatus.value])
 
 const statusIcon = computed(() => {
-  if (props.component.isBroken) return 'kind-icon:warning'
-  if (props.component.underConstruction) return 'kind-icon:hammer'
-  if (props.component.isWorking) return 'kind-icon:check'
-
-  return 'kind-icon:sparkles'
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'kind-icon:warning'
+    case 'UNDER_CONSTRUCTION':
+      return 'kind-icon:hammer'
+    case 'WORKING':
+      return 'kind-icon:check'
+    default:
+      return 'kind-icon:sparkles'
+  }
 })
 
 const statusIconClass = computed(() => {
-  if (props.component.isBroken) {
-    return 'border-error bg-error/10 text-error'
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'border-error bg-error/10 text-error'
+    case 'UNDER_CONSTRUCTION':
+      return 'border-warning bg-warning/10 text-warning'
+    case 'WORKING':
+      return 'border-success bg-success/10 text-success'
+    default:
+      return 'border-accent bg-accent/10 text-accent'
   }
+})
 
-  if (props.component.underConstruction) {
-    return 'border-warning bg-warning/10 text-warning'
+const statusBadgeClass = computed(() => {
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'badge-error'
+    case 'UNDER_CONSTRUCTION':
+      return 'badge-warning'
+    case 'WORKING':
+      return 'badge-success'
+    default:
+      return 'badge-ghost'
   }
-
-  if (props.component.isWorking) {
-    return 'border-success bg-success/10 text-success'
-  }
-
-  return 'border-accent bg-accent/10 text-accent'
 })
 
 const statusCardClass = computed(() => {
-  if (props.component.isBroken) return 'border-error/50'
-  if (props.component.underConstruction) return 'border-warning/50'
-  if (props.component.isWorking) return 'border-success/40'
-
-  return ''
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'border-error/50'
+    case 'UNDER_CONSTRUCTION':
+      return 'border-warning/50'
+    case 'WORKING':
+      return 'border-success/40'
+    default:
+      return ''
+  }
 })
 
 const updatedLabel = computed(() => {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
+    "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/server/api/components/[id].patch.ts
+++ b/server/api/components/[id].patch.ts
@@ -1,8 +1,12 @@
 // /server/api/components/[id].patch.ts
-import { defineEventHandler, createError, getRouterParam, readBody } from 'h3'
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
+import {
+  hasLegacyStatusUpdate,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
 
 type ComponentPatchBody = Partial<Component>
 
@@ -13,10 +17,6 @@ function getStringOrUndefined(value: unknown): string | undefined {
 function getStringOrNullOrUndefined(value: unknown): string | null | undefined {
   if (value === null) return null
   return typeof value === 'string' ? value : undefined
-}
-
-function getBooleanOrUndefined(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
 }
 
 function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
@@ -84,6 +84,9 @@ export default defineEventHandler(async (event) => {
       where: { id: componentId },
       select: {
         id: true,
+        isWorking: true,
+        underConstruction: true,
+        isBroken: true,
       },
     })
 
@@ -95,15 +98,18 @@ export default defineEventHandler(async (event) => {
     }
 
     const artImageId = getPositiveIntegerOrUndefined(body.artImageId)
-
     await assertArtImageExists(artImageId)
+
+    const normalizedStatus = hasLegacyStatusUpdate(body)
+      ? resolveLegacyStatusUpdate(existingComponent, body)
+      : null
 
     const updateData: Prisma.ComponentUpdateInput = {
       componentName: getStringOrUndefined(body.componentName),
       folderName: getStringOrUndefined(body.folderName),
-      isWorking: getBooleanOrUndefined(body.isWorking),
-      underConstruction: getBooleanOrUndefined(body.underConstruction),
-      isBroken: getBooleanOrUndefined(body.isBroken),
+      isWorking: normalizedStatus?.isWorking,
+      underConstruction: normalizedStatus?.underConstruction,
+      isBroken: normalizedStatus?.isBroken,
       title: getStringOrUndefined(body.title),
       notes: getStringOrNullOrUndefined(body.notes),
       ArtImage:

--- a/server/api/components/index.post.ts
+++ b/server/api/components/index.post.ts
@@ -1,8 +1,13 @@
 // /server/api/components/index.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
+import {
+  hasLegacyStatusUpdate,
+  legacyFieldsForComponentStatus,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
 
 type ComponentCreateBody = Partial<Component>
 
@@ -12,10 +17,6 @@ function getStringOrDefault(value: unknown, fallback: string): string {
 
 function getStringOrNull(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function getBooleanOrDefault(value: unknown, fallback: boolean): boolean {
-  return typeof value === 'boolean' ? value : fallback
 }
 
 function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
@@ -65,17 +66,33 @@ export default defineEventHandler(async (event) => {
     }
 
     const artImageId = getPositiveIntegerOrUndefined(componentData.artImageId)
-
     await assertArtImageExists(artImageId)
 
-    const baseData = {
+    const existingComponent = await prisma.component.findUnique({
+      where: { componentName },
+      select: {
+        isWorking: true,
+        underConstruction: true,
+        isBroken: true,
+      },
+    })
+
+    const statusWasProvided = hasLegacyStatusUpdate(componentData)
+    const createStatus = statusWasProvided
+      ? resolveLegacyStatusUpdate(
+          legacyFieldsForComponentStatus('UNREVIEWED'),
+          componentData,
+        )
+      : legacyFieldsForComponentStatus('UNREVIEWED')
+    const updateStatus =
+      statusWasProvided && existingComponent
+        ? resolveLegacyStatusUpdate(existingComponent, componentData)
+        : statusWasProvided
+          ? createStatus
+          : null
+
+    const commonData = {
       folderName,
-      isWorking: getBooleanOrDefault(componentData.isWorking, true),
-      underConstruction: getBooleanOrDefault(
-        componentData.underConstruction,
-        false,
-      ),
-      isBroken: getBooleanOrDefault(componentData.isBroken, false),
       title: getStringOrDefault(componentData.title, componentName),
       notes: getStringOrNull(componentData.notes),
       updatedAt: new Date(),
@@ -84,18 +101,30 @@ export default defineEventHandler(async (event) => {
             connect: { id: artImageId },
           }
         : undefined,
-    } satisfies Omit<Prisma.ComponentUpdateInput, 'componentName'>
+    }
+
+    const updateData: Prisma.ComponentUpdateInput = {
+      ...commonData,
+      isWorking: updateStatus?.isWorking,
+      underConstruction: updateStatus?.underConstruction,
+      isBroken: updateStatus?.isBroken,
+    }
+
+    const createData: Prisma.ComponentCreateInput = {
+      ...commonData,
+      componentName,
+      createdAt: new Date(),
+      isWorking: createStatus.isWorking,
+      underConstruction: createStatus.underConstruction,
+      isBroken: createStatus.isBroken,
+    }
 
     const data = await prisma.component.upsert({
       where: {
         componentName,
       },
-      update: baseData,
-      create: {
-        ...baseData,
-        componentName,
-        createdAt: new Date(),
-      },
+      update: updateData,
+      create: createData,
       include: {
         ArtImage: {
           select: {

--- a/server/api/components/name/[name].patch.ts
+++ b/server/api/components/name/[name].patch.ts
@@ -1,14 +1,19 @@
-import { defineEventHandler, createError, readBody } from 'h3'
+// /server/api/components/name/[name].patch.ts
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
-import type { Component } from '~/prisma/generated/prisma/client'
+import type { Component, Prisma } from '~/prisma/generated/prisma/client'
+import {
+  hasLegacyStatusUpdate,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
 
 export default defineEventHandler(async (event) => {
   let response
   const componentName = event.context.params?.name
+  let requestBody: Partial<Component> | null = null
 
   try {
-    // Validate the component name from the URL params
     if (!componentName || !/^[a-zA-Z0-9\s-]+$/.test(componentName)) {
       throw createError({
         statusCode: 400,
@@ -16,29 +21,22 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Parse the incoming request body
-    const updatedComponentData: Partial<Component> = await readBody(event)
+    requestBody = await readBody<Partial<Component>>(event)
 
-    // Ensure the request body contains valid fields
-    if (
-      !updatedComponentData ||
-      Object.keys(updatedComponentData).length === 0
-    ) {
+    if (!requestBody || Object.keys(requestBody).length === 0) {
       throw createError({
         statusCode: 400,
         message: 'No valid component data provided.',
       })
     }
 
-    // Validate each field in the payload
-    if (updatedComponentData.title && updatedComponentData.title.length > 100) {
+    if (requestBody.title && requestBody.title.length > 100) {
       throw createError({
         statusCode: 400,
         message: 'Invalid title: Must not exceed 100 characters.',
       })
     }
 
-    // Optional: Check for disallowed or unexpected fields
     const allowedFields = [
       'folderName',
       'createdAt',
@@ -50,9 +48,10 @@ export default defineEventHandler(async (event) => {
       'notes',
       'artImageId',
     ]
-    const invalidFields = Object.keys(updatedComponentData).filter(
+    const invalidFields = Object.keys(requestBody).filter(
       (field) => !allowedFields.includes(field),
     )
+
     if (invalidFields.length > 0) {
       throw createError({
         statusCode: 400,
@@ -60,7 +59,6 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Fetch the existing component by name to ensure it exists
     const existingComponent = await prisma.component.findUnique({
       where: { componentName },
     })
@@ -72,27 +70,42 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Update the component in the database
+    const normalizedStatus = hasLegacyStatusUpdate(requestBody)
+      ? resolveLegacyStatusUpdate(existingComponent, requestBody)
+      : null
+
+    const {
+      isWorking: _isWorking,
+      underConstruction: _underConstruction,
+      isBroken: _isBroken,
+      ...nonStatusData
+    } = requestBody
+
+    const updateData: Prisma.ComponentUpdateInput = {
+      ...nonStatusData,
+      isWorking: normalizedStatus?.isWorking,
+      underConstruction: normalizedStatus?.underConstruction,
+      isBroken: normalizedStatus?.isBroken,
+    }
+
     const data = await prisma.component.update({
       where: { componentName },
-      data: updatedComponentData,
+      data: updateData,
     })
 
-    // Return the updated component in the expected response format
     response = {
       success: true,
       data,
-      statusCode: 200, // OK
+      statusCode: 200,
     }
     event.node.res.statusCode = 200
   } catch (error: unknown) {
     const handledError = errorHandler(error)
     console.error(`Failed to update component with name "${componentName}":`, {
       error: handledError,
-      requestBody: await readBody(event),
+      requestBody,
     })
 
-    // Set response and status code based on the handled error
     event.node.res.statusCode = handledError.statusCode || 500
     response = {
       success: false,

--- a/utils/scripts/verifyWonderLabStatus.ts
+++ b/utils/scripts/verifyWonderLabStatus.ts
@@ -1,0 +1,67 @@
+// /utils/scripts/verifyWonderLabStatus.ts
+import assert from 'node:assert/strict'
+import {
+  getLegacyComponentStatus,
+  hasLegacyStatusUpdate,
+  legacyFieldsForComponentStatus,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
+
+assert.equal(
+  getLegacyComponentStatus({
+    isWorking: true,
+    underConstruction: true,
+    isBroken: true,
+  }),
+  'BROKEN',
+  'Legacy contradictions must resolve deterministically.',
+)
+
+assert.deepEqual(legacyFieldsForComponentStatus('UNREVIEWED'), {
+  isWorking: false,
+  underConstruction: false,
+  isBroken: false,
+})
+
+assert.deepEqual(
+  resolveLegacyStatusUpdate(
+    {
+      isWorking: false,
+      underConstruction: false,
+      isBroken: true,
+    },
+    {
+      isWorking: true,
+    },
+  ),
+  {
+    isWorking: true,
+    underConstruction: false,
+    isBroken: false,
+  },
+  'Enabling one state must replace the previous state.',
+)
+
+assert.deepEqual(
+  resolveLegacyStatusUpdate(
+    {
+      isWorking: false,
+      underConstruction: true,
+      isBroken: false,
+    },
+    {
+      underConstruction: false,
+    },
+  ),
+  {
+    isWorking: false,
+    underConstruction: false,
+    isBroken: false,
+  },
+  'Disabling the only active state must produce UNREVIEWED.',
+)
+
+assert.equal(hasLegacyStatusUpdate({ notes: 'No status change' } as never), false)
+assert.equal(hasLegacyStatusUpdate({ isBroken: false }), true)
+
+console.log('WonderLab component status verification passed.')

--- a/utils/wonderlab/componentStatus.ts
+++ b/utils/wonderlab/componentStatus.ts
@@ -1,0 +1,83 @@
+// /utils/wonderlab/componentStatus.ts
+export type LegacyComponentStatus =
+  | 'UNREVIEWED'
+  | 'WORKING'
+  | 'UNDER_CONSTRUCTION'
+  | 'BROKEN'
+
+export type LegacyComponentStatusFields = {
+  isWorking?: boolean | null
+  underConstruction?: boolean | null
+  isBroken?: boolean | null
+}
+
+export type CanonicalLegacyStatusFields = {
+  isWorking: boolean
+  underConstruction: boolean
+  isBroken: boolean
+}
+
+export function getLegacyComponentStatus(
+  component: LegacyComponentStatusFields,
+): LegacyComponentStatus {
+  if (component.isBroken) return 'BROKEN'
+  if (component.underConstruction) return 'UNDER_CONSTRUCTION'
+  if (component.isWorking) return 'WORKING'
+  return 'UNREVIEWED'
+}
+
+export function legacyFieldsForComponentStatus(
+  status: LegacyComponentStatus,
+): CanonicalLegacyStatusFields {
+  return {
+    isWorking: status === 'WORKING',
+    underConstruction: status === 'UNDER_CONSTRUCTION',
+    isBroken: status === 'BROKEN',
+  }
+}
+
+export function hasLegacyStatusUpdate(
+  patch: LegacyComponentStatusFields,
+): boolean {
+  return (
+    typeof patch.isWorking === 'boolean' ||
+    typeof patch.underConstruction === 'boolean' ||
+    typeof patch.isBroken === 'boolean'
+  )
+}
+
+export function resolveLegacyStatusUpdate(
+  existing: LegacyComponentStatusFields,
+  patch: LegacyComponentStatusFields,
+): CanonicalLegacyStatusFields {
+  // A newly enabled state is an explicit selection and should replace the old
+  // state even when callers send only one boolean field.
+  if (patch.isBroken === true) {
+    return legacyFieldsForComponentStatus('BROKEN')
+  }
+  if (patch.underConstruction === true) {
+    return legacyFieldsForComponentStatus('UNDER_CONSTRUCTION')
+  }
+  if (patch.isWorking === true) {
+    return legacyFieldsForComponentStatus('WORKING')
+  }
+
+  // False-only patches clear the supplied flags and preserve any other
+  // existing state. The result is normalized before it reaches Prisma.
+  return legacyFieldsForComponentStatus(
+    getLegacyComponentStatus({
+      isWorking:
+        typeof patch.isWorking === 'boolean'
+          ? patch.isWorking
+          : existing.isWorking,
+      underConstruction:
+        typeof patch.underConstruction === 'boolean'
+          ? patch.underConstruction
+          : existing.underConstruction,
+      isBroken:
+        typeof patch.isBroken === 'boolean'
+          ? patch.isBroken
+          : existing.isBroken,
+    }),
+  )
+}


### PR DESCRIPTION
## What changed

- Adds a shared compatibility helper that derives one canonical status from the current legacy booleans:
  - `UNREVIEWED`
  - `WORKING`
  - `UNDER_CONSTRUCTION`
  - `BROKEN`
- Defines deterministic precedence for already-contradictory rows.
- Normalizes writes through both component PATCH endpoints so enabling one state disables the other two.
- Makes false-only patches clear the requested state without inventing another state.
- Changes component upserts so newly created records default to unreviewed instead of automatically claiming to work.
- Preserves existing status during an upsert when no status fields were supplied.
- Updates component exhibit cards to show one status badge, icon, and border treatment rather than several contradictory badges.
- Adds `npm run test:wonderlab-status` with coverage for contradiction resolution and status transitions.

## Why before the Prisma migration

The database still stores three legacy booleans. Normalizing all current writes first prevents new contradictory data and gives the future enum migration a deterministic backfill rule. This PR intentionally does not change the schema or generated Prisma client yet.

## Stack

This PR is stacked on #393, which is stacked on #388.

Part of #381.