### PR TITLE
model-builder/t-029: make stage rows keyboard selectable

### DIFF
--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -95,8 +95,16 @@
             :class="item.id === selectedItemId ? 'bg-primary/10' : 'hover:bg-base-200'"
             @click="selectedItemId = item.id"
           >
-            <td class="max-w-[10rem] truncate text-xs font-semibold">
-              {{ item.label }}
+            <td class="max-w-[10rem] p-0 text-xs font-semibold">
+              <button
+                type="button"
+                class="w-full truncate rounded-lg px-3 py-2 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary"
+                :aria-pressed="item.id === selectedItemId"
+                :aria-label="`Select ${item.label}`"
+                @click.stop="selectedItemId = item.id"
+              >
+                {{ item.label }}
+              </button>
             </td>
             <td
               v-for="stage in stages"


### PR DESCRIPTION
## Summary
- adds a real button inside each Model Builder stage-matrix item row
- makes item selection reachable by keyboard and understandable to assistive technology
- preserves the existing whole-row mouse selection behavior
- exposes selected state with `aria-pressed` and adds a visible focus ring

## Validation
- scoped one-file Vue template change
- no store, API, persistence, generation, or stage-transition behavior changed
- fetched the complete source file before replacement and preserved the script logic unchanged

## Stakes
Reversible front-end accessibility polish.

## Flags for Reviewer
The native table structure is preserved. The new button lives in the item-name cell rather than assigning `role="button"` to the `<tr>`, avoiding invalid table semantics.

## Kaizen suggestion
Add a small accessibility contract check for clickable table rows without a nested focusable control or keyboard handler.