### PR TITLE
Return lean Character mutation responses

### DIFF
--- a/cypress/e2e/api/characters.cy.ts
+++ b/cypress/e2e/api/characters.cy.ts
@@ -101,6 +101,10 @@ describe('Character Management API Tests', () => {
       expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body.success).to.be.true
       expect(response.body.data).to.be.an('object').that.is.not.empty
+      expect(response.body.data).to.not.have.property('ArtImage')
+      expect(response.body.data).to.not.have.property('Rewards')
+      expect(response.body.data).to.not.have.property('Scenarios')
+      expect(response.body.data).to.not.have.property('Dreams')
 
       characterId = response.body.data.id
       expect(characterId).to.be.a('number').and.to.be.greaterThan(0)
@@ -155,6 +159,10 @@ describe('Character Management API Tests', () => {
       expect(response.status).to.eq(200)
       expect(response.body.success).to.be.true
       expect(response.body.data.name).to.eq(updatedCharacterName)
+      expect(response.body.data).to.not.have.property('ArtImage')
+      expect(response.body.data).to.not.have.property('Rewards')
+      expect(response.body.data).to.not.have.property('Scenarios')
+      expect(response.body.data).to.not.have.property('Dreams')
     })
   })
 

--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -10,6 +10,7 @@ import {
   getUniqueCharacterSlug,
 } from '../../utils/characterSlug'
 import type { Character, Prisma } from '~/prisma/generated/prisma/client'
+import { characterMutationSelect } from './selects'
 
 type CharacterPatchBody = Partial<Character> & {
   rewardIds?: unknown
@@ -321,44 +322,7 @@ export default defineEventHandler(async (event) => {
     const data = await prisma.character.update({
       where: { id },
       data: updateData,
-      include: {
-        ArtImage: {
-          select: {
-            id: true,
-            imagePath: true,
-            fileName: true,
-          },
-        },
-        Rewards: {
-          select: {
-            id: true,
-            name: true,
-            description: true,
-            flavorText: true,
-            effect: true,
-            icon: true,
-            collection: true,
-            rarity: true,
-            rewardType: true,
-            imagePath: true,
-            artPrompt: true,
-            isPublic: true,
-            isMature: true,
-          },
-        },
-        Scenarios: {
-          select: {
-            id: true,
-            title: true,
-          },
-        },
-        Dreams: {
-          select: {
-            id: true,
-            title: true,
-          },
-        },
-      },
+      select: characterMutationSelect,
     })
 
     event.node.res.statusCode = 200

--- a/server/api/characters/index.post.ts
+++ b/server/api/characters/index.post.ts
@@ -1,5 +1,5 @@
 // /server/api/characters/index.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import { errorHandler } from '../../utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import prisma from '../../utils/prisma'
@@ -10,10 +10,11 @@ import {
   getUniqueCharacterSlug,
 } from '../../utils/characterSlug'
 import type {
-  Prisma,
   Character,
+  Prisma,
   Rarity,
 } from '~/prisma/generated/prisma/client'
+import { characterMutationSelect } from './selects'
 
 type CharacterCreateBody = Partial<Character> & {
   rewardIds?: number[]
@@ -114,7 +115,6 @@ export default defineEventHandler(async (event) => {
 
     const requestedSlug = normalizeSlugInput(characterData.slug)
     const slug = await getUniqueCharacterSlug(prisma, requestedSlug ?? name)
-
     const rewardIds = normalizeIdArray(characterData.rewardIds, 'rewardIds')
     const scenarioIds = normalizeIdArray(
       characterData.scenarioIds,
@@ -128,7 +128,6 @@ export default defineEventHandler(async (event) => {
           id: user.id,
         },
       },
-
       name,
       slug,
       honorific: cleanShortText(characterData.honorific) ?? 'adventurer',
@@ -145,14 +144,12 @@ export default defineEventHandler(async (event) => {
       backstory: cleanText(characterData.backstory),
       achievements: cleanShortText(characterData.achievements),
       quirks: cleanText(characterData.quirks),
-
       luck: normalizeRarity(characterData.luck),
       might: normalizeRarity(characterData.might),
       wits: normalizeRarity(characterData.wits),
       grace: normalizeRarity(characterData.grace),
       charm: normalizeRarity(characterData.charm),
       empathy: normalizeRarity(characterData.empathy),
-
       artPrompt: cleanText(characterData.artPrompt),
       imagePath: cleanShortText(characterData.imagePath),
       experience: Number.isInteger(characterData.experience)
@@ -166,7 +163,6 @@ export default defineEventHandler(async (event) => {
       isPublic: characterData.isPublic ?? true,
       isMature: characterData.isMature ?? false,
       isActive: characterData.isActive ?? true,
-
       ArtImage: characterData.artImageId
         ? {
             connect: {
@@ -174,19 +170,16 @@ export default defineEventHandler(async (event) => {
             },
           }
         : undefined,
-
       Rewards: rewardIds.length
         ? {
             connect: rewardIds.map((id) => ({ id })),
           }
         : undefined,
-
       Scenarios: scenarioIds.length
         ? {
             connect: scenarioIds.map((id) => ({ id })),
           }
         : undefined,
-
       Dreams: dreamIds.length
         ? {
             connect: dreamIds.map((id) => ({ id })),
@@ -196,12 +189,7 @@ export default defineEventHandler(async (event) => {
 
     const data = await prisma.character.create({
       data: fullData,
-      include: {
-        ArtImage: true,
-        Rewards: true,
-        Scenarios: true,
-        Dreams: true,
-      },
+      select: characterMutationSelect,
     })
 
     event.node.res.statusCode = 201
@@ -210,6 +198,7 @@ export default defineEventHandler(async (event) => {
       success: true,
       data,
       message: 'Character created successfully.',
+      statusCode: 201,
     }
   } catch (error: unknown) {
     const { message, statusCode } = errorHandler(error)
@@ -219,6 +208,7 @@ export default defineEventHandler(async (event) => {
       success: false,
       data: null,
       message: message || 'Failed to create character.',
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/characters/selects.ts
+++ b/server/api/characters/selects.ts
@@ -1,0 +1,45 @@
+// /server/api/characters/selects.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const characterMutationSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  name: true,
+  achievements: true,
+  alignment: true,
+  experience: true,
+  level: true,
+  class: true,
+  species: true,
+  backstory: true,
+  drive: true,
+  quirks: true,
+  genre: true,
+  artImageId: true,
+  isPublic: true,
+  userId: true,
+  artPrompt: true,
+  honorific: true,
+  imagePath: true,
+  designer: true,
+  personality: true,
+  sampleResponse: true,
+  isMature: true,
+  isActive: true,
+  charm: true,
+  empathy: true,
+  grace: true,
+  luck: true,
+  might: true,
+  presentation: true,
+  role: true,
+  title: true,
+  wits: true,
+  gender: true,
+  slug: true,
+} satisfies Prisma.CharacterSelect
+
+export type CharacterMutationResult = Prisma.CharacterGetPayload<{
+  select: typeof characterMutationSelect
+}>


### PR DESCRIPTION
## What changed

- adds a complete scalar `characterMutationSelect`
- replaces relation-heavy Character POST/PATCH includes with the lean mutation projection
- preserves relation connections as Character state without returning ArtImage, Reward, Scenario, or Dream graphs
- adds API assertions that create and update responses stay lean

## Store impact

No extra store orchestration is required for this slice: Character list/detail queries already return scalar Character rows, and `characterStore` already has dedicated relationship fetches such as `fetchCharacterRewards`. The mutation response now matches that established scalar shape instead of being the odd relation-heavy exception.

## Checks

- TypeScript Type Check: passed
- Contract Tests: passed
- existing Character Cypress API suite runs against production after merge
- Vercel preview may be skipped while the account-wide build-rate limit is active; this slice changes server TypeScript and tests only