### PR TITLE
fix(model-builder): stop synchronous asset generation from persisting to a cancelled run

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -328,6 +328,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // Per-button spinner state for AI drafting: which item/field is in flight.
   const draftingField = ref<{ itemId: string; field: DraftField } | null>(null)
 
+  // Run ids cancelled via cancelRun, so a synchronous generateItemAsset call
+  // still in flight when the user cancels its run can tell "my run was
+  // cancelled" apart from "the user merely navigated to a different run"
+  // (findItem(itemId) alone can't distinguish those — both leave the item
+  // unreachable from the now-different state.run). See generateItemAsset.
+  const cancelledRunIds = new Set<string>()
+
   // --- display helpers ------------------------------------------------------
 
   function sourceLabel(record: SourceRecord | null): string {
@@ -842,6 +849,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   async function generateItemAsset(itemId: string): Promise<boolean> {
     const item = findItem(itemId)
     if (!item || !state.run) return false
+    const runId = state.run.id
 
     if (item.generation !== 'image') {
       // Non-image generation kinds (text, plan, video, 3d) are catalogued but
@@ -883,6 +891,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       if (!result.success || !result.data) {
         throw new Error(result.message || 'Generation failed.')
       }
+
+      // artStore.generateCurrentArt can take long enough for the user to
+      // cancel this exact run while it's rendering. Unlike draftText (which
+      // routes its result through updatePitch/Fields/Prompt's own fresh
+      // findItem lookup), this function has held only the original item
+      // reference since the top of the call, so it would otherwise persist a
+      // candidate — and pop a "Generated a candidate" success toast — for an
+      // item whose run the user just told us to abandon. Checking cancelledRunIds
+      // (rather than just re-resolving via findItem) also avoids the false
+      // positive of the user having merely switched to a different, still-active
+      // run, where the candidate should still be saved.
+      if (cancelledRunIds.has(runId)) return false
 
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
@@ -1475,6 +1495,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         setStatus('error', response.message || 'Failed to cancel run.')
         return
       }
+      // Record the cancellation so a synchronous generateItemAsset call still
+      // in flight for one of this run's items can tell it was cancelled (see
+      // generateItemAsset / cancelledRunIds above).
+      cancelledRunIds.add(runId)
       // Stop any in-flight async art-generation polls (generateItemAssetAsync)
       // for this run's items. pollAsyncArtJob's while loop keys off
       // item.artJobId === jobId, so clearing it makes the loop exit at its


### PR DESCRIPTION
## Summary
- `generateItemAsset` in `stores/modelBuilderStore.ts` (the "Generate candidate" button — the synchronous path, distinct from the async job-queue path fixed in #735) held only its original `BuildItem` object reference across the `artStore.generateCurrentArt` await.
- If the user cancelled that item's run while the render was still in flight (e.g. click "Generate candidate", then switch to Run history and cancel the currently-open run before the render resolves), the promise still resolved and unconditionally wrote the result to the server — `POST .../artifacts` + `PATCH .../items/:id` — for an item belonging to the now-cancelled run, and popped a misleading "Generated a candidate" success toast for work the user had just abandoned.
- This is the same failure mode `cancelRun`'s async-poll fix already prevents for `generateItemAssetAsync` (clearing `item.artJobId`/`item.queueState` so `pollAsyncArtJob`'s loop exits), just on the sibling synchronous code path, which had no equivalent guard.
- A plain `findItem(itemId)` re-check after the await isn't sufficient here: it can't distinguish "this run was cancelled" from "the user merely navigated to a different, still-active run" — both leave the item unreachable from the (now different) `state.run`, but only the first case should discard the candidate.

## Fix
Added a small `cancelledRunIds: Set<string>` to the store. `cancelRun` records the cancelled run's id; `generateItemAsset` captures its run's id up front and, once the render resolves, bails out (no artifact POST, no item PATCH, no success toast) if that specific run was cancelled in the meantime — while still persisting normally if the user simply switched to a different active run.

## Verification
- `npx prettier --check stores/modelBuilderStore.ts` — flags pre-existing drift on lines untouched by this change (confirmed via `git stash` comparison against the unmodified file, which shows the identical drift); the new/changed lines are prettier-clean.
- `npx eslint` and the project's `npm run test` (`vue-tsc --noEmit`) could not run in this sandbox — no `node_modules` present and `npm install`/`nuxt prepare` fail here (matches prior cycles' documented sandbox limitations). Relying on CI for lint/typecheck.

## Test plan
- [ ] CI lint/typecheck/build pass
- [ ] Manual: start a model-builder run, click "Generate candidate" on an image item, then cancel that run from Run history before the render finishes — confirm no success toast appears and no artifact/item PATCH lands for the cancelled item.
- [ ] Manual: same sequence, but switch to a *different* active run instead of cancelling — confirm the candidate still saves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LhLoohRmwAw5B9VMTxNU36)_