### PR TITLE
serendipity/t-012: add tutorial section for Serendipity under scenario channel

### DIFF
--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -131,6 +131,12 @@ export const tutorialChannels = {
         body: 'Create a new scenario with an intro, choices, stakes, and room for players to surprise the narrator.',
         image: tutorialImage('scenario', 'add'),
       },
+      {
+        key: 'serendipity',
+        title: 'Serendipity',
+        body: 'Step into a second-person story woven by the Serendipity bot: pick a tone, open the door, and answer honestly — the questions it asks quietly advance your real honey-dos and human-gated tasks along the way.',
+        image: tutorialImage('scenario', 'serendipity'),
+      },
     ],
   },
 


### PR DESCRIPTION
### Task
serendipity/t-012: Polish and upgrade Serendipity front-end surface (kind: software)

### What changed / what I produced
- Added a `serendipity` section to `tutorialChannels.scenario.sections` in `stores/helpers/tutorialCards.ts` (Stories tutorial channel), alongside the existing Scenario Gallery / Add Scenario entries. It resolves its image via the existing `tutorialImage('scenario', 'serendipity')` helper, falling back to a placeholder until dedicated art lands (same convention as every other entry in this file).

### How I verified
- `npx eslint stores/helpers/tutorialCards.ts` — clean
- `npx prettier --check stores/helpers/tutorialCards.ts` — clean
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0, no errors

### Stakes
reversible

### Flags for Reviewer
- This task's other three steps remain open, matching the precedent set by model-builder/t-029's prior cycle:
  1. Dashboard-tab + tutorial `.webp` art for Serendipity — blocked on the art-generation relay, which is confirmed still down as of this session (job 816, queued 2026-07-20T00:14Z, still `PENDING`/unclaimed 8 hours later).
  2. `liveUrl`/`channelKey`/`tabKey` backfill on the kind_robots Project record — confirmed via `GET /api/projects` that all three are still `null` for `conductorSlug: serendipity`. This needs an admin "Placements" click, not an agent action.
  3. "Evolve the placeholder scaffold into the full interactive experience" — not actually a placeholder: `components/pages/serendipity-page.vue` already implements the full story-weaving loop (LOCATION Dreams, Facets, momentum-driven narrative beats, HONEYDO/needs-human task weaving, and the Story ledger's per-item Apply write-back), per milestones m2/m4/m5 already marked `done` in the conductor roadmap. Treating this step as effectively covered rather than inventing new scope against a component that isn't actually a scaffold.

### Kaizen suggestion
The "Polish and upgrade `<Project>` front-end surface" task template gets filed identically across many projects regardless of how built-out the actual page already is (this is at least the second time — see model-builder/t-029 — where "evolve the placeholder scaffold" turned out to already be a fully-built feature). Worth a lighter-weight task template for projects whose milestones show real feature work already done, so the note doesn't imply scaffold-level work that isn't there.

### Notes for reviewer
Conductor roadmap task `serendipity/t-012` is at `status: review`; conductor-side TALKBACK/roadmap update to follow in the same session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUZiMD4MFQirDeRJxNfnAB)_