### PR TITLE
Balance WonderLab review assignments across the full personality portfolio

### DIFF
--- a/.github/workflows/wonderlab-editorial-audit.yml
+++ b/.github/workflows/wonderlab-editorial-audit.yml
@@ -6,12 +6,24 @@ on:
     paths:
       - '.github/workflows/wonderlab-editorial-audit.yml'
       - 'scripts/wonderlab-production-editorial-audit.mjs'
+      - 'server/api/admin/wonderlab/review-portfolio.get.ts'
+      - 'server/utils/wonderLabReviewPortfolio.ts'
+      - 'utils/scripts/verifyWonderLabReviewerPortfolio.ts'
+      - 'utils/wonderlab/reviewerPortfolio.ts'
   push:
     branches: [main]
     paths:
       - '.github/workflows/wonderlab-editorial-audit.yml'
       - 'scripts/wonderlab-production-editorial-audit.mjs'
+      - 'server/api/admin/wonderlab/review-portfolio.get.ts'
+      - 'server/utils/wonderLabReviewPortfolio.ts'
+      - 'utils/wonderlab/reviewerPortfolio.ts'
   workflow_dispatch:
+    inputs:
+      max_wait_seconds:
+        description: 'Max seconds to wait for the portfolio endpoint to reach production'
+        required: false
+        default: '1200'
 
 permissions:
   contents: read
@@ -23,62 +35,8 @@ concurrency:
 
 jobs:
   validate:
-    name: Validate editorial audit boundary
+    name: Validate editorial portfolio and audit boundary
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Check read-only audit contract
-        run: |
-          set -euo pipefail
-          node --check scripts/wonderlab-production-editorial-audit.mjs
-          node <<'NODE'
-          const fs = require('node:fs')
-          const assert = require('node:assert').strict
-          const source = fs.readFileSync(
-            'scripts/wonderlab-production-editorial-audit.mjs',
-            'utf8',
-          )
-
-          for (const required of [
-            '/api/version',
-            '/api/components',
-            '/api/admin/wonderlab/review-rollout',
-            '/api/admin/wonderlab/review-plan',
-            'reviewersPerComponent',
-            'priorityMissingAssignments',
-            'editorial-coverage-audit.json',
-          ]) {
-            assert.ok(source.includes(required), `missing editorial audit boundary: ${required}`)
-          }
-
-          for (const forbidden of [
-            '/review-drafts/generate',
-            '/publish',
-            '/approve',
-            '/reject',
-            "method: 'POST'",
-            'DATABASE_URL',
-            'prisma.',
-          ]) {
-            assert.ok(!source.includes(forbidden), `editorial audit crossed write boundary: ${forbidden}`)
-          }
-
-          console.log('WonderLab editorial coverage audit boundary passed.')
-          NODE
-
-  audit:
-    name: Audit production editorial coverage
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -90,6 +48,118 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify deterministic reviewer portfolio
+        run: npx tsx utils/scripts/verifyWonderLabReviewerPortfolio.ts
+
+      - name: Check read-only audit contract
+        run: |
+          set -euo pipefail
+          node --check scripts/wonderlab-production-editorial-audit.mjs
+          node <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert').strict
+          const audit = fs.readFileSync(
+            'scripts/wonderlab-production-editorial-audit.mjs',
+            'utf8',
+          )
+          const endpoint = fs.readFileSync(
+            'server/api/admin/wonderlab/review-portfolio.get.ts',
+            'utf8',
+          )
+          const portfolio = fs.readFileSync(
+            'server/utils/wonderLabReviewPortfolio.ts',
+            'utf8',
+          )
+
+          for (const required of [
+            '/api/version',
+            '/api/components',
+            '/api/admin/wonderlab/review-rollout',
+            '/api/admin/wonderlab/review-portfolio',
+            'PORTFOLIO_DIVERSE',
+            'diversityPenalty',
+            'priorityMissingAssignments',
+            'editorial-coverage-audit.json',
+          ]) {
+            assert.ok(audit.includes(required), `missing editorial audit boundary: ${required}`)
+          }
+
+          for (const forbidden of [
+            '/review-drafts/generate',
+            '/publish',
+            '/approve',
+            '/reject',
+            "method: 'POST'",
+            'DATABASE_URL',
+            'prisma.',
+          ]) {
+            assert.ok(!audit.includes(forbidden), `editorial audit crossed write boundary: ${forbidden}`)
+          }
+
+          assert.match(endpoint, /requireAdminApiUser\(event\)/)
+          assert.match(endpoint, /buildWonderLabReviewPortfolio/)
+          assert.doesNotMatch(endpoint, /readBody|defineEventHandler[\s\S]*\.create\(|\.update\(|\.delete\(/)
+          assert.match(portfolio, /assignWonderLabReviewerPortfolio/)
+          assert.match(portfolio, /isWonderLabEditoriallyExcludedReviewer/)
+          assert.match(portfolio, /loadCoverage/)
+          assert.doesNotMatch(portfolio, /INSERT\s+INTO|UPDATE\s+|DELETE\s+FROM/i)
+
+          console.log('WonderLab editorial portfolio audit boundary passed.')
+          NODE
+
+  audit:
+    name: Audit production editorial coverage
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Wait for portfolio endpoint to reach production
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+          TARGET_SHA: ${{ github.sha }}
+          MAX_WAIT: ${{ github.event.inputs.max_wait_seconds || '1200' }}
+        run: |
+          set -euo pipefail
+          echo "Waiting up to ${MAX_WAIT}s for production to serve ${TARGET_SHA} (or a superseding commit)..."
+          deadline=$(( $(date +%s) + MAX_WAIT ))
+          live=""
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            body="$(curl -sf --max-time 15 "${BASE_URL}/api/version" || true)"
+            live="$(printf '%s' "$body" | jq -r '.data.commit // empty' 2>/dev/null || true)"
+            if [ -n "$live" ]; then
+              if [ "$live" = "$TARGET_SHA" ]; then
+                echo "Production is serving ${live} — portfolio endpoint is live."
+                exit 0
+              fi
+              if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+                git fetch --quiet --depth=200 origin main 2>/dev/null || true
+              fi
+              if bash scripts/check-deploy-ancestry.sh "$TARGET_SHA" "$live" 2>/dev/null; then
+                echo "Production is serving ${live}, a newer commit that includes ${TARGET_SHA} — portfolio endpoint is live."
+                exit 0
+              fi
+            fi
+            echo "  not live yet (serving: ${live:-unknown}); retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Production did not serve ${TARGET_SHA} (or a superseding commit) within ${MAX_WAIT}s (last seen: ${live:-unknown})."
+          exit 1
 
       - name: Run read-only production audit
         env:
@@ -127,7 +197,7 @@ jobs:
               : null
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             const lines = [
-              '## WonderLab editorial coverage audit',
+              '## WonderLab editorial portfolio audit',
               '',
               `- **Workflow:** [run ${context.runId}](${runUrl})`,
               `- **Result:** ${process.env.JOB_STATUS}`,
@@ -138,15 +208,17 @@ jobs:
               const diversity = report.diversity || {}
               lines.push(
                 `- **Production:** commit \`${report.production?.commit || 'unknown'}\`; deployment \`${report.production?.deploymentId || 'unknown'}\``,
+                `- **Assignment mode:** ${report.scope?.assignmentMode || 'unknown'}; repeat-use penalty ${report.scope?.diversityPenalty ?? 'unknown'}`,
                 `- **Discovered exhibits:** ${report.scope?.discoveredComponents || 0}`,
-                `- **Planned reviewer slots:** ${coverage.reviewerSlots || 0}`,
+                `- **Planned reviewer slots:** ${coverage.reviewerSlots || 0}/${coverage.targetReviewerSlots || 0} (${coverage.assignmentShortfall || 0} short)`,
                 `- **Published planned slots:** ${coverage.publishedSlots || 0} (${coverage.publishedSlotRate || 0}%)`,
                 `- **Drafted planned slots:** ${coverage.draftedSlots || 0}`,
                 `- **Missing planned slots:** ${coverage.missingSlots || 0}`,
                 `- **Exhibits with any published planned review:** ${coverage.exhibitsWithPublishedReview || 0} (${coverage.exhibitsWithPublishedReviewRate || 0}%)`,
                 `- **Published reviewer diversity:** ${diversity.publishedBots || 0} Bot(s), ${diversity.publishedCharacters || 0} Character(s)`,
                 `- **Assigned reviewer diversity:** ${diversity.assignedBots || 0} Bot(s), ${diversity.assignedCharacters || 0} Character(s)`,
-                `- **No eligible reviewer:** ${coverage.exhibitsWithoutEligibleReviewer || 0} exhibit(s)`,
+                `- **Largest reviewer allocation:** ${diversity.largestAssignmentCount || 0} slots (${diversity.largestAssignmentShare || 0}%)`,
+                `- **Incomplete assignments:** ${coverage.exhibitsWithIncompleteAssignment || 0} exhibit(s)`,
               )
 
               const top = Array.isArray(report.reviewerUsage)
@@ -163,9 +235,9 @@ jobs:
 
               lines.push(
                 '',
-                `> ${report.scope?.note || 'Coverage reflects planner-selected reviewer slots.'}`,
+                `> ${report.scope?.note || 'Coverage reflects portfolio-selected reviewer slots.'}`,
                 '',
-                'The uploaded JSON artifact contains the top 50 missing high-affinity assignments and every exhibit without an eligible reviewer. This workflow is read-only and performs no generation, approval, editing, or publication.',
+                'The uploaded JSON artifact contains the top 50 missing high-affinity assignments and every exhibit without a complete reviewer assignment. This workflow is read-only and performs no generation, approval, editing, or publication.',
               )
             } else {
               lines.push(

--- a/scripts/wonderlab-production-editorial-audit.mjs
+++ b/scripts/wonderlab-production-editorial-audit.mjs
@@ -28,14 +28,6 @@ function assertCondition(condition, message) {
   if (!condition) throw new Error(message)
 }
 
-function chunk(values, size) {
-  const groups = []
-  for (let index = 0; index < values.length; index += size) {
-    groups.push(values.slice(index, index + size))
-  }
-  return groups
-}
-
 function percentage(numerator, denominator) {
   if (!denominator) return 0
   return Math.round((numerator / denominator) * 1000) / 10
@@ -166,19 +158,25 @@ assertCondition(
   'The public Component registry returned an invalid discovered Component ID.',
 )
 
-const planExhibits = []
-for (const ids of chunk(discoveredIds, 100)) {
-  const query = new URLSearchParams({
-    componentIds: ids.join(','),
-    limit: String(ids.length),
-    reviewersPerComponent: '2',
-    minimumScore: '0',
-  })
-  const payload = await adminRequest(`/api/admin/wonderlab/review-plan?${query.toString()}`)
-  const plan = responseDataObject(payload, 'WonderLab review plan')
-  assertCondition(Array.isArray(plan.exhibits), 'WonderLab review plan did not return exhibits.')
-  planExhibits.push(...plan.exhibits)
-}
+const portfolioQuery = new URLSearchParams({
+  limit: '500',
+  reviewersPerComponent: '2',
+  minimumScore: '0',
+  diversityPenalty: '4',
+})
+const portfolioPayload = await adminRequest(
+  `/api/admin/wonderlab/review-portfolio?${portfolioQuery.toString()}`,
+)
+const portfolioPlan = responseDataObject(portfolioPayload, 'WonderLab review portfolio')
+assertCondition(
+  portfolioPlan.assignmentMode === 'PORTFOLIO_DIVERSE',
+  'WonderLab review portfolio did not use the portfolio-diverse assignment mode.',
+)
+assertCondition(
+  Array.isArray(portfolioPlan.exhibits),
+  'WonderLab review portfolio did not return exhibits.',
+)
+const planExhibits = portfolioPlan.exhibits
 
 const returnedIds = planExhibits.map((exhibit) => Number(exhibit.componentId))
 const returnedSet = new Set(returnedIds)
@@ -186,6 +184,7 @@ const duplicatePlanIds = returnedIds.filter((id, index) => returnedIds.indexOf(i
 const missingPlanIds = discoveredIds.filter((id) => !returnedSet.has(id))
 assertCondition(duplicatePlanIds.length === 0, `Planner returned duplicate Components: ${duplicatePlanIds.join(', ')}`)
 assertCondition(missingPlanIds.length === 0, `Planner omitted Components: ${missingPlanIds.join(', ')}`)
+assertCondition(returnedIds.length === discoveredIds.length, 'Planner returned an unexpected Component count.')
 
 const statusCounts = new Map()
 for (const component of discovered) increment(statusCounts, component.status || 'UNKNOWN')
@@ -216,6 +215,8 @@ const publishedSlots = exhibitCoverage.reduce((total, exhibit) => total + exhibi
 const draftedSlots = exhibitCoverage.reduce((total, exhibit) => total + exhibit.draftedSlots, 0)
 const missingSlots = exhibitCoverage.reduce((total, exhibit) => total + exhibit.missingSlots, 0)
 const noEligibleReviewer = exhibitCoverage.filter((exhibit) => exhibit.reviewerSlots === 0)
+const incompleteAssignments = exhibitCoverage.filter((exhibit) => exhibit.reviewerSlots < 2)
+const targetReviewerSlots = exhibitCoverage.length * 2
 const withPublished = exhibitCoverage.filter((exhibit) => exhibit.publishedSlots > 0)
 const fullyPublished = exhibitCoverage.filter(
   (exhibit) => exhibit.reviewerSlots > 0 && exhibit.publishedSlots === exhibit.reviewerSlots,
@@ -226,6 +227,8 @@ const assignedBots = reviewerUsage.filter((reviewer) => reviewer.kind === 'BOT')
 const assignedCharacters = reviewerUsage.filter((reviewer) => reviewer.kind === 'CHARACTER')
 const publishedBots = assignedBots.filter((reviewer) => reviewer.published > 0)
 const publishedCharacters = assignedCharacters.filter((reviewer) => reviewer.published > 0)
+const largestAssignmentCount = reviewerUsage[0]?.assigned || 0
+const largestAssignmentShare = percentage(largestAssignmentCount, reviewerSlots)
 
 const report = {
   generatedAt: new Date().toISOString(),
@@ -238,13 +241,17 @@ const report = {
   scope: {
     discoveredComponents: discovered.length,
     plannedComponents: exhibitCoverage.length,
+    assignmentMode: portfolioPlan.assignmentMode,
     reviewersPerComponent: 2,
     minimumAffinity: 0,
-    note: 'Coverage is measured against the planner-selected reviewer slots. Existing first-party reviews by reviewers outside the current top-two assignment are not represented by this endpoint.',
+    diversityPenalty: Number(portfolioPlan.diversityPenalty) || 4,
+    note: 'Coverage is measured against the deterministic portfolio-selected reviewer slots. Existing published or drafted assignments are pinned when the reviewer remains eligible; new slots apply a repeat-use penalty and prefer Bot/Character contrast.',
   },
   componentStatuses: Object.fromEntries([...statusCounts.entries()].sort()),
   coverage: {
+    targetReviewerSlots,
     reviewerSlots,
+    assignmentShortfall: targetReviewerSlots - reviewerSlots,
     publishedSlots,
     draftedSlots,
     missingSlots,
@@ -255,12 +262,15 @@ const report = {
     exhibitsWithDraft: withDraft.length,
     exhibitsWithoutPublishedReview: withoutPublished.length,
     exhibitsWithoutEligibleReviewer: noEligibleReviewer.length,
+    exhibitsWithIncompleteAssignment: incompleteAssignments.length,
   },
   diversity: {
     assignedBots: assignedBots.length,
     assignedCharacters: assignedCharacters.length,
     publishedBots: publishedBots.length,
     publishedCharacters: publishedCharacters.length,
+    largestAssignmentCount,
+    largestAssignmentShare,
   },
   reviewerUsage,
   priorityMissingAssignments: exhibitCoverage
@@ -288,6 +298,14 @@ const report = {
       left.componentName.localeCompare(right.componentName),
     )
     .slice(0, 50),
+  incompleteAssignments: incompleteAssignments.map((exhibit) => ({
+    componentId: exhibit.componentId,
+    componentName: exhibit.componentName,
+    title: exhibit.title,
+    folderName: exhibit.folderName,
+    sourcePath: exhibit.sourcePath,
+    reviewerSlots: exhibit.reviewerSlots,
+  })),
   noEligibleReviewer: noEligibleReviewer.map((exhibit) => ({
     componentId: exhibit.componentId,
     componentName: exhibit.componentName,
@@ -309,5 +327,5 @@ console.log(
   `Published reviewer diversity: ${publishedBots.length} Bot(s), ${publishedCharacters.length} Character(s).`,
 )
 console.log(
-  `Remaining: ${missingSlots} missing slot(s), ${draftedSlots} drafted slot(s), ${noEligibleReviewer.length} exhibit(s) without an eligible reviewer.`,
+  `Remaining: ${missingSlots} missing slot(s), ${draftedSlots} drafted slot(s), ${incompleteAssignments.length} exhibit(s) with incomplete assignments.`,
 )

--- a/server/api/admin/wonderlab/review-portfolio.get.ts
+++ b/server/api/admin/wonderlab/review-portfolio.get.ts
@@ -1,0 +1,84 @@
+import { createError, defineEventHandler, getQuery, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { buildWonderLabReviewPortfolio } from '@/server/utils/wonderLabReviewPortfolio'
+
+function integerQuery(
+  value: unknown,
+  options: { minimum: number; maximum: number; fallback: number },
+): number {
+  if (value === undefined || value === null || value === '') return options.fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw createError({
+      statusCode: 400,
+      message: `Expected an integer from ${options.minimum} to ${options.maximum}.`,
+    })
+  }
+  return parsed
+}
+
+function numberQuery(
+  value: unknown,
+  options: { minimum: number; maximum: number; fallback: number },
+): number {
+  if (value === undefined || value === null || value === '') return options.fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw createError({
+      statusCode: 400,
+      message: `Expected a number from ${options.minimum} to ${options.maximum}.`,
+    })
+  }
+  return parsed
+}
+
+function componentIds(value: unknown): number[] {
+  if (value === undefined || value === null || value === '') return []
+  const values = Array.isArray(value) ? value : String(value).split(',')
+  const ids = values
+    .flatMap((item) => String(item).split(','))
+    .map((item) => Number(item.trim()))
+
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw createError({ statusCode: 400, message: 'componentIds must contain positive integers.' })
+  }
+
+  return [...new Set(ids)].slice(0, 500)
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const query = getQuery(event)
+
+    const plan = await buildWonderLabReviewPortfolio({
+      componentIds: componentIds(query.componentIds ?? query.componentId),
+      limit: integerQuery(query.limit, { minimum: 1, maximum: 500, fallback: 500 }),
+      reviewersPerComponent: integerQuery(query.reviewersPerComponent, {
+        minimum: 1,
+        maximum: 2,
+        fallback: 2,
+      }),
+      minimumScore: numberQuery(query.minimumScore, {
+        minimum: -100,
+        maximum: 500,
+        fallback: 0,
+      }),
+      diversityPenalty: numberQuery(query.diversityPenalty, {
+        minimum: 0,
+        maximum: 20,
+        fallback: 4,
+      }),
+    })
+
+    return {
+      success: true,
+      data: plan,
+      message: `Portfolio-planned ${plan.reviewerSlots} reviewer slot(s) across ${plan.componentCount} exhibit(s).`,
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/utils/wonderLabReviewPortfolio.ts
+++ b/server/utils/wonderLabReviewPortfolio.ts
@@ -1,0 +1,373 @@
+import prisma from '@/server/utils/prisma'
+import {
+  rankWonderLabReviewers,
+  type WonderLabExhibitProfile,
+  type WonderLabReviewerCandidate,
+} from '@/utils/wonderlab/reviewerAffinity'
+import {
+  assignWonderLabReviewerPortfolio,
+  isWonderLabEditoriallyExcludedReviewer,
+  type WonderLabPortfolioCandidate,
+  type WonderLabPortfolioReviewerUsage,
+} from '@/utils/wonderlab/reviewerPortfolio'
+import type { ReviewDraftAuthorRef, ReviewDraftStatus } from '@/utils/wonderlab/reviewDraft'
+import type {
+  WonderLabReviewCoverage,
+  WonderLabReviewPlanExhibit,
+  WonderLabReviewPlanReviewer,
+} from '@/server/utils/wonderLabReviewPlan'
+
+export type WonderLabReviewPortfolioPlan = {
+  assignmentMode: 'PORTFOLIO_DIVERSE'
+  exhibits: WonderLabReviewPlanExhibit[]
+  componentCount: number
+  reviewerSlots: number
+  missingCount: number
+  draftedCount: number
+  publishedCount: number
+  diversityPenalty: number
+  reviewerUsage: WonderLabPortfolioReviewerUsage[]
+}
+
+export type BuildWonderLabReviewPortfolioOptions = {
+  componentIds?: number[]
+  limit?: number
+  reviewersPerComponent?: number
+  minimumScore?: number
+  diversityPenalty?: number
+}
+
+type DraftCoverageRow = {
+  id: number
+  componentId: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+  status: ReviewDraftStatus
+  publishedReactionId: number | null
+}
+
+type ReactionCoverageRow = {
+  id: number
+  componentId: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+}
+
+type CoverageDetails = {
+  coverage: WonderLabReviewCoverage
+  draftId: number | null
+  draftStatus: ReviewDraftStatus | null
+  reactionId: number | null
+}
+
+function stringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+  if (typeof value !== 'string' || !value.trim()) return []
+  try {
+    return stringArray(JSON.parse(value))
+  } catch {
+    return value
+      .split(/[\n,]/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+}
+
+function authorKey(author: ReviewDraftAuthorRef): string {
+  return `${author.kind}:${author.id}`
+}
+
+function coverageKey(componentId: number, author: ReviewDraftAuthorRef): string {
+  return `${componentId}:${authorKey(author)}`
+}
+
+function rowAuthor(row: {
+  authorBotId: number | null
+  authorCharacterId: number | null
+}): ReviewDraftAuthorRef | null {
+  if (row.authorBotId && !row.authorCharacterId) {
+    return { kind: 'BOT', id: row.authorBotId }
+  }
+  if (row.authorCharacterId && !row.authorBotId) {
+    return { kind: 'CHARACTER', id: row.authorCharacterId }
+  }
+  return null
+}
+
+async function loadExhibits(
+  options: BuildWonderLabReviewPortfolioOptions,
+): Promise<WonderLabExhibitProfile[]> {
+  const componentIds = [...new Set(options.componentIds || [])]
+    .filter((id) => Number.isInteger(id) && id > 0)
+    .slice(0, 500)
+  const limit = Math.max(1, Math.min(500, Math.round(options.limit ?? 500)))
+
+  const components = await prisma.component.findMany({
+    where: {
+      isDiscovered: true,
+      ...(componentIds.length ? { id: { in: componentIds } } : {}),
+    },
+    orderBy: [{ folderName: 'asc' }, { componentName: 'asc' }, { id: 'asc' }],
+    take: componentIds.length ? componentIds.length : limit,
+    select: {
+      id: true,
+      componentName: true,
+      folderName: true,
+      sourcePath: true,
+      title: true,
+      description: true,
+      notes: true,
+      category: true,
+      tags: true,
+    },
+  })
+
+  return components.map((component) => ({
+    id: component.id,
+    componentName: component.componentName,
+    folderName: component.folderName,
+    sourcePath: component.sourcePath,
+    title: component.title,
+    description: component.description,
+    notes: component.notes,
+    category: component.category,
+    tags: stringArray(component.tags),
+  }))
+}
+
+async function loadReviewers(): Promise<WonderLabReviewerCandidate[]> {
+  const [bots, characters] = await Promise.all([
+    prisma.bot.findMany({
+      where: { isActive: true, isPublic: true, isMature: false },
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        subtitle: true,
+        description: true,
+        personality: true,
+        narrativeVoice: true,
+        sampleResponse: true,
+        prompt: true,
+        modules: true,
+        isActive: true,
+        isPublic: true,
+        isMature: true,
+      },
+    }),
+    prisma.character.findMany({
+      where: { isActive: true, isPublic: true, isMature: false },
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        title: true,
+        backstory: true,
+        personality: true,
+        voice: true,
+        sampleResponse: true,
+        drive: true,
+        quirks: true,
+        genre: true,
+        isActive: true,
+        isPublic: true,
+        isMature: true,
+      },
+    }),
+  ])
+
+  return [
+    ...bots.map((bot): WonderLabReviewerCandidate => ({
+      id: bot.id,
+      kind: 'BOT',
+      name: bot.name,
+      slug: bot.slug,
+      subtitle: bot.subtitle,
+      description: bot.description,
+      personality: bot.personality,
+      voice: bot.narrativeVoice,
+      sampleResponse: bot.sampleResponse,
+      prompt: bot.prompt,
+      modules: bot.modules,
+      isActive: bot.isActive,
+      isPublic: bot.isPublic,
+      isMature: bot.isMature,
+    })),
+    ...characters.map((character): WonderLabReviewerCandidate => ({
+      id: character.id,
+      kind: 'CHARACTER',
+      name: character.name,
+      slug: character.slug,
+      subtitle: character.title,
+      description: character.backstory,
+      personality: character.personality,
+      voice: character.voice,
+      sampleResponse: character.sampleResponse,
+      prompt: [character.drive, character.quirks].filter(Boolean).join('\n'),
+      modules: character.genre,
+      isActive: character.isActive,
+      isPublic: character.isPublic,
+      isMature: character.isMature,
+    })),
+  ].filter((candidate) => !isWonderLabEditoriallyExcludedReviewer(candidate))
+}
+
+async function loadCoverage(): Promise<{
+  drafts: Map<string, DraftCoverageRow>
+  reactions: Map<string, ReactionCoverageRow>
+}> {
+  const [draftRows, reactionRows] = await Promise.all([
+    prisma.$queryRaw<DraftCoverageRow[]>`
+      SELECT
+        id,
+        componentId,
+        authorBotId,
+        authorCharacterId,
+        status,
+        publishedReactionId
+      FROM ReviewDraft
+      ORDER BY updatedAt DESC, createdAt DESC, id DESC
+    `,
+    prisma.$queryRaw<ReactionCoverageRow[]>`
+      SELECT id, componentId, authorBotId, authorCharacterId
+      FROM Reaction
+      WHERE reactionCategory = 'COMPONENT'
+        AND componentId IS NOT NULL
+        AND (authorBotId IS NOT NULL OR authorCharacterId IS NOT NULL)
+      ORDER BY updatedAt DESC, createdAt DESC, id DESC
+    `,
+  ])
+
+  const drafts = new Map<string, DraftCoverageRow>()
+  for (const row of draftRows) {
+    const author = rowAuthor(row)
+    if (!author) continue
+    const key = coverageKey(row.componentId, author)
+    if (!drafts.has(key)) drafts.set(key, row)
+  }
+
+  const reactions = new Map<string, ReactionCoverageRow>()
+  for (const row of reactionRows) {
+    const author = rowAuthor(row)
+    if (!author) continue
+    const key = coverageKey(row.componentId, author)
+    if (!reactions.has(key)) reactions.set(key, row)
+  }
+
+  return { drafts, reactions }
+}
+
+function coverageDetails(
+  componentId: number,
+  author: ReviewDraftAuthorRef,
+  coverage: Awaited<ReturnType<typeof loadCoverage>>,
+): CoverageDetails {
+  const key = coverageKey(componentId, author)
+  const draft = coverage.drafts.get(key)
+  const reaction = coverage.reactions.get(key)
+  const reactionId = reaction?.id || draft?.publishedReactionId || null
+  return {
+    coverage: reactionId ? 'PUBLISHED' : draft ? 'DRAFTED' : 'MISSING',
+    draftId: draft?.id ?? null,
+    draftStatus: draft?.status ?? null,
+    reactionId,
+  }
+}
+
+export async function buildWonderLabReviewPortfolio(
+  options: BuildWonderLabReviewPortfolioOptions = {},
+): Promise<WonderLabReviewPortfolioPlan> {
+  const reviewerCount = Math.max(
+    1,
+    Math.min(2, Math.round(options.reviewersPerComponent ?? 2)),
+  )
+  const minimumScore = options.minimumScore ?? 0
+  const diversityPenalty = Math.max(0, Math.min(20, options.diversityPenalty ?? 4))
+  const [exhibits, candidates, coverage] = await Promise.all([
+    loadExhibits(options),
+    loadReviewers(),
+    loadCoverage(),
+  ])
+
+  const portfolioInputs = exhibits.map((exhibit) => {
+    const ranked = rankWonderLabReviewers(exhibit, candidates, {
+      limit: candidates.length,
+      minimumScore: -100,
+      requirePublic: true,
+      includeMature: false,
+    })
+    const candidateRows = ranked
+      .map((entry): WonderLabPortfolioCandidate => {
+        const author: ReviewDraftAuthorRef = {
+          kind: entry.reviewer.kind,
+          id: entry.reviewer.id,
+        }
+        return {
+          ...entry,
+          coverage: coverageDetails(exhibit.id, author, coverage).coverage,
+        }
+      })
+      .filter(
+        (entry) =>
+          entry.coverage !== 'MISSING' ||
+          (entry.voiceReady && entry.score >= minimumScore),
+      )
+
+    return { key: exhibit.id, candidates: candidateRows }
+  })
+
+  const portfolio = assignWonderLabReviewerPortfolio(portfolioInputs, {
+    reviewersPerExhibit: reviewerCount,
+    diversityPenalty,
+  })
+  const assignments = new Map(
+    portfolio.assignments.map((assignment) => [assignment.key, assignment.reviewers]),
+  )
+
+  const planned = exhibits.map((exhibit): WonderLabReviewPlanExhibit => {
+    const selected = assignments.get(exhibit.id) || []
+    return {
+      componentId: exhibit.id,
+      componentName: exhibit.componentName,
+      title: exhibit.title || null,
+      folderName: exhibit.folderName,
+      sourcePath: exhibit.sourcePath || null,
+      status: selected.length ? 'READY' : 'NO_ELIGIBLE_REVIEWER',
+      reviewers: selected.map((entry): WonderLabReviewPlanReviewer => {
+        const author: ReviewDraftAuthorRef = {
+          kind: entry.reviewer.kind,
+          id: entry.reviewer.id,
+        }
+        const details = coverageDetails(exhibit.id, author, coverage)
+        return {
+          author,
+          name: entry.reviewer.name,
+          slug: entry.reviewer.slug || null,
+          score: entry.score,
+          reasons: entry.reasons,
+          coverage: details.coverage,
+          draftId: details.draftId,
+          draftStatus: details.draftStatus,
+          reactionId: details.reactionId,
+        }
+      }),
+    }
+  })
+
+  const reviewers = planned.flatMap((exhibit) => exhibit.reviewers)
+  return {
+    assignmentMode: 'PORTFOLIO_DIVERSE',
+    exhibits: planned,
+    componentCount: planned.length,
+    reviewerSlots: reviewers.length,
+    missingCount: reviewers.filter((reviewer) => reviewer.coverage === 'MISSING').length,
+    draftedCount: reviewers.filter((reviewer) => reviewer.coverage === 'DRAFTED').length,
+    publishedCount: reviewers.filter((reviewer) => reviewer.coverage === 'PUBLISHED').length,
+    diversityPenalty,
+    reviewerUsage: portfolio.reviewerUsage,
+  }
+}

--- a/server/utils/wonderLabReviewPortfolio.ts
+++ b/server/utils/wonderLabReviewPortfolio.ts
@@ -6,6 +6,7 @@ import {
 } from '@/utils/wonderlab/reviewerAffinity'
 import {
   assignWonderLabReviewerPortfolio,
+  isWonderLabActiveEditorialDraft,
   isWonderLabEditoriallyExcludedReviewer,
   type WonderLabPortfolioCandidate,
   type WonderLabPortfolioReviewerUsage,
@@ -270,10 +271,13 @@ function coverageDetails(
   const draft = coverage.drafts.get(key)
   const reaction = coverage.reactions.get(key)
   const reactionId = reaction?.id || draft?.publishedReactionId || null
+  const activeDraft =
+    draft && isWonderLabActiveEditorialDraft(draft.status) ? draft : null
+  const displayedDraft = reactionId ? draft : activeDraft
   return {
-    coverage: reactionId ? 'PUBLISHED' : draft ? 'DRAFTED' : 'MISSING',
-    draftId: draft?.id ?? null,
-    draftStatus: draft?.status ?? null,
+    coverage: reactionId ? 'PUBLISHED' : activeDraft ? 'DRAFTED' : 'MISSING',
+    draftId: displayedDraft?.id ?? null,
+    draftStatus: displayedDraft?.status ?? null,
     reactionId,
   }
 }

--- a/utils/scripts/verifyWonderLabReviewerPortfolio.ts
+++ b/utils/scripts/verifyWonderLabReviewerPortfolio.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import {
+  assignWonderLabReviewerPortfolio,
+  isWonderLabEditoriallyExcludedReviewer,
+  type WonderLabPortfolioCandidate,
+} from '@/utils/wonderlab/reviewerPortfolio'
+
+function candidate(
+  id: number,
+  kind: 'BOT' | 'CHARACTER',
+  name: string,
+  score: number,
+  coverage: 'MISSING' | 'DRAFTED' | 'PUBLISHED' = 'MISSING',
+): WonderLabPortfolioCandidate {
+  return {
+    reviewer: {
+      id,
+      kind,
+      name,
+      voice: `${name} voice`,
+      isActive: true,
+      isPublic: true,
+      isMature: false,
+    },
+    reviewerKey: `${kind}:${id}`,
+    score,
+    voiceReady: true,
+    reasons: [`${name} affinity`],
+    coverage,
+  }
+}
+
+const broad = candidate(1, 'BOT', 'Broad Bot', 3)
+const specialist = candidate(2, 'BOT', 'Specialist', 30)
+const characterA = candidate(3, 'CHARACTER', 'Character A', 2)
+const characterB = candidate(4, 'CHARACTER', 'Character B', 2)
+const characterC = candidate(5, 'CHARACTER', 'Character C', 2)
+
+const inputs = [
+  { key: 1, candidates: [specialist, broad, characterA] },
+  { key: 2, candidates: [broad, characterA, characterB] },
+  { key: 3, candidates: [broad, characterA, characterB, characterC] },
+]
+const result = assignWonderLabReviewerPortfolio(inputs, {
+  reviewersPerExhibit: 2,
+  diversityPenalty: 4,
+})
+
+assert.equal(result.assignments[0]?.reviewers[0]?.reviewer.id, specialist.reviewer.id)
+assert.ok(result.assignments.every((entry) => entry.reviewers.length === 2))
+assert.ok(
+  result.assignments.every(
+    (entry) => new Set(entry.reviewers.map((reviewer) => reviewer.reviewer.kind)).size === 2,
+  ),
+)
+const broadUsage = result.reviewerUsage.find((entry) => entry.id === broad.reviewer.id)?.count || 0
+assert.ok(broadUsage < inputs.length, 'repeat-use penalty should prevent broad reviewer monopoly')
+assert.ok(
+  result.assignments.flatMap((entry) => entry.reviewers).some(
+    (entry) => entry.reasons.some((reason) => reason.startsWith('portfolio balance:')),
+  ),
+)
+
+const pinned = assignWonderLabReviewerPortfolio([
+  {
+    key: 9,
+    candidates: [
+      candidate(10, 'BOT', 'Published Bot', 1, 'PUBLISHED'),
+      candidate(11, 'BOT', 'Higher Bot', 50),
+      candidate(12, 'CHARACTER', 'Drafted Character', 1, 'DRAFTED'),
+    ],
+  },
+], { reviewersPerExhibit: 2 })
+assert.deepEqual(
+  pinned.assignments[0]?.reviewers.map((entry) => entry.reviewer.id),
+  [10, 12],
+  'existing published and drafted editorial work should remain pinned',
+)
+
+const deterministic = assignWonderLabReviewerPortfolio(inputs, {
+  reviewersPerExhibit: 2,
+  diversityPenalty: 4,
+})
+assert.deepEqual(result, deterministic)
+
+assert.equal(
+  isWonderLabEditoriallyExcludedReviewer({ name: 'Princess Donut', slug: null }),
+  true,
+)
+assert.equal(
+  isWonderLabEditoriallyExcludedReviewer({ name: 'Other', slug: 'princess-donut' }),
+  true,
+)
+assert.equal(
+  isWonderLabEditoriallyExcludedReviewer({ name: 'Princess Doughnut', slug: null }),
+  false,
+)
+
+console.log('WonderLab reviewer portfolio contract passed.')

--- a/utils/scripts/verifyWonderLabReviewerPortfolio.ts
+++ b/utils/scripts/verifyWonderLabReviewerPortfolio.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import {
   assignWonderLabReviewerPortfolio,
+  isWonderLabActiveEditorialDraft,
   isWonderLabEditoriallyExcludedReviewer,
   type WonderLabPortfolioCandidate,
 } from '@/utils/wonderlab/reviewerPortfolio'
@@ -82,6 +83,12 @@ const deterministic = assignWonderLabReviewerPortfolio(inputs, {
   diversityPenalty: 4,
 })
 assert.deepEqual(result, deterministic)
+
+assert.equal(isWonderLabActiveEditorialDraft('PROPOSED'), true)
+assert.equal(isWonderLabActiveEditorialDraft('APPROVED'), true)
+assert.equal(isWonderLabActiveEditorialDraft('REJECTED'), false)
+assert.equal(isWonderLabActiveEditorialDraft('FAILED'), false)
+assert.equal(isWonderLabActiveEditorialDraft('SUPERSEDED'), false)
 
 assert.equal(
   isWonderLabEditoriallyExcludedReviewer({ name: 'Princess Donut', slug: null }),

--- a/utils/wonderlab/reviewerPortfolio.ts
+++ b/utils/wonderlab/reviewerPortfolio.ts
@@ -1,0 +1,222 @@
+import type {
+  WonderLabReviewerAffinity,
+  WonderLabReviewerCandidate,
+} from './reviewerAffinity'
+
+export type WonderLabPortfolioCoverage = 'MISSING' | 'DRAFTED' | 'PUBLISHED'
+
+export type WonderLabPortfolioCandidate = WonderLabReviewerAffinity & {
+  coverage: WonderLabPortfolioCoverage
+}
+
+export type WonderLabPortfolioExhibit = {
+  key: number
+  candidates: WonderLabPortfolioCandidate[]
+}
+
+export type WonderLabPortfolioAssignment = {
+  key: number
+  reviewers: WonderLabPortfolioCandidate[]
+}
+
+export type WonderLabPortfolioReviewerUsage = {
+  reviewerKey: string
+  kind: 'BOT' | 'CHARACTER'
+  id: number
+  name: string
+  count: number
+}
+
+export type AssignWonderLabReviewerPortfolioOptions = {
+  reviewersPerExhibit?: number
+  diversityPenalty?: number
+}
+
+const COVERAGE_PRIORITY: Record<WonderLabPortfolioCoverage, number> = {
+  PUBLISHED: 0,
+  DRAFTED: 1,
+  MISSING: 2,
+}
+
+function normalizedReviewerName(value: string | null | undefined): string {
+  return String(value || '')
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function isWonderLabEditoriallyExcludedReviewer(
+  candidate: Pick<WonderLabReviewerCandidate, 'name' | 'slug'>,
+): boolean {
+  return (
+    normalizedReviewerName(candidate.name) === 'princess-donut' ||
+    normalizedReviewerName(candidate.slug) === 'princess-donut'
+  )
+}
+
+function stableCandidateOrder(
+  left: WonderLabPortfolioCandidate,
+  right: WonderLabPortfolioCandidate,
+): number {
+  if (right.score !== left.score) return right.score - left.score
+  if (left.reviewer.kind !== right.reviewer.kind) {
+    return left.reviewer.kind.localeCompare(right.reviewer.kind, 'en')
+  }
+  const nameOrder = left.reviewer.name.localeCompare(right.reviewer.name, 'en')
+  return nameOrder || left.reviewer.id - right.reviewer.id
+}
+
+function pinnedCandidateOrder(
+  left: WonderLabPortfolioCandidate,
+  right: WonderLabPortfolioCandidate,
+): number {
+  const coverageOrder = COVERAGE_PRIORITY[left.coverage] - COVERAGE_PRIORITY[right.coverage]
+  return coverageOrder || stableCandidateOrder(left, right)
+}
+
+function withPortfolioReason(
+  candidate: WonderLabPortfolioCandidate,
+  priorAssignments: number,
+): WonderLabPortfolioCandidate {
+  if (priorAssignments <= 0) return candidate
+  return {
+    ...candidate,
+    reasons: [
+      ...candidate.reasons,
+      `portfolio balance: ${priorAssignments} prior planned assignment${priorAssignments === 1 ? '' : 's'}`,
+    ],
+  }
+}
+
+export function assignWonderLabReviewerPortfolio(
+  exhibits: WonderLabPortfolioExhibit[],
+  options: AssignWonderLabReviewerPortfolioOptions = {},
+): {
+  assignments: WonderLabPortfolioAssignment[]
+  reviewerUsage: WonderLabPortfolioReviewerUsage[]
+} {
+  const reviewerCount = Math.max(
+    1,
+    Math.min(2, Math.round(options.reviewersPerExhibit ?? 2)),
+  )
+  const diversityPenalty = Math.max(0, options.diversityPenalty ?? 4)
+  const usage = new Map<string, number>()
+  const selected = new Map<number, WonderLabPortfolioCandidate[]>()
+
+  // Existing editorial work is stable: preserve published and drafted slots before
+  // balancing new assignments. Published work wins when more historical slots exist
+  // than the current plan requests.
+  for (const exhibit of exhibits) {
+    const pinned = exhibit.candidates
+      .filter((candidate) => candidate.coverage !== 'MISSING')
+      .sort(pinnedCandidateOrder)
+      .slice(0, reviewerCount)
+
+    selected.set(exhibit.key, [...pinned])
+    for (const candidate of pinned) {
+      usage.set(candidate.reviewerKey, (usage.get(candidate.reviewerKey) || 0) + 1)
+    }
+  }
+
+  // Plan high-affinity and constrained exhibits first. New selections pay a
+  // deterministic repeat-use penalty so a generic voice cannot dominate the museum.
+  const fillOrder = exhibits
+    .map((exhibit) => {
+      const alreadySelected = selected.get(exhibit.key) || []
+      const available = exhibit.candidates.filter(
+        (candidate) =>
+          candidate.voiceReady &&
+          !alreadySelected.some((entry) => entry.reviewerKey === candidate.reviewerKey),
+      )
+      return {
+        exhibit,
+        bestScore: available[0]?.score ?? Number.NEGATIVE_INFINITY,
+        availableCount: available.length,
+      }
+    })
+    .sort((left, right) =>
+      right.bestScore - left.bestScore ||
+      left.availableCount - right.availableCount ||
+      left.exhibit.key - right.exhibit.key,
+    )
+
+  for (const { exhibit } of fillOrder) {
+    const reviewers = selected.get(exhibit.key) || []
+
+    while (reviewers.length < reviewerCount) {
+      let pool = exhibit.candidates.filter(
+        (candidate) =>
+          candidate.voiceReady &&
+          !reviewers.some((entry) => entry.reviewerKey === candidate.reviewerKey),
+      )
+      if (!pool.length) break
+
+      // When two voices are requested, prefer a Bot/Character contrast whenever
+      // the exhibit has any eligible opposite-kind candidate.
+      const first = reviewers[0]
+      if (first) {
+        const contrasting = pool.filter(
+          (candidate) => candidate.reviewer.kind !== first.reviewer.kind,
+        )
+        if (contrasting.length) pool = contrasting
+      }
+
+      pool.sort((left, right) => {
+        const leftUsage = usage.get(left.reviewerKey) || 0
+        const rightUsage = usage.get(right.reviewerKey) || 0
+        const leftAdjusted = left.score - leftUsage * diversityPenalty
+        const rightAdjusted = right.score - rightUsage * diversityPenalty
+        return (
+          rightAdjusted - leftAdjusted ||
+          leftUsage - rightUsage ||
+          stableCandidateOrder(left, right)
+        )
+      })
+
+      const choice = pool[0]
+      if (!choice) break
+      const priorAssignments = usage.get(choice.reviewerKey) || 0
+      reviewers.push(withPortfolioReason(choice, priorAssignments))
+      usage.set(choice.reviewerKey, priorAssignments + 1)
+    }
+
+    selected.set(exhibit.key, reviewers)
+  }
+
+  const candidatesByKey = new Map<string, WonderLabPortfolioCandidate>()
+  for (const exhibit of exhibits) {
+    for (const candidate of exhibit.candidates) {
+      if (!candidatesByKey.has(candidate.reviewerKey)) {
+        candidatesByKey.set(candidate.reviewerKey, candidate)
+      }
+    }
+  }
+
+  const reviewerUsage = [...usage.entries()]
+    .map(([reviewerKey, count]): WonderLabPortfolioReviewerUsage => {
+      const candidate = candidatesByKey.get(reviewerKey)
+      if (!candidate) throw new Error(`Missing reviewer candidate for ${reviewerKey}.`)
+      return {
+        reviewerKey,
+        kind: candidate.reviewer.kind,
+        id: candidate.reviewer.id,
+        name: candidate.reviewer.name,
+        count,
+      }
+    })
+    .sort((left, right) =>
+      right.count - left.count ||
+      left.kind.localeCompare(right.kind, 'en') ||
+      left.name.localeCompare(right.name, 'en') ||
+      left.id - right.id,
+    )
+
+  return {
+    assignments: exhibits.map((exhibit) => ({
+      key: exhibit.key,
+      reviewers: selected.get(exhibit.key) || [],
+    })),
+    reviewerUsage,
+  }
+}

--- a/utils/wonderlab/reviewerPortfolio.ts
+++ b/utils/wonderlab/reviewerPortfolio.ts
@@ -2,6 +2,7 @@ import type {
   WonderLabReviewerAffinity,
   WonderLabReviewerCandidate,
 } from './reviewerAffinity'
+import type { ReviewDraftStatus } from './reviewDraft'
 
 export type WonderLabPortfolioCoverage = 'MISSING' | 'DRAFTED' | 'PUBLISHED'
 
@@ -30,6 +31,17 @@ export type WonderLabPortfolioReviewerUsage = {
 export type AssignWonderLabReviewerPortfolioOptions = {
   reviewersPerExhibit?: number
   diversityPenalty?: number
+}
+
+const ACTIVE_EDITORIAL_DRAFT_STATUSES = new Set<ReviewDraftStatus>([
+  'PROPOSED',
+  'APPROVED',
+])
+
+export function isWonderLabActiveEditorialDraft(
+  status: ReviewDraftStatus,
+): boolean {
+  return ACTIVE_EDITORIAL_DRAFT_STATUSES.has(status)
 }
 
 const COVERAGE_PRIORITY: Record<WonderLabPortfolioCoverage, number> = {
@@ -131,7 +143,9 @@ export function assignWonderLabReviewerPortfolio(
       )
       return {
         exhibit,
-        bestScore: available[0]?.score ?? Number.NEGATIVE_INFINITY,
+        bestScore: available.length
+          ? Math.max(...available.map((candidate) => candidate.score))
+          : Number.NEGATIVE_INFINITY,
         availableCount: available.length,
       }
     })


### PR DESCRIPTION
## Summary

Follow-up to #585 and #582. The first live editorial audit found that independent per-exhibit ranking assigned Catbot to 108 of 696 planned slots, AMI Butterfly to 96, and DottiB0t to 64. This PR adds a separate **read-only portfolio planner** so we can verify a diverse museum-wide assignment set before allowing it to drive generation.

- adds a deterministic portfolio assignment utility;
- pins existing `PUBLISHED` and `DRAFTED` work before assigning new slots;
- preserves strong specialist affinities while subtracting a configurable repeat-use penalty;
- prefers Bot/Character contrast for a second reviewer whenever an eligible opposite-kind voice exists;
- explicitly excludes Princess Donut from the editorial candidate pool;
- exposes an admin-only GET endpoint covering up to 500 discovered Components;
- moves the production editorial audit onto the portfolio endpoint;
- reports assignment shortfall and the largest reviewer allocation/share;
- waits for the merged commit (or a superseding descendant) to reach Vercel production before auditing;
- keeps all generation, approval, editing, and publication paths untouched.

## Safety boundary

This PR is assignment-only and read-only. The new endpoint reads Components, eligible personalities, ReviewDraft coverage, and authored Reaction coverage. It performs no inserts, updates, deletes, model calls, approval transitions, or publication.

The existing `/api/admin/wonderlab/review-plan` and batch generator are unchanged. Portfolio assignments will not drive model calls until the production audit is reviewed and a separate integration PR is approved.

## Validation

- deterministic portfolio contract covering specialist retention, repeat-use penalty, Bot/Character contrast, pinned editorial work, exclusion, and rerun stability;
- static workflow boundary forbidding POST/generate/approve/reject/publish behavior;
- TypeScript and repository contract suites;
- Vercel preview build.

After merge, the deploy-aware workflow posts the live balanced coverage report to #582.

Refs #582