### PR TITLE
art: Krea2/Flux.2-Klein engines, persist real seed, tunable retry

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -553,6 +553,21 @@
                         </span>
                       </button>
                     </li>
+                    <li>
+                      <button
+                        type="button"
+                        :disabled="isRetrying(job.id)"
+                        @click="openTune(job, 'NEW_OUTPUT')"
+                      >
+                        <span>
+                          <strong>Adjust settings &amp; retry</strong>
+                          <span class="block text-[11px] opacity-60">
+                            Change steps, checkpoint, seed, cfg, sampler before
+                            re-running.
+                          </span>
+                        </span>
+                      </button>
+                    </li>
                     <li v-if="job.status === 'DONE' && job.artImageId">
                       <button
                         type="button"
@@ -682,14 +697,124 @@
         </div>
       </div>
     </div>
+
+    <div
+      v-if="tuneJob"
+      class="fixed inset-0 z-100 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tune-art-title"
+      @click.self="tuneJob = null"
+    >
+      <div
+        class="w-full max-w-lg rounded-3xl border border-base-300 bg-base-100 p-5 shadow-2xl"
+      >
+        <h3 id="tune-art-title" class="text-lg font-semibold">
+          Adjust settings &amp; retry job #{{ tuneJob.id }}
+        </h3>
+        <p class="mt-1 text-xs text-base-content/60">
+          Blank fields keep the original spec. A blank seed uses a fresh random
+          seed; fill it to reproduce an exact render.
+        </p>
+        <div class="mt-4 grid grid-cols-2 gap-3 text-xs">
+          <label class="flex flex-col gap-1">
+            <span class="font-semibold">Steps</span>
+            <input
+              v-model="tuneForm.steps"
+              type="number"
+              min="1"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="keep"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="font-semibold">CFG</span>
+            <input
+              v-model="tuneForm.cfg"
+              type="number"
+              step="0.1"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="keep"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="font-semibold">Seed</span>
+            <input
+              v-model="tuneForm.seed"
+              type="number"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="random"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="font-semibold">Sampler</span>
+            <input
+              v-model="tuneForm.sampler"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="keep"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="font-semibold">Scheduler</span>
+            <input
+              v-model="tuneForm.scheduler"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="keep"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="font-semibold">Checkpoint / model</span>
+            <input
+              v-model="tuneForm.checkpoint"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="keep"
+            />
+          </label>
+          <label class="col-span-2 flex flex-col gap-1">
+            <span class="font-semibold">Negative prompt</span>
+            <textarea
+              v-model="tuneForm.negativePrompt"
+              rows="2"
+              class="textarea textarea-bordered textarea-sm rounded-xl"
+              placeholder="keep"
+            />
+          </label>
+        </div>
+        <div class="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-2xl"
+            @click="tuneJob = null"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm rounded-2xl"
+            :disabled="isRetrying(tuneJob.id)"
+            @click="confirmTune"
+          >
+            <span
+              v-if="isRetrying(tuneJob.id)"
+              class="loading loading-spinner loading-xs"
+            />
+            Queue with these settings
+          </button>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import type { ArtJob } from '~/prisma/generated/prisma/client'
 import {
   useArtJobStore,
+  type ArtJobOverrides,
   type ArtJobRetryMode,
   type ArtJobStatus,
 } from '@/stores/artJobStore'
@@ -1150,6 +1275,69 @@ function isRetrying(jobId: number): boolean {
 
 async function retryJob(job: ArtJob, mode: ArtJobRetryMode): Promise<void> {
   await artJobStore.reenqueueJob(job.id, mode)
+}
+
+// "Tune & retry": re-run a job with changed settings instead of the frozen
+// payload. Blank fields keep the source spec; a blank seed still means "fresh
+// seed", a filled seed pins it exactly.
+const tuneJob = ref<ArtJob | null>(null)
+const tuneMode = ref<ArtJobRetryMode>('NEW_OUTPUT')
+const tuneForm = reactive({
+  steps: '',
+  cfg: '',
+  seed: '',
+  sampler: '',
+  scheduler: '',
+  checkpoint: '',
+  negativePrompt: '',
+})
+
+function openTune(job: ArtJob, mode: ArtJobRetryMode = 'NEW_OUTPUT'): void {
+  tuneJob.value = job
+  tuneMode.value = mode
+  tuneForm.steps = payloadScalar(job, ['steps'])
+  tuneForm.cfg = payloadScalar(job, ['cfg'])
+  tuneForm.seed = ''
+  tuneForm.sampler = payloadScalar(job, ['sampler', 'sampler_name'])
+  tuneForm.scheduler = payloadScalar(job, ['scheduler'])
+  tuneForm.checkpoint = payloadScalar(job, [
+    'checkpoint',
+    'ckpt_name',
+    'unet_name',
+    'model_name',
+  ])
+  tuneForm.negativePrompt =
+    workflowPrompt(job, 'negative') || payloadScalar(job, ['negativePrompt'])
+}
+
+async function confirmTune(): Promise<void> {
+  const job = tuneJob.value
+  if (!job) return
+
+  const overrides: ArtJobOverrides = {}
+  const stepsNum = Number(tuneForm.steps)
+  if (tuneForm.steps.trim() && Number.isFinite(stepsNum)) {
+    overrides.steps = stepsNum
+  }
+  const cfgNum = Number(tuneForm.cfg)
+  if (tuneForm.cfg.trim() && Number.isFinite(cfgNum)) overrides.cfg = cfgNum
+  const seedNum = Number(tuneForm.seed)
+  const hasSeed = tuneForm.seed.trim() !== '' && Number.isFinite(seedNum)
+  if (hasSeed) overrides.seed = seedNum
+  if (tuneForm.sampler.trim()) overrides.sampler = tuneForm.sampler.trim()
+  if (tuneForm.scheduler.trim()) overrides.scheduler = tuneForm.scheduler.trim()
+  if (tuneForm.checkpoint.trim()) {
+    overrides.checkpoint = tuneForm.checkpoint.trim()
+  }
+  if (tuneForm.negativePrompt.trim()) {
+    overrides.negativePrompt = tuneForm.negativePrompt.trim()
+  }
+
+  const queued = await artJobStore.reenqueueJob(job.id, tuneMode.value, {
+    refreshSeed: !hasSeed,
+    overrides,
+  })
+  if (queued) tuneJob.value = null
 }
 
 // Only finished jobs with a generated ArtImage can be curated (the curator scores

--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -713,9 +713,30 @@
           Adjust settings &amp; retry job #{{ tuneJob.id }}
         </h3>
         <p class="mt-1 text-xs text-base-content/60">
-          Blank fields keep the original spec. A blank seed uses a fresh random
-          seed; fill it to reproduce an exact render.
+          Pick an engine preset to re-render the same prompt on a different
+          model, or keep the engine and just change the fields. Blank fields
+          keep the original spec; a blank seed uses a fresh random seed.
         </p>
+        <label class="mt-4 flex flex-col gap-1 text-xs">
+          <span class="font-semibold">Engine preset</span>
+          <select
+            v-model="tunePreset"
+            class="select select-bordered select-sm rounded-xl"
+          >
+            <option
+              v-for="preset in enginePresets"
+              :key="preset.value"
+              :value="preset.value"
+            >
+              {{ preset.label }}
+            </option>
+          </select>
+          <span class="text-[11px] opacity-60">
+            {{
+              enginePresets.find((preset) => preset.value === tunePreset)?.hint
+            }}
+          </span>
+        </label>
         <div class="mt-4 grid grid-cols-2 gap-3 text-xs">
           <label class="flex flex-col gap-1">
             <span class="font-semibold">Steps</span>
@@ -1282,6 +1303,18 @@ async function retryJob(job: ArtJob, mode: ArtJobRetryMode): Promise<void> {
 // seed", a filled seed pins it exactly.
 const tuneJob = ref<ArtJob | null>(null)
 const tuneMode = ref<ArtJobRetryMode>('NEW_OUTPUT')
+
+// Engine presets: re-render the same prompt on a different engine. 'custom'
+// keeps the source engine and just applies the manual field overrides below.
+const enginePresets: { value: string; label: string; hint: string }[] = [
+  { value: 'custom', label: 'Keep engine (custom)', hint: 'Same engine; apply the fields below.' },
+  { value: 'krea2', label: 'Krea 2 Turbo', hint: '8-step, illustration/creative.' },
+  { value: 'flux2', label: 'Flux.2 Klein', hint: '4-step, Apache-2.0, structured.' },
+  { value: 'sdxl', label: 'SDXL', hint: 'Fast, biggest LoRA ecosystem.' },
+  { value: 'flux', label: 'Flux dev', hint: '30-step, the old default.' },
+]
+const tunePreset = ref('custom')
+
 const tuneForm = reactive({
   steps: '',
   cfg: '',
@@ -1295,6 +1328,7 @@ const tuneForm = reactive({
 function openTune(job: ArtJob, mode: ArtJobRetryMode = 'NEW_OUTPUT'): void {
   tuneJob.value = job
   tuneMode.value = mode
+  tunePreset.value = 'custom'
   tuneForm.steps = payloadScalar(job, ['steps'])
   tuneForm.cfg = payloadScalar(job, ['cfg'])
   tuneForm.seed = ''
@@ -1335,6 +1369,7 @@ async function confirmTune(): Promise<void> {
 
   const queued = await artJobStore.reenqueueJob(job.id, tuneMode.value, {
     refreshSeed: !hasSeed,
+    preset: tunePreset.value === 'custom' ? null : tunePreset.value,
     overrides,
   })
   if (queued) tuneJob.value = null

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -25,6 +25,8 @@ import { errorHandler } from '../../utils/error'
 import { authAndGate } from '../../utils/comfyGate'
 import { buildDefaultComfyWorkflow } from '../comfy/sdxl/utils/workflow'
 import { buildFluxWorkflowFromRequest } from '../comfy/flux/utils/workflow'
+import { buildKrea2WorkflowFromRequest } from '../comfy/krea2/utils/workflow'
+import { buildFlux2KleinWorkflowFromRequest } from '../comfy/flux2/utils/workflow'
 import {
   buildKontextWorkflow,
   getKontextImageExtension,
@@ -48,7 +50,25 @@ import {
 
 // The queueable engines. `openai` is handled synchronously elsewhere.
 // `ltx` and `wan` are image-to-video engines (media: 'video').
-type EnqueueEngine = 'a1111' | 'comfy' | 'flux' | 'kontext' | 'ltx' | 'wan'
+type EnqueueEngine =
+  | 'a1111'
+  | 'comfy'
+  | 'flux'
+  | 'krea2'
+  | 'flux2'
+  | 'kontext'
+  | 'ltx'
+  | 'wan'
+
+// Aliases so callers can say "krea"/"klein"/"flux2-klein" etc.
+const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
+  krea: 'krea2',
+  'krea-2': 'krea2',
+  'krea2-turbo': 'krea2',
+  klein: 'flux2',
+  'flux2-klein': 'flux2',
+  'flux-2': 'flux2',
+}
 
 const VIDEO_ENGINES = new Set<EnqueueEngine>(['ltx', 'wan'])
 
@@ -76,6 +96,11 @@ type ArtEnqueueRequest = {
   width?: number | null
   height?: number | null
   variant?: 'dev' | 'schnell' | null
+  // Flux.2 Klein structured prompt (bound compositions), and an optional
+  // model-only style LoRA (comic/ink) shared by krea2 / flux2.
+  jsonPrompt?: Record<string, unknown> | unknown[] | null
+  loraName?: string | null
+  loraStrength?: number | null
   designer?: string | null
   isPublic?: boolean | null
   isMature?: boolean | null
@@ -104,6 +129,10 @@ const GATE_ENGINE: Record<
   a1111: 'comfy',
   comfy: 'comfy',
   flux: 'flux',
+  // Krea 2 Turbo (8-step) and Flux.2 Klein (4-step) are cheap 2D renders — bill
+  // them at the base comfy 2D tier until they get their own cost tiers.
+  krea2: 'comfy',
+  flux2: 'comfy',
   kontext: 'kontext',
   ltx: 'ltx',
   wan: 'wan',
@@ -112,12 +141,15 @@ const GATE_ENGINE: Record<
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
 
 function normalizeEngine(value: unknown): EnqueueEngine {
-  const engine = String(value || 'a1111').toLowerCase()
+  const raw = String(value || 'a1111').toLowerCase()
+  const engine = ENGINE_ALIASES[raw] ?? raw
 
   if (
     engine === 'a1111' ||
     engine === 'comfy' ||
     engine === 'flux' ||
+    engine === 'krea2' ||
+    engine === 'flux2' ||
     engine === 'kontext' ||
     engine === 'ltx' ||
     engine === 'wan'
@@ -130,7 +162,7 @@ function normalizeEngine(value: unknown): EnqueueEngine {
     message:
       engine === 'openai'
         ? 'OpenAI generation is synchronous; call /api/chats/openai/images/generate instead of enqueuing.'
-        : `Unsupported enqueue engine "${engine}". Use a1111, comfy, flux, kontext, ltx, or wan.`,
+        : `Unsupported enqueue engine "${engine}". Use a1111, comfy, flux, krea2, flux2, kontext, ltx, or wan.`,
   })
 }
 
@@ -280,6 +312,51 @@ function buildJobPayload(
       sampler: body.sampler ?? null,
       scheduler: body.scheduler ?? null,
       denoise: body.denoise ?? null,
+    })
+
+    return {
+      jobEngine: 'COMFY',
+      payload: { workflow, promptString, save },
+    }
+  }
+
+  if (engine === 'krea2') {
+    const { workflow } = buildKrea2WorkflowFromRequest({
+      prompt: promptString,
+      negativePrompt: body.negativePrompt ?? null,
+      width: body.width ?? null,
+      height: body.height ?? null,
+      steps: body.steps ?? null,
+      cfg: body.cfg ?? null,
+      seed: body.seed ?? null,
+      sampler: body.sampler ?? null,
+      scheduler: body.scheduler ?? null,
+      denoise: body.denoise ?? null,
+      loraName: body.loraName ?? null,
+      loraStrength: body.loraStrength ?? null,
+    })
+
+    return {
+      jobEngine: 'COMFY',
+      payload: { workflow, promptString, save },
+    }
+  }
+
+  if (engine === 'flux2') {
+    const { workflow } = buildFlux2KleinWorkflowFromRequest({
+      prompt: promptString,
+      jsonPrompt: body.jsonPrompt ?? null,
+      negativePrompt: body.negativePrompt ?? null,
+      width: body.width ?? null,
+      height: body.height ?? null,
+      steps: body.steps ?? null,
+      cfg: body.cfg ?? null,
+      seed: body.seed ?? null,
+      sampler: body.sampler ?? null,
+      scheduler: body.scheduler ?? null,
+      denoise: body.denoise ?? null,
+      loraName: body.loraName ?? null,
+      loraStrength: body.loraStrength ?? null,
     })
 
     return {

--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -15,6 +15,7 @@ import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import {
   decodeArtJobPayload,
+  extractWorkflowSeed,
   parseArtJobPayload,
   serializeArtJobPayload,
   type ArtJobPayloadRecord,
@@ -146,10 +147,23 @@ function snapshotData(image: ArtImage): Prisma.ArtImageUncheckedCreateInput {
   }
 }
 
+// Prefer the concrete seed baked into the workflow graph over a missing/-1
+// relay echo, so the canonical ArtImage records the real seed used.
+function resolveImageSeed(
+  imageSeed: number | null,
+  workflowSeed: number | null,
+): number | null {
+  if (workflowSeed !== null && (imageSeed == null || imageSeed < 0)) {
+    return workflowSeed
+  }
+  return imageSeed
+}
+
 function replacementData(
   staged: ArtImage,
   userId: number,
   savePolicy: ReturnType<typeof readSavePolicy>,
+  workflowSeed: number | null,
 ): Prisma.ArtImageUncheckedUpdateInput {
   return {
     imageData: staged.imageData,
@@ -164,7 +178,7 @@ function replacementData(
     negativePrompt: staged.negativePrompt,
     promptString: staged.promptString,
     sampler: staged.sampler,
-    seed: staged.seed,
+    seed: resolveImageSeed(staged.seed, workflowSeed),
     serverId: staged.serverId,
     serverName: staged.serverName,
     serverUrl: staged.serverUrl,
@@ -265,6 +279,10 @@ export default defineEventHandler(async (event) => {
       )
       const retry = readRetry(job.payload)
       const savePolicy = readSavePolicy(job.payload)
+      // The real seed the graph render used (randomized at build time and baked
+      // into the workflow). Used to backfill ArtImage.seed when the relay's echo
+      // is missing/-1, so accepted renders are reproducible.
+      const workflowSeed = extractWorkflowSeed(job.payload)
 
       if (retry?.mode === 'OVERWRITE') {
         const targetArtImageId = retry.targetArtImageId
@@ -323,7 +341,7 @@ export default defineEventHandler(async (event) => {
 
           await tx.artImage.update({
             where: { id: targetArtImageId },
-            data: replacementData(staged, job.userId, savePolicy),
+            data: replacementData(staged, job.userId, savePolicy, workflowSeed),
           })
 
           const completed = await tx.artJob.update({
@@ -374,11 +392,16 @@ export default defineEventHandler(async (event) => {
           },
         })
 
+        const backfilledSeed = resolveImageSeed(uploaded.seed, workflowSeed)
+
         await prisma.artImage.update({
           where: { id: uploadedArtImageId },
           data: {
             userId: job.userId,
             ...savePolicy,
+            ...(backfilledSeed !== uploaded.seed
+              ? { seed: backfilledSeed }
+              : {}),
           },
         })
       }

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -32,10 +32,19 @@ import {
   type ArtJobOverrides,
   type ArtJobRetryMode,
 } from '../../../../utils/artJobRetry'
+import {
+  buildWorkflowForEngine,
+  extractRenderRequest,
+  resolvePresetEngine,
+} from '../../../comfy/utils/engineWorkflow'
 
 type ReenqueueBody = {
   mode?: string | null
   refreshSeed?: boolean
+  // Optional engine preset — re-render the same prompt on a different engine
+  // (krea2 | flux2/klein | sdxl | flux). Rebuilds the workflow graph, carrying
+  // over prompt / negative / size / seed. Omit or "custom" to keep the engine.
+  preset?: string | null
   // Optional per-render setting changes for this retry (steps, checkpoint,
   // seed, cfg, sampler, negative prompt). Absent keys keep the source spec.
   overrides?: ArtJobOverrides | null
@@ -104,20 +113,30 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    const payload = applyArtJobOverrides(
-      prepareArtJobRetryPayload(
-        source.payload,
-        source.id,
-        source.artImageId,
-        mode,
-        refreshSeed,
-      ),
-      body?.overrides,
+    const prepared = prepareArtJobRetryPayload(
+      source.payload,
+      source.id,
+      source.artImageId,
+      mode,
+      refreshSeed,
     )
+
+    // Engine preset: rebuild the graph for the requested engine, carrying over
+    // the prompt / negative / size / seed. Only image engines are presetable;
+    // an unknown preset name is ignored (keeps the source engine).
+    const presetEngine = resolvePresetEngine(body?.preset)
+    if (presetEngine) {
+      const req = extractRenderRequest(prepared)
+      prepared.workflow = buildWorkflowForEngine(presetEngine, req)
+      prepared.promptString = req.prompt
+    }
+
+    const payload = applyArtJobOverrides(prepared, body?.overrides)
+    const jobEngine = presetEngine ? 'COMFY' : source.engine
 
     const job = await prisma.artJob.create({
       data: {
-        engine: source.engine,
+        engine: jobEngine,
         payload: serializeArtJobPayload(payload),
         priority: source.priority,
         projectSlug: source.projectSlug,

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -26,14 +26,19 @@ import {
   serializeArtJobPayload,
 } from '../../../../utils/artJobPayload'
 import {
+  applyArtJobOverrides,
   ART_JOB_RETRY_MODES,
   prepareArtJobRetryPayload,
+  type ArtJobOverrides,
   type ArtJobRetryMode,
 } from '../../../../utils/artJobRetry'
 
 type ReenqueueBody = {
   mode?: string | null
   refreshSeed?: boolean
+  // Optional per-render setting changes for this retry (steps, checkpoint,
+  // seed, cfg, sampler, negative prompt). Absent keys keep the source spec.
+  overrides?: ArtJobOverrides | null
 }
 
 export default defineEventHandler(async (event) => {
@@ -57,7 +62,12 @@ export default defineEventHandler(async (event) => {
     const mode = String(
       body?.mode || 'NEW_OUTPUT',
     ).toUpperCase() as ArtJobRetryMode
-    const refreshSeed = body?.refreshSeed !== false
+    // An explicit seed override implies "use exactly this seed", so it wins over
+    // the default seed refresh.
+    const hasSeedOverride =
+      typeof body?.overrides?.seed === 'number' &&
+      Number.isFinite(body.overrides.seed)
+    const refreshSeed = body?.refreshSeed !== false && !hasSeedOverride
 
     if (!ART_JOB_RETRY_MODES.has(mode)) {
       throw createError({
@@ -94,12 +104,15 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    const payload = prepareArtJobRetryPayload(
-      source.payload,
-      source.id,
-      source.artImageId,
-      mode,
-      refreshSeed,
+    const payload = applyArtJobOverrides(
+      prepareArtJobRetryPayload(
+        source.payload,
+        source.id,
+        source.artImageId,
+        mode,
+        refreshSeed,
+      ),
+      body?.overrides,
     )
 
     const job = await prisma.artJob.create({

--- a/server/api/comfy/flux2/utils/workflow.ts
+++ b/server/api/comfy/flux2/utils/workflow.ts
@@ -1,0 +1,73 @@
+// /server/api/comfy/flux2/utils/workflow.ts
+//
+// Flux.2 Klein 4B workflow builder. Apache-2.0 (clean for the storefront),
+// 4-step, <12GB, and takes JSON structured prompts that bind compositions far
+// more faithfully than a run-on sentence — the fix for renders that "veer off".
+// Pass `jsonPrompt` (an object/array) and it is serialized into the positive
+// text encode; otherwise the plain prompt string is used. Flux.2 uses its OWN
+// text encoder and VAE (different from Flux.1).
+//
+// VERIFY these filenames against the Comfy-Org Flux.2 release you download.
+import {
+  buildSimpleCheckpointWorkflow,
+  type ComfyWorkflow,
+} from '../../utils/simpleCheckpointWorkflow'
+
+export const FLUX2_KLEIN_UNET_LOADER: 'UNETLoader' | 'UnetLoaderGGUF' =
+  'UnetLoaderGGUF'
+export const FLUX2_KLEIN_MODEL = 'flux2-klein-4b-Q5_K_M.gguf'
+export const FLUX2_KLEIN_CLIP = 'flux2_klein_text_encoder_fp8_scaled.safetensors'
+export const FLUX2_KLEIN_CLIP_TYPE = 'flux2'
+export const FLUX2_KLEIN_VAE = 'flux2-vae.safetensors'
+export const FLUX2_KLEIN_DEFAULT_STEPS = 4
+export const FLUX2_KLEIN_DEFAULT_CFG = 1
+export const FLUX2_KLEIN_DEFAULT_SAMPLER = 'euler'
+export const FLUX2_KLEIN_DEFAULT_SCHEDULER = 'simple'
+export const FLUX2_KLEIN_DEFAULT_WIDTH = 1024
+export const FLUX2_KLEIN_DEFAULT_HEIGHT = 1024
+
+export function buildFlux2KleinWorkflowFromRequest(input: {
+  prompt?: string | null
+  jsonPrompt?: Record<string, unknown> | unknown[] | null
+  negativePrompt?: string | null
+  width?: number | null
+  height?: number | null
+  steps?: number | null
+  cfg?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  denoise?: number | null
+  loraName?: string | null
+  loraStrength?: number | null
+}): { workflow: ComfyWorkflow; seed: number } {
+  const hasJson =
+    input.jsonPrompt &&
+    (Array.isArray(input.jsonPrompt)
+      ? input.jsonPrompt.length > 0
+      : Object.keys(input.jsonPrompt).length > 0)
+  const prompt = hasJson
+    ? JSON.stringify(input.jsonPrompt)
+    : input.prompt?.trim() || ''
+
+  return buildSimpleCheckpointWorkflow({
+    prompt,
+    negativePrompt: input.negativePrompt ?? '',
+    width: input.width ?? FLUX2_KLEIN_DEFAULT_WIDTH,
+    height: input.height ?? FLUX2_KLEIN_DEFAULT_HEIGHT,
+    steps: input.steps ?? FLUX2_KLEIN_DEFAULT_STEPS,
+    cfg: input.cfg ?? FLUX2_KLEIN_DEFAULT_CFG,
+    seed: input.seed ?? -1,
+    sampler: input.sampler ?? FLUX2_KLEIN_DEFAULT_SAMPLER,
+    scheduler: input.scheduler ?? FLUX2_KLEIN_DEFAULT_SCHEDULER,
+    denoise: input.denoise ?? 1,
+    unetLoader: FLUX2_KLEIN_UNET_LOADER,
+    unetName: FLUX2_KLEIN_MODEL,
+    clipName: FLUX2_KLEIN_CLIP,
+    clipType: FLUX2_KLEIN_CLIP_TYPE,
+    vaeName: FLUX2_KLEIN_VAE,
+    filenamePrefix: 'kindrobots_flux2_klein',
+    loraName: input.loraName ?? null,
+    loraStrength: input.loraStrength ?? null,
+  })
+}

--- a/server/api/comfy/krea2/utils/workflow.ts
+++ b/server/api/comfy/krea2/utils/workflow.ts
@@ -1,0 +1,63 @@
+// /server/api/comfy/krea2/utils/workflow.ts
+//
+// Krea 2 Turbo (Qwen-Image lineage) workflow builder. An 8-step distilled DiT
+// tuned for illustration/painting — the "extreme creativity" lane — and fast on
+// a 12GB card. Stack: single CLIPLoader (type "krea2") -> Qwen3-VL encoder,
+// Qwen-Image VAE, plain KSampler (no FluxGuidance). Negatives are inert at
+// cfg 1 but correctly wired.
+//
+// VERIFY the three filenames against the ComfyUI models folders you download
+// into; GGUF users flip KREA2_UNET_LOADER to 'UnetLoaderGGUF' and point
+// KREA2_MODEL at the .gguf (lighter on 12GB VRAM).
+import {
+  buildSimpleCheckpointWorkflow,
+  type ComfyWorkflow,
+} from '../../utils/simpleCheckpointWorkflow'
+
+export const KREA2_UNET_LOADER: 'UNETLoader' | 'UnetLoaderGGUF' = 'UNETLoader'
+export const KREA2_MODEL = 'krea2_turbo_fp8_scaled.safetensors'
+export const KREA2_CLIP = 'qwen3vl_4b_fp8_scaled.safetensors'
+export const KREA2_CLIP_TYPE = 'krea2'
+export const KREA2_VAE = 'qwen_image_vae.safetensors'
+export const KREA2_DEFAULT_STEPS = 8
+export const KREA2_DEFAULT_CFG = 1
+export const KREA2_DEFAULT_SAMPLER = 'euler'
+export const KREA2_DEFAULT_SCHEDULER = 'simple'
+export const KREA2_DEFAULT_WIDTH = 1024
+export const KREA2_DEFAULT_HEIGHT = 1024
+
+export function buildKrea2WorkflowFromRequest(input: {
+  prompt?: string | null
+  negativePrompt?: string | null
+  width?: number | null
+  height?: number | null
+  steps?: number | null
+  cfg?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  denoise?: number | null
+  loraName?: string | null
+  loraStrength?: number | null
+}): { workflow: ComfyWorkflow; seed: number } {
+  return buildSimpleCheckpointWorkflow({
+    prompt: input.prompt?.trim() || '',
+    negativePrompt: input.negativePrompt ?? '',
+    width: input.width ?? KREA2_DEFAULT_WIDTH,
+    height: input.height ?? KREA2_DEFAULT_HEIGHT,
+    steps: input.steps ?? KREA2_DEFAULT_STEPS,
+    cfg: input.cfg ?? KREA2_DEFAULT_CFG,
+    seed: input.seed ?? -1,
+    sampler: input.sampler ?? KREA2_DEFAULT_SAMPLER,
+    scheduler: input.scheduler ?? KREA2_DEFAULT_SCHEDULER,
+    denoise: input.denoise ?? 1,
+    unetLoader: KREA2_UNET_LOADER,
+    unetName: KREA2_MODEL,
+    clipName: KREA2_CLIP,
+    clipType: KREA2_CLIP_TYPE,
+    vaeName: KREA2_VAE,
+    filenamePrefix: 'kindrobots_krea2',
+    loraName: input.loraName ?? null,
+    loraStrength: input.loraStrength ?? null,
+  })
+}

--- a/server/api/comfy/utils/engineWorkflow.ts
+++ b/server/api/comfy/utils/engineWorkflow.ts
@@ -1,0 +1,167 @@
+// /server/api/comfy/utils/engineWorkflow.ts
+//
+// Rebuild a render's Comfy workflow for a DIFFERENT engine, carrying over the
+// prompt / negative / size / seed from the source job. This is what powers the
+// "re-render this on Klein / SDXL / Krea" presets in the ArtJobs retry UI:
+// switching engine is not a node patch (each engine has its own graph — loaders,
+// CLIP type, VAE) so the graph is rebuilt, not edited.
+import { buildDefaultComfyWorkflow } from '../sdxl/utils/workflow'
+import { buildFluxWorkflowFromRequest } from '../flux/utils/workflow'
+import { buildKrea2WorkflowFromRequest } from '../krea2/utils/workflow'
+import { buildFlux2KleinWorkflowFromRequest } from '../flux2/utils/workflow'
+import type { ComfyWorkflow } from './simpleCheckpointWorkflow'
+
+export type ImageEngine = 'comfy' | 'flux' | 'krea2' | 'flux2'
+
+// Preset name (as sent from the UI) -> concrete graph engine. `custom` is
+// absent on purpose: it means "no rebuild, just apply the manual overrides".
+export const ENGINE_PRESETS: Record<string, ImageEngine> = {
+  comfy: 'comfy',
+  sdxl: 'comfy',
+  flux: 'flux',
+  'flux-dev': 'flux',
+  krea2: 'krea2',
+  krea: 'krea2',
+  'krea2-turbo': 'krea2',
+  flux2: 'flux2',
+  klein: 'flux2',
+  'flux2-klein': 'flux2',
+}
+
+export function resolvePresetEngine(preset: unknown): ImageEngine | null {
+  const key = String(preset || '')
+    .trim()
+    .toLowerCase()
+  if (!key || key === 'custom' || key === 'keep') return null
+  return ENGINE_PRESETS[key] ?? null
+}
+
+type RenderRequest = {
+  prompt: string
+  negativePrompt: string
+  width: number
+  height: number
+  seed: number | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+// Pull the reusable render inputs out of a source payload — works for both the
+// graph engines (reads the workflow nodes) and the raw A1111 path (top-level).
+export function extractRenderRequest(payload: unknown): RenderRequest {
+  const record = asRecord(payload)
+  const workflow = asRecord(record.workflow)
+
+  let prompt = str(record.promptString) || str(record.prompt)
+  let negativePrompt = str(record.negativePrompt)
+  let width = num(record.width)
+  let height = num(record.height)
+  let seed: number | null = num(record.seed)
+
+  for (const node of Object.values(workflow)) {
+    const nodeRecord = asRecord(node)
+    const classType = String(nodeRecord.class_type || '')
+    const inputs = asRecord(nodeRecord.inputs)
+    const title = String(asRecord(nodeRecord._meta).title || '').toLowerCase()
+
+    if (classType === 'CLIPTextEncode' || classType === 'ImpactWildcardEncode') {
+      const text = str(inputs.text) || str(inputs.wildcard_text)
+      if (text) {
+        if (title.includes('negative')) {
+          if (!negativePrompt) negativePrompt = text
+        } else if (!prompt) {
+          prompt = text
+        }
+      }
+    }
+    if (classType === 'EmptyLatentImage') {
+      width = width ?? num(inputs.width)
+      height = height ?? num(inputs.height)
+    }
+    if (seed === null) {
+      seed = num(inputs.seed) ?? num(inputs.noise_seed)
+    }
+  }
+
+  return {
+    prompt,
+    negativePrompt,
+    width: width ?? 1024,
+    height: height ?? 1024,
+    seed,
+  }
+}
+
+// Force every EmptyLatentImage node to the requested size, so switching to an
+// engine whose builder hardcodes the latent (SDXL) still respects the source
+// aspect ratio.
+function applyLatentSize(
+  workflow: ComfyWorkflow,
+  width: number,
+  height: number,
+): void {
+  for (const node of Object.values(workflow)) {
+    if (node?.class_type === 'EmptyLatentImage' && node.inputs) {
+      node.inputs.width = width
+      node.inputs.height = height
+    }
+  }
+}
+
+// Build a fresh COMFY workflow for the target engine from the carried-over
+// render request. A null seed lets the builder randomize (fresh attempt).
+export function buildWorkflowForEngine(
+  engine: ImageEngine,
+  req: RenderRequest,
+): ComfyWorkflow {
+  let workflow: ComfyWorkflow
+
+  if (engine === 'flux') {
+    workflow = buildFluxWorkflowFromRequest({
+      variant: 'dev',
+      prompt: req.prompt,
+      negativePrompt: req.negativePrompt,
+      width: req.width,
+      height: req.height,
+      seed: req.seed,
+    }).workflow
+  } else if (engine === 'krea2') {
+    workflow = buildKrea2WorkflowFromRequest({
+      prompt: req.prompt,
+      negativePrompt: req.negativePrompt,
+      width: req.width,
+      height: req.height,
+      seed: req.seed,
+    }).workflow
+  } else if (engine === 'flux2') {
+    workflow = buildFlux2KleinWorkflowFromRequest({
+      prompt: req.prompt,
+      negativePrompt: req.negativePrompt,
+      width: req.width,
+      height: req.height,
+      seed: req.seed,
+    }).workflow
+  } else {
+    // comfy / sdxl
+    workflow = buildDefaultComfyWorkflow({
+      prompt: req.prompt,
+      negativePrompt: req.negativePrompt,
+      cfgValue: 3,
+      seed: req.seed,
+    })
+  }
+
+  applyLatentSize(workflow, req.width, req.height)
+  return workflow
+}

--- a/server/api/comfy/utils/simpleCheckpointWorkflow.ts
+++ b/server/api/comfy/utils/simpleCheckpointWorkflow.ts
@@ -1,0 +1,143 @@
+// /server/api/comfy/utils/simpleCheckpointWorkflow.ts
+//
+// Shared builder for "simple" single-checkpoint Comfy graphs:
+//   diffusion model -> CLIP -> (+/- text encode) -> KSampler -> VAE -> save
+//
+// Krea 2 Turbo and Flux.2 Klein both use this exact shape. Unlike Flux.1 (which
+// needs a DualCLIPLoader + FluxGuidance node) these newer models load a single
+// CLIP with a model-specific `type` and sample with a plain KSampler. The
+// negative prompt gets its OWN CLIPTextEncode node here — so "no text/border"
+// negatives are live wherever cfg > 1, and merely inert (not silently wired to
+// the positive node, the Flux.1 path's bug) at the cfg-1 distilled settings.
+
+export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
+
+export type ComfyWorkflowNode = {
+  class_type?: string
+  inputs?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+export function resolveComfySeed(seed?: number | null): number {
+  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
+    return Math.floor(seed)
+  }
+  return Math.floor(Math.random() * 1_000_000_000_000_000)
+}
+
+export type SimpleCheckpointInput = {
+  prompt: string
+  negativePrompt: string
+  width: number
+  height: number
+  steps: number
+  cfg: number
+  seed: number
+  sampler: string
+  scheduler: string
+  denoise: number
+  // Loader: 'UnetLoaderGGUF' for a .gguf, 'UNETLoader' for an fp8/safetensors.
+  unetLoader: 'UnetLoaderGGUF' | 'UNETLoader'
+  unetName: string
+  unetDtype?: string
+  clipName: string
+  clipType: string
+  vaeName: string
+  filenamePrefix: string
+  // Optional model-only style LoRA (comic/ink/lineart) for the inked look.
+  loraName?: string | null
+  loraStrength?: number | null
+}
+
+export function buildSimpleCheckpointWorkflow(input: SimpleCheckpointInput): {
+  workflow: ComfyWorkflow
+  seed: number
+} {
+  const seed = resolveComfySeed(input.seed)
+  const text = input.prompt.trim() || 'a beautiful, richly detailed illustration'
+
+  const loaderInputs: Record<string, unknown> =
+    input.unetLoader === 'UnetLoaderGGUF'
+      ? { unet_name: input.unetName }
+      : { unet_name: input.unetName, weight_dtype: input.unetDtype ?? 'default' }
+
+  const workflow: ComfyWorkflow = {
+    '1': {
+      inputs: loaderInputs,
+      class_type: input.unetLoader,
+      _meta: { title: 'Load Diffusion Model' },
+    },
+    '2': {
+      inputs: {
+        clip_name: input.clipName,
+        type: input.clipType,
+        device: 'default',
+      },
+      class_type: 'CLIPLoader',
+      _meta: { title: 'Load CLIP' },
+    },
+    '3': {
+      inputs: { text, clip: ['2', 0] },
+      class_type: 'CLIPTextEncode',
+      _meta: { title: 'Positive Prompt' },
+    },
+    '4': {
+      inputs: { text: input.negativePrompt || '', clip: ['2', 0] },
+      class_type: 'CLIPTextEncode',
+      _meta: { title: 'Negative Prompt' },
+    },
+    '5': {
+      inputs: { vae_name: input.vaeName },
+      class_type: 'VAELoader',
+      _meta: { title: 'Load VAE' },
+    },
+    '6': {
+      inputs: { width: input.width, height: input.height, batch_size: 1 },
+      class_type: 'EmptyLatentImage',
+      _meta: { title: 'Empty Latent Image' },
+    },
+    '7': {
+      inputs: {
+        seed,
+        steps: input.steps,
+        cfg: input.cfg,
+        sampler_name: input.sampler,
+        scheduler: input.scheduler,
+        denoise: input.denoise,
+        model: ['1', 0],
+        positive: ['3', 0],
+        negative: ['4', 0],
+        latent_image: ['6', 0],
+      },
+      class_type: 'KSampler',
+      _meta: { title: 'KSampler' },
+    },
+    '8': {
+      inputs: { samples: ['7', 0], vae: ['5', 0] },
+      class_type: 'VAEDecode',
+      _meta: { title: 'VAE Decode' },
+    },
+    '9': {
+      inputs: { filename_prefix: input.filenamePrefix, images: ['8', 0] },
+      class_type: 'SaveImage',
+      _meta: { title: 'Save Image' },
+    },
+  }
+
+  if (input.loraName) {
+    workflow['10'] = {
+      inputs: {
+        model: ['1', 0],
+        lora_name: input.loraName,
+        strength_model:
+          typeof input.loraStrength === 'number' ? input.loraStrength : 1.0,
+      },
+      class_type: 'LoraLoaderModelOnly',
+      _meta: { title: 'Style LoRA' },
+    }
+    // Route the sampler's model through the LoRA; CLIP stays on the encoder.
+    ;(workflow['7'].inputs as Record<string, unknown>).model = ['10', 0]
+  }
+
+  return { workflow, seed }
+}

--- a/server/utils/artJobPayload.ts
+++ b/server/utils/artJobPayload.ts
@@ -38,3 +38,45 @@ export function decodeArtJobPayload<T extends Pick<ArtJob, 'payload'>>(
     payload: parseArtJobPayload(job.payload),
   }
 }
+
+// The concrete seed a Comfy graph render actually used. For the graph engines
+// the seed is resolved (randomized when unset) at build time and baked into the
+// KSampler `seed` / RandomNoise `noise_seed` input — it is NOT otherwise stored,
+// so ArtImage.seed can end up -1 unless the relay echoes it. This walks the
+// workflow to recover the real seed so completion can persist it. Returns the
+// first concrete non-negative seed found (there is one sampler per graph), or
+// null when the payload carries no workflow (e.g. raw A1111 jobs).
+const WORKFLOW_SEED_KEYS = new Set(['seed', 'noise_seed'])
+
+export function extractWorkflowSeed(payload: unknown): number | null {
+  const workflow = parseArtJobPayload(payload).workflow
+  if (!workflow || typeof workflow !== 'object') return null
+
+  let found: number | null = null
+
+  const visit = (value: unknown, key = ''): void => {
+    if (found !== null) return
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item)
+      return
+    }
+    if (value && typeof value === 'object') {
+      for (const [childKey, child] of Object.entries(value)) {
+        visit(child, childKey)
+        if (found !== null) return
+      }
+      return
+    }
+    if (
+      WORKFLOW_SEED_KEYS.has(key) &&
+      typeof value === 'number' &&
+      Number.isFinite(value) &&
+      value >= 0
+    ) {
+      found = Math.floor(value)
+    }
+  }
+
+  visit(workflow)
+  return found
+}

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -52,6 +52,101 @@ function refreshConcreteSeeds(value: unknown, key = ''): unknown {
   )
 }
 
+// Settings a human can change when re-queuing a failed or completed job from
+// the ArtJobs UI, instead of blindly re-running the frozen payload. Only the
+// keys present are applied; the rest of the render spec is preserved.
+export type ArtJobOverrides = {
+  steps?: number | null
+  cfg?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  checkpoint?: string | null
+  negativePrompt?: string | null
+}
+
+const SAMPLER_NODE_TYPES = new Set([
+  'KSampler',
+  'KSamplerAdvanced',
+  'SamplerCustom',
+])
+const CHECKPOINT_KEYS = ['ckpt_name', 'unet_name', 'model_name']
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+// Apply overrides in place to a cloned generation payload. Handles both the
+// graph engines (patches KSampler / loader / negative-encode nodes inside
+// payload.workflow) and the raw A1111 path (top-level keys).
+export function applyArtJobOverrides(
+  payload: ArtJobPayloadRecord,
+  overrides: ArtJobOverrides | null | undefined,
+): ArtJobPayloadRecord {
+  if (!overrides) return payload
+
+  const steps = num(overrides.steps)
+  const cfg = num(overrides.cfg)
+  const seed = num(overrides.seed)
+  const sampler = overrides.sampler?.trim() || null
+  const scheduler = overrides.scheduler?.trim() || null
+  const checkpoint = overrides.checkpoint?.trim() || null
+  const negativePrompt =
+    typeof overrides.negativePrompt === 'string'
+      ? overrides.negativePrompt
+      : null
+
+  const workflow = asRecord(payload.workflow)
+  const hasWorkflow = Object.keys(workflow).length > 0
+
+  if (hasWorkflow) {
+    for (const node of Object.values(workflow)) {
+      const record = asRecord(node)
+      const classType = String(record.class_type || '')
+      const inputs = asRecord(record.inputs)
+      const meta = asRecord(record._meta)
+
+      if (SAMPLER_NODE_TYPES.has(classType)) {
+        if (steps !== null && 'steps' in inputs) inputs.steps = steps
+        if (cfg !== null && 'cfg' in inputs) inputs.cfg = cfg
+        if (seed !== null && 'seed' in inputs) inputs.seed = seed
+        if (sampler && 'sampler_name' in inputs) inputs.sampler_name = sampler
+        if (scheduler && 'scheduler' in inputs) inputs.scheduler = scheduler
+      }
+      // Advanced-sampler graphs split these across dedicated nodes.
+      if (steps !== null && 'steps' in inputs && classType === 'BasicScheduler')
+        inputs.steps = steps
+      if (seed !== null && 'noise_seed' in inputs) inputs.noise_seed = seed
+      if (checkpoint) {
+        for (const key of CHECKPOINT_KEYS) {
+          if (key in inputs) inputs[key] = checkpoint
+        }
+      }
+      if (
+        negativePrompt !== null &&
+        classType === 'CLIPTextEncode' &&
+        String(meta.title || '')
+          .toLowerCase()
+          .includes('negative')
+      ) {
+        inputs.text = negativePrompt
+      }
+      record.inputs = inputs
+    }
+    payload.workflow = workflow
+  }
+
+  // Raw A1111 path (and a convenience mirror for graph jobs).
+  if (steps !== null) payload.steps = steps
+  if (cfg !== null) payload.cfg = cfg
+  if (seed !== null) payload.seed = seed
+  if (sampler) payload.sampler = sampler
+  if (checkpoint) payload.checkpoint = checkpoint
+  if (negativePrompt !== null) payload.negativePrompt = negativePrompt
+
+  return payload
+}
+
 export function prepareArtJobRetryPayload(
   rawPayload: unknown,
   sourceJobId: number,

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -18,6 +18,19 @@ export type ArtJobStatus =
   | 'CANCELLED'
 
 export type ArtJobRetryMode = 'NEW_OUTPUT' | 'OVERWRITE'
+
+// Per-render settings a human can change on a retry (steps, checkpoint, seed,
+// cfg, sampler, negative prompt). Mirrors the server ArtJobOverrides.
+export type ArtJobOverrides = {
+  steps?: number | null
+  cfg?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  checkpoint?: string | null
+  negativePrompt?: string | null
+}
+
 export type ArtFeedbackSource = 'CURATOR' | 'HUMAN'
 export type ArtFeedbackVerdict = 'PROMOTE' | 'REVISE' | 'REJECT'
 
@@ -447,6 +460,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
   async function reenqueueJob(
     id: number,
     mode: ArtJobRetryMode = 'NEW_OUTPUT',
+    options?: { refreshSeed?: boolean; overrides?: ArtJobOverrides | null },
   ): Promise<number | null> {
     if (state.retryingJobIds.includes(id)) return null
     state.retryingJobIds = [...state.retryingJobIds, id]
@@ -458,7 +472,11 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         targetArtImageId: number | null
       }>(`/api/art/queue/${id}/reenqueue`, {
         method: 'POST',
-        body: JSON.stringify({ mode, refreshSeed: true }),
+        body: JSON.stringify({
+          mode,
+          refreshSeed: options?.refreshSeed ?? true,
+          ...(options?.overrides ? { overrides: options.overrides } : {}),
+        }),
       })
 
       if (res.success && res.data?.job) {

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -460,7 +460,11 @@ export const useArtJobStore = defineStore('artJobStore', () => {
   async function reenqueueJob(
     id: number,
     mode: ArtJobRetryMode = 'NEW_OUTPUT',
-    options?: { refreshSeed?: boolean; overrides?: ArtJobOverrides | null },
+    options?: {
+      refreshSeed?: boolean
+      preset?: string | null
+      overrides?: ArtJobOverrides | null
+    },
   ): Promise<number | null> {
     if (state.retryingJobIds.includes(id)) return null
     state.retryingJobIds = [...state.retryingJobIds, id]
@@ -475,6 +479,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
         body: JSON.stringify({
           mode,
           refreshSeed: options?.refreshSeed ?? true,
+          ...(options?.preset ? { preset: options.preset } : {}),
           ...(options?.overrides ? { overrides: options.overrides } : {}),
         }),
       })


### PR DESCRIPTION
## Why

Mirrors the conductor coloring-book upgrade on the kind_robots art backend so the browser/app art generator **and** the ArtJob queue can use the new creative engines, and so accepted renders are reproducible. Companion to conductor PR #1018.

## What changed

**New creative engines** (`server/api/comfy/`)
- `utils/simpleCheckpointWorkflow.ts` — shared single-checkpoint graph (loader → CLIP → +/- text encode → KSampler → VAE). The negative is wired to **its own** encode node (not the positive, the Flux.1 path's bug), and there's an optional **model-only style-LoRA** hook.
- `krea2/utils/workflow.ts` — **Krea 2 Turbo** (Qwen-lineage, 8-step).
- `flux2/utils/workflow.ts` — **Flux.2 Klein 4B** (4-step, Apache-2.0) with a JSON structured-prompt path.
- `enqueue.post.ts` — dispatch `krea2`/`flux2` (+ aliases), billed at the base 2D tier, passing through `jsonPrompt`/`lora` knobs.

**Real-seed persistence**
- `artJobPayload.ts` — `extractWorkflowSeed()` recovers the concrete seed baked into a graph's `KSampler`/`RandomNoise` node.
- `complete.post.ts` — backfill `ArtImage.seed` from the real workflow seed when the relay echo is missing/`-1`, so accepted renders are reproducible (both the normal and OVERWRITE paths).

**Tunable retry** (the "try again"/"requeue with different settings" ask)
- `artJobRetry.ts` — `applyArtJobOverrides()` patches steps / checkpoint / seed / cfg / sampler / scheduler / negative onto a retry payload (graph nodes **and** the raw A1111 path).
- `reenqueue.post.ts` — accepts an `overrides` block; an explicit seed override wins over the default seed refresh.
- `artJobStore.ts` + `artjob-manager.vue` — an **"Adjust settings & retry"** modal to change those settings before re-running.

## Verification

`node_modules` isn't installed in this environment, so full `vue-tsc` runs in CI. The three self-contained new/changed server utils (`simpleCheckpointWorkflow.ts`, `artJobPayload.ts`, `artJobRetry.ts`) and both engine builders **type-check clean under `tsc --strict`** in isolation. The Nuxt-coupled edits (enqueue/complete/reenqueue dispatch, store, component) are mirror-pattern changes.

> ⚠️ The Krea2/Klein model filenames and CLIP `type` strings are configurable constants at the top of each engine module — verify against your ComfyUI models (Krea uses CLIPLoader type `krea2`, Klein type `flux2`; GGUF users flip the loader constant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9)_