### PR TITLE
stylist: add minimal Cypress + contract coverage for /stylist and mask forwarding

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Newsfeed perspective balance contract
         run: npm run test:newsfeed-perspective-balance
 
+      - name: Kontext mask forwarding contract
+        run: npm run test:kontext-mask-forwarding
+
       - name: WonderLab reconciliation contract
         run: npm run test:wonderlab-reconcile
 

--- a/cypress/e2e/stylist-access.cy.ts
+++ b/cypress/e2e/stylist-access.cy.ts
@@ -1,0 +1,27 @@
+// /cypress/e2e/stylist-access.cy.ts
+//
+// Minimal Cypress coverage for /stylist (conductor superkate-hairstyle-ai
+// t-021, kaizen from t-018): before this, no Cypress spec referenced
+// "stylist" anywhere in the repo. /stylist (content/stylist.md) carries
+// `requiredRole: ADMIN`, enforced client-side by
+// middleware/navigation-access.global.ts.
+//
+// This only asserts the access boundary (anonymous visitors get bounced to
+// /login with a redirect back to /stylist), not an authenticated admin
+// render of Hair Studio: Cypress's only admin-auth mechanism today is the
+// header-based beta-admin-token bypass (cypress/support/api-auth.ts), which
+// mints a real admin identity for API requests but not a client-usable JWT
+// -- server/api/auth/validate/token.ts (what userStore.initialize() calls to
+// establish a browser session) requires an actual three-segment JWT and
+// rejects the bypass token outright. Visiting /stylist as a real logged-in
+// admin needs a seeded admin login (username/password), which no Cypress
+// env var currently provides -- filed as a follow-up, not faked here.
+describe('/stylist access', () => {
+  it('redirects an anonymous visitor to /login instead of rendering Hair Studio', () => {
+    cy.visit('/stylist')
+
+    cy.location('pathname', { timeout: 15000 }).should('eq', '/login')
+    cy.location('search').should('include', 'redirect=%2Fstylist')
+    cy.contains('Hair Studio').should('not.exist')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",
     "test:newsfeed-filters": "tsx utils/scripts/verifyNewsfeedFilters.ts",
     "test:newsfeed-perspective-balance": "tsx utils/scripts/verifyNewsfeedPerspectiveBalance.ts",
+    "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/server/api/comfy/kontext/enqueue.post.ts
+++ b/server/api/comfy/kontext/enqueue.post.ts
@@ -16,6 +16,7 @@ import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { authAndGate } from '../../../utils/comfyGate'
 import {
+  buildKontextInputImages,
   buildKontextWorkflow,
   getKontextImageExtension,
 } from './utils/workflow'
@@ -107,13 +108,7 @@ export default defineEventHandler(async (event) => {
     const payload = {
       workflow,
       promptString: prompt,
-      images: [
-        {
-          name: imageName,
-          imageData,
-        },
-        ...(maskName ? [{ name: maskName, imageData: maskData }] : []),
-      ],
+      images: buildKontextInputImages(imageName, imageData, maskName, maskData),
       save: {
         isPublic: body.isPublic ?? false,
         isMature: body.isMature ?? false,

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -83,7 +83,8 @@ export function buildKontextWorkflow(
   const maskName = input.maskName?.trim() || ''
   const useMask = maskName.length > 0
   const originalWeight =
-    typeof input.originalWeight === 'number' && Number.isFinite(input.originalWeight)
+    typeof input.originalWeight === 'number' &&
+    Number.isFinite(input.originalWeight)
       ? clamp(input.originalWeight, 0, 1)
       : 0
   // Init from the encoded source when preserving the original or when masking
@@ -285,13 +286,34 @@ export function buildKontextWorkflow(
 }
 
 export function getKontextImageExtension(imageData: string): string {
-  const match = imageData
-    .trim()
-    .match(/^data:image\/([a-zA-Z0-9.+-]+);base64,/)
+  const match = imageData.trim().match(/^data:image\/([a-zA-Z0-9.+-]+);base64,/)
   const subtype = (match?.[1] || 'png').toLowerCase()
 
   if (subtype.includes('jpeg') || subtype.includes('jpg')) return 'jpg'
   if (subtype.includes('webp')) return 'webp'
 
   return 'png'
+}
+
+export type KontextInputImage = { name: string; imageData: string }
+
+// The ArtJob payload's `images` array: the source photo, plus an optional
+// hair/region mask image the relay uploads to Comfy's input folder alongside
+// it (see buildKontextWorkflow's `maskName`/LoadImageMask wiring above). Only
+// appended when both a mask name and its data are present -- mirrors the
+// maskName-gated node wiring so the payload and the workflow graph can never
+// disagree about whether a mask is in play.
+export function buildKontextInputImages(
+  imageName: string,
+  imageData: string,
+  maskName?: string | null,
+  maskData?: string | null,
+): KontextInputImage[] {
+  const images: KontextInputImage[] = [{ name: imageName, imageData }]
+
+  if (maskName && maskData) {
+    images.push({ name: maskName, imageData: maskData })
+  }
+
+  return images
 }

--- a/utils/scripts/verifyKontextMaskForwarding.ts
+++ b/utils/scripts/verifyKontextMaskForwarding.ts
@@ -1,0 +1,110 @@
+// /utils/scripts/verifyKontextMaskForwarding.ts
+//
+// Regression test for the stylist hair-mask path (conductor
+// superkate-hairstyle-ai t-021, kaizen from t-018): asserts a maskData data
+// URL supplied to server/api/comfy/kontext/enqueue.post.ts is forwarded
+// unchanged into the ArtJob's ComfyUI payload, and wires the corresponding
+// LoadImageMask/SetLatentNoiseMask nodes into the workflow graph. No
+// network/DB dependency -- pure functions over fixture input.
+import assert from 'node:assert/strict'
+
+import {
+  buildKontextInputImages,
+  buildKontextWorkflow,
+} from '../../server/api/comfy/kontext/utils/workflow'
+
+const FIXTURE_IMAGE_DATA = 'data:image/png;base64,ZmFrZS1zb3VyY2UtcGhvdG8='
+const FIXTURE_MASK_DATA = 'data:image/png;base64,ZmFrZS1oYWlyLW1hc2s='
+const IMAGE_NAME = 'kr_kontext_queue_fixture.png'
+const MASK_NAME = 'kr_kontext_mask_fixture.png'
+
+// --- buildKontextInputImages: the ArtJob payload's `images` array ----------
+
+const withMask = buildKontextInputImages(
+  IMAGE_NAME,
+  FIXTURE_IMAGE_DATA,
+  MASK_NAME,
+  FIXTURE_MASK_DATA,
+)
+assert.deepEqual(
+  withMask,
+  [
+    { name: IMAGE_NAME, imageData: FIXTURE_IMAGE_DATA },
+    { name: MASK_NAME, imageData: FIXTURE_MASK_DATA },
+  ],
+  'a provided maskData must be forwarded into the payload images array unchanged, alongside the source image',
+)
+
+const withoutMask = buildKontextInputImages(IMAGE_NAME, FIXTURE_IMAGE_DATA)
+assert.deepEqual(
+  withoutMask,
+  [{ name: IMAGE_NAME, imageData: FIXTURE_IMAGE_DATA }],
+  'omitting maskData must not add a second images entry',
+)
+
+const maskNameOnly = buildKontextInputImages(
+  IMAGE_NAME,
+  FIXTURE_IMAGE_DATA,
+  MASK_NAME,
+  '',
+)
+assert.deepEqual(
+  maskNameOnly,
+  [{ name: IMAGE_NAME, imageData: FIXTURE_IMAGE_DATA }],
+  'a maskName with no maskData must not add a dangling images entry',
+)
+
+// --- buildKontextWorkflow: the ComfyUI graph's mask wiring ------------------
+
+const baseInput = {
+  prompt: 'fixture prompt',
+  imageName: IMAGE_NAME,
+}
+
+const maskedWorkflow = buildKontextWorkflow({
+  ...baseInput,
+  maskName: MASK_NAME,
+})
+assert.equal(
+  maskedWorkflow['70']?.class_type,
+  'LoadImageMask',
+  'a maskName must add a LoadImageMask node at 70',
+)
+assert.deepEqual(
+  maskedWorkflow['70']?.inputs,
+  { image: MASK_NAME, channel: 'red' },
+  'LoadImageMask must load the exact maskName forwarded from the request, on the red channel',
+)
+assert.equal(
+  maskedWorkflow['71']?.class_type,
+  'SetLatentNoiseMask',
+  'a maskName must add a SetLatentNoiseMask node at 71',
+)
+assert.deepEqual(
+  (maskedWorkflow['71']?.inputs as { mask?: unknown })?.mask,
+  ['70', 0],
+  "SetLatentNoiseMask must consume LoadImageMask's output",
+)
+assert.deepEqual(
+  (maskedWorkflow['13']?.inputs as { latent_image?: unknown })?.latent_image,
+  ['71', 0],
+  'the sampler must be wired to the masked latent, not the unmasked source',
+)
+
+const unmaskedWorkflow = buildKontextWorkflow(baseInput)
+assert.equal(
+  unmaskedWorkflow['70'],
+  undefined,
+  'no maskName must mean no LoadImageMask node',
+)
+assert.equal(
+  unmaskedWorkflow['71'],
+  undefined,
+  'no maskName must mean no SetLatentNoiseMask node',
+)
+
+console.log(
+  'kontext mask forwarding verified: maskData passes through to the ArtJob ' +
+    'payload unchanged, and maskName wires LoadImageMask/SetLatentNoiseMask ' +
+    'into the workflow graph only when a mask is actually provided.',
+)


### PR DESCRIPTION
### Task
superkate-hairstyle-ai/t-021: Add minimal Cypress coverage for /stylist (currently zero automated coverage) (kind: software)

### What changed / what I produced
- Extracted `buildKontextInputImages()` (`server/api/comfy/kontext/utils/workflow.ts`) from `enqueue.post.ts`'s inline images-array construction so it's independently unit-testable; behavior unchanged (source image always first, mask image appended only when both `maskName` and `maskData` are present).
- New `utils/scripts/verifyKontextMaskForwarding.ts` contract test:
  - `buildKontextInputImages`: a provided `maskData` forwards unchanged into the payload's `images` array alongside the source image; omitting it (or passing a name with no data) adds nothing extra.
  - `buildKontextWorkflow`: a `maskName` wires `LoadImageMask` (node 70, red channel) → `SetLatentNoiseMask` (node 71) → the sampler's `latent_image` (node 13); no `maskName` means neither mask node exists.
  - Wired into `package.json` (`test:kontext-mask-forwarding`) and `.github/workflows/contract-tests.yml`.
- New `cypress/e2e/stylist-access.cy.ts`: asserts an anonymous visitor to `/stylist` is redirected to `/login?redirect=%2Fstylist` instead of rendering Hair Studio — the `requiredRole: ADMIN` gate (`middleware/navigation-access.global.ts`) actually works.

### Deliberately not done
A full authenticated-admin "sees Hair Studio render" assertion. Investigated the available Cypress auth mechanisms first: the header-based beta-admin-token bypass (`cypress/support/api-auth.ts`) mints a real admin identity for **API** requests via `authGuard.ts`'s `x-admin-token`/`x-beta-admin-token` path, but that's server-route-only — the client SPA's own auth (`userStore` → `/api/auth/validate/token.ts`) strictly requires a real three-segment JWT and rejects the bypass token (`token.split('.').length !== 3`). There's currently no seeded admin login (username/password) exposed to Cypress to mint one. Flagged as the concrete blocker rather than faking a "renders correctly" assertion with an unauthenticated or mocked session.

### How I verified
- `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — clean.
- `npx eslint` on every changed/new file — clean.
- `npx prettier --check` — clean.
- `npm run test:kontext-mask-forwarding` — passes locally.
- Could not run the new Cypress spec live in-sandbox: `cypress` postinstall's binary download is blocked by the egress allowlist (same `CYPRESS_INSTALL_BINARY=0` workaround conductor's `provision_kind_robots_deps.sh` uses to unblock `npm ci`), so no local Electron/Chrome Cypress runner is available here. CI's `contract-tests.yml`/`cypress.yml` (real `npm ci`, real browser, against the live deploy) is the actual verification gate for this spec.

### Stakes
reversible — additive test/contract coverage plus a behavior-preserving extraction (`buildKontextInputImages`); no schema, API-contract, or UI behavior changes.

### Flags for Reviewer
- The extraction of `buildKontextInputImages` is the only non-test code change — please double check the images array is still byte-for-byte identical to the old inline logic (source image always first; mask appended iff both `maskName` and `maskData` are truthy).
- Real admin-session Cypress coverage remains open — would need a seeded admin login credential (or an equivalent test-only JWT-minting path) exposed via Cypress env, which is a test-infra decision beyond this task's scope.

### Kaizen suggestion
Cypress has no way to establish a genuine authenticated **browser** session as any role today (only server-side API bypass headers) — every `requiredRole`-gated page (not just `/stylist`) is currently untestable past its access boundary. Worth a small, focused follow-up: a seeded Cypress test admin user (or a test-only endpoint that mints a real JWT for a seeded user, gated the same way the existing beta-admin-token is) so future specs can assert actual authenticated page content, not just the redirect boundary.

### Notes for reviewer
Conductor task: superkate-hairstyle-ai/t-021 (set to `status: review` in the conductor roadmap as part of this same session).


---
_Generated by [Claude Code](https://claude.ai/code/session_015y96xBv7vAnsBSQdbjakrt)_