### PR TITLE
digital-storefront/t-029: add gallery-to-swag print-eligibility gate

### DIFF
--- a/components/giftshop/print-swag.vue
+++ b/components/giftshop/print-swag.vue
@@ -48,7 +48,15 @@
       />
     </div>
 
-    <button class="btn btn-primary w-full" @click="addToCart">
+    <p v-if="eligibility && !eligibility.eligible" class="text-sm text-error">
+      🚫 Not eligible for print: {{ eligibility.reason }}
+    </p>
+
+    <button
+      class="btn btn-primary w-full"
+      :disabled="eligibility ? !eligibility.eligible : false"
+      @click="addToCart"
+    >
       ➕ Add to Cart
     </button>
 
@@ -59,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 
 const props = defineProps<{ artImageId?: number }>()
 const emit = defineEmits(['close'])
@@ -67,6 +75,9 @@ const emit = defineEmits(['close'])
 const selectedType = ref('print')
 const quantity = ref(1)
 const customImageUrl = ref('')
+
+type PrintEligibility = { eligible: boolean; reason: string }
+const eligibility = ref<PrintEligibility | null>(null)
 
 const printTypes = [
   { id: 'print', label: 'Art Print', icon: 'kind-icon:print' },
@@ -80,8 +91,29 @@ const imageUrl = computed(() =>
   customImageUrl.value.trim()
     ? customImageUrl.value.trim()
     : props.artImageId
-    ? `/api/media/art/${props.artImageId}`
-    : fallbackImage,
+      ? `/api/media/art/${props.artImageId}`
+      : fallbackImage,
+)
+
+// A custom-URL image (not one of the caller's own ArtImage rows) has no
+// eligibility record to check against, so it is left ungated here.
+watch(
+  () => props.artImageId,
+  async (artImageId) => {
+    eligibility.value = null
+    if (!artImageId) return
+
+    try {
+      const response = await $fetch<
+        { success: boolean; data: PrintEligibility },
+        string
+      >(`/api/art/image/${artImageId}/print-eligibility`)
+      eligibility.value = response.success ? response.data : null
+    } catch {
+      eligibility.value = null
+    }
+  },
+  { immediate: true },
 )
 
 const addToCart = () => {

--- a/server/api/art/image/[id]/print-eligibility.get.ts
+++ b/server/api/art/image/[id]/print-eligibility.get.ts
@@ -1,0 +1,60 @@
+// GET /api/art/image/:id/print-eligibility
+import { createError, defineEventHandler } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { getOptionalApiUser } from '~/server/utils/authGuard'
+import { checkPrintEligibility } from '../../utils/printEligibility'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(event.context.params?.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid ArtImage ID.' })
+    }
+
+    const [image, auth] = await Promise.all([
+      prisma.artImage.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          userId: true,
+          isPublic: true,
+          isMature: true,
+          isActive: true,
+          checkpointResourceId: true,
+          CheckpointResource: { select: { commercialSafe: true } },
+        },
+      }),
+      getOptionalApiUser(event),
+    ])
+
+    if (!image) {
+      throw createError({ statusCode: 404, message: 'ArtImage not found.' })
+    }
+
+    const canView =
+      auth?.isAdmin ||
+      (Boolean(auth?.user.id) && image.userId === auth?.user.id) ||
+      (image.isPublic && !image.isMature)
+
+    if (!canView) {
+      throw createError({
+        statusCode: auth ? 403 : 404,
+        message: auth
+          ? 'You do not have permission to view this ArtImage.'
+          : 'ArtImage not found.',
+      })
+    }
+
+    const result = checkPrintEligibility(image, image.CheckpointResource, {
+      userId: auth?.user.id ?? null,
+      isAdmin: auth?.isAdmin,
+    })
+
+    return { success: true, data: result }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return { ...handled, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/art/utils/printEligibility.ts
+++ b/server/api/art/utils/printEligibility.ts
@@ -1,0 +1,77 @@
+// /server/api/art/utils/printEligibility.ts
+// Gallery-to-swag print-eligibility gate (digital-storefront/t-029).
+// Per projects/digital-storefront/docs/gallery-to-swag-pipeline.md §4:
+// an ArtImage is print-eligible only if it is not mature, the caller owns it
+// (or it is public), and its generation backend is commercial-safe — base-model
+// output (no checkpoint/LoRA override) or an explicitly commercialSafe Resource.
+
+export type PrintEligibilityImage = {
+  userId: number | null
+  isMature: boolean | null
+  isPublic: boolean | null
+  isActive: boolean | null
+  checkpointResourceId: number | null
+}
+
+export type PrintEligibilityResource = {
+  commercialSafe: boolean
+} | null
+
+export type PrintEligibilityCaller = {
+  userId: number | null
+  isAdmin?: boolean
+}
+
+export type PrintEligibilityResult = {
+  eligible: boolean
+  reason: string
+}
+
+export function checkPrintEligibility(
+  image: PrintEligibilityImage,
+  checkpointResource: PrintEligibilityResource,
+  caller: PrintEligibilityCaller,
+): PrintEligibilityResult {
+  if (image.isActive === false) {
+    return { eligible: false, reason: 'Image is inactive.' }
+  }
+
+  if (image.isMature) {
+    return {
+      eligible: false,
+      reason: 'Mature content is not eligible for print-on-demand.',
+    }
+  }
+
+  const ownedByCaller =
+    caller.userId != null &&
+    image.userId != null &&
+    caller.userId === image.userId
+
+  if (!caller.isAdmin && !ownedByCaller && !image.isPublic) {
+    return {
+      eligible: false,
+      reason: 'You can only print your own art, or public gallery pieces.',
+    }
+  }
+
+  if (image.checkpointResourceId == null) {
+    return {
+      eligible: true,
+      reason: 'Base-model generation — no checkpoint/LoRA override.',
+    }
+  }
+
+  if (checkpointResource?.commercialSafe) {
+    return {
+      eligible: true,
+      reason: 'Generated on a commercial-safe checkpoint/LoRA.',
+    }
+  }
+
+  return {
+    eligible: false,
+    reason:
+      'Generated with a checkpoint/LoRA not yet marked commercial-safe (default-deny until confirmed).',
+  }
+}


### PR DESCRIPTION
### Task
conductor digital-storefront/t-029: Wire the print-eligibility gate to read `Resource.commercialSafe` (kind: software)

### What changed / what I produced
- `server/api/art/utils/printEligibility.ts` — pure `checkPrintEligibility()` implementing `projects/digital-storefront/docs/gallery-to-swag-pipeline.md` §4's rule now that `Resource.commercialSafe` exists (kind-robots/t-045, PR #993): not-mature, owned-by-caller-or-public, and either base-model generation (`checkpointResourceId` null) or an explicitly `commercialSafe` checkpoint/LoRA.
- `GET /api/art/image/:id/print-eligibility` — exposes the check, mirroring the existing `facets.get.ts` auth/visibility pattern (`getOptionalApiUser`, admin/owner/public-and-not-mature `canView` gate).
- Wired it into `components/giftshop/print-swag.vue` (the existing print/swag mock UI): fetches eligibility for the selected `artImageId` and disables "Add to Cart" with the specific reason when the image isn't eligible.

### How I verified
- Found no prior "print-eligibility" implementation existed anywhere in the codebase — the design doc's default-deny rule was documented but never wired into runnable code, and `print-swag.vue` was a UI mock with no real cart/checkout logic (`addToCart` just `console.log`s + `alert`s). This PR builds the gate itself rather than "rewiring" a nonexistent one, matching the conductor task's actual intent (see conductor TALKBACK for the discovery note).
- `npx eslint` on all three changed files: 0 errors (1 pre-existing, unrelated `vue/attributes-order` warning on a line this PR didn't touch).
- `npx vue-tsc --noEmit`: 0 errors anywhere in the project (confirmed the initial `$fetch` generic caused `Excessive stack depth`/`TS2589` errors under Nuxt's typed-route inference; fixed by matching this codebase's existing `$fetch<T, string>(url)` convention, e.g. `dream-inspire-button.vue`).
- `npx prettier --check` → `--write` (3 files reformatted to repo style).
- No live DB in this sandbox, so the query itself is unexercised end-to-end — the auth/select pattern is copied directly from `server/api/art/image/[id]/facets.get.ts`, an existing endpoint with the same shape.

### Stakes
reversible

### Flags for Reviewer
- No live-DB verification was possible in this sandbox (standard sandbox limitation, see prior TALKBACK entries on this pattern). The Prisma query shape mirrors `facets.get.ts` exactly (same `select`/auth fields), which is the closest available substitute for a live check.
- `print-swag.vue` itself is still a UI mock (no real Stripe/PrintJob checkout exists yet — see conductor digital-storefront's roadmap, no task currently covers building that). This PR gives the eligibility gate a real, reversible, testable home ahead of that work landing, rather than leaving it unbuilt until the full checkout flow exists.
- A custom pasted image URL (not an owned `ArtImage` id) has no eligibility record to check against and is left ungated — noted in a code comment.

### Kaizen suggestion
File a conductor digital-storefront task for the actual missing piece this PR's investigation surfaced: a `PrintJob` model + real POD checkout flow (gallery-to-swag-pipeline.md §7 steps 2/5/6) — the self-service print entry point doesn't exist yet beyond this mock component, so the eligibility gate currently has no live checkout consumer.

### Notes for reviewer
Small, additive, reversible — no schema changes, no external API calls, no live orders.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FiAPkvBKwqMvCv8iCtVBvP)_