### PR TITLE
Enforce Project mutation input parity

### DIFF
--- a/.github/workflows/project-mutation-input-parity.yml
+++ b/.github/workflows/project-mutation-input-parity.yml
@@ -1,0 +1,38 @@
+name: Project Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/projects/index.ts'
+      - 'server/api/projects/index.post.ts'
+      - 'server/api/projects/[id].patch.ts'
+      - 'cypress/e2e/api/project-input-boundary.cy.ts'
+      - 'utils/scripts/verifyProjectMutationInputParity.ts'
+      - '.github/workflows/project-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Project mutation input parity
+        run: npx tsx utils/scripts/verifyProjectMutationInputParity.ts

--- a/cypress/e2e/api/project-input-boundary.cy.ts
+++ b/cypress/e2e/api/project-input-boundary.cy.ts
@@ -1,0 +1,143 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type ProjectRow = {
+  id: number
+  userId: number | null
+  title: string
+  slug: string | null
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Project mutation input boundary', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let projectsUrl = ''
+  let ownerToken = ''
+  let ownerId: number | undefined
+  let projectId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        projectsUrl = `${apiBase}/projects`
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+      })
+  })
+
+  after(() => {
+    if (projectId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${projectsUrl}/${projectId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      }).then(() => {
+        projectId = undefined
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+  })
+
+  it('creates a Project under the authenticated owner', () => {
+    expect(ownerId).to.exist
+
+    cy.request<ApiResponse<ProjectRow>>({
+      method: 'POST',
+      url: projectsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `BoundaryProject-${stamp}`,
+        slug: `boundary-project-${stamp}`,
+        description: 'A project fixture for the input boundary.',
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+
+      projectId = response.body.data?.id
+      expect(projectId).to.be.a('number')
+    })
+  })
+
+  it('rejects unknown fields on Project creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: projectsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `UnknownFieldProject-${stamp}`,
+        slug: `unknown-field-project-${stamp}`,
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Project fields')
+    })
+  })
+
+  it('rejects unknown fields on Project PATCH', () => {
+    expect(projectId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${projectsUrl}/${projectId}`,
+      headers: ownerHeaders(),
+      body: { bogusField: 'nope' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Project fields')
+    })
+  })
+
+  it('tolerates round-tripped system fields on Project PATCH', () => {
+    expect(projectId).to.exist
+    expect(ownerId).to.exist
+
+    // A round-tripped Partial<Project> can echo server-owned columns; they are
+    // tolerated and never trusted, so the update still succeeds and ownership
+    // is unchanged.
+    cy.request<ApiResponse<ProjectRow>>({
+      method: 'PATCH',
+      url: `${projectsUrl}/${projectId}`,
+      headers: ownerHeaders(),
+      body: {
+        goal: 'Ship the boundary.',
+        id: projectId,
+        userId: ownerId,
+        createdAt: new Date().toISOString(),
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+    })
+  })
+})

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -9,6 +9,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { enforceProjectCap } from '~/server/utils/projectCap'
+import { assertJsonObject, assertOnlyFields } from '~/server/utils/chatApi'
 import {
   assertProjectAccess,
   getProjectId,
@@ -16,6 +17,7 @@ import {
   normalizeNullableId,
   normalizeOptionalText,
   normalizeSlug,
+  projectMutationFields,
   projectPriorities,
   projectStatuses,
 } from './index'
@@ -45,6 +47,10 @@ export default defineEventHandler(async (event) => {
 
     assertProjectAccess(existing, auth.user)
     const body = await readBody<ProjectPatchBody>(event)
+
+    assertJsonObject(body, 'Project patch payload must be a JSON object.')
+    assertOnlyFields(body, projectMutationFields, 'Project')
+
     const data: Prisma.ProjectUncheckedUpdateInput = {}
     const nextStatus = projectStatuses.has(body.status as ProjectStatus)
       ? (body.status as ProjectStatus)

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -10,11 +10,13 @@ import { upsertProjectDirect } from '~/server/utils/projectDirectWrite'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { enforceProjectCap } from '~/server/utils/projectCap'
+import { assertJsonObject, assertOnlyFields } from '~/server/utils/chatApi'
 import {
   normalizeNullableDateTime,
   normalizeNullableId,
   normalizeOptionalText,
   normalizeSlug,
+  projectMutationFields,
   projectPriorities,
   projectStatuses,
 } from './index'
@@ -74,6 +76,10 @@ export default defineEventHandler(async (event) => {
   try {
     const auth = await requireApiUser(event)
     const body = await readBody<ProjectCreateBody>(event)
+
+    assertJsonObject(body, 'Project create payload must be a JSON object.')
+    assertOnlyFields(body, projectMutationFields, 'Project')
+
     const title = normalizeOptionalText(body?.title)
 
     if (!title) {

--- a/server/api/projects/index.ts
+++ b/server/api/projects/index.ts
@@ -21,6 +21,58 @@ export const projectPriorities = new Set<ProjectPriority>([
   'HIGH',
 ])
 
+// Explicit mutation allowlist: every Project column the routes may read, plus the
+// relation keys a round-tripped row (from the store's broad Partial<Project>) can
+// carry. Identity/system columns (id, userId, timestamps) are tolerated here but
+// never trusted — the routes set userId from authentication and ignore the rest.
+// Anything outside this set is rejected instead of silently dropped.
+export const projectMutationFields = new Set<string>([
+  'id',
+  'createdAt',
+  'updatedAt',
+  'title',
+  'slug',
+  'description',
+  'pitch',
+  'flavorText',
+  'goal',
+  'status',
+  'priority',
+  'conductorSlug',
+  'repoUrl',
+  'liveUrl',
+  'channelKey',
+  'tabKey',
+  'lastSyncedAt',
+  'allowReviews',
+  'highlightImage',
+  'icon',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+  'designer',
+  'creationSource',
+  'userId',
+  'managerBotId',
+  'artImageId',
+  'artCollectionId',
+  'isPublic',
+  'isMature',
+  'isActive',
+  // relation keys tolerated when a full row is round-tripped by the client
+  'ArtJobs',
+  'Chats',
+  'PitchSheet',
+  'ArtCollection',
+  'ArtImage',
+  'Manager',
+  'User',
+  'ArtCollectionLinks',
+  'ArtImageLinks',
+  'Reactions',
+  'Todos',
+])
+
 export const projectInclude = {
   Manager: {
     select: {

--- a/utils/scripts/verifyProjectMutationInputParity.ts
+++ b/utils/scripts/verifyProjectMutationInputParity.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+const index = read('server/api/projects/index.ts')
+const createRoute = read('server/api/projects/index.post.ts')
+const patchRoute = read('server/api/projects/[id].patch.ts')
+const cypressSpec = read('cypress/e2e/api/project-input-boundary.cy.ts')
+
+// The shared allowlist is exported and used by both mutation routes.
+requireText(
+  index,
+  'export const projectMutationFields',
+  'Project mutation allowlist',
+)
+
+requireText(
+  createRoute,
+  'assertOnlyFields(body, projectMutationFields',
+  'Project create route wiring',
+)
+requireText(
+  patchRoute,
+  'assertOnlyFields(body, projectMutationFields',
+  'Project patch route wiring',
+)
+
+// Deployed regression it() blocks are pinned to the contract.
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Project creation',
+  'Project create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Project PATCH',
+  'Project patch deployed regression',
+)
+requireText(
+  cypressSpec,
+  'tolerates round-tripped system fields on Project PATCH',
+  'Project compatibility deployed regression',
+)
+
+console.log('Project mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Continues the API overhaul sweep (#570, Phase 1). The Project create and PATCH routes read a fixed set of fields and **silently ignored** everything else. Ownership was already authentication-derived, so this adds the missing explicit field boundary.

- add a shared `projectMutationFields` allowlist covering every Project column plus the relation keys a round-tripped `Partial<Project>` row can carry.
- reject any field outside the allowlist with `assertOnlyFields` (the shared `server/utils/chatApi` helper, already used by Chats) on both create and patch, instead of silently dropping it.
- identity/system columns (`id`, `userId`, timestamps) stay tolerated-but-untrusted so the external conductor project-sync and round-tripped store payloads keep working — the routes continue to set `userId` from authentication on create and never read it from the body on patch.
- add a DB-free parity contract, a deployed input-boundary cypress spec, and a read-only workflow.

## Why

Ownership was safe, but a client could send arbitrary payload keys and the API would silently drop them, obscuring the real contract. A deliberately generous allowlist (all real columns) keeps the conductor sync and existing store callers working while rejecting genuinely unknown/typo/injected fields.

## Checks

- Project Mutation Input Parity (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_