### PR TITLE
WonderLab: build bounded personality review draft prompts

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -136,6 +136,9 @@ jobs:
       - name: WonderLab reviewer affinity contract
         run: npx tsx utils/scripts/verifyWonderLabReviewerAffinity.ts
 
+      - name: WonderLab review draft prompt contract
+        run: npx tsx utils/scripts/verifyWonderLabReviewDraftPrompt.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/utils/scripts/verifyWonderLabReviewDraftPrompt.ts
+++ b/utils/scripts/verifyWonderLabReviewDraftPrompt.ts
@@ -67,7 +67,7 @@ const threads: WonderLabNarratorThreadExcerpt[] = [
     openingText: 'Kindness needs reliable machinery and a readable control panel.',
   },
   {
-    topicKey: 'overflow-topic',
+    topicKey: 'zz-overflow-topic',
     title: 'This fifth thread should be excluded',
     openingText: 'Do not include this text.',
   },
@@ -95,7 +95,7 @@ assert.match(prompt.user, /components\/bots\/bot-manager\.vue/)
 assert.match(prompt.user, /Dotti bot-building affinity/)
 assert.match(prompt.user, /NARRATOR THREAD VOICE REFERENCES/)
 assert.match(prompt.user, /Do not quote or continue the threads/)
-assert.doesNotMatch(prompt.user, /overflow-topic/)
+assert.doesNotMatch(prompt.user, /zz-overflow-topic/)
 assert.doesNotMatch(prompt.user, /Do not include this text/)
 
 const backgroundIndex = prompt.user.indexOf('Topic: background')

--- a/utils/scripts/verifyWonderLabReviewDraftPrompt.ts
+++ b/utils/scripts/verifyWonderLabReviewDraftPrompt.ts
@@ -1,0 +1,227 @@
+// /utils/scripts/verifyWonderLabReviewDraftPrompt.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  buildWonderLabReviewDraftPrompt,
+  type WonderLabNarratorThreadExcerpt,
+} from '@/utils/wonderlab/reviewDraftPrompt'
+import type {
+  WonderLabExhibitProfile,
+  WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+
+const dotti: WonderLabReviewerCandidate = {
+  id: 410,
+  kind: 'BOT',
+  name: 'DottiB0t',
+  slug: 'dottib0t',
+  subtitle: 'Bot Making Mad Scientist',
+  description: 'Dotti builds robots because robots are future friends.',
+  personality: 'wacky, playful, synergistic, technically curious',
+  voice:
+    'Rapid delighted mad-scientist patter, affectionate toward robots, concrete about construction details.',
+  sampleResponse:
+    'Oho! The friendship sockets align, the personality coils are humming, and this chassis is ready to meet somebody!',
+  modules: 'Bot, Markdown',
+  isActive: true,
+  isPublic: true,
+}
+
+const botManager: WonderLabExhibitProfile = {
+  id: 1121,
+  componentName: 'bot-manager',
+  folderName: 'bots',
+  sourcePath: 'components/bots/bot-manager.vue',
+  title: 'Bot Manager',
+  description:
+    'A manager surface for browsing, selecting, creating, and editing Bot records.',
+  notes:
+    'The museum preview uses an explicit context placard because the full manager depends on authenticated stores and live Bot data.',
+  category: 'manager',
+  tags: ['bot', 'builder', 'narrator'],
+}
+
+const threads: WonderLabNarratorThreadExcerpt[] = [
+  {
+    topicKey: 'purpose',
+    title: 'What Dotti builds',
+    openingText:
+      'Every robot is a possible friend with one tiny assembly problem standing between us and destiny.',
+    guidance: 'Celebrate construction details while noticing practical flaws.',
+  },
+  {
+    topicKey: 'background',
+    title: 'Workshop history',
+    openingText:
+      'The workshop has twelve labeled drawers and forty-seven unlabeled emergencies.',
+    starterPrompts: ['What is on the workbench?', 'Which robot needs help?'],
+  },
+  {
+    topicKey: 'the-world',
+    title: 'Robot society',
+    openingText: 'A good interface is a handshake between future friends.',
+  },
+  {
+    topicKey: 'kind-robots',
+    title: 'Kind Robots',
+    openingText: 'Kindness needs reliable machinery and a readable control panel.',
+  },
+  {
+    topicKey: 'overflow-topic',
+    title: 'This fifth thread should be excluded',
+    openingText: 'Do not include this text.',
+  },
+]
+
+const prompt = buildWonderLabReviewDraftPrompt(dotti, botManager, {
+  affinityReasons: [
+    'Dotti bot-building affinity: bot, builder, manager, narrator',
+    'shared expertise: bot, builder',
+  ],
+  narratorThreads: threads,
+  minimumWords: 50,
+  maximumWords: 100,
+})
+
+assert.match(prompt.system, /Write as DottiB0t/)
+assert.match(prompt.system, /between 50 and 100 words/)
+assert.match(prompt.system, /Never claim that it has been published, tested live/)
+assert.match(prompt.system, /Return JSON/)
+
+assert.match(prompt.user, /Canonical voice: Rapid delighted mad-scientist patter/)
+assert.match(prompt.user, /Sample dialogue: Oho!/)
+assert.match(prompt.user, /Exhibit: Bot Manager/)
+assert.match(prompt.user, /components\/bots\/bot-manager\.vue/)
+assert.match(prompt.user, /Dotti bot-building affinity/)
+assert.match(prompt.user, /NARRATOR THREAD VOICE REFERENCES/)
+assert.match(prompt.user, /Do not quote or continue the threads/)
+assert.doesNotMatch(prompt.user, /overflow-topic/)
+assert.doesNotMatch(prompt.user, /Do not include this text/)
+
+const backgroundIndex = prompt.user.indexOf('Topic: background')
+const kindRobotsIndex = prompt.user.indexOf('Topic: kind-robots')
+const purposeIndex = prompt.user.indexOf('Topic: purpose')
+const worldIndex = prompt.user.indexOf('Topic: the-world')
+assert.ok(backgroundIndex >= 0)
+assert.ok(backgroundIndex < kindRobotsIndex)
+assert.ok(kindRobotsIndex < purposeIndex)
+assert.ok(purposeIndex < worldIndex)
+
+assert.deepEqual(prompt.provenance.voiceSources, [
+  'voice',
+  'sampleResponse',
+  'narratorThreads',
+])
+assert.deepEqual(prompt.provenance.narratorThreadTopics, [
+  'background',
+  'kind-robots',
+  'purpose',
+  'the-world',
+])
+assert.equal(prompt.provenance.reviewerKind, 'BOT')
+assert.equal(prompt.provenance.reviewerId, 410)
+assert.equal(prompt.provenance.exhibitId, 1121)
+assert.equal(
+  prompt.provenance.exhibitSourcePath,
+  'components/bots/bot-manager.vue',
+)
+assert.match(
+  prompt.provenance.draftKey,
+  /^bot:dottib0t:410\|component:1121\|components\/bots\/bot-manager\.vue$/,
+)
+
+assert.deepEqual(prompt.responseSchema.required, [
+  'comment',
+  'rating',
+  'confidence',
+  'observations',
+])
+assert.equal(prompt.responseSchema.properties.rating.minimum, 1)
+assert.equal(prompt.responseSchema.properties.rating.maximum, 5)
+assert.equal(prompt.responseSchema.additionalProperties, false)
+
+const repeated = buildWonderLabReviewDraftPrompt(dotti, botManager, {
+  affinityReasons: [
+    'Dotti bot-building affinity: bot, builder, manager, narrator',
+    'shared expertise: bot, builder',
+  ],
+  narratorThreads: [...threads].reverse(),
+  minimumWords: 50,
+  maximumWords: 100,
+})
+assert.deepEqual(
+  prompt.provenance,
+  repeated.provenance,
+  'draft provenance must remain deterministic when thread input order changes',
+)
+assert.equal(prompt.system, repeated.system)
+assert.equal(prompt.user, repeated.user)
+
+assert.throws(
+  () =>
+    buildWonderLabReviewDraftPrompt(
+      {
+        id: 99,
+        kind: 'CHARACTER',
+        name: 'Unvoiced Reviewer',
+      },
+      botManager,
+    ),
+  /has no canonical voice or sample dialogue/,
+)
+
+const incomplete = buildWonderLabReviewDraftPrompt(
+  {
+    id: 99,
+    kind: 'CHARACTER',
+    name: 'Unvoiced Reviewer',
+  },
+  botManager,
+  { allowIncompleteVoice: true },
+)
+assert.deepEqual(incomplete.provenance.voiceSources, [])
+assert.match(incomplete.user, /Canonical voice: Not provided/)
+assert.match(incomplete.user, /Sample dialogue: Not provided/)
+
+const veryLong = 'z'.repeat(5_000)
+const boundedPrompt = buildWonderLabReviewDraftPrompt(
+  {
+    ...dotti,
+    voice: veryLong,
+    sampleResponse: veryLong,
+  },
+  {
+    ...botManager,
+    description: veryLong,
+    notes: veryLong,
+  },
+  {
+    affinityReasons: Array.from(
+      { length: 20 },
+      (_, index) => `${index}-${veryLong}`,
+    ),
+    narratorThreads: [
+      {
+        topicKey: 'long-thread',
+        openingText: veryLong,
+        guidance: veryLong,
+      },
+    ],
+    minimumWords: 1,
+    maximumWords: 999,
+  },
+)
+assert.match(boundedPrompt.system, /between 20 and 300 words/)
+assert.ok(boundedPrompt.provenance.affinityReasons.length <= 8)
+assert.ok(boundedPrompt.provenance.affinityReasons.every((reason) => reason.length <= 240))
+assert.ok(boundedPrompt.user.length < 10_000)
+assert.match(boundedPrompt.user, /…/)
+
+const source = await readFile('utils/wonderlab/reviewDraftPrompt.ts', 'utf8')
+assert.doesNotMatch(source, /Math\.random|\$fetch|prisma\.|fetch\(|openai|anthropic/i)
+assert.match(source, /draft is for human approval/i)
+assert.match(source, /Do not invent component behavior/)
+assert.match(source, /Do not quote or continue the threads/)
+assert.match(source, /additionalProperties: false/)
+
+console.log('WonderLab review draft prompt contract passed.')

--- a/utils/wonderlab/reviewDraftPrompt.ts
+++ b/utils/wonderlab/reviewDraftPrompt.ts
@@ -1,0 +1,286 @@
+// /utils/wonderlab/reviewDraftPrompt.ts
+import {
+  isWonderLabReviewerVoiceReady,
+  wonderLabReviewerKey,
+  type WonderLabExhibitProfile,
+  type WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+
+export type WonderLabNarratorThreadExcerpt = {
+  topicKey: string
+  title?: string | null
+  openingText?: string | null
+  guidance?: string | null
+  starterPrompts?: string[] | null
+}
+
+export type WonderLabReviewDraftPromptOptions = {
+  affinityReasons?: string[]
+  narratorThreads?: WonderLabNarratorThreadExcerpt[]
+  minimumWords?: number
+  maximumWords?: number
+  allowIncompleteVoice?: boolean
+}
+
+export type WonderLabReviewDraftPrompt = {
+  system: string
+  user: string
+  responseSchema: {
+    type: 'object'
+    required: ['comment', 'rating', 'confidence', 'observations']
+    properties: {
+      comment: { type: 'string' }
+      rating: { type: 'integer'; minimum: 1; maximum: 5 }
+      confidence: { type: 'number'; minimum: 0; maximum: 1 }
+      observations: {
+        type: 'array'
+        minItems: 1
+        maxItems: 3
+        items: { type: 'string' }
+      }
+    }
+    additionalProperties: false
+  }
+  provenance: {
+    draftKey: string
+    reviewerKey: string
+    reviewerKind: WonderLabReviewerCandidate['kind']
+    reviewerId: number
+    exhibitId: number
+    exhibitSourcePath: string
+    affinityReasons: string[]
+    narratorThreadTopics: string[]
+    voiceSources: Array<'voice' | 'sampleResponse' | 'narratorThreads'>
+  }
+}
+
+const DEFAULT_MINIMUM_WORDS = 45
+const DEFAULT_MAXIMUM_WORDS = 110
+const MAX_EXHIBIT_FIELD_LENGTH = 900
+const MAX_REVIEWER_FIELD_LENGTH = 1_200
+const MAX_SAMPLE_LENGTH = 700
+const MAX_THREAD_COUNT = 4
+const MAX_THREAD_FIELD_LENGTH = 700
+const MAX_AFFINITY_REASONS = 8
+const MAX_AFFINITY_REASON_LENGTH = 240
+
+function compact(value: string | null | undefined): string {
+  return (value || '').replace(/\s+/g, ' ').trim()
+}
+
+function bounded(
+  value: string | null | undefined,
+  maximumLength: number,
+): string {
+  const normalized = compact(value)
+  if (normalized.length <= maximumLength) return normalized
+  return `${normalized.slice(0, Math.max(0, maximumLength - 1)).trimEnd()}…`
+}
+
+function normalizedWordRange(
+  minimumWords: number | undefined,
+  maximumWords: number | undefined,
+): { minimumWords: number; maximumWords: number } {
+  const minimum = Math.max(
+    20,
+    Math.min(250, Math.floor(minimumWords ?? DEFAULT_MINIMUM_WORDS)),
+  )
+  const maximum = Math.max(
+    minimum,
+    Math.min(300, Math.floor(maximumWords ?? DEFAULT_MAXIMUM_WORDS)),
+  )
+
+  return { minimumWords: minimum, maximumWords: maximum }
+}
+
+function reviewerIdentity(candidate: WonderLabReviewerCandidate): string {
+  const subtitle = bounded(candidate.subtitle, 200)
+  return subtitle ? `${candidate.name} — ${subtitle}` : candidate.name
+}
+
+function exhibitIdentity(exhibit: WonderLabExhibitProfile): string {
+  return (
+    bounded(exhibit.title, 240) ||
+    bounded(exhibit.componentName, 240) ||
+    `Component #${exhibit.id}`
+  )
+}
+
+function exhibitSourcePath(exhibit: WonderLabExhibitProfile): string {
+  return bounded(
+    exhibit.sourcePath ||
+      `components/${exhibit.folderName}/${exhibit.componentName}.vue`,
+    500,
+  )
+}
+
+function sortedThreads(
+  threads: WonderLabNarratorThreadExcerpt[],
+): WonderLabNarratorThreadExcerpt[] {
+  return [...threads]
+    .filter((thread) => Boolean(compact(thread.topicKey)))
+    .sort((left, right) => {
+      const topicOrder = compact(left.topicKey).localeCompare(
+        compact(right.topicKey),
+        'en',
+      )
+      if (topicOrder) return topicOrder
+      return compact(left.title).localeCompare(compact(right.title), 'en')
+    })
+    .slice(0, MAX_THREAD_COUNT)
+}
+
+function threadBlock(thread: WonderLabNarratorThreadExcerpt): string {
+  const lines = [`Topic: ${bounded(thread.topicKey, 180)}`]
+  const title = bounded(thread.title, 240)
+  const opening = bounded(thread.openingText, MAX_THREAD_FIELD_LENGTH)
+  const guidance = bounded(thread.guidance, MAX_THREAD_FIELD_LENGTH)
+  const starters = (thread.starterPrompts || [])
+    .map((prompt) => bounded(prompt, 240))
+    .filter(Boolean)
+    .slice(0, 3)
+
+  if (title) lines.push(`Title: ${title}`)
+  if (opening) lines.push(`Opening voice sample: ${opening}`)
+  if (guidance) lines.push(`Guidance: ${guidance}`)
+  if (starters.length) lines.push(`Starter phrasing: ${starters.join(' | ')}`)
+
+  return lines.join('\n')
+}
+
+function affinityReasons(reasons: string[]): string[] {
+  return reasons
+    .map((reason) => bounded(reason, MAX_AFFINITY_REASON_LENGTH))
+    .filter(Boolean)
+    .slice(0, MAX_AFFINITY_REASONS)
+}
+
+function voiceSources(
+  reviewer: WonderLabReviewerCandidate,
+  threads: WonderLabNarratorThreadExcerpt[],
+): Array<'voice' | 'sampleResponse' | 'narratorThreads'> {
+  const sources: Array<'voice' | 'sampleResponse' | 'narratorThreads'> = []
+  if (compact(reviewer.voice)) sources.push('voice')
+  if (compact(reviewer.sampleResponse)) sources.push('sampleResponse')
+  if (threads.length) sources.push('narratorThreads')
+  return sources
+}
+
+export function buildWonderLabReviewDraftPrompt(
+  reviewer: WonderLabReviewerCandidate,
+  exhibit: WonderLabExhibitProfile,
+  options: WonderLabReviewDraftPromptOptions = {},
+): WonderLabReviewDraftPrompt {
+  if (!options.allowIncompleteVoice && !isWonderLabReviewerVoiceReady(reviewer)) {
+    throw new Error(
+      `Reviewer ${reviewer.name} has no canonical voice or sample dialogue.`,
+    )
+  }
+
+  const range = normalizedWordRange(
+    options.minimumWords,
+    options.maximumWords,
+  )
+  const threads = sortedThreads(options.narratorThreads || [])
+  const reasons = affinityReasons(options.affinityReasons || [])
+  const reviewerKey = wonderLabReviewerKey(reviewer)
+  const sourcePath = exhibitSourcePath(exhibit)
+  const sources = voiceSources(reviewer, threads)
+  const draftKey = `${reviewerKey}|component:${exhibit.id}|${sourcePath.toLowerCase()}`
+
+  const reviewerContext = [
+    `Identity: ${reviewerIdentity(reviewer)}`,
+    `Kind: ${reviewer.kind}`,
+    `Description: ${bounded(reviewer.description, MAX_REVIEWER_FIELD_LENGTH) || 'Not provided'}`,
+    `Personality: ${bounded(reviewer.personality, MAX_REVIEWER_FIELD_LENGTH) || 'Not provided'}`,
+    `Canonical voice: ${bounded(reviewer.voice, MAX_REVIEWER_FIELD_LENGTH) || 'Not provided'}`,
+    `Sample dialogue: ${bounded(reviewer.sampleResponse, MAX_SAMPLE_LENGTH) || 'Not provided'}`,
+  ]
+
+  const exhibitContext = [
+    `Exhibit: ${exhibitIdentity(exhibit)}`,
+    `Component name: ${bounded(exhibit.componentName, 240)}`,
+    `Folder: ${bounded(exhibit.folderName, 240)}`,
+    `Source path: ${sourcePath}`,
+    `Description: ${bounded(exhibit.description, MAX_EXHIBIT_FIELD_LENGTH) || 'Not provided'}`,
+    `Curator notes: ${bounded(exhibit.notes, MAX_EXHIBIT_FIELD_LENGTH) || 'Not provided'}`,
+    `Category: ${bounded(exhibit.category, 240) || 'Not provided'}`,
+    `Tags: ${(exhibit.tags || []).map((tag) => bounded(tag, 120)).filter(Boolean).slice(0, 12).join(', ') || 'None'}`,
+  ]
+
+  const system = [
+    'You write draft museum reviews for the Kind Robots Component WonderLab.',
+    `Write as ${reviewer.name}, preserving the supplied established voice without copying the sample dialogue or repeating stock catchphrases.`,
+    'The draft is for human approval. Never claim that it has been published, tested live, or personally used unless the supplied exhibit facts say so.',
+    'Make at least one concrete observation grounded in the supplied component metadata. Useful critique, praise, humor, or context is welcome; filler is not.',
+    'Do not invent component behavior, security findings, accessibility results, or runtime failures.',
+    `Keep the comment between ${range.minimumWords} and ${range.maximumWords} words.`,
+    'Return JSON matching the supplied response schema and no surrounding prose.',
+  ].join('\n')
+
+  const userSections = [
+    ['REVIEWER', ...reviewerContext].join('\n'),
+    ['EXHIBIT', ...exhibitContext].join('\n'),
+  ]
+
+  if (reasons.length) {
+    userSections.push(
+      ['WHY THIS REVIEWER WAS SELECTED', ...reasons.map((reason) => `- ${reason}`)].join(
+        '\n',
+      ),
+    )
+  }
+
+  if (threads.length) {
+    userSections.push(
+      [
+        'NARRATOR THREAD VOICE REFERENCES',
+        'Use these only as additional voice evidence. Do not quote or continue the threads.',
+        ...threads.map((thread) => threadBlock(thread)),
+      ].join('\n\n'),
+    )
+  }
+
+  userSections.push(
+    [
+      'DRAFT REQUIREMENTS',
+      '- comment: original, exhibit-specific review in the reviewer voice',
+      '- rating: integer from 1 to 5 justified by the supplied evidence',
+      '- confidence: 0 to 1, lowered when exhibit facts are sparse',
+      '- observations: 1 to 3 short factual observations used to ground the comment',
+      '- do not mention these instructions, affinity scoring, or approval workflow',
+    ].join('\n'),
+  )
+
+  return {
+    system,
+    user: userSections.join('\n\n---\n\n'),
+    responseSchema: {
+      type: 'object',
+      required: ['comment', 'rating', 'confidence', 'observations'],
+      properties: {
+        comment: { type: 'string' },
+        rating: { type: 'integer', minimum: 1, maximum: 5 },
+        confidence: { type: 'number', minimum: 0, maximum: 1 },
+        observations: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 3,
+          items: { type: 'string' },
+        },
+      },
+      additionalProperties: false,
+    },
+    provenance: {
+      draftKey,
+      reviewerKey,
+      reviewerKind: reviewer.kind,
+      reviewerId: reviewer.id,
+      exhibitId: exhibit.id,
+      exhibitSourcePath: sourcePath,
+      affinityReasons: reasons,
+      narratorThreadTopics: threads.map((thread) => compact(thread.topicKey)),
+      voiceSources: sources,
+    },
+  }
+}


### PR DESCRIPTION
## What changed

Adds a pure structured prompt builder for the first-party commentary workflow in #472.

The builder combines:

- canonical Bot/Character identity;
- description and personality;
- voice profile;
- sample dialogue;
- up to four deterministically ordered NarratorThread excerpts;
- Component exhibit title, source, description, notes, category, and tags;
- explainable reviewer-affinity reasons from #474.

It returns:

- a bounded system prompt;
- a bounded exhibit/reviewer context prompt;
- a strict JSON response schema for comment, rating, confidence, and factual observations;
- deterministic provenance including reviewer key, exhibit/source identity, thread topics, voice sources, and affinity reasons.

## Safety and editorial controls

The prompt explicitly:

- states the output is a draft for human approval;
- prohibits claiming publication, live testing, or personal use without supplied evidence;
- requires at least one concrete metadata-grounded observation;
- prohibits invented behavior, security findings, accessibility results, or runtime failures;
- uses sample dialogue and NarratorThreads only as voice evidence, not text to quote or continue;
- requires original exhibit-specific commentary;
- performs no model call, API call, database access, draft storage, or Reaction publishing.

Reviewers without canonical voice/sample dialogue are rejected unless an explicit incomplete-voice option is used for diagnostics.

## Validation

The DB-free contract covers:

- Dotti voice, sample dialogue, and four canonical thread excerpts;
- deterministic thread ordering and cap behavior;
- exhibit/source/affinity grounding;
- structured response schema;
- deterministic draft keys and provenance across reruns;
- missing-voice rejection and diagnostic override;
- word-range normalization and input truncation;
- prompt-size bounds;
- source guards against randomness, model providers, network calls, or Prisma access.

No reviews are generated or published by this PR.

Part of #472 and #381.