### PR TITLE
fix(a11y): keyboard-operable photo drop-zone + aria-expanded in stylist-restyle

### DIFF
--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -81,12 +81,16 @@
       <!-- Upload -->
       <div
         v-show="sourceTab === 'upload' && !sourceImageData"
+        role="button"
+        tabindex="0"
+        aria-label="Upload a client photo"
         class="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed p-6 text-center text-xs transition"
         :class="isDragging ? 'border-primary bg-primary/5' : 'border-base-300 hover:border-primary/60'"
         @click="fileInput?.click()"
         @dragover.prevent="isDragging = true"
         @dragleave.prevent="isDragging = false"
         @drop.prevent="handleDrop"
+        @keydown.enter.space.prevent="fileInput?.click()"
       >
         <Icon name="kind-icon:upload" class="h-6 w-6 text-base-content/50" />
         <span class="font-bold text-base-content/70">Drop a photo or click to browse</span>
@@ -208,6 +212,7 @@
       <button
         type="button"
         class="text-left text-[11px] text-base-content/50 underline"
+        :aria-expanded="advancedOpen"
         @click="advancedOpen = !advancedOpen"
       >
         {{ advancedOpen ? 'Hide' : 'Show' }} advanced settings


### PR DESCRIPTION
## Problem

`components/art/stylist-restyle.vue`'s client-photo upload drop-zone was a plain `<div>` driven only by `@click`/`@dragover`/`@dragleave`/`@drop` — no `role`, `tabindex`, or keydown handler, so keyboard-only and screen-reader users had no way to reach or trigger the file picker in that panel. This is the same class of gap already fixed in the sibling drop-zones (`art-styler.vue` PR #383, `image-upload.vue` PR #371) but this one was never brought in line.

Also found and fixed a smaller companion gap in the same file: the "Show/Hide advanced settings" disclosure toggle had no `aria-expanded`, so its open/closed state wasn't announced to assistive tech (sighted users only get the label text swap).

## Changes

- `components/art/stylist-restyle.vue`: added `role="button" tabindex="0" aria-label="Upload a client photo"` and an `@keydown.enter.space.prevent` handler to the upload drop-zone, mirroring the existing pattern in `art-styler.vue`/`image-upload.vue`.
- Added `:aria-expanded="advancedOpen"` to the advanced-settings toggle button.

Both changes are additive only — no logic changes beyond the fix itself.

## Verification

- `npx eslint components/art/stylist-restyle.vue` — clean.
- `npx prettier --check components/art/stylist-restyle.vue` — flags pre-existing formatting drift unrelated to this change (confirmed via `git stash` that the same warning exists on `main` before this diff; CI does not gate on lint/prettier).
- Full-project `vue-tsc --noEmit` — 0 errors.

ai-art-academy/t-010 continuous-improvement cycle, lane 1 (front-end polish), per `projects/ai-art-academy/docs/continuous-improvement-checklist.md`'s rotation rule (previous cycle ran lane 4, curriculum depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174ybCvSNtE8Xr5HieT2UHm

---
_Generated by [Claude Code](https://claude.ai/code/session_0174ybCvSNtE8Xr5HieT2UHm)_