### PR TITLE
[wonderlab-editorial-batch] Plan flavor rollout 042 for six new Components

### DIFF
--- a/.github/workflows/wonderlab-curation-inventory.yml
+++ b/.github/workflows/wonderlab-curation-inventory.yml
@@ -57,7 +57,8 @@ jobs:
           for (const token of forbidden) {
             assert.ok(!workflow.includes(token), `inventory crossed write boundary: ${token}`)
           }
-          assert.ok(Array.isArray(config.expectedTargets) && config.expectedTargets.length > 0)
+          assert.ok(Array.isArray(config.expectedTargets))
+          assert.ok(config.execute === false || config.expectedTargets.length > 0)
           assert.match(config.minimumProductionCommit, /^[0-9a-f]{40}$/)
           console.log('WonderLab curation inventory boundary passed.')
           NODE

--- a/config/wonderlab-editorial-batch.json
+++ b/config/wonderlab-editorial-batch.json
@@ -1,20 +1,13 @@
 {
   "version": 1,
-  "batchId": "wonderlab-source-grounded-rollout-041",
-  "execute": true,
-  "minimumProductionCommit": "78dab9d3669f6a4e44dd497b08e15bdf89a0d389",
-  "componentIds": [2067, 2068, 2070],
-  "limit": 3,
+  "batchId": "wonderlab-flavor-rollout-042",
+  "execute": false,
+  "minimumProductionCommit": "cc0b0ebf0067495b8746dcb29b4892bfc6718935",
+  "componentIds": [2177, 2178, 2179, 2180, 2181, 2182],
+  "limit": 6,
   "reviewersPerComponent": 2,
   "minimumScore": 0,
   "model": "gpt-4o-mini",
   "regenerate": false,
-  "expectedTargets": [
-    { "componentId": 2067, "kind": "CHARACTER", "id": 176 },
-    { "componentId": 2067, "kind": "BOT", "id": 428 },
-    { "componentId": 2068, "kind": "CHARACTER", "id": 1025 },
-    { "componentId": 2068, "kind": "BOT", "id": 420 },
-    { "componentId": 2070, "kind": "CHARACTER", "id": 204 },
-    { "componentId": 2070, "kind": "BOT", "id": 404 }
-  ]
+  "expectedTargets": []
 }


### PR DESCRIPTION
## Scope

Plan deterministic first-party assignments for the six canonical Components created by the latest reconciliation:

- animation-manager (#2177)
- magnetic-sand-garden (#2178)
- paper-lantern-weather (#2179)
- stained-glass-rain (#2180)
- watchlist-browse (#2181)
- watchlist-entry-detail (#2182)

This is a **dry-run planning pass** (`execute: false`). It will select two reviewers per Component and post the exact proposed author assignments to #582. It will not generate, approve, revise, or publish any commentary.

The follow-up execution manifest will lock these assignments and use the new editorial direction: stars carry evaluation; text is deliberately varied personality flavor.