### PR TITLE
Add Resource gallery and durable generation provenance

### DIFF
--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -1,0 +1,435 @@
+<!-- /components/resources/resource-gallery.vue -->
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { ResourceType } from '~/prisma/generated/prisma/client'
+import {
+  useResourceGalleryStore,
+  type ResourceGalleryRecord,
+} from '@/stores/resourceGalleryStore'
+import { useArtStore } from '@/stores/artStore'
+import { useNavStore } from '@/stores/navStore'
+
+const resourceGalleryStore = useResourceGalleryStore()
+const artStore = useArtStore()
+const navStore = useNavStore()
+
+const query = ref('')
+const resourceType = ref('ALL')
+const generation = ref('ALL')
+const maturity = ref<'ALL' | 'SAFE' | 'MATURE'>('ALL')
+const message = ref('')
+const messageTone = ref<'success' | 'error'>('success')
+const activePreviewResourceId = ref<number | null>(null)
+const activeUploadResourceId = ref<number | null>(null)
+
+const resourceTypes = computed(() => {
+  return [...new Set(resourceGalleryStore.resources.map((entry) => entry.resourceType))]
+    .sort()
+})
+
+const generations = computed(() => {
+  return [
+    ...new Set(
+      resourceGalleryStore.resources
+        .map((entry) => entry.generation?.trim())
+        .filter((entry): entry is string => Boolean(entry)),
+    ),
+  ].sort((a, b) => a.localeCompare(b))
+})
+
+const filteredResources = computed(() => {
+  const search = query.value.trim().toLowerCase()
+
+  return resourceGalleryStore.resources.filter((entry) => {
+    if (resourceType.value !== 'ALL' && entry.resourceType !== resourceType.value) {
+      return false
+    }
+
+    if (generation.value !== 'ALL' && entry.generation !== generation.value) {
+      return false
+    }
+
+    if (maturity.value === 'SAFE' && entry.isMature) return false
+    if (maturity.value === 'MATURE' && !entry.isMature) return false
+
+    if (!search) return true
+
+    return [
+      entry.customLabel,
+      entry.name,
+      entry.description,
+      entry.generation,
+      entry.supportedServer,
+      entry.triggerWords,
+      entry.defaultTrigger,
+    ]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(search))
+  })
+})
+
+function resourceLabel(resource: ResourceGalleryRecord): string {
+  return resource.customLabel || resource.name
+}
+
+function resourceEngineName(resource: ResourceGalleryRecord): string {
+  return resource.localPath || resource.name || resource.customLabel || ''
+}
+
+function triggerText(resource: ResourceGalleryRecord): string {
+  return resource.defaultTrigger || resource.triggerWords || resource.artPrompt || ''
+}
+
+function previewSrc(resource: ResourceGalleryRecord): string {
+  return (
+    resource.ArtImage?.thumbnailPath ||
+    resource.ArtImage?.imagePath ||
+    resource.ArtImage?.path ||
+    resource.previewImageUrl ||
+    resource.imagePath ||
+    '/images/kindart.webp'
+  )
+}
+
+function appendPrompt(base: string, addition: string): string {
+  const current = base.trim()
+  const next = addition.trim()
+
+  if (!next || current.toLowerCase().includes(next.toLowerCase())) return current
+  return current ? `${current}, ${next}` : next
+}
+
+function addToGeneration(resource: ResourceGalleryRecord): void {
+  const engineName = resourceEngineName(resource)
+
+  if (resource.resourceType === ResourceType.CHECKPOINT) {
+    artStore.setArtForm({
+      checkpoint: engineName,
+      checkpointResourceId: resource.id,
+    })
+  } else if (
+    resource.resourceType === ResourceType.LORA ||
+    resource.resourceType === ResourceType.LYCORIS
+  ) {
+    const currentIds = artStore.artForm.loraResourceIds ?? []
+    const loraResourceIds = currentIds.includes(resource.id)
+      ? currentIds
+      : [...currentIds, resource.id]
+
+    artStore.setArtForm({
+      loraResourceIds,
+      loraName: artStore.artForm.loraName || engineName,
+      promptString: appendPrompt(
+        artStore.artForm.promptString || '',
+        triggerText(resource),
+      ),
+    })
+  } else {
+    artStore.setArtForm({
+      promptString: appendPrompt(
+        artStore.artForm.promptString || '',
+        triggerText(resource) || resourceLabel(resource),
+      ),
+    })
+  }
+
+  messageTone.value = 'success'
+  message.value = `${resourceLabel(resource)} added to the current generation.`
+}
+
+function startGeneration(resource: ResourceGalleryRecord): void {
+  const isCheckpoint = resource.resourceType === ResourceType.CHECKPOINT
+  const isLora =
+    resource.resourceType === ResourceType.LORA ||
+    resource.resourceType === ResourceType.LYCORIS
+
+  artStore.setArtForm({
+    promptString: triggerText(resource) || resourceLabel(resource),
+    checkpoint: isCheckpoint ? resourceEngineName(resource) : '',
+    checkpointResourceId: isCheckpoint ? resource.id : null,
+    loraName: isLora ? resourceEngineName(resource) : null,
+    loraResourceIds: isLora ? [resource.id] : [],
+  })
+
+  navStore.setDashboardTab(
+    'art',
+    'generate',
+    `Start generation from Resource ${resource.id}`,
+  )
+}
+
+async function generatePreview(resource: ResourceGalleryRecord): Promise<void> {
+  activePreviewResourceId.value = resource.id
+  message.value = ''
+
+  try {
+    const updated = await resourceGalleryStore.generatePreview(resource.id)
+    messageTone.value = 'success'
+    message.value = updated
+      ? `Preview ready for ${resourceLabel(resource)}.`
+      : `Preview queued for ${resourceLabel(resource)}.`
+  } catch (cause) {
+    messageTone.value = 'error'
+    message.value =
+      cause instanceof Error ? cause.message : 'Failed to generate preview.'
+  } finally {
+    activePreviewResourceId.value = null
+  }
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(new Error('Failed to read preview image.'))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function choosePreviewFile(resource: ResourceGalleryRecord): Promise<void> {
+  const input = document.createElement('input')
+  input.type = 'file'
+  input.accept = 'image/png,image/jpeg,image/webp,image/avif'
+
+  input.addEventListener(
+    'change',
+    async () => {
+      const file = input.files?.[0]
+      if (!file) return
+
+      activeUploadResourceId.value = resource.id
+      message.value = ''
+
+      try {
+        const imageData = await readFileAsDataUrl(file)
+        await resourceGalleryStore.uploadPreview({
+          resourceId: resource.id,
+          imageData,
+          fileName: file.name,
+          fileType: file.type.split('/').at(-1),
+        })
+        messageTone.value = 'success'
+        message.value = `Preview uploaded for ${resourceLabel(resource)}.`
+      } catch (cause) {
+        messageTone.value = 'error'
+        message.value =
+          cause instanceof Error ? cause.message : 'Failed to upload preview.'
+      } finally {
+        activeUploadResourceId.value = null
+      }
+    },
+    { once: true },
+  )
+
+  input.click()
+}
+
+onMounted(async () => {
+  await resourceGalleryStore.loadResources()
+})
+</script>
+
+<template>
+  <section class="flex min-h-full w-full flex-col gap-4">
+    <header class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
+      <div class="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+        <div>
+          <h2 class="text-2xl font-bold">Resource Gallery</h2>
+          <p class="max-w-3xl text-sm text-base-content/65">
+            Browse checkpoints, LoRAs, embeddings, and generation tools. Add one to
+            the current build, start fresh, or manufacture a preview when the catalog
+            arrived wearing a paper bag over its head.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-outline btn-sm rounded-2xl"
+          :disabled="resourceGalleryStore.isLoading"
+          @click="resourceGalleryStore.loadResources()"
+        >
+          <span
+            v-if="resourceGalleryStore.isLoading"
+            class="loading loading-spinner loading-xs"
+          />
+          <icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+
+      <div class="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+        <label class="form-control">
+          <span class="label-text text-xs">Search</span>
+          <input
+            v-model="query"
+            type="search"
+            class="input input-bordered rounded-2xl"
+            placeholder="Name, trigger, base model..."
+          />
+        </label>
+
+        <label class="form-control">
+          <span class="label-text text-xs">Type</span>
+          <select v-model="resourceType" class="select select-bordered rounded-2xl">
+            <option value="ALL">All types</option>
+            <option v-for="type in resourceTypes" :key="type" :value="type">
+              {{ type }}
+            </option>
+          </select>
+        </label>
+
+        <label class="form-control">
+          <span class="label-text text-xs">Base model</span>
+          <select v-model="generation" class="select select-bordered rounded-2xl">
+            <option value="ALL">All base models</option>
+            <option v-for="base in generations" :key="base" :value="base">
+              {{ base }}
+            </option>
+          </select>
+        </label>
+
+        <label class="form-control">
+          <span class="label-text text-xs">Maturity</span>
+          <select v-model="maturity" class="select select-bordered rounded-2xl">
+            <option value="ALL">Visible Resources</option>
+            <option value="SAFE">Safe only</option>
+            <option value="MATURE">Mature only</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <div
+      v-if="message"
+      class="rounded-2xl border p-3 text-sm"
+      :class="
+        messageTone === 'error'
+          ? 'border-error/40 bg-error/10 text-error'
+          : 'border-success/40 bg-success/10 text-success'
+      "
+    >
+      {{ message }}
+    </div>
+
+    <div
+      v-if="resourceGalleryStore.error"
+      class="rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
+    >
+      {{ resourceGalleryStore.error }}
+    </div>
+
+    <div
+      v-if="resourceGalleryStore.isLoading && !resourceGalleryStore.resources.length"
+      class="flex min-h-72 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
+    >
+      <span class="loading loading-spinner loading-lg text-primary" />
+    </div>
+
+    <div
+      v-else-if="!filteredResources.length"
+      class="flex min-h-72 items-center justify-center rounded-2xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
+    >
+      No Resources match those filters.
+    </div>
+
+    <div
+      v-else
+      class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
+    >
+      <article
+        v-for="resource in filteredResources"
+        :key="resource.id"
+        class="group flex min-h-[430px] flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+      >
+        <div class="relative aspect-square overflow-hidden bg-base-200">
+          <img
+            :src="previewSrc(resource)"
+            :alt="resourceLabel(resource)"
+            class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+            loading="lazy"
+          />
+
+          <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+            <span class="badge badge-primary badge-sm">{{ resource.resourceType }}</span>
+            <span v-if="resource.generation" class="badge badge-neutral badge-sm">
+              {{ resource.generation }}
+            </span>
+            <span v-if="resource.isMature" class="badge badge-error badge-sm">18+</span>
+          </div>
+
+          <div
+            v-if="triggerText(resource)"
+            class="absolute inset-x-2 bottom-2 translate-y-2 rounded-2xl bg-base-100/95 p-2 text-xs opacity-0 shadow transition group-hover:translate-y-0 group-hover:opacity-100"
+          >
+            <span class="font-semibold">Trigger:</span>
+            {{ triggerText(resource) }}
+          </div>
+        </div>
+
+        <div class="flex flex-1 flex-col gap-3 p-4">
+          <div>
+            <h3 class="line-clamp-2 text-lg font-bold">
+              {{ resourceLabel(resource) }}
+            </h3>
+            <p class="mt-1 line-clamp-3 text-sm text-base-content/65">
+              {{ resource.description || 'No description yet.' }}
+            </p>
+          </div>
+
+          <div class="flex flex-wrap gap-1 text-xs">
+            <span class="badge badge-outline badge-sm">
+              {{ resource.supportedServer }}
+            </span>
+            <span class="badge badge-outline badge-sm">
+              {{ resource._count?.ArtImages || 0 }} checkpoint uses
+            </span>
+            <span class="badge badge-outline badge-sm">
+              {{ resource._count?.UsedInImages || 0 }} LoRA uses
+            </span>
+          </div>
+
+          <div class="mt-auto grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              class="btn btn-primary btn-sm rounded-2xl"
+              @click="addToGeneration(resource)"
+            >
+              Add to build
+            </button>
+            <button
+              type="button"
+              class="btn btn-secondary btn-sm rounded-2xl"
+              @click="startGeneration(resource)"
+            >
+              Start fresh
+            </button>
+            <button
+              type="button"
+              class="btn btn-outline btn-sm rounded-2xl"
+              :disabled="activePreviewResourceId === resource.id"
+              @click="generatePreview(resource)"
+            >
+              <span
+                v-if="activePreviewResourceId === resource.id"
+                class="loading loading-spinner loading-xs"
+              />
+              Generate preview
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm rounded-2xl"
+              :disabled="activeUploadResourceId === resource.id"
+              @click="choosePreviewFile(resource)"
+            >
+              <span
+                v-if="activeUploadResourceId === resource.id"
+                class="loading loading-spinner loading-xs"
+              />
+              Upload preview
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>

--- a/content/channels/build/resources.md
+++ b/content/channels/build/resources.md
@@ -1,0 +1,15 @@
+---
+contentType: tab
+channelKey: build
+tabKey: resources
+label: Resources
+title: Resource Gallery
+subtitle: Models, LoRAs, and generation tools
+description: Browse generation resources, inspect previews and triggers, and seed an art build.
+icon: kind-icon:database
+route: /resources
+modelType: resource
+sort: 65
+---
+
+Browse checkpoints, LoRAs, embeddings, and other generation resources.

--- a/content/resources.md
+++ b/content/resources.md
@@ -1,0 +1,18 @@
+---
+title: 'Resources'
+room: 'Resource Gallery'
+subtitle: 'Models, LoRAs, and generation tools'
+description: 'Browse generation resources, inspect their previews and triggers, and add them directly to an art build.'
+image: 'background/artgallery.webp'
+icon: splash/aartgallerybout.png
+tooltip: Browse checkpoints, LoRAs, embeddings, and other generation resources.
+dottiTip: Some models arrive with gorgeous previews. Some arrive as a mysterious eight-gigabyte brick.
+amiTip: 'A good catalog helps every image remember where it came from.'
+sort: highlight
+channelKey: build
+tabKey: resources
+loadingMessage: Loading resource gallery...
+refreshLabel: Refresh Resources
+---
+
+:resource-gallery

--- a/scripts/lora-catalog/upload_sibling_previews.py
+++ b/scripts/lora-catalog/upload_sibling_previews.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Detect preview images beside cataloged model files and upload them as hosted
+ArtImages for Resources that do not already have a Civitai/CivArchive or hosted
+preview.
+
+Works with both lora-catalog.json and model-catalog.json because each scanner
+stores the model's absolute path in entry.meta.abspath.
+
+Examples:
+  export KIND_ROBOTS_API_KEY=...
+  python3 upload_sibling_previews.py ./catalog/lora-catalog.json \
+    --api-base https://kindrobots.org
+  python3 upload_sibling_previews.py ./catalog/model-catalog.json \
+    --api-base http://localhost:3000 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".avif")
+
+
+def sibling_candidates(model_path: Path) -> list[Path]:
+    stem = model_path.stem
+    names = []
+
+    for extension in IMAGE_EXTENSIONS:
+        names.extend(
+            [
+                f"{stem}.preview{extension}",
+                f"{stem}{extension}",
+                f"{model_path.name}.preview{extension}",
+            ]
+        )
+
+    return [model_path.parent / name for name in names]
+
+
+def find_sibling_preview(model_path: Path) -> Optional[Path]:
+    for candidate in sibling_candidates(model_path):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def api_request(
+    url: str,
+    api_key: str,
+    method: str = "GET",
+    body: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": "kind-robots-sibling-preview-uploader/1.0",
+    }
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            return json.loads(response.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as error:
+        message = error.read().decode("utf-8", "replace")
+        raise RuntimeError(f"HTTP {error.code}: {message}") from error
+
+
+def load_catalog(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("Catalog must contain an entries array.")
+    return entries
+
+
+def resource_key(resource: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(resource.get("hash") or "").strip().lower(),
+        str(resource.get("name") or "").strip().lower(),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Upload sibling model images as hosted Resource previews."
+    )
+    parser.add_argument("catalog", type=Path)
+    parser.add_argument(
+        "--api-base",
+        required=True,
+        help="Kind Robots base URL, for example https://kindrobots.org",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("KIND_ROBOTS_API_KEY", ""),
+        help="User/admin API key. Defaults to KIND_ROBOTS_API_KEY.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not args.api_key and not args.dry_run:
+        print("error: --api-key or KIND_ROBOTS_API_KEY is required", file=sys.stderr)
+        return 2
+
+    catalog_entries = load_catalog(args.catalog.expanduser().resolve())
+    api_base = args.api_base.rstrip("/")
+    resources_response = api_request(
+        f"{api_base}/api/resources",
+        args.api_key,
+    )
+    resources = resources_response.get("data") or []
+
+    by_hash: dict[str, dict[str, Any]] = {}
+    by_name: dict[str, dict[str, Any]] = {}
+    for resource in resources:
+        resource_hash, name = resource_key(resource)
+        if resource_hash:
+            by_hash[resource_hash] = resource
+        if name:
+            by_name[name] = resource
+
+    detected = uploaded = skipped = missing_resource = failed = 0
+
+    for entry in catalog_entries:
+        catalog_resource = entry.get("resource") or {}
+        meta = entry.get("meta") or {}
+        model_path_raw = meta.get("abspath")
+        if not model_path_raw:
+            continue
+
+        model_path = Path(str(model_path_raw))
+        sibling = find_sibling_preview(model_path)
+        if not sibling:
+            continue
+
+        detected += 1
+        model_hash, model_name = resource_key(catalog_resource)
+        resource = by_hash.get(model_hash) or by_name.get(model_name)
+
+        if not resource:
+            missing_resource += 1
+            print(f"MISS  {model_path.name}: Resource not found in API")
+            continue
+
+        if resource.get("artImageId") or resource.get("previewImageUrl"):
+            skipped += 1
+            print(f"SKIP  {model_path.name}: Resource already has a preview")
+            continue
+
+        print(f"FOUND {model_path.name} -> {sibling.name}")
+        if args.dry_run:
+            continue
+
+        try:
+            mime_type = mimetypes.guess_type(sibling.name)[0] or "image/png"
+            encoded = base64.b64encode(sibling.read_bytes()).decode("ascii")
+            image_data = f"data:{mime_type};base64,{encoded}"
+            response = api_request(
+                f"{api_base}/api/resources/{resource['id']}/preview-image",
+                args.api_key,
+                method="POST",
+                body={
+                    "imageData": image_data,
+                    "fileName": sibling.name,
+                    "fileType": sibling.suffix.lstrip(".").lower(),
+                },
+            )
+
+            if response.get("success"):
+                uploaded += 1
+                print(f"UPLOADED Resource #{resource['id']}")
+            else:
+                failed += 1
+                print(
+                    f"FAIL  Resource #{resource['id']}: "
+                    f"{response.get('message') or 'unknown error'}"
+                )
+        except Exception as error:
+            failed += 1
+            print(f"FAIL  Resource #{resource['id']}: {error}")
+
+    print("\n=== Sibling preview summary ===")
+    print(f"  detected         : {detected}")
+    print(f"  uploaded         : {uploaded}")
+    print(f"  skipped existing : {skipped}")
+    print(f"  missing Resource : {missing_resource}")
+    print(f"  failed           : {failed}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/api/art/image/[id].patch.ts
+++ b/server/api/art/image/[id].patch.ts
@@ -13,10 +13,12 @@ type PatchUser = {
   isServerKey: boolean
 }
 
-// Owner transfer is intentionally NOT part of the general patch contract: a
-// dedicated administrative endpoint should own reassignment. `userId` is
-// therefore absent from this allowlist, so neither an owner nor an admin can
-// change an ArtImage's owner through the ordinary PATCH route (audit F-1).
+type LoraRelationPatch = {
+  loraResourceIds: number[]
+  disconnectLoraResourceIds: number[]
+  clearLoraResources: boolean
+}
+
 const ART_IMAGE_PATCH_FIELDS = new Set<
   keyof Prisma.ArtImageUncheckedUpdateInput
 >([
@@ -54,14 +56,62 @@ const ART_IMAGE_PATCH_FIELDS = new Set<
 ])
 
 async function requirePatchUser(event: H3Event): Promise<PatchUser> {
-  // Same machine auth as the rest of the art API (JWT / user apiKey /
-  // beta-admin token) so a token that can READ can also WRITE. Throws 401.
   const auth = await requireMachineUser(event)
 
   return {
     id: auth.user.id,
     isAdmin: auth.isAdmin,
     isServerKey: auth.isServerKey,
+  }
+}
+
+function normalizeIdArray(value: unknown, fieldName: string): number[] {
+  if (typeof value === 'undefined' || value === null) return []
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} must be an array of positive integers.`,
+    })
+  }
+
+  const ids = value.map((entry) => Number(entry))
+
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} must contain only positive integers.`,
+    })
+  }
+
+  return [...new Set(ids)]
+}
+
+function readLoraRelationPatch(body: Record<string, unknown>): LoraRelationPatch {
+  const loraResourceIds = normalizeIdArray(
+    body.loraResourceIds,
+    'loraResourceIds',
+  )
+  const connectIds = new Set(loraResourceIds)
+  const disconnectLoraResourceIds = normalizeIdArray(
+    body.disconnectLoraResourceIds,
+    'disconnectLoraResourceIds',
+  ).filter((id) => !connectIds.has(id))
+
+  if (
+    typeof body.clearLoraResources !== 'undefined' &&
+    typeof body.clearLoraResources !== 'boolean'
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'clearLoraResources must be a boolean.',
+    })
+  }
+
+  return {
+    loraResourceIds,
+    disconnectLoraResourceIds,
+    clearLoraResources: body.clearLoraResources === true,
   }
 }
 
@@ -88,6 +138,36 @@ function sanitizeArtImagePatch(
   }
 
   return updateData
+}
+
+function buildLoraRelationData(
+  patch: LoraRelationPatch,
+): Prisma.ArtImageUpdateInput {
+  if (patch.clearLoraResources) {
+    return { LoraResources: { set: [] } }
+  }
+
+  if (
+    !patch.loraResourceIds.length &&
+    !patch.disconnectLoraResourceIds.length
+  ) {
+    return {}
+  }
+
+  return {
+    LoraResources: {
+      ...(patch.loraResourceIds.length
+        ? {
+            connect: patch.loraResourceIds.map((id) => ({ id })),
+          }
+        : {}),
+      ...(patch.disconnectLoraResourceIds.length
+        ? {
+            disconnect: patch.disconnectLoraResourceIds.map((id) => ({ id })),
+          }
+        : {}),
+    },
+  }
 }
 
 export default defineEventHandler(async (event) => {
@@ -135,17 +215,19 @@ export default defineEventHandler(async (event) => {
     }
 
     const updateData = sanitizeArtImagePatch(body)
+    const loraPatch = readLoraRelationPatch(body)
+    const hasLoraPatch =
+      loraPatch.clearLoraResources ||
+      loraPatch.loraResourceIds.length > 0 ||
+      loraPatch.disconnectLoraResourceIds.length > 0
 
-    if (Object.keys(updateData).length === 0) {
+    if (Object.keys(updateData).length === 0 && !hasLoraPatch) {
       throw createError({
         statusCode: 400,
         message: 'No valid ArtImage fields provided for update.',
       })
     }
 
-    // A connected Server / checkpoint Resource must exist and be public or owned
-    // by the caller (admins bypass the permission check). Raw scalar FK writes
-    // were previously unchecked (audit F-2 residual).
     await assertArtImageRelationsAttachable(
       {
         serverId:
@@ -154,14 +236,21 @@ export default defineEventHandler(async (event) => {
           typeof updateData.checkpointResourceId === 'number'
             ? updateData.checkpointResourceId
             : null,
+        loraResourceIds: loraPatch.loraResourceIds,
       },
       user.id,
       user.isAdmin || user.isServerKey,
     )
 
-    const data = await prisma.artImage.update({
+    const relationData = buildLoraRelationData(loraPatch)
+    const data = {
+      ...updateData,
+      ...relationData,
+    } as Prisma.ArtImageUpdateInput
+
+    const updated = await prisma.artImage.update({
       where: { id },
-      data: updateData,
+      data,
       select: artImageMutationSelect,
     })
 
@@ -170,7 +259,7 @@ export default defineEventHandler(async (event) => {
     return {
       success: true,
       message: `ArtImage #${id} updated successfully.`,
-      data,
+      data: updated,
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/server/api/art/image/index.post.ts
+++ b/server/api/art/image/index.post.ts
@@ -4,6 +4,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
+import { assertArtImageRelationsAttachable } from './relations'
 import { artImageMutationSelect } from './selects'
 
 type CreateArtImagePayload = {
@@ -17,6 +18,8 @@ type CreateArtImagePayload = {
   artPrompt?: unknown
   negativePrompt?: unknown
   checkpoint?: unknown
+  checkpointResourceId?: unknown
+  loraResourceIds?: unknown
   sampler?: unknown
   seed?: unknown
   steps?: unknown
@@ -27,6 +30,7 @@ type CreateArtImagePayload = {
   isPublic?: unknown
   isMature?: unknown
   isActive?: unknown
+  serverId?: unknown
   serverName?: unknown
   serverUrl?: unknown
 }
@@ -42,6 +46,8 @@ const ALLOWED_FIELDS = new Set([
   'artPrompt',
   'negativePrompt',
   'checkpoint',
+  'checkpointResourceId',
+  'loraResourceIds',
   'sampler',
   'seed',
   'steps',
@@ -52,6 +58,7 @@ const ALLOWED_FIELDS = new Set([
   'isPublic',
   'isMature',
   'isActive',
+  'serverId',
   'serverName',
   'serverUrl',
 ])
@@ -129,6 +136,43 @@ function cleanInteger(
   return number
 }
 
+function cleanPositiveId(value: unknown, fieldName: string): number | null {
+  if (typeof value === 'undefined' || value === null || value === '') return null
+
+  const id = Number(value)
+
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} must be a positive integer.`,
+    })
+  }
+
+  return id
+}
+
+function cleanPositiveIdArray(value: unknown, fieldName: string): number[] {
+  if (typeof value === 'undefined' || value === null) return []
+
+  if (!Array.isArray(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} must be an array of positive integers.`,
+    })
+  }
+
+  const ids = value.map((entry) => Number(entry))
+
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} must contain only positive integers.`,
+    })
+  }
+
+  return [...new Set(ids)]
+}
+
 function cleanBoolean(
   value: unknown,
   fieldName: string,
@@ -175,7 +219,7 @@ function getFallbackFileName(
 
 export default defineEventHandler(async (event) => {
   try {
-    const { user } = await requireApiUser(event)
+    const { user, isAdmin } = await requireApiUser(event)
     const body = await readBody<CreateArtImagePayload>(event)
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -228,6 +272,21 @@ export default defineEventHandler(async (event) => {
     const fileName =
       cleanText(body.fileName, 'fileName', 255) ||
       getFallbackFileName(body, fileType)
+    const serverId = cleanPositiveId(body.serverId, 'serverId')
+    const checkpointResourceId = cleanPositiveId(
+      body.checkpointResourceId,
+      'checkpointResourceId',
+    )
+    const loraResourceIds = cleanPositiveIdArray(
+      body.loraResourceIds,
+      'loraResourceIds',
+    )
+
+    await assertArtImageRelationsAttachable(
+      { serverId, checkpointResourceId, loraResourceIds },
+      user.id,
+      isAdmin,
+    )
 
     const data: Prisma.ArtImageCreateInput = {
       imageData,
@@ -263,6 +322,13 @@ export default defineEventHandler(async (event) => {
       User: {
         connect: { id: user.id },
       },
+      Server: serverId ? { connect: { id: serverId } } : undefined,
+      CheckpointResource: checkpointResourceId
+        ? { connect: { id: checkpointResourceId } }
+        : undefined,
+      LoraResources: loraResourceIds.length
+        ? { connect: loraResourceIds.map((id) => ({ id })) }
+        : undefined,
     }
 
     const artImage = await prisma.artImage.create({

--- a/server/api/art/image/relations.ts
+++ b/server/api/art/image/relations.ts
@@ -1,18 +1,52 @@
 // /server/api/art/image/relations.ts
 import { createError } from 'h3'
+import { ResourceType } from '~/prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 
-type OwnableRow = { id: number; userId: number | null; isPublic: boolean | null }
+type OwnableRow = {
+  id: number
+  userId: number | null
+  isPublic: boolean | null
+}
+
+type LoraRow = OwnableRow & {
+  resourceType: ResourceType
+}
 
 export type ArtImageRelationAttachInput = {
   serverId?: number | null
   checkpointResourceId?: number | null
+  loraResourceIds?: number[]
 }
 
-// Verifies existence (404 for missing) and permission (403 for a private target
-// owned by someone else) for the Server / checkpoint Resource an ArtImage patch
-// connects. A non-admin may only attach public or self-owned rows; admins skip
-// the permission check but keep existence. Disconnects (null) are not checked.
+function normalizeIds(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+
+  return [
+    ...new Set(
+      value
+        .map((entry) => Number(entry))
+        .filter((entry) => Number.isInteger(entry) && entry > 0),
+    ),
+  ]
+}
+
+function assertOwnedOrPublic(
+  row: OwnableRow,
+  label: string,
+  userId: number,
+  isAdmin: boolean,
+): void {
+  if (isAdmin) return
+
+  if (row.userId !== userId && row.isPublic !== true) {
+    throw createError({
+      statusCode: 403,
+      message: `You do not have permission to attach this ${label} to an ArtImage.`,
+    })
+  }
+}
+
 async function assertRelationAccessible(
   id: number | null | undefined,
   find: (id: number) => Promise<OwnableRow | null>,
@@ -31,14 +65,43 @@ async function assertRelationAccessible(
     })
   }
 
-  if (isAdmin) return
+  assertOwnedOrPublic(row, label, userId, isAdmin)
+}
 
-  if (row.userId !== userId && row.isPublic !== true) {
+async function assertLoraResourcesAccessible(
+  ids: number[],
+  userId: number,
+  isAdmin: boolean,
+): Promise<void> {
+  const loraResourceIds = normalizeIds(ids)
+  if (!loraResourceIds.length) return
+
+  const rows: LoraRow[] = await prisma.resource.findMany({
+    where: {
+      id: { in: loraResourceIds },
+      resourceType: { in: [ResourceType.LORA, ResourceType.LYCORIS] },
+    },
+    select: {
+      id: true,
+      userId: true,
+      isPublic: true,
+      resourceType: true,
+    },
+  })
+
+  const foundIds = new Set(rows.map((row) => row.id))
+  const missingIds = loraResourceIds.filter((id) => !foundIds.has(id))
+
+  if (missingIds.length) {
     throw createError({
-      statusCode: 403,
-      message: `You do not have permission to attach this ${label} to an ArtImage.`,
+      statusCode: 404,
+      message: `LoRA Resources not found or incompatible: ${missingIds.join(', ')}.`,
     })
   }
+
+  rows.forEach((row) =>
+    assertOwnedOrPublic(row, 'LoRA Resource', userId, isAdmin),
+  )
 }
 
 export async function assertArtImageRelationsAttachable(
@@ -63,11 +126,16 @@ export async function assertArtImageRelationsAttachable(
         ? input.checkpointResourceId
         : undefined,
       (id) =>
-        prisma.resource.findUnique({
-          where: { id },
+        prisma.resource.findFirst({
+          where: { id, resourceType: ResourceType.CHECKPOINT },
           select: { id: true, userId: true, isPublic: true },
         }),
       'checkpoint Resource',
+      userId,
+      isAdmin,
+    ),
+    assertLoraResourcesAccessible(
+      input.loraResourceIds ?? [],
       userId,
       isAdmin,
     ),

--- a/server/api/art/image/selects.ts
+++ b/server/api/art/image/selects.ts
@@ -17,6 +17,15 @@ export const artImageMutationSelect = {
   negativePrompt: true,
   checkpoint: true,
   checkpointResourceId: true,
+  LoraResources: {
+    select: {
+      id: true,
+      name: true,
+      customLabel: true,
+      resourceType: true,
+    },
+    orderBy: { id: 'asc' },
+  },
   sampler: true,
   seed: true,
   steps: true,

--- a/server/api/art/utils/resourceProvenance.ts
+++ b/server/api/art/utils/resourceProvenance.ts
@@ -1,17 +1,4 @@
 // /server/api/art/utils/resourceProvenance.ts
-//
-// Resolves which Resource rows a generated ArtImage used, so provenance can be
-// recorded on the image (ArtImage.checkpointResourceId + ArtImage.LoraResources)
-// and we can later query "all art that used Resource X".
-//
-// It reads the `resources` block that enqueue stamps onto the ArtJob payload
-// (explicit resource IDs from the picker, plus the checkpoint/LoRA name strings
-// for name-backfill of generations made before the picker existed). Every ID is
-// verified to exist before it is returned, so callers can connect the results
-// without risking a foreign-key error.
-//
-// This is intentionally BEST-EFFORT: any failure resolves to "no links" rather
-// than throwing, because provenance must never break a successful render.
 import {
   ResourceType,
   type Prisma,
@@ -24,7 +11,7 @@ type ResourceDelegate = {
   ) => PromiseLike<{ id: number } | null>
   findMany: (
     args: Prisma.ResourceFindManyArgs,
-  ) => PromiseLike<Array<{ id: number }>>
+  ) => PromiseLike<Array<{ id: number; resourceType: ResourceType }>>
 }
 
 type ResourceClient = { resource: unknown }
@@ -54,8 +41,6 @@ function cleanName(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-// Resolve a free-text checkpoint/LoRA name to a Resource id. A model is stored
-// under several names (file stem, pretty label, on-disk path), so we match any.
 async function resolveByName(
   resource: ResourceDelegate,
   name: string,
@@ -64,6 +49,7 @@ async function resolveByName(
   const row = await resource.findFirst({
     where: {
       resourceType: { in: types },
+      isActive: true,
       OR: [{ localPath: name }, { name }, { customLabel: name }],
     },
     select: { id: true },
@@ -77,10 +63,6 @@ export async function resolveArtImageResourceLinks(
   client: ResourceClient,
 ): Promise<ArtImageResourceLinks> {
   try {
-    // Prisma 7's root client and transaction client expose different generic
-    // delegate wrappers even though the two methods used here share the same
-    // runtime contract. Narrow only at the call site instead of requiring a
-    // full PrismaClient delegate type.
     const resource = client.resource as ResourceDelegate
     const record = parseArtJobPayload(payload) as Record<string, unknown>
     const block =
@@ -90,28 +72,42 @@ export async function resolveArtImageResourceLinks(
 
     let checkpointResourceId = posInt(block.checkpointResourceId)
     let loraResourceIds = posIntArray(block.loraResourceIds)
-
-    // Verify the claimed IDs actually exist (drop any that don't).
     const claimed = [
       ...(checkpointResourceId ? [checkpointResourceId] : []),
       ...loraResourceIds,
     ]
+
     if (claimed.length) {
-      const found = new Set(
-        (
-          await resource.findMany({
-            where: { id: { in: claimed } },
-            select: { id: true },
-          })
-        ).map((r) => r.id),
+      const found = await resource.findMany({
+        where: {
+          id: { in: claimed },
+          isActive: true,
+          resourceType: {
+            in: [ResourceType.CHECKPOINT, ...LORA_TYPES],
+          },
+        },
+        select: { id: true, resourceType: true },
+      })
+      const checkpointIds = new Set(
+        found
+          .filter((row) => row.resourceType === ResourceType.CHECKPOINT)
+          .map((row) => row.id),
       )
-      if (checkpointResourceId && !found.has(checkpointResourceId)) {
+      const loraIds = new Set(
+        found
+          .filter((row) => LORA_TYPES.includes(row.resourceType))
+          .map((row) => row.id),
+      )
+
+      if (
+        checkpointResourceId &&
+        !checkpointIds.has(checkpointResourceId)
+      ) {
         checkpointResourceId = null
       }
-      loraResourceIds = loraResourceIds.filter((id) => found.has(id))
+      loraResourceIds = loraResourceIds.filter((id) => loraIds.has(id))
     }
 
-    // Name-backfill when the picker didn't supply IDs (older/string path).
     if (!checkpointResourceId) {
       const name = cleanName(block.checkpointName)
       if (name) {
@@ -120,15 +116,16 @@ export async function resolveArtImageResourceLinks(
         ])
       }
     }
+
     if (!loraResourceIds.length && Array.isArray(block.loraNames)) {
       const names = block.loraNames
         .map(cleanName)
-        .filter((s): s is string => s !== null)
+        .filter((value): value is string => value !== null)
       const resolved = await Promise.all(
-        names.map((n) => resolveByName(resource, n, LORA_TYPES)),
+        names.map((name) => resolveByName(resource, name, LORA_TYPES)),
       )
       loraResourceIds = [
-        ...new Set(resolved.filter((n): n is number => n !== null)),
+        ...new Set(resolved.filter((id): id is number => id !== null)),
       ]
     }
 
@@ -138,10 +135,6 @@ export async function resolveArtImageResourceLinks(
   }
 }
 
-// Build the Prisma update fragment that connects the resolved links onto an
-// ArtImage. Safe to spread into an unchecked update: `checkpointResourceId` is a
-// scalar FK and `LoraResources` is an M2M relation op (available on both checked
-// and unchecked update inputs).
 export function artImageResourceConnectData(links: ArtImageResourceLinks): {
   checkpointResourceId?: number
   LoraResources?: { connect: { id: number }[] }

--- a/server/api/resources/[id].get.ts
+++ b/server/api/resources/[id].get.ts
@@ -2,59 +2,65 @@
 import { defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import { resourceGallerySelect, resourceGalleryWhere } from './gallery'
 
 export default defineEventHandler(async (event) => {
-  let response
   const resourceId = Number(event.context.params?.id)
 
   try {
-    // Validate ID format
-    if (isNaN(resourceId) || resourceId <= 0) {
-      response = {
+    if (!Number.isInteger(resourceId) || resourceId <= 0) {
+      event.node.res.statusCode = 400
+      return {
         success: false,
         message: 'Invalid ID format. ID must be a positive integer.',
         data: null,
         statusCode: 400,
       }
-      event.node.res.statusCode = 400
-      return response
     }
 
-    // Fetch resource
-    const resource = await prisma.resource.findUnique({
-      where: { id: resourceId },
+    const auth = await getOptionalApiUser(event)
+    const resource = await prisma.resource.findFirst({
+      where: {
+        AND: [
+          { id: resourceId },
+          resourceGalleryWhere({
+            userId: auth?.user.id ?? null,
+            isAdmin: auth?.isAdmin ?? false,
+            showMature: Boolean(auth?.user.showMature),
+          }),
+        ],
+      },
+      select: resourceGallerySelect,
     })
 
-    // Resource not found
     if (!resource) {
-      response = {
+      event.node.res.statusCode = 404
+      return {
         success: false,
         message: 'Resource not found.',
         data: null,
         statusCode: 404,
       }
-      event.node.res.statusCode = 404
-      return response
     }
 
-    // Successful retrieval
-    response = {
+    event.node.res.statusCode = 200
+    return {
       success: true,
       message: 'Resource retrieved successfully.',
       data: resource,
       statusCode: 200,
     }
-    event.node.res.statusCode = 200
   } catch (error: unknown) {
     const handledError = errorHandler(error)
-    response = {
+    const statusCode = handledError.statusCode || 500
+    event.node.res.statusCode = statusCode
+
+    return {
       success: false,
       message: handledError.message || 'Failed to retrieve resource.',
       data: null,
-      statusCode: handledError.statusCode || 500,
+      statusCode,
     }
-    event.node.res.statusCode = response.statusCode
   }
-
-  return response
 })

--- a/server/api/resources/[id]/generate-preview.post.ts
+++ b/server/api/resources/[id]/generate-preview.post.ts
@@ -1,0 +1,227 @@
+// /server/api/resources/[id]/generate-preview.post.ts
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import {
+  ResourceType,
+  SupportedServer,
+} from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import { authAndGate } from '~/server/utils/comfyGate'
+import { resourceGallerySelect, resourceGalleryWhere } from '../gallery'
+
+const A1111_RESOURCE_FAMILIES = [
+  SupportedServer.SD15,
+  SupportedServer.SDXL,
+  SupportedServer.GENERIC,
+  SupportedServer.UNKNOWN,
+]
+
+function cleanModelName(value: string | null | undefined): string {
+  return String(value || '').trim()
+}
+
+function resourceEngineName(resource: {
+  localPath: string | null
+  name: string
+  customLabel: string | null
+}): string {
+  return (
+    cleanModelName(resource.localPath) ||
+    cleanModelName(resource.name) ||
+    cleanModelName(resource.customLabel)
+  )
+}
+
+function buildPreviewPrompt(resource: {
+  defaultTrigger: string | null
+  triggerWords: string | null
+  artPrompt: string | null
+  customLabel: string | null
+  name: string
+}): string {
+  const subject =
+    cleanModelName(resource.defaultTrigger) ||
+    cleanModelName(resource.triggerWords) ||
+    cleanModelName(resource.artPrompt) ||
+    cleanModelName(resource.customLabel) ||
+    cleanModelName(resource.name)
+
+  return `${subject}, polished showcase image, clear subject, balanced composition, detailed, clean background`
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const resourceId = Number(getRouterParam(event, 'id'))
+
+    if (!Number.isInteger(resourceId) || resourceId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Resource ID.' })
+    }
+
+    const auth = await requireMachineUser(event)
+    const resource = await prisma.resource.findFirst({
+      where: {
+        AND: [
+          { id: resourceId },
+          resourceGalleryWhere({
+            userId: auth.user.id,
+            isAdmin: auth.isAdmin,
+            showMature: Boolean(auth.user.showMature),
+          }),
+        ],
+      },
+      select: resourceGallerySelect,
+    })
+
+    if (!resource) {
+      throw createError({ statusCode: 404, message: 'Resource not found.' })
+    }
+
+    const isCheckpoint = resource.resourceType === ResourceType.CHECKPOINT
+    const isLora =
+      resource.resourceType === ResourceType.LORA ||
+      resource.resourceType === ResourceType.LYCORIS
+
+    if (!isCheckpoint && !isLora) {
+      throw createError({
+        statusCode: 400,
+        message: 'Automatic previews currently support checkpoints, LoRAs, and LyCORIS resources.',
+      })
+    }
+
+    if (!A1111_RESOURCE_FAMILIES.includes(resource.supportedServer)) {
+      throw createError({
+        statusCode: 409,
+        message: `Automatic previews for ${resource.supportedServer} resources need a compatible Comfy workflow. This Resource can still use an uploaded or imported preview.`,
+      })
+    }
+
+    const checkpoint = isCheckpoint
+      ? resource
+      : await prisma.resource.findFirst({
+          where: {
+            AND: [
+              {
+                resourceType: ResourceType.CHECKPOINT,
+                isActive: true,
+                supportedServer: { in: A1111_RESOURCE_FAMILIES },
+              },
+              auth.isAdmin
+                ? {}
+                : {
+                    OR: [
+                      { isPublic: true },
+                      { userId: auth.user.id },
+                    ],
+                  },
+              {
+                OR: [
+                  ...(resource.generation
+                    ? [{ generation: resource.generation }]
+                    : []),
+                  { supportedServer: resource.supportedServer },
+                  { supportedServer: SupportedServer.SDXL },
+                  { supportedServer: SupportedServer.SD15 },
+                ],
+              },
+            ],
+          },
+          orderBy: [
+            { generation: resource.generation ? 'asc' : 'desc' },
+            { id: 'asc' },
+          ],
+        })
+
+    if (!checkpoint) {
+      throw createError({
+        statusCode: 409,
+        message: 'No accessible A1111-compatible checkpoint is available for this Resource.',
+      })
+    }
+
+    const checkpointName = resourceEngineName(checkpoint)
+    const loraName = isLora ? resourceEngineName(resource) : null
+
+    if (!checkpointName) {
+      throw createError({
+        statusCode: 409,
+        message: 'The compatible checkpoint does not have an engine filename or name.',
+      })
+    }
+
+    const promptString = buildPreviewPrompt(resource)
+    const gate = await authAndGate(event, {
+      engine: 'comfy',
+      steps: 24,
+      width: 768,
+      height: 768,
+    })
+
+    const payload = {
+      promptString,
+      negativePrompt:
+        'low quality, blurry, distorted, cropped, watermark, text, logo',
+      steps: 24,
+      cfg: 6,
+      cfgHalf: false,
+      width: 768,
+      height: 768,
+      sampler: 'Euler a',
+      seed: -1,
+      checkpoint: checkpointName,
+      ...(loraName ? { loraName, loraStrength: 1 } : {}),
+      save: {
+        isPublic: resource.isPublic,
+        isMature: resource.isMature,
+        designer:
+          auth.user.designerName || auth.user.username || `User ${auth.user.id}`,
+      },
+      resources: {
+        checkpointResourceId: checkpoint.id,
+        loraResourceIds: isLora ? [resource.id] : [],
+        checkpointName,
+        loraNames: loraName ? [loraName] : [],
+      },
+      previewResourceId: resource.id,
+    }
+
+    const job = await prisma.artJob.create({
+      data: {
+        engine: 'A1111',
+        payload: JSON.stringify(payload),
+        priority: 1,
+        projectSlug: 'resource-previews',
+        userId: gate.user.id,
+      },
+    })
+
+    const { balance } = await gate.commit(`resource-preview:${job.id}`)
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: `Preview generation queued for ${resource.customLabel || resource.name}.`,
+      data: {
+        jobId: job.id,
+        resourceId: resource.id,
+        status: job.status,
+        promptString,
+        checkpointResourceId: checkpoint.id,
+        loraResourceIds: isLora ? [resource.id] : [],
+        mana: { balance, charged: gate.cost },
+      },
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to queue Resource preview.',
+      data: null,
+      statusCode,
+    }
+  }
+})

--- a/server/api/resources/[id]/generate-preview.post.ts
+++ b/server/api/resources/[id]/generate-preview.post.ts
@@ -3,14 +3,16 @@ import { createError, defineEventHandler, getRouterParam } from 'h3'
 import {
   ResourceType,
   SupportedServer,
+  type Resource,
 } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireMachineUser } from '~/server/utils/authGuard'
-import { authAndGate } from '~/server/utils/comfyGate'
+import { manaGate } from '~/server/utils/manaGate'
+import { estimateArtCostUsd } from '~/server/utils/manaCost'
 import { resourceGallerySelect, resourceGalleryWhere } from '../gallery'
 
-const A1111_RESOURCE_FAMILIES = [
+const A1111_RESOURCE_FAMILIES: SupportedServer[] = [
   SupportedServer.SD15,
   SupportedServer.SDXL,
   SupportedServer.GENERIC,
@@ -50,6 +52,23 @@ function buildPreviewPrompt(resource: {
   return `${subject}, polished showcase image, clear subject, balanced composition, detailed, clean background`
 }
 
+function checkpointScore(checkpoint: Resource, target: Resource): number {
+  let score = 0
+
+  if (
+    target.generation &&
+    checkpoint.generation?.toLowerCase() === target.generation.toLowerCase()
+  ) {
+    score += 100
+  }
+
+  if (checkpoint.supportedServer === target.supportedServer) score += 30
+  if (checkpoint.supportedServer === SupportedServer.SDXL) score += 10
+  if (checkpoint.isPublic) score += 2
+
+  return score
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const resourceId = Number(getRouterParam(event, 'id'))
@@ -85,7 +104,8 @@ export default defineEventHandler(async (event) => {
     if (!isCheckpoint && !isLora) {
       throw createError({
         statusCode: 400,
-        message: 'Automatic previews currently support checkpoints, LoRAs, and LyCORIS resources.',
+        message:
+          'Automatic previews currently support checkpoints, LoRAs, and LyCORIS resources.',
       })
     }
 
@@ -96,9 +116,9 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const checkpoint = isCheckpoint
-      ? resource
-      : await prisma.resource.findFirst({
+    const checkpointCandidates = isCheckpoint
+      ? []
+      : await prisma.resource.findMany({
           where: {
             AND: [
               {
@@ -114,28 +134,22 @@ export default defineEventHandler(async (event) => {
                       { userId: auth.user.id },
                     ],
                   },
-              {
-                OR: [
-                  ...(resource.generation
-                    ? [{ generation: resource.generation }]
-                    : []),
-                  { supportedServer: resource.supportedServer },
-                  { supportedServer: SupportedServer.SDXL },
-                  { supportedServer: SupportedServer.SD15 },
-                ],
-              },
             ],
           },
-          orderBy: [
-            { generation: resource.generation ? 'asc' : 'desc' },
-            { id: 'asc' },
-          ],
         })
+    const checkpoint = isCheckpoint
+      ? resource
+      : [...checkpointCandidates].sort((a, b) => {
+          const scoreDifference =
+            checkpointScore(b, resource) - checkpointScore(a, resource)
+          return scoreDifference || a.id - b.id
+        })[0]
 
     if (!checkpoint) {
       throw createError({
         statusCode: 409,
-        message: 'No accessible A1111-compatible checkpoint is available for this Resource.',
+        message:
+          'No accessible A1111-compatible checkpoint is available for this Resource.',
       })
     }
 
@@ -145,16 +159,21 @@ export default defineEventHandler(async (event) => {
     if (!checkpointName) {
       throw createError({
         statusCode: 409,
-        message: 'The compatible checkpoint does not have an engine filename or name.',
+        message:
+          'The compatible checkpoint does not have an engine filename or name.',
       })
     }
 
     const promptString = buildPreviewPrompt(resource)
-    const gate = await authAndGate(event, {
-      engine: 'comfy',
+    const estimatedCostUsd = estimateArtCostUsd({
+      engine: 'a1111',
       steps: 24,
       width: 768,
       height: 768,
+    })
+    const gate = await manaGate(event, {
+      kind: 'art',
+      estCostUsd: estimatedCostUsd,
     })
 
     const payload = {
@@ -174,7 +193,9 @@ export default defineEventHandler(async (event) => {
         isPublic: resource.isPublic,
         isMature: resource.isMature,
         designer:
-          auth.user.designerName || auth.user.username || `User ${auth.user.id}`,
+          auth.user.designerName ||
+          auth.user.username ||
+          `User ${auth.user.id}`,
       },
       resources: {
         checkpointResourceId: checkpoint.id,

--- a/server/api/resources/[id]/preview-image.post.ts
+++ b/server/api/resources/[id]/preview-image.post.ts
@@ -1,0 +1,154 @@
+// /server/api/resources/[id]/preview-image.post.ts
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import { resourceGallerySelect } from '../gallery'
+
+type PreviewUploadBody = {
+  imageData?: unknown
+  fileName?: unknown
+  fileType?: unknown
+}
+
+const ALLOWED_FILE_TYPES = new Set(['png', 'jpeg', 'jpg', 'webp', 'avif'])
+const MAX_IMAGE_DATA_CHARS = 30_000_000
+
+function requiredText(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} is required.`,
+    })
+  }
+
+  const text = value.trim()
+  if (text.length > maxLength) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldName} must be ${maxLength} characters or fewer.`,
+    })
+  }
+
+  return text
+}
+
+function inferFileType(fileName: string): string {
+  return fileName.split('?')[0]?.split('.').pop()?.toLowerCase() || 'png'
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const resourceId = Number(getRouterParam(event, 'id'))
+
+    if (!Number.isInteger(resourceId) || resourceId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Resource ID.' })
+    }
+
+    const auth = await requireMachineUser(event)
+    const body = await readBody<PreviewUploadBody>(event)
+    const resource = await prisma.resource.findUnique({
+      where: { id: resourceId },
+      select: {
+        id: true,
+        name: true,
+        customLabel: true,
+        userId: true,
+        isMature: true,
+        isPublic: true,
+      },
+    })
+
+    if (!resource) {
+      throw createError({ statusCode: 404, message: 'Resource not found.' })
+    }
+
+    if (!auth.isAdmin && resource.userId !== auth.user.id) {
+      throw createError({
+        statusCode: 403,
+        message: 'Only the Resource owner or an admin can replace its preview.',
+      })
+    }
+
+    const imageData = requiredText(
+      body?.imageData,
+      'imageData',
+      MAX_IMAGE_DATA_CHARS,
+    )
+    const fileName = requiredText(
+      body?.fileName || `resource-${resourceId}-preview.png`,
+      'fileName',
+      255,
+    )
+    const requestedFileType =
+      typeof body?.fileType === 'string' && body.fileType.trim()
+        ? body.fileType.trim().toLowerCase()
+        : inferFileType(fileName)
+    const fileType = requestedFileType === 'jpg' ? 'jpeg' : requestedFileType
+
+    if (!ALLOWED_FILE_TYPES.has(requestedFileType)) {
+      throw createError({
+        statusCode: 400,
+        message: `Unsupported preview file type: ${requestedFileType}.`,
+      })
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const artImage = await tx.artImage.create({
+        data: {
+          imageData,
+          fileName,
+          fileType,
+          promptString: `Preview for ${resource.customLabel || resource.name}`,
+          artPrompt: `Preview for ${resource.customLabel || resource.name}`,
+          designer:
+            auth.user.designerName || auth.user.username || `User ${auth.user.id}`,
+          isPublic: resource.isPublic,
+          isMature: resource.isMature,
+          isActive: true,
+          User: { connect: { id: auth.user.id } },
+        },
+        select: { id: true },
+      })
+
+      const updated = await tx.resource.update({
+        where: { id: resourceId },
+        data: {
+          artImageId: artImage.id,
+          imagePath: null,
+        },
+        select: resourceGallerySelect,
+      })
+
+      return { artImageId: artImage.id, resource: updated }
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: 'Resource preview uploaded and attached.',
+      data: result,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to upload Resource preview.',
+      data: null,
+      statusCode,
+    }
+  }
+})

--- a/server/api/resources/[id]/preview-job/[jobId].get.ts
+++ b/server/api/resources/[id]/preview-job/[jobId].get.ts
@@ -1,0 +1,88 @@
+// /server/api/resources/[id]/preview-job/[jobId].get.ts
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireMachineUser } from '~/server/utils/authGuard'
+import { parseArtJobPayload } from '~/server/utils/artJobPayload'
+import { resourceGallerySelect } from '../../gallery'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const resourceId = Number(getRouterParam(event, 'id'))
+    const jobId = Number(getRouterParam(event, 'jobId'))
+
+    if (!Number.isInteger(resourceId) || resourceId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid Resource ID.' })
+    }
+
+    if (!Number.isInteger(jobId) || jobId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid ArtJob ID.' })
+    }
+
+    const auth = await requireMachineUser(event)
+    const job = await prisma.artJob.findUnique({ where: { id: jobId } })
+
+    if (!job) {
+      throw createError({ statusCode: 404, message: 'Preview ArtJob not found.' })
+    }
+
+    if (!auth.isAdmin && job.userId !== auth.user.id) {
+      throw createError({
+        statusCode: 403,
+        message: 'You do not have permission to inspect this preview ArtJob.',
+      })
+    }
+
+    const payload = parseArtJobPayload(job.payload)
+    const previewResourceId = Number(payload.previewResourceId)
+
+    if (previewResourceId !== resourceId) {
+      throw createError({
+        statusCode: 409,
+        message: 'This ArtJob does not belong to the requested Resource preview.',
+      })
+    }
+
+    let resource = null
+
+    if (job.status === 'DONE' && job.artImageId) {
+      resource = await prisma.resource.update({
+        where: { id: resourceId },
+        data: {
+          artImageId: job.artImageId,
+          imagePath: null,
+        },
+        select: resourceGallerySelect,
+      })
+    }
+
+    return {
+      success: true,
+      message:
+        job.status === 'DONE' && resource
+          ? 'Resource preview attached.'
+          : `Preview ArtJob is ${job.status}.`,
+      data: {
+        job: {
+          id: job.id,
+          status: job.status,
+          artImageId: job.artImageId,
+          error: job.error,
+        },
+        resource,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to inspect Resource preview job.',
+      data: null,
+      statusCode,
+    }
+  }
+})

--- a/server/api/resources/gallery.ts
+++ b/server/api/resources/gallery.ts
@@ -1,0 +1,75 @@
+import type { Prisma } from '~/prisma/generated/prisma/client'
+
+export const resourcePreviewArtImageSelect = {
+  id: true,
+  imagePath: true,
+  path: true,
+  thumbnailPath: true,
+  fileName: true,
+  fileType: true,
+  isMature: true,
+} satisfies Prisma.ArtImageSelect
+
+export const resourceGallerySelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  name: true,
+  customLabel: true,
+  MediaPath: true,
+  customUrl: true,
+  civitaiUrl: true,
+  huggingUrl: true,
+  localPath: true,
+  description: true,
+  isMature: true,
+  resourceType: true,
+  userId: true,
+  artImageId: true,
+  generation: true,
+  supportedServer: true,
+  isPublic: true,
+  isActive: true,
+  artPrompt: true,
+  triggerWords: true,
+  defaultTrigger: true,
+  hash: true,
+  previewImageUrl: true,
+  imagePath: true,
+  slug: true,
+  ArtImage: {
+    select: resourcePreviewArtImageSelect,
+  },
+  _count: {
+    select: {
+      ArtImages: true,
+      UsedInImages: true,
+    },
+  },
+} satisfies Prisma.ResourceSelect
+
+export type ResourceGalleryRecord = Prisma.ResourceGetPayload<{
+  select: typeof resourceGallerySelect
+}>
+
+export function resourceGalleryWhere(options: {
+  userId: number | null
+  isAdmin: boolean
+  showMature: boolean
+}): Prisma.ResourceWhereInput {
+  const where: Prisma.ResourceWhereInput = {
+    isActive: true,
+  }
+
+  if (!options.isAdmin) {
+    where.OR = options.userId
+      ? [{ isPublic: true }, { userId: options.userId }]
+      : [{ isPublic: true }]
+  }
+
+  if (!options.isAdmin && !options.showMature) {
+    where.isMature = false
+  }
+
+  return where
+}

--- a/server/api/resources/index.get.ts
+++ b/server/api/resources/index.get.ts
@@ -2,12 +2,25 @@
 import { defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
-import type { Resource } from '~/prisma/generated/prisma/client'
+import { getOptionalApiUser } from '../../utils/authGuard'
+import {
+  resourceGallerySelect,
+  resourceGalleryWhere,
+  type ResourceGalleryRecord,
+} from './gallery'
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
   try {
-    // Fetch all resources from the database
-    const data = await prisma.resource.findMany()
+    const auth = await getOptionalApiUser(event)
+    const data = await prisma.resource.findMany({
+      where: resourceGalleryWhere({
+        userId: auth?.user.id ?? null,
+        isAdmin: auth?.isAdmin ?? false,
+        showMature: Boolean(auth?.user.showMature),
+      }),
+      select: resourceGallerySelect,
+      orderBy: [{ customLabel: 'asc' }, { name: 'asc' }],
+    })
 
     return {
       success: true,
@@ -16,7 +29,6 @@ export default defineEventHandler(async () => {
       statusCode: 200,
     }
   } catch (error: unknown) {
-    // Handle error using the centralized error handler
     const { success, message, statusCode } = errorHandler(error)
     return {
       success,
@@ -27,7 +39,10 @@ export default defineEventHandler(async () => {
   }
 })
 
-// Function to fetch all Resources, to be used elsewhere if needed
-export async function fetchAllResources(): Promise<Resource[]> {
-  return await prisma.resource.findMany()
+export async function fetchAllResources(): Promise<ResourceGalleryRecord[]> {
+  return await prisma.resource.findMany({
+    where: { isActive: true },
+    select: resourceGallerySelect,
+    orderBy: [{ customLabel: 'asc' }, { name: 'asc' }],
+  })
 }

--- a/stores/resourceGalleryStore.ts
+++ b/stores/resourceGalleryStore.ts
@@ -1,0 +1,221 @@
+// /stores/resourceGalleryStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { ArtImage, Resource } from '~/prisma/generated/prisma/client'
+import { handleError, performFetch } from '@/stores/utils'
+
+export type ResourcePreviewArtImage = Pick<
+  ArtImage,
+  | 'id'
+  | 'imagePath'
+  | 'path'
+  | 'thumbnailPath'
+  | 'fileName'
+  | 'fileType'
+  | 'isMature'
+>
+
+export type ResourceGalleryRecord = Resource & {
+  ArtImage?: ResourcePreviewArtImage | null
+  _count?: {
+    ArtImages: number
+    UsedInImages: number
+  }
+}
+
+type PreviewJob = {
+  id: number
+  status: 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED'
+  artImageId?: number | null
+  error?: string | null
+}
+
+type PreviewQueueResult = {
+  jobId: number
+  resourceId: number
+  status: PreviewJob['status']
+}
+
+type PreviewStatusResult = {
+  job: PreviewJob
+  resource: ResourceGalleryRecord | null
+}
+
+export const useResourceGalleryStore = defineStore('resourceGalleryStore', () => {
+  const resources = ref<ResourceGalleryRecord[]>([])
+  const isLoading = ref(false)
+  const error = ref('')
+  const previewJobs = ref<Record<number, PreviewJob>>({})
+
+  function replaceResource(resource: ResourceGalleryRecord): void {
+    const index = resources.value.findIndex((entry) => entry.id === resource.id)
+
+    if (index === -1) {
+      resources.value.push(resource)
+    } else {
+      resources.value[index] = resource
+    }
+  }
+
+  async function loadResources(): Promise<ResourceGalleryRecord[]> {
+    isLoading.value = true
+    error.value = ''
+
+    try {
+      const response = await performFetch<ResourceGalleryRecord[]>('/api/resources')
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to load Resources.')
+      }
+
+      resources.value = response.data
+      return resources.value
+    } catch (cause) {
+      error.value =
+        cause instanceof Error ? cause.message : 'Failed to load Resources.'
+      handleError(cause, 'loading Resource gallery')
+      return []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function getResource(id: number): Promise<ResourceGalleryRecord | null> {
+    try {
+      const response = await performFetch<ResourceGalleryRecord>(
+        `/api/resources/${id}`,
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to load Resource.')
+      }
+
+      replaceResource(response.data)
+      return response.data
+    } catch (cause) {
+      handleError(cause, `loading Resource ${id}`)
+      return null
+    }
+  }
+
+  async function queuePreview(id: number): Promise<PreviewQueueResult | null> {
+    try {
+      const response = await performFetch<PreviewQueueResult>(
+        `/api/resources/${id}/generate-preview`,
+        { method: 'POST' },
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to queue Resource preview.')
+      }
+
+      previewJobs.value[id] = {
+        id: response.data.jobId,
+        status: response.data.status,
+      }
+      return response.data
+    } catch (cause) {
+      handleError(cause, `queueing Resource ${id} preview`)
+      throw cause
+    }
+  }
+
+  async function refreshPreviewJob(
+    resourceId: number,
+    jobId: number,
+  ): Promise<PreviewStatusResult | null> {
+    try {
+      const response = await performFetch<PreviewStatusResult>(
+        `/api/resources/${resourceId}/preview-job/${jobId}`,
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to inspect preview job.')
+      }
+
+      previewJobs.value[resourceId] = response.data.job
+
+      if (response.data.resource) {
+        replaceResource(response.data.resource)
+      }
+
+      return response.data
+    } catch (cause) {
+      handleError(cause, `checking Resource ${resourceId} preview`)
+      return null
+    }
+  }
+
+  async function waitForPreview(
+    resourceId: number,
+    jobId: number,
+    attempts = 120,
+  ): Promise<ResourceGalleryRecord | null> {
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const result = await refreshPreviewJob(resourceId, jobId)
+
+      if (!result) return null
+      if (result.resource) return result.resource
+      if (result.job.status === 'FAILED' || result.job.status === 'CANCELLED') {
+        throw new Error(result.job.error || `Preview job ${result.job.status}.`)
+      }
+
+      await new Promise((resolve) => window.setTimeout(resolve, 2500))
+    }
+
+    throw new Error('Preview generation is still running. Check the ArtJob queue.')
+  }
+
+  async function generatePreview(
+    resourceId: number,
+  ): Promise<ResourceGalleryRecord | null> {
+    const queued = await queuePreview(resourceId)
+    if (!queued) return null
+    return await waitForPreview(resourceId, queued.jobId)
+  }
+
+  async function uploadPreview(input: {
+    resourceId: number
+    imageData: string
+    fileName: string
+    fileType?: string
+  }): Promise<ResourceGalleryRecord | null> {
+    try {
+      const response = await performFetch<{
+        artImageId: number
+        resource: ResourceGalleryRecord
+      }>(`/api/resources/${input.resourceId}/preview-image`, {
+        method: 'POST',
+        body: JSON.stringify({
+          imageData: input.imageData,
+          fileName: input.fileName,
+          fileType: input.fileType,
+        }),
+      })
+
+      if (!response.success || !response.data?.resource) {
+        throw new Error(response.message || 'Failed to upload Resource preview.')
+      }
+
+      replaceResource(response.data.resource)
+      return response.data.resource
+    } catch (cause) {
+      handleError(cause, `uploading Resource ${input.resourceId} preview`)
+      throw cause
+    }
+  }
+
+  return {
+    resources,
+    isLoading,
+    error,
+    previewJobs,
+    loadResources,
+    getResource,
+    queuePreview,
+    refreshPreviewJob,
+    waitForPreview,
+    generatePreview,
+    uploadPreview,
+  }
+})


### PR DESCRIPTION
## Summary

- finish ArtImage provenance wiring for checkpoint + LoRA Resources across queued completion, direct create, and patch connect/disconnect paths
- add a searchable Resource gallery with preview priority, trigger/base-model filters, and generation actions
- add hosted preview upload support for sibling model images
- add on-demand Resource preview ArtJobs with compatible checkpoint selection and automatic preview attachment
- register the Resource gallery in the Build channel
- add a dependency-free sibling preview uploader for LoRA and model catalog outputs

## Provenance

- `POST /api/art/image` accepts `checkpointResourceId` and `loraResourceIds`
- `PATCH /api/art/image/:id` supports LoRA connect, disconnect, and clear operations
- provenance name fallback now validates active Resource types before linking

## Resource previews

Priority is:

1. hosted/generated `Resource.ArtImage`
2. imported `previewImageUrl`
3. legacy `imagePath`
4. placeholder

`POST /api/resources/:id/generate-preview` queues an A1111 preview for compatible SD resources and records checkpoint/LoRA Resource IDs in the job payload. The gallery polls the preview job endpoint, which attaches the completed ArtImage to `Resource.artImageId`.

`upload_sibling_previews.py` detects `<stem>.preview.*`, `<stem>.*`, and `<filename>.preview.*` images, then uploads them through the hosted preview endpoint when the Resource has no higher-priority preview.

Closes #937
Closes #938