### PR TITLE
newsfeed: swap Activism feed's devex-news source for who-news

### DIFF
--- a/stores/helpers/newsfeed.ts
+++ b/stores/helpers/newsfeed.ts
@@ -293,7 +293,16 @@ export const FEED_DEFINITIONS: FeedDefinition[] = [
       'Movements, campaigns, and organizing making a real difference.',
     icon: 'kind-icon:megaphone',
     defaultEnabled: true,
-    sourceIds: ['globalcitizen', 'devex-news'],
+    // devex-news swapped out 2026-07-25 (newsfeed/t-021): devex.com is
+    // domain-wide bot-blocked (403 on every path tried, not just /rss/news),
+    // so it never renders. who-news is already verified:true, already
+    // correctly unrated (WHO is an international health body, not a
+    // politically-rated outlet), and thematically close enough to
+    // global-development activism to pair with globalcitizen (rated) for a
+    // real rated+unrated tooltip contrast. Swap devex-news back in if it
+    // ever gets a working feed again -- its FeedSourceDefinition is left in
+    // place below, just unreferenced here.
+    sourceIds: ['globalcitizen', 'who-news'],
     defaultSort: 'recent',
     topicPolitical: true,
   },


### PR DESCRIPTION
### Task
conductor/newsfeed t-021: the Activism feed's two configured sources (globalcitizen, devex-news) were meant to give one rated + one unrated source side by side to verify `feed-card.vue`'s perspective tooltip. devex-news has been unreachable (HTTP 403) since 2026-07-19.

### What changed / what I produced
Confirmed directly (curl, this session) that devex.com is domain-wide bot-blocked — tried both `/rss/news` and `/feed`, both 403, not a wrong-path issue. Swapped the Activism feed's second `sourceId` from `devex-news` to `who-news` in `stores/helpers/newsfeed.ts`. `who-news` is already `verified: true` in `FEED_SOURCES`, live-confirmed 200 this session, and correctly carries no `perspective` field (WHO is an international health body, not a politically-rated outlet — this isn't a rating gap, it's accurate). Left `devex-news`'s `FeedSourceDefinition` in place, just unreferenced by this feed, in case it gets a working RSS endpoint again later.

### How I verified
- `curl` directly against `globalcitizen.org` (200), `devex.com/rss/news` and `/feed` (403 both), and `who.int`'s RSS feed (200) from this session.
- Brace-balance check on the edited file (no local `node_modules`/vue-tsc available in this sandbox to run the full typecheck — CI is the verification gate, same convention this repo already uses when a sandbox can't run the full suite).
- The diff is a single-line source-array change plus a comment; no logic touched.

### Stakes
reversible — config-only change to a feed source list, no schema/backend change.

### Notes for reviewer
Companion conductor PR (already merged) records this decision in newsfeed/t-021's roadmap note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8PZgzSAFQxQwRnQhUFG7c)_