### PR TITLE
ai-art-academy/t-010: fix batch-upload status badges for duplicate-named files

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -82,7 +82,7 @@
 
         <Transition name="fade">
           <div
-            v-if="succeededNames.has(item.file.name)"
+            v-if="succeededFiles.has(item.file)"
             class="absolute inset-0 flex items-center justify-center bg-success/60 backdrop-blur-sm"
           >
             <Icon
@@ -94,7 +94,7 @@
 
         <Transition name="fade">
           <div
-            v-if="failedNames.has(item.file.name)"
+            v-if="failedFiles.has(item.file)"
             class="absolute inset-0 flex items-center justify-center bg-error/60 backdrop-blur-sm"
           >
             <Icon
@@ -571,8 +571,8 @@ const message = ref('')
 const error = ref('')
 const connectedModelType = ref<ConnectableModel | ''>('')
 const queuedFiles = ref<QueuedFile[]>([])
-const succeededNames = ref<Set<string>>(new Set())
-const failedNames = ref<Set<string>>(new Set())
+const succeededFiles = ref<Set<File>>(new Set())
+const failedFiles = ref<Set<File>>(new Set())
 
 const collectionOptions = computed(() => collectionStore.collections ?? [])
 
@@ -677,8 +677,8 @@ function addFiles(incoming: FileList | File[]) {
     (file) => !uploadStore.validateFile(file),
   )
   queuedFiles.value.push(...valid.map(makeQueuedFile))
-  succeededNames.value = new Set()
-  failedNames.value = new Set()
+  succeededFiles.value = new Set()
+  failedFiles.value = new Set()
   message.value = ''
   error.value = ''
 }
@@ -686,8 +686,8 @@ function addFiles(incoming: FileList | File[]) {
 function clearQueue() {
   queuedFiles.value.forEach((item) => URL.revokeObjectURL(item.preview))
   queuedFiles.value = []
-  succeededNames.value = new Set()
-  failedNames.value = new Set()
+  succeededFiles.value = new Set()
+  failedFiles.value = new Set()
   connectedModelType.value = ''
   message.value = ''
   error.value = ''
@@ -739,8 +739,8 @@ async function handleBatchUpload() {
     return
   }
 
-  succeededNames.value = new Set()
-  failedNames.value = new Set()
+  succeededFiles.value = new Set()
+  failedFiles.value = new Set()
   message.value = ''
   error.value = ''
 
@@ -752,11 +752,11 @@ async function handleBatchUpload() {
     metadata: buildMetadata(),
   })
 
-  succeededNames.value = new Set(
-    result.succeeded.map((r) => r.fileName).filter(Boolean) as string[],
+  succeededFiles.value = new Set(
+    result.succeeded.map((r) => r.file).filter(Boolean) as File[],
   )
-  failedNames.value = new Set(
-    result.failed.map((r) => r.fileName).filter(Boolean) as string[],
+  failedFiles.value = new Set(
+    result.failed.map((r) => r.file).filter(Boolean) as File[],
   )
 
   // Mirror store messaging locally so the component owns its own banners.

--- a/stores/uploadStore.ts
+++ b/stores/uploadStore.ts
@@ -85,6 +85,7 @@ export interface ImageUploadResult {
   success: boolean
   message: string
   fileName?: string
+  file?: File
   artImage?: ArtImage
 }
 
@@ -551,6 +552,7 @@ export const useUploadStore = defineStore('UploadStore', () => {
           success: true,
           message: `${file.name} uploaded.`,
           fileName: file.name,
+          file,
           artImage,
         })
       } catch (caught) {
@@ -561,6 +563,7 @@ export const useUploadStore = defineStore('UploadStore', () => {
           success: false,
           message: fallback,
           fileName: file.name,
+          file,
         })
       } finally {
         uploadProgress.value++


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software) — lane 1, front-end polish.

### What changed / what I produced
- `components/art/image-upload.vue`'s batch-upload success/failure overlays were keyed by `item.file.name` (a plain string), so two queued files sharing a name (e.g. two camera photos both named `IMG_0001.jpg` — `addFiles`/`uploadStore.validateFile` never dedupe by name) collided in `succeededNames`/`failedNames`: if one succeeded and the other failed, **both** thumbnails would show both the success checkmark and the failure X, misreporting the actual per-file outcome.
- Fixed by keying on the actual `File` object reference instead of its name: added an optional `file?: File` field to `ImageUploadResult` in `stores/uploadStore.ts` (populated in both the `succeeded.push`/`failed.push` calls inside `uploadBatchForActiveTarget`), and changed the component's two Sets from `Set<string>` (names) to `Set<File>`, with the template checks updated to `succeededFiles.has(item.file)` / `failedFiles.has(item.file)`.

### How I verified
- Read through `image-upload.vue` and `stores/uploadStore.ts` end-to-end to confirm `queuedFiles` items are keyed by a synthetic id (not name-deduped) and that the store threads the same `File` reference through its per-file try/catch loop, so reference equality is safe and precise.
- `npx eslint components/art/image-upload.vue stores/uploadStore.ts` — no new errors (the one pre-existing `getSelectedCollectionId` unused-var error in `uploadStore.ts` reproduces identically on `main` before this change, confirmed via `git stash`).
- `npx prettier --check` on both files — same pre-existing warning on `uploadStore.ts` reproduces on `main` unchanged.
- `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — exit 0, no errors.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`addFiles`/`makeQueuedFile` never dedupe by filename, so users can silently queue the exact same file twice (not just same-name-different-content) with no warning — worth a follow-up UX nudge (e.g. a subtle "duplicate name queued" badge) if this comes up again, but out of scope for this fix.

### Notes for reviewer
This is a recurring `t-010` cycle (lane 1: front-end polish), found via a fresh Explore pass over all 7 in-scope Academy/art components with an explicit exclusion list of every previously-fixed item from this task's long history (PRs #275, #301, #332, #371, #380, #383, #385, #387, #397, #515, #520) — this is a genuinely new, verified finding, not a re-report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ni4pP9RC3X1YZrocU5KHyo)_