### PR TITLE
art-styler.vue: validate file type on browse-select, not just drag-drop

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -991,11 +991,22 @@ function isUsableKontextServer(
   return true
 }
 
+const ACCEPTED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+
+function isAcceptedImageFile(file: File): boolean {
+  return ACCEPTED_IMAGE_TYPES.has(file.type)
+}
+
 function handleFileSelect(event: Event) {
   const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
 
-  if (input.files?.[0]) {
-    processUploadedFile(input.files[0])
+  if (file) {
+    if (!isAcceptedImageFile(file)) {
+      errorMessage.value = 'Only PNG, JPEG, or WebP images are supported.'
+    } else {
+      processUploadedFile(file)
+    }
   }
 
   if (fileInput.value) {
@@ -1010,7 +1021,7 @@ function handleDrop(event: DragEvent) {
 
   if (!file) return
 
-  if (!file.type.startsWith('image/')) {
+  if (!isAcceptedImageFile(file)) {
     errorMessage.value = 'Only PNG, JPEG, or WebP images are supported.'
     return
   }


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software) — recurring lane 1 (front-end polish)

### What changed / what I produced
- `components/art/art-styler.vue`: `handleFileSelect` (the hidden `<input type="file">`'s change handler, wired to the "browse" click path) passed whatever file the OS picker returned straight to `processUploadedFile()` with zero type validation. Its sibling `handleDrop` (drag-and-drop path) already validated via `file.type.startsWith('image/')`. Extracted a shared `isAcceptedImageFile()` predicate (exact match against `image/png` / `image/jpeg` / `image/webp`, matching the component's declared support and the input's `accept` attribute) and applied it to both handlers — tightening `handleDrop`'s looser `startsWith('image/')` check in the process (it previously let GIF/SVG/BMP/TIFF through silently, contradicting the UI's "PNG · JPEG · WebP" copy).

### How I verified
- `npx eslint components/art/art-styler.vue` — clean
- `npx prettier --check components/art/art-styler.vue` — clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0

### Stakes
reversible

### Notes for reviewer
Found via an Explore-agent sweep over the Academy component surface with an explicit exclusion list of every bug class already fixed in prior `t-010` cycles (see `projects/ai-art-academy/docs/continuous-improvement-checklist.md` in the conductor repo for the full history). Most OS file dialogs let a user switch to "All Files" even when `accept` is set, and mobile/cross-app pickers may ignore it entirely — so the `accept` attribute alone was not sufficient protection on the browse path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz8gxkqMCHJYLcz1Sm2wA6)_