### PR TITLE
newsfeed/t-019: wire tutorial-channel coverage for the rest of the wonder dashboard

### DIFF
--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -547,6 +547,42 @@ export const tutorialChannels = {
         body: 'A programmable, remixable homepage feed of fresh art, stories, and milestones. Pick which feeds show up, filter by keyword or category, and dial in perspective balance from the Manage feeds panel.',
         image: tutorialImage('wonder', 'newsfeed'),
       },
+      {
+        key: 'wonderlab',
+        title: 'WonderLab',
+        body: 'The open sandbox: the card-matching Memory Dungeon crawl plus a shelf of experimental components and half-finished toys that exist purely because they were fun to make.',
+        image: tutorialImage('wonder', 'wonderlab'),
+      },
+      {
+        key: 'screenfx',
+        title: 'Screen FX',
+        body: 'Control the screen-effect layer -- matrix rain, firefly drift, butterflies, and ambient theater -- and layer overlays until the screen looks exactly as unreasonable as you want.',
+        image: tutorialImage('wonder', 'screenfx'),
+      },
+      {
+        key: 'davinci',
+        title: 'Da Vinci Life Sim',
+        body: 'A generative life-and-legacy simulation: hundreds of achievements, branching choices, and a legacy that remembers what you built.',
+        image: tutorialImage('wonder', 'davinci'),
+      },
+      {
+        key: 'watchlist',
+        title: 'Media Watchlist',
+        body: 'Track films and shows across a clean, structured watchlist -- queue, in-progress, and finished -- so the "what should we watch" argument finally has a source of truth.',
+        image: tutorialImage('wonder', 'watchlist'),
+      },
+      {
+        key: 'ruler-hooked',
+        title: 'Ruler Hooked',
+        body: 'Cast lines, manage a seaside kingdom, and ride the slideshow of tides and decisions where every catch reshapes the realm you rule.',
+        image: tutorialImage('wonder', 'ruler-hooked'),
+      },
+      {
+        key: 'voice-lab',
+        title: 'Voice Lab',
+        body: 'The voice frontier: an Alexa skill and local relay that let Serendipity and friends speak and listen. Watch the relay status and learn how to plug in.',
+        image: tutorialImage('wonder', 'voice-lab'),
+      },
     ],
   },
 } as const satisfies Record<TutorialChannelKey, TutorialChannel>
@@ -564,8 +600,16 @@ const tutorialRouteMap = {
   'scoop-cms': '/scoop-cms',
   mermaids: '/mermaids',
   packs: '/packs',
-  wonder: '/newsfeed',
-} as const satisfies Record<TutorialChannelKey, string>
+  wonder: [
+    '/newsfeed',
+    '/wonderlab',
+    '/screenfx',
+    '/davinci',
+    '/watchlist',
+    '/ruler-hooked',
+    '/voice-lab',
+  ],
+} as const satisfies Record<TutorialChannelKey, string | readonly string[]>
 
 export function isTutorialChannelKey(
   value: string,
@@ -606,16 +650,20 @@ export function resolveTutorialChannelFromRoute(
   let bestLen = -1
 
   for (const key of tutorialChannelKeys) {
-    const route = tutorialRouteMap[key]
-    if (!route) continue
+    const routes = tutorialRouteMap[key]
+    if (!routes) continue
+    const routeList = Array.isArray(routes) ? routes : [routes]
 
-    if (cleanPath === route) return key
+    for (const route of routeList) {
+      if (!route) continue
+      if (cleanPath === route) return key
 
-    const isPrefix = route !== '/' && cleanPath.startsWith(`${route}/`)
+      const isPrefix = route !== '/' && cleanPath.startsWith(`${route}/`)
 
-    if (isPrefix && route.length > bestLen) {
-      bestKey = key
-      bestLen = route.length
+      if (isPrefix && route.length > bestLen) {
+        bestKey = key
+        bestLen = route.length
+      }
     }
   }
 


### PR DESCRIPTION
### Task
newsfeed/t-019: kind_robots: wire tutorial-channel coverage for the rest of the wonder dashboard's routes (kind: software)

### What changed / what I produced
- `stores/helpers/tutorialCards.ts`: added six new sections to the `wonder` tutorialChannel (`wonderlab`, `screenfx`, `davinci`, `watchlist`, `ruler-hooked`, `voice-lab`), mirroring the `newsfeed` section t-012 added.
- Widened `tutorialRouteMap`'s value type from `Record<TutorialChannelKey, string>` to `Record<TutorialChannelKey, string | readonly string[]>` and changed `wonder`'s entry to an array of its 7 routes (`/newsfeed`, `/wonderlab`, `/screenfx`, `/davinci`, `/watchlist`, `/ruler-hooked`, `/voice-lab`).
- Updated `resolveTutorialChannelFromRoute` to check every route in a key's list instead of assuming exactly one route per channel key.
- `mural`, `challenges`, and `humboldt-scoop` were left out — they already have their own separate `tutorialChannel` entries per the task note.

### How I verified
- `npx eslint stores/helpers/tutorialCards.ts` — clean
- `npx prettier --check stores/helpers/tutorialCards.ts` — clean
- `npm run test` (vue-tsc --noEmit) — 0 errors

### Stakes
reversible

### Flags for Reviewer
- The task note offered two designs: extend the single `wonder` channel to cover multiple routes, or split into per-route channels. I chose the single-channel + multi-route-array approach since it's the smaller, more contained change and keeps the "WonderLab is the workshop wing" narrative in one place rather than fragmenting it across 7 near-duplicate channel entries.
- No tutorial images exist yet under `public/images/tutorials/wonder/` for any section (including the pre-existing `newsfeed` one from t-012) — this matches the existing state of the tutorial system, not a new gap introduced here.

### Kaizen suggestion
`resolveTutorialChannelFromRoute`'s prefix-match logic (`bestLen` tie-break) technically now also needs a cross-key length tie-break check when two *different* keys' routes could both prefix-match the same path — not an issue with the current route set (no route is a prefix of another channel's route), but worth a unit test asserting exact-match always wins over prefix-match and that route specificity is respected once more nested wonder-dashboard sub-routes are added.

### Notes for reviewer
Conductor roadmap task (`newsfeed/t-019`) set to `status: review` in the same session; conductor PR to follow with that change plus the task claim.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtTJvXP5YhqAh9vp23Wz57)_