### PR TITLE
Add Persian Miniature Painting to the Academy curriculum

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -335,6 +335,40 @@ export const academyStyles: AcademyStyle[] = [
     },
   },
   {
+    slug: 'persian-miniature',
+    name: 'Persian Miniature Painting',
+    era: 'c. 1400–1600',
+    sortYear: 1400,
+    region: 'Timurid Herat & Safavid Persia',
+    keyIdeas:
+      'Manuscript pages built to be held close and read slowly: court poetry and epic — the Bustan, the Shahnameh — illustrated with a logic opposite to Western perspective. Distant figures sit higher on the page rather than shrinking, light falls flat with no cast shadow, and buildings open in "cutaway" view so inside and outside read at once. Mineral pigment and gold leaf fill flat jewel-bright fields, and the picture surface doubles as ornament — tilework, foliage, and cloth patterns rendered with the same dense precision as the figures.',
+    recognitionCues: [
+      'No Western linear perspective — distant figures placed higher on the page rather than smaller',
+      'Flat, even lighting with no cast shadows',
+      'Brilliant, unmixed jewel colors — ultramarine, vermilion, gold leaf — in flat fields rather than blended',
+      'Dense surface ornament: patterned textiles, tiled architecture, stylized foliage rendered as precisely as the figures',
+      '"Cutaway" architecture showing a building\'s interior and exterior at once',
+      'A framing border of fine floral or geometric pattern around the scene',
+    ],
+    artists: [
+      {
+        name: 'Kamal ud-Din Bihzad',
+        years: 'c. 1450–1535',
+        note: 'Leading painter of the Herat workshop under Timurid and later Safavid patronage; widely regarded as the tradition\'s most technically refined master, sometimes called "the Persian Leonardo."',
+      },
+      {
+        name: 'Sultan Muhammad',
+        years: 'active early–mid 16th century, d. before 1555',
+        note: "Director of Shah Ismail's Tabriz workshop and first project director of the Shahnameh of Shah Tahmasp, known for dense, imaginative compositions.",
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image as a Persian miniature: flat, high-vantage compositions with distant figures placed higher rather than smaller, brilliant unshaded jewel colors, intricate architectural or garden detail, patterned textiles, and a dense floral or geometric border, no Western perspective or cast shadow',
+    },
+  },
+  {
     slug: 'northern-renaissance',
     name: 'Northern Renaissance',
     era: 'c. 1420–1570',


### PR DESCRIPTION
## Summary

- Syncs the 25th AI Art Academy curriculum movement — **Persian Miniature Painting** (`persian-miniature`, c. 1400–1600, Timurid Herat / Safavid Persia) — into `stores/seeds/academyStyles.ts`.
- Content (era, region, key ideas, recognition cues, artists Kamal ud-Din Bihzad and Sultan Muhammad, remix template) is sourced verbatim from conductor's `docs/curriculum-outline.md` §25 — no new facts invented.
- Inserted in chronological position (`sortYear: 1400`), between `renaissance` and `northern-renaissance`.
- `exampleWorks` and `previewImageSrc` are intentionally left for a follow-up task, matching how `ashcan-school` and other recent movement syncs landed (real example-work images need to be sourced/verified and committed separately).

This mirrors the pattern used by prior syncs (t-015 Neoclassicism, t-018 Bauhaus, t-031 Suprematism, t-034 Ashcan School) and closes the curriculum-content half of conductor's `ai-art-academy/t-035`. The other half of t-035 (batch-generating the 25 queued style-preview thumbnails) stays blocked on the home art relay, which is still not claiming jobs as of this session.

## How I verified

- `npx eslint stores/seeds/academyStyles.ts` — 0 errors
- Full project `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — exit 0, 0 TypeScript errors, both before and after rebasing onto latest `main`
- `prettier --write` — unchanged (already formatted correctly)
- Confirmed slug count went from 24 → 25 and the new entry sits in the correct chronological array position

## Stakes
reversible

## Notes for reviewer
Conductor task: `ai-art-academy/t-035` (kind_robots half only — the thumbnail-generation half remains `ready`, blocked on the home relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVudtDnspz1ZWvWm5QF3dU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVudtDnspz1ZWvWm5QF3dU)_