### PR TITLE
a11y: label the identity-preservation range slider in stylist-restyle.vue

### DIFF
--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -196,6 +196,7 @@
         min="0"
         max="0.8"
         step="0.05"
+        aria-label="How much should it still look like them?"
         class="range range-primary range-xs"
       />
       <div class="flex justify-between text-[10px] text-base-content/50">


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor recurring continuous-improvement task): lane 1, front-end polish.

### What changed
- `components/art/stylist-restyle.vue`: the "How much should it still look like them?" identity-preservation range slider had no accessible name — its label text sat in a plain `<span>` sibling, not connected via `<label>`/`aria-label`/`aria-labelledby`. Added `aria-label="How much should it still look like them?"` directly on the `<input type="range">`, mirroring the `theme-lab.vue` labeled-slider convention used elsewhere in this codebase.

### How I verified
- `npx eslint components/art/stylist-restyle.vue` — clean (exit 0).
- `npx prettier --check components/art/stylist-restyle.vue` — flags pre-existing formatting drift unrelated to this change (confirmed via `git stash` that the same warning exists on `main` before this diff, same as the precedent already recorded for this file in PRs #387/#433 — CI does not gate on lint/prettier).
- Full-project `npm run test` (`vue-tsc --noEmit`, provisioned via conductor's `provision_kind_robots_deps.sh`) — exit 0.

### Stakes
reversible

### Notes for reviewer
Found via an Explore-subagent sweep of the Academy/Remix-Studio component set, explicitly excluding everything already fixed by prior `t-010` cycles (PRs #275, #301, #332, #371, #380, #383, #385, #387, #397, #423, #433). One-line additive change, no behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVcU25axpdW928yGwFKod)_