### PR TITLE
WonderLab: fix snapshot orphan cleanup

### DIFF
--- a/.github/workflows/wonderlab-definitive-inventory.yml
+++ b/.github/workflows/wonderlab-definitive-inventory.yml
@@ -58,7 +58,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch --orphan "$SNAPSHOT_BRANCH"
-          git rm -rf .
+          git clean -fdx
           mkdir -p corpus
           cp -R "$snapshot_tmp"/. corpus/
           cat > README.md <<EOF


### PR DESCRIPTION
Fixes the production snapshot publish failure introduced in #852.

`git switch --orphan` already removes tracked files from the working tree. The following `git rm -rf .` therefore failed with `pathspec '.' did not match any files` under `set -e`.

This replaces that command with `git clean -fdx`, which safely removes the untracked inventory output after it has been copied to a temporary directory, then builds and force-pushes the machine-generated snapshot branch.

Locally reproduced the prior failure and verified the corrected command sequence.