### PR TITLE
WonderLab: add admin review draft workflow API

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Review draft storage expand contract
         run: npx tsx utils/scripts/verifyReviewDraftStorageExpand.ts
 
+      - name: Review draft admin API contract
+        run: npx tsx utils/scripts/verifyReviewDraftAdminApi.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/server/api/admin/wonderlab/review-drafts/[id].get.ts
+++ b/server/api/admin/wonderlab/review-drafts/[id].get.ts
@@ -1,0 +1,22 @@
+// /server/api/admin/wonderlab/review-drafts/[id].get.ts
+import { createError, defineEventHandler, getRouterParam, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { getReviewDraftById } from '@/server/utils/reviewDraftRepository'
+import { positiveReviewDraftId } from '@/utils/wonderlab/reviewDraft'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const id = positiveReviewDraftId(getRouterParam(event, 'id'))
+    if (!id) throw createError({ statusCode: 400, message: 'Invalid review draft ID.' })
+
+    const draft = await getReviewDraftById(id)
+    if (!draft) throw createError({ statusCode: 404, message: 'Review draft not found.' })
+
+    return { success: true, data: draft }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/admin/wonderlab/review-drafts/[id].patch.ts
+++ b/server/api/admin/wonderlab/review-drafts/[id].patch.ts
@@ -1,0 +1,99 @@
+// /server/api/admin/wonderlab/review-drafts/[id].patch.ts
+import { createError, defineEventHandler, getRouterParam, H3Error, readBody } from 'h3'
+import { ReactionType } from '~/prisma/generated/prisma/client'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { updateReviewDraft } from '@/server/utils/reviewDraftRepository'
+import {
+  normalizeReviewDraftRating,
+  normalizeReviewDraftStatus,
+  normalizeReviewDraftText,
+  positiveReviewDraftId,
+} from '@/utils/wonderlab/reviewDraft'
+
+type ReviewDraftPatchBody = {
+  status?: unknown
+  editedComment?: unknown
+  rating?: unknown
+  reactionType?: unknown
+  failureReason?: unknown
+}
+
+function optionalReactionType(value: unknown): ReactionType | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'reactionType must be a string.' })
+  }
+
+  const normalized = value.trim().toUpperCase() as ReactionType
+  if (!Object.values(ReactionType).includes(normalized)) {
+    throw createError({ statusCode: 400, message: 'Invalid reactionType.' })
+  }
+  return normalized
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const id = positiveReviewDraftId(getRouterParam(event, 'id'))
+    if (!id) throw createError({ statusCode: 400, message: 'Invalid review draft ID.' })
+
+    const body = await readBody<ReviewDraftPatchBody>(event)
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'Review draft patch is required.' })
+    }
+
+    const status = body.status === undefined ? undefined : normalizeReviewDraftStatus(body.status)
+    if (body.status !== undefined && !status) {
+      throw createError({ statusCode: 400, message: 'Invalid review draft status.' })
+    }
+
+    let editedComment: string | null | undefined
+    let failureReason: string | null | undefined
+    try {
+      editedComment =
+        body.editedComment === undefined
+          ? undefined
+          : normalizeReviewDraftText(body.editedComment, { maxLength: 20_000 })
+      failureReason =
+        body.failureReason === undefined
+          ? undefined
+          : normalizeReviewDraftText(body.failureReason, { maxLength: 4_000 })
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message: error instanceof Error ? error.message : 'Invalid review draft text.',
+      })
+    }
+
+    if (body.rating !== undefined && !Number.isFinite(Number(body.rating))) {
+      throw createError({ statusCode: 400, message: 'rating must be numeric.' })
+    }
+
+    const updated = await updateReviewDraft({
+      id,
+      actorUserId: auth.user.id,
+      status: status ?? undefined,
+      editedComment,
+      rating:
+        body.rating === undefined ? undefined : normalizeReviewDraftRating(body.rating),
+      reactionType: optionalReactionType(body.reactionType),
+      failureReason,
+    })
+
+    return { success: true, data: updated, message: 'Review draft updated.' }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+
+    const message = error instanceof Error ? error.message : 'Failed to update review draft.'
+    if (/not found/i.test(message)) {
+      throw createError({ statusCode: 404, message })
+    }
+    if (/cannot transition|only the controlled publication service/i.test(message)) {
+      throw createError({ statusCode: 409, message })
+    }
+
+    return errorHandler(error)
+  }
+})

--- a/server/api/admin/wonderlab/review-drafts/index.get.ts
+++ b/server/api/admin/wonderlab/review-drafts/index.get.ts
@@ -1,0 +1,56 @@
+// /server/api/admin/wonderlab/review-drafts/index.get.ts
+import { createError, defineEventHandler, getQuery, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { listReviewDrafts } from '@/server/utils/reviewDraftRepository'
+import {
+  normalizeReviewDraftStatus,
+  positiveReviewDraftId,
+} from '@/utils/wonderlab/reviewDraft'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const query = getQuery(event)
+
+    const status = query.status
+      ? normalizeReviewDraftStatus(query.status)
+      : null
+    if (query.status && !status) {
+      throw createError({ statusCode: 400, message: 'Invalid review draft status.' })
+    }
+
+    const componentId = query.componentId
+      ? positiveReviewDraftId(query.componentId)
+      : null
+    const authorBotId = query.authorBotId
+      ? positiveReviewDraftId(query.authorBotId)
+      : null
+    const authorCharacterId = query.authorCharacterId
+      ? positiveReviewDraftId(query.authorCharacterId)
+      : null
+
+    if (query.componentId && !componentId) {
+      throw createError({ statusCode: 400, message: 'Invalid componentId.' })
+    }
+    if (query.authorBotId && !authorBotId) {
+      throw createError({ statusCode: 400, message: 'Invalid authorBotId.' })
+    }
+    if (query.authorCharacterId && !authorCharacterId) {
+      throw createError({ statusCode: 400, message: 'Invalid authorCharacterId.' })
+    }
+
+    const drafts = await listReviewDrafts({
+      status,
+      componentId,
+      authorBotId,
+      authorCharacterId,
+      limit: Number(query.limit) || 100,
+    })
+
+    return { success: true, data: drafts, count: drafts.length }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/admin/wonderlab/review-drafts/index.post.ts
+++ b/server/api/admin/wonderlab/review-drafts/index.post.ts
@@ -1,0 +1,130 @@
+// /server/api/admin/wonderlab/review-drafts/index.post.ts
+import { createError, defineEventHandler, H3Error, readBody } from 'h3'
+import { ReactionType } from '~/prisma/generated/prisma/client'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { createReviewDraft } from '@/server/utils/reviewDraftRepository'
+import {
+  normalizeReviewDraftRating,
+  normalizeReviewDraftText,
+  positiveReviewDraftId,
+  reviewDraftAuthor,
+} from '@/utils/wonderlab/reviewDraft'
+
+type ReviewDraftCreateBody = {
+  componentId?: unknown
+  authorBotId?: unknown
+  authorCharacterId?: unknown
+  promptVersion?: unknown
+  promptHash?: unknown
+  promptPayload?: unknown
+  generatedComment?: unknown
+  rating?: unknown
+  reactionType?: unknown
+  generationModel?: unknown
+  generationProvider?: unknown
+}
+
+function optionalReactionType(value: unknown): ReactionType | null {
+  if (value === null || value === undefined || value === '') return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'reactionType must be a string.' })
+  }
+
+  const normalized = value.trim().toUpperCase() as ReactionType
+  if (!Object.values(ReactionType).includes(normalized)) {
+    throw createError({ statusCode: 400, message: 'Invalid reactionType.' })
+  }
+  return normalized
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const body = await readBody<ReviewDraftCreateBody>(event)
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'Review draft payload is required.' })
+    }
+
+    const componentId = positiveReviewDraftId(body.componentId)
+    if (!componentId) {
+      throw createError({ statusCode: 400, message: 'A valid componentId is required.' })
+    }
+
+    let author
+    try {
+      author = reviewDraftAuthor(body.authorBotId, body.authorCharacterId)
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message: error instanceof Error ? error.message : 'Invalid author identity.',
+      })
+    }
+
+    let promptVersion: string
+    let promptHash: string
+    let generatedComment: string
+    let generationModel: string | null
+    let generationProvider: string | null
+    try {
+      promptVersion = normalizeReviewDraftText(body.promptVersion, {
+        required: true,
+        maxLength: 64,
+      }) as string
+      promptHash = normalizeReviewDraftText(body.promptHash, {
+        required: true,
+        maxLength: 191,
+      }) as string
+      generatedComment = normalizeReviewDraftText(body.generatedComment, {
+        required: true,
+        maxLength: 20_000,
+      }) as string
+      generationModel = normalizeReviewDraftText(body.generationModel, {
+        maxLength: 191,
+      })
+      generationProvider = normalizeReviewDraftText(body.generationProvider, {
+        maxLength: 64,
+      })
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message: error instanceof Error ? error.message : 'Invalid review draft text.',
+      })
+    }
+
+    if (body.promptPayload !== undefined) {
+      try {
+        JSON.stringify(body.promptPayload)
+      } catch {
+        throw createError({ statusCode: 400, message: 'promptPayload must be JSON serializable.' })
+      }
+    }
+
+    const result = await createReviewDraft({
+      componentId,
+      author,
+      promptVersion,
+      promptHash,
+      promptPayload: body.promptPayload,
+      generatedComment,
+      rating: normalizeReviewDraftRating(body.rating),
+      reactionType: optionalReactionType(body.reactionType),
+      generationModel,
+      generationProvider,
+    })
+
+    event.node.res.statusCode = result.created ? 201 : 200
+    return {
+      success: true,
+      data: result.draft,
+      created: result.created,
+      message: result.created
+        ? 'Review draft created.'
+        : 'The deterministic review draft already exists.',
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/utils/reviewDraftRepository.ts
+++ b/server/utils/reviewDraftRepository.ts
@@ -1,0 +1,326 @@
+// /server/utils/reviewDraftRepository.ts
+import prisma from '@/server/utils/prisma'
+import {
+  assertReviewDraftTransition,
+  buildReviewDraftKey,
+  finalReviewDraftComment,
+  type ReviewDraftAuthorRef,
+  type ReviewDraftPublicAuthor,
+  type ReviewDraftStatus,
+} from '@/utils/wonderlab/reviewDraft'
+
+export type ReviewDraftRecord = {
+  id: number
+  createdAt: Date
+  updatedAt: Date | null
+  status: ReviewDraftStatus
+  draftKey: string
+  componentId: number
+  componentName: string
+  componentTitle: string | null
+  authorBotId: number | null
+  authorCharacterId: number | null
+  author: ReviewDraftPublicAuthor
+  publisherUserId: number | null
+  publisherName: string | null
+  publishedReactionId: number | null
+  promptVersion: string
+  promptHash: string
+  promptPayload: unknown
+  generatedComment: string
+  editedComment: string | null
+  finalComment: string
+  rating: number
+  reactionType: string | null
+  generationModel: string | null
+  generationProvider: string | null
+  generationAttempt: number
+  approvedAt: Date | null
+  rejectedAt: Date | null
+  publishedAt: Date | null
+  failureReason: string | null
+}
+
+type ReviewDraftRow = Omit<ReviewDraftRecord, 'author' | 'finalComment' | 'promptPayload'> & {
+  promptPayload: unknown
+  botName: string | null
+  botAvatarImage: string | null
+  botImagePath: string | null
+  botRole: string | null
+  characterName: string | null
+  characterImagePath: string | null
+  characterRole: string | null
+}
+
+export type ReviewDraftListFilters = {
+  status?: ReviewDraftStatus | null
+  componentId?: number | null
+  authorBotId?: number | null
+  authorCharacterId?: number | null
+  limit?: number
+}
+
+export type CreateReviewDraftInput = {
+  componentId: number
+  author: ReviewDraftAuthorRef
+  promptVersion: string
+  promptHash: string
+  promptPayload?: unknown
+  generatedComment: string
+  rating: number
+  reactionType?: string | null
+  generationModel?: string | null
+  generationProvider?: string | null
+}
+
+export type UpdateReviewDraftInput = {
+  id: number
+  actorUserId: number
+  status?: ReviewDraftStatus
+  editedComment?: string | null
+  rating?: number
+  reactionType?: string | null
+  failureReason?: string | null
+}
+
+function safePromptPayload(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+function rowAuthor(row: ReviewDraftRow): ReviewDraftPublicAuthor {
+  if (row.authorBotId) {
+    return {
+      kind: 'BOT',
+      id: row.authorBotId,
+      name: row.botName?.trim() || `Bot #${row.authorBotId}`,
+      avatarImage: row.botAvatarImage?.trim() || row.botImagePath?.trim() || null,
+      role: row.botRole?.trim() || 'BOT',
+    }
+  }
+
+  if (row.authorCharacterId) {
+    return {
+      kind: 'CHARACTER',
+      id: row.authorCharacterId,
+      name: row.characterName?.trim() || `Character #${row.authorCharacterId}`,
+      avatarImage: row.characterImagePath?.trim() || null,
+      role: row.characterRole?.trim() || 'CHARACTER',
+    }
+  }
+
+  throw new Error(`ReviewDraft ${row.id} has no valid first-party author.`)
+}
+
+function mapReviewDraft(row: ReviewDraftRow): ReviewDraftRecord {
+  return {
+    ...row,
+    author: rowAuthor(row),
+    promptPayload: safePromptPayload(row.promptPayload),
+    finalComment: finalReviewDraftComment(row),
+  }
+}
+
+const selectReviewDraft = `
+  SELECT
+    rd.*,
+    c.componentName,
+    c.title AS componentTitle,
+    b.name AS botName,
+    b.avatarImage AS botAvatarImage,
+    b.imagePath AS botImagePath,
+    b.BotType AS botRole,
+    ch.name AS characterName,
+    ch.imagePath AS characterImagePath,
+    ch.role AS characterRole,
+    COALESCE(u.name, u.username) AS publisherName
+  FROM ReviewDraft rd
+  INNER JOIN Component c ON c.id = rd.componentId
+  LEFT JOIN Bot b ON b.id = rd.authorBotId
+  LEFT JOIN Character ch ON ch.id = rd.authorCharacterId
+  LEFT JOIN User u ON u.id = rd.publisherUserId
+`
+
+export async function listReviewDrafts(
+  filters: ReviewDraftListFilters = {},
+): Promise<ReviewDraftRecord[]> {
+  const status = filters.status ?? null
+  const componentId = filters.componentId ?? null
+  const authorBotId = filters.authorBotId ?? null
+  const authorCharacterId = filters.authorCharacterId ?? null
+  const limit = Math.max(1, Math.min(200, Math.round(filters.limit ?? 100)))
+
+  const rows = await prisma.$queryRawUnsafe<ReviewDraftRow[]>(
+    `${selectReviewDraft}
+      WHERE (? IS NULL OR rd.status = ?)
+        AND (? IS NULL OR rd.componentId = ?)
+        AND (? IS NULL OR rd.authorBotId = ?)
+        AND (? IS NULL OR rd.authorCharacterId = ?)
+      ORDER BY rd.updatedAt DESC, rd.createdAt DESC, rd.id DESC
+      LIMIT ?`,
+    status,
+    status,
+    componentId,
+    componentId,
+    authorBotId,
+    authorBotId,
+    authorCharacterId,
+    authorCharacterId,
+    limit,
+  )
+
+  return rows.map(mapReviewDraft)
+}
+
+export async function getReviewDraftById(id: number): Promise<ReviewDraftRecord | null> {
+  const rows = await prisma.$queryRawUnsafe<ReviewDraftRow[]>(
+    `${selectReviewDraft} WHERE rd.id = ? LIMIT 1`,
+    id,
+  )
+  return rows[0] ? mapReviewDraft(rows[0]) : null
+}
+
+export async function getReviewDraftByKey(
+  draftKey: string,
+): Promise<ReviewDraftRecord | null> {
+  const rows = await prisma.$queryRawUnsafe<ReviewDraftRow[]>(
+    `${selectReviewDraft} WHERE rd.draftKey = ? LIMIT 1`,
+    draftKey,
+  )
+  return rows[0] ? mapReviewDraft(rows[0]) : null
+}
+
+async function assertReviewDraftReferences(input: CreateReviewDraftInput): Promise<void> {
+  const components = await prisma.$queryRaw<Array<{ id: number }>>`
+    SELECT id FROM Component WHERE id = ${input.componentId} LIMIT 1
+  `
+  if (!components.length) throw new Error(`Component ${input.componentId} not found.`)
+
+  if (input.author.kind === 'BOT') {
+    const authors = await prisma.$queryRaw<Array<{ id: number }>>`
+      SELECT id FROM Bot
+      WHERE id = ${input.author.id} AND isActive = TRUE AND isPublic = TRUE
+      LIMIT 1
+    `
+    if (!authors.length) throw new Error(`Eligible Bot ${input.author.id} not found.`)
+    return
+  }
+
+  const authors = await prisma.$queryRaw<Array<{ id: number }>>`
+    SELECT id FROM Character
+    WHERE id = ${input.author.id} AND isActive = TRUE AND isPublic = TRUE
+    LIMIT 1
+  `
+  if (!authors.length) throw new Error(`Eligible Character ${input.author.id} not found.`)
+}
+
+export async function createReviewDraft(
+  input: CreateReviewDraftInput,
+): Promise<{ draft: ReviewDraftRecord; created: boolean }> {
+  await assertReviewDraftReferences(input)
+
+  const draftKey = buildReviewDraftKey(input)
+  const authorBotId = input.author.kind === 'BOT' ? input.author.id : null
+  const authorCharacterId = input.author.kind === 'CHARACTER' ? input.author.id : null
+  const payload = input.promptPayload === undefined ? null : JSON.stringify(input.promptPayload)
+
+  const inserted = await prisma.$executeRaw`
+    INSERT IGNORE INTO ReviewDraft (
+      status,
+      draftKey,
+      componentId,
+      authorBotId,
+      authorCharacterId,
+      promptVersion,
+      promptHash,
+      promptPayload,
+      generatedComment,
+      rating,
+      reactionType,
+      generationModel,
+      generationProvider
+    ) VALUES (
+      'PROPOSED',
+      ${draftKey},
+      ${input.componentId},
+      ${authorBotId},
+      ${authorCharacterId},
+      ${input.promptVersion},
+      ${input.promptHash},
+      ${payload},
+      ${input.generatedComment},
+      ${input.rating},
+      ${input.reactionType ?? null},
+      ${input.generationModel ?? null},
+      ${input.generationProvider ?? null}
+    )
+  `
+
+  const draft = await getReviewDraftByKey(draftKey)
+  if (!draft) throw new Error('Review draft was not readable after creation.')
+
+  return { draft, created: inserted > 0 }
+}
+
+export async function updateReviewDraft(
+  input: UpdateReviewDraftInput,
+): Promise<ReviewDraftRecord> {
+  const current = await getReviewDraftById(input.id)
+  if (!current) throw new Error(`Review draft ${input.id} not found.`)
+
+  const contentChanged =
+    input.editedComment !== undefined ||
+    input.rating !== undefined ||
+    input.reactionType !== undefined
+
+  let status = input.status ?? current.status
+  if (contentChanged && current.status === 'APPROVED' && input.status === undefined) {
+    status = 'PROPOSED'
+  }
+
+  if (status === 'PUBLISHED') {
+    throw new Error('Only the controlled publication service may publish a review draft.')
+  }
+
+  assertReviewDraftTransition(current.status, status)
+
+  const editedComment =
+    input.editedComment === undefined ? current.editedComment : input.editedComment
+  const rating = input.rating === undefined ? current.rating : input.rating
+  const reactionType =
+    input.reactionType === undefined ? current.reactionType : input.reactionType
+  const failureReason =
+    status === 'FAILED'
+      ? input.failureReason?.trim() || current.failureReason || 'Draft validation failed.'
+      : input.failureReason === undefined
+        ? current.failureReason
+        : input.failureReason
+
+  const approvedAt = status === 'APPROVED' ? current.approvedAt ?? new Date() : null
+  const rejectedAt = status === 'REJECTED' ? current.rejectedAt ?? new Date() : null
+  const publisherUserId = status === 'APPROVED' ? input.actorUserId : current.publisherUserId
+
+  await prisma.$executeRaw`
+    UPDATE ReviewDraft
+    SET
+      updatedAt = CURRENT_TIMESTAMP(3),
+      status = ${status},
+      editedComment = ${editedComment},
+      rating = ${rating},
+      reactionType = ${reactionType},
+      failureReason = ${failureReason},
+      approvedAt = ${approvedAt},
+      rejectedAt = ${rejectedAt},
+      publisherUserId = ${publisherUserId}
+    WHERE id = ${input.id}
+  `
+
+  const updated = await getReviewDraftById(input.id)
+  if (!updated) throw new Error('Review draft disappeared after update.')
+  return updated
+}

--- a/utils/scripts/verifyReviewDraftAdminApi.ts
+++ b/utils/scripts/verifyReviewDraftAdminApi.ts
@@ -46,24 +46,23 @@ assert.equal(canTransitionReviewDraft('PROPOSED', 'APPROVED'), true)
 assert.equal(canTransitionReviewDraft('PUBLISHED', 'PROPOSED'), false)
 assert.throws(() => assertReviewDraftTransition('SUPERSEDED', 'APPROVED'), /cannot transition/i)
 
-const paths = [
-  'server/api/admin/wonderlab/review-drafts/index.get.ts',
-  'server/api/admin/wonderlab/review-drafts/index.post.ts',
-  'server/api/admin/wonderlab/review-drafts/[id].get.ts',
-  'server/api/admin/wonderlab/review-drafts/[id].patch.ts',
-]
+const listPath = 'server/api/admin/wonderlab/review-drafts/index.get.ts'
+const createPath = 'server/api/admin/wonderlab/review-drafts/index.post.ts'
+const detailPath = 'server/api/admin/wonderlab/review-drafts/[id].get.ts'
+const patchPath = 'server/api/admin/wonderlab/review-drafts/[id].patch.ts'
+const paths = [listPath, createPath, detailPath, patchPath]
 
 for (const path of paths) {
   const source = await readFile(path, 'utf8')
   assert.match(source, /requireAdminApiUser\(event\)/, `${path} must be admin-only`)
 }
 
-const createSource = await readFile(paths[1], 'utf8')
+const createSource = await readFile(createPath, 'utf8')
 assert.doesNotMatch(createSource, /publisherUserId\??:/)
 assert.doesNotMatch(createSource, /publishedReactionId\??:/)
 assert.doesNotMatch(createSource, /status\??:/)
 
-const patchSource = await readFile(paths[3], 'utf8')
+const patchSource = await readFile(patchPath, 'utf8')
 assert.match(patchSource, /controlled publication service/i)
 
 const repositorySource = await readFile('server/utils/reviewDraftRepository.ts', 'utf8')

--- a/utils/scripts/verifyReviewDraftAdminApi.ts
+++ b/utils/scripts/verifyReviewDraftAdminApi.ts
@@ -1,0 +1,74 @@
+// /utils/scripts/verifyReviewDraftAdminApi.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  assertReviewDraftTransition,
+  buildReviewDraftKey,
+  canTransitionReviewDraft,
+  finalReviewDraftComment,
+  normalizeReviewDraftRating,
+  reviewDraftAuthor,
+} from '@/utils/wonderlab/reviewDraft'
+
+const bot = reviewDraftAuthor(7, null)
+const character = reviewDraftAuthor(null, 9)
+assert.deepEqual(bot, { kind: 'BOT', id: 7 })
+assert.deepEqual(character, { kind: 'CHARACTER', id: 9 })
+assert.throws(() => reviewDraftAuthor(null, null), /exactly one/i)
+assert.throws(() => reviewDraftAuthor(7, 9), /exactly one/i)
+
+const keyA = buildReviewDraftKey({
+  componentId: 12,
+  author: bot,
+  promptVersion: 'wonderlab-v1',
+  promptHash: 'abc123',
+})
+const keyB = buildReviewDraftKey({
+  componentId: 12,
+  author: bot,
+  promptVersion: 'wonderlab-v1',
+  promptHash: 'abc123',
+})
+const keyC = buildReviewDraftKey({
+  componentId: 12,
+  author: character,
+  promptVersion: 'wonderlab-v1',
+  promptHash: 'abc123',
+})
+assert.equal(keyA, keyB, 'draft keys must be deterministic')
+assert.notEqual(keyA, keyC, 'reviewer identity must be part of the key')
+assert.ok(keyA.length <= 191)
+
+assert.equal(normalizeReviewDraftRating(7), 5)
+assert.equal(normalizeReviewDraftRating(-2), 0)
+assert.equal(finalReviewDraftComment({ generatedComment: 'generated', editedComment: ' edited ' }), 'edited')
+assert.equal(canTransitionReviewDraft('PROPOSED', 'APPROVED'), true)
+assert.equal(canTransitionReviewDraft('PUBLISHED', 'PROPOSED'), false)
+assert.throws(() => assertReviewDraftTransition('SUPERSEDED', 'APPROVED'), /cannot transition/i)
+
+const paths = [
+  'server/api/admin/wonderlab/review-drafts/index.get.ts',
+  'server/api/admin/wonderlab/review-drafts/index.post.ts',
+  'server/api/admin/wonderlab/review-drafts/[id].get.ts',
+  'server/api/admin/wonderlab/review-drafts/[id].patch.ts',
+]
+
+for (const path of paths) {
+  const source = await readFile(path, 'utf8')
+  assert.match(source, /requireAdminApiUser\(event\)/, `${path} must be admin-only`)
+}
+
+const createSource = await readFile(paths[1], 'utf8')
+assert.doesNotMatch(createSource, /publisherUserId\??:/)
+assert.doesNotMatch(createSource, /publishedReactionId\??:/)
+assert.doesNotMatch(createSource, /status\??:/)
+
+const patchSource = await readFile(paths[3], 'utf8')
+assert.match(patchSource, /controlled publication service/i)
+
+const repositorySource = await readFile('server/utils/reviewDraftRepository.ts', 'utf8')
+assert.match(repositorySource, /INSERT IGNORE INTO ReviewDraft/)
+assert.doesNotMatch(repositorySource, /INSERT\s+(?:IGNORE\s+)?INTO\s+Reaction/i)
+assert.doesNotMatch(repositorySource, /DELETE\s+FROM\s+Reaction/i)
+
+console.log('Review draft admin API contract passed.')

--- a/utils/wonderlab/reviewDraft.ts
+++ b/utils/wonderlab/reviewDraft.ts
@@ -1,0 +1,129 @@
+// /utils/wonderlab/reviewDraft.ts
+import { createHash } from 'node:crypto'
+
+export const reviewDraftStatuses = [
+  'PROPOSED',
+  'APPROVED',
+  'REJECTED',
+  'PUBLISHED',
+  'FAILED',
+  'SUPERSEDED',
+] as const
+
+export type ReviewDraftStatus = (typeof reviewDraftStatuses)[number]
+export type ReviewDraftAuthorKind = 'BOT' | 'CHARACTER'
+
+export type ReviewDraftAuthorRef =
+  | { kind: 'BOT'; id: number }
+  | { kind: 'CHARACTER'; id: number }
+
+export type ReviewDraftPublicAuthor = ReviewDraftAuthorRef & {
+  name: string
+  avatarImage: string | null
+  role: string
+}
+
+const transitionMap: Record<ReviewDraftStatus, ReadonlySet<ReviewDraftStatus>> = {
+  PROPOSED: new Set(['PROPOSED', 'APPROVED', 'REJECTED', 'FAILED', 'SUPERSEDED']),
+  APPROVED: new Set(['APPROVED', 'PROPOSED', 'REJECTED', 'SUPERSEDED']),
+  REJECTED: new Set(['REJECTED', 'PROPOSED', 'SUPERSEDED']),
+  FAILED: new Set(['FAILED', 'PROPOSED', 'SUPERSEDED']),
+  PUBLISHED: new Set(['PUBLISHED']),
+  SUPERSEDED: new Set(['SUPERSEDED']),
+}
+
+export function normalizeReviewDraftStatus(value: unknown): ReviewDraftStatus | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().toUpperCase() as ReviewDraftStatus
+  return reviewDraftStatuses.includes(normalized) ? normalized : null
+}
+
+export function positiveReviewDraftId(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+export function normalizeReviewDraftRating(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 0
+  return Math.max(0, Math.min(5, Math.round(parsed)))
+}
+
+export function normalizeReviewDraftText(
+  value: unknown,
+  options: { required?: boolean; maxLength?: number } = {},
+): string | null {
+  if (value === null || value === undefined) {
+    if (options.required) throw new Error('Text value is required.')
+    return null
+  }
+
+  if (typeof value !== 'string') throw new Error('Text value must be a string.')
+  const text = value.trim()
+  if (!text && options.required) throw new Error('Text value is required.')
+  if (!text) return null
+
+  const maxLength = options.maxLength ?? 20_000
+  if (text.length > maxLength) {
+    throw new Error(`Text value must be ${maxLength} characters or fewer.`)
+  }
+
+  return text
+}
+
+export function reviewDraftAuthor(
+  authorBotId: unknown,
+  authorCharacterId: unknown,
+): ReviewDraftAuthorRef {
+  const botId = positiveReviewDraftId(authorBotId)
+  const characterId = positiveReviewDraftId(authorCharacterId)
+
+  if (Boolean(botId) === Boolean(characterId)) {
+    throw new Error('Exactly one Bot or Character author is required.')
+  }
+
+  return botId
+    ? { kind: 'BOT', id: botId }
+    : { kind: 'CHARACTER', id: characterId as number }
+}
+
+export function canTransitionReviewDraft(
+  from: ReviewDraftStatus,
+  to: ReviewDraftStatus,
+): boolean {
+  return transitionMap[from].has(to)
+}
+
+export function assertReviewDraftTransition(
+  from: ReviewDraftStatus,
+  to: ReviewDraftStatus,
+): void {
+  if (!canTransitionReviewDraft(from, to)) {
+    throw new Error(`Review draft cannot transition from ${from} to ${to}.`)
+  }
+}
+
+export function buildReviewDraftKey(input: {
+  componentId: number
+  author: ReviewDraftAuthorRef
+  promptVersion: string
+  promptHash: string
+}): string {
+  const canonical = [
+    'wonderlab-review-draft-v1',
+    input.componentId,
+    input.author.kind,
+    input.author.id,
+    input.promptVersion.trim(),
+    input.promptHash.trim(),
+  ].join(':')
+
+  return `wonderlab-review-draft:${createHash('sha256').update(canonical).digest('hex')}`
+}
+
+export function finalReviewDraftComment(input: {
+  generatedComment: string
+  editedComment?: string | null
+}): string {
+  return input.editedComment?.trim() || input.generatedComment.trim()
+}


### PR DESCRIPTION
## Summary

Adds the admin-only editorial API and compatibility repository for durable WonderLab personality review drafts.

### Capabilities

- deterministic, idempotent draft creation;
- exactly one eligible public/active Bot or Character author;
- admin-only list and detail reads;
- curator edit, approve, reject, fail, reopen, and supersede transitions;
- bounded ratings, reaction types, text, prompt metadata, and JSON provenance;
- final-copy projection that prefers curator edits;
- publisher accountability captured on approval.

### Safety

- every route requires `requireAdminApiUser`;
- clients cannot provide publisher identity, publication identity, or initial status;
- `PUBLISHED` cannot be reached through the editorial PATCH route;
- no code inserts, updates, or deletes a live Reaction;
- duplicate deterministic requests return the existing draft rather than creating another row.

The repository intentionally uses typed, parameterized compatibility SQL against the expand-only `ReviewDraft` table so the editorial workflow can ship without exposing or depending on a public write path.

Part of #472 and #381.