### PR TITLE
conductor/t-072: regression-test the Character.userId nullability class beyond one call site

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Unquoted reserved-word table identifier contract
         run: npm run test:no-unquoted-reserved-word-tables
 
+      - name: Existing-owner-id nullability contract
+        run: npm run test:existing-owner-id-nullability
+
+      - name: Ownership nullability regression contract
+        run: npm run test:ownership-nullability
+
       - name: Capture-group guard checker self-test
         run: npm run test:capture-group-guards-selftest
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
+    "test:existing-owner-id-nullability": "tsx utils/scripts/verifyExistingOwnerIdNullability.ts",
+    "test:ownership-nullability": "tsx utils/scripts/verifyOwnershipNullability.test.ts",
     "test:capture-group-guards": "tsx utils/scripts/verifyCaptureGroupGuards.ts",
     "test:capture-group-guards-selftest": "tsx utils/scripts/verifyCaptureGroupGuards.test.ts",
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",

--- a/server/api/resources/[id].patch.ts
+++ b/server/api/resources/[id].patch.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '../../utils/error'
 import { normalizeSlugInput } from '~/utils/slugify'
 import { validateApiKey } from '../../utils/validateKey'
 import { resourceMutationSelect } from './selects'
+import { assertOwnershipIsUnchanged } from './compatibility'
 import type { Prisma, Resource } from '~/prisma/generated/prisma/client'
 
 type ResourcePatchBody = Partial<Omit<Resource, 'userId'>> &
@@ -25,26 +26,6 @@ function normalizeIdArray(value: unknown): number[] {
         .filter((id) => Number.isInteger(id) && id > 0),
     ),
   ]
-}
-
-function assertOwnershipIsUnchanged(
-  body: Record<string, unknown>,
-  existingUserId: number | null,
-) {
-  if (!Object.prototype.hasOwnProperty.call(body, 'userId')) return
-
-  const requestedUserId = Number(body.userId)
-
-  if (
-    !existingUserId ||
-    !Number.isInteger(requestedUserId) ||
-    requestedUserId !== existingUserId
-  ) {
-    throw createError({
-      statusCode: 400,
-      message: 'Unsupported Resource ownership reassignment. Ownership is server-owned.',
-    })
-  }
 }
 
 function hasUpdateData(data: Record<string, unknown>): boolean {

--- a/server/api/resources/compatibility.ts
+++ b/server/api/resources/compatibility.ts
@@ -1,0 +1,28 @@
+// /server/api/resources/compatibility.ts
+import { createError } from 'h3'
+
+// Pulled out of [id].patch.ts (conductor/t-072) so this pure ownership check
+// -- and its `existingUserId: number | null` contract, since Resource.userId
+// is `Int?` in prisma/schema.prisma -- can be exercised directly in a
+// DB-free regression test without importing the route handler, which pulls
+// in the Prisma client and throws at import time when DATABASE_URL is unset.
+export function assertOwnershipIsUnchanged(
+  body: Record<string, unknown>,
+  existingUserId: number | null,
+) {
+  if (!Object.prototype.hasOwnProperty.call(body, 'userId')) return
+
+  const requestedUserId = Number(body.userId)
+
+  if (
+    !existingUserId ||
+    !Number.isInteger(requestedUserId) ||
+    requestedUserId !== existingUserId
+  ) {
+    throw createError({
+      statusCode: 400,
+      message:
+        'Unsupported Resource ownership reassignment. Ownership is server-owned.',
+    })
+  }
+}

--- a/utils/scripts/verifyExistingOwnerIdNullability.ts
+++ b/utils/scripts/verifyExistingOwnerIdNullability.ts
@@ -1,0 +1,108 @@
+// /utils/scripts/verifyExistingOwnerIdNullability.ts
+//
+// Static companion to verifyOwnershipNullability.test.ts (conductor/t-072).
+// Scans server/api for a parameter named `existing<Something>UserId` or
+// `existing<Something>OwnerId` -- the naming convention this codebase uses
+// for "an existing record's owner id, passed in so a patch handler can
+// reject ownership reassignment" (server/api/characters/compatibility.ts,
+// server/api/resources/compatibility.ts) -- and fails if one is typed as a
+// bare `number` instead of `number | null`. The corresponding Prisma scalar
+// (Character.userId, Resource.userId, ...) is `Int?` in
+// prisma/schema.prisma, so a bare `number` type-checks locally but only
+// breaks once vue-tsc runs against the real generated Prisma types
+// (conductor/t-069, kind_robots PR #575 / #569).
+//
+// Deliberately narrow to the `existing...UserId`/`existing...OwnerId` naming
+// convention rather than every nullable Int field in the schema -- per
+// kind-robots/t-033's discipline, a heuristic this shape-specific stays
+// narrow until a second concrete instance justifies broadening; a
+// schema-wide nullable-Int scan would false-positive on the many
+// `authenticatedUserId`/`callerUserId` parameters that are genuinely
+// non-nullable (sourced from the authenticated session, not a DB row).
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const SCAN_ROOT = join(repositoryRoot, 'server/api')
+
+const EXCLUDED_DIRECTORIES = new Set(['node_modules'])
+
+// Matches `existingUserId: number` / `existingCharacterOwnerId: number,` but
+// not `existingUserId: number | null` (the union is checked separately so
+// the error message can distinguish "missing | null" from "not a param at
+// all", and so `| null | undefined` etc. still pass).
+const PARAM_PATTERN =
+  /\bexisting[A-Za-z]*(?:UserId|OwnerId)\s*:\s*number\b/g
+
+function listSourceFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    if (EXCLUDED_DIRECTORIES.has(entry.name)) continue
+    const path = join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(path))
+      continue
+    }
+
+    if (entry.isFile() && path.endsWith('.ts')) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function main(): void {
+  const files = listSourceFiles(SCAN_ROOT)
+  const errors: string[] = []
+  let matched = 0
+
+  for (const file of files) {
+    const relativeFile = relative(repositoryRoot, file)
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/)
+
+    lines.forEach((line, index) => {
+      const matches = line.match(PARAM_PATTERN)
+      if (!matches) return
+
+      for (const match of matches) {
+        matched += 1
+        const afterMatch = line.slice(
+          line.indexOf(match) + match.length,
+        )
+
+        if (!/^\s*\|\s*null\b/.test(afterMatch)) {
+          errors.push(
+            `${relativeFile}:${index + 1}: "${match.trim()}" is typed as a bare ` +
+              'number, but this codebase\'s existing<Owner>Id convention marks a ' +
+              'value read from an existing record\'s nullable owner column -- type ' +
+              'it `number | null` and narrow at the call site instead (see ' +
+              'server/api/characters/compatibility.ts / ' +
+              'server/api/resources/compatibility.ts).',
+          )
+        }
+      }
+    })
+  }
+
+  if (errors.length) {
+    console.error(
+      `Existing-owner-id nullability contract failed with ${errors.length} error(s):`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Existing-owner-id nullability contract passed: ${files.length} source file(s) ` +
+      `checked, ${matched} existing<Owner>Id parameter(s) all typed \`number | null\`.`,
+  )
+}
+
+main()

--- a/utils/scripts/verifyOwnershipNullability.test.ts
+++ b/utils/scripts/verifyOwnershipNullability.test.ts
@@ -1,0 +1,120 @@
+// /utils/scripts/verifyOwnershipNullability.test.ts
+//
+// Regression test for the Character.userId nullability class of bug
+// (conductor/t-069, kind_robots PR #575): a helper that compares a patch
+// body's requested owner id against an *existing* record's owner id must
+// accept `existing<X>Id: number | null`, because the corresponding Prisma
+// scalar (`Character.userId`, `Resource.userId`, ...) is `Int?` in
+// prisma/schema.prisma -- a legacy/orphaned row can have no owner at all.
+// Typing the parameter as bare `number` type-checks fine locally (the two
+// call sites here always narrow before calling) and only breaks once
+// vue-tsc runs against the real generated Prisma types, so this exercises
+// the real exported functions -- not a reimplementation -- against the
+// `existingUserId: null` case directly, offline and DB-free.
+//
+// conductor/t-072: confirmed via `grep -rn "existing[A-Za-z]*Id"
+// server/api` that these two call sites (characters, resources) are the
+// only "existing<owner>Id" ownership-reassignment guards in the codebase
+// today, and both are already correctly typed `number | null`. Per
+// kind-robots/t-033's discipline (heuristic pattern checks stay narrow
+// until a second concrete instance justifies broadening), no third
+// call site exists yet to add here -- this file's job is to make sure the
+// two that do exist can never silently regress back to a bare `number`.
+//
+// characters/compatibility.ts re-exports its `CharacterMutationInput` type
+// from characters/mutation.ts, which (as a value import, not type-only)
+// pulls in server/utils/prisma.ts at module load -- and that throws
+// synchronously if DATABASE_URL is unset. No prisma query ever actually
+// runs here (PrismaClient connects lazily), so a syntactically valid dummy
+// value is enough; set one before dynamically importing so this stays a
+// true DB-free contract even when CI hasn't set DATABASE_URL itself.
+import assert from 'node:assert/strict'
+
+process.env.DATABASE_URL ??= 'mysql://user:pass@127.0.0.1:3306/kindrobots'
+
+const { assertCharacterCreateCompatibility, assertCharacterPatchCompatibility } =
+  await import('../../server/api/characters/compatibility.js')
+const { assertOwnershipIsUnchanged } = await import(
+  '../../server/api/resources/compatibility.js'
+)
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+// -- Character.userId (Int? in prisma/schema.prisma) --------------------
+
+check(
+  'assertCharacterPatchCompatibility accepts existingUserId: null when the patch does not touch userId',
+  () => {
+    assertCharacterPatchCompatibility({ name: 'Renamed' }, 42, null)
+  },
+)
+
+check(
+  'assertCharacterPatchCompatibility rejects any userId in the patch when existingUserId is null',
+  () => {
+    assert.throws(() => {
+      assertCharacterPatchCompatibility({ userId: 7 }, 42, null)
+    }, /ownership reassignment/)
+  },
+)
+
+check(
+  'assertCharacterPatchCompatibility accepts a userId in the patch that matches a non-null existingUserId',
+  () => {
+    assertCharacterPatchCompatibility({ userId: 7 }, 42, 7)
+  },
+)
+
+check(
+  'assertCharacterCreateCompatibility still requires a positive userId on create (unaffected by the patch-side nullability fix)',
+  () => {
+    assert.throws(() => {
+      assertCharacterCreateCompatibility({ userId: 0 })
+    }, /must be positive/)
+  },
+)
+
+// -- Resource.userId (Int? in prisma/schema.prisma) ----------------------
+
+check(
+  'assertOwnershipIsUnchanged is a no-op when the patch does not touch userId, even with existingUserId: null',
+  () => {
+    assertOwnershipIsUnchanged({ title: 'Renamed' }, null)
+  },
+)
+
+check(
+  'assertOwnershipIsUnchanged rejects any userId in the patch when existingUserId is null',
+  () => {
+    assert.throws(() => {
+      assertOwnershipIsUnchanged({ userId: 7 }, null)
+    }, /ownership reassignment/)
+  },
+)
+
+check(
+  'assertOwnershipIsUnchanged accepts a userId in the patch that matches a non-null existingUserId',
+  () => {
+    assertOwnershipIsUnchanged({ userId: 7 }, 7)
+  },
+)
+
+if (failures > 0) {
+  console.error(
+    `\nOwnership nullability contract failed: ${failures} case(s) did not behave as expected.`,
+  )
+  process.exitCode = 1
+} else {
+  console.log('\nOwnership nullability contract passed: all cases behaved as expected.')
+}


### PR DESCRIPTION
### Task
conductor/t-072: Regression-test the Character.userId nullability class of Prisma-vs-vue-tsc mismatch beyond this one call site (kind: software)

### What changed / what I produced
- Extracted `assertOwnershipIsUnchanged` out of `server/api/resources/[id].patch.ts` into a new `server/api/resources/compatibility.ts`, mirroring the existing `server/api/characters/compatibility.ts` pattern — this makes the pure ownership check importable in a test without transitively loading the Prisma client (`[id].patch.ts` imports `prisma` at module scope, which throws if `DATABASE_URL` is unset).
- `utils/scripts/verifyOwnershipNullability.test.ts` — a DB-free behavioral regression test exercising the real exported functions (not reimplementations) with `existingUserId: null`, for both known `existing<Owner>Id` call sites: `characters/compatibility.ts` and the newly extracted `resources/compatibility.ts`.
- `utils/scripts/verifyExistingOwnerIdNullability.ts` — a static contract scanning `server/api` for any `existing<X>UserId`/`existing<X>OwnerId` parameter typed as a bare `number` instead of `number | null`, so a new call site of this exact shape (the class of bug that broke CI in kind_robots PR #575) fails immediately instead of waiting for `vue-tsc` to run against the real generated Prisma types.
- Wired both into `.github/workflows/contract-tests.yml` and added `npm run test:existing-owner-id-nullability` / `npm run test:ownership-nullability` scripts.

### How I verified
- `npm run test` (full `vue-tsc --noEmit`) — clean.
- `npx eslint` on all changed/new files — clean.
- Both new contract scripts run locally and pass:
  - `verifyExistingOwnerIdNullability.ts`: 375 source files checked, 3 `existing<Owner>Id` parameters found, all correctly `number | null`.
  - `verifyOwnershipNullability.test.ts`: all 7 behavioral cases pass (null-existing-owner accepted when unchanged, rejected when a patch tries to touch it, accepted when it matches).

### Stakes
reversible

### Flags for Reviewer
- Confirmed via `grep -rn "existing[A-Za-z]*Id" server/api` that `characters/compatibility.ts` and `resources/[id].patch.ts` (now `resources/compatibility.ts`) are the *only* two `existing<Owner>Id`-style ownership-reassignment guards in the codebase today, and both were already correctly typed `number | null` — no second live bug instance exists to fix. Per kind-robots/t-033's discipline (heuristic checks stay narrow until a second concrete instance justifies broadening), I scoped the static contract to this specific naming convention rather than scanning every nullable `Int?` field in `prisma/schema.prisma` (there are 100+, and a broad scan would false-positive on the many `authenticatedUserId`/`callerUserId` params that are genuinely non-nullable — sourced from the authenticated session, not a DB row).
- The `resources/[id].patch.ts` extraction is a small, behavior-preserving refactor (same function, same logic, just relocated + exported) done specifically to make it testable DB-free — flagging in case a reviewer wants to double check the diff reads as a pure move.

### Kaizen suggestion
The `existing<Owner>Id` naming convention worked well as a narrow, low-false-positive heuristic. If a third ownership-reassignment guard is added for another entity (dreams, rewards, themes, scenarios — currently these `mutation.ts` files don't have an equivalent), verifying it also gets pulled out into its own prisma-free `compatibility.ts` module (rather than left inline in the route handler) would keep this class of contract test cheap to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2eZ4GutkCmkAtHYF9JadW)_