### PR TITLE
WonderLab: add read-only registry health view

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -121,6 +121,9 @@ jobs:
       - name: WonderLab component manifest source contract
         run: npx tsx utils/scripts/verifyWonderLabComponentManifest.ts
 
+      - name: WonderLab registry health contract
+        run: npx tsx utils/scripts/verifyWonderLabRegistryHealth.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/wonderlab/component-registry-health.vue
+++ b/components/wonderlab/component-registry-health.vue
@@ -1,0 +1,260 @@
+<!-- /components/wonderlab/component-registry-health.vue -->
+<template>
+  <section
+    class="rounded-3xl border border-base-300 bg-base-100/85 p-4 shadow-sm"
+  >
+    <header class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          Registry Health
+        </p>
+        <h2 class="mt-1 text-xl font-black">Manifest ↔ database coverage</h2>
+        <p class="mt-1 max-w-3xl text-sm leading-relaxed text-base-content/60">
+          Read-only comparison of discovered Vue source files and existing
+          Component records. Reconciliation remains an explicit admin action.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm rounded-xl"
+        :disabled="loading"
+        @click="loadHealth(true)"
+      >
+        <span v-if="loading" class="loading loading-spinner loading-xs" />
+        <Icon v-else name="kind-icon:refresh" class="size-4" />
+        Refresh
+      </button>
+    </header>
+
+    <div
+      v-if="errorMessage"
+      class="mt-4 rounded-2xl border border-error/30 bg-error/10 p-3 text-sm text-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div v-else-if="loading && !health" class="mt-4 grid gap-3 sm:grid-cols-3">
+      <div v-for="index in 6" :key="index" class="skeleton h-20 rounded-2xl" />
+    </div>
+
+    <template v-else-if="health">
+      <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+        <div class="rounded-2xl border border-base-300 bg-base-200/60 p-3">
+          <p class="text-xs font-black uppercase text-base-content/45">Source files</p>
+          <p class="mt-1 text-2xl font-black">{{ health.manifestCount }}</p>
+        </div>
+        <div class="rounded-2xl border border-base-300 bg-base-200/60 p-3">
+          <p class="text-xs font-black uppercase text-base-content/45">DB records</p>
+          <p class="mt-1 text-2xl font-black">{{ health.recordCount }}</p>
+        </div>
+        <div class="rounded-2xl border border-success/30 bg-success/10 p-3">
+          <p class="text-xs font-black uppercase text-success">Matched</p>
+          <p class="mt-1 text-2xl font-black text-success">
+            {{ health.matchedRecordCount }}
+          </p>
+        </div>
+        <div
+          class="rounded-2xl border p-3"
+          :class="
+            health.staleRecordCount
+              ? 'border-warning/35 bg-warning/10'
+              : 'border-success/30 bg-success/10'
+          "
+        >
+          <p class="text-xs font-black uppercase text-base-content/55">
+            Records without source
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ health.staleRecordCount }}</p>
+        </div>
+        <div
+          class="rounded-2xl border p-3"
+          :class="
+            health.missingRecordCount
+              ? 'border-info/35 bg-info/10'
+              : 'border-success/30 bg-success/10'
+          "
+        >
+          <p class="text-xs font-black uppercase text-base-content/55">
+            Sources without record
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ health.missingRecordCount }}</p>
+        </div>
+        <div
+          class="rounded-2xl border p-3"
+          :class="
+            health.duplicateNameCount
+              ? 'border-secondary/35 bg-secondary/10'
+              : 'border-success/30 bg-success/10'
+          "
+        >
+          <p class="text-xs font-black uppercase text-base-content/55">
+            Duplicate names
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ health.duplicateNameCount }}</p>
+        </div>
+      </div>
+
+      <details
+        v-if="health.staleRecordCount || health.missingRecordCount || health.duplicateNameCount"
+        class="mt-4 rounded-2xl border border-base-300 bg-base-200/40 p-3"
+      >
+        <summary class="cursor-pointer font-black text-base-content/80">
+          Review registry differences
+        </summary>
+
+        <div class="mt-3 grid gap-4 lg:grid-cols-3">
+          <section>
+            <h3 class="text-sm font-black text-warning">
+              Database-only records
+            </h3>
+            <p class="mt-1 text-xs text-base-content/55">
+              Preserved records that do not resolve to a current source file.
+            </p>
+            <ul class="mt-2 space-y-1 text-xs">
+              <li
+                v-for="record in health.staleRecords.slice(0, detailLimit)"
+                :key="record.id"
+                class="break-all rounded-lg bg-base-100 px-2 py-1.5 font-mono"
+              >
+                #{{ record.id }} · {{ record.folderName }}/{{ record.componentName }}
+              </li>
+              <li v-if="health.staleRecordCount > detailLimit" class="text-base-content/50">
+                +{{ health.staleRecordCount - detailLimit }} more
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 class="text-sm font-black text-info">Manifest-only sources</h3>
+            <p class="mt-1 text-xs text-base-content/55">
+              Source files that do not yet have a matching Component record.
+            </p>
+            <ul class="mt-2 space-y-1 text-xs">
+              <li
+                v-for="entry in health.missingEntries.slice(0, detailLimit)"
+                :key="entry.sourceKey"
+                class="break-all rounded-lg bg-base-100 px-2 py-1.5 font-mono"
+              >
+                {{ entry.sourcePath }}
+              </li>
+              <li v-if="health.missingRecordCount > detailLimit" class="text-base-content/50">
+                +{{ health.missingRecordCount - detailLimit }} more
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 class="text-sm font-black text-secondary">Duplicate names</h3>
+            <p class="mt-1 text-xs text-base-content/55">
+              Valid when folder context is available; ambiguous for name-only links.
+            </p>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <span
+                v-for="name in health.duplicateNames.slice(0, detailLimit)"
+                :key="name"
+                class="badge badge-secondary badge-outline badge-sm font-mono"
+              >
+                {{ name }}
+              </span>
+              <span
+                v-if="health.duplicateNameCount > detailLimit"
+                class="badge badge-ghost badge-sm"
+              >
+                +{{ health.duplicateNameCount - detailLimit }} more
+              </span>
+            </div>
+          </section>
+        </div>
+      </details>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import {
+  clearWonderLabManifestCache,
+  loadWonderLabComponentManifest,
+  type WonderLabComponentManifest,
+} from '@/utils/wonderlab/componentManifest'
+import {
+  summarizeWonderLabRegistry,
+  type WonderLabRegistryHealth,
+  type WonderLabRegistryRecord,
+} from '@/utils/wonderlab/componentRegistryHealth'
+
+const detailLimit = 8
+const loading = ref(false)
+const errorMessage = ref('')
+const health = ref<WonderLabRegistryHealth | null>(null)
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url, { headers: { accept: 'application/json' } })
+  if (!response.ok) {
+    throw new Error(`${url} request failed (${response.status}).`)
+  }
+  return response.json() as Promise<unknown>
+}
+
+function readComponentRecords(payload: unknown): WonderLabRegistryRecord[] {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Component API returned an invalid response.')
+  }
+
+  const data = (payload as { data?: unknown }).data
+  if (!Array.isArray(data)) {
+    throw new Error('Component API did not return a component list.')
+  }
+
+  return data.flatMap((value) => {
+    if (!value || typeof value !== 'object') return []
+    const candidate = value as Partial<WonderLabRegistryRecord>
+    if (
+      !Number.isInteger(candidate.id) ||
+      typeof candidate.componentName !== 'string' ||
+      typeof candidate.folderName !== 'string'
+    ) {
+      return []
+    }
+
+    return [
+      {
+        id: candidate.id as number,
+        componentName: candidate.componentName,
+        folderName: candidate.folderName,
+      },
+    ]
+  })
+}
+
+async function loadHealth(force = false): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    if (force) clearWonderLabManifestCache()
+
+    const [manifest, componentPayload] = await Promise.all([
+      loadWonderLabComponentManifest(() =>
+        fetchJson('/wonderlab-components.json'),
+      ),
+      fetchJson('/api/components'),
+    ]) as [WonderLabComponentManifest, unknown]
+
+    health.value = summarizeWonderLabRegistry(
+      manifest.entries,
+      readComponentRecords(componentPayload),
+    )
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Failed to inspect registry health.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  void loadHealth()
+})
+</script>

--- a/content/wonderlab.md
+++ b/content/wonderlab.md
@@ -18,4 +18,6 @@ loadingMessage: Loading the museum...
 refreshLabel: Refresh Museum
 ---
 
+:component-registry-health
+
 :lab-manager

--- a/utils/scripts/verifyWonderLabRegistryHealth.ts
+++ b/utils/scripts/verifyWonderLabRegistryHealth.ts
@@ -1,0 +1,107 @@
+// /utils/scripts/verifyWonderLabRegistryHealth.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  clearWonderLabManifestCache,
+  loadWonderLabComponentManifest,
+  type WonderLabComponentManifest,
+} from '@/utils/wonderlab/componentManifest'
+import { summarizeWonderLabRegistry } from '@/utils/wonderlab/componentRegistryHealth'
+
+const manifest: WonderLabComponentManifest = {
+  version: 1,
+  generatedAt: '2026-01-01T00:00:00.000Z',
+  componentRoot: 'components',
+  count: 4,
+  entries: [
+    {
+      sourceKey: 'components/alpha/foo-card.vue',
+      sourcePath: 'components/alpha/foo-card.vue',
+      sourceHash: 'a'.repeat(64),
+      componentName: 'foo-card',
+      slug: 'alpha-foo-card',
+      folderName: 'alpha',
+    },
+    {
+      sourceKey: 'components/beta/bar-panel.vue',
+      sourcePath: 'components/beta/bar-panel.vue',
+      sourceHash: 'b'.repeat(64),
+      componentName: 'bar-panel',
+      slug: 'beta-bar-panel',
+      folderName: 'beta',
+    },
+    {
+      sourceKey: 'components/x/duplicate-card.vue',
+      sourcePath: 'components/x/duplicate-card.vue',
+      sourceHash: 'c'.repeat(64),
+      componentName: 'duplicate-card',
+      slug: 'x-duplicate-card',
+      folderName: 'x',
+    },
+    {
+      sourceKey: 'components/y/duplicate-card.vue',
+      sourcePath: 'components/y/duplicate-card.vue',
+      sourceHash: 'd'.repeat(64),
+      componentName: 'duplicate-card',
+      slug: 'y-duplicate-card',
+      folderName: 'y',
+    },
+  ],
+}
+
+const health = summarizeWonderLabRegistry(manifest.entries, [
+  { id: 1, componentName: 'foo-card', folderName: 'alpha' },
+  { id: 2, componentName: 'duplicate-card', folderName: 'x' },
+  { id: 3, componentName: 'retired-widget', folderName: 'legacy' },
+])
+
+assert.equal(health.manifestCount, 4)
+assert.equal(health.recordCount, 3)
+assert.equal(health.matchedRecordCount, 2)
+assert.equal(health.staleRecordCount, 1)
+assert.equal(health.missingRecordCount, 2)
+assert.equal(health.duplicateNameCount, 1)
+assert.deepEqual(health.staleRecords.map((record) => record.id), [3])
+assert.deepEqual(
+  health.missingEntries.map((entry) => entry.sourcePath),
+  ['components/beta/bar-panel.vue', 'components/y/duplicate-card.vue'],
+)
+assert.deepEqual(health.duplicateNames, ['duplicate-card'])
+
+// A rejected manifest request must not poison the shared cache permanently.
+clearWonderLabManifestCache()
+let attempts = 0
+await assert.rejects(
+  loadWonderLabComponentManifest(async () => {
+    attempts += 1
+    throw new Error('temporary manifest outage')
+  }),
+  /temporary manifest outage/,
+)
+const recovered = await loadWonderLabComponentManifest(async () => {
+  attempts += 1
+  return manifest
+})
+assert.equal(recovered.count, 4)
+assert.equal(attempts, 2)
+clearWonderLabManifestCache()
+
+const panelSource = await readFile(
+  'components/wonderlab/component-registry-health.vue',
+  'utf8',
+)
+assert.match(panelSource, /\/wonderlab-components\.json/)
+assert.match(panelSource, /\/api\/components/)
+assert.match(panelSource, /summarizeWonderLabRegistry/)
+assert.match(panelSource, /Reconciliation remains an explicit admin action/)
+assert.match(panelSource, /clearWonderLabManifestCache/)
+
+const contentSource = await readFile('content/wonderlab.md', 'utf8')
+assert.match(contentSource, /:component-registry-health/)
+assert.match(contentSource, /:lab-manager/)
+assert.ok(
+  contentSource.indexOf(':component-registry-health') <
+    contentSource.indexOf(':lab-manager'),
+)
+
+console.log('WonderLab registry health verification passed.')

--- a/utils/wonderlab/componentManifest.ts
+++ b/utils/wonderlab/componentManifest.ts
@@ -47,19 +47,28 @@ function isManifest(value: unknown): value is WonderLabComponentManifest {
 export function loadWonderLabComponentManifest(
   fetcher: () => Promise<unknown>,
 ): Promise<WonderLabComponentManifest> {
-  manifestPromise ??= fetcher().then((payload) => {
-    if (!isManifest(payload)) {
-      throw new Error('WonderLab component manifest has an invalid shape.')
-    }
+  manifestPromise ??= fetcher()
+    .then((payload) => {
+      if (!isManifest(payload)) {
+        throw new Error('WonderLab component manifest has an invalid shape.')
+      }
 
-    return payload
-  })
+      return payload
+    })
+    .catch((error) => {
+      manifestPromise = null
+      throw error
+    })
 
   return manifestPromise
 }
 
-export function resetWonderLabManifestCacheForTests(): void {
+export function clearWonderLabManifestCache(): void {
   manifestPromise = null
+}
+
+export function resetWonderLabManifestCacheForTests(): void {
+  clearWonderLabManifestCache()
 }
 
 export function resolveWonderLabManifestEntry(

--- a/utils/wonderlab/componentRegistryHealth.ts
+++ b/utils/wonderlab/componentRegistryHealth.ts
@@ -1,0 +1,80 @@
+// /utils/wonderlab/componentRegistryHealth.ts
+import {
+  resolveWonderLabManifestEntry,
+  type WonderLabManifestEntry,
+} from './componentManifest'
+
+export type WonderLabRegistryRecord = {
+  id: number
+  componentName: string
+  folderName: string
+}
+
+export type WonderLabRegistryHealth = {
+  manifestCount: number
+  recordCount: number
+  matchedRecordCount: number
+  staleRecordCount: number
+  missingRecordCount: number
+  duplicateNameCount: number
+  staleRecords: WonderLabRegistryRecord[]
+  missingEntries: WonderLabManifestEntry[]
+  duplicateNames: string[]
+}
+
+function normalizeName(value: string): string {
+  return value.trim().replace(/\.vue$/i, '').toLowerCase()
+}
+
+export function summarizeWonderLabRegistry(
+  entries: WonderLabManifestEntry[],
+  records: WonderLabRegistryRecord[],
+): WonderLabRegistryHealth {
+  const matchedSourcePaths = new Set<string>()
+  const staleRecords: WonderLabRegistryRecord[] = []
+
+  for (const record of records) {
+    const entry = resolveWonderLabManifestEntry(
+      entries,
+      record.componentName,
+      record.folderName,
+    )
+
+    if (entry) {
+      matchedSourcePaths.add(entry.sourcePath.toLowerCase())
+    } else {
+      staleRecords.push(record)
+    }
+  }
+
+  const missingEntries = entries.filter(
+    (entry) => !matchedSourcePaths.has(entry.sourcePath.toLowerCase()),
+  )
+
+  const names = new Map<string, number>()
+  for (const entry of entries) {
+    const name = normalizeName(entry.componentName)
+    names.set(name, (names.get(name) || 0) + 1)
+  }
+
+  const duplicateNames = [...names.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([name]) => name)
+    .sort()
+
+  return {
+    manifestCount: entries.length,
+    recordCount: records.length,
+    matchedRecordCount: records.length - staleRecords.length,
+    staleRecordCount: staleRecords.length,
+    missingRecordCount: missingEntries.length,
+    duplicateNameCount: duplicateNames.length,
+    staleRecords: [...staleRecords].sort((left, right) =>
+      left.componentName.localeCompare(right.componentName),
+    ),
+    missingEntries: [...missingEntries].sort((left, right) =>
+      left.sourcePath.localeCompare(right.sourcePath),
+    ),
+    duplicateNames,
+  }
+}


### PR DESCRIPTION
## What changed

- adds a read-only Registry Health panel above the WonderLab museum;
- loads the canonical component manifest and public Component API in parallel;
- compares them without creating, updating, retiring, or deleting any rows;
- reports:
  - source-file count;
  - database-record count;
  - matched records;
  - database-only/stale records;
  - manifest-only sources awaiting records;
  - duplicate component names;
- provides capped, expandable detail lists for each difference category;
- adds explicit refresh/retry behavior.

## Manifest resilience

The shared manifest loader now clears its cached promise after a failed request, allowing later retries to recover. A public cache-clear function supports the panel’s explicit Refresh action; the existing test reset remains as a compatibility alias.

## Why

WonderLab now uses the manifest for exact preview source resolution, but visitors and admins still cannot see the overall manifest/database drift without running reconciliation. This provides the missing read-only diagnostic while keeping reconciliation an explicit authenticated action.

## Validation

- adds a DB-free registry summary contract covering matches, stale records, missing records, duplicate names, sorting, and counts;
- verifies a failed manifest request does not permanently poison the shared cache;
- verifies the panel reads only `/wonderlab-components.json` and `/api/components`;
- verifies the panel is rendered before the museum manager in `content/wonderlab.md`;
- keeps strict zero-gap preview coverage enabled.

Part of #381.