### PR TITLE
Enforce Dream mutation input parity

### DIFF
--- a/.github/workflows/dream-mutation-input-parity.yml
+++ b/.github/workflows/dream-mutation-input-parity.yml
@@ -1,0 +1,39 @@
+name: Dream Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/dreams/mutation.ts'
+      - 'server/api/dreams/index.post.ts'
+      - 'server/api/dreams/[id].patch.ts'
+      - 'server/api/dreams/batch.post.ts'
+      - 'cypress/e2e/api/dream-input-boundary.cy.ts'
+      - 'utils/scripts/verifyDreamMutationInputParity.ts'
+      - '.github/workflows/dream-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Dream mutation input parity
+        run: npx tsx utils/scripts/verifyDreamMutationInputParity.ts

--- a/cypress/e2e/api/dream-input-boundary.cy.ts
+++ b/cypress/e2e/api/dream-input-boundary.cy.ts
@@ -1,0 +1,243 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+type DreamRow = {
+  id: number
+  title: string
+  userId: number
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Dream mutation input boundary', () => {
+  const stamp = Date.now()
+  let apiBase = ''
+  let adminToken = ''
+  let userId: number | undefined
+  let userToken = ''
+  let dreamId: number | undefined
+
+  const dreamsUrl = () => `${apiBase}/dreams`
+  const headers = () => bearerHeaders(userToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((user) => {
+        userId = user.id
+        userToken = user.token
+      })
+  })
+
+  after(() => {
+    if (dreamId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${dreamsUrl()}/${dreamId}`,
+        headers: headers(),
+        failOnStatusCode: false,
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, userId)
+  })
+
+  it('rejects unknown and spoofed fields on singular Dream creation', () => {
+    expect(userId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: dreamsUrl(),
+      headers: headers(),
+      body: {
+        title: `Unknown Field Dream ${stamp}`,
+        createdAt: new Date().toISOString(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Dream fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: dreamsUrl(),
+      headers: headers(),
+      body: {
+        title: `Spoofed Owner Dream ${stamp}`,
+        userId: (userId ?? 0) + 1_000_000,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('rejects oversized and invalid relation arrays on Dream creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: dreamsUrl(),
+      headers: headers(),
+      body: {
+        title: `Oversized Relations Dream ${stamp}`,
+        characterIds: Array.from({ length: 101 }, (_, index) => index + 1),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: dreamsUrl(),
+      headers: headers(),
+      body: {
+        title: `Invalid Relations Dream ${stamp}`,
+        rewardIds: [1, 0],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('invalid ID at index 1')
+    })
+  })
+
+  it('keeps the current matching-owner store compatibility fields explicit', () => {
+    expect(userId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse<DreamRow>>({
+      method: 'POST',
+      url: dreamsUrl(),
+      headers: headers(),
+      body: {
+        title: `Dream Input Boundary Control ${stamp}`,
+        dreamType: 'PITCH',
+        creationSource: 'HUMAN',
+        userId,
+        tagIds: [],
+        promptIds: [],
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(userId)
+      dreamId = response.body.data?.id
+      expect(dreamId).to.be.a('number').and.greaterThan(0)
+    })
+  })
+
+  it('rejects unknown, mismatched ID, and oversized relation fields on PATCH', () => {
+    expect(dreamId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${dreamsUrl()}/${dreamId}`,
+      headers: headers(),
+      body: {
+        createdAt: new Date().toISOString(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Dream fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${dreamsUrl()}/${dreamId}`,
+      headers: headers(),
+      body: {
+        id: (dreamId ?? 0) + 1,
+        title: `Wrong Route Dream ${stamp}`,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('must match the route')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${dreamsUrl()}/${dreamId}`,
+      headers: headers(),
+      body: {
+        rewardIds: Array.from({ length: 101 }, (_, index) => index + 1),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+  })
+
+  it('applies the same strict boundary to Dream batches', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${dreamsUrl()}/batch`,
+      headers: headers(),
+      body: {
+        dreams: [{ title: `Batch Unknown Field Dream ${stamp}` }],
+        userId,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Dream batch fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${dreamsUrl()}/batch`,
+      headers: headers(),
+      body: [
+        {
+          title: `Batch Spoofed Owner Dream ${stamp}`,
+          userId,
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Dream fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${dreamsUrl()}/batch`,
+      headers: headers(),
+      body: Array.from({ length: 101 }, (_, index) => ({
+        title: `Oversized Dream Batch ${stamp}-${index}`,
+      })),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+  })
+})

--- a/server/api/dreams/[id].patch.ts
+++ b/server/api/dreams/[id].patch.ts
@@ -3,55 +3,26 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
-import type {
-  CreationSource,
-  DreamType,
-  Prisma,
-} from '~/prisma/generated/prisma/client'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import {
   assertDreamAccess,
-  dreamTypes,
   getDreamId,
   normalizeCreationSource,
-  normalizeIdArray,
-  normalizeNullableId,
   normalizeOptionalText,
   normalizeSlug,
   relationFromNullableId,
-  scenariosRelationFromPatch,
 } from './index'
+import {
+  assertDreamMutationInput,
+  boundedScenariosRelationFromPatch,
+  dreamPatchFields,
+  normalizeBoundedDreamIdArray,
+  normalizeBoundedDreamNullableId,
+  type DreamMutationBody,
+} from './mutation'
 import { dreamMutationSelect } from './selects'
 
-type DreamPatchBody = {
-  title?: string
-  slug?: string | null
-  dreamType?: DreamType
-  creationSource?: CreationSource
-  description?: string | null
-  pitch?: string | null
-  flavorText?: string | null
-  examples?: string | null
-  artPrompt?: string | null
-  imagePath?: string | null
-  cardPath?: string | null
-  heroPath?: string | null
-  highlightImage?: string | null
-  icon?: string | null
-  designer?: string | null
-  artImageId?: number | null
-  artCollectionId?: number | null
-  scenarioId?: number | null
-  scenarioIds?: number[]
-  Scenarios?: number[]
-  isPublic?: boolean
-  isMature?: boolean
-  isActive?: boolean
-  allowReviews?: boolean
-  characterIds?: number[]
-  rewardIds?: number[]
-  artImageIds?: number[]
-  artCollectionIds?: number[]
-}
+type DreamPatchBody = DreamMutationBody
 
 function uniqueIds(values: Array<number | null | undefined>): number[] {
   return Array.from(
@@ -64,9 +35,9 @@ function uniqueIds(values: Array<number | null | undefined>): number[] {
   )
 }
 
-function idsFromNullable(value: unknown): number[] {
-  const id = normalizeNullableId(value)
-  return id ? [id] : []
+function idsFromNullable(value: unknown, field: string): number[] {
+  const id = normalizeBoundedDreamNullableId(value, field)
+  return typeof id === 'number' ? [id] : []
 }
 
 function forbiddenRelationError(label: string) {
@@ -84,8 +55,8 @@ async function assertAttachableRelations(
   if (userRole === 'ADMIN') return
 
   const artImageIds = uniqueIds([
-    ...idsFromNullable(body.artImageId),
-    ...(normalizeIdArray(body.artImageIds) ?? []),
+    ...idsFromNullable(body.artImageId, 'artImageId'),
+    ...(normalizeBoundedDreamIdArray(body.artImageIds, 'artImageIds') ?? []),
   ])
 
   if (artImageIds.length) {
@@ -100,8 +71,11 @@ async function assertAttachableRelations(
   }
 
   const artCollectionIds = uniqueIds([
-    ...idsFromNullable(body.artCollectionId),
-    ...(normalizeIdArray(body.artCollectionIds) ?? []),
+    ...idsFromNullable(body.artCollectionId, 'artCollectionId'),
+    ...(normalizeBoundedDreamIdArray(
+      body.artCollectionIds,
+      'artCollectionIds',
+    ) ?? []),
   ])
 
   if (artCollectionIds.length) {
@@ -118,9 +92,9 @@ async function assertAttachableRelations(
   }
 
   const scenarioIds = uniqueIds([
-    ...idsFromNullable(body.scenarioId),
-    ...(normalizeIdArray(body.scenarioIds) ?? []),
-    ...(normalizeIdArray(body.Scenarios) ?? []),
+    ...idsFromNullable(body.scenarioId, 'scenarioId'),
+    ...(normalizeBoundedDreamIdArray(body.scenarioIds, 'scenarioIds') ?? []),
+    ...(normalizeBoundedDreamIdArray(body.Scenarios, 'Scenarios') ?? []),
   ])
 
   if (scenarioIds.length) {
@@ -134,7 +108,8 @@ async function assertAttachableRelations(
     if (count !== scenarioIds.length) throw forbiddenRelationError('Scenario')
   }
 
-  const characterIds = normalizeIdArray(body.characterIds) ?? []
+  const characterIds =
+    normalizeBoundedDreamIdArray(body.characterIds, 'characterIds') ?? []
 
   if (characterIds.length) {
     const count = await prisma.character.count({
@@ -147,7 +122,8 @@ async function assertAttachableRelations(
     if (count !== characterIds.length) throw forbiddenRelationError('Character')
   }
 
-  const rewardIds = normalizeIdArray(body.rewardIds) ?? []
+  const rewardIds =
+    normalizeBoundedDreamIdArray(body.rewardIds, 'rewardIds') ?? []
 
   if (rewardIds.length) {
     const count = await prisma.reward.count({
@@ -203,15 +179,17 @@ export default defineEventHandler(async (event) => {
       action: 'mutate',
     })
 
-    const body = await readBody<DreamPatchBody>(event)
+    const rawBody = await readBody<unknown>(event)
 
-    if (!body || Object.keys(body).length === 0) {
-      throw createError({
-        statusCode: 400,
-        message: 'No data provided for update.',
-      })
-    }
+    assertDreamMutationInput(rawBody, {
+      allowedFields: dreamPatchFields,
+      context: 'Dream patch payload',
+      authenticatedUserId: user.id,
+      routeId: id,
+      requireNonEmpty: true,
+    })
 
+    const body = rawBody
     await assertAttachableRelations(body, user.id, user.Role)
 
     const dataInput: Prisma.DreamUpdateInput = {}
@@ -233,7 +211,7 @@ export default defineEventHandler(async (event) => {
       dataInput.slug = body.slug ? normalizeSlug(body.slug) : null
     }
 
-    if (body.dreamType !== undefined && dreamTypes.includes(body.dreamType)) {
+    if (body.dreamType !== undefined) {
       dataInput.dreamType = body.dreamType
     }
 
@@ -295,7 +273,7 @@ export default defineEventHandler(async (event) => {
       if (relation) dataInput.ArtCollection = relation
     }
 
-    const scenariosRelation = scenariosRelationFromPatch(body)
+    const scenariosRelation = boundedScenariosRelationFromPatch(body)
 
     if (scenariosRelation) {
       dataInput.Scenarios = scenariosRelation
@@ -317,10 +295,22 @@ export default defineEventHandler(async (event) => {
       dataInput.allowReviews = body.allowReviews
     }
 
-    const characterIds = normalizeIdArray(body.characterIds)
-    const rewardIds = normalizeIdArray(body.rewardIds)
-    const artImageIds = normalizeIdArray(body.artImageIds)
-    const artCollectionIds = normalizeIdArray(body.artCollectionIds)
+    const characterIds = normalizeBoundedDreamIdArray(
+      body.characterIds,
+      'characterIds',
+    )
+    const rewardIds = normalizeBoundedDreamIdArray(
+      body.rewardIds,
+      'rewardIds',
+    )
+    const artImageIds = normalizeBoundedDreamIdArray(
+      body.artImageIds,
+      'artImageIds',
+    )
+    const artCollectionIds = normalizeBoundedDreamIdArray(
+      body.artCollectionIds,
+      'artCollectionIds',
+    )
 
     if (characterIds !== undefined) {
       dataInput.Characters = {
@@ -344,6 +334,13 @@ export default defineEventHandler(async (event) => {
       dataInput.ArtCollections = {
         set: artCollectionIds.map((collectionId) => ({ id: collectionId })),
       }
+    }
+
+    if (Object.keys(dataInput).length === 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'No valid Dream update fields provided.',
+      })
     }
 
     const data = await prisma.dream.update({

--- a/server/api/dreams/batch.post.ts
+++ b/server/api/dreams/batch.post.ts
@@ -3,91 +3,32 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
-import type {
-  CreationSource,
-  DreamType,
-  Prisma,
-} from '~/prisma/generated/prisma/client'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import {
   normalizeCreationSource,
   normalizeDreamType,
-  normalizeIdArray,
-  normalizeNullableId,
   normalizeOptionalText,
-  normalizeScenarioIds,
   normalizeSlug,
 } from './index'
+import {
+  assertDreamMutationInput,
+  dreamBatchCreateFields,
+  normalizeBoundedDreamIdArray,
+  normalizeBoundedDreamNullableId,
+  normalizeBoundedDreamScenarioIds,
+  type DreamMutationBody,
+} from './mutation'
 import {
   dreamMutationSelect,
   type DreamMutationResult,
 } from './selects'
 
-const dreamBatchCreateFields = new Set([
-  'title',
-  'slug',
-  'dreamType',
-  'creationSource',
-  'description',
-  'pitch',
-  'flavorText',
-  'examples',
-  'artPrompt',
-  'imagePath',
-  'cardPath',
-  'heroPath',
-  'highlightImage',
-  'icon',
-  'designer',
-  'allowReviews',
-  'artImageId',
-  'artCollectionId',
-  'scenarioId',
-  'scenarioIds',
-  'Scenarios',
-  'characterIds',
-  'rewardIds',
-  'artImageIds',
-  'artCollectionIds',
-  'isPublic',
-  'isMature',
-  'isActive',
-])
-
-type DreamMutationInput = Record<string, unknown> & {
-  title?: string
-  slug?: string | null
-  dreamType?: DreamType
-  creationSource?: CreationSource
-  description?: string | null
-  pitch?: string | null
-  flavorText?: string | null
-  examples?: string | null
-  artPrompt?: string | null
-  imagePath?: string | null
-  cardPath?: string | null
-  heroPath?: string | null
-  highlightImage?: string | null
-  icon?: string | null
-  designer?: string | null
-  allowReviews?: boolean
-  artImageId?: number | null
-  artCollectionId?: number | null
-  scenarioId?: number | null
-  scenarioIds?: number[]
-  Scenarios?: number[]
-  characterIds?: number[]
-  rewardIds?: number[]
-  artImageIds?: number[]
-  artCollectionIds?: number[]
-  isPublic?: boolean
-  isMature?: boolean
-  isActive?: boolean
-}
+const DREAM_BATCH_LIMIT = 100
 
 type DreamBatchBody =
-  | DreamMutationInput[]
+  | DreamMutationBody[]
   | {
-      dreams?: DreamMutationInput[]
+      dreams?: DreamMutationBody[]
     }
 
 type DreamBatchError = {
@@ -97,31 +38,30 @@ type DreamBatchError = {
   statusCode: number
 }
 
-function getDreamsFromBody(body: DreamBatchBody): DreamMutationInput[] {
-  if (Array.isArray(body)) return body
+function getDreamsFromBody(body: unknown): DreamMutationBody[] {
+  if (Array.isArray(body)) return body as DreamMutationBody[]
 
-  if (body && typeof body === 'object' && Array.isArray(body.dreams)) {
-    return body.dreams
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>
+    const unsupported = Object.keys(record).filter((field) => field !== 'dreams')
+
+    if (unsupported.length) {
+      throw createError({
+        statusCode: 400,
+        message: `Unsupported Dream batch fields: ${unsupported.join(', ')}.`,
+      })
+    }
+
+    if (Array.isArray(record.dreams)) {
+      return record.dreams as DreamMutationBody[]
+    }
   }
 
   return []
 }
 
-function assertSupportedFields(body: DreamMutationInput, index: number) {
-  const unsupported = Object.keys(body).filter(
-    (field) => !dreamBatchCreateFields.has(field),
-  )
-
-  if (unsupported.length > 0) {
-    throw createError({
-      statusCode: 400,
-      message: `Unsupported Dream fields at index ${index}: ${unsupported.join(', ')}. Ownership, IDs, and timestamps are server-owned.`,
-    })
-  }
-}
-
 async function createDreamFromInput(
-  body: DreamMutationInput,
+  body: DreamMutationBody,
   callerUserId: number,
   callerUsername: string | null | undefined,
 ): Promise<DreamMutationResult> {
@@ -137,13 +77,31 @@ async function createDreamFromInput(
   const slug = body.slug?.trim()
     ? normalizeSlug(body.slug)
     : normalizeSlug(title)
-  const artImageId = normalizeNullableId(body.artImageId)
-  const artCollectionId = normalizeNullableId(body.artCollectionId)
-  const scenarioIds = normalizeScenarioIds(body)
-  const characterIds = normalizeIdArray(body.characterIds)
-  const rewardIds = normalizeIdArray(body.rewardIds)
-  const artImageIds = normalizeIdArray(body.artImageIds)
-  const artCollectionIds = normalizeIdArray(body.artCollectionIds)
+  const artImageId = normalizeBoundedDreamNullableId(
+    body.artImageId,
+    'artImageId',
+  )
+  const artCollectionId = normalizeBoundedDreamNullableId(
+    body.artCollectionId,
+    'artCollectionId',
+  )
+  const scenarioIds = normalizeBoundedDreamScenarioIds(body)
+  const characterIds = normalizeBoundedDreamIdArray(
+    body.characterIds,
+    'characterIds',
+  )
+  const rewardIds = normalizeBoundedDreamIdArray(
+    body.rewardIds,
+    'rewardIds',
+  )
+  const artImageIds = normalizeBoundedDreamIdArray(
+    body.artImageIds,
+    'artImageIds',
+  )
+  const artCollectionIds = normalizeBoundedDreamIdArray(
+    body.artCollectionIds,
+    'artCollectionIds',
+  )
   const designer =
     normalizeOptionalText(body.designer) ||
     callerUsername ||
@@ -172,14 +130,14 @@ async function createDreamFromInput(
     User: {
       connect: { id: callerUserId },
     },
-    ...(artImageId
+    ...(typeof artImageId === 'number'
       ? {
           ArtImage: {
             connect: { id: artImageId },
           },
         }
       : {}),
-    ...(artCollectionId
+    ...(typeof artCollectionId === 'number'
       ? {
           ArtCollection: {
             connect: { id: artCollectionId },
@@ -250,19 +208,18 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    for (const [index, dreamData] of dreamsData.entries()) {
-      if (
-        !dreamData ||
-        typeof dreamData !== 'object' ||
-        Array.isArray(dreamData)
-      ) {
-        throw createError({
-          statusCode: 400,
-          message: `Invalid dream at index ${index}. Expected an object.`,
-        })
-      }
+    if (dreamsData.length > DREAM_BATCH_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `Dream batch may contain at most ${DREAM_BATCH_LIMIT} entries.`,
+      })
+    }
 
-      assertSupportedFields(dreamData, index)
+    for (const [index, dreamData] of dreamsData.entries()) {
+      assertDreamMutationInput(dreamData, {
+        allowedFields: dreamBatchCreateFields,
+        context: `Dream batch item ${index}`,
+      })
     }
 
     const userRecord = await prisma.user.findUnique({

--- a/server/api/dreams/index.post.ts
+++ b/server/api/dreams/index.post.ts
@@ -3,57 +3,34 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
-import type {
-  CreationSource,
-  DreamType,
-  Prisma,
-} from '~/prisma/generated/prisma/client'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import {
   normalizeCreationSource,
   normalizeDreamType,
-  normalizeIdArray,
-  normalizeNullableId,
   normalizeOptionalText,
-  normalizeScenarioIds,
   normalizeSlug,
 } from './index'
+import {
+  assertDreamMutationInput,
+  dreamCreateFields,
+  normalizeBoundedDreamIdArray,
+  normalizeBoundedDreamNullableId,
+  normalizeBoundedDreamScenarioIds,
+} from './mutation'
 import { dreamMutationSelect } from './selects'
-
-type DreamCreateBody = {
-  title?: string
-  slug?: string | null
-  dreamType?: DreamType
-  creationSource?: CreationSource
-  description?: string | null
-  pitch?: string | null
-  flavorText?: string | null
-  examples?: string | null
-  artPrompt?: string | null
-  imagePath?: string | null
-  cardPath?: string | null
-  heroPath?: string | null
-  highlightImage?: string | null
-  icon?: string | null
-  designer?: string | null
-  allowReviews?: boolean
-  artImageId?: number | null
-  artCollectionId?: number | null
-  scenarioId?: number | null
-  scenarioIds?: number[]
-  Scenarios?: number[]
-  characterIds?: number[]
-  rewardIds?: number[]
-  artImageIds?: number[]
-  artCollectionIds?: number[]
-  isPublic?: boolean
-  isMature?: boolean
-  isActive?: boolean
-}
 
 export default defineEventHandler(async (event) => {
   try {
     const { user } = await requireApiUser(event)
-    const body = await readBody<DreamCreateBody>(event)
+    const rawBody = await readBody<unknown>(event)
+
+    assertDreamMutationInput(rawBody, {
+      allowedFields: dreamCreateFields,
+      context: 'Dream create payload',
+      authenticatedUserId: user.id,
+    })
+
+    const body = rawBody
     const title = body.title?.trim()
 
     if (!title) {
@@ -67,13 +44,31 @@ export default defineEventHandler(async (event) => {
     const slug = body.slug?.trim()
       ? normalizeSlug(body.slug)
       : normalizeSlug(title)
-    const artImageId = normalizeNullableId(body.artImageId)
-    const artCollectionId = normalizeNullableId(body.artCollectionId)
-    const scenarioIds = normalizeScenarioIds(body)
-    const characterIds = normalizeIdArray(body.characterIds)
-    const rewardIds = normalizeIdArray(body.rewardIds)
-    const artImageIds = normalizeIdArray(body.artImageIds)
-    const artCollectionIds = normalizeIdArray(body.artCollectionIds)
+    const artImageId = normalizeBoundedDreamNullableId(
+      body.artImageId,
+      'artImageId',
+    )
+    const artCollectionId = normalizeBoundedDreamNullableId(
+      body.artCollectionId,
+      'artCollectionId',
+    )
+    const scenarioIds = normalizeBoundedDreamScenarioIds(body)
+    const characterIds = normalizeBoundedDreamIdArray(
+      body.characterIds,
+      'characterIds',
+    )
+    const rewardIds = normalizeBoundedDreamIdArray(
+      body.rewardIds,
+      'rewardIds',
+    )
+    const artImageIds = normalizeBoundedDreamIdArray(
+      body.artImageIds,
+      'artImageIds',
+    )
+    const artCollectionIds = normalizeBoundedDreamIdArray(
+      body.artCollectionIds,
+      'artCollectionIds',
+    )
 
     const dataInput: Prisma.DreamCreateInput = {
       title,
@@ -98,14 +93,14 @@ export default defineEventHandler(async (event) => {
       User: {
         connect: { id: user.id },
       },
-      ...(artImageId
+      ...(typeof artImageId === 'number'
         ? {
             ArtImage: {
               connect: { id: artImageId },
             },
           }
         : {}),
-      ...(artCollectionId
+      ...(typeof artCollectionId === 'number'
         ? {
             ArtCollection: {
               connect: { id: artCollectionId },

--- a/server/api/dreams/mutation.ts
+++ b/server/api/dreams/mutation.ts
@@ -1,0 +1,368 @@
+import { createError } from 'h3'
+import type {
+  CreationSource,
+  DreamType,
+  Prisma,
+} from '~/prisma/generated/prisma/client'
+import { creationSources, dreamTypes } from './index'
+
+export const DREAM_RELATION_ID_LIMIT = 100
+
+const persistedMutationFields = [
+  'title',
+  'slug',
+  'dreamType',
+  'creationSource',
+  'description',
+  'pitch',
+  'flavorText',
+  'examples',
+  'artPrompt',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'highlightImage',
+  'icon',
+  'designer',
+  'allowReviews',
+  'artImageId',
+  'artCollectionId',
+  'scenarioId',
+  'scenarioIds',
+  'Scenarios',
+  'characterIds',
+  'rewardIds',
+  'artImageIds',
+  'artCollectionIds',
+  'isPublic',
+  'isMature',
+  'isActive',
+] as const
+
+// The singular store still sends matching userId plus legacy tag/prompt arrays.
+// They are validated and ignored until the client compatibility stage is removed.
+const compatibilityFields = ['userId', 'tagIds', 'promptIds'] as const
+
+export const dreamCreateFields = new Set<string>([
+  ...persistedMutationFields,
+  ...compatibilityFields,
+])
+
+export const dreamPatchFields = new Set<string>([
+  ...persistedMutationFields,
+  ...compatibilityFields,
+  'id',
+])
+
+export const dreamBatchCreateFields = new Set<string>(persistedMutationFields)
+
+export type DreamMutationBody = Record<string, unknown> & {
+  id?: number
+  userId?: number
+  title?: string
+  slug?: string | null
+  dreamType?: DreamType
+  creationSource?: CreationSource
+  description?: string | null
+  pitch?: string | null
+  flavorText?: string | null
+  examples?: string | null
+  artPrompt?: string | null
+  imagePath?: string | null
+  cardPath?: string | null
+  heroPath?: string | null
+  highlightImage?: string | null
+  icon?: string | null
+  designer?: string | null
+  allowReviews?: boolean
+  artImageId?: number | null
+  artCollectionId?: number | null
+  scenarioId?: number | null
+  scenarioIds?: number[]
+  Scenarios?: Array<number | { id: number }>
+  characterIds?: number[]
+  rewardIds?: number[]
+  artImageIds?: number[]
+  artCollectionIds?: number[]
+  tagIds?: number[]
+  promptIds?: number[]
+  isPublic?: boolean
+  isMature?: boolean
+  isActive?: boolean
+}
+
+type DreamMutationBoundaryOptions = {
+  allowedFields: ReadonlySet<string>
+  context: string
+  authenticatedUserId?: number
+  routeId?: number
+  requireNonEmpty?: boolean
+}
+
+const optionalTextFields = [
+  'description',
+  'pitch',
+  'flavorText',
+  'examples',
+  'artPrompt',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'highlightImage',
+  'icon',
+  'designer',
+] as const
+
+const booleanFields = [
+  'allowReviews',
+  'isPublic',
+  'isMature',
+  'isActive',
+] as const
+
+const relationArrayFields = [
+  'scenarioIds',
+  'Scenarios',
+  'characterIds',
+  'rewardIds',
+  'artImageIds',
+  'artCollectionIds',
+  'tagIds',
+  'promptIds',
+] as const
+
+function positiveInteger(value: unknown, field: string): number {
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `Dream field "${field}" must be a positive integer.`,
+    })
+  }
+
+  return parsed
+}
+
+export function normalizeBoundedDreamNullableId(
+  value: unknown,
+  field: string,
+): number | null | undefined {
+  if (value === null) return null
+  if (value === undefined || value === '') return undefined
+  return positiveInteger(value, field)
+}
+
+export function normalizeBoundedDreamIdArray(
+  value: unknown,
+  field: string,
+): number[] | undefined {
+  if (value === undefined) return undefined
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `Dream field "${field}" must be an array.`,
+    })
+  }
+
+  if (value.length > DREAM_RELATION_ID_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `Dream field "${field}" may contain at most ${DREAM_RELATION_ID_LIMIT} entries.`,
+    })
+  }
+
+  const ids = value.map((entry, index) => {
+    const candidate =
+      entry && typeof entry === 'object' && 'id' in entry
+        ? (entry as { id?: unknown }).id
+        : entry
+
+    try {
+      return positiveInteger(candidate, `${field}[${index}]`)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: `Dream field "${field}" contains an invalid ID at index ${index}.`,
+      })
+    }
+  })
+
+  return Array.from(new Set(ids))
+}
+
+export function normalizeBoundedDreamScenarioIds(
+  body: DreamMutationBody,
+): number[] | undefined {
+  if (body.scenarioIds !== undefined) {
+    return normalizeBoundedDreamIdArray(body.scenarioIds, 'scenarioIds')
+  }
+
+  if (body.Scenarios !== undefined) {
+    return normalizeBoundedDreamIdArray(body.Scenarios, 'Scenarios')
+  }
+
+  const scenarioId = normalizeBoundedDreamNullableId(
+    body.scenarioId,
+    'scenarioId',
+  )
+
+  return typeof scenarioId === 'number' ? [scenarioId] : undefined
+}
+
+export function boundedScenariosRelationFromPatch(
+  body: DreamMutationBody,
+): Prisma.ScenarioUpdateManyWithoutDreamsNestedInput | undefined {
+  if (body.scenarioIds !== undefined) {
+    const ids = normalizeBoundedDreamIdArray(body.scenarioIds, 'scenarioIds') ?? []
+    return { set: ids.map((id) => ({ id })) }
+  }
+
+  if (body.Scenarios !== undefined) {
+    const ids = normalizeBoundedDreamIdArray(body.Scenarios, 'Scenarios') ?? []
+    return { set: ids.map((id) => ({ id })) }
+  }
+
+  if (body.scenarioId === undefined) return undefined
+
+  const scenarioId = normalizeBoundedDreamNullableId(
+    body.scenarioId,
+    'scenarioId',
+  )
+
+  if (scenarioId === null) return { set: [] }
+  if (scenarioId) return { set: [{ id: scenarioId }] }
+  return undefined
+}
+
+function assertOptionalText(body: DreamMutationBody, field: string): void {
+  const value = body[field]
+  if (value === undefined || value === null) return
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `Dream field "${field}" must be a string or null.`,
+    })
+  }
+}
+
+export function assertDreamMutationInput(
+  body: unknown,
+  options: DreamMutationBoundaryOptions,
+): asserts body is DreamMutationBody {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.context} must be a JSON object.`,
+    })
+  }
+
+  const input = body as DreamMutationBody
+  const fields = Object.keys(input)
+
+  if (options.requireNonEmpty && fields.length === 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'No data provided for update.',
+    })
+  }
+
+  const unsupported = fields.filter(
+    (field) => !options.allowedFields.has(field),
+  )
+
+  if (unsupported.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Dream fields in ${options.context}: ${unsupported.join(', ')}. IDs, timestamps, identity, and system fields are server-owned.`,
+    })
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'userId')) {
+    if (!options.authenticatedUserId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Dream ownership is server-owned.',
+      })
+    }
+
+    const requestedUserId = positiveInteger(input.userId, 'userId')
+    if (requestedUserId !== options.authenticatedUserId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Unsupported Dream ownership assignment. Ownership is server-owned.',
+      })
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'id')) {
+    const requestedId = positiveInteger(input.id, 'id')
+    if (!options.routeId || requestedId !== options.routeId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Dream ID is immutable and must match the route.',
+      })
+    }
+  }
+
+  if (input.title !== undefined && typeof input.title !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: 'Dream field "title" must be a string.',
+    })
+  }
+
+  if (
+    input.slug !== undefined &&
+    input.slug !== null &&
+    typeof input.slug !== 'string'
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Dream field "slug" must be a string or null.',
+    })
+  }
+
+  for (const field of optionalTextFields) assertOptionalText(input, field)
+
+  if (
+    input.dreamType !== undefined &&
+    !dreamTypes.includes(input.dreamType as DreamType)
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: `Dream field "dreamType" must be one of: ${dreamTypes.join(', ')}.`,
+    })
+  }
+
+  if (
+    input.creationSource !== undefined &&
+    !creationSources.includes(input.creationSource as CreationSource)
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: `Dream field "creationSource" must be one of: ${creationSources.join(', ')}.`,
+    })
+  }
+
+  for (const field of booleanFields) {
+    if (input[field] !== undefined && typeof input[field] !== 'boolean') {
+      throw createError({
+        statusCode: 400,
+        message: `Dream field "${field}" must be a boolean.`,
+      })
+    }
+  }
+
+  normalizeBoundedDreamNullableId(input.artImageId, 'artImageId')
+  normalizeBoundedDreamNullableId(input.artCollectionId, 'artCollectionId')
+  normalizeBoundedDreamNullableId(input.scenarioId, 'scenarioId')
+
+  for (const field of relationArrayFields) {
+    if (input[field] !== undefined) {
+      normalizeBoundedDreamIdArray(input[field], field)
+    }
+  }
+}

--- a/utils/scripts/verifyDreamBatchOwnership.ts
+++ b/utils/scripts/verifyDreamBatchOwnership.ts
@@ -1,17 +1,35 @@
 import { readFileSync } from 'node:fs'
 import { strict as assert } from 'node:assert'
 
-const source = readFileSync('server/api/dreams/batch.post.ts', 'utf8')
+const batchSource = readFileSync('server/api/dreams/batch.post.ts', 'utf8')
+const boundarySource = readFileSync('server/api/dreams/mutation.ts', 'utf8')
 
-assert(!source.includes('userId?: number'), 'Dream batch input must not accept userId')
-assert(!source.includes('callerIsAdmin'), 'Dream batch ownership must not branch on admin status')
-assert(!source.includes('body.userId'), 'Dream batch must not read ownership from request data')
 assert(
-  source.includes('connect: { id: callerUserId }'),
+  !batchSource.includes('callerIsAdmin'),
+  'Dream batch ownership must not branch on admin status',
+)
+assert(
+  !batchSource.includes('body.userId'),
+  'Dream batch must not read ownership from request data',
+)
+assert(
+  batchSource.includes('connect: { id: callerUserId }'),
   'Dream batch must connect every created Dream to the authenticated caller',
 )
 assert(
-  source.includes('Ownership, IDs, and timestamps are server-owned.'),
+  batchSource.includes('allowedFields: dreamBatchCreateFields'),
+  'Dream batch must enforce the shared strict create field set',
+)
+assert(
+  boundarySource.includes(
+    'export const dreamBatchCreateFields = new Set<string>(persistedMutationFields)',
+  ),
+  'Dream batch field set must exclude singular compatibility identity fields',
+)
+assert(
+  boundarySource.includes(
+    'IDs, timestamps, identity, and system fields are server-owned.',
+  ),
   'Dream batch must reject unsupported server-owned fields explicitly',
 )
 

--- a/utils/scripts/verifyDreamMutationInputParity.ts
+++ b/utils/scripts/verifyDreamMutationInputParity.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/api/dreams/mutation.ts')
+const createRoute = read('server/api/dreams/index.post.ts')
+const patchRoute = read('server/api/dreams/[id].patch.ts')
+const batchRoute = read('server/api/dreams/batch.post.ts')
+const cypressSpec = read('cypress/e2e/api/dream-input-boundary.cy.ts')
+
+requireText(
+  boundary,
+  'export const DREAM_RELATION_ID_LIMIT = 100',
+  'Dream relation bound',
+)
+requireText(
+  boundary,
+  "const compatibilityFields = ['userId', 'tagIds', 'promptIds']",
+  'Dream compatibility stage',
+)
+requireText(
+  boundary,
+  'export const dreamBatchCreateFields',
+  'Dream batch strict field set',
+)
+requireText(
+  boundary,
+  'assertDreamMutationInput(',
+  'Dream shared input boundary',
+)
+requireText(
+  boundary,
+  'Unsupported Dream ownership assignment. Ownership is server-owned.',
+  'Dream ownership-match boundary',
+)
+requireText(
+  boundary,
+  'Dream ID is immutable and must match the route.',
+  'Dream route ID boundary',
+)
+requireText(
+  boundary,
+  'may contain at most ${DREAM_RELATION_ID_LIMIT} entries',
+  'Dream relation array cap',
+)
+requireText(
+  boundary,
+  'contains an invalid ID at index ${index}',
+  'Dream invalid relation rejection',
+)
+
+requireText(
+  createRoute,
+  'allowedFields: dreamCreateFields',
+  'Dream singular create boundary',
+)
+requireText(
+  createRoute,
+  'normalizeBoundedDreamIdArray(',
+  'Dream singular relation normalization',
+)
+requireText(
+  patchRoute,
+  'allowedFields: dreamPatchFields',
+  'Dream patch boundary',
+)
+requireText(
+  patchRoute,
+  'routeId: id',
+  'Dream patch immutable ID check',
+)
+requireText(
+  patchRoute,
+  'No valid Dream update fields provided.',
+  'Dream patch compatibility-only rejection',
+)
+requireText(
+  batchRoute,
+  'const DREAM_BATCH_LIMIT = 100',
+  'Dream batch cap',
+)
+requireText(
+  batchRoute,
+  'allowedFields: dreamBatchCreateFields',
+  'Dream batch item boundary',
+)
+forbidText(
+  batchRoute,
+  'const dreamBatchCreateFields = new Set([',
+  'Dream duplicate batch allowlist',
+)
+
+requireText(
+  cypressSpec,
+  'rejects unknown and spoofed fields on singular Dream creation',
+  'Dream singular deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown, mismatched ID, and oversized relation fields on PATCH',
+  'Dream patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'applies the same strict boundary to Dream batches',
+  'Dream batch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'keeps the current matching-owner store compatibility fields explicit',
+  'Dream compatibility deployed regression',
+)
+
+console.log('Dream mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

- adds one shared runtime mutation boundary across singular Dream create, Dream update, and batch create
- rejects unknown IDs, timestamps, identity, system fields, invalid enums, invalid booleans, and malformed relation values instead of silently ignoring them
- validates singular-store compatibility fields (`userId`, `tagIds`, and `promptIds`) explicitly while keeping ownership authentication-derived
- requires a PATCH body `id`, when supplied by the existing store, to match the route ID
- caps each relation array at 100 entries and rejects invalid IDs with their offending index
- caps Dream batches at 100 entries and validates the outer wrapper separately
- preserves the documented `207` partial-success behavior for validly shaped batch items that fail during creation
- adds deployed create/PATCH/batch regressions plus a DB-free parity contract and read-only workflow

## Why

The Dream routes had drifted: batch create rejected unknown fields, while singular create and PATCH silently accepted them; relation normalizers discarded invalid IDs and had no size bound; and the current store still sent compatibility-only fields. This makes the contract explicit and consistent without breaking the current UI compatibility stage.

## Checks

- Dream Mutation Input Parity
- TypeScript Type Check
- Contract Tests
