### PR TITLE
Harden Bot mutation ownership

### DIFF
--- a/.github/workflows/bot-mutation-ownership.yml
+++ b/.github/workflows/bot-mutation-ownership.yml
@@ -1,0 +1,39 @@
+name: Bot Mutation Ownership
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/bots/index.post.ts'
+      - 'server/api/bots/[id].patch.ts'
+      - 'server/api/bots/batch.post.ts'
+      - 'stores/helpers/botHelper.ts'
+      - 'cypress/e2e/api/bots.cy.ts'
+      - 'utils/scripts/verifyBotMutationOwnership.ts'
+      - '.github/workflows/bot-mutation-ownership.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Bot ownership boundary
+        run: npx tsx utils/scripts/verifyBotMutationOwnership.ts

--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -102,6 +102,23 @@ describe('Bot Management API Tests', () => {
     })
   })
 
+  it('rejects client-supplied ownership during Bot creation', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(userToken),
+      body: {
+        name: `${botName}-spoofed-owner`,
+        userId,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.be.false
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
   it('creates a Bot with a lean mutation response', () => {
     expect(userId, 'shared Cypress user id').to.be.a('number').and.be.greaterThan(0)
 
@@ -125,7 +142,6 @@ describe('Bot Management API Tests', () => {
         tagline: 'Your friendly AI companion',
         sampleResponse: 'I am here to help you!',
         modules: 'core, analytics',
-        userId,
       },
     }).then((response) => {
       expect(response.status, JSON.stringify(response.body)).to.eq(201)
@@ -171,6 +187,34 @@ describe('Bot Management API Tests', () => {
       expect(response.status).to.eq(401)
       expect(response.body.success).to.be.false
       expect(response.body.message).to.include('Invalid or expired token')
+    })
+  })
+
+  it('rejects ownership reassignment during singular and batch updates', () => {
+    expect(createdBotId, 'createdBotId').to.be.a('number')
+
+    cy.request({
+      method: 'PATCH',
+      url: `${baseUrl}/${createdBotId}`,
+      headers: bearerHeaders(userToken),
+      body: { userId },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.be.false
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+
+    cy.request({
+      method: 'POST',
+      url: `${baseUrl}/batch`,
+      headers: bearerHeaders(userToken),
+      body: [{ id: createdBotId, userId }],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.be.false
+      expect(response.body.message).to.include('Ownership is server-owned')
     })
   })
 

--- a/server/api/bots/[id].patch.ts
+++ b/server/api/bots/[id].patch.ts
@@ -8,10 +8,20 @@ import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { botMutationSelect } from './selects'
 
-type BotPatchBody = Partial<Bot> & {
-  dreamIds?: unknown
-  addDreamIds?: unknown
-  removeDreamIds?: unknown
+type BotPatchBody = Partial<Omit<Bot, 'userId'>> &
+  Record<string, unknown> & {
+    dreamIds?: unknown
+    addDreamIds?: unknown
+    removeDreamIds?: unknown
+  }
+
+function assertOwnershipIsServerManaged(body: Record<string, unknown>) {
+  if (Object.prototype.hasOwnProperty.call(body, 'userId')) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Bot field: userId. Ownership is server-owned.',
+    })
+  }
 }
 
 function getStringOrUndefined(value: unknown): string | undefined {
@@ -60,25 +70,10 @@ function hasUpdateData(data: Record<string, unknown>): boolean {
 }
 
 async function assertRelatedRecordsExist(options: {
-  userId?: number
   serverId?: number
   artImageId?: number
 }) {
-  const { userId, serverId, artImageId } = options
-
-  if (userId) {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { id: true },
-    })
-
-    if (!user) {
-      throw createError({
-        statusCode: 404,
-        message: `User ID not found: ${userId}.`,
-      })
-    }
-  }
+  const { serverId, artImageId } = options
 
   if (serverId) {
     const server = await prisma.server.findUnique({
@@ -159,29 +154,26 @@ export default defineEventHandler(async (event) => {
 
     const body = await readBody<BotPatchBody>(event)
 
-    if (!body || Object.keys(body).length === 0) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Request body is required.',
+      })
+    }
+
+    if (Object.keys(body).length === 0) {
       throw createError({
         statusCode: 400,
         message: 'No data provided for update.',
       })
     }
 
-    const requestedUserId = getPositiveIntegerOrUndefined(body.userId)
+    assertOwnershipIsServerManaged(body)
+
     const serverId = getPositiveIntegerOrUndefined(body.serverId)
     const artImageId = getPositiveIntegerOrUndefined(body.artImageId)
 
-    if (requestedUserId && !isAdmin && !isServerKey) {
-      throw createError({
-        statusCode: 403,
-        message: 'Only admins can reassign bot ownership.',
-      })
-    }
-
-    await assertRelatedRecordsExist({
-      userId: requestedUserId,
-      serverId,
-      artImageId,
-    })
+    await assertRelatedRecordsExist({ serverId, artImageId })
 
     let slugUpdate: string | null | undefined
     const requestedSlug = normalizeSlugInput(body.slug)
@@ -225,11 +217,6 @@ export default defineEventHandler(async (event) => {
       canDelete: getBooleanOrUndefined(body.canDelete),
       isMature: getBooleanOrUndefined(body.isMature),
       isActive: getBooleanOrUndefined(body.isActive),
-      User: requestedUserId
-        ? {
-            connect: { id: requestedUserId },
-          }
-        : undefined,
       Server:
         body.serverId === null
           ? { disconnect: true }

--- a/server/api/bots/batch.post.ts
+++ b/server/api/bots/batch.post.ts
@@ -1,16 +1,17 @@
 // /server/api/bots/batch.post.ts
-import { defineEventHandler, createError, readBody } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 
-type BotBatchPatch = Partial<Bot> & {
-  id?: number
-  dreamIds?: unknown
-  addDreamIds?: unknown
-  removeDreamIds?: unknown
-}
+type BotBatchPatch = Partial<Omit<Bot, 'userId'>> &
+  Record<string, unknown> & {
+    id?: number
+    dreamIds?: unknown
+    addDreamIds?: unknown
+    removeDreamIds?: unknown
+  }
 
 type BotBatchBody =
   | BotBatchPatch[]
@@ -18,6 +19,19 @@ type BotBatchBody =
       dryRun?: boolean
       bots?: BotBatchPatch[]
     }
+
+function assertOwnershipIsServerManaged(bots: BotBatchPatch[]) {
+  const invalidIndexes = bots.flatMap((bot, index) =>
+    Object.prototype.hasOwnProperty.call(bot, 'userId') ? [index] : [],
+  )
+
+  if (invalidIndexes.length > 0) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Bot field: userId at batch indexes ${invalidIndexes.join(', ')}. Ownership is server-owned.`,
+    })
+  }
+}
 
 function getStringOrUndefined(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
@@ -82,7 +96,6 @@ function getBatchPayload(body: BotBatchBody): {
 }
 
 function getBotUpdateData(body: BotBatchPatch): Prisma.BotUpdateInput {
-  const requestedUserId = getPositiveIntegerOrUndefined(body.userId)
   const serverId = getPositiveIntegerOrUndefined(body.serverId)
   const artImageId = getPositiveIntegerOrUndefined(body.artImageId)
 
@@ -111,11 +124,6 @@ function getBotUpdateData(body: BotBatchPatch): Prisma.BotUpdateInput {
     canDelete: getBooleanOrUndefined(body.canDelete),
     isMature: getBooleanOrUndefined(body.isMature),
     isActive: getBooleanOrUndefined(body.isActive),
-    User: requestedUserId
-      ? {
-          connect: { id: requestedUserId },
-        }
-      : undefined,
     Server:
       body.serverId === null
         ? { disconnect: true }
@@ -133,17 +141,10 @@ function getBotUpdateData(body: BotBatchPatch): Prisma.BotUpdateInput {
 }
 
 async function assertRelatedRecordsExist(options: {
-  userIds: number[]
   serverIds: number[]
   artImageIds: number[]
 }) {
-  const [users, servers, artImages] = await Promise.all([
-    options.userIds.length
-      ? prisma.user.findMany({
-          where: { id: { in: options.userIds } },
-          select: { id: true },
-        })
-      : [],
+  const [servers, artImages] = await Promise.all([
     options.serverIds.length
       ? prisma.server.findMany({
           where: { id: { in: options.serverIds } },
@@ -169,11 +170,6 @@ async function assertRelatedRecordsExist(options: {
     }
   }
 
-  assertFound(
-    'User',
-    options.userIds,
-    users.map((user) => user.id),
-  )
   assertFound(
     'Server',
     options.serverIds,
@@ -206,6 +202,19 @@ export default defineEventHandler(async (event) => {
         message: 'No bot updates provided. Send an array or { bots: [...] }.',
       })
     }
+
+    if (
+      bots.some(
+        (bot) => !bot || typeof bot !== 'object' || Array.isArray(bot),
+      )
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: 'Every bot update must be an object.',
+      })
+    }
+
+    assertOwnershipIsServerManaged(bots)
 
     const ids = bots.map((bot) => getPositiveIntegerOrUndefined(bot.id))
 
@@ -260,13 +269,6 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const userIds = [
-      ...new Set(
-        bots
-          .map((bot) => getPositiveIntegerOrUndefined(bot.userId))
-          .filter((id): id is number => id !== undefined),
-      ),
-    ]
     const serverIds = [
       ...new Set(
         bots
@@ -282,18 +284,7 @@ export default defineEventHandler(async (event) => {
       ),
     ]
 
-    if (userIds.length && !isAdmin && !isServerKey) {
-      throw createError({
-        statusCode: 403,
-        message: 'Only admins can reassign bot ownership.',
-      })
-    }
-
-    await assertRelatedRecordsExist({
-      userIds,
-      serverIds,
-      artImageIds,
-    })
+    await assertRelatedRecordsExist({ serverIds, artImageIds })
 
     const updates = bots.map((bot) => {
       const id = getPositiveIntegerOrUndefined(bot.id) as number

--- a/server/api/bots/index.post.ts
+++ b/server/api/bots/index.post.ts
@@ -8,9 +8,19 @@ import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { botMutationSelect } from './selects'
 
-type BotCreateBody = Partial<Bot> & {
-  Dreams?: { connect?: { id: number }[] } | { id: number }[]
-  dreamIds?: number[]
+type BotCreateBody = Partial<Omit<Bot, 'userId'>> &
+  Record<string, unknown> & {
+    Dreams?: { connect?: { id: number }[] } | { id: number }[]
+    dreamIds?: number[]
+  }
+
+function assertOwnershipIsServerManaged(body: Record<string, unknown>) {
+  if (Object.prototype.hasOwnProperty.call(body, 'userId')) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Bot field: userId. Ownership is server-owned.',
+    })
+  }
 }
 
 function getStringOrDefault(value: unknown, fallback: string): string {
@@ -48,23 +58,10 @@ function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
 }
 
 async function assertRelatedRecordsExist(options: {
-  userId: number
   serverId?: number
   artImageId?: number
 }) {
-  const { userId, serverId, artImageId } = options
-
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true },
-  })
-
-  if (!user) {
-    throw createError({
-      statusCode: 404,
-      message: `User ID not found: ${userId}.`,
-    })
-  }
+  const { serverId, artImageId } = options
 
   if (serverId) {
     const server = await prisma.server.findUnique({
@@ -97,30 +94,17 @@ async function assertRelatedRecordsExist(options: {
 
 export default defineEventHandler(async (event) => {
   try {
-    const auth = await requireApiUser(event)
-    const { user } = auth
+    const { user } = await requireApiUser(event)
     const botData = await readBody<BotCreateBody>(event)
 
-    const isServerKey = auth.isServerKey
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
-    const authenticatedUserId = user.id
-    const requestedUserId = getPositiveIntegerOrUndefined(botData.userId)
-    const userId =
-      (isAdmin || isServerKey) && requestedUserId
-        ? requestedUserId
-        : authenticatedUserId
-
-    if (
-      !isAdmin &&
-      !isServerKey &&
-      requestedUserId &&
-      requestedUserId !== userId
-    ) {
+    if (!botData || typeof botData !== 'object' || Array.isArray(botData)) {
       throw createError({
-        statusCode: 403,
-        message: 'User ID does not match the provided authorization token.',
+        statusCode: 400,
+        message: 'Request body is required.',
       })
     }
+
+    assertOwnershipIsServerManaged(botData)
 
     const name = getStringOrDefault(botData.name, '')
 
@@ -134,11 +118,7 @@ export default defineEventHandler(async (event) => {
     const serverId = getPositiveIntegerOrUndefined(botData.serverId)
     const artImageId = getPositiveIntegerOrUndefined(botData.artImageId)
 
-    await assertRelatedRecordsExist({
-      userId,
-      serverId,
-      artImageId,
-    })
+    await assertRelatedRecordsExist({ serverId, artImageId })
 
     const requestedSlug = normalizeSlugInput(botData.slug)
     const slug = await getUniqueBotSlug(prisma, requestedSlug ?? name)
@@ -175,7 +155,7 @@ export default defineEventHandler(async (event) => {
       isMature: getBooleanOrDefault(botData.isMature, false),
       isActive: getBooleanOrDefault(botData.isActive, true),
       User: {
-        connect: { id: userId },
+        connect: { id: user.id },
       },
       Server: serverId
         ? {

--- a/stores/helpers/botHelper.ts
+++ b/stores/helpers/botHelper.ts
@@ -9,16 +9,22 @@ export interface BotPayload extends Partial<Bot> {
   serverName?: string | null
 }
 
+function withoutBotOwnership(payload: BotPayload): BotPayload {
+  const sanitized = { ...payload }
+  Reflect.deleteProperty(sanitized, 'userId')
+  return sanitized
+}
+
 export async function updateBot(
   id: number,
   botForm: BotPayload,
   avatarImage?: string,
 ): Promise<Bot | null> {
   try {
-    const payload: BotPayload = {
+    const payload = withoutBotOwnership({
       ...botForm,
       ...(avatarImage ? { avatarImage } : {}),
-    }
+    })
 
     const response = await performFetch<Bot>(`/api/bots/${id}`, {
       method: 'PATCH',
@@ -40,7 +46,7 @@ export async function addBot(botData: BotPayload): Promise<Bot | null> {
   try {
     const response = await performFetch<Bot>('/api/bots', {
       method: 'POST',
-      body: JSON.stringify(botData),
+      body: JSON.stringify(withoutBotOwnership(botData)),
     })
 
     if (response.success && response.data) {

--- a/utils/scripts/verifyBotMutationOwnership.ts
+++ b/utils/scripts/verifyBotMutationOwnership.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const createRoute = read('server/api/bots/index.post.ts')
+const patchRoute = read('server/api/bots/[id].patch.ts')
+const batchRoute = read('server/api/bots/batch.post.ts')
+const clientHelper = read('stores/helpers/botHelper.ts')
+const cypressSpec = read('cypress/e2e/api/bots.cy.ts')
+
+requireText(
+  createRoute,
+  'assertOwnershipIsServerManaged(botData)',
+  'Bot create ownership rejection',
+)
+requireText(
+  createRoute,
+  'connect: { id: user.id }',
+  'Bot create authenticated ownership',
+)
+forbidText(createRoute, 'requestedUserId', 'Bot create payload ownership')
+forbidText(createRoute, 'botData.userId', 'Bot create payload ownership')
+
+requireText(
+  patchRoute,
+  'assertOwnershipIsServerManaged(body)',
+  'Bot patch ownership rejection',
+)
+forbidText(patchRoute, 'requestedUserId', 'Bot patch ownership reassignment')
+forbidText(patchRoute, '\n      User:', 'Bot patch ownership relation')
+
+requireText(
+  batchRoute,
+  'assertOwnershipIsServerManaged(bots)',
+  'Bot batch ownership rejection',
+)
+forbidText(batchRoute, 'requestedUserId', 'Bot batch ownership reassignment')
+forbidText(batchRoute, 'userIds', 'Bot batch ownership lookup')
+forbidText(batchRoute, '\n    User:', 'Bot batch ownership relation')
+
+requireText(
+  clientHelper,
+  "Reflect.deleteProperty(sanitized, 'userId')",
+  'Bot client ownership stripping',
+)
+requireText(
+  clientHelper,
+  'withoutBotOwnership(botData)',
+  'Bot create client sanitizer',
+)
+requireText(
+  clientHelper,
+  'const payload = withoutBotOwnership({',
+  'Bot patch client sanitizer',
+)
+
+requireText(
+  cypressSpec,
+  'rejects client-supplied ownership during Bot creation',
+  'Bot create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects ownership reassignment during singular and batch updates',
+  'Bot update deployed regression',
+)
+
+console.log('Bot mutation ownership contract passed.')


### PR DESCRIPTION
## Summary

- binds Bot creation ownership exclusively to the authenticated user, including admin and server-key callers
- rejects `userId` during Bot create, singular update, and batch update operations
- removes all Bot ownership reassignment writes and related user lookups from mutation routes
- strips cached `userId` from Bot client create/update payloads
- updates deployed Cypress coverage for create, singular-update, and batch-update spoofing
- adds a DB-free ownership contract and read-only PR workflow

## Why

The Bot mutation family still treated authenticated admin and server credentials as permission to assign persisted ownership from request payloads. That diverged from the API-overhaul boundary already applied to ArtCollections, Challenges, Dreams, and other resources: authorization decides whether an operation may occur, but ownership itself comes from authentication rather than client data.

## Checks

- Bot Mutation Ownership
- TypeScript Type Check
- Contract Tests
