### PR TITLE
fix(stripe): don't insert PrintJob for a deleted ArtImage on POD purchase

### DIFF
--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -243,17 +243,17 @@ async function handleProductPurchase(session: Stripe.Checkout.Session) {
       })
 
       if (!artImage) {
+        // Do NOT insert a PrintJob here -- artImageId is a required, non-null
+        // FK to ArtImage with no onDelete: SetNull, so pointing it at a
+        // nonexistent row would throw and roll back this whole transaction,
+        // including the Order/OrderItem already created above (same
+        // "check-existence-before-insert" fix as fulfillGiftshopPrintJob
+        // below, digital-storefront/t-034). Leaving the PrintJob out keeps
+        // the Order/OrderItem as the audit trail instead of losing the paid
+        // order entirely.
         console.error(
-          `⚠️ Stripe webhook: POD product "${slug}" references ArtImage ${artImageId} which no longer exists, failing PrintJob`,
+          `⚠️ Stripe webhook: POD product "${slug}" references ArtImage ${artImageId} which no longer exists, skipping PrintJob`,
         )
-        await tx.printJob.create({
-          data: {
-            orderItemId: item.id,
-            artImageId,
-            printfulVariantId,
-            status: 'FAILED',
-          },
-        })
         return
       }
 


### PR DESCRIPTION
### Task
digital-storefront/t-034: fix Order-losing FK bug in POD webhook fulfillment (kind: software)

### What changed / what I produced
- `server/api/stripe/webhook.post.ts`: `handleProductPurchase`'s POD branch, on finding the referenced `ArtImage` no longer exists, no longer calls `tx.printJob.create(...)` with the missing `artImageId`. `PrintJob.artImageId` is a required, non-null FK to `ArtImage` with no `onDelete: SetNull` — that insert would throw a FK violation and roll back the whole `$transaction`, taking the just-created `Order`/`OrderItem` down with it. Net effect before the fix: a user who paid via Stripe for a POD item whose `ArtImage` was deleted between checkout and webhook delivery ended up with **no Order record at all** — worse than the `FAILED` PrintJob status the code was trying to record.
- The fix mirrors the pattern already used a few lines down in `fulfillGiftshopPrintJob` (the general giftshop-cart path, from t-033): skip the `PrintJob` insert entirely when the `ArtImage` is missing, so the `Order`/`OrderItem` survive as the paid-order audit trail.

### How I verified
- `npx eslint server/api/stripe/webhook.post.ts` — clean.
- `npm run test` (full `vue-tsc --noEmit` typecheck via `nuxi prepare` + the project's fix-tsconfig step) — 0 errors.
- Could not exercise the actual FK-violation/rollback path against a live DB (no reachable `DATABASE_URL` in this sandbox, per the task's own note) — the fix is a straightforward structural mirror of the sibling `fulfillGiftshopPrintJob` function, which already handles the identical case correctly.

### Stakes
reversible

### Flags for Reviewer
- Live-DB verification of the actual FK rollback behavior wasn't possible in this sandbox (documented on the task as a known constraint). The fix shape matches the already-shipped, working pattern in `fulfillGiftshopPrintJob` exactly, so risk is low, but a real-DB smoke test before/after would be the strongest confirmation if anyone has one handy.

### Kaizen suggestion
The two POD-fulfillment code paths (`handleProductPurchase` vs. `handleGiftshopCartPurchase`/`fulfillGiftshopPrintJob`) now share the same "skip PrintJob if ArtImage is gone" logic in two separate places. Worth a follow-up task to extract a single shared helper (e.g. `createPrintJobIfEligible(tx, {orderItemId, artImageId, printfulVariantId, userId})`) so future POD-path additions can't reintroduce this exact bug independently.

conductor task: digital-storefront/t-034

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PbKQJBQzjguZuHeHwq1cg1)_