### PR TITLE
Fix WonderLab production reconciliation timeout

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -106,6 +106,9 @@ jobs:
       - name: WonderLab reconciliation contract
         run: npm run test:wonderlab-reconcile
 
+      - name: WonderLab reconciliation transaction timeout contract
+        run: npx tsx utils/scripts/verifyWonderLabReconcileTransaction.ts
+
       - name: WonderLab test-fixture cleanup contract
         run: npm run test:wonderlab-fixture-cleanup
 

--- a/server/api/components/reconcile.post.ts
+++ b/server/api/components/reconcile.post.ts
@@ -10,12 +10,17 @@ import {
 } from '../../utils/wonderlabComponentReconcile'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 
- type ReconcileMode = 'dry-run' | 'apply'
+type ReconcileMode = 'dry-run' | 'apply'
 
 type ReconcileRequestBody = {
   mode?: ReconcileMode
   manifest?: unknown
 }
+
+const RECONCILE_TRANSACTION_OPTIONS = {
+  maxWait: 10_000,
+  timeout: 30_000,
+} as const
 
 function parseMode(value: unknown): ReconcileMode {
   if (value === undefined || value === 'dry-run') return 'dry-run'
@@ -79,6 +84,9 @@ export default defineEventHandler(async (event) => {
     let applied = false
 
     if (mode === 'apply') {
+      // A full production manifest can require hundreds of sequential writes.
+      // Keep them atomic, but explicitly allow more than Prisma's 5-second
+      // interactive-transaction default while retaining a bounded timeout.
       await prisma.$transaction(async (tx) => {
         for (const action of plan.updates) {
           if (!action.existingId) continue
@@ -113,7 +121,7 @@ export default defineEventHandler(async (event) => {
             },
           })
         }
-      })
+      }, RECONCILE_TRANSACTION_OPTIONS)
 
       applied = true
     }

--- a/utils/scripts/verifyWonderLabReconcileTransaction.ts
+++ b/utils/scripts/verifyWonderLabReconcileTransaction.ts
@@ -1,0 +1,30 @@
+// /utils/scripts/verifyWonderLabReconcileTransaction.ts
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const endpointPath = resolve(
+  scriptDirectory,
+  '../../server/api/components/reconcile.post.ts',
+)
+const source = readFileSync(endpointPath, 'utf8')
+
+assert.match(
+  source,
+  /const RECONCILE_TRANSACTION_OPTIONS = \{\s*maxWait: 10_000,\s*timeout: 30_000,\s*\} as const/s,
+  'The production reconciliation must explicitly exceed Prisma interactive transactions\' 5-second default.',
+)
+assert.match(
+  source,
+  /prisma\.\$transaction\(async \(tx\) => \{[\s\S]*?\}, RECONCILE_TRANSACTION_OPTIONS\)/,
+  'The bounded transaction options must be applied to the atomic reconciliation write transaction.',
+)
+assert.doesNotMatch(
+  source,
+  /timeout:\s*5_000/,
+  'The reconciliation must not regress to the timeout that failed the 348-entry production manifest.',
+)
+
+console.log('WonderLab reconciliation transaction timeout contract passed.')


### PR DESCRIPTION
## Production finding

The guarded rollout reached `/api/components/reconcile` on July 19, 2026, but the apply request failed with Prisma `P2028`: the 348-entry manifest required about 6.8 seconds of sequential atomic writes, exceeding Prisma's default 5-second interactive transaction timeout. The transaction aborted before fixture cleanup and the rollout audit.

## Fix

- keeps the full reconciliation atomic;
- adds an explicit 10-second transaction acquisition wait and bounded 30-second execution timeout;
- adds a DB-free contract that prevents regression to the failed 5-second boundary and verifies the options are applied to the write transaction;
- wires the contract into the existing fast contract suite.

After merge and deployment, the existing tagged rollout can be safely retried. Advances #381 and #472.