### PR TITLE
art: queue pause/resume button

### DIFF
--- a/components/art/artjob-manager.vue
+++ b/components/art/artjob-manager.vue
@@ -173,6 +173,24 @@
               {{ stats?.imagesCreatedInWindow ?? 0 }} imgs / {{ windowHours }}h
             </span>
             <button
+              type="button"
+              class="btn btn-xs rounded-2xl"
+              :class="artJobStore.queuePaused ? 'btn-success' : 'btn-warning btn-outline'"
+              :disabled="artJobStore.togglingQueuePause"
+              :title="
+                artJobStore.queuePaused
+                  ? 'Queue is PAUSED — relays are handed no work. Jobs stay queued. Click to resume.'
+                  : 'Pause queue processing — relays stop claiming new jobs, the queue is preserved until you resume.'
+              "
+              @click="artJobStore.setQueuePaused(!artJobStore.queuePaused)"
+            >
+              <span
+                v-if="artJobStore.togglingQueuePause"
+                class="loading loading-spinner loading-xs"
+              />
+              {{ artJobStore.queuePaused ? '▶ Resume queue' : '⏸ Pause queue' }}
+            </button>
+            <button
               v-if="failedJobCount > 0"
               type="button"
               class="btn btn-error btn-xs rounded-2xl"

--- a/prisma/migrations/20260722210000_add_queue_control/migration.sql
+++ b/prisma/migrations/20260722210000_add_queue_control/migration.sql
@@ -1,0 +1,19 @@
+-- ArtJob queue pause control (art queue: front-end pause/resume button).
+-- Additive only: one new singleton table (id = 1), no changes to existing
+-- tables/columns. When `paused` is true the claim endpoint stops handing jobs
+-- to relays, so the queue is preserved but not drained until resumed.
+
+-- CreateTable
+CREATE TABLE `QueueControl` (
+    `id` INTEGER NOT NULL DEFAULT 1,
+    `paused` BOOLEAN NOT NULL DEFAULT false,
+    `pausedBy` VARCHAR(255) NULL,
+    `pausedAt` DATETIME(3) NULL,
+    `note` VARCHAR(500) NULL,
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Seed the single control row (unpaused).
+INSERT INTO `QueueControl` (`id`, `paused`) VALUES (1, false);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1395,6 +1395,18 @@ model ArtJob {
   @@index([projectId])
 }
 
+/// Singleton control row for the ArtJob queue. When `paused` is true the claim
+/// endpoint stops handing jobs to relays, so the queue is preserved but not
+/// drained until resumed. Always id = 1 (one row).
+model QueueControl {
+  id        Int      @id @default(1)
+  paused    Boolean  @default(false)
+  pausedBy  String?  @db.VarChar(255)
+  pausedAt  DateTime?
+  note      String?  @db.VarChar(500)
+  updatedAt DateTime @default(now()) @updatedAt
+}
+
 /// Economy: karma ledger — separate from mana, tracks community contribution score
 model KarmaTransaction {
   id           Int         @id @default(autoincrement())

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -29,6 +29,7 @@ import {
   selectSmartQueueCandidate,
 } from '../../../utils/artJobQueueAffinity'
 import { recordRelayClaimAttempt } from '../../../utils/relayAgentRegistry'
+import { isQueuePaused } from '../../../utils/queueControl'
 
 const STALE_CLAIM_MINUTES = 15
 const MAX_ATTEMPTS = 3
@@ -81,6 +82,22 @@ export default defineEventHandler(async (event) => {
 
     if (!engines.length) {
       throw createError({ statusCode: 400, message: 'No valid engines given.' })
+    }
+
+    // Queue paused (admin toggle): hand out no work so the queue is preserved
+    // but not drained. Graceful — defaults to not-paused if the control table
+    // is not migrated yet, so this can never wedge the pipeline.
+    if (await isQueuePaused()) {
+      return {
+        success: true,
+        message: 'Queue processing is paused.',
+        data: {
+          job: null,
+          paused: true,
+          scheduling: { mode: smartQueue ? 'SMART' : 'FIFO' },
+        },
+        statusCode: 200,
+      }
     }
 
     const staleBefore = new Date(Date.now() - STALE_CLAIM_MINUTES * 60_000)

--- a/server/api/art/queue/control.get.ts
+++ b/server/api/art/queue/control.get.ts
@@ -1,0 +1,32 @@
+// /server/api/art/queue/control.get.ts
+//
+// Read the ArtJob queue pause state for the admin queue UI. Graceful: returns
+// { paused: false } if the QueueControl table has not been migrated yet.
+import { createError, defineEventHandler } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { getQueueControl } from '../../../utils/queueControl'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to read queue control.',
+      })
+    }
+
+    const state = await getQueueControl()
+    return { success: true, message: 'Queue control state.', data: state, statusCode: 200 }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to read queue control.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/art/queue/control.post.ts
+++ b/server/api/art/queue/control.post.ts
@@ -1,0 +1,57 @@
+// /server/api/art/queue/control.post.ts
+//
+// Pause or resume ArtJob queue processing (admin). When paused, the claim
+// endpoint stops handing jobs to relays — the queue is preserved, just not
+// drained — until resumed. Body: { paused: boolean, note?: string }.
+import { createError, defineEventHandler, readBody } from 'h3'
+import { errorHandler } from '../../../utils/error'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { setQueuePaused } from '../../../utils/queueControl'
+
+type ControlBody = { paused?: unknown; note?: unknown }
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to pause/resume the queue.',
+      })
+    }
+
+    const body = (await readBody(event).catch(() => null)) as ControlBody | null
+    if (typeof body?.paused !== 'boolean') {
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required boolean field "paused".',
+      })
+    }
+
+    const note =
+      typeof body.note === 'string' && body.note.trim()
+        ? body.note.trim().slice(0, 500)
+        : null
+    const pausedBy = auth.user?.username || auth.user?.id?.toString() || 'admin'
+
+    const state = await setQueuePaused(body.paused, pausedBy, note)
+
+    return {
+      success: true,
+      message: state.paused
+        ? 'Queue processing paused. Jobs stay queued; relays will not claim new work until resumed.'
+        : 'Queue processing resumed.',
+      data: state,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to update queue control.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/queueControl.ts
+++ b/server/utils/queueControl.ts
@@ -1,0 +1,69 @@
+// /server/utils/queueControl.ts
+//
+// Read/write the singleton ArtJob queue pause flag (QueueControl id = 1).
+// Every read is graceful: if the table does not exist yet (deploy landed before
+// `prisma migrate deploy` ran) or any DB error occurs, we treat the queue as
+// NOT paused so relays keep draining — a missing control row must never wedge
+// the whole pipeline.
+import prisma from './prisma'
+
+export type QueueControlState = {
+  paused: boolean
+  pausedBy: string | null
+  pausedAt: string | null
+  note: string | null
+  updatedAt: string | null
+}
+
+const DEFAULT_STATE: QueueControlState = {
+  paused: false,
+  pausedBy: null,
+  pausedAt: null,
+  note: null,
+  updatedAt: null,
+}
+
+export async function getQueueControl(): Promise<QueueControlState> {
+  try {
+    const row = await prisma.queueControl.findUnique({ where: { id: 1 } })
+    if (!row) return DEFAULT_STATE
+    return {
+      paused: row.paused,
+      pausedBy: row.pausedBy ?? null,
+      pausedAt: row.pausedAt ? row.pausedAt.toISOString() : null,
+      note: row.note ?? null,
+      updatedAt: row.updatedAt ? row.updatedAt.toISOString() : null,
+    }
+  } catch {
+    return DEFAULT_STATE
+  }
+}
+
+export async function isQueuePaused(): Promise<boolean> {
+  return (await getQueueControl()).paused
+}
+
+export async function setQueuePaused(
+  paused: boolean,
+  pausedBy: string | null,
+  note: string | null,
+): Promise<QueueControlState> {
+  const data = {
+    paused,
+    pausedBy: paused ? pausedBy : null,
+    pausedAt: paused ? new Date() : null,
+    note: note ?? null,
+  }
+  const row = await prisma.queueControl.upsert({
+    where: { id: 1 },
+    create: { id: 1, ...data },
+    update: data,
+  })
+  return {
+    paused: row.paused,
+    pausedBy: row.pausedBy ?? null,
+    pausedAt: row.pausedAt ? row.pausedAt.toISOString() : null,
+    note: row.note ?? null,
+    updatedAt: row.updatedAt ? row.updatedAt.toISOString() : null,
+  }
+}

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -173,6 +173,10 @@ type ArtJobState = {
   // verdict lands in payload.curation.curator).
   curationRequestingIds: number[]
   curationRequestedIds: number[]
+  // Queue pause control: when true, relays are handed no work (queue preserved).
+  queuePaused: boolean
+  queuePausedBy: string | null
+  togglingQueuePause: boolean
   error: string | null
   windowHours: number
 }
@@ -196,9 +200,43 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     reenqueueingFailedJobs: false,
     curationRequestingIds: [],
     curationRequestedIds: [],
+    queuePaused: false,
+    queuePausedBy: null,
+    togglingQueuePause: false,
     error: null,
     windowHours: 24,
   })
+
+  async function fetchQueueControl(): Promise<void> {
+    const res = await performFetch<{ paused: boolean; pausedBy: string | null }>(
+      '/api/art/queue/control',
+      { method: 'GET' },
+    )
+    if (res.success && res.data) {
+      state.queuePaused = res.data.paused
+      state.queuePausedBy = res.data.pausedBy ?? null
+    }
+  }
+
+  async function setQueuePaused(paused: boolean): Promise<boolean> {
+    if (state.togglingQueuePause) return false
+    state.togglingQueuePause = true
+    try {
+      const res = await performFetch<{ paused: boolean; pausedBy: string | null }>(
+        '/api/art/queue/control',
+        { method: 'POST', body: JSON.stringify({ paused }) },
+      )
+      if (res.success && res.data) {
+        state.queuePaused = res.data.paused
+        state.queuePausedBy = res.data.pausedBy ?? null
+        return true
+      }
+      state.error = res.message || 'Failed to update queue pause state.'
+      return false
+    } finally {
+      state.togglingQueuePause = false
+    }
+  }
 
   async function fetchStats(): Promise<void> {
     state.loadingStats = true
@@ -531,6 +569,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       fetchUptime(),
       fetchJobs(),
       fetchTrainerJobs(),
+      fetchQueueControl(),
     ])
   }
 
@@ -551,6 +590,8 @@ export const useArtJobStore = defineStore('artJobStore', () => {
     cancelJob,
     reenqueueJob,
     reenqueueFailedJobs,
+    fetchQueueControl,
+    setQueuePaused,
     refreshAll,
     setWindow,
   }


### PR DESCRIPTION
A front-end button to **pause ArtJob queue processing** — relays stop being handed work so the queue is preserved (not lost, not re-submitting) until you resume.

## What changed
- **`QueueControl`** singleton model (id=1) + migration — additive, no changes to existing tables.
- **`queueControl.ts`** read/write helpers. Every read is **graceful**: if the table isn't migrated yet or any DB error occurs it reports "not paused", so a missing control row can never wedge the pipeline.
- **`GET`/`POST /api/art/queue/control`** (admin) to read/toggle the flag.
- **`claim.post.ts`**: when paused, returns no job (relay idles) before touching the queue — so nothing drains, nothing new gets submitted.
- **`artJobStore` + `artjob-manager.vue`**: a **⏸ Pause / ▶ Resume** toggle in the queue toolbar, state refreshed with the rest of the dashboard.

## Deploy note
After merge, run `npm run prisma:migrate` (`prisma migrate deploy`) on the target DB so the `QueueControl` table exists. Until then the button reads/acts as "not paused" via graceful degradation — no breakage, the feature just isn't live yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9)_