### PR TITLE
storymaker: surface live scenario data on the front page, add tutorial section

### DIFF
--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -17,6 +17,20 @@
           Storymaker builds on the Stories engine — bring your characters,
           settings, and rewards and let the narrator help them collide.
         </p>
+        <p v-if="totalScenarios > 0" class="text-xs text-base-content/60">
+          {{ totalScenarios }} scenario{{ totalScenarios === 1 ? '' : 's' }}
+          ready to weave into a story right now.
+        </p>
+        <ul v-if="recentScenarios.length" class="flex flex-col gap-1">
+          <li v-for="scenario in recentScenarios" :key="scenario.id">
+            <NuxtLink
+              to="/stories"
+              class="text-sm text-primary hover:underline"
+            >
+              {{ scenario.title || 'Untitled scenario' }}
+            </NuxtLink>
+          </li>
+        </ul>
         <NuxtLink
           to="/stories"
           class="btn btn-primary btn-sm gap-1.5 rounded-2xl"
@@ -30,7 +44,18 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted } from 'vue'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+import { useScenarioStore } from '@/stores/scenarioStore'
+
+const scenarioStore = useScenarioStore()
+
+onMounted(() => {
+  scenarioStore.initialize()
+})
+
+const totalScenarios = computed(() => scenarioStore.totalScenarios)
+const recentScenarios = computed(() => scenarioStore.scenarios.slice(0, 3))
 
 const config: ProjectFrontConfig = {
   slug: 'storymaker',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -137,6 +137,12 @@ export const tutorialChannels = {
         body: 'Step into a second-person story woven by the Serendipity bot: pick a tone, open the door, and answer honestly — the questions it asks quietly advance your real honey-dos and human-gated tasks along the way.',
         image: tutorialImage('scenario', 'serendipity'),
       },
+      {
+        key: 'storymaker',
+        title: 'Storymaker',
+        body: 'Bring your characters, settings, and rewards together and let the narrator turn choices into consequences with teeth — the long-form loom that gathers everything else into one unfolding story.',
+        image: tutorialImage('scenario', 'storymaker'),
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary

Conductor `storymaker/t-010` polish pass (steps 2 + 4 of 4):

- Added a `storymaker` section under `tutorialChannels.scenario.sections` in `stores/helpers/tutorialCards.ts`, mirroring the existing `serendipity` entry's shape (resolves via the existing `tutorialImage('scenario', 'storymaker')` helper, placeholder fallback until dedicated art lands).
- `components/conductor/storymaker-page.vue`'s `#interactive` slot was a static card with a single link-out to `/stories` and no real data. Wired it to `scenarioStore` (`initialize()` on mount — cheap local/seed data only, no live network fetch) to show a live scenario count and up to 3 scenario titles linking to `/stories`, alongside the existing CTA button. Followed the same store-usage convention already used in `scenario-gallery.vue`/`scenario-interact.vue`/`dream-manager.vue`.

Steps 1 (dashboard-tab + tutorial `.webp` art) and 3 (`liveUrl`/`channelKey`/`tabKey` backfill) remain blocked — the art-generation relay is currently not claiming jobs (confirmed live this session against a pending queued job), and step 3 needs an admin "Placements" click in Conductor. Both are tracked in the conductor roadmap task note; not attempted here.

## How I verified

- `npx eslint components/conductor/storymaker-page.vue stores/helpers/tutorialCards.ts` — clean
- `npx prettier --check` on both files — clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0, no errors
- Confirmed `useScenarioStore` is SSR-safe (guards all `localStorage` access via `isClient`) and that calling `initialize()` with no options only touches localStorage + bundled seed data (no network), matching the pattern in `scenario-gallery.vue`

## Stakes

reversible

## Notes for reviewer

Tracked by conductor project `storymaker`, task `t-010` (recurring "Polish and upgrade front-end surface" task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRpxxMbWxijpX9UjDtaPyJ)_