### PR TITLE
WonderLab: establish one Component loading owner

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -127,6 +127,9 @@ jobs:
       - name: WonderLab museum URL query contract
         run: npx tsx utils/scripts/verifyWonderLabMuseumQuery.ts
 
+      - name: WonderLab single load-owner contract
+        run: npx tsx utils/scripts/verifyWonderLabLoadOwnership.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -1,33 +1,5 @@
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden">
-    <div class="flex shrink-0 justify-end">
-      <button
-        class="btn btn-ghost btn-sm rounded-xl"
-        type="button"
-        :disabled="isLoading"
-        @click="refreshLab"
-      >
-        <span v-if="isLoading" class="loading loading-spinner loading-xs" />
-        <Icon v-else name="kind-icon:refresh" class="size-4" />
-        Refresh
-      </button>
-    </div>
-
-    <div
-      v-if="managerError"
-      class="shrink-0 rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
-    >
-      {{ managerError }}
-    </div>
-
-    <div
-      v-if="isLoading"
-      class="shrink-0 rounded-2xl border border-base-300 bg-base-200 p-4"
-    >
-      <span class="loading loading-spinner loading-sm" />
-      <span class="ml-2">Warming up the lab goblins...</span>
-    </div>
-
+  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
     <section
       v-if="activeTab === 'memory-dungeon'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
@@ -69,9 +41,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { useComponentStore } from '@/stores/componentStore'
 import { useNavStore } from '@/stores/navStore'
 
 import LabInteract from '@/components/wonderlab/lab-interact.vue'
@@ -87,10 +58,6 @@ const validTabs: LabTab[] = ['memory-dungeon', 'wonder-lab', 'screen-fx']
 
 const route = useRoute()
 const navStore = useNavStore()
-const componentStore = useComponentStore()
-
-const isLoading = ref(false)
-const managerError = ref<string | null>(null)
 
 const activeTab = computed<LabTab>(() => {
   const routePath = route.path.replace(/\/+$/, '') || '/'
@@ -108,23 +75,5 @@ const activeTab = computed<LabTab>(() => {
   }
 
   return fallbackTab
-})
-
-async function refreshLab() {
-  isLoading.value = true
-  managerError.value = null
-
-  try {
-    await componentStore.initialize()
-  } catch (error) {
-    managerError.value =
-      error instanceof Error ? error.message : 'Failed to refresh WonderLab.'
-  } finally {
-    isLoading.value = false
-  }
-}
-
-onMounted(async () => {
-  await refreshLab()
 })
 </script>

--- a/utils/scripts/verifyWonderLabLoadOwnership.ts
+++ b/utils/scripts/verifyWonderLabLoadOwnership.ts
@@ -1,0 +1,45 @@
+// /utils/scripts/verifyWonderLabLoadOwnership.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const [managerSource, interactSource, storeSource] = await Promise.all([
+  readFile('components/wonderlab/lab-manager.vue', 'utf8'),
+  readFile('components/wonderlab/lab-interact.vue', 'utf8'),
+  readFile('stores/componentStore.ts', 'utf8'),
+])
+
+assert.doesNotMatch(
+  managerSource,
+  /useComponentStore|componentStore|initialize\(/,
+  'lab-manager must only select the active Lab surface, not load Component data',
+)
+assert.doesNotMatch(
+  managerSource,
+  /onMounted|refreshLab|Warming up the lab goblins/,
+  'lab-manager must not carry a duplicate museum loading lifecycle',
+)
+assert.match(managerSource, /activeTab === 'wonder-lab'/)
+assert.match(managerSource, /<lab-interact/)
+assert.match(managerSource, /activeTab === 'memory-dungeon'/)
+assert.match(managerSource, /activeTab === 'screen-fx'/)
+
+const interactInitializeCalls = interactSource.match(
+  /componentStore\.initialize\(/g,
+) || []
+assert.equal(
+  interactInitializeCalls.length,
+  1,
+  'lab-interact should own exactly one Component initialization call',
+)
+assert.match(interactSource, /async function refreshComponents\(\)/)
+assert.match(interactSource, /componentStore\.initialize\(true\)/)
+assert.match(interactSource, /onMounted\(async \(\) =>/)
+assert.match(interactSource, /if \(components\.value\.length\) return/)
+
+assert.match(
+  storeSource,
+  /if \(isInitialized\.value && !force\) return/,
+  'the sole UI owner should still rely on the store initialization guard',
+)
+
+console.log('WonderLab single load-owner contract passed.')


### PR DESCRIPTION
## What changed

- removes Component-store initialization and refresh state from `lab-manager.vue`;
- makes `lab-manager` a pure route/tab surface selector;
- keeps `lab-interact.vue` as the single Component registry loading owner;
- avoids loading Component data when `/memory` or `/screenfx` is active;
- removes the duplicate top-level Refresh button, loading banner, and error lifecycle from the manager;
- retains the museum’s guarded on-mount initialization and explicit Refresh control.

## Why

Both the manager and the museum UI previously initialized the same Pinia store. The store guard prevented some duplicate network work, but ownership remained ambiguous and force-refresh behavior existed in two layers. This creates one clear responsibility boundary:

- `lab-manager`: choose the active Lab experience;
- `lab-interact`: load and refresh Component museum data.

## Validation

- adds a DB-free load-ownership contract;
- asserts `lab-manager` has no Component store, initialization call, mount lifecycle, or duplicate refresh state;
- asserts `lab-interact` contains exactly one Component initialization call and retains the store guard path;
- keeps route authority, URL filters, preview fixtures, and strict preview coverage unchanged.

Part of #381.