### PR TITLE
WonderLab: add learning and control fixtures

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -106,6 +106,9 @@ jobs:
       - name: WonderLab passive card fixtures contract
         run: npm run test:wonderlab-passive-card-fixtures
 
+      - name: WonderLab learning and control fixtures contract
+        run: npx tsx utils/scripts/verifyWonderLabLearningControlFixtures.ts
+
       - name: WonderLab preview coverage audit
         run: npm run audit:wonderlab-previews 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -207,8 +207,13 @@ const props = withDefaults(
     lesson: AcademyStyle
     showClose?: boolean
     showRemixButton?: boolean
+    allowMarkViewed?: boolean
   }>(),
-  { showClose: true, showRemixButton: true },
+  {
+    showClose: true,
+    showRemixButton: true,
+    allowMarkViewed: true,
+  },
 )
 
 const emit = defineEmits<{
@@ -248,6 +253,8 @@ const reflectPrompts = computed(() => {
 })
 
 onMounted(() => {
-  academyStore.markLessonViewed(props.lesson.slug)
+  if (props.allowMarkViewed) {
+    academyStore.markLessonViewed(props.lesson.slug)
+  }
 })
 </script>

--- a/utils/scripts/verifyWonderLabLearningControlFixtures.ts
+++ b/utils/scripts/verifyWonderLabLearningControlFixtures.ts
@@ -1,0 +1,47 @@
+// /utils/scripts/verifyWonderLabLearningControlFixtures.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { getWonderLabPreviewFixture } from '@/utils/wonderlab/previewFixtureCatalog'
+
+const academy = getWonderLabPreviewFixture('academy-style-detail')
+assert.ok(academy?.props?.lesson)
+assert.equal(academy?.props?.showClose, false)
+assert.equal(academy?.props?.showRemixButton, false)
+assert.equal(academy?.props?.allowMarkViewed, false)
+
+const lesson = academy?.props?.lesson as Record<string, unknown>
+assert.ok(Array.isArray(lesson.recognitionCues))
+assert.ok(Array.isArray(lesson.artists))
+assert.deepEqual(lesson.exampleWorks, [])
+
+const range = getWonderLabPreviewFixture('butterfly-slider')
+assert.deepEqual(range?.props?.modelValue, { min: 24, max: 72 })
+assert.equal(range?.props?.min, 0)
+assert.equal(range?.props?.max, 100)
+assert.equal(range?.props?.originalMin, 10)
+assert.equal(range?.props?.originalMax, 90)
+
+const single = getWonderLabPreviewFixture('single-slider')
+assert.equal(single?.props?.modelValue, 8)
+assert.equal(single?.props?.min, 0)
+assert.equal(single?.props?.max, 20)
+
+for (const key of ['butterfly-toggle', 'choice-manager', 'fx-region'] as const) {
+  const fixture = getWonderLabPreviewFixture(key)
+  assert.ok(fixture?.skipReason, `${key} must explain its required app context.`)
+}
+
+const academySource = await readFile(
+  'components/academy/academy-style-detail.vue',
+  'utf8',
+)
+assert.match(academySource, /allowMarkViewed\?: boolean/)
+assert.match(academySource, /allowMarkViewed: true/)
+assert.match(academySource, /if \(props\.allowMarkViewed\)/)
+
+// Confirm every earlier fixture layer still resolves through the shared catalog.
+assert.ok(getWonderLabPreviewFixture('feed-card')?.props?.item)
+assert.ok(getWonderLabPreviewFixture('hero-showcase')?.props?.items)
+assert.ok(getWonderLabPreviewFixture('component-card')?.props?.component)
+
+console.log('WonderLab learning and control fixture verification passed.')

--- a/utils/wonderlab/previewFixtureCatalog.ts
+++ b/utils/wonderlab/previewFixtureCatalog.ts
@@ -11,6 +11,10 @@ import {
   getWonderLabPassiveCardFixture,
   listWonderLabPassiveCardFixtureKeys,
 } from './previewFixturesPassiveCards'
+import {
+  getWonderLabLearningControlFixture,
+  listWonderLabLearningControlFixtureKeys,
+} from './previewFixturesLearningControls'
 
 export type {
   WonderLabPreviewFixture,
@@ -24,7 +28,8 @@ export function getWonderLabPreviewFixture(
   return (
     getCoreFixture(componentName, sourcePath) ??
     getWonderLabAchievementNavigationFixture(componentName, sourcePath) ??
-    getWonderLabPassiveCardFixture(componentName, sourcePath)
+    getWonderLabPassiveCardFixture(componentName, sourcePath) ??
+    getWonderLabLearningControlFixture(componentName, sourcePath)
   )
 }
 
@@ -34,6 +39,7 @@ export function listWonderLabPreviewFixtureKeys(): string[] {
       ...listCoreFixtureKeys(),
       ...listWonderLabAchievementNavigationFixtureKeys(),
       ...listWonderLabPassiveCardFixtureKeys(),
+      ...listWonderLabLearningControlFixtureKeys(),
     ]),
   ].sort()
 }

--- a/utils/wonderlab/previewFixturesLearningControls.ts
+++ b/utils/wonderlab/previewFixturesLearningControls.ts
@@ -1,0 +1,123 @@
+// /utils/wonderlab/previewFixturesLearningControls.ts
+import type { WonderLabPreviewFixture } from './previewFixtures'
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'academy-style-detail': {
+    title: 'Academy Style Lesson specimen',
+    description:
+      'Uses a synthetic image-free lesson and disables close, remix, and viewed-progress mutation.',
+    viewport: 'tablet',
+    minHeight: '36rem',
+    props: {
+      lesson: {
+        slug: 'wonderlab-luminous-craft',
+        name: 'Luminous Craft',
+        era: 'Imagined Contemporary',
+        region: 'WonderLab',
+        keyIdeas:
+          'Clear silhouettes, deliberate negative space, readable visual hierarchy, and a visible relationship between form and purpose.',
+        recognitionCues: [
+          'Strong shapes that remain legible at card size',
+          'A restrained background that supports the subject',
+          'Small details reserved for meaningful emphasis',
+        ],
+        artists: [
+          {
+            name: 'Mira the Mapmaker',
+            years: 'Current',
+            note: 'Uses hierarchy and spacing to make complex systems approachable.',
+          },
+          {
+            name: 'Dotti Fixturewright',
+            years: 'Current',
+            note: 'Labels every dependency before inviting visitors inside.',
+          },
+        ],
+        exampleWorks: [],
+        remix: {
+          mode: 'prompt',
+          template:
+            'Rebuild the subject with crisp shapes, generous negative space, and one clearly emphasized interaction point.',
+        },
+        failureMode:
+          'Decorative detail competing with the main interaction or reducing readability at small sizes.',
+      },
+      showClose: false,
+      showRemixButton: false,
+      allowMarkViewed: false,
+    },
+  },
+  'butterfly-slider': {
+    title: 'Butterfly Range Slider specimen',
+    description:
+      'A local two-handle range control. Input changes emit only to the preview host.',
+    viewport: 'tablet',
+    minHeight: '12rem',
+    props: {
+      min: 0,
+      max: 100,
+      step: 1,
+      modelValue: { min: 24, max: 72 },
+      label: 'Flutter range',
+      sliderId: 'wonderlab-butterfly-range',
+      originalMin: 10,
+      originalMax: 90,
+    },
+  },
+  'single-slider': {
+    title: 'Single Slider specimen',
+    description:
+      'A local numeric control. Input changes emit only to the preview host.',
+    viewport: 'tablet',
+    minHeight: '10rem',
+    props: {
+      min: 0,
+      max: 20,
+      step: 1,
+      modelValue: 8,
+      label: 'Butterfly count',
+      sliderId: 'wonderlab-butterfly-count',
+    },
+  },
+  'butterfly-toggle': {
+    title: 'Butterfly Layout Toggle',
+    skipReason:
+      'This fixed full-viewport animation measures a real DOM target, runs an animation frame loop, and mutates global display layout state when clicked. It should be exercised from the application shell rather than nested inside a component preview.',
+  },
+  'choice-manager': {
+    title: 'Choice Manager',
+    skipReason:
+      'Choice Manager resolves and mutates a seeded Choice Store entry by label and model. A useful preview requires a dedicated store fixture with disposable options and selection state, not just a label prop.',
+  },
+  'fx-region': {
+    title: 'Screen FX Region',
+    skipReason:
+      'FX Region renders the active global animation-store surface for a named page region. Mounting it in WonderLab could duplicate live effects and pointer-blocking layers, so it must be tested within the Screen FX shell.',
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabLearningControlFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function listWonderLabLearningControlFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## What changed

Adds six measured WonderLab coverage entries through the modular fixture catalog.

### Safe renderable fixtures

- `academy-style-detail`
- `butterfly-slider`
- `single-slider`

### Explicit context placards

- `butterfly-toggle`
- `choice-manager`
- `fx-region`

## Academy preview safety

`academy-style-detail` now accepts `allowMarkViewed`, defaulting to `true` so existing callers retain current behavior. WonderLab passes `false`, preventing a preview from changing Academy progress. The synthetic lesson also disables close/remix controls and contains no external example artwork or links.

## Why the placards are appropriate

- `butterfly-toggle` is a fixed viewport animation that measures a DOM target, runs an animation loop, and mutates global layout state.
- `choice-manager` resolves and mutates seeded Choice Store data rather than rendering meaningfully from its label alone.
- `fx-region` mirrors the active global animation surface and may create duplicate pointer-blocking effects inside the museum.

## Validation

- adds a DB-free fixture verifier directly to Contract Tests;
- verifies the Academy mutation guard defaults on but is disabled in WonderLab;
- verifies numeric slider fixtures and context placards;
- confirms all earlier modular fixture layers still resolve;
- expected movement from 29 covered / 32 uncovered to 35 covered / 26 uncovered, subject to concurrent component additions.

Part of #381.