### PR TITLE
chore: regenerate public/components.json from current main

### DIFF
--- a/public/components.json
+++ b/public/components.json
@@ -79,8 +79,8 @@
     "components": [
       "art-builder",
       "builder-art-input",
-      "builder-card-grid",
       "builder-card",
+      "builder-card-grid",
       "builder-custom-input",
       "builder-input",
       "builder-list-input",
@@ -100,9 +100,9 @@
     "folderName": "butterfly",
     "components": [
       "ami-butterfly",
+      "ami-link",
       "ami-link-butterflies",
       "ami-link-iframe",
-      "ami-link",
       "ami-loader",
       "base-butterfly",
       "butterfly-back",
@@ -157,6 +157,8 @@
       "davinci-page",
       "humboldt-scoop-page",
       "newsfeed-page",
+      "packmaker-admin-panel",
+      "packmaker-pack-editor",
       "packmaker-page",
       "project-deliverables-panel",
       "project-front-page",
@@ -472,8 +474,8 @@
       "user-builder",
       "user-dashboard",
       "user-galleries",
-      "user-manager-directory",
       "user-manager",
+      "user-manager-directory",
       "user-panel",
       "user-picture"
     ]
@@ -483,14 +485,18 @@
     "components": [
       "component-card",
       "component-count",
+      "component-review-feed",
       "component-sync",
+      "component-test-fixture-cleanup",
       "lab-gallery",
       "lab-interact",
       "lab-manager",
       "mural-manager",
       "new-eyeball",
       "reactable-card",
-      "reaction-card"
+      "reaction-card",
+      "wonderlab-preview-host",
+      "wonderlab-selection-router"
     ]
   }
 ]


### PR DESCRIPTION
### Task
kind-robots/t-040: Regenerate and commit public/components.json from a canonical environment (kind: software)

### What changed / what I produced
- Ran `node utils/scripts/create-component-json.mjs` from a clean checkout on current `main` and committed the resulting `public/components.json`.
- Adds the missing real components t-039's deterministic-sort fix surfaced: `packmaker-admin-panel`, `packmaker-pack-editor`, `component-review-feed`, `component-test-fixture-cleanup`, `wonderlab-preview-host`, `wonderlab-selection-router`.
- A few unrelated entries shift position — that's pure alphabetical correction (e.g. `builder-card` before `builder-card-grid`), not the cross-environment reordering churn t-039 fixed. No entries removed.

### How I verified
- Reviewed the full diff line-by-line: only additions + alphabetical corrections, nothing removed, no unexpected reordering.
- Validated the output is well-formed JSON.
- Did not commit the script's other output file (`public/wonderlab-components.json`) — it has never been tracked in this repo's history and is out of this task's scope.

### Stakes
reversible

### Notes for reviewer
Follow-up from t-039 (PR #429). Mechanical drift fix only — no code/logic changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017sfJJocrzyiHeQeRnfHWP2)_