### PR TITLE
feat(store): fulfil general giftshop cart purchases (Order/OrderItem + mana)

### DIFF
--- a/server/api/stripe/checkout.post.ts
+++ b/server/api/stripe/checkout.post.ts
@@ -165,6 +165,12 @@ export default defineEventHandler(async (event) => {
           unit_amount: Math.round(item.price * 100),
         },
         quantity,
+        // Carried through to the webhook's listLineItems() response verbatim
+        // (Stripe LineItem objects have their own metadata field, distinct
+        // from price_data.product_data) so handleGiftshopCartPurchase can
+        // fulfil each line item by its cart catalog type without needing to
+        // parse it back out of the display name.
+        metadata: { giftshopType: id },
       }
     })
 

--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -3,7 +3,9 @@ import { createError, defineEventHandler, getHeader, readRawBody } from 'h3'
 import Stripe from 'stripe'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '~/server/utils/error'
-import { applyMana } from '~/server/utils/mana'
+import { applyMana, usdToMana } from '~/server/utils/mana'
+import { cartItems, type CartItem } from '@/stores/seeds/cartItems'
+import type { ProductType } from '~/prisma/generated/prisma/client'
 
 let stripe: Stripe | null = null
 
@@ -245,6 +247,150 @@ async function handleProductPurchase(session: Stripe.Checkout.Session) {
   )
 }
 
+// General multi-item giftshop cart checkout (digital-storefront/t-031).
+// Unlike handleProductPurchase (one Product per session, via
+// metadata.productSlug), a cart session can mix several
+// stores/seeds/cartItems.ts catalog types in one Stripe session -- each line
+// item carries its own `metadata.giftshopType` (set by checkout.post.ts's
+// per-line `metadata` field) instead of a single session-level productSlug.
+// One Order is created per session with one OrderItem per line item.
+//
+// Scope of this pass: every purchased line item gets a real Order/OrderItem
+// audit record (closing the "succeeds at Stripe, no Order ever created" gap),
+// and 'tokens' additionally credits real mana in the same transaction
+// (mirroring handleManaTopup's PURCHASE-reason pattern) since leaving that
+// unfulfilled would mean charging a user real money for boost tokens and
+// granting nothing. Deliberately NOT implemented here: PrintJob creation for
+// print/shirt/sticker/mug/book -- unlike pod-checkout.post.ts's dedicated
+// route, the general cart's checkout() payload only ever sends `{id,
+// quantity}` per line (stores/cartStore.ts), even though its own CartItem
+// interface tracks a real artImageId client-side; wiring that through plus a
+// server-side checkPrintEligibility re-check is real-art-selection work
+// still needed as a follow-up. Filing a PrintJob against a fabricated
+// artImageId here would misrepresent what art is being printed, so this pass
+// records the sale for those four types and stops there.
+const GIFTSHOP_TYPE_TO_PRODUCT_TYPE: Record<CartItem['type'], ProductType> = {
+  print: 'POD',
+  shirt: 'POD',
+  sticker: 'POD',
+  mug: 'POD',
+  book: 'POD',
+  donation: 'DONATION',
+  tokens: 'MANA_TOPUP',
+}
+
+async function handleGiftshopCartPurchase(session: Stripe.Checkout.Session) {
+  const userId = Number(session.metadata?.userId)
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    console.error(
+      `⚠️ Stripe webhook: giftshop cart session ${session.id} missing/invalid userId metadata`,
+    )
+    return
+  }
+
+  const existingOrder = await prisma.order.findUnique({
+    where: { stripeSessionId: session.id },
+  })
+  if (existingOrder) {
+    console.log(
+      `💤 Stripe webhook: session ${session.id} already fulfilled, skipping`,
+    )
+    return
+  }
+
+  const lineItems = await getStripeClient().checkout.sessions.listLineItems(
+    session.id,
+    { limit: 100 },
+  )
+
+  const customerId =
+    typeof session.customer === 'string'
+      ? session.customer
+      : session.customer?.id
+
+  let fulfilledCount = 0
+  let skippedCount = 0
+
+  await prisma.$transaction(async (tx) => {
+    const order = await tx.order.create({
+      data: {
+        userId,
+        stripeSessionId: session.id,
+        stripeCustomerId: customerId ?? null,
+        status: 'PAID',
+        totalCents: session.amount_total ?? 0,
+      },
+    })
+
+    for (const line of lineItems.data) {
+      const cartType = line.metadata?.giftshopType
+      const catalogEntry = cartItems.find((entry) => entry.id === cartType)
+      const productType = catalogEntry
+        ? GIFTSHOP_TYPE_TO_PRODUCT_TYPE[catalogEntry.type]
+        : undefined
+
+      if (!catalogEntry || !productType) {
+        console.error(
+          `⚠️ Stripe webhook: giftshop cart session ${session.id} has a line item with unknown giftshopType "${cartType}", skipping`,
+        )
+        skippedCount += 1
+        continue
+      }
+
+      const quantity = line.quantity ?? 1
+      const priceCents = Math.round(catalogEntry.price * 100)
+      const slug = `giftshop-${catalogEntry.id}`
+
+      const product = await tx.product.upsert({
+        where: { slug },
+        create: {
+          slug,
+          type: productType,
+          title: catalogEntry.label,
+          priceCents,
+        },
+        update: {},
+      })
+
+      const item = await tx.orderItem.create({
+        data: {
+          orderId: order.id,
+          productId: product.id,
+          quantity,
+          priceCents,
+        },
+      })
+
+      if (catalogEntry.type === 'tokens') {
+        // Real fulfillment, not just an audit record -- unlike donation/POD,
+        // "100 Boost Tokens" has nothing else that represents ownership, so
+        // if mana isn't credited here the user paid real money for nothing.
+        // Passed the same `tx` so this commits atomically with the Order/
+        // OrderItem above rather than opening its own transaction.
+        const manaAmount = usdToMana(catalogEntry.price) * quantity
+
+        await applyMana({
+          userId,
+          amount: manaAmount,
+          reason: 'PURCHASE',
+          refId: `${session.id}:${item.id}`,
+          provider: 'stripe',
+          costUsd: catalogEntry.price * quantity,
+          note: `Giftshop cart purchase: ${catalogEntry.label}`,
+          tx,
+        })
+      }
+
+      fulfilledCount += 1
+    }
+  })
+
+  console.log(
+    `🛍️ Fulfilled giftshop cart session ${session.id} for user ${userId} (${fulfilledCount} line item(s), ${skippedCount} skipped)`,
+  )
+}
+
 // customer.subscription.updated/deleted — keeps isMember in sync with Stripe's
 // view of the subscription (renewal, cancellation, payment failure) independent
 // of whether the cancellation was initiated from our UI or the Stripe dashboard.
@@ -322,6 +468,11 @@ export default defineEventHandler(async (event) => {
         await handleSubscriptionCheckout(session)
       } else if (session.mode === 'payment' && session.metadata?.productSlug) {
         await handleProductPurchase(session)
+      } else if (
+        session.mode === 'payment' &&
+        session.metadata?.kind === 'giftshop_checkout'
+      ) {
+        await handleGiftshopCartPurchase(session)
       }
     } else if (
       stripeEvent.type === 'customer.subscription.updated' ||

--- a/server/utils/mana.ts
+++ b/server/utils/mana.ts
@@ -2,6 +2,15 @@
 import { prisma } from './prisma'
 import type { ManaReason, Role } from '~/prisma/generated/prisma/client'
 
+// prisma is $extends()-wrapped (see server/utils/prisma.ts), so its
+// $transaction callback's tx param has extended InternalArgs that don't
+// structurally match the plain Prisma.TransactionClient type. Derive the
+// type from the actual instance instead of the generated default (same
+// pattern as server/api/model-builder/items/[id]/commit.post.ts).
+type TransactionClient = Parameters<
+  Parameters<typeof prisma.$transaction>[0]
+>[0]
+
 const PEG_USD_PER_MANA = 0.001
 
 export function usdToMana(usd: number) {
@@ -9,6 +18,9 @@ export function usdToMana(usd: number) {
 }
 
 // Atomic credit/debit + ledger row. Throws on insufficient funds.
+// Pass `tx` when this call must participate in a caller's own transaction
+// (e.g. crediting mana alongside an Order/OrderItem write in the same
+// commit) instead of opening its own independent transaction.
 export async function applyMana(opts: {
   userId: number
   amount: number // signed
@@ -18,8 +30,9 @@ export async function applyMana(opts: {
   provider?: string
   costUsd?: number
   allowNegative?: boolean
+  tx?: TransactionClient
 }) {
-  return prisma.$transaction(async (tx) => {
+  const run = async (tx: TransactionClient) => {
     const user = await tx.user.findUniqueOrThrow({
       where: { id: opts.userId },
       select: { mana: true },
@@ -45,7 +58,9 @@ export async function applyMana(opts: {
       },
     })
     return { balance: next, txnId: txn.id }
-  })
+  }
+
+  return opts.tx ? run(opts.tx) : prisma.$transaction(run)
 }
 
 export type { ManaReason }


### PR DESCRIPTION
### What changed
The general multi-item cart checkout (`server/api/stripe/checkout.post.ts`) succeeded at Stripe but never created any fulfillment record — its `metadata.kind: 'giftshop_checkout'` matched no branch in the webhook's dispatch (`handleProductPurchase` is keyed on a single-session `metadata.productSlug`, which a multi-item cart doesn't set).

- `checkout.post.ts`: each Stripe line item now carries its own `metadata: { giftshopType: id }` — Stripe `LineItem` objects have their own per-line `metadata` field (confirmed via the SDK's own type definitions, `node_modules/stripe/esm/resources/LineItems.d.ts`), distinct from `price_data.product_data`, and it round-trips through `checkout.sessions.listLineItems()` with no `expand` needed.
- `webhook.post.ts`: new `handleGiftshopCartPurchase`, dispatched when `session.metadata?.kind === 'giftshop_checkout'`, kept separate from `handleProductPurchase` rather than overloading its single-product shape. Creates one `Order` per session, one `OrderItem` per line item (upserting a generic `Product` row per `stores/seeds/cartItems.ts` catalog type — server-trusted price, reused across purchases). Idempotent the same way `handleProductPurchase` already is: check-then-transact, backstopped by `Order.stripeSessionId`'s unique constraint.
- `tokens` line items additionally credit real mana in the same transaction (mirrors `handleManaTopup`'s `PURCHASE`-reason pattern) — an audit-only record would mean charging real money for "100 Boost Tokens" and granting nothing.
- `server/utils/mana.ts`: extended `applyMana` with an optional `tx` parameter so the mana credit above commits atomically with the Order/OrderItem write instead of opening a second, non-atomic transaction. Backward compatible — every other existing caller (`bounty/fulfill.post.ts`, `manaGate.ts`, `charge.ts`, `refill.ts`) is unaffected, they just don't pass `tx`.

### Deliberately NOT implemented
`PrintJob` creation for `print`/`shirt`/`sticker`/`mug`/`book` line items. `stores/cartStore.ts`'s client-side `CartItem` interface already tracks a real `artImageId` per item, but its `checkout()` function drops it before sending to the server (`{ id: item.type, quantity }` only) — so there's no real, eligibility-checked art to attach a `PrintJob` to today. Filing one against a fabricated `artImageId` would misrepresent what's actually being printed. Tracked as a follow-up in the conductor roadmap (`digital-storefront/t-033`) rather than guessed at here. `donation` line items also intentionally get Order/OrderItem only — correct behavior, not a gap, since there's nothing to "own" for a donation.

### How I verified
- `npx eslint` clean on all three changed files.
- `npx prettier --check` clean.
- Full-project `vue-tsc --noEmit` — 0 errors (after fixing one real type error: the type-to-`ProductType` map's keys must match `stores/seeds/cartItems.ts`'s narrower `CartItem['type']`, not the similarly-named but broader client-side `stores/cartStore.ts` `CartItem` interface, which also declares `extra`/`subscription` types that don't exist in the trusted server catalog).
- `npx tsx utils/scripts/verifyNoPrismaJsonCast.ts` and `verifyFetchGenericPinning.ts` both pass.
- Could not exercise a live Stripe test-mode click-through from this sandbox (no `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET`) — the per-line `metadata` round-trip is verified against the Stripe SDK's own type definitions rather than a live call.

### Stakes
reversible — Stripe test-mode only, no live payment/vendor action, additive-only logic (no schema/migration changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Lpc8S4KHcAW4VeqKgCbE)_