### PR TITLE
Enforce Character mutation input parity

### DIFF
--- a/.github/workflows/character-mutation-input-parity.yml
+++ b/.github/workflows/character-mutation-input-parity.yml
@@ -1,0 +1,40 @@
+name: Character Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/characters/mutation.ts'
+      - 'server/api/characters/compatibility.ts'
+      - 'server/api/characters/index.post.ts'
+      - 'server/api/characters/[id].patch.ts'
+      - 'server/api/characters/batch.post.ts'
+      - 'cypress/e2e/api/character-input-boundary.cy.ts'
+      - 'utils/scripts/verifyCharacterMutationInputParity.ts'
+      - '.github/workflows/character-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Character mutation input parity
+        run: npx tsx utils/scripts/verifyCharacterMutationInputParity.ts

--- a/cypress/e2e/api/character-input-boundary.cy.ts
+++ b/cypress/e2e/api/character-input-boundary.cy.ts
@@ -1,0 +1,244 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+type CharacterRow = {
+  id: number
+  name: string
+  userId: number
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Character mutation input boundary', () => {
+  const stamp = Date.now()
+  let apiBase = ''
+  let adminToken = ''
+  let ownerId: number | undefined
+  let ownerToken = ''
+  let otherId: number | undefined
+  let characterId: number | undefined
+
+  const charactersUrl = () => `${apiBase}/characters`
+  const headers = () => bearerHeaders(ownerToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((owner) => {
+        ownerId = owner.id
+        ownerToken = owner.token
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherId = other.id
+      })
+  })
+
+  after(() => {
+    if (characterId) {
+      cy.request({
+        method: 'DELETE',
+        url: `${charactersUrl()}/${characterId}`,
+        headers: headers(),
+        failOnStatusCode: false,
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
+  })
+
+  it('rejects unknown and malformed Character create fields', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        name: `Unknown Character Field ${stamp}`,
+        createdBy: 'client',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Character fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        name: `Invalid Character Rarity ${stamp}`,
+        luck: 'IMPOSSIBLE',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('luck')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        name: `Invalid Character Boolean ${stamp}`,
+        isPublic: 'yes',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('isPublic')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        name: `Invalid Character Level ${stamp}`,
+        level: 0,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('level')
+    })
+  })
+
+  it('rejects oversized and invalid Character relation arrays', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        name: `Oversized Character Relations ${stamp}`,
+        rewardIds: Array.from({ length: 101 }, (_, index) => index + 1),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        name: `Invalid Character Relations ${stamp}`,
+        dreamIds: [1, 0],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('invalid ID at index 1')
+    })
+  })
+
+  it('ignores legacy create ownership metadata and persists authentication', () => {
+    expect(ownerId).to.be.a('number').and.greaterThan(0)
+    expect(otherId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse<CharacterRow>>({
+      method: 'POST',
+      url: charactersUrl(),
+      headers: headers(),
+      body: {
+        userId: otherId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        name: `Character Boundary Control ${stamp}`,
+        honorific: 'adventurer',
+        luck: 1,
+        might: 'UNCOMMON',
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+      characterId = response.body.data?.id
+      expect(characterId).to.be.a('number').and.greaterThan(0)
+    })
+  })
+
+  it('rejects Character ownership and route identity changes on PATCH', () => {
+    expect(characterId).to.be.a('number').and.greaterThan(0)
+    expect(otherId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${charactersUrl()}/${characterId}`,
+      headers: headers(),
+      body: {
+        userId: otherId,
+        title: 'Spoofed owner update',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${charactersUrl()}/${characterId}`,
+      headers: headers(),
+      body: {
+        id: (characterId ?? 0) + 1,
+        title: 'Wrong route identity',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('must match the route')
+    })
+  })
+
+  it('keeps Character batch imports strict, bounded, and lean', () => {
+    expect(ownerId).to.be.a('number').and.greaterThan(0)
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${charactersUrl()}/batch`,
+      headers: headers(),
+      body: [
+        {
+          name: `Batch Character Identity ${stamp}`,
+          userId: ownerId,
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Character fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${charactersUrl()}/batch`,
+      headers: headers(),
+      body: Array.from({ length: 101 }, (_, index) => ({
+        name: `Oversized Character Batch ${stamp}-${index}`,
+      })),
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+  })
+})

--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -4,148 +4,23 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { normalizeSlugInput } from '../../../utils/slugify'
+import { getUniqueCharacterSlug } from '../../utils/characterSlug'
 import {
-  findCharacterNameDuplicate,
-  getCharacterNameKey,
-  getUniqueCharacterSlug,
-} from '../../utils/characterSlug'
-import type { Character, Prisma } from '~/prisma/generated/prisma/client'
+  assertCharacterMutationInput,
+  buildCharacterUpdateInput,
+  characterPatchFields,
+  normalizeCharacterName,
+} from './mutation'
 import { characterMutationSelect } from './selects'
 
-type CharacterPatchBody = Partial<Character> & {
-  rewardIds?: unknown
-  scenarioIds?: unknown
-  dreamIds?: unknown
-}
-
-function normalizePositiveIdArray(value: unknown, field: string): number[] {
-  if (!Array.isArray(value)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must be an array of positive integer IDs.`,
-    })
-  }
-
-  const ids = value.map((entry) => Number(entry))
-
-  if (!ids.every((entry) => Number.isInteger(entry) && entry > 0)) {
-    throw createError({
-      statusCode: 400,
-      message: `The "${field}" field must contain only positive integer IDs.`,
-    })
-  }
-
-  return [...new Set(ids)]
-}
-
-function normalizeArtImageRelation(
-  value: unknown,
-): Prisma.ArtImageUpdateOneWithoutCharactersNestedInput {
-  if (value === null || value === '') return { disconnect: true }
-
-  const id = Number(value)
-
-  if (!Number.isInteger(id) || id <= 0) {
-    throw createError({
-      statusCode: 400,
-      message: 'artImageId must be a positive integer or null when provided.',
-    })
-  }
-
-  return { connect: { id } }
-}
-
-function getStringOrUndefined(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function getTrimmedStringOrUndefined(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  return trimmed || undefined
-}
-
-function getBooleanOrUndefined(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
-}
-
-function getNumberOrUndefined(value: unknown): number | undefined {
-  if (value === null || typeof value === 'undefined' || value === '') {
-    return undefined
-  }
-
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : undefined
-}
-
-function hasUpdateData(data: Record<string, unknown>): boolean {
-  return Object.values(data).some((value) => value !== undefined)
-}
-
-async function assertRelatedRecordsExist(options: {
-  rewardIds?: number[]
-  scenarioIds?: number[]
-  dreamIds?: number[]
-}) {
-  const { rewardIds, scenarioIds, dreamIds } = options
-
-  if (rewardIds?.length) {
-    const records = await prisma.reward.findMany({
-      where: { id: { in: rewardIds } },
-      select: { id: true },
-    })
-    const foundIds = new Set(records.map((record) => record.id))
-    const missingIds = rewardIds.filter((id) => !foundIds.has(id))
-
-    if (missingIds.length) {
-      throw createError({
-        statusCode: 404,
-        message: `Reward IDs not found: ${missingIds.join(', ')}.`,
-      })
-    }
-  }
-
-  if (scenarioIds?.length) {
-    const records = await prisma.scenario.findMany({
-      where: { id: { in: scenarioIds } },
-      select: { id: true },
-    })
-    const foundIds = new Set(records.map((record) => record.id))
-    const missingIds = scenarioIds.filter((id) => !foundIds.has(id))
-
-    if (missingIds.length) {
-      throw createError({
-        statusCode: 404,
-        message: `Scenario IDs not found: ${missingIds.join(', ')}.`,
-      })
-    }
-  }
-
-  if (dreamIds?.length) {
-    const records = await prisma.dream.findMany({
-      where: { id: { in: dreamIds } },
-      select: { id: true },
-    })
-    const foundIds = new Set(records.map((record) => record.id))
-    const missingIds = dreamIds.filter((id) => !foundIds.has(id))
-
-    if (missingIds.length) {
-      throw createError({
-        statusCode: 404,
-        message: `Dream IDs not found: ${missingIds.join(', ')}.`,
-      })
-    }
-  }
-}
-
 export default defineEventHandler(async (event) => {
-  const id = Number(getRouterParam(event, 'id'))
-
   try {
+    const id = Number(getRouterParam(event, 'id'))
+
     if (!Number.isInteger(id) || id <= 0) {
       throw createError({
         statusCode: 400,
-        message: 'Invalid character ID. It must be a positive integer.',
+        message: 'Invalid Character ID. It must be a positive integer.',
       })
     }
 
@@ -171,159 +46,74 @@ export default defineEventHandler(async (event) => {
     if (!existingCharacter) {
       throw createError({
         statusCode: 404,
-        message: 'Character not found.',
+        message: `Character with ID ${id} does not exist.`,
       })
     }
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
     const isServerKey = kind === 'server'
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
     const isOwner = existingCharacter.userId === user.id
 
-    if (!isOwner && !isAdmin && !isServerKey) {
+    if (!isAdmin && !isServerKey && !isOwner) {
       throw createError({
         statusCode: 403,
-        message: 'You do not have permission to update this character.',
+        message: 'You do not have permission to update this Character.',
       })
     }
 
-    const body = await readBody<CharacterPatchBody>(event)
+    const body = await readBody<unknown>(event)
 
-    if (!body || Object.keys(body).length === 0) {
-      throw createError({
-        statusCode: 400,
-        message: 'No data provided for update.',
+    assertCharacterMutationInput(body, {
+      allowedFields: characterPatchFields,
+      context: 'Character patch payload',
+      requireNonEmpty: true,
+    })
+
+    const data = await buildCharacterUpdateInput(body)
+
+    if (body.name !== undefined) {
+      const name = normalizeCharacterName(body.name)
+      const duplicate = await prisma.character.findFirst({
+        where: {
+          userId: existingCharacter.userId,
+          name,
+          NOT: { id },
+        },
+        select: { id: true },
       })
-    }
-
-    const nextName = getTrimmedStringOrUndefined(body.name)
-
-    if (typeof body.name === 'string' && !nextName) {
-      throw createError({
-        statusCode: 400,
-        message: 'Character name must contain at least one letter or number.',
-      })
-    }
-
-    if (nextName && !getCharacterNameKey(nextName)) {
-      throw createError({
-        statusCode: 400,
-        message: 'Character name must contain at least one letter or number.',
-      })
-    }
-
-    if (nextName && nextName !== existingCharacter.name) {
-      const duplicate = await findCharacterNameDuplicate(
-        prisma,
-        existingCharacter.userId,
-        nextName,
-        id,
-      )
 
       if (duplicate) {
         throw createError({
           statusCode: 409,
-          message: `Character "${nextName}" already exists as #${duplicate.id}.`,
+          message: `Character with this name already exists (ID ${duplicate.id}).`,
         })
       }
+
+      data.name = name
     }
 
     const requestedSlug = normalizeSlugInput(body.slug)
-    let nextSlug: string | null | undefined
 
-    if (typeof requestedSlug !== 'undefined') {
-      nextSlug = requestedSlug
+    if (body.slug !== undefined) {
+      data.slug = requestedSlug
         ? await getUniqueCharacterSlug(prisma, requestedSlug, { excludeId: id })
         : null
-    } else if (!existingCharacter.slug) {
-      nextSlug = await getUniqueCharacterSlug(
-        prisma,
-        nextName ?? existingCharacter.name,
-        { excludeId: id },
-      )
-    }
-
-    const rewardIds =
-      'rewardIds' in body
-        ? normalizePositiveIdArray(body.rewardIds, 'rewardIds')
-        : undefined
-    const scenarioIds =
-      'scenarioIds' in body
-        ? normalizePositiveIdArray(body.scenarioIds, 'scenarioIds')
-        : undefined
-    const dreamIds =
-      'dreamIds' in body
-        ? normalizePositiveIdArray(body.dreamIds, 'dreamIds')
-        : undefined
-
-    await assertRelatedRecordsExist({ rewardIds, scenarioIds, dreamIds })
-
-    const updateData: Prisma.CharacterUpdateInput = {
-      name: nextName,
-      slug: nextSlug,
-      honorific: getStringOrUndefined(body.honorific),
-      title: getStringOrUndefined(body.title),
-      role: getStringOrUndefined(body.role),
-      class: getStringOrUndefined(body.class),
-      species: getStringOrUndefined(body.species),
-      gender: getStringOrUndefined(body.gender),
-      presentation: getStringOrUndefined(body.presentation),
-      genre: getStringOrUndefined(body.genre),
-      alignment: getStringOrUndefined(body.alignment),
-      personality: getStringOrUndefined(body.personality),
-      sampleResponse: getStringOrUndefined(body.sampleResponse),
-      voice: getStringOrUndefined(body.voice),
-      drive: getStringOrUndefined(body.drive),
-      backstory: getStringOrUndefined(body.backstory),
-      achievements: getStringOrUndefined(body.achievements),
-      quirks: getStringOrUndefined(body.quirks),
-      artPrompt: getStringOrUndefined(body.artPrompt),
-      imagePath: getStringOrUndefined(body.imagePath),
-      designer: getStringOrUndefined(body.designer),
-      experience: getNumberOrUndefined(body.experience),
-      level: getNumberOrUndefined(body.level),
-      isPublic: getBooleanOrUndefined(body.isPublic),
-      isMature: getBooleanOrUndefined(body.isMature),
-      isActive: getBooleanOrUndefined(body.isActive),
-      luck: body.luck,
-      might: body.might,
-      wits: body.wits,
-      grace: body.grace,
-      charm: body.charm,
-      empathy: body.empathy,
-    }
-
-    if ('artImageId' in body) {
-      updateData.ArtImage = normalizeArtImageRelation(body.artImageId)
-    }
-
-    if (rewardIds) {
-      updateData.Rewards = {
-        set: rewardIds.map((rewardId) => ({ id: rewardId })),
-      }
-    }
-
-    if (scenarioIds) {
-      updateData.Scenarios = {
-        set: scenarioIds.map((scenarioId) => ({ id: scenarioId })),
-      }
-    }
-
-    if (dreamIds) {
-      updateData.Dreams = {
-        set: dreamIds.map((dreamId) => ({ id: dreamId })),
-      }
-    }
-
-    if (!hasUpdateData(updateData as Record<string, unknown>)) {
-      throw createError({
-        statusCode: 400,
-        message: 'No valid character fields provided for update.',
+    } else if (!existingCharacter.slug && body.name !== undefined) {
+      data.slug = await getUniqueCharacterSlug(prisma, data.name as string, {
+        excludeId: id,
       })
     }
 
-    const data = await prisma.character.update({
+    if (Object.keys(data).length === 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'No valid Character update fields provided.',
+      })
+    }
+
+    const updatedCharacter = await prisma.character.update({
       where: { id },
-      data: updateData,
+      data,
       select: characterMutationSelect,
     })
 
@@ -332,18 +122,20 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: 'Character updated successfully.',
-      data,
+      data: updatedCharacter,
       statusCode: 200,
     }
   } catch (error) {
-    const { message, statusCode } = errorHandler(error)
-    event.node.res.statusCode = statusCode || 500
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
 
     return {
       success: false,
-      message: message || `Failed to update character with ID ${id}.`,
+      message: handled.message || 'Failed to update Character.',
       data: null,
-      statusCode: event.node.res.statusCode,
+      statusCode,
     }
   }
 })

--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -8,9 +8,13 @@ import { getUniqueCharacterSlug } from '../../utils/characterSlug'
 import {
   assertCharacterMutationInput,
   buildCharacterUpdateInput,
-  characterPatchFields,
   normalizeCharacterName,
 } from './mutation'
+import {
+  assertCharacterPatchCompatibility,
+  characterSingularPatchFields,
+  stripCharacterCompatibilityFields,
+} from './compatibility'
 import { characterMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
@@ -61,14 +65,16 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const body = await readBody<unknown>(event)
+    const rawBody = await readBody<unknown>(event)
 
-    assertCharacterMutationInput(body, {
-      allowedFields: characterPatchFields,
+    assertCharacterMutationInput(rawBody, {
+      allowedFields: characterSingularPatchFields,
       context: 'Character patch payload',
       requireNonEmpty: true,
     })
+    assertCharacterPatchCompatibility(rawBody, id, existingCharacter.userId)
 
+    const body = stripCharacterCompatibilityFields(rawBody)
     const data = await buildCharacterUpdateInput(body)
 
     if (body.name !== undefined) {

--- a/server/api/characters/batch.post.ts
+++ b/server/api/characters/batch.post.ts
@@ -1,5 +1,5 @@
 // /server/api/characters/batch.post.ts
-import { defineEventHandler, readBody, createError } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import prisma from '../../utils/prisma'
@@ -8,200 +8,65 @@ import {
   getCharacterNameKey,
   getUniqueCharacterSlug,
 } from '../../utils/characterSlug'
-import type {
-  Prisma,
-  Character,
-  Rarity,
-} from '~/prisma/generated/prisma/client'
+import {
+  assertCharacterMutationInput,
+  buildCharacterCreateInput,
+  CHARACTER_BATCH_LIMIT,
+  characterBatchCreateFields,
+  normalizeCharacterName,
+  type CharacterMutationInput,
+} from './mutation'
+import {
+  characterMutationSelect,
+  type CharacterMutationResult,
+} from './selects'
 
-type ConnectById = {
-  id: number
-}
-
-type RelationConnectInput = {
-  connect?: ConnectById | ConnectById[]
-}
-
-type CharacterBatchCreateBody = Partial<Character> & {
-  rewardIds?: number[]
-  scenarioIds?: number[]
-  dreamIds?: number[]
-  Rewards?: RelationConnectInput
-  Scenarios?: RelationConnectInput
-  Dreams?: RelationConnectInput
-}
+const transactionMaxWaitMs = 10_000
+const transactionTimeoutMs = 30_000
 
 type BatchBody =
-  | CharacterBatchCreateBody[]
+  | CharacterMutationInput[]
   | {
-      characters?: CharacterBatchCreateBody[]
-      data?: CharacterBatchCreateBody[]
+      characters?: CharacterMutationInput[]
+      data?: CharacterMutationInput[]
     }
 
-const fallbackRarity: Rarity = 'COMMON'
-const transactionMaxWaitMs = 10000
-const transactionTimeoutMs = 30000
+function normalizeBatchBody(body: unknown): CharacterMutationInput[] {
+  if (Array.isArray(body)) return body as CharacterMutationInput[]
 
-const characterInclude = {
-  ArtImage: true,
-  Rewards: true,
-  Scenarios: true,
-  Dreams: true,
-} satisfies Prisma.CharacterInclude
-
-type CreatedCharacter = Prisma.CharacterGetPayload<{
-  include: typeof characterInclude
-}>
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function normalizeRarity(value: unknown): Rarity {
-  if (
-    value === 'COMMON' ||
-    value === 'UNCOMMON' ||
-    value === 'RARE' ||
-    value === 'EPIC' ||
-    value === 'LEGENDARY' ||
-    value === 'MYTHIC'
-  ) {
-    return value
-  }
-
-  if (typeof value === 'number') {
-    const rarityByNumber: Record<number, Rarity> = {
-      1: 'COMMON',
-      2: 'UNCOMMON',
-      3: 'RARE',
-      4: 'EPIC',
-      5: 'LEGENDARY',
-      6: 'MYTHIC',
-    }
-
-    return rarityByNumber[value] ?? fallbackRarity
-  }
-
-  return fallbackRarity
-}
-
-function normalizeIdArray(value: unknown, fieldName: string): number[] {
-  if (typeof value === 'undefined' || value === null) return []
-
-  if (!Array.isArray(value)) {
+  if (!body || typeof body !== 'object') {
     throw createError({
       statusCode: 400,
-      message: `${fieldName} must be an array of IDs.`,
+      message:
+        'Request body must be an array, or an object with a characters array.',
     })
   }
 
-  const ids = value.map((entry) => Number(entry))
+  const record = body as Record<string, unknown>
+  const unsupported = Object.keys(record).filter(
+    (field) => field !== 'characters' && field !== 'data',
+  )
 
-  if (!ids.every((id) => Number.isInteger(id) && id > 0)) {
+  if (unsupported.length) {
     throw createError({
       statusCode: 400,
-      message: `${fieldName} must contain only positive integers.`,
+      message: `Unsupported Character batch fields: ${unsupported.join(', ')}.`,
     })
   }
 
-  return [...new Set(ids)]
-}
-
-function normalizeConnectIds(value: unknown, fieldName: string): number[] {
-  if (typeof value === 'undefined' || value === null) return []
-
-  if (!isRecord(value)) {
+  if (Array.isArray(record.characters) && Array.isArray(record.data)) {
     throw createError({
       statusCode: 400,
-      message: `${fieldName} must use { connect: [{ id }] }.`,
+      message: 'Send either "characters" or "data", not both.',
     })
   }
 
-  const connect = value.connect
-
-  if (typeof connect === 'undefined' || connect === null) return []
-
-  const entries = Array.isArray(connect) ? connect : [connect]
-
-  const ids = entries.map((entry) => {
-    if (!isRecord(entry)) return NaN
-    return Number(entry.id)
-  })
-
-  if (!ids.every((id) => Number.isInteger(id) && id > 0)) {
-    throw createError({
-      statusCode: 400,
-      message: `${fieldName}.connect must contain only positive integer IDs.`,
-    })
+  if (Array.isArray(record.characters)) {
+    return record.characters as CharacterMutationInput[]
   }
 
-  return [...new Set(ids)]
-}
-
-function normalizeRelationIds(
-  directValue: unknown,
-  connectValue: unknown,
-  directFieldName: string,
-  connectFieldName: string,
-): number[] {
-  return [
-    ...new Set([
-      ...normalizeIdArray(directValue, directFieldName),
-      ...normalizeConnectIds(connectValue, connectFieldName),
-    ]),
-  ]
-}
-
-function cleanText(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function cleanShortText(value: unknown): string | null {
-  const text = cleanText(value)
-  return text ? text.slice(0, 764) : null
-}
-
-function normalizeBoolean(value: unknown, fallback: boolean): boolean {
-  return typeof value === 'boolean' ? value : fallback
-}
-
-function normalizeOptionalPositiveInt(
-  value: unknown,
-  fieldName: string,
-): number | null {
-  if (typeof value === 'undefined' || value === null) return null
-
-  const id = Number(value)
-
-  if (!Number.isInteger(id) || id <= 0) {
-    throw createError({
-      statusCode: 400,
-      message: `${fieldName} must be a positive integer.`,
-    })
-  }
-
-  return id
-}
-
-function normalizeLevel(value: unknown): number {
-  const level = Number(value)
-  return Number.isInteger(level) && level > 0 ? level : 1
-}
-
-function normalizeExperience(value: unknown): number {
-  const experience = Number(value)
-  return Number.isInteger(experience) && experience >= 0 ? experience : 0
-}
-
-function normalizeBatchBody(body: BatchBody): CharacterBatchCreateBody[] {
-  if (Array.isArray(body)) return body
-
-  if (isRecord(body) && Array.isArray(body.characters)) {
-    return body.characters as CharacterBatchCreateBody[]
-  }
-
-  if (isRecord(body) && Array.isArray(body.data)) {
-    return body.data as CharacterBatchCreateBody[]
+  if (Array.isArray(record.data)) {
+    return record.data as CharacterMutationInput[]
   }
 
   throw createError({
@@ -211,115 +76,8 @@ function normalizeBatchBody(body: BatchBody): CharacterBatchCreateBody[] {
   })
 }
 
-function buildCharacterCreateInput(
-  characterData: CharacterBatchCreateBody,
-  userId: number,
-  index: number,
-  slug: string | null,
-): Prisma.CharacterCreateInput {
-  if (!characterData.name || typeof characterData.name !== 'string') {
-    throw createError({
-      statusCode: 400,
-      message: `characters[${index}].name is required and must be a string.`,
-    })
-  }
-
-  const rewardIds = normalizeRelationIds(
-    characterData.rewardIds,
-    characterData.Rewards,
-    `characters[${index}].rewardIds`,
-    `characters[${index}].Rewards`,
-  )
-
-  const scenarioIds = normalizeRelationIds(
-    characterData.scenarioIds,
-    characterData.Scenarios,
-    `characters[${index}].scenarioIds`,
-    `characters[${index}].Scenarios`,
-  )
-
-  const dreamIds = normalizeRelationIds(
-    characterData.dreamIds,
-    characterData.Dreams,
-    `characters[${index}].dreamIds`,
-    `characters[${index}].Dreams`,
-  )
-
-  const artImageId = normalizeOptionalPositiveInt(
-    characterData.artImageId,
-    `characters[${index}].artImageId`,
-  )
-
-  return {
-    User: {
-      connect: {
-        id: userId,
-      },
-    },
-
-    name: characterData.name.trim(),
-    slug,
-    honorific: cleanShortText(characterData.honorific) ?? 'adventurer',
-    title: cleanShortText(characterData.title),
-    role: cleanShortText(characterData.role),
-    class: cleanShortText(characterData.class),
-    species: cleanShortText(characterData.species),
-    gender: cleanShortText(characterData.gender),
-    presentation: cleanShortText(characterData.presentation),
-    genre: cleanShortText(characterData.genre),
-    alignment: cleanShortText(characterData.alignment),
-    personality: cleanText(characterData.personality),
-    drive: cleanShortText(characterData.drive),
-    backstory: cleanText(characterData.backstory),
-    achievements: cleanShortText(characterData.achievements),
-    quirks: cleanText(characterData.quirks),
-
-    luck: normalizeRarity(characterData.luck),
-    might: normalizeRarity(characterData.might),
-    wits: normalizeRarity(characterData.wits),
-    grace: normalizeRarity(characterData.grace),
-    charm: normalizeRarity(characterData.charm),
-    empathy: normalizeRarity(characterData.empathy),
-
-    artPrompt: cleanText(characterData.artPrompt),
-    imagePath: cleanShortText(characterData.imagePath),
-    experience: normalizeExperience(characterData.experience),
-    level: normalizeLevel(characterData.level),
-    designer: cleanShortText(characterData.designer),
-    isPublic: normalizeBoolean(characterData.isPublic, true),
-    isMature: normalizeBoolean(characterData.isMature, false),
-    isActive: normalizeBoolean(characterData.isActive, true),
-
-    ArtImage: artImageId
-      ? {
-          connect: {
-            id: artImageId,
-          },
-        }
-      : undefined,
-
-    Rewards: rewardIds.length
-      ? {
-          connect: rewardIds.map((id) => ({ id })),
-        }
-      : undefined,
-
-    Scenarios: scenarioIds.length
-      ? {
-          connect: scenarioIds.map((id) => ({ id })),
-        }
-      : undefined,
-
-    Dreams: dreamIds.length
-      ? {
-          connect: dreamIds.map((id) => ({ id })),
-        }
-      : undefined,
-  }
-}
-
 async function resolveCharacterSlugs(
-  characters: CharacterBatchCreateBody[],
+  characters: CharacterMutationInput[],
   userId: number,
 ): Promise<(string | null)[]> {
   const existingCharacters = await prisma.character.findMany({
@@ -327,9 +85,7 @@ async function resolveCharacterSlugs(
     select: { id: true, name: true, slug: true },
     orderBy: { id: 'asc' },
   })
-
-  type ExistingCharacter = (typeof existingCharacters)[number]
-  const existingKeys = new Map<string, ExistingCharacter>(
+  const existingKeys = new Map(
     existingCharacters.map((character) => [
       getCharacterNameKey(character.name),
       character,
@@ -340,14 +96,12 @@ async function resolveCharacterSlugs(
   const slugs: (string | null)[] = []
 
   for (const [index, characterData] of characters.entries()) {
-    if (!characterData.name || typeof characterData.name !== 'string') {
-      throw createError({
-        statusCode: 400,
-        message: `characters[${index}].name is required and must be a string.`,
-      })
-    }
+    assertCharacterMutationInput(characterData, {
+      allowedFields: characterBatchCreateFields,
+      context: `Character batch item ${index}`,
+    })
 
-    const name = characterData.name.trim()
+    const name = normalizeCharacterName(characterData.name)
     const nameKey = getCharacterNameKey(name)
 
     if (!nameKey) {
@@ -368,7 +122,7 @@ async function resolveCharacterSlugs(
 
     const firstBatchIndex = batchKeys.get(nameKey)
 
-    if (typeof firstBatchIndex !== 'undefined') {
+    if (firstBatchIndex !== undefined) {
       throw createError({
         statusCode: 400,
         message: `characters[${index}].name duplicates characters[${firstBatchIndex}].name.`,
@@ -410,23 +164,36 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const slugs = await resolveCharacterSlugs(characters, user.id)
+    if (characters.length > CHARACTER_BATCH_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `Character batch may contain at most ${CHARACTER_BATCH_LIMIT} entries.`,
+      })
+    }
 
-    const createInputs = characters.map((characterData, index) =>
-      buildCharacterCreateInput(characterData, user.id, index, slugs[index] ?? null),
+    const slugs = await resolveCharacterSlugs(characters, user.id)
+    const createInputs = await Promise.all(
+      characters.map((characterData, index) =>
+        buildCharacterCreateInput({
+          rawInput: characterData,
+          userId: user.id,
+          slug: slugs[index] ?? null,
+          batch: true,
+        }),
+      ),
     )
 
     const data = await prisma.$transaction(
       async (tx) => {
-        const createdCharacters: CreatedCharacter[] = []
+        const createdCharacters: CharacterMutationResult[] = []
 
-        for (const fullData of createInputs) {
-          const createdCharacter = await tx.character.create({
-            data: fullData,
-            include: characterInclude,
-          })
-
-          createdCharacters.push(createdCharacter)
+        for (const createInput of createInputs) {
+          createdCharacters.push(
+            await tx.character.create({
+              data: createInput,
+              select: characterMutationSelect,
+            }),
+          )
         }
 
         return createdCharacters
@@ -442,19 +209,19 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       data,
-      message: `${data.length} character${
-        data.length === 1 ? '' : 's'
-      } created successfully.`,
+      message: `${data.length} character${data.length === 1 ? '' : 's'} created successfully.`,
+      statusCode: 201,
     }
   } catch (error: unknown) {
-    const { message, statusCode } = errorHandler(error)
-    event.node.res.statusCode = statusCode || 500
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
 
     return {
       success: false,
       data: null,
-      message: message || 'Failed to create characters.',
-      statusCode: statusCode || 500,
+      message: handled.message || 'Failed to create characters.',
+      statusCode,
     }
   }
 })

--- a/server/api/characters/compatibility.ts
+++ b/server/api/characters/compatibility.ts
@@ -1,0 +1,134 @@
+import { createError } from 'h3'
+import {
+  characterCreateFields,
+  characterPatchFields,
+  type CharacterMutationInput,
+} from './mutation'
+
+const characterStoreCompatibilityFields = [
+  'id',
+  'userId',
+  'createdAt',
+  'updatedAt',
+] as const
+
+export const characterSingularCreateFields = new Set<string>([
+  ...characterCreateFields,
+  ...characterStoreCompatibilityFields,
+])
+
+export const characterSingularPatchFields = new Set<string>([
+  ...characterPatchFields,
+  ...characterStoreCompatibilityFields,
+])
+
+type CharacterCompatibilityInput = CharacterMutationInput & {
+  id?: unknown
+  userId?: unknown
+  createdAt?: unknown
+  updatedAt?: unknown
+}
+
+function integer(value: unknown, field: string): number {
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed)) {
+    throw createError({
+      statusCode: 400,
+      message: `Character compatibility field "${field}" must be an integer.`,
+    })
+  }
+
+  return parsed
+}
+
+function assertTimestamp(value: unknown, field: string): void {
+  if (value === undefined || value === null) return
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `Character compatibility field "${field}" must be a string or null.`,
+    })
+  }
+}
+
+export function assertCharacterCreateCompatibility(
+  body: CharacterCompatibilityInput,
+): void {
+  if (Object.prototype.hasOwnProperty.call(body, 'id')) {
+    const id = integer(body.id, 'id')
+
+    if (id > 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'Character create payload cannot assign a persisted ID.',
+      })
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'userId')) {
+    const userId = integer(body.userId, 'userId')
+
+    if (userId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'Character compatibility field "userId" must be positive.',
+      })
+    }
+  }
+
+  assertTimestamp(body.createdAt, 'createdAt')
+  assertTimestamp(body.updatedAt, 'updatedAt')
+}
+
+export function assertCharacterPatchCompatibility(
+  body: CharacterCompatibilityInput,
+  routeId: number,
+  existingUserId: number,
+): void {
+  if (Object.prototype.hasOwnProperty.call(body, 'id')) {
+    const id = integer(body.id, 'id')
+
+    if (id !== routeId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Character ID is immutable and must match the route.',
+      })
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'userId')) {
+    const userId = integer(body.userId, 'userId')
+
+    if (userId !== existingUserId) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Unsupported Character ownership reassignment. Ownership is server-owned.',
+      })
+    }
+  }
+
+  assertTimestamp(body.createdAt, 'createdAt')
+  assertTimestamp(body.updatedAt, 'updatedAt')
+}
+
+export function stripCharacterCompatibilityFields(
+  body: CharacterCompatibilityInput,
+): CharacterMutationInput {
+  const {
+    id: _id,
+    userId: _userId,
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    ...mutationBody
+  } = body
+
+  void _id
+  void _userId
+  void _createdAt
+  void _updatedAt
+
+  return mutationBody
+}

--- a/server/api/characters/index.post.ts
+++ b/server/api/characters/index.post.ts
@@ -1,196 +1,81 @@
 // /server/api/characters/index.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
-import { errorHandler } from '../../utils/error'
-import { requireApiUser } from '@/server/utils/authGuard'
 import prisma from '../../utils/prisma'
+import { errorHandler } from '../../utils/error'
+import { validateApiKey } from '../../utils/validateKey'
 import { normalizeSlugInput } from '../../../utils/slugify'
 import {
-  findCharacterNameDuplicate,
   getCharacterNameKey,
   getUniqueCharacterSlug,
 } from '../../utils/characterSlug'
-import type {
-  Character,
-  Prisma,
-  Rarity,
-} from '~/prisma/generated/prisma/client'
+import {
+  assertCharacterMutationInput,
+  buildCharacterCreateInput,
+  characterCreateFields,
+  normalizeCharacterName,
+} from './mutation'
 import { characterMutationSelect } from './selects'
-
-type CharacterCreateBody = Partial<Character> & {
-  rewardIds?: number[]
-  scenarioIds?: number[]
-  dreamIds?: number[]
-}
-
-const fallbackRarity: Rarity = 'COMMON'
-
-function normalizeRarity(value: unknown): Rarity {
-  if (
-    value === 'COMMON' ||
-    value === 'UNCOMMON' ||
-    value === 'RARE' ||
-    value === 'EPIC' ||
-    value === 'LEGENDARY' ||
-    value === 'MYTHIC'
-  ) {
-    return value
-  }
-
-  if (typeof value === 'number') {
-    const rarityByNumber: Record<number, Rarity> = {
-      1: 'COMMON',
-      2: 'UNCOMMON',
-      3: 'RARE',
-      4: 'EPIC',
-      5: 'LEGENDARY',
-      6: 'MYTHIC',
-    }
-
-    return rarityByNumber[value] ?? fallbackRarity
-  }
-
-  return fallbackRarity
-}
-
-function normalizeIdArray(value: unknown, fieldName: string): number[] {
-  if (typeof value === 'undefined') return []
-
-  if (!Array.isArray(value)) {
-    throw createError({
-      statusCode: 400,
-      message: `${fieldName} must be an array of IDs.`,
-    })
-  }
-
-  const ids = value.map((entry) => Number(entry))
-
-  if (!ids.every((id) => Number.isInteger(id) && id > 0)) {
-    throw createError({
-      statusCode: 400,
-      message: `${fieldName} must contain only positive integers.`,
-    })
-  }
-
-  return [...new Set(ids)]
-}
-
-function cleanText(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function cleanShortText(value: unknown): string | null {
-  const text = cleanText(value)
-  return text ? text.slice(0, 764) : null
-}
 
 export default defineEventHandler(async (event) => {
   try {
-    const { user } = await requireApiUser(event)
-    const characterData = await readBody<CharacterCreateBody>(event)
+    const { isValid, user } = await validateApiKey(event)
 
-    if (!characterData.name || typeof characterData.name !== 'string') {
+    if (!isValid || !user) {
       throw createError({
-        statusCode: 400,
-        message: 'The "name" field is required and must be a string.',
+        statusCode: 401,
+        message: 'Invalid or expired token.',
       })
     }
 
-    const name = characterData.name.trim()
+    const body = await readBody<unknown>(event)
 
-    if (!getCharacterNameKey(name)) {
+    assertCharacterMutationInput(body, {
+      allowedFields: characterCreateFields,
+      context: 'Character create payload',
+    })
+
+    const name = normalizeCharacterName(body.name)
+    const nameKey = getCharacterNameKey(name)
+
+    if (!nameKey) {
       throw createError({
         statusCode: 400,
         message: 'Character name must contain at least one letter or number.',
       })
     }
 
-    const duplicate = await findCharacterNameDuplicate(prisma, user.id, name)
+    const existingCharacter = await prisma.character.findFirst({
+      where: { userId: user.id },
+      select: { id: true, name: true },
+    })
+
+    const duplicate = existingCharacter
+      ? await prisma.character.findFirst({
+          where: {
+            userId: user.id,
+            name,
+          },
+          select: { id: true },
+        })
+      : null
 
     if (duplicate) {
       throw createError({
         statusCode: 409,
-        message: `Character "${name}" already exists as #${duplicate.id}.`,
+        message: `Character with this name already exists (ID ${duplicate.id}).`,
       })
     }
 
-    const requestedSlug = normalizeSlugInput(characterData.slug)
+    const requestedSlug = normalizeSlugInput(body.slug)
     const slug = await getUniqueCharacterSlug(prisma, requestedSlug ?? name)
-    const rewardIds = normalizeIdArray(characterData.rewardIds, 'rewardIds')
-    const scenarioIds = normalizeIdArray(
-      characterData.scenarioIds,
-      'scenarioIds',
-    )
-    const dreamIds = normalizeIdArray(characterData.dreamIds, 'dreamIds')
-
-    const fullData: Prisma.CharacterCreateInput = {
-      User: {
-        connect: {
-          id: user.id,
-        },
-      },
-      name,
+    const createInput = await buildCharacterCreateInput({
+      rawInput: body,
+      userId: user.id,
       slug,
-      honorific: cleanShortText(characterData.honorific) ?? 'adventurer',
-      title: cleanShortText(characterData.title),
-      role: cleanShortText(characterData.role),
-      class: cleanShortText(characterData.class),
-      species: cleanShortText(characterData.species),
-      gender: cleanShortText(characterData.gender),
-      presentation: cleanShortText(characterData.presentation),
-      genre: cleanShortText(characterData.genre),
-      alignment: cleanShortText(characterData.alignment),
-      personality: cleanText(characterData.personality),
-      sampleResponse: cleanText(characterData.sampleResponse),
-      voice: cleanText(characterData.voice),
-      drive: cleanShortText(characterData.drive),
-      backstory: cleanText(characterData.backstory),
-      achievements: cleanShortText(characterData.achievements),
-      quirks: cleanText(characterData.quirks),
-      luck: normalizeRarity(characterData.luck),
-      might: normalizeRarity(characterData.might),
-      wits: normalizeRarity(characterData.wits),
-      grace: normalizeRarity(characterData.grace),
-      charm: normalizeRarity(characterData.charm),
-      empathy: normalizeRarity(characterData.empathy),
-      artPrompt: cleanText(characterData.artPrompt),
-      imagePath: cleanShortText(characterData.imagePath),
-      experience: Number.isInteger(characterData.experience)
-        ? Number(characterData.experience)
-        : 0,
-      level:
-        Number.isInteger(characterData.level) && Number(characterData.level) > 0
-          ? Number(characterData.level)
-          : 1,
-      designer: cleanShortText(characterData.designer),
-      isPublic: characterData.isPublic ?? true,
-      isMature: characterData.isMature ?? false,
-      isActive: characterData.isActive ?? true,
-      ArtImage: characterData.artImageId
-        ? {
-            connect: {
-              id: characterData.artImageId,
-            },
-          }
-        : undefined,
-      Rewards: rewardIds.length
-        ? {
-            connect: rewardIds.map((id) => ({ id })),
-          }
-        : undefined,
-      Scenarios: scenarioIds.length
-        ? {
-            connect: scenarioIds.map((id) => ({ id })),
-          }
-        : undefined,
-      Dreams: dreamIds.length
-        ? {
-            connect: dreamIds.map((id) => ({ id })),
-          }
-        : undefined,
-    }
+    })
 
     const data = await prisma.character.create({
-      data: fullData,
+      data: createInput,
       select: characterMutationSelect,
     })
 
@@ -198,19 +83,21 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      data,
       message: 'Character created successfully.',
+      data,
       statusCode: 201,
     }
-  } catch (error: unknown) {
-    const { message, statusCode } = errorHandler(error)
-    event.node.res.statusCode = statusCode || 500
+  } catch (error) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
 
     return {
       success: false,
+      message: handled.message || 'Failed to create character.',
       data: null,
-      message: message || 'Failed to create character.',
-      statusCode: event.node.res.statusCode,
+      statusCode,
     }
   }
 })

--- a/server/api/characters/index.post.ts
+++ b/server/api/characters/index.post.ts
@@ -11,9 +11,13 @@ import {
 import {
   assertCharacterMutationInput,
   buildCharacterCreateInput,
-  characterCreateFields,
   normalizeCharacterName,
 } from './mutation'
+import {
+  assertCharacterCreateCompatibility,
+  characterSingularCreateFields,
+  stripCharacterCompatibilityFields,
+} from './compatibility'
 import { characterMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
@@ -27,13 +31,15 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const body = await readBody<unknown>(event)
+    const rawBody = await readBody<unknown>(event)
 
-    assertCharacterMutationInput(body, {
-      allowedFields: characterCreateFields,
+    assertCharacterMutationInput(rawBody, {
+      allowedFields: characterSingularCreateFields,
       context: 'Character create payload',
     })
+    assertCharacterCreateCompatibility(rawBody)
 
+    const body = stripCharacterCompatibilityFields(rawBody)
     const name = normalizeCharacterName(body.name)
     const nameKey = getCharacterNameKey(name)
 
@@ -44,20 +50,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const existingCharacter = await prisma.character.findFirst({
-      where: { userId: user.id },
-      select: { id: true, name: true },
+    const duplicate = await prisma.character.findFirst({
+      where: {
+        userId: user.id,
+        name,
+      },
+      select: { id: true },
     })
-
-    const duplicate = existingCharacter
-      ? await prisma.character.findFirst({
-          where: {
-            userId: user.id,
-            name,
-          },
-          select: { id: true },
-        })
-      : null
 
     if (duplicate) {
       throw createError({

--- a/server/api/characters/mutation.ts
+++ b/server/api/characters/mutation.ts
@@ -1,0 +1,772 @@
+import { createError } from 'h3'
+import {
+  Rarity,
+  type Prisma,
+} from '~/prisma/generated/prisma/client'
+import prisma from '@/server/utils/prisma'
+
+export const CHARACTER_RELATION_ID_LIMIT = 100
+export const CHARACTER_BATCH_LIMIT = 100
+export const CHARACTER_LONG_TEXT_LIMIT = 50_000
+export const CHARACTER_SHORT_TEXT_LIMIT = 764
+
+const characterScalarFields = [
+  'name',
+  'slug',
+  'honorific',
+  'title',
+  'role',
+  'class',
+  'species',
+  'gender',
+  'presentation',
+  'genre',
+  'alignment',
+  'personality',
+  'sampleResponse',
+  'voice',
+  'drive',
+  'backstory',
+  'achievements',
+  'quirks',
+  'luck',
+  'might',
+  'wits',
+  'grace',
+  'charm',
+  'empathy',
+  'artPrompt',
+  'imagePath',
+  'experience',
+  'level',
+  'designer',
+  'isPublic',
+  'isMature',
+  'isActive',
+  'artImageId',
+  'rewardIds',
+  'scenarioIds',
+  'dreamIds',
+] as const
+
+const characterBatchRelationFields = ['Rewards', 'Scenarios', 'Dreams'] as const
+
+export const characterCreateFields = new Set<string>(characterScalarFields)
+export const characterPatchFields = new Set<string>(characterScalarFields)
+export const characterBatchCreateFields = new Set<string>([
+  ...characterScalarFields,
+  ...characterBatchRelationFields,
+])
+
+export type CharacterMutationInput = Record<string, unknown> & {
+  name?: unknown
+  slug?: unknown
+  honorific?: unknown
+  title?: unknown
+  role?: unknown
+  class?: unknown
+  species?: unknown
+  gender?: unknown
+  presentation?: unknown
+  genre?: unknown
+  alignment?: unknown
+  personality?: unknown
+  sampleResponse?: unknown
+  voice?: unknown
+  drive?: unknown
+  backstory?: unknown
+  achievements?: unknown
+  quirks?: unknown
+  luck?: unknown
+  might?: unknown
+  wits?: unknown
+  grace?: unknown
+  charm?: unknown
+  empathy?: unknown
+  artPrompt?: unknown
+  imagePath?: unknown
+  experience?: unknown
+  level?: unknown
+  designer?: unknown
+  isPublic?: unknown
+  isMature?: unknown
+  isActive?: unknown
+  artImageId?: unknown
+  rewardIds?: unknown
+  scenarioIds?: unknown
+  dreamIds?: unknown
+  Rewards?: unknown
+  Scenarios?: unknown
+  Dreams?: unknown
+}
+
+type CharacterBoundaryOptions = {
+  allowedFields: ReadonlySet<string>
+  context: string
+  requireNonEmpty?: boolean
+}
+
+const shortTextFields = [
+  'honorific',
+  'title',
+  'role',
+  'class',
+  'species',
+  'gender',
+  'presentation',
+  'genre',
+  'alignment',
+  'drive',
+  'achievements',
+  'imagePath',
+  'designer',
+] as const
+
+const longTextFields = [
+  'personality',
+  'sampleResponse',
+  'voice',
+  'backstory',
+  'quirks',
+  'artPrompt',
+] as const
+
+const rarityFields = ['luck', 'might', 'wits', 'grace', 'charm', 'empathy'] as const
+const booleanFields = ['isPublic', 'isMature', 'isActive'] as const
+const rarityValues = Object.values(Rarity)
+const rarityByNumber: Record<number, Rarity> = {
+  1: Rarity.COMMON,
+  2: Rarity.UNCOMMON,
+  3: Rarity.RARE,
+  4: Rarity.EPIC,
+  5: Rarity.LEGENDARY,
+  6: Rarity.MYTHIC,
+}
+
+export function assertCharacterMutationInput(
+  body: unknown,
+  options: CharacterBoundaryOptions,
+): asserts body is CharacterMutationInput {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.context} must be a JSON object.`,
+    })
+  }
+
+  const fields = Object.keys(body)
+
+  if (options.requireNonEmpty && fields.length === 0) {
+    throw createError({ statusCode: 400, message: 'No data provided for update.' })
+  }
+
+  const unsupported = fields.filter((field) => !options.allowedFields.has(field))
+
+  if (unsupported.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Character fields in ${options.context}: ${unsupported.join(', ')}. IDs, timestamps, identity, and system fields are server-owned.`,
+    })
+  }
+
+  const input = body as CharacterMutationInput
+
+  if (input.name !== undefined) normalizeCharacterName(input.name)
+
+  if (
+    input.slug !== undefined &&
+    input.slug !== null &&
+    typeof input.slug !== 'string'
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'The "slug" field must be a string or null.',
+    })
+  }
+
+  for (const field of shortTextFields) {
+    if (input[field] !== undefined) {
+      normalizeCharacterNullableText(
+        input[field],
+        field,
+        CHARACTER_SHORT_TEXT_LIMIT,
+      )
+    }
+  }
+
+  for (const field of longTextFields) {
+    if (input[field] !== undefined) {
+      normalizeCharacterNullableText(
+        input[field],
+        field,
+        CHARACTER_LONG_TEXT_LIMIT,
+      )
+    }
+  }
+
+  for (const field of rarityFields) {
+    if (input[field] !== undefined) {
+      normalizeCharacterRarity(input[field], field)
+    }
+  }
+
+  for (const field of booleanFields) {
+    if (input[field] !== undefined) {
+      normalizeCharacterBoolean(input[field], field)
+    }
+  }
+
+  if (input.experience !== undefined) {
+    normalizeCharacterInteger(input.experience, 'experience', 0)
+  }
+  if (input.level !== undefined) {
+    normalizeCharacterInteger(input.level, 'level', 1)
+  }
+  if (input.artImageId !== undefined) {
+    normalizeCharacterNullableId(input.artImageId, 'artImageId')
+  }
+
+  for (const field of ['rewardIds', 'scenarioIds', 'dreamIds'] as const) {
+    if (input[field] !== undefined) {
+      normalizeCharacterIdArray(input[field], field)
+    }
+  }
+
+  for (const field of characterBatchRelationFields) {
+    if (input[field] !== undefined) {
+      normalizeCharacterConnectIds(input[field], field)
+    }
+  }
+}
+
+export function normalizeCharacterName(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw createError({
+      statusCode: 400,
+      message: 'The "name" field is required and must be a non-empty string.',
+    })
+  }
+
+  const name = value.trim()
+
+  if (name.length > CHARACTER_SHORT_TEXT_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `The "name" field must be ${CHARACTER_SHORT_TEXT_LIMIT} characters or fewer.`,
+    })
+  }
+
+  return name
+}
+
+export function normalizeCharacterNullableText(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a string or null.`,
+    })
+  }
+
+  const text = value.trim()
+
+  if (text.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be ${maxLength} characters or fewer.`,
+    })
+  }
+
+  return text || null
+}
+
+export function normalizeCharacterRarity(
+  value: unknown,
+  field: string,
+  fallback?: Rarity,
+): Rarity {
+  if (value === undefined || value === null || value === '') {
+    if (fallback) return fallback
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a valid rarity.`,
+    })
+  }
+
+  if (typeof value === 'number' && rarityByNumber[value]) {
+    return rarityByNumber[value]
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toUpperCase() as Rarity
+    if (rarityValues.includes(normalized)) return normalized
+  }
+
+  throw createError({
+    statusCode: 400,
+    message: `The "${field}" field must be one of: ${rarityValues.join(', ')}, or a legacy number from 1 through 6.`,
+  })
+}
+
+export function normalizeCharacterBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a boolean.`,
+    })
+  }
+
+  return value
+}
+
+export function normalizeCharacterInteger(
+  value: unknown,
+  field: string,
+  minimum: number,
+): number {
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be an integer greater than or equal to ${minimum}.`,
+    })
+  }
+
+  return parsed
+}
+
+export function normalizeCharacterNullableId(
+  value: unknown,
+  field: string,
+): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be a positive integer or null.`,
+    })
+  }
+
+  return parsed
+}
+
+export function normalizeCharacterIdArray(
+  value: unknown,
+  field: string,
+): number[] | undefined {
+  if (value === undefined) return undefined
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must be an array of positive integer IDs.`,
+    })
+  }
+
+  if (value.length > CHARACTER_RELATION_ID_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field may contain at most ${CHARACTER_RELATION_ID_LIMIT} entries.`,
+    })
+  }
+
+  const ids = value.map((entry, index) => {
+    const id = Number(entry)
+
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: `The "${field}" field contains an invalid ID at index ${index}.`,
+      })
+    }
+
+    return id
+  })
+
+  return [...new Set(ids)]
+}
+
+export function normalizeCharacterConnectIds(
+  value: unknown,
+  field: string,
+): number[] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `The "${field}" field must use { connect: [{ id }] }.`,
+    })
+  }
+
+  const connect = (value as { connect?: unknown }).connect
+  if (connect === undefined || connect === null) return []
+  const entries = Array.isArray(connect) ? connect : [connect]
+
+  return normalizeCharacterIdArray(
+    entries.map((entry) =>
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? (entry as { id?: unknown }).id
+        : undefined,
+    ),
+    `${field}.connect`,
+  ) ?? []
+}
+
+export function normalizeCharacterRelationIds(
+  directValue: unknown,
+  connectValue: unknown,
+  directField: string,
+  connectField: string,
+): number[] {
+  const direct = normalizeCharacterIdArray(directValue, directField) ?? []
+  const connected =
+    connectValue === undefined
+      ? []
+      : normalizeCharacterConnectIds(connectValue, connectField)
+  const ids = [...new Set([...direct, ...connected])]
+
+  if (ids.length > CHARACTER_RELATION_ID_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `Combined ${directField}/${connectField} relations may contain at most ${CHARACTER_RELATION_ID_LIMIT} IDs.`,
+    })
+  }
+
+  return ids
+}
+
+function assertFound(
+  requestedIds: number[],
+  records: Array<{ id: number }>,
+  label: string,
+): void {
+  const found = new Set(records.map((record) => record.id))
+  const missing = requestedIds.filter((id) => !found.has(id))
+
+  if (missing.length) {
+    throw createError({
+      statusCode: 404,
+      message: `${label} IDs not found: ${missing.join(', ')}.`,
+    })
+  }
+}
+
+export async function assertCharacterRelationsExist(input: {
+  artImageId?: number | null
+  rewardIds?: number[]
+  scenarioIds?: number[]
+  dreamIds?: number[]
+}): Promise<void> {
+  const artImageIds = typeof input.artImageId === 'number' ? [input.artImageId] : []
+  const rewardIds = input.rewardIds ?? []
+  const scenarioIds = input.scenarioIds ?? []
+  const dreamIds = input.dreamIds ?? []
+
+  const [artImages, rewards, scenarios, dreams] = await Promise.all([
+    artImageIds.length
+      ? prisma.artImage.findMany({
+          where: { id: { in: artImageIds } },
+          select: { id: true },
+        })
+      : [],
+    rewardIds.length
+      ? prisma.reward.findMany({
+          where: { id: { in: rewardIds } },
+          select: { id: true },
+        })
+      : [],
+    scenarioIds.length
+      ? prisma.scenario.findMany({
+          where: { id: { in: scenarioIds } },
+          select: { id: true },
+        })
+      : [],
+    dreamIds.length
+      ? prisma.dream.findMany({
+          where: { id: { in: dreamIds } },
+          select: { id: true },
+        })
+      : [],
+  ])
+
+  assertFound(artImageIds, artImages, 'ArtImage')
+  assertFound(rewardIds, rewards, 'Reward')
+  assertFound(scenarioIds, scenarios, 'Scenario')
+  assertFound(dreamIds, dreams, 'Dream')
+}
+
+export async function buildCharacterCreateInput(options: {
+  rawInput: unknown
+  userId: number
+  slug: string | null
+  batch?: boolean
+}): Promise<Prisma.CharacterCreateInput> {
+  assertCharacterMutationInput(options.rawInput, {
+    allowedFields: options.batch
+      ? characterBatchCreateFields
+      : characterCreateFields,
+    context: options.batch
+      ? 'Character batch create item'
+      : 'Character create payload',
+  })
+
+  const body = options.rawInput
+  const rewardIds = options.batch
+    ? normalizeCharacterRelationIds(
+        body.rewardIds,
+        body.Rewards,
+        'rewardIds',
+        'Rewards',
+      )
+    : normalizeCharacterIdArray(body.rewardIds, 'rewardIds') ?? []
+  const scenarioIds = options.batch
+    ? normalizeCharacterRelationIds(
+        body.scenarioIds,
+        body.Scenarios,
+        'scenarioIds',
+        'Scenarios',
+      )
+    : normalizeCharacterIdArray(body.scenarioIds, 'scenarioIds') ?? []
+  const dreamIds = options.batch
+    ? normalizeCharacterRelationIds(
+        body.dreamIds,
+        body.Dreams,
+        'dreamIds',
+        'Dreams',
+      )
+    : normalizeCharacterIdArray(body.dreamIds, 'dreamIds') ?? []
+  const artImageId = normalizeCharacterNullableId(body.artImageId, 'artImageId')
+
+  await assertCharacterRelationsExist({
+    artImageId,
+    rewardIds,
+    scenarioIds,
+    dreamIds,
+  })
+
+  return {
+    User: { connect: { id: options.userId } },
+    name: normalizeCharacterName(body.name),
+    slug: options.slug,
+    honorific:
+      normalizeCharacterNullableText(
+        body.honorific,
+        'honorific',
+        CHARACTER_SHORT_TEXT_LIMIT,
+      ) ?? 'adventurer',
+    title: normalizeCharacterNullableText(
+      body.title,
+      'title',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    role: normalizeCharacterNullableText(
+      body.role,
+      'role',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    class: normalizeCharacterNullableText(
+      body.class,
+      'class',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    species: normalizeCharacterNullableText(
+      body.species,
+      'species',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    gender: normalizeCharacterNullableText(
+      body.gender,
+      'gender',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    presentation: normalizeCharacterNullableText(
+      body.presentation,
+      'presentation',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    genre: normalizeCharacterNullableText(
+      body.genre,
+      'genre',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    alignment: normalizeCharacterNullableText(
+      body.alignment,
+      'alignment',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    personality: normalizeCharacterNullableText(
+      body.personality,
+      'personality',
+      CHARACTER_LONG_TEXT_LIMIT,
+    ),
+    sampleResponse: normalizeCharacterNullableText(
+      body.sampleResponse,
+      'sampleResponse',
+      CHARACTER_LONG_TEXT_LIMIT,
+    ),
+    voice: normalizeCharacterNullableText(
+      body.voice,
+      'voice',
+      CHARACTER_LONG_TEXT_LIMIT,
+    ),
+    drive: normalizeCharacterNullableText(
+      body.drive,
+      'drive',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    backstory: normalizeCharacterNullableText(
+      body.backstory,
+      'backstory',
+      CHARACTER_LONG_TEXT_LIMIT,
+    ),
+    achievements: normalizeCharacterNullableText(
+      body.achievements,
+      'achievements',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    quirks: normalizeCharacterNullableText(
+      body.quirks,
+      'quirks',
+      CHARACTER_LONG_TEXT_LIMIT,
+    ),
+    luck: normalizeCharacterRarity(body.luck, 'luck', Rarity.COMMON),
+    might: normalizeCharacterRarity(body.might, 'might', Rarity.COMMON),
+    wits: normalizeCharacterRarity(body.wits, 'wits', Rarity.COMMON),
+    grace: normalizeCharacterRarity(body.grace, 'grace', Rarity.COMMON),
+    charm: normalizeCharacterRarity(body.charm, 'charm', Rarity.COMMON),
+    empathy: normalizeCharacterRarity(body.empathy, 'empathy', Rarity.COMMON),
+    artPrompt: normalizeCharacterNullableText(
+      body.artPrompt,
+      'artPrompt',
+      CHARACTER_LONG_TEXT_LIMIT,
+    ),
+    imagePath: normalizeCharacterNullableText(
+      body.imagePath,
+      'imagePath',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    experience:
+      body.experience === undefined
+        ? 0
+        : normalizeCharacterInteger(body.experience, 'experience', 0),
+    level:
+      body.level === undefined
+        ? 1
+        : normalizeCharacterInteger(body.level, 'level', 1),
+    designer: normalizeCharacterNullableText(
+      body.designer,
+      'designer',
+      CHARACTER_SHORT_TEXT_LIMIT,
+    ),
+    isPublic:
+      body.isPublic === undefined
+        ? true
+        : normalizeCharacterBoolean(body.isPublic, 'isPublic'),
+    isMature:
+      body.isMature === undefined
+        ? false
+        : normalizeCharacterBoolean(body.isMature, 'isMature'),
+    isActive:
+      body.isActive === undefined
+        ? true
+        : normalizeCharacterBoolean(body.isActive, 'isActive'),
+    ArtImage:
+      typeof artImageId === 'number'
+        ? { connect: { id: artImageId } }
+        : undefined,
+    Rewards: rewardIds.length
+      ? { connect: rewardIds.map((id) => ({ id })) }
+      : undefined,
+    Scenarios: scenarioIds.length
+      ? { connect: scenarioIds.map((id) => ({ id })) }
+      : undefined,
+    Dreams: dreamIds.length
+      ? { connect: dreamIds.map((id) => ({ id })) }
+      : undefined,
+  }
+}
+
+export async function buildCharacterUpdateInput(
+  body: CharacterMutationInput,
+): Promise<Prisma.CharacterUpdateInput> {
+  const data: Prisma.CharacterUpdateInput = {}
+
+  for (const field of shortTextFields) {
+    if (field in body) {
+      data[field] = normalizeCharacterNullableText(
+        body[field],
+        field,
+        CHARACTER_SHORT_TEXT_LIMIT,
+      ) as never
+    }
+  }
+
+  for (const field of longTextFields) {
+    if (field in body) {
+      data[field] = normalizeCharacterNullableText(
+        body[field],
+        field,
+        CHARACTER_LONG_TEXT_LIMIT,
+      ) as never
+    }
+  }
+
+  for (const field of rarityFields) {
+    if (field in body) {
+      data[field] = normalizeCharacterRarity(body[field], field) as never
+    }
+  }
+
+  for (const field of booleanFields) {
+    if (field in body) {
+      data[field] = normalizeCharacterBoolean(body[field], field) as never
+    }
+  }
+
+  if ('experience' in body) {
+    data.experience = normalizeCharacterInteger(body.experience, 'experience', 0)
+  }
+  if ('level' in body) {
+    data.level = normalizeCharacterInteger(body.level, 'level', 1)
+  }
+
+  const artImageId = normalizeCharacterNullableId(body.artImageId, 'artImageId')
+  const rewardIds = normalizeCharacterIdArray(body.rewardIds, 'rewardIds')
+  const scenarioIds = normalizeCharacterIdArray(body.scenarioIds, 'scenarioIds')
+  const dreamIds = normalizeCharacterIdArray(body.dreamIds, 'dreamIds')
+
+  await assertCharacterRelationsExist({
+    artImageId,
+    rewardIds,
+    scenarioIds,
+    dreamIds,
+  })
+
+  if ('artImageId' in body) {
+    data.ArtImage =
+      typeof artImageId === 'number'
+        ? { connect: { id: artImageId } }
+        : { disconnect: true }
+  }
+  if (rewardIds !== undefined) {
+    data.Rewards = { set: rewardIds.map((id) => ({ id })) }
+  }
+  if (scenarioIds !== undefined) {
+    data.Scenarios = { set: scenarioIds.map((id) => ({ id })) }
+  }
+  if (dreamIds !== undefined) {
+    data.Dreams = { set: dreamIds.map((id) => ({ id })) }
+  }
+
+  return data
+}

--- a/utils/scripts/verifyCharacterMutationInputParity.ts
+++ b/utils/scripts/verifyCharacterMutationInputParity.ts
@@ -62,6 +62,11 @@ requireText(
   'buildCharacterUpdateInput(',
   'Character shared update builder',
 )
+requireText(
+  boundary,
+  'User: { connect: { id: options.userId } }',
+  'Character authenticated create ownership',
+)
 
 requireText(
   compatibility,
@@ -88,11 +93,6 @@ requireText(
   createRoute,
   'stripCharacterCompatibilityFields(rawBody)',
   'Character create compatibility isolation',
-)
-requireText(
-  createRoute,
-  'User: { connect: { id: options.userId } }',
-  'Character authenticated create ownership',
 )
 requireText(
   patchRoute,

--- a/utils/scripts/verifyCharacterMutationInputParity.ts
+++ b/utils/scripts/verifyCharacterMutationInputParity.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/api/characters/mutation.ts')
+const compatibility = read('server/api/characters/compatibility.ts')
+const createRoute = read('server/api/characters/index.post.ts')
+const patchRoute = read('server/api/characters/[id].patch.ts')
+const batchRoute = read('server/api/characters/batch.post.ts')
+const cypressSpec = read('cypress/e2e/api/character-input-boundary.cy.ts')
+
+requireText(
+  boundary,
+  'export const CHARACTER_RELATION_ID_LIMIT = 100',
+  'Character relation cap',
+)
+requireText(
+  boundary,
+  'export const CHARACTER_BATCH_LIMIT = 100',
+  'Character batch cap',
+)
+requireText(
+  boundary,
+  'const rarityValues = Object.values(Rarity)',
+  'Character generated rarity validation',
+)
+requireText(
+  boundary,
+  'legacy number from 1 through 6',
+  'Character numeric rarity compatibility',
+)
+requireText(
+  boundary,
+  'contains an invalid ID at index ${index}',
+  'Character invalid relation rejection',
+)
+requireText(
+  boundary,
+  'await assertCharacterRelationsExist({',
+  'Character relation existence checks',
+)
+requireText(
+  boundary,
+  'buildCharacterUpdateInput(',
+  'Character shared update builder',
+)
+
+requireText(
+  compatibility,
+  'Character create payload cannot assign a persisted ID.',
+  'Character create ID boundary',
+)
+requireText(
+  compatibility,
+  'Unsupported Character ownership reassignment. Ownership is server-owned.',
+  'Character patch ownership boundary',
+)
+requireText(
+  compatibility,
+  'stripCharacterCompatibilityFields(',
+  'Character compatibility stripping',
+)
+
+requireText(
+  createRoute,
+  'allowedFields: characterSingularCreateFields',
+  'Character singular create field boundary',
+)
+requireText(
+  createRoute,
+  'stripCharacterCompatibilityFields(rawBody)',
+  'Character create compatibility isolation',
+)
+requireText(
+  createRoute,
+  'User: { connect: { id: options.userId } }',
+  'Character authenticated create ownership',
+)
+requireText(
+  patchRoute,
+  'allowedFields: characterSingularPatchFields',
+  'Character singular patch field boundary',
+)
+requireText(
+  patchRoute,
+  'assertCharacterPatchCompatibility(rawBody, id, existingCharacter.userId)',
+  'Character patch identity validation',
+)
+requireText(
+  batchRoute,
+  'characters.length > CHARACTER_BATCH_LIMIT',
+  'Character batch cap',
+)
+requireText(
+  batchRoute,
+  'select: characterMutationSelect',
+  'Character lean batch projection',
+)
+forbidText(
+  batchRoute,
+  'include: {',
+  'Character heavy batch mutation response',
+)
+forbidText(
+  batchRoute,
+  'function normalizeRarity',
+  'Character duplicate batch rarity normalizer',
+)
+
+requireText(
+  cypressSpec,
+  'rejects unknown and malformed Character create fields',
+  'Character create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'ignores legacy create ownership metadata and persists authentication',
+  'Character create ownership compatibility regression',
+)
+requireText(
+  cypressSpec,
+  'rejects Character ownership and route identity changes on PATCH',
+  'Character patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'keeps Character batch imports strict, bounded, and lean',
+  'Character batch deployed regression',
+)
+
+console.log('Character mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

- adds one shared runtime mutation boundary across singular Character create, singular PATCH, and atomic batch create
- rejects unknown fields, malformed text/booleans/integers, invalid rarities, invalid relation IDs, and oversized relation arrays
- validates ArtImage, Reward, Scenario, and Dream targets before writes
- validates rarity from the generated Prisma enum while preserving legacy numeric values 1–6
- caps Character batches and relation arrays at 100 entries
- replaces duplicated batch normalizers with the shared builders
- moves batch mutation responses from heavy relation includes to the named lean Character projection
- preserves current full-row CharacterStore compatibility only on singular routes: legacy owner/timestamps are stripped before persistence, positive persisted IDs are forbidden on create, and PATCH owner/route IDs must remain unchanged
- keeps batch imports strict and atomic
- adds deployed create/PATCH/batch regressions plus a DB-free parity contract and read-only workflow

## Why

Character mutations had three different contracts. Singular routes silently ignored unknown model fields and malformed values, batch create duplicated permissive rarity/text coercion, relation arrays were unbounded, create did not verify related records, and batch responses eagerly included several heavy relations. This establishes one deliberate boundary while retaining a narrow compatibility stage for the current Character form.

## Checks

- Character Mutation Input Parity
- TypeScript Type Check
- Contract Tests
