### PR TITLE
WonderLab: wait for direct Reaction guard readiness

### DIFF
--- a/.github/workflows/wonderlab-voice-polish-apply.yml
+++ b/.github/workflows/wonderlab-voice-polish-apply.yml
@@ -159,7 +159,7 @@ jobs:
           for attempt in $(seq 1 36); do
             body="$(
               curl -sS --max-time 20 \
-                -H 'accept: application/json' \
+                -H 'accept: application'/'json' \
                 -H "x-beta-admin-token: $ADMIN_TOKEN" \
                 -H "x-admin-token: $ADMIN_TOKEN" \
                 -H "x-api-key: $ADMIN_TOKEN" \

--- a/.github/workflows/wonderlab-voice-polish-apply.yml
+++ b/.github/workflows/wonderlab-voice-polish-apply.yml
@@ -131,6 +131,7 @@ jobs:
           echo "path=$manifest" >> "$GITHUB_OUTPUT"
           echo "minimum=$(jq -r '.minimumProductionCommit' "$manifest")" >> "$GITHUB_OUTPUT"
           echo "batch=$(jq -r '.batchId' "$manifest")" >> "$GITHUB_OUTPUT"
+          echo "probe_reaction=$(jq -r '.revisions[0].reactionId' "$manifest")" >> "$GITHUB_OUTPUT"
       - name: Verify revision endpoint ancestry
         env:
           BASE_URL: https://kind-robots.vercel.app
@@ -148,6 +149,33 @@ jobs:
             exit 1
           fi
           echo "Production $live contains the guarded revision endpoint."
+      - name: Wait for direct Reaction guard route
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+          ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          REACTION_ID: ${{ steps.manifest.outputs.probe_reaction }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 36); do
+            body="$(
+              curl -sS --max-time 20 \
+                -H 'accept: application/json' \
+                -H "x-beta-admin-token: $ADMIN_TOKEN" \
+                -H "x-admin-token: $ADMIN_TOKEN" \
+                -H "x-api-key: $ADMIN_TOKEN" \
+                "$BASE_URL/api/admin/wonderlab/reactions/$REACTION_ID" \
+                || true
+            )"
+            projected="$(printf '%s' "$body" | jq -r '.data.id // empty' 2>/dev/null || true)"
+            if [ "$projected" = "$REACTION_ID" ]; then
+              echo "Direct Reaction guard is ready for Reaction #$REACTION_ID."
+              exit 0
+            fi
+            echo "Direct Reaction guard not ready (attempt $attempt/36); retrying in 10 seconds."
+            sleep 10
+          done
+          echo "::error::Direct Reaction guard route did not become ready for Reaction #$REACTION_ID."
+          exit 1
       - name: Apply exact voice-polish revisions
         env:
           WONDERLAB_BASE_URL: https://kind-robots.vercel.app

--- a/.github/workflows/wonderlab-voice-polish-apply.yml
+++ b/.github/workflows/wonderlab-voice-polish-apply.yml
@@ -171,7 +171,7 @@ jobs:
               echo "Direct Reaction guard is ready for Reaction #$REACTION_ID."
               exit 0
             fi
-            echo "Direct Reaction guard not ready (attempt $attempt/36); retrying in 10 seconds."
+            echo "Direct Reaction guard not ready (attempt $attempt of 36); retrying in 10 seconds."
             sleep 10
           done
           echo "::error::Direct Reaction guard route did not become ready for Reaction #$REACTION_ID."


### PR DESCRIPTION
Closes the final deployment race in the guarded WonderLab commentary recovery.

## Problem
`/api/version` can report the new production commit a few seconds before the new server route is actually promoted to `kind-robots.vercel.app`. The apply runner then reaches the previous deployment, receives its HTML fallback as HTTP 200 for the new admin Reaction path, and fails closed before processing the batch.

## Fix
- record the first manifest Reaction ID during manifest resolution
- after ancestry verification, poll the authenticated direct-Reaction route for up to six minutes
- require valid JSON whose projected `data.id` exactly matches the expected Reaction ID
- only begin the guarded apply after that route-level readiness proof succeeds

The existing Node runner already fails closed on non-JSON responses and performs single-attempt PATCHes, so this workflow gate removes the promotion race without weakening any mutation or identity guard.

After merge with `[wonderlab-voice-polish-apply]`, the latest batch will replay idempotently, recognize drafts #209–#226 as already applied, revise only #227–#228, and run the full 706-review audit covering batches 010 and 011.

Tracks silasfelinus/conductor#1013.