### PR TITLE
fix(art): consolidate artjob-manager error notice onto .kr-note-error

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -358,7 +358,7 @@
 
             <div
               v-if="job.error"
-              class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
+              class="kr-note kr-note-error p-2 text-xs font-normal"
             >
               {{ job.error }}
             </div>


### PR DESCRIPTION
## Summary
- `artjob-manager.vue`'s per-job error banner used `border-error/30` instead of the canonical `border-error/40` — exactly the opacity drift `.kr-note-*` was introduced to prevent (see `assets/css/tailwind.css`'s `.kr-note` comment).
- Consolidated it onto `kr-note kr-note-error p-2 text-xs font-normal`, matching the same dense-chip override recipe already used elsewhere in this file and in `stylist-relay-status.vue`. No visual change beyond fixing the border-opacity drift (color trio now matches canonical exactly).
- Part of `global-ui/t-023`'s deferred "art status surfaces" cleanup pass. Investigated but left untouched (documented in the conductor roadmap task note, not guessed at here):
  - `artjob-manager.vue`'s adjacent retry-mode info notice — has no text color at all today; migrating would add a new `text-info` color, which is a real visual change this sandbox can't preview-verify.
  - `stylist-relay-status.vue`'s "Silent-stall risk" warning pill — its border/bg/text colors already match the canonical `kr-note-warning` values exactly (no drift to fix), and its shape (`rounded-xl`, `text-[11px]`) would need overrides beyond the established recipe to match `.kr-note`'s baseline shape for no visual benefit, so left as bespoke.
  - `composition-interact.vue`'s narrative panel — lives under `abandonware/`, which is excluded from both Nuxt component discovery (`nuxt.config.ts`) and the TS build (`tsconfig.json`), so it's dead code, not live — moot like `code-library.vue` was in the prior pass.

## Test plan
- [x] `npm run test` (vue-tsc --noEmit via `nuxi prepare`) — clean, no errors
- [x] `npx eslint components/art/artjob-manager.vue` — clean
- [x] `npx prettier --check components/art/artjob-manager.vue` — clean (fixed one formatting nit introduced by the edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDJxYo7UjnR6fbcPWgAWfQ)_