### PR TITLE
Fix missing access checks found in the mutation audit

### DIFF
--- a/.github/workflows/audit-access-checks.yml
+++ b/.github/workflows/audit-access-checks.yml
@@ -1,0 +1,37 @@
+name: Audit Access Checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/bots/threads.post.ts'
+      - 'server/api/bots/topics.post.ts'
+      - 'server/api/prompts/generate.post.ts'
+      - 'utils/scripts/verifyAuditAccessChecks.ts'
+      - '.github/workflows/audit-access-checks.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify audit access checks
+        run: npx tsx utils/scripts/verifyAuditAccessChecks.ts

--- a/server/api/bots/threads.post.ts
+++ b/server/api/bots/threads.post.ts
@@ -50,6 +50,19 @@ export default defineEventHandler(async (event) => {
       }
     }
 
+    // NarratorThread rows are global, non-user-owned content. Match the sibling
+    // transitions/expressions routes: only admins or server keys may write them.
+    const isServerKey = auth.kind === 'server'
+    const isAdmin = auth.user?.Role === 'ADMIN' || auth.user?.id === 1
+    if (!isAdmin && !isServerKey) {
+      event.node.res.statusCode = 403
+      return {
+        success: false,
+        message: 'Only admins or server keys may write narrator threads.',
+        statusCode: 403,
+      }
+    }
+
     const body = (await readBody(event)) as BatchBody
     const threads = Array.isArray(body?.threads) ? body.threads : []
     const dryRun = body?.dryRun === true

--- a/server/api/bots/topics.post.ts
+++ b/server/api/bots/topics.post.ts
@@ -35,6 +35,19 @@ export default defineEventHandler(async (event) => {
       }
     }
 
+    // NarratorTopic rows are global, non-user-owned content. Match the sibling
+    // transitions/expressions routes: only admins or server keys may write them.
+    const isServerKey = auth.kind === 'server'
+    const isAdmin = auth.user?.Role === 'ADMIN' || auth.user?.id === 1
+    if (!isAdmin && !isServerKey) {
+      event.node.res.statusCode = 403
+      return {
+        success: false,
+        message: 'Only admins or server keys may write narrator topics.',
+        statusCode: 403,
+      }
+    }
+
     const body = (await readBody(event)) as BatchBody
     const topics = Array.isArray(body?.topics) ? body.topics : []
     const dryRun = body?.dryRun === true

--- a/server/api/prompts/generate.post.ts
+++ b/server/api/prompts/generate.post.ts
@@ -16,7 +16,7 @@ import { awardKarma } from '../../utils/karma'
 
 export default defineEventHandler(async (event) => {
   try {
-    const { isValid, user } = await validateApiKey(event)
+    const { isValid, user, kind } = await validateApiKey(event)
     if (!isValid || !user) {
       throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
     }
@@ -29,6 +29,18 @@ export default defineEventHandler(async (event) => {
     const prompt = await prisma.prompt.findUnique({ where: { id: body.promptId } })
     if (!prompt) {
       throw createError({ statusCode: 404, statusMessage: 'Prompt not found' })
+    }
+
+    // Only the prompt owner, an admin, or the render relay (server key) may drive
+    // this prompt through the art state machine and rebind its artImageId.
+    const isServerKey = kind === 'server'
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    if (!isAdmin && !isServerKey && prompt.userId !== user.id) {
+      throw createError({
+        statusCode: 403,
+        statusMessage:
+          'You do not have permission to generate art for this prompt.',
+      })
     }
 
     const server = await resolveServer({

--- a/utils/scripts/verifyAuditAccessChecks.ts
+++ b/utils/scripts/verifyAuditAccessChecks.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+// Audit fixes: routes that write global, non-user-owned content (narrator
+// threads/topics) or drive another user's prompt must gate on admin/server-key
+// (or ownership), not merely on a valid API key.
+const threads = read('server/api/bots/threads.post.ts')
+const topics = read('server/api/bots/topics.post.ts')
+const promptGenerate = read('server/api/prompts/generate.post.ts')
+
+for (const [source, name] of [
+  [threads, 'narrator threads'],
+  [topics, 'narrator topics'],
+] as const) {
+  requireText(
+    source,
+    "const isServerKey = auth.kind === 'server'",
+    `${name} server-key check`,
+  )
+  requireText(
+    source,
+    'if (!isAdmin && !isServerKey) {',
+    `${name} admin/server-key gate`,
+  )
+}
+
+requireText(
+  promptGenerate,
+  'if (!isAdmin && !isServerKey && prompt.userId !== user.id) {',
+  'prompt generate ownership gate',
+)
+
+console.log('Audit access-check contract passed.')


### PR DESCRIPTION
## Summary

The Phase 5 thin-resource audit found two routes that granted write access on a valid API key alone, with no ownership or privilege check:

- **`bots/threads.post.ts` and `bots/topics.post.ts`** upsert global, non-user-owned `NarratorThread` / `NarratorTopic` rows but gated only on `auth.isValid` — so **any API key** could create or silently overwrite shared narrator content (title, prompt, openingText, isPublic). Add the same admin-or-server-key gate the sibling `transitions`/`expressions` routes already use (`403`).
- **`prompts/generate.post.ts`** (the deprecated art state-machine driver) loaded a Prompt by id and immediately mutated it (`artStatus`/`serverId`/`artImageId`) with **no ownership check**, letting any authenticated user drive another user's prompt through the state machine. Restrict to the prompt owner, an admin, or the render relay (server key).

Add a DB-free `verifyAuditAccessChecks` contract and a read-only workflow.

## Why

These were the two clear privilege gaps in the audit — write access to global content and cross-user record mutation on nothing more than a valid key. The fixes reuse the existing admin/server-key and owner-check idioms; legitimate paths (admins, the render relay's server key, the prompt owner) are unaffected.

## Checks

- Audit Access Checks (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_