### PR TITLE
ci(vercel): skip production deploys for snapshot data and test-only commits

### DIFF
--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -10,6 +10,12 @@ const ignoredPrefixes = [
   'artifacts/',
   'cypress/',
   'docs/',
+  // Nightly public-content snapshot data (see fallback-snapshot.yml). It is
+  // disaster-outage fallback that gets baked into the *next* real deploy
+  // anyway, so a snapshot-only commit does not warrant its own production
+  // deployment. Trade-off: on a day with no code deploys, the baked fallback
+  // can lag by up to a day — acceptable for outage-only data.
+  'stores/fallback/',
 ]
 
 const ignoredRootFiles = new Set([
@@ -18,6 +24,11 @@ const ignoredRootFiles = new Set([
   'CONTROL.md',
   'README.md',
 ])
+
+// Test/spec files never ship to the running app, so a commit that only touches
+// them (e.g. a "add contract test" chore) should not redeploy production.
+// Cypress specs are already covered by the cypress/ prefix above.
+const testFileSuffixes = ['.test.ts', '.test.js', '.test.mjs', '.spec.ts', '.spec.js', '.spec.mjs']
 
 function continueBuild(reason) {
   console.log(`[vercel-ignore] Build required: ${reason}`)
@@ -33,6 +44,7 @@ function isIgnoredPath(filePath) {
   return (
     ignoredRootFiles.has(filePath) ||
     ignoredPrefixes.some((prefix) => filePath.startsWith(prefix)) ||
+    testFileSuffixes.some((suffix) => filePath.endsWith(suffix)) ||
     filePath.endsWith('.bak')
   )
 }


### PR DESCRIPTION
## What

Broadens the Vercel Ignored Build Step (`scripts/vercel-ignore-build.mjs`) so two classes of non-runtime commit no longer each trigger a production deployment:

- **`stores/fallback/`** — nightly public-content snapshot data. It's baked into the next real deploy anyway, so a snapshot-only commit doesn't warrant its own deployment. (Trade-off: on a day with no code deploys the baked fallback can lag ~a day — fine for outage-only data.)
- **test/spec files** (`*.test.ts`, `*.spec.ts`, `*.mjs` variants) — they never ship to the running app.

## Why

Reduces churn against Vercel's Hobby-plan 100-deployments/day cap (the `api-deployments-free-per-day` error). This is a modest, safe trim — a simulation over the last 24h (73 commits, 51 deploying) showed it never over-skips (test commits bundled with `package.json` changes still correctly deploy). The larger levers (batching merges, Pro plan) remain separate decisions.

## Verification
- `node --check scripts/vercel-ignore-build.mjs` passes.
- Re-simulated the ignore logic across recent `main` commits: no legitimate app-code deploy is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U2f7HZoRLWVNHmWe6ZXHF

---
_Generated by [Claude Code](https://claude.ai/code/session_013U2f7HZoRLWVNHmWe6ZXHF)_