### PR TITLE
WonderLab: make definitive corpus audit complete

### DIFF
--- a/scripts/wonderlab-definitive-inventory.mjs
+++ b/scripts/wonderlab-definitive-inventory.mjs
@@ -44,14 +44,17 @@ function authorProfilePath(author) {
   return author.kind === 'BOT' ? `/api/bots/${author.id}` : `/api/characters/${author.id}`
 }
 
-const [version, components, newestPublished] = await Promise.all([
+const [version, components, corpusStats] = await Promise.all([
   request('/api/version'),
   request('/api/components'),
-  request('/api/admin/wonderlab/review-drafts?status=PUBLISHED&limit=200', { admin: true }),
+  request('/api/admin/wonderlab/review-drafts/stats?status=PUBLISHED', { admin: true }),
 ])
 
-const highestDraftId = Math.max(0, ...newestPublished.map((draft) => Number(draft.id) || 0))
-if (!highestDraftId) throw new Error('No published WonderLab ReviewDrafts were found.')
+const highestDraftId = Number(corpusStats?.highestDraftId) || 0
+const expectedPublishedReviews = Number(corpusStats?.reviewDrafts) || 0
+if (!highestDraftId || !expectedPublishedReviews) {
+  throw new Error('No published WonderLab ReviewDrafts were found.')
+}
 
 const draftIds = Array.from({ length: highestDraftId }, (_, index) => index + 1)
 const scanned = await mapConcurrent(
@@ -63,6 +66,12 @@ const scanned = await mapConcurrent(
 const publishedDrafts = scanned
   .filter((draft) => draft?.status === 'PUBLISHED' && Number(draft?.publishedReactionId) > 0)
   .sort((left, right) => Number(left.id) - Number(right.id))
+
+if (publishedDrafts.length !== expectedPublishedReviews) {
+  throw new Error(
+    `Published ReviewDraft scan was incomplete: stats reported ${expectedPublishedReviews}, but the ID scan captured ${publishedDrafts.length}.`,
+  )
+}
 
 const componentMap = new Map(components.map((component) => [Number(component.id), component]))
 const authors = Array.from(new Map(publishedDrafts.map((draft) => [`${draft.author.kind}:${draft.author.id}`, draft.author])).values())
@@ -101,6 +110,7 @@ const report = {
   production: version,
   scan: {
     highestDraftId,
+    expectedPublishedReviews,
     publishedReviews: inventory.length,
     firstDraftId: inventory[0]?.draftId ?? null,
     lastDraftId: inventory.at(-1)?.draftId ?? null,
@@ -140,7 +150,7 @@ const markdown = [
   '## WonderLab definitive commentary inventory',
   '',
   `- **Production:** \`${version.commit || 'unknown'}\` · deployment \`${version.deploymentId || 'unknown'}\``,
-  `- **Published reviews captured:** ${inventory.length}`,
+  `- **Published reviews captured:** ${inventory.length} / ${expectedPublishedReviews}`,
   `- **Draft range:** #${report.scan.firstDraftId ?? '?'}–#${report.scan.lastDraftId ?? '?'}`,
   `- **Highest draft ID scanned:** #${highestDraftId}`,
   `- **Chronological chunk files:** ${chunks.length} × up to ${chunkSize} reviews`,

--- a/server/api/admin/wonderlab/review-drafts/stats.get.ts
+++ b/server/api/admin/wonderlab/review-drafts/stats.get.ts
@@ -1,0 +1,46 @@
+// /server/api/admin/wonderlab/review-drafts/stats.get.ts
+import { createError, defineEventHandler, getQuery, H3Error } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import prisma from '@/server/utils/prisma'
+import { normalizeReviewDraftStatus } from '@/utils/wonderlab/reviewDraft'
+
+type ReviewDraftCorpusStatsRow = {
+  highestDraftId: number | bigint | null
+  reviewDrafts: number | bigint
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const query = getQuery(event)
+    const status = query.status
+      ? normalizeReviewDraftStatus(query.status)
+      : null
+
+    if (query.status && !status) {
+      throw createError({ statusCode: 400, message: 'Invalid review draft status.' })
+    }
+
+    const rows = await prisma.$queryRawUnsafe<ReviewDraftCorpusStatsRow[]>(
+      `SELECT MAX(id) AS highestDraftId, COUNT(*) AS reviewDrafts
+       FROM ReviewDraft
+       WHERE (? IS NULL OR status = ?)`,
+      status,
+      status,
+    )
+    const row = rows[0]
+
+    return {
+      success: true,
+      data: {
+        highestDraftId: Number(row?.highestDraftId ?? 0),
+        reviewDrafts: Number(row?.reviewDrafts ?? 0),
+        status,
+      },
+    }
+  } catch (error) {
+    if (error instanceof H3Error) throw error
+    return errorHandler(error)
+  }
+})

--- a/utils/scripts/verifyReviewDraftAdminApi.ts
+++ b/utils/scripts/verifyReviewDraftAdminApi.ts
@@ -50,8 +50,9 @@ const listPath = 'server/api/admin/wonderlab/review-drafts/index.get.ts'
 const createPath = 'server/api/admin/wonderlab/review-drafts/index.post.ts'
 const detailPath = 'server/api/admin/wonderlab/review-drafts/[id].get.ts'
 const patchPath = 'server/api/admin/wonderlab/review-drafts/[id].patch.ts'
+const statsPath = 'server/api/admin/wonderlab/review-drafts/stats.get.ts'
 const reactionGuardPath = 'server/api/admin/wonderlab/reactions/[id].get.ts'
-const paths = [listPath, createPath, detailPath, patchPath, reactionGuardPath]
+const paths = [listPath, createPath, detailPath, patchPath, statsPath, reactionGuardPath]
 
 for (const path of paths) {
   const source = await readFile(path, 'utf8')
@@ -66,6 +67,12 @@ assert.doesNotMatch(createSource, /status\??:/)
 const patchSource = await readFile(patchPath, 'utf8')
 assert.match(patchSource, /controlled publication service/i)
 
+const statsSource = await readFile(statsPath, 'utf8')
+assert.match(statsSource, /SELECT MAX\(id\) AS highestDraftId, COUNT\(\*\) AS reviewDrafts/)
+assert.match(statsSource, /WHERE \(\? IS NULL OR status = \?\)/)
+assert.match(statsSource, /normalizeReviewDraftStatus/)
+assert.doesNotMatch(statsSource, /ORDER BY|LIMIT|\$executeRaw|INSERT\s+INTO|UPDATE\s+|DELETE\s+FROM/i)
+
 const reactionGuardSource = await readFile(reactionGuardPath, 'utf8')
 assert.match(reactionGuardSource, /WHERE r\.id = \$\{reactionId\}/)
 assert.match(reactionGuardSource, /LIMIT 1/)
@@ -74,6 +81,12 @@ assert.doesNotMatch(reactionGuardSource, /WHERE r\.componentId/)
 const applySource = await readFile('scripts/apply-wonderlab-voice-polish-batch.mjs', 'utf8')
 assert.match(applySource, /\/api\/admin\/wonderlab\/reactions\/\$\{revision\.reactionId\}/)
 assert.doesNotMatch(applySource, /\/api\/reactions\/component\//)
+
+const inventorySource = await readFile('scripts/wonderlab-definitive-inventory.mjs', 'utf8')
+assert.match(inventorySource, /\/api\/admin\/wonderlab\/review-drafts\/stats\?status=PUBLISHED/)
+assert.match(inventorySource, /expectedPublishedReviews/)
+assert.match(inventorySource, /Published ReviewDraft scan was incomplete/)
+assert.doesNotMatch(inventorySource, /review-drafts\?status=PUBLISHED&limit=200/)
 
 const repositorySource = await readFile('server/utils/reviewDraftRepository.ts', 'utf8')
 assert.match(repositorySource, /INSERT IGNORE INTO ReviewDraft/)


### PR DESCRIPTION
Fixes the definitive WonderLab commentary inventory after batch 011 exposed a discovery flaw.

## Root cause
The inventory inferred its highest ReviewDraft ID from the 200 most recently updated published drafts. After revising canonical reviews 1–220, that window ended at draft #228 and made the read-only audit report 220 reviews even though the untouched corpus continues through #714.

## Repair
- add an admin-only read-only ReviewDraft stats endpoint using `MAX(id)` and `COUNT(*)`
- discover the exact highest published draft ID from that endpoint
- scan every ID through the exact maximum
- reconcile the captured published count against the database count and fail closed on any gap
- include the expected count in JSON and Markdown evidence
- add contract assertions that prohibit the former `limit=200` discovery path

No ReviewDraft or Reaction mutation is added. This PR only repairs read-only audit completeness.

After a green merge, production will deploy the stats endpoint and the definitive inventory workflow can prove the expected 706 reviews through draft #714 before batch 012 begins.

Tracks silasfelinus/conductor#1013.