### PR TITLE
animation-manager/t-005: Animation Manager gallery and promotion workspace

### DIFF
--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -1,0 +1,409 @@
+<!-- /components/animation/animation-manager.vue -->
+<template>
+  <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <div
+      v-if="showHeader"
+      class="flex flex-wrap items-center justify-between gap-3 border-b border-base-300 px-4 py-3"
+    >
+      <div class="flex items-center gap-3">
+        <span
+          class="flex h-11 w-11 items-center justify-center rounded-2xl border border-accent/40 bg-accent/10 text-accent"
+        >
+          <Icon name="kind-icon:sparkles" class="h-6 w-6" />
+        </span>
+        <div>
+          <h2 class="text-lg font-black leading-tight text-base-content">
+            Animation Manager
+          </h2>
+          <p class="text-xs text-base-content/60">
+            {{ store.galleryItems.length }} catalog effects &middot;
+            {{ builtCount }} with build history
+          </p>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <NuxtLink
+          to="/screenfx"
+          class="btn btn-outline btn-sm rounded-xl"
+          title="Toggle effects live on-screen"
+        >
+          <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+          Screen FX
+        </NuxtLink>
+        <NuxtLink
+          to="/conductor"
+          class="btn btn-outline btn-sm rounded-xl"
+          title="Pitches and roadmap tasks for this project live in Conductor"
+        >
+          <Icon name="kind-icon:scroll" class="h-4 w-4" />
+          Conductor
+        </NuxtLink>
+        <button
+          class="btn btn-primary btn-sm rounded-xl"
+          type="button"
+          :disabled="refreshing"
+          @click="refresh"
+        >
+          <Icon
+            name="kind-icon:refresh"
+            class="h-4 w-4"
+            :class="{ 'animate-spin': refreshing }"
+          />
+          Refresh
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="flex flex-wrap items-center gap-2 border-b border-base-300 px-4 py-2"
+    >
+      <button
+        class="badge badge-lg cursor-pointer"
+        :class="store.statusFilter === 'ALL' ? 'badge-primary' : 'badge-outline'"
+        type="button"
+        @click="store.statusFilter = 'ALL'"
+      >
+        All ({{ store.galleryItems.length }})
+      </button>
+      <button
+        v-for="status in statusOrder"
+        :key="status"
+        class="badge badge-lg cursor-pointer"
+        :class="
+          store.statusFilter === status
+            ? statusBadgeClass(status)
+            : 'badge-outline'
+        "
+        type="button"
+        @click="
+          store.statusFilter = store.statusFilter === status ? 'ALL' : status
+        "
+      >
+        {{ statusLabels[status] }} ({{ store.statusCounts[status] ?? 0 }})
+      </button>
+
+      <button
+        v-if="store.compareIds.length > 0"
+        class="badge badge-lg badge-secondary ml-auto cursor-pointer"
+        type="button"
+        @click="store.clearCompare()"
+      >
+        Comparing {{ store.compareIds.length }}/2
+        <Icon name="kind-icon:x" class="ml-1 h-3 w-3" />
+      </button>
+    </div>
+
+    <div class="flex min-h-0 flex-1 overflow-hidden">
+      <div
+        class="grid min-h-0 flex-1 auto-rows-min grid-cols-1 gap-3 overflow-y-auto p-4 sm:grid-cols-2 xl:grid-cols-3"
+      >
+        <div
+          v-for="item in store.filteredGalleryItems"
+          :key="item.effect.id"
+          class="flex flex-col gap-3 rounded-2xl border bg-base-200 p-3 transition-shadow hover:shadow-lg"
+          :class="[
+            statusCardBorderClass(item.status),
+            store.selectedSlug === item.effect.id
+              ? 'ring-2 ring-primary'
+              : '',
+          ]"
+        >
+          <div
+            class="flex cursor-pointer items-start gap-3"
+            @click="store.selectSlug(item.effect.id)"
+          >
+            <span
+              class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border"
+              :style="{ borderColor: item.effect.color, color: item.effect.color }"
+            >
+              <Icon :name="item.effect.icon" class="h-6 w-6" />
+            </span>
+
+            <div class="min-w-0 flex-1">
+              <h3 class="truncate font-black text-base-content">
+                {{ item.effect.label }}
+              </h3>
+              <p class="truncate text-xs text-base-content/55">
+                {{ item.effect.id }}
+              </p>
+            </div>
+
+            <span class="badge badge-sm" :class="statusBadgeClass(item.status)">
+              {{ statusLabels[item.status] }}
+            </span>
+          </div>
+
+          <p class="text-xs text-base-content/60">
+            {{ item.attempts.length }}
+            {{ item.attempts.length === 1 ? 'build' : 'builds' }} logged
+            <span v-if="item.latestAttempt">
+              &middot; latest v{{ latestBuildNumber(item) }}
+            </span>
+            <span v-else>&middot; no attempt history yet</span>
+          </p>
+
+          <div v-if="item.live" class="flex flex-wrap items-center gap-2 text-xs">
+            <span v-if="ratingCount(item.live)" class="font-bold text-warning-content">
+              ★ {{ averageRatingLabel(item.live) }}
+              <span class="font-normal text-base-content/45"
+                >({{ ratingCount(item.live) }})</span
+              >
+            </span>
+            <span v-else class="text-base-content/45">No ratings yet</span>
+          </div>
+
+          <div class="mt-auto flex flex-wrap gap-2">
+            <button
+              class="btn btn-xs rounded-lg"
+              type="button"
+              title="Trigger this effect live on screen"
+              @click="store.previewEffect(item.effect.id)"
+            >
+              <Icon name="kind-icon:eye" class="h-3 w-3" />
+              Preview
+            </button>
+            <button
+              class="btn btn-xs rounded-lg"
+              type="button"
+              @click="store.selectSlug(item.effect.id)"
+            >
+              <Icon name="kind-icon:search" class="h-3 w-3" />
+              History
+            </button>
+            <button
+              v-if="item.latestAttempt"
+              class="btn btn-xs rounded-lg"
+              :class="store.isComparing(item.latestAttempt.id) ? 'btn-secondary' : ''"
+              type="button"
+              title="Add latest build to comparison"
+              @click="store.toggleCompare(item.latestAttempt.id)"
+            >
+              <Icon name="kind-icon:copy" class="h-3 w-3" />
+              Compare
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-if="store.filteredGalleryItems.length === 0"
+          class="col-span-full flex flex-col items-center justify-center gap-2 py-12 text-base-content/50"
+        >
+          <Icon name="kind-icon:sparkles" class="h-8 w-8" />
+          <p>No effects match this filter.</p>
+        </div>
+      </div>
+
+      <aside
+        v-if="store.selectedItem || store.compareAttempts.length > 0"
+        class="flex w-full max-w-sm shrink-0 flex-col gap-3 overflow-y-auto border-l border-base-300 bg-base-100 p-4"
+      >
+        <div v-if="store.compareAttempts.length > 0" class="flex flex-col gap-2">
+          <div class="flex items-center justify-between">
+            <h3 class="font-black text-base-content">Compare builds</h3>
+            <button class="btn btn-ghost btn-xs" type="button" @click="store.clearCompare()">
+              <Icon name="kind-icon:x" class="h-4 w-4" />
+            </button>
+          </div>
+          <component-card
+            v-for="attempt in store.compareAttempts"
+            :key="attempt.id"
+            :component="attempt"
+            compact
+            :show-actions="false"
+          />
+        </div>
+
+        <div v-if="store.selectedItem" class="flex flex-col gap-3">
+          <div class="flex items-center justify-between">
+            <h3 class="font-black text-base-content">
+              {{ store.selectedItem.effect.label }} history
+            </h3>
+            <button
+              class="btn btn-ghost btn-xs"
+              type="button"
+              @click="store.selectSlug(null)"
+            >
+              <Icon name="kind-icon:x" class="h-4 w-4" />
+            </button>
+          </div>
+
+          <p class="text-xs text-base-content/60">
+            {{ store.selectedItem.effect.tooltip }}
+          </p>
+
+          <div
+            v-if="store.selectedItem.attempts.length === 0"
+            class="rounded-xl border border-dashed border-base-300 p-3 text-center text-xs text-base-content/50"
+          >
+            No logged build attempts for this effect yet. The next Animation
+            Manager build cycle (animation-manager/t-007) can log one via
+            componentStore.recordAnimationAttempt.
+          </div>
+
+          <div
+            v-for="attempt in reversedAttempts(store.selectedItem)"
+            :key="attempt.id"
+            class="flex flex-col gap-2"
+          >
+            <component-card
+              :component="attempt"
+              compact
+              :show-actions="false"
+            />
+
+            <div class="flex flex-wrap gap-2 pl-1">
+              <button
+                class="btn btn-xs btn-success rounded-lg"
+                type="button"
+                :disabled="getStatus(attempt) === 'WORKING'"
+                @click="store.promoteAttempt(attempt)"
+              >
+                <Icon name="kind-icon:trophy" class="h-3 w-3" />
+                Promote
+              </button>
+              <button
+                class="btn btn-xs btn-warning rounded-lg"
+                type="button"
+                :disabled="getStatus(attempt) === 'UNDER_CONSTRUCTION'"
+                @click="store.sendToConstruction(attempt)"
+              >
+                <Icon name="kind-icon:gearhammer" class="h-3 w-3" />
+                Polish
+              </button>
+              <button
+                class="btn btn-xs btn-outline rounded-lg"
+                type="button"
+                :disabled="getStatus(attempt) === 'RETIRED'"
+                @click="store.retireAttempt(attempt)"
+              >
+                <Icon name="kind-icon:x" class="h-3 w-3" />
+                Retire
+              </button>
+              <button
+                class="btn btn-xs rounded-lg"
+                :class="store.isComparing(attempt.id) ? 'btn-secondary' : 'btn-outline'"
+                type="button"
+                @click="store.toggleCompare(attempt.id)"
+              >
+                <Icon name="kind-icon:copy" class="h-3 w-3" />
+                Compare
+              </button>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+// /components/animation/animation-manager.vue
+import { computed, onMounted, ref } from 'vue'
+import ComponentCard from '@/components/wonderlab/component-card.vue'
+import { useAnimationManagerStore } from '@/stores/animationManagerStore'
+import {
+  getComponentStatus,
+  type ComponentStatus,
+} from '@/utils/wonderlab/componentStatus'
+import type { KindComponent } from '@/stores/componentStore'
+import type { AnimationGalleryItem } from '@/stores/animationManagerStore'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
+
+const store = useAnimationManagerStore()
+const refreshing = ref(false)
+
+const statusOrder: ComponentStatus[] = [
+  'WORKING',
+  'UNDER_CONSTRUCTION',
+  'BROKEN',
+  'NEEDS_CONTEXT',
+  'UNREVIEWED',
+  'PREVIEW_UNSUPPORTED',
+  'RETIRED',
+]
+
+const statusLabels: Record<ComponentStatus, string> = {
+  UNREVIEWED: 'Unreviewed',
+  WORKING: 'Working',
+  NEEDS_CONTEXT: 'Needs context',
+  UNDER_CONSTRUCTION: 'Building',
+  BROKEN: 'Broken',
+  RETIRED: 'Retired',
+  PREVIEW_UNSUPPORTED: 'Preview unsupported',
+}
+
+const builtCount = computed(
+  () => store.galleryItems.filter((item) => item.attempts.length > 0).length,
+)
+
+function statusBadgeClass(status: ComponentStatus): string {
+  switch (status) {
+    case 'BROKEN':
+      return 'badge-error'
+    case 'UNDER_CONSTRUCTION':
+      return 'badge-warning'
+    case 'WORKING':
+      return 'badge-success'
+    case 'NEEDS_CONTEXT':
+      return 'badge-info'
+    case 'PREVIEW_UNSUPPORTED':
+      return 'badge-secondary'
+    default:
+      return 'badge-ghost'
+  }
+}
+
+function statusCardBorderClass(status: ComponentStatus): string {
+  switch (status) {
+    case 'BROKEN':
+      return 'border-error/50'
+    case 'UNDER_CONSTRUCTION':
+      return 'border-warning/50'
+    case 'WORKING':
+      return 'border-success/40'
+    case 'NEEDS_CONTEXT':
+      return 'border-info/45'
+    case 'RETIRED':
+      return 'border-base-300 opacity-70'
+    default:
+      return 'border-base-300'
+  }
+}
+
+function getStatus(attempt: KindComponent): ComponentStatus {
+  return getComponentStatus(attempt)
+}
+
+function latestBuildNumber(item: AnimationGalleryItem): string {
+  const match = /@v(\d+)$/.exec(item.latestAttempt?.componentName ?? '')
+  return match?.[1] ?? '?'
+}
+
+function reversedAttempts(item: AnimationGalleryItem): KindComponent[] {
+  return [...item.attempts].reverse()
+}
+
+function ratingCount(component: KindComponent): number {
+  return Math.max(0, Number(component.ratingCount) || 0)
+}
+
+function averageRatingLabel(component: KindComponent): string {
+  const value = Number(component.averageRating)
+  return Number.isFinite(value) ? value.toFixed(1) : '—'
+}
+
+async function refresh() {
+  refreshing.value = true
+  try {
+    await store.initialize(true)
+  } finally {
+    refreshing.value = false
+  }
+}
+
+onMounted(() => {
+  store.initialize()
+})
+</script>

--- a/components/screenfx/screen-fx.vue
+++ b/components/screenfx/screen-fx.vue
@@ -23,6 +23,10 @@
           <span class="fx-total-label">
             {{ animationStore.effects.length }} effects
           </span>
+          <NuxtLink to="/animation-manager" class="fx-manage-link">
+            <Icon name="kind-icon:trophy" class="h-3.5 w-3.5" />
+            Manage builds
+          </NuxtLink>
         </div>
       </div>
 
@@ -350,6 +354,28 @@ const placementOptions: {
   border: 1px solid color-mix(in srgb, hsl(var(--bc)) 12%, transparent);
   background: color-mix(in srgb, hsl(var(--b3)) 65%, transparent);
   color: color-mix(in srgb, hsl(var(--bc)) 72%, transparent);
+}
+
+.fx-manage-link {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 1px solid color-mix(in srgb, hsl(var(--p)) 42%, transparent);
+  background: color-mix(in srgb, hsl(var(--p)) 14%, transparent);
+  color: hsl(var(--p));
+  transition: background 0.15s ease;
+}
+
+.fx-manage-link:hover {
+  background: color-mix(in srgb, hsl(var(--p)) 26%, transparent);
 }
 
 .fx-zone-section {

--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -31,6 +31,13 @@
       />
     </section>
 
+    <section
+      v-else-if="activeTab === 'animation-manager'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <animation-manager class="h-full min-h-0 flex-1 overflow-hidden" />
+    </section>
+
     <div
       v-else
       class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
@@ -45,16 +52,22 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useNavStore } from '@/stores/navStore'
 
+import AnimationManager from '@/components/animation/animation-manager.vue'
 import LabInteract from '@/components/wonderlab/lab-interact.vue'
 import MemoryDungeon from '@/components/pages/memory-dungeon.vue'
 import ScreenFx from '@/components/screenfx/screen-fx.vue'
 import WonderlabSelectionRouter from '@/components/wonderlab/wonderlab-selection-router.vue'
 
-type LabTab = 'memory-dungeon' | 'wonder-lab' | 'screen-fx'
+type LabTab = 'memory-dungeon' | 'wonder-lab' | 'screen-fx' | 'animation-manager'
 
 const dashboardKey = 'wonder' as const
 const fallbackTab: LabTab = 'wonder-lab'
-const validTabs: LabTab[] = ['memory-dungeon', 'wonder-lab', 'screen-fx']
+const validTabs: LabTab[] = [
+  'memory-dungeon',
+  'wonder-lab',
+  'screen-fx',
+  'animation-manager',
+]
 
 const route = useRoute()
 const navStore = useNavStore()
@@ -67,6 +80,7 @@ const activeTab = computed<LabTab>(() => {
   if (routePath === '/wonderlab') return 'wonder-lab'
   if (routePath === '/memory') return 'memory-dungeon'
   if (routePath === '/screenfx') return 'screen-fx'
+  if (routePath === '/animation-manager') return 'animation-manager'
 
   const selectedTab = navStore.getDashboardTab(dashboardKey)
 

--- a/content/animation-manager.md
+++ b/content/animation-manager.md
@@ -1,0 +1,21 @@
+---
+title: 'Animation Manager'
+room: 'Animation Manager'
+subtitle: 'The Museum of Passive Chaos'
+description: Browse every Screen FX catalog effect, its build history, working/broken state, and Reaction ratings — then preview, compare, promote, polish, or retire a build.
+image: splash/screenfx.png
+tooltip: A gallery and promotion workspace for every Screen FX animation build attempt.
+icon: kind-icon:sparkles
+sort: highlight
+dottiTip: AMI, how do we know which butterfly build actually works?
+amiTip: We don't guess — we log it, rate it, and promote the one that survives contact with reality.
+channelKey: lab
+tabKey: animation-manager
+dashboardKey: wonder
+dashboardTab: animation-manager
+cards: labCards
+loadingMessage: Loading the Animation Manager...
+refreshLabel: Refresh Gallery
+---
+
+:lab-manager

--- a/content/channels/lab/animation-manager.md
+++ b/content/channels/lab/animation-manager.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: animation-manager
+dashboardKey: wonder
+dashboardTab: animation-manager
+label: Anim. Manager
+title: Animation Manager
+subtitle: The museum of passive chaos
+description: Browse every Screen FX catalog effect, its build history, and Reaction ratings, then preview, compare, promote, polish, or retire a build.
+icon: kind-icon:trophy
+route: /animation-manager
+sort: 130
+requiredRole: GUEST
+---
+
+The gallery and promotion workspace for Screen FX build attempts: status, version lineage, and ratings for every effect, one museum row per build.

--- a/stores/animationManagerStore.ts
+++ b/stores/animationManagerStore.ts
@@ -1,0 +1,195 @@
+// /stores/animationManagerStore.ts
+//
+// conductor animation-manager/t-005: view-model layer for the Animation Manager
+// gallery + promotion workspace. Composes the existing componentStore (Component
+// CRUD + the t-004 recordAnimationAttempt convention) and animationStore (live
+// preview trigger) rather than duplicating their API/CRUD logic — this store owns
+// only gallery grouping, selection, comparison, and status-transition actions.
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import type { Component } from '~/prisma/generated/prisma/client'
+import { useComponentStore, type KindComponent } from '@/stores/componentStore'
+import { useAnimationStore } from '@/stores/animationStore'
+import {
+  animationEffects,
+  type AnimationEffect,
+  type AnimationEffectId,
+} from '@/stores/animationCatalog'
+import {
+  ANIMATION_ATTEMPT_FOLDER,
+  listAnimationAttempts,
+  getLatestAnimationAttempt,
+} from '@/stores/helpers/animationComponentHelper'
+import {
+  getComponentStatus,
+  type ComponentStatus,
+} from '@/utils/wonderlab/componentStatus'
+
+export interface AnimationGalleryItem {
+  effect: AnimationEffect
+  live: KindComponent | null
+  attempts: KindComponent[]
+  latestAttempt: KindComponent | null
+  status: ComponentStatus
+}
+
+export type AnimationManagerStatusFilter = ComponentStatus | 'ALL'
+
+export const useAnimationManagerStore = defineStore('animationManagerStore', () => {
+  const componentStore = useComponentStore()
+  const animationStore = useAnimationStore()
+
+  const selectedSlug = ref<AnimationEffectId | null>(null)
+  const compareIds = ref<number[]>([])
+  const statusFilter = ref<AnimationManagerStatusFilter>('ALL')
+
+  const isInitialized = computed(() => componentStore.getIsInitialized)
+
+  async function initialize(force = false) {
+    await componentStore.initialize(force)
+  }
+
+  // The reconciliation scanner (server/api/components/reconcile.post.ts) logs one
+  // undecorated Component row per discovered file -- componentName === catalog id,
+  // no "@vN" suffix. That is the "live" row; the versioned "@vN" rows are the t-004
+  // attempt museum. Both live in the same folderName ('screenfx').
+  function findLiveComponent(effectId: AnimationEffectId): KindComponent | null {
+    return (
+      componentStore.allComponents.find(
+        (component) =>
+          component.folderName === ANIMATION_ATTEMPT_FOLDER &&
+          component.componentName === effectId,
+      ) ?? null
+    )
+  }
+
+  const galleryItems = computed<AnimationGalleryItem[]>(() => {
+    return animationEffects.map((effect) => {
+      const attempts = listAnimationAttempts(componentStore.allComponents, effect.id)
+      const latestAttempt = getLatestAnimationAttempt(
+        componentStore.allComponents,
+        effect.id,
+      )
+      const live = findLiveComponent(effect.id)
+      const statusSource = latestAttempt ?? live
+
+      return {
+        effect,
+        live,
+        attempts,
+        latestAttempt,
+        status: statusSource ? getComponentStatus(statusSource) : 'UNREVIEWED',
+      }
+    })
+  })
+
+  const filteredGalleryItems = computed(() => {
+    if (statusFilter.value === 'ALL') return galleryItems.value
+    return galleryItems.value.filter((item) => item.status === statusFilter.value)
+  })
+
+  const statusCounts = computed(() => {
+    const counts: Partial<Record<ComponentStatus, number>> = {}
+    for (const item of galleryItems.value) {
+      counts[item.status] = (counts[item.status] ?? 0) + 1
+    }
+    return counts
+  })
+
+  const selectedItem = computed<AnimationGalleryItem | null>(() => {
+    if (!selectedSlug.value) return null
+    return galleryItems.value.find((item) => item.effect.id === selectedSlug.value) ?? null
+  })
+
+  const compareAttempts = computed<KindComponent[]>(() =>
+    compareIds.value
+      .map((id) => componentStore.allComponents.find((component) => component.id === id))
+      .filter((component): component is KindComponent => Boolean(component)),
+  )
+
+  function selectSlug(slug: AnimationEffectId | null) {
+    selectedSlug.value = slug
+    compareIds.value = []
+  }
+
+  function toggleCompare(id: number) {
+    const index = compareIds.value.indexOf(id)
+    if (index !== -1) {
+      compareIds.value = compareIds.value.filter((entry) => entry !== id)
+      return
+    }
+
+    // Compare is a two-up view -- drop the oldest pick rather than growing unbounded.
+    const next = [...compareIds.value, id]
+    compareIds.value = next.length > 2 ? next.slice(next.length - 2) : next
+  }
+
+  function isComparing(id: number) {
+    return compareIds.value.includes(id)
+  }
+
+  function clearCompare() {
+    compareIds.value = []
+  }
+
+  function previewEffect(effectId: AnimationEffectId) {
+    animationStore.toggleScreenEffect(effectId)
+  }
+
+  async function setAttemptStatus(
+    attempt: Component,
+    status: ComponentStatus,
+    statusReason: string,
+  ) {
+    return componentStore.updateComponent({
+      ...attempt,
+      status,
+      statusReason,
+    })
+  }
+
+  async function promoteAttempt(attempt: Component) {
+    return setAttemptStatus(
+      attempt,
+      'WORKING',
+      'Promoted from the Animation Manager gallery.',
+    )
+  }
+
+  async function sendToConstruction(attempt: Component) {
+    return setAttemptStatus(
+      attempt,
+      'UNDER_CONSTRUCTION',
+      'Sent back for polish from the Animation Manager gallery.',
+    )
+  }
+
+  async function retireAttempt(attempt: Component) {
+    return setAttemptStatus(
+      attempt,
+      'RETIRED',
+      'Retired from the Animation Manager gallery.',
+    )
+  }
+
+  return {
+    selectedSlug,
+    compareIds,
+    statusFilter,
+    isInitialized,
+    galleryItems,
+    filteredGalleryItems,
+    statusCounts,
+    selectedItem,
+    compareAttempts,
+    initialize,
+    selectSlug,
+    toggleCompare,
+    isComparing,
+    clearCompare,
+    previewEffect,
+    promoteAttempt,
+    sendToConstruction,
+    retireAttempt,
+  }
+})

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -1131,6 +1131,19 @@ export const dashboardConfigs = {
         route: '/screenfx',
       },
       {
+        key: 'animation-manager',
+        label: 'Anim. Manager',
+        icon: 'kind-icon:trophy',
+        title: 'Animation Manager',
+        summary: 'Gallery and promotion workspace for Screen FX build attempts.',
+        image: tabImage('wonder', 'animation-manager'),
+        flourish: '✦',
+        tagline: 'Preview, compare, promote, polish, or retire a build.',
+        narrative:
+          'Every Screen FX catalog effect in one gallery: build history, working/broken state, version lineage, and Reaction ratings, with actions to preview it live, compare builds side by side, and promote, polish, or retire an attempt.',
+        route: '/animation-manager',
+      },
+      {
         key: 'mural',
         label: 'Mural',
         icon: 'kind-icon:paintbrush',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -97,6 +97,12 @@ export const tutorialChannels = {
         image: tutorialImage('games', 'screen-fx'),
       },
       {
+        key: 'animation-manager',
+        title: 'Animation Manager',
+        body: 'The museum of Screen FX build attempts: browse status and ratings for every effect, then preview, compare, promote, polish, or retire a build.',
+        image: tutorialImage('games', 'animation-manager'),
+      },
+      {
         key: 'wonder-lab',
         title: 'WonderLab',
         body: 'A behind-the-scenes look at the components that make up the site and the experiments that are still earning their shoes.',


### PR DESCRIPTION
### Task
animation-manager/t-005: Build the Animation Manager gallery and promotion workspace (kind: software)

### What changed / what I produced
- `stores/animationManagerStore.ts` — new Pinia store (satisfies the task's "use an animationManagerStore" requirement) that composes the existing `componentStore` (Component CRUD + the t-004 `recordAnimationAttempt` convention), `animationStore` (live preview trigger), and `animationCatalog.ts` — no duplicate API/CRUD layer, no second effect registry. Groups every catalog effect with its `@vN` build-attempt history and its "live file" Component row (the reconciliation scanner's undecorated row for the actual `.vue` source), computing status/rating/version lineage per effect.
- `components/animation/animation-manager.vue` — the gallery + promotion workspace: filterable grid of every catalog effect (status badges, build counts, ratings), a detail sidebar showing full version history for the selected effect, and a two-up compare view. Reuses `components/wonderlab/component-card.vue` (already wired to Reaction ratings) rather than building a new card.
- Actions: **Preview** (triggers the effect live via `animationStore.toggleScreenEffect`), **Compare** (pick two build attempts), **Promote** (→ `WORKING`), **Polish** (→ `UNDER_CONSTRUCTION`), **Retire** (→ `RETIRED`) — all as Component status transitions on the underlying attempt row.
- Wired in: `components/wonderlab/lab-manager.vue` (new `animation-manager` tab), `stores/helpers/dashboardHelper.ts` (new tab under the `wonder` dashboard config, route `/animation-manager`), `stores/helpers/tutorialCards.ts` (new section under the `games` tutorial channel), `content/animation-manager.md` (route mount), and a "Manage builds" link added to `components/screenfx/screen-fx.vue`'s header.

### How I verified
- `npm run test` (vue-tsc --noEmit) — clean, 0 errors.
- `npx eslint` on every touched/new file — clean, 0 errors (1 benign "no config for .md" warning on the content file).
- No live DB in this sandbox (see AGENTS.md cross-repo notes), so I could not exercise `initialize()`/the promote/polish/retire actions against real data or take a browser screenshot. The gallery renders an empty-but-correct state (0 attempts logged per effect) until t-007's build loop or a manual `recordAnimationAttempt` call populates real Component rows — left as a live-smoke follow-up once DB/Vercel-preview access is available in a session.

### Stakes
reversible

### Flags for Reviewer
- "Conductor pitch status" (one of the note's requested surfaces) is not deeply wired — there's no existing kind_robots API exposing animation-manager's `PITCHES.yaml` (that file lives in the conductor repo, not synced into any kind_robots model). Rather than fabricate a second source of truth, I added a plain "Conductor" link out to the existing `/conductor` page instead. Flagging in case a Reviewer wants a real per-effect pitch-status wire-up scoped as a separate task.
- Promote doesn't currently auto-supersede/retire a prior `WORKING` build of the same effect — `linkSupersededAnimationAttempt` exists in `componentStore` but I left that wiring for a follow-up rather than guessing at supersession semantics the task note didn't specify.
- Dashboard-tab/tutorial art (`public/images/dashboard-tabs/wonder/animation-manager.webp`, `public/images/tutorials/games/animation-manager.webp`) not generated this pass — falls back to the existing placeholder convention (same as model-builder/t-029's deferred art step).

### Kaizen suggestion
Wire `promoteAttempt` to auto-call `componentStore.linkSupersededAnimationAttempt` against the effect's previous `WORKING` build (if any) before setting the new one, so "promote" always leaves exactly one `WORKING` attempt per effect instead of relying on a human/agent to retire the old one manually.

### Notes for reviewer
This is genuinely greenfield UI on top of already-built data plumbing (t-004's Component/Reaction convention layer) — no schema changes, no new API routes.


---
_Generated by [Claude Code](https://claude.ai/code/session_018p2aYGitKQaauirZrKRuL4)_