### PR TITLE
fix: recognize Vercel ignore-build no-op deploys in Cypress deploy-wait

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Deploy-wait ancestry check contract
         run: npm run test:deploy-wait-ancestry
 
+      - name: Deploy-wait no-op check contract
+        run: npm run test:deploy-wait-noop
+
       - name: Prisma JSON-cast contract
         run: npm run test:no-prisma-json-cast
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -75,6 +75,18 @@ jobs:
                 echo "Production is serving ${live}, a newer commit that already includes ${TARGET_SHA} — deploy is live (superseded)."
                 exit 0
               fi
+              # The opposite direction: ${live} predates ${TARGET_SHA}, but
+              # scripts/vercel-ignore-build.mjs may have skipped building
+              # TARGET_SHA on its own because every file it changed since
+              # ${live} is deploy-inert (cypress/docs/tests — see
+              # scripts/lib/deployIgnorePaths.mjs). In that case production
+              # will never serve TARGET_SHA and this loop would otherwise
+              # time out waiting for a deployment Vercel already decided not
+              # to build.
+              if node scripts/check-deploy-noop.mjs "$live" "$TARGET_SHA" 2>/dev/null; then
+                echo "Production is serving ${live}; ${TARGET_SHA}'s changes since then are deploy-inert (test/docs only) — deploy is live (no-op)."
+                exit 0
+              fi
             fi
             echo "  not live yet (serving: ${live:-unknown}); retrying in 10s..."
             sleep 10

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -84,7 +84,7 @@ jobs:
               # time out waiting for a deployment Vercel already decided not
               # to build.
               if node scripts/check-deploy-noop.mjs "$live" "$TARGET_SHA" 2>/dev/null; then
-                echo "Production is serving ${live}; ${TARGET_SHA}'s changes since then are deploy-inert (test/docs only) — deploy is live (no-op)."
+                echo "Production is serving ${live}; ${TARGET_SHA}'s changes since then are deploy-inert (test- and docs-only) — deploy is live (no-op)."
                 exit 0
               fi
             fi

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:academy-examples-manifest": "tsx utils/scripts/verifyAcademyExamplesManifest.ts",
     "test:workflow-paths": "tsx utils/scripts/verifyWorkflowPaths.ts",
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
+    "test:deploy-wait-noop": "tsx utils/scripts/verifyDeployWaitNoOp.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
     "test:existing-owner-id-nullability": "tsx utils/scripts/verifyExistingOwnerIdNullability.ts",

--- a/scripts/check-deploy-noop.mjs
+++ b/scripts/check-deploy-noop.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scripts/check-deploy-noop.mjs <live_sha> <target_sha>
+//
+// Shared by .github/workflows/cypress.yml's "Wait for deploy to go live"
+// step and utils/scripts/verifyDeployWaitNoOp.ts's regression test.
+//
+// scripts/vercel-ignore-build.mjs (Vercel's ignoreCommand) intentionally
+// skips a production deployment when a push's changes are all within paths
+// that never affect the running app (cypress/, docs/, *.test.ts, etc — see
+// scripts/lib/deployIgnorePaths.mjs). When that happens, production keeps
+// serving whatever commit was already live and will NEVER serve TARGET_SHA
+// as its own deployment — the deploy-wait step's exact-match and
+// superseding-commit checks (scripts/check-deploy-ancestry.sh) both wait for
+// a deployment that Vercel already decided not to build, and time out.
+//
+// This script recognizes that case: exits 0 (accept) when <live_sha> is an
+// ancestor of <target_sha> AND every file that changed between them is a
+// deploy-inert path per the exact same predicate Vercel's ignoreCommand
+// uses. Exits 1 (reject) otherwise, including when <live_sha> isn't known to
+// this checkout or isn't an ancestor of <target_sha>.
+//
+// Callers are responsible for fetching/deepening the checkout first so
+// <live_sha> is resolvable when it should be — this script does no network
+// I/O, which is what keeps it hermetic and fast to test.
+import { spawnSync } from 'node:child_process'
+import { isIgnoredPath } from './lib/deployIgnorePaths.mjs'
+
+const [liveSha, targetSha] = process.argv.slice(2)
+
+function reject(reason) {
+  console.log(`[deploy-noop] Rejected: ${reason}`)
+  process.exit(1)
+}
+
+if (!liveSha || !targetSha) {
+  reject('usage: check-deploy-noop.mjs <live_sha> <target_sha>')
+}
+
+const ancestry = spawnSync('git', ['merge-base', '--is-ancestor', liveSha, targetSha], {
+  stdio: 'ignore',
+})
+
+if (ancestry.status !== 0) {
+  reject(`${liveSha} is not a known ancestor of ${targetSha}`)
+}
+
+const diff = spawnSync(
+  'git',
+  ['diff', '--name-only', '--diff-filter=ACMRTUXB', liveSha, targetSha],
+  {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+)
+
+if (diff.status !== 0) {
+  reject(diff.stderr.trim() || `git diff exited with ${diff.status ?? 'unknown status'}`)
+}
+
+const changedFiles = diff.stdout
+  .split('\n')
+  .map((filePath) => filePath.trim())
+  .filter(Boolean)
+
+const deployableFiles = changedFiles.filter((filePath) => !isIgnoredPath(filePath))
+
+if (deployableFiles.length > 0) {
+  reject(`deployable change(s) since ${liveSha}: ${deployableFiles.slice(0, 10).join(', ')}`)
+}
+
+console.log(
+  `[deploy-noop] Accepted: every file changed between ${liveSha} and ${targetSha} ` +
+    `(${changedFiles.length} total) is deploy-inert -- Vercel's ignoreCommand will never ` +
+    'build this commit on its own, so the live deployment already reflects it.',
+)
+process.exit(0)

--- a/scripts/lib/deployIgnorePaths.mjs
+++ b/scripts/lib/deployIgnorePaths.mjs
@@ -1,0 +1,49 @@
+// /scripts/lib/deployIgnorePaths.mjs
+//
+// Single source of truth for "does this file's change affect the deployed
+// app?" Shared by scripts/vercel-ignore-build.mjs (Vercel's ignoreCommand,
+// which decides whether a push gets its own production deployment) and
+// scripts/check-deploy-noop.mjs (used by .github/workflows/cypress.yml's
+// "Wait for deploy to go live" step to recognize when production will never
+// serve TARGET_SHA as its own deployment because Vercel already decided, via
+// this same predicate, that TARGET_SHA's changes since the live commit are
+// deploy-inert). Keeping one predicate means those two decisions can't drift
+// apart the way they did before this module existed (see kind-robots
+// roadmap.yaml for the incident this fixed).
+
+export const ignoredPrefixes = [
+  '.github/',
+  '.migration-backups/',
+  'artifacts/',
+  'cypress/',
+  'docs/',
+  // Nightly public-content snapshot data (see fallback-snapshot.yml). It is
+  // disaster-outage fallback that gets baked into the *next* real deploy
+  // anyway, so a snapshot-only commit does not warrant its own production
+  // deployment. Trade-off: on a day with no code deploys, the baked fallback
+  // can lag by up to a day — acceptable for outage-only data.
+  'stores/fallback/',
+]
+
+export const ignoredRootFiles = new Set(['AGENTS.md', 'AI_README.md', 'CONTROL.md', 'README.md'])
+
+// Test/spec files never ship to the running app, so a commit that only touches
+// them (e.g. a "add contract test" chore) should not redeploy production.
+// Cypress specs are already covered by the cypress/ prefix above.
+export const testFileSuffixes = [
+  '.test.ts',
+  '.test.js',
+  '.test.mjs',
+  '.spec.ts',
+  '.spec.js',
+  '.spec.mjs',
+]
+
+export function isIgnoredPath(filePath) {
+  return (
+    ignoredRootFiles.has(filePath) ||
+    ignoredPrefixes.some((prefix) => filePath.startsWith(prefix)) ||
+    testFileSuffixes.some((suffix) => filePath.endsWith(suffix)) ||
+    filePath.endsWith('.bak')
+  )
+}

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,34 +1,9 @@
 // /scripts/vercel-ignore-build.mjs
 import { spawnSync } from 'node:child_process'
+import { isIgnoredPath } from './lib/deployIgnorePaths.mjs'
 
 const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA
 const currentSha = process.env.VERCEL_GIT_COMMIT_SHA
-
-const ignoredPrefixes = [
-  '.github/',
-  '.migration-backups/',
-  'artifacts/',
-  'cypress/',
-  'docs/',
-  // Nightly public-content snapshot data (see fallback-snapshot.yml). It is
-  // disaster-outage fallback that gets baked into the *next* real deploy
-  // anyway, so a snapshot-only commit does not warrant its own production
-  // deployment. Trade-off: on a day with no code deploys, the baked fallback
-  // can lag by up to a day — acceptable for outage-only data.
-  'stores/fallback/',
-]
-
-const ignoredRootFiles = new Set([
-  'AGENTS.md',
-  'AI_README.md',
-  'CONTROL.md',
-  'README.md',
-])
-
-// Test/spec files never ship to the running app, so a commit that only touches
-// them (e.g. a "add contract test" chore) should not redeploy production.
-// Cypress specs are already covered by the cypress/ prefix above.
-const testFileSuffixes = ['.test.ts', '.test.js', '.test.mjs', '.spec.ts', '.spec.js', '.spec.mjs']
 
 function continueBuild(reason) {
   console.log(`[vercel-ignore] Build required: ${reason}`)
@@ -38,15 +13,6 @@ function continueBuild(reason) {
 function ignoreBuild(reason) {
   console.log(`[vercel-ignore] Build skipped: ${reason}`)
   process.exit(0)
-}
-
-function isIgnoredPath(filePath) {
-  return (
-    ignoredRootFiles.has(filePath) ||
-    ignoredPrefixes.some((prefix) => filePath.startsWith(prefix)) ||
-    testFileSuffixes.some((suffix) => filePath.endsWith(suffix)) ||
-    filePath.endsWith('.bak')
-  )
 }
 
 if (!previousSha || !currentSha) {

--- a/utils/scripts/verifyDeployWaitNoOp.ts
+++ b/utils/scripts/verifyDeployWaitNoOp.ts
@@ -1,0 +1,122 @@
+// /utils/scripts/verifyDeployWaitNoOp.ts
+//
+// Regression test for scripts/check-deploy-noop.mjs -- the check
+// .github/workflows/cypress.yml's "Wait for deploy to go live" step uses
+// alongside scripts/check-deploy-ancestry.sh. scripts/vercel-ignore-build.mjs
+// (Vercel's ignoreCommand) skips building a production deployment when every
+// file a push changed is deploy-inert (cypress/, docs/, *.test.ts, etc — see
+// scripts/lib/deployIgnorePaths.mjs). When that happens, production keeps
+// serving the previous commit forever and the deploy-wait step's other two
+// checks (exact match, "live supersedes target") both wait for a deployment
+// Vercel already decided not to build, timing out (see kind-robots
+// roadmap.yaml for the incident this fixed -- a test-only fix PR's Cypress
+// re-run couldn't go green because production never redeployed it).
+//
+// This exercises the exact same script -- not a reimplementation -- against
+// the accept path (live precedes target, only deploy-inert files changed),
+// two reject paths (a real app file changed; live is a non-ancestor sibling
+// commit even though its diff would otherwise qualify), and the
+// unknown-commit edge case, entirely in a hermetic temp git repo with no
+// network calls.
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+const noopScript = join(repositoryRoot, 'scripts/check-deploy-noop.mjs')
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+function writeAndCommit(
+  cwd: string,
+  relativePath: string,
+  contents: string,
+  message: string,
+): string {
+  const fullPath = join(cwd, relativePath)
+  mkdirSync(dirname(fullPath), { recursive: true })
+  writeFileSync(fullPath, contents)
+  git(cwd, 'add', relativePath)
+  git(cwd, 'commit', '--quiet', '-m', message)
+  return git(cwd, 'rev-parse', 'HEAD')
+}
+
+/** Runs the shared no-op script; returns true (accept) / false (reject). */
+function checkNoOp(cwd: string, liveSha: string, targetSha: string): boolean {
+  try {
+    execFileSync('node', [noopScript, liveSha, targetSha], { cwd, stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const repo = mkdtempSync(join(tmpdir(), 'deploy-wait-noop-'))
+
+try {
+  git(repo, 'init', '--quiet', '--initial-branch=main')
+  git(repo, 'config', 'user.email', 'test@example.com')
+  git(repo, 'config', 'user.name', 'Deploy Wait No-Op Test')
+
+  const liveSha = writeAndCommit(repo, 'server/api/seed.ts', 'export const seed = true\n', 'seed commit (this is "live")')
+
+  // Accept path: every file changed since "live" is deploy-inert (a Cypress
+  // spec and a docs file), matching scripts/lib/deployIgnorePaths.mjs's
+  // predicate -- Vercel's ignoreCommand would skip this build, so the live
+  // deployment already reflects TARGET_SHA.
+  writeAndCommit(repo, 'cypress/e2e/api/example.cy.ts', 'describe("noop", () => {})\n', 'test-only change')
+  const inertTargetSha = writeAndCommit(repo, 'docs/notes.md', '# notes\n', 'docs-only change')
+  assert.equal(
+    checkNoOp(repo, liveSha, inertTargetSha),
+    true,
+    `expected TARGET_SHA ${inertTargetSha} to be ACCEPTED: every file changed since live ${liveSha} is deploy-inert`,
+  )
+
+  // Reject path: a real app file changed alongside the inert ones -- Vercel
+  // would build this commit, so it is not yet "live" until it actually is.
+  const deployableTargetSha = writeAndCommit(repo, 'server/api/foo.ts', 'export const foo = 1\n', 'real app change')
+  assert.equal(
+    checkNoOp(repo, liveSha, deployableTargetSha),
+    false,
+    `expected TARGET_SHA ${deployableTargetSha} to be REJECTED: server/api/foo.ts is a deployable change`,
+  )
+
+  // Reject path: "live" is a sibling-branch commit that never precedes
+  // target, even though every file it would diff against target is
+  // deploy-inert-shaped. Ancestry must be checked first, not inferred from
+  // the diff alone.
+  git(repo, 'checkout', '--quiet', '-b', 'sibling-branch', liveSha)
+  const siblingLiveSha = writeAndCommit(
+    repo,
+    'cypress/e2e/api/sibling.cy.ts',
+    'describe("sibling", () => {})\n',
+    'sibling commit (this is "live", not an ancestor of target)',
+  )
+  assert.equal(
+    checkNoOp(repo, siblingLiveSha, inertTargetSha),
+    false,
+    `expected TARGET_SHA ${inertTargetSha} to be REJECTED against sibling-branch commit ${siblingLiveSha} (no ancestor relationship)`,
+  )
+
+  // Unknown-commit edge case: "live" isn't a commit this checkout has ever
+  // seen. Must reject rather than throw an uncaught error.
+  const unknownSha = '0'.repeat(40)
+  assert.equal(
+    checkNoOp(repo, unknownSha, inertTargetSha),
+    false,
+    `expected an unknown live commit (${unknownSha}) to be REJECTED, not accepted or crash`,
+  )
+
+  console.log(
+    'Deploy-wait no-op check verified: accepts deploy-inert-only diffs from an ancestor ' +
+      'live commit, rejects real app changes, non-ancestor "live" commits, and unknown commits.',
+  )
+} finally {
+  rmSync(repo, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Context

kind_robots CI todo #516 (conductor). The scheduled Cypress run on main's current HEAD (`a5862945`, PR #727) timed out at "Wait for deploy to go live" after 1200s, never reaching the test suite — a different failure class from the string of test-payload bugs #719→#720→#721→#724→#727 chased in the same window.

## Root cause

`scripts/vercel-ignore-build.mjs` (Vercel's `ignoreCommand`) intentionally skips building a production deployment when every file a push changed is deploy-inert (`cypress/`, `docs/`, `*.test.ts`, etc). PR #727 only touched a Cypress spec, so Vercel correctly never deployed it — production kept serving PR #725's commit (`cea8027a`), confirmed via the Vercel API (`dpl_GazYTG5SeWb5idehwCvqseC5MJPz`, `readyState: CANCELED`, `errorLink` pointing at the ignored-build-step docs).

`.github/workflows/cypress.yml`'s wait loop only accepted an exact match or a *newer* commit that supersedes `TARGET_SHA` (`scripts/check-deploy-ancestry.sh`). It had no way to recognize "`TARGET_SHA` will never get its own deployment because Vercel already decided its changes are deploy-inert", so it waited the full timeout for a deploy that was never coming.

## Fix

- Extracted the ignored-path predicate out of `vercel-ignore-build.mjs` into `scripts/lib/deployIgnorePaths.mjs`, so it has one definition instead of a second copy that could drift from the first.
- Added `scripts/check-deploy-noop.mjs`: given `(live_sha, target_sha)`, accepts when `live_sha` is an ancestor of `target_sha` **and** every file changed between them is deploy-inert per that same predicate — i.e. Vercel's `ignoreCommand` would/did skip this exact build. Rejects on any real app-code change, a non-ancestor "live" commit, or an unknown commit.
- Wired it into `cypress.yml`'s wait loop as a third acceptance path alongside the existing exact-match and superseding-commit checks.
- Added `utils/scripts/verifyDeployWaitNoOp.ts`, a hermetic regression test matching `verifyDeployWaitAncestry.ts`'s temp-git-repo pattern (accept / reject-on-real-change / reject-on-non-ancestor / reject-on-unknown-commit), wired as `test:deploy-wait-noop` in `package.json` and a new `contract-tests.yml` step.

## How I verified

- `node --experimental-strip-types` against both `verifyDeployWaitAncestry.ts` and `verifyDeployWaitNoOp.ts`: both pass (confirms the `vercel-ignore-build.mjs` refactor didn't change its accept/reject behavior, and the new no-op check passes all 4 scenarios).
- **Replayed the actual incident**: `node scripts/check-deploy-noop.mjs cea8027a... a5862945...` (this repo's real live/target SHAs from the timed-out run) exits 0 — confirms this fix would have accepted that exact deploy as live instead of timing out.
- `node --check` on all changed/new `.mjs` files; `yaml.safe_load` on both edited workflow files; `json.load` on `package.json`.
- No `node_modules` in this sandbox, so `vue-tsc`/`eslint`/`prettier` could not be run directly; the changes are plain Node/TS with no new dependencies, and line lengths/quote style were hand-matched to the existing `verifyDeployWaitAncestry.ts` / `vercel-ignore-build.mjs` conventions.

## Stakes

reversible — CI-workflow and test-tooling only, no product code touched. Widens what the deploy-wait step *accepts* as live (strictly more permissive than today), it never narrows it, so it can't newly block a real deploy.

## Notes for reviewer

Will self-merge if this is clean and CI-relevant checks are green, per the conductor AGENTS.md CI-Janitor policy (Todos outrank roadmap tasks; this is a HIGH-priority incident-routing todo, #516).


---
_Generated by [Claude Code](https://claude.ai/code/session_012XL9bCr1EsFahAkJj9TbJk)_