### PR TITLE
fix(art-styler): clear stale success banner on rejected file type

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1033,6 +1033,13 @@ function handleFileSelect(event: Event) {
 
   if (file) {
     if (!isAcceptedImageFile(file)) {
+      // Every other selection path in this component clears both messages
+      // together (see processUploadedFile/selectGalleryImage/selectStarterEntry
+      // below) so a stale banner never survives the next action. This
+      // rejection path only ever set errorMessage, so a leftover
+      // "Style applied!" success banner from a prior generation stayed on
+      // screen right alongside the new rejection error.
+      successMessage.value = ''
       errorMessage.value = 'Only PNG, JPEG, or WebP images are supported.'
     } else {
       processUploadedFile(file)
@@ -1052,6 +1059,9 @@ function handleDrop(event: DragEvent) {
   if (!file) return
 
   if (!isAcceptedImageFile(file)) {
+    // See handleFileSelect above: clear a stale success banner alongside
+    // the new error so the two don't render at the same time.
+    successMessage.value = ''
     errorMessage.value = 'Only PNG, JPEG, or WebP images are supported.'
     return
   }


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software) — lane 1, front-end polish

### What changed / what I produced
- `components/art/art-styler.vue`: the MIME-rejection branches in `handleFileSelect()` and `handleDrop()` only ever set `errorMessage`, never clearing a leftover `successMessage` from a prior generation. Added `successMessage.value = ''` to both, matching every other selection path in the file (`processUploadedFile`, `selectGalleryImage`, `selectStarterEntry`, `selectStyle`, `clearSelection`, `runStyleTransfer`, etc.) which already clear both messages together.

### How I verified
- `npx prettier --check components/art/art-styler.vue`: one pre-existing warning at line 1278, unrelated to this change and present identically on `main` (confirmed via stash/diff) — not a regression.
- `npx eslint` / `npx nuxi prepare`: fail in this sandbox due to missing `.nuxt`/`node_modules` (known limitation, same as prior lane-1 cycles) — relying on CI.

### Stakes
reversible

### Flags for Reviewer
- None — small, scoped, matches an established in-file pattern exactly.

### Kaizen suggestion
None filed this cycle — narrow, well-precedented fix.

### Notes for reviewer
Concrete failure scenario: user completes a style transfer (success banner shown), then drops/selects a non-PNG/JPEG/WebP file. The rejection error now shows without the stale "Style applied!" banner still on screen.


---
_Generated by [Claude Code](https://claude.ai/code/session_014zEe6njnBMKjyEHVimttHa)_