### PR TITLE
Component: add canonical status compatibility adapter

### DIFF
--- a/utils/scripts/verifyWonderLabStatus.ts
+++ b/utils/scripts/verifyWonderLabStatus.ts
@@ -1,11 +1,27 @@
 // /utils/scripts/verifyWonderLabStatus.ts
 import assert from 'node:assert/strict'
 import {
+  componentStatuses,
+  getComponentStatus,
   getLegacyComponentStatus,
   hasLegacyStatusUpdate,
+  isComponentStatus,
   legacyFieldsForComponentStatus,
   resolveLegacyStatusUpdate,
 } from '@/utils/wonderlab/componentStatus'
+
+assert.deepEqual(componentStatuses, [
+  'UNREVIEWED',
+  'WORKING',
+  'NEEDS_CONTEXT',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+  'RETIRED',
+  'PREVIEW_UNSUPPORTED',
+])
+
+assert.equal(isComponentStatus('RETIRED'), true)
+assert.equal(isComponentStatus('not-real'), false)
 
 assert.equal(
   getLegacyComponentStatus({
@@ -17,7 +33,37 @@ assert.equal(
   'Legacy contradictions must resolve deterministically.',
 )
 
+assert.equal(
+  getComponentStatus({
+    status: 'NEEDS_CONTEXT',
+    isWorking: true,
+    isBroken: true,
+  }),
+  'NEEDS_CONTEXT',
+  'Canonical status must outrank contradictory compatibility booleans.',
+)
+
+assert.equal(
+  getComponentStatus({
+    status: 'invalid-status',
+    isWorking: false,
+    underConstruction: true,
+  }),
+  'UNDER_CONSTRUCTION',
+  'Invalid canonical input must fall back to deterministic legacy fields.',
+)
+
 assert.deepEqual(legacyFieldsForComponentStatus('UNREVIEWED'), {
+  isWorking: false,
+  underConstruction: false,
+  isBroken: false,
+})
+assert.deepEqual(legacyFieldsForComponentStatus('NEEDS_CONTEXT'), {
+  isWorking: false,
+  underConstruction: false,
+  isBroken: false,
+})
+assert.deepEqual(legacyFieldsForComponentStatus('RETIRED'), {
   isWorking: false,
   underConstruction: false,
   isBroken: false,

--- a/utils/wonderlab/componentStatus.ts
+++ b/utils/wonderlab/componentStatus.ts
@@ -1,9 +1,19 @@
 // /utils/wonderlab/componentStatus.ts
-export type LegacyComponentStatus =
-  | 'UNREVIEWED'
-  | 'WORKING'
-  | 'UNDER_CONSTRUCTION'
-  | 'BROKEN'
+export const componentStatuses = [
+  'UNREVIEWED',
+  'WORKING',
+  'NEEDS_CONTEXT',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+  'RETIRED',
+  'PREVIEW_UNSUPPORTED',
+] as const
+
+export type ComponentStatus = (typeof componentStatuses)[number]
+export type LegacyComponentStatus = Extract<
+  ComponentStatus,
+  'UNREVIEWED' | 'WORKING' | 'UNDER_CONSTRUCTION' | 'BROKEN'
+>
 
 export type LegacyComponentStatusFields = {
   isWorking?: boolean | null
@@ -11,10 +21,21 @@ export type LegacyComponentStatusFields = {
   isBroken?: boolean | null
 }
 
+export type ComponentStatusFields = LegacyComponentStatusFields & {
+  status?: ComponentStatus | string | null
+}
+
 export type CanonicalLegacyStatusFields = {
   isWorking: boolean
   underConstruction: boolean
   isBroken: boolean
+}
+
+export function isComponentStatus(value: unknown): value is ComponentStatus {
+  return (
+    typeof value === 'string' &&
+    componentStatuses.includes(value as ComponentStatus)
+  )
 }
 
 export function getLegacyComponentStatus(
@@ -26,8 +47,15 @@ export function getLegacyComponentStatus(
   return 'UNREVIEWED'
 }
 
+export function getComponentStatus(
+  component: ComponentStatusFields,
+): ComponentStatus {
+  if (isComponentStatus(component.status)) return component.status
+  return getLegacyComponentStatus(component)
+}
+
 export function legacyFieldsForComponentStatus(
-  status: LegacyComponentStatus,
+  status: ComponentStatus,
 ): CanonicalLegacyStatusFields {
   return {
     isWorking: status === 'WORKING',
@@ -50,8 +78,6 @@ export function resolveLegacyStatusUpdate(
   existing: LegacyComponentStatusFields,
   patch: LegacyComponentStatusFields,
 ): CanonicalLegacyStatusFields {
-  // A newly enabled state is an explicit selection and should replace the old
-  // state even when callers send only one boolean field.
   if (patch.isBroken === true) {
     return legacyFieldsForComponentStatus('BROKEN')
   }
@@ -62,8 +88,6 @@ export function resolveLegacyStatusUpdate(
     return legacyFieldsForComponentStatus('WORKING')
   }
 
-  // False-only patches clear the supplied flags and preserve any other
-  // existing state. The result is normalized before it reaches Prisma.
   return legacyFieldsForComponentStatus(
     getLegacyComponentStatus({
       isWorking:


### PR DESCRIPTION
## What changed

Adds the runtime-independent compatibility layer for #473.

- defines the complete seven-value `ComponentStatus` contract;
- exports a stable ordered status list and runtime validator;
- adds `getComponentStatus()`:
  - prefers a valid canonical `status` value;
  - falls back to deterministic legacy boolean precedence when status is absent or invalid;
- preserves the existing legacy helper API for current callers;
- expands legacy-field derivation to accept every canonical status;
- maps `NEEDS_CONTEXT`, `RETIRED`, and `PREVIEW_UNSUPPORTED` to all-false legacy booleans because the old schema cannot represent them truthfully;
- does not write the new Prisma column or change any API/store/UI caller yet.

## Validation

Extends the existing WonderLab status contract to verify:

- the exact seven canonical values;
- runtime validation;
- canonical status outranking contradictory legacy booleans;
- invalid canonical input falling back safely;
- deterministic legacy contradiction precedence;
- extended statuses never masquerading as working/building/broken;
- existing partial legacy update behavior remains unchanged.

This is the compatibility adapter between the database expansion in #477 and the upcoming Prisma/API reconciliation stage.

Part of #473 and #381.