### PR TITLE
Fix dream deletion and sync logic to prevent deleted dreams from reappearing

### DIFF
--- a/stores/dreamStore.ts
+++ b/stores/dreamStore.ts
@@ -28,6 +28,7 @@ import {
 import {
   mergeDefinedRecord,
   mergeRecordsById,
+  reconcileRecordsById,
 } from '@/stores/helpers/recordMerge'
 import type {
   ArtCollection,
@@ -936,7 +937,12 @@ export const useDreamStore = defineStore('dreamStore', () => {
           throw new Error(res.message || 'Failed to fetch dreams.')
 
         const normalizedIncoming = res.data.map(normalizeDream)
-        dreams.value = mergeRecordsById(dreams.value, normalizedIncoming)
+        // An unfiltered fetch (`!query`) is the authoritative full list — reconcile
+        // so rows the server no longer returns (deleted dreams) are pruned from
+        // state and localStorage. A filtered/partial fetch only upserts, so a
+        // narrow result set never wipes unrelated cached rows.
+        const combine = query ? mergeRecordsById : reconcileRecordsById
+        dreams.value = combine(dreams.value, normalizedIncoming)
           .map(normalizeDream)
           .sort(sortDreamsByNewest)
 
@@ -1255,8 +1261,13 @@ export const useDreamStore = defineStore('dreamStore', () => {
       if (!res.success)
         throw new Error(res.message || `Failed to delete dream ${dreamId}.`)
 
-      if (hardDelete) removeDreamFromState(dreamId)
-      else if (res.data) upsertDream(res.data)
+      // The dreams DELETE endpoint always HARD-deletes the row (see
+      // server/api/dreams/[id].delete.ts) regardless of the `hard` flag, so the
+      // deleted dream is gone from the DB and every fresh list. Always prune it
+      // from state — the old `else upsertDream(res.data)` branch re-inserted the
+      // just-deleted row (still isActive) and persisted it to localStorage, which
+      // is why deleted dreams reappeared in the gallery even after a cache clear.
+      removeDreamFromState(dreamId)
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
This PR fixes two related issues in the dream store that caused deleted dreams to reappear in the gallery:

1. **Dream deletion logic**: The DELETE endpoint always hard-deletes dreams from the database, but the client was conditionally re-upserting the deleted dream back into state based on a `hardDelete` flag, causing it to persist in localStorage.

2. **Dream list sync logic**: When fetching dreams, the store now distinguishes between full (unfiltered) and partial (filtered) fetches, using different merge strategies to ensure deleted dreams are properly pruned from state.

## Key Changes

- **Reconciliation strategy for full fetches**: Introduced `reconcileRecordsById` helper to replace `mergeRecordsById` when performing unfiltered dream fetches. This ensures that dreams no longer returned by the server (deleted dreams) are removed from state and localStorage, while filtered fetches continue to use the upsert-only `mergeRecordsById` strategy.

- **Simplified deletion logic**: Removed the conditional `hardDelete` branch that was re-upserting deleted dreams. The DELETE endpoint always hard-deletes, so we now unconditionally call `removeDreamFromState()` to prune the dream from state.

## Implementation Details

- The `query` parameter is used to determine if a fetch is filtered or unfiltered — unfiltered fetches are treated as authoritative and use reconciliation.
- Added clarifying comments explaining the server behavior and why the previous approach caused deleted dreams to reappear even after cache clearing.

https://claude.ai/code/session_01AYbKvc2fzwfSnHyoQDrUgb