### PR TITLE
Component: add canonical status and source metadata columns

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -139,6 +139,9 @@ jobs:
       - name: WonderLab review draft prompt contract
         run: npx tsx utils/scripts/verifyWonderLabReviewDraftPrompt.ts
 
+      - name: Component canonical expand migration contract
+        run: npx tsx utils/scripts/verifyComponentCanonicalExpand.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/prisma/migrations/20260718234000_component_canonical_expand/migration.sql
+++ b/prisma/migrations/20260718234000_component_canonical_expand/migration.sql
@@ -1,0 +1,43 @@
+-- Expand Component with canonical WonderLab status and source metadata.
+-- This is intentionally additive: legacy status booleans and componentName
+-- uniqueness remain in place until every runtime caller has migrated.
+
+ALTER TABLE `Component`
+  ADD COLUMN `slug` VARCHAR(255) NULL,
+  ADD COLUMN `sourcePath` VARCHAR(764) NULL,
+  ADD COLUMN `sourceKey` VARCHAR(764) NULL,
+  ADD COLUMN `sourceHash` VARCHAR(64) NULL,
+  ADD COLUMN `status` ENUM(
+    'UNREVIEWED',
+    'WORKING',
+    'NEEDS_CONTEXT',
+    'UNDER_CONSTRUCTION',
+    'BROKEN',
+    'RETIRED',
+    'PREVIEW_UNSUPPORTED'
+  ) NOT NULL DEFAULT 'UNREVIEWED',
+  ADD COLUMN `statusReason` TEXT NULL,
+  ADD COLUMN `description` TEXT NULL,
+  ADD COLUMN `category` VARCHAR(255) NULL,
+  ADD COLUMN `tags` JSON NULL,
+  ADD COLUMN `previewMode` VARCHAR(64) NULL,
+  ADD COLUMN `previewConfig` JSON NULL,
+  ADD COLUMN `lastSeenAt` DATETIME(3) NULL,
+  ADD COLUMN `isDiscovered` BOOLEAN NOT NULL DEFAULT false;
+
+-- Deterministic compatibility backfill. Contradictory legacy rows follow the
+-- documented precedence: broken > under construction > working > unreviewed.
+UPDATE `Component`
+SET `status` = CASE
+  WHEN `isBroken` = true THEN 'BROKEN'
+  WHEN `underConstruction` = true THEN 'UNDER_CONSTRUCTION'
+  WHEN `isWorking` = true THEN 'WORKING'
+  ELSE 'UNREVIEWED'
+END;
+
+CREATE UNIQUE INDEX `Component_slug_key` ON `Component`(`slug`);
+CREATE UNIQUE INDEX `Component_sourceKey_key` ON `Component`(`sourceKey`);
+CREATE INDEX `Component_status_idx` ON `Component`(`status`);
+CREATE INDEX `Component_sourcePath_idx` ON `Component`(`sourcePath`);
+CREATE INDEX `Component_lastSeenAt_idx` ON `Component`(`lastSeenAt`);
+CREATE INDEX `Component_isDiscovered_idx` ON `Component`(`isDiscovered`);

--- a/utils/scripts/verifyComponentCanonicalExpand.ts
+++ b/utils/scripts/verifyComponentCanonicalExpand.ts
@@ -1,0 +1,81 @@
+// /utils/scripts/verifyComponentCanonicalExpand.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const migrationPath =
+  'prisma/migrations/20260718234000_component_canonical_expand/migration.sql'
+const sql = await readFile(migrationPath, 'utf8')
+
+const expectedStatuses = [
+  'UNREVIEWED',
+  'WORKING',
+  'NEEDS_CONTEXT',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+  'RETIRED',
+  'PREVIEW_UNSUPPORTED',
+]
+
+for (const status of expectedStatuses) {
+  assert.match(sql, new RegExp(`'${status}'`), `missing ${status} enum value`)
+}
+
+for (const column of [
+  'slug',
+  'sourcePath',
+  'sourceKey',
+  'sourceHash',
+  'status',
+  'statusReason',
+  'description',
+  'category',
+  'tags',
+  'previewMode',
+  'previewConfig',
+  'lastSeenAt',
+  'isDiscovered',
+]) {
+  assert.match(sql, new RegExp(`ADD COLUMN \\`${column}\\``))
+}
+
+assert.match(sql, /`status`[\s\S]*NOT NULL DEFAULT 'UNREVIEWED'/)
+assert.match(sql, /`isDiscovered` BOOLEAN NOT NULL DEFAULT false/)
+assert.match(sql, /`tags` JSON NULL/)
+assert.match(sql, /`previewConfig` JSON NULL/)
+
+const broken = sql.indexOf("WHEN `isBroken` = true THEN 'BROKEN'")
+const building = sql.indexOf(
+  "WHEN `underConstruction` = true THEN 'UNDER_CONSTRUCTION'",
+)
+const working = sql.indexOf("WHEN `isWorking` = true THEN 'WORKING'")
+const unreviewed = sql.indexOf("ELSE 'UNREVIEWED'")
+
+assert.ok(broken >= 0, 'broken precedence is required')
+assert.ok(broken < building, 'broken must outrank under construction')
+assert.ok(building < working, 'under construction must outrank working')
+assert.ok(working < unreviewed, 'working must outrank unreviewed')
+
+for (const indexName of [
+  'Component_slug_key',
+  'Component_sourceKey_key',
+  'Component_status_idx',
+  'Component_sourcePath_idx',
+  'Component_lastSeenAt_idx',
+  'Component_isDiscovered_idx',
+]) {
+  assert.match(sql, new RegExp(`\\`${indexName}\\``))
+}
+
+assert.doesNotMatch(sql, /\bDELETE\s+FROM\s+`?Component`?/i)
+assert.doesNotMatch(sql, /\bDROP\s+(?:COLUMN|TABLE|INDEX)\b/i)
+assert.doesNotMatch(sql, /ALTER\s+COLUMN\s+`?(?:isWorking|underConstruction|isBroken)`?/i)
+assert.doesNotMatch(sql, /DROP\s+INDEX\s+`?Component_componentName_key`?/i)
+
+const alterIndex = sql.indexOf('ALTER TABLE `Component`')
+const updateIndex = sql.indexOf('UPDATE `Component`')
+const uniqueIndex = sql.indexOf('CREATE UNIQUE INDEX `Component_slug_key`')
+
+assert.ok(alterIndex >= 0 && alterIndex < updateIndex)
+assert.ok(updateIndex < uniqueIndex, 'backfill must precede new indexes')
+
+console.log('Component canonical expand migration contract passed.')

--- a/utils/scripts/verifyComponentCanonicalExpand.ts
+++ b/utils/scripts/verifyComponentCanonicalExpand.ts
@@ -35,7 +35,7 @@ for (const column of [
   'lastSeenAt',
   'isDiscovered',
 ]) {
-  assert.match(sql, new RegExp(`ADD COLUMN \\`${column}\\``))
+  assert.match(sql, new RegExp('ADD COLUMN `' + column + '`'))
 }
 
 assert.match(sql, /`status`[\s\S]*NOT NULL DEFAULT 'UNREVIEWED'/)
@@ -63,12 +63,15 @@ for (const indexName of [
   'Component_lastSeenAt_idx',
   'Component_isDiscovered_idx',
 ]) {
-  assert.match(sql, new RegExp(`\\`${indexName}\\``))
+  assert.match(sql, new RegExp('`' + indexName + '`'))
 }
 
 assert.doesNotMatch(sql, /\bDELETE\s+FROM\s+`?Component`?/i)
 assert.doesNotMatch(sql, /\bDROP\s+(?:COLUMN|TABLE|INDEX)\b/i)
-assert.doesNotMatch(sql, /ALTER\s+COLUMN\s+`?(?:isWorking|underConstruction|isBroken)`?/i)
+assert.doesNotMatch(
+  sql,
+  /ALTER\s+COLUMN\s+`?(?:isWorking|underConstruction|isBroken)`?/i,
+)
 assert.doesNotMatch(sql, /DROP\s+INDEX\s+`?Component_componentName_key`?/i)
 
 const alterIndex = sql.indexOf('ALTER TABLE `Component`')


### PR DESCRIPTION
## What changed

Adds the additive database expansion stage for #473.

- adds canonical Component status values:
  - `UNREVIEWED`
  - `WORKING`
  - `NEEDS_CONTEXT`
  - `UNDER_CONSTRUCTION`
  - `BROKEN`
  - `RETIRED`
  - `PREVIEW_UNSUPPORTED`
- adds nullable source/exhibit metadata:
  - `slug`
  - `sourcePath`
  - `sourceKey`
  - `sourceHash`
  - `statusReason`
  - `description`
  - `category`
  - `tags`
  - `previewMode`
  - `previewConfig`
  - `lastSeenAt`
- adds `isDiscovered` with a conservative default of `false`;
- defaults canonical status to `UNREVIEWED`;
- deterministically backfills existing rows with precedence:
  1. broken
  2. under construction
  3. working
  4. unreviewed
- adds unique indexes for nullable `slug` and `sourceKey` plus lookup indexes for status/discovery/source activity.

## Compatibility strategy

This PR intentionally changes only the database migration layer.

It does **not**:

- remove or alter `isWorking`, `underConstruction`, or `isBroken`;
- remove `componentName` uniqueness;
- update Prisma runtime types yet;
- change Component API behavior;
- reconcile source metadata;
- delete Component rows or Reactions.

That separation lets the production database safely expand before runtime callers adopt the new fields. The next staged PR will update `schema.prisma`, generated types, status adapters, and reconciliation while retaining the legacy compatibility fields.

## Validation

Adds a DB-free migration contract that verifies:

- all seven enum values and all expected columns exist;
- status and discovery defaults are conservative;
- JSON columns are typed as JSON;
- backfill precedence is ordered correctly;
- expected unique and lookup indexes exist;
- no Component delete, column/table/index drop, legacy boolean alteration, or `componentName` uniqueness removal is present;
- the backfill occurs after expansion and before index creation.

Part of #473 and #381.