### PR TITLE
sketchy: fix invalid tutorialChannels key, add tutorial section, real preview

### DIFF
--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -2,25 +2,132 @@
 <template>
   <ProjectFrontPage slug="sketchy" :fallback="config">
     <template #interactive>
-      <ProjectPitchBoard
-        slug="sketchy"
-        noun="assignment"
-        title="Your sketch assignments"
-        icon="kind-icon:pencil"
-        body-placeholder="Draft a drawing assignment — subject, constraint, time limit."
-        empty-text="No assignments yet. Give yourself the first prompt."
-      />
+      <section
+        class="flex flex-col items-start gap-3 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+      >
+        <div class="flex items-center gap-2">
+          <Icon name="kind-icon:pencil" class="size-5 text-primary" />
+          <h3
+            class="text-sm font-black uppercase tracking-wide text-base-content/70"
+          >
+            Try today's assignment
+          </h3>
+        </div>
+        <p class="text-sm text-base-content/70">
+          Sketchy hands you a tier-appropriate drawing prompt, then critiques
+          the result on five dimensions and picks your next study. Preview a
+          sample from each skill tier below.
+        </p>
+
+        <div class="flex flex-wrap gap-2" role="tablist">
+          <button
+            v-for="tier in skillTiers"
+            :key="tier.key"
+            type="button"
+            role="tab"
+            :aria-selected="activeTier === tier.key"
+            class="btn btn-sm rounded-2xl"
+            :class="
+              activeTier === tier.key
+                ? 'btn-primary'
+                : 'btn-ghost border border-base-300'
+            "
+            @click="activeTier = tier.key"
+          >
+            {{ tier.label }}
+          </button>
+        </div>
+
+        <div
+          class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/60 p-4"
+        >
+          <p class="text-sm font-semibold text-base-content">
+            {{ activeSample.prompt }}
+          </p>
+          <p class="text-xs text-base-content/60">
+            {{ activeSample.window }} · Fundamentals
+          </p>
+          <div class="flex flex-wrap gap-1.5 pt-1">
+            <span
+              v-for="dim in activeSample.scoredDimensions"
+              :key="dim"
+              class="badge badge-sm badge-primary badge-outline rounded-xl"
+            >
+              {{ dim }}
+            </span>
+            <span
+              v-for="dim in activeSample.sometimesDimensions"
+              :key="dim"
+              class="badge badge-sm badge-ghost rounded-xl"
+            >
+              {{ dim }} (sometimes)
+            </span>
+          </div>
+        </div>
+
+        <p class="text-xs text-base-content/50">
+          The full assignment engine and AI critique loop are in active
+          development — this preview mirrors the real skill ladder and rubric.
+        </p>
+      </section>
     </template>
   </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
+
+type SkillTierKey = 'beginner' | 'intermediate' | 'advanced'
+
+// Fundamentals-category samples pulled verbatim from
+// projects/sketchy/SKILL-LADDER.md; dimension applicability from
+// projects/sketchy/CRITIQUE-RUBRIC.md §2 ("Fundamentals" row).
+const skillTiers: { key: SkillTierKey; label: string }[] = [
+  { key: 'beginner', label: 'Beginner' },
+  { key: 'intermediate', label: 'Intermediate' },
+  { key: 'advanced', label: 'Advanced' },
+]
+
+const samplesByTier: Record<
+  SkillTierKey,
+  {
+    prompt: string
+    window: string
+    scoredDimensions: string[]
+    sometimesDimensions: string[]
+  }
+> = {
+  beginner: {
+    prompt:
+      'Draw 10 straight lines, 10 curves, and 10 ellipses; circle the cleanest three of each.',
+    window: '5–20 min',
+    scoredDimensions: ['Construction', 'Proportions', 'Line quality'],
+    sometimesDimensions: ['Value', 'Observation'],
+  },
+  intermediate: {
+    prompt:
+      'Draw a pair of shoes using simplified boxes and cylinders before adding contour.',
+    window: '20–60 min',
+    scoredDimensions: ['Construction', 'Proportions', 'Line quality'],
+    sometimesDimensions: ['Value', 'Observation'],
+  },
+  advanced: {
+    prompt:
+      'Build a complex prop, such as a bicycle or coffee grinder, from major forms first.',
+    window: '45–120 min',
+    scoredDimensions: ['Construction', 'Proportions', 'Line quality'],
+    sometimesDimensions: ['Value', 'Observation'],
+  },
+}
+
+const activeTier = ref<SkillTierKey>('beginner')
+const activeSample = computed(() => samplesByTier[activeTier.value])
 
 const config: ProjectFrontConfig = {
   slug: 'sketchy',
   title: 'Sketchy',
-  channelKey: 'academy',
+  channelKey: 'wonder',
   tabKey: 'sketchy',
   icon: 'kind-icon:pencil',
   tagline: 'Show up, fill the page, get a little better.',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -620,6 +620,12 @@ export const tutorialChannels = {
         body: 'The voice frontier: an Alexa skill and local relay that let Serendipity and friends speak and listen. Watch the relay status and learn how to plug in.',
         image: tutorialImage('wonder', 'voice-lab'),
       },
+      {
+        key: 'sketchy',
+        title: 'Sketchy',
+        body: 'A drawing-habit studio: a tier-appropriate assignment, a timer, and kind AI critique that turns "I can\'t draw" into a stack of finished pages.',
+        image: tutorialImage('wonder', 'sketchy'),
+      },
     ],
   },
 } as const satisfies Record<TutorialChannelKey, TutorialChannel>
@@ -645,6 +651,7 @@ const tutorialRouteMap = {
     '/watchlist',
     '/ruler-hooked',
     '/voice-lab',
+    '/sketchy',
   ],
 } as const satisfies Record<TutorialChannelKey, string | readonly string[]>
 


### PR DESCRIPTION
### Task
conductor/sketchy/t-007: Polish and upgrade Sketchy front-end surface (kind: software)

### What changed / what I produced
- Fixed `sketchy-page.vue`'s `ProjectFrontConfig.channelKey`, which was `'academy'` — a value that does not exist anywhere in `stores/helpers/tutorialCards.ts`'s `TutorialChannelKey` union. (`'academy'` *is* a real key, but in the separate `dashboardHelper.ts` dashboard-tab system, for the unrelated Art Academy dashboard — that's where the mix-up came from.) Sketchy's content lives in `content/channels/lab/sketchy.md` alongside davinci, watchlist, ruler-hooked, and voice-lab, which all correctly use tutorialChannels key `'wonder'` — corrected sketchy to match.
- Added the missing `'sketchy'` section under `tutorialChannels.wonder.sections` and the `/sketchy` entry in the `wonder` tutorial route map.
- Replaced the `#interactive` slot's generic `ProjectPitchBoard` (a user-submitted-pitch board that doesn't match Sketchy's actual product — an AI-assigned drawing prompt, not a user draft board) with a tier-selectable sample-assignment preview. Content is pulled verbatim from `projects/sketchy/SKILL-LADDER.md` (Fundamentals-category samples per tier) and `projects/sketchy/CRITIQUE-RUBRIC.md` §2 (applicable critique dimensions). No backend/API exists yet for a live version (see sketchy/t-008's explicit scope note), so this is an honest static preview, not a placeholder pretending to be more.

### How I verified
- `npx eslint` on both changed files: clean.
- `npx prettier --check`: clean (auto-formatted once).
- `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`): exit 0, no errors.

### Stakes
reversible

### Flags for Reviewer
- Dashboard-tab art (`dashboard-tabs/academy/sketchy.webp`) already had a pending art-prompts.yaml request from an earlier cycle — left as-is (that path is correct, dashboardKey `academy` is real). Added a new tutorial-art request (`tutorials/wonder/sketchy.webp`, id `kind-robots-sketchy-tutorial-a3f0e6c2`) in the conductor repo's `art-prompts.yaml` since the old one didn't exist under the corrected path. Queued a live consume via `consume_art_requests.py --live` this session; the art-generation relay was still slow/unresponsive (consistent with every other project's finding today) so the job may still be pending — no code depends on the image existing (graceful placeholder fallback).
- Step (3) (verify/backfill the Project's `liveUrl`/`channelKey`/`tabKey` via the admin Placements button) is an admin-only action, not independently doable from this session.

### Kaizen suggestion
`utils/scripts/verifyChannelResolver.ts` (or a new lightweight script) could assert that every `components/conductor/*-page.vue`'s `ProjectFrontConfig.channelKey` is a real `TutorialChannelKey`, so a typo like this fails CI instead of silently producing a channel-less tutorial entry.

### Notes for reviewer
conductor roadmap task set to `status: review` alongside this PR; will flip to `done` after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VUrPQN2UiPiBUBdJUhSwCY)_