### PR TITLE
appmaker/t-012: add AppMaker section to conductor tutorial channel

### DIFF
--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -526,6 +526,12 @@ export const tutorialChannels = {
         body: 'Add a PortOS server to use a host of services. For more information, visit https://github.com/atomantic/PortOS',
         image: `images/tutorials/conductor/conductor.webp`,
       },
+      {
+        key: 'appmaker',
+        title: 'AppMaker',
+        body: 'The app factory — browse the fleet of apps already built, or spin up a new one from a name and a one-line description. Every app is a workspace folder, a project roadmap, and a Dream sharing one slug, so it plugs straight into the rest of Kind Robots.',
+        image: tutorialImage('conductor', 'appmaker'),
+      },
     ],
   },
   packs: {


### PR DESCRIPTION
### Task
conductor appmaker/t-012: Polish and upgrade AppMaker front-end surface (kind: software)

### What changed / what I produced
- Added an `appmaker` section under `tutorialChannels.conductor.sections` in `stores/helpers/tutorialCards.ts`, mirroring the existing `model-builder` entry under `tutorialChannels.builder.sections`. Resolves its image via the existing `tutorialImage('conductor', 'appmaker')` helper (placeholder fallback until dedicated art lands at `public/images/tutorials/conductor/appmaker.webp`).

### How I verified
- `npx eslint stores/helpers/tutorialCards.ts` — clean
- `npm run test` (`vue-tsc --noEmit` across the whole repo) — exit 0, clean

### Stakes
reversible

### Flags for Reviewer
- Remaining steps on conductor appmaker/t-012 (out of scope for this PR, tracked there): dashboard-tab + tutorial `.webp` art generation, and the admin "Placements" backfill of the AppMaker Dream's `liveUrl`/`channelKey`/`tabKey`. `components/pages/appmaker-page.vue` (270 lines: browse the app fleet, create-app form, project jump-in) is already a full interactive experience, not a placeholder scaffold — so step (4) of the roadmap task's note is effectively already covered by prior work (appmaker/t-004).

### Kaizen suggestion
None this cycle — small, scoped follow-up to an existing task pattern.

### Notes for reviewer
Conductor-side roadmap task (appmaker/t-012) claimed and will be updated with progress notes after this PR lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_0152uKH7puyZtVJjvMDQWyrz)_