### PR TITLE
animation-manager/t-012: auto-supersede prior WORKING build on promote

### DIFF
--- a/stores/animationManagerStore.ts
+++ b/stores/animationManagerStore.ts
@@ -19,6 +19,7 @@ import {
   ANIMATION_ATTEMPT_FOLDER,
   listAnimationAttempts,
   getLatestAnimationAttempt,
+  findAttemptToSupersede,
 } from '@/stores/helpers/animationComponentHelper'
 import {
   getComponentStatus,
@@ -149,6 +150,14 @@ export const useAnimationManagerStore = defineStore('animationManagerStore', () 
   }
 
   async function promoteAttempt(attempt: Component) {
+    const priorWorking = findAttemptToSupersede(componentStore.allComponents, attempt)
+    if (priorWorking) {
+      await componentStore.linkSupersededAnimationAttempt(
+        priorWorking,
+        attempt.componentName,
+      )
+    }
+
     return setAttemptStatus(
       attempt,
       'WORKING',

--- a/stores/helpers/animationComponentHelper.ts
+++ b/stores/helpers/animationComponentHelper.ts
@@ -106,6 +106,23 @@ export function getLatestAnimationAttempt<
   return attempts.at(-1) ?? null
 }
 
+// conductor animation-manager/t-012: find the attempt that a newly-promoted
+// build should supersede -- the other WORKING row for the same slug, if any.
+// Used to keep exactly one WORKING attempt per effect instead of letting
+// promoteAttempt() leave the previous WORKING build's status untouched.
+export function findAttemptToSupersede<
+  T extends Pick<Component, 'id' | 'folderName' | 'componentName' | 'status'>,
+>(components: T[], promoted: T): T | null {
+  const parsed = parseAnimationComponentName(promoted.componentName)
+  if (!parsed) return null
+
+  return (
+    listAnimationAttempts(components, parsed.slug).find(
+      (component) => component.id !== promoted.id && component.status === 'WORKING',
+    ) ?? null
+  )
+}
+
 export function nextAnimationBuildNumber<
   T extends Pick<Component, 'folderName' | 'componentName'>,
 >(components: T[], slug: string): number {

--- a/utils/scripts/verifyAnimationComponentAttempts.ts
+++ b/utils/scripts/verifyAnimationComponentAttempts.ts
@@ -3,12 +3,14 @@
 // conventions used to log animation build attempts as Component "museum" rows
 // (stores/helpers/animationComponentHelper.ts). Pure logic only -- no database.
 import assert from 'node:assert/strict'
+import type { Component } from '~/prisma/generated/prisma/client'
 import { animationEffects } from '@/stores/animationCatalog'
 import {
   ANIMATION_ATTEMPT_FOLDER,
   buildAnimationAttemptPayload,
   buildAnimationComponentName,
   buildSupersededTags,
+  findAttemptToSupersede,
   getLatestAnimationAttempt,
   isAnimationAttemptComponent,
   listAnimationAttempts,
@@ -168,8 +170,57 @@ assert.throws(
   'linking supersession against a row with no attempt tags must fail loudly, not silently corrupt data',
 )
 
+// conductor animation-manager/t-012: promoteAttempt() must find the other
+// WORKING attempt for the same slug to supersede, excluding itself, and
+// never cross slugs or non-WORKING rows.
+const attemptRowWithStatus = (
+  id: number,
+  componentName: string,
+  status: Component['status'],
+) => ({ id, folderName: ANIMATION_ATTEMPT_FOLDER, componentName, status })
+
+const supersedeCandidates = [
+  attemptRowWithStatus(1, 'bioluminescent-tide@v1', 'RETIRED'),
+  attemptRowWithStatus(2, 'bioluminescent-tide@v2', 'WORKING'),
+  attemptRowWithStatus(3, 'gravity-garden@v1', 'WORKING'),
+]
+
+assert.equal(
+  findAttemptToSupersede(
+    supersedeCandidates,
+    attemptRowWithStatus(4, 'bioluminescent-tide@v3', 'UNDER_CONSTRUCTION'),
+  )?.id,
+  2,
+  'promoting a new build for an already-tracked slug must find the existing WORKING row for that slug',
+)
+assert.equal(
+  findAttemptToSupersede(
+    supersedeCandidates,
+    attemptRowWithStatus(3, 'gravity-garden@v1', 'WORKING'),
+  ),
+  null,
+  'must not find itself as the attempt to supersede',
+)
+assert.equal(
+  findAttemptToSupersede(
+    supersedeCandidates,
+    attemptRowWithStatus(5, 'brand-new-effect@v1', 'WORKING'),
+  ),
+  null,
+  'a slug with no prior WORKING attempt must have nothing to supersede',
+)
+assert.equal(
+  findAttemptToSupersede(
+    supersedeCandidates,
+    attemptRowWithStatus(6, 'not-versioned', 'WORKING'),
+  ),
+  null,
+  'a componentName that fails to parse must not throw or match anything',
+)
+
 console.log(
   'Animation attempt Component conventions verified: naming/parsing round-trips, ' +
     `all ${animationEffects.length} catalog slugs produce a server-acceptable componentName, ` +
-    'listing/latest/next-build-number, payload composition, and supersession linking.',
+    'listing/latest/next-build-number, payload composition, supersession linking, ' +
+    'and supersede-candidate lookup.',
 )


### PR DESCRIPTION
## Summary
- `promoteAttempt()` in `stores/animationManagerStore.ts` set the promoted attempt's status to `WORKING` but never touched the prior `WORKING` attempt for the same effect slug, so promoting could leave more than one `WORKING` Component row per catalog effect.
- Added a pure `findAttemptToSupersede()` helper in `stores/helpers/animationComponentHelper.ts` that looks up the other `WORKING` attempt for the same slug (excluding the one being promoted), and wired `promoteAttempt()` to call the existing `componentStore.linkSupersededAnimationAttempt()` on it before setting the new attempt's status.
- Covered the new helper's slug-matching, self-exclusion, no-prior-WORKING, and unparseable-componentName cases in `utils/scripts/verifyAnimationComponentAttempts.ts`.

Conductor task: `animation-manager/t-012` (kaizen from t-005's review, kind_robots PR #590).

## Test plan
- [x] `npm run test:animation-component-attempts` — new supersede-lookup cases pass alongside existing conventions
- [x] `npm test` (vue-tsc, full repo) — clean
- [x] `npx eslint` on all three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp52tTt6NU4FGaLNzewnnk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp52tTt6NU4FGaLNzewnnk)_