### PR TITLE
global-ui/t-023: migrate generic solid-panel wrappers onto .kr-panel / .kr-panel-muted

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -3,7 +3,7 @@
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
     <div
       v-if="isLoadingManager"
-      class="flex h-full min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6"
+      class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"
     >
       <div class="flex flex-col items-center gap-3 text-center">
         <span class="loading loading-spinner loading-lg text-primary" />

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -111,7 +111,7 @@
     <!-- Empty state -->
     <div
       v-if="!currentArtImage"
-      class="flex min-h-72 flex-col items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-center text-base-content/55"
+      class="flex min-h-72 flex-col items-center justify-center kr-panel text-center text-base-content/55"
     >
       <Icon name="kind-icon:image" class="h-12 w-12 text-primary" />
       <p class="mt-2 text-lg font-bold">No image selected.</p>

--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -3,7 +3,7 @@
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
     <div
       v-if="isLoadingManager"
-      class="flex h-full min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6"
+      class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"
     >
       <div class="flex flex-col items-center gap-3 text-center">
         <span class="loading loading-spinner loading-lg text-primary" />

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -283,7 +283,7 @@
 
       <div
         v-else-if="filteredBots.length === 0"
-        class="flex h-full flex-col items-center justify-center gap-3 rounded-2xl border border-base-300 bg-base-200 p-6 text-center text-base-content/60"
+        class="flex h-full flex-col items-center justify-center gap-3 kr-panel-muted text-center text-base-content/60"
       >
         <Icon name="kind-icon:robot" class="h-12 w-12 text-primary" />
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -168,7 +168,7 @@
 
       <div
         v-else-if="filteredCharacters.length === 0"
-        class="flex h-full flex-col items-center justify-center gap-3 rounded-2xl border border-base-300 bg-base-200 p-6 text-center text-base-content/60"
+        class="flex h-full flex-col items-center justify-center gap-3 kr-panel-muted text-center text-base-content/60"
       >
         <Icon name="kind-icon:theater" class="h-12 w-12 text-primary" />
 

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -279,7 +279,7 @@
 
       <div
         v-else-if="filteredRewards.length === 0"
-        class="flex h-full flex-col items-center justify-center gap-3 rounded-2xl border border-base-300 bg-base-200 p-6 text-center text-base-content/60"
+        class="flex h-full flex-col items-center justify-center gap-3 kr-panel-muted text-center text-base-content/60"
       >
         <Icon name="kind-icon:gift" class="h-10 w-10" />
 

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -13,7 +13,7 @@
 
     <div
       v-if="!activeUserId"
-      class="flex min-h-48 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-center"
+      class="flex min-h-48 flex-1 items-center justify-center kr-panel text-center"
     >
       <div>
         <p class="text-lg font-black">No user selected.</p>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -100,7 +100,7 @@
 
     <div
       v-else
-      class="flex min-h-48 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-center"
+      class="flex min-h-48 flex-1 items-center justify-center kr-panel text-center"
     >
       <div>
         <p class="text-lg font-black">No user profile available.</p>

--- a/components/wonderlab/lab-interact.vue
+++ b/components/wonderlab/lab-interact.vue
@@ -141,7 +141,7 @@
 
           <div
             v-else-if="filteredComponents.length === 0"
-            class="flex h-full flex-col items-center justify-center rounded-2xl border border-base-300 bg-base-200 p-6 text-center text-base-content/55"
+            class="flex h-full flex-col items-center justify-center kr-panel-muted text-center text-base-content/55"
           >
             <Icon name="kind-icon:sparkles" class="h-12 w-12 text-accent" />
 

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -10,7 +10,7 @@
 
   <div
     v-else-if="isPageLoading"
-    class="flex h-full min-h-64 flex-col items-center justify-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-6 text-center"
+    class="flex h-full min-h-64 flex-col items-center justify-center gap-3 kr-panel text-center"
   >
     <Icon name="kind-icon:spinner" class="h-10 w-10 animate-spin text-info" />
 
@@ -36,7 +36,7 @@
 
   <div
     v-else
-    class="flex h-full min-h-64 flex-col items-center justify-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-6 text-center"
+    class="flex h-full min-h-64 flex-col items-center justify-center gap-3 kr-panel text-center"
   >
     <Icon name="kind-icon:alert" class="h-10 w-10 text-warning" />
 


### PR DESCRIPTION
### Task
global-ui/t-023: item (d) — generic-solid-panel migration onto .kr-panel/.kr-panel-muted (kind: software)

### What changed / what I produced
- Swapped hand-written `rounded-2xl border border-base-300 bg-base-100 p-6` → `.kr-panel`, and `rounded-2xl border border-base-300 bg-base-200 p-6` → `.kr-panel-muted`, in 10 files where the class list was an exact match to the shared utility (defined in `assets/css/tailwind.css`):
  - `components/art/art-manager.vue` — loading-state wrapper
  - `components/academy/academy-manager.vue` — loading-state wrapper
  - `pages/[...slug].vue` — "Loading page…" and "Page not found" states (2 occurrences)
  - `components/art/art-interact.vue` — "No image selected" empty state
  - `components/user/user-galleries.vue` — "No user selected" placeholder
  - `components/user/user-panel.vue` — "No user profile available" (guest mode) placeholder
  - `components/bots/bot-gallery.vue` — "No bots found" empty state
  - `components/characters/character-gallery.vue` — empty-state gallery card
  - `components/rewards/reward-gallery.vue` — "No rewards found" empty state
  - `components/wonderlab/lab-interact.vue` — "No components found" empty state
- Purely a class-name swap onto an identical Tailwind `@apply` rule — no layout, spacing, or color change.
- Left two borderline cases untouched pending manual review (not in this PR): `components/art/art-reactions.vue` (has `shadow-lg`, not `shadow-sm`) and `components/builder/builder-manager.vue`'s confirmation-modal card (has `shadow-xl`, sits inside a bespoke modal scrim) — both technically match the base 4 classes but carry an intentional shadow variant that deviates from the plain `.kr-panel` look.
- `components/butterfly/butterfly-demo.vue` excluded as bespoke (custom `butterfly-card` class + `shadow-lg`).
- `code-library.vue`'s class-map item from t-023's option (e) is moot — that file lives in `abandonware/`, not live code.
- Items (a) art status surfaces, (b) `/30`-opacity notices, (c) stage-manager pills remain deferred, same as before — they need a preview-deploy eyeball this sandbox can't do (no DB).

### How I verified
- `eslint` on all 10 changed files: 2 pre-existing errors (`character-gallery.vue` unused var, `pages/[...slug].vue` multi-root template) — confirmed via `git stash` that both exist identically on `main` before this diff, unrelated to this change.
- `prettier --check` flagged 5 of the 10 files — confirmed via `git stash` that the same 5 files already fail prettier on `main` (pre-existing repo-wide drift); left untouched per this repo's established practice of not shipping unrelated reformats, and CI doesn't gate on lint/prettier.
- Full-project `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`), provisioned via conductor's `provision_kind_robots_deps.sh`: exit 0, no errors.

### Stakes
reversible

### Flags for Reviewer
- None — purely mechanical, verified class-for-class equivalent to the pre-existing hand-written Tailwind classes.

### Kaizen suggestion
The two borderline "matches the 4 core classes but carries a shadow variant" cases (`art-reactions.vue`, `builder-manager.vue`'s modal card) are worth a follow-up decision: either accept the shadow difference and migrate them too, or codify a `.kr-panel-elevated` variant with `shadow-lg`/`shadow-xl` for modal-context panels so they have a canonical home instead of staying hand-written indefinitely.

### Notes for reviewer
Conductor task global-ui/t-023 is at `status: review` pending this PR; will flip to `ready` (re-arms, task never reaches `done` — see t-023's own history of prior partial passes) once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyNcVZeJxSiMtGc44SaRn8)_