### PR TITLE
model-builder: block approving a stale asset while a regenerate is in flight

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -372,6 +372,9 @@ const preview = computed(() => store.previewCommit(props.itemId))
 const canApproveAssets = computed(() => {
   if (!item.value) return false
   if (isLocked('GENERATE_ASSETS')) return false
+  // A regenerate in flight means the current artImageId is about to be
+  // replaced — approving now would commit a candidate the user never saw.
+  if (isGenerating.value || isQueued.value) return false
   // For image outputs, require a generated candidate first.
   if (item.value.generation === 'image') return Boolean(item.value.artImageId)
   return true


### PR DESCRIPTION
## Why

`canApproveAssets` (`components/model-builder/model-builder-item-panel.vue`) only checked `isLocked('GENERATE_ASSETS')` and `Boolean(item.artImageId)` — it never consulted `isGenerating`/`isQueued`, both of which already exist as computeds in this file and already gate the generate/regenerate buttons themselves.

## Concrete failure scenario

1. User generates a candidate for an item; it succeeds — `artImageId = A`, stage `GENERATE_ASSETS = 'ready'`.
2. User clicks "Regenerate candidate" (sync or async). The store immediately flips the stage to `'in-progress'`, but neither `generateItemAsset` nor `generateItemAssetAsync` clears `item.artImageId` while the new render is in flight — it's only ever reassigned on completion.
3. Because `canApproveAssets` never checked `isGenerating`/`isQueued`, "Keep this asset" stayed enabled the whole time, still seeing the stale `artImageId = A`.
4. Clicking it approves stage `GENERATE_ASSETS` (and unlocks `COMMIT`) using candidate A, even though a replacement is actively rendering and the user never reviewed it.
5. When the in-flight regeneration finishes, the completion handler unconditionally overwrites `item.artImageId = B` and resets `item.stages.GENERATE_ASSETS` back to `'ready'` — silently downgrading the stage the user just approved, while `COMMIT` may already have been executed against the now-orphaned candidate A.

## Fix

Gate `canApproveAssets` on `isGenerating`/`isQueued` too, mirroring the existing disabled-condition on the generate/regenerate buttons a few lines above it. Once a regenerate is in flight, "Keep this asset" is disabled until it resolves.

## Verification
- `npx eslint components/model-builder/model-builder-item-panel.vue` — clean
- `npx prettier --check` — same pre-existing formatting drift as `main` (confirmed via `git stash` before this change); this PR's diff is a minimal, hand-applied 3-line addition, not a `--write` reformat of the whole file
- `node ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit` — exit 0, zero errors

## Context

This is this cycle's `model-builder/t-029` "polish and upgrade front-end" pass (conductor repo) — a recurring task that sweeps the model-builder surface for genuine, previously-unfixed bugs each cycle. Verified via full-file reads that none of the three previously-fixed bug classes in this task's history (run-history cancel confirm, per-field item-panel watches, state-free async poll) recurred; this is a new, distinct approval-gating race.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XQX2AoPyZjbndp9aUDhnuc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQX2AoPyZjbndp9aUDhnuc)_