### PR TITLE
Return lean Project mutations across Prisma and fallback paths

### DIFF
--- a/cypress/e2e/api/projects.cy.ts
+++ b/cypress/e2e/api/projects.cy.ts
@@ -1,26 +1,55 @@
 // /cypress/e2e/api/projects.cy.ts
-import { createLoggedInTestUser } from '../../support/api-auth'
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+const expectLeanProject = (project: Record<string, unknown>) => {
+  expect(project).to.not.have.property('Manager')
+  expect(project).to.not.have.property('ArtImage')
+  expect(project).to.not.have.property('ArtCollection')
+  expect(project).to.not.have.property('PitchSheet')
+  expect(project).to.not.have.property('_count')
+}
+
 describe('Project API', () => {
-  const baseUrl = 'https://kind-robots.vercel.app/api/projects'
   const stamp = Date.now()
   const slug = `cypress-project-${stamp}`
+
+  let apiBase = ''
+  let baseUrl = ''
+  let adminToken = ''
   let token = ''
+  let userId = 0
   let projectId = 0
 
   before(() => {
-    createLoggedInTestUser().then((auth) => {
-      token = auth.token
-    })
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        baseUrl = `${apiBase}/projects`
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((auth) => {
+        token = auth.token
+        userId = auth.id
+      })
   })
 
-  it('creates a first-class Project instead of a Project Dream', () => {
+  after(() => {
+    deleteTestUser(apiBase, adminToken, userId)
+  })
+
+  it('creates a first-class Project with a lean mutation response', () => {
     cy.request({
       method: 'POST',
       url: baseUrl,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: bearerHeaders(token),
       body: {
         title: `Cypress Project ${stamp}`,
         slug,
@@ -34,32 +63,38 @@ describe('Project API', () => {
         isPublic: false,
       },
     }).then((response) => {
-      expect(response.status).to.eq(201)
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body.success).to.be.true
       expect(response.body.data.slug).to.eq(slug)
       expect(response.body.data.status).to.eq('ACTIVE')
       expect(response.body.data.priority).to.eq('HIGH')
       expect(response.body.data.channelKey).to.eq('plan')
       expect(response.body.data.tabKey).to.eq('projects')
+      expectLeanProject(response.body.data)
       projectId = response.body.data.id
     })
   })
 
-  it('retrieves the same Project by slug', () => {
+  it('retrieves the same Project detail by slug', () => {
     cy.request({
       url: `${baseUrl}/${slug}`,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: bearerHeaders(token),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data.id).to.eq(projectId)
       expect(response.body.data.conductorSlug).to.eq(slug)
+      expect(response.body.data).to.have.property('Manager')
+      expect(response.body.data).to.have.property('ArtImage')
+      expect(response.body.data).to.have.property('ArtCollection')
+      expect(response.body.data).to.have.property('PitchSheet')
+      expect(response.body.data).to.have.property('_count')
     })
   })
 
   it('lists the authenticated user Projects', () => {
     cy.request({
       url: `${baseUrl}?mine=true&includeInactive=true`,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: bearerHeaders(token),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data).to.be.an('array')
@@ -71,11 +106,11 @@ describe('Project API', () => {
     })
   })
 
-  it('updates placement and presentation fields', () => {
+  it('updates placement fields with a lean mutation response', () => {
     cy.request({
       method: 'PATCH',
       url: `${baseUrl}/${projectId}`,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: bearerHeaders(token),
       body: {
         priority: 'LOW',
         channelKey: 'lab',
@@ -89,6 +124,7 @@ describe('Project API', () => {
       expect(response.body.data.channelKey).to.eq('lab')
       expect(response.body.data.tabKey).to.eq('challenges')
       expect(response.body.data.allowReviews).to.be.true
+      expectLeanProject(response.body.data)
     })
   })
 
@@ -96,7 +132,7 @@ describe('Project API', () => {
     cy.request({
       method: 'DELETE',
       url: `${baseUrl}/${projectId}`,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: bearerHeaders(token),
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.data.isActive).to.be.false

--- a/docs/architecture/thin-resource-api-audit.md
+++ b/docs/architecture/thin-resource-api-audit.md
@@ -37,7 +37,7 @@ Examples of explicit commands include publish, import, reconcile, generate, comm
 | Resource | Finding | Action |
 | --- | --- | --- |
 | Bot | POST/PATCH returned User, Server, and ArtImage summaries; the helper used a nonexistent singular route and posted arrays to single-resource CRUD | Added `botMutationSelect`; mutations return Bot scalars. `botHelper` now uses `/api/bots` and coordinates multiple creates as individual POSTs |
-| Project | Returns manager, art, collection, pitch sheet, and six counts after create | Return Project mutation fields; retain the stale-connection fallback as persistence infrastructure |
+| Project | POST/PATCH returned manager, art, collection, pitch sheet, and six counts; direct fallback fabricated empty relation objects | Added `projectMutationSelect`; Prisma and direct-write paths return the same Project scalar shape. `projectStore` merges lean rows into loaded detail and clears stale relation objects when foreign keys change |
 | PitchSheet | One create route handles standalone and Dream-derived creation and returns Dream plus ArtImage | Keep Dream-derived creation as an explicit command route; use lean PitchSheet mutation responses |
 | SocialPost | Creates owned SocialTarget children as part of the post aggregate | Keep aggregate creation; replace full target rows with the smallest useful response where callers allow it |
 
@@ -81,7 +81,7 @@ For Dreams, collection creation remains an explicit `collectionStore` action. Ch
 1. ✅ Dream mutation boundaries and regression tests.
 2. ✅ Dream store/form cleanup and removal of obsolete collection/chat flags.
 3. ✅ Character, Scenario, Reward, and Prompt resource projections.
-4. Bot, Project, PitchSheet, and SocialPost response cleanup. Bot is complete; Project is next.
+4. Bot, Project, PitchSheet, and SocialPost response cleanup. Bot and Project are complete; PitchSheet is next.
 5. Database referential-action migration for deletes that currently require manual cross-resource cleanup.
 6. Re-run deployed API Cypress tests and compare Vercel mutation duration/error volume when production catches up to the merged API tier.
 

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -16,10 +16,10 @@ import {
   normalizeNullableId,
   normalizeOptionalText,
   normalizeSlug,
-  projectInclude,
   projectPriorities,
   projectStatuses,
 } from './index'
+import { projectMutationSelect } from './selects'
 
 type ProjectPatchBody = Record<string, unknown>
 
@@ -32,15 +32,20 @@ export default defineEventHandler(async (event) => {
     const id = getProjectId(event)
     const auth = await requireApiUser(event)
     const existing = await prisma.project.findUnique({ where: { id } })
+
     if (!existing) {
       event.node.res.statusCode = 404
-      return { success: false, message: 'Project not found.', statusCode: 404 }
+
+      return {
+        success: false,
+        message: 'Project not found.',
+        statusCode: 404,
+      }
     }
 
     assertProjectAccess(existing, auth.user)
     const body = await readBody<ProjectPatchBody>(event)
     const data: Prisma.ProjectUncheckedUpdateInput = {}
-
     const nextStatus = projectStatuses.has(body.status as ProjectStatus)
       ? (body.status as ProjectStatus)
       : existing.status
@@ -58,60 +63,83 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (body.title !== undefined)
+    if (body.title !== undefined) {
       data.title = normalizeOptionalText(body.title) ?? existing.title
+    }
+
     if (body.slug !== undefined) data.slug = normalizeSlug(body.slug)
-    if (body.description !== undefined)
+    if (body.description !== undefined) {
       data.description = normalizeOptionalText(body.description)
+    }
     if (body.pitch !== undefined) data.pitch = normalizeOptionalText(body.pitch)
-    if (body.flavorText !== undefined)
+    if (body.flavorText !== undefined) {
       data.flavorText = normalizeOptionalText(body.flavorText)
+    }
     if (body.goal !== undefined) data.goal = normalizeOptionalText(body.goal)
-    if (body.conductorSlug !== undefined)
+    if (body.conductorSlug !== undefined) {
       data.conductorSlug = normalizeSlug(body.conductorSlug)
-    if (body.lastSyncedAt !== undefined)
+    }
+    if (body.lastSyncedAt !== undefined) {
       data.lastSyncedAt = normalizeNullableDateTime(body.lastSyncedAt)
-    if (body.repoUrl !== undefined)
+    }
+    if (body.repoUrl !== undefined) {
       data.repoUrl = normalizeOptionalText(body.repoUrl)
-    if (body.liveUrl !== undefined)
+    }
+    if (body.liveUrl !== undefined) {
       data.liveUrl = normalizeOptionalText(body.liveUrl)
-    if (body.channelKey !== undefined)
+    }
+    if (body.channelKey !== undefined) {
       data.channelKey = normalizeOptionalText(body.channelKey)
-    if (body.tabKey !== undefined)
+    }
+    if (body.tabKey !== undefined) {
       data.tabKey = normalizeOptionalText(body.tabKey)
-    if (body.highlightImage !== undefined)
+    }
+    if (body.highlightImage !== undefined) {
       data.highlightImage = normalizeOptionalText(body.highlightImage)
+    }
     if (body.icon !== undefined) data.icon = normalizeOptionalText(body.icon)
-    if (body.imagePath !== undefined)
+    if (body.imagePath !== undefined) {
       data.imagePath = normalizeOptionalText(body.imagePath)
-    if (body.cardPath !== undefined)
+    }
+    if (body.cardPath !== undefined) {
       data.cardPath = normalizeOptionalText(body.cardPath)
-    if (body.heroPath !== undefined)
+    }
+    if (body.heroPath !== undefined) {
       data.heroPath = normalizeOptionalText(body.heroPath)
-    if (body.designer !== undefined)
+    }
+    if (body.designer !== undefined) {
       data.designer = normalizeOptionalText(body.designer)
-    if (body.managerBotId !== undefined)
+    }
+    if (body.managerBotId !== undefined) {
       data.managerBotId = normalizeNullableId(body.managerBotId)
-    if (body.artImageId !== undefined)
+    }
+    if (body.artImageId !== undefined) {
       data.artImageId = normalizeNullableId(body.artImageId)
-    if (body.artCollectionId !== undefined)
+    }
+    if (body.artCollectionId !== undefined) {
       data.artCollectionId = normalizeNullableId(body.artCollectionId)
-    if (typeof body.allowReviews === 'boolean')
+    }
+    if (typeof body.allowReviews === 'boolean') {
       data.allowReviews = body.allowReviews
+    }
     if (typeof body.isPublic === 'boolean') data.isPublic = body.isPublic
     if (typeof body.isMature === 'boolean') data.isMature = body.isMature
     if (typeof body.isActive === 'boolean') data.isActive = body.isActive
-    if (projectStatuses.has(body.status as ProjectStatus))
+    if (projectStatuses.has(body.status as ProjectStatus)) {
       data.status = body.status as ProjectStatus
-    if (projectPriorities.has(body.priority as ProjectPriority))
+    }
+    if (projectPriorities.has(body.priority as ProjectPriority)) {
       data.priority = body.priority as ProjectPriority
+    }
 
     const project = await prisma.project.update({
       where: { id },
       data,
-      include: projectInclude,
+      select: projectMutationSelect,
     })
+
     event.node.res.statusCode = 200
+
     return {
       success: true,
       message: 'Project updated successfully.',
@@ -122,6 +150,7 @@ export default defineEventHandler(async (event) => {
     const handled = errorHandler(error)
     const statusCode = handled.statusCode ?? 500
     event.node.res.statusCode = statusCode
+
     return { ...handled, statusCode }
   }
 })

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -15,10 +15,10 @@ import {
   normalizeNullableId,
   normalizeOptionalText,
   normalizeSlug,
-  projectInclude,
   projectPriorities,
   projectStatuses,
 } from './index'
+import { projectMutationSelect } from './selects'
 
 type ProjectCreateBody = {
   title?: unknown
@@ -56,7 +56,7 @@ async function createProjectWithDirectFallback(
   try {
     return await prisma.project.create({
       data,
-      include: projectInclude,
+      select: projectMutationSelect,
     })
   } catch (error: unknown) {
     if (!isStaleDatabaseConnectionError(error)) throw error
@@ -65,6 +65,7 @@ async function createProjectWithDirectFallback(
       conductorSlug,
       action: 'upsert',
     })
+
     return upsertProjectDirect(data, conductorSlug)
   }
 }
@@ -149,6 +150,7 @@ export default defineEventHandler(async (event) => {
     )
 
     event.node.res.statusCode = 201
+
     return {
       success: true,
       message: 'Project created successfully.',
@@ -159,6 +161,7 @@ export default defineEventHandler(async (event) => {
     const handled = errorHandler(error)
     const statusCode = handled.statusCode ?? 500
     event.node.res.statusCode = statusCode
+
     return { ...handled, statusCode }
   }
 })

--- a/server/api/projects/selects.ts
+++ b/server/api/projects/selects.ts
@@ -1,0 +1,41 @@
+// /server/api/projects/selects.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const projectMutationSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  title: true,
+  slug: true,
+  description: true,
+  pitch: true,
+  flavorText: true,
+  goal: true,
+  status: true,
+  priority: true,
+  conductorSlug: true,
+  repoUrl: true,
+  liveUrl: true,
+  channelKey: true,
+  tabKey: true,
+  lastSyncedAt: true,
+  allowReviews: true,
+  highlightImage: true,
+  icon: true,
+  imagePath: true,
+  cardPath: true,
+  heroPath: true,
+  designer: true,
+  creationSource: true,
+  userId: true,
+  managerBotId: true,
+  artImageId: true,
+  artCollectionId: true,
+  isPublic: true,
+  isMature: true,
+  isActive: true,
+} satisfies Prisma.ProjectSelect
+
+export type ProjectMutationResult = Prisma.ProjectGetPayload<{
+  select: typeof projectMutationSelect
+}>

--- a/server/utils/projectDirectWrite.ts
+++ b/server/utils/projectDirectWrite.ts
@@ -123,18 +123,6 @@ export async function upsertProjectDirect(
       isPublic: booleanValue(project.isPublic),
       isMature: booleanValue(project.isMature),
       isActive: booleanValue(project.isActive),
-      Manager: null,
-      ArtImage: null,
-      ArtCollection: null,
-      PitchSheet: null,
-      _count: {
-        Chats: 0,
-        Todos: 0,
-        Reactions: 0,
-        ArtJobs: 0,
-        ArtImageLinks: 0,
-        ArtCollectionLinks: 0,
-      },
     }
   } finally {
     await connection.end().catch((disconnectError: unknown) => {

--- a/stores/projectStore.ts
+++ b/stores/projectStore.ts
@@ -60,12 +60,38 @@ export type ApplyPlacementsResult = {
 
 function queryString(options: ProjectListOptions): string {
   const query = new URLSearchParams()
+
   for (const [key, value] of Object.entries(options)) {
     if (value === undefined || value === null || value === '') continue
     query.set(key, String(value))
   }
+
   const value = query.toString()
   return value ? `?${value}` : ''
+}
+
+function mergeProjectDetail(
+  existing: ProjectWithRelations,
+  incoming: Project,
+): ProjectWithRelations {
+  const merged: ProjectWithRelations = {
+    ...existing,
+    ...incoming,
+  }
+
+  if (incoming.managerBotId !== existing.managerBotId) {
+    merged.Manager = null
+  }
+
+  if (incoming.artImageId !== existing.artImageId) {
+    merged.ArtImage = null
+  }
+
+  if (incoming.artCollectionId !== existing.artCollectionId) {
+    merged.ArtCollection = null
+  }
+
+  return merged
 }
 
 export const useProjectStore = defineStore('projectStore', () => {
@@ -102,14 +128,24 @@ export const useProjectStore = defineStore('projectStore', () => {
     return projectsBySlug.value.get(slug) ?? null
   }
 
-  function replaceProject(project: ProjectWithRelations): ProjectWithRelations {
+  function replaceProject(project: Project): ProjectWithRelations {
     const index = projects.value.findIndex((entry) => entry.id === project.id)
-    if (index >= 0) projects.value[index] = project
-    else projects.value.unshift(project)
+    const previous =
+      index >= 0
+        ? projects.value[index]
+        : selectedProject.value?.id === project.id
+          ? selectedProject.value
+          : null
+    const next = previous ? mergeProjectDetail(previous, project) : project
+
+    if (index >= 0) projects.value[index] = next
+    else projects.value.unshift(next)
+
     if (selectedProject.value?.id === project.id) {
-      selectedProject.value = project
+      selectedProject.value = next
     }
-    return project
+
+    return next
   }
 
   async function fetchProjects(
@@ -117,15 +153,19 @@ export const useProjectStore = defineStore('projectStore', () => {
   ): Promise<ProjectWithRelations[]> {
     loading.value = true
     error.value = null
+
     try {
       const response = await performFetch<ProjectWithRelations[]>(
         `/api/projects${queryString(options)}`,
       )
+
       if (!response.success) {
         throw new Error(response.message || 'Failed to fetch Projects.')
       }
+
       projects.value = response.data ?? []
       loaded.value = true
+
       return projects.value
     } catch (cause) {
       error.value = cause instanceof Error ? cause.message : String(cause)
@@ -140,15 +180,19 @@ export const useProjectStore = defineStore('projectStore', () => {
   ): Promise<ProjectWithRelations> {
     loading.value = true
     error.value = null
+
     try {
       const response = await performFetch<ProjectWithRelations>(
         `/api/projects/${key}`,
       )
+
       if (!response.success || !response.data) {
         throw new Error(response.message || 'Project not found.')
       }
+
       selectedProject.value = replaceProject(response.data)
-      return response.data
+
+      return selectedProject.value
     } finally {
       loading.value = false
     }
@@ -158,18 +202,18 @@ export const useProjectStore = defineStore('projectStore', () => {
     input: Partial<Project> & Pick<Project, 'title'>,
   ): Promise<ProjectWithRelations> {
     saving.value = true
+
     try {
-      const response = await performFetch<ProjectWithRelations>(
-        '/api/projects',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(input),
-        },
-      )
+      const response = await performFetch<Project>('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
       if (!response.success || !response.data) {
         throw new Error(response.message || 'Failed to create Project.')
       }
+
       return replaceProject(response.data)
     } finally {
       saving.value = false
@@ -181,18 +225,18 @@ export const useProjectStore = defineStore('projectStore', () => {
     input: Partial<Project>,
   ): Promise<ProjectWithRelations> {
     saving.value = true
+
     try {
-      const response = await performFetch<ProjectWithRelations>(
-        `/api/projects/${id}`,
-        {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(input),
-        },
-      )
+      const response = await performFetch<Project>(`/api/projects/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
       if (!response.success || !response.data) {
         throw new Error(response.message || 'Failed to update Project.')
       }
+
       return replaceProject(response.data)
     } finally {
       saving.value = false
@@ -201,26 +245,23 @@ export const useProjectStore = defineStore('projectStore', () => {
 
   async function archiveProject(id: number): Promise<ProjectWithRelations> {
     saving.value = true
+
     try {
       const response = await performFetch<ProjectWithRelations>(
         `/api/projects/${id}`,
         { method: 'DELETE' },
       )
+
       if (!response.success || !response.data) {
         throw new Error(response.message || 'Failed to archive Project.')
       }
+
       return replaceProject(response.data)
     } finally {
       saving.value = false
     }
   }
 
-  // Backfill channelKey / tabKey / liveUrl on loaded Project rows from the
-  // canonical PROJECT_PLACEMENTS map, using the existing PATCH endpoint (which is
-  // admin/owner-gated server-side). Runs over projects already in the store, so
-  // load them (admin: includeInactive) before calling. liveUrl is only filled
-  // when empty unless overwriteLiveUrl is set. Individual PATCH failures are
-  // reported per slug so the rest of the migration can continue.
   async function applyPlacements(
     overwriteLiveUrl = false,
   ): Promise<ApplyPlacementsResult> {
@@ -234,6 +275,7 @@ export const useProjectStore = defineStore('projectStore', () => {
         projectForSlug(slug) ??
         projects.value.find((entry) => entry.conductorSlug === slug) ??
         null
+
       if (!project) {
         missing.push(slug)
         continue
@@ -264,7 +306,9 @@ export const useProjectStore = defineStore('projectStore', () => {
         failed.push({
           slug,
           message:
-            cause instanceof Error ? cause.message : 'Unknown Project update error',
+            cause instanceof Error
+              ? cause.message
+              : 'Unknown Project update error',
         })
       }
     }


### PR DESCRIPTION
## What changed

- adds a complete scalar `projectMutationSelect`
- makes Project create and update return Project fields only
- keeps the stale-database direct MariaDB fallback, but makes it return the same scalar shape instead of fabricated relation stubs and zero counts
- updates `projectStore` to merge scalar mutation rows into loaded detail records
- clears cached Manager, ArtImage, or ArtCollection detail when the corresponding foreign key changes
- avoids mandatory detail refetches during bulk placement updates
- adds lean-response assertions to Project create/update tests while confirming the GET route retains detail
- makes the Project test user disposable and cleans it after the run
- records Project as completed in the API audit

## Boundary

Project mutations own Project persistence. Manager, artwork, collection, PitchSheet, and count graphs remain query concerns. The database fallback remains infrastructure because it preserves the same persistence contract during stale Prisma connections.

## Checks

- TypeScript Type Check: passed
- Contract Tests: passed
- Project Cypress API suite runs against production after merge