### PR TITLE
academy: close expanded style detail with Escape key

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -105,7 +105,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, type ComponentPublicInstance } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  type ComponentPublicInstance,
+} from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import type { AcademyStyle } from '@/stores/seeds/academyStyles'
 
@@ -142,6 +149,24 @@ function closeStyle() {
     if (slug) gridRefs.get(slug)?.focus()
   })
 }
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && expandedSlug.value) {
+    closeStyle()
+  }
+}
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', onKeydown)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('keydown', onKeydown)
+  }
+})
 
 const expandedStyle = computed<AcademyStyle | null>(() => {
   if (!expandedSlug.value) return null

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -98,7 +98,13 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref, type ComponentPublicInstance } from 'vue'
+import {
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  type ComponentPublicInstance,
+} from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 
 const emit = defineEmits<{
@@ -132,4 +138,22 @@ function closeLesson(slug: string) {
     toggleRefs.get(slug)?.focus()
   })
 }
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && expandedSlug.value) {
+    closeLesson(expandedSlug.value)
+  }
+}
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', onKeydown)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('keydown', onKeydown)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary

Adds keyboard Escape support to dismiss the expanded `academy-style-detail`
panel, in both `academy-styles-browser.vue` (grid detail panel) and
`academy-timeline.vue` (expanded timeline entry). Mirrors the existing
close-button behavior exactly, including focus restoration to the
triggering grid card / timeline toggle button.

Matches the established `window.addEventListener('keydown', ...)` +
`onBeforeUnmount` cleanup pattern already used in
`components/navigation/tutorial-flyer.vue`, guarded with
`typeof window !== 'undefined'` for SSR safety.

Tracked as `ai-art-academy/t-010` (recurring "continuous improvement pass",
lane 1: front-end polish) in the `conductor` roadmap.

## Checks

- `npx eslint components/academy/academy-styles-browser.vue components/academy/academy-timeline.vue` — clean
- `npx vue-tsc --noEmit` — clean

## Flags for Reviewer

None — small, scoped, reversible UI change; no API/store/schema changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Eanc5DEtB9su3uNMxm7KM)_