### PR TITLE
migrate: apply SSL to whichever URL Prisma uses, so MIGRATION_DATABASE_URL can't strip TLS

### DIFF
--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -7,11 +7,16 @@ import mariadb from 'mariadb'
 import { repairKnownFailedMigrations } from './repair-known-prisma-migrations.mjs'
 import { withConnectionRetry } from './db-connection-retry.mjs'
 
-const databaseUrl = process.env.DATABASE_URL
+// Resolve the same URL Prisma Migrate will use. prisma.config.ts reads
+// `MIGRATION_DATABASE_URL ?? DATABASE_URL`, so we must resolve it identically —
+// otherwise a MIGRATION_DATABASE_URL set without SSL params bypasses the TLS
+// setup below, and ProxySQL (which requires TLS) rejects with P1000.
+const databaseUrl =
+  process.env.MIGRATION_DATABASE_URL ?? process.env.DATABASE_URL
 const caFilePath = '/tmp/kindrobots-proxysql-ca.pem'
 
 if (!databaseUrl) {
-  throw new Error('DATABASE_URL is missing')
+  throw new Error('MIGRATION_DATABASE_URL / DATABASE_URL is missing')
 }
 
 function readDatabaseSslCa() {
@@ -36,7 +41,11 @@ function runPrismaCommand(url, args) {
       stdio: 'inherit',
       env: {
         ...process.env,
+        // Force BOTH vars to the SSL-augmented URL so prisma.config.ts
+        // (`MIGRATION_DATABASE_URL ?? DATABASE_URL`) cannot route around the
+        // TLS params ProxySQL requires.
         DATABASE_URL: url,
+        MIGRATION_DATABASE_URL: url,
       },
     })
 

--- a/utils/scripts/verify-known-migration-repair.mjs
+++ b/utils/scripts/verify-known-migration-repair.mjs
@@ -176,6 +176,16 @@ assert.match(
   /withConnectionRetry[\s\S]*repairKnownFailedMigrations[\s\S]*await runPrismaMigrate/,
 )
 
+// Migrations must resolve the same URL Prisma uses (MIGRATION_DATABASE_URL ??
+// DATABASE_URL) and force SSL onto it — otherwise a MIGRATION_DATABASE_URL set
+// without TLS params bypasses ProxySQL's SSL requirement and fails with P1000.
+assert.match(
+  deploySource,
+  /process\.env\.MIGRATION_DATABASE_URL\s*\?\?\s*process\.env\.DATABASE_URL/,
+)
+// ...and both vars are forced to the SSL-augmented URL in the child prisma env.
+assert.match(deploySource, /MIGRATION_DATABASE_URL:\s*url/)
+
 // --- Connection-retry classification ---------------------------------------
 // Transient connection-level failures are retryable...
 assert.equal(


### PR DESCRIPTION
## Why

Follow-up hardening for the foot-gun that broke every production deploy tonight after `MIGRATION_DATABASE_URL` was set.

`prisma.config.ts` resolves the migration datasource as `MIGRATION_DATABASE_URL ?? DATABASE_URL`. But `scripts/prisma-migrate-deploy.mjs` only ever augmented **`DATABASE_URL`** with the ProxySQL TLS params (`sslcert` + `sslaccept=strict`, from `DATABASE_SSL_CA_BASE64`) and passed that via the `DATABASE_URL` env override. So the moment `MIGRATION_DATABASE_URL` was set — even to the *same* ProxySQL host — `prisma migrate deploy` used a URL with **no SSL**, and ProxySQL (which requires TLS) rejected it with:

```
P1000: Authentication failed … credentials for `(not available)`
```

…failing the build at the migration step, while the raw-driver repair (which builds its own `ssl: {}` object) connected fine — a confusing split.

## What

- Resolve the base URL the **same way** `prisma.config.ts` does: `MIGRATION_DATABASE_URL ?? DATABASE_URL`, and apply the SSL params to it.
- Force **both** `DATABASE_URL` and `MIGRATION_DATABASE_URL` in the child `prisma` env to the SSL-augmented URL, so neither can route around the required TLS.
- Extend the contract harness (`utils/scripts/verify-known-migration-repair.mjs`, run in `contract-tests.yml`) to assert the coalesced resolution and the dual env override.

## Effect

Setting `MIGRATION_DATABASE_URL` (e.g. to point migrations at a different endpoint) no longer silently drops TLS and breaks deploys against ProxySQL. Behavior is unchanged when it's unset (the current production state).

> Context: production is already healthy — the immediate incident was resolved by clearing the stuck migration and deleting the errant `MIGRATION_DATABASE_URL`. This just makes that class of misconfiguration non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016S977EButP57vFwiqQiHQK

---
_Generated by [Claude Code](https://claude.ai/code/session_016S977EButP57vFwiqQiHQK)_