### PR TITLE
Canonicalize art paths and replace vague visual-style defaults

### DIFF
--- a/server/api/art/queue/index.post.ts
+++ b/server/api/art/queue/index.post.ts
@@ -13,6 +13,7 @@ import {
   serializeArtJobPayload,
 } from '../../../utils/artJobPayload'
 import { enrichArtJobPayload } from '../../../utils/artJobProvenance'
+import { normalizeQueuedArtJobPayload } from '../../../utils/artJobNormalization'
 
 const ENGINES = new Set(['A1111', 'COMFY'])
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
@@ -67,10 +68,11 @@ export default defineEventHandler(async (event) => {
     const priority = Number.isInteger(body?.priority)
       ? Number(body?.priority)
       : 0
+    const normalizedPayload = normalizeQueuedArtJobPayload(rawPayload).payload
 
     const { payload, provenance } = enrichArtJobPayload(
       engine as 'A1111' | 'COMFY',
-      rawPayload,
+      normalizedPayload,
       {
         projectSlug,
         idempotencyKey: body?.idempotencyKey,

--- a/server/api/art/queue/reenqueue-failed.post.ts
+++ b/server/api/art/queue/reenqueue-failed.post.ts
@@ -9,16 +9,56 @@ import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
 import { normalizeFailedArtJobIds } from '../../../utils/failedArtJobScope'
+import {
+  serializeArtJobPayload,
+} from '../../../utils/artJobPayload'
+import {
+  enrichArtJobPayload,
+  readArtJobProvenance,
+} from '../../../utils/artJobProvenance'
+import { normalizeQueuedArtJobPayload } from '../../../utils/artJobNormalization'
 
 const REQUEUE_CONCURRENCY = 10
 
-async function requeueFailedJob(id: number): Promise<number> {
+type FailedJobSource = {
+  id: number
+  engine: 'A1111' | 'COMFY'
+  projectSlug: string | null
+  payload: string
+}
+
+type RequeueResult = {
+  id: number
+  imagePathChanged: boolean
+  promptChanged: boolean
+}
+
+async function requeueFailedJob(source: FailedJobSource): Promise<RequeueResult> {
+  const normalization = normalizeQueuedArtJobPayload(source.payload)
+  const priorProvenance = readArtJobProvenance(source.payload)
+  const { payload } = enrichArtJobPayload(
+    source.engine,
+    normalization.payload,
+    {
+      projectSlug: source.projectSlug,
+      idempotencyKey: priorProvenance?.idempotencyKey,
+      requireCompletionProof: priorProvenance?.requireCompletionProof,
+    },
+  )
+
+  payload.queueRepair = {
+    repairedAt: new Date().toISOString(),
+    imagePathChanged: normalization.imagePathChanged,
+    promptChanged: normalization.promptChanged,
+  }
+
   const updated = await prisma.artJob.updateMany({
     where: {
-      id,
+      id: source.id,
       status: 'FAILED',
     },
     data: {
+      payload: serializeArtJobPayload(payload),
       status: 'PENDING',
       claimedAt: null,
       claimedBy: null,
@@ -28,10 +68,14 @@ async function requeueFailedJob(id: number): Promise<number> {
   })
 
   if (updated.count !== 1) {
-    throw new Error(`ArtJob ${id} was no longer FAILED.`)
+    throw new Error(`ArtJob ${source.id} was no longer FAILED.`)
   }
 
-  return id
+  return {
+    id: source.id,
+    imagePathChanged: normalization.imagePathChanged,
+    promptChanged: normalization.promptChanged,
+  }
 }
 
 export default defineEventHandler(async (event) => {
@@ -61,21 +105,30 @@ export default defineEventHandler(async (event) => {
         id: { in: selectedJobIds },
         status: 'FAILED',
       },
-      select: { id: true },
+      select: {
+        id: true,
+        engine: true,
+        projectSlug: true,
+        payload: true,
+      },
     })
-    const matchingIds = new Set(matchingRows.map((row) => row.id))
+    const sourcesById = new Map(
+      matchingRows.map((row) => [row.id, row as FailedJobSource]),
+    )
     const sources = selectedJobIds
-      .filter((id) => matchingIds.has(id))
-      .map((id) => ({ id }))
-    const skippedJobIds = selectedJobIds.filter((id) => !matchingIds.has(id))
+      .map((id) => sourcesById.get(id))
+      .filter((source): source is FailedJobSource => Boolean(source))
+    const skippedJobIds = selectedJobIds.filter((id) => !sourcesById.has(id))
 
     const requeuedJobIds: number[] = []
     const failedSourceJobIds: number[] = []
+    let repairedImagePathCount = 0
+    let repairedPromptCount = 0
 
     for (let index = 0; index < sources.length; index += REQUEUE_CONCURRENCY) {
       const batch = sources.slice(index, index + REQUEUE_CONCURRENCY)
       const results = await Promise.allSettled(
-        batch.map((source) => requeueFailedJob(source.id)),
+        batch.map((source) => requeueFailedJob(source)),
       )
 
       results.forEach((result, resultIndex) => {
@@ -83,7 +136,9 @@ export default defineEventHandler(async (event) => {
         if (!source) return
 
         if (result.status === 'fulfilled') {
-          requeuedJobIds.push(result.value)
+          requeuedJobIds.push(result.value.id)
+          if (result.value.imagePathChanged) repairedImagePathCount += 1
+          if (result.value.promptChanged) repairedPromptCount += 1
         } else {
           failedSourceJobIds.push(source.id)
         }
@@ -102,16 +157,18 @@ export default defineEventHandler(async (event) => {
         requestedCount === 0
           ? 'None of the selected ArtJobs are still failed.'
           : failedCount > 0
-            ? `Requeued ${queuedCount} of ${requestedCount} selected failed ArtJobs. ${failedCount} could not be requeued.`
+            ? `Repaired and requeued ${queuedCount} of ${requestedCount} selected failed ArtJobs. ${failedCount} could not be requeued.`
             : skippedCount > 0
-              ? `Requeued ${queuedCount} selected failed ArtJobs. ${skippedCount} selected jobs were skipped because they were missing or no longer failed.`
-              : `Requeued ${queuedCount} selected failed ArtJobs in place.`,
+              ? `Repaired and requeued ${queuedCount} selected failed ArtJobs. ${skippedCount} selected jobs were skipped because they were missing or no longer failed.`
+              : `Repaired and requeued ${queuedCount} selected failed ArtJobs in place.`,
       data: {
         selectedCount,
         requestedCount,
         queuedCount,
         failedCount,
         skippedCount,
+        repairedImagePathCount,
+        repairedPromptCount,
         selectedJobIds,
         sourceJobIds: sources.map((source) => source.id),
         skippedJobIds,

--- a/server/utils/artJobNormalization.ts
+++ b/server/utils/artJobNormalization.ts
@@ -17,14 +17,32 @@ function asRecord(value: unknown): ArtJobPayloadRecord {
   return value as ArtJobPayloadRecord
 }
 
+function unsafePath(value: string): boolean {
+  return value
+    .replace(/\\/g, '/')
+    .split(/[?#]/, 1)[0]!
+    .split('/')
+    .some((part) => part === '..')
+}
+
 function cleanPath(value: unknown): string {
   let path = String(value || '').trim().replace(/\\/g, '/')
   if (!path) return ''
 
-  try {
-    const parsed = new URL(path, 'https://kindrobots.org')
-    path = decodeURIComponent(parsed.pathname)
-  } catch {
+  if (unsafePath(path)) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsafe Kind Robots imagePath "${path}".`,
+    })
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    try {
+      path = decodeURIComponent(new URL(path).pathname)
+    } catch {
+      path = path.split('?', 1)[0]!.split('#', 1)[0]!
+    }
+  } else {
     path = path.split('?', 1)[0]!.split('#', 1)[0]!
   }
 

--- a/server/utils/artJobNormalization.ts
+++ b/server/utils/artJobNormalization.ts
@@ -1,0 +1,123 @@
+import { createError } from 'h3'
+import {
+  parseArtJobPayload,
+  type ArtJobPayloadRecord,
+} from './artJobPayload'
+
+export const KIND_ROBOTS_REPO = 'silasfelinus/kind_robots'
+
+export const DEFAULT_ASSET_ART_DIRECTION =
+  'detailed mature western animation with multidimensional worldbuilding, expressive anatomy and faces, confident ink-like linework, dimensional shapes, rich controlled color, cinematic lighting, tactile environments, and clear readable silhouettes; cast characters naturally across many species, ages, body sizes, body shapes, gender presentations, and levels of conventional attractiveness; include robots only when the subject or scene explicitly calls for them'
+
+const VAGUE_ART_DIRECTION =
+  /\b(?:(?:rich|cohesive|friendly)\s+)?Kind Robots\s+(?:visual\s+)?(?:style|language)\b/gi
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+function cleanPath(value: unknown): string {
+  let path = String(value || '').trim().replace(/\\/g, '/')
+  if (!path) return ''
+
+  try {
+    const parsed = new URL(path, 'https://kindrobots.org')
+    path = decodeURIComponent(parsed.pathname)
+  } catch {
+    path = path.split('?', 1)[0]!.split('#', 1)[0]!
+  }
+
+  while (path.startsWith('./')) path = path.slice(2)
+  return path.replace(/^\/+/, '')
+}
+
+function assertSafePath(path: string): void {
+  const parts = path.split('/')
+  if (
+    parts.length < 3 ||
+    parts.some((part) => !part || part === '.' || part === '..')
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: `Unsafe Kind Robots imagePath "${path}".`,
+    })
+  }
+}
+
+export function normalizeKindRobotsImagePath(value: unknown): string {
+  const path = cleanPath(value)
+  let normalized = ''
+
+  if (path.startsWith('public/images/')) {
+    normalized = path
+  } else if (path.startsWith('images/')) {
+    normalized = `public/${path}`
+  } else if (path.startsWith('public/rewards/')) {
+    normalized = `public/images/${path.slice('public/'.length)}`
+  } else if (path.startsWith('rewards/')) {
+    normalized = `public/images/${path}`
+  }
+
+  if (!normalized) {
+    throw createError({
+      statusCode: 400,
+      message:
+        'Kind Robots ArtJob imagePath must begin with public/images/.',
+    })
+  }
+
+  assertSafePath(normalized)
+  return normalized
+}
+
+export function replaceVagueArtDirection(value: string): string {
+  return value
+    .replace(VAGUE_ART_DIRECTION, DEFAULT_ASSET_ART_DIRECTION)
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function normalizeStringsDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeStringsDeep)
+
+  if (!value || typeof value !== 'object') {
+    return typeof value === 'string' ? replaceVagueArtDirection(value) : value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+      key,
+      normalizeStringsDeep(child),
+    ]),
+  )
+}
+
+export type ArtJobNormalizationResult = {
+  payload: ArtJobPayloadRecord
+  imagePathChanged: boolean
+  promptChanged: boolean
+}
+
+export function normalizeQueuedArtJobPayload(
+  rawPayload: unknown,
+): ArtJobNormalizationResult {
+  const original = structuredClone(parseArtJobPayload(rawPayload))
+  const normalized = asRecord(normalizeStringsDeep(original))
+  const targetRepo = String(normalized.targetRepo || '').trim()
+  const originalImagePath = String(original.imagePath || '').trim()
+  const originalPrompt = String(original.promptString || '').trim()
+
+  if (targetRepo === KIND_ROBOTS_REPO) {
+    normalized.imagePath = normalizeKindRobotsImagePath(normalized.imagePath)
+  }
+
+  return {
+    payload: normalized,
+    imagePathChanged:
+      targetRepo === KIND_ROBOTS_REPO &&
+      String(normalized.imagePath || '') !== originalImagePath,
+    promptChanged:
+      String(normalized.promptString || '') !== originalPrompt,
+  }
+}

--- a/server/utils/artPromptQuality.ts
+++ b/server/utils/artPromptQuality.ts
@@ -11,6 +11,9 @@ const LEGACY_FALLBACK_PATTERNS = [
   /^polished web illustration for .+?, clear subject, cohesive Kind Robots visual style, no text$/i,
 ]
 
+const VAGUE_BRAND_STYLE_PATTERN =
+  /\b(?:(?:rich|cohesive|friendly)\s+)?Kind Robots\s+(?:visual\s+)?(?:style|language)\b/i
+
 const GENERIC_LABEL_PATTERNS = [
   /^image\s*#?\s*\d+$/i,
   /^art\s*image\s*#?\s*\d+$/i,
@@ -47,6 +50,8 @@ export function assessArtPrompt(value: unknown): ArtPromptAssessment {
   if (prompt && isGenericArtLabel(prompt)) reasons.push('generic-label')
   if (LEGACY_FALLBACK_PATTERNS.some((pattern) => pattern.test(prompt))) {
     reasons.push('legacy-generic-fallback')
+  } else if (VAGUE_BRAND_STYLE_PATTERN.test(prompt)) {
+    reasons.push('vague-brand-style')
   }
 
   const referencedArtImageId = extractReferencedArtImageId(prompt)

--- a/server/utils/artRequestYaml.ts
+++ b/server/utils/artRequestYaml.ts
@@ -1,16 +1,22 @@
 // /server/utils/artRequestYaml.ts
 //
-// Pure, dependency-free rendering of Conductor art-queue entries into the
-// exact YAML list style that conductor's projects/art-prompts.yaml uses.
+// Rendering of Conductor art-queue entries into the exact YAML list style that
+// conductor's projects/art-prompts.yaml uses.
 //
 // This lives in its own module (extracted from api/conductor/art-request.post.ts)
-// so the indentation contract can be unit-tested without pulling in h3, prisma,
-// or the rest of the Nuxt server runtime. See utils/scripts/verifyArtRequestYaml.ts.
+// so the indentation and normalization contracts can be unit-tested without
+// pulling in prisma or the Nuxt server runtime. See
+// utils/scripts/verifyArtRequestYaml.ts.
 //
 // THE CONTRACT (art-generator-connect/t-008): every request is a block-sequence
 // item whose `- ` marker sits at COLUMN 0 and whose continuation keys are indented
 // exactly 2 spaces. conductor's PyYAML parser rejects mixed indentation, which is
 // the silent-stall bug this module's test guards against (kind_robots PR #84).
+import {
+  KIND_ROBOTS_REPO,
+  normalizeKindRobotsImagePath,
+  replaceVagueArtDirection,
+} from './artJobNormalization'
 
 export type ArtVariant = 'icon' | 'card' | 'hero' | 'image'
 
@@ -38,35 +44,55 @@ export function yamlFolded(key: string, value: string, indent = '    '): string 
   return `${key}: >\n${indent}${clean}`
 }
 
+export function normalizeArtQueueEntry(entry: ArtQueueEntry): ArtQueueEntry {
+  if (entry.target_repo !== KIND_ROBOTS_REPO) {
+    return {
+      ...entry,
+      prompt: replaceVagueArtDirection(entry.prompt),
+    }
+  }
+
+  return {
+    ...entry,
+    image_path: normalizeKindRobotsImagePath(entry.image_path),
+    prompt: replaceVagueArtDirection(entry.prompt),
+  }
+}
+
 // Entries must sit at column 0 to match the existing `requests:` list style in
 // conductor's art-prompts.yaml — mixed indentation breaks the YAML parser there.
 export function renderRequestEntry(entry: ArtQueueEntry): string {
+  const normalized = normalizeArtQueueEntry(entry)
   const lines = [
-    `- id: ${yamlQuoted(entry.id)}`,
-    `  source: ${yamlQuoted(entry.source)}`,
-    `  status: ${yamlQuoted(entry.status)}`,
-    `  target_repo: ${yamlQuoted(entry.target_repo)}`,
-    `  image_path: ${yamlQuoted(entry.image_path)}`,
-    `  source_url: ${yamlQuoted(entry.source_url)}`,
+    `- id: ${yamlQuoted(normalized.id)}`,
+    `  source: ${yamlQuoted(normalized.source)}`,
+    `  status: ${yamlQuoted(normalized.status)}`,
+    `  target_repo: ${yamlQuoted(normalized.target_repo)}`,
+    `  image_path: ${yamlQuoted(normalized.image_path)}`,
+    `  source_url: ${yamlQuoted(normalized.source_url)}`,
   ]
 
-  if (entry.page_url) lines.push(`  page_url: ${yamlQuoted(entry.page_url)}`)
-  lines.push(`  variant: ${yamlQuoted(entry.variant)}`)
-  if (entry.size) lines.push(`  size: ${yamlQuoted(entry.size)}`)
-  if (entry.label) lines.push(`  label: ${yamlQuoted(entry.label)}`)
-  lines.push(`  ${yamlFolded('prompt', entry.prompt, '    ')}`)
+  if (normalized.page_url) {
+    lines.push(`  page_url: ${yamlQuoted(normalized.page_url)}`)
+  }
+  lines.push(`  variant: ${yamlQuoted(normalized.variant)}`)
+  if (normalized.size) lines.push(`  size: ${yamlQuoted(normalized.size)}`)
+  if (normalized.label) lines.push(`  label: ${yamlQuoted(normalized.label)}`)
+  lines.push(`  ${yamlFolded('prompt', normalized.prompt, '    ')}`)
 
   return lines.join('\n')
 }
 
 export function requestAlreadyQueued(content: string, entry: ArtQueueEntry): boolean {
-  return content.includes(entry.id) || content.includes(entry.image_path)
+  const normalized = normalizeArtQueueEntry(entry)
+  return content.includes(normalized.id) || content.includes(normalized.image_path)
 }
 
 export function appendRequest(content: string, entry: ArtQueueEntry): string {
-  if (requestAlreadyQueued(content, entry)) return content
+  const normalized = normalizeArtQueueEntry(entry)
+  if (requestAlreadyQueued(content, normalized)) return content
 
-  const serialized = renderRequestEntry(entry)
+  const serialized = renderRequestEntry(normalized)
   const trimmed = content.trimEnd()
 
   if (/^requests:\s*\[\]\s*$/m.test(trimmed)) {

--- a/server/utils/conductorArtPrompt.ts
+++ b/server/utils/conductorArtPrompt.ts
@@ -4,6 +4,7 @@ import {
   cleanArtPrompt,
   isGenericArtLabel,
 } from './artPromptQuality'
+import { DEFAULT_ASSET_ART_DIRECTION } from './artJobNormalization'
 
 type ArtPromptTarget = {
   sourceUrl: string
@@ -171,7 +172,7 @@ function contextualFallback(
     `Create artwork for ${subject}.`,
     `Visible subject and scene context: ${context}.`,
     compositionFor(target),
-    'modern western animation for young adults, crisp expressive linework, saturated but balanced color, readable silhouettes, tactile environmental detail, intentional cinematic lighting',
+    DEFAULT_ASSET_ART_DIRECTION,
     'no readable text, no logos, no watermark, no collage',
   ].join(' ')
 
@@ -211,15 +212,16 @@ export async function buildContextualArtPrompt(
       body: JSON.stringify({
         model: openAiModel(),
         instructions: [
-          'You write production-ready image generation prompts for the Kind Robots website.',
+          'You write production-ready image generation prompts for a multidimensional asset-creation platform.',
           'Infer the actual visible subject from the asset path, page URL, meaningful image label, and surrounding page context.',
           'Never treat a database id, filename number, or phrases such as “Image 529” as a subject.',
-          'Never say “Kind Robots style” or “cohesive visual style”; those phrases give an image model no visual information.',
-          'Use concrete art direction instead: modern western animation for young adults, crisp expressive linework, saturated color, readable silhouettes, and intentional cinematic lighting when suitable.',
+          'Never use “Kind Robots style”, “Kind Robots visual style”, “Kind Robots visual language”, or “cohesive visual style”; those phrases give an image model no visual information and often cause unwanted robots.',
+          `Use this concrete default art direction when the surrounding context does not specify another medium: ${DEFAULT_ASSET_ART_DIRECTION}.`,
+          'Robots are not a default mascot. Include a robot only when the requested subject, story, or surrounding page context explicitly requires one.',
           'Return one vivid prompt only. No markdown, no JSON, no quotes.',
           'Always describe the visible subject, action or pose, setting, composition, mood, and concrete rendering style, ending with no readable text.',
           'Respect the requested variant: icon is square and simple, card is 2:3 portrait, hero is 16:9 landscape.',
-          'Avoid copyrighted characters, logos, brands, text in the image, collages, and vague filler.',
+          'Avoid copyrighted characters, licensed style names, logos, brands, text in the image, collages, and vague filler.',
           'If the supplied context does not identify a real subject, return exactly INSUFFICIENT_CONTEXT.',
         ].join(' '),
         input: [

--- a/utils/scripts/verifyArtPromptRepair.ts
+++ b/utils/scripts/verifyArtPromptRepair.ts
@@ -72,6 +72,8 @@ const normalizedWorkflow = normalization.payload.workflow as Record<
   string,
   WorkflowNode
 >
+const defaultDirectionLead = DEFAULT_ASSET_ART_DIRECTION.split(';').at(0) ?? ''
+
 assert.equal(normalization.imagePathChanged, true)
 assert.equal(normalization.promptChanged, true)
 assert.equal(
@@ -84,7 +86,10 @@ assert.equal(
   normalizedWorkflow.positive?.inputs.text,
   normalization.payload.promptString,
 )
-assert.match(String(normalization.payload.promptString), new RegExp(DEFAULT_ASSET_ART_DIRECTION.split(';')[0]!))
+assert.match(
+  String(normalization.payload.promptString),
+  new RegExp(defaultDirectionLead),
+)
 
 const repaired = applyArtJobOverrides(structuredClone(payload), {
   promptString: strongPrompt,

--- a/utils/scripts/verifyArtPromptRepair.ts
+++ b/utils/scripts/verifyArtPromptRepair.ts
@@ -4,6 +4,11 @@ import {
   extractReferencedArtImageId,
   isGenericArtLabel,
 } from '../../server/utils/artPromptQuality'
+import {
+  DEFAULT_ASSET_ART_DIRECTION,
+  normalizeKindRobotsImagePath,
+  normalizeQueuedArtJobPayload,
+} from '../../server/utils/artJobNormalization'
 import { applyArtJobOverrides } from '../../server/utils/artJobRetry'
 
 type WorkflowNode = {
@@ -13,7 +18,7 @@ type WorkflowNode = {
 const weakPrompt =
   'polished web illustration for Image 529, clear subject, cohesive Kind Robots visual style, no text'
 const strongPrompt =
-  'A weathered red panda museum visitor leans over a glowing kinetic sculpture, curious expression, layered gallery depth, crisp modern western animation linework, saturated teal and amber light, no readable text'
+  'A weathered red panda museum visitor leans over a glowing kinetic sculpture, curious expression, layered gallery depth, crisp mature western animation linework, saturated teal and amber light, no readable text'
 const concisePrompt = 'Clockwork fox guards neon greenhouse'
 
 assert.equal(assessArtPrompt(weakPrompt).useful, false)
@@ -24,9 +29,28 @@ assert.equal(assessArtPrompt(strongPrompt).useful, true)
 assert.equal(assessArtPrompt(concisePrompt).useful, true)
 assert.equal(assessArtPrompt('red dog').useful, true)
 assert.equal(assessArtPrompt('robot').useful, true)
-assert.deepEqual(assessArtPrompt('Image 529').reasons, ['generic-label'])
+assert.equal(assessArtPrompt('Image 529').reasons[0], 'generic-label')
+assert.equal(
+  assessArtPrompt('Friendly Kind Robots visual language, portrait').reasons[0],
+  'vague-brand-style',
+)
+
+assert.equal(
+  normalizeKindRobotsImagePath('public/rewards/item/lucky-penny.webp'),
+  'public/images/rewards/item/lucky-penny.webp',
+)
+assert.equal(
+  normalizeKindRobotsImagePath('/images/characters/grandmother-whalehall.webp'),
+  'public/images/characters/grandmother-whalehall.webp',
+)
+assert.throws(
+  () => normalizeKindRobotsImagePath('public/rewards/../secret.webp'),
+  /Unsafe Kind Robots imagePath/,
+)
 
 const payload = {
+  targetRepo: 'silasfelinus/kind_robots',
+  imagePath: 'public/rewards/item/identity-mask.webp',
   promptString: weakPrompt,
   negativePrompt: 'blurry, text',
   workflow: {
@@ -43,6 +67,25 @@ const payload = {
   },
 }
 
+const normalization = normalizeQueuedArtJobPayload(payload)
+const normalizedWorkflow = normalization.payload.workflow as Record<
+  string,
+  WorkflowNode
+>
+assert.equal(normalization.imagePathChanged, true)
+assert.equal(normalization.promptChanged, true)
+assert.equal(
+  normalization.payload.imagePath,
+  'public/images/rewards/item/identity-mask.webp',
+)
+assert.match(String(normalization.payload.promptString), /multidimensional worldbuilding/)
+assert.doesNotMatch(String(normalization.payload.promptString), /Kind Robots visual/i)
+assert.equal(
+  normalizedWorkflow.positive?.inputs.text,
+  normalization.payload.promptString,
+)
+assert.match(String(normalization.payload.promptString), new RegExp(DEFAULT_ASSET_ART_DIRECTION.split(';')[0]!))
+
 const repaired = applyArtJobOverrides(structuredClone(payload), {
   promptString: strongPrompt,
 })
@@ -51,4 +94,4 @@ const workflow = repaired.workflow as Record<string, WorkflowNode>
 assert.equal(workflow.positive?.inputs.text, strongPrompt)
 assert.equal(workflow.negative?.inputs.text, 'blurry, text')
 
-console.log('Art prompt quality and workflow repair checks passed.')
+console.log('Art prompt quality, canonical path, and workflow repair checks passed.')


### PR DESCRIPTION
## What changed
- Enforce `public/images/...` for all Kind Robots-targeted ArtJob payloads.
- Canonicalize legacy `public/rewards/...` destinations to `public/images/rewards/...`.
- Replace vague `Kind Robots visual style/language` tokens in top-level prompts and embedded Comfy workflows before provenance is calculated.
- Repair selected failed ArtJobs in place before returning them to `PENDING`.
- Canonicalize missing-image YAML requests at the serialization boundary.
- Define the default art direction as detailed mature western animation with multidimensional casting across species, ages, bodies, presentation, and attractiveness; robots appear only when context requires them.

## Verification
- Expanded `test:art-prompt-repair` coverage for path normalization, traversal rejection, workflow prompt replacement, and vague-style rejection.

This intentionally uses no licensed artist, studio, or character names in the production prompt direction.