### PR TITLE
Add guarded WonderLab published-review revision

### DIFF
--- a/server/api/admin/wonderlab/review-drafts/[id]/revise.patch.ts
+++ b/server/api/admin/wonderlab/review-drafts/[id]/revise.patch.ts
@@ -1,0 +1,110 @@
+// /server/api/admin/wonderlab/review-drafts/[id]/revise.patch.ts
+import { createError, defineEventHandler, getRouterParam, H3Error, readBody } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { revisePublishedReview } from '@/server/utils/publishedReviewRevision'
+import {
+  normalizeReviewDraftText,
+  positiveReviewDraftId,
+  type ReviewDraftAuthorKind,
+} from '@/utils/wonderlab/reviewDraft'
+
+type PublishedReviewRevisionBody = {
+  editedComment?: unknown
+  expectedComponentId?: unknown
+  expectedReactionId?: unknown
+  expectedAuthorKind?: unknown
+  expectedAuthorId?: unknown
+  expectedCurrentCommentHash?: unknown
+}
+
+function expectedAuthorKind(value: unknown): ReviewDraftAuthorKind {
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, message: 'expectedAuthorKind is required.' })
+  }
+  const kind = value.trim().toUpperCase()
+  if (kind !== 'BOT' && kind !== 'CHARACTER') {
+    throw createError({ statusCode: 400, message: 'expectedAuthorKind must be BOT or CHARACTER.' })
+  }
+  return kind
+}
+
+function expectedCommentHash(value: unknown): string {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/i.test(value.trim())) {
+    throw createError({
+      statusCode: 400,
+      message: 'expectedCurrentCommentHash must be a SHA-256 hex digest.',
+    })
+  }
+  return value.trim().toLowerCase()
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const draftId = positiveReviewDraftId(getRouterParam(event, 'id'))
+    if (!draftId) throw createError({ statusCode: 400, message: 'Invalid review draft ID.' })
+
+    const body = await readBody<PublishedReviewRevisionBody>(event)
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw createError({ statusCode: 400, message: 'Published review revision body is required.' })
+    }
+
+    let editedComment: string | null
+    try {
+      editedComment = normalizeReviewDraftText(body.editedComment, {
+        required: true,
+        maxLength: 20_000,
+      })
+    } catch (error) {
+      throw createError({
+        statusCode: 400,
+        message: error instanceof Error ? error.message : 'Invalid revised review text.',
+      })
+    }
+
+    const expectedComponentId = positiveReviewDraftId(body.expectedComponentId)
+    const expectedReactionId = positiveReviewDraftId(body.expectedReactionId)
+    const expectedAuthorId = positiveReviewDraftId(body.expectedAuthorId)
+    if (!expectedComponentId || !expectedReactionId || !expectedAuthorId) {
+      throw createError({
+        statusCode: 400,
+        message: 'Expected Component, Reaction, and author IDs must be positive integers.',
+      })
+    }
+
+    const result = await revisePublishedReview({
+      draftId,
+      editedComment: editedComment as string,
+      expectedComponentId,
+      expectedReactionId,
+      expectedAuthor: {
+        kind: expectedAuthorKind(body.expectedAuthorKind),
+        id: expectedAuthorId,
+      },
+      expectedCurrentCommentHash: expectedCommentHash(body.expectedCurrentCommentHash),
+    })
+
+    return {
+      success: true,
+      data: result,
+      message: 'Published review commentary revised without changing its assignment.',
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+
+    const message = error instanceof Error ? error.message : 'Failed to revise published review.'
+    if (/not found|no longer exists/i.test(message)) {
+      throw createError({ statusCode: 404, message })
+    }
+    if (
+      /only a published|missing publisher|lock|linkage|changed after|no first-party author/i.test(
+        message,
+      )
+    ) {
+      throw createError({ statusCode: 409, message })
+    }
+
+    return errorHandler(error)
+  }
+})

--- a/server/utils/publishedReviewRevision.ts
+++ b/server/utils/publishedReviewRevision.ts
@@ -1,0 +1,166 @@
+// /server/utils/publishedReviewRevision.ts
+import { createHash } from 'node:crypto'
+import prisma from '@/server/utils/prisma'
+import { getReviewDraftById, type ReviewDraftRecord } from './reviewDraftRepository'
+
+export type PublishedReviewRevisionAuthor =
+  | { kind: 'BOT'; id: number }
+  | { kind: 'CHARACTER'; id: number }
+
+export type RevisePublishedReviewInput = {
+  draftId: number
+  editedComment: string
+  expectedComponentId: number
+  expectedReactionId: number
+  expectedAuthor: PublishedReviewRevisionAuthor
+  expectedCurrentCommentHash: string
+}
+
+type LockedPublishedDraft = {
+  id: number
+  status: string
+  componentId: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+  publisherUserId: number | null
+  publishedReactionId: number | null
+}
+
+type LockedReaction = {
+  id: number
+  userId: number
+  componentId: number
+  reactionCategory: string
+  comment: string | null
+  authorBotId: number | null
+  authorCharacterId: number | null
+}
+
+export type PublishedReviewRevisionResult = {
+  draft: ReviewDraftRecord
+  reactionId: number
+  previousCommentHash: string
+  revisedCommentHash: string
+}
+
+export function publishedReviewCommentHash(value: string | null | undefined): string {
+  return createHash('sha256').update(String(value ?? '')).digest('hex')
+}
+
+function assertExpectedAuthor(
+  draft: LockedPublishedDraft,
+  reaction: LockedReaction,
+  author: PublishedReviewRevisionAuthor,
+): void {
+  const expectedBotId = author.kind === 'BOT' ? author.id : null
+  const expectedCharacterId = author.kind === 'CHARACTER' ? author.id : null
+
+  if (
+    draft.authorBotId !== expectedBotId ||
+    draft.authorCharacterId !== expectedCharacterId ||
+    reaction.authorBotId !== expectedBotId ||
+    reaction.authorCharacterId !== expectedCharacterId
+  ) {
+    throw new Error('Published review author lock does not match the draft and Reaction.')
+  }
+}
+
+export async function revisePublishedReview(
+  input: RevisePublishedReviewInput,
+): Promise<PublishedReviewRevisionResult> {
+  const revisedComment = input.editedComment.trim()
+  if (!revisedComment) throw new Error('A revised review comment is required.')
+
+  const revision = await prisma.$transaction(async (tx) => {
+    const drafts = await tx.$queryRaw<LockedPublishedDraft[]>`
+      SELECT
+        id,
+        status,
+        componentId,
+        authorBotId,
+        authorCharacterId,
+        publisherUserId,
+        publishedReactionId
+      FROM ReviewDraft
+      WHERE id = ${input.draftId}
+      LIMIT 1
+      FOR UPDATE
+    `
+    const draft = drafts[0]
+    if (!draft) throw new Error(`Review draft ${input.draftId} not found.`)
+    if (draft.status !== 'PUBLISHED') {
+      throw new Error('Only a published review draft may use the revision service.')
+    }
+    if (!draft.publisherUserId || !draft.publishedReactionId) {
+      throw new Error('Published review draft is missing publisher or Reaction linkage.')
+    }
+    if (
+      draft.componentId !== input.expectedComponentId ||
+      draft.publishedReactionId !== input.expectedReactionId
+    ) {
+      throw new Error('Published review Component or Reaction lock is stale.')
+    }
+
+    const reactions = await tx.$queryRaw<LockedReaction[]>`
+      SELECT
+        id,
+        userId,
+        componentId,
+        reactionCategory,
+        comment,
+        authorBotId,
+        authorCharacterId
+      FROM Reaction
+      WHERE id = ${draft.publishedReactionId}
+      LIMIT 1
+      FOR UPDATE
+    `
+    const reaction = reactions[0]
+    if (!reaction) throw new Error('The linked published Reaction no longer exists.')
+    if (
+      reaction.componentId !== draft.componentId ||
+      reaction.reactionCategory !== 'COMPONENT' ||
+      reaction.userId !== draft.publisherUserId
+    ) {
+      throw new Error('Published Reaction linkage no longer matches the ReviewDraft.')
+    }
+
+    assertExpectedAuthor(draft, reaction, input.expectedAuthor)
+
+    const previousCommentHash = publishedReviewCommentHash(reaction.comment)
+    if (previousCommentHash !== input.expectedCurrentCommentHash) {
+      throw new Error('Published review comment changed after the revision was prepared.')
+    }
+
+    await tx.$executeRaw`
+      UPDATE ReviewDraft
+      SET
+        updatedAt = CURRENT_TIMESTAMP(3),
+        editedComment = ${revisedComment}
+      WHERE id = ${draft.id}
+        AND status = 'PUBLISHED'
+        AND publishedReactionId = ${reaction.id}
+    `
+
+    await tx.$executeRaw`
+      UPDATE Reaction
+      SET
+        updatedAt = CURRENT_TIMESTAMP(3),
+        comment = ${revisedComment}
+      WHERE id = ${reaction.id}
+        AND componentId = ${draft.componentId}
+        AND userId = ${draft.publisherUserId}
+    `
+
+    return {
+      reactionId: reaction.id,
+      previousCommentHash,
+      revisedCommentHash: publishedReviewCommentHash(revisedComment),
+    }
+  })
+
+  const draft = await getReviewDraftById(input.draftId)
+  if (!draft) throw new Error('Revised published review draft could not be reloaded.')
+
+  return { draft, ...revision }
+}

--- a/utils/scripts/verifyReviewDraftPublication.ts
+++ b/utils/scripts/verifyReviewDraftPublication.ts
@@ -5,11 +5,16 @@ import { readFile } from 'node:fs/promises'
 const publisherPath = 'server/utils/reviewDraftPublisher.ts'
 const endpointPath =
   'server/api/admin/wonderlab/review-drafts/[id]/publish.post.ts'
+const revisionServicePath = 'server/utils/publishedReviewRevision.ts'
+const revisionEndpointPath =
+  'server/api/admin/wonderlab/review-drafts/[id]/revise.patch.ts'
 const componentReviewsPath = 'server/api/reactions/component/[id].get.ts'
 const componentFeedPath = 'components/wonderlab/component-review-feed.vue'
 
 const publisher = await readFile(publisherPath, 'utf8')
 const endpoint = await readFile(endpointPath, 'utf8')
+const revisionService = await readFile(revisionServicePath, 'utf8')
+const revisionEndpoint = await readFile(revisionEndpointPath, 'utf8')
 const componentReviews = await readFile(componentReviewsPath, 'utf8')
 const componentFeed = await readFile(componentFeedPath, 'utf8')
 const ordinaryPost = await readFile('server/api/reactions/index.post.ts', 'utf8')
@@ -28,7 +33,32 @@ assert.match(publisher, /status = 'PUBLISHED'/)
 assert.match(publisher, /publishedReactionId = \$\{reactionId\}/)
 assert.match(publisher, /status IN \('PROPOSED', 'APPROVED', 'FAILED'\)/)
 assert.doesNotMatch(publisher, /DELETE\s+FROM\s+Reaction/i)
-assert.doesNotMatch(publisher, /authorBotId\s+IS\s+NULL\s+AND\s+authorCharacterId\s+IS\s+NULL[\s\S]*UPDATE Reaction/i)
+assert.doesNotMatch(
+  publisher,
+  /authorBotId\s+IS\s+NULL\s+AND\s+authorCharacterId\s+IS\s+NULL[\s\S]*UPDATE Reaction/i,
+)
+
+assert.match(revisionEndpoint, /requireAdminApiUser\(event\)/)
+assert.match(revisionEndpoint, /expectedCurrentCommentHash/)
+assert.match(revisionEndpoint, /revisePublishedReview/)
+assert.match(revisionService, /prisma\.\$transaction/)
+assert.match(revisionService, /FROM ReviewDraft[\s\S]*FOR UPDATE/)
+assert.match(revisionService, /FROM Reaction[\s\S]*FOR UPDATE/)
+assert.match(revisionService, /draft\.status !== 'PUBLISHED'/)
+assert.match(revisionService, /reaction\.userId !== draft\.publisherUserId/)
+assert.match(revisionService, /assertExpectedAuthor/)
+assert.match(revisionService, /expectedCurrentCommentHash/)
+assert.match(revisionService, /UPDATE ReviewDraft[\s\S]*editedComment/)
+assert.match(revisionService, /UPDATE Reaction[\s\S]*comment/)
+assert.doesNotMatch(revisionService, /INSERT\s+INTO|DELETE\s+FROM/i)
+assert.doesNotMatch(
+  revisionService,
+  /UPDATE ReviewDraft[\s\S]*authorBotId\s*=|UPDATE ReviewDraft[\s\S]*authorCharacterId\s*=/i,
+)
+assert.doesNotMatch(
+  revisionService,
+  /UPDATE Reaction[\s\S]*authorBotId\s*=|UPDATE Reaction[\s\S]*authorCharacterId\s*=/i,
+)
 
 assert.match(componentReviews, /LEFT JOIN Bot b ON b\.id = r\.authorBotId/)
 assert.match(componentReviews, /LEFT JOIN \\`Character\\` ch ON ch\.id = r\.authorCharacterId/)
@@ -37,8 +67,12 @@ assert.doesNotMatch(componentReviews, /include:\s*\{/)
 
 assert.match(componentFeed, /review\.Author\?\.name/)
 assert.match(componentFeed, /First-party \{\{ review\.Author\.kind\.toLowerCase\(\) \}\}/)
+assert.match(componentFeed, /<NuxtLink/)
+assert.match(componentFeed, /`\/bots\?bot=\$\{review\.Author\.id\}`/)
+assert.match(componentFeed, /`\/characters\?character=\$\{review\.Author\.id\}`/)
+assert.match(componentFeed, /prepareAuthorSelection/)
 
 assert.doesNotMatch(ordinaryPost, /authorBotId/)
 assert.doesNotMatch(ordinaryPost, /authorCharacterId/)
 
-console.log('Review draft publication contract passed.')
+console.log('Review draft publication and revision contract passed.')


### PR DESCRIPTION
## Summary

Adds a narrowly scoped admin-only operation for revising the commentary of an already-published WonderLab ReviewDraft without changing its assignment.

The service:

- locks both ReviewDraft and linked Reaction in one transaction;
- requires the draft to remain `PUBLISHED`;
- requires exact Component, Reaction, Bot/Character, publisher, and current-comment-hash locks;
- changes only `ReviewDraft.editedComment`, `Reaction.comment`, and timestamps;
- preserves rating, reaction type, first-party author, Component, original publisher accountability, publication link, and publication status;
- refuses stale or mismatched revision manifests.

The existing ReviewDraft publication contract now covers this revision boundary and the new author-gallery links.

## Why

The first editorial batches need a voice-quality pass, but replacing reviews or directly editing Reaction rows would weaken the assignment and publication guarantees. This creates the safe path required for exact in-place personality rewrites.

Refs #582.