### PR TITLE
Enforce PitchSheet mutation input parity

### DIFF
--- a/.github/workflows/sheet-mutation-input-parity.yml
+++ b/.github/workflows/sheet-mutation-input-parity.yml
@@ -1,0 +1,39 @@
+name: Sheet Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/utils/pitchSheets/payload.ts'
+      - 'server/api/sheets/index.post.ts'
+      - 'server/api/sheets/[id].patch.ts'
+      - 'server/api/sheets/by-dream/[dreamId].post.ts'
+      - 'cypress/e2e/api/sheet-input-boundary.cy.ts'
+      - 'utils/scripts/verifySheetMutationInputParity.ts'
+      - '.github/workflows/sheet-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Sheet mutation input parity
+        run: npx tsx utils/scripts/verifySheetMutationInputParity.ts

--- a/cypress/e2e/api/sheet-input-boundary.cy.ts
+++ b/cypress/e2e/api/sheet-input-boundary.cy.ts
@@ -1,0 +1,172 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type SheetRow = {
+  id: number
+  userId: number | null
+  dreamId: number | null
+  title: string
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('PitchSheet mutation input boundary', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let sheetsUrl = ''
+  let ownerToken = ''
+  let ownerId: number | undefined
+  let sheetId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        sheetsUrl = `${apiBase}/sheets`
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+      })
+  })
+
+  after(() => {
+    if (sheetId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${sheetsUrl}/${sheetId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      }).then(() => {
+        sheetId = undefined
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+  })
+
+  it('creates a standalone PitchSheet under the authenticated owner', () => {
+    expect(ownerId).to.exist
+
+    cy.request<ApiResponse<SheetRow>>({
+      method: 'POST',
+      url: sheetsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `BoundarySheet-${stamp}`,
+        subtitle: 'A standalone pitch sheet fixture.',
+        extraData: JSON.stringify({ dreamCycle: false }),
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+      expect(response.body.data?.dreamId).to.eq(null)
+
+      sheetId = response.body.data?.id
+      expect(sheetId).to.be.a('number')
+    })
+  })
+
+  it('rejects unknown fields on standalone PitchSheet creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: sheetsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `UnknownFieldSheet-${stamp}`,
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported PitchSheet fields')
+    })
+  })
+
+  it('rejects an invalid artImageId and non-string extraData on PitchSheet creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: sheetsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `InvalidArtImageSheet-${stamp}`,
+        artImageId: 0,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('positive integer or null')
+    })
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: sheetsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `NonStringExtraDataSheet-${stamp}`,
+        extraData: { dreamCycle: true },
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('serialized JSON string')
+    })
+  })
+
+  it('rejects unknown fields on PitchSheet PATCH', () => {
+    expect(sheetId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${sheetsUrl}/${sheetId}`,
+      headers: ownerHeaders(),
+      body: { createdAt: new Date().toISOString(), bogusField: 'nope' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported PitchSheet fields')
+    })
+  })
+
+  it('tolerates round-tripped system fields on PitchSheet PATCH', () => {
+    expect(sheetId).to.exist
+    expect(ownerId).to.exist
+
+    // The broad SheetUpdatePayload can echo server-owned fields; they are
+    // validated and ignored rather than rejected, so the update still succeeds.
+    cy.request<ApiResponse<SheetRow>>({
+      method: 'PATCH',
+      url: `${sheetsUrl}/${sheetId}`,
+      headers: ownerHeaders(),
+      body: {
+        title: `BoundarySheet-${stamp}-updated`,
+        userId: ownerId,
+        id: sheetId,
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+      expect(response.body.data?.title).to.eq(`BoundarySheet-${stamp}-updated`)
+    })
+  })
+})

--- a/server/api/sheets/[id].patch.ts
+++ b/server/api/sheets/[id].patch.ts
@@ -3,7 +3,10 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
-import { sanitizePitchSheetPayload } from '@/server/utils/pitchSheets/payload'
+import {
+  assertPitchSheetMutationInput,
+  sanitizePitchSheetPayload,
+} from '@/server/utils/pitchSheets/payload'
 import { pitchSheetMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
@@ -53,6 +56,9 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = await readBody<Record<string, unknown>>(event).catch(() => ({}))
+
+    assertPitchSheetMutationInput(body || {}, 'PitchSheet patch payload')
+
     const data = sanitizePitchSheetPayload(body || {})
 
     if (Object.keys(data).length === 0) {

--- a/server/api/sheets/by-dream/[dreamId].post.ts
+++ b/server/api/sheets/by-dream/[dreamId].post.ts
@@ -4,7 +4,10 @@ import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import { buildPitchSheetFromDream } from '@/server/utils/pitchSheets/defaults'
-import { sanitizePitchSheetPayload } from '@/server/utils/pitchSheets/payload'
+import {
+  assertPitchSheetMutationInput,
+  sanitizePitchSheetPayload,
+} from '@/server/utils/pitchSheets/payload'
 import { pitchSheetMutationSelect } from '../selects'
 
 export default defineEventHandler(async (event) => {
@@ -56,6 +59,8 @@ export default defineEventHandler(async (event) => {
     const body = await readBody<Record<string, unknown>>(event).catch(
       () => ({} as Record<string, unknown>),
     )
+    assertPitchSheetMutationInput(body, 'PitchSheet by-dream payload')
+
     const overrides = sanitizePitchSheetPayload(body)
     const data = buildPitchSheetFromDream(dream, user.id, overrides)
     const created = await prisma.pitchSheet.create({

--- a/server/api/sheets/index.post.ts
+++ b/server/api/sheets/index.post.ts
@@ -3,7 +3,10 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
-import { sanitizePitchSheetPayload } from '@/server/utils/pitchSheets/payload'
+import {
+  assertPitchSheetMutationInput,
+  sanitizePitchSheetPayload,
+} from '@/server/utils/pitchSheets/payload'
 import { pitchSheetMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
@@ -20,6 +23,8 @@ export default defineEventHandler(async (event) => {
           'Dream-derived PitchSheets must be created through /api/sheets/by-dream/:dreamId.',
       })
     }
+
+    assertPitchSheetMutationInput(body, 'PitchSheet create payload')
 
     const overrides = sanitizePitchSheetPayload(body)
     const title = typeof overrides.title === 'string' ? overrides.title.trim() : ''

--- a/server/utils/pitchSheets/payload.ts
+++ b/server/utils/pitchSheets/payload.ts
@@ -1,5 +1,8 @@
 // /server/utils/pitchSheets/payload.ts
+import { createError } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const PITCHSHEET_EXTRA_DATA_LIMIT = 50_000
 
 const allowedKeys = [
   'layoutKey',
@@ -46,4 +49,97 @@ export function sanitizePitchSheetPayload(
     }
     return clean
   }, {})
+}
+
+const allowedKeySet = new Set<string>(allowedKeys)
+
+// The current SheetCreate/UpdatePayload is a broad Partial<PitchSheet>, so a
+// round-tripped row can carry these server-owned fields. They are validated and
+// ignored (never persisted — they are absent from allowedKeys) rather than
+// rejected, while genuinely unknown fields are rejected.
+const compatibilityKeys = [
+  'id',
+  'userId',
+  'createdAt',
+  'updatedAt',
+  'dreamId',
+  'projectId',
+] as const
+
+const compatibilityKeySet = new Set<string>(compatibilityKeys)
+
+const booleanKeys = ['isPublic', 'isActive', 'isMature'] as const
+
+// Rejects unknown/system fields (silent-strip → explicit reject) and validates the
+// two previously-unchecked pass-through fields: artImageId and the extraData blob.
+export function assertPitchSheetMutationInput(
+  body: unknown,
+  context: string,
+): asserts body is Record<string, unknown> {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({
+      statusCode: 400,
+      message: `${context} must be a JSON object.`,
+    })
+  }
+
+  const input = body as Record<string, unknown>
+
+  const unsupported = Object.keys(input).filter(
+    (key) => !allowedKeySet.has(key) && !compatibilityKeySet.has(key),
+  )
+
+  if (unsupported.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported PitchSheet fields in ${context}: ${unsupported.join(', ')}. IDs, timestamps, identity, and system fields are server-owned.`,
+    })
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(input, 'artImageId') &&
+    input.artImageId !== null &&
+    input.artImageId !== undefined
+  ) {
+    const parsed = Number(input.artImageId)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'PitchSheet field "artImageId" must be a positive integer or null.',
+      })
+    }
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(input, 'extraData') &&
+    input.extraData !== null &&
+    input.extraData !== undefined
+  ) {
+    if (typeof input.extraData !== 'string') {
+      throw createError({
+        statusCode: 400,
+        message: 'PitchSheet field "extraData" must be a serialized JSON string or null.',
+      })
+    }
+
+    if (input.extraData.length > PITCHSHEET_EXTRA_DATA_LIMIT) {
+      throw createError({
+        statusCode: 400,
+        message: `PitchSheet "extraData" may not exceed ${PITCHSHEET_EXTRA_DATA_LIMIT} characters.`,
+      })
+    }
+  }
+
+  for (const key of booleanKeys) {
+    if (
+      Object.prototype.hasOwnProperty.call(input, key) &&
+      input[key] !== undefined &&
+      typeof input[key] !== 'boolean'
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: `PitchSheet field "${key}" must be a boolean.`,
+      })
+    }
+  }
 }

--- a/utils/scripts/verifySheetMutationInputParity.ts
+++ b/utils/scripts/verifySheetMutationInputParity.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/utils/pitchSheets/payload.ts')
+const createRoute = read('server/api/sheets/index.post.ts')
+const patchRoute = read('server/api/sheets/[id].patch.ts')
+const byDreamRoute = read('server/api/sheets/by-dream/[dreamId].post.ts')
+const cypressSpec = read('cypress/e2e/api/sheet-input-boundary.cy.ts')
+
+// The payload helper now exports an explicit reject boundary + a size cap.
+requireText(
+  boundary,
+  'export const PITCHSHEET_EXTRA_DATA_LIMIT',
+  'PitchSheet extraData cap',
+)
+requireText(
+  boundary,
+  'export function assertPitchSheetMutationInput',
+  'PitchSheet mutation boundary',
+)
+requireText(
+  boundary,
+  'Unsupported PitchSheet fields in',
+  'PitchSheet unknown-field error',
+)
+requireText(
+  boundary,
+  'must be a positive integer or null',
+  'PitchSheet artImageId validation',
+)
+requireText(
+  boundary,
+  'must be a serialized JSON string or null',
+  'PitchSheet extraData validation',
+)
+
+// Every single-record mutation route runs the boundary before persisting.
+requireText(
+  createRoute,
+  'assertPitchSheetMutationInput(body',
+  'PitchSheet create route wiring',
+)
+requireText(
+  patchRoute,
+  'assertPitchSheetMutationInput(body',
+  'PitchSheet patch route wiring',
+)
+requireText(
+  byDreamRoute,
+  'assertPitchSheetMutationInput(body',
+  'PitchSheet by-dream route wiring',
+)
+
+// Deployed regression it() blocks are pinned to the contract.
+requireText(
+  cypressSpec,
+  'rejects unknown fields on standalone PitchSheet creation',
+  'PitchSheet create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects an invalid artImageId and non-string extraData on PitchSheet creation',
+  'PitchSheet field-validation deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown fields on PitchSheet PATCH',
+  'PitchSheet patch deployed regression',
+)
+
+console.log('PitchSheet mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Continues the API overhaul sweep (#570, Phase 1). The single-record PitchSheet routes routed every body through `sanitizePitchSheetPayload`, which **silently stripped** unknown fields, and passed `artImageId` and the `extraData` blob straight to Prisma with no validation.

- add `assertPitchSheetMutationInput` to `server/utils/pitchSheets/payload.ts`: rejects unknown/system fields (silent-strip → explicit `400`), validates `artImageId` as a positive integer or null, requires `extraData` to be a serialized JSON string, and caps it at `PITCHSHEET_EXTRA_DATA_LIMIT` (50k) on the uncapped `LongText` column; also type-checks the boolean flags.
- keep a validated-and-ignored compatibility set (`id`, `userId`, `createdAt`, `updatedAt`, `dreamId`, `projectId`) so the current broad `Partial<PitchSheet>` store payload — which can echo server-owned fields from a round-tripped row — is tolerated (never persisted), while genuinely unknown fields are rejected.
- wire the boundary into the create, PATCH, and by-dream routes before `sanitize`.
- leave the admin/server-gated batch route unchanged: it uses its own bounded `getBatchBody` normalizer, not the silent-strip path.
- add a DB-free parity contract, a deployed input-boundary cypress spec, and a read-only workflow.

## Why

Ownership was already authentication-derived and responses were already lean (`pitchSheetMutationSelect`), but a client could send arbitrary payload fields (silently dropped), an `artImageId` of any shape, or an `extraData` object that would fail only as a raw Prisma error against the `String` column. This makes the boundary explicit and validates the two previously-unchecked pass-through fields.

## Checks

- Sheet Mutation Input Parity (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_