### PR TITLE
ai-art-academy/t-034: add Ashcan School to the academyStyles.ts front-end seed

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -999,6 +999,50 @@ export const academyStyles: AcademyStyle[] = [
     },
   },
   {
+    slug: 'ashcan-school',
+    name: 'Ashcan School',
+    era: 'c. 1900–1913',
+    sortYear: 1900,
+    region: 'New York',
+    keyIdeas:
+      'Robert Henri told his students to forget polite academy subjects and paint what was actually outside their studio windows — tenements, saloons, boxing clubs, crowded streets. His circle, nicknamed "the Ashcan School" by a critic who meant it as an insult, gave the modern industrial city the same serious, confident brushwork as a mythological scene: gritty, loud, and alive, like photojournalism painted in oil decades before photojournalism existed.',
+    recognitionCues: [
+      'Loose, confident, visibly gestural brushwork — energy and immediacy over polished finish',
+      'A dark, murky, earthy palette (browns, blacks, muddy grays) punctuated by small bright accents',
+      'Everyday urban subjects treated with the seriousness of history painting — streets, tenements, saloons, boxing matches',
+      'Dramatic, low, often artificial lighting (gaslight, ring lights) rather than even daylight',
+    ],
+    artists: [
+      {
+        name: 'Robert Henri',
+        years: '1865–1929',
+        note: 'The movement’s teacher and organizer; urged students to paint life "with such vitality" that gallery walls would seem to disappear.',
+      },
+      {
+        name: 'George Bellows',
+        years: '1882–1925',
+        note: 'Best known for ringside boxing scenes, rendered with blurred, aggressive brushwork that puts the viewer in the crowd.',
+      },
+      {
+        name: 'John Sloan',
+        years: '1871–1951',
+        note: 'Chronicler of Greenwich Village street life, rooftops, and working-class New Yorkers going about ordinary days.',
+      },
+      {
+        name: 'William Glackens',
+        years: '1870–1938',
+        note: 'Painted the city’s social scenes — cafes, restaurants, parks — in a looser, more colorful hand than his Ashcan peers.',
+      },
+    ],
+    failureMode:
+      'Under-cooks toward a lightly-graded photo if the prompt underweights brushwork/palette — lean on "gestural," "murky," "low-key lighting"',
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image in the Ashcan School style: loose, gestural brushwork, a dark and earthy urban palette, unglamorized everyday city subject matter, and dramatic, low-key lighting like a newspaper illustrator working in oil',
+    },
+  },
+  {
     slug: 'expressionism',
     name: 'Expressionism',
     era: 'c. 1905–1930',


### PR DESCRIPTION
### Task
ai-art-academy/t-034: kind_robots: add Ashcan School to the academyStyles.ts front-end seed (kind: software)

### What changed / what I produced
- Added the `ashcan-school` entry to `stores/seeds/academyStyles.ts` (23rd curriculum movement): slug, name, era, sortYear, region, keyIdeas, recognitionCues, artists (Robert Henri, George Bellows, John Sloan, William Glackens), failureMode, and remix template.
- Content sourced verbatim from `conductor/projects/ai-art-academy/docs/curriculum-outline.md` §23 (remix template = the outline's `remix_hint`) and `docs/teaching-notes.md`'s per-style failure-mode column — no new facts invented.
- Inserted in chronological position (`sortYear: 1900`, between `art-nouveau` and `expressionism`) matching the array's runtime `.sort((a,b) => a.sortYear - b.sortYear)`, mirroring how t-015/t-018/t-031 placed their entries.
- Example works are intentionally left out — a follow-up task will add the four VERIFIED example-works entries to `examples.manifest.json`, mirroring t-013's pattern.

### How I verified
- `grep -c "slug:"` + a small node script confirmed 23 unique slugs, no duplicates, `ashcan-school` present.
- `npx prettier --check stores/seeds/academyStyles.ts` — clean.
- `npm run test` (`vue-tsc --noEmit`, full project) — 0 errors.
- `npx eslint stores/seeds/academyStyles.ts` — clean.
- Rebased onto latest `main` and re-ran all three checks after rebase (still clean).

### Stakes
reversible

### Flags for Reviewer
- None — small, additive, one-file change, no design judgment required.

### Kaizen suggestion
`examples.manifest.json` still doesn't have an Ashcan School entry — a follow-up task (mirroring t-013) should add the four VERIFIED example works from curriculum-outline.md §23.

### Notes for reviewer
conductor roadmap task ai-art-academy/t-034 claimed by session `claude-conductor-agentrun-20260718T2300Z`; will be flipped to `done` after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PML8gg1F5V4tMoAqfnawV5)_