### PR TITLE
Add read-only WonderLab curation inventory

### DIFF
--- a/.github/workflows/wonderlab-curation-inventory.yml
+++ b/.github/workflows/wonderlab-curation-inventory.yml
@@ -1,0 +1,232 @@
+name: WonderLab Curation Inventory
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-curation-inventory.yml'
+      - 'config/wonderlab-editorial-batch.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-curation-inventory.yml'
+      - 'config/wonderlab-editorial-batch.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  CURATION_OUTPUT_DIR: /tmp/wonderlab-curation-inventory
+  CURATION_OUTPUT_STEM: inventory
+  CURATION_OUTPUT_EXT: json
+  PRODUCTION_OUTPUT_STEM: production-version
+
+jobs:
+  validate:
+    name: Validate read-only curation inventory
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate boundary
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert').strict
+          const workflow = fs.readFileSync('.github/workflows/wonderlab-curation-inventory.yml', 'utf8')
+          const config = JSON.parse(fs.readFileSync('config/wonderlab-editorial-batch.json', 'utf8'))
+          for (const required of [
+            '/api/version',
+            '/api/components',
+            '/api/admin/wonderlab/review-drafts?componentId=',
+            'expectedTargets',
+            'WonderLab curation handoff:',
+          ]) assert.ok(workflow.includes(required), `missing inventory boundary: ${required}`)
+          const forbidden = [
+            ...['generate', 'approve', 'publish', 'reject'].map((segment) => `/${segment}`),
+            `method: '${['PAT', 'CH'].join('')}'`,
+            `method: '${['PO', 'ST'].join('')}'`,
+            ['DATABASE', 'URL'].join('_'),
+            ['pris', 'ma.'].join(''),
+          ]
+          for (const token of forbidden) {
+            assert.ok(!workflow.includes(token), `inventory crossed write boundary: ${token}`)
+          }
+          assert.ok(Array.isArray(config.expectedTargets) && config.expectedTargets.length > 0)
+          assert.match(config.minimumProductionCommit, /^[0-9a-f]{40}$/)
+          console.log('WonderLab curation inventory boundary passed.')
+          NODE
+
+  inventory:
+    name: Inventory locked drafts for curation
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[wonderlab-curation-inventory]'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Verify compatible production runtime
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+        run: |
+          set -euo pipefail
+          mkdir -p "$CURATION_OUTPUT_DIR"
+          baseline_sha="$(jq -r '.minimumProductionCommit // empty' config/wonderlab-editorial-batch.json)"
+          git fetch --quiet --no-tags origin main
+          if ! git cat-file -e "${baseline_sha}^{commit}" 2>/dev/null; then
+            echo "::error::Configured production baseline ${baseline_sha} is unavailable."
+            exit 1
+          fi
+          for attempt in $(seq 1 90); do
+            payload="$(curl -sS --max-time 20 "${BASE_URL}/api/version" || true)"
+            live_sha="$(printf '%s' "$payload" | jq -r 'if .success == true then .data.commit // empty else empty end' 2>/dev/null || true)"
+            if [ -n "$live_sha" ] && bash scripts/check-deploy-ancestry.sh "$baseline_sha" "$live_sha"; then
+              output_path="$CURATION_OUTPUT_DIR/$PRODUCTION_OUTPUT_STEM.$CURATION_OUTPUT_EXT"
+              printf '%s\n' "$payload" > "$output_path"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Production did not reach inventory baseline ${baseline_sha} or a descendant."
+          exit 1
+      - name: Build read-only curation inventory
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const config = JSON.parse(fs.readFileSync('config/wonderlab-editorial-batch.json', 'utf8'))
+          const baseUrl = process.env.WONDERLAB_BASE_URL.replace(/\/$/, '')
+          const token = String(process.env.WONDERLAB_ADMIN_TOKEN || '').trim()
+          const jsonMime = ['application', 'json'].join('/')
+          const outputName = `${process.env.CURATION_OUTPUT_STEM}.${process.env.CURATION_OUTPUT_EXT}`
+          const outputPath = path.join(process.env.CURATION_OUTPUT_DIR, outputName)
+          if (!token) throw new Error('CYPRESS_BETA_ADMIN_TOKEN is not configured.')
+
+          async function request(requestPath, admin = false) {
+            const response = await fetch(`${baseUrl}${requestPath}`, {
+              headers: admin
+                ? { accept: jsonMime, 'x-beta-admin-token': token, 'x-admin-token': token, 'x-api-key': token }
+                : { accept: jsonMime },
+            })
+            const body = await response.json()
+            if (!response.ok) throw new Error(body?.message || `${requestPath} returned ${response.status}.`)
+            return body?.data
+          }
+
+          const components = await request('/api/components')
+          const componentMap = new Map(components.map((entry) => [Number(entry.id), entry]))
+          const inventory = []
+          for (const target of config.expectedTargets) {
+            const drafts = await request(`/api/admin/wonderlab/review-drafts?componentId=${target.componentId}&limit=200`, true)
+            const draft = drafts.find((entry) => entry?.author?.kind === target.kind && Number(entry?.author?.id) === target.id)
+            if (!draft) throw new Error(`No locked draft exists for Component ${target.componentId} / ${target.kind} #${target.id}.`)
+            const component = componentMap.get(Number(target.componentId))
+            if (!component) throw new Error(`Component ${target.componentId} is missing from production.`)
+            inventory.push({
+              component: {
+                id: Number(component.id),
+                name: component.componentName || component.name || '',
+                sourceKey: component.sourceKey || '',
+              },
+              target,
+              draft: {
+                id: Number(draft.id),
+                status: draft.status,
+                author: draft.author,
+                generatedComment: draft.generatedComment,
+                editedComment: draft.editedComment,
+                rating: draft.rating,
+                reactionType: draft.reactionType,
+                failureReason: draft.failureReason,
+                provenance: draft.promptPayload?.provenance || null,
+              },
+            })
+          }
+          fs.mkdirSync(process.env.CURATION_OUTPUT_DIR, { recursive: true })
+          fs.writeFileSync(outputPath, `${JSON.stringify({ config, inventory }, null, 2)}\n`)
+          NODE
+      - name: Upload inventory evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: wonderlab-curation-inventory-${{ github.run_id }}
+          path: ${{ env.CURATION_OUTPUT_DIR }}/${{ env.CURATION_OUTPUT_STEM }}.${{ env.CURATION_OUTPUT_EXT }}
+          retention-days: 30
+      - name: Create durable curation handoff
+        uses: actions/github-script@v7
+        env:
+          INVENTORY_PATH: ${{ env.CURATION_OUTPUT_DIR }}/${{ env.CURATION_OUTPUT_STEM }}.${{ env.CURATION_OUTPUT_EXT }}
+        with:
+          script: |
+            const fs = require('node:fs')
+            const payload = JSON.parse(fs.readFileSync(process.env.INVENTORY_PATH, 'utf8'))
+            const compact = (value, maximum) => {
+              const text = String(value || '').replace(/\s+/g, ' ').trim()
+              return text.length <= maximum ? text : `${text.slice(0, maximum - 1).trimEnd()}…`
+            }
+            const quote = (value) => compact(value, 1400).split('\n').map((line) => `> ${line}`).join('\n')
+            const lines = [
+              '# WonderLab curation handoff',
+              '',
+              `- **Batch:** \`${payload.config.batchId}\``,
+              `- **Locked drafts:** ${payload.inventory.length}`,
+              '- **Boundary:** read-only inventory; no generation, approval, editing, or publication occurred',
+            ]
+            for (const entry of payload.inventory) {
+              const provenance = entry.draft.provenance || {}
+              const facts = Array.isArray(provenance.sourceEvidenceFacts)
+                ? provenance.sourceEvidenceFacts.slice(0, 4).map((fact) => compact(fact, 240))
+                : []
+              lines.push(
+                '',
+                `## Draft #${entry.draft.id} · Component #${entry.component.id} ${entry.component.name} · ${entry.draft.author?.name || `${entry.target.kind} #${entry.target.id}`}`,
+                '',
+                `- **Status:** ${entry.draft.status}`,
+                `- **Author:** ${entry.draft.author?.kind || entry.target.kind} #${entry.draft.author?.id || entry.target.id} · slug \`${entry.draft.author?.slug || 'unknown'}\``,
+                `- **Source:** \`${entry.component.sourceKey || provenance.exhibitSourcePath || 'unknown'}\``,
+                `- **Rating / reaction:** ${entry.draft.rating ?? 'unset'} / ${entry.draft.reactionType || 'unset'}`,
+              )
+              if (entry.draft.failureReason) lines.push(`- **Failure reason:** ${compact(entry.draft.failureReason, 600)}`)
+              if (facts.length) lines.push('- **Bounded source facts:**', ...facts.map((fact) => `  - ${fact}`))
+              lines.push('', '**Generated copy**', '', quote(entry.draft.generatedComment || 'No generated comment recorded.'))
+            }
+            const title = `WonderLab curation handoff: ${payload.config.batchId}`
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            })
+            const match = existing.find((issue) => !issue.pull_request && issue.title === title)
+            if (match) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: lines.join('\n'),
+                state: 'open',
+              })
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: lines.join('\n'),
+              })
+            }


### PR DESCRIPTION
Adds a read-only workflow that inventories the exact reviewer targets locked in the current editorial manifest. It verifies production ancestry, performs only GET requests against the Component registry and draft-admin list endpoint, uploads durable evidence, and creates a curation handoff with exact draft, reviewer, source, bounded facts, failure reason, and generated copy.

The workflow cannot generate, edit, approve, reject, or publish reviews. This branch starts from the current rollout-011 `main` state.

Refs #582, #606, #693, and #694.