### PR TITLE
ruler-hooked: fix 2 eslint errors on Phase 2 play-screen (conductor t-012)

### DIFF
--- a/stores/rulerHookedStore.ts
+++ b/stores/rulerHookedStore.ts
@@ -94,7 +94,7 @@ export const useRulerHookedStore = defineStore('rulerHooked', () => {
     const card = activeCard.value
     const choice = card.choices.find((c) => c.id === choiceId)
     if (!choice) return
-    let next = resolveChoice(save.value, card, choice)
+    const next = resolveChoice(save.value, card, choice)
     next.counters.cardsResolved = (next.counters.cardsResolved ?? 0) + 1
     save.value = next
     activeCard.value = null

--- a/utils/rulerHooked/applyEffects.ts
+++ b/utils/rulerHooked/applyEffects.ts
@@ -74,7 +74,7 @@ export function applyEffect(save: RunSave, effect: Effect): void {
         if (arc) arc.step = advance
       }
     }
-    if (complete) delete save.deckState.activeArcs[complete]
+    if (complete) Reflect.deleteProperty(save.deckState.activeArcs, complete)
   }
   if (effect.ending) {
     save.endingKey = effect.ending


### PR DESCRIPTION
### Task
Cross-repo: conductor **ruler-hooked/t-012** (Ruler Hooked PoC Phase 2). PR #329 landed the play-screen (Pinia store, 5 Vue components, content bundle) but the conductor roadmap task was still sitting at `status: ready`/`passes: 1` with a `retry_context` from a pre-merge Reviewer rejection (12 vue-tsc errors, 3 new to that PR). Since PR #329 merged directly on 2026-07-16, main has been carrying that code for 5 days.

### What changed / what I produced
Verified the actual current state of the merged code rather than assuming the stale rejection still applied:
- `npm run test` (vue-tsc --noEmit) is **clean** on current main (also confirmed via CI: `TypeScript Type Check` run 29821460238, conclusion `success`) — the type errors from the retry_context are gone.
- Both headless self-tests (`engine.selftest.ts`, `game.selftest.ts`) pass, proving all four DESIGN-BRIEF m2 exit criteria at the logic layer: playable fish→card→choice loop; ≥2 regions × ≥2 states recompositing on choices; the heir-elopes character arc end-to-end + warlock/druid choice; multi-slot save/load.
- `components/conductor/ruler-hooked-page.vue` wires `<RulerHookedGame />` into `ProjectFrontPage`'s `#interactive` slot — `/ruler-hooked` is genuinely playable.
- Found (via `eslint` over the ruler-hooked files, which isn't part of `npm run test`/CI but is repo convention) 2 pre-existing lint errors and fixed them:
  - `stores/rulerHookedStore.ts:97` — `let next = resolveChoice(...)` never reassigned → `const` (`prefer-const`).
  - `utils/rulerHooked/applyEffects.ts:77` — `delete save.deckState.activeArcs[complete]` → `Reflect.deleteProperty(...)` (`@typescript-eslint/no-dynamic-delete`), matching the existing convention in `stores/helpers/botHelper.ts`.

### How I verified
- `vue-tsc --noEmit -p tsconfig.json` (full project, via `npm run test`) → exit 0, both before and after the lint fix.
- `npx eslint components/ruler-hooked/ utils/rulerHooked/ stores/rulerHookedStore.ts components/conductor/ruler-hooked-page.vue` → 0 errors after the fix (2 before).
- `npx tsx utils/rulerHooked/engine.selftest.ts` and `game.selftest.ts` → ALL PASS, before and after.
- Confirmed CI's `typecheck.yml` is green on main's current tip independent of my local run.

### Stakes
reversible — 2-line lint-only diff, no behavior change (confirmed by self-tests passing identically before/after).

### Flags for Reviewer
- This PR only fixes lint; the substantive Phase 2 feature work is already merged (PR #329). The real deliverable of this cycle is the conductor-side roadmap correction (marking `ruler-hooked/t-012` done and unblocking `t-007`), tracked in conductor separately.
- No visual/browser verification was possible in this sandbox (`npm run dev` 500s — `DATABASE_URL` points at an unreachable dummy host per repo convention); relied on the headless self-tests + static analysis instead.

### Kaizen suggestion
`retry_context` on a task can go stale silently when a human merges the PR directly after a Reviewer rejection (bypassing the normal reject→retry→re-review loop) — worth a note in AGENTS.md's "Rotation collisions"/claim-flow section that a task carrying `passes > 0` should always re-verify current `main` state before assuming the rejection still holds, rather than treating `retry_context` as necessarily live.


---
_Generated by [Claude Code](https://claude.ai/code/session_018xrHu91hRv4LPkzcpxJDaB)_