### PR TITLE
WonderLab: add Builder and Ruler Hooked fixtures

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -109,6 +109,9 @@ jobs:
       - name: WonderLab learning and control fixtures contract
         run: npx tsx utils/scripts/verifyWonderLabLearningControlFixtures.ts
 
+      - name: WonderLab Builder and Ruler Hooked fixtures contract
+        run: npx tsx utils/scripts/verifyWonderLabBuilderRulerFixtures.ts
+
       - name: WonderLab preview coverage audit
         run: npm run audit:wonderlab-previews 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -4,7 +4,7 @@
     type="button"
     class="group flex min-h-44 w-full flex-col overflow-hidden rounded-2xl border-2 bg-base-200 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg sm:min-h-52 md:min-h-56 xl:min-h-[8.5rem] xl:flex-row"
     :class="cardClass"
-    @click="store.selectCard(card.key)"
+    @click="selectCard"
   >
     <div
       class="relative flex min-h-36 w-full shrink-0 items-center justify-center overflow-hidden bg-base-300 sm:min-h-44 md:min-h-52 xl:min-h-full xl:w-2/5 xl:max-w-[10rem]"
@@ -95,7 +95,15 @@ import { computed } from 'vue'
 import { useBuilderStore } from '@/stores/builderStore'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
 
-const props = defineProps<{ card: BuilderCard }>()
+const props = withDefaults(
+  defineProps<{
+    card: BuilderCard
+    allowSelect?: boolean
+  }>(),
+  {
+    allowSelect: true,
+  },
+)
 
 const store = useBuilderStore()
 
@@ -107,4 +115,10 @@ const cardClass = computed(() => {
   if (isCompleted.value) return 'border-success/50 bg-success/5'
   return 'border-base-300 hover:border-primary/60'
 })
+
+function selectCard() {
+  if (props.allowSelect) {
+    store.selectCard(props.card.key)
+  }
+}
 </script>

--- a/components/ruler-hooked/ruler-hooked-stage.vue
+++ b/components/ruler-hooked/ruler-hooked-stage.vue
@@ -5,8 +5,10 @@
      Any matching /images/ruler-hooked/{region}-{state}[-{time}].webp is overlaid
      on top via the asset fallback ladder; missing art simply shows the band. -->
 <template>
-  <div class="relative w-full overflow-hidden rounded-xl border border-base-300 shadow-inner"
-       :aria-label="`Lakeside kingdom at ${scene?.time ?? 'day'}`">
+  <div
+    class="relative w-full overflow-hidden rounded-xl border border-base-300 shadow-inner"
+    :aria-label="`Lakeside kingdom at ${scene?.time ?? 'day'}`"
+  >
     <div class="flex h-72 flex-col sm:h-96">
       <div
         v-for="layer in layers"
@@ -21,12 +23,16 @@
           class="pointer-events-none absolute inset-0 h-full w-full object-cover"
           @error="onImgError(layer.region)"
         />
-        <span class="absolute bottom-1 left-2 text-[10px] font-medium uppercase tracking-wide text-white/70 drop-shadow">
+        <span
+          class="absolute bottom-1 left-2 text-[10px] font-medium uppercase tracking-wide text-white/70 drop-shadow"
+        >
           {{ layer.label }}
         </span>
       </div>
     </div>
-    <div class="pointer-events-none absolute right-2 top-2 rounded-full bg-black/40 px-2 py-0.5 text-xs text-white">
+    <div
+      class="pointer-events-none absolute right-2 top-2 rounded-full bg-black/40 px-2 py-0.5 text-xs text-white"
+    >
       {{ scene?.time ?? 'day' }}
     </div>
   </div>
@@ -34,12 +40,22 @@
 
 <script setup lang="ts">
 import { assetCandidates } from '~/utils/rulerHooked/compositor'
-import type { RegionKey, RegionsManifest, SceneState } from '~/types/ruler-hooked'
+import type {
+  RegionKey,
+  RegionsManifest,
+  SceneState,
+} from '~/types/ruler-hooked'
 
-const props = defineProps<{
-  scene: SceneState | null
-  regions: RegionsManifest
-}>()
+const props = withDefaults(
+  defineProps<{
+    scene: SceneState | null
+    regions: RegionsManifest
+    showImages?: boolean
+  }>(),
+  {
+    showImages: true,
+  },
+)
 
 // Per-region index into the asset fallback ladder (advances on <img> error).
 const errIndex = reactive<Record<string, number>>({})
@@ -73,7 +89,12 @@ const STATE_CLASS: Record<string, string> = {
   fishing: 'bg-gradient-to-b from-amber-200 to-amber-400',
 }
 
-interface Layer { region: RegionKey; label: string; classes: string; src: string | null }
+interface Layer {
+  region: RegionKey
+  label: string
+  classes: string
+  src: string | null
+}
 
 const layers = computed<Layer[]>(() => {
   const scene = props.scene
@@ -84,7 +105,9 @@ const layers = computed<Layer[]>(() => {
     .sort((a, b) => (regs[a]!.z ?? 0) - (regs[b]!.z ?? 0))
     .map((region) => {
       const state = scene.regionStates[region]
-      const cands = assetCandidates(region, state, scene.time)
+      const cands = props.showImages
+        ? assetCandidates(region, state, scene.time)
+        : []
       const idx = errIndex[region] ?? 0
       return {
         region,

--- a/utils/scripts/verifyWonderLabBuilderRulerFixtures.ts
+++ b/utils/scripts/verifyWonderLabBuilderRulerFixtures.ts
@@ -1,0 +1,55 @@
+// /utils/scripts/verifyWonderLabBuilderRulerFixtures.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { getWonderLabPreviewFixture } from '@/utils/wonderlab/previewFixtureCatalog'
+
+const builder = getWonderLabPreviewFixture('builder-card')
+assert.ok(builder?.props?.card)
+assert.equal(builder?.props?.allowSelect, false)
+const builderCard = builder?.props?.card as Record<string, unknown>
+assert.equal(builderCard.deckImage, null)
+assert.ok(Array.isArray(builderCard.steps) && builderCard.steps.length === 3)
+
+const eventCard = getWonderLabPreviewFixture('ruler-hooked-card')
+const card = eventCard?.props?.card as Record<string, unknown>
+assert.equal(card.kind, 'arc-step')
+assert.ok(Array.isArray(card.choices) && card.choices.length >= 2)
+
+const health = getWonderLabPreviewFixture('ruler-hooked-health')
+assert.deepEqual(health?.props?.health, {
+  nature: 72,
+  prosperity: 58,
+  treasury: 41,
+  joy: 83,
+  order: 66,
+})
+
+const stage = getWonderLabPreviewFixture('ruler-hooked-stage')
+assert.equal(stage?.props?.showImages, false)
+assert.ok(stage?.props?.scene)
+assert.ok(stage?.props?.regions)
+
+for (const key of ['dream-inspire-button', 'project-gallery-strip'] as const) {
+  const fixture = getWonderLabPreviewFixture(key)
+  assert.ok(fixture?.skipReason, `${key} must explain its operational context.`)
+}
+
+const builderSource = await readFile('components/builder/builder-card.vue', 'utf8')
+assert.match(builderSource, /allowSelect\?: boolean/)
+assert.match(builderSource, /allowSelect: true/)
+assert.match(builderSource, /if \(props\.allowSelect\)/)
+
+const stageSource = await readFile(
+  'components/ruler-hooked/ruler-hooked-stage.vue',
+  'utf8',
+)
+assert.match(stageSource, /showImages\?: boolean/)
+assert.match(stageSource, /showImages: true/)
+assert.match(stageSource, /props\.showImages/)
+
+// Confirm earlier fixture modules remain available through the catalog.
+assert.ok(getWonderLabPreviewFixture('academy-style-detail')?.props?.lesson)
+assert.ok(getWonderLabPreviewFixture('feed-card')?.props?.item)
+assert.ok(getWonderLabPreviewFixture('component-card')?.props?.component)
+
+console.log('WonderLab Builder and Ruler Hooked fixture verification passed.')

--- a/utils/wonderlab/previewFixtureCatalog.ts
+++ b/utils/wonderlab/previewFixtureCatalog.ts
@@ -15,6 +15,10 @@ import {
   getWonderLabLearningControlFixture,
   listWonderLabLearningControlFixtureKeys,
 } from './previewFixturesLearningControls'
+import {
+  getWonderLabBuilderRulerFixture,
+  listWonderLabBuilderRulerFixtureKeys,
+} from './previewFixturesBuilderRuler'
 
 export type {
   WonderLabPreviewFixture,
@@ -29,7 +33,8 @@ export function getWonderLabPreviewFixture(
     getCoreFixture(componentName, sourcePath) ??
     getWonderLabAchievementNavigationFixture(componentName, sourcePath) ??
     getWonderLabPassiveCardFixture(componentName, sourcePath) ??
-    getWonderLabLearningControlFixture(componentName, sourcePath)
+    getWonderLabLearningControlFixture(componentName, sourcePath) ??
+    getWonderLabBuilderRulerFixture(componentName, sourcePath)
   )
 }
 
@@ -40,6 +45,7 @@ export function listWonderLabPreviewFixtureKeys(): string[] {
       ...listWonderLabAchievementNavigationFixtureKeys(),
       ...listWonderLabPassiveCardFixtureKeys(),
       ...listWonderLabLearningControlFixtureKeys(),
+      ...listWonderLabBuilderRulerFixtureKeys(),
     ]),
   ].sort()
 }

--- a/utils/wonderlab/previewFixturesBuilderRuler.ts
+++ b/utils/wonderlab/previewFixturesBuilderRuler.ts
@@ -1,0 +1,144 @@
+// /utils/wonderlab/previewFixturesBuilderRuler.ts
+import type { WonderLabPreviewFixture } from './previewFixtures'
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'builder-card': {
+    title: 'Builder Card specimen',
+    description:
+      'Uses a synthetic builder deck card with store selection disabled and no image asset.',
+    viewport: 'tablet',
+    minHeight: '18rem',
+    props: {
+      card: {
+        key: 'wonderlab-fixture',
+        label: 'Fixture Lab',
+        title: 'Design a Safe Component Preview',
+        tagline: 'Make context visible before making it interactive.',
+        narrative:
+          'Identify required props, provide synthetic values, and disable any action that could touch real application state.',
+        icon: 'kind-icon:cards',
+        deckImage: null,
+        steps: [
+          { key: 'inspect', label: 'Inspect dependencies' },
+          { key: 'fixture', label: 'Build synthetic props' },
+          { key: 'verify', label: 'Add a safety contract' },
+        ],
+      },
+      allowSelect: false,
+    },
+  },
+  'ruler-hooked-card': {
+    title: 'Ruler Hooked Event Card specimen',
+    description:
+      'Uses a synthetic kingdom event. Choice buttons emit only to the preview host and do not apply game effects.',
+    viewport: 'tablet',
+    minHeight: '18rem',
+    props: {
+      card: {
+        id: 'museum-fishing-decree',
+        deck: 'wonderlab',
+        kind: 'arc-step',
+        characters: ['the-ruler', 'lake-warden'],
+        title: 'The Lake Demands Better Labels',
+        body:
+          'A silver fish surfaces beside the royal dock carrying a tiny placard: “Context required.”',
+        choices: [
+          {
+            id: 'label-it',
+            text: 'Label the dependency before continuing',
+            result: 'The court understands what the exhibit needs.',
+          },
+          {
+            id: 'defer-it',
+            text: 'Return it to the backlog with a clear reason',
+            requeue: true,
+          },
+        ],
+      },
+    },
+  },
+  'ruler-hooked-health': {
+    title: 'Ruler Hooked Kingdom Health specimen',
+    description:
+      'Renders a static synthetic kingdom-health snapshot with no store or game-engine dependency.',
+    viewport: 'tablet',
+    minHeight: '12rem',
+    props: {
+      health: {
+        nature: 72,
+        prosperity: 58,
+        treasury: 41,
+        joy: 83,
+        order: 66,
+      },
+    },
+  },
+  'ruler-hooked-stage': {
+    title: 'Ruler Hooked Stage specimen',
+    description:
+      'Renders the compositor’s color-band fallback with image asset probing disabled.',
+    viewport: 'desktop',
+    minHeight: '28rem',
+    props: {
+      regions: {
+        regions: {
+          sky: { z: 0, states: ['open'], times: ['day'] },
+          far_shore: { z: 10, states: ['pristine', 'farmed'] },
+          treeline: { z: 20, states: ['wild', 'tended'] },
+          village_edge: { z: 30, states: ['hamlet', 'township'] },
+          castle_grounds: { z: 40, states: ['humble', 'flourishing'] },
+          lake: { z: 50, states: ['clear', 'fishing'] },
+        },
+      },
+      scene: {
+        regionStates: {
+          sky: 'open',
+          far_shore: 'pristine',
+          treeline: 'wild',
+          village_edge: 'hamlet',
+          castle_grounds: 'flourishing',
+          lake: 'clear',
+        },
+        time: 'day',
+        fx: [],
+      },
+      showImages: false,
+    },
+  },
+  'dream-inspire-button': {
+    title: 'Dream Inspiration Generator',
+    skipReason:
+      'This control loads pending prompt records on mount, resolves the user’s preferred art server, and can POST generation jobs. It belongs in an authenticated Dream workflow with disposable prompt fixtures, not a passive museum preview.',
+  },
+  'project-gallery-strip': {
+    title: 'Conductor Project Gallery Strip',
+    skipReason:
+      'This project-scoped strip fetches all Art Collections with images and resolves one by live collection label. A useful preview needs an explicit image-array override or a seeded collection-store wrapper before it can remain network-free.',
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabBuilderRulerFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function listWonderLabBuilderRulerFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## What changed

Adds six more measured WonderLab coverage entries.

### Safe renderable fixtures

- `builder-card`
- `ruler-hooked-card`
- `ruler-hooked-health`
- `ruler-hooked-stage`

### Explicit operational-context placards

- `dream-inspire-button`
- `project-gallery-strip`

## Preview safety controls

- `builder-card` adds `allowSelect`, defaulting to `true`; WonderLab passes `false` so clicking the specimen cannot change the active Builder card.
- `ruler-hooked-stage` adds `showImages`, defaulting to `true`; WonderLab passes `false` so the stage demonstrates its color-band compositor without probing the asset fallback ladder.

Normal application behavior is unchanged by default.

## Why the placards are appropriate

- Dream Inspire loads pending prompts, resolves art servers, and can enqueue generation POSTs.
- Project Gallery Strip fetches Art Collections with images and resolves live store data by collection label.

Both need dedicated disposable data wrappers before a network-free preview would be truthful.

## Validation

- adds a DB-free fixture/guard verifier directly to Contract Tests;
- verifies synthetic Builder, event-card, health, and stage inputs;
- verifies the new guards default on but are disabled in WonderLab;
- confirms earlier modular fixture layers still resolve;
- expected audit movement from 35 covered / 26 uncovered to 41 covered / 20 uncovered, subject to concurrent component additions.

Part of #381.