### PR TITLE
model-builder/t-030: batch item PATCH endpoint

### DIFF
--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -7,31 +7,14 @@ import { requireApiUser } from '~/server/utils/authGuard'
 import {
   assertRunAccess,
   getItemId,
-  normalizeJson,
-  normalizeNullableId,
-  normalizeText,
+  prepareItemUpdate,
+  type ItemPatchBody,
 } from '../runs/index'
 
 const itemInclude = {
   Artifacts: { orderBy: { id: 'asc' } },
   Revisions: { orderBy: { id: 'asc' } },
 } satisfies Prisma.ModelBuildItemInclude
-
-type ItemPatchBody = {
-  stageStatuses?: unknown
-  pitch?: unknown
-  fieldsDraft?: unknown
-  promptDraft?: unknown
-  relationshipDraft?: unknown
-  staleReason?: unknown
-  error?: unknown
-  artImageId?: unknown
-  targetType?: unknown
-  targetId?: unknown
-  // Revision metadata (optional):
-  stage?: unknown
-  reason?: unknown
-}
 
 export default defineEventHandler(async (event) => {
   try {
@@ -53,70 +36,16 @@ export default defineEventHandler(async (event) => {
     assertRunAccess(existing.Run, auth.user)
 
     const body = await readBody<ItemPatchBody>(event)
-    const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
-
-    if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
-      const stageStatuses = normalizeJson(body.stageStatuses)
-      if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
-    }
-    if (body.pitch !== undefined) data.pitch = normalizeText(body.pitch)
-    if (body.fieldsDraft !== undefined)
-      data.fieldsDraft = normalizeText(body.fieldsDraft)
-    if (body.promptDraft !== undefined)
-      data.promptDraft = normalizeText(body.promptDraft)
-    const relationshipDraft = normalizeJson(body.relationshipDraft)
-    if (relationshipDraft !== undefined)
-      data.relationshipDraft = relationshipDraft
-    if (body.staleReason !== undefined)
-      data.staleReason = normalizeText(body.staleReason)
-    if (body.error !== undefined) data.error = normalizeText(body.error)
-    if (body.artImageId !== undefined)
-      data.artImageId = normalizeNullableId(body.artImageId)
-    if (body.targetType !== undefined)
-      data.targetType = normalizeText(body.targetType)
-    if (body.targetId !== undefined)
-      data.targetId = normalizeNullableId(body.targetId)
-
-    // Record a revision whenever editable draft content changes, so upstream
-    // edits are never silently lost. Stage-status transitions (approve/reject/
-    // stale) are frequent and not themselves revisions.
-    const contentChanged =
-      body.pitch !== undefined ||
-      body.fieldsDraft !== undefined ||
-      body.promptDraft !== undefined ||
-      body.relationshipDraft !== undefined
-
-    const stageLabel =
-      typeof body.stage === 'string' ? body.stage.slice(0, 48) : 'EDIT'
-    const reason =
-      typeof body.reason === 'string' ? body.reason.slice(0, 255) : null
-
-    const previousPayload = JSON.stringify({
-      pitch: existing.pitch,
-      fieldsDraft: existing.fieldsDraft,
-      promptDraft: existing.promptDraft,
-      stageStatuses: existing.stageStatuses,
-      relationshipDraft: existing.relationshipDraft,
-    })
-    const nextPayload = JSON.stringify({
-      pitch: data.pitch ?? existing.pitch,
-      fieldsDraft: data.fieldsDraft ?? existing.fieldsDraft,
-      promptDraft: data.promptDraft ?? existing.promptDraft,
-      stageStatuses: data.stageStatuses ?? existing.stageStatuses,
-      relationshipDraft: data.relationshipDraft ?? existing.relationshipDraft,
-    })
+    const { data, revision } = prepareItemUpdate(
+      existing,
+      body,
+      auth.user.username ?? String(auth.user.id),
+    )
 
     const item = await prisma.$transaction(async (tx) => {
-      if (contentChanged) {
+      if (revision) {
         await tx.modelBuildRevision.create({
-          data: {
-            itemId: id,
-            stage: stageLabel,
-            reason,
-            actor: auth.user.username ?? String(auth.user.id),
-            previousPayload,
-            nextPayload,
-          },
+          data: { itemId: id, ...revision },
         })
       }
       return tx.modelBuildItem.update({

--- a/server/api/model-builder/items/batch.patch.ts
+++ b/server/api/model-builder/items/batch.patch.ts
@@ -1,0 +1,153 @@
+// /server/api/model-builder/items/batch.patch.ts
+// Batch-update multiple build items in a single request. Body shape:
+// { "items": [ { "id": number, ...ItemPatchBody }, ... ] }
+// Each item is validated and updated independently (a single failing entry
+// does not abort the others) but all succeeding updates + their revisions
+// commit in one transaction, so a whole group edit is one round-trip instead
+// of N per-item PATCH requests.
+import { defineEventHandler, createError, readBody } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  assertRunAccess,
+  prepareItemUpdate,
+  type ItemPatchBody,
+} from '../runs/index'
+
+const itemInclude = {
+  Artifacts: { orderBy: { id: 'asc' } },
+  Revisions: { orderBy: { id: 'asc' } },
+} satisfies Prisma.ModelBuildItemInclude
+
+type ItemBatchEntry = ItemPatchBody & { id?: unknown }
+
+type ItemBatchBody = {
+  items?: unknown
+}
+
+type BatchResult = {
+  id: number | null
+  success: boolean
+  message: string
+  statusCode: number
+  data?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = await readBody<ItemBatchBody>(event)
+
+    if (!body || !Array.isArray(body.items) || body.items.length === 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'Request body must include a non-empty "items" array.',
+      })
+    }
+
+    const entries = body.items as ItemBatchEntry[]
+    const actor = auth.user.username ?? String(auth.user.id)
+    const results: BatchResult[] = []
+
+    // Each entry validates/loads independently, but every entry that passes
+    // validation is applied in one transaction so the batch is atomic for the
+    // items it actually touches (a mid-batch DB error rolls all of them back
+    // rather than leaving the group half-applied).
+    const applied: Array<{
+      id: number
+      data: Prisma.ModelBuildItemUncheckedUpdateInput
+      revision: ReturnType<typeof prepareItemUpdate>['revision']
+    }> = []
+
+    for (const entry of entries) {
+      let id: number | null = null
+      try {
+        if (!entry || typeof entry !== 'object') {
+          throw createError({
+            statusCode: 400,
+            message: 'Each item entry must be an object with an "id".',
+          })
+        }
+
+        id = Number(entry.id)
+        if (!Number.isInteger(id) || id <= 0) {
+          throw createError({
+            statusCode: 400,
+            message: 'Invalid item ID. It must be a positive integer.',
+          })
+        }
+
+        const existing = await prisma.modelBuildItem.findUnique({
+          where: { id },
+          include: { Run: { select: { userId: true } } },
+        })
+        if (!existing) {
+          throw createError({
+            statusCode: 404,
+            message: 'Build item not found.',
+          })
+        }
+        assertRunAccess(existing.Run, auth.user)
+
+        const { id: _omit, ...fields } = entry
+        void _omit
+        const { data, revision } = prepareItemUpdate(existing, fields, actor)
+        applied.push({ id, data, revision })
+        results.push({ id, success: true, message: 'Queued.', statusCode: 200 })
+      } catch (error: unknown) {
+        const handled = errorHandler(error)
+        results.push({
+          id,
+          success: false,
+          message:
+            handled.message || `Failed to update item ${id ?? 'unknown'}.`,
+          statusCode: handled.statusCode || 500,
+        })
+      }
+    }
+
+    if (applied.length) {
+      const updatedById = await prisma.$transaction(async (tx) => {
+        const byId = new Map<number, unknown>()
+        for (const { id, data, revision } of applied) {
+          if (revision) {
+            await tx.modelBuildRevision.create({
+              data: { itemId: id, ...revision },
+            })
+          }
+          const item = await tx.modelBuildItem.update({
+            where: { id },
+            data,
+            include: itemInclude,
+          })
+          byId.set(id, item)
+        }
+        return byId
+      })
+
+      for (const result of results) {
+        if (result.success && result.id !== null) {
+          result.data = updatedById.get(result.id)
+          result.message = 'Build item updated successfully.'
+        }
+      }
+    }
+
+    const updatedCount = results.filter((result) => result.success).length
+    const failedCount = results.length - updatedCount
+
+    event.node.res.statusCode = failedCount === 0 ? 200 : 207
+    return {
+      success: failedCount === 0,
+      message: `Batch complete: ${updatedCount} updated, ${failedCount} failed.`,
+      data: results,
+      statusCode: event.node.res.statusCode,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -1,8 +1,11 @@
 // /server/api/model-builder/runs/index.ts
 import { createError, getRouterParam } from 'h3'
 import type { H3Event } from 'h3'
-import { Prisma } from '~/prisma/generated/prisma/client'
-import type { ModelBuildStatus } from '~/prisma/generated/prisma/client'
+import type {
+  Prisma,
+  ModelBuildStatus,
+  ModelBuildItem,
+} from '~/prisma/generated/prisma/client'
 
 export const modelBuildStatuses = new Set<ModelBuildStatus>([
   'DRAFT',
@@ -109,15 +112,122 @@ export function normalizeJson(value: unknown): string | null | undefined {
   }
 }
 
-export function parseStoredJson<T = unknown>(
-  value: unknown,
-  fallback: T,
-): T {
+export function parseStoredJson<T = unknown>(value: unknown, fallback: T): T {
   if (typeof value !== 'string' || !value.trim()) return fallback
 
   try {
     return JSON.parse(value) as T
   } catch {
     return fallback
+  }
+}
+
+export type ItemPatchBody = {
+  stageStatuses?: unknown
+  pitch?: unknown
+  fieldsDraft?: unknown
+  promptDraft?: unknown
+  relationshipDraft?: unknown
+  staleReason?: unknown
+  error?: unknown
+  artImageId?: unknown
+  targetType?: unknown
+  targetId?: unknown
+  // Revision metadata (optional):
+  stage?: unknown
+  reason?: unknown
+}
+
+export type PreparedItemUpdate = {
+  data: Prisma.ModelBuildItemUncheckedUpdateInput
+  // Present only when editable draft content changed, so the caller records a
+  // ModelBuildRevision alongside the update.
+  revision: {
+    stage: string
+    reason: string | null
+    actor: string
+    previousPayload: string
+    nextPayload: string
+  } | null
+}
+
+// Shared by the single-item and batch PATCH routes: validates/normalizes an
+// ItemPatchBody against an existing item and builds the Prisma update input
+// plus (when editable content changed) the revision-history entry to record
+// alongside it. Stage-status-only transitions (approve/reject/stale) are
+// frequent and not themselves revisions.
+export function prepareItemUpdate(
+  existing: Pick<
+    ModelBuildItem,
+    | 'pitch'
+    | 'fieldsDraft'
+    | 'promptDraft'
+    | 'stageStatuses'
+    | 'relationshipDraft'
+  >,
+  body: ItemPatchBody,
+  actor: string,
+): PreparedItemUpdate {
+  const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
+
+  if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
+    const stageStatuses = normalizeJson(body.stageStatuses)
+    if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
+  }
+  if (body.pitch !== undefined) data.pitch = normalizeText(body.pitch)
+  if (body.fieldsDraft !== undefined)
+    data.fieldsDraft = normalizeText(body.fieldsDraft)
+  if (body.promptDraft !== undefined)
+    data.promptDraft = normalizeText(body.promptDraft)
+  const relationshipDraft = normalizeJson(body.relationshipDraft)
+  if (relationshipDraft !== undefined)
+    data.relationshipDraft = relationshipDraft
+  if (body.staleReason !== undefined)
+    data.staleReason = normalizeText(body.staleReason)
+  if (body.error !== undefined) data.error = normalizeText(body.error)
+  if (body.artImageId !== undefined)
+    data.artImageId = normalizeNullableId(body.artImageId)
+  if (body.targetType !== undefined)
+    data.targetType = normalizeText(body.targetType)
+  if (body.targetId !== undefined)
+    data.targetId = normalizeNullableId(body.targetId)
+
+  const contentChanged =
+    body.pitch !== undefined ||
+    body.fieldsDraft !== undefined ||
+    body.promptDraft !== undefined ||
+    body.relationshipDraft !== undefined
+
+  if (!contentChanged) return { data, revision: null }
+
+  const stageLabel =
+    typeof body.stage === 'string' ? body.stage.slice(0, 48) : 'EDIT'
+  const reason =
+    typeof body.reason === 'string' ? body.reason.slice(0, 255) : null
+
+  const previousPayload = JSON.stringify({
+    pitch: existing.pitch,
+    fieldsDraft: existing.fieldsDraft,
+    promptDraft: existing.promptDraft,
+    stageStatuses: existing.stageStatuses,
+    relationshipDraft: existing.relationshipDraft,
+  })
+  const nextPayload = JSON.stringify({
+    pitch: data.pitch ?? existing.pitch,
+    fieldsDraft: data.fieldsDraft ?? existing.fieldsDraft,
+    promptDraft: data.promptDraft ?? existing.promptDraft,
+    stageStatuses: data.stageStatuses ?? existing.stageStatuses,
+    relationshipDraft: data.relationshipDraft ?? existing.relationshipDraft,
+  })
+
+  return {
+    data,
+    revision: {
+      stage: stageLabel,
+      reason,
+      actor,
+      previousPayload,
+      nextPayload,
+    },
   }
 }

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -547,6 +547,37 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       .catch((error) => handleError(error, 'saving build item'))
   }
 
+  // Background persistence of a whole group edit in one round-trip. Callers
+  // mutate local state first (optimistic) and pass only the changed fields per
+  // item, same contract as pushItem — this just collapses N per-item PATCH
+  // requests into a single batch request.
+  function batchPushItems(
+    entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }>,
+  ): void {
+    if (!entries.length) return
+    performFetch('/api/model-builder/items/batch', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: entries.map(({ item, payload, meta }) => ({
+          id: item.id,
+          ...payload,
+          ...meta,
+        })),
+      }),
+    })
+      .then((response) => {
+        if (!response.success) {
+          setStatus('error', response.message || 'Failed to save changes.')
+        }
+      })
+      .catch((error) => handleError(error, 'saving build items'))
+  }
+
   // Stale-invalidation: editing an upstream stage marks every downstream stage
   // stale (unless still locked). Commit is always downstream of everything.
   function markDownstreamStale(item: BuildItem, fromStage: BuildStageKey): void {
@@ -1073,21 +1104,35 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // Set one model field to the same value on every item in a group (e.g. rarity =
   // RARE across 10 rewards). Only rewrites items whose value actually changes.
+  // Persists the whole group in a single batch request rather than one PATCH
+  // per changed item.
   function batchSetField(
     outputKey: string,
     fieldKey: string,
     value: string,
   ): void {
     const items = groupItems(outputKey)
-    let changed = 0
+    const entries: Array<{
+      item: BuildItem
+      payload: Record<string, unknown>
+      meta?: { stage?: string; reason?: string }
+    }> = []
     for (const item of items) {
       const next = setFieldLine(item.fieldsDraft, fieldKey, value)
-      if (next !== item.fieldsDraft) {
-        updateFields(item.id, next)
-        changed++
-      }
+      if (next === item.fieldsDraft) continue
+      item.fieldsDraft = next
+      markDownstreamStale(item, 'FIELDS_AND_PROMPTS')
+      entries.push({
+        item,
+        payload: { stageStatuses: item.stages, fieldsDraft: item.fieldsDraft },
+        meta: { stage: 'FIELDS_AND_PROMPTS', reason: 'edited fields' },
+      })
     }
-    setStatus('success', `Set ${fieldKey} on ${changed}/${items.length} items.`)
+    batchPushItems(entries)
+    setStatus(
+      'success',
+      `Set ${fieldKey} on ${entries.length}/${items.length} items.`,
+    )
   }
 
   // Approve a stage for every (unlocked) item in a group at once.


### PR DESCRIPTION
## Summary
- Kaizen from t-027 (PR #353): the batch editor and `autoBuildRun` looped the single-item PATCH (`/api/model-builder/items/:id`) once per item, firing N requests for a group edit across N items.
- Added `PATCH /api/model-builder/items/batch` (body: `{ items: [{ id, ...fields }] }`), sharing the same per-item validation/normalization and revision-history logic as the single-item route via a new `prepareItemUpdate` helper in `runs/index.ts`. All entries that pass validation apply in one transaction; a per-entry failure doesn't abort the others (returns 200 or 207 partial, mirroring the existing `scenarios/batch.patch.ts` pattern).
- Added a `batchPushItems` store helper and wired `batchSetField` to use it, so setting one field across a whole item group now persists in a single round-trip instead of one PATCH per changed item.
- No schema change; the per-item PATCH route is untouched in behavior (refactored to call the shared helper).

## Test plan
- [x] `npx eslint` on all touched files — clean
- [x] `npx prettier --check` on all touched files — clean
- [x] `npm run test` (nuxi prepare + vue-tsc --noEmit) — passes with no errors
- [ ] Live exercise of the batch endpoint against a real run (no DB in this sandbox) — left for a preview-deploy smoke pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EK6RhEc8JWbEs8rsX7nK58


---
_Generated by [Claude Code](https://claude.ai/code/session_01EK6RhEc8JWbEs8rsX7nK58)_