### PR TITLE
ci-janitor: fix 5 stale Cypress specs + real Scenario batch-PATCH id bug

### DIFF
--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -51,7 +51,12 @@ describe('Bot Management API Tests', () => {
       .then((auth) => {
         userToken = auth.token
         userId = auth.id
-        return createLoggedInTestUser({ fresh: true })
+        // `fresh: true` is a deprecated no-op (the suite reuses a shared
+        // run-scoped identity for it) -- role: 'second' is what actually
+        // creates an isolated disposable account, needed here since this
+        // "other" user's private Dream must be owned by someone other than
+        // the primary test user for the permission check below to be real.
+        return createLoggedInTestUser({ role: 'second' })
       })
       .then((other) => {
         otherToken = other.token

--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -76,7 +76,6 @@ describe('Dream and Scenario Facet assignments', () => {
         dreamType: 'PITCH',
         description: 'Dream Facet assignment coverage.',
         isPublic: false,
-        createCollection: false,
       },
     }).then((response) => {
       expect(response.status).to.eq(201)

--- a/cypress/e2e/api/relationships.cy.ts
+++ b/cypress/e2e/api/relationships.cy.ts
@@ -206,7 +206,6 @@ describe('Relationship API Tests', () => {
           isDefault: false,
           isActive: true,
           isEditable: true,
-          supportsTxt2Img: true,
         }),
       )
       .then(() =>

--- a/cypress/e2e/api/server-health-report-ownership.cy.ts
+++ b/cypress/e2e/api/server-health-report-ownership.cy.ts
@@ -55,14 +55,21 @@ describe('Browser server health report ownership', () => {
     cy.then(() => {
       const stamp = Date.now()
 
+      // Ownership is always server-derived from the authenticated caller (no
+      // admin override -- see server/utils/serverApi.ts's
+      // assertServerCreateOwnership), so the server must be created with
+      // owner's own token rather than admin + an explicit userId. That also
+      // means isPublic is forced to false for a non-admin creator
+      // (buildServerCreateData), which is fine: these tests only exercise
+      // health-report ownership (401/403/200), not public visibility.
       return cy.request<ApiResponse<ServerRecord>>({
         method: 'POST',
         url: `${apiBase}/server`,
-        headers: adminHeaders(adminToken),
+        headers: bearerHeaders(owner.token),
         body: {
           title: `Browser health report ${stamp}`,
           label: 'Health report test',
-          description: 'Disposable public server for browser health ownership tests',
+          description: 'Disposable server for browser health ownership tests',
           category: 'test',
           serverType: 'CUSTOM',
           accessMode: 'BROWSER',
@@ -70,10 +77,6 @@ describe('Browser server health report ownership', () => {
           baseUrl: 'https://example.com',
           endpointPath: '/api',
           healthPath: '/health',
-          userId: owner.id,
-          isPublic: true,
-          isOfficial: false,
-          isDefault: false,
           isActive: true,
           isEditable: true,
           isMature: false,
@@ -85,7 +88,7 @@ describe('Browser server health report ownership', () => {
       expect(response.status, JSON.stringify(response.body)).to.eq(201)
       expect(response.body.success).to.eq(true)
       expect(response.body.data?.userId).to.eq(owner.id)
-      expect(response.body.data?.isPublic).to.eq(true)
+      expect(response.body.data?.isPublic).to.eq(false)
 
       server = response.body.data as ServerRecord
 
@@ -103,7 +106,7 @@ describe('Browser server health report ownership', () => {
     })
   })
 
-  it('rejects an anonymous report for a public server', () => {
+  it('rejects an anonymous report for a browser-mode server', () => {
     cy.request<ApiResponse>({
       method: 'PATCH',
       url: `${apiBase}/server/health/${server.id}`,

--- a/server/api/scenarios/batch.patch.ts
+++ b/server/api/scenarios/batch.patch.ts
@@ -40,6 +40,7 @@ async function processEntry(
       allowedFields: scenarioBatchPatchFields,
       context: `Scenario batch update item ${index}`,
       requireNonEmpty: true,
+      allowBatchId: true,
     })
 
     const entry = rawEntry as ScenarioBatchEntry

--- a/server/api/scenarios/mutation.ts
+++ b/server/api/scenarios/mutation.ts
@@ -96,6 +96,11 @@ type ScenarioBoundaryOptions = {
   authenticatedUserId?: number
   routeId?: number
   allowTemporaryId?: boolean
+  // Batch PATCH entries carry their own `id` in the body (there is no per-item
+  // route) to say which record to update; it is a lookup key, not a write
+  // target, so it should not trip the "ID is server-owned" immutability check
+  // routeId enforces for single-record PATCH.
+  allowBatchId?: boolean
 }
 
 const nullableTextFields = [
@@ -193,6 +198,13 @@ export function assertScenarioMutationInput(
         throw createError({
           statusCode: 400,
           message: 'Scenario create payload cannot assign a persisted ID.',
+        })
+      }
+    } else if (options.allowBatchId) {
+      if (requestedId <= 0) {
+        throw createError({
+          statusCode: 400,
+          message: 'Invalid scenario ID. It must be a positive integer.',
         })
       }
     } else {


### PR DESCRIPTION
### Task
CI Janitor Todo #506 (`ci-janitor:silasfelinus/kind_robots:cypress.yml:29770267938`) — the scheduled Cypress Tests run failed. (kind: software)

### What changed / what I produced
That flagged run (29770267938) predated PR #679's Cypress-hang fix and inherited the same already-fixed timeout signature — not a new incident. The next scheduled run after #679 merged ([29777691847](https://github.com/silasfelinus/kind_robots/actions/runs/29777691847)) completed the full suite for the first time in days (no more hang) and surfaced 6 real, distinct test failures across 5 of 58 specs. Root-caused each:

1. **`bots.cy.ts`** — "forbids attaching another user private Dream on Bot creation" got `201` instead of `403`. `createLoggedInTestUser({ fresh: true })` is a deprecated no-op (`api-auth.ts`: "the suite now reuses run-scoped identities") — the test called it twice expecting two distinct users, so `userToken` and `otherToken` silently resolved to the same shared seed user, and the bot's own "private Dream" was never actually another user's. Not a security regression — switched the second call to `role: 'second'`, the actual mechanism for an isolated account.
2. **`facet-assignments.cy.ts`** (2 failures, one direct + one cascade) — sent `createCollection: false` on Dream create, one of the legacy fields `server/api/dreams/mutation.ts` now hard-rejects (same hardening PR #679 already fixed in `dream-mutation-boundaries.cy.ts`; this spec was never touched). Removed the stale field.
3. **`relationships.cy.ts`** — Server creation sent `supportsTxt2Img: true`, a field with no backing Prisma column and never present in `serverCreateFields`. Removed the stale field.
4. **`scenario.cy.ts`** — batch PATCH's own documented contract is `{ updates: [{ id, ...fields }] }`, and `scenarioBatchPatchFields` explicitly allows `id` in each entry — but `assertScenarioMutationInput`'s id-ownership check only had two valid modes (`routeId` match for single-record PATCH, `allowTemporaryId` for create) and threw `"Scenario ID is server-owned"` for anything else, including the batch route's own legitimate `id` field. **A real product bug, not a stale test.** Added an `allowBatchId` option (id is a lookup key in batch mode, not a write target) and set it on `batch.patch.ts`'s call.
5. **`server-health-report-ownership.cy.ts`** — `before()` created a server as admin with `userId: owner.id` + `isPublic: true`, expecting admin to assign ownership to a different user. Ownership assignment has no admin bypass anywhere in this codebase (Dream/Scenario/Bot/Server all enforce `requestedUserId === authenticatedUserId` unconditionally, by design per `docs/architecture/thin-resource-api-audit.md`) — admin-token auth also resolves to one fixed real user (the beta-admin account), so `userId: owner.id` could never have produced a server owned by `owner`. Rewrote to create the server with owner's own token (`isPublic` is then correctly `false`, since only admins can set it `true`) and adjusted the two assertions/title that depended on the old, unreachable shape. The actual ownership-permission tests (401 anon / 403 non-owner / 200 owner) are unchanged.

### How I verified
- Fetched the full job log for run 29777691847 and located all 6 failures via the final per-spec summary table (`5 of 58 failed (9%)`), then traced each to its root cause in the relevant server route / test fixture.
- Read `server/utils/serverApi.ts`, `server/api/bots/relations.ts`, `server/api/dreams/mutation.ts`, and `server/api/scenarios/mutation.ts` to confirm each failure's actual cause (stale test vs. product bug) rather than guessing from the error message alone.
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0, no new errors.
- `npx eslint` on all 6 changed files — clean except `relationships.cy.ts`'s 2 pre-existing errors, confirmed via `git stash` against `main` (unrelated to this change: `no-explicit-any` on an unrelated line, `no-unused-expressions` on a chai getter assertion).
- `npx prettier --check` flags pre-existing drift in 4 of the 6 files at baseline (confirmed via `git stash`) — kept the diff scoped to the intended changes rather than reformatting unrelated lines.
- Could not run the live Cypress suite in this sandbox (no `CYPRESS_BETA_ADMIN_TOKEN`/`CYPRESS_API_KEY`); confidence comes from tracing each failure's exact request/response against the actual route source, not just pattern-matching the earlier PR #679 fix.

### Stakes
reversible

### Flags for Reviewer
- Item 4 (`allowBatchId`) is the one genuine product-code change in this PR — everything else is test-fixture drift. Worth a closer look than the rest.
- I could not confirm with a fresh live run that all 6 failures are now fixed (no Cypress credentials in this sandbox); the next scheduled run is the real signal.

### Kaizen suggestion
`createLoggedInTestUser({ fresh: true })` being a silent no-op (rather than throwing/warning when called a second time expecting a distinct identity) is exactly the kind of stale-API-usage trap that caused failure #1 here. Consider having it warn (or the deprecated option throw) when `role` is omitted more than once per spec file, so future call-site drift like this fails loudly in CI instead of silently degrading test coverage.

### Notes for reviewer
Will self-merge once CI is green, per the conductor AGENTS.md CI-Janitor policy (Todos outrank roadmap tasks; this is a HIGH-priority incident-routing todo).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SQarPV3ADCHpb9jqa1nyXa)_