### PR TITLE
Wire Resource selection through art generation for provenance (#937)

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1448,6 +1448,9 @@ async function runStyleTransfer(): Promise<void> {
       isMature: sourceImage.isMature ?? false,
       sourceImageId: sourceImage.id > 0 ? sourceImage.id : undefined,
       sourceImageBase64: base64Payload,
+      // Provenance: link the generated image back to the LoRA Resource this
+      // style is backed by (see resourceProvenance.ts / #937).
+      loraResourceIds: style.resourceId ? [style.resourceId] : undefined,
     })
 
     if (!result.success || !result.data) {

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -2268,6 +2268,13 @@ export const useArtStore = defineStore('artStore', () => {
         state.artForm.checkpoint ||
         checkpointStore.selectedCheckpoint?.name ||
         '',
+      // Resource-backed selection carried through for provenance (#937). Pulled
+      // straight from the caller so the finished ArtImage links to the exact
+      // checkpoint + LoRA Resources it used.
+      checkpointResourceId: artData?.checkpointResourceId ?? null,
+      loraName: artData?.loraName ?? null,
+      loraStrength: artData?.loraStrength ?? null,
+      loraResourceIds: artData?.loraResourceIds ?? null,
       sampler:
         artData?.sampler ||
         state.artForm.sampler ||


### PR DESCRIPTION
Follow-up to the catalog/provenance work already merged (PRs #930 + #940). Those landed the scanners, the `Resource` schema migration (`triggerWords`/`defaultTrigger`/`hash`/`previewImageUrl` + `VAE`/`TEXT_ENCODER`/`DIFFUSION_MODEL`/`LTX`/`WAN` enums), the batch importer, the provenance backend (`resourceProvenance.ts` + `enqueue`/`complete` wiring), and the reusable `lora-picker.vue`.

This PR closes the last gap so resource selection actually reaches the backend from the art form.

## Changes

- **`stores/artStore.ts`** — `buildGenerateArtData` whitelists fields (it does not spread), so it now explicitly carries `checkpointResourceId` / `loraName` / `loraStrength` / `loraResourceIds` from the caller. `enqueueAndRenderArtImage` already spreads `...data` to `/api/art/enqueue`, so these now reach the backend on both the generate-and-await and enqueue-only paths → provenance capture works.
- **`components/art/art-styler.vue`** — the Kontext style-transfer call passes the selected style's backing LoRA `resourceId` as `loraResourceIds`, so style-transfer outputs link to the LoRA `Resource` they used. (art-styler already has its own LoRA-as-style picker, so this feeds provenance rather than duplicating a widget; the generic `lora-picker.vue` is for the main art form.)

## Effect

With the catalog imported, generated images now record which checkpoint + LoRA `Resource`s produced them (`ArtImage.checkpointResourceId` + `ArtImage.LoraResources`), making "all art that used Resource X" queryable. Name-backfill (already merged) covers string-based generations too.

Refs #937. Remaining UI polish (placing `<LoraPicker>` in the main generation form) is best done against imported Resources with the app running — see #938 for the gallery/image-pathway phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPKPh958Hm1EZr885LSKJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPKPh958Hm1EZr885LSKJB)_