### PR TITLE
Squash accidental ArtJob retry duplicates

### DIFF
--- a/.github/workflows/artjob-lineage-cleanup-contract.yml
+++ b/.github/workflows/artjob-lineage-cleanup-contract.yml
@@ -1,0 +1,33 @@
+name: ArtJob Lineage Cleanup Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'prisma/migrations/20260720235000_squash_artjob_lineage_duplicates/migration.sql'
+      - 'utils/scripts/verifyArtJobLineageCleanup.ts'
+      - '.github/workflows/artjob-lineage-cleanup-contract.yml'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify lineage cleanup migration
+        run: npx tsx utils/scripts/verifyArtJobLineageCleanup.ts

--- a/prisma/migrations/20260720235000_squash_artjob_lineage_duplicates/migration.sql
+++ b/prisma/migrations/20260720235000_squash_artjob_lineage_duplicates/migration.sql
@@ -1,0 +1,63 @@
+-- Collapse the duplicate ArtJob rows created by the former bulk re-enqueue
+-- behavior. Those retries cloned FAILED jobs into fresh PENDING rows; the queue
+-- now retries the original row in place. Keep the root work item, cancel its
+-- still-pending NEW_OUTPUT descendants, and reset a failed root to PENDING.
+--
+-- This intentionally does not compare prompts or raw payload equality. Repeated
+-- prompts can be a legitimate batch. Only explicit retry lineage whose root is
+-- still unresolved is consolidated.
+
+CREATE TEMPORARY TABLE `_ArtJobLineageDuplicate` (
+  `cloneId` INTEGER NOT NULL,
+  `rootId` INTEGER NOT NULL,
+  PRIMARY KEY (`cloneId`),
+  INDEX `_ArtJobLineageDuplicate_rootId_idx` (`rootId`)
+);
+
+INSERT INTO `_ArtJobLineageDuplicate` (`cloneId`, `rootId`)
+SELECT
+  clone.`id`,
+  root.`id`
+FROM `ArtJob` AS clone
+INNER JOIN `ArtJob` AS root
+  ON root.`id` = CAST(
+    COALESCE(
+      NULLIF(JSON_UNQUOTE(JSON_EXTRACT(clone.`payload`, '$.retry.rootJobId')), ''),
+      JSON_UNQUOTE(JSON_EXTRACT(clone.`payload`, '$.retry.sourceJobId'))
+    ) AS UNSIGNED
+  )
+WHERE clone.`status` = 'PENDING'
+  AND root.`status` IN ('FAILED', 'PENDING')
+  AND clone.`id` <> root.`id`
+  AND JSON_VALID(clone.`payload`) = 1
+  AND JSON_UNQUOTE(JSON_EXTRACT(clone.`payload`, '$.retry.mode')) = 'NEW_OUTPUT';
+
+UPDATE `ArtJob` AS clone
+INNER JOIN `_ArtJobLineageDuplicate` AS duplicate
+  ON duplicate.`cloneId` = clone.`id`
+SET
+  clone.`status` = 'CANCELLED',
+  clone.`claimedAt` = NULL,
+  clone.`claimedBy` = NULL,
+  clone.`error` = CONCAT(
+    'Cancelled as duplicate retry descendant of ArtJob #',
+    duplicate.`rootId`,
+    '; the original job was retained.'
+  )
+WHERE clone.`status` = 'PENDING';
+
+UPDATE `ArtJob` AS root
+INNER JOIN (
+  SELECT DISTINCT `rootId`
+  FROM `_ArtJobLineageDuplicate`
+) AS duplicateRoot
+  ON duplicateRoot.`rootId` = root.`id`
+SET
+  root.`status` = 'PENDING',
+  root.`attempts` = 0,
+  root.`claimedAt` = NULL,
+  root.`claimedBy` = NULL,
+  root.`error` = NULL
+WHERE root.`status` = 'FAILED';
+
+DROP TEMPORARY TABLE `_ArtJobLineageDuplicate`;

--- a/utils/scripts/verifyArtJobLineageCleanup.ts
+++ b/utils/scripts/verifyArtJobLineageCleanup.ts
@@ -1,0 +1,25 @@
+// /utils/scripts/verifyArtJobLineageCleanup.ts
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const migrationPath =
+  'prisma/migrations/20260720235000_squash_artjob_lineage_duplicates/migration.sql'
+const sql = await readFile(migrationPath, 'utf8')
+
+assert.match(sql, /CREATE TEMPORARY TABLE `_ArtJobLineageDuplicate`/)
+assert.match(sql, /clone\.`status` = 'PENDING'/)
+assert.match(sql, /root\.`status` IN \('FAILED', 'PENDING'\)/)
+assert.match(
+  sql,
+  /JSON_UNQUOTE\(JSON_EXTRACT\(clone\.`payload`, '\$\.retry\.mode'\)\) = 'NEW_OUTPUT'/,
+)
+assert.match(sql, /clone\.`status` = 'CANCELLED'/)
+assert.match(sql, /root\.`status` = 'PENDING'/)
+assert.match(sql, /root\.`attempts` = 0/)
+assert.match(sql, /root\.`error` = NULL/)
+assert.match(sql, /DROP TEMPORARY TABLE `_ArtJobLineageDuplicate`/)
+assert.doesNotMatch(sql, /DELETE\s+FROM/i)
+assert.doesNotMatch(sql, /DROP\s+TABLE\s+`ArtJob`/i)
+assert.doesNotMatch(sql, /TRUNCATE/i)
+
+console.log('ArtJob lineage cleanup migration contract passed.')


### PR DESCRIPTION
## Problem

The former bulk re-enqueue behavior cloned each `FAILED` ArtJob into a fresh `PENDING` `NEW_OUTPUT` descendant. After the same-row retry fix deployed, the database could still contain both the unresolved original and one or more pending descendants. Their seeds differ, so raw payload equality is not a safe way to find them.

## Cleanup

This adds a one-time production data migration that:

- identifies only `PENDING` jobs with explicit `retry.mode = NEW_OUTPUT` lineage
- resolves the retained job through `retry.rootJobId`, falling back to `retry.sourceJobId`
- acts only when the retained root is still `FAILED` or `PENDING`
- cancels every matching pending descendant with an audit reason
- resets a retained `FAILED` root to `PENDING`, clears its claim/error, and starts a fresh attempt cycle
- leaves completed roots, unrelated pending work, and repeated prompts without retry lineage untouched

No ArtJob rows are deleted. Cancelled descendants remain available for audit while leaving the runnable queue.

## Deployment behavior

Production Vercel builds already run `prisma migrate deploy`, so merging this PR applies the cleanup once during the next production deployment.

## Validation

A dedicated contract verifies the lineage gates, cancellation/reset behavior, and absence of `DELETE`, `TRUNCATE`, or `DROP ArtJob` operations.