### PR TITLE
WonderLab: preserve museum filters in shareable URLs

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -124,6 +124,9 @@ jobs:
       - name: WonderLab registry health contract
         run: npx tsx utils/scripts/verifyWonderLabRegistryHealth.ts
 
+      - name: WonderLab museum URL query contract
+        run: npx tsx utils/scripts/verifyWonderLabMuseumQuery.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/wonderlab/lab-interact.vue
+++ b/components/wonderlab/lab-interact.vue
@@ -111,6 +111,7 @@
               v-model="searchQuery"
               class="input input-bordered input-sm w-full bg-base-200"
               type="search"
+              aria-label="Search WonderLab components"
               placeholder="Search components..."
             />
 
@@ -118,6 +119,7 @@
               <select
                 v-model="folderFilter"
                 class="select select-bordered select-sm bg-base-200"
+                aria-label="Filter WonderLab components by folder"
               >
                 <option value="">All folders</option>
 
@@ -133,6 +135,7 @@
               <select
                 v-model="statusFilter"
                 class="select select-bordered select-sm bg-base-200"
+                aria-label="Filter WonderLab components by status"
               >
                 <option value="all">All statuses</option>
                 <option value="UNREVIEWED">Unreviewed</option>
@@ -140,6 +143,22 @@
                 <option value="UNDER_CONSTRUCTION">Building</option>
                 <option value="BROKEN">Broken</option>
               </select>
+            </div>
+
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-xs text-base-content/55">
+                {{ filteredComponents.length }} of {{ componentCount }} exhibits
+              </p>
+
+              <button
+                v-if="hasActiveFilters"
+                class="btn btn-ghost btn-xs rounded-xl"
+                type="button"
+                @click="clearMuseumFilters"
+              >
+                <Icon name="kind-icon:x" class="size-3.5" />
+                Clear filters
+              </button>
             </div>
           </div>
         </div>
@@ -381,6 +400,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import type { Component as PrismaComponent } from '~/prisma/generated/prisma/client'
 import { useComponentStore } from '@/stores/componentStore'
 import { useUserStore } from '@/stores/userStore'
@@ -389,8 +409,14 @@ import {
   legacyFieldsForComponentStatus,
   type LegacyComponentStatus,
 } from '@/utils/wonderlab/componentStatus'
-
-type ComponentStatusFilter = 'all' | LegacyComponentStatus
+import {
+  normalizeWonderLabMuseumQuery,
+  sameWonderLabMuseumQuery,
+  wonderLabMuseumQuery,
+  type WonderLabMuseumQueryState,
+  type WonderLabQuery,
+  type WonderLabStatusFilter,
+} from '@/utils/wonderlab/museumQuery'
 
 const statusOptions: Array<{
   value: LegacyComponentStatus
@@ -402,12 +428,30 @@ const statusOptions: Array<{
   { value: 'BROKEN', label: 'Broken' },
 ]
 
+const route = useRoute()
+const router = useRouter()
 const componentStore = useComponentStore()
 const userStore = useUserStore()
 
-const searchQuery = ref('')
-const folderFilter = ref('')
-const statusFilter = ref<ComponentStatusFilter>('all')
+const museumQueryState = computed(() =>
+  normalizeWonderLabMuseumQuery(route.query as WonderLabQuery),
+)
+
+const searchQuery = computed<string>({
+  get: () => museumQueryState.value.search,
+  set: (search) => setMuseumQuery({ search }, 'replace'),
+})
+
+const folderFilter = computed<string>({
+  get: () => museumQueryState.value.folder,
+  set: (folder) => setMuseumQuery({ folder }, 'push'),
+})
+
+const statusFilter = computed<WonderLabStatusFilter>({
+  get: () => museumQueryState.value.status,
+  set: (status) => setMuseumQuery({ status }, 'push'),
+})
+
 const isLoading = ref(false)
 const isSavingComponent = ref(false)
 const statusMessage = ref('')
@@ -415,6 +459,12 @@ const statusTone = ref<'success' | 'error'>('success')
 const reviewFeedVersion = ref(0)
 
 const isAdmin = computed(() => userStore.isAdmin)
+const hasActiveFilters = computed(
+  () =>
+    Boolean(museumQueryState.value.search) ||
+    Boolean(museumQueryState.value.folder) ||
+    museumQueryState.value.status !== 'all',
+)
 
 const components = computed<PrismaComponent[]>(() => {
   const fromAll = componentStore.allComponents || []
@@ -502,6 +552,35 @@ const filteredComponents = computed(() => {
     return leftLabel.localeCompare(rightLabel)
   })
 })
+
+function setMuseumQuery(
+  partial: Partial<WonderLabMuseumQueryState>,
+  historyMode: 'push' | 'replace',
+): void {
+  const current = museumQueryState.value
+  const next = { ...current, ...partial }
+  if (sameWonderLabMuseumQuery(current, next)) return
+
+  const location = {
+    path: route.path,
+    query: wonderLabMuseumQuery(route.query as WonderLabQuery, next),
+    hash: route.hash,
+  }
+
+  if (historyMode === 'replace') void router.replace(location)
+  else void router.push(location)
+}
+
+function clearMuseumFilters(): void {
+  setMuseumQuery(
+    {
+      search: '',
+      folder: '',
+      status: 'all',
+    },
+    'push',
+  )
+}
 
 function componentStatus(component: PrismaComponent): LegacyComponentStatus {
   return getLegacyComponentStatus(component)

--- a/utils/scripts/verifyWonderLabMuseumQuery.ts
+++ b/utils/scripts/verifyWonderLabMuseumQuery.ts
@@ -1,0 +1,111 @@
+// /utils/scripts/verifyWonderLabMuseumQuery.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  normalizeWonderLabMuseumQuery,
+  sameWonderLabMuseumQuery,
+  wonderLabMuseumQuery,
+} from '@/utils/wonderlab/museumQuery'
+
+const normalized = normalizeWonderLabMuseumQuery({
+  q: '  butterfly swarm  ',
+  folder: ['screenfx', 'ignored'],
+  status: 'working',
+})
+
+assert.deepEqual(normalized, {
+  search: 'butterfly swarm',
+  folder: 'screenfx',
+  status: 'WORKING',
+})
+
+assert.deepEqual(
+  normalizeWonderLabMuseumQuery({
+    q: [null, 'second value'],
+    folder: null,
+    status: 'not-a-real-status',
+  }),
+  {
+    search: 'second value',
+    folder: '',
+    status: 'all',
+  },
+  'invalid or missing query values should be harmless',
+)
+
+const preserved = wonderLabMuseumQuery(
+  {
+    component: 'wonderlab/component-card',
+    tab: 'museum',
+    q: 'old search',
+    folder: 'old-folder',
+    status: 'BROKEN',
+  },
+  {
+    search: 'preview host',
+    folder: 'wonderlab',
+    status: 'UNDER_CONSTRUCTION',
+  },
+)
+
+assert.deepEqual(preserved, {
+  component: 'wonderlab/component-card',
+  tab: 'museum',
+  q: 'preview host',
+  folder: 'wonderlab',
+  status: 'UNDER_CONSTRUCTION',
+})
+
+assert.deepEqual(
+  wonderLabMuseumQuery(preserved, {
+    search: '',
+    folder: '',
+    status: 'all',
+  }),
+  {
+    component: 'wonderlab/component-card',
+    tab: 'museum',
+  },
+  'clearing filters should preserve exhibit selection and unrelated query state',
+)
+
+assert.equal(
+  sameWonderLabMuseumQuery(normalized, { ...normalized }),
+  true,
+)
+assert.equal(
+  sameWonderLabMuseumQuery(normalized, {
+    ...normalized,
+    status: 'BROKEN',
+  }),
+  false,
+)
+
+const [labSource, selectionRouterSource] = await Promise.all([
+  readFile('components/wonderlab/lab-interact.vue', 'utf8'),
+  readFile('components/wonderlab/wonderlab-selection-router.vue', 'utf8'),
+])
+
+for (const queryKey of ['q', 'folder', 'status']) {
+  assert.match(
+    labSource,
+    new RegExp(`\\b${queryKey}\\b`),
+    `lab-interact should expose the ${queryKey} query key`,
+  )
+}
+
+assert.match(labSource, /useRoute\(\)/)
+assert.match(labSource, /useRouter\(\)/)
+assert.match(labSource, /setMuseumQuery\(\{ search \}, 'replace'\)/)
+assert.match(labSource, /setMuseumQuery\(\{ folder \}, 'push'\)/)
+assert.match(labSource, /setMuseumQuery\(\{ status \}, 'push'\)/)
+assert.match(labSource, /clearMuseumFilters/)
+assert.match(labSource, /filteredComponents\.length \}\} of \{\{ componentCount/)
+
+assert.match(
+  selectionRouterSource,
+  /const query = \{ \.\.\.route\.query \}/,
+  'component selection routing must preserve museum filter query parameters',
+)
+
+console.log('WonderLab museum URL query contract passed.')

--- a/utils/scripts/verifyWonderLabMuseumQuery.ts
+++ b/utils/scripts/verifyWonderLabMuseumQuery.ts
@@ -81,16 +81,17 @@ assert.equal(
   false,
 )
 
-const [labSource, selectionRouterSource] = await Promise.all([
+const [querySource, labSource, selectionRouterSource] = await Promise.all([
+  readFile('utils/wonderlab/museumQuery.ts', 'utf8'),
   readFile('components/wonderlab/lab-interact.vue', 'utf8'),
   readFile('components/wonderlab/wonderlab-selection-router.vue', 'utf8'),
 ])
 
 for (const queryKey of ['q', 'folder', 'status']) {
   assert.match(
-    labSource,
+    querySource,
     new RegExp(`\\b${queryKey}\\b`),
-    `lab-interact should expose the ${queryKey} query key`,
+    `museumQuery should own the ${queryKey} query key`,
   )
 }
 

--- a/utils/wonderlab/museumQuery.ts
+++ b/utils/wonderlab/museumQuery.ts
@@ -1,0 +1,91 @@
+// /utils/wonderlab/museumQuery.ts
+export const wonderLabStatusFilters = [
+  'UNREVIEWED',
+  'WORKING',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+] as const
+
+export type WonderLabStatusFilter =
+  | 'all'
+  | (typeof wonderLabStatusFilters)[number]
+
+export type WonderLabMuseumQueryState = {
+  search: string
+  folder: string
+  status: WonderLabStatusFilter
+}
+
+export type WonderLabQueryValue =
+  | string
+  | null
+  | undefined
+  | Array<string | null>
+
+export type WonderLabQuery = Record<string, WonderLabQueryValue>
+
+const SEARCH_LIMIT = 160
+const FOLDER_LIMIT = 160
+
+function firstQueryValue(value: WonderLabQueryValue): string {
+  if (Array.isArray(value)) {
+    return value.find((entry): entry is string => typeof entry === 'string') || ''
+  }
+
+  return typeof value === 'string' ? value : ''
+}
+
+function normalizedText(value: WonderLabQueryValue, limit: number): string {
+  return firstQueryValue(value).trim().slice(0, limit)
+}
+
+function normalizedStatus(value: WonderLabQueryValue): WonderLabStatusFilter {
+  const candidate = normalizedText(value, 40).toUpperCase()
+
+  return wonderLabStatusFilters.includes(
+    candidate as (typeof wonderLabStatusFilters)[number],
+  )
+    ? (candidate as WonderLabStatusFilter)
+    : 'all'
+}
+
+export function normalizeWonderLabMuseumQuery(
+  query: WonderLabQuery,
+): WonderLabMuseumQueryState {
+  return {
+    search: normalizedText(query.q, SEARCH_LIMIT),
+    folder: normalizedText(query.folder, FOLDER_LIMIT),
+    status: normalizedStatus(query.status),
+  }
+}
+
+export function wonderLabMuseumQuery(
+  currentQuery: WonderLabQuery,
+  state: WonderLabMuseumQueryState,
+): WonderLabQuery {
+  const query: WonderLabQuery = { ...currentQuery }
+  const search = state.search.trim().slice(0, SEARCH_LIMIT)
+  const folder = state.folder.trim().slice(0, FOLDER_LIMIT)
+
+  if (search) query.q = search
+  else delete query.q
+
+  if (folder) query.folder = folder
+  else delete query.folder
+
+  if (state.status === 'all') delete query.status
+  else query.status = state.status
+
+  return query
+}
+
+export function sameWonderLabMuseumQuery(
+  left: WonderLabMuseumQueryState,
+  right: WonderLabMuseumQueryState,
+): boolean {
+  return (
+    left.search === right.search &&
+    left.folder === right.folder &&
+    left.status === right.status
+  )
+}


### PR DESCRIPTION
## What changed

- makes WonderLab search, folder, and status filters URL-backed:
  - `q`
  - `folder`
  - `status`
- preserves the existing canonical `component` exhibit deep link and unrelated query state;
- restores filter state automatically on refresh and browser back/forward;
- uses history replacement for search typing and history pushes for folder/status changes;
- treats arrays, missing values, and unknown statuses safely;
- adds result counts and a one-click Clear filters action;
- adds accessible labels to the search and filter controls.

## Query contract

A new pure utility normalizes and serializes museum query state. Default/empty filters are omitted from the URL, while exhibit selection and other route query values are preserved.

Examples:

- `/wonderlab?q=butterfly`
- `/wonderlab?folder=screenfx&status=WORKING`
- `/wonderlab?component=wonderlab%2Fcomponent-card&folder=wonderlab`

## Validation

- adds a DB-free query contract covering trimming, arrays, status normalization, invalid values, preservation of `component`, and filter clearing;
- verifies search uses `router.replace` while folder/status use `router.push`;
- verifies the selection router continues spreading existing query parameters;
- keeps strict required-prop preview coverage enabled.

Part of #381.