### PR TITLE
Use global WonderLab portfolio for bounded draft batches

### DIFF
--- a/.github/workflows/wonderlab-editorial-audit.yml
+++ b/.github/workflows/wonderlab-editorial-audit.yml
@@ -7,21 +7,31 @@ on:
       - '.github/workflows/wonderlab-editorial-audit.yml'
       - 'scripts/post-wonderlab-editorial-audit-comment.mjs'
       - 'scripts/wonderlab-production-editorial-audit.mjs'
+      - 'server/api/admin/wonderlab/review-drafts/generate-batch.post.ts'
+      - 'server/api/admin/wonderlab/review-plan.get.ts'
       - 'server/api/admin/wonderlab/review-portfolio.get.ts'
+      - 'server/utils/wonderLabReviewBatchPlan.ts'
       - 'server/utils/wonderLabReviewPortfolio.ts'
       - 'utils/scripts/verifyWonderLabEditorialAuditComment.mjs'
+      - 'utils/scripts/verifyWonderLabReviewBatchPlan.ts'
       - 'utils/scripts/verifyWonderLabReviewerPortfolio.ts'
       - 'utils/wonderlab/reviewerPortfolio.ts'
+      - 'utils/wonderlab/reviewPortfolioBatch.ts'
   push:
     branches: [main]
     paths:
       - '.github/workflows/wonderlab-editorial-audit.yml'
       - 'scripts/post-wonderlab-editorial-audit-comment.mjs'
       - 'scripts/wonderlab-production-editorial-audit.mjs'
+      - 'server/api/admin/wonderlab/review-drafts/generate-batch.post.ts'
+      - 'server/api/admin/wonderlab/review-plan.get.ts'
       - 'server/api/admin/wonderlab/review-portfolio.get.ts'
+      - 'server/utils/wonderLabReviewBatchPlan.ts'
       - 'server/utils/wonderLabReviewPortfolio.ts'
       - 'utils/scripts/verifyWonderLabEditorialAuditComment.mjs'
+      - 'utils/scripts/verifyWonderLabReviewBatchPlan.ts'
       - 'utils/wonderlab/reviewerPortfolio.ts'
+      - 'utils/wonderlab/reviewPortfolioBatch.ts'
   workflow_dispatch:
     inputs:
       max_wait_seconds:
@@ -61,6 +71,9 @@ jobs:
 
       - name: Verify deterministic reviewer portfolio
         run: npx tsx utils/scripts/verifyWonderLabReviewerPortfolio.ts
+
+      - name: Verify global portfolio batch planning
+        run: npx tsx utils/scripts/verifyWonderLabReviewBatchPlan.ts
 
       - name: Check read-only audit contract
         run: |

--- a/server/api/admin/wonderlab/review-drafts/generate-batch.post.ts
+++ b/server/api/admin/wonderlab/review-drafts/generate-batch.post.ts
@@ -2,11 +2,9 @@
 import { createError, defineEventHandler, H3Error, readBody } from 'h3'
 import { requireAdminApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
+import { buildWonderLabReviewBatchPlan } from '@/server/utils/wonderLabReviewBatchPlan'
 import { generateWonderLabReviewDraft } from '@/server/utils/wonderLabReviewDraftGenerator'
-import {
-  buildWonderLabReviewPlan,
-  type WonderLabReviewPlanReviewer,
-} from '@/server/utils/wonderLabReviewPlan'
+import type { WonderLabReviewPlanReviewer } from '@/server/utils/wonderLabReviewPlan'
 
 const MAX_BATCH_COMPONENTS = 10
 const MAX_BATCH_GENERATIONS = 20
@@ -87,7 +85,7 @@ function componentIds(value: unknown): number[] {
 }
 
 function generationTargets(
-  plan: Awaited<ReturnType<typeof buildWonderLabReviewPlan>>,
+  plan: Awaited<ReturnType<typeof buildWonderLabReviewBatchPlan>>,
   regenerate: boolean,
 ): BatchTarget[] {
   return plan.exhibits
@@ -142,7 +140,9 @@ export default defineEventHandler(async (event) => {
     }
     const model = typeof body.model === 'string' ? body.model.trim() || null : null
 
-    const plan = await buildWonderLabReviewPlan({
+    // Always compute assignments against the full museum portfolio, then select
+    // the bounded requested batch. Small batches must not invent a different cast.
+    const plan = await buildWonderLabReviewBatchPlan({
       componentIds: ids,
       limit,
       reviewersPerComponent,
@@ -160,7 +160,7 @@ export default defineEventHandler(async (event) => {
           targets,
           generated: [],
         },
-        message: `Dry run planned ${targets.length} generation(s); no model calls or writes were made.`,
+        message: `Dry run selected ${targets.length} global portfolio generation(s); no model calls or writes were made.`,
       }
     }
 
@@ -218,7 +218,7 @@ export default defineEventHandler(async (event) => {
         targets,
         generated,
       },
-      message: `Completed ${succeeded} of ${generated.length} planned generation(s). No drafts were approved or published.`,
+      message: `Completed ${succeeded} of ${generated.length} global portfolio generation(s). No drafts were approved or published.`,
     }
   } catch (error) {
     if (error instanceof H3Error) throw error

--- a/server/api/admin/wonderlab/review-plan.get.ts
+++ b/server/api/admin/wonderlab/review-plan.get.ts
@@ -2,7 +2,7 @@
 import { createError, defineEventHandler, getQuery, H3Error } from 'h3'
 import { requireAdminApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
-import { buildWonderLabReviewPlan } from '@/server/utils/wonderLabReviewPlan'
+import { buildWonderLabReviewBatchPlan } from '@/server/utils/wonderLabReviewBatchPlan'
 
 function integerQuery(
   value: unknown,
@@ -53,7 +53,7 @@ export default defineEventHandler(async (event) => {
     await requireAdminApiUser(event)
     const query = getQuery(event)
 
-    const plan = await buildWonderLabReviewPlan({
+    const plan = await buildWonderLabReviewBatchPlan({
       componentIds: componentIds(query.componentIds ?? query.componentId),
       limit: integerQuery(query.limit, { minimum: 1, maximum: 100, fallback: 25 }),
       reviewersPerComponent: integerQuery(query.reviewersPerComponent, {
@@ -71,7 +71,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       data: plan,
-      message: `Planned ${plan.reviewerSlots} reviewer slot(s) across ${plan.componentCount} exhibit(s).`,
+      message: `Selected ${plan.reviewerSlots} globally portfolio-planned reviewer slot(s) across ${plan.componentCount} exhibit(s).`,
     }
   } catch (error) {
     if (error instanceof H3Error) throw error

--- a/server/utils/wonderLabReviewBatchPlan.ts
+++ b/server/utils/wonderLabReviewBatchPlan.ts
@@ -1,8 +1,6 @@
-import {
-  buildWonderLabReviewPortfolio,
-  type WonderLabPortfolioRepresentationSummary,
-} from '@/server/utils/wonderLabReviewPortfolio'
+import { buildWonderLabReviewPortfolio } from '@/server/utils/wonderLabReviewPortfolio'
 import type { WonderLabReviewPlan } from '@/server/utils/wonderLabReviewPlan'
+import type { WonderLabPortfolioRepresentationSummary } from '@/utils/wonderlab/reviewerPortfolio'
 import { selectWonderLabReviewPortfolioBatch } from '@/utils/wonderlab/reviewPortfolioBatch'
 
 export const WONDERLAB_EDITORIAL_PORTFOLIO_POLICY = {

--- a/server/utils/wonderLabReviewBatchPlan.ts
+++ b/server/utils/wonderLabReviewBatchPlan.ts
@@ -1,0 +1,71 @@
+import {
+  buildWonderLabReviewPortfolio,
+  type WonderLabPortfolioRepresentationSummary,
+} from '@/server/utils/wonderLabReviewPortfolio'
+import type { WonderLabReviewPlan } from '@/server/utils/wonderLabReviewPlan'
+import { selectWonderLabReviewPortfolioBatch } from '@/utils/wonderlab/reviewPortfolioBatch'
+
+export const WONDERLAB_EDITORIAL_PORTFOLIO_POLICY = {
+  diversityPenalty: 4,
+  minimumAssignmentsPerReviewer: 2,
+  representationMinimumScore: 1,
+} as const
+
+export type BuildWonderLabReviewBatchPlanOptions = {
+  componentIds?: number[]
+  limit?: number
+  reviewersPerComponent?: number
+  minimumScore?: number
+}
+
+export type WonderLabReviewBatchPlan = WonderLabReviewPlan & {
+  assignmentMode: 'PORTFOLIO_DIVERSE'
+  portfolio: {
+    componentCount: number
+    reviewerSlots: number
+    missingCount: number
+    draftedCount: number
+    publishedCount: number
+    diversityPenalty: number
+    representationTarget: number
+    representationMinimumScore: number
+    representation: WonderLabPortfolioRepresentationSummary
+  }
+}
+
+export async function buildWonderLabReviewBatchPlan(
+  options: BuildWonderLabReviewBatchPlanOptions = {},
+): Promise<WonderLabReviewBatchPlan> {
+  const globalPortfolio = await buildWonderLabReviewPortfolio({
+    limit: 500,
+    reviewersPerComponent: options.reviewersPerComponent,
+    minimumScore: options.minimumScore,
+    ...WONDERLAB_EDITORIAL_PORTFOLIO_POLICY,
+  })
+  const exhibits = selectWonderLabReviewPortfolioBatch(globalPortfolio.exhibits, {
+    componentIds: options.componentIds,
+    limit: options.limit,
+  })
+  const reviewers = exhibits.flatMap((exhibit) => exhibit.reviewers)
+
+  return {
+    assignmentMode: globalPortfolio.assignmentMode,
+    exhibits,
+    componentCount: exhibits.length,
+    reviewerSlots: reviewers.length,
+    missingCount: reviewers.filter((reviewer) => reviewer.coverage === 'MISSING').length,
+    draftedCount: reviewers.filter((reviewer) => reviewer.coverage === 'DRAFTED').length,
+    publishedCount: reviewers.filter((reviewer) => reviewer.coverage === 'PUBLISHED').length,
+    portfolio: {
+      componentCount: globalPortfolio.componentCount,
+      reviewerSlots: globalPortfolio.reviewerSlots,
+      missingCount: globalPortfolio.missingCount,
+      draftedCount: globalPortfolio.draftedCount,
+      publishedCount: globalPortfolio.publishedCount,
+      diversityPenalty: globalPortfolio.diversityPenalty,
+      representationTarget: globalPortfolio.representationTarget,
+      representationMinimumScore: globalPortfolio.representationMinimumScore,
+      representation: globalPortfolio.representation,
+    },
+  }
+}

--- a/utils/scripts/verifyWonderLabReviewBatchPlan.ts
+++ b/utils/scripts/verifyWonderLabReviewBatchPlan.ts
@@ -1,35 +1,45 @@
 // /utils/scripts/verifyWonderLabReviewBatchPlan.ts
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
+import { selectWonderLabReviewPortfolioBatch } from '@/utils/wonderlab/reviewPortfolioBatch'
 
-const planPath = 'server/utils/wonderLabReviewPlan.ts'
+const portfolioPlanPath = 'server/utils/wonderLabReviewBatchPlan.ts'
+const selectorPath = 'utils/wonderlab/reviewPortfolioBatch.ts'
 const getPath = 'server/api/admin/wonderlab/review-plan.get.ts'
 const batchPath = 'server/api/admin/wonderlab/review-drafts/generate-batch.post.ts'
 const pagePath = 'pages/admin/wonderlab-review-plan.vue'
 
-const plan = await readFile(planPath, 'utf8')
+const portfolioPlan = await readFile(portfolioPlanPath, 'utf8')
+const selector = await readFile(selectorPath, 'utf8')
 const getEndpoint = await readFile(getPath, 'utf8')
 const batch = await readFile(batchPath, 'utf8')
 const page = await readFile(pagePath, 'utf8')
 
 assert.match(getEndpoint, /requireAdminApiUser\(event\)/)
-assert.match(getEndpoint, /buildWonderLabReviewPlan/)
-assert.match(getEndpoint, /reviewersPerComponent/)
+assert.match(getEndpoint, /buildWonderLabReviewBatchPlan/)
+assert.match(getEndpoint, /globally portfolio-planned/)
+assert.doesNotMatch(getEndpoint, /buildWonderLabReviewPlan/)
 
-assert.match(plan, /rankWonderLabReviewers/)
-assert.match(plan, /reviewer\.kind !== first\.reviewer\.kind/)
-assert.match(plan, /coverage: coverageStatus/)
-assert.match(plan, /'MISSING' \| 'DRAFTED' \| 'PUBLISHED'/)
-assert.match(plan, /authorBotId IS NOT NULL OR authorCharacterId IS NOT NULL/)
-assert.doesNotMatch(plan, /INSERT\s+INTO/i)
-assert.doesNotMatch(plan, /UPDATE\s+/i)
-assert.doesNotMatch(plan, /DELETE\s+FROM/i)
+assert.match(portfolioPlan, /buildWonderLabReviewPortfolio/)
+assert.match(portfolioPlan, /limit: 500/)
+assert.match(portfolioPlan, /minimumAssignmentsPerReviewer: 2/)
+assert.match(portfolioPlan, /representationMinimumScore: 1/)
+assert.match(portfolioPlan, /selectWonderLabReviewPortfolioBatch/)
+assert.match(portfolioPlan, /assignmentMode: globalPortfolio\.assignmentMode/)
+assert.doesNotMatch(portfolioPlan, /INSERT\s+INTO|UPDATE\s+|DELETE\s+FROM/i)
+
+assert.match(selector, /cast representation floor:/)
+assert.match(selector, /Explicit IDs preserve caller order/)
+assert.doesNotMatch(selector, /prisma|\$fetch|fetch\(/)
 
 assert.match(batch, /const MAX_BATCH_COMPONENTS = 10/)
 assert.match(batch, /const MAX_BATCH_GENERATIONS = 20/)
+assert.match(batch, /buildWonderLabReviewBatchPlan/)
+assert.doesNotMatch(batch, /buildWonderLabReviewPlan/)
 assert.match(batch, /booleanValue\(body\.dryRun, true, 'dryRun'\)/)
 assert.match(batch, /if \(dryRun\)/)
 assert.match(batch, /no model calls or writes were made/i)
+assert.match(batch, /Small batches must not invent a different cast/)
 assert.match(batch, /for \(const target of targets\)/)
 assert.match(batch, /generateWonderLabReviewDraft/)
 assert.match(batch, /coverage === 'PUBLISHED'\) return false/)
@@ -45,5 +55,42 @@ assert.match(page, /dryRun,/)
 assert.match(page, /Enable model calls for this batch/)
 assert.doesNotMatch(page, /onMounted\([\s\S]{0,500}runBatch\(false\)/)
 assert.doesNotMatch(page, /\/publish/)
+
+const genericMissing = {
+  coverage: 'MISSING' as const,
+  score: 20,
+  reasons: ['shared expertise: interface'],
+}
+const representationMissing = {
+  coverage: 'MISSING' as const,
+  score: 5,
+  reasons: ['cast representation floor: assignment 1 of 2'],
+}
+const published = {
+  coverage: 'PUBLISHED' as const,
+  score: 50,
+  reasons: ['existing publication'],
+}
+const exhibits = [
+  { componentId: 1, reviewers: [genericMissing] },
+  { componentId: 2, reviewers: [representationMissing] },
+  { componentId: 3, reviewers: [published] },
+]
+
+assert.deepEqual(
+  selectWonderLabReviewPortfolioBatch(exhibits, { limit: 1 }).map(
+    (exhibit) => exhibit.componentId,
+  ),
+  [2],
+  'automatic batches should prioritize missing cast-representation assignments',
+)
+assert.deepEqual(
+  selectWonderLabReviewPortfolioBatch(exhibits, {
+    componentIds: [3, 1, 3],
+    limit: 1,
+  }).map((exhibit) => exhibit.componentId),
+  [3, 1],
+  'explicit Component IDs should preserve caller order and ignore the automatic limit',
+)
 
 console.log('WonderLab review batch planning contract passed.')

--- a/utils/wonderlab/reviewPortfolioBatch.ts
+++ b/utils/wonderlab/reviewPortfolioBatch.ts
@@ -1,0 +1,80 @@
+export type WonderLabPortfolioBatchCoverage = 'MISSING' | 'DRAFTED' | 'PUBLISHED'
+
+export type WonderLabPortfolioBatchReviewer = {
+  coverage: WonderLabPortfolioBatchCoverage
+  score: number
+  reasons: string[]
+}
+
+export type WonderLabPortfolioBatchExhibit = {
+  componentId: number
+  reviewers: WonderLabPortfolioBatchReviewer[]
+}
+
+export type SelectWonderLabPortfolioBatchOptions = {
+  componentIds?: number[]
+  limit?: number
+}
+
+type ExhibitPriority = {
+  representationMissing: number
+  missing: number
+  drafted: number
+  bestMissingScore: number
+}
+
+function priority(exhibit: WonderLabPortfolioBatchExhibit): ExhibitPriority {
+  const missingReviewers = exhibit.reviewers.filter(
+    (reviewer) => reviewer.coverage === 'MISSING',
+  )
+  return {
+    representationMissing: missingReviewers.filter((reviewer) =>
+      reviewer.reasons.some((reason) => reason.startsWith('cast representation floor:')),
+    ).length,
+    missing: missingReviewers.length,
+    drafted: exhibit.reviewers.filter((reviewer) => reviewer.coverage === 'DRAFTED').length,
+    bestMissingScore: missingReviewers.length
+      ? Math.max(...missingReviewers.map((reviewer) => reviewer.score))
+      : Number.NEGATIVE_INFINITY,
+  }
+}
+
+/**
+ * Selects a bounded editorial batch from an already-computed global portfolio.
+ *
+ * Explicit IDs preserve caller order. Automatic selection gives first priority
+ * to missing cast-representation placements, then other missing high-affinity
+ * work. It never recalculates reviewer assignments from the small batch.
+ */
+export function selectWonderLabReviewPortfolioBatch<
+  T extends WonderLabPortfolioBatchExhibit,
+>(
+  exhibits: readonly T[],
+  options: SelectWonderLabPortfolioBatchOptions = {},
+): T[] {
+  const limit = Math.max(1, Math.floor(options.limit ?? 10))
+  const requestedIds = [...new Set(options.componentIds || [])].filter(
+    (id) => Number.isInteger(id) && id > 0,
+  )
+
+  if (requestedIds.length) {
+    const byId = new Map(exhibits.map((exhibit) => [exhibit.componentId, exhibit]))
+    return requestedIds
+      .map((id) => byId.get(id))
+      .filter((exhibit): exhibit is T => Boolean(exhibit))
+  }
+
+  return [...exhibits]
+    .sort((left, right) => {
+      const leftPriority = priority(left)
+      const rightPriority = priority(right)
+      return (
+        rightPriority.representationMissing - leftPriority.representationMissing ||
+        rightPriority.missing - leftPriority.missing ||
+        leftPriority.drafted - rightPriority.drafted ||
+        rightPriority.bestMissingScore - leftPriority.bestMissingScore ||
+        left.componentId - right.componentId
+      )
+    })
+    .slice(0, limit)
+}


### PR DESCRIPTION
## Summary

Connects WonderLab preview and bounded draft creation to the globally balanced reviewer portfolio from #588 and #609.

Before this change, the audit used the full museum portfolio while the preview and batch route recalculated assignments from only the requested Components. A small batch could therefore disagree with the verified museum-wide cast.

- compute the full portfolio before selecting a bounded batch;
- use one shared adapter for preview and batch execution;
- prioritize missing cast-representation placements, then other missing high-affinity work;
- preserve explicit curator-selected Component order;
- include global portfolio and representation metadata in dry-run results;
- retain the existing caps of 10 Components and 20 sequential targets;
- retain administrator auth, default dry run, published-slot skipping, and the existing editorial draft boundary;
- perform no approval or publication.

The bounded selector is pure and receives an already-computed portfolio, preserving the reusable “global assignment first, bounded execution second” pattern for #606.

## Validation

- representation-gap priority and explicit-ID behavior have executable contracts;
- preview and batch routes must use the same global adapter;
- legacy per-batch planning is forbidden in both routes;
- normal TypeScript, Contract Tests, dedicated WonderLab validation, and Vercel preview.

Refs #582
Refs #606