### PR TITLE
Inventory early WonderLab reviews for personality polish

### DIFF
--- a/.github/workflows/wonderlab-voice-polish-inventory.yml
+++ b/.github/workflows/wonderlab-voice-polish-inventory.yml
@@ -1,0 +1,130 @@
+name: WonderLab Voice Polish Inventory
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-voice-polish-inventory.yml'
+      - 'scripts/wonderlab-voice-polish-inventory.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-voice-polish-inventory.yml'
+      - 'scripts/wonderlab-voice-polish-inventory.mjs'
+  workflow_dispatch:
+    inputs:
+      review_limit:
+        description: 'Number of oldest published reviews to inventory'
+        required: false
+        default: '120'
+      max_draft_id:
+        description: 'Highest ReviewDraft ID to inspect'
+        required: false
+        default: '260'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: wonderlab-voice-polish-inventory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate read-only voice inventory
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate script boundary
+        run: |
+          set -euo pipefail
+          node --check scripts/wonderlab-voice-polish-inventory.mjs
+          node <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert').strict
+          const source = fs.readFileSync('scripts/wonderlab-voice-polish-inventory.mjs', 'utf8')
+          for (const required of [
+            '/api/version',
+            '/api/components',
+            '/api/admin/wonderlab/review-drafts/',
+            'currentCommentHash',
+            'technicalScore',
+            'publicVoiceProfile',
+          ]) assert.ok(source.includes(required), `missing inventory contract: ${required}`)
+          for (const forbidden of [
+            "method: 'POST'",
+            'method: "POST"',
+            "method: 'PATCH'",
+            'method: "PATCH"',
+            '/publish',
+            '/revise',
+            'DATABASE_URL',
+            'prisma.',
+          ]) assert.ok(!source.includes(forbidden), `inventory crossed write boundary: ${forbidden}`)
+          console.log('WonderLab voice-polish inventory boundary passed.')
+          NODE
+
+  inventory:
+    name: Inventory oldest published reviews
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[wonderlab-voice-polish-inventory]'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Build read-only voice-polish inventory
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_VOICE_POLISH_OUTPUT: wonderlab-voice-polish-artifacts
+          WONDERLAB_VOICE_POLISH_LIMIT: ${{ github.event.inputs.review_limit || '120' }}
+          WONDERLAB_VOICE_POLISH_MAX_DRAFT_ID: ${{ github.event.inputs.max_draft_id || '260' }}
+        run: node scripts/wonderlab-voice-polish-inventory.mjs
+      - name: Upload voice-polish evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: wonderlab-voice-polish-inventory-${{ github.run_id }}
+          path: wonderlab-voice-polish-artifacts
+          retention-days: 30
+      - name: Update rollout ledger
+        uses: actions/github-script@v7
+        env:
+          COMMENT_PATH: wonderlab-voice-polish-artifacts/wonderlab-voice-polish-comment.md
+        with:
+          script: |
+            const fs = require('node:fs')
+            const marker = '<!-- WONDERLAB_VOICE_POLISH_INVENTORY -->'
+            const report = fs.readFileSync(process.env.COMMENT_PATH, 'utf8')
+            const body = `${marker}\n${report}\n- **Workflow:** [run ${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 582,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: 582,
+                body,
+              })
+            }

--- a/scripts/wonderlab-voice-polish-inventory.mjs
+++ b/scripts/wonderlab-voice-polish-inventory.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const baseUrl = String(
+  process.env.WONDERLAB_BASE_URL || 'https://kind-robots.vercel.app',
+).replace(/\/$/, '')
+const token = String(process.env.WONDERLAB_ADMIN_TOKEN || '').trim()
+const outputDir = resolve(
+  process.env.WONDERLAB_VOICE_POLISH_OUTPUT || 'wonderlab-voice-polish-artifacts',
+)
+const reviewLimit = positiveInteger(process.env.WONDERLAB_VOICE_POLISH_LIMIT, 120)
+const maxDraftId = positiveInteger(process.env.WONDERLAB_VOICE_POLISH_MAX_DRAFT_ID, 260)
+const concurrency = Math.min(
+  20,
+  positiveInteger(process.env.WONDERLAB_VOICE_POLISH_CONCURRENCY, 12),
+)
+
+if (!token) throw new Error('WONDERLAB_ADMIN_TOKEN is required.')
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function sha256(value) {
+  return createHash('sha256').update(String(value ?? '')).digest('hex')
+}
+
+async function request(path, { admin = false, allowNotFound = false } = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: admin
+      ? {
+          accept: 'application/json',
+          'x-beta-admin-token': token,
+          'x-admin-token': token,
+          'x-api-key': token,
+        }
+      : { accept: 'application/json' },
+  })
+
+  if (allowNotFound && response.status === 404) return null
+  const body = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(body?.message || `${path} returned ${response.status}.`)
+  }
+  return body?.data ?? body
+}
+
+async function mapConcurrent(values, worker, limit) {
+  const output = new Array(values.length)
+  let cursor = 0
+
+  async function consume() {
+    while (cursor < values.length) {
+      const index = cursor++
+      output[index] = await worker(values[index], index)
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, consume))
+  return output
+}
+
+const technicalPatterns = [
+  ['component-summary', /\b(?:the\s+)?component\b/gi, 2],
+  ['template-language', /\btemplate(?:\s+composes|\s+uses|\s+declares)?\b/gi, 3],
+  ['function-inventory', /\b(?:function|functions|source-defined functions)\b/gi, 3],
+  ['implementation-tokens', /\b(?:props?|emits?|imports?|computed|watchers?|v-model|store|endpoint|api)\b/gi, 2],
+  ['source-audit-language', /\b(?:native elements|static interface text|source facts?|source-defined)\b/gi, 4],
+  ['generic-review-language', /\b(?:structured approach|functionality|utilizes|implements|presents a structured|gets the job done)\b/gi, 2],
+  ['identifier-heavy', /`[^`]{2,80}`/g, 1],
+]
+
+function technicalSignals(comment) {
+  const signals = []
+  let score = 0
+  for (const [name, pattern, weight] of technicalPatterns) {
+    const matches = comment.match(pattern) || []
+    if (!matches.length) continue
+    signals.push({ name, count: matches.length, weight })
+    score += matches.length * weight
+  }
+  return { score, signals }
+}
+
+function authorProfilePath(author) {
+  return author.kind === 'BOT'
+    ? `/api/bots/${author.id}`
+    : `/api/characters/${author.id}`
+}
+
+function publicVoiceProfile(author, profile) {
+  if (author.kind === 'BOT') {
+    return {
+      id: author.id,
+      kind: author.kind,
+      name: profile?.name || author.name,
+      slug: profile?.slug || null,
+      personality: profile?.personality || null,
+      narrativeVoice: profile?.narrativeVoice || null,
+      sampleResponse: profile?.sampleResponse || null,
+      tagline: profile?.tagline || null,
+      description: profile?.description || null,
+      botIntro: profile?.botIntro || null,
+    }
+  }
+
+  return {
+    id: author.id,
+    kind: author.kind,
+    name: profile?.name || author.name,
+    slug: profile?.slug || null,
+    personality: profile?.personality || null,
+    voice: profile?.voice || null,
+    sampleResponse: profile?.sampleResponse || null,
+    drive: profile?.drive || null,
+    quirks: profile?.quirks || null,
+    backstory: profile?.backstory || null,
+  }
+}
+
+const [version, components] = await Promise.all([
+  request('/api/version'),
+  request('/api/components'),
+])
+const componentMap = new Map(
+  components.map((component) => [Number(component.id), component]),
+)
+
+const draftIds = Array.from({ length: maxDraftId }, (_, index) => index + 1)
+const scannedDrafts = await mapConcurrent(
+  draftIds,
+  (id) =>
+    request(`/api/admin/wonderlab/review-drafts/${id}`, {
+      admin: true,
+      allowNotFound: true,
+    }),
+  concurrency,
+)
+
+const publishedDrafts = scannedDrafts
+  .filter(
+    (draft) =>
+      draft?.status === 'PUBLISHED' &&
+      Number.isInteger(Number(draft?.publishedReactionId)) &&
+      Number(draft.publishedReactionId) > 0,
+  )
+  .sort((left, right) => Number(left.id) - Number(right.id))
+  .slice(0, reviewLimit)
+
+if (publishedDrafts.length < reviewLimit) {
+  throw new Error(
+    `Only ${publishedDrafts.length} published drafts were found through ReviewDraft #${maxDraftId}; expected ${reviewLimit}.`,
+  )
+}
+
+const authorKeys = Array.from(
+  new Map(
+    publishedDrafts.map((draft) => [
+      `${draft.author.kind}:${draft.author.id}`,
+      draft.author,
+    ]),
+  ).values(),
+)
+const authorProfiles = new Map()
+await mapConcurrent(
+  authorKeys,
+  async (author) => {
+    const profile = await request(authorProfilePath(author))
+    authorProfiles.set(`${author.kind}:${author.id}`, publicVoiceProfile(author, profile))
+  },
+  concurrency,
+)
+
+const inventory = publishedDrafts.map((draft) => {
+  const component = componentMap.get(Number(draft.componentId)) || {}
+  const comment = String(draft.finalComment || draft.editedComment || draft.generatedComment || '')
+  const analysis = technicalSignals(comment)
+  const provenance = draft.promptPayload?.provenance || null
+
+  return {
+    draft: {
+      id: Number(draft.id),
+      status: draft.status,
+      publishedReactionId: Number(draft.publishedReactionId),
+      publisherUserId: Number(draft.publisherUserId),
+      publishedAt: draft.publishedAt,
+      updatedAt: draft.updatedAt,
+      rating: Number(draft.rating),
+      reactionType: draft.reactionType,
+      generatedComment: draft.generatedComment,
+      editedComment: draft.editedComment,
+      currentComment: comment,
+      currentCommentHash: sha256(comment),
+    },
+    component: {
+      id: Number(draft.componentId),
+      name: component.componentName || draft.componentName || '',
+      title: component.title || draft.componentTitle || null,
+      sourceKey: component.sourceKey || provenance?.exhibitSourcePath || '',
+      category: component.category || null,
+      tags: component.tags || null,
+    },
+    author: authorProfiles.get(`${draft.author.kind}:${draft.author.id}`),
+    provenance,
+    technicalScore: analysis.score,
+    technicalSignals: analysis.signals,
+  }
+})
+
+const ranked = [...inventory].sort(
+  (left, right) =>
+    right.technicalScore - left.technicalScore || left.draft.id - right.draft.id,
+)
+const flagged = ranked.filter((entry) => entry.technicalScore >= 4)
+const report = {
+  generatedAt: new Date().toISOString(),
+  production: version,
+  scan: {
+    requestedPublishedReviews: reviewLimit,
+    scannedDraftIds: maxDraftId,
+    firstDraftId: inventory[0]?.draft.id ?? null,
+    lastDraftId: inventory.at(-1)?.draft.id ?? null,
+    flaggedTechnicalReviews: flagged.length,
+  },
+  inventory,
+  rankedTechnicalCandidates: ranked,
+}
+
+const markdown = [
+  '## WonderLab early-review voice-polish inventory',
+  '',
+  `- **Production:** \`${version.commit || 'unknown'}\` · deployment \`${version.deploymentId || 'unknown'}\``,
+  `- **Oldest published reviews inventoried:** ${inventory.length}`,
+  `- **Draft range:** #${report.scan.firstDraftId}–#${report.scan.lastDraftId}`,
+  `- **Technical/template-heavy candidates:** ${flagged.length}`,
+  '- **Boundary:** read-only; no ReviewDraft or Reaction was edited',
+  '',
+  '### Highest-priority voice rewrites',
+  '',
+  ...ranked.slice(0, 25).map(
+    (entry) =>
+      `- Draft #${entry.draft.id} / Reaction #${entry.draft.publishedReactionId} · Component #${entry.component.id} **${entry.component.name}** · **${entry.author.name}** (${entry.author.kind}) · technical score ${entry.technicalScore}`,
+  ),
+  '',
+  'The JSON artifact contains the exact current-comment hashes, original assignments, Component/source provenance, and canonical public voice profiles needed for guarded in-place revision.',
+  '',
+].join('\n')
+
+await mkdir(outputDir, { recursive: true })
+await Promise.all([
+  writeFile(
+    resolve(outputDir, 'wonderlab-voice-polish-inventory.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+  ),
+  writeFile(resolve(outputDir, 'wonderlab-voice-polish-comment.md'), markdown),
+])
+
+console.log(markdown)


### PR DESCRIPTION
## Summary

Adds a read-only inventory for the oldest published WonderLab first-party reviews.

The inventory:

- scans ReviewDrafts in ascending ID order and selects the oldest 120 published reviews;
- records exact draft, linked Reaction, Component, author, publisher, rating, reaction type, and current-comment hash locks;
- includes the current public Bot/Character voice profile and stored Component provenance;
- ranks likely technical/template-heavy prose using transparent heuristics;
- uploads the full JSON artifact and updates the single #582 rollout ledger comment;
- performs no generation, editing, approval, publication, or database access.

This gives the editorial pass an exact live candidate set rather than relying on an approximate “first 100” cutoff.

Refs #582.