### PR TITLE
Handle ownerless Character compatibility checks

### DIFF
--- a/server/api/characters/compatibility.ts
+++ b/server/api/characters/compatibility.ts
@@ -85,7 +85,7 @@ export function assertCharacterCreateCompatibility(
 export function assertCharacterPatchCompatibility(
   body: CharacterCompatibilityInput,
   routeId: number,
-  existingUserId: number,
+  existingUserId: number | null,
 ): void {
   if (Object.prototype.hasOwnProperty.call(body, 'id')) {
     const id = integer(body.id, 'id')


### PR DESCRIPTION
Fix the TypeScript regression introduced by the Character mutation parity merge.

`Character.userId` is nullable in Prisma, so the compatibility guard must accept `number | null`. Behavior remains strict: if an ownerless historical Character payload attempts to submit a numeric `userId`, it is rejected as an ownership reassignment.

No API behavior is broadened and no database changes are included.