### PR TITLE
fix: art-styler stops rendering broken images for placeholder-tagged paths

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -892,6 +892,17 @@ const galleryImages = computed<ArtImage[]>(() => {
     .slice(0, 48)
 })
 
+// ArtImage.path is not always a URL: upload flows across the app (this
+// component, image-upload.vue, art-maker.vue, add-bot/-character/-reward/
+// -scenario.vue) write bracketed metadata tags like '[UploadedImage]' into
+// it instead, since imagePath is the real path and is only populated
+// outside production (see server/utils/UploadArtImage.ts). Treating one of
+// those tags as an <img> src renders a broken-image icon even when a usable
+// thumbnailData/imageData payload is available one branch below.
+function isPlaceholderImagePath(path?: string | null): boolean {
+  return !!path && path.startsWith('[') && path.endsWith(']')
+}
+
 const sourceImageSrc = computed<string>(() => {
   if (uploadedImageData.value) return uploadedImageData.value
   if (!selectedSourceImage.value) return ''
@@ -904,7 +915,8 @@ const sourceImageSrc = computed<string>(() => {
   }
 
   // Path-first: stored path, then inline base64, then the base64 thumb cache.
-  const path = img.imagePath || img.path || ''
+  const path =
+    img.imagePath || (isPlaceholderImagePath(img.path) ? '' : img.path) || ''
   if (path) return path
 
   if (img.thumbnailData) {
@@ -928,7 +940,8 @@ const resultImageSrc = computed<string>(() => {
   }
 
   // Path-first: stored path, then inline base64.
-  const path = img.imagePath || img.path || ''
+  const path =
+    img.imagePath || (isPlaceholderImagePath(img.path) ? '' : img.path) || ''
   if (path) return path
 
   if (img.imageData) {


### PR DESCRIPTION
## Summary
- `ArtImage.path` holds a real URL only for folder-synced collections; every upload flow (`art-styler.vue` itself, `image-upload.vue`, `art-maker.vue`, and the add-bot/-character/-reward/-scenario upload targets) instead writes a bracketed metadata tag like `'[UploadedImage]'` into `path`, since `imagePath` is the real path field and is only populated outside production (`server/utils/UploadArtImage.ts`).
- `sourceImageSrc`/`resultImageSrc` in `art-styler.vue` (used by the AI Art Academy's Remix Studio) treated `img.path` as a URL fallback whenever `imagePath` was empty, so selecting an uploaded gallery image as a remix source rendered a broken-image icon in both the "Ready to style" banner and the Source/Result comparison panel — even though a usable `thumbnailData`/`imageData` payload had just been fetched and was sitting unused one branch below.
- Added a small `isPlaceholderImagePath()` guard so a bracketed tag is skipped in the path-fallback chain, letting the computed fall through to the inline base64 thumbnail/image data instead. Folder-synced images (where `path` is a genuine URL) are unaffected.

Conductor: `ai-art-academy/t-010` (recurring continuous-improvement task), lane 1 (front-end polish).

## Test plan
- [x] `npx eslint components/art/art-styler.vue` — clean
- [x] `npx prettier --check components/art/art-styler.vue` — clean (after `--write`)
- [x] `npm run test` (`vue-tsc --noEmit`) — exit 0, no errors
- [x] Traced the bug end-to-end: Prisma schema (`path` vs `imagePath` columns), `UploadArtImage.ts` (imagePath only set outside production), every `path:` write site across the app (all bracketed placeholder tags), and the `/api/art/image/[id]` read path (unconditionally selects `path`) to confirm the failure is real and reproducible, not speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BsPBJpKTH4hNpLqD9vJE3w)_