### PR TITLE
WonderLab: preview harness and fixture catalog foundation

### DIFF
--- a/components/wonderlab/wonderlab-preview-host.vue
+++ b/components/wonderlab/wonderlab-preview-host.vue
@@ -1,0 +1,258 @@
+<!-- /components/wonderlab/wonderlab-preview-host.vue -->
+<template>
+  <section class="rounded-3xl border border-base-300 bg-base-200/60 p-3">
+    <header class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          Preview Harness
+        </p>
+        <h3 class="mt-1 truncate text-lg font-black">
+          {{ fixture?.title || componentName }}
+        </h3>
+        <p class="mt-1 break-all font-mono text-xs text-base-content/50">
+          {{ resolvedPath || expectedPath }}
+        </p>
+        <p
+          v-if="fixture?.description"
+          class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65"
+        >
+          {{ fixture.description }}
+        </p>
+      </div>
+
+      <div v-if="showControls" class="flex flex-wrap items-center gap-2">
+        <select
+          v-model="viewport"
+          class="select select-bordered select-xs rounded-xl bg-base-100"
+          aria-label="Preview viewport"
+        >
+          <option value="mobile">Mobile</option>
+          <option value="tablet">Tablet</option>
+          <option value="desktop">Desktop</option>
+          <option value="full">Full width</option>
+        </select>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl"
+          @click="resetPreview"
+        >
+          <Icon name="kind-icon:refresh" class="size-3.5" />
+          Reset
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="fixture?.skipReason"
+      class="mt-3 rounded-2xl border border-info/30 bg-info/10 p-4"
+    >
+      <div class="flex items-start gap-3">
+        <Icon name="kind-icon:info" class="mt-0.5 size-5 shrink-0 text-info" />
+        <div>
+          <p class="font-black text-info-content">Context fixture required</p>
+          <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+            {{ fixture.skipReason }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else-if="previewNotFound"
+      class="mt-3 rounded-2xl border border-dashed border-warning/40 bg-warning/5 p-5 text-center"
+    >
+      <Icon name="kind-icon:search" class="mx-auto size-8 text-warning" />
+      <p class="mt-2 font-black">Component source not found</p>
+      <p class="mt-1 text-sm text-base-content/60">
+        The manifest or database path may be stale. No database record was
+        changed.
+      </p>
+    </div>
+
+    <div
+      v-else-if="previewError"
+      class="mt-3 rounded-2xl border border-error/40 bg-error/5 p-4"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <p class="font-black text-error">Preview error contained</p>
+          <pre
+            class="mt-2 max-h-48 overflow-auto whitespace-pre-wrap text-xs text-error/80"
+          >{{ previewError }}</pre>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-error btn-outline btn-xs shrink-0 rounded-xl"
+          @click="resetPreview"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="mt-3 overflow-auto rounded-2xl border border-base-300 bg-base-100 p-4 shadow-inner"
+    >
+      <div
+        class="mx-auto w-full transition-[max-width] duration-200"
+        :class="viewportClass"
+        :style="previewStyle"
+      >
+        <Suspense v-if="dynamicComponent">
+          <component
+            :is="dynamicComponent"
+            :key="renderKey"
+            v-bind="fixture?.props || {}"
+          />
+
+          <template #fallback>
+            <div class="flex min-h-40 items-center justify-center">
+              <span class="loading loading-spinner loading-md text-primary" />
+            </div>
+          </template>
+        </Suspense>
+
+        <div v-else class="flex min-h-40 items-center justify-center">
+          <span class="loading loading-spinner loading-md text-primary" />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  computed,
+  defineAsyncComponent,
+  onErrorCaptured,
+  ref,
+  watch,
+} from 'vue'
+import {
+  getWonderLabPreviewFixture,
+  type WonderLabPreviewViewport,
+} from '@/utils/wonderlab/previewFixtures'
+
+const props = withDefaults(
+  defineProps<{
+    componentName: string
+    folderName: string
+    sourcePath?: string
+    showControls?: boolean
+  }>(),
+  {
+    sourcePath: '',
+    showControls: true,
+  },
+)
+
+const emit = defineEmits<{
+  resolved: [path: string]
+  error: [message: string]
+}>()
+
+const allModules = import.meta.glob('@/components/**/*.vue')
+const dynamicComponent = ref<ReturnType<typeof defineAsyncComponent> | null>(
+  null,
+)
+const resolvedPath = ref('')
+const previewNotFound = ref(false)
+const previewError = ref('')
+const renderKey = ref(0)
+const viewport = ref<WonderLabPreviewViewport>('desktop')
+
+const fixture = computed(() =>
+  getWonderLabPreviewFixture(props.componentName, props.sourcePath),
+)
+
+const expectedPath = computed(() => {
+  const name = props.componentName.replace(/\.vue$/i, '')
+  return `/components/${props.folderName}/${name}.vue`
+})
+
+const viewportClass = computed(() => {
+  switch (viewport.value) {
+    case 'mobile':
+      return 'max-w-sm'
+    case 'tablet':
+      return 'max-w-2xl'
+    case 'desktop':
+      return 'max-w-5xl'
+    default:
+      return 'max-w-none'
+  }
+})
+
+const previewStyle = computed(() => ({
+  minHeight: fixture.value?.minHeight || '12rem',
+}))
+
+function normalizedSourcePath(value: string): string {
+  const path = value.trim().replace(/\\/g, '/')
+  if (!path) return ''
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function buildCandidates(): string[] {
+  const name = props.componentName.replace(/\.vue$/i, '')
+  const explicit = normalizedSourcePath(props.sourcePath)
+
+  return [
+    explicit,
+    `/components/${props.folderName}/${name}.vue`,
+    `/components/content/${props.folderName}/${name}.vue`,
+    `/components/${name}.vue`,
+  ].filter((value, index, list) => Boolean(value) && list.indexOf(value) === index)
+}
+
+function resolveComponent(): void {
+  dynamicComponent.value = null
+  resolvedPath.value = ''
+  previewNotFound.value = false
+  previewError.value = ''
+  renderKey.value += 1
+  viewport.value = fixture.value?.viewport || 'desktop'
+
+  if (fixture.value?.skipReason) return
+
+  const matchedPath = buildCandidates().find((candidate) => allModules[candidate])
+  if (!matchedPath) {
+    previewNotFound.value = true
+    return
+  }
+
+  resolvedPath.value = matchedPath
+  emit('resolved', matchedPath)
+
+  dynamicComponent.value = defineAsyncComponent({
+    loader: allModules[matchedPath] as () => Promise<{ default: unknown }>,
+    timeout: 10_000,
+    onError(error, _retry, fail) {
+      const message = error instanceof Error ? error.message : String(error)
+      previewError.value = message
+      emit('error', message)
+      fail()
+    },
+  })
+}
+
+function resetPreview(): void {
+  resolveComponent()
+}
+
+watch(
+  () => [props.componentName, props.folderName, props.sourcePath],
+  resolveComponent,
+  { immediate: true },
+)
+
+onErrorCaptured((error) => {
+  const message = error instanceof Error ? error.message : String(error)
+  previewError.value = message
+  emit('error', message)
+  return false
+})
+</script>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
     "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
+    "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/utils/scripts/auditWonderLabPreviews.ts
+++ b/utils/scripts/auditWonderLabPreviews.ts
@@ -1,0 +1,138 @@
+// /utils/scripts/auditWonderLabPreviews.ts
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { getWonderLabPreviewFixture } from '../wonderlab/previewFixtures'
+
+const componentRoot = path.resolve(process.cwd(), 'components')
+const ignoredSegments = new Set(['abandonware', '__tests__', '__fixtures__'])
+const strict = process.argv.includes('--strict')
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join('/')
+}
+
+function shouldIgnore(relativePath: string): boolean {
+  return toPosix(relativePath)
+    .split('/')
+    .some((segment) => ignoredSegments.has(segment))
+}
+
+async function collectVueFiles(directory: string, files: string[] = []) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = path.relative(componentRoot, absolutePath)
+
+    if (shouldIgnore(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      await collectVueFiles(absolutePath, files)
+    } else if (entry.isFile() && entry.name.endsWith('.vue')) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+function extractTypeRequiredProps(source: string): string[] {
+  const matches = source.matchAll(/defineProps\s*<\s*\{([\s\S]*?)\}\s*>\s*\(/g)
+  const props = new Set<string>()
+
+  for (const match of matches) {
+    const body = match[1] || ''
+    const lines = body.split('\n')
+
+    for (const line of lines) {
+      const property = line.match(/^\s*([A-Za-z_$][\w$]*)\s*:\s*/)
+      if (property?.[1]) props.add(property[1])
+    }
+  }
+
+  return [...props]
+}
+
+function extractRuntimeRequiredProps(source: string): string[] {
+  const props = new Set<string>()
+  const objectMatch = source.match(/defineProps\s*\(\s*\{([\s\S]*?)\}\s*\)/)
+  const body = objectMatch?.[1] || ''
+  const propertyPattern = /([A-Za-z_$][\w$]*)\s*:\s*\{([\s\S]*?)\}(?:,|$)/g
+
+  for (const match of body.matchAll(propertyPattern)) {
+    if (/required\s*:\s*true/.test(match[2] || '') && match[1]) {
+      props.add(match[1])
+    }
+  }
+
+  return [...props]
+}
+
+function extractRequiredProps(source: string): string[] {
+  return [
+    ...new Set([
+      ...extractTypeRequiredProps(source),
+      ...extractRuntimeRequiredProps(source),
+    ]),
+  ].sort()
+}
+
+async function main() {
+  const files = await collectVueFiles(componentRoot)
+  const uncovered: Array<{
+    sourcePath: string
+    componentName: string
+    requiredProps: string[]
+    missingProps: string[]
+  }> = []
+  let covered = 0
+
+  for (const absolutePath of files) {
+    const source = await fs.readFile(absolutePath, 'utf8')
+    const requiredProps = extractRequiredProps(source)
+    if (!requiredProps.length) continue
+
+    const relativePath = toPosix(path.relative(componentRoot, absolutePath))
+    const sourcePath = `components/${relativePath}`
+    const componentName = path.basename(relativePath, '.vue')
+    const fixture = getWonderLabPreviewFixture(componentName, sourcePath)
+
+    if (fixture?.skipReason) {
+      covered += 1
+      continue
+    }
+
+    const fixtureProps = new Set(Object.keys(fixture?.props || {}))
+    const missingProps = requiredProps.filter((prop) => !fixtureProps.has(prop))
+
+    if (missingProps.length) {
+      uncovered.push({
+        sourcePath,
+        componentName,
+        requiredProps,
+        missingProps,
+      })
+    } else {
+      covered += 1
+    }
+  }
+
+  console.log(`WonderLab preview audit scanned ${files.length} Vue components.`)
+  console.log(`${covered} required-prop components have fixture coverage or an explicit skip reason.`)
+  console.log(`${uncovered.length} required-prop components still need preview coverage.`)
+
+  for (const item of uncovered) {
+    console.log(
+      `- ${item.sourcePath}: missing fixture props ${item.missingProps.join(', ')}`,
+    )
+  }
+
+  if (strict && uncovered.length) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error('WonderLab preview audit failed:', error)
+  process.exitCode = 1
+})

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -1,0 +1,90 @@
+// /utils/wonderlab/previewFixtures.ts
+export type WonderLabPreviewViewport = 'mobile' | 'tablet' | 'desktop' | 'full'
+
+export type WonderLabPreviewFixture = {
+  title?: string
+  description?: string
+  props?: Record<string, unknown>
+  viewport?: WonderLabPreviewViewport
+  minHeight?: string
+  skipReason?: string
+}
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'component-card': {
+    title: 'Component Card specimen',
+    description:
+      'Uses a synthetic museum component and disables live reactions and edit actions.',
+    viewport: 'desktop',
+    minHeight: '20rem',
+    props: {
+      component: {
+        id: -1,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        folderName: 'wonderlab',
+        componentName: 'component-card',
+        isWorking: true,
+        underConstruction: false,
+        isBroken: false,
+        title: 'Museum Component Card',
+        notes:
+          'A safe fixture used to demonstrate the Component Card without requiring a database record.',
+        artImageId: null,
+      },
+      showReaction: false,
+      allowEdit: false,
+      allowCopyName: false,
+      showMeta: true,
+      showSelectButton: false,
+    },
+  },
+  'component-sync': {
+    title: 'Component reconciliation',
+    skipReason:
+      'This admin tool requires an authenticated admin session and performs deliberate server actions. Preview it from the WonderLab admin surface instead.',
+  },
+  'workspace-narrator': {
+    title: 'Workspace Narrator',
+    skipReason:
+      'The narrator remote depends on active page, narrator, expression, chat, and layout stores. It needs a dedicated workspace fixture rather than a naked mount.',
+  },
+  'narrator-chat': {
+    title: 'Narrator Chat',
+    skipReason:
+      'Narrator Chat depends on a resolved narrator identity, thread context, and chat server selection.',
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabPreviewFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function hasWonderLabPreviewFixture(
+  componentName: string,
+  sourcePath = '',
+): boolean {
+  return Boolean(getWonderLabPreviewFixture(componentName, sourcePath))
+}
+
+export function listWonderLabPreviewFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## What changed

- Adds a typed WonderLab preview fixture catalog with:
  - default props;
  - preferred viewport;
  - minimum preview height;
  - fixture descriptions;
  - explicit `skipReason` placards for components that need application context.
- Seeds safe fixtures for `component-card` and explicit context requirements for the component reconciliation and narrator surfaces.
- Adds `wonderlab-preview-host.vue`, which provides:
  - recursive build-time component resolution;
  - fixture prop binding;
  - mobile/tablet/desktop/full viewport controls;
  - reset/remount behavior;
  - isolated async-load and render error containment;
  - intentional context-required and source-not-found states;
  - no database mutation when previews fail.
- Adds `npm run audit:wonderlab-previews` to scan Vue components for required props and report components without fixture coverage or an explicit skip reason.
- Supports a future `--strict` audit mode without making the existing backlog fail CI yet.

## Scope

This PR establishes the reusable preview host and coverage audit. Replacing the current inline naked mount in `lab-interact.vue` is intentionally left as the next focused UI integration step, so the harness can be reviewed independently first.

## Stack

This PR is stacked on #394, which is stacked on #393 and #388.

Part of #381.