### PR TITLE
Upgrade the Facet Library to canonical profiles

### DIFF
--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -1,6 +1,6 @@
 <!-- /components/facets/facet-manager.vue -->
 <template>
-  <section class="mx-auto w-full max-w-6xl space-y-4 p-4">
+  <section class="mx-auto w-full max-w-7xl space-y-4 p-4">
     <header
       class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
     >
@@ -8,8 +8,8 @@
       <div class="min-w-0 flex-1">
         <h1 class="text-xl font-black">Facet Library</h1>
         <p class="text-sm text-base-content/60">
-          The reusable flavor shared by Dreams, Scenarios, and Art. Aliases
-          resolve to one canonical Facet.
+          Canonical reusable concepts for Characters, Dreams, Scenarios, Art,
+          and random generation. Aliases resolve to one record.
         </p>
       </div>
       <span
@@ -24,29 +24,21 @@
         v-model="search"
         type="search"
         class="input input-bordered input-sm w-full max-w-xs rounded-xl bg-base-200"
-        placeholder="Search title, slug, or alias..."
+        placeholder="Search title, alias, taxonomy, or group..."
       />
-      <div class="flex flex-wrap gap-1">
-        <button
-          type="button"
-          class="btn btn-xs rounded-xl"
-          :class="kindFilter === null ? 'btn-secondary' : 'btn-ghost'"
-          @click="kindFilter = null"
+      <select
+        v-model="taxonomyFilter"
+        class="select select-bordered select-sm rounded-xl"
+      >
+        <option :value="null">All taxonomies</option>
+        <option
+          v-for="taxonomy in facetTaxonomies"
+          :key="taxonomy"
+          :value="taxonomy"
         >
-          All
-        </button>
-        <button
-          v-for="kind in facetKinds"
-          :key="kind"
-          type="button"
-          class="btn btn-xs rounded-xl"
-          :class="kindFilter === kind ? 'btn-secondary' : 'btn-ghost'"
-          @click="kindFilter = kindFilter === kind ? null : kind"
-        >
-          {{ kindLabel(kind) }}
-          <span class="opacity-50">{{ kindCounts[kind] || 0 }}</span>
-        </button>
-      </div>
+          {{ taxonomyLabel(taxonomy) }} ({{ taxonomyCounts[taxonomy] || 0 }})
+        </option>
+      </select>
       <label
         class="ml-auto flex items-center gap-2 text-xs text-base-content/60"
       >
@@ -67,37 +59,107 @@
         class="cursor-pointer px-4 py-3 text-sm font-bold text-base-content/70"
         @click.prevent="createOpen = !createOpen"
       >
-        + Create a new Facet
+        + Create a canonical Facet
       </summary>
-      <div class="grid gap-2 border-t border-base-300 p-4 sm:grid-cols-2">
-        <input
-          v-model="newTitle"
-          type="text"
-          class="input input-bordered input-sm rounded-xl"
-          placeholder="Canonical title, e.g. CowCore"
-        />
-        <select
-          v-model="newKind"
-          class="select select-bordered select-sm rounded-xl"
-        >
-          <option v-for="kind in facetKinds" :key="kind" :value="kind">
-            {{ kindLabel(kind) }}
-          </option>
-        </select>
-        <input
-          v-model="newAliases"
-          type="text"
-          class="input input-bordered input-sm rounded-xl sm:col-span-2"
-          placeholder="Aliases separated by commas, e.g. cow, cows"
-        />
-        <textarea
-          v-model="newDescription"
-          class="textarea textarea-bordered min-h-16 rounded-xl sm:col-span-2"
-          placeholder="What this facet means (optional)..."
-        />
+      <div class="grid gap-3 border-t border-base-300 p-4 sm:grid-cols-2 xl:grid-cols-4">
+        <label class="form-control xl:col-span-2">
+          <span class="label-text text-xs">Canonical title</span>
+          <input
+            v-model="newTitle"
+            type="text"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="CowCore"
+          />
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs">Taxonomy</span>
+          <select
+            v-model="newTaxonomy"
+            class="select select-bordered select-sm rounded-xl"
+          >
+            <option
+              v-for="taxonomy in facetTaxonomies"
+              :key="taxonomy"
+              :value="taxonomy"
+            >
+              {{ taxonomyLabel(taxonomy) }}
+            </option>
+          </select>
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs">Random weight</span>
+          <input
+            v-model.number="newRandomWeight"
+            type="number"
+            min="0"
+            step="0.1"
+            class="input input-bordered input-sm rounded-xl"
+          />
+        </label>
+        <label class="form-control sm:col-span-2 xl:col-span-4">
+          <span class="label-text text-xs">Aliases</span>
+          <input
+            v-model="newAliases"
+            type="text"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="Aliases separated by commas"
+          />
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs">Group key</span>
+          <input
+            v-model="newGroupKey"
+            type="text"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="cosmic-species"
+          />
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs">Group label</span>
+          <input
+            v-model="newGroupLabel"
+            type="text"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="Cosmic Species"
+          />
+        </label>
+        <label class="form-control sm:col-span-2">
+          <span class="label-text text-xs">Description</span>
+          <textarea
+            v-model="newDescription"
+            class="textarea textarea-bordered min-h-20 rounded-xl"
+            placeholder="What this reusable concept means..."
+          />
+        </label>
+        <div class="flex flex-wrap items-center gap-5 text-xs sm:col-span-2 xl:col-span-4">
+          <label class="flex items-center gap-2">
+            <input
+              v-model="newIsRandomizable"
+              type="checkbox"
+              class="toggle toggle-secondary toggle-xs"
+            />
+            Available to randomizers
+          </label>
+          <label class="flex items-center gap-2">
+            <input
+              v-model="newArtRequired"
+              type="checkbox"
+              class="toggle toggle-accent toggle-xs"
+            />
+            Artwork expected
+          </label>
+          <label class="flex items-center gap-2">
+            <input
+              v-model="newIsPublic"
+              type="checkbox"
+              class="toggle toggle-primary toggle-xs"
+            />
+            Public
+          </label>
+        </div>
         <button
           type="button"
-          class="btn btn-secondary btn-sm rounded-xl sm:col-span-2"
+          class="btn btn-secondary btn-sm rounded-xl sm:col-span-2 xl:col-span-4"
           :disabled="!newTitle.trim() || facetStore.saving"
           @click="createFacet"
         >
@@ -106,7 +168,7 @@
             class="loading loading-spinner loading-xs"
           />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
-          Create Facet
+          Create canonical Facet
         </button>
       </div>
     </details>
@@ -125,9 +187,12 @@
       >
         <div class="flex items-start justify-between gap-2">
           <div class="min-w-0">
-            <div class="flex items-center gap-2">
-              <span class="badge badge-outline badge-xs shrink-0">
-                {{ kindLabel(facet.kind) }}
+            <div class="flex flex-wrap items-center gap-1">
+              <span class="badge badge-secondary badge-xs">
+                {{ taxonomyLabel(facet.taxonomy) }}
+              </span>
+              <span v-if="facet.groupLabel" class="badge badge-outline badge-xs">
+                {{ facet.groupLabel }}
               </span>
               <span v-if="!facet.isActive" class="badge badge-error badge-xs">
                 archived
@@ -144,12 +209,11 @@
           <button
             type="button"
             class="btn btn-ghost btn-xs rounded-xl"
+            :aria-label="editingId === facet.id ? 'Close editor' : `Edit ${facet.title}`"
             @click="toggleEdit(facet)"
           >
             <Icon
-              :name="
-                editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'
-              "
+              :name="editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'"
               class="size-4"
             />
           </button>
@@ -162,33 +226,88 @@
           {{ facet.description }}
         </p>
 
-        <div v-if="editingId === facet.id" class="mt-3 space-y-2">
+        <div
+          v-if="editingId !== facet.id"
+          class="mt-3 flex flex-wrap gap-1 text-[11px]"
+        >
+          <span class="badge badge-ghost badge-xs">
+            weight {{ facet.randomWeight }}
+          </span>
+          <span class="badge badge-ghost badge-xs">
+            {{ facet.isRandomizable ? 'randomizable' : 'manual only' }}
+          </span>
+          <span class="badge badge-ghost badge-xs">
+            {{ facet.artRequired ? 'art expected' : 'art optional' }}
+          </span>
+        </div>
+
+        <div v-if="editingId === facet.id" class="mt-3 grid gap-2 sm:grid-cols-2">
           <input
             v-model="editForm.title"
             type="text"
-            class="input input-bordered input-sm w-full rounded-xl"
+            class="input input-bordered input-sm rounded-xl sm:col-span-2"
             placeholder="Title"
           />
           <select
-            v-model="editForm.kind"
-            class="select select-bordered select-sm w-full rounded-xl"
+            v-model="editForm.taxonomy"
+            class="select select-bordered select-sm rounded-xl"
           >
-            <option v-for="kind in facetKinds" :key="kind" :value="kind">
-              {{ kindLabel(kind) }}
+            <option
+              v-for="taxonomy in facetTaxonomies"
+              :key="taxonomy"
+              :value="taxonomy"
+            >
+              {{ taxonomyLabel(taxonomy) }}
             </option>
           </select>
           <input
+            v-model.number="editForm.randomWeight"
+            type="number"
+            min="0"
+            step="0.1"
+            class="input input-bordered input-sm rounded-xl"
+            aria-label="Random weight"
+          />
+          <input
             v-model="editForm.aliases"
             type="text"
-            class="input input-bordered input-sm w-full rounded-xl"
+            class="input input-bordered input-sm rounded-xl sm:col-span-2"
             placeholder="Aliases, comma separated"
+          />
+          <input
+            v-model="editForm.groupKey"
+            type="text"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="Group key"
+          />
+          <input
+            v-model="editForm.groupLabel"
+            type="text"
+            class="input input-bordered input-sm rounded-xl"
+            placeholder="Group label"
           />
           <textarea
             v-model="editForm.description"
-            class="textarea textarea-bordered min-h-16 w-full rounded-xl"
+            class="textarea textarea-bordered min-h-20 rounded-xl sm:col-span-2"
             placeholder="Description"
           />
-          <div class="flex items-center gap-3 text-xs">
+          <div class="flex flex-wrap gap-4 text-xs sm:col-span-2">
+            <label class="flex items-center gap-1">
+              <input
+                v-model="editForm.isRandomizable"
+                type="checkbox"
+                class="toggle toggle-secondary toggle-xs"
+              />
+              Randomizable
+            </label>
+            <label class="flex items-center gap-1">
+              <input
+                v-model="editForm.artRequired"
+                type="checkbox"
+                class="toggle toggle-accent toggle-xs"
+              />
+              Art expected
+            </label>
             <label class="flex items-center gap-1">
               <input
                 v-model="editForm.isPublic"
@@ -206,7 +325,7 @@
               Mature
             </label>
           </div>
-          <div class="flex gap-2">
+          <div class="flex gap-2 sm:col-span-2">
             <button
               type="button"
               class="btn btn-secondary btn-sm flex-1 rounded-xl"
@@ -217,7 +336,7 @@
                 v-if="facetStore.saving"
                 class="loading loading-spinner loading-xs"
               />
-              Save
+              Save canonical profile
             </button>
             <button
               v-if="facet.isActive"
@@ -246,41 +365,57 @@
       v-if="!facetStore.loading && !filteredFacets.length"
       class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50"
     >
-      No facets match. Create one above to start the library.
+      No Facets match these filters.
     </p>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import type { FacetKind } from '~/prisma/generated/prisma/client'
 import { useFacetStore, type FacetWithAliases } from '@/stores/facetStore'
+import {
+  FACET_TAXONOMIES,
+  type FacetTaxonomy,
+} from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 
 const facetStore = useFacetStore()
+const facetTaxonomies = [...FACET_TAXONOMIES]
 
 const search = ref('')
-const kindFilter = ref<FacetKind | null>(null)
+const taxonomyFilter = ref<FacetTaxonomy | null>(null)
 const showArchived = ref(false)
 const errorMessage = ref('')
 const editingId = ref<number | null>(null)
 const createOpen = ref(false)
 
 const newTitle = ref('')
-const newKind = ref<FacetKind>('OTHER')
+const newTaxonomy = ref<FacetTaxonomy>('OTHER')
 const newAliases = ref('')
 const newDescription = ref('')
+const newGroupKey = ref('')
+const newGroupLabel = ref('')
+const newRandomWeight = ref(1)
+const newIsRandomizable = ref(true)
+const newArtRequired = ref(true)
+const newIsPublic = ref(true)
 
 const editForm = reactive({
   title: '',
-  kind: 'OTHER' as FacetKind,
+  taxonomy: 'OTHER' as FacetTaxonomy,
   aliases: '',
   description: '',
+  groupKey: '',
+  groupLabel: '',
+  randomWeight: 1,
+  isRandomizable: true,
+  artRequired: true,
   isPublic: true,
   isMature: false,
 })
 
-const facetKinds: FacetKind[] = [
+const broadKinds = new Set<FacetTaxonomy>([
   'GENRE',
   'ANIMAL',
   'COLOR',
@@ -291,16 +426,25 @@ const facetKinds: FacetKind[] = [
   'SETTING',
   'ART_DIRECTION',
   'OTHER',
-]
+])
+
+function kindForTaxonomy(taxonomy: FacetTaxonomy): FacetKind {
+  if (taxonomy === 'PROMPT_ENHANCEMENT') return 'ART_DIRECTION'
+  return broadKinds.has(taxonomy) ? (taxonomy as FacetKind) : 'OTHER'
+}
+
+watch(newTaxonomy, (taxonomy) => {
+  newArtRequired.value = taxonomy !== 'COLOR'
+})
 
 const visibleFacets = computed(() =>
   showArchived.value ? facetStore.facets : facetStore.activeFacets,
 )
 
-const kindCounts = computed(() => {
-  const counts: Partial<Record<FacetKind, number>> = {}
+const taxonomyCounts = computed(() => {
+  const counts: Partial<Record<FacetTaxonomy, number>> = {}
   for (const facet of visibleFacets.value) {
-    counts[facet.kind] = (counts[facet.kind] || 0) + 1
+    counts[facet.taxonomy] = (counts[facet.taxonomy] || 0) + 1
   }
   return counts
 })
@@ -308,9 +452,19 @@ const kindCounts = computed(() => {
 const filteredFacets = computed(() => {
   const needle = normalizeFacetLookupKey(search.value)
   return visibleFacets.value.filter((facet) => {
-    if (kindFilter.value && facet.kind !== kindFilter.value) return false
+    if (taxonomyFilter.value && facet.taxonomy !== taxonomyFilter.value) {
+      return false
+    }
     if (!needle) return true
-    const values = [facet.title, facet.slug, ...facet.aliases]
+    const values = [
+      facet.title,
+      facet.canonicalValue,
+      facet.slug,
+      facet.taxonomy,
+      facet.groupKey,
+      facet.groupLabel,
+      ...facet.aliases,
+    ]
     return values.some((value) =>
       normalizeFacetLookupKey(value || '').includes(needle),
     )
@@ -319,15 +473,15 @@ const filteredFacets = computed(() => {
 
 onMounted(async () => {
   try {
-    await facetStore.fetchFacets({ includeInactive: true })
+    await facetStore.fetchFacets({ includeInactive: true, includeMature: true })
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : 'Facets could not be loaded.'
   }
 })
 
-function kindLabel(kind: FacetKind): string {
-  return kind
+function taxonomyLabel(taxonomy: FacetTaxonomy): string {
+  return taxonomy
     .toLowerCase()
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (letter) => letter.toUpperCase())
@@ -347,12 +501,16 @@ function toggleEdit(facet: FacetWithAliases) {
   }
   editingId.value = facet.id
   editForm.title = facet.title
-  editForm.kind = facet.kind
-  // The canonical slug leads the alias list; only the extra aliases are editable.
+  editForm.taxonomy = facet.taxonomy
   editForm.aliases = facet.aliases
     .filter((alias) => alias !== facet.slug)
     .join(', ')
   editForm.description = facet.description || ''
+  editForm.groupKey = facet.groupKey || ''
+  editForm.groupLabel = facet.groupLabel || ''
+  editForm.randomWeight = facet.randomWeight
+  editForm.isRandomizable = facet.isRandomizable
+  editForm.artRequired = facet.artRequired
   editForm.isPublic = facet.isPublic
   editForm.isMature = facet.isMature
 }
@@ -362,15 +520,22 @@ async function createFacet() {
   try {
     await facetStore.createFacet({
       title: newTitle.value.trim(),
-      kind: newKind.value,
+      kind: kindForTaxonomy(newTaxonomy.value),
+      taxonomy: newTaxonomy.value,
       aliases: splitAliases(newAliases.value),
       description: newDescription.value.trim() || null,
-      isPublic: true,
+      groupKey: newGroupKey.value.trim() || null,
+      groupLabel: newGroupLabel.value.trim() || null,
+      randomWeight: Math.max(0, Number(newRandomWeight.value) || 0),
+      isRandomizable: newIsRandomizable.value,
+      artRequired: newArtRequired.value,
+      isPublic: newIsPublic.value,
     })
     newTitle.value = ''
     newAliases.value = ''
     newDescription.value = ''
-    newKind.value = 'OTHER'
+    newGroupKey.value = ''
+    newGroupLabel.value = ''
     createOpen.value = false
   } catch (error) {
     errorMessage.value =
@@ -383,9 +548,15 @@ async function saveEdit(id: number) {
   try {
     await facetStore.updateFacet(id, {
       title: editForm.title.trim(),
-      kind: editForm.kind,
+      kind: kindForTaxonomy(editForm.taxonomy),
+      taxonomy: editForm.taxonomy,
       aliases: splitAliases(editForm.aliases),
       description: editForm.description.trim() || null,
+      groupKey: editForm.groupKey.trim() || null,
+      groupLabel: editForm.groupLabel.trim() || null,
+      randomWeight: Math.max(0, Number(editForm.randomWeight) || 0),
+      isRandomizable: editForm.isRandomizable,
+      artRequired: editForm.artRequired,
       isPublic: editForm.isPublic,
       isMature: editForm.isMature,
     })

--- a/server/utils/facetAssignments.ts
+++ b/server/utils/facetAssignments.ts
@@ -3,6 +3,10 @@ import { createError } from 'h3'
 import type { Facet, FacetKind, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { resolveFacetAlias } from '~/server/utils/facetAliases'
+import {
+  FACET_TAXONOMIES,
+  type FacetTaxonomy,
+} from '~/server/utils/facetCatalog'
 
 export type FacetSummary = Pick<
   Facet,
@@ -20,6 +24,16 @@ export type FacetSummary = Pick<
   | 'isActive'
 > & {
   aliases: string[]
+  taxonomy: FacetTaxonomy
+  canonicalValue: string
+  groupKey: string | null
+  groupLabel: string | null
+  sortOrder: number
+  isRandomizable: boolean
+  randomWeight: number
+  artRequired: boolean
+  sourceRank: number
+  metadata: Record<string, unknown> | null
 }
 
 export const facetKinds: FacetKind[] = [
@@ -78,22 +92,47 @@ function normalizeKeys(value: unknown): string[] {
   )
 }
 
+function taxonomyFromKind(kind: FacetKind): FacetTaxonomy {
+  return FACET_TAXONOMIES.includes(kind as FacetTaxonomy)
+    ? (kind as FacetTaxonomy)
+    : 'OTHER'
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> | null {
+  if (!value) return null
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
 export async function hydrateFacetSummaries(
   facets: RawFacetSummary[],
 ): Promise<FacetSummary[]> {
   if (!facets.length) return []
 
-  const aliases = await prisma.facetAlias.findMany({
-    where: {
-      facetId: { in: facets.map((facet) => facet.id) },
-      isActive: true,
-    },
-    orderBy: [{ isCanonical: 'desc' }, { alias: 'asc' }],
-    select: {
-      facetId: true,
-      alias: true,
-    },
-  })
+  const facetIds = facets.map((facet) => facet.id)
+  const [aliases, profiles] = await Promise.all([
+    prisma.facetAlias.findMany({
+      where: {
+        facetId: { in: facetIds },
+        isActive: true,
+      },
+      orderBy: [{ isCanonical: 'desc' }, { alias: 'asc' }],
+      select: {
+        facetId: true,
+        alias: true,
+      },
+    }),
+    prisma.facetProfile.findMany({
+      where: { facetId: { in: facetIds } },
+    }),
+  ])
 
   const aliasesByFacet = new Map<number, string[]>()
   for (const alias of aliases) {
@@ -101,11 +140,33 @@ export async function hydrateFacetSummaries(
     entries.push(alias.alias)
     aliasesByFacet.set(alias.facetId, entries)
   }
+  const profilesByFacet = new Map(
+    profiles.map((profile) => [profile.facetId, profile]),
+  )
 
-  return facets.map((facet) => ({
-    ...facet,
-    aliases: aliasesByFacet.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
-  }))
+  return facets.map((facet) => {
+    const profile = profilesByFacet.get(facet.id)
+    const taxonomy = profile?.taxonomy
+      ? FACET_TAXONOMIES.includes(profile.taxonomy as FacetTaxonomy)
+        ? (profile.taxonomy as FacetTaxonomy)
+        : 'OTHER'
+      : taxonomyFromKind(facet.kind)
+
+    return {
+      ...facet,
+      aliases: aliasesByFacet.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
+      taxonomy,
+      canonicalValue: profile?.canonicalValue || facet.title,
+      groupKey: profile?.groupKey ?? null,
+      groupLabel: profile?.groupLabel ?? null,
+      sortOrder: profile?.sortOrder ?? 0,
+      isRandomizable: profile?.isRandomizable ?? true,
+      randomWeight: profile?.randomWeight ?? 1,
+      artRequired: profile?.artRequired ?? taxonomy !== 'COLOR',
+      sourceRank: profile?.sourceRank ?? 5,
+      metadata: parseMetadata(profile?.metadata ?? null),
+    }
+  })
 }
 
 export async function loadFacetSummaries(

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import type { Facet, FacetKind } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+import type { FacetTaxonomy } from '@/stores/facetCatalogStore'
 
 export type FacetWithAliases = Pick<
   Facet,
@@ -21,6 +22,16 @@ export type FacetWithAliases = Pick<
   | 'isActive'
 > & {
   aliases: string[]
+  taxonomy: FacetTaxonomy
+  canonicalValue: string
+  groupKey: string | null
+  groupLabel: string | null
+  sortOrder: number
+  isRandomizable: boolean
+  randomWeight: number
+  artRequired: boolean
+  sourceRank: number
+  metadata: Record<string, unknown> | null
 }
 
 export type FacetListOptions = {
@@ -37,6 +48,16 @@ export type FacetCreateInput = {
   title: string
   slug?: string
   kind?: FacetKind
+  taxonomy?: FacetTaxonomy
+  canonicalValue?: string | null
+  groupKey?: string | null
+  groupLabel?: string | null
+  sortOrder?: number
+  isRandomizable?: boolean
+  randomWeight?: number
+  artRequired?: boolean
+  sourceRank?: number
+  metadata?: Record<string, unknown> | null
   description?: string | null
   flavorText?: string | null
   imagePath?: string | null
@@ -79,7 +100,12 @@ export const useFacetStore = defineStore('facetStore', () => {
   const facetsByLookupKey = computed(() => {
     const index = new Map<string, FacetWithAliases>()
     for (const facet of facets.value) {
-      const keys = [facet.slug, facet.title, ...facet.aliases]
+      const keys = [
+        facet.slug,
+        facet.title,
+        facet.canonicalValue,
+        ...facet.aliases,
+      ]
       for (const key of keys) {
         const lookupKey = normalizeFacetLookupKey(key || '')
         if (lookupKey) index.set(lookupKey, facet)
@@ -98,9 +124,11 @@ export const useFacetStore = defineStore('facetStore', () => {
     if (index >= 0) facets.value[index] = facet
     else facets.value.push(facet)
     facets.value.sort((a, b) =>
-      a.kind === b.kind
-        ? a.title.localeCompare(b.title)
-        : a.kind.localeCompare(b.kind),
+      a.taxonomy === b.taxonomy
+        ? a.sortOrder === b.sortOrder
+          ? a.title.localeCompare(b.title)
+          : a.sortOrder - b.sortOrder
+        : a.taxonomy.localeCompare(b.taxonomy),
     )
     return facet
   }

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -40,6 +40,7 @@ export type FacetListOptions = {
   includeInactive?: boolean
   includeMature?: boolean
   mine?: boolean
+  /** Page size. The store continues until all matching pages are loaded. */
   take?: number
   skip?: number
 }
@@ -73,6 +74,8 @@ export type FacetUpdateInput = Partial<FacetCreateInput> & {
 
 export type FacetOwnerType = 'dream' | 'scenario' | 'artImage'
 
+const FACET_LIBRARY_PAGE_SIZE = 250
+
 function toQuery(options: FacetListOptions): string {
   const query = new URLSearchParams()
   for (const [key, value] of Object.entries(options)) {
@@ -81,6 +84,16 @@ function toQuery(options: FacetListOptions): string {
   }
   const result = query.toString()
   return result ? `?${result}` : ''
+}
+
+function sortFacets(entries: FacetWithAliases[]): FacetWithAliases[] {
+  return entries.sort((a, b) =>
+    a.taxonomy === b.taxonomy
+      ? a.sortOrder === b.sortOrder
+        ? a.title.localeCompare(b.title)
+        : a.sortOrder - b.sortOrder
+      : a.taxonomy.localeCompare(b.taxonomy),
+  )
 }
 
 export const useFacetStore = defineStore('facetStore', () => {
@@ -123,13 +136,7 @@ export const useFacetStore = defineStore('facetStore', () => {
     const index = facets.value.findIndex((entry) => entry.id === facet.id)
     if (index >= 0) facets.value[index] = facet
     else facets.value.push(facet)
-    facets.value.sort((a, b) =>
-      a.taxonomy === b.taxonomy
-        ? a.sortOrder === b.sortOrder
-          ? a.title.localeCompare(b.title)
-          : a.sortOrder - b.sortOrder
-        : a.taxonomy.localeCompare(b.taxonomy),
-    )
+    facets.value = sortFacets([...facets.value])
     return facet
   }
 
@@ -139,13 +146,28 @@ export const useFacetStore = defineStore('facetStore', () => {
     loading.value = true
     error.value = null
     try {
-      const response = await performFetch<FacetWithAliases[]>(
-        `/api/facets${toQuery(options)}`,
+      const pageSize = Math.min(
+        FACET_LIBRARY_PAGE_SIZE,
+        Math.max(1, options.take ?? FACET_LIBRARY_PAGE_SIZE),
       )
-      if (!response.success) {
-        throw new Error(response.message || 'Failed to fetch Facets.')
+      let skip = Math.max(0, options.skip ?? 0)
+      const byId = new Map<number, FacetWithAliases>()
+
+      while (true) {
+        const response = await performFetch<FacetWithAliases[]>(
+          `/api/facets${toQuery({ ...options, take: pageSize, skip })}`,
+        )
+        if (!response.success) {
+          throw new Error(response.message || 'Failed to fetch Facets.')
+        }
+
+        const page = response.data ?? []
+        for (const facet of page) byId.set(facet.id, facet)
+        if (page.length < pageSize) break
+        skip += page.length
       }
-      facets.value = response.data ?? []
+
+      facets.value = sortFacets(Array.from(byId.values()))
       loaded.value = true
       return facets.value
     } catch (cause) {

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -38,9 +38,12 @@ async function main(): Promise<void> {
       'prisma/migrations/20260725113000_facet_catalog_cutover/migration.sql',
     catalog: 'server/utils/facetCatalog.ts',
     catalogRoute: 'server/api/facets/catalog.get.ts',
+    facetAssignments: 'server/utils/facetAssignments.ts',
     facetCreate: 'server/api/facets/index.post.ts',
     facetPatch: 'server/api/facets/[id].patch.ts',
     profileInput: 'server/utils/facetProfileInput.ts',
+    facetStore: 'stores/facetStore.ts',
+    facetManager: 'components/facets/facet-manager.vue',
     characterGet: 'server/api/characters/[id]/facets.get.ts',
     characterPut: 'server/api/characters/[id]/facets.put.ts',
     seed: 'utils/scripts/seedFacetCatalog.ts',
@@ -105,6 +108,18 @@ async function main(): Promise<void> {
   requireText(files.facetPatch, text.facetPatch, 'buildFacetProfileUpdateData')
   requireText(files.facetPatch, text.facetPatch, 'tx.facetProfile.upsert')
   requireText(files.facetPatch, text.facetPatch, 'where: { facetId: id }')
+
+  requireText(files.facetAssignments, text.facetAssignments, 'prisma.facetProfile.findMany')
+  requireText(files.facetAssignments, text.facetAssignments, 'randomWeight: profile?.randomWeight')
+  requireText(files.facetAssignments, text.facetAssignments, 'metadata: parseMetadata')
+  requireText(files.facetStore, text.facetStore, 'FACET_LIBRARY_PAGE_SIZE')
+  requireText(files.facetStore, text.facetStore, 'while (true)')
+  requireText(files.facetStore, text.facetStore, 'skip += page.length')
+  requireText(files.facetStore, text.facetStore, 'taxonomy: FacetTaxonomy')
+  requireText(files.facetManager, text.facetManager, 'Create canonical Facet')
+  requireText(files.facetManager, text.facetManager, 'newRandomWeight')
+  requireText(files.facetManager, text.facetManager, 'editForm.isRandomizable')
+  requireText(files.facetManager, text.facetManager, 'kindForTaxonomy')
 
   requireText(files.characterGet, text.characterGet, 'getOptionalApiUser')
   requireText(files.characterPut, text.characterPut, 'requireApiUser')


### PR DESCRIPTION
## Problems closed

1. The management endpoint pages at 250 records, but `facetStore` loaded only the default first 100. Most of the 1,301-record library was invisible in the Facet Library.
2. The manager exposed only the legacy ten-value `FacetKind`, even though runtime behavior now depends on `FacetProfile.taxonomy`, grouping, ordering, randomization, artwork policy, and metadata.

## Change

- enriches ordinary Facet summaries with their `FacetProfile` and parsed metadata
- supplies safe profile defaults for older profile-less records
- paginates `/api/facets` to exhaustion in bounded 250-record requests
- de-duplicates records by ID and sorts by canonical taxonomy/order
- replaces broad-kind filtering with all 20 canonical taxonomies
- exposes taxonomy, group key/label, random weight, randomizable status, and artwork policy in create/edit flows
- derives the legacy broad `FacetKind` automatically for compatibility
- shows canonical profile status directly on library cards
- adds contract coverage for profile hydration, complete management paging, and canonical authoring controls

## Result

The Facet Library now manages the same model used by Character Builder, `randomStore`, and the catalog API, and it can see the complete production library rather than only its first 100 rows.