### PR TITLE
ci-janitor: fix Dream mutation-boundary test + Cypress timeout + contract-tests drift

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,15 @@ jobs:
   cypress:
     name: API Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The trigger-change fix (#648) already noted deploy wait + DB readiness +
+    # the suite itself "commonly exceeds 20-30 minutes" but left this at 30 --
+    # with push-triggered concurrency cancellation gone, this job timeout
+    # became the new binding cancellation cause (run 29761819284 and others,
+    # all "cancelled" with the Cypress step SIGTERM'd right at the 30-minute
+    # mark, cleanup steps completing fine afterward). Raised to give the full
+    # suite real margin to reach an actual pass/fail instead of an artificial
+    # cutoff.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/cypress/e2e/api/dream-mutation-boundaries.cy.ts
+++ b/cypress/e2e/api/dream-mutation-boundaries.cy.ts
@@ -71,7 +71,7 @@ describe('Dream mutation boundaries', () => {
     deleteTestUser(apiBase, adminToken, user?.id)
   })
 
-  it('creates only a Dream even when legacy side-effect flags are sent', () => {
+  it('creates only a Dream when given supported fields', () => {
     cy.request<ApiResponse<DreamResponse>>({
       method: 'POST',
       url: dreamsUrl(),
@@ -83,8 +83,6 @@ describe('Dream mutation boundaries', () => {
         dreamType: 'LOCATION',
         creationSource: 'HUMAN',
         isPublic: false,
-        createCollection: true,
-        seedStarterImages: true,
       },
     }).then((res) => {
       expect(res.status, JSON.stringify(res.body)).to.eq(201)
@@ -104,6 +102,29 @@ describe('Dream mutation boundaries', () => {
     })
   })
 
+  it('rejects legacy side-effect flags on create instead of silently dropping them', () => {
+    cy.request<ApiResponse<DreamResponse>>({
+      method: 'POST',
+      url: dreamsUrl(),
+      headers: authHeaders(),
+      failOnStatusCode: false,
+      body: {
+        title: `Cypress Rejected Dream ${time}`,
+        slug: `cypress-rejected-dream-${time}`,
+        dreamType: 'LOCATION',
+        creationSource: 'HUMAN',
+        isPublic: false,
+        createCollection: true,
+        seedStarterImages: true,
+      },
+    }).then((res) => {
+      expect(res.status, JSON.stringify(res.body)).to.eq(400)
+      expect(res.body.success).to.eq(false)
+      expect(res.body.message).to.include('createCollection')
+      expect(res.body.message).to.include('seedStarterImages')
+    })
+  })
+
   it('does not create a Dream chat during creation', () => {
     cy.request<ApiResponse<ChatResponse[]>>({
       method: 'GET',
@@ -116,15 +137,13 @@ describe('Dream mutation boundaries', () => {
     })
   })
 
-  it('updates only the Dream even when legacy side-effect fields are sent', () => {
+  it('updates only the Dream when given supported fields', () => {
     cy.request<ApiResponse<DreamResponse>>({
       method: 'PATCH',
       url: `${dreamsUrl()}/${dreamId}`,
       headers: authHeaders(),
       body: {
         description: 'Updated without creating a timeline chat or collection.',
-        addArtImageToCollection: true,
-        updateNote: 'This must not become a Chat row.',
       },
     }).then((res) => {
       expect(res.status, JSON.stringify(res.body)).to.eq(200)
@@ -134,6 +153,24 @@ describe('Dream mutation boundaries', () => {
       expect(res.body.data?.artCollectionId).to.eq(null)
       expect(res.body.data).to.not.have.property('Chats')
       expect(res.body.data).to.not.have.property('ArtCollection')
+    })
+  })
+
+  it('rejects legacy side-effect flags on update instead of silently dropping them', () => {
+    cy.request<ApiResponse<DreamResponse>>({
+      method: 'PATCH',
+      url: `${dreamsUrl()}/${dreamId}`,
+      headers: authHeaders(),
+      failOnStatusCode: false,
+      body: {
+        addArtImageToCollection: true,
+        updateNote: 'This must not become a Chat row.',
+      },
+    }).then((res) => {
+      expect(res.status, JSON.stringify(res.body)).to.eq(400)
+      expect(res.body.success).to.eq(false)
+      expect(res.body.message).to.include('addArtImageToCollection')
+      expect(res.body.message).to.include('updateNote')
     })
   })
 
@@ -162,8 +199,6 @@ describe('Dream mutation boundaries', () => {
           dreamType: 'LOCATION',
           creationSource: 'HUMAN',
           isPublic: false,
-          createCollection: true,
-          seedStarterImages: true,
         },
       ],
     }).then((res) => {
@@ -181,6 +216,31 @@ describe('Dream mutation boundaries', () => {
       expect(dream).to.not.have.property('Chats')
       expect(dream).to.not.have.property('ArtCollection')
       expect(dream).to.not.have.property('ArtImages')
+    })
+  })
+
+  it('rejects legacy side-effect flags on batch create instead of silently dropping them', () => {
+    cy.request<ApiResponse<DreamResponse[]>>({
+      method: 'POST',
+      url: `${dreamsUrl()}/batch`,
+      headers: authHeaders(),
+      failOnStatusCode: false,
+      body: [
+        {
+          title: `Cypress Rejected Batch Dream ${time}`,
+          slug: `cypress-rejected-batch-dream-${time}`,
+          dreamType: 'LOCATION',
+          creationSource: 'HUMAN',
+          isPublic: false,
+          createCollection: true,
+          seedStarterImages: true,
+        },
+      ],
+    }).then((res) => {
+      expect(res.status, JSON.stringify(res.body)).to.eq(400)
+      expect(res.body.success).to.eq(false)
+      expect(res.body.message).to.include('createCollection')
+      expect(res.body.message).to.include('seedStarterImages')
     })
   })
 

--- a/utils/scripts/verifyDreamStoreFetchMerge.ts
+++ b/utils/scripts/verifyDreamStoreFetchMerge.ts
@@ -50,8 +50,12 @@ assert.equal(rows.find((row) => row.id === 3)?.title, 'New filtered row')
 
 const dreamStoreSource = readFileSync('stores/dreamStore.ts', 'utf8')
 assert.ok(
-  dreamStoreSource.includes('mergeRecordsById(dreams.value, normalizedIncoming)'),
-  'dreamStore must merge filtered fetch rows into the existing cache.',
+  dreamStoreSource.includes(
+    'const combine = query ? mergeRecordsById : reconcileRecordsById',
+  ) && dreamStoreSource.includes('combine(dreams.value, normalizedIncoming)'),
+  'dreamStore must merge filtered fetch rows into the existing cache (mergeRecordsById) ' +
+    'while reconciling the authoritative unfiltered fetch against server-side deletions ' +
+    '(reconcileRecordsById).',
 )
 assert.ok(
   dreamStoreSource.includes('fetchPromises.value[url]'),


### PR DESCRIPTION
### Task
CI Janitor Todo #504 (`ci-janitor:silasfelinus/kind_robots:cypress.yml:29761819284`) — the scheduled Cypress Tests run failed. (kind: software)

### What changed / what I produced
Three compounding root causes found and fixed:

1. **Stale test contract in `cypress/e2e/api/dream-mutation-boundaries.cy.ts`.** The test sent legacy side-effect flags (`createCollection`, `seedStarterImages`, `addArtImageToCollection`, `updateNote`) expecting the API to silently ignore them. `server/api/dreams/mutation.ts` (added 2026-07-19, "Add shared Dream mutation boundary") tightened Dream create/patch/batch validation to reject any unrecognized field with `400` — matching the reject-unknown-fields pattern applied everywhere else in `docs/architecture/thin-resource-api-audit.md`. No live client sends these fields (confirmed via repo-wide search). The test predates that hardening and was never updated. Updated it to match the current, intentional contract: plain requests without legacy fields still succeed and touch only the Dream, and three new cases assert legacy side-effect flags are now explicitly rejected (still proving no side effects can be smuggled in — via rejection instead of silent tolerance).
2. **`.github/workflows/cypress.yml` job `timeout-minutes: 30` was too tight.** The earlier trigger-change fix (#648) already noted "deploy wait + DB readiness + the suite itself commonly exceeds 20-30 minutes" but left the job timeout unchanged. With push-triggered concurrency cancellation gone, this became the new binding cancellation cause — three consecutive runs after #648 all got `SIGTERM`'d by the job timeout with the Cypress step still running, never reaching a real pass/fail. Raised to 60 minutes.
3. **(Found while getting this PR's own checks green) `utils/scripts/verifyDreamStoreFetchMerge.ts` had a stale source-text assertion**, unrelated to the above. main's Contract Tests workflow has been red since PR #677 ("dreams: stop deleted dreams reappearing in the gallery", merged today), which legitimately changed `fetchDreams` to pick `mergeRecordsById` vs. `reconcileRecordsById` via a `combine` variable — a real behavior fix (filtered fetches still upsert; the authoritative unfiltered fetch now prunes server-deleted rows instead of leaking them forever). That changed the literal source string this contract check grepped for, even though the intent it protects still holds. Updated the assertion to match the current source shape while checking the same intent (both the ternary and the `combine()` call site must be present). Confirmed via the last 3 push runs on `main` (before I touched anything) that this was already broken independently of my Cypress fix — I bundled the fix into this PR since it was otherwise going to block this PR's own required checks from ever going green.

### How I verified
- Fetched the failing Cypress run (29761819284) via the GitHub Actions API, confirmed job step 8 ("Run Cypress tests") was cancelled at exactly the 30-minute job-timeout mark (SIGINT then SIGTERM in the logs), with cleanup steps completing normally afterward — not a real test failure at the job level.
- Read the actual Cypress log output: a genuine `400` from `/api/dreams` with message `Unsupported Dream fields in Dream create payload: createCollection, seedStarterImages...`, traced to `cypress/e2e/api/dream-mutation-boundaries.cy.ts`.
- Traced git history (`server/api/dreams/mutation.ts`, `index.post.ts`, `[id].patch.ts`, `batch.post.ts`, and the originating PR #403) to confirm the test was written *before* strict field validation existed, and that all three Dream mutation routes now share the same strict validator.
- For the contract-tests break: confirmed main's last 3 push runs (9cd2f3e7, fbfe2a86, 4fd90b22) all failed the same "Dream store fetch merge contract" step, traced it to PR #677's diff, ran the fixed script directly (`npx tsx utils/scripts/verifyDreamStoreFetchMerge.ts` → passes) plus the 8 contract steps immediately before/after it in the workflow, all green locally.
- `npx eslint` and `npx prettier --check` clean on all three changed files (one pre-existing, unrelated `no-unused-expressions` lint error on an untouched line of the Cypress test file predates this change — confirmed via `git stash` diff against `main`).
- `vue-tsc`/`tsc --noEmit` shows the same pre-existing `muralStore.ts` errors on `main` and this branch (unrelated route-typing issue), none touching the changed files.
- Did not have Cypress credentials to run the live E2E suite locally; confidence in fix #1 comes from replaying the exact request/response already captured in the failed run's logs, which the new rejection-path assertions reproduce directly.

### Stakes
reversible

### Flags for Reviewer
- I could not run the actual Cypress suite in this sandbox (no `CYPRESS_BETA_ADMIN_TOKEN`/`CYPRESS_API_KEY`), so the new assertions in fix #1 are verified against the literal request/response already observed in the failed run's logs, not a fresh local run.
- The 60-minute Cypress timeout is a judgment call — I don't have a completed successful run to know the true suite duration; if it's still not enough, the next signal will be a "cancelled" run again rather than silence.
- Fix #3 is scope creep relative to the original Todo, but was necessary to get this PR's own required checks green at all — flagging in case you'd rather it land as a separate PR.

### Kaizen suggestion
`stores/muralStore.ts` has 9 pre-existing `tsc` errors (excessive type-instantiation depth + missing `regions`/`palette` properties around the ColoringPageDefinition fetch, line ~204-215) that predate this PR and aren't part of any workflow gate today, but will eventually need a real fix. Also, `cypress/e2e/api/dream-mutation-boundaries.cy.ts:90` has a pre-existing `@typescript-eslint/no-unused-expressions` lint error on `expect(res.body.data).to.exist` (chai getter assertion vs. the rule) that predates this change.

### Notes for reviewer
Will self-merge once CI is green, per the conductor AGENTS.md CI-Janitor policy (Todos outrank roadmap tasks; this is a HIGH-priority incident-routing todo).
