### PR TITLE
Music Mentor: audio singing & arrangement feedback page

### DIFF
--- a/composables/useAudioAnalysis.ts
+++ b/composables/useAudioAnalysis.ts
@@ -1,0 +1,564 @@
+// /composables/useAudioAnalysis.ts
+//
+// Client-side audio feature extraction for the Music Mentor page. Accepts audio
+// or video files (the audio track is pulled out of mp4/mov, so an iPhone video
+// recording works without converting first). Runs entirely in the browser via
+// the Web Audio API — the raw audio never leaves the device; only the compact
+// numeric summary this returns is sent to the server for the LLM to reason over.
+// Deliberately dependency-free (a hand-rolled autocorrelation pitch tracker):
+// good for monophonic vocal takes, and honestly flagged as less reliable on
+// mixed/polyphonic material. A heavier pitch model can later slot in behind this
+// same AudioFeatureSummary shape (see conductor music-mentor/t-007).
+
+export interface FeatureSegment {
+  startSec: number
+  endSec: number
+  relativeLoudness: 'soft' | 'medium' | 'loud'
+}
+
+export interface AudioFeatureSummary {
+  durationSec: number
+  analyzedSampleRate: number
+  pitch: {
+    voicedPercent: number
+    medianPitchHz: number | null
+    medianNoteName: string | null
+    meanAbsCentsOff: number | null
+    pitchJitterCents: number | null
+    estimatedKey: string | null
+    vibratoRateHz: number | null
+    rangeSemitones: number | null
+  }
+  timing: {
+    estimatedTempoBpm: number | null
+    tempoStability: number | null
+    onsetCount: number
+    rushDragTrend: 'steady' | 'rushing' | 'dragging' | null
+  }
+  dynamics: {
+    loudnessRangeDb: number | null
+    dynamicContrastDb: number | null
+    overallTrend: 'steady' | 'building' | 'fading' | null
+    clippingSuspected: boolean
+  }
+  structure: {
+    approxSectionCount: number | null
+    segments: FeatureSegment[]
+  }
+  notes: string[]
+}
+
+const TARGET_RATE = 16000
+const FRAME = 1024
+const MIN_F0 = 70 // Hz — below this we treat a frame as unvoiced
+const MAX_F0 = 1100 // Hz — top of a comfortable sung range
+const NOTE_NAMES = [
+  'C',
+  'C#',
+  'D',
+  'D#',
+  'E',
+  'F',
+  'F#',
+  'G',
+  'G#',
+  'A',
+  'A#',
+  'B',
+]
+
+// Krumhansl–Schmuckler key profiles (major / minor), used to guess a key from
+// the pitch-class distribution of the voiced frames.
+const MAJOR_PROFILE = [
+  6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88,
+]
+const MINOR_PROFILE = [
+  6.33, 2.68, 3.52, 5.38, 2.6, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17,
+]
+
+function getAudioContextCtor(): typeof AudioContext | null {
+  if (typeof window === 'undefined') return null
+  const w = window as unknown as {
+    AudioContext?: typeof AudioContext
+    webkitAudioContext?: typeof AudioContext
+  }
+  return w.AudioContext || w.webkitAudioContext || null
+}
+
+function getOfflineCtor(): typeof OfflineAudioContext | null {
+  if (typeof window === 'undefined') return null
+  const w = window as unknown as {
+    OfflineAudioContext?: typeof OfflineAudioContext
+    webkitOfflineAudioContext?: typeof OfflineAudioContext
+  }
+  return w.OfflineAudioContext || w.webkitOfflineAudioContext || null
+}
+
+// Decode any browser-supported media file, then downmix to mono and resample to
+// TARGET_RATE using an OfflineAudioContext (handles anti-aliasing for us).
+async function decodeToMono(file: File): Promise<Float32Array> {
+  const Ctx = getAudioContextCtor()
+  const Offline = getOfflineCtor()
+  if (!Ctx || !Offline) {
+    throw new Error('This browser does not support the Web Audio API.')
+  }
+
+  const arrayBuf = await file.arrayBuffer()
+  const decodeCtx = new Ctx()
+  let decoded: AudioBuffer
+  try {
+    // decodeAudioData pulls the audio track out of the container, so this works
+    // for plain audio (mp3/m4a/wav/ogg) AND for video files (mp4/mov) — we never
+    // touch the video, just its audio. Support varies by browser/codec, so a
+    // decode failure gets a friendly, actionable message rather than a raw throw.
+    decoded = await decodeCtx.decodeAudioData(arrayBuf.slice(0))
+  } catch {
+    throw new Error(
+      'Could not read audio from this file. Most mp3/m4a/wav and iPhone mp4/mov recordings work; if this one does not, try a different browser (Safari/Chrome) or export an audio file (m4a/mp3).',
+    )
+  } finally {
+    await decodeCtx.close()
+  }
+
+  const frames = Math.max(1, Math.ceil(decoded.duration * TARGET_RATE))
+  const offline = new Offline(1, frames, TARGET_RATE)
+  const source = offline.createBufferSource()
+  source.buffer = decoded
+  source.connect(offline.destination)
+  source.start()
+  const rendered = await offline.startRendering()
+  return rendered.getChannelData(0).slice()
+}
+
+function hzToMidi(hz: number): number {
+  return 69 + 12 * Math.log2(hz / 440)
+}
+
+function noteNameFromMidi(midi: number): string {
+  const rounded = Math.round(midi)
+  const name = NOTE_NAMES[((rounded % 12) + 12) % 12] ?? '?'
+  const octave = Math.floor(rounded / 12) - 1
+  return `${name}${octave}`
+}
+
+function median(values: number[]): number | null {
+  if (!values.length) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2
+    ? (sorted[mid] ?? null)
+    : ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (!sorted.length) return 0
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.round((p / 100) * (sorted.length - 1))),
+  )
+  return sorted[idx] ?? 0
+}
+
+function mean(values: number[]): number {
+  if (!values.length) return 0
+  return values.reduce((sum, v) => sum + v, 0) / values.length
+}
+
+function stdDev(values: number[]): number {
+  if (values.length < 2) return 0
+  const m = mean(values)
+  return Math.sqrt(mean(values.map((v) => (v - m) ** 2)))
+}
+
+function autocorrAt(frame: Float32Array, lag: number): number {
+  if (lag < 1 || lag >= frame.length) return 0
+  let corr = 0
+  for (let i = 0; i < frame.length - lag; i++) {
+    corr += (frame[i] ?? 0) * (frame[i + lag] ?? 0)
+  }
+  return corr
+}
+
+// Normalized autocorrelation pitch detector for a single frame. Returns the
+// fundamental in Hz, or null when the frame is too quiet or has no clear period.
+function detectPitch(frame: Float32Array, sampleRate: number): number | null {
+  let energy = 0
+  for (const s of frame) energy += s * s
+  const rms = Math.sqrt(energy / frame.length)
+  if (rms < 0.01) return null // silence / unvoiced gate
+
+  const minLag = Math.floor(sampleRate / MAX_F0)
+  const maxLag = Math.min(frame.length - 1, Math.floor(sampleRate / MIN_F0))
+
+  let bestLag = -1
+  let bestCorr = 0
+  let lastCorr = 0
+  let ascending = false
+
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let corr = 0
+    for (let i = 0; i < frame.length - lag; i++) {
+      corr += (frame[i] ?? 0) * (frame[i + lag] ?? 0)
+    }
+    // Only consider peaks that come after the correlation first starts rising —
+    // avoids latching onto the zero-lag shoulder and halving/doubling errors.
+    if (!ascending && corr > lastCorr) ascending = true
+    if (ascending && corr > bestCorr) {
+      bestCorr = corr
+      bestLag = lag
+    }
+    lastCorr = corr
+  }
+
+  if (bestLag < 0 || energy <= 0 || bestCorr / energy < 0.5) return null
+
+  // Parabolic interpolation around the peak for sub-sample precision.
+  const y0 = autocorrAt(frame, bestLag - 1)
+  const y1 = bestCorr
+  const y2 = autocorrAt(frame, bestLag + 1)
+  const denom = 2 * (2 * y1 - y0 - y2)
+  const shift = denom !== 0 ? (y2 - y0) / denom : 0
+  const refinedLag = bestLag + shift
+
+  const f0 = sampleRate / refinedLag
+  return f0 >= MIN_F0 && f0 <= MAX_F0 ? f0 : null
+}
+
+function estimateKey(pitchClassWeights: number[]): string | null {
+  const total = pitchClassWeights.reduce((s, v) => s + v, 0)
+  if (total <= 0) return null
+
+  const modes: ReadonlyArray<readonly [string, number[]]> = [
+    ['major', MAJOR_PROFILE],
+    ['minor', MINOR_PROFILE],
+  ]
+
+  let best: { score: number; tonic: number; mode: string } | null = null
+  for (let tonic = 0; tonic < 12; tonic++) {
+    for (const [mode, profile] of modes) {
+      let score = 0
+      for (let pc = 0; pc < 12; pc++) {
+        score +=
+          (pitchClassWeights[pc] ?? 0) * (profile[(pc - tonic + 12) % 12] ?? 0)
+      }
+      if (!best || score > best.score) best = { score, tonic, mode }
+    }
+  }
+
+  if (!best) return null
+  return `${NOTE_NAMES[best.tonic] ?? '?'} ${best.mode}`
+}
+
+// Estimate tempo (BPM) from the onset-strength envelope via autocorrelation over
+// a plausible tempo band. Returns null when no periodicity stands out.
+function estimateTempo(onsetEnv: number[], hopSec: number): number | null {
+  if (onsetEnv.length < 8 || hopSec <= 0) return null
+  const minBpm = 50
+  const maxBpm = 200
+  const minLag = Math.max(1, Math.floor(60 / maxBpm / hopSec))
+  const maxLag = Math.min(onsetEnv.length - 1, Math.ceil(60 / minBpm / hopSec))
+
+  let bestLag = -1
+  let bestScore = 0
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let score = 0
+    for (let i = 0; i + lag < onsetEnv.length; i++) {
+      score += (onsetEnv[i] ?? 0) * (onsetEnv[i + lag] ?? 0)
+    }
+    if (score > bestScore) {
+      bestScore = score
+      bestLag = lag
+    }
+  }
+  if (bestLag < 1 || bestScore <= 0) return null
+  return Math.round(60 / (bestLag * hopSec))
+}
+
+async function yieldToUi(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * Extract a compact, LLM-friendly feature summary from an audio OR video file
+ * (the audio track is decoded out of mp4/mov containers), fully in the browser.
+ * Yields periodically so the page stays responsive while a longer clip is
+ * analyzed.
+ */
+export async function analyzeAudioFile(
+  file: File,
+): Promise<AudioFeatureSummary> {
+  const samples = await decodeToMono(file)
+  const durationSec = samples.length / TARGET_RATE
+  const notes: string[] = []
+
+  // Adaptive hop: keep the total frame count bounded (~3000) so a long medley
+  // still analyzes in a couple of seconds without freezing the tab.
+  const rawHop = Math.floor(FRAME / 2)
+  const maxFrames = 3000
+  const naturalFrames = Math.floor((samples.length - FRAME) / rawHop)
+  const hop =
+    naturalFrames > maxFrames
+      ? Math.ceil((samples.length - FRAME) / maxFrames)
+      : rawHop
+  const hopSec = hop / TARGET_RATE
+
+  const pitchesHz: number[] = []
+  const voicedMidi: number[] = []
+  const pitchClassWeights = new Array<number>(12).fill(0)
+  const frameDb: number[] = []
+  const onsetEnv: number[] = []
+  let voicedFrames = 0
+  let totalFrames = 0
+  let prevEnergy = 0
+  let clippingSuspected = false
+
+  for (let start = 0; start + FRAME <= samples.length; start += hop) {
+    const frame = samples.subarray(start, start + FRAME)
+
+    // Dynamics: frame RMS in dBFS.
+    let sumSq = 0
+    let peak = 0
+    for (const s of frame) {
+      sumSq += s * s
+      const a = Math.abs(s)
+      if (a > peak) peak = a
+    }
+    if (peak >= 0.999) clippingSuspected = true
+    const rms = Math.sqrt(sumSq / frame.length)
+    const db = 20 * Math.log10(Math.max(rms, 1e-6))
+    frameDb.push(db)
+
+    // Onset strength: positive change in energy (half-wave rectified flux).
+    onsetEnv.push(Math.max(0, rms - prevEnergy))
+    prevEnergy = rms
+
+    // Pitch.
+    const f0 = detectPitch(frame, TARGET_RATE)
+    totalFrames++
+    if (f0 != null) {
+      voicedFrames++
+      pitchesHz.push(f0)
+      const midi = hzToMidi(f0)
+      voicedMidi.push(midi)
+      const pc = ((Math.round(midi) % 12) + 12) % 12
+      pitchClassWeights[pc] = (pitchClassWeights[pc] ?? 0) + 1
+    }
+
+    if (totalFrames % 200 === 0) await yieldToUi()
+  }
+
+  // ---- Pitch summary ----
+  const voicedPercent = totalFrames
+    ? Math.round((voicedFrames / totalFrames) * 1000) / 10
+    : 0
+  const medianPitchHz = median(pitchesHz)
+  const medianNoteName =
+    medianPitchHz != null ? noteNameFromMidi(hzToMidi(medianPitchHz)) : null
+
+  // Intonation: average absolute distance (cents) from the nearest semitone.
+  let meanAbsCentsOff: number | null = null
+  if (voicedMidi.length) {
+    const centsOff = voicedMidi.map((m) => Math.abs(m - Math.round(m)) * 100)
+    meanAbsCentsOff = Math.round(mean(centsOff))
+  }
+  // Jitter: median frame-to-frame pitch wobble within voiced regions (cents).
+  let pitchJitterCents: number | null = null
+  if (voicedMidi.length > 2) {
+    const diffs: number[] = []
+    for (let i = 1; i < voicedMidi.length; i++) {
+      diffs.push(
+        Math.abs((voicedMidi[i] ?? 0) - (voicedMidi[i - 1] ?? 0)) * 100,
+      )
+    }
+    pitchJitterCents = Math.round(median(diffs) ?? 0)
+  }
+  const rangeSemitones =
+    voicedMidi.length > 1
+      ? Math.round(Math.max(...voicedMidi) - Math.min(...voicedMidi))
+      : null
+  const estimatedKey = estimateKey(pitchClassWeights)
+
+  // Vibrato: rate of oscillation of the pitch contour in voiced spans. Count
+  // direction changes of the frame-differenced pitch track per second.
+  let vibratoRateHz: number | null = null
+  if (voicedMidi.length > 8 && hopSec > 0) {
+    let signChanges = 0
+    let prevDir = 0
+    for (let i = 1; i < voicedMidi.length; i++) {
+      const d = (voicedMidi[i] ?? 0) - (voicedMidi[i - 1] ?? 0)
+      const dir = d > 0 ? 1 : d < 0 ? -1 : prevDir
+      if (dir !== 0 && prevDir !== 0 && dir !== prevDir) signChanges++
+      if (dir !== 0) prevDir = dir
+    }
+    const voicedDurSec = voicedMidi.length * hopSec
+    // Each vibrato cycle produces two direction changes.
+    if (voicedDurSec > 0) {
+      const rate = signChanges / 2 / voicedDurSec
+      vibratoRateHz = rate >= 3 && rate <= 9 ? Math.round(rate * 10) / 10 : null
+    }
+  }
+
+  // ---- Timing summary ----
+  const positiveOnsets = onsetEnv.filter((v) => v > 0)
+  const onsetThreshold = mean(onsetEnv) + 1.2 * stdDev(positiveOnsets)
+  const onsetTimes: number[] = []
+  for (let i = 1; i < onsetEnv.length - 1; i++) {
+    const cur = onsetEnv[i] ?? 0
+    if (
+      cur > onsetThreshold &&
+      cur >= (onsetEnv[i - 1] ?? 0) &&
+      cur > (onsetEnv[i + 1] ?? 0)
+    ) {
+      onsetTimes.push(i * hopSec)
+    }
+  }
+  const estimatedTempoBpm = estimateTempo(onsetEnv, hopSec)
+
+  let tempoStability: number | null = null
+  let rushDragTrend: 'steady' | 'rushing' | 'dragging' | null = null
+  if (onsetTimes.length > 3) {
+    const iois: number[] = []
+    for (let i = 1; i < onsetTimes.length; i++) {
+      iois.push((onsetTimes[i] ?? 0) - (onsetTimes[i - 1] ?? 0))
+    }
+    const ioiMean = mean(iois)
+    if (ioiMean > 0) {
+      const cv = stdDev(iois) / ioiMean
+      tempoStability = Math.max(
+        0,
+        Math.min(1, Math.round((1 - cv) * 100) / 100),
+      )
+      // Trend: are the later gaps shorter (rushing) or longer (dragging)?
+      const half = Math.floor(iois.length / 2)
+      const drift =
+        (mean(iois.slice(half)) - mean(iois.slice(0, half))) / ioiMean
+      rushDragTrend =
+        drift < -0.08 ? 'rushing' : drift > 0.08 ? 'dragging' : 'steady'
+    }
+  }
+
+  // ---- Dynamics summary ----
+  let loudnessRangeDb: number | null = null
+  let dynamicContrastDb: number | null = null
+  let overallTrend: 'steady' | 'building' | 'fading' | null = null
+  const audibleDb = frameDb.filter((d) => d > -60)
+  if (audibleDb.length) {
+    const sorted = [...audibleDb].sort((a, b) => a - b)
+    loudnessRangeDb = Math.round(percentile(sorted, 95) - percentile(sorted, 5))
+    dynamicContrastDb = Math.round(stdDev(audibleDb) * 10) / 10
+    const half = Math.floor(frameDb.length / 2)
+    const delta = mean(frameDb.slice(half)) - mean(frameDb.slice(0, half))
+    overallTrend = delta > 2 ? 'building' : delta < -2 ? 'fading' : 'steady'
+  }
+
+  // ---- Structure summary ----
+  const segments = segmentByLoudness(frameDb, hopSec)
+  const approxSectionCount = segments.length || null
+
+  // ---- Honest caveats ----
+  if (voicedPercent < 40) {
+    notes.push(
+      'Less than half the take registered a clear pitch — likely quiet, breathy, heavily mixed, or instrumental passages, so pitch stats are approximate.',
+    )
+  }
+  if (clippingSuspected) {
+    notes.push(
+      'The recording appears to clip (peaks at full scale); loudness range and tone may be affected by distortion.',
+    )
+  }
+  if (durationSec < 5) {
+    notes.push('Short clip — tempo and structure estimates are rough.')
+  }
+  notes.push(
+    'Pitch is tracked monophonically; on full-mix or polyphonic audio the intonation and key estimates are less reliable than on an isolated vocal.',
+  )
+
+  return {
+    durationSec: Math.round(durationSec * 10) / 10,
+    analyzedSampleRate: TARGET_RATE,
+    pitch: {
+      voicedPercent,
+      medianPitchHz: medianPitchHz != null ? Math.round(medianPitchHz) : null,
+      medianNoteName,
+      meanAbsCentsOff,
+      pitchJitterCents,
+      estimatedKey,
+      vibratoRateHz,
+      rangeSemitones,
+    },
+    timing: {
+      estimatedTempoBpm,
+      tempoStability,
+      onsetCount: onsetTimes.length,
+      rushDragTrend,
+    },
+    dynamics: {
+      loudnessRangeDb,
+      dynamicContrastDb,
+      overallTrend,
+      clippingSuspected,
+    },
+    structure: {
+      approxSectionCount,
+      segments,
+    },
+    notes,
+  }
+}
+
+// Segment the take into coarse sections by sustained loudness level. Smooths the
+// dB envelope over ~1.5s, then splits where the level shifts by >6 dB and holds
+// for at least ~3s. Returns segments tagged soft/medium/loud.
+function segmentByLoudness(
+  frameDb: number[],
+  hopSec: number,
+): FeatureSegment[] {
+  if (!frameDb.length || hopSec <= 0) return []
+
+  const smoothWin = Math.max(1, Math.round(1.5 / hopSec))
+  const smoothed: number[] = []
+  for (let i = 0; i < frameDb.length; i++) {
+    const from = Math.max(0, i - smoothWin)
+    const to = Math.min(frameDb.length, i + smoothWin + 1)
+    smoothed.push(mean(frameDb.slice(from, to)))
+  }
+
+  const minSegFrames = Math.max(1, Math.round(3 / hopSec))
+  const changeDb = 6
+  const boundaries: number[] = [0]
+  let anchor = smoothed[0] ?? 0
+  let lastBoundary = 0
+  for (let i = 1; i < smoothed.length; i++) {
+    const level = smoothed[i] ?? 0
+    if (
+      Math.abs(level - anchor) > changeDb &&
+      i - lastBoundary >= minSegFrames
+    ) {
+      boundaries.push(i)
+      lastBoundary = i
+      anchor = level
+    }
+  }
+  boundaries.push(smoothed.length)
+
+  const audible = smoothed.filter((d) => d > -60)
+  const sortedAudible = [...audible].sort((a, b) => a - b)
+  const lowCut = percentile(sortedAudible, 33)
+  const highCut = percentile(sortedAudible, 66)
+
+  const segments: FeatureSegment[] = []
+  for (let b = 0; b < boundaries.length - 1; b++) {
+    const startIdx = boundaries[b] ?? 0
+    const endIdx = boundaries[b + 1] ?? 0
+    if (endIdx <= startIdx) continue
+    const level = mean(smoothed.slice(startIdx, endIdx))
+    const relativeLoudness =
+      level <= lowCut ? 'soft' : level >= highCut ? 'loud' : 'medium'
+    segments.push({
+      startSec: Math.round(startIdx * hopSec * 10) / 10,
+      endSec: Math.round(endIdx * hopSec * 10) / 10,
+      relativeLoudness,
+    })
+  }
+  return segments
+}

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -1,0 +1,274 @@
+<template>
+  <div class="p-6 space-y-6 max-w-3xl mx-auto">
+    <header class="space-y-1">
+      <h1 class="text-2xl font-bold">🎤 Music Mentor</h1>
+      <p class="text-sm opacity-70">
+        Upload a recording of your sung medley and get honest, specific feedback
+        on the singing and the arrangement. Everything is analyzed
+        <strong>in your browser</strong> — the audio never leaves your device,
+        and nothing is stored.
+      </p>
+      <p class="text-xs opacity-60">
+        Honest heads-up: this measures the objective stuff (pitch, timing,
+        dynamics, structure) and reasons over your setlist. It can't judge tone,
+        emotion, or "is this a good voice" — that still needs a human ear.
+      </p>
+    </header>
+
+    <div v-if="!isLoggedIn" class="alert alert-warning text-sm" role="alert">
+      You need to be signed in to run an analysis — the coaching step is billed
+      to your account's mana.
+    </div>
+
+    <!-- File -->
+    <section class="space-y-2">
+      <label class="font-semibold">
+        Recording <span class="text-error">*</span>
+      </label>
+      <input
+        type="file"
+        accept="audio/*,video/*,.mp3,.m4a,.wav,.ogg,.mp4,.mov"
+        class="file-input file-input-bordered w-full"
+        @change="onFileChange"
+      />
+      <p v-if="fileName" class="text-xs opacity-70">
+        {{ fileName }} ({{ fileSizeMb }} MB) — only the audio track is read.
+      </p>
+      <p v-else class="text-xs opacity-50">
+        Audio or video is fine (mp3, m4a, wav, or an iPhone mp4/mov — we just
+        read the audio). Up to {{ MAX_MB }} MB.
+      </p>
+    </section>
+
+    <!-- Setlist -->
+    <section class="space-y-2">
+      <label class="font-semibold">Setlist / notes</label>
+      <textarea
+        v-model="setlist"
+        rows="4"
+        class="textarea textarea-bordered w-full"
+        placeholder="List the songs in your medley (and keys if you know them), plus anything you want feedback on. This sharpens the arrangement feedback."
+      />
+    </section>
+
+    <!-- Dimensions -->
+    <section class="space-y-2">
+      <label class="font-semibold">What should I listen for?</label>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="opt in DIMENSIONS"
+          :key="opt.value"
+          type="button"
+          class="btn btn-sm"
+          :class="selected.includes(opt.value) ? 'btn-accent' : 'btn-outline'"
+          @click="toggle(opt.value)"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+      <p class="text-xs opacity-60">
+        Pick at least one. All four selected by default.
+      </p>
+    </section>
+
+    <!-- Analyze -->
+    <section class="space-y-3">
+      <button
+        type="button"
+        class="btn btn-accent btn-lg w-full"
+        :disabled="!canAnalyze"
+        @click="run"
+      >
+        <span v-if="store.isBusy" class="loading loading-spinner loading-sm" />
+        {{ analyzeLabel }}
+      </button>
+
+      <div v-if="store.state.message" class="text-sm opacity-70 text-center">
+        {{ store.state.message }}
+      </div>
+
+      <div
+        v-if="store.state.error"
+        class="alert alert-error text-sm"
+        role="alert"
+      >
+        {{ store.state.error }}
+      </div>
+    </section>
+
+    <!-- Feedback -->
+    <section v-if="store.state.feedback" class="space-y-2">
+      <h2 class="font-semibold">Mentor feedback</h2>
+      <div
+        class="whitespace-pre-line rounded-2xl border border-base-300 bg-base-200/60 p-4 text-sm leading-relaxed"
+      >
+        {{ store.state.feedback }}
+      </div>
+    </section>
+
+    <!-- Extracted features (transparency) -->
+    <details v-if="store.state.features" class="text-sm">
+      <summary class="cursor-pointer opacity-70">
+        What I measured (the numbers behind the feedback)
+      </summary>
+      <div class="mt-2 grid gap-2 sm:grid-cols-2">
+        <div
+          v-for="row in featureRows"
+          :key="row.label"
+          class="flex justify-between gap-3 rounded-lg border border-base-300 bg-base-100 px-3 py-2"
+        >
+          <span class="opacity-70">{{ row.label }}</span>
+          <span class="font-medium text-right">{{ row.value }}</span>
+        </div>
+      </div>
+      <ul
+        v-if="store.state.features.notes.length"
+        class="mt-3 list-disc space-y-1 pl-5 text-xs opacity-70"
+      >
+        <li v-for="(note, i) in store.state.features.notes" :key="i">
+          {{ note }}
+        </li>
+      </ul>
+    </details>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import {
+  useMusicMentorStore,
+  type MentorDimension,
+} from '@/stores/musicMentorStore'
+import { useUserStore } from '@/stores/userStore'
+
+const MAX_MB = 250
+
+const DIMENSIONS: { value: MentorDimension; label: string }[] = [
+  { value: 'intonation', label: 'Intonation / pitch' },
+  { value: 'timing', label: 'Timing & rhythm' },
+  { value: 'dynamics', label: 'Dynamics & expression' },
+  { value: 'arrangement', label: 'Arrangement & structure' },
+]
+
+const store = useMusicMentorStore()
+const userStore = useUserStore()
+
+const isLoggedIn = computed(() => userStore.isLoggedIn)
+
+const file = ref<File | null>(null)
+const fileName = ref('')
+const fileSizeMb = ref('0')
+const setlist = ref('')
+const selected = ref<MentorDimension[]>(DIMENSIONS.map((d) => d.value))
+
+const canAnalyze = computed(
+  () =>
+    isLoggedIn.value &&
+    !store.isBusy &&
+    !!file.value &&
+    selected.value.length > 0,
+)
+
+const analyzeLabel = computed(() => {
+  if (store.state.status === 'extracting') return 'Listening…'
+  if (store.state.status === 'thinking') return 'Thinking…'
+  return 'Analyze my medley'
+})
+
+function onFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const picked = target.files?.[0] ?? null
+  store.reset()
+  if (!picked) {
+    file.value = null
+    fileName.value = ''
+    return
+  }
+  const sizeMb = picked.size / (1024 * 1024)
+  if (sizeMb > MAX_MB) {
+    file.value = null
+    fileName.value = ''
+    store.state.status = 'error'
+    store.state.error = `That file is ${sizeMb.toFixed(0)} MB — please keep it under ${MAX_MB} MB (a shorter clip, or export just the audio).`
+    return
+  }
+  file.value = picked
+  fileName.value = picked.name
+  fileSizeMb.value = sizeMb.toFixed(1)
+}
+
+function toggle(value: MentorDimension) {
+  selected.value = selected.value.includes(value)
+    ? selected.value.filter((v) => v !== value)
+    : [...selected.value, value]
+}
+
+const featureRows = computed(() => {
+  const f = store.state.features
+  if (!f) return []
+  const dash = (v: unknown) => (v === null || v === undefined ? '—' : String(v))
+  return [
+    { label: 'Duration', value: `${f.durationSec}s` },
+    { label: 'Voiced', value: `${f.pitch.voicedPercent}%` },
+    {
+      label: 'Median pitch',
+      value: f.pitch.medianNoteName
+        ? `${f.pitch.medianNoteName} (${dash(f.pitch.medianPitchHz)} Hz)`
+        : '—',
+    },
+    { label: 'Est. key', value: dash(f.pitch.estimatedKey) },
+    {
+      label: 'Intonation (avg off)',
+      value:
+        f.pitch.meanAbsCentsOff != null
+          ? `${f.pitch.meanAbsCentsOff} cents`
+          : '—',
+    },
+    {
+      label: 'Vocal range',
+      value:
+        f.pitch.rangeSemitones != null
+          ? `${f.pitch.rangeSemitones} semitones`
+          : '—',
+    },
+    {
+      label: 'Vibrato',
+      value:
+        f.pitch.vibratoRateHz != null ? `${f.pitch.vibratoRateHz} Hz` : '—',
+    },
+    {
+      label: 'Tempo',
+      value:
+        f.timing.estimatedTempoBpm != null
+          ? `${f.timing.estimatedTempoBpm} BPM`
+          : '—',
+    },
+    {
+      label: 'Tempo steadiness',
+      value:
+        f.timing.tempoStability != null
+          ? `${Math.round(f.timing.tempoStability * 100)}%`
+          : '—',
+    },
+    { label: 'Timing trend', value: dash(f.timing.rushDragTrend) },
+    {
+      label: 'Loudness range',
+      value:
+        f.dynamics.loudnessRangeDb != null
+          ? `${f.dynamics.loudnessRangeDb} dB`
+          : '—',
+    },
+    { label: 'Dynamic trend', value: dash(f.dynamics.overallTrend) },
+    { label: 'Sections (approx)', value: dash(f.structure.approxSectionCount) },
+  ]
+})
+
+async function run() {
+  if (!canAnalyze.value || !file.value) return
+  await store.analyze({
+    file: file.value,
+    setlist: setlist.value,
+    dimensions: selected.value,
+  })
+}
+</script>

--- a/server/api/music-mentor/analyze.post.ts
+++ b/server/api/music-mentor/analyze.post.ts
@@ -1,0 +1,172 @@
+// /server/api/music-mentor/analyze.post.ts
+//
+// Music Mentor feedback endpoint. Receives a compact, browser-extracted audio
+// feature summary (pitch/intonation, timing, dynamics, structure) plus the
+// user's setlist and the feedback dimensions they picked, and asks an LLM to
+// turn those numbers into honest singing + arrangement coaching. The raw audio
+// never reaches the server — this endpoint only ever sees the numeric summary,
+// and nothing is persisted. Reuses the suggest-provider plumbing so it inherits
+// the same provider selection, key resolution, and mana billing as /api/suggest.
+import { defineEventHandler, readBody, createError } from 'h3'
+import { manaGate } from '../../utils/manaGate'
+import { estimateTextCostUsd } from '../../utils/manaCost'
+import {
+  callSuggestProvider,
+  deriveSuggestProvider,
+  resolveSuggestModel,
+  str,
+} from '../../utils/suggest/suggestProviders'
+import type { SuggestServerSnapshot } from '../../utils/suggest/suggestTypes'
+
+type Dimension = 'intonation' | 'timing' | 'dynamics' | 'arrangement'
+
+const DIMENSION_GUIDES: Record<Dimension, string> = {
+  intonation:
+    'Intonation & pitch: comment on how in-tune the singing is (use meanAbsCentsOff — under ~20 cents is quite accurate, 20–40 is workable, over 40 reads as noticeably off), note stability/jitter, range, and the estimated key. Say whether any flat/sharp tendency is worth drilling.',
+  timing:
+    'Timing & rhythm: comment on the tempo estimate, how steady it is (tempoStability closer to 1 is steadier), and any rushing/dragging trend. Frame it around keeping the medley grooving.',
+  dynamics:
+    'Dynamics & expression: comment on the loudness range and contrast — is the take dynamically flat or expressive? Note the overall build/fade and flag suspected clipping if present.',
+  arrangement:
+    'Arrangement & structure: reason over the setlist the user provided plus the detected section structure. Comment on song-to-song transitions, key relationships between songs, pacing across the medley, and overall cohesion. This is the most important dimension — be concrete and musical.',
+}
+
+type AnalyzeBody = {
+  features?: unknown
+  setlist?: string
+  dimensions?: string[]
+  server?: SuggestServerSnapshot
+  maxTokens?: number | null
+}
+
+const SYSTEM_PROMPT = `You are Music Mentor, a warm, specific vocal and arrangement coach for a songwriter workshopping a sung medley.
+
+You are given OBJECTIVE audio measurements extracted in the singer's browser (pitch/intonation, timing, dynamics, rough section structure) plus a setlist they typed. You never hear the audio yourself — you only see these numbers.
+
+Rules:
+- Be honest about the boundary: you can speak to what the measurements support (intonation, timing, dynamics, structure). You CANNOT judge tone, emotion, timbre, or "is this a good voice" — say so briefly if the user seems to expect it, and don't fake it.
+- Lead with what is working, then give the one or two highest-leverage things to improve. Be concrete and actionable, never vague praise or vague scolding.
+- Reference the actual numbers when they justify a point (e.g. "averaging ~35 cents off suggests..."). If a measurement is missing or the notes flag low reliability, hedge accordingly instead of inventing detail.
+- Warm rehearsal-buddy voice. Use short Markdown sections with a heading per requested dimension. Keep it tight.`
+
+function toDimensions(input: unknown): Dimension[] {
+  const valid: Dimension[] = ['intonation', 'timing', 'dynamics', 'arrangement']
+  if (!Array.isArray(input)) return valid
+  const picked = input.filter((d): d is Dimension =>
+    valid.includes(d as Dimension),
+  )
+  return picked.length ? picked : valid
+}
+
+function buildUserPrompt(
+  features: unknown,
+  setlist: string,
+  dimensions: Dimension[],
+): string {
+  const featureJson = JSON.stringify(features, null, 2)
+  const focus = dimensions.map((d) => `- ${DIMENSION_GUIDES[d]}`).join('\n')
+  const setlistBlock = setlist.trim()
+    ? setlist.trim()
+    : '(No setlist provided — infer what you can about arrangement from the section structure, and gently note that a setlist would sharpen the arrangement feedback.)'
+
+  return `Here is the singer's medley setlist / notes:
+${setlistBlock}
+
+Here are the objective measurements from their recording:
+\`\`\`json
+${featureJson}
+\`\`\`
+
+Give feedback on these dimensions only:
+${focus}
+
+Write one short Markdown section per dimension above (in that order), then a brief "Next take" line with the single most useful thing to try next.`
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody<AnalyzeBody>(event)
+
+    if (!body || typeof body.features !== 'object' || body.features === null) {
+      return {
+        success: false,
+        message: 'A feature summary is required.',
+      }
+    }
+
+    const dimensions = toDimensions(body.dimensions)
+    const setlist = typeof body.setlist === 'string' ? body.setlist : ''
+    const server = body.server
+
+    const config = useRuntimeConfig()
+    const provider = deriveSuggestProvider(server)
+    const model = resolveSuggestModel(provider, server?.model)
+
+    const maxTokens = Math.min(
+      Math.max(Math.trunc(body.maxTokens ?? 1200), 256),
+      4096,
+    )
+
+    const gate = await manaGate(event, {
+      kind: 'text',
+      estCostUsd: estimateTextCostUsd({ model, maxTokens }),
+    })
+
+    const userPrompt = buildUserPrompt(body.features, setlist, dimensions)
+
+    const feedback = await callSuggestProvider(SYSTEM_PROMPT, userPrompt, {
+      provider,
+      model,
+      maxTokens,
+      apiKey:
+        provider === 'anthropic'
+          ? str(config.anthropicApiKey)
+          : str(config.openaiApiKey),
+      baseUrl:
+        provider === 'ollama'
+          ? str(
+              server?.baseUrl,
+              str(config.ollamaBaseUrl, 'http://localhost:11434'),
+            )
+          : provider === 'openai_compatible'
+            ? str(server?.baseUrl, 'http://localhost:1234')
+            : undefined,
+      endpointPath:
+        provider === 'openai_compatible'
+          ? str(server?.endpointPath, '/v1/chat/completions')
+          : undefined,
+    })
+
+    if (!feedback) {
+      return {
+        success: false,
+        message: 'The model returned an empty response.',
+      }
+    }
+
+    const { balance } = await gate.commit(`music-mentor:${Date.now()}`)
+
+    return {
+      success: true,
+      message: 'Feedback generated.',
+      data: { feedback, dimensions },
+      mana: {
+        balance,
+        charged: gate.cost,
+        free: gate.free,
+      },
+    }
+  } catch (error) {
+    console.error('[music-mentor] analyze failed:', error)
+
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    throw createError({
+      statusCode: 500,
+      statusMessage:
+        error instanceof Error ? error.message : 'Analysis request failed.',
+    })
+  }
+})

--- a/stores/musicMentorStore.ts
+++ b/stores/musicMentorStore.ts
@@ -1,0 +1,100 @@
+// /stores/musicMentorStore.ts
+//
+// Front-end store for the Music Mentor page. Extracts audio features in the
+// browser (composables/useAudioAnalysis), then POSTs only the compact numeric
+// summary + setlist + selected dimensions to /api/music-mentor/analyze and keeps
+// the returned coaching feedback. The audio itself never leaves the device and
+// nothing is persisted. A single synchronous request — no enqueue/poll — so this
+// is a slimmer cousin of stores/videoStore.ts.
+import { defineStore } from 'pinia'
+import { reactive, computed } from 'vue'
+import { performFetch } from '@/stores/utils'
+import {
+  analyzeAudioFile,
+  type AudioFeatureSummary,
+} from '@/composables/useAudioAnalysis'
+
+export type MentorDimension =
+  'intonation' | 'timing' | 'dynamics' | 'arrangement'
+
+export type MentorStatus = 'idle' | 'extracting' | 'thinking' | 'done' | 'error'
+
+export interface AnalyzeParams {
+  file: File
+  setlist: string
+  dimensions: MentorDimension[]
+}
+
+interface AnalyzeResponse {
+  feedback: string
+  dimensions: MentorDimension[]
+}
+
+export const useMusicMentorStore = defineStore('musicMentorStore', () => {
+  const state = reactive({
+    status: 'idle' as MentorStatus,
+    features: null as AudioFeatureSummary | null,
+    feedback: '',
+    dimensions: [] as MentorDimension[],
+    message: '',
+    error: '',
+  })
+
+  const isBusy = computed(
+    () => state.status === 'extracting' || state.status === 'thinking',
+  )
+
+  function reset(): void {
+    state.status = 'idle'
+    state.features = null
+    state.feedback = ''
+    state.dimensions = []
+    state.message = ''
+    state.error = ''
+  }
+
+  async function analyze(params: AnalyzeParams): Promise<void> {
+    reset()
+    state.status = 'extracting'
+    state.message = 'Listening to your recording in the browser…'
+
+    try {
+      const features = await analyzeAudioFile(params.file)
+      state.features = features
+
+      state.status = 'thinking'
+      state.message = 'Thinking through your take and arrangement…'
+
+      const res = await performFetch<AnalyzeResponse>(
+        '/api/music-mentor/analyze',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            features,
+            setlist: params.setlist,
+            dimensions: params.dimensions,
+          }),
+        },
+        2,
+        90_000,
+      )
+
+      if (!res.success || !res.data?.feedback) {
+        throw new Error(
+          res.message || 'The mentor could not generate feedback.',
+        )
+      }
+
+      state.feedback = res.data.feedback
+      state.dimensions = res.data.dimensions ?? params.dimensions
+      state.status = 'done'
+      state.message = ''
+    } catch (err) {
+      state.status = 'error'
+      state.error = err instanceof Error ? err.message : String(err)
+      state.message = ''
+    }
+  }
+
+  return { state, isBusy, reset, analyze }
+})


### PR DESCRIPTION
## What

Adds **`/music-mentor`** — upload a recording of a sung medley (audio **or** video) and get honest, specific feedback on the singing and the arrangement, with toggleable feedback dimensions (intonation, timing, dynamics, arrangement).

Tracked as conductor project `music-mentor`.

## How it works

- **`composables/useAudioAnalysis.ts`** — dependency-free Web Audio feature extraction that runs entirely in the browser: pitch/intonation (cents-off, estimated key, jitter, vibrato, range), timing (tempo + steadiness, rush/drag), dynamics (loudness range/contrast, clipping), and rough section structure. Accepts audio **and video** files — it decodes the audio track straight out of an iPhone mp4/mov, so no conversion is needed (up to 250 MB).
- **`server/api/music-mentor/analyze.post.ts`** — reasons over the compact numeric summary + the user's setlist via the shared suggest-provider plumbing (`callSuggestProvider` + `manaGate`). Defaults to Claude.
- **`stores/musicMentorStore.ts`** + **`pages/music-mentor.vue`** — extract locally, POST only the summary, render the coaching feedback plus a transparent "here are the numbers I measured" breakdown.

## Privacy / scope

**Ephemeral by design:** the raw audio never leaves the browser — only the numeric feature summary is sent onward, and nothing is persisted (no schema changes). The tool is deliberately honest: it speaks only to what the measurements support and does not pretend to judge tone or emotion.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run lint` (eslint + prettier) — clean
- Local `nuxt dev` can't run in the sandbox (dummy DB); recommend a click-through on the Vercel preview with a real recording.

Follow-ups tracked in the roadmap: frontend placement + project art (t-006), accuracy pass with a heavier pitch model (t-007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLERFDHJjGqjisHTrBtvP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLERFDHJjGqjisHTrBtvP5)_