### PR TITLE
Harden Prompt creation ownership

### DIFF
--- a/.github/workflows/prompt-create-ownership.yml
+++ b/.github/workflows/prompt-create-ownership.yml
@@ -1,0 +1,36 @@
+name: Prompt Create Ownership
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/prompts/index.post.ts'
+      - 'cypress/e2e/api/prompt-ownership.cy.ts'
+      - 'utils/scripts/verifyPromptCreateOwnership.ts'
+      - '.github/workflows/prompt-create-ownership.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Prompt ownership boundary
+        run: npx tsx utils/scripts/verifyPromptCreateOwnership.ts

--- a/cypress/e2e/api/prompt-ownership.cy.ts
+++ b/cypress/e2e/api/prompt-ownership.cy.ts
@@ -1,0 +1,54 @@
+import {
+  adminHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+type ApiResponse = {
+  success: boolean
+  message: string
+}
+
+describe('Prompt ownership boundary', () => {
+  let apiBase = ''
+  let adminToken = ''
+  let targetUserId: number | undefined
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((user) => {
+        targetUserId = user.id
+      })
+  })
+
+  after(() => {
+    deleteTestUser(apiBase, adminToken, targetUserId)
+  })
+
+  it('does not let elevated credentials assign Prompt ownership', () => {
+    expect(targetUserId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${apiBase}/prompts`,
+      headers: adminHeaders(adminToken),
+      body: {
+        prompt: `Cypress elevated ownership spoof ${Date.now()}`,
+        userId: targetUserId,
+        creationSource: 'HUMAN',
+        isPublic: false,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+})

--- a/server/api/prompts/index.post.ts
+++ b/server/api/prompts/index.post.ts
@@ -7,9 +7,10 @@ import { awardKarma } from '../../utils/karma'
 import type { Prisma, Prompt } from '~/prisma/generated/prisma/client'
 import { promptResourceSelect } from './selects'
 
-type PromptCreateBody = Partial<Prompt> & {
-  CreationSource?: string
-}
+type PromptCreateBody = Partial<Omit<Prompt, 'userId'>> &
+  Record<string, unknown> & {
+    CreationSource?: string
+  }
 
 function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
   const numericValue = Number(value)
@@ -18,24 +19,30 @@ function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
     : undefined
 }
 
+function assertOwnershipMatchesAuthentication(
+  body: Record<string, unknown>,
+  authenticatedUserId: number,
+) {
+  if (!Object.prototype.hasOwnProperty.call(body, 'userId')) return
+
+  const requestedUserId = Number(body.userId)
+
+  if (
+    !Number.isInteger(requestedUserId) ||
+    requestedUserId !== authenticatedUserId
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Prompt ownership assignment. Ownership is server-owned.',
+    })
+  }
+}
+
 async function assertRelatedRecordsExist(options: {
-  userId: number
   botId?: number
   artImageId?: number
 }) {
-  const { userId, botId, artImageId } = options
-
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true },
-  })
-
-  if (!user) {
-    throw createError({
-      statusCode: 404,
-      message: `User ID not found: ${userId}.`,
-    })
-  }
+  const { botId, artImageId } = options
 
   if (botId) {
     const bot = await prisma.bot.findUnique({
@@ -68,7 +75,7 @@ async function assertRelatedRecordsExist(options: {
 
 export default defineEventHandler(async (event) => {
   try {
-    const { isValid, user, kind } = await validateApiKey(event)
+    const { isValid, user } = await validateApiKey(event)
 
     if (!isValid || !user) {
       throw createError({
@@ -79,6 +86,13 @@ export default defineEventHandler(async (event) => {
 
     const promptData = await readBody<PromptCreateBody>(event)
 
+    if (!promptData || typeof promptData !== 'object' || Array.isArray(promptData)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Prompt payload is required.',
+      })
+    }
+
     if (!promptData.prompt || typeof promptData.prompt !== 'string') {
       throw createError({
         statusCode: 400,
@@ -87,32 +101,12 @@ export default defineEventHandler(async (event) => {
     }
 
     const authenticatedUserId = user.id
-    const requestedUserId = getPositiveIntegerOrUndefined(promptData.userId)
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
-    const isServerKey = kind === 'server'
-
-    const userId =
-      (isAdmin || isServerKey) && requestedUserId
-        ? requestedUserId
-        : authenticatedUserId
-
-    if (
-      requestedUserId &&
-      requestedUserId !== authenticatedUserId &&
-      !isAdmin &&
-      !isServerKey
-    ) {
-      throw createError({
-        statusCode: 403,
-        message: 'User ID does not match the authenticated user.',
-      })
-    }
+    assertOwnershipMatchesAuthentication(promptData, authenticatedUserId)
 
     const botId = getPositiveIntegerOrUndefined(promptData.botId)
     const artImageId = getPositiveIntegerOrUndefined(promptData.artImageId)
 
     await assertRelatedRecordsExist({
-      userId,
       botId,
       artImageId,
     })
@@ -132,7 +126,7 @@ export default defineEventHandler(async (event) => {
       isPublic: promptData.isPublic ?? false,
       isActive: promptData.isActive ?? true,
       User: {
-        connect: { id: userId },
+        connect: { id: authenticatedUserId },
       },
       Bot: botId
         ? {
@@ -153,7 +147,7 @@ export default defineEventHandler(async (event) => {
 
     if (data.isPublic) {
       void awardKarma({
-        userId,
+        userId: authenticatedUserId,
         reason: 'CONTENT_CREATED_PUBLIC',
         refId: String(data.id),
       }).catch(() => {})

--- a/utils/scripts/verifyPromptCreateOwnership.ts
+++ b/utils/scripts/verifyPromptCreateOwnership.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const createRoute = read('server/api/prompts/index.post.ts')
+const cypressSpec = read('cypress/e2e/api/prompt-ownership.cy.ts')
+
+requireText(
+  createRoute,
+  'assertOwnershipMatchesAuthentication(promptData, authenticatedUserId)',
+  'Prompt create ownership boundary',
+)
+requireText(
+  createRoute,
+  'connect: { id: authenticatedUserId }',
+  'Prompt authenticated owner connection',
+)
+requireText(
+  createRoute,
+  'userId: authenticatedUserId',
+  'Prompt karma authenticated owner',
+)
+forbidText(createRoute, 'const userId =', 'Prompt payload ownership selection')
+forbidText(createRoute, 'isServerKey', 'Prompt server-key ownership selection')
+forbidText(createRoute, 'const isAdmin', 'Prompt admin ownership selection')
+forbidText(createRoute, 'where: { id: userId }', 'Prompt requested-user lookup')
+
+requireText(
+  cypressSpec,
+  'does not let elevated credentials assign Prompt ownership',
+  'Prompt elevated deployed regression',
+)
+requireText(
+  cypressSpec,
+  'adminHeaders(adminToken)',
+  'Prompt elevated credential coverage',
+)
+
+console.log('Prompt create ownership contract passed.')


### PR DESCRIPTION
## Summary

- binds Prompt creation to the authenticated user for ordinary, admin, and server-key credentials
- rejects attempted ownership assignment when a payload `userId` differs from authentication
- preserves compatibility with the existing Prompt store and Cypress suite when they redundantly send the matching authenticated ID
- removes requested-user lookup and elevated-credential owner selection
- ensures public-content karma is awarded to the authenticated owner
- adds deployed coverage for an elevated ownership-spoof attempt
- adds a DB-free ownership contract and read-only PR workflow

## Why

`POST /api/prompts` still allowed admin and server credentials to select a persisted owner through request data. Authorization may permit an elevated caller to create content, but it should not make payload identity authoritative. Prompt PATCH was already strict and never wrote ownership; this closes the remaining create-path gap.

## Checks

- Prompt Create Ownership
- TypeScript Type Check
- Contract Tests
