### PR TITLE
fix: don't re-upload already-succeeded files on batch upload retry

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -761,6 +761,19 @@ async function handleBatchUpload() {
     result.failed.map((r) => r.file).filter(Boolean) as File[],
   )
 
+  // Drop already-uploaded files from the queue so a retry click only
+  // resubmits the ones that actually failed — otherwise a second click
+  // re-uploads the whole batch, including files that already succeeded,
+  // creating duplicate ArtImage rows.
+  if (succeededFiles.value.size) {
+    queuedFiles.value
+      .filter((item) => succeededFiles.value.has(item.file))
+      .forEach((item) => URL.revokeObjectURL(item.preview))
+    queuedFiles.value = queuedFiles.value.filter(
+      (item) => !succeededFiles.value.has(item.file),
+    )
+  }
+
   // Mirror store messaging locally so the component owns its own banners.
   message.value = uploadStore.message ?? ''
   error.value = result.failed.length


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software) — lane 1, front-end polish

### What changed / what I produced
- `components/art/image-upload.vue`: `handleBatchUpload()` now removes already-succeeded files from `queuedFiles` (revoking their object URLs) as soon as the batch result comes back, instead of leaving the whole original batch queued.

### How I verified
- `npx eslint components/art/image-upload.vue` — clean
- `npx prettier --check components/art/image-upload.vue` — clean
- `npm run test` (`vue-tsc --noEmit`) — 0 errors

### Stakes
reversible

### Flags for Reviewer
- none

### Kaizen suggestion
The single-clean-run path calls `clearQueue()` *after* setting `message.value`/`error.value` for the success banner, but `clearQueue()` itself resets both back to `''` — so the success message is set then immediately wiped on a fully-clean batch upload. Worth a follow-up to swap the order or have `clearQueue()` take an option to preserve messaging.

### Notes for reviewer
Found via a dedicated Explore pass over the Academy/art-styler component set as part of `ai-art-academy/t-010`'s recurring continuous-improvement cycle (previously fixed classes excluded: focus restoration, aria wiring, showRemixButton no-op, Set-keying by object identity, silent drag-and-drop rejection). Bug: when a batch partially fails, `queuedFiles` was left untouched, so clicking "Upload N images" again to retry the failures re-uploaded the entire original batch — including files that already succeeded — creating duplicate `ArtImage` rows and duplicate collection/model attachments.


---
_Generated by [Claude Code](https://claude.ai/code/session_014knakVStjLLuaA7mLtLJzx)_