### PR TITLE
Run first reviewed WonderLab draft batch

### DIFF
--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,13 +1,24 @@
 {
   "version": 1,
-  "batchId": "wonderlab-editorial-001-dry-run",
-  "execute": false,
+  "batchId": "wonderlab-editorial-001-generate",
+  "execute": true,
   "minimumProductionCommit": "043ea2cdf12b3e3929b970778303391413c19284",
-  "componentIds": [],
+  "componentIds": [126, 1951, 124, 127, 885],
   "limit": 5,
   "reviewersPerComponent": 2,
   "minimumScore": 0,
   "model": "gpt-4o-mini",
   "regenerate": false,
-  "expectedTargets": []
+  "expectedTargets": [
+    { "componentId": 126, "kind": "CHARACTER", "id": 318 },
+    { "componentId": 126, "kind": "CHARACTER", "id": 333 },
+    { "componentId": 1951, "kind": "CHARACTER", "id": 365 },
+    { "componentId": 1951, "kind": "BOT", "id": 12 },
+    { "componentId": 124, "kind": "CHARACTER", "id": 242 },
+    { "componentId": 124, "kind": "BOT", "id": 398 },
+    { "componentId": 127, "kind": "CHARACTER", "id": 260 },
+    { "componentId": 127, "kind": "BOT", "id": 433 },
+    { "componentId": 885, "kind": "CHARACTER", "id": 243 },
+    { "componentId": 885, "kind": "BOT", "id": 394 }
+  ]
 }


### PR DESCRIPTION
Locks the exact ten reviewer targets returned by successful production dry run 29717322108. The guarded workflow will create editorial drafts only; approval and publication remain separate. Refs #582 and #606.