### PR TITLE
WonderLab: generate grounded personality review drafts

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -178,6 +178,9 @@ jobs:
       - name: Review draft curator UI contract
         run: npx tsx utils/scripts/verifyReviewDraftCuratorUi.ts
 
+      - name: Review draft generation contract
+        run: npx tsx utils/scripts/verifyReviewDraftGeneration.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/pages/admin/wonderlab-review-generator.vue
+++ b/pages/admin/wonderlab-review-generator.vue
@@ -1,0 +1,199 @@
+<!-- /pages/admin/wonderlab-review-generator.vue -->
+<template>
+  <main class="mx-auto min-h-screen max-w-3xl space-y-4 p-4 md:p-6">
+    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+      <p class="text-xs font-black uppercase tracking-widest text-primary">
+        WonderLab Editorial
+      </p>
+      <h1 class="mt-2 text-3xl font-black">Generate a personality review draft</h1>
+      <p class="mt-2 text-sm leading-relaxed text-base-content/60">
+        This creates a proposed draft only. A curator must review, approve, and separately
+        publish it from the curator workspace.
+      </p>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-primary btn-sm">
+          Open curator workspace
+        </NuxtLink>
+        <NuxtLink to="/wonderlab" class="btn btn-outline btn-sm">Open WonderLab</NuxtLink>
+      </div>
+    </header>
+
+    <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </section>
+
+    <section v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
+      <h2 class="text-xl font-black">Administrator access required</h2>
+    </section>
+
+    <template v-else>
+      <form class="grid gap-4 rounded-3xl border border-base-300 bg-base-100 p-5" @submit.prevent="generate">
+        <div class="grid gap-3 sm:grid-cols-2">
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Component ID</span>
+            <input v-model="form.componentId" required type="number" min="1" class="input input-bordered mt-1" />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Reviewer kind</span>
+            <select v-model="form.authorKind" class="select select-bordered mt-1">
+              <option value="BOT">Bot</option>
+              <option value="CHARACTER">Character</option>
+            </select>
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Reviewer ID</span>
+            <input v-model="form.authorId" required type="number" min="1" class="input input-bordered mt-1" />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">OpenAI model</span>
+            <input v-model="form.model" class="input input-bordered mt-1" placeholder="gpt-4o-mini" />
+          </label>
+        </div>
+
+        <label class="flex cursor-pointer items-start gap-3 rounded-2xl bg-base-200/70 p-4">
+          <input v-model="form.regenerate" type="checkbox" class="checkbox checkbox-primary mt-0.5" />
+          <span>
+            <strong class="block">Create a new generation attempt</strong>
+            <span class="text-sm text-base-content/60">
+              Without this, the endpoint reuses the latest draft for the same Component and reviewer.
+            </span>
+          </span>
+        </label>
+
+        <button class="btn btn-primary" :disabled="loading">
+          <span v-if="loading" class="loading loading-spinner loading-sm" />
+          Generate proposed draft
+        </button>
+      </form>
+
+      <p v-if="notice" class="rounded-2xl border p-4 text-sm" :class="failed ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'">
+        {{ notice }}
+      </p>
+
+      <article v-if="result" class="rounded-3xl border border-base-300 bg-base-100 p-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-black uppercase text-primary">{{ result.draft.author.kind }}</p>
+            <h2 class="text-2xl font-black">{{ result.draft.author.name }}</h2>
+            <p class="text-sm text-base-content/60">
+              {{ result.draft.componentTitle || result.draft.componentName }} · Draft #{{ result.draft.id }}
+            </p>
+          </div>
+          <span class="badge" :class="result.draft.status === 'FAILED' ? 'badge-error' : 'badge-warning'">
+            {{ result.draft.status }}
+          </span>
+        </div>
+
+        <p class="mt-4 whitespace-pre-wrap leading-relaxed">{{ result.draft.generatedComment }}</p>
+
+        <dl class="mt-4 grid gap-3 rounded-2xl bg-base-200/70 p-4 text-sm sm:grid-cols-2">
+          <div><dt class="font-black">Rating</dt><dd>{{ result.draft.rating }} / 5</dd></div>
+          <div><dt class="font-black">Confidence</dt><dd>{{ confidenceLabel }}</dd></div>
+          <div><dt class="font-black">Attempt</dt><dd>{{ result.draft.generationAttempt }}</dd></div>
+          <div><dt class="font-black">Model</dt><dd>{{ result.draft.generationModel }}</dd></div>
+        </dl>
+
+        <div v-if="result.observations.length" class="mt-4">
+          <h3 class="font-black">Grounding observations</h3>
+          <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-base-content/70">
+            <li v-for="observation in result.observations" :key="observation">{{ observation }}</li>
+          </ul>
+        </div>
+
+        <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-secondary btn-sm mt-5">
+          Review this draft
+        </NuxtLink>
+      </article>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { performFetch } from '@/stores/utils'
+
+type GeneratedDraft = {
+  draft: {
+    id: number
+    status: string
+    componentName: string
+    componentTitle: string | null
+    generatedComment: string
+    rating: number
+    generationAttempt: number
+    generationModel: string | null
+    author: { kind: 'BOT' | 'CHARACTER'; name: string }
+  }
+  generated: boolean
+  reused: boolean
+  confidence: number | null
+  observations: string[]
+}
+
+const userStore = useUserStore()
+const ready = ref(false)
+const loading = ref(false)
+const failed = ref(false)
+const notice = ref('')
+const result = ref<GeneratedDraft | null>(null)
+const form = reactive({
+  componentId: '',
+  authorKind: 'BOT' as 'BOT' | 'CHARACTER',
+  authorId: '',
+  model: 'gpt-4o-mini',
+  regenerate: false,
+})
+
+const confidenceLabel = computed(() =>
+  result.value?.confidence === null || result.value?.confidence === undefined
+    ? 'Existing draft'
+    : result.value.confidence.toFixed(2),
+)
+
+onMounted(async () => {
+  await userStore.initialize()
+  ready.value = true
+})
+
+async function generate(): Promise<void> {
+  loading.value = true
+  failed.value = false
+  notice.value = ''
+  result.value = null
+
+  try {
+    const componentId = Number(form.componentId)
+    const authorId = Number(form.authorId)
+    if (!Number.isInteger(componentId) || componentId <= 0) throw new Error('Valid Component ID required.')
+    if (!Number.isInteger(authorId) || authorId <= 0) throw new Error('Valid reviewer ID required.')
+
+    const body: Record<string, unknown> = {
+      componentId,
+      model: form.model.trim() || 'gpt-4o-mini',
+      regenerate: form.regenerate,
+    }
+    body[form.authorKind === 'BOT' ? 'authorBotId' : 'authorCharacterId'] = authorId
+
+    const response = await performFetch<GeneratedDraft>(
+      '/api/admin/wonderlab/review-drafts/generate',
+      { method: 'POST', body: JSON.stringify(body) },
+      1,
+      75_000,
+    )
+    if (!response.success || !response.data) throw new Error(response.message)
+
+    result.value = response.data
+    notice.value = response.data.generated
+      ? response.data.draft.status === 'FAILED'
+        ? 'The draft was saved but held because its confidence was too low.'
+        : 'The proposed draft is ready for curator review.'
+      : 'The existing draft was reused. Enable regeneration for another attempt.'
+  } catch (error) {
+    failed.value = true
+    notice.value = error instanceof Error ? error.message : 'Review generation failed.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/server/api/admin/wonderlab/review-drafts/generate.post.ts
+++ b/server/api/admin/wonderlab/review-drafts/generate.post.ts
@@ -1,0 +1,84 @@
+// /server/api/admin/wonderlab/review-drafts/generate.post.ts
+import { createError, defineEventHandler, H3Error, readBody } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { generateWonderLabReviewDraft } from '@/server/utils/wonderLabReviewDraftGenerator'
+import {
+  positiveReviewDraftId,
+  reviewDraftAuthor,
+} from '@/utils/wonderlab/reviewDraft'
+
+type GenerateReviewDraftBody = {
+  componentId?: unknown
+  authorBotId?: unknown
+  authorCharacterId?: unknown
+  model?: unknown
+  regenerate?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const body = await readBody<GenerateReviewDraftBody>(event)
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'Generation payload is required.' })
+    }
+
+    const componentId = positiveReviewDraftId(body.componentId)
+    if (!componentId) {
+      throw createError({ statusCode: 400, message: 'A valid componentId is required.' })
+    }
+
+    let author
+    try {
+      author = reviewDraftAuthor(body.authorBotId, body.authorCharacterId)
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message: error instanceof Error ? error.message : 'Invalid reviewer identity.',
+      })
+    }
+
+    if (body.model !== undefined && typeof body.model !== 'string') {
+      throw createError({ statusCode: 400, message: 'model must be a string.' })
+    }
+    if (body.regenerate !== undefined && typeof body.regenerate !== 'boolean') {
+      throw createError({ statusCode: 400, message: 'regenerate must be boolean.' })
+    }
+
+    const result = await generateWonderLabReviewDraft({
+      componentId,
+      author,
+      actorUserId: auth.user.id,
+      model: typeof body.model === 'string' ? body.model : null,
+      regenerate: body.regenerate === true,
+    })
+
+    event.node.res.statusCode = result.generated ? 201 : 200
+    return {
+      success: true,
+      data: result,
+      message: result.generated
+        ? result.draft.status === 'FAILED'
+          ? 'Review draft generated but held for low confidence.'
+          : 'Review draft generated for editorial review.'
+        : 'An existing draft was reused. Set regenerate=true to create another attempt.',
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    const message = error instanceof Error ? error.message : 'Review generation failed.'
+
+    if (/not found/i.test(message)) {
+      throw createError({ statusCode: 404, message })
+    }
+    if (/voice data|confidence|generated review|provider returned|invalid json/i.test(message)) {
+      throw createError({ statusCode: 422, message })
+    }
+    if (/api key|openai review generation failed|empty review draft/i.test(message)) {
+      throw createError({ statusCode: 502, message })
+    }
+
+    return errorHandler(error)
+  }
+})

--- a/server/utils/reviewDraftRepository.ts
+++ b/server/utils/reviewDraftRepository.ts
@@ -71,6 +71,7 @@ export type CreateReviewDraftInput = {
   reactionType?: string | null
   generationModel?: string | null
   generationProvider?: string | null
+  generationAttempt?: number
 }
 
 export type UpdateReviewDraftInput = {
@@ -228,6 +229,7 @@ export async function createReviewDraft(
   const authorBotId = input.author.kind === 'BOT' ? input.author.id : null
   const authorCharacterId = input.author.kind === 'CHARACTER' ? input.author.id : null
   const payload = input.promptPayload === undefined ? null : JSON.stringify(input.promptPayload)
+  const generationAttempt = Math.max(1, Math.round(input.generationAttempt ?? 1))
 
   const inserted = await prisma.$executeRaw`
     INSERT IGNORE INTO ReviewDraft (
@@ -243,7 +245,8 @@ export async function createReviewDraft(
       rating,
       reactionType,
       generationModel,
-      generationProvider
+      generationProvider,
+      generationAttempt
     ) VALUES (
       'PROPOSED',
       ${draftKey},
@@ -257,7 +260,8 @@ export async function createReviewDraft(
       ${input.rating},
       ${input.reactionType ?? null},
       ${input.generationModel ?? null},
-      ${input.generationProvider ?? null}
+      ${input.generationProvider ?? null},
+      ${generationAttempt}
     )
   `
 

--- a/server/utils/wonderLabReviewDraftGenerator.ts
+++ b/server/utils/wonderLabReviewDraftGenerator.ts
@@ -1,0 +1,449 @@
+// /server/utils/wonderLabReviewDraftGenerator.ts
+import { createHash } from 'node:crypto'
+import prisma from '@/server/utils/prisma'
+import {
+  createReviewDraft,
+  listReviewDrafts,
+  updateReviewDraft,
+  type ReviewDraftRecord,
+} from '@/server/utils/reviewDraftRepository'
+import {
+  buildWonderLabReviewDraftPrompt,
+  type WonderLabNarratorThreadExcerpt,
+} from '@/utils/wonderlab/reviewDraftPrompt'
+import {
+  rankWonderLabReviewers,
+  type WonderLabExhibitProfile,
+  type WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+import type { ReviewDraftAuthorRef } from '@/utils/wonderlab/reviewDraft'
+
+const PROMPT_VERSION = 'wonderlab-personality-review-v1'
+const MINIMUM_CONFIDENCE = 0.45
+const MINIMUM_COMMENT_WORDS = 20
+const MAXIMUM_COMMENT_WORDS = 160
+
+export type GenerateWonderLabReviewDraftInput = {
+  componentId: number
+  author: ReviewDraftAuthorRef
+  actorUserId: number
+  model?: string | null
+  regenerate?: boolean
+}
+
+export type GeneratedWonderLabReviewDraft = {
+  draft: ReviewDraftRecord
+  generated: boolean
+  reused: boolean
+  confidence: number | null
+  observations: string[]
+}
+
+type GeneratedPayload = {
+  comment: string
+  rating: number
+  confidence: number
+  observations: string[]
+}
+
+type NarratorThreadRecord = {
+  title: string | null
+  openingText: string | null
+  guidance: string | null
+  starterPrompts: unknown
+  Topic: { key: string; title: string | null } | null
+}
+
+function stringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+  if (typeof value !== 'string' || !value.trim()) return []
+  try {
+    return stringArray(JSON.parse(value))
+  } catch {
+    return value
+      .split(/[\n,]/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+}
+
+function tags(value: unknown): string[] {
+  return stringArray(value).slice(0, 24)
+}
+
+async function loadExhibit(componentId: number): Promise<WonderLabExhibitProfile> {
+  const component = await prisma.component.findUnique({
+    where: { id: componentId },
+    select: {
+      id: true,
+      componentName: true,
+      folderName: true,
+      sourcePath: true,
+      title: true,
+      description: true,
+      notes: true,
+      category: true,
+      tags: true,
+    },
+  })
+
+  if (!component) throw new Error(`Component ${componentId} not found.`)
+
+  return {
+    id: component.id,
+    componentName: component.componentName,
+    folderName: component.folderName,
+    sourcePath: component.sourcePath,
+    title: component.title,
+    description: component.description,
+    notes: component.notes,
+    category: component.category,
+    tags: tags(component.tags),
+  }
+}
+
+async function loadReviewer(
+  author: ReviewDraftAuthorRef,
+): Promise<WonderLabReviewerCandidate> {
+  if (author.kind === 'BOT') {
+    const bot = await prisma.bot.findFirst({
+      where: { id: author.id, isActive: true, isPublic: true },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        subtitle: true,
+        description: true,
+        personality: true,
+        narrativeVoice: true,
+        sampleResponse: true,
+        prompt: true,
+        modules: true,
+        isActive: true,
+        isPublic: true,
+        isMature: true,
+      },
+    })
+    if (!bot) throw new Error(`Eligible Bot ${author.id} not found.`)
+
+    return {
+      id: bot.id,
+      kind: 'BOT',
+      name: bot.name,
+      slug: bot.slug,
+      subtitle: bot.subtitle,
+      description: bot.description,
+      personality: bot.personality,
+      voice: bot.narrativeVoice,
+      sampleResponse: bot.sampleResponse,
+      prompt: bot.prompt,
+      modules: bot.modules,
+      isActive: bot.isActive,
+      isPublic: bot.isPublic,
+      isMature: bot.isMature,
+    }
+  }
+
+  const character = await prisma.character.findFirst({
+    where: { id: author.id, isActive: true, isPublic: true },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      title: true,
+      backstory: true,
+      personality: true,
+      voice: true,
+      sampleResponse: true,
+      drive: true,
+      quirks: true,
+      genre: true,
+      isActive: true,
+      isPublic: true,
+      isMature: true,
+    },
+  })
+  if (!character) throw new Error(`Eligible Character ${author.id} not found.`)
+
+  return {
+    id: character.id,
+    kind: 'CHARACTER',
+    name: character.name,
+    slug: character.slug,
+    subtitle: character.title,
+    description: character.backstory,
+    personality: character.personality,
+    voice: character.voice,
+    sampleResponse: character.sampleResponse,
+    prompt: [character.drive, character.quirks].filter(Boolean).join('\n'),
+    modules: character.genre,
+    isActive: character.isActive,
+    isPublic: character.isPublic,
+    isMature: character.isMature,
+  }
+}
+
+async function loadNarratorThreads(
+  author: ReviewDraftAuthorRef,
+): Promise<WonderLabNarratorThreadExcerpt[]> {
+  if (author.kind !== 'BOT') return []
+
+  const threads = (await prisma.narratorThread.findMany({
+    where: { botId: author.id, isActive: true },
+    orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+    take: 8,
+    select: {
+      title: true,
+      openingText: true,
+      guidance: true,
+      starterPrompts: true,
+      Topic: { select: { key: true, title: true } },
+    },
+  })) as NarratorThreadRecord[]
+
+  return threads.map((thread) => ({
+    topicKey: thread.Topic?.key || thread.title || 'general',
+    title: thread.Topic?.title || thread.title,
+    openingText: thread.openingText,
+    guidance: thread.guidance,
+    starterPrompts: stringArray(thread.starterPrompts),
+  }))
+}
+
+async function latestDraft(
+  componentId: number,
+  author: ReviewDraftAuthorRef,
+): Promise<ReviewDraftRecord | null> {
+  const drafts = await listReviewDrafts({
+    componentId,
+    authorBotId: author.kind === 'BOT' ? author.id : null,
+    authorCharacterId: author.kind === 'CHARACTER' ? author.id : null,
+    limit: 1,
+  })
+  return drafts[0] ?? null
+}
+
+async function nextGenerationAttempt(
+  componentId: number,
+  author: ReviewDraftAuthorRef,
+): Promise<number> {
+  const authorBotId = author.kind === 'BOT' ? author.id : null
+  const authorCharacterId = author.kind === 'CHARACTER' ? author.id : null
+  const rows = await prisma.$queryRaw<Array<{ attempt: bigint | number | null }>>`
+    SELECT COALESCE(MAX(generationAttempt), 0) AS attempt
+    FROM ReviewDraft
+    WHERE componentId = ${componentId}
+      AND (${authorBotId} IS NULL OR authorBotId = ${authorBotId})
+      AND (${authorCharacterId} IS NULL OR authorCharacterId = ${authorCharacterId})
+  `
+  return Number(rows[0]?.attempt ?? 0) + 1
+}
+
+function normalizeModel(value?: string | null): string {
+  const model = value?.trim() || 'gpt-4o-mini'
+  if (!/^[a-zA-Z0-9._:-]{1,100}$/.test(model)) {
+    throw new Error('Invalid text generation model name.')
+  }
+  return model
+}
+
+function validateGeneratedPayload(value: unknown): GeneratedPayload {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('The generation provider returned a non-object response.')
+  }
+  const payload = value as Record<string, unknown>
+  const comment = typeof payload.comment === 'string' ? payload.comment.trim() : ''
+  const rating = Number(payload.rating)
+  const confidence = Number(payload.confidence)
+  const observations = Array.isArray(payload.observations)
+    ? payload.observations
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .slice(0, 3)
+    : []
+  const wordCount = comment.split(/\s+/).filter(Boolean).length
+
+  if (wordCount < MINIMUM_COMMENT_WORDS || wordCount > MAXIMUM_COMMENT_WORDS) {
+    throw new Error(
+      `Generated review must contain ${MINIMUM_COMMENT_WORDS}-${MAXIMUM_COMMENT_WORDS} words.`,
+    )
+  }
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    throw new Error('Generated review rating must be an integer from 1 to 5.')
+  }
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new Error('Generated review confidence must be between 0 and 1.')
+  }
+  if (!observations.length) {
+    throw new Error('Generated review must include at least one grounded observation.')
+  }
+
+  return { comment, rating, confidence, observations }
+}
+
+async function requestOpenAiReview(input: {
+  model: string
+  system: string
+  user: string
+  responseSchema: Record<string, unknown>
+}): Promise<GeneratedPayload> {
+  const config = useRuntimeConfig()
+  const apiKey = String(config.openaiApiKey || process.env.OPENAI_API_KEY || '').trim()
+  if (!apiKey) throw new Error('No OpenAI API key is configured for review generation.')
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 60_000)
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: apiKey.startsWith('Bearer ') ? apiKey : `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: input.model,
+        messages: [
+          { role: 'system', content: input.system },
+          { role: 'user', content: input.user },
+        ],
+        temperature: 0.65,
+        max_tokens: 500,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'wonderlab_review_draft',
+            strict: true,
+            schema: input.responseSchema,
+          },
+        },
+      }),
+    })
+
+    const body = (await response.json().catch(() => null)) as
+      | { choices?: Array<{ message?: { content?: string | null } }>; error?: { message?: string } }
+      | null
+    if (!response.ok) {
+      throw new Error(body?.error?.message || `OpenAI review generation failed (${response.status}).`)
+    }
+
+    const content = body?.choices?.[0]?.message?.content?.trim()
+    if (!content) throw new Error('OpenAI returned an empty review draft.')
+
+    try {
+      return validateGeneratedPayload(JSON.parse(content))
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error('OpenAI returned invalid JSON for the review draft.')
+      }
+      throw error
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function reactionTypeForRating(rating: number): string {
+  if (rating >= 4) return 'LOVED'
+  if (rating === 3) return 'CLAPPED'
+  if (rating === 2) return 'NEUTRAL'
+  return 'BOOED'
+}
+
+export async function generateWonderLabReviewDraft(
+  input: GenerateWonderLabReviewDraftInput,
+): Promise<GeneratedWonderLabReviewDraft> {
+  const existing = await latestDraft(input.componentId, input.author)
+  if (existing && !input.regenerate) {
+    return {
+      draft: existing,
+      generated: false,
+      reused: true,
+      confidence: null,
+      observations: [],
+    }
+  }
+
+  const [exhibit, reviewer, threads, attempt] = await Promise.all([
+    loadExhibit(input.componentId),
+    loadReviewer(input.author),
+    loadNarratorThreads(input.author),
+    nextGenerationAttempt(input.componentId, input.author),
+  ])
+
+  const affinity = rankWonderLabReviewers(exhibit, [reviewer], {
+    limit: 1,
+    minimumScore: -100,
+    includeMature: false,
+  })[0]
+  if (!affinity?.voiceReady) {
+    throw new Error(`${reviewer.name} does not have enough canonical voice data.`)
+  }
+
+  const prompt = buildWonderLabReviewDraftPrompt(reviewer, exhibit, {
+    affinityReasons: affinity.reasons,
+    narratorThreads: threads,
+  })
+  const model = normalizeModel(input.model)
+  const basePromptHash = createHash('sha256')
+    .update(JSON.stringify({
+      model,
+      system: prompt.system,
+      user: prompt.user,
+      responseSchema: prompt.responseSchema,
+    }))
+    .digest('hex')
+  const promptHash = createHash('sha256')
+    .update(`${basePromptHash}:attempt:${attempt}`)
+    .digest('hex')
+
+  const generated = await requestOpenAiReview({
+    model,
+    system: prompt.system,
+    user: prompt.user,
+    responseSchema: prompt.responseSchema,
+  })
+
+  const created = await createReviewDraft({
+    componentId: input.componentId,
+    author: input.author,
+    promptVersion: PROMPT_VERSION,
+    promptHash,
+    promptPayload: {
+      ...prompt,
+      basePromptHash,
+      generationAttempt: attempt,
+      generationResult: {
+        confidence: generated.confidence,
+        observations: generated.observations,
+      },
+    },
+    generatedComment: generated.comment,
+    rating: generated.rating,
+    reactionType: reactionTypeForRating(generated.rating),
+    generationModel: model,
+    generationProvider: 'OPENAI',
+    generationAttempt: attempt,
+  })
+
+  let draft = created.draft
+  if (generated.confidence < MINIMUM_CONFIDENCE) {
+    draft = await updateReviewDraft({
+      id: draft.id,
+      actorUserId: input.actorUserId,
+      status: 'FAILED',
+      failureReason: `Generation confidence ${generated.confidence.toFixed(2)} is below ${MINIMUM_CONFIDENCE.toFixed(2)}.`,
+    })
+  }
+
+  return {
+    draft,
+    generated: true,
+    reused: false,
+    confidence: generated.confidence,
+    observations: generated.observations,
+  }
+}

--- a/server/utils/wonderLabReviewDraftGenerator.ts
+++ b/server/utils/wonderLabReviewDraftGenerator.ts
@@ -51,7 +51,7 @@ type NarratorThreadRecord = {
   openingText: string | null
   guidance: string | null
   starterPrompts: unknown
-  Topic: { key: string; title: string | null } | null
+  Topic: { slug: string; title: string | null } | null
 }
 
 function stringArray(value: unknown): string[] {
@@ -199,12 +199,12 @@ async function loadNarratorThreads(
       openingText: true,
       guidance: true,
       starterPrompts: true,
-      Topic: { select: { key: true, title: true } },
+      Topic: { select: { slug: true, title: true } },
     },
   })) as NarratorThreadRecord[]
 
   return threads.map((thread) => ({
-    topicKey: thread.Topic?.key || thread.title || 'general',
+    topicKey: thread.Topic?.slug || thread.title || 'general',
     title: thread.Topic?.title || thread.title,
     openingText: thread.openingText,
     guidance: thread.guidance,

--- a/utils/scripts/verifyReviewDraftGeneration.ts
+++ b/utils/scripts/verifyReviewDraftGeneration.ts
@@ -1,0 +1,43 @@
+// /utils/scripts/verifyReviewDraftGeneration.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const generatorPath = 'server/utils/wonderLabReviewDraftGenerator.ts'
+const endpointPath = 'server/api/admin/wonderlab/review-drafts/generate.post.ts'
+const pagePath = 'pages/admin/wonderlab-review-generator.vue'
+const repositoryPath = 'server/utils/reviewDraftRepository.ts'
+
+const generator = await readFile(generatorPath, 'utf8')
+const endpoint = await readFile(endpointPath, 'utf8')
+const page = await readFile(pagePath, 'utf8')
+const repository = await readFile(repositoryPath, 'utf8')
+
+assert.match(endpoint, /requireAdminApiUser\(event\)/)
+assert.match(endpoint, /generateWonderLabReviewDraft/)
+assert.doesNotMatch(endpoint, /publishReviewDraft/)
+assert.doesNotMatch(endpoint, /status:\s*'APPROVED'/)
+
+assert.match(generator, /buildWonderLabReviewDraftPrompt/)
+assert.match(generator, /rankWonderLabReviewers/)
+assert.match(generator, /prisma\.narratorThread\.findMany/)
+assert.match(generator, /response_format:[\s\S]*type: 'json_schema'/)
+assert.match(generator, /validateGeneratedPayload/)
+assert.match(generator, /MINIMUM_CONFIDENCE/)
+assert.match(generator, /status: 'FAILED'/)
+assert.match(generator, /createReviewDraft/)
+assert.match(generator, /generationAttempt: attempt/)
+assert.doesNotMatch(generator, /INSERT\s+INTO\s+Reaction/i)
+assert.doesNotMatch(generator, /UPDATE\s+Reaction/i)
+assert.doesNotMatch(generator, /publishReviewDraft/)
+
+assert.match(repository, /generationAttempt\?: number/)
+assert.match(repository, /generationAttempt\n\s*\)/)
+assert.match(repository, /\$\{generationAttempt\}/)
+
+assert.match(page, /This creates a proposed draft only/)
+assert.match(page, /\/api\/admin\/wonderlab\/review-drafts\/generate/)
+assert.match(page, /Open curator workspace/)
+assert.doesNotMatch(page, /\/publish/)
+assert.doesNotMatch(page, /status:\s*'APPROVED'/)
+
+console.log('Review draft generation contract passed.')


### PR DESCRIPTION
## Summary

Adds an explicit, admin-controlled generation adapter for WonderLab Bot/Character review drafts.

### Grounded generation

- loads canonical Component metadata and an eligible public/active Bot or Character;
- ranks the selected reviewer through the merged affinity layer;
- includes canonical voice, sample dialogue, and active Bot NarratorThread excerpts;
- uses the bounded structured prompt and strict JSON schema;
- validates comment length, rating, confidence, and factual observations;
- persists prompt provenance, base hash, model, provider, observations, confidence, and generation attempt.

### Editorial controls

- the endpoint creates `PROPOSED` drafts only;
- low-confidence output is retained as `FAILED` for curator inspection rather than published;
- an existing Component/reviewer draft is reused unless the admin explicitly requests regeneration;
- regeneration increments the durable attempt and creates a distinct deterministic draft key;
- a dedicated admin page generates one selected reviewer draft and links to the curator workspace.

### Safety

- administrator authentication is required;
- no generation path approves or publishes;
- no live Reaction is inserted or updated;
- provider output is schema-validated before storage;
- no user-provided publisher identity is accepted.

Includes a required generation contract. Part of #472 and #381.