### PR TITLE
Gate Bot relation connects by permission (audit F-2)

### DIFF
--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -33,6 +33,11 @@ describe('Bot Management API Tests', () => {
   let userId = 0
   let createdBotId: number | undefined
 
+  // Second user + their private Dream, used to prove relation attach permission.
+  let otherToken = ''
+  let otherId: number | undefined
+  let privateDreamId: number | undefined
+
   const botName = `testbot-${Date.now()}`
 
   before(() => {
@@ -46,6 +51,26 @@ describe('Bot Management API Tests', () => {
       .then((auth) => {
         userToken = auth.token
         userId = auth.id
+        return createLoggedInTestUser({ fresh: true })
+      })
+      .then((other) => {
+        otherToken = other.token
+        otherId = other.id
+
+        return cy
+          .request({
+            method: 'POST',
+            url: `${apiRoot}/dreams`,
+            headers: bearerHeaders(otherToken),
+            body: {
+              title: `PrivateDream-${Date.now()}`,
+              isPublic: false,
+            },
+            failOnStatusCode: false,
+          })
+          .then((response) => {
+            privateDreamId = response.body?.data?.id
+          })
       })
   })
 
@@ -59,7 +84,17 @@ describe('Bot Management API Tests', () => {
       })
     }
 
+    if (privateDreamId && otherToken) {
+      cy.request({
+        method: 'DELETE',
+        url: `${apiRoot}/dreams/${privateDreamId}`,
+        headers: bearerHeaders(otherToken),
+        failOnStatusCode: false,
+      })
+    }
+
     deleteTestUser(apiRoot, adminToken, userId)
+    deleteTestUser(apiRoot, adminToken, otherId)
   })
 
   it('should not allow creating a bot without an authorization token', () => {
@@ -116,6 +151,25 @@ describe('Bot Management API Tests', () => {
       expect(response.status).to.eq(400)
       expect(response.body.success).to.be.false
       expect(response.body.message).to.include('Ownership is server-owned')
+    })
+  })
+
+  it('forbids attaching another user private Dream on Bot creation', () => {
+    expect(privateDreamId, 'privateDreamId').to.be.a('number')
+
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(userToken),
+      body: {
+        name: `${botName}-forbidden-dream`,
+        dreamIds: [privateDreamId],
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(403)
+      expect(response.body.success).to.be.false
+      expect(response.body.message).to.include('permission to attach')
     })
   })
 

--- a/server/api/bots/[id].patch.ts
+++ b/server/api/bots/[id].patch.ts
@@ -7,6 +7,7 @@ import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { botMutationSelect } from './selects'
+import { assertBotRelationsAttachable } from './relations'
 
 type BotPatchBody = Partial<Omit<Bot, 'userId'>> &
   Record<string, unknown> & {
@@ -51,6 +52,23 @@ function getDreamRelationUpdate(
   if (disconnect.length) relation.disconnect = disconnect
 
   return Object.keys(relation).length ? relation : undefined
+}
+
+// Dream IDs that would be newly attached (set + connect). Disconnected IDs are
+// omitted because removing a relation needs no attach permission.
+function getDreamAttachIds(body: BotPatchBody): number[] {
+  const toIds = (value: unknown): number[] =>
+    Array.isArray(value)
+      ? value
+          .map((entry) =>
+            entry && typeof entry === 'object'
+              ? Number((entry as { id?: unknown }).id)
+              : Number(entry),
+          )
+          .filter((id) => Number.isInteger(id) && id > 0)
+      : []
+
+  return [...toIds(body.dreamIds), ...toIds(body.addDreamIds)]
 }
 
 function getBooleanOrUndefined(value: unknown): boolean | undefined {
@@ -172,8 +190,18 @@ export default defineEventHandler(async (event) => {
 
     const serverId = getPositiveIntegerOrUndefined(body.serverId)
     const artImageId = getPositiveIntegerOrUndefined(body.artImageId)
+    const dreamIds = getDreamAttachIds(body)
 
     await assertRelatedRecordsExist({ serverId, artImageId })
+    await assertBotRelationsAttachable(
+      {
+        serverIds: serverId ? [serverId] : [],
+        artImageIds: artImageId ? [artImageId] : [],
+        dreamIds,
+      },
+      user?.id ?? 0,
+      isAdmin || isServerKey,
+    )
 
     let slugUpdate: string | null | undefined
     const requestedSlug = normalizeSlugInput(body.slug)

--- a/server/api/bots/batch.post.ts
+++ b/server/api/bots/batch.post.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
+import { assertBotRelationsAttachable } from './relations'
 
 type BotBatchPatch = Partial<Omit<Bot, 'userId'>> &
   Record<string, unknown> & {
@@ -72,6 +73,23 @@ function getDreamRelationUpdate(
   if (disconnect.length) op.disconnect = disconnect
 
   return Object.keys(op).length ? op : undefined
+}
+
+// Dream IDs a batch entry would newly attach (set + connect). Disconnected IDs
+// are omitted because removing a relation needs no attach permission.
+function getDreamAttachIds(body: BotBatchPatch): number[] {
+  const toIds = (value: unknown): number[] =>
+    Array.isArray(value)
+      ? value
+          .map((item) =>
+            item && typeof item === 'object'
+              ? Number((item as { id?: unknown }).id)
+              : Number(item),
+          )
+          .filter((id) => Number.isInteger(id) && id > 0)
+      : []
+
+  return [...toIds(body.dreamIds), ...toIds(body.addDreamIds)]
 }
 
 function hasUpdateData(data: Record<string, unknown>): boolean {
@@ -285,6 +303,16 @@ export default defineEventHandler(async (event) => {
     ]
 
     await assertRelatedRecordsExist({ serverIds, artImageIds })
+
+    const dreamAttachIds = [
+      ...new Set(bots.flatMap((bot) => getDreamAttachIds(bot))),
+    ]
+
+    await assertBotRelationsAttachable(
+      { serverIds, artImageIds, dreamIds: dreamAttachIds },
+      user?.id ?? 0,
+      isAdmin || isServerKey,
+    )
 
     const updates = bots.map((bot) => {
       const id = getPositiveIntegerOrUndefined(bot.id) as number

--- a/server/api/bots/index.post.ts
+++ b/server/api/bots/index.post.ts
@@ -7,6 +7,7 @@ import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { botMutationSelect } from './selects'
+import { assertBotRelationsAttachable } from './relations'
 
 type BotCreateBody = Partial<Omit<Bot, 'userId'>> &
   Record<string, unknown> & {
@@ -94,7 +95,7 @@ async function assertRelatedRecordsExist(options: {
 
 export default defineEventHandler(async (event) => {
   try {
-    const { user } = await requireApiUser(event)
+    const { user, isAdmin, isServerKey } = await requireApiUser(event)
     const botData = await readBody<BotCreateBody>(event)
 
     if (!botData || typeof botData !== 'object' || Array.isArray(botData)) {
@@ -117,8 +118,19 @@ export default defineEventHandler(async (event) => {
 
     const serverId = getPositiveIntegerOrUndefined(botData.serverId)
     const artImageId = getPositiveIntegerOrUndefined(botData.artImageId)
+    const dreamConnect = getDreamConnect(botData.Dreams ?? botData.dreamIds)
+    const dreamIds = dreamConnect?.connect.map((entry) => entry.id) ?? []
 
     await assertRelatedRecordsExist({ serverId, artImageId })
+    await assertBotRelationsAttachable(
+      {
+        serverIds: serverId ? [serverId] : [],
+        artImageIds: artImageId ? [artImageId] : [],
+        dreamIds,
+      },
+      user.id,
+      isAdmin || isServerKey,
+    )
 
     const requestedSlug = normalizeSlugInput(botData.slug)
     const slug = await getUniqueBotSlug(prisma, requestedSlug ?? name)
@@ -167,7 +179,7 @@ export default defineEventHandler(async (event) => {
             connect: { id: artImageId },
           }
         : undefined,
-      Dreams: getDreamConnect(botData.Dreams ?? botData.dreamIds),
+      Dreams: dreamConnect,
     }
 
     const bot = await prisma.bot.create({

--- a/server/api/bots/relations.ts
+++ b/server/api/bots/relations.ts
@@ -1,0 +1,102 @@
+// /server/api/bots/relations.ts
+import { createError } from 'h3'
+import prisma from '../../utils/prisma'
+
+export const BOT_RELATION_ID_LIMIT = 100
+
+type OwnableRow = { id: number; userId: number | null; isPublic: boolean | null }
+
+export type BotRelationAttachInput = {
+  serverIds?: number[]
+  artImageIds?: number[]
+  dreamIds?: number[]
+}
+
+// Verifies existence (404 for missing) and permission (403 for a private target
+// owned by someone else) for every connect/set relation target on a Bot. A
+// non-admin may only attach public or self-owned rows; admins (and trusted
+// server keys) skip the permission check but still get the existence check.
+// Disconnect (removeDreamIds / null) targets are not checked because
+// disconnecting a missing relation is a no-op.
+async function assertRelationAccessible(
+  ids: number[],
+  find: (idsIn: number[]) => Promise<OwnableRow[]>,
+  label: string,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (!ids.length) return
+
+  const rows = await find(ids)
+  const foundIds = new Set(rows.map((row) => row.id))
+  const missing = ids.filter((id) => !foundIds.has(id))
+
+  if (missing.length) {
+    throw createError({
+      statusCode: 404,
+      message: `${label} not found: ${missing.join(', ')}.`,
+    })
+  }
+
+  if (isAdmin) return
+
+  const forbidden = rows.filter(
+    (row) => row.userId !== userId && row.isPublic !== true,
+  )
+
+  if (forbidden.length) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach one or more ${label} records to this Bot.`,
+    })
+  }
+}
+
+export async function assertBotRelationsAttachable(
+  input: BotRelationAttachInput,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  const dedupe = (ids: number[] = []) =>
+    Array.from(new Set(ids.filter((id) => Number.isInteger(id) && id > 0)))
+
+  const serverIds = dedupe(input.serverIds)
+  const artImageIds = dedupe(input.artImageIds)
+  const dreamIds = dedupe(input.dreamIds)
+
+  await Promise.all([
+    assertRelationAccessible(
+      serverIds,
+      (idsIn) =>
+        prisma.server.findMany({
+          where: { id: { in: idsIn } },
+          select: { id: true, userId: true, isPublic: true },
+        }),
+      'Bot Server relation',
+      userId,
+      isAdmin,
+    ),
+    assertRelationAccessible(
+      artImageIds,
+      (idsIn) =>
+        prisma.artImage.findMany({
+          where: { id: { in: idsIn } },
+          select: { id: true, userId: true, isPublic: true },
+        }),
+      'Bot ArtImage relation',
+      userId,
+      isAdmin,
+    ),
+    assertRelationAccessible(
+      dreamIds,
+      (idsIn) =>
+        prisma.dream.findMany({
+          where: { id: { in: idsIn } },
+          select: { id: true, userId: true, isPublic: true },
+        }),
+      'Bot Dream relation',
+      userId,
+      isAdmin,
+    ),
+  ])
+}

--- a/utils/scripts/verifyBotMutationOwnership.ts
+++ b/utils/scripts/verifyBotMutationOwnership.ts
@@ -23,6 +23,7 @@ function forbidText(source: string, text: string, label: string): void {
 const createRoute = read('server/api/bots/index.post.ts')
 const patchRoute = read('server/api/bots/[id].patch.ts')
 const batchRoute = read('server/api/bots/batch.post.ts')
+const relations = read('server/api/bots/relations.ts')
 const clientHelper = read('stores/helpers/botHelper.ts')
 const cypressSpec = read('cypress/e2e/api/bots.cy.ts')
 
@@ -81,6 +82,39 @@ requireText(
   cypressSpec,
   'rejects ownership reassignment during singular and batch updates',
   'Bot update deployed regression',
+)
+
+// Relation attach permission: every connect/set target (Server, ArtImage, Dream)
+// must exist and be public-or-owned-or-admin before it can be attached.
+requireText(
+  relations,
+  'export async function assertBotRelationsAttachable',
+  'Bot relation attach gate',
+)
+requireText(
+  relations,
+  'row.userId !== userId && row.isPublic !== true',
+  'Bot relation permission predicate',
+)
+requireText(
+  createRoute,
+  'assertBotRelationsAttachable(',
+  'Bot create relation gate wiring',
+)
+requireText(
+  patchRoute,
+  'assertBotRelationsAttachable(',
+  'Bot patch relation gate wiring',
+)
+requireText(
+  batchRoute,
+  'assertBotRelationsAttachable(',
+  'Bot batch relation gate wiring',
+)
+requireText(
+  cypressSpec,
+  'forbids attaching another user private Dream on Bot creation',
+  'Bot relation permission deployed regression',
 )
 
 console.log('Bot mutation ownership contract passed.')


### PR DESCRIPTION
## Summary

Closes audit finding **F-2** for Bots. Create/PATCH/batch connected `serverId` / `artImageId` / `dreamIds` after format + existence validation only — and **Dreams were never even existence-checked** — so a non-admin could attach another user's **private** Server, ArtImage, or Dream to a Bot.

- add `server/api/bots/relations.ts`: `assertBotRelationsAttachable` — every connect/set target must **exist** (`404` if missing) and be **public or owned by the caller** (`403` otherwise); admins and trusted server keys skip the permission check but keep the existence check. Disconnect (`removeDreamIds` / `null`) targets are not checked.
- wire it into the create, PATCH, and batch routes, aggregating attach IDs (set + connect for Dreams) and skipping disconnects.
- extend the Bot ownership contract and add a deployed cypress regression (owner attaching another user's private Dream → `403`).

## Why

Brings Bots in line with the Dream/Scenario/Character/Reward/Project relation gates. Public content (the common case) and self-owned targets are unaffected.

## Checks

- Bot Mutation Ownership (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`, 0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_