### PR TITLE
Capture sixth WonderLab batch handoff

### DIFF
--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
-  "batchId": "wonderlab-source-grounded-rollout-006-dry-run",
+  "batchId": "wonderlab-source-grounded-rollout-006-reviewable-dry-run",
   "execute": false,
-  "minimumProductionCommit": "c450f66af5389912312921c9f426795fc648bae4",
+  "minimumProductionCommit": "1c187bfd9acfa7a5485845cd94fb41db5a7cd51b",
   "componentIds": [],
   "limit": 10,
   "reviewersPerComponent": 2,


### PR DESCRIPTION
Retriggers the read-only sixth WonderLab portfolio selection now that durable per-batch handoff issues are installed.

- uses current `main` as the production baseline
- selects 10 representation-priority Components and up to 20 reviewers
- writes no drafts and performs no model calls
- causes the completed production run to create/update a dedicated handoff issue containing the exact execution target JSON

Refs #582 and #606.