### PR TITLE
WonderLab: dry-run cleanup for leaked Component test fixtures

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -88,6 +88,9 @@ jobs:
       - name: mysql:// URL parser contract
         run: npm run test:parse-mysql-url
 
+      - name: WonderLab test-fixture cleanup contract
+        run: npm run test:wonderlab-fixture-cleanup
+
       - name: Fetch main for capture-group guard diff
         # actions/checkout only fetches the ref it checks out (the PR's
         # merge ref, not a local `origin/main`), even with fetch-depth: 0 --

--- a/components/wonderlab/component-sync.vue
+++ b/components/wonderlab/component-sync.vue
@@ -163,6 +163,10 @@
         </ul>
       </details>
     </template>
+
+    <div class="mt-5 border-t border-base-300 pt-5">
+      <component-test-fixture-cleanup />
+    </div>
   </section>
 </template>
 

--- a/components/wonderlab/component-test-fixture-cleanup.vue
+++ b/components/wonderlab/component-test-fixture-cleanup.vue
@@ -1,0 +1,215 @@
+<!-- /components/wonderlab/component-test-fixture-cleanup.vue -->
+<template>
+  <section class="rounded-2xl border border-warning/35 bg-warning/5 p-4">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="text-xs font-black uppercase tracking-widest text-warning">
+          Historical Test Cleanup
+        </p>
+        <h3 class="mt-1 text-lg font-black">Leaked Cypress Components</h3>
+        <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">
+          Finds only records whose component name starts with
+          <code>TestComponent-</code> or <code>TestComponent_</code> and whose
+          folder or title also identifies it as a test fixture. Dry run is
+          required before deletion.
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn btn-outline btn-sm rounded-xl"
+          :disabled="isBusy"
+          @click="runDryRun"
+        >
+          <span v-if="isDryRunning" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:search" class="size-4" />
+          Find Test Fixtures
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-error btn-sm rounded-xl"
+          :disabled="!canApply || isBusy"
+          @click="applyCleanup"
+        >
+          <span v-if="isApplying" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:trash" class="size-4" />
+          Delete {{ candidates.length || '' }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="errorMessage"
+      class="mt-4 rounded-xl border border-error/40 bg-error/10 p-3 text-sm text-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div
+      v-if="successMessage"
+      class="mt-4 rounded-xl border border-success/40 bg-success/10 p-3 text-sm text-success"
+    >
+      {{ successMessage }}
+    </div>
+
+    <template v-if="result && !result.applied">
+      <div
+        v-if="!candidates.length"
+        class="mt-4 rounded-xl border border-base-300 bg-base-100 p-4 text-sm text-base-content/65"
+      >
+        No matching historical test fixtures were found.
+      </div>
+
+      <div v-else class="mt-4 grid gap-3">
+        <article
+          v-for="candidate in candidates"
+          :key="candidate.id"
+          class="rounded-xl border border-warning/30 bg-base-100 p-3"
+        >
+          <div class="flex flex-wrap items-start justify-between gap-2">
+            <div class="min-w-0">
+              <p class="break-all font-mono text-sm font-black">
+                {{ candidate.componentName }}
+              </p>
+              <p class="mt-1 break-all text-xs text-base-content/55">
+                {{ candidate.folderName }} · Component #{{ candidate.id }}
+              </p>
+            </div>
+            <span class="badge badge-warning badge-sm">
+              {{ candidate.reactionCount }} reactions
+            </span>
+          </div>
+          <p class="mt-2 text-xs text-base-content/50">
+            Created {{ formatDate(candidate.createdAt) }}
+          </p>
+        </article>
+
+        <label
+          class="flex cursor-pointer items-start gap-3 rounded-xl border border-error/30 bg-error/5 p-3"
+        >
+          <input
+            v-model="confirmed"
+            type="checkbox"
+            class="checkbox checkbox-error checkbox-sm mt-0.5"
+          />
+          <span class="text-sm leading-relaxed">
+            I reviewed these IDs and confirm they are disposable Cypress test
+            fixtures. Attached Component reactions will also be deleted.
+          </span>
+        </label>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useComponentStore } from '@/stores/componentStore'
+import { performFetch } from '@/stores/utils'
+
+type FixtureCandidate = {
+  id: number
+  componentName: string
+  folderName: string
+  title: string | null
+  createdAt: string | Date
+  updatedAt: string | Date
+  reactionCount: number
+}
+
+type FixtureCleanupResult = {
+  mode: 'dry-run' | 'apply'
+  applied: boolean
+  candidates: FixtureCandidate[]
+  deleted: {
+    components: number
+    reactions: number
+  }
+}
+
+const componentStore = useComponentStore()
+const result = ref<FixtureCleanupResult | null>(null)
+const isDryRunning = ref(false)
+const isApplying = ref(false)
+const confirmed = ref(false)
+const errorMessage = ref('')
+const successMessage = ref('')
+
+const candidates = computed(() => result.value?.candidates || [])
+const isBusy = computed(() => isDryRunning.value || isApplying.value)
+const canApply = computed(
+  () =>
+    result.value?.mode === 'dry-run' &&
+    !result.value.applied &&
+    candidates.value.length > 0 &&
+    confirmed.value,
+)
+
+async function requestCleanup(
+  mode: 'dry-run' | 'apply',
+): Promise<FixtureCleanupResult> {
+  const response = await performFetch<FixtureCleanupResult>(
+    '/api/components/cleanup-test-fixtures',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        mode,
+        candidateIds:
+          mode === 'apply'
+            ? candidates.value.map((candidate) => candidate.id)
+            : undefined,
+      }),
+    },
+  )
+
+  if (!response.success || !response.data) {
+    throw new Error(response.message || 'Historical fixture cleanup failed.')
+  }
+
+  successMessage.value = response.message
+  return response.data
+}
+
+async function runDryRun(): Promise<void> {
+  isDryRunning.value = true
+  confirmed.value = false
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    result.value = await requestCleanup('dry-run')
+  } catch (error) {
+    result.value = null
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Fixture dry run failed.'
+  } finally {
+    isDryRunning.value = false
+  }
+}
+
+async function applyCleanup(): Promise<void> {
+  if (!canApply.value) return
+
+  isApplying.value = true
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    result.value = await requestCleanup('apply')
+    confirmed.value = false
+    await componentStore.initialize(true)
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Fixture cleanup failed.'
+  } finally {
+    isApplying.value = false
+  }
+}
+
+function formatDate(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString()
+}
+</script>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:wonderlab-reconcile": "tsx utils/scripts/verifyWonderLabReconcile.ts",
     "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
     "test:wonderlab-selection": "tsx utils/scripts/verifyWonderLabSelection.ts",
+    "test:wonderlab-fixture-cleanup": "tsx utils/scripts/verifyComponentTestFixtures.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/server/api/components/cleanup-test-fixtures.post.ts
+++ b/server/api/components/cleanup-test-fixtures.post.ts
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
         updatedAt: true,
         _count: {
           select: {
-            Reaction: true,
+            Reactions: true,
           },
         },
       },
@@ -56,7 +56,7 @@ export default defineEventHandler(async (event) => {
         title: component.title,
         createdAt: component.createdAt,
         updatedAt: component.updatedAt,
-        reactionCount: component._count.Reaction,
+        reactionCount: component._count.Reactions,
       }),
     )
 

--- a/server/api/components/cleanup-test-fixtures.post.ts
+++ b/server/api/components/cleanup-test-fixtures.post.ts
@@ -1,0 +1,159 @@
+// /server/api/components/cleanup-test-fixtures.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import { requireAdminApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import {
+  parseComponentFixtureIds,
+  selectComponentTestFixtures,
+} from '../../utils/componentTestFixtures'
+
+type CleanupMode = 'dry-run' | 'apply'
+
+type CleanupRequestBody = {
+  mode?: CleanupMode
+  candidateIds?: unknown
+}
+
+function parseMode(value: unknown): CleanupMode {
+  if (value === undefined || value === 'dry-run') return 'dry-run'
+  if (value === 'apply') return 'apply'
+
+  throw createError({
+    statusCode: 400,
+    message: 'Cleanup mode must be "dry-run" or "apply".',
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const body = await readBody<CleanupRequestBody>(event)
+    const mode = parseMode(body?.mode)
+
+    const components = await prisma.component.findMany({
+      orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        componentName: true,
+        folderName: true,
+        title: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: {
+            Reaction: true,
+          },
+        },
+      },
+    })
+
+    const safeCandidates = selectComponentTestFixtures(components).map(
+      (component) => ({
+        id: component.id,
+        componentName: component.componentName,
+        folderName: component.folderName,
+        title: component.title,
+        createdAt: component.createdAt,
+        updatedAt: component.updatedAt,
+        reactionCount: component._count.Reaction,
+      }),
+    )
+
+    if (mode === 'dry-run') {
+      return {
+        success: true,
+        message: safeCandidates.length
+          ? `Found ${safeCandidates.length} historical Component test fixture${safeCandidates.length === 1 ? '' : 's'}. No records were changed.`
+          : 'No historical Component test fixtures were found.',
+        data: {
+          mode,
+          applied: false,
+          requestedBy: {
+            id: auth.user.id,
+            username: auth.user.username,
+          },
+          candidates: safeCandidates,
+          deleted: {
+            components: 0,
+            reactions: 0,
+          },
+        },
+        statusCode: 200,
+      }
+    }
+
+    const candidateIds = parseComponentFixtureIds(body?.candidateIds)
+    if (!candidateIds.length) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Apply requires candidate IDs from a reviewed cleanup dry run.',
+      })
+    }
+
+    const safeById = new Map(
+      safeCandidates.map((candidate) => [candidate.id, candidate]),
+    )
+    const unsafeIds = candidateIds.filter((id) => !safeById.has(id))
+
+    if (unsafeIds.length) {
+      throw createError({
+        statusCode: 409,
+        message:
+          'One or more requested records no longer match the strict test-fixture rules. Run a new dry run.',
+        data: { unsafeIds },
+      })
+    }
+
+    const candidatesToDelete = candidateIds.map((id) => safeById.get(id)!)
+    const deleted = await prisma.$transaction(async (tx) => {
+      const reactions = await tx.reaction.deleteMany({
+        where: {
+          componentId: { in: candidateIds },
+        },
+      })
+
+      const componentResult = await tx.component.deleteMany({
+        where: {
+          id: { in: candidateIds },
+        },
+      })
+
+      return {
+        reactions: reactions.count,
+        components: componentResult.count,
+      }
+    })
+
+    return {
+      success: true,
+      message: `Deleted ${deleted.components} historical Component test fixture${deleted.components === 1 ? '' : 's'} and ${deleted.reactions} attached reaction${deleted.reactions === 1 ? '' : 's'}.`,
+      data: {
+        mode,
+        applied: true,
+        requestedBy: {
+          id: auth.user.id,
+          username: auth.user.username,
+        },
+        candidates: candidatesToDelete,
+        deleted,
+      },
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      message:
+        handled.message || 'Failed to clean historical Component test fixtures.',
+      data:
+        error && typeof error === 'object' && 'data' in error
+          ? (error as { data?: unknown }).data
+          : null,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/componentTestFixtures.ts
+++ b/server/utils/componentTestFixtures.ts
@@ -1,0 +1,40 @@
+// /server/utils/componentTestFixtures.ts
+export type ComponentTestFixtureRecord = {
+  id: number
+  componentName: string
+  folderName: string
+  title?: string | null
+}
+
+const componentNamePattern = /^TestComponent[-_]/i
+const folderNamePattern = /^test-folder(?:-|$)/i
+const titlePattern = /^(?:Updated )?Test Component$/i
+
+export function isComponentTestFixture(
+  component: ComponentTestFixtureRecord,
+): boolean {
+  if (!componentNamePattern.test(component.componentName.trim())) return false
+
+  return (
+    folderNamePattern.test(component.folderName.trim()) ||
+    titlePattern.test(component.title?.trim() || '')
+  )
+}
+
+export function selectComponentTestFixtures<
+  T extends ComponentTestFixtureRecord,
+>(components: readonly T[]): T[] {
+  return components.filter(isComponentTestFixture)
+}
+
+export function parseComponentFixtureIds(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+
+  return [
+    ...new Set(
+      value
+        .map((candidate) => Number(candidate))
+        .filter((id) => Number.isSafeInteger(id) && id > 0),
+    ),
+  ].sort((left, right) => left - right)
+}

--- a/utils/scripts/verifyComponentTestFixtures.ts
+++ b/utils/scripts/verifyComponentTestFixtures.ts
@@ -1,0 +1,47 @@
+// /utils/scripts/verifyComponentTestFixtures.ts
+import assert from 'node:assert/strict'
+import {
+  isComponentTestFixture,
+  parseComponentFixtureIds,
+  selectComponentTestFixtures,
+} from '@/server/utils/componentTestFixtures'
+
+const records = [
+  {
+    id: 1,
+    componentName: 'TestComponent-1783889202735',
+    folderName: 'test-folder-1783889202735',
+    title: 'Test Component',
+  },
+  {
+    id: 2,
+    componentName: 'TestComponent_1784371054025',
+    folderName: 'test-folder',
+    title: 'Test Component',
+  },
+  {
+    id: 3,
+    componentName: 'ComponentTestPanel',
+    folderName: 'wonderlab',
+    title: 'Test Component',
+  },
+  {
+    id: 4,
+    componentName: 'TestComponent-Documentation',
+    folderName: 'wonderlab',
+    title: 'Real documentation component',
+  },
+]
+
+assert.equal(isComponentTestFixture(records[0]!), true)
+assert.equal(isComponentTestFixture(records[1]!), true)
+assert.equal(isComponentTestFixture(records[2]!), false)
+assert.equal(isComponentTestFixture(records[3]!), false)
+assert.deepEqual(
+  selectComponentTestFixtures(records).map((record) => record.id),
+  [1, 2],
+)
+assert.deepEqual(parseComponentFixtureIds([2, '1', 2, -1, 'bad']), [1, 2])
+assert.deepEqual(parseComponentFixtureIds(null), [])
+
+console.log('Component test fixture cleanup verification passed.')


### PR DESCRIPTION
## What changed

- adds a strict historical Component test-fixture matcher;
- adds an admin-only `POST /api/components/cleanup-test-fixtures` endpoint with:
  - dry-run as the default;
  - exact candidate metadata and attached Reaction counts;
  - apply requiring candidate IDs from the reviewed dry run;
  - revalidation that every requested ID still matches the strict fixture rules;
  - transactional deletion of attached Component reactions and the selected Component rows;
- adds a cleanup panel inside the existing WonderLab Component reconciliation tool;
- requires an explicit confirmation checkbox before apply;
- refreshes the Component store after cleanup;
- adds `npm run test:wonderlab-fixture-cleanup` coverage for positive matches, false-positive resistance, and candidate-ID parsing.

## Matching safety

A row is eligible only when both conditions hold:

1. `componentName` starts with `TestComponent-` or `TestComponent_`; and
2. either `folderName` starts with `test-folder` or the title is exactly `Test Component` / `Updated Test Component`.

Ordinary components that merely contain words such as “test” or “component” do not match.

## Why

Live WonderLab verification found two historical Cypress Component fixtures in production. #405 prevents future leaks and protects Component mutations with admin auth; this PR provides a narrow, reviewable way to remove the already-leaked records without enabling general automatic deletion.

## Non-goals

- no deploy-time or startup cleanup;
- no deletion of ordinary missing-from-manifest Components;
- no broad name search;
- no automatic execution after merge.

Part of #381.