### PR TITLE
Synchronize Character Facets inside server mutations

### DIFF
--- a/plugins/20.facet-catalog.client.ts
+++ b/plugins/20.facet-catalog.client.ts
@@ -3,7 +3,6 @@ import { defineNuxtPlugin } from '#app'
 import { ADVENTURE_CARDS } from '@/stores/helpers/adventureCards'
 import type { BuilderChoice } from '@/stores/helpers/builderCards'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
-import { useCharacterStore } from '@/stores/characterStore'
 import {
   CHARACTER_FIELD_TAXONOMIES,
   useFacetCatalogStore,
@@ -11,10 +10,6 @@ import {
 import { useGeneratorStore } from '@/stores/generatorStore'
 
 type MutableGeneratorStore = ReturnType<typeof useGeneratorStore> & {
-  __facetCatalogPatched?: boolean
-}
-
-type MutableCharacterStore = ReturnType<typeof useCharacterStore> & {
   __facetCatalogPatched?: boolean
 }
 
@@ -146,29 +141,6 @@ function patchGenerator(catalog: ReturnType<typeof useFacetCatalogStore>): void 
   generator.__facetCatalogPatched = true
 }
 
-function patchCharacterSave(
-  catalog: ReturnType<typeof useFacetCatalogStore>,
-): void {
-  const characterStore = useCharacterStore() as MutableCharacterStore
-  if (characterStore.__facetCatalogPatched) return
-
-  const originalSave = characterStore.saveCharacter.bind(characterStore)
-  characterStore.saveCharacter = async () => {
-    const result = await originalSave()
-    const character = result.data
-
-    if (result.success && character?.id) {
-      await catalog.syncCharacterFacets(
-        character.id,
-        character as unknown as Record<string, unknown>,
-      )
-    }
-
-    return result
-  }
-  characterStore.__facetCatalogPatched = true
-}
-
 export default defineNuxtPlugin(async () => {
   const catalog = useFacetCatalogStore()
 
@@ -178,7 +150,6 @@ export default defineNuxtPlugin(async () => {
 
     hydrateAdventureBuilder(catalog)
     patchGenerator(catalog)
-    patchCharacterSave(catalog)
 
     // Registration stores the same mutable card graph. Re-register after the
     // async catalog fetch so an already-mounted Character Builder observes the

--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { normalizeSlugInput } from '../../../utils/slugify'
 import { getUniqueCharacterSlug } from '../../utils/characterSlug'
+import { syncCharacterFacetsInTransaction } from '../../utils/characterFacetSync'
 import {
   assertCharacterMutationInput,
   assertCharacterRelationsAttachable,
@@ -121,10 +122,20 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const updatedCharacter = await prisma.character.update({
-      where: { id },
-      data,
-      select: characterMutationSelect,
+    const updatedCharacter = await prisma.$transaction(async (tx) => {
+      const character = await tx.character.update({
+        where: { id },
+        data,
+        select: characterMutationSelect,
+      })
+
+      await syncCharacterFacetsInTransaction(
+        tx,
+        character as unknown as Record<string, unknown> & { id: number },
+        { userId: existingCharacter.userId ?? user.id, isAdmin },
+      )
+
+      return character
     })
 
     event.node.res.statusCode = 200

--- a/server/api/characters/index.post.ts
+++ b/server/api/characters/index.post.ts
@@ -8,6 +8,7 @@ import {
   getCharacterNameKey,
   getUniqueCharacterSlug,
 } from '../../utils/characterSlug'
+import { syncCharacterFacetsInTransaction } from '../../utils/characterFacetSync'
 import {
   assertCharacterMutationInput,
   assertCharacterRelationsAttachable,
@@ -41,12 +42,9 @@ export default defineEventHandler(async (event) => {
     assertCharacterCreateCompatibility(rawBody)
 
     const body = stripCharacterCompatibilityFields(rawBody)
+    const isAdmin = user.Role === 'ADMIN' || user.id === 1
 
-    await assertCharacterRelationsAttachable(
-      body,
-      user.id,
-      user.Role === 'ADMIN' || user.id === 1,
-    )
+    await assertCharacterRelationsAttachable(body, user.id, isAdmin)
 
     const name = normalizeCharacterName(body.name)
     const nameKey = getCharacterNameKey(name)
@@ -81,9 +79,19 @@ export default defineEventHandler(async (event) => {
       slug,
     })
 
-    const data = await prisma.character.create({
-      data: createInput,
-      select: characterMutationSelect,
+    const data = await prisma.$transaction(async (tx) => {
+      const character = await tx.character.create({
+        data: createInput,
+        select: characterMutationSelect,
+      })
+
+      await syncCharacterFacetsInTransaction(
+        tx,
+        character as unknown as Record<string, unknown> & { id: number },
+        { userId: user.id, isAdmin },
+      )
+
+      return character
     })
 
     event.node.res.statusCode = 201

--- a/server/utils/characterFacetSync.ts
+++ b/server/utils/characterFacetSync.ts
@@ -1,0 +1,154 @@
+// /server/utils/characterFacetSync.ts
+import type { Prisma } from '~/prisma/generated/prisma/client'
+import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+import type { FacetTaxonomy } from '~/server/utils/facetCatalog'
+
+const CHARACTER_FIELD_TAXONOMIES: Record<string, readonly FacetTaxonomy[]> = {
+  genre: ['GENRE'],
+  species: ['ANIMAL', 'SPECIES'],
+  class: ['OCCUPATION', 'ARCHETYPE', 'ROLE'],
+  alignment: ['ALIGNMENT'],
+  personality: ['PERSONALITY'],
+  backstory: ['BACKSTORY'],
+  quirks: ['QUIRK'],
+  role: ['ROLE'],
+}
+
+type CharacterFacetSource = Record<string, unknown> & { id: number }
+
+type PendingAssignment = {
+  fieldKey: string
+  lookupKey: string
+  sortOrder: number
+}
+
+function splitCharacterField(fieldKey: string, value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  const trimmed = value.trim()
+  if (!trimmed) return []
+
+  if (fieldKey === 'quirks' || fieldKey === 'personality') {
+    return trimmed
+      .split(/\n---\n|\||\n|;|,/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+
+  return [trimmed]
+}
+
+function collectAssignments(character: CharacterFacetSource): PendingAssignment[] {
+  const assignments: PendingAssignment[] = []
+
+  for (const fieldKey of Object.keys(CHARACTER_FIELD_TAXONOMIES)) {
+    for (const [sortOrder, value] of splitCharacterField(
+      fieldKey,
+      character[fieldKey],
+    ).entries()) {
+      const lookupKey = normalizeFacetLookupKey(value)
+      if (!lookupKey) continue
+      assignments.push({ fieldKey, lookupKey, sortOrder })
+    }
+  }
+
+  return assignments
+}
+
+export async function syncCharacterFacetsInTransaction(
+  tx: Prisma.TransactionClient,
+  character: CharacterFacetSource,
+  options: { userId: number; isAdmin: boolean },
+): Promise<number> {
+  const pending = collectAssignments(character)
+  const lookupKeys = Array.from(
+    new Set(pending.map((assignment) => assignment.lookupKey)),
+  )
+
+  if (!lookupKeys.length) {
+    await tx.characterFacet.deleteMany({
+      where: { characterId: character.id },
+    })
+    return 0
+  }
+
+  const aliases = await tx.facetAlias.findMany({
+    where: {
+      lookupKey: { in: lookupKeys },
+      isActive: true,
+    },
+    select: { lookupKey: true, facetId: true },
+  })
+  const facetIds = Array.from(new Set(aliases.map((alias) => alias.facetId)))
+
+  const [profiles, facets] = await Promise.all([
+    tx.facetProfile.findMany({
+      where: { facetId: { in: facetIds } },
+      select: { facetId: true, taxonomy: true },
+    }),
+    tx.facet.findMany({
+      where: {
+        id: { in: facetIds },
+        isActive: true,
+        ...(options.isAdmin
+          ? {}
+          : {
+              OR: [{ isPublic: true }, { userId: options.userId }],
+            }),
+      },
+      select: { id: true },
+    }),
+  ])
+
+  const visibleFacetIds = new Set(facets.map((facet) => facet.id))
+  const taxonomyByFacetId = new Map(
+    profiles.map((profile) => [
+      profile.facetId,
+      profile.taxonomy as FacetTaxonomy,
+    ]),
+  )
+  const facetIdByLookupKey = new Map(
+    aliases
+      .filter((alias) => visibleFacetIds.has(alias.facetId))
+      .map((alias) => [alias.lookupKey, alias.facetId]),
+  )
+
+  const rows = new Map<
+    string,
+    {
+      characterId: number
+      facetId: number
+      fieldKey: string
+      sortOrder: number
+      weight: number
+      source: string
+    }
+  >()
+
+  for (const assignment of pending) {
+    const facetId = facetIdByLookupKey.get(assignment.lookupKey)
+    if (!facetId) continue
+
+    const taxonomy = taxonomyByFacetId.get(facetId)
+    const allowed = CHARACTER_FIELD_TAXONOMIES[assignment.fieldKey] ?? []
+    if (!taxonomy || !allowed.includes(taxonomy)) continue
+
+    rows.set(`${assignment.fieldKey}:${facetId}`, {
+      characterId: character.id,
+      facetId,
+      fieldKey: assignment.fieldKey,
+      sortOrder: assignment.sortOrder,
+      weight: 1,
+      source: 'CHARACTER_MUTATION',
+    })
+  }
+
+  await tx.characterFacet.deleteMany({ where: { characterId: character.id } })
+  if (rows.size) {
+    await tx.characterFacet.createMany({
+      data: Array.from(rows.values()),
+      skipDuplicates: true,
+    })
+  }
+
+  return rows.size
+}

--- a/server/utils/characterFacetSync.ts
+++ b/server/utils/characterFacetSync.ts
@@ -1,5 +1,4 @@
 // /server/utils/characterFacetSync.ts
-import type { Prisma } from '~/prisma/generated/prisma/client'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
 import type { FacetTaxonomy } from '~/server/utils/facetCatalog'
 
@@ -20,6 +19,34 @@ type PendingAssignment = {
   fieldKey: string
   lookupKey: string
   sortOrder: number
+}
+
+type CharacterFacetRow = {
+  characterId: number
+  facetId: number
+  fieldKey: string
+  sortOrder: number
+  weight: number
+  source: string
+}
+
+// Prisma 7 extended transaction clients are not assignable to the generated
+// default TransactionClient type. Describe only the delegate methods this
+// helper uses so both the application client and an extended transaction fit.
+type CharacterFacetSyncClient = {
+  facetAlias: {
+    findMany(args: unknown): PromiseLike<Array<{ lookupKey: string; facetId: number }>>
+  }
+  facetProfile: {
+    findMany(args: unknown): PromiseLike<Array<{ facetId: number; taxonomy: string }>>
+  }
+  facet: {
+    findMany(args: unknown): PromiseLike<Array<{ id: number }>>
+  }
+  characterFacet: {
+    deleteMany(args: unknown): PromiseLike<unknown>
+    createMany(args: unknown): PromiseLike<unknown>
+  }
 }
 
 function splitCharacterField(fieldKey: string, value: unknown): string[] {
@@ -55,7 +82,7 @@ function collectAssignments(character: CharacterFacetSource): PendingAssignment[
 }
 
 export async function syncCharacterFacetsInTransaction(
-  tx: Prisma.TransactionClient,
+  tx: CharacterFacetSyncClient,
   character: CharacterFacetSource,
   options: { userId: number; isAdmin: boolean },
 ): Promise<number> {
@@ -112,17 +139,7 @@ export async function syncCharacterFacetsInTransaction(
       .map((alias) => [alias.lookupKey, alias.facetId]),
   )
 
-  const rows = new Map<
-    string,
-    {
-      characterId: number
-      facetId: number
-      fieldKey: string
-      sortOrder: number
-      weight: number
-      source: string
-    }
-  >()
+  const rows = new Map<string, CharacterFacetRow>()
 
   for (const assignment of pending) {
     const facetId = facetIdByLookupKey.get(assignment.lookupKey)

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -44,6 +44,9 @@ async function main(): Promise<void> {
     profileInput: 'server/utils/facetProfileInput.ts',
     facetStore: 'stores/facetStore.ts',
     facetManager: 'components/facets/facet-manager.vue',
+    characterCreate: 'server/api/characters/index.post.ts',
+    characterPatch: 'server/api/characters/[id].patch.ts',
+    characterFacetSync: 'server/utils/characterFacetSync.ts',
     characterGet: 'server/api/characters/[id]/facets.get.ts',
     characterPut: 'server/api/characters/[id]/facets.put.ts',
     seedWrapper: 'utils/scripts/runFacetCatalogSeed.ts',
@@ -122,6 +125,20 @@ async function main(): Promise<void> {
   requireText(files.facetManager, text.facetManager, 'editForm.isRandomizable')
   requireText(files.facetManager, text.facetManager, 'kindForTaxonomy')
 
+  requireText(
+    files.characterFacetSync,
+    text.characterFacetSync,
+    'syncCharacterFacetsInTransaction',
+  )
+  requireText(files.characterFacetSync, text.characterFacetSync, 'CHARACTER_MUTATION')
+  requireText(files.characterFacetSync, text.characterFacetSync, 'tx.characterFacet.deleteMany')
+  requireText(files.characterFacetSync, text.characterFacetSync, 'tx.characterFacet.createMany')
+  requireText(files.characterFacetSync, text.characterFacetSync, 'allowed.includes(taxonomy)')
+  requireText(files.characterCreate, text.characterCreate, 'prisma.$transaction')
+  requireText(files.characterCreate, text.characterCreate, 'syncCharacterFacetsInTransaction')
+  requireText(files.characterPatch, text.characterPatch, 'prisma.$transaction')
+  requireText(files.characterPatch, text.characterPatch, 'syncCharacterFacetsInTransaction')
+
   requireText(files.characterGet, text.characterGet, 'getOptionalApiUser')
   requireText(files.characterPut, text.characterPut, 'requireApiUser')
   requireText(files.characterPut, text.characterPut, 'resolveFacetSelection')
@@ -157,7 +174,8 @@ async function main(): Promise<void> {
   requireText(files.catalogStore, text.catalogStore, 'entriesById.set(entry.id, entry)')
   requireText(files.builderPlugin, text.builderPlugin, 'hydrateAdventureBuilder')
   requireText(files.builderPlugin, text.builderPlugin, 'patchGenerator')
-  requireText(files.builderPlugin, text.builderPlugin, 'patchCharacterSave')
+  forbidText(files.builderPlugin, text.builderPlugin, 'patchCharacterSave')
+  forbidText(files.builderPlugin, text.builderPlugin, 'useCharacterStore')
 
   requireText(files.randomStore, text.randomStore, 'useFacetCatalogStore')
   requireText(files.randomStore, text.randomStore, 'weightedSample')


### PR DESCRIPTION
## Problem

Character saves were monkey-patched in a client startup plugin. The Character API committed first, then the browser made a separate `/characters/:id/facets` request. A catalog/network/client failure could therefore leave the Character saved but its canonical assignments stale or missing, and non-Builder API callers did not receive automatic assignment synchronization at all.

## Change

- adds a server-side `syncCharacterFacetsInTransaction` helper
- resolves canonical aliases for genre, species, class, alignment, personality, backstory, quirks, and role
- enforces the allowed taxonomy for each Character field
- respects active/public/owned Facet visibility
- splits multi-valued personality and quirk fields consistently
- creates Character and CharacterFacet rows in one transaction
- updates Character and replaces CharacterFacet rows in one transaction
- marks automatic assignments with source `CHARACTER_MUTATION`
- removes the `characterStore.saveCharacter` monkey-patch and its Character-store import from the client plugin
- keeps the explicit Character Facet PUT endpoint for deliberate/manual assignment workflows
- extends the Facet cutover contract to enforce server-side synchronization and forbid the save wrapper from returning

## Result

Every Character mutation path—not only the Builder—produces canonical CharacterFacet assignments atomically with the Character row.