### PR TITLE
fix(art): clamp generated seeds to 32-bit range

### DIFF
--- a/server/api/art/queue/[id]/edit.post.ts
+++ b/server/api/art/queue/[id]/edit.post.ts
@@ -31,7 +31,7 @@ type EditBody = {
 }
 
 function randomSeed(): number {
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/art/save-generated.post.ts
+++ b/server/api/art/save-generated.post.ts
@@ -54,6 +54,15 @@ function normalizeFileType(raw: string | null | undefined): string | null {
   return ALLOWED_FILE_TYPES.has(token) ? token : null
 }
 
+// ArtImage.seed is a 32-bit MySQL INT. Job builders already generate seeds
+// within that range, but clamp here too so an oversized value from any
+// caller can never blow up this write (see coloring-book/t-030).
+const MAX_INT32_SEED = 2_147_483_647
+function clampArtImageSeed(raw: number | null | undefined): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return -1
+  return Math.min(Math.trunc(raw), MAX_INT32_SEED)
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const requestData: SaveGeneratedRequestData = await readBody(event)
@@ -162,7 +171,7 @@ export default defineEventHandler(async (event) => {
         checkpoint: resolvedCheckpoint.checkpoint,
         checkpointResourceId: resolvedCheckpoint.checkpointResourceId,
         sampler: requestData.sampler ?? null,
-        seed: requestData.seed ?? -1,
+        seed: clampArtImageSeed(requestData.seed),
         steps: requestData.steps ?? 20,
         designer: validatedData.designer ?? null,
         promptString: requestData.promptString.trim(),

--- a/server/api/comfy/characterSheet.post.ts
+++ b/server/api/comfy/characterSheet.post.ts
@@ -578,7 +578,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function sleep(ms: number): Promise<void> {

--- a/server/api/comfy/flux/utils/workflow.ts
+++ b/server/api/comfy/flux/utils/workflow.ts
@@ -57,7 +57,7 @@ export function resolveFluxSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 export function buildFluxWorkflow(input: {

--- a/server/api/comfy/hunyuan3d.post.ts
+++ b/server/api/comfy/hunyuan3d.post.ts
@@ -669,7 +669,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function sleep(ms: number): Promise<void> {

--- a/server/api/comfy/kontext/generate.post.ts
+++ b/server/api/comfy/kontext/generate.post.ts
@@ -754,7 +754,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function sleep(ms: number): Promise<void> {

--- a/server/api/comfy/kontext/kombine.post.ts
+++ b/server/api/comfy/kontext/kombine.post.ts
@@ -704,7 +704,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function sleep(ms: number): Promise<void> {

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -64,7 +64,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/server/api/comfy/ltx/image2Video.post.ts
+++ b/server/api/comfy/ltx/image2Video.post.ts
@@ -713,7 +713,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function stringifyServerError(errorData: unknown): string {

--- a/server/api/comfy/ltx/text2Video.post.ts
+++ b/server/api/comfy/ltx/text2Video.post.ts
@@ -716,7 +716,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function stringifyServerError(errorData: unknown): string {

--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -66,7 +66,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 // Frame count LTX expects: whole frames across the duration, +1 for the anchor

--- a/server/api/comfy/utils/simpleCheckpointWorkflow.ts
+++ b/server/api/comfy/utils/simpleCheckpointWorkflow.ts
@@ -22,7 +22,7 @@ export function resolveComfySeed(seed?: number | null): number {
   if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
     return Math.floor(seed)
   }
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 export type SimpleCheckpointInput = {

--- a/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
@@ -75,7 +75,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 // WAN wants a 4n+1 frame count. Round the requested seconds to the nearest

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -19,7 +19,7 @@ function asRecord(value: unknown): ArtJobPayloadRecord {
 }
 
 function nextSeed(): number {
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function refreshConcreteSeeds(value: unknown, key = ''): unknown {

--- a/server/utils/comfyTestClient.ts
+++ b/server/utils/comfyTestClient.ts
@@ -449,7 +449,7 @@ function resolveSeed(seed?: number | null): number {
     return Math.floor(seed)
   }
 
-  return Math.floor(Math.random() * 1_000_000_000_000_000)
+  return Math.floor(Math.random() * 2_147_483_647)
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
### Task
conductor/coloring-book/t-030: fix ArtJob seed overflow silently killing coloring-book generation jobs (kind: software)

### What changed / what I produced
- `ArtImage.seed` is a MySQL `Int` column (max `2_147_483_647`), but every ComfyUI job builder's fallback seed generator (`server/api/comfy/**`, `server/utils/artJobRetry.ts`, `server/utils/comfyTestClient.ts`, `server/api/art/queue/[id]/edit.post.ts` — 14 call sites total) produced `Math.floor(Math.random() * 1_000_000_000_000_000)`, six orders of magnitude past the column's range. Clamped every one to `Math.floor(Math.random() * 2_147_483_647)`.
- Added a defensive clamp (`clampArtImageSeed`) at the single Prisma write site, `server/api/art/save-generated.post.ts`, so any other caller-supplied oversized seed can never blow up that write again.

### How I verified
- `npx prettier --check` on all 15 touched files — clean (pre-existing formatting warnings on 4 unrelated files confirmed present on `main` too, not introduced here).
- `npx eslint` on all 15 touched files — 0 new errors (1 pre-existing unrelated error in `characterSheet.post.ts` confirmed present on `main` too).
- Full-project `npm run test` (`vue-tsc --noEmit` via `nuxi prepare`) — 0 errors.
- Confirmed `prisma/schema.prisma`'s `ArtImage.seed` is `Int?` (32-bit).

### Stakes
reversible

### Flags for Reviewer
- None — small, mechanical, scoped fix matching the task's own suggested approach.

### Kaizen suggestion
14 call sites duplicate the same fallback-seed-generator shape; a shared `server/utils/randomSeed.ts` helper would prevent this exact bug class from recurring if the range ever needs to change again. Deferred here to keep this fix minimal — worth doing next time one of these files is touched anyway.

### Notes for reviewer
Root cause and impact analysis: 17+ ArtImage generation jobs (`projectSlug: "coloring-book"`) permanently failed between 2026-07-25T05:23-11:27 UTC with `Value out of range for the type: Out of range value for column 'seed'`, exhausting all 3 retry attempts each time since `artJobRetry.ts`'s `refreshConcreteSeeds()` regenerated an equally oversized seed on every retry. Filed and root-caused in ai-art-academy/t-010's roadmap-accuracy cycle earlier today; this PR is the fix for `coloring-book/t-030`.

---
Generated by [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V23c6REVsA7MoAEQq42VHf)_