### PR TITLE
Harden Challenge mutation ownership

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -218,8 +218,9 @@ jobs:
       - name: Capture-group guard contract (new/changed lines vs main)
         run: npm run test:capture-group-guards -- origin/main
 
-      - name: Challenge Center seed validation (dry run, no database)
+      - name: Challenge Center contracts and seed validation (dry run, no database)
         run: |
+          npm run test:challenge-center
           npm run test:seed-challenges
           npm run test:seed-contenders
 

--- a/cypress/e2e/api/challenges.cy.ts
+++ b/cypress/e2e/api/challenges.cy.ts
@@ -1,0 +1,193 @@
+import {
+  adminHeaders,
+  bearerHeaders,
+  createLoggedInTestUser,
+  getApiEnv,
+  type TestUserAuth,
+} from '../../support/api-auth'
+
+type ApiResponse<T = unknown> = {
+  success?: boolean
+  message?: string
+  data?: T
+  statusCode?: number
+}
+
+type Challenge = {
+  id: number
+  createdAt: string
+  updatedAt: string | null
+  slug: string
+  title: string
+  challengeType: string
+  difficulty: number
+  promptText: string
+  judgeNotes: string | null
+  status: string
+  isMature: boolean
+  userId: number | null
+  User?: unknown
+  Submissions?: unknown
+}
+
+describe('Challenge mutation ownership', () => {
+  let apiBase = ''
+  let adminToken = ''
+  let ordinaryUser: TestUserAuth
+  let challenge: Challenge
+  const stamp = `${Date.now()}-${Cypress._.random(1000, 9999)}`
+  const slug = `cypress-challenge-${stamp}`
+
+  const challengeBody = {
+    slug,
+    title: `Cypress Challenge ${stamp}`,
+    challengeType: 'TEXT',
+    difficulty: 3,
+    promptText: 'Write a tiny robot fable with an honest ending.',
+    judgeNotes: 'Prefer clarity over ornamental fog.',
+    status: 'OPEN',
+    isMature: false,
+  }
+
+  before(() => {
+    getApiEnv().then((env) => {
+      apiBase = env.apiBase
+      adminToken = env.adminToken
+    })
+
+    createLoggedInTestUser({ role: 'second' }).then((auth) => {
+      ordinaryUser = auth
+    })
+  })
+
+  it('denies anonymous creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${apiBase}/challenges`,
+      body: challengeBody,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.statusCode).to.eq(401)
+    })
+  })
+
+  it('denies non-admin creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${apiBase}/challenges`,
+      headers: bearerHeaders(ordinaryUser.token),
+      body: challengeBody,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.statusCode).to.eq(403)
+    })
+  })
+
+  it('rejects caller-supplied identity and server-owned fields', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${apiBase}/challenges`,
+      headers: adminHeaders(adminToken),
+      body: {
+        ...challengeBody,
+        userId: ordinaryUser.id,
+        createdAt: new Date().toISOString(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message || '').to.match(/unsupported challenge fields/i)
+      expect(response.body.message || '').to.match(/userId/i)
+      expect(response.body.message || '').to.match(/createdAt/i)
+    })
+  })
+
+  it('lets an admin create a lean Challenge owned by authentication', () => {
+    cy.request<ApiResponse<Challenge>>({
+      method: 'POST',
+      url: `${apiBase}/challenges`,
+      headers: adminHeaders(adminToken),
+      body: challengeBody,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.statusCode).to.eq(201)
+      expect(response.body.data?.slug).to.eq(slug)
+      expect(response.body.data?.userId).to.be.a('number').and.be.greaterThan(0)
+      expect(response.body.data?.userId).not.to.eq(ordinaryUser.id)
+      expect(response.body.data).not.to.have.property('User')
+      expect(response.body.data).not.to.have.property('Submissions')
+      challenge = response.body.data as Challenge
+
+      cy.task(
+        'cypressCleanup:register',
+        {
+          label: `Challenge ${challenge.id}`,
+          method: 'DELETE',
+          url: `${apiBase}/challenges/${challenge.slug}`,
+          headers: adminHeaders(adminToken),
+          expectedStatuses: [200, 404],
+        },
+        { log: false },
+      )
+    })
+  })
+
+  it('returns 409 for a duplicate slug', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${apiBase}/challenges`,
+      headers: adminHeaders(adminToken),
+      body: challengeBody,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(409)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.statusCode).to.eq(409)
+    })
+  })
+
+  it('denies anonymous deletion', () => {
+    cy.request<ApiResponse>({
+      method: 'DELETE',
+      url: `${apiBase}/challenges/${challenge.slug}`,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('denies non-admin deletion', () => {
+    cy.request<ApiResponse>({
+      method: 'DELETE',
+      url: `${apiBase}/challenges/${challenge.slug}`,
+      headers: bearerHeaders(ordinaryUser.token),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+    })
+  })
+
+  it('lets an admin delete the Challenge without manual relationship cleanup', () => {
+    cy.request<ApiResponse<Challenge>>({
+      method: 'DELETE',
+      url: `${apiBase}/challenges/${challenge.slug}`,
+      headers: adminHeaders(adminToken),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.id).to.eq(challenge.id)
+      expect(response.body.data).not.to.have.property('User')
+      expect(response.body.data).not.to.have.property('Submissions')
+    })
+  })
+})

--- a/docs/architecture/thin-resource-api-audit.md
+++ b/docs/architecture/thin-resource-api-audit.md
@@ -34,6 +34,7 @@ Examples of explicit commands include publish, import, reconcile, generate, comm
 | Logs | Any authenticated user could list, read, or delete another user’s logs; POST accepted forged identity/timestamps; errors often returned HTTP 200 | Reads and deletes are owner/admin scoped, lists default to self, POST derives identity/time from auth, and every route returns explicit HTTP status envelopes |
 | ArtImage create and lookup | Create accepted caller ownership plus Server/Checkpoint and many unrelated relationship IDs; the by-IDs helper posted lookup bodies to the create route | Create derives ownership from auth and accepts scalar metadata only; relationship writes stay explicit; bounded visibility-aware `/by-ids` lookup now owns batch retrieval |
 | ArtCollection membership | Create/PATCH accepted any existing ArtImage ID, so collection owners could attach another user’s private images; store and fixtures still sent body identity | Collection ownership comes from auth, add/replace requires owned active images, relation commands are bounded and unambiguous, empty replace clears membership, and callers no longer send user IDs |
+| Challenge mutations | Admin create accepted request-body `userId`, used handwritten enum lists, returned an unbounded model row, and had no cleanup-safe delete route | Create derives owner from admin authentication, rejects server-owned and unknown fields, validates generated Prisma enums, returns a scalar projection, maps duplicate slugs to `409`, and admin delete relies on the database to protect Challenges with submissions |
 
 ### P1 — Completed response and resource-boundary cleanup
 
@@ -99,7 +100,7 @@ For Dreams, collection creation remains an explicit `collectionStore` action. Ch
 2. ✅ Dream store/form cleanup and removal of obsolete collection/chat flags.
 3. ✅ Character, Scenario, Reward, and Prompt resource projections, including explicit Scenario single/batch create routes and a whitelisted Prompt PATCH contract.
 4. ✅ Bot, Project, Server, Theme, Resource, SmartIcon, Reaction, and PitchSheet response/create-boundary cleanup; retired the unused SocialPost/SocialTarget prototype instead of preserving dead CRUD.
-5. ✅ Dream delete referential actions and route simplification; continue the same audit for other resources only where manual cleanup remains.
+5. ✅ Dream delete referential actions, ArtCollection ownership, and Challenge admin mutation boundaries; continue the same audit for other resources only where evidence remains.
 6. Re-run deployed API Cypress tests and compare Vercel mutation duration/error volume when production catches up to the merged API tier.
 
 ## Definition of Done

--- a/server/api/challenges/[slug].delete.ts
+++ b/server/api/challenges/[slug].delete.ts
@@ -1,0 +1,69 @@
+// /server/api/challenges/[slug].delete.ts
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import { Prisma } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { userIsAdmin } from '~/server/utils/authUser'
+import { challengeMutationSelect } from '~/server/utils/challengeResource'
+import { validateApiKey } from '~/server/utils/validateKey'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await validateApiKey(event)
+
+    if (!auth.isValid || !auth.user) {
+      throw createError({ statusCode: 401, message: 'Authentication required.' })
+    }
+
+    if (!userIsAdmin(auth.user)) {
+      throw createError({ statusCode: 403, message: 'Admin access required.' })
+    }
+
+    const slug = getRouterParam(event, 'slug')?.trim()
+
+    if (!slug) {
+      throw createError({ statusCode: 400, message: 'Challenge slug is required.' })
+    }
+
+    const existing = await prisma.challenge.findUnique({
+      where: { slug },
+      select: { id: true },
+    })
+
+    if (!existing) {
+      throw createError({ statusCode: 404, message: 'Challenge not found.' })
+    }
+
+    const challenge = await prisma.challenge.delete({
+      where: { id: existing.id },
+      select: challengeMutationSelect,
+    })
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Challenge deleted successfully.',
+      data: challenge,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2003'
+    ) {
+      event.node.res.statusCode = 409
+      return {
+        success: false,
+        message: 'Challenges with submissions cannot be deleted.',
+        statusCode: 409,
+      }
+    }
+
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+
+    return { ...handled, statusCode }
+  }
+})

--- a/server/api/challenges/index.post.ts
+++ b/server/api/challenges/index.post.ts
@@ -1,20 +1,30 @@
 // /server/api/challenges/index.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
+import {
+  ChallengeStatus,
+  ChallengeType,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { userIsAdmin } from '~/server/utils/authUser'
+import { challengeMutationSelect } from '~/server/utils/challengeResource'
 import { validateApiKey } from '~/server/utils/validateKey'
 
-const challengeTypes = new Set([
-  'ART',
-  'TEXT',
-  'CHARACTER',
-  'SCENARIO',
-  'REASONING',
+const challengeTypes = Object.values(ChallengeType)
+const challengeStatuses = Object.values(ChallengeStatus)
+const challengeCreateFields = new Set([
+  'slug',
+  'title',
+  'challengeType',
+  'difficulty',
+  'promptText',
+  'judgeNotes',
+  'status',
+  'isMature',
 ])
-const challengeStatuses = new Set(['OPEN', 'JUDGING', 'CLOSED'])
 
-type ChallengeCreateBody = {
+type ChallengeCreateBody = Record<string, unknown> & {
   slug?: unknown
   title?: unknown
   challengeType?: unknown
@@ -23,7 +33,19 @@ type ChallengeCreateBody = {
   judgeNotes?: unknown
   status?: unknown
   isMature?: unknown
-  userId?: unknown
+}
+
+function assertSupportedFields(body: ChallengeCreateBody) {
+  const unsupported = Object.keys(body).filter(
+    (field) => !challengeCreateFields.has(field),
+  )
+
+  if (unsupported.length > 0) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Challenge fields: ${unsupported.join(', ')}. Ownership, IDs, and timestamps are server-owned.`,
+    })
+  }
 }
 
 function requiredString(value: unknown, field: string, maxLength: number): string {
@@ -46,28 +68,55 @@ function requiredString(value: unknown, field: string, maxLength: number): strin
   return normalized
 }
 
-function enumValue(
+function optionalString(
   value: unknown,
-  allowed: Set<string>,
   field: string,
-  fallback?: string,
-): string {
-  if (value === undefined || value === null || value === '') {
-    if (fallback) return fallback
-    throw createError({ statusCode: 400, message: `${field} is required.` })
+  maxLength: number,
+): string | null {
+  if (value === undefined || value === null || value === '') return null
+
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: `${field} must be a string.` })
   }
 
-  const normalized = String(value).trim().toUpperCase()
+  const normalized = value.trim()
+  if (!normalized) return null
 
-  if (!allowed.has(normalized)) {
-    throw createError({ statusCode: 400, message: `Invalid ${field}.` })
+  if (normalized.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be ${maxLength} characters or fewer.`,
+    })
   }
 
   return normalized
 }
 
-function optionalPositiveInteger(value: unknown, fallback: number): number {
-  if (value === undefined || value === null || value === '') return fallback
+function enumValue<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  field: string,
+  fallback?: T,
+): T {
+  if (value === undefined || value === null || value === '') {
+    if (fallback !== undefined) return fallback
+    throw createError({ statusCode: 400, message: `${field} is required.` })
+  }
+
+  const normalized = String(value).trim().toUpperCase() as T
+
+  if (!allowed.includes(normalized)) {
+    throw createError({
+      statusCode: 400,
+      message: `${field} must be one of: ${allowed.join(', ')}.`,
+    })
+  }
+
+  return normalized
+}
+
+function difficultyValue(value: unknown): number {
+  if (value === undefined || value === null || value === '') return 1
 
   const number = Number(value)
 
@@ -79,6 +128,32 @@ function optionalPositiveInteger(value: unknown, fallback: number): number {
   }
 
   return number
+}
+
+function booleanValue(value: unknown, field: string): boolean {
+  if (value === undefined || value === null) return false
+
+  if (typeof value !== 'boolean') {
+    throw createError({ statusCode: 400, message: `${field} must be a boolean.` })
+  }
+
+  return value
+}
+
+function slugValue(value: unknown): string {
+  const slug = requiredString(value, 'slug', 255)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  if (!slug) {
+    throw createError({
+      statusCode: 400,
+      message: 'slug must contain at least one letter or number.',
+    })
+  }
+
+  return slug
 }
 
 export default defineEventHandler(async (event) => {
@@ -95,43 +170,34 @@ export default defineEventHandler(async (event) => {
 
     const body = await readBody<ChallengeCreateBody>(event)
 
-    if (!body) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
       throw createError({ statusCode: 400, message: 'Request body is required.' })
     }
 
-    const requestedUserId = Number(body.userId)
-    const userId =
-      Number.isInteger(requestedUserId) && requestedUserId > 0
-        ? requestedUserId
-        : auth.user.id
+    assertSupportedFields(body)
 
     const challenge = await prisma.challenge.create({
       data: {
-        slug: requiredString(body.slug, 'slug', 255)
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-+|-+$/g, ''),
+        slug: slugValue(body.slug),
         title: requiredString(body.title, 'title', 764),
         challengeType: enumValue(
           body.challengeType,
           challengeTypes,
           'challengeType',
-        ) as never,
-        difficulty: optionalPositiveInteger(body.difficulty, 1),
+        ),
+        difficulty: difficultyValue(body.difficulty),
         promptText: requiredString(body.promptText, 'promptText', 50000),
-        judgeNotes:
-          typeof body.judgeNotes === 'string' && body.judgeNotes.trim()
-            ? body.judgeNotes.trim()
-            : null,
+        judgeNotes: optionalString(body.judgeNotes, 'judgeNotes', 50000),
         status: enumValue(
           body.status,
           challengeStatuses,
           'status',
-          'OPEN',
-        ) as never,
-        isMature: body.isMature === true,
-        User: { connect: { id: userId } },
+          ChallengeStatus.OPEN,
+        ),
+        isMature: booleanValue(body.isMature, 'isMature'),
+        userId: auth.user.id,
       },
+      select: challengeMutationSelect,
     })
 
     event.node.res.statusCode = 201
@@ -143,6 +209,18 @@ export default defineEventHandler(async (event) => {
       statusCode: 201,
     }
   } catch (error: unknown) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      event.node.res.statusCode = 409
+      return {
+        success: false,
+        message: 'A Challenge with this slug already exists.',
+        statusCode: 409,
+      }
+    }
+
     const handled = errorHandler(error)
     const statusCode = handled.statusCode ?? 500
     event.node.res.statusCode = statusCode

--- a/server/utils/challengeResource.ts
+++ b/server/utils/challengeResource.ts
@@ -1,0 +1,17 @@
+// /server/utils/challengeResource.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const challengeMutationSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  slug: true,
+  title: true,
+  challengeType: true,
+  difficulty: true,
+  promptText: true,
+  judgeNotes: true,
+  status: true,
+  isMature: true,
+  userId: true,
+} satisfies Prisma.ChallengeSelect

--- a/utils/scripts/verifyChallengeCenter.ts
+++ b/utils/scripts/verifyChallengeCenter.ts
@@ -1,10 +1,34 @@
 // /utils/scripts/verifyChallengeCenter.ts
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   buildChallengeLeaderboard,
   buildFacetLeaderboard,
   scoreChallengeReactions,
 } from '../../server/utils/challengeCenter'
+
+const readSource = (path: string) =>
+  readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+const challengeCreateRoute = readSource('server/api/challenges/index.post.ts')
+const challengeDeleteRoute = readSource(
+  'server/api/challenges/[slug].delete.ts',
+)
+const challengeResource = readSource('server/utils/challengeResource.ts')
+
+assert.match(challengeCreateRoute, /const challengeCreateFields = new Set/)
+assert.match(challengeCreateRoute, /Object\.values\(ChallengeType\)/)
+assert.match(challengeCreateRoute, /Object\.values\(ChallengeStatus\)/)
+assert.match(challengeCreateRoute, /userId:\s*auth\.user\.id/)
+assert.doesNotMatch(challengeCreateRoute, /body\.userId/)
+assert.match(challengeCreateRoute, /select:\s*challengeMutationSelect/)
+assert.match(challengeCreateRoute, /error\.code === 'P2002'/)
+assert.match(challengeDeleteRoute, /userIsAdmin\(auth\.user\)/)
+assert.match(challengeDeleteRoute, /prisma\.challenge\.delete/)
+assert.match(challengeDeleteRoute, /select:\s*challengeMutationSelect/)
+assert.match(challengeDeleteRoute, /error\.code === 'P2003'/)
+assert.match(challengeResource, /satisfies Prisma\.ChallengeSelect/)
+assert.doesNotMatch(challengeResource, /\bUser\b|\bSubmissions\b/)
 
 // scoreChallengeReactions
 assert.deepEqual(
@@ -174,4 +198,4 @@ const byGenerator = buildFacetLeaderboard(
 )
 assert.equal(byGenerator.length, 0)
 
-console.log('Challenge Center leaderboard/facet logic verified.')
+console.log('Challenge Center logic and mutation contracts verified.')


### PR DESCRIPTION
## Summary

- derive Challenge ownership exclusively from authenticated admin identity
- reject request-body identity, timestamps, arrays, and unknown fields
- validate Challenge enums from generated Prisma values
- return a named scalar mutation projection and a `409` for duplicate slugs
- add an admin-only delete route that relies on the database to protect Challenges with submissions
- add deployed Cypress coverage for anonymous, non-admin, spoofed-identity, admin, duplicate, and cleanup behavior
- add the Challenge source contract to the normal Contract Tests gate
- update the thin-resource API audit

## Why

`POST /api/challenges` was admin-only but still accepted `body.userId`, allowing an authenticated admin request to assign persistence ownership from untrusted input. It also used handwritten enum sets and returned the default model selection without a named mutation contract.

This keeps Challenge persistence aligned with the API-overhaul rule: identity comes from authentication, mutations accept deliberate scalar fields, and referential behavior belongs to the database rather than manual cleanup choreography.

## Checks

- TypeScript Type Check — pending CI
- Contract Tests — pending CI
- deployed Cypress Challenge ownership suite — added with registered fixture cleanup
