### PR TITLE
Fix recurring Stylist Cypress failures

### DIFF
--- a/content/channels/lab/hair-studio.md
+++ b/content/channels/lab/hair-studio.md
@@ -11,6 +11,7 @@ description: Restyle a private client photo with a new color or cut in a dedicat
 icon: kind-icon:magic
 route: /hair-studio
 sort: 95
+requiredRole: GUEST
 ---
 
 A dedicated hairstyle experiment lab, separate from the Superkate service calculator and client book.

--- a/cypress/e2e/stylist-access.cy.ts
+++ b/cypress/e2e/stylist-access.cy.ts
@@ -19,9 +19,13 @@ describe('Superkate services and Hair Studio access', () => {
   })
 
   it('removes the obsolete combined project route', () => {
-    cy.request({
-      url: '/projects/build/stylist',
-      failOnStatusCode: false,
-    }).its('status').should('eq', 404)
+    cy.visit('/projects/build/stylist', { failOnStatusCode: false })
+
+    cy.location('pathname', { timeout: 15000 }).should(
+      'eq',
+      '/projects/build/stylist',
+    )
+    cy.contains('Page not found').should('exist')
+    cy.contains('The whole salon in one tab').should('not.exist')
   })
 })


### PR DESCRIPTION
## What changed

- Mark the Hair Studio Lab tab as explicitly public with `requiredRole: GUEST`, preventing the global navigation middleware from inheriting the Lab channel's `ADMIN` requirement and redirecting visitors to `/login`.
- Update the obsolete `/projects/build/stylist` Cypress assertion to verify the Nuxt Content catch-all renders `Page not found` and does not render the removed combined-studio content.

## Root cause

The recurring scheduled Cypress failures were both in `cypress/e2e/stylist-access.cy.ts`:

1. `/hair-studio` was intended to be public, but its tab inherited the parent Lab channel's admin-only access metadata.
2. The obsolete project content file was correctly deleted, but Nuxt's catch-all page still returns the application shell and renders an in-app not-found state, so a raw HTTP `404` assertion could never describe the actual behavior.

## Evidence

The latest failed scheduled run was Actions run `30114148332`. Deploy readiness, database checks, stale-user cleanup, and post-run cleanup all passed; only the Cypress test step failed. Its screenshot artifact contained exactly the two failing Stylist access cases addressed here.

## Validation

- Branch is based directly on current `main` (`642637e`).
- Diff is limited to the Hair Studio navigation metadata and its Cypress acceptance spec.
- CI checks will validate TypeScript and repository contracts before merge.