### PR TITLE
Fix image-upload.vue: success checkmark overlay never rendered

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -512,7 +512,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, reactive, ref, watchEffect } from 'vue'
+import {
+  computed,
+  nextTick,
+  onUnmounted,
+  reactive,
+  ref,
+  watchEffect,
+} from 'vue'
 import { storeToRefs } from 'pinia'
 import { useUploadStore } from '@/stores/uploadStore'
 import type { ConnectableModel, UploadMetadata } from '@/stores/uploadStore'
@@ -760,6 +767,16 @@ async function handleBatchUpload() {
   failedFiles.value = new Set(
     result.failed.map((r) => r.file).filter(Boolean) as File[],
   )
+
+  // Give the per-thumbnail success checkmark a frame to actually render
+  // before its item is spliced out of the queue (or the whole queue is
+  // cleared) below — both used to happen in this same synchronous tick,
+  // so `succeededFiles` was populated and then immediately made
+  // unobservable before Vue ever flushed a DOM update showing it.
+  if (succeededFiles.value.size) {
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 700))
+  }
 
   // Drop already-uploaded files from the queue so a retry click only
   // resubmits the ones that actually failed — otherwise a second click


### PR DESCRIPTION
## Summary
- Builds the front-end-polish (lane 1) pass from conductor `ai-art-academy/t-010`'s continuous improvement loop.
- `image-upload.vue`'s `handleBatchUpload()` populated `succeededFiles` purely to drive the per-thumbnail success checkmark overlay, but in every real code path the same synchronous tick immediately spliced those items out of `queuedFiles` (or cleared the whole queue on a fully-clean batch) before Vue ever flushed a DOM update showing the checkmark — the overlay markup and its backing `Set` were dead code.
- Fix: after populating `succeededFiles`, `await nextTick()` plus a short `setTimeout` (700ms) before pruning/clearing the queue, so the checkmark actually gets a frame to paint. The existing `clearQueue()`-before-message-assignment ordering (from a prior fix) is preserved unchanged.

## Test plan
- [x] `npx eslint components/art/image-upload.vue` — clean
- [x] `npx prettier --check components/art/image-upload.vue` — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — exit 0
- [ ] Live browser confirmation that the checkmark now visibly appears before removal — deferred, no reachable `DATABASE_URL` in this sandbox (same class of blocker noted on other Academy/t-010 cycles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NT4hPjc85zezajbAB9NLog


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT4hPjc85zezajbAB9NLog)_