### PR TITLE
Enforce Reward mutation input parity

### DIFF
--- a/.github/workflows/reward-mutation-input-parity.yml
+++ b/.github/workflows/reward-mutation-input-parity.yml
@@ -1,0 +1,40 @@
+name: Reward Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/rewards/mutation.ts'
+      - 'server/api/rewards/index.ts'
+      - 'server/api/rewards/index.post.ts'
+      - 'server/api/rewards/[id].patch.ts'
+      - 'server/api/rewards/batch.post.ts'
+      - 'cypress/e2e/api/reward-input-boundary.cy.ts'
+      - 'utils/scripts/verifyRewardMutationInputParity.ts'
+      - '.github/workflows/reward-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Reward mutation input parity
+        run: npx tsx utils/scripts/verifyRewardMutationInputParity.ts

--- a/cypress/e2e/api/reward-input-boundary.cy.ts
+++ b/cypress/e2e/api/reward-input-boundary.cy.ts
@@ -1,0 +1,227 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type RewardRow = {
+  id: number
+  userId: number | null
+  name: string
+  rarity: string
+  rewardType: string
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  reward?: T | null
+  errors?: Array<{ index: number; message: string }>
+  statusCode?: number
+}
+
+describe('Reward mutation input boundary', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let rewardsUrl = ''
+  let ownerToken = ''
+  let ownerId: number | undefined
+  let rewardId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        rewardsUrl = `${apiBase}/rewards`
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+      })
+  })
+
+  after(() => {
+    if (rewardId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${rewardsUrl}/${rewardId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      }).then(() => {
+        rewardId = undefined
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+  })
+
+  it('creates a Reward under the authenticated owner', () => {
+    expect(ownerId).to.exist
+
+    cy.request<ApiResponse<RewardRow>>({
+      method: 'POST',
+      url: rewardsUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `BoundaryReward-${stamp}`,
+        slug: `boundary-reward-${stamp}`,
+        rewardType: 'ITEM',
+        rarity: 'COMMON',
+        isPublic: false,
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      const reward = response.body.data || response.body.reward
+      expect(reward?.userId).to.eq(ownerId)
+
+      rewardId = reward?.id
+      expect(rewardId).to.be.a('number')
+    })
+  })
+
+  it('rejects unknown fields on singular Reward creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: rewardsUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `UnknownFieldReward-${stamp}`,
+        createdAt: new Date().toISOString(),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Reward fields')
+    })
+  })
+
+  it('rejects oversized and invalid relation arrays on Reward creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: rewardsUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `OversizedRelationReward-${stamp}`,
+        characterIds: Array.from({ length: 101 }, (_, index) => index + 1),
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: rewardsUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `InvalidRelationReward-${stamp}`,
+        characterIds: [1, 0],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('invalid ID at index 1')
+    })
+  })
+
+  it('rejects nonexistent relation targets on Reward creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: rewardsUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `MissingRelationReward-${stamp}`,
+        characterIds: [2000000001],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(404)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Character relation not found')
+    })
+  })
+
+  it('rejects unknown, mismatched ID, and invalid enum fields on Reward PATCH', () => {
+    expect(rewardId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${rewardsUrl}/${rewardId}`,
+      headers: ownerHeaders(),
+      body: { createdAt: new Date().toISOString() },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Reward fields')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${rewardsUrl}/${rewardId}`,
+      headers: ownerHeaders(),
+      body: { id: (rewardId as number) + 1 },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('must match the route')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${rewardsUrl}/${rewardId}`,
+      headers: ownerHeaders(),
+      body: { rarity: 'NOT_A_RARITY' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('must be a valid Rarity')
+    })
+  })
+
+  it('applies the same strict boundary to Reward batches', () => {
+    const oversized = Array.from({ length: 101 }, (_, index) => ({
+      name: `BatchCapReward-${stamp}-${index}`,
+    }))
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${rewardsUrl}/batch`,
+      headers: ownerHeaders(),
+      body: oversized,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('at most 100 entries')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${rewardsUrl}/batch`,
+      headers: ownerHeaders(),
+      body: [
+        {
+          name: `BatchUnknownFieldReward-${stamp}`,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Reward fields')
+    })
+  })
+})

--- a/server/api/rewards/[id].patch.ts
+++ b/server/api/rewards/[id].patch.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { updateRewardById, type RewardMutationInput } from './index'
+import { assertRewardMutationInput, rewardPatchFields } from './mutation'
 
 export default defineEventHandler(async (event) => {
   const rewardId = Number(event.context.params?.id)
@@ -71,6 +72,13 @@ export default defineEventHandler(async (event) => {
         message: 'Reward ownership cannot be changed here.',
       })
     }
+
+    assertRewardMutationInput(rewardData, {
+      allowedFields: rewardPatchFields,
+      context: 'Reward patch payload',
+      routeId: rewardId,
+      requireNonEmpty: true,
+    })
 
     const data = await updateRewardById(rewardId, rewardData)
 

--- a/server/api/rewards/batch.post.ts
+++ b/server/api/rewards/batch.post.ts
@@ -3,6 +3,11 @@ import { defineEventHandler, readBody, createError } from 'h3'
 import { createRewardsBatch, type RewardMutationInput } from './'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import {
+  assertRewardMutationInput,
+  rewardBatchCreateFields,
+  REWARD_BATCH_LIMIT,
+} from './mutation'
 
 type RewardBatchBody =
   | RewardMutationInput[]
@@ -50,6 +55,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    if (rewardsData.length > REWARD_BATCH_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `Reward batch may contain at most ${REWARD_BATCH_LIMIT} entries.`,
+      })
+    }
+
     for (const [index, rewardData] of rewardsData.entries()) {
       if (
         !rewardData ||
@@ -72,6 +84,11 @@ export default defineEventHandler(async (event) => {
           message: `User ID in reward at index ${index} does not match the authenticated user.`,
         })
       }
+
+      assertRewardMutationInput(rewardData, {
+        allowedFields: rewardBatchCreateFields,
+        context: `Reward batch item ${index}`,
+      })
     }
 
     const { count, rewards, errors } = await createRewardsBatch(

--- a/server/api/rewards/index.post.ts
+++ b/server/api/rewards/index.post.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, readBody, createError } from 'h3'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { createReward, type RewardMutationInput } from './'
+import { assertRewardMutationInput, rewardCreateFields } from './mutation'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -39,6 +40,11 @@ export default defineEventHandler(async (event) => {
           'User ID in the reward data does not match the authenticated user.',
       })
     }
+
+    assertRewardMutationInput(rewardData, {
+      allowedFields: rewardCreateFields,
+      context: 'Reward create payload',
+    })
 
     const data = await createReward(rewardData, user.id)
 

--- a/server/api/rewards/index.ts
+++ b/server/api/rewards/index.ts
@@ -11,6 +11,7 @@ import {
   rewardMutationSelect,
   type RewardMutationResult,
 } from './selects'
+import { assertRewardRelationsExist } from './mutation'
 
 export type RewardRelationInput = {
   characterIds?: number[]
@@ -395,6 +396,8 @@ export async function createReward(
   input: RewardMutationInput,
   authenticatedUserId: number,
 ): Promise<RewardMutationResult> {
+  await assertRewardRelationsExist(input)
+
   return await prisma.reward.create({
     data: buildCreateData(input, authenticatedUserId),
     select: rewardMutationSelect,
@@ -476,6 +479,8 @@ export async function updateRewardById(
   id: number,
   input: RewardMutationInput,
 ): Promise<RewardMutationResult> {
+  await assertRewardRelationsExist(input)
+
   return await prisma.reward.update({
     where: { id },
     data: buildUpdateData(input),

--- a/server/api/rewards/mutation.ts
+++ b/server/api/rewards/mutation.ts
@@ -1,0 +1,383 @@
+// /server/api/rewards/mutation.ts
+import { createError } from 'h3'
+import { Rarity, RewardType } from '~/prisma/generated/prisma/client'
+import prisma from '../../utils/prisma'
+
+export const REWARD_RELATION_ID_LIMIT = 100
+export const REWARD_BATCH_LIMIT = 100
+
+// Scalar/alias fields the Reward builders persist. Aliases (label/text/power/type)
+// are retained for the current client and normalized in buildCreate/UpdateData.
+const persistedMutationFields = [
+  'name',
+  'label',
+  'slug',
+  'description',
+  'text',
+  'flavorText',
+  'effect',
+  'power',
+  'icon',
+  'collection',
+  'rarity',
+  'rewardType',
+  'type',
+  'artImageId',
+  'imagePath',
+  'artPrompt',
+  'isMature',
+  'isPublic',
+  'isActive',
+] as const
+
+const createRelationFields = ['characterIds', 'dreamIds'] as const
+const patchRelationFields = [
+  'characterIds',
+  'dreamIds',
+  'setCharacterIds',
+  'setDreamIds',
+  'removeCharacterIds',
+  'removeDreamIds',
+] as const
+
+// A matching userId is validated by the routes (403 on mismatch). It is allowlisted
+// on singular routes so it is not rejected as an unknown field; batch stays strict.
+const compatibilityFields = ['userId'] as const
+
+export const rewardCreateFields = new Set<string>([
+  ...persistedMutationFields,
+  ...createRelationFields,
+  ...compatibilityFields,
+])
+
+export const rewardPatchFields = new Set<string>([
+  ...persistedMutationFields,
+  ...patchRelationFields,
+  ...compatibilityFields,
+  'id',
+])
+
+export const rewardBatchCreateFields = new Set<string>([
+  ...persistedMutationFields,
+  ...createRelationFields,
+])
+
+export type RewardMutationBody = Record<string, unknown> & {
+  id?: number
+  userId?: number | null
+  rarity?: unknown
+  rewardType?: unknown
+  type?: unknown
+  artImageId?: number | null
+  characterIds?: unknown
+  dreamIds?: unknown
+  setCharacterIds?: unknown
+  setDreamIds?: unknown
+  removeCharacterIds?: unknown
+  removeDreamIds?: unknown
+}
+
+type RewardMutationBoundaryOptions = {
+  allowedFields: ReadonlySet<string>
+  context: string
+  routeId?: number
+  requireNonEmpty?: boolean
+}
+
+const validRarities = new Set<string>(Object.values(Rarity))
+const validRewardTypes = new Set<string>(Object.values(RewardType))
+
+const nullableTextFields = [
+  'slug',
+  'description',
+  'text',
+  'flavorText',
+  'effect',
+  'power',
+  'icon',
+  'collection',
+  'imagePath',
+  'artPrompt',
+] as const
+
+const booleanFields = ['isMature', 'isPublic', 'isActive'] as const
+
+const relationArrayFields = [
+  'characterIds',
+  'dreamIds',
+  'setCharacterIds',
+  'setDreamIds',
+  'removeCharacterIds',
+  'removeDreamIds',
+] as const
+
+function positiveInteger(value: unknown, field: string): number {
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `Reward field "${field}" must be a positive integer.`,
+    })
+  }
+
+  return parsed
+}
+
+export function normalizeBoundedRewardNullableId(
+  value: unknown,
+  field: string,
+): number | null | undefined {
+  if (value === null) return null
+  if (value === undefined || value === '') return undefined
+  return positiveInteger(value, field)
+}
+
+export function normalizeBoundedRewardIdArray(
+  value: unknown,
+  field: string,
+): number[] | undefined {
+  if (value === undefined) return undefined
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `Reward field "${field}" must be an array.`,
+    })
+  }
+
+  if (value.length > REWARD_RELATION_ID_LIMIT) {
+    throw createError({
+      statusCode: 400,
+      message: `Reward field "${field}" may contain at most ${REWARD_RELATION_ID_LIMIT} entries.`,
+    })
+  }
+
+  const ids = value.map((entry, index) => {
+    const candidate =
+      entry && typeof entry === 'object' && 'id' in entry
+        ? (entry as { id?: unknown }).id
+        : entry
+
+    try {
+      return positiveInteger(candidate, `${field}[${index}]`)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: `Reward field "${field}" contains an invalid ID at index ${index}.`,
+      })
+    }
+  })
+
+  return Array.from(new Set(ids))
+}
+
+function assertNullableText(body: RewardMutationBody, field: string): void {
+  const value = body[field]
+  if (value === undefined || value === null) return
+
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `Reward field "${field}" must be a string or null.`,
+    })
+  }
+}
+
+function assertEnum(
+  body: RewardMutationBody,
+  field: 'rarity' | 'rewardType' | 'type',
+  valid: ReadonlySet<string>,
+  label: string,
+): void {
+  const value = body[field]
+  if (value === undefined) return
+
+  if (typeof value !== 'string' || !valid.has(value.toUpperCase())) {
+    throw createError({
+      statusCode: 400,
+      message: `Reward field "${field}" must be a valid ${label}.`,
+    })
+  }
+}
+
+export function assertRewardMutationInput(
+  body: unknown,
+  options: RewardMutationBoundaryOptions,
+): asserts body is RewardMutationBody {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({
+      statusCode: 400,
+      message: `${options.context} must be a JSON object.`,
+    })
+  }
+
+  const input = body as RewardMutationBody
+  const fields = Object.keys(input)
+
+  if (options.requireNonEmpty && fields.length === 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'No valid data provided for update.',
+    })
+  }
+
+  const unsupported = fields.filter(
+    (field) => !options.allowedFields.has(field),
+  )
+
+  if (unsupported.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported Reward fields in ${options.context}: ${unsupported.join(', ')}. IDs, timestamps, identity, and system fields are server-owned.`,
+    })
+  }
+
+  // Ownership (userId) is enforced by the routes (403 on mismatch); it is only
+  // allowlisted here. Route identity stays immutable.
+  if (Object.prototype.hasOwnProperty.call(input, 'id')) {
+    const requestedId = positiveInteger(input.id, 'id')
+    if (!options.routeId || requestedId !== options.routeId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Reward ID is immutable and must match the route.',
+      })
+    }
+  }
+
+  if (
+    input.name !== undefined &&
+    input.name !== null &&
+    typeof input.name !== 'string'
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Reward field "name" must be a string.',
+    })
+  }
+
+  if (
+    input.label !== undefined &&
+    input.label !== null &&
+    typeof input.label !== 'string'
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'Reward field "label" must be a string.',
+    })
+  }
+
+  for (const field of nullableTextFields) assertNullableText(input, field)
+
+  for (const field of booleanFields) {
+    if (input[field] !== undefined && typeof input[field] !== 'boolean') {
+      throw createError({
+        statusCode: 400,
+        message: `Reward field "${field}" must be a boolean.`,
+      })
+    }
+  }
+
+  assertEnum(input, 'rarity', validRarities, 'Rarity')
+  assertEnum(input, 'rewardType', validRewardTypes, 'RewardType')
+  assertEnum(input, 'type', validRewardTypes, 'RewardType')
+
+  normalizeBoundedRewardNullableId(input.artImageId, 'artImageId')
+
+  for (const field of relationArrayFields) {
+    if (input[field] !== undefined) {
+      normalizeBoundedRewardIdArray(input[field], field)
+    }
+  }
+}
+
+async function assertIdsExist(
+  ids: number[],
+  find: (idsIn: number[]) => Promise<Array<{ id: number }>>,
+  label: string,
+): Promise<void> {
+  if (!ids.length) return
+
+  const found = await find(ids)
+  const foundIds = new Set(found.map((row) => row.id))
+  const missing = ids.filter((id) => !foundIds.has(id))
+
+  if (missing.length) {
+    throw createError({
+      statusCode: 404,
+      message: `${label} not found: ${missing.join(', ')}.`,
+    })
+  }
+}
+
+type RewardRelationExistenceInput = {
+  characterIds?: unknown
+  dreamIds?: unknown
+  setCharacterIds?: unknown
+  setDreamIds?: unknown
+  artImageId?: unknown
+}
+
+// Verifies that every connect/set relation target and artImage referenced by a
+// Reward mutation actually exists before the write. Disconnect (remove*) targets
+// are not existence-checked because disconnecting a missing relation is a no-op.
+export async function assertRewardRelationsExist(
+  input: RewardRelationExistenceInput,
+): Promise<void> {
+  const characterIds = Array.from(
+    new Set([
+      ...(normalizeBoundedRewardIdArray(input.characterIds, 'characterIds') ??
+        []),
+      ...(normalizeBoundedRewardIdArray(
+        input.setCharacterIds,
+        'setCharacterIds',
+      ) ?? []),
+    ]),
+  )
+
+  const dreamIds = Array.from(
+    new Set([
+      ...(normalizeBoundedRewardIdArray(input.dreamIds, 'dreamIds') ?? []),
+      ...(normalizeBoundedRewardIdArray(input.setDreamIds, 'setDreamIds') ?? []),
+    ]),
+  )
+
+  const artImageId = normalizeBoundedRewardNullableId(
+    input.artImageId,
+    'artImageId',
+  )
+
+  await assertIdsExist(
+    characterIds,
+    (idsIn) =>
+      prisma.character.findMany({
+        where: { id: { in: idsIn } },
+        select: { id: true },
+      }),
+    'Reward Character relation',
+  )
+
+  await assertIdsExist(
+    dreamIds,
+    (idsIn) =>
+      prisma.dream.findMany({
+        where: { id: { in: idsIn } },
+        select: { id: true },
+      }),
+    'Reward Dream relation',
+  )
+
+  if (typeof artImageId === 'number') {
+    const artImage = await prisma.artImage.findUnique({
+      where: { id: artImageId },
+      select: { id: true },
+    })
+
+    if (!artImage) {
+      throw createError({
+        statusCode: 404,
+        message: `Reward ArtImage relation not found: ${artImageId}.`,
+      })
+    }
+  }
+}

--- a/utils/scripts/verifyRewardMutationInputParity.ts
+++ b/utils/scripts/verifyRewardMutationInputParity.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/api/rewards/mutation.ts')
+const index = read('server/api/rewards/index.ts')
+const createRoute = read('server/api/rewards/index.post.ts')
+const patchRoute = read('server/api/rewards/[id].patch.ts')
+const batchRoute = read('server/api/rewards/batch.post.ts')
+const cypressSpec = read('cypress/e2e/api/reward-input-boundary.cy.ts')
+
+// Boundary exports caps, allowlists, the assertion, and the existence check.
+requireText(
+  boundary,
+  'export const REWARD_RELATION_ID_LIMIT = 100',
+  'Reward relation cap',
+)
+requireText(
+  boundary,
+  'export const REWARD_BATCH_LIMIT = 100',
+  'Reward batch cap',
+)
+requireText(boundary, 'export const rewardCreateFields', 'Reward create allowlist')
+requireText(boundary, 'export const rewardPatchFields', 'Reward patch allowlist')
+requireText(
+  boundary,
+  'export const rewardBatchCreateFields',
+  'Reward batch allowlist',
+)
+requireText(
+  boundary,
+  'export function assertRewardMutationInput',
+  'Reward mutation boundary',
+)
+requireText(
+  boundary,
+  'export async function assertRewardRelationsExist',
+  'Reward relation existence check',
+)
+requireText(boundary, 'Unsupported Reward fields in', 'Reward unknown-field error')
+requireText(
+  boundary,
+  'Reward ID is immutable and must match the route.',
+  'Reward immutable-id error',
+)
+requireText(
+  boundary,
+  'may contain at most ${REWARD_RELATION_ID_LIMIT} entries',
+  'Reward relation cap error',
+)
+requireText(
+  boundary,
+  'contains an invalid ID at index',
+  'Reward invalid-relation-id error',
+)
+requireText(boundary, 'must be a valid ${label}', 'Reward enum error')
+
+// Batch allowlist stays strict: only persisted + create-relation fields.
+requireText(
+  boundary,
+  'export const rewardBatchCreateFields = new Set<string>([\n  ...persistedMutationFields,\n  ...createRelationFields,\n])',
+  'Reward strict batch allowlist',
+)
+
+// The builders run the existence check before every write, so singular and batch
+// both reject nonexistent relation targets.
+requireText(
+  index,
+  'await assertRewardRelationsExist(input)',
+  'Reward existence check wiring',
+)
+
+// Routes wire the boundary with the correct allowlist.
+requireText(
+  createRoute,
+  'allowedFields: rewardCreateFields',
+  'Reward create route wiring',
+)
+requireText(
+  patchRoute,
+  'allowedFields: rewardPatchFields',
+  'Reward patch route wiring',
+)
+requireText(patchRoute, 'routeId: rewardId', 'Reward patch immutable-id wiring')
+requireText(
+  batchRoute,
+  'allowedFields: rewardBatchCreateFields',
+  'Reward batch route wiring',
+)
+requireText(batchRoute, 'REWARD_BATCH_LIMIT', 'Reward batch size cap wiring')
+
+// Deployed regression it() blocks are pinned to the contract.
+requireText(
+  cypressSpec,
+  'rejects unknown fields on singular Reward creation',
+  'Reward create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects oversized and invalid relation arrays on Reward creation',
+  'Reward relation deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects nonexistent relation targets on Reward creation',
+  'Reward existence deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown, mismatched ID, and invalid enum fields on Reward PATCH',
+  'Reward patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'applies the same strict boundary to Reward batches',
+  'Reward batch deployed regression',
+)
+
+console.log('Reward mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Continues the API overhaul (#570) with the Reward mutation family — the worst gap the remaining-route sweep found. Reward ownership was already authentication-derived and mutation responses were already lean, but the routes silently ignored unknown fields and accepted **unbounded, unchecked** relation-ID arrays (`characterIds`/`dreamIds`/`set*`/`remove*`).

- add `server/api/rewards/mutation.ts`: `rewardCreateFields` / `rewardPatchFields` / `rewardBatchCreateFields` allowlists and `assertRewardMutationInput`, which rejects unknown fields, mismatched route `id`, invalid `Rarity`/`RewardType` enums (previously silently defaulted), and malformed text/boolean values.
- cap every relation array at `REWARD_RELATION_ID_LIMIT` (100), dedupe, and reject non-positive IDs with their offending index.
- add `assertRewardRelationsExist`: a bounded existence check for connect/set `Character`, `Dream`, and `ArtImage` targets, run inside `createReward`/`updateRewardById` so **singular and batch both** reject nonexistent relations (previously any ID was connected blind, failing only on a raw FK error).
- cap Reward batches at `REWARD_BATCH_LIMIT` (100) and run each item through the strict allowlist, preserving the existing `201`/`207`/`400` behavior.
- keep the existing authenticated-ownership `403` checks unchanged; `userId` is allowlisted on singular routes and excluded from the strict batch allowlist.
- add a DB-free parity contract (`verifyRewardMutationInputParity.ts`), a deployed input-boundary cypress spec, and a read-only workflow.

## Why

Reward mutations were ownership-safe but input-unsafe: a client could send arbitrary payload fields, an unbounded list of relation IDs, or IDs that don't exist, and the API would silently drop the extras or attempt a blind connect. This establishes one explicit, bounded, existence-checked boundary without weakening the existing ownership handling or the lean response projection.

## Checks

- Reward Mutation Input Parity (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_