### PR TITLE
WonderLab: add deterministic first-party reviewer affinity

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -133,6 +133,9 @@ jobs:
       - name: WonderLab canonical manifest contract
         run: npx tsx utils/scripts/verifyWonderLabCanonicalManifest.ts
 
+      - name: WonderLab reviewer affinity contract
+        run: npx tsx utils/scripts/verifyWonderLabReviewerAffinity.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/utils/scripts/verifyWonderLabReviewerAffinity.ts
+++ b/utils/scripts/verifyWonderLabReviewerAffinity.ts
@@ -1,0 +1,174 @@
+// /utils/scripts/verifyWonderLabReviewerAffinity.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  isWonderLabReviewerVoiceReady,
+  rankWonderLabReviewers,
+  wonderLabReviewerKey,
+  type WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+
+const candidates: WonderLabReviewerCandidate[] = [
+  {
+    id: 10,
+    kind: 'BOT',
+    name: 'DottiB0t',
+    slug: 'dottib0t',
+    description: 'Bot Making Mad Scientist who builds robot friends.',
+    personality: 'wacky, playful, synergistic',
+    voice: 'Rapid, delighted, technically precise mad-scientist patter.',
+    sampleResponse: 'Oho! This bot chassis has excellent friendship sockets!',
+    modules: 'Bot, Markdown',
+    isActive: true,
+    isPublic: true,
+  },
+  {
+    id: 11,
+    kind: 'CHARACTER',
+    name: 'Catbot',
+    slug: 'catbot',
+    description: 'A cat-shaped critic with broad museum privileges.',
+    voice: 'Communicates through concise cat behavior and selective judgment.',
+    sampleResponse: '*purrs, then pushes the confusing control off the table*',
+    isActive: true,
+    isPublic: true,
+  },
+  {
+    id: 12,
+    kind: 'BOT',
+    name: 'Interface Cartographer',
+    slug: 'interface-cartographer',
+    description: 'Maps navigation, route state, panels, and component layouts.',
+    voice: 'Calm, spatial, and exact.',
+    sampleResponse: 'The route is sound, but the panel hierarchy needs a clearer landmark.',
+    tags: ['navigation', 'layout', 'route'],
+    isActive: true,
+    isPublic: true,
+  },
+  {
+    id: 13,
+    kind: 'CHARACTER',
+    name: 'Silent Specialist',
+    description: 'Knows bot managers but has no established voice data.',
+    tags: ['bot', 'manager'],
+    isActive: true,
+    isPublic: true,
+  },
+  {
+    id: 14,
+    kind: 'BOT',
+    name: 'Private Builder',
+    description: 'A private bot builder.',
+    voice: 'Private voice.',
+    tags: ['bot', 'builder'],
+    isActive: true,
+    isPublic: false,
+  },
+  {
+    id: 15,
+    kind: 'CHARACTER',
+    name: 'Retired Engineer',
+    description: 'A retired bot engineer.',
+    voice: 'Tired but exact.',
+    tags: ['bot', 'engineer'],
+    isActive: false,
+    isPublic: true,
+  },
+]
+
+const botManager = {
+  id: 1121,
+  componentName: 'bot-manager',
+  folderName: 'bots',
+  sourcePath: 'components/bots/bot-manager.vue',
+  title: 'Bot Manager',
+  description: 'Build, edit, and organize robot personalities and narrator bots.',
+  tags: ['bot', 'builder', 'narrator'],
+}
+
+const ranking = rankWonderLabReviewers(botManager, candidates, { limit: 6 })
+
+assert.equal(ranking[0]?.reviewer.name, 'DottiB0t')
+assert.ok((ranking[0]?.score || 0) >= 30)
+assert.ok(
+  ranking[0]?.reasons.some((reason) =>
+    reason.startsWith('Dotti bot-building affinity:'),
+  ),
+)
+assert.ok(ranking.some((entry) => entry.reviewer.name === 'Catbot'))
+assert.equal(
+  ranking.some((entry) => entry.reviewer.name === 'Private Builder'),
+  false,
+  'private reviewers should be excluded by default',
+)
+assert.equal(
+  ranking.some((entry) => entry.reviewer.name === 'Retired Engineer'),
+  false,
+  'inactive reviewers should be excluded by default',
+)
+
+const silent = ranking.find(
+  (entry) => entry.reviewer.name === 'Silent Specialist',
+)
+assert.equal(silent?.voiceReady, false)
+assert.ok(silent?.reasons.includes('voice data incomplete'))
+assert.equal(isWonderLabReviewerVoiceReady(candidates[0]!), true)
+assert.equal(isWonderLabReviewerVoiceReady(candidates[3]!), false)
+
+const unrelatedExhibit = {
+  id: 200,
+  componentName: 'rain-effect',
+  folderName: 'screenfx',
+  sourcePath: 'components/screenfx/rain-effect.vue',
+  title: 'Rain Effect',
+}
+
+const ambient = rankWonderLabReviewers(unrelatedExhibit, candidates, {
+  limit: 6,
+})
+assert.equal(ambient[0]?.reviewer.name, 'Catbot')
+assert.deepEqual(ambient[0]?.reasons, ['Catbot broad museum eligibility'])
+
+const dottiKey = wonderLabReviewerKey(candidates[0]!)
+const overridden = rankWonderLabReviewers(botManager, candidates, {
+  limit: 6,
+  overrides: [
+    {
+      reviewerKey: dottiKey,
+      excluded: true,
+      reason: 'Curator reserved Dotti for a later pass.',
+    },
+    {
+      reviewerKey: 'interface-cartographer',
+      boost: 50,
+      reason: 'Curator selected a navigation specialist.',
+    },
+  ],
+})
+
+assert.equal(
+  overridden.some((entry) => entry.reviewer.name === 'DottiB0t'),
+  false,
+)
+assert.equal(overridden[0]?.reviewer.name, 'Interface Cartographer')
+assert.ok(
+  overridden[0]?.reasons.includes(
+    'Curator selected a navigation specialist.',
+  ),
+)
+
+const repeated = rankWonderLabReviewers(botManager, candidates, { limit: 6 })
+assert.deepEqual(
+  ranking.map((entry) => [entry.reviewerKey, entry.score, entry.reasons]),
+  repeated.map((entry) => [entry.reviewerKey, entry.score, entry.reasons]),
+  'reviewer ranking must be deterministic across reruns',
+)
+
+const source = await readFile('utils/wonderlab/reviewerAffinity.ts', 'utf8')
+assert.doesNotMatch(source, /Math\.random|\$fetch|prisma\.|fetch\(/)
+assert.match(source, /Dotti bot-building affinity/)
+assert.match(source, /Catbot broad museum eligibility/)
+assert.match(source, /voice data incomplete/)
+assert.match(source, /curator affinity adjustment/)
+
+console.log('WonderLab reviewer affinity contract passed.')

--- a/utils/wonderlab/reviewerAffinity.ts
+++ b/utils/wonderlab/reviewerAffinity.ts
@@ -1,0 +1,328 @@
+// /utils/wonderlab/reviewerAffinity.ts
+export type WonderLabReviewerKind = 'BOT' | 'CHARACTER'
+
+export type WonderLabReviewerCandidate = {
+  id: number
+  kind: WonderLabReviewerKind
+  name: string
+  slug?: string | null
+  subtitle?: string | null
+  description?: string | null
+  personality?: string | null
+  voice?: string | null
+  sampleResponse?: string | null
+  prompt?: string | null
+  modules?: string | null
+  tags?: string[] | null
+  isActive?: boolean | null
+  isPublic?: boolean | null
+  isMature?: boolean | null
+}
+
+export type WonderLabExhibitProfile = {
+  id: number
+  componentName: string
+  folderName: string
+  sourcePath?: string | null
+  title?: string | null
+  description?: string | null
+  notes?: string | null
+  category?: string | null
+  tags?: string[] | null
+}
+
+export type WonderLabReviewerOverride = {
+  reviewerKey: string
+  excluded?: boolean
+  boost?: number
+  reason?: string
+}
+
+export type WonderLabReviewerAffinity = {
+  reviewer: WonderLabReviewerCandidate
+  reviewerKey: string
+  score: number
+  voiceReady: boolean
+  reasons: string[]
+}
+
+export type RankWonderLabReviewersOptions = {
+  limit?: number
+  includeMature?: boolean
+  includeInactive?: boolean
+  requirePublic?: boolean
+  minimumScore?: number
+  overrides?: WonderLabReviewerOverride[]
+}
+
+const DEFAULT_LIMIT = 6
+const DEFAULT_MINIMUM_SCORE = 1
+
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'component',
+  'components',
+  'for',
+  'from',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'the',
+  'this',
+  'to',
+  'with',
+])
+
+const DOTTI_NAMES = new Set(['dotti', 'dottib0t', 'dottibot'])
+const CATBOT_NAMES = new Set(['catbot', 'cat-bot', 'cat bot'])
+
+const DOTTI_COMPONENT_TERMS = new Set([
+  'agent',
+  'bot',
+  'bots',
+  'builder',
+  'chatbot',
+  'manager',
+  'model',
+  'narrator',
+  'persona',
+  'prompt',
+  'robot',
+  'thread',
+])
+
+function normalize(value: string): string {
+  return value
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function reviewerNameKey(candidate: WonderLabReviewerCandidate): string {
+  return normalize(candidate.slug || candidate.name)
+}
+
+export function wonderLabReviewerKey(
+  candidate: Pick<WonderLabReviewerCandidate, 'id' | 'kind' | 'name' | 'slug'>,
+): string {
+  return `${candidate.kind.toLowerCase()}:${reviewerNameKey(candidate)}:${candidate.id}`
+}
+
+function textParts(values: Array<string | null | undefined>): string {
+  return values.filter((value): value is string => Boolean(value?.trim())).join(' ')
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(
+    normalize(value)
+      .split('-')
+      .filter((token) => token.length > 1 && !STOP_WORDS.has(token)),
+  )
+}
+
+function candidateText(candidate: WonderLabReviewerCandidate): string {
+  return textParts([
+    candidate.name,
+    candidate.slug,
+    candidate.subtitle,
+    candidate.description,
+    candidate.personality,
+    candidate.voice,
+    candidate.sampleResponse,
+    candidate.prompt,
+    candidate.modules,
+    ...(candidate.tags || []),
+  ])
+}
+
+function exhibitText(exhibit: WonderLabExhibitProfile): string {
+  return textParts([
+    exhibit.componentName,
+    exhibit.folderName,
+    exhibit.sourcePath,
+    exhibit.title,
+    exhibit.description,
+    exhibit.notes,
+    exhibit.category,
+    ...(exhibit.tags || []),
+  ])
+}
+
+function overlap(
+  reviewerTokens: Set<string>,
+  exhibitTokens: Set<string>,
+): string[] {
+  return [...reviewerTokens]
+    .filter((token) => exhibitTokens.has(token))
+    .sort((left, right) => left.localeCompare(right, 'en'))
+}
+
+function isDotti(candidate: WonderLabReviewerCandidate): boolean {
+  const normalized = normalize(candidate.name).replace(/-/g, '')
+  const slug = normalize(candidate.slug || '').replace(/-/g, '')
+  return DOTTI_NAMES.has(normalized) || DOTTI_NAMES.has(slug)
+}
+
+function isCatbot(candidate: WonderLabReviewerCandidate): boolean {
+  const normalizedName = normalize(candidate.name)
+  const normalizedSlug = normalize(candidate.slug || '')
+  return CATBOT_NAMES.has(normalizedName) || CATBOT_NAMES.has(normalizedSlug)
+}
+
+export function isWonderLabReviewerVoiceReady(
+  candidate: WonderLabReviewerCandidate,
+): boolean {
+  return Boolean(candidate.voice?.trim() || candidate.sampleResponse?.trim())
+}
+
+function overrideFor(
+  candidate: WonderLabReviewerCandidate,
+  overrides: WonderLabReviewerOverride[],
+): WonderLabReviewerOverride | undefined {
+  const fullKey = wonderLabReviewerKey(candidate)
+  const nameKey = reviewerNameKey(candidate)
+
+  return overrides.find((override) => {
+    const key = normalize(override.reviewerKey)
+    return (
+      override.reviewerKey === fullKey ||
+      key === nameKey ||
+      key === normalize(candidate.name)
+    )
+  })
+}
+
+function specialistScore(
+  candidate: WonderLabReviewerCandidate,
+  exhibit: WonderLabExhibitProfile,
+): { score: number; reasons: string[] } {
+  const reviewerTokens = tokenize(candidateText(candidate))
+  const exhibitTokens = tokenize(exhibitText(exhibit))
+  const shared = overlap(reviewerTokens, exhibitTokens)
+  const reasons: string[] = []
+  let score = 0
+
+  if (shared.length) {
+    const displayed = shared.slice(0, 5)
+    score += displayed.length * 4
+    reasons.push(`shared expertise: ${displayed.join(', ')}`)
+  }
+
+  const folderToken = normalize(exhibit.folderName)
+  if (folderToken && reviewerTokens.has(folderToken)) {
+    score += 5
+    reasons.push(`folder affinity: ${exhibit.folderName}`)
+  }
+
+  return { score, reasons }
+}
+
+function firstPartyRules(
+  candidate: WonderLabReviewerCandidate,
+  exhibit: WonderLabExhibitProfile,
+): { score: number; reasons: string[] } {
+  const exhibitTokens = tokenize(exhibitText(exhibit))
+  const reasons: string[] = []
+  let score = 0
+
+  if (isDotti(candidate)) {
+    const matches = [...DOTTI_COMPONENT_TERMS]
+      .filter((token) => exhibitTokens.has(token))
+      .sort((left, right) => left.localeCompare(right, 'en'))
+
+    if (matches.length) {
+      score += 24 + Math.min(matches.length, 4) * 3
+      reasons.push(`Dotti bot-building affinity: ${matches.slice(0, 4).join(', ')}`)
+    }
+  }
+
+  if (isCatbot(candidate)) {
+    score += 3
+    reasons.push('Catbot broad museum eligibility')
+
+    if (
+      exhibitTokens.has('cat') ||
+      exhibitTokens.has('animal') ||
+      exhibitTokens.has('pet')
+    ) {
+      score += 8
+      reasons.push('Catbot subject affinity')
+    }
+  }
+
+  return { score, reasons }
+}
+
+export function rankWonderLabReviewers(
+  exhibit: WonderLabExhibitProfile,
+  candidates: WonderLabReviewerCandidate[],
+  options: RankWonderLabReviewersOptions = {},
+): WonderLabReviewerAffinity[] {
+  const limit = Math.max(0, Math.floor(options.limit ?? DEFAULT_LIMIT))
+  const minimumScore = options.minimumScore ?? DEFAULT_MINIMUM_SCORE
+  const overrides = options.overrides || []
+
+  return candidates
+    .filter((candidate) => {
+      if (!options.includeInactive && candidate.isActive === false) return false
+      if (!options.includeMature && candidate.isMature === true) return false
+      if (options.requirePublic !== false && candidate.isPublic === false) return false
+      return true
+    })
+    .map((candidate): WonderLabReviewerAffinity | null => {
+      const override = overrideFor(candidate, overrides)
+      if (override?.excluded) return null
+
+      const specialist = specialistScore(candidate, exhibit)
+      const firstParty = firstPartyRules(candidate, exhibit)
+      const reasons = [...firstParty.reasons, ...specialist.reasons]
+      let score = firstParty.score + specialist.score
+
+      if (override?.boost) {
+        score += override.boost
+        reasons.push(
+          override.reason || `curator affinity adjustment: ${override.boost}`,
+        )
+      } else if (override?.reason) {
+        reasons.push(override.reason)
+      }
+
+      const voiceReady = isWonderLabReviewerVoiceReady(candidate)
+      if (!voiceReady) reasons.push('voice data incomplete')
+
+      return {
+        reviewer: candidate,
+        reviewerKey: wonderLabReviewerKey(candidate),
+        score,
+        voiceReady,
+        reasons,
+      }
+    })
+    .filter(
+      (entry): entry is WonderLabReviewerAffinity =>
+        Boolean(entry) && entry.score >= minimumScore,
+    )
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score
+      if (left.reviewer.kind !== right.reviewer.kind) {
+        return left.reviewer.kind.localeCompare(right.reviewer.kind, 'en')
+      }
+      const nameOrder = left.reviewer.name.localeCompare(
+        right.reviewer.name,
+        'en',
+      )
+      return nameOrder || left.reviewer.id - right.reviewer.id
+    })
+    .slice(0, limit)
+}

--- a/utils/wonderlab/reviewerAffinity.ts
+++ b/utils/wonderlab/reviewerAffinity.ts
@@ -311,7 +311,7 @@ export function rankWonderLabReviewers(
     })
     .filter(
       (entry): entry is WonderLabReviewerAffinity =>
-        Boolean(entry) && entry.score >= minimumScore,
+        entry !== null && entry.score >= minimumScore,
     )
     .sort((left, right) => {
       if (right.score !== left.score) return right.score - left.score


### PR DESCRIPTION
## What changed

Adds a pure, deterministic reviewer-affinity foundation for #472.

- defines typed Component exhibit profiles and Bot/Character reviewer candidates;
- ranks reviewers using explainable metadata overlap;
- adds explicit first-party rules:
  - DottiB0t receives strong affinity for bot, narrator, builder, prompt, model, thread, and robot surfaces;
  - Catbot receives low broad museum eligibility plus extra subject affinity for cat/animal/pet exhibits;
- reports the reasons behind every score;
- tracks whether canonical voice/sample-dialogue data is present;
- filters inactive, mature, and private reviewers by default;
- supports curator boosts, reasons, and exclusions;
- uses stable reviewer keys and deterministic tie-breaking;
- never calls an API, database, random source, or generation model.

## Why

The voice prerequisite is complete, but assigning reviewers randomly would still create repetitive or irrelevant commentary. This creates an inspectable selection layer that can later feed the draft/approval workflow after authorship and Component schema migrations land.

## Validation

The DB-free contract covers:

- Dotti ranking first for a bot-manager exhibit;
- Catbot's broad eligibility on an unrelated exhibit;
- specialist metadata overlap;
- voice-ready and incomplete-voice reporting;
- private/inactive reviewer exclusion;
- curator exclusion and boost overrides;
- stable ranking across repeated runs;
- source guards against randomness, network access, or Prisma writes.

No reviews are generated or published by this PR.

Part of #472 and #381.