### PR TITLE
art-styler.vue: fix cross-tab source-selection race condition

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -860,7 +860,12 @@ const isDragging = ref(false)
 const gallerySearch = ref('')
 const galleryThumbs = ref<Record<number, string>>({})
 const isLoadingGallery = ref(false)
-let gallerySelectionToken = 0
+// Shared across all three source tabs (upload/gallery/starters), not just
+// gallery-to-gallery: an in-flight starter or upload read can otherwise
+// resolve after a later selection on a different tab and silently overwrite
+// it, since each tab's own async load has no way to know a newer pick
+// happened elsewhere in the meantime.
+let sourceSelectionToken = 0
 
 const starterEntries = ref<StarterEntry[]>([])
 const isLoadingStarters = ref(false)
@@ -1059,9 +1064,12 @@ function buildSyntheticSourceImage(
 }
 
 function processUploadedFile(file: File) {
+  const token = ++sourceSelectionToken
   const reader = new FileReader()
 
   reader.onload = (event) => {
+    if (token !== sourceSelectionToken) return
+
     const dataUrl = event.target?.result as string
 
     uploadedImageData.value = dataUrl
@@ -1123,6 +1131,7 @@ async function selectStarterEntry(entry: StarterEntry): Promise<void> {
   // painted a frame -- clicking a starter gave no visual feedback beyond
   // the (identical-looking) disabled state on every thumbnail.
   selectedStarterFile.value = entry.file
+  const token = ++sourceSelectionToken
 
   try {
     const response = await fetch(starterImageSrc(entry))
@@ -1134,6 +1143,11 @@ async function selectStarterEntry(entry: StarterEntry): Promise<void> {
       reader.readAsDataURL(blob)
     })
 
+    // A later selection on any tab (upload, gallery, or another starter)
+    // may have already claimed a newer token while this fetch was in
+    // flight -- don't let a slow-but-successful load clobber it.
+    if (token !== sourceSelectionToken) return
+
     uploadedImageData.value = dataUrl
     selectedSourceImage.value = buildSyntheticSourceImage(
       dataUrl,
@@ -1141,6 +1155,8 @@ async function selectStarterEntry(entry: StarterEntry): Promise<void> {
       blob.type || 'image/jpeg',
     )
   } catch (error) {
+    if (token !== sourceSelectionToken) return
+
     errorMessage.value =
       error instanceof Error ? error.message : 'Could not load starter image.'
     // Roll back the optimistic selection so a failed load doesn't leave a
@@ -1149,6 +1165,10 @@ async function selectStarterEntry(entry: StarterEntry): Promise<void> {
       selectedStarterFile.value = null
     }
   } finally {
+    // Always clear the loading flag regardless of token: it gates every
+    // starter thumbnail's disabled state (see template), and nothing else
+    // resets it once this fetch settles -- leaving it true after a stale
+    // race would strand every starter thumbnail disabled.
     isLoadingStarterImage.value = false
   }
 }
@@ -1160,7 +1180,7 @@ async function selectGalleryImage(image: ArtImage) {
   successMessage.value = ''
   selectedStarterFile.value = null
 
-  const token = ++gallerySelectionToken
+  const token = ++sourceSelectionToken
 
   if (galleryThumbs.value[image.id]) {
     selectedSourceImage.value = image
@@ -1173,7 +1193,7 @@ async function selectGalleryImage(image: ArtImage) {
       includeThumbnailData: true,
     })
 
-    if (token !== gallerySelectionToken) return
+    if (token !== sourceSelectionToken) return
 
     if (fetched) {
       const hydrated = fetched as ArtImage & { thumbnailData?: string | null }
@@ -1190,7 +1210,7 @@ async function selectGalleryImage(image: ArtImage) {
       selectedSourceImage.value = image
     }
   } catch {
-    if (token === gallerySelectionToken) {
+    if (token === sourceSelectionToken) {
       selectedSourceImage.value = image
     }
   }


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor): Academy continuous improvement pass — lane 1 (front-end polish). (kind: software)

### What changed / what I produced
- `components/art/art-styler.vue`: widened the existing `gallerySelectionToken` guard (previously only protecting gallery-to-gallery races) into a single `sourceSelectionToken` shared by all three source-selection paths — `processUploadedFile()`, `selectStarterEntry()`, and `selectGalleryImage()`.
- Bug: the source-tab buttons and gallery thumbnails are never disabled while a starter image is loading, so a user can click a starter thumbnail (slow fetch begins), switch to the Gallery or Upload tab, and pick a different image before the starter fetch resolves. `selectStarterEntry()`'s success path previously wrote `uploadedImageData`/`selectedSourceImage` unconditionally, silently overwriting the newer selection with the stale starter image once the slow fetch finally completed.
- Fix mirrors the pattern already used for gallery-to-gallery races: each selection path claims a fresh token up front, and only applies its async result if it still holds the current token. Also fixed a related issue I introduced and caught in review: `isLoadingStarterImage` (which disables *every* starter thumbnail via `:disabled="isLoadingStarterImage"` in the template) must always clear in `finally` regardless of token — gating it on the token would strand all starter thumbnails permanently disabled after a stale race.

### How I verified
- `npx eslint components/art/art-styler.vue` — clean
- `npx prettier --check components/art/art-styler.vue` — clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0, both before and after rebasing onto latest `main`
- Traced the two affected UI states by reading the template's bindings for `selectedStarterFile`/`isLoadingStarterImage`/`selectedSourceImage` to confirm the finally-block fix doesn't leave starter thumbnails stuck disabled

### Stakes
reversible

### Flags for Reviewer
- None — self-contained race-condition fix, no API/schema changes, no live generation involved.

### Kaizen suggestion
The `art-styler.vue` source-selection race-condition class (this is the second instance found, after the earlier gallery-only fix) suggests a small shared composable (e.g. `useLatestSelection()`) could generalize the "only apply the result of the most recent async selection" pattern instead of hand-rolling a token per call site — worth considering if a third instance turns up.

### Notes for reviewer
Found via a full-file Explore-agent read of every in-scope Academy front-end file (art-styler.vue, image-upload.vue, all components/academy/*.vue, academyStore.ts, styleHelper.ts, academyStyles.ts), cross-checked against the exclusion list of ~15 prior continuous-improvement-pass fixes in `projects/ai-art-academy/docs/continuous-improvement-checklist.md` (conductor repo) to confirm this is a new bug class, not a rediscovery.


---
_Generated by [Claude Code](https://claude.ai/code/session_015TXqtaJ9yuPMyYJbR8zxVM)_