### PR TITLE
Confine ArtImage owner transfer out of the general PATCH (audit F-1)

### DIFF
--- a/.github/workflows/art-image-patch-owner-transfer.yml
+++ b/.github/workflows/art-image-patch-owner-transfer.yml
@@ -1,0 +1,36 @@
+name: ArtImage Patch Owner Transfer
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/api/art/image/\[id\].patch.ts'
+      - 'cypress/e2e/api/art-image-create-contract.cy.ts'
+      - 'utils/scripts/verifyArtImagePatchOwnerTransfer.ts'
+      - '.github/workflows/art-image-patch-owner-transfer.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify ArtImage patch owner transfer
+        run: npx tsx utils/scripts/verifyArtImagePatchOwnerTransfer.ts

--- a/cypress/e2e/api/art-image-create-contract.cy.ts
+++ b/cypress/e2e/api/art-image-create-contract.cy.ts
@@ -193,6 +193,26 @@ describe('ArtImage create and by-ids contracts', () => {
     })
   })
 
+  it('ignores userId owner-transfer on ArtImage PATCH', () => {
+    // The general patch route must not reassign ownership (audit F-1). The owner
+    // patches a real field alongside a userId reassignment; the field updates,
+    // the owner is unchanged.
+    cy.request<ApiResponse<ArtImage>>({
+      method: 'PATCH',
+      url: `${apiBase}/art/image/${privateImage.id}`,
+      headers: bearerHeaders(owner.token),
+      body: {
+        artPrompt: 'owner-transfer attempt',
+        userId: secondUser.id,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success).to.eq(true)
+      expect(response.body.data?.userId).to.eq(owner.id)
+    })
+  })
+
   it('requires authentication and bounded positive IDs for batch lookup', () => {
     cy.request<ApiResponse>({
       method: 'POST',

--- a/server/api/art/image/[id].patch.ts
+++ b/server/api/art/image/[id].patch.ts
@@ -10,10 +10,13 @@ type PatchUser = {
   isAdmin: boolean
 }
 
+// Owner transfer is intentionally NOT part of the general patch contract: a
+// dedicated administrative endpoint should own reassignment. `userId` is
+// therefore absent from this allowlist, so neither an owner nor an admin can
+// change an ArtImage's owner through the ordinary PATCH route (audit F-1).
 const ART_IMAGE_PATCH_FIELDS = new Set<
   keyof Prisma.ArtImageUncheckedUpdateInput
 >([
-  'userId',
   'imageData',
   'thumbnailData',
   'thumbnailPath',
@@ -60,7 +63,6 @@ async function requirePatchUser(event: H3Event): Promise<PatchUser> {
 
 function sanitizeArtImagePatch(
   body: Record<string, unknown>,
-  user: PatchUser,
 ): Prisma.ArtImageUncheckedUpdateInput {
   const updateData: Prisma.ArtImageUncheckedUpdateInput = {}
 
@@ -74,10 +76,6 @@ function sanitizeArtImagePatch(
     }
 
     if (value === undefined) {
-      continue
-    }
-
-    if (key === 'userId' && !user.isAdmin) {
       continue
     }
 
@@ -132,7 +130,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const updateData = sanitizeArtImagePatch(body, user)
+    const updateData = sanitizeArtImagePatch(body)
 
     if (Object.keys(updateData).length === 0) {
       throw createError({

--- a/utils/scripts/verifyArtImagePatchOwnerTransfer.ts
+++ b/utils/scripts/verifyArtImagePatchOwnerTransfer.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8')
+}
+
+function requireText(source: string, text: string, label: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: expected to find ${JSON.stringify(text)}`)
+  }
+}
+
+function forbidText(source: string, text: string, label: string): void {
+  if (source.includes(text)) {
+    throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
+  }
+}
+
+const patchRoute = read('server/api/art/image/[id].patch.ts')
+const cypressSpec = read('cypress/e2e/api/art-image-create-contract.cy.ts')
+
+// Owner transfer is confined to a dedicated endpoint: `userId` must not be a
+// member of the general patch allowlist, and the old admin-only userId
+// passthrough branch must be gone.
+forbidText(
+  patchRoute,
+  "  'userId',\n  'imageData'",
+  'ArtImage patch allowlist still contains userId',
+)
+forbidText(
+  patchRoute,
+  "key === 'userId'",
+  'ArtImage patch userId reassignment branch',
+)
+
+// Ownership is still enforced before any write.
+requireText(
+  patchRoute,
+  '!user.isAdmin && existing.userId !== user.id',
+  'ArtImage patch ownership guard',
+)
+
+// Deployed regression pins the behavior.
+requireText(
+  cypressSpec,
+  'ignores userId owner-transfer on ArtImage PATCH',
+  'ArtImage patch owner-transfer deployed regression',
+)
+
+console.log('ArtImage patch owner-transfer contract passed.')


### PR DESCRIPTION
## Summary

Closes audit finding **F-1**. `server/api/art/image/[id].patch.ts` kept `userId` in `ART_IMAGE_PATCH_FIELDS` and let an admin token **reassign ArtImage ownership** through the ordinary patch route. The definition-of-done wants owner transfer behind a dedicated administrative endpoint, not folded into the general mutation contract.

## Changes

- Drop `userId` from the patch allowlist and remove the now-dead admin-only `userId` passthrough branch, so **neither an owner nor an admin** can change an ArtImage's owner via PATCH. The ownership guard (owner-or-admin may edit) is unchanged.
- Add a DB-free contract, a deployed cypress regression (owner patches a real field plus a `userId` reassignment → the field updates, the owner does not), and a path-filtered CI workflow.

No non-admin path ever existed, so this is a policy tightening, not an active-exploit fix.

## Checks

- ArtImage Patch Owner Transfer (DB-free contract) — passes locally
- TypeScript Type Check — clean (`vue-tsc --noEmit`, 0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_