### PR TITLE
Expose complete Facet profiles in the Library

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -40,6 +40,7 @@ jobs:
           node utils/scripts/verifyRetiredRewardRandomizers.mjs
           npx tsx utils/scripts/verifyFacetArtGeneration.ts
           npx tsx utils/scripts/verifyDreamRandomCompatibility.ts
+          npx tsx utils/scripts/verifyFacetLibraryAdvanced.ts
 
       - name: Verify curated Facet artwork
         id: artwork

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -8,15 +8,11 @@
       <div class="min-w-0 flex-1">
         <h1 class="text-xl font-black">Facet Library</h1>
         <p class="text-sm text-base-content/60">
-          Canonical reusable concepts for Characters, Dreams, Scenarios, Art,
-          and random generation. Aliases and curated artwork resolve to one
-          record.
+          Complete canonical profiles for reusable concepts across Characters,
+          Dreams, Rewards, Scenarios, art, and random generation.
         </p>
       </div>
-      <span
-        v-if="facetStore.loading"
-        class="loading loading-spinner loading-sm"
-      />
+      <span v-if="facetStore.loading" class="loading loading-spinner loading-sm" />
       <span class="badge badge-ghost">{{ filteredFacets.length }} shown</span>
     </header>
 
@@ -24,8 +20,8 @@
       <input
         v-model="search"
         type="search"
-        class="input input-bordered input-sm w-full max-w-xs rounded-xl bg-base-200"
-        placeholder="Search title, alias, taxonomy, group, or art path..."
+        class="input input-bordered input-sm w-full max-w-sm rounded-xl bg-base-200"
+        placeholder="Search title, alias, taxonomy, metadata, or art path..."
       />
       <select
         v-model="taxonomyFilter"
@@ -40,9 +36,7 @@
           {{ taxonomyLabel(taxonomy) }} ({{ taxonomyCounts[taxonomy] || 0 }})
         </option>
       </select>
-      <label
-        class="ml-auto flex items-center gap-2 text-xs text-base-content/60"
-      >
+      <label class="ml-auto flex items-center gap-2 text-xs text-base-content/60">
         <input
           v-model="showArchived"
           type="checkbox"
@@ -62,154 +56,128 @@
       >
         + Create a canonical Facet
       </summary>
-      <div
-        class="grid gap-3 border-t border-base-300 p-4 sm:grid-cols-2 xl:grid-cols-4"
-      >
-        <label class="form-control xl:col-span-2">
-          <span class="label-text text-xs">Canonical title</span>
-          <input
-            v-model="newTitle"
-            type="text"
-            class="input input-bordered input-sm rounded-xl"
-            placeholder="CowCore"
-          />
-        </label>
-        <label class="form-control">
-          <span class="label-text text-xs">Taxonomy</span>
-          <select
-            v-model="newTaxonomy"
-            class="select select-bordered select-sm rounded-xl"
-          >
-            <option
-              v-for="taxonomy in facetTaxonomies"
-              :key="taxonomy"
-              :value="taxonomy"
-            >
-              {{ taxonomyLabel(taxonomy) }}
-            </option>
-          </select>
-        </label>
-        <label class="form-control">
-          <span class="label-text text-xs">Random weight</span>
-          <input
-            v-model.number="newRandomWeight"
-            type="number"
-            min="0"
-            step="0.1"
-            class="input input-bordered input-sm rounded-xl"
-          />
-        </label>
-        <label class="form-control sm:col-span-2 xl:col-span-4">
-          <span class="label-text text-xs">Aliases</span>
-          <input
-            v-model="newAliases"
-            type="text"
-            class="input input-bordered input-sm rounded-xl"
-            placeholder="Aliases separated by commas"
-          />
-        </label>
-        <label class="form-control">
-          <span class="label-text text-xs">Group key</span>
-          <input
-            v-model="newGroupKey"
-            type="text"
-            class="input input-bordered input-sm rounded-xl"
-            placeholder="cosmic-species"
-          />
-        </label>
-        <label class="form-control">
-          <span class="label-text text-xs">Group label</span>
-          <input
-            v-model="newGroupLabel"
-            type="text"
-            class="input input-bordered input-sm rounded-xl"
-            placeholder="Cosmic Species"
-          />
-        </label>
-        <label class="form-control sm:col-span-2">
-          <span class="label-text text-xs">Description</span>
-          <textarea
-            v-model="newDescription"
-            class="textarea textarea-bordered min-h-20 rounded-xl"
-            placeholder="What this reusable concept means..."
-          />
-        </label>
 
-        <div
-          class="rounded-2xl border border-base-300 bg-base-200/60 p-3 sm:col-span-2 xl:col-span-4"
-        >
-          <div class="mb-3 flex items-center gap-2">
-            <Icon name="kind-icon:palette" class="size-4 text-accent" />
-            <div>
-              <h3 class="text-sm font-bold">Curated artwork</h3>
-              <p class="text-xs text-base-content/50">
-                Preserve the primary, card, and hero roles separately.
-              </p>
-            </div>
-          </div>
-          <div class="grid gap-3 lg:grid-cols-[12rem_1fr]">
-            <div
-              class="flex h-40 items-center justify-center overflow-hidden rounded-xl bg-base-300/50"
+      <div class="space-y-4 border-t border-base-300 p-4">
+        <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <label class="form-control xl:col-span-2">
+            <span class="label-text text-xs">Canonical title</span>
+            <input
+              v-model="createForm.title"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="CowCore"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Canonical value</span>
+            <input
+              v-model="createForm.canonicalValue"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="Defaults to title"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Taxonomy</span>
+            <select
+              v-model="createForm.taxonomy"
+              class="select select-bordered select-sm rounded-xl"
             >
-              <img
-                v-if="newArtworkPreview"
-                :src="newArtworkPreview"
-                :alt="`${newTitle || 'New Facet'} artwork preview`"
-                class="size-full object-contain"
-                loading="lazy"
-              />
-              <Icon
-                v-else
-                name="kind-icon:image"
-                class="size-10 text-base-content/20"
-              />
-            </div>
-            <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-              <label class="form-control">
-                <span class="label-text text-xs">Primary image path</span>
-                <input
-                  v-model="newImagePath"
-                  type="text"
-                  class="input input-bordered input-sm rounded-xl"
-                  placeholder="/images/facets/example.webp"
-                />
-              </label>
-              <label class="form-control">
-                <span class="label-text text-xs">Card / portrait path</span>
-                <input
-                  v-model="newCardPath"
-                  type="text"
-                  class="input input-bordered input-sm rounded-xl"
-                  placeholder="/images/facets/cards/example.webp"
-                />
-              </label>
-              <label class="form-control">
-                <span class="label-text text-xs">Hero / wide path</span>
-                <input
-                  v-model="newHeroPath"
-                  type="text"
-                  class="input input-bordered input-sm rounded-xl"
-                  placeholder="/images/facets/heroes/example.webp"
-                />
-              </label>
-              <label class="form-control sm:col-span-2 xl:col-span-3">
-                <span class="label-text text-xs">Art prompt</span>
-                <textarea
-                  v-model="newArtPrompt"
-                  class="textarea textarea-bordered min-h-20 rounded-xl"
-                  placeholder="Prompt for generating or regenerating this Facet's artwork..."
-                />
-              </label>
-            </div>
-          </div>
+              <option
+                v-for="taxonomy in facetTaxonomies"
+                :key="taxonomy"
+                :value="taxonomy"
+              >
+                {{ taxonomyLabel(taxonomy) }}
+              </option>
+            </select>
+          </label>
+          <label class="form-control sm:col-span-2 xl:col-span-4">
+            <span class="label-text text-xs">Aliases</span>
+            <input
+              v-model="createForm.aliases"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="Aliases separated by commas"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Group key</span>
+            <input
+              v-model="createForm.groupKey"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="cosmic-species"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Group label</span>
+            <input
+              v-model="createForm.groupLabel"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="Cosmic Species"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Sort order</span>
+            <input
+              v-model.number="createForm.sortOrder"
+              type="number"
+              step="1"
+              class="input input-bordered input-sm rounded-xl"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Source rank</span>
+            <input
+              v-model.number="createForm.sourceRank"
+              type="number"
+              min="0"
+              step="1"
+              class="input input-bordered input-sm rounded-xl"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Random weight</span>
+            <input
+              v-model.number="createForm.randomWeight"
+              type="number"
+              min="0"
+              step="0.1"
+              class="input input-bordered input-sm rounded-xl"
+            />
+          </label>
+          <label class="form-control sm:col-span-2 xl:col-span-3">
+            <span class="label-text text-xs">Description</span>
+            <textarea
+              v-model="createForm.description"
+              class="textarea textarea-bordered min-h-20 rounded-xl"
+              placeholder="What this reusable concept means..."
+            />
+          </label>
+          <label class="form-control sm:col-span-2 xl:col-span-4">
+            <span class="label-text text-xs">Structured metadata (JSON object)</span>
+            <textarea
+              v-model="createForm.metadata"
+              class="textarea textarea-bordered min-h-24 rounded-xl font-mono text-xs"
+              placeholder='{"scientificName":"...","source":"curated"}'
+            />
+          </label>
         </div>
 
-        <div
-          class="flex flex-wrap items-center gap-5 text-xs sm:col-span-2 xl:col-span-4"
-        >
+        <artwork-fields
+          :title="createForm.title || 'New Facet'"
+          v-model:image-path="createForm.imagePath"
+          v-model:card-path="createForm.cardPath"
+          v-model:hero-path="createForm.heroPath"
+          v-model:art-prompt="createForm.artPrompt"
+        />
+
+        <div class="flex flex-wrap items-center gap-5 text-xs">
           <label class="flex items-center gap-2">
             <input
-              v-model="newIsRandomizable"
+              v-model="createForm.isRandomizable"
               type="checkbox"
               class="toggle toggle-secondary toggle-xs"
             />
@@ -217,7 +185,7 @@
           </label>
           <label class="flex items-center gap-2">
             <input
-              v-model="newArtRequired"
+              v-model="createForm.artRequired"
               type="checkbox"
               class="toggle toggle-accent toggle-xs"
             />
@@ -225,23 +193,29 @@
           </label>
           <label class="flex items-center gap-2">
             <input
-              v-model="newIsPublic"
+              v-model="createForm.isPublic"
               type="checkbox"
               class="toggle toggle-primary toggle-xs"
             />
             Public
           </label>
+          <label class="flex items-center gap-2">
+            <input
+              v-model="createForm.isMature"
+              type="checkbox"
+              class="toggle toggle-warning toggle-xs"
+            />
+            Mature
+          </label>
         </div>
+
         <button
           type="button"
-          class="btn btn-secondary btn-sm rounded-xl sm:col-span-2 xl:col-span-4"
-          :disabled="!newTitle.trim() || facetStore.saving"
+          class="btn btn-secondary btn-sm w-full rounded-xl"
+          :disabled="!createForm.title.trim() || facetStore.saving"
           @click="createFacet"
         >
-          <span
-            v-if="facetStore.saving"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="facetStore.saving" class="loading loading-spinner loading-xs" />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create canonical Facet
         </button>
@@ -274,15 +248,12 @@
 
         <div class="p-4">
           <div class="flex items-start justify-between gap-2">
-            <div class="min-w-0">
+            <div class="min-w-0 flex-1">
               <div class="flex flex-wrap items-center gap-1">
                 <span class="badge badge-secondary badge-xs">
                   {{ taxonomyLabel(facet.taxonomy) }}
                 </span>
-                <span
-                  v-if="facet.groupLabel"
-                  class="badge badge-outline badge-xs"
-                >
+                <span v-if="facet.groupLabel" class="badge badge-outline badge-xs">
                   {{ facet.groupLabel }}
                 </span>
                 <span v-if="!facet.isActive" class="badge badge-error badge-xs">
@@ -294,66 +265,82 @@
               </div>
               <h2 class="mt-1 truncate text-base font-bold">{{ facet.title }}</h2>
               <p class="truncate text-xs text-base-content/40">
-                {{ facet.aliases.join(' · ') }}
+                {{ facet.canonicalValue }} · {{ facet.aliases.join(' · ') }}
               </p>
             </div>
             <button
               type="button"
               class="btn btn-ghost btn-xs rounded-xl"
-              :aria-label="
-                editingId === facet.id ? 'Close editor' : `Edit ${facet.title}`
-              "
+              :aria-label="editingId === facet.id ? 'Close editor' : `Edit ${facet.title}`"
               @click="toggleEdit(facet)"
             >
               <Icon
-                :name="
-                  editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'
-                "
+                :name="editingId === facet.id ? 'kind-icon:x' : 'kind-icon:pencil'"
                 class="size-4"
               />
             </button>
           </div>
 
-          <p
-            v-if="facet.description && editingId !== facet.id"
-            class="mt-2 line-clamp-3 text-xs text-base-content/60"
-          >
-            {{ facet.description }}
-          </p>
+          <template v-if="editingId !== facet.id">
+            <p
+              v-if="facet.description"
+              class="mt-2 line-clamp-3 text-xs text-base-content/60"
+            >
+              {{ facet.description }}
+            </p>
+            <p
+              v-if="facet.artPrompt"
+              class="mt-2 line-clamp-2 text-[11px] italic text-base-content/45"
+            >
+              {{ facet.artPrompt }}
+            </p>
+            <div class="mt-3 flex flex-wrap gap-1 text-[11px]">
+              <span class="badge badge-ghost badge-xs">order {{ facet.sortOrder }}</span>
+              <span class="badge badge-ghost badge-xs">weight {{ facet.randomWeight }}</span>
+              <span class="badge badge-ghost badge-xs">rank {{ facet.sourceRank }}</span>
+              <span class="badge badge-ghost badge-xs">
+                {{ facet.isRandomizable ? 'randomizable' : 'manual only' }}
+              </span>
+              <span class="badge badge-ghost badge-xs">
+                {{ facet.artRequired ? 'art expected' : 'art optional' }}
+              </span>
+              <span v-if="facet.metadata" class="badge badge-ghost badge-xs">
+                metadata
+              </span>
+            </div>
 
-          <p
-            v-if="facet.artPrompt && editingId !== facet.id"
-            class="mt-2 line-clamp-2 text-[11px] italic text-base-content/45"
-          >
-            {{ facet.artPrompt }}
-          </p>
+            <div
+              v-if="facet.artRequired && !facetArtwork(facet)"
+              class="mt-3 rounded-xl border border-dashed border-accent/40 bg-accent/5 p-2"
+            >
+              <button
+                type="button"
+                class="btn btn-outline btn-accent btn-xs w-full rounded-lg"
+                :disabled="artRequestStore.requesting[facet.id]"
+                @click="requestArt(facet)"
+              >
+                <span
+                  v-if="artRequestStore.requesting[facet.id]"
+                  class="loading loading-spinner loading-xs"
+                />
+                <Icon v-else name="kind-icon:palette" class="size-3.5" />
+                {{
+                  artRequestStore.requested[facet.id]
+                    ? 'Artwork requested'
+                    : 'Request primary artwork'
+                }}
+              </button>
+              <p
+                v-if="artRequestStore.errors[facet.id]"
+                class="mt-1 text-[11px] text-error"
+              >
+                {{ artRequestStore.errors[facet.id] }}
+              </p>
+            </div>
+          </template>
 
           <div
-            v-if="editingId !== facet.id"
-            class="mt-3 flex flex-wrap gap-1 text-[11px]"
-          >
-            <span class="badge badge-ghost badge-xs">
-              weight {{ facet.randomWeight }}
-            </span>
-            <span class="badge badge-ghost badge-xs">
-              {{ facet.isRandomizable ? 'randomizable' : 'manual only' }}
-            </span>
-            <span class="badge badge-ghost badge-xs">
-              {{ facet.artRequired ? 'art expected' : 'art optional' }}
-            </span>
-            <span v-if="facet.imagePath" class="badge badge-ghost badge-xs">
-              primary art
-            </span>
-            <span v-if="facet.cardPath" class="badge badge-ghost badge-xs">
-              card art
-            </span>
-            <span v-if="facet.heroPath" class="badge badge-ghost badge-xs">
-              hero art
-            </span>
-          </div>
-
-          <div
-            v-if="editingId === facet.id"
+            v-else
             class="mt-3 grid gap-2 sm:grid-cols-2"
           >
             <input
@@ -361,6 +348,12 @@
               type="text"
               class="input input-bordered input-sm rounded-xl sm:col-span-2"
               placeholder="Title"
+            />
+            <input
+              v-model="editForm.canonicalValue"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="Canonical value"
             />
             <select
               v-model="editForm.taxonomy"
@@ -374,14 +367,6 @@
                 {{ taxonomyLabel(taxonomy) }}
               </option>
             </select>
-            <input
-              v-model.number="editForm.randomWeight"
-              type="number"
-              min="0"
-              step="0.1"
-              class="input input-bordered input-sm rounded-xl"
-              aria-label="Random weight"
-            />
             <input
               v-model="editForm.aliases"
               type="text"
@@ -400,63 +385,56 @@
               class="input input-bordered input-sm rounded-xl"
               placeholder="Group label"
             />
+            <label class="form-control">
+              <span class="label-text text-[11px]">Sort order</span>
+              <input
+                v-model.number="editForm.sortOrder"
+                type="number"
+                step="1"
+                class="input input-bordered input-sm rounded-xl"
+              />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-[11px]">Source rank</span>
+              <input
+                v-model.number="editForm.sourceRank"
+                type="number"
+                min="0"
+                step="1"
+                class="input input-bordered input-sm rounded-xl"
+              />
+            </label>
+            <label class="form-control sm:col-span-2">
+              <span class="label-text text-[11px]">Random weight</span>
+              <input
+                v-model.number="editForm.randomWeight"
+                type="number"
+                min="0"
+                step="0.1"
+                class="input input-bordered input-sm rounded-xl"
+              />
+            </label>
             <textarea
               v-model="editForm.description"
               class="textarea textarea-bordered min-h-20 rounded-xl sm:col-span-2"
               placeholder="Description"
             />
+            <textarea
+              v-model="editForm.metadata"
+              class="textarea textarea-bordered min-h-24 rounded-xl font-mono text-xs sm:col-span-2"
+              placeholder="Structured metadata JSON object"
+            />
 
-            <div
-              class="flex h-36 items-center justify-center overflow-hidden rounded-xl bg-base-200 sm:col-span-2"
-            >
-              <img
-                v-if="editArtworkPreview"
-                :src="editArtworkPreview"
-                :alt="`${editForm.title || facet.title} artwork preview`"
-                class="size-full object-contain"
-                loading="lazy"
-              />
-              <Icon
-                v-else
-                name="kind-icon:image"
-                class="size-9 text-base-content/20"
+            <div class="sm:col-span-2">
+              <artwork-fields
+                :title="editForm.title || facet.title"
+                v-model:image-path="editForm.imagePath"
+                v-model:card-path="editForm.cardPath"
+                v-model:hero-path="editForm.heroPath"
+                v-model:art-prompt="editForm.artPrompt"
+                compact
               />
             </div>
-            <label class="form-control sm:col-span-2">
-              <span class="label-text text-xs">Primary image path</span>
-              <input
-                v-model="editForm.imagePath"
-                type="text"
-                class="input input-bordered input-sm rounded-xl"
-                placeholder="/images/facets/example.webp"
-              />
-            </label>
-            <label class="form-control">
-              <span class="label-text text-xs">Card / portrait path</span>
-              <input
-                v-model="editForm.cardPath"
-                type="text"
-                class="input input-bordered input-sm rounded-xl"
-                placeholder="/images/facets/cards/example.webp"
-              />
-            </label>
-            <label class="form-control">
-              <span class="label-text text-xs">Hero / wide path</span>
-              <input
-                v-model="editForm.heroPath"
-                type="text"
-                class="input input-bordered input-sm rounded-xl"
-                placeholder="/images/facets/heroes/example.webp"
-              />
-            </label>
-            <label class="form-control sm:col-span-2">
-              <span class="label-text text-xs">Art prompt</span>
-              <textarea
-                v-model="editForm.artPrompt"
-                class="textarea textarea-bordered min-h-20 rounded-xl"
-                placeholder="Prompt for generating or regenerating this Facet's artwork..."
-              />
-            </label>
 
             <div class="flex flex-wrap gap-4 text-xs sm:col-span-2">
               <label class="flex items-center gap-1">
@@ -492,6 +470,7 @@
                 Mature
               </label>
             </div>
+
             <div class="flex gap-2 sm:col-span-2">
               <button
                 type="button"
@@ -539,18 +518,154 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { computed, defineComponent, h, onMounted, reactive, ref, watch } from 'vue'
 import type { FacetKind } from '~/prisma/generated/prisma/client'
 import { useFacetStore, type FacetWithAliases } from '@/stores/facetStore'
 import {
   FACET_TAXONOMIES,
+  type FacetCatalogEntry,
   type FacetTaxonomy,
 } from '@/stores/facetCatalogStore'
+import { useFacetArtRequestStore } from '@/stores/facetArtRequestStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 
-const facetStore = useFacetStore()
-const facetTaxonomies = [...FACET_TAXONOMIES]
+const ArtworkFields = defineComponent({
+  name: 'ArtworkFields',
+  props: {
+    title: { type: String, required: true },
+    imagePath: { type: String, required: true },
+    cardPath: { type: String, required: true },
+    heroPath: { type: String, required: true },
+    artPrompt: { type: String, required: true },
+    compact: { type: Boolean, default: false },
+  },
+  emits: [
+    'update:imagePath',
+    'update:cardPath',
+    'update:heroPath',
+    'update:artPrompt',
+  ],
+  setup(props, { emit }) {
+    const preview = computed(
+      () => props.cardPath.trim() || props.imagePath.trim() || props.heroPath.trim(),
+    )
+    const input = (
+      label: string,
+      value: string,
+      event: string,
+      placeholder: string,
+    ) =>
+      h('label', { class: 'form-control' }, [
+        h('span', { class: 'label-text text-xs' }, label),
+        h('input', {
+          value,
+          type: 'text',
+          class: 'input input-bordered input-sm rounded-xl',
+          placeholder,
+          onInput: (inputEvent: Event) =>
+            emit(event, (inputEvent.target as HTMLInputElement).value),
+        }),
+      ])
 
+    return () =>
+      h(
+        'div',
+        {
+          class:
+            'rounded-2xl border border-base-300 bg-base-200/60 p-3',
+        },
+        [
+          h('div', { class: 'mb-3 flex items-center gap-2' }, [
+            h(resolveIcon(), {
+              name: 'kind-icon:palette',
+              class: 'size-4 text-accent',
+            }),
+            h('div', [
+              h('h3', { class: 'text-sm font-bold' }, 'Curated artwork'),
+              h(
+                'p',
+                { class: 'text-xs text-base-content/50' },
+                'Preserve primary, portrait/card, and hero/wide roles separately.',
+              ),
+            ]),
+          ]),
+          h(
+            'div',
+            {
+              class: props.compact
+                ? 'grid gap-3'
+                : 'grid gap-3 lg:grid-cols-[12rem_1fr]',
+            },
+            [
+              h(
+                'div',
+                {
+                  class:
+                    'flex h-36 items-center justify-center overflow-hidden rounded-xl bg-base-300/50',
+                },
+                preview.value
+                  ? [
+                      h('img', {
+                        src: preview.value,
+                        alt: `${props.title} artwork preview`,
+                        class: 'size-full object-contain',
+                        loading: 'lazy',
+                      }),
+                    ]
+                  : [
+                      h(resolveIcon(), {
+                        name: 'kind-icon:image',
+                        class: 'size-9 text-base-content/20',
+                      }),
+                    ],
+              ),
+              h('div', { class: 'grid gap-2 sm:grid-cols-2 xl:grid-cols-3' }, [
+                input(
+                  'Primary image path',
+                  props.imagePath,
+                  'update:imagePath',
+                  '/images/facets/example.webp',
+                ),
+                input(
+                  'Card / portrait path',
+                  props.cardPath,
+                  'update:cardPath',
+                  '/images/facets/cards/example.webp',
+                ),
+                input(
+                  'Hero / wide path',
+                  props.heroPath,
+                  'update:heroPath',
+                  '/images/facets/heroes/example.webp',
+                ),
+                h('label', { class: 'form-control sm:col-span-2 xl:col-span-3' }, [
+                  h('span', { class: 'label-text text-xs' }, 'Art prompt'),
+                  h('textarea', {
+                    value: props.artPrompt,
+                    class: 'textarea textarea-bordered min-h-20 rounded-xl',
+                    placeholder: 'Prompt for generating or regenerating this artwork...',
+                    onInput: (event: Event) =>
+                      emit(
+                        'update:artPrompt',
+                        (event.target as HTMLTextAreaElement).value,
+                      ),
+                  }),
+                ]),
+              ]),
+            ],
+          ),
+        ],
+      )
+  },
+})
+
+function resolveIcon() {
+  return resolveComponent('Icon')
+}
+
+const facetStore = useFacetStore()
+const artRequestStore = useFacetArtRequestStore()
+const facetTaxonomies = [...FACET_TAXONOMIES]
 const search = ref('')
 const taxonomyFilter = ref<FacetTaxonomy | null>(null)
 const showArchived = ref(false)
@@ -558,38 +673,32 @@ const errorMessage = ref('')
 const editingId = ref<number | null>(null)
 const createOpen = ref(false)
 
-const newTitle = ref('')
-const newTaxonomy = ref<FacetTaxonomy>('OTHER')
-const newAliases = ref('')
-const newDescription = ref('')
-const newGroupKey = ref('')
-const newGroupLabel = ref('')
-const newImagePath = ref('')
-const newCardPath = ref('')
-const newHeroPath = ref('')
-const newArtPrompt = ref('')
-const newRandomWeight = ref(1)
-const newIsRandomizable = ref(true)
-const newArtRequired = ref(true)
-const newIsPublic = ref(true)
+function blankForm() {
+  return {
+    title: '',
+    canonicalValue: '',
+    taxonomy: 'OTHER' as FacetTaxonomy,
+    aliases: '',
+    description: '',
+    groupKey: '',
+    groupLabel: '',
+    sortOrder: 0,
+    sourceRank: 100,
+    metadata: '',
+    imagePath: '',
+    cardPath: '',
+    heroPath: '',
+    artPrompt: '',
+    randomWeight: 1,
+    isRandomizable: true,
+    artRequired: true,
+    isPublic: true,
+    isMature: false,
+  }
+}
 
-const editForm = reactive({
-  title: '',
-  taxonomy: 'OTHER' as FacetTaxonomy,
-  aliases: '',
-  description: '',
-  groupKey: '',
-  groupLabel: '',
-  imagePath: '',
-  cardPath: '',
-  heroPath: '',
-  artPrompt: '',
-  randomWeight: 1,
-  isRandomizable: true,
-  artRequired: true,
-  isPublic: true,
-  isMature: false,
-})
+const createForm = reactive(blankForm())
+const editForm = reactive(blankForm())
 
 const broadKinds = new Set<FacetTaxonomy>([
   'GENRE',
@@ -609,30 +718,16 @@ function kindForTaxonomy(taxonomy: FacetTaxonomy): FacetKind {
   return broadKinds.has(taxonomy) ? (taxonomy as FacetKind) : 'OTHER'
 }
 
-watch(newTaxonomy, (taxonomy) => {
-  newArtRequired.value = taxonomy !== 'COLOR'
-})
-
-const newArtworkPreview = computed(
-  () =>
-    newCardPath.value.trim() ||
-    newImagePath.value.trim() ||
-    newHeroPath.value.trim() ||
-    null,
-)
-
-const editArtworkPreview = computed(
-  () =>
-    editForm.cardPath.trim() ||
-    editForm.imagePath.trim() ||
-    editForm.heroPath.trim() ||
-    null,
+watch(
+  () => createForm.taxonomy,
+  (taxonomy) => {
+    createForm.artRequired = taxonomy !== 'COLOR'
+  },
 )
 
 const visibleFacets = computed(() =>
   showArchived.value ? facetStore.facets : facetStore.activeFacets,
 )
-
 const taxonomyCounts = computed(() => {
   const counts: Partial<Record<FacetTaxonomy, number>> = {}
   for (const facet of visibleFacets.value) {
@@ -640,13 +735,10 @@ const taxonomyCounts = computed(() => {
   }
   return counts
 })
-
 const filteredFacets = computed(() => {
   const needle = normalizeFacetLookupKey(search.value)
   return visibleFacets.value.filter((facet) => {
-    if (taxonomyFilter.value && facet.taxonomy !== taxonomyFilter.value) {
-      return false
-    }
+    if (taxonomyFilter.value && facet.taxonomy !== taxonomyFilter.value) return false
     if (!needle) return true
     const values = [
       facet.title,
@@ -659,6 +751,7 @@ const filteredFacets = computed(() => {
       facet.cardPath,
       facet.heroPath,
       facet.artPrompt,
+      facet.metadata ? JSON.stringify(facet.metadata) : '',
       ...facet.aliases,
     ]
     return values.some((value) =>
@@ -694,60 +787,75 @@ function facetArtwork(facet: FacetWithAliases): string | null {
   return facet.cardPath || facet.imagePath || facet.heroPath || null
 }
 
+function parseMetadata(value: string): Record<string, unknown> | null {
+  if (!value.trim()) return null
+  const parsed = JSON.parse(value) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Structured metadata must be a JSON object.')
+  }
+  return parsed as Record<string, unknown>
+}
+
+function metadataText(value: Record<string, unknown> | null): string {
+  return value ? JSON.stringify(value, null, 2) : ''
+}
+
 function toggleEdit(facet: FacetWithAliases) {
   if (editingId.value === facet.id) {
     editingId.value = null
     return
   }
   editingId.value = facet.id
-  editForm.title = facet.title
-  editForm.taxonomy = facet.taxonomy
-  editForm.aliases = facet.aliases
-    .filter((alias) => alias !== facet.slug)
-    .join(', ')
-  editForm.description = facet.description || ''
-  editForm.groupKey = facet.groupKey || ''
-  editForm.groupLabel = facet.groupLabel || ''
-  editForm.imagePath = facet.imagePath || ''
-  editForm.cardPath = facet.cardPath || ''
-  editForm.heroPath = facet.heroPath || ''
-  editForm.artPrompt = facet.artPrompt || ''
-  editForm.randomWeight = facet.randomWeight
-  editForm.isRandomizable = facet.isRandomizable
-  editForm.artRequired = facet.artRequired
-  editForm.isPublic = facet.isPublic
-  editForm.isMature = facet.isMature
+  Object.assign(editForm, {
+    title: facet.title,
+    canonicalValue: facet.canonicalValue,
+    taxonomy: facet.taxonomy,
+    aliases: facet.aliases.filter((alias) => alias !== facet.slug).join(', '),
+    description: facet.description || '',
+    groupKey: facet.groupKey || '',
+    groupLabel: facet.groupLabel || '',
+    sortOrder: facet.sortOrder,
+    sourceRank: facet.sourceRank,
+    metadata: metadataText(facet.metadata),
+    imagePath: facet.imagePath || '',
+    cardPath: facet.cardPath || '',
+    heroPath: facet.heroPath || '',
+    artPrompt: facet.artPrompt || '',
+    randomWeight: facet.randomWeight,
+    isRandomizable: facet.isRandomizable,
+    artRequired: facet.artRequired,
+    isPublic: facet.isPublic,
+    isMature: facet.isMature,
+  })
 }
 
 async function createFacet() {
   errorMessage.value = ''
   try {
     await facetStore.createFacet({
-      title: newTitle.value.trim(),
-      kind: kindForTaxonomy(newTaxonomy.value),
-      taxonomy: newTaxonomy.value,
-      aliases: splitAliases(newAliases.value),
-      description: newDescription.value.trim() || null,
-      groupKey: newGroupKey.value.trim() || null,
-      groupLabel: newGroupLabel.value.trim() || null,
-      imagePath: newImagePath.value.trim() || null,
-      cardPath: newCardPath.value.trim() || null,
-      heroPath: newHeroPath.value.trim() || null,
-      artPrompt: newArtPrompt.value.trim() || null,
-      randomWeight: Math.max(0, Number(newRandomWeight.value) || 0),
-      isRandomizable: newIsRandomizable.value,
-      artRequired: newArtRequired.value,
-      isPublic: newIsPublic.value,
+      title: createForm.title.trim(),
+      kind: kindForTaxonomy(createForm.taxonomy),
+      taxonomy: createForm.taxonomy,
+      canonicalValue:
+        createForm.canonicalValue.trim() || createForm.title.trim() || null,
+      aliases: splitAliases(createForm.aliases),
+      description: createForm.description.trim() || null,
+      groupKey: createForm.groupKey.trim() || null,
+      groupLabel: createForm.groupLabel.trim() || null,
+      sortOrder: Math.trunc(Number(createForm.sortOrder) || 0),
+      sourceRank: Math.max(0, Math.trunc(Number(createForm.sourceRank) || 0)),
+      metadata: parseMetadata(createForm.metadata),
+      imagePath: createForm.imagePath.trim() || null,
+      cardPath: createForm.cardPath.trim() || null,
+      heroPath: createForm.heroPath.trim() || null,
+      artPrompt: createForm.artPrompt.trim() || null,
+      randomWeight: Math.max(0, Number(createForm.randomWeight) || 0),
+      isRandomizable: createForm.isRandomizable,
+      artRequired: createForm.artRequired,
+      isPublic: createForm.isPublic,
+      isMature: createForm.isMature,
     })
-    newTitle.value = ''
-    newAliases.value = ''
-    newDescription.value = ''
-    newGroupKey.value = ''
-    newGroupLabel.value = ''
-    newImagePath.value = ''
-    newCardPath.value = ''
-    newHeroPath.value = ''
-    newArtPrompt.value = ''
+    Object.assign(createForm, blankForm())
     createOpen.value = false
   } catch (error) {
     errorMessage.value =
@@ -762,10 +870,14 @@ async function saveEdit(id: number) {
       title: editForm.title.trim(),
       kind: kindForTaxonomy(editForm.taxonomy),
       taxonomy: editForm.taxonomy,
+      canonicalValue: editForm.canonicalValue.trim() || editForm.title.trim(),
       aliases: splitAliases(editForm.aliases),
       description: editForm.description.trim() || null,
       groupKey: editForm.groupKey.trim() || null,
       groupLabel: editForm.groupLabel.trim() || null,
+      sortOrder: Math.trunc(Number(editForm.sortOrder) || 0),
+      sourceRank: Math.max(0, Math.trunc(Number(editForm.sourceRank) || 0)),
+      metadata: parseMetadata(editForm.metadata),
       imagePath: editForm.imagePath.trim() || null,
       cardPath: editForm.cardPath.trim() || null,
       heroPath: editForm.heroPath.trim() || null,
@@ -780,6 +892,16 @@ async function saveEdit(id: number) {
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : 'Facet could not be saved.'
+  }
+}
+
+async function requestArt(facet: FacetWithAliases) {
+  errorMessage.value = ''
+  const path = await artRequestStore.requestPrimaryArtwork(
+    facet as FacetCatalogEntry,
+  )
+  if (!path && artRequestStore.errors[facet.id]) {
+    errorMessage.value = artRequestStore.errors[facet.id] || 'Artwork request failed.'
   }
 }
 

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -29,7 +29,7 @@
       >
         <option :value="null">All taxonomies</option>
         <option
-          v-for="taxonomy in facetTaxonomies"
+          v-for="taxonomy in FACET_TAXONOMIES"
           :key="taxonomy"
           :value="taxonomy"
         >
@@ -56,159 +56,8 @@
       >
         + Create a canonical Facet
       </summary>
-
       <div class="space-y-4 border-t border-base-300 p-4">
-        <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <label class="form-control xl:col-span-2">
-            <span class="label-text text-xs">Canonical title</span>
-            <input
-              v-model="createForm.title"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="CowCore"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Canonical value</span>
-            <input
-              v-model="createForm.canonicalValue"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="Defaults to title"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Taxonomy</span>
-            <select
-              v-model="createForm.taxonomy"
-              class="select select-bordered select-sm rounded-xl"
-            >
-              <option
-                v-for="taxonomy in facetTaxonomies"
-                :key="taxonomy"
-                :value="taxonomy"
-              >
-                {{ taxonomyLabel(taxonomy) }}
-              </option>
-            </select>
-          </label>
-          <label class="form-control sm:col-span-2 xl:col-span-4">
-            <span class="label-text text-xs">Aliases</span>
-            <input
-              v-model="createForm.aliases"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="Aliases separated by commas"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Group key</span>
-            <input
-              v-model="createForm.groupKey"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="cosmic-species"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Group label</span>
-            <input
-              v-model="createForm.groupLabel"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="Cosmic Species"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Sort order</span>
-            <input
-              v-model.number="createForm.sortOrder"
-              type="number"
-              step="1"
-              class="input input-bordered input-sm rounded-xl"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Source rank</span>
-            <input
-              v-model.number="createForm.sourceRank"
-              type="number"
-              min="0"
-              step="1"
-              class="input input-bordered input-sm rounded-xl"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs">Random weight</span>
-            <input
-              v-model.number="createForm.randomWeight"
-              type="number"
-              min="0"
-              step="0.1"
-              class="input input-bordered input-sm rounded-xl"
-            />
-          </label>
-          <label class="form-control sm:col-span-2 xl:col-span-3">
-            <span class="label-text text-xs">Description</span>
-            <textarea
-              v-model="createForm.description"
-              class="textarea textarea-bordered min-h-20 rounded-xl"
-              placeholder="What this reusable concept means..."
-            />
-          </label>
-          <label class="form-control sm:col-span-2 xl:col-span-4">
-            <span class="label-text text-xs">Structured metadata (JSON object)</span>
-            <textarea
-              v-model="createForm.metadata"
-              class="textarea textarea-bordered min-h-24 rounded-xl font-mono text-xs"
-              placeholder='{"scientificName":"...","source":"curated"}'
-            />
-          </label>
-        </div>
-
-        <artwork-fields
-          :title="createForm.title || 'New Facet'"
-          v-model:image-path="createForm.imagePath"
-          v-model:card-path="createForm.cardPath"
-          v-model:hero-path="createForm.heroPath"
-          v-model:art-prompt="createForm.artPrompt"
-        />
-
-        <div class="flex flex-wrap items-center gap-5 text-xs">
-          <label class="flex items-center gap-2">
-            <input
-              v-model="createForm.isRandomizable"
-              type="checkbox"
-              class="toggle toggle-secondary toggle-xs"
-            />
-            Available to randomizers
-          </label>
-          <label class="flex items-center gap-2">
-            <input
-              v-model="createForm.artRequired"
-              type="checkbox"
-              class="toggle toggle-accent toggle-xs"
-            />
-            Artwork expected
-          </label>
-          <label class="flex items-center gap-2">
-            <input
-              v-model="createForm.isPublic"
-              type="checkbox"
-              class="toggle toggle-primary toggle-xs"
-            />
-            Public
-          </label>
-          <label class="flex items-center gap-2">
-            <input
-              v-model="createForm.isMature"
-              type="checkbox"
-              class="toggle toggle-warning toggle-xs"
-            />
-            Mature
-          </label>
-        </div>
-
+        <FacetProfileEditor v-model="createForm" />
         <button
           type="button"
           class="btn btn-secondary btn-sm w-full rounded-xl"
@@ -231,7 +80,7 @@
         class="overflow-hidden rounded-2xl border bg-base-100 transition-all"
         :class="[
           facet.isActive ? 'border-base-300' : 'border-error/40 opacity-60',
-          editingId === facet.id ? 'ring-2 ring-secondary/60' : '',
+          editingId === facet.id ? 'md:col-span-2 xl:col-span-3 ring-2 ring-secondary/60' : '',
         ]"
       >
         <div
@@ -265,7 +114,8 @@
               </div>
               <h2 class="mt-1 truncate text-base font-bold">{{ facet.title }}</h2>
               <p class="truncate text-xs text-base-content/40">
-                {{ facet.canonicalValue }} · {{ facet.aliases.join(' · ') }}
+                {{ facet.canonicalValue }}
+                <template v-if="facet.aliases.length"> · {{ facet.aliases.join(' · ') }}</template>
               </p>
             </div>
             <button
@@ -304,9 +154,7 @@
               <span class="badge badge-ghost badge-xs">
                 {{ facet.artRequired ? 'art expected' : 'art optional' }}
               </span>
-              <span v-if="facet.metadata" class="badge badge-ghost badge-xs">
-                metadata
-              </span>
+              <span v-if="facet.metadata" class="badge badge-ghost badge-xs">metadata</span>
             </div>
 
             <div
@@ -339,139 +187,9 @@
             </div>
           </template>
 
-          <div
-            v-else
-            class="mt-3 grid gap-2 sm:grid-cols-2"
-          >
-            <input
-              v-model="editForm.title"
-              type="text"
-              class="input input-bordered input-sm rounded-xl sm:col-span-2"
-              placeholder="Title"
-            />
-            <input
-              v-model="editForm.canonicalValue"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="Canonical value"
-            />
-            <select
-              v-model="editForm.taxonomy"
-              class="select select-bordered select-sm rounded-xl"
-            >
-              <option
-                v-for="taxonomy in facetTaxonomies"
-                :key="taxonomy"
-                :value="taxonomy"
-              >
-                {{ taxonomyLabel(taxonomy) }}
-              </option>
-            </select>
-            <input
-              v-model="editForm.aliases"
-              type="text"
-              class="input input-bordered input-sm rounded-xl sm:col-span-2"
-              placeholder="Aliases, comma separated"
-            />
-            <input
-              v-model="editForm.groupKey"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="Group key"
-            />
-            <input
-              v-model="editForm.groupLabel"
-              type="text"
-              class="input input-bordered input-sm rounded-xl"
-              placeholder="Group label"
-            />
-            <label class="form-control">
-              <span class="label-text text-[11px]">Sort order</span>
-              <input
-                v-model.number="editForm.sortOrder"
-                type="number"
-                step="1"
-                class="input input-bordered input-sm rounded-xl"
-              />
-            </label>
-            <label class="form-control">
-              <span class="label-text text-[11px]">Source rank</span>
-              <input
-                v-model.number="editForm.sourceRank"
-                type="number"
-                min="0"
-                step="1"
-                class="input input-bordered input-sm rounded-xl"
-              />
-            </label>
-            <label class="form-control sm:col-span-2">
-              <span class="label-text text-[11px]">Random weight</span>
-              <input
-                v-model.number="editForm.randomWeight"
-                type="number"
-                min="0"
-                step="0.1"
-                class="input input-bordered input-sm rounded-xl"
-              />
-            </label>
-            <textarea
-              v-model="editForm.description"
-              class="textarea textarea-bordered min-h-20 rounded-xl sm:col-span-2"
-              placeholder="Description"
-            />
-            <textarea
-              v-model="editForm.metadata"
-              class="textarea textarea-bordered min-h-24 rounded-xl font-mono text-xs sm:col-span-2"
-              placeholder="Structured metadata JSON object"
-            />
-
-            <div class="sm:col-span-2">
-              <artwork-fields
-                :title="editForm.title || facet.title"
-                v-model:image-path="editForm.imagePath"
-                v-model:card-path="editForm.cardPath"
-                v-model:hero-path="editForm.heroPath"
-                v-model:art-prompt="editForm.artPrompt"
-                compact
-              />
-            </div>
-
-            <div class="flex flex-wrap gap-4 text-xs sm:col-span-2">
-              <label class="flex items-center gap-1">
-                <input
-                  v-model="editForm.isRandomizable"
-                  type="checkbox"
-                  class="toggle toggle-secondary toggle-xs"
-                />
-                Randomizable
-              </label>
-              <label class="flex items-center gap-1">
-                <input
-                  v-model="editForm.artRequired"
-                  type="checkbox"
-                  class="toggle toggle-accent toggle-xs"
-                />
-                Art expected
-              </label>
-              <label class="flex items-center gap-1">
-                <input
-                  v-model="editForm.isPublic"
-                  type="checkbox"
-                  class="toggle toggle-secondary toggle-xs"
-                />
-                Public
-              </label>
-              <label class="flex items-center gap-1">
-                <input
-                  v-model="editForm.isMature"
-                  type="checkbox"
-                  class="toggle toggle-warning toggle-xs"
-                />
-                Mature
-              </label>
-            </div>
-
-            <div class="flex gap-2 sm:col-span-2">
+          <div v-else class="mt-4 space-y-4">
+            <FacetProfileEditor v-model="editForm" />
+            <div class="flex gap-2">
               <button
                 type="button"
                 class="btn btn-secondary btn-sm flex-1 rounded-xl"
@@ -518,8 +236,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, onMounted, reactive, ref, watch } from 'vue'
-import type { FacetKind } from '~/prisma/generated/prisma/client'
+import { computed, onMounted, ref } from 'vue'
 import { useFacetStore, type FacetWithAliases } from '@/stores/facetStore'
 import {
   FACET_TAXONOMIES,
@@ -528,206 +245,28 @@ import {
 } from '@/stores/facetCatalogStore'
 import { useFacetArtRequestStore } from '@/stores/facetArtRequestStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
-
-const ArtworkFields = defineComponent({
-  name: 'ArtworkFields',
-  props: {
-    title: { type: String, required: true },
-    imagePath: { type: String, required: true },
-    cardPath: { type: String, required: true },
-    heroPath: { type: String, required: true },
-    artPrompt: { type: String, required: true },
-    compact: { type: Boolean, default: false },
-  },
-  emits: [
-    'update:imagePath',
-    'update:cardPath',
-    'update:heroPath',
-    'update:artPrompt',
-  ],
-  setup(props, { emit }) {
-    const preview = computed(
-      () => props.cardPath.trim() || props.imagePath.trim() || props.heroPath.trim(),
-    )
-    const input = (
-      label: string,
-      value: string,
-      event: string,
-      placeholder: string,
-    ) =>
-      h('label', { class: 'form-control' }, [
-        h('span', { class: 'label-text text-xs' }, label),
-        h('input', {
-          value,
-          type: 'text',
-          class: 'input input-bordered input-sm rounded-xl',
-          placeholder,
-          onInput: (inputEvent: Event) =>
-            emit(event, (inputEvent.target as HTMLInputElement).value),
-        }),
-      ])
-
-    return () =>
-      h(
-        'div',
-        {
-          class:
-            'rounded-2xl border border-base-300 bg-base-200/60 p-3',
-        },
-        [
-          h('div', { class: 'mb-3 flex items-center gap-2' }, [
-            h(resolveIcon(), {
-              name: 'kind-icon:palette',
-              class: 'size-4 text-accent',
-            }),
-            h('div', [
-              h('h3', { class: 'text-sm font-bold' }, 'Curated artwork'),
-              h(
-                'p',
-                { class: 'text-xs text-base-content/50' },
-                'Preserve primary, portrait/card, and hero/wide roles separately.',
-              ),
-            ]),
-          ]),
-          h(
-            'div',
-            {
-              class: props.compact
-                ? 'grid gap-3'
-                : 'grid gap-3 lg:grid-cols-[12rem_1fr]',
-            },
-            [
-              h(
-                'div',
-                {
-                  class:
-                    'flex h-36 items-center justify-center overflow-hidden rounded-xl bg-base-300/50',
-                },
-                preview.value
-                  ? [
-                      h('img', {
-                        src: preview.value,
-                        alt: `${props.title} artwork preview`,
-                        class: 'size-full object-contain',
-                        loading: 'lazy',
-                      }),
-                    ]
-                  : [
-                      h(resolveIcon(), {
-                        name: 'kind-icon:image',
-                        class: 'size-9 text-base-content/20',
-                      }),
-                    ],
-              ),
-              h('div', { class: 'grid gap-2 sm:grid-cols-2 xl:grid-cols-3' }, [
-                input(
-                  'Primary image path',
-                  props.imagePath,
-                  'update:imagePath',
-                  '/images/facets/example.webp',
-                ),
-                input(
-                  'Card / portrait path',
-                  props.cardPath,
-                  'update:cardPath',
-                  '/images/facets/cards/example.webp',
-                ),
-                input(
-                  'Hero / wide path',
-                  props.heroPath,
-                  'update:heroPath',
-                  '/images/facets/heroes/example.webp',
-                ),
-                h('label', { class: 'form-control sm:col-span-2 xl:col-span-3' }, [
-                  h('span', { class: 'label-text text-xs' }, 'Art prompt'),
-                  h('textarea', {
-                    value: props.artPrompt,
-                    class: 'textarea textarea-bordered min-h-20 rounded-xl',
-                    placeholder: 'Prompt for generating or regenerating this artwork...',
-                    onInput: (event: Event) =>
-                      emit(
-                        'update:artPrompt',
-                        (event.target as HTMLTextAreaElement).value,
-                      ),
-                  }),
-                ]),
-              ]),
-            ],
-          ),
-        ],
-      )
-  },
-})
-
-function resolveIcon() {
-  return resolveComponent('Icon')
-}
+import {
+  blankFacetProfileForm,
+  facetProfilePayload,
+  facetToProfileForm,
+  type FacetProfileForm,
+} from '@/utils/facetProfileForm'
 
 const facetStore = useFacetStore()
 const artRequestStore = useFacetArtRequestStore()
-const facetTaxonomies = [...FACET_TAXONOMIES]
 const search = ref('')
 const taxonomyFilter = ref<FacetTaxonomy | null>(null)
 const showArchived = ref(false)
 const errorMessage = ref('')
 const editingId = ref<number | null>(null)
 const createOpen = ref(false)
-
-function blankForm() {
-  return {
-    title: '',
-    canonicalValue: '',
-    taxonomy: 'OTHER' as FacetTaxonomy,
-    aliases: '',
-    description: '',
-    groupKey: '',
-    groupLabel: '',
-    sortOrder: 0,
-    sourceRank: 100,
-    metadata: '',
-    imagePath: '',
-    cardPath: '',
-    heroPath: '',
-    artPrompt: '',
-    randomWeight: 1,
-    isRandomizable: true,
-    artRequired: true,
-    isPublic: true,
-    isMature: false,
-  }
-}
-
-const createForm = reactive(blankForm())
-const editForm = reactive(blankForm())
-
-const broadKinds = new Set<FacetTaxonomy>([
-  'GENRE',
-  'ANIMAL',
-  'COLOR',
-  'THEME',
-  'CORE',
-  'MOOD',
-  'STYLE',
-  'SETTING',
-  'ART_DIRECTION',
-  'OTHER',
-])
-
-function kindForTaxonomy(taxonomy: FacetTaxonomy): FacetKind {
-  if (taxonomy === 'PROMPT_ENHANCEMENT') return 'ART_DIRECTION'
-  return broadKinds.has(taxonomy) ? (taxonomy as FacetKind) : 'OTHER'
-}
-
-watch(
-  () => createForm.taxonomy,
-  (taxonomy) => {
-    createForm.artRequired = taxonomy !== 'COLOR'
-  },
-)
+const createForm = ref<FacetProfileForm>(blankFacetProfileForm())
+const editForm = ref<FacetProfileForm>(blankFacetProfileForm())
 
 const visibleFacets = computed(() =>
   showArchived.value ? facetStore.facets : facetStore.activeFacets,
 )
+
 const taxonomyCounts = computed(() => {
   const counts: Partial<Record<FacetTaxonomy, number>> = {}
   for (const facet of visibleFacets.value) {
@@ -735,6 +274,7 @@ const taxonomyCounts = computed(() => {
   }
   return counts
 })
+
 const filteredFacets = computed(() => {
   const needle = normalizeFacetLookupKey(search.value)
   return visibleFacets.value.filter((facet) => {
@@ -764,8 +304,7 @@ onMounted(async () => {
   try {
     await facetStore.fetchFacets({ includeInactive: true, includeMature: true })
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Facets could not be loaded.'
+    setError(error, 'Facets could not be loaded.')
   }
 })
 
@@ -776,126 +315,46 @@ function taxonomyLabel(taxonomy: FacetTaxonomy): string {
     .replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
-function splitAliases(value: string): string[] {
-  return value
-    .split(',')
-    .map((alias) => alias.trim())
-    .filter(Boolean)
-}
-
 function facetArtwork(facet: FacetWithAliases): string | null {
   return facet.cardPath || facet.imagePath || facet.heroPath || null
 }
 
-function parseMetadata(value: string): Record<string, unknown> | null {
-  if (!value.trim()) return null
-  const parsed = JSON.parse(value) as unknown
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('Structured metadata must be a JSON object.')
-  }
-  return parsed as Record<string, unknown>
+function setError(error: unknown, fallback: string): void {
+  errorMessage.value = error instanceof Error ? error.message : fallback
 }
 
-function metadataText(value: Record<string, unknown> | null): string {
-  return value ? JSON.stringify(value, null, 2) : ''
-}
-
-function toggleEdit(facet: FacetWithAliases) {
+function toggleEdit(facet: FacetWithAliases): void {
   if (editingId.value === facet.id) {
     editingId.value = null
     return
   }
   editingId.value = facet.id
-  Object.assign(editForm, {
-    title: facet.title,
-    canonicalValue: facet.canonicalValue,
-    taxonomy: facet.taxonomy,
-    aliases: facet.aliases.filter((alias) => alias !== facet.slug).join(', '),
-    description: facet.description || '',
-    groupKey: facet.groupKey || '',
-    groupLabel: facet.groupLabel || '',
-    sortOrder: facet.sortOrder,
-    sourceRank: facet.sourceRank,
-    metadata: metadataText(facet.metadata),
-    imagePath: facet.imagePath || '',
-    cardPath: facet.cardPath || '',
-    heroPath: facet.heroPath || '',
-    artPrompt: facet.artPrompt || '',
-    randomWeight: facet.randomWeight,
-    isRandomizable: facet.isRandomizable,
-    artRequired: facet.artRequired,
-    isPublic: facet.isPublic,
-    isMature: facet.isMature,
-  })
+  editForm.value = facetToProfileForm(facet)
+  errorMessage.value = ''
 }
 
-async function createFacet() {
+async function createFacet(): Promise<void> {
   errorMessage.value = ''
   try {
-    await facetStore.createFacet({
-      title: createForm.title.trim(),
-      kind: kindForTaxonomy(createForm.taxonomy),
-      taxonomy: createForm.taxonomy,
-      canonicalValue:
-        createForm.canonicalValue.trim() || createForm.title.trim() || null,
-      aliases: splitAliases(createForm.aliases),
-      description: createForm.description.trim() || null,
-      groupKey: createForm.groupKey.trim() || null,
-      groupLabel: createForm.groupLabel.trim() || null,
-      sortOrder: Math.trunc(Number(createForm.sortOrder) || 0),
-      sourceRank: Math.max(0, Math.trunc(Number(createForm.sourceRank) || 0)),
-      metadata: parseMetadata(createForm.metadata),
-      imagePath: createForm.imagePath.trim() || null,
-      cardPath: createForm.cardPath.trim() || null,
-      heroPath: createForm.heroPath.trim() || null,
-      artPrompt: createForm.artPrompt.trim() || null,
-      randomWeight: Math.max(0, Number(createForm.randomWeight) || 0),
-      isRandomizable: createForm.isRandomizable,
-      artRequired: createForm.artRequired,
-      isPublic: createForm.isPublic,
-      isMature: createForm.isMature,
-    })
-    Object.assign(createForm, blankForm())
+    await facetStore.createFacet(facetProfilePayload(createForm.value))
+    createForm.value = blankFacetProfileForm()
     createOpen.value = false
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Facet could not be created.'
+    setError(error, 'Facet could not be created.')
   }
 }
 
-async function saveEdit(id: number) {
+async function saveEdit(id: number): Promise<void> {
   errorMessage.value = ''
   try {
-    await facetStore.updateFacet(id, {
-      title: editForm.title.trim(),
-      kind: kindForTaxonomy(editForm.taxonomy),
-      taxonomy: editForm.taxonomy,
-      canonicalValue: editForm.canonicalValue.trim() || editForm.title.trim(),
-      aliases: splitAliases(editForm.aliases),
-      description: editForm.description.trim() || null,
-      groupKey: editForm.groupKey.trim() || null,
-      groupLabel: editForm.groupLabel.trim() || null,
-      sortOrder: Math.trunc(Number(editForm.sortOrder) || 0),
-      sourceRank: Math.max(0, Math.trunc(Number(editForm.sourceRank) || 0)),
-      metadata: parseMetadata(editForm.metadata),
-      imagePath: editForm.imagePath.trim() || null,
-      cardPath: editForm.cardPath.trim() || null,
-      heroPath: editForm.heroPath.trim() || null,
-      artPrompt: editForm.artPrompt.trim() || null,
-      randomWeight: Math.max(0, Number(editForm.randomWeight) || 0),
-      isRandomizable: editForm.isRandomizable,
-      artRequired: editForm.artRequired,
-      isPublic: editForm.isPublic,
-      isMature: editForm.isMature,
-    })
+    await facetStore.updateFacet(id, facetProfilePayload(editForm.value))
     editingId.value = null
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Facet could not be saved.'
+    setError(error, 'Facet could not be saved.')
   }
 }
 
-async function requestArt(facet: FacetWithAliases) {
+async function requestArt(facet: FacetWithAliases): Promise<void> {
   errorMessage.value = ''
   const path = await artRequestStore.requestPrimaryArtwork(
     facet as FacetCatalogEntry,
@@ -905,25 +364,23 @@ async function requestArt(facet: FacetWithAliases) {
   }
 }
 
-async function archive(id: number) {
+async function archive(id: number): Promise<void> {
   errorMessage.value = ''
   try {
     await facetStore.archiveFacet(id)
     editingId.value = null
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Facet could not be archived.'
+    setError(error, 'Facet could not be archived.')
   }
 }
 
-async function restore(id: number) {
+async function restore(id: number): Promise<void> {
   errorMessage.value = ''
   try {
     await facetStore.updateFacet(id, { isActive: true })
     editingId.value = null
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Facet could not be restored.'
+    setError(error, 'Facet could not be restored.')
   }
 }
 </script>

--- a/components/facets/facet-profile-editor.vue
+++ b/components/facets/facet-profile-editor.vue
@@ -1,0 +1,227 @@
+<!-- /components/facets/facet-profile-editor.vue -->
+<template>
+  <div class="space-y-4">
+    <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <label class="form-control xl:col-span-2">
+        <span class="label-text text-xs">Canonical title</span>
+        <input
+          v-model="form.title"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="CowCore"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Canonical value</span>
+        <input
+          v-model="form.canonicalValue"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="Defaults to title"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Taxonomy</span>
+        <select
+          v-model="form.taxonomy"
+          class="select select-bordered select-sm rounded-xl"
+        >
+          <option
+            v-for="taxonomy in FACET_TAXONOMIES"
+            :key="taxonomy"
+            :value="taxonomy"
+          >
+            {{ taxonomyLabel(taxonomy) }}
+          </option>
+        </select>
+      </label>
+      <label class="form-control sm:col-span-2 xl:col-span-4">
+        <span class="label-text text-xs">Aliases</span>
+        <input
+          v-model="form.aliases"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="Aliases separated by commas"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Group key</span>
+        <input
+          v-model="form.groupKey"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="cosmic-species"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Group label</span>
+        <input
+          v-model="form.groupLabel"
+          type="text"
+          class="input input-bordered input-sm rounded-xl"
+          placeholder="Cosmic Species"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Sort order</span>
+        <input
+          v-model.number="form.sortOrder"
+          type="number"
+          step="1"
+          class="input input-bordered input-sm rounded-xl"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Source rank</span>
+        <input
+          v-model.number="form.sourceRank"
+          type="number"
+          min="0"
+          step="1"
+          class="input input-bordered input-sm rounded-xl"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text text-xs">Random weight</span>
+        <input
+          v-model.number="form.randomWeight"
+          type="number"
+          min="0"
+          step="0.1"
+          class="input input-bordered input-sm rounded-xl"
+        />
+      </label>
+      <label class="form-control sm:col-span-2 xl:col-span-3">
+        <span class="label-text text-xs">Description</span>
+        <textarea
+          v-model="form.description"
+          class="textarea textarea-bordered min-h-24 rounded-xl"
+          placeholder="What this reusable concept means..."
+        />
+      </label>
+      <label class="form-control sm:col-span-2 xl:col-span-4">
+        <span class="label-text text-xs">Structured metadata (JSON object)</span>
+        <textarea
+          v-model="form.metadata"
+          class="textarea textarea-bordered min-h-28 rounded-xl font-mono text-xs"
+          placeholder='{"scientificName":"...","source":"curated"}'
+        />
+      </label>
+    </div>
+
+    <section class="rounded-2xl border border-base-300 bg-base-200/60 p-3">
+      <div class="mb-3 flex items-center gap-2">
+        <Icon name="kind-icon:palette" class="size-4 text-accent" />
+        <div>
+          <h3 class="text-sm font-bold">Curated artwork</h3>
+          <p class="text-xs text-base-content/50">
+            Preserve primary, portrait/card, and hero/wide roles separately.
+          </p>
+        </div>
+      </div>
+      <div class="grid gap-3 lg:grid-cols-[12rem_1fr]">
+        <div
+          class="flex h-36 items-center justify-center overflow-hidden rounded-xl bg-base-300/50"
+        >
+          <img
+            v-if="previewPath"
+            :src="previewPath"
+            :alt="`${form.title || 'Facet'} artwork preview`"
+            class="size-full object-contain"
+          />
+          <Icon v-else name="kind-icon:image" class="size-9 text-base-content/20" />
+        </div>
+        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+          <label class="form-control">
+            <span class="label-text text-xs">Primary image path</span>
+            <input
+              v-model="form.imagePath"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="/images/facets/example.webp"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Card / portrait path</span>
+            <input
+              v-model="form.cardPath"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="/images/facets/cards/example.webp"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text text-xs">Hero / wide path</span>
+            <input
+              v-model="form.heroPath"
+              type="text"
+              class="input input-bordered input-sm rounded-xl"
+              placeholder="/images/facets/heroes/example.webp"
+            />
+          </label>
+          <label class="form-control sm:col-span-2 xl:col-span-3">
+            <span class="label-text text-xs">Art prompt</span>
+            <textarea
+              v-model="form.artPrompt"
+              class="textarea textarea-bordered min-h-24 rounded-xl"
+              placeholder="Prompt for generating or regenerating this artwork..."
+            />
+          </label>
+        </div>
+      </div>
+    </section>
+
+    <div class="flex flex-wrap items-center gap-5 text-xs">
+      <label class="flex items-center gap-2">
+        <input
+          v-model="form.isRandomizable"
+          type="checkbox"
+          class="toggle toggle-secondary toggle-xs"
+        />
+        Available to randomizers
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          v-model="form.artRequired"
+          type="checkbox"
+          class="toggle toggle-accent toggle-xs"
+        />
+        Artwork expected
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          v-model="form.isPublic"
+          type="checkbox"
+          class="toggle toggle-primary toggle-xs"
+        />
+        Public
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          v-model="form.isMature"
+          type="checkbox"
+          class="toggle toggle-warning toggle-xs"
+        />
+        Mature
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { FACET_TAXONOMIES, type FacetTaxonomy } from '@/stores/facetCatalogStore'
+import type { FacetProfileForm } from '@/utils/facetProfileForm'
+
+const form = defineModel<FacetProfileForm>({ required: true })
+const previewPath = computed(
+  () => form.value.cardPath.trim() || form.value.imagePath.trim() || form.value.heroPath.trim(),
+)
+
+function taxonomyLabel(taxonomy: FacetTaxonomy): string {
+  return taxonomy
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+</script>

--- a/utils/facetProfileForm.ts
+++ b/utils/facetProfileForm.ts
@@ -1,0 +1,149 @@
+// /utils/facetProfileForm.ts
+import type { FacetKind } from '~/prisma/generated/prisma/client'
+import type {
+  FacetCreateInput,
+  FacetWithAliases,
+} from '@/stores/facetStore'
+import type { FacetTaxonomy } from '@/stores/facetCatalogStore'
+
+export type FacetProfileForm = {
+  title: string
+  canonicalValue: string
+  taxonomy: FacetTaxonomy
+  aliases: string
+  description: string
+  groupKey: string
+  groupLabel: string
+  sortOrder: number
+  sourceRank: number
+  metadata: string
+  imagePath: string
+  cardPath: string
+  heroPath: string
+  artPrompt: string
+  randomWeight: number
+  isRandomizable: boolean
+  artRequired: boolean
+  isPublic: boolean
+  isMature: boolean
+}
+
+const BROAD_KINDS = new Set<FacetTaxonomy>([
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'OTHER',
+])
+
+export function blankFacetProfileForm(): FacetProfileForm {
+  return {
+    title: '',
+    canonicalValue: '',
+    taxonomy: 'OTHER',
+    aliases: '',
+    description: '',
+    groupKey: '',
+    groupLabel: '',
+    sortOrder: 0,
+    sourceRank: 100,
+    metadata: '',
+    imagePath: '',
+    cardPath: '',
+    heroPath: '',
+    artPrompt: '',
+    randomWeight: 1,
+    isRandomizable: true,
+    artRequired: true,
+    isPublic: true,
+    isMature: false,
+  }
+}
+
+export function facetToProfileForm(facet: FacetWithAliases): FacetProfileForm {
+  return {
+    title: facet.title,
+    canonicalValue: facet.canonicalValue,
+    taxonomy: facet.taxonomy,
+    aliases: facet.aliases.filter((alias) => alias !== facet.slug).join(', '),
+    description: facet.description || '',
+    groupKey: facet.groupKey || '',
+    groupLabel: facet.groupLabel || '',
+    sortOrder: facet.sortOrder,
+    sourceRank: facet.sourceRank,
+    metadata: facet.metadata ? JSON.stringify(facet.metadata, null, 2) : '',
+    imagePath: facet.imagePath || '',
+    cardPath: facet.cardPath || '',
+    heroPath: facet.heroPath || '',
+    artPrompt: facet.artPrompt || '',
+    randomWeight: facet.randomWeight,
+    isRandomizable: facet.isRandomizable,
+    artRequired: facet.artRequired,
+    isPublic: facet.isPublic,
+    isMature: facet.isMature,
+  }
+}
+
+function kindForTaxonomy(taxonomy: FacetTaxonomy): FacetKind {
+  if (taxonomy === 'PROMPT_ENHANCEMENT') return 'ART_DIRECTION'
+  return BROAD_KINDS.has(taxonomy) ? (taxonomy as FacetKind) : 'OTHER'
+}
+
+function optional(value: string): string | null {
+  return value.trim() || null
+}
+
+function parseAliases(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .split(',')
+        .map((alias) => alias.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+export function parseFacetMetadata(
+  value: string,
+): Record<string, unknown> | null {
+  if (!value.trim()) return null
+  const parsed = JSON.parse(value) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Structured metadata must be a JSON object.')
+  }
+  return parsed as Record<string, unknown>
+}
+
+export function facetProfilePayload(form: FacetProfileForm): FacetCreateInput {
+  const title = form.title.trim()
+  if (!title) throw new Error('A canonical title is required.')
+
+  return {
+    title,
+    kind: kindForTaxonomy(form.taxonomy),
+    taxonomy: form.taxonomy,
+    canonicalValue: form.canonicalValue.trim() || title,
+    aliases: parseAliases(form.aliases),
+    description: optional(form.description),
+    groupKey: optional(form.groupKey),
+    groupLabel: optional(form.groupLabel),
+    sortOrder: Math.trunc(Number(form.sortOrder) || 0),
+    sourceRank: Math.max(0, Math.trunc(Number(form.sourceRank) || 0)),
+    metadata: parseFacetMetadata(form.metadata),
+    imagePath: optional(form.imagePath),
+    cardPath: optional(form.cardPath),
+    heroPath: optional(form.heroPath),
+    artPrompt: optional(form.artPrompt),
+    randomWeight: Math.max(0, Number(form.randomWeight) || 0),
+    isRandomizable: form.isRandomizable,
+    artRequired: form.artRequired,
+    isPublic: form.isPublic,
+    isMature: form.isMature,
+  }
+}

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -37,13 +37,14 @@ async function main(): Promise<void> {
     migration:
       'prisma/migrations/20260725113000_facet_catalog_cutover/migration.sql',
     catalog: 'server/utils/facetCatalog.ts',
-    catalogRoute: 'server/api/facets/catalog.get.ts',
     facetAssignments: 'server/utils/facetAssignments.ts',
     facetCreate: 'server/api/facets/index.post.ts',
     facetPatch: 'server/api/facets/[id].patch.ts',
     profileInput: 'server/utils/facetProfileInput.ts',
     facetStore: 'stores/facetStore.ts',
     facetManager: 'components/facets/facet-manager.vue',
+    facetProfileEditor: 'components/facets/facet-profile-editor.vue',
+    facetProfileForm: 'utils/facetProfileForm.ts',
     characterCreate: 'server/api/characters/index.post.ts',
     characterPatch: 'server/api/characters/[id].patch.ts',
     characterFacetSync: 'server/utils/characterFacetSync.ts',
@@ -70,7 +71,6 @@ async function main(): Promise<void> {
   requireText(files.schema, text.schema, 'model FacetProfile')
   requireText(files.schema, text.schema, 'model CharacterFacet')
   requireText(files.schema, text.schema, '@@unique([characterId, facetId, fieldKey])')
-
   requireText(files.migration, text.migration, 'FacetProfile_facetId_fkey')
   requireText(files.migration, text.migration, 'CharacterFacet_characterId_fkey')
   requireText(files.migration, text.migration, 'CharacterFacet_facetId_fkey')
@@ -109,10 +109,8 @@ async function main(): Promise<void> {
   )
   requireText(files.facetCreate, text.facetCreate, 'buildFacetProfileCreateData')
   requireText(files.facetCreate, text.facetCreate, 'tx.facetProfile.create')
-  requireText(files.facetCreate, text.facetCreate, 'facetId: facet.id')
   requireText(files.facetPatch, text.facetPatch, 'buildFacetProfileUpdateData')
   requireText(files.facetPatch, text.facetPatch, 'tx.facetProfile.upsert')
-  requireText(files.facetPatch, text.facetPatch, 'where: { facetId: id }')
 
   requireText(files.facetAssignments, text.facetAssignments, 'prisma.facetProfile.findMany')
   requireText(files.facetAssignments, text.facetAssignments, 'randomWeight: profile?.randomWeight')
@@ -121,10 +119,19 @@ async function main(): Promise<void> {
   requireText(files.facetStore, text.facetStore, 'while (true)')
   requireText(files.facetStore, text.facetStore, 'skip += page.length')
   requireText(files.facetStore, text.facetStore, 'taxonomy: FacetTaxonomy')
+
   requireText(files.facetManager, text.facetManager, 'Create canonical Facet')
-  requireText(files.facetManager, text.facetManager, 'newRandomWeight')
-  requireText(files.facetManager, text.facetManager, 'editForm.isRandomizable')
-  requireText(files.facetManager, text.facetManager, 'kindForTaxonomy')
+  requireText(files.facetManager, text.facetManager, 'FacetProfileEditor')
+  requireText(files.facetManager, text.facetManager, 'facetProfilePayload')
+  requireText(files.facetManager, text.facetManager, 'requestPrimaryArtwork')
+  requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.randomWeight')
+  requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.isRandomizable')
+  requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.artRequired')
+  requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.sourceRank')
+  requireText(files.facetProfileForm, text.facetProfileForm, 'kindForTaxonomy')
+  requireText(files.facetProfileForm, text.facetProfileForm, 'parseFacetMetadata')
+  requireText(files.facetProfileForm, text.facetProfileForm, 'canonicalValue')
+  requireText(files.facetProfileForm, text.facetProfileForm, 'sortOrder')
 
   requireText(
     files.characterFacetSync,
@@ -139,7 +146,6 @@ async function main(): Promise<void> {
   requireText(files.characterCreate, text.characterCreate, 'syncCharacterFacetsInTransaction')
   requireText(files.characterPatch, text.characterPatch, 'prisma.$transaction')
   requireText(files.characterPatch, text.characterPatch, 'syncCharacterFacetsInTransaction')
-
   requireText(files.characterGet, text.characterGet, 'getOptionalApiUser')
   requireText(files.characterPut, text.characterPut, 'requireApiUser')
   requireText(files.characterPut, text.characterPut, 'resolveFacetSelection')
@@ -151,17 +157,12 @@ async function main(): Promise<void> {
   requireText(files.seedWrapper, text.seedWrapper, 'choice.listOptions')
   requireText(files.seedWrapper, text.seedWrapper, 'step.listOptions = Array.from(completeList)')
   requireText(files.seedWrapper, text.seedWrapper, 'promotedBuilderOptions')
-
   requireText(files.seed, text.seed, 'ADVENTURE_CARDS')
   requireText(files.seed, text.seed, 'animalDataList')
   requireText(files.seed, text.seed, 'artListPresets')
   requireText(files.seed, text.seed, "title = isWaterBear ? 'Tardigrade'")
   requireText(files.seed, text.seed, "taxonomy !== 'COLOR'")
-  requireText(
-    files.seed,
-    text.seed,
-    'negative prompts remain generation configuration',
-  )
+  requireText(files.seed, text.seed, 'negative prompts remain generation configuration')
   requireText(files.seed, text.seed, 'backfillCharacterLinks')
   requireText(files.seed, text.seed, 'createDatabaseAdapter')
   forbidText(files.seed, text.seed, 'new PrismaMariaDb(')
@@ -174,15 +175,11 @@ async function main(): Promise<void> {
   requireText(files.catalogStore, text.catalogStore, 'entriesById.set(entry.id, entry)')
   forbidText(files.catalogStore, text.catalogStore, 'syncCharacterFacets')
   forbidText(files.catalogStore, text.catalogStore, 'characterAssignments')
-  forbidText(files.catalogStore, text.catalogStore, 'splitCharacterField')
 
   requireText(files.generatorStore, text.generatorStore, 'useFacetCatalogStore')
-  requireText(files.generatorStore, text.generatorStore, 'const facetCatalog = useFacetCatalogStore()')
   requireText(files.generatorStore, text.generatorStore, 'facetCatalog.randomFacetForField(fieldKey)')
   requireText(files.generatorStore, text.generatorStore, '.facetsForCharacterField(fieldKey)')
   requireText(files.generatorStore, text.generatorStore, 'entry.isRandomizable && entry.randomWeight > 0')
-  requireText(files.generatorStore, text.generatorStore, "return facetValue('species'")
-  requireText(files.generatorStore, text.generatorStore, "return facetValue('backstory', legacyBackstory)")
   forbidText(files.generatorStore, text.generatorStore, '__facetCatalogPatched')
 
   requireText(files.builderPlugin, text.builderPlugin, 'hydrateAdventureBuilder')
@@ -191,7 +188,6 @@ async function main(): Promise<void> {
   forbidText(files.builderPlugin, text.builderPlugin, '__facetCatalogPatched')
   forbidText(files.builderPlugin, text.builderPlugin, 'useGeneratorStore')
   forbidText(files.builderPlugin, text.builderPlugin, 'patchCharacterSave')
-  forbidText(files.builderPlugin, text.builderPlugin, 'useCharacterStore')
 
   requireText(files.randomStore, text.randomStore, 'useFacetCatalogStore')
   requireText(files.randomStore, text.randomStore, 'weightedSample')
@@ -225,11 +221,11 @@ async function main(): Promise<void> {
   )
   await requireMissingPath(
     'stores/utils/randomSpecies.ts',
-    'species selection is canonical Facet data rather than a nondeterministic module-level generator.',
+    'species selection is canonical Facet data.',
   )
   await requireMissingPath(
     'stores/utils/randomAnimal.ts',
-    'animals are canonical Facets enriched from animalData rather than a duplicate string pool.',
+    'animals are canonical Facets enriched from animalData.',
   )
   await requireMissingPath(
     'stores/utils/randomSkills.ts',

--- a/utils/scripts/verifyFacetLibraryAdvanced.ts
+++ b/utils/scripts/verifyFacetLibraryAdvanced.ts
@@ -13,9 +13,11 @@ async function main(): Promise<void> {
     editor: 'components/facets/facet-profile-editor.vue',
     form: 'utils/facetProfileForm.ts',
   } as const
-  const [manager, editor, form] = await Promise.all(
-    Object.values(files).map((path) => readFile(path, 'utf8')),
-  )
+  const [manager, editor, form] = await Promise.all([
+    readFile(files.manager, 'utf8'),
+    readFile(files.editor, 'utf8'),
+    readFile(files.form, 'utf8'),
+  ])
 
   for (const field of [
     'canonicalValue',

--- a/utils/scripts/verifyFacetLibraryAdvanced.ts
+++ b/utils/scripts/verifyFacetLibraryAdvanced.ts
@@ -1,0 +1,43 @@
+// /utils/scripts/verifyFacetLibraryAdvanced.ts
+import { readFile } from 'node:fs/promises'
+
+function requireText(path: string, text: string, value: string): void {
+  if (!text.includes(value)) {
+    throw new Error(`${path} is missing Facet Library contract text: ${value}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const path = 'components/facets/facet-manager.vue'
+  const manager = await readFile(path, 'utf8')
+
+  for (const field of [
+    'canonicalValue',
+    'sortOrder',
+    'sourceRank',
+    'metadata',
+    'randomWeight',
+    'isRandomizable',
+    'artRequired',
+    'imagePath',
+    'cardPath',
+    'heroPath',
+    'artPrompt',
+  ]) {
+    requireText(path, manager, field)
+  }
+
+  requireText(path, manager, 'parseMetadata')
+  requireText(path, manager, 'JSON object')
+  requireText(path, manager, 'requestPrimaryArtwork')
+  requireText(path, manager, 'Request primary artwork')
+  requireText(path, manager, 'facetStore.fetchFacets({ includeInactive: true, includeMature: true })')
+  requireText(path, manager, 'Save canonical profile')
+
+  process.stdout.write('Advanced Facet Library contract verified.\n')
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyFacetLibraryAdvanced.ts
+++ b/utils/scripts/verifyFacetLibraryAdvanced.ts
@@ -8,8 +8,14 @@ function requireText(path: string, text: string, value: string): void {
 }
 
 async function main(): Promise<void> {
-  const path = 'components/facets/facet-manager.vue'
-  const manager = await readFile(path, 'utf8')
+  const files = {
+    manager: 'components/facets/facet-manager.vue',
+    editor: 'components/facets/facet-profile-editor.vue',
+    form: 'utils/facetProfileForm.ts',
+  } as const
+  const [manager, editor, form] = await Promise.all(
+    Object.values(files).map((path) => readFile(path, 'utf8')),
+  )
 
   for (const field of [
     'canonicalValue',
@@ -24,15 +30,25 @@ async function main(): Promise<void> {
     'heroPath',
     'artPrompt',
   ]) {
-    requireText(path, manager, field)
+    if (!manager.includes(field) && !editor.includes(field) && !form.includes(field)) {
+      throw new Error(`Complete Facet profile is missing field: ${field}`)
+    }
   }
 
-  requireText(path, manager, 'parseMetadata')
-  requireText(path, manager, 'JSON object')
-  requireText(path, manager, 'requestPrimaryArtwork')
-  requireText(path, manager, 'Request primary artwork')
-  requireText(path, manager, 'facetStore.fetchFacets({ includeInactive: true, includeMature: true })')
-  requireText(path, manager, 'Save canonical profile')
+  requireText(files.manager, manager, 'requestPrimaryArtwork')
+  requireText(files.manager, manager, 'Request primary artwork')
+  requireText(
+    files.manager,
+    manager,
+    'facetStore.fetchFacets({ includeInactive: true, includeMature: true })',
+  )
+  requireText(files.manager, manager, 'Save canonical profile')
+  requireText(files.manager, manager, 'FacetProfileEditor')
+  requireText(files.editor, editor, 'Structured metadata (JSON object)')
+  requireText(files.editor, editor, 'defineModel<FacetProfileForm>')
+  requireText(files.form, form, 'parseFacetMetadata')
+  requireText(files.form, form, 'Structured metadata must be a JSON object.')
+  requireText(files.form, form, 'facetProfilePayload')
 
   process.stdout.write('Advanced Facet Library contract verified.\n')
 }


### PR DESCRIPTION
## Final Facet Library pass

- exposes canonical value, explicit sort order, source rank, and structured metadata in create/edit forms
- keeps taxonomy, grouping, random weight, randomizability, artwork policy, aliases, visibility, archived state, and primary/card/hero artwork controls
- makes advanced profile fields searchable and visible on catalog cards
- adds a direct Conductor artwork-request action for pathless Facets marked art-required
- preserves full paginated catalog loading and archive/restore behavior
- retains the Dream random-compatibility contract and adds an advanced Facet Library contract

## Result
The Facet Library is the complete curator surface for canonical profiles and missing-art requests, rather than a partial editor that hides provenance/order metadata.