### PR TITLE
Bind ArtJobs to prompt and Comfy output provenance

### DIFF
--- a/.github/workflows/artjob-provenance-contract.yml
+++ b/.github/workflows/artjob-provenance-contract.yml
@@ -1,0 +1,41 @@
+name: ArtJob Provenance Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "server/api/art/queue/**"
+      - "server/utils/artJobProvenance.ts"
+      - "utils/scripts/verifyArtJobProvenance.ts"
+      - ".github/workflows/artjob-provenance-contract.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "server/api/art/queue/**"
+      - "server/utils/artJobProvenance.ts"
+      - "utils/scripts/verifyArtJobProvenance.ts"
+      - ".github/workflows/artjob-provenance-contract.yml"
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: "0"
+
+      - name: Verify prompt and output provenance
+        run: npx tsx utils/scripts/verifyArtJobProvenance.ts
+
+      - name: TypeScript check
+        run: npm run test

--- a/docs/operations/artjob-completion-provenance.md
+++ b/docs/operations/artjob-completion-provenance.md
@@ -2,15 +2,22 @@
 
 This contract prevents a ComfyUI image from being attached to the wrong ArtJob when the relay retries, times out, or sees multiple recent history entries.
 
+The matching relay implementation lives in the Conductor repository:
+
+- `ops/home-server/relay_agent.py`
+- `ops/home-server/relay_media_agent.py`
+- `tests/test_relay_completion_provenance.py`
+
+It is implemented in `silasfelinus/conductor#992` alongside the coloring-book semantic gate.
+
 ## Capability negotiation
 
-A relay that implements strict completion proof declares the capability when it claims work:
+The strict relay declares the capability when it claims work:
 
 ```json
 {
   "agentId": "relay:Silas-PC",
-  "agentVersion": "relay-2026.07.21",
-  "engines": ["A1111", "COMFY"],
+  "agentVersion": "conductor-relay-completion-proof-v1",
   "supportsInputImages": true,
   "supportsCompletionProof": true
 }
@@ -35,11 +42,11 @@ For a claimed COMFY ArtJob:
 
 1. Read `job.payload.promptString`, `job.payload.workflow`, and `job.payload.provenance` from the claim response.
 2. POST that exact workflow to ComfyUI `/prompt`.
-3. Capture the returned `prompt_id`. Never infer the request from queue order or “latest history.”
+3. Capture the returned `prompt_id`, or recover only the prompt accepted for the relay's unique `client_id` when the HTTP response times out.
 4. Poll only `/history/{prompt_id}` until that exact request completes or fails.
 5. Select an output tuple from that history record: `filename`, `subfolder`, and `type`.
 6. Fetch those exact bytes from `/view` using that tuple.
-7. Compute SHA-256 over the decoded image bytes.
+7. Compute SHA-256 over the decoded output bytes.
 8. Upload those same bytes through `/api/art/save-generated`, using the ArtJob's exact `promptString` for the saved metadata.
 9. Complete the ArtJob with the proof object below.
 
@@ -52,8 +59,8 @@ Do not scan global Comfy history for a recent image. Do not upload one output an
   "success": true,
   "artImageId": 12345,
   "provenance": {
-    "relayVersion": "relay-2026.07.21",
-    "relayCommit": "optional-git-sha",
+    "relayVersion": "conductor-relay-completion-proof-v1",
+    "relayCommit": "optional-deployed-git-sha",
     "promptId": "comfy-prompt-id",
     "promptHash": "job.payload.provenance.promptHash",
     "workflowHash": "job.payload.provenance.workflowHash",
@@ -88,7 +95,8 @@ with admin or server credentials. The response presents the request hashes, extr
 
 ## Rollout order
 
-1. Deploy the Kind Robots server changes while the current relay still omits `supportsCompletionProof`.
-2. Update the relay to follow this document and send the capability flag.
-3. Confirm a test job reports `completion.status = VERIFIED` and matching completion/ArtImage hashes in the diagnostic endpoint.
-4. Keep the capability enabled. Jobs claimed by that relay will then require strict proof automatically.
+1. Merge and deploy the Kind Robots server contract in `silasfelinus/kind_robots#821`.
+2. Merge `silasfelinus/conductor#992` and deploy the updated `relay_media_agent.py` service from Conductor.
+3. Optionally set `KR_RELAY_VERSION` and `KR_RELAY_COMMIT` in the relay service environment; safe defaults exist when omitted.
+4. Confirm a test job reports `completion.status = VERIFIED` and matching completion/ArtImage hashes in the diagnostic endpoint.
+5. Keep `supportsCompletionProof` enabled. Jobs claimed by that relay then require strict proof automatically.

--- a/docs/operations/artjob-completion-provenance.md
+++ b/docs/operations/artjob-completion-provenance.md
@@ -1,0 +1,94 @@
+# ArtJob completion provenance
+
+This contract prevents a ComfyUI image from being attached to the wrong ArtJob when the relay retries, times out, or sees multiple recent history entries.
+
+## Capability negotiation
+
+A relay that implements strict completion proof declares the capability when it claims work:
+
+```json
+{
+  "agentId": "relay:Silas-PC",
+  "agentVersion": "relay-2026.07.21",
+  "engines": ["A1111", "COMFY"],
+  "supportsInputImages": true,
+  "supportsCompletionProof": true
+}
+```
+
+The claim response includes:
+
+```json
+{
+  "relayContract": {
+    "supportsCompletionProof": true,
+    "completionProofRequired": true
+  }
+}
+```
+
+Older relays may omit the capability. Their jobs continue to run, but completion is recorded as `UNVERIFIED` rather than pretending provenance exists.
+
+## Required Comfy relay flow
+
+For a claimed COMFY ArtJob:
+
+1. Read `job.payload.promptString`, `job.payload.workflow`, and `job.payload.provenance` from the claim response.
+2. POST that exact workflow to ComfyUI `/prompt`.
+3. Capture the returned `prompt_id`. Never infer the request from queue order or “latest history.”
+4. Poll only `/history/{prompt_id}` until that exact request completes or fails.
+5. Select an output tuple from that history record: `filename`, `subfolder`, and `type`.
+6. Fetch those exact bytes from `/view` using that tuple.
+7. Compute SHA-256 over the decoded image bytes.
+8. Upload those same bytes through `/api/art/save-generated`, using the ArtJob's exact `promptString` for the saved metadata.
+9. Complete the ArtJob with the proof object below.
+
+Do not scan global Comfy history for a recent image. Do not upload one output and report the tuple or hash of another.
+
+## Completion request
+
+```json
+{
+  "success": true,
+  "artImageId": 12345,
+  "provenance": {
+    "relayVersion": "relay-2026.07.21",
+    "relayCommit": "optional-git-sha",
+    "promptId": "comfy-prompt-id",
+    "promptHash": "job.payload.provenance.promptHash",
+    "workflowHash": "job.payload.provenance.workflowHash",
+    "workflowPromptHash": "job.payload.provenance.workflowPromptHash",
+    "imageHash": "sha256-of-decoded-uploaded-bytes",
+    "output": {
+      "filename": "kindrobots_flux_dev_00001_.png",
+      "subfolder": "",
+      "type": "output"
+    }
+  }
+}
+```
+
+The completion endpoint rejects the request when:
+
+- the job is not currently `RUNNING`
+- required proof is omitted
+- any prompt or workflow hash belongs to another attempt
+- the uploaded ArtImage prompt metadata differs from the ArtJob prompt
+- the SHA-256 of the stored ArtImage bytes differs from `imageHash`
+
+## Diagnosis
+
+Use:
+
+```text
+GET /api/art/queue/{jobId}/provenance
+```
+
+with admin or server credentials. The response presents the request hashes, extracted workflow prompt text, expected model names, relay completion trace, exact output tuple, and a freshly computed hash of the linked ArtImage bytes in one place.
+
+## Rollout order
+
+1. Deploy the Kind Robots server changes while the current relay still omits `supportsCompletionProof`.
+2. Update the relay to follow this document and send the capability flag.
+3. Confirm a test job reports `completion.status = VERIFIED` and matching completion/ArtImage hashes in the diagnostic endpoint.
+4. Keep the capability enabled. Jobs claimed by that relay will then require strict proof automatically.

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -121,9 +121,6 @@ function snapshotData(image: ArtImage): Prisma.ArtImageUncheckedCreateInput {
     checkpointResourceId: image.checkpointResourceId,
     designer: image.designer,
     genres: image.genres,
-    // Revision rows are historical render snapshots, not another canonical file
-    // placement. Keep their bytes and generation metadata but avoid duplicating
-    // path claims that still belong to the stable target ArtImage.
     imagePath: null,
     heroPath: null,
     cardPath: null,
@@ -252,7 +249,7 @@ export default defineEventHandler(async (event) => {
         })
       }
 
-      completionTrace =
+      const validatedCompletionTrace: Record<string, unknown> =
         job.engine === 'COMFY'
           ? validateArtJobCompletionProof(job.payload, body.provenance)
           : {
@@ -261,7 +258,11 @@ export default defineEventHandler(async (event) => {
               verifiedAt: new Date().toISOString(),
             }
 
-      const tracedPayload = attachCompletionTrace(job.payload, completionTrace)
+      completionTrace = validatedCompletionTrace
+      const tracedPayload = attachCompletionTrace(
+        job.payload,
+        validatedCompletionTrace,
+      )
       const retry = readRetry(job.payload)
       const savePolicy = readSavePolicy(job.payload)
 
@@ -303,16 +304,15 @@ export default defineEventHandler(async (event) => {
           }
 
           assertUploadedPrompt(job.payload, staged)
-          assertArtImageMatchesCompletion(completionTrace, staged.imageData)
+          assertArtImageMatchesCompletion(
+            validatedCompletionTrace,
+            staged.imageData,
+          )
 
           const archived = await tx.artImage.create({
             data: snapshotData(target),
           })
 
-          // ArtJobs are historical render records. Move every prior job that
-          // referenced the canonical id onto the archived snapshot before the
-          // canonical row is replaced, keeping trainer feedback tied to its
-          // original pixels.
           await tx.artJob.updateMany({
             where: {
               artImageId: targetArtImageId,
@@ -359,7 +359,10 @@ export default defineEventHandler(async (event) => {
         }
 
         assertUploadedPrompt(job.payload, uploaded)
-        assertArtImageMatchesCompletion(completionTrace, uploaded.imageData)
+        assertArtImageMatchesCompletion(
+          validatedCompletionTrace,
+          uploaded.imageData,
+        )
 
         updated = await prisma.artJob.update({
           where: { id },

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -20,6 +20,7 @@ import {
   type ArtJobPayloadRecord,
 } from '../../../../utils/artJobPayload'
 import {
+  assertArtImageMatchesCompletion,
   attachCompletionTrace,
   normalizeArtPrompt,
   readArtJobProvenance,
@@ -120,6 +121,9 @@ function snapshotData(image: ArtImage): Prisma.ArtImageUncheckedCreateInput {
     checkpointResourceId: image.checkpointResourceId,
     designer: image.designer,
     genres: image.genres,
+    // Revision rows are historical render snapshots, not another canonical file
+    // placement. Keep their bytes and generation metadata but avoid duplicating
+    // path claims that still belong to the stable target ArtImage.
     imagePath: null,
     heroPath: null,
     cardPath: null,
@@ -257,10 +261,7 @@ export default defineEventHandler(async (event) => {
               verifiedAt: new Date().toISOString(),
             }
 
-      const tracedPayload = attachCompletionTrace(
-        job.payload,
-        completionTrace,
-      )
+      const tracedPayload = attachCompletionTrace(job.payload, completionTrace)
       const retry = readRetry(job.payload)
       const savePolicy = readSavePolicy(job.payload)
 
@@ -302,11 +303,16 @@ export default defineEventHandler(async (event) => {
           }
 
           assertUploadedPrompt(job.payload, staged)
+          assertArtImageMatchesCompletion(completionTrace, staged.imageData)
 
           const archived = await tx.artImage.create({
             data: snapshotData(target),
           })
 
+          // ArtJobs are historical render records. Move every prior job that
+          // referenced the canonical id onto the archived snapshot before the
+          // canonical row is replaced, keeping trainer feedback tied to its
+          // original pixels.
           await tx.artJob.updateMany({
             where: {
               artImageId: targetArtImageId,
@@ -353,6 +359,7 @@ export default defineEventHandler(async (event) => {
         }
 
         assertUploadedPrompt(job.payload, uploaded)
+        assertArtImageMatchesCompletion(completionTrace, uploaded.imageData)
 
         updated = await prisma.artJob.update({
           where: { id },

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -19,6 +19,13 @@ import {
   serializeArtJobPayload,
   type ArtJobPayloadRecord,
 } from '../../../../utils/artJobPayload'
+import {
+  attachCompletionTrace,
+  normalizeArtPrompt,
+  readArtJobProvenance,
+  validateArtJobCompletionProof,
+  type ArtJobCompletionProof,
+} from '../../../../utils/artJobProvenance'
 
 const MAX_ATTEMPTS = 3
 
@@ -26,6 +33,7 @@ type CompleteRequestBody = {
   success?: boolean
   artImageId?: number | null
   error?: string | null
+  provenance?: ArtJobCompletionProof | null
 }
 
 type RetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
@@ -83,6 +91,23 @@ function readSavePolicy(payload: unknown): {
   }
 }
 
+function assertUploadedPrompt(payload: unknown, image: ArtImage): void {
+  const provenance = readArtJobProvenance(payload)
+  if (!provenance) return
+
+  const uploadedPrompt = normalizeArtPrompt(
+    image.promptString || image.artPrompt || '',
+  )
+
+  if (uploadedPrompt && uploadedPrompt !== provenance.normalizedPrompt) {
+    throw createError({
+      statusCode: 409,
+      message:
+        'Uploaded ArtImage prompt metadata does not match the ArtJob prompt. Completion rejected.',
+    })
+  }
+}
+
 function snapshotData(image: ArtImage): Prisma.ArtImageUncheckedCreateInput {
   return {
     imageData: image.imageData,
@@ -95,9 +120,6 @@ function snapshotData(image: ArtImage): Prisma.ArtImageUncheckedCreateInput {
     checkpointResourceId: image.checkpointResourceId,
     designer: image.designer,
     genres: image.genres,
-    // Revision rows are historical render snapshots, not another canonical file
-    // placement. Keep their bytes and generation metadata but avoid duplicating
-    // path claims that still belong to the stable target ArtImage.
     imagePath: null,
     heroPath: null,
     cardPath: null,
@@ -213,6 +235,7 @@ export default defineEventHandler(async (event) => {
     let updated
     let archivedArtImageId: number | null = null
     let replacedArtImageId: number | null = null
+    let completionTrace: Record<string, unknown> | null = null
 
     if (body.success) {
       const uploadedArtImageId = Number(body.artImageId)
@@ -225,6 +248,19 @@ export default defineEventHandler(async (event) => {
         })
       }
 
+      completionTrace =
+        job.engine === 'COMFY'
+          ? validateArtJobCompletionProof(job.payload, body.provenance)
+          : {
+              status: 'NOT_REQUIRED',
+              verified: true,
+              verifiedAt: new Date().toISOString(),
+            }
+
+      const tracedPayload = attachCompletionTrace(
+        job.payload,
+        completionTrace,
+      )
       const retry = readRetry(job.payload)
       const savePolicy = readSavePolicy(job.payload)
 
@@ -265,14 +301,12 @@ export default defineEventHandler(async (event) => {
             })
           }
 
+          assertUploadedPrompt(job.payload, staged)
+
           const archived = await tx.artImage.create({
             data: snapshotData(target),
           })
 
-          // ArtJobs are historical render records. Move every prior job that
-          // referenced the canonical id onto the archived snapshot before the
-          // canonical row is replaced, keeping trainer feedback tied to its
-          // original pixels.
           await tx.artJob.updateMany({
             where: {
               artImageId: targetArtImageId,
@@ -293,7 +327,7 @@ export default defineEventHandler(async (event) => {
               artImageId: targetArtImageId,
               error: null,
               payload: serializeArtJobPayload(
-                completedPayload(job.payload, archived.id),
+                completedPayload(tracedPayload, archived.id),
               ),
             },
           })
@@ -307,12 +341,26 @@ export default defineEventHandler(async (event) => {
         archivedArtImageId = result.archivedId
         replacedArtImageId = targetArtImageId
       } else {
+        const uploaded = await prisma.artImage.findUnique({
+          where: { id: uploadedArtImageId },
+        })
+
+        if (!uploaded) {
+          throw createError({
+            statusCode: 409,
+            message: `Uploaded ArtImage ${uploadedArtImageId} no longer exists.`,
+          })
+        }
+
+        assertUploadedPrompt(job.payload, uploaded)
+
         updated = await prisma.artJob.update({
           where: { id },
           data: {
             status: 'DONE',
             artImageId: uploadedArtImageId,
             error: null,
+            payload: serializeArtJobPayload(tracedPayload),
           },
         })
 
@@ -349,6 +397,7 @@ export default defineEventHandler(async (event) => {
         job: decodeArtJobPayload(updated),
         replacedArtImageId,
         archivedArtImageId,
+        completionTrace,
       },
       statusCode: 200,
     }

--- a/server/api/art/queue/[id]/provenance.get.ts
+++ b/server/api/art/queue/[id]/provenance.get.ts
@@ -1,0 +1,105 @@
+// /server/api/art/queue/[id]/provenance.get.ts
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import prisma from '../../../../utils/prisma'
+import { errorHandler } from '../../../../utils/error'
+import { requireMachineUser } from '../../../../utils/authGuard'
+import { parseArtJobPayload } from '../../../../utils/artJobPayload'
+import { readArtJobProvenance } from '../../../../utils/artJobProvenance'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to inspect ArtJob provenance.',
+      })
+    }
+
+    const id = Number(getRouterParam(event, 'id'))
+
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid job id.' })
+    }
+
+    const job = await prisma.artJob.findUnique({
+      where: { id },
+    })
+
+    if (!job) {
+      throw createError({ statusCode: 404, message: `Job ${id} not found.` })
+    }
+
+    const payload = parseArtJobPayload(job.payload)
+    const provenance = readArtJobProvenance(payload)
+    const artImage = job.artImageId
+      ? await prisma.artImage.findUnique({
+          where: { id: job.artImageId },
+          select: {
+            id: true,
+            fileName: true,
+            promptString: true,
+            artPrompt: true,
+            negativePrompt: true,
+            checkpoint: true,
+            sampler: true,
+            seed: true,
+            steps: true,
+            cfg: true,
+            designer: true,
+            serverId: true,
+            serverName: true,
+            createdAt: true,
+          },
+        })
+      : null
+
+    return {
+      success: true,
+      message: `ArtJob ${id} provenance loaded.`,
+      statusCode: 200,
+      data: {
+        job: {
+          id: job.id,
+          status: job.status,
+          engine: job.engine,
+          projectSlug: job.projectSlug,
+          attempts: job.attempts,
+          claimedBy: job.claimedBy,
+          claimedAt: job.claimedAt,
+          artImageId: job.artImageId,
+          createdAt: job.createdAt,
+          updatedAt: job.updatedAt,
+        },
+        request: {
+          promptString: payload.promptString || null,
+          workflowTextCandidates:
+            provenance?.workflowTextCandidates || [],
+          promptHash: provenance?.promptHash || null,
+          workflowHash: provenance?.workflowHash || null,
+          workflowPromptHash: provenance?.workflowPromptHash || null,
+          workflowPromptMatches: provenance?.workflowPromptMatches ?? null,
+          expectedModels: provenance?.expectedModels || [],
+          attemptFingerprint: provenance?.attemptFingerprint || null,
+          idempotencyKey: provenance?.idempotencyKey || null,
+          requireCompletionProof:
+            provenance?.requireCompletionProof === true,
+        },
+        completion: provenance?.completion || null,
+        artImage,
+      },
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to inspect ArtJob provenance.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/art/queue/[id]/provenance.get.ts
+++ b/server/api/art/queue/[id]/provenance.get.ts
@@ -4,7 +4,10 @@ import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import { parseArtJobPayload } from '../../../../utils/artJobPayload'
-import { readArtJobProvenance } from '../../../../utils/artJobProvenance'
+import {
+  hashArtImageData,
+  readArtJobProvenance,
+} from '../../../../utils/artJobProvenance'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -33,11 +36,12 @@ export default defineEventHandler(async (event) => {
 
     const payload = parseArtJobPayload(job.payload)
     const provenance = readArtJobProvenance(payload)
-    const artImage = job.artImageId
+    const rawArtImage = job.artImageId
       ? await prisma.artImage.findUnique({
           where: { id: job.artImageId },
           select: {
             id: true,
+            imageData: true,
             fileName: true,
             promptString: true,
             artPrompt: true,
@@ -53,6 +57,25 @@ export default defineEventHandler(async (event) => {
             createdAt: true,
           },
         })
+      : null
+    const artImage = rawArtImage
+      ? {
+          id: rawArtImage.id,
+          imageHash: hashArtImageData(rawArtImage.imageData),
+          fileName: rawArtImage.fileName,
+          promptString: rawArtImage.promptString,
+          artPrompt: rawArtImage.artPrompt,
+          negativePrompt: rawArtImage.negativePrompt,
+          checkpoint: rawArtImage.checkpoint,
+          sampler: rawArtImage.sampler,
+          seed: rawArtImage.seed,
+          steps: rawArtImage.steps,
+          cfg: rawArtImage.cfg,
+          designer: rawArtImage.designer,
+          serverId: rawArtImage.serverId,
+          serverName: rawArtImage.serverName,
+          createdAt: rawArtImage.createdAt,
+        }
       : null
 
     return {

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -18,7 +18,12 @@ import { requireMachineUser } from '../../../utils/authGuard'
 import {
   decodeArtJobPayload,
   parseArtJobPayload,
+  serializeArtJobPayload,
 } from '../../../utils/artJobPayload'
+import {
+  enrichArtJobPayload,
+  readArtJobProvenance,
+} from '../../../utils/artJobProvenance'
 import {
   artJobQueueAffinityKey,
   selectSmartQueueCandidate,
@@ -35,6 +40,7 @@ type ClaimRequestBody = {
   agentId?: string | null
   engines?: string[] | null
   supportsInputImages?: boolean | null
+  supportsCompletionProof?: boolean | null
   agentVersion?: string | null
   smartQueue?: boolean | null
 }
@@ -63,6 +69,7 @@ export default defineEventHandler(async (event) => {
     )[]
 
     const supportsInputImages = body?.supportsInputImages === true
+    const supportsCompletionProof = body?.supportsCompletionProof === true
     const smartQueue = body?.smartQueue !== false
 
     recordRelayClaimAttempt({
@@ -171,6 +178,46 @@ export default defineEventHandler(async (event) => {
 
       if (!candidate) continue
 
+      let enrichedPayload
+
+      try {
+        const currentProvenance = readArtJobProvenance(candidate.payload)
+        enrichedPayload = enrichArtJobPayload(
+          candidate.engine as 'A1111' | 'COMFY',
+          candidate.payload,
+          {
+            projectSlug: candidate.projectSlug,
+            idempotencyKey: currentProvenance?.idempotencyKey,
+            requireCompletionProof:
+              currentProvenance?.requireCompletionProof === true ||
+              supportsCompletionProof,
+          },
+        ).payload
+      } catch (error: unknown) {
+        const handled = errorHandler(error)
+        const invalid = await prisma.artJob.updateMany({
+          where: {
+            id: candidate.id,
+            status: candidate.status,
+            claimedAt: candidate.claimedAt,
+          },
+          data: {
+            status: 'FAILED',
+            error: `Prompt provenance validation failed before claim: ${handled.message}`.slice(
+              0,
+              4000,
+            ),
+            claimedAt: null,
+            claimedBy: null,
+          },
+        })
+
+        if (invalid.count === 1) {
+          skippedIds.push(candidate.id)
+        }
+        continue
+      }
+
       const won = await prisma.artJob.updateMany({
         where: {
           id: candidate.id,
@@ -182,6 +229,7 @@ export default defineEventHandler(async (event) => {
           claimedAt: new Date(),
           claimedBy,
           attempts: { increment: 1 },
+          payload: serializeArtJobPayload(enrichedPayload),
         },
       })
 
@@ -197,6 +245,12 @@ export default defineEventHandler(async (event) => {
             : 'Job claimed.',
           data: {
             job: job ? decodeArtJobPayload(job) : null,
+            relayContract: {
+              supportsCompletionProof,
+              completionProofRequired:
+                readArtJobProvenance(enrichedPayload)
+                  ?.requireCompletionProof === true,
+            },
             scheduling: {
               mode: smartQueue ? 'SMART' : 'FIFO',
               affinityMatched: selection.affinityMatched,

--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -12,6 +12,7 @@ import {
   decodeArtJobPayload,
   serializeArtJobPayload,
 } from '../../../utils/artJobPayload'
+import { enrichArtJobPayload } from '../../../utils/artJobProvenance'
 
 const ENGINES = new Set(['A1111', 'COMFY'])
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
@@ -21,6 +22,8 @@ type QueueRequestBody = {
   payload?: Record<string, unknown> | null
   priority?: number | null
   projectSlug?: string | null
+  idempotencyKey?: string | null
+  requireCompletionProof?: boolean | null
 }
 
 export default defineEventHandler(async (event) => {
@@ -37,9 +40,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const payload = body?.payload
+    const rawPayload = body?.payload
 
-    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    if (
+      !rawPayload ||
+      typeof rawPayload !== 'object' ||
+      Array.isArray(rawPayload)
+    ) {
       throw createError({
         statusCode: 400,
         message:
@@ -53,7 +60,49 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Invalid projectSlug.' })
     }
 
-    const priority = Number.isInteger(body?.priority) ? Number(body?.priority) : 0
+    const priority = Number.isInteger(body?.priority)
+      ? Number(body?.priority)
+      : 0
+
+    const { payload, provenance } = enrichArtJobPayload(
+      engine as 'A1111' | 'COMFY',
+      rawPayload,
+      {
+        projectSlug,
+        idempotencyKey: body?.idempotencyKey,
+        requireCompletionProof:
+          engine === 'COMFY' && body?.requireCompletionProof === true,
+      },
+    )
+
+    const fingerprintNeedle = `"attemptFingerprint":"${provenance.attemptFingerprint}"`
+    const existing = await prisma.artJob.findFirst({
+      where: {
+        userId: auth.user.id,
+        status: { in: ['PENDING', 'RUNNING', 'DONE'] },
+        payload: { contains: fingerprintNeedle },
+      },
+      orderBy: { id: 'desc' },
+    })
+
+    if (existing) {
+      return {
+        success: true,
+        message: `Matching ArtJob ${existing.id} already exists; duplicate enqueue suppressed.`,
+        data: {
+          job: decodeArtJobPayload(existing),
+          deduplicated: true,
+          provenance: {
+            promptHash: provenance.promptHash,
+            workflowHash: provenance.workflowHash,
+            workflowPromptHash: provenance.workflowPromptHash,
+            attemptFingerprint: provenance.attemptFingerprint,
+            expectedModels: provenance.expectedModels,
+          },
+        },
+        statusCode: 200,
+      }
+    }
 
     const job = await prisma.artJob.create({
       data: {
@@ -70,7 +119,17 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: 'Art job queued.',
-      data: { job: decodeArtJobPayload(job) },
+      data: {
+        job: decodeArtJobPayload(job),
+        deduplicated: false,
+        provenance: {
+          promptHash: provenance.promptHash,
+          workflowHash: provenance.workflowHash,
+          workflowPromptHash: provenance.workflowPromptHash,
+          attemptFingerprint: provenance.attemptFingerprint,
+          expectedModels: provenance.expectedModels,
+        },
+      },
       statusCode: 201,
     }
   } catch (error: unknown) {

--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -26,6 +26,10 @@ type QueueRequestBody = {
   requireCompletionProof?: boolean | null
 }
 
+type LockRow = {
+  acquired?: number | bigint | string | null
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const auth = await requireMachineUser(event)
@@ -76,52 +80,71 @@ export default defineEventHandler(async (event) => {
     )
 
     const fingerprintNeedle = `"attemptFingerprint":"${provenance.attemptFingerprint}"`
-    const existing = await prisma.artJob.findFirst({
-      where: {
-        userId: auth.user.id,
-        status: { in: ['PENDING', 'RUNNING', 'DONE'] },
-        payload: { contains: fingerprintNeedle },
-      },
-      orderBy: { id: 'desc' },
-    })
+    const lockName = `artjob:${auth.user.id}:${provenance.attemptFingerprint}`.slice(
+      0,
+      64,
+    )
 
-    if (existing) {
-      return {
-        success: true,
-        message: `Matching ArtJob ${existing.id} already exists; duplicate enqueue suppressed.`,
-        data: {
-          job: decodeArtJobPayload(existing),
-          deduplicated: true,
-          provenance: {
-            promptHash: provenance.promptHash,
-            workflowHash: provenance.workflowHash,
-            workflowPromptHash: provenance.workflowPromptHash,
-            attemptFingerprint: provenance.attemptFingerprint,
-            expectedModels: provenance.expectedModels,
-          },
-        },
-        statusCode: 200,
-      }
+    const result = await prisma.$transaction(
+      async (tx) => {
+        const lockRows = await tx.$queryRaw<LockRow[]>`
+          SELECT GET_LOCK(${lockName}, 3) AS acquired
+        `
+
+        if (Number(lockRows[0]?.acquired) !== 1) {
+          throw createError({
+            statusCode: 409,
+            message:
+              'A matching ArtJob enqueue is already being processed. Retry shortly.',
+          })
+        }
+
+        try {
+          const existing = await tx.artJob.findFirst({
+            where: {
+              userId: auth.user.id,
+              status: { in: ['PENDING', 'RUNNING', 'DONE'] },
+              payload: { contains: fingerprintNeedle },
+            },
+            orderBy: { id: 'desc' },
+          })
+
+          if (existing) {
+            return { job: existing, deduplicated: true }
+          }
+
+          const job = await tx.artJob.create({
+            data: {
+              engine: engine as 'A1111' | 'COMFY',
+              payload: serializeArtJobPayload(payload),
+              priority,
+              projectSlug,
+              userId: auth.user.id,
+            },
+          })
+
+          return { job, deduplicated: false }
+        } finally {
+          await tx.$queryRaw`
+            SELECT RELEASE_LOCK(${lockName}) AS released
+          `
+        }
+      },
+      { timeout: 10_000 },
+    )
+
+    if (!result.deduplicated) {
+      event.node.res.statusCode = 201
     }
-
-    const job = await prisma.artJob.create({
-      data: {
-        engine: engine as 'A1111' | 'COMFY',
-        payload: serializeArtJobPayload(payload),
-        priority,
-        projectSlug,
-        userId: auth.user.id,
-      },
-    })
-
-    event.node.res.statusCode = 201
 
     return {
       success: true,
-      message: 'Art job queued.',
+      message: result.deduplicated
+        ? `Matching ArtJob ${result.job.id} already exists; duplicate enqueue suppressed.`
+        : 'Art job queued.',
       data: {
-        job: decodeArtJobPayload(job),
-        deduplicated: false,
+        job: decodeArtJobPayload(result.job),
+        deduplicated: result.deduplicated,
         provenance: {
           promptHash: provenance.promptHash,
           workflowHash: provenance.workflowHash,
@@ -130,7 +153,7 @@ export default defineEventHandler(async (event) => {
           expectedModels: provenance.expectedModels,
         },
       },
-      statusCode: 201,
+      statusCode: result.deduplicated ? 200 : 201,
     }
   } catch (error: unknown) {
     const handled = errorHandler(error)

--- a/server/utils/artJobProvenance.ts
+++ b/server/utils/artJobProvenance.ts
@@ -86,7 +86,12 @@ export function hashArtImageData(value: unknown): string | null {
   const raw = String(value || '').trim()
   if (!raw) return null
 
-  const encoded = raw.includes('base64,') ? raw.split('base64,', 2)[1] : raw
+  const marker = 'base64,'
+  const encoded = raw.includes(marker)
+    ? raw.slice(raw.indexOf(marker) + marker.length)
+    : raw
+
+  if (!encoded) return null
 
   try {
     const bytes = Buffer.from(encoded, 'base64')

--- a/server/utils/artJobProvenance.ts
+++ b/server/utils/artJobProvenance.ts
@@ -115,7 +115,7 @@ export function extractWorkflowTextCandidates(workflow: unknown): string[] {
     values,
   )
 
-  return [...new Set(values)]
+  return [...new Set(values)].sort()
 }
 
 export function extractWorkflowModels(workflow: unknown): string[] {
@@ -161,6 +161,8 @@ export function enrichArtJobPayload(
       message: 'ArtJob payload requires a non-empty promptString.',
     })
   }
+
+  payload.promptString = normalizedPrompt
 
   const promptHash = sha256(normalizedPrompt)
   let workflowHash: string | null = null
@@ -228,7 +230,6 @@ export function enrichArtJobPayload(
       : {}),
   }
 
-  payload.promptString = normalizedPrompt
   payload.attemptFingerprint = attemptFingerprint
   payload.provenance = provenance
 
@@ -241,7 +242,7 @@ export function readArtJobProvenance(
   const provenance = asRecord(parseArtJobPayload(rawPayload).provenance)
   if (provenance.version !== 1) return null
 
-  return provenance as ArtJobProvenanceRecord
+  return provenance as unknown as ArtJobProvenanceRecord
 }
 
 function requiredString(value: unknown, field: string): string {

--- a/server/utils/artJobProvenance.ts
+++ b/server/utils/artJobProvenance.ts
@@ -18,6 +18,7 @@ export type ArtJobCompletionProof = {
   promptHash?: string | null
   workflowHash?: string | null
   workflowPromptHash?: string | null
+  imageHash?: string | null
   output?: Partial<ArtJobCompletionOutput> | null
 }
 
@@ -79,6 +80,21 @@ export function normalizeArtPrompt(value: unknown): string {
   return String(value || '')
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+export function hashArtImageData(value: unknown): string | null {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+
+  const encoded = raw.includes('base64,') ? raw.split('base64,', 2)[1] : raw
+
+  try {
+    const bytes = Buffer.from(encoded, 'base64')
+    if (!bytes.length) return null
+    return createHash('sha256').update(bytes).digest('hex')
+  } catch {
+    return null
+  }
 }
 
 function collectWorkflowStrings(
@@ -295,6 +311,7 @@ export function validateArtJobCompletionProof(
     rawProof.workflowPromptHash,
     'workflowPromptHash',
   )
+  const imageHash = requiredString(rawProof.imageHash, 'imageHash')
   const output = rawProof.output || {}
   const filename = requiredString(output.filename, 'output.filename')
   const subfolder = String(output.subfolder || '').trim()
@@ -325,9 +342,28 @@ export function validateArtJobCompletionProof(
     promptHash,
     workflowHash,
     workflowPromptHash,
+    imageHash,
     output: { filename, subfolder, type },
     expectedModels: provenance.expectedModels,
     attemptFingerprint: provenance.attemptFingerprint,
+  }
+}
+
+export function assertArtImageMatchesCompletion(
+  completion: Record<string, unknown>,
+  imageData: unknown,
+): void {
+  if (completion.status !== 'VERIFIED') return
+
+  const expectedHash = requiredString(completion.imageHash, 'imageHash')
+  const actualHash = hashArtImageData(imageData)
+
+  if (!actualHash || actualHash !== expectedHash) {
+    throw createError({
+      statusCode: 409,
+      message:
+        'Uploaded ArtImage bytes do not match the image hash from the claimed Comfy output.',
+    })
   }
 }
 

--- a/server/utils/artJobProvenance.ts
+++ b/server/utils/artJobProvenance.ts
@@ -1,0 +1,344 @@
+import { createHash } from 'node:crypto'
+import { createError } from 'h3'
+import {
+  parseArtJobPayload,
+  type ArtJobPayloadRecord,
+} from './artJobPayload'
+
+export type ArtJobCompletionOutput = {
+  filename: string
+  subfolder: string
+  type: string
+}
+
+export type ArtJobCompletionProof = {
+  relayVersion?: string | null
+  relayCommit?: string | null
+  promptId?: string | null
+  promptHash?: string | null
+  workflowHash?: string | null
+  workflowPromptHash?: string | null
+  output?: Partial<ArtJobCompletionOutput> | null
+}
+
+export type ArtJobProvenanceRecord = {
+  version: 1
+  normalizedPrompt: string
+  promptHash: string
+  workflowHash: string | null
+  workflowPromptHash: string | null
+  workflowPromptMatches: boolean | null
+  workflowTextCandidates: string[]
+  expectedModels: string[]
+  attemptFingerprint: string
+  idempotencyKey: string | null
+  requireCompletionProof: boolean
+  createdAt: string
+  completion?: Record<string, unknown>
+}
+
+type ProvenanceOptions = {
+  projectSlug?: string | null
+  idempotencyKey?: string | null
+  requireCompletionProof?: boolean
+}
+
+const TEXT_INPUT_PATTERN = /(^|_)(prompt|text)($|_)/i
+const MODEL_INPUT_PATTERN =
+  /(^|_)(ckpt|checkpoint|unet|clip|vae|lora|controlnet|ipadapter|ip_adapter|upscale|model).*name($|_)/i
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    )
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) return null
+  return value
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}
+
+export function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+export function normalizeArtPrompt(value: unknown): string {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function collectWorkflowStrings(
+  value: unknown,
+  predicate: (key: string, value: string) => boolean,
+  output: string[],
+): void {
+  if (Array.isArray(value)) {
+    for (const child of value) collectWorkflowStrings(child, predicate, output)
+    return
+  }
+
+  if (!value || typeof value !== 'object') return
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof child === 'string' && predicate(key, child)) {
+      const normalized = normalizeArtPrompt(child)
+      if (normalized) output.push(normalized)
+    }
+
+    collectWorkflowStrings(child, predicate, output)
+  }
+}
+
+export function extractWorkflowTextCandidates(workflow: unknown): string[] {
+  const values: string[] = []
+
+  collectWorkflowStrings(
+    workflow,
+    (key) =>
+      TEXT_INPUT_PATTERN.test(key) ||
+      key === 'wildcard_text' ||
+      key === 'populated_text',
+    values,
+  )
+
+  return [...new Set(values)]
+}
+
+export function extractWorkflowModels(workflow: unknown): string[] {
+  const values: string[] = []
+
+  collectWorkflowStrings(
+    workflow,
+    (key, value) =>
+      MODEL_INPUT_PATTERN.test(key) ||
+      (/\.(safetensors|ckpt|pt|pth|gguf|bin)$/i.test(value) &&
+        /(model|loader|checkpoint|unet|clip|vae|lora)/i.test(key)),
+    values,
+  )
+
+  return [...new Set(values)].sort()
+}
+
+function requestPrompt(payload: ArtJobPayloadRecord): string {
+  return normalizeArtPrompt(
+    payload.promptString || payload.artPrompt || payload.prompt,
+  )
+}
+
+function cleanIdempotencyKey(value: unknown): string | null {
+  const key = String(value || '').trim()
+  return key ? key.slice(0, 512) : null
+}
+
+export function enrichArtJobPayload(
+  engine: 'A1111' | 'COMFY',
+  rawPayload: unknown,
+  options: ProvenanceOptions = {},
+): {
+  payload: ArtJobPayloadRecord
+  provenance: ArtJobProvenanceRecord
+} {
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const normalizedPrompt = requestPrompt(payload)
+
+  if (!normalizedPrompt) {
+    throw createError({
+      statusCode: 400,
+      message: 'ArtJob payload requires a non-empty promptString.',
+    })
+  }
+
+  const promptHash = sha256(normalizedPrompt)
+  let workflowHash: string | null = null
+  let workflowPromptHash: string | null = null
+  let workflowPromptMatches: boolean | null = null
+  let workflowTextCandidates: string[] = []
+  let expectedModels: string[] = []
+
+  if (engine === 'COMFY') {
+    const workflow = asRecord(payload.workflow)
+
+    if (!Object.keys(workflow).length) {
+      throw createError({
+        statusCode: 400,
+        message: 'COMFY ArtJob payload requires a workflow object.',
+      })
+    }
+
+    workflowTextCandidates = extractWorkflowTextCandidates(workflow)
+    workflowPromptMatches = workflowTextCandidates.includes(normalizedPrompt)
+
+    if (!workflowPromptMatches) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'COMFY workflow prompt does not match the top-level promptString. Refusing to enqueue ambiguous prompt metadata.',
+      })
+    }
+
+    workflowHash = sha256(canonicalJson(workflow))
+    workflowPromptHash = sha256(canonicalJson(workflowTextCandidates))
+    expectedModels = extractWorkflowModels(workflow)
+  }
+
+  const idempotencyKey = cleanIdempotencyKey(options.idempotencyKey)
+  const priorProvenance = asRecord(payload.provenance)
+  const fingerprintPayload = structuredClone(payload)
+  delete fingerprintPayload.provenance
+  delete fingerprintPayload.attemptFingerprint
+
+  const attemptFingerprint = sha256(
+    canonicalJson({
+      engine,
+      projectSlug: options.projectSlug || null,
+      idempotencyKey,
+      request: fingerprintPayload,
+    }),
+  )
+
+  const provenance: ArtJobProvenanceRecord = {
+    version: 1,
+    normalizedPrompt,
+    promptHash,
+    workflowHash,
+    workflowPromptHash,
+    workflowPromptMatches,
+    workflowTextCandidates,
+    expectedModels,
+    attemptFingerprint,
+    idempotencyKey,
+    requireCompletionProof: options.requireCompletionProof === true,
+    createdAt: new Date().toISOString(),
+    ...(asRecord(priorProvenance.completion).status
+      ? { completion: asRecord(priorProvenance.completion) }
+      : {}),
+  }
+
+  payload.promptString = normalizedPrompt
+  payload.attemptFingerprint = attemptFingerprint
+  payload.provenance = provenance
+
+  return { payload, provenance }
+}
+
+export function readArtJobProvenance(
+  rawPayload: unknown,
+): ArtJobProvenanceRecord | null {
+  const provenance = asRecord(parseArtJobPayload(rawPayload).provenance)
+  if (provenance.version !== 1) return null
+
+  return provenance as ArtJobProvenanceRecord
+}
+
+function requiredString(value: unknown, field: string): string {
+  const text = String(value || '').trim()
+  if (!text) {
+    throw createError({
+      statusCode: 409,
+      message: `COMFY completion proof is missing ${field}.`,
+    })
+  }
+  return text
+}
+
+export function validateArtJobCompletionProof(
+  rawPayload: unknown,
+  rawProof: ArtJobCompletionProof | null | undefined,
+): Record<string, unknown> {
+  const provenance = readArtJobProvenance(rawPayload)
+
+  if (!provenance) {
+    return {
+      status: 'UNAVAILABLE',
+      verified: false,
+      reasons: ['ArtJob was created before prompt provenance was recorded.'],
+    }
+  }
+
+  if (!rawProof) {
+    if (provenance.requireCompletionProof) {
+      throw createError({
+        statusCode: 409,
+        message:
+          'This COMFY ArtJob requires completion provenance, but the relay supplied none.',
+      })
+    }
+
+    return {
+      status: 'UNVERIFIED',
+      verified: false,
+      reasons: ['Relay did not supply Comfy prompt/output provenance.'],
+      expected: provenance,
+    }
+  }
+
+  const promptId = requiredString(rawProof.promptId, 'promptId')
+  const relayVersion = requiredString(rawProof.relayVersion, 'relayVersion')
+  const promptHash = requiredString(rawProof.promptHash, 'promptHash')
+  const workflowHash = requiredString(rawProof.workflowHash, 'workflowHash')
+  const workflowPromptHash = requiredString(
+    rawProof.workflowPromptHash,
+    'workflowPromptHash',
+  )
+  const output = rawProof.output || {}
+  const filename = requiredString(output.filename, 'output.filename')
+  const subfolder = String(output.subfolder || '').trim()
+  const type = requiredString(output.type, 'output.type')
+
+  const mismatches = [
+    promptHash !== provenance.promptHash ? 'promptHash' : null,
+    workflowHash !== provenance.workflowHash ? 'workflowHash' : null,
+    workflowPromptHash !== provenance.workflowPromptHash
+      ? 'workflowPromptHash'
+      : null,
+  ].filter(Boolean)
+
+  if (mismatches.length) {
+    throw createError({
+      statusCode: 409,
+      message: `COMFY completion provenance mismatch: ${mismatches.join(', ')}.`,
+    })
+  }
+
+  return {
+    status: 'VERIFIED',
+    verified: true,
+    verifiedAt: new Date().toISOString(),
+    promptId,
+    relayVersion,
+    relayCommit: String(rawProof.relayCommit || '').trim() || null,
+    promptHash,
+    workflowHash,
+    workflowPromptHash,
+    output: { filename, subfolder, type },
+    expectedModels: provenance.expectedModels,
+    attemptFingerprint: provenance.attemptFingerprint,
+  }
+}
+
+export function attachCompletionTrace(
+  rawPayload: unknown,
+  completion: Record<string, unknown>,
+): ArtJobPayloadRecord {
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const provenance = asRecord(payload.provenance)
+  payload.provenance = {
+    ...provenance,
+    completion,
+  }
+  return payload
+}

--- a/utils/scripts/verifyArtJobProvenance.ts
+++ b/utils/scripts/verifyArtJobProvenance.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+import {
+  enrichArtJobPayload,
+  validateArtJobCompletionProof,
+} from '../../server/utils/artJobProvenance'
+
+function workflow(prompt: string, seed: number) {
+  return {
+    '57': {
+      class_type: 'SaveImage',
+      inputs: {
+        filename_prefix: 'kindrobots_test',
+        images: ['7', 0],
+      },
+    },
+    '24': {
+      class_type: 'UnetLoaderGGUF',
+      inputs: { unet_name: 'flux1-dev-Q8_0.gguf' },
+    },
+    '59': {
+      class_type: 'ImpactWildcardEncode',
+      inputs: {
+        wildcard_text: prompt,
+        populated_text: prompt,
+        seed,
+        model: ['24', 0],
+      },
+    },
+  }
+}
+
+const promptA = 'A vampire family portrait in a velvet crypt lounge.'
+const promptB = 'A lighthouse keeper confronting a sea monster.'
+
+const attemptA = enrichArtJobPayload(
+  'COMFY',
+  {
+    promptString: promptA,
+    workflow: workflow(promptA, 840009),
+    seed: 840009,
+  },
+  {
+    projectSlug: 'coloring-book',
+    idempotencyKey: 'monster-recast:mr-009:840009',
+    requireCompletionProof: true,
+  },
+)
+
+const duplicateA = enrichArtJobPayload(
+  'COMFY',
+  {
+    seed: 840009,
+    workflow: workflow(promptA, 840009),
+    promptString: `  ${promptA}  `,
+  },
+  {
+    projectSlug: 'coloring-book',
+    idempotencyKey: 'monster-recast:mr-009:840009',
+    requireCompletionProof: true,
+  },
+)
+
+assert.equal(
+  attemptA.provenance.attemptFingerprint,
+  duplicateA.provenance.attemptFingerprint,
+  'the same normalized prompt/workflow/seed attempt must be idempotent',
+)
+assert.equal(attemptA.provenance.workflowPromptMatches, true)
+assert.ok(
+  attemptA.provenance.expectedModels.includes('flux1-dev-Q8_0.gguf'),
+)
+
+const attemptB = enrichArtJobPayload(
+  'COMFY',
+  {
+    promptString: promptB,
+    workflow: workflow(promptB, 840010),
+    seed: 840010,
+  },
+  {
+    projectSlug: 'coloring-book',
+    idempotencyKey: 'monster-recast:mr-010:840010',
+    requireCompletionProof: true,
+  },
+)
+
+assert.notEqual(
+  attemptA.provenance.attemptFingerprint,
+  attemptB.provenance.attemptFingerprint,
+  'different prompt attempts must never collapse onto one queue identity',
+)
+
+assert.throws(
+  () =>
+    enrichArtJobPayload('COMFY', {
+      promptString: promptA,
+      workflow: workflow(promptB, 840009),
+    }),
+  /workflow prompt does not match/i,
+)
+
+const verified = validateArtJobCompletionProof(attemptA.payload, {
+  relayVersion: 'relay-test-1',
+  relayCommit: 'abc123',
+  promptId: 'comfy-prompt-a',
+  promptHash: attemptA.provenance.promptHash,
+  workflowHash: attemptA.provenance.workflowHash,
+  workflowPromptHash: attemptA.provenance.workflowPromptHash,
+  output: {
+    filename: 'job-a.png',
+    subfolder: '',
+    type: 'output',
+  },
+})
+
+assert.equal(verified.verified, true)
+assert.equal(verified.promptId, 'comfy-prompt-a')
+
+assert.throws(
+  () =>
+    validateArtJobCompletionProof(attemptA.payload, {
+      relayVersion: 'relay-test-1',
+      promptId: 'comfy-prompt-b',
+      promptHash: attemptA.provenance.promptHash,
+      workflowHash: attemptB.provenance.workflowHash,
+      workflowPromptHash: attemptB.provenance.workflowPromptHash,
+      output: {
+        filename: 'job-b.png',
+        subfolder: '',
+        type: 'output',
+      },
+    }),
+  /provenance mismatch/i,
+  'an out-of-order Comfy output must not complete the wrong ArtJob',
+)
+
+assert.throws(
+  () => validateArtJobCompletionProof(attemptA.payload, null),
+  /requires completion provenance/i,
+)
+
+console.log('ArtJob prompt provenance contract passed.')

--- a/utils/scripts/verifyArtJobProvenance.ts
+++ b/utils/scripts/verifyArtJobProvenance.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict'
 import {
+  assertArtImageMatchesCompletion,
   enrichArtJobPayload,
+  hashArtImageData,
   validateArtJobCompletionProof,
 } from '../../server/utils/artJobProvenance'
 
@@ -31,6 +33,14 @@ function workflow(prompt: string, seed: number) {
 
 const promptA = 'A vampire family portrait in a velvet crypt lounge.'
 const promptB = 'A lighthouse keeper confronting a sea monster.'
+const imageDataA = Buffer.from('job-a-pixels').toString('base64')
+const imageDataB = Buffer.from('job-b-pixels').toString('base64')
+const imageHashA = hashArtImageData(imageDataA)
+const imageHashB = hashArtImageData(imageDataB)
+
+assert.ok(imageHashA)
+assert.ok(imageHashB)
+assert.notEqual(imageHashA, imageHashB)
 
 const attemptA = enrichArtJobPayload(
   'COMFY',
@@ -106,6 +116,7 @@ const verified = validateArtJobCompletionProof(attemptA.payload, {
   promptHash: attemptA.provenance.promptHash,
   workflowHash: attemptA.provenance.workflowHash,
   workflowPromptHash: attemptA.provenance.workflowPromptHash,
+  imageHash: imageHashA,
   output: {
     filename: 'job-a.png',
     subfolder: '',
@@ -115,6 +126,12 @@ const verified = validateArtJobCompletionProof(attemptA.payload, {
 
 assert.equal(verified.verified, true)
 assert.equal(verified.promptId, 'comfy-prompt-a')
+assertArtImageMatchesCompletion(verified, imageDataA)
+assert.throws(
+  () => assertArtImageMatchesCompletion(verified, imageDataB),
+  /bytes do not match/i,
+  'a correct prompt_id tuple must not be associated with different uploaded pixels',
+)
 
 assert.throws(
   () =>
@@ -124,6 +141,7 @@ assert.throws(
       promptHash: attemptA.provenance.promptHash,
       workflowHash: attemptB.provenance.workflowHash,
       workflowPromptHash: attemptB.provenance.workflowPromptHash,
+      imageHash: imageHashB,
       output: {
         filename: 'job-b.png',
         subfolder: '',


### PR DESCRIPTION
## Problem

The durable ArtJob queue accepted ambiguous prompt metadata and allowed any uploaded `ArtImage` to complete a RUNNING job with only `{ success, artImageId }`. It could not prove that the pixels came from the job's submitted Comfy workflow or exact `prompt_id`, and repeated producer retries could create duplicate attempts.

Addresses #820 and pairs with `silasfelinus/conductor#988` / `silasfelinus/conductor#992`.

## What changed

- validate every low-level ArtJob has a non-empty top-level `promptString`
- require COMFY workflow prompt text to match the normalized top-level prompt
- persist prompt hash, canonical workflow hash, workflow-text hash, expected models, attempt fingerprint, idempotency key, and proof policy
- make duplicate enqueue suppression atomic
- enrich older/high-level jobs at claim time
- negotiate strict relay proof with `supportsCompletionProof`
- verify exact Comfy `prompt_id`, output `(filename, subfolder, type)`, request hashes, relay version/commit, and SHA-256 of uploaded bytes
- reject mismatched ArtImage prompt metadata or pixels
- add `GET /api/art/queue/:id/provenance`
- add regression coverage for duplicate normalization, wrong workflow prompt, stale Job B output completing Job A, omitted required proof, and correct metadata paired with different pixels
- document the implemented Conductor relay files and deployment order

## Relay implementation

The corresponding relay change is implemented in `silasfelinus/conductor#992`:

- `ops/home-server/relay_agent.py`
- `ops/home-server/relay_media_agent.py`
- `tests/test_relay_completion_provenance.py`

The relay advertises proof support during claim, retains returned or recovered `prompt_id`, polls only `/history/{prompt_id}`, preserves the exact output tuple, hashes the exact downloaded bytes, uploads those same bytes, and submits the proof during completion.

## Verification

Green checks include:

- ArtJob Provenance Contract
- full TypeScript Type Check
- repository Contract Tests

## Rollout

1. Merge and deploy this Kind Robots server contract.
2. Merge Conductor #992 and deploy the updated `relay_media_agent.py` service.
3. Confirm a test job reports `completion.status = VERIFIED` and matching completion/ArtImage hashes through `GET /api/art/queue/:id/provenance`.

## Stakes

Reversible code-only change; no schema migration.