### PR TITLE
Add smart model-affinity scheduling for ArtJobs

### DIFF
--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -5,10 +5,12 @@
 // network). Restricted to admin/server credentials: the relay executes other
 // users' jobs, so a plain user key must not be able to drain the queue.
 //
-// Claimable jobs, in order: PENDING by priority desc then id asc, else a
-// RUNNING job whose claim went stale (crashed relay). The claim itself is an
-// updateMany guarded on the expected status, so two relays can never win the
-// same job — the loser just retries the next candidate.
+// Smart queueing is enabled by default. Within the highest-priority tier, the
+// relay prefers a bounded lookahead job whose model-loader affinity matches the
+// last job that relay completed. The bypass cap prevents a busy model family
+// from starving older work indefinitely. Set smartQueue=false for strict FIFO.
+// The claim itself is an updateMany guarded on the expected status, so two
+// relays can never win the same job — the loser retries another candidate.
 import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
@@ -17,23 +19,24 @@ import {
   decodeArtJobPayload,
   parseArtJobPayload,
 } from '../../../utils/artJobPayload'
+import {
+  artJobQueueAffinityKey,
+  selectSmartQueueCandidate,
+} from '../../../utils/artJobQueueAffinity'
 import { recordRelayClaimAttempt } from '../../../utils/relayAgentRegistry'
 
 const STALE_CLAIM_MINUTES = 15
 const MAX_ATTEMPTS = 3
 const CLAIM_CANDIDATE_TRIES = 5
+const CLAIM_LOOKAHEAD = 50
+const SMART_QUEUE_MAX_BYPASS = 24
 
 type ClaimRequestBody = {
   agentId?: string | null
   engines?: string[] | null
-  // Capability handshake: jobs whose payload carries input images (e.g. Hair
-  // Studio kontext jobs) are only handed to agents that declare support, so
-  // a stale relay never claims-and-fails them — they wait instead.
   supportsInputImages?: boolean | null
-  // Optional relay build identifier. Not required — older relay builds that
-  // don't send it just show as "unknown" in the admin diagnostics readout
-  // (see relayAgentRegistry.ts) instead of failing the request.
   agentVersion?: string | null
+  smartQueue?: boolean | null
 }
 
 export default defineEventHandler(async (event) => {
@@ -55,17 +58,13 @@ export default defineEventHandler(async (event) => {
     const engines = (body?.engines || ['A1111', 'COMFY'])
       .map((engine) => String(engine).toUpperCase())
       .filter((engine) => engine === 'A1111' || engine === 'COMFY') as (
-      'A1111' | 'COMFY'
+      | 'A1111'
+      | 'COMFY'
     )[]
 
     const supportsInputImages = body?.supportsInputImages === true
+    const smartQueue = body?.smartQueue !== false
 
-    // Record this poll up front — before engine validation and before we know
-    // whether a job gets handed out — so a relay that's alive but never wins
-    // a candidate (wrong engines, every job skipped by the image-capability
-    // gate below) still shows up in the admin diagnostics readout instead of
-    // looking indistinguishable from a relay that's stopped polling
-    // entirely.
     recordRelayClaimAttempt({
       agentId: claimedBy,
       supportsInputImages,
@@ -80,11 +79,6 @@ export default defineEventHandler(async (event) => {
     const staleBefore = new Date(Date.now() - STALE_CLAIM_MINUTES * 60_000)
     const skippedIds: number[] = []
 
-    // Reap zombies: a RUNNING job whose claim went stale AND has already used up
-    // all its attempts is never re-offered (the candidate query requires
-    // attempts < MAX_ATTEMPTS) and never completed — it would sit RUNNING
-    // forever. Mark those FAILED so they surface in the dashboard instead of
-    // silently stalling the queue. Runs opportunistically on each claim poll.
     await prisma.artJob.updateMany({
       where: {
         status: 'RUNNING',
@@ -99,8 +93,30 @@ export default defineEventHandler(async (event) => {
       },
     })
 
+    const previousJob = smartQueue
+      ? await prisma.artJob.findFirst({
+          where: {
+            claimedBy,
+            status: 'DONE',
+            engine: { in: engines },
+          },
+          orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
+          select: {
+            engine: true,
+            payload: true,
+          },
+        })
+      : null
+
+    const preferredAffinity = previousJob
+      ? artJobQueueAffinityKey(
+          previousJob.engine,
+          parseArtJobPayload(previousJob.payload),
+        )
+      : null
+
     for (let attempt = 0; attempt < CLAIM_CANDIDATE_TRIES; attempt++) {
-      const candidate = await prisma.artJob.findFirst({
+      const candidates = await prisma.artJob.findMany({
         where: {
           engine: { in: engines },
           attempts: { lt: MAX_ATTEMPTS },
@@ -111,26 +127,49 @@ export default defineEventHandler(async (event) => {
           ],
         },
         orderBy: [{ priority: 'desc' }, { id: 'asc' }],
+        take: CLAIM_LOOKAHEAD,
       })
 
-      if (!candidate) {
+      if (!candidates.length) {
         return {
           success: true,
           message: 'No runnable jobs.',
-          data: { job: null },
+          data: {
+            job: null,
+            scheduling: {
+              mode: smartQueue ? 'SMART' : 'FIFO',
+              preferredAffinity,
+            },
+          },
           statusCode: 200,
         }
       }
 
-      const payload = parseArtJobPayload(candidate.payload)
-      const needsInputImages =
-        Array.isArray(payload.images) && payload.images.length > 0
+      const eligible = candidates
+        .map((candidate) => ({
+          ...candidate,
+          payload: parseArtJobPayload(candidate.payload),
+        }))
+        .filter((candidate) => {
+          const needsInputImages =
+            Array.isArray(candidate.payload.images) &&
+            candidate.payload.images.length > 0
+          return !needsInputImages || supportsInputImages
+        })
 
-      if (needsInputImages && !supportsInputImages) {
-        // Leave the job for an image-capable agent instead of failing it.
-        skippedIds.push(candidate.id)
+      if (!eligible.length) {
+        skippedIds.push(...candidates.map((candidate) => candidate.id))
         continue
       }
+
+      const selection = selectSmartQueueCandidate(
+        eligible,
+        smartQueue ? preferredAffinity : null,
+        smartQueue ? SMART_QUEUE_MAX_BYPASS : 0,
+      )
+      const candidate = selection.candidate
+
+      if (!candidate) continue
 
       const won = await prisma.artJob.updateMany({
         where: {
@@ -153,18 +192,36 @@ export default defineEventHandler(async (event) => {
 
         return {
           success: true,
-          message: 'Job claimed.',
-          data: { job: job ? decodeArtJobPayload(job) : null },
+          message: selection.affinityMatched
+            ? `Job claimed with model affinity (${selection.bypassedCount} older same-priority job(s) bypassed).`
+            : 'Job claimed.',
+          data: {
+            job: job ? decodeArtJobPayload(job) : null,
+            scheduling: {
+              mode: smartQueue ? 'SMART' : 'FIFO',
+              affinityMatched: selection.affinityMatched,
+              bypassedCount: selection.bypassedCount,
+              preferredAffinity: selection.preferredAffinity,
+              selectedAffinity: selection.selectedAffinity,
+            },
+          },
           statusCode: 200,
         }
       }
-      // Lost the race to another relay — try the next candidate.
+
+      skippedIds.push(candidate.id)
     }
 
     return {
       success: true,
       message: 'Queue contended; retry shortly.',
-      data: { job: null },
+      data: {
+        job: null,
+        scheduling: {
+          mode: smartQueue ? 'SMART' : 'FIFO',
+          preferredAffinity,
+        },
+      },
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/server/utils/artJobQueueAffinity.ts
+++ b/server/utils/artJobQueueAffinity.ts
@@ -1,0 +1,239 @@
+// /server/utils/artJobQueueAffinity.ts
+
+type JsonRecord = Record<string, unknown>
+
+export type ArtJobAffinityCandidate = {
+  id: number
+  engine: string
+  payload: unknown
+  priority: number
+}
+
+export type SmartQueueSelection<T extends ArtJobAffinityCandidate> = {
+  candidate: T | null
+  affinityMatched: boolean
+  bypassedCount: number
+  preferredAffinity: string | null
+  selectedAffinity: string | null
+}
+
+const MODEL_RESOURCE_KEYS = new Set([
+  'checkpoint',
+  'checkpoint_name',
+  'ckpt_name',
+  'clip_name',
+  'clip_name1',
+  'clip_name2',
+  'clip_name3',
+  'control_net_name',
+  'controlnet_name',
+  'diffusion_model',
+  'ipadapter_file',
+  'lora_name',
+  'model_name',
+  'sd_model_checkpoint',
+  'style_model_name',
+  'unet_name',
+  'upscale_model',
+  'upscale_model_name',
+  'vae_name',
+])
+
+const MODEL_LOADER_CLASS_PATTERN =
+  /(checkpoint|unet|clip|vae|lora|controlnet|ipadapter|stylemodel|upscalemodel|modelloader)/i
+
+const DYNAMIC_LOADER_INPUT_KEYS = new Set([
+  'batch_size',
+  'denoise',
+  'height',
+  'image',
+  'images',
+  'latent',
+  'negative',
+  'noise',
+  'noise_seed',
+  'positive',
+  'prompt',
+  'seed',
+  'steps',
+  'text',
+  'width',
+])
+
+function asRecord(value: unknown): JsonRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as JsonRecord
+}
+
+function stableValue(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    if (
+      value.length === 2 &&
+      (typeof value[0] === 'string' || typeof value[0] === 'number') &&
+      typeof value[1] === 'number'
+    ) {
+      return '@link'
+    }
+
+    return value.map((item) => stableValue(item))
+  }
+
+  const record = asRecord(value)
+  if (!record) return String(value)
+
+  return Object.fromEntries(
+    Object.entries(record)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, stableValue(child)]),
+  )
+}
+
+function collectNamedResources(
+  value: unknown,
+  resources: Set<string>,
+  depth = 0,
+): void {
+  if (depth > 8 || value === null || value === undefined) return
+
+  if (Array.isArray(value)) {
+    for (const child of value) collectNamedResources(child, resources, depth + 1)
+    return
+  }
+
+  const record = asRecord(value)
+  if (!record) return
+
+  for (const [key, child] of Object.entries(record)) {
+    const normalizedKey = key.toLowerCase()
+
+    if (
+      MODEL_RESOURCE_KEYS.has(normalizedKey) &&
+      (typeof child === 'string' || typeof child === 'number')
+    ) {
+      const normalizedValue = String(child).trim().toLowerCase()
+      if (normalizedValue) resources.add(`${normalizedKey}:${normalizedValue}`)
+    }
+
+    collectNamedResources(child, resources, depth + 1)
+  }
+}
+
+function collectComfyLoaderSettings(
+  payload: JsonRecord,
+  loaderSettings: Set<string>,
+): void {
+  const workflow = asRecord(payload.workflow)
+  if (!workflow) return
+
+  for (const node of Object.values(workflow)) {
+    const record = asRecord(node)
+    if (!record) continue
+
+    const classType = String(record.class_type || '').trim()
+    if (!classType || !MODEL_LOADER_CLASS_PATTERN.test(classType)) continue
+
+    const inputs = asRecord(record.inputs) ?? {}
+    const stableInputs = Object.fromEntries(
+      Object.entries(inputs)
+        .filter(([key]) => !DYNAMIC_LOADER_INPUT_KEYS.has(key.toLowerCase()))
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, value]) => [key, stableValue(value)]),
+    )
+
+    loaderSettings.add(
+      `${classType.toLowerCase()}:${JSON.stringify(stableInputs)}`,
+    )
+  }
+}
+
+export function artJobQueueAffinityKey(
+  engine: string,
+  rawPayload: unknown,
+): string {
+  const normalizedEngine = String(engine || 'UNKNOWN').toUpperCase()
+  const payload = asRecord(rawPayload) ?? {}
+  const resources = new Set<string>()
+  const loaderSettings = new Set<string>()
+
+  collectNamedResources(payload, resources)
+  if (normalizedEngine === 'COMFY') {
+    collectComfyLoaderSettings(payload, loaderSettings)
+  }
+
+  const parts = [...resources, ...loaderSettings].sort()
+  return `${normalizedEngine}|${parts.length ? parts.join('|') : 'default'}`
+}
+
+export function selectSmartQueueCandidate<T extends ArtJobAffinityCandidate>(
+  candidates: T[],
+  preferredAffinity: string | null,
+  maxBypass = 24,
+): SmartQueueSelection<T> {
+  const ordered = [...candidates].sort(
+    (left, right) => right.priority - left.priority || left.id - right.id,
+  )
+  const oldest = ordered[0] ?? null
+
+  if (!oldest) {
+    return {
+      candidate: null,
+      affinityMatched: false,
+      bypassedCount: 0,
+      preferredAffinity,
+      selectedAffinity: null,
+    }
+  }
+
+  const oldestAffinity = artJobQueueAffinityKey(oldest.engine, oldest.payload)
+  if (!preferredAffinity) {
+    return {
+      candidate: oldest,
+      affinityMatched: false,
+      bypassedCount: 0,
+      preferredAffinity: null,
+      selectedAffinity: oldestAffinity,
+    }
+  }
+
+  const highestPriority = oldest.priority
+  const samePriority = ordered.filter(
+    (candidate) => candidate.priority === highestPriority,
+  )
+  const matchIndex = samePriority.findIndex((candidate) => {
+    return (
+      artJobQueueAffinityKey(candidate.engine, candidate.payload) ===
+      preferredAffinity
+    )
+  })
+
+  if (matchIndex >= 0 && matchIndex <= Math.max(0, maxBypass)) {
+    const candidate = samePriority[matchIndex] ?? oldest
+    return {
+      candidate,
+      affinityMatched: true,
+      bypassedCount: matchIndex,
+      preferredAffinity,
+      selectedAffinity: artJobQueueAffinityKey(
+        candidate.engine,
+        candidate.payload,
+      ),
+    }
+  }
+
+  return {
+    candidate: oldest,
+    affinityMatched: oldestAffinity === preferredAffinity,
+    bypassedCount: 0,
+    preferredAffinity,
+    selectedAffinity: oldestAffinity,
+  }
+}

--- a/utils/scripts/verifyArtJobQueueAffinity.ts
+++ b/utils/scripts/verifyArtJobQueueAffinity.ts
@@ -1,0 +1,129 @@
+// /utils/scripts/verifyArtJobQueueAffinity.ts
+import assert from 'node:assert/strict'
+import {
+  artJobQueueAffinityKey,
+  selectSmartQueueCandidate,
+} from '../../server/utils/artJobQueueAffinity'
+
+function comfyPayload(checkpoint: string, seed: number, strength = 1) {
+  return {
+    workflow: {
+      '1': {
+        class_type: 'CheckpointLoaderSimple',
+        inputs: { ckpt_name: checkpoint },
+      },
+      '2': {
+        class_type: 'LoraLoader',
+        inputs: {
+          model: ['1', 0],
+          clip: ['1', 1],
+          lora_name: 'ami-style.safetensors',
+          strength_model: strength,
+          strength_clip: strength,
+        },
+      },
+      '3': {
+        class_type: 'KSampler',
+        inputs: { seed, steps: 24, model: ['2', 0] },
+      },
+    },
+  }
+}
+
+const firstAffinity = artJobQueueAffinityKey(
+  'COMFY',
+  comfyPayload('dream-a.safetensors', 100),
+)
+const sameModelNewSeed = artJobQueueAffinityKey(
+  'COMFY',
+  comfyPayload('dream-a.safetensors', 999),
+)
+const differentCheckpoint = artJobQueueAffinityKey(
+  'COMFY',
+  comfyPayload('dream-b.safetensors', 100),
+)
+const differentLoraStrength = artJobQueueAffinityKey(
+  'COMFY',
+  comfyPayload('dream-a.safetensors', 100, 0.65),
+)
+
+assert.equal(
+  firstAffinity,
+  sameModelNewSeed,
+  'seed changes must not split model affinity',
+)
+assert.notEqual(
+  firstAffinity,
+  differentCheckpoint,
+  'different checkpoints must use different affinity',
+)
+assert.notEqual(
+  firstAffinity,
+  differentLoraStrength,
+  'different loader settings must use different affinity',
+)
+
+const candidates = [
+  {
+    id: 10,
+    engine: 'COMFY',
+    payload: comfyPayload('dream-b.safetensors', 1),
+    priority: 0,
+  },
+  {
+    id: 11,
+    engine: 'COMFY',
+    payload: comfyPayload('dream-a.safetensors', 2),
+    priority: 0,
+  },
+]
+
+const affinitySelection = selectSmartQueueCandidate(
+  candidates,
+  firstAffinity,
+  24,
+)
+assert.equal(affinitySelection.candidate?.id, 11)
+assert.equal(affinitySelection.affinityMatched, true)
+assert.equal(affinitySelection.bypassedCount, 1)
+
+const prioritySelection = selectSmartQueueCandidate(
+  [
+    ...candidates,
+    {
+      id: 20,
+      engine: 'COMFY',
+      payload: comfyPayload('dream-b.safetensors', 3),
+      priority: 5,
+    },
+  ],
+  firstAffinity,
+  24,
+)
+assert.equal(
+  prioritySelection.candidate?.id,
+  20,
+  'model affinity must never jump a higher-priority job',
+)
+
+const fairnessCandidates = Array.from({ length: 27 }, (_, index) => ({
+  id: index + 1,
+  engine: 'COMFY',
+  payload: comfyPayload(
+    index === 26 ? 'dream-a.safetensors' : 'dream-b.safetensors',
+    index,
+  ),
+  priority: 0,
+}))
+const fairnessSelection = selectSmartQueueCandidate(
+  fairnessCandidates,
+  firstAffinity,
+  24,
+)
+assert.equal(
+  fairnessSelection.candidate?.id,
+  1,
+  'affinity must not bypass more than the configured fairness cap',
+)
+
+console.log('ArtJob smart queue affinity checks passed.')


### PR DESCRIPTION
## Why

The ArtJob claim endpoint currently chooses strictly by priority descending and job id ascending. That is fair, but it can alternate between incompatible Comfy checkpoints and loader configurations even when several compatible jobs are already waiting. Those switches can force unnecessary model loading/offloading work.

ComfyUI already caches compatible loader/model objects between API prompts. The queue should help it by keeping compatible work together instead of fighting that cache.

## What changed

- smart queueing is enabled by default in `POST /api/art/queue/claim`
- the relay's most recently completed job establishes its preferred model affinity
- affinity includes the engine plus checkpoint, UNet, CLIP, VAE, LoRA, ControlNet, IP-Adapter, style-model, and upscale-model loader resources/settings
- seeds, prompts, dimensions, sampling settings, images, and other per-render inputs do not split compatible batches
- selection never crosses a priority boundary
- at most 24 older same-priority jobs may be bypassed, preventing model-affinity starvation
- candidate lookahead increases from single-row probing to a bounded pool of 50
- `smartQueue: false` restores strict priority/FIFO behavior for diagnostic or specialized relays
- claim responses include scheduling diagnostics: mode, affinity match, selected affinity, and bypass count

## Expected behavior

If relay `home-comfy` last completed a job using checkpoint A with the same loader configuration, its next claim prefers another highest-priority checkpoint-A job already in the bounded lookahead. When no compatible job exists, a higher-priority job exists, or the fairness cap would be exceeded, the oldest eligible job wins.

## Validation

Added a DB-free verifier covering:

- seed changes preserve affinity
- checkpoint changes split affinity
- LoRA loader-setting changes split affinity
- affinity grouping within one priority tier
- higher priorities always win
- the bypass cap prevents starvation

The verifier passed locally through TypeScript transpilation and Node execution. Full repository TypeScript and existing contract checks are left to CI.