### PR TITLE
ci: fix Cypress Tests never completing (push-cancel storm)

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,8 +1,18 @@
 name: Cypress Tests
 
+# Runs on a schedule rather than `push`. main's commit velocity (often multiple
+# merges per minute during active conductor cycles) is faster than a single
+# run can complete (deploy wait + DB readiness + the suite itself commonly
+# exceeds 20-30 minutes), so a push-triggered run under cancel-in-progress
+# concurrency was preempted by the next push before it could ever finish --
+# every run in the history showed conclusion "cancelled", so main effectively
+# had no Cypress signal at all. The "wait for deploy" step already tolerates
+# testing a commit that has been superseded by a later one on main, so a
+# periodic run against whatever is live works the same way a push-triggered
+# run did, just decoupled from push cadence.
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '*/30 * * * *'
   workflow_dispatch:
     inputs:
       max_wait_seconds:


### PR DESCRIPTION
## Summary
- The `Cypress Tests` workflow (`.github/workflows/cypress.yml`) triggers on every push to `main` with `concurrency: cancel-in-progress: true`. main's commit velocity (frequent conductor-driven merges, sometimes multiple per minute) is faster than one run can complete — the workflow itself waits up to 20 minutes for the deploy to go live, then does DB-readiness soak checks, then the actual Cypress suite.
- Checked 60+ of the most recent runs: **every single one has `conclusion: cancelled`**, going back many hours. `main` has effectively had zero real Cypress signal — not a test failure, a workflow trigger/concurrency fault.
- Fix: switch the trigger from `push` to a `schedule` cron (every 30 minutes), keeping `workflow_dispatch` for manual runs. The workflow's existing "wait for deploy" step already tolerates testing a commit that gets superseded by a later one on `main` (it walks ancestry), so a periodic run against whatever is currently live behaves the same as the old push-triggered run, just decoupled from push cadence so it can actually finish.
- No other logic changed.

Root-cause investigation and repair per the CI Janitor Todo for run [29742927233](https://github.com/silasfelinus/kind_robots/actions/runs/29742927233) (and the same cancellation pattern on run 29741776828 and every run before it that was checked).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cypress.yml'))"` — YAML parses.
- [ ] Confirm the workflow fires on its cron schedule and a run reaches `completed` with a real conclusion (not `cancelled`) within the next 30-60 minutes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_012LAsEGuSM9xKphZ5Ds2ssd)_