### PR TITLE
Reject unknown fields on Bot creation (audit F-4)

### DIFF
--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -154,6 +154,23 @@ describe('Bot Management API Tests', () => {
     })
   })
 
+  it('rejects unknown fields on Bot creation', () => {
+    cy.request({
+      method: 'POST',
+      url: baseUrl,
+      headers: bearerHeaders(userToken),
+      body: {
+        name: `${botName}-unknown-field`,
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.be.false
+      expect(response.body.message).to.include('Unsupported Bot fields')
+    })
+  })
+
   it('forbids attaching another user private Dream on Bot creation', () => {
     expect(privateDreamId, 'privateDreamId').to.be.a('number')
 

--- a/server/api/bots/index.post.ts
+++ b/server/api/bots/index.post.ts
@@ -3,11 +3,71 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
+import { assertOnlyFields } from '../../utils/chatApi'
 import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueBotSlug } from '../../utils/botSlug'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { botMutationSelect } from './selects'
 import { assertBotRelationsAttachable } from './relations'
+
+// Every persisted Bot column plus the relation keys a round-tripped Bot object
+// (the store sends a full Partial<Bot>) can echo, plus the `dreamIds` input
+// alias. Persisted fields are read below; identity/system/relation keys are
+// tolerated but never trusted. Anything outside this set is rejected (400)
+// instead of silently dropped (audit F-4).
+const botCreateFields = new Set<string>([
+  // persisted scalars
+  'BotType',
+  'name',
+  'slug',
+  'subtitle',
+  'description',
+  'avatarImage',
+  'imagePath',
+  'botIntro',
+  'userIntro',
+  'prompt',
+  'trainingPath',
+  'theme',
+  'personality',
+  'modules',
+  'sampleResponse',
+  'tagline',
+  'narrativeVoice',
+  'forgeIntro',
+  'chatBorderImage',
+  'designer',
+  'serverName',
+  'artPrompt',
+  'isPublic',
+  'underConstruction',
+  'canDelete',
+  'isMature',
+  'isActive',
+  // relation inputs
+  'serverId',
+  'artImageId',
+  'Dreams',
+  'dreamIds',
+  // identity/system + relation keys tolerated on a round-tripped row
+  'id',
+  'createdAt',
+  'updatedAt',
+  'userId',
+  'ArtImage',
+  'Server',
+  'User',
+  'ChallengeSubmissions',
+  'Chats',
+  'NarratedDreams',
+  'ExpressionMedia',
+  'ExpressionTransition',
+  'LifeRuns',
+  'NarratorThreads',
+  'ManagedProjects',
+  'Prompts',
+  'Reactions',
+])
 
 type BotCreateBody = Partial<Omit<Bot, 'userId'>> &
   Record<string, unknown> & {
@@ -106,6 +166,7 @@ export default defineEventHandler(async (event) => {
     }
 
     assertOwnershipIsServerManaged(botData)
+    assertOnlyFields(botData, botCreateFields, 'Bot')
 
     const name = getStringOrDefault(botData.name, '')
 

--- a/utils/scripts/verifyBotMutationOwnership.ts
+++ b/utils/scripts/verifyBotMutationOwnership.ts
@@ -117,4 +117,17 @@ requireText(
   'Bot relation permission deployed regression',
 )
 
+// Create-path input boundary: unknown fields are rejected, not silently dropped.
+requireText(createRoute, 'const botCreateFields = new Set<string>([', 'Bot create allowlist')
+requireText(
+  createRoute,
+  "assertOnlyFields(botData, botCreateFields, 'Bot')",
+  'Bot create field boundary wiring',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Bot creation',
+  'Bot create input boundary deployed regression',
+)
+
 console.log('Bot mutation ownership contract passed.')


### PR DESCRIPTION
## Summary

Partial close of audit finding **F-4** (bots). The Bot create route derived a fixed set of columns from a broad `Partial<Bot>` body and **silently dropped** everything else. This brings it to the same reject boundary the hardened families use.

- Add `botCreateFields` — an explicit allowlist of every persisted column **plus** the identity/system/relation keys a round-tripped `Bot` object (the store sends a full `Partial<Bot>`) legitimately echoes, **plus** the `dreamIds` input alias. Any key outside that set now returns **400** instead of being silently ignored.
- Call the shared `assertOnlyFields` after the ownership check; the generous compat set keeps round-tripped payloads working.
- Extend the Bot ownership contract and add a deployed cypress regression (unknown field on create → 400).

Ownership and relation gating are unchanged.

## ⚠️ Needs a smoke test before merge

The Bot create payload round-trips a full `Partial<Bot>` from the store (`stores/helpers/botHelper.ts` → `addBot`). I built the compat set from every current Bot column, so only genuinely-unknown keys should 400 — but I can't exercise your live create form. **Please create a bot from the running app** (or `workflow_dispatch` the bot cypress spec against the deployed instance) to confirm a normal create still returns 201. If it 400s with "Unsupported Bot fields: X", tell me `X` and I'll add it to the compat set.

## Checks

- Bot Mutation Ownership (DB-free contract, extended) — passes locally
- TypeScript Type Check — clean (0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_