### PR TITLE
digital-storefront/t-028: wire ArtImage.storefrontFeatured into giftshop swag rail

### DIFF
--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -101,6 +101,40 @@
           </NuxtLink>
         </div>
 
+        <div v-if="featuredArt.length" class="space-y-3">
+          <h4 class="font-black text-primary">Featured prints</h4>
+
+          <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            <article
+              v-for="art in featuredArt"
+              :key="art.id"
+              class="overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+            >
+              <img
+                :src="resolveArtImageThumbSrc(art)"
+                :alt="art.promptString || 'Featured print'"
+                class="h-40 w-full object-cover"
+                loading="lazy"
+              />
+
+              <div class="space-y-2 p-4">
+                <p class="line-clamp-2 text-sm text-base-content/70">
+                  {{ art.promptString || 'Featured print' }}
+                </p>
+
+                <button
+                  type="button"
+                  class="btn btn-sm btn-outline rounded-2xl"
+                  @click="addFeaturedPrint(art)"
+                >
+                  <Icon name="kind-icon:plus" class="h-4 w-4" />
+                  Add to cart
+                </button>
+              </div>
+            </article>
+          </div>
+        </div>
+
         <div class="grid gap-3 xl:grid-cols-2">
           <article
             v-for="item in showcaseItems"
@@ -196,9 +230,24 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useCartStore, type CartItem } from '@/stores/cartStore'
 import { useNavStore } from '@/stores/navStore'
+import { performFetch } from '@/stores/utils'
+import {
+  resolveArtImageSrc,
+  resolveArtImageThumbSrc,
+} from '@/utils/artImageSrc'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
+
+// Placeholder print price until the POD product/pricing pipeline (digital-storefront
+// t-023's PrintJob work) exists to derive a real per-item price for featured art.
+const FEATURED_PRINT_PRICE = 12
+
+type FeaturedArtImage = Pick<
+  ArtImage,
+  'id' | 'promptString' | 'imagePath' | 'path' | 'thumbnailPath' | 'cardPath'
+>
 
 type GiftshopFeature = {
   title: string
@@ -218,6 +267,7 @@ type ShowcaseItem = {
 
 const cartStore = useCartStore()
 const navStore = useNavStore()
+const featuredArt = ref<FeaturedArtImage[]>([])
 
 const giftshopFeatures: GiftshopFeature[] = [
   {
@@ -260,7 +310,31 @@ const showcaseItems: ShowcaseItem[] = [
 
 onMounted(() => {
   void cartStore.initialize()
+  void loadFeaturedArt()
 })
+
+async function loadFeaturedArt() {
+  const response = await performFetch<FeaturedArtImage[]>(
+    '/api/art/storefront-featured',
+  )
+
+  if (response.success && response.data) {
+    featuredArt.value = response.data
+  }
+}
+
+function addFeaturedPrint(art: FeaturedArtImage) {
+  cartStore.addItem({
+    type: 'print',
+    artImageId: art.id,
+    imageUrl: resolveArtImageSrc(art),
+    quantity: 1,
+    price: FEATURED_PRINT_PRICE,
+    notes: art.promptString || 'Featured print',
+  })
+
+  goToCart()
+}
 
 function addDemoItem(item: ShowcaseItem) {
   cartStore.addItem({

--- a/server/api/art/storefront-featured.get.ts
+++ b/server/api/art/storefront-featured.get.ts
@@ -1,0 +1,57 @@
+// /server/api/art/storefront-featured.get.ts
+import { defineEventHandler, getQuery } from 'h3'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '../../utils/error'
+
+const DEFAULT_LIMIT = 12
+const MAX_LIMIT = 24
+
+function readLimit(value: unknown): number {
+  const parsed = Number(Array.isArray(value) ? value[0] : value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT
+  return Math.min(Math.floor(parsed), MAX_LIMIT)
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const query = getQuery(event)
+    const limit = readLimit(query.limit)
+
+    const data = await prisma.artImage.findMany({
+      where: {
+        storefrontFeatured: true,
+        isPublic: true,
+        isActive: true,
+        isMature: false,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        imagePath: true,
+        path: true,
+        thumbnailPath: true,
+        cardPath: true,
+        promptString: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    })
+
+    event.node.res.statusCode = 200
+
+    return {
+      success: true,
+      message: 'Storefront-featured art retrieved successfully.',
+      data,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to fetch storefront-featured art.',
+      data: [],
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- Adds `GET /api/art/storefront-featured`, querying `ArtImage` rows where `storefrontFeatured: true` (scoped to `isPublic: true`, `isActive: true`, `isMature: false`, ordered newest-first, capped at 24), mirroring the visibility convention used by `server/api/art/image/index.get.ts`.
- `components/giftshop/giftshop-interact.vue` now fetches this endpoint on mount and renders a "Featured prints" rail (image, prompt text, add-to-cart) whenever any rows are flagged, reusing the existing `cartStore.addItem` pattern already used by the hardcoded `showcaseItems` demo row below it.
- This is conductor task `digital-storefront/t-028`, a kaizen follow-up from `kind-robots/t-047` (PR #994, which added the `ArtImage.storefrontFeatured` column) — this PR is the field's first real consumer, per the design in `digital-storefront/docs/gallery-to-swag-pipeline.md` §5.

## Notes
- No admin UI exists yet to toggle `ArtImage.storefrontFeatured` — until one is built, Silas sets it directly via DB/admin tooling. The rail simply renders nothing until at least one row is flagged, so this ships safely ahead of that UI.
- Per-item price is still a flat placeholder (`$12`, matching the existing demo item) since there's no real POD product/pricing model wired up yet (that's the separate `digital-storefront/t-023` PrintJob work).

## Test plan
- [x] `npx eslint` on both changed files — clean
- [x] `vue-tsc --noEmit` (full project) — clean
- [x] `npx prettier --check` on both changed files — clean
- [ ] CI (no live DB in this sandbox to exercise the query against real data)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WPtQeeMgaRiSxSZzy6DYRE)_