### PR TITLE
Generate tenth WonderLab review batch [wonderlab-editorial-batch]

### DIFF
--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,13 +1,34 @@
 {
   "version": 1,
-  "batchId": "wonderlab-source-grounded-rollout-010-dry-run",
-  "execute": false,
+  "batchId": "wonderlab-source-grounded-rollout-010",
+  "execute": true,
   "minimumProductionCommit": "f7d276757f15b79473b580d8b7c640c834cdc165",
-  "componentIds": [],
+  "componentIds": [909, 910, 911, 912, 927, 931, 959, 960, 961, 987],
   "limit": 10,
   "reviewersPerComponent": 2,
   "minimumScore": 0,
   "model": "gpt-4o-mini",
   "regenerate": false,
-  "expectedTargets": []
+  "expectedTargets": [
+    { "componentId": 909, "kind": "CHARACTER", "id": 245 },
+    { "componentId": 909, "kind": "BOT", "id": 404 },
+    { "componentId": 910, "kind": "BOT", "id": 428 },
+    { "componentId": 910, "kind": "CHARACTER", "id": 285 },
+    { "componentId": 911, "kind": "BOT", "id": 419 },
+    { "componentId": 911, "kind": "BOT", "id": 413 },
+    { "componentId": 912, "kind": "BOT", "id": 420 },
+    { "componentId": 912, "kind": "CHARACTER", "id": 279 },
+    { "componentId": 927, "kind": "CHARACTER", "id": 160 },
+    { "componentId": 927, "kind": "CHARACTER", "id": 232 },
+    { "componentId": 931, "kind": "CHARACTER", "id": 265 },
+    { "componentId": 931, "kind": "CHARACTER", "id": 122 },
+    { "componentId": 959, "kind": "CHARACTER", "id": 208 },
+    { "componentId": 959, "kind": "CHARACTER", "id": 126 },
+    { "componentId": 960, "kind": "CHARACTER", "id": 126 },
+    { "componentId": 960, "kind": "CHARACTER", "id": 208 },
+    { "componentId": 961, "kind": "CHARACTER", "id": 229 },
+    { "componentId": 961, "kind": "CHARACTER", "id": 249 },
+    { "componentId": 987, "kind": "CHARACTER", "id": 198 },
+    { "componentId": 987, "kind": "BOT", "id": 20 }
+  ]
 }


### PR DESCRIPTION
## Summary

Generates the exact 20 source-grounded drafts selected in handoff #690.

- locks Components 909, 910, 911, 912, 927, 931, 959, 960, 961, and 987
- locks the exact Bot/Character identities from the dry-run portfolio
- makes model calls only after merge through the guarded workflow
- performs no approvals or publications
- preserves the editorial boundary so the generated essays will be rewritten into concise paired world scenes before release

Refs #582, #606, and #690.