### PR TITLE
Enforce Todo mutation input parity

### DIFF
--- a/.github/workflows/todo-mutation-input-parity.yml
+++ b/.github/workflows/todo-mutation-input-parity.yml
@@ -1,0 +1,38 @@
+name: Todo Mutation Input Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/todos/mutation.ts'
+      - 'server/api/todos/index.post.ts'
+      - 'server/api/todos/[id].patch.ts'
+      - 'cypress/e2e/api/todo-input-boundary.cy.ts'
+      - 'utils/scripts/verifyTodoMutationInputParity.ts'
+      - '.github/workflows/todo-mutation-input-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify Todo mutation input parity
+        run: npx tsx utils/scripts/verifyTodoMutationInputParity.ts

--- a/cypress/e2e/api/todo-input-boundary.cy.ts
+++ b/cypress/e2e/api/todo-input-boundary.cy.ts
@@ -1,0 +1,142 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type TodoRow = {
+  id: number
+  userId: number | null
+  title: string
+  status: string
+}
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Todo mutation input boundary', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let todosUrl = ''
+  let ownerToken = ''
+  let ownerId: number | undefined
+  let todoId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        todosUrl = `${apiBase}/todos`
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+      })
+  })
+
+  after(() => {
+    if (todoId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${todosUrl}/${todoId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      }).then(() => {
+        todoId = undefined
+      })
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+  })
+
+  it('creates a Todo under the authenticated owner', () => {
+    expect(ownerId).to.exist
+
+    cy.request<ApiResponse<TodoRow>>({
+      method: 'POST',
+      url: todosUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `BoundaryTodo-${stamp}`,
+        priority: 'HIGH',
+        category: 'AGENT',
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(ownerId)
+
+      todoId = response.body.data?.id
+      expect(todoId).to.be.a('number')
+    })
+  })
+
+  it('rejects unknown fields on Todo creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: todosUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `UnknownFieldTodo-${stamp}`,
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Todo fields')
+    })
+  })
+
+  it('rejects unknown fields on Todo PATCH', () => {
+    expect(todoId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'PATCH',
+      url: `${todosUrl}/${todoId}`,
+      headers: ownerHeaders(),
+      body: { bogusField: 'nope' },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.message).to.include('Unsupported Todo fields')
+    })
+  })
+
+  it('tolerates round-tripped system fields on Todo PATCH', () => {
+    expect(todoId).to.exist
+    expect(ownerId).to.exist
+
+    // Identity/system columns are tolerated and ignored; the write stays scoped to
+    // the authenticated owner and still succeeds.
+    cy.request<ApiResponse<TodoRow>>({
+      method: 'PATCH',
+      url: `${todosUrl}/${todoId}`,
+      headers: ownerHeaders(),
+      body: {
+        status: 'DONE',
+        id: todoId,
+        userId: ownerId,
+        createdAt: new Date().toISOString(),
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.status).to.eq('DONE')
+      expect(response.body.data?.userId).to.eq(ownerId)
+    })
+  })
+})

--- a/server/api/todos/[id].patch.ts
+++ b/server/api/todos/[id].patch.ts
@@ -3,6 +3,8 @@ import { defineEventHandler, readBody, createError, getRouterParam, H3Error } fr
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
+import { assertOnlyFields } from '@/server/utils/chatApi'
+import { todoMutationFields } from './mutation'
 import type { Todo } from '@/stores/todoStore'
 
 type TodoPatchBody = {
@@ -36,9 +38,11 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = await readBody<TodoPatchBody>(event)
-    if (!body || !Object.keys(body).length) {
+    if (!body || typeof body !== 'object' || Array.isArray(body) || !Object.keys(body).length) {
       throw createError({ statusCode: 400, message: 'No fields to update' })
     }
+
+    assertOnlyFields(body as Record<string, unknown>, todoMutationFields, 'Todo')
 
     const title = body.title !== undefined ? (body.title.trim() || current.title) : current.title
     const description = 'description' in body ? (body.description ?? null) : current.description

--- a/server/api/todos/index.post.ts
+++ b/server/api/todos/index.post.ts
@@ -3,6 +3,8 @@ import { createError, defineEventHandler, H3Error, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
+import { assertOnlyFields } from '@/server/utils/chatApi'
+import { todoMutationFields } from './mutation'
 
 const todoPriorities = ['LOW', 'NORMAL', 'HIGH'] as const
 const todoCategories = [
@@ -63,6 +65,16 @@ export default defineEventHandler(async (event) => {
     const auth = await requireApiUser(event)
     const userId = auth.user.id
     const body = await readBody<TodoCreateBody>(event)
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Todo create payload must be a JSON object.',
+      })
+    }
+
+    assertOnlyFields(body as Record<string, unknown>, todoMutationFields, 'Todo')
+
     const title = body?.title?.trim()
 
     if (!title) {

--- a/server/api/todos/mutation.ts
+++ b/server/api/todos/mutation.ts
@@ -1,0 +1,27 @@
+// /server/api/todos/mutation.ts
+
+// Explicit mutation allowlist for Todo create/patch. Covers every field the routes
+// accept (create sets status server-side; patch also accepts status), plus the
+// identity/system columns and relation keys a round-tripped row could carry. Those
+// are tolerated but never trusted — the routes set userId from authentication and
+// scope every write by it. Anything outside this set is rejected, not dropped.
+export const todoMutationFields = new Set<string>([
+  'title',
+  'description',
+  'status',
+  'priority',
+  'category',
+  'dueDate',
+  'icon',
+  'imagePath',
+  'order',
+  'dreamId',
+  'projectId',
+  // tolerated-but-untrusted identity/system columns and relations
+  'id',
+  'userId',
+  'createdAt',
+  'updatedAt',
+  'Dream',
+  'Project',
+])

--- a/utils/scripts/verifyTodoMutationInputParity.ts
+++ b/utils/scripts/verifyTodoMutationInputParity.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+const boundary = read('server/api/todos/mutation.ts')
+const createRoute = read('server/api/todos/index.post.ts')
+const patchRoute = read('server/api/todos/[id].patch.ts')
+const cypressSpec = read('cypress/e2e/api/todo-input-boundary.cy.ts')
+
+requireText(boundary, 'export const todoMutationFields', 'Todo mutation allowlist')
+
+requireText(
+  createRoute,
+  'assertOnlyFields(body as Record<string, unknown>, todoMutationFields',
+  'Todo create route wiring',
+)
+requireText(
+  patchRoute,
+  'assertOnlyFields(body as Record<string, unknown>, todoMutationFields',
+  'Todo patch route wiring',
+)
+
+// Deployed regression it() blocks are pinned to the contract.
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Todo creation',
+  'Todo create deployed regression',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Todo PATCH',
+  'Todo patch deployed regression',
+)
+
+console.log('Todo mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Completes the Phase-1 sweep (#570). The Todo create and PATCH routes read a fixed set of fields and **silently ignored** everything else. Ownership was already strong — `userId` is set from authentication on create, and every raw-SQL write in PATCH is scoped by `AND userId = ${userId}` — so this just adds the missing explicit field boundary.

- add a shared `todoMutationFields` allowlist covering every accepted field plus the identity/system columns and relation keys a round-tripped row could carry.
- reject any field outside the allowlist with `assertOnlyFields` (the shared `chatApi` helper) on both create and patch, instead of silently dropping it.
- identity/system columns stay tolerated-but-untrusted; the routes keep deriving ownership from authentication and scoping every write by it.
- add a DB-free parity contract, a deployed input-boundary cypress spec, and a read-only workflow.

## Why

The store already uses precise `TodoCreate`/`TodoUpdate` types, but the API accepted arbitrary keys and silently dropped them. This makes the contract explicit without changing the (already safe) ownership handling or the raw-SQL column set.

## Checks

- Todo Mutation Input Parity (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_