### PR TITLE
Make Facets first-class in art requests and ArtJobs

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -38,6 +38,7 @@ jobs:
           node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
           node utils/scripts/verifyFacetLegacySeedSnapshots.mjs
           node utils/scripts/verifyRetiredRewardRandomizers.mjs
+          npx tsx utils/scripts/verifyFacetArtGeneration.ts
 
       - name: Verify curated Facet artwork
         id: artwork

--- a/components/art/art-creator.vue
+++ b/components/art/art-creator.vue
@@ -1,6 +1,12 @@
 <!-- /components/art/art-creator.vue -->
 <template>
   <section class="flex w-full flex-col gap-3">
+    <art-facet-selector
+      v-model="artFacetDraft.selectedIds"
+      label="Creative Facets"
+      :compact="true"
+    />
+
     <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
       <div
         class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
@@ -58,9 +64,7 @@
         "
       >
         <icon
-          :name="
-            messageTone === 'error' ? 'kind-icon:alert' : 'kind-icon:check'
-          "
+          :name="messageTone === 'error' ? 'kind-icon:alert' : 'kind-icon:check'"
           class="mt-0.5 h-4 w-4 shrink-0"
         />
         <span>{{ message }}</span>
@@ -83,6 +87,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 import { ErrorType, useErrorStore } from '@/stores/errorStore'
 import { useArtStore, type GenerateArtData } from '@/stores/artStore'
+import { useArtFacetDraftStore } from '@/stores/artFacetDraftStore'
 
 const props = withDefaults(
   defineProps<{
@@ -121,6 +126,7 @@ const emit = defineEmits<{
 }>()
 
 const artStore = useArtStore()
+const artFacetDraft = useArtFacetDraftStore()
 const errorStore = useErrorStore()
 
 const localMessage = ref('')
@@ -144,9 +150,9 @@ const displayTitle = computed(() => {
 
 const promptPreview = computed(() => {
   if (!props.showPreview || !cleanPrompt.value) return ''
-  return cleanPrompt.value.length > 260
-    ? `${cleanPrompt.value.slice(0, 260)}…`
-    : cleanPrompt.value
+  const decorated = artFacetDraft.decorateGenerationData({}, cleanPrompt.value)
+  const prompt = decorated.promptString
+  return prompt.length > 260 ? `${prompt.slice(0, 260)}…` : prompt
 })
 
 const selectedGenerationEngine = computed(() => {
@@ -154,15 +160,10 @@ const selectedGenerationEngine = computed(() => {
 })
 
 const activeServer = computed(() => artStore.activeGenerationServer)
-
 const needsServer = computed(() => {
   return !['openai', 'kontext'].includes(String(selectedGenerationEngine.value))
 })
-
-const needsCheckpoint = computed(() => {
-  return activeServer.value?.serverType === 'A1111'
-})
-
+const needsCheckpoint = computed(() => activeServer.value?.serverType === 'A1111')
 const hasGenerationSetup = computed(() => {
   if (needsServer.value && !artStore.artForm.serverId) return false
   if (needsCheckpoint.value && !artStore.selectedCheckpointName) return false
@@ -186,15 +187,10 @@ const statusLabel = computed(() => {
   return 'Ready to generate.'
 })
 
-const message = computed(() => {
-  return localMessage.value || artStore.generationMessage
-})
-
-const messageTone = computed(() => {
-  return localMessage.value
-    ? localMessageTone.value
-    : artStore.generationMessageTone
-})
+const message = computed(() => localMessage.value || artStore.generationMessage)
+const messageTone = computed(() =>
+  localMessage.value ? localMessageTone.value : artStore.generationMessageTone,
+)
 
 function getImagePath(image: ArtImage): string | null {
   const record = image as ArtImage & {
@@ -203,15 +199,12 @@ function getImagePath(image: ArtImage): string | null {
     path?: string | null
     fileType?: string | null
   }
-
   if (record.imagePath) return record.imagePath
   if (record.path) return record.path
-
   if (record.imageData) {
     const fileType = record.fileType || 'png'
     return `data:image/${fileType};base64,${record.imageData}`
   }
-
   return null
 }
 
@@ -220,19 +213,23 @@ function setLocalMessage(tone: 'success' | 'error', text: string) {
   localMessage.value = text
 }
 
+function decoratedOverrides(): Partial<GenerateArtData> {
+  return artFacetDraft.decorateGenerationData(
+    {
+      ...props.overrides,
+      title: props.modelTitle || props.imageRole || props.purpose,
+    } as Record<string, unknown>,
+    cleanPrompt.value,
+  ) as Partial<GenerateArtData>
+}
+
 function syncPromptToArtForm() {
   if (!cleanPrompt.value) return
-
-  artStore.setArtForm({
-    promptString: cleanPrompt.value,
-    title: props.modelTitle || props.imageRole || props.purpose,
-    ...props.overrides,
-  })
+  artStore.setArtForm(decoratedOverrides())
 }
 
 async function generateImage() {
   syncPromptToArtForm()
-
   if (!cleanPrompt.value) {
     const message = 'Add a prompt before generating.'
     setLocalMessage('error', message)
@@ -250,12 +247,9 @@ async function generateImage() {
     return
   }
 
-  const result = await artStore.generateCurrentArt({
-    ...props.overrides,
-    promptString: cleanPrompt.value,
-    title: props.modelTitle || props.imageRole || props.purpose,
-  })
-
+  const result = await artStore.generateCurrentArt(
+    decoratedOverrides() as GenerateArtData,
+  )
   if (!result.success || !result.data) {
     const message = result.message || 'Image generation failed.'
     setLocalMessage('error', message)
@@ -265,29 +259,24 @@ async function generateImage() {
   }
 
   const imagePath = getImagePath(result.data)
-
   generatedImage.value = result.data
   setLocalMessage('success', result.message || 'Image generated.')
-
   emit('update', {
     prompt: cleanPrompt.value,
     imagePath,
     artImageId: result.data.id,
     artImage: result.data,
   })
-
   emit('generated', result.data)
 }
 
 watch(
   () => props.prompt,
-  () => {
-    syncPromptToArtForm()
-  },
+  () => syncPromptToArtForm(),
 )
 
 onMounted(async () => {
-  await artStore.prepareArtGenerator()
+  await Promise.all([artStore.prepareArtGenerator(), artFacetDraft.initialize()])
   syncPromptToArtForm()
 })
 </script>
@@ -298,16 +287,13 @@ onMounted(async () => {
     opacity 300ms ease,
     transform 300ms cubic-bezier(0.34, 1.2, 0.64, 1);
 }
-
 .art-creator-reveal-leave-active {
   transition: opacity 180ms ease;
 }
-
 .art-creator-reveal-enter-from {
   opacity: 0;
   transform: translateY(8px) scale(0.98);
 }
-
 .art-creator-reveal-leave-to {
   opacity: 0;
 }

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -55,13 +55,10 @@
         v-if="open && search.trim()"
         class="absolute z-40 mt-1 max-h-72 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
       >
-        <button
+        <div
           v-for="facet in results"
           :key="facet.id"
-          type="button"
-          class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left hover:bg-base-200 disabled:opacity-40"
-          :disabled="selectedSet.has(facet.id)"
-          @click="addFacet(facet.id)"
+          class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-base-200"
         >
           <span
             class="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
@@ -74,20 +71,52 @@
             />
             <Icon v-else :name="facet.icon || 'kind-icon:tag'" class="size-4" />
           </span>
-          <span class="min-w-0 flex-1">
+          <button
+            type="button"
+            class="min-w-0 flex-1 text-left disabled:opacity-40"
+            :disabled="selectedSet.has(facet.id)"
+            @click="addFacet(facet.id)"
+          >
             <span class="block truncate text-sm font-semibold">{{ facet.title }}</span>
             <span class="block truncate text-[11px] text-base-content/45">
               {{ taxonomyLabel(facet.taxonomy) }}
               <template v-if="facet.groupLabel"> · {{ facet.groupLabel }}</template>
             </span>
-          </span>
-          <Icon name="kind-icon:plus" class="size-3.5" />
-        </button>
+          </button>
+          <button
+            v-if="!facetArtwork(facet)"
+            type="button"
+            class="btn btn-ghost btn-xs rounded-xl"
+            :disabled="artRequests.requesting[facet.id]"
+            :title="`Request curated artwork for ${facet.title}`"
+            @click="requestArtwork(facet)"
+          >
+            <span
+              v-if="artRequests.requesting[facet.id]"
+              class="loading loading-spinner loading-xs"
+            />
+            <Icon v-else name="kind-icon:image" class="size-3.5" />
+            {{ artRequests.requested[facet.id] ? 'Requested' : 'Art' }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs btn-circle"
+            :disabled="selectedSet.has(facet.id)"
+            aria-label="Add Facet"
+            @click="addFacet(facet.id)"
+          >
+            <Icon name="kind-icon:plus" class="size-3.5" />
+          </button>
+        </div>
         <p v-if="!results.length" class="px-3 py-3 text-xs text-base-content/45">
           No matching canonical Facet.
         </p>
       </div>
     </div>
+
+    <p v-if="requestMessage" class="text-xs" :class="requestMessageClass">
+      {{ requestMessage }}
+    </p>
   </section>
 </template>
 
@@ -98,6 +127,7 @@ import {
   type FacetCatalogEntry,
   type FacetTaxonomy,
 } from '@/stores/facetCatalogStore'
+import { useFacetArtRequestStore } from '@/stores/facetArtRequestStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 
 const props = withDefaults(
@@ -119,8 +149,11 @@ const emit = defineEmits<{
 }>()
 
 const catalog = useFacetCatalogStore()
+const artRequests = useFacetArtRequestStore()
 const search = ref('')
 const open = ref(false)
+const requestMessage = ref('')
+const requestMessageClass = ref('text-success')
 const selectedSet = computed(() => new Set(props.modelValue))
 const allowedTaxonomies = computed(() =>
   props.taxonomies?.length ? new Set(props.taxonomies) : null,
@@ -175,6 +208,14 @@ function addFacet(id: number): void {
 
 function removeFacet(id: number): void {
   emitValue(props.modelValue.filter((value) => value !== id))
+}
+
+async function requestArtwork(facet: FacetCatalogEntry): Promise<void> {
+  const path = await artRequests.requestPrimaryArtwork(facet)
+  requestMessageClass.value = path ? 'text-success' : 'text-error'
+  requestMessage.value = path
+    ? `Queued curated artwork for ${facet.title} → ${path}`
+    : artRequests.errors[facet.id] || 'Artwork request failed.'
 }
 
 function facetArtwork(facet: FacetCatalogEntry): string | null {

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -1,0 +1,190 @@
+<!-- /components/art/art-facet-selector.vue -->
+<template>
+  <section class="space-y-2 rounded-2xl border border-base-300 bg-base-100 p-3">
+    <div class="flex items-center gap-2">
+      <Icon name="kind-icon:tag" class="size-4 text-secondary" />
+      <div class="min-w-0 flex-1">
+        <h3 class="text-sm font-bold">{{ label }}</h3>
+        <p v-if="!compact" class="text-xs text-base-content/50">
+          Canonical creative direction recorded on the ArtJob and finished image.
+        </p>
+      </div>
+      <button
+        v-if="modelValue.length"
+        type="button"
+        class="btn btn-ghost btn-xs rounded-xl"
+        @click="emitValue([])"
+      >
+        Clear
+      </button>
+    </div>
+
+    <div v-if="selectedFacets.length" class="flex flex-wrap gap-1.5">
+      <button
+        v-for="facet in selectedFacets"
+        :key="facet.id"
+        type="button"
+        class="badge badge-secondary h-auto min-h-7 gap-1 rounded-xl py-1 pl-1"
+        :title="`${taxonomyLabel(facet.taxonomy)} · click to remove`"
+        @click="removeFacet(facet.id)"
+      >
+        <span
+          v-if="facetArtwork(facet)"
+          class="size-5 overflow-hidden rounded-lg bg-base-200"
+        >
+          <img
+            :src="facetArtwork(facet) || ''"
+            :alt="`${facet.title} artwork`"
+            class="size-full object-cover"
+          />
+        </span>
+        {{ facet.title }}
+        <span class="opacity-60">×</span>
+      </button>
+    </div>
+
+    <div class="relative">
+      <input
+        v-model="search"
+        type="search"
+        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        placeholder="Add style, theme, mood, material, character trait…"
+        @focus="open = true"
+      />
+      <div
+        v-if="open && search.trim()"
+        class="absolute z-40 mt-1 max-h-72 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
+      >
+        <button
+          v-for="facet in results"
+          :key="facet.id"
+          type="button"
+          class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left hover:bg-base-200 disabled:opacity-40"
+          :disabled="selectedSet.has(facet.id)"
+          @click="addFacet(facet.id)"
+        >
+          <span
+            class="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+          >
+            <img
+              v-if="facetArtwork(facet)"
+              :src="facetArtwork(facet) || ''"
+              :alt="`${facet.title} artwork`"
+              class="size-full object-cover"
+            />
+            <Icon v-else :name="facet.icon || 'kind-icon:tag'" class="size-4" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="block truncate text-sm font-semibold">{{ facet.title }}</span>
+            <span class="block truncate text-[11px] text-base-content/45">
+              {{ taxonomyLabel(facet.taxonomy) }}
+              <template v-if="facet.groupLabel"> · {{ facet.groupLabel }}</template>
+            </span>
+          </span>
+          <Icon name="kind-icon:plus" class="size-3.5" />
+        </button>
+        <p v-if="!results.length" class="px-3 py-3 text-xs text-base-content/45">
+          No matching canonical Facet.
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  useFacetCatalogStore,
+  type FacetCatalogEntry,
+  type FacetTaxonomy,
+} from '@/stores/facetCatalogStore'
+import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: number[]
+    label?: string
+    compact?: boolean
+    taxonomies?: FacetTaxonomy[] | null
+  }>(),
+  {
+    label: 'Creative Facets',
+    compact: false,
+    taxonomies: null,
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number[]]
+}>()
+
+const catalog = useFacetCatalogStore()
+const search = ref('')
+const open = ref(false)
+const selectedSet = computed(() => new Set(props.modelValue))
+const allowedTaxonomies = computed(() =>
+  props.taxonomies?.length ? new Set(props.taxonomies) : null,
+)
+
+const selectedFacets = computed(() => {
+  const byId = new Map(catalog.entries.map((entry) => [entry.id, entry]))
+  return props.modelValue
+    .map((id) => byId.get(id))
+    .filter((entry): entry is FacetCatalogEntry => Boolean(entry))
+})
+
+const results = computed(() => {
+  const needle = normalizeFacetLookupKey(search.value)
+  if (!needle) return []
+  return catalog.entries
+    .filter((facet) => {
+      if (!facet.isActive) return false
+      if (allowedTaxonomies.value && !allowedTaxonomies.value.has(facet.taxonomy)) {
+        return false
+      }
+      return [
+        facet.title,
+        facet.canonicalValue,
+        facet.slug || '',
+        facet.taxonomy,
+        facet.groupLabel || '',
+        ...facet.aliases,
+      ].some((value) => normalizeFacetLookupKey(value).includes(needle))
+    })
+    .slice(0, 40)
+})
+
+onMounted(async () => {
+  if (!catalog.loaded) {
+    await catalog.fetchCatalog({ includeMature: true, take: 1000 })
+  }
+})
+
+function emitValue(ids: number[]): void {
+  emit(
+    'update:modelValue',
+    [...new Set(ids.filter((id) => Number.isInteger(id) && id > 0))].slice(0, 50),
+  )
+}
+
+function addFacet(id: number): void {
+  emitValue([...props.modelValue, id])
+  search.value = ''
+  open.value = false
+}
+
+function removeFacet(id: number): void {
+  emitValue(props.modelValue.filter((value) => value !== id))
+}
+
+function facetArtwork(facet: FacetCatalogEntry): string | null {
+  return facet.cardPath || facet.imagePath || facet.heroPath || null
+}
+
+function taxonomyLabel(taxonomy: string): string {
+  return taxonomy
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+</script>

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -10,14 +10,12 @@
     <div
       class="flex max-h-[94vh] w-full max-w-4xl flex-col overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-2xl"
     >
-      <div class="flex items-start justify-between gap-3 border-b border-base-300 p-4">
+      <header class="flex items-start justify-between gap-3 border-b border-base-300 p-4">
         <div>
           <h3 id="artjob-editor-title" class="text-lg font-semibold">
             {{ editorTitle }}
           </h3>
-          <p class="mt-1 text-xs text-base-content/60">
-            {{ actionHint }}
-          </p>
+          <p class="mt-1 text-xs text-base-content/60">{{ actionHint }}</p>
         </div>
         <button
           type="button"
@@ -27,7 +25,7 @@
         >
           ✕
         </button>
-      </div>
+      </header>
 
       <div class="min-h-0 flex-1 overflow-y-auto p-4">
         <div
@@ -40,7 +38,7 @@
         <div class="grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)]">
           <div class="flex min-w-0 flex-col gap-4">
             <label class="flex flex-col gap-1 text-sm">
-              <span class="font-semibold">Prompt</span>
+              <span class="font-semibold">Base prompt</span>
               <textarea
                 v-model="form.promptString"
                 rows="8"
@@ -48,9 +46,14 @@
                 placeholder="Describe the visible subject, action, setting, composition, mood, and concrete rendering style."
               />
               <span class="text-[11px] text-base-content/50">
-                Image ids and phrases like “Kind Robots style” are rejected as insufficient context.
+                Facet direction is rebuilt separately, so adding or removing chips never duplicates prompt text.
               </span>
             </label>
+
+            <art-facet-selector
+              v-model="facetIds"
+              label="ArtJob Facets"
+            />
 
             <label class="flex flex-col gap-1 text-sm">
               <span class="font-semibold">Negative prompt</span>
@@ -63,75 +66,23 @@
             </label>
 
             <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">Width</span>
+              <label
+                v-for="field in numericFields"
+                :key="field.key"
+                class="flex flex-col gap-1 text-xs"
+              >
+                <span class="font-semibold">{{ field.label }}</span>
                 <input
-                  v-model="form.width"
+                  v-model="form[field.key]"
                   type="number"
-                  min="64"
-                  step="8"
+                  :min="field.min"
+                  :max="field.max"
+                  :step="field.step"
                   class="input input-bordered input-sm rounded-xl"
+                  :placeholder="field.placeholder"
                 />
               </label>
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">Height</span>
-                <input
-                  v-model="form.height"
-                  type="number"
-                  min="64"
-                  step="8"
-                  class="input input-bordered input-sm rounded-xl"
-                />
-              </label>
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">Seed</span>
-                <input
-                  v-model="form.seed"
-                  type="number"
-                  class="input input-bordered input-sm rounded-xl"
-                  placeholder="blank = random"
-                />
-              </label>
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">Steps</span>
-                <input
-                  v-model="form.steps"
-                  type="number"
-                  min="1"
-                  class="input input-bordered input-sm rounded-xl"
-                />
-              </label>
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">CFG</span>
-                <input
-                  v-model="form.cfg"
-                  type="number"
-                  min="0"
-                  step="0.1"
-                  class="input input-bordered input-sm rounded-xl"
-                />
-              </label>
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">Guidance</span>
-                <input
-                  v-model="form.guidance"
-                  type="number"
-                  min="0"
-                  step="0.1"
-                  class="input input-bordered input-sm rounded-xl"
-                />
-              </label>
-              <label class="flex flex-col gap-1 text-xs">
-                <span class="font-semibold">Denoise</span>
-                <input
-                  v-model="form.denoise"
-                  type="number"
-                  min="0"
-                  max="1"
-                  step="0.05"
-                  class="input input-bordered input-sm rounded-xl"
-                />
-              </label>
+
               <label class="flex flex-col gap-1 text-xs">
                 <span class="font-semibold">Sampler</span>
                 <input
@@ -158,9 +109,6 @@
                 class="input input-bordered rounded-2xl"
                 placeholder="Keep the current model or choose a preset"
               />
-              <span class="text-[11px] text-base-content/50">
-                Engine presets replace this with a compatible default. You can still type another installed model filename.
-              </span>
             </label>
           </div>
 
@@ -213,8 +161,11 @@
             </div>
 
             <div class="rounded-2xl border border-base-300 p-3 text-xs">
-              <div class="font-semibold">Preset defaults</div>
+              <div class="font-semibold">Current selection</div>
               <div class="mt-2 flex flex-wrap gap-1">
+                <span class="badge badge-outline badge-sm rounded-2xl">
+                  {{ facetIds.length }} Facets
+                </span>
                 <span class="badge badge-outline badge-sm rounded-2xl">
                   {{ form.steps || '—' }} steps
                 </span>
@@ -224,18 +175,15 @@
                 <span class="badge badge-outline badge-sm rounded-2xl">
                   {{ form.sampler || 'sampler default' }}
                 </span>
-                <span class="badge badge-outline badge-sm rounded-2xl">
-                  {{ form.scheduler || 'scheduler default' }}
-                </span>
               </div>
             </div>
           </aside>
         </div>
       </div>
 
-      <div class="flex flex-wrap items-center justify-between gap-3 border-t border-base-300 p-4">
+      <footer class="flex flex-wrap items-center justify-between gap-3 border-t border-base-300 p-4">
         <p class="text-xs text-base-content/50">
-          Blank seed = fresh random seed. Other blank numeric/model fields keep the current value unless an engine preset supplies defaults.
+          Blank seed creates a fresh random seed. Facets are persisted as canonical ArtJob provenance.
         </p>
         <div class="flex gap-2">
           <button
@@ -256,7 +204,7 @@
             {{ actionLabel }}
           </button>
         </div>
-      </div>
+      </footer>
     </div>
 
     <datalist id="artjob-sampler-presets">
@@ -294,6 +242,18 @@ import {
 
 type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
 type JsonRecord = Record<string, unknown>
+type FormKey =
+  | 'width'
+  | 'height'
+  | 'steps'
+  | 'cfg'
+  | 'guidance'
+  | 'denoise'
+  | 'seed'
+type FacetAwareOverrides = ArtJobOverrides & {
+  basePromptString?: string | null
+  facetIds?: number[] | null
+}
 type Preset = {
   value: string
   label: string
@@ -307,16 +267,8 @@ type Preset = {
   scheduler: string
 }
 
-const props = defineProps<{
-  job: ArtJobRecord
-  action: EditorAction
-}>()
-
-const emit = defineEmits<{
-  close: []
-  saved: []
-}>()
-
+const props = defineProps<{ job: ArtJobRecord; action: EditorAction }>()
+const emit = defineEmits<{ close: []; saved: [] }>()
 const artJobStore = useArtJobStore()
 const localError = ref('')
 const preset = ref('keep')
@@ -337,7 +289,7 @@ const enginePresets: Preset[] = [
   {
     value: 'krea2',
     label: 'Krea 2 Turbo',
-    hint: 'Fast, highly creative illustration preset built for the installed 12 GB workflow.',
+    hint: 'Fast, highly creative illustration preset.',
     checkpoint: 'Krea-2-Turbo-Q5_K_S.gguf',
     steps: '8',
     cfg: '1',
@@ -349,7 +301,7 @@ const enginePresets: Preset[] = [
   {
     value: 'flux2',
     label: 'Flux.2 Klein 4B',
-    hint: 'Four-step structured prompt model with a compact Apache-2.0 workflow.',
+    hint: 'Four-step structured prompt model.',
     checkpoint: 'flux-2-klein-4b-Q4_K_M.gguf',
     steps: '4',
     cfg: '1',
@@ -361,7 +313,7 @@ const enginePresets: Preset[] = [
   {
     value: 'flux',
     label: 'Flux.1 Dev',
-    hint: 'Slower high-detail Flux workflow using the corrected T5-XXL encoder path.',
+    hint: 'Slower high-detail Flux workflow.',
     checkpoint: 'flux1-dev-Q8_0.gguf',
     steps: '30',
     cfg: '1',
@@ -373,7 +325,7 @@ const enginePresets: Preset[] = [
   {
     value: 'sdxl',
     label: 'Comfy checkpoint workflow',
-    hint: 'Traditional checkpoint workflow with broader sampler and LoRA compatibility.',
+    hint: 'Traditional checkpoint workflow with broad compatibility.',
     checkpoint: 'v1-5-pruned-emaonly.safetensors',
     steps: '20',
     cfg: '3',
@@ -385,18 +337,17 @@ const enginePresets: Preset[] = [
 ]
 
 function asRecord(value: unknown): JsonRecord {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
-  return value as JsonRecord
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {}
 }
-
 function scalar(value: unknown): string {
   if (typeof value === 'string') return value.trim()
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   return ''
 }
-
 function nestedScalar(value: unknown, keys: string[], depth = 0): string {
-  if (depth > 6 || value === null || value === undefined) return ''
+  if (depth > 6 || value == null) return ''
   if (Array.isArray(value)) {
     for (const child of value) {
       const result = nestedScalar(child, keys, depth + 1)
@@ -404,7 +355,6 @@ function nestedScalar(value: unknown, keys: string[], depth = 0): string {
     }
     return ''
   }
-
   const record = asRecord(value)
   for (const key of keys) {
     const direct = scalar(record[key])
@@ -416,7 +366,6 @@ function nestedScalar(value: unknown, keys: string[], depth = 0): string {
   }
   return ''
 }
-
 function payloadScalar(keys: string[]): string {
   const payload = asRecord(props.job.payload)
   for (const key of keys) {
@@ -425,7 +374,6 @@ function payloadScalar(keys: string[]): string {
   }
   return nestedScalar(payload.workflow, keys)
 }
-
 function workflowPrompt(kind: 'positive' | 'negative'): string {
   const workflow = asRecord(asRecord(props.job.payload).workflow)
   for (const value of Object.values(workflow)) {
@@ -447,9 +395,22 @@ function workflowPrompt(kind: 'positive' | 'negative'): string {
   }
   return ''
 }
+function payloadFacetIds(): number[] {
+  const facets = asRecord(props.job.payload).facets
+  if (!Array.isArray(facets)) return []
+  return [
+    ...new Set(
+      facets
+        .map((value) => Number(asRecord(value).id))
+        .filter((id) => Number.isInteger(id) && id > 0),
+    ),
+  ]
+}
 
+const facetIds = ref<number[]>(payloadFacetIds())
 const form = reactive({
   promptString:
+    payloadScalar(['basePromptString']) ||
     payloadScalar(['promptString', 'artPrompt', 'positivePrompt', 'prompt']) ||
     workflowPrompt('positive'),
   negativePrompt:
@@ -471,6 +432,23 @@ const form = reactive({
     'model_name',
   ]),
 })
+
+const numericFields: Array<{
+  key: FormKey
+  label: string
+  min?: string
+  max?: string
+  step?: string
+  placeholder?: string
+}> = [
+  { key: 'width', label: 'Width', min: '64', step: '8' },
+  { key: 'height', label: 'Height', min: '64', step: '8' },
+  { key: 'seed', label: 'Seed', placeholder: 'blank = random' },
+  { key: 'steps', label: 'Steps', min: '1' },
+  { key: 'cfg', label: 'CFG', min: '0', step: '0.1' },
+  { key: 'guidance', label: 'Guidance', min: '0', step: '0.1' },
+  { key: 'denoise', label: 'Denoise', min: '0', max: '1', step: '0.05' },
+]
 
 const selectedPreset = computed(
   () => enginePresets.find((option) => option.value === preset.value) ?? enginePresets[0]!,
@@ -494,21 +472,21 @@ const actionLabel = computed(() => {
 })
 const actionHint = computed(() => {
   if (props.action === 'EDIT') {
-    return 'The same pending, failed, or cancelled job is updated and returned to PENDING.'
+    return 'Update this queue row and return it to PENDING.'
   }
   if (props.action === 'OVERWRITE') {
-    return 'The replacement preserves the canonical ArtImage id and archives the current render.'
+    return 'Preserve the canonical ArtImage id and archive the current render.'
   }
-  return 'The original job and ArtImage remain unchanged; this creates a separate attempt.'
+  return 'Keep the original job and create a separate attempt.'
 })
 const actionDescription = computed(() => {
   if (props.action === 'EDIT') {
-    return 'No duplicate queue row is created. Failed state, claims, errors, and attempts are cleared.'
+    return 'Failed state, claims, errors, and attempts are cleared.'
   }
   if (props.action === 'OVERWRITE') {
-    return 'Use this when the generic render already landed in a linked ArtImage that needs repair in place.'
+    return 'Use this to repair a linked ArtImage in place.'
   }
-  return 'Use this for running or completed jobs when you want another candidate without replacing the existing image.'
+  return 'Use this when you want another candidate without replacing existing art.'
 })
 
 function applyPreset(): void {
@@ -523,7 +501,6 @@ function applyPreset(): void {
   form.scheduler = selected.scheduler
   form.seed = ''
 }
-
 function numberValue(value: string): number | null {
   if (!value.trim()) return null
   const parsed = Number(value)
@@ -538,11 +515,12 @@ async function save(): Promise<void> {
     return
   }
 
-  const overrides: ArtJobOverrides = {
+  const overrides: FacetAwareOverrides = {
     promptString: prompt,
+    basePromptString: prompt,
+    facetIds: [...facetIds.value],
     negativePrompt: form.negativePrompt.trim(),
   }
-
   const numeric: Array<[keyof ArtJobOverrides, string]> = [
     ['width', form.width],
     ['height', form.height],
@@ -556,7 +534,6 @@ async function save(): Promise<void> {
     const parsed = numberValue(value)
     if (parsed !== null) overrides[key] = parsed as never
   }
-
   if (form.sampler.trim()) overrides.sampler = form.sampler.trim()
   if (form.scheduler.trim()) overrides.scheduler = form.scheduler.trim()
   if (form.checkpoint.trim()) overrides.checkpoint = form.checkpoint.trim()
@@ -566,7 +543,6 @@ async function save(): Promise<void> {
     preset: preset.value === 'keep' ? null : preset.value,
     overrides,
   }
-
   let success = false
   if (props.action === 'EDIT') {
     success = await artJobStore.editJob(props.job.id, options)

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -1,6 +1,12 @@
 <!-- /components/art/generate-button.vue -->
 <template>
   <section class="flex w-full flex-col gap-3">
+    <art-facet-selector
+      v-model="artFacetDraft.selectedIds"
+      label="Creative Facets"
+      :compact="true"
+    />
+
     <div
       class="grid w-full grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
     >
@@ -115,6 +121,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import type { ArtImage, Server } from '~/prisma/generated/prisma/client'
 import { ErrorType, useErrorStore } from '@/stores/errorStore'
 import { useArtStore, type GenerateArtData } from '@/stores/artStore'
+import { useArtFacetDraftStore } from '@/stores/artFacetDraftStore'
 import { useManaStore } from '@/stores/manaStore'
 import { useUserStore } from '@/stores/userStore'
 import { useServerStore } from '@/stores/serverStore'
@@ -152,6 +159,7 @@ const emit = defineEmits<{
 }>()
 
 const artStore = useArtStore()
+const artFacetDraft = useArtFacetDraftStore()
 const errorStore = useErrorStore()
 const manaStore = useManaStore()
 const userStore = useUserStore()
@@ -163,9 +171,6 @@ const resultImage = computed(
   () => artStore.lastGeneratedArtImage || artStore.currentArtImage || null,
 )
 
-// While a generation is in flight it now goes through the durable ArtJob
-// queue: reflect whether the job is waiting for the relay ("Queued…") or
-// actively rendering ("Rendering…"). Falls back to the caller's busyLabel.
 const busyText = computed(() => {
   if (artStore.queueState === 'queued') return 'Queued…'
   if (artStore.queueState === 'rendering') return 'Rendering…'
@@ -190,7 +195,6 @@ const hasServerChoices = computed(() => {
 
 const alternateServerOptions = computed<Server[]>(() => {
   const defaultId = defaultServerId.value
-
   return serverOptions.value.filter((server) => {
     if (!server?.id) return false
     return server.id !== defaultId
@@ -199,28 +203,19 @@ const alternateServerOptions = computed<Server[]>(() => {
 
 const selectedSpecificServerId = computed<number | null>(() => {
   if (!serverChoice.value.startsWith('server:')) return null
-
   const id = Number(serverChoice.value.replace('server:', ''))
-
   return Number.isInteger(id) && id > 0 ? id : null
 })
 
 const selectedSpecificServer = computed<Server | null>(() => {
   const id = selectedSpecificServerId.value
   if (!id) return null
-
   return serverStore.getServerById(id) || null
 })
 
 const displayServer = computed<Server | null>(() => {
-  if (serverChoice.value === 'default') {
-    return defaultServer.value
-  }
-
-  if (serverChoice.value.startsWith('server:')) {
-    return selectedSpecificServer.value
-  }
-
+  if (serverChoice.value === 'default') return defaultServer.value
+  if (serverChoice.value.startsWith('server:')) return selectedSpecificServer.value
   return artStore.activeGenerationServer || defaultServer.value || null
 })
 
@@ -229,10 +224,7 @@ const billingServer = computed<Server | null>(() => {
 })
 
 const defaultServerOptionLabel = computed(() => {
-  if (!defaultServer.value) {
-    return 'Default Image Server'
-  }
-
+  if (!defaultServer.value) return 'Default Image Server'
   return `Default: ${getServerDisplayLabel(defaultServer.value)}`
 })
 
@@ -252,13 +244,8 @@ const selectionSummary = computed(() => {
   if (serverChoice.value === 'any') {
     return 'Whatever compatible image server is available'
   }
-
   const server = displayServer.value
-
-  if (!server) {
-    return 'No image server selected'
-  }
-
+  if (!server) return 'No image server selected'
   return getServerDisplayLabel(server)
 })
 
@@ -268,38 +255,32 @@ const selectionDetail = computed(() => {
       ? 'Uses your preferred image server. Change this in Server Connections.'
       : 'No preferred image server is currently saved.'
   }
-
   if (serverChoice.value === 'any') {
     return 'The art store will pick the best compatible server for this request.'
   }
-
   return 'Uses this server for this generation only.'
 })
 
 const usesOwnServer = computed(() => {
   const server = billingServer.value
-
-  if (!server) return false
-  if (!server.isActive) return false
+  if (!server || !server.isActive) return false
   if (server.userId && server.userId === userStore.userId) return true
   if (server.isPublic && !server.isOfficial) return true
-
   return false
 })
 
 const canAfford = computed(() => {
   if (manaStore.isFamily) return true
   if (usesOwnServer.value) return true
-
   return manaStore.balance > 0
 })
 
 const canClick = computed(() => {
   return Boolean(
     artStore.canGenerateArt &&
-    !artStore.isGenerating &&
-    canAfford.value &&
-    hasServerChoices.value,
+      !artStore.isGenerating &&
+      canAfford.value &&
+      hasServerChoices.value,
   )
 })
 
@@ -307,20 +288,15 @@ watch(
   () => artStore.artForm.serverId,
   (serverId) => {
     if (!serverId) {
-      if (serverChoice.value.startsWith('server:')) {
-        serverChoice.value = 'default'
-      }
-
+      if (serverChoice.value.startsWith('server:')) serverChoice.value = 'default'
       return
     }
-
     serverChoice.value = getSpecificServerValue(serverId)
   },
 )
 
 onMounted(async () => {
-  await artStore.prepareArtGenerator()
-
+  await Promise.all([artStore.prepareArtGenerator(), artFacetDraft.initialize()])
   if (artStore.artForm.serverId) {
     serverChoice.value = getSpecificServerValue(artStore.artForm.serverId)
   }
@@ -335,7 +311,6 @@ function getServerEngineLabel(server: Server): string {
   if (server.serverType === 'COMFY') return 'Comfy'
   if (server.serverType === 'A1111') return 'Stable Diffusion'
   if (server.serverType === 'ANTHROPIC') return 'Anthropic'
-
   return 'Image'
 }
 
@@ -345,24 +320,16 @@ function getServerDisplayLabel(server: Server): string {
 }
 
 function handleServerChoiceChange() {
-  if (serverChoice.value === 'default') {
+  if (serverChoice.value === 'default' || serverChoice.value === 'any') {
     artStore.selectGenerationServer(null)
     return
   }
-
-  if (serverChoice.value === 'any') {
-    artStore.selectGenerationServer(null)
-    return
-  }
-
   const serverId = selectedSpecificServerId.value
-
   if (!serverId) {
     artStore.selectGenerationServer(null)
     serverChoice.value = 'default'
     return
   }
-
   artStore.selectGenerationServer(serverId)
 }
 
@@ -387,46 +354,55 @@ function buildCleanRoutingOverrides(): Pick<
 
 function buildGenerationOverrides(): GenerateArtDataWithRouting {
   const cleanRouting = buildCleanRoutingOverrides()
+  let routed: GenerateArtDataWithRouting
 
   if (serverChoice.value === 'default') {
-    return {
+    routed = {
       ...props.overrides,
       ...cleanRouting,
       serverId: null,
       serverName: null,
       serverSelectionMode: 'default',
     }
-  }
-
-  if (serverChoice.value === 'any') {
-    return {
+  } else if (serverChoice.value === 'any') {
+    routed = {
       ...props.overrides,
       ...cleanRouting,
       serverId: null,
       serverName: null,
       serverSelectionMode: 'any',
     }
+  } else {
+    const server = selectedSpecificServer.value
+    routed = {
+      ...props.overrides,
+      ...cleanRouting,
+      serverId: server?.id ?? null,
+      serverName: server
+        ? server.label || server.title || `Server #${server.id}`
+        : null,
+      serverSelectionMode: 'specific',
+    }
   }
 
-  const server = selectedSpecificServer.value
-
-  return {
-    ...props.overrides,
-    ...cleanRouting,
-    serverId: server?.id ?? null,
-    serverName: server
-      ? server.label || server.title || `Server #${server.id}`
-      : null,
-    serverSelectionMode: 'specific',
-  }
+  const basePrompt = String(
+    routed.promptString ||
+      routed.artPrompt ||
+      routed.prompt ||
+      artStore.finalPromptString ||
+      artStore.artForm.promptString ||
+      '',
+  )
+  return artFacetDraft.decorateGenerationData(
+    routed as Record<string, unknown>,
+    basePrompt,
+  ) as GenerateArtDataWithRouting
 }
 
 async function handleGenerate() {
   const result = await artStore.generateCurrentArt(buildGenerationOverrides())
-
   if (!result.success || !result.data) {
     const message = result.message || 'Generation failed.'
-
     if (/mana|⚡/i.test(message)) {
       errorStore.addError(
         ErrorType.INTERACTION_ERROR,
@@ -435,11 +411,9 @@ async function handleGenerate() {
     } else {
       errorStore.addError(ErrorType.GENERAL_ERROR, message)
     }
-
     emit('failed', message)
     return
   }
-
   emit('generated', result.data)
 }
 </script>

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -1,24 +1,4 @@
 // /server/api/art/enqueue.post.ts
-//
-// High-level, engine-dispatching enqueue endpoint. This is the single surface
-// the browser art flow (stores/artStore.ts) posts to: it charges mana, builds
-// the correct ArtJob payload for the requested engine, and creates a durable
-// ArtJob. The home relay agent then claims the job outward, renders it against
-// local A1111/Comfy, uploads via /api/art/save-generated, and completes it —
-// so generation works even though the deployed backend cannot reach the home
-// GPU box. Poll /api/art/queue/:id until DONE, then load the ArtImage.
-//
-// Distinct from POST /api/art/queue (the low-level producer surface used by
-// conductor scripts with pre-built payloads and no mana gate). Browser/billed
-// work must go through here so mana is charged exactly once, at enqueue time.
-//
-// The payload carries a `save` block (isPublic/isMature/designer); the complete
-// endpoint applies it plus ownership by the enqueuing user to the uploaded
-// ArtImage, since the relay uploads as its own machine user.
-//
-// OpenAI is intentionally NOT handled here — the backend reaches OpenAI
-// directly (no relay needed), so the browser keeps calling the synchronous
-// /api/chats/openai/images/generate for that engine.
 import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
@@ -47,9 +27,14 @@ import {
   WAN_DEFAULT_DURATION,
   WAN_DEFAULT_FRAME_RATE,
 } from '../comfy/wan/utils/imageToVideoWorkflow'
+import {
+  applyArtFacetsToPayload,
+  normalizeArtFacetIds,
+  resolveArtFacetSelection,
+} from '../../utils/artFacetSelection'
 
-// The queueable engines. `openai` is handled synchronously elsewhere.
-// `ltx` and `wan` are image-to-video engines (media: 'video').
+const ART_FACET_WORKFLOW_KEY = '__kindRobotsFacetSelection'
+
 type EnqueueEngine =
   | 'a1111'
   | 'comfy'
@@ -60,31 +45,15 @@ type EnqueueEngine =
   | 'ltx'
   | 'wan'
 
-// Aliases so callers can say "krea"/"klein"/"flux2-klein"/"sdxl" etc.
-const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
-  krea: 'krea2',
-  'krea-2': 'krea2',
-  'krea2-turbo': 'krea2',
-  klein: 'flux2',
-  'flux2-klein': 'flux2',
-  'flux-2': 'flux2',
-  // The SDXL/SD graph is the default "comfy" engine; let callers name it 'sdxl'.
-  sdxl: 'comfy',
-}
+type JsonRecord = Record<string, unknown>
 
-const VIDEO_ENGINES = new Set<EnqueueEngine>(['ltx', 'wan'])
-
-// Sensible negative prompt for video so callers can omit it.
-const DEFAULT_VIDEO_NEGATIVE =
-  'low quality, blurry, distorted, jittery, flickering, watermark, text, logo'
-
-// GenerateArtData-shaped body (a superset; only the fields used per engine are
-// read). Mirrors stores/artStore.ts GenerateArtData.
 type ArtEnqueueRequest = {
   engine?: string | null
   promptString?: string | null
   prompt?: string | null
   artPrompt?: string | null
+  basePromptString?: string | null
+  facetIds?: number[] | null
   negativePrompt?: string | null
   checkpoint?: string | null
   sampler?: string | null
@@ -98,13 +67,9 @@ type ArtEnqueueRequest = {
   width?: number | null
   height?: number | null
   variant?: 'dev' | 'schnell' | null
-  // Flux.2 Klein structured prompt (bound compositions), and an optional
-  // model-only style LoRA (comic/ink) shared by krea2 / flux2.
   jsonPrompt?: Record<string, unknown> | unknown[] | null
   loraName?: string | null
   loraStrength?: number | null
-  // Resource provenance: the picker sends the Resource ids it selected so the
-  // finished ArtImage can be linked back to them (see resourceProvenance.ts).
   checkpointResourceId?: number | null
   loraResourceIds?: number[] | null
   designer?: string | null
@@ -114,20 +79,36 @@ type ArtEnqueueRequest = {
   serverName?: string | null
   projectSlug?: string | null
   priority?: number | null
-  // Kontext (image-to-image) source.
   sourceImageBase64?: string | null
-  // Video (ltx / wan) inputs. Both images optional; if neither is given the
-  // engine falls back to a text-driven clip.
   firstImageBase64?: string | null
   secondImageBase64?: string | null
   durationSeconds?: number | null
   fps?: number | null
   frameRate?: number | null
   loop?: boolean | null
+  workflow?: Record<string, unknown> | null
 }
 
-// ComfyEngine used by the mana gate — a1111 shares comfy's base 2D cost, and
-// the video engines bill against their own cost tiers.
+type SaveBlock = {
+  isPublic: boolean
+  isMature: boolean
+  designer: string | null
+}
+
+type QueuedImage = { name: string; imageData: string }
+
+const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
+  krea: 'krea2',
+  'krea-2': 'krea2',
+  'krea2-turbo': 'krea2',
+  klein: 'flux2',
+  'flux2-klein': 'flux2',
+  'flux-2': 'flux2',
+  sdxl: 'comfy',
+}
+const VIDEO_ENGINES = new Set<EnqueueEngine>(['ltx', 'wan'])
+const DEFAULT_VIDEO_NEGATIVE =
+  'low quality, blurry, distorted, jittery, flickering, watermark, text, logo'
 const GATE_ENGINE: Record<
   EnqueueEngine,
   'comfy' | 'flux' | 'kontext' | 'ltx' | 'wan'
@@ -135,21 +116,38 @@ const GATE_ENGINE: Record<
   a1111: 'comfy',
   comfy: 'comfy',
   flux: 'flux',
-  // Krea 2 Turbo (8-step) and Flux.2 Klein (4-step) are cheap 2D renders — bill
-  // them at the base comfy 2D tier until they get their own cost tiers.
   krea2: 'comfy',
   flux2: 'comfy',
   kontext: 'kontext',
   ltx: 'ltx',
   wan: 'wan',
 }
-
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {}
+}
+
+function facetRequest(body: ArtEnqueueRequest | null): {
+  facetIds: number[]
+  basePromptString: string
+} {
+  const carrier = asRecord(asRecord(body?.workflow)[ART_FACET_WORKFLOW_KEY])
+  const directIds = normalizeArtFacetIds(body?.facetIds)
+  const carrierIds = normalizeArtFacetIds(carrier.facetIds)
+  return {
+    facetIds: directIds.length ? directIds : carrierIds,
+    basePromptString: String(
+      body?.basePromptString || carrier.basePromptString || '',
+    ).trim(),
+  }
+}
 
 function normalizeEngine(value: unknown): EnqueueEngine {
   const raw = String(value || 'a1111').toLowerCase()
   const engine = ENGINE_ALIASES[raw] ?? raw
-
   if (
     engine === 'a1111' ||
     engine === 'comfy' ||
@@ -162,42 +160,29 @@ function normalizeEngine(value: unknown): EnqueueEngine {
   ) {
     return engine
   }
-
   throw createError({
     statusCode: 400,
     message:
       engine === 'openai'
-        ? 'OpenAI generation is synchronous; call /api/chats/openai/images/generate instead of enqueuing.'
-        : `Unsupported enqueue engine "${engine}". Use a1111, comfy, flux, krea2, flux2, kontext, ltx, or wan.`,
+        ? 'OpenAI generation is synchronous; call the OpenAI image endpoint instead.'
+        : `Unsupported enqueue engine "${engine}".`,
   })
 }
 
 export default defineEventHandler(async (event) => {
   try {
     const body = (await readBody(event)) as ArtEnqueueRequest | null
-
     const engine = normalizeEngine(body?.engine)
-
-    const promptString = (
-      body?.promptString ||
-      body?.artPrompt ||
-      body?.prompt ||
-      ''
+    const requestedPrompt = String(
+      body?.promptString || body?.artPrompt || body?.prompt || '',
     ).trim()
-
-    if (!promptString) {
-      throw createError({
-        statusCode: 400,
-        message: 'Missing required field: "promptString".',
-      })
+    if (!requestedPrompt) {
+      throw createError({ statusCode: 400, message: 'Missing required field: "promptString".' })
     }
 
-    // Video clips bill by frame count (duration × fps), so heavier clips cost
-    // more mana. Non-video engines leave this null and bill per-image.
     const videoFrames = VIDEO_ENGINES.has(engine)
       ? resolveVideoFrames(engine, body)
       : null
-
     const gate = await authAndGate(event, {
       engine: GATE_ENGINE[engine],
       steps: body?.steps ?? null,
@@ -207,32 +192,40 @@ export default defineEventHandler(async (event) => {
       serverId: body?.serverId ?? null,
     })
 
-    const projectSlug = body?.projectSlug?.trim().toLowerCase() || null
-
-    if (projectSlug && !SLUG_PATTERN.test(projectSlug)) {
-      throw createError({ statusCode: 400, message: 'Invalid projectSlug.' })
-    }
-
-    const priority = Number.isInteger(body?.priority)
-      ? Number(body?.priority)
-      : 0
+    const requestedFacets = facetRequest(body)
+    const basePromptString = requestedFacets.basePromptString || requestedPrompt
+    const facets = await resolveArtFacetSelection({
+      facetIds: requestedFacets.facetIds,
+      userId: gate.user.id,
+      isAdmin: Boolean((gate.user as { isAdmin?: boolean }).isAdmin),
+      includeMature: Boolean(body?.isMature),
+    })
 
     const save = {
       isPublic: body?.isPublic ?? true,
       isMature: body?.isMature ?? false,
       designer: body?.designer?.trim() || null,
     }
+    const previewPayload: Record<string, unknown> = {}
+    const promptString = applyArtFacetsToPayload(
+      previewPayload,
+      basePromptString,
+      facets,
+    )
+
+    const projectSlug = body?.projectSlug?.trim().toLowerCase() || null
+    if (projectSlug && !SLUG_PATTERN.test(projectSlug)) {
+      throw createError({ statusCode: 400, message: 'Invalid projectSlug.' })
+    }
+    const priority = Number.isInteger(body?.priority) ? Number(body?.priority) : 0
 
     const { jobEngine, payload } = buildJobPayload(engine, {
       body: body ?? {},
       promptString,
       save,
     })
+    applyArtFacetsToPayload(payload, basePromptString, facets)
 
-    // Stamp resource provenance onto the payload so completion can link the
-    // finished ArtImage back to the checkpoint + LoRA Resources it used. Both
-    // explicit ids (from the picker) and the name strings (for backfill) are
-    // stored; completion resolves and verifies them best-effort.
     const provenanceResources = {
       checkpointResourceId:
         Number.isInteger(body?.checkpointResourceId) &&
@@ -242,9 +235,9 @@ export default defineEventHandler(async (event) => {
       loraResourceIds: Array.isArray(body?.loraResourceIds)
         ? [
             ...new Set(
-              body!.loraResourceIds!
+              body.loraResourceIds
                 .map(Number)
-                .filter((n) => Number.isInteger(n) && n > 0),
+                .filter((id) => Number.isInteger(id) && id > 0),
             ),
           ]
         : [],
@@ -269,11 +262,8 @@ export default defineEventHandler(async (event) => {
         userId: gate.user.id,
       },
     })
-
     const { balance } = await gate.commit(`art-enqueue:${job.id}`)
-
     event.node.res.statusCode = 201
-
     return {
       success: true,
       message: 'Art job queued. Poll /api/art/queue/:id until DONE.',
@@ -286,32 +276,20 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error: unknown) {
     const handled = errorHandler(error)
-    const statusCode = handled.statusCode || 500
-
-    event.node.res.statusCode = statusCode
-
+    event.node.res.statusCode = handled.statusCode || 500
     return {
       success: false,
       message: handled.message || 'Failed to queue art job.',
-      statusCode,
+      statusCode: event.node.res.statusCode,
     }
   }
 })
 
-type SaveBlock = {
-  isPublic: boolean
-  isMature: boolean
-  designer: string | null
-}
-
-// Build the ArtJob engine + payload for the resolved generation engine. A1111
-// jobs carry raw txt2img params; Comfy-family jobs carry a prebuilt workflow.
 function buildJobPayload(
   engine: EnqueueEngine,
   ctx: { body: ArtEnqueueRequest; promptString: string; save: SaveBlock },
 ): { jobEngine: 'A1111' | 'COMFY'; payload: Record<string, unknown> } {
   const { body, promptString, save } = ctx
-
   if (engine === 'a1111') {
     return {
       jobEngine: 'A1111',
@@ -330,10 +308,7 @@ function buildJobPayload(
       },
     }
   }
-
-  if (engine === 'ltx' || engine === 'wan') {
-    return buildVideoJobPayload(engine, ctx)
-  }
+  if (engine === 'ltx' || engine === 'wan') return buildVideoJobPayload(engine, ctx)
 
   if (engine === 'flux') {
     const { workflow } = buildFluxWorkflowFromRequest({
@@ -350,11 +325,7 @@ function buildJobPayload(
       scheduler: body.scheduler ?? null,
       denoise: body.denoise ?? null,
     })
-
-    return {
-      jobEngine: 'COMFY',
-      payload: { workflow, promptString, save },
-    }
+    return { jobEngine: 'COMFY', payload: { workflow, promptString, save } }
   }
 
   if (engine === 'krea2') {
@@ -372,11 +343,7 @@ function buildJobPayload(
       loraName: body.loraName ?? null,
       loraStrength: body.loraStrength ?? null,
     })
-
-    return {
-      jobEngine: 'COMFY',
-      payload: { workflow, promptString, save },
-    }
+    return { jobEngine: 'COMFY', payload: { workflow, promptString, save } }
   }
 
   if (engine === 'flux2') {
@@ -395,30 +362,22 @@ function buildJobPayload(
       loraName: body.loraName ?? null,
       loraStrength: body.loraStrength ?? null,
     })
-
-    return {
-      jobEngine: 'COMFY',
-      payload: { workflow, promptString, save },
-    }
+    return { jobEngine: 'COMFY', payload: { workflow, promptString, save } }
   }
 
   if (engine === 'kontext') {
     const imageData = body.sourceImageBase64?.trim()
-
     if (!imageData) {
       throw createError({
         statusCode: 400,
         message: 'Kontext generation requires "sourceImageBase64".',
       })
     }
-
     const normalizedImageData = imageData.startsWith('data:image/')
       ? imageData
       : `data:image/png;base64,${imageData}`
-
     const extension = getKontextImageExtension(normalizedImageData)
     const imageName = `kr_kontext_queue_${crypto.randomUUID()}.${extension}`
-
     const workflow = buildKontextWorkflow({
       prompt: promptString,
       imageName,
@@ -433,7 +392,6 @@ function buildJobPayload(
       loraName: body.loraName ?? null,
       loraStrength: body.loraStrength ?? null,
     })
-
     return {
       jobEngine: 'COMFY',
       payload: {
@@ -445,7 +403,6 @@ function buildJobPayload(
     }
   }
 
-  // comfy (default SDXL/SD graph)
   const workflow = buildDefaultComfyWorkflow({
     prompt: promptString,
     negativePrompt: body.negativePrompt ?? '',
@@ -455,15 +412,8 @@ function buildJobPayload(
     checkpoint: body.checkpoint ?? null,
     sampler: body.sampler ?? null,
   })
-
-  return {
-    jobEngine: 'COMFY',
-    payload: { workflow, promptString, save },
-  }
+  return { jobEngine: 'COMFY', payload: { workflow, promptString, save } }
 }
-
-// A named image the relay uploads to Comfy before running the workflow.
-type QueuedImage = { name: string; imageData: string }
 
 function normalizeVideoImage(raw: string, slot: 'first' | 'last'): QueuedImage {
   const trimmed = raw.trim()
@@ -471,14 +421,12 @@ function normalizeVideoImage(raw: string, slot: 'first' | 'last'): QueuedImage {
     ? trimmed
     : `data:image/png;base64,${trimmed}`
   const extension = getKontextImageExtension(normalized)
-  const name = `kr_video_${slot}_${crypto.randomUUID()}.${extension}`
-
-  return { name, imageData: normalized }
+  return {
+    name: `kr_video_${slot}_${crypto.randomUUID()}.${extension}`,
+    imageData: normalized,
+  }
 }
 
-// Resolve the requested clip length into concrete frames for the target engine.
-// Used both for mana billing (before the payload is built) and inside the
-// payload builder, so keep it pure and cheap.
 function resolveVideoFrames(
   engine: EnqueueEngine,
   body: ArtEnqueueRequest | null | undefined,
@@ -495,7 +443,6 @@ function resolveVideoFrames(
     0.25,
     30,
   )
-
   return engine === 'wan'
     ? wanFrameCount(duration, fps)
     : ltxFrameCount(duration, fps)
@@ -507,22 +454,17 @@ function clampNumber(
   min: number,
   max: number,
 ): number {
-  const n =
+  const numberValue =
     typeof value === 'number' && Number.isFinite(value) ? value : fallback
-  return Math.min(max, Math.max(min, n))
+  return Math.min(max, Math.max(min, numberValue))
 }
 
-// Build a COMFY ArtJob payload for an image-to-video engine (ltx | wan). The
-// payload mirrors the kontext queue contract — a `workflow` plus a named
-// `images` array the relay uploads first — and adds a `media: 'video'` marker
-// plus the clip settings so the relay/save path can treat the output as video.
 function buildVideoJobPayload(
   engine: 'ltx' | 'wan',
   ctx: { body: ArtEnqueueRequest; promptString: string; save: SaveBlock },
 ): { jobEngine: 'COMFY'; payload: Record<string, unknown> } {
   const { body, promptString, save } = ctx
   const isWan = engine === 'wan'
-
   const width = clampNumber(
     body.width,
     isWan ? WAN_DEFAULT_WIDTH : LTX_DEFAULT_WIDTH,
@@ -548,7 +490,6 @@ function buildVideoJobPayload(
     30,
   )
   const negativePrompt = body.negativePrompt?.trim() || DEFAULT_VIDEO_NEGATIVE
-
   const images: QueuedImage[] = []
   let firstImageName: string | null = null
   let lastImageName: string | null = null
@@ -558,18 +499,15 @@ function buildVideoJobPayload(
     firstImageName = first.name
     images.push(first)
   }
-
   if (body.secondImageBase64?.trim()) {
     const last = normalizeVideoImage(body.secondImageBase64, 'last')
     lastImageName = last.name
     images.push(last)
   }
-
   if (!firstImageName) {
     throw createError({
       statusCode: 400,
-      message:
-        'Video generation needs at least a first image. Send "firstImageBase64".',
+      message: 'Video generation needs at least a first image.',
     })
   }
 
@@ -577,7 +515,6 @@ function buildVideoJobPayload(
   const frames = isWan
     ? wanFrameCount(duration, frameRate)
     : ltxFrameCount(duration, frameRate)
-
   const workflow = isWan
     ? buildWanImageToVideoWorkflow({
         prompt: promptString,
@@ -615,9 +552,6 @@ function buildVideoJobPayload(
       workflow,
       promptString,
       images,
-      // Marks this ArtJob as video so the relay/save path stores the output as
-      // a clip (mp4/webm) rather than a still. The relay reads `video` for the
-      // playback hints (loop, fps, duration, frame count).
       media: 'video',
       video: {
         model: engine,

--- a/server/api/art/queue/[id]/edit.post.ts
+++ b/server/api/art/queue/[id]/edit.post.ts
@@ -17,6 +17,11 @@ import {
   applyArtJobOverrides,
   type ArtJobOverrides,
 } from '../../../../utils/artJobRetry'
+import {
+  applyArtFacetsToPayload,
+  readArtFacetIds,
+  resolveArtFacetSelection,
+} from '../../../../utils/artFacetSelection'
 import { assessArtPrompt, cleanArtPrompt } from '../../../../utils/artPromptQuality'
 import {
   buildWorkflowForEngine,
@@ -51,11 +56,9 @@ export default defineEventHandler(async (event) => {
 
     const body = (await readBody(event).catch(() => null)) as EditBody | null
     const source = await prisma.artJob.findUnique({ where: { id } })
-
     if (!source) {
       throw createError({ statusCode: 404, message: `Job ${id} not found.` })
     }
-
     if (!['PENDING', 'FAILED', 'CANCELLED'].includes(source.status)) {
       throw createError({
         statusCode: 409,
@@ -68,10 +71,24 @@ export default defineEventHandler(async (event) => {
 
     const payload = structuredClone(parseArtJobPayload(source.payload))
     const currentRequest = extractRenderRequest(payload)
-    const requestedPrompt = cleanArtPrompt(body?.overrides?.promptString)
-    const prompt = requestedPrompt || currentRequest.prompt
+    const currentBasePrompt = cleanArtPrompt(payload.basePromptString)
+    const requestedBasePrompt = cleanArtPrompt(
+      body?.overrides?.basePromptString ?? body?.overrides?.promptString,
+    )
+    const basePrompt = requestedBasePrompt || currentBasePrompt || currentRequest.prompt
+    const hasFacetOverride = Array.isArray(body?.overrides?.facetIds)
+    const facetIds = hasFacetOverride
+      ? body?.overrides?.facetIds
+      : readArtFacetIds(payload)
+    const facets = await resolveArtFacetSelection({
+      facetIds,
+      userId: auth.user.id,
+      isAdmin: auth.isAdmin,
+      includeMature: true,
+    })
+    const previewPayload: Record<string, unknown> = {}
+    const prompt = applyArtFacetsToPayload(previewPayload, basePrompt, facets)
     const promptAssessment = assessArtPrompt(prompt)
-
     if (!promptAssessment.useful) {
       throw createError({
         statusCode: 422,
@@ -91,6 +108,7 @@ export default defineEventHandler(async (event) => {
 
     if (presetEngine) {
       payload.workflow = buildWorkflowForEngine(presetEngine, {
+        ...currentRequest,
         prompt,
         negativePrompt:
           typeof body?.overrides?.negativePrompt === 'string'
@@ -103,13 +121,15 @@ export default defineEventHandler(async (event) => {
       payload.promptString = prompt
     }
 
-    delete payload.curation
-
-    const updatedPayload = applyArtJobOverrides(payload, {
+    const renderOverrides: ArtJobOverrides = {
       ...body?.overrides,
       promptString: prompt,
       ...(seed !== null ? { seed } : {}),
-    })
+    }
+    delete renderOverrides.facetIds
+    delete renderOverrides.basePromptString
+    const updatedPayload = applyArtJobOverrides(payload, renderOverrides)
+    applyArtFacetsToPayload(updatedPayload, basePrompt, facets)
     updatedPayload.queueEdit = {
       editedAt: new Date().toISOString(),
       editedByUserId: auth.user.id,
@@ -137,13 +157,11 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error: unknown) {
     const handled = errorHandler(error)
-    const statusCode = handled.statusCode || 500
-    event.node.res.statusCode = statusCode
-
+    event.node.res.statusCode = handled.statusCode || 500
     return {
       success: false,
       message: handled.message || 'Failed to edit queued ArtJob.',
-      statusCode,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -1,17 +1,4 @@
 // /server/api/art/queue/[id]/reenqueue.post.ts
-//
-// Admin action: re-run any ArtJob by cloning its generation spec into a fresh
-// PENDING job. Two explicit intents are supported:
-//
-// - NEW_OUTPUT: keep the source ArtImage intact and create another ArtImage.
-// - OVERWRITE: render into a temporary ArtImage, then atomically replace the
-//   source ArtImage's pixels/metadata at completion while preserving its id and
-//   every Dream/Bot/Reward/etc. relation that points at it.
-//
-// Retry metadata lives in payload.retry so the relay remains generic and the UI
-// can explain ancestry. Curator/human feedback is deliberately not copied to the
-// fresh attempt, and concrete generation seeds are refreshed by default so a
-// Comfy retry does not reproduce the exact same pixels.
 import {
   createError,
   defineEventHandler,
@@ -32,6 +19,11 @@ import {
   type ArtJobOverrides,
   type ArtJobRetryMode,
 } from '../../../../utils/artJobRetry'
+import {
+  applyArtFacetsToPayload,
+  readArtFacetIds,
+  resolveArtFacetSelection,
+} from '../../../../utils/artFacetSelection'
 import { assessArtPrompt, cleanArtPrompt } from '../../../../utils/artPromptQuality'
 import {
   buildWorkflowForEngine,
@@ -49,7 +41,6 @@ type ReenqueueBody = {
 export default defineEventHandler(async (event) => {
   try {
     const auth = await requireMachineUser(event)
-
     if (!auth.isAdmin && !auth.isServerKey) {
       throw createError({
         statusCode: 403,
@@ -58,15 +49,12 @@ export default defineEventHandler(async (event) => {
     }
 
     const id = Number(getRouterParam(event, 'id'))
-
     if (!Number.isInteger(id) || id <= 0) {
       throw createError({ statusCode: 400, message: 'Invalid job id.' })
     }
 
     const body = (await readBody(event).catch(() => null)) as ReenqueueBody | null
-    const mode = String(
-      body?.mode || 'NEW_OUTPUT',
-    ).toUpperCase() as ArtJobRetryMode
+    const mode = String(body?.mode || 'NEW_OUTPUT').toUpperCase() as ArtJobRetryMode
     const hasSeedOverride =
       typeof body?.overrides?.seed === 'number' &&
       Number.isFinite(body.overrides.seed)
@@ -80,7 +68,6 @@ export default defineEventHandler(async (event) => {
     }
 
     const source = await prisma.artJob.findUnique({ where: { id } })
-
     if (!source) {
       throw createError({ statusCode: 404, message: `Job ${id} not found.` })
     }
@@ -93,12 +80,10 @@ export default defineEventHandler(async (event) => {
             'Overwrite retries require a completed source job with an ArtImage.',
         })
       }
-
       const target = await prisma.artImage.findUnique({
         where: { id: source.artImageId },
         select: { id: true },
       })
-
       if (!target) {
         throw createError({
           statusCode: 409,
@@ -114,41 +99,53 @@ export default defineEventHandler(async (event) => {
       mode,
       refreshSeed,
     )
-
-    const requestedPrompt = cleanArtPrompt(body?.overrides?.promptString)
-    if (requestedPrompt && !assessArtPrompt(requestedPrompt).useful) {
-      throw createError({
-        statusCode: 422,
-        message:
-          'The replacement prompt is still too vague. Describe the visible subject, action, setting, composition, and concrete art direction.',
-      })
-    }
-
     const sourceRequest = extractRenderRequest(prepared)
-    const effectivePrompt = requestedPrompt || sourceRequest.prompt
+    const currentBasePrompt = cleanArtPrompt(prepared.basePromptString)
+    const requestedBasePrompt = cleanArtPrompt(
+      body?.overrides?.basePromptString ?? body?.overrides?.promptString,
+    )
+    const basePrompt = requestedBasePrompt || currentBasePrompt || sourceRequest.prompt
+    const hasFacetOverride = Array.isArray(body?.overrides?.facetIds)
+    const facetIds = hasFacetOverride
+      ? body?.overrides?.facetIds
+      : readArtFacetIds(prepared)
+    const facets = await resolveArtFacetSelection({
+      facetIds,
+      userId: auth.user.id,
+      isAdmin: auth.isAdmin,
+      includeMature: true,
+    })
+    const previewPayload: Record<string, unknown> = {}
+    const effectivePrompt = applyArtFacetsToPayload(
+      previewPayload,
+      basePrompt,
+      facets,
+    )
     const promptAssessment = assessArtPrompt(effectivePrompt)
-
     if (!promptAssessment.useful) {
       throw createError({
         statusCode: 422,
-        message: `Retry blocked because the source prompt is not usable (${promptAssessment.reasons.join(', ')}). Supply a specific prompt override instead of reusing it.`,
+        message: `Retry blocked because the prompt is not usable (${promptAssessment.reasons.join(', ')}). Supply a specific prompt instead.`,
       })
     }
 
     const presetEngine = resolvePresetEngine(body?.preset)
     if (presetEngine) {
-      const req = {
+      prepared.workflow = buildWorkflowForEngine(presetEngine, {
         ...sourceRequest,
         prompt: effectivePrompt,
-      }
-      prepared.workflow = buildWorkflowForEngine(presetEngine, req)
-      prepared.promptString = req.prompt
+      })
+      prepared.promptString = effectivePrompt
     }
 
-    const payload = applyArtJobOverrides(prepared, {
+    const renderOverrides: ArtJobOverrides = {
       ...body?.overrides,
-      ...(requestedPrompt ? { promptString: requestedPrompt } : {}),
-    })
+      promptString: effectivePrompt,
+    }
+    delete renderOverrides.facetIds
+    delete renderOverrides.basePromptString
+    const payload = applyArtJobOverrides(prepared, renderOverrides)
+    applyArtFacetsToPayload(payload, basePrompt, facets)
     const jobEngine = presetEngine ? 'COMFY' : source.engine
 
     const job = await prisma.artJob.create({
@@ -163,7 +160,6 @@ export default defineEventHandler(async (event) => {
     })
 
     event.node.res.statusCode = 201
-
     return {
       success: true,
       message:
@@ -180,14 +176,11 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error: unknown) {
     const handled = errorHandler(error)
-    const statusCode = handled.statusCode || 500
-
-    event.node.res.statusCode = statusCode
-
+    event.node.res.statusCode = handled.statusCode || 500
     return {
       success: false,
       message: handled.message || 'Failed to re-enqueue art job.',
-      statusCode,
+      statusCode: event.node.res.statusCode,
     }
   }
 })

--- a/server/utils/artFacetSelection.ts
+++ b/server/utils/artFacetSelection.ts
@@ -1,0 +1,79 @@
+// /server/utils/artFacetSelection.ts
+import { createError } from 'h3'
+import { loadFacetCatalogEntries } from './facetCatalog'
+import {
+  composeArtPromptWithFacets,
+  type ArtFacetPromptEntry,
+} from '~/utils/artFacetPrompt'
+
+export type ArtFacetSnapshot = ArtFacetPromptEntry & {
+  slug: string | null
+  imagePath: string | null
+  cardPath: string | null
+  heroPath: string | null
+}
+
+export function normalizeArtFacetIds(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+  return [
+    ...new Set(
+      value
+        .map(Number)
+        .filter((id) => Number.isInteger(id) && id > 0),
+    ),
+  ].slice(0, 50)
+}
+
+export async function resolveArtFacetSelection(options: {
+  facetIds: unknown
+  userId: number
+  isAdmin?: boolean
+  includeMature?: boolean
+}): Promise<ArtFacetSnapshot[]> {
+  const facetIds = normalizeArtFacetIds(options.facetIds)
+  if (!facetIds.length) return []
+
+  const entries = await loadFacetCatalogEntries({
+    facetIds,
+    userId: options.userId,
+    isAdmin: Boolean(options.isAdmin),
+    includeMature: Boolean(options.includeMature),
+    includeInactive: false,
+  })
+  const byId = new Map(entries.map((entry) => [entry.id, entry]))
+  const missing = facetIds.filter((id) => !byId.has(id))
+  if (missing.length) {
+    throw createError({
+      statusCode: 400,
+      message: `One or more selected Facets are unavailable: ${missing.join(', ')}.`,
+    })
+  }
+
+  return facetIds.map((id) => {
+    const entry = byId.get(id)!
+    return {
+      id: entry.id,
+      title: entry.title,
+      slug: entry.slug,
+      taxonomy: entry.taxonomy,
+      canonicalValue: entry.canonicalValue,
+      artPrompt: entry.artPrompt,
+      imagePath: entry.imagePath,
+      cardPath: entry.cardPath,
+      heroPath: entry.heroPath,
+    }
+  })
+}
+
+export function applyArtFacetsToPayload(
+  payload: Record<string, unknown>,
+  basePromptString: string,
+  facets: readonly ArtFacetSnapshot[],
+): string {
+  const basePrompt = String(basePromptString || '').replace(/\s+/g, ' ').trim()
+  const promptString = composeArtPromptWithFacets(basePrompt, facets)
+  payload.basePromptString = basePrompt
+  payload.promptString = promptString
+  payload.facets = facets.map((facet) => ({ ...facet }))
+  return promptString
+}

--- a/server/utils/artFacetSelection.ts
+++ b/server/utils/artFacetSelection.ts
@@ -13,6 +13,14 @@ export type ArtFacetSnapshot = ArtFacetPromptEntry & {
   heroPath: string | null
 }
 
+type JsonRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {}
+}
+
 export function normalizeArtFacetIds(value: unknown): number[] {
   if (!Array.isArray(value)) return []
   return [
@@ -22,6 +30,30 @@ export function normalizeArtFacetIds(value: unknown): number[] {
         .filter((id) => Number.isInteger(id) && id > 0),
     ),
   ].slice(0, 50)
+}
+
+export function readArtFacetSnapshots(payload: unknown): ArtFacetSnapshot[] {
+  const facets = asRecord(payload).facets
+  if (!Array.isArray(facets)) return []
+  return facets
+    .map((value) => asRecord(value))
+    .filter((value) => Number.isInteger(Number(value.id)) && Number(value.id) > 0)
+    .map((value) => ({
+      id: Number(value.id),
+      title: String(value.title || '').trim(),
+      slug: typeof value.slug === 'string' ? value.slug : null,
+      taxonomy: String(value.taxonomy || 'OTHER'),
+      canonicalValue:
+        typeof value.canonicalValue === 'string' ? value.canonicalValue : null,
+      artPrompt: typeof value.artPrompt === 'string' ? value.artPrompt : null,
+      imagePath: typeof value.imagePath === 'string' ? value.imagePath : null,
+      cardPath: typeof value.cardPath === 'string' ? value.cardPath : null,
+      heroPath: typeof value.heroPath === 'string' ? value.heroPath : null,
+    }))
+}
+
+export function readArtFacetIds(payload: unknown): number[] {
+  return normalizeArtFacetIds(readArtFacetSnapshots(payload).map((facet) => facet.id))
 }
 
 export async function resolveArtFacetSelection(options: {
@@ -76,4 +108,21 @@ export function applyArtFacetsToPayload(
   payload.promptString = promptString
   payload.facets = facets.map((facet) => ({ ...facet }))
   return promptString
+}
+
+export async function updateArtJobFacetSelection(options: {
+  payload: JsonRecord
+  facetIds: unknown
+  basePromptString: string
+  userId: number
+  isAdmin?: boolean
+  includeMature?: boolean
+}): Promise<{ facets: ArtFacetSnapshot[]; promptString: string }> {
+  const facets = await resolveArtFacetSelection(options)
+  const promptString = applyArtFacetsToPayload(
+    options.payload,
+    options.basePromptString,
+    facets,
+  )
+  return { facets, promptString }
 }

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -82,6 +82,8 @@ function replaceExactPrompt(
 
 export type ArtJobOverrides = {
   promptString?: string | null
+  basePromptString?: string | null
+  facetIds?: number[] | null
   negativePrompt?: string | null
   width?: number | null
   height?: number | null

--- a/stores/artFacetDraftStore.ts
+++ b/stores/artFacetDraftStore.ts
@@ -1,0 +1,70 @@
+// /stores/artFacetDraftStore.ts
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import { useFacetCatalogStore } from '@/stores/facetCatalogStore'
+import { composeArtPromptWithFacets } from '@/utils/artFacetPrompt'
+
+export const ART_FACET_WORKFLOW_KEY = '__kindRobotsFacetSelection'
+
+type WorkflowRecord = Record<string, unknown>
+
+function asWorkflow(value: unknown): WorkflowRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as WorkflowRecord) }
+    : {}
+}
+
+export const useArtFacetDraftStore = defineStore('artFacetDraftStore', () => {
+  const catalog = useFacetCatalogStore()
+  const selectedIds = ref<number[]>([])
+
+  const selectedFacets = computed(() => {
+    const byId = new Map(catalog.entries.map((entry) => [entry.id, entry]))
+    return selectedIds.value
+      .map((id) => byId.get(id))
+      .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
+  })
+
+  async function initialize(): Promise<void> {
+    if (!catalog.loaded) {
+      await catalog.fetchCatalog({ includeMature: true, take: 1000 })
+    }
+  }
+
+  function setSelectedIds(ids: number[]): void {
+    selectedIds.value = [
+      ...new Set(ids.filter((id) => Number.isInteger(id) && id > 0)),
+    ].slice(0, 50)
+  }
+
+  function clear(): void {
+    selectedIds.value = []
+  }
+
+  function decorateGenerationData<T extends Record<string, unknown>>(
+    data: T,
+    basePrompt: string,
+  ): T & { promptString: string; workflow: WorkflowRecord } {
+    const cleanBase = String(basePrompt || '').replace(/\s+/g, ' ').trim()
+    const workflow = asWorkflow(data.workflow)
+    workflow[ART_FACET_WORKFLOW_KEY] = {
+      facetIds: [...selectedIds.value],
+      basePromptString: cleanBase,
+    }
+
+    return {
+      ...data,
+      promptString: composeArtPromptWithFacets(cleanBase, selectedFacets.value),
+      workflow,
+    }
+  }
+
+  return {
+    selectedIds,
+    selectedFacets,
+    initialize,
+    setSelectedIds,
+    clear,
+    decorateGenerationData,
+  }
+})

--- a/stores/facetArtRequestStore.ts
+++ b/stores/facetArtRequestStore.ts
@@ -1,0 +1,83 @@
+// /stores/facetArtRequestStore.ts
+import { reactive } from 'vue'
+import { defineStore } from 'pinia'
+import { performFetch } from '@/stores/utils'
+import type { FacetCatalogEntry } from '@/stores/facetCatalogStore'
+import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+
+function safeSegment(value: string): string {
+  return (
+    normalizeFacetLookupKey(value)
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'facet'
+  )
+}
+
+export function defaultFacetArtworkPath(facet: FacetCatalogEntry): string {
+  return `/images/facets/${safeSegment(facet.taxonomy)}/${safeSegment(
+    facet.slug || facet.canonicalValue || facet.title,
+  )}.webp`
+}
+
+export const useFacetArtRequestStore = defineStore('facetArtRequestStore', () => {
+  const requesting = reactive<Record<number, boolean>>({})
+  const requested = reactive<Record<number, string>>({})
+  const errors = reactive<Record<number, string>>({})
+
+  async function requestPrimaryArtwork(
+    facet: FacetCatalogEntry,
+  ): Promise<string | null> {
+    if (requesting[facet.id]) return null
+    requesting[facet.id] = true
+    errors[facet.id] = ''
+    const src = facet.imagePath || defaultFacetArtworkPath(facet)
+
+    try {
+      const response = await performFetch<{ targetPath?: string }>(
+        '/api/conductor/art-request',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            src,
+            pageUrl:
+              typeof window !== 'undefined'
+                ? window.location.href
+                : '/facets',
+            label: facet.title,
+            alt: `${facet.title} canonical Facet artwork`,
+            variant: 'image',
+            size: '1024x1024',
+            prompt:
+              facet.artPrompt ||
+              facet.description ||
+              `A clear, expressive reference illustration of ${facet.title}, suitable for a reusable creative concept card.`,
+            pageTitle: 'Facet Library',
+            pageDescription: `Canonical ${facet.taxonomy} Facet requiring curated artwork.`,
+            nearbyText: [
+              facet.canonicalValue,
+              facet.groupLabel,
+              facet.flavorText,
+              facet.examples,
+            ]
+              .filter(Boolean)
+              .join(' · '),
+          }),
+        },
+      )
+
+      if (!response.success) {
+        throw new Error(response.message || 'Art request could not be queued.')
+      }
+      requested[facet.id] = src
+      return src
+    } catch (error) {
+      errors[facet.id] =
+        error instanceof Error ? error.message : 'Art request could not be queued.'
+      return null
+    } finally {
+      requesting[facet.id] = false
+    }
+  }
+
+  return { requesting, requested, errors, requestPrimaryArtwork }
+})

--- a/utils/artFacetPrompt.ts
+++ b/utils/artFacetPrompt.ts
@@ -1,0 +1,31 @@
+// /utils/artFacetPrompt.ts
+
+export type ArtFacetPromptEntry = {
+  id: number
+  title: string
+  taxonomy: string
+  canonicalValue?: string | null
+  artPrompt?: string | null
+}
+
+export function artFacetPromptValue(entry: ArtFacetPromptEntry): string {
+  return String(entry.artPrompt || entry.canonicalValue || entry.title).trim()
+}
+
+export function buildArtFacetPromptAddon(
+  entries: readonly ArtFacetPromptEntry[],
+): string {
+  const values = Array.from(
+    new Set(entries.map(artFacetPromptValue).filter(Boolean)),
+  )
+  return values.length ? `Facet direction: ${values.join(', ')}` : ''
+}
+
+export function composeArtPromptWithFacets(
+  basePrompt: string,
+  entries: readonly ArtFacetPromptEntry[],
+): string {
+  const base = String(basePrompt || '').replace(/\s+/g, ' ').trim()
+  const addon = buildArtFacetPromptAddon(entries)
+  return [base, addon].filter(Boolean).join(', ')
+}

--- a/utils/scripts/verifyFacetArtGeneration.ts
+++ b/utils/scripts/verifyFacetArtGeneration.ts
@@ -1,0 +1,62 @@
+// /utils/scripts/verifyFacetArtGeneration.ts
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+
+async function source(path: string): Promise<string> {
+  return readFile(resolve(root, path), 'utf8')
+}
+
+function requireText(path: string, text: string, value: string): void {
+  if (!text.includes(value)) {
+    throw new Error(`${path} is missing required Facet art contract text: ${value}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const files = {
+    selector: 'components/art/art-facet-selector.vue',
+    generateButton: 'components/art/generate-button.vue',
+    creator: 'components/art/art-creator.vue',
+    editor: 'components/art/artjob-editor.vue',
+    draftStore: 'stores/artFacetDraftStore.ts',
+    requestStore: 'stores/facetArtRequestStore.ts',
+    enqueue: 'server/api/art/enqueue.post.ts',
+    edit: 'server/api/art/queue/[id]/edit.post.ts',
+    reenqueue: 'server/api/art/queue/[id]/reenqueue.post.ts',
+    selection: 'server/utils/artFacetSelection.ts',
+    prompt: 'utils/artFacetPrompt.ts',
+  } as const
+
+  const entries = await Promise.all(
+    Object.entries(files).map(
+      async ([key, path]) => [key, await source(path)] as const,
+    ),
+  )
+  const text = Object.fromEntries(entries) as Record<keyof typeof files, string>
+
+  requireText(files.selector, text.selector, 'requestPrimaryArtwork')
+  requireText(files.selector, text.selector, 'update:modelValue')
+  requireText(files.generateButton, text.generateButton, 'art-facet-selector')
+  requireText(files.generateButton, text.generateButton, 'decorateGenerationData')
+  requireText(files.creator, text.creator, 'art-facet-selector')
+  requireText(files.editor, text.editor, 'ArtJob Facets')
+  requireText(files.editor, text.editor, 'basePromptString')
+  requireText(files.editor, text.editor, 'facetIds')
+  requireText(files.draftStore, text.draftStore, '__kindRobotsFacetSelection')
+  requireText(files.requestStore, text.requestStore, '/api/conductor/art-request')
+  requireText(files.enqueue, text.enqueue, 'resolveArtFacetSelection')
+  requireText(files.enqueue, text.enqueue, 'applyArtFacetsToPayload')
+  requireText(files.edit, text.edit, 'readArtFacetIds')
+  requireText(files.reenqueue, text.reenqueue, 'readArtFacetIds')
+  requireText(files.selection, text.selection, 'readArtFacetSnapshots')
+  requireText(files.prompt, text.prompt, 'Facet direction:')
+
+  process.stdout.write('Facet art generation contract verified.\n')
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What was missing

The Facet Library could view/create/edit canonical records, and generated ArtImages could be assigned Facets afterward, but art generation itself had no reusable Facet selector. Pathless Facets also had no explicit way to request curated art, and ArtJobs could not preserve or edit canonical Facet provenance.

## Change

- adds a reusable artwork-aware Facet selector with add/remove chips
- adds an explicit Conductor art-request action for pathless Facets
- wires Facets into the shared generate button and embedded art creator
- carries selected IDs and the untouched base prompt through reserved generation metadata
- validates selected Facets server-side against the authenticated user
- composes canonical `artPrompt`/value direction into rendered prompts
- stores canonical Facet snapshots plus `basePromptString` in ArtJob payloads
- adds Facet editing to pending, failed, cancelled, retry, and overwrite ArtJob flows
- rebuilds workflows from base prompt + current chips so editing never duplicates old Facet text
- adds a dedicated Facet-art integration contract

## Deliberate boundaries

- Negative prompts remain generation configuration, not Facets.
- Procedural names and Reward records remain their own canonical domains.
- This PR establishes ArtJob provenance; completion-time automatic ArtImage linking will be added after the generated Prisma/types pass confirms the payload contract.

## Follow-up

Once this is green and live, Daily Dream generation can consume the same canonical selection helpers to build structured dream, character, and reward-item blueprints.