### PR TITLE
Make Facet authoring create canonical profiles

### DIFF
--- a/server/api/facets/[id].patch.ts
+++ b/server/api/facets/[id].patch.ts
@@ -10,6 +10,10 @@ import {
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+import {
+  buildFacetProfileCreateData,
+  buildFacetProfileUpdateData,
+} from '~/server/utils/facetProfileInput'
 import { assertFacetRelationsAttachable } from './relations'
 
 type FacetPatchBody = Record<string, unknown>
@@ -62,7 +66,7 @@ export default defineEventHandler(async (event) => {
     const auth = await requireApiUser(event)
     const existing = await prisma.facet.findUnique({
       where: { id },
-      select: { id: true, userId: true, slug: true },
+      select: { id: true, userId: true, slug: true, title: true, kind: true },
     })
 
     if (!existing) {
@@ -78,6 +82,8 @@ export default defineEventHandler(async (event) => {
 
     const body = await readBody<FacetPatchBody>(event)
     const data: Prisma.FacetUncheckedUpdateInput = {}
+    let nextTitle = existing.title
+    let nextKind = existing.kind
 
     if (body.title !== undefined) {
       const title = optionalText(body.title)
@@ -88,6 +94,7 @@ export default defineEventHandler(async (event) => {
         })
       }
       data.title = title
+      nextTitle = title
     }
     if (body.kind !== undefined) {
       if (!facetKinds.includes(body.kind as FacetKind)) {
@@ -97,6 +104,7 @@ export default defineEventHandler(async (event) => {
         })
       }
       data.kind = body.kind as FacetKind
+      nextKind = body.kind as FacetKind
     }
     if (body.description !== undefined)
       data.description = optionalText(body.description)
@@ -141,6 +149,14 @@ export default defineEventHandler(async (event) => {
 
     const nextAliases =
       body.aliases !== undefined ? normalizeAliases(body.aliases) : null
+    const profileCreateData = buildFacetProfileCreateData(body, {
+      title: nextTitle,
+      kind: nextKind,
+    })
+    const profileUpdateData = buildFacetProfileUpdateData(body, {
+      title: nextTitle,
+      kind: nextKind,
+    })
 
     const updated = await prisma.$transaction(async (tx) => {
       // Restoring an archived Facet must also revive its aliases — archive
@@ -225,11 +241,22 @@ export default defineEventHandler(async (event) => {
         })
       }
 
-      return tx.facet.update({
+      const facet = await tx.facet.update({
         where: { id },
         data,
         select: facetSummarySelect,
       })
+
+      await tx.facetProfile.upsert({
+        where: { facetId: id },
+        create: {
+          facetId: id,
+          ...profileCreateData,
+        },
+        update: profileUpdateData,
+      })
+
+      return facet
     })
 
     const [facet] = await hydrateFacetSummaries([updated])

--- a/server/api/facets/index.post.ts
+++ b/server/api/facets/index.post.ts
@@ -14,12 +14,23 @@ import {
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+import { buildFacetProfileCreateData } from '~/server/utils/facetProfileInput'
 import { assertFacetRelationsAttachable } from './relations'
 
 type FacetCreateBody = {
   title?: unknown
   slug?: unknown
   kind?: unknown
+  taxonomy?: unknown
+  canonicalValue?: unknown
+  groupKey?: unknown
+  groupLabel?: unknown
+  sortOrder?: unknown
+  isRandomizable?: unknown
+  randomWeight?: unknown
+  artRequired?: unknown
+  sourceRank?: unknown
+  metadata?: unknown
   description?: unknown
   flavorText?: unknown
   examples?: unknown
@@ -105,6 +116,7 @@ export default defineEventHandler(async (event) => {
     )
       ? (body.creationSource as CreationSource)
       : 'HUMAN'
+    const profileData = buildFacetProfileCreateData(body, { title, kind })
 
     const artImageId = positiveId(body.artImageId)
     const artCollectionId = positiveId(body.artCollectionId)
@@ -151,6 +163,13 @@ export default defineEventHandler(async (event) => {
       const facet = await tx.facet.create({
         data,
         select: facetSummarySelect,
+      })
+
+      await tx.facetProfile.create({
+        data: {
+          facetId: facet.id,
+          ...profileData,
+        },
       })
 
       await tx.facetAlias.createMany({

--- a/server/utils/facetProfileInput.ts
+++ b/server/utils/facetProfileInput.ts
@@ -1,0 +1,155 @@
+// /server/utils/facetProfileInput.ts
+import { createError } from 'h3'
+import type { FacetKind } from '~/prisma/generated/prisma/client'
+import {
+  FACET_TAXONOMIES,
+  type FacetTaxonomy,
+} from '~/server/utils/facetCatalog'
+
+export type FacetProfileInput = Record<string, unknown>
+
+export type FacetProfileData = {
+  taxonomy: FacetTaxonomy
+  canonicalValue: string
+  groupKey: string | null
+  groupLabel: string | null
+  sortOrder: number
+  isRandomizable: boolean
+  randomWeight: number
+  artRequired: boolean
+  sourceRank: number
+  metadata: string | null
+}
+
+function optionalText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function finiteNumber(
+  value: unknown,
+  fallback: number,
+  options: { min?: number; integer?: boolean } = {},
+): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return fallback
+  const normalized = options.integer ? Math.trunc(parsed) : parsed
+  return options.min != null && normalized < options.min
+    ? options.min
+    : normalized
+}
+
+function taxonomyFromKind(kind: FacetKind): FacetTaxonomy {
+  return FACET_TAXONOMIES.includes(kind as FacetTaxonomy)
+    ? (kind as FacetTaxonomy)
+    : 'OTHER'
+}
+
+export function normalizeFacetTaxonomy(
+  value: unknown,
+  fallbackKind: FacetKind,
+): FacetTaxonomy {
+  if (value == null || value === '') return taxonomyFromKind(fallbackKind)
+
+  const normalized = String(value).trim().toUpperCase()
+  if (!FACET_TAXONOMIES.includes(normalized as FacetTaxonomy)) {
+    throw createError({
+      statusCode: 400,
+      message: `Invalid Facet taxonomy. Expected one of: ${FACET_TAXONOMIES.join(', ')}.`,
+    })
+  }
+
+  return normalized as FacetTaxonomy
+}
+
+function normalizeMetadata(value: unknown): string | null {
+  if (value == null || value === '') return null
+
+  if (typeof value === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(value)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Metadata must be a JSON object.')
+      }
+      return JSON.stringify(parsed)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: 'Facet metadata must be a valid JSON object.',
+      })
+    }
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return JSON.stringify(value)
+  }
+
+  throw createError({
+    statusCode: 400,
+    message: 'Facet metadata must be an object or JSON object string.',
+  })
+}
+
+export function buildFacetProfileCreateData(
+  body: FacetProfileInput,
+  defaults: { title: string; kind: FacetKind },
+): FacetProfileData {
+  const taxonomy = normalizeFacetTaxonomy(body.taxonomy, defaults.kind)
+
+  return {
+    taxonomy,
+    canonicalValue: optionalText(body.canonicalValue) ?? defaults.title,
+    groupKey: optionalText(body.groupKey),
+    groupLabel: optionalText(body.groupLabel),
+    sortOrder: finiteNumber(body.sortOrder, 0, { integer: true }),
+    isRandomizable:
+      typeof body.isRandomizable === 'boolean' ? body.isRandomizable : true,
+    randomWeight: finiteNumber(body.randomWeight, 1, { min: 0 }),
+    artRequired:
+      typeof body.artRequired === 'boolean'
+        ? body.artRequired
+        : taxonomy !== 'COLOR',
+    sourceRank: finiteNumber(body.sourceRank, 5, {
+      min: 0,
+      integer: true,
+    }),
+    metadata: normalizeMetadata(body.metadata),
+  }
+}
+
+export function buildFacetProfileUpdateData(
+  body: FacetProfileInput,
+  defaults: { title: string; kind: FacetKind },
+): Partial<FacetProfileData> {
+  const data: Partial<FacetProfileData> = {}
+
+  if (body.taxonomy !== undefined || body.kind !== undefined) {
+    data.taxonomy = normalizeFacetTaxonomy(body.taxonomy, defaults.kind)
+  }
+  if (body.canonicalValue !== undefined || body.title !== undefined) {
+    data.canonicalValue = optionalText(body.canonicalValue) ?? defaults.title
+  }
+  if (body.groupKey !== undefined) data.groupKey = optionalText(body.groupKey)
+  if (body.groupLabel !== undefined)
+    data.groupLabel = optionalText(body.groupLabel)
+  if (body.sortOrder !== undefined) {
+    data.sortOrder = finiteNumber(body.sortOrder, 0, { integer: true })
+  }
+  if (typeof body.isRandomizable === 'boolean') {
+    data.isRandomizable = body.isRandomizable
+  }
+  if (body.randomWeight !== undefined) {
+    data.randomWeight = finiteNumber(body.randomWeight, 1, { min: 0 })
+  }
+  if (typeof body.artRequired === 'boolean') {
+    data.artRequired = body.artRequired
+  }
+  if (body.sourceRank !== undefined) {
+    data.sourceRank = finiteNumber(body.sourceRank, 5, {
+      min: 0,
+      integer: true,
+    })
+  }
+  if (body.metadata !== undefined) data.metadata = normalizeMetadata(body.metadata)
+
+  return data
+}

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -27,6 +27,9 @@ async function main(): Promise<void> {
       'prisma/migrations/20260725113000_facet_catalog_cutover/migration.sql',
     catalog: 'server/utils/facetCatalog.ts',
     catalogRoute: 'server/api/facets/catalog.get.ts',
+    facetCreate: 'server/api/facets/index.post.ts',
+    facetPatch: 'server/api/facets/[id].patch.ts',
+    profileInput: 'server/utils/facetProfileInput.ts',
     characterGet: 'server/api/characters/[id]/facets.get.ts',
     characterPut: 'server/api/characters/[id]/facets.put.ts',
     seed: 'utils/scripts/seedFacetCatalog.ts',
@@ -75,6 +78,18 @@ async function main(): Promise<void> {
   requireText(files.catalog, text.catalog, 'lookupKey: { contains: normalizedSearch }')
   requireText(files.catalog, text.catalog, 'id: { in: aliasFacetIds }')
   requireText(files.catalog, text.catalog, 'if (options.take == null)')
+
+  requireText(files.profileInput, text.profileInput, 'normalizeFacetTaxonomy')
+  requireText(files.profileInput, text.profileInput, 'buildFacetProfileCreateData')
+  requireText(files.profileInput, text.profileInput, 'buildFacetProfileUpdateData')
+  requireText(files.profileInput, text.profileInput, "taxonomy !== 'COLOR'")
+  requireText(files.profileInput, text.profileInput, 'Facet metadata must be a valid JSON object.')
+  requireText(files.facetCreate, text.facetCreate, 'buildFacetProfileCreateData')
+  requireText(files.facetCreate, text.facetCreate, 'tx.facetProfile.create')
+  requireText(files.facetCreate, text.facetCreate, 'facetId: facet.id')
+  requireText(files.facetPatch, text.facetPatch, 'buildFacetProfileUpdateData')
+  requireText(files.facetPatch, text.facetPatch, 'tx.facetProfile.upsert')
+  requireText(files.facetPatch, text.facetPatch, 'where: { facetId: id }')
 
   requireText(files.characterGet, text.characterGet, 'getOptionalApiUser')
   requireText(files.characterPut, text.characterPut, 'requireApiUser')


### PR DESCRIPTION
Superseded by PR #968, which applies the same already-validated transactional FacetProfile authoring change on top of current `main` after the production build hotfix.