### PR TITLE
academy-remix.vue: key the style-detail panel so lesson-viewed credit fires per style

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -37,6 +37,7 @@
       <aside class="flex min-h-0 flex-col gap-3">
         <academy-style-detail
           v-if="academyStore.selectedStyle"
+          :key="academyStore.selectedStyle.slug"
           :lesson="academyStore.selectedStyle"
           :show-close="false"
           :show-remix-button="false"


### PR DESCRIPTION
## Summary

The `<academy-style-detail>` instance in Remix Studio (`components/academy/academy-remix.vue`) had no `:key`, so switching styles in the embedded `art-styler` grid patched the same component instance in place instead of remounting it. `academy-style-detail.vue` only calls `academyStore.markLessonViewed(props.lesson.slug)` inside `onMounted`, so every style opened this way after the first in a session silently never got credited as viewed — no checkmark in the Style Gallery, no `lessonsViewedCount` increment, no error, and the miss persists to `localStorage` via the store.

Same bug class PR #646 already fixed in `academy-styles-browser.vue` (which keys its own `academy-style-detail` usage by `expandedStyle.slug`), but that fix never touched `academy-remix.vue`'s independent instance. Fixed by adding the equivalent `:key="academyStore.selectedStyle.slug"`.

ai-art-academy/t-010 continuous improvement cycle (conductor), lane 1 — front-end polish.

## Test plan
- [x] `npx eslint components/academy/academy-remix.vue` — clean
- [x] `npx prettier --check components/academy/academy-remix.vue` — clean
- [x] Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SwnK1yh1BBUZttBWC8yzDm)_