### PR TITLE
Return lean Bot mutations and fix store orchestration

### DIFF
--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -1,11 +1,12 @@
 import {
   bearerHeaders,
   createLoggedInTestUser,
+  deleteTestUser,
   getApiEnv,
   jsonHeaders,
 } from '../../support/api-auth'
+
 /* eslint-disable @typescript-eslint/no-unused-expressions */
-// cypress/e2e/api/bots.cy.ts
 
 type Bot = {
   id: number
@@ -13,9 +14,19 @@ type Bot = {
   description?: string
 }
 
+const expectLeanBot = (bot: Record<string, unknown>) => {
+  expect(bot).to.not.have.property('User')
+  expect(bot).to.not.have.property('Server')
+  expect(bot).to.not.have.property('ArtImage')
+  expect(bot).to.not.have.property('Dreams')
+  expect(bot).to.not.have.property('ExpressionMedia')
+  expect(bot).to.not.have.property('_count')
+}
+
 describe('Bot Management API Tests', () => {
-  let apiRoot = 'https://kind-robots.vercel.app/api'
-  let baseUrl = `${apiRoot}/bots`
+  let apiRoot = ''
+  let baseUrl = ''
+  let adminToken = ''
   const invalidToken = 'someInvalidTokenValue'
 
   let userToken = ''
@@ -25,11 +36,12 @@ describe('Bot Management API Tests', () => {
   const botName = `testbot-${Date.now()}`
 
   before(() => {
-    getApiEnv()
+    return getApiEnv()
       .then((env) => {
         apiRoot = env.apiBase
+        adminToken = env.adminToken
         baseUrl = `${apiRoot}/bots`
-        return createLoggedInTestUser()
+        return createLoggedInTestUser({ fresh: true })
       })
       .then((auth) => {
         userToken = auth.token
@@ -46,6 +58,8 @@ describe('Bot Management API Tests', () => {
         failOnStatusCode: false,
       })
     }
+
+    deleteTestUser(apiRoot, adminToken, userId)
   })
 
   it('should not allow creating a bot without an authorization token', () => {
@@ -88,7 +102,7 @@ describe('Bot Management API Tests', () => {
     })
   })
 
-  it('Create a New Bot with Valid Authentication', () => {
+  it('creates a Bot with a lean mutation response', () => {
     expect(userId, 'shared Cypress user id').to.be.a('number').and.be.greaterThan(0)
 
     cy.request({
@@ -114,9 +128,10 @@ describe('Bot Management API Tests', () => {
         userId,
       },
     }).then((response) => {
-      expect(response.status).to.eq(201)
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body).to.have.property('success', true)
       expect(response.body).to.have.property('data')
+      expectLeanBot(response.body.data)
 
       createdBotId = response.body.data.id
       expect(createdBotId).to.be.a('number')
@@ -159,7 +174,7 @@ describe('Bot Management API Tests', () => {
     })
   })
 
-  it('Update Bot with Valid Authentication', () => {
+  it('updates a Bot with the same lean mutation response', () => {
     expect(createdBotId, 'createdBotId').to.be.a('number')
 
     cy.request({
@@ -175,15 +190,16 @@ describe('Bot Management API Tests', () => {
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body).to.have.property('success', true)
-      expect(response.body.data).to.have.property('id')
       expect(response.body.data).to.include({
+        id: createdBotId,
         description: 'Updated description for the test bot',
         tagline: 'Now with advanced features',
       })
+      expectLeanBot(response.body.data)
     })
   })
 
-  it('Fetch Bot Details in General Listing', () => {
+  it('fetches Bot details in the general listing', () => {
     expect(createdBotId, 'createdBotId').to.be.a('number')
 
     cy.request({
@@ -195,7 +211,9 @@ describe('Bot Management API Tests', () => {
       expect(response.body).to.have.property('success', true)
       expect(response.body.data).to.be.an('array')
 
-      const bot = response.body.data.find((candidate: Bot) => candidate.id === createdBotId)
+      const bot = response.body.data.find(
+        (candidate: Bot) => candidate.id === createdBotId,
+      )
 
       expect(bot).to.include({
         id: createdBotId,
@@ -235,7 +253,7 @@ describe('Bot Management API Tests', () => {
     })
   })
 
-  it('Delete Bot with Valid Authentication', () => {
+  it('deletes a Bot with valid authentication', () => {
     expect(createdBotId, 'createdBotId').to.be.a('number')
 
     cy.request({

--- a/docs/architecture/thin-resource-api-audit.md
+++ b/docs/architecture/thin-resource-api-audit.md
@@ -34,9 +34,9 @@ Examples of explicit commands include publish, import, reconcile, generate, comm
 
 ### P2 — Moderate response weight or combined command behavior
 
-| Resource | Finding | Planned action |
+| Resource | Finding | Action |
 | --- | --- | --- |
-| Bot | Creates only Bot and uses a bounded include, but mutation callers receive relation summaries by default | Add a mutation projection and explicitly refresh detail in `botStore` |
+| Bot | POST/PATCH returned User, Server, and ArtImage summaries; the helper used a nonexistent singular route and posted arrays to single-resource CRUD | Added `botMutationSelect`; mutations return Bot scalars. `botHelper` now uses `/api/bots` and coordinates multiple creates as individual POSTs |
 | Project | Returns manager, art, collection, pitch sheet, and six counts after create | Return Project mutation fields; retain the stale-connection fallback as persistence infrastructure |
 | PitchSheet | One create route handles standalone and Dream-derived creation and returns Dream plus ArtImage | Keep Dream-derived creation as an explicit command route; use lean PitchSheet mutation responses |
 | SocialPost | Creates owned SocialTarget children as part of the post aggregate | Keep aggregate creation; replace full target rows with the smallest useful response where callers allow it |
@@ -81,9 +81,9 @@ For Dreams, collection creation remains an explicit `collectionStore` action. Ch
 1. ✅ Dream mutation boundaries and regression tests.
 2. ✅ Dream store/form cleanup and removal of obsolete collection/chat flags.
 3. ✅ Character, Scenario, Reward, and Prompt resource projections.
-4. Bot, Project, PitchSheet, and SocialPost response cleanup.
+4. Bot, Project, PitchSheet, and SocialPost response cleanup. Bot is complete; Project is next.
 5. Database referential-action migration for deletes that currently require manual cross-resource cleanup.
-6. Re-run deployed API Cypress tests and compare Vercel mutation duration/error volume when the account build-rate limit clears.
+6. Re-run deployed API Cypress tests and compare Vercel mutation duration/error volume when production catches up to the merged API tier.
 
 ## Definition of Done
 

--- a/server/api/bots/[id].patch.ts
+++ b/server/api/bots/[id].patch.ts
@@ -1,38 +1,46 @@
 // /server/api/bots/[id].patch.ts
-import { defineEventHandler, createError, getRouterParam, readBody } from 'h3'
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
+import { botMutationSelect } from './selects'
 
-type BotPatchBody = Partial<Bot>
+type BotPatchBody = Partial<Bot> & {
+  dreamIds?: unknown
+  addDreamIds?: unknown
+  removeDreamIds?: unknown
+}
 
 function getStringOrUndefined(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
 function getDreamRelationUpdate(
-  body: any,
+  body: BotPatchBody,
 ): Prisma.DreamUpdateManyWithoutBotsNestedInput | undefined {
-  const toIds = (v: unknown) =>
-    Array.isArray(v)
-      ? v
-          .map((x: any) => (typeof x === 'object' ? Number(x.id) : Number(x)))
-          .filter((n) => Number.isInteger(n) && n > 0)
+  const toIds = (value: unknown) =>
+    Array.isArray(value)
+      ? value
+          .map((entry: any) =>
+            typeof entry === 'object' ? Number(entry.id) : Number(entry),
+          )
+          .filter((id) => Number.isInteger(id) && id > 0)
           .map((id) => ({ id }))
       : []
 
   const set = body.dreamIds !== undefined ? toIds(body.dreamIds) : undefined
   const connect = toIds(body.addDreamIds)
   const disconnect = toIds(body.removeDreamIds)
+  const relation: Prisma.DreamUpdateManyWithoutBotsNestedInput = {}
 
-  const op: any = {}
-  if (set !== undefined) op.set = set
-  if (connect.length) op.connect = connect
-  if (disconnect.length) op.disconnect = disconnect
-  return Object.keys(op).length ? op : undefined
+  if (set !== undefined) relation.set = set
+  if (connect.length) relation.connect = connect
+  if (disconnect.length) relation.disconnect = disconnect
+
+  return Object.keys(relation).length ? relation : undefined
 }
 
 function getBooleanOrUndefined(value: unknown): boolean | undefined {
@@ -175,10 +183,9 @@ export default defineEventHandler(async (event) => {
       artImageId,
     })
 
-    // Slug handling: dedupe an explicitly provided slug; otherwise backfill a
-    // missing slug from the (new or existing) name so every bot ends up with one.
     let slugUpdate: string | null | undefined
     const requestedSlug = normalizeSlugInput(body.slug)
+
     if (requestedSlug !== undefined) {
       slugUpdate = requestedSlug
         ? await getUniqueBotSlug(prisma, requestedSlug, { excludeId: id })
@@ -197,6 +204,7 @@ export default defineEventHandler(async (event) => {
       subtitle: getStringOrUndefined(body.subtitle),
       description: getStringOrUndefined(body.description),
       avatarImage: getStringOrUndefined(body.avatarImage),
+      imagePath: getStringOrUndefined(body.imagePath),
       botIntro: getStringOrUndefined(body.botIntro),
       userIntro: getStringOrUndefined(body.userIntro),
       prompt: getStringOrUndefined(body.prompt),
@@ -206,8 +214,9 @@ export default defineEventHandler(async (event) => {
       modules: getStringOrUndefined(body.modules),
       sampleResponse: getStringOrUndefined(body.sampleResponse),
       tagline: getStringOrUndefined(body.tagline),
-      narrativeVoice: getStringOrUndefined(body.narrativeVoice), // ADD
-      forgeIntro: getStringOrUndefined(body.forgeIntro), // ADD
+      narrativeVoice: getStringOrUndefined(body.narrativeVoice),
+      forgeIntro: getStringOrUndefined(body.forgeIntro),
+      chatBorderImage: getStringOrUndefined(body.chatBorderImage),
       designer: getStringOrUndefined(body.designer),
       serverName: getStringOrUndefined(body.serverName),
       artPrompt: getStringOrUndefined(body.artPrompt),
@@ -233,7 +242,7 @@ export default defineEventHandler(async (event) => {
           : artImageId
             ? { connect: { id: artImageId } }
             : undefined,
-      Dreams: getDreamRelationUpdate(body), // ADD
+      Dreams: getDreamRelationUpdate(body),
     }
 
     if (!hasUpdateData(updateData as Record<string, unknown>)) {
@@ -246,30 +255,7 @@ export default defineEventHandler(async (event) => {
     const data = await prisma.bot.update({
       where: { id },
       data: updateData,
-      include: {
-        User: {
-          select: {
-            id: true,
-            username: true,
-            Role: true,
-          },
-        },
-        Server: {
-          select: {
-            id: true,
-            title: true,
-            label: true,
-            serverType: true,
-          },
-        },
-        ArtImage: {
-          select: {
-            id: true,
-            imagePath: true,
-            fileName: true,
-          },
-        },
-      },
+      select: botMutationSelect,
     })
 
     event.node.res.statusCode = 200

--- a/server/api/bots/index.post.ts
+++ b/server/api/bots/index.post.ts
@@ -1,11 +1,12 @@
 // /server/api/bots/index.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
+import { botMutationSelect } from './selects'
 
 type BotCreateBody = Partial<Bot> & {
   Dreams?: { connect?: { id: number }[] } | { id: number }[]
@@ -30,8 +31,11 @@ function getDreamConnect(
   const raw = (value as any)?.connect ?? value
   if (!Array.isArray(raw)) return undefined
   const ids = raw
-    .map((x: any) => (typeof x === 'object' ? Number(x.id) : Number(x)))
-    .filter((n) => Number.isInteger(n) && n > 0)
+    .map((entry: any) =>
+      typeof entry === 'object' ? Number(entry.id) : Number(entry),
+    )
+    .filter((id) => Number.isInteger(id) && id > 0)
+
   return ids.length ? { connect: ids.map((id) => ({ id })) } : undefined
 }
 
@@ -95,7 +99,6 @@ export default defineEventHandler(async (event) => {
   try {
     const auth = await requireApiUser(event)
     const { user } = auth
-
     const botData = await readBody<BotCreateBody>(event)
 
     const isServerKey = auth.isServerKey
@@ -147,6 +150,7 @@ export default defineEventHandler(async (event) => {
       subtitle: getStringOrNull(botData.subtitle),
       description: getStringOrNull(botData.description),
       avatarImage: getStringOrNull(botData.avatarImage),
+      imagePath: getStringOrNull(botData.imagePath),
       botIntro: getStringOrDefault(
         botData.botIntro,
         'I am a freshly created bot.',
@@ -161,6 +165,7 @@ export default defineEventHandler(async (event) => {
       tagline: getStringOrNull(botData.tagline),
       narrativeVoice: getStringOrNull(botData.narrativeVoice),
       forgeIntro: getStringOrNull(botData.forgeIntro),
+      chatBorderImage: getStringOrNull(botData.chatBorderImage),
       designer: getStringOrDefault(botData.designer, 'silasfelinus'),
       serverName: getStringOrNull(botData.serverName),
       artPrompt: getStringOrNull(botData.artPrompt),
@@ -182,35 +187,12 @@ export default defineEventHandler(async (event) => {
             connect: { id: artImageId },
           }
         : undefined,
-      Dreams: getDreamConnect(botData.Dreams ?? (botData as any).dreamIds),
+      Dreams: getDreamConnect(botData.Dreams ?? botData.dreamIds),
     }
 
     const bot = await prisma.bot.create({
       data,
-      include: {
-        User: {
-          select: {
-            id: true,
-            username: true,
-            Role: true,
-          },
-        },
-        Server: {
-          select: {
-            id: true,
-            title: true,
-            label: true,
-            serverType: true,
-          },
-        },
-        ArtImage: {
-          select: {
-            id: true,
-            imagePath: true,
-            fileName: true,
-          },
-        },
-      },
+      select: botMutationSelect,
     })
 
     event.node.res.statusCode = 201

--- a/server/api/bots/selects.ts
+++ b/server/api/bots/selects.ts
@@ -1,0 +1,42 @@
+// /server/api/bots/selects.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const botMutationSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  BotType: true,
+  name: true,
+  slug: true,
+  subtitle: true,
+  description: true,
+  avatarImage: true,
+  imagePath: true,
+  botIntro: true,
+  userIntro: true,
+  prompt: true,
+  trainingPath: true,
+  theme: true,
+  personality: true,
+  modules: true,
+  sampleResponse: true,
+  tagline: true,
+  narrativeVoice: true,
+  forgeIntro: true,
+  chatBorderImage: true,
+  designer: true,
+  userId: true,
+  serverId: true,
+  serverName: true,
+  artImageId: true,
+  isPublic: true,
+  underConstruction: true,
+  canDelete: true,
+  isMature: true,
+  isActive: true,
+  artPrompt: true,
+} satisfies Prisma.BotSelect
+
+export type BotMutationResult = Prisma.BotGetPayload<{
+  select: typeof botMutationSelect
+}>

--- a/stores/helpers/botHelper.ts
+++ b/stores/helpers/botHelper.ts
@@ -38,7 +38,7 @@ export async function updateBot(
 
 export async function addBot(botData: BotPayload): Promise<Bot | null> {
   try {
-    const response = await performFetch<Bot>('/api/bot', {
+    const response = await performFetch<Bot>('/api/bots', {
       method: 'POST',
       body: JSON.stringify(botData),
     })
@@ -55,17 +55,9 @@ export async function addBot(botData: BotPayload): Promise<Bot | null> {
 }
 
 export async function addBots(botsData: BotPayload[]): Promise<Bot[]> {
-  try {
-    const response = await performFetch<Bot[]>('/api/bots', {
-      method: 'POST',
-      body: JSON.stringify(botsData),
-    })
+  const results = await Promise.all(botsData.map((bot) => addBot(bot)))
 
-    return response.success && response.data ? response.data : []
-  } catch (error: unknown) {
-    handleError(error, 'adding bots')
-    return []
-  }
+  return results.filter((bot): bot is Bot => bot !== null)
 }
 
 export async function deleteBot(id: number): Promise<boolean> {


### PR DESCRIPTION
## What changed

- adds a complete scalar `botMutationSelect`
- makes Bot create and update return Bot fields only instead of User, Server, and ArtImage summaries
- preserves Dream, Server, ArtImage, and ownership links as Bot state
- fixes `botHelper.addBot()` to use the real `/api/bots` route
- changes `botHelper.addBots()` from posting an unsupported array to coordinating individual resource POSTs
- adds lean-response assertions to the Bot Cypress suite
- makes the Bot test user disposable and cleans it after the run
- updates the API audit with Bot as the first completed P2 resource

## Store impact

`botStore` already stores scalar Prisma Bot rows and resolves artwork through `artStore` by `artImageId`. No detail refetch is needed after mutation. Multi-create is now explicitly coordinated by the helper/store layer rather than widening the Bot CRUD contract.

## Checks

- TypeScript Type Check: passed
- Contract Tests: passed
- Bot Cypress API suite runs against production after merge