### PR TITLE
Skip full Facet seed for merge-only changes

### DIFF
--- a/scripts/lib/facetCatalogSeedPolicy.mjs
+++ b/scripts/lib/facetCatalogSeedPolicy.mjs
@@ -18,7 +18,6 @@ const FACET_CATALOG_SOURCE_FILES = new Set([
   'utils/facetAliases.ts',
   'utils/seeds/facetLegacyCharacterLists.ts',
   'utils/seeds/facetLegacyCreativeLists.ts',
-  'utils/scripts/mergeCanonicalFacetDuplicates.ts',
   'utils/scripts/runFacetCatalogSeed.ts',
   'utils/scripts/seedFacetCatalog.ts',
 ])
@@ -42,7 +41,10 @@ export function decideFacetCatalogSeed({
   diffError,
 }) {
   if (!isVercelBuild) {
-    return { run: true, reason: 'non-Vercel build preserves explicit local seed behavior' }
+    return {
+      run: true,
+      reason: 'non-Vercel build preserves explicit local seed behavior',
+    }
   }
 
   if (!isProductionDeployment) {
@@ -69,9 +71,12 @@ export function decideFacetCatalogSeed({
     }
   }
 
+  // mergeCanonicalFacetDuplicates.ts runs as its own production-build step after
+  // this decision. A merge-only code change therefore does not need to rewrite
+  // all 1,358 source-backed Facets before exercising the updated merger.
   return {
     run: false,
-    reason: 'no canonical Facet source, schema, migration, or merge file changed',
+    reason: 'no canonical Facet source, schema, or migration changed',
     relevantFiles: [],
   }
 }

--- a/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
+++ b/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
@@ -21,6 +21,10 @@ assert.equal(
   ),
   true,
 )
+assert.equal(
+  isFacetCatalogSourcePath('utils/scripts/mergeCanonicalFacetDuplicates.ts'),
+  false,
+)
 assert.equal(isFacetCatalogSourcePath('components/facets/facet-manager.vue'), false)
 assert.equal(isFacetCatalogSourcePath('README.md'), false)
 
@@ -47,6 +51,15 @@ assert.deepEqual(
     isVercelBuild: true,
     isProductionDeployment: true,
     changedFiles: ['components/facets/facet-manager.vue'],
+  }).run,
+  false,
+)
+
+assert.deepEqual(
+  decideFacetCatalogSeed({
+    isVercelBuild: true,
+    isProductionDeployment: true,
+    changedFiles: ['utils/scripts/mergeCanonicalFacetDuplicates.ts'],
   }).run,
   false,
 )


### PR DESCRIPTION
## Problem

`mergeCanonicalFacetDuplicates.ts` runs as a separate step on every production build, but the seed policy also classified the merge script as a catalog source. Editing merge preservation logic therefore forced a full 1,358-record seed before running the merger, producing overlapping long builds and unnecessary database load.

## Change

- removes the canonical merge script from full-seed source detection
- keeps schemas, migrations, Adventure cards, art presets, animal data, aliases, and seed snapshots as seed triggers
- documents that the merger runs independently after the seed decision
- adds regression coverage proving merge-only production changes skip the full seed
- preserves forced and defensive reseeding behavior

## Result

Artwork and duplicate-merge safeguards can deploy quickly without competing catalog rewrites, while real source-data changes still rebuild the canonical catalog.