### PR TITLE
WonderLab: resolve previews from canonical source manifest

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -118,6 +118,9 @@ jobs:
       - name: WonderLab final coverage fixtures contract
         run: npx tsx utils/scripts/verifyWonderLabCoverageClosureFixtures.ts
 
+      - name: WonderLab component manifest source contract
+        run: npx tsx utils/scripts/verifyWonderLabComponentManifest.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/wonderlab/wonderlab-preview-host.vue
+++ b/components/wonderlab/wonderlab-preview-host.vue
@@ -12,6 +12,46 @@
         <p class="mt-1 break-all font-mono text-xs text-base-content/50">
           {{ resolvedPath || expectedPath }}
         </p>
+
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <span
+            v-if="manifestEntry"
+            class="badge badge-success badge-outline badge-sm"
+          >
+            manifest matched
+          </span>
+          <span
+            v-else-if="manifestLoaded"
+            class="badge badge-warning badge-outline badge-sm"
+          >
+            manifest unmatched
+          </span>
+          <span
+            v-if="manifestEntry"
+            class="badge badge-ghost badge-sm font-mono"
+            :title="manifestEntry.sourceHash"
+          >
+            sha {{ manifestEntry.sourceHash.slice(0, 12) }}
+          </span>
+          <a
+            v-if="sourceUrl"
+            :href="sourceUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn btn-ghost btn-xs rounded-xl"
+          >
+            <Icon name="kind-icon:external-link" class="size-3.5" />
+            Source
+          </a>
+        </div>
+
+        <p
+          v-if="manifestError"
+          class="mt-2 text-xs leading-relaxed text-warning"
+        >
+          {{ manifestError }} Preview fallback resolution is still available.
+        </p>
+
         <p
           v-if="fixture?.description"
           class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65"
@@ -128,6 +168,7 @@ import {
   computed,
   defineAsyncComponent,
   onErrorCaptured,
+  onMounted,
   ref,
   watch,
 } from 'vue'
@@ -135,6 +176,12 @@ import {
   getWonderLabPreviewFixture,
   type WonderLabPreviewViewport,
 } from '@/utils/wonderlab/previewFixtureCatalog'
+import {
+  loadWonderLabComponentManifest,
+  resolveWonderLabManifestEntry,
+  wonderLabSourceUrl,
+  type WonderLabComponentManifest,
+} from '@/utils/wonderlab/componentManifest'
 
 const props = withDefaults(
   defineProps<{
@@ -158,20 +205,44 @@ const allModules = import.meta.glob('@/components/**/*.vue')
 const dynamicComponent = ref<ReturnType<typeof defineAsyncComponent> | null>(
   null,
 )
+const manifest = ref<WonderLabComponentManifest | null>(null)
+const manifestError = ref('')
 const resolvedPath = ref('')
 const previewNotFound = ref(false)
 const previewError = ref('')
 const renderKey = ref(0)
 const viewport = ref<WonderLabPreviewViewport>('desktop')
 
+const manifestEntry = computed(() =>
+  resolveWonderLabManifestEntry(
+    manifest.value?.entries || [],
+    props.componentName,
+    props.folderName,
+    props.sourcePath,
+  ),
+)
+
+const manifestLoaded = computed(() => Boolean(manifest.value))
+
+const fixtureSourcePath = computed(
+  () => props.sourcePath || manifestEntry.value?.sourcePath || '',
+)
+
 const fixture = computed(() =>
-  getWonderLabPreviewFixture(props.componentName, props.sourcePath),
+  getWonderLabPreviewFixture(props.componentName, fixtureSourcePath.value),
 )
 
 const expectedPath = computed(() => {
+  const manifestPath = manifestEntry.value?.sourcePath
+  if (manifestPath) return normalizedSourcePath(manifestPath)
+
   const name = props.componentName.replace(/\.vue$/i, '')
   return `/components/${props.folderName}/${name}.vue`
 })
+
+const sourceUrl = computed(() =>
+  manifestEntry.value ? wonderLabSourceUrl(manifestEntry.value) : '',
+)
 
 const viewportClass = computed(() => {
   switch (viewport.value) {
@@ -198,7 +269,7 @@ function normalizedSourcePath(value: string): string {
 
 function buildCandidates(): string[] {
   const name = props.componentName.replace(/\.vue$/i, '')
-  const explicit = normalizedSourcePath(props.sourcePath)
+  const explicit = normalizedSourcePath(fixtureSourcePath.value)
 
   return [
     explicit,
@@ -243,11 +314,31 @@ function resetPreview(): void {
   resolveComponent()
 }
 
+async function loadManifest(): Promise<void> {
+  manifestError.value = ''
+
+  try {
+    manifest.value = await loadWonderLabComponentManifest(() =>
+      $fetch('/wonderlab-components.json'),
+    )
+    resolveComponent()
+  } catch (error) {
+    manifestError.value =
+      error instanceof Error
+        ? error.message
+        : 'Failed to load the component manifest.'
+  }
+}
+
 watch(
   () => [props.componentName, props.folderName, props.sourcePath],
   resolveComponent,
   { immediate: true },
 )
+
+onMounted(() => {
+  void loadManifest()
+})
 
 onErrorCaptured((error) => {
   const message = error instanceof Error ? error.message : String(error)

--- a/components/wonderlab/wonderlab-preview-host.vue
+++ b/components/wonderlab/wonderlab-preview-host.vue
@@ -314,13 +314,23 @@ function resetPreview(): void {
   resolveComponent()
 }
 
+async function fetchManifestAsset(): Promise<unknown> {
+  const response = await fetch('/wonderlab-components.json', {
+    headers: { accept: 'application/json' },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Component manifest request failed (${response.status}).`)
+  }
+
+  return response.json() as Promise<unknown>
+}
+
 async function loadManifest(): Promise<void> {
   manifestError.value = ''
 
   try {
-    manifest.value = await loadWonderLabComponentManifest(() =>
-      $fetch('/wonderlab-components.json'),
-    )
+    manifest.value = await loadWonderLabComponentManifest(fetchManifestAsset)
     resolveComponent()
   } catch (error) {
     manifestError.value =

--- a/utils/scripts/verifyWonderLabComponentManifest.ts
+++ b/utils/scripts/verifyWonderLabComponentManifest.ts
@@ -1,0 +1,115 @@
+// /utils/scripts/verifyWonderLabComponentManifest.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  loadWonderLabComponentManifest,
+  resetWonderLabManifestCacheForTests,
+  resolveWonderLabManifestEntry,
+  wonderLabSourceUrl,
+  type WonderLabComponentManifest,
+} from '@/utils/wonderlab/componentManifest'
+
+const manifest: WonderLabComponentManifest = {
+  version: 1,
+  generatedAt: '2026-01-01T00:00:00.000Z',
+  componentRoot: 'components',
+  count: 3,
+  entries: [
+    {
+      sourceKey: 'components/content/cards/demo-card.vue',
+      sourcePath: 'components/content/cards/demo-card.vue',
+      sourceHash: 'a'.repeat(64),
+      componentName: 'demo-card',
+      slug: 'content-cards-demo-card',
+      folderName: 'content/cards',
+    },
+    {
+      sourceKey: 'components/admin/demo-card.vue',
+      sourcePath: 'components/admin/demo-card.vue',
+      sourceHash: 'b'.repeat(64),
+      componentName: 'demo-card',
+      slug: 'admin-demo-card',
+      folderName: 'admin',
+    },
+    {
+      sourceKey: 'components/wonderlab/unique-panel.vue',
+      sourcePath: 'components/wonderlab/unique-panel.vue',
+      sourceHash: 'c'.repeat(64),
+      componentName: 'unique-panel',
+      slug: 'wonderlab-unique-panel',
+      folderName: 'wonderlab',
+    },
+  ],
+}
+
+assert.equal(
+  resolveWonderLabManifestEntry(
+    manifest.entries,
+    'demo-card',
+    'content/cards',
+  )?.sourcePath,
+  'components/content/cards/demo-card.vue',
+)
+
+assert.equal(
+  resolveWonderLabManifestEntry(manifest.entries, 'demo-card.vue', 'cards')
+    ?.sourcePath,
+  'components/content/cards/demo-card.vue',
+)
+
+assert.equal(
+  resolveWonderLabManifestEntry(
+    manifest.entries,
+    'wrong-name',
+    '',
+    '/components/admin/demo-card.vue',
+  )?.sourcePath,
+  'components/admin/demo-card.vue',
+)
+
+assert.equal(
+  resolveWonderLabManifestEntry(manifest.entries, 'unique-panel')?.sourcePath,
+  'components/wonderlab/unique-panel.vue',
+)
+
+assert.equal(resolveWonderLabManifestEntry(manifest.entries, 'missing'), null)
+assert.equal(resolveWonderLabManifestEntry(manifest.entries, 'demo-card'), null)
+
+assert.equal(
+  wonderLabSourceUrl(manifest.entries[0]!),
+  'https://github.com/silasfelinus/kind_robots/blob/main/components/content/cards/demo-card.vue',
+)
+
+resetWonderLabManifestCacheForTests()
+let fetchCount = 0
+const first = loadWonderLabComponentManifest(async () => {
+  fetchCount += 1
+  return manifest
+})
+const second = loadWonderLabComponentManifest(async () => {
+  fetchCount += 1
+  return manifest
+})
+assert.equal(first, second)
+assert.equal((await first).count, 3)
+assert.equal(fetchCount, 1)
+
+resetWonderLabManifestCacheForTests()
+await assert.rejects(
+  loadWonderLabComponentManifest(async () => ({ version: 2, entries: [] })),
+  /invalid shape/i,
+)
+resetWonderLabManifestCacheForTests()
+
+const hostSource = await readFile(
+  'components/wonderlab/wonderlab-preview-host.vue',
+  'utf8',
+)
+assert.match(hostSource, /wonderlab-components\.json/)
+assert.match(hostSource, /manifest matched/)
+assert.match(hostSource, /manifest unmatched/)
+assert.match(hostSource, /sourceHash\.slice\(0, 12\)/)
+assert.match(hostSource, /wonderLabSourceUrl/)
+assert.match(hostSource, /fixtureSourcePath/)
+
+console.log('WonderLab component manifest verification passed.')

--- a/utils/wonderlab/componentManifest.ts
+++ b/utils/wonderlab/componentManifest.ts
@@ -1,0 +1,116 @@
+// /utils/wonderlab/componentManifest.ts
+export type WonderLabManifestEntry = {
+  sourceKey: string
+  sourcePath: string
+  sourceHash: string
+  componentName: string
+  slug: string
+  folderName: string
+}
+
+export type WonderLabComponentManifest = {
+  version: number
+  generatedAt: string
+  componentRoot: string
+  count: number
+  entries: WonderLabManifestEntry[]
+}
+
+let manifestPromise: Promise<WonderLabComponentManifest> | null = null
+
+function normalizePath(value: string): string {
+  return value.trim().replace(/\\/g, '/').replace(/^\/+/, '')
+}
+
+function normalizeComponentName(value: string): string {
+  return value.trim().replace(/\.vue$/i, '').toLowerCase()
+}
+
+function isManifest(value: unknown): value is WonderLabComponentManifest {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as Partial<WonderLabComponentManifest>
+  return (
+    candidate.version === 1 &&
+    Array.isArray(candidate.entries) &&
+    candidate.entries.every(
+      (entry) =>
+        entry &&
+        typeof entry.sourcePath === 'string' &&
+        typeof entry.sourceHash === 'string' &&
+        typeof entry.componentName === 'string' &&
+        typeof entry.folderName === 'string',
+    )
+  )
+}
+
+export function loadWonderLabComponentManifest(
+  fetcher: () => Promise<unknown>,
+): Promise<WonderLabComponentManifest> {
+  manifestPromise ??= fetcher().then((payload) => {
+    if (!isManifest(payload)) {
+      throw new Error('WonderLab component manifest has an invalid shape.')
+    }
+
+    return payload
+  })
+
+  return manifestPromise
+}
+
+export function resetWonderLabManifestCacheForTests(): void {
+  manifestPromise = null
+}
+
+export function resolveWonderLabManifestEntry(
+  entries: WonderLabManifestEntry[],
+  componentName: string,
+  folderName = '',
+  sourcePath = '',
+): WonderLabManifestEntry | null {
+  const normalizedSourcePath = normalizePath(sourcePath).toLowerCase()
+  if (normalizedSourcePath) {
+    const exactPath = entries.find(
+      (entry) => normalizePath(entry.sourcePath).toLowerCase() === normalizedSourcePath,
+    )
+    if (exactPath) return exactPath
+  }
+
+  const normalizedName = normalizeComponentName(componentName)
+  const candidates = entries.filter(
+    (entry) => normalizeComponentName(entry.componentName) === normalizedName,
+  )
+
+  if (!candidates.length) return null
+  if (candidates.length === 1) return candidates[0] ?? null
+
+  const normalizedFolder = normalizePath(folderName).toLowerCase()
+  if (!normalizedFolder) return null
+
+  return (
+    candidates.find(
+      (entry) => normalizePath(entry.folderName).toLowerCase() === normalizedFolder,
+    ) ??
+    candidates.find((entry) => {
+      const entryFolder = normalizePath(entry.folderName).toLowerCase()
+      return (
+        entryFolder.endsWith(`/${normalizedFolder}`) ||
+        normalizedFolder.endsWith(`/${entryFolder}`)
+      )
+    }) ??
+    null
+  )
+}
+
+export function wonderLabSourceUrl(
+  entry: WonderLabManifestEntry,
+  repository = 'silasfelinus/kind_robots',
+  ref = 'main',
+): string {
+  const safePath = normalizePath(entry.sourcePath)
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+
+  return `https://github.com/${repository}/blob/${encodeURIComponent(ref)}/${safePath}`
+}


### PR DESCRIPTION
## What changed

- adds a cached, validated client resolver for `public/wonderlab-components.json`;
- matches Component records to manifest entries by explicit source path, component name, and folder context;
- updates the preview host to prefer the manifest’s exact source path before legacy folder/name fallbacks;
- passes the canonical path into fixture lookup as well as dynamic component import;
- displays:
  - manifest matched/unmatched state;
  - the first 12 characters of the SHA-256 source hash;
  - a direct GitHub source link;
- preserves preview fallback behavior when the manifest is unavailable or invalid.

## Why

WonderLab’s canonical recursive manifest already contains source identity and hashes, but the museum preview still guessed paths from the legacy database fields. This makes the manifest useful immediately—before the Component schema migration—while remaining compatible with that future migration.

## Validation

- adds a DB-free resolver/cache/source-URL contract;
- covers duplicate component names, nested-folder matching, explicit source paths, unique-name fallback, invalid manifests, and fetch caching;
- verifies the preview host exposes manifest state, hash, source link, and canonical fixture path;
- keeps the strict zero-gap preview audit in place.

Part of #381.