### PR TITLE
Return the lean projection from Project archive/delete (audit F-5)

### DIFF
--- a/server/api/projects/[id].delete.ts
+++ b/server/api/projects/[id].delete.ts
@@ -3,7 +3,8 @@ import { defineEventHandler } from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
-import { assertProjectAccess, getProjectId, projectInclude } from './index'
+import { assertProjectAccess, getProjectId } from './index'
+import { projectMutationSelect } from './selects'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -20,7 +21,7 @@ export default defineEventHandler(async (event) => {
     const project = await prisma.project.update({
       where: { id },
       data: { isActive: false, status: 'ARCHIVED' },
-      include: projectInclude,
+      select: projectMutationSelect,
     })
 
     event.node.res.statusCode = 200


### PR DESCRIPTION
## Summary

Small cosmetic slice of audit finding **F-5**. `server/api/projects/[id].delete.ts` archives the project (`isActive:false`, `status:ARCHIVED`) then returned the full `projectInclude` graph (Manager, ArtImage, ArtCollection, PitchSheet, `_count`), while create and PATCH already return the lean `projectMutationSelect`. This aligns the archive response with the other two mutation routes so all three share one lean projection.

No behavior change beyond the response shape; ownership and archive semantics are untouched.

## Checks

- TypeScript Type Check — clean (`vue-tsc --noEmit`, 0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_