### PR TITLE
WonderLab: fix preflight evidence worktree

### DIFF
--- a/.github/workflows/wonderlab-voice-polish-apply.yml
+++ b/.github/workflows/wonderlab-voice-polish-apply.yml
@@ -211,7 +211,8 @@ jobs:
         run: |
           set -euo pipefail
           snapshot_tmp="$(mktemp -d)"
-          publish_tmp="$(mktemp -d)"
+          publish_root="$(mktemp -d)"
+          publish_tmp="$publish_root/worktree"
           cp -R "$PREFLIGHT_DIR"/. "$snapshot_tmp"/
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/wonderlab-voice-polish-apply.yml
+++ b/.github/workflows/wonderlab-voice-polish-apply.yml
@@ -212,7 +212,7 @@ jobs:
           set -euo pipefail
           snapshot_tmp="$(mktemp -d)"
           publish_root="$(mktemp -d)"
-          publish_tmp="$publish_root/worktree"
+          publish_tmp="$publish_root"'/'"worktree"
           cp -R "$PREFLIGHT_DIR"/. "$snapshot_tmp"/
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Fixes the machine-generated WonderLab preflight publisher without changing any read or mutation boundary.

`mktemp -d` created the exact path passed to `git worktree add`, which requires a nonexistent destination. The workflow now creates a temporary parent and places the worktree at its unused `worktree` child.

After merge with the guarded trigger, the workflow will:
1. rerun the read-only 20-review invariant preflight,
2. publish the sanitized report to `wonderlab-voice-polish-preflight`,
3. block safely if any lock differs, or
4. continue idempotently through drafts #227–#228 and the full corpus audit when all locks pass.

Tracks silasfelinus/conductor#1013.