### PR TITLE
Protect curated Facet artwork migration

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -38,4 +38,15 @@ jobs:
           node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
           node utils/scripts/verifyFacetLegacySeedSnapshots.mjs
           node utils/scripts/verifyRetiredRewardRandomizers.mjs
-          npx tsx utils/scripts/verifyFacetArtworkMigration.ts
+
+      - name: Verify curated Facet artwork
+        id: artwork
+        run: npx tsx utils/scripts/verifyFacetArtworkMigration.ts 2>&1 | tee facet-artwork-report.txt
+
+      - name: Upload Facet artwork diagnostics
+        if: failure() && steps.artwork.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: facet-artwork-diagnostics
+          path: facet-artwork-report.txt
+          if-no-files-found: error

--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -38,3 +38,4 @@ jobs:
           node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
           node utils/scripts/verifyFacetLegacySeedSnapshots.mjs
           node utils/scripts/verifyRetiredRewardRandomizers.mjs
+          npx tsx utils/scripts/verifyFacetArtworkMigration.ts

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -24,11 +24,21 @@
         v-for="facet in selectedFacets"
         :key="facet.id"
         type="button"
-        class="badge badge-secondary badge-lg gap-1 rounded-xl"
+        class="badge badge-secondary badge-lg h-auto min-h-8 gap-1 rounded-xl py-1 pl-1"
         :title="facetTitle(facet)"
         :disabled="saving"
         @click="removeFacet(facet.id)"
       >
+        <span
+          v-if="facetArtwork(facet)"
+          class="size-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
+        >
+          <img
+            :src="facetArtwork(facet) || ''"
+            :alt="`${facet.title} artwork`"
+            class="size-full object-cover"
+          />
+        </span>
         <span>{{ facet.title }}</span>
         <span class="text-secondary-content/60">×</span>
       </button>
@@ -51,10 +61,25 @@
           v-for="facet in searchResults"
           :key="facet.id"
           type="button"
-          class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left hover:bg-base-200 disabled:opacity-40"
+          class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left hover:bg-base-200 disabled:opacity-40"
           :disabled="selectedIds.has(facet.id) || saving"
           @click="addFacet(facet.id)"
         >
+          <span
+            class="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+          >
+            <img
+              v-if="facetArtwork(facet)"
+              :src="facetArtwork(facet) || ''"
+              :alt="`${facet.title} artwork`"
+              class="size-full object-cover"
+            />
+            <Icon
+              v-else
+              :name="facet.icon || 'kind-icon:tag'"
+              class="size-5 text-base-content/40"
+            />
+          </span>
           <span class="badge badge-outline badge-xs shrink-0">{{
             kindLabel(facet.kind)
           }}</span>
@@ -234,6 +259,10 @@ function kindLabel(kind: FacetKind): string {
     .toLowerCase()
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function facetArtwork(facet: FacetWithAliases): string | null {
+  return facet.cardPath || facet.imagePath || facet.heroPath || null
 }
 
 function facetTitle(facet: FacetWithAliases): string {

--- a/server/utils/facetAssignments.ts
+++ b/server/utils/facetAssignments.ts
@@ -16,8 +16,14 @@ export type FacetSummary = Pick<
   | 'kind'
   | 'description'
   | 'flavorText'
+  | 'examples'
+  | 'artPrompt'
   | 'imagePath'
+  | 'cardPath'
+  | 'heroPath'
   | 'icon'
+  | 'artImageId'
+  | 'artCollectionId'
   | 'userId'
   | 'isPublic'
   | 'isMature'
@@ -56,8 +62,14 @@ export const facetSummarySelect = {
   kind: true,
   description: true,
   flavorText: true,
+  examples: true,
+  artPrompt: true,
   imagePath: true,
+  cardPath: true,
+  heroPath: true,
   icon: true,
+  artImageId: true,
+  artCollectionId: true,
   userId: true,
   isPublic: true,
   isMature: true,

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -14,8 +14,14 @@ export type FacetWithAliases = Pick<
   | 'kind'
   | 'description'
   | 'flavorText'
+  | 'examples'
+  | 'artPrompt'
   | 'imagePath'
+  | 'cardPath'
+  | 'heroPath'
   | 'icon'
+  | 'artImageId'
+  | 'artCollectionId'
   | 'userId'
   | 'isPublic'
   | 'isMature'
@@ -61,8 +67,14 @@ export type FacetCreateInput = {
   metadata?: Record<string, unknown> | null
   description?: string | null
   flavorText?: string | null
+  examples?: string | null
+  artPrompt?: string | null
   imagePath?: string | null
+  cardPath?: string | null
+  heroPath?: string | null
   icon?: string | null
+  artImageId?: number | null
+  artCollectionId?: number | null
   aliases?: string[]
   isPublic?: boolean
   isMature?: boolean

--- a/utils/scripts/verifyFacetArtworkMigration.ts
+++ b/utils/scripts/verifyFacetArtworkMigration.ts
@@ -1,0 +1,162 @@
+// /utils/scripts/verifyFacetArtworkMigration.ts
+import { access, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { ADVENTURE_CARDS } from '../../stores/helpers/adventureCards'
+import { normalizeFacetLookupKey } from '../facetAliases'
+
+const root = process.cwd()
+
+type CuratedArtwork = {
+  title: string
+  value: string
+  fieldKey: string
+  cardKey: string
+  stepKey: string
+  imagePath: string
+}
+
+function requireText(path: string, text: string, fragment: string): void {
+  if (!text.includes(fragment)) {
+    throw new Error(`${path} is missing artwork migration contract text: ${fragment}`)
+  }
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+async function main(): Promise<void> {
+  const curated: CuratedArtwork[] = []
+  const artworkByFacetKey = new Map<string, CuratedArtwork>()
+  const failures: string[] = []
+
+  for (const card of ADVENTURE_CARDS) {
+    for (const step of card.steps) {
+      const fieldKey = clean(step.field) || clean(step.key) || clean(card.key)
+
+      for (const choice of step.choices ?? []) {
+        // List/custom controls are UI affordances, not canonical Facet records.
+        if (choice.opensCustom || choice.opensList) continue
+
+        const imagePath = clean(choice.image)
+        if (!imagePath) continue
+
+        const value = clean(choice.value)
+        const title = clean(choice.label) || value
+        if (!value || !title) {
+          failures.push(
+            `${card.key}/${step.key} has curated artwork without a canonical title/value: ${imagePath}`,
+          )
+          continue
+        }
+
+        if (!imagePath.startsWith('/images/')) {
+          failures.push(
+            `${card.key}/${step.key}/${title} uses a non-public curated image path: ${imagePath}`,
+          )
+          continue
+        }
+
+        const artwork: CuratedArtwork = {
+          title,
+          value,
+          fieldKey,
+          cardKey: card.key,
+          stepKey: step.key,
+          imagePath,
+        }
+        curated.push(artwork)
+
+        try {
+          await access(resolve(root, 'public', imagePath.slice(1)))
+        } catch {
+          failures.push(`${title} references missing artwork: public${imagePath}`)
+        }
+
+        // seedFacetCatalog currently canonicalizes by normalized title. Conflicting
+        // curated images for the same title would therefore be nondeterministic and
+        // must be resolved explicitly rather than silently choosing the first one.
+        const facetKey = normalizeFacetLookupKey(title)
+        const existing = artworkByFacetKey.get(facetKey)
+        if (existing && existing.imagePath !== imagePath) {
+          failures.push(
+            `Conflicting curated artwork for canonical title "${title}": ` +
+              `${existing.imagePath} (${existing.cardKey}/${existing.stepKey}) vs ` +
+              `${imagePath} (${card.key}/${step.key})`,
+          )
+        } else if (!existing) {
+          artworkByFacetKey.set(facetKey, artwork)
+        }
+      }
+    }
+  }
+
+  if (curated.length < 50) {
+    failures.push(
+      `Only ${curated.length} curated Adventure images were found; expected at least 50.`,
+    )
+  }
+
+  const [seed, catalogApi, catalogStore] = await Promise.all([
+    readFile(resolve(root, 'utils/scripts/seedFacetCatalog.ts'), 'utf8'),
+    readFile(resolve(root, 'server/utils/facetCatalog.ts'), 'utf8'),
+    readFile(resolve(root, 'stores/facetCatalogStore.ts'), 'utf8'),
+  ])
+
+  // Source -> candidate.
+  requireText(
+    'utils/scripts/seedFacetCatalog.ts',
+    seed,
+    'imagePath: clean(choice.image) || undefined',
+  )
+  requireText(
+    'utils/scripts/seedFacetCatalog.ts',
+    seed,
+    'imagePath: item.imagePath',
+  )
+
+  // Candidate -> Facet create/update. Existing curated art must survive lower-rank
+  // enrichment sources and idempotent reruns.
+  requireText(
+    'utils/scripts/seedFacetCatalog.ts',
+    seed,
+    'imagePath: candidate.imagePath',
+  )
+  requireText(
+    'utils/scripts/seedFacetCatalog.ts',
+    seed,
+    'imagePath: candidate.imagePath || existingFacet.imagePath',
+  )
+  requireText(
+    'utils/scripts/seedFacetCatalog.ts',
+    seed,
+    'imagePath: candidate.imagePath || winner.imagePath',
+  )
+
+  // Facet -> canonical API -> Builder card. The richer card/hero fallbacks remain
+  // available for manually authored Facets, while Adventure choice art continues
+  // to work through imagePath.
+  for (const field of ['imagePath: true', 'cardPath: true', 'heroPath: true']) {
+    requireText('server/utils/facetCatalog.ts', catalogApi, field)
+  }
+  requireText(
+    'stores/facetCatalogStore.ts',
+    catalogStore,
+    'image: entry.cardPath || entry.imagePath || entry.heroPath || undefined',
+  )
+
+  if (failures.length) {
+    throw new Error(`Facet artwork migration contract failed:\n- ${failures.join('\n- ')}`)
+  }
+
+  const uniquePaths = new Set(curated.map((entry) => entry.imagePath))
+  process.stdout.write(
+    `Facet artwork migration verified: ${curated.length} curated choices, ` +
+      `${artworkByFacetKey.size} canonical titles, ${uniquePaths.size} image files.\n`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyFacetArtworkMigration.ts
+++ b/utils/scripts/verifyFacetArtworkMigration.ts
@@ -97,11 +97,14 @@ async function main(): Promise<void> {
     )
   }
 
-  const [seed, catalogApi, catalogStore] = await Promise.all([
-    readFile(resolve(root, 'utils/scripts/seedFacetCatalog.ts'), 'utf8'),
-    readFile(resolve(root, 'server/utils/facetCatalog.ts'), 'utf8'),
-    readFile(resolve(root, 'stores/facetCatalogStore.ts'), 'utf8'),
-  ])
+  const [seed, catalogApi, catalogStore, facetSummaries, facetStore] =
+    await Promise.all([
+      readFile(resolve(root, 'utils/scripts/seedFacetCatalog.ts'), 'utf8'),
+      readFile(resolve(root, 'server/utils/facetCatalog.ts'), 'utf8'),
+      readFile(resolve(root, 'stores/facetCatalogStore.ts'), 'utf8'),
+      readFile(resolve(root, 'server/utils/facetAssignments.ts'), 'utf8'),
+      readFile(resolve(root, 'stores/facetStore.ts'), 'utf8'),
+    ])
 
   // Source -> candidate.
   requireText(
@@ -144,6 +147,31 @@ async function main(): Promise<void> {
     catalogStore,
     'image: entry.cardPath || entry.imagePath || entry.heroPath || undefined',
   )
+
+  // General Facet CRUD and assignment summaries must not downgrade richer artwork.
+  // These surfaces feed the Facet Library and owner assignment stores, so omitting
+  // card/hero paths here would make curated media disappear after a normal refresh.
+  for (const field of [
+    "| 'artPrompt'",
+    "| 'imagePath'",
+    "| 'cardPath'",
+    "| 'heroPath'",
+    "| 'artImageId'",
+    "| 'artCollectionId'",
+  ]) {
+    requireText('server/utils/facetAssignments.ts', facetSummaries, field)
+    requireText('stores/facetStore.ts', facetStore, field)
+  }
+  for (const field of [
+    'artPrompt: true',
+    'imagePath: true',
+    'cardPath: true',
+    'heroPath: true',
+    'artImageId: true',
+    'artCollectionId: true',
+  ]) {
+    requireText('server/utils/facetAssignments.ts', facetSummaries, field)
+  }
 
   if (failures.length) {
     throw new Error(`Facet artwork migration contract failed:\n- ${failures.join('\n- ')}`)


### PR DESCRIPTION
## Why

Adventure Builder choices contain heavily curated per-object artwork. The seed copies `choice.image` into `Facet.imagePath`, preserves it across idempotent updates and lower-priority enrichment sources, and the canonical catalog returns it to Builder cards. That behavior was not protected by an executable contract.

A second gap was found during review: the rich canonical catalog exposed `cardPath` and `heroPath`, but ordinary Facet CRUD and assignment summaries returned only `imagePath`. That could make richer artwork disappear from the Facet Library and owner-assignment stores after a refresh.

## Change

- adds a Facet artwork migration verifier
- walks every direct Adventure Builder choice with curated artwork
- verifies each `/images/...` reference exists under `public/`
- rejects conflicting artwork for a canonical title, matching the seed's current title-based deduplication behavior
- verifies the source → seed candidate → Facet create/update mapping
- verifies `imagePath`, `cardPath`, and `heroPath` remain exposed by the canonical catalog
- verifies Builder choices retain the `cardPath || imagePath || heroPath` rendering fallback
- expands general Facet summaries to retain `examples`, `artPrompt`, `imagePath`, `cardPath`, `heroPath`, `artImageId`, and `artCollectionId`
- expands the client Facet store types and create/update inputs to round-trip those fields
- shows curated thumbnails in the generic Facet picker for both selected and search-result Facets
- preserves a focused diagnostics artifact when the artwork contract fails

## Impact

Future Builder refactors, file moves, seed changes, CRUD projections, assignment responses, and catalog rendering changes can no longer silently discard the curated artwork library. Curated Facet art also remains visible outside the Character Builder instead of collapsing back to text-only tags.