### PR TITLE
fix: correct BotType casing in relationships.cy.ts Bot fixture

### DIFF
--- a/cypress/e2e/api/relationships.cy.ts
+++ b/cypress/e2e/api/relationships.cy.ts
@@ -242,7 +242,7 @@ describe('Relationship API Tests', () => {
       )
       .then(() =>
         postRecord('bot', {
-          botType: 'PROMPTBOT',
+          BotType: 'PROMPTBOT',
           name: `cypress-bot-${time}`,
           subtitle: 'Relationship bot',
           description: 'Cypress relationship bot fixture',


### PR DESCRIPTION
### Context
CI-janitor todo #516 flagged red Cypress CI (referencing run 29780457098, already fixed by #721/#724). Checking the *actual latest* Cypress run on main (29782607317, on #724's own commit 049cca41) showed CI is still genuinely red — one field further into the same test, same class of bug as #721/#724.

### What changed
`relationships.cy.ts`'s Bot fixture sent `botType: 'PROMPTBOT'` (lowercase), but the Prisma column is `BotType` and `botCreateFields` (server/api/bots/index.post.ts) only allows the capitalized key — every other Bot-creating spec (`bots.cy.ts`) already uses `BotType` correctly. The stray lowercase key 400'd as an unsupported field:
```
Unsupported Bot fields: botType. Ownership, IDs, and timestamps are server-owned.
```
Fixed the casing to `BotType`.

### How I verified
- Cross-checked every remaining `postRecord()` call in this test (character, prompt, scenario, reward, dream, chat) against their current server-side field allowlists — no other mismatches found, so this should be the full fix for this test.
- `npm run test` (`vue-tsc --noEmit`) exits 0.
- `npx eslint` / `npx prettier --check` on the file both show the same 2 pre-existing issues (`no-explicit-any`, `no-unused-expressions`, and formatting drift) confirmed present on `main` HEAD via `git stash` — not introduced by this change.

### Stakes
reversible — test-only change, no product code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_0141uK3UscssQejZCtDghZEB)_