### PR TITLE
Guarantee responsible WonderLab cast representation

### DIFF
--- a/scripts/post-wonderlab-editorial-audit-comment.mjs
+++ b/scripts/post-wonderlab-editorial-audit-comment.mjs
@@ -41,6 +41,7 @@ function reportLines(report) {
 
   const coverage = report.coverage || {}
   const diversity = report.diversity || {}
+  const representation = report.representation || {}
   lines.push(
     `- **Production:** commit \`${report.production?.commit || 'unknown'}\`; deployment \`${report.production?.deploymentId || 'unknown'}\``,
     `- **Assignment mode:** ${report.scope?.assignmentMode || 'unknown'}; repeat-use penalty ${report.scope?.diversityPenalty ?? 'unknown'}`,
@@ -50,14 +51,16 @@ function reportLines(report) {
     `- **Drafted planned slots:** ${coverage.draftedSlots || 0}`,
     `- **Missing planned slots:** ${coverage.missingSlots || 0}`,
     `- **Exhibits with any published planned review:** ${coverage.exhibitsWithPublishedReview || 0} (${coverage.exhibitsWithPublishedReviewRate || 0}%)`,
+    `- **Eligible cast representation:** ${representation.representedReviewers || 0}/${representation.eligibleReviewers || 0} represented; ${representation.meetingTargetReviewers || 0}/${representation.eligibleReviewers || 0} meet the target of ${representation.targetPerReviewer || 0}`,
+    `- **Underrepresented eligible reviewers:** ${representation.underrepresentedReviewerCount || 0}`,
     `- **Published reviewer diversity:** ${diversity.publishedBots || 0} Bot(s), ${diversity.publishedCharacters || 0} Character(s)`,
-    `- **Assigned reviewer diversity:** ${diversity.assignedBots || 0} Bot(s), ${diversity.assignedCharacters || 0} Character(s)`,
+    `- **Assigned reviewer diversity:** ${diversity.assignedBots || 0}/${diversity.eligibleBots || 0} Bot(s), ${diversity.assignedCharacters || 0}/${diversity.eligibleCharacters || 0} Character(s)`,
     `- **Largest reviewer allocation:** ${diversity.largestAssignmentCount || 0} slots (${diversity.largestAssignmentShare || 0}%)`,
     `- **Incomplete assignments:** ${coverage.exhibitsWithIncompleteAssignment || 0} exhibit(s)`,
   )
 
   const top = Array.isArray(report.reviewerUsage)
-    ? report.reviewerUsage.slice(0, 10)
+    ? report.reviewerUsage.filter((reviewer) => reviewer.assigned > 0).slice(0, 10)
     : []
   if (top.length) {
     lines.push('', '### Most-used planned reviewers', '')
@@ -68,11 +71,23 @@ function reportLines(report) {
     }
   }
 
+  const underrepresented = Array.isArray(report.underrepresentedReviewers)
+    ? report.underrepresentedReviewers.slice(0, 10)
+    : []
+  if (underrepresented.length) {
+    lines.push('', '### Cast members needing responsible placements', '')
+    for (const reviewer of underrepresented) {
+      lines.push(
+        `- **${reviewer.name}** (${reviewer.kind} #${reviewer.id}): ${reviewer.count}/${reviewer.target}; ${reviewer.reason}; best score ${reviewer.bestScore ?? 'none'} across ${reviewer.responsibleExhibitCount || 0} responsible exhibit(s)`,
+      )
+    }
+  }
+
   lines.push(
     '',
     `> ${report.scope?.note || 'Coverage reflects portfolio-selected reviewer slots.'}`,
     '',
-    'The uploaded JSON artifact contains the top 50 missing high-affinity assignments and every exhibit without a complete reviewer assignment. This workflow is read-only and performs no generation, approval, editing, or publication.',
+    'The uploaded JSON artifact contains the complete eligible-cast usage table, all representation gaps, the top 50 missing high-affinity assignments, and every exhibit without a complete reviewer assignment. This workflow is read-only and performs no generation, approval, editing, or publication.',
   )
   return lines
 }

--- a/scripts/wonderlab-production-editorial-audit.mjs
+++ b/scripts/wonderlab-production-editorial-audit.mjs
@@ -85,16 +85,16 @@ function responseDataObject(payload, label) {
   return data
 }
 
-function reviewerKey(reviewer) {
-  return `${reviewer.author.kind}:${reviewer.author.id}`
+function reviewerKey(kind, id) {
+  return `${kind}:${id}`
 }
 
-function summarizeReviewerUsage(exhibits) {
+function summarizeSelectedReviewerUsage(exhibits) {
   const usage = new Map()
 
   for (const exhibit of exhibits) {
     for (const reviewer of exhibit.reviewers || []) {
-      const key = reviewerKey(reviewer)
+      const key = reviewerKey(reviewer.author.kind, reviewer.author.id)
       const current = usage.get(key) || {
         key,
         kind: reviewer.author.kind,
@@ -116,18 +116,43 @@ function summarizeReviewerUsage(exhibits) {
     }
   }
 
-  return [...usage.values()]
-    .map((entry) => ({
-      ...entry,
-      averageScore: entry.assigned
-        ? Math.round((entry.scoreTotal / entry.assigned) * 10) / 10
-        : 0,
-    }))
-    .sort((left, right) =>
-      right.assigned - left.assigned ||
-      right.published - left.published ||
-      left.name.localeCompare(right.name),
-    )
+  return [...usage.values()].map((entry) => ({
+    ...entry,
+    averageScore: entry.assigned
+      ? Math.round((entry.scoreTotal / entry.assigned) * 10) / 10
+      : 0,
+  }))
+}
+
+function mergeReviewerUsage(selectedUsage, portfolioUsage) {
+  const selected = new Map(selectedUsage.map((entry) => [entry.key, entry]))
+  const source = Array.isArray(portfolioUsage) ? portfolioUsage : []
+  const rows = source.map((entry) => {
+    const key = reviewerKey(entry.kind, entry.id)
+    const details = selected.get(key)
+    return {
+      key,
+      kind: entry.kind,
+      id: Number(entry.id),
+      name: entry.name,
+      slug: details?.slug || null,
+      assigned: Number(entry.count) || 0,
+      missing: details?.missing || 0,
+      drafted: details?.drafted || 0,
+      published: details?.published || 0,
+      averageScore: details?.averageScore || 0,
+    }
+  })
+
+  for (const entry of selectedUsage) {
+    if (!rows.some((row) => row.key === entry.key)) rows.push(entry)
+  }
+
+  return rows.sort((left, right) =>
+    right.assigned - left.assigned ||
+    right.published - left.published ||
+    left.name.localeCompare(right.name),
+  )
 }
 
 await mkdir(outputDir, { recursive: true })
@@ -163,6 +188,8 @@ const portfolioQuery = new URLSearchParams({
   reviewersPerComponent: '2',
   minimumScore: '0',
   diversityPenalty: '4',
+  minimumAssignmentsPerReviewer: '2',
+  representationMinimumScore: '1',
 })
 const portfolioPayload = await adminRequest(
   `/api/admin/wonderlab/review-portfolio?${portfolioQuery.toString()}`,
@@ -175,6 +202,10 @@ assertCondition(
 assertCondition(
   Array.isArray(portfolioPlan.exhibits),
   'WonderLab review portfolio did not return exhibits.',
+)
+assertCondition(
+  portfolioPlan.representation && typeof portfolioPlan.representation === 'object',
+  'WonderLab review portfolio did not return cast representation evidence.',
 )
 const planExhibits = portfolioPlan.exhibits
 
@@ -209,7 +240,8 @@ const exhibitCoverage = planExhibits.map((exhibit) => {
   }
 })
 
-const reviewerUsage = summarizeReviewerUsage(exhibitCoverage)
+const selectedReviewerUsage = summarizeSelectedReviewerUsage(exhibitCoverage)
+const reviewerUsage = mergeReviewerUsage(selectedReviewerUsage, portfolioPlan.reviewerUsage)
 const reviewerSlots = exhibitCoverage.reduce((total, exhibit) => total + exhibit.reviewerSlots, 0)
 const publishedSlots = exhibitCoverage.reduce((total, exhibit) => total + exhibit.publishedSlots, 0)
 const draftedSlots = exhibitCoverage.reduce((total, exhibit) => total + exhibit.draftedSlots, 0)
@@ -223,12 +255,18 @@ const fullyPublished = exhibitCoverage.filter(
 )
 const withDraft = exhibitCoverage.filter((exhibit) => exhibit.draftedSlots > 0)
 const withoutPublished = exhibitCoverage.filter((exhibit) => exhibit.publishedSlots === 0)
-const assignedBots = reviewerUsage.filter((reviewer) => reviewer.kind === 'BOT')
-const assignedCharacters = reviewerUsage.filter((reviewer) => reviewer.kind === 'CHARACTER')
-const publishedBots = assignedBots.filter((reviewer) => reviewer.published > 0)
-const publishedCharacters = assignedCharacters.filter((reviewer) => reviewer.published > 0)
+const eligibleBots = reviewerUsage.filter((reviewer) => reviewer.kind === 'BOT')
+const eligibleCharacters = reviewerUsage.filter((reviewer) => reviewer.kind === 'CHARACTER')
+const assignedBots = eligibleBots.filter((reviewer) => reviewer.assigned > 0)
+const assignedCharacters = eligibleCharacters.filter((reviewer) => reviewer.assigned > 0)
+const publishedBots = eligibleBots.filter((reviewer) => reviewer.published > 0)
+const publishedCharacters = eligibleCharacters.filter((reviewer) => reviewer.published > 0)
 const largestAssignmentCount = reviewerUsage[0]?.assigned || 0
 const largestAssignmentShare = percentage(largestAssignmentCount, reviewerSlots)
+const representation = portfolioPlan.representation
+const underrepresentedReviewers = Array.isArray(representation.underrepresentedReviewers)
+  ? representation.underrepresentedReviewers
+  : []
 
 const report = {
   generatedAt: new Date().toISOString(),
@@ -245,7 +283,9 @@ const report = {
     reviewersPerComponent: 2,
     minimumAffinity: 0,
     diversityPenalty: Number(portfolioPlan.diversityPenalty) || 4,
-    note: 'Coverage is measured against the deterministic portfolio-selected reviewer slots. Existing published or drafted assignments are pinned when the reviewer remains eligible; new slots apply a repeat-use penalty and prefer Bot/Character contrast.',
+    representationTarget: Number(representation.targetPerReviewer) || 0,
+    representationMinimumScore: Number(representation.minimumScore) || 0,
+    note: 'Coverage is measured against deterministic portfolio-selected reviewer slots. Existing published or drafted assignments remain pinned; responsible cast representation floors reserve each eligible voice\'s best grounded placements before repeat-use balancing fills the remaining slots.',
   },
   componentStatuses: Object.fromEntries([...statusCounts.entries()].sort()),
   coverage: {
@@ -265,6 +305,8 @@ const report = {
     exhibitsWithIncompleteAssignment: incompleteAssignments.length,
   },
   diversity: {
+    eligibleBots: eligibleBots.length,
+    eligibleCharacters: eligibleCharacters.length,
     assignedBots: assignedBots.length,
     assignedCharacters: assignedCharacters.length,
     publishedBots: publishedBots.length,
@@ -272,7 +314,16 @@ const report = {
     largestAssignmentCount,
     largestAssignmentShare,
   },
+  representation: {
+    targetPerReviewer: Number(representation.targetPerReviewer) || 0,
+    minimumScore: Number(representation.minimumScore) || 0,
+    eligibleReviewers: Number(representation.eligibleReviewers) || 0,
+    representedReviewers: Number(representation.representedReviewers) || 0,
+    meetingTargetReviewers: Number(representation.meetingTargetReviewers) || 0,
+    underrepresentedReviewerCount: underrepresentedReviewers.length,
+  },
   reviewerUsage,
+  underrepresentedReviewers,
   priorityMissingAssignments: exhibitCoverage
     .flatMap((exhibit) =>
       exhibit.reviewers
@@ -324,8 +375,8 @@ console.log(
   `WonderLab editorial audit: ${publishedSlots}/${reviewerSlots} planned slots published (${report.coverage.publishedSlotRate}%).`,
 )
 console.log(
-  `Published reviewer diversity: ${publishedBots.length} Bot(s), ${publishedCharacters.length} Character(s).`,
+  `Cast representation: ${report.representation.meetingTargetReviewers}/${report.representation.eligibleReviewers} eligible reviewers meet the target of ${report.representation.targetPerReviewer}.`,
 )
 console.log(
-  `Remaining: ${missingSlots} missing slot(s), ${draftedSlots} drafted slot(s), ${incompleteAssignments.length} exhibit(s) with incomplete assignments.`,
+  `Remaining: ${missingSlots} missing slot(s), ${draftedSlots} drafted slot(s), ${incompleteAssignments.length} exhibit(s) with incomplete assignments, ${underrepresentedReviewers.length} underrepresented reviewer(s).`,
 )

--- a/server/api/admin/wonderlab/review-portfolio.get.ts
+++ b/server/api/admin/wonderlab/review-portfolio.get.ts
@@ -70,12 +70,22 @@ export default defineEventHandler(async (event) => {
         maximum: 20,
         fallback: 4,
       }),
+      minimumAssignmentsPerReviewer: integerQuery(query.minimumAssignmentsPerReviewer, {
+        minimum: 0,
+        maximum: 2,
+        fallback: 2,
+      }),
+      representationMinimumScore: numberQuery(query.representationMinimumScore, {
+        minimum: -100,
+        maximum: 500,
+        fallback: 1,
+      }),
     })
 
     return {
       success: true,
       data: plan,
-      message: `Portfolio-planned ${plan.reviewerSlots} reviewer slot(s) across ${plan.componentCount} exhibit(s).`,
+      message: `Portfolio-planned ${plan.reviewerSlots} reviewer slot(s) across ${plan.componentCount} exhibit(s); ${plan.representation.meetingTargetReviewers}/${plan.representation.eligibleReviewers} eligible reviewers meet the cast target.`,
     }
   } catch (error) {
     if (error instanceof H3Error) throw error

--- a/server/utils/wonderLabReviewPortfolio.ts
+++ b/server/utils/wonderLabReviewPortfolio.ts
@@ -9,6 +9,7 @@ import {
   isWonderLabActiveEditorialDraft,
   isWonderLabEditoriallyExcludedReviewer,
   type WonderLabPortfolioCandidate,
+  type WonderLabPortfolioRepresentationSummary,
   type WonderLabPortfolioReviewerUsage,
 } from '@/utils/wonderlab/reviewerPortfolio'
 import type { ReviewDraftAuthorRef, ReviewDraftStatus } from '@/utils/wonderlab/reviewDraft'
@@ -27,7 +28,10 @@ export type WonderLabReviewPortfolioPlan = {
   draftedCount: number
   publishedCount: number
   diversityPenalty: number
+  representationTarget: number
+  representationMinimumScore: number
   reviewerUsage: WonderLabPortfolioReviewerUsage[]
+  representation: WonderLabPortfolioRepresentationSummary
 }
 
 export type BuildWonderLabReviewPortfolioOptions = {
@@ -36,6 +40,8 @@ export type BuildWonderLabReviewPortfolioOptions = {
   reviewersPerComponent?: number
   minimumScore?: number
   diversityPenalty?: number
+  minimumAssignmentsPerReviewer?: number
+  representationMinimumScore?: number
 }
 
 type DraftCoverageRow = {
@@ -291,6 +297,14 @@ export async function buildWonderLabReviewPortfolio(
   )
   const minimumScore = options.minimumScore ?? 0
   const diversityPenalty = Math.max(0, Math.min(20, options.diversityPenalty ?? 4))
+  const representationTarget = Math.max(
+    0,
+    Math.min(2, Math.round(options.minimumAssignmentsPerReviewer ?? 2)),
+  )
+  const representationMinimumScore = Math.max(
+    minimumScore,
+    Math.min(500, options.representationMinimumScore ?? 1),
+  )
   const [exhibits, candidates, coverage] = await Promise.all([
     loadExhibits(options),
     loadReviewers(),
@@ -327,6 +341,8 @@ export async function buildWonderLabReviewPortfolio(
   const portfolio = assignWonderLabReviewerPortfolio(portfolioInputs, {
     reviewersPerExhibit: reviewerCount,
     diversityPenalty,
+    minimumAssignmentsPerReviewer: representationTarget,
+    representationMinimumScore,
   })
   const assignments = new Map(
     portfolio.assignments.map((assignment) => [assignment.key, assignment.reviewers]),
@@ -372,6 +388,9 @@ export async function buildWonderLabReviewPortfolio(
     draftedCount: reviewers.filter((reviewer) => reviewer.coverage === 'DRAFTED').length,
     publishedCount: reviewers.filter((reviewer) => reviewer.coverage === 'PUBLISHED').length,
     diversityPenalty,
+    representationTarget,
+    representationMinimumScore,
     reviewerUsage: portfolio.reviewerUsage,
+    representation: portfolio.representation,
   }
 }

--- a/server/utils/wonderLabReviewPortfolio.ts
+++ b/server/utils/wonderLabReviewPortfolio.ts
@@ -329,11 +329,7 @@ export async function buildWonderLabReviewPortfolio(
           coverage: coverageDetails(exhibit.id, author, coverage).coverage,
         }
       })
-      .filter(
-        (entry) =>
-          entry.coverage !== 'MISSING' ||
-          (entry.voiceReady && entry.score >= minimumScore),
-      )
+      .filter((entry) => entry.coverage !== 'MISSING' || entry.voiceReady)
 
     return { key: exhibit.id, candidates: candidateRows }
   })
@@ -341,6 +337,7 @@ export async function buildWonderLabReviewPortfolio(
   const portfolio = assignWonderLabReviewerPortfolio(portfolioInputs, {
     reviewersPerExhibit: reviewerCount,
     diversityPenalty,
+    assignmentMinimumScore: minimumScore,
     minimumAssignmentsPerReviewer: representationTarget,
     representationMinimumScore,
   })

--- a/utils/scripts/verifyWonderLabEditorialAuditComment.mjs
+++ b/utils/scripts/verifyWonderLabEditorialAuditComment.mjs
@@ -33,12 +33,22 @@ try {
           exhibitsWithIncompleteAssignment: 0,
         },
         diversity: {
+          eligibleBots: 2,
+          eligibleCharacters: 2,
           publishedBots: 1,
           publishedCharacters: 0,
           assignedBots: 2,
           assignedCharacters: 2,
           largestAssignmentCount: 1,
           largestAssignmentShare: 25,
+        },
+        representation: {
+          targetPerReviewer: 2,
+          minimumScore: 1,
+          eligibleReviewers: 4,
+          representedReviewers: 4,
+          meetingTargetReviewers: 3,
+          underrepresentedReviewerCount: 1,
         },
         reviewerUsage: [
           {
@@ -49,6 +59,18 @@ try {
             published: 1,
             drafted: 0,
             missing: 0,
+          },
+        ],
+        underrepresentedReviewers: [
+          {
+            name: 'Fixture Character',
+            kind: 'CHARACTER',
+            id: 2,
+            count: 1,
+            target: 2,
+            reason: 'INSUFFICIENT_RESPONSIBLE_MATCHES',
+            bestScore: 5,
+            responsibleExhibitCount: 1,
           },
         ],
       },
@@ -79,7 +101,10 @@ try {
   const comment = await readFile(commentPath, 'utf8')
   assert.match(comment, /PORTFOLIO_DIVERSE/)
   assert.match(comment, /Fixture Bot/)
+  assert.match(comment, /Fixture Character/)
   assert.match(comment, /4\/4 \(0 short\)/)
+  assert.match(comment, /3\/4 meet the target of 2/)
+  assert.match(comment, /INSUFFICIENT_RESPONSIBLE_MATCHES/)
   assert.match(comment, /run 12345/)
   assert.doesNotMatch(comment, /undefined|null/)
 

--- a/utils/scripts/verifyWonderLabReviewerPortfolio.ts
+++ b/utils/scripts/verifyWonderLabReviewerPortfolio.ts
@@ -92,6 +92,7 @@ const representationInputs = [
 const representation = assignWonderLabReviewerPortfolio(representationInputs, {
   reviewersPerExhibit: 2,
   diversityPenalty: 4,
+  assignmentMinimumScore: 0,
   minimumAssignmentsPerReviewer: 2,
   representationMinimumScore: 1,
 })
@@ -114,6 +115,7 @@ const qualityBoundary = assignWonderLabReviewerPortfolio([
   { key: 30, candidates: [weakOnly, candidate(31, 'CHARACTER', 'Grounded Character', 5)] },
 ], {
   reviewersPerExhibit: 1,
+  assignmentMinimumScore: 1,
   minimumAssignmentsPerReviewer: 1,
   representationMinimumScore: 1,
 })
@@ -126,6 +128,18 @@ assert.equal(
   'NO_RESPONSIBLE_AFFINITY',
   'representation must report weak matches instead of forcing filler',
 )
+
+const weakVisibleButUnassigned = assignWonderLabReviewerPortfolio([
+  { key: 32, candidates: [candidate(32, 'BOT', 'Below Assignment Threshold', 0)] },
+], {
+  reviewersPerExhibit: 1,
+  assignmentMinimumScore: 1,
+  minimumAssignmentsPerReviewer: 0,
+  representationMinimumScore: 1,
+})
+assert.equal(weakVisibleButUnassigned.assignments[0]?.reviewers.length, 0)
+assert.equal(weakVisibleButUnassigned.reviewerUsage[0]?.count, 0)
+assert.equal(weakVisibleButUnassigned.representation.eligibleReviewers, 1)
 
 const deterministic = assignWonderLabReviewerPortfolio(inputs, {
   reviewersPerExhibit: 2,

--- a/utils/scripts/verifyWonderLabReviewerPortfolio.ts
+++ b/utils/scripts/verifyWonderLabReviewerPortfolio.ts
@@ -45,6 +45,7 @@ const inputs = [
 const result = assignWonderLabReviewerPortfolio(inputs, {
   reviewersPerExhibit: 2,
   diversityPenalty: 4,
+  minimumAssignmentsPerReviewer: 0,
 })
 
 assert.equal(result.assignments[0]?.reviewers[0]?.reviewer.id, specialist.reviewer.id)
@@ -71,16 +72,65 @@ const pinned = assignWonderLabReviewerPortfolio([
       candidate(12, 'CHARACTER', 'Drafted Character', 1, 'DRAFTED'),
     ],
   },
-], { reviewersPerExhibit: 2 })
+], { reviewersPerExhibit: 2, minimumAssignmentsPerReviewer: 0 })
 assert.deepEqual(
   pinned.assignments[0]?.reviewers.map((entry) => entry.reviewer.id),
   [10, 12],
   'existing published and drafted editorial work should remain pinned',
 )
 
+const representedBot = candidate(20, 'BOT', 'Represented Bot', 8)
+const representedCharacter = candidate(21, 'CHARACTER', 'Represented Character', 7)
+const secondBot = candidate(22, 'BOT', 'Second Bot', 6)
+const secondCharacter = candidate(23, 'CHARACTER', 'Second Character', 5)
+const representationInputs = [
+  { key: 20, candidates: [representedBot, representedCharacter, secondBot, secondCharacter] },
+  { key: 21, candidates: [representedBot, representedCharacter, secondBot, secondCharacter] },
+  { key: 22, candidates: [representedBot, representedCharacter, secondBot, secondCharacter] },
+  { key: 23, candidates: [representedBot, representedCharacter, secondBot, secondCharacter] },
+]
+const representation = assignWonderLabReviewerPortfolio(representationInputs, {
+  reviewersPerExhibit: 2,
+  diversityPenalty: 4,
+  minimumAssignmentsPerReviewer: 2,
+  representationMinimumScore: 1,
+})
+assert.equal(representation.representation.eligibleReviewers, 4)
+assert.equal(representation.representation.representedReviewers, 4)
+assert.equal(representation.representation.meetingTargetReviewers, 4)
+assert.equal(representation.representation.underrepresentedReviewers.length, 0)
+assert.ok(
+  representation.reviewerUsage.every((entry) => entry.count >= 2),
+  'every responsible voice-ready reviewer should meet the requested representation floor',
+)
+assert.ok(
+  representation.assignments.flatMap((entry) => entry.reviewers).some(
+    (entry) => entry.reasons.some((reason) => reason.startsWith('cast representation floor:')),
+  ),
+)
+
+const weakOnly = candidate(30, 'BOT', 'Weak Only', 0)
+const qualityBoundary = assignWonderLabReviewerPortfolio([
+  { key: 30, candidates: [weakOnly, candidate(31, 'CHARACTER', 'Grounded Character', 5)] },
+], {
+  reviewersPerExhibit: 1,
+  minimumAssignmentsPerReviewer: 1,
+  representationMinimumScore: 1,
+})
+const weakUsage = qualityBoundary.reviewerUsage.find((entry) => entry.id === weakOnly.reviewer.id)
+assert.equal(weakUsage?.count, 0)
+assert.equal(
+  qualityBoundary.representation.underrepresentedReviewers.find(
+    (entry) => entry.id === weakOnly.reviewer.id,
+  )?.reason,
+  'NO_RESPONSIBLE_AFFINITY',
+  'representation must report weak matches instead of forcing filler',
+)
+
 const deterministic = assignWonderLabReviewerPortfolio(inputs, {
   reviewersPerExhibit: 2,
   diversityPenalty: 4,
+  minimumAssignmentsPerReviewer: 0,
 })
 assert.deepEqual(result, deterministic)
 

--- a/utils/wonderlab/reviewerPortfolio.ts
+++ b/utils/wonderlab/reviewerPortfolio.ts
@@ -28,9 +28,38 @@ export type WonderLabPortfolioReviewerUsage = {
   count: number
 }
 
+export type WonderLabPortfolioRepresentationGapReason =
+  | 'NO_RESPONSIBLE_AFFINITY'
+  | 'INSUFFICIENT_RESPONSIBLE_MATCHES'
+  | 'PORTFOLIO_CAPACITY'
+
+export type WonderLabPortfolioRepresentationGap = {
+  reviewerKey: string
+  kind: 'BOT' | 'CHARACTER'
+  id: number
+  name: string
+  count: number
+  target: number
+  deficit: number
+  bestScore: number | null
+  responsibleExhibitCount: number
+  reason: WonderLabPortfolioRepresentationGapReason
+}
+
+export type WonderLabPortfolioRepresentationSummary = {
+  targetPerReviewer: number
+  minimumScore: number
+  eligibleReviewers: number
+  representedReviewers: number
+  meetingTargetReviewers: number
+  underrepresentedReviewers: WonderLabPortfolioRepresentationGap[]
+}
+
 export type AssignWonderLabReviewerPortfolioOptions = {
   reviewersPerExhibit?: number
   diversityPenalty?: number
+  minimumAssignmentsPerReviewer?: number
+  representationMinimumScore?: number
 }
 
 const ACTIVE_EDITORIAL_DRAFT_STATUSES = new Set<ReviewDraftStatus>([
@@ -48,6 +77,11 @@ const COVERAGE_PRIORITY: Record<WonderLabPortfolioCoverage, number> = {
   PUBLISHED: 0,
   DRAFTED: 1,
   MISSING: 2,
+}
+
+type CandidatePlacement = {
+  exhibit: WonderLabPortfolioExhibit
+  candidate: WonderLabPortfolioCandidate
 }
 
 function normalizedReviewerName(value: string | null | undefined): string {
@@ -79,6 +113,17 @@ function stableCandidateOrder(
   return nameOrder || left.reviewer.id - right.reviewer.id
 }
 
+function stableReviewerOrder(
+  left: WonderLabPortfolioCandidate,
+  right: WonderLabPortfolioCandidate,
+): number {
+  if (left.reviewer.kind !== right.reviewer.kind) {
+    return left.reviewer.kind.localeCompare(right.reviewer.kind, 'en')
+  }
+  const nameOrder = left.reviewer.name.localeCompare(right.reviewer.name, 'en')
+  return nameOrder || left.reviewer.id - right.reviewer.id
+}
+
 function pinnedCandidateOrder(
   left: WonderLabPortfolioCandidate,
   right: WonderLabPortfolioCandidate,
@@ -101,20 +146,82 @@ function withPortfolioReason(
   }
 }
 
+function withRepresentationReason(
+  candidate: WonderLabPortfolioCandidate,
+  assignmentNumber: number,
+  target: number,
+): WonderLabPortfolioCandidate {
+  return {
+    ...candidate,
+    reasons: [
+      ...candidate.reasons,
+      `cast representation floor: assignment ${assignmentNumber} of ${target}`,
+    ],
+  }
+}
+
+function placementOrder(
+  selected: Map<number, WonderLabPortfolioCandidate[]>,
+  left: CandidatePlacement,
+  right: CandidatePlacement,
+): number {
+  if (right.candidate.score !== left.candidate.score) {
+    return right.candidate.score - left.candidate.score
+  }
+
+  const leftSelected = selected.get(left.exhibit.key) || []
+  const rightSelected = selected.get(right.exhibit.key) || []
+  const leftContrast = leftSelected.some(
+    (entry) => entry.reviewer.kind !== left.candidate.reviewer.kind,
+  )
+  const rightContrast = rightSelected.some(
+    (entry) => entry.reviewer.kind !== right.candidate.reviewer.kind,
+  )
+
+  return (
+    Number(rightContrast) - Number(leftContrast) ||
+    leftSelected.length - rightSelected.length ||
+    left.exhibit.key - right.exhibit.key
+  )
+}
+
 export function assignWonderLabReviewerPortfolio(
   exhibits: WonderLabPortfolioExhibit[],
   options: AssignWonderLabReviewerPortfolioOptions = {},
 ): {
   assignments: WonderLabPortfolioAssignment[]
   reviewerUsage: WonderLabPortfolioReviewerUsage[]
+  representation: WonderLabPortfolioRepresentationSummary
 } {
   const reviewerCount = Math.max(
     1,
     Math.min(2, Math.round(options.reviewersPerExhibit ?? 2)),
   )
   const diversityPenalty = Math.max(0, options.diversityPenalty ?? 4)
+  const representationTarget = Math.max(
+    0,
+    Math.min(2, Math.round(options.minimumAssignmentsPerReviewer ?? 1)),
+  )
+  const representationMinimumScore = options.representationMinimumScore ?? 1
   const usage = new Map<string, number>()
   const selected = new Map<number, WonderLabPortfolioCandidate[]>()
+  const candidatesByKey = new Map<string, WonderLabPortfolioCandidate>()
+  const voiceReadyReviewerKeys = new Set<string>()
+  const responsiblePlacements = new Map<string, CandidatePlacement[]>()
+
+  for (const exhibit of exhibits) {
+    for (const candidate of exhibit.candidates) {
+      if (!candidatesByKey.has(candidate.reviewerKey)) {
+        candidatesByKey.set(candidate.reviewerKey, candidate)
+      }
+      if (!candidate.voiceReady) continue
+      voiceReadyReviewerKeys.add(candidate.reviewerKey)
+      if (candidate.score < representationMinimumScore) continue
+      const placements = responsiblePlacements.get(candidate.reviewerKey) || []
+      placements.push({ exhibit, candidate })
+      responsiblePlacements.set(candidate.reviewerKey, placements)
+    }
+  }
 
   // Existing editorial work is stable: preserve published and drafted slots before
   // balancing new assignments. Published work wins when more historical slots exist
@@ -128,6 +235,52 @@ export function assignWonderLabReviewerPortfolio(
     selected.set(exhibit.key, [...pinned])
     for (const candidate of pinned) {
       usage.set(candidate.reviewerKey, (usage.get(candidate.reviewerKey) || 0) + 1)
+    }
+  }
+
+  // Reserve responsible placements for the eligible cast before broad reviewers
+  // consume the portfolio. This is a domain-neutral representation floor: the
+  // caller defines eligibility and affinity, while this utility only allocates
+  // bounded slots without displacing existing editorial work.
+  const representationOrder = [...voiceReadyReviewerKeys]
+    .map((reviewerKey) => {
+      const candidate = candidatesByKey.get(reviewerKey)
+      if (!candidate) throw new Error(`Missing reviewer candidate for ${reviewerKey}.`)
+      const placements = responsiblePlacements.get(reviewerKey) || []
+      const bestScore = placements.length
+        ? Math.max(...placements.map((placement) => placement.candidate.score))
+        : Number.NEGATIVE_INFINITY
+      return { reviewerKey, candidate, placements, bestScore }
+    })
+    .sort((left, right) =>
+      left.placements.length - right.placements.length ||
+      right.bestScore - left.bestScore ||
+      stableReviewerOrder(left.candidate, right.candidate),
+    )
+
+  for (let round = 1; round <= representationTarget; round += 1) {
+    for (const entry of representationOrder) {
+      const currentUsage = usage.get(entry.reviewerKey) || 0
+      if (currentUsage >= round) continue
+
+      const available = entry.placements
+        .filter(({ exhibit }) => {
+          const reviewers = selected.get(exhibit.key) || []
+          return (
+            reviewers.length < reviewerCount &&
+            !reviewers.some((reviewer) => reviewer.reviewerKey === entry.reviewerKey)
+          )
+        })
+        .sort((left, right) => placementOrder(selected, left, right))
+
+      const placement = available[0]
+      if (!placement) continue
+      const reviewers = selected.get(placement.exhibit.key) || []
+      reviewers.push(
+        withRepresentationReason(placement.candidate, currentUsage + 1, representationTarget),
+      )
+      selected.set(placement.exhibit.key, reviewers)
+      usage.set(entry.reviewerKey, currentUsage + 1)
     }
   }
 
@@ -198,17 +351,9 @@ export function assignWonderLabReviewerPortfolio(
     selected.set(exhibit.key, reviewers)
   }
 
-  const candidatesByKey = new Map<string, WonderLabPortfolioCandidate>()
-  for (const exhibit of exhibits) {
-    for (const candidate of exhibit.candidates) {
-      if (!candidatesByKey.has(candidate.reviewerKey)) {
-        candidatesByKey.set(candidate.reviewerKey, candidate)
-      }
-    }
-  }
-
-  const reviewerUsage = [...usage.entries()]
-    .map(([reviewerKey, count]): WonderLabPortfolioReviewerUsage => {
+  const reviewerKeys = new Set([...voiceReadyReviewerKeys, ...usage.keys()])
+  const reviewerUsage = [...reviewerKeys]
+    .map((reviewerKey): WonderLabPortfolioReviewerUsage => {
       const candidate = candidatesByKey.get(reviewerKey)
       if (!candidate) throw new Error(`Missing reviewer candidate for ${reviewerKey}.`)
       return {
@@ -216,11 +361,44 @@ export function assignWonderLabReviewerPortfolio(
         kind: candidate.reviewer.kind,
         id: candidate.reviewer.id,
         name: candidate.reviewer.name,
-        count,
+        count: usage.get(reviewerKey) || 0,
       }
     })
     .sort((left, right) =>
       right.count - left.count ||
+      left.kind.localeCompare(right.kind, 'en') ||
+      left.name.localeCompare(right.name, 'en') ||
+      left.id - right.id,
+    )
+
+  const underrepresentedReviewers = representationOrder
+    .filter((entry) => (usage.get(entry.reviewerKey) || 0) < representationTarget)
+    .map((entry): WonderLabPortfolioRepresentationGap => {
+      const count = usage.get(entry.reviewerKey) || 0
+      const responsibleExhibitCount = entry.placements.length
+      const bestScore = responsibleExhibitCount > 0 ? entry.bestScore : null
+      const reason: WonderLabPortfolioRepresentationGapReason =
+        responsibleExhibitCount === 0
+          ? 'NO_RESPONSIBLE_AFFINITY'
+          : responsibleExhibitCount < representationTarget
+            ? 'INSUFFICIENT_RESPONSIBLE_MATCHES'
+            : 'PORTFOLIO_CAPACITY'
+      return {
+        reviewerKey: entry.reviewerKey,
+        kind: entry.candidate.reviewer.kind,
+        id: entry.candidate.reviewer.id,
+        name: entry.candidate.reviewer.name,
+        count,
+        target: representationTarget,
+        deficit: representationTarget - count,
+        bestScore,
+        responsibleExhibitCount,
+        reason,
+      }
+    })
+    .sort((left, right) =>
+      right.deficit - left.deficit ||
+      left.reason.localeCompare(right.reason, 'en') ||
       left.kind.localeCompare(right.kind, 'en') ||
       left.name.localeCompare(right.name, 'en') ||
       left.id - right.id,
@@ -232,5 +410,17 @@ export function assignWonderLabReviewerPortfolio(
       reviewers: selected.get(exhibit.key) || [],
     })),
     reviewerUsage,
+    representation: {
+      targetPerReviewer: representationTarget,
+      minimumScore: representationMinimumScore,
+      eligibleReviewers: representationOrder.length,
+      representedReviewers: representationOrder.filter(
+        (entry) => (usage.get(entry.reviewerKey) || 0) > 0,
+      ).length,
+      meetingTargetReviewers: representationOrder.filter(
+        (entry) => (usage.get(entry.reviewerKey) || 0) >= representationTarget,
+      ).length,
+      underrepresentedReviewers,
+    },
   }
 }

--- a/utils/wonderlab/reviewerPortfolio.ts
+++ b/utils/wonderlab/reviewerPortfolio.ts
@@ -58,6 +58,7 @@ export type WonderLabPortfolioRepresentationSummary = {
 export type AssignWonderLabReviewerPortfolioOptions = {
   reviewersPerExhibit?: number
   diversityPenalty?: number
+  assignmentMinimumScore?: number
   minimumAssignmentsPerReviewer?: number
   representationMinimumScore?: number
 }
@@ -198,6 +199,7 @@ export function assignWonderLabReviewerPortfolio(
     Math.min(2, Math.round(options.reviewersPerExhibit ?? 2)),
   )
   const diversityPenalty = Math.max(0, options.diversityPenalty ?? 4)
+  const assignmentMinimumScore = options.assignmentMinimumScore ?? 0
   const representationTarget = Math.max(
     0,
     Math.min(2, Math.round(options.minimumAssignmentsPerReviewer ?? 1)),
@@ -292,6 +294,7 @@ export function assignWonderLabReviewerPortfolio(
       const available = exhibit.candidates.filter(
         (candidate) =>
           candidate.voiceReady &&
+          candidate.score >= assignmentMinimumScore &&
           !alreadySelected.some((entry) => entry.reviewerKey === candidate.reviewerKey),
       )
       return {
@@ -315,6 +318,7 @@ export function assignWonderLabReviewerPortfolio(
       let pool = exhibit.candidates.filter(
         (candidate) =>
           candidate.voiceReady &&
+          candidate.score >= assignmentMinimumScore &&
           !reviewers.some((entry) => entry.reviewerKey === candidate.reviewerKey),
       )
       if (!pool.length) break


### PR DESCRIPTION
## Summary

Implements the explicit completion target recorded on #582: every eligible Bot and Character should be represented in WonderLab at least once, with a preferred target of two responsible assignments before broad generalists accumulate substantial repeats.

- adds a deterministic representation-floor pass to the pure portfolio assignment utility;
- defaults the production portfolio to two assignments per eligible voice-ready reviewer;
- reserves each personality's best responsible placements before ordinary repeat-use balancing fills the remaining slots;
- preserves all existing published and active draft assignments;
- does not force filler: representation requires a positive affinity by default, and reviewers without enough grounded matches are reported with explicit gap reasons;
- keeps weak/negative-affinity personalities visible in the eligible-cast audit while preventing them from being assigned below the ordinary assignment threshold;
- reports complete eligible Bot/Character inventory, represented count, target attainment, and underrepresented personalities;
- extends durable issue #582 evidence with the cast members needing stronger matches or curator work.

## Reuse boundary

The representation-floor algorithm remains a pure portfolio rule. The caller supplies reviewer eligibility, target evidence, affinity scores, capacity, and thresholds. Component loading, ReviewDraft/Reaction coverage, and WonderLab reporting stay in the WonderLab adapter. This preserves the logic for the broader object-to-object editorial direction in #606 without delaying the current rollout.

## Safety

This PR remains read-only and assignment-only:

- no model calls;
- no draft creation or status transitions;
- no approval or publication;
- no database writes;
- no changes to human/community reactions.

Existing first-party work remains pinned. A reviewer with no responsible match is surfaced for curation rather than placed generically.

## Validation

- deterministic specialist and repeat-use behavior;
- Bot/Character contrast;
- published/drafted pinning;
- two-assignment cast representation floor;
- explicit no-responsible-affinity gap instead of filler;
- deterministic reruns;
- durable audit comment rendering;
- normal TypeScript, Contract Tests, WonderLab editorial audit validation, and Vercel preview.

Refs #582
Refs #606