### PR TITLE
ui: migrate artjob-manager/stylist-relay-status notices to kr-note-*

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -45,26 +45,22 @@
 
       <div
         v-if="artJobStore.error"
-        class="rounded-2xl border border-error/40 bg-error/10 p-2 text-xs text-error"
+        class="kr-note kr-note-error p-2 text-xs font-normal"
       >
         {{ artJobStore.error }}
       </div>
 
       <div
         v-if="bulkRetryMessage"
-        class="rounded-2xl border p-2 text-xs"
-        :class="
-          bulkRetryHasFailures
-            ? 'border-warning/40 bg-warning/10 text-warning'
-            : 'border-success/40 bg-success/10 text-success'
-        "
+        class="kr-note p-2 text-xs font-normal"
+        :class="bulkRetryHasFailures ? 'kr-note-warning' : 'kr-note-success'"
       >
         {{ bulkRetryMessage }}
       </div>
 
       <div
         v-if="stats?.oldestPending"
-        class="rounded-2xl border border-warning/40 bg-warning/10 p-2 text-xs text-warning"
+        class="kr-note kr-note-warning p-2 text-xs font-normal"
       >
         Oldest PENDING job #{{ stats.oldestPending.id }} has been waiting
         {{ formatAge(stats.oldestPending.ageSeconds) }} — if this keeps

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -43,10 +43,7 @@
         </button>
       </div>
 
-      <div
-        v-if="error"
-        class="rounded-2xl border border-error/40 bg-error/10 p-2 text-xs text-error"
-      >
+      <div v-if="error" class="kr-note kr-note-error p-2 text-xs font-normal">
         {{ error }}
       </div>
 


### PR DESCRIPTION
## Summary
- Continuation of `global-ui/t-023`'s deferred item (a) — art-status surfaces (`artjob-manager.vue`, `stylist-relay-status.vue`).
- Migrated only the notices whose colors are an **exact** match for `.kr-note-*` (`border-{status}/40 bg-{status}/10`, already carrying an explicit `text-{status}` class), using the `kr-note kr-note-* p-2 text-xs font-normal` override recipe the task note already prescribed for these dense surfaces.
- Left untouched (still need a preview-deploy eyeball, not decided unilaterally): the two full-height admin-only/agents-empty banners, the `/30`- and `/50`-opacity drift cases, and `artjob-manager.vue`'s info notice that currently sets no text color at all.
- Investigated `server-selector.vue`'s "Edit Local Server" info panel too (also item (b) of the same kaizen task): it's colored `border-info/40 bg-info/10`, an exact match, but its sibling `<h3>` has no explicit text-size class and Tailwind Preflight resets heading `font-size` to `inherit` — migrating would silently shrink that heading to `text-sm` while its "Add Local Server" sibling panel (uncovered by `.kr-note`, no `secondary` variant exists) stays whatever size it is today, a real visual regression with no way to confirm without a live preview. Left as-is; documented in the roadmap task for the next preview-driven pass.

## Test plan
- [x] `eslint` on both changed files — clean
- [x] `prettier --check` on both changed files — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — exit 0, no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdUSMPjmAG31iPnjDubsxC


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdUSMPjmAG31iPnjDubsxC)_