### PR TITLE
stylist: add freehand hair-mask brush for masked restyling

### DIFF
--- a/components/art/stylist-mask-brush.vue
+++ b/components/art/stylist-mask-brush.vue
@@ -1,0 +1,288 @@
+<!-- /components/art/stylist-mask-brush.vue -->
+<!--
+  Freehand "paint the hair" mask tool for stylist-restyle.vue (conductor
+  superkate-hairstyle-ai/t-018). The Kontext graph already accepts a mask
+  (workflow.ts's LoadImageMask reads the red channel — white = repaint, black =
+  keep) but nothing produced one. This paints it: strokes are recorded on an
+  offscreen canvas at the source photo's NATURAL resolution, independent of how
+  the visible preview is letterboxed, so the exported mask lines up pixel-for-
+  pixel with the photo the relay uploads regardless of the preview's aspect fit.
+-->
+<template>
+  <div class="stylist-mask-brush flex flex-col gap-2">
+    <canvas
+      ref="viewCanvas"
+      class="block h-64 w-full touch-none rounded-lg border border-base-300 bg-base-300"
+      style="cursor: crosshair"
+      @pointerdown="startStroke"
+      @pointermove="continueStroke"
+      @pointerup="endStroke"
+      @pointerleave="endStroke"
+      @pointercancel="endStroke"
+    />
+    <div class="flex flex-wrap items-center gap-2 text-xs">
+      <label class="flex items-center gap-1">
+        <span class="font-bold text-base-content/70">Brush size</span>
+        <input
+          v-model.number="brushSize"
+          type="range"
+          min="8"
+          max="80"
+          step="2"
+          aria-label="Brush size"
+          class="range range-primary range-xs w-24"
+        />
+      </label>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs"
+        :disabled="!hasPainted"
+        @click="clear"
+      >
+        <Icon name="mdi:eraser" class="h-3.5 w-3.5" /> Clear
+      </button>
+      <span class="text-base-content/50">
+        {{
+          hasPainted
+            ? 'Painted area will be restyled — everything else stays untouched.'
+            : 'Paint over the hair to restrict the change to just that area.'
+        }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps<{
+  sourceImageData: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:maskData', value: string | null): void
+}>()
+
+const viewCanvas = ref<HTMLCanvasElement | null>(null)
+const brushSize = ref(32)
+const hasPainted = ref(false)
+
+const photoImg = new Image()
+let photoReady = false
+
+// The mask itself, at the photo's natural resolution — the source of truth.
+// White strokes on a transparent background; only visible pixels count.
+let maskCanvas: HTMLCanvasElement | null = null
+let maskCtx: CanvasRenderingContext2D | null = null
+
+// object-contain-style fit of the natural photo into the visible canvas box,
+// recomputed whenever either changes. Both drawing and pointer→natural-space
+// coordinate mapping go through this so they can never disagree.
+let fit = { scale: 1, offsetX: 0, offsetY: 0, drawW: 0, drawH: 0 }
+
+let isDrawing = false
+let lastNatural: { x: number; y: number } | null = null
+let resizeObserver: ResizeObserver | null = null
+
+function computeFit() {
+  const canvas = viewCanvas.value
+  if (!canvas || !photoReady) return
+  const boxW = canvas.width
+  const boxH = canvas.height
+  const natW = photoImg.naturalWidth
+  const natH = photoImg.naturalHeight
+  if (!boxW || !boxH || !natW || !natH) return
+  const scale = Math.min(boxW / natW, boxH / natH)
+  const drawW = natW * scale
+  const drawH = natH * scale
+  fit = {
+    scale,
+    offsetX: (boxW - drawW) / 2,
+    offsetY: (boxH - drawH) / 2,
+    drawW,
+    drawH,
+  }
+}
+
+function ensureMaskCanvas() {
+  if (!photoReady) return
+  const natW = photoImg.naturalWidth
+  const natH = photoImg.naturalHeight
+  if (!natW || !natH) return
+  if (maskCanvas && maskCanvas.width === natW && maskCanvas.height === natH)
+    return
+  maskCanvas = document.createElement('canvas')
+  maskCanvas.width = natW
+  maskCanvas.height = natH
+  maskCtx = maskCanvas.getContext('2d')
+  hasPainted.value = false
+}
+
+function syncCanvasBox() {
+  const canvas = viewCanvas.value
+  if (!canvas) return
+  const rect = canvas.getBoundingClientRect()
+  const width = Math.max(1, Math.round(rect.width))
+  const height = Math.max(1, Math.round(rect.height))
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width
+    canvas.height = height
+  }
+  computeFit()
+  redraw()
+}
+
+function redraw() {
+  const canvas = viewCanvas.value
+  const ctx = canvas?.getContext('2d')
+  if (!canvas || !ctx) return
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  if (!photoReady) return
+  ctx.drawImage(photoImg, fit.offsetX, fit.offsetY, fit.drawW, fit.drawH)
+  if (maskCanvas) {
+    ctx.globalAlpha = 0.55
+    ctx.drawImage(maskCanvas, fit.offsetX, fit.offsetY, fit.drawW, fit.drawH)
+    ctx.globalAlpha = 1
+  }
+}
+
+function loadPhoto(src: string) {
+  photoReady = false
+  hasPainted.value = false
+  maskCanvas = null
+  maskCtx = null
+  photoImg.onload = () => {
+    photoReady = true
+    ensureMaskCanvas()
+    computeFit()
+    redraw()
+  }
+  photoImg.src = src
+  emit('update:maskData', null)
+}
+
+function naturalPointFromEvent(
+  event: PointerEvent,
+): { x: number; y: number } | null {
+  const canvas = viewCanvas.value
+  if (!canvas || !photoReady || fit.scale <= 0) return null
+  const rect = canvas.getBoundingClientRect()
+  const canvasX = ((event.clientX - rect.left) / rect.width) * canvas.width
+  const canvasY = ((event.clientY - rect.top) / rect.height) * canvas.height
+  const natW = photoImg.naturalWidth
+  const natH = photoImg.naturalHeight
+  const x = (canvasX - fit.offsetX) / fit.scale
+  const y = (canvasY - fit.offsetY) / fit.scale
+  return {
+    x: Math.min(Math.max(x, 0), natW),
+    y: Math.min(Math.max(y, 0), natH),
+  }
+}
+
+function strokeAt(
+  point: { x: number; y: number },
+  from: { x: number; y: number } | null,
+) {
+  if (!maskCtx) return
+  const radius = brushSize.value / 2 / fit.scale
+  maskCtx.fillStyle = '#fff'
+  maskCtx.strokeStyle = '#fff'
+  maskCtx.lineWidth = radius * 2
+  maskCtx.lineCap = 'round'
+  maskCtx.lineJoin = 'round'
+  if (from) {
+    maskCtx.beginPath()
+    maskCtx.moveTo(from.x, from.y)
+    maskCtx.lineTo(point.x, point.y)
+    maskCtx.stroke()
+  } else {
+    maskCtx.beginPath()
+    maskCtx.arc(point.x, point.y, radius, 0, Math.PI * 2)
+    maskCtx.fill()
+  }
+}
+
+function startStroke(event: PointerEvent) {
+  if (!photoReady) return
+  ensureMaskCanvas()
+  const point = naturalPointFromEvent(event)
+  if (!point) return
+  isDrawing = true
+  hasPainted.value = true
+  lastNatural = point
+  strokeAt(point, null)
+  redraw()
+  viewCanvas.value?.setPointerCapture(event.pointerId)
+}
+
+function continueStroke(event: PointerEvent) {
+  if (!isDrawing) return
+  const point = naturalPointFromEvent(event)
+  if (!point) return
+  strokeAt(point, lastNatural)
+  lastNatural = point
+  redraw()
+}
+
+function endStroke() {
+  if (!isDrawing) return
+  isDrawing = false
+  lastNatural = null
+  emitMask()
+}
+
+function emitMask() {
+  if (!maskCanvas || !hasPainted.value) {
+    emit('update:maskData', null)
+    return
+  }
+  // Composite onto solid black: workflow.ts's LoadImageMask reads the red
+  // channel, and a black backdrop avoids any alpha-decoding ambiguity.
+  const out = document.createElement('canvas')
+  out.width = maskCanvas.width
+  out.height = maskCanvas.height
+  const outCtx = out.getContext('2d')
+  if (!outCtx) {
+    emit('update:maskData', null)
+    return
+  }
+  outCtx.fillStyle = '#000'
+  outCtx.fillRect(0, 0, out.width, out.height)
+  outCtx.drawImage(maskCanvas, 0, 0)
+  emit('update:maskData', out.toDataURL('image/png'))
+}
+
+function clear() {
+  ensureMaskCanvas()
+  if (maskCtx && maskCanvas) {
+    maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height)
+  }
+  hasPainted.value = false
+  redraw()
+  emit('update:maskData', null)
+}
+
+watch(
+  () => props.sourceImageData,
+  (next) => {
+    if (next) loadPhoto(next)
+  },
+)
+
+onMounted(() => {
+  if (props.sourceImageData) loadPhoto(props.sourceImageData)
+  const canvas = viewCanvas.value
+  if (canvas && 'ResizeObserver' in window) {
+    resizeObserver = new ResizeObserver(() => syncCanvasBox())
+    resizeObserver.observe(canvas)
+  }
+  syncCanvasBox()
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  photoImg.onload = null
+})
+
+defineExpose({ clear })
+</script>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -116,7 +116,7 @@
       </div>
 
       <!-- Preview -->
-      <div v-if="sourceImageData" class="relative">
+      <div v-if="sourceImageData && !maskEnabled" class="relative">
         <img :src="sourceImageData" alt="Client photo" class="max-h-64 w-full rounded-lg object-contain" />
         <button
           type="button"
@@ -125,6 +125,28 @@
           @click="clearSource"
         >
           <Icon name="mdi:close" class="h-4 w-4" />
+        </button>
+      </div>
+
+      <label v-if="sourceImageData" class="flex items-center gap-2">
+        <input v-model="maskEnabled" type="checkbox" class="checkbox checkbox-xs checkbox-primary" />
+        <span class="text-xs text-base-content/70">
+          Only restyle the hair (paint a mask instead of changing the whole photo)
+        </span>
+      </label>
+
+      <div v-if="sourceImageData && maskEnabled" class="flex flex-col gap-2">
+        <stylist-mask-brush
+          :source-image-data="sourceImageData"
+          @update:mask-data="maskData = $event"
+        />
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs self-start"
+          title="Remove photo"
+          @click="clearSource"
+        >
+          <Icon name="mdi:close" class="h-4 w-4" /> Remove photo
         </button>
       </div>
     </div>
@@ -418,7 +440,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import {
   useStylistStore,
   clientFromDesigner,
@@ -435,6 +457,12 @@ const sourceTab = ref<'upload' | 'camera'>('upload')
 const sourceImageData = ref<string | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
 const isDragging = ref(false)
+
+// Optional hair-only mask (t-018): when enabled, stylist-mask-brush replaces
+// the plain preview and the painted mask restricts the Kontext repaint to
+// just that region instead of the whole photo.
+const maskEnabled = ref(false)
+const maskData = ref<string | null>(null)
 
 const videoEl = ref<HTMLVideoElement | null>(null)
 const cameraActive = ref(false)
@@ -671,7 +699,13 @@ function closeCamera() {
 
 function clearSource() {
   sourceImageData.value = null
+  maskEnabled.value = false
+  maskData.value = null
 }
+
+watch(maskEnabled, (enabled) => {
+  if (!enabled) maskData.value = null
+})
 
 function submit() {
   if (!sourceImageData.value || !hasAnyChange.value) return
@@ -684,6 +718,7 @@ function submit() {
     guidance: guidanceValue.value,
     steps: stepsValue.value,
     ...(protectIdentity.value ? { negativePrompt: IDENTITY_NEGATIVE } : {}),
+    ...(maskEnabled.value && maskData.value ? { maskData: maskData.value } : {}),
   })
 }
 


### PR DESCRIPTION
### Task
superkate-hairstyle-ai/t-018: Hair-mask SOURCE for true hair-only restyling (auto-seg or brush)  (kind: software)

### What changed / what I produced
- New `components/art/stylist-mask-brush.vue`: a freehand canvas paint tool. The user drags over the hair in the preview photo; strokes are recorded on an offscreen canvas at the source photo's **natural** resolution (not the CSS-letterboxed display size), so the exported mask lines up pixel-for-pixel with what the relay uploads regardless of the preview's aspect-fit. Exports as a solid-black-background + white-strokes PNG data URL, matching `workflow.ts`'s `LoadImageMask` red-channel read.
- `components/art/stylist-restyle.vue`: added an opt-in "Only restyle the hair" checkbox. When enabled, the plain photo preview is swapped for `<stylist-mask-brush>` and the painted mask is forwarded into `runStylist()`'s existing (already-wired, previously-unused) `maskData` field. Off by default — unchanged full-photo behavior when not enabled.
- No server/API changes — `maskData` plumbing (`stylistStore.ts`, `enqueue.post.ts`, `workflow.ts`'s `LoadImageMask`/`SetLatentNoiseMask` nodes) already existed and was unused before this PR.

### How I verified
- `npm run test` (nuxi prepare + vue-tsc --noEmit) — clean.
- `npx eslint` on both changed files — clean.
- Confirmed the pre-existing `maskData` plumbing end-to-end by reading `stores/stylistStore.ts:54,268`, `server/api/comfy/kontext/enqueue.post.ts:41,84-87,115`, and `server/api/comfy/kontext/utils/workflow.ts:249-261`.
- Could **not** verify in a live browser: `/stylist` requires `ADMIN` auth and this sandbox has no real `DATABASE_URL`/DB — even the home page 500s identically ("DATABASE_URL is missing"), confirming it's a sandbox-wide limitation, not something introduced by this change. This matches conductor AGENTS.md's documented local-verification bar for kind_robots cross-repo tasks (vue-tsc/eslint only); real end-to-end coverage is PR CI (contract tests) plus this PR's own Vercel preview deploy.

### Stakes
reversible — purely additive client-side UI; opt-in and off by default; no server/schema changes.

### Flags for Reviewer
- No Cypress coverage exists for `stylist-restyle.vue` today (pre-existing gap, confirmed via `grep -rli stylist cypress/` returning nothing) — this PR doesn't add any either, consistent with the existing gap rather than introducing a new untested surface class.
- The brush's exported mask uses a solid black background (not transparent) specifically so `LoadImageMask`'s red-channel read has no alpha-decoding ambiguity — flagging this decision in case there's a reason ComfyUI's node prefers transparency I'm not aware of.
- Picked the manual-brush half of the task's two options (vs. a MediaPipe auto-segmentation dependency) since it's self-contained and needs no new npm package/model download.

### Kaizen suggestion
Add a minimal Cypress test harness for `/stylist` (even just "renders Hair Studio for an admin session") — right now neither the pre-existing `maskData` API path nor any UI in this component has any automated coverage, so a regression here would only surface manually.

### Notes for reviewer
Conductor task: superkate-hairstyle-ai/t-018 (set to `status: review` in the conductor roadmap as part of this same session).


---
_Generated by [Claude Code](https://claude.ai/code/session_016vj5vJWrb9ekqfyUsYJukb)_