### PR TITLE
conductor-app/t-011: CI guard for conductor write-endpoint auth guards

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -97,6 +97,12 @@ jobs:
       - name: Capture-group guard checker self-test
         run: npm run test:capture-group-guards-selftest
 
+      - name: Conductor API auth-guard checker self-test
+        run: npm run test:conductor-api-auth-guards-selftest
+
+      - name: Conductor API auth-guard contract
+        run: npm run test:conductor-api-auth-guards
+
       - name: Pack manifest validator self-test
         run: npm run test:pack-manifest
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "test:ownership-nullability": "tsx utils/scripts/verifyOwnershipNullability.test.ts",
     "test:capture-group-guards": "tsx utils/scripts/verifyCaptureGroupGuards.ts",
     "test:capture-group-guards-selftest": "tsx utils/scripts/verifyCaptureGroupGuards.test.ts",
+    "test:conductor-api-auth-guards": "tsx utils/scripts/verifyConductorApiAuthGuards.ts",
+    "test:conductor-api-auth-guards-selftest": "tsx utils/scripts/verifyConductorApiAuthGuards.test.ts",
     "test:pack-manifest": "tsx utils/scripts/verifyPackManifest.test.ts",
     "test:pack-scaffold-extraction": "tsx utils/scripts/verifyPackScaffoldExtraction.test.ts",
     "test:parse-mysql-url": "tsx utils/scripts/verifyParseMysqlUrl.ts",

--- a/utils/scripts/verifyConductorApiAuthGuards.test.ts
+++ b/utils/scripts/verifyConductorApiAuthGuards.test.ts
@@ -1,0 +1,151 @@
+// /utils/scripts/verifyConductorApiAuthGuards.test.ts
+//
+// Self-test for verifyConductorApiAuthGuards.ts (conductor-app/t-011).
+// Exercises the real exported detection functions against fixture files in
+// a temp directory -- not a reimplementation of the scan logic -- covering
+// the two legitimate guard shapes (requireAdminApiUser and the manual
+// validateApiKey + userIsAdmin pattern) plus an unguarded file and a
+// read-only (.get.ts) file that must be ignored entirely.
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  fileHasRecognizedAuthGuard,
+  findUnguardedConductorWriteEndpoints,
+  listConductorWriteEndpoints,
+} from './verifyConductorApiAuthGuards.js'
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+check('fileHasRecognizedAuthGuard accepts requireAdminApiUser', () => {
+  assert.equal(
+    fileHasRecognizedAuthGuard(
+      'await requireAdminApiUser(event)\nexport default defineEventHandler(async (event) => {})',
+    ),
+    true,
+  )
+})
+
+check('fileHasRecognizedAuthGuard accepts requireApiUser', () => {
+  assert.equal(
+    fileHasRecognizedAuthGuard('const auth = await requireApiUser(event)'),
+    true,
+  )
+})
+
+check('fileHasRecognizedAuthGuard accepts validateApiKey + userIsAdmin', () => {
+  assert.equal(
+    fileHasRecognizedAuthGuard(
+      'const { isValid, user } = await validateApiKey(event)\nif (!userIsAdmin(user)) throw createError({ statusCode: 403 })',
+    ),
+    true,
+  )
+})
+
+check(
+  'fileHasRecognizedAuthGuard rejects validateApiKey alone with no admin check',
+  () => {
+    assert.equal(
+      fileHasRecognizedAuthGuard(
+        'const { isValid } = await validateApiKey(event)',
+      ),
+      false,
+    )
+  },
+)
+
+check(
+  'fileHasRecognizedAuthGuard rejects a file with no guard call at all',
+  () => {
+    assert.equal(
+      fileHasRecognizedAuthGuard(
+        'export default defineEventHandler(async (event) => { return { ok: true } })',
+      ),
+      false,
+    )
+  },
+)
+
+const fixtureDir = mkdtempSync(join(tmpdir(), 'conductor-api-auth-guard-test-'))
+
+try {
+  writeFileSync(
+    join(fixtureDir, 'guarded.post.ts'),
+    'export default defineEventHandler(async (event) => { await requireAdminApiUser(event) })',
+  )
+  writeFileSync(
+    join(fixtureDir, 'manual-guard.post.ts'),
+    'export default defineEventHandler(async (event) => {\n  const { user } = await validateApiKey(event)\n  if (!userIsAdmin(user)) throw createError({ statusCode: 403 })\n})',
+  )
+  writeFileSync(
+    join(fixtureDir, 'unguarded.post.ts'),
+    'export default defineEventHandler(async (event) => { return { ok: true } })',
+  )
+  writeFileSync(
+    join(fixtureDir, 'unguarded-write.put.ts'),
+    'export default defineEventHandler(async (event) => { return { ok: true } })',
+  )
+  // Read-only endpoints are out of scope for this contract and must be
+  // ignored even though this one has no guard.
+  writeFileSync(
+    join(fixtureDir, 'readonly.get.ts'),
+    'export default defineEventHandler(async () => ({ ok: true }))',
+  )
+
+  check('listConductorWriteEndpoints finds only write-method files', () => {
+    const files = listConductorWriteEndpoints(fixtureDir).map((f) =>
+      f.slice(fixtureDir.length + 1),
+    )
+    assert.deepEqual(files.sort(), [
+      'guarded.post.ts',
+      'manual-guard.post.ts',
+      'unguarded-write.put.ts',
+      'unguarded.post.ts',
+    ])
+  })
+
+  check(
+    'findUnguardedConductorWriteEndpoints flags exactly the two unguarded write files',
+    () => {
+      const unguarded = findUnguardedConductorWriteEndpoints(fixtureDir).map(
+        (f) => f.split('/').pop(),
+      )
+      assert.deepEqual(unguarded.sort(), [
+        'unguarded-write.put.ts',
+        'unguarded.post.ts',
+      ])
+    },
+  )
+
+  check(
+    'listConductorWriteEndpoints on a missing directory returns empty, not a throw',
+    () => {
+      assert.deepEqual(
+        listConductorWriteEndpoints(join(fixtureDir, 'does-not-exist')),
+        [],
+      )
+    },
+  )
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true })
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} failure(s).`)
+  process.exitCode = 1
+} else {
+  console.log('\nAll conductor API auth-guard self-tests passed.')
+}

--- a/utils/scripts/verifyConductorApiAuthGuards.ts
+++ b/utils/scripts/verifyConductorApiAuthGuards.ts
@@ -1,0 +1,98 @@
+// /utils/scripts/verifyConductorApiAuthGuards.ts
+//
+// Regression guard (conductor-app/t-011, kaizen from the kind_robots PR #70
+// security fix): every write endpoint under server/api/conductor/ must call
+// a recognized auth guard before doing work, so a missing guard on a new
+// endpoint is caught in CI instead of by manual audit.
+//
+// Recognized guards:
+//   - requireApiUser / requireAdminApiUser / requireMachineUser
+//     (server/utils/authGuard.ts)
+//   - validateApiKey(...) paired with a userIsAdmin(...) check
+//     (server/utils/validateKey.ts + server/utils/authUser.ts) -- the older
+//     pattern used by art-request.post.ts and curate-request.post.ts. It is
+//     functionally equivalent (same JWT / user-api-key / beta-admin-token
+//     resolution as requireAdminApiUser) so it is accepted, not flagged.
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const CONDUCTOR_API_DIR = join(repositoryRoot, 'server/api/conductor')
+const WRITE_METHOD_SUFFIXES = ['.post.ts', '.put.ts', '.patch.ts', '.delete.ts']
+
+const AUTH_GUARD_CALL_PATTERN =
+  /\b(?:requireApiUser|requireAdminApiUser|requireMachineUser)\s*\(/
+const MANUAL_KEY_CHECK_PATTERN = /\bvalidateApiKey\s*\(/
+const MANUAL_ADMIN_CHECK_PATTERN = /\buserIsAdmin\s*\(/
+
+export function listConductorWriteEndpoints(directory: string): string[] {
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = readdirSync(directory, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  return entries
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        WRITE_METHOD_SUFFIXES.some((suffix) => entry.name.endsWith(suffix)),
+    )
+    .map((entry) => join(directory, entry.name))
+    .sort()
+}
+
+export function fileHasRecognizedAuthGuard(content: string): boolean {
+  if (AUTH_GUARD_CALL_PATTERN.test(content)) return true
+  return (
+    MANUAL_KEY_CHECK_PATTERN.test(content) &&
+    MANUAL_ADMIN_CHECK_PATTERN.test(content)
+  )
+}
+
+export function findUnguardedConductorWriteEndpoints(
+  directory: string,
+): string[] {
+  const files = listConductorWriteEndpoints(directory)
+  const unguarded: string[] = []
+
+  for (const file of files) {
+    const content = readFileSync(file, 'utf8')
+    if (!fileHasRecognizedAuthGuard(content)) {
+      unguarded.push(relative(repositoryRoot, file))
+    }
+  }
+
+  return unguarded
+}
+
+function main(): void {
+  const files = listConductorWriteEndpoints(CONDUCTOR_API_DIR)
+  const unguarded = findUnguardedConductorWriteEndpoints(CONDUCTOR_API_DIR)
+
+  if (unguarded.length) {
+    console.error(
+      `Conductor API auth-guard contract failed: ${unguarded.length} write ` +
+        'endpoint(s) call none of requireApiUser / requireAdminApiUser / ' +
+        'requireMachineUser (server/utils/authGuard.ts), nor the ' +
+        'validateApiKey + userIsAdmin pattern:',
+    )
+    for (const file of unguarded) console.error(`- ${file}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Conductor API auth-guard contract passed: ${files.length} write ` +
+      'endpoint(s) checked under server/api/conductor/, all call a ' +
+      'recognized auth guard.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Task
conductor-app/t-011 (kaizen from the Reviewer on kind_robots PR #70's security fix): add a CI check that fails the build if a `server/api/conductor/*.post.ts` write endpoint doesn't call an auth guard, so a missing guard on a new endpoint is caught in CI instead of by manual audit.

## What changed
- `utils/scripts/verifyConductorApiAuthGuards.ts` — scans `server/api/conductor/` for write-method files (`*.post.ts`, `*.put.ts`, `*.patch.ts`, `*.delete.ts`) and fails if any calls none of the recognized auth guards.
- Recognizes two legitimate guard shapes, not just the two functions the original kaizen note named:
  - `requireApiUser` / `requireAdminApiUser` / `requireMachineUser` (`server/utils/authGuard.ts`)
  - `validateApiKey(...)` paired with a `userIsAdmin(...)` check (`server/utils/validateKey.ts` + `server/utils/authUser.ts`) — the older but functionally-equivalent pattern already used by `art-request.post.ts` and `curate-request.post.ts` (same JWT / user-api-key / beta-admin-token resolution as `requireAdminApiUser`, just not routed through that specific helper). A guard scoped to only the two named functions would have false-flagged both of those real, already-secured endpoints.
- `utils/scripts/verifyConductorApiAuthGuards.test.ts` — self-test against fixture files in a temp dir, covering both guard shapes, an unguarded `.post.ts`, an unguarded `.put.ts`, and a guard-less `.get.ts` that must be ignored (read-only, out of scope).
- Wired into `package.json` (`test:conductor-api-auth-guards`, `test:conductor-api-auth-guards-selftest`) and `.github/workflows/contract-tests.yml`, alongside the other `verify*` contract checks in that job.

## How I verified
- `npm run test:conductor-api-auth-guards` — passes against the real repo (7 write endpoints checked, all guarded).
- `npm run test:conductor-api-auth-guards-selftest` — all 8 self-test cases pass.
- `npx eslint` + `npx prettier --check` on both new files — clean.
- Full `npm run test` (`vue-tsc --noEmit`) — 0 errors.

## Stakes
Reversible — a new CI-only contract check, no runtime code touched.

## Notes for reviewer
No existing endpoint was flagged (the two non-`requireApiUser`-based ones are legitimately guarded via the manual pattern above), so this PR is additive only.


---
_Generated by [Claude Code](https://claude.ai/code/session_014kzwDE9ZNvYrNVgX5y2VPe)_