### PR TITLE
Gate model-builder runs by source-record ownership (audit P6 CRITICAL)

### DIFF
--- a/server/api/model-builder/runs/index.post.ts
+++ b/server/api/model-builder/runs/index.post.ts
@@ -8,6 +8,53 @@ import { runInclude } from './index'
 
 const actions = new Set<ModelBuildAction>(['CREATE', 'UPDATE', 'ASSET_ONLY'])
 
+// Source models a build run may target — exactly the ones the commit path can
+// write (promoteAsset / updateText / linkSourceToTarget). Each has a `userId`.
+const SOURCE_OWNER_MODELS: Record<
+  string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { findUnique: (args: any) => Promise<unknown> }
+> = {
+  Project: prisma.project,
+  Character: prisma.character,
+  Bot: prisma.bot,
+  Facet: prisma.facet,
+  Dream: prisma.dream,
+  Reward: prisma.reward,
+  Scenario: prisma.scenario,
+}
+
+async function assertSourceOwnership(
+  sourceType: string,
+  sourceId: number,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  const model = SOURCE_OWNER_MODELS[sourceType]
+  if (!model) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsupported sourceType: ${sourceType}.`,
+    })
+  }
+  const row = (await model.findUnique({
+    where: { id: sourceId },
+    select: { userId: true },
+  })) as { userId: number | null } | null
+  if (!row) {
+    throw createError({
+      statusCode: 404,
+      message: `${sourceType} not found: ${sourceId}.`,
+    })
+  }
+  if (!isAdmin && row.userId !== userId) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to build on this ${sourceType}.`,
+    })
+  }
+}
+
 type RunItemInput = {
   outputKey?: unknown
   label?: unknown
@@ -59,6 +106,13 @@ export default defineEventHandler(async (event) => {
         message: 'A valid sourceId is required.',
       })
     }
+
+    // The whole run — every commit item — writes to this source record. Verify
+    // the caller owns it (or is admin) HERE, once, so a build can't be pointed
+    // at another user's Bot/Character/Dream/etc. and overwrite it on commit
+    // (audit P6 CRITICAL). This also constrains sourceType to the models the
+    // commit path can actually target.
+    await assertSourceOwnership(sourceType, sourceId, auth.user.id, auth.isAdmin)
 
     if (!Array.isArray(body.items) || body.items.length === 0) {
       throw createError({


### PR DESCRIPTION
## Summary

Part of the #570 API overhaul — Phase 6 sweep of the previously un-audited mutation families.

`POST /api/model-builder/runs` accepted an arbitrary `sourceType`/`sourceId` with **no ownership check**. Because the commit path (`promoteAsset` / `updateText` / `linkSourceToTarget`) writes back to that source record, any authenticated user could open a build run pointed at **another user's** `Bot`, `Character`, `Dream`, `Project`, `Facet`, `Reward`, or `Scenario` and overwrite it on commit.

## Fix

- Added `SOURCE_OWNER_MODELS` — the exact set of models the commit path can target, each carrying a `userId`.
- Added `assertSourceOwnership(sourceType, sourceId, userId, isAdmin)`: resolves the source row, 404s if missing, 403s unless the caller owns it (admins bypass). This also constrains `sourceType` to a known-safe allowlist — an unsupported type now 400s instead of silently proceeding.
- Called once, right after `sourceId` validation, before any run/items are created.

## Verification

- `vue-tsc --noEmit` clean (only the 2 pre-existing, unrelated `wonderLabSourceEvidence` errors remain).
- Ownership check mirrors the established `reactions/index.post.ts` delegate-typing pattern.


---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_