### PR TITLE
Fix ghost friend requests and mutual acceptance

### DIFF
--- a/cypress/e2e/api/friend-notifications.cy.ts
+++ b/cypress/e2e/api/friend-notifications.cy.ts
@@ -1,0 +1,209 @@
+import { createLoggedInTestUser } from '../../support/api-auth'
+
+/// <reference types="cypress" />
+
+type ApiResponse<T = unknown> = {
+  success: boolean
+  message?: string
+  data?: T
+}
+
+type UserRelation = {
+  id: number
+  userId: number
+  relatedUserId: number
+  type: 'FRIEND'
+  status: 'PENDING' | 'ACCEPTED' | 'DECLINED'
+  pairId?: number | null
+}
+
+type Notification = {
+  id: number
+  userId: number
+  type: string
+  actorId?: number | null
+  entityId?: number | null
+}
+
+type NotificationInbox = {
+  items: Notification[]
+  unreadCount: number
+}
+
+type TestUser = {
+  id: number
+  token: string
+}
+
+const fallbackApiBase = 'https://kind-robots.vercel.app'
+const relationIds = new Set<number>()
+
+let apiBase = fallbackApiBase
+let requester: TestUser
+let recipient: TestUser
+
+const headersFor = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+})
+
+const requestFriend = (from: TestUser, to: TestUser) =>
+  cy
+    .request<ApiResponse<UserRelation>>({
+      method: 'POST',
+      url: `${apiBase}/api/relations`,
+      headers: headersFor(from.token),
+      body: { relatedUserId: to.id, type: 'FRIEND' },
+      failOnStatusCode: false,
+    })
+    .then((response) => {
+      expect([200, 201], JSON.stringify(response.body)).to.include(response.status)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+      expect(response.body.data, JSON.stringify(response.body)).to.exist
+      const relation = response.body.data as UserRelation
+      relationIds.add(relation.id)
+      return relation
+    })
+
+const acceptFriend = (relationId: number, token: string) =>
+  cy.request<ApiResponse<UserRelation>>({
+    method: 'PATCH',
+    url: `${apiBase}/api/relations/${relationId}`,
+    headers: headersFor(token),
+    body: { status: 'ACCEPTED' },
+    failOnStatusCode: false,
+  })
+
+const deleteRelation = (relationId: number, token: string) =>
+  cy
+    .request<ApiResponse>({
+      method: 'DELETE',
+      url: `${apiBase}/api/relations/${relationId}`,
+      headers: headersFor(token),
+      failOnStatusCode: false,
+    })
+    .then((response) => {
+      if ([200, 202, 204, 404].includes(response.status)) {
+        relationIds.delete(relationId)
+      }
+      return response
+    })
+
+const loadNotifications = (token: string) =>
+  cy
+    .request<ApiResponse<NotificationInbox>>({
+      method: 'GET',
+      url: `${apiBase}/api/notifications`,
+      headers: headersFor(token),
+      failOnStatusCode: false,
+    })
+    .then((response) => {
+      expect(response.status, JSON.stringify(response.body)).to.eq(200)
+      expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+      return response.body.data as NotificationInbox
+    })
+
+const findFriendRequest = (inbox: NotificationInbox, actorId: number) =>
+  inbox.items.find(
+    (notification) =>
+      notification.type === 'FRIEND_REQUEST' && notification.actorId === actorId,
+  )
+
+describe('Friend request notification lifecycle', () => {
+  before(() => {
+    cy.env(['API_BASE']).then((env) => {
+      apiBase = String(env.API_BASE || fallbackApiBase).replace(/\/+$/, '')
+    })
+
+    createLoggedInTestUser().then((user) => {
+      requester = user
+      return createLoggedInTestUser({ role: 'second' }).then((secondUser) => {
+        recipient = secondUser
+      })
+    })
+  })
+
+  it('links and removes the notification when a request is canceled', () => {
+    requestFriend(requester, recipient).then((relation) => {
+      expect(relation.status).to.eq('PENDING')
+
+      loadNotifications(recipient.token).then((inbox) => {
+        const notification = findFriendRequest(inbox, requester.id)
+        expect(notification, 'recipient sees friend request notification').to.exist
+        expect(notification?.entityId).to.eq(relation.id)
+      })
+
+      deleteRelation(relation.id, requester.token).then((response) => {
+        expect([200, 202, 204], JSON.stringify(response.body)).to.include(
+          response.status,
+        )
+
+        loadNotifications(recipient.token).then((inbox) => {
+          expect(
+            findFriendRequest(inbox, requester.id),
+            'canceled request notification is removed',
+          ).to.be.undefined
+        })
+      })
+    })
+  })
+
+  it('removes the request notification after explicit acceptance', () => {
+    requestFriend(requester, recipient).then((relation) => {
+      acceptFriend(relation.id, recipient.token).then((response) => {
+        expect(response.status, JSON.stringify(response.body)).to.eq(200)
+        expect(response.body.success, JSON.stringify(response.body)).to.eq(true)
+        expect(response.body.data?.status).to.eq('ACCEPTED')
+
+        loadNotifications(recipient.token).then((inbox) => {
+          expect(
+            findFriendRequest(inbox, requester.id),
+            'accepted request notification is removed',
+          ).to.be.undefined
+        })
+
+        deleteRelation(relation.id, requester.token).then((deleteResponse) => {
+          expect([200, 202, 204], JSON.stringify(deleteResponse.body)).to.include(
+            deleteResponse.status,
+          )
+        })
+      })
+    })
+  })
+
+  it('auto-accepts crossed requests and returns the caller-owned friend row', () => {
+    requestFriend(requester, recipient).then((requesterRow) => {
+      requestFriend(recipient, requester).then((recipientRow) => {
+        expect(recipientRow.status).to.eq('ACCEPTED')
+        expect(recipientRow.userId, 'response row belongs to second requester').to.eq(
+          recipient.id,
+        )
+        expect(recipientRow.relatedUserId).to.eq(requester.id)
+
+        loadNotifications(recipient.token).then((inbox) => {
+          expect(
+            findFriendRequest(inbox, requester.id),
+            'crossed request notification is removed',
+          ).to.be.undefined
+        })
+
+        deleteRelation(recipientRow.id, recipient.token).then((response) => {
+          expect([200, 202, 204], JSON.stringify(response.body)).to.include(
+            response.status,
+          )
+          relationIds.delete(requesterRow.id)
+        })
+      })
+    })
+  })
+
+  after(() => {
+    for (const relationId of relationIds) {
+      deleteRelation(relationId, requester.token).then((response) => {
+        if (response.status === 403) {
+          deleteRelation(relationId, recipient.token)
+        }
+      })
+    }
+  })
+})

--- a/server/api/notifications/index.get.ts
+++ b/server/api/notifications/index.get.ts
@@ -9,6 +9,57 @@ export default defineEventHandler(async (event) => {
   try {
     const { user } = await requireApiUser(event)
 
+    // Older notifications were not linked to their UserRelation row, so a
+    // canceled request or deleted test account could leave a convincing ghost.
+    // Reconcile request notifications against the live pending relationships
+    // whenever the notification inbox is loaded.
+    const requestNotifications = await prisma.notification.findMany({
+      where: { userId: user.id, type: 'FRIEND_REQUEST' },
+      select: { id: true, actorId: true, entityId: true },
+    })
+
+    if (requestNotifications.length > 0) {
+      const actorIds = [
+        ...new Set(
+          requestNotifications
+            .map((notification) => notification.actorId)
+            .filter((actorId): actorId is number => actorId !== null),
+        ),
+      ]
+      const pendingRequests =
+        actorIds.length > 0
+          ? await prisma.userRelation.findMany({
+              where: {
+                userId: { in: actorIds },
+                relatedUserId: user.id,
+                type: 'FRIEND',
+                status: 'PENDING',
+              },
+              select: { id: true, userId: true },
+            })
+          : []
+      const pendingByActor = new Map(
+        pendingRequests.map((request) => [request.userId, request.id]),
+      )
+      const staleIds = requestNotifications
+        .filter((notification) => {
+          if (notification.actorId === null) return true
+          const relationId = pendingByActor.get(notification.actorId)
+          if (!relationId) return true
+          return (
+            notification.entityId !== null &&
+            notification.entityId !== relationId
+          )
+        })
+        .map((notification) => notification.id)
+
+      if (staleIds.length > 0) {
+        await prisma.notification.deleteMany({
+          where: { id: { in: staleIds } },
+        })
+      }
+    }
+
     const [items, unreadCount] = await Promise.all([
       prisma.notification.findMany({
         where: { userId: user.id },

--- a/server/api/relations/[id].delete.ts
+++ b/server/api/relations/[id].delete.ts
@@ -5,6 +5,7 @@
 import prisma from '../../utils/prisma'
 import { getCurrentUserId } from '../../utils/auth'
 import { maybeRevertChildRole } from '../../utils/relations'
+import { deleteFriendRequestNotifications } from '../../utils/notify'
 
 export default defineEventHandler(async (event) => {
   const userId = await getCurrentUserId(event)
@@ -42,6 +43,19 @@ export default defineEventHandler(async (event) => {
   let childToCheck: number | null = null
   if (existing.type === 'PARENT') childToCheck = existing.relatedUserId
   else if (existing.type === 'CHILD') childToCheck = existing.userId
+
+  if (existing.type === 'FRIEND') {
+    await Promise.all([
+      deleteFriendRequestNotifications({
+        requesterId: existing.userId,
+        recipientId: existing.relatedUserId,
+      }),
+      deleteFriendRequestNotifications({
+        requesterId: existing.relatedUserId,
+        recipientId: existing.userId,
+      }),
+    ])
+  }
 
   // Remove both halves if this row is part of an accepted pair.
   if (existing.pairId) {

--- a/server/api/relations/[id].patch.ts
+++ b/server/api/relations/[id].patch.ts
@@ -53,13 +53,13 @@ export default defineEventHandler(async (event) => {
       }
     }
     const { acceptedRow, inverseRow } = await acceptPair(existing.id)
-    await deleteFriendRequestNotifications({
-      requesterId: existing.userId,
-      recipientId: existing.relatedUserId,
-      relationId: existing.id,
-    })
     // Tell the original requester their request was accepted.
     if (existing.type === 'FRIEND') {
+      await deleteFriendRequestNotifications({
+        requesterId: existing.userId,
+        recipientId: existing.relatedUserId,
+        relationId: existing.id,
+      })
       const accepter = await prisma.user.findUnique({
         where: { id: userId },
         select: { username: true },

--- a/server/api/relations/[id].patch.ts
+++ b/server/api/relations/[id].patch.ts
@@ -6,7 +6,10 @@
 import prisma from '../../utils/prisma'
 import { getCurrentUserId } from '../../utils/auth'
 import { acceptPair } from '../../utils/relations'
-import { createNotification } from '../../utils/notify'
+import {
+  createNotification,
+  deleteFriendRequestNotifications,
+} from '../../utils/notify'
 import type { RelationStatus } from '~/prisma/generated/prisma/client'
 
 export default defineEventHandler(async (event) => {
@@ -50,6 +53,11 @@ export default defineEventHandler(async (event) => {
       }
     }
     const { acceptedRow, inverseRow } = await acceptPair(existing.id)
+    await deleteFriendRequestNotifications({
+      requesterId: existing.userId,
+      recipientId: existing.relatedUserId,
+      relationId: existing.id,
+    })
     // Tell the original requester their request was accepted.
     if (existing.type === 'FRIEND') {
       const accepter = await prisma.user.findUnique({
@@ -62,6 +70,7 @@ export default defineEventHandler(async (event) => {
         title: `${accepter?.username ?? 'Someone'} accepted your friend request`,
         linkPath: '/friends',
         actorId: userId,
+        entityId: acceptedRow.id,
       })
     }
     return {

--- a/server/api/relations/index.post.ts
+++ b/server/api/relations/index.post.ts
@@ -9,7 +9,10 @@
 import prisma from '../../utils/prisma'
 import { getCurrentUserId } from '../../utils/auth'
 import { acceptPair } from '../../utils/relations'
-import { createNotification } from '../../utils/notify'
+import {
+  createNotification,
+  deleteFriendRequestNotifications,
+} from '../../utils/notify'
 import type { RelationType } from '~/prisma/generated/prisma/client'
 
 const VALID_TYPES: RelationType[] = [
@@ -102,7 +105,12 @@ export default defineEventHandler(async (event) => {
       },
     })
     if (reverse) {
-      const { acceptedRow } = await acceptPair(reverse.id)
+      const { acceptedRow, inverseRow } = await acceptPair(reverse.id)
+      await deleteFriendRequestNotifications({
+        requesterId: reverse.userId,
+        recipientId: reverse.relatedUserId,
+        relationId: reverse.id,
+      })
       // Both are now friends — tell the person who asked first.
       await createNotification({
         userId: relatedUserId,
@@ -110,12 +118,15 @@ export default defineEventHandler(async (event) => {
         title: `${me?.username ?? 'Someone'} accepted your friend request`,
         linkPath: '/friends',
         actorId: userId,
+        entityId: acceptedRow.id,
       })
       setResponseStatus(event, 200)
       return {
         success: true,
         message: 'Friend request accepted.',
-        data: acceptedRow,
+        // The caller owns the inverse row. Returning it lets the current client
+        // render the new friendship immediately, even before a full reload.
+        data: inverseRow ?? acceptedRow,
         pairCreated: true,
       }
     }
@@ -144,6 +155,7 @@ export default defineEventHandler(async (event) => {
       title: `${me?.username ?? 'Someone'} sent you a friend request`,
       linkPath: '/friends',
       actorId: userId,
+      entityId: data.id,
     })
   }
 

--- a/server/utils/notify.ts
+++ b/server/utils/notify.ts
@@ -29,3 +29,26 @@ export async function createNotification(input: {
     console.error('[notify] failed to create notification:', err)
   }
 }
+
+export async function deleteFriendRequestNotifications(input: {
+  requesterId: number
+  recipientId: number
+  relationId?: number | null
+}): Promise<void> {
+  try {
+    await prisma.notification.deleteMany({
+      where: {
+        userId: input.recipientId,
+        actorId: input.requesterId,
+        type: 'FRIEND_REQUEST',
+        ...(input.relationId
+          ? {
+              OR: [{ entityId: input.relationId }, { entityId: null }],
+            }
+          : {}),
+      },
+    })
+  } catch (err) {
+    console.error('[notify] failed to delete friend request notifications:', err)
+  }
+}

--- a/server/utils/userPurge.ts
+++ b/server/utils/userPurge.ts
@@ -22,6 +22,12 @@ export async function deleteUserWithOwnedData(
         }),
       )
       track(
+        'notifications',
+        await tx.notification.deleteMany({
+          where: { OR: [{ userId }, { actorId: userId }] },
+        }),
+      )
+      track(
         'referrals',
         await tx.referral.deleteMany({
           where: { OR: [{ referrerId: userId }, { referredId: userId }] },


### PR DESCRIPTION
## What changed

- link new friend-request notifications to their `UserRelation` row
- remove request notifications when a request is accepted, canceled, declined, or the friendship is removed
- reconcile legacy notification records against live pending relationships when the notification inbox loads
- delete notifications created by disposable users during account purge
- return the caller-owned accepted row when crossed friend requests auto-accept, so the current UI immediately shows the friendship
- add live API regression coverage for cancellation, explicit acceptance, and crossed requests

## Root cause

Friend request notifications were independent records with no relation identifier. Relationship cleanup could therefore delete the pending request while leaving a believable notification behind. Separately, crossed requests returned the row owned by the original requester; the current client stored that row locally but did not recognize it as its own accepted friendship.

## User impact

The `/friends` page and notification bell now agree. Old ghost request notifications are cleaned on inbox load, and sending a request to someone who already requested you immediately becomes a confirmed friendship.

## Validation

- added `cypress/e2e/api/friend-notifications.cy.ts`
- covers notification linkage/removal for cancel and accept
- covers crossed-request auto-accept and verifies the response row belongs to the caller
