### PR TITLE
[Superseded] Build nested Facet-driven Daily Dreams

### DIFF
--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -1,0 +1,166 @@
+<!-- /components/dreams/daily-dream-generator.vue -->
+<template>
+  <details class="group mb-2 shrink-0 rounded-2xl border border-secondary/30 bg-secondary/10">
+    <summary
+      class="flex cursor-pointer list-none items-center gap-3 px-4 py-3 marker:hidden"
+    >
+      <span
+        class="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content"
+      >
+        <Icon name="kind-icon:sparkles" class="size-5" />
+      </span>
+      <span class="min-w-0 flex-1">
+        <span class="block font-black">Today’s Facet Dream</span>
+        <span class="block truncate text-xs text-base-content/55">
+          A complete Dream graph: world, cast, and material-driven objects.
+        </span>
+      </span>
+      <span class="badge badge-secondary rounded-xl">{{ dateKey }}</span>
+      <Icon
+        name="kind-icon:chevron-down"
+        class="size-4 transition-transform group-open:rotate-180"
+      />
+    </summary>
+
+    <div class="border-t border-secondary/20 p-4">
+      <div class="grid gap-3 md:grid-cols-[8rem_8rem_minmax(0,1fr)_auto] md:items-end">
+        <label class="form-control">
+          <span class="label py-1 text-xs font-bold">Characters</span>
+          <select v-model.number="characterCount" class="select select-bordered select-sm rounded-xl">
+            <option :value="1">1</option>
+            <option :value="2">2</option>
+            <option :value="3">3</option>
+            <option :value="4">4</option>
+          </select>
+        </label>
+        <label class="form-control">
+          <span class="label py-1 text-xs font-bold">Objects</span>
+          <select v-model.number="rewardCount" class="select select-bordered select-sm rounded-xl">
+            <option :value="1">1</option>
+            <option :value="2">2</option>
+            <option :value="3">3</option>
+            <option :value="4">4</option>
+          </select>
+        </label>
+        <p class="text-xs leading-relaxed text-base-content/55">
+          The date supplies a stable seed. Reopening today returns the same Dream rather than creating duplicates.
+        </p>
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm rounded-xl"
+          :disabled="loading"
+          @click="createDailyDream"
+        >
+          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:dream" class="size-4" />
+          Build today’s Dream
+        </button>
+      </div>
+
+      <div
+        v-if="message"
+        class="mt-3 rounded-xl border p-3 text-sm"
+        :class="error ? 'border-error/30 bg-error/10 text-error' : 'border-success/30 bg-success/10 text-success'"
+      >
+        {{ message }}
+      </div>
+
+      <div v-if="blueprint" class="mt-3 grid gap-2 md:grid-cols-3">
+        <div class="rounded-xl bg-base-100 p-3">
+          <p class="text-[11px] font-black uppercase tracking-wide text-base-content/45">Dream</p>
+          <p class="mt-1 font-bold">{{ blueprint.title }}</p>
+          <p class="mt-1 line-clamp-3 text-xs text-base-content/55">{{ blueprint.pitch }}</p>
+        </div>
+        <div class="rounded-xl bg-base-100 p-3">
+          <p class="text-[11px] font-black uppercase tracking-wide text-base-content/45">Cast</p>
+          <p
+            v-for="character in blueprint.characters"
+            :key="character.name"
+            class="mt-1 text-xs"
+          >
+            <strong>{{ character.name }}</strong> · {{ character.species }} {{ character.characterClass }} · {{ character.alignment }}
+          </p>
+        </div>
+        <div class="rounded-xl bg-base-100 p-3">
+          <p class="text-[11px] font-black uppercase tracking-wide text-base-content/45">Objects</p>
+          <p
+            v-for="reward in blueprint.rewards"
+            :key="reward.name"
+            class="mt-1 text-xs"
+          >
+            <strong>{{ reward.name }}</strong> · {{ reward.rarity }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { performFetch } from '@/stores/utils'
+import type { DreamWithRelations } from '@/stores/dreamStore'
+
+type Blueprint = {
+  title: string
+  pitch: string
+  characters: Array<{
+    name: string
+    species: string
+    characterClass: string
+    alignment: string
+  }>
+  rewards: Array<{ name: string; rarity: string }>
+}
+
+type DailyDreamResponse = {
+  dream: DreamWithRelations
+  blueprint: Blueprint
+  reused: boolean
+}
+
+const emit = defineEmits<{ created: [dream: DreamWithRelations] }>()
+const loading = ref(false)
+const message = ref('')
+const error = ref(false)
+const blueprint = ref<Blueprint | null>(null)
+const characterCount = ref(2)
+const rewardCount = ref(2)
+const today = new Date()
+const dateKey = [
+  today.getFullYear(),
+  String(today.getMonth() + 1).padStart(2, '0'),
+  String(today.getDate()).padStart(2, '0'),
+].join('-')
+
+async function createDailyDream(): Promise<void> {
+  loading.value = true
+  message.value = ''
+  error.value = false
+  try {
+    const response = await performFetch<DailyDreamResponse>('/api/dreams/daily', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dateKey,
+        characterCount: characterCount.value,
+        rewardCount: rewardCount.value,
+        isPublic: false,
+        isMature: false,
+      }),
+    })
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Daily Dream could not be created.')
+    }
+    blueprint.value = response.data.blueprint
+    message.value = response.message || 'Daily Dream ready.'
+    emit('created', response.data.dream)
+  } catch (cause) {
+    error.value = true
+    message.value =
+      cause instanceof Error ? cause.message : 'Daily Dream could not be created.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/components/dreams/dream-manager.vue
+++ b/components/dreams/dream-manager.vue
@@ -38,6 +38,8 @@
       </button>
     </div>
 
+    <daily-dream-generator @created="onDailyDreamCreated" />
+
     <section
       v-if="activeTab === 'dreammaker'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
@@ -143,6 +145,13 @@ function onDreamEditing() {
 
 function onDreamCreated() {
   setTab('dreammaker')
+}
+
+async function onDailyDreamCreated(dream: DreamWithRelations) {
+  await loadManagerData(true)
+  await dreamStore.selectDreamById(dream.id)
+  setupUploadTarget()
+  setTab('dreams')
 }
 
 async function onDreamSaved(id?: number | number[] | DreamWithRelations) {

--- a/prisma/facet-catalog.prisma
+++ b/prisma/facet-catalog.prisma
@@ -2,9 +2,9 @@
 //
 // Facet remains the reusable creative concept. FacetProfile carries the richer
 // taxonomy and randomization metadata without duplicating the concept row.
-// CharacterFacet records how a Facet is used by a Character; fieldKey is usage
-// metadata, so an ANIMAL Facet such as Octopus can fill the species slot without
-// creating a duplicate SPECIES Facet.
+// CharacterFacet and RewardFacet record how a Facet is used by a nested object;
+// fieldKey is usage metadata, so a MATERIAL Facet can shape an ITEM Reward while
+// an ANIMAL Facet can fill a Character species slot.
 
 model FacetProfile {
   facetId          Int      @id
@@ -38,5 +38,21 @@ model CharacterFacet {
 
   @@unique([characterId, facetId, fieldKey])
   @@index([characterId, fieldKey, sortOrder])
+  @@index([facetId])
+}
+
+model RewardFacet {
+  id        Int      @id @default(autoincrement())
+  rewardId  Int
+  facetId   Int
+  fieldKey  String   @db.VarChar(64)
+  sortOrder Int      @default(0)
+  weight    Float    @default(1)
+  source    String   @default("CURATED") @db.VarChar(64)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([rewardId, facetId, fieldKey])
+  @@index([rewardId, fieldKey, sortOrder])
   @@index([facetId])
 }

--- a/prisma/migrations/20260726020000_reward_facet_daily_dream/migration.sql
+++ b/prisma/migrations/20260726020000_reward_facet_daily_dream/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `RewardFacet` (
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
+  `rewardId` INTEGER NOT NULL,
+  `facetId` INTEGER NOT NULL,
+  `fieldKey` VARCHAR(64) NOT NULL,
+  `sortOrder` INTEGER NOT NULL DEFAULT 0,
+  `weight` DOUBLE NOT NULL DEFAULT 1,
+  `source` VARCHAR(64) NOT NULL DEFAULT 'CURATED',
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+  UNIQUE INDEX `RewardFacet_rewardId_facetId_fieldKey_key`(`rewardId`, `facetId`, `fieldKey`),
+  INDEX `RewardFacet_rewardId_fieldKey_sortOrder_idx`(`rewardId`, `fieldKey`, `sortOrder`),
+  INDEX `RewardFacet_facetId_idx`(`facetId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `RewardFacet`
+  ADD CONSTRAINT `RewardFacet_rewardId_fkey`
+  FOREIGN KEY (`rewardId`) REFERENCES `Reward`(`id`)
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `RewardFacet`
+  ADD CONSTRAINT `RewardFacet_facetId_fkey`
+  FOREIGN KEY (`facetId`) REFERENCES `Facet`(`id`)
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/api/dreams/daily.post.ts
+++ b/server/api/dreams/daily.post.ts
@@ -1,0 +1,201 @@
+// /server/api/dreams/daily.post.ts
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { buildDailyDreamFacetBlueprint } from '~/server/utils/dailyDreamFacetBlueprint'
+
+type DailyDreamRequest = {
+  dateKey?: string | null
+  characterCount?: number | null
+  rewardCount?: number | null
+  isPublic?: boolean | null
+  isMature?: boolean | null
+}
+
+const DATE_KEY = /^\d{4}-\d{2}-\d{2}$/
+
+function count(value: unknown, fallback: number): number {
+  const numeric = Number(value)
+  return Number.isInteger(numeric)
+    ? Math.min(4, Math.max(1, numeric))
+    : fallback
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = (await readBody(event).catch(() => null)) as DailyDreamRequest | null
+    const dateKey = String(
+      body?.dateKey || new Date().toISOString().slice(0, 10),
+    ).trim()
+    if (!DATE_KEY.test(dateKey)) {
+      throw createError({
+        statusCode: 400,
+        message: 'dateKey must use YYYY-MM-DD.',
+      })
+    }
+
+    const blueprint = await buildDailyDreamFacetBlueprint({
+      userId: auth.user.id,
+      isAdmin: auth.isAdmin,
+      includeMature: Boolean(body?.isMature && auth.user.showMature),
+      dateKey,
+      characterCount: count(body?.characterCount, 2),
+      rewardCount: count(body?.rewardCount, 2),
+    })
+
+    const existing = await prisma.dream.findFirst({
+      where: { slug: blueprint.slug, userId: auth.user.id, isActive: true },
+      include: {
+        Characters: true,
+        Rewards: true,
+        FacetLinks: { include: { Facet: true } },
+      },
+    })
+    if (existing) {
+      return {
+        success: true,
+        message: `Daily Dream for ${dateKey} already exists.`,
+        data: { dream: existing, blueprint, reused: true },
+        statusCode: 200,
+      }
+    }
+
+    const isPublic = body?.isPublic ?? false
+    const isMature = Boolean(body?.isMature)
+    const created = await prisma.$transaction(async (tx) => {
+      const dream = await tx.dream.create({
+        data: {
+          title: blueprint.title,
+          slug: blueprint.slug,
+          description: blueprint.description,
+          pitch: blueprint.pitch,
+          flavorText: blueprint.flavorText,
+          artPrompt: blueprint.artPrompt,
+          dreamType: 'PITCH',
+          creationSource: 'AI',
+          designer: 'Daily Dream Facet Engine',
+          userId: auth.user.id,
+          isPublic,
+          isMature,
+          isActive: true,
+        },
+      })
+
+      if (blueprint.facets.length) {
+        await tx.dreamFacet.createMany({
+          data: blueprint.facets.map((facet) => ({
+            dreamId: dream.id,
+            facetId: facet.facetId,
+          })),
+          skipDuplicates: true,
+        })
+      }
+
+      const characterIds: number[] = []
+      for (const character of blueprint.characters) {
+        const createdCharacter = await tx.character.create({
+          data: {
+            name: character.name,
+            species: character.species,
+            class: character.characterClass,
+            role: character.role,
+            alignment: character.alignment,
+            personality: character.personality,
+            quirks: character.quirks,
+            backstory: character.backstory,
+            artPrompt: character.artPrompt,
+            designer: 'Daily Dream Facet Engine',
+            userId: auth.user.id,
+            isPublic,
+            isMature,
+            isActive: true,
+          },
+        })
+        characterIds.push(createdCharacter.id)
+        if (character.facets.length) {
+          await tx.characterFacet.createMany({
+            data: character.facets.map((facet, index) => ({
+              characterId: createdCharacter.id,
+              facetId: facet.facetId,
+              fieldKey: facet.fieldKey,
+              sortOrder: index,
+              source: 'DAILY_DREAM',
+            })),
+            skipDuplicates: true,
+          })
+        }
+      }
+
+      const rewardIds: number[] = []
+      for (const reward of blueprint.rewards) {
+        const createdReward = await tx.reward.create({
+          data: {
+            name: reward.name,
+            description: reward.description,
+            effect: reward.effect,
+            flavorText: reward.flavorText,
+            artPrompt: reward.artPrompt,
+            rewardType: 'ITEM',
+            rarity: reward.rarity,
+            collection: 'Daily Dream Objects',
+            userId: auth.user.id,
+            isPublic,
+            isMature,
+            isActive: true,
+          },
+        })
+        rewardIds.push(createdReward.id)
+        if (reward.facets.length) {
+          await tx.rewardFacet.createMany({
+            data: reward.facets.map((facet, index) => ({
+              rewardId: createdReward.id,
+              facetId: facet.facetId,
+              fieldKey: facet.fieldKey,
+              sortOrder: index,
+              source: 'DAILY_DREAM',
+            })),
+            skipDuplicates: true,
+          })
+        }
+      }
+
+      const connected = await tx.dream.update({
+        where: { id: dream.id },
+        data: {
+          Characters: {
+            connect: characterIds.map((id) => ({ id })),
+          },
+          Rewards: {
+            connect: rewardIds.map((id) => ({ id })),
+          },
+        },
+        include: {
+          Characters: true,
+          Rewards: true,
+          FacetLinks: { include: { Facet: true } },
+        },
+      })
+
+      return { dream: connected, characterIds, rewardIds }
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: `Created the Daily Dream for ${dateKey} with ${created.characterIds.length} characters and ${created.rewardIds.length} objects.`,
+      data: { ...created, blueprint, reused: false },
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode ?? 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to create Daily Dream.',
+      data: null,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/dailyDreamFacetBlueprint.ts
+++ b/server/utils/dailyDreamFacetBlueprint.ts
@@ -1,0 +1,330 @@
+// /server/utils/dailyDreamFacetBlueprint.ts
+import {
+  loadFacetCatalogEntries,
+  type FacetCatalogEntry,
+  type FacetTaxonomy,
+} from './facetCatalog'
+
+export type DailyDreamFacetUse = {
+  facetId: number
+  fieldKey: string
+  taxonomy: FacetTaxonomy
+  title: string
+  value: string
+  artPrompt: string | null
+  imagePath: string | null
+}
+
+export type DailyDreamCharacterBlueprint = {
+  name: string
+  species: string
+  characterClass: string
+  role: string | null
+  alignment: string
+  personality: string
+  quirks: string
+  backstory: string
+  artPrompt: string
+  facets: DailyDreamFacetUse[]
+}
+
+export type DailyDreamRewardBlueprint = {
+  name: string
+  description: string
+  effect: string
+  flavorText: string
+  artPrompt: string
+  rarity: 'COMMON' | 'UNCOMMON' | 'RARE'
+  facets: DailyDreamFacetUse[]
+}
+
+export type DailyDreamBlueprint = {
+  dateKey: string
+  title: string
+  slug: string
+  description: string
+  pitch: string
+  flavorText: string
+  artPrompt: string
+  facets: DailyDreamFacetUse[]
+  characters: DailyDreamCharacterBlueprint[]
+  rewards: DailyDreamRewardBlueprint[]
+}
+
+const FIRST_NAMES = [
+  'Mira',
+  'Juniper',
+  'Orlo',
+  'Tamsin',
+  'Vesper',
+  'Quill',
+  'Yara',
+  'Moss',
+  'Clover',
+  'Gadget',
+  'Nim',
+  'Rook',
+]
+const LAST_NAMES = [
+  'Voss',
+  'Underbridge',
+  'Moonspoon',
+  'Softstep',
+  'Nightjar',
+  'Starling',
+  'Foxglove',
+  'Glasswater',
+  'Tanglebone',
+  'Oddwick',
+]
+const ITEM_NOUNS = [
+  'Lantern',
+  'Key',
+  'Compass',
+  'Mask',
+  'Bell',
+  'Cup',
+  'Needle',
+  'Crown',
+  'Map',
+  'Blade',
+  'Locket',
+  'Dice',
+]
+
+function hashSeed(value: string): number {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let value = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function pick<T>(values: readonly T[], random: () => number): T | null {
+  if (!values.length) return null
+  return values[Math.floor(random() * values.length)] ?? null
+}
+
+function weightedPick(
+  entries: readonly FacetCatalogEntry[],
+  random: () => number,
+): FacetCatalogEntry | null {
+  const viable = entries.filter(
+    (entry) => entry.isRandomizable && entry.randomWeight > 0,
+  )
+  if (!viable.length) return null
+  const total = viable.reduce((sum, entry) => sum + entry.randomWeight, 0)
+  let roll = random() * total
+  for (const entry of viable) {
+    roll -= entry.randomWeight
+    if (roll <= 0) return entry
+  }
+  return viable.at(-1) ?? null
+}
+
+function weightedMany(
+  entries: readonly FacetCatalogEntry[],
+  count: number,
+  random: () => number,
+): FacetCatalogEntry[] {
+  const remaining = [...entries]
+  const selected: FacetCatalogEntry[] = []
+  while (remaining.length && selected.length < count) {
+    const chosen = weightedPick(remaining, random)
+    if (!chosen) break
+    selected.push(chosen)
+    remaining.splice(
+      remaining.findIndex((entry) => entry.id === chosen.id),
+      1,
+    )
+  }
+  return selected
+}
+
+function value(entry: FacetCatalogEntry | null): string {
+  return entry?.canonicalValue || entry?.title || ''
+}
+
+function use(
+  entry: FacetCatalogEntry | null,
+  fieldKey: string,
+): DailyDreamFacetUse | null {
+  if (!entry) return null
+  return {
+    facetId: entry.id,
+    fieldKey,
+    taxonomy: entry.taxonomy,
+    title: entry.title,
+    value: value(entry),
+    artPrompt: entry.artPrompt,
+    imagePath: entry.cardPath || entry.imagePath || entry.heroPath,
+  }
+}
+
+function uses(
+  entries: readonly FacetCatalogEntry[],
+  fieldKey: string,
+): DailyDreamFacetUse[] {
+  return entries
+    .map((entry) => use(entry, fieldKey))
+    .filter((entry): entry is DailyDreamFacetUse => Boolean(entry))
+}
+
+function slugSegment(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'dream'
+  )
+}
+
+function sentenceList(values: string[]): string {
+  const clean = values.filter(Boolean)
+  if (clean.length < 2) return clean[0] || ''
+  if (clean.length === 2) return `${clean[0]} and ${clean[1]}`
+  return `${clean.slice(0, -1).join(', ')}, and ${clean.at(-1)}`
+}
+
+export async function buildDailyDreamFacetBlueprint(options: {
+  userId: number
+  isAdmin?: boolean
+  includeMature?: boolean
+  dateKey: string
+  characterCount?: number
+  rewardCount?: number
+}): Promise<DailyDreamBlueprint> {
+  const catalog = await loadFacetCatalogEntries({
+    userId: options.userId,
+    isAdmin: Boolean(options.isAdmin),
+    includeMature: Boolean(options.includeMature),
+    randomizableOnly: true,
+  })
+  const byTaxonomy = new Map<FacetTaxonomy, FacetCatalogEntry[]>()
+  for (const entry of catalog) {
+    const list = byTaxonomy.get(entry.taxonomy) ?? []
+    list.push(entry)
+    byTaxonomy.set(entry.taxonomy, list)
+  }
+  const pool = (...taxonomies: FacetTaxonomy[]) =>
+    taxonomies.flatMap((taxonomy) => byTaxonomy.get(taxonomy) ?? [])
+  const random = mulberry32(hashSeed(`${options.userId}:${options.dateKey}`))
+  const one = (...taxonomies: FacetTaxonomy[]) =>
+    weightedPick(pool(...taxonomies), random)
+
+  const genre = one('GENRE')
+  const theme = one('THEME')
+  const mood = one('MOOD')
+  const setting = one('SETTING')
+  const style = one('STYLE')
+  const color = one('COLOR')
+  const dreamEntries = [genre, theme, mood, setting, style, color].filter(
+    (entry): entry is FacetCatalogEntry => Boolean(entry),
+  )
+  const dreamValues = dreamEntries.map(value)
+  const titleCore = value(theme) || value(setting) || value(genre) || 'Daily Dream'
+  const title = `${titleCore}: ${value(genre) || value(style) || 'A Strange Invitation'}`
+
+  const characters: DailyDreamCharacterBlueprint[] = []
+  const characterCount = Math.min(4, Math.max(1, options.characterCount ?? 2))
+  for (let index = 0; index < characterCount; index++) {
+    const species = one('ANIMAL', 'SPECIES')
+    const characterClass = one('OCCUPATION', 'ARCHETYPE', 'ROLE')
+    const alignment = one('ALIGNMENT')
+    const personalities = weightedMany(pool('PERSONALITY'), 2, random)
+    const quirks = weightedMany(pool('QUIRK'), 1, random)
+    const backstory = one('BACKSTORY')
+    const name = `${pick(FIRST_NAMES, random) || 'Mira'} ${pick(LAST_NAMES, random) || 'Voss'}`
+    const classValue = value(characterClass) || 'Wanderer'
+    const speciesValue = value(species) || 'Mysterious Being'
+    const alignmentValue = value(alignment) || 'Uncertain'
+    const personalityValue = sentenceList(personalities.map(value)) || 'curious'
+    const quirkValue = sentenceList(quirks.map(value)) || 'impossible to overlook'
+    const backstoryValue = value(backstory) || 'They arrived carrying a history nobody agrees on.'
+    const facetUses = [
+      use(species, 'species'),
+      use(characterClass, characterClass?.taxonomy === 'ROLE' ? 'role' : 'class'),
+      use(alignment, 'alignment'),
+      ...uses(personalities, 'personality'),
+      ...uses(quirks, 'quirks'),
+      use(backstory, 'backstory'),
+    ].filter((entry): entry is DailyDreamFacetUse => Boolean(entry))
+
+    characters.push({
+      name,
+      species: speciesValue,
+      characterClass: classValue,
+      role: characterClass?.taxonomy === 'ROLE' ? classValue : null,
+      alignment: alignmentValue,
+      personality: personalityValue,
+      quirks: quirkValue,
+      backstory: `${backstoryValue} In this Dream, ${name} must decide what ${alignmentValue.toLowerCase()} means when certainty is dangerous.`,
+      artPrompt: `${name}, ${speciesValue} ${classValue}, ${personalityValue}, ${quirkValue}, ${sentenceList(dreamValues)}, expressive full character design`,
+      facets: facetUses,
+    })
+  }
+
+  const rewards: DailyDreamRewardBlueprint[] = []
+  const rewardCount = Math.min(4, Math.max(1, options.rewardCount ?? 2))
+  for (let index = 0; index < rewardCount; index++) {
+    const material = one('MATERIAL')
+    const rewardTheme = one('THEME') || theme
+    const rewardColor = one('COLOR')
+    const noun = pick(ITEM_NOUNS, random) || 'Relic'
+    const materialValue = value(material) || 'Impossible'
+    const themeValue = value(rewardTheme)
+    const colorValue = value(rewardColor)
+    const name = `${materialValue} ${noun}${themeValue ? ` of ${themeValue}` : ''}`
+    const rarityRoll = random()
+    const rarity =
+      rarityRoll > 0.9 ? 'RARE' : rarityRoll > 0.6 ? 'UNCOMMON' : 'COMMON'
+    const facetUses = [
+      use(material, 'material'),
+      use(rewardTheme, 'theme'),
+      use(rewardColor, 'color'),
+    ].filter((entry): entry is DailyDreamFacetUse => Boolean(entry))
+
+    rewards.push({
+      name,
+      description: `A ${colorValue ? `${colorValue} ` : ''}${noun.toLowerCase()} made from ${materialValue}${themeValue ? ` and shaped by ${themeValue}` : ''}.`,
+      effect: `When introduced into a scene, the ${noun.toLowerCase()} changes what the characters believe is possible, but demands a choice that reflects the Dream's central conflict.`,
+      flavorText: `It feels as though it remembers tomorrow.` ,
+      artPrompt: `${name}, singular magical reward item, ${colorValue}, ${sentenceList(dreamValues)}, readable silhouette, detailed object illustration`,
+      rarity,
+      facets: facetUses,
+    })
+  }
+
+  const castSummary = characters
+    .map((character) => `${character.name}, a ${character.species} ${character.characterClass}`)
+    .join('; ')
+  const rewardSummary = rewards.map((reward) => reward.name).join('; ')
+  const description = `A ${sentenceList(dreamValues)} Dream. Its cast: ${castSummary}. Its consequential objects: ${rewardSummary}.`
+  const pitch = `The Dream begins when ${characters[0]?.name || 'a stranger'} discovers ${rewards[0]?.name || 'an impossible object'} and learns that ${value(theme) || 'the apparent theme'} is not a mood but a rule. Every character wants something different from that rule, and the objects inside the Dream can alter it.`
+
+  return {
+    dateKey: options.dateKey,
+    title,
+    slug: `daily-dream-${options.dateKey}-${options.userId}-${slugSegment(titleCore)}`,
+    description,
+    pitch,
+    flavorText: `Generated as a nested Facet blueprint for ${options.dateKey}.`,
+    artPrompt: `${title}, ${description}, cinematic ensemble scene, characters interacting with visible reward objects, ${sentenceList(dreamValues)}, coherent visual storytelling`,
+    facets: uses(dreamEntries, 'dream'),
+    characters,
+    rewards,
+  }
+}


### PR DESCRIPTION
Superseded by #998, which transplants the feature onto current `main` and adds Reward Facet APIs, picker persistence, merge safety, and contract coverage.