### PR TITLE
davinci: guard resolve against COMPLETE-run recompute, add play-loop regression test

### DIFF
--- a/.github/workflows/davinci-seed-verify.yml
+++ b/.github/workflows/davinci-seed-verify.yml
@@ -5,6 +5,11 @@ name: Da Vinci Seed Verify
 # repo's Prisma schema to a scratch MariaDB service, and run the 15-check
 # importer verification suite. Catches payload-shape drift between the
 # conductor generator and the kind_robots importer/schema automatically.
+#
+# Also runs the play-loop regression (davinci/t-011) against the same
+# database once the endings are seeded: create-run -> record-choice ->
+# resolve -> re-resolve -> reject-a-late-choice, headless (no dev server /
+# auth needed) via server/utils/davinci.ts directly.
 
 on:
   schedule:
@@ -70,3 +75,6 @@ jobs:
 
       - name: Run seed regression suite
         run: npm run seed:davinci:verify -- /tmp/davinci-endings.jsonl
+
+      - name: Run play-loop regression suite
+        run: npm run seed:davinci:playloop-verify

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "characters:repair": "tsx utils/scripts/repairCharacterSlugs.mjs",
     "seed:davinci": "tsx utils/scripts/seedDaVinciEndings.ts",
     "seed:davinci:verify": "tsx utils/scripts/verifyDaVinciSeed.ts",
+    "seed:davinci:playloop-verify": "tsx utils/scripts/verifyDaVinciPlayLoop.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",
     "generate:achievement-art": "tsx scripts/generate_achievement_art.ts",
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts",

--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -50,6 +50,75 @@ export interface ResolveLifeRunResult {
   lifeAchievementAwarded: boolean
 }
 
+// prisma is $extends()-wrapped (see server/utils/prisma.ts), so its
+// $transaction callback's tx param has extended InternalArgs that don't
+// structurally match the plain Prisma.TransactionClient type. Derive the
+// type from the actual instance instead of the generated default.
+type TransactionClient = Parameters<
+  Parameters<typeof prisma.$transaction>[0]
+>[0]
+
+// Read-only counterpart to resolveLifeRunEnding's write path, used when a run
+// is already COMPLETE: re-derives the ResolveLifeRunResult shape from the
+// stored outcomeKey/statsSnapshot/ending instead of recomputing stats and
+// re-running the award transaction. Never awards — awarding only happens once,
+// on the run's first resolve.
+async function resolveCompletedLifeRun(
+  tx: TransactionClient,
+  run: { id: number; statsSnapshot: string | null },
+  outcomeKey: string,
+  endingId: number,
+  userId: number,
+): Promise<ResolveLifeRunResult> {
+  const ending = await tx.lifeEnding.findUnique({ where: { id: endingId } })
+  if (!ending) {
+    const error = new Error(
+      `LifeEnding ${endingId} referenced by LifeRun ${run.id} no longer exists.`,
+    )
+    ;(error as Error & { statusCode?: number }).statusCode = 500
+    throw error
+  }
+
+  const stats: Record<string, number> = run.statsSnapshot
+    ? JSON.parse(run.statsSnapshot)
+    : {}
+
+  const achievementRecord = ending.achievementId
+    ? await tx.achievementRecord.findFirst({
+        where: { achievementId: ending.achievementId, userId },
+        select: { id: true },
+      })
+    : null
+
+  const lifeAchievement = await tx.lifeAchievement.findFirst({
+    where: { endingId: ending.id, isActive: true },
+    select: { id: true },
+  })
+  const unlock = lifeAchievement
+    ? await tx.lifeAchievementUnlock.findFirst({
+        where: { userId, achievementId: lifeAchievement.id },
+        select: { id: true },
+      })
+    : null
+
+  return {
+    outcomeKey,
+    stats,
+    ending: {
+      id: ending.id,
+      title: ending.title,
+      slug: ending.slug,
+      victoryType: ending.victoryType,
+    },
+    achievementId: ending.achievementId,
+    achievementRecordId: achievementRecord?.id ?? null,
+    achievementAwarded: false,
+    lifeAchievementId: lifeAchievement?.id ?? null,
+    unlockId: unlock?.id ?? null,
+    lifeAchievementAwarded: false,
+  }
+}
+
 // Resolves a LifeRun's stats into its deterministic ending and awards the
 // linked Achievement + LifeAchievement. Idempotent: re-resolving an already
 // completed run re-derives the same ending and awards nothing twice.
@@ -80,6 +149,30 @@ export async function resolveLifeRunEnding(
       )
       ;(error as Error & { statusCode?: number }).statusCode = 403
       throw error
+    }
+
+    // Guard: a COMPLETE run already has its outcomeKey/ending/awards settled.
+    // Read the stored result back instead of recomputing stats and re-running
+    // the award transaction — recompute is redundant once resolved (Stats
+    // never change post-completion) and skipping it avoids a wasted write on
+    // every repeat resolve call (e.g. a client retrying after a dropped
+    // response). achievementAwarded/lifeAchievementAwarded are always false
+    // here since a genuinely new award only happens on first resolve.
+    if (run.status === 'COMPLETE') {
+      if (!run.outcomeKey || run.endingId == null) {
+        const error = new Error(
+          `LifeRun ${lifeRunId} is COMPLETE but missing its outcomeKey/endingId.`,
+        )
+        ;(error as Error & { statusCode?: number }).statusCode = 500
+        throw error
+      }
+      return resolveCompletedLifeRun(
+        tx,
+        run,
+        run.outcomeKey,
+        run.endingId,
+        userId,
+      )
     }
 
     const stats: Record<string, number> = {}

--- a/utils/scripts/verifyDaVinciPlayLoop.ts
+++ b/utils/scripts/verifyDaVinciPlayLoop.ts
@@ -1,0 +1,168 @@
+// utils/scripts/verifyDaVinciPlayLoop.ts
+//
+// Headless regression check for the Da Vinci play loop (davinci/t-011).
+// Drives server/utils/davinci.ts's functions directly — create-run ->
+// record-choice -> resolve -> re-resolve -> reject-a-late-choice — so the
+// whole loop gets coverage without a dev server or auth session. Calls the
+// exact functions the live API handlers (server/api/davinci/runs/**) call,
+// so this catches regressions in the same code path production traffic hits.
+//
+// Requires at least one LifeEnding seeded for the all-pass outcomeKey
+// ("1111111111...", one '1' per DAVINCI_DIMENSIONS entry) — run
+// `npm run seed:davinci:verify` (or `seed:davinci -- --write`) against the
+// same database first.
+//
+// Point it at a scratch database — it WRITES (a throwaway User, LifeRun,
+// LifeChoice, LifeStat, and award rows). Cleans up everything it creates in
+// a `finally` block so a re-run against a persisted database stays
+// idempotent, but this is still not meant for production data.
+//
+// Usage:
+//   npm run seed:davinci:playloop-verify
+//
+// Requires DATABASE_URL.
+
+import 'dotenv/config'
+import prisma from '../../server/utils/prisma'
+import {
+  DAVINCI_DIMENSIONS,
+  createLifeRun,
+  recordLifeChoice,
+  resolveLifeRunEnding,
+  resolveOutcomeKey,
+} from '../../server/utils/davinci'
+
+const TEST_USERNAME = 'davinci-playloop-verify'
+
+let failures = 0
+function check(cond: unknown, label: string): void {
+  if (cond) {
+    console.log(`  ok: ${label}`)
+  } else {
+    failures += 1
+    console.error(`  FAIL: ${label}`)
+  }
+}
+
+async function main() {
+  const user = await prisma.user.upsert({
+    where: { username: TEST_USERNAME },
+    create: { username: TEST_USERNAME },
+    update: {},
+  })
+
+  try {
+    console.log('1. create run')
+    const run = await createLifeRun(user.id, { title: 'Play loop verify run' })
+    check(run.status === 'ACTIVE', `run starts ACTIVE (${run.status})`)
+    check(run.userId === user.id, 'run is owned by the test user')
+
+    console.log('2. record choice (pass every dimension)')
+    const effects = Object.fromEntries(
+      DAVINCI_DIMENSIONS.map((dimension) => [dimension, 1]),
+    )
+    const { choice, stats } = await recordLifeChoice(run.id, user.id, {
+      chapter: 1,
+      prompt: 'Test prompt',
+      choiceText: 'Test choice',
+      effects,
+    })
+    check(choice.lifeRunId === run.id, 'choice recorded against the run')
+    check(
+      stats.length === DAVINCI_DIMENSIONS.length,
+      `all ${DAVINCI_DIMENSIONS.length} dimensions got a LifeStat row (${stats.length})`,
+    )
+
+    console.log('3. resolve')
+    const expectedOutcomeKey = resolveOutcomeKey(
+      Object.fromEntries(stats.map((stat) => [stat.key, stat.value])),
+    )
+    check(
+      expectedOutcomeKey === '1'.repeat(DAVINCI_DIMENSIONS.length),
+      `all-pass choice yields the all-pass outcomeKey (${expectedOutcomeKey})`,
+    )
+    const firstResolve = await resolveLifeRunEnding(
+      run.id,
+      user.id,
+      user.username,
+    )
+    check(
+      firstResolve.outcomeKey === expectedOutcomeKey,
+      `resolve derives the expected outcomeKey (${firstResolve.outcomeKey})`,
+    )
+    check(
+      firstResolve.achievementAwarded,
+      'first resolve awards the Achievement',
+    )
+    check(
+      firstResolve.lifeAchievementAwarded,
+      'first resolve awards the LifeAchievement',
+    )
+
+    console.log('4. re-resolve (COMPLETE guard, davinci/t-011)')
+    const secondResolve = await resolveLifeRunEnding(
+      run.id,
+      user.id,
+      user.username,
+    )
+    check(
+      secondResolve.outcomeKey === firstResolve.outcomeKey,
+      're-resolve returns the same outcomeKey',
+    )
+    check(
+      secondResolve.ending.id === firstResolve.ending.id,
+      're-resolve returns the same ending',
+    )
+    check(
+      secondResolve.achievementAwarded === false,
+      're-resolve does not re-award the Achievement',
+    )
+    check(
+      secondResolve.lifeAchievementAwarded === false,
+      're-resolve does not re-award the LifeAchievement',
+    )
+    check(
+      secondResolve.achievementRecordId === firstResolve.achievementRecordId,
+      're-resolve reports the same AchievementRecord id',
+    )
+    check(
+      secondResolve.unlockId === firstResolve.unlockId,
+      're-resolve reports the same LifeAchievementUnlock id',
+    )
+
+    console.log('5. choices rejected on a COMPLETE run')
+    let rejected = false
+    let statusCode: number | undefined
+    try {
+      await recordLifeChoice(run.id, user.id, {
+        chapter: 2,
+        prompt: 'Too late',
+        choiceText: 'Should be rejected',
+      })
+    } catch (error) {
+      rejected = true
+      statusCode = (error as { statusCode?: number }).statusCode
+    }
+    check(rejected, 'a choice on a COMPLETE run throws')
+    check(
+      statusCode === 409,
+      `rejection carries a 409 status (got ${statusCode})`,
+    )
+
+    if (failures > 0) {
+      console.error(`\n${failures} check(s) FAILED`)
+      process.exitCode = 1
+    } else {
+      console.log('\nALL PLAY LOOP CHECKS PASSED')
+    }
+  } finally {
+    await prisma.lifeRun.deleteMany({ where: { userId: user.id } })
+    await prisma.achievementRecord.deleteMany({ where: { userId: user.id } })
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

- `resolveLifeRunEnding` previously recomputed stats/ending and re-ran the full award transaction on every call, even for a run already `COMPLETE`. It now short-circuits to a read-only path (`resolveCompletedLifeRun`) that returns the stored outcomeKey/ending/award ids without rewriting the run or re-awarding — a repeat resolve call (e.g. a client retrying after a dropped response) no longer does a wasted write.
- Adds `utils/scripts/verifyDaVinciPlayLoop.ts`, a headless tsx driver that exercises create-run → record-choice → resolve → re-resolve → choice-rejected-on-COMPLETE directly against `server/utils/davinci.ts` (no dev server or auth needed), and wires it into `davinci-seed-verify.yml` so the whole play loop gets CI coverage on the nightly/`workflow_dispatch` run.

Conductor `davinci/t-011`.

## Test plan

- [x] `eslint` clean on changed files
- [x] `prettier --check` clean on changed files
- [x] Full-project `vue-tsc --noEmit` — 0 errors
- [ ] CI: `Da Vinci Seed Verify` workflow (new "Run play-loop regression suite" step) — runs against a scratch MariaDB service in CI; not runnable locally in this sandbox (no DB available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvDusFL9Ehgtgish66Z6Wm)_