### PR TITLE
art: Build Bench — A/B test bench for generation builds

### DIFF
--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -1,0 +1,241 @@
+<template>
+  <section class="mx-auto flex w-full max-w-6xl flex-col gap-4 p-3">
+    <header class="flex flex-wrap items-center justify-between gap-2">
+      <div>
+        <h1 class="text-xl font-semibold">⚗️ Build Bench</h1>
+        <p class="text-xs text-base-content/60">
+          Pit two full builds head-to-head — clone one side, change a single knob,
+          render both, pick the winner. Renders jump the queue (priority) and land
+          in your gallery.
+        </p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <button class="btn btn-primary btn-sm rounded-2xl" :disabled="running" @click="runBoth">
+          <span v-if="running" class="loading loading-spinner loading-xs" />
+          Run both
+        </button>
+        <button class="btn btn-ghost btn-sm rounded-2xl" :disabled="running" @click="store.newMatchup">
+          New matchup
+        </button>
+      </div>
+    </header>
+
+    <p v-if="store.state.error" class="kr-note-warning rounded-xl p-2 text-xs">
+      {{ store.state.error }}
+    </p>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div
+        v-for="side in (['A', 'B'] as BenchSide[])"
+        :key="side"
+        class="flex flex-col gap-3 rounded-3xl border p-3"
+        :class="store.state.winner === side ? 'border-success bg-success/5' : 'border-base-300 bg-base-100'"
+      >
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <span class="badge badge-lg" :class="side === 'A' ? 'badge-primary' : 'badge-secondary'">
+              Build {{ side }}
+            </span>
+            <span v-if="store.state.winner === side" class="badge badge-success badge-sm">🏆 winner</span>
+          </div>
+          <button
+            class="btn btn-ghost btn-xs rounded-xl"
+            :disabled="running"
+            :title="`Copy Build ${side}'s entire config onto Build ${side === 'A' ? 'B' : 'A'}`"
+            @click="store.cloneTo(side)"
+          >
+            Clone → {{ side === 'A' ? 'B' : 'A' }}
+          </button>
+        </div>
+
+        <label class="flex flex-col gap-1 text-xs">
+          <span class="font-semibold">Engine</span>
+          <select
+            class="select select-bordered select-sm rounded-xl"
+            :value="cfg(side).engine"
+            @change="store.setEngine(side, ($event.target as HTMLSelectElement).value as BenchEngineKey)"
+          >
+            <option v-for="e in store.BENCH_ENGINES" :key="e.key" :value="e.key">
+              {{ e.label }} — {{ e.hint }}
+            </option>
+          </select>
+        </label>
+
+        <label class="flex flex-col gap-1 text-xs">
+          <span class="font-semibold">Prompt</span>
+          <textarea
+            v-model="cfg(side).prompt"
+            rows="3"
+            class="textarea textarea-bordered textarea-sm rounded-xl"
+            placeholder="Describe the image…"
+            @change="store.persist"
+          />
+        </label>
+
+        <details class="text-xs">
+          <summary class="cursor-pointer font-semibold opacity-70">Negative + advanced</summary>
+          <textarea
+            v-model="cfg(side).negativePrompt"
+            rows="2"
+            class="textarea textarea-bordered textarea-sm mt-2 w-full rounded-xl"
+            placeholder="Negative prompt (works on cfg>1 engines)"
+            @change="store.persist"
+          />
+          <div class="mt-2 grid grid-cols-3 gap-2">
+            <label class="flex flex-col gap-1">
+              <span>Steps</span>
+              <input v-model.number="cfg(side).steps" type="number" min="1" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>CFG</span>
+              <input v-model.number="cfg(side).cfg" type="number" step="0.1" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>Guidance</span>
+              <input v-model.number="cfg(side).guidance" type="number" step="0.1" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>Seed</span>
+              <input
+                :value="cfg(side).seed ?? ''"
+                type="number"
+                placeholder="random"
+                class="input input-bordered input-xs rounded-lg"
+                @change="onSeed(side, $event)"
+              />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>Width</span>
+              <input v-model.number="cfg(side).width" type="number" step="8" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>Height</span>
+              <input v-model.number="cfg(side).height" type="number" step="8" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>Sampler</span>
+              <input v-model="cfg(side).sampler" type="text" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>Scheduler</span>
+              <input v-model="cfg(side).scheduler" type="text" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span>LoRA</span>
+              <input v-model="cfg(side).loraName" type="text" placeholder="none" class="input input-bordered input-xs rounded-lg" @change="store.persist" />
+            </label>
+          </div>
+        </details>
+
+        <button class="btn btn-outline btn-sm rounded-2xl" :disabled="running" @click="store.runSide(side)">
+          Render Build {{ side }}
+        </button>
+
+        <!-- result -->
+        <div class="flex min-h-48 items-center justify-center rounded-2xl bg-base-200 p-2">
+          <div v-if="result(side).status === 'idle'" class="text-xs opacity-50">No render yet</div>
+          <div v-else-if="result(side).status === 'queued' || result(side).status === 'rendering'" class="flex flex-col items-center gap-2 text-xs">
+            <span class="loading loading-spinner loading-md" />
+            {{ result(side).status === 'rendering' ? 'Rendering…' : 'Queued…' }}
+            <span v-if="result(side).jobId" class="opacity-50">job #{{ result(side).jobId }}</span>
+          </div>
+          <div v-else-if="result(side).status === 'failed'" class="kr-note-warning rounded-xl p-2 text-xs">
+            Failed: {{ result(side).error }}
+          </div>
+          <img
+            v-else-if="result(side).src"
+            :src="result(side).src"
+            :alt="`Build ${side} render`"
+            class="max-h-96 w-auto rounded-xl"
+          />
+        </div>
+
+        <div v-if="result(side).status === 'done'" class="flex items-center justify-between text-[11px] opacity-70">
+          <span>seed {{ result(side).seed ?? '—' }} · {{ elapsed(side) }} · ArtImage #{{ result(side).artImageId }}</span>
+          <button
+            class="btn btn-xs rounded-xl"
+            :class="store.state.winner === side ? 'btn-success' : 'btn-ghost'"
+            @click="store.pickWinner(side)"
+          >
+            {{ store.state.winner === side ? '🏆 winner' : 'Pick winner' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- save / notes -->
+    <div class="flex flex-wrap items-center gap-2 rounded-2xl border border-base-300 p-3">
+      <input
+        v-model="store.state.note"
+        type="text"
+        placeholder="Notes on this matchup (why the winner won)…"
+        class="input input-bordered input-sm flex-1 rounded-xl"
+      />
+      <button class="btn btn-sm rounded-2xl" @click="store.saveMatchup">Save matchup</button>
+    </div>
+
+    <!-- saved matchups -->
+    <details v-if="store.state.saved.length" class="rounded-2xl border border-base-300 p-3 text-xs">
+      <summary class="cursor-pointer font-semibold">Saved matchups ({{ store.state.saved.length }})</summary>
+      <ul class="mt-2 flex flex-col gap-1">
+        <li
+          v-for="m in store.state.saved"
+          :key="m.id"
+          class="flex items-center justify-between gap-2 rounded-xl bg-base-200 px-2 py-1"
+        >
+          <span class="truncate">
+            <strong>{{ engineLabel(m.a.engine) }}</strong> vs <strong>{{ engineLabel(m.b.engine) }}</strong>
+            <span v-if="m.winner" class="badge badge-success badge-xs ml-1">{{ m.winner }} won</span>
+            <span class="ml-1 opacity-60">{{ m.note }}</span>
+          </span>
+          <span class="flex gap-1">
+            <button class="btn btn-ghost btn-xs" @click="store.loadSaved(m)">Load</button>
+            <button class="btn btn-ghost btn-xs text-error" @click="store.deleteSaved(m.id)">✕</button>
+          </span>
+        </li>
+      </ul>
+    </details>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import {
+  useBuildBenchStore,
+  type BenchSide,
+  type BenchEngineKey,
+  type BuildConfig,
+  type BuildResult,
+} from '@/stores/buildBenchStore'
+
+const store = useBuildBenchStore()
+
+onMounted(() => store.hydrate())
+
+function cfg(side: BenchSide): BuildConfig {
+  return side === 'A' ? store.state.buildA : store.state.buildB
+}
+function result(side: BenchSide): BuildResult {
+  return side === 'A' ? store.state.resultA : store.state.resultB
+}
+function elapsed(side: BenchSide): string {
+  const ms = result(side).elapsedMs
+  return ms == null ? '' : `${(ms / 1000).toFixed(1)}s`
+}
+function engineLabel(key: BenchEngineKey): string {
+  return store.BENCH_ENGINES.find((e) => e.key === key)?.label ?? key
+}
+function onSeed(side: BenchSide, event: Event): void {
+  const raw = (event.target as HTMLInputElement).value.trim()
+  cfg(side).seed = raw === '' ? null : Number(raw)
+  store.persist()
+}
+
+const running = computed(
+  () =>
+    store.state.resultA.status === 'queued' ||
+    store.state.resultA.status === 'rendering' ||
+    store.state.resultB.status === 'queued' ||
+    store.state.resultB.status === 'rendering',
+)
+</script>

--- a/pages/build-bench.vue
+++ b/pages/build-bench.vue
@@ -1,0 +1,12 @@
+<!-- /pages/build-bench.vue -->
+<!--
+  Build Bench — a head-to-head A/B test bench for image-generation builds.
+  Thin wrapper around <BuildBench>; the whole surface is the two-panel bench.
+-->
+<template>
+  <BuildBench />
+</template>
+
+<script setup lang="ts">
+import BuildBench from '@/components/art/build-bench.vue'
+</script>

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -60,7 +60,7 @@ type EnqueueEngine =
   | 'ltx'
   | 'wan'
 
-// Aliases so callers can say "krea"/"klein"/"flux2-klein" etc.
+// Aliases so callers can say "krea"/"klein"/"flux2-klein"/"sdxl" etc.
 const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
   krea: 'krea2',
   'krea-2': 'krea2',
@@ -68,6 +68,8 @@ const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
   klein: 'flux2',
   'flux2-klein': 'flux2',
   'flux-2': 'flux2',
+  // The SDXL/SD graph is the default "comfy" engine; let callers name it 'sdxl'.
+  sdxl: 'comfy',
 }
 
 const VIDEO_ENGINES = new Set<EnqueueEngine>(['ltx', 'wan'])

--- a/stores/buildBenchStore.ts
+++ b/stores/buildBenchStore.ts
@@ -1,0 +1,361 @@
+// /stores/buildBenchStore.ts
+//
+// Build Bench: a head-to-head A/B test bench for image-generation builds. Each
+// side is a full build (engine + prompt + settings). "Run both" enqueues two
+// ArtJobs (reusing /api/art/enqueue + every engine), polls them, and shows the
+// renders side by side so you can eyeball and pick a winner. A clone button
+// copies one side's whole config onto the other so you can vary a single knob
+// (e.g. clone A->B, then double B's steps, or swap B's engine to Flux.2).
+//
+// Local-first: bench state + saved matchups persist to localStorage; the two
+// rendered images are real ArtImages in the gallery. No new backend — this is a
+// thin driver over the existing enqueue/queue/image endpoints.
+import { defineStore } from 'pinia'
+import { reactive } from 'vue'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+import { resolveArtImageSource } from '~/utils/artImageSource'
+import { performFetch } from '@/stores/utils'
+
+export type BenchSide = 'A' | 'B'
+export type BenchEngineKey = 'krea2' | 'flux2' | 'sdxl' | 'flux'
+
+export interface BenchEngineDef {
+  key: BenchEngineKey
+  label: string
+  hint: string
+  defaults: { steps: number; cfg: number; guidance: number; sampler: string; scheduler: string }
+}
+
+// The engines the bench can pit against each other. `key` is sent as the enqueue
+// `engine` (sdxl is aliased to the comfy graph server-side). Defaults auto-fill
+// each engine's native cadence when you switch.
+export const BENCH_ENGINES: BenchEngineDef[] = [
+  { key: 'krea2', label: 'Krea 2 Turbo', hint: '8-step, illustration/creative', defaults: { steps: 8, cfg: 1, guidance: 3.5, sampler: 'euler', scheduler: 'simple' } },
+  { key: 'flux2', label: 'Flux.2 Klein', hint: '4-step, structured/JSON', defaults: { steps: 4, cfg: 1, guidance: 3.5, sampler: 'euler', scheduler: 'simple' } },
+  { key: 'sdxl', label: 'SDXL', hint: 'big LoRA ecosystem, cfg matters', defaults: { steps: 25, cfg: 6, guidance: 3.5, sampler: 'euler', scheduler: 'normal' } },
+  { key: 'flux', label: 'Flux dev', hint: '30-step, the old default', defaults: { steps: 30, cfg: 1, guidance: 3.5, sampler: 'euler', scheduler: 'beta' } },
+]
+
+export interface BuildConfig {
+  engine: BenchEngineKey
+  prompt: string
+  negativePrompt: string
+  steps: number
+  cfg: number
+  guidance: number
+  seed: number | null // null = random (server assigns; recorded on the result)
+  width: number
+  height: number
+  sampler: string
+  scheduler: string
+  loraName: string
+  loraStrength: number
+}
+
+export type BenchStatus = 'idle' | 'queued' | 'rendering' | 'done' | 'failed'
+
+export interface BuildResult {
+  status: BenchStatus
+  jobId: number | null
+  artImageId: number | null
+  src: string
+  seed: number | null
+  error: string | null
+  elapsedMs: number | null
+}
+
+export interface SavedMatchup {
+  id: string
+  at: string
+  a: BuildConfig
+  b: BuildConfig
+  resultA: BuildResult
+  resultB: BuildResult
+  winner: BenchSide | null
+  note: string
+}
+
+interface BuildBenchState {
+  buildA: BuildConfig
+  buildB: BuildConfig
+  resultA: BuildResult
+  resultB: BuildResult
+  winner: BenchSide | null
+  note: string
+  saved: SavedMatchup[]
+  error: string | null
+}
+
+const STORAGE_KEY = 'kr_build_bench_v1'
+const POLL_MS = 5_000
+const POLL_TIMEOUT_MS = 20 * 60_000 // krea first-load on a small box is slow
+const BENCH_PRIORITY = 100 // jump the shared queue so bench renders come fast
+
+function engineDef(key: BenchEngineKey): BenchEngineDef {
+  return BENCH_ENGINES.find((e) => e.key === key) ?? BENCH_ENGINES[0]
+}
+
+function freshConfig(engine: BenchEngineKey): BuildConfig {
+  const d = engineDef(engine).defaults
+  return {
+    engine,
+    prompt: '',
+    negativePrompt: '',
+    steps: d.steps,
+    cfg: d.cfg,
+    guidance: d.guidance,
+    seed: null,
+    width: 1024,
+    height: 1536,
+    sampler: d.sampler,
+    scheduler: d.scheduler,
+    loraName: '',
+    loraStrength: 1,
+  }
+}
+
+function freshResult(): BuildResult {
+  return { status: 'idle', jobId: null, artImageId: null, src: '', seed: null, error: null, elapsedMs: null }
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+export const useBuildBenchStore = defineStore('buildBenchStore', () => {
+  const state = reactive<BuildBenchState>({
+    buildA: freshConfig('krea2'),
+    buildB: freshConfig('flux2'),
+    resultA: freshResult(),
+    resultB: freshResult(),
+    winner: null,
+    note: '',
+    saved: [],
+    error: null,
+  })
+
+  function persist(): void {
+    if (!import.meta.client) return
+    try {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ buildA: state.buildA, buildB: state.buildB, saved: state.saved }),
+      )
+    } catch {
+      /* storage full / unavailable — non-fatal */
+    }
+  }
+
+  function hydrate(): void {
+    if (!import.meta.client) return
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw)
+      if (parsed.buildA) Object.assign(state.buildA, parsed.buildA)
+      if (parsed.buildB) Object.assign(state.buildB, parsed.buildB)
+      if (Array.isArray(parsed.saved)) state.saved = parsed.saved
+    } catch {
+      /* ignore corrupt storage */
+    }
+  }
+
+  function configOf(side: BenchSide): BuildConfig {
+    return side === 'A' ? state.buildA : state.buildB
+  }
+  function resultOf(side: BenchSide): BuildResult {
+    return side === 'A' ? state.resultA : state.resultB
+  }
+
+  // Switching engine auto-fills that engine's native step/cfg/sampler cadence
+  // (only the fields the user hasn't obviously customized are worth resetting;
+  // here we reset the cadence fields so a fresh engine behaves as designed).
+  function setEngine(side: BenchSide, engine: BenchEngineKey): void {
+    const cfg = configOf(side)
+    const d = engineDef(engine).defaults
+    cfg.engine = engine
+    cfg.steps = d.steps
+    cfg.cfg = d.cfg
+    cfg.guidance = d.guidance
+    cfg.sampler = d.sampler
+    cfg.scheduler = d.scheduler
+    persist()
+  }
+
+  // Clone one side's ENTIRE build onto the other — the controlled-comparison
+  // move: copy, then change a single knob on the target.
+  function cloneTo(from: BenchSide): void {
+    const to: BenchSide = from === 'A' ? 'B' : 'A'
+    const source = clone(configOf(from))
+    if (to === 'A') state.buildA = source
+    else state.buildB = source
+    persist()
+  }
+
+  function resetResults(): void {
+    state.resultA = freshResult()
+    state.resultB = freshResult()
+    state.winner = null
+    state.note = ''
+  }
+
+  function newMatchup(): void {
+    state.buildA = freshConfig('krea2')
+    state.buildB = freshConfig('flux2')
+    resetResults()
+    persist()
+  }
+
+  // --- enqueue + poll + load, mirroring stores/artStore.ts's queue path -------
+  function enqueueBody(cfg: BuildConfig): Record<string, unknown> {
+    return {
+      engine: cfg.engine,
+      promptString: cfg.prompt.trim(),
+      negativePrompt: cfg.negativePrompt.trim() || null,
+      steps: cfg.steps,
+      cfg: cfg.cfg,
+      guidance: cfg.guidance,
+      seed: cfg.seed, // null -> server randomizes and bakes a concrete seed
+      width: cfg.width,
+      height: cfg.height,
+      sampler: cfg.sampler || null,
+      scheduler: cfg.scheduler || null,
+      loraName: cfg.loraName.trim() || null,
+      loraStrength: cfg.loraName.trim() ? cfg.loraStrength : null,
+      priority: BENCH_PRIORITY,
+      projectSlug: 'build-bench',
+      designer: 'Build Bench',
+      isPublic: true,
+    }
+  }
+
+  async function pollJob(
+    jobId: number,
+  ): Promise<{ status: string; artImageId: number | null; error: string | null; seed: number | null }> {
+    const started = Date.now()
+    while (Date.now() - started < POLL_TIMEOUT_MS) {
+      const res = await performFetch<{
+        job: { status: string; artImageId: number | null; error: string | null }
+      }>(`/api/art/queue/${jobId}`, { method: 'GET' }, 2, 20_000)
+      const job = res.success ? res.data?.job : null
+      if (job && ['DONE', 'FAILED', 'CANCELLED'].includes(job.status)) {
+        return { status: job.status, artImageId: job.artImageId ?? null, error: job.error ?? null, seed: null }
+      }
+      await new Promise((r) => setTimeout(r, POLL_MS))
+    }
+    throw new Error('Timed out waiting for the render (the job stays queued; its image will still land).')
+  }
+
+  async function loadImage(artImageId: number): Promise<{ src: string; seed: number | null }> {
+    const res = await performFetch<ArtImage & { seed?: number | null }>(
+      `/api/art/image/${artImageId}?includeImageData=true`,
+      { method: 'GET' },
+      1,
+      30_000,
+    )
+    if (!res.success || !res.data) throw new Error('Rendered image could not be loaded.')
+    return { src: resolveArtImageSource(res.data).src, seed: res.data.seed ?? null }
+  }
+
+  async function runSide(side: BenchSide): Promise<void> {
+    const cfg = configOf(side)
+    if (!cfg.prompt.trim()) {
+      state.error = `Build ${side}: add a prompt first.`
+      return
+    }
+    state.error = null
+    const result = freshResult()
+    result.status = 'queued'
+    if (side === 'A') state.resultA = result
+    else state.resultB = result
+    // clearing the winner whenever a render (re)starts keeps the pick honest
+    state.winner = null
+
+    const startedAt = Date.now()
+    try {
+      const enq = await performFetch<{ jobId: number }>(
+        '/api/art/enqueue',
+        { method: 'POST', body: JSON.stringify(enqueueBody(cfg)) },
+        2,
+        60_000,
+      )
+      if (!enq.success || !enq.data?.jobId) throw new Error(enq.message || 'Enqueue failed.')
+      result.jobId = enq.data.jobId
+      result.status = 'rendering'
+
+      const job = await pollJob(result.jobId)
+      if (job.status !== 'DONE' || !job.artImageId) {
+        throw new Error(job.error || `Render ${job.status.toLowerCase()}.`)
+      }
+      result.artImageId = job.artImageId
+      const img = await loadImage(job.artImageId)
+      result.src = img.src
+      result.seed = img.seed
+      result.status = 'done'
+    } catch (error) {
+      result.status = 'failed'
+      result.error = error instanceof Error ? error.message : String(error)
+    } finally {
+      result.elapsedMs = Date.now() - startedAt
+    }
+  }
+
+  async function runBoth(): Promise<void> {
+    await Promise.all([runSide('A'), runSide('B')])
+  }
+
+  function pickWinner(side: BenchSide): void {
+    state.winner = state.winner === side ? null : side
+  }
+
+  function saveMatchup(): void {
+    if (state.resultA.status !== 'done' && state.resultB.status !== 'done') {
+      state.error = 'Render at least one side before saving.'
+      return
+    }
+    const entry: SavedMatchup = {
+      id: `${state.resultA.artImageId ?? 'x'}-${state.resultB.artImageId ?? 'x'}-${state.saved.length + 1}`,
+      at: new Date().toISOString(),
+      a: clone(state.buildA),
+      b: clone(state.buildB),
+      resultA: clone(state.resultA),
+      resultB: clone(state.resultB),
+      winner: state.winner,
+      note: state.note,
+    }
+    state.saved.unshift(entry)
+    state.saved = state.saved.slice(0, 50)
+    persist()
+  }
+
+  function loadSaved(entry: SavedMatchup): void {
+    state.buildA = clone(entry.a)
+    state.buildB = clone(entry.b)
+    state.resultA = clone(entry.resultA)
+    state.resultB = clone(entry.resultB)
+    state.winner = entry.winner
+    state.note = entry.note
+  }
+
+  function deleteSaved(id: string): void {
+    state.saved = state.saved.filter((m) => m.id !== id)
+    persist()
+  }
+
+  return {
+    state,
+    BENCH_ENGINES,
+    hydrate,
+    setEngine,
+    cloneTo,
+    resetResults,
+    newMatchup,
+    runSide,
+    runBoth,
+    pickWinner,
+    saveMatchup,
+    loadSaved,
+    deleteSaved,
+    persist,
+  }
+})

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -198,6 +198,20 @@ export const dashboardConfigs = {
         route: '/artjob',
         requiredRole: 'ADMIN',
       },
+      {
+        key: 'build-bench',
+        label: 'Build Bench',
+        icon: 'kind-icon:server',
+        title: 'Build Bench',
+        summary: 'Pit two generation builds head-to-head and pick the winner.',
+        image: tabImage('art', 'artjob'),
+        flourish: '⚗',
+        tagline: 'Two builds enter. You decide.',
+        narrative:
+          'A/B test image-generation builds: configure two full builds (engine, steps, cfg, seed, LoRA, prompt), clone one onto the other, render both side by side, and pick the winner. Reuses the ArtJob pipeline and every engine (Krea2, Flux.2, SDXL, Flux).',
+        route: '/build-bench',
+        requiredRole: 'ADMIN',
+      },
     ],
   },
 


### PR DESCRIPTION
A focused **Build Bench** for A/B-testing image-generation builds — distinct from the `/challenges` community voting arena. This is a builder's tool: configure two full builds, render both, pick the winner yourself.

## What it does
- **Two build panels (A vs B)** — each a complete spec: engine + prompt + negative + steps + cfg + guidance + seed + width/height + sampler + scheduler + LoRA. Switching engine auto-fills that engine's native cadence.
- **Clone A→B / B→A** — copy one side's whole build onto the other, then change a single knob (the controlled-comparison move: clone, then 2× the steps, or swap the engine at the same seed).
- **Run both** — enqueues two ArtJobs, polls, shows renders side by side.
- **Pick winner** (manual) + save the matchup with a note.
- Engines: **Krea 2, Flux.2 Klein, SDXL, Flux.**

## How it's built
- `stores/buildBenchStore.ts` — two configs, clone/run/winner actions, **local-first** (localStorage) state + saved matchups. Type-checks clean under `tsc --strict` in isolation.
- `components/art/build-bench.vue` + `pages/build-bench.vue` — two-panel UI, registered as an admin **Build Bench** tab in the art channel.
- **No new backend** — drives the existing `/api/art/enqueue` → `/api/art/queue/:id` → `/api/art/image/:id` pipeline. Bench jobs enqueue at **high priority** to jump the shared queue.
- `enqueue.post.ts` — adds an `sdxl` alias for the default `comfy` SD/SDXL graph.

## Companion
conductor `claude/coloring-book-art-model-fceui3` wires the new engines into the CLI matchup runner and adds the Build Bench spec doc.

> Front-end SFCs can't be standalone type-checked here (no `node_modules`); full `vue-tsc` runs in CI. The store logic type-checks clean under `tsc --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbJHCLGDUvnVi3ccnmpun9)_