### PR TITLE
ai-art-academy/t-010: add aria-label to model-unlink button in image-upload.vue

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -370,6 +370,7 @@
               <button
                 type="button"
                 class="btn btn-ghost btn-xs ml-auto h-6 min-h-0 px-2"
+                :aria-label="`Unlink ${connectedModelType} #${connectedModelId}`"
                 @click="clearModelSelection"
               >
                 <Icon name="mdi:close" class="h-3 w-3" />


### PR DESCRIPTION
## Summary
- Recurring `t-010` Academy continuous-improvement cycle (conductor repo), lane 1: front-end polish pass, per the checklist's rotation rule (previous cycle ran lane 4, curriculum depth).
- Dispatched an Explore subagent over all Academy components (`academy-manager.vue`, `academy-timeline.vue`, `academy-styles-browser.vue`, `academy-style-detail.vue`, `academy-remix.vue`) plus `art-styler.vue` and `image-upload.vue`, explicitly excluding everything already fixed by PRs #275, #301, #332, #371, #380, #383, #385, #387.
- Found: `image-upload.vue`'s connected-model "unlink" button (icon-only, `mdi:close`) had zero accessible name — no `title`, no `aria-label`. Every other icon-only button in the same file has at least a `title` fallback (e.g. the file-remove button uses a dynamic `:title`). A screen reader announced this one only as "button", with no indication it unlinks the currently-connected model.
- Fix: added a dynamic `:aria-label="`Unlink ${connectedModelType} #${connectedModelId}`"` mirroring the exact pattern the file already uses for its file-remove button and its upload drop-zone's `aria-label="Upload images"`.
- Additive, one-attribute change — no logic touched.

## Flags for Reviewer
None — purely additive a11y attribute, no behavior change.

## Test plan
- [x] `npx eslint components/art/image-upload.vue` — clean
- [x] `npx prettier --check components/art/image-upload.vue` — clean
- [x] Full-project `npm run test` (`vue-tsc --noEmit`, provisioned via conductor's `provision_kind_robots_deps.sh`) — exit 0, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189dC9C9mKCBhZ73EqNrkKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0189dC9C9mKCBhZ73EqNrkKQ)_