### PR TITLE
WonderLab: preserve exhibit selection in the URL

### DIFF
--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -42,6 +42,7 @@
       v-else-if="activeTab === 'wonder-lab'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
     >
+      <wonderlab-selection-router />
       <lab-interact
         class="h-full min-h-0 flex-1 overflow-hidden"
         :show-header="false"
@@ -76,6 +77,7 @@ import { useNavStore } from '@/stores/navStore'
 import LabInteract from '@/components/wonderlab/lab-interact.vue'
 import MemoryDungeon from '@/components/pages/memory-dungeon.vue'
 import ScreenFx from '@/components/screenfx/screen-fx.vue'
+import WonderlabSelectionRouter from '@/components/wonderlab/wonderlab-selection-router.vue'
 
 type LabTab = 'memory-dungeon' | 'wonder-lab' | 'screen-fx'
 

--- a/components/wonderlab/wonderlab-selection-router.vue
+++ b/components/wonderlab/wonderlab-selection-router.vue
@@ -1,0 +1,111 @@
+<!-- /components/wonderlab/wonderlab-selection-router.vue -->
+<template>
+  <span class="hidden" aria-hidden="true" />
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { Component as PrismaComponent } from '~/prisma/generated/prisma/client'
+import { useComponentStore } from '@/stores/componentStore'
+import {
+  findWonderLabComponentForQuery,
+  normalizeWonderLabComponentQuery,
+  wonderLabComponentQueryValue,
+} from '@/utils/wonderlab/componentSelection'
+
+const route = useRoute()
+const router = useRouter()
+const componentStore = useComponentStore()
+
+const components = computed<PrismaComponent[]>(() => {
+  const fromAll = componentStore.allComponents || []
+  const fromMain = componentStore.components || []
+  return fromAll.length ? fromAll : fromMain
+})
+
+const routeComponentQuery = computed(() => route.query.component)
+
+function queryWithComponent(value: string | null) {
+  const query = { ...route.query }
+
+  if (value) {
+    query.component = value
+  } else {
+    delete query.component
+  }
+
+  return query
+}
+
+async function replaceComponentQuery(value: string | null): Promise<void> {
+  await router.replace({
+    path: route.path,
+    query: queryWithComponent(value),
+    hash: route.hash,
+  })
+}
+
+async function pushComponentQuery(value: string | null): Promise<void> {
+  await router.push({
+    path: route.path,
+    query: queryWithComponent(value),
+    hash: route.hash,
+  })
+}
+
+watch(
+  [routeComponentQuery, components],
+  () => {
+    const query = normalizeWonderLabComponentQuery(routeComponentQuery.value)
+
+    if (!query) {
+      if (componentStore.selectedComponent) {
+        componentStore.selectedComponent = null
+      }
+      return
+    }
+
+    const resolved = findWonderLabComponentForQuery(components.value, query)
+
+    if (!resolved) {
+      if (components.value.length) {
+        componentStore.selectedComponent = null
+        void replaceComponentQuery(null)
+      }
+      return
+    }
+
+    if (componentStore.selectedComponent?.id !== resolved.id) {
+      componentStore.selectedComponent = resolved
+    }
+
+    const canonicalQuery = wonderLabComponentQueryValue(resolved)
+    if (query !== canonicalQuery) {
+      void replaceComponentQuery(canonicalQuery)
+    }
+  },
+  { immediate: true, flush: 'post' },
+)
+
+watch(
+  () => componentStore.selectedComponent?.id ?? null,
+  (selectedId) => {
+    const routeSelection = findWonderLabComponentForQuery(
+      components.value,
+      routeComponentQuery.value,
+    )
+    const routeSelectedId = routeSelection?.id ?? null
+
+    if (routeSelectedId === selectedId) return
+
+    const selected = selectedId
+      ? components.value.find((component) => component.id === selectedId) ?? null
+      : null
+
+    void pushComponentQuery(
+      selected ? wonderLabComponentQueryValue(selected) : null,
+    )
+  },
+)
+</script>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",
     "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
     "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
+    "test:wonderlab-selection": "tsx utils/scripts/verifyWonderLabSelection.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/utils/scripts/verifyWonderLabSelection.ts
+++ b/utils/scripts/verifyWonderLabSelection.ts
@@ -1,0 +1,33 @@
+// /utils/scripts/verifyWonderLabSelection.ts
+import assert from 'node:assert/strict'
+import {
+  findWonderLabComponentForQuery,
+  normalizeWonderLabComponentName,
+  normalizeWonderLabComponentQuery,
+  wonderLabComponentQueryValue,
+} from '@/utils/wonderlab/componentSelection'
+
+const components = [
+  { id: 12, componentName: 'ComponentCard' },
+  { id: 25, componentName: 'narrator-chat' },
+  { id: 41, componentName: 'WorkspaceNarrator' },
+]
+
+assert.equal(normalizeWonderLabComponentQuery(['25', '41']), '25')
+assert.equal(normalizeWonderLabComponentQuery(null), '')
+assert.equal(normalizeWonderLabComponentName('WorkspaceNarrator'), 'workspace-narrator')
+
+assert.equal(findWonderLabComponentForQuery(components, '12')?.id, 12)
+assert.equal(
+  findWonderLabComponentForQuery(components, 'narrator-chat')?.id,
+  25,
+)
+assert.equal(
+  findWonderLabComponentForQuery(components, 'workspace-narrator')?.id,
+  41,
+)
+assert.equal(findWonderLabComponentForQuery(components, '999'), null)
+assert.equal(findWonderLabComponentForQuery(components, ''), null)
+assert.equal(wonderLabComponentQueryValue(components[0]!), '12')
+
+console.log('WonderLab component selection verification passed.')

--- a/utils/wonderlab/componentSelection.ts
+++ b/utils/wonderlab/componentSelection.ts
@@ -1,0 +1,55 @@
+// /utils/wonderlab/componentSelection.ts
+export type WonderLabSelectableComponent = {
+  id: number
+  componentName: string
+}
+
+export function normalizeWonderLabComponentQuery(value: unknown): string {
+  const candidate = Array.isArray(value) ? value[0] : value
+  return typeof candidate === 'string' ? candidate.trim() : ''
+}
+
+export function normalizeWonderLabComponentName(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function findWonderLabComponentForQuery<
+  T extends WonderLabSelectableComponent,
+>(components: readonly T[], value: unknown): T | null {
+  const query = normalizeWonderLabComponentQuery(value)
+  if (!query) return null
+
+  if (/^\d+$/.test(query)) {
+    const id = Number(query)
+    if (Number.isSafeInteger(id) && id > 0) {
+      return components.find((component) => component.id === id) ?? null
+    }
+  }
+
+  const exact = components.find(
+    (component) => component.componentName === query,
+  )
+  if (exact) return exact
+
+  const normalizedQuery = normalizeWonderLabComponentName(query)
+  if (!normalizedQuery) return null
+
+  return (
+    components.find(
+      (component) =>
+        normalizeWonderLabComponentName(component.componentName) ===
+        normalizedQuery,
+    ) ?? null
+  )
+}
+
+export function wonderLabComponentQueryValue(
+  component: WonderLabSelectableComponent,
+): string {
+  return String(component.id)
+}


### PR DESCRIPTION
## What changed

- adds a headless WonderLab selection router mounted beside the component museum;
- makes `?component=<id>` the canonical exhibit selection state;
- pushes a history entry when visitors select or clear an exhibit;
- restores selection on direct visits, refreshes, and browser back/forward navigation;
- accepts legacy component-name links and canonicalizes them to numeric IDs;
- clears stale or invalid component query values once the live collection is available;
- prevents an old Pinia selection from overriding a URL with no component query;
- adds shared query parsing/resolution helpers and `npm run test:wonderlab-selection` coverage.

## Why

The museum selection previously lived only in Pinia memory. Refreshing or sharing the page lost the active exhibit, and browser navigation could not move through prior selections. This makes the URL authoritative without coupling routing code into the large museum component.

## Safety

- does not mutate Component records;
- preserves unrelated query parameters and hashes;
- falls back safely when a linked component no longer exists;
- existing route authority for `/wonderlab`, `/memory`, and `/screenfx` remains unchanged.

Part of #381.