### PR TITLE
media-watchlist/t-010: Entry Detail panel + private review editor

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -1,12 +1,13 @@
 <!-- /components/watchlist/watchlist-browse.vue -->
 <!--
-  Minimal browse/filter/stats UI for the Media Watchlist personal log
-  (media-watchlist/t-009), wired to GET /api/media-entries and
+  Browse/filter/stats UI for the Media Watchlist personal log
+  (media-watchlist/t-009, t-010), wired to GET /api/media-entries and
   GET /api/media-entries/stats per conductor
   projects/media-watchlist/BROWSE-UX.md. Admin-only (this is Silas's private
   log) -- renders a locked notice for any non-admin viewer instead of erroring.
-  Detail panel, review editor, and CSV export are out of scope for this
-  minimal pass; see the roadmap kaizen note for follow-on work.
+  Selecting an entry opens watchlist-entry-detail.vue (BROWSE-UX.md §3/§5).
+  The Stats view's CSV export (§4) is a separate, smaller follow-on -- still
+  out of scope here.
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -153,30 +154,55 @@
         </div>
       </div>
 
-      <ul v-if="!errorMessage && entries.length" class="flex flex-col gap-1.5">
-        <li
-          v-for="entry in entries"
-          :key="entry.id"
-          class="flex items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-2.5"
-        >
-          <div class="flex min-w-0 items-center gap-2">
-            <Icon
-              v-if="entry.starred"
-              name="kind-icon:star"
-              class="size-3.5 shrink-0 text-warning"
-            />
-            <span class="truncate text-sm font-semibold text-base-content">{{
-              entry.title
-            }}</span>
-          </div>
-          <div
-            class="flex shrink-0 items-center gap-2 text-xs text-base-content/50"
+      <watchlist-entry-detail
+        v-if="selectedEntry"
+        :key="`detail-${selectedEntry.id}`"
+        :entry="selectedEntry"
+        @updated="handleEntryUpdated"
+      >
+        <template #close>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            @click="selectedId = null"
           >
-            <span class="badge badge-ghost badge-sm rounded-lg">{{
-              entry.mediaType
-            }}</span>
-            <span>{{ formatDate(entry) }}</span>
-          </div>
+            <Icon name="kind-icon:close" class="size-4" />
+          </button>
+        </template>
+      </watchlist-entry-detail>
+
+      <ul v-if="!errorMessage && entries.length" class="flex flex-col gap-1.5">
+        <li v-for="entry in entries" :key="entry.id">
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-2xl border bg-base-100 px-4 py-2.5 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :class="
+              selectedId === entry.id
+                ? 'border-primary'
+                : 'border-base-300 hover:border-base-content/20'
+            "
+            :aria-pressed="selectedId === entry.id"
+            @click="selectedId = selectedId === entry.id ? null : entry.id"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <Icon
+                v-if="entry.starred"
+                name="kind-icon:star"
+                class="size-3.5 shrink-0 text-warning"
+              />
+              <span class="truncate text-sm font-semibold text-base-content">{{
+                entry.title
+              }}</span>
+            </div>
+            <div
+              class="flex shrink-0 items-center gap-2 text-xs text-base-content/50"
+            >
+              <span class="badge badge-ghost badge-sm rounded-lg">{{
+                entry.mediaType
+              }}</span>
+              <span>{{ formatDate(entry) }}</span>
+            </div>
+          </button>
         </li>
       </ul>
 
@@ -199,16 +225,13 @@
 import { computed, ref, watch, onMounted } from 'vue'
 import { useUserStore } from '@/stores/userStore'
 import type { MediaType } from '~/prisma/generated/prisma/client'
+import type { MediaEntryDetail } from './watchlist-entry-detail.vue'
 
-type MediaEntrySummary = {
-  id: number
-  title: string
-  mediaType: MediaType
-  starred: boolean
-  watchedMonth: number | null
-  watchedDay: number | null
-  dateRaw: string | null
-}
+// The list/browse endpoint returns the full MediaEntry row (no `select`
+// clause), so every field the detail panel needs (review, rating, external
+// links, ...) is already present on each entry -- the detail panel reuses
+// this same type rather than requiring a second per-entry fetch.
+type MediaEntrySummary = MediaEntryDetail
 
 type MediaEntriesResponse = {
   success: boolean
@@ -255,8 +278,18 @@ const total = ref(0)
 const isLoading = ref(false)
 const errorMessage = ref('')
 const stats = ref<MediaEntryStats | null>(null)
+const selectedId = ref<number | null>(null)
 
 const canShowMore = computed(() => entries.value.length < total.value)
+const selectedEntry = computed(
+  () => entries.value.find((entry) => entry.id === selectedId.value) ?? null,
+)
+
+function handleEntryUpdated(updated: MediaEntryDetail) {
+  const index = entries.value.findIndex((entry) => entry.id === updated.id)
+  if (index !== -1)
+    entries.value[index] = { ...entries.value[index], ...updated }
+}
 
 function toggleType(type: MediaType) {
   const next = new Set(activeTypes.value)

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -1,0 +1,249 @@
+<!-- /components/watchlist/watchlist-entry-detail.vue -->
+<!--
+  Entry Detail panel for the Media Watchlist browse view (media-watchlist/t-010,
+  BROWSE-UX.md §3/§5). Renders the selected entry's header, a private markdown
+  review editor with auto-save draft + explicit Publish action, and any external
+  links. Talks to PATCH /api/media-entries/:id. Admin-gated by the parent
+  (watchlist-browse.vue) -- this component assumes it's only ever mounted for
+  an admin viewer.
+-->
+<template>
+  <section
+    class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+  >
+    <div class="flex items-start justify-between gap-3">
+      <div class="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl px-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          :disabled="isSavingStar"
+          @click="toggleStarred"
+        >
+          <Icon
+            name="kind-icon:star"
+            class="size-4"
+            :class="entry.starred ? 'text-warning' : 'text-base-content/25'"
+          />
+        </button>
+        <h2 class="truncate text-lg font-black text-base-content">
+          {{ entry.title }}
+        </h2>
+      </div>
+      <div class="flex shrink-0 items-center gap-2">
+        <span class="badge badge-ghost badge-sm rounded-lg">{{
+          entry.mediaType
+        }}</span>
+        <slot name="close" />
+      </div>
+    </div>
+
+    <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-base-content/70">
+      <div>
+        <dt class="text-xs font-semibold uppercase text-base-content/45">
+          Consumed
+        </dt>
+        <dd>{{ consumedLabel }}</dd>
+      </div>
+      <div v-if="entry.year">
+        <dt class="text-xs font-semibold uppercase text-base-content/45">
+          Year
+        </dt>
+        <dd>{{ entry.year }}</dd>
+      </div>
+    </dl>
+
+    <!-- Review editor -->
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <h3
+          class="text-xs font-black uppercase tracking-wide text-base-content/60"
+        >
+          Review
+        </h3>
+        <span
+          v-if="entry.reviewPublic"
+          class="badge badge-success badge-sm gap-1 rounded-lg"
+        >
+          <Icon name="kind-icon:check" class="size-3" />
+          Published
+        </span>
+        <span
+          v-else-if="saveState !== 'idle'"
+          class="text-xs text-base-content/45"
+        >
+          {{ saveStateLabel }}
+        </span>
+      </div>
+
+      <textarea
+        v-model="draft"
+        rows="6"
+        maxlength="4000"
+        placeholder="Private notes — markdown supported. Auto-saves as you type."
+        class="textarea textarea-bordered w-full rounded-2xl text-sm"
+        @input="scheduleAutoSave"
+      />
+
+      <div class="flex items-center justify-between">
+        <span class="text-xs text-base-content/40"
+          >{{ draft.length }} / 4000</span
+        >
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :disabled="saveState === 'saving' || draft === entry.review"
+            @click="saveDraft"
+          >
+            Save now
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :disabled="entry.reviewPublic || isPublishing || !draft.trim()"
+            @click="publish"
+          >
+            <span
+              v-if="isPublishing"
+              class="loading loading-spinner loading-xs"
+            />
+            {{ entry.reviewPublic ? 'Published' : 'Publish' }}
+          </button>
+        </div>
+      </div>
+
+      <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
+    </div>
+
+    <!-- External links -->
+    <div v-if="entry.externalUrl" class="flex flex-col gap-1">
+      <h3
+        class="text-xs font-black uppercase tracking-wide text-base-content/60"
+      >
+        External links
+      </h3>
+      <a
+        :href="entry.externalUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="link link-primary text-sm"
+      >
+        {{ entry.externalId || entry.externalUrl }}
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import type { MediaType } from '~/prisma/generated/prisma/client'
+
+export type MediaEntryDetail = {
+  id: number
+  title: string
+  mediaType: MediaType
+  starred: boolean
+  year: number | null
+  watchedMonth: number | null
+  watchedDay: number | null
+  dateRaw: string | null
+  review: string | null
+  reviewPublic: boolean
+  rating: number | null
+  externalId: string | null
+  externalUrl: string | null
+}
+
+type MediaEntryPatchResponse = {
+  success: boolean
+  data: MediaEntryDetail
+}
+
+const props = defineProps<{ entry: MediaEntryDetail }>()
+const emit = defineEmits<{ (e: 'updated', entry: MediaEntryDetail): void }>()
+
+const draft = ref(props.entry.review ?? '')
+const saveState = ref<'idle' | 'saving' | 'saved'>('idle')
+const isPublishing = ref(false)
+const isSavingStar = ref(false)
+const errorMessage = ref('')
+
+// Reset local draft state whenever a different entry is selected.
+watch(
+  () => props.entry.id,
+  () => {
+    draft.value = props.entry.review ?? ''
+    saveState.value = 'idle'
+    errorMessage.value = ''
+  },
+)
+
+const saveStateLabel = computed(() => {
+  if (saveState.value === 'saving') return 'Saving…'
+  if (saveState.value === 'saved') return 'Saved'
+  return ''
+})
+
+const consumedLabel = computed(() => {
+  if (!props.entry.watchedMonth) return 'Date unknown'
+  const month = new Date(2000, props.entry.watchedMonth - 1, 1).toLocaleString(
+    'en-US',
+    { month: 'long' },
+  )
+  return props.entry.watchedDay ? `${month} ${props.entry.watchedDay}` : month
+})
+
+let autoSaveTimer: ReturnType<typeof setTimeout> | undefined
+
+function scheduleAutoSave() {
+  clearTimeout(autoSaveTimer)
+  autoSaveTimer = setTimeout(() => {
+    void saveDraft()
+  }, 1200)
+}
+
+async function patch(
+  body: Record<string, unknown>,
+): Promise<MediaEntryDetail | null> {
+  errorMessage.value = ''
+  try {
+    const res = await $fetch<MediaEntryPatchResponse>(
+      `/api/media-entries/${props.entry.id}`,
+      { method: 'PATCH', body },
+    )
+    if (!res?.success) throw new Error('Update failed.')
+    emit('updated', res.data)
+    return res.data
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Failed to save.'
+    return null
+  }
+}
+
+async function saveDraft() {
+  if (draft.value === (props.entry.review ?? '')) return
+  saveState.value = 'saving'
+  const result = await patch({ review: draft.value })
+  saveState.value = result ? 'saved' : 'idle'
+}
+
+async function publish() {
+  if (!draft.value.trim()) return
+  isPublishing.value = true
+  // Save the latest draft text in the same request that flips the flag, so
+  // publishing never ships a stale review a debounce cycle behind.
+  await patch({ review: draft.value, publish: true })
+  isPublishing.value = false
+}
+
+async function toggleStarred() {
+  isSavingStar.value = true
+  await patch({ starred: !props.entry.starred })
+  isSavingStar.value = false
+}
+
+onBeforeUnmount(() => {
+  clearTimeout(autoSaveTimer)
+})
+</script>

--- a/server/api/media-entries/[id].patch.ts
+++ b/server/api/media-entries/[id].patch.ts
@@ -1,0 +1,106 @@
+// PATCH /api/media-entries/:id
+//
+// Write route for the Media Watchlist Entry Detail panel (media-watchlist/t-010,
+// BROWSE-UX.md §3/§5). Lets the private review editor save a draft, publish it,
+// and edit rating/starred. Admin-gated, same convention as the browse/stats
+// routes in this directory.
+//
+// Body (all optional, at least one required):
+//   review    string | null   — freeform markdown, max 4000 chars per BROWSE-UX.md §5
+//   rating    number | null   — 1-10 scale
+//   starred   boolean
+//   publish   boolean         — true sets reviewPublic = true (one-way per the
+//                                MVP rule: "Publish" only sets the flag, no UI
+//                                exposes un-publishing)
+import { defineEventHandler, readBody, getRouterParam, createError } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireAdminApiUser } from '~/server/utils/authGuard'
+
+const REVIEW_MAX_LENGTH = 4000
+
+type MediaEntryPatchBody = {
+  review?: string | null
+  rating?: number | null
+  starred?: boolean
+  publish?: boolean
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+
+    const rawId = getRouterParam(event, 'id')
+    const id = Number(rawId)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid media entry id.' })
+    }
+
+    const existing = await prisma.mediaEntry.findUnique({ where: { id } })
+    if (!existing) {
+      throw createError({ statusCode: 404, message: 'Media entry not found.' })
+    }
+
+    const body = await readBody<MediaEntryPatchBody>(event)
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'Invalid request body.' })
+    }
+
+    const data: Record<string, unknown> = {}
+
+    if ('review' in body) {
+      const review = body.review
+      if (review !== null && typeof review !== 'string') {
+        throw createError({
+          statusCode: 400,
+          message: 'review must be a string or null.',
+        })
+      }
+      if (typeof review === 'string' && review.length > REVIEW_MAX_LENGTH) {
+        throw createError({
+          statusCode: 400,
+          message: `review must be ${REVIEW_MAX_LENGTH} characters or fewer.`,
+        })
+      }
+      data.review = review === '' ? null : review
+    }
+
+    if ('rating' in body) {
+      const rating = body.rating ?? null
+      if (
+        rating !== null &&
+        (!Number.isInteger(rating) || rating < 1 || rating > 10)
+      ) {
+        throw createError({
+          statusCode: 400,
+          message: 'rating must be an integer from 1 to 10, or null.',
+        })
+      }
+      data.rating = rating
+    }
+
+    if ('starred' in body) {
+      if (typeof body.starred !== 'boolean') {
+        throw createError({
+          statusCode: 400,
+          message: 'starred must be a boolean.',
+        })
+      }
+      data.starred = body.starred
+    }
+
+    if (body.publish === true) {
+      data.reviewPublic = true
+    }
+
+    if (!Object.keys(data).length) {
+      throw createError({ statusCode: 400, message: 'No fields to update.' })
+    }
+
+    const updated = await prisma.mediaEntry.update({ where: { id }, data })
+
+    return { success: true, data: updated }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})


### PR DESCRIPTION
### Task
media-watchlist/t-010: Entry detail view + private review editor (BROWSE-UX.md sections 3/5) (kind: software)

### What changed / what I produced
- New `components/watchlist/watchlist-entry-detail.vue`: title/mediaType/year header, starred toggle, a private markdown review editor (debounced auto-save draft + explicit "Publish" button that sets `reviewPublic = true`, one-way per the MVP rule — no UI exposes un-publishing), and a read-only external-links section (only rendered when `externalUrl` is set).
- New `server/api/media-entries/[id].patch.ts`: admin-gated PATCH route accepting `review` (max 4000 chars per BROWSE-UX.md §5), `rating` (1–10 or null), `starred` (boolean), and `publish` (sets `reviewPublic: true`). Validates each field independently; 400s on bad input, 404 if the entry doesn't exist.
- `components/watchlist/watchlist-browse.vue`: list rows are now clickable buttons that open the detail panel for the selected entry; `MediaEntrySummary` now reuses the full `MediaEntryDetail` type since the existing list endpoint already returns the full row (no new fetch needed to populate the detail panel); an `updated` event from the detail panel merges the PATCH response back into local list state.
- No schema change: `review`/`reviewPublic`/`rating`/`externalId`/`externalUrl` already existed on `MediaEntry` from t-008.

### How I verified
- `npm run test` (vue-tsc --noEmit via the full Nuxt typecheck) — exit 0.
- `npx eslint` on all three changed/added files — clean.
- `npx prettier --write` on all three files, then confirmed via `git diff` that only lines I actually authored changed (no unrelated reformatting of pre-existing code, per this repo's documented prettier-scope caution).
- Live browser/DB smoke not possible in this sandbox (no reachable `DATABASE_URL`, same documented limitation as prior watchlist/model-builder/davinci cycles) — relying on CI (TypeScript, Contract verifiers, GitGuardian).

### Stakes
reversible

### Flags for Reviewer
- The Stats view's CSV export button (BROWSE-UX.md §4) is explicitly out of scope per this task's own note — left untouched.
- `rating` has a working write path now but no UI control yet (BROWSE-UX.md's Entry Detail mockup doesn't show one explicitly); left for a follow-up if Silas wants a rating widget in the detail panel.

### Kaizen suggestion
Add a seeded-admin Cypress spec for `/watchlist` (browse → open detail → edit review → publish → verify `reviewPublic` flag), since this surface still has zero automated coverage and now has its first real write path.

### Notes for reviewer
conductor task set to `status: review`; will flip to `done` after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds7Q9ZBgZC8aH2F89ciqvE)_