### PR TITLE
Gitignore the generated WonderLab component manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ kindblank_*.sql
 .env*
 /public/images/**
 !/public/images/.gitkeep
+/public/wonderlab-components.json


### PR DESCRIPTION
## Summary

- `public/wonderlab-components.json` is regenerated on every build by the `build:before` hook in `nuxt.config.ts` (`create-component-json.mjs`), so it's a pure build artifact — but it wasn't in `.gitignore`, leaving it as an untracked stray file after any local `npm run test`/`nuxi prepare`/build.
- Found while verifying the persian-miniature curriculum sync (PR #616) locally.
- Confirmed the file is not referenced anywhere as something that must pre-exist in the repo: `verifyWonderLabCanonicalManifest.ts`'s "canonical path" check only asserts the *generator script* references the right path/logic, not that the JSON output is committed.

## How I verified

- `git status --porcelain` clean after adding the ignore entry
- Confirmed the regeneration hook (`build:before` in `nuxt.config.ts`) runs `create-component-json.mjs` on every build, so no data is lost by not tracking it

## Stakes
reversible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVudtDnspz1ZWvWm5QF3dU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVudtDnspz1ZWvWm5QF3dU)_