### PR TITLE
Gate Dream relation connects by permission on create

### DIFF
--- a/.github/workflows/dream-mutation-input-parity.yml
+++ b/.github/workflows/dream-mutation-input-parity.yml
@@ -9,6 +9,7 @@ on:
       - 'server/api/dreams/[id].patch.ts'
       - 'server/api/dreams/batch.post.ts'
       - 'cypress/e2e/api/dream-input-boundary.cy.ts'
+      - 'cypress/e2e/api/dream-relation-permission.cy.ts'
       - 'utils/scripts/verifyDreamMutationInputParity.ts'
       - '.github/workflows/dream-mutation-input-parity.yml'
   workflow_dispatch:

--- a/cypress/e2e/api/dream-relation-permission.cy.ts
+++ b/cypress/e2e/api/dream-relation-permission.cy.ts
@@ -1,0 +1,146 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type IdRow = { id: number; isPublic?: boolean }
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Dream relation permission gate', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let dreamsUrl = ''
+  let charactersUrl = ''
+  let ownerToken = ''
+  let otherToken = ''
+  let ownerId: number | undefined
+  let otherId: number | undefined
+  let privateCharacterId: number | undefined
+  let publicCharacterId: number | undefined
+  let dreamId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+  const otherHeaders = () => bearerHeaders(otherToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        dreamsUrl = `${apiBase}/dreams`
+        charactersUrl = `${apiBase}/characters`
+        return createLoggedInTestUser()
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherToken = other.token
+        otherId = other.id
+
+        // The other user owns one private and one public Character.
+        return cy
+          .request<ApiResponse<IdRow>>({
+            method: 'POST',
+            url: charactersUrl,
+            headers: otherHeaders(),
+            body: { name: `PrivateChar-${stamp}`, isPublic: false },
+          })
+          .then((res) => {
+            expect(res.status, JSON.stringify(res.body)).to.eq(201)
+            privateCharacterId = res.body.data?.id
+            expect(privateCharacterId).to.be.a('number')
+
+            return cy.request<ApiResponse<IdRow>>({
+              method: 'POST',
+              url: charactersUrl,
+              headers: otherHeaders(),
+              body: { name: `PublicChar-${stamp}`, isPublic: true },
+            })
+          })
+          .then((res) => {
+            expect(res.status, JSON.stringify(res.body)).to.eq(201)
+            publicCharacterId = res.body.data?.id
+            expect(publicCharacterId).to.be.a('number')
+          })
+      })
+  })
+
+  after(() => {
+    if (dreamId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${dreamsUrl}/${dreamId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      })
+    }
+
+    for (const id of [privateCharacterId, publicCharacterId]) {
+      if (id && otherToken) {
+        cy.request({
+          method: 'DELETE',
+          url: `${charactersUrl}/${id}`,
+          headers: otherHeaders(),
+          failOnStatusCode: false,
+        })
+      }
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
+  })
+
+  it('forbids attaching another user private Character on Dream creation', () => {
+    expect(privateCharacterId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: dreamsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `PrivateRelationDream-${stamp}`,
+        characterIds: [privateCharacterId],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('permission to attach')
+    })
+  })
+
+  it('allows attaching a public Character on Dream creation', () => {
+    expect(publicCharacterId).to.exist
+
+    cy.request<ApiResponse<IdRow>>({
+      method: 'POST',
+      url: dreamsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `PublicRelationDream-${stamp}`,
+        characterIds: [publicCharacterId],
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+
+      dreamId = response.body.data?.id
+      expect(dreamId).to.be.a('number')
+    })
+  })
+})

--- a/server/api/dreams/[id].patch.ts
+++ b/server/api/dreams/[id].patch.ts
@@ -14,128 +14,12 @@ import {
 } from './index'
 import {
   assertDreamMutationInput,
+  assertDreamRelationsAttachable,
   boundedScenariosRelationFromPatch,
   dreamPatchFields,
   normalizeBoundedDreamIdArray,
-  normalizeBoundedDreamNullableId,
-  type DreamMutationBody,
 } from './mutation'
 import { dreamMutationSelect } from './selects'
-
-type DreamPatchBody = DreamMutationBody
-
-function uniqueIds(values: Array<number | null | undefined>): number[] {
-  return Array.from(
-    new Set(
-      values.filter(
-        (id): id is number =>
-          typeof id === 'number' && Number.isInteger(id) && id > 0,
-      ),
-    ),
-  )
-}
-
-function idsFromNullable(value: unknown, field: string): number[] {
-  const id = normalizeBoundedDreamNullableId(value, field)
-  return typeof id === 'number' ? [id] : []
-}
-
-function forbiddenRelationError(label: string) {
-  return createError({
-    statusCode: 403,
-    message: `You do not have permission to attach one or more ${label} records to this Dream.`,
-  })
-}
-
-async function assertAttachableRelations(
-  body: DreamPatchBody,
-  userId: number,
-  userRole: string,
-) {
-  if (userRole === 'ADMIN') return
-
-  const artImageIds = uniqueIds([
-    ...idsFromNullable(body.artImageId, 'artImageId'),
-    ...(normalizeBoundedDreamIdArray(body.artImageIds, 'artImageIds') ?? []),
-  ])
-
-  if (artImageIds.length) {
-    const count = await prisma.artImage.count({
-      where: {
-        id: { in: artImageIds },
-        OR: [{ userId }, { isPublic: true }],
-      },
-    })
-
-    if (count !== artImageIds.length) throw forbiddenRelationError('ArtImage')
-  }
-
-  const artCollectionIds = uniqueIds([
-    ...idsFromNullable(body.artCollectionId, 'artCollectionId'),
-    ...(normalizeBoundedDreamIdArray(
-      body.artCollectionIds,
-      'artCollectionIds',
-    ) ?? []),
-  ])
-
-  if (artCollectionIds.length) {
-    const count = await prisma.artCollection.count({
-      where: {
-        id: { in: artCollectionIds },
-        OR: [{ userId }, { isPublic: true }],
-      },
-    })
-
-    if (count !== artCollectionIds.length) {
-      throw forbiddenRelationError('ArtCollection')
-    }
-  }
-
-  const scenarioIds = uniqueIds([
-    ...idsFromNullable(body.scenarioId, 'scenarioId'),
-    ...(normalizeBoundedDreamIdArray(body.scenarioIds, 'scenarioIds') ?? []),
-    ...(normalizeBoundedDreamIdArray(body.Scenarios, 'Scenarios') ?? []),
-  ])
-
-  if (scenarioIds.length) {
-    const count = await prisma.scenario.count({
-      where: {
-        id: { in: scenarioIds },
-        OR: [{ userId }, { isPublic: true }],
-      },
-    })
-
-    if (count !== scenarioIds.length) throw forbiddenRelationError('Scenario')
-  }
-
-  const characterIds =
-    normalizeBoundedDreamIdArray(body.characterIds, 'characterIds') ?? []
-
-  if (characterIds.length) {
-    const count = await prisma.character.count({
-      where: {
-        id: { in: characterIds },
-        OR: [{ userId }, { isPublic: true }],
-      },
-    })
-
-    if (count !== characterIds.length) throw forbiddenRelationError('Character')
-  }
-
-  const rewardIds =
-    normalizeBoundedDreamIdArray(body.rewardIds, 'rewardIds') ?? []
-
-  if (rewardIds.length) {
-    const count = await prisma.reward.count({
-      where: {
-        id: { in: rewardIds },
-        OR: [{ userId }, { isPublic: true }],
-      },
-    })
-
-    if (count !== rewardIds.length) throw forbiddenRelationError('Reward')
-  }
-}
 
 function setTextField<T extends keyof Prisma.DreamUpdateInput>(
   dataInput: Prisma.DreamUpdateInput,
@@ -190,7 +74,7 @@ export default defineEventHandler(async (event) => {
     })
 
     const body = rawBody
-    await assertAttachableRelations(body, user.id, user.Role)
+    await assertDreamRelationsAttachable(body, user.id, user.Role)
 
     const dataInput: Prisma.DreamUpdateInput = {}
 

--- a/server/api/dreams/index.post.ts
+++ b/server/api/dreams/index.post.ts
@@ -12,6 +12,7 @@ import {
 } from './index'
 import {
   assertDreamMutationInput,
+  assertDreamRelationsAttachable,
   dreamCreateFields,
   normalizeBoundedDreamIdArray,
   normalizeBoundedDreamNullableId,
@@ -39,6 +40,10 @@ export default defineEventHandler(async (event) => {
         message: 'The "title" field is required.',
       })
     }
+
+    // Same permission gate as Dream PATCH: a non-admin may only connect public or
+    // self-owned relation targets. Previously create performed no check at all.
+    await assertDreamRelationsAttachable(body, user.id, user.Role)
 
     const sender = user.username || `User ${user.id}`
     const slug = body.slug?.trim()

--- a/server/api/dreams/mutation.ts
+++ b/server/api/dreams/mutation.ts
@@ -4,6 +4,7 @@ import type {
   DreamType,
   Prisma,
 } from '~/prisma/generated/prisma/client'
+import prisma from '../../utils/prisma'
 import { creationSources, dreamTypes } from './index'
 
 export const DREAM_RELATION_ID_LIMIT = 100
@@ -364,5 +365,124 @@ export function assertDreamMutationInput(
     if (input[field] !== undefined) {
       normalizeBoundedDreamIdArray(input[field], field)
     }
+  }
+}
+
+function uniqueIds(values: Array<number | null | undefined>): number[] {
+  return Array.from(
+    new Set(
+      values.filter(
+        (id): id is number =>
+          typeof id === 'number' && Number.isInteger(id) && id > 0,
+      ),
+    ),
+  )
+}
+
+function idsFromNullable(value: unknown, field: string): number[] {
+  const id = normalizeBoundedDreamNullableId(value, field)
+  return typeof id === 'number' ? [id] : []
+}
+
+function forbiddenRelationError(label: string) {
+  return createError({
+    statusCode: 403,
+    message: `You do not have permission to attach one or more ${label} records to this Dream.`,
+  })
+}
+
+// Verifies the caller may connect every relation target referenced by a Dream
+// mutation: each must be public or owned by the caller (admins bypass). Shared by
+// Dream create and PATCH so both paths gate connects identically — a non-admin can
+// no longer attach another user's private ArtImage/ArtCollection/Scenario/
+// Character/Reward to a Dream. A missing ID also fails the count (403), replacing
+// the create path's previous reliance on a raw Prisma foreign-key error.
+export async function assertDreamRelationsAttachable(
+  body: DreamMutationBody,
+  userId: number,
+  userRole: string,
+): Promise<void> {
+  if (userRole === 'ADMIN') return
+
+  const artImageIds = uniqueIds([
+    ...idsFromNullable(body.artImageId, 'artImageId'),
+    ...(normalizeBoundedDreamIdArray(body.artImageIds, 'artImageIds') ?? []),
+  ])
+
+  if (artImageIds.length) {
+    const count = await prisma.artImage.count({
+      where: {
+        id: { in: artImageIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== artImageIds.length) throw forbiddenRelationError('ArtImage')
+  }
+
+  const artCollectionIds = uniqueIds([
+    ...idsFromNullable(body.artCollectionId, 'artCollectionId'),
+    ...(normalizeBoundedDreamIdArray(
+      body.artCollectionIds,
+      'artCollectionIds',
+    ) ?? []),
+  ])
+
+  if (artCollectionIds.length) {
+    const count = await prisma.artCollection.count({
+      where: {
+        id: { in: artCollectionIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== artCollectionIds.length) {
+      throw forbiddenRelationError('ArtCollection')
+    }
+  }
+
+  const scenarioIds = uniqueIds([
+    ...idsFromNullable(body.scenarioId, 'scenarioId'),
+    ...(normalizeBoundedDreamIdArray(body.scenarioIds, 'scenarioIds') ?? []),
+    ...(normalizeBoundedDreamIdArray(body.Scenarios, 'Scenarios') ?? []),
+  ])
+
+  if (scenarioIds.length) {
+    const count = await prisma.scenario.count({
+      where: {
+        id: { in: scenarioIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== scenarioIds.length) throw forbiddenRelationError('Scenario')
+  }
+
+  const characterIds =
+    normalizeBoundedDreamIdArray(body.characterIds, 'characterIds') ?? []
+
+  if (characterIds.length) {
+    const count = await prisma.character.count({
+      where: {
+        id: { in: characterIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== characterIds.length) throw forbiddenRelationError('Character')
+  }
+
+  const rewardIds =
+    normalizeBoundedDreamIdArray(body.rewardIds, 'rewardIds') ?? []
+
+  if (rewardIds.length) {
+    const count = await prisma.reward.count({
+      where: {
+        id: { in: rewardIds },
+        OR: [{ userId }, { isPublic: true }],
+      },
+    })
+
+    if (count !== rewardIds.length) throw forbiddenRelationError('Reward')
   }
 }

--- a/utils/scripts/verifyDreamMutationInputParity.ts
+++ b/utils/scripts/verifyDreamMutationInputParity.ts
@@ -25,6 +25,7 @@ const createRoute = read('server/api/dreams/index.post.ts')
 const patchRoute = read('server/api/dreams/[id].patch.ts')
 const batchRoute = read('server/api/dreams/batch.post.ts')
 const cypressSpec = read('cypress/e2e/api/dream-input-boundary.cy.ts')
+const permissionSpec = read('cypress/e2e/api/dream-relation-permission.cy.ts')
 
 requireText(
   boundary,
@@ -127,6 +128,45 @@ requireText(
   cypressSpec,
   'keeps the current matching-owner store compatibility fields explicit',
   'Dream compatibility deployed regression',
+)
+
+// Phase 2: relation-connect targets must be public or owned by the caller (admins
+// bypass). The gate is shared by create and PATCH.
+requireText(
+  boundary,
+  'export async function assertDreamRelationsAttachable',
+  'Dream relation permission gate',
+)
+requireText(
+  boundary,
+  'OR: [{ userId }, { isPublic: true }]',
+  'Dream relation permission clause',
+)
+requireText(
+  createRoute,
+  'assertDreamRelationsAttachable(body, user.id, user.Role)',
+  'Dream create relation permission wiring',
+)
+requireText(
+  patchRoute,
+  'assertDreamRelationsAttachable(body, user.id, user.Role)',
+  'Dream patch relation permission wiring',
+)
+// The permission helper is now shared, not duplicated in the patch route.
+forbidText(
+  patchRoute,
+  'async function assertAttachableRelations',
+  'Dream patch duplicate permission helper',
+)
+requireText(
+  permissionSpec,
+  'forbids attaching another user private Character on Dream creation',
+  'Dream create permission deployed regression',
+)
+requireText(
+  permissionSpec,
+  'allows attaching a public Character on Dream creation',
+  'Dream create public-attach deployed regression',
 )
 
 console.log('Dream mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Starts Phase 2 (relationship safety) of the API overhaul (#570). Dream **PATCH** already refused to attach another user's private `ArtImage`/`ArtCollection`/`Scenario`/`Character`/`Reward` via a permission-aware helper — but Dream **create** performed *no* relation check at all: it built `connect` clauses directly and relied on a raw Prisma foreign-key error. So a caller could attach another user's private records to a brand-new Dream.

- extract the PATCH helper into `server/api/dreams/mutation.ts` as the shared, exported `assertDreamRelationsAttachable(body, userId, userRole)`. A non-admin may only connect targets that are **public or self-owned** (`OR: [{ userId }, { isPublic: true }]`); a missing target now fails the count as a `403` instead of surfacing a Prisma FK error.
- apply it to Dream create after input validation, closing the gap.
- keep Dream PATCH behavior identical by importing the shared helper instead of the former local copy (removes the duplicate).
- extend the Dream parity contract to assert both routes share the gate, and add a deployed cypress spec proving a private, other-owned Character is refused (`403`) while a public one is accepted (`201`).

## Why

Create and PATCH had asymmetric relation safety — the newer, stricter PATCH gate never covered the create path. This makes the two identical and reuses semantics already running in production on PATCH, so the behavior change is limited to the previously-unguarded create path.

## Checks

- Dream Mutation Input Parity (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_