### PR TITLE
Harden Server mutation ownership

### DIFF
--- a/.github/workflows/server-mutation-ownership.yml
+++ b/.github/workflows/server-mutation-ownership.yml
@@ -1,0 +1,39 @@
+name: Server Mutation Ownership
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/utils/serverApi.ts'
+      - 'server/api/server/index.post.ts'
+      - 'server/api/server/batch.post.ts'
+      - 'server/api/server/[id].patch.ts'
+      - 'cypress/e2e/api/server-ownership.cy.ts'
+      - 'utils/scripts/verifyServerMutationOwnership.ts'
+      - '.github/workflows/server-mutation-ownership.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Server ownership boundary
+        run: npx tsx utils/scripts/verifyServerMutationOwnership.ts

--- a/cypress/e2e/api/server-ownership.cy.ts
+++ b/cypress/e2e/api/server-ownership.cy.ts
@@ -1,0 +1,144 @@
+import {
+  adminHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+type ServerRecord = {
+  id: number
+  title: string
+  userId?: number | null
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  skipped?: string[]
+}
+
+describe('Server ownership boundary', () => {
+  const stamp = Date.now()
+  let apiBase = ''
+  let adminToken = ''
+  let targetUserId: number | undefined
+  let createdServerId: number | undefined
+
+  const serverUrl = () => `${apiBase}/server`
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((user) => {
+        targetUserId = user.id
+      })
+  })
+
+  after(() => {
+    if (createdServerId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${serverUrl()}/${createdServerId}`,
+        headers: adminHeaders(adminToken),
+        failOnStatusCode: false,
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, targetUserId)
+  })
+
+  it('does not let elevated credentials assign Server ownership on create', () => {
+    expect(targetUserId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: serverUrl(),
+      headers: adminHeaders(adminToken),
+      body: {
+        title: `Cypress Server Ownership Spoof ${stamp}`,
+        baseUrl: 'https://example.com',
+        userId: targetUserId,
+        isPublic: false,
+        isOfficial: false,
+        isDefault: false,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('does not let elevated credentials assign Server ownership in batches', () => {
+    expect(targetUserId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse<ServerRecord[]>>({
+      method: 'POST',
+      url: `${serverUrl()}/batch`,
+      headers: adminHeaders(adminToken),
+      body: [
+        {
+          title: `Cypress Batch Server Ownership Spoof ${stamp}`,
+          baseUrl: 'https://example.com',
+          userId: targetUserId,
+          isPublic: false,
+          isOfficial: false,
+          isDefault: false,
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.data).to.deep.eq([])
+      expect(response.body.skipped?.[0]).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('does not let elevated credentials reassign Server ownership', () => {
+    expect(targetUserId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse<ServerRecord>>({
+      method: 'POST',
+      url: serverUrl(),
+      headers: adminHeaders(adminToken),
+      body: {
+        title: `Cypress Server Ownership Control ${stamp}`,
+        baseUrl: 'https://example.com',
+        isPublic: false,
+        isOfficial: false,
+        isDefault: false,
+        isActive: true,
+        isEditable: true,
+      },
+    }).then((createResponse) => {
+      expect(createResponse.status, JSON.stringify(createResponse.body)).to.eq(
+        201,
+      )
+      createdServerId = createResponse.body.data?.id
+      expect(createdServerId).to.be.a('number').and.greaterThan(0)
+
+      cy.request<ApiResponse>({
+        method: 'PATCH',
+        url: `${serverUrl()}/${createdServerId}`,
+        headers: adminHeaders(adminToken),
+        body: {
+          userId: targetUserId,
+        },
+        failOnStatusCode: false,
+      }).then((patchResponse) => {
+        expect(patchResponse.status).to.eq(400)
+        expect(patchResponse.body.success).to.eq(false)
+        expect(patchResponse.body.message).to.include(
+          'Ownership is server-owned',
+        )
+      })
+    })
+  })
+})

--- a/server/api/server/[id].patch.ts
+++ b/server/api/server/[id].patch.ts
@@ -3,6 +3,7 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from './../../utils/prisma'
 import { errorHandler } from './../../utils/error'
 import {
+  assertServerOwnershipUnchanged,
   buildServerUpdateData,
   canMutateServer,
   parseId,
@@ -39,6 +40,7 @@ export default defineEventHandler(async (event) => {
         : {}
 
     validateServerEnums(safeBody)
+    assertServerOwnershipUnchanged(safeBody, server.userId)
 
     const data = buildServerUpdateData(safeBody, user)
     const updatedServer = await prisma.server.update({

--- a/server/utils/serverApi.ts
+++ b/server/utils/serverApi.ts
@@ -154,7 +154,41 @@ export function safeServers(servers: Server[], user?: AuthUser | null) {
   return servers.map((server) => safeServer(server, user))
 }
 
+export function assertServerCreateOwnership(
+  input: ServerInput,
+  authenticatedUserId: number,
+): void {
+  if (!Object.prototype.hasOwnProperty.call(input, 'userId')) return
+
+  const requestedUserId = cleanInt(input.userId)
+
+  if (requestedUserId !== authenticatedUserId) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Server ownership assignment. Ownership is server-owned.',
+    })
+  }
+}
+
+export function assertServerOwnershipUnchanged(
+  input: ServerInput,
+  existingUserId: number | null,
+): void {
+  if (!Object.prototype.hasOwnProperty.call(input, 'userId')) return
+
+  const requestedUserId = cleanInt(input.userId)
+
+  if (!existingUserId || requestedUserId !== existingUserId) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Server ownership reassignment. Ownership is server-owned.',
+    })
+  }
+}
+
 export function buildServerCreateData(input: ServerInput, user: AuthUser) {
+  assertServerCreateOwnership(input, user.id)
+
   const title = cleanText(input.title)
   const baseUrl = cleanText(input.baseUrl)
 
@@ -201,8 +235,7 @@ export function buildServerCreateData(input: ServerInput, user: AuthUser) {
     version: cleanText(input.version),
     sortOrder: cleanInt(input.sortOrder) ?? 0,
 
-    userId:
-      user.isAdmin && cleanInt(input.userId) ? cleanInt(input.userId) : user.id,
+    userId: user.id,
 
     isPublic: user.isAdmin ? Boolean(input.isPublic) : false,
     isOfficial: user.isAdmin ? Boolean(input.isOfficial) : false,
@@ -277,10 +310,6 @@ export function buildServerUpdateData(input: ServerInput, user: AuthUser) {
       if (field in input) {
         data[field] = Boolean(input[field])
       }
-    }
-
-    if ('userId' in input) {
-      data.userId = cleanInt(input.userId) ?? null
     }
   }
 

--- a/utils/scripts/verifyServerMutationOwnership.ts
+++ b/utils/scripts/verifyServerMutationOwnership.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const serverApi = read('server/utils/serverApi.ts')
+const createRoute = read('server/api/server/index.post.ts')
+const batchRoute = read('server/api/server/batch.post.ts')
+const patchRoute = read('server/api/server/[id].patch.ts')
+const cypressSpec = read('cypress/e2e/api/server-ownership.cy.ts')
+
+requireText(
+  serverApi,
+  'assertServerCreateOwnership(input, user.id)',
+  'Server create ownership boundary',
+)
+requireText(
+  serverApi,
+  'userId: user.id',
+  'Server authenticated owner assignment',
+)
+requireText(
+  serverApi,
+  'export function assertServerOwnershipUnchanged(',
+  'Server update ownership boundary',
+)
+forbidText(
+  serverApi,
+  'user.isAdmin && cleanInt(input.userId)',
+  'Server elevated create ownership selection',
+)
+forbidText(
+  serverApi,
+  'data.userId =',
+  'Server ownership reassignment write',
+)
+
+requireText(
+  createRoute,
+  'buildServerCreateData(safeBody, user)',
+  'Server singular create shared boundary',
+)
+requireText(
+  batchRoute,
+  'buildServerCreateData(safeBody, user)',
+  'Server batch create shared boundary',
+)
+requireText(
+  patchRoute,
+  'assertServerOwnershipUnchanged(safeBody, server.userId)',
+  'Server patch ownership rejection',
+)
+
+requireText(
+  cypressSpec,
+  'does not let elevated credentials assign Server ownership on create',
+  'Server create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'does not let elevated credentials assign Server ownership in batches',
+  'Server batch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'does not let elevated credentials reassign Server ownership',
+  'Server patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'adminHeaders(adminToken)',
+  'Server elevated credential coverage',
+)
+
+console.log('Server mutation ownership contract passed.')


### PR DESCRIPTION
## Summary

- binds singular and batch Server creation to the authenticated user for ordinary and admin credentials
- removes admin authority to choose a persisted Server owner through request data
- prevents Server ownership reassignment during PATCH, including for admins
- preserves compatibility when existing callers redundantly send the matching authenticated/current owner ID
- keeps admin control of `isPublic`, `isOfficial`, and `isDefault` unchanged
- adds deployed coverage for elevated create, batch-create, and update spoofing
- adds a DB-free ownership contract and read-only PR workflow

## Why

The shared Server mutation builder still treated administrator credentials as permission to assign or reassign `userId` from request payloads. Authorization should control whether an elevated caller may create or edit a Server, but ownership must remain authentication-derived. This closes the same boundary already hardened for Dreams, Bots, Resources, and Prompts without weakening Server visibility or official/default administration.

## Checks

- Server Mutation Ownership
- TypeScript Type Check
- Contract Tests
