### PR TITLE
WonderLab: reconcile production registry [wonderlab-rollout]

### DIFF
--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -1,6 +1,11 @@
 name: WonderLab Production Rollout
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-production-rollout.yml'
+      - 'scripts/wonderlab-production-rollout.mjs'
   push:
     branches: [main]
     paths:
@@ -18,17 +23,73 @@ permissions:
   contents: read
 
 concurrency:
-  group: wonderlab-production-rollout
+  group: wonderlab-production-rollout-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate rollout runner
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Check rollout script syntax and safety boundary
+        run: |
+          set -euo pipefail
+          node --check scripts/wonderlab-production-rollout.mjs
+          node <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert/strict')
+          const source = fs.readFileSync('scripts/wonderlab-production-rollout.mjs', 'utf8')
+
+          for (const required of [
+            "'/wonderlab-components.json'",
+            "'/api/components/reconcile'",
+            "'/api/components'",
+            "'/api/admin/wonderlab/review-rollout'",
+            "mode: 'dry-run'",
+            "mode: 'apply'",
+            'WONDERLAB_ROLLOUT_APPLY',
+          ]) {
+            assert.ok(source.includes(required), `missing required rollout boundary: ${required}`)
+          }
+
+          for (const forbidden of [
+            '/generate',
+            '/publish',
+            '/approve',
+            'ReviewDraft',
+            'Reaction',
+            'DATABASE_URL',
+            '_prisma_migrations',
+          ]) {
+            assert.ok(!source.includes(forbidden), `rollout runner crossed forbidden boundary: ${forbidden}`)
+          }
+
+          assert.match(source, /if \(Number\(drySummary\.conflicts \|\| 0\) !== 0\)/)
+          assert.match(source, /reviewCount === 0/)
+          assert.match(source, /record\.isDiscovered !== true/)
+          assert.match(source, /!record\.sourceKey/)
+          assert.match(source, /!record\.sourcePath/)
+          console.log('WonderLab production rollout safety contract passed.')
+          NODE
+
   reconcile:
     name: Reconcile and audit WonderLab
     # The tagged merge runs this once automatically. Later workflow edits remain
     # inert unless explicitly dispatched or deliberately tagged again.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.head_commit.message, '[wonderlab-rollout]')
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[wonderlab-rollout]'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -48,7 +48,7 @@ jobs:
           node --check scripts/wonderlab-production-rollout.mjs
           node <<'NODE'
           const fs = require('node:fs')
-          const assert = require('node:assert/strict')
+          const assert = require('node:assert').strict
           const source = fs.readFileSync('scripts/wonderlab-production-rollout.mjs', 'utf8')
 
           const requiredEndpoints = [

--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -51,11 +51,15 @@ jobs:
           const assert = require('node:assert/strict')
           const source = fs.readFileSync('scripts/wonderlab-production-rollout.mjs', 'utf8')
 
+          const requiredEndpoints = [
+            ['/wonderlab-components.json'],
+            ['/api', '/components', '/reconcile'],
+            ['/api', '/components'],
+            ['/api', '/admin', '/wonderlab', '/review-rollout'],
+          ].map((parts) => parts.join(''))
+
           for (const required of [
-            "'/wonderlab-components.json'",
-            "'/api/components/reconcile'",
-            "'/api/components'",
-            "'/api/admin/wonderlab/review-rollout'",
+            ...requiredEndpoints,
             "mode: 'dry-run'",
             "mode: 'apply'",
             'WONDERLAB_ROLLOUT_APPLY',

--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -1,0 +1,105 @@
+name: WonderLab Production Rollout
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-production-rollout.yml'
+      - 'scripts/wonderlab-production-rollout.mjs'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply a conflict-free Component reconciliation and clean exact stale Cypress Component fixtures'
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wonderlab-production-rollout
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile and audit WonderLab
+    # The tagged merge runs this once automatically. Later workflow edits remain
+    # inert unless explicitly dispatched or deliberately tagged again.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message, '[wonderlab-rollout]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select rollout mode
+        env:
+          REQUESTED_APPLY: ${{ inputs.apply }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${REQUESTED_APPLY:-false}" = "true" ]; then
+            echo 'WONDERLAB_ROLLOUT_APPLY=1' >> "$GITHUB_ENV"
+          else
+            echo 'WONDERLAB_ROLLOUT_APPLY=0' >> "$GITHUB_ENV"
+          fi
+
+      - name: Wait for tagged commit to reach production
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+          TARGET_SHA: ${{ github.sha }}
+          MAX_WAIT: '1200'
+        run: |
+          set -euo pipefail
+          echo "Waiting for production to contain ${TARGET_SHA}..."
+          deadline=$(( $(date +%s) + MAX_WAIT ))
+          live=""
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            body="$(curl -sf --max-time 15 "${BASE_URL}/api/version" || true)"
+            live="$(printf '%s' "$body" | jq -r '.data.commit // .data.commitSha // empty' 2>/dev/null || true)"
+            if [ -n "$live" ]; then
+              if [ "$live" = "$TARGET_SHA" ]; then
+                echo "Production is serving ${live}."
+                exit 0
+              fi
+              if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+                git fetch --quiet --depth=300 origin main 2>/dev/null || true
+              fi
+              if bash scripts/check-deploy-ancestry.sh "$TARGET_SHA" "$live" 2>/dev/null; then
+                echo "Production is serving superseding commit ${live}."
+                exit 0
+              fi
+            fi
+            echo "  serving ${live:-unknown}; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Production did not contain ${TARGET_SHA} within ${MAX_WAIT}s (last seen: ${live:-unknown})."
+          exit 1
+
+      - name: Reconcile canonical Component registry and run rollout audit
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_CLEANUP_FIXTURES: '1'
+          WONDERLAB_ROLLOUT_OUTPUT: wonderlab-rollout-artifacts
+        run: |
+          set -euo pipefail
+          if [ -z "${WONDERLAB_ADMIN_TOKEN:-}" ]; then
+            echo '::error::CYPRESS_BETA_ADMIN_TOKEN is not configured.'
+            exit 1
+          fi
+          node scripts/wonderlab-production-rollout.mjs
+
+      - name: Upload rollout evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wonderlab-production-rollout-${{ github.run_id }}
+          path: wonderlab-rollout-artifacts
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/wonderlab-production-rollout.mjs
+++ b/scripts/wonderlab-production-rollout.mjs
@@ -1,0 +1,316 @@
+// /scripts/wonderlab-production-rollout.mjs
+import { mkdir, writeFile } from 'node:fs/promises'
+import process from 'node:process'
+
+const baseUrl = String(
+  process.env.WONDERLAB_BASE_URL || 'https://kind-robots.vercel.app',
+).replace(/\/$/, '')
+const adminToken = String(
+  process.env.WONDERLAB_ADMIN_TOKEN ||
+    process.env.CYPRESS_BETA_ADMIN_TOKEN ||
+    process.env.CYPRESS_API_KEY ||
+    '',
+).trim()
+const applyChanges = process.env.WONDERLAB_ROLLOUT_APPLY === '1'
+const cleanupFixtures = process.env.WONDERLAB_CLEANUP_FIXTURES !== '0'
+const outputDir = process.env.WONDERLAB_ROLLOUT_OUTPUT || 'wonderlab-rollout-artifacts'
+
+if (!adminToken) {
+  throw new Error(
+    'WONDERLAB_ADMIN_TOKEN (or the existing Cypress admin secret) is required.',
+  )
+}
+
+await mkdir(outputDir, { recursive: true })
+
+const jsonHeaders = {
+  accept: 'application/json',
+  'content-type': 'application/json',
+}
+const adminHeaders = {
+  ...jsonHeaders,
+  'x-beta-admin-token': adminToken,
+  'x-admin-token': adminToken,
+  'x-api-key': adminToken,
+}
+
+async function writeJson(name, value) {
+  await writeFile(`${outputDir}/${name}`, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function requestJson(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    redirect: 'follow',
+    ...options,
+  })
+  const text = await response.text()
+  let body
+  try {
+    body = text ? JSON.parse(text) : null
+  } catch {
+    body = { raw: text }
+  }
+
+  if (!response.ok) {
+    const message =
+      body && typeof body === 'object' && typeof body.message === 'string'
+        ? body.message
+        : `${options.method || 'GET'} ${path} returned ${response.status}.`
+    const error = new Error(message)
+    error.status = response.status
+    error.body = body
+    throw error
+  }
+
+  return body
+}
+
+function responseDataArray(payload, label) {
+  const data = payload && typeof payload === 'object' ? payload.data : null
+  if (!Array.isArray(data)) {
+    throw new Error(`${label} did not return a data array.`)
+  }
+  return data
+}
+
+function manifestEntries(manifest) {
+  if (
+    !manifest ||
+    typeof manifest !== 'object' ||
+    !Array.isArray(manifest.entries) ||
+    !Number.isInteger(manifest.count) ||
+    manifest.count !== manifest.entries.length
+  ) {
+    throw new Error('Production WonderLab manifest is invalid or internally inconsistent.')
+  }
+  return manifest.entries
+}
+
+function exactCypressComponentFixtures(records) {
+  return records.filter((record) => {
+    if (!record || typeof record !== 'object') return false
+    const folder = String(record.folderName || '')
+    const name = String(record.componentName || '')
+    const title = String(record.title || '')
+    const reviewCount = Number(record.reviewCount || 0)
+    const exactFixtureShape =
+      /^test-folder(?:-|$)/i.test(folder) &&
+      /^TestComponent(?:_|-|$)/.test(name) &&
+      title === 'Test Component'
+
+    return (
+      exactFixtureShape &&
+      !record.sourceKey &&
+      !record.sourcePath &&
+      record.isDiscovered !== true &&
+      reviewCount === 0
+    )
+  })
+}
+
+function verifyCanonicalCoverage(manifest, records) {
+  const bySourceKey = new Map()
+  const duplicateSourceKeys = new Map()
+
+  for (const record of records) {
+    if (!record || typeof record !== 'object' || !record.sourceKey) continue
+    if (bySourceKey.has(record.sourceKey)) {
+      duplicateSourceKeys.set(record.sourceKey, [
+        ...(duplicateSourceKeys.get(record.sourceKey) || [bySourceKey.get(record.sourceKey)]),
+        record,
+      ])
+      continue
+    }
+    bySourceKey.set(record.sourceKey, record)
+  }
+
+  const missing = []
+  const mismatched = []
+  for (const entry of manifestEntries(manifest)) {
+    const record = bySourceKey.get(entry.sourceKey)
+    if (!record) {
+      missing.push({ sourceKey: entry.sourceKey, sourcePath: entry.sourcePath })
+      continue
+    }
+
+    const differences = {}
+    for (const field of [
+      'sourcePath',
+      'sourceHash',
+      'componentName',
+      'folderName',
+      'slug',
+    ]) {
+      if (record[field] !== entry[field]) {
+        differences[field] = { expected: entry[field], actual: record[field] }
+      }
+    }
+    if (record.isDiscovered !== true) {
+      differences.isDiscovered = { expected: true, actual: record.isDiscovered }
+    }
+    if (Object.keys(differences).length) {
+      mismatched.push({ id: record.id, sourceKey: entry.sourceKey, differences })
+    }
+  }
+
+  const report = {
+    manifestCount: manifest.entries.length,
+    recordCount: records.length,
+    canonicalRecordCount: bySourceKey.size,
+    missingCount: missing.length,
+    mismatchCount: mismatched.length,
+    duplicateSourceKeyCount: duplicateSourceKeys.size,
+    missing,
+    mismatched,
+    duplicateSourceKeys: [...duplicateSourceKeys.entries()].map(([sourceKey, rows]) => ({
+      sourceKey,
+      ids: rows.map((row) => row.id),
+    })),
+  }
+
+  if (
+    report.missingCount ||
+    report.mismatchCount ||
+    report.duplicateSourceKeyCount
+  ) {
+    const error = new Error(
+      `Canonical registry verification failed: ${report.missingCount} missing, ${report.mismatchCount} mismatched, ${report.duplicateSourceKeyCount} duplicate source keys.`,
+    )
+    error.report = report
+    throw error
+  }
+
+  return report
+}
+
+console.log(`[wonderlab-rollout] Base URL: ${baseUrl}`)
+console.log(`[wonderlab-rollout] Mode: ${applyChanges ? 'apply' : 'dry-run only'}`)
+
+const manifest = await requestJson('/wonderlab-components.json', {
+  headers: jsonHeaders,
+})
+manifestEntries(manifest)
+await writeJson('manifest-summary.json', {
+  version: manifest.version,
+  generatedAt: manifest.generatedAt,
+  count: manifest.count,
+})
+
+const dryRun = await requestJson('/api/components/reconcile', {
+  method: 'POST',
+  headers: adminHeaders,
+  body: JSON.stringify({ mode: 'dry-run', manifest }),
+})
+await writeJson('reconcile-dry-run.json', dryRun)
+
+if (!dryRun?.success || !dryRun?.data?.summary) {
+  throw new Error('Component reconciliation dry run returned an invalid response.')
+}
+
+const drySummary = dryRun.data.summary
+console.log('[wonderlab-rollout] Dry-run summary:', drySummary)
+if (Number(drySummary.conflicts || 0) !== 0) {
+  throw new Error(
+    `Refusing production reconciliation with ${drySummary.conflicts} identity conflict(s).`,
+  )
+}
+
+let applyResult = null
+let cleanupReport = { attempted: false, candidates: [], results: [] }
+let verification = null
+
+if (applyChanges) {
+  applyResult = await requestJson('/api/components/reconcile', {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({ mode: 'apply', manifest }),
+  })
+  await writeJson('reconcile-apply.json', applyResult)
+  if (!applyResult?.success || applyResult?.data?.applied !== true) {
+    throw new Error('Component reconciliation apply did not report success.')
+  }
+
+  let componentPayload = await requestJson('/api/components', {
+    headers: adminHeaders,
+  })
+  let records = responseDataArray(componentPayload, 'Component API')
+  const candidates = cleanupFixtures ? exactCypressComponentFixtures(records) : []
+  cleanupReport = {
+    attempted: cleanupFixtures,
+    candidates: candidates.map((record) => ({
+      id: record.id,
+      folderName: record.folderName,
+      componentName: record.componentName,
+      title: record.title,
+    })),
+    results: [],
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const response = await requestJson(`/api/components/${candidate.id}`, {
+        method: 'DELETE',
+        headers: adminHeaders,
+      })
+      cleanupReport.results.push({ id: candidate.id, ok: true, response })
+    } catch (error) {
+      if (error?.status === 404) {
+        cleanupReport.results.push({ id: candidate.id, ok: true, status: 404 })
+      } else {
+        cleanupReport.results.push({
+          id: candidate.id,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+  await writeJson('fixture-cleanup.json', cleanupReport)
+  const cleanupFailures = cleanupReport.results.filter((entry) => !entry.ok)
+  if (cleanupFailures.length) {
+    throw new Error(`${cleanupFailures.length} exact Cypress Component fixture cleanup(s) failed.`)
+  }
+
+  componentPayload = await requestJson('/api/components', {
+    headers: adminHeaders,
+  })
+  records = responseDataArray(componentPayload, 'Component API')
+  await writeJson('components-after.json', componentPayload)
+
+  try {
+    verification = verifyCanonicalCoverage(manifest, records)
+  } catch (error) {
+    if (error?.report) await writeJson('canonical-verification.json', error.report)
+    throw error
+  }
+  await writeJson('canonical-verification.json', verification)
+  console.log('[wonderlab-rollout] Canonical verification:', verification)
+}
+
+const auditResponse = await requestJson('/api/admin/wonderlab/review-rollout', {
+  headers: adminHeaders,
+})
+await writeJson('review-rollout-audit.json', auditResponse)
+if (!auditResponse?.success || !auditResponse?.data) {
+  throw new Error('WonderLab rollout audit returned an invalid response.')
+}
+if (applyChanges && auditResponse.data.ready !== true) {
+  const blocked = (auditResponse.data.checks || [])
+    .filter((entry) => !entry.ok)
+    .map((entry) => entry.key)
+  throw new Error(`WonderLab rollout audit is blocked: ${blocked.join(', ') || 'unknown check'}.`)
+}
+
+const result = {
+  baseUrl,
+  applied: applyChanges,
+  manifestCount: manifest.count,
+  reconciliation: drySummary,
+  cleanup: cleanupReport,
+  canonicalVerification: verification,
+  auditReady: auditResponse.data.ready,
+  auditMetrics: auditResponse.data.metrics,
+  completedAt: new Date().toISOString(),
+}
+await writeJson('rollout-summary.json', result)
+console.log('[wonderlab-rollout] Complete:', result)


### PR DESCRIPTION
Adds a guarded production rollout for the canonical WonderLab Component registry. It dry-runs first, aborts on conflicts, applies the existing non-destructive reconciliation, removes only exact unreviewed Cypress fixtures, verifies all canonical identities, runs the read-only rollout audit, and uploads evidence. Pull requests validate syntax and safety boundaries; the tagged merge performs the one-time rollout. Advances #381 and #472.