### PR TITLE
fix(facet-catalog): make concurrent seed runs race-safe

### DIFF
--- a/utils/scripts/seedFacetCatalog.ts
+++ b/utils/scripts/seedFacetCatalog.ts
@@ -432,16 +432,39 @@ async function runWithConcurrency<T>(
   worker: (item: T) => Promise<void>,
 ): Promise<void> {
   let cursor = 0
+  const errors: unknown[] = []
   async function lane(): Promise<void> {
     while (cursor < items.length) {
       const item = items[cursor]
       cursor++
-      if (item !== undefined) await worker(item)
+      if (item === undefined) continue
+      // Catch per-item rather than letting a throw escape the lane: main()'s
+      // `finally` disconnects the shared Prisma client the instant this
+      // function's returned promise settles. Promise.all below settles (and
+      // rejects) the moment the FIRST lane throws, but the other lanes keep
+      // running in the background against a client that's about to be torn
+      // down -- their in-flight queries then hang forever waiting on a
+      // closed connection instead of erroring, which silently reintroduced
+      // BUILD_EXCEEDED_MAXIMUM_TIME on 2026-07-25 (two production builds
+      // race-seeding the same slug: the loser's create() threw, the other 7
+      // lanes were still mid-query when $disconnect() fired). Every lane
+      // must fully drain before this function settles either way.
+      try {
+        await worker(item)
+      } catch (error) {
+        errors.push(error)
+      }
     }
   }
   await Promise.all(
     Array.from({ length: Math.min(limit, items.length) }, () => lane()),
   )
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors,
+      `${errors.length} of ${items.length} item(s) failed`,
+    )
+  }
 }
 
 type ExistingFacetRow = {
@@ -499,6 +522,62 @@ async function loadCatalogState(): Promise<CatalogState> {
   }
 }
 
+function isUniqueConstraintError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === 'P2002',
+  )
+}
+
+async function createOrRecoverFacet(
+  candidate: Candidate,
+  slug: string,
+): Promise<ExistingFacetRow> {
+  try {
+    return await prisma.facet.create({
+      data: {
+        title: candidate.title,
+        slug,
+        kind: legacyKind(candidate.taxonomy),
+        description: candidate.description,
+        imagePath: candidate.imagePath,
+        icon: candidate.icon,
+        designer: 'facet-catalog',
+        creationSource: 'HUMAN',
+        userId: 1,
+        isPublic: true,
+        isMature: false,
+        isActive: true,
+      },
+    })
+  } catch (error) {
+    // Two seed runs (e.g. back-to-back production deploys) can race on a
+    // brand-new slug: loadCatalogState()'s up-front snapshot only reflects
+    // whichever Facet rows existed when EACH run started, so both runs can
+    // decide "this is new" and both call create(). The DB's unique
+    // constraint on `slug` is the real arbiter -- the loser gets P2002, not
+    // a corrupted catalog. Recover by reading the winner's row and updating
+    // it instead of failing the whole seed (see the concurrent-seed-run
+    // incident logged on runWithConcurrency above, 2026-07-25).
+    if (!isUniqueConstraintError(error)) throw error
+    const winner = await prisma.facet.findUnique({ where: { slug } })
+    if (!winner) throw error
+    return prisma.facet.update({
+      where: { id: winner.id },
+      data: {
+        title: candidate.title,
+        kind: legacyKind(candidate.taxonomy),
+        description: candidate.description || winner.description,
+        imagePath: candidate.imagePath || winner.imagePath,
+        icon: candidate.icon || winner.icon,
+        isActive: true,
+      },
+    })
+  }
+}
+
 async function saveCandidate(
   candidate: Candidate,
   state: CatalogState,
@@ -527,22 +606,7 @@ async function saveCandidate(
           isActive: true,
         },
       })
-    : await prisma.facet.create({
-        data: {
-          title: candidate.title,
-          slug,
-          kind: legacyKind(candidate.taxonomy),
-          description: candidate.description,
-          imagePath: candidate.imagePath,
-          icon: candidate.icon,
-          designer: 'facet-catalog',
-          creationSource: 'HUMAN',
-          userId: 1,
-          isPublic: true,
-          isMature: false,
-          isActive: true,
-        },
-      })
+    : await createOrRecoverFacet(candidate, slug)
 
   state.facetsBySlug.set(slug, facet)
   state.facetsById.set(facet.id, facet)


### PR DESCRIPTION
### What changed
PR #953 fixed the original `BUILD_EXCEEDED_MAXIMUM_TIME` by batching the Facet catalog seed's reads, but two production builds landing back-to-back (#953's own deploy + #954, triggered ~2s apart) exposed a new failure mode I caught live while verifying #953 actually restored production:

- `seedFacetCatalog.ts`'s create-vs-update branch decides per-run from its own up-front `loadCatalogState()` snapshot, so two concurrent runs can both see a slug as "new" and both call `facet.create()`. The loser hit `Unique constraint failed on the constraint: Facet_slug_key` (P2002).
- That per-item throw escaped `runWithConcurrency`'s `Promise.all`, which settles (and rejects) the instant the *first* lane throws while the other 7 lanes keep running in the background against the same Prisma client. `main()`'s `finally` then calls `prisma.$disconnect()` while those lanes are still mid-query, and their queries hang forever on the closing connection instead of erroring. That silently reintroduced the exact `BUILD_EXCEEDED_MAXIMUM_TIME` symptom #953 was meant to fix — observed directly: the `#954` production build (`kind-robots-6zdmaeeps`) sat stuck for 45+ minutes past the P2002 with no further build log output.

### Fix
- `runWithConcurrency` now catches per-item inside each lane and aggregates errors, so every lane fully drains before the shared client disconnects (no more hang).
- `saveCandidate`'s create path (extracted to `createOrRecoverFacet`) catches P2002 and recovers by reading the race winner's row and updating it instead of failing/hanging the whole seed — concurrent seed runs (an expected, recurring situation whenever two deploys land close together) now converge safely.

### How I verified
- `npx tsc --noEmit` — clean, no new errors.
- `npx eslint utils/scripts/seedFacetCatalog.ts` — clean.
- `npx prettier --check` — clean.
- Confirmed the failure mode against the actual stuck production build's logs (Vercel deployment `dpl_AMXnShETayK8TgRzRoSbwLwmauZz`, commit 2b19d4a) before writing the fix — the P2002 stack trace pointed exactly at the `create()` call this PR now guards, and the silent 45+min stall afterward matches the disconnect-race explained above.

### Stakes
reversible — pure application-code robustness fix to a maintenance script, no schema/migration change.

### Flags for Reviewer
- The stuck production build (`#954`, commit `2b19d4a`) will either time out on its own or get superseded once this merges and a fresh deploy runs — no manual intervention needed, production itself has been serving the healthy `#953` build (`392f9a6`) throughout, so there's no live-site regression.
- ci-janitor todo #751 / #752 tracks the original outage this PR closes out.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQHGeH1qKHQn3m8Ls87REj)_