### PR TITLE
fix: make component manifest sort collation-stable (kind-robots/t-039)

### DIFF
--- a/utils/scripts/create-component-json.mjs
+++ b/utils/scripts/create-component-json.mjs
@@ -78,17 +78,21 @@ function buildLegacyFolders(entries) {
   }
 
   return [...folders.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
+    .sort(([left], [right]) => left.localeCompare(right, 'en'))
     .map(([folderName, components]) => ({
       folderName,
-      components: components.sort((left, right) => left.localeCompare(right)),
+      components: components.sort((left, right) =>
+        left.localeCompare(right, 'en'),
+      ),
     }))
 }
 
 async function generateComponentManifest() {
   const files = await collectVueFiles(COMPONENT_ROOT)
   const entries = await Promise.all(files.map(buildManifestEntry))
-  entries.sort((left, right) => left.sourcePath.localeCompare(right.sourcePath))
+  entries.sort((left, right) =>
+    left.sourcePath.localeCompare(right.sourcePath, 'en'),
+  )
 
   const manifest = {
     version: 1,


### PR DESCRIPTION
### Task
kind-robots/t-039: Make `utils/scripts/create-component-json.mjs`'s folder/component sort collation-stable (kind: software)

### What changed / what I produced
- `buildLegacyFolders`'s two `sort` calls and `generateComponentManifest`'s `entries.sort` now pin `localeCompare(..., 'en')` instead of bare `localeCompare()`, so the generator produces the same ordering regardless of the running Node/ICU build's default collation.
- Kaizen from `newsfeed/t-006` (kind_robots PR #425, 2026-07-18): regenerating `public/components.json` via this script (run implicitly by `nuxi prepare`'s postinstall, i.e. every `npm run test`/`npm run dev`) in a fresh sandbox reordered several already-committed entries (e.g. `builder-card-grid`/`builder-card`, `ami-link-butterflies`/`ami-link`) purely from re-running `Array.prototype.sort`/`localeCompare` in a different Node/ICU environment.

### How I verified
- `npx eslint utils/scripts/create-component-json.mjs` — clean
- `npx prettier --check utils/scripts/create-component-json.mjs` — clean (fixed one line-length wrap the diff introduced)
- `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — exit 0
- Regenerated the manifest locally via `node utils/scripts/create-component-json.mjs` and confirmed the reordering the task described (`builder-card-grid`/`builder-card`, `ami-link-butterflies`/`ami-link`, `user-manager`/`user-manager-directory`) no longer occurs relative to the currently committed file.

### Stakes
reversible

### Flags for Reviewer
- The regenerated `public/components.json` also picked up several real components that exist on disk but are missing from the committed file (`packmaker-admin-panel`, `packmaker-pack-editor`, `component-review-feed`, `component-test-fixture-cleanup`, `wonderlab-preview-host`, `wonderlab-selection-router`) — this is the *drift* half of the original kaizen note, explicitly called out there as "not this task's concern." Left `public/components.json` untouched here to keep this diff scoped to the sort-determinism fix; a full regenerate-and-commit pass is a separate follow-up.
- `public/wonderlab-components.json` is a build artifact regenerated by the same script but has never been committed to the repo (confirmed via `git log --all`) — left it out of this diff, matching existing convention.

### Kaizen suggestion
File the "regenerate-and-commit `public/components.json` from a canonical environment" follow-up as its own task (the drift/missing-components half flagged above) — small, mechanical, and now safe to do without reordering noise since this fix is in.

### Notes for reviewer
Conductor roadmap: `kind-robots/t-039`, claimed as `worker/claude-conductor-session-20260718T1815Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSAcqLc48LbS3QmzFVteu)_