### PR TITLE
WonderLab: publish guarded voice-polish preflight

### DIFF
--- a/.github/workflows/wonderlab-voice-polish-apply.yml
+++ b/.github/workflows/wonderlab-voice-polish-apply.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/wonderlab-voice-polish-apply.yml'
       - 'scripts/apply-wonderlab-voice-polish-batch.mjs'
+      - 'scripts/preflight-wonderlab-voice-polish-batch.mjs'
       - 'scripts/wonderlab-definitive-inventory.mjs'
       - 'config/*wonderlab-voice-polish-batch*.json'
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - '.github/workflows/wonderlab-voice-polish-apply.yml'
       - 'scripts/apply-wonderlab-voice-polish-batch.mjs'
+      - 'scripts/preflight-wonderlab-voice-polish-batch.mjs'
       - 'scripts/wonderlab-definitive-inventory.mjs'
       - 'config/*wonderlab-voice-polish-batch*.json'
   workflow_dispatch:
@@ -23,7 +25,7 @@ on:
         default: ''
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: wonderlab-voice-polish-apply
@@ -42,6 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           node --check scripts/apply-wonderlab-voice-polish-batch.mjs
+          node --check scripts/preflight-wonderlab-voice-polish-batch.mjs
           node --check scripts/wonderlab-definitive-inventory.mjs
           node <<'NODE'
           const fs = require('node:fs')
@@ -80,6 +83,7 @@ jobs:
             }
           }
           const runner = fs.readFileSync('scripts/apply-wonderlab-voice-polish-batch.mjs', 'utf8')
+          const preflight = fs.readFileSync('scripts/preflight-wonderlab-voice-polish-batch.mjs', 'utf8')
           for (const required of [
             '/review-drafts/${revision.draftId}/revise',
             'expectedCurrentCommentHash',
@@ -89,6 +93,17 @@ jobs:
             'publisherUserId',
             'flavorLength',
           ]) assert.ok(runner.includes(required), `missing guarded apply boundary: ${required}`)
+          for (const required of [
+            'publicationState',
+            'componentAssignment',
+            'reactionAssignment',
+            'reviewerAssignment',
+            'sourceLock',
+            'ratingLock',
+            'reactionTypeLock',
+            'publicReactionIdentity',
+            'draftProjectionAgreement',
+          ]) assert.ok(preflight.includes(required), `missing guarded preflight boundary: ${required}`)
           for (const forbidden of [
             '/publish',
             '/generate',
@@ -96,7 +111,10 @@ jobs:
             '/reject',
             'DATABASE_URL',
             'prisma.',
-          ]) assert.ok(!runner.includes(forbidden), `voice-polish runner crossed boundary: ${forbidden}`)
+          ]) {
+            assert.ok(!runner.includes(forbidden), `voice-polish runner crossed boundary: ${forbidden}`)
+            assert.ok(!preflight.includes(forbidden), `voice-polish preflight crossed boundary: ${forbidden}`)
+          }
           console.log(`WonderLab guarded flavor manifests passed: ${paths.length}.`)
           NODE
 
@@ -176,6 +194,48 @@ jobs:
           done
           echo "::error::Direct Reaction guard route did not become ready for Reaction #$REACTION_ID."
           exit 1
+      - name: Inspect exact publication locks
+        id: preflight
+        continue-on-error: true
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_VOICE_POLISH_MANIFEST: ${{ steps.manifest.outputs.path }}
+          WONDERLAB_VOICE_POLISH_PREFLIGHT_OUTPUT: wonderlab-voice-polish-preflight-artifacts
+        run: node scripts/preflight-wonderlab-voice-polish-batch.mjs
+      - name: Publish preflight evidence
+        if: always() && steps.preflight.outcome != 'skipped'
+        env:
+          PREFLIGHT_BRANCH: wonderlab-voice-polish-preflight
+          PREFLIGHT_DIR: wonderlab-voice-polish-preflight-artifacts
+        run: |
+          set -euo pipefail
+          snapshot_tmp="$(mktemp -d)"
+          publish_tmp="$(mktemp -d)"
+          cp -R "$PREFLIGHT_DIR"/. "$snapshot_tmp"/
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git worktree add --detach "$publish_tmp" HEAD
+          cd "$publish_tmp"
+          git switch --orphan "$PREFLIGHT_BRANCH"
+          git rm -rf .
+          mkdir -p preflight
+          cp -R "$snapshot_tmp"/. preflight/
+          cat > README.md <<EOF
+          # WonderLab voice-polish preflight
+
+          Generated from the authenticated production API by workflow run ${GITHUB_RUN_ID}.
+
+          This branch is machine-generated and force-updated. It records IDs, hashes and invariant comparisons only; it contains no credentials or full commentary text.
+          EOF
+          git add README.md preflight
+          git commit -m "[skip ci] WonderLab voice-polish preflight (run ${GITHUB_RUN_ID})"
+          git push --force origin "HEAD:${PREFLIGHT_BRANCH}"
+      - name: Enforce preflight result
+        if: steps.preflight.outcome != 'success'
+        run: |
+          echo "::error::Guarded voice-polish preflight found a lock mismatch or read failure."
+          exit 1
       - name: Apply exact voice-polish revisions
         env:
           WONDERLAB_BASE_URL: https://kind-robots.vercel.app
@@ -194,16 +254,19 @@ jobs:
         with:
           name: wonderlab-voice-polish-${{ steps.manifest.outputs.batch }}-${{ github.run_id }}
           path: |
+            wonderlab-voice-polish-preflight-artifacts
             wonderlab-voice-polish-apply-artifacts
             wonderlab-voice-polish-post-audit
           retention-days: 30
       - name: Write workflow summary
         env:
+          PREFLIGHT_COMMENT: wonderlab-voice-polish-preflight-artifacts/wonderlab-voice-polish-preflight.md
           APPLY_REPORT: wonderlab-voice-polish-apply-artifacts/wonderlab-voice-polish-apply.json
           APPLY_COMMENT: wonderlab-voice-polish-apply-artifacts/wonderlab-voice-polish-apply.md
           AUDIT_REPORT: wonderlab-voice-polish-post-audit/wonderlab-definitive-inventory.json
         run: |
           set -euo pipefail
+          cat "$PREFLIGHT_COMMENT" >> "$GITHUB_STEP_SUMMARY"
           cat "$APPLY_COMMENT" >> "$GITHUB_STEP_SUMMARY"
           printf '\n## Full-corpus post-audit\n\n' >> "$GITHUB_STEP_SUMMARY"
           published="$(jq -r '.scan.publishedReviews' "$AUDIT_REPORT")"

--- a/scripts/preflight-wonderlab-voice-polish-batch.mjs
+++ b/scripts/preflight-wonderlab-voice-polish-batch.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const baseUrl = String(
+  process.env.WONDERLAB_BASE_URL || 'https://kind-robots.vercel.app',
+).replace(/\/$/, '')
+const token = String(process.env.WONDERLAB_ADMIN_TOKEN || '').trim()
+const manifestPath = resolve(
+  process.env.WONDERLAB_VOICE_POLISH_MANIFEST ||
+    'config/wonderlab-voice-polish-batch-001.json',
+)
+const outputDir = resolve(
+  process.env.WONDERLAB_VOICE_POLISH_PREFLIGHT_OUTPUT ||
+    'wonderlab-voice-polish-preflight-artifacts',
+)
+const timeoutMs = Math.max(
+  5_000,
+  Number(process.env.WONDERLAB_VOICE_POLISH_PREFLIGHT_TIMEOUT_MS || 20_000),
+)
+const attempts = Math.max(
+  1,
+  Number(process.env.WONDERLAB_VOICE_POLISH_PREFLIGHT_ATTEMPTS || 2),
+)
+
+if (!token) throw new Error('WONDERLAB_ADMIN_TOKEN is required.')
+
+function sha256(value) {
+  return createHash('sha256').update(String(value ?? '')).digest('hex')
+}
+
+function adminHeaders() {
+  return {
+    accept: 'application/json',
+    'cache-control': 'no-store',
+    'x-beta-admin-token': token,
+    'x-admin-token': token,
+    'x-api-key': token,
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms))
+}
+
+async function request(path) {
+  let lastError = null
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetch(`${baseUrl}${path}`, {
+        headers: adminHeaders(),
+        cache: 'no-store',
+        signal: controller.signal,
+      })
+      clearTimeout(timeoutId)
+      const payload = await response.json().catch(() => null)
+      if (!response.ok) {
+        throw new Error(
+          payload?.message || payload?.statusMessage || `${path} returned ${response.status}.`,
+        )
+      }
+      if (!payload || typeof payload !== 'object') {
+        throw new Error(`${path} returned a non-JSON response.`)
+      }
+      return payload?.data ?? payload
+    } catch (error) {
+      clearTimeout(timeoutId)
+      lastError = error
+      if (attempt < attempts) await sleep(attempt * 1_000)
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(`Failed to read ${path}.`)
+}
+
+function authorRef(value) {
+  if (!value || typeof value !== 'object') return null
+  return {
+    kind: value.kind ?? null,
+    id: Number(value.id) || null,
+  }
+}
+
+function authorMatches(actual, expected) {
+  return actual?.kind === expected.kind && Number(actual?.id) === expected.id
+}
+
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+const version = await request('/api/version')
+const results = []
+
+for (const revision of manifest.revisions) {
+  const entry = {
+    canonicalOrder: revision.canonicalOrder,
+    draftId: revision.draftId,
+    expected: {
+      status: 'PUBLISHED',
+      componentId: revision.componentId,
+      reactionId: revision.reactionId,
+      author: authorRef(revision.author),
+      sourceKey: revision.sourceKey,
+      rating: revision.expectedRating,
+      reactionType: revision.expectedReactionType,
+      currentCommentHash: revision.expectedCurrentCommentHash,
+    },
+    actual: null,
+    checks: null,
+    error: null,
+  }
+
+  try {
+    const draft = await request(
+      `/api/admin/wonderlab/review-drafts/${revision.draftId}`,
+    )
+    const reaction = await request(
+      `/api/admin/wonderlab/reactions/${revision.reactionId}`,
+    )
+    const sourceKey =
+      draft?.promptPayload?.provenance?.exhibitSourcePath ?? null
+    const actual = {
+      status: draft?.status ?? null,
+      componentId: Number(draft?.componentId) || null,
+      reactionId: Number(draft?.publishedReactionId) || null,
+      author: authorRef(draft?.author),
+      sourceKey,
+      rating: Number(draft?.rating),
+      reactionType: draft?.reactionType ?? null,
+      publisherUserId: Number(draft?.publisherUserId) || null,
+      draftCommentHash: sha256(
+        draft?.finalComment ?? draft?.editedComment ?? draft?.generatedComment ?? '',
+      ),
+      publicReactionId: Number(reaction?.id) || null,
+      publicComponentId: Number(reaction?.componentId) || null,
+      publicAuthor: authorRef(reaction?.Author),
+      publicPublisherUserId: Number(reaction?.userId) || null,
+      publicRating: Number(reaction?.rating),
+      publicReactionType: reaction?.reactionType ?? null,
+      publicCommentHash: sha256(reaction?.comment ?? ''),
+    }
+    const checks = {
+      publicationState: actual.status === 'PUBLISHED',
+      componentAssignment: actual.componentId === revision.componentId,
+      reactionAssignment: actual.reactionId === revision.reactionId,
+      reviewerAssignment: authorMatches(actual.author, revision.author),
+      sourceLock: actual.sourceKey === revision.sourceKey,
+      ratingLock: actual.rating === revision.expectedRating,
+      reactionTypeLock:
+        actual.reactionType === revision.expectedReactionType,
+      publicReactionIdentity: actual.publicReactionId === revision.reactionId,
+      publicComponentLock:
+        actual.publicComponentId === revision.componentId,
+      publicReviewerLock:
+        authorMatches(actual.publicAuthor, revision.author),
+      publicPublisherLock:
+        actual.publicPublisherUserId === actual.publisherUserId,
+      publicRatingLock:
+        actual.publicRating === revision.expectedRating,
+      publicReactionTypeLock:
+        actual.publicReactionType === revision.expectedReactionType,
+      draftProjectionAgreement:
+        actual.draftCommentHash === actual.publicCommentHash,
+      expectedCurrentHash:
+        actual.publicCommentHash === revision.expectedCurrentCommentHash,
+      alreadyApplied:
+        actual.publicCommentHash === sha256(revision.editedComment),
+    }
+    entry.actual = actual
+    entry.checks = checks
+  } catch (error) {
+    entry.error = error instanceof Error ? error.message : String(error)
+  }
+
+  results.push(entry)
+}
+
+const blockers = results.filter((entry) => {
+  if (entry.error) return true
+  const checks = entry.checks || {}
+  const invariantChecks = Object.entries(checks).filter(
+    ([name]) => name !== 'expectedCurrentHash' && name !== 'alreadyApplied',
+  )
+  if (invariantChecks.some(([, passed]) => passed !== true)) return true
+  return checks.alreadyApplied !== true && checks.expectedCurrentHash !== true
+})
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  batchId: manifest.batchId,
+  manifestPath,
+  production: version,
+  revisions: results.length,
+  blockers: blockers.length,
+  results,
+}
+
+const markdown = [
+  `## WonderLab voice-polish preflight ${manifest.batchId}`,
+  '',
+  `- **Production:** \`${version.commit || 'unknown'}\` · deployment \`${version.deploymentId || 'unknown'}\``,
+  `- **Revisions inspected:** ${results.length}`,
+  `- **Blocking lock mismatches or read errors:** ${blockers.length}`,
+  '- **Mutation boundary:** read-only; no ReviewDraft or Reaction was edited',
+  '',
+  ...blockers.map((entry) => {
+    const failed = entry.error
+      ? entry.error
+      : Object.entries(entry.checks || {})
+          .filter(([name, passed]) =>
+            !['expectedCurrentHash', 'alreadyApplied'].includes(name) && passed !== true,
+          )
+          .map(([name]) => name)
+          .join(', ') || 'comment hash differs from both expected and revised text'
+    return `- Draft #${entry.draftId} / Reaction #${entry.expected.reactionId}: ${failed}`
+  }),
+  '',
+].join('\n')
+
+await mkdir(outputDir, { recursive: true })
+await Promise.all([
+  writeFile(
+    resolve(outputDir, 'wonderlab-voice-polish-preflight.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+  ),
+  writeFile(
+    resolve(outputDir, 'wonderlab-voice-polish-preflight.md'),
+    markdown,
+  ),
+])
+
+console.log(markdown)
+if (blockers.length) process.exitCode = 1


### PR DESCRIPTION
Makes the definitive commentary runner self-diagnosing before any production mutation.

## Read-only preflight
- inspects every manifest ReviewDraft and exact published Reaction
- compares publication state, Component, Reaction, reviewer, source provenance, publisher, rating, reaction type, and draft/public projection agreement
- records SHA-256 hashes only; no full commentary or credentials are published
- recognizes both untouched expected text and already-applied revised text
- blocks the apply whenever any invariant differs or a guarded read fails

## Durable evidence
- force-publishes the sanitized report to the machine-generated `wonderlab-voice-polish-preflight` branch
- uses `[skip ci]` so the evidence branch does not create deployment churn
- preserves the ordinary Actions artifact and workflow summary
- keeps the existing single-attempt PATCH boundary unchanged

This resolves the remaining observability gap at draft #227: the next triggered run will either identify the exact safe lock mismatch or, if all preflight checks pass, continue idempotently through drafts #227–#228 and the full 706-review audit.

Tracks silasfelinus/conductor#1013.