### PR TITLE
Enforce Theme mutation input parity

### DIFF
--- a/.github/workflows/theme-mutation-input-parity.yml
+++ b/.github/workflows/theme-mutation-input-parity.yml
@@ -1,0 +1,41 @@
+name: Theme Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/themes/mutation.ts'
+      - 'server/api/themes/index.ts'
+      - 'server/api/themes/index.post.ts'
+      - 'server/api/themes/[id].patch.ts'
+      - 'server/api/themes/batch.post.ts'
+      - 'stores/themeStore.ts'
+      - 'cypress/e2e/api/theme-input-boundary.cy.ts'
+      - 'utils/scripts/verifyThemeMutationInputParity.ts'
+      - '.github/workflows/theme-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Theme mutation input parity
+        run: npx tsx utils/scripts/verifyThemeMutationInputParity.ts

--- a/cypress/e2e/api/theme-input-boundary.cy.ts
+++ b/cypress/e2e/api/theme-input-boundary.cy.ts
@@ -1,0 +1,234 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type ThemeRow = {
+  id: number
+  userId: number | null
+  name: string
+  colorScheme: string
+  artPrompt: string | null
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Theme mutation input boundary', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let themeBaseUrl = ''
+  let ownerToken = ''
+  let ownerId: number | undefined
+  let otherId: number | undefined
+  let themeId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+
+  const baseValues = {
+    '--color-primary': '#3366ff',
+    '--color-secondary': '#ff66aa',
+  }
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        themeBaseUrl = `${apiBase}/themes`
+        return createLoggedInTestUser()
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherId = other.id
+      })
+  })
+
+  after(() => {
+    if (themeId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${themeBaseUrl}/${themeId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      }).then(() => {
+        themeId = undefined
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
+  })
+
+  it('creates a Theme under the authenticated owner', () => {
+    expect(ownerId).to.exist
+
+    cy.request<ApiResponse<ThemeRow>>({
+      method: 'POST',
+      url: themeBaseUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `BoundaryTheme-${stamp}`,
+        values: baseValues,
+        isPublic: false,
+        colorScheme: 'dark',
+        artPrompt: 'a calm neon skyline',
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+      expect(response.body.data?.colorScheme).to.eq('dark')
+      expect(response.body.data?.artPrompt).to.eq('a calm neon skyline')
+
+      themeId = response.body.data?.id
+      expect(themeId).to.be.a('number')
+    })
+  })
+
+  it('rejects unknown and spoofed fields on singular Theme creation', () => {
+    expect(otherId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: themeBaseUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `UnknownFieldTheme-${stamp}`,
+        values: baseValues,
+        createdAt: new Date().toISOString(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Theme fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: themeBaseUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `SpoofedOwnerTheme-${stamp}`,
+        values: baseValues,
+        userId: otherId,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('enforces the serialized values size limit on Theme creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: themeBaseUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `OversizedValuesTheme-${stamp}`,
+        values: { '--x': 'a'.repeat(50_001) },
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('serialized characters')
+    })
+  })
+
+  it('rejects unknown, mismatched ID, and spoofed owner fields on Theme PATCH', () => {
+    expect(themeId).to.exist
+    expect(otherId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${themeBaseUrl}/${themeId}`,
+      headers: ownerHeaders(),
+      body: { createdAt: new Date().toISOString() },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Theme fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${themeBaseUrl}/${themeId}`,
+      headers: ownerHeaders(),
+      body: { id: (themeId as number) + 1 },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('must match the route')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${themeBaseUrl}/${themeId}`,
+      headers: ownerHeaders(),
+      body: { userId: otherId },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('applies the same strict boundary to Theme batches', () => {
+    const oversized = Array.from({ length: 101 }, (_, index) => ({
+      name: `BatchCapTheme-${stamp}-${index}`,
+      values: baseValues,
+    }))
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${themeBaseUrl}/batch`,
+      headers: ownerHeaders(),
+      body: oversized,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<
+      ApiResponse<{ failed: Array<{ name: string; message: string }> }>
+    >({
+      method: 'POST',
+      url: `${themeBaseUrl}/batch`,
+      headers: ownerHeaders(),
+      body: [
+        {
+          name: `BatchUnknownFieldTheme-${stamp}`,
+          values: baseValues,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.data?.failed).to.have.length(1)
+      expect(response.body.data?.failed?.[0]?.message).to.include(
+        'Unsupported Theme fields',
+      )
+    })
+  })
+})

--- a/server/api/themes/[id].patch.ts
+++ b/server/api/themes/[id].patch.ts
@@ -4,6 +4,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
 import { stringifyValues, parseTheme } from '@/server/api/themes/index'
+import { assertThemeMutationInput, themePatchFields } from './mutation'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 
 export default defineEventHandler(async (event) => {
@@ -54,6 +55,14 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    assertThemeMutationInput(raw, {
+      allowedFields: themePatchFields,
+      context: 'Theme patch payload',
+      authenticatedUserId: user.id,
+      routeId: id,
+      requireNonEmpty: true,
+    })
+
     const allowed = [
       'name',
       'values',
@@ -62,6 +71,7 @@ export default defineEventHandler(async (event) => {
       'prefersDark',
       'colorScheme',
       'isPublic',
+      'artPrompt',
     ] as const
     const data: Prisma.ThemeUpdateInput = {}
 
@@ -124,6 +134,7 @@ export default defineEventHandler(async (event) => {
 
       if (key === 'tagline') data.tagline = normalized
       if (key === 'room') data.room = normalized
+      if (key === 'artPrompt') data.artPrompt = normalized
     }
 
     const updated = await prisma.theme.update({ where: { id }, data })

--- a/server/api/themes/batch.post.ts
+++ b/server/api/themes/batch.post.ts
@@ -13,6 +13,11 @@ import {
   type ThemeBatchSkip,
   type ThemeCreateInput,
 } from './index'
+import {
+  assertThemeMutationInput,
+  themeBatchCreateFields,
+  THEME_BATCH_LIMIT,
+} from './mutation'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -34,6 +39,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    if (body.length > THEME_BATCH_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `Theme batch may contain at most ${THEME_BATCH_LIMIT} entries.`,
+      })
+    }
+
     const created: ParsedTheme[] = []
     const skipped: ThemeBatchSkip[] = []
     const failed: ThemeBatchFailure[] = []
@@ -42,6 +54,11 @@ export default defineEventHandler(async (event) => {
       const fallbackName = fallbackThemeName(entry)
 
       try {
+        assertThemeMutationInput(entry, {
+          allowedFields: themeBatchCreateFields,
+          context: 'Theme batch item',
+        })
+
         const createInput = normalizeThemeInput(entry, user.id)
 
         try {

--- a/server/api/themes/index.post.ts
+++ b/server/api/themes/index.post.ts
@@ -9,6 +9,7 @@ import {
   parseTheme,
   type ThemeCreateInput,
 } from './index'
+import { assertThemeMutationInput, themeCreateFields } from './mutation'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -37,6 +38,12 @@ export default defineEventHandler(async (event) => {
         message: 'Request body is required.',
       })
     }
+
+    assertThemeMutationInput(body, {
+      allowedFields: themeCreateFields,
+      context: 'Theme create payload',
+      authenticatedUserId: user.id,
+    })
 
     const createInput = normalizeThemeInput(body, user.id)
 

--- a/server/api/themes/mutation.ts
+++ b/server/api/themes/mutation.ts
@@ -1,0 +1,204 @@
+// /server/api/themes/mutation.ts
+import { createError } from 'h3'
+import { stringifyValues } from './index'
+
+// Themes have no writable relations (only a read-only Reactions[] back-relation),
+// so this boundary bounds scalar input and the serialized `values` blob rather than
+// relation-ID arrays. `values` maps to a LongText column with no database-side cap.
+export const THEME_VALUES_LIMIT = 50_000
+export const THEME_BATCH_LIMIT = 100
+
+// Fields the Theme mutation routes actually persist.
+const persistedMutationFields = [
+  'name',
+  'values',
+  'isPublic',
+  'tagline',
+  'room',
+  'prefersDark',
+  'colorScheme',
+  'artPrompt',
+] as const
+
+// The current Theme store still sends a matching userId. It is validated and
+// ignored (ownership is authentication-derived) until the client stops sending it.
+const compatibilityFields = ['userId'] as const
+
+export const themeCreateFields = new Set<string>([
+  ...persistedMutationFields,
+  ...compatibilityFields,
+])
+
+export const themePatchFields = new Set<string>([
+  ...persistedMutationFields,
+  ...compatibilityFields,
+  'id',
+])
+
+// Batch imports stay strict: no identity/compatibility fields.
+export const themeBatchCreateFields = new Set<string>(persistedMutationFields)
+
+export type ThemeMutationBody = Record<string, unknown> & {
+  id?: number
+  userId?: number
+  name?: string
+  values?: unknown
+  isPublic?: boolean
+  tagline?: string | null
+  room?: string | null
+  prefersDark?: boolean
+  colorScheme?: string
+  artPrompt?: string | null
+}
+
+type ThemeMutationBoundaryOptions = {
+  allowedFields: ReadonlySet<string>
+  context: string
+  authenticatedUserId?: number
+  routeId?: number
+  requireNonEmpty?: boolean
+}
+
+const optionalTextFields = ['tagline', 'room', 'artPrompt'] as const
+const booleanFields = ['isPublic', 'prefersDark'] as const
+
+function positiveInteger(value: unknown, field: string): number {
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `Theme field "${field}" must be a positive integer.`,
+    })
+  }
+
+  return parsed
+}
+
+function assertOptionalText(body: ThemeMutationBody, field: string): void {
+  const value = body[field]
+  if (value === undefined || value === null) return
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `Theme field "${field}" must be a string or null.`,
+    })
+  }
+}
+
+// Validates the `values` blob shape (when present) and bounds its serialized size.
+// Required-ness on create stays in normalizeThemeInput; this only rejects a present
+// but malformed or oversized value.
+export function assertThemeValuesWithinLimit(body: ThemeMutationBody): void {
+  if (!('values' in body) || body.values === undefined || body.values === null) {
+    return
+  }
+
+  const serialized = stringifyValues(body.values)
+
+  if (!serialized) {
+    throw createError({
+      statusCode: 400,
+      message: '"values" must be a valid object or JSON string.',
+    })
+  }
+
+  if (serialized.length > THEME_VALUES_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `Theme "values" may not exceed ${THEME_VALUES_LIMIT} serialized characters.`,
+    })
+  }
+}
+
+export function assertThemeMutationInput(
+  body: unknown,
+  options: ThemeMutationBoundaryOptions,
+): asserts body is ThemeMutationBody {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.context} must be a JSON object.`,
+    })
+  }
+
+  const input = body as ThemeMutationBody
+  const fields = Object.keys(input)
+
+  if (options.requireNonEmpty && fields.length === 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'No data provided for update.',
+    })
+  }
+
+  const unsupported = fields.filter(
+    (field) => !options.allowedFields.has(field),
+  )
+
+  if (unsupported.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Theme fields in ${options.context}: ${unsupported.join(', ')}. IDs, timestamps, identity, and system fields are server-owned.`,
+    })
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'userId')) {
+    if (!options.authenticatedUserId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Theme ownership is server-owned.',
+      })
+    }
+
+    const requestedUserId = positiveInteger(input.userId, 'userId')
+    if (requestedUserId !== options.authenticatedUserId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Unsupported Theme ownership assignment. Ownership is server-owned.',
+      })
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'id')) {
+    const requestedId = positiveInteger(input.id, 'id')
+    if (!options.routeId || requestedId !== options.routeId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Theme ID is immutable and must match the route.',
+      })
+    }
+  }
+
+  if (input.name !== undefined && typeof input.name !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: 'Theme field "name" must be a string.',
+    })
+  }
+
+  for (const field of optionalTextFields) assertOptionalText(input, field)
+
+  for (const field of booleanFields) {
+    if (input[field] !== undefined && typeof input[field] !== 'boolean') {
+      throw createError({
+        statusCode: 400,
+        message: `Theme field "${field}" must be a boolean.`,
+      })
+    }
+  }
+
+  if (
+    input.colorScheme !== undefined &&
+    input.colorScheme !== 'light' &&
+    input.colorScheme !== 'dark'
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: '"colorScheme" must be either "light" or "dark".',
+    })
+  }
+
+  assertThemeValuesWithinLimit(input)
+}

--- a/stores/themeStore.ts
+++ b/stores/themeStore.ts
@@ -6,7 +6,6 @@ import {
   loadSnapshot,
   markSnapshotActive,
 } from '@/stores/helpers/snapshotLoader'
-import { useUserStore } from '@/stores/userStore'
 import { useErrorStore, ErrorType } from '@/stores/errorStore'
 import type { Theme } from '~/prisma/generated/prisma/client'
 
@@ -50,10 +49,7 @@ const themeStorageKey = 'theme'
 const themeFormStorageKey = 'themeForm'
 const showCustomStorageKey = 'showCustom'
 
-function toApiPayload(
-  src: ThemeForm | Partial<Theme>,
-  userId?: number,
-): ThemeApiPayload {
+function toApiPayload(src: ThemeForm | Partial<Theme>): ThemeApiPayload {
   const raw = (src as ThemeForm).values
   const values: string | undefined =
     typeof raw === 'string'
@@ -62,9 +58,9 @@ function toApiPayload(
         ? JSON.stringify(sanitizeThemeValues(raw))
         : undefined
 
+  // Ownership is authentication-derived server-side; identity/system fields
+  // (id, userId) are never sent.
   return {
-    id: (src as Partial<Theme>).id,
-    userId: userId ?? (src as Partial<Theme>).userId ?? undefined,
     name: (src as Partial<Theme>).name,
     values,
     isPublic: (src as Partial<Theme>).isPublic,
@@ -484,9 +480,7 @@ export const useThemeStore = defineStore('themeStore', () => {
   }
 
   async function addTheme(theme: ThemeForm | Partial<Theme>) {
-    const userStore = useUserStore()
-    const userId = userStore.user?.id || 10
-    const payload = toApiPayload(theme, userId)
+    const payload = toApiPayload(theme)
 
     try {
       const result = await performFetch('/api/themes', {
@@ -519,9 +513,7 @@ export const useThemeStore = defineStore('themeStore', () => {
     id: number,
     updates: ThemeForm | Partial<Theme>,
   ): Promise<void> {
-    const userStore = useUserStore()
-    const userId = userStore.user?.id || 10
-    const payload = toApiPayload(updates, userId)
+    const payload = toApiPayload(updates)
 
     try {
       const { success, message } = await performFetch(`/api/themes/${id}`, {

--- a/utils/scripts/verifyThemeMutationInputParity.ts
+++ b/utils/scripts/verifyThemeMutationInputParity.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/api/themes/mutation.ts')
+const createRoute = read('server/api/themes/index.post.ts')
+const patchRoute = read('server/api/themes/[id].patch.ts')
+const batchRoute = read('server/api/themes/batch.post.ts')
+const store = read('stores/themeStore.ts')
+const cypressSpec = read('cypress/e2e/api/theme-input-boundary.cy.ts')
+
+// Boundary exports the caps, allowlists, and the shared assertion.
+requireText(boundary, 'export const THEME_VALUES_LIMIT', 'Theme values cap')
+requireText(boundary, 'export const THEME_BATCH_LIMIT', 'Theme batch cap')
+requireText(boundary, 'export const themeCreateFields', 'Theme create allowlist')
+requireText(boundary, 'export const themePatchFields', 'Theme patch allowlist')
+requireText(
+  boundary,
+  'export const themeBatchCreateFields',
+  'Theme batch allowlist',
+)
+requireText(
+  boundary,
+  'export function assertThemeMutationInput',
+  'Theme mutation boundary',
+)
+requireText(boundary, 'Unsupported Theme fields in', 'Theme unknown-field error')
+requireText(
+  boundary,
+  'Ownership is server-owned',
+  'Theme spoofed-ownership error',
+)
+requireText(
+  boundary,
+  'Theme ID is immutable and must match the route.',
+  'Theme immutable-id error',
+)
+requireText(
+  boundary,
+  'serialized characters',
+  'Theme values size-limit error',
+)
+
+// Batch imports stay strict: no identity or compatibility fields.
+requireText(
+  boundary,
+  'new Set<string>(persistedMutationFields)',
+  'Theme strict batch allowlist',
+)
+
+// Routes wire the boundary with the correct allowlist before persisting.
+requireText(
+  createRoute,
+  'allowedFields: themeCreateFields',
+  'Theme create route wiring',
+)
+requireText(
+  patchRoute,
+  'allowedFields: themePatchFields',
+  'Theme patch route wiring',
+)
+requireText(patchRoute, 'routeId: id', 'Theme patch route immutable-id wiring')
+requireText(patchRoute, "'artPrompt'", 'Theme patch artPrompt parity')
+requireText(
+  batchRoute,
+  'allowedFields: themeBatchCreateFields',
+  'Theme batch route wiring',
+)
+requireText(
+  batchRoute,
+  'THEME_BATCH_LIMIT',
+  'Theme batch route size cap',
+)
+
+// The store no longer sends identity/system fields or falls back to a user id.
+forbidText(store, 'id: (src as Partial<Theme>).id', 'Theme store id leak')
+forbidText(store, 'userId ??', 'Theme store userId leak')
+forbidText(store, '|| 10', 'Theme store fallback user')
+
+// Deployed regression it() blocks are pinned to the contract.
+requireText(
+  cypressSpec,
+  'rejects unknown and spoofed fields on singular Theme creation',
+  'Theme create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'enforces the serialized values size limit on Theme creation',
+  'Theme values-limit deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown, mismatched ID, and spoofed owner fields on Theme PATCH',
+  'Theme patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'applies the same strict boundary to Theme batches',
+  'Theme batch deployed regression',
+)
+
+console.log('Theme mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Continues the API overhaul (#570, Phase 1) with the Theme mutation family, following the Dream/Scenario/Character parity pattern. The Theme routes already derived ownership from authentication and validated the `values` shape, so this closes the remaining gaps rather than reworking ownership.

- add `server/api/themes/mutation.ts`: `themeCreateFields` / `themePatchFields` / `themeBatchCreateFields` allowlists and `assertThemeMutationInput`, which **rejects unknown fields** (previously silently dropped), spoofed `userId` (must match the authenticated caller), mismatched route `id`, and malformed `name`/text/boolean/`colorScheme` values.
- bound the `values` blob at `THEME_VALUES_LIMIT` (50k serialized chars) — `values` maps to an uncapped `LongText` column with no prior size limit.
- cap Theme batches at `THEME_BATCH_LIMIT` (100) and run each entry through the strict allowlist, preserving the existing `201`/`207`/`400` partial-batch behavior.
- add `artPrompt` to the PATCH allowlist and apply it, reconciling create/patch parity (create already accepted it).
- stop the theme store (`toApiPayload`) from sending `id`/`userId` and drop the `|| 10` fallback user in `addTheme`/`updateTheme`; ownership stays authentication-derived.
- add a DB-free parity contract (`verifyThemeMutationInputParity.ts`), a deployed input-boundary cypress spec, and a read-only workflow.

## Why

Theme had three subtly different input behaviors: create/batch silently ignored unknown model fields, PATCH used an allowlist but omitted `artPrompt`, and nothing bounded the serialized `values` size. This makes one deliberate boundary explicit without weakening the existing ownership or duplicate handling.

## Checks

- Theme Mutation Input Parity (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_