### PR TITLE
kind-robots/t-043: add trusted-caller mana-charge endpoint

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 
+      - name: Mana-gate on-behalf-of target authorization contract
+        run: npm run test:mana-gate-on-behalf-of-target
+
       - name: WonderLab reconciliation contract
         run: npm run test:wonderlab-reconcile
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test:newsfeed-perspective-balance": "tsx utils/scripts/verifyNewsfeedPerspectiveBalance.ts",
     "test:tutorial-channel-resolver": "tsx utils/scripts/verifyTutorialChannelResolver.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
+    "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",
     "components:manifest": "node utils/scripts/create-component-json.mjs",
     "cypress:open": "cypress open",

--- a/server/api/economy/mana/charge.post.ts
+++ b/server/api/economy/mana/charge.post.ts
@@ -1,0 +1,109 @@
+// /server/api/economy/mana/charge.post.ts
+//
+// kind-robots/t-043 (pitch: pitches/2026-07-21-sketchy-cross-app-mana-charge-endpoint.md).
+// Lets a trusted external app (Sketchy today) debit a Kind Robots user's real
+// mana balance for work it performed on its own infrastructure. Reuses the
+// existing machine-user auth (requireMachineUser) and manaGate/applyMana
+// verbatim -- the only new surface is manaGate's targetUserId override,
+// which is only honored for a server-key caller (see
+// server/utils/manaGate.ts resolveManaGateTarget).
+import { createError, defineEventHandler, readBody } from 'h3'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { manaGate, type ManaGateChargeableKind } from '../../../utils/manaGate'
+import { errorHandler } from '../../../utils/error'
+
+const CHARGEABLE_KINDS: ManaGateChargeableKind[] = [
+  'text',
+  'art',
+  'video',
+  'model',
+]
+
+type ManaChargeRequest = {
+  krUserId?: unknown
+  kind?: unknown
+  estCostUsd?: unknown
+  refId?: unknown
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    // requireMachineUser resolves the CALLER's own identity (session JWT,
+    // user apiKey, or beta-admin-token). This route only accepts the
+    // server-key (beta-admin-token / future scoped machine-credential) path
+    // -- a regular user's own JWT/apiKey must never be able to charge
+    // someone else's mana, even though requireMachineUser would authenticate
+    // it fine for in-process routes.
+    const auth = await requireMachineUser(event)
+
+    if (!auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message:
+          'This endpoint requires a trusted machine-caller credential, not a user session.',
+      })
+    }
+
+    const body = (await readBody(event)) as ManaChargeRequest | null
+
+    const krUserId = Number(body?.krUserId)
+    const kind = body?.kind as ManaGateChargeableKind
+    const estCostUsd = Number(body?.estCostUsd)
+    const refId = typeof body?.refId === 'string' ? body.refId.trim() : ''
+
+    if (!Number.isInteger(krUserId) || krUserId <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'krUserId must be a positive integer.',
+      })
+    }
+
+    if (!CHARGEABLE_KINDS.includes(kind)) {
+      throw createError({
+        statusCode: 400,
+        message: `kind must be one of: ${CHARGEABLE_KINDS.join(', ')}.`,
+      })
+    }
+
+    if (!Number.isFinite(estCostUsd) || estCostUsd <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'estCostUsd must be a positive number.',
+      })
+    }
+
+    if (!refId) {
+      throw createError({
+        statusCode: 400,
+        message: 'refId is required.',
+      })
+    }
+
+    const gate = await manaGate(event, {
+      kind,
+      estCostUsd,
+      targetUserId: krUserId,
+    })
+
+    const { balance } = await gate.commit(refId, estCostUsd)
+
+    return {
+      success: true,
+      message: 'Mana charged.',
+      statusCode: 200,
+      data: {
+        balance,
+        charged: gate.cost,
+        free: gate.free,
+      },
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to charge mana.',
+      statusCode: event.node.res.statusCode,
+    }
+  }
+})

--- a/server/utils/manaGate.ts
+++ b/server/utils/manaGate.ts
@@ -2,16 +2,28 @@
 import { createError, type H3Event } from 'h3'
 import prisma from './prisma'
 import { requireApiUser } from './authGuard'
+import { userIsAdmin } from './authUser'
 import { applyMana } from './mana'
 import type { ManaReason } from './mana'
+import { resolveManaGateTarget } from './manaGateTarget'
 
 type ManaGateKind = 'text' | 'art' | 'video' | 'model' | 'free'
+
+// Kinds an external caller may request via /api/economy/mana/charge -- 'free'
+// is deliberately excluded, it's an internal-only bypass, not something a
+// trusted caller should be able to request directly.
+export type ManaGateChargeableKind = Exclude<ManaGateKind, 'free'>
 
 type ManaGateInput = {
   kind: ManaGateKind
   estCostUsd?: number
   serverId?: number | null
   useOwnResource?: boolean
+  // Set only by a trusted machine caller (economy/mana/charge.post.ts) to
+  // charge a different user for work the caller performed on its own
+  // infrastructure. Ignored (falls back to the caller's own id) unless the
+  // caller authenticates as a server key -- see resolveManaGateTarget.
+  targetUserId?: number | null
 }
 
 type ManaGateResult = {
@@ -45,9 +57,15 @@ export async function manaGate(
 ): Promise<ManaGateResult> {
   const auth = await requireApiUser(event)
 
+  const { userId: targetUserId, onBehalfOfOtherUser } = resolveManaGateTarget({
+    callerUserId: auth.user.id,
+    isServerKey: auth.isServerKey,
+    targetUserId: input.targetUserId,
+  })
+
   const user = await prisma.user.findUnique({
     where: {
-      id: auth.user.id,
+      id: targetUserId,
     },
     select: {
       id: true,
@@ -58,8 +76,10 @@ export async function manaGate(
 
   if (!user) {
     throw createError({
-      statusCode: 401,
-      message: 'Authorization user was not found.',
+      statusCode: onBehalfOfOtherUser ? 404 : 401,
+      message: onBehalfOfOtherUser
+        ? 'Target user was not found.'
+        : 'Authorization user was not found.',
     })
   }
 
@@ -67,8 +87,11 @@ export async function manaGate(
     userId: user.id,
     serverId: input.serverId ?? null,
     useOwnResource: input.useOwnResource ?? false,
-    isAdmin: auth.isAdmin,
-    isServerKey: auth.isServerKey,
+    // On-behalf-of charges bill the target user for real. The caller's own
+    // admin/server-key standing must not grant a free pass on someone else's
+    // account, or every cross-app charge would silently cost nothing.
+    isAdmin: onBehalfOfOtherUser ? userIsAdmin(user) : auth.isAdmin,
+    isServerKey: onBehalfOfOtherUser ? false : auth.isServerKey,
     userRole: user.Role,
     kind: input.kind,
   })

--- a/server/utils/manaGateTarget.ts
+++ b/server/utils/manaGateTarget.ts
@@ -1,0 +1,38 @@
+// /server/utils/manaGateTarget.ts
+//
+// Pure (no DB, no Nuxt runtime) authorization boundary for on-behalf-of mana
+// charges. Split out of manaGate.ts so it has a direct, dependency-free unit
+// test (utils/scripts/verifyManaGateOnBehalfOfTarget.test.ts) -- manaGate.ts
+// itself pulls in authGuard.ts -> server/api/auth, which calls Nuxt's
+// useRuntimeConfig() at module load and can only run inside the Nuxt/Nitro
+// runtime, not a standalone tsx script.
+//
+// Only a caller that authenticated as a server key (requireMachineUser's
+// beta-admin-token / future scoped machine-credential path, see
+// server/utils/authGuard.ts) may specify a targetUserId other than its own --
+// a regular session JWT or user apiKey must never be able to redirect a
+// charge onto someone else's balance (kind-robots/t-043,
+// server/api/economy/mana/charge.post.ts).
+import { createError } from 'h3'
+
+export function resolveManaGateTarget(input: {
+  callerUserId: number
+  isServerKey: boolean
+  targetUserId?: number | null
+}): { userId: number; onBehalfOfOtherUser: boolean } {
+  const requested = input.targetUserId ?? null
+
+  if (requested == null || requested === input.callerUserId) {
+    return { userId: input.callerUserId, onBehalfOfOtherUser: false }
+  }
+
+  if (!input.isServerKey) {
+    throw createError({
+      statusCode: 403,
+      message:
+        'Only a trusted machine caller may charge mana against a different user.',
+    })
+  }
+
+  return { userId: requested, onBehalfOfOtherUser: true }
+}

--- a/utils/scripts/verifyManaGateOnBehalfOfTarget.ts
+++ b/utils/scripts/verifyManaGateOnBehalfOfTarget.ts
@@ -1,0 +1,97 @@
+// /utils/scripts/verifyManaGateOnBehalfOfTarget.ts
+//
+// Regression guard for kind-robots/t-043 (server/api/economy/mana/charge.post.ts,
+// pitches/2026-07-21-sketchy-cross-app-mana-charge-endpoint.md): the on-behalf-of
+// mana-charge authorization boundary must reject any caller that is not a
+// server key from redirecting a charge onto a different user's balance. This
+// is the entire security property the trusted-caller endpoint depends on, so
+// it gets a direct DB-free test against the real exported function rather
+// than only integration coverage.
+import assert from 'node:assert/strict'
+import { resolveManaGateTarget } from '../../server/utils/manaGateTarget'
+
+let failures = 0
+
+function check(label: string, fn: () => void): void {
+  try {
+    fn()
+    console.log(`ok - ${label}`)
+  } catch (error) {
+    failures += 1
+    console.error(`FAIL - ${label}`)
+    console.error(error instanceof Error ? error.message : error)
+  }
+}
+
+check(
+  'same-user charge is always allowed, regardless of server-key status',
+  () => {
+    assert.deepEqual(
+      resolveManaGateTarget({
+        callerUserId: 5,
+        isServerKey: false,
+        targetUserId: 5,
+      }),
+      { userId: 5, onBehalfOfOtherUser: false },
+    )
+  },
+)
+
+check(
+  'no targetUserId resolves to the caller, regardless of server-key status',
+  () => {
+    assert.deepEqual(
+      resolveManaGateTarget({ callerUserId: 5, isServerKey: false }),
+      {
+        userId: 5,
+        onBehalfOfOtherUser: false,
+      },
+    )
+  },
+)
+
+check('a non-server-key caller cannot charge a different user', () => {
+  assert.throws(
+    () =>
+      resolveManaGateTarget({
+        callerUserId: 5,
+        isServerKey: false,
+        targetUserId: 9,
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as { statusCode?: number }).statusCode === 403,
+  )
+})
+
+check('a server-key caller CAN charge a different user', () => {
+  assert.deepEqual(
+    resolveManaGateTarget({
+      callerUserId: 1,
+      isServerKey: true,
+      targetUserId: 9,
+    }),
+    { userId: 9, onBehalfOfOtherUser: true },
+  )
+})
+
+check(
+  'a server-key caller charging its own id is not flagged on-behalf-of',
+  () => {
+    assert.deepEqual(
+      resolveManaGateTarget({
+        callerUserId: 1,
+        isServerKey: true,
+        targetUserId: 1,
+      }),
+      { userId: 1, onBehalfOfOtherUser: false },
+    )
+  },
+)
+
+if (failures > 0) {
+  console.error(`\n${failures} failure(s).`)
+  process.exitCode = 1
+} else {
+  console.log('\nAll mana-gate on-behalf-of target self-tests passed.')
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/economy/mana/charge` so a trusted external app (Sketchy) can debit a Kind Robots user's real mana balance for work it performed on its own infrastructure — implements the approved pitch at `pitches/2026-07-21-sketchy-cross-app-mana-charge-endpoint.md` (conductor `kind-robots/t-043`, already cleared by Silas: `gate_human: true` / `approved_by_human: true`).
- Reuses `requireMachineUser` / `manaGate` / `applyMana` verbatim — no schema change, no new `ManaReason`, no new mana math. The only new surface is `manaGate`'s optional `targetUserId` override.
- The on-behalf-of authorization boundary (`resolveManaGateTarget`) only allows a caller authenticated as a server key (`requireMachineUser`'s beta-admin-token / future scoped machine-credential path) to specify a `targetUserId` other than its own — a regular session JWT or user apiKey can never redirect a charge onto someone else's balance.
- On-behalf-of charges bill the **target user's** own admin/mana standing, not the calling machine credential's — otherwise every cross-app charge would silently be free just because the caller authenticated as a server key.
- `resolveManaGateTarget` is split into its own dependency-free module (`server/utils/manaGateTarget.ts`) so it has a direct, no-mock unit test (`utils/scripts/verifyManaGateOnBehalfOfTarget.ts`) — `manaGate.ts`'s own import chain (`authGuard.ts` → `server/api/auth`) needs the Nuxt/Nitro runtime (`useRuntimeConfig()`) and can't run standalone via `tsx`.
- Wired the new test into `package.json` (`test:mana-gate-on-behalf-of-target`) and `.github/workflows/contract-tests.yml` so the authorization boundary is CI-gated going forward.

## Test plan
- [x] `npx tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts` — all 5 cases pass (same-user always allowed; no-target resolves to caller; non-server-key caller rejected with 403 when targeting another user; server-key caller allowed; server-key caller targeting itself not flagged on-behalf-of).
- [x] `npx eslint` on all changed/added files — clean.
- [x] `npx prettier --check` on all changed/added files — clean.
- [x] Full `vue-tsc --noEmit` typecheck — exit 0, zero errors.
- [ ] Live Sketchy integration (issuing the actual scoped machine credential and wiring the two `sketchy/TOKEN-TIERS.md` call sites) is explicitly out of scope per the pitch's "Suggested first task" — tracked separately.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FFtidf8mP13CkzKZJx53YG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFtidf8mP13CkzKZJx53YG)_