### PR TITLE
Music Mentor: nav placement + play-channel tab

### DIFF
--- a/content/channels/play/music-mentor.md
+++ b/content/channels/play/music-mentor.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: music-mentor
+dashboardKey: scenario
+dashboardTab: music-mentor
+label: Music Mentor
+title: Music Mentor
+subtitle: Feedback on your singing and arrangement
+description: Upload a sung medley and get honest, specific feedback on pitch, timing, dynamics, and arrangement — analyzed right in your browser.
+icon: kind-icon:microphone
+route: /music-mentor
+sort: 95
+---
+
+Upload a recording of your medley and get coaching on the singing and the arrangement.

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -12,6 +12,11 @@ export type ProjectPlacement = {
 }
 
 export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
+  'music-mentor': {
+    channelKey: 'play',
+    tabKey: 'music-mentor',
+    route: '/music-mentor',
+  },
   'coloring-book': {
     channelKey: 'play',
     tabKey: 'coloring',


### PR DESCRIPTION
## What

Adds the Music Mentor page to the site navigation (follow-up to #920, which merged the feature itself).

## Changes

- **`utils/projectPlacements.ts`** — registers `music-mentor` → `{ channelKey: 'play', tabKey: 'music-mentor', route: '/music-mentor' }`.
- **`content/channels/play/music-mentor.md`** — the play-channel tab (label "Music Mentor", `kind-icon:microphone`, `dashboardKey: scenario`) so the page surfaces in the nav.

## Verification

- `npm run test:channel-content` — passed
- `npm run test:channel-resolver` — passed
- `kind-icon:microphone` exists (`assets/icons/microphone.svg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLERFDHJjGqjisHTrBtvP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLERFDHJjGqjisHTrBtvP5)_