### PR TITLE
Park WonderLab review acceptance in audit mode [wonderlab-review-audit]

### DIFF
--- a/config/wonderlab-review-acceptance.json
+++ b/config/wonderlab-review-acceptance.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "stage": "publish",
+  "stage": "audit",
   "minimumProductionCommit": "7dc69b3e475f7396ad170435e45a58d042baa404",
   "component": {
     "id": 96,
@@ -25,30 +25,5 @@
     "model": "gpt-4o-mini",
     "regenerate": false
   },
-  "publications": [
-    {
-      "draftId": 1,
-      "reviewer": {
-        "kind": "BOT",
-        "id": 17,
-        "name": "DottiB0t",
-        "slug": "dotti-bot"
-      },
-      "editedComment": "BotCard is doing the useful kind of robot wrangling: one rounded exhibit handles selection, reactions, themed art, public/private and BotType badges, plus permission-gated edit, clone, and delete controls. When selected, it can unfold description, personality, prompt, and Chat/Select actions without bypassing the bot store. That is a lot of little robot doors in one card. I’d still love the WonderLab record to gain curator notes and tags, but the component itself looks like a practical launchpad for adopting yet another bot.",
-      "rating": 4,
-      "reactionType": "LOVED"
-    },
-    {
-      "draftId": 2,
-      "reviewer": {
-        "kind": "BOT",
-        "id": 133,
-        "name": "Catbot",
-        "slug": "cat-bot"
-      },
-      "editedComment": "BotCard has correctly arranged the servants: themed portrait, status badges, metadata, reactions, and conditional edit, clone, delete, Chat, and Select controls, all inside one rounded card. It even falls back to an avatar when the grand portrait is unavailable, which is more contingency planning than most humans manage before breakfast. The selected-state detail panel can reveal description, personality, prompt, status, or debug data without cluttering the resting card. Annoyingly competent. I award four stars and will now sit on it.",
-      "rating": 4,
-      "reactionType": "LOVED"
-    }
-  ]
+  "publications": []
 }


### PR DESCRIPTION
## Purpose

Leave the completed representative review acceptance workflow in a safe resting state after DottiB0t draft #1 and Catbot draft #2 were published successfully as Reactions #1572 and #1573.

## Change

- changes the checked-in acceptance stage from `publish` to read-only `audit`;
- removes all publication instructions, curated copy, ratings, reaction types, and exact draft IDs from the active manifest;
- retains the verified Component, representative reviewers, and compatible production runtime baseline for future audits.

## Expected merge behavior

The explicit `[wonderlab-review-audit]` marker runs the acceptance workflow in audit mode only. It will verify the production baseline, canonical BotCard identity, and the rollout audit without generating, approving, editing, or publishing any review.

## Completed evidence

- production registry: 348/348 canonical components;
- representative reviews: DottiB0t Reaction #1572 and Catbot Reaction #1573;
- final audit: ready, 2 first-party reviews, 0 duplicate groups, 0 unsafe rows, 0 published-draft mismatches;
- public Component and Reaction APIs expose both curated reviews;
- WonderLab, Memory, and Screen FX routes return successfully;
- Vercel runtime errors: none in the final one-hour acceptance window.

Finalizes the safe operating state for #381, #472, and #531.