### PR TITLE
kind-robots/t-046: wire /video-generator into site navigation

### DIFF
--- a/content/channels/lab/video-generator.md
+++ b/content/channels/lab/video-generator.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: lab
+tabKey: video-generator
+dashboardKey: art
+dashboardTab: video
+label: Video Gen
+title: Video Generator
+subtitle: Animate a still into a short clip
+description: Turn a still image into a short looping clip with LTX or WAN, with an optional first-to-last morph and a motion prompt.
+icon: kind-icon:video
+route: /video-generator
+sort: 65
+---
+
+Feed in a still, describe the motion, and queue a short animated clip on the studio engine.

--- a/utils/dataSurfaceManifest.ts
+++ b/utils/dataSurfaceManifest.ts
@@ -35,4 +35,11 @@ export const DATA_SURFACES: DataSurfaceEntry[] = [
     dataSource: 'stores/todoStore.ts: todoStore.honeyDoTodos',
     navEntry: { channelKey: 'home', tabKey: 'for-you' },
   },
+  {
+    id: 'video-generator',
+    label: 'Image-to-video generator',
+    dataSource:
+      'pages/video-generator.vue: stores/videoStore.ts -> POST /api/art/enqueue',
+    navEntry: { channelKey: 'lab', tabKey: 'video-generator' },
+  },
 ]


### PR DESCRIPTION
## Summary

- `pages/video-generator.vue` already fully implements the LTX/WAN image-to-video generator (first/end image, motion prompt, duration/fps/loop, engine picker) and genuinely calls the real backend — it was never a stub, just unreachable.
- The only prior reference was a `dashboardConfigs.art` `'video'` tab that routes through `components/art/art-manager.vue`, which has zero callers anywhere in `pages/`/`components/` — dead, unwired code.
- Adds a real top-level channel/tab entry instead: `content/channels/lab/video-generator.md` (channelKey `lab`, tabKey `video-generator`, route `/video-generator`), placed next to `coat-dance` (another video-remix tool) in the sort order.
- Registers the surface in `utils/dataSurfaceManifest.ts` (`navEntry: { channelKey: 'lab', tabKey: 'video-generator' }`) per the file's own contract, so this gap can't reopen silently — CI's `test:data-surface-manifest` now enforces it.
- No backend changes — pure front-end nav wiring.

Conductor task: `kind-robots/t-046`.

## Test plan

- [x] `npm run test:channel-content` — 66 tabs (up from 65), 0 errors
- [x] `npm run test:data-surface-manifest` — 2 surfaces, 2 wired, 0 errors
- [x] `npm run test:channel-resolver` — passes
- [x] `npx eslint` / `npx prettier --check` clean on both changed files
- [x] `npm run test` (`vue-tsc --noEmit`, full project) — exit 0, no errors
- [ ] Manual click-through in a running app (not available in this sandbox — no live server)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KUhPKsbZfJ8NuVLYAjzxJ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUhPKsbZfJ8NuVLYAjzxJ3)_