### PR TITLE
media-watchlist/t-006: add CSV export, fix stale deliverables list

### DIFF
--- a/components/conductor/watchlist-page.vue
+++ b/components/conductor/watchlist-page.vue
@@ -42,9 +42,11 @@ const config: ProjectFrontConfig = {
     done: [
       'Real viewing log parsed and validated (2,440 entries, 12 years)',
       'Import + normalization rules for 12 media types',
-      'MediaEntry data model, browse + stats API, and a minimal browse UI',
+      'MediaEntry data model, browse + stats API, and a full browse UI',
+      'Entry detail view with private review editor and rating control',
+      'CSV export of the current filtered view',
     ],
-    next: ['Entry detail view + private review editor', 'CSV export'],
+    next: [],
   },
 }
 </script>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -6,8 +6,8 @@
   projects/media-watchlist/BROWSE-UX.md. Admin-only (this is Silas's private
   log) -- renders a locked notice for any non-admin viewer instead of erroring.
   Selecting an entry opens watchlist-entry-detail.vue (BROWSE-UX.md §3/§5).
-  The Stats view's CSV export (§4) is a separate, smaller follow-on -- still
-  out of scope here.
+  Export downloads GET /api/media-entries/export (media-watchlist/t-006),
+  honoring the current search/type/starred/sort filters.
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -120,6 +120,15 @@
           <option value="title_desc">Title Z–A</option>
           <option value="starred_first">Starred first</option>
         </select>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm ml-auto gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          @click="exportCsv"
+        >
+          <Icon name="kind-icon:download" class="size-3.5" />
+          Export CSV
+        </button>
       </div>
 
       <!-- Results -->
@@ -377,6 +386,23 @@ watch([activeTypes, starredOnly, sort], () => {
 function showMore() {
   skip.value += take
   void loadEntries()
+}
+
+function exportCsv() {
+  const params = new URLSearchParams()
+  if (search.value) params.set('search', search.value)
+  if (activeTypes.value.size) {
+    params.set('mediaType', Array.from(activeTypes.value).join(','))
+  }
+  if (starredOnly.value) params.set('starred', 'true')
+  params.set('sort', sort.value)
+
+  const link = document.createElement('a')
+  link.href = `/api/media-entries/export?${params.toString()}`
+  link.rel = 'noopener'
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
 }
 
 onMounted(() => {

--- a/server/api/media-entries/export.get.ts
+++ b/server/api/media-entries/export.get.ts
@@ -1,0 +1,151 @@
+// GET /api/media-entries/export
+//
+// CSV export for the Media Watchlist Stats view (media-watchlist/t-006,
+// BROWSE-UX.md §4: "Export button (CSV): downloads a filtered view as CSV.
+// Private data; no public sharing at MVP."). Honors the same filters the
+// browse UI exposes (search, mediaType, starred, sort) so "export what I'm
+// currently looking at" matches what's on screen -- mirrors the filter
+// parsing in index.get.ts but skips pagination (an export is the whole
+// filtered set, not one page of it). Admin-gated, same as every other
+// media-entries route.
+import { defineEventHandler, getQuery, setHeader } from 'h3'
+import type { MediaEntry, Prisma } from '~/prisma/generated/prisma/client'
+import { MediaType } from '~/prisma/generated/prisma/client'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireAdminApiUser } from '~/server/utils/authGuard'
+
+const MEDIA_TYPES = Object.values(MediaType) as string[]
+const SORT_MODES = [
+  'date_desc',
+  'date_asc',
+  'title_asc',
+  'title_desc',
+  'starred_first',
+] as const
+type SortMode = (typeof SORT_MODES)[number]
+
+// Hard cap so a filterless export on a much larger future log can't build an
+// unbounded CSV in memory; the current log is ~2,440 entries total.
+const MAX_ROWS = 20_000
+
+function toOrderBy(
+  sort: SortMode,
+): Prisma.MediaEntryOrderByWithRelationInput[] {
+  switch (sort) {
+    case 'date_asc':
+      return [{ watchedMonth: 'asc' }, { watchedDay: 'asc' }]
+    case 'title_asc':
+      return [{ title: 'asc' }]
+    case 'title_desc':
+      return [{ title: 'desc' }]
+    case 'starred_first':
+      return [
+        { starred: 'desc' },
+        { watchedMonth: 'desc' },
+        { watchedDay: 'desc' },
+      ]
+    case 'date_desc':
+    default:
+      return [{ watchedMonth: 'desc' }, { watchedDay: 'desc' }]
+  }
+}
+
+const CSV_COLUMNS = [
+  'title',
+  'mediaType',
+  'year',
+  'watchedMonth',
+  'watchedDay',
+  'starred',
+  'rating',
+  'rewatch',
+  'author',
+  'season',
+  'pageCount',
+  'durationHours',
+  'issueCount',
+  'issueRange',
+  'review',
+  'reviewPublic',
+  'externalUrl',
+  'notes',
+] as const
+
+// RFC 4180 field escaping: quote any field containing a comma, quote, or
+// line break, doubling embedded quotes. `review`/`notes` are freeform text
+// (BROWSE-UX.md §5) and routinely contain all three.
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  const str = typeof value === 'boolean' ? String(value) : String(value)
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+function toCsv(entries: MediaEntry[]): string {
+  const header = CSV_COLUMNS.join(',')
+  const rows = entries.map((entry) =>
+    CSV_COLUMNS.map((column) => csvEscape(entry[column])).join(','),
+  )
+  return [header, ...rows].join('\r\n')
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+
+    const query = getQuery(event)
+
+    const andFilters: Prisma.MediaEntryWhereInput[] = []
+
+    const mediaTypes =
+      typeof query.mediaType === 'string'
+        ? query.mediaType
+            .split(',')
+            .map((entry) => entry.trim())
+            .filter((entry) => MEDIA_TYPES.includes(entry))
+        : []
+    if (mediaTypes.length) {
+      andFilters.push({ mediaType: { in: mediaTypes as MediaType[] } })
+    }
+
+    if (query.starred === 'true') {
+      andFilters.push({ starred: true })
+    }
+
+    const search = typeof query.search === 'string' ? query.search.trim() : ''
+    if (search) {
+      andFilters.push({
+        OR: [{ title: { contains: search } }, { author: { contains: search } }],
+      })
+    }
+
+    const sort = SORT_MODES.includes(query.sort as SortMode)
+      ? (query.sort as SortMode)
+      : 'date_desc'
+
+    const where = andFilters.length ? { AND: andFilters } : undefined
+
+    const entries = await prisma.mediaEntry.findMany({
+      where,
+      orderBy: toOrderBy(sort),
+      take: MAX_ROWS,
+    })
+
+    const csv = toCsv(entries)
+    const filename = `media-watchlist-export-${new Date().toISOString().slice(0, 10)}.csv`
+
+    setHeader(event, 'Content-Type', 'text/csv; charset=utf-8')
+    setHeader(
+      event,
+      'Content-Disposition',
+      `attachment; filename="${filename}"`,
+    )
+
+    return csv
+  } catch (error) {
+    return errorHandler(error)
+  }
+})


### PR DESCRIPTION
### Task
conductor `media-watchlist/t-006`: Polish and upgrade Media Watchlist front-end surface (recurring)

### What changed
- New `GET /api/media-entries/export` — CSV export of the watchlist, honoring the same `search`/`mediaType`/`starred`/`sort` filters the browse UI exposes (admin-gated, same pattern as the other `media-entries` routes). Implements the last unbuilt piece of `BROWSE-UX.md` §4: "Export button (CSV): downloads a filtered view as CSV."
- `watchlist-browse.vue`: added an "Export CSV" button to the filter bar that triggers the download with the current filter state.
- `watchlist-page.vue`: corrected the `deliverables` list, which still listed "Entry detail view + private review editor" under `next` even though it shipped weeks ago (t-010/t-011) — moved it, and CSV export, to `done`.

### How I verified
- `npx eslint` and `npx prettier --check` clean on all three changed files.
- Full-project `npm run test` (`vue-tsc --noEmit`): the pre-existing `rewardFacet`-related type errors in unrelated files (`server/api/dreams/daily.post.ts`, `server/api/rewards/[id]/facets.put.ts`, `server/utils/rewardFacetCatalog.ts`, `utils/scripts/mergeRewardFacetDuplicateLinks.ts`) reproduce identically with these changes stashed out, confirming they predate this PR. No new errors from the files touched here.

### Stakes
Reversible. Admin-gated, additive-only (new route + one new button); no schema or migration changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZM7rSvwrAv4bzEYzduKrv)_