### PR TITLE
WonderLab: add interaction and display fixtures

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -112,6 +112,9 @@ jobs:
       - name: WonderLab Builder and Ruler Hooked fixtures contract
         run: npx tsx utils/scripts/verifyWonderLabBuilderRulerFixtures.ts
 
+      - name: WonderLab interaction and display fixtures contract
+        run: npx tsx utils/scripts/verifyWonderLabInteractionDisplayFixtures.ts
+
       - name: WonderLab preview coverage audit
         run: npm run audit:wonderlab-previews 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/icons/smart-nav.vue
+++ b/components/icons/smart-nav.vue
@@ -5,7 +5,7 @@
       v-for="comp in componentList"
       :key="comp"
       class="px-4 py-2 bg-secondary text-black font-bold rounded-2xl border border-black hover:bg-accent transition"
-      @click="() => displayStore.setMainComponent(comp)"
+      @click="selectComponent(comp)"
     >
       {{ formatLabel(comp) }}
     </button>
@@ -15,10 +15,24 @@
 <script setup lang="ts">
 import { useDisplayStore } from '@/stores/displayStore'
 
-defineProps<{ componentList: string[] }>()
+const props = withDefaults(
+  defineProps<{
+    componentList: string[]
+    allowSelect?: boolean
+  }>(),
+  {
+    allowSelect: true,
+  },
+)
 
 const displayStore = useDisplayStore()
 
 const formatLabel = (comp: string) =>
   comp.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
+
+function selectComponent(componentName: string) {
+  if (props.allowSelect) {
+    displayStore.setMainComponent(componentName)
+  }
+}
 </script>

--- a/utils/scripts/verifyWonderLabInteractionDisplayFixtures.ts
+++ b/utils/scripts/verifyWonderLabInteractionDisplayFixtures.ts
@@ -1,0 +1,54 @@
+// /utils/scripts/verifyWonderLabInteractionDisplayFixtures.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { getWonderLabPreviewFixture } from '@/utils/wonderlab/previewFixtureCatalog'
+
+const smartNav = getWonderLabPreviewFixture('smart-nav')
+assert.ok(Array.isArray(smartNav?.props?.componentList))
+assert.equal(smartNav?.props?.allowSelect, false)
+
+const stageSlot = getWonderLabPreviewFixture('stage-slot')
+assert.ok(stageSlot?.props?.slot)
+assert.deepEqual(stageSlot?.props?.characters, [])
+assert.deepEqual(stageSlot?.props?.bots, [])
+assert.equal(stageSlot?.props?.removable, false)
+const slot = stageSlot?.props?.slot as Record<string, unknown>
+assert.equal(slot.participantType, 'temporary-bot')
+assert.equal(slot.participantId, null)
+assert.ok(slot.temporary)
+
+const butterfly = getWonderLabPreviewFixture('butterfly-component')
+assert.ok(butterfly?.props?.butterfly)
+const butterflyValue = butterfly?.props?.butterfly as Record<string, unknown>
+assert.equal(butterflyValue.artImageId, undefined)
+assert.ok(butterflyValue.wingTopColor)
+assert.ok(butterflyValue.wingBottomColor)
+
+const gallery = getWonderLabPreviewFixture('butterfly-gallery')
+const slots = gallery?.props?.slots
+assert.ok(Array.isArray(slots) && slots.length >= 6)
+assert.ok(
+  (slots as Array<Record<string, unknown>>).some((entry) => entry.butterfly),
+)
+assert.ok(
+  (slots as Array<Record<string, unknown>>).some(
+    (entry) => entry.butterfly === null,
+  ),
+)
+
+for (const key of ['facet-picker', 'reaction-card', 'butterfly-modal'] as const) {
+  const fixture = getWonderLabPreviewFixture(key)
+  assert.ok(fixture?.skipReason, `${key} must explain its write/global context.`)
+}
+
+const smartNavSource = await readFile('components/icons/smart-nav.vue', 'utf8')
+assert.match(smartNavSource, /allowSelect\?: boolean/)
+assert.match(smartNavSource, /allowSelect: true/)
+assert.match(smartNavSource, /if \(props\.allowSelect\)/)
+
+// Confirm previous fixture modules remain visible through the combined catalog.
+assert.ok(getWonderLabPreviewFixture('builder-card')?.props?.card)
+assert.ok(getWonderLabPreviewFixture('academy-style-detail')?.props?.lesson)
+assert.ok(getWonderLabPreviewFixture('component-card')?.props?.component)
+
+console.log('WonderLab interaction and display fixture verification passed.')

--- a/utils/wonderlab/previewFixtureCatalog.ts
+++ b/utils/wonderlab/previewFixtureCatalog.ts
@@ -19,6 +19,10 @@ import {
   getWonderLabBuilderRulerFixture,
   listWonderLabBuilderRulerFixtureKeys,
 } from './previewFixturesBuilderRuler'
+import {
+  getWonderLabInteractionDisplayFixture,
+  listWonderLabInteractionDisplayFixtureKeys,
+} from './previewFixturesInteractionDisplays'
 
 export type {
   WonderLabPreviewFixture,
@@ -34,7 +38,8 @@ export function getWonderLabPreviewFixture(
     getWonderLabAchievementNavigationFixture(componentName, sourcePath) ??
     getWonderLabPassiveCardFixture(componentName, sourcePath) ??
     getWonderLabLearningControlFixture(componentName, sourcePath) ??
-    getWonderLabBuilderRulerFixture(componentName, sourcePath)
+    getWonderLabBuilderRulerFixture(componentName, sourcePath) ??
+    getWonderLabInteractionDisplayFixture(componentName, sourcePath)
   )
 }
 
@@ -46,6 +51,7 @@ export function listWonderLabPreviewFixtureKeys(): string[] {
       ...listWonderLabPassiveCardFixtureKeys(),
       ...listWonderLabLearningControlFixtureKeys(),
       ...listWonderLabBuilderRulerFixtureKeys(),
+      ...listWonderLabInteractionDisplayFixtureKeys(),
     ]),
   ].sort()
 }

--- a/utils/wonderlab/previewFixturesInteractionDisplays.ts
+++ b/utils/wonderlab/previewFixturesInteractionDisplays.ts
@@ -1,0 +1,150 @@
+// /utils/wonderlab/previewFixturesInteractionDisplays.ts
+import type { WonderLabPreviewFixture } from './previewFixtures'
+
+const fixtureButterfly = {
+  id: 'Prismatic Librarian',
+  name: 'Prismatic Librarian',
+  x: 45,
+  y: 35,
+  z: 1.1,
+  zIndex: 4,
+  baseZIndex: 4,
+  rotation: 12,
+  heading: 0,
+  wingTopColor: 'hsl(280, 75%, 62%)',
+  wingBottomColor: 'hsl(190, 80%, 55%)',
+  speed: 1.2,
+  wingSpeed: 0.8,
+  rarity: 17,
+  status: 'float',
+  scale: 1,
+  scaleMod: 1,
+  message: 'Every component deserves a readable field guide.',
+  noiseOffsetX: 0,
+  noiseOffsetY: 0,
+  designer: 'WonderLab',
+  goal: { x: 60, y: 40 },
+}
+
+const fixtures: Record<string, WonderLabPreviewFixture> = {
+  'smart-nav': {
+    title: 'Smart Navigation specimen',
+    description:
+      'Renders a static navigation choice set with global display-store selection disabled.',
+    viewport: 'tablet',
+    minHeight: '10rem',
+    props: {
+      componentList: [
+        'component-gallery',
+        'preview-fixtures',
+        'review-feed',
+        'reconciliation',
+      ],
+      allowSelect: false,
+    },
+  },
+  'stage-slot': {
+    title: 'Filled Stage Slot specimen',
+    description:
+      'Uses a temporary synthetic performer so the slot renders without Character, Bot, Art, or image-resolution dependencies.',
+    viewport: 'mobile',
+    minHeight: '10rem',
+    props: {
+      slot: {
+        slotId: 'wonderlab-curator',
+        roleKey: 'curator',
+        participantType: 'temporary-bot',
+        participantId: null,
+        temporary: {
+          name: 'Fixture Curator',
+          species: 'Helpful construct',
+          imagePath: null,
+          artImageId: null,
+          personality: 'Patient, precise, and unwilling to hide missing context.',
+        },
+      },
+      characters: [],
+      bots: [],
+      performers: [],
+      removable: false,
+    },
+  },
+  'butterfly-component': {
+    title: 'Butterfly specimen',
+    description:
+      'Renders one synthetic butterfly. It reads only the store’s display-name preference and does not mutate swarm state.',
+    viewport: 'tablet',
+    minHeight: '14rem',
+    props: {
+      butterfly: fixtureButterfly,
+    },
+  },
+  'butterfly-gallery': {
+    title: 'Butterfly Field Guide specimen',
+    description:
+      'Uses a short synthetic roster containing caught and uncaught slots. Inspection emits only to the preview host.',
+    viewport: 'tablet',
+    minHeight: '14rem',
+    props: {
+      slots: [
+        { rarityNumber: 15, butterfly: null },
+        { rarityNumber: 16, butterfly: null },
+        { rarityNumber: 17, butterfly: fixtureButterfly },
+        {
+          rarityNumber: 18,
+          butterfly: {
+            ...fixtureButterfly,
+            id: 'Amber Archivist',
+            name: 'Amber Archivist',
+            rarity: 18,
+            wingTopColor: 'hsl(38, 88%, 58%)',
+            wingBottomColor: 'hsl(12, 78%, 52%)',
+          },
+        },
+        { rarityNumber: 19, butterfly: null },
+        { rarityNumber: 20, butterfly: null },
+      ],
+    },
+  },
+  'facet-picker': {
+    title: 'Facet Picker',
+    skipReason:
+      'Facet Picker fetches the global Facet catalog on mount, may fetch persisted owner assignments, and can create or attach database records. A truthful preview needs a disposable Facet Store wrapper or explicit facet-data override.',
+  },
+  'reaction-card': {
+    title: 'Reaction Editor',
+    skipReason:
+      'Reaction Card is an authenticated write surface that can create Reaction rows and copy share text. WonderLab already hosts the real editor beside each selected exhibit, so recursively mounting another writer would be misleading.',
+  },
+  'butterfly-modal': {
+    title: 'Butterfly Capture Modal',
+    skipReason:
+      'Butterfly Modal teleports two full-screen overlays to document.body and also observes the global discovery butterfly. It should be tested through the capture/discovery flow or a dedicated teleport fixture, not nested in the museum viewport.',
+  },
+}
+
+function normalizeFixtureKey(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.vue$/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function getWonderLabInteractionDisplayFixture(
+  componentName: string,
+  sourcePath = '',
+): WonderLabPreviewFixture | null {
+  const sourceKey = normalizeFixtureKey(sourcePath)
+  const componentKey = normalizeFixtureKey(componentName)
+
+  return fixtures[sourceKey] ?? fixtures[componentKey] ?? null
+}
+
+export function listWonderLabInteractionDisplayFixtureKeys(): string[] {
+  return Object.keys(fixtures).sort()
+}


### PR DESCRIPTION
## What changed

Adds seven measured WonderLab coverage entries.

### Safe renderable fixtures

- `smart-nav`
- `stage-slot`
- `butterfly-component`
- `butterfly-gallery`

### Explicit context placards

- `facet-picker`
- `reaction-card`
- `butterfly-modal`

## Smart Nav safety

`smart-nav` now accepts `allowSelect`, defaulting to `true` so existing callers retain current behavior. WonderLab passes `false`, so clicking the specimen cannot change the global main component.

## Fixture design

- Stage Slot uses a filled temporary participant with empty Character/Bot arrays and no image identifiers.
- Butterfly Component and Gallery use deterministic synthetic butterfly data with no ArtImage relation.
- Facet Picker is kept out of passive previews because it fetches and mutates persisted Facet assignments.
- Reaction Card is already mounted as the real authenticated editor beside selected exhibits; recursively mounting another writer would be misleading.
- Butterfly Modal teleports full-screen overlays to `document.body` and observes global discovery state.

## Validation

- adds a DB-free verifier directly to Contract Tests;
- verifies Smart Nav’s guard defaults on but is disabled in WonderLab;
- verifies synthetic Stage and Butterfly inputs;
- verifies all three context placards;
- confirms earlier modular fixture layers remain available;
- expected audit movement from 41 covered / 20 uncovered to 48 covered / 13 uncovered, subject to concurrent component additions.

Part of #381.