### PR TITLE
Harden comfy SSRF + challenge-submission relation attach (audit P6 HIGH)

### DIFF
--- a/server/api/challenges/[slug]/submissions.post.ts
+++ b/server/api/challenges/[slug]/submissions.post.ts
@@ -9,6 +9,7 @@ import { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
+import { userIsAdmin } from '~/server/utils/authUser'
 
 type SubmissionBody = {
   contenderSlug?: unknown
@@ -71,6 +72,56 @@ function optionalJson(value: unknown): string | undefined {
   return JSON.stringify(value)
 }
 
+// A submission may only attach records the submitter is allowed to see:
+// their own, or public ones (admins bypass). Without this gate a caller could
+// connect ANY id — including another user's private ArtImage/Character/
+// Scenario — and then read it back through the response include, turning this
+// route into an enumeration oracle for private content (audit P6 HIGH).
+async function assertSubmissionRelationsAttachable(
+  ids: { artImageId: number | null; characterId: number | null; scenarioId: number | null },
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (isAdmin) return
+
+  const notAttachable = { NOT: { OR: [{ userId }, { isPublic: true }] } }
+
+  const [artForbidden, characterForbidden, scenarioForbidden] =
+    await Promise.all([
+      ids.artImageId
+        ? prisma.artImage.count({
+            where: { id: ids.artImageId, ...notAttachable },
+          })
+        : 0,
+      ids.characterId
+        ? prisma.character.count({
+            where: { id: ids.characterId, ...notAttachable },
+          })
+        : 0,
+      ids.scenarioId
+        ? prisma.scenario.count({
+            where: { id: ids.scenarioId, ...notAttachable },
+          })
+        : 0,
+    ])
+
+  const forbiddenLabel =
+    artForbidden > 0
+      ? 'ArtImage'
+      : characterForbidden > 0
+        ? 'Character'
+        : scenarioForbidden > 0
+          ? 'Scenario'
+          : null
+
+  if (forbiddenLabel) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach that ${forbiddenLabel} to this submission.`,
+    })
+  }
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const auth = await validateApiKey(event)
@@ -123,6 +174,12 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 404, message: 'Active contender not found.' })
     }
 
+    await assertSubmissionRelationsAttachable(
+      { artImageId, characterId, scenarioId },
+      auth.user.id,
+      userIsAdmin(auth.user),
+    )
+
     const submission = await prisma.challengeSubmission.create({
       data: {
         Challenge: { connect: { id: challenge.id } },
@@ -138,11 +195,25 @@ export default defineEventHandler(async (event) => {
         Scenario: scenarioId ? { connect: { id: scenarioId } } : undefined,
         status: 'READY',
       },
-      include: {
-        Contender: true,
-        ArtImage: true,
-        Character: true,
-        Scenario: true,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        challengeId: true,
+        contenderId: true,
+        variantKey: true,
+        agentModel: true,
+        outputText: true,
+        promptUsed: true,
+        settings: true,
+        randomSelections: true,
+        status: true,
+        artImageId: true,
+        characterId: true,
+        scenarioId: true,
+        Contender: {
+          select: { id: true, slug: true, name: true, kind: true },
+        },
       },
     })
 

--- a/server/api/comfy/characterSheet.post.ts
+++ b/server/api/comfy/characterSheet.post.ts
@@ -8,8 +8,6 @@ import { authAndGate } from '../../utils/comfyGate'
 type CharacterSheetRequest = {
   serverId?: number | null
   serverName?: string | null
-  apiUrl?: string | null
-
   prompt?: string | null
   characterName?: string | null
   characterType?: string | null
@@ -110,9 +108,12 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const baseUrl = body.apiUrl?.trim()
-      ? cleanComfyBaseUrl(body.apiUrl)
-      : getComfyBaseUrl(server)
+    // SSRF hardening (audit P6 HIGH): never honor a client-supplied apiUrl.
+    // The outbound request carries ART_SERVER_PROXY_TOKEN in the
+    // X-Kindrobots-Server-Token header, so an attacker-controlled baseUrl would
+    // both reach arbitrary hosts and exfiltrate that token. Always use the
+    // access-checked server resolved from serverId/serverName.
+    const baseUrl = getComfyBaseUrl(server)
 
     const prompt =
       body.prompt?.trim() ||

--- a/server/api/comfy/hunyuan3d.post.ts
+++ b/server/api/comfy/hunyuan3d.post.ts
@@ -8,7 +8,6 @@ import { authAndGate } from '../../utils/comfyGate'
 type Hunyuan3dRequest = {
   serverId?: number | null
   serverName?: string | null
-  apiUrl?: string | null
   imageData?: string | null
   seed?: number | null
   steps?: number | null
@@ -108,9 +107,12 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const baseUrl = body.apiUrl?.trim()
-      ? cleanComfyBaseUrl(body.apiUrl)
-      : getComfyBaseUrl(server)
+    // SSRF hardening (audit P6 HIGH): never honor a client-supplied apiUrl.
+    // The outbound request carries ART_SERVER_PROXY_TOKEN in the
+    // X-Kindrobots-Server-Token header, so an attacker-controlled baseUrl would
+    // both reach arbitrary hosts and exfiltrate that token. Always use the
+    // access-checked server resolved from serverId/serverName.
+    const baseUrl = getComfyBaseUrl(server)
 
     const uploadedImage = await uploadImageToComfy({
       baseUrl,

--- a/server/api/comfy/kontext/generate.post.ts
+++ b/server/api/comfy/kontext/generate.post.ts
@@ -13,7 +13,6 @@ import { authAndGate } from '../../../utils/comfyGate'
 type KontextGenerateRequest = {
   serverId?: number | null
   serverName?: string | null
-  apiUrl?: string | null
   prompt?: string | null
   imageData?: string | null
   width?: number | null
@@ -130,9 +129,12 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const baseUrl = body.apiUrl?.trim()
-      ? cleanComfyBaseUrl(body.apiUrl)
-      : getComfyBaseUrl(server)
+    // SSRF hardening (audit P6 HIGH): never honor a client-supplied apiUrl.
+    // The outbound request carries ART_SERVER_PROXY_TOKEN in the
+    // X-Kindrobots-Server-Token header, so an attacker-controlled baseUrl would
+    // both reach arbitrary hosts and exfiltrate that token. Always use the
+    // access-checked server resolved from serverId/serverName.
+    const baseUrl = getComfyBaseUrl(server)
 
     const prompt = body.prompt?.trim() || defaultPrompt
     const uploadedImage = await uploadImageToComfy({

--- a/server/api/comfy/kontext/kombine.post.ts
+++ b/server/api/comfy/kontext/kombine.post.ts
@@ -8,7 +8,6 @@ import { authAndGate } from '../../../utils/comfyGate'
 type KombineGenerateRequest = {
   serverId?: number | null
   serverName?: string | null
-  apiUrl?: string | null
   prompt?: string | null
   imageDataA?: string | null
   imageDataB?: string | null
@@ -127,9 +126,12 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const baseUrl = body.apiUrl?.trim()
-      ? cleanComfyBaseUrl(body.apiUrl)
-      : getComfyBaseUrl(server)
+    // SSRF hardening (audit P6 HIGH): never honor a client-supplied apiUrl.
+    // The outbound request carries ART_SERVER_PROXY_TOKEN in the
+    // X-Kindrobots-Server-Token header, so an attacker-controlled baseUrl would
+    // both reach arbitrary hosts and exfiltrate that token. Always use the
+    // access-checked server resolved from serverId/serverName.
+    const baseUrl = getComfyBaseUrl(server)
 
     const [uploadedA, uploadedB] = await Promise.all([
       uploadImageToComfy({

--- a/server/api/comfy/ltx/image2Video.post.ts
+++ b/server/api/comfy/ltx/image2Video.post.ts
@@ -8,7 +8,6 @@ import { authAndGate } from '../../../utils/comfyGate'
 type LtxTextToVideoRequest = {
   serverId?: number | null
   serverName?: string | null
-  apiUrl?: string | null
   prompt?: string | null
   negativePrompt?: string | null
   width?: number | null
@@ -98,9 +97,12 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const baseUrl = body.apiUrl?.trim()
-      ? cleanComfyBaseUrl(body.apiUrl)
-      : getComfyBaseUrl(server)
+    // SSRF hardening (audit P6 HIGH): never honor a client-supplied apiUrl.
+    // The outbound request carries ART_SERVER_PROXY_TOKEN in the
+    // X-Kindrobots-Server-Token header, so an attacker-controlled baseUrl would
+    // both reach arbitrary hosts and exfiltrate that token. Always use the
+    // access-checked server resolved from serverId/serverName.
+    const baseUrl = getComfyBaseUrl(server)
 
     const workflow = buildLtxTextToVideoWorkflow({
       prompt: body.prompt?.trim() || defaultPrompt,

--- a/server/api/comfy/ltx/text2Video.post.ts
+++ b/server/api/comfy/ltx/text2Video.post.ts
@@ -8,7 +8,6 @@ import { authAndGate } from '../../../utils/comfyGate'
 type LtxTextToVideoRequest = {
   serverId?: number | null
   serverName?: string | null
-  apiUrl?: string | null
   prompt?: string | null
   negativePrompt?: string | null
   width?: number | null
@@ -103,9 +102,12 @@ export default defineEventHandler(async (event) => {
 
     assertComfyServer(server)
 
-    const baseUrl = body.apiUrl?.trim()
-      ? cleanComfyBaseUrl(body.apiUrl)
-      : getComfyBaseUrl(server)
+    // SSRF hardening (audit P6 HIGH): never honor a client-supplied apiUrl.
+    // The outbound request carries ART_SERVER_PROXY_TOKEN in the
+    // X-Kindrobots-Server-Token header, so an attacker-controlled baseUrl would
+    // both reach arbitrary hosts and exfiltrate that token. Always use the
+    // access-checked server resolved from serverId/serverName.
+    const baseUrl = getComfyBaseUrl(server)
 
     const workflow = buildLtxTextToVideoWorkflow({
       prompt: body.prompt?.trim() || defaultPrompt,

--- a/server/api/comfy/utils/resolveComfyUrl.ts
+++ b/server/api/comfy/utils/resolveComfyUrl.ts
@@ -6,20 +6,17 @@ import type { Server } from '~/prisma/generated/prisma/client'
 
 type ResolveComfyUrlInput = {
   serverId?: number | null
-  apiUrl?: string | null
 }
 
 export async function resolveComfyUrl(
   input: ResolveComfyUrlInput,
 ): Promise<string> {
-  if (input.apiUrl?.trim()) {
-    return cleanComfyBaseUrl(input.apiUrl)
-  }
-
+  // Client-supplied apiUrl is intentionally NOT honored (audit P6 HIGH SSRF).
+  // Comfy targets are resolved only from an access-checked Server record.
   if (!input.serverId) {
     throw createError({
       statusCode: 400,
-      message: 'serverId or apiUrl is required.',
+      message: 'serverId is required.',
     })
   }
 


### PR DESCRIPTION
Part of the #570 API overhaul — Phase 6 sweep of the previously un-audited mutation families. Two independent HIGH findings.

## 1. Comfy SSRF + server-token exfiltration

Six Comfy routes (`characterSheet`, `hunyuan3d`, `kontext/generate`, `kontext/kombine`, `ltx/image2Video`, `ltx/text2Video`) resolved a legitimate `Server` via `resolveServer(...)` but then **overrode** its base URL with a client-supplied `body.apiUrl`. Because the outbound request attaches `ART_SERVER_PROXY_TOKEN` in the `X-Kindrobots-Server-Token` header, an attacker-controlled `apiUrl` meant both **SSRF** (reach arbitrary hosts from the server) and **token exfiltration** (leak the proxy token to that host).

**Fix:** the base URL now always comes from the access-checked `Server` (`getComfyBaseUrl(server)`). `apiUrl` is removed from each request body type. `resolveComfyUrl` drops its `apiUrl` branch entirely — its only caller (`prompt/[promptId].get.ts`) passes just `serverId`, and that route sends no token header.

## 2. Challenge-submission relation attach + private-content read oracle

`POST /api/challenges/[slug]/submissions` connected `artImageId`/`characterId`/`scenarioId` with **no permission check** and then echoed the full related rows back via `include`. Any authenticated user could attach — and read back — another user's **private** ArtImage/Character/Scenario, turning the route into an enumeration oracle.

**Fix:** `assertSubmissionRelationsAttachable` gates each id to records the submitter may attach (own OR `isPublic`, admins bypass) before the connect, and the response now uses a lean `select` (scalar submission fields + minimal Contender) instead of echoing full relation graphs.

## Verification

- `vue-tsc --noEmit` clean (only the 2 pre-existing, unrelated `wonderLabSourceEvidence` errors remain).
- `eslint` clean on all touched files (one pre-existing unrelated `negativePrompt` unused-var in `characterSheet` predates this branch and is left untouched to keep the diff focused).


---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_