### PR TITLE
newsfeed: add adjustable political perspective balance

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Newsfeed programmable filters contract
         run: npm run test:newsfeed-filters
 
+      - name: Newsfeed perspective balance contract
+        run: npm run test:newsfeed-perspective-balance
+
       - name: WonderLab reconciliation contract
         run: npm run test:wonderlab-reconcile
 

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -51,11 +51,20 @@
       <div
         class="mt-auto flex flex-wrap items-center justify-between gap-2 pt-1"
       >
-        <span
-          class="truncate text-xs font-bold text-base-content/55"
-          :title="item.source"
-        >
-          {{ item.source }}
+        <span class="flex min-w-0 items-center gap-1.5">
+          <span
+            class="truncate text-xs font-bold text-base-content/55"
+            :title="item.source"
+          >
+            {{ item.source }}
+          </span>
+          <span
+            v-if="perspectiveLabel"
+            class="badge badge-ghost badge-xs shrink-0 gap-1 rounded-xl border-base-300"
+            :title="`Perspective rating from ${item.perspective?.source} — political-lean labels are provenance, not fact.`"
+          >
+            {{ perspectiveLabel }}
+          </span>
         </span>
         <span
           class="flex shrink-0 items-center gap-1 text-xs text-base-content/45"
@@ -81,6 +90,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { NewsFeedItem } from '@/stores/helpers/newsfeed'
+import { useFeedPreferenceStore } from '@/stores/feedPreferenceStore'
 
 const props = withDefaults(
   defineProps<{
@@ -94,10 +104,25 @@ const props = withDefaults(
   },
 )
 
+const feedPreferenceStore = useFeedPreferenceStore()
+
 const imageFailed = ref(false)
 
 const imageSrc = computed(() => props.item.image || '')
 const primaryCategory = computed(() => props.item.category?.[0] || '')
+
+// "show or hide perspective labels" (BIAS-CONTROLS.md) -- never shown when
+// no source-level rating exists ("unrated sources remain usable and
+// visibly unrated": no label here just means no label, not "neutral").
+const perspectiveLabel = computed(() => {
+  if (!feedPreferenceStore.labelsVisible) return ''
+  const label = props.item.perspective?.label
+  if (!label) return ''
+  return label
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('-')
+})
 
 function relativeTime(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime()

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -144,6 +144,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import {
   applyNewsfeedFilters,
+  applyPerspectiveBalance,
   getFeedDefinition,
   type NewsFeedItem,
 } from '@/stores/helpers/newsfeed'
@@ -213,14 +214,20 @@ function filterPrefs() {
 }
 
 const allItems = computed<NewsFeedItem[]>(() =>
-  applyNewsfeedFilters(rawItems.value, filterPrefs()),
+  applyPerspectiveBalance(
+    applyNewsfeedFilters(rawItems.value, filterPrefs()),
+    feedPreferenceStore.perspectiveWeights,
+  ),
 )
 
 const visibleItems = computed<NewsFeedItem[]>(() => {
   if (activeSlug.value === 'all') return allItems.value
   const groupItems =
     groups.value.find((group) => group.slug === activeSlug.value)?.items ?? []
-  return applyNewsfeedFilters(groupItems, filterPrefs())
+  return applyPerspectiveBalance(
+    applyNewsfeedFilters(groupItems, filterPrefs()),
+    feedPreferenceStore.perspectiveWeights,
+  )
 })
 
 const displayedItems = computed(() =>
@@ -259,7 +266,12 @@ async function loadFeed(): Promise<void> {
         slug: aggregated.slug,
         title: definition?.title || aggregated.slug,
         icon: definition?.icon || 'kind-icon:news',
-        items: aggregated.items,
+        // Stamped here (not by the server) so applyPerspectiveBalance can
+        // gate on a merged, multi-feed list without needing feed context.
+        items: aggregated.items.map((item) => ({
+          ...item,
+          topicPolitical: definition?.topicPolitical ?? false,
+        })),
       }
     })
     sourceErrorCount.value = res.data.reduce(

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -152,6 +152,44 @@
       </div>
     </div>
 
+    <div class="flex flex-col gap-1.5">
+      <span class="text-xs font-bold">Perspective balance</span>
+      <p class="text-xs text-base-content/55">
+        Only reshapes feeds that carry political coverage (e.g. Activism) —
+        other feeds are never affected.
+      </p>
+      <div class="flex flex-wrap gap-1.5">
+        <button
+          v-for="mode in perspectiveModes"
+          :key="mode.value"
+          type="button"
+          class="btn btn-xs rounded-xl"
+          :class="
+            feedPreferenceStore.perspectiveMode === mode.value
+              ? 'btn-primary'
+              : 'btn-ghost border border-base-300'
+          "
+          :aria-pressed="feedPreferenceStore.perspectiveMode === mode.value"
+          @click="feedPreferenceStore.setPerspectiveMode(mode.value)"
+        >
+          {{ mode.label }}
+        </button>
+      </div>
+      <label class="flex w-fit items-center gap-2 pt-1 text-xs font-bold">
+        <input
+          type="checkbox"
+          class="toggle toggle-primary toggle-sm"
+          :checked="feedPreferenceStore.labelsVisible"
+          @change="
+            feedPreferenceStore.setLabelsVisible(
+              ($event.target as HTMLInputElement).checked,
+            )
+          "
+        />
+        Show perspective labels
+      </label>
+    </div>
+
     <div class="flex items-center gap-2">
       <label for="newsfeed-sort-mode" class="text-xs font-bold">Sort by</label>
       <select
@@ -175,7 +213,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import type { NewsFeedItem } from '@/stores/helpers/newsfeed'
+import type { NewsFeedItem, PerspectiveMode } from '@/stores/helpers/newsfeed'
 import { useFeedPreferenceStore } from '@/stores/feedPreferenceStore'
 
 const props = defineProps<{
@@ -187,6 +225,15 @@ const feedPreferenceStore = useFeedPreferenceStore()
 
 const includeDraft = ref('')
 const excludeDraft = ref('')
+
+// Custom (per-bucket weight sliders) is deferred per this task's own note --
+// "Custom per-bucket weights ... may follow once the simple modes work
+// cleanly." The store/type already support it for forward compatibility.
+const perspectiveModes: Array<{ value: Exclude<PerspectiveMode, 'custom'>; label: string }> = [
+  { value: 'focused', label: 'Focused' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'broad', label: 'Broad spectrum' },
+]
 
 const categories = computed<string[]>(() => {
   const seen = new Set<string>()

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:wonderlab-passive-card-fixtures": "tsx utils/scripts/verifyWonderLabPassiveCardFixtures.ts",
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",
     "test:newsfeed-filters": "tsx utils/scripts/verifyNewsfeedFilters.ts",
+    "test:newsfeed-perspective-balance": "tsx utils/scripts/verifyNewsfeedPerspectiveBalance.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/stores/feedPreferenceStore.ts
+++ b/stores/feedPreferenceStore.ts
@@ -13,6 +13,7 @@ import { computed, ref } from 'vue'
 import {
   DEFAULT_PERSPECTIVE_WEIGHTS,
   FEED_DEFINITIONS,
+  PERSPECTIVE_MODE_PRESETS,
   defaultEnabledFeedSlugs,
   getFeedDefinition,
   getFeedSources,
@@ -287,8 +288,14 @@ export const useFeedPreferenceStore = defineStore('feedPreferenceStore', () => {
     persist()
   }
 
+  // Focused/Balanced/Broad apply their preset weight shape (BIAS-CONTROLS.md
+  // MVP path); Custom keeps whatever weights setPerspectiveWeights last set,
+  // since it's the user's own dial-in rather than a preset.
   function setPerspectiveMode(mode: PerspectiveMode): void {
     perspectiveMode.value = mode
+    if (mode !== 'custom') {
+      perspectiveWeights.value = { ...PERSPECTIVE_MODE_PRESETS[mode] }
+    }
     persist()
   }
 

--- a/stores/helpers/newsfeed.ts
+++ b/stores/helpers/newsfeed.ts
@@ -74,6 +74,13 @@ export interface NewsFeedItem {
     source?: string
     confidence?: 'low' | 'medium' | 'high'
   }
+  /**
+   * Stamped client-side from the parent feed's FeedDefinition.topicPolitical
+   * when items are grouped (newsfeed-feed.vue) -- lets applyPerspectiveBalance
+   * gate on a merged, multi-feed item list without needing feed context of
+   * its own. Absent/false items are never reordered by perspective weight.
+   */
+  topicPolitical?: boolean
 }
 
 export type PerspectiveMode = 'focused' | 'balanced' | 'broad' | 'custom'
@@ -92,6 +99,29 @@ export const DEFAULT_PERSPECTIVE_WEIGHTS: PerspectiveWeights = {
   center: 1,
   centerRight: 1,
   right: 1,
+}
+
+/**
+ * Preset weight shapes for the three starter modes (BIAS-CONTROLS.md MVP
+ * path). `custom` has no preset -- it's whatever the user dialed in via
+ * setPerspectiveWeights. Weights are relative shape, not requirements: every
+ * bucket stays above zero so no viewpoint is ever fully excluded, per the
+ * "still surfacing major opposing coverage" / "don't force artificial
+ * symmetry" guardrails.
+ */
+export const PERSPECTIVE_MODE_PRESETS: Record<
+  Exclude<PerspectiveMode, 'custom'>,
+  PerspectiveWeights
+> = {
+  balanced: { left: 1, centerLeft: 1, center: 1, centerRight: 1, right: 1 },
+  focused: {
+    left: 0.6,
+    centerLeft: 1,
+    center: 1.4,
+    centerRight: 1,
+    right: 0.6,
+  },
+  broad: { left: 1.3, centerLeft: 1, center: 0.7, centerRight: 1, right: 1.3 },
 }
 
 // --- Source registry --------------------------------------------------
@@ -408,6 +438,136 @@ export function applyNewsfeedFilters(
   }
 
   return filtered.sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+}
+
+// --- Perspective balance (t-011) -----------------------------------------
+// A second, independent ranking pass layered on top of applyNewsfeedFilters'
+// recency/relevance ordering. Only ever reorders items among themselves
+// where item.topicPolitical is true -- non-political items keep their exact
+// index, so balancing one feed's mix can never distort another (BIAS-
+// CONTROLS.md guardrail). Unrated political items (no source perspective
+// label) are their own bucket, weighted as the average of the five named
+// buckets, so they're never excluded or penalized to zero -- "unrated
+// sources remain usable and visibly unrated."
+
+type PerspectiveBucketKey = PerspectiveLabel | 'unrated'
+
+const LABEL_TO_WEIGHT_KEY: Record<PerspectiveLabel, keyof PerspectiveWeights> = {
+  left: 'left',
+  'center-left': 'centerLeft',
+  center: 'center',
+  'center-right': 'centerRight',
+  right: 'right',
+}
+
+function bucketKeyFor(item: NewsFeedItem): PerspectiveBucketKey {
+  return item.perspective?.label ?? 'unrated'
+}
+
+function averageWeight(weights: PerspectiveWeights): number {
+  const values = Object.values(weights)
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function weightFor(
+  key: PerspectiveBucketKey,
+  weights: PerspectiveWeights,
+): number {
+  if (key === 'unrated') return Math.max(0, averageWeight(weights))
+  return Math.max(0, weights[LABEL_TO_WEIGHT_KEY[key]])
+}
+
+/**
+ * Smooth weighted round-robin merge (the same algorithm nginx uses for
+ * weighted load balancing): each bucket accumulates its weight every round
+ * and the highest accumulator is picked next, then debited by the total.
+ * This guarantees output proportion tracks input weight while preserving
+ * each bucket's own relative (already recency/relevance-sorted) order.
+ */
+function weightedRoundRobinMerge<T>(
+  buckets: Array<{ key: string; items: T[]; weight: number }>,
+): T[] {
+  const total = buckets.reduce((sum, bucket) => sum + bucket.weight, 0)
+  const cursors = new Map(buckets.map((bucket) => [bucket.key, 0]))
+  const currents = new Map(buckets.map((bucket) => [bucket.key, 0]))
+  const remaining = buckets.reduce((sum, bucket) => sum + bucket.items.length, 0)
+  const result: T[] = []
+
+  while (result.length < remaining) {
+    let winner: (typeof buckets)[number] | null = null
+    let winnerCurrent = -Infinity
+
+    for (const bucket of buckets) {
+      if ((cursors.get(bucket.key) ?? 0) >= bucket.items.length) continue
+      const next = (currents.get(bucket.key) ?? 0) + bucket.weight
+      currents.set(bucket.key, next)
+      if (next > winnerCurrent) {
+        winner = bucket
+        winnerCurrent = next
+      }
+    }
+
+    if (!winner) break // safety net: every non-empty bucket has weight <= 0
+
+    const index = cursors.get(winner.key) ?? 0
+    result.push(winner.items[index] as T)
+    cursors.set(winner.key, index + 1)
+    currents.set(winner.key, winnerCurrent - (total || 1))
+  }
+
+  return result
+}
+
+/**
+ * Reorders the political subset of `items` (those with `topicPolitical:
+ * true`) by perspective weight via weighted round-robin, leaving every
+ * non-political item pinned at its original index. Pure and
+ * side-effect-free -- pass the output of applyNewsfeedFilters straight in.
+ */
+export function applyPerspectiveBalance(
+  items: NewsFeedItem[],
+  weights: PerspectiveWeights,
+): NewsFeedItem[] {
+  const politicalIndices: number[] = []
+  const politicalItems: NewsFeedItem[] = []
+
+  items.forEach((item, index) => {
+    if (item.topicPolitical) {
+      politicalIndices.push(index)
+      politicalItems.push(item)
+    }
+  })
+
+  if (politicalItems.length < 2) return items
+
+  const byBucket = new Map<PerspectiveBucketKey, NewsFeedItem[]>()
+  for (const item of politicalItems) {
+    const key = bucketKeyFor(item)
+    const bucket = byBucket.get(key)
+    if (bucket) {
+      bucket.push(item)
+    } else {
+      byBucket.set(key, [item])
+    }
+  }
+
+  const buckets = [...byBucket.entries()].map(([key, bucketItems]) => ({
+    key,
+    items: bucketItems,
+    weight: weightFor(key, weights),
+  }))
+
+  const hasWeight = buckets.some((bucket) => bucket.weight > 0)
+  const merged = hasWeight
+    ? weightedRoundRobinMerge(buckets)
+    : politicalItems // every bucket weighted to zero -- leave order untouched
+
+  const result = [...items]
+  politicalIndices.forEach((originalIndex, i) => {
+    const replacement = merged[i]
+    if (replacement) result[originalIndex] = replacement
+  })
+  return result
 }
 
 /** Trims, dedupes (case-insensitive), drops empties, and bounds a keyword list. */

--- a/utils/scripts/verifyNewsfeedPerspectiveBalance.ts
+++ b/utils/scripts/verifyNewsfeedPerspectiveBalance.ts
@@ -1,0 +1,191 @@
+// /utils/scripts/verifyNewsfeedPerspectiveBalance.ts
+//
+// Regression test for the perspective-balance ranking layer (conductor
+// projects/newsfeed t-011, per BIAS-CONTROLS.md): stores/helpers/newsfeed.ts's
+// applyPerspectiveBalance() and PERSPECTIVE_MODE_PRESETS. No network/Vue
+// dependency -- pure functions over fixture NewsFeedItem objects.
+import assert from 'node:assert/strict'
+
+import {
+  DEFAULT_PERSPECTIVE_WEIGHTS,
+  PERSPECTIVE_MODE_PRESETS,
+  applyPerspectiveBalance,
+  type NewsFeedItem,
+  type PerspectiveLabel,
+  type PerspectiveWeights,
+} from '../../stores/helpers/newsfeed'
+
+function item(overrides: Partial<NewsFeedItem>): NewsFeedItem {
+  return {
+    id: overrides.id ?? 'fixture-id',
+    title: overrides.title ?? 'Fixture title',
+    summary: overrides.summary ?? '',
+    source: overrides.source ?? 'Fixture Source',
+    sourceId: overrides.sourceId ?? 'fixture-source',
+    url: overrides.url ?? 'https://example.com',
+    publishedAt: overrides.publishedAt ?? '2026-01-01T00:00:00.000Z',
+    category: overrides.category ?? [],
+    ...overrides,
+  }
+}
+
+function politicalItem(id: string, label?: PerspectiveLabel): NewsFeedItem {
+  return item({
+    id,
+    topicPolitical: true,
+    perspective: label ? { label, source: 'Fixture Rater' } : undefined,
+  })
+}
+
+// --- non-political items are never touched ---------------------------------
+
+const nonPolitical = [
+  item({ id: 'tech-1' }),
+  item({ id: 'tech-2' }),
+  item({ id: 'tech-3' }),
+]
+assert.deepEqual(
+  applyPerspectiveBalance(nonPolitical, DEFAULT_PERSPECTIVE_WEIGHTS).map(
+    (i) => i.id,
+  ),
+  ['tech-1', 'tech-2', 'tech-3'],
+  'items with no topicPolitical flag must keep their exact original order',
+)
+
+// --- fewer than two political items is a pass-through -----------------------
+
+const singlePolitical = [item({ id: 'a' }), politicalItem('b', 'left')]
+assert.deepEqual(
+  applyPerspectiveBalance(singlePolitical, DEFAULT_PERSPECTIVE_WEIGHTS).map(
+    (i) => i.id,
+  ),
+  ['a', 'b'],
+  'a single political item has nothing to balance against -- pass through unchanged',
+)
+
+// --- non-political items pinned at their original index ---------------------
+
+const mixed = [
+  item({ id: 'tech-a' }),
+  politicalItem('left-1', 'left'),
+  politicalItem('right-1', 'right'),
+  item({ id: 'tech-b' }),
+  politicalItem('left-2', 'left'),
+  politicalItem('right-2', 'right'),
+]
+const mixedBalanced = applyPerspectiveBalance(mixed, DEFAULT_PERSPECTIVE_WEIGHTS)
+assert.equal(mixedBalanced[0]?.id, 'tech-a', 'non-political item must stay at index 0')
+assert.equal(mixedBalanced[3]?.id, 'tech-b', 'non-political item must stay at index 3')
+assert.deepEqual(
+  mixedBalanced.map((i) => i.id).filter((id) => id.startsWith('tech-')),
+  ['tech-a', 'tech-b'],
+  'non-political items must never move relative to each other or the whole list',
+)
+
+// --- equal weights interleave buckets rather than grouping them -------------
+
+const evenLeft = [
+  politicalItem('left-1', 'left'),
+  politicalItem('left-2', 'left'),
+  politicalItem('left-3', 'left'),
+]
+const evenRight = [
+  politicalItem('right-1', 'right'),
+  politicalItem('right-2', 'right'),
+  politicalItem('right-3', 'right'),
+]
+const evenMerged = applyPerspectiveBalance(
+  [...evenLeft, ...evenRight],
+  DEFAULT_PERSPECTIVE_WEIGHTS,
+).map((i) => i.id)
+assert.notDeepEqual(
+  evenMerged,
+  ['left-1', 'left-2', 'left-3', 'right-1', 'right-2', 'right-3'],
+  'equal weights must interleave left/right rather than leaving them grouped by input order',
+)
+// Every bucket's own internal order is preserved regardless of interleaving.
+assert.deepEqual(
+  evenMerged.filter((id) => id.startsWith('left-')),
+  ['left-1', 'left-2', 'left-3'],
+)
+assert.deepEqual(
+  evenMerged.filter((id) => id.startsWith('right-')),
+  ['right-1', 'right-2', 'right-3'],
+)
+
+// --- weighting toward one bucket surfaces it earlier ------------------------
+
+const skewWeights: PerspectiveWeights = {
+  left: 5,
+  centerLeft: 1,
+  center: 1,
+  centerRight: 1,
+  right: 0.2,
+}
+const skewed = applyPerspectiveBalance(
+  [...evenLeft, ...evenRight],
+  skewWeights,
+).map((i) => i.id)
+assert.ok(
+  skewed.indexOf('left-1') < skewed.indexOf('right-1'),
+  'a heavily left-weighted balance must surface the first left item before the first right item',
+)
+
+// --- unrated political items form their own bucket, never excluded ---------
+
+const withUnrated = [
+  politicalItem('left-1', 'left'),
+  politicalItem('unrated-1'),
+  politicalItem('right-1', 'right'),
+  politicalItem('unrated-2'),
+]
+const unratedResult = applyPerspectiveBalance(
+  withUnrated,
+  DEFAULT_PERSPECTIVE_WEIGHTS,
+).map((i) => i.id)
+assert.deepEqual(
+  [...unratedResult].sort(),
+  [...withUnrated.map((i) => i.id)].sort(),
+  'unrated political items must remain present -- never dropped',
+)
+
+// --- all-zero custom weights degrades to a no-op rather than looping -------
+
+const zeroWeights: PerspectiveWeights = {
+  left: 0,
+  centerLeft: 0,
+  center: 0,
+  centerRight: 0,
+  right: 0,
+}
+const zeroResult = applyPerspectiveBalance(
+  [politicalItem('a', 'left'), politicalItem('b', 'right')],
+  zeroWeights,
+).map((i) => i.id)
+assert.deepEqual(
+  zeroResult,
+  ['a', 'b'],
+  'all-zero weights must fall back to original order, not hang or throw',
+)
+
+// --- mode presets: every bucket stays above zero (never fully excludes) ----
+
+for (const [mode, weights] of Object.entries(PERSPECTIVE_MODE_PRESETS)) {
+  for (const [bucket, value] of Object.entries(weights)) {
+    assert.ok(
+      value > 0,
+      `${mode} preset's ${bucket} weight must stay above zero -- no viewpoint fully excluded`,
+    )
+  }
+}
+assert.deepEqual(
+  PERSPECTIVE_MODE_PRESETS.balanced,
+  DEFAULT_PERSPECTIVE_WEIGHTS,
+  'balanced preset must match the neutral default weights',
+)
+
+console.log(
+  'newsfeed perspective balance verified: non-political pass-through, ' +
+    'weighted interleaving, unrated-bucket inclusion, zero-weight safety, ' +
+    'and mode preset shape.',
+)


### PR DESCRIPTION
### Task
newsfeed/t-011: Add adjustable political perspective balance (kind: software)

### What changed
Wires up the perspective-balance plumbing that earlier tasks (t-004/t-008) built ahead of schedule but nothing read yet, per `projects/newsfeed/BIAS-CONTROLS.md`:

- **`stores/helpers/newsfeed.ts`**: added `PERSPECTIVE_MODE_PRESETS` (focused/balanced/broad — every bucket weight stays above zero so no viewpoint is ever fully excluded) and a new pure `applyPerspectiveBalance()` — a smooth weighted round-robin merge that reorders only items from feeds flagged `topicPolitical: true`; every non-political item is pinned at its exact original index, so balancing one feed can never distort another. Unrated political items (no source perspective label) form their own bucket weighted as the average of the five named buckets, so they're never excluded or penalized to zero. Added an optional `topicPolitical` field to `NewsFeedItem`.
- **`stores/feedPreferenceStore.ts`**: `setPerspectiveMode()` now actually applies the mode's preset weights instead of leaving `perspectiveWeights` untouched (previously a no-op on weights for focused/balanced/broad).
- **`components/newsfeed/newsfeed-feed.vue`**: stamps `topicPolitical` onto each item from its `FeedDefinition` at group-assembly time (client-side), so a merged, multi-feed "All" view can still gate perspective balancing correctly; applies `applyPerspectiveBalance` after the existing recency/relevance filter pass.
- **`components/newsfeed/newsfeed-filters.vue`**: added a Focused/Balanced/Broad-spectrum mode selector and a "Show perspective labels" toggle.
- **`components/newsfeed/feed-card.vue`**: added a perspective badge, shown only when the item carries a source rating *and* labels are visible — never shown for unrated sources (they stay visibly unrated, not silently backfilled).
- **`utils/scripts/verifyNewsfeedPerspectiveBalance.ts`** (new): pass-through-for-non-political, weighted-interleave, unrated-bucket-inclusion, zero-weight-safety, and preset-shape assertions. Wired into `package.json` (`test:newsfeed-perspective-balance`) and `.github/workflows/contract-tests.yml`.

**Deferred (per the task's own note):** Custom per-bucket weight sliders and "contrasting-coverage" grouping — the note explicitly says these "may follow once the simple modes work cleanly." The `custom` mode value stays supported in the type/store for forward compatibility; it's just not exposed in this UI yet.

**Deliberately not done:** seeding real `perspective` ratings onto `FEED_SOURCES` entries (currently all empty). Assigning a political-lean label to a specific real organization (e.g. the Activism feed's `globalcitizen`/`devex-news` sources) needs an actual rating methodology or citation — inventing one myself would violate BIAS-CONTROLS.md's own guardrail ("never describe source bias ratings as objective fact; expose methodology and provenance") rather than satisfy it. Left as a flagged follow-up for whoever has a real source to cite.

### How I verified
- `npm run test` (nuxi prepare + vue-tsc --noEmit) — clean.
- `npx eslint` on every changed file — clean.
- All three newsfeed contract scripts (`test:newsfeed-filters`, `test:newsfeed-aggregation`, `test:newsfeed-perspective-balance`) pass.
- `test:wonderlab-passive-card-fixtures` still passes — `feed-card.vue` is also a WonderLab preview fixture and that script regex-asserts several exact substrings in its source; none were touched.

### Stakes
Reversible — purely additive: new optional item field, new pure ranking function applied only to feeds already flagged `topicPolitical` (today, only the Activism feed), new UI controls, no server/schema changes.

### Flags for Reviewer
- No real source perspective ratings exist yet in `FEED_SOURCES`, so today the mode selector and badge have nothing to visibly act on for a normal user until at least one source gets a `perspective` value — the ranking/UI code path is real and tested, but there's no live demo data yet.
- The `contrastPreference` boolean already persisted by the store (from earlier tasks) is still unused by ranking logic — intentional, per this task's own deferred scope.

### Notes for reviewer
Conductor task: newsfeed/t-011 (set to `status: review` in the conductor roadmap as part of this same session).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9yuj5pJGidMDWvZtvznB4)_