### PR TITLE
newsfeed/t-018: source real perspective rating for Global Citizen, leave Devex unrated

### DIFF
--- a/stores/helpers/newsfeed.ts
+++ b/stores/helpers/newsfeed.ts
@@ -164,8 +164,16 @@ export const FEED_SOURCES: FeedSourceDefinition[] = [
     url: 'https://www.globalcitizen.org/en/rss/',
     kind: 'rss',
     verified: false,
+    perspective: {
+      label: 'center-left',
+      source: 'Media Bias/Fact Check (mediabiasfactcheck.com/global-citizen)',
+      confidence: 'medium',
+    },
   },
   {
+    // Media Bias/Fact Check has no profile for Devex, and Ground News reports
+    // its bias/factuality as unrated too (checked 2026-07-19) -- no `perspective`
+    // per BIAS-CONTROLS.md "unrated sources remain usable and visibly unrated".
     id: 'devex-news',
     name: 'Devex — Global Development News',
     url: 'https://www.devex.com/rss/news',
@@ -452,13 +460,14 @@ export function applyNewsfeedFilters(
 
 type PerspectiveBucketKey = PerspectiveLabel | 'unrated'
 
-const LABEL_TO_WEIGHT_KEY: Record<PerspectiveLabel, keyof PerspectiveWeights> = {
-  left: 'left',
-  'center-left': 'centerLeft',
-  center: 'center',
-  'center-right': 'centerRight',
-  right: 'right',
-}
+const LABEL_TO_WEIGHT_KEY: Record<PerspectiveLabel, keyof PerspectiveWeights> =
+  {
+    left: 'left',
+    'center-left': 'centerLeft',
+    center: 'center',
+    'center-right': 'centerRight',
+    right: 'right',
+  }
 
 function bucketKeyFor(item: NewsFeedItem): PerspectiveBucketKey {
   return item.perspective?.label ?? 'unrated'
@@ -490,7 +499,10 @@ function weightedRoundRobinMerge<T>(
   const total = buckets.reduce((sum, bucket) => sum + bucket.weight, 0)
   const cursors = new Map(buckets.map((bucket) => [bucket.key, 0]))
   const currents = new Map(buckets.map((bucket) => [bucket.key, 0]))
-  const remaining = buckets.reduce((sum, bucket) => sum + bucket.items.length, 0)
+  const remaining = buckets.reduce(
+    (sum, bucket) => sum + bucket.items.length,
+    0,
+  )
   const result: T[] = []
 
   while (result.length < remaining) {
@@ -558,9 +570,7 @@ export function applyPerspectiveBalance(
   }))
 
   const hasWeight = buckets.some((bucket) => bucket.weight > 0)
-  const merged = hasWeight
-    ? weightedRoundRobinMerge(buckets)
-    : politicalItems // every bucket weighted to zero -- leave order untouched
+  const merged = hasWeight ? weightedRoundRobinMerge(buckets) : politicalItems // every bucket weighted to zero -- leave order untouched
 
   const result = [...items]
   politicalIndices.forEach((originalIndex, i) => {


### PR DESCRIPTION
## Summary
- `stores/helpers/newsfeed.ts`'s Activism feed (`topicPolitical: true`) has two sources, `globalcitizen` and `devex-news`, whose `perspective` field was empty since t-011 shipped the perspective-balance UI/ranking with nothing to actually display yet.
- Per `BIAS-CONTROLS.md`, any rating must come from a real published media-bias methodology with citation, never an invented judgment call.
- **Global Citizen**: Media Bias/Fact Check rates it "Left-Center" bias / "High" factual reporting (mediabiasfactcheck.com/global-citizen) — mapped to `center-left` with `source` citing MBFC and `confidence: 'medium'` (single-methodology rating, not a multi-source aggregate).
- **Devex**: no profile exists on Media Bias/Fact Check, and Ground News reports its bias/factuality as unknown too (no AllSides/Ad Fontes/MBFC rating to aggregate). Left unrated per the guardrail "unrated sources remain usable and visibly unrated" — a documented comment explains why, so a future cycle doesn't waste time re-discovering the same absence.
- Also fixed pre-existing prettier drift on `LABEL_TO_WEIGHT_KEY`'s formatting in the same file (unrelated to this change but required for `prettier --check` to pass).

This is `newsfeed/t-018` (conductor roadmap), kaizen follow-on from t-011.

## Test plan
- [x] `npx eslint stores/helpers/newsfeed.ts` — clean
- [x] `npx prettier --check stores/helpers/newsfeed.ts` — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — 0 errors (after parking pre-existing untracked leftover files — `components/code/`, `components/composition/`, `components/giftshop/social-publisher.vue` — that reference removed stores and aren't part of this diff)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrK2MqoVhcZHmWSQ4TGZAa)_