### PR TITLE
Normalize Todo response envelopes and error status codes

### DIFF
--- a/.github/workflows/todo-mutation-input-parity.yml
+++ b/.github/workflows/todo-mutation-input-parity.yml
@@ -7,6 +7,7 @@ on:
       - 'server/api/todos/mutation.ts'
       - 'server/api/todos/index.post.ts'
       - 'server/api/todos/[id].patch.ts'
+      - 'server/api/todos/[id].delete.ts'
       - 'cypress/e2e/api/todo-input-boundary.cy.ts'
       - 'utils/scripts/verifyTodoMutationInputParity.ts'
       - '.github/workflows/todo-mutation-input-parity.yml'

--- a/server/api/todos/[id].delete.ts
+++ b/server/api/todos/[id].delete.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/[id].delete.ts
-import { defineEventHandler, createError, getRouterParam, H3Error } from 'h3'
+import { defineEventHandler, createError, getRouterParam } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -23,9 +23,22 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 404, message: 'Todo not found' })
     }
 
-    return { success: true, message: 'Todo deleted.' }
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Todo deleted.',
+      data: null,
+      statusCode: 200,
+    }
   } catch (error) {
-    if (error instanceof H3Error) throw error
-    return errorHandler(error)
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to delete Todo.',
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
   }
 })

--- a/server/api/todos/[id].patch.ts
+++ b/server/api/todos/[id].patch.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/[id].patch.ts
-import { defineEventHandler, readBody, createError, getRouterParam, H3Error } from 'h3'
+import { defineEventHandler, readBody, createError, getRouterParam } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -79,9 +79,22 @@ export default defineEventHandler(async (event) => {
       SELECT * FROM \`Todo\` WHERE id = ${id} AND userId = ${userId}
     `
 
-    return { success: true, message: 'Todo updated.', data: updated }
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Todo updated.',
+      data: updated,
+      statusCode: 200,
+    }
   } catch (error) {
-    if (error instanceof H3Error) throw error
-    return errorHandler(error)
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to update Todo.',
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
   }
 })

--- a/server/api/todos/index.post.ts
+++ b/server/api/todos/index.post.ts
@@ -1,5 +1,5 @@
 // /server/api/todos/index.post.ts
-import { createError, defineEventHandler, H3Error, readBody } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
@@ -140,10 +140,13 @@ export default defineEventHandler(async (event) => {
     })
 
     event.node.res.statusCode = 201
-    return { success: true, message: 'Todo created.', data: todo }
+    return {
+      success: true,
+      message: 'Todo created.',
+      data: todo,
+      statusCode: 201,
+    }
   } catch (error) {
-    if (error instanceof H3Error) throw error
-
     const handled = errorHandler(error)
     event.node.res.statusCode = handled.statusCode || 500
 

--- a/utils/scripts/verifyTodoMutationInputParity.ts
+++ b/utils/scripts/verifyTodoMutationInputParity.ts
@@ -14,9 +14,16 @@ function requireText(source: string, text: string, label: string): void {
   }
 }
 
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
 const boundary = read('server/api/todos/mutation.ts')
 const createRoute = read('server/api/todos/index.post.ts')
 const patchRoute = read('server/api/todos/[id].patch.ts')
+const deleteRoute = read('server/api/todos/[id].delete.ts')
 const cypressSpec = read('cypress/e2e/api/todo-input-boundary.cy.ts')
 
 requireText(boundary, 'export const todoMutationFields', 'Todo mutation allowlist')
@@ -43,5 +50,27 @@ requireText(
   'rejects unknown fields on Todo PATCH',
   'Todo patch deployed regression',
 )
+
+// Phase 3: every Todo route returns the standard { success, message, data,
+// statusCode } envelope, and errors no longer re-throw H3Errors as Nuxt's default
+// error shape (which previously bypassed the envelope and left errors at HTTP 200).
+for (const [route, name] of [
+  [createRoute, 'create'],
+  [patchRoute, 'patch'],
+  [deleteRoute, 'delete'],
+] as const) {
+  requireText(route, 'data: null,', `Todo ${name} error envelope data`)
+  requireText(
+    route,
+    'statusCode: event.node.res.statusCode,',
+    `Todo ${name} error envelope statusCode`,
+  )
+  forbidText(
+    route,
+    'if (error instanceof H3Error) throw error',
+    `Todo ${name} H3Error re-throw`,
+  )
+  forbidText(route, 'return errorHandler(error)', `Todo ${name} bare error return`)
+}
 
 console.log('Todo mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Starts Phase 3 (response/error consistency) of the API overhaul (#570) with the worst offender the envelope audit found. The Todo routes re-threw H3Errors (`if (error instanceof H3Error) throw error`), so every `createError`-based 4xx returned Nuxt's default error shape instead of the standard envelope; the PATCH and DELETE catches also fell through to a bare `return errorHandler(error)` that never set `event.node.res.statusCode`, so **non-H3 failures returned HTTP 200**.

- create / PATCH / DELETE now return the standard `{ success, message, data, statusCode }` envelope on success (create `201`, PATCH/DELETE `200`; DELETE gains `data: null`).
- all three catches funnel through `errorHandler`, set `event.node.res.statusCode` to match, and return `{ success: false, message, data: null, statusCode }` — H3Errors included, so 4xx responses now carry the standard envelope **and** the correct HTTP status.
- extend the Todo contract to require the error envelope and forbid the H3Error re-throw / bare error return, and add the delete route to the workflow paths.

## Why

Error responses were inconsistent and, worse, some returned HTTP `200` on failure — clients branching on HTTP status (or on `body.success`) got the wrong signal. This brings Todo in line with the `projects`/`logs` gold-standard envelope.

## Checks

- Todo Mutation Input Parity (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_