### PR TITLE
WonderLab: publish approved personality reviews safely

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Review draft admin API contract
         run: npx tsx utils/scripts/verifyReviewDraftAdminApi.ts
 
+      - name: Review draft publication contract
+        run: npx tsx utils/scripts/verifyReviewDraftPublication.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/components/wonderlab/component-review-feed.vue
+++ b/components/wonderlab/component-review-feed.vue
@@ -66,13 +66,17 @@
             class="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-primary/20 bg-primary/10"
           >
             <img
-              v-if="review.User?.avatarImage"
-              :src="normalizeImagePath(review.User.avatarImage)"
+              v-if="authorAvatar(review)"
+              :src="normalizeImagePath(authorAvatar(review) as string)"
               :alt="authorName(review)"
               class="h-full w-full object-cover"
               loading="lazy"
             />
-            <Icon v-else name="kind-icon:user" class="size-5 text-primary" />
+            <Icon
+              v-else
+              :name="review.Author ? 'kind-icon:sparkles' : 'kind-icon:user'"
+              class="size-5 text-primary"
+            />
           </div>
 
           <div class="min-w-0 flex-1">
@@ -81,10 +85,16 @@
                 <p class="truncate font-black">{{ authorName(review) }}</p>
                 <div class="mt-1 flex flex-wrap items-center gap-2">
                   <span
-                    v-if="review.User?.Role"
+                    v-if="review.Author"
+                    class="badge badge-primary badge-outline badge-xs"
+                  >
+                    First-party {{ review.Author.kind.toLowerCase() }}
+                  </span>
+                  <span
+                    v-if="authorRole(review)"
                     class="badge badge-outline badge-xs"
                   >
-                    {{ review.User.Role }}
+                    {{ authorRole(review) }}
                   </span>
                   <span class="text-xs text-base-content/45">
                     {{ formatDate(review.createdAt) }}
@@ -130,7 +140,7 @@ import { computed, ref, watch } from 'vue'
 import type { Reaction } from '~/prisma/generated/prisma/client'
 import { useReactionStore } from '@/stores/reactionStore'
 
-type PublicReviewAuthor = {
+type PublicReviewUser = {
   id: number
   username: string | null
   name: string | null
@@ -139,8 +149,17 @@ type PublicReviewAuthor = {
   isPublic: boolean
 }
 
+type PublicFirstPartyAuthor = {
+  kind: 'BOT' | 'CHARACTER'
+  id: number
+  name: string
+  avatarImage: string | null
+  role: string | null
+}
+
 type PublicComponentReview = Reaction & {
-  User?: PublicReviewAuthor | null
+  User?: PublicReviewUser | null
+  Author?: PublicFirstPartyAuthor | null
 }
 
 const props = withDefaults(
@@ -203,10 +222,19 @@ async function loadReviews(force = false): Promise<void> {
 
 function authorName(review: PublicComponentReview): string {
   return (
+    review.Author?.name?.trim() ||
     review.User?.name?.trim() ||
     review.User?.username?.trim() ||
     (review.userId ? `User #${review.userId}` : 'Anonymous visitor')
   )
+}
+
+function authorAvatar(review: PublicComponentReview): string | null {
+  return review.Author?.avatarImage || review.User?.avatarImage || null
+}
+
+function authorRole(review: PublicComponentReview): string | null {
+  return review.Author?.role || review.User?.Role || null
 }
 
 function normalizeImagePath(value: string): string {

--- a/server/api/admin/wonderlab/review-drafts/[id]/publish.post.ts
+++ b/server/api/admin/wonderlab/review-drafts/[id]/publish.post.ts
@@ -1,0 +1,37 @@
+// /server/api/admin/wonderlab/review-drafts/[id]/publish.post.ts
+import { createError, defineEventHandler, getRouterParam, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { publishReviewDraft } from '@/server/utils/reviewDraftPublisher'
+import { positiveReviewDraftId } from '@/utils/wonderlab/reviewDraft'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const id = positiveReviewDraftId(getRouterParam(event, 'id'))
+    if (!id) throw createError({ statusCode: 400, message: 'Invalid review draft ID.' })
+
+    const result = await publishReviewDraft(id, auth.user.id)
+    event.node.res.statusCode = result.created ? 201 : 200
+
+    return {
+      success: true,
+      data: result,
+      message: result.created
+        ? 'Approved review draft published.'
+        : 'Approved review draft reconciled with its existing Reaction.',
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    const message = error instanceof Error ? error.message : 'Failed to publish review draft.'
+
+    if (/not found/i.test(message)) {
+      throw createError({ statusCode: 404, message })
+    }
+    if (/only an approved|no first-party author|no publishable comment/i.test(message)) {
+      throw createError({ statusCode: 409, message })
+    }
+
+    return errorHandler(error)
+  }
+})

--- a/server/api/reactions/component/[id].get.ts
+++ b/server/api/reactions/component/[id].get.ts
@@ -2,6 +2,114 @@
 import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { errorHandler } from '../../../utils/error'
 import prisma from '../../../utils/prisma'
+import {
+  firstPartyReactionAuthor,
+  type FirstPartyReactionAuthor,
+} from '@/utils/reactions/firstPartyReactionAuthor'
+
+type ComponentReactionRow = {
+  id: number
+  createdAt: Date
+  updatedAt: Date | null
+  comment: string | null
+  userId: number
+  componentId: number | null
+  reactionType: string
+  reactionCategory: string
+  rating: number
+  artImageId: number | null
+  botId: number | null
+  promptId: number | null
+  resourceId: number | null
+  rewardId: number | null
+  chatId: number | null
+  dreamId: number | null
+  artCollectionId: number | null
+  butterflyId: number | null
+  characterId: number | null
+  scenarioId: number | null
+  themeId: number | null
+  challengeSubmissionId: number | null
+  projectId: number | null
+  facetId: number | null
+  authorBotId: number | null
+  authorCharacterId: number | null
+  userUsername: string | null
+  userName: string | null
+  userAvatarImage: string | null
+  userRole: string | null
+  userIsPublic: boolean | number
+  authorBotName: string | null
+  authorBotAvatarImage: string | null
+  authorBotImagePath: string | null
+  authorBotRole: string | null
+  authorCharacterName: string | null
+  authorCharacterImagePath: string | null
+  authorCharacterRole: string | null
+}
+
+function projectFirstPartyAuthor(
+  row: ComponentReactionRow,
+): FirstPartyReactionAuthor | null {
+  try {
+    return firstPartyReactionAuthor({
+      authorBotId: row.authorBotId,
+      authorCharacterId: row.authorCharacterId,
+      AuthorBot: row.authorBotId
+        ? {
+            id: row.authorBotId,
+            name: row.authorBotName,
+            avatarImage: row.authorBotAvatarImage,
+            imagePath: row.authorBotImagePath,
+            BotType: row.authorBotRole,
+          }
+        : null,
+      AuthorCharacter: row.authorCharacterId
+        ? {
+            id: row.authorCharacterId,
+            name: row.authorCharacterName,
+            imagePath: row.authorCharacterImagePath,
+            characterType: row.authorCharacterRole,
+          }
+        : null,
+    })
+  } catch {
+    return null
+  }
+}
+
+function projectComponentReaction(row: ComponentReactionRow) {
+  const {
+    authorBotId: _authorBotId,
+    authorCharacterId: _authorCharacterId,
+    userUsername,
+    userName,
+    userAvatarImage,
+    userRole,
+    userIsPublic,
+    authorBotName: _authorBotName,
+    authorBotAvatarImage: _authorBotAvatarImage,
+    authorBotImagePath: _authorBotImagePath,
+    authorBotRole: _authorBotRole,
+    authorCharacterName: _authorCharacterName,
+    authorCharacterImagePath: _authorCharacterImagePath,
+    authorCharacterRole: _authorCharacterRole,
+    ...reaction
+  } = row
+
+  return {
+    ...reaction,
+    User: {
+      id: row.userId,
+      username: userUsername,
+      name: userName,
+      avatarImage: userAvatarImage,
+      Role: userRole,
+      isPublic: Boolean(userIsPublic),
+    },
+    Author: projectFirstPartyAuthor(row),
+  }
+}
 
 export default defineEventHandler(async (event) => {
   const componentId = Number(getRouterParam(event, 'id'))
@@ -14,22 +122,29 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const data = await prisma.reaction.findMany({
-      where: { componentId },
-      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-      include: {
-        User: {
-          select: {
-            id: true,
-            username: true,
-            name: true,
-            avatarImage: true,
-            Role: true,
-            isPublic: true,
-          },
-        },
-      },
-    })
+    const rows = await prisma.$queryRaw<ComponentReactionRow[]>`
+      SELECT
+        r.*,
+        u.username AS userUsername,
+        u.name AS userName,
+        u.avatarImage AS userAvatarImage,
+        u.Role AS userRole,
+        u.isPublic AS userIsPublic,
+        b.name AS authorBotName,
+        b.avatarImage AS authorBotAvatarImage,
+        b.imagePath AS authorBotImagePath,
+        b.BotType AS authorBotRole,
+        ch.name AS authorCharacterName,
+        ch.imagePath AS authorCharacterImagePath,
+        ch.role AS authorCharacterRole
+      FROM Reaction r
+      INNER JOIN User u ON u.id = r.userId
+      LEFT JOIN Bot b ON b.id = r.authorBotId
+      LEFT JOIN Character ch ON ch.id = r.authorCharacterId
+      WHERE r.componentId = ${componentId}
+      ORDER BY r.createdAt DESC, r.id DESC
+    `
+    const data = rows.map(projectComponentReaction)
 
     event.node.res.statusCode = 200
 

--- a/server/utils/reviewDraftPublisher.ts
+++ b/server/utils/reviewDraftPublisher.ts
@@ -1,0 +1,214 @@
+// /server/utils/reviewDraftPublisher.ts
+import prisma from '@/server/utils/prisma'
+import {
+  finalReviewDraftComment,
+  type ReviewDraftStatus,
+} from '@/utils/wonderlab/reviewDraft'
+import { getReviewDraftById, type ReviewDraftRecord } from './reviewDraftRepository'
+
+type LockedDraftRow = {
+  id: number
+  status: ReviewDraftStatus
+  componentId: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+  publisherUserId: number | null
+  publishedReactionId: number | null
+  generatedComment: string
+  editedComment: string | null
+  rating: number
+  reactionType: string | null
+}
+
+type IdRow = { id: number }
+
+export type PublishedReviewDraft = {
+  draft: ReviewDraftRecord
+  reactionId: number
+  created: boolean
+}
+
+function defaultReactionType(rating: number): string {
+  if (rating >= 4) return 'LOVED'
+  if (rating === 3) return 'CLAPPED'
+  return 'NEUTRAL'
+}
+
+async function findAuthoredReaction(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  draft: LockedDraftRow,
+): Promise<number | null> {
+  if (draft.authorBotId) {
+    const rows = await tx.$queryRaw<IdRow[]>`
+      SELECT id
+      FROM Reaction
+      WHERE componentId = ${draft.componentId}
+        AND reactionCategory = 'COMPONENT'
+        AND authorBotId = ${draft.authorBotId}
+        AND authorCharacterId IS NULL
+      ORDER BY id ASC
+      LIMIT 1
+      FOR UPDATE
+    `
+    return rows[0]?.id ?? null
+  }
+
+  if (draft.authorCharacterId) {
+    const rows = await tx.$queryRaw<IdRow[]>`
+      SELECT id
+      FROM Reaction
+      WHERE componentId = ${draft.componentId}
+        AND reactionCategory = 'COMPONENT'
+        AND authorCharacterId = ${draft.authorCharacterId}
+        AND authorBotId IS NULL
+      ORDER BY id ASC
+      LIMIT 1
+      FOR UPDATE
+    `
+    return rows[0]?.id ?? null
+  }
+
+  throw new Error('Approved review draft has no first-party author.')
+}
+
+async function supersedeOtherDrafts(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  draft: LockedDraftRow,
+): Promise<void> {
+  if (draft.authorBotId) {
+    await tx.$executeRaw`
+      UPDATE ReviewDraft
+      SET status = 'SUPERSEDED', updatedAt = CURRENT_TIMESTAMP(3)
+      WHERE id != ${draft.id}
+        AND componentId = ${draft.componentId}
+        AND authorBotId = ${draft.authorBotId}
+        AND authorCharacterId IS NULL
+        AND status IN ('PROPOSED', 'APPROVED', 'FAILED')
+    `
+    return
+  }
+
+  await tx.$executeRaw`
+    UPDATE ReviewDraft
+    SET status = 'SUPERSEDED', updatedAt = CURRENT_TIMESTAMP(3)
+    WHERE id != ${draft.id}
+      AND componentId = ${draft.componentId}
+      AND authorCharacterId = ${draft.authorCharacterId}
+      AND authorBotId IS NULL
+      AND status IN ('PROPOSED', 'APPROVED', 'FAILED')
+  `
+}
+
+export async function publishReviewDraft(
+  draftId: number,
+  publisherUserId: number,
+): Promise<PublishedReviewDraft> {
+  const publication = await prisma.$transaction(async (tx) => {
+    const drafts = await tx.$queryRaw<LockedDraftRow[]>`
+      SELECT
+        id,
+        status,
+        componentId,
+        authorBotId,
+        authorCharacterId,
+        publisherUserId,
+        publishedReactionId,
+        generatedComment,
+        editedComment,
+        rating,
+        reactionType
+      FROM ReviewDraft
+      WHERE id = ${draftId}
+      LIMIT 1
+      FOR UPDATE
+    `
+    const draft = drafts[0]
+    if (!draft) throw new Error(`Review draft ${draftId} not found.`)
+
+    if (draft.status === 'PUBLISHED' && draft.publishedReactionId) {
+      return { reactionId: draft.publishedReactionId, created: false }
+    }
+    if (draft.status !== 'APPROVED') {
+      throw new Error('Only an approved review draft may be published.')
+    }
+
+    // Serializes all first-party publication work for the same exhibit, including
+    // different draft rows for the same reviewer, so duplicate reactions cannot race.
+    await tx.$queryRaw<IdRow[]>`
+      SELECT id FROM Component WHERE id = ${draft.componentId} LIMIT 1 FOR UPDATE
+    `
+
+    const comment = finalReviewDraftComment(draft)
+    if (!comment) throw new Error('Approved review draft has no publishable comment.')
+
+    const reactionType = draft.reactionType || defaultReactionType(draft.rating)
+    let reactionId = await findAuthoredReaction(tx, draft)
+    const created = !reactionId
+
+    if (reactionId) {
+      await tx.$executeRaw`
+        UPDATE Reaction
+        SET
+          updatedAt = CURRENT_TIMESTAMP(3),
+          userId = ${publisherUserId},
+          componentId = ${draft.componentId},
+          reactionType = ${reactionType},
+          reactionCategory = 'COMPONENT',
+          rating = ${draft.rating},
+          comment = ${comment},
+          authorBotId = ${draft.authorBotId},
+          authorCharacterId = ${draft.authorCharacterId}
+        WHERE id = ${reactionId}
+      `
+    } else {
+      await tx.$executeRaw`
+        INSERT INTO Reaction (
+          userId,
+          componentId,
+          reactionType,
+          reactionCategory,
+          rating,
+          comment,
+          authorBotId,
+          authorCharacterId
+        ) VALUES (
+          ${publisherUserId},
+          ${draft.componentId},
+          ${reactionType},
+          'COMPONENT',
+          ${draft.rating},
+          ${comment},
+          ${draft.authorBotId},
+          ${draft.authorCharacterId}
+        )
+      `
+      const inserted = await tx.$queryRaw<Array<{ id: bigint | number }>>`
+        SELECT LAST_INSERT_ID() AS id
+      `
+      reactionId = Number(inserted[0]?.id)
+      if (!Number.isInteger(reactionId) || reactionId <= 0) {
+        throw new Error('Published Reaction ID was not returned by the database.')
+      }
+    }
+
+    await tx.$executeRaw`
+      UPDATE ReviewDraft
+      SET
+        updatedAt = CURRENT_TIMESTAMP(3),
+        status = 'PUBLISHED',
+        publisherUserId = ${publisherUserId},
+        publishedReactionId = ${reactionId},
+        publishedAt = CURRENT_TIMESTAMP(3),
+        failureReason = NULL
+      WHERE id = ${draft.id}
+    `
+
+    await supersedeOtherDrafts(tx, draft)
+    return { reactionId, created }
+  })
+
+  const draft = await getReviewDraftById(draftId)
+  if (!draft) throw new Error('Published review draft could not be reloaded.')
+
+  return { draft, ...publication }
+}

--- a/server/utils/reviewDraftPublisher.ts
+++ b/server/utils/reviewDraftPublisher.ts
@@ -1,5 +1,4 @@
 // /server/utils/reviewDraftPublisher.ts
-import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import {
   finalReviewDraftComment,
@@ -22,6 +21,7 @@ type LockedDraftRow = {
 }
 
 type IdRow = { id: number }
+type ReviewDraftTransaction = Pick<typeof prisma, '$queryRaw' | '$executeRaw'>
 
 export type PublishedReviewDraft = {
   draft: ReviewDraftRecord
@@ -36,7 +36,7 @@ function defaultReactionType(rating: number): string {
 }
 
 async function findAuthoredReaction(
-  tx: Prisma.TransactionClient,
+  tx: ReviewDraftTransaction,
   draft: LockedDraftRow,
 ): Promise<number | null> {
   if (draft.authorBotId) {
@@ -73,7 +73,7 @@ async function findAuthoredReaction(
 }
 
 async function supersedeOtherDrafts(
-  tx: Prisma.TransactionClient,
+  tx: ReviewDraftTransaction,
   draft: LockedDraftRow,
 ): Promise<void> {
   if (draft.authorBotId) {

--- a/server/utils/reviewDraftPublisher.ts
+++ b/server/utils/reviewDraftPublisher.ts
@@ -1,4 +1,5 @@
 // /server/utils/reviewDraftPublisher.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '@/server/utils/prisma'
 import {
   finalReviewDraftComment,
@@ -35,7 +36,7 @@ function defaultReactionType(rating: number): string {
 }
 
 async function findAuthoredReaction(
-  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  tx: Prisma.TransactionClient,
   draft: LockedDraftRow,
 ): Promise<number | null> {
   if (draft.authorBotId) {
@@ -72,7 +73,7 @@ async function findAuthoredReaction(
 }
 
 async function supersedeOtherDrafts(
-  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  tx: Prisma.TransactionClient,
   draft: LockedDraftRow,
 ): Promise<void> {
   if (draft.authorBotId) {

--- a/utils/scripts/verifyReviewDraftPublication.ts
+++ b/utils/scripts/verifyReviewDraftPublication.ts
@@ -1,0 +1,44 @@
+// /utils/scripts/verifyReviewDraftPublication.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const publisherPath = 'server/utils/reviewDraftPublisher.ts'
+const endpointPath =
+  'server/api/admin/wonderlab/review-drafts/[id]/publish.post.ts'
+const componentReviewsPath = 'server/api/reactions/component/[id].get.ts'
+const componentFeedPath = 'components/wonderlab/component-review-feed.vue'
+
+const publisher = await readFile(publisherPath, 'utf8')
+const endpoint = await readFile(endpointPath, 'utf8')
+const componentReviews = await readFile(componentReviewsPath, 'utf8')
+const componentFeed = await readFile(componentFeedPath, 'utf8')
+const ordinaryPost = await readFile('server/api/reactions/index.post.ts', 'utf8')
+
+assert.match(endpoint, /requireAdminApiUser\(event\)/)
+assert.match(endpoint, /publishReviewDraft\(id, auth\.user\.id\)/)
+
+assert.match(publisher, /prisma\.\$transaction/)
+assert.match(publisher, /FROM ReviewDraft[\s\S]*FOR UPDATE/)
+assert.match(publisher, /FROM Component[\s\S]*FOR UPDATE/)
+assert.match(publisher, /authorBotId = \$\{draft\.authorBotId\}/)
+assert.match(publisher, /authorCharacterId = \$\{draft\.authorCharacterId\}/)
+assert.match(publisher, /INSERT INTO Reaction/)
+assert.match(publisher, /UPDATE Reaction/)
+assert.match(publisher, /status = 'PUBLISHED'/)
+assert.match(publisher, /publishedReactionId = \$\{reactionId\}/)
+assert.match(publisher, /status IN \('PROPOSED', 'APPROVED', 'FAILED'\)/)
+assert.doesNotMatch(publisher, /DELETE\s+FROM\s+Reaction/i)
+assert.doesNotMatch(publisher, /authorBotId\s+IS\s+NULL\s+AND\s+authorCharacterId\s+IS\s+NULL[\s\S]*UPDATE Reaction/i)
+
+assert.match(componentReviews, /LEFT JOIN Bot b ON b\.id = r\.authorBotId/)
+assert.match(componentReviews, /LEFT JOIN Character ch ON ch\.id = r\.authorCharacterId/)
+assert.match(componentReviews, /Author: projectFirstPartyAuthor\(row\)/)
+assert.doesNotMatch(componentReviews, /include:\s*\{/)
+
+assert.match(componentFeed, /review\.Author\?\.name/)
+assert.match(componentFeed, /First-party \{\{ review\.Author\.kind\.toLowerCase\(\) \}\}/)
+
+assert.doesNotMatch(ordinaryPost, /authorBotId/)
+assert.doesNotMatch(ordinaryPost, /authorCharacterId/)
+
+console.log('Review draft publication contract passed.')


### PR DESCRIPTION
## Summary

Completes the controlled publication boundary for approved WonderLab personality review drafts.

### Controlled publication

- admin-only publish endpoint;
- only `APPROVED` drafts may publish;
- publisher identity comes from the authenticated admin, never the request body;
- transaction and row locks serialize publication for the exhibit;
- an existing first-party Reaction for the same Component and Bot/Character is updated rather than duplicated;
- already-published drafts return idempotently;
- stale proposed, approved, or failed drafts for the same exhibit/reviewer are superseded.

### Public review identity

- Component review reads join the first-party Bot or Character server-side;
- public output contains one bounded `Author` projection: kind, stable ID, name, avatar, and role;
- the accountable publisher remains in `User` but is not shown as the personality author;
- WonderLab review cards clearly label first-party Bot/Character commentary.

### Preservation and safety

- no human Reaction is selected for overwrite because publication reconciliation requires a first-party author foreign key;
- no Reaction is deleted;
- ordinary Reaction POST remains unable to set first-party author identity;
- malformed dual-author records are projected without breaking the public feed.

Includes a required publication contract. Part of #472 and #381.