### PR TITLE
fix: seed Challenge Center contenders on deploy, fix red Cypress CI

### DIFF
--- a/scripts/seed_contenders.ts
+++ b/scripts/seed_contenders.ts
@@ -10,7 +10,7 @@
 import 'dotenv/config'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '../prisma/generated/prisma/client'
-import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import { createDatabaseAdapter } from '../server/utils/databaseAdapterConfig'
 
 type ContenderSeed = {
   slug: string
@@ -165,7 +165,9 @@ export function createSeedPrismaClient(): PrismaClient {
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required when running with --write')
   }
-  return new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
+  // SSL-aware adapter (see server/utils/prisma.ts) — ProxySQL enforces TLS,
+  // and a bare `new PrismaMariaDb(url)` is rejected with "SSL is required".
+  return new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
 }
 
 export async function seedContenders(

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 const binExtension = process.platform === 'win32' ? '.cmd' : ''
 const prismaBinary = path.resolve(`node_modules/.bin/prisma${binExtension}`)
+const tsxBinary = path.resolve(`node_modules/.bin/tsx${binExtension}`)
 const nuxtBinary = path.resolve('node_modules/.bin/nuxt')
 
 function run(command, args, label) {
@@ -30,6 +31,11 @@ run(prismaBinary, ['generate'], 'Generating Prisma client')
 
 if (!isVercelBuild || isProductionDeployment) {
   run(process.execPath, ['scripts/prisma-migrate-deploy.mjs'], 'Applying production migrations')
+  run(
+    tsxBinary,
+    ['scripts/seed_contenders.ts', '--write'],
+    'Seeding Challenge Center contenders',
+  )
 } else {
   console.log(`[vercel-build] Skipping migrations for Vercel ${process.env.VERCEL_ENV || 'unknown'} deployment`)
 }


### PR DESCRIPTION
## Summary
- `GET /api/contenders` was returning zero active rows in production because `scripts/seed_contenders.ts` was never run against the live database — no deploy step or workflow ever invoked it. This starves `cypress/e2e/api/challenge-submissions.cy.ts`'s `before()` hook (`expect(active, 'an active seeded Contender').to.exist`), which has kept the scheduled `main` Cypress run red (run [29787521411](https://github.com/silasfelinus/kind_robots/actions/runs/29787521411)).
- Fixed a latent bug in the seed script itself: it built its Prisma adapter with a bare `new PrismaMariaDb(url)`, which ProxySQL rejects with "SSL is required" (per `server/utils/databaseAdapterConfig.ts`'s own warning comment). Switched it to the shared `createDatabaseAdapter()` helper the running server and other maintenance scripts (e.g. `utils/scripts/backfillSlugs.ts`) already use.
- Wired the now-fixed, idempotent (upsert-based) seed into `scripts/vercel-build.mjs` right after `prisma migrate deploy`, gated on the same production-only condition, so the Challenge Center contender roster stays seeded automatically on every future production deploy instead of requiring a manual one-off run.

## Root cause
`scripts/seed_contenders.ts` (idempotent, `--write`-gated) has existed since 2026-07-13/14 but was only ever wired into a DB-free dry-run contract check in `.github/workflows/contract-tests.yml`. Nothing ever ran it with `--write` against production, so the `Contender` table stayed empty. This PR is the first automation that actually seeds it.

## Test plan
- [x] `npm run test:seed-contenders` (dry run, no DB) — passes, prints the 9-contender table
- [x] `npm run test` (vue-tsc `--noEmit`) — passes with the new import
- [x] `npx eslint scripts/seed_contenders.ts scripts/vercel-build.mjs` — clean
- [ ] Confirm `cypress/e2e/api/challenge-submissions.cy.ts` goes green on the next scheduled `main` Cypress run after this merges and a production deploy runs `vercel-build` (the seed step needs a live production `DATABASE_URL`, not available in this sandbox — will monitor the next scheduled run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UR6Fno1Enehwwim2PdUvCi)_