### PR TITLE
WonderLab: add durable personality review draft storage

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Reaction first-party author runtime contract
         run: npx tsx utils/scripts/verifyFirstPartyReactionAuthor.ts
 
+      - name: Review draft storage expand contract
+        run: npx tsx utils/scripts/verifyReviewDraftStorageExpand.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/prisma/migrations/20260719033500_review_draft_storage_expand/migration.sql
+++ b/prisma/migrations/20260719033500_review_draft_storage_expand/migration.sql
@@ -1,0 +1,66 @@
+-- Expand-only storage for editorially reviewed first-party Component commentary.
+-- No generation or publication path is introduced by this migration.
+
+CREATE TABLE `ReviewDraft` (
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NULL,
+  `status` ENUM('PROPOSED', 'APPROVED', 'REJECTED', 'PUBLISHED', 'FAILED', 'SUPERSEDED') NOT NULL DEFAULT 'PROPOSED',
+  `draftKey` VARCHAR(191) NOT NULL,
+  `componentId` INTEGER NOT NULL,
+  `authorBotId` INTEGER NULL,
+  `authorCharacterId` INTEGER NULL,
+  `publisherUserId` INTEGER NULL,
+  `publishedReactionId` INTEGER NULL,
+  `promptVersion` VARCHAR(64) NOT NULL,
+  `promptHash` VARCHAR(191) NOT NULL,
+  `promptPayload` JSON NULL,
+  `generatedComment` TEXT NOT NULL,
+  `editedComment` TEXT NULL,
+  `rating` INTEGER NOT NULL DEFAULT 0,
+  `reactionType` VARCHAR(64) NULL,
+  `generationModel` VARCHAR(191) NULL,
+  `generationProvider` VARCHAR(64) NULL,
+  `generationAttempt` INTEGER NOT NULL DEFAULT 1,
+  `approvedAt` DATETIME(3) NULL,
+  `rejectedAt` DATETIME(3) NULL,
+  `publishedAt` DATETIME(3) NULL,
+  `failureReason` TEXT NULL,
+
+  UNIQUE INDEX `ReviewDraft_draftKey_key`(`draftKey`),
+  INDEX `ReviewDraft_componentId_status_idx`(`componentId`, `status`),
+  INDEX `ReviewDraft_authorBotId_idx`(`authorBotId`),
+  INDEX `ReviewDraft_authorCharacterId_idx`(`authorCharacterId`),
+  INDEX `ReviewDraft_publisherUserId_idx`(`publisherUserId`),
+  INDEX `ReviewDraft_publishedReactionId_idx`(`publishedReactionId`),
+  CONSTRAINT `ReviewDraft_single_author_chk`
+    CHECK ((`authorBotId` IS NULL) <> (`authorCharacterId` IS NULL)),
+  CONSTRAINT `ReviewDraft_rating_range_chk`
+    CHECK (`rating` >= 0 AND `rating` <= 5),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `ReviewDraft`
+  ADD CONSTRAINT `ReviewDraft_componentId_fkey`
+  FOREIGN KEY (`componentId`) REFERENCES `Component`(`id`)
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE `ReviewDraft`
+  ADD CONSTRAINT `ReviewDraft_authorBotId_fkey`
+  FOREIGN KEY (`authorBotId`) REFERENCES `Bot`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE `ReviewDraft`
+  ADD CONSTRAINT `ReviewDraft_authorCharacterId_fkey`
+  FOREIGN KEY (`authorCharacterId`) REFERENCES `Character`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE `ReviewDraft`
+  ADD CONSTRAINT `ReviewDraft_publisherUserId_fkey`
+  FOREIGN KEY (`publisherUserId`) REFERENCES `User`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE `ReviewDraft`
+  ADD CONSTRAINT `ReviewDraft_publishedReactionId_fkey`
+  FOREIGN KEY (`publishedReactionId`) REFERENCES `Reaction`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/utils/scripts/verifyReviewDraftStorageExpand.ts
+++ b/utils/scripts/verifyReviewDraftStorageExpand.ts
@@ -1,0 +1,58 @@
+// /utils/scripts/verifyReviewDraftStorageExpand.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const migrationPath =
+  'prisma/migrations/20260719033500_review_draft_storage_expand/migration.sql'
+const sql = await readFile(migrationPath, 'utf8')
+
+for (const fragment of [
+  'CREATE TABLE `ReviewDraft`',
+  "ENUM('PROPOSED', 'APPROVED', 'REJECTED', 'PUBLISHED', 'FAILED', 'SUPERSEDED')",
+  '`draftKey` VARCHAR(191) NOT NULL',
+  '`componentId` INTEGER NOT NULL',
+  '`authorBotId` INTEGER NULL',
+  '`authorCharacterId` INTEGER NULL',
+  '`publisherUserId` INTEGER NULL',
+  '`publishedReactionId` INTEGER NULL',
+  '`promptVersion` VARCHAR(64) NOT NULL',
+  '`promptHash` VARCHAR(191) NOT NULL',
+  '`promptPayload` JSON NULL',
+  '`generatedComment` TEXT NOT NULL',
+  '`editedComment` TEXT NULL',
+  'UNIQUE INDEX `ReviewDraft_draftKey_key`',
+  'CONSTRAINT `ReviewDraft_single_author_chk`',
+  'CONSTRAINT `ReviewDraft_rating_range_chk`',
+  'FOREIGN KEY (`componentId`) REFERENCES `Component`(`id`)',
+  'FOREIGN KEY (`authorBotId`) REFERENCES `Bot`(`id`)',
+  'FOREIGN KEY (`authorCharacterId`) REFERENCES `Character`(`id`)',
+  'FOREIGN KEY (`publisherUserId`) REFERENCES `User`(`id`)',
+  'FOREIGN KEY (`publishedReactionId`) REFERENCES `Reaction`(`id`)',
+]) {
+  assert.match(sql, new RegExp(fragment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+}
+
+assert.match(
+  sql,
+  /CHECK \(\(`authorBotId` IS NULL\) <> \(`authorCharacterId` IS NULL\)\)/,
+  'each draft must have exactly one Bot or Character author',
+)
+assert.match(sql, /CHECK \(`rating` >= 0 AND `rating` <= 5\)/)
+
+for (const destructive of [
+  /DROP\s+TABLE/i,
+  /DROP\s+COLUMN/i,
+  /DELETE\s+FROM/i,
+  /UPDATE\s+`?(?:Reaction|Component|Bot|Character|User)`?/i,
+  /ALTER\s+TABLE\s+`?(?:Reaction|Component|Bot|Character|User)`?\s+DROP/i,
+]) {
+  assert.doesNotMatch(sql, destructive)
+}
+
+assert.doesNotMatch(
+  sql,
+  /INSERT\s+INTO\s+`?Reaction`?/i,
+  'draft migration must not publish live Reactions',
+)
+
+console.log('ReviewDraft expand migration contract passed.')


### PR DESCRIPTION
## Summary

Adds the expand-only database foundation for editorially controlled first-party Component review drafts.

### ReviewDraft storage

- deterministic unique `draftKey`;
- target Component;
- exactly one Bot or Character reviewer;
- lifecycle status: proposed, approved, rejected, published, failed, or superseded;
- bounded prompt provenance and prompt payload;
- generated and curator-edited copy;
- optional rating and reaction type;
- provider/model/attempt metadata;
- publisher identity and approval/rejection/publication timestamps;
- nullable link to the eventual published Reaction.

### Safety constraints

- exactly one first-party author kind;
- rating restricted to 0–5;
- no generation code;
- no API or UI write path;
- no insertion into live Reactions;
- no existing records updated or deleted.

A required DB-free contract verifies the schema, foreign keys, uniqueness, constraints, and absence of destructive or publishing SQL.

Part of #472 and #381.