### PR TITLE
Harden Dream batch ownership

### DIFF
--- a/.github/workflows/dream-batch-ownership.yml
+++ b/.github/workflows/dream-batch-ownership.yml
@@ -1,0 +1,28 @@
+name: Dream Batch Ownership
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/dreams/batch.post.ts'
+      - 'utils/scripts/verifyDreamBatchOwnership.ts'
+      - '.github/workflows/dream-batch-ownership.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+      - run: npx tsx utils/scripts/verifyDreamBatchOwnership.ts

--- a/server/api/dreams/batch.post.ts
+++ b/server/api/dreams/batch.post.ts
@@ -22,7 +22,38 @@ import {
   type DreamMutationResult,
 } from './selects'
 
-type DreamMutationInput = {
+const dreamBatchCreateFields = new Set([
+  'title',
+  'slug',
+  'dreamType',
+  'creationSource',
+  'description',
+  'pitch',
+  'flavorText',
+  'examples',
+  'artPrompt',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'highlightImage',
+  'icon',
+  'designer',
+  'allowReviews',
+  'artImageId',
+  'artCollectionId',
+  'scenarioId',
+  'scenarioIds',
+  'Scenarios',
+  'characterIds',
+  'rewardIds',
+  'artImageIds',
+  'artCollectionIds',
+  'isPublic',
+  'isMature',
+  'isActive',
+])
+
+type DreamMutationInput = Record<string, unknown> & {
   title?: string
   slug?: string | null
   dreamType?: DreamType
@@ -51,7 +82,6 @@ type DreamMutationInput = {
   isPublic?: boolean
   isMature?: boolean
   isActive?: boolean
-  userId?: number
 }
 
 type DreamBatchBody =
@@ -77,16 +107,24 @@ function getDreamsFromBody(body: DreamBatchBody): DreamMutationInput[] {
   return []
 }
 
+function assertSupportedFields(body: DreamMutationInput, index: number) {
+  const unsupported = Object.keys(body).filter(
+    (field) => !dreamBatchCreateFields.has(field),
+  )
+
+  if (unsupported.length > 0) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Dream fields at index ${index}: ${unsupported.join(', ')}. Ownership, IDs, and timestamps are server-owned.`,
+    })
+  }
+}
+
 async function createDreamFromInput(
   body: DreamMutationInput,
   callerUserId: number,
   callerUsername: string | null | undefined,
-  callerIsAdmin: boolean,
 ): Promise<DreamMutationResult> {
-  const userId =
-    callerIsAdmin && body.userId && Number.isInteger(body.userId) && body.userId > 0
-      ? body.userId
-      : callerUserId
   const title = body.title?.trim()
 
   if (!title) {
@@ -132,7 +170,7 @@ async function createDreamFromInput(
     isMature: body.isMature ?? false,
     isActive: body.isActive ?? true,
     User: {
-      connect: { id: userId },
+      connect: { id: callerUserId },
     },
     ...(artImageId
       ? {
@@ -223,13 +261,14 @@ export default defineEventHandler(async (event) => {
           message: `Invalid dream at index ${index}. Expected an object.`,
         })
       }
+
+      assertSupportedFields(dreamData, index)
     }
 
     const userRecord = await prisma.user.findUnique({
       where: { id: user.id },
       select: { username: true },
     })
-    const callerIsAdmin = user.Role === 'ADMIN' || user.id === 1
     const dreams: DreamMutationResult[] = []
     const errors: DreamBatchError[] = []
 
@@ -239,7 +278,6 @@ export default defineEventHandler(async (event) => {
           dreamData,
           user.id,
           userRecord?.username,
-          callerIsAdmin,
         )
 
         dreams.push(dream)

--- a/utils/scripts/verifyDreamBatchOwnership.ts
+++ b/utils/scripts/verifyDreamBatchOwnership.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { strict as assert } from 'node:assert'
+
+const source = readFileSync('server/api/dreams/batch.post.ts', 'utf8')
+
+assert(!source.includes('userId?: number'), 'Dream batch input must not accept userId')
+assert(!source.includes('callerIsAdmin'), 'Dream batch ownership must not branch on admin status')
+assert(!source.includes('body.userId'), 'Dream batch must not read ownership from request data')
+assert(
+  source.includes('connect: { id: callerUserId }'),
+  'Dream batch must connect every created Dream to the authenticated caller',
+)
+assert(
+  source.includes('Ownership, IDs, and timestamps are server-owned.'),
+  'Dream batch must reject unsupported server-owned fields explicitly',
+)
+
+console.log('Dream batch ownership contract passed.')


### PR DESCRIPTION
## Summary

- removes `userId` from Dream batch input
- binds every created Dream to the authenticated caller, including admin callers
- rejects unsupported identity, ID, timestamp, and unknown fields before processing the batch
- preserves the existing per-item creation behavior and `207` partial-success response contract
- adds a DB-free ownership contract and read-only PR workflow

## Why

`POST /api/dreams/batch` still allowed an authenticated admin to assign persisted Dream ownership from each request item. That diverged from the API-overhaul rule that ownership comes from authentication rather than client payloads.

## Checks

- Dream batch ownership contract
- TypeScript Type Check
- existing Contract Tests
