### PR TITLE
Increase WonderLab revision transaction timeout

### DIFF
--- a/server/utils/publishedReviewRevision.ts
+++ b/server/utils/publishedReviewRevision.ts
@@ -157,6 +157,9 @@ export async function revisePublishedReview(
       previousCommentHash,
       revisedCommentHash: publishedReviewCommentHash(revisedComment),
     }
+  }, {
+    maxWait: 10_000,
+    timeout: 20_000,
   })
 
   const draft = await getReviewDraftById(input.draftId)

--- a/utils/scripts/verifyReviewDraftPublication.ts
+++ b/utils/scripts/verifyReviewDraftPublication.ts
@@ -50,6 +50,11 @@ assert.match(revisionEndpoint, /requireAdminApiUser\(event\)/)
 assert.match(revisionEndpoint, /expectedCurrentCommentHash/)
 assert.match(revisionEndpoint, /revisePublishedReview/)
 assert.match(revisionService, /prisma\.\$transaction/)
+assert.match(
+  revisionService,
+  /maxWait:\s*10_000,[\s\S]*timeout:\s*20_000/,
+  'Published review revision must declare a transaction budget above Prisma\'s 5-second default.',
+)
 assert.match(revisionService, /FROM ReviewDraft[\s\S]*FOR UPDATE/)
 assert.match(revisionService, /FROM Reaction[\s\S]*FOR UPDATE/)
 assert.match(revisionService, /draft\.status !== 'PUBLISHED'/)


### PR DESCRIPTION
Repairs the partial batch-018 rollout failure at ReviewDraft #361.

## Failure observed
- The guarded batch applied #349–#360 successfully.
- #361 exceeded Prisma's default 5-second interactive transaction timeout (`P2028`) after roughly 7 seconds.
- The workflow stopped immediately; #362–#368 were untouched and the full audit did not run.

## Fix
- Keep the same exact row locks, author/Component/Reaction/hash guards, and atomic ReviewDraft + Reaction writes.
- Set `maxWait: 10_000` and `timeout: 20_000` on the interactive transaction.
- Extend the established review publication/revision contract to require that explicit budget, preventing regression to Prisma's default.

The batch apply script is already idempotent: after this reaches production, re-running the failed job will report #349–#360 as `ALREADY_APPLIED` and revise only #361–#368 from their untouched hashes.

Tracks silasfelinus/conductor#1013.