### PR TITLE
Enforce Reaction create input boundaries

### DIFF
--- a/.github/workflows/reaction-create-input-boundary.yml
+++ b/.github/workflows/reaction-create-input-boundary.yml
@@ -1,0 +1,36 @@
+name: Reaction Create Input Boundary
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/reactions/index.post.ts'
+      - 'cypress/e2e/api/reactions.cy.ts'
+      - 'utils/scripts/verifyReactionCreateInputBoundary.ts'
+      - '.github/workflows/reaction-create-input-boundary.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Reaction create input boundary
+        run: npx tsx utils/scripts/verifyReactionCreateInputBoundary.ts

--- a/cypress/e2e/api/reactions.cy.ts
+++ b/cypress/e2e/api/reactions.cy.ts
@@ -159,17 +159,63 @@ describe('Reaction Management API Tests', () => {
     })
   })
 
+  it('rejects spoofed Reaction ownership', () => {
+    expect(themeId).to.exist
+    expect(otherId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: reactionBaseUrl,
+      headers: ownerHeaders(),
+      body: {
+        userId: otherId,
+        reactionType: 'LOVED',
+        reactionCategory: 'THEME',
+        themeId,
+        rating: 5,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('rejects unsupported Reaction create fields', () => {
+    expect(themeId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: reactionBaseUrl,
+      headers: ownerHeaders(),
+      body: {
+        reactionType: 'LOVED',
+        reactionCategory: 'THEME',
+        themeId,
+        rating: 5,
+        createdAt: new Date().toISOString(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include(
+        'Unsupported Reaction create fields',
+      )
+    })
+  })
+
   it('creates a Reaction under the authenticated owner', () => {
     expect(themeId).to.exist
     expect(ownerId).to.exist
-    expect(otherId).to.exist
 
     cy.request<ApiResponse<ReactionRow>>({
       method: 'POST',
       url: reactionBaseUrl,
       headers: ownerHeaders(),
       body: {
-        userId: otherId,
+        userId: ownerId,
         reactionType: 'LOVED',
         reactionCategory: 'THEME',
         themeId,

--- a/server/api/reactions/index.post.ts
+++ b/server/api/reactions/index.post.ts
@@ -10,7 +10,7 @@ import {
   type Prisma,
 } from '~/prisma/generated/prisma/client'
 
-type ReactionBody = {
+type ReactionBody = Record<string, unknown> & {
   userId?: unknown
   reactionType?: unknown
   reactionCategory?: unknown
@@ -30,6 +30,27 @@ type ReactionBody = {
   scenarioId?: unknown
   themeId?: unknown
 }
+
+const REACTION_CREATE_FIELDS = new Set([
+  'userId',
+  'reactionType',
+  'reactionCategory',
+  'comment',
+  'rating',
+  'artImageId',
+  'artId',
+  'artCollectionId',
+  'botId',
+  'characterId',
+  'chatId',
+  'componentId',
+  'dreamId',
+  'promptId',
+  'resourceId',
+  'rewardId',
+  'scenarioId',
+  'themeId',
+])
 
 const validReactionTypes = Object.values(ReactionType)
 const validReactionCategories = Object.values(Reaction_reactionCategory)
@@ -54,6 +75,38 @@ const reactionCategoryAliases: Record<string, Reaction_reactionCategory> = {
   REWARD: Reaction_reactionCategory.REWARD,
   SCENARIO: Reaction_reactionCategory.SCENARIO,
   THEME: Reaction_reactionCategory.THEME,
+}
+
+function assertReactionCreateFields(body: ReactionBody): void {
+  const unsupportedFields = Object.keys(body).filter(
+    (field) => !REACTION_CREATE_FIELDS.has(field),
+  )
+
+  if (unsupportedFields.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Reaction create fields: ${unsupportedFields.join(', ')}. IDs, timestamps, and system fields are server-owned.`,
+    })
+  }
+}
+
+function assertReactionOwnershipMatchesAuthentication(
+  value: unknown,
+  authenticatedUserId: number,
+): void {
+  if (value === undefined) return
+
+  const requestedUserId = Number(value)
+
+  if (
+    !Number.isInteger(requestedUserId) ||
+    requestedUserId !== authenticatedUserId
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported Reaction ownership assignment. Ownership is server-owned.',
+    })
+  }
 }
 
 function normalizeReactionType(value: unknown): ReactionType {
@@ -331,6 +384,9 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    assertReactionCreateFields(body)
+    assertReactionOwnershipMatchesAuthentication(body.userId, user.id)
+
     const reactionType = normalizeReactionType(body.reactionType)
     const reactionCategory = normalizeReactionCategory(body.reactionCategory)
     const targets = getTargetFields(body)
@@ -400,6 +456,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: handledError.message || 'Failed to create/update reaction.',
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/utils/scripts/verifyReactionCreateInputBoundary.ts
+++ b/utils/scripts/verifyReactionCreateInputBoundary.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const createRoute = read('server/api/reactions/index.post.ts')
+const cypressSpec = read('cypress/e2e/api/reactions.cy.ts')
+
+requireText(
+  createRoute,
+  'const REACTION_CREATE_FIELDS = new Set([',
+  'Reaction create allowlist',
+)
+requireText(
+  createRoute,
+  "'artId',",
+  'Reaction legacy art target alias',
+)
+requireText(
+  createRoute,
+  'assertReactionCreateFields(body)',
+  'Reaction unsupported-field rejection',
+)
+requireText(
+  createRoute,
+  'assertReactionOwnershipMatchesAuthentication(body.userId, user.id)',
+  'Reaction ownership-match boundary',
+)
+requireText(
+  createRoute,
+  'userId: user.id',
+  'Reaction authenticated ownership write',
+)
+forbidText(
+  createRoute,
+  'userId: body.userId',
+  'Reaction payload ownership write',
+)
+forbidText(
+  createRoute,
+  'userId: requestedUserId',
+  'Reaction requested ownership write',
+)
+
+requireText(
+  cypressSpec,
+  'rejects spoofed Reaction ownership',
+  'Reaction ownership deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unsupported Reaction create fields',
+  'Reaction allowlist deployed regression',
+)
+requireText(
+  cypressSpec,
+  'creates a Reaction under the authenticated owner',
+  'Reaction valid create regression',
+)
+
+console.log('Reaction create input boundary contract passed.')


### PR DESCRIPTION
## Summary

- adds an explicit runtime allowlist for Reaction creation fields while retaining the legacy `artId` target alias
- rejects arbitrary IDs, timestamps, system fields, and other unknown payload keys
- rejects a supplied `userId` unless it matches the authenticated caller
- continues to persist and query Reaction ownership exclusively through authentication
- updates deployed Cypress coverage for spoofed ownership, unsupported fields, and a valid authenticated create
- adds a DB-free boundary contract and read-only PR workflow

## Why

Reaction creation was ownership-safe in persistence, but it silently ignored arbitrary payload fields and even a mismatched `userId`. That made malformed or stale clients look successful and obscured the API's real contract. This makes the boundary explicit without breaking the current store, which sends the matching authenticated ID.

## Checks

- Reaction Create Input Boundary
- TypeScript Type Check
- Contract Tests
