### PR TITLE
Make Prompt endpoints resource-only

### DIFF
--- a/cypress/e2e/api/prompts.cy.ts
+++ b/cypress/e2e/api/prompts.cy.ts
@@ -1,35 +1,66 @@
-import { createLoggedInTestUser } from '../../support/api-auth'
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+  jsonHeaders,
+} from '../../support/api-auth'
+
 // cypress/e2e/api/prompts.cy.ts
-
 describe('Prompt Management API Tests', () => {
-
-  const baseUrl = 'https://kind-robots.vercel.app/api/prompts'
   const invalidToken = 'someInvalidTokenValue'
   const uniquePrompt = `devil bunny ${Date.now()}`
 
+  let apiBase = ''
+  let baseUrl = ''
+  let adminToken = ''
   let userToken = ''
   let userId = 0
   let promptId: number | undefined
+
+  const expectPromptResource = (prompt: Record<string, unknown>) => {
+    expect(prompt).to.have.property('id')
+    expect(prompt).to.have.property('prompt')
+    expect(prompt).to.have.property('userId')
+    expect(prompt).to.not.have.property('User')
+    expect(prompt).to.not.have.property('Bot')
+    expect(prompt).to.not.have.property('ArtImage')
+    expect(prompt).to.not.have.property('artIds')
+  }
+
   before(() => {
-    return createLoggedInTestUser().then((auth) => {
-      userToken = auth.token
-      userId = auth.id
-    })
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        baseUrl = `${apiBase}/prompts`
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((auth) => {
+        userToken = auth.token
+        userId = auth.id
+      })
   })
 
+  after(() => {
+    if (promptId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${baseUrl}/${promptId}`,
+        headers: bearerHeaders(userToken),
+        failOnStatusCode: false,
+      })
+    }
 
-
-
+    deleteTestUser(apiBase, adminToken, userId)
+  })
 
   it('should not allow creating a prompt without an authorization token', () => {
     cy.request({
       method: 'POST',
       url: baseUrl,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: jsonHeaders(),
       body: {
-        galleryId: 21,
         userId,
         prompt: uniquePrompt,
       },
@@ -44,12 +75,8 @@ describe('Prompt Management API Tests', () => {
     cy.request({
       method: 'POST',
       url: baseUrl,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${invalidToken}`,
-      },
+      headers: bearerHeaders(invalidToken),
       body: {
-        galleryId: 21,
         userId,
         prompt: uniquePrompt,
       },
@@ -60,39 +87,34 @@ describe('Prompt Management API Tests', () => {
     })
   })
 
-  it('Create a New Prompt with Valid Authentication', () => {
+  it('creates a Prompt without returning related object graphs', () => {
     cy.request({
       method: 'POST',
       url: baseUrl,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${userToken}`,
-      },
+      headers: bearerHeaders(userToken),
       body: {
-        galleryId: 21,
         userId,
         prompt: uniquePrompt,
-        CreationSource: 'HUMAN',
+        creationSource: 'HUMAN',
+        isPublic: false,
       },
     }).then((response) => {
-      expect(response.status).to.eq(201)
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body).to.have.property('success', true)
+      expectPromptResource(response.body.data)
 
       promptId = response.body.data.id
-
-      expect(promptId).to.be.a('number')
+      expect(promptId).to.be.a('number').and.greaterThan(0)
     })
   })
 
-  it('Attempt to Update Prompt without Authentication (expect failure)', () => {
+  it('should not update a prompt without authentication', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'PATCH',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: jsonHeaders(),
       body: {
         prompt: 'unauthorized bunny update',
       },
@@ -103,16 +125,13 @@ describe('Prompt Management API Tests', () => {
     })
   })
 
-  it('Attempt to Update Prompt with Invalid Token (expect failure)', () => {
+  it('should not update a prompt with an invalid token', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'PATCH',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${invalidToken}`,
-      },
+      headers: bearerHeaders(invalidToken),
       body: {
         prompt: 'invalid token bunny update',
       },
@@ -123,16 +142,13 @@ describe('Prompt Management API Tests', () => {
     })
   })
 
-  it('Update Prompt with Authentication', () => {
+  it('updates a Prompt with the same resource-only shape', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'PATCH',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${userToken}`,
-      },
+      headers: bearerHeaders(userToken),
       body: {
         prompt: 'angel bunny',
       },
@@ -140,34 +156,31 @@ describe('Prompt Management API Tests', () => {
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
       expect(response.body.data.prompt).to.eq('angel bunny')
+      expectPromptResource(response.body.data)
     })
   })
 
-  it('Get Prompt by ID', () => {
+  it('gets the Prompt resource without fetching related art', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'GET',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${userToken}`,
-      },
+      headers: bearerHeaders(userToken),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
+      expect(response.body.data.id).to.eq(promptId)
       expect(response.body.data.prompt).to.eq('angel bunny')
+      expectPromptResource(response.body.data)
     })
   })
 
-  it('Get All Prompts', () => {
+  it('gets all prompts', () => {
     cy.request({
       method: 'GET',
       url: baseUrl,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${userToken}`,
-      },
+      headers: bearerHeaders(userToken),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
@@ -177,59 +190,52 @@ describe('Prompt Management API Tests', () => {
     })
   })
 
-  it('Attempt to Delete Prompt without Authentication (expect failure)', () => {
+  it('should not delete a prompt without authentication', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'DELETE',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: jsonHeaders(),
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(401)
-      expect(response.body.message).to.include(
-        'Authorization token is required',
+      expect(response.body.message).to.match(
+        /Authorization token is required|Invalid or expired token/,
       )
     })
   })
 
-  it('Attempt to Delete Prompt with Invalid Token (expect failure)', () => {
+  it('should not delete a prompt with an invalid token', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'DELETE',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${invalidToken}`,
-      },
+      headers: bearerHeaders(invalidToken),
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(401)
-      expect(response.body.message).to.include(
-        'Authorization token is required',
+      expect(response.body.message).to.match(
+        /Authorization token is required|Invalid or expired token/,
       )
     })
   })
 
-  it('Delete Prompt with Authentication', () => {
+  it('deletes a Prompt with authentication', () => {
     expect(promptId).to.exist
 
     cy.request({
       method: 'DELETE',
       url: `${baseUrl}/${promptId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${userToken}`,
-      },
+      headers: bearerHeaders(userToken),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
       expect(response.body.message).to.include(
         `Prompt with ID ${promptId} successfully deleted.`,
       )
+      promptId = undefined
     })
   })
 })

--- a/docs/architecture/thin-resource-api-audit.md
+++ b/docs/architecture/thin-resource-api-audit.md
@@ -16,21 +16,21 @@ Examples of explicit commands include publish, import, reconcile, generate, comm
 
 ### P0 — Cross-resource side effects
 
-| Resource | Current problem | Action |
+| Resource | Previous problem | Completed action |
 | --- | --- | --- |
 | Dream create | Created ArtCollection and Chat records, updated ArtCollection, and returned `dreamInclude` | Removed unrelated writes and replaced the response with `dreamMutationSelect` |
-| Dream patch | Updated ArtCollection, created Chat records as an update log, re-read `dreamInclude` | Removed unrelated writes and second read; return the updated Dream projection |
+| Dream patch | Updated ArtCollection, created Chat records as an update log, re-read `dreamInclude` | Removed unrelated writes and second read; returns the updated Dream projection |
 | Dream batch create | Created ArtCollection, three ArtImage rows, Chat rows, updated Dream and collection, then re-read every Dream | Reduced to batch Dream creation with optional links to existing records |
-| Dream delete | Manually detaches Chats, Reactions, and many-to-many links before deletion | Keep temporarily for referential integrity; replace with explicit database delete behavior in a migration before simplifying the route |
+| Dream delete | Manually detaches Chats, Reactions, and many-to-many links before deletion | Kept temporarily for referential integrity; replace with explicit database delete behavior in a migration before simplifying the route |
 
-### P1 — Oversized mutation responses or mixed single/batch behavior
+### P1 — Completed response and resource-boundary cleanup
 
-| Resource | Finding | Planned action |
+| Resource | Previous finding | Completed action |
 | --- | --- | --- |
-| Character | Creates only Character, but accepts several relation sets and returns ArtImage, Rewards, Scenarios, and Dreams | Add a scalar mutation projection; let `characterStore` refresh detail when needed |
-| Scenario | One route handles both single and batch creation and returns ArtImage, User, Characters, and Dreams | Move batch behavior to the batch route and make single create return a scalar projection |
-| Reward | Shared helpers return ArtImage, Characters, Dreams, Reactions, and User after every mutation | Split mutation and detail projections; update `rewardStore` hydration |
-| Prompt | Returns User, Bot, and ArtImage after create and also awards public-content karma | Return a scalar Prompt projection; keep karma as server-side domain policy but isolate it from response shaping |
+| Character | POST/PATCH returned ArtImage, Rewards, Scenarios, and Dreams | Added `characterMutationSelect`; mutation routes return Character scalars while relationship fetches remain explicit |
+| Scenario | Single/batch create and PATCH returned ArtImage, User, Characters, and Dreams | Added `scenarioMutationSelect`; `scenarioStore` force-hydrates detail after mutations. The existing single-or-array POST contract remains temporarily for compatibility |
+| Reward | Shared helpers returned ArtImage, Characters, Dreams, Reactions, and User after every mutation | Added `rewardMutationSelect`; create, batch create, and update return Reward scalars while GET routes retain detail |
+| Prompt | Create returned User, Bot, and ArtImage; GET also fetched related art IDs | Added `promptResourceSelect`; Prompt POST/PATCH/GET return Prompt only. Related art remains on the existing art-by-prompt endpoint. Public-content karma remains isolated server-side domain policy |
 
 ### P2 — Moderate response weight or combined command behavior
 
@@ -78,12 +78,12 @@ For Dreams, collection creation remains an explicit `collectionStore` action. Ch
 
 ## Execution Order
 
-1. Dream mutation boundaries and regression tests.
-2. Dream store/form cleanup and removal of obsolete collection/chat flags.
-3. Character, Scenario, Reward, and Prompt mutation projections.
+1. ✅ Dream mutation boundaries and regression tests.
+2. ✅ Dream store/form cleanup and removal of obsolete collection/chat flags.
+3. ✅ Character, Scenario, Reward, and Prompt resource projections.
 4. Bot, Project, PitchSheet, and SocialPost response cleanup.
 5. Database referential-action migration for deletes that currently require manual cross-resource cleanup.
-6. Re-run API Cypress tests and compare Vercel mutation duration/error volume before merging each tier.
+6. Re-run deployed API Cypress tests and compare Vercel mutation duration/error volume when the account build-rate limit clears.
 
 ## Definition of Done
 

--- a/server/api/prompts/[id].get.ts
+++ b/server/api/prompts/[id].get.ts
@@ -1,65 +1,49 @@
 // /server/api/prompts/[id].get.ts
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
+import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
-import { fetchArtByPromptId, fetchPromptById } from '.'
+import { promptResourceSelect } from './selects'
 
-// Event handler for fetching Prompt and related Art by ID
 export default defineEventHandler(async (event) => {
-  let response
-
   try {
     const id = Number(event.context.params?.id)
 
-    if (isNaN(id) || id <= 0) {
-      throw new Error('Invalid ID format. It must be a positive integer.')
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid prompt ID. It must be a positive integer.',
+      })
     }
 
-    console.log(`Fetching Prompt with ID: ${id}`)
+    const data = await prisma.prompt.findUnique({
+      where: { id },
+      select: promptResourceSelect,
+    })
 
-    // Fetch Prompt by ID
-    const prompt = await fetchPromptById(id)
-
-    if (!prompt) {
-      console.warn(`Prompt with ID ${id} not found`)
-      return {
-        success: false,
-        message: 'Prompt not found',
-        statusCode: 404, // Not Found
-      }
+    if (!data) {
+      throw createError({
+        statusCode: 404,
+        message: 'Prompt not found.',
+      })
     }
 
-    console.log(`Fetched Prompt: ${JSON.stringify(prompt)}`)
+    event.node.res.statusCode = 200
 
-    // Fetch related Art by Prompt ID
-    const art = await fetchArtByPromptId(id)
-    console.log(`Fetched related Art: ${JSON.stringify(art)}`)
-
-    // Extract Art IDs
-    const artIds = art.map((a) => a.id)
-
-    // Successful response with prompt and art IDs
-    response = {
+    return {
       success: true,
-      data: {
-        prompt: prompt.prompt,
-        artIds,
-      },
+      data,
+      message: 'Prompt fetched successfully.',
       statusCode: 200,
     }
   } catch (error: unknown) {
-    console.error('Error fetching prompt or related art:', error)
-    // Use the errorHandler to process the error
-    const { message, statusCode } = errorHandler({
-      error,
-      context: 'Fetching Prompt and related Art by ID',
-    })
+    const { message, statusCode } = errorHandler(error)
+    event.node.res.statusCode = statusCode || 500
 
-    response = {
+    return {
       success: false,
-      message: message || 'Failed to fetch prompt and related art.',
-      statusCode: statusCode || 500,
+      data: null,
+      message: message || 'Failed to fetch prompt.',
+      statusCode: event.node.res.statusCode,
     }
   }
-
-  return response
 })

--- a/server/api/prompts/[id].patch.ts
+++ b/server/api/prompts/[id].patch.ts
@@ -1,23 +1,24 @@
-// /server/api/art/prompts/[id].patch.ts
-import { defineEventHandler, createError, readBody } from 'h3'
+// /server/api/prompts/[id].patch.ts
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import type { Prompt } from '~/prisma/generated/prisma/client'
+import { promptResourceSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
   try {
-    // Parse and validate the prompt ID from the URL params
     const id = Number(event.context.params?.id)
-    if (isNaN(id) || id <= 0) {
+
+    if (!Number.isInteger(id) || id <= 0) {
       throw createError({
         statusCode: 400,
         message: 'Invalid prompt ID. It must be a positive integer.',
       })
     }
 
-    // Authenticate the user
     const { isValid, user } = await validateApiKey(event)
+
     if (!isValid || !user) {
       throw createError({
         statusCode: 401,
@@ -25,56 +26,61 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Parse the incoming request body as partial prompt data
-    const updatedPromptData: Partial<Prompt> = await readBody(event)
+    const updatedPromptData = await readBody<Partial<Prompt>>(event)
+
     if (!updatedPromptData || Object.keys(updatedPromptData).length === 0) {
-      event.node.res.statusCode = 400
-      return {
-        success: false,
+      throw createError({
+        statusCode: 400,
         message: 'No data provided for update.',
-      }
+      })
     }
 
-    // Fetch the existing prompt to verify ownership
-    const existingPrompt = await prisma.prompt.findUnique({ where: { id } })
+    const existingPrompt = await prisma.prompt.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+      },
+    })
+
     if (!existingPrompt) {
-      event.node.res.statusCode = 404
-      return {
-        success: false,
+      throw createError({
+        statusCode: 404,
         message: 'Prompt not found.',
-      }
+      })
     }
 
-    // Verify ownership of the prompt
     if (existingPrompt.userId !== user.id) {
-      event.node.res.statusCode = 403
-      return {
-        success: false,
+      throw createError({
+        statusCode: 403,
         message: 'You do not have permission to update this prompt.',
-      }
+      })
     }
 
-    // Update the prompt in the database
     const data = await prisma.prompt.update({
       where: { id },
       data: updatedPromptData,
+      select: promptResourceSelect,
     })
 
-    // Set status code for successful update
     event.node.res.statusCode = 200
+
     return {
       success: true,
       data,
       message: 'Prompt updated successfully.',
+      statusCode: 200,
     }
   } catch (error) {
-    // Handle the error using the error handler
     const { message, statusCode } = errorHandler(error)
     event.node.res.statusCode = statusCode || 500
+
     return {
       success: false,
+      data: null,
       message: message || 'Failed to update the prompt.',
       error: message || 'An unknown error occurred',
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/prompts/index.post.ts
+++ b/server/api/prompts/index.post.ts
@@ -1,10 +1,11 @@
 // /server/api/prompts/index.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { awardKarma } from '../../utils/karma'
 import type { Prisma, Prompt } from '~/prisma/generated/prisma/client'
+import { promptResourceSelect } from './selects'
 
 type PromptCreateBody = Partial<Prompt> & {
   CreationSource?: string
@@ -147,32 +148,15 @@ export default defineEventHandler(async (event) => {
 
     const data = await prisma.prompt.create({
       data: createData,
-      include: {
-        User: {
-          select: {
-            id: true,
-            username: true,
-            Role: true,
-          },
-        },
-        Bot: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-        ArtImage: {
-          select: {
-            id: true,
-            imagePath: true,
-            fileName: true,
-          },
-        },
-      },
+      select: promptResourceSelect,
     })
 
     if (data.isPublic) {
-      awardKarma({ userId, reason: 'CONTENT_CREATED_PUBLIC', refId: String(data.id) }).catch(() => {})
+      void awardKarma({
+        userId,
+        reason: 'CONTENT_CREATED_PUBLIC',
+        refId: String(data.id),
+      }).catch(() => {})
     }
 
     event.node.res.statusCode = 201

--- a/server/api/prompts/selects.ts
+++ b/server/api/prompts/selects.ts
@@ -1,0 +1,34 @@
+// /server/api/prompts/selects.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const promptResourceSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  prompt: true,
+  userId: true,
+  botId: true,
+  artImageId: true,
+  creationSource: true,
+  isMature: true,
+  isPublic: true,
+  isActive: true,
+  artPrompt: true,
+  imagePath: true,
+  serverId: true,
+  artStatus: true,
+  batchId: true,
+  batchIndex: true,
+  queuePosition: true,
+  startedAt: true,
+  completedAt: true,
+  errorMessage: true,
+  notifiedAt: true,
+  isBounty: true,
+  bountyStatus: true,
+  claimerId: true,
+} satisfies Prisma.PromptSelect
+
+export type PromptResource = Prisma.PromptGetPayload<{
+  select: typeof promptResourceSelect
+}>


### PR DESCRIPTION
## What changed

- adds a complete scalar `promptResourceSelect`
- makes Prompt create and update return Prompt fields only
- changes `GET /api/prompts/:id` to return the Prompt resource instead of fetching related ArtImage IDs
- leaves related art on the existing `/api/art/prompt/:id` endpoint already used by `promptStore`
- keeps public-content karma as isolated server-side domain policy rather than response shaping
- updates Prompt Cypress coverage to assert the resource-only shape and clean up its disposable test user
- records Character, Scenario, Reward, and Prompt as the completed P1 API-thinning tier

## Store impact

`promptStore.fetchPromptById()` already expects a Prompt row, and `promptStore.fetchArtByPromptId()` already owns the separate art query. The route now matches the store architecture instead of returning a hybrid `{ prompt, artIds }` object.

## Checks

- TypeScript Type Check: passed
- Contract Tests: passed
- Prompt Cypress API suite runs against production after merge
- Vercel preview may be skipped while the account-wide build-rate limit is active