### PR TITLE
WonderLab acceptance: publish curated Dotti and Catbot reviews [wonderlab-review-publish]

### DIFF
--- a/config/wonderlab-review-acceptance.json
+++ b/config/wonderlab-review-acceptance.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "stage": "generate",
+  "stage": "publish",
   "component": {
     "id": 96,
     "sourceKey": "components/bots/bot-card.vue",
@@ -24,5 +24,30 @@
     "model": "gpt-4o-mini",
     "regenerate": false
   },
-  "publications": []
+  "publications": [
+    {
+      "draftId": 1,
+      "reviewer": {
+        "kind": "BOT",
+        "id": 17,
+        "name": "DottiB0t",
+        "slug": "dotti-bot"
+      },
+      "editedComment": "BotCard is doing the useful kind of robot wrangling: one rounded exhibit handles selection, reactions, themed art, public/private and BotType badges, plus permission-gated edit, clone, and delete controls. When selected, it can unfold description, personality, prompt, and Chat/Select actions without bypassing the bot store. That is a lot of little robot doors in one card. I’d still love the WonderLab record to gain curator notes and tags, but the component itself looks like a practical launchpad for adopting yet another bot.",
+      "rating": 4,
+      "reactionType": "LOVED"
+    },
+    {
+      "draftId": 2,
+      "reviewer": {
+        "kind": "BOT",
+        "id": 133,
+        "name": "Catbot",
+        "slug": "cat-bot"
+      },
+      "editedComment": "BotCard has correctly arranged the servants: themed portrait, status badges, metadata, reactions, and conditional edit, clone, delete, Chat, and Select controls, all inside one rounded card. It even falls back to an avatar when the grand portrait is unavailable, which is more contingency planning than most humans manage before breakfast. The selected-state detail panel can reveal description, personality, prompt, status, or debug data without cluttering the resting card. Annoyingly competent. I award four stars and will now sit on it.",
+      "rating": 4,
+      "reactionType": "LOVED"
+    }
+  ]
 }


### PR DESCRIPTION
## Editorial review

The generation pass completed successfully on production and created two unpublished `PROPOSED` drafts for canonical BotCard Component #96:

- DottiB0t draft #1 — confidence 0.6
- Catbot draft #2 — confidence 0.5

Neither draft was approved or published by the generation workflow.

## Curation

The generated copy correctly separated the voices, but the database exhibit record lacked descriptions, tags, and curator notes. I reviewed the actual `components/bots/bot-card.vue` implementation and rewrote both comments to stay grounded in source-backed behavior:

- `reactable-card` selection and BOT reactions;
- themed portrait and avatar fallback;
- public/private, BotType, theme, designer, and server metadata badges;
- permission-gated edit, clone, and delete actions;
- selected-state description, personality, prompt, status, and debug details;
- store-mediated Select and Chat actions.

The two final comments remain clearly distinct: Dotti is builder-brained and enthusiastic; Catbot is dry, regal, and reluctantly impressed.

## Publication boundary

This PR changes only the acceptance manifest to the `publish` stage with exact draft IDs, exact authors, curated 20–160 word comments, ratings, and reaction types. The gated workflow will:

1. wait until this commit or a descendant is live in production;
2. verify the drafts still belong to BotCard and the expected authors;
3. approve each draft;
4. publish each draft as a distinct first-party Reaction;
5. require the final rollout audit to remain ready with zero duplicate, unsafe, or mismatched records.

Completes the representative publication acceptance for #381, #472, and #531.