### PR TITLE
fix: replace FK-column CHECK constraints with triggers (unblocks stuck prod migration)

### DIFF
--- a/prisma/migrations/20260719031500_reaction_first_party_author_expand/migration.sql
+++ b/prisma/migrations/20260719031500_reaction_first_party_author_expand/migration.sql
@@ -15,6 +15,26 @@ ALTER TABLE `Reaction`
     ON DELETE SET NULL ON UPDATE CASCADE,
   ADD CONSTRAINT `Reaction_authorCharacterId_fkey`
     FOREIGN KEY (`authorCharacterId`) REFERENCES `Character`(`id`)
-    ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT `Reaction_firstPartyAuthor_check`
-    CHECK (`authorBotId` IS NULL OR `authorCharacterId` IS NULL);
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- MariaDB rejects a CHECK constraint on a column that also carries a FOREIGN
+-- KEY (error 1901, "Function or expression '<col>' cannot be used in the
+-- CHECK clause"), in either statement order. Enforce the same "at most one
+-- first-party author" invariant with triggers instead.
+CREATE TRIGGER `Reaction_firstPartyAuthor_check_ins` BEFORE INSERT ON `Reaction`
+FOR EACH ROW
+BEGIN
+  IF NEW.`authorBotId` IS NOT NULL AND NEW.`authorCharacterId` IS NOT NULL THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Reaction_firstPartyAuthor_check: authorBotId and authorCharacterId cannot both be set';
+  END IF;
+END;
+
+CREATE TRIGGER `Reaction_firstPartyAuthor_check_upd` BEFORE UPDATE ON `Reaction`
+FOR EACH ROW
+BEGIN
+  IF NEW.`authorBotId` IS NOT NULL AND NEW.`authorCharacterId` IS NOT NULL THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Reaction_firstPartyAuthor_check: authorBotId and authorCharacterId cannot both be set';
+  END IF;
+END;

--- a/prisma/migrations/20260719033500_review_draft_storage_expand/migration.sql
+++ b/prisma/migrations/20260719033500_review_draft_storage_expand/migration.sql
@@ -33,8 +33,6 @@ CREATE TABLE `ReviewDraft` (
   INDEX `ReviewDraft_authorCharacterId_idx`(`authorCharacterId`),
   INDEX `ReviewDraft_publisherUserId_idx`(`publisherUserId`),
   INDEX `ReviewDraft_publishedReactionId_idx`(`publishedReactionId`),
-  CONSTRAINT `ReviewDraft_single_author_chk`
-    CHECK ((`authorBotId` IS NULL) <> (`authorCharacterId` IS NULL)),
   CONSTRAINT `ReviewDraft_rating_range_chk`
     CHECK (`rating` >= 0 AND `rating` <= 5),
   PRIMARY KEY (`id`)
@@ -64,3 +62,27 @@ ALTER TABLE `ReviewDraft`
   ADD CONSTRAINT `ReviewDraft_publishedReactionId_fkey`
   FOREIGN KEY (`publishedReactionId`) REFERENCES `Reaction`(`id`)
   ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- MariaDB rejects a CHECK constraint on a column that also carries a FOREIGN
+-- KEY (error 1901, "Function or expression '<col>' cannot be used in the
+-- CHECK clause"), regardless of statement order (see the sibling
+-- 20260719031500_reaction_first_party_author_expand fix for the repro).
+-- Enforce the original "exactly one first-party author" invariant with
+-- triggers instead of the CHECK this table was created with above.
+CREATE TRIGGER `ReviewDraft_single_author_chk_ins` BEFORE INSERT ON `ReviewDraft`
+FOR EACH ROW
+BEGIN
+  IF (NEW.`authorBotId` IS NULL) = (NEW.`authorCharacterId` IS NULL) THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'ReviewDraft_single_author_chk: exactly one of authorBotId/authorCharacterId must be set';
+  END IF;
+END;
+
+CREATE TRIGGER `ReviewDraft_single_author_chk_upd` BEFORE UPDATE ON `ReviewDraft`
+FOR EACH ROW
+BEGIN
+  IF (NEW.`authorBotId` IS NULL) = (NEW.`authorCharacterId` IS NULL) THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'ReviewDraft_single_author_chk: exactly one of authorBotId/authorCharacterId must be set';
+  END IF;
+END;

--- a/utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
+++ b/utils/scripts/verifyReactionFirstPartyAuthorExpand.ts
@@ -19,10 +19,25 @@ assert.match(
   sql,
   /FOREIGN KEY \(`authorCharacterId`\) REFERENCES `Character`\(`id`\)[\s\S]*?ON DELETE SET NULL ON UPDATE CASCADE/,
 )
+// MariaDB rejects a CHECK constraint on a column that also carries a
+// FOREIGN KEY (error 1901), in either statement order, so the "at most one
+// first-party author" invariant is enforced with BEFORE INSERT/UPDATE
+// triggers instead of a CHECK clause. See the migration's own comment for
+// the reproduction.
 assert.match(
   sql,
-  /CHECK \(`authorBotId` IS NULL OR `authorCharacterId` IS NULL\)/,
-  'a Reaction must never claim both a Bot and Character display author',
+  /CREATE TRIGGER `Reaction_firstPartyAuthor_check_ins` BEFORE INSERT ON `Reaction`[\s\S]*?NEW\.`authorBotId` IS NOT NULL AND NEW\.`authorCharacterId` IS NOT NULL[\s\S]*?SIGNAL SQLSTATE '45000'/,
+  'a Reaction must never claim both a Bot and Character display author on insert',
+)
+assert.match(
+  sql,
+  /CREATE TRIGGER `Reaction_firstPartyAuthor_check_upd` BEFORE UPDATE ON `Reaction`[\s\S]*?NEW\.`authorBotId` IS NOT NULL AND NEW\.`authorCharacterId` IS NOT NULL[\s\S]*?SIGNAL SQLSTATE '45000'/,
+  'a Reaction must never claim both a Bot and Character display author on update',
+)
+assert.doesNotMatch(
+  sql,
+  /\bCHECK\s*\(/i,
+  'CHECK constraints on FK columns fail on MariaDB (error 1901) — use triggers instead',
 )
 
 for (const destructiveStatement of [

--- a/utils/scripts/verifyReviewDraftStorageExpand.ts
+++ b/utils/scripts/verifyReviewDraftStorageExpand.ts
@@ -21,7 +21,6 @@ for (const fragment of [
   '`generatedComment` TEXT NOT NULL',
   '`editedComment` TEXT NULL',
   'UNIQUE INDEX `ReviewDraft_draftKey_key`',
-  'CONSTRAINT `ReviewDraft_single_author_chk`',
   'CONSTRAINT `ReviewDraft_rating_range_chk`',
   'FOREIGN KEY (`componentId`) REFERENCES `Component`(`id`)',
   'FOREIGN KEY (`authorBotId`) REFERENCES `Bot`(`id`)',
@@ -32,12 +31,28 @@ for (const fragment of [
   assert.match(sql, new RegExp(fragment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
 }
 
+// MariaDB rejects a CHECK constraint on a column that also carries a
+// FOREIGN KEY (error 1901), in either statement order — authorBotId and
+// authorCharacterId both get FOREIGN KEYs below, so the "exactly one
+// first-party author" invariant is enforced with BEFORE INSERT/UPDATE
+// triggers instead of a CHECK clause on those columns. `rating` carries no
+// FOREIGN KEY, so its CHECK is unaffected and stays as-is.
 assert.match(
   sql,
-  /CHECK \(\(`authorBotId` IS NULL\) <> \(`authorCharacterId` IS NULL\)\)/,
-  'each draft must have exactly one Bot or Character author',
+  /CREATE TRIGGER `ReviewDraft_single_author_chk_ins` BEFORE INSERT ON `ReviewDraft`[\s\S]*?\(NEW\.`authorBotId` IS NULL\) = \(NEW\.`authorCharacterId` IS NULL\)[\s\S]*?SIGNAL SQLSTATE '45000'/,
+  'each draft must have exactly one Bot or Character author on insert',
+)
+assert.match(
+  sql,
+  /CREATE TRIGGER `ReviewDraft_single_author_chk_upd` BEFORE UPDATE ON `ReviewDraft`[\s\S]*?\(NEW\.`authorBotId` IS NULL\) = \(NEW\.`authorCharacterId` IS NULL\)[\s\S]*?SIGNAL SQLSTATE '45000'/,
+  'each draft must have exactly one Bot or Character author on update',
 )
 assert.match(sql, /CHECK \(`rating` >= 0 AND `rating` <= 5\)/)
+assert.doesNotMatch(
+  sql,
+  /CHECK\s*\(\(?`authorBotId`/i,
+  'CHECK constraints on FK columns fail on MariaDB (error 1901) — use triggers instead',
+)
 
 for (const destructive of [
   /DROP\s+TABLE/i,


### PR DESCRIPTION
## Summary

Fixes the red `Cypress Tests` / `API Tests` CI on `main` (run [29671897968](https://github.com/silasfelinus/kind_robots/actions/runs/29671897968), CI-janitor Todo #444). The actual failure is upstream of Cypress: **every production deploy since 2026-07-19 03:27 UTC has been failing during `prisma migrate deploy`**, so the "wait for deploy to go live" CI step times out after 20 minutes.

**Root cause:** the `20260719031500_reaction_first_party_author_expand` migration tries to add a `CHECK` constraint on a column (`authorBotId`) that also carries a `FOREIGN KEY`, in the same `ALTER TABLE` statement as the FK. MariaDB rejects this with error 1901: `Function or expression 'authorBotId' cannot be used in the CHECK clause`.

I reproduced this against a real MariaDB 10.11 instance (matching what `scripts/prisma-migrate-deploy.mjs` connects to via the `mariadb` npm driver) and confirmed it is **not** a statement-grouping issue — MariaDB refuses a CHECK constraint on any column that also has a FOREIGN KEY, regardless of:
- same ALTER TABLE statement vs. separate statements
- which one (FK or CHECK) is added first
- CHECK defined inline in `CREATE TABLE` vs. added later via `ALTER TABLE`

This also affects the very next migration in the queue, `20260719033500_review_draft_storage_expand` (`ReviewDraft_single_author_chk`), which hasn't run yet (it's queued behind the failed one) but would hit the identical error the moment it's attempted.

**Fix:** enforce the same invariants with `BEFORE INSERT`/`BEFORE UPDATE` triggers instead of `CHECK` constraints:
- `Reaction`: "at most one of `authorBotId`/`authorCharacterId`" — this migration never fully succeeded anywhere (deterministic bug), so it's safe to edit in place; the ADD COLUMN/CREATE INDEX statements that already committed on prod are unchanged.
- `ReviewDraft`: "exactly one of `authorBotId`/`authorCharacterId`" (XOR) — this migration hasn't been attempted anywhere yet, edited freely. `ReviewDraft_rating_range_chk` doesn't touch an FK'd column, so it's unaffected and stays a real CHECK.

Updated `utils/scripts/verifyReactionFirstPartyAuthorExpand.ts` and `utils/scripts/verifyReviewDraftStorageExpand.ts` to assert on the new trigger definitions (same safety intent, not weakened) instead of the removed CHECK clauses.

## How I verified

All against a real MariaDB 10.11 server (`apt install mariadb-server`, no Docker available in this sandbox):
- Reproduced the exact production error (byte-identical MariaDB message) with the original migration SQL.
- Confirmed the FK+CHECK incompatibility holds across every statement ordering I could think of (5 separate repro databases).
- Rewrote both migrations to use triggers, then ran them end-to-end through Prisma's actual `db execute` / `migrate deploy` (not just raw SQL) on fresh databases — both apply cleanly, and the trigger logic was verified with real INSERT/UPDATE statements (single author allowed, both authors rejected, `ReviewDraft`'s "neither" also rejected, rating range still enforced).
- **Reproduced production's exact stuck state** end-to-end: built a minimal schema + the original buggy migration, ran real `prisma migrate deploy`, got the identical P3018/1901 failure with `_prisma_migrations` left with `finished_at IS NULL` (exactly matching prod). Then validated the full recovery path: applied a targeted repair SQL (the missing FK + trigger statements) via `prisma db execute`, ran `prisma migrate resolve --applied 20260719031500_reaction_first_party_author_expand`, and confirmed a subsequent `prisma migrate deploy` proceeds cleanly through the fixed `ReviewDraft` migration with no further errors.
- `npm run test` (vue-tsc --noEmit): clean.
- `npx eslint` on both changed `.ts` files: clean.
- All 4 relevant contract scripts pass: `verifyReactionFirstPartyAuthorExpand.ts`, `verifyFirstPartyReactionAuthor.ts`, `verifyReviewDraftStorageExpand.ts`, `verifyWonderLabReviewDraftPrompt.ts`.

## Stakes

reversible (schema is additive-only; no `DROP`/`DELETE`/data rewrite anywhere in either migration)

## ⚠️ Still required: a one-time manual step against production

**This PR alone will not unblock production.** Prisma deliberately refuses to auto-retry a migration it already recorded as failed (P3018) — someone with the production `DATABASE_URL` needs to run, once, before/at merge:

```bash
# 1) Bring prod's Reaction table in line with what the fixed migration would have produced
#    (its ADD COLUMN / CREATE INDEX statements already committed; only this tail is missing):
cat > /tmp/reaction_repair.sql <<'SQL'
ALTER TABLE `Reaction`
  ADD CONSTRAINT `Reaction_authorBotId_fkey`
    FOREIGN KEY (`authorBotId`) REFERENCES `Bot`(`id`)
    ON DELETE SET NULL ON UPDATE CASCADE,
  ADD CONSTRAINT `Reaction_authorCharacterId_fkey`
    FOREIGN KEY (`authorCharacterId`) REFERENCES `Character`(`id`)
    ON DELETE SET NULL ON UPDATE CASCADE;

CREATE TRIGGER `Reaction_firstPartyAuthor_check_ins` BEFORE INSERT ON `Reaction`
FOR EACH ROW
BEGIN
  IF NEW.`authorBotId` IS NOT NULL AND NEW.`authorCharacterId` IS NOT NULL THEN
    SIGNAL SQLSTATE '45000'
      SET MESSAGE_TEXT = 'Reaction_firstPartyAuthor_check: authorBotId and authorCharacterId cannot both be set';
  END IF;
END;

CREATE TRIGGER `Reaction_firstPartyAuthor_check_upd` BEFORE UPDATE ON `Reaction`
FOR EACH ROW
BEGIN
  IF NEW.`authorBotId` IS NOT NULL AND NEW.`authorCharacterId` IS NOT NULL THEN
    SIGNAL SQLSTATE '45000'
      SET MESSAGE_TEXT = 'Reaction_firstPartyAuthor_check: authorBotId and authorCharacterId cannot both be set';
  END IF;
END;
SQL
DATABASE_URL="<prod DATABASE_URL>" npx prisma db execute --file /tmp/reaction_repair.sql

# 2) Tell Prisma this migration is now genuinely complete (it now matches reality):
DATABASE_URL="<prod DATABASE_URL>" npx prisma migrate resolve --applied 20260719031500_reaction_first_party_author_expand
```

After that one-time step, the next deploy (this PR, once merged) will apply `20260719033500_review_draft_storage_expand` automatically and CI/production will go green — no further manual steps needed. I don't have production database credentials in this sandbox, so I can't run this myself; I verified the exact same two commands against a simulated copy of production's stuck state (see "How I verified" above) and they resolve it cleanly.

## Flags for Reviewer

- Separately noticed (out of scope for this fix, not touched here): neither of these two migrations' new columns/tables (`Reaction.authorBotId`/`authorCharacterId`, the whole `ReviewDraft` model) were ever added to `prisma/schema.prisma`. The raw SQL will apply fine, but Prisma Client won't expose any of these fields/model until schema.prisma catches up — worth a follow-up task.
- `public/wonderlab-components.json` shows as untracked in my sandbox (regenerated by the `postinstall`/`nuxi prepare` step) — intentionally left out of this commit, not part of the fix.

## Kaizen suggestion

Add a CI-only smoke step (or a pre-commit contract) that runs each new migration's SQL against a throwaway MariaDB container before merge, the way I did manually here — would have caught this specific FK+CHECK incompatibility before it ever reached `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019nfna8Huq93GgPJzXYrCUM)_