### PR TITLE
fix(model-builder): link committed narrator Bot back to its Dream

### DIFF
--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -480,6 +480,13 @@ async function linkSourceToTarget(
     })
     return true
   }
+  if (sourceType === 'Dream' && targetType === 'Bot') {
+    await tx.dream.update({
+      where: { id: sourceId },
+      data: { narratorId: targetId },
+    })
+    return true
+  }
   if (sourceType === 'Character' && targetType === 'Reward') {
     await tx.character.update({
       where: { id: sourceId },


### PR DESCRIPTION
### What changed
`linkSourceToTarget` in `server/api/model-builder/items/[id]/commit.post.ts` had a `Project`→`Bot` case (sets `managerBotId`) but no `Dream`→`Bot` case, even though the `expand-narrator-bot` recipe output (`CREATE_TARGETS['expand-narrator-bot'] = 'Bot'`) targets `Dream` sources, and `Dream.narratorId` exists specifically for this (`prisma/schema.prisma` line 345, relation `DreamNarrator`).

### Bug
Committing a Model Builder item whose recipe output is "Narrator bot" for a Dream source created the `Bot` row (via `createRecord`) but `linkSourceToTarget` fell through every branch and returned `false` — the Dream's `narratorId` was never set, and the item's commit response still reported `target: { ..., linked: false }` behind a plain success toast in the store. Net effect: an orphaned, unlinked `Bot` row, with the user believing the Dream now has a narrator.

### Fix
Added the missing `Dream`→`Bot` branch, mirroring the existing `Project`→`Bot` pattern:
```ts
if (sourceType === 'Dream' && targetType === 'Bot') {
  await tx.dream.update({
    where: { id: sourceId },
    data: { narratorId: targetId },
  })
  return true
}
```

### How I verified
- `npx eslint` on the changed file — clean.
- `npx prettier --check` — reports drift, confirmed pre-existing via `git stash` (identical warning with and without this diff), consistent with prior model-builder/t-029 cycles' documented prettier-version-mismatch note.
- Full-project `npm run test` (`vue-tsc --noEmit`) — clean, 0 errors.
- Traced the schema/catalog chain by hand: `stores/helpers/modelBuilderRecipes.ts` (`expand-narrator-bot` description "Optional narrator bot for a dream"), `stores/helpers/modelBuilderFields.ts` (`CREATE_TARGETS['expand-narrator-bot'] = 'Bot'`), `prisma/schema.prisma` (`Dream.narratorId` / `Narrator Bot? @relation("DreamNarrator", ...)`).

### Stakes
reversible — additive logic in an existing transaction branch, no schema change, no destructive write.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Lpc8S4KHcAW4VeqKgCbE)_