### PR TITLE
Make Facet catalog search resolve aliases

### DIFF
--- a/server/utils/facetCatalog.ts
+++ b/server/utils/facetCatalog.ts
@@ -1,6 +1,7 @@
 // /server/utils/facetCatalog.ts
 import type { FacetKind, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
+import { normalizeFacetLookupKey } from '~/utils/facetAliases'
 
 export const FACET_TAXONOMIES = [
   'GENRE',
@@ -130,6 +131,24 @@ export async function loadFacetCatalogEntries(options: {
   )
   const requestedFacetIds = profiles.map((profile) => profile.facetId)
   const search = options.search?.trim()
+  const normalizedSearch = search ? normalizeFacetLookupKey(search) : ''
+  const aliasFacetIds = search
+    ? (
+        await prisma.facetAlias.findMany({
+          where: {
+            isActive: true,
+            OR: [
+              { alias: { contains: search } },
+              ...(normalizedSearch
+                ? [{ lookupKey: { contains: normalizedSearch } }]
+                : []),
+            ],
+          },
+          select: { facetId: true },
+          distinct: ['facetId'],
+        })
+      ).map((alias) => alias.facetId)
+    : []
 
   const facets = await prisma.facet.findMany({
     where: {
@@ -146,10 +165,17 @@ export async function loadFacetCatalogEntries(options: {
           }),
       ...(search
         ? {
-            OR: [
-              { title: { contains: search } },
-              { slug: { contains: search } },
-              { description: { contains: search } },
+            AND: [
+              {
+                OR: [
+                  { title: { contains: search } },
+                  { slug: { contains: search } },
+                  { description: { contains: search } },
+                  ...(aliasFacetIds.length
+                    ? [{ id: { in: aliasFacetIds } }]
+                    : []),
+                ],
+              },
             ],
           }
         : {}),
@@ -192,7 +218,8 @@ export async function loadFacetCatalogEntries(options: {
         artRequired: profile.artRequired,
         sourceRank: profile.sourceRank,
         metadata: parseMetadata(profile.metadata),
-        aliases: aliasesByFacetId.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
+        aliases:
+          aliasesByFacetId.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
       }
     })
     .filter((entry): entry is FacetCatalogEntry => Boolean(entry))

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -39,7 +39,9 @@ async function main(): Promise<void> {
   } as const
 
   const entries = await Promise.all(
-    Object.entries(files).map(async ([key, path]) => [key, await source(path)] as const),
+    Object.entries(files).map(
+      async ([key, path]) => [key, await source(path)] as const,
+    ),
   )
   const text = Object.fromEntries(entries) as Record<keyof typeof files, string>
 
@@ -66,6 +68,12 @@ async function main(): Promise<void> {
   ]) {
     requireText(files.catalog, text.catalog, `'${taxonomy}'`)
   }
+
+  requireText(files.catalog, text.catalog, 'normalizeFacetLookupKey')
+  requireText(files.catalog, text.catalog, 'prisma.facetAlias.findMany')
+  requireText(files.catalog, text.catalog, 'aliasFacetIds')
+  requireText(files.catalog, text.catalog, 'lookupKey: { contains: normalizedSearch }')
+  requireText(files.catalog, text.catalog, 'id: { in: aliasFacetIds }')
 
   requireText(files.characterGet, text.characterGet, 'getOptionalApiUser')
   requireText(files.characterPut, text.characterPut, 'requireApiUser')


### PR DESCRIPTION
## Live issue

The production duplicate cleanup is correct: Tardigrade is the single active record and includes `Water Bear` in its alias list. However, `/api/facets/catalog?search=Water%20Bear` returned zero because catalog search only checked Facet title, slug, and description.

## Change

- searches active `FacetAlias.alias` values
- also searches normalized `lookupKey`, so formatting variants such as `water-bear`, `water bear`, and `waterBear` resolve consistently
- merges matching alias Facet IDs into the existing title/slug/description search
- preserves all taxonomy, activity, maturity, ownership, and public/private filters on the final Facet query
- adds a cutover contract requiring alias-aware search to remain in place

## Expected behavior

Searching either `Tardigrade` or `Water Bear` returns the same canonical illustrated ANIMAL Facet (ID 1358 in the current production catalog).