### PR TITLE
digital-storefront/t-032: re-check print eligibility at webhook fulfillment time

### DIFF
--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -6,6 +6,7 @@ import { errorHandler } from '~/server/utils/error'
 import { applyMana, usdToMana } from '~/server/utils/mana'
 import { cartItems, type CartItem } from '@/stores/seeds/cartItems'
 import type { ProductType } from '~/prisma/generated/prisma/client'
+import { checkPrintEligibility } from '../art/utils/printEligibility'
 
 let stripe: Stripe | null = null
 
@@ -219,6 +220,60 @@ async function handleProductPurchase(session: Stripe.Checkout.Session) {
         console.error(
           `⚠️ Stripe webhook: POD product "${slug}" missing artImageId/printfulVariantId metadata, skipping PrintJob creation`,
         )
+        return
+      }
+
+      // Re-check print eligibility against the ArtImage's *current* state —
+      // pod-checkout.post.ts only checked this at session-creation time, and
+      // an image can be taken down (isActive/isMature flipped) during the
+      // window between "added to cart" and "payment completed" (t-029's gate,
+      // gallery-to-swag-pipeline.md §4). Don't trust anything cached on the
+      // Product/session from checkout-creation time.
+      const artImage = await tx.artImage.findUnique({
+        where: { id: artImageId },
+        select: {
+          userId: true,
+          isMature: true,
+          isPublic: true,
+          isActive: true,
+          checkpointResourceId: true,
+          CheckpointResource: { select: { commercialSafe: true } },
+        },
+      })
+
+      if (!artImage) {
+        console.error(
+          `⚠️ Stripe webhook: POD product "${slug}" references ArtImage ${artImageId} which no longer exists, failing PrintJob`,
+        )
+        await tx.printJob.create({
+          data: {
+            orderItemId: item.id,
+            artImageId,
+            printfulVariantId,
+            status: 'FAILED',
+          },
+        })
+        return
+      }
+
+      const eligibility = checkPrintEligibility(
+        artImage,
+        artImage.CheckpointResource,
+        { userId },
+      )
+
+      if (!eligibility.eligible) {
+        console.error(
+          `⚠️ Stripe webhook: POD product "${slug}" failed print-eligibility re-check at fulfillment time for ArtImage ${artImageId} (${eligibility.reason}), failing PrintJob instead of shipping it`,
+        )
+        await tx.printJob.create({
+          data: {
+            orderItemId: item.id,
+            artImageId,
+            printfulVariantId,
+            status: 'FAILED',
+          },
+        })
         return
       }
 


### PR DESCRIPTION
### Task
digital-storefront/t-032: re-check ArtImage takedown/eligibility at Stripe webhook time for POD purchases, not just at checkout-creation time (kind: software)

### What changed / what I produced
- `server/api/stripe/webhook.post.ts`: `handleProductPurchase`'s POD branch now re-fetches the `ArtImage`'s current state (`isMature`, `isActive`, `isPublic`, `userId`, `checkpointResourceId` + `CheckpointResource.commercialSafe`) and re-runs `checkPrintEligibility` (the same gate `pod-checkout.post.ts` already applies at session-creation time) before creating the `PrintJob`.
- On failure (image taken down/flagged mature/deactivated between "added to cart" and "payment completed", or the ArtImage row no longer exists), the `PrintJob` is still created but with `status: 'FAILED'` instead of the default `PENDING` — so the failure is visible/auditable rather than either silently shipping it or silently dropping the record.
- Matches `gallery-to-swag-pipeline.md` §4 ("an image flagged between 'added to cart' and 'payment completed' should fail the webhook's PrintJob creation step ... rather than silently shipping it").

### How I verified
- `npx eslint server/api/stripe/webhook.post.ts` — clean
- `npx prettier --check server/api/stripe/webhook.post.ts` — clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — 0 errors
- `utils/scripts/verifyNoPrismaJsonCast.ts` and `utils/scripts/verifyFetchGenericPinning.ts` — both pass

### Stakes
reversible

### Flags for Reviewer
- No live Stripe test-mode click-through was run (no `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` in this sandbox) — verified via type-checking and matching the existing `pod-checkout.post.ts` pattern exactly (same `checkPrintEligibility` call shape, same select fields).
- Currently inert in production either way: no Printful vendor account/API key exists yet, so `PrintJob` rows stay `PENDING`/now sometimes `FAILED` with no real vendor call regardless — this closes the gap before the real Printful submission call is wired, per the task's own note.

### Kaizen suggestion
None beyond this task's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEnaCkhHvsdygWfCK8pZbk)_