### PR TITLE
Load the complete canonical Facet catalog

### DIFF
--- a/server/api/challenges/variants.post.ts
+++ b/server/api/challenges/variants.post.ts
@@ -121,7 +121,6 @@ export default defineEventHandler(async (event) => {
         randomizableOnly: true,
         userId: auth.user.id,
         isAdmin: auth.user.Role === 'ADMIN' || auth.user.id === 1,
-        take: 1000,
       })
 
       for (const [placeholder, taxonomies] of Object.entries(

--- a/server/utils/facetCatalog.ts
+++ b/server/utils/facetCatalog.ts
@@ -108,6 +108,10 @@ export async function loadFacetCatalogEntries(options: {
   userId?: number
   isAdmin?: boolean
   search?: string
+  /**
+   * Optional page size for externally paginated consumers. Internal callers that
+   * omit `take` receive the complete matching catalog from `skip` onward.
+   */
   take?: number
   skip?: number
 } = {}): Promise<FacetCatalogEntry[]> {
@@ -234,7 +238,9 @@ export async function loadFacetCatalogEntries(options: {
     )
 
   const skip = Math.max(0, options.skip ?? 0)
-  const take = Math.min(1000, Math.max(1, options.take ?? 500))
+  if (options.take == null) return entries.slice(skip)
+
+  const take = Math.min(1000, Math.max(1, options.take))
   return entries.slice(skip, skip + take)
 }
 
@@ -249,7 +255,6 @@ export async function loadCharacterFacetCatalog(characterId: number) {
     includeMature: true,
     includeInactive: true,
     isAdmin: true,
-    take: 1000,
   })
   const entryById = new Map(entries.map((entry) => [entry.id, entry]))
 

--- a/stores/facetCatalogStore.ts
+++ b/stores/facetCatalogStore.ts
@@ -68,6 +68,19 @@ export type CharacterFacetAssignment = {
   source?: string
 }
 
+type FacetCatalogQuery = {
+  taxonomies?: FacetTaxonomy[]
+  includeInactive?: boolean
+  includeMature?: boolean
+  randomizableOnly?: boolean
+  search?: string
+  /** Page size. The store continues requesting pages until the result is complete. */
+  take?: number
+  skip?: number
+}
+
+const FACET_CATALOG_PAGE_SIZE = 1000
+
 export const CHARACTER_FIELD_TAXONOMIES: Record<string, FacetTaxonomy[]> = {
   genre: ['GENRE'],
   species: ['ANIMAL', 'SPECIES'],
@@ -79,15 +92,7 @@ export const CHARACTER_FIELD_TAXONOMIES: Record<string, FacetTaxonomy[]> = {
   role: ['ROLE'],
 }
 
-function toQuery(options: {
-  taxonomies?: FacetTaxonomy[]
-  includeInactive?: boolean
-  includeMature?: boolean
-  randomizableOnly?: boolean
-  search?: string
-  take?: number
-  skip?: number
-}): string {
+function toQuery(options: FacetCatalogQuery): string {
   const query = new URLSearchParams()
   if (options.taxonomies?.length) {
     query.set('taxonomy', options.taxonomies.join(','))
@@ -100,6 +105,34 @@ function toQuery(options: {
   if (options.skip != null) query.set('skip', String(options.skip))
   const value = query.toString()
   return value ? `?${value}` : ''
+}
+
+async function fetchAllCatalogPages(
+  options: FacetCatalogQuery,
+): Promise<FacetCatalogEntry[]> {
+  const pageSize = Math.min(
+    FACET_CATALOG_PAGE_SIZE,
+    Math.max(1, options.take ?? FACET_CATALOG_PAGE_SIZE),
+  )
+  let skip = Math.max(0, options.skip ?? 0)
+  const entriesById = new Map<number, FacetCatalogEntry>()
+
+  while (true) {
+    const response = await performFetch<FacetCatalogEntry[]>(
+      `/api/facets/catalog${toQuery({ ...options, take: pageSize, skip })}`,
+    )
+    if (!response.success) {
+      throw new Error(response.message || 'Failed to load canonical Facets.')
+    }
+
+    const page = response.data ?? []
+    for (const entry of page) entriesById.set(entry.id, entry)
+
+    if (page.length < pageSize) break
+    skip += page.length
+  }
+
+  return Array.from(entriesById.values())
 }
 
 function splitCharacterField(fieldKey: string, value: unknown): string[] {
@@ -165,7 +198,7 @@ export const useFacetCatalogStore = defineStore('facetCatalogStore', () => {
   })
 
   async function fetchCatalog(
-    options: Parameters<typeof toQuery>[0] = {},
+    options: FacetCatalogQuery = {},
     force = false,
   ): Promise<FacetCatalogEntry[]> {
     if (loaded.value && !force && !Object.keys(options).length) {
@@ -175,13 +208,7 @@ export const useFacetCatalogStore = defineStore('facetCatalogStore', () => {
     loading.value = true
     error.value = null
     try {
-      const response = await performFetch<FacetCatalogEntry[]>(
-        `/api/facets/catalog${toQuery({ take: 1000, ...options })}`,
-      )
-      if (!response.success) {
-        throw new Error(response.message || 'Failed to load canonical Facets.')
-      }
-      entries.value = response.data ?? []
+      entries.value = await fetchAllCatalogPages(options)
       loaded.value = true
       return entries.value
     } catch (cause) {

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -74,6 +74,7 @@ async function main(): Promise<void> {
   requireText(files.catalog, text.catalog, 'aliasFacetIds')
   requireText(files.catalog, text.catalog, 'lookupKey: { contains: normalizedSearch }')
   requireText(files.catalog, text.catalog, 'id: { in: aliasFacetIds }')
+  requireText(files.catalog, text.catalog, 'if (options.take == null)')
 
   requireText(files.characterGet, text.characterGet, 'getOptionalApiUser')
   requireText(files.characterPut, text.characterPut, 'requireApiUser')
@@ -94,6 +95,10 @@ async function main(): Promise<void> {
 
   requireText(files.catalogStore, text.catalogStore, 'CHARACTER_FIELD_TAXONOMIES')
   requireText(files.catalogStore, text.catalogStore, 'syncCharacterFacets')
+  requireText(files.catalogStore, text.catalogStore, 'fetchAllCatalogPages')
+  requireText(files.catalogStore, text.catalogStore, 'while (true)')
+  requireText(files.catalogStore, text.catalogStore, 'skip += page.length')
+  requireText(files.catalogStore, text.catalogStore, 'entriesById.set(entry.id, entry)')
   requireText(files.builderPlugin, text.builderPlugin, 'hydrateAdventureBuilder')
   requireText(files.builderPlugin, text.builderPlugin, 'patchGenerator')
   requireText(files.builderPlugin, text.builderPlugin, 'patchCharacterSave')
@@ -113,6 +118,7 @@ async function main(): Promise<void> {
 
   requireText(files.variants, text.variants, 'loadFacetCatalogEntries')
   requireText(files.variants, text.variants, 'prisma.reward.findMany')
+  forbidText(files.variants, text.variants, 'take: 1000')
   forbidText(files.variants, text.variants, 'prisma.dream.findMany')
   forbidText(files.variants, text.variants, 'dreamToRandomListItem')
 


### PR DESCRIPTION
## Root cause

Production contains 1,301 active canonical Facets, but the catalog API intentionally caps each response at 1,000 records. `facetCatalogStore` requested one 1,000-record page and treated it as the complete catalog, silently excluding the final taxonomies from Character Builder hydration, generator selection, and `randomStore`.

## Change

- treats the 1,000-record limit as a page size rather than a catalog size
- keeps requesting `/api/facets/catalog` with increasing `skip` values until a short final page is returned
- de-duplicates page results by Facet ID
- retains the API's bounded per-request maximum
- makes internal `loadFacetCatalogEntries()` calls complete by default when `take` is omitted
- removes the 1,000-record cap from Challenge variant Facet pools
- removes the unnecessary cap from CharacterFacet hydration
- extends the Facet cutover contract to require complete pagination and prohibit the Challenge cap from returning

## Result

The current 1,301-record production catalog is loaded in two bounded requests, so Species, Style, Theme, and the complete Quirk catalog are available to live Facet-backed consumers.