### PR TITLE
Preserve curated Facet artwork during canonical merges

### DIFF
--- a/utils/scripts/mergeCanonicalFacetDuplicates.ts
+++ b/utils/scripts/mergeCanonicalFacetDuplicates.ts
@@ -16,6 +16,8 @@ type MergeDefinition = {
   aliases: string[]
 }
 
+type JsonObject = Record<string, unknown>
+
 const MERGES: MergeDefinition[] = [
   {
     canonicalSlug: 'tardigrade',
@@ -23,6 +25,41 @@ const MERGES: MergeDefinition[] = [
     aliases: ['Water Bear'],
   },
 ]
+
+function parseMetadata(value: string | null | undefined): JsonObject {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function mergedProfileMetadata(options: {
+  canonicalMetadata?: string | null
+  duplicateMetadata?: string | null
+  canonicalId: number
+  duplicateId: number
+  duplicateSlug: string
+}): string {
+  return JSON.stringify({
+    ...parseMetadata(options.duplicateMetadata),
+    ...parseMetadata(options.canonicalMetadata),
+    mergedDuplicateFacetId: options.duplicateId,
+    mergedDuplicateSlug: options.duplicateSlug,
+    canonicalFacetId: options.canonicalId,
+  })
+}
+
+function bestSourceRank(...values: Array<number | null | undefined>): number {
+  const ranks = values.filter(
+    (value): value is number => Number.isInteger(value) && Number(value) >= 0,
+  )
+  return ranks.length ? Math.min(...ranks) : 100
+}
 
 async function mergeDefinition(definition: MergeDefinition): Promise<object> {
   const canonical = await prisma.facet.findUnique({
@@ -84,6 +121,8 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
   }
 
   const [
+    canonicalProfile,
+    duplicateProfile,
     characterLinks,
     dreamLinks,
     scenarioLinks,
@@ -92,6 +131,8 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
     relations,
     reactionCount,
   ] = await Promise.all([
+    prisma.facetProfile.findUnique({ where: { facetId: canonical.id } }),
+    prisma.facetProfile.findUnique({ where: { facetId: duplicate.id } }),
     prisma.characterFacet.findMany({
       where: { facetId: duplicate.id },
       select: {
@@ -143,6 +184,18 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
     relations: relations.length,
     reactions: reactionCount,
     aliases: aliases.map((alias) => alias.alias),
+    preservedFacetFields: [
+      'description',
+      'flavorText',
+      'examples',
+      'artPrompt',
+      'imagePath',
+      'cardPath',
+      'heroPath',
+      'icon',
+      'artImageId',
+      'artCollectionId',
+    ],
     action: apply ? 'merged' : 'would-merge',
   }
 
@@ -223,6 +276,8 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
     prisma.facetAlias.deleteMany({ where: { facetId: duplicate.id } }),
   ])
 
+  // Never discard curated content when collapsing a duplicate. Canonical data wins;
+  // the duplicate only fills fields that are still empty on the canonical record.
   await prisma.facet.update({
     where: { id: canonical.id },
     data: {
@@ -230,7 +285,12 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
       slug: 'tardigrade',
       kind: 'ANIMAL',
       description: canonical.description || duplicate.description,
+      flavorText: canonical.flavorText || duplicate.flavorText,
+      examples: canonical.examples || duplicate.examples,
+      artPrompt: canonical.artPrompt || duplicate.artPrompt,
       imagePath: canonical.imagePath || duplicate.imagePath,
+      cardPath: canonical.cardPath || duplicate.cardPath,
+      heroPath: canonical.heroPath || duplicate.heroPath,
       icon: canonical.icon || duplicate.icon,
       artImageId: canonical.artImageId ?? duplicate.artImageId,
       artCollectionId:
@@ -239,14 +299,52 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
     },
   })
 
-  await prisma.facetProfile.updateMany({
+  await prisma.facetProfile.upsert({
     where: { facetId: canonical.id },
-    data: {
+    create: {
+      facetId: canonical.id,
       taxonomy: 'ANIMAL',
       canonicalValue: 'Tardigrade',
+      groupKey: canonicalProfile?.groupKey ?? duplicateProfile?.groupKey ?? null,
+      groupLabel:
+        canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel ?? null,
+      sortOrder: canonicalProfile?.sortOrder ?? duplicateProfile?.sortOrder ?? 0,
       isRandomizable: true,
       randomWeight: 1,
       artRequired: true,
+      sourceRank: bestSourceRank(
+        canonicalProfile?.sourceRank,
+        duplicateProfile?.sourceRank,
+      ),
+      metadata: mergedProfileMetadata({
+        canonicalMetadata: canonicalProfile?.metadata,
+        duplicateMetadata: duplicateProfile?.metadata,
+        canonicalId: canonical.id,
+        duplicateId: duplicate.id,
+        duplicateSlug: definition.duplicateSlug,
+      }),
+    },
+    update: {
+      taxonomy: 'ANIMAL',
+      canonicalValue: 'Tardigrade',
+      groupKey: canonicalProfile?.groupKey ?? duplicateProfile?.groupKey ?? null,
+      groupLabel:
+        canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel ?? null,
+      sortOrder: canonicalProfile?.sortOrder ?? duplicateProfile?.sortOrder ?? 0,
+      isRandomizable: true,
+      randomWeight: 1,
+      artRequired: true,
+      sourceRank: bestSourceRank(
+        canonicalProfile?.sourceRank,
+        duplicateProfile?.sourceRank,
+      ),
+      metadata: mergedProfileMetadata({
+        canonicalMetadata: canonicalProfile?.metadata,
+        duplicateMetadata: duplicateProfile?.metadata,
+        canonicalId: canonical.id,
+        duplicateId: duplicate.id,
+        duplicateSlug: definition.duplicateSlug,
+      }),
     },
   })
 
@@ -285,6 +383,7 @@ async function mergeDefinition(definition: MergeDefinition): Promise<object> {
       randomWeight: 0,
       artRequired: false,
       metadata: JSON.stringify({
+        ...parseMetadata(duplicateProfile?.metadata),
         mergedIntoFacetId: canonical.id,
         canonicalSlug: definition.canonicalSlug,
       }),
@@ -299,7 +398,9 @@ async function main(): Promise<void> {
   for (const definition of MERGES) {
     results.push(await mergeDefinition(definition))
   }
-  process.stdout.write(`${JSON.stringify({ mode: apply ? 'apply' : 'dry-run', results }, null, 2)}\n`)
+  process.stdout.write(
+    `${JSON.stringify({ mode: apply ? 'apply' : 'dry-run', results }, null, 2)}\n`,
+  )
 }
 
 main()

--- a/utils/scripts/verifyFacetCanonicalMerges.ts
+++ b/utils/scripts/verifyFacetCanonicalMerges.ts
@@ -53,6 +53,37 @@ async function main(): Promise<void> {
   requireText(files.merge, text.merge, 'isActive: false')
   requireText(files.merge, text.merge, 'facetAlias.upsert')
 
+  // Canonical data wins; duplicate data fills missing curated content and media.
+  for (const field of [
+    'description: canonical.description || duplicate.description',
+    'flavorText: canonical.flavorText || duplicate.flavorText',
+    'examples: canonical.examples || duplicate.examples',
+    'artPrompt: canonical.artPrompt || duplicate.artPrompt',
+    'imagePath: canonical.imagePath || duplicate.imagePath',
+    'cardPath: canonical.cardPath || duplicate.cardPath',
+    'heroPath: canonical.heroPath || duplicate.heroPath',
+    'icon: canonical.icon || duplicate.icon',
+    'artImageId: canonical.artImageId ?? duplicate.artImageId',
+    'canonical.artCollectionId ?? duplicate.artCollectionId',
+  ]) {
+    requireText(files.merge, text.merge, field)
+  }
+
+  requireText(files.merge, text.merge, 'prisma.facetProfile.findUnique')
+  requireText(files.merge, text.merge, 'prisma.facetProfile.upsert')
+  requireText(files.merge, text.merge, 'mergedProfileMetadata')
+  requireText(files.merge, text.merge, 'bestSourceRank')
+  requireText(
+    files.merge,
+    text.merge,
+    'canonicalProfile?.groupKey ?? duplicateProfile?.groupKey ?? null',
+  )
+  requireText(
+    files.merge,
+    text.merge,
+    'canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel ?? null',
+  )
+
   requireText(files.build, text.build, 'runFacetCatalogSeed.ts')
   requireText(files.build, text.build, 'mergeCanonicalFacetDuplicates.ts')
   forbidText(


### PR DESCRIPTION
## Risk found

The canonical duplicate merger already moved Character/Dream/Scenario assignments and many-to-many ArtImage/ArtCollection links, but its Facet field merge only preserved `imagePath`, `icon`, and direct art IDs. A future duplicate collapse could therefore discard curated `cardPath`, `heroPath`, `artPrompt`, flavor text, examples, and profile provenance.

## Change

- preserves every Facet-owned content/art field with canonical-first precedence
- adds `flavorText`, `examples`, `artPrompt`, `cardPath`, and `heroPath` preservation
- retains direct `artImageId` and `artCollectionId` fallback behavior
- keeps moving all many-to-many ArtImage and ArtCollection links
- loads both FacetProfiles and preserves group/order metadata
- retains the strongest source priority and merges metadata/provenance
- upserts the canonical profile instead of assuming it already exists
- extends the canonical merge contract across all preserved fields

## Result

Canonicalization can no longer erase curated artwork or its generation/provenance context when one Facet is retired into another.