### PR TITLE
Fix WonderLab reconciliation with atomic batch transaction

### DIFF
--- a/server/api/components/reconcile.post.ts
+++ b/server/api/components/reconcile.post.ts
@@ -17,11 +17,6 @@ type ReconcileRequestBody = {
   manifest?: unknown
 }
 
-const RECONCILE_TRANSACTION_OPTIONS = {
-  maxWait: 10_000,
-  timeout: 30_000,
-} as const
-
 function parseMode(value: unknown): ReconcileMode {
   if (value === undefined || value === 'dry-run') return 'dry-run'
   if (value === 'apply') return 'apply'
@@ -44,6 +39,32 @@ function updateDataForChanges(
     sourceHash: changes.sourceHash,
     isDiscovered: changes.isDiscovered,
     lastSeenAt: changes.lastSeenAt ? new Date(changes.lastSeenAt) : undefined,
+    updatedAt: new Date(),
+  }
+}
+
+function createDataForAction(
+  action: ReturnType<typeof buildComponentReconcilePlan>['creates'][number],
+  generatedAt: string,
+): Prisma.ComponentCreateManyInput {
+  return {
+    componentName: action.componentName,
+    folderName: action.changes.folderName || 'root',
+    slug: action.changes.slug,
+    sourcePath: action.changes.sourcePath,
+    sourceKey: action.changes.sourceKey,
+    sourceHash: action.changes.sourceHash,
+    lastSeenAt: action.changes.lastSeenAt
+      ? new Date(action.changes.lastSeenAt)
+      : new Date(generatedAt),
+    isDiscovered: action.changes.isDiscovered ?? true,
+    status: 'UNREVIEWED',
+    title: action.componentName,
+    notes: null,
+    isWorking: false,
+    underConstruction: false,
+    isBroken: false,
+    createdAt: new Date(),
     updatedAt: new Date(),
   }
 }
@@ -84,45 +105,32 @@ export default defineEventHandler(async (event) => {
     let applied = false
 
     if (mode === 'apply') {
-      // A full production manifest can require hundreds of sequential writes.
-      // Keep them atomic, but explicitly allow more than Prisma's 5-second
-      // interactive-transaction default while retaining a bounded timeout.
-      await prisma.$transaction(async (tx) => {
-        for (const action of plan.updates) {
-          if (!action.existingId) continue
+      // Keep the full reconciliation atomic without an interactive transaction.
+      // Production manifests can require hundreds of writes, and the callback
+      // transaction timeout expired even at 30 seconds. A batch transaction has
+      // no interactive callback deadline, while createMany collapses all new
+      // records into one statement instead of one round trip per Component.
+      const updateOperations = plan.updates.flatMap((action) =>
+        action.existingId
+          ? [
+              prisma.component.update({
+                where: { id: action.existingId },
+                data: updateDataForChanges(action.changes),
+              }),
+            ]
+          : [],
+      )
+      const createOperations = plan.creates.length
+        ? [
+            prisma.component.createMany({
+              data: plan.creates.map((action) =>
+                createDataForAction(action, manifest.generatedAt),
+              ),
+            }),
+          ]
+        : []
 
-          await tx.component.update({
-            where: { id: action.existingId },
-            data: updateDataForChanges(action.changes),
-          })
-        }
-
-        for (const action of plan.creates) {
-          await tx.component.create({
-            data: {
-              componentName: action.componentName,
-              folderName: action.changes.folderName || 'root',
-              slug: action.changes.slug,
-              sourcePath: action.changes.sourcePath,
-              sourceKey: action.changes.sourceKey,
-              sourceHash: action.changes.sourceHash,
-              lastSeenAt: action.changes.lastSeenAt
-                ? new Date(action.changes.lastSeenAt)
-                : new Date(manifest.generatedAt),
-              isDiscovered: action.changes.isDiscovered ?? true,
-              status: 'UNREVIEWED',
-              title: action.componentName,
-              notes: null,
-              isWorking: false,
-              underConstruction: false,
-              isBroken: false,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-          })
-        }
-      }, RECONCILE_TRANSACTION_OPTIONS)
-
+      await prisma.$transaction([...updateOperations, ...createOperations])
       applied = true
     }
 

--- a/utils/scripts/verifyWonderLabReconcileTransaction.ts
+++ b/utils/scripts/verifyWonderLabReconcileTransaction.ts
@@ -11,20 +11,30 @@ const endpointPath = resolve(
 )
 const source = readFileSync(endpointPath, 'utf8')
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /const RECONCILE_TRANSACTION_OPTIONS = \{\s*maxWait: 10_000,\s*timeout: 30_000,\s*\} as const/s,
-  'The production reconciliation must explicitly exceed Prisma interactive transactions\' 5-second default.',
+  /prisma\.\$transaction\(async\s*\(/,
+  'Production reconciliation must not use an interactive callback transaction with an expiry deadline.',
 )
 assert.match(
   source,
-  /prisma\.\$transaction\(async \(tx\) => \{[\s\S]*?\}, RECONCILE_TRANSACTION_OPTIONS\)/,
-  'The bounded transaction options must be applied to the atomic reconciliation write transaction.',
+  /const updateOperations = plan\.updates\.flatMap/,
+  'Existing Component updates must be prepared as atomic batch transaction operations.',
+)
+assert.match(
+  source,
+  /prisma\.component\.createMany\(/,
+  'New manifest Components must be collapsed into a single createMany statement.',
+)
+assert.match(
+  source,
+  /await prisma\.\$transaction\(\[\.\.\.updateOperations, \.\.\.createOperations\]\)/,
+  'Updates and the bulk create must commit together in a non-interactive batch transaction.',
 )
 assert.doesNotMatch(
   source,
-  /timeout:\s*5_000/,
-  'The reconciliation must not regress to the timeout that failed the 348-entry production manifest.',
+  /RECONCILE_TRANSACTION_OPTIONS|timeout:\s*\d/,
+  'The reconciliation must not regress to an interactive transaction timeout workaround.',
 )
 
-console.log('WonderLab reconciliation transaction timeout contract passed.')
+console.log('WonderLab reconciliation batch transaction contract passed.')


### PR DESCRIPTION
## Production finding

The second guarded apply still failed atomically with Prisma `P2028`: the callback transaction expired at 30.35 seconds while processing the 348-entry manifest. There were still zero identity conflicts and no writes committed.

## Fix

- replaces the interactive callback transaction with Prisma's non-interactive atomic batch transaction;
- prepares existing Component updates as transaction operations;
- collapses all 172 new Components into one `createMany` statement;
- commits the updates and bulk create together;
- removes the timeout workaround entirely;
- updates the regression contract to forbid callback transactions and require batch updates plus `createMany`.

This reduces the apply from hundreds of callback round trips to 175 update operations plus one bulk create, without weakening atomicity or touching unmatched Components/Reactions. After deployment, rerun the guarded `[wonderlab-rollout]` apply. Advances #381, #472, #473, and #531.