### PR TITLE
Narrow ArtQueueEntry.variant to the ArtVariant union

### DIFF
--- a/server/api/conductor/art-request.post.ts
+++ b/server/api/conductor/art-request.post.ts
@@ -6,7 +6,7 @@ import { errorHandler } from '@/server/utils/error'
 import { userIsAdmin } from '@/server/utils/authUser'
 import { validateApiKey } from '@/server/utils/validateKey'
 import { buildContextualArtPrompt } from '@/server/utils/conductorArtPrompt'
-import { type ArtQueueEntry, appendRequest } from '@/server/utils/artRequestYaml'
+import { type ArtQueueEntry, type ArtVariant, appendRequest } from '@/server/utils/artRequestYaml'
 
 const GITHUB_API = 'https://api.github.com'
 const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
@@ -20,8 +20,6 @@ const VARIANT_SIZES = {
   hero: '1280x720',
   image: '',
 } as const
-
-type ArtVariant = keyof typeof VARIANT_SIZES
 
 type MissingArtRequestBody = {
   src?: string

--- a/server/utils/artRequestYaml.ts
+++ b/server/utils/artRequestYaml.ts
@@ -12,6 +12,8 @@
 // exactly 2 spaces. conductor's PyYAML parser rejects mixed indentation, which is
 // the silent-stall bug this module's test guards against (kind_robots PR #84).
 
+export type ArtVariant = 'icon' | 'card' | 'hero' | 'image'
+
 export type ArtQueueEntry = {
   id: string
   source: string
@@ -20,7 +22,7 @@ export type ArtQueueEntry = {
   image_path: string
   source_url: string
   page_url: string
-  variant: string
+  variant: ArtVariant
   size: string
   label: string
   prompt: string


### PR DESCRIPTION
### Task
art-generator-connect/t-020: Re-tighten `ArtQueueEntry.variant` from `string` back to the `ArtVariant` union (kind: software)

Closing unmerged — superseded by #581, which landed the identical fix (same `ArtVariant` union, same base commit `d06f365`) a few minutes ahead of this one. Classic rotation collision: both sessions read `status: ready` on the conductor roadmap before either had claimed/pushed, so both fully implemented it. See conductor `art-generator-connect/TALKBACK.md` for the record.

No further action needed here — `main` already has this change via #581.
