### PR TITLE
Attach ArtJob Facets to completed ArtImages

### DIFF
--- a/server/api/art/queue/[id]/complete.post.ts
+++ b/server/api/art/queue/[id]/complete.post.ts
@@ -30,6 +30,11 @@ import {
 } from '../../../../utils/artJobProvenance'
 import { resolvePersistedArtImageSeed } from '../../../../utils/artImageSeed'
 import {
+  copyArtImageFacets,
+  syncCompletedArtImageFacets,
+  type FacetCompletionTransaction,
+} from '../../../../utils/artFacetCompletion'
+import {
   artImageResourceConnectData,
   resolveArtImageResourceLinks,
 } from '../../utils/resourceProvenance'
@@ -244,6 +249,7 @@ export default defineEventHandler(async (event) => {
     let archivedArtImageId: number | null = null
     let replacedArtImageId: number | null = null
     let completionTrace: Record<string, unknown> | null = null
+    let completedFacetIds: number[] = []
 
     if (body.success) {
       const uploadedArtImageId = Number(body.artImageId)
@@ -320,6 +326,12 @@ export default defineEventHandler(async (event) => {
           const archived = await tx.artImage.create({
             data: snapshotData(target),
           })
+          const facetTx = tx as unknown as FacetCompletionTransaction
+          await copyArtImageFacets(
+            facetTx,
+            targetArtImageId,
+            archived.id,
+          )
 
           await tx.artJob.updateMany({
             where: {
@@ -329,7 +341,6 @@ export default defineEventHandler(async (event) => {
             data: { artImageId: archived.id },
           })
 
-          // Record which Resources this render used (best-effort provenance).
           const resourceLinks = await resolveArtImageResourceLinks(
             job.payload,
             tx,
@@ -342,6 +353,11 @@ export default defineEventHandler(async (event) => {
               ...artImageResourceConnectData(resourceLinks),
             },
           })
+          const facetIds = await syncCompletedArtImageFacets(
+            facetTx,
+            tracedPayload,
+            targetArtImageId,
+          )
 
           const completed = await tx.artJob.update({
             where: { id },
@@ -357,12 +373,13 @@ export default defineEventHandler(async (event) => {
 
           await tx.artImage.delete({ where: { id: uploadedArtImageId } })
 
-          return { completed, archivedId: archived.id }
+          return { completed, archivedId: archived.id, facetIds }
         })
 
         updated = result.completed
         archivedArtImageId = result.archivedId
         replacedArtImageId = targetArtImageId
+        completedFacetIds = result.facetIds
       } else {
         const normalResult = await prisma.$transaction(async (tx) => {
           const uploaded = await tx.artImage.findUnique({
@@ -387,7 +404,6 @@ export default defineEventHandler(async (event) => {
             workflowSeed,
           )
 
-          // Record which Resources this render used (best-effort provenance).
           const resourceLinks = await resolveArtImageResourceLinks(
             job.payload,
             tx,
@@ -404,6 +420,11 @@ export default defineEventHandler(async (event) => {
               ...artImageResourceConnectData(resourceLinks),
             },
           })
+          const facetIds = await syncCompletedArtImageFacets(
+            tx as unknown as FacetCompletionTransaction,
+            tracedPayload,
+            uploadedArtImageId,
+          )
 
           const completed = await tx.artJob.update({
             where: { id },
@@ -415,10 +436,11 @@ export default defineEventHandler(async (event) => {
             },
           })
 
-          return { completed }
+          return { completed, facetIds }
         })
 
         updated = normalResult.completed
+        completedFacetIds = normalResult.facetIds
       }
     } else {
       const message = String(body.error || 'Generation failed.').slice(0, 4000)
@@ -446,6 +468,7 @@ export default defineEventHandler(async (event) => {
         replacedArtImageId,
         archivedArtImageId,
         completionTrace,
+        completedFacetIds,
       },
       statusCode: 200,
     }

--- a/server/utils/artFacetCompletion.ts
+++ b/server/utils/artFacetCompletion.ts
@@ -1,0 +1,58 @@
+// /server/utils/artFacetCompletion.ts
+import { readArtFacetIds } from './artFacetSelection'
+
+type FacetLink = { facetId: number }
+
+type FacetArtImageDelegate = {
+  findMany(args: {
+    where: { artImageId: number }
+    select: { facetId: true }
+  }): Promise<FacetLink[]>
+  deleteMany(args: { where: { artImageId: number } }): Promise<unknown>
+  createMany(args: {
+    data: Array<{ artImageId: number; facetId: number }>
+    skipDuplicates: true
+  }): Promise<unknown>
+}
+
+export type FacetCompletionTransaction = {
+  facetArtImage: FacetArtImageDelegate
+}
+
+async function replaceArtImageFacetLinks(
+  tx: FacetCompletionTransaction,
+  artImageId: number,
+  facetIds: readonly number[],
+): Promise<void> {
+  await tx.facetArtImage.deleteMany({ where: { artImageId } })
+  if (!facetIds.length) return
+
+  await tx.facetArtImage.createMany({
+    data: facetIds.map((facetId) => ({ artImageId, facetId })),
+    skipDuplicates: true,
+  })
+}
+
+export async function syncCompletedArtImageFacets(
+  tx: FacetCompletionTransaction,
+  payload: unknown,
+  artImageId: number,
+): Promise<number[]> {
+  const facetIds = readArtFacetIds(payload)
+  await replaceArtImageFacetLinks(tx, artImageId, facetIds)
+  return facetIds
+}
+
+export async function copyArtImageFacets(
+  tx: FacetCompletionTransaction,
+  sourceArtImageId: number,
+  targetArtImageId: number,
+): Promise<number[]> {
+  const links = await tx.facetArtImage.findMany({
+    where: { artImageId: sourceArtImageId },
+    select: { facetId: true },
+  })
+  const facetIds = [...new Set(links.map((link) => link.facetId))]
+  await replaceArtImageFacetLinks(tx, targetArtImageId, facetIds)
+  return facetIds
+}

--- a/utils/scripts/verifyFacetArtGeneration.ts
+++ b/utils/scripts/verifyFacetArtGeneration.ts
@@ -25,7 +25,9 @@ async function main(): Promise<void> {
     enqueue: 'server/api/art/enqueue.post.ts',
     edit: 'server/api/art/queue/[id]/edit.post.ts',
     reenqueue: 'server/api/art/queue/[id]/reenqueue.post.ts',
+    complete: 'server/api/art/queue/[id]/complete.post.ts',
     selection: 'server/utils/artFacetSelection.ts',
+    completion: 'server/utils/artFacetCompletion.ts',
     prompt: 'utils/artFacetPrompt.ts',
   } as const
 
@@ -51,6 +53,11 @@ async function main(): Promise<void> {
   requireText(files.edit, text.edit, 'readArtFacetIds')
   requireText(files.reenqueue, text.reenqueue, 'readArtFacetIds')
   requireText(files.selection, text.selection, 'readArtFacetSnapshots')
+  requireText(files.complete, text.complete, 'copyArtImageFacets')
+  requireText(files.complete, text.complete, 'syncCompletedArtImageFacets')
+  requireText(files.complete, text.complete, 'completedFacetIds')
+  requireText(files.completion, text.completion, 'facetArtImage.deleteMany')
+  requireText(files.completion, text.completion, 'facetArtImage.createMany')
   requireText(files.prompt, text.prompt, 'Facet direction:')
 
   process.stdout.write('Facet art generation contract verified.\n')


### PR DESCRIPTION
## Final provenance hop

ArtJobs now carry canonical Facet snapshots and allow chips to be edited, but completion still left the finished ArtImage unlinked unless a curator assigned the same Facets manually afterward.

## Change

- replaces each completed ArtImage's `FacetArtImage` links with the ArtJob's current canonical Facet IDs
- applies the same behavior to normal completion and overwrite retries
- when overwriting, copies the old canonical image's Facets to the archived revision before applying the current job's Facets to the canonical image
- returns `completedFacetIds` in the completion response for relay/debug visibility
- adds a contract guarding both link creation and archive preservation

## Result

Facet provenance now survives the complete lifecycle: generation request → ArtJob → edited/retried ArtJob → finished ArtImage, without duplicate manual assignment.