### PR TITLE
Reject unknown fields on prompt/resource/server creation (audit F-4)

### DIFF
--- a/cypress/e2e/api/prompt-ownership.cy.ts
+++ b/cypress/e2e/api/prompt-ownership.cy.ts
@@ -51,4 +51,21 @@ describe('Prompt ownership boundary', () => {
       expect(response.body.message).to.include('Ownership is server-owned')
     })
   })
+
+  it('rejects unknown fields on Prompt creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: `${apiBase}/prompts`,
+      headers: adminHeaders(adminToken),
+      body: {
+        prompt: `Cypress unknown field ${Date.now()}`,
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Prompt fields')
+    })
+  })
 })

--- a/cypress/e2e/api/resources.cy.ts
+++ b/cypress/e2e/api/resources.cy.ts
@@ -134,6 +134,25 @@ describe('Resource Management API Tests', () => {
     })
   })
 
+  it('rejects unknown fields on Resource creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: baseUrl,
+      headers: headers(),
+      body: {
+        name: `Unknown-${uniqueResourceName}`,
+        resourceType: 'URL',
+        supportedServer: 'GENERIC',
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Resource fields')
+    })
+  })
+
   it('creates one Resource with a lean mutation response', () => {
     cy.request<ApiResponse<ResourceRow>>({
       method: 'POST',

--- a/cypress/e2e/api/server-create-boundaries.cy.ts
+++ b/cypress/e2e/api/server-create-boundaries.cy.ts
@@ -79,6 +79,25 @@ describe('Server create boundaries', () => {
     })
   })
 
+  it('rejects unknown fields on Server creation', () => {
+    cy.request<ApiResponse>({
+      method: 'POST',
+      url: baseUrl(),
+      headers: headers(),
+      body: {
+        title: `Unknown Field Server ${stamp}`,
+        serverType: 'OLLAMA',
+        baseUrl: 'http://127.0.0.1:11434',
+        bogusField: 'nope',
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(400)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message).to.include('Unsupported Server fields')
+    })
+  })
+
   it('creates and updates an OLLAMA server with a masked API key', () => {
     cy.request<ApiResponse<ServerRow>>({
       method: 'POST',

--- a/server/api/prompts/index.post.ts
+++ b/server/api/prompts/index.post.ts
@@ -3,6 +3,7 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { assertOnlyFields } from '../../utils/chatApi'
 import { awardKarma } from '../../utils/karma'
 import type { Prisma, Prompt } from '~/prisma/generated/prisma/client'
 import { promptResourceSelect } from './selects'
@@ -11,6 +12,48 @@ type PromptCreateBody = Partial<Omit<Prompt, 'userId'>> &
   Record<string, unknown> & {
     CreationSource?: string
   }
+
+// Every persisted Prompt column plus the identity/system/relation keys a
+// round-tripped Prompt object can echo, plus the `CreationSource` alias.
+// Anything outside this set is rejected (400) instead of silently dropped
+// (audit F-4).
+const promptCreateFields = new Set<string>([
+  // persisted / read on create
+  'prompt',
+  'artPrompt',
+  'creationSource',
+  'CreationSource',
+  'isMature',
+  'isPublic',
+  'isActive',
+  'botId',
+  'artImageId',
+  // identity/system + relation keys tolerated on a round-tripped row
+  'id',
+  'createdAt',
+  'updatedAt',
+  'userId',
+  'serverId',
+  'imagePath',
+  'artStatus',
+  'batchId',
+  'batchIndex',
+  'queuePosition',
+  'startedAt',
+  'completedAt',
+  'errorMessage',
+  'notifiedAt',
+  'isBounty',
+  'bountyStatus',
+  'claimerId',
+  'Chats',
+  'ArtImage',
+  'Bot',
+  'Claimer',
+  'Server',
+  'User',
+  'Reactions',
+])
 
 function getPositiveIntegerOrUndefined(value: unknown): number | undefined {
   const numericValue = Number(value)
@@ -99,6 +142,8 @@ export default defineEventHandler(async (event) => {
         message: 'The "prompt" field is required and must be a string.',
       })
     }
+
+    assertOnlyFields(promptData, promptCreateFields, 'Prompt')
 
     const authenticatedUserId = user.id
     assertOwnershipMatchesAuthentication(promptData, authenticatedUserId)

--- a/server/api/resources/create.ts
+++ b/server/api/resources/create.ts
@@ -17,6 +17,48 @@ export type ResourceCreateBody = Partial<Omit<Resource, 'userId'>> &
     usedInImageIds?: number[]
   }
 
+// Every persisted Resource column plus the identity/system/relation keys a
+// round-tripped Resource object can echo, plus the relation-alias arrays the
+// builder accepts. Anything outside this set is rejected (400) instead of
+// silently dropped (audit F-4).
+export const resourceCreateFields = new Set<string>([
+  // persisted / read by buildResourceCreateInput
+  'name',
+  'customLabel',
+  'MediaPath',
+  'customUrl',
+  'civitaiUrl',
+  'huggingUrl',
+  'localPath',
+  'description',
+  'isMature',
+  'resourceType',
+  'artImageId',
+  'generation',
+  'supportedServer',
+  'isPublic',
+  'isActive',
+  'artPrompt',
+  'imagePath',
+  'slug',
+  // relation-alias inputs the builder understands
+  'connectServerIds',
+  'serverIds',
+  'connectLoraImageIds',
+  'usedInImageIds',
+  // identity/system + relation keys tolerated on a round-tripped row
+  'id',
+  'createdAt',
+  'updatedAt',
+  'userId',
+  'ArtImages',
+  'Reactions',
+  'ArtImage',
+  'User',
+  'UsedInImages',
+  'Servers',
+])
+
 export type ResourceBatchSkip = {
   name: string
   reason: string

--- a/server/api/resources/index.post.ts
+++ b/server/api/resources/index.post.ts
@@ -3,9 +3,11 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { assertOnlyFields } from '../../utils/chatApi'
 import {
   buildResourceCreateInput,
   isResourceDuplicateError,
+  resourceCreateFields,
   type ResourceCreateBody,
 } from './create'
 import { resourceMutationSelect } from './selects'
@@ -37,6 +39,12 @@ export default defineEventHandler(async (event) => {
         message: 'Resource data is required.',
       })
     }
+
+    assertOnlyFields(
+      body as Record<string, unknown>,
+      resourceCreateFields,
+      'Resource',
+    )
 
     const data = await buildResourceCreateInput({
       entry: body,

--- a/server/api/server/index.post.ts
+++ b/server/api/server/index.post.ts
@@ -2,12 +2,60 @@
 import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from './../../utils/prisma'
 import { errorHandler } from './../../utils/error'
+import { assertOnlyFields } from './../../utils/chatApi'
 import {
   buildServerCreateData,
   requireAuthUser,
   safeServer,
   validateServerEnums,
 } from './../../utils/serverApi'
+
+// Every persisted Server column plus the identity/system/relation keys a
+// round-tripped Server object can echo. Privilege columns (isOfficial,
+// isDefault, isEditable, apiKey, ...) stay tolerated here but remain gated
+// inside buildServerCreateData; anything outside this set is rejected (400)
+// instead of silently dropped (audit F-4).
+const serverCreateFields = new Set<string>([
+  'title',
+  'label',
+  'description',
+  'serverType',
+  'category',
+  'baseUrl',
+  'endpointPath',
+  'healthPath',
+  'isPublic',
+  'isOfficial',
+  'isDefault',
+  'isActive',
+  'isEditable',
+  'apiKeyName',
+  'apiLink',
+  'model',
+  'apiKey',
+  'designer',
+  'version',
+  'notes',
+  'sortOrder',
+  'lastCheckedAt',
+  'lastStatus',
+  'accessMode',
+  'isMature',
+  'artPrompt',
+  'authType',
+  // identity/system + relation keys tolerated on a round-tripped row
+  'id',
+  'createdAt',
+  'updatedAt',
+  'userId',
+  'ArtImages',
+  'Bots',
+  'Chats',
+  'Prompts',
+  'user',
+  'HealthChecks',
+  'Resources',
+])
 
 export default defineEventHandler(async (event) => {
   try {
@@ -26,6 +74,7 @@ export default defineEventHandler(async (event) => {
       body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
 
     validateServerEnums(safeBody)
+    assertOnlyFields(safeBody, serverCreateFields, 'Server')
 
     const data = buildServerCreateData(safeBody, user)
     const server = await prisma.server.create({ data })

--- a/utils/scripts/verifyPromptCreateOwnership.ts
+++ b/utils/scripts/verifyPromptCreateOwnership.ts
@@ -54,4 +54,21 @@ requireText(
   'Prompt elevated credential coverage',
 )
 
+// Create-path input boundary (audit F-4): unknown fields are rejected.
+requireText(
+  createRoute,
+  'const promptCreateFields = new Set<string>([',
+  'Prompt create allowlist',
+)
+requireText(
+  createRoute,
+  "assertOnlyFields(promptData, promptCreateFields, 'Prompt')",
+  'Prompt create field boundary wiring',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Prompt creation',
+  'Prompt create input boundary deployed regression',
+)
+
 console.log('Prompt create ownership contract passed.')

--- a/utils/scripts/verifyResourceMutationOwnership.ts
+++ b/utils/scripts/verifyResourceMutationOwnership.ts
@@ -87,4 +87,21 @@ requireText(
   'Resource patch deployed regression',
 )
 
+// Create-path input boundary (audit F-4): unknown fields are rejected.
+requireText(
+  createHelper,
+  'export const resourceCreateFields = new Set<string>([',
+  'Resource create allowlist',
+)
+requireText(
+  createRoute,
+  'resourceCreateFields',
+  'Resource create field boundary wiring',
+)
+requireText(
+  cypressSpec,
+  'rejects unknown fields on Resource creation',
+  'Resource create input boundary deployed regression',
+)
+
 console.log('Resource mutation ownership contract passed.')

--- a/utils/scripts/verifyServerMutationOwnership.ts
+++ b/utils/scripts/verifyServerMutationOwnership.ts
@@ -25,6 +25,7 @@ const createRoute = read('server/api/server/index.post.ts')
 const batchRoute = read('server/api/server/batch.post.ts')
 const patchRoute = read('server/api/server/[id].patch.ts')
 const cypressSpec = read('cypress/e2e/api/server-ownership.cy.ts')
+const createBoundarySpec = read('cypress/e2e/api/server-create-boundaries.cy.ts')
 
 requireText(
   serverApi,
@@ -87,6 +88,23 @@ requireText(
   cypressSpec,
   'adminHeaders(adminToken)',
   'Server elevated credential coverage',
+)
+
+// Create-path input boundary (audit F-4): unknown fields are rejected.
+requireText(
+  createRoute,
+  'const serverCreateFields = new Set<string>([',
+  'Server create allowlist',
+)
+requireText(
+  createRoute,
+  "assertOnlyFields(safeBody, serverCreateFields, 'Server')",
+  'Server create field boundary wiring',
+)
+requireText(
+  createBoundarySpec,
+  'rejects unknown fields on Server creation',
+  'Server create input boundary deployed regression',
 )
 
 console.log('Server mutation ownership contract passed.')


### PR DESCRIPTION
## Summary

Closes the remainder of audit finding **F-4** (prompts, resources, server; bots is PR #623). Each create route derived a fixed set of columns from a broad `Partial<Model>` body and **silently dropped** everything else. This brings all three to the same reject boundary the hardened families use.

- **prompts** — add `promptCreateFields` + `assertOnlyFields(promptData, …)`
- **resources** — add `resourceCreateFields` (in `create.ts`) + `assertOnlyFields` in `index.post.ts`
- **server** — add `serverCreateFields` + `assertOnlyFields(safeBody, …)`

Each allowlist is every persisted column **plus** the identity/system/relation keys a round-tripped model object (the stores send full `Partial<Model>` payloads) can echo, **plus** each route's relation-alias inputs. Compatible payloads keep working; genuinely-unknown keys now return **400** instead of being silently ignored. Ownership, enum, and relation checks are unchanged; privilege columns on server stay gated inside `buildServerCreateData`.

Extends the prompt/resource/server ownership contracts and adds a deployed cypress regression to each spec (unknown field on create → 400).

## ⚠️ Needs a smoke test before merge

These three create routes round-trip full `Partial<Model>` payloads from their stores. I built each compat set from every current model column, so only genuinely-unknown keys should 400 — but I can't exercise your live create flows. Please, from the running app (or by `workflow_dispatch`-ing the relevant cypress specs against the deployed instance):

1. **Create a Prompt** (e.g. generate/save a prompt) → expect 201, not 400
2. **Create a Resource** (add a LoRA/checkpoint/URL resource) → expect 201
3. **Create a Server** (add a server in settings) → expect 201

If any returns `400 "Unsupported <Model> fields: X"`, tell me `X` and I'll add it to that compat set.

## Checks

- Prompt / Resource / Server Mutation Ownership (DB-free contracts, extended) — pass locally
- TypeScript Type Check — clean (0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_