### PR TITLE
Verify canonical Component responses in production audit

### DIFF
--- a/.github/workflows/wonderlab-production-rollout.yml
+++ b/.github/workflows/wonderlab-production-rollout.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - '.github/workflows/wonderlab-production-rollout.yml'
       - 'scripts/wonderlab-production-rollout.mjs'
+      - 'scripts/wonderlab-production-component-contract.mjs'
   push:
     branches: [main]
     paths:
       - '.github/workflows/wonderlab-production-rollout.yml'
       - 'scripts/wonderlab-production-rollout.mjs'
+      - 'scripts/wonderlab-production-component-contract.mjs'
   workflow_dispatch:
     inputs:
       apply:
@@ -43,14 +45,19 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Check rollout script syntax and safety boundary
+      - name: Check rollout scripts and safety boundaries
         run: |
           set -euo pipefail
           node --check scripts/wonderlab-production-rollout.mjs
+          node --check scripts/wonderlab-production-component-contract.mjs
           node <<'NODE'
           const fs = require('node:fs')
           const assert = require('node:assert').strict
           const source = fs.readFileSync('scripts/wonderlab-production-rollout.mjs', 'utf8')
+          const componentContract = fs.readFileSync(
+            'scripts/wonderlab-production-component-contract.mjs',
+            'utf8',
+          )
 
           const requiredEndpoints = [
             ['/wonderlab-components.json'],
@@ -85,6 +92,27 @@ jobs:
           assert.match(source, /record\.isDiscovered !== true/)
           assert.match(source, /!record\.sourceKey/)
           assert.match(source, /!record\.sourcePath/)
+
+          for (const required of [
+            '/api/components',
+            'UNREVIEWED',
+            'PREVIEW_UNSUPPORTED',
+            'isWorking',
+            'underConstruction',
+            'isBroken',
+            'sourceKey',
+            'sourcePath',
+            'sourceHash',
+            'component-contract-verification.json',
+          ]) {
+            assert.ok(
+              componentContract.includes(required),
+              `missing Component contract check: ${required}`,
+            )
+          }
+          assert.doesNotMatch(componentContract, /method\s*:/)
+          assert.doesNotMatch(componentContract, /WONDERLAB_ADMIN_TOKEN|x-api-key|x-admin-token/)
+          assert.doesNotMatch(componentContract, /\/reconcile|\/publish|\/generate|\/approve/)
           console.log('WonderLab production rollout safety contract passed.')
           NODE
 
@@ -145,6 +173,12 @@ jobs:
           echo "Production prerequisites are ready at commit $(printf '%s' "$version" | jq -r '.data.commit')."
           echo "Live manifest contains $(printf '%s' "$manifest" | jq -r '.count') Components."
 
+      - name: Verify canonical Component API contract
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ROLLOUT_OUTPUT: wonderlab-rollout-artifacts
+        run: node scripts/wonderlab-production-component-contract.mjs
+
       - name: Reconcile canonical Component registry and run rollout audit
         env:
           WONDERLAB_BASE_URL: https://kind-robots.vercel.app
@@ -190,6 +224,7 @@ jobs:
             }
 
             const productionVersion = readJson('production-version.json')
+            const componentContract = readJson('component-contract-verification.json')
             const summary = readJson('rollout-summary.json')
             const dryRun = readJson('reconcile-dry-run.json')
             const apply = readJson('reconcile-apply.json')
@@ -212,6 +247,11 @@ jobs:
               `- **Production base:** ${summary?.baseUrl || 'https://kind-robots.vercel.app'}`,
             ]
 
+            if (componentContract) {
+              lines.push(
+                `- **Component API contract:** ${componentContract.recordCount || 0} records; ${componentContract.invalidStatusCount || 0} invalid statuses; ${componentContract.retiredFieldExposureCount || 0} retired-field exposures; ${componentContract.incompleteDiscoveredCount || 0} incomplete discovered identities`,
+              )
+            }
             if (drySummary) {
               lines.push(
                 `- **Reconciliation dry run:** ${drySummary.creates || 0} creates, ${drySummary.updates || 0} updates, ${drySummary.unchanged || 0} unchanged, ${drySummary.missingFromManifest || 0} database-only, ${drySummary.conflicts || 0} conflicts`,
@@ -244,7 +284,7 @@ jobs:
             lines.push('', '_Automated evidence report; no review generation, approval, or publication occurs in this workflow._')
 
             const body = lines.join('\n')
-            for (const issue_number of [381, 472]) {
+            for (const issue_number of [381, 472, 473]) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -268,13 +308,16 @@ jobs:
               `1. Verify \`/api/version\` still reports \`${liveCommit}\` or a newer descendant.`,
               '2. Read #381, #472, and #473 before changing rollout behavior.',
               process.env.WONDERLAB_ROLLOUT_APPLY === '1'
-                ? '3. If this apply succeeded, proceed to representative Dotti/Catbot draft generation, curator approval, publication, and desktop/mobile acceptance.'
-                : '3. Do not run an apply until production contains PR #527 (`5fa25cdb67f0d3dacad3b6eceb2e4bdd1de2088d`) or a descendant.',
+                ? '3. If this apply succeeded, continue with any remaining desktop/mobile acceptance and post-rollout cleanup.'
+                : '3. This run is read-only. Use `[wonderlab-rollout]` only when an explicitly reviewed reconciliation apply is required.',
               '4. Use `[wonderlab-audit]` for a read-only refresh; use `[wonderlab-rollout]` only for the conflict-gated write rollout.',
               '5. Neither trigger generates, approves, or publishes personality reviews.',
               '',
               '## Current machine checks',
               '',
+              `- Component API contract available: ${componentContract ? 'yes' : 'no'}`,
+              `- Component retired-field exposures: ${componentContract?.retiredFieldExposureCount ?? 'unknown'}`,
+              `- Component invalid statuses: ${componentContract?.invalidStatusCount ?? 'unknown'}`,
               `- Audit ready: ${auditData?.ready === true ? 'yes' : 'no'}`,
               `- Blocked audit checks: ${blockedChecks.join(', ') || 'none reported'}`,
               `- Reconciliation conflicts: ${drySummary?.conflicts ?? 'unknown'}`,

--- a/scripts/wonderlab-production-component-contract.mjs
+++ b/scripts/wonderlab-production-component-contract.mjs
@@ -1,0 +1,110 @@
+// /scripts/wonderlab-production-component-contract.mjs
+import { mkdir, writeFile } from 'node:fs/promises'
+
+const baseUrl = String(
+  process.env.WONDERLAB_BASE_URL ||
+    process.env.BASE_URL ||
+    'https://kind-robots.vercel.app',
+).replace(/\/$/, '')
+const outputDir =
+  process.env.WONDERLAB_ROLLOUT_OUTPUT ||
+  process.env.OUTPUT_DIR ||
+  'wonderlab-rollout-artifacts'
+
+const canonicalStatuses = new Set([
+  'UNREVIEWED',
+  'WORKING',
+  'NEEDS_CONTEXT',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+  'RETIRED',
+  'PREVIEW_UNSUPPORTED',
+])
+const retiredFields = ['isWorking', 'underConstruction', 'isBroken']
+
+await mkdir(outputDir, { recursive: true })
+
+const response = await fetch(`${baseUrl}/api/components`, {
+  headers: { accept: 'application/json' },
+  redirect: 'follow',
+})
+const text = await response.text()
+let payload
+try {
+  payload = text ? JSON.parse(text) : null
+} catch {
+  payload = { raw: text }
+}
+
+if (!response.ok) {
+  throw new Error(`GET /api/components returned ${response.status}.`)
+}
+if (!payload?.success || !Array.isArray(payload.data)) {
+  throw new Error('Production Component API did not return a successful data array.')
+}
+
+const statusCounts = Object.fromEntries(
+  [...canonicalStatuses].map((status) => [status, 0]),
+)
+const invalidStatusRows = []
+const retiredFieldRows = []
+const incompleteDiscoveredRows = []
+let discoveredCount = 0
+
+for (const record of payload.data) {
+  const id = Number(record?.id)
+  const status = record?.status
+
+  if (!canonicalStatuses.has(status)) {
+    invalidStatusRows.push({ id, status: status ?? null })
+  } else {
+    statusCounts[status] += 1
+  }
+
+  const exposedRetiredFields = retiredFields.filter((field) =>
+    Object.prototype.hasOwnProperty.call(record, field),
+  )
+  if (exposedRetiredFields.length) {
+    retiredFieldRows.push({ id, fields: exposedRetiredFields })
+  }
+
+  if (record?.isDiscovered === true) {
+    discoveredCount += 1
+    const missing = ['sourceKey', 'sourcePath', 'sourceHash'].filter(
+      (field) => typeof record[field] !== 'string' || record[field].trim() === '',
+    )
+    if (missing.length) incompleteDiscoveredRows.push({ id, missing })
+  }
+}
+
+const report = {
+  baseUrl,
+  checkedAt: new Date().toISOString(),
+  recordCount: payload.data.length,
+  discoveredCount,
+  databaseOnlyCount: payload.data.length - discoveredCount,
+  statusCounts,
+  invalidStatusCount: invalidStatusRows.length,
+  retiredFieldExposureCount: retiredFieldRows.length,
+  incompleteDiscoveredCount: incompleteDiscoveredRows.length,
+  invalidStatusRows,
+  retiredFieldRows,
+  incompleteDiscoveredRows,
+}
+
+await writeFile(
+  `${outputDir}/component-contract-verification.json`,
+  `${JSON.stringify(report, null, 2)}\n`,
+)
+
+if (
+  report.invalidStatusCount ||
+  report.retiredFieldExposureCount ||
+  report.incompleteDiscoveredCount
+) {
+  throw new Error(
+    `Production Component contract failed: ${report.invalidStatusCount} invalid statuses, ${report.retiredFieldExposureCount} retired-field exposures, ${report.incompleteDiscoveredCount} incomplete discovered identities.`,
+  )
+}
+
+console.log('[wonderlab-component-contract] Verified:', report)

--- a/scripts/wonderlab-production-component-contract.mjs
+++ b/scripts/wonderlab-production-component-contract.mjs
@@ -27,6 +27,7 @@ await mkdir(outputDir, { recursive: true })
 const response = await fetch(`${baseUrl}/api/components`, {
   headers: { accept: 'application/json' },
   redirect: 'follow',
+  signal: AbortSignal.timeout(30_000),
 })
 const text = await response.text()
 let payload

--- a/utils/scripts/verifyWonderLabReviewRolloutAudit.ts
+++ b/utils/scripts/verifyWonderLabReviewRolloutAudit.ts
@@ -6,11 +6,19 @@ const auditPath = 'server/utils/wonderLabReviewRolloutAudit.ts'
 const endpointPath = 'server/api/admin/wonderlab/review-rollout.get.ts'
 const pagePath = 'pages/admin/wonderlab-review-rollout.vue'
 const runbookPath = 'docs/wonderlab-personality-review-rollout.md'
+const productionWorkflowPath = '.github/workflows/wonderlab-production-rollout.yml'
+const componentContractPath =
+  'scripts/wonderlab-production-component-contract.mjs'
 
-const audit = await readFile(auditPath, 'utf8')
-const endpoint = await readFile(endpointPath, 'utf8')
-const page = await readFile(pagePath, 'utf8')
-const runbook = await readFile(runbookPath, 'utf8')
+const [audit, endpoint, page, runbook, productionWorkflow, componentContract] =
+  await Promise.all([
+    readFile(auditPath, 'utf8'),
+    readFile(endpointPath, 'utf8'),
+    readFile(pagePath, 'utf8'),
+    readFile(runbookPath, 'utf8'),
+    readFile(productionWorkflowPath, 'utf8'),
+    readFile(componentContractPath, 'utf8'),
+  ])
 
 assert.match(endpoint, /requireAdminApiUser\(event\)/)
 assert.match(endpoint, /auditWonderLabReviewRollout/)
@@ -41,5 +49,46 @@ assert.match(runbook, /Only an `APPROVED` draft can be published/)
 assert.match(runbook, /Do not manually edit `_prisma_migrations`/)
 assert.match(runbook, /Dotti/)
 assert.match(runbook, /Catbot/)
+
+assert.match(
+  productionWorkflow,
+  /Verify canonical Component API contract[\s\S]*wonderlab-production-component-contract\.mjs/,
+)
+assert.match(
+  productionWorkflow,
+  /component-contract-verification\.json/,
+)
+assert.match(productionWorkflow, /for \(const issue_number of \[381, 472, 473\]\)/)
+
+for (const status of [
+  'UNREVIEWED',
+  'WORKING',
+  'NEEDS_CONTEXT',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+  'RETIRED',
+  'PREVIEW_UNSUPPORTED',
+]) {
+  assert.match(componentContract, new RegExp(status))
+}
+for (const retiredField of [
+  'isWorking',
+  'underConstruction',
+  'isBroken',
+]) {
+  assert.match(componentContract, new RegExp(retiredField))
+}
+for (const sourceField of ['sourceKey', 'sourcePath', 'sourceHash']) {
+  assert.match(componentContract, new RegExp(sourceField))
+}
+assert.match(componentContract, /\/api\/components/)
+assert.match(componentContract, /component-contract-verification\.json/)
+assert.match(componentContract, /Object\.prototype\.hasOwnProperty\.call/)
+assert.doesNotMatch(componentContract, /method\s*:/)
+assert.doesNotMatch(
+  componentContract,
+  /WONDERLAB_ADMIN_TOKEN|x-api-key|x-admin-token/,
+)
+assert.doesNotMatch(componentContract, /\/reconcile|\/publish|\/generate|\/approve/)
 
 console.log('WonderLab review rollout audit contract passed.')


### PR DESCRIPTION
## Summary

Strengthen the existing WonderLab production audit with an explicit public Component API contract check.

The new read-only checker fails the audit when production exposes:

- a status outside the seven canonical `ComponentStatus` values;
- any retired `isWorking`, `underConstruction`, or `isBroken` field;
- a currently discovered Component missing `sourceKey`, `sourcePath`, or `sourceHash`.

It writes `component-contract-verification.json` into the existing rollout artifact directory. The durable report and handoff now include these metrics and post evidence to #381, #472, and #473.

## Safety

- GET `/api/components` only;
- no administrator token;
- no reconciliation, generation, approval, publication, or database access;
- existing reconciliation and personality audit behavior remains unchanged;
- permanent contract coverage verifies the read-only boundary.

The merge commit will use `[wonderlab-audit]` to trigger a read-only production evidence refresh.