### PR TITLE
Serendipity: expose pending chat streaming state + badge/filter story todos

### DIFF
--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -810,9 +810,23 @@
               >
                 🤖 Agent
                 <span
-                  v-if="todoStore.agentTodos.length"
+                  v-if="todoStore.regularAgentTodos.length"
                   class="badge badge-xs badge-primary"
-                  >{{ todoStore.agentTodos.length }}</span
+                  >{{ todoStore.regularAgentTodos.length }}</span
+                >
+              </button>
+              <button
+                type="button"
+                role="tab"
+                class="tab gap-1 text-xs"
+                :class="taskTab === 'SERENDIPITY' ? 'tab-active' : ''"
+                @click="taskTab = 'SERENDIPITY'"
+              >
+                ✨ Story
+                <span
+                  v-if="todoStore.serendipityAgentTodos.length"
+                  class="badge badge-xs badge-secondary"
+                  >{{ todoStore.serendipityAgentTodos.length }}</span
                 >
               </button>
               <button
@@ -954,6 +968,11 @@
                     v-if="todoFilter !== 'OPEN' && todo.category === 'KAIZEN'"
                     class="badge badge-secondary badge-xs shrink-0"
                     >✨ kaizen</span
+                  >
+                  <span
+                    v-if="todoStore.isSerendipityAgentTodo(todo)"
+                    class="badge badge-secondary badge-xs shrink-0"
+                    >✨ story</span
                   >
                   <div class="flex shrink-0 gap-1">
                     <button
@@ -2098,7 +2117,7 @@ const newTodoPriority = ref<ProjectPriorityLevel>('NORMAL')
 const newTodoCategory = ref<TodoCategory>('AGENT')
 const todoFilter = ref<'OPEN' | 'DONE' | 'ARCHIVED'>('OPEN')
 const todoFilterOptions = ['OPEN', 'DONE', 'ARCHIVED'] as const
-const taskTab = ref<'AGENT' | 'KAIZEN' | 'HONEYDO'>('AGENT')
+const taskTab = ref<'AGENT' | 'SERENDIPITY' | 'KAIZEN' | 'HONEYDO'>('AGENT')
 const requestingPitches = ref(false)
 
 let saveMessageTimer: ReturnType<typeof setTimeout> | null = null
@@ -2230,12 +2249,14 @@ const filteredTodos = computed(() => {
   if (todoFilter.value === 'DONE') return todoStore.doneTodos
   if (todoFilter.value === 'ARCHIVED') return todoStore.archivedTodos
   switch (taskTab.value) {
+    case 'SERENDIPITY':
+      return todoStore.serendipityAgentTodos
     case 'KAIZEN':
       return todoStore.kaizenTodos
     case 'HONEYDO':
       return todoStore.honeyDoTodos
     default:
-      return todoStore.agentTodos
+      return todoStore.regularAgentTodos
   }
 })
 
@@ -2442,7 +2463,7 @@ watch(viewMode, async (mode) => {
 })
 
 watch(taskTab, (tab) => {
-  newTodoCategory.value = tab
+  newTodoCategory.value = tab === 'SERENDIPITY' ? 'AGENT' : tab
 })
 
 watch(
@@ -2617,7 +2638,7 @@ async function submitNewTodo() {
   newTodoTitle.value = ''
   newTodoDescription.value = ''
   newTodoPriority.value = 'NORMAL'
-  newTodoCategory.value = taskTab.value
+  newTodoCategory.value = taskTab.value === 'SERENDIPITY' ? 'AGENT' : taskTab.value
   todoFilter.value = 'OPEN'
 }
 

--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -255,6 +255,12 @@ export const useChatStore = defineStore('chatStore', () => {
   const selectedRecipientId = ref<number | null>(null)
   const isInitialized = ref(false)
 
+  // Set to the chat's id while generateText is streaming its response, and
+  // cleared once the stream settles (success or failure). Lets streaming
+  // consumers (e.g. Serendipity) reference the in-flight chat directly
+  // instead of assuming it is always the last entry in `chats`.
+  const pendingChatId = ref<number | null>(null)
+
   const initializePromise = ref<Promise<void> | null>(null)
   const fetchChatsPromise = ref<Promise<void> | null>(null)
   const lastFetchedUserId = ref<number | null>(null)
@@ -395,6 +401,13 @@ export const useChatStore = defineStore('chatStore', () => {
   const canGenerateText = computed(() => {
     return Boolean(!state.isGenerating && state.textForm.prompt.trim())
   })
+
+  const pendingChat = computed<Chat | null>(() => {
+    if (pendingChatId.value === null) return null
+    return chats.value.find((chat) => chat.id === pendingChatId.value) ?? null
+  })
+
+  const pendingText = computed(() => pendingChat.value?.botResponse ?? '')
 
   function setGenerationMessage(
     tone: 'success' | 'error',
@@ -1320,6 +1333,7 @@ export const useChatStore = defineStore('chatStore', () => {
 
       const newChat = await createChat(chatPayload)
       chats.value.push(newChat)
+      pendingChatId.value = newChat.id
       refreshUnreadMessages()
       saveToLocalStorage()
 
@@ -1352,6 +1366,7 @@ export const useChatStore = defineStore('chatStore', () => {
       }
     } finally {
       state.isGenerating = false
+      pendingChatId.value = null
     }
   }
 
@@ -1653,6 +1668,9 @@ export const useChatStore = defineStore('chatStore', () => {
     selectedChat,
     selectedRecipientId,
     isInitialized,
+    pendingChatId,
+    pendingChat,
+    pendingText,
     initializePromise,
     fetchChatsPromise,
     lastFetchedUserId,

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -334,6 +334,7 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
           description: `Captured by Serendipity for conductor task ${question.projectSlug}/${question.conductorTaskId} ("${context?.title ?? ''}").\n\nProtagonist's answer: ${beat.answer.text}\n\nThe conductor task stays needs-human until Silas edits the roadmap.`,
           category: 'AGENT',
           projectId: projectId.value,
+          icon: 'kind-icon:sparkles',
         })
         ok = created !== null
       }

--- a/stores/serendipityStore.ts
+++ b/stores/serendipityStore.ts
@@ -149,17 +149,14 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
   const userStore = useUserStore()
 
   const session = ref<SerendipitySession | null>(null)
-  const weaveStartChatCount = ref<number | null>(null)
   const isWeaving = ref(false)
   const errorMessage = ref('')
 
-  // generateText pushes the new chat into chatStore.chats before streaming
-  // into its botResponse, and only resolves once the stream ends — so the
-  // live text is on the chat added after weaving began.
+  // chatStore tracks the in-flight streaming chat directly via pendingText,
+  // so this no longer needs to guess at it from the last entry in `chats`.
   const streamingText = computed(() => {
-    if (!isWeaving.value || weaveStartChatCount.value === null) return ''
-    if (chatStore.chats.length <= weaveStartChatCount.value) return ''
-    return chatStore.chats[chatStore.chats.length - 1]?.botResponse ?? ''
+    if (!isWeaving.value) return ''
+    return chatStore.pendingText
   })
 
   const currentBeat = computed(
@@ -409,7 +406,6 @@ export const useSerendipityStore = defineStore('serendipityStore', () => {
 
   function resetSession() {
     session.value = null
-    weaveStartChatCount.value = null
     errorMessage.value = ''
     saveToLocalStorage()
   }
@@ -551,7 +547,6 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
     if (!session.value) return false
     isWeaving.value = true
     errorMessage.value = ''
-    weaveStartChatCount.value = chatStore.chats.length
     try {
       const result = await chatStore.generateText({
         prompt,
@@ -593,7 +588,6 @@ story, and end with warmth. This is the finale — do NOT end with a question.`
       return false
     } finally {
       isWeaving.value = false
-      weaveStartChatCount.value = null
     }
   }
 

--- a/stores/todoStore.ts
+++ b/stores/todoStore.ts
@@ -71,6 +71,25 @@ export const useTodoStore = defineStore('todoStore', () => {
   const agentTodos = computed(() =>
     openTodos.value.filter((todo) => !todo.category || todo.category === 'AGENT'),
   )
+
+  function isSerendipityAgentTodo(todo: Todo): boolean {
+    if (todo.category && todo.category !== 'AGENT') return false
+    const title = todo.title.toLowerCase()
+    const description = todo.description?.toLowerCase() ?? ''
+    return (
+      todo.icon === 'kind-icon:sparkles' ||
+      title.startsWith('story decision on ') ||
+      description.startsWith('captured by serendipity for conductor task ')
+    )
+  }
+
+  const serendipityAgentTodos = computed(() =>
+    agentTodos.value.filter((todo) => isSerendipityAgentTodo(todo)),
+  )
+  const regularAgentTodos = computed(() =>
+    agentTodos.value.filter((todo) => !isSerendipityAgentTodo(todo)),
+  )
+
   const kaizenTodos = computed(() =>
     openTodos.value.filter((todo) => todo.category === 'KAIZEN'),
   )
@@ -274,6 +293,9 @@ export const useTodoStore = defineStore('todoStore', () => {
     doneTodos,
     archivedTodos,
     agentTodos,
+    serendipityAgentTodos,
+    regularAgentTodos,
+    isSerendipityAgentTodo,
     kaizenTodos,
     honeyDoTodos,
     dreamKaizens,


### PR DESCRIPTION
### Task
- serendipity/t-008: Expose the in-flight chat (pending chat id or ref) from kind_robots chatStore for streaming consumers (kind: software)
- serendipity/t-011: Badge and filter Serendipity-created AGENT todos in the Todos surface (kind: software)

Both are small, independent serendipity UI/store tasks that ended up on the same session branch; landing them in one PR since neither is large enough to warrant splitting after the fact.

### What changed / what I produced
**t-008:**
- `stores/chatStore.ts`: added `pendingChatId` (set to the new chat's id right after it's pushed in `generateText`, cleared in `finally` once the stream settles), plus `pendingChat` and `pendingText` computed values derived from it. All three are returned from the store.
- `stores/serendipityStore.ts`: `streamingText` now reads `chatStore.pendingText` directly instead of assuming the in-flight chat is always `chats[chats.length - 1]`, gated by a chat-count snapshot (`weaveStartChatCount`). Removed `weaveStartChatCount` entirely — it's now redundant.

**t-011:**
- `stores/todoStore.ts`: added `isSerendipityAgentTodo()` (detects story-created AGENT todos by icon or title/description prefix), plus `serendipityAgentTodos` / `regularAgentTodos` computed splits of `agentTodos`.
- `stores/serendipityStore.ts`: the story-decision `createTodo` call now sets `icon: 'kind-icon:sparkles'` so created todos are reliably detectable.
- `components/pages/conductor-page.vue`: added a "✨ Story" tab (between Agent and Kaizen) filtered to `serendipityAgentTodos`; the Agent tab now shows `regularAgentTodos` so story todos don't double-count; added a "✨ story" badge on the todo card shown in all filters (open/done/archived, matching the kaizen badge's existing pattern but without the `todoFilter !== 'OPEN'` gate per this task's own verification checklist).

### How I verified
- `npm run test` (vue-tsc --noEmit) — clean, no errors, both commits.
- `npx eslint` on all changed files — 2 pre-existing `no-empty` errors in `chatStore.ts` at lines 169/177 (unrelated empty catch blocks, untouched by this diff); no new lint errors introduced by either commit.
- Manual code trace of the Story/Agent tab split and the `newTodoCategory` assignment sites (`watch(taskTab)` and `submitNewTodo`) to confirm creating a new todo while the Story tab is active still creates a regular `AGENT` todo, not something typed `SERENDIPITY` (not a real `TodoCategory`).

### Stakes
reversible

### Notes for reviewer
Per each task's note, a prior ChatGPT/connector-only session had the same intended changes blocked by a GitHub connector write-safety filter and left both tasks at `status: ready` for a local-code session to pick up (t-011's full intended patch was already drafted at `projects/serendipity/docs/t-011-serendipity-agent-todo-badge-filter.md` in the conductor repo) — this session has full git + GitHub MCP access, so implementing directly.
