### PR TITLE
Persist WonderLab editorial batch handoffs

### DIFF
--- a/.github/workflows/wonderlab-editorial-batch-handoff.yml
+++ b/.github/workflows/wonderlab-editorial-batch-handoff.yml
@@ -1,0 +1,123 @@
+name: WonderLab Editorial Batch Handoff
+
+on:
+  workflow_run:
+    workflows: [WonderLab Editorial Batch]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: wonderlab-editorial-batch-handoff-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  handoff:
+    name: Persist editorial batch handoff
+    if: >-
+      github.event.workflow_run.event != 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Download editorial batch evidence
+        uses: actions/download-artifact@v4
+        with:
+          name: wonderlab-editorial-batch-${{ github.event.workflow_run.id }}
+          path: wonderlab-editorial-batch-artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Create or update durable batch handoff
+        uses: actions/github-script@v7
+        env:
+          SUMMARY_PATH: wonderlab-editorial-batch-artifacts/batch-summary.json
+        with:
+          script: |
+            const fs = require('node:fs')
+
+            if (!fs.existsSync(process.env.SUMMARY_PATH)) {
+              core.setFailed(`Missing ${process.env.SUMMARY_PATH}`)
+              return
+            }
+
+            const summary = JSON.parse(fs.readFileSync(process.env.SUMMARY_PATH, 'utf8'))
+            const batchId = String(summary.batchId || '').trim()
+            if (!batchId) {
+              core.setFailed('Batch summary does not contain a batchId.')
+              return
+            }
+
+            const targets = Array.isArray(summary.targets) ? summary.targets : []
+            const title = `WonderLab batch handoff: ${batchId}`
+            const lines = [
+              '# WonderLab editorial batch handoff',
+              '',
+              `- **Source workflow:** [run ${context.payload.workflow_run.id}](${context.payload.workflow_run.html_url})`,
+              `- **Batch:** \`${batchId}\``,
+              `- **Stage:** ${summary.stage || 'unknown'}`,
+              `- **Production:** \`${summary.production?.commit || 'unknown'}\``,
+              `- **Targets:** ${targets.length}`,
+              '',
+              '## Reviewed targets',
+              '',
+            ]
+
+            for (const target of targets) {
+              const representation = Array.isArray(target.reasons)
+                && target.reasons.some((reason) => String(reason).startsWith('cast representation floor:'))
+              lines.push(
+                `- Component #${target.componentId} **${target.componentName || 'Untitled'}** → **${target.reviewerName || `${target.kind} #${target.id}`}** (${target.kind} #${target.id}, affinity ${target.score}${representation ? ', cast floor' : ''})`,
+              )
+            }
+
+            lines.push(
+              '',
+              '## Machine-readable execution targets',
+              '',
+              '```json',
+              JSON.stringify(
+                targets.map((target) => ({
+                  componentId: target.componentId,
+                  kind: target.kind,
+                  id: target.id,
+                })),
+                null,
+                2,
+              ),
+              '```',
+              '',
+              'This issue is an editorial handoff. It does not approve, generate, or publish reviews.',
+              '',
+              'Refs #582 and #606.',
+            )
+
+            const body = lines.join('\n')
+            const query = `repo:${context.repo.owner}/${context.repo.repo} in:title \"${title}\"`
+            const search = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 20 })
+            const existing = search.data.items.find((item) => !item.pull_request && item.title === title)
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                title,
+                body,
+                state: 'open',
+              })
+              core.info(`Updated handoff issue #${existing.number}.`)
+              return
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            })
+            core.info(`Created handoff issue #${created.data.number}.`)


### PR DESCRIPTION
Makes every successful production WonderLab editorial batch produce a durable, fetchable handoff issue.

- runs only after successful non-PR editorial workflows
- downloads the exact uploaded `batch-summary.json`
- creates or updates one issue per batch ID
- includes the readable Component/reviewer assignments
- includes machine-readable `{ componentId, kind, id }` execution targets
- performs no generation, approval, publication, database access, or content mutation
- remains idempotent across workflow reruns

This preserves the human review boundary while making long-running rollouts resumable without depending on a single giant tracker comment stream.

Refs #582 and #606.