### PR TITLE
academy-timeline: wire aria-controls + id for the expanded lesson panel

### DIFF
--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -58,6 +58,7 @@
           type="button"
           class="group flex w-full flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
           aria-expanded="false"
+          :aria-controls="`academy-style-detail-${style.slug}`"
           @click="expandedSlug = style.slug"
         >
           <span class="text-xl leading-none">🏛️</span>
@@ -86,12 +87,13 @@
           />
         </button>
 
-        <academy-style-detail
-          v-else
-          :lesson="style"
-          @close="closeLesson(style.slug)"
-          @remix="emit('remix', $event)"
-        />
+        <div v-else :id="`academy-style-detail-${style.slug}`">
+          <academy-style-detail
+            :lesson="style"
+            @close="closeLesson(style.slug)"
+            @remix="emit('remix', $event)"
+          />
+        </div>
       </li>
     </ol>
   </section>


### PR DESCRIPTION
### Task
conductor ai-art-academy/t-010 (recurring "Academy continuous improvement pass") — this cycle: front-end polish lane, per `projects/ai-art-academy/docs/continuous-improvement-checklist.md`'s rotation state (last lane was curriculum depth; next preferred was front-end polish).

### What changed / what I produced
- `components/academy/academy-timeline.vue`: the lesson-toggle button had no `aria-controls`, and the expanded `academy-style-detail` panel had no `id` — so screen readers had no programmatic link between the toggle and the content it reveals. `components/academy/academy-styles-browser.vue` already has this exact pattern (wrapping `div` with `:id="academy-style-detail-${slug}"`, button `aria-controls` pointing at it); the timeline view was the one place it was missing.
- Wrapped the expanded `<academy-style-detail>` in a `div` carrying `:id="academy-style-detail-${style.slug}"` and added `:aria-controls` to the toggle button referencing it.

### How I verified
- `npm run test` (vue-tsc --noEmit via nuxi prepare) — clean.
- `npx eslint components/academy/academy-timeline.vue` — clean.
- Confirmed via `ls public/images/academy/styles/` that no Academy style preview images have landed yet, so the "wire previewImageSrc" lane (`ai-art-academy/t-019`) is still genuinely blocked and this cycle correctly rotated to front-end polish instead of re-discovering that same blocker.
- Did not spin up a full authenticated dev-server browser session for this pass (DB-backed); verification is typecheck + lint + direct comparison against the sibling component's already-shipped, working pattern.

### Stakes
reversible

### Flags for Reviewer
- Small, purely markup-additive change (8 lines) — no logic changes, no new props, no store changes.

### Kaizen suggestion
Consider adding a Cypress a11y assertion (e.g. `cy.get('[aria-controls]').each(...)` checking each referenced id exists) across academy components so this class of toggle/panel wiring gap gets caught mechanically instead of by manual code review.

### Notes for reviewer
This closes this cycle of conductor's recurring `ai-art-academy/t-010` task (rotation state will be updated in conductor's roadmap to record "Front-end polish" as the completed lane).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VV2TfqbV3o5KZxPnbqXypy)_