### PR TITLE
Convert self-service user PATCH to an explicit allowlist (audit F-3)

### DIFF
--- a/.github/workflows/user-patch-allowlist.yml
+++ b/.github/workflows/user-patch-allowlist.yml
@@ -1,0 +1,36 @@
+name: User Patch Allowlist
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/users/\[id\].patch.ts'
+      - 'cypress/e2e/api/users.cy.ts'
+      - 'utils/scripts/verifyUserPatchAllowlist.ts'
+      - '.github/workflows/user-patch-allowlist.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify User patch allowlist
+        run: npx tsx utils/scripts/verifyUserPatchAllowlist.ts

--- a/cypress/e2e/api/users.cy.ts
+++ b/cypress/e2e/api/users.cy.ts
@@ -230,6 +230,41 @@ describe('User Management API Tests', () => {
           })
         })
     })
+
+    it('ignores privileged fields on self-service update', () => {
+      expect(createdUserId).to.exist
+      expect(createdUserToken).to.be.a('string').and.not.be.empty
+
+      const newBio = `allowlisted-bio-${Date.now()}`
+
+      cy.request({
+        method: 'PATCH',
+        url: `${baseUrl}/${createdUserId}`,
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${createdUserToken}`,
+        },
+        // A self-service caller tries to escalate alongside a legit edit. The
+        // allowlist writes only `bio`; privilege/economy/membership fields are
+        // silently ignored, never persisted.
+        body: {
+          bio: newBio,
+          Role: 'ADMIN',
+          karma: 999999,
+          mana: 999999,
+          isMember: true,
+          isRestricted: false,
+        },
+      }).then((response) => {
+        expect(response.status, JSON.stringify(response.body)).to.eq(200)
+        expect(response.body.success).to.eq(true)
+        expect(response.body.data.bio).to.eq(newBio)
+        expect(response.body.data.Role).to.not.eq('ADMIN')
+        expect(response.body.data.karma).to.not.eq(999999)
+        expect(response.body.data.mana).to.not.eq(999999)
+        expect(response.body.data.isMember).to.eq(false)
+      })
+    })
   })
 
   context('Authentication and Error Handling Tests', () => {

--- a/server/api/users/[id].patch.ts
+++ b/server/api/users/[id].patch.ts
@@ -86,60 +86,120 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'No data provided.' })
     }
 
-    const DENY = new Set([
-      'id',
-      'Role',
-      'role',
-      'karma',
-      'mana',
-      'token',
-      'apiKey',
-      'password',
-      'emailVerified',
-      'stripeCustomerId',
-      'googleId',
+    // Explicit allowlist of self-editable profile + preference columns. Every
+    // other User column is NOT writable through this self-service route and is
+    // silently ignored, so a round-tripped full User object stays compatible
+    // while no privileged column can be set. Deliberately excluded:
+    //   - privilege: Role
+    //   - economy: karma, mana, manaCap, questPoints, clickRecord, matchRecord,
+    //     lastReward, signupBonusGiven, lastManaRefill
+    //   - membership/billing: isMember, memberUntil, stripeCustomerId,
+    //     stripeSubscriptionId, brevoContactId, referralCode
+    //   - moderation: isRestricted, restrictedAt, restrictedById,
+    //     restrictedReason, isActive, isGuest
+    //   - identity/secrets: apiKey, token, password, emailVerified, googleId,
+    //     googleEmail
+    //   - system: id, createdAt, updatedAt, newsletterConfirmedAt
+    // Ownership was verified above (user.id === userId); this route is
+    // owner-only, never admin, so none of the above may be self-granted.
+    const TEXT_FIELDS = new Set([
+      'username',
+      'email',
+      'name',
+      'address1',
+      'address2',
+      'avatarImage',
+      'bio',
+      'city',
+      'country',
+      'state',
+      'phone',
+      'timezone',
+      'languages',
+      'discordUrl',
+      'facebookUrl',
+      'instagramUrl',
+      'kindrobotsUrl',
+      'twitterUrl',
+      'designerName',
+      'artPrompt',
     ])
-
-    const JSONISH = new Set(['vibes', 'artModels', 'textModels', 'blockList'])
-    const BOOLS = new Set(['isPublic', 'showMature', 'customIcons', 'isMember'])
-    const DATES = new Set(['memberUntil'])
-    const IDS = new Set(['artImageId'])
+    const BOOL_FIELDS = new Set([
+      'isPublic',
+      'showMature',
+      'customIcons',
+      'allowFriendRequests',
+      'listInDirectory',
+    ])
+    const JSON_FIELDS = new Set([
+      'vibes',
+      'artModels',
+      'textModels',
+      'blockList',
+      'hiddenServerIds',
+    ])
+    const DATE_FIELDS = new Set(['birthday'])
+    const ID_FIELDS = new Set([
+      'artImageId',
+      'preferredArtServerId',
+      'preferredTextServerId',
+    ])
+    const ENUM_FIELDS: Record<string, Set<string>> = {
+      messagePolicy: new Set(['EVERYONE', 'FRIENDS', 'NONE']),
+      newsletterFrequency: new Set([
+        'NEVER',
+        'SPECIAL',
+        'MONTHLY',
+        'WEEKLY',
+        'DAILY',
+      ]),
+    }
 
     const updateData: Record<string, unknown> = {}
 
     for (const [k, v] of Object.entries(body)) {
-      if (DENY.has(k)) continue
-
       if (k === 'smartBar') {
         updateData[k] = normalizeSmartBar(v)
         continue
       }
 
-      if (IDS.has(k)) {
+      if (ID_FIELDS.has(k)) {
         const id = normalizeOptionalId(v)
         if (id !== undefined) updateData[k] = id
         continue
       }
 
-      if (DATES.has(k)) {
+      if (DATE_FIELDS.has(k)) {
         const d = toDateLike(v)
         if (d) updateData[k] = d
         else if (v == null) updateData[k] = null
         continue
       }
 
-      if (BOOLS.has(k)) {
+      if (BOOL_FIELDS.has(k)) {
         const b = toBooleanLike(v)
         if (b !== undefined) updateData[k] = b
         continue
       }
 
-      if (JSONISH.has(k)) {
+      if (JSON_FIELDS.has(k)) {
         updateData[k] = toStringOrJson(v)
         continue
       }
 
-      updateData[k] = v
+      const enumValues = ENUM_FIELDS[k]
+      if (enumValues) {
+        if (typeof v === 'string' && enumValues.has(v)) updateData[k] = v
+        continue
+      }
+
+      if (TEXT_FIELDS.has(k)) {
+        updateData[k] = v
+        continue
+      }
+
+      // Any other key (system, privilege, economy, moderation, secrets) is not
+      // self-editable and is intentionally ignored.
     }
 
     if (isOversizedAvatarPayload(updateData.avatarImage)) {

--- a/utils/scripts/verifyUserPatchAllowlist.ts
+++ b/utils/scripts/verifyUserPatchAllowlist.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const patchRoute = read('server/api/users/[id].patch.ts')
+const cypressSpec = read('cypress/e2e/api/users.cy.ts')
+
+// The self-service patch derives writes from an explicit allowlist, not a
+// blocklist. The old DENY set (which let every un-denied column through) must
+// be gone, and the loop must no longer end with an unconditional passthrough.
+requireText(patchRoute, 'const TEXT_FIELDS = new Set([', 'User patch allowlist')
+requireText(patchRoute, 'const BOOL_FIELDS = new Set([', 'User patch booleans')
+requireText(patchRoute, 'const ENUM_FIELDS', 'User patch enum validation')
+forbidText(patchRoute, 'const DENY = new Set(', 'User patch blocklist removed')
+
+// Privilege / economy / membership / moderation columns must NOT be listed as
+// self-editable text fields.
+for (const forbidden of [
+  "'Role'",
+  "'karma'",
+  "'mana'",
+  "'isMember'",
+  "'memberUntil'",
+  "'isRestricted'",
+  "'apiKey'",
+  "'password'",
+]) {
+  forbidText(
+    patchRoute,
+    `TEXT_FIELDS = new Set([\n${forbidden}`,
+    'User patch privileged field',
+  )
+}
+
+// Ownership is still verified before any write.
+requireText(
+  patchRoute,
+  'user?.id !== userId',
+  'User patch ownership verification',
+)
+
+// Deployed regression pins the allowlist behavior.
+requireText(
+  cypressSpec,
+  'ignores privileged fields on self-service update',
+  'User patch deployed regression',
+)
+
+console.log('User patch allowlist contract passed.')


### PR DESCRIPTION
## Summary

Closes audit finding **F-3**. `server/api/users/[id].patch.ts` used a **blocklist**: it denied a fixed set of columns (`Role`, `karma`, `mana`, `apiKey`, `password`, …) and wrote **every other** User scalar straight through. Any column not on the deny list was therefore writable by the account owner on their own record — including **`isMember`**, **`memberUntil`**, `questPoints`, `manaCap`, **`isRestricted`**, `signupBonusGiven`, `lastReward`. A user could self-grant membership, extend their own `memberUntil`, or clear their own restriction.

## Changes

- Replace the `DENY` blocklist with explicit self-editable **allowlists** (TEXT / BOOL / JSON / DATE / ID field sets + validated enum fields). Every other column is silently ignored, so a round-tripped full `User` object stays compatible while no privilege / economy / membership / moderation / secret column can be set through this route.
- Validate `messagePolicy` / `newsletterFrequency` against their enum values; normalize `preferredArtServerId` / `preferredTextServerId` as IDs.
- Add a DB-free allowlist contract, a deployed cypress regression (a self update that also tries `Role`/`karma`/`mana`/`isMember` only persists the allowed field), and a path-filtered CI workflow.

Ownership is unchanged — owner-only, verified before any write (`user.id === userId`); this route is never admin.

## Deliberately excluded from self-edit

privilege (`Role`), economy (`karma`, `mana`, `manaCap`, `questPoints`, counters, `lastReward`, `signupBonusGiven`), membership/billing (`isMember`, `memberUntil`, `stripe*`, `referralCode`, `brevoContactId`), moderation (`isRestricted`, `restricted*`, `isActive`, `isGuest`), identity/secrets (`apiKey`, `token`, `password`, `emailVerified`, `google*`), system (`id`, timestamps).

## Checks

- User Patch Allowlist (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`, 0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_