### PR TITLE
WonderLab: wait for definitive corpus stats

### DIFF
--- a/.github/workflows/wonderlab-definitive-inventory.yml
+++ b/.github/workflows/wonderlab-definitive-inventory.yml
@@ -37,6 +37,33 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+      - name: Wait for exact corpus stats route
+        env:
+          WONDERLAB_BASE_URL: https://kind-robots.vercel.app
+          WONDERLAB_ADMIN_TOKEN: ${{ secrets.CYPRESS_BETA_ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 36); do
+            body="$(
+              curl -sS --max-time 20 \
+                -H 'accept: application'/'json' \
+                -H "x-beta-admin-token: $WONDERLAB_ADMIN_TOKEN" \
+                -H "x-admin-token: $WONDERLAB_ADMIN_TOKEN" \
+                -H "x-api-key: $WONDERLAB_ADMIN_TOKEN" \
+                "$WONDERLAB_BASE_URL/api/admin/wonderlab/review-drafts/stats?status=PUBLISHED" \
+                || true
+            )"
+            highest="$(printf '%s' "$body" | jq -r '.data.highestDraftId // 0' 2>/dev/null || true)"
+            published="$(printf '%s' "$body" | jq -r '.data.reviewDrafts // 0' 2>/dev/null || true)"
+            if [ "$highest" -gt 0 ] 2>/dev/null && [ "$published" -gt 0 ] 2>/dev/null; then
+              echo "Exact corpus stats route is ready: $published published drafts through #$highest."
+              exit 0
+            fi
+            echo "Exact corpus stats route not ready (attempt $attempt of 36); retrying in 10 seconds."
+            sleep 10
+          done
+          echo "::error::Exact corpus stats route did not become ready."
+          exit 1
       - name: Capture canonical production corpus
         env:
           WONDERLAB_BASE_URL: https://kind-robots.vercel.app


### PR DESCRIPTION
Hardens the definitive commentary inventory against deployment races.

The audit repair in #880 adds the exact ReviewDraft corpus stats route, but the push-triggered inventory workflow starts immediately and can reach production before that route is deployed. The stale snapshot confirmed that race.

## Change
- probe the authenticated published-draft stats route before inventory capture
- require positive `highestDraftId` and `reviewDrafts` values from the exact JSON shape
- retry for up to six minutes with bounded 20-second requests
- fail closed instead of publishing a partial or stale snapshot

No ReviewDraft or Reaction mutation is added. This is workflow orchestration only.

After a green merge, the workflow will rerun against the already-deployed audit repair and should publish 706 captured of 706 expected through draft #714.

Tracks silasfelinus/conductor#1013.