### PR TITLE
WonderLab: capture definitive full commentary corpus

### DIFF
--- a/.github/workflows/wonderlab-definitive-inventory.yml
+++ b/.github/workflows/wonderlab-definitive-inventory.yml
@@ -1,0 +1,84 @@
+name: WonderLab Definitive Commentary Inventory
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-definitive-inventory.yml'
+      - 'scripts/wonderlab-definitive-inventory.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-definitive-inventory.yml'
+      - 'scripts/wonderlab-definitive-inventory.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: wonderlab-definitive-inventory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node --check scripts/wonderlab-definitive-inventory.mjs
+
+  inventory:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Capture canonical production corpus
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_DEFINITIVE_OUTPUT: wonderlab-definitive-artifacts
+        run: node scripts/wonderlab-definitive-inventory.mjs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wonderlab-definitive-inventory-${{ github.run_id }}
+          path: wonderlab-definitive-artifacts
+          retention-days: 30
+      - name: Post inventory status to initiative
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: wonderlab-definitive-artifacts/wonderlab-definitive-inventory.md
+        with:
+          script: |
+            const fs = require('node:fs')
+            const marker = '<!-- WONDERLAB_DEFINITIVE_INVENTORY -->'
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8')
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const body = `${marker}\n${report}\n- **Workflow:** [run ${context.runId}](${runUrl})`
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 1013,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: 1013,
+                body,
+              })
+            }

--- a/scripts/wonderlab-definitive-inventory.mjs
+++ b/scripts/wonderlab-definitive-inventory.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const baseUrl = String(process.env.WONDERLAB_BASE_URL || 'https://kind-robots.vercel.app').replace(/\/$/, '')
+const token = String(process.env.WONDERLAB_ADMIN_TOKEN || '').trim()
+const outputDir = resolve(process.env.WONDERLAB_DEFINITIVE_OUTPUT || 'wonderlab-definitive-artifacts')
+const concurrency = Math.min(20, Math.max(1, Number(process.env.WONDERLAB_DEFINITIVE_CONCURRENCY || 12)))
+
+if (!token) throw new Error('WONDERLAB_ADMIN_TOKEN is required.')
+
+function sha256(value) {
+  return createHash('sha256').update(String(value ?? '')).digest('hex')
+}
+
+async function request(path, { admin = false, allowNotFound = false } = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: admin
+      ? { accept: 'application/json', 'x-beta-admin-token': token, 'x-admin-token': token, 'x-api-key': token }
+      : { accept: 'application/json' },
+  })
+  if (allowNotFound && response.status === 404) return null
+  const body = await response.json().catch(() => null)
+  if (!response.ok) throw new Error(body?.message || `${path} returned ${response.status}.`)
+  return body?.data ?? body
+}
+
+async function mapConcurrent(values, worker, limit) {
+  const output = new Array(values.length)
+  let cursor = 0
+  async function consume() {
+    while (cursor < values.length) {
+      const index = cursor++
+      output[index] = await worker(values[index], index)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, consume))
+  return output
+}
+
+function authorProfilePath(author) {
+  return author.kind === 'BOT' ? `/api/bots/${author.id}` : `/api/characters/${author.id}`
+}
+
+const [version, components, newestPublished] = await Promise.all([
+  request('/api/version'),
+  request('/api/components'),
+  request('/api/admin/wonderlab/review-drafts?status=PUBLISHED&limit=200', { admin: true }),
+])
+
+const highestDraftId = Math.max(0, ...newestPublished.map((draft) => Number(draft.id) || 0))
+if (!highestDraftId) throw new Error('No published WonderLab ReviewDrafts were found.')
+
+const draftIds = Array.from({ length: highestDraftId }, (_, index) => index + 1)
+const scanned = await mapConcurrent(
+  draftIds,
+  (id) => request(`/api/admin/wonderlab/review-drafts/${id}`, { admin: true, allowNotFound: true }),
+  concurrency,
+)
+
+const publishedDrafts = scanned
+  .filter((draft) => draft?.status === 'PUBLISHED' && Number(draft?.publishedReactionId) > 0)
+  .sort((left, right) => Number(left.id) - Number(right.id))
+
+const componentMap = new Map(components.map((component) => [Number(component.id), component]))
+const authors = Array.from(new Map(publishedDrafts.map((draft) => [`${draft.author.kind}:${draft.author.id}`, draft.author])).values())
+const authorProfiles = new Map()
+await mapConcurrent(authors, async (author) => {
+  authorProfiles.set(`${author.kind}:${author.id}`, await request(authorProfilePath(author)))
+}, concurrency)
+
+const inventory = publishedDrafts.map((draft) => {
+  const component = componentMap.get(Number(draft.componentId)) || {}
+  const currentComment = String(draft.finalComment || draft.editedComment || draft.generatedComment || '')
+  return {
+    draftId: Number(draft.id),
+    publishedReactionId: Number(draft.publishedReactionId),
+    componentId: Number(draft.componentId),
+    componentName: component.componentName || draft.componentName || '',
+    componentTitle: component.title || draft.componentTitle || null,
+    sourceKey: component.sourceKey || draft.promptPayload?.provenance?.exhibitSourcePath || '',
+    author: draft.author,
+    authorProfile: authorProfiles.get(`${draft.author.kind}:${draft.author.id}`) || null,
+    rating: Number(draft.rating),
+    reactionType: draft.reactionType,
+    currentComment,
+    currentCommentHash: sha256(currentComment),
+    createdAt: draft.createdAt,
+    updatedAt: draft.updatedAt,
+    publishedAt: draft.publishedAt,
+    publisherUserId: Number(draft.publisherUserId),
+    provenance: draft.promptPayload?.provenance || null,
+  }
+})
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  production: version,
+  scan: {
+    highestDraftId,
+    publishedReviews: inventory.length,
+    firstDraftId: inventory[0]?.draftId ?? null,
+    lastDraftId: inventory.at(-1)?.draftId ?? null,
+  },
+  inventory,
+}
+
+const markdown = [
+  '## WonderLab definitive commentary inventory',
+  '',
+  `- **Production:** \`${version.commit || 'unknown'}\` · deployment \`${version.deploymentId || 'unknown'}\``,
+  `- **Published reviews captured:** ${inventory.length}`,
+  `- **Draft range:** #${report.scan.firstDraftId ?? '?'}–#${report.scan.lastDraftId ?? '?'}`,
+  `- **Highest draft ID scanned:** #${highestDraftId}`,
+  '- **Boundary:** read-only; no ReviewDraft or Reaction was edited',
+  '',
+  'The JSON artifact contains the exact current comments and hashes, stars, reaction IDs, reviewer assignments and voice profiles required for guarded in-place rewrite batches.',
+  '',
+].join('\n')
+
+await mkdir(outputDir, { recursive: true })
+await Promise.all([
+  writeFile(resolve(outputDir, 'wonderlab-definitive-inventory.json'), `${JSON.stringify(report, null, 2)}\n`),
+  writeFile(resolve(outputDir, 'wonderlab-definitive-inventory.md'), markdown),
+])
+console.log(markdown)


### PR DESCRIPTION
Starts the definitive museum-commentary rewrite initiative from production truth.

- discovers the current highest ReviewDraft through the authenticated API
- scans every ReviewDraft ID and retains every published Reaction
- records exact current comments and hashes, stars, reaction IDs, reviewer assignments, chronology, provenance, and voice profiles
- uploads a canonical JSON artifact
- posts the inventory result and workflow link to #1013
- remains strictly read-only

Once merged, the push workflow runs immediately against production and supplies the source for the first guarded rewrite batch.

Closes no issue; begins execution of #1013.