### PR TITLE
WonderLab: show canonical registry identity coverage

### DIFF
--- a/components/wonderlab/component-registry-health.vue
+++ b/components/wonderlab/component-registry-health.vue
@@ -10,7 +10,7 @@
         </p>
         <h2 class="mt-1 text-xl font-black">Manifest ↔ database coverage</h2>
         <p class="mt-1 max-w-3xl text-sm leading-relaxed text-base-content/60">
-          Read-only comparison of discovered Vue source files and existing
+          Read-only comparison of canonical Vue source identity and existing
           Component records. Reconciliation remains an explicit admin action.
         </p>
       </div>
@@ -35,11 +35,11 @@
     </div>
 
     <div v-else-if="loading && !health" class="mt-4 grid gap-3 sm:grid-cols-3">
-      <div v-for="index in 6" :key="index" class="skeleton h-20 rounded-2xl" />
+      <div v-for="index in 9" :key="index" class="skeleton h-20 rounded-2xl" />
     </div>
 
     <template v-else-if="health">
-      <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+      <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         <div class="rounded-2xl border border-base-300 bg-base-200/60 p-3">
           <p class="text-xs font-black uppercase text-base-content/45">Source files</p>
           <p class="mt-1 text-2xl font-black">{{ health.manifestCount }}</p>
@@ -53,6 +53,45 @@
           <p class="mt-1 text-2xl font-black text-success">
             {{ health.matchedRecordCount }}
           </p>
+        </div>
+        <div
+          class="rounded-2xl border p-3"
+          :class="
+            health.canonicalMatchCount === health.matchedRecordCount
+              ? 'border-success/30 bg-success/10'
+              : 'border-info/35 bg-info/10'
+          "
+        >
+          <p class="text-xs font-black uppercase text-base-content/55">
+            Canonical identity
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ health.canonicalMatchCount }}</p>
+        </div>
+        <div
+          class="rounded-2xl border p-3"
+          :class="
+            health.legacyFallbackCount
+              ? 'border-warning/35 bg-warning/10'
+              : 'border-success/30 bg-success/10'
+          "
+        >
+          <p class="text-xs font-black uppercase text-base-content/55">
+            Legacy fallback
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ health.legacyFallbackCount }}</p>
+        </div>
+        <div
+          class="rounded-2xl border p-3"
+          :class="
+            health.undiscoveredRecordCount
+              ? 'border-warning/35 bg-warning/10'
+              : 'border-success/30 bg-success/10'
+          "
+        >
+          <p class="text-xs font-black uppercase text-base-content/55">
+            Not discovered
+          </p>
+          <p class="mt-1 text-2xl font-black">{{ health.undiscoveredRecordCount }}</p>
         </div>
         <div
           class="rounded-2xl border p-3"
@@ -96,14 +135,19 @@
       </div>
 
       <details
-        v-if="health.staleRecordCount || health.missingRecordCount || health.duplicateNameCount"
+        v-if="
+          health.staleRecordCount ||
+          health.missingRecordCount ||
+          health.legacyFallbackCount ||
+          health.duplicateNameCount
+        "
         class="mt-4 rounded-2xl border border-base-300 bg-base-200/40 p-3"
       >
         <summary class="cursor-pointer font-black text-base-content/80">
           Review registry differences
         </summary>
 
-        <div class="mt-3 grid gap-4 lg:grid-cols-3">
+        <div class="mt-3 grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
           <section>
             <h3 class="text-sm font-black text-warning">
               Database-only records
@@ -145,9 +189,28 @@
           </section>
 
           <section>
+            <h3 class="text-sm font-black text-warning">Legacy fallback matches</h3>
+            <p class="mt-1 text-xs text-base-content/55">
+              Matched by folder/name because canonical source identity is not populated yet.
+            </p>
+            <ul class="mt-2 space-y-1 text-xs">
+              <li
+                v-for="record in health.legacyFallbackRecords.slice(0, detailLimit)"
+                :key="record.id"
+                class="break-all rounded-lg bg-base-100 px-2 py-1.5 font-mono"
+              >
+                #{{ record.id }} · {{ record.folderName }}/{{ record.componentName }}
+              </li>
+              <li v-if="health.legacyFallbackCount > detailLimit" class="text-base-content/50">
+                +{{ health.legacyFallbackCount - detailLimit }} more
+              </li>
+            </ul>
+          </section>
+
+          <section>
             <h3 class="text-sm font-black text-secondary">Duplicate names</h3>
             <p class="mt-1 text-xs text-base-content/55">
-              Valid when folder context is available; ambiguous for name-only links.
+              Valid by source identity, but still blocked by legacy global name uniqueness.
             </p>
             <div class="mt-2 flex flex-wrap gap-1.5">
               <span
@@ -223,6 +286,13 @@ function readComponentRecords(payload: unknown): WonderLabRegistryRecord[] {
         id: candidate.id as number,
         componentName: candidate.componentName,
         folderName: candidate.folderName,
+        sourceKey:
+          typeof candidate.sourceKey === 'string' ? candidate.sourceKey : null,
+        sourcePath:
+          typeof candidate.sourcePath === 'string' ? candidate.sourcePath : null,
+        sourceHash:
+          typeof candidate.sourceHash === 'string' ? candidate.sourceHash : null,
+        isDiscovered: candidate.isDiscovered === true,
       },
     ]
   })

--- a/utils/scripts/verifyWonderLabRegistryHealth.ts
+++ b/utils/scripts/verifyWonderLabRegistryHealth.ts
@@ -50,23 +50,58 @@ const manifest: WonderLabComponentManifest = {
 }
 
 const health = summarizeWonderLabRegistry(manifest.entries, [
-  { id: 1, componentName: 'foo-card', folderName: 'alpha' },
-  { id: 2, componentName: 'duplicate-card', folderName: 'x' },
-  { id: 3, componentName: 'retired-widget', folderName: 'legacy' },
+  {
+    id: 1,
+    componentName: 'outdated-display-name',
+    folderName: 'old-alpha',
+    sourceKey: 'COMPONENTS/ALPHA/FOO-CARD.VUE',
+    sourcePath: 'components/old-alpha/foo-card.vue',
+    sourceHash: 'a'.repeat(64),
+    isDiscovered: true,
+  },
+  {
+    id: 2,
+    componentName: 'duplicate-card',
+    folderName: 'x',
+    sourceKey: null,
+    sourcePath: null,
+    sourceHash: null,
+    isDiscovered: false,
+  },
+  {
+    id: 3,
+    componentName: 'retired-widget',
+    folderName: 'legacy',
+    sourceKey: 'components/legacy/retired-widget.vue',
+    sourcePath: 'components/legacy/retired-widget.vue',
+    sourceHash: 'z'.repeat(64),
+    isDiscovered: false,
+  },
 ])
 
 assert.equal(health.manifestCount, 4)
 assert.equal(health.recordCount, 3)
 assert.equal(health.matchedRecordCount, 2)
+assert.equal(health.canonicalMatchCount, 1)
+assert.equal(health.legacyFallbackCount, 1)
+assert.equal(health.undiscoveredRecordCount, 2)
 assert.equal(health.staleRecordCount, 1)
 assert.equal(health.missingRecordCount, 2)
 assert.equal(health.duplicateNameCount, 1)
 assert.deepEqual(health.staleRecords.map((record) => record.id), [3])
+assert.deepEqual(health.legacyFallbackRecords.map((record) => record.id), [2])
+assert.deepEqual(health.undiscoveredRecords.map((record) => record.id), [2, 3])
 assert.deepEqual(
   health.missingEntries.map((entry) => entry.sourcePath),
   ['components/beta/bar-panel.vue', 'components/y/duplicate-card.vue'],
 )
 assert.deepEqual(health.duplicateNames, ['duplicate-card'])
+
+// A canonical source key must win even when the display name/folder are stale.
+assert.equal(
+  health.staleRecords.some((record) => record.id === 1),
+  false,
+)
 
 // A rejected manifest request must not poison the shared cache permanently.
 clearWonderLabManifestCache()
@@ -86,15 +121,25 @@ assert.equal(recovered.count, 4)
 assert.equal(attempts, 2)
 clearWonderLabManifestCache()
 
-const panelSource = await readFile(
-  'components/wonderlab/component-registry-health.vue',
-  'utf8',
-)
+const [panelSource, healthSource] = await Promise.all([
+  readFile('components/wonderlab/component-registry-health.vue', 'utf8'),
+  readFile('utils/wonderlab/componentRegistryHealth.ts', 'utf8'),
+])
 assert.match(panelSource, /\/wonderlab-components\.json/)
 assert.match(panelSource, /\/api\/components/)
 assert.match(panelSource, /summarizeWonderLabRegistry/)
 assert.match(panelSource, /Reconciliation remains an explicit admin action/)
 assert.match(panelSource, /clearWonderLabManifestCache/)
+assert.match(panelSource, /canonicalMatchCount/)
+assert.match(panelSource, /legacyFallbackCount/)
+assert.match(panelSource, /undiscoveredRecordCount/)
+assert.match(panelSource, /candidate\.sourceKey/)
+assert.match(panelSource, /candidate\.sourcePath/)
+assert.match(panelSource, /candidate\.sourceHash/)
+assert.match(panelSource, /candidate\.isDiscovered === true/)
+assert.match(healthSource, /entriesBySourceKey/)
+assert.match(healthSource, /entriesBySourcePath/)
+assert.match(healthSource, /canonicalEntry \|\|/)
 
 const contentSource = await readFile('content/wonderlab.md', 'utf8')
 assert.match(contentSource, /:component-registry-health/)
@@ -104,4 +149,4 @@ assert.ok(
     contentSource.indexOf(':lab-manager'),
 )
 
-console.log('WonderLab registry health verification passed.')
+console.log('WonderLab canonical registry health verification passed.')

--- a/utils/wonderlab/componentRegistryHealth.ts
+++ b/utils/wonderlab/componentRegistryHealth.ts
@@ -8,16 +8,25 @@ export type WonderLabRegistryRecord = {
   id: number
   componentName: string
   folderName: string
+  sourceKey?: string | null
+  sourcePath?: string | null
+  sourceHash?: string | null
+  isDiscovered?: boolean | null
 }
 
 export type WonderLabRegistryHealth = {
   manifestCount: number
   recordCount: number
   matchedRecordCount: number
+  canonicalMatchCount: number
+  legacyFallbackCount: number
+  undiscoveredRecordCount: number
   staleRecordCount: number
   missingRecordCount: number
   duplicateNameCount: number
   staleRecords: WonderLabRegistryRecord[]
+  legacyFallbackRecords: WonderLabRegistryRecord[]
+  undiscoveredRecords: WonderLabRegistryRecord[]
   missingEntries: WonderLabManifestEntry[]
   duplicateNames: string[]
 }
@@ -26,29 +35,53 @@ function normalizeName(value: string): string {
   return value.trim().replace(/\.vue$/i, '').toLowerCase()
 }
 
+function normalizeSource(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
 export function summarizeWonderLabRegistry(
   entries: WonderLabManifestEntry[],
   records: WonderLabRegistryRecord[],
 ): WonderLabRegistryHealth {
+  const entriesBySourceKey = new Map(
+    entries.map((entry) => [normalizeSource(entry.sourceKey), entry]),
+  )
+  const entriesBySourcePath = new Map(
+    entries.map((entry) => [normalizeSource(entry.sourcePath), entry]),
+  )
   const matchedSourcePaths = new Set<string>()
   const staleRecords: WonderLabRegistryRecord[] = []
+  const legacyFallbackRecords: WonderLabRegistryRecord[] = []
+  let canonicalMatchCount = 0
 
   for (const record of records) {
-    const entry = resolveWonderLabManifestEntry(
-      entries,
-      record.componentName,
-      record.folderName,
-    )
+    const sourceKey = normalizeSource(record.sourceKey)
+    const sourcePath = normalizeSource(record.sourcePath)
+    const canonicalEntry =
+      (sourceKey ? entriesBySourceKey.get(sourceKey) : undefined) ||
+      (sourcePath ? entriesBySourcePath.get(sourcePath) : undefined)
+    const entry =
+      canonicalEntry ||
+      resolveWonderLabManifestEntry(
+        entries,
+        record.componentName,
+        record.folderName,
+      )
 
     if (entry) {
-      matchedSourcePaths.add(entry.sourcePath.toLowerCase())
+      matchedSourcePaths.add(normalizeSource(entry.sourcePath))
+      if (canonicalEntry) canonicalMatchCount += 1
+      else legacyFallbackRecords.push(record)
     } else {
       staleRecords.push(record)
     }
   }
 
   const missingEntries = entries.filter(
-    (entry) => !matchedSourcePaths.has(entry.sourcePath.toLowerCase()),
+    (entry) => !matchedSourcePaths.has(normalizeSource(entry.sourcePath)),
+  )
+  const undiscoveredRecords = records.filter(
+    (record) => record.isDiscovered !== true,
   )
 
   const names = new Map<string, number>()
@@ -62,16 +95,24 @@ export function summarizeWonderLabRegistry(
     .map(([name]) => name)
     .sort()
 
+  const byComponentName = (
+    left: WonderLabRegistryRecord,
+    right: WonderLabRegistryRecord,
+  ) => left.componentName.localeCompare(right.componentName)
+
   return {
     manifestCount: entries.length,
     recordCount: records.length,
     matchedRecordCount: records.length - staleRecords.length,
+    canonicalMatchCount,
+    legacyFallbackCount: legacyFallbackRecords.length,
+    undiscoveredRecordCount: undiscoveredRecords.length,
     staleRecordCount: staleRecords.length,
     missingRecordCount: missingEntries.length,
     duplicateNameCount: duplicateNames.length,
-    staleRecords: [...staleRecords].sort((left, right) =>
-      left.componentName.localeCompare(right.componentName),
-    ),
+    staleRecords: [...staleRecords].sort(byComponentName),
+    legacyFallbackRecords: [...legacyFallbackRecords].sort(byComponentName),
+    undiscoveredRecords: [...undiscoveredRecords].sort(byComponentName),
     missingEntries: [...missingEntries].sort((left, right) =>
       left.sourcePath.localeCompare(right.sourcePath),
     ),


### PR DESCRIPTION
## Summary

Updates WonderLab’s read-only registry health panel after #482.

- match Component records by source key or source path before legacy folder/name fallback;
- show canonical matches, legacy fallback matches, and undiscovered records separately;
- retain database-only, manifest-only, and duplicate-name reporting;
- keep the panel read-only;
- extend the existing registry-health contract for the new counts and source fields.

This provides a clear before-and-after view for the upcoming production reconciliation.

Part of #473 and #381.