### PR TITLE
newsfeed: add feed selection and reordering UI

### DIFF
--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -40,17 +40,38 @@
         </button>
       </div>
 
-      <button
-        type="button"
-        class="btn btn-ghost btn-sm rounded-xl"
-        :disabled="isLoading"
-        @click="loadFeed()"
-      >
-        <span v-if="isLoading" class="loading loading-spinner loading-xs" />
-        <Icon v-else name="kind-icon:refresh" class="size-4" />
-        Refresh
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm gap-1.5 rounded-xl"
+          @click="showManageFeeds = !showManageFeeds"
+        >
+          <Icon name="kind-icon:sliders" class="size-4" />
+          Manage feeds
+          <Icon
+            :name="
+              showManageFeeds
+                ? 'kind-icon:chevron-up'
+                : 'kind-icon:chevron-down'
+            "
+            class="size-3.5"
+          />
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl"
+          :disabled="isLoading"
+          @click="loadFeed()"
+        >
+          <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:refresh" class="size-4" />
+          Refresh
+        </button>
+      </div>
     </header>
+
+    <NewsfeedPreferences v-if="showManageFeeds" />
 
     <div
       v-if="errorMessage"
@@ -136,8 +157,10 @@ const errorMessage = ref('')
 const groups = ref<FeedGroup[]>([])
 const sourceErrorCount = ref(0)
 const activeSlug = ref<string>('all')
+const showManageFeeds = ref(false)
 const pageSize = 12
 const visibleLimit = ref(props.initialLimit || pageSize)
+let hasLoadedOnce = false
 
 const allItems = computed<NewsFeedItem[]>(() => {
   const seen = new Set<string>()
@@ -216,12 +239,25 @@ async function loadFeed(): Promise<void> {
       error instanceof Error ? error.message : 'Failed to load the newsfeed.'
   } finally {
     isLoading.value = false
+    hasLoadedOnce = true
   }
 }
 
 watch(activeSlug, () => {
   visibleLimit.value = props.initialLimit || pageSize
 })
+
+// Reordering only changes array position, but .join(',') still changes since
+// it's order-sensitive -- catches both membership and reorder edits made via
+// NewsfeedPreferences. Ignored until the first load resolves, so hydrate()'s
+// own initial mutation (inside loadFeed) can't trigger a redundant refetch.
+watch(
+  () => feedPreferenceStore.enabledFeedSlugs.join(','),
+  () => {
+    if (!hasLoadedOnce) return
+    void loadFeed()
+  },
+)
 
 onMounted(() => {
   void loadFeed()

--- a/components/newsfeed/newsfeed-preferences.vue
+++ b/components/newsfeed/newsfeed-preferences.vue
@@ -1,0 +1,125 @@
+<!-- /components/newsfeed/newsfeed-preferences.vue -->
+<!--
+  Manage-feeds panel for the recommended newsfeed (conductor projects/newsfeed
+  t-007). Lets a user enable/disable recommended feeds and reorder the
+  enabled ones. Reads and writes stores/feedPreferenceStore (t-004) directly
+  -- no new schema, localStorage-backed like the rest of that store.
+-->
+<template>
+  <div class="kr-panel-flat p-4">
+    <div class="mb-3 flex items-center justify-between gap-3">
+      <div>
+        <h3 class="font-black">Manage feeds</h3>
+        <p class="text-xs text-base-content/55">
+          Choose which feeds appear and the order they're shown in.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs rounded-xl"
+        @click="feedPreferenceStore.resetToDefaults()"
+      >
+        Reset to defaults
+      </button>
+    </div>
+
+    <ul class="flex flex-col divide-y divide-base-300">
+      <li
+        v-for="(feed, index) in enabledFeeds"
+        :key="feed.slug"
+        class="flex items-center justify-between gap-3 py-2.5"
+      >
+        <div class="flex min-w-0 items-center gap-2">
+          <Icon :name="feed.icon" class="size-4 shrink-0 text-primary" />
+          <div class="min-w-0">
+            <span class="block truncate font-semibold">{{ feed.title }}</span>
+            <span class="block truncate text-xs text-base-content/55">
+              {{ feed.description }}
+            </span>
+          </div>
+        </div>
+
+        <div class="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs px-1.5"
+            :disabled="index === 0"
+            aria-label="Move feed up"
+            @click="moveFeed(feed.slug, -1)"
+          >
+            <Icon name="kind-icon:chevron-up" class="size-4" />
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs px-1.5"
+            :disabled="index === enabledFeeds.length - 1"
+            aria-label="Move feed down"
+            @click="moveFeed(feed.slug, 1)"
+          >
+            <Icon name="kind-icon:chevron-down" class="size-4" />
+          </button>
+          <input
+            type="checkbox"
+            class="toggle toggle-primary toggle-sm ml-1"
+            checked
+            aria-label="Disable feed"
+            @change="feedPreferenceStore.disableFeed(feed.slug)"
+          />
+        </div>
+      </li>
+
+      <li
+        v-for="feed in availableFeeds"
+        :key="feed.slug"
+        class="flex items-center justify-between gap-3 py-2.5 opacity-70"
+      >
+        <div class="flex min-w-0 items-center gap-2">
+          <Icon :name="feed.icon" class="size-4 shrink-0" />
+          <div class="min-w-0">
+            <span class="block truncate font-semibold">{{ feed.title }}</span>
+            <span class="block truncate text-xs text-base-content/55">
+              {{ feed.description }}
+            </span>
+          </div>
+        </div>
+
+        <input
+          type="checkbox"
+          class="toggle toggle-sm"
+          aria-label="Enable feed"
+          @change="feedPreferenceStore.enableFeed(feed.slug)"
+        />
+      </li>
+    </ul>
+
+    <p
+      v-if="!enabledFeeds.length"
+      class="pt-2 text-center text-xs text-base-content/55"
+    >
+      No feeds enabled — turn one on above to see it here.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useFeedPreferenceStore } from '@/stores/feedPreferenceStore'
+
+const feedPreferenceStore = useFeedPreferenceStore()
+
+const enabledFeeds = computed(() => feedPreferenceStore.enabledFeeds)
+const availableFeeds = computed(() => feedPreferenceStore.availableFeeds)
+
+function moveFeed(slug: string, direction: -1 | 1): void {
+  const order = [...feedPreferenceStore.enabledFeedSlugs]
+  const index = order.indexOf(slug)
+  const swapIndex = index + direction
+  if (index < 0 || swapIndex < 0 || swapIndex >= order.length) return
+  const current = order[index]
+  const swapped = order[swapIndex]
+  if (current === undefined || swapped === undefined) return
+  order[index] = swapped
+  order[swapIndex] = current
+  feedPreferenceStore.reorderFeeds(order)
+}
+</script>

--- a/public/components.json
+++ b/public/components.json
@@ -275,7 +275,8 @@
     "folderName": "newsfeed",
     "components": [
       "feed-card",
-      "newsfeed-feed"
+      "newsfeed-feed",
+      "newsfeed-preferences"
     ]
   },
   {


### PR DESCRIPTION
### Task
newsfeed/t-007: Add user feed selection and ordering (kind: software)

### What changed / what I produced
- New `components/newsfeed/newsfeed-preferences.vue` — a "Manage feeds" panel listing every recommended feed (`FEED_DEFINITIONS`) with an enable/disable toggle, plus move-up/move-down reordering for currently-enabled feeds. Wired directly to the existing `feedPreferenceStore` (t-004) actions: `enableFeed`, `disableFeed`, `reorderFeeds`. No new schema — same localStorage-backed persistence the store already had.
- `components/newsfeed/newsfeed-feed.vue` — added a "Manage feeds" header button that toggles the new panel, and a `watch` on `feedPreferenceStore.enabledFeedSlugs.join(',')` (order-sensitive) so toggling or reordering feeds triggers an automatic refetch. Guarded with a `hasLoadedOnce` flag so the store's own initial-hydrate mutation doesn't cause a redundant fetch on mount.
- Registered the new component in `public/components.json` under the `newsfeed` folder entry.

### How I verified
- `npm run test` (vue-tsc --noEmit via `nuxi prepare`): 0 errors.
- `npx eslint` on both changed/new `.vue` files: clean.
- `npx prettier --check` on both changed/new `.vue` files: clean (the one remaining warning on `public/components.json` is pre-existing drift on `main`, confirmed via `git stash`/re-check before my edit — unrelated to this change).
- Could not visually verify in a live preview (sandbox has no DB / deployed preview). The toggle/reorder logic and store wiring type-check and lint clean; the UI reuses established patterns 1:1 (DaisyUI `toggle` checkboxes per `account-settings.vue`, `kind-icon:chevron-up/down` per several existing disclosure/reorder-adjacent UIs, `.kr-panel-flat` per the documented `kr-*` surface system).

### Stakes
reversible

### Flags for Reviewer
- No drag-and-drop library exists in this repo yet, so reordering uses move-up/move-down buttons rather than a drag handle — matches the Explore research finding that no sortable/draggable dependency is currently installed.
- The "All" tab still sorts merged items purely chronologically; feed order from this panel only affects the per-feed filter-chip button order, not "All" item interleaving. Kept as-is since t-007's note scopes this to selection + ordering, not a new "All" sort mode — flagging in case Silas wants feed-order-aware "All" sorting as a follow-up.
- A pre-existing quirk (not touched by this PR): if a user disables every feed, `newsfeed-feed.vue`'s fallback logic (`enabledFeedSlugs.length ? ... : availableFeeds...`) ends up fetching all feeds anyway, since `availableFeeds` becomes the full registry when nothing is enabled. Worth a dedicated follow-up if "truly zero feeds" should be a supported state.

### Kaizen suggestion
No drag-and-drop/sortable dependency exists in this codebase at all — several other roadmap items (this one included) reach for move-up/move-down buttons as a workaround. Worth a small, standalone task to pick and wire one lightweight, dependency-light sortable-list primitive (or a tiny custom composable) once a second feature actually needs true drag-and-drop, so it's not each ad-hoc reinvented per feature.

### Notes for reviewer
Conductor roadmap task set to `status: review` (owner: worker) in the same session; will flip to `done` after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VfjitxNB2RwNtLe9dpHmvu)_