### PR TITLE
Harden Resource mutation ownership

### DIFF
--- a/.github/workflows/resource-mutation-ownership.yml
+++ b/.github/workflows/resource-mutation-ownership.yml
@@ -1,0 +1,39 @@
+name: Resource Mutation Ownership
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/resources/create.ts'
+      - 'server/api/resources/index.post.ts'
+      - 'server/api/resources/batch.post.ts'
+      - 'server/api/resources/[id].patch.ts'
+      - 'cypress/e2e/api/resources.cy.ts'
+      - 'utils/scripts/verifyResourceMutationOwnership.ts'
+      - '.github/workflows/resource-mutation-ownership.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Resource ownership boundary
+        run: npx tsx utils/scripts/verifyResourceMutationOwnership.ts

--- a/cypress/e2e/api/resources.cy.ts
+++ b/cypress/e2e/api/resources.cy.ts
@@ -43,6 +43,7 @@ describe('Resource Management API Tests', () => {
   let batchResourceId: number | undefined
 
   const headers = () => bearerHeaders(userToken)
+  const spoofedUserId = () => (userId ?? 0) + 1_000_000
 
   const expectLeanMutation = (resource: Record<string, unknown>) => {
     expect(resource).to.not.have.property('User')
@@ -114,6 +115,25 @@ describe('Resource Management API Tests', () => {
     })
   })
 
+  it('rejects Resource creation with spoofed ownership', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: baseUrl,
+      headers: headers(),
+      body: {
+        name: `Spoofed-${uniqueResourceName}`,
+        resourceType: 'URL',
+        supportedServer: 'GENERIC',
+        userId: spoofedUserId(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
   it('creates one Resource with a lean mutation response', () => {
     cy.request<ApiResponse<ResourceRow>>({
       method: 'POST',
@@ -179,6 +199,31 @@ describe('Resource Management API Tests', () => {
     })
   })
 
+  it('rejects spoofed ownership in Resource batches', () => {
+    cy.request<ApiResponse<ResourceBatchData>>({
+      method: 'POST',
+      url: `${baseUrl}/batch`,
+      headers: headers(),
+      body: [
+        {
+          name: `SpoofedBatch-${stamp}`,
+          resourceType: 'LORA',
+          supportedServer: 'SDXL',
+          userId: spoofedUserId(),
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.data?.created).to.have.length(0)
+      expect(response.body.data?.failed).to.have.length(1)
+      expect(response.body.data?.failed[0].message).to.include(
+        'Ownership is server-owned',
+      )
+    })
+  })
+
   it('uses the explicit batch route for created, skipped, and failed rows', () => {
     cy.request<ApiResponse<ResourceBatchData>>({
       method: 'POST',
@@ -214,6 +259,24 @@ describe('Resource Management API Tests', () => {
       )
 
       batchResourceId = response.body.data?.created[0].id
+    })
+  })
+
+  it('rejects Resource ownership reassignment on update', () => {
+    expect(resourceId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${baseUrl}/${resourceId}`,
+      headers: headers(),
+      body: {
+        userId: spoofedUserId(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
     })
   })
 

--- a/server/api/resources/[id].patch.ts
+++ b/server/api/resources/[id].patch.ts
@@ -7,12 +7,13 @@ import { validateApiKey } from '../../utils/validateKey'
 import { resourceMutationSelect } from './selects'
 import type { Prisma, Resource } from '~/prisma/generated/prisma/client'
 
-type ResourcePatchBody = Partial<Resource> & {
-  connectServerIds?: number[]
-  disconnectServerIds?: number[]
-  connectLoraImageIds?: number[]
-  disconnectLoraImageIds?: number[]
-}
+type ResourcePatchBody = Partial<Omit<Resource, 'userId'>> &
+  Record<string, unknown> & {
+    connectServerIds?: number[]
+    disconnectServerIds?: number[]
+    connectLoraImageIds?: number[]
+    disconnectLoraImageIds?: number[]
+  }
 
 function normalizeIdArray(value: unknown): number[] {
   if (!Array.isArray(value)) return []
@@ -24,6 +25,26 @@ function normalizeIdArray(value: unknown): number[] {
         .filter((id) => Number.isInteger(id) && id > 0),
     ),
   ]
+}
+
+function assertOwnershipIsUnchanged(
+  body: Record<string, unknown>,
+  existingUserId: number | null,
+) {
+  if (!Object.prototype.hasOwnProperty.call(body, 'userId')) return
+
+  const requestedUserId = Number(body.userId)
+
+  if (
+    !existingUserId ||
+    !Number.isInteger(requestedUserId) ||
+    requestedUserId !== existingUserId
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Resource ownership reassignment. Ownership is server-owned.',
+    })
+  }
 }
 
 function hasUpdateData(data: Record<string, unknown>): boolean {
@@ -71,19 +92,21 @@ export default defineEventHandler(async (event) => {
 
     const body = await readBody<ResourcePatchBody>(event)
 
-    if (!body || Object.keys(body).length === 0) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Request body is required.',
+      })
+    }
+
+    if (Object.keys(body).length === 0) {
       throw createError({
         statusCode: 400,
         message: 'No data provided for update.',
       })
     }
 
-    if (typeof body.userId === 'number' && !isAdmin) {
-      throw createError({
-        statusCode: 403,
-        message: 'Only admins can reassign Resource ownership.',
-      })
-    }
+    assertOwnershipIsUnchanged(body, existingResource.userId)
 
     const connectServerIds = normalizeIdArray(body.connectServerIds)
     const disconnectServerIds = normalizeIdArray(body.disconnectServerIds)
@@ -137,6 +160,7 @@ export default defineEventHandler(async (event) => {
       connectLoraImageIds: _connectLoraImageIds,
       disconnectLoraImageIds: _disconnectLoraImageIds,
       id: _id,
+      userId: _userId,
       createdAt: _createdAt,
       updatedAt: _updatedAt,
       ...resourceFields
@@ -163,10 +187,6 @@ export default defineEventHandler(async (event) => {
       isPublic: resourceFields.isPublic,
       isActive: resourceFields.isActive,
       artPrompt: resourceFields.artPrompt,
-      User:
-        typeof resourceFields.userId === 'number'
-          ? { connect: { id: resourceFields.userId } }
-          : undefined,
       ArtImage:
         typeof resourceFields.artImageId === 'number'
           ? { connect: { id: resourceFields.artImageId } }
@@ -218,7 +238,8 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: false,
-      message: handled.message || `Failed to update resource with ID ${resourceId}.`,
+      message:
+        handled.message || `Failed to update resource with ID ${resourceId}.`,
       data: null,
       statusCode,
     }

--- a/server/api/resources/batch.post.ts
+++ b/server/api/resources/batch.post.ts
@@ -19,9 +19,9 @@ import {
 
 export default defineEventHandler(async (event) => {
   try {
-    const { isValid, user, kind } = await validateApiKey(event)
+    const { isValid, user } = await validateApiKey(event)
 
-    if (!isValid) {
+    if (!isValid || !user) {
       throw createError({
         statusCode: 401,
         message: 'Invalid or expired token.',
@@ -37,10 +37,6 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
-    const fallbackUserId = user?.id || 1
-    const canAssignUserId = isAdmin || isServerKey
     const created: ResourceMutationResult[] = []
     const skipped: ResourceBatchSkip[] = []
     const failed: ResourceBatchFailure[] = []
@@ -51,8 +47,7 @@ export default defineEventHandler(async (event) => {
       try {
         const data = await buildResourceCreateInput({
           entry,
-          fallbackUserId,
-          canAssignUserId,
+          authenticatedUserId: user.id,
         })
 
         try {

--- a/server/api/resources/create.ts
+++ b/server/api/resources/create.ts
@@ -9,12 +9,13 @@ import {
   type Resource,
 } from '~/prisma/generated/prisma/client'
 
-export type ResourceCreateBody = Partial<Resource> & {
-  connectServerIds?: number[]
-  serverIds?: number[]
-  connectLoraImageIds?: number[]
-  usedInImageIds?: number[]
-}
+export type ResourceCreateBody = Partial<Omit<Resource, 'userId'>> &
+  Record<string, unknown> & {
+    connectServerIds?: number[]
+    serverIds?: number[]
+    connectLoraImageIds?: number[]
+    usedInImageIds?: number[]
+  }
 
 export type ResourceBatchSkip = {
   name: string
@@ -28,6 +29,25 @@ export type ResourceBatchFailure = {
 
 const resourceTypes = Object.values(ResourceType)
 const supportedServers = Object.values(SupportedServer)
+
+function assertOwnershipMatchesAuthentication(
+  entry: Record<string, unknown>,
+  authenticatedUserId: number,
+) {
+  if (!Object.prototype.hasOwnProperty.call(entry, 'userId')) return
+
+  const requestedUserId = Number(entry.userId)
+
+  if (
+    !Number.isInteger(requestedUserId) ||
+    requestedUserId !== authenticatedUserId
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Resource ownership assignment. Ownership is server-owned.',
+    })
+  }
+}
 
 function normalizeIdArray(value: unknown): number[] {
   if (!Array.isArray(value)) return []
@@ -105,16 +125,11 @@ function optionalPositiveId(value: unknown, field: string): number | undefined {
 }
 
 async function assertRelatedRecordsExist(options: {
-  userId: number
   artImageId?: number
   serverIds: number[]
   loraImageIds: number[]
 }): Promise<void> {
-  const [user, artImage, servers, loraImages] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: options.userId },
-      select: { id: true },
-    }),
+  const [artImage, servers, loraImages] = await Promise.all([
     options.artImageId
       ? prisma.artImage.findUnique({
           where: { id: options.artImageId },
@@ -134,13 +149,6 @@ async function assertRelatedRecordsExist(options: {
         })
       : [],
   ])
-
-  if (!user) {
-    throw createError({
-      statusCode: 404,
-      message: `User ID not found: ${options.userId}.`,
-    })
-  }
 
   if (options.artImageId && !artImage) {
     throw createError({
@@ -195,14 +203,12 @@ export function isResourceInfrastructureError(error: unknown): boolean {
 
 export async function buildResourceCreateInput(options: {
   entry: ResourceCreateBody
-  fallbackUserId: number
-  canAssignUserId: boolean
+  authenticatedUserId: number
 }): Promise<Prisma.ResourceCreateInput> {
-  const { entry, fallbackUserId, canAssignUserId } = options
+  const { entry, authenticatedUserId } = options
+  assertOwnershipMatchesAuthentication(entry, authenticatedUserId)
+
   const name = requiredText(entry.name, 'name')
-  const requestedUserId = optionalPositiveId(entry.userId, 'userId')
-  const userId =
-    canAssignUserId && requestedUserId ? requestedUserId : fallbackUserId
   const artImageId = optionalPositiveId(entry.artImageId, 'artImageId')
   const serverIds = normalizeIdArray(entry.connectServerIds ?? entry.serverIds)
   const loraImageIds = normalizeIdArray(
@@ -210,7 +216,6 @@ export async function buildResourceCreateInput(options: {
   )
 
   await assertRelatedRecordsExist({
-    userId,
     artImageId,
     serverIds,
     loraImageIds,
@@ -244,7 +249,7 @@ export async function buildResourceCreateInput(options: {
       fallback: SupportedServer.SDXL,
       field: 'supportedServer',
     }),
-    User: { connect: { id: userId } },
+    User: { connect: { id: authenticatedUserId } },
     ArtImage: artImageId ? { connect: { id: artImageId } } : undefined,
     Servers: serverIds.length
       ? { connect: serverIds.map((id) => ({ id })) }

--- a/server/api/resources/index.post.ts
+++ b/server/api/resources/index.post.ts
@@ -12,9 +12,9 @@ import { resourceMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
   try {
-    const { isValid, user, kind } = await validateApiKey(event)
+    const { isValid, user } = await validateApiKey(event)
 
-    if (!isValid) {
+    if (!isValid || !user) {
       throw createError({
         statusCode: 401,
         message: 'Invalid or expired token.',
@@ -38,12 +38,9 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
     const data = await buildResourceCreateInput({
       entry: body,
-      fallbackUserId: user?.id || 1,
-      canAssignUserId: isAdmin || isServerKey,
+      authenticatedUserId: user.id,
     })
 
     try {

--- a/utils/scripts/verifyResourceMutationOwnership.ts
+++ b/utils/scripts/verifyResourceMutationOwnership.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const createHelper = read('server/api/resources/create.ts')
+const createRoute = read('server/api/resources/index.post.ts')
+const batchRoute = read('server/api/resources/batch.post.ts')
+const patchRoute = read('server/api/resources/[id].patch.ts')
+const cypressSpec = read('cypress/e2e/api/resources.cy.ts')
+
+requireText(
+  createHelper,
+  'assertOwnershipMatchesAuthentication(entry, authenticatedUserId)',
+  'Resource create ownership boundary',
+)
+requireText(
+  createHelper,
+  'User: { connect: { id: authenticatedUserId } }',
+  'Resource create authenticated ownership',
+)
+forbidText(createHelper, 'canAssignUserId', 'Resource create payload ownership')
+forbidText(createHelper, 'fallbackUserId', 'Resource create payload ownership')
+
+requireText(
+  createRoute,
+  'authenticatedUserId: user.id',
+  'Resource create caller identity',
+)
+forbidText(createRoute, 'kind', 'Resource create elevated identity assignment')
+
+requireText(
+  batchRoute,
+  'authenticatedUserId: user.id',
+  'Resource batch caller identity',
+)
+forbidText(batchRoute, 'canAssignUserId', 'Resource batch payload ownership')
+forbidText(batchRoute, 'fallbackUserId', 'Resource batch payload ownership')
+
+requireText(
+  patchRoute,
+  'assertOwnershipIsUnchanged(body, existingResource.userId)',
+  'Resource patch ownership boundary',
+)
+requireText(
+  patchRoute,
+  'userId: _userId',
+  'Resource patch ownership stripping',
+)
+forbidText(patchRoute, '\n      User:', 'Resource patch ownership relation')
+forbidText(
+  patchRoute,
+  'Only admins can reassign Resource ownership',
+  'Resource patch admin reassignment',
+)
+
+requireText(
+  cypressSpec,
+  'rejects Resource creation with spoofed ownership',
+  'Resource create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects spoofed ownership in Resource batches',
+  'Resource batch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects Resource ownership reassignment on update',
+  'Resource patch deployed regression',
+)
+
+console.log('Resource mutation ownership contract passed.')


### PR DESCRIPTION
## Summary

- binds single and batch Resource creation to the authenticated user
- removes admin/server-key authority to choose a persisted Resource owner
- prevents Resource ownership reassignment during PATCH, including for admins
- keeps legacy callers compatible when they redundantly send the authenticated/current owner ID, but ignores that value rather than deriving ownership from it
- adds deployed Cypress coverage for create, batch, and update spoofing
- adds a DB-free ownership contract and read-only PR workflow

## Why

Resource mutations still treated elevated credentials as permission to assign or reassign `userId` from request payloads. Authorization should decide who may perform a mutation; it should not make payload identity authoritative. This aligns Resource ownership with the authentication-derived boundary already applied to ArtCollections, Challenges, Dreams, and Bots.

## Checks

- Resource Mutation Ownership
- TypeScript Type Check
- Contract Tests
