### PR TITLE
digital-storefront/t-033: wire real artImageId through general giftshop cart checkout for PrintJob creation

### DIFF
--- a/server/api/store/pod-checkout.post.ts
+++ b/server/api/store/pod-checkout.post.ts
@@ -12,6 +12,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { checkPrintEligibility } from '../art/utils/printEligibility'
+import { POD_CATALOG } from './podCatalog'
 
 let stripe: Stripe | null = null
 
@@ -27,36 +28,6 @@ function getStripeClient() {
 
   stripe ??= new Stripe(secretKey)
   return stripe
-}
-
-// Placeholder Printful catalog — variant ids are not real Printful catalog
-// ids (no vendor account exists yet). Pricing mirrors the display-only
-// stores/seeds/cartItems.ts tiers so this doesn't introduce a second price
-// for the same product type.
-const POD_CATALOG: Record<
-  string,
-  { title: string; priceCents: number; printfulVariantId: string }
-> = {
-  print: {
-    title: 'Art Print',
-    priceCents: 1299,
-    printfulVariantId: 'PLACEHOLDER_PRINT',
-  },
-  shirt: {
-    title: 'T-Shirt',
-    priceCents: 2499,
-    printfulVariantId: 'PLACEHOLDER_SHIRT',
-  },
-  sticker: {
-    title: 'Sticker',
-    priceCents: 499,
-    printfulVariantId: 'PLACEHOLDER_STICKER',
-  },
-  mug: {
-    title: 'Mug',
-    priceCents: 1649,
-    printfulVariantId: 'PLACEHOLDER_MUG',
-  },
 }
 
 function parseBody(body: unknown): {

--- a/server/api/store/podCatalog.ts
+++ b/server/api/store/podCatalog.ts
@@ -1,0 +1,32 @@
+// /server/api/store/podCatalog.ts
+// Shared print-on-demand catalog for the two checkout paths that create
+// PrintJob rows: pod-checkout.post.ts (single-item POD flow) and the
+// webhook's handleGiftshopCartPurchase (general multi-item cart, t-033).
+// Keys match both stores/seeds/cartItems.ts ids and pod-checkout.post.ts's
+// printType param — not real Printful catalog ids (no vendor account/API key
+// exists yet, digital-storefront/t-015, needs-human).
+export const POD_CATALOG: Record<
+  string,
+  { title: string; priceCents: number; printfulVariantId: string }
+> = {
+  print: {
+    title: 'Art Print',
+    priceCents: 1299,
+    printfulVariantId: 'PLACEHOLDER_PRINT',
+  },
+  shirt: {
+    title: 'T-Shirt',
+    priceCents: 2499,
+    printfulVariantId: 'PLACEHOLDER_SHIRT',
+  },
+  sticker: {
+    title: 'Sticker',
+    priceCents: 499,
+    printfulVariantId: 'PLACEHOLDER_STICKER',
+  },
+  mug: {
+    title: 'Mug',
+    priceCents: 1649,
+    printfulVariantId: 'PLACEHOLDER_MUG',
+  },
+}

--- a/server/api/stripe/checkout.post.ts
+++ b/server/api/stripe/checkout.post.ts
@@ -5,6 +5,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { cartItems } from '@/stores/seeds/cartItems'
+import { checkPrintEligibility } from '../art/utils/printEligibility'
 
 let stripe: Stripe | null = null
 
@@ -22,7 +23,16 @@ function getStripeClient() {
   return stripe
 }
 
-function parseCart(body: unknown): Array<{ id: string; quantity: number }> {
+type ParsedCartEntry = {
+  id: string
+  quantity: number
+  // Only set (and required) for catalog items where needsArt is true
+  // (print/shirt/sticker/mug — see stores/seeds/cartItems.ts). null for
+  // every other type (donation, tokens, book, ...).
+  artImageId: number | null
+}
+
+function parseCart(body: unknown): ParsedCartEntry[] {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
     throw createError({
       statusCode: 400,
@@ -56,7 +66,11 @@ function parseCart(body: unknown): Array<{ id: string; quantity: number }> {
     })
   }
 
-  const quantities = new Map<string, number>()
+  // Dedup key for needsArt items includes artImageId so two different prints
+  // of the same product type (e.g. two different "print" line items) stay as
+  // distinct entries instead of being merged into one combined-quantity line
+  // with no way to tell which art each unit is for.
+  const entries = new Map<string, ParsedCartEntry>()
 
   for (const entry of record.cart) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
@@ -68,7 +82,8 @@ function parseCart(body: unknown): Array<{ id: string; quantity: number }> {
 
     const item = entry as Record<string, unknown>
     const invalidFields = Object.keys(item).filter(
-      (field) => field !== 'id' && field !== 'quantity',
+      (field) =>
+        field !== 'id' && field !== 'quantity' && field !== 'artImageId',
     )
 
     if (invalidFields.length) {
@@ -111,7 +126,25 @@ function parseCart(body: unknown): Array<{ id: string; quantity: number }> {
       })
     }
 
-    const combinedQuantity = (quantities.get(id) || 0) + quantity
+    let artImageId: number | null = null
+
+    if (trustedItem.needsArt) {
+      if (
+        !Number.isSafeInteger(item.artImageId) ||
+        (item.artImageId as number) <= 0
+      ) {
+        throw createError({
+          statusCode: 400,
+          message: `A valid artImageId is required for ${id}.`,
+        })
+      }
+
+      artImageId = Number(item.artImageId)
+    }
+
+    const dedupeKey = artImageId != null ? `${id}:${artImageId}` : id
+    const existing = entries.get(dedupeKey)
+    const combinedQuantity = (existing?.quantity || 0) + quantity
 
     if (combinedQuantity > 25) {
       throw createError({
@@ -120,18 +153,63 @@ function parseCart(body: unknown): Array<{ id: string; quantity: number }> {
       })
     }
 
-    quantities.set(id, combinedQuantity)
+    entries.set(dedupeKey, { id, artImageId, quantity: combinedQuantity })
   }
 
-  return Array.from(quantities, ([id, quantity]) => ({ id, quantity }))
+  return Array.from(entries.values())
 }
 
 export default defineEventHandler(async (event) => {
   try {
-    const { user } = await requireApiUser(event)
+    const { user, isAdmin } = await requireApiUser(event)
     const cart = parseCart(await readBody<unknown>(event))
     const stripeClient = getStripeClient()
     const email = user.email || `user-${user.id}@kindrobots.org`
+
+    // Re-check print eligibility server-side for every art-requiring line
+    // before creating the Stripe session — never trust the client's
+    // disabled-button state (same enforcement point as pod-checkout.post.ts).
+    // Any ineligible line fails the whole checkout rather than silently
+    // dropping just that item, so the user is never charged for less than
+    // the cart they reviewed.
+    for (const { id, artImageId } of cart) {
+      if (artImageId == null) continue
+
+      const image = await prisma.artImage.findUnique({
+        where: { id: artImageId },
+        select: {
+          userId: true,
+          isMature: true,
+          isPublic: true,
+          isActive: true,
+          checkpointResourceId: true,
+          CheckpointResource: { select: { commercialSafe: true } },
+        },
+      })
+
+      if (!image) {
+        throw createError({
+          statusCode: 404,
+          message: `ArtImage ${artImageId} for ${id} not found.`,
+        })
+      }
+
+      const eligibility = checkPrintEligibility(
+        image,
+        image.CheckpointResource,
+        {
+          userId: user.id,
+          isAdmin,
+        },
+      )
+
+      if (!eligibility.eligible) {
+        throw createError({
+          statusCode: 403,
+          message: `${id} (ArtImage ${artImageId}): ${eligibility.reason}`,
+        })
+      }
+    }
 
     const customerId =
       user.stripeCustomerId ??
@@ -144,7 +222,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const lineItems = cart.map(({ id, quantity }) => {
+    const lineItems = cart.map(({ id, quantity, artImageId }) => {
       const item = cartItems.find((candidate) => candidate.id === id)
 
       if (!item) {
@@ -169,8 +247,13 @@ export default defineEventHandler(async (event) => {
         // (Stripe LineItem objects have their own metadata field, distinct
         // from price_data.product_data) so handleGiftshopCartPurchase can
         // fulfil each line item by its cart catalog type without needing to
-        // parse it back out of the display name.
-        metadata: { giftshopType: id },
+        // parse it back out of the display name. artImageId (string — Stripe
+        // metadata values are always strings) is only present for needsArt
+        // types, so handleGiftshopCartPurchase can create a real PrintJob.
+        metadata: {
+          giftshopType: id,
+          ...(artImageId != null ? { artImageId: String(artImageId) } : {}),
+        },
       }
     })
 

--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -7,6 +7,7 @@ import { applyMana, usdToMana } from '~/server/utils/mana'
 import { cartItems, type CartItem } from '@/stores/seeds/cartItems'
 import type { ProductType } from '~/prisma/generated/prisma/client'
 import { checkPrintEligibility } from '../art/utils/printEligibility'
+import { POD_CATALOG } from '../store/podCatalog'
 
 let stripe: Stripe | null = null
 
@@ -310,20 +311,15 @@ async function handleProductPurchase(session: Stripe.Checkout.Session) {
 // per-line `metadata` field) instead of a single session-level productSlug.
 // One Order is created per session with one OrderItem per line item.
 //
-// Scope of this pass: every purchased line item gets a real Order/OrderItem
-// audit record (closing the "succeeds at Stripe, no Order ever created" gap),
-// and 'tokens' additionally credits real mana in the same transaction
-// (mirroring handleManaTopup's PURCHASE-reason pattern) since leaving that
-// unfulfilled would mean charging a user real money for boost tokens and
-// granting nothing. Deliberately NOT implemented here: PrintJob creation for
-// print/shirt/sticker/mug/book -- unlike pod-checkout.post.ts's dedicated
-// route, the general cart's checkout() payload only ever sends `{id,
-// quantity}` per line (stores/cartStore.ts), even though its own CartItem
-// interface tracks a real artImageId client-side; wiring that through plus a
-// server-side checkPrintEligibility re-check is real-art-selection work
-// still needed as a follow-up. Filing a PrintJob against a fabricated
-// artImageId here would misrepresent what art is being printed, so this pass
-// records the sale for those four types and stops there.
+// Scope: every purchased line item gets a real Order/OrderItem audit record
+// (closing the "succeeds at Stripe, no Order ever created" gap); 'tokens'
+// additionally credits real mana (mirroring handleManaTopup's PURCHASE-reason
+// pattern); and print/shirt/sticker/mug (needsArt in stores/seeds/cartItems.ts)
+// get a real PrintJob (digital-storefront/t-033) using the artImageId
+// checkout.post.ts now carries through per-line metadata. 'book' is also POD
+// but needsArt is false -- it's the fixed "Mermaids of Venice (Signed)"
+// product, not a print of a specific ArtImage, and has no POD_CATALOG entry
+// (no Printful variant), so it stays Order/OrderItem-only like donation.
 const GIFTSHOP_TYPE_TO_PRODUCT_TYPE: Record<CartItem['type'], ProductType> = {
   print: 'POD',
   shirt: 'POD',
@@ -332,6 +328,95 @@ const GIFTSHOP_TYPE_TO_PRODUCT_TYPE: Record<CartItem['type'], ProductType> = {
   book: 'POD',
   donation: 'DONATION',
   tokens: 'MANA_TOPUP',
+}
+
+// prisma is $extends()-wrapped (see server/utils/prisma.ts), so its
+// $transaction callback's tx param has extended InternalArgs that don't
+// structurally match the plain Prisma.TransactionClient type. Derive the
+// type from the actual instance instead (same pattern as server/utils/mana.ts).
+type TransactionClient = Parameters<
+  Parameters<typeof prisma.$transaction>[0]
+>[0]
+
+// Creates a PrintJob for one needsArt line item, re-checking print
+// eligibility against the ArtImage's *current* state -- checkout.post.ts only
+// checked this at session-creation time, and an image can be taken down
+// (isActive/isMature flipped) during the window before payment completes
+// (same re-check-at-fulfillment-time pattern as handleProductPurchase's POD
+// branch, t-029's gate). Unlike that branch, this deliberately does NOT
+// insert a FAILED PrintJob when the artImageId is missing/invalid or the
+// ArtImage no longer exists -- PrintJob.artImageId is a required, non-null FK
+// to ArtImage, so inserting one referencing a nonexistent row would throw and
+// roll back the whole transaction (losing the Order/OrderItem too). The
+// Order/OrderItem audit record still gets created; only the PrintJob is
+// skipped in that case.
+async function fulfillGiftshopPrintJob(
+  tx: TransactionClient,
+  orderItemId: number,
+  catalogEntry: CartItem,
+  rawArtImageId: string | undefined,
+  userId: number,
+): Promise<boolean> {
+  const podEntry = POD_CATALOG[catalogEntry.id]
+  const artImageId = Number(rawArtImageId)
+
+  if (!podEntry) {
+    console.error(
+      `⚠️ Stripe webhook: giftshop cart line "${catalogEntry.id}" has no POD_CATALOG entry, skipping PrintJob`,
+    )
+    return false
+  }
+
+  if (!Number.isInteger(artImageId) || artImageId <= 0) {
+    console.error(
+      `⚠️ Stripe webhook: giftshop cart line "${catalogEntry.id}" missing/invalid artImageId metadata, skipping PrintJob`,
+    )
+    return false
+  }
+
+  const artImage = await tx.artImage.findUnique({
+    where: { id: artImageId },
+    select: {
+      userId: true,
+      isMature: true,
+      isPublic: true,
+      isActive: true,
+      checkpointResourceId: true,
+      CheckpointResource: { select: { commercialSafe: true } },
+    },
+  })
+
+  if (!artImage) {
+    console.error(
+      `⚠️ Stripe webhook: giftshop cart line "${catalogEntry.id}" references ArtImage ${artImageId} which no longer exists, skipping PrintJob`,
+    )
+    return false
+  }
+
+  const eligibility = checkPrintEligibility(
+    artImage,
+    artImage.CheckpointResource,
+    {
+      userId,
+    },
+  )
+
+  await tx.printJob.create({
+    data: {
+      orderItemId,
+      artImageId,
+      printfulVariantId: podEntry.printfulVariantId,
+      status: eligibility.eligible ? undefined : 'FAILED',
+    },
+  })
+
+  if (!eligibility.eligible) {
+    console.error(
+      `⚠️ Stripe webhook: giftshop cart line "${catalogEntry.id}" failed print-eligibility re-check at fulfillment time for ArtImage ${artImageId} (${eligibility.reason}), failing PrintJob instead of shipping it`,
+    )
+  }
+
+  return true
 }
 
 async function handleGiftshopCartPurchase(session: Stripe.Checkout.Session) {
@@ -435,6 +520,14 @@ async function handleGiftshopCartPurchase(session: Stripe.Checkout.Session) {
           note: `Giftshop cart purchase: ${catalogEntry.label}`,
           tx,
         })
+      } else if (catalogEntry.needsArt) {
+        await fulfillGiftshopPrintJob(
+          tx,
+          item.id,
+          catalogEntry,
+          line.metadata?.artImageId,
+          userId,
+        )
       }
 
       fulfilledCount += 1

--- a/stores/cartStore.ts
+++ b/stores/cartStore.ts
@@ -256,9 +256,13 @@ export const useCartStore = defineStore('cartStore', () => {
           }
         }
 
+        // artImageId is sent for every line; the server only requires/uses it
+        // for needsArt catalog types (print/shirt/sticker/mug) and ignores it
+        // otherwise (see server/api/stripe/checkout.post.ts's parseCart).
         const cartPayload = items.value.map((item) => ({
           id: item.type,
           quantity: item.quantity,
+          artImageId: item.artImageId,
         }))
 
         const result = await performFetch<{ url: string }>(


### PR DESCRIPTION
## Summary

`stores/cartStore.ts`'s `checkout()` already tracked a real `artImageId` per client-side `CartItem`, but dropped it before sending to the server (`{ id: item.type, quantity }` only). `server/api/stripe/checkout.post.ts`'s `parseCart` never had anywhere to put it either. t-031 wired real Order/OrderItem fulfillment for the general giftshop cart but deliberately stopped short of creating a `PrintJob` for print/shirt/sticker/mug line items, since doing so would need a real, eligibility-checked `artImageId` that didn't exist anywhere in the payload.

This closes that gap:

- **`stores/cartStore.ts`**: `checkout()` now sends `artImageId` per cart line.
- **`server/api/stripe/checkout.post.ts`**: `parseCart` requires + validates `artImageId` for `needsArt` catalog types (print/shirt/sticker/mug — see `stores/seeds/cartItems.ts`), dedupes cart entries by `(type, artImageId)` instead of `type` alone so two different prints of the same product type stay distinct line items, re-runs `checkPrintEligibility` server-side for every art-requiring line before creating the Stripe session (an ineligible line fails the whole checkout — never silently drops just that item, so the user is never charged for less than the cart they reviewed), and carries `artImageId` through Stripe line-item metadata (mirroring the existing `giftshopType` mechanism).
- **`server/api/stripe/webhook.post.ts`**: new `fulfillGiftshopPrintJob` helper re-checks print eligibility against the ArtImage's *current* state at fulfillment time (same pattern as `handleProductPurchase`'s POD branch, t-029's gate) and creates a real `PrintJob` for `needsArt` line items. Deliberately does **not** insert a `FAILED` `PrintJob` when `artImageId` is missing/invalid or the `ArtImage` no longer exists — `PrintJob.artImageId` is a required, non-null FK, so that insert would throw and roll back the whole transaction (losing the Order/OrderItem audit record too). In that case the Order/OrderItem still records the sale; only the `PrintJob` is skipped.
- **`book` stays Order/OrderItem-only**, unchanged: `needsArt` is already `false` for it in `stores/seeds/cartItems.ts` — it's the fixed "Mermaids of Venice (Signed)" product, not a print of a specific `ArtImage`, and has no `POD_CATALOG` entry (no Printful variant).
- Extracted `POD_CATALOG` (title/price/`printfulVariantId` per POD type) out of `pod-checkout.post.ts` into `server/api/store/podCatalog.ts` so both checkout paths share one source of truth instead of two copies drifting apart.

Note the demo showcase items in `giftshop-interact.vue` (`addDemoItem`, "Butterfly Print") and `giving-page.vue`'s donation button use placeholder `artImageId` values that don't correspond to real `ArtImage` rows — the print placeholder will now fail a real eligibility check (`ArtImage not found`), which is correct behavior per the task note, not a bug to work around here.

Reversible, Stripe test-mode only, no live vendor action.

## Verification

- `eslint` clean on all changed/new files (the 2 pre-existing `cartStore.ts` `no-empty` errors on unrelated lines 49/57 predate this change — confirmed via `git stash`)
- `prettier --check` clean
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0

## Test plan

- [x] `eslint` on changed files
- [x] `prettier --check` on changed files
- [x] `npm run test` (vue-tsc, full project)
- [ ] Live Stripe test-mode checkout smoke (deferred — sandbox has no reachable `DATABASE_URL`/Stripe test keys, same limitation noted on prior digital-storefront PRs in this series)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZEo6tbaPE8ELxhPxzzALu)_