### PR TITLE
coat-dance/t-010: tutorial card entry + real interactive slot

### DIFF
--- a/components/conductor/coat-dance-page.vue
+++ b/components/conductor/coat-dance-page.vue
@@ -1,10 +1,77 @@
 <!-- /components/conductor/coat-dance-page.vue -->
 <template>
-  <ProjectFrontPage slug="coat-dance" :fallback="config" />
+  <ProjectFrontPage slug="coat-dance" :fallback="config">
+    <template #interactive>
+      <section
+        class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+      >
+        <div class="flex items-center gap-2">
+          <Icon name="kind-icon:sparkles" class="size-5 text-primary" />
+          <h3
+            class="text-sm font-black uppercase tracking-wide text-base-content/70"
+          >
+            Behind the coat
+          </h3>
+        </div>
+        <p class="text-sm leading-relaxed text-base-content/70">
+          The source is real: an experimental physical-theater duet with a black
+          Goodwill trench coat, performed around 2006 while finishing a dance
+          major at Humboldt State University — physical theater, object
+          manipulation, juggling vocabulary, spins, pantomime, and deliberate
+          weirdness. The plan is to use that original recording as the
+          choreographic spine for an AI-assisted remix, expanding it with
+          animation, perspective shifts, and style changes while keeping the
+          strange intimacy between performer and coat.
+        </p>
+        <ul class="flex flex-col gap-1.5">
+          <li
+            v-for="stage in productionStages"
+            :key="stage.key"
+            class="flex items-center gap-2 text-sm"
+          >
+            <span
+              class="badge badge-sm rounded-lg"
+              :class="stage.status === 'done' ? 'badge-success' : 'badge-ghost'"
+            >
+              {{ stage.status === 'done' ? 'done' : 'planned' }}
+            </span>
+            <span class="text-base-content/80">{{ stage.title }}</span>
+          </li>
+        </ul>
+      </section>
+    </template>
+  </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+
+// Mirrors projects/coat-dance/roadmap.yaml milestones m1-m5. Update alongside
+// the roadmap if a milestone's status changes.
+type ProductionStage = {
+  key: string
+  title: string
+  status: 'not-started' | 'done'
+}
+const productionStages: ProductionStage[] = [
+  { key: 'm1', title: 'Source ingest and beat map', status: 'not-started' },
+  {
+    key: 'm2',
+    title: 'Creative treatment and section plan',
+    status: 'not-started',
+  },
+  {
+    key: 'm3',
+    title: 'Pipeline tests and style frames',
+    status: 'not-started',
+  },
+  { key: 'm4', title: 'Section remixes and assembly', status: 'not-started' },
+  {
+    key: 'm5',
+    title: 'Final review, export, and release decision',
+    status: 'not-started',
+  },
+]
 
 const config: ProjectFrontConfig = {
   slug: 'coat-dance',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -293,6 +293,13 @@ export const tutorialChannels = {
         body: 'Pick a page from a set, tap a region to fill it, and group-fill matching sections with one color. Switch to a custom shade any time, undo mistakes, and save your progress or export a finished page as an image — it all saves itself as you go.',
         image: tutorialImage('art', 'coloring'),
       },
+      {
+        key: 'coat-dance',
+        title: 'Coat Dance',
+        body: 'An experimental AI-remixed music video built from a real 2006 physical-theater performance with a trench coat as duet partner. Still in early production planning.',
+        image: tutorialImage('art', 'coat-dance'),
+        underConstruction: true,
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary
- Add a `coat-dance` section under `tutorialChannels.art.sections` in `stores/helpers/tutorialCards.ts` (marked `underConstruction`, matching the existing pattern for early-stage features like `giftshop`/`community`).
- Replace the bare `ProjectFrontPage` scaffold in `components/conductor/coat-dance-page.vue` with a real `#interactive` slot: the true 2006 HSU trench-coat performance premise (from `projects/coat-dance/roadmap.yaml`'s `notes_from_silas`) plus a production-stage tracker mirroring the roadmap's five milestones (all `not-started`, matching current roadmap state — no fabricated remix-tool functionality since content production hasn't started yet).

Dashboard-tab/tutorial `.webp` art generation and the `liveUrl`/`channelKey` Placements backfill (steps 1 and 3 of `coat-dance/t-010`) remain blocked — art-generation relay down and an admin-only action respectively — noted in the roadmap task rather than attempted here.

## Test plan
- [x] `npx prettier --check` on both touched files — clean
- [x] `npx eslint` on both touched files — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — 0 errors
- [ ] Silas: confirm the coat-dance dashboard-tab/tutorial art once the relay is back, and run the Conductor "Placements" button to backfill `liveUrl`/`channelKey`/`tabKey`

Conductor task: `projects/coat-dance/roadmap.yaml` t-010 (claimed as `claude-burst-rotation-20260720T1440Z`).

https://claude.ai/code/session_01Q4hpfBS7SfXf8oa7BQFJFE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4hpfBS7SfXf8oa7BQFJFE)_