### PR TITLE
ai-art-academy/t-032: fix style-remix race condition mis-attributing which style gets marked remixed

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -89,9 +89,9 @@ function onStyleSelected(entry: StyleEntry | null) {
   academyStore.selectStyle(entry?.slug ?? null)
 }
 
-function onGenerated(_image: ArtImage) {
-  if (academyStore.selectedStyleSlug) {
-    academyStore.markStyleRemixed(academyStore.selectedStyleSlug)
+function onGenerated(_image: ArtImage, style: StyleEntry | null) {
+  if (style?.slug) {
+    academyStore.markStyleRemixed(style.slug)
   }
 }
 </script>

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -641,7 +641,7 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  generated: [image: ArtImage]
+  generated: [image: ArtImage, style: StyleEntry | null]
   close: []
   styleSelected: [style: StyleEntry | null]
 }>()
@@ -1365,7 +1365,7 @@ async function runStyleTransfer(): Promise<void> {
 
     resultImage.value = result.data
     successMessage.value = `Style applied! Image #${result.data.id} created.`
-    emit('generated', result.data)
+    emit('generated', result.data, style)
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : 'Generation failed.'


### PR DESCRIPTION
### Task
ai-art-academy/t-032: fix style-remix race condition mis-attributing which style gets marked remixed (kind: software)

### What changed / what I produced
- `components/art/art-styler.vue`: the `generated` emit now carries the `StyleEntry` that was actually used for the request (`emit('generated', result.data, style)`), instead of only the resulting `ArtImage`. `style` is the value captured into a local `const` at the start of `runStyleTransfer()`, so it reflects the request that actually ran, not whatever is currently selected in the UI.
- `components/academy/academy-remix.vue`: `onGenerated` now reads the style from that emit argument (`style?.slug`) instead of re-reading `academyStore.selectedStyleSlug` — the store's *current* value — at completion time.

### Why
`art-styler.vue`'s style swatches have no `:disabled` guard tied to `isGenerating` (only the textarea and Clear button do), so a user can select a different style while a style-transfer request is still in flight. Before this fix, `academy-remix.vue`'s `onGenerated` looked up which style to credit from the live store state *after* the async request resolved — not from what was actually used for that request.

Concrete failure this fixes: pick Baroque, click Apply (generation starts), switch to Cubism while it's still running, Baroque's result lands — and the old code credited **Cubism** (never actually generated) instead of Baroque (the style that was actually used). This corrupted the Academy's persisted (localStorage) "styles remixed" progress count and checkmarks shown in `academy-timeline.vue`/`academy-styles-browser.vue`.

### How I verified
- `npx eslint` on both changed files: 0 errors.
- `npx prettier --check` on both changed files: clean.
- Full-project `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`), provisioned via conductor's `provision_kind_robots_deps.sh`: exit 0, no type errors.
- Checked all three existing callers of `art-styler`'s `@generated` event (`avatar-picker.vue`, `coloring-book-page.vue` x2) — none of them read a second argument, so adding one to the emit signature is backward compatible.

### Stakes
reversible

### Flags for Reviewer
- None — scoped, additive-only change to an emit signature and its one real consumer.

### Kaizen suggestion
`art-styler.vue`'s style swatches (and its gallery/starter source-image tiles) still have no `:disabled`/pointer-events guard during `isGenerating`, so a user can still visually reselect mid-request even though the result is now correctly attributed. A follow-up UX pass could disable those controls while `isGenerating` is true, matching the existing textarea/Clear-button pattern, to make the in-flight state visually clear rather than just data-correct.

### Notes for reviewer
Filed and found via this cycle's `ai-art-academy/t-010` (recurring continuous-improvement task) lane-1 investigation — tracked as its own task, `ai-art-academy/t-032`, since t-010 was already claimed by a concurrent session when this was discovered.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UuUuQArgsjrboLF7r3nmik)_