### PR TITLE
Gate Project relation connects by permission (audit F-2)

### DIFF
--- a/cypress/e2e/api/project-input-boundary.cy.ts
+++ b/cypress/e2e/api/project-input-boundary.cy.ts
@@ -27,11 +27,16 @@ describe('Project mutation input boundary', () => {
   let apiBase = ''
   let adminToken = ''
   let projectsUrl = ''
+  let botsUrl = ''
   let ownerToken = ''
+  let otherToken = ''
   let ownerId: number | undefined
+  let otherId: number | undefined
   let projectId: number | undefined
+  let privateBotId: number | undefined
 
   const ownerHeaders = () => bearerHeaders(ownerToken)
+  const otherHeaders = () => bearerHeaders(otherToken)
 
   before(() => {
     return getApiEnv()
@@ -39,11 +44,31 @@ describe('Project mutation input boundary', () => {
         apiBase = env.apiBase
         adminToken = env.adminToken
         projectsUrl = `${apiBase}/projects`
+        botsUrl = `${apiBase}/bots`
         return createLoggedInTestUser({ fresh: true })
       })
       .then((owner) => {
         ownerToken = owner.token
         ownerId = owner.id
+        return createLoggedInTestUser({ role: 'second' })
+      })
+      .then((other) => {
+        otherToken = other.token
+        otherId = other.id
+
+        // The other user owns one private Bot.
+        return cy
+          .request<ApiResponse<ProjectRow>>({
+            method: 'POST',
+            url: botsUrl,
+            headers: otherHeaders(),
+            body: { name: `ProjectPrivateBot-${stamp}`, isPublic: false },
+          })
+          .then((res) => {
+            expect(res.status, JSON.stringify(res.body)).to.eq(201)
+            privateBotId = res.body.data?.id
+            expect(privateBotId).to.be.a('number')
+          })
       })
   })
 
@@ -59,7 +84,17 @@ describe('Project mutation input boundary', () => {
       })
     }
 
+    if (privateBotId && otherToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${botsUrl}/${privateBotId}`,
+        headers: otherHeaders(),
+        failOnStatusCode: false,
+      })
+    }
+
     deleteTestUser(apiBase, adminToken, ownerId)
+    deleteTestUser(apiBase, adminToken, otherId)
   })
 
   it('creates a Project under the authenticated owner', () => {
@@ -81,6 +116,26 @@ describe('Project mutation input boundary', () => {
 
       projectId = response.body.data?.id
       expect(projectId).to.be.a('number')
+    })
+  })
+
+  it('forbids attaching another user private Bot on Project creation', () => {
+    expect(privateBotId).to.exist
+
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: projectsUrl,
+      headers: ownerHeaders(),
+      body: {
+        title: `PrivateBotProject-${stamp}`,
+        slug: `private-bot-project-${stamp}`,
+        managerBotId: privateBotId,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('permission to attach')
     })
   })
 

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -12,6 +12,7 @@ import { enforceProjectCap } from '~/server/utils/projectCap'
 import { assertJsonObject, assertOnlyFields } from '~/server/utils/chatApi'
 import {
   assertProjectAccess,
+  assertProjectRelationsAttachable,
   getProjectId,
   normalizeNullableDateTime,
   normalizeNullableId,
@@ -50,6 +51,8 @@ export default defineEventHandler(async (event) => {
 
     assertJsonObject(body, 'Project patch payload must be a JSON object.')
     assertOnlyFields(body, projectMutationFields, 'Project')
+
+    await assertProjectRelationsAttachable(body, auth.user.id, auth.isAdmin)
 
     const data: Prisma.ProjectUncheckedUpdateInput = {}
     const nextStatus = projectStatuses.has(body.status as ProjectStatus)

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -12,6 +12,7 @@ import { requireApiUser } from '~/server/utils/authGuard'
 import { enforceProjectCap } from '~/server/utils/projectCap'
 import { assertJsonObject, assertOnlyFields } from '~/server/utils/chatApi'
 import {
+  assertProjectRelationsAttachable,
   normalizeNullableDateTime,
   normalizeNullableId,
   normalizeOptionalText,
@@ -79,6 +80,8 @@ export default defineEventHandler(async (event) => {
 
     assertJsonObject(body, 'Project create payload must be a JSON object.')
     assertOnlyFields(body, projectMutationFields, 'Project')
+
+    await assertProjectRelationsAttachable(body, auth.user.id, auth.isAdmin)
 
     const title = normalizeOptionalText(body?.title)
 

--- a/server/api/projects/index.ts
+++ b/server/api/projects/index.ts
@@ -6,6 +6,7 @@ import type {
   ProjectPriority,
   ProjectStatus,
 } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
 
 export const projectStatuses = new Set<ProjectStatus>([
   'ACTIVE',
@@ -197,4 +198,78 @@ export function assertProjectAccess(
       message: 'You do not have permission to modify this Project.',
     })
   }
+}
+
+async function assertRelationTargetAttachable(
+  id: number | null | undefined,
+  find: (
+    targetId: number,
+  ) => Promise<{ userId: number | null; isPublic: boolean | null } | null>,
+  label: string,
+  userId: number,
+): Promise<void> {
+  if (id === null || id === undefined) return
+
+  const row = await find(id)
+  if (!row) {
+    throw createError({ statusCode: 404, message: `${label} not found: ${id}.` })
+  }
+
+  if (row.userId !== userId && row.isPublic !== true) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach this ${label} to a Project.`,
+    })
+  }
+}
+
+// A non-admin may only connect a manager Bot, ArtImage, or ArtCollection that is
+// public or self-owned. Each is a single nullable scalar FK; admins bypass.
+export async function assertProjectRelationsAttachable(
+  input: {
+    managerBotId?: unknown
+    artImageId?: unknown
+    artCollectionId?: unknown
+  },
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (isAdmin) return
+
+  const managerBotId = normalizeNullableId(input.managerBotId)
+  const artImageId = normalizeNullableId(input.artImageId)
+  const artCollectionId = normalizeNullableId(input.artCollectionId)
+
+  await Promise.all([
+    assertRelationTargetAttachable(
+      managerBotId,
+      (id) =>
+        prisma.bot.findUnique({
+          where: { id },
+          select: { userId: true, isPublic: true },
+        }),
+      'Bot',
+      userId,
+    ),
+    assertRelationTargetAttachable(
+      artImageId,
+      (id) =>
+        prisma.artImage.findUnique({
+          where: { id },
+          select: { userId: true, isPublic: true },
+        }),
+      'ArtImage',
+      userId,
+    ),
+    assertRelationTargetAttachable(
+      artCollectionId,
+      (id) =>
+        prisma.artCollection.findUnique({
+          where: { id },
+          select: { userId: true, isPublic: true },
+        }),
+      'ArtCollection',
+      userId,
+    ),
+  ])
 }

--- a/utils/scripts/verifyProjectMutationInputParity.ts
+++ b/utils/scripts/verifyProjectMutationInputParity.ts
@@ -54,4 +54,32 @@ requireText(
   'Project compatibility deployed regression',
 )
 
+// Phase 2: manager Bot / ArtImage / ArtCollection connect targets must be public
+// or owned by the caller (admins bypass). Gate is shared by create and PATCH.
+requireText(
+  index,
+  'export async function assertProjectRelationsAttachable',
+  'Project relation permission gate',
+)
+requireText(
+  index,
+  'row.userId !== userId && row.isPublic !== true',
+  'Project relation permission rule',
+)
+requireText(
+  createRoute,
+  'assertProjectRelationsAttachable(body, auth.user.id, auth.isAdmin)',
+  'Project create relation permission wiring',
+)
+requireText(
+  patchRoute,
+  'assertProjectRelationsAttachable(body, auth.user.id, auth.isAdmin)',
+  'Project patch relation permission wiring',
+)
+requireText(
+  cypressSpec,
+  'forbids attaching another user private Bot on Project creation',
+  'Project relation permission deployed regression',
+)
+
 console.log('Project mutation input parity contract passed.')


### PR DESCRIPTION
## Summary

Closes audit finding **F-2** for Projects. Create/PATCH connected `managerBotId` / `artImageId` / `artCollectionId` after format validation only — a non-admin could attach another user's **private** Bot, ArtImage, or ArtCollection to a Project.

- add `assertProjectRelationsAttachable`: each connect target must exist and be **public or owned by the caller** (`403` otherwise; missing → `404`); admins bypass.
- wire it into the create and PATCH routes using `auth.user.id` / `auth.isAdmin`.
- extend the Project parity contract and add a deployed cypress regression (owner attaching another user's private Bot → `403`).

## Why

Brings Projects in line with the Dream/Scenario/Character/Reward/Chat relation gates. Public content (the common case) and self-owned targets are unaffected.

## Checks

- Project Mutation Input Parity (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_