### PR TITLE
Complete Phase 3 response envelope normalization

### DIFF
--- a/server/api/art/generate.post.ts
+++ b/server/api/art/generate.post.ts
@@ -239,6 +239,7 @@ export default defineEventHandler(async (event) => {
       success: true,
       message: 'ArtImage generated successfully.',
       data: updatedImage,
+      statusCode: 201,
       mana: {
         balance,
         charged: gate.cost,
@@ -251,6 +252,8 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: handledError.message || 'Failed to generate art image.',
+      data: null,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/art/image/[id].patch.ts
+++ b/server/api/art/image/[id].patch.ts
@@ -152,6 +152,7 @@ export default defineEventHandler(async (event) => {
       success: true,
       message: `ArtImage #${id} updated successfully.`,
       data,
+      statusCode: 200,
     }
   } catch (error: unknown) {
     const handled = errorHandler(error)
@@ -161,6 +162,7 @@ export default defineEventHandler(async (event) => {
       success: false,
       message: handled.message || `Failed to update ArtImage #${id}.`,
       data: null,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/art/image/[id]/facets.put.ts
+++ b/server/api/art/image/[id]/facets.put.ts
@@ -57,14 +57,21 @@ export default defineEventHandler(async (event) => {
       }
     })
 
+    event.node.res.statusCode = 200
     return {
       success: true,
       message: 'ArtImage Facets updated.',
       data: facets,
+      statusCode: 200,
     }
   } catch (error) {
     const handled = errorHandler(error)
     event.node.res.statusCode = handled.statusCode ?? 500
-    return { ...handled, statusCode: event.node.res.statusCode }
+    return {
+      success: false,
+      message: handled.message,
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
   }
 })

--- a/server/api/dream-relations/[id].delete.ts
+++ b/server/api/dream-relations/[id].delete.ts
@@ -47,6 +47,6 @@ export default defineEventHandler(async (event) => {
     const handled = errorHandler(error)
     const statusCode = handled.statusCode ?? 500
     event.node.res.statusCode = statusCode
-    return { ...handled, statusCode }
+    return { success: false, message: handled.message, data: null, statusCode }
   }
 })

--- a/server/api/dream-relations/index.post.ts
+++ b/server/api/dream-relations/index.post.ts
@@ -106,6 +106,6 @@ export default defineEventHandler(async (event) => {
     const handled = errorHandler(error)
     const statusCode = handled.statusCode ?? 500
     event.node.res.statusCode = statusCode
-    return { ...handled, statusCode }
+    return { success: false, message: handled.message, data: null, statusCode }
   }
 })

--- a/server/api/dreams/[id]/facets.put.ts
+++ b/server/api/dreams/[id]/facets.put.ts
@@ -56,14 +56,21 @@ export default defineEventHandler(async (event) => {
       }
     })
 
+    event.node.res.statusCode = 200
     return {
       success: true,
       message: 'Dream Facets updated.',
       data: facets,
+      statusCode: 200,
     }
   } catch (error) {
     const handled = errorHandler(error)
     event.node.res.statusCode = handled.statusCode ?? 500
-    return { ...handled, statusCode: event.node.res.statusCode }
+    return {
+      success: false,
+      message: handled.message,
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
   }
 })

--- a/server/api/dreams/batch.post.ts
+++ b/server/api/dreams/batch.post.ts
@@ -288,6 +288,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: handled.message || 'Failed to create dreams batch.',
+      data: null,
       statusCode,
     }
   }

--- a/server/api/rewards/[id].patch.ts
+++ b/server/api/rewards/[id].patch.ts
@@ -100,6 +100,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: message || `Failed to update reward with ID ${rewardId}.`,
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/server/api/rewards/batch.post.ts
+++ b/server/api/rewards/batch.post.ts
@@ -133,6 +133,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: message || 'Failed to create rewards batch.',
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/server/api/rewards/index.post.ts
+++ b/server/api/rewards/index.post.ts
@@ -66,6 +66,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: false,
       message: message || 'Failed to create reward.',
+      data: null,
       statusCode: event.node.res.statusCode,
     }
   }

--- a/server/api/scenarios/[id]/facets.put.ts
+++ b/server/api/scenarios/[id]/facets.put.ts
@@ -55,14 +55,21 @@ export default defineEventHandler(async (event) => {
       }
     })
 
+    event.node.res.statusCode = 200
     return {
       success: true,
       message: 'Scenario Facets updated.',
       data: facets,
+      statusCode: 200,
     }
   } catch (error) {
     const handled = errorHandler(error)
     event.node.res.statusCode = handled.statusCode ?? 500
-    return { ...handled, statusCode: event.node.res.statusCode }
+    return {
+      success: false,
+      message: handled.message,
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
   }
 })


### PR DESCRIPTION
## Summary

Finishes the remaining envelope gaps from the Phase 3 audit — all cosmetic (no HTTP-status or client-shape bugs, unlike the earlier Todo/delete/reaction fixes).

- **art/image/[id].patch.ts, art/generate.post.ts**: add `statusCode` to the success body (and `data: null` + `statusCode` to generate's catch); `art/generate` keeps its `mana` field.
- **the three facet PUTs** (`dreams`, `scenarios`, `art/image`): set `res.statusCode = 200` and add `statusCode` on success; replace the `{ ...handled }` catch with an explicit `{ success: false, message, data: null, statusCode }`.
- **catch bodies gain the missing `data: null`**: rewards create/patch/batch, the dreams batch create, and dream-relations create/delete.

Every mutation route now returns the standard `{ success, message, data, statusCode }` envelope on both success and error.

## Checks

- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests (rewards + dream parity contracts cover the touched routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_