### PR TITLE
WonderLab review rollout audit

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -193,6 +193,9 @@ jobs:
       - name: WonderLab review batch planning contract
         run: npx tsx utils/scripts/verifyWonderLabReviewBatchPlan.ts
 
+      - name: WonderLab review rollout audit contract
+        run: npx tsx utils/scripts/verifyWonderLabReviewRolloutAudit.ts
+
       - name: WonderLab preview coverage no-regression gate
         run: npm run audit:wonderlab-previews -- --strict 2>&1 | tee wonderlab-preview-audit.txt
 

--- a/docs/wonderlab-personality-review-rollout.md
+++ b/docs/wonderlab-personality-review-rollout.md
@@ -1,0 +1,153 @@
+# WonderLab personality review rollout
+
+This runbook covers the first production rollout of first-party Bot/Character commentary for Component WonderLab.
+
+## Non-negotiable guardrails
+
+- Human and community Reactions are never deleted, rewritten, or converted.
+- Bot/Character identity can only be assigned by the controlled publication service.
+- Generation creates `PROPOSED` or `FAILED` ReviewDraft rows only.
+- Approval and publication are separate administrator actions.
+- Build, deploy, startup, page load, filtering, and plan previews never generate or publish.
+- A Component/reviewer pair reconciles to one authored Reaction.
+
+## 1. Production deployment and migration
+
+Deploy current `main` through the production Vercel target.
+
+The migration wrapper handles one known historical failure only:
+
+`20260719031500_reaction_first_party_author_expand`
+
+If that exact migration is unfinished, the wrapper verifies and completes its expand-only columns, indexes, and foreign keys, refuses unsafe data, uses Prisma's supported `migrate resolve --applied`, and then runs ordinary `prisma migrate deploy`.
+
+Expected applied migrations:
+
+- `20260719031500_reaction_first_party_author_expand`
+- `20260719033500_review_draft_storage_expand`
+
+Do not manually edit `_prisma_migrations`.
+
+## 2. Run the rollout audit
+
+Open:
+
+`/admin/wonderlab-review-rollout`
+
+The audit must report **Ready** before generating production drafts. In particular:
+
+- both migrations are applied with no unfinished record;
+- `ReviewDraft` exists;
+- both Reaction author columns exist;
+- duplicate authored Component/reviewer groups are zero;
+- dual-author and orphan author rows are zero;
+- published draft/Reaction mismatches are zero.
+
+The audit is read-only.
+
+## 3. Preview reviewer coverage
+
+Open:
+
+`/admin/wonderlab-review-plan`
+
+Start with a small batch:
+
+- 5–10 Components;
+- 1–2 reviewers per Component;
+- `regenerate` off;
+- run **Preview plan** or **Verify dry run** first.
+
+Review the affinity scores and reasons. A second reviewer is selected with Bot/Character diversity when a competitive voice-ready option exists.
+
+Dry run defaults to true and makes no model calls or writes.
+
+## 4. Generate proposed drafts
+
+On the coverage-plan page, explicitly check **Enable model calls for this batch**, then generate.
+
+Batch limits:
+
+- at most 10 Components;
+- at most 20 reviewer slots;
+- sequential model calls;
+- published slots skipped;
+- per-slot errors retained in the result instead of aborting the batch.
+
+Generated output is validated for:
+
+- structured JSON;
+- 20–160 words;
+- integer rating from 1–5;
+- confidence from 0–1;
+- at least one grounded observation;
+- canonical reviewer voice readiness.
+
+Low-confidence output is saved as `FAILED`, not discarded and not published.
+
+## 5. Curate and approve
+
+Open:
+
+`/admin/wonderlab-reviews`
+
+For each draft:
+
+1. Compare generated copy with the reviewer voice and prompt provenance.
+2. Edit the comment, rating, or reaction type as needed.
+3. Save.
+4. Approve only when the copy is useful, grounded, and clearly belongs to that reviewer.
+
+Editing an already approved draft without an explicit status transition returns it to `PROPOSED`.
+
+Representative acceptance cases should include:
+
+- Dotti on a Bot/builder/prompt Component;
+- Catbot on a broadly accessible museum Component;
+- two reviewers evaluating the same exhibit with visibly distinct voices.
+
+## 6. Publish explicitly
+
+Only an `APPROVED` draft can be published.
+
+Publication:
+
+- uses the authenticated administrator as `Reaction.userId` for accountability;
+- stores the Bot or Character in the separate first-party author identity;
+- locks the draft and Component transactionally;
+- updates an existing authored Reaction for the same Component/reviewer;
+- inserts only when no authored Reaction exists;
+- marks the draft `PUBLISHED` and links its Reaction;
+- supersedes stale unpublished attempts for that Component/reviewer;
+- never selects a human Reaction for overwrite.
+
+After publishing a representative set, rerun `/admin/wonderlab-review-rollout`.
+
+## 7. Public verification
+
+Verify on production:
+
+- `/wonderlab`
+- `/memory`
+- `/screenfx`
+
+In WonderLab, confirm:
+
+- human reviews still display with their user identity;
+- first-party reviews display the Bot/Character name, avatar, role, and first-party label;
+- rating/review counts include the new normal Reactions;
+- no duplicate first-party comments appear after repeated publication;
+- desktop and mobile exhibit layouts remain usable;
+- browser back/forward and URL filters still restore state.
+
+## 8. Rollback and incident handling
+
+If generation quality is poor, stop generating. Existing drafts can remain `PROPOSED`, `FAILED`, or `REJECTED`; none are public.
+
+If a published first-party review is incorrect:
+
+- edit or regenerate a draft;
+- approve it;
+- republish to reconcile the same authored Reaction.
+
+Do not delete human reviews. Do not resolve an unexpected migration failure automatically. The deploy repair is intentionally allowlisted to one known migration and aborts on any unexpected schema or data state.

--- a/pages/admin/wonderlab-review-rollout.vue
+++ b/pages/admin/wonderlab-review-rollout.vue
@@ -1,0 +1,162 @@
+<!-- /pages/admin/wonderlab-review-rollout.vue -->
+<template>
+  <main class="mx-auto min-h-screen max-w-6xl space-y-4 p-4 md:p-6">
+    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p class="text-xs font-black uppercase tracking-widest text-primary">
+            WonderLab Operations
+          </p>
+          <h1 class="mt-2 text-3xl font-black">Personality review rollout audit</h1>
+          <p class="mt-2 max-w-3xl text-sm text-base-content/60">
+            Read-only production checks for migrations, author identity, draft links,
+            and duplicate prevention. This page never generates, approves, or publishes.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <NuxtLink to="/admin/wonderlab-review-plan" class="btn btn-outline btn-sm">
+            Coverage plan
+          </NuxtLink>
+          <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-outline btn-sm">
+            Curator workspace
+          </NuxtLink>
+          <button class="btn btn-primary btn-sm" :disabled="loading" @click="loadAudit">
+            <span v-if="loading" class="loading loading-spinner loading-xs" />
+            Run audit
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </section>
+
+    <section v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
+      <h2 class="text-xl font-black">Administrator access required</h2>
+    </section>
+
+    <template v-else>
+      <p v-if="notice" class="rounded-2xl border border-error/40 bg-error/10 p-4 text-error">
+        {{ notice }}
+      </p>
+
+      <section v-if="audit" class="rounded-3xl border p-5" :class="audit.ready ? 'border-success/40 bg-success/10' : 'border-warning/40 bg-warning/10'">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest">Rollout state</p>
+            <h2 class="mt-1 text-2xl font-black">
+              {{ audit.ready ? 'Ready' : 'Blocked' }}
+            </h2>
+            <p class="mt-1 text-sm text-base-content/60">
+              {{ audit.databaseName || 'No database' }} · checked {{ formatDate(audit.checkedAt) }}
+            </p>
+          </div>
+          <Icon :name="audit.ready ? 'kind-icon:check' : 'kind-icon:warning'" class="size-12" />
+        </div>
+      </section>
+
+      <section v-if="audit" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <div v-for="metric in metricCards" :key="metric.label" class="stat rounded-3xl border border-base-300 bg-base-100">
+          <div class="stat-title text-xs">{{ metric.label }}</div>
+          <div class="stat-value text-2xl">{{ metric.value }}</div>
+        </div>
+      </section>
+
+      <section v-if="audit" class="grid gap-3 md:grid-cols-2">
+        <article v-for="entry in audit.checks" :key="entry.key" class="rounded-3xl border bg-base-100 p-4" :class="entry.ok ? 'border-success/30' : 'border-error/40'">
+          <div class="flex items-start gap-3">
+            <Icon :name="entry.ok ? 'kind-icon:check' : 'kind-icon:warning'" class="mt-0.5 size-5 shrink-0" :class="entry.ok ? 'text-success' : 'text-error'" />
+            <div class="min-w-0">
+              <h3 class="font-black">{{ entry.label }}</h3>
+              <p class="mt-1 text-sm text-base-content/65">{{ entry.detail }}</p>
+              <p class="mt-2 truncate font-mono text-xs text-base-content/45">
+                {{ entry.value }}
+              </p>
+            </div>
+          </div>
+        </article>
+      </section>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { performFetch } from '@/stores/utils'
+
+type Audit = {
+  ready: boolean
+  checkedAt: string
+  databaseName: string | null
+  checks: Array<{
+    key: string
+    label: string
+    ok: boolean
+    value: number | string | boolean | null
+    detail: string
+  }>
+  metrics: {
+    humanComponentReviews: number
+    firstPartyComponentReviews: number
+    proposedDrafts: number
+    approvedDrafts: number
+    rejectedDrafts: number
+    failedDrafts: number
+    publishedDrafts: number
+    supersededDrafts: number
+    duplicateFirstPartyReviews: number
+    unsafeFirstPartyReviews: number
+    publishedDraftMismatches: number
+  }
+}
+
+const userStore = useUserStore()
+const ready = ref(false)
+const loading = ref(false)
+const notice = ref('')
+const audit = ref<Audit | null>(null)
+
+const metricCards = computed(() => {
+  if (!audit.value) return []
+  const metrics = audit.value.metrics
+  return [
+    { label: 'Human reviews', value: metrics.humanComponentReviews },
+    { label: 'First-party reviews', value: metrics.firstPartyComponentReviews },
+    { label: 'Proposed drafts', value: metrics.proposedDrafts },
+    { label: 'Approved drafts', value: metrics.approvedDrafts },
+    { label: 'Published drafts', value: metrics.publishedDrafts },
+    { label: 'Failed drafts', value: metrics.failedDrafts },
+    { label: 'Rejected drafts', value: metrics.rejectedDrafts },
+    { label: 'Superseded drafts', value: metrics.supersededDrafts },
+    { label: 'Duplicate groups', value: metrics.duplicateFirstPartyReviews },
+    { label: 'Link mismatches', value: metrics.publishedDraftMismatches },
+  ]
+})
+
+onMounted(async () => {
+  await userStore.initialize()
+  ready.value = true
+  if (userStore.isAdmin) await loadAudit()
+})
+
+async function loadAudit(): Promise<void> {
+  loading.value = true
+  notice.value = ''
+  try {
+    const response = await performFetch<Audit>('/api/admin/wonderlab/review-rollout')
+    if (!response.success || !response.data) throw new Error(response.message)
+    audit.value = response.data
+  } catch (error) {
+    notice.value = error instanceof Error ? error.message : 'Rollout audit failed.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+</script>

--- a/server/api/admin/wonderlab/review-rollout.get.ts
+++ b/server/api/admin/wonderlab/review-rollout.get.ts
@@ -1,0 +1,23 @@
+// /server/api/admin/wonderlab/review-rollout.get.ts
+import { defineEventHandler, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { auditWonderLabReviewRollout } from '@/server/utils/wonderLabReviewRolloutAudit'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const audit = await auditWonderLabReviewRollout()
+
+    return {
+      success: true,
+      data: audit,
+      message: audit.ready
+        ? 'WonderLab personality review rollout checks passed.'
+        : 'WonderLab personality review rollout still has blocking checks.',
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/utils/wonderLabReviewRolloutAudit.ts
+++ b/server/utils/wonderLabReviewRolloutAudit.ts
@@ -1,0 +1,359 @@
+// /server/utils/wonderLabReviewRolloutAudit.ts
+import prisma from '@/server/utils/prisma'
+
+const REQUIRED_MIGRATIONS = [
+  '20260719031500_reaction_first_party_author_expand',
+  '20260719033500_review_draft_storage_expand',
+] as const
+
+export type WonderLabReviewRolloutCheck = {
+  key: string
+  label: string
+  ok: boolean
+  value: number | string | boolean | null
+  detail: string
+}
+
+export type WonderLabReviewRolloutAudit = {
+  ready: boolean
+  checkedAt: string
+  databaseName: string | null
+  checks: WonderLabReviewRolloutCheck[]
+  metrics: {
+    humanComponentReviews: number
+    firstPartyComponentReviews: number
+    proposedDrafts: number
+    approvedDrafts: number
+    rejectedDrafts: number
+    failedDrafts: number
+    publishedDrafts: number
+    supersededDrafts: number
+    duplicateFirstPartyReviews: number
+    unsafeFirstPartyReviews: number
+    publishedDraftMismatches: number
+  }
+}
+
+type DatabaseRow = { databaseName: string | null }
+type CountRow = { count: bigint | number | null }
+type MigrationRow = {
+  migrationName: string
+  applied: bigint | number | boolean
+  unfinished: bigint | number
+}
+type ColumnRow = { columnName: string }
+type TableRow = { tableName: string }
+type DraftStatusRow = { status: string; count: bigint | number }
+
+function count(value: bigint | number | null | undefined): number {
+  return Number(value || 0)
+}
+
+function check(
+  key: string,
+  label: string,
+  ok: boolean,
+  value: WonderLabReviewRolloutCheck['value'],
+  detail: string,
+): WonderLabReviewRolloutCheck {
+  return { key, label, ok, value, detail }
+}
+
+async function databaseName(): Promise<string | null> {
+  const rows = await prisma.$queryRaw<DatabaseRow[]>`
+    SELECT DATABASE() AS databaseName
+  `
+  return rows[0]?.databaseName ?? null
+}
+
+async function tableNames(database: string): Promise<Set<string>> {
+  const rows = await prisma.$queryRaw<TableRow[]>`
+    SELECT TABLE_NAME AS tableName
+    FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = ${database}
+      AND TABLE_NAME IN ('Reaction', 'ReviewDraft', '_prisma_migrations')
+  `
+  return new Set(rows.map((row) => row.tableName))
+}
+
+async function reactionAuthorColumns(database: string): Promise<Set<string>> {
+  const rows = await prisma.$queryRaw<ColumnRow[]>`
+    SELECT COLUMN_NAME AS columnName
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = ${database}
+      AND TABLE_NAME = 'Reaction'
+      AND COLUMN_NAME IN ('authorBotId', 'authorCharacterId')
+  `
+  return new Set(rows.map((row) => row.columnName))
+}
+
+async function migrationState(): Promise<Map<string, MigrationRow>> {
+  const rows = await prisma.$queryRaw<MigrationRow[]>`
+    SELECT
+      migration_name AS migrationName,
+      MAX(finished_at IS NOT NULL AND rolled_back_at IS NULL) AS applied,
+      SUM(finished_at IS NULL AND rolled_back_at IS NULL) AS unfinished
+    FROM _prisma_migrations
+    WHERE migration_name IN (
+      '20260719031500_reaction_first_party_author_expand',
+      '20260719033500_review_draft_storage_expand'
+    )
+    GROUP BY migration_name
+  `
+  return new Map(rows.map((row) => [row.migrationName, row]))
+}
+
+async function scalarCount(sql: 'human' | 'firstParty' | 'duplicates' | 'unsafe') {
+  let rows: CountRow[]
+  switch (sql) {
+    case 'human':
+      rows = await prisma.$queryRaw<CountRow[]>`
+        SELECT COUNT(*) AS count
+        FROM Reaction
+        WHERE reactionCategory = 'COMPONENT'
+          AND authorBotId IS NULL
+          AND authorCharacterId IS NULL
+      `
+      break
+    case 'firstParty':
+      rows = await prisma.$queryRaw<CountRow[]>`
+        SELECT COUNT(*) AS count
+        FROM Reaction
+        WHERE reactionCategory = 'COMPONENT'
+          AND (
+            (authorBotId IS NOT NULL AND authorCharacterId IS NULL)
+            OR (authorBotId IS NULL AND authorCharacterId IS NOT NULL)
+          )
+      `
+      break
+    case 'duplicates':
+      rows = await prisma.$queryRaw<CountRow[]>`
+        SELECT COUNT(*) AS count
+        FROM (
+          SELECT componentId, authorBotId, authorCharacterId
+          FROM Reaction
+          WHERE reactionCategory = 'COMPONENT'
+            AND componentId IS NOT NULL
+            AND (authorBotId IS NOT NULL OR authorCharacterId IS NOT NULL)
+          GROUP BY componentId, authorBotId, authorCharacterId
+          HAVING COUNT(*) > 1
+        ) duplicateGroups
+      `
+      break
+    case 'unsafe':
+      rows = await prisma.$queryRaw<CountRow[]>`
+        SELECT COUNT(*) AS count
+        FROM Reaction r
+        LEFT JOIN Bot b ON b.id = r.authorBotId
+        LEFT JOIN Character c ON c.id = r.authorCharacterId
+        WHERE
+          (r.authorBotId IS NOT NULL AND r.authorCharacterId IS NOT NULL)
+          OR (r.authorBotId IS NOT NULL AND b.id IS NULL)
+          OR (r.authorCharacterId IS NOT NULL AND c.id IS NULL)
+      `
+      break
+  }
+  return count(rows[0]?.count)
+}
+
+async function draftMetrics(): Promise<{
+  statuses: Map<string, number>
+  mismatches: number
+}> {
+  const [statusRows, mismatchRows] = await Promise.all([
+    prisma.$queryRaw<DraftStatusRow[]>`
+      SELECT status, COUNT(*) AS count
+      FROM ReviewDraft
+      GROUP BY status
+    `,
+    prisma.$queryRaw<CountRow[]>`
+      SELECT COUNT(*) AS count
+      FROM ReviewDraft rd
+      LEFT JOIN Reaction r ON r.id = rd.publishedReactionId
+      WHERE rd.status = 'PUBLISHED'
+        AND (
+          rd.publishedReactionId IS NULL
+          OR r.id IS NULL
+          OR r.reactionCategory != 'COMPONENT'
+          OR r.componentId != rd.componentId
+          OR NOT (r.authorBotId <=> rd.authorBotId)
+          OR NOT (r.authorCharacterId <=> rd.authorCharacterId)
+        )
+    `,
+  ])
+
+  return {
+    statuses: new Map(statusRows.map((row) => [row.status, count(row.count)])),
+    mismatches: count(mismatchRows[0]?.count),
+  }
+}
+
+export async function auditWonderLabReviewRollout(): Promise<WonderLabReviewRolloutAudit> {
+  const database = await databaseName()
+  const checks: WonderLabReviewRolloutCheck[] = []
+  const emptyMetrics: WonderLabReviewRolloutAudit['metrics'] = {
+    humanComponentReviews: 0,
+    firstPartyComponentReviews: 0,
+    proposedDrafts: 0,
+    approvedDrafts: 0,
+    rejectedDrafts: 0,
+    failedDrafts: 0,
+    publishedDrafts: 0,
+    supersededDrafts: 0,
+    duplicateFirstPartyReviews: 0,
+    unsafeFirstPartyReviews: 0,
+    publishedDraftMismatches: 0,
+  }
+
+  if (!database) {
+    checks.push(
+      check(
+        'database',
+        'Active database selected',
+        false,
+        null,
+        'No active database name was returned.',
+      ),
+    )
+    return {
+      ready: false,
+      checkedAt: new Date().toISOString(),
+      databaseName: null,
+      checks,
+      metrics: emptyMetrics,
+    }
+  }
+
+  checks.push(
+    check('database', 'Active database selected', true, database, database),
+  )
+
+  const tables = await tableNames(database)
+  const migrationTableReady = tables.has('_prisma_migrations')
+  const reactionReady = tables.has('Reaction')
+  const reviewDraftReady = tables.has('ReviewDraft')
+  checks.push(
+    check(
+      'reaction-table',
+      'Reaction table available',
+      reactionReady,
+      reactionReady,
+      reactionReady ? 'Reaction is queryable.' : 'Reaction table is missing.',
+    ),
+    check(
+      'review-draft-table',
+      'ReviewDraft table available',
+      reviewDraftReady,
+      reviewDraftReady,
+      reviewDraftReady
+        ? 'Durable editorial drafts are available.'
+        : 'ReviewDraft migration has not completed.',
+    ),
+  )
+
+  let migrations = new Map<string, MigrationRow>()
+  if (migrationTableReady) migrations = await migrationState()
+  for (const migrationName of REQUIRED_MIGRATIONS) {
+    const state = migrations.get(migrationName)
+    const applied = Boolean(state?.applied) && count(state?.unfinished) === 0
+    checks.push(
+      check(
+        `migration:${migrationName}`,
+        migrationName,
+        applied,
+        applied,
+        applied
+          ? 'Applied with no unfinished record.'
+          : 'Missing, failed, or still unfinished.',
+      ),
+    )
+  }
+
+  if (reactionReady) {
+    const columns = await reactionAuthorColumns(database)
+    const authorColumnsReady =
+      columns.has('authorBotId') && columns.has('authorCharacterId')
+    checks.push(
+      check(
+        'reaction-author-columns',
+        'Reaction author identity columns',
+        authorColumnsReady,
+        columns.size,
+        authorColumnsReady
+          ? 'Both first-party author columns are present.'
+          : 'One or both first-party author columns are missing.',
+      ),
+    )
+  }
+
+  if (!reactionReady || !reviewDraftReady) {
+    return {
+      ready: false,
+      checkedAt: new Date().toISOString(),
+      databaseName: database,
+      checks,
+      metrics: emptyMetrics,
+    }
+  }
+
+  const [humanReviews, firstPartyReviews, duplicates, unsafe, drafts] =
+    await Promise.all([
+      scalarCount('human'),
+      scalarCount('firstParty'),
+      scalarCount('duplicates'),
+      scalarCount('unsafe'),
+      draftMetrics(),
+    ])
+
+  const metrics: WonderLabReviewRolloutAudit['metrics'] = {
+    humanComponentReviews: humanReviews,
+    firstPartyComponentReviews: firstPartyReviews,
+    proposedDrafts: drafts.statuses.get('PROPOSED') || 0,
+    approvedDrafts: drafts.statuses.get('APPROVED') || 0,
+    rejectedDrafts: drafts.statuses.get('REJECTED') || 0,
+    failedDrafts: drafts.statuses.get('FAILED') || 0,
+    publishedDrafts: drafts.statuses.get('PUBLISHED') || 0,
+    supersededDrafts: drafts.statuses.get('SUPERSEDED') || 0,
+    duplicateFirstPartyReviews: duplicates,
+    unsafeFirstPartyReviews: unsafe,
+    publishedDraftMismatches: drafts.mismatches,
+  }
+
+  checks.push(
+    check(
+      'duplicate-first-party-reviews',
+      'Duplicate first-party review groups',
+      duplicates === 0,
+      duplicates,
+      duplicates === 0
+        ? 'No Component/reviewer pair has multiple first-party Reactions.'
+        : 'Run reconciliation before publishing more reviews.',
+    ),
+    check(
+      'unsafe-first-party-reviews',
+      'Unsafe first-party author rows',
+      unsafe === 0,
+      unsafe,
+      unsafe === 0
+        ? 'No dual-author or orphan first-party Reaction rows found.'
+        : 'Author identity data needs manual repair.',
+    ),
+    check(
+      'published-draft-links',
+      'Published draft/Reaction links',
+      drafts.mismatches === 0,
+      drafts.mismatches,
+      drafts.mismatches === 0
+        ? 'Every published draft points to the matching authored Component Reaction.'
+        : 'Published draft links are inconsistent.',
+    ),
+  )
+
+  return {
+    ready: checks.every((entry) => entry.ok),
+    checkedAt: new Date().toISOString(),
+    databaseName: database,
+    checks,
+    metrics,
+  }
+}

--- a/utils/scripts/verifyWonderLabReviewRolloutAudit.ts
+++ b/utils/scripts/verifyWonderLabReviewRolloutAudit.ts
@@ -1,0 +1,45 @@
+// /utils/scripts/verifyWonderLabReviewRolloutAudit.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const auditPath = 'server/utils/wonderLabReviewRolloutAudit.ts'
+const endpointPath = 'server/api/admin/wonderlab/review-rollout.get.ts'
+const pagePath = 'pages/admin/wonderlab-review-rollout.vue'
+const runbookPath = 'docs/wonderlab-personality-review-rollout.md'
+
+const audit = await readFile(auditPath, 'utf8')
+const endpoint = await readFile(endpointPath, 'utf8')
+const page = await readFile(pagePath, 'utf8')
+const runbook = await readFile(runbookPath, 'utf8')
+
+assert.match(endpoint, /requireAdminApiUser\(event\)/)
+assert.match(endpoint, /auditWonderLabReviewRollout/)
+
+assert.match(audit, /20260719031500_reaction_first_party_author_expand/)
+assert.match(audit, /20260719033500_review_draft_storage_expand/)
+assert.match(audit, /duplicateFirstPartyReviews/)
+assert.match(audit, /unsafeFirstPartyReviews/)
+assert.match(audit, /publishedDraftMismatches/)
+assert.match(audit, /authorBotId IS NULL[\s\S]*authorCharacterId IS NULL/)
+assert.match(audit, /HAVING COUNT\(\*\) > 1/)
+assert.match(audit, /NOT \(r\.authorBotId <=> rd\.authorBotId\)/)
+assert.doesNotMatch(audit, /\$executeRaw/)
+assert.doesNotMatch(audit, /INSERT\s+INTO/i)
+assert.doesNotMatch(audit, /UPDATE\s+/i)
+assert.doesNotMatch(audit, /DELETE\s+FROM/i)
+
+assert.match(page, /Read-only production checks/)
+assert.match(page, /This page never generates, approves, or publishes/)
+assert.match(page, /\/api\/admin\/wonderlab\/review-rollout/)
+assert.doesNotMatch(page, /method:\s*'POST'/)
+assert.doesNotMatch(page, /method:\s*'PATCH'/)
+assert.doesNotMatch(page, /\/publish/)
+
+assert.match(runbook, /Human and community Reactions are never deleted/)
+assert.match(runbook, /Dry run defaults to true/)
+assert.match(runbook, /Only an `APPROVED` draft can be published/)
+assert.match(runbook, /Do not manually edit `_prisma_migrations`/)
+assert.match(runbook, /Dotti/)
+assert.match(runbook, /Catbot/)
+
+console.log('WonderLab review rollout audit contract passed.')


### PR DESCRIPTION
Adds the read-only WonderLab review rollout dashboard, audit endpoint, contract, and operating guide. Part of #472 and #381.