### PR TITLE
WonderLab: run guarded batch 011 recovery

### DIFF
--- a/.github/workflows/wonderlab-voice-polish-recovery.yml
+++ b/.github/workflows/wonderlab-voice-polish-recovery.yml
@@ -1,0 +1,131 @@
+name: WonderLab Voice Polish Recovery
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-voice-polish-recovery.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-voice-polish-recovery.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wonderlab-voice-polish-recovery
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate one-shot recovery workflow
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate fixed recovery inputs
+        run: |
+          set -euo pipefail
+          node --check scripts/preflight-wonderlab-voice-polish-batch.mjs
+          node --check scripts/apply-wonderlab-voice-polish-batch.mjs
+          node --check scripts/wonderlab-definitive-inventory.mjs
+          test -f config/wonderlab-voice-polish-batch-014.json
+
+  recover:
+    name: Recover definitive commentary batch 011
+    if: >-
+      github.event_name == 'push' &&
+      contains(github.event.head_commit.message, '[wonderlab-voice-polish-recovery]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Verify production ancestry and direct guard
+        env:
+          BASE_URL: https://kind-robots.vercel.app
+          ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          MANIFEST: config/wonderlab-voice-polish-batch-014.json
+        run: |
+          set -euo pipefail
+          minimum="$(jq -r '.minimumProductionCommit' "$MANIFEST")"
+          reaction_id="$(jq -r '.revisions[0].reactionId' "$MANIFEST")"
+          version="$(curl -sf --max-time 20 "$BASE_URL/api/version")"
+          live="$(printf '%s' "$version" | jq -r '.data.commit // empty')"
+          test -n "$live"
+          if ! git cat-file -e "${live}^{commit}" 2>/dev/null; then
+            git fetch --quiet origin main
+          fi
+          git merge-base --is-ancestor "$minimum" "$live"
+          for attempt in $(seq 1 36); do
+            body="$(
+              curl -sS --max-time 20 \
+                -H 'accept: application'/'json' \
+                -H "x-beta-admin-token: $ADMIN_TOKEN" \
+                -H "x-admin-token: $ADMIN_TOKEN" \
+                -H "x-api-key: $ADMIN_TOKEN" \
+                "$BASE_URL/api/admin/wonderlab/reactions/$reaction_id" \
+                || true
+            )"
+            projected="$(printf '%s' "$body" | jq -r '.data.id // empty' 2>/dev/null || true)"
+            if [ "$projected" = "$reaction_id" ]; then
+              echo "Production $live and direct Reaction guard are ready."
+              exit 0
+            fi
+            echo "Direct Reaction guard not ready (attempt $attempt of 36); retrying."
+            sleep 10
+          done
+          exit 1
+      - name: Preflight exact publication locks
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_VOICE_POLISH_MANIFEST: config/wonderlab-voice-polish-batch-014.json
+          WONDERLAB_VOICE_POLISH_PREFLIGHT_OUTPUT: wonderlab-voice-polish-preflight-artifacts
+        run: node scripts/preflight-wonderlab-voice-polish-batch.mjs
+      - name: Apply exact revisions
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_VOICE_POLISH_MANIFEST: config/wonderlab-voice-polish-batch-014.json
+          WONDERLAB_VOICE_POLISH_OUTPUT: wonderlab-voice-polish-apply-artifacts
+        run: node scripts/apply-wonderlab-voice-polish-batch.mjs
+      - name: Re-audit full published corpus
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+          WONDERLAB_DEFINITIVE_OUTPUT: wonderlab-voice-polish-post-audit
+        run: node scripts/wonderlab-definitive-inventory.mjs
+      - name: Upload recovery evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wonderlab-voice-polish-recovery-${{ github.run_id }}
+          path: |
+            wonderlab-voice-polish-preflight-artifacts
+            wonderlab-voice-polish-apply-artifacts
+            wonderlab-voice-polish-post-audit
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Write recovery summary
+        if: success()
+        run: |
+          set -euo pipefail
+          cat wonderlab-voice-polish-preflight-artifacts/wonderlab-voice-polish-preflight.md >> "$GITHUB_STEP_SUMMARY"
+          cat wonderlab-voice-polish-apply-artifacts/wonderlab-voice-polish-apply.md >> "$GITHUB_STEP_SUMMARY"
+          audit=wonderlab-voice-polish-post-audit/wonderlab-definitive-inventory.json
+          printf '\n## Full-corpus recovery audit\n\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' \
+            "- **Published reviews captured:** $(jq -r '.scan.publishedReviews' "$audit")" \
+            "- **Draft range:** #$(jq -r '.scan.firstDraftId' "$audit")–#$(jq -r '.scan.lastDraftId' "$audit")" \
+            "- **Highest draft ID scanned:** #$(jq -r '.scan.highestDraftId' "$audit")" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wonderlab-voice-polish-recovery.yml
+++ b/.github/workflows/wonderlab-voice-polish-recovery.yml
@@ -118,14 +118,15 @@ jobs:
           retention-days: 30
       - name: Write recovery summary
         if: success()
+        env:
+          AUDIT_REPORT: wonderlab-voice-polish-post-audit/wonderlab-definitive-inventory.json
         run: |
           set -euo pipefail
           cat wonderlab-voice-polish-preflight-artifacts/wonderlab-voice-polish-preflight.md >> "$GITHUB_STEP_SUMMARY"
           cat wonderlab-voice-polish-apply-artifacts/wonderlab-voice-polish-apply.md >> "$GITHUB_STEP_SUMMARY"
-          audit=wonderlab-voice-polish-post-audit/wonderlab-definitive-inventory.json
           printf '\n## Full-corpus recovery audit\n\n' >> "$GITHUB_STEP_SUMMARY"
           printf '%s\n' \
-            "- **Published reviews captured:** $(jq -r '.scan.publishedReviews' "$audit")" \
-            "- **Draft range:** #$(jq -r '.scan.firstDraftId' "$audit")–#$(jq -r '.scan.lastDraftId' "$audit")" \
-            "- **Highest draft ID scanned:** #$(jq -r '.scan.highestDraftId' "$audit")" \
+            "- **Published reviews captured:** $(jq -r '.scan.publishedReviews' "$AUDIT_REPORT")" \
+            "- **Draft range:** #$(jq -r '.scan.firstDraftId' "$AUDIT_REPORT")–#$(jq -r '.scan.lastDraftId' "$AUDIT_REPORT")" \
+            "- **Highest draft ID scanned:** #$(jq -r '.scan.highestDraftId' "$AUDIT_REPORT")" \
             >> "$GITHUB_STEP_SUMMARY"

--- a/config/academy-example-manifest-pending.json
+++ b/config/academy-example-manifest-pending.json
@@ -1,0 +1,44 @@
+[
+  {
+    "movement": "expressionism",
+    "file": "public/images/academy/examples/the-yellow-cow-49-1210.jpg",
+    "workTitle": "The Yellow Cow",
+    "artist": "Franz Marc",
+    "artistDied": 1916,
+    "year": "1911",
+    "collection": "Solomon R. Guggenheim Museum",
+    "accessionId": "49.1210",
+    "sourceUrl": "https://commons.wikimedia.org/wiki/File:Franz_Marc-The_Yellow_Cow-1911.jpg",
+    "license": "PD-Mark",
+    "licenseTermsUrl": "https://commons.wikimedia.org/wiki/Commons:Reusing_content_outside_Wikimedia",
+    "retrievedDate": "2026-07-21"
+  },
+  {
+    "movement": "cubism",
+    "file": "public/images/academy/examples/fantomas-1976-59-1.jpg",
+    "workTitle": "Fantômas",
+    "artist": "Juan Gris",
+    "artistDied": 1927,
+    "year": "1915",
+    "collection": "National Gallery of Art, Washington",
+    "accessionId": "1976.59.1",
+    "sourceUrl": "https://www.nga.gov/artworks/56101-fantomas",
+    "license": "CC0",
+    "licenseTermsUrl": "https://www.nga.gov/artworks/free-images-and-open-access",
+    "retrievedDate": "2026-07-21"
+  },
+  {
+    "movement": "bauhaus",
+    "file": "public/images/academy/examples/composition-8-37-262.jpg",
+    "workTitle": "Composition 8 (Komposition 8)",
+    "artist": "Wassily Kandinsky",
+    "artistDied": 1944,
+    "year": "July 1923",
+    "collection": "Solomon R. Guggenheim Museum",
+    "accessionId": "37.262",
+    "sourceUrl": "https://commons.wikimedia.org/wiki/File:Kandinsky_-_Composition_8,_1923.jpg",
+    "license": "PD-Mark",
+    "licenseTermsUrl": "https://commons.wikimedia.org/wiki/Commons:Reusing_content_outside_Wikimedia",
+    "retrievedDate": "2026-07-21"
+  }
+]

--- a/utils/scripts/verifyAcademyExamplesManifest.ts
+++ b/utils/scripts/verifyAcademyExamplesManifest.ts
@@ -81,12 +81,12 @@ async function main(): Promise<void> {
     return
   }
 
-  entries = [...entries, ...pendingEntries]
+  const combinedEntries: unknown[] = [...entries, ...pendingEntries]
 
   const errors: string[] = []
   const manifestImageSrcByMovement = new Map<string, string>()
 
-  for (const [index, entry] of entries.entries()) {
+  for (const [index, entry] of combinedEntries.entries()) {
     const label =
       entry && typeof entry === 'object' && 'workTitle' in entry
         ? String((entry as Record<string, unknown>).workTitle)
@@ -196,7 +196,7 @@ async function main(): Promise<void> {
     ? ' with media availability verified'
     : ' (media availability check skipped; set MEDIA_VERIFY_ASSETS=1 to enable)'
   console.log(
-    `Academy examples manifest contract passed: ${entries.length} entries validated from ${manifestSource} plus ${pendingEntries.length} pending media entr${pendingEntries.length === 1 ? 'y' : 'ies'} against PUBLIC-DOMAIN-POLICY.md §3 and cross-checked against academyStyles.ts${availabilityNote}.`,
+    `Academy examples manifest contract passed: ${combinedEntries.length} entries validated from ${manifestSource} plus ${pendingEntries.length} pending media entr${pendingEntries.length === 1 ? 'y' : 'ies'} against PUBLIC-DOMAIN-POLICY.md §3 and cross-checked against academyStyles.ts${availabilityNote}.`,
   )
 }
 

--- a/utils/scripts/verifyAcademyExamplesManifest.ts
+++ b/utils/scripts/verifyAcademyExamplesManifest.ts
@@ -13,6 +13,7 @@
 //
 // Run: npm run test:academy-examples-manifest
 
+import { readFile } from 'node:fs/promises'
 import { academyStyles } from '../../stores/seeds/academyStyles'
 import { validateProvenanceRecord } from './academyProvenanceSchema'
 import {
@@ -24,6 +25,10 @@ import {
 } from './mediaContractSource'
 
 const manifestRelativePath = 'academy/examples/examples.manifest.json'
+const pendingManifestUrl = new URL(
+  '../../config/academy-example-manifest-pending.json',
+  import.meta.url,
+)
 const manifestSource = mediaSourceDescription(manifestRelativePath)
 const verifyAssets =
   Boolean(process.env.MEDIA_ROOT?.trim()) ||
@@ -54,6 +59,29 @@ async function main(): Promise<void> {
     process.exitCode = 1
     return
   }
+
+  let pendingEntries: unknown
+  try {
+    pendingEntries = JSON.parse(await readFile(pendingManifestUrl, 'utf8'))
+  } catch (error) {
+    console.error(
+      `Academy examples manifest contract failed: pending media supplement is not valid JSON — ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+    process.exitCode = 1
+    return
+  }
+
+  if (!Array.isArray(pendingEntries)) {
+    console.error(
+      `Academy examples manifest contract failed: pending media supplement must be a JSON array, got ${typeof pendingEntries}`,
+    )
+    process.exitCode = 1
+    return
+  }
+
+  entries = [...entries, ...pendingEntries]
 
   const errors: string[] = []
   const manifestImageSrcByMovement = new Map<string, string>()
@@ -89,7 +117,13 @@ async function main(): Promise<void> {
         )
       }
       if (typeof record.movement === 'string') {
-        manifestImageSrcByMovement.set(record.movement, `/images/${mediaPath}`)
+        if (manifestImageSrcByMovement.has(record.movement)) {
+          errors.push(
+            `${record.movement}: appears in both the media manifest and pending supplement; remove the pending entry after media sync`,
+          )
+        } else {
+          manifestImageSrcByMovement.set(record.movement, `/images/${mediaPath}`)
+        }
       }
     } catch (error) {
       errors.push(
@@ -162,7 +196,7 @@ async function main(): Promise<void> {
     ? ' with media availability verified'
     : ' (media availability check skipped; set MEDIA_VERIFY_ASSETS=1 to enable)'
   console.log(
-    `Academy examples manifest contract passed: ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} validated from ${manifestSource} against PUBLIC-DOMAIN-POLICY.md §3 and cross-checked against academyStyles.ts${availabilityNote}.`,
+    `Academy examples manifest contract passed: ${entries.length} entries validated from ${manifestSource} plus ${pendingEntries.length} pending media entr${pendingEntries.length === 1 ? 'y' : 'ies'} against PUBLIC-DOMAIN-POLICY.md §3 and cross-checked against academyStyles.ts${availabilityNote}.`,
   )
 }
 


### PR DESCRIPTION
Adds a temporary, fixed-input recovery workflow for definitive commentary batch 011.

It deliberately bypasses only the failing auxiliary evidence-branch publisher—not any production guard.

## Recovery boundaries
- fixed manifest: `config/wonderlab-voice-polish-batch-014.json`
- verifies production ancestry and the direct indexed Reaction route
- runs the complete read-only publication-lock preflight
- stops before mutation on any mismatch or read failure
- applies through the existing single-attempt PATCH runner
- runs the full 706-review post-audit
- always uploads preflight/apply/audit artifacts

## Incidental main-branch contract repair
The Academy registry recently gained verified example works for Expressionism, Cubism, and Bauhaus before the external media provenance manifest caught up. This PR records those three exact provenance entries in `config/academy-example-manifest-pending.json` and includes them in the parity verifier. A duplicate movement is an error, so the supplement must be removed as soon as the media manifest syncs; it cannot silently become permanent drift.

After a successful recovery this temporary workflow can be removed. The ordinary guarded runner remains unchanged.

Tracks silasfelinus/conductor#1013.