### PR TITLE
Gate Character relation connects by permission

### DIFF
--- a/.github/workflows/character-mutation-input-parity.yml
+++ b/.github/workflows/character-mutation-input-parity.yml
@@ -10,6 +10,7 @@ on:
       - 'server/api/characters/[id].patch.ts'
       - 'server/api/characters/batch.post.ts'
       - 'cypress/e2e/api/character-input-boundary.cy.ts'
+      - 'cypress/e2e/api/character-relation-permission.cy.ts'
       - 'utils/scripts/verifyCharacterMutationInputParity.ts'
       - '.github/workflows/character-mutation-input-parity.yml'
   workflow_dispatch:

--- a/cypress/e2e/api/character-relation-permission.cy.ts
+++ b/cypress/e2e/api/character-relation-permission.cy.ts
@@ -1,0 +1,144 @@
+import {
+  bearerHeaders,
+  createLoggedInTestUser,
+  deleteTestUser,
+  getApiEnv,
+} from '../../support/api-auth'
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+type IdRow = { id: number }
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message: string
+  data?: T | null
+  reward?: T | null
+  statusCode?: number
+}
+
+describe('Character relation permission gate', () => {
+  const stamp = Date.now()
+
+  let apiBase = ''
+  let adminToken = ''
+  let charactersUrl = ''
+  let rewardsUrl = ''
+  let ownerToken = ''
+  let otherToken = ''
+  let ownerId: number | undefined
+  let otherId: number | undefined
+  let privateRewardId: number | undefined
+  let publicRewardId: number | undefined
+  let characterId: number | undefined
+
+  const ownerHeaders = () => bearerHeaders(ownerToken)
+  const otherHeaders = () => bearerHeaders(otherToken)
+
+  const createReward = (isPublic: boolean, label: string) =>
+    cy
+      .request<ApiResponse<IdRow>>({
+        method: 'POST',
+        url: rewardsUrl,
+        headers: otherHeaders(),
+        body: { name: `CharRel${label}Reward-${stamp}`, isPublic },
+      })
+      .then((res) => {
+        expect(res.status, JSON.stringify(res.body)).to.eq(201)
+        const reward = res.body.data || res.body.reward
+        expect(reward?.id).to.be.a('number')
+        return reward!.id
+      })
+
+  before(() => {
+    return getApiEnv()
+      .then((env) => {
+        apiBase = env.apiBase
+        adminToken = env.adminToken
+        charactersUrl = `${apiBase}/characters`
+        rewardsUrl = `${apiBase}/rewards`
+        return createLoggedInTestUser()
+      })
+      .then((owner) => {
+        ownerToken = owner.token
+        ownerId = owner.id
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherToken = other.token
+        otherId = other.id
+        return createReward(false, 'Private')
+      })
+      .then((id) => {
+        privateRewardId = id
+        return createReward(true, 'Public')
+      })
+      .then((id) => {
+        publicRewardId = id
+      })
+  })
+
+  after(() => {
+    if (characterId && ownerToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${charactersUrl}/${characterId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      })
+    }
+
+    for (const id of [privateRewardId, publicRewardId]) {
+      if (id && otherToken) {
+        cy.request({
+          method: 'DELETE',
+          url: `${rewardsUrl}/${id}`,
+          headers: otherHeaders(),
+          failOnStatusCode: false,
+        })
+      }
+    }
+
+    deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
+  })
+
+  it('forbids attaching another user private Reward on Character creation', () => {
+    expect(privateRewardId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: charactersUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `PrivateRelationChar-${stamp}`,
+        rewardIds: [privateRewardId],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('permission to attach')
+    })
+  })
+
+  it('allows attaching a public Reward on Character creation', () => {
+    expect(publicRewardId).to.exist
+
+    cy.request<ApiResponse<IdRow>>({
+      method: 'POST',
+      url: charactersUrl,
+      headers: ownerHeaders(),
+      body: {
+        name: `PublicRelationChar-${stamp}`,
+        rewardIds: [publicRewardId],
+      },
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(201)
+      expect(response.body.success).to.eq(true)
+
+      characterId = response.body.data?.id
+      expect(characterId).to.be.a('number')
+    })
+  })
+})

--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -7,6 +7,7 @@ import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueCharacterSlug } from '../../utils/characterSlug'
 import {
   assertCharacterMutationInput,
+  assertCharacterRelationsAttachable,
   buildCharacterUpdateInput,
   normalizeCharacterName,
 } from './mutation'
@@ -75,6 +76,9 @@ export default defineEventHandler(async (event) => {
     assertCharacterPatchCompatibility(rawBody, id, existingCharacter.userId)
 
     const body = stripCharacterCompatibilityFields(rawBody)
+
+    await assertCharacterRelationsAttachable(body, user.id, isAdmin)
+
     const data = await buildCharacterUpdateInput(body)
 
     if (body.name !== undefined) {

--- a/server/api/characters/batch.post.ts
+++ b/server/api/characters/batch.post.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/characterSlug'
 import {
   assertCharacterMutationInput,
+  assertCharacterRelationsAttachable,
   buildCharacterCreateInput,
   CHARACTER_BATCH_LIMIT,
   characterBatchCreateFields,
@@ -172,15 +173,22 @@ export default defineEventHandler(async (event) => {
     }
 
     const slugs = await resolveCharacterSlugs(characters, user.id)
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
     const createInputs = await Promise.all(
-      characters.map((characterData, index) =>
-        buildCharacterCreateInput({
+      characters.map(async (characterData, index) => {
+        await assertCharacterRelationsAttachable(
+          characterData,
+          user.id,
+          isAdmin,
+        )
+
+        return buildCharacterCreateInput({
           rawInput: characterData,
           userId: user.id,
           slug: slugs[index] ?? null,
           batch: true,
-        }),
-      ),
+        })
+      }),
     )
 
     const data = await prisma.$transaction(

--- a/server/api/characters/index.post.ts
+++ b/server/api/characters/index.post.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/characterSlug'
 import {
   assertCharacterMutationInput,
+  assertCharacterRelationsAttachable,
   buildCharacterCreateInput,
   normalizeCharacterName,
 } from './mutation'
@@ -40,6 +41,13 @@ export default defineEventHandler(async (event) => {
     assertCharacterCreateCompatibility(rawBody)
 
     const body = stripCharacterCompatibilityFields(rawBody)
+
+    await assertCharacterRelationsAttachable(
+      body,
+      user.id,
+      user.Role === 'ADMIN' || user.id === 1,
+    )
+
     const name = normalizeCharacterName(body.name)
     const nameKey = getCharacterNameKey(name)
 

--- a/server/api/characters/mutation.ts
+++ b/server/api/characters/mutation.ts
@@ -505,6 +505,93 @@ export async function assertCharacterRelationsExist(input: {
   assertFound(dreamIds, dreams, 'Dream')
 }
 
+// Permission gate for relation connects: a non-admin may only attach public or
+// self-owned ArtImage/Reward/Scenario/Dream targets. Composes with the existence
+// check (which runs inside the builders) — it counts only rows that exist AND are
+// private AND owned by someone else, so a missing ID still yields the 404 existence
+// error rather than a masked 403. Admins bypass. Handles both the direct id-array
+// and batch connect-object relation forms.
+export async function assertCharacterRelationsAttachable(
+  body: {
+    artImageId?: unknown
+    rewardIds?: unknown
+    Rewards?: unknown
+    scenarioIds?: unknown
+    Scenarios?: unknown
+    dreamIds?: unknown
+    Dreams?: unknown
+  },
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (isAdmin) return
+
+  const artImageId = normalizeCharacterNullableId(body.artImageId, 'artImageId')
+  const artImageIds = typeof artImageId === 'number' ? [artImageId] : []
+  const rewardIds = normalizeCharacterRelationIds(
+    body.rewardIds,
+    body.Rewards,
+    'rewardIds',
+    'Rewards',
+  )
+  const scenarioIds = normalizeCharacterRelationIds(
+    body.scenarioIds,
+    body.Scenarios,
+    'scenarioIds',
+    'Scenarios',
+  )
+  const dreamIds = normalizeCharacterRelationIds(
+    body.dreamIds,
+    body.Dreams,
+    'dreamIds',
+    'Dreams',
+  )
+
+  const notAttachable = { NOT: { OR: [{ userId }, { isPublic: true }] } }
+
+  const [artForbidden, rewardForbidden, scenarioForbidden, dreamForbidden] =
+    await Promise.all([
+      artImageIds.length
+        ? prisma.artImage.count({
+            where: { id: { in: artImageIds }, ...notAttachable },
+          })
+        : 0,
+      rewardIds.length
+        ? prisma.reward.count({
+            where: { id: { in: rewardIds }, ...notAttachable },
+          })
+        : 0,
+      scenarioIds.length
+        ? prisma.scenario.count({
+            where: { id: { in: scenarioIds }, ...notAttachable },
+          })
+        : 0,
+      dreamIds.length
+        ? prisma.dream.count({
+            where: { id: { in: dreamIds }, ...notAttachable },
+          })
+        : 0,
+    ])
+
+  const forbiddenLabel =
+    artForbidden > 0
+      ? 'ArtImage'
+      : rewardForbidden > 0
+        ? 'Reward'
+        : scenarioForbidden > 0
+          ? 'Scenario'
+          : dreamForbidden > 0
+            ? 'Dream'
+            : null
+
+  if (forbiddenLabel) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach one or more ${forbiddenLabel} records to this Character.`,
+    })
+  }
+}
+
 export async function buildCharacterCreateInput(options: {
   rawInput: unknown
   userId: number

--- a/utils/scripts/verifyCharacterMutationInputParity.ts
+++ b/utils/scripts/verifyCharacterMutationInputParity.ts
@@ -26,6 +26,9 @@ const createRoute = read('server/api/characters/index.post.ts')
 const patchRoute = read('server/api/characters/[id].patch.ts')
 const batchRoute = read('server/api/characters/batch.post.ts')
 const cypressSpec = read('cypress/e2e/api/character-input-boundary.cy.ts')
+const permissionSpec = read(
+  'cypress/e2e/api/character-relation-permission.cy.ts',
+)
 
 requireText(
   boundary,
@@ -144,6 +147,39 @@ requireText(
   cypressSpec,
   'keeps Character batch imports strict, bounded, and lean',
   'Character batch deployed regression',
+)
+
+// Phase 2: relation-connect targets must be public or owned by the caller (admins
+// bypass). The gate is wired into create, PATCH, and batch routes.
+requireText(
+  boundary,
+  'export async function assertCharacterRelationsAttachable',
+  'Character relation permission gate',
+)
+requireText(
+  boundary,
+  'NOT: { OR: [{ userId }, { isPublic: true }] }',
+  'Character relation permission clause',
+)
+requireText(
+  createRoute,
+  'assertCharacterRelationsAttachable(',
+  'Character create relation permission wiring',
+)
+requireText(
+  patchRoute,
+  'assertCharacterRelationsAttachable(body, user.id, isAdmin)',
+  'Character patch relation permission wiring',
+)
+requireText(
+  batchRoute,
+  'assertCharacterRelationsAttachable(',
+  'Character batch relation permission wiring',
+)
+requireText(
+  permissionSpec,
+  'forbids attaching another user private Reward on Character creation',
+  'Character relation permission deployed regression',
 )
 
 console.log('Character mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Phase 2 (relationship safety) for Characters, extending the existence-only `assertCharacterRelationsExist`. A non-admin could attach any existing `ArtImage`/`Reward`/`Scenario`/`Dream` to a Character — including another user's **private** records.

- add `assertCharacterRelationsAttachable`: a permission gate a non-admin must pass to connect relation targets (**public or self-owned**). It composes with the existing existence check by counting only rows that exist **and** are private **and** owned by someone else, so a missing ID still yields the `404` existence error rather than a masked `403`. Admins bypass. Handles both the direct id-array and batch connect-object relation forms via `normalizeCharacterRelationIds`.
- wire it into the create, PATCH, and batch routes using the caller id and the `isAdmin` idiom (`Role === 'ADMIN' || id === 1`).
- extend the Character parity contract and add a deployed cypress regression proving a private, other-owned Reward is refused (`403`) and a public one accepted (`201`).

## Why

Completes the Phase-2 relation-permission gate across the major relation-bearing families (Dream, Reward, Scenario, Character), closing the gap where any authenticated user could wire another user's private content into a Character. Public content (the common shared-library case) is unaffected.

## Checks

- Character Mutation Input Parity (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_