### PR TITLE
Reactions: add first-party Bot/Character author identity

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -160,6 +160,9 @@ jobs:
       - name: WonderLab Component catalog metrics contract
         run: npx tsx utils/scripts/verifyWonderLabComponentCatalog.ts
 
+      - name: Reaction first-party author expand migration contract
+        run: npx tsx utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/prisma/migrations/20260719031500_reaction_first_party_author_expand/migration.sql
+++ b/prisma/migrations/20260719031500_reaction_first_party_author_expand/migration.sql
@@ -1,0 +1,20 @@
+-- Expand-only migration for first-party Bot/Character review authorship.
+-- Reaction.userId remains the authenticated publisher/accountability identity.
+-- Existing human and target-relation fields are unchanged.
+
+ALTER TABLE `Reaction`
+  ADD COLUMN `authorBotId` INTEGER NULL,
+  ADD COLUMN `authorCharacterId` INTEGER NULL;
+
+CREATE INDEX `Reaction_authorBotId_idx` ON `Reaction`(`authorBotId`);
+CREATE INDEX `Reaction_authorCharacterId_idx` ON `Reaction`(`authorCharacterId`);
+
+ALTER TABLE `Reaction`
+  ADD CONSTRAINT `Reaction_authorBotId_fkey`
+    FOREIGN KEY (`authorBotId`) REFERENCES `Bot`(`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT `Reaction_authorCharacterId_fkey`
+    FOREIGN KEY (`authorCharacterId`) REFERENCES `Character`(`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT `Reaction_firstPartyAuthor_check`
+    CHECK (`authorBotId` IS NULL OR `authorCharacterId` IS NULL);

--- a/utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
+++ b/utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
@@ -1,0 +1,44 @@
+// /utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const migrationPath =
+  'prisma/migrations/20260719031500_reaction_first_party_author_expand/migration.sql'
+const sql = await readFile(migrationPath, 'utf8')
+
+assert.match(sql, /ALTER TABLE `Reaction`/)
+assert.match(sql, /ADD COLUMN `authorBotId` INTEGER NULL/)
+assert.match(sql, /ADD COLUMN `authorCharacterId` INTEGER NULL/)
+assert.match(sql, /CREATE INDEX `Reaction_authorBotId_idx`/)
+assert.match(sql, /CREATE INDEX `Reaction_authorCharacterId_idx`/)
+assert.match(
+  sql,
+  /FOREIGN KEY \(`authorBotId`\) REFERENCES `Bot`\(`id`\)[\s\S]*?ON DELETE SET NULL ON UPDATE CASCADE/,
+)
+assert.match(
+  sql,
+  /FOREIGN KEY \(`authorCharacterId`\) REFERENCES `Character`\(`id`\)[\s\S]*?ON DELETE SET NULL ON UPDATE CASCADE/,
+)
+assert.match(
+  sql,
+  /CHECK \(`authorBotId` IS NULL OR `authorCharacterId` IS NULL\)/,
+  'a Reaction must never claim both a Bot and Character display author',
+)
+
+for (const destructiveStatement of [
+  /DROP TABLE/i,
+  /DROP COLUMN/i,
+  /DELETE FROM/i,
+  /TRUNCATE/i,
+  /UPDATE `Reaction`/i,
+]) {
+  assert.doesNotMatch(sql, destructiveStatement)
+}
+
+assert.doesNotMatch(
+  sql,
+  /\bMODIFY\b|\bCHANGE\b/i,
+  'the expand migration must not rewrite existing Reaction columns',
+)
+
+console.log('Reaction first-party author expand migration contract passed.')


### PR DESCRIPTION
## Summary

Adds the database-only expansion stage for first-party personality review authorship.

### New nullable identity fields

- `Reaction.authorBotId`
- `Reaction.authorCharacterId`

`Reaction.userId` remains the authenticated publisher/accountability identity. Existing `botId` and `characterId` fields remain target relations and are not repurposed.

### Database protections

- indexes for both author relations;
- foreign keys to `Bot` and `Character` with `ON DELETE SET NULL`;
- check constraint preventing a Reaction from claiming both author kinds.

### Safety

This migration is additive only:

- no existing Reaction is updated;
- no table or column is dropped;
- no current relation or unique constraint changes;
- no API or client can set the new fields yet;
- all human reviews remain unchanged.

A required DB-free contract verifies the nullable fields, indexes, foreign keys, single-author constraint, and absence of destructive SQL.

The next compatibility PR will adopt these fields in Prisma, add bounded public author projections, and restrict author assignment to controlled admin/service paths.

Part of #472 and #381.