### PR TITLE
fix(kontext): wire loraName/loraStrength into the Kontext render graph

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1478,6 +1478,11 @@ async function runStyleTransfer(): Promise<void> {
       isMature: sourceImage.isMature ?? false,
       sourceImageId: sourceImage.id > 0 ? sourceImage.id : undefined,
       sourceImageBase64: base64Payload,
+      // Actually load the style's LoRA in the render graph (see
+      // buildKontextWorkflow's LoraLoaderModelOnly wiring) — previously this
+      // only reached the graph as inert `<lora:...>` prompt text.
+      loraName: style.loraPath || undefined,
+      loraStrength: style.loraPath ? (style.loraWeight ?? 1) : undefined,
       // Provenance: link the generated image back to the LoRA Resource this
       // style is backed by (see resourceProvenance.ts / #937).
       loraResourceIds: style.resourceId ? [style.resourceId] : undefined,

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -430,6 +430,8 @@ function buildJobPayload(
       sampler: body.sampler ?? null,
       scheduler: body.scheduler ?? null,
       denoise: body.denoise ?? null,
+      loraName: body.loraName ?? null,
+      loraStrength: body.loraStrength ?? null,
     })
 
     return {

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -43,6 +43,13 @@ export type KontextWorkflowInput = {
   // SetLatentNoiseMask over the source-init latent — everything else is locked
   // to the original. Core ComfyUI nodes only (LoadImageMask/SetLatentNoiseMask).
   maskName?: string | null
+  // Optional style LoRA (matches GenerateArtData.loraName/loraStrength and the
+  // pattern already used by simpleCheckpointWorkflow.ts / imageToVideoWorkflow.ts).
+  // When set, a LoraLoaderModelOnly node is spliced between the base UNet loader
+  // and ModelSamplingFlux so the render graph actually applies the LoRA — until
+  // now this only ever reached the graph as inert `<lora:...>` prompt text.
+  loraName?: string | null
+  loraStrength?: number | null
 }
 
 export const DEFAULT_KONTEXT_WIDTH = 1024
@@ -239,6 +246,28 @@ export function buildKontextWorkflow(
       class_type: 'DetailDaemonSamplerNode',
       _meta: { title: 'Detail Daemon Sampler' },
     },
+  }
+
+  // --- optional style LoRA: load once off the base UNet and route
+  //     ModelSamplingFlux's model input through it, so both the scheduler and
+  //     guider (which both read model from node 30) pick it up. Mirrors the
+  //     LoraLoaderModelOnly pattern in simpleCheckpointWorkflow.ts /
+  //     imageToVideoWorkflow.ts. No-op (base graph unchanged) when no LoRA is
+  //     requested, so prompt-only styles keep their existing behavior. ---
+  const loraName = input.loraName?.trim() || ''
+  if (loraName) {
+    workflow['61'] = {
+      inputs: {
+        model: ['59', 0],
+        lora_name: loraName,
+        strength_model:
+          typeof input.loraStrength === 'number' ? input.loraStrength : 1.0,
+      },
+      class_type: 'LoraLoaderModelOnly',
+      _meta: { title: 'Style LoRA' },
+    }
+
+    ;(workflow['30']!.inputs as Record<string, unknown>).model = ['61', 0]
   }
 
   // --- img2img init: start from the encoded source photo (node 39) so the


### PR DESCRIPTION
### Task
ai-art-academy/t-037: Wire LoRA loading into the Kontext generation workflow (currently prompt-only regardless of registry mode)  (kind: software)

### What changed / what I produced
- `server/api/comfy/kontext/utils/workflow.ts`: `buildKontextWorkflow` now accepts `loraName`/`loraStrength` and, when a LoRA is requested, splices a `LoraLoaderModelOnly` node between the base UNet loader (`59`) and `ModelSamplingFlux` (`30`) — the same pattern already used in `simpleCheckpointWorkflow.ts` and `imageToVideoWorkflow.ts`. No-op when no LoRA is requested, so prompt-mode styles are unaffected.
- `server/api/art/enqueue.post.ts`: the `kontext` engine branch now forwards `body.loraName`/`body.loraStrength` into `buildKontextWorkflow` — previously only `krea2`/`flux2` forwarded these generic fields; `kontext` silently dropped them.
- `components/art/art-styler.vue`: `runStyleTransfer()` now actually sends `loraName`/`loraStrength` (from `style.loraPath`/`style.loraWeight`) in the `generateArt()` call. Previously the LoRA reference only ever reached the backend baked as inert `<lora:...>` text inside the prompt string (ComfyUI/Flux's `CLIPTextEncode` doesn't parse that A1111-style syntax) plus a `loraResourceIds` provenance link — never as a real graph node.

Net effect: Academy styles registered as `mode: lora` (~13 entries in `style-lora-registry.md`) will now actually load their LoRA at render time instead of being indistinguishable from prompt-mode.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean, no errors.
- `npx eslint` on the three changed files — clean.
- `npx prettier --check` on the three changed files — clean, except a pre-existing unrelated warning in `enqueue.post.ts` (confirmed present before this change via `git stash`, untouched by this diff).
- Traced the field-name/format convention (`loraName` = a `localPath`-style value like `FLUX/watercolor.safetensors`, same as `lora-picker.vue`'s `engineName()` and the existing krea2/flux2 wiring) to confirm this change is consistent with, not a departure from, the existing codebase pattern.
- **Not yet done**: a real render against a live Comfy job. The task's own note flags the relay queue as backlogged (82 PENDING/oldest ~35h as of 2026-07-25) and recommends picking a quieter window — deferred rather than burning a live generation slot in an uncertain queue state. Recommend a follow-up live smoke test once the queue is calmer.

### Stakes
reversible

### Flags for Reviewer
- No live-render verification yet (see above) — this is a real gap, not just a formality, since a wrong ComfyUI node/input name would only surface at render time, not at type-check time. I double-checked the node shape against three other already-shipped call sites (`simpleCheckpointWorkflow.ts`, `imageToVideoWorkflow.ts`, and the `krea2`/`flux2` `loraName` wiring) to minimize that risk, but flagging it explicitly per AGENTS.md's verification-honesty norm.
- Left `server/api/comfy/kontext/enqueue.post.ts` (the separate mask-based hair-remix route) and `server/api/comfy/kontext/generate.post.ts` (a private duplicate builder, per its own file-header comment) unchanged — out of scope for this task, which specifically named `art/enqueue.post.ts` and `art-styler.vue`/`academyStyles.ts` as the touchpoints.
- Deliberately left the `<lora:...>` prompt-text baking in `art-styler.vue`'s `buildLoraReference()`/`promptString` construction alone, even though it's now redundant now that the graph does the real work — removing it felt like a second, separable cleanup outside this task's stated scope. Flagging as a possible kaizen.

### Kaizen suggestion
`buildLoraReference()` in `art-styler.vue` still bakes `<lora:path:weight>` into the prompt string for every LoRA-mode style, even now that the LoRA loads for real via the graph. That's inert-but-harmless junk text in the CLIP encode today, but worth a follow-up to strip it now that it no longer serves any purpose (and to confirm it doesn't measurably affect output quality as literal prompt tokens).

### Notes for reviewer
This closes the loop `ai-art-academy/t-004` was blocked on (an A/B eval of the wired-up LoRA workflow) — t-004 depends_on t-037 and should unblock once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EXg5217rbTyHQSHFt5Cry2)_