### PR TITLE
Normalize DELETE response envelopes

### DIFF
--- a/.github/workflows/delete-response-envelope.yml
+++ b/.github/workflows/delete-response-envelope.yml
@@ -1,0 +1,41 @@
+name: Delete Response Envelope
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/server/[id].delete.ts'
+      - 'server/api/art/collection/[id].delete.ts'
+      - 'server/api/art/image/[id].delete.ts'
+      - 'server/api/themes/[id].delete.ts'
+      - 'server/api/resources/[id].delete.ts'
+      - 'server/api/rewards/[id].delete.ts'
+      - 'server/api/bots/[id].delete.ts'
+      - 'utils/scripts/verifyDeleteResponseEnvelopes.ts'
+      - '.github/workflows/delete-response-envelope.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify delete response envelopes
+        run: npx tsx utils/scripts/verifyDeleteResponseEnvelopes.ts

--- a/server/api/art/collection/[id].delete.ts
+++ b/server/api/art/collection/[id].delete.ts
@@ -41,13 +41,15 @@ export default defineEventHandler(async (event) => {
 
     await prisma.artCollection.delete({ where: { id: collectionId } })
 
+    event.node.res.statusCode = 200
     response = {
       success: true,
       message: isAdmin
         ? `Art Collection with ID ${collectionId} deleted successfully by admin.`
         : `Collection with ID ${collectionId} deleted successfully.`,
+      data: null,
+      statusCode: 200,
     }
-    event.node.res.statusCode = 200
   } catch (error: unknown) {
     const handledError = errorHandler(error)
     event.node.res.statusCode = handledError.statusCode || 500
@@ -56,6 +58,8 @@ export default defineEventHandler(async (event) => {
       message:
         handledError.message ||
         `Failed to delete collection with ID ${collectionId}.`,
+      data: null,
+      statusCode: event.node.res.statusCode,
     }
   }
 

--- a/server/api/art/image/[id].delete.ts
+++ b/server/api/art/image/[id].delete.ts
@@ -71,6 +71,7 @@ export default defineEventHandler(async (event) => {
       message: user.isAdmin
         ? `Art Image with ID ${imageId} deleted successfully by admin.`
         : `Art image ${imageId} deleted successfully.`,
+      data: null,
       statusCode: 200,
     }
   } catch (error: unknown) {
@@ -83,6 +84,7 @@ export default defineEventHandler(async (event) => {
       message:
         handledError.message ||
         `Failed to delete art image with ID ${imageId ?? 'unknown'}.`,
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/server/api/bots/[id].delete.ts
+++ b/server/api/bots/[id].delete.ts
@@ -54,10 +54,13 @@ export default defineEventHandler(async (event) => {
       where: { id },
     })
 
+    event.node.res.statusCode = 200
+
     return {
       success: true,
       message: 'Bot deleted successfully.',
       data: deleted,
+      statusCode: 200,
     }
   } catch (error) {
     const { message, statusCode } = errorHandler(error)

--- a/server/api/resources/[id].delete.ts
+++ b/server/api/resources/[id].delete.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
     response = {
       success: true,
       message: `Resource with ID ${resourceId} successfully deleted.`,
+      data: null,
       statusCode: 200,
     }
     event.node.res.statusCode = 200
@@ -55,6 +56,7 @@ export default defineEventHandler(async (event) => {
       message:
         handledError.message ||
         `Failed to delete resource with ID ${resourceId}.`,
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/server/api/rewards/[id].delete.ts
+++ b/server/api/rewards/[id].delete.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
       message: isAdmin
         ? `Reward entry with ID ${rewardId} deleted successfully by admin.`
         : `Reward with ID ${rewardId} successfully deleted.`,
+      data: null,
       statusCode: 200,
     }
     event.node.res.statusCode = 200
@@ -54,6 +55,7 @@ export default defineEventHandler(async (event) => {
       success: false,
       message:
         handledError.message || `Failed to delete reward with ID ${rewardId}.`,
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/server/api/server/[id].delete.ts
+++ b/server/api/server/[id].delete.ts
@@ -27,9 +27,13 @@ export default defineEventHandler(async (event) => {
       where: { id },
     })
 
+    event.node.res.statusCode = 200
+
     return {
       success: true,
       message: 'Server deleted successfully.',
+      data: null,
+      statusCode: 200,
     }
   } catch (error) {
     const handledError = errorHandler(error)
@@ -38,6 +42,8 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: handledError.message || 'Failed to delete server.',
+      data: null,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/themes/[id].delete.ts
+++ b/server/api/themes/[id].delete.ts
@@ -41,10 +41,20 @@ export default defineEventHandler(async (event) => {
 
     await prisma.theme.delete({ where: { id } })
     event.node.res.statusCode = 200
-    return { success: true, message: `Theme ${id} deleted.` }
+    return {
+      success: true,
+      message: `Theme ${id} deleted.`,
+      data: null,
+      statusCode: 200,
+    }
   } catch (error) {
     const { message, statusCode } = errorHandler(error)
     event.node.res.statusCode = statusCode || 500
-    return { success: false, message }
+    return {
+      success: false,
+      message,
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
   }
 })

--- a/utils/scripts/verifyDeleteResponseEnvelopes.ts
+++ b/utils/scripts/verifyDeleteResponseEnvelopes.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+// Every DELETE route must return the standard { success, message, data, statusCode }
+// envelope on both success and error, setting event.node.res.statusCode to match.
+const deleteRoutes = [
+  'server/api/server/[id].delete.ts',
+  'server/api/art/collection/[id].delete.ts',
+  'server/api/art/image/[id].delete.ts',
+  'server/api/themes/[id].delete.ts',
+  'server/api/resources/[id].delete.ts',
+  'server/api/rewards/[id].delete.ts',
+  'server/api/bots/[id].delete.ts',
+] as const
+
+for (const path of deleteRoutes) {
+  const source = read(path)
+
+  // Success envelope carries an explicit status code.
+  requireText(source, 'statusCode: 200,', `${path} success statusCode`)
+
+  // Error envelope is standard: data: null + statusCode mirrored from the response.
+  requireText(source, 'data: null', `${path} error envelope data`)
+  requireText(
+    source,
+    'statusCode: event.node.res.statusCode,',
+    `${path} error envelope statusCode`,
+  )
+}
+
+console.log('Delete response envelope contract passed.')


### PR DESCRIPTION
## Summary

Phase 3 (response/error consistency). Seven DELETE routes dropped `data` and/or `statusCode` from their success and/or error bodies, diverging from the standard `{ success, message, data, statusCode }` envelope.

- **server, art/collection, themes**: add `data: null` + `statusCode` to both success and catch (and set `event.node.res.statusCode = 200` on success where it was unset).
- **art/image, resources, rewards**: add the missing `data: null` to success and catch.
- **bots**: add `statusCode` (and set `res.statusCode = 200`) on success; its catch was already standard.
- add a cross-cutting `verifyDeleteResponseEnvelopes` contract and a read-only workflow so the delete envelope can't silently regress.

## Why

Response ownership/authorization behavior is unchanged; only the response shape is normalized (deletes carry no row payload, so `data` is `null`). This brings all delete routes in line with the `projects`/`logs`/`chats` gold-standard envelope.

## Checks

- Delete Response Envelope (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_