### PR TITLE
Fix WonderLab rollout with a single bulk canonical update

### DIFF
--- a/server/api/components/reconcile.post.ts
+++ b/server/api/components/reconcile.post.ts
@@ -6,9 +6,8 @@ import { requireAdminApiUser } from '../../utils/authGuard'
 import {
   buildComponentReconcilePlan,
   parseWonderLabManifest,
-  type ComponentReconcileChanges,
 } from '../../utils/wonderlabComponentReconcile'
-import type { Prisma } from '~/prisma/generated/prisma/client'
+import { Prisma } from '~/prisma/generated/prisma/client'
 
 type ReconcileMode = 'dry-run' | 'apply'
 
@@ -16,6 +15,14 @@ type ReconcileRequestBody = {
   mode?: ReconcileMode
   manifest?: unknown
 }
+
+type ComponentUpdateAction = ReturnType<
+  typeof buildComponentReconcilePlan
+>['updates'][number] & {
+  existingId: number
+}
+
+type ComponentUpdateValue = string | number | boolean | Date
 
 function parseMode(value: unknown): ReconcileMode {
   if (value === undefined || value === 'dry-run') return 'dry-run'
@@ -27,20 +34,100 @@ function parseMode(value: unknown): ReconcileMode {
   })
 }
 
-function updateDataForChanges(
-  changes: ComponentReconcileChanges,
-): Prisma.ComponentUpdateInput {
-  return {
-    componentName: changes.componentName,
-    folderName: changes.folderName,
-    slug: changes.slug,
-    sourcePath: changes.sourcePath,
-    sourceKey: changes.sourceKey,
-    sourceHash: changes.sourceHash,
-    isDiscovered: changes.isDiscovered,
-    lastSeenAt: changes.lastSeenAt ? new Date(changes.lastSeenAt) : undefined,
-    updatedAt: new Date(),
+function hasExistingId(
+  action: ReturnType<typeof buildComponentReconcilePlan>['updates'][number],
+): action is ComponentUpdateAction {
+  return Number.isInteger(action.existingId)
+}
+
+function buildCaseBranches(
+  actions: ComponentUpdateAction[],
+  valueFor: (action: ComponentUpdateAction) => ComponentUpdateValue | undefined,
+): Prisma.Sql[] {
+  return actions.flatMap((action) => {
+    const value = valueFor(action)
+    return value === undefined
+      ? []
+      : [Prisma.sql`WHEN ${action.existingId} THEN ${value}`]
+  })
+}
+
+function addCaseAssignment(
+  assignments: Prisma.Sql[],
+  column: Prisma.Sql,
+  branches: Prisma.Sql[],
+): void {
+  if (!branches.length) return
+
+  assignments.push(
+    Prisma.sql`${column} = CASE \`id\` ${Prisma.join(branches, ' ')} ELSE ${column} END`,
+  )
+}
+
+function buildBulkUpdateQuery(
+  actions: ReturnType<typeof buildComponentReconcilePlan>['updates'],
+  updatedAt: Date,
+): Prisma.Sql | null {
+  const updateActions = actions.filter(hasExistingId)
+  if (updateActions.length !== actions.length) {
+    throw new Error('Component reconciliation update is missing an existing ID.')
   }
+  if (!updateActions.length) return null
+
+  const assignments: Prisma.Sql[] = []
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`componentName\``,
+    buildCaseBranches(updateActions, (action) => action.changes.componentName),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`folderName\``,
+    buildCaseBranches(updateActions, (action) => action.changes.folderName),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`slug\``,
+    buildCaseBranches(updateActions, (action) => action.changes.slug),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`sourcePath\``,
+    buildCaseBranches(updateActions, (action) => action.changes.sourcePath),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`sourceKey\``,
+    buildCaseBranches(updateActions, (action) => action.changes.sourceKey),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`sourceHash\``,
+    buildCaseBranches(updateActions, (action) => action.changes.sourceHash),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`isDiscovered\``,
+    buildCaseBranches(updateActions, (action) => action.changes.isDiscovered),
+  )
+  addCaseAssignment(
+    assignments,
+    Prisma.sql`\`lastSeenAt\``,
+    buildCaseBranches(updateActions, (action) =>
+      action.changes.lastSeenAt
+        ? new Date(action.changes.lastSeenAt)
+        : undefined,
+    ),
+  )
+  assignments.push(Prisma.sql`\`updatedAt\` = ${updatedAt}`)
+
+  return Prisma.sql`
+    UPDATE \`Component\`
+    SET ${Prisma.join(assignments, ', ')}
+    WHERE \`id\` IN (${Prisma.join(
+      updateActions.map((action) => action.existingId),
+    )})
+  `
 }
 
 function createDataForAction(
@@ -105,32 +192,21 @@ export default defineEventHandler(async (event) => {
     let applied = false
 
     if (mode === 'apply') {
-      // Keep the full reconciliation atomic without an interactive transaction.
-      // Production manifests can require hundreds of writes, and the callback
-      // transaction timeout expired even at 30 seconds. A batch transaction has
-      // no interactive callback deadline, while createMany collapses all new
-      // records into one statement instead of one round trip per Component.
-      const updateOperations = plan.updates.flatMap((action) =>
-        action.existingId
+      const updateQuery = buildBulkUpdateQuery(plan.updates, new Date())
+      const operations = [
+        ...(updateQuery ? [prisma.$executeRaw(updateQuery)] : []),
+        ...(plan.creates.length
           ? [
-              prisma.component.update({
-                where: { id: action.existingId },
-                data: updateDataForChanges(action.changes),
+              prisma.component.createMany({
+                data: plan.creates.map((action) =>
+                  createDataForAction(action, manifest.generatedAt),
+                ),
               }),
             ]
-          : [],
-      )
-      const createOperations = plan.creates.length
-        ? [
-            prisma.component.createMany({
-              data: plan.creates.map((action) =>
-                createDataForAction(action, manifest.generatedAt),
-              ),
-            }),
-          ]
-        : []
+          : []),
+      ]
 
-      await prisma.$transaction([...updateOperations, ...createOperations])
+      if (operations.length) await prisma.$transaction(operations)
       applied = true
     }
 

--- a/utils/scripts/verifyWonderLabReconcileTransaction.ts
+++ b/utils/scripts/verifyWonderLabReconcileTransaction.ts
@@ -16,25 +16,45 @@ assert.doesNotMatch(
   /prisma\.\$transaction\(async\s*\(/,
   'Production reconciliation must not use an interactive callback transaction with an expiry deadline.',
 )
+assert.doesNotMatch(
+  source,
+  /prisma\.component\.update\(/,
+  'Canonical updates must not issue one Prisma operation per Component.',
+)
 assert.match(
   source,
-  /const updateOperations = plan\.updates\.flatMap/,
-  'Existing Component updates must be prepared as atomic batch transaction operations.',
+  /function buildBulkUpdateQuery/,
+  'Canonical updates must be assembled into one bounded bulk statement.',
+)
+assert.ok(
+  source.includes('UPDATE \\`Component\\`') &&
+    source.includes('CASE \\`id\\`'),
+  'The bulk update must target Component rows by their existing IDs.',
+)
+assert.match(
+  source,
+  /prisma\.\$executeRaw\(updateQuery\)/,
+  'The canonical update plan must execute as one parameterized raw statement.',
 )
 assert.match(
   source,
   /prisma\.component\.createMany\(/,
-  'New manifest Components must be collapsed into a single createMany statement.',
+  'New manifest Components must be collapsed into one createMany statement.',
 )
 assert.match(
   source,
-  /await prisma\.\$transaction\(\[\.\.\.updateOperations, \.\.\.createOperations\]\)/,
-  'Updates and the bulk create must commit together in a non-interactive batch transaction.',
+  /await prisma\.\$transaction\(operations\)/,
+  'The bulk update and bulk create must commit together atomically.',
+)
+assert.match(
+  source,
+  /Prisma\.join\(assignments, ', '\)/,
+  'Bulk assignments must be composed through Prisma SQL helpers.',
 )
 assert.doesNotMatch(
   source,
-  /RECONCILE_TRANSACTION_OPTIONS|timeout:\s*\d/,
-  'The reconciliation must not regress to an interactive transaction timeout workaround.',
+  /\$executeRawUnsafe|Prisma\.raw\(/,
+  'The reconciliation must not interpolate manifest data through unsafe raw SQL.',
 )
 
-console.log('WonderLab reconciliation batch transaction contract passed.')
+console.log('WonderLab reconciliation bulk statement contract passed.')


### PR DESCRIPTION
## Production finding

The guarded WonderLab apply was retried against healthy production commit `62cc12c2dc1088a21d1d11b7af10d446ea60a92a`. Its conflict-checking dry run remained safe and unchanged:

- 172 creates
- 175 updates
- 1 unchanged
- 46 database-only rows preserved
- 0 identity conflicts

The apply still failed with Prisma `P2028`: the array-form transaction queued 175 individual `component.update()` operations and exceeded the MariaDB transaction's 5-second boundary (`5567 ms`). No reconciliation writes committed.

## Fix

- composes all existing Component changes into one parameterized `UPDATE Component ... CASE id ...` statement;
- retains `createMany` for all new canonical Components;
- commits the one bulk update and one bulk create atomically;
- preserves unmatched historical Components, human reviews, and every Reaction;
- rejects malformed update actions missing an existing ID;
- forbids per-Component Prisma updates, unsafe raw SQL, and callback transactions in the regression contract.

This directly reduces the failing 176-operation workload to at most two statements without weakening the conflict gate or cleanup boundaries.

## Verification

- reproduced the production failure through guarded Actions run `29687986007`;
- confirmed production manifest count is 348 at deployment `dpl_EBJ7MEmriynGwUnpSAgnKE4nD5MS`;
- confirmed every one of the 175 planned updates has the same canonical source/status field shape;
- ran the revised static transaction contract locally against the proposed endpoint source.

After CI and deployment, rerun the guarded production apply and complete canonical verification, exact fixture cleanup, rollout audit, and UI acceptance.

Advances #381, #472, #473, and #531.