### PR TITLE
ai-art-academy/t-010: warn on skipped invalid files in image-upload

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -673,14 +673,16 @@ function makeQueuedFile(file: File): QueuedFile {
 }
 
 function addFiles(incoming: FileList | File[]) {
-  const valid = Array.from(incoming).filter(
-    (file) => !uploadStore.validateFile(file),
-  )
+  const files = Array.from(incoming)
+  const valid = files.filter((file) => !uploadStore.validateFile(file))
+  const skipped = files.length - valid.length
   queuedFiles.value.push(...valid.map(makeQueuedFile))
   succeededFiles.value = new Set()
   failedFiles.value = new Set()
   message.value = ''
-  error.value = ''
+  error.value = skipped
+    ? `${skipped} file${skipped === 1 ? '' : 's'} skipped — PNG, JPEG, or WebP only`
+    : ''
 }
 
 function clearQueue() {


### PR DESCRIPTION
## Summary
- `image-upload.vue`'s `addFiles()` silently dropped any file that failed `uploadStore.validateFile()` (non-PNG/JPEG/WebP) and unconditionally cleared `error.value`/`message.value` right after — with zero user-visible feedback.
- Drag-and-drop bypasses the hidden `<input accept="...">` constraint entirely (that attribute only affects the native picker dialog), so a mixed-type drop (e.g. 4 PNGs + 1 GIF) silently loses the invalid file with no indication why the preview grid shows fewer tiles than files dropped.
- This also meant `uploadStore.uploadBatchForActiveTarget`'s own working "N skipped, invalid type" messaging was unreachable from this component — invalid files never survive long enough to reach it.
- Fix: `addFiles()` now counts skipped files and sets `error.value` to `"${n} file(s) skipped — PNG, JPEG, or WebP only"` when any are rejected, reusing the existing error banner already wired in the template.

This is part of `ai-art-academy/t-010` (recurring "Academy continuous improvement pass" — front-end polish lane), distinct from PR #544 (which fixed post-upload result-keying by filename instead of File reference).

## Test plan
- [x] `npx eslint components/art/image-upload.vue` — clean (unrelated pre-existing `uploadStore.ts` unused-var error confirmed present on `main`)
- [x] `npx prettier --check components/art/image-upload.vue` — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — exit 0, no new errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01KWufdaMZdq7uw1yvDPNYkV)_