### PR TITLE
Fix /api/relations BLOCK 500 on missing user; drop dead Composition ref

### DIFF
--- a/cypress/e2e/api/friendships.cy.ts
+++ b/cypress/e2e/api/friendships.cy.ts
@@ -249,6 +249,29 @@ describe('Friendship / UserRelation API Tests', () => {
       },
       [400, 422],
     )
+
+    // A non-existent target must 404, not trip the relatedUserId foreign key
+    // as an unhandled 500. BLOCK is the regression case: it upserts before any
+    // existence check, so it previously surfaced Prisma P2003 as a 500.
+    const missingUserId = 2_000_000_000
+    expectedFailureRequest(
+      {
+        method: 'POST',
+        url: urlFor(),
+        headers: userHeaders(),
+        body: { relatedUserId: missingUserId, type: 'FRIEND' },
+      },
+      [404],
+    )
+    expectedFailureRequest(
+      {
+        method: 'POST',
+        url: urlFor(),
+        headers: userHeaders(),
+        body: { relatedUserId: missingUserId, type: 'BLOCK' },
+      },
+      [404],
+    )
   })
 
   it('runs the complete friend request, accept, and removal lifecycle', () => {

--- a/server/api/relations/index.post.ts
+++ b/server/api/relations/index.post.ts
@@ -42,6 +42,17 @@ export default defineEventHandler(async (event) => {
 
   // BLOCK: immediate, no request, no inverse.
   if (type === 'BLOCK') {
+    // Confirm the target exists first; otherwise the upsert trips the
+    // relatedUserId foreign key and surfaces as an unhandled 500 (P2003).
+    const target = await prisma.user.findUnique({
+      where: { id: relatedUserId },
+      select: { id: true },
+    })
+    if (!target) {
+      setResponseStatus(event, 404)
+      return { success: false, message: 'User not found.' }
+    }
+
     const data = await prisma.userRelation.upsert({
       where: {
         userId_relatedUserId_type: { userId, relatedUserId, type },

--- a/utils/scripts/repairCharacterSlugs.mjs
+++ b/utils/scripts/repairCharacterSlugs.mjs
@@ -237,10 +237,6 @@ async function mergeCharacter(tx, plan) {
       where: { characterId: plan.duplicateId },
       data: { characterId: plan.canonicalId },
     }),
-    tx.composition.updateMany({
-      where: { characterId: plan.duplicateId },
-      data: { characterId: plan.canonicalId },
-    }),
     tx.lifeRun.updateMany({
       where: { characterId: plan.duplicateId },
       data: { characterId: plan.canonicalId },


### PR DESCRIPTION
Follow-up to #518 (which merged the migration-repair hardening). These two fixes were pushed after #518 merged, so they land here as a fresh PR.

## 1. `/api/relations` (POST) — unhandled 500 on BLOCK of a missing user

The `BLOCK` branch ran `prisma.userRelation.upsert()` **before** any check that `relatedUserId` exists (unlike the FRIEND/family paths, which already 404). Blocking a non-existent user tripped the `relatedUserId` foreign key → unhandled 500 (Prisma **P2003**), which appeared in the Vercel runtime logs.

**Fix:** add the same existence check to the BLOCK branch → returns 404. Extends `cypress/e2e/api/friendships.cy.ts` to assert both FRIEND and BLOCK against a missing user return 404.

## 2. Dead `Composition` reference in the `characters:repair` script

`Composition` was removed (migration `20260717113000_remove_code_and_composition`), but `mergeCharacter()` in `utils/scripts/repairCharacterSlugs.mjs` still called `tx.composition.updateMany()`. `tx.composition` is now `undefined`, so `npm run characters:repair` would throw. Dropped the dead reassignment. Confirmed nothing else in live code (schema, API routes) references Composition.

> Note: merge this **after** the stuck `20260719031500_reaction_first_party_author_expand` migration is resolved — until then every production deploy still fails at the repair step, so this PR's deploy would fail too (for the migration reason, not these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016S977EButP57vFwiqQiHQK

---
_Generated by [Claude Code](https://claude.ai/code/session_016S977EButP57vFwiqQiHQK)_