### PR TITLE
Gate Scenario relation connects by permission

### DIFF
--- a/.github/workflows/scenario-mutation-input-parity.yml
+++ b/.github/workflows/scenario-mutation-input-parity.yml
@@ -11,6 +11,7 @@ on:
       - 'server/api/scenarios/batch.post.ts'
       - 'server/api/scenarios/batch.patch.ts'
       - 'cypress/e2e/api/scenario-input-boundary.cy.ts'
+      - 'cypress/e2e/api/scenario-relation-permission.cy.ts'
       - 'utils/scripts/verifyScenarioMutationInputParity.ts'
       - '.github/workflows/scenario-mutation-input-parity.yml'
   workflow_dispatch:

--- a/cypress/e2e/api/scenario-relation-permission.cy.ts
+++ b/cypress/e2e/api/scenario-relation-permission.cy.ts
@@ -1,0 +1,145 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type IdRow = { id: number }
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  statusCode?: number
+}
+
+describe('Scenario relation permission gate', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let scenariosUrl = ''
+  let charactersUrl = ''
+  let ownerToken = ''
+  let otherToken = ''
+  let ownerId: number | undefined
+  let otherId: number | undefined
+  let privateCharacterId: number | undefined
+  let publicCharacterId: number | undefined
+  let scenarioId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+  const otherHeaders = () => bearerHeaders(otherToken)
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        scenariosUrl = `${apiBase}/scenarios`
+        charactersUrl = `${apiBase}/characters`
+        return createLoggedInTestUser()
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherToken = other.token
+        otherId = other.id
+
+        return cy
+          .request<ApiResponse<IdRow>>({
+            method: 'POST',
+            url: charactersUrl,
+            headers: otherHeaders(),
+            body: { name: `ScenarioPrivateChar-${stamp}`, isPublic: false },
+          })
+          .then((res) => {
+            expect(res.status, JSON.stringify(res.body)).to.eq(201)
+            privateCharacterId = res.body.data?.id
+            expect(privateCharacterId).to.be.a('number')
+
+            return cy.request<ApiResponse<IdRow>>({
+              method: 'POST',
+              url: charactersUrl,
+              headers: otherHeaders(),
+              body: { name: `ScenarioPublicChar-${stamp}`, isPublic: true },
+            })
+          })
+          .then((res) => {
+            expect(res.status, JSON.stringify(res.body)).to.eq(201)
+            publicCharacterId = res.body.data?.id
+            expect(publicCharacterId).to.be.a('number')
+          })
+      })
+  })
+
+  after(() => {
+    if (scenarioId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${scenariosUrl}/${scenarioId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      })
+    }
+
+    for (const id of [privateCharacterId, publicCharacterId]) {
+      if (id && otherToken) {
+        cy.request({
+          method: 'DELETE',
+          url: `${charactersUrl}/${id}`,
+          headers: otherHeaders(),
+          failOnStatusCode: false,
+        })
+      }
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
+  })
+
+  it('forbids attaching another user private Character on Scenario creation', () => {
+    expect(privateCharacterId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: scenariosUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `PrivateRelationScenario-${stamp}`,
+        characterIds: [privateCharacterId],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('permission to attach')
+    })
+  })
+
+  it('allows attaching a public Character on Scenario creation', () => {
+    expect(publicCharacterId).to.exist
+
+    cy.request<ApiResponse<IdRow>>({
+      method: 'POST',
+      url: scenariosUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `PublicRelationScenario-${stamp}`,
+        characterIds: [publicCharacterId],
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+
+      scenarioId = response.body.data?.id
+      expect(scenarioId).to.be.a('number')
+    })
+  })
+})

--- a/server/api/scenarios/[id].patch.ts
+++ b/server/api/scenarios/[id].patch.ts
@@ -6,6 +6,7 @@ import { validateApiKey } from '../../utils/validateKey'
 import { userIsAdmin } from '../../utils/authUser'
 import {
   assertScenarioMutationInput,
+  assertScenarioRelationsAttachable,
   buildScenarioUpdateInput,
   scenarioPatchFields,
 } from './mutation'
@@ -64,6 +65,8 @@ export default defineEventHandler(async (event) => {
       authenticatedUserId: user.id,
       routeId: id,
     })
+
+    await assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))
 
     const data = await buildScenarioUpdateInput(body)
 

--- a/server/api/scenarios/batch.patch.ts
+++ b/server/api/scenarios/batch.patch.ts
@@ -10,6 +10,7 @@ import { validateApiKey } from '../../utils/validateKey'
 import { userIsAdmin } from '../../utils/authUser'
 import {
   assertScenarioMutationInput,
+  assertScenarioRelationsAttachable,
   buildScenarioUpdateInput,
   SCENARIO_BATCH_LIMIT,
   scenarioBatchPatchFields,
@@ -82,6 +83,8 @@ async function processEntry(
         message: 'No data provided for update.',
       })
     }
+
+    await assertScenarioRelationsAttachable(fields, user.id, userIsAdmin(user))
 
     const data = await buildScenarioUpdateInput(fields)
 

--- a/server/api/scenarios/batch.post.ts
+++ b/server/api/scenarios/batch.post.ts
@@ -3,6 +3,7 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { userIsAdmin } from '@/server/utils/authUser'
 import {
   buildScenarioCreateInput,
   fallbackScenarioTitle,
@@ -13,7 +14,10 @@ import {
   type ScenarioPostInput,
   type SkippedScenario,
 } from './create'
-import { SCENARIO_BATCH_LIMIT } from './mutation'
+import {
+  assertScenarioRelationsAttachable,
+  SCENARIO_BATCH_LIMIT,
+} from './mutation'
 import {
   scenarioMutationSelect,
   type ScenarioMutationResult,
@@ -55,6 +59,12 @@ export default defineEventHandler(async (event) => {
       const fallbackTitle = fallbackScenarioTitle(scenarioData)
 
       try {
+        await assertScenarioRelationsAttachable(
+          scenarioData,
+          user.id,
+          userIsAdmin(user),
+        )
+
         const createInput = await buildScenarioCreateInput(
           scenarioData,
           user.id,

--- a/server/api/scenarios/index.post.ts
+++ b/server/api/scenarios/index.post.ts
@@ -3,11 +3,13 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { userIsAdmin } from '@/server/utils/authUser'
 import {
   buildScenarioCreateInput,
   findExistingScenario,
   type ScenarioPostInput,
 } from './create'
+import { assertScenarioRelationsAttachable } from './mutation'
 import { scenarioMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
@@ -30,6 +32,8 @@ export default defineEventHandler(async (event) => {
           'POST /api/scenarios creates one Scenario. Use /api/scenarios/batch for arrays.',
       })
     }
+
+    await assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))
 
     const createInput = await buildScenarioCreateInput(body, user.id)
     const existingScenario = await findExistingScenario(

--- a/server/api/scenarios/mutation.ts
+++ b/server/api/scenarios/mutation.ts
@@ -550,6 +550,65 @@ function assertFound(
   }
 }
 
+// Permission gate for relation connects: a non-admin may only attach public or
+// self-owned ArtImage/Dream/Character targets. Composes with the existence check
+// (which runs inside the builders) — it only counts rows that exist AND are
+// private AND owned by someone else, so a missing ID falls through to the 404
+// existence check instead of being masked as a 403 here.
+export async function assertScenarioRelationsAttachable(
+  body: {
+    artImageId?: unknown
+    dreamIds?: unknown
+    characterIds?: unknown
+  },
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (isAdmin) return
+
+  const artImageId = normalizeScenarioNullableId(body.artImageId, 'artImageId')
+  const artImageIds = typeof artImageId === 'number' ? [artImageId] : []
+  const dreamIds = normalizeScenarioIdArray(body.dreamIds, 'dreamIds') ?? []
+  const characterIds =
+    normalizeScenarioIdArray(body.characterIds, 'characterIds') ?? []
+
+  const notAttachable = { NOT: { OR: [{ userId }, { isPublic: true }] } }
+
+  const [artForbidden, dreamForbidden, characterForbidden] = await Promise.all([
+    artImageIds.length
+      ? prisma.artImage.count({
+          where: { id: { in: artImageIds }, ...notAttachable },
+        })
+      : 0,
+    dreamIds.length
+      ? prisma.dream.count({
+          where: { id: { in: dreamIds }, ...notAttachable },
+        })
+      : 0,
+    characterIds.length
+      ? prisma.character.count({
+          where: { id: { in: characterIds }, ...notAttachable },
+        })
+      : 0,
+  ])
+
+  const forbiddenLabel =
+    artForbidden > 0
+      ? 'ArtImage'
+      : dreamForbidden > 0
+        ? 'Dream'
+        : characterForbidden > 0
+          ? 'Character'
+          : null
+
+  if (forbiddenLabel) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach one or more ${forbiddenLabel} records to this Scenario.`,
+    })
+  }
+}
+
 export async function assertScenarioRelationsExist(input: {
   artImageId?: number | null
   dreamIds?: number[]

--- a/utils/scripts/verifyScenarioMutationInputParity.ts
+++ b/utils/scripts/verifyScenarioMutationInputParity.ts
@@ -27,6 +27,9 @@ const patchRoute = read('server/api/scenarios/[id].patch.ts')
 const batchCreateRoute = read('server/api/scenarios/batch.post.ts')
 const batchPatchRoute = read('server/api/scenarios/batch.patch.ts')
 const cypressSpec = read('cypress/e2e/api/scenario-input-boundary.cy.ts')
+const permissionSpec = read(
+  'cypress/e2e/api/scenario-relation-permission.cy.ts',
+)
 
 requireText(
   boundary,
@@ -159,6 +162,44 @@ requireText(
   cypressSpec,
   'keeps Scenario batch create and patch imports strict and bounded',
   'Scenario batch deployed regression',
+)
+
+// Phase 2: relation-connect targets must be public or owned by the caller (admins
+// bypass). The gate is wired into create, PATCH, and both batch routes.
+requireText(
+  boundary,
+  'export async function assertScenarioRelationsAttachable',
+  'Scenario relation permission gate',
+)
+requireText(
+  boundary,
+  'NOT: { OR: [{ userId }, { isPublic: true }] }',
+  'Scenario relation permission clause',
+)
+requireText(
+  createRoute,
+  'assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))',
+  'Scenario create relation permission wiring',
+)
+requireText(
+  patchRoute,
+  'assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))',
+  'Scenario patch relation permission wiring',
+)
+requireText(
+  batchCreateRoute,
+  'assertScenarioRelationsAttachable(',
+  'Scenario batch create relation permission wiring',
+)
+requireText(
+  batchPatchRoute,
+  'assertScenarioRelationsAttachable(fields, user.id, userIsAdmin(user))',
+  'Scenario batch patch relation permission wiring',
+)
+requireText(
+  permissionSpec,
+  'forbids attaching another user private Character on Scenario creation',
+  'Scenario relation permission deployed regression',
 )
 
 console.log('Scenario mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Phase 2 (relationship safety) for Scenarios, extending the existence-only `assertScenarioRelationsExist`. A non-admin could attach any existing `ArtImage`/`Dream`/`Character` to a Scenario — including another user's **private** records.

- add `assertScenarioRelationsAttachable`: a permission gate a non-admin must pass to connect relation targets (**public or self-owned**). It composes cleanly with the existing existence check by counting only rows that exist **and** are private **and** owned by someone else — so a missing ID still yields the `404` existence error rather than a masked `403`. Admins bypass.
- wire it into all four mutation routes (create, PATCH, batch create, batch patch) using the caller id and `userIsAdmin(user)`; the batch routes keep their per-item behavior.
- extend the Scenario parity contract and add a deployed cypress regression proving a private, other-owned Character is refused (`403`) and a public one accepted (`201`).

## Why

Mirrors the Dream and Reward relation gates for Scenario's connect targets, closing the gap where any authenticated user could wire another user's private content into a Scenario. Public content (the common shared-library case) is unaffected.

## Checks

- Scenario Mutation Input Parity (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_