### PR TITLE
newsfeed: stale-source tolerance for aggregateFeed (t-009)

### DIFF
--- a/server/utils/newsfeed.ts
+++ b/server/utils/newsfeed.ts
@@ -20,6 +20,21 @@ import { getFeedSources } from '../../stores/helpers/newsfeed'
 const MAX_SUMMARY_LENGTH = 280
 const MAX_TITLE_LENGTH = 200
 const FETCH_TIMEOUT_MS = 8000
+// Stale-source tolerance: when a source's live fetch fails, serve its last
+// successful result instead of dropping it to zero items -- as long as that
+// result isn't older than this bound. Beyond the bound we'd rather show
+// nothing than pass off week-old headlines as current, so the fallback
+// expires like the live fetch would have anyway. In-memory only (per
+// process), so it's a pure improvement over always-empty on a warm instance
+// and a no-op (same as before) on a cold one.
+const STALE_FALLBACK_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+interface SourceCacheEntry {
+  items: NewsFeedItem[]
+  fetchedAt: number
+}
+
+const lastGoodSourceItems = new Map<string, SourceCacheEntry>()
 
 interface RawFeedEntry {
   title?: string
@@ -172,6 +187,20 @@ export interface SourceFetchResult {
   sourceId: string
   items: NewsFeedItem[]
   error?: string
+  /** True when `items` came from the last-known-good cache, not this fetch. */
+  stale?: boolean
+}
+
+/** Falls back to the last successful fetch for this source, if any and not too old. */
+function staleFallback(
+  sourceId: string,
+  error: string,
+): SourceFetchResult | null {
+  const cached = lastGoodSourceItems.get(sourceId)
+  if (!cached) return null
+  if (Date.now() - cached.fetchedAt > STALE_FALLBACK_MAX_AGE_MS) return null
+
+  return { sourceId, items: cached.items, error, stale: true }
 }
 
 export async function fetchSourceItems(
@@ -195,7 +224,14 @@ export async function fetchSourceItems(
     }
 
     if (!res.ok) {
-      return { sourceId: source.id, items: [], error: `HTTP ${res.status}` }
+      const error = `HTTP ${res.status}`
+      return (
+        staleFallback(source.id, error) || {
+          sourceId: source.id,
+          items: [],
+          error,
+        }
+      )
     }
 
     const xml = await res.text()
@@ -203,19 +239,26 @@ export async function fetchSourceItems(
       .map((raw) => normalizeEntry(raw, source))
       .filter((item): item is NewsFeedItem => item !== null)
 
+    lastGoodSourceItems.set(source.id, { items, fetchedAt: Date.now() })
     return { sourceId: source.id, items }
   } catch (error) {
     const message =
       error instanceof Error ? error.message : 'Unknown fetch error'
     console.warn(`📰 Newsfeed source "${source.id}" failed: ${message}`)
-    return { sourceId: source.id, items: [], error: message }
+    return (
+      staleFallback(source.id, message) || {
+        sourceId: source.id,
+        items: [],
+        error: message,
+      }
+    )
   }
 }
 
 export interface AggregatedFeed {
   slug: string
   items: NewsFeedItem[]
-  sourceErrors: Array<{ sourceId: string; error: string }>
+  sourceErrors: Array<{ sourceId: string; error: string; stale?: boolean }>
 }
 
 function matchesTagFilters(item: NewsFeedItem, feed: FeedDefinition): boolean {
@@ -243,11 +286,15 @@ export async function aggregateFeed(
 
   const seen = new Set<string>()
   const items: NewsFeedItem[] = []
-  const sourceErrors: Array<{ sourceId: string; error: string }> = []
+  const sourceErrors: AggregatedFeed['sourceErrors'] = []
 
   for (const result of results) {
     if (result.error)
-      sourceErrors.push({ sourceId: result.sourceId, error: result.error })
+      sourceErrors.push({
+        sourceId: result.sourceId,
+        error: result.error,
+        ...(result.stale ? { stale: true } : {}),
+      })
 
     for (const item of result.items) {
       if (seen.has(item.id)) continue

--- a/utils/scripts/verifyNewsfeedAggregation.ts
+++ b/utils/scripts/verifyNewsfeedAggregation.ts
@@ -8,6 +8,8 @@
 // "one broken source can't blank the homepage" guarantee this module exists
 // to provide.
 import assert from 'node:assert/strict'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 
 import {
   aggregateFeed,
@@ -204,9 +206,64 @@ async function run() {
     'unknown source ids are skipped, not errored',
   )
 
+  // --- fetchSourceItems: stale-source tolerance -----------------------------
+  // A source that has previously succeeded, then goes down, must keep serving
+  // its last-known-good items (flagged `stale: true`) instead of dropping to
+  // zero -- the actual gap t-009 closes on top of t-005's existing "one
+  // broken source can't blank the homepage" guarantee.
+
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/rss+xml' })
+    res.end(RSS_FIXTURE)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+
+  const flakySource: FeedSourceDefinition = {
+    id: 'flaky-fixture',
+    name: 'Flaky Fixture',
+    url: `http://127.0.0.1:${port}/feed.xml`,
+    kind: 'rss',
+    verified: false,
+  }
+
+  const liveResult = await fetchSourceItems(flakySource)
+  assert.equal(liveResult.items.length, 2, 'live fetch must parse both items')
+  assert.equal(liveResult.stale, undefined, 'a live fetch is never stale')
+  assert.equal(liveResult.error, undefined, 'a successful fetch has no error')
+
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+
+  const staleResult = await fetchSourceItems(flakySource)
+  assert.deepEqual(
+    staleResult.items,
+    liveResult.items,
+    'once the source goes down, its last successful items must still be served',
+  )
+  assert.equal(
+    staleResult.stale,
+    true,
+    'items served from the fallback cache must be flagged stale',
+  )
+  assert.ok(
+    staleResult.error,
+    'a stale-fallback result must still report the underlying fetch error',
+  )
+
+  // A source that has never succeeded has nothing to fall back to -- it must
+  // keep the original always-empty behavior, not synthesize items from thin air.
+  const neverSucceededResult = await fetchSourceItems(unreachableSource)
+  assert.deepEqual(
+    neverSucceededResult.items,
+    [],
+    'a source with no prior success has no stale cache to fall back to',
+  )
+  assert.equal(neverSucceededResult.stale, undefined)
+
   console.log(
     'newsfeed aggregation verified: RSS + Atom parsing, sanitization, category ' +
-      'extraction, malformed-input safety, and unreachable-source resilience.',
+      'extraction, malformed-input safety, unreachable-source resilience, and ' +
+      'stale-source fallback.',
   )
 }
 


### PR DESCRIPTION
## Summary
- `fetchSourceItems` now keeps a small in-memory last-known-good cache per source, keyed by source id.
- When a live fetch fails (HTTP error or thrown exception), it falls back to that source's last successful items (bounded to 24h old) instead of dropping to zero items, and flags the result `stale: true`.
- `AggregatedFeed.sourceErrors` now carries the `stale` flag through so a degraded-but-still-serving source is distinguishable from a fully broken one.
- A source with no prior success keeps the original always-empty-on-failure behavior — nothing is synthesized from thin air.

This closes conductor `projects/newsfeed/roadmap.yaml` task **t-009** ("Add bounded caching, stable item identity, duplicate removal, stale-source tolerance, and partial-success behavior so one broken feed does not blank the homepage"). Route-level bounded caching, stable item identity, duplicate removal, and partial-success-across-sources were already in place from t-005; stale-source tolerance was the one remaining gap.

## Test plan
- [x] `npm run test:newsfeed-aggregation` — added coverage: a source that succeeds once via a local HTTP fixture server, then goes down, must serve its last-known-good items with `stale: true` and a populated `error`; a source that never succeeded must still return empty items unchanged.
- [x] `npm test` (vue-tsc --noEmit) — exit 0
- [x] `npx eslint server/utils/newsfeed.ts utils/scripts/verifyNewsfeedAggregation.ts` — clean
- [x] `npx prettier --check` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsURUbcXxMGx4asYEK3Sbd)_