### PR TITLE
Production: safely repair failed Reaction authorship migration

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Database pool defaults contract
         run: npm run test:database-pool-defaults
 
+      - name: Known failed Prisma migration repair contract
+        run: node utils/scripts/verify-known-migration-repair.mjs
+
       - name: Academy style-detail caller-doc contract
         run: npm run test:academy-style-detail-callers
 

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -4,6 +4,7 @@ import { writeFile, unlink } from 'node:fs/promises'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import mariadb from 'mariadb'
+import { repairKnownFailedMigrations } from './repair-known-prisma-migrations.mjs'
 
 const databaseUrl = process.env.DATABASE_URL
 const caFilePath = '/tmp/kindrobots-proxysql-ca.pem'
@@ -26,11 +27,11 @@ function readDatabaseSslCa() {
   return plain || undefined
 }
 
-function runPrismaMigrate(url) {
+function runPrismaCommand(url, args) {
   const prismaBinary = path.resolve('node_modules/.bin/prisma')
 
   return new Promise((resolve, reject) => {
-    const child = spawn(prismaBinary, ['migrate', 'deploy'], {
+    const child = spawn(prismaBinary, args, {
       stdio: 'inherit',
       env: {
         ...process.env,
@@ -48,36 +49,35 @@ function runPrismaMigrate(url) {
       reject(
         new Error(
           signal
-            ? `prisma migrate deploy terminated by ${signal}`
-            : `prisma migrate deploy exited with code ${code ?? 'unknown'}`,
+            ? `prisma ${args.join(' ')} terminated by ${signal}`
+            : `prisma ${args.join(' ')} exited with code ${code ?? 'unknown'}`,
         ),
       )
     })
   })
 }
 
-async function verifyTlsConnection(parsedUrl, sslCa) {
-  let connection
+function runPrismaMigrate(url) {
+  return runPrismaCommand(url, ['migrate', 'deploy'])
+}
 
-  try {
-    connection = await mariadb.createConnection({
-      host: parsedUrl.hostname,
-      port: Number.parseInt(parsedUrl.port || '3306', 10),
-      user: decodeURIComponent(parsedUrl.username),
-      password: decodeURIComponent(parsedUrl.password),
-      database: decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, '')),
-      connectTimeout: 5_000,
-      ssl: {
-        ca: sslCa,
-        rejectUnauthorized: true,
-      },
-    })
+async function createTlsConnection(parsedUrl, sslCa) {
+  const connection = await mariadb.createConnection({
+    host: parsedUrl.hostname,
+    port: Number.parseInt(parsedUrl.port || '3306', 10),
+    user: decodeURIComponent(parsedUrl.username),
+    password: decodeURIComponent(parsedUrl.password),
+    database: decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, '')),
+    connectTimeout: 5_000,
+    ssl: {
+      ca: sslCa,
+      rejectUnauthorized: true,
+    },
+  })
 
-    await connection.query('SELECT 1 AS tls_connection_ok')
-    console.log('[database] Verified TLS connection to ProxySQL before migration.')
-  } finally {
-    await connection?.end()
-  }
+  await connection.query('SELECT 1 AS tls_connection_ok')
+  console.log('[database] Verified TLS connection to ProxySQL before migration.')
+  return connection
 }
 
 async function main() {
@@ -106,15 +106,26 @@ async function main() {
 
   await writeFile(caFilePath, `${sslCa}\n`, { mode: 0o600 })
 
+  let connection
   try {
     const parsedUrl = new URL(databaseUrl)
-    await verifyTlsConnection(parsedUrl, sslCa)
+    connection = await createTlsConnection(parsedUrl, sslCa)
 
     parsedUrl.searchParams.set('sslcert', caFilePath)
     parsedUrl.searchParams.set('sslaccept', 'strict')
+    const prismaUrl = parsedUrl.toString()
 
-    await runPrismaMigrate(parsedUrl.toString())
+    await repairKnownFailedMigrations({
+      connection,
+      prismaUrl,
+      runPrismaCommand,
+    })
+
+    await connection.end()
+    connection = undefined
+    await runPrismaMigrate(prismaUrl)
   } finally {
+    await connection?.end().catch(() => undefined)
     await unlink(caFilePath).catch(() => undefined)
   }
 }

--- a/scripts/repair-known-prisma-migrations.mjs
+++ b/scripts/repair-known-prisma-migrations.mjs
@@ -1,0 +1,252 @@
+// /scripts/repair-known-prisma-migrations.mjs
+
+const REACTION_AUTHOR_MIGRATION =
+  '20260719031500_reaction_first_party_author_expand'
+
+function rows(result) {
+  return Array.isArray(result) ? result : []
+}
+
+async function currentDatabase(connection) {
+  const result = rows(await connection.query('SELECT DATABASE() AS databaseName'))
+  const databaseName = result[0]?.databaseName
+  if (typeof databaseName !== 'string' || !databaseName) {
+    throw new Error('[database repair] Could not resolve the active database name.')
+  }
+  return databaseName
+}
+
+async function failedMigrationExists(connection, migrationName) {
+  try {
+    const result = rows(
+      await connection.query(
+        `SELECT migration_name
+           FROM _prisma_migrations
+          WHERE migration_name = ?
+            AND finished_at IS NULL
+            AND rolled_back_at IS NULL
+          LIMIT 1`,
+        [migrationName],
+      ),
+    )
+    return result.length > 0
+  } catch (error) {
+    if (error?.code === 'ER_NO_SUCH_TABLE') return false
+    throw error
+  }
+}
+
+async function columnDefinition(connection, databaseName, columnName) {
+  const result = rows(
+    await connection.query(
+      `SELECT DATA_TYPE AS dataType, IS_NULLABLE AS isNullable
+         FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = ?
+          AND TABLE_NAME = 'Reaction'
+          AND COLUMN_NAME = ?
+        LIMIT 1`,
+      [databaseName, columnName],
+    ),
+  )
+  return result[0] || null
+}
+
+async function indexExists(connection, databaseName, indexName) {
+  const result = rows(
+    await connection.query(
+      `SELECT INDEX_NAME
+         FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = ?
+          AND TABLE_NAME = 'Reaction'
+          AND INDEX_NAME = ?
+        LIMIT 1`,
+      [databaseName, indexName],
+    ),
+  )
+  return result.length > 0
+}
+
+async function foreignKeyExists(connection, databaseName, constraintName) {
+  const result = rows(
+    await connection.query(
+      `SELECT CONSTRAINT_NAME
+         FROM information_schema.KEY_COLUMN_USAGE
+        WHERE TABLE_SCHEMA = ?
+          AND TABLE_NAME = 'Reaction'
+          AND CONSTRAINT_NAME = ?
+          AND REFERENCED_TABLE_NAME IS NOT NULL
+        LIMIT 1`,
+      [databaseName, constraintName],
+    ),
+  )
+  return result.length > 0
+}
+
+async function checkConstraintExists(connection, databaseName, constraintName) {
+  const result = rows(
+    await connection.query(
+      `SELECT CONSTRAINT_NAME
+         FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = ?
+          AND TABLE_NAME = 'Reaction'
+          AND CONSTRAINT_NAME = ?
+          AND CONSTRAINT_TYPE = 'CHECK'
+        LIMIT 1`,
+      [databaseName, constraintName],
+    ),
+  )
+  return result.length > 0
+}
+
+async function assertNullableIntegerColumn(connection, databaseName, columnName) {
+  const definition = await columnDefinition(connection, databaseName, columnName)
+  if (!definition) {
+    await connection.query(
+      `ALTER TABLE \`Reaction\` ADD COLUMN \`${columnName}\` INTEGER NULL`,
+    )
+    return
+  }
+
+  if (definition.dataType !== 'int' || definition.isNullable !== 'YES') {
+    throw new Error(
+      `[database repair] Reaction.${columnName} exists with an unexpected definition; refusing automatic repair.`,
+    )
+  }
+}
+
+async function ensureIndex(connection, databaseName, indexName, columnName) {
+  if (await indexExists(connection, databaseName, indexName)) return
+  await connection.query(
+    `CREATE INDEX \`${indexName}\` ON \`Reaction\`(\`${columnName}\`)`,
+  )
+}
+
+async function ensureForeignKey(
+  connection,
+  databaseName,
+  constraintName,
+  columnName,
+  referencedTable,
+) {
+  if (await foreignKeyExists(connection, databaseName, constraintName)) return
+  await connection.query(
+    `ALTER TABLE \`Reaction\`
+       ADD CONSTRAINT \`${constraintName}\`
+       FOREIGN KEY (\`${columnName}\`) REFERENCES \`${referencedTable}\`(\`id\`)
+       ON DELETE SET NULL ON UPDATE CASCADE`,
+  )
+}
+
+async function assertSafeAuthorRows(connection) {
+  const result = rows(
+    await connection.query(
+      `SELECT
+         SUM(authorBotId IS NOT NULL AND authorCharacterId IS NOT NULL) AS dualAuthors,
+         SUM(authorBotId IS NOT NULL AND b.id IS NULL) AS missingBots,
+         SUM(authorCharacterId IS NOT NULL AND c.id IS NULL) AS missingCharacters
+       FROM Reaction r
+       LEFT JOIN Bot b ON b.id = r.authorBotId
+       LEFT JOIN Character c ON c.id = r.authorCharacterId`,
+    ),
+  )
+  const counts = result[0] || {}
+  const unsafe = [counts.dualAuthors, counts.missingBots, counts.missingCharacters].some(
+    (value) => Number(value || 0) > 0,
+  )
+  if (unsafe) {
+    throw new Error(
+      '[database repair] Existing Reaction author data violates the intended foreign-key or single-author invariants; refusing automatic repair.',
+    )
+  }
+}
+
+async function repairReactionAuthorMigration(connection, databaseName) {
+  console.warn(
+    `[database repair] Found failed ${REACTION_AUTHOR_MIGRATION}; reconciling its expand-only schema state.`,
+  )
+
+  await assertNullableIntegerColumn(connection, databaseName, 'authorBotId')
+  await assertNullableIntegerColumn(connection, databaseName, 'authorCharacterId')
+  await ensureIndex(
+    connection,
+    databaseName,
+    'Reaction_authorBotId_idx',
+    'authorBotId',
+  )
+  await ensureIndex(
+    connection,
+    databaseName,
+    'Reaction_authorCharacterId_idx',
+    'authorCharacterId',
+  )
+
+  if (
+    await checkConstraintExists(
+      connection,
+      databaseName,
+      'Reaction_firstPartyAuthor_check',
+    )
+  ) {
+    await connection.query(
+      'ALTER TABLE `Reaction` DROP CONSTRAINT `Reaction_firstPartyAuthor_check`',
+    )
+  }
+
+  await assertSafeAuthorRows(connection)
+  await ensureForeignKey(
+    connection,
+    databaseName,
+    'Reaction_authorBotId_fkey',
+    'authorBotId',
+    'Bot',
+  )
+  await ensureForeignKey(
+    connection,
+    databaseName,
+    'Reaction_authorCharacterId_fkey',
+    'authorCharacterId',
+    'Character',
+  )
+
+  const requiredState = await Promise.all([
+    columnDefinition(connection, databaseName, 'authorBotId'),
+    columnDefinition(connection, databaseName, 'authorCharacterId'),
+    indexExists(connection, databaseName, 'Reaction_authorBotId_idx'),
+    indexExists(connection, databaseName, 'Reaction_authorCharacterId_idx'),
+    foreignKeyExists(connection, databaseName, 'Reaction_authorBotId_fkey'),
+    foreignKeyExists(connection, databaseName, 'Reaction_authorCharacterId_fkey'),
+  ])
+  if (requiredState.some((value) => !value)) {
+    throw new Error(
+      `[database repair] ${REACTION_AUTHOR_MIGRATION} schema verification failed; migration history was not changed.`,
+    )
+  }
+}
+
+export async function repairKnownFailedMigrations({
+  connection,
+  prismaUrl,
+  runPrismaCommand,
+}) {
+  if (
+    !(await failedMigrationExists(connection, REACTION_AUTHOR_MIGRATION))
+  ) {
+    return { repaired: [] }
+  }
+
+  const databaseName = await currentDatabase(connection)
+  await repairReactionAuthorMigration(connection, databaseName)
+  await runPrismaCommand(prismaUrl, [
+    'migrate',
+    'resolve',
+    '--applied',
+    REACTION_AUTHOR_MIGRATION,
+  ])
+
+  console.log(
+    `[database repair] Marked ${REACTION_AUTHOR_MIGRATION} applied after verifying its complete fixed schema state.`,
+  )
+  return { repaired: [REACTION_AUTHOR_MIGRATION] }
+}
+
+export const knownFailedMigrationNames = [REACTION_AUTHOR_MIGRATION]

--- a/utils/scripts/verify-known-migration-repair.mjs
+++ b/utils/scripts/verify-known-migration-repair.mjs
@@ -1,0 +1,168 @@
+// /utils/scripts/verify-known-migration-repair.mjs
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  knownFailedMigrationNames,
+  repairKnownFailedMigrations,
+} from '../../scripts/repair-known-prisma-migrations.mjs'
+
+const migrationName = '20260719031500_reaction_first_party_author_expand'
+assert.deepEqual(knownFailedMigrationNames, [migrationName])
+
+function fakeConnection(options = {}) {
+  const state = {
+    failed: options.failed ?? true,
+    columns: new Map(options.columns || []),
+    indexes: new Set(options.indexes || []),
+    foreignKeys: new Set(options.foreignKeys || []),
+    checkConstraint: options.checkConstraint ?? false,
+    unsafeRows: options.unsafeRows ?? false,
+    statements: [],
+  }
+
+  return {
+    state,
+    async query(sql, params = []) {
+      const normalized = String(sql).replace(/\s+/g, ' ').trim()
+      state.statements.push(normalized)
+
+      if (normalized.startsWith('SELECT migration_name FROM _prisma_migrations')) {
+        return state.failed ? [{ migration_name: migrationName }] : []
+      }
+      if (normalized.startsWith('SELECT DATABASE() AS databaseName')) {
+        return [{ databaseName: 'kindrobots' }]
+      }
+      if (normalized.includes('FROM information_schema.COLUMNS')) {
+        const column = params[1]
+        const definition = state.columns.get(column)
+        return definition ? [definition] : []
+      }
+      if (normalized.includes('FROM information_schema.STATISTICS')) {
+        return state.indexes.has(params[1]) ? [{ INDEX_NAME: params[1] }] : []
+      }
+      if (normalized.includes('FROM information_schema.KEY_COLUMN_USAGE')) {
+        return state.foreignKeys.has(params[1])
+          ? [{ CONSTRAINT_NAME: params[1] }]
+          : []
+      }
+      if (normalized.includes('FROM information_schema.TABLE_CONSTRAINTS')) {
+        return state.checkConstraint ? [{ CONSTRAINT_NAME: params[1] }] : []
+      }
+      if (normalized.startsWith('SELECT SUM(authorBotId')) {
+        return [
+          state.unsafeRows
+            ? { dualAuthors: 1, missingBots: 0, missingCharacters: 0 }
+            : { dualAuthors: 0, missingBots: 0, missingCharacters: 0 },
+        ]
+      }
+      if (normalized.includes('ADD COLUMN `authorBotId`')) {
+        state.columns.set('authorBotId', { dataType: 'int', isNullable: 'YES' })
+        return { affectedRows: 0 }
+      }
+      if (normalized.includes('ADD COLUMN `authorCharacterId`')) {
+        state.columns.set('authorCharacterId', {
+          dataType: 'int',
+          isNullable: 'YES',
+        })
+        return { affectedRows: 0 }
+      }
+      if (normalized.startsWith('CREATE INDEX `Reaction_authorBotId_idx`')) {
+        state.indexes.add('Reaction_authorBotId_idx')
+        return { affectedRows: 0 }
+      }
+      if (
+        normalized.startsWith('CREATE INDEX `Reaction_authorCharacterId_idx`')
+      ) {
+        state.indexes.add('Reaction_authorCharacterId_idx')
+        return { affectedRows: 0 }
+      }
+      if (normalized.includes('DROP CONSTRAINT `Reaction_firstPartyAuthor_check`')) {
+        state.checkConstraint = false
+        return { affectedRows: 0 }
+      }
+      if (normalized.includes('ADD CONSTRAINT `Reaction_authorBotId_fkey`')) {
+        state.foreignKeys.add('Reaction_authorBotId_fkey')
+        return { affectedRows: 0 }
+      }
+      if (
+        normalized.includes('ADD CONSTRAINT `Reaction_authorCharacterId_fkey`')
+      ) {
+        state.foreignKeys.add('Reaction_authorCharacterId_fkey')
+        return { affectedRows: 0 }
+      }
+
+      throw new Error(`Unexpected repair query: ${normalized}`)
+    },
+  }
+}
+
+const noOp = fakeConnection({ failed: false })
+const noOpCommands = []
+assert.deepEqual(
+  await repairKnownFailedMigrations({
+    connection: noOp,
+    prismaUrl: 'mysql://example',
+    runPrismaCommand: async (...args) => noOpCommands.push(args),
+  }),
+  { repaired: [] },
+)
+assert.deepEqual(noOpCommands, [])
+
+const partial = fakeConnection({
+  columns: [
+    ['authorBotId', { dataType: 'int', isNullable: 'YES' }],
+    ['authorCharacterId', { dataType: 'int', isNullable: 'YES' }],
+  ],
+  indexes: ['Reaction_authorBotId_idx', 'Reaction_authorCharacterId_idx'],
+})
+const repairCommands = []
+assert.deepEqual(
+  await repairKnownFailedMigrations({
+    connection: partial,
+    prismaUrl: 'mysql://example',
+    runPrismaCommand: async (...args) => repairCommands.push(args),
+  }),
+  { repaired: [migrationName] },
+)
+assert.ok(partial.state.foreignKeys.has('Reaction_authorBotId_fkey'))
+assert.ok(partial.state.foreignKeys.has('Reaction_authorCharacterId_fkey'))
+assert.deepEqual(repairCommands, [
+  [
+    'mysql://example',
+    ['migrate', 'resolve', '--applied', migrationName],
+  ],
+])
+
+const unsafe = fakeConnection({
+  columns: [
+    ['authorBotId', { dataType: 'int', isNullable: 'YES' }],
+    ['authorCharacterId', { dataType: 'int', isNullable: 'YES' }],
+  ],
+  indexes: ['Reaction_authorBotId_idx', 'Reaction_authorCharacterId_idx'],
+  unsafeRows: true,
+})
+const unsafeCommands = []
+await assert.rejects(
+  repairKnownFailedMigrations({
+    connection: unsafe,
+    prismaUrl: 'mysql://example',
+    runPrismaCommand: async (...args) => unsafeCommands.push(args),
+  }),
+  /violates the intended foreign-key or single-author invariants/i,
+)
+assert.deepEqual(unsafeCommands, [])
+
+const repairSource = await readFile(
+  'scripts/repair-known-prisma-migrations.mjs',
+  'utf8',
+)
+const deploySource = await readFile('scripts/prisma-migrate-deploy.mjs', 'utf8')
+assert.match(repairSource, /migrate',\s*'resolve',\s*'--applied'/)
+assert.match(repairSource, /schema verification failed; migration history was not changed/)
+assert.doesNotMatch(repairSource, /UPDATE\s+_prisma_migrations/i)
+assert.doesNotMatch(repairSource, /DELETE\s+FROM/i)
+assert.doesNotMatch(repairSource, /DROP\s+TABLE/i)
+assert.match(deploySource, /repairKnownFailedMigrations/)
+assert.match(deploySource, /await repairKnownFailedMigrations[\s\S]*await runPrismaMigrate/)
+
+console.log('Known failed Prisma migration repair contract passed.')


### PR DESCRIPTION
## Summary

Unblocks production's known Prisma P3009 state by adding a narrowly scoped, guarded repair for `20260719031500_reaction_first_party_author_expand` before `prisma migrate deploy`.

### Why production is stuck

The original migration successfully ran its expand-only column/index statements, then failed when MariaDB rejected the former author CHECK constraint alongside `ON DELETE SET NULL` foreign keys. The migration SQL has since been fixed, but Prisma correctly refuses every subsequent deployment while the failed migration record remains unresolved.

### Guarded repair

Only when that exact migration is recorded as unfinished and not rolled back, the deploy script:

- resolves the active database through the already-verified TLS connection;
- adds either nullable integer author column only if missing;
- adds either index only if missing;
- removes the now-invalid named CHECK only if it somehow exists;
- refuses repair if existing rows have dual authors or orphan author IDs;
- adds either expected foreign key only if missing;
- re-queries and verifies every required column, index, and foreign key;
- invokes Prisma's supported `migrate resolve --applied` command only after verification;
- then runs ordinary `prisma migrate deploy`, allowing the ReviewDraft and later migrations to proceed.

### Safety boundaries

- exact migration allowlist: one known failed migration;
- no direct writes to `_prisma_migrations`;
- no data deletion or table deletion;
- no mutation when the failure record is absent;
- unexpected column definitions or unsafe data abort the deployment without changing migration history;
- DB-free fake-connection tests cover no-op, partial-DDL recovery, verification, and unsafe-data refusal.

This is the automated equivalent of the manual production repair documented in #502.