### PR TITLE
Gate Reward relation connects by permission

### DIFF
--- a/cypress/e2e/api/reward-input-boundary.cy.ts
+++ b/cypress/e2e/api/reward-input-boundary.cy.ts
@@ -30,11 +30,16 @@ describe('Reward mutation input boundary', () => {
   let apiBase = ''
   let adminToken = ''
   let rewardsUrl = ''
+  let charactersUrl = ''
   let ownerToken = ''
+  let otherToken = ''
   let ownerId: number | undefined
+  let otherId: number | undefined
   let rewardId: number | undefined
+  let privateCharacterId: number | undefined
 
   const ownerHeaders = () => bearerHeaders(ownerToken)
+  const otherHeaders = () => bearerHeaders(otherToken)
 
   before(() => {
     return getApiEnv()
@@ -42,11 +47,31 @@ describe('Reward mutation input boundary', () => {
         apiBase = env.apiBase
         adminToken = env.adminToken
         rewardsUrl = `${apiBase}/rewards`
+        charactersUrl = `${apiBase}/characters`
         return createLoggedInTestUser({ fresh: true })
       })
       .then((owner) => {
         ownerToken = owner.token
         ownerId = owner.id
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherToken = other.token
+        otherId = other.id
+
+        // The other user owns one private Character.
+        return cy
+          .request<ApiResponse<{ id: number }>>({
+            method: 'POST',
+            url: charactersUrl,
+            headers: otherHeaders(),
+            body: { name: `RewardPrivateChar-${stamp}`, isPublic: false },
+          })
+          .then((res) => {
+            expect(res.status, JSON.stringify(res.body)).to.eq(201)
+            privateCharacterId = res.body.data?.id
+            expect(privateCharacterId).to.be.a('number')
+          })
       })
   })
 
@@ -62,7 +87,17 @@ describe('Reward mutation input boundary', () => {
       })
     }
 
+    if (privateCharacterId && otherToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${charactersUrl}/${privateCharacterId}`,
+        headers: otherHeaders(),
+        failOnStatusCode: false,
+      })
+    }
+
     deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
   })
 
   it('creates a Reward under the authenticated owner', () => {
@@ -151,6 +186,25 @@ describe('Reward mutation input boundary', () => {
       expect(response.status).to.eq(404)
       expect(response.body.success).to.eq(false)
       expect(response.body.message).to.include('Character relation not found')
+    })
+  })
+
+  it('forbids attaching another user private Character on Reward creation', () => {
+    expect(privateCharacterId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: rewardsUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `ForbiddenRelationReward-${stamp}`,
+        characterIds: [privateCharacterId],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('permission to attach')
     })
   })
 

--- a/server/api/rewards/[id].patch.ts
+++ b/server/api/rewards/[id].patch.ts
@@ -80,7 +80,8 @@ export default defineEventHandler(async (event) => {
       requireNonEmpty: true,
     })
 
-    const data = await updateRewardById(rewardId, rewardData)
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const data = await updateRewardById(rewardId, rewardData, user.id, isAdmin)
 
     event.node.res.statusCode = 200
 

--- a/server/api/rewards/batch.post.ts
+++ b/server/api/rewards/batch.post.ts
@@ -91,9 +91,11 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
     const { count, rewards, errors } = await createRewardsBatch(
       rewardsData,
       user.id,
+      isAdmin,
     )
 
     if (errors.length > 0) {

--- a/server/api/rewards/index.post.ts
+++ b/server/api/rewards/index.post.ts
@@ -46,7 +46,8 @@ export default defineEventHandler(async (event) => {
       context: 'Reward create payload',
     })
 
-    const data = await createReward(rewardData, user.id)
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const data = await createReward(rewardData, user.id, isAdmin)
 
     event.node.res.statusCode = 201
 

--- a/server/api/rewards/index.ts
+++ b/server/api/rewards/index.ts
@@ -11,7 +11,7 @@ import {
   rewardMutationSelect,
   type RewardMutationResult,
 } from './selects'
-import { assertRewardRelationsExist } from './mutation'
+import { assertRewardRelationsAttachable } from './mutation'
 
 export type RewardRelationInput = {
   characterIds?: number[]
@@ -395,8 +395,9 @@ export function buildUpdateData(
 export async function createReward(
   input: RewardMutationInput,
   authenticatedUserId: number,
+  isAdmin: boolean,
 ): Promise<RewardMutationResult> {
-  await assertRewardRelationsExist(input)
+  await assertRewardRelationsAttachable(input, authenticatedUserId, isAdmin)
 
   return await prisma.reward.create({
     data: buildCreateData(input, authenticatedUserId),
@@ -407,6 +408,7 @@ export async function createReward(
 export async function createRewardsBatch(
   inputs: RewardMutationInput[],
   authenticatedUserId: number,
+  isAdmin: boolean,
 ): Promise<{
   count: number
   rewards: RewardMutationResult[]
@@ -417,7 +419,7 @@ export async function createRewardsBatch(
 
   for (const [index, input] of inputs.entries()) {
     try {
-      const reward = await createReward(input, authenticatedUserId)
+      const reward = await createReward(input, authenticatedUserId, isAdmin)
 
       rewards.push(reward)
     } catch (error) {
@@ -478,8 +480,10 @@ export async function fetchAllRewards(): Promise<RewardWithRelations[]> {
 export async function updateRewardById(
   id: number,
   input: RewardMutationInput,
+  authenticatedUserId: number,
+  isAdmin: boolean,
 ): Promise<RewardMutationResult> {
-  await assertRewardRelationsExist(input)
+  await assertRewardRelationsAttachable(input, authenticatedUserId, isAdmin)
 
   return await prisma.reward.update({
     where: { id },

--- a/server/api/rewards/mutation.ts
+++ b/server/api/rewards/mutation.ts
@@ -291,25 +291,6 @@ export function assertRewardMutationInput(
   }
 }
 
-async function assertIdsExist(
-  ids: number[],
-  find: (idsIn: number[]) => Promise<Array<{ id: number }>>,
-  label: string,
-): Promise<void> {
-  if (!ids.length) return
-
-  const found = await find(ids)
-  const foundIds = new Set(found.map((row) => row.id))
-  const missing = ids.filter((id) => !foundIds.has(id))
-
-  if (missing.length) {
-    throw createError({
-      statusCode: 404,
-      message: `${label} not found: ${missing.join(', ')}.`,
-    })
-  }
-}
-
 type RewardRelationExistenceInput = {
   characterIds?: unknown
   dreamIds?: unknown
@@ -318,11 +299,51 @@ type RewardRelationExistenceInput = {
   artImageId?: unknown
 }
 
-// Verifies that every connect/set relation target and artImage referenced by a
-// Reward mutation actually exists before the write. Disconnect (remove*) targets
-// are not existence-checked because disconnecting a missing relation is a no-op.
-export async function assertRewardRelationsExist(
+type OwnableRow = { id: number; userId: number | null; isPublic: boolean | null }
+
+// Verifies existence (404 for missing) and permission (403 for a private target
+// owned by someone else) for every connect/set relation target. A non-admin may
+// only attach public or self-owned rows; admins skip the permission check but
+// still get the existence check. Disconnect (remove*) targets are not checked
+// because disconnecting a missing relation is a no-op.
+async function assertRelationAccessible(
+  ids: number[],
+  find: (idsIn: number[]) => Promise<OwnableRow[]>,
+  label: string,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (!ids.length) return
+
+  const rows = await find(ids)
+  const foundIds = new Set(rows.map((row) => row.id))
+  const missing = ids.filter((id) => !foundIds.has(id))
+
+  if (missing.length) {
+    throw createError({
+      statusCode: 404,
+      message: `${label} not found: ${missing.join(', ')}.`,
+    })
+  }
+
+  if (isAdmin) return
+
+  const forbidden = rows.filter(
+    (row) => row.userId !== userId && row.isPublic !== true,
+  )
+
+  if (forbidden.length) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach one or more ${label} records to this Reward.`,
+    })
+  }
+}
+
+export async function assertRewardRelationsAttachable(
   input: RewardRelationExistenceInput,
+  userId: number,
+  isAdmin: boolean,
 ): Promise<void> {
   const characterIds = Array.from(
     new Set([
@@ -347,37 +368,39 @@ export async function assertRewardRelationsExist(
     'artImageId',
   )
 
-  await assertIdsExist(
+  await assertRelationAccessible(
     characterIds,
     (idsIn) =>
       prisma.character.findMany({
         where: { id: { in: idsIn } },
-        select: { id: true },
+        select: { id: true, userId: true, isPublic: true },
       }),
     'Reward Character relation',
+    userId,
+    isAdmin,
   )
 
-  await assertIdsExist(
+  await assertRelationAccessible(
     dreamIds,
     (idsIn) =>
       prisma.dream.findMany({
         where: { id: { in: idsIn } },
-        select: { id: true },
+        select: { id: true, userId: true, isPublic: true },
       }),
     'Reward Dream relation',
+    userId,
+    isAdmin,
   )
 
-  if (typeof artImageId === 'number') {
-    const artImage = await prisma.artImage.findUnique({
-      where: { id: artImageId },
-      select: { id: true },
-    })
-
-    if (!artImage) {
-      throw createError({
-        statusCode: 404,
-        message: `Reward ArtImage relation not found: ${artImageId}.`,
-      })
-    }
-  }
+  await assertRelationAccessible(
+    typeof artImageId === 'number' ? [artImageId] : [],
+    (idsIn) =>
+      prisma.artImage.findMany({
+        where: { id: { in: idsIn } },
+        select: { id: true, userId: true, isPublic: true },
+      }),
+    'Reward ArtImage relation',
+    userId,
+    isAdmin,
+  )
 }

--- a/utils/scripts/verifyRewardMutationInputParity.ts
+++ b/utils/scripts/verifyRewardMutationInputParity.ts
@@ -46,8 +46,13 @@ requireText(
 )
 requireText(
   boundary,
-  'export async function assertRewardRelationsExist',
-  'Reward relation existence check',
+  'export async function assertRewardRelationsAttachable',
+  'Reward relation existence + permission check',
+)
+requireText(
+  boundary,
+  'row.userId !== userId && row.isPublic !== true',
+  'Reward relation permission rule',
 )
 requireText(boundary, 'Unsupported Reward fields in', 'Reward unknown-field error')
 requireText(
@@ -74,12 +79,12 @@ requireText(
   'Reward strict batch allowlist',
 )
 
-// The builders run the existence check before every write, so singular and batch
-// both reject nonexistent relation targets.
+// The builders run the existence + permission check before every write, so
+// singular and batch both reject nonexistent and non-attachable relation targets.
 requireText(
   index,
-  'await assertRewardRelationsExist(input)',
-  'Reward existence check wiring',
+  'await assertRewardRelationsAttachable(input, authenticatedUserId, isAdmin)',
+  'Reward relation check wiring',
 )
 
 // Routes wire the boundary with the correct allowlist.
@@ -116,6 +121,11 @@ requireText(
   cypressSpec,
   'rejects nonexistent relation targets on Reward creation',
   'Reward existence deployed regression',
+)
+requireText(
+  cypressSpec,
+  'forbids attaching another user private Character on Reward creation',
+  'Reward relation permission deployed regression',
 )
 requireText(
   cypressSpec,


### PR DESCRIPTION
## Summary

Phase 2 (relationship safety) for Rewards, extending the existence check added in #579. A non-admin could attach any existing `Character`/`Dream`/`ArtImage` to a Reward — including another user's **private** records.

- replace `assertRewardRelationsExist` with `assertRewardRelationsAttachable`, which keeps the existence check (`404` for missing, same message) and adds a permission check: a non-admin may only connect targets that are **public or self-owned** (`row.userId === caller || row.isPublic === true`); a private, other-owned target now returns `403`. Admins keep the existence check but bypass permission.
- thread the authenticated user id and an `isAdmin` flag through `createReward`, `updateRewardById`, and `createRewardsBatch` so create, PATCH, and batch all gate identically; batch keeps its per-item `207` behavior.
- extend the Reward parity contract and add a deployed cypress regression proving a private, other-owned Character is refused (`403`).

## Why

This mirrors the Dream relation gate (public-or-owned) for the Reward relation targets, closing the gap where any authenticated user could wire another user's private content into a Reward. Public content (the common shared-library case) is unaffected.

## Checks

- Reward Mutation Input Parity (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_