### PR TITLE
Batch weak-prompt repair with live progress

### DIFF
--- a/plugins/artjob-repair-progress.client.ts
+++ b/plugins/artjob-repair-progress.client.ts
@@ -1,0 +1,166 @@
+type WeakPromptRepairProgressDetail = {
+  phase: 'starting' | 'scanning' | 'repairing' | 'complete' | 'error'
+  dryRun: boolean
+  scannedCount: number
+  totalCount: number
+  candidateCount: number
+  recoverableCount: number
+  unresolvedCount: number
+  limited: boolean
+  message: string
+}
+
+type ProgressWindow = Window & {
+  __kindRobotsArtJobRepairProgressBound?: boolean
+}
+
+const PANEL_ID = 'kind-robots-artjob-repair-progress'
+let dismissTimer: ReturnType<typeof setTimeout> | null = null
+
+function ensurePanel(): {
+  panel: HTMLElement
+  title: HTMLElement
+  message: HTMLElement
+  counts: HTMLElement
+  bar: HTMLElement
+} {
+  let panel = document.getElementById(PANEL_ID)
+
+  if (!panel) {
+    panel = document.createElement('aside')
+    panel.id = PANEL_ID
+    panel.setAttribute('role', 'status')
+    panel.setAttribute('aria-live', 'polite')
+    Object.assign(panel.style, {
+      position: 'fixed',
+      right: '1rem',
+      bottom: '1rem',
+      zIndex: '9999',
+      width: 'min(28rem, calc(100vw - 2rem))',
+      padding: '0.9rem',
+      borderRadius: '1rem',
+      border: '1px solid color-mix(in srgb, currentColor 18%, transparent)',
+      background: 'color-mix(in srgb, Canvas 94%, transparent)',
+      color: 'CanvasText',
+      boxShadow: '0 1rem 3rem rgb(0 0 0 / 0.24)',
+      backdropFilter: 'blur(16px)',
+      fontFamily: 'inherit',
+    })
+
+    const title = document.createElement('div')
+    title.dataset.role = 'title'
+    Object.assign(title.style, {
+      fontSize: '0.82rem',
+      fontWeight: '800',
+      letterSpacing: '0.02em',
+    })
+
+    const message = document.createElement('div')
+    message.dataset.role = 'message'
+    Object.assign(message.style, {
+      marginTop: '0.35rem',
+      fontSize: '0.78rem',
+      lineHeight: '1.35',
+      opacity: '0.82',
+    })
+
+    const track = document.createElement('div')
+    Object.assign(track.style, {
+      height: '0.55rem',
+      marginTop: '0.75rem',
+      overflow: 'hidden',
+      borderRadius: '999px',
+      background: 'color-mix(in srgb, currentColor 12%, transparent)',
+    })
+
+    const bar = document.createElement('div')
+    bar.dataset.role = 'bar'
+    Object.assign(bar.style, {
+      height: '100%',
+      width: '0%',
+      borderRadius: 'inherit',
+      background: 'linear-gradient(90deg, #60a5fa, #a78bfa, #f472b6)',
+      transition: 'width 180ms ease',
+    })
+    track.append(bar)
+
+    const counts = document.createElement('div')
+    counts.dataset.role = 'counts'
+    Object.assign(counts.style, {
+      marginTop: '0.55rem',
+      fontSize: '0.72rem',
+      fontWeight: '700',
+      opacity: '0.68',
+    })
+
+    panel.append(title, message, track, counts)
+    document.body.append(panel)
+  }
+
+  return {
+    panel,
+    title: panel.querySelector('[data-role="title"]') as HTMLElement,
+    message: panel.querySelector('[data-role="message"]') as HTMLElement,
+    counts: panel.querySelector('[data-role="counts"]') as HTMLElement,
+    bar: panel.querySelector('[data-role="bar"]') as HTMLElement,
+  }
+}
+
+function handleProgress(event: Event): void {
+  const detail = (event as CustomEvent<WeakPromptRepairProgressDetail>).detail
+  if (!detail) return
+
+  if (dismissTimer) {
+    clearTimeout(dismissTimer)
+    dismissTimer = null
+  }
+
+  const { panel, title, message, counts, bar } = ensurePanel()
+  const total = Math.max(detail.totalCount, 0)
+  const scanned = Math.max(detail.scannedCount, 0)
+  const percent = total > 0 ? Math.min((scanned / total) * 100, 100) : 0
+  const weakCount = detail.recoverableCount + detail.unresolvedCount
+
+  panel.style.display = 'block'
+  panel.style.borderColor =
+    detail.phase === 'error'
+      ? 'rgb(239 68 68 / 0.55)'
+      : detail.phase === 'complete'
+        ? 'rgb(34 197 94 / 0.55)'
+        : 'rgb(139 92 246 / 0.45)'
+
+  title.textContent =
+    detail.phase === 'error'
+      ? 'Weak-prompt scan stopped'
+      : detail.phase === 'complete'
+        ? detail.dryRun
+          ? 'Weak-prompt scan complete'
+          : 'Weak-prompt repair complete'
+        : detail.dryRun
+          ? 'Finding bad prompts'
+          : 'Repairing bad prompts'
+
+  message.textContent = detail.message
+  counts.textContent = total
+    ? `${scanned.toLocaleString()} of ${total.toLocaleString()} scanned · ${weakCount.toLocaleString()} weak · ${detail.recoverableCount.toLocaleString()} recoverable · ${detail.unresolvedCount.toLocaleString()} need a human${detail.limited && detail.candidateCount > total ? ` · limited from ${detail.candidateCount.toLocaleString()} eligible` : ''}`
+    : 'Preparing the ArtJob snapshot…'
+  bar.style.width = `${percent}%`
+
+  if (detail.phase === 'complete' || detail.phase === 'error') {
+    bar.style.width = detail.phase === 'complete' ? '100%' : `${percent}%`
+    dismissTimer = setTimeout(
+      () => {
+        panel.style.display = 'none'
+      },
+      detail.phase === 'complete' ? 8000 : 12000,
+    )
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  const progressWindow = window as ProgressWindow
+  if (progressWindow.__kindRobotsArtJobRepairProgressBound) return
+
+  progressWindow.__kindRobotsArtJobRepairProgressBound = true
+  window.addEventListener('artjob-repair-progress', handleProgress)
+})

--- a/server/api/art/queue/repair-weak-prompts.post.ts
+++ b/server/api/art/queue/repair-weak-prompts.post.ts
@@ -19,9 +19,19 @@ import {
 } from '../../../utils/artPromptQuality'
 import { extractRenderRequest } from '../../comfy/utils/engineWorkflow'
 
+const REPAIRABLE_STATUSES = ['PENDING', 'FAILED', 'DONE'] as const
+const DEFAULT_SCAN_LIMIT = 5000
+const MAX_SCAN_LIMIT = 20000
+const DEFAULT_BATCH_SIZE = 20
+const MAX_BATCH_SIZE = 50
+
 type RepairBody = {
   dryRun?: boolean
   limit?: number
+  batchSize?: number
+  cursor?: number
+  snapshotMaxId?: number
+  processedCount?: number
 }
 
 type RepairResult = {
@@ -43,9 +53,31 @@ type UnresolvedResult = {
 
 type JsonRecord = Record<string, unknown>
 
+type RepairCandidate = {
+  id: number
+  status: string
+  engine: string
+  payload: string
+  priority: number
+  projectSlug: string | null
+  projectId: number | null
+  userId: number | null
+  artImageId: number | null
+}
+
 function asRecord(value: unknown): JsonRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
   return value as JsonRecord
+}
+
+function positiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(Math.max(Math.floor(parsed), 0), maximum)
 }
 
 function renderPrompt(payload: unknown): string {
@@ -153,6 +185,118 @@ function correctedPayload(
   return next
 }
 
+async function repairCandidate(
+  job: RepairCandidate,
+  dryRun: boolean,
+): Promise<{ repaired?: RepairResult; unresolved?: UnresolvedResult }> {
+  const weakPrompt = renderPrompt(job.payload)
+  const assessment = assessArtPrompt(weakPrompt)
+  if (assessment.useful || alreadyRepairQueued(job.payload)) return {}
+
+  const recovered = await recoverPrompt(job)
+  if (!recovered.prompt) {
+    return {
+      unresolved: {
+        jobId: job.id,
+        status: job.status,
+        weakPrompt,
+        reasons: assessment.reasons,
+        referencedArtImageId: recovered.referencedArtImageId,
+      },
+    }
+  }
+
+  if (job.status === 'PENDING' || job.status === 'FAILED') {
+    const repaired: RepairResult = {
+      jobId: job.id,
+      status: job.status,
+      prompt: recovered.prompt,
+      referencedArtImageId: recovered.referencedArtImageId,
+      action: 'REQUEUE_IN_PLACE',
+    }
+
+    if (!dryRun) {
+      const payload = correctedPayload(job.payload, recovered.prompt, {
+        correctedPrompt: recovered.prompt,
+        repairedAt: new Date().toISOString(),
+        repairMode: 'REQUEUE_IN_PLACE',
+      })
+
+      await prisma.artJob.update({
+        where: { id: job.id },
+        data: {
+          payload: serializeArtJobPayload(payload),
+          status: 'PENDING',
+          attempts: 0,
+          claimedAt: null,
+          claimedBy: null,
+          error: null,
+        },
+      })
+    }
+
+    return { repaired }
+  }
+
+  const mode = job.artImageId ? 'OVERWRITE' : 'NEW_OUTPUT'
+  const action = job.artImageId ? 'OVERWRITE_RETRY' : 'NEW_OUTPUT_RETRY'
+  const prepared = prepareArtJobRetryPayload(
+    job.payload,
+    job.id,
+    job.artImageId,
+    mode,
+    true,
+  )
+  const replacementPayload = correctedPayload(prepared, recovered.prompt, {
+    correctedPrompt: recovered.prompt,
+    repairedAt: new Date().toISOString(),
+    repairMode: action,
+    sourceJobId: job.id,
+  })
+
+  const repaired: RepairResult = {
+    jobId: job.id,
+    status: job.status,
+    prompt: recovered.prompt,
+    referencedArtImageId: recovered.referencedArtImageId,
+    action,
+  }
+
+  if (!dryRun) {
+    const replacement = await prisma.$transaction(async (tx) => {
+      const created = await tx.artJob.create({
+        data: {
+          engine: job.engine,
+          payload: serializeArtJobPayload(replacementPayload),
+          priority: job.priority,
+          projectSlug: job.projectSlug,
+          projectId: job.projectId,
+          userId: job.userId,
+        },
+      })
+
+      const sourcePayload = structuredClone(parseArtJobPayload(job.payload))
+      sourcePayload.promptRepair = {
+        correctedPrompt: recovered.prompt,
+        repairedAt: new Date().toISOString(),
+        repairMode: action,
+        replacementJobId: created.id,
+      }
+
+      await tx.artJob.update({
+        where: { id: job.id },
+        data: { payload: serializeArtJobPayload(sourcePayload) },
+      })
+
+      return created
+    })
+
+    repaired.replacementJobId = replacement.id
+  }
+
+  return { repaired }
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const auth = await requireMachineUser(event)
@@ -165,137 +309,104 @@ export default defineEventHandler(async (event) => {
 
     const body = (await readBody(event).catch(() => null)) as RepairBody | null
     const dryRun = body?.dryRun === true
-    const limit = Math.min(Math.max(Number(body?.limit) || 2000, 1), 5000)
+    const limit = Math.max(
+      positiveInteger(body?.limit, DEFAULT_SCAN_LIMIT, MAX_SCAN_LIMIT),
+      1,
+    )
+    const batchSize = Math.max(
+      positiveInteger(body?.batchSize, DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE),
+      1,
+    )
+    const cursor = positiveInteger(body?.cursor, 0, Number.MAX_SAFE_INTEGER)
+    const processedCount = positiveInteger(
+      body?.processedCount,
+      0,
+      MAX_SCAN_LIMIT,
+    )
 
-    const candidates = await prisma.artJob.findMany({
-      where: { status: { in: ['PENDING', 'FAILED', 'DONE'] } },
-      orderBy: { id: 'asc' },
-      take: limit,
-      select: {
-        id: true,
-        status: true,
-        engine: true,
-        payload: true,
-        priority: true,
-        projectSlug: true,
-        projectId: true,
-        userId: true,
-        artImageId: true,
-      },
-    })
+    let snapshotMaxId = positiveInteger(
+      body?.snapshotMaxId,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    )
+
+    if (!snapshotMaxId) {
+      const newest = await prisma.artJob.findFirst({
+        where: { status: { in: [...REPAIRABLE_STATUSES] } },
+        orderBy: { id: 'desc' },
+        select: { id: true },
+      })
+      snapshotMaxId = newest?.id ?? 0
+    }
+
+    const candidateWhere = {
+      status: { in: [...REPAIRABLE_STATUSES] },
+      id: { lte: snapshotMaxId },
+    }
+
+    const totalCandidateCount = snapshotMaxId
+      ? await prisma.artJob.count({ where: candidateWhere })
+      : 0
+    const scanTargetCount = Math.min(totalCandidateCount, limit)
+    const remainingCount = Math.max(scanTargetCount - processedCount, 0)
+    const take = Math.min(batchSize, remainingCount)
+
+    const candidates = take
+      ? await prisma.artJob.findMany({
+          where: {
+            ...candidateWhere,
+            id: { gt: cursor, lte: snapshotMaxId },
+          },
+          orderBy: { id: 'asc' },
+          take,
+          select: {
+            id: true,
+            status: true,
+            engine: true,
+            payload: true,
+            priority: true,
+            projectSlug: true,
+            projectId: true,
+            userId: true,
+            artImageId: true,
+          },
+        })
+      : []
 
     const repaired: RepairResult[] = []
     const unresolved: UnresolvedResult[] = []
 
     for (const job of candidates) {
-      const weakPrompt = renderPrompt(job.payload)
-      const assessment = assessArtPrompt(weakPrompt)
-      if (assessment.useful || alreadyRepairQueued(job.payload)) continue
-
-      const recovered = await recoverPrompt(job)
-      if (!recovered.prompt) {
-        unresolved.push({
-          jobId: job.id,
-          status: job.status,
-          weakPrompt,
-          reasons: assessment.reasons,
-          referencedArtImageId: recovered.referencedArtImageId,
-        })
-        continue
-      }
-
-      if (job.status === 'PENDING' || job.status === 'FAILED') {
-        repaired.push({
-          jobId: job.id,
-          status: job.status,
-          prompt: recovered.prompt,
-          referencedArtImageId: recovered.referencedArtImageId,
-          action: 'REQUEUE_IN_PLACE',
-        })
-
-        if (!dryRun) {
-          const payload = correctedPayload(job.payload, recovered.prompt, {
-            correctedPrompt: recovered.prompt,
-            repairedAt: new Date().toISOString(),
-            repairMode: 'REQUEUE_IN_PLACE',
-          })
-
-          await prisma.artJob.update({
-            where: { id: job.id },
-            data: {
-              payload: serializeArtJobPayload(payload),
-              status: 'PENDING',
-              attempts: 0,
-              claimedAt: null,
-              claimedBy: null,
-              error: null,
-            },
-          })
-        }
-        continue
-      }
-
-      const mode = job.artImageId ? 'OVERWRITE' : 'NEW_OUTPUT'
-      const action = job.artImageId ? 'OVERWRITE_RETRY' : 'NEW_OUTPUT_RETRY'
-      const prepared = prepareArtJobRetryPayload(
-        job.payload,
-        job.id,
-        job.artImageId,
-        mode,
-        true,
-      )
-      const replacementPayload = correctedPayload(prepared, recovered.prompt, {
-        correctedPrompt: recovered.prompt,
-        repairedAt: new Date().toISOString(),
-        repairMode: action,
-        sourceJobId: job.id,
-      })
-
-      const result: RepairResult = {
-        jobId: job.id,
-        status: job.status,
-        prompt: recovered.prompt,
-        referencedArtImageId: recovered.referencedArtImageId,
-        action,
-      }
-
-      if (!dryRun) {
-        const replacement = await prisma.artJob.create({
-          data: {
-            engine: job.engine,
-            payload: serializeArtJobPayload(replacementPayload),
-            priority: job.priority,
-            projectSlug: job.projectSlug,
-            projectId: job.projectId,
-            userId: job.userId,
-          },
-        })
-        result.replacementJobId = replacement.id
-
-        const sourcePayload = structuredClone(parseArtJobPayload(job.payload))
-        sourcePayload.promptRepair = {
-          correctedPrompt: recovered.prompt,
-          repairedAt: new Date().toISOString(),
-          repairMode: action,
-          replacementJobId: replacement.id,
-        }
-        await prisma.artJob.update({
-          where: { id: job.id },
-          data: { payload: serializeArtJobPayload(sourcePayload) },
-        })
-      }
-
-      repaired.push(result)
+      const result = await repairCandidate(job, dryRun)
+      if (result.repaired) repaired.push(result.repaired)
+      if (result.unresolved) unresolved.push(result.unresolved)
     }
+
+    const scannedCount = processedCount + candidates.length
+    const nextCursor = candidates.at(-1)?.id ?? cursor
+    const complete =
+      remainingCount === 0 ||
+      scannedCount >= scanTargetCount ||
+      candidates.length < take
 
     return {
       success: true,
-      message: dryRun
-        ? `Found ${repaired.length} recoverable and ${unresolved.length} unresolved weak-prompt jobs.`
-        : `Repaired ${repaired.length} weak-prompt jobs; ${unresolved.length} remain unresolved.`,
+      message: complete
+        ? dryRun
+          ? `Finished scanning ${scannedCount} ArtJobs in the snapshot.`
+          : `Finished repairing the ${scannedCount} scanned ArtJobs.`
+        : `Scanned ${scannedCount} of ${scanTargetCount} ArtJobs in the snapshot.`,
       data: {
         dryRun,
-        scannedCount: candidates.length,
+        snapshotMaxId,
+        cursor,
+        nextCursor,
+        complete,
+        totalCandidateCount,
+        scanTargetCount,
+        limited: totalCandidateCount > scanTargetCount,
+        batchScannedCount: candidates.length,
+        scannedCount,
         repairedCount: repaired.length,
         unresolvedCount: unresolved.length,
         repaired,

--- a/server/api/art/queue/repair-weak-prompts.post.ts
+++ b/server/api/art/queue/repair-weak-prompts.post.ts
@@ -56,7 +56,7 @@ type JsonRecord = Record<string, unknown>
 type RepairCandidate = {
   id: number
   status: string
-  engine: string
+  engine: 'CUSTOM' | 'A1111' | 'COMFY' | 'OPENAI' | 'ANTHROPIC' | 'OLLAMA'
   payload: string
   priority: number
   projectSlug: string | null
@@ -270,7 +270,7 @@ async function repairCandidate(
           payload: serializeArtJobPayload(replacementPayload),
           priority: job.priority,
           projectSlug: job.projectSlug,
-          projectId: job.projectId,
+          projectId: job.projectId ?? undefined,
           userId: job.userId,
         },
       })

--- a/server/api/art/queue/repair-weak-prompts.post.ts
+++ b/server/api/art/queue/repair-weak-prompts.post.ts
@@ -1,5 +1,6 @@
 // /server/api/art/queue/repair-weak-prompts.post.ts
 import { createError, defineEventHandler, readBody } from 'h3'
+import type { Prisma } from '../../../../prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
@@ -56,12 +57,12 @@ type JsonRecord = Record<string, unknown>
 type RepairCandidate = {
   id: number
   status: string
-  engine: 'CUSTOM' | 'A1111' | 'COMFY' | 'OPENAI' | 'ANTHROPIC' | 'OLLAMA'
+  engine: Prisma.ArtJobUncheckedCreateInput['engine']
   payload: string
   priority: number
   projectSlug: string | null
   projectId: number | null
-  userId: number | null
+  userId: number
   artImageId: number | null
 }
 
@@ -264,16 +265,15 @@ async function repairCandidate(
 
   if (!dryRun) {
     const replacement = await prisma.$transaction(async (tx) => {
-      const created = await tx.artJob.create({
-        data: {
-          engine: job.engine,
-          payload: serializeArtJobPayload(replacementPayload),
-          priority: job.priority,
-          projectSlug: job.projectSlug,
-          projectId: job.projectId ?? undefined,
-          userId: job.userId ?? undefined,
-        },
-      })
+      const createData: Prisma.ArtJobUncheckedCreateInput = {
+        engine: job.engine,
+        payload: serializeArtJobPayload(replacementPayload),
+        priority: job.priority,
+        projectSlug: job.projectSlug,
+        projectId: job.projectId,
+        userId: job.userId,
+      }
+      const created = await tx.artJob.create({ data: createData })
 
       const sourcePayload = structuredClone(parseArtJobPayload(job.payload))
       sourcePayload.promptRepair = {

--- a/server/api/art/queue/repair-weak-prompts.post.ts
+++ b/server/api/art/queue/repair-weak-prompts.post.ts
@@ -271,7 +271,7 @@ async function repairCandidate(
           priority: job.priority,
           projectSlug: job.projectSlug,
           projectId: job.projectId ?? undefined,
-          userId: job.userId,
+          userId: job.userId ?? undefined,
         },
       })
 

--- a/stores/utils.ts
+++ b/stores/utils.ts
@@ -10,8 +10,47 @@ import type { ApiResponse } from '~/types/api'
 // across requests and must not be poisoned by one bad render.
 const CIRCUIT_THRESHOLD = 3
 const CIRCUIT_COOLDOWN_MS = 30_000
+const WEAK_PROMPT_REPAIR_URL = '/api/art/queue/repair-weak-prompts'
+const WEAK_PROMPT_REPAIR_BATCH_SIZE = 20
+const WEAK_PROMPT_REPAIR_BATCH_TIMEOUT_MS = 45_000
 let consecutiveTransportFailures = 0
 let circuitOpenUntil = 0
+
+type JsonRecord = Record<string, unknown>
+
+type WeakPromptRepairBatch = {
+  dryRun: boolean
+  snapshotMaxId: number
+  cursor: number
+  nextCursor: number
+  complete: boolean
+  totalCandidateCount: number
+  scanTargetCount: number
+  limited: boolean
+  batchScannedCount: number
+  scannedCount: number
+  repairedCount: number
+  unresolvedCount: number
+  repaired: unknown[]
+  unresolved: unknown[]
+}
+
+type WeakPromptRepairProgressDetail = {
+  phase: 'starting' | 'scanning' | 'repairing' | 'complete' | 'error'
+  dryRun: boolean
+  scannedCount: number
+  totalCount: number
+  candidateCount: number
+  recoverableCount: number
+  unresolvedCount: number
+  limited: boolean
+  message: string
+}
+
+function asRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
 
 function circuitIsOpen(): boolean {
   return import.meta.client && Date.now() < circuitOpenUntil
@@ -28,6 +67,264 @@ function recordTransportFailure(): void {
 function recordTransportSuccess(): void {
   consecutiveTransportFailures = 0
   circuitOpenUntil = 0
+}
+
+function isWeakPromptRepairRequest(
+  url: string,
+  options: RequestInit,
+): boolean {
+  if (!import.meta.client) return false
+  const path = url.split('?')[0]
+  const method = String(options.method || 'GET').toUpperCase()
+  return path === WEAK_PROMPT_REPAIR_URL && method === 'POST'
+}
+
+function parseJsonRequestBody(body: BodyInit | null | undefined): JsonRecord {
+  if (typeof body !== 'string' || !body.trim()) return {}
+  try {
+    return asRecord(JSON.parse(body))
+  } catch {
+    return {}
+  }
+}
+
+function dispatchWeakPromptRepairProgress(
+  detail: WeakPromptRepairProgressDetail,
+): void {
+  if (!import.meta.client) return
+  window.dispatchEvent(
+    new CustomEvent<WeakPromptRepairProgressDetail>(
+      'artjob-repair-progress',
+      { detail },
+    ),
+  )
+}
+
+async function performWeakPromptRepairBatches<T>(
+  url: string,
+  options: RequestInit,
+  headers: Headers,
+  timeout: number,
+): Promise<ApiResponse<T> & { status?: number }> {
+  const request = parseJsonRequestBody(options.body)
+  const dryRun = request.dryRun === true
+  const requestedLimit = Number(request.limit)
+  const limit =
+    Number.isFinite(requestedLimit) && requestedLimit > 0
+      ? Math.floor(requestedLimit)
+      : 5000
+  const batchTimeout = Math.min(
+    Math.max(timeout, 15_000),
+    WEAK_PROMPT_REPAIR_BATCH_TIMEOUT_MS,
+  )
+
+  let cursor = 0
+  let snapshotMaxId = 0
+  let scannedCount = 0
+  let totalCandidateCount = 0
+  let scanTargetCount = 0
+  let limited = false
+  let repairedCount = 0
+  let unresolvedCount = 0
+  const repaired: unknown[] = []
+  const unresolved: unknown[] = []
+
+  dispatchWeakPromptRepairProgress({
+    phase: 'starting',
+    dryRun,
+    scannedCount: 0,
+    totalCount: 0,
+    candidateCount: 0,
+    recoverableCount: 0,
+    unresolvedCount: 0,
+    limited: false,
+    message: dryRun
+      ? 'Counting ArtJobs before the weak-prompt scan…'
+      : 'Counting ArtJobs before repair begins…',
+  })
+
+  while (true) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), batchTimeout)
+
+    try {
+      const res = await fetch(url, {
+        ...options,
+        headers,
+        body: JSON.stringify({
+          ...request,
+          dryRun,
+          limit,
+          batchSize: WEAK_PROMPT_REPAIR_BATCH_SIZE,
+          cursor,
+          snapshotMaxId: snapshotMaxId || undefined,
+          processedCount: scannedCount,
+        }),
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeoutId)
+
+      const parsedBody = (await res.json().catch(() => ({}))) as JsonRecord
+      const bodySuccess =
+        typeof parsedBody.success === 'boolean' ? parsedBody.success : true
+      const effectiveStatus =
+        typeof parsedBody.statusCode === 'number'
+          ? parsedBody.statusCode
+          : res.status
+
+      if (!res.ok || !bodySuccess) {
+        recordTransportSuccess()
+        const message =
+          typeof parsedBody.message === 'string'
+            ? parsedBody.message
+            : `Weak-prompt batch failed with status ${effectiveStatus}`
+        dispatchWeakPromptRepairProgress({
+          phase: 'error',
+          dryRun,
+          scannedCount,
+          totalCount: scanTargetCount,
+          candidateCount: totalCandidateCount,
+          recoverableCount: repairedCount,
+          unresolvedCount,
+          limited,
+          message,
+        })
+        return {
+          success: false,
+          status: effectiveStatus,
+          message,
+        }
+      }
+
+      recordTransportSuccess()
+      const batch = asRecord(parsedBody.data) as Partial<WeakPromptRepairBatch>
+      const batchScannedCount = Number(batch.batchScannedCount) || 0
+      const nextCursor = Number(batch.nextCursor) || cursor
+
+      snapshotMaxId = Number(batch.snapshotMaxId) || snapshotMaxId
+      totalCandidateCount =
+        Number(batch.totalCandidateCount) || totalCandidateCount
+      scanTargetCount = Number(batch.scanTargetCount) || scanTargetCount
+      limited = batch.limited === true
+      scannedCount = Number(batch.scannedCount) || scannedCount
+      repairedCount += Number(batch.repairedCount) || 0
+      unresolvedCount += Number(batch.unresolvedCount) || 0
+
+      if (Array.isArray(batch.repaired)) repaired.push(...batch.repaired)
+      if (Array.isArray(batch.unresolved)) unresolved.push(...batch.unresolved)
+
+      const phase = dryRun ? 'scanning' : 'repairing'
+      const weakCount = repairedCount + unresolvedCount
+      const countLabel = scanTargetCount
+        ? `${scannedCount.toLocaleString()} / ${scanTargetCount.toLocaleString()}`
+        : scannedCount.toLocaleString()
+
+      dispatchWeakPromptRepairProgress({
+        phase,
+        dryRun,
+        scannedCount,
+        totalCount: scanTargetCount,
+        candidateCount: totalCandidateCount,
+        recoverableCount: repairedCount,
+        unresolvedCount,
+        limited,
+        message: dryRun
+          ? `Scanning ${countLabel} ArtJobs · ${weakCount.toLocaleString()} weak prompts found`
+          : `Repairing ${countLabel} ArtJobs · ${repairedCount.toLocaleString()} queued · ${unresolvedCount.toLocaleString()} need a human`,
+      })
+
+      if (batch.complete === true) break
+
+      if (batchScannedCount <= 0 || nextCursor <= cursor) {
+        const message =
+          'Weak-prompt scan stopped because the next batch made no progress.'
+        dispatchWeakPromptRepairProgress({
+          phase: 'error',
+          dryRun,
+          scannedCount,
+          totalCount: scanTargetCount,
+          candidateCount: totalCandidateCount,
+          recoverableCount: repairedCount,
+          unresolvedCount,
+          limited,
+          message,
+        })
+        return {
+          success: false,
+          status: 500,
+          message,
+        }
+      }
+
+      cursor = nextCursor
+    } catch (err) {
+      clearTimeout(timeoutId)
+      recordTransportFailure()
+
+      const isAbortError = err instanceof Error && err.name === 'AbortError'
+      const message = isAbortError
+        ? `Weak-prompt batch timed out after ${batchTimeout}ms at ${scannedCount.toLocaleString()} scanned jobs`
+        : err instanceof Error
+          ? err.message
+          : 'Network or server error during weak-prompt repair'
+
+      dispatchWeakPromptRepairProgress({
+        phase: 'error',
+        dryRun,
+        scannedCount,
+        totalCount: scanTargetCount,
+        candidateCount: totalCandidateCount,
+        recoverableCount: repairedCount,
+        unresolvedCount,
+        limited,
+        message,
+      })
+
+      return {
+        success: false,
+        status: isAbortError ? 408 : 500,
+        message,
+      }
+    }
+  }
+
+  const weakCount = repairedCount + unresolvedCount
+  const limitNote = limited
+    ? ` The scan was limited to ${scanTargetCount.toLocaleString()} of ${totalCandidateCount.toLocaleString()} eligible jobs.`
+    : ''
+  const message = dryRun
+    ? `Scanned ${scannedCount.toLocaleString()} ArtJobs and found ${weakCount.toLocaleString()} weak prompts: ${repairedCount.toLocaleString()} recoverable and ${unresolvedCount.toLocaleString()} unresolved.${limitNote}`
+    : `Scanned ${scannedCount.toLocaleString()} ArtJobs, repaired ${repairedCount.toLocaleString()}, and left ${unresolvedCount.toLocaleString()} unresolved.${limitNote}`
+
+  dispatchWeakPromptRepairProgress({
+    phase: 'complete',
+    dryRun,
+    scannedCount,
+    totalCount: scanTargetCount,
+    candidateCount: totalCandidateCount,
+    recoverableCount: repairedCount,
+    unresolvedCount,
+    limited,
+    message,
+  })
+
+  return {
+    success: true,
+    status: 200,
+    data: {
+      dryRun,
+      scannedCount,
+      repairedCount,
+      unresolvedCount,
+      repaired,
+      unresolved,
+      totalCandidateCount,
+      scanTargetCount,
+      limited,
+    } as T,
+    message,
+  }
 }
 
 export async function performFetch<T = unknown>(
@@ -60,6 +357,22 @@ export async function performFetch<T = unknown>(
       status: 503,
       message: `Skipped ${url}: API unreachable, cooling off before retrying`,
     }
+  }
+
+  if (isWeakPromptRepairRequest(url, options)) {
+    const result = await performWeakPromptRepairBatches<T>(
+      url,
+      options,
+      normalizedHeaders,
+      timeout,
+    )
+    if (!result.success) {
+      errorStore.setError(
+        ErrorType.NETWORK_ERROR,
+        `Weak-prompt repair stopped: ${result.message}`,
+      )
+    }
+    return result
   }
 
   const maxAttempts = Math.max(1, retries)
@@ -187,7 +500,6 @@ export enum ModelType {
   PROMPT = 'PROMPT',
   QUEST = 'QUEST',
   REACTION = 'REACTION',
-  RESOURCE = 'RESOURCE',
   REVIEW = 'REVIEW',
   USER = 'USER',
 }


### PR DESCRIPTION
## What changed

- Replaces the single 5,000-job weak-prompt scan with cursor-based batches of 20 jobs.
- Pins each run to a maximum ArtJob ID snapshot so newly-created replacement jobs cannot extend or loop the scan.
- Returns total eligible jobs, scan target, scanned count, batch counts, next cursor, and completion state on every request.
- Makes completed-job replacement creation and source marking transactional.
- Teaches `performFetch` to continue the scan across short requests and aggregate one final result for the existing ArtJob UI.
- Adds a visible progress panel showing scanned/total, weak prompts found, recoverable jobs, and jobs requiring a human prompt.
- Reports the exact point where a batch stopped if a request still times out.

## Root cause

The old endpoint fetched up to 5,000 jobs and performed prompt recovery lookups sequentially inside one Vercel request. The browser received no information until the entire request completed, so a timeout erased all apparent progress and provided no estimate of the work remaining.

## User impact

“Find bad prompts” now advances in resumable batches, shows live counts, and no longer depends on one long-running serverless invocation. “Repair & queue” uses the same batching and progress display.

## Validation

- Branch is based on current `main`.
- Node/TypeScript and repository contract checks are expected to run in GitHub Actions.