### PR TITLE
newsfeed: accessibility and reduced-motion polish

### DIFF
--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -5,7 +5,7 @@
     :href="allowNavigation ? item.url : undefined"
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
-    class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl"
+    class="group flex h-full flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
   >
     <figure
       v-if="showImage"
@@ -15,7 +15,7 @@
         v-if="imageSrc && !imageFailed"
         :src="imageSrc"
         :alt="item.title"
-        class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+        class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-300 motion-safe:group-hover:scale-[1.03]"
         loading="lazy"
         @error="imageFailed = true"
       />
@@ -61,7 +61,12 @@
           class="flex shrink-0 items-center gap-1 text-xs text-base-content/45"
         >
           <Icon name="kind-icon:clock" class="size-3" />
-          {{ relativeTime(item.publishedAt) }}
+          <time
+            :datetime="item.publishedAt"
+            :title="absoluteTime(item.publishedAt)"
+          >
+            {{ relativeTime(item.publishedAt) }}
+          </time>
           <Icon
             v-if="allowNavigation"
             name="kind-icon:external-link"
@@ -107,5 +112,14 @@ function relativeTime(iso: string): string {
   if (days < 30) return `${days}d ago`
   const months = Math.round(days / 30)
   return `${months}mo ago`
+}
+
+function absoluteTime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
 }
 </script>

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -13,12 +13,13 @@
       <div class="flex flex-wrap gap-1.5">
         <button
           type="button"
-          class="btn btn-sm rounded-xl"
+          class="btn btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           :class="
             activeSlug === 'all'
               ? 'btn-primary'
               : 'btn-ghost border border-base-300'
           "
+          :aria-pressed="activeSlug === 'all'"
           @click="activeSlug = 'all'"
         >
           All
@@ -27,12 +28,13 @@
           v-for="group in groups"
           :key="group.slug"
           type="button"
-          class="btn btn-sm gap-1.5 rounded-xl"
+          class="btn btn-sm gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           :class="
             activeSlug === group.slug
               ? 'btn-primary'
               : 'btn-ghost border border-base-300'
           "
+          :aria-pressed="activeSlug === group.slug"
           @click="activeSlug = group.slug"
         >
           <Icon :name="group.icon" class="size-3.5" />
@@ -43,7 +45,9 @@
       <div class="flex items-center gap-2">
         <button
           type="button"
-          class="btn btn-ghost btn-sm gap-1.5 rounded-xl"
+          class="btn btn-ghost btn-sm gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          :aria-expanded="showManageFeeds"
+          aria-controls="newsfeed-manage-feeds-panel"
           @click="showManageFeeds = !showManageFeeds"
         >
           <Icon name="kind-icon:sliders" class="size-4" />
@@ -60,8 +64,9 @@
 
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="btn btn-ghost btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           :disabled="isLoading"
+          :aria-busy="isLoading"
           @click="loadFeed()"
         >
           <span v-if="isLoading" class="loading loading-spinner loading-xs" />
@@ -71,45 +76,54 @@
       </div>
     </header>
 
-    <NewsfeedPreferences v-if="showManageFeeds" />
+    <NewsfeedPreferences
+      v-if="showManageFeeds"
+      id="newsfeed-manage-feeds-panel"
+    />
 
-    <div
-      v-if="errorMessage"
-      class="rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
-    >
-      {{ errorMessage }}
+    <div aria-live="polite" aria-atomic="true">
+      <div
+        v-if="errorMessage"
+        class="rounded-2xl border border-error/40 bg-error/10 p-4 text-sm text-error"
+      >
+        {{ errorMessage }}
+      </div>
+
+      <div
+        v-else-if="isLoading && !allItems.length"
+        class="flex min-h-40 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+      >
+        <span class="loading loading-spinner loading-md text-primary" />
+        <span class="sr-only">Loading the newsfeed…</span>
+      </div>
+
+      <div
+        v-else-if="!visibleItems.length"
+        class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"
+      >
+        <Icon
+          name="kind-icon:news"
+          class="mx-auto size-10 text-base-content/25"
+        />
+        <p class="mt-2 font-black">Nothing here yet</p>
+        <p class="mt-1 text-sm text-base-content/55">
+          The swarm hasn't published anything for this feed in a bit — check
+          back soon.
+        </p>
+      </div>
     </div>
 
     <div
-      v-else-if="isLoading && !allItems.length"
-      class="flex min-h-40 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+      v-if="!errorMessage && visibleItems.length"
+      class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
     >
-      <span class="loading loading-spinner loading-md text-primary" />
-    </div>
-
-    <div
-      v-else-if="!visibleItems.length"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100 p-8 text-center"
-    >
-      <Icon
-        name="kind-icon:news"
-        class="mx-auto size-10 text-base-content/25"
-      />
-      <p class="mt-2 font-black">Nothing here yet</p>
-      <p class="mt-1 text-sm text-base-content/55">
-        The swarm hasn't published anything for this feed in a bit — check back
-        soon.
-      </p>
-    </div>
-
-    <div v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       <FeedCard v-for="item in displayedItems" :key="item.id" :item="item" />
     </div>
 
     <button
       v-if="canShowMore"
       type="button"
-      class="btn btn-ghost btn-sm mx-auto rounded-xl"
+      class="btn btn-ghost btn-sm mx-auto rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
       @click="visibleLimit += pageSize"
     >
       Show more

--- a/components/newsfeed/newsfeed-preferences.vue
+++ b/components/newsfeed/newsfeed-preferences.vue
@@ -16,7 +16,7 @@
       </div>
       <button
         type="button"
-        class="btn btn-ghost btn-xs rounded-xl"
+        class="btn btn-ghost btn-xs rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
         @click="feedPreferenceStore.resetToDefaults()"
       >
         Reset to defaults
@@ -42,27 +42,27 @@
         <div class="flex shrink-0 items-center gap-1">
           <button
             type="button"
-            class="btn btn-ghost btn-xs px-1.5"
+            class="btn btn-ghost btn-xs px-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             :disabled="index === 0"
-            aria-label="Move feed up"
+            :aria-label="`Move ${feed.title} up`"
             @click="moveFeed(feed.slug, -1)"
           >
             <Icon name="kind-icon:chevron-up" class="size-4" />
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-xs px-1.5"
+            class="btn btn-ghost btn-xs px-1.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             :disabled="index === enabledFeeds.length - 1"
-            aria-label="Move feed down"
+            :aria-label="`Move ${feed.title} down`"
             @click="moveFeed(feed.slug, 1)"
           >
             <Icon name="kind-icon:chevron-down" class="size-4" />
           </button>
           <input
             type="checkbox"
-            class="toggle toggle-primary toggle-sm ml-1"
+            class="toggle toggle-primary toggle-sm ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             checked
-            aria-label="Disable feed"
+            :aria-label="`Disable ${feed.title}`"
             @change="feedPreferenceStore.disableFeed(feed.slug)"
           />
         </div>
@@ -85,8 +85,8 @@
 
         <input
           type="checkbox"
-          class="toggle toggle-sm"
-          aria-label="Enable feed"
+          class="toggle toggle-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          :aria-label="`Enable ${feed.title}`"
           @change="feedPreferenceStore.enableFeed(feed.slug)"
         />
       </li>


### PR DESCRIPTION
### Task
newsfeed/t-010: Polish accessibility and responsive presentation (kind: software)

### What changed / what I produced
- `components/newsfeed/newsfeed-feed.vue`: `aria-pressed` on the "All"/category filter buttons, `aria-expanded`/`aria-controls` on the "Manage feeds" toggle (wired to a new `id` on the `NewsfeedPreferences` panel it controls), `aria-busy` on the Refresh button, an `aria-live="polite"` wrapper around the loading/error/empty status region, and visible `focus-visible` outlines on every button in the header/footer row.
- `components/newsfeed/feed-card.vue`: hover lift/scale transforms now use `motion-safe:` variants (users with `prefers-reduced-motion: reduce` get the shadow change but no movement); a `focus-visible` ring on the card's link/article wrapper; the relative timestamp is now inside a semantic `<time datetime="...">` element with a full localized date/time in `title` for a readable, accessible timestamp instead of a bare "5m ago" string.
- `components/newsfeed/newsfeed-preferences.vue`: `focus-visible` rings on Reset/reorder/toggle controls, and the reorder/enable/disable `aria-label`s now name the specific feed (e.g. "Move TechCrunch up") instead of a generic label.

### How I verified
- `npm run test` (vue-tsc --noEmit) — clean.
- `npx eslint` on all three changed files — clean.
- `npx prettier --check` on all three changed files — clean.
- Rebased onto latest `main` (past #485) before opening this PR; re-ran eslint after rebase.

### Stakes
reversible

### Flags for Reviewer
- Could not get a live `nuxt dev` render of `/newsfeed` in this sandbox — `DATABASE_URL` points at an unreachable dummy MariaDB host, so SSR 500s before ever reaching the newsfeed markup. This is the same sandbox limitation already documented on `newsfeed/t-014`. Verification here is static (types/lint/format) only, not a rendered visual/keyboard-nav check. A session with real preview-deploy access should do a quick tab-through + reduced-motion toggle check.
- Left button/touch-target sizing (`btn-xs`, `btn-sm`) unchanged to match the rest of the app's density conventions rather than enlarging for mobile touch targets, per the task note's "final visual consistency" ask.

### Kaizen suggestion
`newsfeed/t-014` (preview-deploy visual check) and this task hit the same sandbox DB wall from two different tasks now — worth a standing note in AGENTS.md's cross-repo section pointing sessions at whatever preview-deploy connector (e.g. Vercel MCP) can actually reach a real deployed preview URL for kind_robots, instead of each task rediscovering "no local nuxt dev" independently.

### Notes for reviewer
conductor/newsfeed roadmap task: t-010. Claimed via `claim_task.py` as session `claude-conductor-agentrun-20260719T0110Z`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADxJBhFoH5UWvBZsh3Xiv4)_