### PR TITLE
Add CI contract guard for unquoted reserved-word table identifiers

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Prisma JSON-cast contract
         run: npm run test:no-prisma-json-cast
 
+      - name: Unquoted reserved-word table identifier contract
+        run: npm run test:no-unquoted-reserved-word-tables
+
       - name: Capture-group guard checker self-test
         run: npm run test:capture-group-guards-selftest
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
+    "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
     "test:capture-group-guards": "tsx utils/scripts/verifyCaptureGroupGuards.ts",
     "test:capture-group-guards-selftest": "tsx utils/scripts/verifyCaptureGroupGuards.test.ts",
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",

--- a/server/api/characters/compatibility.ts
+++ b/server/api/characters/compatibility.ts
@@ -85,7 +85,7 @@ export function assertCharacterCreateCompatibility(
 export function assertCharacterPatchCompatibility(
   body: CharacterCompatibilityInput,
   routeId: number,
-  existingUserId: number,
+  existingUserId: number | null,
 ): void {
   if (Object.prototype.hasOwnProperty.call(body, 'id')) {
     const id = integer(body.id, 'id')

--- a/utils/scripts/verifyNoUnquotedReservedWordTables.ts
+++ b/utils/scripts/verifyNoUnquotedReservedWordTables.ts
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyNoUnquotedReservedWordTables.ts
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Regression guard: CHARACTER is a reserved word in MariaDB's grammar. An
+// unquoted `FROM Character` / `LEFT JOIN Character c ON ...` in raw SQL
+// ($queryRaw/$queryRawUnsafe/$executeRaw/$executeRawUnsafe, or a raw driver
+// `.query()`) throws ER_PARSE_ERROR at query time -- it typechecks fine
+// locally since Prisma's generated client and this contract's own mocks
+// never exercise real MariaDB grammar. This exact shape shipped across four
+// call sites in kind_robots (a migration-repair script that runs during
+// `npm run vercel-build`, plus three API/util files) before anyone noticed;
+// the migration-repair one broke every production deploy until it was fixed
+// by quoting the identifier with backticks (`` `Character` ``). Add new
+// reserved words here as they're found to bite a real call site -- keep the
+// list narrow (grep false positives on a common word like "Character" are
+// expensive to review) rather than importing the full MariaDB reserved-word
+// list up front.
+const RESERVED_WORD_TABLE_NAMES = ['Character']
+
+const RAW_SQL_TRIGGERS = [
+  '$queryRaw',
+  '$queryRawUnsafe',
+  '$executeRaw',
+  '$executeRawUnsafe',
+  '.query(',
+]
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SCAN_EXTENSIONS = ['.ts', '.tsx', '.vue', '.js', '.mjs', '.cjs']
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.nuxt',
+  '.output',
+  '.vercel',
+  'node_modules',
+  'dist',
+  'coverage',
+  'cypress',
+  'prisma/generated',
+])
+// This file documents/references the exact triggers and words it scans for
+// -- exclude it from its own scan rather than obscuring the pattern to dodge
+// a self-match.
+const EXCLUDED_FILES = new Set([
+  'utils/scripts/verifyNoUnquotedReservedWordTables.ts',
+])
+
+// A reserved word directly after FROM/JOIN/INTO/UPDATE/TABLE with no
+// backtick in between is the unquoted, unsafe form. `\s+` cannot match a
+// backtick, so a correctly quoted `` FROM `Character` `` never matches this
+// pattern -- the identifier immediately following the whitespace would be a
+// backtick, not the bare word.
+function buildUnquotedPattern(word: string): RegExp {
+  return new RegExp(`\\b(?:FROM|JOIN|INTO|UPDATE|TABLE)\\s+(${word})\\b`, 'g')
+}
+
+function isExcluded(relativePath: string): boolean {
+  if (EXCLUDED_FILES.has(relativePath)) return true
+  return [...EXCLUDED_DIRECTORIES].some(
+    (excluded) =>
+      relativePath === excluded || relativePath.startsWith(`${excluded}/`),
+  )
+}
+
+function listSourceFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name)
+    const relativePath = relative(repositoryRoot, path)
+    if (isExcluded(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(path))
+      continue
+    }
+
+    if (entry.isFile() && SCAN_EXTENSIONS.some((ext) => path.endsWith(ext))) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function lineNumberAt(content: string, index: number): number {
+  let line = 1
+  for (let i = 0; i < index; i += 1) {
+    if (content[i] === '\n') line += 1
+  }
+  return line
+}
+
+function main(): void {
+  const files = listSourceFiles(repositoryRoot)
+  const errors: string[] = []
+  let scannedRawSqlFiles = 0
+
+  for (const file of files) {
+    const relativeFile = relative(repositoryRoot, file)
+    const content = readFileSync(file, 'utf8')
+
+    // Cheap pre-filter: only files that actually issue raw SQL can hit this
+    // bug class, so skip the (much larger) set of files that merely mention
+    // "Character" in TypeScript types, Vue templates, comments, etc.
+    if (!RAW_SQL_TRIGGERS.some((trigger) => content.includes(trigger))) {
+      continue
+    }
+    scannedRawSqlFiles += 1
+
+    for (const word of RESERVED_WORD_TABLE_NAMES) {
+      const pattern = buildUnquotedPattern(word)
+      let match: RegExpExecArray | null
+      while ((match = pattern.exec(content)) !== null) {
+        const line = lineNumberAt(content, match.index)
+        errors.push(
+          `${relativeFile}:${line}: unquoted reserved-word table identifier ` +
+            `\`${word}\` in raw SQL ("${match[0]}") -- MariaDB will throw ` +
+            `ER_PARSE_ERROR at query time. Quote it: \`\`${word}\`\`.`,
+        )
+      }
+    }
+  }
+
+  if (errors.length) {
+    console.error(
+      `Unquoted reserved-word table contract failed with ${errors.length} error(s):`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Unquoted reserved-word table contract passed: ${scannedRawSqlFiles} raw-SQL ` +
+      `source file(s) checked, no unquoted ${RESERVED_WORD_TABLE_NAMES.join(', ')} ` +
+      'table identifiers found.',
+  )
+}
+
+main()


### PR DESCRIPTION
### Task
conductor/t-069: Flag unquoted MariaDB/MySQL reserved words used as raw-SQL table identifiers (kind: software)

### What changed
- Added `utils/scripts/verifyNoUnquotedReservedWordTables.ts`, a fast contract check scanning raw-SQL call sites (`$queryRaw`/`$queryRawUnsafe`/`$executeRaw`/`$executeRawUnsafe`/`.query(`) for reserved words used as unquoted table identifiers directly after `FROM`/`JOIN`/`INTO`/`UPDATE`/`TABLE`. Starts with `Character` (the word list is a small array, easy to extend).
- Wired it into `.github/workflows/contract-tests.yml` as a new step.
- Added the `test:no-unquoted-reserved-word-tables` npm script.
- **Unrelated incidental fix** (needed to get this PR's own TypeScript check green): `server/api/characters/compatibility.ts`'s `assertCharacterPatchCompatibility` typed its `existingUserId` parameter as non-nullable `number`, but `Character.userId` is `Int?` in `prisma/schema.prisma` and its only call site (`server/api/characters/[id].patch.ts:75`) passes the nullable field directly. This was already broken on `main` (merged via PR #569, commit `60a32129`, same-day change) and was failing the TypeScript CI check on every PR, including this one, for a reason unrelated to the reserved-word contract change. Type-only widening to `number | null`; the runtime comparison already handled `null` correctly.

### Why
`CHARACTER` is a reserved word in MariaDB's grammar. An unquoted `FROM Character` / `LEFT JOIN Character c ON ...` in raw SQL throws `ER_PARSE_ERROR` at query time but typechecks fine locally, since neither Prisma's generated client nor the existing mocks (e.g. `verify-known-migration-repair.mjs`'s `fakeConnection`) exercise real MariaDB grammar. This exact shape shipped across four call sites in the same PR cluster (#511-#515) and broke every production deploy via the migration-repair script (which runs during `npm run vercel-build`) until PR #517 fixed it by quoting the identifier with backticks. There was no regression guard for this bug class before this PR.

### How I verified
- Ran the new check against current `main`: passes clean (21 raw-SQL files scanned, 0 unquoted `Character` identifiers — confirms PR #517's fix holds).
- Injected a deliberately bad snippet (`LEFT JOIN Character c ON ...`, unquoted) into a temp file and confirmed the check flags it with file:line and exits non-zero; removed the temp file afterward.
- Full `npm run test` (vue-tsc, project-wide) — clean, after the `compatibility.ts` fix.
- `npx eslint utils/scripts/verifyNoUnquotedReservedWordTables.ts` — clean.

### Stakes
reversible (new CI-only advisory/gating script + a type-only nullability widening; no runtime behavior change)

### Flags for Reviewer
- The `compatibility.ts` fix is out of this task's original scope but was necessary to unblock this PR's own CI, since `main` was already broken. Filing conductor/t-071 to record it for the learning ledger.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
