### PR TITLE
CI: publish WonderLab preview coverage audit

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -97,6 +97,9 @@ jobs:
       - name: WonderLab visual preview fixtures contract
         run: npm run test:wonderlab-visual-fixtures
 
+      - name: WonderLab preview coverage audit
+        run: npm run audit:wonderlab-previews 2>&1 | tee wonderlab-preview-audit.txt
+
       - name: Fetch main for capture-group guard diff
         # actions/checkout only fetches the ref it checks out (the PR's
         # merge ref, not a local `origin/main`), even with fetch-depth: 0 --
@@ -123,5 +126,6 @@ jobs:
           path: |
             academy-examples-contract.txt
             channel-artwork-audit.txt
+            wonderlab-preview-audit.txt
           if-no-files-found: warn
           retention-days: 14


### PR DESCRIPTION
## What changed

- runs the existing non-strict WonderLab preview coverage audit in every Contract Tests workflow;
- preserves the audit output as `wonderlab-preview-audit.txt`;
- uploads that report with the other contract diagnostics artifacts.

## Why

WonderLab now has safe fixture batches for core gallery cards and visual-content cards, but the remaining required-prop backlog is still visible only when someone runs the audit manually. Publishing the report on every PR creates a durable baseline with exact source paths and missing fixture inputs.

## Behavior

- the audit remains non-blocking for the existing backlog;
- new fixture contracts remain blocking;
- no application/runtime code changes;
- the report can later support a no-regression threshold or strict gating once coverage is sufficient.

Part of #381.