### PR TITLE
Cards show real collection art; stop re-requesting images that already exist

### DIFF
--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -10,12 +10,13 @@
       class="relative flex min-h-36 w-full shrink-0 items-center justify-center overflow-hidden bg-base-300 sm:min-h-44 md:min-h-52 xl:min-h-full xl:w-2/5 xl:max-w-[10rem]"
     >
       <img
-        v-if="card.deckImage"
-        :src="card.deckImage"
+        v-if="deckImage"
+        :src="deckImage"
         :alt="card.label"
         class="h-full max-h-full w-full max-w-full object-contain p-2 transition-transform duration-300 group-hover:scale-[1.03]"
         loading="lazy"
         decoding="async"
+        @error="handleDeckImageError"
       />
 
       <div
@@ -91,9 +92,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useBuilderStore } from '@/stores/builderStore'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
+import { resolveCollectionCardImage } from '@/utils/collectionCardImage'
 
 const props = withDefaults(
   defineProps<{
@@ -106,6 +108,35 @@ const props = withDefaults(
 )
 
 const store = useBuilderStore()
+
+// Start from the card's own placeholder image (same as before), then upgrade it
+// on the client to real art from the card's collection folder when available.
+// Purely additive: if nothing resolves, or the resolved image fails to load, we
+// fall back to the original image (which keeps the global default fallback).
+const deckImage = ref(props.card.deckImage)
+
+async function upgradeDeckImage() {
+  const resolved = await resolveCollectionCardImage(props.card.key, 'card')
+  if (resolved) deckImage.value = resolved
+}
+
+onMounted(upgradeDeckImage)
+
+watch(
+  () => props.card.key,
+  () => {
+    deckImage.value = props.card.deckImage
+    upgradeDeckImage()
+  },
+)
+
+function handleDeckImageError() {
+  // A collection image that fails to load reverts to the card's original image
+  // rather than a broken tile.
+  if (deckImage.value !== props.card.deckImage) {
+    deckImage.value = props.card.deckImage
+  }
+}
 
 const isCompleted = computed(() => Boolean(store.completedCards[props.card.key]))
 const isActive = computed(() => store.activeCardKey === props.card.key)

--- a/server/api/conductor/art-request.post.ts
+++ b/server/api/conductor/art-request.post.ts
@@ -13,6 +13,16 @@ const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
 const CONDUCTOR_REPO = 'silasfelinus/conductor'
 const ART_PROMPTS_PATH = 'projects/art-prompts.yaml'
 const DEFAULT_BRANCH = 'main'
+// Kind Robots images live on the self-hosted media host, not in the repo
+// (public/images/** is git-ignored). The GitHub existence check below can
+// therefore NEVER see a kind_robots card/hero/icon that already exists on the
+// mount, so on its own it re-requests art we already have. Probe the media
+// host too. Same origin convention as utils/scripts/mediaContractSource.ts and
+// Conductor's media_direct_consumer.py.
+const MEDIA_ORIGIN = (
+  process.env.MEDIA_ORIGIN?.trim() || 'https://media.acrocatranch.com'
+).replace(/\/+$/, '')
+const MEDIA_EXISTS_TIMEOUT_MS = 8000
 const IMAGE_EXTENSIONS = new Set(['.webp', '.png', '.jpg', '.jpeg', '.gif', '.svg'])
 const VARIANT_SIZES: Record<ArtVariant, string> = {
   icon: '256x256',
@@ -237,6 +247,42 @@ async function githubFileExists(target: ImageTarget, token: string): Promise<boo
   return Boolean(file)
 }
 
+// public/images/foo.webp -> https://media.acrocatranch.com/images/foo.webp
+// (strip the leading `public/`, same as the Conductor consumer's _media_url).
+function mediaUrlForTarget(target: ImageTarget): string | null {
+  if (target.targetRepo !== KIND_ROBOTS_REPO) return null
+  const relative = target.imagePath.replace(/^public\//, '')
+  if (!relative || relative === target.imagePath) return null
+  const encoded = relative.split('/').map(encodeURIComponent).join('/')
+  return `${MEDIA_ORIGIN}/${encoded}`
+}
+
+// HEAD the media host to see if the asset is already served. Best-effort: any
+// network/timeout error resolves false so we fall through to the GitHub check
+// and (worst case) queue a request rather than wrongly suppress one.
+async function mediaFileExists(target: ImageTarget): Promise<boolean> {
+  const url = mediaUrlForTarget(target)
+  if (!url) return false
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), MEDIA_EXISTS_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, { method: 'HEAD', signal: controller.signal })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// A target is "already satisfied" if it exists in the repo OR on the media host.
+// GitHub covers conductor-committed art; media covers the git-ignored
+// kind_robots mount. Check media first (cheap HEAD, no token) and short-circuit.
+async function imageAlreadyExists(target: ImageTarget, token: string): Promise<boolean> {
+  if (await mediaFileExists(target)) return true
+  return githubFileExists(target, token)
+}
+
 function decodeGithubContent(file: GitHubFile): string {
   return Buffer.from(file.content.replace(/\n/g, ''), 'base64').toString('utf-8')
 }
@@ -354,10 +400,10 @@ export default defineEventHandler(async (event) => {
     const body = await readBody<MissingArtRequestBody>(event)
     const target = targetFromSource(body)
 
-    if (await githubFileExists(target, token)) {
+    if (await imageAlreadyExists(target, token)) {
       return {
         success: true,
-        message: 'Image already exists in the target repo; no request created.',
+        message: 'Image already exists in the target repo or on media; no request created.',
         data: { created: false, target },
         statusCode: 200,
       }

--- a/utils/collectionCardImage.ts
+++ b/utils/collectionCardImage.ts
@@ -1,0 +1,69 @@
+// utils/collectionCardImage.ts
+//
+// Upgrade a content/nav card's placeholder image to real art from its OWN
+// collection, using the app's folder-collection resolver
+// (GET /api/art/collection/folder/<slug> -> server/utils/folderCollections:
+// "every image in a slug's media folder is part of that slug's collection just
+// by existing there").
+//
+// This is what lets generic Md cards show their own artwork instead of the
+// single shared default (botcafe.webp): once the art pipeline has generated a
+// card's image into its media folder, the folder resolver returns it and the
+// card picks it up. Cards for which no folder art exists yet simply keep their
+// current image — this is strictly additive and never renders worse than today.
+//
+// Best-effort and cached per slug: any invalid slug, network error, or empty
+// folder resolves to '' so the caller keeps its existing image.
+
+type FolderImagesResponse = {
+  data?: { slug?: string; images?: string[] | null } | null
+}
+
+export type CardImageVariant = 'card' | 'hero' | 'icon'
+
+// Mirrors SLUG_PATTERN in server/utils/folderCollections so we never issue a
+// request the route would just 400.
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
+
+const folderImageCache = new Map<string, Promise<string[]>>()
+
+async function fetchFolderImages(slug: string): Promise<string[]> {
+  const clean = slug.trim().toLowerCase()
+  if (!SLUG_PATTERN.test(clean)) return []
+
+  let pending = folderImageCache.get(clean)
+  if (!pending) {
+    pending = $fetch<FolderImagesResponse>(
+      `/api/art/collection/folder/${encodeURIComponent(clean)}`,
+    )
+      .then((res) =>
+        Array.isArray(res?.data?.images) ? (res.data?.images as string[]) : [],
+      )
+      .catch(() => [])
+    folderImageCache.set(clean, pending)
+  }
+  return pending
+}
+
+/** Prefer an image named for the variant (…-card.webp / …/card.webp); else the first. */
+function pickVariantImage(images: string[], variant: CardImageVariant): string {
+  if (!images.length) return ''
+  const wanted = images.find((src) => {
+    const lower = src.toLowerCase()
+    return lower.includes(`-${variant}.`) || lower.includes(`/${variant}.`)
+  })
+  return wanted || images[0] || ''
+}
+
+/**
+ * Resolve the best real image for a card's collection folder, or '' if none.
+ * `slug` is typically the card key. Safe to call on the server or client.
+ */
+export async function resolveCollectionCardImage(
+  slug: string | null | undefined,
+  variant: CardImageVariant = 'card',
+): Promise<string> {
+  if (!slug) return ''
+  const images = await fetchFolderImages(slug)
+  return pickVariantImage(images, variant)
+}


### PR DESCRIPTION
## Why

Two linked fixes for the missing-frontend-image problem.

**Cards** — generic Md/content cards all fell back to the single shared default (`botcafe.webp`) because their image is a synthesized `/images/dashboard-tabs/<k>/<t>.webp` path that 404s. Projects were the only exception (they resolve real art via a DB + committed-art chain).

**Intake** — the missing-image gate (`art-request.post.ts`) checked GitHub for "does it already exist?", but kind_robots images live on the self-hosted media host (`public/images/**` is git-ignored), so the check could never see them and kept queuing duplicates.

## Changes

- `utils/collectionCardImage.ts` (new): resolve a card's real art from its own collection folder via the app's folder-collection resolver (`/api/art/collection/folder/<slug>`). Best-effort + cached; returns `''` on any miss.
- `builder-card.vue`: start from the card's existing placeholder, then upgrade to the resolved collection image on mount; revert on load error. **Strictly additive** — a card with no folder art yet renders exactly as before, and lights up automatically as the art pipeline fills its media folder. This deliberately connects the generation pipeline's output to the card display.
- `art-request.post.ts`: `imageAlreadyExists` now checks the **media host** (HEAD) as well as GitHub — best-effort, fails open — so it stops re-requesting art that already exists on the mount.

## Verification

⚠️ This could not be typechecked/run in the CI sandbox (no `node_modules`). Please let the repo's `vue-tsc` CI (`npm run test`) be the gate before merge. The card change is written to never render worse than today; the **folder-slug mapping** (`card.key` → collection folder) in particular wants a live check against real media.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDhGwV9s918vamrHqR7qnp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDhGwV9s918vamrHqR7qnp)_