### PR TITLE
conductor-app: wire live roadmap progress into the front page, add tutorial section

### DIFF
--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -1,10 +1,76 @@
 <!-- /components/conductor/conductor-app-page.vue -->
 <template>
-  <ProjectFrontPage slug="conductor-app" :fallback="config" />
+  <ProjectFrontPage slug="conductor-app" :fallback="config">
+    <template #interactive>
+      <section
+        class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+      >
+        <div class="flex items-center gap-2">
+          <Icon name="kind-icon:server" class="size-5 text-primary" />
+          <h3
+            class="text-sm font-black uppercase tracking-wide text-base-content/70"
+          >
+            Build progress
+          </h3>
+        </div>
+        <p class="text-sm text-base-content/70">
+          The Flutter client is built in the open, one roadmap task at a time —
+          the same conductor roadmap that steers every other project here.
+        </p>
+        <div v-if="totalTasks > 0" class="flex items-center gap-3">
+          <progress
+            class="progress progress-primary w-40"
+            :value="doneTasks"
+            :max="totalTasks"
+          />
+          <span class="text-xs text-base-content/60">
+            {{ doneTasks }} of {{ totalTasks }} tasks done
+          </span>
+        </div>
+        <ul v-if="nextTasks.length" class="flex flex-col gap-1">
+          <li
+            v-for="task in nextTasks"
+            :key="task.id"
+            class="text-sm text-base-content/70"
+          >
+            <Icon
+              name="kind-icon:sparkles"
+              class="mr-1 inline size-3.5 text-primary/70"
+            />
+            {{ task.title }}
+          </li>
+        </ul>
+        <p class="text-xs text-base-content/50">
+          Not on the App Store or Play Store yet — store readiness is its own
+          tracked task before any submission.
+        </p>
+      </section>
+    </template>
+  </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted } from 'vue'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+import { useConductorStore } from '@/stores/conductorStore'
+
+const conductorStore = useConductorStore()
+
+onMounted(() => {
+  conductorStore.fetchProjects()
+})
+
+const project = computed(() =>
+  conductorStore.projects.find((entry) => entry.slug === 'conductor-app'),
+)
+const tasks = computed(() => project.value?.tasks ?? [])
+const totalTasks = computed(() => tasks.value.length)
+const doneTasks = computed(
+  () => tasks.value.filter((task) => task.status === 'done').length,
+)
+const nextTasks = computed(() =>
+  tasks.value.filter((task) => task.status === 'ready').slice(0, 3),
+)
 
 const config: ProjectFrontConfig = {
   slug: 'conductor-app',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -538,6 +538,12 @@ export const tutorialChannels = {
         body: 'The app factory — browse the fleet of apps already built, or spin up a new one from a name and a one-line description. Every app is a workspace folder, a project roadmap, and a Dream sharing one slug, so it plugs straight into the rest of Kind Robots.',
         image: tutorialImage('conductor', 'appmaker'),
       },
+      {
+        key: 'conductor-app',
+        title: 'Conductor App',
+        body: 'The companion Flutter client for Conductor — review projects, approve gates, and nudge the build loop from a phone. Built in the open, one roadmap task at a time; not on the App Store or Play Store yet.',
+        image: tutorialImage('conductor', 'conductor-app'),
+      },
     ],
   },
   packs: {


### PR DESCRIPTION
## Summary
- `conductor-app-page.vue` had a scaffold (`ProjectFrontPage` + fallback config) but no `#interactive` slot, unlike storymaker/serendipity/davinci which already wire live data in. Added one showing live done/total task counts and the next `ready` tasks for the conductor-app project, sourced from `conductorStore.projects` (same store `appmaker-page.vue` already uses).
- `stores/helpers/tutorialCards.ts`'s `conductor` channel had sections for `conductor`, `portos`, and `appmaker` but was missing one for `conductor-app`. Added it.

## Test plan
- [x] `npx eslint components/conductor/conductor-app-page.vue stores/helpers/tutorialCards.ts` — clean
- [x] `npx prettier --check` on both files — clean
- [x] `npm run test` (`vue-tsc --noEmit` across the whole project) — 0 errors
- [ ] CI: TypeScript / Contract verifiers / GitGuardian

Part of conductor-app/t-013 ("Polish and upgrade Conductor App front-end surface"), conductor-tracked. Dashboard-tab/tutorial art (step 1) and the `liveUrl`/`channelKey`/`tabKey` backfill (step 3) remain blocked on the art-generation relay and an admin Placements click, respectively — left `ready` in the roadmap note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTwxGSinDBwBLgLoLR1EJc)_