### PR TITLE
fix: map Prisma P2025 to 404 in shared error handler (fixes red Cypress cleanup check)

### DIFF
--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -172,6 +172,12 @@ function handlePrismaError(
         message: 'Cannot connect to database.',
         statusCode: 503,
       }
+    case 'P2025':
+      return {
+        success: false,
+        message: 'Record not found.',
+        statusCode: 404,
+      }
     default:
       return {
         success: false,


### PR DESCRIPTION
## Summary
- `main`'s "Kind Robots Cypress Tests" workflow has been red — but only at the **"Verify Cypress cleanup"** step, not the actual Cypress run (run [29645995197](https://github.com/silasfelinus/kind_robots/actions/runs/29645995197): 367/367 specs passed, 0 failures).
- Root cause: `components.cy.ts` / `component-reactions.cy.ts` register a safety-net cleanup task (`cy.task('cypressCleanup:register', ...)`) for fixtures they also delete explicitly during the test. There's no unregister, so the safety net replays `DELETE` against an already-deleted row at suite end.
- `server/api/components/[id].delete.ts` calls `prisma.component.delete()` directly; Prisma throws `P2025` (record not found) for the already-deleted row, and the shared `handlePrismaError()` in `server/utils/error.ts` had no case for `P2025`, so it fell into the `default` branch and returned **500**.
- The cleanup verifier (`scripts/verify-cypress-cleanup.mjs`) tolerates `[200, 404]` but not 500, so it flagged a false "leak" and failed the job even though nothing actually leaked.
- `server/api/chatgpt/index.post.ts` already maps `P2025 -> 404` for exactly this case; this PR brings the shared handler in line with that existing convention so every endpoint routing through `errorHandler()` gets the same, correct behavior.

## Change
- `server/utils/error.ts`: add a `case 'P2025':` to `handlePrismaError()` returning `{ statusCode: 404, message: 'Record not found.' }`.

## Test plan
- [x] Provisioned deps locally (`npm ci` + `prisma generate` + `nuxi prepare`) and ran `npm run test` (vue-tsc typecheck) — clean.
- [x] `npx eslint server/utils/error.ts server/api/components/[id].delete.ts` — clean.
- [x] Confirmed via `git stash` diff that the file's existing Prettier warnings predate this change (unrelated, pre-existing drift).
- [ ] Full Cypress run requires a live DB/server not available in this sandbox — relying on the confirmed root-cause diagnosis (fix mirrors the existing, working `P2025 -> 404` pattern in `chatgpt/index.post.ts`) plus the passing typecheck/lint.

Fixes ci-janitor Todo #413.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr6ginBwH7iKr8Rok7pqQ6)_