### PR TITLE
Render ArtImages path-first in the art-tool components (F-5)

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -903,6 +903,10 @@ const sourceImageSrc = computed<string>(() => {
     path?: string | null
   }
 
+  // Path-first: stored path, then inline base64, then the base64 thumb cache.
+  const path = img.imagePath || img.path || ''
+  if (path) return path
+
   if (img.thumbnailData) {
     return `data:image/${img.fileType || 'png'};base64,${img.thumbnailData}`
   }
@@ -911,7 +915,7 @@ const sourceImageSrc = computed<string>(() => {
     return `data:image/${img.fileType || 'png'};base64,${img.imageData}`
   }
 
-  return img.imagePath || img.path || galleryThumbs.value[img.id] || ''
+  return galleryThumbs.value[img.id] || ''
 })
 
 const resultImageSrc = computed<string>(() => {
@@ -923,11 +927,15 @@ const resultImageSrc = computed<string>(() => {
     path?: string | null
   }
 
+  // Path-first: stored path, then inline base64.
+  const path = img.imagePath || img.path || ''
+  if (path) return path
+
   if (img.imageData) {
     return `data:image/${img.fileType || 'png'};base64,${img.imageData}`
   }
 
-  return img.imagePath || img.path || ''
+  return ''
 })
 
 const kontextServer = computed<Server | null>(() => {

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -350,12 +350,13 @@ const previewArtImage = computed<ArtImage | null>(() => {
 
 const previewImage = computed(() => {
   if (isHiddenMature.value) return ''
+  // Path-first: prefer the stored path, fall back to inline base64.
   return (
-    createImageDataUrl(previewArtImage.value) ||
     safeText(previewArtImage.value?.imagePath).trim() ||
     safeText(
       (previewArtImage.value as ArtImage & { path?: string })?.path,
     ).trim() ||
+    createImageDataUrl(previewArtImage.value) ||
     safeText(props.fallbackImage).trim()
   )
 })

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -548,6 +548,14 @@ function shouldFetchFullImage(image: ArtImage) {
 }
 
 function shouldPreferImagePath(image: ArtImage) {
+  // Path-first: a real stored path (imagePath/path) wins over inline base64.
+  // A bare fileName is NOT a real path here, so it can't preempt usable base64.
+  const realPath =
+    image.imagePath?.trim() ||
+    (image as { path?: string | null }).path?.trim() ||
+    ''
+  if (realPath) return true
+
   const pathUrl = createImagePathUrl(image)
   if (!pathUrl) return false
   if (!image.imageData) return true

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -595,13 +595,16 @@ function historyImageSrc(image: ArtImage): string {
     imagePath?: string | null
     path?: string | null
   }
+  // Path-first: stored path, then inline base64.
+  const path = img.imagePath || img.path || ''
+  if (path) return path
   if (img.thumbnailData) {
     return `data:image/${img.fileType || 'png'};base64,${img.thumbnailData}`
   }
   if (img.imageData) {
     return `data:image/${img.fileType || 'png'};base64,${img.imageData}`
   }
-  return img.imagePath || img.path || ''
+  return ''
 }
 
 function handleFileSelect(event: Event) {

--- a/components/rewards/reward-card.vue
+++ b/components/rewards/reward-card.vue
@@ -283,17 +283,15 @@ const imageCandidates = computed<string[]>(() => {
   const candidates: string[] = []
   const image = embeddedArtImage.value || artImage.value
 
-  if (image?.imageData) {
-    candidates.push(
-      `data:${normalizeImageMime(image.fileType)};base64,${image.imageData}`,
-    )
-  }
+  // Path-first: try the art image's own path, the reward's imagePath, and the
+  // slug-derived path before any inline base64. The <img> onerror handler
+  // advances through this list, so base64 stays a graceful fallback.
+  const artPath =
+    image?.imagePath?.trim() ||
+    (image as { path?: string | null } | null | undefined)?.path?.trim() ||
+    ''
 
-  if (image?.thumbnailData) {
-    candidates.push(
-      `data:${normalizeImageMime(image.fileType)};base64,${image.thumbnailData}`,
-    )
-  }
+  if (artPath) candidates.push(artPath)
 
   const path = props.reward.imagePath?.trim()
 
@@ -314,6 +312,18 @@ const imageCandidates = computed<string[]>(() => {
 
   if (slug && rewardType) {
     candidates.push(`/images/rewards/${rewardType}/${slug}.webp`)
+  }
+
+  if (image?.imageData) {
+    candidates.push(
+      `data:${normalizeImageMime(image.fileType)};base64,${image.imageData}`,
+    )
+  }
+
+  if (image?.thumbnailData) {
+    candidates.push(
+      `data:${normalizeImageMime(image.fileType)};base64,${image.thumbnailData}`,
+    )
   }
 
   return Array.from(new Set(candidates))

--- a/components/rewards/reward-interact.vue
+++ b/components/rewards/reward-interact.vue
@@ -661,17 +661,14 @@ const heroImageCandidates = computed<string[]>(() => {
   const candidates: string[] = []
   const image = reward.ArtImage
 
-  if (image?.imageData) {
-    candidates.push(
-      `data:${normalizeImageMime(image.fileType)};base64,${image.imageData}`,
-    )
-  }
+  // Path-first: stored paths before inline base64; the <img> onerror handler
+  // advances through this list, so base64 stays a graceful fallback.
+  const artPath =
+    image?.imagePath?.trim() ||
+    (image as { path?: string | null } | null | undefined)?.path?.trim() ||
+    ''
 
-  if (image?.thumbnailData) {
-    candidates.push(
-      `data:${normalizeImageMime(image.fileType)};base64,${image.thumbnailData}`,
-    )
-  }
+  if (artPath) candidates.push(artPath)
 
   const path = reward.imagePath?.trim()
 
@@ -692,6 +689,18 @@ const heroImageCandidates = computed<string[]>(() => {
 
   if (slug && rewardType) {
     candidates.push(`/images/rewards/${rewardType}/${slug}.webp`)
+  }
+
+  if (image?.imageData) {
+    candidates.push(
+      `data:${normalizeImageMime(image.fileType)};base64,${image.imageData}`,
+    )
+  }
+
+  if (image?.thumbnailData) {
+    candidates.push(
+      `data:${normalizeImageMime(image.fileType)};base64,${image.thumbnailData}`,
+    )
   }
 
   return Array.from(new Set(candidates))


### PR DESCRIPTION
## Summary

Second/final client slice of the F-5 migration — the art-tool components. Flips the remaining saved-art render sites from base64-first to path-first, consistent with the stores + content cards in #637. **Self-contained** (no dependency on #637; can merge in either order).

- **image-card** — `shouldPreferImagePath` now prefers a **real** stored path (`imagePath`/`path`) over usable inline base64. Crucially, a bare `fileName` is *not* treated as a real path, so it can't preempt base64 (this is the exact bug that broke dreams; avoided here).
- **reward-card / reward-interact** — the `<img>` candidate array now lists stored paths (art image path, reward `imagePath`, slug-derived path) **before** inline base64. The `onerror` handler still advances through the list, so base64 remains an automatic fallback.
- **collection-card** — preview prefers `imagePath`/`path` before base64.
- **art-styler** (source + result) and **stylist-restyle** (history) — prefer the stored path, fall back to inline base64.

## Left unchanged on purpose

- `art-creator` — already path-first.
- `art-test` — renders a live generation `url`, not the standard ArtImage path flow.
- the art-styler base64 **thumbnail cache** and raw-base64 / upload-preview sites — these have no ArtImage path sibling to prefer (live generation / uploads in progress).

## After this + #637 merge

Every ArtImage render site is path-first, which unblocks the **server-side response lean** (dropping the heavy `imageData`/`*Data` columns from `art/image` create/patch/save responses) — I'll do that as the final PR, keeping the write path intact so uploads still persist.

## Checks

- TypeScript Type Check — clean (0 new errors)
- ESLint on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_