### PR TITLE
newsfeed/t-006: render the recommended newsfeed on the homepage

### DIFF
--- a/components/conductor/newsfeed-page.vue
+++ b/components/conductor/newsfeed-page.vue
@@ -1,6 +1,15 @@
 <!-- /components/conductor/newsfeed-page.vue -->
 <template>
-  <ProjectFrontPage slug="newsfeed" :fallback="config" />
+  <ProjectFrontPage slug="newsfeed" :fallback="config">
+    <template #interactive>
+      <section
+        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+      >
+        <h2 class="mb-4 text-base font-black text-base-content">Live feed</h2>
+        <NewsfeedFeed />
+      </section>
+    </template>
+  </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">
@@ -30,8 +39,13 @@ const config: ProjectFrontConfig = {
     },
   ],
   deliverables: {
-    done: ['Feed concept and content sources mapped'],
-    next: ['Feed builder + item renderers', 'Homepage placement'],
+    done: [
+      'Feed concept and content sources mapped',
+      'Server-side RSS/Atom aggregation pipeline',
+      'Feed builder + item renderers',
+      'Homepage placement',
+    ],
+    next: ['Category filtering beyond feed slugs', 'Perspective balancing UI'],
   },
 }
 </script>

--- a/components/home/home-feed-placeholder.vue
+++ b/components/home/home-feed-placeholder.vue
@@ -1,45 +1,36 @@
 <!-- /components/home/home-feed-placeholder.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col items-center justify-center gap-6 rounded-2xl border border-base-300 bg-base-200 p-8 text-center"
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto p-1"
   >
-    <div
-      class="flex h-16 w-16 items-center justify-center rounded-full bg-primary/15"
+    <header
+      class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200 p-4"
     >
-      <Icon name="kind-icon:scroll" class="h-8 w-8 text-primary" />
-    </div>
+      <div>
+        <h1 class="text-lg font-black text-base-content sm:text-xl">
+          {{ headline }}
+        </h1>
+        <p class="text-sm text-base-content/60">
+          AI news, activism, and the rest of the swarm's activity, curated right
+          here.
+        </p>
+      </div>
 
-    <div class="flex max-w-md flex-col items-center gap-2">
-      <h1 class="text-xl font-black text-base-content">
-        {{ headline }}
-      </h1>
-      <p class="text-sm text-base-content/60">
-        The recommended newsfeed is on its way — AI news, activism, and the rest
-        of the swarm's activity, curated right here. Until it lands, here's
-        where to go next.
-      </p>
-    </div>
-
-    <div class="flex flex-wrap items-center justify-center gap-3">
       <NuxtLink
         v-if="isLoggedIn"
         to="/dashboard"
-        class="btn btn-primary rounded-xl px-6"
+        class="btn btn-primary btn-sm rounded-xl"
       >
         <Icon name="kind-icon:dashboard" class="size-4" />
-        Go to your Dashboard
+        Dashboard
       </NuxtLink>
-
-      <NuxtLink v-else to="/login" class="btn btn-primary rounded-xl px-6">
+      <NuxtLink v-else to="/login" class="btn btn-primary btn-sm rounded-xl">
         <Icon name="kind-icon:login" class="size-4" />
         Log In
       </NuxtLink>
+    </header>
 
-      <NuxtLink to="/newsfeed" class="btn btn-ghost rounded-xl px-6">
-        <Icon name="kind-icon:news" class="size-4" />
-        Preview the Newsfeed Lab
-      </NuxtLink>
-    </div>
+    <NewsfeedFeed :initial-limit="9" />
   </section>
 </template>
 

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -1,0 +1,105 @@
+<!-- /components/newsfeed/feed-card.vue -->
+<template>
+  <a
+    :href="item.url"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl"
+  >
+    <figure
+      v-if="showImage"
+      class="relative aspect-video w-full overflow-hidden bg-base-300"
+    >
+      <img
+        v-if="imageSrc && !imageFailed"
+        :src="imageSrc"
+        :alt="item.title"
+        class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+        loading="lazy"
+        @error="imageFailed = true"
+      />
+      <div
+        v-else
+        class="flex h-full w-full items-center justify-center bg-linear-to-br from-primary/20 via-secondary/10 to-accent/20 text-primary"
+      >
+        <Icon name="kind-icon:news" class="h-10 w-10 opacity-70" />
+      </div>
+
+      <span
+        v-if="primaryCategory"
+        class="badge badge-primary badge-sm absolute left-2 top-2 rounded-xl shadow"
+      >
+        {{ primaryCategory }}
+      </span>
+    </figure>
+
+    <div class="flex flex-1 flex-col gap-2 p-3">
+      <h3
+        class="line-clamp-2 text-sm font-black leading-tight text-base-content sm:text-base"
+      >
+        {{ item.title }}
+      </h3>
+
+      <p
+        v-if="item.summary"
+        class="line-clamp-2 text-xs leading-relaxed text-base-content/65 sm:text-sm"
+      >
+        {{ item.summary }}
+      </p>
+
+      <div
+        class="mt-auto flex flex-wrap items-center justify-between gap-2 pt-1"
+      >
+        <span
+          class="truncate text-xs font-bold text-base-content/55"
+          :title="item.source"
+        >
+          {{ item.source }}
+        </span>
+        <span
+          class="flex shrink-0 items-center gap-1 text-xs text-base-content/45"
+        >
+          <Icon name="kind-icon:clock" class="size-3" />
+          {{ relativeTime(item.publishedAt) }}
+          <Icon name="kind-icon:external-link" class="size-3" />
+        </span>
+      </div>
+    </div>
+  </a>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { NewsFeedItem } from '@/stores/helpers/newsfeed'
+
+const props = withDefaults(
+  defineProps<{
+    item: NewsFeedItem
+    showImage?: boolean
+  }>(),
+  {
+    showImage: true,
+  },
+)
+
+const imageFailed = ref(false)
+
+const imageSrc = computed(() => props.item.image || '')
+
+const primaryCategory = computed(() => props.item.category?.[0] || '')
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  if (!Number.isFinite(diffMs)) return ''
+
+  const minutes = Math.round(diffMs / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.round(days / 30)
+  return `${months}mo ago`
+}
+</script>

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -1,0 +1,229 @@
+<!-- /components/newsfeed/newsfeed-feed.vue -->
+<!--
+  The recommended newsfeed (conductor projects/newsfeed t-006). Aggregates the
+  user's enabled feeds (stores/feedPreferenceStore, t-004) via the server
+  pipeline (server/api/newsfeed, t-005) into a responsive card grid with
+  per-feed category filtering and chronological ordering. Reused on both the
+  homepage (content/index.md) and the Newsfeed Lab project page
+  (components/conductor/newsfeed-page.vue).
+-->
+<template>
+  <section class="flex flex-col gap-4">
+    <header class="flex flex-wrap items-center justify-between gap-3">
+      <div class="flex flex-wrap gap-1.5">
+        <button
+          type="button"
+          class="btn btn-sm rounded-xl"
+          :class="
+            activeSlug === 'all'
+              ? 'btn-primary'
+              : 'btn-ghost border border-base-300'
+          "
+          @click="activeSlug = 'all'"
+        >
+          All
+        </button>
+        <button
+          v-for="group in groups"
+          :key="group.slug"
+          type="button"
+          class="btn btn-sm gap-1.5 rounded-xl"
+          :class="
+            activeSlug === group.slug
+              ? 'btn-primary'
+              : 'btn-ghost border border-base-300'
+          "
+          @click="activeSlug = group.slug"
+        >
+          <Icon :name="group.icon" class="size-3.5" />
+          {{ group.title }}
+        </button>
+      </div>
+
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm rounded-xl"
+        :disabled="isLoading"
+        @click="loadFeed()"
+      >
+        <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+        <Icon v-else name="kind-icon:refresh" class="size-4" />
+        Refresh
+      </button>
+    </header>
+
+    <div
+      v-if="errorMessage"
+      class="rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div
+      v-else-if="isLoading && !allItems.length"
+      class="flex min-h-40 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+    >
+      <span class="loading loading-spinner loading-md text-primary" />
+    </div>
+
+    <div
+      v-else-if="!visibleItems.length"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"
+    >
+      <Icon
+        name="kind-icon:news"
+        class="mx-auto size-10 text-base-content/25"
+      />
+      <p class="mt-2 font-black">Nothing here yet</p>
+      <p class="mt-1 text-sm text-base-content/55">
+        The swarm hasn't published anything for this feed in a bit — check back
+        soon.
+      </p>
+    </div>
+
+    <div v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <FeedCard v-for="item in displayedItems" :key="item.id" :item="item" />
+    </div>
+
+    <button
+      v-if="canShowMore"
+      type="button"
+      class="btn btn-ghost btn-sm mx-auto rounded-xl"
+      @click="visibleLimit += pageSize"
+    >
+      Show more
+    </button>
+
+    <p v-if="sourceErrorCount" class="text-center text-xs text-base-content/40">
+      {{ sourceErrorCount }} source{{ sourceErrorCount === 1 ? '' : 's' }}
+      couldn't be reached this refresh — showing what did load.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { getFeedDefinition, type NewsFeedItem } from '@/stores/helpers/newsfeed'
+import { useFeedPreferenceStore } from '@/stores/feedPreferenceStore'
+
+const props = withDefaults(
+  defineProps<{
+    /** Cap the initial number of visible cards (0 = show all). */
+    initialLimit?: number
+  }>(),
+  {
+    initialLimit: 0,
+  },
+)
+
+interface FeedGroup {
+  slug: string
+  title: string
+  icon: string
+  items: NewsFeedItem[]
+}
+
+interface AggregatedFeedResponse {
+  slug: string
+  items: NewsFeedItem[]
+  sourceErrors: Array<{ sourceId: string; error: string }>
+}
+
+const feedPreferenceStore = useFeedPreferenceStore()
+
+const isLoading = ref(false)
+const errorMessage = ref('')
+const groups = ref<FeedGroup[]>([])
+const sourceErrorCount = ref(0)
+const activeSlug = ref<string>('all')
+const pageSize = 12
+const visibleLimit = ref(props.initialLimit || pageSize)
+
+const allItems = computed<NewsFeedItem[]>(() => {
+  const seen = new Set<string>()
+  const merged: NewsFeedItem[] = []
+
+  for (const group of groups.value) {
+    for (const item of group.items) {
+      if (seen.has(item.id)) continue
+      seen.add(item.id)
+      merged.push(item)
+    }
+  }
+
+  return merged.sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+})
+
+const visibleItems = computed<NewsFeedItem[]>(() => {
+  if (activeSlug.value === 'all') return allItems.value
+  return (
+    groups.value.find((group) => group.slug === activeSlug.value)?.items ?? []
+  )
+})
+
+const displayedItems = computed(() =>
+  visibleItems.value.slice(0, visibleLimit.value),
+)
+
+const canShowMore = computed(
+  () => visibleItems.value.length > displayedItems.value.length,
+)
+
+async function loadFeed(): Promise<void> {
+  isLoading.value = true
+  errorMessage.value = ''
+
+  try {
+    feedPreferenceStore.hydrate()
+    const slugs = feedPreferenceStore.enabledFeedSlugs.length
+      ? feedPreferenceStore.enabledFeedSlugs
+      : feedPreferenceStore.availableFeeds.map((feed) => feed.slug)
+
+    const res = await $fetch<{
+      success: boolean
+      message: string
+      data: AggregatedFeedResponse[] | null
+    }>('/api/newsfeed', {
+      query: slugs.length ? { feeds: slugs.join(',') } : undefined,
+    })
+
+    if (!res?.success || !res.data) {
+      throw new Error(res?.message || 'Failed to load the newsfeed.')
+    }
+
+    groups.value = res.data.map((aggregated) => {
+      const definition = getFeedDefinition(aggregated.slug)
+      return {
+        slug: aggregated.slug,
+        title: definition?.title || aggregated.slug,
+        icon: definition?.icon || 'kind-icon:news',
+        items: aggregated.items,
+      }
+    })
+    sourceErrorCount.value = res.data.reduce(
+      (sum, aggregated) => sum + aggregated.sourceErrors.length,
+      0,
+    )
+
+    if (
+      activeSlug.value !== 'all' &&
+      !groups.value.some((g) => g.slug === activeSlug.value)
+    ) {
+      activeSlug.value = 'all'
+    }
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Failed to load the newsfeed.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+watch(activeSlug, () => {
+  visibleLimit.value = props.initialLimit || pageSize
+})
+
+onMounted(() => {
+  void loadFeed()
+})
+</script>

--- a/public/components.json
+++ b/public/components.json
@@ -210,6 +210,12 @@
     ]
   },
   {
+    "folderName": "home",
+    "components": [
+      "home-feed-placeholder"
+    ]
+  },
+  {
     "folderName": "icons",
     "components": [
       "add-icon",
@@ -262,6 +268,13 @@
       "workspace-header",
       "workspace-narrator",
       "workspace-sheet"
+    ]
+  },
+  {
+    "folderName": "newsfeed",
+    "components": [
+      "feed-card",
+      "newsfeed-feed"
     ]
   },
   {


### PR DESCRIPTION
### Task
newsfeed/t-006: Render the recommended newsfeed on the user homepage (kind: software)

### What changed / what I produced
- `components/newsfeed/feed-card.vue` — single feed-item card, forking `dream-card.vue`'s title/badge/image/timestamp grammar (image fallback chain, source badge, category badge, relative timestamp, external link).
- `components/newsfeed/newsfeed-feed.vue` — fetches `/api/newsfeed` (t-005's aggregation pipeline) filtered by `feedPreferenceStore.enabledFeedSlugs` (t-004), merges + dedupes + sorts chronologically, with loading/empty/error states and per-feed category filter chips (mirrors `component-review-feed.vue`'s state pattern).
- `components/home/home-feed-placeholder.vue` — replaced the "on its way" placeholder copy with a slim welcome header (unchanged login/dashboard CTAs) plus the live `<NewsfeedFeed :initial-limit="9" />`.
- `components/conductor/newsfeed-page.vue` — slotted `<NewsfeedFeed />` into `ProjectFrontPage`'s `#interactive` slot (kept the pitch/marketing page as-is, per the task note) and updated `deliverables.done`/`next`.
- `public/components.json` — added the new `home` and `newsfeed` component-folder entries (hand-added rather than regenerated, since a full regen in this sandbox reorders unrelated entries due to environment-specific `localeCompare` collation — see Flags below).

### How I verified
- `npm run test` (vue-tsc --noEmit): clean, exit 0.
- `npx eslint` on all changed/new files: clean.
- `npx prettier --check`/`--write` on all changed/new files: clean.
- Attempted a local `npm run dev` preview: the homepage 500s against the sandbox's dummy `DATABASE_URL` (no live MariaDB) — this is the same documented sandbox limitation noted in newsfeed/t-014 ("could not boot a working nuxt dev preview... a DB/session limitation of that session, not a code defect"), not something this change introduced.

### Stakes
reversible

### Flags for Reviewer
- Visual confirmation of the feed rendering (image fallbacks, card grid responsiveness, filter chips) still needs a real preview-deploy — same limitation flagged on t-014/t-023's deferred items. Recommend a follow-up preview-deploy visual check task (t-014 already exists for the earlier `/`+`/dashboard` swap and could be extended, or a new one filed).
- `public/components.json`: regenerating it via `node utils/scripts/create-component-json.mjs` (or `npm run test`'s `nuxi prepare` postinstall) in this sandbox reorders several unrelated existing entries (e.g. `builder-card`/`builder-card-grid`, `ami-link`) and adds several real components missing from the committed file (`packmaker-admin-panel`, `component-review-feed`, `wonderlab-preview-host`, etc.) that predate this PR — looks like environment-dependent `Array.prototype.sort`/`localeCompare` collation, or the committed file has simply drifted from a stale generation. I hand-added only my two new folder entries to keep this diff scoped; the drift itself is worth its own kaizen task.
- `FEED_SOURCES` in `stores/helpers/newsfeed.ts` are still all `verified: false` (newsfeed/t-013 covers batch-verifying reachability) — this PR renders whatever the aggregation pipeline successfully fetches and shows a small "N sources couldn't be reached" note otherwise; it doesn't change source verification status.

### Kaizen suggestion
File a task to regenerate/reconcile `public/components.json` from a canonical environment (or make the legacy-folder sort collation-stable, e.g. explicit `localeCompare(b, 'en')` or a plain codepoint sort) so future sessions don't have to hand-patch it to avoid unrelated churn.

### Notes for reviewer
Depends on newsfeed/t-003 (homepage relocation) and t-005 (aggregation pipeline), both already merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_014ByPWNCdbNtNcnsVRjexNr)_