### PR TITLE
Add guarded WonderLab editorial batch runner

### DIFF
--- a/.github/workflows/wonderlab-editorial-batch.yml
+++ b/.github/workflows/wonderlab-editorial-batch.yml
@@ -1,0 +1,231 @@
+name: WonderLab Editorial Batch
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-editorial-batch.yml'
+      - 'config/wonderlab-editorial-batch.json'
+      - 'scripts/wonderlab-editorial-batch.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-editorial-batch.yml'
+      - 'config/wonderlab-editorial-batch.json'
+      - 'scripts/wonderlab-editorial-batch.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: wonderlab-editorial-batch
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate editorial batch boundary
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Validate manifest and runner safety
+        env:
+          WONDERLAB_EDITORIAL_BATCH_VALIDATE_ONLY: '1'
+          WONDERLAB_EDITORIAL_BATCH_ALLOW_EXECUTE: '1'
+          WONDERLAB_EDITORIAL_BATCH_OUTPUT: /tmp/wonderlab-editorial-batch-validation
+        run: |
+          set -euo pipefail
+          node --check scripts/wonderlab-editorial-batch.mjs
+          node scripts/wonderlab-editorial-batch.mjs
+          node <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert').strict
+          const source = fs.readFileSync('scripts/wonderlab-editorial-batch.mjs', 'utf8')
+          const config = JSON.parse(fs.readFileSync('config/wonderlab-editorial-batch.json', 'utf8'))
+
+          for (const required of [
+            '/api/version',
+            '/api/admin/wonderlab/review-rollout',
+            '/api/admin/wonderlab/review-drafts/generate-batch',
+            'dryRun: true',
+            'expectedTargets',
+            'WONDERLAB_EDITORIAL_BATCH_ALLOW_EXECUTE',
+            'The global portfolio targets changed after review',
+          ]) {
+            assert.ok(source.includes(required), `missing editorial batch boundary: ${required}`)
+          }
+
+          for (const forbidden of [
+            '/publish',
+            '/approve',
+            '/reject',
+            "status: 'APPROVED'",
+            'DATABASE_URL',
+            'prisma.',
+          ]) {
+            assert.ok(!source.includes(forbidden), `editorial batch crossed forbidden boundary: ${forbidden}`)
+          }
+
+          assert.match(source, /if \(config\.execute\)[\s\S]*expectedTargets/)
+          assert.match(source, /dryRunPayload[\s\S]*if \(config\.execute\)[\s\S]*dryRun: false/)
+          assert.ok(config.execute === false || config.expectedTargets.length > 0)
+          assert.match(config.minimumProductionCommit, /^[0-9a-f]{40}$/)
+          console.log('WonderLab editorial batch safety contract passed.')
+          NODE
+
+  batch:
+    name: Run reviewed editorial batch
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[wonderlab-editorial-batch]'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify compatible production runtime
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+        run: |
+          set -euo pipefail
+          baseline_sha="$(jq -r '.minimumProductionCommit // empty' config/wonderlab-editorial-batch.json)"
+          if ! printf '%s' "$baseline_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo '::error::minimumProductionCommit must be a full 40-character commit SHA.'
+            exit 1
+          fi
+
+          git fetch --quiet --no-tags origin main
+          if ! git cat-file -e "${baseline_sha}^{commit}" 2>/dev/null; then
+            echo "::error::Configured production baseline ${baseline_sha} is unavailable."
+            exit 1
+          fi
+
+          for attempt in $(seq 1 90); do
+            payload="$(curl -sS --max-time 20 "${BASE_URL}/api/version" || true)"
+            live_sha="$(printf '%s' "$payload" | jq -r 'if .success == true then .data.commit // empty else empty end' 2>/dev/null || true)"
+            if [ -n "$live_sha" ] && bash scripts/check-deploy-ancestry.sh "$baseline_sha" "$live_sha"; then
+              printf '%s\n' "$payload" > production-version.json
+              echo "Production ${live_sha} contains required editorial runtime ${baseline_sha}."
+              exit 0
+            fi
+            echo "Production is not compatible yet (${attempt}/90; live=${live_sha:-unknown})."
+            sleep 10
+          done
+          echo "::error::Production did not reach editorial runtime ${baseline_sha} or a descendant."
+          exit 1
+
+      - name: Run guarded editorial batch
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_EDITORIAL_BATCH_ALLOW_EXECUTE: '1'
+          WONDERLAB_EDITORIAL_BATCH_OUTPUT: wonderlab-editorial-batch-artifacts
+        run: |
+          set -euo pipefail
+          if [ -z "${WONDERLAB_ADMIN_TOKEN:-}" ]; then
+            echo '::error::CYPRESS_BETA_ADMIN_TOKEN is not configured.'
+            exit 1
+          fi
+          node scripts/wonderlab-editorial-batch.mjs
+
+      - name: Include deploy evidence
+        if: always()
+        run: |
+          mkdir -p wonderlab-editorial-batch-artifacts
+          if [ -f production-version.json ]; then
+            cp production-version.json wonderlab-editorial-batch-artifacts/workflow-production-version.json
+          fi
+
+      - name: Upload editorial batch evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wonderlab-editorial-batch-${{ github.run_id }}
+          path: wonderlab-editorial-batch-artifacts
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Post durable batch report
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+          OUTPUT_DIR: wonderlab-editorial-batch-artifacts
+        with:
+          script: |
+            const fs = require('node:fs')
+            const path = require('node:path')
+            const readJson = (name) => {
+              const target = path.join(process.env.OUTPUT_DIR, name)
+              if (!fs.existsSync(target)) return null
+              try {
+                return JSON.parse(fs.readFileSync(target, 'utf8'))
+              } catch (error) {
+                return { parseError: error.message }
+              }
+            }
+
+            const summary = readJson('batch-summary.json')
+            const failure = readJson('failure.json')
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const lines = [
+              '## WonderLab editorial batch report',
+              '',
+              `- **Workflow:** [run ${context.runId}](${runUrl})`,
+              `- **Result:** ${process.env.JOB_STATUS}`,
+              `- **Batch:** ${summary?.batchId || 'unknown'}`,
+              `- **Stage:** ${summary?.stage || 'unknown'}`,
+              `- **Production:** \`${summary?.production?.commit || 'unknown'}\``,
+              `- **Targets:** ${summary?.targetCount ?? 0}`,
+            ]
+
+            if (Array.isArray(summary?.targets)) {
+              lines.push('', '### Reviewed targets', '')
+              for (const target of summary.targets) {
+                const representation = Array.isArray(target.reasons)
+                  && target.reasons.some((reason) => String(reason).startsWith('cast representation floor:'))
+                lines.push(
+                  `- Component #${target.componentId} **${target.componentName || 'Untitled'}** → **${target.reviewerName || `${target.kind} #${target.id}`}** (${target.kind} #${target.id}, affinity ${target.score}${representation ? ', cast floor' : ''})`,
+                )
+              }
+            }
+
+            if (Array.isArray(summary?.generated) && summary.generated.length) {
+              lines.push('', '### Draft results', '')
+              for (const entry of summary.generated) {
+                lines.push(
+                  `- Component #${entry.componentId} / **${entry.reviewer?.name || 'Reviewer'}**: ${entry.success ? `draft #${entry.draftId} · ${entry.status}` : `failed · ${entry.message}`}`,
+                )
+              }
+              lines.push('', '- **Editorial boundary:** zero approvals and zero publications')
+            }
+
+            if (failure) lines.push('', `- **Failure:** ${failure.message || 'See uploaded evidence.'}`)
+            if (!summary && !failure) lines.push('', '- **Evidence:** no summary was produced; inspect the uploaded artifact and logs.')
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 582,
+              body: lines.join('\n'),
+            })

--- a/.github/workflows/wonderlab-editorial-batch.yml
+++ b/.github/workflows/wonderlab-editorial-batch.yml
@@ -150,10 +150,13 @@ jobs:
 
       - name: Include deploy evidence
         if: always()
+        env:
+          OUTPUT_DIR: wonderlab-editorial-batch-artifacts
+          DEPLOY_EVIDENCE: workflow-production-version.json
         run: |
-          mkdir -p wonderlab-editorial-batch-artifacts
+          mkdir -p "$OUTPUT_DIR"
           if [ -f production-version.json ]; then
-            cp production-version.json wonderlab-editorial-batch-artifacts/workflow-production-version.json
+            cp production-version.json "${OUTPUT_DIR}/${DEPLOY_EVIDENCE}"
           fi
 
       - name: Upload editorial batch evidence

--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "batchId": "wonderlab-editorial-001-dry-run",
+  "execute": false,
+  "minimumProductionCommit": "043ea2cdf12b3e3929b970778303391413c19284",
+  "componentIds": [],
+  "limit": 5,
+  "reviewersPerComponent": 2,
+  "minimumScore": 0,
+  "model": "gpt-4o-mini",
+  "regenerate": false,
+  "expectedTargets": []
+}

--- a/scripts/wonderlab-editorial-batch.mjs
+++ b/scripts/wonderlab-editorial-batch.mjs
@@ -1,0 +1,310 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import process from 'node:process'
+
+const configPath =
+  process.env.WONDERLAB_EDITORIAL_BATCH_CONFIG ||
+  'config/wonderlab-editorial-batch.json'
+const outputDir =
+  process.env.WONDERLAB_EDITORIAL_BATCH_OUTPUT ||
+  'wonderlab-editorial-batch-artifacts'
+const baseUrl = String(
+  process.env.WONDERLAB_BASE_URL || 'https://kind-robots.vercel.app',
+).replace(/\/$/, '')
+const adminToken = String(
+  process.env.WONDERLAB_ADMIN_TOKEN ||
+    process.env.CYPRESS_BETA_ADMIN_TOKEN ||
+    process.env.CYPRESS_API_KEY ||
+    '',
+).trim()
+const validateOnly = process.env.WONDERLAB_EDITORIAL_BATCH_VALIDATE_ONLY === '1'
+const executeAllowed = process.env.WONDERLAB_EDITORIAL_BATCH_ALLOW_EXECUTE === '1'
+
+const MAX_COMPONENTS = 10
+const MAX_TARGETS = 20
+
+function assertCondition(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function positiveInteger(value, label) {
+  const parsed = Number(value)
+  assertCondition(Number.isInteger(parsed) && parsed > 0, `${label} must be a positive integer.`)
+  return parsed
+}
+
+function boundedNumber(value, label, minimum, maximum) {
+  const parsed = Number(value)
+  assertCondition(
+    Number.isFinite(parsed) && parsed >= minimum && parsed <= maximum,
+    `${label} must be from ${minimum} to ${maximum}.`,
+  )
+  return parsed
+}
+
+function boundedString(value, label, maximum = 200) {
+  assertCondition(typeof value === 'string' && value.trim(), `${label} is required.`)
+  const trimmed = value.trim()
+  assertCondition(trimmed.length <= maximum, `${label} must be at most ${maximum} characters.`)
+  return trimmed
+}
+
+function uniquePositiveIds(value, label) {
+  assertCondition(Array.isArray(value), `${label} must be an array.`)
+  const ids = value.map((entry, index) => positiveInteger(entry, `${label}[${index}]`))
+  assertCondition(new Set(ids).size === ids.length, `${label} must not contain duplicates.`)
+  assertCondition(ids.length <= MAX_COMPONENTS, `${label} may contain at most ${MAX_COMPONENTS} IDs.`)
+  return ids
+}
+
+function validateExpectedTarget(value, index) {
+  assertCondition(value && typeof value === 'object' && !Array.isArray(value), `expectedTargets[${index}] must be an object.`)
+  assertCondition(value.kind === 'BOT' || value.kind === 'CHARACTER', `expectedTargets[${index}].kind must be BOT or CHARACTER.`)
+  return {
+    componentId: positiveInteger(value.componentId, `expectedTargets[${index}].componentId`),
+    kind: value.kind,
+    id: positiveInteger(value.id, `expectedTargets[${index}].id`),
+  }
+}
+
+function validateConfig(value) {
+  assertCondition(value && typeof value === 'object' && !Array.isArray(value), 'Editorial batch config must be an object.')
+  assertCondition(value.version === 1, 'Editorial batch config version must be 1.')
+  assertCondition(typeof value.execute === 'boolean', 'execute must be boolean.')
+
+  const componentIds = uniquePositiveIds(value.componentIds, 'componentIds')
+  const expectedTargets = Array.isArray(value.expectedTargets)
+    ? value.expectedTargets.map(validateExpectedTarget)
+    : (() => {
+        throw new Error('expectedTargets must be an array.')
+      })()
+  assertCondition(expectedTargets.length <= MAX_TARGETS, `expectedTargets may contain at most ${MAX_TARGETS} entries.`)
+  assertCondition(
+    new Set(expectedTargets.map((target) => `${target.componentId}:${target.kind}:${target.id}`)).size === expectedTargets.length,
+    'expectedTargets must not contain duplicates.',
+  )
+
+  const config = {
+    version: 1,
+    batchId: boundedString(value.batchId, 'batchId', 120),
+    execute: value.execute,
+    minimumProductionCommit: boundedString(value.minimumProductionCommit, 'minimumProductionCommit', 40),
+    componentIds,
+    limit: positiveInteger(value.limit, 'limit'),
+    reviewersPerComponent: positiveInteger(value.reviewersPerComponent, 'reviewersPerComponent'),
+    minimumScore: boundedNumber(value.minimumScore, 'minimumScore', -100, 500),
+    model: boundedString(value.model, 'model', 100),
+    regenerate: value.regenerate === true,
+    expectedTargets,
+  }
+
+  assertCondition(/^[0-9a-f]{40}$/.test(config.minimumProductionCommit), 'minimumProductionCommit must be a full lowercase commit SHA.')
+  assertCondition(config.limit <= MAX_COMPONENTS, `limit may not exceed ${MAX_COMPONENTS}.`)
+  assertCondition(config.reviewersPerComponent >= 1 && config.reviewersPerComponent <= 2, 'reviewersPerComponent must be 1 or 2.')
+  assertCondition(/^[a-zA-Z0-9._:-]+$/.test(config.model), 'model contains invalid characters.')
+
+  if (config.execute) {
+    assertCondition(config.componentIds.length > 0, 'Execution requires explicit componentIds from a reviewed dry run.')
+    assertCondition(config.expectedTargets.length > 0, 'Execution requires explicit expectedTargets from a reviewed dry run.')
+    assertCondition(executeAllowed, 'Execution requires WONDERLAB_EDITORIAL_BATCH_ALLOW_EXECUTE=1.')
+  } else {
+    assertCondition(config.expectedTargets.length === 0, 'Dry-run manifests must not contain expectedTargets.')
+  }
+
+  return config
+}
+
+async function writeJson(name, value) {
+  await writeFile(`${outputDir}/${name}`, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function requestJson(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    redirect: 'follow',
+    ...options,
+  })
+  const text = await response.text()
+  let body
+  try {
+    body = text ? JSON.parse(text) : null
+  } catch {
+    body = { raw: text }
+  }
+
+  if (!response.ok) {
+    const message =
+      body && typeof body === 'object' && typeof body.message === 'string'
+        ? body.message
+        : `${options.method || 'GET'} ${path} returned ${response.status}.`
+    const error = new Error(message)
+    error.status = response.status
+    error.body = body
+    throw error
+  }
+
+  return body
+}
+
+async function publicRequest(path) {
+  return requestJson(path, { headers: { accept: 'application/json' } })
+}
+
+async function adminRequest(path, options = {}) {
+  assertCondition(adminToken, 'WONDERLAB_ADMIN_TOKEN (or the existing Cypress admin secret) is required.')
+  return requestJson(path, {
+    ...options,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'x-beta-admin-token': adminToken,
+      'x-admin-token': adminToken,
+      'x-api-key': adminToken,
+    },
+  })
+}
+
+function responseDataObject(payload, label) {
+  const data = payload && typeof payload === 'object' ? payload.data : null
+  assertCondition(data && typeof data === 'object' && !Array.isArray(data), `${label} did not return a data object.`)
+  return data
+}
+
+function normalizedTargets(data) {
+  const targets = Array.isArray(data?.targets) ? data.targets : []
+  return targets.map((target, index) => {
+    const author = target?.reviewer?.author
+    assertCondition(author?.kind === 'BOT' || author?.kind === 'CHARACTER', `targets[${index}] has an invalid author kind.`)
+    return {
+      componentId: positiveInteger(target.componentId, `targets[${index}].componentId`),
+      componentName: String(target.componentName || ''),
+      kind: author.kind,
+      id: positiveInteger(author.id, `targets[${index}].author.id`),
+      reviewerName: String(target.reviewer?.name || ''),
+      score: Number(target.reviewer?.score) || 0,
+      reasons: Array.isArray(target.reviewer?.reasons) ? target.reviewer.reasons : [],
+      coverage: String(target.reviewer?.coverage || ''),
+    }
+  })
+}
+
+function targetIdentity(target) {
+  return {
+    componentId: target.componentId,
+    kind: target.kind,
+    id: target.id,
+  }
+}
+
+await mkdir(outputDir, { recursive: true })
+
+try {
+  const config = validateConfig(JSON.parse(await readFile(configPath, 'utf8')))
+  await writeJson('validated-config.json', config)
+
+  if (validateOnly) {
+    console.log(`WonderLab editorial batch config validated: ${config.batchId} (${config.execute ? 'execute' : 'dry run'}).`)
+    process.exit(0)
+  }
+
+  const [versionPayload, auditPayload] = await Promise.all([
+    publicRequest('/api/version'),
+    adminRequest('/api/admin/wonderlab/review-rollout'),
+  ])
+  const version = responseDataObject(versionPayload, 'Production version')
+  const audit = responseDataObject(auditPayload, 'WonderLab rollout audit')
+  const blocked = Array.isArray(audit.checks)
+    ? audit.checks.filter((check) => check?.ok !== true).map((check) => check?.key || 'unknown')
+    : ['checks-unavailable']
+  assertCondition(audit.ready === true && blocked.length === 0, `WonderLab rollout audit is blocked: ${blocked.join(', ')}`)
+
+  const requestBody = {
+    componentIds: config.componentIds.length ? config.componentIds : undefined,
+    limit: config.limit,
+    reviewersPerComponent: config.reviewersPerComponent,
+    minimumScore: config.minimumScore,
+    model: config.model,
+    regenerate: config.regenerate,
+    dryRun: true,
+  }
+  const dryRunPayload = await adminRequest('/api/admin/wonderlab/review-drafts/generate-batch', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  })
+  const dryRunData = responseDataObject(dryRunPayload, 'Editorial batch dry run')
+  assertCondition(dryRunData.dryRun === true, 'Editorial batch preview did not remain a dry run.')
+  const targets = normalizedTargets(dryRunData)
+  assertCondition(targets.length <= MAX_TARGETS, `Dry run returned more than ${MAX_TARGETS} targets.`)
+  await writeJson('batch-dry-run.json', dryRunPayload)
+
+  if (config.execute) {
+    assertCondition(
+      JSON.stringify(targets.map(targetIdentity)) === JSON.stringify(config.expectedTargets),
+      'The global portfolio targets changed after review; execution was stopped.',
+    )
+  }
+
+  let executionPayload = null
+  let generated = []
+  if (config.execute) {
+    executionPayload = await adminRequest('/api/admin/wonderlab/review-drafts/generate-batch', {
+      method: 'POST',
+      body: JSON.stringify({ ...requestBody, dryRun: false }),
+    })
+    const executionData = responseDataObject(executionPayload, 'Editorial batch execution')
+    assertCondition(executionData.dryRun === false, 'Editorial batch execution unexpectedly remained a dry run.')
+    generated = Array.isArray(executionData.generated) ? executionData.generated : []
+    await writeJson('batch-execution.json', executionPayload)
+  }
+
+  const summary = {
+    batchId: config.batchId,
+    stage: config.execute ? 'EXECUTED' : 'DRY_RUN',
+    baseUrl,
+    production: {
+      commit: version.commit || null,
+      deploymentId: version.deploymentId || null,
+    },
+    rolloutReady: true,
+    request: {
+      componentIds: config.componentIds,
+      limit: config.limit,
+      reviewersPerComponent: config.reviewersPerComponent,
+      minimumScore: config.minimumScore,
+      model: config.model,
+      regenerate: config.regenerate,
+    },
+    portfolio: dryRunData.plan?.portfolio || null,
+    targetCount: targets.length,
+    targets,
+    generated: generated.map((entry) => ({
+      componentId: entry.componentId,
+      reviewer: entry.reviewer
+        ? {
+            kind: entry.reviewer.author?.kind,
+            id: entry.reviewer.author?.id,
+            name: entry.reviewer.name,
+          }
+        : null,
+      success: entry.success === true,
+      draftId: entry.draftId || null,
+      status: entry.status || null,
+      message: entry.message || null,
+    })),
+    editorialBoundary: {
+      approved: 0,
+      published: 0,
+    },
+  }
+  await writeJson('batch-summary.json', summary)
+  console.log(
+    `WonderLab editorial batch ${config.batchId}: ${summary.stage}; ${targets.length} target(s); ${generated.filter((entry) => entry.success).length} generated successfully.`,
+  )
+} catch (error) {
+  const failure = {
+    message: error instanceof Error ? error.message : String(error),
+    status: error?.status || null,
+    body: error?.body || null,
+  }
+  await writeJson('failure.json', failure)
+  console.error(failure.message)
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary

Adds an auditable, checked-in runner for the first real WonderLab editorial batches.

The initial manifest is dry-run only and automatically asks the global portfolio for five representation-priority Components. The runner records the exact Component/reviewer targets and posts them to #582 for review.

A later execution manifest must:

- use explicit Component IDs from that reviewed dry run;
- include the exact ordered Bot/Character target identities;
- pass a fresh production dry run immediately before execution;
- stop if any target has changed;
- receive the explicit workflow execution gate.

## Safety

- administrator token required;
- rollout audit must be Ready;
- no execution from pull-request validation;
- no execution unless the checked-in manifest says `execute: true`;
- no execution unless `WONDERLAB_EDITORIAL_BATCH_ALLOW_EXECUTE=1` is present;
- every execution is preceded by a matching dry run;
- maximum 10 Components and 20 targets;
- no approval, rejection, or publication APIs exist in the runner;
- generated results remain editorial drafts only.

The workflow runs on merge only when the merge message contains `[wonderlab-editorial-batch]`, preventing unrelated edits from replaying a reviewed manifest.

## Initial batch

`wonderlab-editorial-001-dry-run`

- execute: false
- automatic representation-priority selection
- 5 Components / up to 10 reviewer targets
- global portfolio policy from #609 and #614
- production baseline: `043ea2cdf12b3e3929b970778303391413c19284`

## Validation

- Node syntax and config validation;
- static forbidden-boundary checks;
- explicit target-drift contract;
- repository TypeScript and Contract Tests;
- Vercel preview.

Refs #582
Refs #606