### PR TITLE
media-watchlist/t-006: show real corpus stats on the watchlist front page

### DIFF
--- a/components/conductor/watchlist-page.vue
+++ b/components/conductor/watchlist-page.vue
@@ -15,6 +15,11 @@ const config: ProjectFrontConfig = {
   tagline: 'Everything you meant to watch, in one honest list.',
   description:
     'A structured log for films and shows. Queue what you want to watch, mark what you are in the middle of, and archive what you finished — so "what should we watch tonight" finally has a single source of truth.',
+  stats: [
+    { label: 'entries logged', value: '2,440', icon: 'kind-icon:list' },
+    { label: 'years tracked', value: '12', icon: 'kind-icon:calendar' },
+    { label: 'starred favorites', value: '60', icon: 'kind-icon:star' },
+  ],
   sections: [
     {
       key: 'queue',
@@ -31,10 +36,10 @@ const config: ProjectFrontConfig = {
   ],
   deliverables: {
     done: [
-      'Watchlist data model and API',
-      'Status flow (queued / watching / done)',
+      'Real viewing log parsed and validated (2,440 entries, 12 years)',
+      'Import + normalization rules for 12 media types',
     ],
-    next: ['List + detail UI', 'Shared household lists'],
+    next: ['MediaEntry data model and API', 'List + detail UI'],
   },
 }
 </script>


### PR DESCRIPTION
### Task
media-watchlist/t-006: Polish and upgrade Media Watchlist front-end surface (kind: software)

### What changed / what I produced
- Added real headline `stats` to `components/conductor/watchlist-page.vue`'s fallback config: 2,440 entries logged, 12 years tracked, 60 starred favorites — sourced from the validated `media_list.md` import (media-watchlist/t-007, already merged, `data/import-report.md` in the conductor repo).
- Corrected the `deliverables.done`/`next` lists, which previously claimed a "Watchlist data model and API" that doesn't exist yet (no `MediaEntry` Prisma model or server route in this repo — verified by search). Now accurately reflects what's shipped (the parsed/validated real log) vs. what's next (the actual data model/API, list+detail UI).

### How I verified
- `npx eslint components/conductor/watchlist-page.vue` — clean
- `npx prettier --check components/conductor/watchlist-page.vue` — clean
- Full-project `vue-tsc --noEmit` — exit 0
- Confirmed the icon names used (`kind-icon:list`, `kind-icon:calendar`, `kind-icon:star`) already exist in the local kind-icon collection
- Confirmed the `stats` field on `ProjectFrontConfig` is an established pattern (used by `davinci-page.vue`, `humboldt-scoop-page.vue`, `scoop-cms-page.vue`)

### Stakes
reversible

### Flags for Reviewer
- Task t-006's other steps remain blocked: step (2) tutorial section already existed (no action needed, confirmed pre-existing in `tutorialCards.ts`); step (1) dashboard-tab/tutorial art is still queued in `art-prompts.yaml` (`kind-robots-watchlist-image-607fccd0`, `status: pending`) behind the art-generation relay, which multiple sessions today confirmed is still down; step (3) liveUrl/channelKey/tabKey backfill needs an admin "Placements" click. Roadmap task stays `ready`-with-progress rather than `done`, consistent with how serendipity/t-012, storymaker/t-010, and davinci/t-014 handled the same blocked steps today.
- No backend data model exists yet for Media Watchlist (only the conductor-side import scripts + JSON). Building the actual `MediaEntry` schema/API is out of scope for this polish pass — left as the natural next task.

### Kaizen suggestion
File a task to spec the `MediaEntry` Prisma model + minimal browse API from `SCHEMA-PROPOSAL.md`/`BROWSE-UX.md` (both already written), now that the real corpus is validated — this is the actual next milestone (m3: "Browse, filter, and stats UI") blocker.

### Notes for reviewer
Small, self-contained, config-only diff — no runtime logic changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt7kcZDY7mybMncSwfkkkj)_