### PR TITLE
Fix dream-card path-first: don't treat a bare fileName as a path

### DIFF
--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -389,14 +389,15 @@ function imageToSrc(image?: Partial<ArtImage> | null): string {
   const thumb = (image as { thumbnailData?: string | null }).thumbnailData
   const fileType = (image as { fileType?: string | null }).fileType || 'png'
 
-  const rawPath =
-    image.imagePath ||
-    (image as { path?: string | null }).path ||
-    image.fileName ||
-    ''
+  // Path-first, but only a *real* stored path (imagePath/path) may beat inline
+  // base64. A bare fileName ("foo.webp") must NOT — isProbablyPath() treats any
+  // "*.webp" as a path, so folding fileName in here resolved pathless art to a
+  // broken URL and blanked it.
+  const storedPath =
+    image.imagePath || (image as { path?: string | null }).path || ''
 
-  if (rawPath && isProbablyPath(rawPath)) {
-    return normalizeImagePath(rawPath)
+  if (storedPath && isProbablyPath(storedPath)) {
+    return normalizeImagePath(storedPath)
   }
   if (thumb && !isProbablyPath(thumb)) {
     return `data:image/${fileType};base64,${thumb}`
@@ -405,7 +406,8 @@ function imageToSrc(image?: Partial<ArtImage> | null): string {
     return `data:image/${fileType};base64,${data}`
   }
 
-  return normalizeImagePath(rawPath)
+  // Last resort: a bare fileName only when there is no path and no base64.
+  return normalizeImagePath(storedPath || image.fileName || '')
 }
 
 async function loadPrimaryArt() {


### PR DESCRIPTION
Reapplies the fix that was lost from the #637 squash. `imageToSrc` folded `fileName` into its path candidate, and `isProbablyPath()` treats any `*.webp` string as a path — so after the path-first flip, dream art with base64 + a bare `fileName` but no real `imagePath` resolved the fileName to a broken URL and blanked the card. Only a real stored path (`imagePath`/`path`) may now beat inline base64; a bare `fileName` drops to the last resort, after base64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_