### PR TITLE
model-builder: async art generation via the ArtJob queue

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -194,18 +194,37 @@
           />
         </div>
 
-        <button
-          type="button"
-          class="btn btn-sm btn-primary w-full rounded-xl"
-          :disabled="!isEditable('GENERATE_ASSETS') || isGenerating"
-          @click="store.generateItemAsset(item.id)"
+        <div class="flex gap-1.5">
+          <button
+            type="button"
+            class="btn btn-sm btn-primary flex-1 rounded-xl"
+            :disabled="!isEditable('GENERATE_ASSETS') || isGenerating || isQueued"
+            @click="store.generateItemAsset(item.id)"
+          >
+            <span v-if="isGenerating" class="loading loading-dots loading-sm" />
+            <template v-else>
+              <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+              {{ item.imagePath ? 'Regenerate candidate' : 'Generate candidate' }}
+            </template>
+          </button>
+          <button
+            type="button"
+            class="btn btn-sm btn-outline btn-primary rounded-xl"
+            :disabled="!isEditable('GENERATE_ASSETS') || isGenerating || isQueued"
+            title="Queue generation and keep working — polls in the background, no need to wait here."
+            @click="store.generateItemAssetAsync(item.id)"
+          >
+            <Icon name="kind-icon:clock" class="h-4 w-4" />
+          </button>
+        </div>
+
+        <div
+          v-if="isQueued"
+          class="mt-1.5 flex items-center gap-1.5 rounded-lg bg-base-200 px-2 py-1 text-xs text-base-content/70"
         >
-          <span v-if="isGenerating" class="loading loading-dots loading-sm" />
-          <template v-else>
-            <Icon name="kind-icon:sparkles" class="h-4 w-4" />
-            {{ item.imagePath ? 'Regenerate candidate' : 'Generate candidate' }}
-          </template>
-        </button>
+          <span class="loading loading-dots loading-xs" />
+          {{ item.queueState === 'rendering' ? 'Rendering…' : 'Queued…' }}
+        </div>
       </template>
 
       <div
@@ -321,6 +340,7 @@ watch(
 )
 
 const isGenerating = computed(() => store.generatingItemId === props.itemId)
+const isQueued = computed(() => Boolean(item.value?.artJobId))
 const isCommitting = computed(() => store.committingItemId === props.itemId)
 const isAutoBuilding = computed(() => store.autoBuildingItemId === props.itemId)
 

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -96,6 +96,14 @@ export type ArtImageGenerationEngine =
 
 export type ArtImageGenerationTransport = 'browser' | 'backend'
 
+// Shape of a job polled from GET /api/art/queue/:id.
+export type QueuedArtJob = {
+  id: number
+  status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
+  artImageId?: number | null
+  error?: string | null
+}
+
 export interface GenerateArtData {
   promptString: string
   prompt?: string
@@ -648,12 +656,12 @@ export const useArtStore = defineStore('artStore', () => {
     }
   }
 
-  async function generateCurrentArt(
-    overrides: Partial<GenerateArtData> = {},
-  ): Promise<ApiResponse<ArtImage>> {
-    clearGenerationMessage()
-
-    const result = await generateArt({
+  // Shared by generateCurrentArt (synchronous) and enqueueCurrentArt (queue-only)
+  // so the "current form + overrides" merge logic can't drift between the two.
+  function mergeCurrentArtOverrides(
+    overrides: Partial<GenerateArtData>,
+  ): GenerateArtData {
+    return {
       ...state.artForm,
       ...overrides,
       promptString:
@@ -678,7 +686,15 @@ export const useArtStore = defineStore('artStore', () => {
         selectedSamplerName.value ||
         state.artForm.sampler ||
         'Euler a',
-    })
+    }
+  }
+
+  async function generateCurrentArt(
+    overrides: Partial<GenerateArtData> = {},
+  ): Promise<ApiResponse<ArtImage>> {
+    clearGenerationMessage()
+
+    const result = await generateArt(mergeCurrentArtOverrides(overrides))
 
     if (!result.success) {
       setGenerationMessage('error', result.message || 'Generation failed.')
@@ -692,6 +708,23 @@ export const useArtStore = defineStore('artStore', () => {
     setGenerationMessage('success', result.message || 'Image generated.')
 
     return result
+  }
+
+  // Queue-only counterpart to generateCurrentArt: enqueues via the ArtJob
+  // queue and returns immediately with a jobId instead of awaiting the
+  // render. Callers that want per-item queued/rendering/done state (e.g.
+  // Model Builder's async generation path) poll getArtJobStatus(jobId) and
+  // call finalizeQueuedArtImage once it reports DONE.
+  async function enqueueCurrentArt(
+    overrides: Partial<GenerateArtData> = {},
+  ): Promise<{
+    success: boolean
+    jobId?: number
+    data?: GenerateArtData
+    message?: string
+  }> {
+    clearGenerationMessage()
+    return enqueueArtGeneration(mergeCurrentArtOverrides(overrides))
   }
 
   const getPromptString = computed<string>(() => {
@@ -2057,13 +2090,6 @@ export const useArtStore = defineStore('artStore', () => {
   const ART_QUEUE_POLL_MS = 5_000
   const ART_QUEUE_TIMEOUT_MS = 10 * 60_000
 
-  type QueuedArtJob = {
-    id: number
-    status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
-    artImageId?: number | null
-    error?: string | null
-  }
-
   function queueSleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
@@ -2291,6 +2317,174 @@ export const useArtStore = defineStore('artStore', () => {
     }
   }
 
+  // Resolves the server + generation route for an already-built GenerateArtData
+  // (server selection, hosted-Kontext fallback, sync-vs-queue routing). Shared
+  // by generateArt (awaits the render) and enqueueArtGeneration (returns after
+  // enqueueing) so the routing rules can't drift between the two paths.
+  async function resolveArtGenerationRoute(data: GenerateArtData): Promise<{
+    data: GenerateArtData
+    engine: ArtImageGenerationEngine
+    synchronous: boolean
+  }> {
+    const server = getSelectedArtServer(data)
+
+    const resolvedData: GenerateArtData = server
+      ? {
+          ...data,
+          serverId: server.id,
+          serverName: getServerLabel(server),
+        }
+      : data
+
+    // Hosted Kontext (no explicit server): route through the ArtJob queue so
+    // the home relay renders it, same as every other engine.
+    if (resolvedData.engine === 'kontext' && !server) {
+      return {
+        data: { ...data, serverId: null, serverName: null, engine: 'kontext' },
+        engine: 'kontext',
+        synchronous: false,
+      }
+    }
+
+    if (!server) {
+      throw new Error('No active image generation server selected.')
+    }
+
+    const route = getArtImageGenerationRoute(server, resolvedData)
+
+    return {
+      data: { ...resolvedData, engine: route.engine },
+      // OpenAI runs on the backend directly (no home relay needed), so it
+      // stays synchronous. Every other engine goes through the durable
+      // ArtJob queue.
+      engine: route.engine,
+      synchronous: route.engine === 'openai',
+    }
+  }
+
+  // Validates + resolves a generation request and enqueues it via the ArtJob
+  // queue, returning the jobId immediately instead of awaiting the render.
+  // Mirrors generateArt's guest-promotion and validation steps but stops
+  // short of generateBackendArtImage/enqueueAndRenderArtImage. Callers poll
+  // getArtJobStatus(jobId) and finish with finalizeQueuedArtImage.
+  async function enqueueArtGeneration(artData?: GenerateArtData): Promise<{
+    success: boolean
+    jobId?: number
+    data?: GenerateArtData
+    message?: string
+  }> {
+    const previewPrompt =
+      artData?.promptString?.trim() ||
+      artData?.artPrompt?.trim() ||
+      artData?.prompt?.trim() ||
+      finalPromptString.value ||
+      ''
+    if (!previewPrompt) {
+      return { success: false, message: 'Image prompt is empty.' }
+    }
+
+    if (userStore.isGuest) {
+      const promo = await userStore.ensureRealUser()
+      if (!promo.success) {
+        return {
+          success: false,
+          message:
+            promo.message ||
+            'We could not set up your account for generating. Please try again.',
+        }
+      }
+      void useManaStore().fetch()
+    }
+
+    try {
+      clearError()
+
+      const data = buildGenerateArtData(artData)
+      const promptValidation = validateImagePrompt(data.promptString)
+
+      if (!promptValidation.success) {
+        return {
+          success: false,
+          message: promptValidation.message || 'Invalid image prompt.',
+        }
+      }
+
+      const resolved = await resolveArtGenerationRoute(data)
+
+      if (resolved.synchronous) {
+        throw new Error(
+          'This engine generates synchronously and cannot be queued.',
+        )
+      }
+
+      const jobId = await enqueueArtJob(resolved.data, resolved.engine)
+
+      return { success: true, jobId, data: resolved.data }
+    } catch (error) {
+      handleError(error, 'queueing image generation')
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error',
+      }
+    }
+  }
+
+  // Single-shot status check (no polling loop, no shared queueState mutation)
+  // so callers that track multiple concurrent jobs — e.g. Model Builder, one
+  // per build item — can poll independently without stomping on the
+  // interactive generator's global state.queueState/currentJobId.
+  async function getArtJobStatus(jobId: number): Promise<QueuedArtJob | null> {
+    const response = await performFetch<{ job: QueuedArtJob }>(
+      `/api/art/queue/${jobId}`,
+      { method: 'GET' },
+      2,
+      20_000,
+    )
+
+    return response.success ? (response.data?.job ?? null) : null
+  }
+
+  // Loads the finished ArtImage for a DONE job and applies it (collections,
+  // achievements, generation message) — the same completion generateArt runs
+  // inline. Callers own their own polling loop and call this once a
+  // getArtJobStatus() poll reports a terminal status.
+  async function finalizeQueuedArtImage(
+    job: QueuedArtJob,
+    data: GenerateArtData,
+  ): Promise<ApiResponse<ArtImage>> {
+    try {
+      if (job.status !== 'DONE' || !job.artImageId) {
+        throw new Error(
+          job.error || `Art job ${job.id} ${job.status.toLowerCase()}.`,
+        )
+      }
+
+      const image = await getArtImageById(job.artImageId, {
+        force: true,
+        includeImageData: true,
+      })
+
+      if (!image) {
+        throw new Error(
+          `Art job ${job.id} finished but its image (${job.artImageId}) could not be loaded.`,
+        )
+      }
+
+      await applyGeneratedArtImage(image, data)
+
+      return {
+        success: true,
+        data: image,
+        message: 'Image created and added to collections.',
+      }
+    } catch (error) {
+      handleError(error, 'completing queued image generation')
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      setGenerationMessage('error', message)
+      return { success: false, message }
+    }
+  }
+
   async function generateArt(
     artData?: GenerateArtData,
   ): Promise<ApiResponse<ArtImage>> {
@@ -2342,59 +2536,14 @@ export const useArtStore = defineStore('artStore', () => {
           message: promptValidation.message || 'Invalid image prompt.',
         }
       }
-      const server = getSelectedArtServer(data)
 
-      const resolvedData: GenerateArtData = server
-        ? {
-            ...data,
-            serverId: server.id,
-            serverName: getServerLabel(server),
-          }
-        : data
+      const resolved = await resolveArtGenerationRoute(data)
 
-      // Hosted Kontext (no explicit server): enqueue an image-to-image job so
-      // the home relay renders it, same as every other engine.
-      if (resolvedData.engine === 'kontext' && !server) {
-        const dataWithHostedKontext: GenerateArtData = {
-          ...data,
-          serverId: null,
-          serverName: null,
-          engine: 'kontext',
-        }
+      const image = resolved.synchronous
+        ? await generateBackendArtImage(resolved.data, 'openai')
+        : await enqueueAndRenderArtImage(resolved.data, resolved.engine)
 
-        const image = await enqueueAndRenderArtImage(
-          dataWithHostedKontext,
-          'kontext',
-        )
-
-        await applyGeneratedArtImage(image, dataWithHostedKontext)
-
-        return {
-          success: true,
-          data: image,
-          message: 'Image created and added to collections.',
-        }
-      }
-
-      if (!server) {
-        throw new Error('No active image generation server selected.')
-      }
-
-      const route = getArtImageGenerationRoute(server, resolvedData)
-
-      const dataWithServer: GenerateArtData = {
-        ...resolvedData,
-        engine: route.engine,
-      }
-
-      // OpenAI runs on the backend directly (no home relay needed), so it stays
-      // synchronous. Every other engine goes through the durable ArtJob queue.
-      const image =
-        route.engine === 'openai'
-          ? await generateBackendArtImage(dataWithServer, 'openai')
-          : await enqueueAndRenderArtImage(dataWithServer, route.engine)
-
-      await applyGeneratedArtImage(image, dataWithServer)
+      await applyGeneratedArtImage(image, resolved.data)
 
       return {
         success: true,
@@ -2501,6 +2650,10 @@ export const useArtStore = defineStore('artStore', () => {
 
     generateArt,
     generateImageFromBrowserServer,
+    enqueueCurrentArt,
+    enqueueArtGeneration,
+    getArtJobStatus,
+    finalizeQueuedArtImage,
 
     uploadImage,
     deleteArtImage,

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -17,7 +17,11 @@
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, toRefs } from 'vue'
 import { performFetch, handleError } from '@/stores/utils'
-import { useArtStore } from '@/stores/artStore'
+import {
+  useArtStore,
+  type GenerateArtData,
+  type QueuedArtJob,
+} from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
 import {
   BUILD_STAGES,
@@ -74,6 +78,12 @@ export interface BuildItem {
   promptDraft: string
   artImageId: number | null
   imagePath: string | null
+  // Async generation (t-025): set while a GENERATE_ASSETS ArtJob is in
+  // flight for this item. Ephemeral — not persisted server-side, so a page
+  // refresh drops an in-progress poll (the job itself keeps rendering; the
+  // item just needs a manual re-generate to pick up the finished image).
+  artJobId: number | null
+  queueState: 'queued' | 'rendering' | null
   targetType: string | null
   targetId: number | null
   error: string | null
@@ -268,6 +278,8 @@ function adaptItem(server: ServerItem): BuildItem {
     promptDraft: server.promptDraft ?? '',
     artImageId: server.artImageId ?? null,
     imagePath: artifact?.promotedPath ?? artifact?.draftPath ?? null,
+    artJobId: null,
+    queueState: null,
     targetType: server.targetType ?? null,
     targetId: server.targetId ?? null,
     error: server.error ?? null,
@@ -862,6 +874,142 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
+  // --- GENERATE_ASSETS (async): queue via ArtJob, poll per item -------------
+  //
+  // generateItemAsset above blocks the whole call on the render (up to
+  // ART_QUEUE_TIMEOUT_MS). This is the "normal" async path from the roadmap
+  // note: enqueue, store the jobId on the item, poll independently so
+  // multiple items can be in flight at once with their own queued/rendering
+  // state, and promote the image once the job finishes. Keeps
+  // generateItemAsset as the synchronous "art first, interactively" option.
+
+  const ASYNC_ART_POLL_MS = 5_000
+
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    generateData: GenerateArtData,
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+  ): Promise<void> {
+    const artStore = useArtStore()
+
+    // If another call re-queues this item (or the item is dropped from the
+    // run), item.artJobId will no longer match — stop, the newer poll (or
+    // nothing) owns the item now.
+    while (item.artJobId === jobId) {
+      const job: QueuedArtJob | null = await artStore.getArtJobStatus(jobId)
+
+      if (item.artJobId !== jobId) return
+
+      if (!job || job.status === 'PENDING' || job.status === 'RUNNING') {
+        item.queueState = job?.status === 'RUNNING' ? 'rendering' : 'queued'
+        item.stages.GENERATE_ASSETS = {
+          status: 'in-progress',
+          note: item.queueState,
+        }
+        await new Promise((resolve) => setTimeout(resolve, ASYNC_ART_POLL_MS))
+        continue
+      }
+
+      // Terminal status (DONE/FAILED/CANCELLED).
+      item.artJobId = null
+      item.queueState = null
+
+      const result = await artStore.finalizeQueuedArtImage(job, generateData)
+
+      if (!result.success || !result.data) {
+        item.error = result.message || `Art job ${jobId} did not complete.`
+        item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+        setStatus('error', item.error)
+        return
+      }
+
+      const image = result.data as { id: number; imagePath?: string | null }
+      item.artImageId = image.id
+      item.imagePath = image.imagePath ?? null
+      item.stages.GENERATE_ASSETS = { status: 'ready' }
+
+      await recordArtifact(item, image, output, prompt, dims)
+      pushItem(item, {
+        stageStatuses: item.stages,
+        artImageId: item.artImageId,
+      })
+
+      setStatus('success', `Generated a candidate for ${item.label}.`)
+      return
+    }
+  }
+
+  // Enqueues generation and returns as soon as the job is queued — it does
+  // NOT wait for the render. Progress shows via item.queueState
+  // ('queued' | 'rendering') until pollAsyncArtJob resolves the item.
+  async function generateItemAssetAsync(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    if (item.generation !== 'image') {
+      item.error = `${item.generation} generation is not wired into the front-end slice yet.`
+      item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+      setStatus('error', item.error)
+      return false
+    }
+
+    const prompt = item.promptDraft.trim() || item.pitch.trim()
+    if (!prompt) {
+      item.error = 'Add a prompt in Fields & Prompts before generating.'
+      setStatus('error', item.error)
+      return false
+    }
+
+    const output = getOutput(item.outputKey)
+    const dims = sizeToDimensions(output?.size)
+    const artStore = useArtStore()
+
+    item.error = null
+    item.queueState = 'queued'
+    item.stages.GENERATE_ASSETS = { status: 'in-progress', note: 'queued' }
+    clearStatus()
+
+    try {
+      await artStore.prepareArtGenerator()
+
+      const enqueued = await artStore.enqueueCurrentArt({
+        promptString: prompt,
+        title: `${state.run.sourceLabel} — ${item.label}`,
+        width: dims.width,
+        height: dims.height,
+        engine: output?.engine,
+        isPublic: false,
+      })
+
+      if (!enqueued.success || !enqueued.jobId || !enqueued.data) {
+        throw new Error(enqueued.message || 'Failed to queue generation.')
+      }
+
+      item.artJobId = enqueued.jobId
+      void pollAsyncArtJob(
+        item,
+        enqueued.jobId,
+        enqueued.data,
+        output,
+        prompt,
+        dims,
+      )
+      return true
+    } catch (error) {
+      handleError(error, 'queueing model builder asset')
+      item.error =
+        error instanceof Error ? error.message : 'Failed to queue generation.'
+      item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+      item.queueState = null
+      item.artJobId = null
+      setStatus('error', item.error)
+      return false
+    }
+  }
+
   // --- COMMIT: preview only (durable write is a gated backend milestone) ----
 
   interface CommitPreview {
@@ -1338,6 +1486,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     updatePrompt,
     draftText,
     generateItemAsset,
+    generateItemAssetAsync,
     previewCommit,
     commitItem,
     toggleIncludeArt,


### PR DESCRIPTION
### Task
conductor/model-builder/t-025: Async art generation via the ArtJob queue (kind: software)

### What changed / what I produced
- `stores/artStore.ts`: added a queue-only generation path alongside the existing synchronous one.
  - `enqueueCurrentArt` / `enqueueArtGeneration` — validate + resolve + enqueue via `POST /api/art/enqueue`, return the `jobId` immediately instead of awaiting the render.
  - `getArtJobStatus(jobId)` — single-shot `GET /api/art/queue/:id` poll with no shared-state mutation, so multiple callers can track independent jobs without stomping on the interactive generator's global `state.queueState`/`currentJobId`.
  - `finalizeQueuedArtImage(job, data)` — loads the finished `ArtImage` and applies it (collections, achievements, generation message) once a poll reports `DONE`.
  - Extracted `resolveArtGenerationRoute` (server selection + hosted-Kontext fallback + sync-vs-queue routing) out of `generateArt`, and `mergeCurrentArtOverrides` out of `generateCurrentArt`, so the existing synchronous path and the new async path share the exact same rules instead of duplicating/drifting them. `generateArt`/`generateCurrentArt` behavior is unchanged — same steps, same order, same early-return semantics — just calling the extracted helpers.
- `stores/modelBuilderStore.ts`: added `generateItemAssetAsync(itemId)` + a per-item `pollAsyncArtJob` loop.
  - `BuildItem` gains `artJobId`/`queueState` (ephemeral, not persisted server-side — ".artJobId" is deliberately client-only since the job itself keeps rendering server-side regardless).
  - Enqueues via `artStore.enqueueCurrentArt`, then polls independently per item (`getArtJobStatus` every ~5s) so multiple build items can be queued concurrently, each showing its own `queued`/`rendering` state — unlike the existing `generateItemAsset`, which blocks the whole call on `artStore.generateCurrentArt`'s internal wait (up to 10 minutes) and only exposes a single global `isGenerating` flag.
  - On completion, reuses the exact same success path as the sync flow (`recordArtifact` + `pushItem` + success status) via `artStore.finalizeQueuedArtImage`.
  - Kept `generateItemAsset` (synchronous) unchanged as the "art first, interactively" option per the roadmap note.
- `components/model-builder/model-builder-item-panel.vue`: added a second small button next to "Generate/Regenerate candidate" (clock icon, tooltip "Queue generation and keep working…") that calls the new async path, plus a `queued…`/`rendering…` status pill while a job is in flight. Both buttons disable while either a sync generation or an async job is active for that item.

### How I verified
- `npx vue-tsc --noEmit` — clean (0 errors), same as the pre-change baseline on this branch.
- `npx eslint stores/artStore.ts stores/modelBuilderStore.ts components/model-builder/model-builder-item-panel.vue` — same 6 pre-existing errors as on `main` before this change (verified via `git stash`/re-lint diff), zero new ones introduced.
- Could not exercise this live end-to-end: the sandbox has no reachable `DATABASE_URL`/render backend, and the ComfyUI/Alexandria relay behind the ArtJob queue has been failing every hourly run since ~2026-07-17 per `coloring-book/t-022`'s notes (independently confirmed today via the GitHub Actions run history for `process-color-art-events.yml` — 30+ consecutive failures). PR CI (TypeScript/build checks) is the verification gate for this change; a live smoke test of the async path is natural follow-up once the render backend is confirmed healthy.

### Stakes
reversible

### Flags for Reviewer
- `BuildItem.artJobId`/`queueState` are intentionally NOT persisted server-side (no `/api/model-builder/items` schema change) — a page refresh mid-poll drops the client-side tracking, but the ArtJob itself keeps rendering; the user just needs to click generate again to pick up (or the image lands via a future page's normal fetch once `artImageId` gets set through some other flow). Flagging in case persisting `artJobId` durably is wanted in a follow-up — kept this PR scoped to the client-side async plumbing the task asked for.
- Genuinely couldn't do a live `/model-builder` smoke run given the render-backend outage referenced above — noted rather than silently skipped.

### Kaizen suggestion
Once the ComfyUI/Alexandria render backend is confirmed healthy again (tracked via `coloring-book/t-022`'s FOR-SILAS note), a follow-up task should do a live `/model-builder` smoke test of this async path specifically — queue 2-3 items concurrently, confirm independent queued/rendering state and no cross-item interference — since none of that could be verified without a live backend this cycle.

### Notes for reviewer
Conductor task: https://github.com/silasfelinus/conductor (projects/model-builder/roadmap.yaml, t-025)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DzXyKuQArQDyjLUvhZV2T7)_