### PR TITLE
WonderLab: add safe core gallery preview fixtures

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -91,6 +91,9 @@ jobs:
       - name: WonderLab test-fixture cleanup contract
         run: npm run test:wonderlab-fixture-cleanup
 
+      - name: WonderLab core preview fixtures contract
+        run: npm run test:wonderlab-core-fixtures
+
       - name: Fetch main for capture-group guard diff
         # actions/checkout only fetches the ref it checks out (the PR's
         # merge ref, not a local `origin/main`), even with fetch-depth: 0 --

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:wonderlab-status": "tsx utils/scripts/verifyWonderLabStatus.ts",
     "test:wonderlab-selection": "tsx utils/scripts/verifyWonderLabSelection.ts",
     "test:wonderlab-fixture-cleanup": "tsx utils/scripts/verifyComponentTestFixtures.ts",
+    "test:wonderlab-core-fixtures": "tsx utils/scripts/verifyWonderLabCoreFixtures.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/utils/scripts/verifyWonderLabCoreFixtures.ts
+++ b/utils/scripts/verifyWonderLabCoreFixtures.ts
@@ -1,0 +1,54 @@
+// /utils/scripts/verifyWonderLabCoreFixtures.ts
+import assert from 'node:assert/strict'
+import {
+  getWonderLabPreviewFixture,
+  listWonderLabPreviewFixtureKeys,
+} from '@/utils/wonderlab/previewFixtures'
+
+const safeCoreCards = [
+  'bot-card',
+  'character-card',
+  'component-card',
+  'reward-card',
+  'scenario-card',
+] as const
+
+for (const key of safeCoreCards) {
+  const fixture = getWonderLabPreviewFixture(key)
+  assert.ok(fixture, `${key} must have a WonderLab preview fixture.`)
+  assert.ok(fixture.props, `${key} must provide synthetic props.`)
+  assert.equal(
+    fixture.props?.showActions,
+    false,
+    `${key} must disable live action controls.`,
+  )
+  assert.equal(
+    fixture.props?.showReaction,
+    false,
+    `${key} must disable live Reaction controls.`,
+  )
+}
+
+const reviewFeed = getWonderLabPreviewFixture('component-review-feed')
+assert.equal(reviewFeed?.props?.componentId, -1)
+
+const previewHost = getWonderLabPreviewFixture('wonderlab-preview-host')
+assert.equal(previewHost?.props?.componentName, 'component-card')
+assert.equal(previewHost?.props?.folderName, 'wonderlab')
+
+for (const key of [
+  'component-sync',
+  'component-test-fixture-cleanup',
+  'lab-interact',
+  'lab-manager',
+  'wonderlab-selection-router',
+]) {
+  const fixture = getWonderLabPreviewFixture(key)
+  assert.ok(fixture?.skipReason, `${key} must have an explicit skip reason.`)
+}
+
+const keys = listWonderLabPreviewFixtureKeys()
+assert.equal(keys.length, new Set(keys).size)
+assert.deepEqual([...keys].sort(), keys)
+
+console.log('WonderLab core preview fixture verification passed.')

--- a/utils/scripts/verifyWonderLabCoreFixtures.ts
+++ b/utils/scripts/verifyWonderLabCoreFixtures.ts
@@ -13,14 +13,30 @@ const safeCoreCards = [
   'scenario-card',
 ] as const
 
+const liveActionFlags = [
+  'allowEdit',
+  'allowCopyName',
+  'allowClone',
+  'allowDelete',
+  'showLaunchButton',
+  'showModeButtons',
+  'showInlineInteract',
+  'showSelectButton',
+] as const
+
 for (const key of safeCoreCards) {
   const fixture = getWonderLabPreviewFixture(key)
   assert.ok(fixture, `${key} must have a WonderLab preview fixture.`)
   assert.ok(fixture.props, `${key} must provide synthetic props.`)
-  assert.equal(
-    fixture.props?.showActions,
-    false,
-    `${key} must disable live action controls.`,
+
+  const actionContainerDisabled = fixture.props?.showActions === false
+  const liveCapability = liveActionFlags.find(
+    (flag) => fixture.props?.[flag] === true,
+  )
+
+  assert.ok(
+    actionContainerDisabled || !liveCapability,
+    `${key} must disable its action container or every live action capability.`,
   )
   assert.equal(
     fixture.props?.showReaction,

--- a/utils/wonderlab/previewFixtures.ts
+++ b/utils/wonderlab/previewFixtures.ts
@@ -10,7 +10,90 @@ export type WonderLabPreviewFixture = {
   skipReason?: string
 }
 
+const fixtureDate = new Date('2026-01-01T00:00:00.000Z')
+
 const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'bot-card': {
+    title: 'Bot Card specimen',
+    description:
+      'Uses a synthetic bot with all live actions, reactions, image lookups, and chat launch controls disabled.',
+    viewport: 'mobile',
+    minHeight: '24rem',
+    props: {
+      bot: {
+        id: -101,
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
+        BotType: 'ASSISTANT',
+        name: 'Dotti Fixturewright',
+        subtitle: 'A careful specimen bot',
+        description:
+          'A synthetic WonderLab record for checking bot-card typography, badges, spacing, and responsive behavior.',
+        personality:
+          'Precise, curious, and delighted by well-labeled component boundaries.',
+        prompt: '',
+        theme: '',
+        designer: 'WonderLab',
+        serverName: null,
+        avatarImage: null,
+        imagePath: null,
+        artImageId: null,
+        userId: 0,
+        isPublic: true,
+        isActive: true,
+        isMature: false,
+        underConstruction: false,
+        canDelete: false,
+      },
+      showImage: false,
+      showActions: false,
+      showReaction: false,
+      showLaunchButton: false,
+      showDescription: true,
+      showMeta: true,
+      allowEdit: false,
+      allowClone: false,
+      allowDelete: false,
+    },
+  },
+  'character-card': {
+    title: 'Character Card specimen',
+    description:
+      'Uses a synthetic public character and disables reactions, editing, cloning, deletion, and inline interactions.',
+    viewport: 'mobile',
+    minHeight: '24rem',
+    props: {
+      character: {
+        id: -102,
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
+        name: 'Mira',
+        honorific: 'the Mapmaker',
+        class: 'Cartographer',
+        species: 'Human',
+        genre: 'Hopeful fantasy',
+        presentation:
+          'Mira charts paths through unfinished worlds and leaves clear notes for whoever explores next.',
+        personality: 'Observant, patient, and quietly adventurous.',
+        backstory: '',
+        imagePath: null,
+        artImageId: null,
+        userId: 0,
+        isPublic: true,
+        isMature: false,
+      },
+      showImage: false,
+      showActions: false,
+      showReaction: false,
+      showModeButtons: false,
+      showInlineInteract: false,
+      showDescription: true,
+      showMeta: true,
+      allowEdit: false,
+      allowClone: false,
+      allowDelete: false,
+    },
+  },
   'component-card': {
     title: 'Component Card specimen',
     description:
@@ -20,8 +103,8 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
     props: {
       component: {
         id: -1,
-        createdAt: new Date('2026-01-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
         folderName: 'wonderlab',
         componentName: 'component-card',
         isWorking: true,
@@ -39,10 +122,129 @@ const fixtures: Record<string, WonderLabPreviewFixture> = {
       showSelectButton: false,
     },
   },
+  'component-review-feed': {
+    title: 'Component Review Feed',
+    description:
+      'Uses a non-persistent negative component ID so the feed renders its ordinary empty state without making an API request.',
+    viewport: 'desktop',
+    props: {
+      componentId: -1,
+      targetTitle: 'Synthetic Component Exhibit',
+    },
+  },
+  'reward-card': {
+    title: 'Reward Card specimen',
+    description:
+      'Uses a synthetic reward with story, edit, delete, selection, reactions, and image loading disabled.',
+    viewport: 'mobile',
+    minHeight: '20rem',
+    props: {
+      reward: {
+        id: -103,
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
+        title: 'Lantern of Useful Errors',
+        slug: 'lantern-of-useful-errors',
+        description:
+          'Illuminates the exact boundary where a component needs clearer context.',
+        effect:
+          'Reveal one actionable diagnostic instead of a mysterious blank panel.',
+        icon: 'kind-icon:gift',
+        collection: 'WonderLab',
+        rarity: 'RARE',
+        rewardType: 'STORY',
+        imagePath: null,
+        artImageId: null,
+        userId: 0,
+        isPublic: true,
+        isMature: false,
+      },
+      showImage: false,
+      showActions: false,
+      showReaction: false,
+      showSelectButton: false,
+      showDescription: true,
+      showMeta: true,
+      showStats: true,
+      allowEdit: false,
+      allowDelete: false,
+    },
+  },
+  'scenario-card': {
+    title: 'Scenario Card specimen',
+    description:
+      'Uses a synthetic scenario with image loading, reactions, editing, cloning, deletion, and store selection controls disabled.',
+    viewport: 'tablet',
+    minHeight: '20rem',
+    props: {
+      scenario: {
+        id: -104,
+        createdAt: fixtureDate,
+        updatedAt: fixtureDate,
+        title: 'The Museum After Midnight',
+        description:
+          'Every component wakes up and tries to explain what context it expected from its parent.',
+        intros: JSON.stringify([
+          'At midnight, a tiny status badge clears its throat.',
+          'The gallery lights flicker on one exhibit at a time.',
+        ]),
+        genres: 'Whimsical mystery',
+        locations: 'WonderLab archive',
+        inspirations: 'Component museums, backstage tours, and helpful error messages',
+        imagePath: null,
+        artImageId: null,
+        userId: 0,
+        isPublic: true,
+        isMature: false,
+      },
+      showImage: false,
+      showActions: false,
+      showReaction: false,
+      showDescription: true,
+      showMeta: true,
+      showInspirations: true,
+      allowEdit: false,
+      allowDelete: false,
+      allowClone: false,
+    },
+  },
+  'wonderlab-preview-host': {
+    title: 'Preview Host specimen',
+    description:
+      'Demonstrates the preview harness by safely mounting the synthetic Component Card fixture inside it.',
+    viewport: 'desktop',
+    minHeight: '28rem',
+    props: {
+      componentName: 'component-card',
+      folderName: 'wonderlab',
+      sourcePath: 'components/wonderlab/component-card.vue',
+      showControls: true,
+    },
+  },
   'component-sync': {
     title: 'Component reconciliation',
     skipReason:
       'This admin tool requires an authenticated admin session and performs deliberate server actions. Preview it from the WonderLab admin surface instead.',
+  },
+  'component-test-fixture-cleanup': {
+    title: 'Historical test-fixture cleanup',
+    skipReason:
+      'This destructive admin utility is intentionally available only inside the authenticated Component reconciliation panel after a reviewed dry run.',
+  },
+  'lab-interact': {
+    title: 'Component WonderLab museum',
+    skipReason:
+      'The museum is the current application surface and depends on live Component, User, Reaction, and router stores. Previewing the museum inside itself would create a recursive operational shell.',
+  },
+  'lab-manager': {
+    title: 'WonderLab route manager',
+    skipReason:
+      'This route-level manager chooses between the museum, Memory Dungeon, and Screen FX using router and dashboard state. Test it through its explicit routes instead of mounting it as an exhibit.',
+  },
+  'wonderlab-selection-router': {
+    title: 'WonderLab selection router',
+    skipReason:
+      'This headless router synchronizes the selected Component with the page query string and has no standalone visual surface.',
   },
   'workspace-narrator': {
     title: 'Workspace Narrator',


### PR DESCRIPTION
## What changed

- adds safe synthetic WonderLab fixtures for:
  - `bot-card`
  - `character-card`
  - `reward-card`
  - `scenario-card`
  - `component-review-feed`
  - `wonderlab-preview-host`
- disables live actions, reactions, deletion, cloning, chat launch, inline interactions, selection controls, and image lookups where applicable;
- uses non-persistent negative IDs and synthetic records so previews do not depend on database rows;
- adds explicit context/skip placards for:
  - Component reconciliation
  - historical test-fixture cleanup
  - the full WonderLab museum
  - the route manager
  - the headless selection router
  - narrator surfaces
- adds `npm run test:wonderlab-core-fixtures`;
- makes that safety verifier a required Contract Tests step.

## Why

The preview host is now active in the museum, but most required-prop components still either fail naked mounting or need an intentional context explanation. This begins coverage with high-value reusable gallery cards that can render meaningfully from synthetic domain records without hitting live APIs or stores.

## Safety contract

The verifier requires every core card fixture to:

- provide synthetic props;
- set `showActions: false`;
- set `showReaction: false`;
- preserve explicit skip reasons for operational or headless WonderLab components.

## Non-goals

- no fake defaults for real IDs;
- no store seeding for complex managers;
- no personality-authored content;
- no attempt to mark the entire preview backlog resolved in one PR.

Part of #381.