### PR TITLE
model-builder: fix cross-field textarea clobbering in item panel

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -329,13 +329,25 @@ const fields = ref(item.value?.fieldsDraft ?? '')
 const prompt = ref(item.value?.promptDraft ?? '')
 
 // Keep the textareas in sync when the store's draft fields change under us —
-// e.g. an AI draft writes into the item.
+// e.g. an AI draft writes into the item. Watched per-field (not as one combined
+// array) so a draft/update landing on one field doesn't clobber unsaved edits
+// the user is mid-typing in the other two textareas of the same item.
 watch(
-  () => [item.value?.pitch, item.value?.fieldsDraft, item.value?.promptDraft],
-  () => {
-    pitch.value = item.value?.pitch ?? ''
-    fields.value = item.value?.fieldsDraft ?? ''
-    prompt.value = item.value?.promptDraft ?? ''
+  () => item.value?.pitch,
+  (value) => {
+    pitch.value = value ?? ''
+  },
+)
+watch(
+  () => item.value?.fieldsDraft,
+  (value) => {
+    fields.value = value ?? ''
+  },
+)
+watch(
+  () => item.value?.promptDraft,
+  (value) => {
+    prompt.value = value ?? ''
   },
 )
 


### PR DESCRIPTION
## Summary
- `model-builder-item-panel.vue` synced its three local textarea refs (`pitch`, `fields`, `prompt`) with one combined `watch` over all three store values.
- Any single-field AI draft (or auto-build's sequential per-field drafting) resolving for *one* field reset **all three** local refs to the store's last-persisted values — silently discarding unsaved edits the user was mid-typing in the *other* two textareas of the same item.
- Fixed by splitting into three independent per-field watches, so each only reacts to its own store value.

Related to the conductor roadmap task `model-builder/t-029` ("Polish and upgrade Model Builder front-end surface"), continuing the pattern from PRs #671 and #735 of finding and fixing real gaps in the interactive build experience.

## Test plan
- [x] `npx eslint components/model-builder/model-builder-item-panel.vue` — clean
- [x] `npm run test` (vue-tsc --noEmit) — passes
- [x] `npx prettier --check` on the file shows pre-existing drift unrelated to this change (confirmed via `git stash` — same warning without the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D16dadrTwWin7oEePhFKS


---
_Generated by [Claude Code](https://claude.ai/code/session_016D16dadrTwWin7oEePhFKS)_