### PR TITLE
Stop Resource gallery from bundling Prisma runtime

### DIFF
--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -1,13 +1,18 @@
 <!-- /components/resources/resource-gallery.vue -->
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { ResourceType } from '~/prisma/generated/prisma/client'
 import {
   useResourceGalleryStore,
   type ResourceGalleryRecord,
 } from '@/stores/resourceGalleryStore'
 import { useArtStore } from '@/stores/artStore'
 import { useNavStore } from '@/stores/navStore'
+
+const RESOURCE_TYPE = {
+  CHECKPOINT: 'CHECKPOINT',
+  LORA: 'LORA',
+  LYCORIS: 'LYCORIS',
+} as const
 
 const resourceGalleryStore = useResourceGalleryStore()
 const artStore = useArtStore()
@@ -102,14 +107,14 @@ function appendPrompt(base: string, addition: string): string {
 function addToGeneration(resource: ResourceGalleryRecord): void {
   const engineName = resourceEngineName(resource)
 
-  if (resource.resourceType === ResourceType.CHECKPOINT) {
+  if (resource.resourceType === RESOURCE_TYPE.CHECKPOINT) {
     artStore.setArtForm({
       checkpoint: engineName,
       checkpointResourceId: resource.id,
     })
   } else if (
-    resource.resourceType === ResourceType.LORA ||
-    resource.resourceType === ResourceType.LYCORIS
+    resource.resourceType === RESOURCE_TYPE.LORA ||
+    resource.resourceType === RESOURCE_TYPE.LYCORIS
   ) {
     const currentIds = artStore.artForm.loraResourceIds ?? []
     const loraResourceIds = currentIds.includes(resource.id)
@@ -138,10 +143,10 @@ function addToGeneration(resource: ResourceGalleryRecord): void {
 }
 
 function startGeneration(resource: ResourceGalleryRecord): void {
-  const isCheckpoint = resource.resourceType === ResourceType.CHECKPOINT
+  const isCheckpoint = resource.resourceType === RESOURCE_TYPE.CHECKPOINT
   const isLora =
-    resource.resourceType === ResourceType.LORA ||
-    resource.resourceType === ResourceType.LYCORIS
+    resource.resourceType === RESOURCE_TYPE.LORA ||
+    resource.resourceType === RESOURCE_TYPE.LYCORIS
 
   artStore.setArtForm({
     promptString: triggerText(resource) || resourceLabel(resource),


### PR DESCRIPTION
## Production failure

Every production deployment since Resource gallery PR #961 has failed during the Nuxt client build. `components/resources/resource-gallery.vue` imported the runtime `ResourceType` enum from `~/prisma/generated/prisma/client`, which caused Vite to bundle `@prisma/client/runtime/client.mjs` for the browser. Rollup then failed on Node-only exports such as `webcrypto`.

## Fix

- removes the Prisma client runtime import from the Vue component
- uses a small local `as const` set for the three Resource type comparisons needed by the UI
- preserves all Resource gallery behavior and API values

## Evidence

The production build failed with:

`@prisma/client/runtime/client.mjs: "webcrypto" is not exported by "__vite-browser-external"`

This is a client-bundle-only correction with no schema or database changes.