### PR TITLE
fix(academy): link style cards to detail panels

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -34,12 +34,16 @@
       </label>
     </header>
 
-    <academy-style-detail
+    <div
       v-if="expandedStyle"
-      :lesson="expandedStyle"
-      @close="closeStyle"
-      @remix="emit('remix', $event)"
-    />
+      :id="`academy-style-detail-${expandedStyle.slug}`"
+    >
+      <academy-style-detail
+        :lesson="expandedStyle"
+        @close="closeStyle"
+        @remix="emit('remix', $event)"
+      />
+    </div>
 
     <div
       class="grid gap-3"
@@ -59,6 +63,7 @@
             : 'border-base-300 bg-base-100 hover:border-primary/50 hover:shadow-sm'
         "
         :aria-expanded="expandedSlug === style.slug"
+        :aria-controls="`academy-style-detail-${style.slug}`"
         @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
       >
         <div class="flex items-center justify-between gap-2">


### PR DESCRIPTION
## What changed
- wrapped the expanded Academy style lesson in a stable, slug-specific detail-panel id
- added matching `aria-controls` values to each expandable style card
- preserved the existing `aria-expanded`, focus-restoration, filtering, and remix behavior

## Verification
- reviewed the branch diff against current `main`
- scoped to `components/academy/academy-styles-browser.vue`
- no API, store, schema, deployment, or outward-facing changes
- GitHub CI must pass before merge

## Stakes
Reversible accessibility polish.

## Flags for reviewer
None.

## Kaizen suggestion
Consider a small accessibility contract test for expandable controls that expose `aria-expanded` without a corresponding controlled element.