### PR TITLE
Normalize nested reaction PATCH response envelopes

### DIFF
--- a/.github/workflows/reaction-subpatch-envelope.yml
+++ b/.github/workflows/reaction-subpatch-envelope.yml
@@ -1,0 +1,36 @@
+name: Reaction Sub-Patch Envelope
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/reactions/art/[id].patch.ts'
+      - 'server/api/reactions/dream/[id].patch.ts'
+      - 'utils/scripts/verifyReactionSubPatchEnvelope.ts'
+      - '.github/workflows/reaction-subpatch-envelope.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify reaction sub-patch envelopes
+        run: npx tsx utils/scripts/verifyReactionSubPatchEnvelope.ts

--- a/server/api/reactions/art/[id].patch.ts
+++ b/server/api/reactions/art/[id].patch.ts
@@ -50,10 +50,16 @@ export default defineEventHandler(async (event) => {
           },
         })
 
+    event.node.res.statusCode = existingReaction ? 200 : 201
+
     return {
       success: true,
+      message: existingReaction
+        ? 'Reaction updated successfully.'
+        : 'Reaction created successfully.',
       data: reaction,
       reaction,
+      statusCode: event.node.res.statusCode,
     }
   } catch (error: unknown) {
     const handledError = errorHandler(error)
@@ -61,11 +67,11 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: false,
-      data: {
-        message:
-          handledError.message ||
-          `Failed to update/create reaction for art with ID ${artImageId}.`,
-      },
+      message:
+        handledError.message ||
+        `Failed to update/create reaction for art with ID ${artImageId}.`,
+      data: null,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/reactions/dream/[id].patch.ts
+++ b/server/api/reactions/dream/[id].patch.ts
@@ -120,11 +120,12 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      data: { reaction },
-      reaction,
       message: existingReaction
         ? `Reaction for dream #${dreamId} updated.`
         : `Reaction for dream #${dreamId} created.`,
+      data: reaction,
+      reaction,
+      statusCode: event.node.res.statusCode,
     }
   } catch (error: unknown) {
     const handledError = errorHandler(error)
@@ -132,11 +133,11 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: false,
-      data: {
-        message:
-          handledError.message ||
-          `Failed to update reaction for dream with ID ${dreamId}.`,
-      },
+      message:
+        handledError.message ||
+        `Failed to update reaction for dream with ID ${dreamId}.`,
+      data: null,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/utils/scripts/verifyReactionSubPatchEnvelope.ts
+++ b/utils/scripts/verifyReactionSubPatchEnvelope.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+// The nested art/dream reaction PATCH routes previously returned a broken error
+// shape (data: { message }, no top-level message, no statusCode) and a non-standard
+// success shape. Both now return the standard { success, message, data, statusCode }
+// envelope while keeping the legacy top-level `reaction` alias.
+const routes = [
+  'server/api/reactions/art/[id].patch.ts',
+  'server/api/reactions/dream/[id].patch.ts',
+] as const
+
+for (const path of routes) {
+  const source = read(path)
+
+  requireText(source, 'data: reaction,', `${path} success data is the record`)
+  requireText(source, 'reaction,', `${path} legacy reaction alias preserved`)
+  requireText(
+    source,
+    'statusCode: event.node.res.statusCode,',
+    `${path} envelope statusCode`,
+  )
+  requireText(source, 'data: null,', `${path} error envelope data`)
+  // The old error wrapper put the message inside data.
+  forbidText(source, 'data: {\n        message', `${path} legacy error wrapper`)
+}
+
+console.log('Reaction sub-patch response envelope contract passed.')


### PR DESCRIPTION
## Summary

Phase 3 (response/error consistency). The nested `reactions/art/[id].patch.ts` and `reactions/dream/[id].patch.ts` returned a broken error shape — `data: { message }`, no top-level `message`, no `statusCode` — and a non-standard success shape (art omitted `message`/`statusCode` and never set a create status; dream wrapped the record as `data: { reaction }`).

- both now return the standard `{ success, message, data, statusCode }` envelope; the record is `data`, and the legacy top-level `reaction` alias is kept.
- art now sets `201` on create / `200` on update.
- both catches return `{ success: false, message, data: null, statusCode }`.
- add a `verifyReactionSubPatchEnvelope` contract and a read-only workflow.

These two endpoints have no first-party callers, so the shape change carries no client-breakage risk.

## Checks
- Reaction Sub-Patch Envelope (DB-free contract) — passes locally
- TypeScript Type Check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_