### PR TITLE
storymaker: add a "Start a new scenario" CTA that deep-links to the add tab

### DIFF
--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -31,13 +31,23 @@
             </NuxtLink>
           </li>
         </ul>
-        <NuxtLink
-          to="/stories"
-          class="btn btn-primary btn-sm gap-1.5 rounded-2xl"
-        >
-          <Icon name="kind-icon:story" class="size-4" />
-          Open the Stories studio
-        </NuxtLink>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-primary btn-sm gap-1.5 rounded-2xl"
+            @click="startNewScenario"
+          >
+            <Icon name="kind-icon:sparkles" class="size-4" />
+            Start a new scenario
+          </button>
+          <NuxtLink
+            to="/stories"
+            class="btn btn-ghost btn-sm gap-1.5 rounded-2xl"
+          >
+            <Icon name="kind-icon:story" class="size-4" />
+            Open the Stories studio
+          </NuxtLink>
+        </div>
       </section>
     </template>
   </ProjectFrontPage>
@@ -56,6 +66,18 @@ onMounted(() => {
 
 const totalScenarios = computed(() => scenarioStore.totalScenarios)
 const recentScenarios = computed(() => scenarioStore.scenarios.slice(0, 3))
+
+/**
+ * The Stories manager resolves its dashboard tab from content frontmatter
+ * (dashboardTab: scenarios) on every load, so presetting navStore's tab
+ * before navigating here gets clobbered the instant /stories mounts.
+ * ?scenario=new is scenario-manager.vue's own deep-link query, read and
+ * applied in its onMounted (after that frontmatter resolution), same
+ * pattern as giftshop-manager.vue's ?manaTopup/?subscription flags.
+ */
+function startNewScenario() {
+  navigateTo('/stories?scenario=new')
+}
 
 const config: ProjectFrontConfig = {
   slug: 'storymaker',

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -52,6 +52,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from '#app'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useChoiceStore } from '@/stores/choiceStore'
 import { useNavStore } from '@/stores/navStore'
@@ -68,6 +69,8 @@ const characterStore = useCharacterStore()
 const choiceStore = useChoiceStore()
 const navStore = useNavStore()
 const rewardStore = useRewardStore()
+const route = useRoute()
+const router = useRouter()
 const scenarioStore = useScenarioStore()
 const serverStore = useServerStore()
 
@@ -165,6 +168,19 @@ async function refreshManagerData() {
 
 onMounted(async () => {
   await loadManagerData()
+
+  // Deep-link support: a caller (e.g. the storymaker front page's "Start a
+  // new scenario" CTA) can land here with ?scenario=new to jump straight to
+  // the add tab. This must run *after* loadManagerData, since the page's
+  // own content frontmatter (dashboardTab: scenarios) already resolved the
+  // tab to 'scenarios' before this component mounted -- setting it here is
+  // what actually overrides that default.
+  if (route.query.scenario === 'new') {
+    navStore.setDashboardTab(dashboardKey.value, 'add')
+    const { scenario: _drop, ...restQuery } = route.query
+    router.replace({ query: restQuery })
+    return
+  }
 
   if (activeTab.value === 'add') {
     prepareAddForm()


### PR DESCRIPTION
## Summary
- The storymaker front page's interactive card only linked out to the general Stories studio, leaving visitors to find the create flow themselves.
- Added a primary "Start a new scenario" CTA that navigates to `/stories?scenario=new`.
- `scenario-manager.vue` reads that query param in its `onMounted` (after content frontmatter has already resolved the dashboard tab to `'scenarios'`) and overrides it to `'add'` — mirroring the existing `?manaTopup`/`?subscription` query-flag pattern already used in `giftshop-manager.vue`.
- Investigated and confirmed that simply calling `navStore.setDashboardTab('scenario', 'add')` *before* navigating (the naive approach) does not work: `/stories`'s own content frontmatter (`dashboardTab: scenarios`) re-resolves and overwrites the tab on every page load, so the preset gets clobbered the instant the target page mounts. The query-param approach avoids that race.

Part of conductor `storymaker/t-010` (evolve the placeholder scaffold into the full interactive experience).

## Test plan
- [x] `npx eslint components/scenarios/scenario-manager.vue components/conductor/storymaker-page.vue` — clean
- [x] `npm run test` (vue-tsc --noEmit) — exit 0
- [x] `npx prettier --check` on both files — `storymaker-page.vue` clean; `scenario-manager.vue` reports pre-existing drift confirmed via `git stash` to predate this change (not touched)
- [ ] Live browser smoke of the `/storymaker` → `/stories?scenario=new` → add-tab flow (no reachable DATABASE_URL in this sandbox, same class of blocker noted elsewhere in the roadmap — e.g. model-builder/t-031, davinci/t-014)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FXmLwSbKt5VeBeT9UsBQjJ)_