### PR TITLE
WonderLab: plan and batch-generate personality review coverage

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -181,6 +181,12 @@ jobs:
       - name: Review draft generation contract
         run: npx tsx utils/scripts/verifyReviewDraftGeneration.ts
 
+      - name: WonderLab reviewer voice diversity acceptance
+        run: npx tsx utils/scripts/verifyWonderLabReviewVoiceDiversity.ts
+
+      - name: WonderLab review batch planning contract
+        run: npx tsx utils/scripts/verifyWonderLabReviewBatchPlan.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/pages/admin/wonderlab-review-plan.vue
+++ b/pages/admin/wonderlab-review-plan.vue
@@ -1,0 +1,360 @@
+<!-- /pages/admin/wonderlab-review-plan.vue -->
+<template>
+  <main class="mx-auto min-h-screen max-w-7xl space-y-4 p-4 md:p-6">
+    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+      <p class="text-xs font-black uppercase tracking-widest text-primary">
+        WonderLab Editorial
+      </p>
+      <h1 class="mt-2 text-3xl font-black">Personality review coverage plan</h1>
+      <p class="mt-2 max-w-4xl text-sm leading-relaxed text-base-content/60">
+        Preview deterministic reviewer assignments and existing coverage before making
+        any model calls. Batch generation creates proposed drafts only; it never approves
+        or publishes them.
+      </p>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-primary btn-sm">
+          Curator workspace
+        </NuxtLink>
+        <NuxtLink to="/admin/wonderlab-review-generator" class="btn btn-outline btn-sm">
+          Single-draft generator
+        </NuxtLink>
+        <NuxtLink to="/wonderlab" class="btn btn-ghost btn-sm">WonderLab</NuxtLink>
+      </div>
+    </header>
+
+    <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </section>
+
+    <section
+      v-else-if="!userStore.isAdmin"
+      class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center"
+    >
+      <h2 class="text-xl font-black">Administrator access required</h2>
+    </section>
+
+    <template v-else>
+      <section class="rounded-3xl border border-base-300 bg-base-100 p-5">
+        <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          <label class="form-control xl:col-span-2">
+            <span class="label-text text-xs font-bold">Component IDs (optional)</span>
+            <input
+              v-model="form.componentIds"
+              class="input input-bordered input-sm mt-1"
+              placeholder="12, 18, 25"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Component limit</span>
+            <input
+              v-model.number="form.limit"
+              type="number"
+              min="1"
+              max="10"
+              class="input input-bordered input-sm mt-1"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Reviewers per exhibit</span>
+            <select v-model.number="form.reviewersPerComponent" class="select select-bordered select-sm mt-1">
+              <option :value="1">1 reviewer</option>
+              <option :value="2">2 reviewers</option>
+            </select>
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs font-bold">Minimum affinity</span>
+            <input
+              v-model.number="form.minimumScore"
+              type="number"
+              min="-100"
+              max="500"
+              class="input input-bordered input-sm mt-1"
+            />
+          </label>
+          <label class="form-control md:col-span-2 xl:col-span-3">
+            <span class="label-text text-xs font-bold">Generation model</span>
+            <input
+              v-model="form.model"
+              class="input input-bordered input-sm mt-1"
+              placeholder="gpt-4o-mini"
+            />
+          </label>
+          <label class="flex cursor-pointer items-center gap-3 rounded-2xl bg-base-200/70 p-3 md:col-span-2">
+            <input v-model="form.regenerate" type="checkbox" class="checkbox checkbox-warning" />
+            <span class="text-sm">
+              Include existing unpublished drafts as new regeneration attempts
+            </span>
+          </label>
+        </div>
+
+        <div class="mt-4 flex flex-wrap gap-2">
+          <button class="btn btn-outline btn-sm" :disabled="loading" @click="loadPlan">
+            <span v-if="loading" class="loading loading-spinner loading-xs" />
+            Preview plan
+          </button>
+          <button class="btn btn-ghost btn-sm" :disabled="loading" @click="runBatch(true)">
+            Verify dry run
+          </button>
+        </div>
+
+        <label class="mt-4 flex cursor-pointer items-start gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-4">
+          <input v-model="executeEnabled" type="checkbox" class="checkbox checkbox-warning mt-0.5" />
+          <span>
+            <strong class="block">Enable model calls for this batch</strong>
+            <span class="text-sm text-base-content/65">
+              This may create proposed or failed drafts. It cannot approve or publish.
+            </span>
+          </span>
+        </label>
+        <button
+          class="btn btn-warning mt-3"
+          :disabled="loading || !executeEnabled || !plan?.missingCount && !form.regenerate"
+          @click="runBatch(false)"
+        >
+          Generate planned drafts
+        </button>
+      </section>
+
+      <p
+        v-if="notice"
+        class="rounded-2xl border p-4 text-sm"
+        :class="noticeError ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'"
+      >
+        {{ notice }}
+      </p>
+
+      <section v-if="plan" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="stat rounded-3xl border border-base-300 bg-base-100">
+          <div class="stat-title">Exhibits</div>
+          <div class="stat-value text-primary">{{ plan.componentCount }}</div>
+        </div>
+        <div class="stat rounded-3xl border border-base-300 bg-base-100">
+          <div class="stat-title">Missing</div>
+          <div class="stat-value text-warning">{{ plan.missingCount }}</div>
+        </div>
+        <div class="stat rounded-3xl border border-base-300 bg-base-100">
+          <div class="stat-title">Drafted</div>
+          <div class="stat-value text-secondary">{{ plan.draftedCount }}</div>
+        </div>
+        <div class="stat rounded-3xl border border-base-300 bg-base-100">
+          <div class="stat-title">Published</div>
+          <div class="stat-value text-success">{{ plan.publishedCount }}</div>
+        </div>
+      </section>
+
+      <section v-if="batchResults.length" class="rounded-3xl border border-base-300 bg-base-100 p-4">
+        <h2 class="text-xl font-black">Latest batch results</h2>
+        <div class="mt-3 grid gap-2">
+          <div
+            v-for="result in batchResults"
+            :key="`${result.componentId}-${result.reviewer.author.kind}-${result.reviewer.author.id}`"
+            class="flex flex-wrap items-center justify-between gap-2 rounded-2xl bg-base-200/70 p-3 text-sm"
+          >
+            <span>
+              <strong>{{ result.reviewer.name }}</strong> on Component #{{ result.componentId }}
+            </span>
+            <span class="badge" :class="result.success ? 'badge-success' : 'badge-error'">
+              {{ result.message }}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section v-if="plan" class="grid gap-4 lg:grid-cols-2">
+        <article
+          v-for="exhibit in plan.exhibits"
+          :key="exhibit.componentId"
+          class="rounded-3xl border border-base-300 bg-base-100 p-4"
+        >
+          <header class="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h2 class="text-lg font-black">{{ exhibit.title || exhibit.componentName }}</h2>
+              <p class="text-sm text-base-content/55">
+                {{ exhibit.folderName }} · Component #{{ exhibit.componentId }}
+              </p>
+            </div>
+            <span class="badge badge-outline">{{ exhibit.status }}</span>
+          </header>
+
+          <div v-if="!exhibit.reviewers.length" class="mt-4 rounded-2xl bg-error/10 p-4 text-sm text-error">
+            No eligible voice-ready reviewer met this plan's constraints.
+          </div>
+
+          <div v-else class="mt-4 grid gap-3">
+            <div
+              v-for="reviewer in exhibit.reviewers"
+              :key="`${reviewer.author.kind}-${reviewer.author.id}`"
+              class="rounded-2xl border border-base-300 p-3"
+            >
+              <div class="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <p class="font-black">{{ reviewer.name }}</p>
+                  <p class="text-xs text-base-content/55">
+                    {{ reviewer.author.kind }} #{{ reviewer.author.id }} · affinity {{ reviewer.score }}
+                  </p>
+                </div>
+                <span class="badge" :class="coverageClass(reviewer.coverage)">
+                  {{ reviewer.coverage }}
+                </span>
+              </div>
+              <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-base-content/65">
+                <li v-for="reason in reviewer.reasons" :key="reason">{{ reason }}</li>
+              </ul>
+              <p v-if="reviewer.draftId || reviewer.reactionId" class="mt-2 text-xs text-base-content/50">
+                <span v-if="reviewer.draftId">Draft #{{ reviewer.draftId }} {{ reviewer.draftStatus }}</span>
+                <span v-if="reviewer.reactionId"> · Reaction #{{ reviewer.reactionId }}</span>
+              </p>
+            </div>
+          </div>
+        </article>
+      </section>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { performFetch } from '@/stores/utils'
+
+type Coverage = 'MISSING' | 'DRAFTED' | 'PUBLISHED'
+type PlanReviewer = {
+  author: { kind: 'BOT' | 'CHARACTER'; id: number }
+  name: string
+  slug: string | null
+  score: number
+  reasons: string[]
+  coverage: Coverage
+  draftId: number | null
+  draftStatus: string | null
+  reactionId: number | null
+}
+type Plan = {
+  exhibits: Array<{
+    componentId: number
+    componentName: string
+    title: string | null
+    folderName: string
+    sourcePath: string | null
+    status: string
+    reviewers: PlanReviewer[]
+  }>
+  componentCount: number
+  reviewerSlots: number
+  missingCount: number
+  draftedCount: number
+  publishedCount: number
+}
+type BatchResult = {
+  componentId: number
+  reviewer: PlanReviewer
+  success: boolean
+  draftId: number | null
+  status: string | null
+  message: string
+}
+type BatchResponse = {
+  dryRun: boolean
+  plan: Plan
+  targetCount: number
+  generated: BatchResult[]
+}
+
+const userStore = useUserStore()
+const ready = ref(false)
+const loading = ref(false)
+const executeEnabled = ref(false)
+const notice = ref('')
+const noticeError = ref(false)
+const plan = ref<Plan | null>(null)
+const batchResults = ref<BatchResult[]>([])
+const form = reactive({
+  componentIds: '',
+  limit: 10,
+  reviewersPerComponent: 2,
+  minimumScore: 0,
+  model: 'gpt-4o-mini',
+  regenerate: false,
+})
+
+onMounted(async () => {
+  await userStore.initialize()
+  ready.value = true
+  if (userStore.isAdmin) await loadPlan()
+})
+
+function queryParams(): URLSearchParams {
+  const query = new URLSearchParams({
+    limit: String(form.limit),
+    reviewersPerComponent: String(form.reviewersPerComponent),
+    minimumScore: String(form.minimumScore),
+  })
+  if (form.componentIds.trim()) query.set('componentIds', form.componentIds.trim())
+  return query
+}
+
+function requestBody(dryRun: boolean): Record<string, unknown> {
+  return {
+    componentIds: form.componentIds.trim() || undefined,
+    limit: form.limit,
+    reviewersPerComponent: form.reviewersPerComponent,
+    minimumScore: form.minimumScore,
+    model: form.model.trim() || 'gpt-4o-mini',
+    regenerate: form.regenerate,
+    dryRun,
+  }
+}
+
+async function loadPlan(): Promise<void> {
+  loading.value = true
+  notice.value = ''
+  try {
+    const response = await performFetch<Plan>(
+      `/api/admin/wonderlab/review-plan?${queryParams().toString()}`,
+    )
+    if (!response.success || !response.data) throw new Error(response.message)
+    plan.value = response.data
+  } catch (error) {
+    noticeError.value = true
+    notice.value = error instanceof Error ? error.message : 'Failed to load review plan.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function runBatch(dryRun: boolean): Promise<void> {
+  if (!dryRun && !executeEnabled.value) return
+  loading.value = true
+  notice.value = ''
+  batchResults.value = []
+  try {
+    const response = await performFetch<BatchResponse>(
+      '/api/admin/wonderlab/review-drafts/generate-batch',
+      { method: 'POST', body: JSON.stringify(requestBody(dryRun)) },
+      1,
+      dryRun ? 15_000 : 180_000,
+    )
+    if (!response.success || !response.data) throw new Error(response.message)
+
+    plan.value = response.data.plan
+    batchResults.value = response.data.generated
+    noticeError.value = false
+    notice.value = dryRun
+      ? `Dry run confirmed ${response.data.targetCount} target(s); no model calls or writes occurred.`
+      : `Batch completed ${response.data.generated.filter((item) => item.success).length} of ${response.data.targetCount} target(s). All results remain unpublished.`
+    if (!dryRun) executeEnabled.value = false
+    if (!dryRun) await loadPlan()
+  } catch (error) {
+    noticeError.value = true
+    notice.value = error instanceof Error ? error.message : 'Batch generation failed.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function coverageClass(coverage: Coverage): string {
+  if (coverage === 'PUBLISHED') return 'badge-success'
+  if (coverage === 'DRAFTED') return 'badge-secondary'
+  return 'badge-warning'
+}
+</script>

--- a/server/api/admin/wonderlab/review-drafts/generate-batch.post.ts
+++ b/server/api/admin/wonderlab/review-drafts/generate-batch.post.ts
@@ -1,0 +1,227 @@
+// /server/api/admin/wonderlab/review-drafts/generate-batch.post.ts
+import { createError, defineEventHandler, H3Error, readBody } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { generateWonderLabReviewDraft } from '@/server/utils/wonderLabReviewDraftGenerator'
+import {
+  buildWonderLabReviewPlan,
+  type WonderLabReviewPlanReviewer,
+} from '@/server/utils/wonderLabReviewPlan'
+
+const MAX_BATCH_COMPONENTS = 10
+const MAX_BATCH_GENERATIONS = 20
+
+type GenerateBatchBody = {
+  componentIds?: unknown
+  limit?: unknown
+  reviewersPerComponent?: unknown
+  minimumScore?: unknown
+  model?: unknown
+  regenerate?: unknown
+  dryRun?: unknown
+}
+
+type BatchTarget = {
+  componentId: number
+  componentName: string
+  reviewer: WonderLabReviewPlanReviewer
+}
+
+function integerValue(
+  value: unknown,
+  options: { minimum: number; maximum: number; fallback: number; field: string },
+): number {
+  if (value === undefined || value === null || value === '') return options.fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.field} must be an integer from ${options.minimum} to ${options.maximum}.`,
+    })
+  }
+  return parsed
+}
+
+function numberValue(
+  value: unknown,
+  options: { minimum: number; maximum: number; fallback: number; field: string },
+): number {
+  if (value === undefined || value === null || value === '') return options.fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.field} must be a number from ${options.minimum} to ${options.maximum}.`,
+    })
+  }
+  return parsed
+}
+
+function booleanValue(value: unknown, fallback: boolean, field: string): boolean {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'boolean') {
+    throw createError({ statusCode: 400, message: `${field} must be boolean.` })
+  }
+  return value
+}
+
+function componentIds(value: unknown): number[] {
+  if (value === undefined || value === null || value === '') return []
+  const values = Array.isArray(value) ? value : String(value).split(',')
+  const ids = values
+    .flatMap((item) => String(item).split(','))
+    .map((item) => Number(item.trim()))
+
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw createError({ statusCode: 400, message: 'componentIds must contain positive integers.' })
+  }
+
+  const unique = [...new Set(ids)]
+  if (unique.length > MAX_BATCH_COMPONENTS) {
+    throw createError({
+      statusCode: 400,
+      message: `A batch may include at most ${MAX_BATCH_COMPONENTS} Components.`,
+    })
+  }
+  return unique
+}
+
+function generationTargets(
+  plan: Awaited<ReturnType<typeof buildWonderLabReviewPlan>>,
+  regenerate: boolean,
+): BatchTarget[] {
+  return plan.exhibits
+    .flatMap((exhibit) =>
+      exhibit.reviewers.map((reviewer) => ({
+        componentId: exhibit.componentId,
+        componentName: exhibit.title || exhibit.componentName,
+        reviewer,
+      })),
+    )
+    .filter((target) => {
+      if (target.reviewer.coverage === 'PUBLISHED') return false
+      if (regenerate) return true
+      return target.reviewer.coverage === 'MISSING'
+    })
+    .slice(0, MAX_BATCH_GENERATIONS)
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireAdminApiUser(event)
+    const body = await readBody<GenerateBatchBody>(event)
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'Batch generation payload is required.' })
+    }
+
+    const ids = componentIds(body.componentIds)
+    const limit = integerValue(body.limit, {
+      minimum: 1,
+      maximum: MAX_BATCH_COMPONENTS,
+      fallback: MAX_BATCH_COMPONENTS,
+      field: 'limit',
+    })
+    const reviewersPerComponent = integerValue(body.reviewersPerComponent, {
+      minimum: 1,
+      maximum: 2,
+      fallback: 2,
+      field: 'reviewersPerComponent',
+    })
+    const minimumScore = numberValue(body.minimumScore, {
+      minimum: -100,
+      maximum: 500,
+      fallback: 0,
+      field: 'minimumScore',
+    })
+    const regenerate = booleanValue(body.regenerate, false, 'regenerate')
+    const dryRun = booleanValue(body.dryRun, true, 'dryRun')
+
+    if (body.model !== undefined && typeof body.model !== 'string') {
+      throw createError({ statusCode: 400, message: 'model must be a string.' })
+    }
+    const model = typeof body.model === 'string' ? body.model.trim() || null : null
+
+    const plan = await buildWonderLabReviewPlan({
+      componentIds: ids,
+      limit,
+      reviewersPerComponent,
+      minimumScore,
+    })
+    const targets = generationTargets(plan, regenerate)
+
+    if (dryRun) {
+      return {
+        success: true,
+        data: {
+          dryRun: true,
+          plan,
+          targetCount: targets.length,
+          targets,
+          generated: [],
+        },
+        message: `Dry run planned ${targets.length} generation(s); no model calls or writes were made.`,
+      }
+    }
+
+    const generated: Array<{
+      componentId: number
+      reviewer: WonderLabReviewPlanReviewer
+      success: boolean
+      draftId: number | null
+      status: string | null
+      message: string
+    }> = []
+
+    // Intentionally sequential: keeps provider pressure bounded and produces a
+    // reviewable result for every requested slot instead of failing the whole batch.
+    for (const target of targets) {
+      try {
+        const result = await generateWonderLabReviewDraft({
+          componentId: target.componentId,
+          author: target.reviewer.author,
+          actorUserId: auth.user.id,
+          model,
+          regenerate,
+        })
+        generated.push({
+          componentId: target.componentId,
+          reviewer: target.reviewer,
+          success: true,
+          draftId: result.draft.id,
+          status: result.draft.status,
+          message: result.reused
+            ? 'Existing draft reused.'
+            : result.draft.status === 'FAILED'
+              ? 'Generated draft held for curator review.'
+              : 'Proposed draft generated.',
+        })
+      } catch (error) {
+        generated.push({
+          componentId: target.componentId,
+          reviewer: target.reviewer,
+          success: false,
+          draftId: null,
+          status: null,
+          message: error instanceof Error ? error.message : 'Generation failed.',
+        })
+      }
+    }
+
+    const succeeded = generated.filter((result) => result.success).length
+    return {
+      success: true,
+      data: {
+        dryRun: false,
+        plan,
+        targetCount: targets.length,
+        targets,
+        generated,
+      },
+      message: `Completed ${succeeded} of ${generated.length} planned generation(s). No drafts were approved or published.`,
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/admin/wonderlab/review-plan.get.ts
+++ b/server/api/admin/wonderlab/review-plan.get.ts
@@ -1,0 +1,80 @@
+// /server/api/admin/wonderlab/review-plan.get.ts
+import { createError, defineEventHandler, getQuery, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { buildWonderLabReviewPlan } from '@/server/utils/wonderLabReviewPlan'
+
+function integerQuery(
+  value: unknown,
+  options: { minimum: number; maximum: number; fallback: number },
+): number {
+  if (value === undefined || value === null || value === '') return options.fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw createError({
+      statusCode: 400,
+      message: `Expected an integer from ${options.minimum} to ${options.maximum}.`,
+    })
+  }
+  return parsed
+}
+
+function numberQuery(
+  value: unknown,
+  options: { minimum: number; maximum: number; fallback: number },
+): number {
+  if (value === undefined || value === null || value === '') return options.fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw createError({
+      statusCode: 400,
+      message: `Expected a number from ${options.minimum} to ${options.maximum}.`,
+    })
+  }
+  return parsed
+}
+
+function componentIds(value: unknown): number[] {
+  if (value === undefined || value === null || value === '') return []
+  const values = Array.isArray(value) ? value : String(value).split(',')
+  const ids = values
+    .flatMap((item) => String(item).split(','))
+    .map((item) => Number(item.trim()))
+
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw createError({ statusCode: 400, message: 'componentIds must contain positive integers.' })
+  }
+
+  return [...new Set(ids)].slice(0, 100)
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const query = getQuery(event)
+
+    const plan = await buildWonderLabReviewPlan({
+      componentIds: componentIds(query.componentIds ?? query.componentId),
+      limit: integerQuery(query.limit, { minimum: 1, maximum: 100, fallback: 25 }),
+      reviewersPerComponent: integerQuery(query.reviewersPerComponent, {
+        minimum: 1,
+        maximum: 2,
+        fallback: 2,
+      }),
+      minimumScore: numberQuery(query.minimumScore, {
+        minimum: -100,
+        maximum: 500,
+        fallback: 0,
+      }),
+    })
+
+    return {
+      success: true,
+      data: plan,
+      message: `Planned ${plan.reviewerSlots} reviewer slot(s) across ${plan.componentCount} exhibit(s).`,
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/utils/wonderLabReviewPlan.ts
+++ b/server/utils/wonderLabReviewPlan.ts
@@ -270,12 +270,12 @@ function chooseReviewers(
   count: number,
 ): WonderLabReviewerAffinity[] {
   const voiceReady = ranked.filter((entry) => entry.voiceReady)
-  if (!voiceReady.length || count <= 0) return []
+  const first = voiceReady[0]
+  if (!first || count <= 0) return []
 
-  const selected = [voiceReady[0] as WonderLabReviewerAffinity]
+  const selected: WonderLabReviewerAffinity[] = [first]
   if (count === 1) return selected
 
-  const first = selected[0]
   const diverse = voiceReady.find(
     (entry, index) =>
       index > 0 &&

--- a/server/utils/wonderLabReviewPlan.ts
+++ b/server/utils/wonderLabReviewPlan.ts
@@ -1,0 +1,360 @@
+// /server/utils/wonderLabReviewPlan.ts
+import prisma from '@/server/utils/prisma'
+import {
+  rankWonderLabReviewers,
+  type WonderLabExhibitProfile,
+  type WonderLabReviewerAffinity,
+  type WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+import type { ReviewDraftAuthorRef, ReviewDraftStatus } from '@/utils/wonderlab/reviewDraft'
+
+export type WonderLabReviewCoverage = 'MISSING' | 'DRAFTED' | 'PUBLISHED'
+
+export type WonderLabReviewPlanReviewer = {
+  author: ReviewDraftAuthorRef
+  name: string
+  slug: string | null
+  score: number
+  reasons: string[]
+  coverage: WonderLabReviewCoverage
+  draftId: number | null
+  draftStatus: ReviewDraftStatus | null
+  reactionId: number | null
+}
+
+export type WonderLabReviewPlanExhibit = {
+  componentId: number
+  componentName: string
+  title: string | null
+  folderName: string
+  sourcePath: string | null
+  status: string
+  reviewers: WonderLabReviewPlanReviewer[]
+}
+
+export type WonderLabReviewPlan = {
+  exhibits: WonderLabReviewPlanExhibit[]
+  componentCount: number
+  reviewerSlots: number
+  missingCount: number
+  draftedCount: number
+  publishedCount: number
+}
+
+export type BuildWonderLabReviewPlanOptions = {
+  componentIds?: number[]
+  limit?: number
+  reviewersPerComponent?: number
+  minimumScore?: number
+}
+
+type DraftCoverageRow = {
+  id: number
+  componentId: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+  status: ReviewDraftStatus
+  publishedReactionId: number | null
+}
+
+type ReactionCoverageRow = {
+  id: number
+  componentId: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+}
+
+function stringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+  if (typeof value !== 'string' || !value.trim()) return []
+  try {
+    return stringArray(JSON.parse(value))
+  } catch {
+    return value
+      .split(/[\n,]/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+}
+
+function authorKey(author: ReviewDraftAuthorRef): string {
+  return `${author.kind}:${author.id}`
+}
+
+function coverageKey(componentId: number, author: ReviewDraftAuthorRef): string {
+  return `${componentId}:${authorKey(author)}`
+}
+
+function rowAuthor(row: {
+  authorBotId: number | null
+  authorCharacterId: number | null
+}): ReviewDraftAuthorRef | null {
+  if (row.authorBotId && !row.authorCharacterId) {
+    return { kind: 'BOT', id: row.authorBotId }
+  }
+  if (row.authorCharacterId && !row.authorBotId) {
+    return { kind: 'CHARACTER', id: row.authorCharacterId }
+  }
+  return null
+}
+
+async function loadExhibits(
+  options: BuildWonderLabReviewPlanOptions,
+): Promise<WonderLabExhibitProfile[]> {
+  const componentIds = [...new Set(options.componentIds || [])]
+    .filter((id) => Number.isInteger(id) && id > 0)
+    .slice(0, 100)
+  const limit = Math.max(1, Math.min(100, Math.round(options.limit ?? 25)))
+
+  const components = await prisma.component.findMany({
+    where: {
+      isDiscovered: true,
+      ...(componentIds.length ? { id: { in: componentIds } } : {}),
+    },
+    orderBy: [{ folderName: 'asc' }, { componentName: 'asc' }, { id: 'asc' }],
+    take: componentIds.length ? componentIds.length : limit,
+    select: {
+      id: true,
+      componentName: true,
+      folderName: true,
+      sourcePath: true,
+      title: true,
+      description: true,
+      notes: true,
+      category: true,
+      tags: true,
+    },
+  })
+
+  return components.map((component) => ({
+    id: component.id,
+    componentName: component.componentName,
+    folderName: component.folderName,
+    sourcePath: component.sourcePath,
+    title: component.title,
+    description: component.description,
+    notes: component.notes,
+    category: component.category,
+    tags: stringArray(component.tags),
+  }))
+}
+
+async function loadReviewers(): Promise<WonderLabReviewerCandidate[]> {
+  const [bots, characters] = await Promise.all([
+    prisma.bot.findMany({
+      where: { isActive: true, isPublic: true, isMature: false },
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        subtitle: true,
+        description: true,
+        personality: true,
+        narrativeVoice: true,
+        sampleResponse: true,
+        prompt: true,
+        modules: true,
+        isActive: true,
+        isPublic: true,
+        isMature: true,
+      },
+    }),
+    prisma.character.findMany({
+      where: { isActive: true, isPublic: true, isMature: false },
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        title: true,
+        backstory: true,
+        personality: true,
+        voice: true,
+        sampleResponse: true,
+        drive: true,
+        quirks: true,
+        genre: true,
+        isActive: true,
+        isPublic: true,
+        isMature: true,
+      },
+    }),
+  ])
+
+  return [
+    ...bots.map((bot): WonderLabReviewerCandidate => ({
+      id: bot.id,
+      kind: 'BOT',
+      name: bot.name,
+      slug: bot.slug,
+      subtitle: bot.subtitle,
+      description: bot.description,
+      personality: bot.personality,
+      voice: bot.narrativeVoice,
+      sampleResponse: bot.sampleResponse,
+      prompt: bot.prompt,
+      modules: bot.modules,
+      isActive: bot.isActive,
+      isPublic: bot.isPublic,
+      isMature: bot.isMature,
+    })),
+    ...characters.map((character): WonderLabReviewerCandidate => ({
+      id: character.id,
+      kind: 'CHARACTER',
+      name: character.name,
+      slug: character.slug,
+      subtitle: character.title,
+      description: character.backstory,
+      personality: character.personality,
+      voice: character.voice,
+      sampleResponse: character.sampleResponse,
+      prompt: [character.drive, character.quirks].filter(Boolean).join('\n'),
+      modules: character.genre,
+      isActive: character.isActive,
+      isPublic: character.isPublic,
+      isMature: character.isMature,
+    })),
+  ]
+}
+
+async function loadCoverage(): Promise<{
+  drafts: Map<string, DraftCoverageRow>
+  reactions: Map<string, ReactionCoverageRow>
+}> {
+  const [draftRows, reactionRows] = await Promise.all([
+    prisma.$queryRaw<DraftCoverageRow[]>`
+      SELECT
+        id,
+        componentId,
+        authorBotId,
+        authorCharacterId,
+        status,
+        publishedReactionId
+      FROM ReviewDraft
+      ORDER BY updatedAt DESC, createdAt DESC, id DESC
+    `,
+    prisma.$queryRaw<ReactionCoverageRow[]>`
+      SELECT id, componentId, authorBotId, authorCharacterId
+      FROM Reaction
+      WHERE reactionCategory = 'COMPONENT'
+        AND componentId IS NOT NULL
+        AND (authorBotId IS NOT NULL OR authorCharacterId IS NOT NULL)
+      ORDER BY updatedAt DESC, createdAt DESC, id DESC
+    `,
+  ])
+
+  const drafts = new Map<string, DraftCoverageRow>()
+  for (const row of draftRows) {
+    const author = rowAuthor(row)
+    if (!author) continue
+    const key = coverageKey(row.componentId, author)
+    if (!drafts.has(key)) drafts.set(key, row)
+  }
+
+  const reactions = new Map<string, ReactionCoverageRow>()
+  for (const row of reactionRows) {
+    const author = rowAuthor(row)
+    if (!author) continue
+    const key = coverageKey(row.componentId, author)
+    if (!reactions.has(key)) reactions.set(key, row)
+  }
+
+  return { drafts, reactions }
+}
+
+function chooseReviewers(
+  ranked: WonderLabReviewerAffinity[],
+  count: number,
+): WonderLabReviewerAffinity[] {
+  const voiceReady = ranked.filter((entry) => entry.voiceReady)
+  if (!voiceReady.length || count <= 0) return []
+
+  const selected = [voiceReady[0] as WonderLabReviewerAffinity]
+  if (count === 1) return selected
+
+  const first = selected[0]
+  const diverse = voiceReady.find(
+    (entry, index) =>
+      index > 0 &&
+      entry.reviewer.kind !== first.reviewer.kind &&
+      entry.score >= Math.max(0, first.score - 12),
+  )
+  const fallback = voiceReady.find((entry) => entry !== first)
+  const second = diverse || fallback
+  if (second) selected.push(second)
+
+  return selected.slice(0, count)
+}
+
+export async function buildWonderLabReviewPlan(
+  options: BuildWonderLabReviewPlanOptions = {},
+): Promise<WonderLabReviewPlan> {
+  const reviewerCount = Math.max(
+    1,
+    Math.min(2, Math.round(options.reviewersPerComponent ?? 2)),
+  )
+  const [exhibits, candidates, coverage] = await Promise.all([
+    loadExhibits(options),
+    loadReviewers(),
+    loadCoverage(),
+  ])
+
+  const planned = exhibits.map((exhibit): WonderLabReviewPlanExhibit => {
+    const ranked = rankWonderLabReviewers(exhibit, candidates, {
+      limit: 20,
+      minimumScore: options.minimumScore ?? 0,
+      requirePublic: true,
+      includeMature: false,
+    })
+    const selected = chooseReviewers(ranked, reviewerCount)
+
+    return {
+      componentId: exhibit.id,
+      componentName: exhibit.componentName,
+      title: exhibit.title || null,
+      folderName: exhibit.folderName,
+      sourcePath: exhibit.sourcePath || null,
+      status: selected.length ? 'READY' : 'NO_ELIGIBLE_REVIEWER',
+      reviewers: selected.map((entry): WonderLabReviewPlanReviewer => {
+        const author: ReviewDraftAuthorRef = {
+          kind: entry.reviewer.kind,
+          id: entry.reviewer.id,
+        }
+        const key = coverageKey(exhibit.id, author)
+        const draft = coverage.drafts.get(key)
+        const reaction = coverage.reactions.get(key)
+        const publishedReactionId = reaction?.id || draft?.publishedReactionId || null
+        const coverageStatus: WonderLabReviewCoverage = publishedReactionId
+          ? 'PUBLISHED'
+          : draft
+            ? 'DRAFTED'
+            : 'MISSING'
+
+        return {
+          author,
+          name: entry.reviewer.name,
+          slug: entry.reviewer.slug || null,
+          score: entry.score,
+          reasons: entry.reasons,
+          coverage: coverageStatus,
+          draftId: draft?.id ?? null,
+          draftStatus: draft?.status ?? null,
+          reactionId: publishedReactionId,
+        }
+      }),
+    }
+  })
+
+  const reviewers = planned.flatMap((exhibit) => exhibit.reviewers)
+  return {
+    exhibits: planned,
+    componentCount: planned.length,
+    reviewerSlots: reviewers.length,
+    missingCount: reviewers.filter((reviewer) => reviewer.coverage === 'MISSING').length,
+    draftedCount: reviewers.filter((reviewer) => reviewer.coverage === 'DRAFTED').length,
+    publishedCount: reviewers.filter((reviewer) => reviewer.coverage === 'PUBLISHED').length,
+  }
+}

--- a/utils/scripts/verifyWonderLabReviewBatchPlan.ts
+++ b/utils/scripts/verifyWonderLabReviewBatchPlan.ts
@@ -1,0 +1,49 @@
+// /utils/scripts/verifyWonderLabReviewBatchPlan.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const planPath = 'server/utils/wonderLabReviewPlan.ts'
+const getPath = 'server/api/admin/wonderlab/review-plan.get.ts'
+const batchPath = 'server/api/admin/wonderlab/review-drafts/generate-batch.post.ts'
+const pagePath = 'pages/admin/wonderlab-review-plan.vue'
+
+const plan = await readFile(planPath, 'utf8')
+const getEndpoint = await readFile(getPath, 'utf8')
+const batch = await readFile(batchPath, 'utf8')
+const page = await readFile(pagePath, 'utf8')
+
+assert.match(getEndpoint, /requireAdminApiUser\(event\)/)
+assert.match(getEndpoint, /buildWonderLabReviewPlan/)
+assert.match(getEndpoint, /reviewersPerComponent/)
+
+assert.match(plan, /rankWonderLabReviewers/)
+assert.match(plan, /reviewer\.kind !== first\.reviewer\.kind/)
+assert.match(plan, /coverage: coverageStatus/)
+assert.match(plan, /'MISSING' \| 'DRAFTED' \| 'PUBLISHED'/)
+assert.match(plan, /authorBotId IS NOT NULL OR authorCharacterId IS NOT NULL/)
+assert.doesNotMatch(plan, /INSERT\s+INTO/i)
+assert.doesNotMatch(plan, /UPDATE\s+/i)
+assert.doesNotMatch(plan, /DELETE\s+FROM/i)
+
+assert.match(batch, /const MAX_BATCH_COMPONENTS = 10/)
+assert.match(batch, /const MAX_BATCH_GENERATIONS = 20/)
+assert.match(batch, /booleanValue\(body\.dryRun, true, 'dryRun'\)/)
+assert.match(batch, /if \(dryRun\)/)
+assert.match(batch, /no model calls or writes were made/i)
+assert.match(batch, /for \(const target of targets\)/)
+assert.match(batch, /generateWonderLabReviewDraft/)
+assert.match(batch, /coverage === 'PUBLISHED'\) return false/)
+assert.doesNotMatch(batch, /publishReviewDraft/)
+assert.doesNotMatch(batch, /status:\s*'APPROVED'/)
+
+assert.match(page, /Preview deterministic reviewer assignments/)
+assert.match(page, /Batch generation creates proposed drafts only/)
+assert.match(page, /executeEnabled/)
+assert.match(page, /runBatch\(true\)/)
+assert.match(page, /runBatch\(false\)/)
+assert.match(page, /dryRun,/)
+assert.match(page, /Enable model calls for this batch/)
+assert.doesNotMatch(page, /onMounted\([\s\S]{0,500}runBatch\(false\)/)
+assert.doesNotMatch(page, /\/publish/)
+
+console.log('WonderLab review batch planning contract passed.')

--- a/utils/scripts/verifyWonderLabReviewVoiceDiversity.ts
+++ b/utils/scripts/verifyWonderLabReviewVoiceDiversity.ts
@@ -1,0 +1,94 @@
+// /utils/scripts/verifyWonderLabReviewVoiceDiversity.ts
+import assert from 'node:assert/strict'
+import { buildWonderLabReviewDraftPrompt } from '@/utils/wonderlab/reviewDraftPrompt'
+import type {
+  WonderLabExhibitProfile,
+  WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+
+const exhibit: WonderLabExhibitProfile = {
+  id: 42,
+  componentName: 'bot-builder-panel',
+  folderName: 'bots',
+  sourcePath: 'components/bots/bot-builder-panel.vue',
+  title: 'Bot Builder Panel',
+  description: 'A guided interface for assembling a Bot personality and prompt.',
+  category: 'builder',
+  tags: ['bot', 'builder', 'prompt', 'persona'],
+}
+
+const dotti: WonderLabReviewerCandidate = {
+  id: 7,
+  kind: 'BOT',
+  name: 'Dotti',
+  slug: 'dotti',
+  subtitle: 'Bot-building specialist',
+  description: 'A precise and enthusiastic guide to constructing useful Bots.',
+  personality: 'Curious, practical, encouraging, and attentive to prompt structure.',
+  voice: 'Speak like a friendly workshop engineer: concrete, energetic, and exact.',
+  sampleResponse: 'Let us tighten that instruction until the Bot knows exactly where to stand.',
+  isActive: true,
+  isPublic: true,
+  isMature: false,
+}
+
+const catbot: WonderLabReviewerCandidate = {
+  id: 9,
+  kind: 'CHARACTER',
+  name: 'Catbot',
+  slug: 'catbot',
+  subtitle: 'Curious museum mascot',
+  description: 'A playful robotic cat who notices how interfaces feel to visitors.',
+  personality: 'Warm, mischievous, observant, and concise.',
+  voice: 'Use light feline humor and sensory observations without becoming vague.',
+  sampleResponse: 'My whisker sensors approve of the clear controls, though the corner feels crowded.',
+  isActive: true,
+  isPublic: true,
+  isMature: false,
+}
+
+const dottiPrompt = buildWonderLabReviewDraftPrompt(dotti, exhibit, {
+  affinityReasons: ['Dotti bot-building affinity: bot, builder, prompt, persona'],
+  narratorThreads: [
+    {
+      topicKey: 'bot-building',
+      title: 'Build a better Bot',
+      openingText: 'Start with the job, then make every instruction earn its place.',
+      guidance: 'Favor specific engineering observations over general praise.',
+    },
+  ],
+})
+const catbotPrompt = buildWonderLabReviewDraftPrompt(catbot, exhibit, {
+  affinityReasons: ['Catbot broad museum eligibility'],
+})
+
+assert.notEqual(dottiPrompt.system, catbotPrompt.system)
+assert.notEqual(dottiPrompt.user, catbotPrompt.user)
+assert.notEqual(dottiPrompt.provenance.reviewerKey, catbotPrompt.provenance.reviewerKey)
+assert.notEqual(dottiPrompt.provenance.draftKey, catbotPrompt.provenance.draftKey)
+
+assert.match(dottiPrompt.system, /Write as Dotti/)
+assert.match(dottiPrompt.user, /friendly workshop engineer/i)
+assert.match(dottiPrompt.user, /tighten that instruction/i)
+assert.match(dottiPrompt.user, /bot-building affinity/i)
+assert.deepEqual(dottiPrompt.provenance.voiceSources, [
+  'voice',
+  'sampleResponse',
+  'narratorThreads',
+])
+
+assert.match(catbotPrompt.system, /Write as Catbot/)
+assert.match(catbotPrompt.user, /feline humor/i)
+assert.match(catbotPrompt.user, /whisker sensors/i)
+assert.match(catbotPrompt.user, /broad museum eligibility/i)
+assert.deepEqual(catbotPrompt.provenance.voiceSources, ['voice', 'sampleResponse'])
+
+assert.doesNotMatch(dottiPrompt.user, /whisker sensors/i)
+assert.doesNotMatch(catbotPrompt.user, /workshop engineer/i)
+assert.equal(dottiPrompt.provenance.exhibitId, catbotPrompt.provenance.exhibitId)
+assert.equal(
+  dottiPrompt.provenance.exhibitSourcePath,
+  catbotPrompt.provenance.exhibitSourcePath,
+)
+
+console.log('WonderLab reviewer voice diversity acceptance test passed.')


### PR DESCRIPTION
## Summary

Adds deterministic coverage planning and safely bounded batch generation for WonderLab personality reviews.

### Coverage planning

- ranks eligible public, active, non-mature Bots and Characters for discovered Components;
- selects one or two voice-ready reviewers per exhibit, preferring kind diversity when scores remain competitive;
- reports missing, drafted, and published reviewer slots;
- exposes reviewer scores, affinity reasons, draft IDs/statuses, and published Reaction IDs;
- performs no writes.

### Batch generation

- administrator-only endpoint;
- dry-run defaults to true and makes no model calls or writes;
- maximum 10 Components and 20 generation targets per request;
- skips published reviewer slots;
- generates sequentially to bound provider pressure;
- records individual failures without aborting the entire batch;
- creates proposed or failed drafts only, never approval or publication.

### Editorial UI and acceptance coverage

- `/admin/wonderlab-review-plan` previews the assignment and coverage report;
- executing model calls requires a deliberate checkbox and button action;
- Dotti/Catbot voice-swap acceptance verifies that identical exhibit context produces distinct reviewer prompts and provenance;
- required contracts prevent automatic generation, approval, or publication.

Part of #472 and #381.