### PR TITLE
newsfeed: server-side RSS/Atom aggregation pipeline (t-005)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:wonderlab-core-fixtures": "tsx utils/scripts/verifyWonderLabCoreFixtures.ts",
     "test:wonderlab-visual-fixtures": "tsx utils/scripts/verifyWonderLabVisualFixtures.ts",
     "test:wonderlab-ui-fixtures": "tsx utils/scripts/verifyWonderLabUiFixtures.ts",
+    "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/server/api/newsfeed/index.get.ts
+++ b/server/api/newsfeed/index.get.ts
@@ -1,0 +1,86 @@
+// /server/api/newsfeed/index.get.ts
+//
+// Aggregates one or more recommended feeds (conductor projects/newsfeed t-005).
+// ?feed=ai-news              -- a single feed
+// ?feeds=ai-news,activism    -- several feeds
+// (neither)                  -- every default-enabled feed
+//
+// Cached 15 minutes via defineCachedEventHandler: this repo has no prior
+// caching precedent (DESIGN-BRIEF.md), and 15 minutes is far below how often
+// any of these RSS sources actually publish, so it bounds egress to the ~15
+// source hosts to 4x/hour regardless of homepage traffic.
+import { getQuery } from 'h3'
+import {
+  defaultEnabledFeedSlugs,
+  getFeedDefinition,
+  isFeedSlug,
+} from '@/stores/helpers/newsfeed'
+import { aggregateFeed } from '../../utils/newsfeed'
+import { errorHandler } from '../../utils/error'
+
+const CACHE_TTL_SECONDS = 60 * 15
+
+function requestedSlugs(query: Record<string, unknown>): string[] {
+  const single = typeof query.feed === 'string' ? [query.feed] : []
+  const many =
+    typeof query.feeds === 'string'
+      ? query.feeds
+          .split(',')
+          .map((slug) => slug.trim())
+          .filter(Boolean)
+      : []
+
+  const slugs = [...single, ...many]
+  return slugs.length ? slugs : defaultEnabledFeedSlugs()
+}
+
+export default defineCachedEventHandler(
+  async (event) => {
+    try {
+      const query = getQuery(event)
+      const slugs = requestedSlugs(query)
+      const invalid = slugs.filter((slug) => !isFeedSlug(slug))
+
+      if (invalid.length) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: `Unknown feed slug(s): ${invalid.join(', ')}`,
+        })
+      }
+
+      const feeds = slugs
+        .map((slug) => getFeedDefinition(slug))
+        .filter((feed): feed is NonNullable<typeof feed> => Boolean(feed))
+
+      const aggregated = await Promise.all(
+        feeds.map((feed) => aggregateFeed(feed)),
+      )
+      const itemCount = aggregated.reduce(
+        (sum, feed) => sum + feed.items.length,
+        0,
+      )
+
+      return {
+        success: true,
+        message: `Aggregated ${itemCount} item(s) across ${aggregated.length} feed(s).`,
+        data: aggregated,
+      }
+    } catch (error) {
+      const { message, statusCode } = errorHandler(error)
+      event.node.res.statusCode = statusCode || 500
+
+      return {
+        success: false,
+        message: message || 'Failed to aggregate newsfeed.',
+        data: null,
+        statusCode: event.node.res.statusCode,
+      }
+    }
+  },
+  {
+    maxAge: CACHE_TTL_SECONDS,
+    name: 'newsfeed',
+    getKey: (event) =>
+      requestedSlugs(getQuery(event)).slice().sort().join(',') || 'default',
+  },
+)

--- a/server/utils/newsfeed.ts
+++ b/server/utils/newsfeed.ts
@@ -1,0 +1,262 @@
+// /server/utils/newsfeed.ts
+//
+// RSS/Atom aggregation for the newsfeed feature (conductor projects/newsfeed
+// t-005, per DESIGN-BRIEF.md). Deliberately dependency-free: feeds are simple,
+// well-formed RSS 2.0 / Atom documents and a handful of known tags don't
+// justify a full XML parser dependency yet ("smallest reliable ingestion
+// approach", DESIGN-BRIEF.md). Never throws -- a broken or slow source must
+// not blank the rest of the feed, so failures are captured as data, not
+// exceptions.
+// Relative import (not the `@/` alias) so this module -- and its regression
+// test, utils/scripts/verifyNewsfeedAggregation.ts -- can be run directly via
+// tsx without a Nuxt build step.
+import type {
+  FeedDefinition,
+  FeedSourceDefinition,
+  NewsFeedItem,
+} from '../../stores/helpers/newsfeed'
+import { getFeedSources } from '../../stores/helpers/newsfeed'
+
+const MAX_SUMMARY_LENGTH = 280
+const MAX_TITLE_LENGTH = 200
+const FETCH_TIMEOUT_MS = 8000
+
+interface RawFeedEntry {
+  title?: string
+  link?: string
+  description?: string
+  pubDate?: string
+  guid?: string
+  image?: string
+  categories: string[]
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+function stripCdata(value: string): string {
+  const match = value.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/)
+  return match ? (match[1] ?? '') : value
+}
+
+function extractTag(block: string, tag: string): string | undefined {
+  const match = block.match(
+    new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i'),
+  )
+  return match ? decodeEntities(stripCdata(match[1] ?? '').trim()) : undefined
+}
+
+function extractAttr(
+  block: string,
+  tag: string,
+  attr: string,
+): string | undefined {
+  const match = block.match(
+    new RegExp(`<${tag}[^>]*\\b${attr}=["']([^"']+)["'][^>]*/?>`, 'i'),
+  )
+  return match ? match[1] : undefined
+}
+
+function extractCategories(block: string): string[] {
+  const categories: string[] = []
+  const re =
+    /<category\b[^>]*>([\s\S]*?)<\/category>|<category\b[^>]*\bterm=["']([^"']+)["'][^>]*\/?>/gi
+  let match: RegExpExecArray | null
+  while ((match = re.exec(block))) {
+    const value = match[1]
+      ? decodeEntities(stripCdata(match[1]).trim())
+      : match[2]
+    if (value) categories.push(value)
+  }
+  return categories
+}
+
+/** Strips tags/entities and truncates -- feed HTML is never rendered raw. */
+export function sanitizeText(
+  html: string,
+  maxLength = MAX_SUMMARY_LENGTH,
+): string {
+  const collapsed = decodeEntities(stripCdata(html))
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (collapsed.length <= maxLength) return collapsed
+  return `${collapsed.slice(0, maxLength - 1).trimEnd()}…`
+}
+
+export function parseFeedXml(xml: string): RawFeedEntry[] {
+  const rssItems = xml.match(/<item\b[\s\S]*?<\/item>/gi)
+  if (rssItems) {
+    return rssItems.map((block) => ({
+      title: extractTag(block, 'title'),
+      link: extractTag(block, 'link') || extractAttr(block, 'link', 'href'),
+      description:
+        extractTag(block, 'description') ||
+        extractTag(block, 'content:encoded'),
+      pubDate: extractTag(block, 'pubDate') || extractTag(block, 'dc:date'),
+      guid: extractTag(block, 'guid'),
+      image:
+        extractAttr(block, 'enclosure', 'url') ||
+        extractAttr(block, 'media:content', 'url') ||
+        extractAttr(block, 'media:thumbnail', 'url'),
+      categories: extractCategories(block),
+    }))
+  }
+
+  const atomEntries = xml.match(/<entry\b[\s\S]*?<\/entry>/gi)
+  if (atomEntries) {
+    return atomEntries.map((block) => ({
+      title: extractTag(block, 'title'),
+      link: extractAttr(block, 'link', 'href') || extractTag(block, 'link'),
+      description: extractTag(block, 'summary') || extractTag(block, 'content'),
+      pubDate: extractTag(block, 'updated') || extractTag(block, 'published'),
+      guid: extractTag(block, 'id'),
+      categories: extractCategories(block),
+    }))
+  }
+
+  return []
+}
+
+function stableId(sourceId: string, raw: RawFeedEntry): string {
+  const basis = raw.guid || raw.link || `${sourceId}:${raw.title ?? ''}`
+  let hash = 0
+  for (let i = 0; i < basis.length; i += 1) {
+    hash = (hash * 31 + basis.charCodeAt(i)) | 0
+  }
+  return `${sourceId}-${(hash >>> 0).toString(36)}`
+}
+
+function parseDate(value: string | undefined): string {
+  if (!value) return new Date(0).toISOString()
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime())
+    ? new Date(0).toISOString()
+    : parsed.toISOString()
+}
+
+export function normalizeEntry(
+  raw: RawFeedEntry,
+  source: FeedSourceDefinition,
+): NewsFeedItem | null {
+  if (!raw.title || !raw.link) return null
+
+  return {
+    id: stableId(source.id, raw),
+    title: sanitizeText(raw.title, MAX_TITLE_LENGTH),
+    summary: raw.description ? sanitizeText(raw.description) : '',
+    source: source.name,
+    url: raw.link,
+    publishedAt: parseDate(raw.pubDate),
+    category: raw.categories,
+    image: raw.image,
+    perspective: source.perspective
+      ? {
+          label: source.perspective.label,
+          source: source.perspective.source,
+          confidence: source.perspective.confidence,
+        }
+      : undefined,
+  }
+}
+
+export interface SourceFetchResult {
+  sourceId: string
+  items: NewsFeedItem[]
+  error?: string
+}
+
+export async function fetchSourceItems(
+  source: FeedSourceDefinition,
+): Promise<SourceFetchResult> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+    let res: Response
+    try {
+      res = await fetch(source.url, {
+        signal: controller.signal,
+        headers: {
+          Accept:
+            'application/rss+xml, application/atom+xml, application/xml, text/xml',
+        },
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    if (!res.ok) {
+      return { sourceId: source.id, items: [], error: `HTTP ${res.status}` }
+    }
+
+    const xml = await res.text()
+    const items = parseFeedXml(xml)
+      .map((raw) => normalizeEntry(raw, source))
+      .filter((item): item is NewsFeedItem => item !== null)
+
+    return { sourceId: source.id, items }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown fetch error'
+    console.warn(`📰 Newsfeed source "${source.id}" failed: ${message}`)
+    return { sourceId: source.id, items: [], error: message }
+  }
+}
+
+export interface AggregatedFeed {
+  slug: string
+  items: NewsFeedItem[]
+  sourceErrors: Array<{ sourceId: string; error: string }>
+}
+
+function matchesTagFilters(item: NewsFeedItem, feed: FeedDefinition): boolean {
+  const haystack = [item.title, item.summary, ...item.category]
+    .join(' ')
+    .toLowerCase()
+
+  if (feed.excludeTags?.some((tag) => haystack.includes(tag.toLowerCase()))) {
+    return false
+  }
+  if (feed.includeTags?.length) {
+    return feed.includeTags.some((tag) => haystack.includes(tag.toLowerCase()))
+  }
+  return true
+}
+
+/** Fetches every source in a feed in parallel and merges into one sorted, deduped list. */
+export async function aggregateFeed(
+  feed: FeedDefinition,
+): Promise<AggregatedFeed> {
+  const sources = getFeedSources(feed)
+  const results = await Promise.all(
+    sources.map((source) => fetchSourceItems(source)),
+  )
+
+  const seen = new Set<string>()
+  const items: NewsFeedItem[] = []
+  const sourceErrors: Array<{ sourceId: string; error: string }> = []
+
+  for (const result of results) {
+    if (result.error)
+      sourceErrors.push({ sourceId: result.sourceId, error: result.error })
+
+    for (const item of result.items) {
+      if (seen.has(item.id)) continue
+      seen.add(item.id)
+      if (matchesTagFilters(item, feed)) items.push(item)
+    }
+  }
+
+  items.sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+
+  return { slug: feed.slug, items, sourceErrors }
+}

--- a/utils/scripts/verifyNewsfeedAggregation.ts
+++ b/utils/scripts/verifyNewsfeedAggregation.ts
@@ -1,0 +1,213 @@
+// /utils/scripts/verifyNewsfeedAggregation.ts
+//
+// Regression test for server/utils/newsfeed.ts (conductor projects/newsfeed
+// t-005). No network dependency for the parsing assertions -- fixtures cover
+// RSS 2.0 and Atom, HTML/CDATA sanitization, category-tag extraction, and
+// malformed input. One live-network assertion proves fetchSourceItems never
+// throws on an unreachable host (a closed local port), which is the actual
+// "one broken source can't blank the homepage" guarantee this module exists
+// to provide.
+import assert from 'node:assert/strict'
+
+import {
+  aggregateFeed,
+  fetchSourceItems,
+  normalizeEntry,
+  parseFeedXml,
+  sanitizeText,
+} from '../../server/utils/newsfeed'
+import type {
+  FeedDefinition,
+  FeedSourceDefinition,
+} from '../../stores/helpers/newsfeed'
+
+// --- sanitizeText --------------------------------------------------------
+
+assert.equal(
+  sanitizeText('<p>Hello &amp; <strong>world</strong></p>'),
+  'Hello & world',
+  'tags must be stripped and entities decoded',
+)
+assert.equal(
+  sanitizeText('<![CDATA[<em>cdata</em> body]]>'),
+  'cdata body',
+  'CDATA wrapper must be unwrapped before tag-stripping',
+)
+assert.equal(
+  sanitizeText('a'.repeat(300)),
+  `${'a'.repeat(279)}…`,
+  'text longer than maxLength must be truncated with an ellipsis',
+)
+
+// --- parseFeedXml: RSS 2.0 -------------------------------------------------
+
+const RSS_FIXTURE = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Fixture Feed</title>
+    <item>
+      <title>First &amp; Best Post</title>
+      <link>https://example.com/first</link>
+      <guid>urn:uuid:first</guid>
+      <description><![CDATA[<p>Summary of the <b>first</b> post.</p>]]></description>
+      <pubDate>Mon, 01 Jan 2026 12:00:00 GMT</pubDate>
+      <category>ai</category>
+      <category>research</category>
+    </item>
+    <item>
+      <title>Second Post</title>
+      <link>https://example.com/second</link>
+      <description>Plain text summary.</description>
+      <pubDate>Tue, 02 Jan 2026 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`
+
+const rssEntries = parseFeedXml(RSS_FIXTURE)
+assert.equal(rssEntries.length, 2, 'must find both <item> blocks')
+const [firstRssEntry, secondRssEntry] = rssEntries
+assert.ok(
+  firstRssEntry && secondRssEntry,
+  'both fixture entries must be present',
+)
+assert.equal(firstRssEntry.title, 'First & Best Post')
+assert.equal(firstRssEntry.link, 'https://example.com/first')
+assert.equal(
+  firstRssEntry.description,
+  '<p>Summary of the <b>first</b> post.</p>',
+)
+assert.deepEqual(firstRssEntry.categories, ['ai', 'research'])
+assert.equal(secondRssEntry.guid, undefined, 'guid is optional')
+
+// --- parseFeedXml: Atom -----------------------------------------------------
+
+const ATOM_FIXTURE = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Atom Entry</title>
+    <link href="https://example.com/atom-entry" />
+    <id>tag:example.com,2026:atom-entry</id>
+    <summary>An atom summary.</summary>
+    <updated>2026-01-03T00:00:00Z</updated>
+    <category term="engineering" />
+  </entry>
+</feed>`
+
+const atomEntries = parseFeedXml(ATOM_FIXTURE)
+assert.equal(atomEntries.length, 1, 'must find the <entry> block')
+const [firstAtomEntry] = atomEntries
+assert.ok(firstAtomEntry, 'the fixture entry must be present')
+assert.equal(firstAtomEntry.link, 'https://example.com/atom-entry')
+assert.equal(firstAtomEntry.pubDate, '2026-01-03T00:00:00Z')
+assert.deepEqual(firstAtomEntry.categories, ['engineering'])
+
+// --- parseFeedXml: malformed / empty input must not throw ------------------
+
+assert.deepEqual(parseFeedXml(''), [], 'empty input returns no entries')
+assert.deepEqual(
+  parseFeedXml('not xml at all'),
+  [],
+  'non-XML input returns no entries',
+)
+
+// --- normalizeEntry ---------------------------------------------------------
+
+const FIXTURE_SOURCE: FeedSourceDefinition = {
+  id: 'fixture-source',
+  name: 'Fixture Source',
+  url: 'https://example.com/feed.xml',
+  kind: 'rss',
+  verified: false,
+}
+
+const normalized = normalizeEntry(firstRssEntry, FIXTURE_SOURCE)
+assert.ok(normalized, 'entry with title + link must normalize')
+assert.equal(normalized?.source, 'Fixture Source')
+assert.equal(
+  normalized?.publishedAt,
+  new Date('Mon, 01 Jan 2026 12:00:00 GMT').toISOString(),
+)
+assert.deepEqual(normalized?.category, ['ai', 'research'])
+
+assert.equal(
+  normalizeEntry(
+    { title: undefined, link: 'https://example.com/x', categories: [] },
+    FIXTURE_SOURCE,
+  ),
+  null,
+  'an entry missing a title must be dropped rather than rendered blank',
+)
+assert.equal(
+  normalizeEntry(
+    { title: 'No link', link: undefined, categories: [] },
+    FIXTURE_SOURCE,
+  ),
+  null,
+  'an entry missing a link must be dropped -- nothing for the user to click through to',
+)
+
+const noDateEntry = normalizeEntry(
+  { title: 'No date', link: 'https://example.com/no-date', categories: [] },
+  FIXTURE_SOURCE,
+)
+assert.ok(
+  noDateEntry && !Number.isNaN(new Date(noDateEntry.publishedAt).getTime()),
+  'a missing pubDate must fall back to a valid (epoch) timestamp, never NaN',
+)
+
+// --- fetchSourceItems: unreachable host must resolve, never throw ----------
+
+async function run() {
+  const unreachableSource: FeedSourceDefinition = {
+    id: 'unreachable-fixture',
+    name: 'Unreachable Fixture',
+    url: 'http://127.0.0.1:1/feed.xml',
+    kind: 'rss',
+    verified: false,
+  }
+
+  const result = await fetchSourceItems(unreachableSource)
+  assert.equal(result.sourceId, 'unreachable-fixture')
+  assert.deepEqual(
+    result.items,
+    [],
+    'an unreachable source must yield an empty item list',
+  )
+  assert.ok(
+    result.error,
+    'an unreachable source must report an error string, not throw',
+  )
+
+  // --- aggregateFeed: a feed with only broken sources must still resolve ---
+
+  const feed: FeedDefinition = {
+    slug: 'fixture-feed',
+    title: 'Fixture Feed',
+    description: 'test',
+    icon: 'kind-icon:test',
+    defaultEnabled: true,
+    sourceIds: ['unreachable-fixture'],
+    defaultSort: 'recent',
+    topicPolitical: false,
+  }
+
+  // aggregateFeed resolves sources by id via the real registry, so a source
+  // id absent from FEED_SOURCES simply yields zero sources -- this still
+  // proves the "no sources / all sources failed" path returns an empty,
+  // well-formed AggregatedFeed instead of throwing.
+  const aggregated = await aggregateFeed(feed)
+  assert.equal(aggregated.slug, 'fixture-feed')
+  assert.deepEqual(aggregated.items, [])
+  assert.deepEqual(
+    aggregated.sourceErrors,
+    [],
+    'unknown source ids are skipped, not errored',
+  )
+
+  console.log(
+    'newsfeed aggregation verified: RSS + Atom parsing, sanitization, category ' +
+      'extraction, malformed-input safety, and unreachable-source resilience.',
+  )
+}
+
+run()


### PR DESCRIPTION
### Task
conductor `newsfeed/t-005`: Build a minimal feed aggregation pipeline (kind: software)

### What changed / what I produced
- `server/utils/newsfeed.ts` — dependency-free RSS 2.0 / Atom parsing (regex-based; no new npm dependency for a handful of known tags, per DESIGN-BRIEF.md's "smallest reliable ingestion approach"), HTML/CDATA sanitization + truncation, per-source `fetch` with an 8s timeout that never throws (a broken/slow source returns `[]` + an error string instead), and `aggregateFeed()` which fetches every source in a feed's registry entry in parallel, dedupes by stable id, sorts newest-first, and applies optional `includeTags`/`excludeTags` keyword filtering.
- `server/api/newsfeed/index.get.ts` — thin handler modeled on `server/api/conductor/prs.get.ts`'s shape (route + shared util split) but using this repo's dominant `{ success, message, data }` + `errorHandler` response convention (110+ existing GET routes use it; `prs.get.ts` is a rare conductor-only outlier). Accepts `?feed=<slug>` or `?feeds=<slug,slug>` (defaults to every `defaultEnabled` feed from the existing `t-004` registry). Wrapped in `defineCachedEventHandler` at a 15-minute TTL — this repo's first use of Nitro's cache layer, so I documented the TTL choice in a comment: RSS sources update far slower than 15 minutes, and this bounds egress to the ~15 registry hosts to 4x/hour regardless of homepage traffic.
- `utils/scripts/verifyNewsfeedAggregation.ts` (+ `test:newsfeed-aggregation` script in `package.json`, following the existing `test:verify*` convention) — regression test with RSS and Atom fixtures (multi-`<category>` extraction, CDATA, HTML entities), malformed/empty-input safety, and a live assertion against an unreachable local port proving `fetchSourceItems` resolves with an error string instead of throwing — the actual "one broken source can't blank the homepage" guarantee this module exists to provide.

### How I verified
- `npm run test:newsfeed-aggregation` — all assertions pass.
- `npm run test` (full-project `vue-tsc --noEmit`) — clean, no new errors (caught and fixed two real `noUncheckedIndexedAccess` type errors during development).
- `npx eslint` on all 3 touched/added files — clean.
- `npx prettier --check` — clean (ran `--write` once during development to match repo style).

### Stakes
reversible

### Flags for Reviewer
- No live network verification of the actual RSS source URLs in the `t-004` registry — they're all still `verified: false` (see the doc comment on `FeedSourceDefinition`); this sandbox's egress may or may not reach any given host. The aggregation pipeline itself is verified against fixtures + a deliberately-unreachable host; flipping individual sources to `verified: true` is left for whenever a session confirms them live (their own docstring already says so).
- `category` on `NewsFeedItem` is now populated from each entry's actual RSS/Atom `<category>` tags (falls back to `[]` if a source has none) rather than being synthesized from the feed slug — this seemed truer to the "include/exclude tags or keywords" wording in DESIGN-BRIEF.md's feed-definition contract, but no current `FEED_DEFINITIONS` entry actually sets `includeTags`/`excludeTags` yet so that filtering path is untested against real data.
- Frontend consumption (feed cards, `FeedCard.vue`) is `t-006`, not in scope here.

### Kaizen suggestion
Once at least one source in `FEED_SOURCES` is confirmed reachable from a live session, flip its `verified: false` → `true` and consider a small scheduled/CI smoke check that hits `GET /api/newsfeed?feed=<slug>` and asserts a non-empty `sourceErrors`-free response, so registry rot (a source silently breaking) gets caught before a user notices a thin feed.

### Notes for reviewer
Conductor task `newsfeed/t-005` will be set to `status: review` in the companion conductor PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_012wRnX9EgV47CHFFBPXgsXv)_