### PR TITLE
Gate ArtImage patch + reaction sub-patch relations by permission (audit F-2 residual)

### DIFF
--- a/.github/workflows/art-image-patch-owner-transfer.yml
+++ b/.github/workflows/art-image-patch-owner-transfer.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'server/api/art/image/\[id\].patch.ts'
+      - 'server/api/art/image/relations.ts'
       - 'cypress/e2e/api/art-image-create-contract.cy.ts'
       - 'utils/scripts/verifyArtImagePatchOwnerTransfer.ts'
       - '.github/workflows/art-image-patch-owner-transfer.yml'

--- a/.github/workflows/reaction-subpatch-envelope.yml
+++ b/.github/workflows/reaction-subpatch-envelope.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'server/api/reactions/art/\[id\].patch.ts'
       - 'server/api/reactions/dream/\[id\].patch.ts'
+      - 'server/api/reactions/access.ts'
+      - 'cypress/e2e/api/reactions.cy.ts'
       - 'utils/scripts/verifyReactionSubPatchEnvelope.ts'
       - '.github/workflows/reaction-subpatch-envelope.yml'
   workflow_dispatch:

--- a/cypress/e2e/api/art-image-create-contract.cy.ts
+++ b/cypress/e2e/api/art-image-create-contract.cy.ts
@@ -213,6 +213,25 @@ describe('ArtImage create and by-ids contracts', () => {
     })
   })
 
+  it('rejects a missing Server relation on ArtImage PATCH', () => {
+    // The connect target is existence + permission gated (audit F-2 residual);
+    // a nonexistent serverId is a 404 before any write.
+    cy.request<ApiResponse<ArtImage>>({
+      method: 'PATCH',
+      url: `${apiBase}/art/image/${privateImage.id}`,
+      headers: bearerHeaders(owner.token),
+      body: {
+        artPrompt: 'relation gate probe',
+        serverId: 999_999_999,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(404)
+      expect(response.body.success).to.eq(false)
+      expect(response.body.message || '').to.include('Server not found')
+    })
+  })
+
   it('requires authentication and bounded positive IDs for batch lookup', () => {
     cy.request<ApiResponse>({
       method: 'POST',

--- a/cypress/e2e/api/reactions.cy.ts
+++ b/cypress/e2e/api/reactions.cy.ts
@@ -262,6 +262,54 @@ describe('Reaction Management API Tests', () => {
     })
   })
 
+  it('forbids reacting to another user private ArtImage via the art sub-route', () => {
+    expect(otherToken).to.exist
+
+    // Create a private ArtImage owned by the owner, then confirm a different
+    // authenticated user cannot react to it through /api/reactions/art/:id
+    // (the sub-route now enforces the same visibility rule as POST /reactions).
+    cy.request<ApiResponse<{ id: number }>>({
+      method: 'POST',
+      url: `${apiBase}/art/image`,
+      headers: ownerHeaders(),
+      body: {
+        imagePath: `/images/test/private-reaction-${Date.now()}.webp`,
+        path: `/images/test/private-reaction-${Date.now()}.webp`,
+        fileName: 'private-reaction.webp',
+        fileType: 'webp',
+        isPublic: false,
+      },
+      failOnStatusCode: false,
+    }).then((createResponse) => {
+      expect(createResponse.status, JSON.stringify(createResponse.body)).to.eq(
+        201,
+      )
+      const privateArtImageId = createResponse.body.data?.id
+      expect(privateArtImageId).to.be.a('number')
+
+      cy.request<ApiResponse>({
+        method: 'PATCH',
+        url: `${apiBase}/reactions/art/${privateArtImageId}`,
+        headers: otherHeaders(),
+        body: { reactionType: 'LOVED' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(403)
+        expect(response.body.success).to.eq(false)
+        expect(response.body.message).to.include(
+          'permission to react to this ArtImage',
+        )
+      })
+
+      cy.request({
+        method: 'DELETE',
+        url: `${apiBase}/art/image/${privateArtImageId}`,
+        headers: ownerHeaders(),
+        failOnStatusCode: false,
+      })
+    })
+  })
+
   it('accepts a genuinely partial Reaction PATCH', () => {
     expect(reactionId).to.exist
 

--- a/server/api/art/image/[id].patch.ts
+++ b/server/api/art/image/[id].patch.ts
@@ -4,6 +4,7 @@ import type { ArtImage, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
+import { assertArtImageRelationsAttachable } from './relations'
 
 type PatchUser = {
   id: number
@@ -138,6 +139,22 @@ export default defineEventHandler(async (event) => {
         message: 'No valid ArtImage fields provided for update.',
       })
     }
+
+    // A connected Server / checkpoint Resource must exist and be public or owned
+    // by the caller (admins bypass the permission check). Raw scalar FK writes
+    // were previously unchecked (audit F-2 residual).
+    await assertArtImageRelationsAttachable(
+      {
+        serverId:
+          typeof updateData.serverId === 'number' ? updateData.serverId : null,
+        checkpointResourceId:
+          typeof updateData.checkpointResourceId === 'number'
+            ? updateData.checkpointResourceId
+            : null,
+      },
+      user.id,
+      user.isAdmin,
+    )
 
     const data: ArtImage = await prisma.artImage.update({
       where: { id },

--- a/server/api/art/image/[id].patch.ts
+++ b/server/api/art/image/[id].patch.ts
@@ -9,6 +9,7 @@ import { assertArtImageRelationsAttachable } from './relations'
 type PatchUser = {
   id: number
   isAdmin: boolean
+  isServerKey: boolean
 }
 
 // Owner transfer is intentionally NOT part of the general patch contract: a
@@ -59,6 +60,7 @@ async function requirePatchUser(event: H3Event): Promise<PatchUser> {
   return {
     id: auth.user.id,
     isAdmin: auth.isAdmin,
+    isServerKey: auth.isServerKey,
   }
 }
 
@@ -153,7 +155,7 @@ export default defineEventHandler(async (event) => {
             : null,
       },
       user.id,
-      user.isAdmin,
+      user.isAdmin || user.isServerKey,
     )
 
     const data: ArtImage = await prisma.artImage.update({

--- a/server/api/art/image/relations.ts
+++ b/server/api/art/image/relations.ts
@@ -1,0 +1,75 @@
+// /server/api/art/image/relations.ts
+import { createError } from 'h3'
+import prisma from '../../../utils/prisma'
+
+type OwnableRow = { id: number; userId: number | null; isPublic: boolean | null }
+
+export type ArtImageRelationAttachInput = {
+  serverId?: number | null
+  checkpointResourceId?: number | null
+}
+
+// Verifies existence (404 for missing) and permission (403 for a private target
+// owned by someone else) for the Server / checkpoint Resource an ArtImage patch
+// connects. A non-admin may only attach public or self-owned rows; admins skip
+// the permission check but keep existence. Disconnects (null) are not checked.
+async function assertRelationAccessible(
+  id: number | null | undefined,
+  find: (id: number) => Promise<OwnableRow | null>,
+  label: string,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (typeof id !== 'number' || id <= 0) return
+
+  const row = await find(id)
+
+  if (!row) {
+    throw createError({
+      statusCode: 404,
+      message: `${label} not found: ${id}.`,
+    })
+  }
+
+  if (isAdmin) return
+
+  if (row.userId !== userId && row.isPublic !== true) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach this ${label} to an ArtImage.`,
+    })
+  }
+}
+
+export async function assertArtImageRelationsAttachable(
+  input: ArtImageRelationAttachInput,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  await Promise.all([
+    assertRelationAccessible(
+      typeof input.serverId === 'number' ? input.serverId : undefined,
+      (id) =>
+        prisma.server.findUnique({
+          where: { id },
+          select: { id: true, userId: true, isPublic: true },
+        }),
+      'Server',
+      userId,
+      isAdmin,
+    ),
+    assertRelationAccessible(
+      typeof input.checkpointResourceId === 'number'
+        ? input.checkpointResourceId
+        : undefined,
+      (id) =>
+        prisma.resource.findUnique({
+          where: { id },
+          select: { id: true, userId: true, isPublic: true },
+        }),
+      'checkpoint Resource',
+      userId,
+      isAdmin,
+    ),
+  ])
+}

--- a/server/api/reactions/access.ts
+++ b/server/api/reactions/access.ts
@@ -1,0 +1,36 @@
+// /server/api/reactions/access.ts
+import { createError } from 'h3'
+
+type OwnableRow = { userId: number | null; isPublic: boolean | null }
+
+// A content reaction target (ArtImage, Dream, ...) must exist and be public or
+// owned by the reacting user; admins bypass. Used by the per-target reaction
+// sub-routes so they enforce the same visibility rule as POST /api/reactions
+// (audit F-2 residual).
+export async function assertReactionContentTargetAccessible(options: {
+  find: () => Promise<OwnableRow | null>
+  label: string
+  targetId: number
+  userId: number
+  isAdmin: boolean
+}): Promise<void> {
+  const { find, label, targetId, userId, isAdmin } = options
+
+  const row = await find()
+
+  if (!row) {
+    throw createError({
+      statusCode: 404,
+      message: `${label} #${targetId} not found.`,
+    })
+  }
+
+  if (isAdmin) return
+
+  if (row.userId !== userId && row.isPublic !== true) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to react to this ${label}.`,
+    })
+  }
+}

--- a/server/api/reactions/art/[id].patch.ts
+++ b/server/api/reactions/art/[id].patch.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireApiUser } from '../../../utils/authGuard'
+import { assertReactionContentTargetAccessible } from '../access'
 
 export default defineEventHandler(async (event) => {
   let artImageId: number | null = null
@@ -17,7 +18,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const { user } = await requireApiUser(event)
+    const { user, isAdmin } = await requireApiUser(event)
     const userId = user.id
 
     const body = await readBody(event)
@@ -29,6 +30,21 @@ export default defineEventHandler(async (event) => {
         message: 'Reaction type is required.',
       })
     }
+
+    // The target ArtImage must exist and be public or owned by the reacting
+    // user (admins bypass), matching POST /api/reactions (audit F-2 residual).
+    const targetArtImageId: number = artImageId
+    await assertReactionContentTargetAccessible({
+      find: () =>
+        prisma.artImage.findUnique({
+          where: { id: targetArtImageId },
+          select: { userId: true, isPublic: true },
+        }),
+      label: 'ArtImage',
+      targetId: targetArtImageId,
+      userId,
+      isAdmin,
+    })
 
     const existingReaction = await prisma.reaction.findFirst({
       where: {

--- a/server/api/reactions/dream/[id].patch.ts
+++ b/server/api/reactions/dream/[id].patch.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { validateApiKey } from '../../../utils/validateKey'
+import { assertReactionContentTargetAccessible } from '../access'
 import {
   ReactionType,
   Reaction_reactionCategory,
@@ -75,17 +76,21 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const dream = await prisma.dream.findUnique({
-      where: { id: dreamId },
-      select: { id: true },
+    // The target Dream must exist and be public or owned by the reacting user
+    // (admins bypass), matching POST /api/reactions (audit F-2 residual).
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const targetDreamId: number = dreamId
+    await assertReactionContentTargetAccessible({
+      find: () =>
+        prisma.dream.findUnique({
+          where: { id: targetDreamId },
+          select: { userId: true, isPublic: true },
+        }),
+      label: 'Dream',
+      targetId: targetDreamId,
+      userId: user.id,
+      isAdmin,
     })
-
-    if (!dream) {
-      throw createError({
-        statusCode: 404,
-        message: `Dream #${dreamId} not found.`,
-      })
-    }
 
     const body = await readBody<DreamReactionPatchBody>(event)
     const reactionType = normalizeReactionType(body?.reactionType)

--- a/utils/scripts/verifyArtImagePatchOwnerTransfer.ts
+++ b/utils/scripts/verifyArtImagePatchOwnerTransfer.ts
@@ -51,4 +51,28 @@ requireText(
   'ArtImage patch owner-transfer deployed regression',
 )
 
+// Relation attach gate (audit F-2 residual): connected Server / checkpoint
+// Resource must exist and be public-or-owned-or-admin.
+const relations = read('server/api/art/image/relations.ts')
+requireText(
+  relations,
+  'export async function assertArtImageRelationsAttachable',
+  'ArtImage relation attach gate',
+)
+requireText(
+  relations,
+  'row.userId !== userId && row.isPublic !== true',
+  'ArtImage relation permission predicate',
+)
+requireText(
+  patchRoute,
+  'assertArtImageRelationsAttachable(',
+  'ArtImage patch relation gate wiring',
+)
+requireText(
+  cypressSpec,
+  'rejects a missing Server relation on ArtImage PATCH',
+  'ArtImage relation gate deployed regression',
+)
+
 console.log('ArtImage patch owner-transfer contract passed.')

--- a/utils/scripts/verifyReactionSubPatchEnvelope.ts
+++ b/utils/scripts/verifyReactionSubPatchEnvelope.ts
@@ -42,6 +42,35 @@ for (const path of routes) {
   requireText(source, 'data: null,', `${path} error envelope data`)
   // The old error wrapper put the message inside data.
   forbidText(source, 'data: {\n        message', `${path} legacy error wrapper`)
+
+  // Target visibility gate (audit F-2 residual): the reaction target must be
+  // existence + permission checked before the reaction is written.
+  requireText(
+    source,
+    'assertReactionContentTargetAccessible({',
+    `${path} target visibility gate`,
+  )
 }
+
+// The shared visibility helper enforces public-or-owned-or-admin.
+const access = read('server/api/reactions/access.ts')
+requireText(
+  access,
+  'export async function assertReactionContentTargetAccessible',
+  'Reaction content target access helper',
+)
+requireText(
+  access,
+  'row.userId !== userId && row.isPublic !== true',
+  'Reaction content target permission predicate',
+)
+
+// Deployed regression pins the visibility gate on the art sub-route.
+const cypressSpec = read('cypress/e2e/api/reactions.cy.ts')
+requireText(
+  cypressSpec,
+  'forbids reacting to another user private ArtImage via the art sub-route',
+  'Reaction sub-route visibility deployed regression',
+)
 
 console.log('Reaction sub-patch response envelope contract passed.')


### PR DESCRIPTION
## Summary

Closes the remaining **F-2 residual** relation/target permission gaps — the paths not covered by the bots/projects fix.

### 1. ArtImage patch relations

The ArtImage patch route wrote `serverId` and `checkpointResourceId` as raw scalar FKs with **no existence or permission check**, so a caller could point their ArtImage at another user's private Server or checkpoint Resource.

- add `server/api/art/image/relations.ts`: `assertArtImageRelationsAttachable` — each connected Server / checkpoint Resource must **exist** (404) and be **public or owned by the caller** (403); admins **and server keys (render relay)** bypass the permission check but keep existence. Disconnects (`null`) are not checked.

### 2. Reaction sub-patch targets

The per-target reaction sub-routes (`/api/reactions/art/:id`, `/api/reactions/dream/:id`) wrote a Reaction without checking the target was visible to the reacting user, unlike the main `POST /api/reactions` which enforces per-category access. The art sub-route checked neither existence nor visibility; the dream sub-route checked existence only.

- add `server/api/reactions/access.ts`: `assertReactionContentTargetAccessible` — target must exist (404) and be public or owned by the caller (403); admins bypass. Wired into both the art and dream reaction sub-patch routes.

## Tests

- extends the ArtImage-patch and reaction-sub-patch DB-free contracts with the new gates
- deployed cypress regressions: missing `serverId` on ArtImage PATCH → 404; reacting to another user's private ArtImage via the art sub-route → 403

## Note on the render pipeline

`Server.isPublic` defaults to `false`, so **server keys** bypass the ArtImage permission check (matching the Bot gate) to avoid the render relay tripping the gate on a shared-but-private server. A regular user patching their own image can still only attach a public or self-owned Server/Resource. If your generation flow drives art-image patches with a non-server-key user token attaching an admin-owned private server, that would now 403 — worth a quick check, though the existing owner check already constrained this path.

## Checks

- ArtImage Patch Owner Transfer + Reaction Sub-Patch Envelope (DB-free contracts, extended) — pass locally
- TypeScript Type Check — clean (0 errors)
- Contract Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)