### PR TITLE
Run animation catalog contract in CI

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Animation attempt Component conventions contract
         run: npm run test:animation-component-attempts
 
+      - name: Animation catalog contract
+        run: npm run test:animation-catalog
+
       - name: WonderLab learning and control fixtures contract
         run: npx tsx utils/scripts/verifyWonderLabLearningControlFixtures.ts
 


### PR DESCRIPTION
## Summary
- add the existing `test:animation-catalog` verifier to the Contract Tests workflow
- run it beside the animation Component-attempt contract so catalog, id, surface, and `generationSafe` regressions fail before merge

## Verification
- branch diff is limited to `.github/workflows/contract-tests.yml`
- the PR workflow is the verification gate for the newly wired command

## Stakes
Reversible CI-only change. No runtime behavior, schema, deployment, secrets, billing, or production data changes.

## Flags for Reviewer
None.

## Conductor
`animation-manager/t-014`

## Kaizen suggestion
When a standalone `test:*` script guards production invariants, add an explicit CI-wiring check or inventory so future verifiers cannot silently remain local-only.