### PR TITLE
Vercel error investigation: unblock prod deploys + fix relations 500 and dead Composition ref

### DIFF
--- a/scripts/db-connection-retry.mjs
+++ b/scripts/db-connection-retry.mjs
@@ -1,0 +1,79 @@
+// /scripts/db-connection-retry.mjs
+//
+// Small, DB-agnostic retry helper for the production migration bootstrap.
+//
+// The known-failed-migration repair (scripts/repair-known-prisma-migrations.mjs)
+// runs a short sequence of idempotent, existence-guarded statements against
+// ProxySQL during `npm run vercel-build`. ProxySQL can drop a backend/frontend
+// connection mid-sequence (observed as MariaDB SQLState 08S01 / errno 45009,
+// "socket has unexpectedly been closed"), which fails the whole production
+// deploy even though nothing is logically wrong. Because every repair step is
+// idempotent, reconnecting and re-running the repair is safe, so we retry the
+// repair on connection-level (not query-logic) errors.
+
+/**
+ * Classifies whether an error is a transient *connection* failure that is safe
+ * to retry with a fresh connection. Deliberately narrow: only socket/connection
+ * level failures qualify. Logical errors (parse errors, constraint violations,
+ * permission errors, etc.) are never retried — retrying those just wastes a
+ * deploy and hides a real bug.
+ */
+export function isRetryableConnectionError(error) {
+  if (!error) return false
+
+  const code = typeof error.code === 'string' ? error.code : ''
+  if (
+    code === 'ER_SOCKET_UNEXPECTED_CLOSE' ||
+    code === 'ER_CONNECTION_ALREADY_CLOSED' ||
+    code === 'ER_GET_CONNECTION_TIMEOUT' ||
+    code === 'ECONNRESET' ||
+    code === 'ECONNREFUSED' ||
+    code === 'EPIPE' ||
+    code === 'ETIMEDOUT'
+  ) {
+    return true
+  }
+
+  // SQLState class "08" is the SQL standard "connection exception" class
+  // (e.g. 08S01 "socket has unexpectedly been closed", 08004, 08006).
+  const sqlState = typeof error.sqlState === 'string' ? error.sqlState : ''
+  if (sqlState.startsWith('08')) return true
+
+  return false
+}
+
+const defaultDelay = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+/**
+ * Runs `run` with bounded retries and exponential backoff, retrying only when
+ * `isRetryable` says the failure was a transient connection error. `run`
+ * receives the 1-based attempt number and is responsible for acquiring (and
+ * releasing) any per-attempt connection, so each retry gets a fresh connection.
+ */
+export async function withConnectionRetry(
+  run,
+  {
+    attempts = 4,
+    baseDelayMs = 1_000,
+    isRetryable = isRetryableConnectionError,
+    onRetry = () => {},
+    delay = defaultDelay,
+  } = {},
+) {
+  let lastError
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await run(attempt)
+    } catch (error) {
+      lastError = error
+      if (attempt >= attempts || !isRetryable(error)) throw error
+      const backoff = baseDelayMs * 2 ** (attempt - 1)
+      onRetry({ attempt, attempts, error, backoff })
+      await delay(backoff)
+    }
+  }
+  throw lastError
+}

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { spawn } from 'node:child_process'
 import mariadb from 'mariadb'
 import { repairKnownFailedMigrations } from './repair-known-prisma-migrations.mjs'
+import { withConnectionRetry } from './db-connection-retry.mjs'
 
 const databaseUrl = process.env.DATABASE_URL
 const caFilePath = '/tmp/kindrobots-proxysql-ca.pem'
@@ -106,26 +107,44 @@ async function main() {
 
   await writeFile(caFilePath, `${sslCa}\n`, { mode: 0o600 })
 
-  let connection
   try {
     const parsedUrl = new URL(databaseUrl)
-    connection = await createTlsConnection(parsedUrl, sslCa)
-
     parsedUrl.searchParams.set('sslcert', caFilePath)
     parsedUrl.searchParams.set('sslaccept', 'strict')
     const prismaUrl = parsedUrl.toString()
 
-    await repairKnownFailedMigrations({
-      connection,
-      prismaUrl,
-      runPrismaCommand,
-    })
+    // The repair runs a short sequence of idempotent, existence-guarded
+    // statements against ProxySQL, which can drop the connection mid-sequence
+    // (SQLState 08S01, "socket has unexpectedly been closed"). Reconnect and
+    // re-run the repair on connection-level failures — safe because every step
+    // is idempotent — instead of failing the whole production deploy.
+    await withConnectionRetry(
+      async () => {
+        let connection
+        try {
+          connection = await createTlsConnection(parsedUrl, sslCa)
+          await repairKnownFailedMigrations({
+            connection,
+            prismaUrl,
+            runPrismaCommand,
+          })
+        } finally {
+          await connection?.end().catch(() => undefined)
+        }
+      },
+      {
+        onRetry: ({ attempt, attempts, error, backoff }) => {
+          console.warn(
+            `[database repair] Attempt ${attempt}/${attempts} hit a transient connection error (${
+              error?.code || error?.sqlState || 'unknown'
+            }); reconnecting in ${backoff}ms.`,
+          )
+        },
+      },
+    )
 
-    await connection.end()
-    connection = undefined
     await runPrismaMigrate(prismaUrl)
   } finally {
-    await connection?.end().catch(() => undefined)
     await unlink(caFilePath).catch(() => undefined)
   }
 }

--- a/utils/scripts/verify-known-migration-repair.mjs
+++ b/utils/scripts/verify-known-migration-repair.mjs
@@ -5,6 +5,10 @@ import {
   knownFailedMigrationNames,
   repairKnownFailedMigrations,
 } from '../../scripts/repair-known-prisma-migrations.mjs'
+import {
+  isRetryableConnectionError,
+  withConnectionRetry,
+} from '../../scripts/db-connection-retry.mjs'
 
 const migrationName = '20260719031500_reaction_first_party_author_expand'
 assert.deepEqual(knownFailedMigrationNames, [migrationName])
@@ -164,5 +168,97 @@ assert.doesNotMatch(repairSource, /DELETE\s+FROM/i)
 assert.doesNotMatch(repairSource, /DROP\s+TABLE/i)
 assert.match(deploySource, /repairKnownFailedMigrations/)
 assert.match(deploySource, /await repairKnownFailedMigrations[\s\S]*await runPrismaMigrate/)
+// The repair must run inside the connection-retry wrapper so a transient
+// ProxySQL socket drop (SQLState 08S01) reconnects instead of failing the deploy.
+assert.match(deploySource, /withConnectionRetry/)
+assert.match(
+  deploySource,
+  /withConnectionRetry[\s\S]*repairKnownFailedMigrations[\s\S]*await runPrismaMigrate/,
+)
+
+// --- Connection-retry classification ---------------------------------------
+// Transient connection-level failures are retryable...
+assert.equal(
+  isRetryableConnectionError({
+    code: 'ER_SOCKET_UNEXPECTED_CLOSE',
+    sqlState: '08S01',
+    errno: 45009,
+    fatal: true,
+  }),
+  true,
+)
+assert.equal(isRetryableConnectionError({ sqlState: '08S01' }), true)
+assert.equal(isRetryableConnectionError({ code: 'ECONNRESET' }), true)
+// ...but logical/query errors are not (retrying would hide a real bug).
+assert.equal(
+  isRetryableConnectionError({ code: 'ER_PARSE_ERROR', sqlState: '42000' }),
+  false,
+)
+assert.equal(
+  isRetryableConnectionError({ code: 'ER_DUP_ENTRY', sqlState: '23000' }),
+  false,
+)
+assert.equal(isRetryableConnectionError(null), false)
+
+// --- withConnectionRetry behavior ------------------------------------------
+const noDelay = async () => {}
+
+// Retries a transient socket close, then succeeds on a fresh attempt.
+let transientCalls = 0
+const retryAttempts = []
+const retryResult = await withConnectionRetry(
+  async () => {
+    transientCalls += 1
+    if (transientCalls < 3) {
+      const error = new Error('socket has unexpectedly been closed')
+      error.code = 'ER_SOCKET_UNEXPECTED_CLOSE'
+      error.sqlState = '08S01'
+      error.fatal = true
+      throw error
+    }
+    return 'repaired'
+  },
+  {
+    baseDelayMs: 0,
+    delay: noDelay,
+    onRetry: ({ attempt }) => retryAttempts.push(attempt),
+  },
+)
+assert.equal(retryResult, 'repaired')
+assert.equal(transientCalls, 3)
+assert.deepEqual(retryAttempts, [1, 2])
+
+// Does NOT retry a non-connection (logical) error.
+let parseCalls = 0
+await assert.rejects(
+  withConnectionRetry(
+    async () => {
+      parseCalls += 1
+      const error = new Error('You have an error in your SQL syntax')
+      error.code = 'ER_PARSE_ERROR'
+      error.sqlState = '42000'
+      throw error
+    },
+    { delay: noDelay },
+  ),
+  /SQL syntax/,
+)
+assert.equal(parseCalls, 1)
+
+// Gives up after the attempt budget on a persistent transient error.
+let persistentCalls = 0
+await assert.rejects(
+  withConnectionRetry(
+    async () => {
+      persistentCalls += 1
+      const error = new Error('socket has unexpectedly been closed')
+      error.code = 'ER_SOCKET_UNEXPECTED_CLOSE'
+      throw error
+    },
+    { attempts: 3, baseDelayMs: 0, delay: noDelay },
+  ),
+  /socket has unexpectedly been closed/,
+)
+assert.equal(persistentCalls, 3)
 
 console.log('Known failed Prisma migration repair contract passed.')


### PR DESCRIPTION
Findings and fixes from investigating ~2 days of Vercel errors.

## 1. Production deploys blocked (the main event)

Every push to `main` was failing at the DB-migration step of `npm run vercel-build`. Site stayed up on an older deployment, but **nothing new shipped to production**. Root cause: migration `20260719031500_reaction_first_party_author_expand` is stuck in a failed state in the prod DB, and the auto-repair that reconciles it kept failing — with a *different* error each deploy as each blocker was removed:

1. MariaDB **1901** — `CHECK` constraint referencing FK-cascade columns (fixed: CHECK dropped from migration)
2. **P3009** — failed migration blocks all new ones (fixed: repair script added, #512)
3. MariaDB **1064** — unquoted `Character` reserved word in the repair query (fixed: #517 backticks)
4. MariaDB **08S01 / errno 45009** — `ER_SOCKET_UNEXPECTED_CLOSE`, ~6s into the repair ← **this PR**

#517 worked — the build now gets past the query that used to fail to parse, but ProxySQL drops the connection mid-repair before it can mark the migration applied. It's a transient connection-level drop, not a logic error.

**Fix:**
- `scripts/db-connection-retry.mjs` (new): `withConnectionRetry(run, opts)` + `isRetryableConnectionError(error)`. Retries are narrow — only connection-level failures (SQLState class `08`, `ER_SOCKET_UNEXPECTED_CLOSE`, `ECONNRESET`, `EPIPE`, `ETIMEDOUT`). Logical errors fail fast so a real bug is never masked.
- `scripts/prisma-migrate-deploy.mjs`: wraps connect + `repairKnownFailedMigrations` in that retry (fresh connection per attempt; safe because every repair step is idempotent/existence-guarded).
- `utils/scripts/verify-known-migration-repair.mjs` (runs in `contract-tests.yml`): covers the classifier, retry-then-succeed, fail-fast, budget-exhaustion, and asserts the repair runs inside the retry wrapper.

Effect: the next deploy retries through a transient ProxySQL drop, the migration self-heals, and prod deploys unblock.

## 2. `/api/relations` (POST) — unhandled 500 on BLOCK of a missing user

The `BLOCK` branch ran `prisma.userRelation.upsert()` **before** any check that `relatedUserId` exists (unlike the FRIEND/family paths, which already 404). Blocking a non-existent user tripped the `relatedUserId` foreign key → unhandled 500 (Prisma **P2003**), which showed up in the runtime logs.

**Fix:** add the same existence check to the BLOCK branch → returns 404. Extends `cypress/e2e/api/friendships.cy.ts` to assert both FRIEND and BLOCK against a missing user return 404.

## 3. Dead `Composition` reference in the `characters:repair` script

`Composition` was removed (migration `20260717113000_remove_code_and_composition`), but `mergeCharacter()` in `utils/scripts/repairCharacterSlugs.mjs` still called `tx.composition.updateMany()`. `tx.composition` is now `undefined`, so `npm run characters:repair` would throw. Dropped the dead reassignment. Confirmed nothing else in live code (schema, API routes) references Composition — the remaining hits are historical migrations, seeds, and abandonware.

> The other top runtime-error groups (401 `Invalid or expired token`, 404 `not found` on delete/fetch) are benign client/auth noise and are intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016S977EButP57vFwiqQiHQK