### PR TITLE
Enforce Scenario mutation input parity

### DIFF
--- a/.github/workflows/scenario-mutation-input-parity.yml
+++ b/.github/workflows/scenario-mutation-input-parity.yml
@@ -1,0 +1,41 @@
+name: Scenario Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/scenarios/mutation.ts'
+      - 'server/api/scenarios/create.ts'
+      - 'server/api/scenarios/index.post.ts'
+      - 'server/api/scenarios/[id].patch.ts'
+      - 'server/api/scenarios/batch.post.ts'
+      - 'server/api/scenarios/batch.patch.ts'
+      - 'cypress/e2e/api/scenario-input-boundary.cy.ts'
+      - 'utils/scripts/verifyScenarioMutationInputParity.ts'
+      - '.github/workflows/scenario-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Scenario mutation input parity
+        run: npx tsx utils/scripts/verifyScenarioMutationInputParity.ts

--- a/cypress/e2e/api/scenario-input-boundary.cy.ts
+++ b/cypress/e2e/api/scenario-input-boundary.cy.ts
@@ -1,0 +1,272 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+type ScenarioRow = {
+  id: number
+  title: string
+  userId: number
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Scenario mutation input boundary', () => {
+  const stamp = Date.now()
+  let apiBase = ''
+  let adminToken = ''
+  let userId: number | undefined
+  let userToken = ''
+  let scenarioId: number | undefined
+
+  const scenariosUrl = () => `${apiBase}/scenarios`
+  const headers = () => bearerHeaders(userToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((user) => {
+        userId = user.id
+        userToken = user.token
+      })
+  })
+
+  after(() => {
+    if (scenarioId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${scenariosUrl()}/${scenarioId}`,
+        headers: headers(),
+        failOnStatusCode: false,
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, userId)
+  })
+
+  it('rejects unknown and spoofed fields on singular Scenario creation', () => {
+    expect(userId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        title: `Unknown Scenario Field ${stamp}`,
+        serverId: 1,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Scenario fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        title: `Spoofed Scenario Owner ${stamp}`,
+        userId: (userId ?? 0) + 1_000_000,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('rejects malformed enums, booleans, and relation arrays', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        title: `Invalid Scenario Enum ${stamp}`,
+        outputType: 'BANANA',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('outputType')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        title: `Invalid Scenario Boolean ${stamp}`,
+        isPublic: 'yes',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('isPublic')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        title: `Oversized Scenario Relations ${stamp}`,
+        dreamIds: Array.from({ length: 101 }, (_, index) => index + 1),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        title: `Invalid Scenario Relations ${stamp}`,
+        characterIds: [1, 0],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('invalid ID at index 1')
+    })
+  })
+
+  it('keeps singular ScenarioStore compatibility explicit and auth-bound', () => {
+    expect(userId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse<ScenarioRow>>({
+      method: 'POST',
+      url: scenariosUrl(),
+      headers: headers(),
+      body: {
+        id: -1,
+        userId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        title: `Scenario Boundary Control ${stamp}`,
+        outputType: 'STORY',
+        intros: ['A strict but compatible opening.'],
+        dreamIds: [],
+        characterIds: [],
+        facetIds: [],
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(userId)
+      scenarioId = response.body.data?.id
+      expect(scenarioId).to.be.a('number').and.greaterThan(0)
+    })
+  })
+
+  it('rejects unknown, mismatched ID, and oversized PATCH fields', () => {
+    expect(scenarioId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${scenariosUrl()}/${scenarioId}`,
+      headers: headers(),
+      body: { serverId: 1 },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Scenario fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${scenariosUrl()}/${scenarioId}`,
+      headers: headers(),
+      body: {
+        id: (scenarioId ?? 0) + 1,
+        title: `Wrong Route Scenario ${stamp}`,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('must match the route')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${scenariosUrl()}/${scenarioId}`,
+      headers: headers(),
+      body: {
+        facetIds: Array.from({ length: 101 }, (_, index) => index + 1),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+  })
+
+  it('keeps Scenario batch create and patch imports strict and bounded', () => {
+    expect(userId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${scenariosUrl()}/batch`,
+      headers: headers(),
+      body: [
+        {
+          title: `Batch Scenario Identity ${stamp}`,
+          userId,
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.data?.failed?.[0]?.message).to.include(
+        'Unsupported Scenario fields',
+      )
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${scenariosUrl()}/batch`,
+      headers: headers(),
+      body: Array.from({ length: 101 }, (_, index) => ({
+        title: `Oversized Scenario Batch ${stamp}-${index}`,
+      })),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${scenariosUrl()}/batch`,
+      headers: headers(),
+      body: {
+        updates: Array.from({ length: 101 }, (_, index) => ({
+          id: index + 1,
+          title: `Oversized Scenario Patch ${stamp}-${index}`,
+        })),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+  })
+})

--- a/server/api/scenarios/[id].patch.ts
+++ b/server/api/scenarios/[id].patch.ts
@@ -4,356 +4,12 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { userIsAdmin } from '../../utils/authUser'
-import { normalizeSlugInput } from '~/utils/slugify'
-import type {
-  Prisma,
-  ScenarioOutputType,
-} from '~/prisma/generated/prisma/client'
+import {
+  assertScenarioMutationInput,
+  buildScenarioUpdateInput,
+  scenarioPatchFields,
+} from './mutation'
 import { scenarioMutationSelect } from './selects'
-
-type ScenarioPatchInput = {
-  title?: unknown
-  slug?: unknown
-  description?: unknown
-  intros?: unknown
-  outputType?: unknown
-  cast?: unknown
-  dreamIds?: unknown
-  artImageId?: unknown
-  imagePath?: unknown
-  locations?: unknown
-  artPrompt?: unknown
-  genres?: unknown
-  inspirations?: unknown
-  isMature?: unknown
-  isPublic?: unknown
-  isActive?: unknown
-  difficulty?: unknown
-  tier?: unknown
-  group?: unknown
-  secretNotes?: unknown
-  characterIds?: unknown
-}
-
-const scenarioOutputTypes: ScenarioOutputType[] = [
-  'STORY',
-  'ART',
-  'CHARACTER',
-  'REWARD',
-  'DREAM',
-  'SCENARIO',
-  'MIXED',
-]
-
-function normalizeOutputType(value: unknown): ScenarioOutputType {
-  return scenarioOutputTypes.includes(value as ScenarioOutputType)
-    ? (value as ScenarioOutputType)
-    : 'STORY'
-}
-
-function normalizeRequiredString(
-  value: unknown,
-  field: string,
-  maxLength = 191,
-): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be a non-empty string when provided.`,
-    })
-  }
-
-  const trimmed = value.trim()
-
-  if (trimmed.length > maxLength) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
-    })
-  }
-
-  return trimmed
-}
-
-function normalizeString(value: unknown, field: string): string {
-  if (typeof value !== 'string') {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be a string when provided.`,
-    })
-  }
-
-  return value.trim()
-}
-
-function normalizeNullableString(value: unknown, field: string): string | null {
-  if (value === null) return null
-
-  if (typeof value !== 'string') {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be a string or null when provided.`,
-    })
-  }
-
-  const trimmed = value.trim()
-  return trimmed || null
-}
-
-function normalizeJsonString(value: unknown, field: string): string | null {
-  if (value === null) return null
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-
-    try {
-      JSON.parse(trimmed)
-      return trimmed
-    } catch {
-      return JSON.stringify(trimmed)
-    }
-  }
-
-  try {
-    return JSON.stringify(value)
-  } catch {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be JSON-serializable.`,
-    })
-  }
-}
-
-function normalizeBoolean(value: unknown, field: string): boolean {
-  if (typeof value === 'boolean') return value
-
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    if (normalized === 'true') return true
-    if (normalized === 'false') return false
-  }
-
-  throw createError({
-    statusCode: 400,
-    message: `The "${field}" field must be a boolean when provided.`,
-  })
-}
-
-function normalizeNullableInteger(
-  value: unknown,
-  field: string,
-): number | null {
-  if (value === null || value === '') return null
-
-  const parsed = Number(value)
-
-  if (!Number.isInteger(parsed)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be an integer or null when provided.`,
-    })
-  }
-
-  return parsed
-}
-
-function normalizePositiveIdArray(value: unknown, field: string): number[] {
-  if (!Array.isArray(value)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be an array of positive integer IDs.`,
-    })
-  }
-
-  const ids = value.map((entry) => Number(entry))
-
-  if (!ids.every((entry) => Number.isInteger(entry) && entry > 0)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must contain only positive integer IDs.`,
-    })
-  }
-
-  return [...new Set(ids)]
-}
-
-function normalizeIntros(value: unknown): string {
-  if (value === null) return '[]'
-
-  if (Array.isArray(value)) {
-    return JSON.stringify(
-      value.map((entry) => String(entry).trim()).filter(Boolean),
-    )
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return '[]'
-
-    try {
-      const parsed = JSON.parse(trimmed)
-      if (Array.isArray(parsed)) {
-        return JSON.stringify(
-          parsed.map((entry) => String(entry).trim()).filter(Boolean),
-        )
-      }
-
-      return JSON.stringify([trimmed])
-    } catch {
-      return JSON.stringify(
-        trimmed
-          .split('\n')
-          .map((entry) => entry.trim())
-          .filter(Boolean),
-      )
-    }
-  }
-
-  throw createError({
-    statusCode: 400,
-    message:
-      'The "intros" field must be an array, JSON array string, plain string, or null when provided.',
-  })
-}
-
-function normalizeArtImageRelation(
-  value: unknown,
-): Prisma.ArtImageUpdateOneWithoutScenariosNestedInput {
-  if (value === null || value === '') return { disconnect: true }
-
-  const id = Number(value)
-
-  if (!Number.isInteger(id) || id <= 0) {
-    throw createError({
-      statusCode: 400,
-      message: 'artImageId must be a positive integer or null when provided.',
-    })
-  }
-
-  return { connect: { id } }
-}
-
-async function assertRelatedRecordsExist(options: {
-  characterIds?: number[]
-  dreamIds?: number[]
-}) {
-  const { characterIds, dreamIds } = options
-
-  if (characterIds?.length) {
-    const records = await prisma.character.findMany({
-      where: { id: { in: characterIds } },
-      select: { id: true },
-    })
-    const foundIds = new Set(records.map((record) => record.id))
-    const missingIds = characterIds.filter((id) => !foundIds.has(id))
-
-    if (missingIds.length) {
-      throw createError({
-        statusCode: 404,
-        message: `Character IDs not found: ${missingIds.join(', ')}.`,
-      })
-    }
-  }
-
-  if (dreamIds?.length) {
-    const records = await prisma.dream.findMany({
-      where: { id: { in: dreamIds } },
-      select: { id: true },
-    })
-    const foundIds = new Set(records.map((record) => record.id))
-    const missingIds = dreamIds.filter((id) => !foundIds.has(id))
-
-    if (missingIds.length) {
-      throw createError({
-        statusCode: 404,
-        message: `Dream IDs not found: ${missingIds.join(', ')}.`,
-      })
-    }
-  }
-}
-
-async function buildScenarioUpdateInput(
-  body: ScenarioPatchInput,
-): Promise<Prisma.ScenarioUpdateInput> {
-  const data: Prisma.ScenarioUpdateInput = {}
-
-  if ('title' in body) data.title = normalizeRequiredString(body.title, 'title')
-  if ('slug' in body) data.slug = normalizeSlugInput(body.slug)
-  if ('description' in body) {
-    data.description = normalizeString(body.description, 'description')
-  }
-  if ('intros' in body) data.intros = normalizeIntros(body.intros)
-  if ('outputType' in body)
-    data.outputType = normalizeOutputType(body.outputType)
-  if ('cast' in body) data.cast = normalizeJsonString(body.cast, 'cast')
-  if ('imagePath' in body) {
-    data.imagePath = normalizeNullableString(body.imagePath, 'imagePath')
-  }
-  if ('locations' in body) {
-    data.locations = normalizeNullableString(body.locations, 'locations')
-  }
-  if ('artPrompt' in body) {
-    data.artPrompt = normalizeNullableString(body.artPrompt, 'artPrompt')
-  }
-  if ('genres' in body) {
-    data.genres = normalizeNullableString(body.genres, 'genres')
-  }
-  if ('inspirations' in body) {
-    data.inspirations = normalizeNullableString(
-      body.inspirations,
-      'inspirations',
-    )
-  }
-  if ('isMature' in body) {
-    data.isMature = normalizeBoolean(body.isMature, 'isMature')
-  }
-  if ('isPublic' in body) {
-    data.isPublic = normalizeBoolean(body.isPublic, 'isPublic')
-  }
-  if ('isActive' in body) {
-    data.isActive = normalizeBoolean(body.isActive, 'isActive')
-  }
-  if ('difficulty' in body) {
-    data.difficulty = normalizeNullableInteger(body.difficulty, 'difficulty')
-  }
-  if ('tier' in body) data.tier = normalizeNullableString(body.tier, 'tier')
-  if ('group' in body) data.group = normalizeNullableString(body.group, 'group')
-  if ('secretNotes' in body) {
-    data.secretNotes = normalizeNullableString(body.secretNotes, 'secretNotes')
-  }
-  if ('artImageId' in body) {
-    data.ArtImage = normalizeArtImageRelation(body.artImageId)
-  }
-
-  const characterIds =
-    'characterIds' in body
-      ? normalizePositiveIdArray(body.characterIds, 'characterIds')
-      : undefined
-  const dreamIds =
-    'dreamIds' in body
-      ? normalizePositiveIdArray(body.dreamIds, 'dreamIds')
-      : undefined
-
-  await assertRelatedRecordsExist({
-    characterIds,
-    dreamIds,
-  })
-
-  if (characterIds) {
-    data.Characters = {
-      set: characterIds.map((id) => ({ id })),
-    }
-  }
-
-  if (dreamIds) {
-    data.Dreams = {
-      set: dreamIds.map((id) => ({ id })),
-    }
-  }
-
-  return data
-}
 
 export default defineEventHandler(async (event) => {
   let id: number | null = null
@@ -399,14 +55,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const body = await readBody<ScenarioPatchInput>(event)
+    const body = await readBody<unknown>(event)
 
-    if (!body || Object.keys(body).length === 0) {
-      throw createError({
-        statusCode: 400,
-        message: 'No data provided for update.',
-      })
-    }
+    assertScenarioMutationInput(body, {
+      allowedFields: scenarioPatchFields,
+      context: 'Scenario patch payload',
+      requireNonEmpty: true,
+    })
 
     const data = await buildScenarioUpdateInput(body)
 
@@ -432,14 +87,18 @@ export default defineEventHandler(async (event) => {
       statusCode: 200,
     }
   } catch (error: unknown) {
-    const handledError = errorHandler(error)
-    event.node.res.statusCode = handledError.statusCode || 500
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
 
     return {
       success: false,
       message:
-        handledError.message || `Failed to update scenario with ID ${id}.`,
-      statusCode: event.node.res.statusCode,
+        handled.message ||
+        `Failed to update scenario with ID ${id ?? 'unknown'}.`,
+      data: null,
+      statusCode,
     }
   }
 })

--- a/server/api/scenarios/[id].patch.ts
+++ b/server/api/scenarios/[id].patch.ts
@@ -61,6 +61,8 @@ export default defineEventHandler(async (event) => {
       allowedFields: scenarioPatchFields,
       context: 'Scenario patch payload',
       requireNonEmpty: true,
+      authenticatedUserId: user.id,
+      routeId: id,
     })
 
     const data = await buildScenarioUpdateInput(body)

--- a/server/api/scenarios/batch.patch.ts
+++ b/server/api/scenarios/batch.patch.ts
@@ -3,39 +3,21 @@
 // Body shape: { "updates": [ { "id": number, ...scenarioFields }, ... ] }
 // Each scenario is validated and updated independently; a single failing
 // entry does not abort the others. Returns a per-item results array.
-import { defineEventHandler, createError, readBody } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { userIsAdmin } from '../../utils/authUser'
-import type { Prisma } from '~/prisma/generated/prisma/client'
+import {
+  assertScenarioMutationInput,
+  buildScenarioUpdateInput,
+  SCENARIO_BATCH_LIMIT,
+  scenarioBatchPatchFields,
+  type ScenarioMutationInput,
+} from './mutation'
 import { scenarioMutationSelect } from './selects'
 
-type ScenarioPatchInput = {
-  title?: unknown
-  description?: unknown
-  intros?: unknown
-  artImageId?: unknown
-  imagePath?: unknown
-  locations?: unknown
-  artPrompt?: unknown
-  genres?: unknown
-  inspirations?: unknown
-  isMature?: unknown
-  isPublic?: unknown
-  isActive?: unknown
-  difficulty?: unknown
-  tier?: unknown
-  group?: unknown
-  secretNotes?: unknown
-  characterIds?: unknown
-}
-
-type ScenarioBatchEntry = ScenarioPatchInput & { id?: unknown }
-
-type ScenarioBatchBody = {
-  updates?: unknown
-}
+type ScenarioBatchEntry = ScenarioMutationInput & { id?: unknown }
 
 type BatchResult = {
   id: number | null
@@ -45,272 +27,21 @@ type BatchResult = {
   data?: unknown
 }
 
-function normalizeRequiredString(
-  value: unknown,
-  field: string,
-  maxLength = 191,
-): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be a non-empty string when provided.`,
-    })
-  }
-
-  const trimmed = value.trim()
-
-  if (trimmed.length > maxLength) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
-    })
-  }
-
-  return trimmed
-}
-
-function normalizeString(value: unknown, field: string): string {
-  if (typeof value !== 'string') {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be a string when provided.`,
-    })
-  }
-
-  return value.trim()
-}
-
-function normalizeNullableString(value: unknown, field: string): string | null {
-  if (value === null) return null
-
-  if (typeof value !== 'string') {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be a string or null when provided.`,
-    })
-  }
-
-  const trimmed = value.trim()
-  return trimmed || null
-}
-
-function normalizeBoolean(value: unknown, field: string): boolean {
-  if (typeof value === 'boolean') return value
-
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-
-    if (normalized === 'true') return true
-    if (normalized === 'false') return false
-  }
-
-  throw createError({
-    statusCode: 400,
-    message: `The "${field}" field must be a boolean when provided.`,
-  })
-}
-
-function normalizeNullableInteger(
-  value: unknown,
-  field: string,
-): number | null {
-  if (value === null || value === '') return null
-
-  const parsed = Number(value)
-
-  if (!Number.isInteger(parsed)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be an integer or null when provided.`,
-    })
-  }
-
-  return parsed
-}
-
-function normalizePositiveIdArray(value: unknown, field: string): number[] {
-  if (typeof value === 'undefined') return []
-
-  if (!Array.isArray(value)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be an array of positive integer IDs.`,
-    })
-  }
-
-  const ids = value.map((entry) => Number(entry))
-
-  if (!ids.every((entry) => Number.isInteger(entry) && entry > 0)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must contain only positive integer IDs.`,
-    })
-  }
-
-  return [...new Set(ids)]
-}
-
-function normalizeIntros(value: unknown): string {
-  if (value === null) return '[]'
-
-  if (Array.isArray(value)) {
-    return JSON.stringify(
-      value.map((entry) => String(entry).trim()).filter(Boolean),
-    )
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-
-    if (!trimmed) return '[]'
-
-    try {
-      const parsed = JSON.parse(trimmed)
-
-      if (Array.isArray(parsed)) {
-        return JSON.stringify(
-          parsed.map((entry) => String(entry).trim()).filter(Boolean),
-        )
-      }
-
-      return JSON.stringify([trimmed])
-    } catch {
-      return JSON.stringify(
-        trimmed
-          .split('\n')
-          .map((entry) => entry.trim())
-          .filter(Boolean),
-      )
-    }
-  }
-
-  throw createError({
-    statusCode: 400,
-    message:
-      'The "intros" field must be an array, JSON array string, plain string, or null when provided.',
-  })
-}
-
-function normalizeArtImageRelation(
-  value: unknown,
-): Prisma.ArtImageUpdateOneWithoutScenariosNestedInput {
-  if (value === null || value === '') {
-    return {
-      disconnect: true,
-    }
-  }
-
-  const id = Number(value)
-
-  if (!Number.isInteger(id) || id <= 0) {
-    throw createError({
-      statusCode: 400,
-      message: 'artImageId must be a positive integer or null when provided.',
-    })
-  }
-
-  return {
-    connect: {
-      id,
-    },
-  }
-}
-
-async function assertRelatedRecordsExist(options: { characterIds: number[] }) {
-  const { characterIds } = options
-
-  if (characterIds.length) {
-    const characters = await prisma.character.findMany({
-      where: { id: { in: characterIds } },
-      select: { id: true },
-    })
-
-    const foundIds = new Set(characters.map((character) => character.id))
-    const missingIds = characterIds.filter((id) => !foundIds.has(id))
-
-    if (missingIds.length) {
-      throw createError({
-        statusCode: 404,
-        message: `Character IDs not found: ${missingIds.join(', ')}.`,
-      })
-    }
-  }
-}
-
-async function buildScenarioUpdateInput(
-  body: ScenarioPatchInput,
-): Promise<Prisma.ScenarioUpdateInput> {
-  const data: Prisma.ScenarioUpdateInput = {}
-
-  if ('title' in body) data.title = normalizeRequiredString(body.title, 'title')
-  if ('description' in body) {
-    data.description = normalizeString(body.description, 'description')
-  }
-  if ('intros' in body) data.intros = normalizeIntros(body.intros)
-  if ('imagePath' in body) {
-    data.imagePath = normalizeNullableString(body.imagePath, 'imagePath')
-  }
-  if ('locations' in body) {
-    data.locations = normalizeNullableString(body.locations, 'locations')
-  }
-  if ('artPrompt' in body) {
-    data.artPrompt = normalizeNullableString(body.artPrompt, 'artPrompt')
-  }
-  if ('genres' in body) {
-    data.genres = normalizeNullableString(body.genres, 'genres')
-  }
-  if ('inspirations' in body) {
-    data.inspirations = normalizeNullableString(
-      body.inspirations,
-      'inspirations',
-    )
-  }
-  if ('isMature' in body) {
-    data.isMature = normalizeBoolean(body.isMature, 'isMature')
-  }
-  if ('isPublic' in body) {
-    data.isPublic = normalizeBoolean(body.isPublic, 'isPublic')
-  }
-  if ('isActive' in body) {
-    data.isActive = normalizeBoolean(body.isActive, 'isActive')
-  }
-  if ('difficulty' in body) {
-    data.difficulty = normalizeNullableInteger(body.difficulty, 'difficulty')
-  }
-  if ('tier' in body) data.tier = normalizeNullableString(body.tier, 'tier')
-  if ('group' in body) data.group = normalizeNullableString(body.group, 'group')
-  if ('secretNotes' in body) {
-    data.secretNotes = normalizeNullableString(body.secretNotes, 'secretNotes')
-  }
-  if ('artImageId' in body) {
-    data.ArtImage = normalizeArtImageRelation(body.artImageId)
-  }
-
-  const characterIds = normalizePositiveIdArray(
-    body.characterIds,
-    'characterIds',
-  )
-
-  await assertRelatedRecordsExist({
-    characterIds,
-  })
-
-  if (characterIds.length) {
-    data.Characters = {
-      connect: characterIds.map((id) => ({ id })),
-    }
-  }
-
-  return data
-}
-
 async function processEntry(
-  entry: ScenarioBatchEntry,
+  rawEntry: unknown,
+  index: number,
   user: { id: number; Role?: string | null },
 ): Promise<BatchResult> {
   let id: number | null = null
 
   try {
+    assertScenarioMutationInput(rawEntry, {
+      allowedFields: scenarioBatchPatchFields,
+      context: `Scenario batch update item ${index}`,
+      requireNonEmpty: true,
+    })
+
+    const entry = rawEntry as ScenarioBatchEntry
     id = Number(entry.id)
 
     if (!Number.isInteger(id) || id <= 0) {
@@ -342,9 +73,8 @@ async function processEntry(
       })
     }
 
-    // Strip the routing id before building the Prisma update input.
-    const { id: _omit, ...fields } = entry
-    void _omit
+    const { id: _routingId, ...fields } = entry
+    void _routingId
 
     if (Object.keys(fields).length === 0) {
       throw createError({
@@ -400,9 +130,26 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const body = await readBody<ScenarioBatchBody>(event)
+    const body = await readBody<unknown>(event)
 
-    if (!body || !Array.isArray(body.updates) || body.updates.length === 0) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Request body must be a JSON object.',
+      })
+    }
+
+    const record = body as Record<string, unknown>
+    const unsupported = Object.keys(record).filter((field) => field !== 'updates')
+
+    if (unsupported.length) {
+      throw createError({
+        statusCode: 400,
+        message: `Unsupported Scenario batch patch fields: ${unsupported.join(', ')}.`,
+      })
+    }
+
+    if (!Array.isArray(record.updates) || record.updates.length === 0) {
       throw createError({
         statusCode: 400,
         message:
@@ -410,42 +157,41 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    if (record.updates.length > SCENARIO_BATCH_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `Scenario batch patch may contain at most ${SCENARIO_BATCH_LIMIT} entries.`,
+      })
+    }
+
     const results: BatchResult[] = []
 
-    for (const entry of body.updates as ScenarioBatchEntry[]) {
-      if (!entry || typeof entry !== 'object') {
-        results.push({
-          id: null,
-          success: false,
-          message: 'Each update entry must be an object with an "id".',
-          statusCode: 400,
-        })
-        continue
-      }
-
-      results.push(await processEntry(entry, user))
+    for (const [index, entry] of record.updates.entries()) {
+      results.push(await processEntry(entry, index, user))
     }
 
     const updatedCount = results.filter((result) => result.success).length
     const failedCount = results.length - updatedCount
 
-    // 200 if everything succeeded, 207 (Multi-Status) if partial.
     event.node.res.statusCode = failedCount === 0 ? 200 : 207
 
     return {
       success: failedCount === 0,
-      message: `Batch complete: ${updatedCount} updated, ${failedCount} failed.`,
+      message: `${updatedCount} updated, ${failedCount} failed.`,
       data: results,
       statusCode: event.node.res.statusCode,
     }
   } catch (error: unknown) {
     const handledError = errorHandler(error)
-    event.node.res.statusCode = handledError.statusCode || 500
+    const statusCode = handledError.statusCode || 500
+
+    event.node.res.statusCode = statusCode
 
     return {
       success: false,
-      message: handledError.message || 'Failed to process scenario batch.',
-      statusCode: event.node.res.statusCode,
+      message: handledError.message || 'Failed to batch-update scenarios.',
+      data: null,
+      statusCode,
     }
   }
 })

--- a/server/api/scenarios/batch.post.ts
+++ b/server/api/scenarios/batch.post.ts
@@ -13,6 +13,7 @@ import {
   type ScenarioPostInput,
   type SkippedScenario,
 } from './create'
+import { SCENARIO_BATCH_LIMIT } from './mutation'
 import {
   scenarioMutationSelect,
   type ScenarioMutationResult,
@@ -29,7 +30,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const body = await readBody<ScenarioPostInput[]>(event)
+    const body = await readBody<unknown>(event)
 
     if (!Array.isArray(body) || !body.length) {
       throw createError({
@@ -38,15 +39,23 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    if (body.length > SCENARIO_BATCH_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `Scenario batch may contain at most ${SCENARIO_BATCH_LIMIT} entries.`,
+      })
+    }
+
     const created: ScenarioMutationResult[] = []
     const skipped: SkippedScenario[] = []
     const failed: FailedScenario[] = []
 
-    for (const scenarioData of body) {
+    for (const rawScenarioData of body) {
+      const scenarioData = rawScenarioData as ScenarioPostInput
       const fallbackTitle = fallbackScenarioTitle(scenarioData)
 
       try {
-        const createInput = buildScenarioCreateInput(scenarioData, user.id)
+        const createInput = await buildScenarioCreateInput(scenarioData, user.id)
         const existingScenario = await findExistingScenario(
           createInput.title,
           user.id,

--- a/server/api/scenarios/batch.post.ts
+++ b/server/api/scenarios/batch.post.ts
@@ -55,7 +55,11 @@ export default defineEventHandler(async (event) => {
       const fallbackTitle = fallbackScenarioTitle(scenarioData)
 
       try {
-        const createInput = await buildScenarioCreateInput(scenarioData, user.id)
+        const createInput = await buildScenarioCreateInput(
+          scenarioData,
+          user.id,
+          { batch: true },
+        )
         const existingScenario = await findExistingScenario(
           createInput.title,
           user.id,

--- a/server/api/scenarios/create.ts
+++ b/server/api/scenarios/create.ts
@@ -1,34 +1,25 @@
-import { createError } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { normalizeSlugInput } from '~/utils/slugify'
-import type {
-  Prisma,
-  ScenarioOutputType,
-} from '~/prisma/generated/prisma/client'
+import { ScenarioOutputType, type Prisma } from '~/prisma/generated/prisma/client'
+import {
+  assertScenarioMutationInput,
+  assertScenarioRelationsExist,
+  normalizeScenarioBoolean,
+  normalizeScenarioIdArray,
+  normalizeScenarioIntros,
+  normalizeScenarioJsonString,
+  normalizeScenarioNullableId,
+  normalizeScenarioNullableInteger,
+  normalizeScenarioNullableString,
+  normalizeScenarioOutputType,
+  normalizeScenarioRequiredString,
+  normalizeScenarioString,
+  scenarioCreateFields,
+  type ScenarioMutationInput,
+} from './mutation'
 
-export type ScenarioPostInput = {
-  title?: unknown
-  slug?: unknown
-  description?: unknown
-  intros?: unknown
-  outputType?: unknown
-  cast?: unknown
-  dreamIds?: unknown
-  artImageId?: unknown
-  imagePath?: unknown
-  locations?: unknown
-  artPrompt?: unknown
-  genres?: unknown
-  inspirations?: unknown
-  isMature?: unknown
-  isPublic?: unknown
-  isActive?: unknown
-  difficulty?: unknown
-  tier?: unknown
-  group?: unknown
-  secretNotes?: unknown
-}
+export type ScenarioPostInput = ScenarioMutationInput
 
 export type SkippedScenario = {
   title: string
@@ -41,172 +32,8 @@ export type FailedScenario = {
   message: string
 }
 
-const scenarioOutputTypes: ScenarioOutputType[] = [
-  'STORY',
-  'ART',
-  'CHARACTER',
-  'REWARD',
-  'DREAM',
-  'SCENARIO',
-  'MIXED',
-]
-
-function normalizeOutputType(value: unknown): ScenarioOutputType {
-  return scenarioOutputTypes.includes(value as ScenarioOutputType)
-    ? (value as ScenarioOutputType)
-    : 'STORY'
-}
-
-function normalizeIdArray(value: unknown): number[] {
-  if (!Array.isArray(value)) return []
-
-  const ids = value
-    .map((entry) => Number(entry))
-    .filter((entry) => Number.isInteger(entry) && entry > 0)
-
-  return [...new Set(ids)]
-}
-
-function normalizeRequiredString(
-  value: unknown,
-  field: string,
-  maxLength = 191,
-): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field is required and must be a string.`,
-    })
-  }
-
-  const trimmed = value.trim()
-  if (trimmed.length > maxLength) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
-    })
-  }
-
-  return trimmed
-}
-
-function normalizeString(value: unknown, fallback = ''): string {
-  return typeof value === 'string' ? value.trim() : fallback
-}
-
-function normalizeNullableString(value: unknown): string | null | undefined {
-  if (value === null) return null
-  if (value === undefined) return undefined
-  if (typeof value !== 'string') return undefined
-
-  const trimmed = value.trim()
-  return trimmed || null
-}
-
-function normalizeBoolean(value: unknown, fallback: boolean): boolean {
-  if (typeof value === 'boolean') return value
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    if (normalized === 'true') return true
-    if (normalized === 'false') return false
-  }
-
-  return fallback
-}
-
-function normalizeNullableInteger(value: unknown): number | null | undefined {
-  if (value === null) return null
-  if (value === undefined || value === '') return undefined
-
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed)) {
-    throw createError({
-      statusCode: 400,
-      message: 'difficulty must be an integer when provided.',
-    })
-  }
-
-  return parsed
-}
-
-function normalizeIntros(value: unknown): string {
-  if (!value) return '[]'
-
-  if (Array.isArray(value)) {
-    return JSON.stringify(
-      value.map((entry) => String(entry).trim()).filter(Boolean),
-    )
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return '[]'
-
-    try {
-      const parsed = JSON.parse(trimmed)
-      if (Array.isArray(parsed)) {
-        return JSON.stringify(
-          parsed.map((entry) => String(entry).trim()).filter(Boolean),
-        )
-      }
-      return JSON.stringify([trimmed])
-    } catch {
-      return JSON.stringify(
-        trimmed
-          .split('\n')
-          .map((entry) => entry.trim())
-          .filter(Boolean),
-      )
-    }
-  }
-
-  return '[]'
-}
-
-function normalizeOptionalJsonString(
-  value: unknown,
-): string | null | undefined {
-  if (value === undefined) return undefined
-  if (value === null) return null
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-
-    try {
-      JSON.parse(trimmed)
-      return trimmed
-    } catch {
-      return JSON.stringify(trimmed)
-    }
-  }
-
-  try {
-    return JSON.stringify(value)
-  } catch {
-    throw createError({
-      statusCode: 400,
-      message: 'The "cast" field must be JSON-serializable.',
-    })
-  }
-}
-
-function normalizeOptionalId(value: unknown): number | undefined {
-  if (value === null || value === undefined || value === '') return undefined
-
-  const id = Number(value)
-  if (!Number.isInteger(id) || id <= 0) {
-    throw createError({
-      statusCode: 400,
-      message: 'artImageId must be a positive integer when provided.',
-    })
-  }
-
-  return id
-}
-
 export function fallbackScenarioTitle(input: ScenarioPostInput): string {
-  return typeof input.title === 'string' && input.title.trim()
+  return typeof input?.title === 'string' && input.title.trim()
     ? input.title.trim()
     : 'Untitled scenario'
 }
@@ -220,39 +47,103 @@ export function isScenarioInfrastructureError(error: unknown): boolean {
   return Number(handled.statusCode) >= 500
 }
 
-export function buildScenarioCreateInput(
-  scenarioData: ScenarioPostInput,
+export async function buildScenarioCreateInput(
+  rawInput: unknown,
   authenticatedUserId: number,
-): Prisma.ScenarioCreateInput {
-  const title = normalizeRequiredString(scenarioData.title, 'title')
-  const artImageId = normalizeOptionalId(scenarioData.artImageId)
-  const difficulty = normalizeNullableInteger(scenarioData.difficulty)
-  const dreamIds = normalizeIdArray(scenarioData.dreamIds)
+): Promise<Prisma.ScenarioCreateInput> {
+  assertScenarioMutationInput(rawInput, {
+    allowedFields: scenarioCreateFields,
+    context: 'Scenario create payload',
+  })
+
+  const scenarioData = rawInput
+  const title = normalizeScenarioRequiredString(scenarioData.title, 'title')
+  const artImageId = normalizeScenarioNullableId(
+    scenarioData.artImageId,
+    'artImageId',
+  )
+  const difficulty = normalizeScenarioNullableInteger(
+    scenarioData.difficulty,
+    'difficulty',
+  )
+  const dreamIds = normalizeScenarioIdArray(scenarioData.dreamIds, 'dreamIds')
+  const characterIds = normalizeScenarioIdArray(
+    scenarioData.characterIds,
+    'characterIds',
+  )
+  const facetIds = normalizeScenarioIdArray(scenarioData.facetIds, 'facetIds')
+
+  await assertScenarioRelationsExist({
+    artImageId,
+    dreamIds,
+    characterIds,
+    facetIds,
+  })
 
   return {
     User: { connect: { id: authenticatedUserId } },
     title,
     slug: normalizeSlugInput(scenarioData.slug) ?? undefined,
-    description: normalizeString(scenarioData.description),
-    intros: normalizeIntros(scenarioData.intros),
-    outputType: normalizeOutputType(scenarioData.outputType),
-    cast: normalizeOptionalJsonString(scenarioData.cast),
-    imagePath: normalizeNullableString(scenarioData.imagePath),
-    locations: normalizeNullableString(scenarioData.locations),
-    artPrompt: normalizeNullableString(scenarioData.artPrompt),
-    genres: normalizeNullableString(scenarioData.genres),
-    inspirations: normalizeNullableString(scenarioData.inspirations),
-    isMature: normalizeBoolean(scenarioData.isMature, false),
-    isPublic: normalizeBoolean(scenarioData.isPublic, true),
-    isActive: normalizeBoolean(scenarioData.isActive, true),
+    description: normalizeScenarioString(
+      scenarioData.description,
+      'description',
+      '',
+    ),
+    intros: normalizeScenarioIntros(scenarioData.intros),
+    outputType: normalizeScenarioOutputType(
+      scenarioData.outputType,
+      ScenarioOutputType.STORY,
+    ),
+    cast: normalizeScenarioJsonString(scenarioData.cast, 'cast'),
+    imagePath: normalizeScenarioNullableString(
+      scenarioData.imagePath,
+      'imagePath',
+    ),
+    locations: normalizeScenarioNullableString(
+      scenarioData.locations,
+      'locations',
+    ),
+    artPrompt: normalizeScenarioNullableString(
+      scenarioData.artPrompt,
+      'artPrompt',
+    ),
+    genres: normalizeScenarioNullableString(scenarioData.genres, 'genres'),
+    inspirations: normalizeScenarioNullableString(
+      scenarioData.inspirations,
+      'inspirations',
+    ),
+    isMature:
+      scenarioData.isMature === undefined
+        ? false
+        : normalizeScenarioBoolean(scenarioData.isMature, 'isMature'),
+    isPublic:
+      scenarioData.isPublic === undefined
+        ? true
+        : normalizeScenarioBoolean(scenarioData.isPublic, 'isPublic'),
+    isActive:
+      scenarioData.isActive === undefined
+        ? true
+        : normalizeScenarioBoolean(scenarioData.isActive, 'isActive'),
     difficulty,
-    tier: normalizeNullableString(scenarioData.tier),
-    group: normalizeNullableString(scenarioData.group),
-    secretNotes: normalizeNullableString(scenarioData.secretNotes),
-    ArtImage: artImageId ? { connect: { id: artImageId } } : undefined,
-    ...(dreamIds.length
-      ? { Dreams: { connect: dreamIds.map((id) => ({ id })) } }
-      : {}),
+    tier: normalizeScenarioNullableString(scenarioData.tier, 'tier'),
+    group: normalizeScenarioNullableString(scenarioData.group, 'group'),
+    secretNotes: normalizeScenarioNullableString(
+      scenarioData.secretNotes,
+      'secretNotes',
+    ),
+    ArtImage:
+      typeof artImageId === 'number'
+        ? { connect: { id: artImageId } }
+        : undefined,
+    Dreams: dreamIds?.length
+      ? { connect: dreamIds.map((id) => ({ id })) }
+      : undefined,
+    Characters: characterIds?.length
+      ? { connect: characterIds.map((id) => ({ id })) }
+      : undefined,
+    Facets: facetIds?.length
+      ? { connect: facetIds.map((id) => ({ id })) }
+      : undefined,
   }
 }
 

--- a/server/api/scenarios/create.ts
+++ b/server/api/scenarios/create.ts
@@ -15,6 +15,7 @@ import {
   normalizeScenarioOutputType,
   normalizeScenarioRequiredString,
   normalizeScenarioString,
+  scenarioBatchCreateFields,
   scenarioCreateFields,
   type ScenarioMutationInput,
 } from './mutation'
@@ -50,10 +51,17 @@ export function isScenarioInfrastructureError(error: unknown): boolean {
 export async function buildScenarioCreateInput(
   rawInput: unknown,
   authenticatedUserId: number,
+  options: { batch?: boolean } = {},
 ): Promise<Prisma.ScenarioCreateInput> {
   assertScenarioMutationInput(rawInput, {
-    allowedFields: scenarioCreateFields,
-    context: 'Scenario create payload',
+    allowedFields: options.batch
+      ? scenarioBatchCreateFields
+      : scenarioCreateFields,
+    context: options.batch
+      ? 'Scenario batch create item'
+      : 'Scenario create payload',
+    authenticatedUserId: options.batch ? undefined : authenticatedUserId,
+    allowTemporaryId: !options.batch,
   })
 
   const scenarioData = rawInput

--- a/server/api/scenarios/create.ts
+++ b/server/api/scenarios/create.ts
@@ -79,13 +79,11 @@ export async function buildScenarioCreateInput(
     scenarioData.characterIds,
     'characterIds',
   )
-  const facetIds = normalizeScenarioIdArray(scenarioData.facetIds, 'facetIds')
 
   await assertScenarioRelationsExist({
     artImageId,
     dreamIds,
     characterIds,
-    facetIds,
   })
 
   return {
@@ -148,9 +146,6 @@ export async function buildScenarioCreateInput(
       : undefined,
     Characters: characterIds?.length
       ? { connect: characterIds.map((id) => ({ id })) }
-      : undefined,
-    Facets: facetIds?.length
-      ? { connect: facetIds.map((id) => ({ id })) }
       : undefined,
   }
 }

--- a/server/api/scenarios/index.post.ts
+++ b/server/api/scenarios/index.post.ts
@@ -31,14 +31,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (!body || typeof body !== 'object') {
-      throw createError({
-        statusCode: 400,
-        message: 'Request body is required.',
-      })
-    }
-
-    const createInput = buildScenarioCreateInput(body, user.id)
+    const createInput = await buildScenarioCreateInput(body, user.id)
     const existingScenario = await findExistingScenario(
       createInput.title,
       user.id,

--- a/server/api/scenarios/mutation.ts
+++ b/server/api/scenarios/mutation.ts
@@ -1,0 +1,563 @@
+import { createError } from 'h3'
+import {
+  ScenarioOutputType,
+  type Prisma,
+} from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+import { normalizeSlugInput } from '~/utils/slugify'
+
+export const SCENARIO_RELATION_ID_LIMIT = 100
+export const SCENARIO_BATCH_LIMIT = 100
+export const SCENARIO_JSON_TEXT_LIMIT = 50_000
+
+const scenarioMutationFields = [
+  'title',
+  'slug',
+  'description',
+  'intros',
+  'outputType',
+  'cast',
+  'dreamIds',
+  'characterIds',
+  'facetIds',
+  'artImageId',
+  'imagePath',
+  'locations',
+  'artPrompt',
+  'genres',
+  'inspirations',
+  'isMature',
+  'isPublic',
+  'isActive',
+  'difficulty',
+  'tier',
+  'group',
+  'secretNotes',
+] as const
+
+export const scenarioCreateFields = new Set<string>(scenarioMutationFields)
+export const scenarioPatchFields = new Set<string>(scenarioMutationFields)
+export const scenarioBatchPatchFields = new Set<string>([
+  ...scenarioMutationFields,
+  'id',
+])
+
+export type ScenarioMutationInput = Record<string, unknown> & {
+  id?: unknown
+  title?: unknown
+  slug?: unknown
+  description?: unknown
+  intros?: unknown
+  outputType?: unknown
+  cast?: unknown
+  dreamIds?: unknown
+  characterIds?: unknown
+  facetIds?: unknown
+  artImageId?: unknown
+  imagePath?: unknown
+  locations?: unknown
+  artPrompt?: unknown
+  genres?: unknown
+  inspirations?: unknown
+  isMature?: unknown
+  isPublic?: unknown
+  isActive?: unknown
+  difficulty?: unknown
+  tier?: unknown
+  group?: unknown
+  secretNotes?: unknown
+}
+
+type ScenarioBoundaryOptions = {
+  allowedFields: ReadonlySet<string>
+  context: string
+  requireNonEmpty?: boolean
+}
+
+const nullableTextFields = [
+  'imagePath',
+  'locations',
+  'artPrompt',
+  'genres',
+  'inspirations',
+  'tier',
+  'group',
+  'secretNotes',
+] as const
+
+const booleanFields = ['isMature', 'isPublic', 'isActive'] as const
+const relationFields = ['dreamIds', 'characterIds', 'facetIds'] as const
+const outputTypes = Object.values(ScenarioOutputType)
+
+export function assertScenarioMutationInput(
+  body: unknown,
+  options: ScenarioBoundaryOptions,
+): asserts body is ScenarioMutationInput {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.context} must be a JSON object.`,
+    })
+  }
+
+  const fields = Object.keys(body)
+
+  if (options.requireNonEmpty && fields.length === 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'No data provided for update.',
+    })
+  }
+
+  const unsupported = fields.filter(
+    (field) => !options.allowedFields.has(field),
+  )
+
+  if (unsupported.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Scenario fields in ${options.context}: ${unsupported.join(', ')}. IDs, timestamps, identity, and system fields are server-owned.`,
+    })
+  }
+
+  const input = body as ScenarioMutationInput
+
+  if (input.title !== undefined) {
+    normalizeScenarioRequiredString(input.title, 'title')
+  }
+
+  if (input.slug !== undefined) {
+    if (
+      input.slug !== null &&
+      (typeof input.slug !== 'string' || !input.slug.trim())
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: 'The "slug" field must be a non-empty string or null.',
+      })
+    }
+  }
+
+  if (input.description !== undefined) {
+    normalizeScenarioString(input.description, 'description')
+  }
+
+  if (input.intros !== undefined) normalizeScenarioIntros(input.intros)
+  if (input.outputType !== undefined) normalizeScenarioOutputType(input.outputType)
+  if (input.cast !== undefined) normalizeScenarioJsonString(input.cast, 'cast')
+
+  for (const field of nullableTextFields) {
+    if (input[field] !== undefined) {
+      normalizeScenarioNullableString(input[field], field)
+    }
+  }
+
+  for (const field of booleanFields) {
+    if (input[field] !== undefined) {
+      normalizeScenarioBoolean(input[field], field)
+    }
+  }
+
+  if (input.difficulty !== undefined) {
+    normalizeScenarioNullableInteger(input.difficulty, 'difficulty')
+  }
+
+  if (input.artImageId !== undefined) {
+    normalizeScenarioNullableId(input.artImageId, 'artImageId')
+  }
+
+  for (const field of relationFields) {
+    if (input[field] !== undefined) {
+      normalizeScenarioIdArray(input[field], field)
+    }
+  }
+}
+
+export function normalizeScenarioRequiredString(
+  value: unknown,
+  field: string,
+  maxLength = 191,
+): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field is required and must be a non-empty string.`,
+    })
+  }
+
+  const trimmed = value.trim()
+
+  if (trimmed.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
+    })
+  }
+
+  return trimmed
+}
+
+export function normalizeScenarioString(
+  value: unknown,
+  field: string,
+  fallback?: string,
+): string {
+  if (value === undefined && fallback !== undefined) return fallback
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a string.`,
+    })
+  }
+
+  return value.trim()
+}
+
+export function normalizeScenarioNullableString(
+  value: unknown,
+  field: string,
+): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a string or null.`,
+    })
+  }
+
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+export function normalizeScenarioBoolean(
+  value: unknown,
+  field: string,
+): boolean {
+  if (typeof value !== 'boolean') {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a boolean.`,
+    })
+  }
+
+  return value
+}
+
+export function normalizeScenarioNullableInteger(
+  value: unknown,
+  field: string,
+): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed)) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be an integer or null.`,
+    })
+  }
+
+  return parsed
+}
+
+export function normalizeScenarioNullableId(
+  value: unknown,
+  field: string,
+): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a positive integer or null.`,
+    })
+  }
+
+  return parsed
+}
+
+export function normalizeScenarioIdArray(
+  value: unknown,
+  field: string,
+): number[] | undefined {
+  if (value === undefined) return undefined
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be an array of positive integer IDs.`,
+    })
+  }
+
+  if (value.length > SCENARIO_RELATION_ID_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field may contain at most ${SCENARIO_RELATION_ID_LIMIT} entries.`,
+    })
+  }
+
+  const ids = value.map((entry, index) => {
+    const id = Number(entry)
+
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: `The "${field}" field contains an invalid ID at index ${index}.`,
+      })
+    }
+
+    return id
+  })
+
+  return [...new Set(ids)]
+}
+
+export function normalizeScenarioOutputType(
+  value: unknown,
+  fallback?: ScenarioOutputType,
+): ScenarioOutputType {
+  if (value === undefined && fallback) return fallback
+
+  if (
+    typeof value !== 'string' ||
+    !outputTypes.includes(value as ScenarioOutputType)
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: `The "outputType" field must be one of: ${outputTypes.join(', ')}.`,
+    })
+  }
+
+  return value as ScenarioOutputType
+}
+
+export function normalizeScenarioIntros(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '[]'
+
+  let entries: unknown[]
+
+  if (Array.isArray(value)) {
+    entries = value
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return '[]'
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      entries = Array.isArray(parsed) ? parsed : [trimmed]
+    } catch {
+      entries = trimmed.split('\n')
+    }
+  } else {
+    throw createError({
+      statusCode: 400,
+      message:
+        'The "intros" field must be an array, JSON array string, plain string, or null.',
+    })
+  }
+
+  if (entries.length > SCENARIO_RELATION_ID_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `The "intros" field may contain at most ${SCENARIO_RELATION_ID_LIMIT} entries.`,
+    })
+  }
+
+  const normalized = entries.map((entry, index) => {
+    if (typeof entry !== 'string') {
+      throw createError({
+        statusCode: 400,
+        message: `The "intros" field contains a non-string entry at index ${index}.`,
+      })
+    }
+
+    return entry.trim()
+  }).filter(Boolean)
+
+  const serialized = JSON.stringify(normalized)
+
+  if (serialized.length > SCENARIO_JSON_TEXT_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `The "intros" field must serialize to ${SCENARIO_JSON_TEXT_LIMIT} characters or fewer.`,
+    })
+  }
+
+  return serialized
+}
+
+export function normalizeScenarioJsonString(
+  value: unknown,
+  field: string,
+): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+
+  let serialized: string
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+
+    try {
+      JSON.parse(trimmed)
+      serialized = trimmed
+    } catch {
+      serialized = JSON.stringify(trimmed)
+    }
+  } else {
+    try {
+      serialized = JSON.stringify(value)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: `The "${field}" field must be JSON-serializable.`,
+      })
+    }
+  }
+
+  if (serialized.length > SCENARIO_JSON_TEXT_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must serialize to ${SCENARIO_JSON_TEXT_LIMIT} characters or fewer.`,
+    })
+  }
+
+  return serialized
+}
+
+async function assertIdsExist(options: {
+  model: 'artImage' | 'dream' | 'character' | 'facet'
+  ids: number[]
+  label: string
+}): Promise<void> {
+  if (!options.ids.length) return
+
+  const records = await (prisma[options.model] as {
+    findMany(args: unknown): Promise<Array<{ id: number }>>
+  }).findMany({
+    where: { id: { in: options.ids } },
+    select: { id: true },
+  })
+  const found = new Set(records.map((record) => record.id))
+  const missing = options.ids.filter((id) => !found.has(id))
+
+  if (missing.length) {
+    throw createError({
+      statusCode: 404,
+      message: `${options.label} IDs not found: ${missing.join(', ')}.`,
+    })
+  }
+}
+
+export async function assertScenarioRelationsExist(input: {
+  artImageId?: number | null
+  dreamIds?: number[]
+  characterIds?: number[]
+  facetIds?: number[]
+}): Promise<void> {
+  await Promise.all([
+    assertIdsExist({
+      model: 'artImage',
+      ids: typeof input.artImageId === 'number' ? [input.artImageId] : [],
+      label: 'ArtImage',
+    }),
+    assertIdsExist({
+      model: 'dream',
+      ids: input.dreamIds ?? [],
+      label: 'Dream',
+    }),
+    assertIdsExist({
+      model: 'character',
+      ids: input.characterIds ?? [],
+      label: 'Character',
+    }),
+    assertIdsExist({
+      model: 'facet',
+      ids: input.facetIds ?? [],
+      label: 'Facet',
+    }),
+  ])
+}
+
+export async function buildScenarioUpdateInput(
+  body: ScenarioMutationInput,
+): Promise<Prisma.ScenarioUpdateInput> {
+  const data: Prisma.ScenarioUpdateInput = {}
+
+  if ('title' in body) {
+    data.title = normalizeScenarioRequiredString(body.title, 'title')
+  }
+  if ('slug' in body) data.slug = normalizeSlugInput(body.slug)
+  if ('description' in body) {
+    data.description = normalizeScenarioString(body.description, 'description')
+  }
+  if ('intros' in body) data.intros = normalizeScenarioIntros(body.intros)
+  if ('outputType' in body) {
+    data.outputType = normalizeScenarioOutputType(body.outputType)
+  }
+  if ('cast' in body) data.cast = normalizeScenarioJsonString(body.cast, 'cast')
+
+  for (const field of nullableTextFields) {
+    if (field in body) {
+      data[field] = normalizeScenarioNullableString(
+        body[field],
+        field,
+      ) as never
+    }
+  }
+
+  for (const field of booleanFields) {
+    if (field in body) {
+      data[field] = normalizeScenarioBoolean(body[field], field) as never
+    }
+  }
+
+  if ('difficulty' in body) {
+    data.difficulty = normalizeScenarioNullableInteger(
+      body.difficulty,
+      'difficulty',
+    )
+  }
+
+  const artImageId = normalizeScenarioNullableId(body.artImageId, 'artImageId')
+  const dreamIds = normalizeScenarioIdArray(body.dreamIds, 'dreamIds')
+  const characterIds = normalizeScenarioIdArray(
+    body.characterIds,
+    'characterIds',
+  )
+  const facetIds = normalizeScenarioIdArray(body.facetIds, 'facetIds')
+
+  await assertScenarioRelationsExist({
+    artImageId,
+    dreamIds,
+    characterIds,
+    facetIds,
+  })
+
+  if ('artImageId' in body) {
+    data.ArtImage =
+      typeof artImageId === 'number'
+        ? { connect: { id: artImageId } }
+        : { disconnect: true }
+  }
+  if (dreamIds !== undefined) {
+    data.Dreams = { set: dreamIds.map((id) => ({ id })) }
+  }
+  if (characterIds !== undefined) {
+    data.Characters = { set: characterIds.map((id) => ({ id })) }
+  }
+  if (facetIds !== undefined) {
+    data.Facets = { set: facetIds.map((id) => ({ id })) }
+  }
+
+  return data
+}

--- a/server/api/scenarios/mutation.ts
+++ b/server/api/scenarios/mutation.ts
@@ -19,7 +19,6 @@ const scenarioMutationFields = [
   'cast',
   'dreamIds',
   'characterIds',
-  'facetIds',
   'artImageId',
   'imagePath',
   'locations',
@@ -37,11 +36,14 @@ const scenarioMutationFields = [
 
 // ScenarioForm currently spreads these model fields into singular mutations.
 // They are validated and ignored until the client payload helper is narrowed.
+// facetIds is also compatibility-only because Prisma currently exposes Facets
+// in Scenario reads but no writable ScenarioCreateInput/ScenarioUpdateInput relation.
 const scenarioStoreCompatibilityFields = [
   'id',
   'userId',
   'createdAt',
   'updatedAt',
+  'facetIds',
 ] as const
 
 export const scenarioCreateFields = new Set<string>([
@@ -108,7 +110,7 @@ const nullableTextFields = [
 ] as const
 
 const booleanFields = ['isMature', 'isPublic', 'isActive'] as const
-const relationFields = ['dreamIds', 'characterIds', 'facetIds'] as const
+const relationFields = ['dreamIds', 'characterIds'] as const
 const outputTypes = Object.values(ScenarioOutputType)
 
 function normalizeCompatibilityId(value: unknown, field: string): number {
@@ -262,6 +264,10 @@ export function assertScenarioMutationInput(
     if (input[field] !== undefined) {
       normalizeScenarioIdArray(input[field], field)
     }
+  }
+
+  if (input.facetIds !== undefined) {
+    normalizeScenarioIdArray(input.facetIds, 'facetIds')
   }
 }
 
@@ -548,14 +554,12 @@ export async function assertScenarioRelationsExist(input: {
   artImageId?: number | null
   dreamIds?: number[]
   characterIds?: number[]
-  facetIds?: number[]
 }): Promise<void> {
   const artImageIds = typeof input.artImageId === 'number' ? [input.artImageId] : []
   const dreamIds = input.dreamIds ?? []
   const characterIds = input.characterIds ?? []
-  const facetIds = input.facetIds ?? []
 
-  const [artImages, dreams, characters, facets] = await Promise.all([
+  const [artImages, dreams, characters] = await Promise.all([
     artImageIds.length
       ? prisma.artImage.findMany({
           where: { id: { in: artImageIds } },
@@ -574,18 +578,11 @@ export async function assertScenarioRelationsExist(input: {
           select: { id: true },
         })
       : [],
-    facetIds.length
-      ? prisma.facet.findMany({
-          where: { id: { in: facetIds } },
-          select: { id: true },
-        })
-      : [],
   ])
 
   assertFound(artImageIds, artImages, 'ArtImage')
   assertFound(dreamIds, dreams, 'Dream')
   assertFound(characterIds, characters, 'Character')
-  assertFound(facetIds, facets, 'Facet')
 }
 
 export async function buildScenarioUpdateInput(
@@ -657,13 +654,11 @@ export async function buildScenarioUpdateInput(
     body.characterIds,
     'characterIds',
   )
-  const facetIds = normalizeScenarioIdArray(body.facetIds, 'facetIds')
 
   await assertScenarioRelationsExist({
     artImageId,
     dreamIds,
     characterIds,
-    facetIds,
   })
 
   if ('artImageId' in body) {
@@ -677,9 +672,6 @@ export async function buildScenarioUpdateInput(
   }
   if (characterIds !== undefined) {
     data.Characters = { set: characterIds.map((id) => ({ id })) }
-  }
-  if (facetIds !== undefined) {
-    data.Facets = { set: facetIds.map((id) => ({ id })) }
   }
 
   return data

--- a/server/api/scenarios/mutation.ts
+++ b/server/api/scenarios/mutation.ts
@@ -35,8 +35,24 @@ const scenarioMutationFields = [
   'secretNotes',
 ] as const
 
-export const scenarioCreateFields = new Set<string>(scenarioMutationFields)
-export const scenarioPatchFields = new Set<string>(scenarioMutationFields)
+// ScenarioForm currently spreads these model fields into singular mutations.
+// They are validated and ignored until the client payload helper is narrowed.
+const scenarioStoreCompatibilityFields = [
+  'id',
+  'userId',
+  'createdAt',
+  'updatedAt',
+] as const
+
+export const scenarioCreateFields = new Set<string>([
+  ...scenarioMutationFields,
+  ...scenarioStoreCompatibilityFields,
+])
+export const scenarioBatchCreateFields = new Set<string>(scenarioMutationFields)
+export const scenarioPatchFields = new Set<string>([
+  ...scenarioMutationFields,
+  ...scenarioStoreCompatibilityFields,
+])
 export const scenarioBatchPatchFields = new Set<string>([
   ...scenarioMutationFields,
   'id',
@@ -44,6 +60,9 @@ export const scenarioBatchPatchFields = new Set<string>([
 
 export type ScenarioMutationInput = Record<string, unknown> & {
   id?: unknown
+  userId?: unknown
+  createdAt?: unknown
+  updatedAt?: unknown
   title?: unknown
   slug?: unknown
   description?: unknown
@@ -72,6 +91,9 @@ type ScenarioBoundaryOptions = {
   allowedFields: ReadonlySet<string>
   context: string
   requireNonEmpty?: boolean
+  authenticatedUserId?: number
+  routeId?: number
+  allowTemporaryId?: boolean
 }
 
 const nullableTextFields = [
@@ -88,6 +110,19 @@ const nullableTextFields = [
 const booleanFields = ['isMature', 'isPublic', 'isActive'] as const
 const relationFields = ['dreamIds', 'characterIds', 'facetIds'] as const
 const outputTypes = Object.values(ScenarioOutputType)
+
+function normalizeCompatibilityId(value: unknown, field: string): number {
+  const id = Number(value)
+
+  if (!Number.isInteger(id)) {
+    throw createError({
+      statusCode: 400,
+      message: `Scenario compatibility field "${field}" must be an integer.`,
+    })
+  }
+
+  return id
+}
 
 export function assertScenarioMutationInput(
   body: unknown,
@@ -121,6 +156,63 @@ export function assertScenarioMutationInput(
   }
 
   const input = body as ScenarioMutationInput
+
+  if (Object.prototype.hasOwnProperty.call(input, 'userId')) {
+    if (!options.authenticatedUserId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Scenario ownership is server-owned.',
+      })
+    }
+
+    const requestedUserId = normalizeCompatibilityId(input.userId, 'userId')
+
+    if (requestedUserId !== options.authenticatedUserId) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Unsupported Scenario ownership assignment. Ownership is server-owned.',
+      })
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'id')) {
+    const requestedId = normalizeCompatibilityId(input.id, 'id')
+
+    if (options.routeId) {
+      if (requestedId !== options.routeId) {
+        throw createError({
+          statusCode: 400,
+          message: 'Scenario ID is immutable and must match the route.',
+        })
+      }
+    } else if (options.allowTemporaryId) {
+      if (requestedId > 0) {
+        throw createError({
+          statusCode: 400,
+          message: 'Scenario create payload cannot assign a persisted ID.',
+        })
+      }
+    } else {
+      throw createError({
+        statusCode: 400,
+        message: 'Scenario ID is server-owned.',
+      })
+    }
+  }
+
+  for (const field of ['createdAt', 'updatedAt'] as const) {
+    if (
+      Object.prototype.hasOwnProperty.call(input, field) &&
+      input[field] !== null &&
+      typeof input[field] !== 'string'
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: `Scenario compatibility field "${field}" must be a string or null.`,
+      })
+    }
+  }
 
   if (input.title !== undefined) {
     normalizeScenarioRequiredString(input.title, 'title')
@@ -371,16 +463,18 @@ export function normalizeScenarioIntros(value: unknown): string {
     })
   }
 
-  const normalized = entries.map((entry, index) => {
-    if (typeof entry !== 'string') {
-      throw createError({
-        statusCode: 400,
-        message: `The "intros" field contains a non-string entry at index ${index}.`,
-      })
-    }
+  const normalized = entries
+    .map((entry, index) => {
+      if (typeof entry !== 'string') {
+        throw createError({
+          statusCode: 400,
+          message: `The "intros" field contains a non-string entry at index ${index}.`,
+        })
+      }
 
-    return entry.trim()
-  }).filter(Boolean)
+      return entry.trim()
+    })
+    .filter(Boolean)
 
   const serialized = JSON.stringify(normalized)
 
@@ -434,26 +528,18 @@ export function normalizeScenarioJsonString(
   return serialized
 }
 
-async function assertIdsExist(options: {
-  model: 'artImage' | 'dream' | 'character' | 'facet'
-  ids: number[]
-  label: string
-}): Promise<void> {
-  if (!options.ids.length) return
-
-  const records = await (prisma[options.model] as {
-    findMany(args: unknown): Promise<Array<{ id: number }>>
-  }).findMany({
-    where: { id: { in: options.ids } },
-    select: { id: true },
-  })
+function assertFound(
+  requestedIds: number[],
+  records: Array<{ id: number }>,
+  label: string,
+): void {
   const found = new Set(records.map((record) => record.id))
-  const missing = options.ids.filter((id) => !found.has(id))
+  const missing = requestedIds.filter((id) => !found.has(id))
 
   if (missing.length) {
     throw createError({
       statusCode: 404,
-      message: `${options.label} IDs not found: ${missing.join(', ')}.`,
+      message: `${label} IDs not found: ${missing.join(', ')}.`,
     })
   }
 }
@@ -464,28 +550,42 @@ export async function assertScenarioRelationsExist(input: {
   characterIds?: number[]
   facetIds?: number[]
 }): Promise<void> {
-  await Promise.all([
-    assertIdsExist({
-      model: 'artImage',
-      ids: typeof input.artImageId === 'number' ? [input.artImageId] : [],
-      label: 'ArtImage',
-    }),
-    assertIdsExist({
-      model: 'dream',
-      ids: input.dreamIds ?? [],
-      label: 'Dream',
-    }),
-    assertIdsExist({
-      model: 'character',
-      ids: input.characterIds ?? [],
-      label: 'Character',
-    }),
-    assertIdsExist({
-      model: 'facet',
-      ids: input.facetIds ?? [],
-      label: 'Facet',
-    }),
+  const artImageIds = typeof input.artImageId === 'number' ? [input.artImageId] : []
+  const dreamIds = input.dreamIds ?? []
+  const characterIds = input.characterIds ?? []
+  const facetIds = input.facetIds ?? []
+
+  const [artImages, dreams, characters, facets] = await Promise.all([
+    artImageIds.length
+      ? prisma.artImage.findMany({
+          where: { id: { in: artImageIds } },
+          select: { id: true },
+        })
+      : [],
+    dreamIds.length
+      ? prisma.dream.findMany({
+          where: { id: { in: dreamIds } },
+          select: { id: true },
+        })
+      : [],
+    characterIds.length
+      ? prisma.character.findMany({
+          where: { id: { in: characterIds } },
+          select: { id: true },
+        })
+      : [],
+    facetIds.length
+      ? prisma.facet.findMany({
+          where: { id: { in: facetIds } },
+          select: { id: true },
+        })
+      : [],
   ])
+
+  assertFound(artImageIds, artImages, 'ArtImage')
+  assertFound(dreamIds, dreams, 'Dream')
+  assertFound(characterIds, characters, 'Character')
+  assertFound(facetIds, facets, 'Facet')
 }
 
 export async function buildScenarioUpdateInput(
@@ -505,22 +605,45 @@ export async function buildScenarioUpdateInput(
     data.outputType = normalizeScenarioOutputType(body.outputType)
   }
   if ('cast' in body) data.cast = normalizeScenarioJsonString(body.cast, 'cast')
-
-  for (const field of nullableTextFields) {
-    if (field in body) {
-      data[field] = normalizeScenarioNullableString(
-        body[field],
-        field,
-      ) as never
-    }
+  if ('imagePath' in body) {
+    data.imagePath = normalizeScenarioNullableString(body.imagePath, 'imagePath')
   }
-
-  for (const field of booleanFields) {
-    if (field in body) {
-      data[field] = normalizeScenarioBoolean(body[field], field) as never
-    }
+  if ('locations' in body) {
+    data.locations = normalizeScenarioNullableString(body.locations, 'locations')
   }
-
+  if ('artPrompt' in body) {
+    data.artPrompt = normalizeScenarioNullableString(body.artPrompt, 'artPrompt')
+  }
+  if ('genres' in body) {
+    data.genres = normalizeScenarioNullableString(body.genres, 'genres')
+  }
+  if ('inspirations' in body) {
+    data.inspirations = normalizeScenarioNullableString(
+      body.inspirations,
+      'inspirations',
+    )
+  }
+  if ('tier' in body) {
+    data.tier = normalizeScenarioNullableString(body.tier, 'tier')
+  }
+  if ('group' in body) {
+    data.group = normalizeScenarioNullableString(body.group, 'group')
+  }
+  if ('secretNotes' in body) {
+    data.secretNotes = normalizeScenarioNullableString(
+      body.secretNotes,
+      'secretNotes',
+    )
+  }
+  if ('isMature' in body) {
+    data.isMature = normalizeScenarioBoolean(body.isMature, 'isMature')
+  }
+  if ('isPublic' in body) {
+    data.isPublic = normalizeScenarioBoolean(body.isPublic, 'isPublic')
+  }
+  if ('isActive' in body) {
+    data.isActive = normalizeScenarioBoolean(body.isActive, 'isActive')
+  }
   if ('difficulty' in body) {
     data.difficulty = normalizeScenarioNullableInteger(
       body.difficulty,

--- a/utils/scripts/verifyScenarioMutationInputParity.ts
+++ b/utils/scripts/verifyScenarioMutationInputParity.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/api/scenarios/mutation.ts')
+const createHelper = read('server/api/scenarios/create.ts')
+const createRoute = read('server/api/scenarios/index.post.ts')
+const patchRoute = read('server/api/scenarios/[id].patch.ts')
+const batchCreateRoute = read('server/api/scenarios/batch.post.ts')
+const batchPatchRoute = read('server/api/scenarios/batch.patch.ts')
+const cypressSpec = read('cypress/e2e/api/scenario-input-boundary.cy.ts')
+
+requireText(
+  boundary,
+  'export const SCENARIO_RELATION_ID_LIMIT = 100',
+  'Scenario relation cap',
+)
+requireText(
+  boundary,
+  'export const SCENARIO_BATCH_LIMIT = 100',
+  'Scenario batch cap',
+)
+requireText(
+  boundary,
+  "const scenarioStoreCompatibilityFields = [",
+  'Scenario singular store compatibility stage',
+)
+requireText(
+  boundary,
+  'export const scenarioBatchCreateFields = new Set<string>(scenarioMutationFields)',
+  'Scenario strict batch create fields',
+)
+requireText(
+  boundary,
+  'Unsupported Scenario ownership assignment. Ownership is server-owned.',
+  'Scenario ownership-match boundary',
+)
+requireText(
+  boundary,
+  'Scenario ID is immutable and must match the route.',
+  'Scenario route ID boundary',
+)
+requireText(
+  boundary,
+  'contains an invalid ID at index ${index}',
+  'Scenario invalid relation rejection',
+)
+requireText(
+  boundary,
+  'data.Facets = { set: facetIds.map((id) => ({ id })) }',
+  'Scenario Facet update persistence',
+)
+
+requireText(
+  createHelper,
+  'allowedFields: options.batch',
+  'Scenario singular/batch field selection',
+)
+requireText(
+  createHelper,
+  'Characters: characterIds?.length',
+  'Scenario Character create persistence',
+)
+requireText(
+  createHelper,
+  'Facets: facetIds?.length',
+  'Scenario Facet create persistence',
+)
+requireText(
+  createRoute,
+  'await buildScenarioCreateInput(body, user.id)',
+  'Scenario singular create boundary',
+)
+requireText(
+  patchRoute,
+  'allowedFields: scenarioPatchFields',
+  'Scenario singular patch boundary',
+)
+requireText(
+  patchRoute,
+  'routeId: id',
+  'Scenario singular route ID validation',
+)
+requireText(
+  batchCreateRoute,
+  '{ batch: true }',
+  'Scenario strict batch create boundary',
+)
+requireText(
+  batchCreateRoute,
+  'body.length > SCENARIO_BATCH_LIMIT',
+  'Scenario batch create cap',
+)
+requireText(
+  batchPatchRoute,
+  'allowedFields: scenarioBatchPatchFields',
+  'Scenario batch patch item boundary',
+)
+requireText(
+  batchPatchRoute,
+  'record.updates.length > SCENARIO_BATCH_LIMIT',
+  'Scenario batch patch cap',
+)
+forbidText(
+  patchRoute,
+  'function normalizePositiveIdArray',
+  'Scenario duplicate singular normalizer',
+)
+forbidText(
+  batchPatchRoute,
+  'function normalizePositiveIdArray',
+  'Scenario duplicate batch normalizer',
+)
+
+requireText(
+  cypressSpec,
+  'rejects unknown and spoofed fields on singular Scenario creation',
+  'Scenario singular deployed regression',
+)
+requireText(
+  cypressSpec,
+  'keeps singular ScenarioStore compatibility explicit and auth-bound',
+  'Scenario compatibility deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown, mismatched ID, and oversized PATCH fields',
+  'Scenario patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'keeps Scenario batch create and patch imports strict and bounded',
+  'Scenario batch deployed regression',
+)
+
+console.log('Scenario mutation input parity contract passed.')

--- a/utils/scripts/verifyScenarioMutationInputParity.ts
+++ b/utils/scripts/verifyScenarioMutationInputParity.ts
@@ -40,8 +40,18 @@ requireText(
 )
 requireText(
   boundary,
-  "const scenarioStoreCompatibilityFields = [",
+  'const scenarioStoreCompatibilityFields = [',
   'Scenario singular store compatibility stage',
+)
+requireText(
+  boundary,
+  "'facetIds',",
+  'Scenario Facet compatibility field',
+)
+requireText(
+  boundary,
+  'no writable ScenarioCreateInput/ScenarioUpdateInput relation',
+  'Scenario Facet write limitation documentation',
 )
 requireText(
   boundary,
@@ -63,10 +73,15 @@ requireText(
   'contains an invalid ID at index ${index}',
   'Scenario invalid relation rejection',
 )
-requireText(
+forbidText(
   boundary,
-  'data.Facets = { set: facetIds.map((id) => ({ id })) }',
-  'Scenario Facet update persistence',
+  'data.Facets =',
+  'Unsupported Scenario Facet update write',
+)
+forbidText(
+  createHelper,
+  'Facets:',
+  'Unsupported Scenario Facet create write',
 )
 
 requireText(
@@ -78,11 +93,6 @@ requireText(
   createHelper,
   'Characters: characterIds?.length',
   'Scenario Character create persistence',
-)
-requireText(
-  createHelper,
-  'Facets: facetIds?.length',
-  'Scenario Facet create persistence',
 )
 requireText(
   createRoute,


### PR DESCRIPTION
## Summary

- adds one shared runtime mutation boundary across singular Scenario create, singular PATCH, batch create, and batch PATCH
- rejects unknown fields, spoofed ownership, persisted IDs on create, mismatched route IDs, malformed enums/booleans/JSON, and invalid relation IDs
- caps Scenario batches, batch patches, intro arrays, and relation arrays at 100 entries
- validates ArtImage, Dream, and Character relation targets before writes
- persists Character selections that the Scenario store previously sent but the API silently ignored
- explicitly validates `facetIds` as compatibility-only because Prisma exposes Facets in Scenario reads but no writable Scenario create/update relation
- replaces duplicated singular/batch PATCH normalization with the shared builder
- keeps current ScenarioStore model-field compatibility explicit: matching `userId`, matching/temporary `id`, serialized timestamps, and bounded `facetIds` are validated and ignored rather than trusted
- keeps batch imports strict and preserves per-item `207` behavior
- adds deployed create/PATCH/batch regressions plus a DB-free parity contract and read-only workflow

## Why

The Scenario mutation family had four different input contracts. Create silently defaulted malformed values and discarded bad relation IDs, PATCH duplicated stricter normalization, batch create had no size cap, batch PATCH duplicated another validator, and Character selections were silently lost. This establishes one deliberate boundary without weakening ownership or batch isolation.

## Checks

- Scenario Mutation Input Parity
- TypeScript Type Check
- Contract Tests
