### PR TITLE
cypress: fix bots.cy.ts private-Dream permission test (same-account bug)

### DIFF
--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -51,7 +51,11 @@ describe('Bot Management API Tests', () => {
       .then((auth) => {
         userToken = auth.token
         userId = auth.id
-        return createLoggedInTestUser({ fresh: true })
+        // Must be a genuinely distinct account -- `fresh` is deprecated and
+        // now a no-op (the suite reuses the shared seed identity), so this
+        // was silently returning the SAME user as `userToken` above and
+        // making "another user's private Dream" actually self-owned.
+        return createLoggedInTestUser({ role: 'second' })
       })
       .then((other) => {
         otherToken = other.token
@@ -191,7 +195,9 @@ describe('Bot Management API Tests', () => {
   })
 
   it('creates a Bot with a lean mutation response', () => {
-    expect(userId, 'shared Cypress user id').to.be.a('number').and.be.greaterThan(0)
+    expect(userId, 'shared Cypress user id')
+      .to.be.a('number')
+      .and.be.greaterThan(0)
 
     cy.request({
       method: 'POST',


### PR DESCRIPTION
### Task
Follow-up to #679 (merged) / CI Janitor Todo #504/#506 lineage. After #679 fixed the Cypress job hang and stale Dream-mutation test contract, the next scheduled run (29777691847, main@64ce1bff, completed in ~13 min — no more timeout) surfaced one genuine remaining failure: `api/bots.cy.ts` → "forbids attaching another user private Dream on Bot creation" got `201` where it expected `403`. (kind: software)

### What changed / what I produced
Root cause is in the test, not the product. `bots.cy.ts`'s `before()` hook called `createLoggedInTestUser({ fresh: true })` for **both** the bot-creating user and the "other" user meant to own the private Dream. `fresh` is a deprecated, now-ignored option — `cypress/support/api-auth.ts` says outright: *"The suite now reuses run-scoped identities"* — only `{ role: 'second' }` actually provisions a genuinely distinct, isolated account (via `createFreshLoggedInTestUser`, which registers a brand-new stamped username/email). So `otherToken`/`otherId` silently resolved to the **same shared seed user** as `userToken`/`userId`, making the "private Dream" the bot-creator's own Dream. The API correctly allows attaching your own Dream — 201 was the right response given the test's actual (broken) setup. `server/api/bots/relations.ts`'s permission-enforcement logic is fine as-is.

~15 other specs already establish the correct pattern for this exact "another user's private resource" scenario — `dream-relation-permission.cy.ts`, `character-relation-permission.cy.ts`, `scenario-relation-permission.cy.ts`, `reward-input-boundary.cy.ts`, etc. — all call `{ role: 'second' }` for the second identity. Applied the same fix to `bots.cy.ts`.

### How I verified
- Pulled the failing run's Cypress log (run 29777691847, job 88470981625), confirmed the AssertionError: `expected 201 to equal 403`, and that this was the *only* failing test across all 58 specs — everything else, including all the Dream-mutation-boundary and contract-tests fixes from #679, is green.
- Traced `createLoggedInTestUser` → `CreateLoggedInTestUserOptions` in `cypress/support/api-auth.ts` and confirmed `fresh` is explicitly marked `@deprecated`/ignored; only `role: 'second'` reaches `createFreshLoggedInTestUser()`.
- Cross-checked ~15 other specs using the identical two-user "private resource" pattern to confirm `role: 'second'` is the established, working convention.
- `npx eslint` and `npx prettier --check` clean on the changed file.
- Could not run the live Cypress suite in this sandbox (no `CYPRESS_BETA_ADMIN_TOKEN`/`CYPRESS_API_KEY`); confidence comes from the helper's implementation and the matching pattern already proven to work in sibling specs.

### Stakes
reversible

### Flags for Reviewer
- Same sandbox limitation as always: no live Cypress credentials, so this is verified by code tracing + pattern-matching against already-passing sibling specs, not a fresh local run.
- I did not touch `achievement-scores.cy.ts`, which has the same `{ fresh: true }` / `{ fresh: true }` double-call shape but is currently passing (7/7) — its logic apparently doesn't depend on true user distinctness, so I left it alone per scope discipline rather than "fixing" something not observed to be broken.

### Kaizen suggestion
Grep for `createLoggedInTestUser({ fresh: true })` appearing twice in the same spec's setup — that shape is the actual bug signature (single-use `fresh: true` is fine; back-to-back calls both using it usually means the author wanted two distinct identities and didn't know `fresh` no longer does that). `achievement-scores.cy.ts` is the other spec with this shape; worth a quick look even though it's not currently red, in case it's silently testing something weaker than intended for the same reason `bots.cy.ts` was.

### Notes for reviewer
This branch previously carried two commits (Dream mutation-boundary test fix + contract-tests fix) that were closed as superseded by #679 — this PR is a clean rebuild off current `main` with only this new, unrelated fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CWTTF1Gvzw3ALt2wPyxWAG)_