### PR TITLE
Link public human review authors to profiles

### DIFF
--- a/components/bots/bot-manager.vue
+++ b/components/bots/bot-manager.vue
@@ -88,7 +88,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from '#app'
 import { useBotStore } from '@/stores/botStore'
 import { useNavStore } from '@/stores/navStore'
 import {
@@ -101,6 +102,7 @@ import {
 
 const dashboardKey: DashboardKey = 'bot'
 
+const route = useRoute()
 const botStore = useBotStore()
 const navStore = useNavStore()
 
@@ -163,8 +165,23 @@ async function loadManagerData(force = false) {
   }
 }
 
+function querySelectionId(value: unknown): number | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+async function syncBotFromRoute(): Promise<void> {
+  const id = querySelectionId(route.query.botId)
+  if (!id) return
+
+  navStore.setDashboardTab(dashboardKey, 'bots')
+  await botStore.selectBot(id)
+}
+
 async function refreshManagerData() {
   await loadManagerData(true)
+  await syncBotFromRoute()
 }
 
 function goToBots() {
@@ -182,5 +199,13 @@ async function handleBotSaved() {
 
 onMounted(async () => {
   await loadManagerData()
+  await syncBotFromRoute()
+
+  watch(
+    () => route.query.botId,
+    () => {
+      void syncBotFromRoute()
+    },
+  )
 })
 </script>

--- a/components/bots/bot-manager.vue
+++ b/components/bots/bot-manager.vue
@@ -172,7 +172,7 @@ function querySelectionId(value: unknown): number | null {
 }
 
 async function syncBotFromRoute(): Promise<void> {
-  const id = querySelectionId(route.query.botId)
+  const id = querySelectionId(route.query.botId ?? route.query.bot)
   if (!id) return
 
   navStore.setDashboardTab(dashboardKey, 'bots')
@@ -202,7 +202,7 @@ onMounted(async () => {
   await syncBotFromRoute()
 
   watch(
-    () => route.query.botId,
+    () => [route.query.botId, route.query.bot],
     () => {
       void syncBotFromRoute()
     },

--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -75,7 +75,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from '#app'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useNavStore } from '@/stores/navStore'
 import {
@@ -88,6 +89,7 @@ import {
 
 const dashboardKey: DashboardKey = 'character'
 
+const route = useRoute()
 const characterStore = useCharacterStore()
 const navStore = useNavStore()
 
@@ -151,8 +153,23 @@ async function loadManagerData(force = false) {
   }
 }
 
+function querySelectionId(value: unknown): number | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+async function syncCharacterFromRoute(): Promise<void> {
+  const id = querySelectionId(route.query.characterId)
+  if (!id) return
+
+  navStore.setDashboardTab(dashboardKey, 'characters')
+  await characterStore.selectCharacter(id)
+}
+
 async function refreshManagerData() {
   await loadManagerData(true)
+  await syncCharacterFromRoute()
 }
 
 function goToDefaultTab() {
@@ -161,5 +178,13 @@ function goToDefaultTab() {
 
 onMounted(async () => {
   await loadManagerData()
+  await syncCharacterFromRoute()
+
+  watch(
+    () => route.query.characterId,
+    () => {
+      void syncCharacterFromRoute()
+    },
+  )
 })
 </script>

--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -160,7 +160,7 @@ function querySelectionId(value: unknown): number | null {
 }
 
 async function syncCharacterFromRoute(): Promise<void> {
-  const id = querySelectionId(route.query.characterId)
+  const id = querySelectionId(route.query.characterId ?? route.query.character)
   if (!id) return
 
   navStore.setDashboardTab(dashboardKey, 'characters')
@@ -181,7 +181,7 @@ onMounted(async () => {
   await syncCharacterFromRoute()
 
   watch(
-    () => route.query.characterId,
+    () => [route.query.characterId, route.query.character],
     () => {
       void syncCharacterFromRoute()
     },

--- a/components/wonderlab/component-review-feed.vue
+++ b/components/wonderlab/component-review-feed.vue
@@ -275,15 +275,20 @@ function authorHref(review: PublicComponentReview): string | null {
   if (review.Author?.kind === 'CHARACTER') {
     return `/characters?character=${review.Author.id}`
   }
-
-  // There is not yet a public per-user dashboard route. Do not turn a private or
-  // unresolved publisher identity into a misleading link.
+  if (review.User?.isPublic && review.User.id > 0) {
+    return `/users/${review.User.id}`
+  }
   return null
 }
 
 function authorLinkLabel(review: PublicComponentReview): string {
-  const destination = review.Author?.kind === 'BOT' ? 'Bot Gallery' : 'Character Gallery'
-  return `View ${authorName(review)} in the ${destination}`
+  if (review.Author?.kind === 'BOT') {
+    return `View ${authorName(review)} in the Bot Gallery`
+  }
+  if (review.Author?.kind === 'CHARACTER') {
+    return `View ${authorName(review)} in the Character Gallery`
+  }
+  return `View ${authorName(review)}'s public profile`
 }
 
 function prepareAuthorSelection(review: PublicComponentReview): void {

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -1,0 +1,140 @@
+<!-- /pages/users/[id].vue -->
+<template>
+  <section class="h-full min-h-0 overflow-y-auto p-4 sm:p-6">
+    <div class="mx-auto max-w-2xl">
+      <NuxtLink
+        to="/wonderlab"
+        class="btn btn-ghost btn-sm mb-4 rounded-xl"
+      >
+        <Icon name="kind-icon:arrow-left" class="size-4" />
+        Back to WonderLab
+      </NuxtLink>
+
+      <article
+        v-if="user"
+        class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg"
+      >
+        <div class="h-28 bg-linear-to-br from-primary/25 via-secondary/15 to-accent/20" />
+        <div class="px-5 pb-6 sm:px-8">
+          <div
+            class="-mt-14 flex size-28 items-center justify-center overflow-hidden rounded-3xl border-4 border-base-100 bg-base-200 shadow-md"
+          >
+            <img
+              v-if="user.avatarImage"
+              :src="normalizeImagePath(user.avatarImage)"
+              :alt="displayName"
+              class="h-full w-full object-cover"
+            />
+            <Icon v-else name="kind-icon:user" class="size-12 text-primary/60" />
+          </div>
+
+          <div class="mt-4 flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0">
+              <p class="text-xs font-black uppercase tracking-widest text-primary">
+                Public Kind Robots profile
+              </p>
+              <h1 class="mt-1 break-words text-3xl font-black">
+                {{ displayName }}
+              </h1>
+              <p
+                v-if="user.username"
+                class="mt-1 text-sm font-semibold text-base-content/55"
+              >
+                @{{ user.username }}
+              </p>
+            </div>
+            <span v-if="user.Role" class="badge badge-outline rounded-xl">
+              {{ formatRole(user.Role) }}
+            </span>
+          </div>
+
+          <p class="mt-5 rounded-2xl bg-base-200/70 p-4 text-sm leading-relaxed text-base-content/70">
+            This member has chosen to make their Kind Robots profile public.
+          </p>
+        </div>
+      </article>
+
+      <div
+        v-else-if="status === 'pending'"
+        class="flex min-h-64 items-center justify-center rounded-3xl border border-base-300 bg-base-100"
+      >
+        <span class="loading loading-spinner loading-lg text-primary" />
+      </div>
+
+      <div
+        v-else
+        class="flex min-h-64 flex-col items-center justify-center gap-3 rounded-3xl border border-warning/40 bg-warning/5 p-6 text-center"
+      >
+        <Icon name="kind-icon:user" class="size-12 text-warning" />
+        <h1 class="text-xl font-black">Public profile unavailable</h1>
+        <p class="max-w-md text-sm text-base-content/65">
+          {{ errorMessage }}
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from '#app'
+
+type PublicUser = {
+  id: number
+  username: string | null
+  name: string | null
+  avatarImage: string | null
+  artImageId: number | null
+  designerName: string | null
+  Role: string | null
+  isPublic: boolean
+}
+
+type PublicUserResponse = {
+  success: boolean
+  data?: PublicUser
+  message: string
+  statusCode?: number
+}
+
+const route = useRoute()
+const userId = computed(() => {
+  const raw = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id
+  const parsed = Number(raw)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0
+})
+
+const { data, status } = await useFetch<PublicUserResponse>(
+  () => `/api/users/public/${userId.value}`,
+  {
+    key: () => `public-user:${userId.value}`,
+    watch: [userId],
+  },
+)
+
+const user = computed(() => (data.value?.success ? data.value.data ?? null : null))
+const displayName = computed(
+  () =>
+    user.value?.designerName?.trim() ||
+    user.value?.name?.trim() ||
+    user.value?.username?.trim() ||
+    'Kind Robots member',
+)
+const errorMessage = computed(
+  () => data.value?.message || 'This profile is private or does not exist.',
+)
+
+useSeoMeta({
+  title: () => `${displayName.value} · Kind Robots`,
+  description: () => `Public Kind Robots profile for ${displayName.value}.`,
+})
+
+function normalizeImagePath(value: string): string {
+  if (value.startsWith('/') || value.startsWith('http')) return value
+  return `/images/${value}`
+}
+
+function formatRole(role: string): string {
+  return role.charAt(0).toUpperCase() + role.slice(1).toLowerCase()
+}
+</script>

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -103,11 +103,12 @@ const userId = computed(() => {
   const parsed = Number(raw)
   return Number.isInteger(parsed) && parsed > 0 ? parsed : 0
 })
+const asyncKey = computed(() => `public-user:${userId.value}`)
 
-const { data, status } = await useFetch<PublicUserResponse>(
-  () => `/api/users/public/${userId.value}`,
+const { data, status } = await useAsyncData<PublicUserResponse>(
+  asyncKey,
+  () => $fetch<PublicUserResponse>(`/api/users/public/${userId.value}` as string),
   {
-    key: () => `public-user:${userId.value}`,
     watch: [userId],
   },
 )

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -107,7 +107,7 @@ const asyncKey = computed(() => `public-user:${userId.value}`)
 
 const { data, status } = await useAsyncData<PublicUserResponse>(
   asyncKey,
-  () => $fetch<PublicUserResponse>(`/api/users/public/${userId.value}` as string),
+  () => $fetch<PublicUserResponse, string>(`/api/users/public/${userId.value}`),
   {
     watch: [userId],
   },

--- a/server/api/users/public/[id].get.ts
+++ b/server/api/users/public/[id].get.ts
@@ -13,28 +13,34 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const user = await prisma.user.findUnique({
-      where: { id },
+    const user = await prisma.user.findFirst({
+      where: {
+        id,
+        isPublic: true,
+      },
       select: {
         id: true,
         username: true,
+        name: true,
         avatarImage: true,
         artImageId: true,
         designerName: true,
+        Role: true,
+        isPublic: true,
       },
     })
 
     if (!user) {
       return errorHandler({
         statusCode: 404,
-        message: 'User not found.',
+        message: 'Public user profile not found.',
       })
     }
 
     return {
       success: true,
       data: user,
-      message: 'User found.',
+      message: 'Public user found.',
     }
   } catch (error) {
     return errorHandler(error)

--- a/utils/scripts/verifyReviewDraftPublication.ts
+++ b/utils/scripts/verifyReviewDraftPublication.ts
@@ -10,6 +10,8 @@ const revisionEndpointPath =
   'server/api/admin/wonderlab/review-drafts/[id]/revise.patch.ts'
 const componentReviewsPath = 'server/api/reactions/component/[id].get.ts'
 const componentFeedPath = 'components/wonderlab/component-review-feed.vue'
+const botManagerPath = 'components/bots/bot-manager.vue'
+const characterManagerPath = 'components/characters/character-manager.vue'
 const publicUserEndpointPath = 'server/api/users/public/[id].get.ts'
 const publicUserPagePath = 'pages/users/[id].vue'
 
@@ -19,6 +21,8 @@ const revisionService = await readFile(revisionServicePath, 'utf8')
 const revisionEndpoint = await readFile(revisionEndpointPath, 'utf8')
 const componentReviews = await readFile(componentReviewsPath, 'utf8')
 const componentFeed = await readFile(componentFeedPath, 'utf8')
+const botManager = await readFile(botManagerPath, 'utf8')
+const characterManager = await readFile(characterManagerPath, 'utf8')
 const publicUserEndpoint = await readFile(publicUserEndpointPath, 'utf8')
 const publicUserPage = await readFile(publicUserPagePath, 'utf8')
 const ordinaryPost = await readFile('server/api/reactions/index.post.ts', 'utf8')
@@ -77,6 +81,10 @@ assert.match(componentFeed, /`\/characters\?character=\$\{review\.Author\.id\}`/
 assert.match(componentFeed, /`\/users\/\$\{review\.User\.id\}`/)
 assert.match(componentFeed, /review\.User\?\.isPublic/)
 assert.match(componentFeed, /prepareAuthorSelection/)
+assert.match(botManager, /route\.query\.botId \?\? route\.query\.bot/)
+assert.match(botManager, /await botStore\.selectBot\(id\)/)
+assert.match(characterManager, /route\.query\.characterId \?\? route\.query\.character/)
+assert.match(characterManager, /await characterStore\.selectCharacter\(id\)/)
 
 assert.match(publicUserEndpoint, /isPublic:\s*true/)
 assert.match(publicUserEndpoint, /Public user profile not found/)

--- a/utils/scripts/verifyReviewDraftPublication.ts
+++ b/utils/scripts/verifyReviewDraftPublication.ts
@@ -10,6 +10,8 @@ const revisionEndpointPath =
   'server/api/admin/wonderlab/review-drafts/[id]/revise.patch.ts'
 const componentReviewsPath = 'server/api/reactions/component/[id].get.ts'
 const componentFeedPath = 'components/wonderlab/component-review-feed.vue'
+const publicUserEndpointPath = 'server/api/users/public/[id].get.ts'
+const publicUserPagePath = 'pages/users/[id].vue'
 
 const publisher = await readFile(publisherPath, 'utf8')
 const endpoint = await readFile(endpointPath, 'utf8')
@@ -17,6 +19,8 @@ const revisionService = await readFile(revisionServicePath, 'utf8')
 const revisionEndpoint = await readFile(revisionEndpointPath, 'utf8')
 const componentReviews = await readFile(componentReviewsPath, 'utf8')
 const componentFeed = await readFile(componentFeedPath, 'utf8')
+const publicUserEndpoint = await readFile(publicUserEndpointPath, 'utf8')
+const publicUserPage = await readFile(publicUserPagePath, 'utf8')
 const ordinaryPost = await readFile('server/api/reactions/index.post.ts', 'utf8')
 
 assert.match(endpoint, /requireAdminApiUser\(event\)/)
@@ -70,9 +74,16 @@ assert.match(componentFeed, /First-party \{\{ review\.Author\.kind\.toLowerCase\
 assert.match(componentFeed, /<NuxtLink/)
 assert.match(componentFeed, /`\/bots\?bot=\$\{review\.Author\.id\}`/)
 assert.match(componentFeed, /`\/characters\?character=\$\{review\.Author\.id\}`/)
+assert.match(componentFeed, /`\/users\/\$\{review\.User\.id\}`/)
+assert.match(componentFeed, /review\.User\?\.isPublic/)
 assert.match(componentFeed, /prepareAuthorSelection/)
+
+assert.match(publicUserEndpoint, /isPublic:\s*true/)
+assert.match(publicUserEndpoint, /Public user profile not found/)
+assert.match(publicUserPage, /\/api\/users\/public\/\$\{userId\.value\}/)
+assert.match(publicUserPage, /Public Kind Robots profile/)
 
 assert.doesNotMatch(ordinaryPost, /authorBotId/)
 assert.doesNotMatch(ordinaryPost, /authorCharacterId/)
 
-console.log('Review draft publication and revision contract passed.')
+console.log('Review draft publication, revision, and author-link contract passed.')


### PR DESCRIPTION
## Summary

Completes the review-author navigation requirement for human reviewers.

- adds a public `/users/:id` profile page;
- restricts the public-user API to accounts with `isPublic = true`;
- links both the avatar and author name of a public human review to that profile;
- keeps private or unavailable human identities as plain text;
- preserves the existing Bot and Character gallery links and keyboard-visible focus treatment.

## Safety

The public profile exposes only already-public identity fields and refuses private accounts. No review, publisher, or friendship data is changed.

Refs #582.