### PR TITLE
Document WonderLab editorial dry-run retriggers

### DIFF
--- a/scripts/wonderlab-editorial-batch.mjs
+++ b/scripts/wonderlab-editorial-batch.mjs
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import process from 'node:process'
 
+// A documentation-only change to this runner may safely retrigger the checked-in
+// dry-run manifest; execution remains controlled exclusively by validated config.
 const configPath =
   process.env.WONDERLAB_EDITORIAL_BATCH_CONFIG ||
   'config/wonderlab-editorial-batch.json'


### PR DESCRIPTION
Documentation-only change to the existing WonderLab editorial runner. The checked-in manifest remains dry-run-only and unchanged. This gives the installed workflow a normal follow-up push so it can produce its read-only target report for #582.