### PR TITLE
fix(academy): preserve batch-upload success banner in image-upload.vue

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -774,16 +774,18 @@ async function handleBatchUpload() {
     )
   }
 
+  // Clear the queue only on a clean run. Must happen before the message
+  // assignment below — clearQueue() resets message/error, and doing it
+  // first would wipe the success banner we're about to set.
+  if (result.succeeded.length && !result.failed.length) {
+    clearQueue()
+  }
+
   // Mirror store messaging locally so the component owns its own banners.
   message.value = uploadStore.message ?? ''
   error.value = result.failed.length
     ? `${result.failed.length} image${result.failed.length === 1 ? '' : 's'} failed.`
     : ''
-
-  // Clear the queue only on a clean run.
-  if (result.succeeded.length && !result.failed.length) {
-    clearQueue()
-  }
 }
 
 onUnmounted(() => {


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software) — lane 1 of the 4-lane rotation (front-end style/polish pass on Academy or art-styler surfaces).

### What changed / what I produced
- `components/art/image-upload.vue`: `handleBatchUpload()` set `message.value = uploadStore.message ?? ''` (the success confirmation banner text) and then, on a fully-successful batch, immediately called `clearQueue()` — which unconditionally resets `message.value`/`error.value` back to `''` on the very next line, in the same synchronous tick. Vue never got a chance to render the intermediate state, so the "✓ N images uploaded" confirmation never actually appeared on the happy path (the most common outcome). The failure/partial-failure path was unaffected since `clearQueue()` isn't called there — which is why this asymmetry was easy to miss.
- Fix: reordered so `clearQueue()` (and its internal message/error reset) runs first, then the real success/failure message assignment happens last and survives.

### How I verified
- Read the change in context and confirmed the bug by tracing execution order before fixing.
- `npx eslint components/art/image-upload.vue` — clean
- `npx prettier --check components/art/image-upload.vue` — clean
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0, no errors

### Stakes
reversible

### Flags for Reviewer
none

### Kaizen suggestion
None beyond this task's scope — this cycle's find was small and self-contained.

### Notes for reviewer
This is the ai-art-academy/t-010 recurring "continuous improvement" task, lane 1 (front-end polish) per the checklist's 1→2→3→4 rotation. Conductor roadmap task will be re-armed to `ready` after this merges, per the recurring-task convention documented in AGENTS.md.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AgYiamX4Fvs9HFwtAYM8tN)_