### PR TITLE
kind-robots/t-048: remove dead 'video' tab from dashboardConfigs.art

### DIFF
--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -172,19 +172,6 @@ export const dashboardConfigs = {
         route: '/coat-dance',
       },
       {
-        key: 'video',
-        label: 'Video',
-        icon: 'kind-icon:video',
-        title: 'Video Generator',
-        summary: 'Animate a still into a short looping clip with LTX or WAN.',
-        image: tabImage('art', 'video'),
-        flourish: '✨',
-        tagline: 'Turn a single frame into motion.',
-        narrative:
-          'Feed in a still (start with Use logo), add a motion prompt, pick LTX or WAN, set the seconds and fps, and queue an image-to-video job on the art box. The finished clip loops right on the page — perfect for launch gifs and endless randomized variants.',
-        route: '/video-generator',
-      },
-      {
         key: 'artjob',
         label: 'ArtJob',
         icon: 'kind-icon:server',


### PR DESCRIPTION
## Summary

- `dashboardConfigs.art`'s `'video'` tab entry (`stores/helpers/dashboardHelper.ts`) routed at `art-manager.vue`, but that component's own `validTabs` never included `'video'` in the first place — the entry was always a dead link, unrelated to whether `art-manager.vue` itself is live (it is, for 7 other tabs).
- `video-generator.vue` already has a real, working nav path via the `lab` channel's `video-generator` tab (`content/channels/lab/video-generator.md`, added by PR #988), so this dead entry can only confuse the next person looking for the actual nav wiring.
- Deletes exactly the 13-line `'video'` tab object between `coat-dance` and `artjob` in `dashboardConfigs.art.tabs`. Nothing else touched — `art-manager.vue` and its other 7 tabs (generate/gallery/checkpoints/styler/stylist/coloring/art-test/artjob) are untouched.

Conductor task: `kind-robots/t-048` (corrected scope — an earlier draft of this task incorrectly proposed deleting `art-manager.vue` itself based on a grep that missed its Nuxt Content MDC embeds in `content/art.md`/`content/artjob.md`; this PR reflects the corrected, narrower scope).

## Test plan

- [x] `npm run test` (`vue-tsc --noEmit`, full project) — exit 0, no errors
- [x] `npx eslint stores/helpers/dashboardHelper.ts` — clean
- [x] `npm run test:channel-content` — 66 tabs, 0 errors (unchanged count — this tab was never part of the channel-content contract)
- [x] `npm run test:data-surface-manifest` — 2 surfaces, 2 wired, 0 errors
- [x] Grepped for any remaining reference to the `'video'` dashboard tab key — none found
- [ ] Manual click-through in a running app (not available in this sandbox — no live server)

Note: `npx prettier --check` on this file reports a pre-existing, unrelated formatting issue elsewhere in the file (an `animation-manager` tab's `summary` line-wrap) — confirmed present on `main` before this change too, left untouched to keep this diff scoped to the task.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BH9ZGcCQMcj4nNMFH9rKMV)_