### PR TITLE
WonderLab: add passive card and context fixtures

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -103,6 +103,9 @@ jobs:
       - name: WonderLab achievement and navigation fixtures contract
         run: npm run test:wonderlab-achievement-navigation-fixtures
 
+      - name: WonderLab passive card fixtures contract
+        run: npm run test:wonderlab-passive-card-fixtures
+
       - name: WonderLab preview coverage audit
         run: npm run audit:wonderlab-previews 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -1,9 +1,10 @@
 <!-- /components/newsfeed/feed-card.vue -->
 <template>
-  <a
-    :href="item.url"
-    target="_blank"
-    rel="noopener noreferrer"
+  <component
+    :is="allowNavigation ? 'a' : 'article'"
+    :href="allowNavigation ? item.url : undefined"
+    :target="allowNavigation ? '_blank' : undefined"
+    :rel="allowNavigation ? 'noopener noreferrer' : undefined"
     class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl"
   >
     <figure
@@ -61,11 +62,15 @@
         >
           <Icon name="kind-icon:clock" class="size-3" />
           {{ relativeTime(item.publishedAt) }}
-          <Icon name="kind-icon:external-link" class="size-3" />
+          <Icon
+            v-if="allowNavigation"
+            name="kind-icon:external-link"
+            class="size-3"
+          />
         </span>
       </div>
     </div>
-  </a>
+  </component>
 </template>
 
 <script setup lang="ts">
@@ -76,16 +81,17 @@ const props = withDefaults(
   defineProps<{
     item: NewsFeedItem
     showImage?: boolean
+    allowNavigation?: boolean
   }>(),
   {
     showImage: true,
+    allowNavigation: true,
   },
 )
 
 const imageFailed = ref(false)
 
 const imageSrc = computed(() => props.item.image || '')
-
 const primaryCategory = computed(() => props.item.category?.[0] || '')
 
 function relativeTime(iso: string): string {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:wonderlab-visual-fixtures": "tsx utils/scripts/verifyWonderLabVisualFixtures.ts",
     "test:wonderlab-ui-fixtures": "tsx utils/scripts/verifyWonderLabUiFixtures.ts",
     "test:wonderlab-achievement-navigation-fixtures": "tsx utils/scripts/verifyWonderLabAchievementNavigationFixtures.ts",
+    "test:wonderlab-passive-card-fixtures": "tsx utils/scripts/verifyWonderLabPassiveCardFixtures.ts",
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",

--- a/utils/scripts/verifyWonderLabPassiveCardFixtures.ts
+++ b/utils/scripts/verifyWonderLabPassiveCardFixtures.ts
@@ -1,0 +1,48 @@
+// /utils/scripts/verifyWonderLabPassiveCardFixtures.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { getWonderLabPreviewFixture } from '@/utils/wonderlab/previewFixtureCatalog'
+
+const stageMessage = getWonderLabPreviewFixture('stage-message')
+assert.ok(stageMessage?.props?.entry)
+const entry = stageMessage.props.entry as Record<string, unknown>
+assert.equal(entry.speakerArtImageId, null)
+assert.equal(entry.speakerImagePath, null)
+assert.equal(entry.kind, 'speaker')
+
+const stagePreset = getWonderLabPreviewFixture('stage-preset')
+assert.equal(stagePreset?.props?.isSelected, true)
+const preset = stagePreset?.props?.preset as Record<string, unknown>
+assert.equal(preset.imagePath, null)
+assert.ok(Array.isArray(preset.roles) && preset.roles.length >= 2)
+
+const honeydo = getWonderLabPreviewFixture('honeydo-card')
+assert.ok(honeydo?.props?.todo)
+assert.equal(honeydo?.props?.project, null)
+assert.equal(honeydo?.props?.showRelativeTime, false)
+assert.equal(honeydo?.props?.showArchiveAction, false)
+assert.equal(honeydo?.props?.showDeleteAction, false)
+
+const feed = getWonderLabPreviewFixture('feed-card')
+assert.ok(feed?.props?.item)
+assert.equal(feed?.props?.showImage, false)
+assert.equal(feed?.props?.allowNavigation, false)
+const feedItem = feed.props.item as Record<string, unknown>
+assert.equal(feedItem.image, null)
+
+for (const key of ['loading-messages', 'tutorial-flyer'] as const) {
+  const fixture = getWonderLabPreviewFixture(key)
+  assert.ok(fixture?.skipReason, `${key} must explain its application context.`)
+}
+
+const feedSource = await readFile('components/newsfeed/feed-card.vue', 'utf8')
+assert.match(feedSource, /allowNavigation\?: boolean/)
+assert.match(feedSource, /allowNavigation: true/)
+assert.match(feedSource, /allowNavigation \? 'a' : 'article'/)
+assert.match(feedSource, /v-if="allowNavigation"/)
+
+// Confirm earlier fixture modules still resolve after adding another catalog layer.
+assert.ok(getWonderLabPreviewFixture('hero-showcase')?.props?.items)
+assert.ok(getWonderLabPreviewFixture('component-card')?.props?.component)
+
+console.log('WonderLab passive card fixture verification passed.')

--- a/utils/wonderlab/previewFixtureCatalog.ts
+++ b/utils/wonderlab/previewFixtureCatalog.ts
@@ -7,6 +7,10 @@ import {
   getWonderLabAchievementNavigationFixture,
   listWonderLabAchievementNavigationFixtureKeys,
 } from './previewFixturesAchievementNavigation'
+import {
+  getWonderLabPassiveCardFixture,
+  listWonderLabPassiveCardFixtureKeys,
+} from './previewFixturesPassiveCards'
 
 export type {
   WonderLabPreviewFixture,
@@ -19,7 +23,8 @@ export function getWonderLabPreviewFixture(
 ) {
   return (
     getCoreFixture(componentName, sourcePath) ??
-    getWonderLabAchievementNavigationFixture(componentName, sourcePath)
+    getWonderLabAchievementNavigationFixture(componentName, sourcePath) ??
+    getWonderLabPassiveCardFixture(componentName, sourcePath)
   )
 }
 
@@ -28,6 +33,7 @@ export function listWonderLabPreviewFixtureKeys(): string[] {
     ...new Set([
       ...listCoreFixtureKeys(),
       ...listWonderLabAchievementNavigationFixtureKeys(),
+      ...listWonderLabPassiveCardFixtureKeys(),
     ]),
   ].sort()
 }

--- a/utils/wonderlab/previewFixturesPassiveCards.ts
+++ b/utils/wonderlab/previewFixturesPassiveCards.ts
@@ -1,0 +1,143 @@
+// /utils/wonderlab/previewFixturesPassiveCards.ts
+import type { WonderLabPreviewFixture } from './previewFixtures'
+
+const fixtureDate = new Date('2026-01-01T00:00:00.000Z')
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'stage-message': {
+    title: 'Stage Message specimen',
+    description:
+      'Renders a synthetic speaker transcript entry without artwork resolution, stores, or streaming state.',
+    viewport: 'tablet',
+    minHeight: '10rem',
+    props: {
+      entry: {
+        id: 'wonderlab-message',
+        kind: 'speaker',
+        speakerId: 'fixture-guide',
+        speakerLabel: 'Fixture Guide',
+        speakerArtImageId: null,
+        speakerImagePath: null,
+        content:
+          'A useful preview should reveal a dependency instead of hiding it behind a mysterious blank panel.',
+        createdAt: fixtureDate.toISOString(),
+      },
+    },
+  },
+  'stage-preset': {
+    title: 'Stage Preset specimen',
+    description:
+      'Uses a selected synthetic stage preset with image-free role badges. Selection emits only to the preview host.',
+    viewport: 'mobile',
+    minHeight: '16rem',
+    props: {
+      preset: {
+        id: 'museum-tour',
+        label: 'Museum Tour',
+        tagline: 'A narrator and curator inspect one component at a time.',
+        icon: 'kind-icon:stage',
+        imagePath: null,
+        roles: [
+          {
+            key: 'narrator',
+            label: 'Narrator',
+            description: 'Guides the exhibit tour.',
+            badgeImagePath: null,
+          },
+          {
+            key: 'curator',
+            label: 'Curator',
+            description: 'Explains status and context.',
+            badgeImagePath: null,
+          },
+        ],
+      },
+      isSelected: true,
+    },
+  },
+  'honeydo-card': {
+    title: 'Honey-do Card specimen',
+    description:
+      'Uses a synthetic high-priority task. All controls emit local events; archive, delete, project navigation, and relative time are hidden.',
+    viewport: 'tablet',
+    minHeight: '10rem',
+    props: {
+      todo: {
+        id: -501,
+        createdAt: fixtureDate.toISOString(),
+        updatedAt: fixtureDate.toISOString(),
+        title: 'Label context-dependent exhibits',
+        description:
+          'Replace naked mounting failures with a useful explanation of required props, stores, or parent slots.',
+        status: 'OPEN',
+        priority: 'HIGH',
+        category: 'HONEYDO',
+        projectId: null,
+        userId: 0,
+      },
+      project: null,
+      showRelativeTime: false,
+      showCategoryBadge: true,
+      showArchiveAction: false,
+      showDeleteAction: false,
+    },
+  },
+  'feed-card': {
+    title: 'News Feed Card specimen',
+    description:
+      'Uses a synthetic image-free news item and renders as an article rather than an external link.',
+    viewport: 'mobile',
+    minHeight: '16rem',
+    props: {
+      item: {
+        id: 'wonderlab-news',
+        title: 'WonderLab fixture coverage expands again',
+        summary:
+          'The component museum now measures required-prop coverage and publishes the remaining backlog on every pull request.',
+        url: 'https://example.invalid/wonderlab-preview',
+        source: 'Kind Robots Development Desk',
+        publishedAt: fixtureDate.toISOString(),
+        image: null,
+        category: ['Development', 'WonderLab'],
+      },
+      showImage: false,
+      allowNavigation: false,
+    },
+  },
+  'loading-messages': {
+    title: 'Application Loading Overlay',
+    skipReason:
+      'This full-screen boot overlay owns fixed document coverage, timed message rotation, and the global load store reveal sequence. It should be verified through application startup rather than nested inside the museum.',
+  },
+  'tutorial-flyer': {
+    title: 'Channel Tutorial Flyer',
+    skipReason:
+      'This surface awaits channel-content initialization and coordinates tutorial-store visibility, persistence, keyboard handling, and document body overflow. It needs a dedicated store-aware wrapper before standalone museum rendering is appropriate.',
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabPassiveCardFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function listWonderLabPassiveCardFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## What changed

Adds the next measured WonderLab preview batch through the modular fixture catalog:

### Renderable synthetic fixtures

- `stage-message`
- `stage-preset`
- `honeydo-card`
- `feed-card`

### Explicit application-context placards

- `loading-messages`
- `tutorial-flyer`

## News-card safety

`feed-card` now accepts `allowNavigation`, defaulting to `true` so normal behavior is unchanged. WonderLab sets it to `false`, rendering the card as an `article` instead of an external anchor and hiding the external-link indicator.

## Why two placards instead of fake previews

- `loading-messages` is a fixed full-screen application boot overlay with timed rotation and global load-store reveal behavior.
- `tutorial-flyer` initializes channel content and coordinates tutorial persistence, modal state, keyboard handling, and document-body overflow.

Naked mounting either inside the museum would be misleading or disruptive. Their placards state the real integration context needed.

## Validation

- adds `npm run test:wonderlab-passive-card-fixtures`;
- makes the verifier a required Contract Tests step;
- verifies earlier fixture modules still resolve through the catalog;
- expected movement from the current 23 covered / 38 uncovered baseline: six additional covered items.

Part of #381.