### PR TITLE
WonderLab: safe reconciliation, status, previews, and reviews

### DIFF
--- a/components/wonderlab/component-card.vue
+++ b/components/wonderlab/component-card.vue
@@ -1,4 +1,4 @@
-<!-- /components/content/wonderlab/component-card.vue -->
+<!-- /components/wonderlab/component-card.vue -->
 <template>
   <reactable-card
     :selected="activeSelected"
@@ -76,22 +76,8 @@
     </p>
 
     <div v-if="showStatus" class="flex flex-wrap gap-2">
-      <span
-        class="badge badge-sm"
-        :class="component.isWorking ? 'badge-success' : 'badge-ghost'"
-      >
-        {{ component.isWorking ? 'Working' : 'Not verified' }}
-      </span>
-
-      <span
-        v-if="component.underConstruction"
-        class="badge badge-warning badge-sm"
-      >
-        Building
-      </span>
-
-      <span v-if="component.isBroken" class="badge badge-error badge-sm">
-        Broken
+      <span class="badge badge-sm" :class="statusBadgeClass">
+        {{ statusLabel }}
       </span>
 
       <span v-if="component.artImageId" class="badge badge-primary badge-sm">
@@ -158,10 +144,13 @@
 </template>
 
 <script setup lang="ts">
-// /components/content/wonderlab/component-card.vue
 import { computed } from 'vue'
 import type { KindComponent as Component } from '@/stores/componentStore'
 import { useComponentStore } from '@/stores/componentStore'
+import {
+  getLegacyComponentStatus,
+  type LegacyComponentStatus,
+} from '@/utils/wonderlab/componentStatus'
 
 const props = withDefaults(
   defineProps<{
@@ -215,44 +204,69 @@ const componentTitle = computed(() => {
   )
 })
 
-const statusLabel = computed(() => {
-  if (props.component.isBroken) return 'Broken'
-  if (props.component.underConstruction) return 'Building'
-  if (props.component.isWorking) return 'Working'
+const componentStatus = computed(() =>
+  getLegacyComponentStatus(props.component),
+)
 
-  return 'Unverified'
-})
+const statusLabels: Record<LegacyComponentStatus, string> = {
+  UNREVIEWED: 'Unreviewed',
+  WORKING: 'Working',
+  UNDER_CONSTRUCTION: 'Building',
+  BROKEN: 'Broken',
+}
+
+const statusLabel = computed(() => statusLabels[componentStatus.value])
 
 const statusIcon = computed(() => {
-  if (props.component.isBroken) return 'kind-icon:warning'
-  if (props.component.underConstruction) return 'kind-icon:hammer'
-  if (props.component.isWorking) return 'kind-icon:check'
-
-  return 'kind-icon:sparkles'
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'kind-icon:warning'
+    case 'UNDER_CONSTRUCTION':
+      return 'kind-icon:hammer'
+    case 'WORKING':
+      return 'kind-icon:check'
+    default:
+      return 'kind-icon:sparkles'
+  }
 })
 
 const statusIconClass = computed(() => {
-  if (props.component.isBroken) {
-    return 'border-error bg-error/10 text-error'
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'border-error bg-error/10 text-error'
+    case 'UNDER_CONSTRUCTION':
+      return 'border-warning bg-warning/10 text-warning'
+    case 'WORKING':
+      return 'border-success bg-success/10 text-success'
+    default:
+      return 'border-accent bg-accent/10 text-accent'
   }
+})
 
-  if (props.component.underConstruction) {
-    return 'border-warning bg-warning/10 text-warning'
+const statusBadgeClass = computed(() => {
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'badge-error'
+    case 'UNDER_CONSTRUCTION':
+      return 'badge-warning'
+    case 'WORKING':
+      return 'badge-success'
+    default:
+      return 'badge-ghost'
   }
-
-  if (props.component.isWorking) {
-    return 'border-success bg-success/10 text-success'
-  }
-
-  return 'border-accent bg-accent/10 text-accent'
 })
 
 const statusCardClass = computed(() => {
-  if (props.component.isBroken) return 'border-error/50'
-  if (props.component.underConstruction) return 'border-warning/50'
-  if (props.component.isWorking) return 'border-success/40'
-
-  return ''
+  switch (componentStatus.value) {
+    case 'BROKEN':
+      return 'border-error/50'
+    case 'UNDER_CONSTRUCTION':
+      return 'border-warning/50'
+    case 'WORKING':
+      return 'border-success/40'
+    default:
+      return ''
+  }
 })
 
 const updatedLabel = computed(() => {

--- a/components/wonderlab/component-review-feed.vue
+++ b/components/wonderlab/component-review-feed.vue
@@ -1,0 +1,257 @@
+<!-- /components/wonderlab/component-review-feed.vue -->
+<template>
+  <section class="rounded-3xl border border-base-300 bg-base-200/60 p-4">
+    <header class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          Museum Reviews
+        </p>
+        <h3 class="mt-1 text-xl font-black">
+          {{ targetTitle || `Component #${componentId}` }}
+        </h3>
+        <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
+          <span class="font-black text-warning">{{ averageRatingLabel }}</span>
+          <span aria-hidden="true" class="text-warning">★</span>
+          <span class="text-base-content/55">
+            {{ reviewCountLabel }}
+          </span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm rounded-xl"
+        :disabled="isLoading"
+        @click="loadReviews(true)"
+      >
+        <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+        <Icon v-else name="kind-icon:refresh" class="size-4" />
+        Refresh
+      </button>
+    </header>
+
+    <div
+      v-if="errorMessage"
+      class="mt-4 rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div
+      v-else-if="isLoading && !reviews.length"
+      class="mt-4 flex min-h-32 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+    >
+      <span class="loading loading-spinner loading-md text-primary" />
+    </div>
+
+    <div
+      v-else-if="!reviews.length"
+      class="mt-4 rounded-2xl border border-dashed border-base-300 bg-base-100 p-6 text-center"
+    >
+      <Icon name="kind-icon:comment" class="mx-auto size-10 text-base-content/25" />
+      <p class="mt-2 font-black">No reviews yet</p>
+      <p class="mt-1 text-sm text-base-content/55">
+        This exhibit is waiting for its first visitor note.
+      </p>
+    </div>
+
+    <div v-else class="mt-4 grid gap-3">
+      <article
+        v-for="review in reviews"
+        :key="review.id"
+        class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm"
+      >
+        <div class="flex items-start gap-3">
+          <div
+            class="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-primary/20 bg-primary/10"
+          >
+            <img
+              v-if="review.User?.avatarImage"
+              :src="normalizeImagePath(review.User.avatarImage)"
+              :alt="authorName(review)"
+              class="h-full w-full object-cover"
+              loading="lazy"
+            />
+            <Icon v-else name="kind-icon:user" class="size-5 text-primary" />
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-start justify-between gap-2">
+              <div class="min-w-0">
+                <p class="truncate font-black">{{ authorName(review) }}</p>
+                <div class="mt-1 flex flex-wrap items-center gap-2">
+                  <span
+                    v-if="review.User?.Role"
+                    class="badge badge-outline badge-xs"
+                  >
+                    {{ review.User.Role }}
+                  </span>
+                  <span class="text-xs text-base-content/45">
+                    {{ formatDate(review.createdAt) }}
+                  </span>
+                </div>
+              </div>
+
+              <div class="flex shrink-0 items-center gap-2">
+                <span
+                  class="badge badge-sm"
+                  :class="reactionBadgeClass(review.reactionType)"
+                >
+                  {{ formatReactionType(review.reactionType) }}
+                </span>
+                <span
+                  v-if="review.rating > 0"
+                  class="font-black text-warning"
+                  :aria-label="`${review.rating} out of 5 stars`"
+                >
+                  {{ review.rating }} ★
+                </span>
+              </div>
+            </div>
+
+            <p
+              v-if="review.comment"
+              class="mt-3 whitespace-pre-wrap text-sm leading-relaxed text-base-content/75"
+            >
+              {{ review.comment }}
+            </p>
+            <p v-else class="mt-3 text-sm italic text-base-content/40">
+              No written comment.
+            </p>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { Reaction } from '~/prisma/generated/prisma/client'
+import { useReactionStore } from '@/stores/reactionStore'
+
+type PublicReviewAuthor = {
+  id: number
+  username: string | null
+  name: string | null
+  avatarImage: string | null
+  Role: string | null
+  isPublic: boolean
+}
+
+type PublicComponentReview = Reaction & {
+  User?: PublicReviewAuthor | null
+}
+
+const props = withDefaults(
+  defineProps<{
+    componentId: number
+    targetTitle?: string
+  }>(),
+  {
+    targetTitle: '',
+  },
+)
+
+const reactionStore = useReactionStore()
+const isLoading = ref(false)
+const errorMessage = ref('')
+
+const reviews = computed<PublicComponentReview[]>(() => {
+  return [...reactionStore.getReactionsByComponentId(props.componentId)]
+    .map((reaction) => reaction as PublicComponentReview)
+    .sort((left, right) => {
+      return new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
+    })
+})
+
+const reviewCountLabel = computed(() => {
+  const count = reviews.value.length
+  return `${count} ${count === 1 ? 'review' : 'reviews'}`
+})
+
+const averageRating = computed(() => {
+  const rated = reviews.value.filter((review) => review.rating > 0)
+  if (!rated.length) return 0
+
+  return rated.reduce((total, review) => total + review.rating, 0) / rated.length
+})
+
+const averageRatingLabel = computed(() => {
+  return averageRating.value ? averageRating.value.toFixed(1) : '—'
+})
+
+async function loadReviews(force = false): Promise<void> {
+  if (!Number.isInteger(props.componentId) || props.componentId <= 0) return
+
+  isLoading.value = true
+  errorMessage.value = ''
+
+  try {
+    await reactionStore.fetchReactionsByComponentId(props.componentId, force)
+
+    if (reactionStore.lastError) {
+      throw new Error(reactionStore.lastError)
+    }
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Failed to load component reviews.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function authorName(review: PublicComponentReview): string {
+  return (
+    review.User?.name?.trim() ||
+    review.User?.username?.trim() ||
+    (review.userId ? `User #${review.userId}` : 'Anonymous visitor')
+  )
+}
+
+function normalizeImagePath(value: string): string {
+  if (value.startsWith('/') || value.startsWith('http')) return value
+  return `/images/${value}`
+}
+
+function formatDate(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown date'
+
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatReactionType(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/^./, (letter) => letter.toUpperCase())
+}
+
+function reactionBadgeClass(value: string): string {
+  switch (value) {
+    case 'LOVED':
+    case 'CLAPPED':
+      return 'badge-success'
+    case 'BOOED':
+    case 'HATED':
+      return 'badge-error'
+    case 'FLAGGED':
+      return 'badge-warning'
+    default:
+      return 'badge-ghost'
+  }
+}
+
+watch(
+  () => props.componentId,
+  () => {
+    void loadReviews()
+  },
+  { immediate: true },
+)
+</script>

--- a/components/wonderlab/component-sync.vue
+++ b/components/wonderlab/component-sync.vue
@@ -1,62 +1,335 @@
-<!-- /components/content/wonderlab/component-sync.vue -->
-// /components/content/wonderlab/component-sync.vue
+<!-- /components/wonderlab/component-sync.vue -->
 <template>
-  <div class="flex flex-col items-center p-4 bg-base-200 rounded-lg shadow-md">
-    <h2 class="text-lg font-bold mb-4">Component Sync</h2>
-    <button class="btn btn-primary" :disabled="isSyncing" @click="handleSync">
-      {{ isSyncing ? 'Syncing...' : 'Sync Components' }}
-    </button>
-    <p v-if="progressMessage" class="mt-4 text-info">{{ progressMessage }}</p>
-    <p v-if="syncMessage" class="mt-4 text-success">{{ syncMessage }}</p>
-    <p v-if="syncError" class="mt-4 text-error">{{ syncError }}</p>
-  </div>
+  <section class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-lg">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          Admin Tool
+        </p>
+        <h2 class="mt-1 text-xl font-black">Component Reconciliation</h2>
+        <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
+          Compare the generated WonderLab manifest with the database before
+          applying changes. Unmatched database records are reported but never
+          deleted.
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn btn-outline btn-sm rounded-xl"
+          :disabled="isBusy"
+          @click="runDryRun"
+        >
+          <span v-if="isDryRunning" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:search" class="size-4" />
+          Dry Run
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-primary btn-sm rounded-xl"
+          :disabled="!canApply || isBusy"
+          @click="applyPlan"
+        >
+          <span v-if="isApplying" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:check" class="size-4" />
+          Apply Safe Changes
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="mt-4 rounded-2xl border border-info/30 bg-info/10 px-4 py-3 text-sm text-info-content"
+    >
+      Apply creates missing records and updates component names or folders. It
+      does not delete records, remove reactions, or mark missing components as
+      broken.
+    </div>
+
+    <div
+      v-if="errorMessage"
+      class="mt-4 rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div
+      v-if="successMessage"
+      class="mt-4 rounded-2xl border border-success/40 bg-success/10 p-4 text-sm text-success"
+    >
+      {{ successMessage }}
+    </div>
+
+    <template v-if="result">
+      <div class="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+        <article
+          v-for="metric in summaryMetrics"
+          :key="metric.label"
+          class="rounded-2xl border border-base-300 bg-base-200/60 p-3"
+        >
+          <p class="text-xs font-bold uppercase tracking-wide text-base-content/50">
+            {{ metric.label }}
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ metric.value }}</p>
+        </article>
+      </div>
+
+      <p class="mt-3 text-xs text-base-content/50">
+        Manifest generated {{ formatDate(result.manifest.generatedAt) }} with
+        {{ result.manifest.count }} entries.
+      </p>
+
+      <section
+        v-if="result.plan.conflicts.length"
+        class="mt-4 rounded-2xl border border-error/40 bg-error/5 p-4"
+      >
+        <h3 class="font-black text-error">Naming conflicts block apply</h3>
+        <div class="mt-3 grid gap-3">
+          <article
+            v-for="conflict in result.plan.conflicts"
+            :key="conflict.key"
+            class="rounded-xl border border-error/25 bg-base-100 p-3"
+          >
+            <p class="font-mono text-xs font-bold text-error">
+              {{ conflict.key }}
+            </p>
+            <p class="mt-1 text-sm">{{ conflict.componentNames.join(', ') }}</p>
+            <p class="mt-2 text-xs leading-relaxed text-base-content/60">
+              {{ conflict.reason }}
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <details
+        v-if="result.plan.creates.length"
+        class="mt-4 rounded-2xl border border-base-300 bg-base-200/35 p-4"
+      >
+        <summary class="cursor-pointer font-black">
+          New records ({{ result.plan.creates.length }})
+        </summary>
+        <ul class="mt-3 grid gap-1 text-sm">
+          <li
+            v-for="action in result.plan.creates.slice(0, 50)"
+            :key="action.componentName"
+            class="font-mono text-xs"
+          >
+            {{ action.changes.folderName }}/{{ action.componentName }}
+          </li>
+        </ul>
+      </details>
+
+      <details
+        v-if="result.plan.updates.length"
+        class="mt-3 rounded-2xl border border-base-300 bg-base-200/35 p-4"
+      >
+        <summary class="cursor-pointer font-black">
+          Updates ({{ result.plan.updates.length }})
+        </summary>
+        <div class="mt-3 grid gap-2">
+          <article
+            v-for="action in result.plan.updates.slice(0, 50)"
+            :key="`${action.existingId}-${action.componentName}`"
+            class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs"
+          >
+            <p class="font-mono font-bold">{{ action.componentName }}</p>
+            <p class="mt-1 text-base-content/60">
+              {{ formatChanges(action.changes) }}
+            </p>
+          </article>
+        </div>
+      </details>
+
+      <details
+        v-if="result.plan.missingFromManifest.length"
+        class="mt-3 rounded-2xl border border-warning/40 bg-warning/5 p-4"
+      >
+        <summary class="cursor-pointer font-black text-warning-content">
+          Missing from manifest ({{ result.plan.missingFromManifest.length }})
+        </summary>
+        <p class="mt-2 text-xs leading-relaxed text-base-content/60">
+          These records remain untouched so notes, status, artwork, and reactions
+          are preserved for review.
+        </p>
+        <ul class="mt-3 grid gap-1 text-sm">
+          <li
+            v-for="component in result.plan.missingFromManifest.slice(0, 50)"
+            :key="component.id"
+            class="font-mono text-xs"
+          >
+            {{ component.folderName }}/{{ component.componentName }}
+          </li>
+        </ul>
+      </details>
+    </template>
+  </section>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useComponentStore } from '@/stores/componentStore'
+import { computed, ref } from 'vue'
+import { performFetch } from '@/stores/utils'
 
-const componentStore = useComponentStore()
-const isSyncing = ref(false)
-const progressMessage = ref('')
-const syncMessage = ref('')
-const syncError = ref('')
+type WonderLabManifest = {
+  version: number
+  generatedAt: string
+  componentRoot: string
+  count: number
+  entries: unknown[]
+}
 
-const handleSync = async () => {
-  isSyncing.value = true
-  syncMessage.value = ''
-  syncError.value = ''
-  progressMessage.value = 'Initializing sync...'
+type ReconcileAction = {
+  kind: 'create' | 'update'
+  componentName: string
+  existingId?: number
+  changes: Record<string, string>
+}
 
-  try {
-    await componentStore.syncComponents((progress: string) => {
-      console.log('[ComponentSync] Progress:', progress)
-      progressMessage.value = progress
-    })
-    syncMessage.value = 'Components synced successfully!'
-  } catch (error) {
-    console.error('[ComponentSync] Sync error:', error)
-    syncError.value =
-      error instanceof Error
-        ? error.message
-        : typeof error === 'string'
-          ? error
-          : 'An unexpected error occurred during the sync process.'
-  } finally {
-    isSyncing.value = false
-    progressMessage.value = ''
+type ReconcileConflict = {
+  key: string
+  componentNames: string[]
+  reason: string
+}
+
+type MissingComponent = {
+  id: number
+  componentName: string
+  folderName: string
+}
+
+type ReconcileResult = {
+  mode: 'dry-run' | 'apply'
+  applied: boolean
+  manifest: {
+    version: number
+    generatedAt: string
+    count: number
+  }
+  summary: {
+    creates: number
+    updates: number
+    unchanged: number
+    missingFromManifest: number
+    conflicts: number
+  }
+  plan: {
+    creates: ReconcileAction[]
+    updates: ReconcileAction[]
+    unchanged: string[]
+    missingFromManifest: MissingComponent[]
+    conflicts: ReconcileConflict[]
   }
 }
-</script>
 
-<style scoped>
-.text-info {
-  color: var(--color-info);
+const manifest = ref<WonderLabManifest | null>(null)
+const result = ref<ReconcileResult | null>(null)
+const isDryRunning = ref(false)
+const isApplying = ref(false)
+const errorMessage = ref('')
+const successMessage = ref('')
+
+const isBusy = computed(() => isDryRunning.value || isApplying.value)
+const canApply = computed(
+  () =>
+    result.value?.mode === 'dry-run' &&
+    result.value.summary.conflicts === 0 &&
+    Boolean(manifest.value),
+)
+
+const summaryMetrics = computed(() => {
+  const summary = result.value?.summary
+  if (!summary) return []
+
+  return [
+    { label: 'Create', value: summary.creates },
+    { label: 'Update', value: summary.updates },
+    { label: 'Unchanged', value: summary.unchanged },
+    { label: 'Missing', value: summary.missingFromManifest },
+    { label: 'Conflicts', value: summary.conflicts },
+  ]
+})
+
+async function loadManifest(): Promise<WonderLabManifest> {
+  const response = await fetch('/wonderlab-components.json', {
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error('The generated WonderLab component manifest is unavailable.')
+  }
+
+  const data = (await response.json()) as WonderLabManifest
+  if (!Array.isArray(data.entries)) {
+    throw new Error('The WonderLab component manifest has an invalid format.')
+  }
+
+  return data
 }
-.text-success {
-  color: var(--color-success);
+
+async function reconcile(mode: 'dry-run' | 'apply'): Promise<void> {
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  const activeManifest =
+    mode === 'apply' && manifest.value ? manifest.value : await loadManifest()
+  manifest.value = activeManifest
+
+  const response = await performFetch<ReconcileResult>(
+    '/api/components/reconcile',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        mode,
+        manifest: activeManifest,
+      }),
+    },
+  )
+
+  if (!response.success || !response.data) {
+    throw new Error(response.message || 'Component reconciliation failed.')
+  }
+
+  result.value = response.data
+  successMessage.value = response.message
 }
-.text-error {
-  color: var(--color-error);
+
+async function runDryRun(): Promise<void> {
+  isDryRunning.value = true
+
+  try {
+    await reconcile('dry-run')
+  } catch (error) {
+    result.value = null
+    manifest.value = null
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Component dry run failed.'
+  } finally {
+    isDryRunning.value = false
+  }
 }
-</style>
+
+async function applyPlan(): Promise<void> {
+  if (!canApply.value) return
+  isApplying.value = true
+
+  try {
+    await reconcile('apply')
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Component reconciliation failed.'
+  } finally {
+    isApplying.value = false
+  }
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+function formatChanges(changes: Record<string, string>): string {
+  return Object.entries(changes)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(' · ')
+}
+</script>

--- a/components/wonderlab/wonderlab-preview-host.vue
+++ b/components/wonderlab/wonderlab-preview-host.vue
@@ -1,0 +1,258 @@
+<!-- /components/wonderlab/wonderlab-preview-host.vue -->
+<template>
+  <section class="rounded-3xl border border-base-300 bg-base-200/60 p-3">
+    <header class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          Preview Harness
+        </p>
+        <h3 class="mt-1 truncate text-lg font-black">
+          {{ fixture?.title || componentName }}
+        </h3>
+        <p class="mt-1 break-all font-mono text-xs text-base-content/50">
+          {{ resolvedPath || expectedPath }}
+        </p>
+        <p
+          v-if="fixture?.description"
+          class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65"
+        >
+          {{ fixture.description }}
+        </p>
+      </div>
+
+      <div v-if="showControls" class="flex flex-wrap items-center gap-2">
+        <select
+          v-model="viewport"
+          class="select select-bordered select-xs rounded-xl bg-base-100"
+          aria-label="Preview viewport"
+        >
+          <option value="mobile">Mobile</option>
+          <option value="tablet">Tablet</option>
+          <option value="desktop">Desktop</option>
+          <option value="full">Full width</option>
+        </select>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs rounded-xl"
+          @click="resetPreview"
+        >
+          <Icon name="kind-icon:refresh" class="size-3.5" />
+          Reset
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="fixture?.skipReason"
+      class="mt-3 rounded-2xl border border-info/30 bg-info/10 p-4"
+    >
+      <div class="flex items-start gap-3">
+        <Icon name="kind-icon:info" class="mt-0.5 size-5 shrink-0 text-info" />
+        <div>
+          <p class="font-black text-info-content">Context fixture required</p>
+          <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+            {{ fixture.skipReason }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else-if="previewNotFound"
+      class="mt-3 rounded-2xl border border-dashed border-warning/40 bg-warning/5 p-5 text-center"
+    >
+      <Icon name="kind-icon:search" class="mx-auto size-8 text-warning" />
+      <p class="mt-2 font-black">Component source not found</p>
+      <p class="mt-1 text-sm text-base-content/60">
+        The manifest or database path may be stale. No database record was
+        changed.
+      </p>
+    </div>
+
+    <div
+      v-else-if="previewError"
+      class="mt-3 rounded-2xl border border-error/40 bg-error/5 p-4"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <p class="font-black text-error">Preview error contained</p>
+          <pre
+            class="mt-2 max-h-48 overflow-auto whitespace-pre-wrap text-xs text-error/80"
+          >{{ previewError }}</pre>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-error btn-outline btn-xs shrink-0 rounded-xl"
+          @click="resetPreview"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="mt-3 overflow-auto rounded-2xl border border-base-300 bg-base-100 p-4 shadow-inner"
+    >
+      <div
+        class="mx-auto w-full transition-[max-width] duration-200"
+        :class="viewportClass"
+        :style="previewStyle"
+      >
+        <Suspense v-if="dynamicComponent">
+          <component
+            :is="dynamicComponent"
+            :key="renderKey"
+            v-bind="fixture?.props || {}"
+          />
+
+          <template #fallback>
+            <div class="flex min-h-40 items-center justify-center">
+              <span class="loading loading-spinner loading-md text-primary" />
+            </div>
+          </template>
+        </Suspense>
+
+        <div v-else class="flex min-h-40 items-center justify-center">
+          <span class="loading loading-spinner loading-md text-primary" />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  computed,
+  defineAsyncComponent,
+  onErrorCaptured,
+  ref,
+  watch,
+} from 'vue'
+import {
+  getWonderLabPreviewFixture,
+  type WonderLabPreviewViewport,
+} from '@/utils/wonderlab/previewFixtures'
+
+const props = withDefaults(
+  defineProps<{
+    componentName: string
+    folderName: string
+    sourcePath?: string
+    showControls?: boolean
+  }>(),
+  {
+    sourcePath: '',
+    showControls: true,
+  },
+)
+
+const emit = defineEmits<{
+  resolved: [path: string]
+  error: [message: string]
+}>()
+
+const allModules = import.meta.glob('@/components/**/*.vue')
+const dynamicComponent = ref<ReturnType<typeof defineAsyncComponent> | null>(
+  null,
+)
+const resolvedPath = ref('')
+const previewNotFound = ref(false)
+const previewError = ref('')
+const renderKey = ref(0)
+const viewport = ref<WonderLabPreviewViewport>('desktop')
+
+const fixture = computed(() =>
+  getWonderLabPreviewFixture(props.componentName, props.sourcePath),
+)
+
+const expectedPath = computed(() => {
+  const name = props.componentName.replace(/\.vue$/i, '')
+  return `/components/${props.folderName}/${name}.vue`
+})
+
+const viewportClass = computed(() => {
+  switch (viewport.value) {
+    case 'mobile':
+      return 'max-w-sm'
+    case 'tablet':
+      return 'max-w-2xl'
+    case 'desktop':
+      return 'max-w-5xl'
+    default:
+      return 'max-w-none'
+  }
+})
+
+const previewStyle = computed(() => ({
+  minHeight: fixture.value?.minHeight || '12rem',
+}))
+
+function normalizedSourcePath(value: string): string {
+  const path = value.trim().replace(/\\/g, '/')
+  if (!path) return ''
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function buildCandidates(): string[] {
+  const name = props.componentName.replace(/\.vue$/i, '')
+  const explicit = normalizedSourcePath(props.sourcePath)
+
+  return [
+    explicit,
+    `/components/${props.folderName}/${name}.vue`,
+    `/components/content/${props.folderName}/${name}.vue`,
+    `/components/${name}.vue`,
+  ].filter((value, index, list) => Boolean(value) && list.indexOf(value) === index)
+}
+
+function resolveComponent(): void {
+  dynamicComponent.value = null
+  resolvedPath.value = ''
+  previewNotFound.value = false
+  previewError.value = ''
+  renderKey.value += 1
+  viewport.value = fixture.value?.viewport || 'desktop'
+
+  if (fixture.value?.skipReason) return
+
+  const matchedPath = buildCandidates().find((candidate) => allModules[candidate])
+  if (!matchedPath) {
+    previewNotFound.value = true
+    return
+  }
+
+  resolvedPath.value = matchedPath
+  emit('resolved', matchedPath)
+
+  dynamicComponent.value = defineAsyncComponent({
+    loader: allModules[matchedPath] as () => Promise<{ default: unknown }>,
+    timeout: 10_000,
+    onError(error, _retry, fail) {
+      const message = error instanceof Error ? error.message : String(error)
+      previewError.value = message
+      emit('error', message)
+      fail()
+    },
+  })
+}
+
+function resetPreview(): void {
+  resolveComponent()
+}
+
+watch(
+  () => [props.componentName, props.folderName, props.sourcePath],
+  resolveComponent,
+  { immediate: true },
+)
+
+onErrorCaptured((error) => {
+  const message = error instanceof Error ? error.message : String(error)
+  previewError.value = message
+  emit('error', message)
+  return false
+})
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -120,16 +120,18 @@ export default defineNuxtConfig({
 
   hooks: {
     'build:before': async () => {
-      if (process.env.NODE_ENV !== 'development') {
-        console.log('Skipping component JSON generation in production mode.')
-        return
-      }
-      const { execSync } = await import('node:child_process')
+      const { execFileSync } = await import('node:child_process')
+
       try {
-        const out = execSync('node utils/scripts/create-component-json.mjs')
-        console.log(out.toString())
-      } catch (err) {
-        console.error('Failed to generate components JSON:', err)
+        const output = execFileSync(
+          process.execPath,
+          ['utils/scripts/create-component-json.mjs'],
+          { encoding: 'utf8' },
+        )
+        console.log(output.trim())
+      } catch (error) {
+        console.error('Failed to generate WonderLab component manifest:', error)
+        throw error
       }
     },
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
     "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
+    "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
+    "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
+    "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "generatesmart": "node utils/scripts/generate-smart-icons.mjs"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
+    "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/server/api/components/[id].patch.ts
+++ b/server/api/components/[id].patch.ts
@@ -1,8 +1,12 @@
 // /server/api/components/[id].patch.ts
-import { defineEventHandler, createError, getRouterParam, readBody } from 'h3'
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
+import {
+  hasLegacyStatusUpdate,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
 
 type ComponentPatchBody = Partial<Component>
 
@@ -13,10 +17,6 @@ function getStringOrUndefined(value: unknown): string | undefined {
 function getStringOrNullOrUndefined(value: unknown): string | null | undefined {
   if (value === null) return null
   return typeof value === 'string' ? value : undefined
-}
-
-function getBooleanOrUndefined(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
 }
 
 function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
@@ -84,6 +84,9 @@ export default defineEventHandler(async (event) => {
       where: { id: componentId },
       select: {
         id: true,
+        isWorking: true,
+        underConstruction: true,
+        isBroken: true,
       },
     })
 
@@ -95,15 +98,18 @@ export default defineEventHandler(async (event) => {
     }
 
     const artImageId = getPositiveIntegerOrUndefined(body.artImageId)
-
     await assertArtImageExists(artImageId)
+
+    const normalizedStatus = hasLegacyStatusUpdate(body)
+      ? resolveLegacyStatusUpdate(existingComponent, body)
+      : null
 
     const updateData: Prisma.ComponentUpdateInput = {
       componentName: getStringOrUndefined(body.componentName),
       folderName: getStringOrUndefined(body.folderName),
-      isWorking: getBooleanOrUndefined(body.isWorking),
-      underConstruction: getBooleanOrUndefined(body.underConstruction),
-      isBroken: getBooleanOrUndefined(body.isBroken),
+      isWorking: normalizedStatus?.isWorking,
+      underConstruction: normalizedStatus?.underConstruction,
+      isBroken: normalizedStatus?.isBroken,
       title: getStringOrUndefined(body.title),
       notes: getStringOrNullOrUndefined(body.notes),
       ArtImage:

--- a/server/api/components/index.post.ts
+++ b/server/api/components/index.post.ts
@@ -1,8 +1,13 @@
 // /server/api/components/index.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
+import {
+  hasLegacyStatusUpdate,
+  legacyFieldsForComponentStatus,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
 
 type ComponentCreateBody = Partial<Component>
 
@@ -12,10 +17,6 @@ function getStringOrDefault(value: unknown, fallback: string): string {
 
 function getStringOrNull(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function getBooleanOrDefault(value: unknown, fallback: boolean): boolean {
-  return typeof value === 'boolean' ? value : fallback
 }
 
 function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
@@ -65,17 +66,33 @@ export default defineEventHandler(async (event) => {
     }
 
     const artImageId = getPositiveIntegerOrUndefined(componentData.artImageId)
-
     await assertArtImageExists(artImageId)
 
-    const baseData = {
+    const existingComponent = await prisma.component.findUnique({
+      where: { componentName },
+      select: {
+        isWorking: true,
+        underConstruction: true,
+        isBroken: true,
+      },
+    })
+
+    const statusWasProvided = hasLegacyStatusUpdate(componentData)
+    const createStatus = statusWasProvided
+      ? resolveLegacyStatusUpdate(
+          legacyFieldsForComponentStatus('UNREVIEWED'),
+          componentData,
+        )
+      : legacyFieldsForComponentStatus('UNREVIEWED')
+    const updateStatus =
+      statusWasProvided && existingComponent
+        ? resolveLegacyStatusUpdate(existingComponent, componentData)
+        : statusWasProvided
+          ? createStatus
+          : null
+
+    const commonData = {
       folderName,
-      isWorking: getBooleanOrDefault(componentData.isWorking, true),
-      underConstruction: getBooleanOrDefault(
-        componentData.underConstruction,
-        false,
-      ),
-      isBroken: getBooleanOrDefault(componentData.isBroken, false),
       title: getStringOrDefault(componentData.title, componentName),
       notes: getStringOrNull(componentData.notes),
       updatedAt: new Date(),
@@ -84,18 +101,30 @@ export default defineEventHandler(async (event) => {
             connect: { id: artImageId },
           }
         : undefined,
-    } satisfies Omit<Prisma.ComponentUpdateInput, 'componentName'>
+    }
+
+    const updateData: Prisma.ComponentUpdateInput = {
+      ...commonData,
+      isWorking: updateStatus?.isWorking,
+      underConstruction: updateStatus?.underConstruction,
+      isBroken: updateStatus?.isBroken,
+    }
+
+    const createData: Prisma.ComponentCreateInput = {
+      ...commonData,
+      componentName,
+      createdAt: new Date(),
+      isWorking: createStatus.isWorking,
+      underConstruction: createStatus.underConstruction,
+      isBroken: createStatus.isBroken,
+    }
 
     const data = await prisma.component.upsert({
       where: {
         componentName,
       },
-      update: baseData,
-      create: {
-        ...baseData,
-        componentName,
-        createdAt: new Date(),
-      },
+      update: updateData,
+      create: createData,
       include: {
         ArtImage: {
           select: {

--- a/server/api/components/name/[name].patch.ts
+++ b/server/api/components/name/[name].patch.ts
@@ -1,14 +1,19 @@
-import { defineEventHandler, createError, readBody } from 'h3'
+// /server/api/components/name/[name].patch.ts
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
-import type { Component } from '~/prisma/generated/prisma/client'
+import type { Component, Prisma } from '~/prisma/generated/prisma/client'
+import {
+  hasLegacyStatusUpdate,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
 
 export default defineEventHandler(async (event) => {
   let response
   const componentName = event.context.params?.name
+  let requestBody: Partial<Component> | null = null
 
   try {
-    // Validate the component name from the URL params
     if (!componentName || !/^[a-zA-Z0-9\s-]+$/.test(componentName)) {
       throw createError({
         statusCode: 400,
@@ -16,29 +21,22 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Parse the incoming request body
-    const updatedComponentData: Partial<Component> = await readBody(event)
+    requestBody = await readBody<Partial<Component>>(event)
 
-    // Ensure the request body contains valid fields
-    if (
-      !updatedComponentData ||
-      Object.keys(updatedComponentData).length === 0
-    ) {
+    if (!requestBody || Object.keys(requestBody).length === 0) {
       throw createError({
         statusCode: 400,
         message: 'No valid component data provided.',
       })
     }
 
-    // Validate each field in the payload
-    if (updatedComponentData.title && updatedComponentData.title.length > 100) {
+    if (requestBody.title && requestBody.title.length > 100) {
       throw createError({
         statusCode: 400,
         message: 'Invalid title: Must not exceed 100 characters.',
       })
     }
 
-    // Optional: Check for disallowed or unexpected fields
     const allowedFields = [
       'folderName',
       'createdAt',
@@ -50,9 +48,10 @@ export default defineEventHandler(async (event) => {
       'notes',
       'artImageId',
     ]
-    const invalidFields = Object.keys(updatedComponentData).filter(
+    const invalidFields = Object.keys(requestBody).filter(
       (field) => !allowedFields.includes(field),
     )
+
     if (invalidFields.length > 0) {
       throw createError({
         statusCode: 400,
@@ -60,7 +59,6 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Fetch the existing component by name to ensure it exists
     const existingComponent = await prisma.component.findUnique({
       where: { componentName },
     })
@@ -72,27 +70,42 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Update the component in the database
+    const normalizedStatus = hasLegacyStatusUpdate(requestBody)
+      ? resolveLegacyStatusUpdate(existingComponent, requestBody)
+      : null
+
+    const {
+      isWorking: _isWorking,
+      underConstruction: _underConstruction,
+      isBroken: _isBroken,
+      ...nonStatusData
+    } = requestBody
+
+    const updateData: Prisma.ComponentUpdateInput = {
+      ...nonStatusData,
+      isWorking: normalizedStatus?.isWorking,
+      underConstruction: normalizedStatus?.underConstruction,
+      isBroken: normalizedStatus?.isBroken,
+    }
+
     const data = await prisma.component.update({
       where: { componentName },
-      data: updatedComponentData,
+      data: updateData,
     })
 
-    // Return the updated component in the expected response format
     response = {
       success: true,
       data,
-      statusCode: 200, // OK
+      statusCode: 200,
     }
     event.node.res.statusCode = 200
   } catch (error: unknown) {
     const handledError = errorHandler(error)
     console.error(`Failed to update component with name "${componentName}":`, {
       error: handledError,
-      requestBody: await readBody(event),
+      requestBody,
     })
 
-    // Set response and status code based on the handled error
     event.node.res.statusCode = handledError.statusCode || 500
     response = {
       success: false,

--- a/server/api/components/reconcile.post.ts
+++ b/server/api/components/reconcile.post.ts
@@ -1,0 +1,149 @@
+// /server/api/components/reconcile.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '../../utils/error'
+import { requireAdminApiUser } from '../../utils/authGuard'
+import {
+  buildComponentReconcilePlan,
+  parseWonderLabManifest,
+} from '../../utils/wonderlabComponentReconcile'
+
+ type ReconcileMode = 'dry-run' | 'apply'
+
+ type ReconcileRequestBody = {
+  mode?: ReconcileMode
+  manifest?: unknown
+}
+
+function parseMode(value: unknown): ReconcileMode {
+  if (value === undefined || value === 'dry-run') return 'dry-run'
+  if (value === 'apply') return 'apply'
+
+  throw createError({
+    statusCode: 400,
+    message: 'Reconciliation mode must be "dry-run" or "apply".',
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const body = await readBody<ReconcileRequestBody>(event)
+    const mode = parseMode(body?.mode)
+
+    let manifest
+    try {
+      manifest = parseWonderLabManifest(body?.manifest)
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message:
+          error instanceof Error ? error.message : 'Invalid component manifest.',
+      })
+    }
+
+    const existingComponents = await prisma.component.findMany({
+      orderBy: { id: 'asc' },
+    })
+    const plan = buildComponentReconcilePlan(manifest, existingComponents)
+
+    if (mode === 'apply' && plan.conflicts.length) {
+      throw createError({
+        statusCode: 409,
+        message:
+          'Component reconciliation has naming conflicts. Review the dry-run result before applying.',
+        data: {
+          conflicts: plan.conflicts,
+        },
+      })
+    }
+
+    let applied = false
+
+    if (mode === 'apply') {
+      await prisma.$transaction(async (tx) => {
+        for (const action of plan.updates) {
+          if (!action.existingId) continue
+
+          await tx.component.update({
+            where: { id: action.existingId },
+            data: {
+              componentName: action.changes.componentName,
+              folderName: action.changes.folderName,
+              updatedAt: new Date(),
+            },
+          })
+        }
+
+        for (const action of plan.creates) {
+          await tx.component.create({
+            data: {
+              componentName: action.componentName,
+              folderName: action.changes.folderName || 'root',
+              title: action.componentName,
+              notes: null,
+              isWorking: false,
+              underConstruction: false,
+              isBroken: false,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          })
+        }
+      })
+
+      applied = true
+    }
+
+    const summary = {
+      creates: plan.creates.length,
+      updates: plan.updates.length,
+      unchanged: plan.unchanged.length,
+      missingFromManifest: plan.missingFromManifest.length,
+      conflicts: plan.conflicts.length,
+    }
+
+    return {
+      success: true,
+      message:
+        mode === 'apply'
+          ? 'Component reconciliation applied without deleting unmatched records.'
+          : 'Component reconciliation dry run complete. No database records were changed.',
+      data: {
+        mode,
+        applied,
+        requestedBy: {
+          id: auth.user.id,
+          username: auth.user.username,
+        },
+        manifest: {
+          version: manifest.version,
+          generatedAt: manifest.generatedAt,
+          count: manifest.count,
+        },
+        summary,
+        plan: {
+          creates: plan.creates,
+          updates: plan.updates,
+          unchanged: plan.unchanged,
+          missingFromManifest: plan.missingFromManifest,
+          conflicts: plan.conflicts,
+        },
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to reconcile WonderLab components.',
+      data:
+        error && typeof error === 'object' && 'data' in error
+          ? (error as { data?: unknown }).data
+          : null,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/api/reactions/component/[id].get.ts
+++ b/server/api/reactions/component/[id].get.ts
@@ -1,59 +1,54 @@
 // /server/api/reactions/component/[id].get.ts
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { errorHandler } from '../../../utils/error'
 import prisma from '../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
-  let componentId
-  try {
-    // Extract componentId from the route parameters
-    componentId = Number(event.context.params?.id)
+  const componentId = Number(getRouterParam(event, 'id'))
 
-    // Validate componentId
-    if (isNaN(componentId) || componentId <= 0) {
-      event.node.res.statusCode = 400
-      throw new Error('A valid component ID is required.')
+  try {
+    if (!Number.isInteger(componentId) || componentId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'A valid component ID is required.',
+      })
     }
 
-    // Fetch reactions associated with the given componentId
     const data = await prisma.reaction.findMany({
       where: { componentId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       include: {
-        User: true, // Include user data associated with the reaction
+        User: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+            avatarImage: true,
+            Role: true,
+            isPublic: true,
+          },
+        },
       },
     })
 
-    if (!data || data.length === 0) {
-      event.node.res.statusCode = 404
-      return {
-        success: false,
-        data: {
-          message: `No reactions found for component with ID ${componentId}.`,
-        },
-      }
-    }
-
-    // Return the reactions wrapped in a data object
     event.node.res.statusCode = 200
+
     return {
       success: true,
       data,
+      statusCode: 200,
     }
   } catch (error: unknown) {
-    console.error(
-      `Error fetching reactions for component ID ${event.context.params?.id}:`,
-      error,
-    )
-    // Standardized error handling with errorHandler
     const handledError = errorHandler(error)
     event.node.res.statusCode = handledError.statusCode || 500
+
     return {
       success: false,
-      data: {
-        message:
-          handledError.message ||
-          `Failed to retrieve reactions for component with ID ${componentId}.`,
-      },
+      message:
+        handledError.message ||
+        `Failed to retrieve reactions for component with ID ${componentId}.`,
+      data: [],
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/utils/wonderlabComponentReconcile.ts
+++ b/server/utils/wonderlabComponentReconcile.ts
@@ -1,0 +1,247 @@
+// /server/utils/wonderlabComponentReconcile.ts
+import type { Component } from '~/prisma/generated/prisma/client'
+
+export type WonderLabManifestEntry = {
+  sourceKey: string
+  sourcePath: string
+  sourceHash: string
+  componentName: string
+  slug: string
+  folderName: string
+}
+
+export type WonderLabManifest = {
+  version: number
+  generatedAt: string
+  componentRoot: string
+  count: number
+  entries: WonderLabManifestEntry[]
+}
+
+export type ComponentReconcileAction = {
+  kind: 'create' | 'update'
+  componentName: string
+  existingId?: number
+  changes: Record<string, string>
+}
+
+export type ComponentReconcileConflict = {
+  key: string
+  componentNames: string[]
+  reason: string
+}
+
+export type ComponentReconcilePlan = {
+  creates: ComponentReconcileAction[]
+  updates: ComponentReconcileAction[]
+  unchanged: string[]
+  missingFromManifest: Array<
+    Pick<Component, 'id' | 'componentName' | 'folderName'>
+  >
+  conflicts: ComponentReconcileConflict[]
+  matchedComponentIds: number[]
+}
+
+const MAX_MANIFEST_ENTRIES = 5000
+
+export function normalizeComponentName(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Manifest entry field "${field}" must be a non-empty string.`)
+  }
+
+  return value.trim()
+}
+
+export function parseWonderLabManifest(value: unknown): WonderLabManifest {
+  if (!value || typeof value !== 'object') {
+    throw new Error('A WonderLab component manifest is required.')
+  }
+
+  const input = value as Partial<WonderLabManifest>
+  if (input.version !== 1) {
+    throw new Error(
+      `Unsupported WonderLab manifest version: ${String(input.version)}.`,
+    )
+  }
+
+  if (!Array.isArray(input.entries)) {
+    throw new Error('Manifest entries must be an array.')
+  }
+
+  if (input.entries.length > MAX_MANIFEST_ENTRIES) {
+    throw new Error(
+      `Manifest exceeds the ${MAX_MANIFEST_ENTRIES} entry safety limit.`,
+    )
+  }
+
+  const entries = input.entries.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`Manifest entry ${index} must be an object.`)
+    }
+
+    const record = entry as Partial<WonderLabManifestEntry>
+    return {
+      sourceKey: requireString(
+        record.sourceKey,
+        `entries[${index}].sourceKey`,
+      ),
+      sourcePath: requireString(
+        record.sourcePath,
+        `entries[${index}].sourcePath`,
+      ),
+      sourceHash: requireString(
+        record.sourceHash,
+        `entries[${index}].sourceHash`,
+      ),
+      componentName: requireString(
+        record.componentName,
+        `entries[${index}].componentName`,
+      ),
+      slug: requireString(record.slug, `entries[${index}].slug`),
+      folderName: requireString(
+        record.folderName,
+        `entries[${index}].folderName`,
+      ),
+    }
+  })
+
+  if (typeof input.count === 'number' && input.count !== entries.length) {
+    throw new Error(
+      `Manifest count mismatch: declared ${input.count}, received ${entries.length}.`,
+    )
+  }
+
+  return {
+    version: 1,
+    generatedAt:
+      typeof input.generatedAt === 'string'
+        ? input.generatedAt
+        : new Date(0).toISOString(),
+    componentRoot:
+      typeof input.componentRoot === 'string' && input.componentRoot.trim()
+        ? input.componentRoot.trim()
+        : 'components',
+    count: entries.length,
+    entries,
+  }
+}
+
+export function buildComponentReconcilePlan(
+  manifest: WonderLabManifest,
+  existingComponents: Component[],
+): ComponentReconcilePlan {
+  const conflicts: ComponentReconcileConflict[] = []
+  const creates: ComponentReconcileAction[] = []
+  const updates: ComponentReconcileAction[] = []
+  const unchanged: string[] = []
+  const matchedComponentIds = new Set<number>()
+
+  const manifestByNormalizedName = new Map<string, WonderLabManifestEntry[]>()
+  for (const entry of manifest.entries) {
+    const key = normalizeComponentName(entry.componentName)
+    const group = manifestByNormalizedName.get(key) ?? []
+    group.push(entry)
+    manifestByNormalizedName.set(key, group)
+  }
+
+  for (const [key, entries] of manifestByNormalizedName) {
+    if (entries.length > 1) {
+      conflicts.push({
+        key,
+        componentNames: entries.map((entry) => entry.componentName),
+        reason:
+          'Multiple source components normalize to the same database component name. A source-path schema migration is required before these can be reconciled safely.',
+      })
+    }
+  }
+
+  const databaseByNormalizedName = new Map<string, Component[]>()
+  for (const component of existingComponents) {
+    const key = normalizeComponentName(component.componentName)
+    const group = databaseByNormalizedName.get(key) ?? []
+    group.push(component)
+    databaseByNormalizedName.set(key, group)
+  }
+
+  for (const [key, components] of databaseByNormalizedName) {
+    if (components.length > 1) {
+      conflicts.push({
+        key,
+        componentNames: components.map((component) => component.componentName),
+        reason:
+          'Multiple database rows normalize to the same component name. Resolve the duplicate before applying reconciliation.',
+      })
+    }
+  }
+
+  const blockedKeys = new Set(conflicts.map((conflict) => conflict.key))
+
+  for (const entry of manifest.entries) {
+    const normalizedName = normalizeComponentName(entry.componentName)
+    if (blockedKeys.has(normalizedName)) continue
+
+    const exact = existingComponents.find(
+      (component) => component.componentName === entry.componentName,
+    )
+    const normalizedMatches = databaseByNormalizedName.get(normalizedName) ?? []
+    const existing = exact ?? normalizedMatches[0]
+
+    if (!existing) {
+      creates.push({
+        kind: 'create',
+        componentName: entry.componentName,
+        changes: {
+          folderName: entry.folderName,
+        },
+      })
+      continue
+    }
+
+    matchedComponentIds.add(existing.id)
+
+    const changes: Record<string, string> = {}
+    if (existing.componentName !== entry.componentName) {
+      changes.componentName = entry.componentName
+    }
+    if (existing.folderName !== entry.folderName) {
+      changes.folderName = entry.folderName
+    }
+
+    if (Object.keys(changes).length) {
+      updates.push({
+        kind: 'update',
+        componentName: entry.componentName,
+        existingId: existing.id,
+        changes,
+      })
+    } else {
+      unchanged.push(entry.componentName)
+    }
+  }
+
+  const missingFromManifest = existingComponents
+    .filter((component) => !matchedComponentIds.has(component.id))
+    .map(({ id, componentName, folderName }) => ({
+      id,
+      componentName,
+      folderName,
+    }))
+
+  return {
+    creates,
+    updates,
+    unchanged,
+    missingFromManifest,
+    conflicts,
+    matchedComponentIds: [...matchedComponentIds],
+  }
+}

--- a/stores/componentStore.ts
+++ b/stores/componentStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { Component } from '~/prisma/generated/prisma/client'
 import {
   fetchComponentById as helperFetch,
@@ -14,12 +14,6 @@ import {
   loadSnapshot,
   markSnapshotActive,
 } from '@/stores/helpers/snapshotLoader'
-import { useErrorStore, ErrorType } from '@/stores/errorStore'
-
-interface Folder {
-  folderName: string
-  components: string[]
-}
 
 export const useComponentStore = defineStore('componentStore', () => {
   const components = ref<Component[]>([])
@@ -35,6 +29,7 @@ export const useComponentStore = defineStore('componentStore', () => {
 
   async function initialize() {
     if (isInitialized.value) return
+
     try {
       // performFetch (not raw fetch) so a dead DB trips the shared circuit
       // breaker instead of hanging every page that lists components.
@@ -79,9 +74,9 @@ export const useComponentStore = defineStore('componentStore', () => {
   }
 
   async function fetchComponentById(id: number) {
-    const comp = await helperFetch(id)
-    if (comp) selectedComponent.value = comp
-    return comp
+    const component = await helperFetch(id)
+    if (component) selectedComponent.value = component
+    return component
   }
 
   async function createComponent(component: Component) {
@@ -92,9 +87,7 @@ export const useComponentStore = defineStore('componentStore', () => {
 
   async function updateComponent(component: Component) {
     const updated = await helperUpdate(component)
-    const index = components.value.findIndex(
-      (c: { id: any }) => c.id === component.id,
-    )
+    const index = components.value.findIndex((entry) => entry.id === component.id)
     if (index !== -1) components.value[index] = updated
     return updated
   }
@@ -102,9 +95,7 @@ export const useComponentStore = defineStore('componentStore', () => {
   async function deleteComponent(id: number) {
     const success = await helperDelete(id)
     if (success) {
-      components.value = components.value.filter(
-        (c: { id: number }) => c.id !== id,
-      )
+      components.value = components.value.filter((entry) => entry.id !== id)
     }
     return success
   }
@@ -120,143 +111,15 @@ export const useComponentStore = defineStore('componentStore', () => {
     action: 'create' | 'update',
   ) {
     const result = await helperCreateOrUpdate(component, action)
+
     if (action === 'create') {
       components.value.push(result)
     } else {
-      const index = components.value.findIndex(
-        (c: { id: any }) => c.id === result.id,
-      )
+      const index = components.value.findIndex((entry) => entry.id === result.id)
       if (index !== -1) components.value[index] = result
     }
+
     return result
-  }
-
-  async function syncComponents(progressCallback?: (msg: string) => void) {
-    const errorStore = useErrorStore()
-
-    return errorStore.handleError(
-      async () => {
-        const log = (msg: string) => {
-          console.log(`[SyncComponents] ${msg}`)
-          if (progressCallback) progressCallback(msg)
-        }
-
-        log('Fetching components.json...')
-        const response = await fetch('/components.json')
-        if (!response.ok) throw new Error('Failed to fetch components.json')
-        const folderData: Folder[] = await response.json()
-
-        if (!Array.isArray(folderData)) {
-          throw new Error(
-            'Invalid data format: components.json must be an array',
-          )
-        }
-
-        log('Fetched components.json.')
-        log('Fetching existing components from the API...')
-        const apiData = await performFetch<Component[]>('/api/components')
-        if (!apiData.success || !Array.isArray(apiData.data)) {
-          throw new Error('Invalid API response: expected data array')
-        }
-
-        const apiComponents: Component[] = apiData.data
-        const matchedComponentIds = new Set<number>()
-
-        const normalize = (str: string) =>
-          str
-            .replace(/([a-z])([A-Z])/g, '$1-$2')
-            .replace(/[\s_]+/g, '-')
-            .toLowerCase()
-
-        for (const folder of folderData) {
-          for (const name of folder.components) {
-            const normalizedName = normalize(name)
-
-            const existing = apiComponents.find(
-              (c) => normalize(c.componentName) === normalizedName,
-            )
-            const directMatch = apiComponents.find(
-              (c) => c.componentName === name,
-            )
-
-            if (existing) {
-              if (directMatch && directMatch.id !== existing.id) {
-                log(`Merging "${existing.componentName}" into "${name}"`)
-
-                const patchRes = await performFetch<Component>(
-                  `/api/components/${directMatch.id}`,
-                  {
-                    method: 'PATCH',
-                    body: JSON.stringify({
-                      folderName: folder.folderName,
-                      updatedAt: new Date(),
-                    }),
-                  },
-                )
-
-                if (!patchRes.success)
-                  throw new Error(
-                    `Failed to update folderName: ${patchRes.message}`,
-                  )
-
-                matchedComponentIds.add(directMatch.id)
-                await deleteComponent(existing.id)
-                log(`Deleted duplicate "${existing.componentName}"`)
-              } else {
-                const patchRes = await performFetch<Component>(
-                  `/api/components/${existing.id}`,
-                  {
-                    method: 'PATCH',
-                    body: JSON.stringify({
-                      componentName: name,
-                      folderName: folder.folderName,
-                      updatedAt: new Date(),
-                    }),
-                  },
-                )
-
-                if (!patchRes.success)
-                  throw new Error(
-                    `Failed to update ${name}: ${patchRes.message}`,
-                  )
-
-                matchedComponentIds.add(existing.id)
-                log(`Updated: ${name}`)
-              }
-            } else {
-              const newComp: Omit<Component, 'id'> = {
-                componentName: name,
-                folderName: folder.folderName,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                isWorking: true,
-                underConstruction: false,
-                isBroken: false,
-                title: null,
-                notes: null,
-                artImageId: null,
-              }
-
-              const created = await createComponent(newComp as Component)
-              matchedComponentIds.add(created.id)
-              log(`Created: ${name}`)
-            }
-          }
-        }
-
-        const stale = apiComponents.filter(
-          (c) => !matchedComponentIds.has(c.id),
-        )
-        for (const comp of stale) {
-          log(`Deleting unmatched: ${comp.componentName}`)
-          await deleteComponent(comp.id)
-        }
-
-        log('Component sync complete.')
-      },
-      ErrorType.GENERAL_ERROR,
-      'Error syncing components',
-    )
   }
 
   return {
@@ -279,7 +142,6 @@ export const useComponentStore = defineStore('componentStore', () => {
     deleteComponent,
     findComponentByName,
     createOrUpdateComponent,
-    syncComponents,
   }
 })
 

--- a/utils/scripts/auditWonderLabPreviews.ts
+++ b/utils/scripts/auditWonderLabPreviews.ts
@@ -1,0 +1,138 @@
+// /utils/scripts/auditWonderLabPreviews.ts
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { getWonderLabPreviewFixture } from '../wonderlab/previewFixtures'
+
+const componentRoot = path.resolve(process.cwd(), 'components')
+const ignoredSegments = new Set(['abandonware', '__tests__', '__fixtures__'])
+const strict = process.argv.includes('--strict')
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join('/')
+}
+
+function shouldIgnore(relativePath: string): boolean {
+  return toPosix(relativePath)
+    .split('/')
+    .some((segment) => ignoredSegments.has(segment))
+}
+
+async function collectVueFiles(directory: string, files: string[] = []) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = path.relative(componentRoot, absolutePath)
+
+    if (shouldIgnore(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      await collectVueFiles(absolutePath, files)
+    } else if (entry.isFile() && entry.name.endsWith('.vue')) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+function extractTypeRequiredProps(source: string): string[] {
+  const matches = source.matchAll(/defineProps\s*<\s*\{([\s\S]*?)\}\s*>\s*\(/g)
+  const props = new Set<string>()
+
+  for (const match of matches) {
+    const body = match[1] || ''
+    const lines = body.split('\n')
+
+    for (const line of lines) {
+      const property = line.match(/^\s*([A-Za-z_$][\w$]*)\s*:\s*/)
+      if (property?.[1]) props.add(property[1])
+    }
+  }
+
+  return [...props]
+}
+
+function extractRuntimeRequiredProps(source: string): string[] {
+  const props = new Set<string>()
+  const objectMatch = source.match(/defineProps\s*\(\s*\{([\s\S]*?)\}\s*\)/)
+  const body = objectMatch?.[1] || ''
+  const propertyPattern = /([A-Za-z_$][\w$]*)\s*:\s*\{([\s\S]*?)\}(?:,|$)/g
+
+  for (const match of body.matchAll(propertyPattern)) {
+    if (/required\s*:\s*true/.test(match[2] || '') && match[1]) {
+      props.add(match[1])
+    }
+  }
+
+  return [...props]
+}
+
+function extractRequiredProps(source: string): string[] {
+  return [
+    ...new Set([
+      ...extractTypeRequiredProps(source),
+      ...extractRuntimeRequiredProps(source),
+    ]),
+  ].sort()
+}
+
+async function main() {
+  const files = await collectVueFiles(componentRoot)
+  const uncovered: Array<{
+    sourcePath: string
+    componentName: string
+    requiredProps: string[]
+    missingProps: string[]
+  }> = []
+  let covered = 0
+
+  for (const absolutePath of files) {
+    const source = await fs.readFile(absolutePath, 'utf8')
+    const requiredProps = extractRequiredProps(source)
+    if (!requiredProps.length) continue
+
+    const relativePath = toPosix(path.relative(componentRoot, absolutePath))
+    const sourcePath = `components/${relativePath}`
+    const componentName = path.basename(relativePath, '.vue')
+    const fixture = getWonderLabPreviewFixture(componentName, sourcePath)
+
+    if (fixture?.skipReason) {
+      covered += 1
+      continue
+    }
+
+    const fixtureProps = new Set(Object.keys(fixture?.props || {}))
+    const missingProps = requiredProps.filter((prop) => !fixtureProps.has(prop))
+
+    if (missingProps.length) {
+      uncovered.push({
+        sourcePath,
+        componentName,
+        requiredProps,
+        missingProps,
+      })
+    } else {
+      covered += 1
+    }
+  }
+
+  console.log(`WonderLab preview audit scanned ${files.length} Vue components.`)
+  console.log(`${covered} required-prop components have fixture coverage or an explicit skip reason.`)
+  console.log(`${uncovered.length} required-prop components still need preview coverage.`)
+
+  for (const item of uncovered) {
+    console.log(
+      `- ${item.sourcePath}: missing fixture props ${item.missingProps.join(', ')}`,
+    )
+  }
+
+  if (strict && uncovered.length) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error('WonderLab preview audit failed:', error)
+  process.exitCode = 1
+})

--- a/utils/scripts/create-component-json.mjs
+++ b/utils/scripts/create-component-json.mjs
@@ -1,32 +1,118 @@
-// create-component-json.ts
-import { promises as fs } from 'fs'
-import path from 'path'
+// /utils/scripts/create-component-json.mjs
+import { createHash } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
-async function generateComponentJSON() {
-  try {
-    const componentPath = path.resolve(process.cwd(), 'components/')
-    const folderNames = await fs.readdir(componentPath)
-    const folders = []
+const ROOT = process.cwd()
+const COMPONENT_ROOT = path.resolve(ROOT, 'components')
+const LEGACY_OUTPUT = path.resolve(ROOT, 'public/components.json')
+const MANIFEST_OUTPUT = path.resolve(ROOT, 'public/wonderlab-components.json')
 
-    for (const folderName of folderNames) {
-      const folderPath = path.join(componentPath, folderName)
-      const stat = await fs.stat(folderPath)
+const ignoredSegments = new Set(['abandonware', '__tests__', '__fixtures__'])
 
-      if (stat.isDirectory()) {
-        const componentFiles = await fs.readdir(folderPath)
-        const components = componentFiles
-          .filter((file) => file.endsWith('.vue'))
-          .map((file) => file.replace('.vue', ''))
-        folders.push({ folderName, components })
-      }
+function toPosix(value) {
+  return value.split(path.sep).join('/')
+}
+
+function toSlug(value) {
+  return value
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+function shouldIgnore(relativePath) {
+  const segments = toPosix(relativePath).split('/')
+  return segments.some((segment) => ignoredSegments.has(segment))
+}
+
+async function collectVueFiles(directory, files = []) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = path.relative(COMPONENT_ROOT, absolutePath)
+
+    if (shouldIgnore(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      await collectVueFiles(absolutePath, files)
+      continue
     }
 
-    const outputPath = path.resolve(process.cwd(), 'public/components.json')
-    await fs.writeFile(outputPath, JSON.stringify(folders, null, 2))
-    console.log('Component JSON generated successfully:', outputPath)
-  } catch (error) {
-    console.error('Failed to generate component JSON:', error)
+    if (entry.isFile() && entry.name.endsWith('.vue')) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+async function buildManifestEntry(absolutePath) {
+  const relativePath = toPosix(path.relative(COMPONENT_ROOT, absolutePath))
+  const sourcePath = `components/${relativePath}`
+  const folderName = toPosix(path.dirname(relativePath))
+  const componentName = path.basename(relativePath, '.vue')
+  const source = await fs.readFile(absolutePath)
+  const sourceHash = createHash('sha256').update(source).digest('hex')
+
+  return {
+    sourceKey: sourcePath.toLowerCase(),
+    sourcePath,
+    sourceHash,
+    componentName,
+    slug: toSlug(relativePath),
+    folderName: folderName === '.' ? 'root' : folderName,
   }
 }
 
-generateComponentJSON()
+function buildLegacyFolders(entries) {
+  const folders = new Map()
+
+  for (const entry of entries) {
+    const names = folders.get(entry.folderName) ?? []
+    names.push(entry.componentName)
+    folders.set(entry.folderName, names)
+  }
+
+  return [...folders.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([folderName, components]) => ({
+      folderName,
+      components: components.sort((left, right) => left.localeCompare(right)),
+    }))
+}
+
+async function generateComponentManifest() {
+  const files = await collectVueFiles(COMPONENT_ROOT)
+  const entries = await Promise.all(files.map(buildManifestEntry))
+  entries.sort((left, right) => left.sourcePath.localeCompare(right.sourcePath))
+
+  const manifest = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    componentRoot: 'components',
+    count: entries.length,
+    entries,
+  }
+
+  await fs.mkdir(path.dirname(MANIFEST_OUTPUT), { recursive: true })
+  await Promise.all([
+    fs.writeFile(MANIFEST_OUTPUT, `${JSON.stringify(manifest, null, 2)}\n`),
+    fs.writeFile(
+      LEGACY_OUTPUT,
+      `${JSON.stringify(buildLegacyFolders(entries), null, 2)}\n`,
+    ),
+  ])
+
+  console.log(
+    `Generated ${entries.length} WonderLab component entries at ${path.relative(ROOT, MANIFEST_OUTPUT)}.`,
+  )
+}
+
+generateComponentManifest().catch((error) => {
+  console.error('Failed to generate WonderLab component manifest:', error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyWonderLabReconcile.ts
+++ b/utils/scripts/verifyWonderLabReconcile.ts
@@ -1,0 +1,105 @@
+// /utils/scripts/verifyWonderLabReconcile.ts
+import assert from 'node:assert/strict'
+import type { Component } from '~/prisma/generated/prisma/client'
+import {
+  buildComponentReconcilePlan,
+  parseWonderLabManifest,
+  type WonderLabManifest,
+} from '@/server/utils/wonderlabComponentReconcile'
+
+function component(
+  id: number,
+  componentName: string,
+  folderName: string,
+): Component {
+  return {
+    id,
+    componentName,
+    folderName,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    isWorking: false,
+    underConstruction: false,
+    isBroken: false,
+    title: componentName,
+    notes: null,
+    artImageId: null,
+  }
+}
+
+function manifest(
+  entries: WonderLabManifest['entries'],
+): WonderLabManifest {
+  return {
+    version: 1,
+    generatedAt: '2026-07-18T00:00:00.000Z',
+    componentRoot: 'components',
+    count: entries.length,
+    entries,
+  }
+}
+
+function entry(componentName: string, folderName: string) {
+  const sourcePath = `components/${folderName}/${componentName}.vue`
+
+  return {
+    sourceKey: sourcePath.toLowerCase(),
+    sourcePath,
+    sourceHash: 'a'.repeat(64),
+    componentName,
+    slug: `${folderName}-${componentName}`.toLowerCase(),
+    folderName,
+  }
+}
+
+const safePlan = buildComponentReconcilePlan(
+  manifest([entry('ExistingCard', 'cards'), entry('NewPanel', 'panels')]),
+  [
+    component(1, 'ExistingCard', 'legacy'),
+    component(2, 'RetiredWidget', 'legacy'),
+  ],
+)
+
+assert.equal(safePlan.updates.length, 1)
+assert.deepEqual(safePlan.updates[0]?.changes, { folderName: 'cards' })
+assert.equal(safePlan.creates.length, 1)
+assert.equal(safePlan.creates[0]?.componentName, 'NewPanel')
+assert.deepEqual(
+  safePlan.missingFromManifest.map((item) => item.componentName),
+  ['RetiredWidget'],
+  'Unmatched database records must be reported rather than deleted.',
+)
+assert.equal(safePlan.conflicts.length, 0)
+
+const renamePlan = buildComponentReconcilePlan(
+  manifest([entry('NarratorCard', 'navigation')]),
+  [component(3, 'narrator-card', 'legacy')],
+)
+
+assert.equal(renamePlan.updates.length, 1)
+assert.deepEqual(renamePlan.updates[0]?.changes, {
+  componentName: 'NarratorCard',
+  folderName: 'navigation',
+})
+
+const conflictPlan = buildComponentReconcilePlan(
+  manifest([
+    entry('StatusBadge', 'one'),
+    entry('status-badge', 'two'),
+  ]),
+  [],
+)
+
+assert.equal(conflictPlan.conflicts.length, 1)
+assert.equal(conflictPlan.creates.length, 0)
+
+assert.throws(
+  () =>
+    parseWonderLabManifest({
+      ...manifest([entry('Counted', 'cards')]),
+      count: 2,
+    }),
+  /count mismatch/i,
+)
+
+console.log('WonderLab component reconciliation verification passed.')

--- a/utils/scripts/verifyWonderLabStatus.ts
+++ b/utils/scripts/verifyWonderLabStatus.ts
@@ -1,0 +1,67 @@
+// /utils/scripts/verifyWonderLabStatus.ts
+import assert from 'node:assert/strict'
+import {
+  getLegacyComponentStatus,
+  hasLegacyStatusUpdate,
+  legacyFieldsForComponentStatus,
+  resolveLegacyStatusUpdate,
+} from '@/utils/wonderlab/componentStatus'
+
+assert.equal(
+  getLegacyComponentStatus({
+    isWorking: true,
+    underConstruction: true,
+    isBroken: true,
+  }),
+  'BROKEN',
+  'Legacy contradictions must resolve deterministically.',
+)
+
+assert.deepEqual(legacyFieldsForComponentStatus('UNREVIEWED'), {
+  isWorking: false,
+  underConstruction: false,
+  isBroken: false,
+})
+
+assert.deepEqual(
+  resolveLegacyStatusUpdate(
+    {
+      isWorking: false,
+      underConstruction: false,
+      isBroken: true,
+    },
+    {
+      isWorking: true,
+    },
+  ),
+  {
+    isWorking: true,
+    underConstruction: false,
+    isBroken: false,
+  },
+  'Enabling one state must replace the previous state.',
+)
+
+assert.deepEqual(
+  resolveLegacyStatusUpdate(
+    {
+      isWorking: false,
+      underConstruction: true,
+      isBroken: false,
+    },
+    {
+      underConstruction: false,
+    },
+  ),
+  {
+    isWorking: false,
+    underConstruction: false,
+    isBroken: false,
+  },
+  'Disabling the only active state must produce UNREVIEWED.',
+)
+
+assert.equal(hasLegacyStatusUpdate({ notes: 'No status change' } as never), false)
+assert.equal(hasLegacyStatusUpdate({ isBroken: false }), true)
+
+console.log('WonderLab component status verification passed.')

--- a/utils/wonderlab/componentStatus.ts
+++ b/utils/wonderlab/componentStatus.ts
@@ -1,0 +1,83 @@
+// /utils/wonderlab/componentStatus.ts
+export type LegacyComponentStatus =
+  | 'UNREVIEWED'
+  | 'WORKING'
+  | 'UNDER_CONSTRUCTION'
+  | 'BROKEN'
+
+export type LegacyComponentStatusFields = {
+  isWorking?: boolean | null
+  underConstruction?: boolean | null
+  isBroken?: boolean | null
+}
+
+export type CanonicalLegacyStatusFields = {
+  isWorking: boolean
+  underConstruction: boolean
+  isBroken: boolean
+}
+
+export function getLegacyComponentStatus(
+  component: LegacyComponentStatusFields,
+): LegacyComponentStatus {
+  if (component.isBroken) return 'BROKEN'
+  if (component.underConstruction) return 'UNDER_CONSTRUCTION'
+  if (component.isWorking) return 'WORKING'
+  return 'UNREVIEWED'
+}
+
+export function legacyFieldsForComponentStatus(
+  status: LegacyComponentStatus,
+): CanonicalLegacyStatusFields {
+  return {
+    isWorking: status === 'WORKING',
+    underConstruction: status === 'UNDER_CONSTRUCTION',
+    isBroken: status === 'BROKEN',
+  }
+}
+
+export function hasLegacyStatusUpdate(
+  patch: LegacyComponentStatusFields,
+): boolean {
+  return (
+    typeof patch.isWorking === 'boolean' ||
+    typeof patch.underConstruction === 'boolean' ||
+    typeof patch.isBroken === 'boolean'
+  )
+}
+
+export function resolveLegacyStatusUpdate(
+  existing: LegacyComponentStatusFields,
+  patch: LegacyComponentStatusFields,
+): CanonicalLegacyStatusFields {
+  // A newly enabled state is an explicit selection and should replace the old
+  // state even when callers send only one boolean field.
+  if (patch.isBroken === true) {
+    return legacyFieldsForComponentStatus('BROKEN')
+  }
+  if (patch.underConstruction === true) {
+    return legacyFieldsForComponentStatus('UNDER_CONSTRUCTION')
+  }
+  if (patch.isWorking === true) {
+    return legacyFieldsForComponentStatus('WORKING')
+  }
+
+  // False-only patches clear the supplied flags and preserve any other
+  // existing state. The result is normalized before it reaches Prisma.
+  return legacyFieldsForComponentStatus(
+    getLegacyComponentStatus({
+      isWorking:
+        typeof patch.isWorking === 'boolean'
+          ? patch.isWorking
+          : existing.isWorking,
+      underConstruction:
+        typeof patch.underConstruction === 'boolean'
+          ? patch.underConstruction
+          : existing.underConstruction,
+      isBroken:
+        typeof patch.isBroken === 'boolean'
+          ? patch.isBroken
+          : existing.isBroken,
+    }),
+  )
+}

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -1,0 +1,90 @@
+// /utils/wonderlab/previewFixtures.ts
+export type WonderLabPreviewViewport = 'mobile' | 'tablet' | 'desktop' | 'full'
+
+export type WonderLabPreviewFixture = {
+  title?: string
+  description?: string
+  props?: Record<string, unknown>
+  viewport?: WonderLabPreviewViewport
+  minHeight?: string
+  skipReason?: string
+}
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'component-card': {
+    title: 'Component Card specimen',
+    description:
+      'Uses a synthetic museum component and disables live reactions and edit actions.',
+    viewport: 'desktop',
+    minHeight: '20rem',
+    props: {
+      component: {
+        id: -1,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        folderName: 'wonderlab',
+        componentName: 'component-card',
+        isWorking: true,
+        underConstruction: false,
+        isBroken: false,
+        title: 'Museum Component Card',
+        notes:
+          'A safe fixture used to demonstrate the Component Card without requiring a database record.',
+        artImageId: null,
+      },
+      showReaction: false,
+      allowEdit: false,
+      allowCopyName: false,
+      showMeta: true,
+      showSelectButton: false,
+    },
+  },
+  'component-sync': {
+    title: 'Component reconciliation',
+    skipReason:
+      'This admin tool requires an authenticated admin session and performs deliberate server actions. Preview it from the WonderLab admin surface instead.',
+  },
+  'workspace-narrator': {
+    title: 'Workspace Narrator',
+    skipReason:
+      'The narrator remote depends on active page, narrator, expression, chat, and layout stores. It needs a dedicated workspace fixture rather than a naked mount.',
+  },
+  'narrator-chat': {
+    title: 'Narrator Chat',
+    skipReason:
+      'Narrator Chat depends on a resolved narrator identity, thread context, and chat server selection.',
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabPreviewFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function hasWonderLabPreviewFixture(
+  componentName: string,
+  sourcePath = '',
+): boolean {
+  return Boolean(getWonderLabPreviewFixture(componentName, sourcePath))
+}
+
+export function listWonderLabPreviewFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## Consolidated WonderLab integration

This PR now targets `main` directly and contains the remaining net work after #388 merged:

- safe admin-only component reconciliation with dry-run/apply;
- removal of destructive client-side sync;
- canonical legacy-status normalization and tests;
- preview fixture catalog, isolated preview host, viewport/reset controls, and coverage audit;
- safe component review endpoint and reusable review feed;
- public author projection instead of exposing full User rows;
- no personality-authored content generation or seeding.

## Safety

- No automatic component deletion.
- No automatic missing-record reclassification.
- Apply is blocked on naming conflicts.
- Database writes are transactional.
- New components default to unreviewed.
- Preview failures remain local to the exhibit.
- Empty review collections return HTTP 200 with an empty array.

This consolidates and supersedes #393, #394, and #395 after the manifest foundation in #388 was merged.

Part of #381.