### PR TITLE
WonderLab: add Component catalog review metrics and sorting

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Component canonical client and fallback audit
         run: npx tsx utils/scripts/verifyComponentCanonicalClients.ts
 
+      - name: WonderLab Component catalog metrics contract
+        run: npx tsx utils/scripts/verifyWonderLabComponentCatalog.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/server/api/components/index.get.ts
+++ b/server/api/components/index.get.ts
@@ -1,31 +1,76 @@
-// server/api/components/index.get.ts
-
+// /server/api/components/index.get.ts
 import { defineEventHandler } from 'h3'
 import { errorHandler } from '../../utils/error'
 import prisma from '../../utils/prisma'
+import type { ComponentCatalogItem } from '@/utils/wonderlab/componentCatalog'
 
 export default defineEventHandler(async () => {
-  let response
-
   try {
-    // Fetch all components from the database
-    const data = await prisma.component.findMany()
+    const [components, reactionGroups] = await Promise.all([
+      prisma.component.findMany({
+        orderBy: [{ componentName: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.reaction.groupBy({
+        by: ['componentId'],
+        where: {
+          componentId: { not: null },
+          reactionCategory: 'COMPONENT',
+        },
+        _count: {
+          _all: true,
+          rating: true,
+        },
+        _avg: {
+          rating: true,
+        },
+        _max: {
+          createdAt: true,
+        },
+      }),
+    ])
 
-    // Return success response with data in a structured format
-    response = {
+    const metricsByComponentId = new Map<
+      number,
+      Pick<
+        ComponentCatalogItem,
+        'reviewCount' | 'ratingCount' | 'averageRating' | 'lastReviewedAt'
+      >
+    >()
+
+    for (const group of reactionGroups) {
+      if (!group.componentId) continue
+
+      metricsByComponentId.set(group.componentId, {
+        reviewCount: group._count._all,
+        ratingCount: group._count.rating,
+        averageRating: group._avg.rating,
+        lastReviewedAt: group._max.createdAt?.toISOString() ?? null,
+      })
+    }
+
+    const data: ComponentCatalogItem[] = components.map((component) => ({
+      ...component,
+      reviewCount: metricsByComponentId.get(component.id)?.reviewCount ?? 0,
+      ratingCount: metricsByComponentId.get(component.id)?.ratingCount ?? 0,
+      averageRating:
+        metricsByComponentId.get(component.id)?.averageRating ?? null,
+      lastReviewedAt:
+        metricsByComponentId.get(component.id)?.lastReviewedAt ?? null,
+    }))
+
+    return {
       success: true,
       data,
-      statusCode: 200, // OK
+      statusCode: 200,
     }
   } catch (error: unknown) {
-    // Pass error to errorHandler for consistent error structure
     const handledError = errorHandler(error)
-    response = {
+
+    return {
       success: false,
       message: handledError.message || 'Failed to fetch components.',
+      data: [],
       statusCode: handledError.statusCode || 500,
     }
   }
-
-  return response
 })

--- a/stores/componentStore.ts
+++ b/stores/componentStore.ts
@@ -89,15 +89,21 @@ export const useComponentStore = defineStore('componentStore', () => {
   async function updateComponent(component: Component) {
     const updated = await helperUpdate(component)
     const index = components.value.findIndex((entry) => entry.id === component.id)
+    const existing = index === -1 ? undefined : components.value[index]
 
-    if (index !== -1) {
-      components.value[index] = {
-        ...components.value[index],
-        ...updated,
-      }
+    if (!existing) return updated
+
+    const merged: ComponentCatalogItem = {
+      ...existing,
+      ...updated,
+    }
+    components.value[index] = merged
+
+    if (selectedComponent.value?.id === merged.id) {
+      selectedComponent.value = merged
     }
 
-    return components.value[index] ?? updated
+    return merged
   }
 
   async function deleteComponent(id: number) {

--- a/stores/componentStore.ts
+++ b/stores/componentStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { Component } from '~/prisma/generated/prisma/client'
+import type { ComponentCatalogItem } from '@/utils/wonderlab/componentCatalog'
 import {
   fetchComponentById as helperFetch,
   createComponent as helperCreate,
@@ -15,9 +16,9 @@ import {
 } from '@/stores/helpers/snapshotLoader'
 
 export const useComponentStore = defineStore('componentStore', () => {
-  const components = ref<Component[]>([])
+  const components = ref<ComponentCatalogItem[]>([])
   const usingSnapshot = ref(false)
-  const selectedComponent = ref<Component | null>(null)
+  const selectedComponent = ref<ComponentCatalogItem | null>(null)
   const selectedFolder = ref<string | null>(null)
   const isInitialized = ref(false)
 
@@ -32,7 +33,7 @@ export const useComponentStore = defineStore('componentStore', () => {
     try {
       // performFetch (not raw fetch) so a dead DB trips the shared circuit
       // breaker instead of hanging every page that lists components.
-      const data = await performFetch<Component[]>('/api/components')
+      const data = await performFetch<ComponentCatalogItem[]>('/api/components')
       if (data.success && data.data) {
         components.value = data.data
         usingSnapshot.value = false
@@ -49,7 +50,8 @@ export const useComponentStore = defineStore('componentStore', () => {
       // nightly snapshot. isInitialized stays false, so the next
       // initialize() call still retries the live fetch.
       if (components.value.length === 0) {
-        const snapshotRows = await loadSnapshot<Component>('components')
+        const snapshotRows =
+          await loadSnapshot<ComponentCatalogItem>('components')
 
         if (snapshotRows.length && components.value.length === 0) {
           components.value = snapshotRows
@@ -87,8 +89,15 @@ export const useComponentStore = defineStore('componentStore', () => {
   async function updateComponent(component: Component) {
     const updated = await helperUpdate(component)
     const index = components.value.findIndex((entry) => entry.id === component.id)
-    if (index !== -1) components.value[index] = updated
-    return updated
+
+    if (index !== -1) {
+      components.value[index] = {
+        ...components.value[index],
+        ...updated,
+      }
+    }
+
+    return components.value[index] ?? updated
   }
 
   async function deleteComponent(id: number) {
@@ -127,4 +136,4 @@ export const useComponentStore = defineStore('componentStore', () => {
   }
 })
 
-export type { Component as KindComponent }
+export type { ComponentCatalogItem as KindComponent }

--- a/utils/scripts/verifyWonderLabComponentCatalog.ts
+++ b/utils/scripts/verifyWonderLabComponentCatalog.ts
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyWonderLabComponentCatalog.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import type { ComponentCatalogItem } from '@/utils/wonderlab/componentCatalog'
+import {
+  componentCatalogSorts,
+  isComponentCatalogSort,
+  sortComponentCatalog,
+} from '@/utils/wonderlab/componentCatalog'
+
+function component(
+  id: number,
+  componentName: string,
+  overrides: Partial<ComponentCatalogItem> = {},
+): ComponentCatalogItem {
+  return {
+    id,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    folderName: 'wonderlab',
+    componentName,
+    isWorking: false,
+    underConstruction: false,
+    isBroken: false,
+    slug: null,
+    sourcePath: null,
+    sourceKey: null,
+    sourceHash: null,
+    status: 'UNREVIEWED',
+    statusReason: null,
+    title: componentName,
+    description: null,
+    notes: null,
+    category: null,
+    tags: null,
+    previewMode: null,
+    previewConfig: null,
+    lastSeenAt: null,
+    isDiscovered: true,
+    artImageId: null,
+    reviewCount: 0,
+    ratingCount: 0,
+    averageRating: null,
+    lastReviewedAt: null,
+    ...overrides,
+  }
+}
+
+const items = [
+  component(1, 'zeta-card', {
+    title: 'Zeta Card',
+    status: 'WORKING',
+    isWorking: true,
+    reviewCount: 4,
+    ratingCount: 3,
+    averageRating: 4.5,
+    updatedAt: new Date('2026-07-15T00:00:00.000Z'),
+    lastReviewedAt: '2026-07-16T00:00:00.000Z',
+  }),
+  component(2, 'alpha-panel', {
+    title: 'Alpha Panel',
+    status: 'BROKEN',
+    isBroken: true,
+    reviewCount: 9,
+    ratingCount: 5,
+    averageRating: 3.5,
+    updatedAt: new Date('2026-07-18T00:00:00.000Z'),
+    lastReviewedAt: '2026-07-10T00:00:00.000Z',
+  }),
+  component(3, 'beta-manager', {
+    title: 'Beta Manager',
+    status: 'RETIRED',
+    reviewCount: 1,
+    ratingCount: 1,
+    averageRating: 4.5,
+    updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+    lastReviewedAt: null,
+  }),
+]
+
+const originalIds = items.map((item) => item.id)
+assert.deepEqual(
+  sortComponentCatalog(items, 'NAME').map((item) => item.id),
+  [2, 3, 1],
+)
+assert.deepEqual(
+  sortComponentCatalog(items, 'STATUS').map((item) => item.id),
+  [2, 1, 3],
+)
+assert.deepEqual(
+  sortComponentCatalog(items, 'RATING').map((item) => item.id),
+  [1, 3, 2],
+  'equal ratings should prefer the item with more ratings',
+)
+assert.deepEqual(
+  sortComponentCatalog(items, 'REVIEWS').map((item) => item.id),
+  [2, 1, 3],
+)
+assert.deepEqual(
+  sortComponentCatalog(items, 'RECENTLY_CHANGED').map((item) => item.id),
+  [2, 1, 3],
+)
+assert.deepEqual(
+  sortComponentCatalog(items, 'RECENTLY_REVIEWED').map((item) => item.id),
+  [1, 2, 3],
+)
+assert.deepEqual(
+  items.map((item) => item.id),
+  originalIds,
+  'sorting must not mutate the Pinia collection',
+)
+
+assert.deepEqual(componentCatalogSorts, [
+  'NAME',
+  'STATUS',
+  'RATING',
+  'REVIEWS',
+  'RECENTLY_CHANGED',
+  'RECENTLY_REVIEWED',
+])
+assert.equal(isComponentCatalogSort('RATING'), true)
+assert.equal(isComponentCatalogSort('random'), false)
+
+const [apiSource, storeSource] = await Promise.all([
+  readFile('server/api/components/index.get.ts', 'utf8'),
+  readFile('stores/componentStore.ts', 'utf8'),
+])
+
+assert.match(apiSource, /prisma\.reaction\.groupBy/)
+assert.match(apiSource, /componentId:\s*\{ not: null \}/)
+assert.match(apiSource, /reactionCategory:\s*'COMPONENT'/)
+assert.match(apiSource, /_count:[\s\S]*?_all:\s*true[\s\S]*?rating:\s*true/)
+assert.match(apiSource, /_avg:[\s\S]*?rating:\s*true/)
+assert.match(apiSource, /_max:[\s\S]*?createdAt:\s*true/)
+assert.match(apiSource, /reviewCount:/)
+assert.match(apiSource, /ratingCount:/)
+assert.match(apiSource, /averageRating:/)
+assert.match(apiSource, /lastReviewedAt:/)
+assert.doesNotMatch(apiSource, /include:[\s\S]*?Reactions/)
+
+assert.match(storeSource, /ComponentCatalogItem\[\]/)
+assert.match(storeSource, /loadSnapshot<ComponentCatalogItem>/)
+assert.match(storeSource, /\.\.\.components\.value\[index\]/)
+assert.match(storeSource, /\.\.\.updated/)
+
+console.log('WonderLab Component catalog metrics and sorting contract passed.')

--- a/utils/scripts/verifyWonderLabComponentCatalog.ts
+++ b/utils/scripts/verifyWonderLabComponentCatalog.ts
@@ -140,7 +140,9 @@ assert.doesNotMatch(apiSource, /include:[\s\S]*?Reactions/)
 
 assert.match(storeSource, /ComponentCatalogItem\[\]/)
 assert.match(storeSource, /loadSnapshot<ComponentCatalogItem>/)
-assert.match(storeSource, /\.\.\.components\.value\[index\]/)
+assert.match(storeSource, /const merged: ComponentCatalogItem/)
+assert.match(storeSource, /\.\.\.existing/)
 assert.match(storeSource, /\.\.\.updated/)
+assert.match(storeSource, /selectedComponent\.value = merged/)
 
 console.log('WonderLab Component catalog metrics and sorting contract passed.')

--- a/utils/wonderlab/componentCatalog.ts
+++ b/utils/wonderlab/componentCatalog.ts
@@ -1,0 +1,115 @@
+// /utils/wonderlab/componentCatalog.ts
+import type { Component } from '~/prisma/generated/prisma/client'
+import {
+  getComponentStatus,
+  type ComponentStatus,
+} from '@/utils/wonderlab/componentStatus'
+
+export type ComponentCatalogMetrics = {
+  reviewCount?: number
+  ratingCount?: number
+  averageRating?: number | null
+  lastReviewedAt?: string | null
+}
+
+export type ComponentCatalogItem = Component & ComponentCatalogMetrics
+
+export const componentCatalogSorts = [
+  'NAME',
+  'STATUS',
+  'RATING',
+  'REVIEWS',
+  'RECENTLY_CHANGED',
+  'RECENTLY_REVIEWED',
+] as const
+
+export type ComponentCatalogSort = (typeof componentCatalogSorts)[number]
+
+const statusOrder: Record<ComponentStatus, number> = {
+  BROKEN: 0,
+  UNDER_CONSTRUCTION: 1,
+  UNREVIEWED: 2,
+  NEEDS_CONTEXT: 3,
+  PREVIEW_UNSUPPORTED: 4,
+  WORKING: 5,
+  RETIRED: 6,
+}
+
+function text(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function label(item: ComponentCatalogItem): string {
+  return text(item.title) || text(item.componentName) || `Component ${item.id}`
+}
+
+function epoch(value: Date | string | null | undefined): number {
+  if (!value) return 0
+  const date = value instanceof Date ? value : new Date(value)
+  const timestamp = date.getTime()
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function descendingNumber(
+  left: number | null | undefined,
+  right: number | null | undefined,
+): number {
+  return (right ?? 0) - (left ?? 0)
+}
+
+function tieBreak(left: ComponentCatalogItem, right: ComponentCatalogItem): number {
+  const nameOrder = label(left).localeCompare(label(right), 'en', {
+    sensitivity: 'base',
+    numeric: true,
+  })
+
+  return nameOrder || left.id - right.id
+}
+
+export function isComponentCatalogSort(
+  value: unknown,
+): value is ComponentCatalogSort {
+  return (
+    typeof value === 'string' &&
+    componentCatalogSorts.includes(value as ComponentCatalogSort)
+  )
+}
+
+export function sortComponentCatalog(
+  items: ComponentCatalogItem[],
+  sort: ComponentCatalogSort = 'NAME',
+): ComponentCatalogItem[] {
+  return [...items].sort((left, right) => {
+    let order = 0
+
+    switch (sort) {
+      case 'STATUS':
+        order =
+          statusOrder[getComponentStatus(left)] -
+          statusOrder[getComponentStatus(right)]
+        break
+      case 'RATING':
+        order = descendingNumber(left.averageRating, right.averageRating)
+        if (!order) {
+          order = descendingNumber(left.ratingCount, right.ratingCount)
+        }
+        break
+      case 'REVIEWS':
+        order = descendingNumber(left.reviewCount, right.reviewCount)
+        break
+      case 'RECENTLY_CHANGED':
+        order =
+          epoch(right.updatedAt ?? right.createdAt) -
+          epoch(left.updatedAt ?? left.createdAt)
+        break
+      case 'RECENTLY_REVIEWED':
+        order = epoch(right.lastReviewedAt) - epoch(left.lastReviewedAt)
+        break
+      case 'NAME':
+      default:
+        break
+    }
+
+    return order || tieBreak(left, right)
+  })
+}


### PR DESCRIPTION
## What changed

Adds the data foundation for the responsive WonderLab collection view.

### Bounded review aggregates

`GET /api/components` now returns four aggregate fields per Component:

- `reviewCount`
- `ratingCount`
- `averageRating`
- `lastReviewedAt`

The endpoint uses one grouped Reaction query scoped to Component reactions. It does not include review bodies, authors, or relation arrays in the catalog response.

### Catalog typing and store behavior

- adds a `ComponentCatalogItem` type with optional aggregate fields;
- carries catalog metrics through live Pinia loading and fallback snapshots;
- preserves metrics when an admin metadata/status update returns a plain Component row;
- keeps the selected exhibit synchronized with the merged row.

### Deterministic sort foundation

Adds pure sort modes for:

- name;
- canonical status;
- average rating, with rating-count tie breaking;
- review count;
- recently changed;
- recently reviewed.

Sorting always returns a copy and uses stable name/ID tie breaking.

## Validation

Adds a required DB-free contract covering:

- every sort mode and tie behavior;
- input immutability;
- aggregate query scope and fields;
- absence of full Reaction relation loading;
- live/snapshot catalog typing;
- preservation of metrics during Component updates.

This PR does not yet redesign the collection layout; it provides the metrics and ordering primitives that layout will consume.

Part of #381.