### PR TITLE
WonderLab: retry bounded read checks during voice polish

### DIFF
--- a/scripts/apply-wonderlab-voice-polish-batch.mjs
+++ b/scripts/apply-wonderlab-voice-polish-batch.mjs
@@ -15,6 +15,18 @@ const outputDir = resolve(
   process.env.WONDERLAB_VOICE_POLISH_OUTPUT ||
     'wonderlab-voice-polish-apply-artifacts',
 )
+const getAttempts = Math.max(
+  1,
+  Number(process.env.WONDERLAB_VOICE_POLISH_GET_ATTEMPTS || 4),
+)
+const getTimeoutMs = Math.max(
+  5_000,
+  Number(process.env.WONDERLAB_VOICE_POLISH_GET_TIMEOUT_MS || 30_000),
+)
+const mutationTimeoutMs = Math.max(
+  10_000,
+  Number(process.env.WONDERLAB_VOICE_POLISH_MUTATION_TIMEOUT_MS || 60_000),
+)
 
 if (!token) throw new Error('WONDERLAB_ADMIN_TOKEN is required.')
 
@@ -33,22 +45,67 @@ function adminHeaders() {
   }
 }
 
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms))
+}
+
 async function request(path, { method = 'GET', body, admin = false } = {}) {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method,
-    headers: admin
-      ? adminHeaders()
-      : { accept: 'application/json', 'cache-control': 'no-store' },
-    body: body === undefined ? undefined : JSON.stringify(body),
-    cache: 'no-store',
-  })
-  const payload = await response.json().catch(() => null)
-  if (!response.ok) {
-    throw new Error(
-      payload?.message || payload?.statusMessage || `${method} ${path} returned ${response.status}.`,
-    )
+  const normalizedMethod = method.toUpperCase()
+  const isRead = normalizedMethod === 'GET'
+  const attempts = isRead ? getAttempts : 1
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const controller = new AbortController()
+    const timeoutMs = isRead ? getTimeoutMs : mutationTimeoutMs
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    let response
+
+    try {
+      response = await fetch(`${baseUrl}${path}`, {
+        method: normalizedMethod,
+        headers: admin
+          ? adminHeaders()
+          : { accept: 'application/json', 'cache-control': 'no-store' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        cache: 'no-store',
+        signal: controller.signal,
+      })
+    } catch (error) {
+      clearTimeout(timeoutId)
+      if (isRead && attempt < attempts) {
+        const delayMs = 1_000 * attempt
+        console.warn(
+          `GET ${path} failed on attempt ${attempt}/${attempts}; retrying in ${delayMs}ms: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        await sleep(delayMs)
+        continue
+      }
+      throw error
+    }
+
+    clearTimeout(timeoutId)
+    const payload = await response.json().catch(() => null)
+    if (!response.ok) {
+      const message =
+        payload?.message ||
+        payload?.statusMessage ||
+        `${normalizedMethod} ${path} returned ${response.status}.`
+      const retryableRead =
+        isRead && (response.status === 429 || response.status >= 500)
+      if (retryableRead && attempt < attempts) {
+        const delayMs = 1_000 * attempt
+        console.warn(
+          `GET ${path} returned ${response.status} on attempt ${attempt}/${attempts}; retrying in ${delayMs}ms.`,
+        )
+        await sleep(delayMs)
+        continue
+      }
+      throw new Error(message)
+    }
+    return payload?.data ?? payload
   }
-  return payload?.data ?? payload
+
+  throw new Error(`GET ${path} exhausted ${attempts} attempts.`)
 }
 
 function assertPositiveInteger(value, label) {


### PR DESCRIPTION
Hardens the guarded production commentary runner after batch 011 stalled between drafts #226 and #227 without an HTTP error.

## Change
- adds a 30-second timeout to read-only GET checks
- retries GETs up to four times with bounded linear backoff
- retries transient network failures, aborts, HTTP 429, and HTTP 5xx responses
- leaves PATCH mutations strictly single-attempt to avoid ambiguous duplicate writes
- makes timeout and attempt counts configurable through environment variables

## Recovery behavior
The latest manifest remains batch 014 (definitive batch 011). After this PR is merged with the apply trigger, the runner will:
- recognize drafts #209–#226 as already applied
- resume the Siege Engine pair at #227–#228
- run the complete 706-review post-audit, validating both batch 010 and batch 011

No commentary text, assignments, ratings, Reaction IDs, or source locks change in this PR.

Tracks silasfelinus/conductor#1013.