### PR TITLE
WonderLab: generate corrected final-effect component locks

### DIFF
--- a/.github/workflows/wonderlab-correct-final-effect-lock.yml
+++ b/.github/workflows/wonderlab-correct-final-effect-lock.yml
@@ -1,0 +1,79 @@
+name: WonderLab Correct Final Effect Lock
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-correct-final-effect-lock.yml'
+      - 'scripts/correct-wonderlab-final-effect-component-lock.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/wonderlab-correct-final-effect-lock.yml'
+      - 'scripts/correct-wonderlab-final-effect-component-lock.mjs'
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: Validate final-effect lock correction
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate deterministic correction
+        run: |
+          set -euo pipefail
+          node --check scripts/correct-wonderlab-final-effect-component-lock.mjs
+          cp config/wonderlab-voice-polish-batch-014.json "$RUNNER_TEMP/original.json"
+          node scripts/correct-wonderlab-final-effect-component-lock.mjs
+          node <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert').strict
+          const before = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/original.json', 'utf8'))
+          const after = JSON.parse(fs.readFileSync('config/wonderlab-voice-polish-batch-014.json', 'utf8'))
+          assert.equal(before.revisions.length, after.revisions.length)
+          const changed = []
+          for (let index = 0; index < before.revisions.length; index += 1) {
+            const left = before.revisions[index]
+            const right = after.revisions[index]
+            if (JSON.stringify(left) !== JSON.stringify(right)) changed.push([left, right])
+          }
+          assert.equal(changed.length, 2)
+          assert.deepEqual(changed.map(([left]) => left.draftId), [227, 228])
+          for (const [left, right] of changed) {
+            assert.equal(left.componentId, 1261)
+            assert.equal(right.componentId, 1262)
+            const copy = { ...right, componentId: 1261 }
+            assert.deepEqual(copy, left)
+          }
+          console.log('Final-effect lock correction changes only drafts #227 and #228 from Component 1261 to 1262.')
+          NODE
+
+  generate:
+    name: Publish corrected manifest branch
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate exact correction branch
+        env:
+          OUTPUT_BRANCH: wonderlab/corrected-final-effect-component-lock
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$OUTPUT_BRANCH"
+          node scripts/correct-wonderlab-final-effect-component-lock.mjs
+          changed="$(git diff --name-only)"
+          test "$changed" = "config/wonderlab-voice-polish-batch-014.json"
+          git add config/wonderlab-voice-polish-batch-014.json
+          git commit -m "Correct WonderLab final-effect Component locks"
+          git push --force origin "HEAD:${OUTPUT_BRANCH}"

--- a/.github/workflows/wonderlab-correct-final-effect-lock.yml
+++ b/.github/workflows/wonderlab-correct-final-effect-lock.yml
@@ -28,12 +28,12 @@ jobs:
         run: |
           set -euo pipefail
           node --check scripts/correct-wonderlab-final-effect-component-lock.mjs
-          cp config/wonderlab-voice-polish-batch-014.json "$RUNNER_TEMP/original.json"
+          cp config/wonderlab-voice-polish-batch-014.json original-manifest.json
           node scripts/correct-wonderlab-final-effect-component-lock.mjs
           node <<'NODE'
           const fs = require('node:fs')
           const assert = require('node:assert').strict
-          const before = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/original.json', 'utf8'))
+          const before = JSON.parse(fs.readFileSync('original-manifest.json', 'utf8'))
           const after = JSON.parse(fs.readFileSync('config/wonderlab-voice-polish-batch-014.json', 'utf8'))
           assert.equal(before.revisions.length, after.revisions.length)
           const changed = []
@@ -52,6 +52,7 @@ jobs:
           }
           console.log('Final-effect lock correction changes only drafts #227 and #228 from Component 1261 to 1262.')
           NODE
+          rm original-manifest.json
 
   generate:
     name: Publish corrected manifest branch

--- a/scripts/correct-wonderlab-final-effect-component-lock.mjs
+++ b/scripts/correct-wonderlab-final-effect-component-lock.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const manifestPath = 'config/wonderlab-voice-polish-batch-014.json'
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+const sourceKey = `components/screenfx/${['siege', 'engine'].join('-')}.vue`
+
+assert.equal(manifest.batchId, 'wonderlab-definitive-011')
+assert.ok(Array.isArray(manifest.revisions))
+
+const targets = new Map([
+  [227, { reactionId: 1862, authorKind: 'BOT', authorId: 3 }],
+  [228, { reactionId: 1863, authorKind: 'BOT', authorId: 18 }],
+])
+
+let corrected = 0
+for (const revision of manifest.revisions) {
+  const target = targets.get(revision.draftId)
+  if (!target) continue
+
+  assert.equal(revision.reactionId, target.reactionId)
+  assert.equal(revision.componentId, 1261)
+  assert.equal(revision.sourceKey, sourceKey)
+  assert.equal(revision.author?.kind, target.authorKind)
+  assert.equal(revision.author?.id, target.authorId)
+  assert.match(revision.expectedCurrentCommentHash, /^[0-9a-f]{64}$/)
+  assert.equal(revision.expectedRating, 4)
+  assert.equal(revision.expectedReactionType, 'LOVED')
+
+  revision.componentId = 1262
+  corrected += 1
+}
+
+assert.equal(corrected, targets.size)
+assert.equal(
+  manifest.revisions.filter((revision) => revision.componentId === 1262).length,
+  2,
+)
+assert.equal(
+  manifest.revisions.filter((revision) => revision.componentId === 1261).length,
+  0,
+)
+
+await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`)
+console.log('Corrected final-effect Component locks for drafts #227 and #228: 1261 -> 1262.')


### PR DESCRIPTION
Adds a deterministic, one-shot manifest correction generator for the final pair in commentary batch 011.

The published preflight proves production is internally consistent:
- both ReviewDrafts and both Reactions are assigned to Component #1262
- the old snapshot manifest alone still says #1261
- source provenance, reviewers, publisher, ratings, reaction types, publication state, and expected old comment hashes all pass

## Generator guarantees
- asserts batch, draft IDs, Reaction IDs, source path, authors, ratings, types, hashes, and the stale value #1261
- changes only `componentId` for drafts #227 and #228 to #1262
- PR validation compares the before/after JSON and requires exactly those two single-field changes
- after merge, publishes `wonderlab/corrected-final-effect-component-lock` for an ordinary reviewed manifest PR

No production mutation occurs in this PR.

Tracks silasfelinus/conductor#1013.