### PR TITLE
art: point Krea2/Klein at chosen GGUF quants

### DIFF
--- a/server/api/comfy/flux2/utils/workflow.ts
+++ b/server/api/comfy/flux2/utils/workflow.ts
@@ -15,7 +15,7 @@ import {
 
 export const FLUX2_KLEIN_UNET_LOADER: 'UNETLoader' | 'UnetLoaderGGUF' =
   'UnetLoaderGGUF'
-export const FLUX2_KLEIN_MODEL = 'flux2-klein-4b-Q5_K_M.gguf'
+export const FLUX2_KLEIN_MODEL = 'flux-2-klein-4b-Q4_K_M.gguf'
 export const FLUX2_KLEIN_CLIP = 'flux2_klein_text_encoder_fp8_scaled.safetensors'
 export const FLUX2_KLEIN_CLIP_TYPE = 'flux2'
 export const FLUX2_KLEIN_VAE = 'flux2-vae.safetensors'

--- a/server/api/comfy/krea2/utils/workflow.ts
+++ b/server/api/comfy/krea2/utils/workflow.ts
@@ -14,8 +14,9 @@ import {
   type ComfyWorkflow,
 } from '../../utils/simpleCheckpointWorkflow'
 
-export const KREA2_UNET_LOADER: 'UNETLoader' | 'UnetLoaderGGUF' = 'UNETLoader'
-export const KREA2_MODEL = 'krea2_turbo_fp8_scaled.safetensors'
+export const KREA2_UNET_LOADER: 'UNETLoader' | 'UnetLoaderGGUF' =
+  'UnetLoaderGGUF'
+export const KREA2_MODEL = 'Krea-2-Turbo-Q5_K_S.gguf'
 export const KREA2_CLIP = 'qwen3vl_4b_fp8_scaled.safetensors'
 export const KREA2_CLIP_TYPE = 'krea2'
 export const KREA2_VAE = 'qwen_image_vae.safetensors'


### PR DESCRIPTION
Follow-up to merged PR #868. Sets the engine constants to the GGUF quants Silas is downloading:

- **Krea 2 Turbo** → `Krea-2-Turbo-Q5_K_S.gguf` via `UnetLoaderGGUF`.
- **Flux.2 Klein** → `flux-2-klein-4b-Q4_K_M.gguf`.

Encoder + VAE stay the Comfy-Org safetensors (they load independently of the diffusion quant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9)_