### PR TITLE
WonderLab: maintain rollout handoff issue [wonderlab-audit]

### DIFF
--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -129,8 +129,11 @@ jobs:
           BASE_URL: https://kind-robots.vercel.app
         run: |
           set -euo pipefail
+          mkdir -p wonderlab-rollout-artifacts
+
           version="$(curl -sf --max-time 20 "${BASE_URL}/api/version")"
           printf '%s' "$version" | jq -e '.success == true and (.data.commit | type == "string")' >/dev/null
+          printf '%s\n' "$version" > wonderlab-rollout-artifacts/production-version.json
 
           manifest="$(curl -sf --max-time 30 "${BASE_URL}/wonderlab-components.json")"
           printf '%s' "$manifest" | jq -e '.count > 0 and (.entries | length) == .count' >/dev/null
@@ -185,6 +188,7 @@ jobs:
               }
             }
 
+            const productionVersion = readJson('production-version.json')
             const summary = readJson('rollout-summary.json')
             const dryRun = readJson('reconcile-dry-run.json')
             const apply = readJson('reconcile-apply.json')
@@ -194,12 +198,16 @@ jobs:
             const drySummary = dryRun?.data?.summary || summary?.reconciliation || null
             const auditData = audit?.data || null
             const mode = process.env.WONDERLAB_ROLLOUT_APPLY === '1' ? 'apply' : 'read-only audit'
+            const liveCommit = productionVersion?.data?.commit || 'unknown'
+            const deploymentId = productionVersion?.data?.deploymentId || 'unknown'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             const lines = [
               `## WonderLab production ${mode} report`,
               '',
               `- **Workflow:** [run ${context.runId}](${runUrl})`,
               `- **Result:** ${process.env.JOB_STATUS}`,
+              `- **Production commit:** \`${liveCommit}\``,
+              `- **Deployment:** \`${deploymentId}\``,
               `- **Production base:** ${summary?.baseUrl || 'https://kind-robots.vercel.app'}`,
             ]
 
@@ -243,3 +251,41 @@ jobs:
                 body,
               })
             }
+
+            const blockedChecks = (auditData?.checks || [])
+              .filter((entry) => !entry.ok)
+              .map((entry) => entry.key)
+            const handoff = [
+              '# WonderLab production rollout evidence and resume handoff',
+              '',
+              '## Latest automated status',
+              '',
+              body,
+              '',
+              '## Resume checklist',
+              '',
+              `1. Verify \`/api/version\` still reports \`${liveCommit}\` or a newer descendant.`,
+              '2. Read #381, #472, and #473 before changing rollout behavior.',
+              process.env.WONDERLAB_ROLLOUT_APPLY === '1'
+                ? '3. If this apply succeeded, proceed to representative Dotti/Catbot draft generation, curator approval, publication, and desktop/mobile acceptance.'
+                : '3. Do not run an apply until production contains PR #527 (`5fa25cdb67f0d3dacad3b6eceb2e4bdd1de2088d`) or a descendant.',
+              '4. Use `[wonderlab-audit]` for a read-only refresh; use `[wonderlab-rollout]` only for the conflict-gated write rollout.',
+              '5. Neither trigger generates, approves, or publishes personality reviews.',
+              '',
+              '## Current machine checks',
+              '',
+              `- Audit ready: ${auditData?.ready === true ? 'yes' : 'no'}`,
+              `- Blocked audit checks: ${blockedChecks.join(', ') || 'none reported'}`,
+              `- Reconciliation conflicts: ${drySummary?.conflicts ?? 'unknown'}`,
+              `- Database-only Component rows: ${drySummary?.missingFromManifest ?? 'unknown'}`,
+              `- Canonical verification available: ${verification ? 'yes' : 'no'}`,
+              '',
+              `Last updated by [Actions run ${context.runId}](${runUrl}).`,
+            ].join('\n')
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 531,
+              body: handoff,
+            })

--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -127,13 +127,14 @@ jobs:
       - name: Verify live production prerequisites
         env:
           BASE_URL: https://kind-robots.vercel.app
+          OUTPUT_DIR: wonderlab-rollout-artifacts
         run: |
           set -euo pipefail
-          mkdir -p wonderlab-rollout-artifacts
+          mkdir -p "$OUTPUT_DIR"
 
           version="$(curl -sf --max-time 20 "${BASE_URL}/api/version")"
           printf '%s' "$version" | jq -e '.success == true and (.data.commit | type == "string")' >/dev/null
-          printf '%s\n' "$version" > wonderlab-rollout-artifacts/production-version.json
+          printf '%s\n' "$version" > "${OUTPUT_DIR}/production-version.json"
 
           manifest="$(curl -sf --max-time 30 "${BASE_URL}/wonderlab-components.json")"
           printf '%s' "$manifest" | jq -e '.count > 0 and (.entries | length) == .count' >/dev/null


### PR DESCRIPTION
Updates the guarded workflow so every audit/apply records the exact live commit and deployment, comments concise evidence on #381/#472, and replaces issue #531 with a single current resume handoff. This tagged merge runs read-only: conflict-checking reconciliation dry run plus personality rollout audit, with no Component writes, fixture cleanup, review generation, approval, or publication.