### PR TITLE
Secure Component mutations and stop Cypress fixture leaks

### DIFF
--- a/cypress/e2e/api/component-reactions.cy.ts
+++ b/cypress/e2e/api/component-reactions.cy.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import {
+  adminHeaders,
   bearerHeaders,
   createLoggedInTestUser,
   deleteTestUser,
@@ -12,15 +13,7 @@ import {
 
 type CleanupResponse = Cypress.Response<unknown> | null
 
-let userId = 0
-
 describe('Component Reactions API Tests', () => {
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-      userId = auth.id
-    })
-  })
-
   let apiBase = ''
   let adminToken = ''
   let componentId: number | undefined
@@ -71,7 +64,7 @@ describe('Component Reactions API Tests', () => {
       cy.request({
         method: 'POST',
         url: `${apiBase}/components`,
-        headers: authHeaders(),
+        headers: adminHeaders(adminToken),
         body: {
           folderName: 'test-folder',
           componentName: `TestComponent_${Date.now()}`,
@@ -85,10 +78,22 @@ describe('Component Reactions API Tests', () => {
         expect(response.body).to.have.property('success', true)
 
         componentId = response.body.data.id
-
         expect(componentId).to.be.a('number')
 
-        createdComponents.push(assertDefined(componentId, 'componentId'))
+        const id = assertDefined(componentId, 'componentId')
+        createdComponents.push(id)
+
+        cy.task(
+          'cypressCleanup:register',
+          {
+            label: `component-reaction fixture component ${id}`,
+            method: 'DELETE',
+            url: `${apiBase}/components/${id}`,
+            headers: adminHeaders(adminToken),
+            expectedStatuses: [200, 404],
+          },
+          { log: false },
+        )
       })
     })
   })
@@ -130,10 +135,22 @@ describe('Component Reactions API Tests', () => {
       expect(response.body).to.have.property('success', true)
 
       reactionId = response.body.data.id
-
       expect(reactionId).to.be.a('number')
 
-      createdReactions.push(assertDefined(reactionId, 'reactionId'))
+      const id = assertDefined(reactionId, 'reactionId')
+      createdReactions.push(id)
+
+      cy.task(
+        'cypressCleanup:register',
+        {
+          label: `component reaction fixture ${id}`,
+          method: 'DELETE',
+          url: `${apiBase}/reactions/${id}`,
+          headers: authHeaders(),
+          expectedStatuses: [200, 404],
+        },
+        { log: false },
+      )
     })
   })
 
@@ -165,7 +182,6 @@ describe('Component Reactions API Tests', () => {
       expect(response.body).to.have.property('success', true)
 
       const reaction = response.body.data
-
       expect(reaction.id).to.eq(reactionId)
       expect(reaction.componentId).to.eq(componentId)
       expect(reaction.userId).to.eq(testUser!.id)
@@ -269,6 +285,8 @@ describe('Component Reactions API Tests', () => {
           url: `${apiBase}/reactions/${id}`,
           headers: authHeaders(),
           failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([200, 404])
         })
       })
 
@@ -276,8 +294,10 @@ describe('Component Reactions API Tests', () => {
         cy.request({
           method: 'DELETE',
           url: `${apiBase}/components/${id}`,
-          headers: authHeaders(),
+          headers: adminHeaders(adminToken),
           failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.be.oneOf([200, 404])
         })
       })
     }

--- a/cypress/e2e/api/components.cy.ts
+++ b/cypress/e2e/api/components.cy.ts
@@ -1,38 +1,43 @@
-import { createLoggedInTestUser } from '../../support/api-auth'
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 // cypress/e2e/api/components.cy.ts
 
-let userId = 0
+import { adminHeaders, getApiEnv } from '../../support/api-auth'
 
 describe('Component Management API Tests', () => {
-
-  // Auth migration: fresh disposable JWT user
-  before(() => {
-    createLoggedInTestUser().then((auth) => {
-      userId = auth.id
-    })
-  })
-
-  const baseUrl = 'https://kind-robots.vercel.app/api/components'
   const uniqueFolderName = `test-folder-${Date.now()}`
   const uniqueComponentName = `TestComponent-${Date.now()}`
 
-  let apiKey = ''
-  let componentId: number
+  let apiBase = ''
+  let adminToken = ''
+  let componentId: number | undefined
 
   before(() => {
-    cy.env(['API_KEY']).then((env) => {
-      apiKey = String(env.API_KEY || '')
-      expect(apiKey, 'API_KEY').to.be.a('string').and.not.be.empty
+    getApiEnv().then((env) => {
+      apiBase = `${env.apiBase}/components`
+      adminToken = env.adminToken
     })
   })
 
+  after(() => {
+    if (!componentId) return
 
+    cy.request({
+      method: 'DELETE',
+      url: `${apiBase}/${componentId}`,
+      headers: adminHeaders(adminToken),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(
+        response.status,
+        `component cleanup ${componentId}: ${JSON.stringify(response.body)}`,
+      ).to.be.oneOf([200, 404])
+    })
+  })
 
   it('Get All Folder Names', () => {
     cy.request({
       method: 'GET',
-      url: `${baseUrl}/folders`,
+      url: `${apiBase}/folders`,
       headers: {
         Accept: 'application/json',
       },
@@ -48,12 +53,8 @@ describe('Component Management API Tests', () => {
   it('Create New Component', () => {
     cy.request({
       method: 'POST',
-      url: baseUrl,
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-      },
+      url: apiBase,
+      headers: adminHeaders(adminToken),
       body: {
         folderName: uniqueFolderName,
         componentName: uniqueComponentName,
@@ -61,22 +62,32 @@ describe('Component Management API Tests', () => {
         underConstruction: false,
         isBroken: false,
         title: 'Test Component',
-        userId,
       },
     }).then((response) => {
       expect(response.status).to.eq(201)
       expect(response.body).to.have.property('success', true)
 
       componentId = response.body.data.id
-
       expect(componentId).to.be.a('number')
+
+      cy.task(
+        'cypressCleanup:register',
+        {
+          label: `component fixture ${componentId}`,
+          method: 'DELETE',
+          url: `${apiBase}/${componentId}`,
+          headers: adminHeaders(adminToken),
+          expectedStatuses: [200, 404],
+        },
+        { log: false },
+      )
     })
   })
 
   it('Get All Components', () => {
     cy.request({
       method: 'GET',
-      url: baseUrl,
+      url: apiBase,
       headers: {
         Accept: 'application/json',
       },
@@ -92,7 +103,7 @@ describe('Component Management API Tests', () => {
   it('Get Components from Specific Folder', () => {
     cy.request({
       method: 'GET',
-      url: `${baseUrl}/folder/${uniqueFolderName}`,
+      url: `${apiBase}/folder/${uniqueFolderName}`,
       headers: {
         Accept: 'application/json',
       },
@@ -117,7 +128,7 @@ describe('Component Management API Tests', () => {
 
     cy.request({
       method: 'GET',
-      url: `${baseUrl}/${componentId}`,
+      url: `${apiBase}/${componentId}`,
       headers: {
         Accept: 'application/json',
       },
@@ -140,25 +151,18 @@ describe('Component Management API Tests', () => {
 
     cy.request({
       method: 'PATCH',
-      url: `${baseUrl}/${componentId}`,
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-      },
+      url: `${apiBase}/${componentId}`,
+      headers: adminHeaders(adminToken),
       body: {
         isWorking: false,
         underConstruction: true,
         title: 'Updated Test Component',
       },
     }).then((response) => {
-      cy.log(JSON.stringify(response.body))
-
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
 
       const updatedComponent = response.body.data
-
       expect(updatedComponent.isWorking).to.be.false
       expect(updatedComponent.underConstruction).to.be.true
       expect(updatedComponent.title).to.eq('Updated Test Component')
@@ -170,17 +174,16 @@ describe('Component Management API Tests', () => {
 
     cy.request({
       method: 'DELETE',
-      url: `${baseUrl}/${componentId}`,
-      headers: {
-        Accept: 'application/json',
-        'x-api-key': apiKey,
-      },
+      url: `${apiBase}/${componentId}`,
+      headers: adminHeaders(adminToken),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
       expect(response.body.message).to.include(
         `Component with ID ${componentId} deleted successfully`,
       )
+
+      componentId = undefined
     })
   })
 })

--- a/server/api/components/[id].delete.ts
+++ b/server/api/components/[id].delete.ts
@@ -1,6 +1,7 @@
 // server/api/components/[id].delete.ts
-import { defineEventHandler, createError } from 'h3'
+import { createError, defineEventHandler } from 'h3'
 import { errorHandler } from '../../utils/error'
+import { requireAdminApiUser } from '../../utils/authGuard'
 import prisma from '../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
@@ -8,28 +9,27 @@ export default defineEventHandler(async (event) => {
   let componentId: number | null = null
 
   try {
-    // Validate and parse the component ID
+    await requireAdminApiUser(event)
+
     componentId = Number(event.context.params?.id)
-    if (isNaN(componentId) || componentId <= 0) {
+    if (Number.isNaN(componentId) || componentId <= 0) {
       throw createError({
-        statusCode: 400, // Bad Request
+        statusCode: 400,
         message: 'Invalid Component ID. It must be a positive integer.',
       })
     }
 
-    // Attempt to delete the component by ID
     const deletedComponent = await prisma.component.delete({
       where: { id: componentId },
     })
 
     if (!deletedComponent) {
       throw createError({
-        statusCode: 404, // Not Found
+        statusCode: 404,
         message: `Component with ID ${componentId} does not exist.`,
       })
     }
 
-    // Successful deletion response
     response = {
       success: true,
       message: `Component with ID ${componentId} deleted successfully.`,
@@ -44,7 +44,6 @@ export default defineEventHandler(async (event) => {
       handledError,
     )
 
-    // Set the appropriate status code and response based on the handled error
     event.node.res.statusCode = handledError.statusCode || 500
     response = {
       success: false,

--- a/server/api/components/[id].patch.ts
+++ b/server/api/components/[id].patch.ts
@@ -2,6 +2,7 @@
 import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
+import { requireAdminApiUser } from '../../utils/authGuard'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
 import {
   hasLegacyStatusUpdate,
@@ -49,6 +50,8 @@ export default defineEventHandler(async (event) => {
   const componentId = Number(getRouterParam(event, 'id'))
 
   try {
+    await requireAdminApiUser(event)
+
     if (!Number.isInteger(componentId) || componentId <= 0) {
       throw createError({
         statusCode: 400,

--- a/server/api/components/index.post.ts
+++ b/server/api/components/index.post.ts
@@ -2,6 +2,7 @@
 import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
+import { requireAdminApiUser } from '../../utils/authGuard'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
 import {
   hasLegacyStatusUpdate,
@@ -43,6 +44,8 @@ async function assertArtImageExists(artImageId?: number) {
 
 export default defineEventHandler(async (event) => {
   try {
+    await requireAdminApiUser(event)
+
     const componentData = await readBody<ComponentCreateBody>(event)
 
     const componentName = getStringOrDefault(componentData.componentName, '')

--- a/server/api/components/name/[name].patch.ts
+++ b/server/api/components/name/[name].patch.ts
@@ -2,6 +2,7 @@
 import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
+import { requireAdminApiUser } from '../../../utils/authGuard'
 import type { Component, Prisma } from '~/prisma/generated/prisma/client'
 import {
   hasLegacyStatusUpdate,
@@ -14,6 +15,8 @@ export default defineEventHandler(async (event) => {
   let requestBody: Partial<Component> | null = null
 
   try {
+    await requireAdminApiUser(event)
+
     if (!componentName || !/^[a-zA-Z0-9\s-]+$/.test(componentName)) {
       throw createError({
         statusCode: 400,


### PR DESCRIPTION
## What changed

- requires `requireAdminApiUser` for every Component mutation route:
  - `POST /api/components`
  - `PATCH /api/components/:id`
  - `PATCH /api/components/name/:name`
  - `DELETE /api/components/:id`
- keeps public Component reads unchanged;
- updates Component API Cypress tests to use the configured API target instead of hard-coding production;
- uses explicit admin headers for Component fixture creation, updates, and deletion;
- registers Component and Reaction cleanup immediately after fixture creation so the global cleanup runner can recover after a failed or interrupted spec;
- retains best-effort `after()` cleanup and now asserts cleanup responses instead of silently ignoring failures;
- removes redundant test-user setup from the Component Reaction suite.

## Why

Live WonderLab verification exposed stale `TestComponent-*` records in the production Component table. The Component CRUD suite only deleted its fixture in the final test, so an earlier failure permanently leaked the row. Component mutation endpoints were also unauthenticated even though WonderLab browsing is public and metadata/status management is intended to be admin-only.

## Safety

- public museum browsing and Component GET endpoints are unchanged;
- the admin WonderLab editor already sends authenticated requests;
- API-key and beta-admin-token test workflows remain supported by the existing auth guard;
- no existing production rows are deleted by this PR.

Part of #381 and related to the broader Cypress cleanup work.