### PR TITLE
Generate sixth WonderLab rollout batch

### DIFF
--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,13 +1,34 @@
 {
   "version": 1,
-  "batchId": "wonderlab-source-grounded-rollout-006-final-dry-run",
-  "execute": false,
+  "batchId": "wonderlab-source-grounded-rollout-006",
+  "execute": true,
   "minimumProductionCommit": "e58bb532fc39241ee05dfdf4b528d6d248fe47ae",
-  "componentIds": [],
+  "componentIds": [1916, 1919, 1957, 1959, 1975, 1978, 1985, 2051, 1953, 47],
   "limit": 10,
   "reviewersPerComponent": 2,
   "minimumScore": 0,
   "model": "gpt-4o-mini",
   "regenerate": false,
-  "expectedTargets": []
+  "expectedTargets": [
+    { "componentId": 1916, "kind": "BOT", "id": 395 },
+    { "componentId": 1916, "kind": "CHARACTER", "id": 199 },
+    { "componentId": 1919, "kind": "BOT", "id": 12 },
+    { "componentId": 1919, "kind": "CHARACTER", "id": 133 },
+    { "componentId": 1957, "kind": "CHARACTER", "id": 228 },
+    { "componentId": 1957, "kind": "BOT", "id": 9 },
+    { "componentId": 1959, "kind": "BOT", "id": 290 },
+    { "componentId": 1959, "kind": "CHARACTER", "id": 228 },
+    { "componentId": 1975, "kind": "CHARACTER", "id": 206 },
+    { "componentId": 1975, "kind": "CHARACTER", "id": 261 },
+    { "componentId": 1978, "kind": "CHARACTER", "id": 120 },
+    { "componentId": 1978, "kind": "CHARACTER", "id": 359 },
+    { "componentId": 1985, "kind": "CHARACTER", "id": 225 },
+    { "componentId": 1985, "kind": "CHARACTER", "id": 180 },
+    { "componentId": 2051, "kind": "CHARACTER", "id": 281 },
+    { "componentId": 2051, "kind": "CHARACTER", "id": 145 },
+    { "componentId": 1953, "kind": "CHARACTER", "id": 286 },
+    { "componentId": 1953, "kind": "CHARACTER", "id": 984 },
+    { "componentId": 47, "kind": "CHARACTER", "id": 362 },
+    { "componentId": 47, "kind": "CHARACTER", "id": 150 }
+  ]
 }


### PR DESCRIPTION
Locks the exact 20 reviewer assignments recorded in handoff issue #659.

- 10 Components
- 20 assignments
- 15 distinct personalities
- all selected through the global representation-priority portfolio
- exact Component order and Bot/Character identities pinned from the production dry run
- model generation creates editorial drafts only
- zero approvals and zero publications

The merge trigger runs one bounded request per target, inventories resulting drafts, and posts durable evidence back to #582.

Refs #582, #606, and #659.