### PR TITLE
fix: red Cypress CI follow-up — 4 stale test payloads + 1 batch-PATCH regression

### DIFF
--- a/cypress/e2e/api/bots.cy.ts
+++ b/cypress/e2e/api/bots.cy.ts
@@ -51,7 +51,14 @@ describe('Bot Management API Tests', () => {
       .then((auth) => {
         userToken = auth.token
         userId = auth.id
-        return createLoggedInTestUser({ fresh: true })
+        // `fresh: true` is a deprecated no-op (createLoggedInTestUser now
+        // always reuses the run-scoped seed identity for it) -- the private
+        // Dream owner below must use `role: 'second'` to actually get a
+        // distinct account, otherwise this ends up being the same user as
+        // `userToken` and the "forbids attaching another user private Dream"
+        // test below is attaching a self-owned Dream, which is legitimately
+        // allowed and can never observe the 403 it asserts.
+        return createLoggedInTestUser({ role: 'second' })
       })
       .then((other) => {
         otherToken = other.token

--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -76,7 +76,6 @@ describe('Dream and Scenario Facet assignments', () => {
         dreamType: 'PITCH',
         description: 'Dream Facet assignment coverage.',
         isPublic: false,
-        createCollection: false,
       },
     }).then((response) => {
       expect(response.status).to.eq(201)

--- a/cypress/e2e/api/relationships.cy.ts
+++ b/cypress/e2e/api/relationships.cy.ts
@@ -206,7 +206,6 @@ describe('Relationship API Tests', () => {
           isDefault: false,
           isActive: true,
           isEditable: true,
-          supportsTxt2Img: true,
         }),
       )
       .then(() =>

--- a/cypress/e2e/api/server-health-report-ownership.cy.ts
+++ b/cypress/e2e/api/server-health-report-ownership.cy.ts
@@ -55,10 +55,17 @@ describe('Browser server health report ownership', () => {
     cy.then(() => {
       const stamp = Date.now()
 
+      // Server ownership is derived exclusively from the authenticated
+      // caller (server/utils/serverApi.ts assertServerCreateOwnership) --
+      // even admin credentials may not assign `userId` on create (see
+      // server-ownership.cy.ts's dedicated "Server ownership boundary"
+      // coverage). So the fixture must be created AS its intended owner;
+      // isPublic is admin-only, so that's applied in a follow-up admin
+      // PATCH rather than at creation time.
       return cy.request<ApiResponse<ServerRecord>>({
         method: 'POST',
         url: `${apiBase}/server`,
-        headers: adminHeaders(adminToken),
+        headers: bearerHeaders(owner.token),
         body: {
           title: `Browser health report ${stamp}`,
           label: 'Health report test',
@@ -70,10 +77,6 @@ describe('Browser server health report ownership', () => {
           baseUrl: 'https://example.com',
           endpointPath: '/api',
           healthPath: '/health',
-          userId: owner.id,
-          isPublic: true,
-          isOfficial: false,
-          isDefault: false,
           isActive: true,
           isEditable: true,
           isMature: false,
@@ -81,26 +84,42 @@ describe('Browser server health report ownership', () => {
         },
         failOnStatusCode: false,
       })
-    }).then((response) => {
-      expect(response.status, JSON.stringify(response.body)).to.eq(201)
-      expect(response.body.success).to.eq(true)
-      expect(response.body.data?.userId).to.eq(owner.id)
-      expect(response.body.data?.isPublic).to.eq(true)
+    })
+      .then((response) => {
+        expect(response.status, JSON.stringify(response.body)).to.eq(201)
+        expect(response.body.success).to.eq(true)
+        expect(response.body.data?.userId).to.eq(owner.id)
 
-      server = response.body.data as ServerRecord
+        server = response.body.data as ServerRecord
 
-      cy.task(
-        'cypressCleanup:register',
-        {
-          label: `Browser health server ${server.id}`,
-          method: 'DELETE',
+        cy.task(
+          'cypressCleanup:register',
+          {
+            label: `Browser health server ${server.id}`,
+            method: 'DELETE',
+            url: `${apiBase}/server/${server.id}`,
+            headers: adminHeaders(adminToken),
+            expectedStatuses: [200, 404],
+          },
+          { log: false },
+        )
+
+        return cy.request<ApiResponse<ServerRecord>>({
+          method: 'PATCH',
           url: `${apiBase}/server/${server.id}`,
           headers: adminHeaders(adminToken),
-          expectedStatuses: [200, 404],
-        },
-        { log: false },
-      )
-    })
+          body: { isPublic: true },
+          failOnStatusCode: false,
+        })
+      })
+      .then((patchResponse) => {
+        expect(patchResponse.status, JSON.stringify(patchResponse.body)).to.eq(
+          200,
+        )
+        expect(patchResponse.body.success).to.eq(true)
+        expect(patchResponse.body.data?.isPublic).to.eq(true)
+        server.isPublic = true
+      })
   })
 
   it('rejects an anonymous report for a public server', () => {

--- a/server/api/scenarios/batch.patch.ts
+++ b/server/api/scenarios/batch.patch.ts
@@ -36,21 +36,38 @@ async function processEntry(
   let id: number | null = null
 
   try {
-    assertScenarioMutationInput(rawEntry, {
-      allowedFields: scenarioBatchPatchFields,
-      context: `Scenario batch update item ${index}`,
-      requireNonEmpty: true,
-    })
+    if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
+      throw createError({
+        statusCode: 400,
+        message: `Scenario batch update item ${index} must be a JSON object.`,
+      })
+    }
 
-    const entry = rawEntry as ScenarioBatchEntry
-    id = Number(entry.id)
+    const candidateId = Number((rawEntry as Record<string, unknown>).id)
 
-    if (!Number.isInteger(id) || id <= 0) {
+    if (!Number.isInteger(candidateId) || candidateId <= 0) {
       throw createError({
         statusCode: 400,
         message: 'Invalid scenario ID. It must be a positive integer.',
       })
     }
+
+    id = candidateId
+
+    // Unlike the singular PATCH route, batch entries carry their own routing
+    // id in the body (there's no per-item URL). assertScenarioMutationInput's
+    // id handling rejects a bare `id` field unless told what it's allowed to
+    // match against, so pass the id we just validated as `routeId` -- this
+    // is the same "id must match the route" contract as [id].patch.ts, just
+    // with the entry itself acting as its own route.
+    assertScenarioMutationInput(rawEntry, {
+      allowedFields: scenarioBatchPatchFields,
+      context: `Scenario batch update item ${index}`,
+      requireNonEmpty: true,
+      routeId: id,
+    })
+
+    const entry = rawEntry as ScenarioBatchEntry
 
     const existingScenario = await prisma.scenario.findUnique({
       where: { id },


### PR DESCRIPTION
## Context

Follow-up to #679, which fixed the scheduled Cypress CI hang (ffmpeg video-compression on GitHub Actions) and one stale test file. The first scheduled run after #679 merged (run `29777691847`, commit `64ce1bff`) confirms the hang is fixed — the suite now completes in under 10 minutes instead of timing out at 30 — but surfaced 6 real test failures across 5 spec files. This PR root-causes and fixes all 5.

kind_robots CI todo #506 (conductor repo).

## Root causes + fixes

### Stale test payloads hitting field-allowlist hardening (same class of bug #679 fixed)

1. **`cypress/e2e/api/facet-assignments.cy.ts`** — POST to `/api/dreams` sent a dead `createCollection: false` field. Not present in `dreamCreateFields` (`server/api/dreams/mutation.ts`), not referenced anywhere else in the codebase. Dropped the field, matching the exact precedent set in #679's fix to `dream-mutation-boundaries.cy.ts`.

2. **`cypress/e2e/api/relationships.cy.ts`** — Server-create body sent a dead `supportsTxt2Img: true` field. Not present in `serverCreateFields` (`server/api/server/index.post.ts`), not a Prisma column, not referenced anywhere else. Dropped the field.

3. **`cypress/e2e/api/server-health-report-ownership.cy.ts`** — the `before` hook created its fixture Server with **admin** credentials while assigning `userId: owner.id` in the body. `assertServerCreateOwnership` (`server/utils/serverApi.ts`) now intentionally rejects *any* client-supplied `userId` on create that doesn't match the authenticated caller — including for admins — and this is deliberately covered by its own dedicated suite (`server-ownership.cy.ts`, "Server ownership boundary": *"does not let elevated credentials assign Server ownership on create"*). So this was the test working against a real, intentional, already-tested product decision. Rewrote the fixture setup: create the Server authenticated **as** the intended owner (ownership is then correctly derived from the caller), then a follow-up **admin** PATCH sets `isPublic: true` (an admin-only field, unrelated to ownership).

4. **`cypress/e2e/api/bots.cy.ts`** — `createLoggedInTestUser({ fresh: true })` is a **deprecated no-op** (see `cypress/support/api-auth.ts`: `fresh` only has a `@deprecated` JSDoc tag and the implementation ignores it — only `{ role: 'second' }` yields a genuinely distinct account). The "forbids attaching another user private Dream on Bot creation" test used `{ fresh: true }` for *both* the acting user and the intended "other" private-Dream owner, so both ended up resolving to the identical seed-user identity. The bot creation was therefore attaching a **self-owned** Dream, which is legitimately allowed — hence the observed 201 instead of 403. **This is a stale test bug, not a security regression**: I verified `assertBotRelationsAttachable` (`server/api/bots/relations.ts`) still correctly 403s a non-admin attaching another user's private Dream, and every other spec in the suite already uses `role: 'second'` for exactly this purpose (`character-relation-permission.cy.ts`, `dream-relation-permission.cy.ts`, `reward-input-boundary.cy.ts`, etc.). Fixed by switching the second call to `{ role: 'second' }`.

### Real API bug

5. **`server/api/scenarios/batch.patch.ts`** — Scenario batch PATCH's own documented body shape is `{ updates: [{ id, ...fields }] }` — each entry must carry its own routing `id` since there's no per-item URL. But `processEntry` called the shared `assertScenarioMutationInput` validator without a `routeId`, and that validator unconditionally rejects a bare `id` field unless told what it's allowed to match (`routeId` or `allowTemporaryId`). Net effect: **every** batch-PATCH call, from any caller, failed every entry with `400 "Scenario ID is server-owned."` — this endpoint could never succeed as documented. Fixed by validating/extracting `id` first, then passing it as `routeId` to the assertion (the entry acts as its own route, mirroring `[id].patch.ts`'s "id must match the route" contract).

## Verification

- `npm test` (`vue-tsc --noEmit`) exits 0.
- `npx prettier --check` on all 5 touched files: the only remaining warnings are **pre-existing drift that predates this change** — confirmed by running prettier against each file's `HEAD` version in isolation and diffing. None of my own added/changed lines are flagged; unrelated reformatting was reverted to keep the diff scoped.
- Full local repro of server behavior wasn't run against a live DB in this environment; reasoning is from direct code reading of the allowlists/validators plus cross-referencing sibling test files' already-passing conventions (e.g. `server-ownership.cy.ts`, other specs' `role: 'second'` usage).
- A dispatch of `.github/workflows/cypress.yml` against this branch (or the next scheduled run) is the real-signal check — see follow-up comment on this PR for the observed run result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJwphXyBQAXLkTnnrgfrvq)_