### PR TITLE
Migrate two shadow-variant panels onto kr-panel/kr-panel-muted

### DIFF
--- a/components/art/art-reactions.vue
+++ b/components/art/art-reactions.vue
@@ -1,7 +1,7 @@
 // /components/content/art/art-reactions.vue
 <template>
   <div
-    class="relative mx-auto w-full max-w-3xl space-y-6 rounded-2xl border border-base-300 bg-base-200 p-6 shadow-lg"
+    class="kr-panel-muted relative mx-auto w-full max-w-3xl space-y-6 shadow-lg"
   >
     <h2 class="text-xl font-bold text-primary">React to this Image</h2>
 

--- a/components/builder/builder-manager.vue
+++ b/components/builder/builder-manager.vue
@@ -97,7 +97,7 @@
           <div class="absolute inset-0 bg-base-300/60 backdrop-blur-sm" />
 
           <div
-            class="relative w-full max-w-sm rounded-2xl border border-base-300 bg-base-100 p-6 shadow-xl"
+            class="kr-panel relative w-full max-w-sm shadow-xl"
           >
             <h3 class="text-lg font-black text-base-content">
               Clear this builder?


### PR DESCRIPTION
## Summary
- `components/art/art-reactions.vue`'s root panel and `components/builder/builder-manager.vue`'s "Clear this builder?" confirm-modal card matched the `.kr-panel`/`.kr-panel-muted` base classes (`rounded-2xl border border-base-300 bg-base-{100,200} p-6`) exactly, except each carries an extra shadow (`shadow-lg` / `shadow-xl`) that the shared classes don't include (`shadow-sm` on `.kr-panel`, none on `.kr-panel-muted`).
- A prior migration pass (kind_robots PR #398 / conductor `global-ui/t-023`) left these two untouched and filed a follow-up decision task (`global-ui/t-025`): either accept the shadow difference and migrate anyway, or add a new `.kr-panel-elevated` variant.
- Resolved as: migrate both onto the shared class and layer the extra shadow utility on top in the template — the same override pattern the codebase already uses for `.kr-note` (`kr-note kr-note-* p-2 text-xs font-normal`). Utility classes in Tailwind's `utilities` layer win over `@layer components` classes like `.kr-panel`, so `shadow-xl`/`shadow-lg` in the class list correctly overrides `.kr-panel`'s `shadow-sm`. No new global class needed for what both surfaces already share with an existing surface, just a heavier shadow.

## Test plan
- [x] `npx eslint components/art/art-reactions.vue components/builder/builder-manager.vue` — clean
- [x] `npx prettier --check` on both files — `art-reactions.vue` clean; `builder-manager.vue`'s pre-existing drift confirmed unrelated to this change (present on `main` before this diff)
- [x] `npx vue-tsc --noEmit` — clean, no new errors
- [ ] Visual/preview-deploy check (sandbox has no DB) — purely a class-name swap to an existing, already-used shared surface class, so visual risk is minimal

Resolves conductor `global-ui/t-025`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01389buAMShs8LngfdfopnjN)_