### PR TITLE
Stop returning the password hash from credential validation (P6 HIGH)

### DIFF
--- a/server/api/auth/index.ts
+++ b/server/api/auth/index.ts
@@ -168,7 +168,12 @@ export async function validateUserCredentials(
 
     const token = await createToken(user)
 
-    return { user, token }
+    // Never return the bcrypt password hash to any caller (login response,
+    // client logs/caches). Callers that need to verify a password re-fetch and
+    // compare server-side; nothing legitimately consumes this field.
+    const { password: _password, ...safeUser } = user
+
+    return { user: safeUser, token }
   } catch (error: unknown) {
     console.error(
       `Failed to validate user credentials: ${errorHandler(error).message}`,


### PR DESCRIPTION
**Audit finding (Phase 6, HIGH).** `validateUserCredentials` did `prisma.user.findUnique` with no `select` and returned the full row; `login.post.ts` spread it into the response — leaking the bcrypt **password hash** (offline-crackable, and into any client log/cache/proxy) on every successful login, alongside email/Role/stripe/mana.

Fix: strip `password` from the returned user at the source, so every caller (`login`, `password/change`) is covered. Auth is unaffected — the client authenticates with the JWT `token` (Bearer), and password verification happens server-side inside this function *before* the strip.

Follow-ups noted for later (lower severity): the login response still echoes the user's own `apiKey` (their own credential, the client's `apiKey` computed reads it) and the auth family lacks rate limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_