### PR TITLE
Trust referenced ArtImage prompts during repair

### DIFF
--- a/server/utils/artPromptQuality.ts
+++ b/server/utils/artPromptQuality.ts
@@ -22,8 +22,6 @@ const GENERIC_LABEL_PATTERNS = [
   /^untitled$/i,
 ]
 
-const MIN_DESCRIPTIVE_WORDS = 4
-
 export function cleanArtPrompt(value: unknown): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
 }
@@ -44,11 +42,9 @@ export function extractReferencedArtImageId(value: unknown): number | null {
 export function assessArtPrompt(value: unknown): ArtPromptAssessment {
   const prompt = cleanArtPrompt(value)
   const reasons: string[] = []
-  const wordCount = prompt ? prompt.split(/\s+/).length : 0
 
   if (!prompt) reasons.push('empty')
   if (prompt && isGenericArtLabel(prompt)) reasons.push('generic-label')
-  if (prompt && wordCount < MIN_DESCRIPTIVE_WORDS) reasons.push('too-short')
   if (LEGACY_FALLBACK_PATTERNS.some((pattern) => pattern.test(prompt))) {
     reasons.push('legacy-generic-fallback')
   }

--- a/utils/scripts/verifyArtPromptRepair.ts
+++ b/utils/scripts/verifyArtPromptRepair.ts
@@ -22,11 +22,9 @@ assert.equal(isGenericArtLabel('Image 529'), true)
 assert.equal(isGenericArtLabel('Music Mentor'), false)
 assert.equal(assessArtPrompt(strongPrompt).useful, true)
 assert.equal(assessArtPrompt(concisePrompt).useful, true)
-assert.equal(assessArtPrompt('red dog').useful, false)
-assert.deepEqual(assessArtPrompt('Image 529').reasons, [
-  'generic-label',
-  'too-short',
-])
+assert.equal(assessArtPrompt('red dog').useful, true)
+assert.equal(assessArtPrompt('robot').useful, true)
+assert.deepEqual(assessArtPrompt('Image 529').reasons, ['generic-label'])
 
 const payload = {
   promptString: weakPrompt,


### PR DESCRIPTION
## What changed
- removed prompt-length rejection from Art prompt quality checks
- concise but meaningful stored prompts such as `red dog` or `robot` are now accepted
- generic placeholders such as `Image 529` remain rejected
- updated the Art prompt repair contract checks

## Why
The weak-prompt repair flow already resolves `Image #...` and `ArtImage #...` references back to the ArtImage record. However, it then rejected the recovered prompt when it was shorter than four words, sending otherwise repairable jobs into human review.

This change treats prompt length as an editorial concern rather than a repair blocker. Human review remains for blank prompts, generic database labels, and the known legacy placeholder templates.

## Impact
Running **Find bad prompts** again should automatically recover many of the current human-review items by substituting the referenced ArtImage's stored prompt, even when that prompt is terse.

## Validation
- updated `verifyArtPromptRepair.ts` to assert concise source prompts are accepted
- generic ArtImage labels remain rejected