### PR TITLE
feat(stripe): fulfill Product purchases on checkout.session.completed

### DIFF
--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -110,6 +110,81 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session) {
   )
 }
 
+// digital-storefront Product purchase (digital-storefront/t-022): checkout
+// sessions for catalog items carry `metadata.productSlug` (set by the
+// checkout-creation route, mirroring mana_topup's `metadata.kind` convention)
+// so this handler knows which Product to fulfill. Order.stripeSessionId is
+// the idempotency key (unique constraint from t-011's migration) — a
+// redelivered webhook event finds the existing Order and returns without
+// double-fulfilling.
+async function handleProductPurchase(session: Stripe.Checkout.Session) {
+  const slug = session.metadata?.productSlug
+  const userId = Number(session.metadata?.userId)
+
+  if (!slug || !Number.isInteger(userId) || userId <= 0) {
+    console.error(
+      `⚠️ Stripe webhook: payment session ${session.id} missing productSlug/userId metadata`,
+    )
+    return
+  }
+
+  const existingOrder = await prisma.order.findUnique({
+    where: { stripeSessionId: session.id },
+  })
+  if (existingOrder) {
+    console.log(
+      `💤 Stripe webhook: session ${session.id} already fulfilled, skipping`,
+    )
+    return
+  }
+
+  const product = await prisma.product.findUnique({ where: { slug } })
+  if (!product || !product.active) {
+    console.error(
+      `⚠️ Stripe webhook: session ${session.id} references unknown/inactive product "${slug}"`,
+    )
+    return
+  }
+
+  const customerId =
+    typeof session.customer === 'string'
+      ? session.customer
+      : session.customer?.id
+
+  await prisma.$transaction(async (tx) => {
+    const order = await tx.order.create({
+      data: {
+        userId,
+        stripeSessionId: session.id,
+        stripeCustomerId: customerId ?? null,
+        status: 'PAID',
+        totalCents: session.amount_total ?? product.priceCents,
+      },
+    })
+
+    const item = await tx.orderItem.create({
+      data: {
+        orderId: order.id,
+        productId: product.id,
+        quantity: 1,
+        priceCents: product.priceCents,
+      },
+    })
+
+    await tx.entitlement.create({
+      data: {
+        userId,
+        productId: product.id,
+        orderItemId: item.id,
+      },
+    })
+  })
+
+  console.log(
+    `🎟️ Granted entitlement for product "${slug}" to user ${userId} (session ${session.id})`,
+  )
+}
+
 // customer.subscription.updated/deleted — keeps isMember in sync with Stripe's
 // view of the subscription (renewal, cancellation, payment failure) independent
 // of whether the cancellation was initiated from our UI or the Stripe dashboard.
@@ -185,6 +260,8 @@ export default defineEventHandler(async (event) => {
         await handleManaTopup(session)
       } else if (session.mode === 'subscription') {
         await handleSubscriptionCheckout(session)
+      } else if (session.mode === 'payment' && session.metadata?.productSlug) {
+        await handleProductPurchase(session)
       }
     } else if (
       stripeEvent.type === 'customer.subscription.updated' ||


### PR DESCRIPTION
### Task
digital-storefront/t-022: Stripe webhook (checkout.session.completed, payment mode) credits an Entitlement for the Mermaids PDF product (kind: software)

### What changed / what I produced
- `server/api/stripe/webhook.post.ts`: added `handleProductPurchase(session)`, called when a `checkout.session.completed` event has `session.mode === 'payment'` and `session.metadata?.productSlug` set (mirrors the existing `mana_topup` metadata convention on `handleManaTopup`).
- Resolves the `Product` by `slug`, then creates `Order` + `OrderItem` + `Entitlement` in a single `prisma.$transaction`.
- Idempotent on `Order.stripeSessionId` (unique constraint already added by t-011's migration) — checks for an existing `Order` for the session first and returns early (logs `💤 ... already fulfilled, skipping`) if found, same shape as `handleManaTopup`'s `ManaTransaction.refId` guard.

### How I verified
- `npm run test` (nuxi prepare + vue-tsc --noEmit, full project): exit 0, no errors.
- `npx eslint server/api/stripe/webhook.post.ts`: clean.
- `npx prettier --check server/api/stripe/webhook.post.ts`: clean.
- `npx prisma validate`: schema valid (confirms `Order`/`OrderItem`/`Entitlement`/`Product` models and the `stripeSessionId` unique constraint referenced here already exist from t-011).
- No live Stripe call made — this only adds a new branch to existing webhook-routing logic; did not touch `checkout.post.ts`/`topup.post.ts` or any live route.
- Could not exercise this against a real signed Stripe event from this sandbox (no egress/test secrets here); the repo has no existing test convention for this file either (confirmed no vitest, no existing webhook test to extend) — CI is the verification gate before merge, consistent with how the underlying migration (t-011 step 1) and PR #345 (mana_topup handler) were verified.

### Stakes
outward-facing — this is real purchase-fulfillment logic (grants a paid Entitlement). `gate_human: true` on the roadmap task; not self-merging.

### Flags for Reviewer
- This webhook branch expects the *checkout-session-creation* route to set `metadata.productSlug` (and `metadata.userId`) on the session, following the `topup.post.ts` → `metadata.kind = 'mana_topup'` precedent. No such creation route exists yet for storefront Products — that's t-023 (still `status: waiting`, depends on this task). t-023 will need to set that metadata contract when it builds the checkout route; documented here so it isn't rediscovered from scratch.
- `STRIPE_WEBHOOK_SECRET` isn't listed in either docker-compose file (only `STRIPE_SECRET_KEY` is) even though the existing webhook handler already reads it — pre-existing gap, not introduced by this change, flagging in case it's relevant to whoever configures the live webhook endpoint for this Product.
- EGRESS-BLOCKERS.md shows `api.stripe.com` reachability has been intermittent (blocked as of 2026-07-17T09:54, reachable again 2026-07-17T15:07) — did not need live Stripe egress for this change since it's local-logic-only, so didn't re-check.

### Kaizen suggestion
The three `server/api/stripe/*.ts` routes each redefine an identical `getStripeClient()` helper. Worth extracting to a shared `server/utils/stripe.ts` in a follow-up — out of scope here to keep this diff focused on t-022.

### Notes for reviewer
Per AGENTS.md, this stays at `status: needs-human` on the conductor roadmap (gate_human: true, stakes: outward-facing) — not merging live without Silas's explicit approval, even though CI passing. Please review and merge (or hold) at your discretion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjebR7SsaBZveLNmKiNkkB)_