### PR TITLE
[ai-art-academy/t-010 lane 1] Fix dead loading-spinner overlay in art-styler starter picker

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1114,6 +1114,15 @@ async function selectStarterEntry(entry: StarterEntry): Promise<void> {
   successMessage.value = ''
   resultImage.value = null
   isLoadingStarterImage.value = true
+  // Mark this entry selected immediately, not after the fetch resolves --
+  // the template's overlay (spinner while loading, checkmark once done) is
+  // gated on `selectedStarterFile === entry.file`. Setting it only on
+  // success meant it flipped true in the same synchronous tick as
+  // isLoadingStarterImage flipping back to false, so Vue only ever
+  // rendered the "done" state and the loading spinner branch never
+  // painted a frame -- clicking a starter gave no visual feedback beyond
+  // the (identical-looking) disabled state on every thumbnail.
+  selectedStarterFile.value = entry.file
 
   try {
     const response = await fetch(starterImageSrc(entry))
@@ -1131,10 +1140,14 @@ async function selectStarterEntry(entry: StarterEntry): Promise<void> {
       `${entry.workTitle} — ${entry.artist}`,
       blob.type || 'image/jpeg',
     )
-    selectedStarterFile.value = entry.file
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : 'Could not load starter image.'
+    // Roll back the optimistic selection so a failed load doesn't leave a
+    // checkmark on a thumbnail that was never actually applied as source.
+    if (selectedStarterFile.value === entry.file) {
+      selectedStarterFile.value = null
+    }
   } finally {
     isLoadingStarterImage.value = false
   }


### PR DESCRIPTION
## What was the bug

In `components/art/art-styler.vue`, the "Starters" source tab lets a user pick a public-domain starter image to remix. Each thumbnail button has an overlay gated on `selectedStarterFile === entry.file` that's meant to show a spinner while that specific starter image is being fetched/loaded, then a checkmark once it's done:

```html
<div v-if="selectedStarterFile === entry.file" ...>
  <Icon v-if="!isLoadingStarterImage" name="mdi:check-circle" ... />
  <span v-else class="loading loading-spinner loading-sm ..." />
</div>
```

`selectStarterEntry()`, however, only set `selectedStarterFile.value = entry.file` **after** the fetch succeeded — in the same synchronous block of statements as the `finally { isLoadingStarterImage.value = false }` that follows it. Since there's no `await` between those two assignments, Vue's reactivity batches them into a single render flush. The result: `selectedStarterFile === entry.file` and `isLoadingStarterImage === false` become true in the same tick, so the DOM only ever renders the "done" (checkmark) state — the loading-spinner branch never gets a frame to paint.

**Concrete failure scenario**: a user on a slow connection clicks a starter thumbnail to load it as their remix source. Every thumbnail in the grid gets disabled (existing `:disabled="isLoadingStarterImage"` behavior, unaffected), but nothing distinguishes *which* thumbnail they clicked — the intended per-item spinner overlay silently never renders — until the fetch resolves and the checkmark just appears with no prior loading indication. This code path (and its now-dead spinner branch) has existed unchanged since it was introduced in #366 and survived every subsequent front-end polish cycle on this file.

## The fix

Set `selectedStarterFile.value = entry.file` immediately when the user clicks, before the fetch starts, so the overlay (and its spinner) actually renders during the load. On failure, roll the selection back to `null` in the `catch` block so a failed load doesn't leave a false checkmark on a thumbnail that was never actually applied as the source image.

Narrowly scoped — only `selectStarterEntry()` in this one file was touched; no template changes, no unrelated cleanup.

## Verification

- `npx eslint components/art/art-styler.vue` — clean, no output.
- `npx prettier --check components/art/art-styler.vue` — `All matched files use Prettier code style!`
- `npm run test` (full-project `vue-tsc --noEmit`) — exited 0, no type errors.

## Out of scope / not touched

Read all in-scope Academy surface files in full (`components/academy/*.vue`, `stores/academyStore.ts`, `stores/helpers/styleHelper.ts`, `stores/seeds/academyStyles.ts`, `components/art/art-styler.vue`, `components/art/image-upload.vue`) and ruled out re-hitting any previously-fixed bug class (upload MIME validation, queue-splice-on-retry, success-banner-clear ordering, missing-checkmark nextTick, drop/browse MIME parity, placeholder-image-path fallback, gallery-selection race token, `:key` on `academy-style-detail`, focus-management, aria wiring). No other new bug found this cycle.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVqGB4THmRkJr57ykmwZw5)_