### PR TITLE
Skip unchanged Facet catalog seeds during production builds

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -33,4 +33,6 @@ jobs:
           CYPRESS_INSTALL_BINARY: '0'
 
       - name: Validate schema and cutover contract
-        run: npm run test:facet-catalog
+        run: |
+          npm run test:facet-catalog
+          node utils/scripts/verifyFacetCatalogSeedPolicy.mjs

--- a/scripts/lib/facetCatalogSeedPolicy.mjs
+++ b/scripts/lib/facetCatalogSeedPolicy.mjs
@@ -1,0 +1,124 @@
+// /scripts/lib/facetCatalogSeedPolicy.mjs
+import { spawnSync } from 'node:child_process'
+
+const FACET_CATALOG_SOURCE_FILES = new Set([
+  'prisma/facet-alias.prisma',
+  'prisma/facet-catalog.prisma',
+  'prisma/schema.prisma',
+  'stores/helpers/adventureCards.ts',
+  'stores/seeds/artList.ts',
+  'stores/utils/animalData.ts',
+  'stores/utils/randomBackstory.ts',
+  'stores/utils/randomClass.ts',
+  'stores/utils/randomColor.ts',
+  'stores/utils/randomGenre.ts',
+  'stores/utils/randomMaterial.ts',
+  'stores/utils/randomPersonality.ts',
+  'stores/utils/randomQuirks.ts',
+  'utils/facetAliases.ts',
+  'utils/scripts/mergeCanonicalFacetDuplicates.ts',
+  'utils/scripts/runFacetCatalogSeed.ts',
+  'utils/scripts/seedFacetCatalog.ts',
+])
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
+export function isFacetCatalogSourcePath(filePath) {
+  const normalized = String(filePath ?? '').trim().replaceAll('\\', '/')
+  if (!normalized) return false
+  if (FACET_CATALOG_SOURCE_FILES.has(normalized)) return true
+  // A new database migration can change catalog constraints or data semantics;
+  // reseeding is the safe default even when the migration name is unfamiliar.
+  return normalized.startsWith('prisma/migrations/')
+}
+
+export function decideFacetCatalogSeed({
+  isVercelBuild,
+  isProductionDeployment,
+  forceValue,
+  changedFiles,
+  diffError,
+}) {
+  if (!isVercelBuild) {
+    return { run: true, reason: 'non-Vercel build preserves explicit local seed behavior' }
+  }
+
+  if (!isProductionDeployment) {
+    return { run: false, reason: 'non-production Vercel deployment' }
+  }
+
+  if (TRUE_VALUES.has(String(forceValue ?? '').trim().toLowerCase())) {
+    return { run: true, reason: 'FACET_CATALOG_SEED_ON_BUILD forced the seed' }
+  }
+
+  if (diffError) {
+    return {
+      run: true,
+      reason: `commit diff unavailable; seeding defensively (${diffError})`,
+    }
+  }
+
+  const relevantFiles = (changedFiles ?? []).filter(isFacetCatalogSourcePath)
+  if (relevantFiles.length > 0) {
+    return {
+      run: true,
+      reason: `catalog source changed: ${relevantFiles.join(', ')}`,
+      relevantFiles,
+    }
+  }
+
+  return {
+    run: false,
+    reason: 'no canonical Facet source, schema, migration, or merge file changed',
+    relevantFiles: [],
+  }
+}
+
+export function readVercelChangedFiles(env = process.env) {
+  const previousSha = env.VERCEL_GIT_PREVIOUS_SHA?.trim()
+  const currentSha = env.VERCEL_GIT_COMMIT_SHA?.trim()
+
+  if (!previousSha || !currentSha) {
+    return {
+      changedFiles: [],
+      diffError: 'missing Vercel commit ancestry',
+    }
+  }
+
+  const diff = spawnSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACMRTUXB', previousSha, currentSha],
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  if (diff.status !== 0) {
+    return {
+      changedFiles: [],
+      diffError:
+        diff.stderr?.trim() ||
+        `git diff exited with ${diff.status ?? 'unknown status'}`,
+    }
+  }
+
+  return {
+    changedFiles: diff.stdout
+      .split('\n')
+      .map((filePath) => filePath.trim())
+      .filter(Boolean),
+    diffError: null,
+  }
+}
+
+export function resolveFacetCatalogSeedDecision(env = process.env) {
+  const { changedFiles, diffError } = readVercelChangedFiles(env)
+  return decideFacetCatalogSeed({
+    isVercelBuild: env.VERCEL === '1',
+    isProductionDeployment: env.VERCEL_ENV === 'production',
+    forceValue: env.FACET_CATALOG_SEED_ON_BUILD,
+    changedFiles,
+    diffError,
+  })
+}

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,6 +1,7 @@
 // /scripts/vercel-build.mjs
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
+import { resolveFacetCatalogSeedDecision } from './lib/facetCatalogSeedPolicy.mjs'
 
 const binExtension = process.platform === 'win32' ? '.cmd' : ''
 const prismaBinary = path.resolve(`node_modules/.bin/prisma${binExtension}`)
@@ -15,10 +16,7 @@ function run(command, args, label) {
     stdio: 'inherit',
   })
 
-  if (result.error) {
-    throw result.error
-  }
-
+  if (result.error) throw result.error
   if (result.status !== 0) {
     throw new Error(`${label} exited with code ${result.status ?? 'unknown'}`)
   }
@@ -35,13 +33,24 @@ if (!isVercelBuild || isProductionDeployment) {
     ['scripts/prisma-migrate-deploy.mjs'],
     'Applying production migrations',
   )
-  // runFacetCatalogSeed.ts normalizes source synonyms before importing
-  // seedFacetCatalog.ts; the latter remains the canonical catalog writer.
-  run(
-    tsxBinary,
-    ['utils/scripts/runFacetCatalogSeed.ts', '--apply'],
-    'Seeding canonical Facet catalog and Character assignments',
-  )
+
+  const facetSeedDecision = resolveFacetCatalogSeedDecision()
+  if (facetSeedDecision.run) {
+    // runFacetCatalogSeed.ts normalizes source synonyms before importing
+    // seedFacetCatalog.ts; the latter remains the canonical catalog writer.
+    run(
+      tsxBinary,
+      ['utils/scripts/runFacetCatalogSeed.ts', '--apply'],
+      `Seeding canonical Facet catalog and Character assignments (${facetSeedDecision.reason})`,
+    )
+  } else {
+    console.log(
+      `[vercel-build] Skipping unchanged canonical Facet catalog seed: ${facetSeedDecision.reason}`,
+    )
+  }
+
+  // Cheap and idempotent: retain this on every production build so any partial
+  // historical cleanup converges even when the 1,300-record catalog seed is skipped.
   run(
     tsxBinary,
     ['utils/scripts/mergeCanonicalFacetDuplicates.ts', '--apply'],

--- a/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
+++ b/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
@@ -1,0 +1,75 @@
+// /utils/scripts/verifyFacetCatalogSeedPolicy.mjs
+import assert from 'node:assert/strict'
+import {
+  decideFacetCatalogSeed,
+  isFacetCatalogSourcePath,
+} from '../../scripts/lib/facetCatalogSeedPolicy.mjs'
+
+assert.equal(isFacetCatalogSourcePath('stores/helpers/adventureCards.ts'), true)
+assert.equal(isFacetCatalogSourcePath('stores/utils/animalData.ts'), true)
+assert.equal(
+  isFacetCatalogSourcePath(
+    'prisma/migrations/20260725113000_facet_catalog_cutover/migration.sql',
+  ),
+  true,
+)
+assert.equal(isFacetCatalogSourcePath('components/facets/facet-manager.vue'), false)
+assert.equal(isFacetCatalogSourcePath('README.md'), false)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: false,
+    isProductionDeployment: false,
+    changedFiles: [],
+  }).run,
+  true,
+)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: true,
+    isProductionDeployment: false,
+    changedFiles: ['stores/helpers/adventureCards.ts'],
+  }).run,
+  false,
+)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: true,
+    isProductionDeployment: true,
+    changedFiles: ['components/facets/facet-manager.vue'],
+  }).run,
+  false,
+)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: true,
+    isProductionDeployment: true,
+    changedFiles: ['stores/helpers/adventureCards.ts'],
+  }).run,
+  true,
+)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: true,
+    isProductionDeployment: true,
+    forceValue: 'true',
+    changedFiles: [],
+  }).run,
+  true,
+)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: true,
+    isProductionDeployment: true,
+    changedFiles: [],
+    diffError: 'missing ancestry',
+  }).run,
+  true,
+)
+
+console.log('Facet catalog seed policy verified.')


### PR DESCRIPTION
## Problem

The canonical catalog is now correct, but the successful production seed rewrites roughly 1,300 Facets and takes about ten minutes. Running that on every unrelated deploy wastes most of the build and increases overlap/race exposure.

## Change

- compares `VERCEL_GIT_PREVIOUS_SHA` and `VERCEL_GIT_COMMIT_SHA`
- runs the full catalog seed only when curated source arrays, Facet schema/migrations, alias logic, or canonical merge scripts changed
- preserves full seeding for explicit non-Vercel/local runs
- supports `FACET_CATALOG_SEED_ON_BUILD=true` as an emergency/manual override
- seeds defensively if Vercel ancestry or `git diff` is unavailable
- continues running the cheap, idempotent canonical duplicate cleanup on every production build
- adds a pure policy contract covering source matches, unrelated changes, preview behavior, force mode, and missing ancestry

## Expected result

Unrelated production deploys proceed from migration to the small cleanup/contender steps and Nuxt build without the ten-minute Facet rewrite. Actual catalog-source changes still trigger the complete normalized seed and CharacterFacet backfill.