### PR TITLE
Drop retired Component status columns

### DIFF
--- a/.github/workflows/wonderlab-component-migration-smoke.yml
+++ b/.github/workflows/wonderlab-component-migration-smoke.yml
@@ -1,0 +1,135 @@
+name: WonderLab Component Migration Smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-component-migration-smoke.yml'
+      - 'prisma/schema.prisma'
+      - 'prisma/generated/prisma/models/Component.ts'
+      - 'prisma/migrations/20260719125500_component_canonical_contract/migration.sql'
+      - 'utils/scripts/verify-component-canonical-contract.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-component-migration-smoke.yml'
+      - 'prisma/schema.prisma'
+      - 'prisma/generated/prisma/models/Component.ts'
+      - 'prisma/migrations/20260719125500_component_canonical_contract/migration.sql'
+      - 'utils/scripts/verify-component-canonical-contract.mjs'
+
+permissions:
+  contents: read
+
+jobs:
+  mariadb-contract:
+    name: Preserve Components and Reactions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: kindrobots
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify schema, generated client, and migration boundary
+        run: node utils/scripts/verify-component-canonical-contract.mjs
+
+      - name: Install MariaDB client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mariadb-client
+
+      - name: Seed post-expand Component and Reaction fixtures
+        env:
+          MYSQL_PWD: root
+        run: |
+          mariadb --protocol=TCP -h 127.0.0.1 -P 3306 -uroot kindrobots <<'SQL'
+          CREATE TABLE `Component` (
+            `id` INT NOT NULL AUTO_INCREMENT,
+            `componentName` VARCHAR(255) NOT NULL,
+            `status` ENUM(
+              'UNREVIEWED',
+              'WORKING',
+              'NEEDS_CONTEXT',
+              'UNDER_CONSTRUCTION',
+              'BROKEN',
+              'RETIRED',
+              'PREVIEW_UNSUPPORTED'
+            ) NOT NULL DEFAULT 'UNREVIEWED',
+            `isWorking` BOOLEAN NOT NULL DEFAULT TRUE,
+            `underConstruction` BOOLEAN NOT NULL DEFAULT FALSE,
+            `isBroken` BOOLEAN NOT NULL DEFAULT FALSE,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `Component_componentName_key` (`componentName`)
+          );
+
+          CREATE TABLE `Reaction` (
+            `id` INT NOT NULL AUTO_INCREMENT,
+            `componentId` INT NULL,
+            `comment` TEXT NULL,
+            PRIMARY KEY (`id`),
+            KEY `Reaction_componentId_idx` (`componentId`),
+            CONSTRAINT `Reaction_componentId_fkey`
+              FOREIGN KEY (`componentId`) REFERENCES `Component` (`id`)
+          );
+
+          INSERT INTO `Component`
+            (`id`, `componentName`, `status`, `isWorking`, `underConstruction`, `isBroken`)
+          VALUES
+            (1, 'WorkingCard', 'WORKING', TRUE, FALSE, FALSE),
+            (2, 'BrokenPanel', 'BROKEN', FALSE, FALSE, TRUE);
+
+          INSERT INTO `Reaction` (`id`, `componentId`, `comment`)
+          VALUES (41, 1, 'Preserve this review.');
+          SQL
+
+      - name: Apply canonical Component contract migration
+        env:
+          MYSQL_PWD: root
+        run: |
+          mariadb --protocol=TCP -h 127.0.0.1 -P 3306 -uroot kindrobots \
+            < prisma/migrations/20260719125500_component_canonical_contract/migration.sql
+
+      - name: Verify rows, relations, and canonical statuses survive
+        env:
+          MYSQL_PWD: root
+        run: |
+          set -euo pipefail
+          query() {
+            mariadb --batch --skip-column-names --protocol=TCP \
+              -h 127.0.0.1 -P 3306 -uroot kindrobots -e "$1"
+          }
+
+          legacy_columns="$(query "
+            SELECT COUNT(*)
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = 'kindrobots'
+              AND TABLE_NAME = 'Component'
+              AND COLUMN_NAME IN ('isWorking', 'underConstruction', 'isBroken');
+          ")"
+          component_count="$(query 'SELECT COUNT(*) FROM `Component`;')"
+          reaction_count="$(query 'SELECT COUNT(*) FROM `Reaction`;')"
+          reaction_component="$(query 'SELECT `componentId` FROM `Reaction` WHERE `id` = 41;')"
+          status_rows="$(query 'SELECT GROUP_CONCAT(CONCAT(`id`, ":", `status`) ORDER BY `id`) FROM `Component`;')"
+
+          test "$legacy_columns" = '0'
+          test "$component_count" = '2'
+          test "$reaction_count" = '1'
+          test "$reaction_component" = '1'
+          test "$status_rows" = '1:WORKING,2:BROKEN'
+
+          echo 'MariaDB Component contract migration preserved canonical rows and Reactions.'

--- a/prisma/migrations/20260719125500_component_canonical_contract/migration.sql
+++ b/prisma/migrations/20260719125500_component_canonical_contract/migration.sql
@@ -1,0 +1,7 @@
+-- Remove redundant Component status booleans after canonical production verification.
+-- Component.status is NOT NULL and was backfilled before this contract migration.
+
+ALTER TABLE `Component`
+  DROP COLUMN `isWorking`,
+  DROP COLUMN `underConstruction`,
+  DROP COLUMN `isBroken`;

--- a/utils/scripts/verify-component-canonical-contract.mjs
+++ b/utils/scripts/verify-component-canonical-contract.mjs
@@ -1,0 +1,58 @@
+// /utils/scripts/verify-component-canonical-contract.mjs
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const migrationPath =
+  'prisma/migrations/20260719125500_component_canonical_contract/migration.sql'
+
+const [schema, migration, generatedComponent] = await Promise.all([
+  readFile('prisma/schema.prisma', 'utf8'),
+  readFile(migrationPath, 'utf8'),
+  readFile('prisma/generated/prisma/models/Component.ts', 'utf8'),
+])
+
+const componentBlock =
+  schema.match(/model Component \{[\s\S]*?\n\}/)?.[0] || ''
+assert.ok(componentBlock, 'Prisma Component model must exist.')
+assert.match(
+  componentBlock,
+  /^\s*status\s+ComponentStatus\s+@default\(UNREVIEWED\)/m,
+)
+assert.match(componentBlock, /^\s*Reactions\s+Reaction\[\]/m)
+
+const legacyFields = ['isWorking', 'underConstruction', 'isBroken']
+for (const field of legacyFields) {
+  assert.doesNotMatch(
+    componentBlock,
+    new RegExp(`^\\s*${field}\\s+`, 'm'),
+    `${field} must be removed from the Prisma Component model.`,
+  )
+  assert.doesNotMatch(
+    generatedComponent,
+    new RegExp(`\\b${field}\\b`),
+    `${field} must be removed from the generated Component client.`,
+  )
+}
+
+assert.match(migration, /^ALTER TABLE `Component`/m)
+for (const field of legacyFields) {
+  assert.equal(
+    (migration.match(new RegExp('DROP COLUMN `' + field + '`', 'g')) || [])
+      .length,
+    1,
+    `The contract migration must drop ${field} exactly once.`,
+  )
+}
+assert.equal(
+  (migration.match(/DROP COLUMN/g) || []).length,
+  legacyFields.length,
+  'The contract migration must drop only the three retired status columns.',
+)
+assert.doesNotMatch(migration, /DROP\s+TABLE|DELETE\s+FROM|TRUNCATE/i)
+assert.doesNotMatch(
+  migration,
+  /DROP\s+COLUMN\s+`(?:status|componentName|sourceKey)`/i,
+)
+assert.doesNotMatch(migration, /Reaction/i)
+
+console.log('Component canonical contract migration verification passed.')


### PR DESCRIPTION
## Summary

Stage 2 of the final Component contract rollout for #473.

This PR contains only the physical database contract migration and its evidence boundary:

- drop `Component.isWorking`;
- drop `Component.underConstruction`;
- drop `Component.isBroken`;
- preserve canonical `Component.status`, every Component row, and every Reaction relation;
- verify the SQL drops exactly those three columns and no protected data structures;
- run the migration against MariaDB 11.4 fixtures with surviving status and Reaction assertions.

## Production gate

Do not merge until production `/api/version` reports Stage 1 merge `a9b85ae3601d0af6898c080c1527e56f5488de30` or a newer descendant and `/api/components` is healthy.

That gate ensures the currently serving Prisma client no longer selects or writes the retired columns before Vercel applies this migration during the next production build.

## Validation

- Component migration boundary verifier
- MariaDB 11.4 preservation smoke
- normal repository TypeScript and contract gates
- production version/API check before merge
- post-deploy runtime error and API verification