### PR TITLE
art-generator-connect/t-020: narrow ArtQueueEntry.variant back to ArtVariant union

### DIFF
--- a/server/api/conductor/art-request.post.ts
+++ b/server/api/conductor/art-request.post.ts
@@ -6,7 +6,7 @@ import { errorHandler } from '@/server/utils/error'
 import { userIsAdmin } from '@/server/utils/authUser'
 import { validateApiKey } from '@/server/utils/validateKey'
 import { buildContextualArtPrompt } from '@/server/utils/conductorArtPrompt'
-import { type ArtQueueEntry, appendRequest } from '@/server/utils/artRequestYaml'
+import { type ArtQueueEntry, type ArtVariant, appendRequest } from '@/server/utils/artRequestYaml'
 
 const GITHUB_API = 'https://api.github.com'
 const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
@@ -14,14 +14,12 @@ const CONDUCTOR_REPO = 'silasfelinus/conductor'
 const ART_PROMPTS_PATH = 'projects/art-prompts.yaml'
 const DEFAULT_BRANCH = 'main'
 const IMAGE_EXTENSIONS = new Set(['.webp', '.png', '.jpg', '.jpeg', '.gif', '.svg'])
-const VARIANT_SIZES = {
+const VARIANT_SIZES: Record<ArtVariant, string> = {
   icon: '256x256',
   card: '512x768',
   hero: '1280x720',
   image: '',
-} as const
-
-type ArtVariant = keyof typeof VARIANT_SIZES
+}
 
 type MissingArtRequestBody = {
   src?: string

--- a/server/utils/artRequestYaml.ts
+++ b/server/utils/artRequestYaml.ts
@@ -12,6 +12,8 @@
 // exactly 2 spaces. conductor's PyYAML parser rejects mixed indentation, which is
 // the silent-stall bug this module's test guards against (kind_robots PR #84).
 
+export type ArtVariant = 'icon' | 'card' | 'hero' | 'image'
+
 export type ArtQueueEntry = {
   id: string
   source: string
@@ -20,7 +22,7 @@ export type ArtQueueEntry = {
   image_path: string
   source_url: string
   page_url: string
-  variant: string
+  variant: ArtVariant
   size: string
   label: string
   prompt: string


### PR DESCRIPTION
### Task
art-generator-connect/t-020: Re-tighten `ArtQueueEntry.variant` from string back to the ArtVariant union in `server/utils/artRequestYaml.ts` (kind: software)

### What changed
- `server/utils/artRequestYaml.ts`: added `export type ArtVariant = 'icon' | 'card' | 'hero' | 'image'` and narrowed `ArtQueueEntry.variant` from `string` to `ArtVariant`.
- `server/api/conductor/art-request.post.ts`: now imports `ArtVariant` from `artRequestYaml.ts` instead of re-declaring its own local `type ArtVariant = keyof typeof VARIANT_SIZES`, and pins `VARIANT_SIZES` to `Record<ArtVariant, string>` so the two definitions can't silently drift apart again.

### Why
When `renderRequestEntry`'s YAML logic was extracted out of `art-request.post.ts` into `artRequestYaml.ts` (PR #108, t-008/t-017), `ArtQueueEntry.variant` was quietly widened to plain `string`. Harmless today (all call sites already pass valid `ArtVariant` values), but it loosens the compile-time contract on a module whose entire purpose is enforcing one.

### How I verified
- `npm run test:art-request-yaml` (`tsx utils/scripts/verifyArtRequestYaml.ts`) — all checks pass.
- Full project typecheck (`npm run test`, `vue-tsc --noEmit`) — clean, no errors.

### Stakes
reversible (type-only narrowing; no runtime behavior change, all existing call sites already conform)

### Notes for reviewer
No other module imports `ArtVariant`/`ArtQueueEntry` besides these two files (confirmed via grep); `curationRequestYaml.ts` is a separate, unrelated sibling module.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0142ioErb4ow7oLcLrdhggwo

---
_Generated by [Claude Code](https://claude.ai/code/session_0142ioErb4ow7oLcLrdhggwo)_