### PR TITLE
newsfeed/t-020: unit tests for resolveTutorialChannelFromRoute exact-vs-prefix precedence

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Newsfeed perspective balance contract
         run: npm run test:newsfeed-perspective-balance
 
+      - name: Tutorial channel resolver contract
+        run: npm run test:tutorial-channel-resolver
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:newsfeed-aggregation": "tsx utils/scripts/verifyNewsfeedAggregation.ts",
     "test:newsfeed-filters": "tsx utils/scripts/verifyNewsfeedFilters.ts",
     "test:newsfeed-perspective-balance": "tsx utils/scripts/verifyNewsfeedPerspectiveBalance.ts",
+    "test:tutorial-channel-resolver": "tsx utils/scripts/verifyTutorialChannelResolver.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -639,6 +639,12 @@ export function getTutorialEarningsMessage(
 
 export function resolveTutorialChannelFromRoute(
   path: string,
+  // Overridable for tests exercising the exact-vs-prefix precedence rules
+  // with controlled route data; real callers always use the defaults.
+  routeMap: Partial<
+    Record<TutorialChannelKey, string | readonly string[]>
+  > = tutorialRouteMap,
+  keys: readonly TutorialChannelKey[] = tutorialChannelKeys,
 ): TutorialChannelKey | null {
   let cleanPath = path || ''
   const queryIndex = cleanPath.indexOf('?')
@@ -649,8 +655,8 @@ export function resolveTutorialChannelFromRoute(
   let bestKey: TutorialChannelKey | null = null
   let bestLen = -1
 
-  for (const key of tutorialChannelKeys) {
-    const routes = tutorialRouteMap[key]
+  for (const key of keys) {
+    const routes = routeMap[key]
     if (!routes) continue
     const routeList = Array.isArray(routes) ? routes : [routes]
 

--- a/utils/scripts/verifyTutorialChannelResolver.ts
+++ b/utils/scripts/verifyTutorialChannelResolver.ts
@@ -1,0 +1,124 @@
+// /utils/scripts/verifyTutorialChannelResolver.ts
+//
+// Regression test for resolveTutorialChannelFromRoute() in tutorialCards.ts
+// (newsfeed/t-020, kaizen from t-019). Exercises the real function against
+// real production route data (the wonder key's 7 real routes) and against
+// controlled routeMap/keys overrides for the exact-vs-prefix precedence
+// rules that no real route pair currently exercises (per t-019's note: "no
+// route in the current set is a prefix of another channel's route").
+import assert from 'node:assert/strict'
+import { resolveTutorialChannelFromRoute } from '@/stores/helpers/tutorialCards'
+
+// (1) Exact match always wins even when a shorter route from a different
+// key would also match as a prefix -- and even when that shorter route is
+// reached first during iteration.
+{
+  const routeMap = {
+    games: '/shop',
+    art: '/shop/gallery',
+  }
+  const keys = ['games', 'art'] as const
+
+  const result = resolveTutorialChannelFromRoute(
+    '/shop/gallery',
+    routeMap,
+    keys,
+  )
+  assert.equal(
+    result,
+    'art',
+    'an exact match on a longer route must win over an earlier-seen prefix match on a shorter route from a different key',
+  )
+}
+
+// (2) Prefix match picks the most specific (longest) route across
+// different keys, via the cross-key bestLen tie-break.
+{
+  const routeMap = {
+    games: '/shop',
+    art: '/shop/gallery',
+  }
+  const keys = ['games', 'art'] as const
+
+  const result = resolveTutorialChannelFromRoute(
+    '/shop/gallery/extra',
+    routeMap,
+    keys,
+  )
+  assert.equal(
+    result,
+    'art',
+    'prefix matching must prefer the longer, more specific route across different keys, not the first one seen',
+  )
+
+  // Sanity check: a path that only matches the shorter route resolves to it.
+  const shorterOnly = resolveTutorialChannelFromRoute(
+    '/shop/other',
+    routeMap,
+    keys,
+  )
+  assert.equal(
+    shorterOnly,
+    'games',
+    'a path matching only the shorter route must still resolve to its key',
+  )
+}
+
+// (3) The wonder key's multi-route array resolves correctly for each of
+// its 7 real routes (using the real, unmodified production route map).
+{
+  const wonderRoutes = [
+    '/newsfeed',
+    '/wonderlab',
+    '/screenfx',
+    '/davinci',
+    '/watchlist',
+    '/ruler-hooked',
+    '/voice-lab',
+  ]
+
+  for (const route of wonderRoutes) {
+    assert.equal(
+      resolveTutorialChannelFromRoute(route),
+      'wonder',
+      `expected ${route} to resolve to the wonder channel`,
+    )
+    assert.equal(
+      resolveTutorialChannelFromRoute(`${route}/sub-page`),
+      'wonder',
+      `expected a sub-path of ${route} to prefix-resolve to the wonder channel`,
+    )
+  }
+
+  // No other real channel route is a prefix of a wonder route or vice
+  // versa, so an unrelated real route must not resolve to wonder.
+  assert.equal(
+    resolveTutorialChannelFromRoute('/dreams'),
+    'dream',
+    'an unrelated real route must still resolve to its own channel, not wonder',
+  )
+}
+
+// query/hash stripping still works with the injectable parameters in play.
+{
+  const routeMap = { games: '/shop' }
+  const keys = ['games'] as const
+  assert.equal(
+    resolveTutorialChannelFromRoute('/shop?ref=footer#top', routeMap, keys),
+    'games',
+    'query strings and hash fragments must be stripped before matching',
+  )
+}
+
+assert.equal(
+  resolveTutorialChannelFromRoute('/nowhere-real'),
+  null,
+  'a path matching no channel route must resolve to null',
+)
+
+console.log(
+  'Tutorial channel resolver contract passed: exact match beats an ' +
+    'earlier-seen shorter prefix from a different key, prefix matching ' +
+    'picks the longest route across different keys, all 7 real wonder ' +
+    'routes resolve correctly, and query/hash stripping still works.',
+)


### PR DESCRIPTION
## Summary
- `resolveTutorialChannelFromRoute` (in `stores/helpers/tutorialCards.ts`) had no test coverage for its exact-match-wins and cross-key longest-prefix-wins rules, per t-019's kaizen note. No real route pair currently overlaps as a prefix, so the behavior was never exercised.
- Gave the function two optional, defaulted parameters (`routeMap`, `keys`) so a test can inject controlled overlapping route data without changing behavior for any real caller (e.g. `workspace-sheet.vue`, which still calls it with just `route.path`).
- Added `utils/scripts/verifyTutorialChannelResolver.ts`, wired as `npm run test:tutorial-channel-resolver`, covering:
  1. exact match wins even when a shorter route from a different key is found as a prefix candidate first during iteration
  2. prefix matching picks the longest/most-specific route across different keys (cross-key `bestLen` tie-break)
  3. all 7 real `wonder` channel routes (plus a sub-path each) resolve correctly against the real, unmodified route map
  4. a null result for an unmatched path, and query/hash stripping still working with the injectable parameters in play
- Wired the new check into `.github/workflows/contract-tests.yml` alongside the other newsfeed contract checks.

## Test plan
- [x] `npm run test:tutorial-channel-resolver` passes
- [x] `npx eslint stores/helpers/tutorialCards.ts utils/scripts/verifyTutorialChannelResolver.ts` clean
- [x] `npx prettier --check` clean
- [x] `npm run test` (`vue-tsc --noEmit`) — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NwXVLp4qHqnETWNdPczGU

---
_Generated by [Claude Code](https://claude.ai/code/session_011NwXVLp4qHqnETWNdPczGU)_