### PR TITLE
Phase 6 MEDIUM hardening sweep + audit doc (issue #570)

### DIFF
--- a/docs/api-mutation-audit.md
+++ b/docs/api-mutation-audit.md
@@ -1,9 +1,20 @@
 # API Mutation Audit — thin-resource pass
 
-_Definition-of-done audit for the API overhaul (issue #570), Phase 5. Enumerates
-every public mutation route with its authentication, ownership source, input
-contract, relation validation, response projection, and test coverage, then lists
-the remaining findings ranked by risk._
+_Definition-of-done audit for the API overhaul (issue #570). Phase 5 enumerated
+the "core" mutation families (dreams, scenarios, characters, rewards, themes,
+reactions, sheets, projects, todos, logs, chats, achievements, art, bots,
+prompts, resources, server, users) with their authentication, ownership source,
+input contract, relation validation, response projection, and test coverage.
+**Phase 6** (see its own section below) then swept the 16 mutation families the
+core pass never covered — comfy, challenges, model-builder, facets,
+dream-relations, davinci, botcafe, stripe, appmaker, relations, and the chatgpt
+schema-relation service — and closed the findings that sweep surfaced._
+
+> **Scope correction (Phase 6):** an earlier revision of this doc claimed the
+> definition-of-done held across "every public mutation route." That was only
+> ever verified for the core families in the table below. The Phase 6 families
+> were outside that table; they are now audited and their findings fixed, and
+> the definition-of-done statements have been re-scoped accordingly.
 
 Legend — **Input:** _reject_ = unknown fields return 400 via an explicit allowlist;
 _ignore_ = unknown fields silently dropped. **Relations:** _E_ = existence-only,
@@ -92,6 +103,71 @@ only when it matches.
   owner checks on `characters`/`bots` mutation/delete. No owner **reassignment** is
   possible, so this is a trust-level choice, not a takeover.
 
+## Phase 6 — the previously un-audited families
+
+The core pass covered ~18 families but described itself as covering "every
+public mutation route." It did not. Phase 6 audited the 16 remaining mutation
+families and fixed the findings below (all merged to `main`; each bullet notes
+the fix, not a TODO).
+
+### High
+- **[FIXED] auth/login password-hash leak** — `validateUserCredentials` returned
+  the full `User` row (including the bcrypt `password` hash) to the login
+  response. Now strips `password` before returning (PR #653).
+- **[FIXED] model-builder run source-ownership (CRITICAL)** —
+  `model-builder/runs` accepted any `sourceType`/`sourceId`; the commit path
+  writes back to that record, so a user could point a run at another user's
+  Bot/Character/Dream/etc. and overwrite it. Now `assertSourceOwnership` gates
+  the run's source record to owner/admin and constrains `sourceType` to a known
+  allowlist (PR #655).
+- **[FIXED] comfy SSRF + server-token exfiltration** — six comfy routes
+  (`characterSheet`, `hunyuan3d`, `kontext/generate`, `kontext/kombine`,
+  `ltx/image2Video`, `ltx/text2Video`) honored a client-supplied `apiUrl` and
+  then sent `ART_SERVER_PROXY_TOKEN` to it. `apiUrl` is no longer accepted; the
+  base URL always comes from the access-checked Server. `resolveComfyUrl` drops
+  its `apiUrl` branch (PR #658).
+- **[FIXED] challenge-submission relation attach + read oracle** —
+  `challenges/[slug]/submissions` connected `artImageId`/`characterId`/
+  `scenarioId` with no permission check and echoed the full related rows. Now
+  gated to own-or-public (admins bypass) with a lean response select (PR #658).
+
+### Medium
+- **[FIXED] appmaker scaffold command injection** — `scaffold-request` built a
+  shell command string (stored for Worker execution) by interpolating `title`
+  unescaped and `description` with only quote-swapping. Both are now POSIX
+  single-quoted and length-capped.
+- **[FIXED] relations block self-unblock** — `relations/[id]` delete & patch let
+  either participant act, so a blocked user could remove/neutralize the BLOCK.
+  BLOCK edits are now owner-only; status is enum-validated.
+- **[FIXED] facet attach gates** — `facets` create/patch attached
+  `artImageId`/`artCollectionId` raw. Now gated to own-or-public via
+  `assertFacetRelationsAttachable`.
+- **[FIXED] dream-relation target access** — `dream-relations` existence-checked
+  the target Dream only. Now gated behind `assertDreamAccess` view (own/admin/
+  public), closing a private-Dream link + enumeration oracle.
+- **[FIXED] model-builder artImage attach** — item/artifact `artImageId` is later
+  promoted onto the run's source record; `assertArtImageAttachable` now gates it
+  to own-or-public on the single patch, batch patch, and artifacts routes.
+- **[FIXED] davinci life-run/choice attach** — `createLifeRun`/`recordLifeChoice`
+  attached `characterId`/`dreamId`/`botId`/`artCollectionId`/`chatId` raw; now
+  gated to own-or-public.
+- **[FIXED] chatgpt M2M relation injection** — an M2M `relation.add` mutates the
+  target's visible relation set (join row shows on both sides) but required only
+  read on the target. It now requires write access to the target; scalar links
+  and removes keep read-on-target.
+- **[FIXED] botcafe billing bypass** — `n` (completions) was sent to the provider
+  but omitted from the mana estimate and `max_tokens` was unclamped. `n` is now
+  in `estimateTextCostUsd` and both `n`/`max_tokens` are clamped.
+- **[FIXED] stripe subscribe envelope** — the catch passed a wrapper object to
+  `errorHandler` and never set the HTTP status, returning 200 on failure. Now
+  uses the standard `errorHandler` + status envelope.
+
+### Audited — clean
+- Stripe money routes (`checkout`, webhooks) do not trust client-supplied
+  amounts or user identity.
+- The admin / components / conductor / chatgpt-content mutation surfaces were
+  reviewed and found already gated (admin/server-key or owner checks in place).
+
 ## Workflows
 - The only auto-committing pipeline is `fallback-snapshot.yml` (`contents: write`),
   triggered by `schedule`/`workflow_dispatch` only — never `pull_request` — and
@@ -101,15 +177,21 @@ only when it matches.
   server-key gated; the achievements/wonderlab ones are.
 
 ## Definition-of-done status
-- No public mutation persists ownership from request identity. ✅
-- Every public create/patch path rejects unknown/system fields via an explicit
-  allowlist (F-4 closed for bots/prompts/resources/server). ✅
-- Relation IDs are bounded + existence + permission checked across every family
-  with writable relations, including bots, projects, the `art/image` patch, and
-  the reaction sub-patches (F-2 fully closed). ✅
+- No public mutation persists ownership from request identity, across both the
+  core families and the Phase 6 sweep. ✅
+- Every public create/patch path in the audited families rejects unknown/system
+  fields via an explicit allowlist (F-4 closed for bots/prompts/resources/
+  server). ✅
+- Relation IDs are bounded + existence + permission checked across every audited
+  family with writable relations — the core set (bots, projects, `art/image`
+  patch, reaction sub-patches; F-2 closed) plus the Phase 6 attach gates
+  (challenges, facets, dream-relations, model-builder, davinci, chatgpt M2M). ✅
 - The self-service user PATCH is an explicit allowlist; no owner-reassignment
   path remains (F-1 closed, F-3 closed). ✅
-- Mutation envelopes and status codes are consistent. ✅
+- Mutation envelopes and status codes are consistent (stripe/subscribe envelope
+  fixed in Phase 6). ✅
+- No credential or server secret leaks through a mutation response or an
+  outbound proxy request (auth/login hash + comfy SSRF/token closed in Phase 6). ✅
 - CI has no self-mutating PR workflows. ✅
 - The only remainders — F-5 (art/image blob projection) and Phase 4 (the `?? 10`
   store fallback) — are client-coupled and intentionally left for a client-side

--- a/server/api/appmaker/scaffold-request.post.ts
+++ b/server/api/appmaker/scaffold-request.post.ts
@@ -16,6 +16,15 @@ type ScaffoldRequestBody = {
   description?: string
 }
 
+// The scaffold command string is stored in a Todo and later run in a shell by
+// the Worker cycle. `slug` is charset-validated, but `title`/`description` are
+// free-form, so they must be shell-quoted — not merely quote-swapped. POSIX
+// single-quoting makes the value fully literal (no $(), backticks, or \ escape
+// inside single quotes), closing a stored command-injection (audit P6 MEDIUM).
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
 function slugify(value: string): string {
   return value
     .toLowerCase()
@@ -39,6 +48,12 @@ export default defineEventHandler(async (event) => {
     if (!title) {
       throw createError({ statusCode: 400, message: 'title is required.' })
     }
+    if (title.length > 200) {
+      throw createError({
+        statusCode: 400,
+        message: 'title must be 200 characters or fewer.',
+      })
+    }
 
     const slug = body.slug?.trim() ? body.slug.trim().toLowerCase() : slugify(title)
     if (!SLUG_RE.test(slug)) {
@@ -49,6 +64,12 @@ export default defineEventHandler(async (event) => {
     }
 
     const description = body.description?.trim() || null
+    if (description && description.length > 1000) {
+      throw createError({
+        statusCode: 400,
+        message: 'description must be 1000 characters or fewer.',
+      })
+    }
     const [existingProject, existingDream] = await Promise.all([
       prisma.project.findFirst({
         where: { OR: [{ slug }, { conductorSlug: slug }] },
@@ -68,8 +89,8 @@ export default defineEventHandler(async (event) => {
     await enforceProjectCap({ userId: user.id, userRole: user.Role, isAdmin })
 
     const scaffoldCommand =
-      `python scripts/new_app.py ${slug} --title "${title}"` +
-      (description ? ` --description "${description.replace(/"/g, "'")}"` : '')
+      `python scripts/new_app.py ${slug} --title ${shellSingleQuote(title)}` +
+      (description ? ` --description ${shellSingleQuote(description)}` : '')
 
     const { project, todo } = await prisma.$transaction(async (tx) => {
       const project = await tx.project.create({

--- a/server/api/botcafe/index.post.ts
+++ b/server/api/botcafe/index.post.ts
@@ -43,7 +43,11 @@ export default defineEventHandler(async (event) => {
   try {
     const body = await readBody<BotCafeProxyBody>(event)
     const model = body.model || process.env.OPENAI_TEXT_MODEL || 'gpt-4o-mini'
-    const maxTokens = body.max_tokens ?? body.maxTokens ?? 500
+    // Clamp caller-controlled cost drivers so a request can't run up unbilled
+    // usage: max_tokens is bounded, and n (completions) both bounded AND folded
+    // into the mana estimate below (audit P6 MEDIUM billing bypass).
+    const maxTokens = clampInt(body.max_tokens ?? body.maxTokens, 500, 1, 8192)
+    const n = clampInt(body.n, 1, 1, 8)
     const messages = normalizeMessages(body)
 
     if (!messages.length) {
@@ -58,6 +62,7 @@ export default defineEventHandler(async (event) => {
       estCostUsd: estimateTextCostUsd({
         model,
         maxTokens,
+        n,
       }),
       serverId: body.serverId ?? null,
     })
@@ -97,7 +102,7 @@ export default defineEventHandler(async (event) => {
         model,
         messages,
         temperature: body.temperature ?? 0.7,
-        n: body.n ?? 1,
+        n,
         max_tokens: maxTokens,
       }),
     })
@@ -136,6 +141,19 @@ export default defineEventHandler(async (event) => {
     }
   }
 })
+
+// Coerce a caller value to an integer within [min, max], falling back to
+// `fallback` for missing/invalid input. Used to bound billable request params.
+function clampInt(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const n = Math.floor(Number(value))
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, n))
+}
 
 function normalizeMessages(body: BotCafeProxyBody): ChatMessage[] {
   if (Array.isArray(body.messages) && body.messages.length) {

--- a/server/api/dream-relations/index.post.ts
+++ b/server/api/dream-relations/index.post.ts
@@ -65,7 +65,7 @@ export default defineEventHandler(async (event) => {
       }),
       prisma.dream.findUnique({
         where: { id: toDreamId },
-        select: { id: true },
+        select: { id: true, userId: true, isPublic: true },
       }),
     ])
     if (!fromDream) {
@@ -80,6 +80,16 @@ export default defineEventHandler(async (event) => {
       userId: auth.user.id,
       userRole: auth.user.Role,
       action: 'mutate',
+    })
+
+    // The target Dream was previously existence-checked only, so a caller could
+    // link to — and probe the existence of — another user's private Dream. Gate
+    // it behind view access: own, admin, or public (audit P6 MEDIUM).
+    assertDreamAccess({
+      dream: toDream,
+      userId: auth.user.id,
+      userRole: auth.user.Role,
+      action: 'view',
     })
 
     const relation = await prisma.dreamRelation.upsert({

--- a/server/api/facets/[id].patch.ts
+++ b/server/api/facets/[id].patch.ts
@@ -10,6 +10,7 @@ import {
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+import { assertFacetRelationsAttachable } from './relations'
 
 type FacetPatchBody = Record<string, unknown>
 
@@ -110,10 +111,22 @@ export default defineEventHandler(async (event) => {
     if (body.heroPath !== undefined) data.heroPath = optionalText(body.heroPath)
     if (body.icon !== undefined) data.icon = optionalText(body.icon)
     if (body.designer !== undefined) data.designer = optionalText(body.designer)
-    if (body.artImageId !== undefined)
-      data.artImageId = nullableId(body.artImageId)
-    if (body.artCollectionId !== undefined)
-      data.artCollectionId = nullableId(body.artCollectionId)
+    const nextArtImageId =
+      body.artImageId !== undefined ? nullableId(body.artImageId) : undefined
+    const nextArtCollectionId =
+      body.artCollectionId !== undefined
+        ? nullableId(body.artCollectionId)
+        : undefined
+    if (nextArtImageId !== undefined || nextArtCollectionId !== undefined) {
+      await assertFacetRelationsAttachable(
+        { artImageId: nextArtImageId, artCollectionId: nextArtCollectionId },
+        auth.user.id,
+        auth.isAdmin,
+      )
+    }
+    if (nextArtImageId !== undefined) data.artImageId = nextArtImageId
+    if (nextArtCollectionId !== undefined)
+      data.artCollectionId = nextArtCollectionId
     if (typeof body.isPublic === 'boolean') data.isPublic = body.isPublic
     if (typeof body.isMature === 'boolean') data.isMature = body.isMature
     if (typeof body.isActive === 'boolean') data.isActive = body.isActive

--- a/server/api/facets/index.post.ts
+++ b/server/api/facets/index.post.ts
@@ -14,6 +14,7 @@ import {
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+import { assertFacetRelationsAttachable } from './relations'
 
 type FacetCreateBody = {
   title?: unknown
@@ -105,6 +106,14 @@ export default defineEventHandler(async (event) => {
       ? (body.creationSource as CreationSource)
       : 'HUMAN'
 
+    const artImageId = positiveId(body.artImageId)
+    const artCollectionId = positiveId(body.artCollectionId)
+    await assertFacetRelationsAttachable(
+      { artImageId, artCollectionId },
+      auth.user.id,
+      auth.isAdmin,
+    )
+
     const explicitAliases = normalizeAliases(body.aliases)
     const aliasesByKey = new Map<string, { alias: string; isCanonical: boolean }>()
     const canonicalKey = normalizeFacetLookupKey(slug)
@@ -132,8 +141,8 @@ export default defineEventHandler(async (event) => {
         designer: optionalText(body.designer),
         creationSource,
         userId: auth.user.id,
-        artImageId: positiveId(body.artImageId),
-        artCollectionId: positiveId(body.artCollectionId),
+        artImageId,
+        artCollectionId,
         isPublic: body.isPublic !== false,
         isMature: body.isMature === true,
         isActive: true,

--- a/server/api/facets/relations.ts
+++ b/server/api/facets/relations.ts
@@ -1,0 +1,44 @@
+// Shared relation-attachability gate for Facet create/patch.
+// A Facet may only reference an ArtImage / ArtCollection the caller is allowed
+// to attach — their own, or a public one (admins bypass). Without this, the
+// raw artImageId/artCollectionId FKs let a user pin another user's PRIVATE
+// ArtImage/ArtCollection onto their Facet (audit P6 MEDIUM).
+import { createError } from 'h3'
+import prisma from '~/server/utils/prisma'
+
+export async function assertFacetRelationsAttachable(
+  ids: { artImageId?: number | null; artCollectionId?: number | null },
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (isAdmin) return
+
+  const notAttachable = { NOT: { OR: [{ userId }, { isPublic: true }] } }
+
+  const [artForbidden, collectionForbidden] = await Promise.all([
+    ids.artImageId
+      ? prisma.artImage.count({
+          where: { id: ids.artImageId, ...notAttachable },
+        })
+      : 0,
+    ids.artCollectionId
+      ? prisma.artCollection.count({
+          where: { id: ids.artCollectionId, ...notAttachable },
+        })
+      : 0,
+  ])
+
+  const forbiddenLabel =
+    artForbidden > 0
+      ? 'ArtImage'
+      : collectionForbidden > 0
+        ? 'ArtCollection'
+        : null
+
+  if (forbiddenLabel) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach that ${forbiddenLabel} to this Facet.`,
+    })
+  }
+}

--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -10,6 +10,7 @@ import {
   prepareItemUpdate,
   type ItemPatchBody,
 } from '../runs/index'
+import { assertArtImageAttachable } from '../relations'
 
 const itemInclude = {
   Artifacts: { orderBy: { id: 'asc' } },
@@ -36,6 +37,9 @@ export default defineEventHandler(async (event) => {
     assertRunAccess(existing.Run, auth.user)
 
     const body = await readBody<ItemPatchBody>(event)
+    if (body.artImageId !== undefined) {
+      await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
+    }
     const { data, revision } = prepareItemUpdate(
       existing,
       body,

--- a/server/api/model-builder/items/[id]/artifacts.post.ts
+++ b/server/api/model-builder/items/[id]/artifacts.post.ts
@@ -5,6 +5,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { assertRunAccess, getItemId, normalizeNullableId } from '../../runs/index'
+import { assertArtImageAttachable } from '../../relations'
 
 const reviewStates = new Set<ModelBuildReviewState>([
   'PENDING',
@@ -65,6 +66,7 @@ export default defineEventHandler(async (event) => {
         message: 'Artifact "kind" is required.',
       })
     }
+    await assertArtImageAttachable(body.artImageId, auth.user.id, auth.isAdmin)
 
     const artifact = await prisma.modelBuildArtifact.create({
       data: {

--- a/server/api/model-builder/items/batch.patch.ts
+++ b/server/api/model-builder/items/batch.patch.ts
@@ -15,6 +15,7 @@ import {
   prepareItemUpdate,
   type ItemPatchBody,
 } from '../runs/index'
+import { assertArtImageAttachable } from '../relations'
 
 const itemInclude = {
   Artifacts: { orderBy: { id: 'asc' } },
@@ -90,6 +91,14 @@ export default defineEventHandler(async (event) => {
           })
         }
         assertRunAccess(existing.Run, auth.user)
+
+        if (entry.artImageId !== undefined) {
+          await assertArtImageAttachable(
+            entry.artImageId,
+            auth.user.id,
+            auth.isAdmin,
+          )
+        }
 
         const { id: _omit, ...fields } = entry
         void _omit

--- a/server/api/model-builder/relations.ts
+++ b/server/api/model-builder/relations.ts
@@ -1,0 +1,30 @@
+// Shared ArtImage-attachability gate for model-builder item/artifact writes.
+// An item's artImageId is later promoted onto the run's owner-verified source
+// record (see items/[id]/commit.post.ts → promoteAsset), so an unchecked FK
+// lets a user pin another user's PRIVATE ArtImage onto their own record and
+// surface it through that record's canonical art link (audit P6 MEDIUM).
+// Attachable = own OR public; admins bypass.
+import { createError } from 'h3'
+import prisma from '~/server/utils/prisma'
+
+export async function assertArtImageAttachable(
+  rawArtImageId: unknown,
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  if (isAdmin) return
+
+  const id = Number(rawArtImageId)
+  // null / clear / invalid — nothing to attach, so nothing to gate.
+  if (!Number.isInteger(id) || id <= 0) return
+
+  const forbidden = await prisma.artImage.count({
+    where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+  })
+  if (forbidden > 0) {
+    throw createError({
+      statusCode: 403,
+      message: 'You do not have permission to attach that ArtImage.',
+    })
+  }
+}

--- a/server/api/relations/[id].delete.ts
+++ b/server/api/relations/[id].delete.ts
@@ -25,7 +25,14 @@ export default defineEventHandler(async (event) => {
     return { success: true, message: 'Relation already removed.', data: { id } }
   }
 
-  if (existing.userId !== userId && existing.relatedUserId !== userId) {
+  // A BLOCK is one-directional: only the blocker (userId) may remove it. The
+  // blocked user (relatedUserId) is a participant but must NOT be able to
+  // self-unblock (audit P6 MEDIUM). Symmetric relations (FRIEND/PARENT/CHILD/
+  // REFEREE) may be removed by either party.
+  const isOwner = existing.userId === userId
+  const isTarget = existing.relatedUserId === userId
+  const canDelete = existing.type === 'BLOCK' ? isOwner : isOwner || isTarget
+  if (!canDelete) {
     setResponseStatus(event, 403)
     return { success: false, message: 'You cannot delete this relation.' }
   }

--- a/server/api/relations/[id].patch.ts
+++ b/server/api/relations/[id].patch.ts
@@ -31,6 +31,15 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const nextStatus = body?.status as RelationStatus | undefined
 
+  const VALID_STATUSES: RelationStatus[] = ['PENDING', 'ACCEPTED', 'DECLINED']
+  if (nextStatus !== undefined && !VALID_STATUSES.includes(nextStatus)) {
+    setResponseStatus(event, 400)
+    return {
+      success: false,
+      message: 'status must be one of PENDING, ACCEPTED, or DECLINED.',
+    }
+  }
+
   if (nextStatus === 'ACCEPTED') {
     // Only the recipient of a pending request may confirm it.
     if (existing.relatedUserId !== userId || existing.status !== 'PENDING') {
@@ -63,8 +72,14 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // Any other status edit: either participant may touch the row.
-  if (existing.userId !== userId && existing.relatedUserId !== userId) {
+  // Any other status edit: either participant may touch the row — EXCEPT a
+  // BLOCK, which is one-directional. Only the blocker (userId) may edit it, so
+  // the blocked user (relatedUserId) cannot neutralize the block by flipping
+  // its status/note (audit P6 MEDIUM).
+  const isOwner = existing.userId === userId
+  const isTarget = existing.relatedUserId === userId
+  const canModify = existing.type === 'BLOCK' ? isOwner : isOwner || isTarget
+  if (!canModify) {
     setResponseStatus(event, 403)
     return { success: false, message: 'You cannot modify this relation.' }
   }

--- a/server/api/stripe/subscribe.post.ts
+++ b/server/api/stripe/subscribe.post.ts
@@ -57,12 +57,14 @@ export default defineEventHandler(async (event) => {
       url: session.url,
       message: '✨ Subscription checkout initialized',
     }
-  } catch (error: any) {
-    console.error('🔥 Stripe Subscribe Error:', error)
-    return errorHandler({
-      error,
-      message: '😵 Subscription failed',
-      statusCode: error?.statusCode || 500,
-    })
+  } catch (error: unknown) {
+    // errorHandler takes the error itself, not a wrapper object — passing
+    // { error, message, statusCode } fell through to the generic branch and,
+    // because the HTTP status was never set, returned 200 on failure (audit P6
+    // MEDIUM). Use the standard envelope + status wiring instead.
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode ?? 500
+    event.node.res.statusCode = statusCode
+    return { ...handled, statusCode }
   }
 })

--- a/server/chatgpt/services/schemaRelationService.ts
+++ b/server/chatgpt/services/schemaRelationService.ts
@@ -331,10 +331,14 @@ async function assertCanRelate({
   actor,
   from,
   to,
+  definition,
+  action,
 }: {
   actor: ChatGptActor
   from: ContentRef
   to: ContentRef
+  definition: RelationDefinition
+  action: 'add' | 'remove'
 }) {
   const [fromPermission, toPermission] = await Promise.all([
     readPermissionRecord(from),
@@ -347,12 +351,29 @@ async function assertCanRelate({
     config: fromPermission.config,
     record: fromPermission.record,
   })
-  assertReadable({
-    actor,
-    ref: to,
-    config: toPermission.config,
-    record: toPermission.record,
-  })
+
+  // Adding a many-to-many edge creates a join row that is visible from BOTH
+  // sides, so the target's relation set is effectively mutated too. Requiring
+  // only read on `to` let a user inject their content into another user's
+  // PUBLIC Dream/Scenario/ArtCollection (audit P6 MEDIUM). An M2M add therefore
+  // requires WRITE access to `to`. Scalar links only touch `from`, and a remove
+  // only detaches the actor's own `from`, so read on `to` stays sufficient.
+  const isManyToManyAdd = definition.config.mode !== 'scalar' && action === 'add'
+  if (isManyToManyAdd) {
+    assertWritable({
+      actor,
+      ref: to,
+      config: toPermission.config,
+      record: toPermission.record,
+    })
+  } else {
+    assertReadable({
+      actor,
+      ref: to,
+      config: toPermission.config,
+      record: toPermission.record,
+    })
+  }
 }
 
 async function assertCanReadRelations({
@@ -446,7 +467,7 @@ export async function addRelation({
     toResource: to.resource,
   })
 
-  await assertCanRelate({ actor, from, to })
+  await assertCanRelate({ actor, from, to, definition, action: 'add' })
   const data = await mutateRelation({
     from,
     to,
@@ -476,7 +497,7 @@ export async function removeRelation({
     toResource: to.resource,
   })
 
-  await assertCanRelate({ actor, from, to })
+  await assertCanRelate({ actor, from, to, definition, action: 'remove' })
   const data = await mutateRelation({
     from,
     to,

--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -287,6 +287,33 @@ function withStatusCode(message: string, statusCode: number): Error {
   return error
 }
 
+// A life run/choice may only reference records the player is allowed to attach:
+// their own, or a public one. Without this the raw characterId/dreamId/botId/
+// artCollectionId/chatId FKs let a user pin — and then read back through the run
+// — another user's PRIVATE record (audit P6 MEDIUM/LOW). A non-existent id
+// passes here and is caught by the FK constraint on write.
+async function assertAttachable(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: { count: (args: any) => Promise<number> },
+  id: number | null | undefined,
+  userId: number,
+  label: string,
+): Promise<void> {
+  if (id === null || id === undefined) return
+  if (!Number.isInteger(id) || id <= 0) {
+    throw withStatusCode(`${label} must be a positive integer.`, 400)
+  }
+  const forbidden = await model.count({
+    where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+  })
+  if (forbidden > 0) {
+    throw withStatusCode(
+      `You do not have permission to attach that ${label}.`,
+      403,
+    )
+  }
+}
+
 export interface CreateLifeRunInput {
   title: string
   seed?: string | null
@@ -310,6 +337,18 @@ export async function createLifeRun(userId: number, input: CreateLifeRunInput) {
     typeof input.currentChapter === 'number' && input.currentChapter > 0
       ? input.currentChapter
       : 1
+
+  await Promise.all([
+    assertAttachable(prisma.character, input.characterId, userId, 'Character'),
+    assertAttachable(prisma.dream, input.dreamId, userId, 'Dream'),
+    assertAttachable(prisma.bot, input.botId, userId, 'Bot'),
+    assertAttachable(
+      prisma.artCollection,
+      input.artCollectionId,
+      userId,
+      'ArtCollection',
+    ),
+  ])
 
   return prisma.lifeRun.create({
     data: {
@@ -363,6 +402,8 @@ export async function recordLifeChoice(
       throw withStatusCode(`effect "${key}" must be a finite number.`, 400)
     }
   }
+
+  await assertAttachable(prisma.chat, input.chatId, userId, 'Chat')
 
   return prisma.$transaction(async (tx) => {
     const run = await tx.lifeRun.findUnique({ where: { id: lifeRunId } })

--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -292,23 +292,50 @@ function withStatusCode(message: string, statusCode: number): Error {
 // artCollectionId/chatId FKs let a user pin — and then read back through the run
 // — another user's PRIVATE record (audit P6 MEDIUM/LOW). A non-existent id
 // passes here and is caught by the FK constraint on write.
+type AttachableResource = 'Character' | 'Dream' | 'Bot' | 'ArtCollection' | 'Chat'
+
 async function assertAttachable(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  model: { count: (args: any) => Promise<number> },
+  resource: AttachableResource,
   id: number | null | undefined,
   userId: number,
-  label: string,
 ): Promise<void> {
   if (id === null || id === undefined) return
   if (!Number.isInteger(id) || id <= 0) {
-    throw withStatusCode(`${label} must be a positive integer.`, 400)
+    throw withStatusCode(`${resource} id must be a positive integer.`, 400)
   }
-  const forbidden = await model.count({
-    where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
-  })
+
+  let forbidden = 0
+  switch (resource) {
+    case 'Character':
+      forbidden = await prisma.character.count({
+        where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+      })
+      break
+    case 'Dream':
+      forbidden = await prisma.dream.count({
+        where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+      })
+      break
+    case 'Bot':
+      forbidden = await prisma.bot.count({
+        where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+      })
+      break
+    case 'ArtCollection':
+      forbidden = await prisma.artCollection.count({
+        where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+      })
+      break
+    case 'Chat':
+      forbidden = await prisma.chat.count({
+        where: { id, NOT: { OR: [{ userId }, { isPublic: true }] } },
+      })
+      break
+  }
+
   if (forbidden > 0) {
     throw withStatusCode(
-      `You do not have permission to attach that ${label}.`,
+      `You do not have permission to attach that ${resource}.`,
       403,
     )
   }
@@ -339,15 +366,10 @@ export async function createLifeRun(userId: number, input: CreateLifeRunInput) {
       : 1
 
   await Promise.all([
-    assertAttachable(prisma.character, input.characterId, userId, 'Character'),
-    assertAttachable(prisma.dream, input.dreamId, userId, 'Dream'),
-    assertAttachable(prisma.bot, input.botId, userId, 'Bot'),
-    assertAttachable(
-      prisma.artCollection,
-      input.artCollectionId,
-      userId,
-      'ArtCollection',
-    ),
+    assertAttachable('Character', input.characterId, userId),
+    assertAttachable('Dream', input.dreamId, userId),
+    assertAttachable('Bot', input.botId, userId),
+    assertAttachable('ArtCollection', input.artCollectionId, userId),
   ])
 
   return prisma.lifeRun.create({
@@ -403,7 +425,7 @@ export async function recordLifeChoice(
     }
   }
 
-  await assertAttachable(prisma.chat, input.chatId, userId, 'Chat')
+  await assertAttachable('Chat', input.chatId, userId)
 
   return prisma.$transaction(async (tx) => {
     const run = await tx.lifeRun.findUnique({ where: { id: lifeRunId } })

--- a/server/utils/manaCost.ts
+++ b/server/utils/manaCost.ts
@@ -40,9 +40,14 @@ export function estimateArtCostUsd(opts: {
 export function estimateTextCostUsd(opts: {
   model: string
   maxTokens?: number | null
+  // Number of completions requested (OpenAI `n`). Each completion generates up
+  // to maxTokens, so total output — and cost — scales with n. Omitting it here
+  // undercharged multi-completion requests (audit P6 MEDIUM billing bypass).
+  n?: number | null
 }): number {
   const m = opts.model.toLowerCase()
   const out = opts.maxTokens ?? 2048
+  const n = Math.max(1, Math.floor(opts.n ?? 1))
 
   // Per-output-token USD rates, conservative.
   let rate = 0.0000006 // gpt-4o-mini-ish
@@ -51,5 +56,5 @@ export function estimateTextCostUsd(opts: {
   if (m.includes('claude') && m.includes('sonnet')) rate = 0.000015
   if (m.includes('claude') && m.includes('haiku')) rate = 0.000004
 
-  return Math.max(0.0005, out * rate)
+  return Math.max(0.0005, out * rate * n)
 }


### PR DESCRIPTION
Closes out the MEDIUM findings from the Phase 6 sweep of the 16 previously un-audited mutation families (#570), and corrects the audit doc's overstated coverage claim. Each concern is a focused commit.

## Fixes

- **appmaker scaffold shell-escape** — `scaffold-request` interpolated `title` unescaped (and `description` with only quote-swapping) into a shell command string stored for the Worker to execute. Both are now POSIX single-quoted (fully literal) and length-capped → closes stored command injection.
- **relations block self-unblock** — `relations/[id]` delete & patch let either participant act, so a blocked user could delete/status-flip the one-directional BLOCK to self-unblock. BLOCK edits are now owner-only; symmetric relations unchanged; `status` is enum-validated.
- **facet + dream-relation attach** — `facets` create/patch attached `artImageId`/`artCollectionId` raw; `dream-relations` existence-checked the target Dream only (private-Dream link + enumeration oracle). Both now gated to own-or-public (facets via `assertFacetRelationsAttachable`, dream target via `assertDreamAccess` view).
- **model-builder / davinci / chatgpt attach** — item/artifact `artImageId` (later promoted onto the run's source record), davinci life-run/choice FKs (`characterId`/`dreamId`/`botId`/`artCollectionId`/`chatId`), and the chatgpt M2M `relation.add` are now access-gated. The M2M add requires **write** on the target (a join row is visible from both sides), preventing content injection into another user's public record; scalar links and removes keep read-on-target.
- **botcafe billing** — `n` (completions) was sent to the provider but omitted from the mana estimate, and `max_tokens` was unclamped. `n` is now folded into `estimateTextCostUsd` and both `n`/`max_tokens` are clamped.
- **stripe subscribe envelope** — the catch passed a wrapper object to `errorHandler` and never set the HTTP status, so failures returned 200 with a generic message. Now uses the standard `errorHandler` + status envelope.
- **audit doc** — adds a Phase 6 section enumerating the 16 families and their fixes, and re-scopes the definition-of-done statements (the doc previously claimed coverage of "every public mutation route" when only the core families had been verified).

The HIGH/CRITICAL Phase 6 findings landed separately in #653 (auth hash leak), #655 (model-builder run source ownership), and #658 (comfy SSRF + challenge relation oracle).

## Verification

- `vue-tsc --noEmit` clean (only the 2 pre-existing, unrelated `wonderLabSourceEvidence` errors remain).
- `eslint` clean on all 16 touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_011G2JMMS8XcuXcq4PZFqrxC)_