### PR TITLE
Seed Character Builder More options into Facets

### DIFF
--- a/utils/scripts/runFacetCatalogSeed.ts
+++ b/utils/scripts/runFacetCatalogSeed.ts
@@ -1,8 +1,9 @@
 // /utils/scripts/runFacetCatalogSeed.ts
 //
-// Normalize known source synonyms before the canonical Facet seed imports its
-// source arrays. This keeps one concept row per idea while preserving the
-// original animal metadata for the canonical record.
+// Normalize source data before the canonical Facet seed imports its arrays.
+// This keeps one concept row per idea and makes compact Builder controls expose
+// their complete underlying option lists to the catalog importer.
+import { ADVENTURE_CARDS } from './../../stores/helpers/adventureCards'
 import { animalDataList } from './../../stores/utils/animalData'
 import { normalizeFacetLookupKey } from './../facetAliases'
 
@@ -20,6 +21,31 @@ if (waterBear) {
     '[facet-catalog] Water Bear source entry was not found; continuing without source normalization.',
   )
 }
+
+let promotedBuilderOptions = 0
+for (const card of ADVENTURE_CARDS) {
+  for (const step of card.steps) {
+    const completeList = new Set(step.listOptions ?? [])
+
+    for (const choice of step.choices ?? []) {
+      if (!choice.opensList) continue
+      for (const option of choice.listOptions ?? []) {
+        const value = option.trim()
+        if (!value || completeList.has(value)) continue
+        completeList.add(value)
+        promotedBuilderOptions++
+      }
+    }
+
+    if (completeList.size !== (step.listOptions?.length ?? 0)) {
+      step.listOptions = Array.from(completeList)
+    }
+  }
+}
+
+console.log(
+  `[facet-catalog] Promoted ${promotedBuilderOptions} Builder “More options” entries into canonical seed input.`,
+)
 
 // seedFacetCatalog reads process.argv itself, so --apply passes through.
 await import('./seedFacetCatalog')

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -46,6 +46,7 @@ async function main(): Promise<void> {
     facetManager: 'components/facets/facet-manager.vue',
     characterGet: 'server/api/characters/[id]/facets.get.ts',
     characterPut: 'server/api/characters/[id]/facets.put.ts',
+    seedWrapper: 'utils/scripts/runFacetCatalogSeed.ts',
     seed: 'utils/scripts/seedFacetCatalog.ts',
     catalogStore: 'stores/facetCatalogStore.ts',
     randomStore: 'stores/randomStore.ts',
@@ -126,6 +127,12 @@ async function main(): Promise<void> {
   requireText(files.characterPut, text.characterPut, 'resolveFacetSelection')
   requireText(files.characterPut, text.characterPut, 'characterFacet.deleteMany')
   requireText(files.characterPut, text.characterPut, 'characterFacet.createMany')
+
+  requireText(files.seedWrapper, text.seedWrapper, 'ADVENTURE_CARDS')
+  requireText(files.seedWrapper, text.seedWrapper, 'if (!choice.opensList) continue')
+  requireText(files.seedWrapper, text.seedWrapper, 'choice.listOptions')
+  requireText(files.seedWrapper, text.seedWrapper, 'step.listOptions = Array.from(completeList)')
+  requireText(files.seedWrapper, text.seedWrapper, 'promotedBuilderOptions')
 
   requireText(files.seed, text.seed, 'ADVENTURE_CARDS')
   requireText(files.seed, text.seed, 'animalDataList')


### PR DESCRIPTION
## Root cause

The canonical seed's Character Builder collector skips any control with `opensList` before reading that control's `listOptions`. As a result, every compact “More options…” list was omitted from the catalog.

This explains the live gaps:

- `ROLE` contains zero records
- known entries such as `Reluctant Chosen One` are absent entirely
- many extended occupations, archetypes, species, personalities, backstories, and quirks never reached Facets

## Change

- normalizes `ADVENTURE_CARDS` before the seed engine imports it
- promotes each `opensList` control's `listOptions` into its step-level canonical `listOptions`
- de-duplicates values through a Set
- applies the normalization across every Builder card, not just Class
- logs the promoted entry count during production seeding
- extends the Facet cutover contract so these hidden lists cannot be skipped again

## Deployment behavior

This source file is already part of the Facet seed change policy, so production will run one complete idempotent catalog seed and CharacterFacet backfill. Existing records are updated; missing extended choices are created with the same curated Builder priority and field classification rules.