### PR TITLE
WonderLab: guard commentary by direct Reaction ID

### DIFF
--- a/scripts/apply-wonderlab-voice-polish-batch.mjs
+++ b/scripts/apply-wonderlab-voice-polish-batch.mjs
@@ -166,12 +166,11 @@ function authorMatches(actual, expected) {
   return actual?.kind === expected.kind && Number(actual?.id) === expected.id
 }
 
-function findPublicReaction(reviews, reactionId) {
-  return reviews.find((review) => Number(review.id) === reactionId)
-}
-
 function assertPublicLock(review, revision, publisherUserId) {
   if (!review) throw new Error(`Reaction ${revision.reactionId} is not publicly projected.`)
+  if (Number(review.id) !== revision.reactionId) {
+    throw new Error(`Reaction ${revision.reactionId} identity lock changed.`)
+  }
   if (Number(review.componentId) !== revision.componentId) {
     throw new Error(`Reaction ${revision.reactionId} Component lock changed.`)
   }
@@ -219,10 +218,10 @@ for (const revision of manifest.revisions) {
     throw new Error(`Draft ${revision.draftId} reaction type lock changed.`)
   }
 
-  const beforeReviews = await request(
-    `/api/reactions/component/${revision.componentId}?voicePolish=${Date.now()}`,
+  const beforeReaction = await request(
+    `/api/admin/wonderlab/reactions/${revision.reactionId}`,
+    { admin: true },
   )
-  const beforeReaction = findPublicReaction(beforeReviews, revision.reactionId)
   const publisherUserId = Number(beforeDraft.publisherUserId)
   assertPositiveInteger(publisherUserId, 'publisherUserId')
   assertPublicLock(beforeReaction, revision, publisherUserId)
@@ -275,10 +274,10 @@ for (const revision of manifest.revisions) {
     `/api/admin/wonderlab/review-drafts/${revision.draftId}`,
     { admin: true },
   )
-  const afterReviews = await request(
-    `/api/reactions/component/${revision.componentId}?voicePolish=${Date.now()}-${revision.draftId}`,
+  const afterReaction = await request(
+    `/api/admin/wonderlab/reactions/${revision.reactionId}`,
+    { admin: true },
   )
-  const afterReaction = findPublicReaction(afterReviews, revision.reactionId)
   assertPublicLock(afterReaction, revision, publisherUserId)
 
   if (afterDraft.status !== 'PUBLISHED') {

--- a/server/api/admin/wonderlab/reactions/[id].get.ts
+++ b/server/api/admin/wonderlab/reactions/[id].get.ts
@@ -1,0 +1,132 @@
+// /server/api/admin/wonderlab/reactions/[id].get.ts
+import { createError, defineEventHandler, getRouterParam, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import prisma from '@/server/utils/prisma'
+import {
+  firstPartyReactionAuthor,
+  type FirstPartyReactionAuthor,
+} from '@/utils/reactions/firstPartyReactionAuthor'
+
+type GuardedReactionRow = {
+  id: number
+  comment: string | null
+  userId: number
+  componentId: number | null
+  reactionType: string
+  rating: number
+  authorBotId: number | null
+  authorCharacterId: number | null
+  userUsername: string | null
+  userName: string | null
+  userAvatarImage: string | null
+  userRole: string | null
+  userIsPublic: boolean | number
+  authorBotName: string | null
+  authorBotAvatarImage: string | null
+  authorBotImagePath: string | null
+  authorBotRole: string | null
+  authorCharacterName: string | null
+  authorCharacterImagePath: string | null
+  authorCharacterRole: string | null
+}
+
+function projectFirstPartyAuthor(
+  row: GuardedReactionRow,
+): FirstPartyReactionAuthor | null {
+  try {
+    return firstPartyReactionAuthor({
+      authorBotId: row.authorBotId,
+      authorCharacterId: row.authorCharacterId,
+      AuthorBot: row.authorBotId
+        ? {
+            id: row.authorBotId,
+            name: row.authorBotName,
+            avatarImage: row.authorBotAvatarImage,
+            imagePath: row.authorBotImagePath,
+            BotType: row.authorBotRole,
+          }
+        : null,
+      AuthorCharacter: row.authorCharacterId
+        ? {
+            id: row.authorCharacterId,
+            name: row.authorCharacterName,
+            imagePath: row.authorCharacterImagePath,
+            characterType: row.authorCharacterRole,
+          }
+        : null,
+    })
+  } catch {
+    return null
+  }
+}
+
+function projectGuardedReaction(row: GuardedReactionRow) {
+  return {
+    id: row.id,
+    comment: row.comment,
+    userId: row.userId,
+    componentId: row.componentId,
+    reactionType: row.reactionType,
+    rating: row.rating,
+    User: {
+      id: row.userId,
+      username: row.userUsername,
+      name: row.userName,
+      avatarImage: row.userAvatarImage,
+      Role: row.userRole,
+      isPublic: Boolean(row.userIsPublic),
+    },
+    Author: projectFirstPartyAuthor(row),
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const reactionId = Number(getRouterParam(event, 'id'))
+    if (!Number.isInteger(reactionId) || reactionId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Reaction ID.' })
+    }
+
+    const rows = await prisma.$queryRaw<GuardedReactionRow[]>`
+      SELECT
+        r.id,
+        r.comment,
+        r.userId,
+        r.componentId,
+        r.reactionType,
+        r.rating,
+        r.authorBotId,
+        r.authorCharacterId,
+        u.username AS userUsername,
+        u.name AS userName,
+        u.avatarImage AS userAvatarImage,
+        u.Role AS userRole,
+        u.isPublic AS userIsPublic,
+        b.name AS authorBotName,
+        b.avatarImage AS authorBotAvatarImage,
+        b.imagePath AS authorBotImagePath,
+        b.BotType AS authorBotRole,
+        ch.name AS authorCharacterName,
+        ch.imagePath AS authorCharacterImagePath,
+        ch.role AS authorCharacterRole
+      FROM Reaction r
+      INNER JOIN User u ON u.id = r.userId
+      LEFT JOIN Bot b ON b.id = r.authorBotId
+      LEFT JOIN \`Character\` ch ON ch.id = r.authorCharacterId
+      WHERE r.id = ${reactionId}
+      LIMIT 1
+    `
+
+    const row = rows[0]
+    if (!row) {
+      throw createError({ statusCode: 404, message: 'Reaction not found.' })
+    }
+
+    return { success: true, data: projectGuardedReaction(row) }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/server/api/comfy/utils/simpleCheckpointWorkflow.ts
+++ b/server/api/comfy/utils/simpleCheckpointWorkflow.ts
@@ -135,8 +135,13 @@ export function buildSimpleCheckpointWorkflow(input: SimpleCheckpointInput): {
       class_type: 'LoraLoaderModelOnly',
       _meta: { title: 'Style LoRA' },
     }
+
     // Route the sampler's model through the LoRA; CLIP stays on the encoder.
-    ;(workflow['7'].inputs as Record<string, unknown>).model = ['10', 0]
+    const sampler = workflow['7']
+    if (!sampler?.inputs) {
+      throw new Error('KSampler node is missing from the simple checkpoint workflow.')
+    }
+    sampler.inputs.model = ['10', 0]
   }
 
   return { workflow, seed }

--- a/utils/scripts/verifyReviewDraftAdminApi.ts
+++ b/utils/scripts/verifyReviewDraftAdminApi.ts
@@ -50,7 +50,8 @@ const listPath = 'server/api/admin/wonderlab/review-drafts/index.get.ts'
 const createPath = 'server/api/admin/wonderlab/review-drafts/index.post.ts'
 const detailPath = 'server/api/admin/wonderlab/review-drafts/[id].get.ts'
 const patchPath = 'server/api/admin/wonderlab/review-drafts/[id].patch.ts'
-const paths = [listPath, createPath, detailPath, patchPath]
+const reactionGuardPath = 'server/api/admin/wonderlab/reactions/[id].get.ts'
+const paths = [listPath, createPath, detailPath, patchPath, reactionGuardPath]
 
 for (const path of paths) {
   const source = await readFile(path, 'utf8')
@@ -64,6 +65,15 @@ assert.doesNotMatch(createSource, /status\??:/)
 
 const patchSource = await readFile(patchPath, 'utf8')
 assert.match(patchSource, /controlled publication service/i)
+
+const reactionGuardSource = await readFile(reactionGuardPath, 'utf8')
+assert.match(reactionGuardSource, /WHERE r\.id = \$\{reactionId\}/)
+assert.match(reactionGuardSource, /LIMIT 1/)
+assert.doesNotMatch(reactionGuardSource, /WHERE r\.componentId/)
+
+const applySource = await readFile('scripts/apply-wonderlab-voice-polish-batch.mjs', 'utf8')
+assert.match(applySource, /\/api\/admin\/wonderlab\/reactions\/\$\{revision\.reactionId\}/)
+assert.doesNotMatch(applySource, /\/api\/reactions\/component\//)
 
 const repositorySource = await readFile('server/utils/reviewDraftRepository.ts', 'utf8')
 assert.match(repositorySource, /INSERT IGNORE INTO ReviewDraft/)


### PR DESCRIPTION
Removes the deterministic stall in the guarded WonderLab commentary runner by replacing broad Component reaction scans with an indexed single-Reaction projection.

## New admin projection
- adds `GET /api/admin/wonderlab/reactions/:id`
- requires `requireAdminApiUser`
- queries `Reaction.id` directly with `LIMIT 1`
- returns only the fields required to lock publication identity: Reaction ID, comment, Component, publisher, first-party author, stars, and reaction type
- projects the same `User` and `Author` shapes used by the public component endpoint

## Runner change
- verifies the exact published Reaction before and after each PATCH
- preserves all existing draft, source, assignment, publisher, star, type, and hash guards
- adds an explicit Reaction identity assertion
- removes all dependence on `/api/reactions/component/:id`, whose unbounded all-reactions query hangs for Siege Engine Component #1261
- retains bounded GET retries and single-attempt PATCH behavior

## Contract
The ReviewDraft admin API contract now requires the direct admin route, its `WHERE r.id = ${reactionId}` / `LIMIT 1` query, and forbids the apply script from referencing the broad Component endpoint.

## Incidental CI blocker
TypeScript also exposed an unsafe indexed access introduced by the recently merged simple checkpoint workflow. This PR adds a narrow KSampler existence/input guard before routing the optional LoRA model through node 7; valid workflows behave identically.

After merge with the apply trigger, batch 014 will replay idempotently, recognize #209–#226 as already applied, finish #227–#228, and run the full 706-review audit covering batches 010 and 011.

Tracks silasfelinus/conductor#1013.