### PR TITLE
appmaker/t-009: Worker external-repo support (installation tokens + scaffold PR flow)

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1088,9 +1088,19 @@ async function loadStarterEntries(): Promise<void> {
   isLoadingStarters.value = true
 
   try {
-    starterEntries.value = await $fetch<StarterEntry[]>(
+    // Plain `fetch`, not Nuxt's `$fetch`: this is a static public/ asset, not
+    // a server/api/** route, but `$fetch`'s generic overload still resolves
+    // every request against the full typed NitroFetchRequest route-key union
+    // (TypedInternalResponse/MatchedRoutes). That match gets more expensive
+    // as server/api/** grows and pushed vue-tsc over its recursion limit
+    // here (TS2589) once appmaker/t-009 added a couple more route files —
+    // this call only ever runs client-side (triggered by a sourceTab watcher
+    // on user interaction), so a relative URL resolves fine without $fetch's
+    // isomorphic base-URL handling.
+    const response = await fetch(
       '/images/academy/starters/starters.manifest.json',
     )
+    starterEntries.value = (await response.json()) as StarterEntry[]
   } catch (error) {
     console.warn('[art-styler] loadStarterEntries:', error)
   } finally {

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -296,9 +296,23 @@ function isInProgress(setSlug: string, pageId: string): boolean {
   return coloringStore.inProgressPageIds.includes(`${setSlug}/${pageId}`)
 }
 
+// Plain `fetch`, not Nuxt's `$fetch`, for these three: they're static public/
+// data files, not server/api/** routes, but $fetch's generic overload still
+// resolves every request against the full typed NitroFetchRequest route-key
+// union — expensive, and got expensive enough to push vue-tsc over its
+// recursion limit (TS2589) once appmaker/t-009 added a couple more route
+// files. All three only ever run client-side (loadSets is onMounted-only,
+// openPage is a user click), so a relative URL resolves fine.
+async function fetchStaticJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  return (await response.json()) as T
+}
+
 async function loadSetSlugs(): Promise<string[]> {
   try {
-    const index = await $fetch<{ sets: string[] }>(`${DATA_BASE}/index.json`)
+    const index = await fetchStaticJson<{ sets: string[] }>(
+      `${DATA_BASE}/index.json`,
+    )
     return Array.isArray(index?.sets) && index.sets.length
       ? index.sets
       : FALLBACK_SET_SLUGS
@@ -314,7 +328,9 @@ async function loadSets() {
     const slugs = await loadSetSlugs()
     const loaded = await Promise.all(
       slugs.map((slug) =>
-        $fetch<ColoringSetManifest>(`${DATA_BASE}/${slug}/manifest.json`),
+        fetchStaticJson<ColoringSetManifest>(
+          `${DATA_BASE}/${slug}/manifest.json`,
+        ),
       ),
     )
 
@@ -329,7 +345,7 @@ async function openPage(set: ColoringSetManifest, pageRef: ColoringSetPageRef) {
   loadError.value = ''
 
   try {
-    const definition = await $fetch<ColoringPageDefinition>(
+    const definition = await fetchStaticJson<ColoringPageDefinition>(
       `${DATA_BASE}/${set.slug}/${pageRef.file}`,
     )
 

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -5,16 +5,22 @@
       <div class="modal-box">
         <h3 class="font-bold text-lg">Select Art Server</h3>
         <p class="py-2 text-sm opacity-70">
-          No preferred art server found. Choose one to generate inspiration images:
+          No preferred art server found. Choose one to generate inspiration
+          images:
         </p>
-        <select v-model="selectedServerId" class="select select-bordered w-full mt-2">
+        <select
+          v-model="selectedServerId"
+          class="select select-bordered w-full mt-2"
+        >
           <option :value="null" disabled>-- Select a server --</option>
           <option v-for="srv in availableServers" :key="srv.id" :value="srv.id">
             {{ srv.title }}
           </option>
         </select>
         <div class="modal-action">
-          <button class="btn btn-ghost btn-sm" @click="closeModal">Cancel</button>
+          <button class="btn btn-ghost btn-sm" @click="closeModal">
+            Cancel
+          </button>
           <button
             class="btn btn-primary btn-sm"
             :disabled="!selectedServerId"
@@ -50,11 +56,14 @@
         :class="{
           'badge-warning': s.status === 'generating',
           'badge-success': s.status === 'done',
-          'badge-error':   s.status === 'failed',
-          'badge-ghost':   s.status === 'pending',
+          'badge-error': s.status === 'failed',
+          'badge-ghost': s.status === 'pending',
         }"
       >
-        <span v-if="s.status === 'generating'" class="loading loading-spinner loading-xs" />
+        <span
+          v-if="s.status === 'generating'"
+          class="loading loading-spinner loading-xs"
+        />
         {{ s.label }}
       </div>
     </div>
@@ -84,44 +93,63 @@ const statuses = ref<PromptStatus[]>([])
 
 const pathPrefix = computed(() => `public/images/artcollections/${props.slug}/`)
 
+interface PendingPromptsResponse {
+  success: boolean
+  data: Array<{
+    id: number
+    imagePath: string | null
+    artStatus: string | null
+  }>
+}
+
 async function loadPendingPrompts() {
   try {
-    const res = await $fetch<{ success: boolean; data: Array<{
-      id: number
-      imagePath: string | null
-      artStatus: string | null
-    }> }>('/api/prompts')
+    // Explicit `<PendingPromptsResponse, string>` generics: pinning R to
+    // `string` keeps $fetch's route-match typing cheap rather than letting
+    // it infer against the full NitroFetchRequest route-key union, which got
+    // expensive enough to push vue-tsc over its recursion limit (TS2589)
+    // once appmaker/t-009 added a couple more route files.
+    const res = await $fetch<PendingPromptsResponse, string>('/api/prompts')
     const all = res?.data ?? []
     pendingPrompts.value = all.filter(
-      p => p.imagePath?.startsWith(pathPrefix.value) &&
-           (!p.artStatus || p.artStatus === 'PENDING'),
+      (p) =>
+        p.imagePath?.startsWith(pathPrefix.value) &&
+        (!p.artStatus || p.artStatus === 'PENDING'),
     )
   } catch {
     pendingPrompts.value = []
   }
 }
 
+interface PreferredServerResponse {
+  success: boolean
+  data: { preferredArtServerId: number | null }
+}
+
 async function checkPreferredServer(): Promise<number | null> {
   try {
-    const res = await $fetch<{ success: boolean; data: { preferredArtServerId: number | null } }>(
-      '/api/users/me',
-    )
+    const res = await $fetch<PreferredServerResponse, string>('/api/users/me')
     return res?.data?.preferredArtServerId ?? null
   } catch {
     return null
   }
 }
 
+interface ServersResponse {
+  success: boolean
+  data: Array<{
+    id: number
+    title: string
+    serverType: string
+    isActive: boolean
+  }>
+}
+
 async function loadServers() {
   try {
-    const res = await $fetch<{ success: boolean; data: Array<{
-      id: number
-      title: string
-      serverType: string
-      isActive: boolean
-    }> }>('/api/servers')
+    const res = await $fetch<ServersResponse, string>('/api/servers')
     availableServers.value = (res?.data ?? []).filter(
-      s => s.isActive && ['A1111', 'COMFY', 'OPENAI'].includes(s.serverType),
+      (s) => s.isActive && ['A1111', 'COMFY', 'OPENAI'].includes(s.serverType),
     )
   } catch {
     availableServers.value = []
@@ -162,22 +190,24 @@ function labelFor(imagePath: string | null): string {
 async function runGeneration() {
   generating.value = true
   errorMsg.value = ''
-  statuses.value = pendingPrompts.value.map(p => ({
+  statuses.value = pendingPrompts.value.map((p) => ({
     promptId: p.id,
     label: labelFor(p.imagePath),
     status: 'pending' as const,
   }))
 
   for (const prompt of pendingPrompts.value) {
-    const entry = statuses.value.find(s => s.promptId === prompt.id)
+    const entry = statuses.value.find((s) => s.promptId === prompt.id)
     if (entry) entry.status = 'generating'
 
     try {
-      await $fetch('/api/prompts/generate', {
+      await $fetch<unknown, string>('/api/prompts/generate', {
         method: 'POST',
         body: {
           promptId: prompt.id,
-          ...(selectedServerId.value != null ? { serverId: selectedServerId.value } : {}),
+          ...(selectedServerId.value != null
+            ? { serverId: selectedServerId.value }
+            : {}),
         },
       })
       if (entry) entry.status = 'done'

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -248,11 +248,14 @@ async function loadFeed(): Promise<void> {
       ? feedPreferenceStore.enabledFeedSlugs
       : feedPreferenceStore.availableFeeds.map((feed) => feed.slug)
 
-    const res = await $fetch<{
-      success: boolean
-      message: string
-      data: AggregatedFeedResponse[] | null
-    }>('/api/newsfeed', {
+    const res = await $fetch<
+      {
+        success: boolean
+        message: string
+        data: AggregatedFeedResponse[] | null
+      },
+      string
+    >('/api/newsfeed', {
       query: slugs.length ? { feeds: slugs.join(',') } : undefined,
     })
 

--- a/components/pages/super-form.vue
+++ b/components/pages/super-form.vue
@@ -202,7 +202,7 @@ const sendBrevoEmail = async (data: FormData & { totalCost: number }) => {
   }
 
   try {
-    await $fetch('https://api.brevo.com/v3/smtp/email', {
+    await $fetch<unknown, string>('https://api.brevo.com/v3/smtp/email', {
       method: 'POST',
       headers: {
         'api-key': apiKey, // Safely pass the API key now

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -315,7 +315,7 @@ function formatDate(entry: MediaEntrySummary): string {
 
 async function loadStats(): Promise<void> {
   try {
-    const res = await $fetch<MediaEntryStatsResponse>(
+    const res = await $fetch<MediaEntryStatsResponse, string>(
       '/api/media-entries/stats',
     )
     if (res?.success) stats.value = res.data
@@ -329,18 +329,21 @@ async function loadEntries(): Promise<void> {
   errorMessage.value = ''
 
   try {
-    const res = await $fetch<MediaEntriesResponse>('/api/media-entries', {
-      query: {
-        search: search.value || undefined,
-        mediaType: activeTypes.value.size
-          ? Array.from(activeTypes.value).join(',')
-          : undefined,
-        starred: starredOnly.value ? 'true' : undefined,
-        sort: sort.value,
-        take,
-        skip: skip.value,
+    const res = await $fetch<MediaEntriesResponse, string>(
+      '/api/media-entries',
+      {
+        query: {
+          search: search.value || undefined,
+          mediaType: activeTypes.value.size
+            ? Array.from(activeTypes.value).join(',')
+            : undefined,
+          starred: starredOnly.value ? 'true' : undefined,
+          sort: sort.value,
+          take,
+          skip: skip.value,
+        },
       },
-    })
+    )
 
     if (!res?.success) {
       throw new Error('Failed to load the watchlist.')

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -248,7 +248,7 @@ async function patch(
 ): Promise<MediaEntryDetail | null> {
   errorMessage.value = ''
   try {
-    const res = await $fetch<MediaEntryPatchResponse>(
+    const res = await $fetch<MediaEntryPatchResponse, string>(
       `/api/media-entries/${props.entry.id}`,
       { method: 'PATCH', body },
     )

--- a/pages/challenges/leaderboard.vue
+++ b/pages/challenges/leaderboard.vue
@@ -296,12 +296,7 @@
 
 <script setup lang="ts">
 type ChallengeType =
-  | ''
-  | 'ART'
-  | 'TEXT'
-  | 'CHARACTER'
-  | 'SCENARIO'
-  | 'REASONING'
+  '' | 'ART' | 'TEXT' | 'CHARACTER' | 'SCENARIO' | 'REASONING'
 type Facet = 'contender' | 'kind' | 'provider' | 'model' | 'generator'
 
 type ContenderLeaderboardEntry = {
@@ -434,7 +429,7 @@ async function loadLeaderboard(): Promise<void> {
     if (typeFilter.value) query.type = typeFilter.value
     if (facetFilter.value !== 'contender') query.facet = facetFilter.value
 
-    const response = await $fetch<LeaderboardResponse>(
+    const response = await $fetch<LeaderboardResponse, string>(
       '/api/challenges/leaderboard',
       {
         query: Object.keys(query).length ? query : undefined,

--- a/server/api/appmaker/github/create-app.post.ts
+++ b/server/api/appmaker/github/create-app.post.ts
@@ -1,0 +1,209 @@
+// POST /api/appmaker/github/create-app — self-serve app creation on an
+// external repo the user already granted the GitHub App (appmaker/t-009,
+// GITHUB-APP-DESIGN.md §5b steps 1-2). Mirrors scaffold-request.post.ts's
+// monorepo flow, but writes an AppRepo (installationId set) instead of
+// scaffolding into apps/<slug>/, and files a Todo asking the Worker to
+// trigger POST /api/appmaker/github/scaffold rather than scripts/new_app.py.
+import { defineEventHandler, readBody, createError, H3Error } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { requireApiUser } from '@/server/utils/authGuard'
+import { enforceProjectCap } from '@/server/utils/projectCap'
+import { listInstallationRepositories } from '@/server/utils/appmakerGithub'
+
+const SLUG_RE = /^[a-z][a-z0-9-]{1,40}$/
+
+type CreateAppBody = {
+  installationId?: number
+  owner?: string
+  repo?: string
+  subPath?: string
+  title?: string
+  slug?: string
+  description?: string
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+}
+
+function getWorkerUserId(): number {
+  const raw = Number(process.env.BETA_ADMIN_USER_ID || 1)
+  return Number.isInteger(raw) && raw > 0 ? raw : 1
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const { user } = await requireApiUser(event)
+    const body = await readBody<CreateAppBody>(event)
+
+    const installationId = Number(body.installationId)
+    if (!Number.isInteger(installationId) || installationId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'installationId is required.',
+      })
+    }
+    const owner = body.owner?.trim()
+    const repo = body.repo?.trim()
+    if (!owner || !repo) {
+      throw createError({
+        statusCode: 400,
+        message: 'owner and repo are required.',
+      })
+    }
+    const subPath = body.subPath?.trim().replace(/^\/+|\/+$/g, '') ?? ''
+
+    const title = body.title?.trim()
+    if (!title) {
+      throw createError({ statusCode: 400, message: 'title is required.' })
+    }
+    if (title.length > 200) {
+      throw createError({
+        statusCode: 400,
+        message: 'title must be 200 characters or fewer.',
+      })
+    }
+
+    const slug = body.slug?.trim()
+      ? body.slug.trim().toLowerCase()
+      : slugify(title)
+    if (!SLUG_RE.test(slug)) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'slug must be kebab-case: start with a letter, then letters/digits/hyphens.',
+      })
+    }
+
+    const description = body.description?.trim() || null
+    if (description && description.length > 1000) {
+      throw createError({
+        statusCode: 400,
+        message: 'description must be 1000 characters or fewer.',
+      })
+    }
+
+    // The installation must belong to this user, and GitHub must currently
+    // report the repo as granted — never trust owner/repo from the client
+    // alone, or any user could point AppMaker at a repo they don't control.
+    const installation = await prisma.githubInstallation.findFirst({
+      where: { id: installationId, userId: user.id },
+    })
+    if (!installation) {
+      throw createError({
+        statusCode: 404,
+        message: 'GitHub installation not found.',
+      })
+    }
+    if (installation.suspendedAt) {
+      throw createError({
+        statusCode: 409,
+        message: 'This GitHub installation is suspended.',
+      })
+    }
+
+    const granted = await listInstallationRepositories(
+      Number(installation.installationId),
+    )
+    const isGranted = granted.some((r) => r.owner === owner && r.repo === repo)
+    if (!isGranted) {
+      throw createError({
+        statusCode: 403,
+        message: `${owner}/${repo} is not among the repos granted to this installation.`,
+      })
+    }
+
+    const [existingProject, existingDream, existingAppRepo] = await Promise.all(
+      [
+        prisma.project.findFirst({
+          where: { OR: [{ slug }, { conductorSlug: slug }] },
+          select: { id: true },
+        }),
+        prisma.dream.findUnique({ where: { slug }, select: { id: true } }),
+        prisma.appRepo.findUnique({
+          where: { slug_userId: { slug, userId: user.id } },
+          select: { id: true },
+        }),
+      ],
+    )
+
+    if (existingProject || existingDream || existingAppRepo) {
+      throw createError({
+        statusCode: 409,
+        message: `Slug '${slug}' is already taken.`,
+      })
+    }
+
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    await enforceProjectCap({ userId: user.id, userRole: user.Role, isAdmin })
+
+    const { project, appRepo, todo } = await prisma.$transaction(async (tx) => {
+      const project = await tx.project.create({
+        data: {
+          title,
+          slug,
+          conductorSlug: slug,
+          description,
+          status: 'ACTIVE',
+          priority: 'NORMAL',
+          userId: user.id,
+          isPublic: true,
+          isActive: true,
+        },
+      })
+
+      const appRepo = await tx.appRepo.create({
+        data: {
+          slug,
+          owner,
+          repo,
+          subPath,
+          installationId: installation.id,
+          userId: user.id,
+        },
+      })
+
+      // The Worker only reads its own Todo queue (same convention as
+      // scaffold-request.post.ts); the request is filed under the worker
+      // account while remaining scoped to the requester's Project/AppRepo.
+      const todo = await tx.todo.create({
+        data: {
+          title: `Scaffold external app '${slug}' via AppMaker GitHub integration`,
+          description: [
+            `AppMaker external-repo request from user ${user.id}.`,
+            `Repo: ${owner}/${repo}${subPath ? ` (subPath: ${subPath})` : ''}`,
+            `Call: POST /api/appmaker/github/scaffold with { "appRepoId": ${appRepo.id} }`,
+            `Project ${project.id} and AppRepo ${appRepo.id} already exist (slug parity) — do not create another.`,
+          ].join('\n'),
+          status: 'OPEN',
+          priority: 'NORMAL',
+          category: 'AGENT',
+          userId: getWorkerUserId(),
+          projectId: project.id,
+        },
+      })
+
+      return { project, appRepo, todo }
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      data: {
+        projectId: project.id,
+        appRepoId: appRepo.id,
+        slug,
+        todoId: todo.id,
+      },
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/appmaker/github/repos.get.ts
+++ b/server/api/appmaker/github/repos.get.ts
@@ -1,10 +1,14 @@
 // /server/api/appmaker/github/repos.get.ts
 // GITHUB-APP-DESIGN.md §5a step 4: list the current user's GitHub App
-// installations and any AppRepo mappings already created against them, so
-// the AppMaker UI can offer granted repos for app creation/graduation.
+// installations, the AppRepo mappings already created against them, and
+// (appmaker/t-009) the live set of repos GitHub says the installation was
+// actually granted — the create-app flow (5b step 1) needs to offer a repo
+// the user can pick a slug for, and AppRepo alone only reflects repos we've
+// already mapped, not what's newly available on a fresh install.
 import { defineEventHandler } from 'h3'
 import prisma from '~/server/utils/prisma'
 import { requireApiUser } from '~/server/utils/authGuard'
+import { listInstallationRepositories } from '~/server/utils/appmakerGithub'
 
 export default defineEventHandler(async (event) => {
   const { user } = await requireApiUser(event)
@@ -15,20 +19,45 @@ export default defineEventHandler(async (event) => {
     orderBy: { createdAt: 'desc' },
   })
 
-  return {
-    success: true,
-    data: installations.map((installation) => ({
-      id: installation.id,
-      accountLogin: installation.accountLogin,
-      suspended: installation.suspendedAt !== null,
-      createdAt: installation.createdAt,
-      appRepos: installation.AppRepos.map((repo) => ({
+  const data = await Promise.all(
+    installations.map(async (installation) => {
+      const appRepos = installation.AppRepos.map((repo) => ({
         id: repo.id,
         slug: repo.slug,
         owner: repo.owner,
         repo: repo.repo,
         subPath: repo.subPath,
-      })),
-    })),
-  }
+      }))
+
+      // A suspended installation's token mint would just fail on GitHub's
+      // side — skip the live lookup and return the mapped repos we already
+      // know about rather than surfacing a 502 for the whole list.
+      let availableRepos: Array<{
+        owner: string
+        repo: string
+        defaultBranch: string
+        private: boolean
+      }> = []
+      if (!installation.suspendedAt) {
+        const mappedKeys = new Set(appRepos.map((r) => `${r.owner}/${r.repo}`))
+        const granted = await listInstallationRepositories(
+          Number(installation.installationId),
+        )
+        availableRepos = granted.filter(
+          (r) => !mappedKeys.has(`${r.owner}/${r.repo}`),
+        )
+      }
+
+      return {
+        id: installation.id,
+        accountLogin: installation.accountLogin,
+        suspended: installation.suspendedAt !== null,
+        createdAt: installation.createdAt,
+        appRepos,
+        availableRepos,
+      }
+    }),
+  )
+
+  return { success: true, data }
 })

--- a/server/api/appmaker/github/scaffold.post.ts
+++ b/server/api/appmaker/github/scaffold.post.ts
@@ -1,0 +1,225 @@
+// POST /api/appmaker/github/scaffold — appmaker/t-009, GITHUB-APP-DESIGN.md
+// §5b step 3: mint an installation token, push a `worker/scaffold-<slug>`
+// branch with the app skeleton to the user's own repo, open a PR there.
+// Admin-only (the Worker authenticates with the beta-admin token per
+// AGENTS.md's KR_API_TOKEN convention, which authGuard.ts maps to
+// isAdmin: true) — this is the one path that spends a real installation
+// token, so it is never triggered directly by the app-creating user.
+import { defineEventHandler, readBody, createError, H3Error } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { pushScaffoldBranchAndOpenPr } from '@/server/utils/appmakerGithub'
+
+type ScaffoldBody = {
+  appRepoId?: number
+}
+
+function packageName(slug: string): string {
+  return slug.replace(/-/g, '_')
+}
+
+function appClassName(slug: string): string {
+  return (
+    slug
+      .split('-')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('') + 'App'
+  )
+}
+
+function withSubPath(subPath: string, relativePath: string): string {
+  return subPath ? `${subPath}/${relativePath}` : relativePath
+}
+
+// Mirrors scripts/new_app.py's Flutter skeleton, minus the conductor-only
+// projects/<slug>/roadmap.yaml + CHANGELOG.md files — those describe our own
+// agent workflow and have no meaning inside a user's external repo.
+function buildScaffoldFiles(params: {
+  slug: string
+  title: string
+  subPath: string
+}) {
+  const { slug, title, subPath } = params
+  const pkg = packageName(slug)
+  const appClass = appClassName(slug)
+
+  const pubspec = `name: ${pkg}
+description: "${title} — built with AppMaker on conductor."
+publish_to: "none"
+version: 0.1.0+1
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true
+`
+
+  const analysisOptions = `include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_single_quotes: true
+    always_declare_return_types: true
+`
+
+  const gitignore = `.dart_tool/
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+*.iml
+.idea/
+*.env
+*.keystore
+key.properties
+**/GoogleService-Info.plist
+**/google-services.json
+`
+
+  const readme = `# ${title}
+
+Scaffolded by AppMaker (kind_robots \`server/api/appmaker/github/scaffold.post.ts\`).
+
+First checkout on a dev machine:
+
+\`\`\`sh
+${subPath ? `cd ${subPath}\n` : ''}flutter create . --org org.kindrobots --project-name ${pkg} --platforms ios,android
+flutter pub get
+flutter test
+\`\`\`
+`
+
+  const mainDart = `import 'package:flutter/material.dart';
+
+void main() => runApp(const ${appClass}());
+
+class ${appClass} extends StatelessWidget {
+  const ${appClass}({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: '${title}',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF6750A4)),
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('${title}')),
+        body: const Center(child: Text('${title} — scaffolded by AppMaker')),
+      ),
+    );
+  }
+}
+`
+
+  const widgetTest = `import 'package:flutter_test/flutter_test.dart';
+import 'package:${pkg}/main.dart';
+
+void main() {
+  testWidgets('app boots', (tester) async {
+    await tester.pumpWidget(const ${appClass}());
+    expect(find.text('${title}'), findsWidgets);
+  });
+}
+`
+
+  return [
+    { path: withSubPath(subPath, 'pubspec.yaml'), content: pubspec },
+    {
+      path: withSubPath(subPath, 'analysis_options.yaml'),
+      content: analysisOptions,
+    },
+    { path: withSubPath(subPath, '.gitignore'), content: gitignore },
+    { path: withSubPath(subPath, 'README.md'), content: readme },
+    { path: withSubPath(subPath, 'lib/main.dart'), content: mainDart },
+    {
+      path: withSubPath(subPath, 'test/widget_test.dart'),
+      content: widgetTest,
+    },
+  ]
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const body = await readBody<ScaffoldBody>(event)
+
+    const appRepoId = Number(body.appRepoId)
+    if (!Number.isInteger(appRepoId) || appRepoId <= 0) {
+      throw createError({ statusCode: 400, message: 'appRepoId is required.' })
+    }
+
+    const appRepo = await prisma.appRepo.findUnique({
+      where: { id: appRepoId },
+      include: { Installation: true },
+    })
+    if (!appRepo) {
+      throw createError({ statusCode: 404, message: 'AppRepo not found.' })
+    }
+    if (!appRepo.Installation) {
+      throw createError({
+        statusCode: 409,
+        message:
+          'This AppRepo has no linked GitHub installation (monorepo apps scaffold via scripts/new_app.py, not this endpoint).',
+      })
+    }
+    if (appRepo.Installation.suspendedAt) {
+      throw createError({
+        statusCode: 409,
+        message: 'The linked GitHub installation is suspended.',
+      })
+    }
+
+    const project = await prisma.project.findFirst({
+      where: { OR: [{ slug: appRepo.slug }, { conductorSlug: appRepo.slug }] },
+      select: { title: true },
+    })
+
+    const files = buildScaffoldFiles({
+      slug: appRepo.slug,
+      title: project?.title ?? appRepo.slug,
+      subPath: appRepo.subPath,
+    })
+
+    const result = await pushScaffoldBranchAndOpenPr({
+      installationId: Number(appRepo.Installation.installationId),
+      owner: appRepo.owner,
+      repo: appRepo.repo,
+      slug: appRepo.slug,
+      files,
+      prTitle: `AppMaker: scaffold ${appRepo.slug}`,
+      prBody: [
+        `Scaffolded by AppMaker (kind_robots project ${appRepo.slug}).`,
+        '',
+        'This PR was opened by an installation-scoped GitHub App token — the',
+        'Worker role: only ever pushes `worker/*` branches and opens PRs, never',
+        'merges (GITHUB-APP-DESIGN.md §5d). A human on this repo reviews and',
+        'merges when ready.',
+      ].join('\n'),
+    })
+
+    return {
+      success: true,
+      data: {
+        appRepoId: appRepo.id,
+        branch: result.branch,
+        prUrl: result.prUrl,
+        prNumber: result.prNumber,
+      },
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/art/sd/currentModel.get.ts
+++ b/server/api/art/sd/currentModel.get.ts
@@ -134,7 +134,7 @@ export default defineEventHandler(async (event) => {
 
     const url = getA1111OptionsUrl(server)
 
-    const res = await $fetch<SDOptionsResponse>(url, {
+    const res = await $fetch<SDOptionsResponse, string>(url, {
       method: 'GET',
       headers: buildServerHeaders(server),
       timeout: 20_000,

--- a/server/api/auth/google/callback.ts
+++ b/server/api/auth/google/callback.ts
@@ -36,7 +36,7 @@ export default defineEventHandler(async (event) => {
   const redirectUri = 'https://kind-robots.vercel.app/api/auth/google/callback'
 
   try {
-    const tokenResponse = await $fetch<GoogleTokenResponse>(
+    const tokenResponse = await $fetch<GoogleTokenResponse, string>(
       'https://oauth2.googleapis.com/token',
       {
         method: 'POST',
@@ -52,7 +52,7 @@ export default defineEventHandler(async (event) => {
 
     const { access_token } = tokenResponse
 
-    const userInfo = await $fetch<GoogleUserInfoResponse>(
+    const userInfo = await $fetch<GoogleUserInfoResponse, string>(
       'https://www.googleapis.com/oauth2/v3/userinfo',
       { headers: { Authorization: `Bearer ${access_token}` } },
     )

--- a/server/utils/appmakerGithub.ts
+++ b/server/utils/appmakerGithub.ts
@@ -104,8 +104,9 @@ export interface GithubInstallationDetails {
 /**
  * Fetches installation details as the app itself (§5a step 3). Used only to
  * confirm the installation exists and to read the account it was granted on
- * — never to mint an installation access token (that's t-009's scope, when
- * AppMaker actually needs to act on a granted repo).
+ * — signed with the app JWT, not an installation token (see
+ * `mintInstallationToken` below for the latter, used when AppMaker actually
+ * needs to act on a granted repo).
  */
 export async function fetchInstallationDetails(
   installationId: number,
@@ -161,4 +162,227 @@ export function verifyWebhookSignature(
   if (a.length !== b.length) return false
 
   return crypto.timingSafeEqual(a, b)
+}
+
+// --- appmaker/t-009: installation tokens + scaffold PR flow (§5b, §5d) -----
+
+interface CachedToken {
+  token: string
+  expiresAtMs: number
+}
+
+// Per-invocation cache keyed by installation id (§3: "on serverless that
+// degrades to per-invocation minting, which is acceptable"). A module-level
+// Map still helps within one warm Lambda across requests, and the 60s safety
+// margin keeps a token from being handed out right before GitHub expires it.
+const tokenCache = new Map<number, CachedToken>()
+const TOKEN_SAFETY_MARGIN_MS = 60_000
+
+/**
+ * Mints a short-lived installation access token (§3, §6 invariant 3). NEVER
+ * return this value from an API response — it grants exactly the repos the
+ * user chose to install the app on. Callers use it same-request, server-side
+ * only, to call the GitHub REST/Git-Data API on the installation's behalf.
+ */
+async function mintInstallationToken(installationId: number): Promise<string> {
+  const cached = tokenCache.get(installationId)
+  if (cached && cached.expiresAtMs - TOKEN_SAFETY_MARGIN_MS > Date.now()) {
+    return cached.token
+  }
+
+  const appJwt = await signAppJwt()
+  const res = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: { ...GITHUB_API_HEADERS, Authorization: `Bearer ${appJwt}` },
+    },
+  )
+
+  if (!res.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GitHub installation-token mint failed (${res.status})`,
+    })
+  }
+
+  const data = (await res.json()) as { token: string; expires_at: string }
+  tokenCache.set(installationId, {
+    token: data.token,
+    expiresAtMs: new Date(data.expires_at).getTime(),
+  })
+  return data.token
+}
+
+function installationApiHeaders(token: string) {
+  return { ...GITHUB_API_HEADERS, Authorization: `token ${token}` }
+}
+
+async function githubApi(
+  path: string,
+  token: string,
+  init?: { method?: string; body?: unknown },
+): Promise<Response> {
+  return fetch(`https://api.github.com${path}`, {
+    method: init?.method ?? 'GET',
+    headers: {
+      ...installationApiHeaders(token),
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  })
+}
+
+export interface GrantedRepo {
+  owner: string
+  repo: string
+  defaultBranch: string
+  private: boolean
+}
+
+/**
+ * Lists the repos the installation was actually granted on GitHub (§5a step
+ * 4) — distinct from `AppRepo`, which is only the subset we've already
+ * mapped to a slug. Used by the create-app UI to offer repos the user can
+ * pick a slug/name for.
+ */
+export async function listInstallationRepositories(
+  installationId: number,
+): Promise<GrantedRepo[]> {
+  const token = await mintInstallationToken(installationId)
+  const res = await githubApi('/installation/repositories?per_page=100', token)
+
+  if (!res.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GitHub granted-repo list failed (${res.status})`,
+    })
+  }
+
+  const data = (await res.json()) as {
+    repositories: Array<{
+      name: string
+      owner: { login: string }
+      default_branch: string
+      private: boolean
+    }>
+  }
+
+  return data.repositories.map((repo) => ({
+    owner: repo.owner.login,
+    repo: repo.name,
+    defaultBranch: repo.default_branch,
+    private: repo.private,
+  }))
+}
+
+export interface ScaffoldFile {
+  path: string
+  content: string
+}
+
+export interface ScaffoldPrResult {
+  branch: string
+  prUrl: string
+  prNumber: number
+}
+
+/**
+ * Worker role rules (§5d) enforced here: always a `worker/*` branch, always
+ * a PR into the repo's default branch, never a merge — the installation
+ * token could technically do more, but this helper is the only path AppMaker
+ * code uses to write to an external repo, so it is the enforcement point.
+ */
+export async function pushScaffoldBranchAndOpenPr(params: {
+  installationId: number
+  owner: string
+  repo: string
+  slug: string
+  files: ScaffoldFile[]
+  prTitle: string
+  prBody: string
+}): Promise<ScaffoldPrResult> {
+  const { installationId, owner, repo, slug, files, prTitle, prBody } = params
+  const token = await mintInstallationToken(installationId)
+  const branch = `worker/scaffold-${slug}`
+
+  const repoRes = await githubApi(`/repos/${owner}/${repo}`, token)
+  if (!repoRes.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GitHub repo lookup failed (${repoRes.status})`,
+    })
+  }
+  const repoData = (await repoRes.json()) as { default_branch: string }
+  const baseBranch = repoData.default_branch
+
+  const refRes = await githubApi(
+    `/repos/${owner}/${repo}/git/ref/heads/${baseBranch}`,
+    token,
+  )
+  if (!refRes.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GitHub base-branch lookup failed (${refRes.status})`,
+    })
+  }
+  const refData = (await refRes.json()) as { object: { sha: string } }
+  const baseSha = refData.object.sha
+
+  const createRefRes = await githubApi(
+    `/repos/${owner}/${repo}/git/refs`,
+    token,
+    {
+      method: 'POST',
+      body: { ref: `refs/heads/${branch}`, sha: baseSha },
+    },
+  )
+  // 422 = ref already exists (a retry of a partially-completed scaffold) —
+  // reuse it rather than fail; any other non-2xx is a real error.
+  if (!createRefRes.ok && createRefRes.status !== 422) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GitHub branch creation failed (${createRefRes.status})`,
+    })
+  }
+
+  for (const file of files) {
+    const putRes = await githubApi(
+      `/repos/${owner}/${repo}/contents/${file.path}`,
+      token,
+      {
+        method: 'PUT',
+        body: {
+          message: `AppMaker: scaffold ${file.path}`,
+          content: Buffer.from(file.content, 'utf-8').toString('base64'),
+          branch,
+        },
+      },
+    )
+    if (!putRes.ok) {
+      throw createError({
+        statusCode: 502,
+        statusMessage: `GitHub file write failed for ${file.path} (${putRes.status})`,
+      })
+    }
+  }
+
+  const prRes = await githubApi(`/repos/${owner}/${repo}/pulls`, token, {
+    method: 'POST',
+    body: {
+      title: prTitle,
+      head: branch,
+      base: baseBranch,
+      body: prBody,
+    },
+  })
+  if (!prRes.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `GitHub PR creation failed (${prRes.status})`,
+    })
+  }
+  const prData = (await prRes.json()) as { html_url: string; number: number }
+
+  return { branch, prUrl: prData.html_url, prNumber: prData.number }
 }

--- a/stores/muralStore.ts
+++ b/stores/muralStore.ts
@@ -201,7 +201,7 @@ export async function loadMuralPageDefinition(): Promise<ColoringPageDefinition>
   if (cachedPageDefinition) return cachedPageDefinition
 
   try {
-    const page = await $fetch<ColoringPageDefinition>(MURAL_PAGE_URL)
+    const page = await $fetch<ColoringPageDefinition, string>(MURAL_PAGE_URL)
 
     if (page?.regions?.length && page.palette?.length) {
       cachedPageDefinition = {

--- a/utils/collectionCardImage.ts
+++ b/utils/collectionCardImage.ts
@@ -33,7 +33,15 @@ async function fetchFolderImages(slug: string): Promise<string[]> {
 
   let pending = folderImageCache.get(clean)
   if (!pending) {
-    pending = $fetch<FolderImagesResponse>(
+    // Explicit `<FolderImagesResponse, string>` generics, not just a type
+    // argument on the response: pinning R to `string` (rather than letting
+    // it infer from the dynamic template-literal URL and fall back to the
+    // full NitroFetchRequest route-key union) keeps `$fetch`'s route-match
+    // typing cheap. A dynamic segment there is otherwise one of the more
+    // expensive shapes for TS to resolve, and this call tipped vue-tsc's
+    // recursion limit (TS2589) once the route surface grew enough — see the
+    // similar fix on art-styler.vue's static-asset $fetch, appmaker/t-009.
+    pending = $fetch<FolderImagesResponse, string>(
       `/api/art/collection/folder/${encodeURIComponent(clean)}`,
     )
       .then((res) =>


### PR DESCRIPTION
### Task
appmaker/t-009: Worker external-repo support: installation tokens + scaffold PR flow (kind: software)

### What changed / what I produced
- `server/utils/appmakerGithub.ts`: added `mintInstallationToken` (cached, never exported/returned — GITHUB-APP-DESIGN.md §6 invariant 3), `listInstallationRepositories` (live GitHub-granted-repo list via the installation token, distinct from `AppRepo` which only reflects repos we've already mapped to a slug), and `pushScaffoldBranchAndOpenPr` (creates `worker/scaffold-<slug>`, writes files via the Contents API, opens a PR — never merges, per the Worker role in §5d).
- `server/api/appmaker/github/repos.get.ts`: each installation now also returns `availableRepos` (live granted repos not yet mapped), needed so the create-app flow can offer something to pick from on a fresh install.
- `server/api/appmaker/github/create-app.post.ts` (new): self-serve external-repo app creation (§5b steps 1-2) — verifies the installation belongs to the caller and that GitHub currently reports the repo as granted, then writes an `AppRepo` + `Project` (slug parity) and files a Worker `Todo` pointing at the scaffold endpoint.
- `server/api/appmaker/github/scaffold.post.ts` (new): admin/Worker-only (§5b step 3) — mints the token and does the actual branch/write/PR. Scaffold content mirrors `scripts/new_app.py`'s Flutter skeleton minus the conductor-only roadmap/changelog files.
- **Follow-up fix (2nd commit):** the 2 new route files above grew the typed `NitroFetchRequest` route surface just enough to push `vue-tsc` over its recursion limit (TS2589) on several *pre-existing, unrelated* `$fetch` call sites across the app. Chased and fixed all of them (12 files) by pinning `$fetch`'s `R` generic explicitly instead of letting it infer against the full route union — zero behavior change, see that commit message for the full account.

### How I verified
- `npm run test` (vue-tsc --noEmit): now clean, 0 errors (was failing at exit 2 in CI before the 2nd commit — root-caused and fixed, not just worked around for one call site).
- `eslint` + `prettier --check`: clean on all 16 changed/new files.
- `npm run test:no-prisma-json-cast`, `test:no-unquoted-reserved-word-tables`, `test:conductor-api-auth-guards(-selftest)`: all pass.

### Stakes
reversible

### Flags for Reviewer
- No live `DATABASE_URL` or `APPMAKER_GH_APP_KEY` in this sandbox, so a real install → token mint → branch/PR round-trip against GitHub is not verified end-to-end — same limitation t-008 (the prerequisite task) had. The token-mint/branch/PR calls follow standard GitHub REST API shapes.
- `scaffold.post.ts` is gated with `requireAdminApiUser`, matching how the Worker authenticates via `KR_API_TOKEN`.
- The `$fetch` typing fix touches 12 files outside the original t-009 scope, but was necessary to get this PR's own CI green rather than merge on a check that was failing because of this PR — see commit 2 for the full reasoning. It's a pre-existing repo-wide fragility (confirmed: the identical failure reproduces on `main`'s own tip once the route surface is nudged at all), not something introduced by t-009's feature code itself.

### Kaizen suggestion
`apps.get.ts` still only lists monorepo `apps/<slug>/` scaffolds — a follow-up could extend it to surface `AppRepo` external-repo state too.

### Notes for reviewer
Conductor-side: `projects/appmaker/roadmap.yaml` t-009 is at `status: review` (conductor PR #977).
