### PR TITLE
fix: repair 10 red Cypress API tests behind two stale-test root causes

### DIFF
--- a/cypress/e2e/api/art.cy.ts
+++ b/cypress/e2e/api/art.cy.ts
@@ -64,7 +64,6 @@ describe('ArtImage Management API Tests', () => {
           steps: 10,
           path: ' ',
           seed: -1,
-          userId,
           imagePath: 'justfortesting',
         },
         failOnStatusCode: false,

--- a/cypress/e2e/api/dreams.cy.ts
+++ b/cypress/e2e/api/dreams.cy.ts
@@ -438,7 +438,6 @@ describe('Dream API tests', () => {
         title: 'Cypress first arrival',
         content:
           'Add a silver fox made of moonlight and make the greenhouse warmer.',
-        userId: user?.id,
         dreamId: publicDreamId,
         channel: `dream-${publicDreamId}`,
         isPublic: true,

--- a/cypress/e2e/api/project-workspace.cy.ts
+++ b/cypress/e2e/api/project-workspace.cy.ts
@@ -8,7 +8,6 @@ describe('First-class Project workspace API', () => {
   const stamp = Date.now()
   const slug = `cypress-project-workspace-${stamp}`
   let token = ''
-  let userId = 0
   let projectId = 0
   let todoId = 0
   let chatId = 0
@@ -16,7 +15,6 @@ describe('First-class Project workspace API', () => {
   before(() => {
     createLoggedInTestUser().then((auth) => {
       token = auth.token
-      userId = auth.id
     })
   })
 
@@ -126,7 +124,6 @@ describe('First-class Project workspace API', () => {
         botResponse: 'Persisted Project response.',
         channel: `project-${projectId}-assistant`,
         isPublic: false,
-        userId,
         projectId,
         dreamId: null,
       },

--- a/cypress/e2e/api/prompts.cy.ts
+++ b/cypress/e2e/api/prompts.cy.ts
@@ -61,12 +61,12 @@ describe('Prompt Management API Tests', () => {
         apiBase = env.apiBase
         adminToken = env.adminToken
         baseUrl = `${apiBase}/prompts`
-        return createLoggedInTestUser({ fresh: true })
+        return createLoggedInTestUser()
       })
       .then((owner) => {
         ownerToken = owner.token
         ownerId = owner.id
-        return createLoggedInTestUser({ fresh: true })
+        return createLoggedInTestUser({ role: 'second' })
       })
       .then((other) => {
         otherToken = other.token

--- a/cypress/e2e/api/reactions.cy.ts
+++ b/cypress/e2e/api/reactions.cy.ts
@@ -55,12 +55,12 @@ describe('Reaction Management API Tests', () => {
         adminToken = env.adminToken
         reactionBaseUrl = `${apiBase}/reactions`
         themeBaseUrl = `${apiBase}/themes`
-        return createLoggedInTestUser({ fresh: true })
+        return createLoggedInTestUser()
       })
       .then((owner) => {
         ownerToken = owner.token
         ownerId = owner.id
-        return createLoggedInTestUser({ fresh: true })
+        return createLoggedInTestUser({ role: 'second' })
       })
       .then((other) => {
         otherToken = other.token

--- a/cypress/e2e/stylist-access.cy.ts
+++ b/cypress/e2e/stylist-access.cy.ts
@@ -21,7 +21,10 @@ describe('/stylist access', () => {
     cy.visit('/stylist')
 
     cy.location('pathname', { timeout: 15000 }).should('eq', '/login')
-    cy.location('search').should('include', 'redirect=%2Fstylist')
+    // Vue Router's query serializer does not percent-encode `/` in query
+    // values (it's unreserved in the query component per RFC 3986), so the
+    // redirect param may render as either `/stylist` or `%2Fstylist`.
+    cy.location('search').should('match', /redirect=(%2F|\/)stylist/)
     cy.contains('Hair Studio').should('not.exist')
   })
 })


### PR DESCRIPTION
## Summary

Fixes kind_robots Todo #446 (ci-janitor) — red "Kind Robots Cypress Tests" workflow (e.g. [run 29679887584](https://github.com/silasfelinus/kind_robots/actions/runs/29679887584), and confirmed recurring in the several subsequent runs during today's active session, e.g. [run 29685359788](https://github.com/silasfelinus/kind_robots/actions/runs/29685359788): 6 of 44 specs / 10 of 383 tests failing).

All 10 failures trace to two systemic **test-staleness** issues, not product bugs:

**1. Deprecated `{ fresh: true }` collapsing two identities into one seed user** — `prompts.cy.ts` and `reactions.cy.ts` called `createLoggedInTestUser({ fresh: true })` twice to build "owner" and "another user" for ownership-boundary tests. That option is a documented no-op today (`getSeedTestUser()` always returns the same run-scoped seed identity), so both "owner" and "other" resolved to the *same* user. `prevents another user from updating/deleting the X` assertions therefore saw `200` instead of `403` — and in `reactions.cy.ts` that cascaded into a `404` on the final delete test, since the "other" user had already deleted the row. Fixed by using the plain call for the owner and `{ role: 'second' }` for a genuinely distinct identity — the same pattern already used correctly in `art-collection-image-ownership.cy.ts`, `log-ownership.cy.ts`, and `friendships.cy.ts`.

**2. `/api/chats` and `/api/art/image` now reject client-supplied `userId`** — both routes were hardened to treat ownership as server-owned ("Ownership, IDs, and timestamps are server-owned"), but `dreams.cy.ts`, `project-workspace.cy.ts`, and `art.cy.ts` still sent `userId` in their POST bodies. The resulting `400`s cascaded: no chat/art-image got created, so follow-on assertions (chat lookup, `Project._count.Chats`, and `art.cy.ts`'s entire fixture `before()` hook) failed or were skipped. Fixed by dropping the stale `userId` field from each request body.

**3. Unrelated:** `stylist-access.cy.ts`'s redirect-encoding assertion assumed `/` is always percent-encoded in a query value. Vue Router's serializer leaves `/` unencoded in the query component (valid per RFC 3986), so it renders as `?redirect=/stylist`. Relaxed the assertion to accept either form.

## Changes

- `cypress/e2e/api/prompts.cy.ts` — second test-user call uses `{ role: 'second' }`
- `cypress/e2e/api/reactions.cy.ts` — second test-user call uses `{ role: 'second' }`
- `cypress/e2e/api/dreams.cy.ts` — drop `userId` from chat-creation body
- `cypress/e2e/api/project-workspace.cy.ts` — drop `userId` from chat-creation body (and the now-unused `userId` local)
- `cypress/e2e/api/art.cy.ts` — drop `userId` from art-image-creation body
- `cypress/e2e/stylist-access.cy.ts` — accept encoded or unencoded `/` in the redirect query value

## Test plan

- [x] Diagnosed each failure from the actual CI job logs (not guessed) — confirmed the exact `AssertionError`/`CypressError` for every one of the 10 failing tests across the 6 specs
- [x] Verified `/api/prompts/[id].patch.ts` and `/api/art/image/index.post.ts` already correctly enforce ownership/field allowlists server-side — the bug is entirely in the test fixtures, not the API
- [x] Confirmed the `{ role: 'second' }` fix pattern against currently-passing specs that already use it correctly
- [x] `eslint`/`prettier` on changed files show only pre-existing issues, unchanged before/after this diff
- [ ] CI run on this PR (Cypress Tests workflow) — will confirm green once it runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHVmaR6QTTDL55xubhuGFr)_