### PR TITLE
newsfeed/t-012: wire tutorial help for /newsfeed, refresh deliverables copy

### DIFF
--- a/components/conductor/newsfeed-page.vue
+++ b/components/conductor/newsfeed-page.vue
@@ -44,8 +44,10 @@ const config: ProjectFrontConfig = {
       'Server-side RSS/Atom aggregation pipeline',
       'Feed builder + item renderers',
       'Homepage placement',
+      'Category filtering beyond feed slugs',
+      'Perspective balancing UI (Focused/Balanced/Broad spectrum presets)',
     ],
-    next: ['Category filtering beyond feed slugs', 'Perspective balancing UI'],
+    next: ['Custom per-bucket perspective weight sliders'],
   },
 }
 </script>

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -35,6 +35,7 @@ export type ExtraTutorialKey =
   | 'scoop-cms'
   | 'mermaids'
   | 'packs'
+  | 'wonder'
 export type TutorialChannelKey = FooterKey | ExtraTutorialKey
 
 export type TutorialSection = {
@@ -532,6 +533,22 @@ export const tutorialChannels = {
       },
     ],
   },
+
+  wonder: {
+    key: 'wonder',
+    title: 'WonderLab',
+    tagline: 'Experimental toys, tests, and delightful nonsense.',
+    overview:
+      'WonderLab is the workshop wing of Kind Robots -- games, generative sims, and the Newsfeed, all still earning their shoes.',
+    sections: [
+      {
+        key: 'newsfeed',
+        title: 'Newsfeed',
+        body: 'A programmable, remixable homepage feed of fresh art, stories, and milestones. Pick which feeds show up, filter by keyword or category, and dial in perspective balance from the Manage feeds panel.',
+        image: tutorialImage('wonder', 'newsfeed'),
+      },
+    ],
+  },
 } as const satisfies Record<TutorialChannelKey, TutorialChannel>
 
 export const tutorialChannelKeys = Object.keys(
@@ -547,6 +564,7 @@ const tutorialRouteMap = {
   'scoop-cms': '/scoop-cms',
   mermaids: '/mermaids',
   packs: '/packs',
+  wonder: '/newsfeed',
 } as const satisfies Record<TutorialChannelKey, string>
 
 export function isTutorialChannelKey(


### PR DESCRIPTION
### Task
newsfeed/t-012: Polish and upgrade Newsfeed front-end surface (kind: software)

### What changed / what I produced
- Added a `wonder` tutorial channel to `stores/helpers/tutorialCards.ts` with a `newsfeed` section, plus a `tutorialRouteMap` entry (`wonder: '/newsfeed'`). Previously `resolveTutorialChannelFromRoute('/newsfeed')` returned `null`, so the workspace sheet's "Show tutorial" toggle silently had nothing to render on this page — this wires it up, image path `/images/tutorials/wonder/newsfeed.webp`.
- Updated `components/conductor/newsfeed-page.vue`'s `deliverables` config: "Category filtering beyond feed slugs" and "Perspective balancing UI" were already fully implemented in code (`newsfeed-filters.vue`'s category chips/source toggles, `feedPreferenceStore.ts`'s Focused/Balanced/Broad presets) but the front-page copy still listed them as "next" — moved to "done". Left "Custom per-bucket perspective weight sliders" as the one genuinely-remaining item (explicitly deferred in `newsfeed-filters.vue`'s own comment).
- Companion conductor-repo change (not in this diff): queued the missing tutorial-card art request (`public/images/tutorials/wonder/newsfeed.webp`) in `projects/art-prompts.yaml` so the auto-generation pipeline picks it up; the matching dashboard-tab image was already queued.

### How I verified
- `npm run test` (vue-tsc --noEmit across the whole repo): clean, exit 0.
- `npx eslint` / `npx prettier --write` on both changed files: clean.
- `utils/scripts/verifyNewsfeedAggregation.ts`, `verifyNewsfeedFilters.ts`, `verifyNewsfeedPerspectiveBalance.ts`: all pass.
- `utils/scripts/verifyNavigationRouteAccess.ts`, `verifyChannelResolver.ts`, `auditChannelAssets.ts`: all pass (exit 0); `auditChannelAssets` reports pre-existing missing dashboard-tab images unrelated to this change.

### Stakes
reversible

### Flags for Reviewer
- Task note's step 3 ("verify the PROJECT Dream liveUrl points at /newsfeed") is not verifiable from this sandbox — no live DB access (dummy `DATABASE_URL`) and no admin session to run the Conductor "Placements" backfill button. Flagging as a soft follow-up rather than blocking this PR.
- The tutorial art image itself (`public/images/tutorials/wonder/newsfeed.webp`) doesn't exist yet — now queued in conductor's `art-prompts.yaml`; the tutorial section renders with `getTutorialHeroPath`'s fallback path until it lands, same as every other channel with a `status: pending` image.

### Kaizen suggestion
`resolveTutorialChannelFromRoute` only does exact-or-prefix route matching against a single `TutorialChannelKey`; several `wonder`-dashboard routes (`/wonderlab`, `/screenfx`, `/davinci`, `/watchlist`, `/ruler-hooked`, `/voice-lab`) still have no tutorial-channel coverage at all (same gap this PR just fixed for `/newsfeed`). Worth a follow-up sweep to wire the rest of the `wonder` tabs' tutorial sections in one pass rather than one route at a time.

### Notes for reviewer
Conductor roadmap task: `projects/newsfeed/roadmap.yaml` t-012 (claimed as `claude-conductor-burst-20260719T1313Z`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ScZFvWUfaEzXuH58qyqhZt)_