### PR TITLE
model-builder: stop async art-generation polls when a run is cancelled

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1424,6 +1424,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         setStatus('error', response.message || 'Failed to cancel run.')
         return
       }
+      // Stop any in-flight async art-generation polls (generateItemAssetAsync)
+      // for this run's items. pollAsyncArtJob's while loop keys off
+      // item.artJobId === jobId, so clearing it makes the loop exit at its
+      // next check instead of finishing minutes later and PATCHing/POSTing
+      // artifacts onto items that belong to a run the user just cancelled —
+      // and popping a misleading "Generated a candidate" success toast for
+      // work they said they no longer want.
+      const cancelledRun =
+        state.runs.find((entry) => entry.id === runId) ??
+        (state.run?.id === runId ? state.run : null)
+      cancelledRun?.items.forEach((item) => {
+        item.artJobId = null
+        item.queueState = null
+      })
       state.runs = state.runs.filter((entry) => entry.id !== runId)
       if (state.run?.id === runId) resetRun()
       setStatus('success', 'Run cancelled.')


### PR DESCRIPTION
### Task
conductor/model-builder-t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `cancelRun()` now clears `artJobId`/`queueState` on every item of the cancelled run before removing it from local state.
- Previously, `pollAsyncArtJob`'s while loop (`while (item.artJobId === jobId)`) had no way to learn its run had been cancelled. A job that finished rendering after the user cancelled the run would still `POST` an artifact and `PATCH` the item via `/api/model-builder/items/{id}/artifacts` / `/api/model-builder/items/{id}`, and pop a "Generated a candidate for X" success toast — for a run the user explicitly told the app they no longer wanted.
- The fix clears the item's `artJobId`, which the poll loop already checks at its next iteration (and immediately after its next `getArtJobStatus` await resolves), so it exits cleanly with no further network calls instead of writing to a dead run.

### How I verified
- `./node_modules/.bin/eslint stores/modelBuilderStore.ts` — clean except 2 pre-existing `no-empty` errors in unrelated `catch {}` blocks (confirmed pre-existing via `git stash`, same 2 errors with and without this diff).
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0, no TypeScript errors.
- Note: `./node_modules/.bin/prettier --check` currently reports drift across this file that pre-dates this change (confirmed via `git stash` — the file fails prettier's check on unmodified `main` too, likely a prettier-version mismatch in this sandbox vs. whatever last formatted it). I did not run a blanket `--write` reformat since that would balloon this diff to ~80 unrelated lines; my actual 14-line addition matches the surrounding code's existing style by hand.

### Stakes
reversible

### Flags for Reviewer
- The `prettier --check` drift on this file (pre-existing, not introduced here) may be worth a dedicated formatting-only PR at some point so future diffs on this file stay small.

### Kaizen suggestion
Add a repo-wide `prettier --check` step to CI (if not already gating) so version-mismatch drift like this is caught centrally instead of discovered ad hoc per file during unrelated polish passes.

### Notes for reviewer
Conductor roadmap task: model-builder/t-029 (recurring "Polish and upgrade Model Builder front-end surface"). Steps (1) dashboard-tab/tutorial art and (3) liveUrl backfill remain genuinely blocked (art-gen backend / admin-only action) per this task's prior cycles — not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01837uVfkUg1WPxeTxTQqF63)_