### PR TITLE
academy-styles-browser: fix focus loss when search filters the expanded style's grid button

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -25,6 +25,7 @@
           class="h-3.5 w-3.5 shrink-0 text-base-content/40"
         />
         <input
+          ref="searchInputRef"
           v-model="searchQuery"
           type="search"
           class="min-w-0 flex-1 bg-transparent"
@@ -124,6 +125,7 @@ const academyStore = useAcademyStore()
 
 const searchQuery = ref('')
 const expandedSlug = ref<string | null>(null)
+const searchInputRef = ref<HTMLInputElement | null>(null)
 
 // The grid button stays mounted while its detail panel is open, but the
 // panel's own close button unmounts (v-if) the instant it's clicked — the
@@ -146,7 +148,12 @@ function closeStyle() {
   const slug = expandedSlug.value
   expandedSlug.value = null
   nextTick(() => {
-    if (slug) gridRefs.get(slug)?.focus()
+    // The grid button can be gone even though its slug is known — an active
+    // search filter unmounts (and deletes the ref for) any style that no
+    // longer matches while its detail panel stays open. Fall back to the
+    // search input so focus never drops to <body>.
+    const target = (slug && gridRefs.get(slug)) || searchInputRef.value
+    target?.focus()
   })
 }
 


### PR DESCRIPTION
## Summary

- `closeStyle()` in `components/academy/academy-styles-browser.vue` restores keyboard focus to the grid button that opened the style detail panel — but that button unmounts (deleting its `gridRefs` entry) when an active search query no longer matches its style while the panel is still open. Closing the panel at that point silently dropped focus to `<body>`, exactly the regression this code was originally written to prevent.
- Added a `searchInputRef` (always mounted) as a fallback focus target when the original grid button is gone.

conductor: `ai-art-academy/t-010` continuous-improvement cycle, front-end polish lane (per `docs/continuous-improvement-checklist.md` rotation state).

## Test plan

- [x] `npx eslint components/academy/academy-styles-browser.vue` — clean
- [x] `npx prettier --check components/academy/academy-styles-browser.vue` — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X93dJMSSdD9nTGpVFCm1f4)_