### PR TITLE
davinci: wire real endings/achievements into the front page interactive slot

### DIFF
--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -1,10 +1,56 @@
 <!-- /components/conductor/davinci-page.vue -->
 <template>
-  <ProjectFrontPage slug="davinci" :fallback="config" />
+  <ProjectFrontPage slug="davinci" :fallback="config">
+    <template #interactive>
+      <section
+        class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+      >
+        <div class="flex items-center gap-2">
+          <Icon name="kind-icon:trophy" class="size-5 text-primary" />
+          <h3
+            class="text-sm font-black uppercase tracking-wide text-base-content/70"
+          >
+            Endings on record
+          </h3>
+        </div>
+        <p class="text-sm text-base-content/70">
+          Each life resolves into one of the seeded endings below — reach it
+          once and the matching achievement is yours for good.
+        </p>
+        <p v-if="totalEndings > 0" class="text-xs text-base-content/60">
+          {{ totalEndings }} ending{{ totalEndings === 1 ? '' : 's' }} seeded so
+          far.
+        </p>
+        <ul v-if="recentEndings.length" class="flex flex-col gap-1">
+          <li v-for="ending in recentEndings" :key="ending.id">
+            <span class="text-sm text-base-content/80">{{ ending.label }}</span>
+          </li>
+        </ul>
+      </section>
+    </template>
+  </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted } from 'vue'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+import { useAchievementStore } from '@/stores/achievementStore'
+
+const achievementStore = useAchievementStore()
+
+onMounted(() => {
+  achievementStore.fetchAchievements()
+})
+
+const davinciEndingAchievements = computed(() =>
+  achievementStore.achievements.filter((achievement) =>
+    achievement.triggerCode?.startsWith('davinci-ending-'),
+  ),
+)
+const totalEndings = computed(() => davinciEndingAchievements.value.length)
+const recentEndings = computed(() =>
+  davinciEndingAchievements.value.slice(0, 3),
+)
 
 const config: ProjectFrontConfig = {
   slug: 'davinci',


### PR DESCRIPTION
### Task
davinci/t-014: Polish and upgrade Da Vinci front-end surface (kind: software)

### What changed / what I produced
- `components/conductor/davinci-page.vue`: added a `#interactive` slot to the `ProjectFrontPage` shell that fetches achievements client-side and lists the seeded `davinci-ending-*` achievements (title + live count), mirroring the pattern already shipped for `storymaker-page.vue` (live store data wired into the front page, not a full bespoke build).

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean, both before and after the change.
- `npx eslint components/conductor/davinci-page.vue` — clean.
- `npx prettier --check` — clean after `--write`.
- Confirmed `GET /api/achievements` is a public, unauthenticated endpoint (safe to call from this public marketing page).
- Confirmed via `GET https://kind-robots.vercel.app/api/projects` that the davinci project's `liveUrl`/`channelKey`/`tabKey` are all still `null` (step 3 of the roadmap task — needs an admin Placements click, not an agent action).

### Stakes
reversible

### Flags for Reviewer
- Roadmap task t-014 has 4 steps. Status of each:
  - (1) dashboard-tab + hero art: already queued in `art-prompts.yaml` (`kind-robots-davinci-image-*`, `conductor-davinci-hero-*`), blocked on the art-generation relay, which other sessions today (serendipity/t-012, storymaker/t-010) confirmed is still down.
  - (2) tutorialChannels entry: already present (`wonder.sections` has a `davinci` entry) — no action needed.
  - (3) liveUrl backfill: confirmed still null via live API, needs an admin Placements click.
  - (4) full interactive experience: the play-loop API (`POST /api/davinci/runs`, choices, resolve) exists server-side, but the AI-narration layer that would actually generate playable chapter content doesn't exist yet — building a full playable UI now would have nothing real to display. Scoped this pass to a smaller, real, live-data addition instead (the endings/achievements teaser above), same judgment call storymaker/t-010 made for its own scaffold.
- Noticed the front page's static `launch` CTA ("Begin a life") on `/davinci` points at `/davinci` itself (the same route), so it's currently a no-op link. Pre-existing, unrelated to this change — left alone rather than scope-creeping into it.

### Kaizen suggestion
File a task to design the Da Vinci AI-narration layer (prompt/response shape for chapter choices) — that's the actual blocker standing between the existing play-loop API and a real playable run UI, not front-end polish.

### Notes for reviewer
Conductor roadmap task davinci/t-014, claimed by session `claude-conductor-agent-20260720T-run1` (owner: reviewer).


---
_Generated by [Claude Code](https://claude.ai/code/session_0172oPjxefCRrVX5naD3ffHM)_