### PR TITLE
Remove Reaction userId create compatibility

### DIFF
--- a/components/art/art-reactions.vue
+++ b/components/art/art-reactions.vue
@@ -238,7 +238,6 @@ async function submitReaction() {
   try {
     await reactionStore.addReaction({
       artImageId: imageId,
-      userId: activeUserId,
       rating: rating.value,
       reactionType: selectedReactionType.value,
       comment: comment.value,

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -304,7 +304,6 @@ async function submitReaction() {
   try {
     await reactionStore.addReaction({
       ...getReactionTargetPayload(props.targetType, props.targetId),
-      userId: userStore.user.id,
       rating: rating.value,
       reactionType: selectedReactionType.value,
       comment: comment.value.trim(),

--- a/cypress/e2e/api/component-reactions.cy.ts
+++ b/cypress/e2e/api/component-reactions.cy.ts
@@ -41,7 +41,6 @@ describe('Component Reactions API Tests', () => {
     expect(componentId).to.exist
 
     return {
-      userId: testUser!.id,
       reactionType: 'CLAPPED',
       reactionCategory: 'COMPONENT',
       componentId,

--- a/cypress/e2e/api/reactions.cy.ts
+++ b/cypress/e2e/api/reactions.cy.ts
@@ -159,16 +159,19 @@ describe('Reaction Management API Tests', () => {
     })
   })
 
-  it('rejects spoofed Reaction ownership', () => {
+  it('rejects a supplied userId as an unsupported Reaction create field', () => {
     expect(themeId).to.exist
-    expect(otherId).to.exist
+    expect(ownerId).to.exist
 
+    // Ownership is exclusively authentication-derived: the #560 matching-userId
+    // compatibility path is gone, so even the caller's own id is now rejected as
+    // an unsupported field.
     cy.request<ApiResponse>({
       method: 'POST',
       url: reactionBaseUrl,
       headers: ownerHeaders(),
       body: {
-        userId: otherId,
+        userId: ownerId,
         reactionType: 'LOVED',
         reactionCategory: 'THEME',
         themeId,
@@ -178,7 +181,9 @@ describe('Reaction Management API Tests', () => {
     }).then((response) => {
       expect(response.status).to.eq(400)
       expect(response.body.success).to.eq(false)
-      expect(response.body.message).to.include('Ownership is server-owned')
+      expect(response.body.message).to.include(
+        'Unsupported Reaction create fields',
+      )
     })
   })
 
@@ -215,7 +220,6 @@ describe('Reaction Management API Tests', () => {
       url: reactionBaseUrl,
       headers: ownerHeaders(),
       body: {
-        userId: ownerId,
         reactionType: 'LOVED',
         reactionCategory: 'THEME',
         themeId,

--- a/server/api/reactions/index.post.ts
+++ b/server/api/reactions/index.post.ts
@@ -11,7 +11,6 @@ import {
 } from '~/prisma/generated/prisma/client'
 
 type ReactionBody = Record<string, unknown> & {
-  userId?: unknown
   reactionType?: unknown
   reactionCategory?: unknown
   comment?: unknown
@@ -32,7 +31,6 @@ type ReactionBody = Record<string, unknown> & {
 }
 
 const REACTION_CREATE_FIELDS = new Set([
-  'userId',
   'reactionType',
   'reactionCategory',
   'comment',
@@ -86,25 +84,6 @@ function assertReactionCreateFields(body: ReactionBody): void {
     throw createError({
       statusCode: 400,
       message: `Unsupported Reaction create fields: ${unsupportedFields.join(', ')}. IDs, timestamps, and system fields are server-owned.`,
-    })
-  }
-}
-
-function assertReactionOwnershipMatchesAuthentication(
-  value: unknown,
-  authenticatedUserId: number,
-): void {
-  if (value === undefined) return
-
-  const requestedUserId = Number(value)
-
-  if (
-    !Number.isInteger(requestedUserId) ||
-    requestedUserId !== authenticatedUserId
-  ) {
-    throw createError({
-      statusCode: 400,
-      message: 'Unsupported Reaction ownership assignment. Ownership is server-owned.',
     })
   }
 }
@@ -385,7 +364,6 @@ export default defineEventHandler(async (event) => {
     }
 
     assertReactionCreateFields(body)
-    assertReactionOwnershipMatchesAuthentication(body.userId, user.id)
 
     const reactionType = normalizeReactionType(body.reactionType)
     const reactionCategory = normalizeReactionCategory(body.reactionCategory)

--- a/stores/reactionStore.ts
+++ b/stores/reactionStore.ts
@@ -69,7 +69,6 @@ type ReactionTargetIdKey =
   | 'themeId'
 
 type AddReactionPayload = {
-  userId: number
   reactionType: ReactionTypeEnum
   rating: number
   comment?: string

--- a/utils/scripts/verifyReactionCreateInputBoundary.ts
+++ b/utils/scripts/verifyReactionCreateInputBoundary.ts
@@ -40,13 +40,20 @@ requireText(
 )
 requireText(
   createRoute,
-  'assertReactionOwnershipMatchesAuthentication(body.userId, user.id)',
-  'Reaction ownership-match boundary',
-)
-requireText(
-  createRoute,
   'userId: user.id',
   'Reaction authenticated ownership write',
+)
+// The #560 matching-userId compatibility path is fully removed: ownership is now
+// exclusively authentication-derived and a supplied userId is an unsupported field.
+forbidText(
+  createRoute,
+  "'userId',",
+  'Reaction userId create allowlist entry',
+)
+forbidText(
+  createRoute,
+  'assertReactionOwnershipMatchesAuthentication',
+  'Reaction ownership-match compatibility boundary',
 )
 forbidText(
   createRoute,
@@ -61,8 +68,8 @@ forbidText(
 
 requireText(
   cypressSpec,
-  'rejects spoofed Reaction ownership',
-  'Reaction ownership deployed regression',
+  'rejects a supplied userId as an unsupported Reaction create field',
+  'Reaction supplied-userId deployed regression',
 )
 requireText(
   cypressSpec,


### PR DESCRIPTION
## Summary

Completes the Reaction cleanup item from the API overhaul (#570, Phase 1). PR #560 intentionally retained a compatibility path that accepted a `userId` in the create body as long as it matched the authenticated caller. This removes that path so Reaction ownership is **exclusively authentication-derived**.

- remove `'userId'` from `REACTION_CREATE_FIELDS` and delete `assertReactionOwnershipMatchesAuthentication` (function + call). A supplied `userId` now falls through to `assertReactionCreateFields` and is rejected as an unsupported field. The write still sets `userId: user.id` from the authenticated session.
- drop `userId` from `reactionStore`'s `AddReactionPayload` and its first-party callers (`components/art/art-reactions.vue`, `components/wonderlab/reaction-card.vue`) so clients stop sending it.
- stop building reaction bodies with `userId` in the deployed cypress specs (`reactions.cy.ts`, `component-reactions.cy.ts`); the previously-matching-`userId` create case now asserts a `400` unsupported-field rejection.
- update the DB-free boundary contract (`verifyReactionCreateInputBoundary.ts`) to forbid the `userId` allowlist entry and the compatibility boundary while keeping the authenticated-write assertion.

## Why

Reaction persistence was already ownership-safe, but the create route still accepted a matching `userId`, which kept a stale client contract alive and obscured that ownership is server-owned. With the store and first-party callers migrated off `userId`, the compatibility stage can be removed entirely.

## Checks

- Reaction Create Input Boundary (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

_Note: the `userId` computed/filter reads still present in `art-reactions.vue` are display-only (deduping the current user's own reaction) and are a separate Phase-4 store-safety follow-up, not part of the create-payload contract._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_