### PR TITLE
Reactions: adopt safe first-party author projection

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -163,6 +163,9 @@ jobs:
       - name: Reaction first-party author expand migration contract
         run: npx tsx utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
 
+      - name: Reaction first-party author runtime contract
+        run: npx tsx utils/scripts/verifyFirstPartyReactionAuthor.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/utils/reactions/firstPartyReactionAuthor.ts
+++ b/utils/reactions/firstPartyReactionAuthor.ts
@@ -1,0 +1,83 @@
+// /utils/reactions/firstPartyReactionAuthor.ts
+export type FirstPartyReactionAuthorKind = 'BOT' | 'CHARACTER'
+
+export type FirstPartyReactionAuthor = {
+  kind: FirstPartyReactionAuthorKind
+  id: number
+  name: string
+  avatarImage: string | null
+  role: string | null
+}
+
+type AuthorEntity = {
+  id: number
+  name?: string | null
+  avatarImage?: string | null
+  imagePath?: string | null
+  BotType?: string | null
+  characterType?: string | null
+}
+
+export type FirstPartyReactionAuthorSource = {
+  authorBotId?: number | null
+  authorCharacterId?: number | null
+  AuthorBot?: AuthorEntity | null
+  AuthorCharacter?: AuthorEntity | null
+}
+
+function positiveId(value: unknown): number | null {
+  const id = Number(value)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+function publicName(entity: AuthorEntity, fallback: string): string {
+  return entity.name?.trim() || fallback
+}
+
+function publicAvatar(entity: AuthorEntity): string | null {
+  return entity.avatarImage?.trim() || entity.imagePath?.trim() || null
+}
+
+export function assertSingleFirstPartyReactionAuthor(
+  source: Pick<FirstPartyReactionAuthorSource, 'authorBotId' | 'authorCharacterId'>,
+): void {
+  if (positiveId(source.authorBotId) && positiveId(source.authorCharacterId)) {
+    throw new Error('A Reaction cannot have both a Bot and Character display author.')
+  }
+}
+
+export function firstPartyReactionAuthor(
+  source: FirstPartyReactionAuthorSource,
+): FirstPartyReactionAuthor | null {
+  assertSingleFirstPartyReactionAuthor(source)
+
+  const botId = positiveId(source.authorBotId)
+  if (botId) {
+    if (!source.AuthorBot || source.AuthorBot.id !== botId) return null
+
+    return {
+      kind: 'BOT',
+      id: botId,
+      name: publicName(source.AuthorBot, `Bot #${botId}`),
+      avatarImage: publicAvatar(source.AuthorBot),
+      role: source.AuthorBot.BotType?.trim() || 'BOT',
+    }
+  }
+
+  const characterId = positiveId(source.authorCharacterId)
+  if (characterId) {
+    if (!source.AuthorCharacter || source.AuthorCharacter.id !== characterId) {
+      return null
+    }
+
+    return {
+      kind: 'CHARACTER',
+      id: characterId,
+      name: publicName(source.AuthorCharacter, `Character #${characterId}`),
+      avatarImage: publicAvatar(source.AuthorCharacter),
+      role: source.AuthorCharacter.characterType?.trim() || 'CHARACTER',
+    }
+  }
+
+  return null
+}

--- a/utils/scripts/verifyFirstPartyReactionAuthor.ts
+++ b/utils/scripts/verifyFirstPartyReactionAuthor.ts
@@ -1,0 +1,71 @@
+// /utils/scripts/verifyFirstPartyReactionAuthor.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  assertSingleFirstPartyReactionAuthor,
+  firstPartyReactionAuthor,
+} from '@/utils/reactions/firstPartyReactionAuthor'
+
+assert.equal(firstPartyReactionAuthor({}), null)
+
+assert.deepEqual(
+  firstPartyReactionAuthor({
+    authorBotId: 7,
+    AuthorBot: {
+      id: 7,
+      name: 'Dotti',
+      avatarImage: '/images/bots/dotti.webp',
+      BotType: 'NARRATOR',
+    },
+  }),
+  {
+    kind: 'BOT',
+    id: 7,
+    name: 'Dotti',
+    avatarImage: '/images/bots/dotti.webp',
+    role: 'NARRATOR',
+  },
+)
+
+assert.deepEqual(
+  firstPartyReactionAuthor({
+    authorCharacterId: 9,
+    AuthorCharacter: {
+      id: 9,
+      name: 'Catbot',
+      imagePath: '/images/characters/catbot.webp',
+      characterType: 'MASCOT',
+    },
+  }),
+  {
+    kind: 'CHARACTER',
+    id: 9,
+    name: 'Catbot',
+    avatarImage: '/images/characters/catbot.webp',
+    role: 'MASCOT',
+  },
+)
+
+assert.equal(
+  firstPartyReactionAuthor({
+    authorBotId: 7,
+    AuthorBot: { id: 8, name: 'Wrong bot' },
+  }),
+  null,
+  'joined identity must match the stored author id',
+)
+
+assert.throws(
+  () =>
+    assertSingleFirstPartyReactionAuthor({
+      authorBotId: 1,
+      authorCharacterId: 2,
+    }),
+  /cannot have both/i,
+)
+
+const postSource = await readFile('server/api/reactions/index.post.ts', 'utf8')
+assert.doesNotMatch(postSource, /authorBotId/)
+assert.doesNotMatch(postSource, /authorCharacterId/)
+
+console.log('First-party Reaction author projection contract passed.')


### PR DESCRIPTION
## Summary

Adds the runtime identity boundary for first-party Bot/Character-authored Reactions.

### Public author projection

- normalizes Bot and Character authors into one bounded shape: kind, stable id, name, avatar, and role;
- accepts identity only from server-joined author records;
- verifies the joined entity id matches the stored author foreign key;
- rejects impossible dual Bot/Character author states.

### Impersonation guard

A permanent contract verifies the ordinary authenticated Reaction POST route does not accept `authorBotId` or `authorCharacterId`. This PR adds no author-assignment write path and does not alter existing human Reaction behavior.

### Validation

- Contract Tests: passed
- TypeScript Type Check: passed

Follow-up work will adopt the database columns in Prisma/read projections and then add controlled admin/service-only assignment through the review-draft publication pipeline.

Part of #472 and #381.