### PR TITLE
Separate Scenario CRUD from batch creation

### DIFF
--- a/cypress/e2e/api/scenario.cy.ts
+++ b/cypress/e2e/api/scenario.cy.ts
@@ -118,10 +118,47 @@ describe('Scenario Management API Tests', () => {
     })
   })
 
-  it('should return lean rows for batch creation too', () => {
+  it('should return 409 instead of a skipped pseudo-Scenario for duplicates', () => {
     cy.request({
       method: 'POST',
       url: baseUrl,
+      headers: bearerHeaders(userToken),
+      body: {
+        title: uniqueScenarioTitle,
+        description: 'This duplicate must not masquerade as a Scenario row.',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(409)
+      expect(response.body.success).to.be.false
+      expect(response.body.data).to.eq(null)
+      expect(response.body.message).to.include('Scenario already exists')
+    })
+  })
+
+  it('should reject arrays on single-resource Scenario POST', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(userToken),
+      body: [
+        {
+          title: uniqueBatchScenarioTitle,
+          description: 'This belongs on the explicit batch route.',
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.be.false
+      expect(response.body.message).to.include('/api/scenarios/batch')
+    })
+  })
+
+  it('should return lean rows from the explicit batch route', () => {
+    cy.request({
+      method: 'POST',
+      url: `${baseUrl}/batch`,
       headers: bearerHeaders(userToken),
       body: [
         {
@@ -136,6 +173,8 @@ describe('Scenario Management API Tests', () => {
       expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body.success).to.be.true
       expect(response.body.data.created).to.be.an('array').with.length(1)
+      expect(response.body.data.skipped).to.deep.eq([])
+      expect(response.body.data.failed).to.deep.eq([])
 
       const scenario = response.body.data.created[0]
       expectLeanMutation(scenario)

--- a/docs/architecture/thin-resource-api-audit.md
+++ b/docs/architecture/thin-resource-api-audit.md
@@ -28,7 +28,7 @@ Examples of explicit commands include publish, import, reconcile, generate, comm
 | Resource  | Previous finding                                                                               | Completed action                                                                                                                                                                                    |
 | --------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Character | POST/PATCH returned ArtImage, Rewards, Scenarios, and Dreams                                   | Added `characterMutationSelect`; mutation routes return Character scalars while relationship fetches remain explicit                                                                                |
-| Scenario  | Single/batch create and PATCH returned ArtImage, User, Characters, and Dreams                  | Added `scenarioMutationSelect`; `scenarioStore` force-hydrates detail after mutations. The existing single-or-array POST contract remains temporarily for compatibility                             |
+| Scenario  | Single/batch create and PATCH returned ArtImage, User, Characters, and Dreams; single-resource POST also accepted arrays and returned skipped pseudo-records | Added `scenarioMutationSelect`; `scenarioStore` force-hydrates detail after mutations. `POST /api/scenarios` now creates one Scenario and returns `409` for duplicates; `POST /api/scenarios/batch` owns array, skip, and partial-success behavior |
 | Reward    | Shared helpers returned ArtImage, Characters, Dreams, Reactions, and User after every mutation | Added `rewardMutationSelect`; create, batch create, and update return Reward scalars while GET routes retain detail                                                                                 |
 | Prompt    | Create returned User, Bot, and ArtImage; GET also fetched related art IDs                      | Added `promptResourceSelect`; Prompt POST/PATCH/GET return Prompt only. Related art remains on the existing art-by-prompt endpoint. Public-content karma remains isolated server-side domain policy |
 
@@ -79,7 +79,7 @@ For Dreams, collection creation remains an explicit `collectionStore` action. Ch
 
 1. ✅ Dream mutation boundaries and regression tests.
 2. ✅ Dream store/form cleanup and removal of obsolete collection/chat flags.
-3. ✅ Character, Scenario, Reward, and Prompt resource projections.
+3. ✅ Character, Scenario, Reward, and Prompt resource projections, including explicit Scenario single/batch create routes.
 4. ✅ Bot, Project, and PitchSheet response cleanup; retired the unused SocialPost/SocialTarget prototype instead of preserving dead CRUD.
 5. ✅ Dream delete referential actions and route simplification; continue the same audit for other resources only where manual cleanup remains.
 6. Re-run deployed API Cypress tests and compare Vercel mutation duration/error volume when production catches up to the merged API tier.

--- a/server/api/scenarios/batch.post.ts
+++ b/server/api/scenarios/batch.post.ts
@@ -1,0 +1,113 @@
+// /server/api/scenarios/batch.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { validateApiKey } from '@/server/utils/validateKey'
+import {
+  buildScenarioCreateInput,
+  fallbackScenarioTitle,
+  findExistingScenario,
+  getScenarioErrorMessage,
+  isScenarioInfrastructureError,
+  type FailedScenario,
+  type ScenarioPostInput,
+  type SkippedScenario,
+} from './create'
+import {
+  scenarioMutationSelect,
+  type ScenarioMutationResult,
+} from './selects'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const { isValid, user } = await validateApiKey(event)
+
+    if (!isValid || !user) {
+      throw createError({
+        statusCode: 401,
+        message: 'Invalid or expired token.',
+      })
+    }
+
+    const body = await readBody<ScenarioPostInput[]>(event)
+
+    if (!Array.isArray(body) || !body.length) {
+      throw createError({
+        statusCode: 400,
+        message: 'Scenario batch body must be a non-empty array.',
+      })
+    }
+
+    const created: ScenarioMutationResult[] = []
+    const skipped: SkippedScenario[] = []
+    const failed: FailedScenario[] = []
+
+    for (const scenarioData of body) {
+      const fallbackTitle = fallbackScenarioTitle(scenarioData)
+
+      try {
+        const createInput = buildScenarioCreateInput(scenarioData, user.id)
+        const existingScenario = await findExistingScenario(
+          createInput.title,
+          user.id,
+        )
+
+        if (existingScenario) {
+          skipped.push({
+            title: createInput.title,
+            existingId: existingScenario.id,
+            reason: 'Scenario with this title already exists for this user.',
+          })
+          continue
+        }
+
+        const createdScenario = await prisma.scenario.create({
+          data: createInput,
+          select: scenarioMutationSelect,
+        })
+
+        created.push(createdScenario)
+      } catch (error) {
+        if (isScenarioInfrastructureError(error)) throw error
+
+        failed.push({
+          title: fallbackTitle,
+          message: getScenarioErrorMessage(error),
+        })
+      }
+    }
+
+    if (failed.length && !created.length && !skipped.length) {
+      event.node.res.statusCode = 400
+
+      return {
+        success: false,
+        data: { created, skipped, failed },
+        message: `No scenarios were created. ${failed.length} failed.`,
+        statusCode: 400,
+      }
+    }
+
+    const statusCode = failed.length ? 207 : created.length ? 201 : 200
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: failed.length === 0,
+      data: { created, skipped, failed },
+      message: `${created.length} created, ${skipped.length} skipped, ${failed.length} failed.`,
+      statusCode,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      data: null,
+      message: handled.message || 'Failed to batch-create scenarios.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/scenarios/create.ts
+++ b/server/api/scenarios/create.ts
@@ -1,0 +1,264 @@
+import { createError } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { normalizeSlugInput } from '~/utils/slugify'
+import type {
+  Prisma,
+  ScenarioOutputType,
+} from '~/prisma/generated/prisma/client'
+
+export type ScenarioPostInput = {
+  title?: unknown
+  slug?: unknown
+  description?: unknown
+  intros?: unknown
+  outputType?: unknown
+  cast?: unknown
+  dreamIds?: unknown
+  artImageId?: unknown
+  imagePath?: unknown
+  locations?: unknown
+  artPrompt?: unknown
+  genres?: unknown
+  inspirations?: unknown
+  isMature?: unknown
+  isPublic?: unknown
+  isActive?: unknown
+  difficulty?: unknown
+  tier?: unknown
+  group?: unknown
+  secretNotes?: unknown
+}
+
+export type SkippedScenario = {
+  title: string
+  reason: string
+  existingId?: number
+}
+
+export type FailedScenario = {
+  title: string
+  message: string
+}
+
+const scenarioOutputTypes: ScenarioOutputType[] = [
+  'STORY',
+  'ART',
+  'CHARACTER',
+  'REWARD',
+  'DREAM',
+  'SCENARIO',
+  'MIXED',
+]
+
+function normalizeOutputType(value: unknown): ScenarioOutputType {
+  return scenarioOutputTypes.includes(value as ScenarioOutputType)
+    ? (value as ScenarioOutputType)
+    : 'STORY'
+}
+
+function normalizeIdArray(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+
+  const ids = value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isInteger(entry) && entry > 0)
+
+  return [...new Set(ids)]
+}
+
+function normalizeRequiredString(
+  value: unknown,
+  field: string,
+  maxLength = 191,
+): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field is required and must be a string.`,
+    })
+  }
+
+  const trimmed = value.trim()
+  if (trimmed.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
+    })
+  }
+
+  return trimmed
+}
+
+function normalizeString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value.trim() : fallback
+}
+
+function normalizeNullableString(value: unknown): string | null | undefined {
+  if (value === null) return null
+  if (value === undefined) return undefined
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true') return true
+    if (normalized === 'false') return false
+  }
+
+  return fallback
+}
+
+function normalizeNullableInteger(value: unknown): number | null | undefined {
+  if (value === null) return null
+  if (value === undefined || value === '') return undefined
+
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed)) {
+    throw createError({
+      statusCode: 400,
+      message: 'difficulty must be an integer when provided.',
+    })
+  }
+
+  return parsed
+}
+
+function normalizeIntros(value: unknown): string {
+  if (!value) return '[]'
+
+  if (Array.isArray(value)) {
+    return JSON.stringify(
+      value.map((entry) => String(entry).trim()).filter(Boolean),
+    )
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return '[]'
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) {
+        return JSON.stringify(
+          parsed.map((entry) => String(entry).trim()).filter(Boolean),
+        )
+      }
+      return JSON.stringify([trimmed])
+    } catch {
+      return JSON.stringify(
+        trimmed
+          .split('\n')
+          .map((entry) => entry.trim())
+          .filter(Boolean),
+      )
+    }
+  }
+
+  return '[]'
+}
+
+function normalizeOptionalJsonString(
+  value: unknown,
+): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+
+    try {
+      JSON.parse(trimmed)
+      return trimmed
+    } catch {
+      return JSON.stringify(trimmed)
+    }
+  }
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    throw createError({
+      statusCode: 400,
+      message: 'The "cast" field must be JSON-serializable.',
+    })
+  }
+}
+
+function normalizeOptionalId(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'artImageId must be a positive integer when provided.',
+    })
+  }
+
+  return id
+}
+
+export function fallbackScenarioTitle(input: ScenarioPostInput): string {
+  return typeof input.title === 'string' && input.title.trim()
+    ? input.title.trim()
+    : 'Untitled scenario'
+}
+
+export function getScenarioErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown scenario seed error.'
+}
+
+export function isScenarioInfrastructureError(error: unknown): boolean {
+  const handled = errorHandler(error)
+  return Number(handled.statusCode) >= 500
+}
+
+export function buildScenarioCreateInput(
+  scenarioData: ScenarioPostInput,
+  authenticatedUserId: number,
+): Prisma.ScenarioCreateInput {
+  const title = normalizeRequiredString(scenarioData.title, 'title')
+  const artImageId = normalizeOptionalId(scenarioData.artImageId)
+  const difficulty = normalizeNullableInteger(scenarioData.difficulty)
+  const dreamIds = normalizeIdArray(scenarioData.dreamIds)
+
+  return {
+    User: { connect: { id: authenticatedUserId } },
+    title,
+    slug: normalizeSlugInput(scenarioData.slug) ?? undefined,
+    description: normalizeString(scenarioData.description),
+    intros: normalizeIntros(scenarioData.intros),
+    outputType: normalizeOutputType(scenarioData.outputType),
+    cast: normalizeOptionalJsonString(scenarioData.cast),
+    imagePath: normalizeNullableString(scenarioData.imagePath),
+    locations: normalizeNullableString(scenarioData.locations),
+    artPrompt: normalizeNullableString(scenarioData.artPrompt),
+    genres: normalizeNullableString(scenarioData.genres),
+    inspirations: normalizeNullableString(scenarioData.inspirations),
+    isMature: normalizeBoolean(scenarioData.isMature, false),
+    isPublic: normalizeBoolean(scenarioData.isPublic, true),
+    isActive: normalizeBoolean(scenarioData.isActive, true),
+    difficulty,
+    tier: normalizeNullableString(scenarioData.tier),
+    group: normalizeNullableString(scenarioData.group),
+    secretNotes: normalizeNullableString(scenarioData.secretNotes),
+    ArtImage: artImageId ? { connect: { id: artImageId } } : undefined,
+    ...(dreamIds.length
+      ? { Dreams: { connect: dreamIds.map((id) => ({ id })) } }
+      : {}),
+  }
+}
+
+export async function findExistingScenario(title: string, userId: number) {
+  return await prisma.scenario.findFirst({
+    where: { title, userId },
+    select: { id: true, title: true },
+  })
+}

--- a/server/api/scenarios/index.post.ts
+++ b/server/api/scenarios/index.post.ts
@@ -1,269 +1,19 @@
 // /server/api/scenarios/index.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
-import { errorHandler } from '../../utils/error'
-import { validateApiKey } from '../../utils/validateKey'
-import { normalizeSlugInput } from '~/utils/slugify'
-import { Prisma } from '~/prisma/generated/prisma/client'
-import type { ScenarioOutputType } from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { validateApiKey } from '@/server/utils/validateKey'
 import {
-  scenarioMutationSelect,
-  type ScenarioMutationResult,
-} from './selects'
-
-type ScenarioPostInput = {
-  title?: unknown
-  slug?: unknown
-  description?: unknown
-  intros?: unknown
-  outputType?: unknown
-  cast?: unknown
-  dreamIds?: unknown
-  artImageId?: unknown
-  imagePath?: unknown
-  locations?: unknown
-  artPrompt?: unknown
-  genres?: unknown
-  inspirations?: unknown
-  isMature?: unknown
-  isPublic?: unknown
-  isActive?: unknown
-  difficulty?: unknown
-  tier?: unknown
-  group?: unknown
-  secretNotes?: unknown
-}
-
-type SkippedScenario = {
-  title: string
-  reason: string
-  existingId?: number
-}
-
-type FailedScenario = {
-  title: string
-  message: string
-}
-
-const scenarioOutputTypes: ScenarioOutputType[] = [
-  'STORY',
-  'ART',
-  'CHARACTER',
-  'REWARD',
-  'DREAM',
-  'SCENARIO',
-  'MIXED',
-]
-
-function normalizeOutputType(value: unknown): ScenarioOutputType {
-  return scenarioOutputTypes.includes(value as ScenarioOutputType)
-    ? (value as ScenarioOutputType)
-    : 'STORY'
-}
-
-function normalizeIdArray(value: unknown): number[] {
-  if (!Array.isArray(value)) return []
-
-  const ids = value
-    .map((entry) => Number(entry))
-    .filter((entry) => Number.isInteger(entry) && entry > 0)
-
-  return [...new Set(ids)]
-}
-
-function normalizeRequiredString(
-  value: unknown,
-  field: string,
-  maxLength = 191,
-): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field is required and must be a string.`,
-    })
-  }
-
-  const trimmed = value.trim()
-  if (trimmed.length > maxLength) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
-    })
-  }
-
-  return trimmed
-}
-
-function normalizeString(value: unknown, fallback = ''): string {
-  return typeof value === 'string' ? value.trim() : fallback
-}
-
-function normalizeNullableString(value: unknown): string | null | undefined {
-  if (value === null) return null
-  if (value === undefined) return undefined
-  if (typeof value !== 'string') return undefined
-
-  const trimmed = value.trim()
-  return trimmed || null
-}
-
-function normalizeBoolean(value: unknown, fallback: boolean): boolean {
-  if (typeof value === 'boolean') return value
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    if (normalized === 'true') return true
-    if (normalized === 'false') return false
-  }
-
-  return fallback
-}
-
-function normalizeNullableInteger(value: unknown): number | null | undefined {
-  if (value === null) return null
-  if (value === undefined || value === '') return undefined
-
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed)) {
-    throw createError({
-      statusCode: 400,
-      message: 'difficulty must be an integer when provided.',
-    })
-  }
-
-  return parsed
-}
-
-function normalizeIntros(value: unknown): string {
-  if (!value) return '[]'
-
-  if (Array.isArray(value)) {
-    return JSON.stringify(
-      value.map((entry) => String(entry).trim()).filter(Boolean),
-    )
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return '[]'
-
-    try {
-      const parsed = JSON.parse(trimmed)
-      if (Array.isArray(parsed)) {
-        return JSON.stringify(
-          parsed.map((entry) => String(entry).trim()).filter(Boolean),
-        )
-      }
-      return JSON.stringify([trimmed])
-    } catch {
-      return JSON.stringify(
-        trimmed
-          .split('\n')
-          .map((entry) => entry.trim())
-          .filter(Boolean),
-      )
-    }
-  }
-
-  return '[]'
-}
-
-function normalizeOptionalJsonString(
-  value: unknown,
-): string | null | undefined {
-  if (value === undefined) return undefined
-  if (value === null) return null
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-
-    try {
-      JSON.parse(trimmed)
-      return trimmed
-    } catch {
-      return JSON.stringify(trimmed)
-    }
-  }
-
-  try {
-    return JSON.stringify(value)
-  } catch {
-    throw createError({
-      statusCode: 400,
-      message: 'The "cast" field must be JSON-serializable.',
-    })
-  }
-}
-
-function normalizeOptionalId(value: unknown): number | undefined {
-  if (value === null || value === undefined || value === '') return undefined
-
-  const id = Number(value)
-  if (!Number.isInteger(id) || id <= 0) {
-    throw createError({
-      statusCode: 400,
-      message: 'artImageId must be a positive integer when provided.',
-    })
-  }
-
-  return id
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message
-  return 'Unknown scenario seed error.'
-}
-
-function isInfrastructureError(error: unknown): boolean {
-  const handled = errorHandler(error)
-  return Number(handled.statusCode) >= 500
-}
-
-function buildScenarioCreateInput(
-  scenarioData: ScenarioPostInput,
-  authenticatedUserId: number,
-): Prisma.ScenarioCreateInput {
-  const title = normalizeRequiredString(scenarioData.title, 'title')
-  const artImageId = normalizeOptionalId(scenarioData.artImageId)
-  const difficulty = normalizeNullableInteger(scenarioData.difficulty)
-  const dreamIds = normalizeIdArray(scenarioData.dreamIds)
-
-  return {
-    User: { connect: { id: authenticatedUserId } },
-    title,
-    slug: normalizeSlugInput(scenarioData.slug) ?? undefined,
-    description: normalizeString(scenarioData.description),
-    intros: normalizeIntros(scenarioData.intros),
-    outputType: normalizeOutputType(scenarioData.outputType),
-    cast: normalizeOptionalJsonString(scenarioData.cast),
-    imagePath: normalizeNullableString(scenarioData.imagePath),
-    locations: normalizeNullableString(scenarioData.locations),
-    artPrompt: normalizeNullableString(scenarioData.artPrompt),
-    genres: normalizeNullableString(scenarioData.genres),
-    inspirations: normalizeNullableString(scenarioData.inspirations),
-    isMature: normalizeBoolean(scenarioData.isMature, false),
-    isPublic: normalizeBoolean(scenarioData.isPublic, true),
-    isActive: normalizeBoolean(scenarioData.isActive, true),
-    difficulty,
-    tier: normalizeNullableString(scenarioData.tier),
-    group: normalizeNullableString(scenarioData.group),
-    secretNotes: normalizeNullableString(scenarioData.secretNotes),
-    ArtImage: artImageId ? { connect: { id: artImageId } } : undefined,
-    ...(dreamIds.length
-      ? { Dreams: { connect: dreamIds.map((id) => ({ id })) } }
-      : {}),
-  }
-}
-
-async function findExistingScenario(title: string, userId: number) {
-  return await prisma.scenario.findFirst({
-    where: { title, userId },
-    select: { id: true, title: true },
-  })
-}
+  buildScenarioCreateInput,
+  findExistingScenario,
+  type ScenarioPostInput,
+} from './create'
+import { scenarioMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
   try {
     const { isValid, user } = await validateApiKey(event)
+
     if (!isValid || !user) {
       throw createError({
         statusCode: 401,
@@ -272,93 +22,59 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = await readBody<ScenarioPostInput | ScenarioPostInput[]>(event)
-    if (!body) {
+
+    if (Array.isArray(body)) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'POST /api/scenarios creates one Scenario. Use /api/scenarios/batch for arrays.',
+      })
+    }
+
+    if (!body || typeof body !== 'object') {
       throw createError({
         statusCode: 400,
         message: 'Request body is required.',
       })
     }
 
-    const isBatch = Array.isArray(body)
-    const scenarioInputs = isBatch ? body : [body]
-    if (!scenarioInputs.length) {
+    const createInput = buildScenarioCreateInput(body, user.id)
+    const existingScenario = await findExistingScenario(
+      createInput.title,
+      user.id,
+    )
+
+    if (existingScenario) {
       throw createError({
-        statusCode: 400,
-        message: 'Request body must include at least one scenario.',
+        statusCode: 409,
+        message: `Scenario already exists with ID ${existingScenario.id}.`,
       })
     }
 
-    const created: ScenarioMutationResult[] = []
-    const skipped: SkippedScenario[] = []
-    const failed: FailedScenario[] = []
+    const data = await prisma.scenario.create({
+      data: createInput,
+      select: scenarioMutationSelect,
+    })
 
-    for (const scenarioData of scenarioInputs) {
-      const fallbackTitle =
-        typeof scenarioData.title === 'string' && scenarioData.title.trim()
-          ? scenarioData.title.trim()
-          : 'Untitled scenario'
+    event.node.res.statusCode = 201
 
-      try {
-        const createInput = buildScenarioCreateInput(scenarioData, user.id)
-        const title = createInput.title
-        const existingScenario = await findExistingScenario(title, user.id)
-
-        if (existingScenario) {
-          skipped.push({
-            title,
-            existingId: existingScenario.id,
-            reason: 'Scenario with this title already exists for this user.',
-          })
-          continue
-        }
-
-        const createdScenario = await prisma.scenario.create({
-          data: createInput,
-          select: scenarioMutationSelect,
-        })
-
-        created.push(createdScenario)
-      } catch (error) {
-        if (isInfrastructureError(error)) throw error
-
-        failed.push({
-          title: fallbackTitle,
-          message: getErrorMessage(error),
-        })
-      }
-    }
-
-    if (failed.length && !created.length && !skipped.length) {
-      event.node.res.statusCode = 400
-      return {
-        success: false,
-        data: { created, skipped, failed },
-        message: `No scenarios were created. ${failed.length} failed.`,
-      }
-    }
-
-    event.node.res.statusCode = failed.length ? 207 : 201
     return {
-      success: failed.length === 0,
-      data: isBatch
-        ? { created, skipped, failed }
-        : created[0] || skipped[0] || failed[0],
-      message: isBatch
-        ? `${created.length} created, ${skipped.length} skipped, ${failed.length} failed.`
-        : created.length
-          ? 'Scenario created successfully.'
-          : skipped.length
-            ? 'Scenario already exists. Skipped duplicate.'
-            : 'Scenario failed to create.',
+      success: true,
+      data,
+      message: 'Scenario created successfully.',
+      statusCode: 201,
     }
   } catch (error: unknown) {
-    const { message, statusCode } = errorHandler(error)
-    event.node.res.statusCode = statusCode || 500
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
 
     return {
       success: false,
       data: null,
-      message: message || 'Failed to create scenario.',
+      message: handled.message || 'Failed to create scenario.',
+      statusCode,
     }
   }
 })


### PR DESCRIPTION
## What changed

- makes `POST /api/scenarios` accept exactly one Scenario payload
- rejects arrays on the single-resource endpoint with a pointer to `/api/scenarios/batch`
- returns `409` for duplicate user/title creates instead of a skipped pseudo-record
- adds `POST /api/scenarios/batch` for array, skip, and partial-success semantics
- extracts shared Scenario create normalization and duplicate lookup into `server/api/scenarios/create.ts`
- keeps lean `scenarioMutationSelect` responses on both routes
- updates the Scenario Cypress suite and the thin-resource API audit

## Caller impact

`scenarioStore` already creates one Scenario at a time and needs no change. Repository search found no application caller posting arrays to `/api/scenarios`; the legacy array caller was the Cypress test and now targets the explicit batch endpoint.

## Checks

- TypeScript Type Check: passed
- Contract Tests: passed
- final changed files: 5
- Scenario Cypress API suite runs after deployment