### PR TITLE
Finalize sixth WonderLab dry-run handoff

### DIFF
--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
-  "batchId": "wonderlab-source-grounded-rollout-006-reviewable-dry-run",
+  "batchId": "wonderlab-source-grounded-rollout-006-final-dry-run",
   "execute": false,
-  "minimumProductionCommit": "1c187bfd9acfa7a5485845cd94fb41db5a7cd51b",
+  "minimumProductionCommit": "e58bb532fc39241ee05dfdf4b528d6d248fe47ae",
   "componentIds": [],
   "limit": 10,
   "reviewersPerComponent": 2,


### PR DESCRIPTION
Runs the sixth read-only portfolio selection under the bot-report-backed durable handoff path.

- selects ten current representation-priority Components
- requests up to twenty exact reviewer assignments
- performs no model calls or writes
- uses a known deployed WonderLab runtime baseline
- causes the canonical bot report on #582 to create/update a dedicated batch handoff issue with execution JSON

Refs #582 and #606.