### PR TITLE
fix(test): follow shared database adapter config

### DIFF
--- a/utils/scripts/verifyDatabasePoolDefaults.ts
+++ b/utils/scripts/verifyDatabasePoolDefaults.ts
@@ -45,6 +45,10 @@ const prismaSource = readFileSync(
   new URL('../../server/utils/prisma.ts', import.meta.url),
   'utf8',
 )
+const adapterSource = readFileSync(
+  new URL('../../server/utils/databaseAdapterConfig.ts', import.meta.url),
+  'utf8',
+)
 const directProbeSource = readFileSync(
   new URL('../../server/utils/databaseDirectProbe.ts', import.meta.url),
   'utf8',
@@ -58,20 +62,25 @@ const projectCreateSource = readFileSync(
   'utf8',
 )
 
-assert.match(prismaSource, /process\.env\.DATABASE_PING_TIMEOUT_MS/)
-assert.match(prismaSource, /pingTimeout:\s*readPositiveInteger/)
-assert.match(prismaSource, /DEFAULT_IDLE_TIMEOUT_SECONDS/)
-assert.match(prismaSource, /DEFAULT_MINIMUM_IDLE/)
-assert.doesNotMatch(prismaSource, /DATABASE_IDLE_TIMEOUT_SECONDS,\s*15/)
-assert.doesNotMatch(prismaSource, /DATABASE_MINIMUM_IDLE,\s*0/)
-assert.match(prismaSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
+// Pool configuration lives in the shared, side-effect-free adapter module so
+// request-time Prisma and standalone maintenance scripts use identical defaults.
+assert.match(adapterSource, /process\.env\.DATABASE_PING_TIMEOUT_MS/)
+assert.match(adapterSource, /pingTimeout:\s*readPositiveInteger/)
+assert.match(adapterSource, /DEFAULT_IDLE_TIMEOUT_SECONDS/)
+assert.match(adapterSource, /DEFAULT_MINIMUM_IDLE/)
+assert.doesNotMatch(adapterSource, /DATABASE_IDLE_TIMEOUT_SECONDS,\s*15/)
+assert.doesNotMatch(adapterSource, /DATABASE_MINIMUM_IDLE,\s*0/)
+assert.match(adapterSource, /process\.env\.DATABASE_USE_TEXT_PROTOCOL/)
+assert.match(
+  adapterSource,
+  /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
+)
+
+// The request-time singleton must consume the shared pool builder and protocol
+// reader rather than growing an independent adapter configuration again.
 assert.match(
   prismaSource,
   /new PrismaMariaDb\(buildDatabaseConfig\(databaseUrl\),\s*\{\s*useTextProtocol/,
-)
-assert.match(
-  prismaSource,
-  /return raw !== 'false' && raw !== '0' && raw !== 'no'/,
 )
 
 // A stale socket poisons the adapter client that owns its pool. Recovery must


### PR DESCRIPTION
## Root cause

PR #432 moved the database pool environment readers and defaults from `server/utils/prisma.ts` into the shared, side-effect-free `server/utils/databaseAdapterConfig.ts`. The contract verifier still searched `prisma.ts` for those literal source patterns, so `test:database-pool-defaults` failed even though the runtime behavior remained intact.

## Changes

- Read `databaseAdapterConfig.ts` in `verifyDatabasePoolDefaults.ts`.
- Run pool-default, timeout, and text-protocol source assertions against the shared adapter module.
- Keep Prisma singleton construction, recovery, transaction, and direct-write fallback assertions against their existing runtime files.
- Preserve the assertion that `prisma.ts` consumes `buildDatabaseConfig(databaseUrl)` and `useTextProtocol`.

## Impact

Test-only correction. No runtime database, TLS, pool, Prisma, or Vercel behavior changes.

## Validation

- Branch is one commit ahead of current `main` and changes only `utils/scripts/verifyDatabasePoolDefaults.ts`.
- Every relocated assertion matches the implementation introduced by #432.
- GitHub Contract Tests are the authoritative final gate.