### PR TITLE
academy-styles-browser: key style detail panel by slug

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -40,6 +40,7 @@
       :id="`academy-style-detail-${expandedStyle.slug}`"
     >
       <academy-style-detail
+        :key="expandedStyle.slug"
         :lesson="expandedStyle"
         @close="closeStyle"
         @remix="emit('remix', $event)"


### PR DESCRIPTION
## Summary
- `academy-styles-browser.vue` renders the expanded style's detail panel via a shared `academy-style-detail` instance with no `:key`. Clicking a new grid tile while a panel is already open moves `expandedSlug` directly from one slug to another (never through `null`), so `v-if="expandedStyle"` stays true and Vue patches the same component instance in place instead of remounting it.
- `academy-style-detail.vue` records a lesson as viewed only in `onMounted` (`markLessonViewed(props.lesson.slug)`), so switching styles without closing the panel first means the newly-selected style's `onMounted` never re-fires — its viewed checkmark and `lessonsViewedCount` silently stop being tracked.
- `academy-timeline.vue` doesn't have this bug: each style lives in its own `v-for` `<li :key="style.slug">`, so switching styles there always mounts a genuinely distinct component instance.

## Fix
Add `:key="expandedStyle.slug"` to the `academy-style-detail` usage in `academy-styles-browser.vue`, forcing Vue to unmount/remount on slug change so `onMounted` (and therefore `markLessonViewed`) fires per style, matching the timeline's already-correct behavior.

## Test plan
- [x] `npx prettier --check components/academy/academy-styles-browser.vue` — passes
- [ ] CI: TypeScript / Contract verifiers / GitGuardian (this session has no `node_modules` installed to run the full local suite; relying on CI same as prior cycles in this rotation)
- [x] Manual trace: confirmed `expandedSlug` click handler (`academy-styles-browser.vue:68`) transitions directly between two non-null slugs, confirmed `academy-style-detail.vue`'s viewed-tracking is `onMounted`-only, confirmed `academy-timeline.vue` avoids the bug via per-item keyed `v-for`

Part of the ai-art-academy/t-010 continuous-improvement rotation (lane 1: front-end polish), conductor-tracked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PqjvJoDrr25paSzo7XG7Nf)_