### PR TITLE
Match second quality probe target order

### DIFF
--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "batchId": "wonderlab-source-grounded-quality-probe-002",
+  "batchId": "wonderlab-source-grounded-quality-probe-002-retry",
   "execute": true,
   "minimumProductionCommit": "c4cf3d8d071d708b1b81be0b354a2fa9e533c187",
   "componentIds": [1951, 124],
@@ -12,7 +12,7 @@
   "expectedTargets": [
     { "componentId": 1951, "kind": "CHARACTER", "id": 365 },
     { "componentId": 1951, "kind": "BOT", "id": 12 },
-    { "componentId": 124, "kind": "BOT", "id": 398 },
-    { "componentId": 124, "kind": "CHARACTER", "id": 242 }
+    { "componentId": 124, "kind": "CHARACTER", "id": 242 },
+    { "componentId": 124, "kind": "BOT", "id": 398 }
   ]
 }


### PR DESCRIPTION
Updates only the target order returned by the current production portfolio. Reviewer identities, Components, model, regeneration behavior, and editorial safeguards are unchanged. No execution occurs on the PR.

Refs #582 and #606.