### PR TITLE
fix(academy): don't hide Timeline/Style Gallery behind art-server load state

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -1,15 +1,44 @@
 <!-- /components/academy/academy-manager.vue -->
 <template>
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <!--
+      Timeline and Style Gallery render purely off academyStore's static seed
+      data (hydrated synchronously in onMounted below) — they never need
+      serverStore/artStore, so they must not be blocked by isLoadingManager /
+      managerError, which only reflect the Remix Studio / Style Lab art-server
+      fetch (see loadManagerData). Keeping these two branches first ensures a
+      failed or slow art-server call never hides tabs that don't depend on it.
+    -->
+    <section
+      v-if="activeTab === 'timeline'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <academy-timeline class="min-h-full w-full" @remix="goToRemix" />
+      </div>
+    </section>
+
+    <section
+      v-else-if="activeTab === 'styles'"
+      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+        <academy-styles-browser class="min-h-full w-full" @remix="goToRemix" />
+      </div>
+    </section>
+
     <div
-      v-if="isLoadingManager"
+      v-else-if="isLoadingManager"
       role="status"
       aria-live="polite"
       aria-busy="true"
       class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"
     >
       <div class="flex flex-col items-center gap-3 text-center">
-        <span class="loading loading-spinner loading-lg text-primary" aria-hidden="true" />
+        <span
+          class="loading loading-spinner loading-lg text-primary"
+          aria-hidden="true"
+        />
         <p class="text-sm text-base-content/70">
           Dusting off the timeline, warming up the remix engine, and politely
           waking twenty-five centuries of dead masters...
@@ -33,24 +62,6 @@
         </button>
       </div>
     </div>
-
-    <section
-      v-else-if="activeTab === 'timeline'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
-        <academy-timeline class="min-h-full w-full" @remix="goToRemix" />
-      </div>
-    </section>
-
-    <section
-      v-else-if="activeTab === 'styles'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
-        <academy-styles-browser class="min-h-full w-full" @remix="goToRemix" />
-      </div>
-    </section>
 
     <section
       v-else-if="activeTab === 'remix'"


### PR DESCRIPTION
### Task
conductor ai-art-academy/t-010 continuous-improvement pass (kind: software) — front-end polish lane.

### What changed / what I produced
- `components/academy/academy-manager.vue`: reordered the tab-rendering `v-if`/`v-else-if` chain so `activeTab === 'timeline'` and `activeTab === 'styles'` are checked *before* `isLoadingManager`/`managerError`, instead of after.
- Root cause: those two tabs render purely from `academyStore`'s static seed data (hydrated synchronously in `onMounted`) and never touch `serverStore`/`artStore`. But `isLoadingManager`/`managerError` only reflect `loadManagerData()`'s `Promise.all([serverStore.initialize(...), artStore.initialize(...)])` — data that only Remix Studio and Style Lab actually need (confirmed both use `artStore`/`serverStore` directly for image generation). If that call is slow or fails (no art server configured, a flaky fetch, a 500), the old ordering hid *all four* tabs behind a full-panel loading spinner or error banner, even though Timeline/Style Gallery work fine with zero network dependency.
- Remix Studio and Style Lab keep the exact same loading/error gating as before — this is a reordering, not a behavior change for those two tabs.

### How I verified
- `npm run test` (vue-tsc --noEmit) — exit 0, no new errors.
- `npx eslint components/academy/academy-manager.vue` — clean.
- `npx prettier --check` — clean after `--write` (only reformatted a pre-existing line, not part of the logic change).
- Read through `academy-timeline.vue`/`academy-styles-browser.vue` (only import `useAcademyStore`) and `art-styler.vue` (imports and uses both `useArtStore`/`useServerStore` directly for generation) to confirm the tab/store dependency split.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`loadManagerData()` still unconditionally fires on every Academy mount regardless of `activeTab`, even though it's now only needed for Remix/Style Lab — fine as a prefetch, but if it ever imposes a real cost (e.g. rate limits), it could be deferred until the user actually switches to one of those two tabs.

### Notes for reviewer
Filed under conductor's `ai-art-academy/t-010` (recurring continuous-improvement task, front-end polish lane). Root cause found via an Explore-agent sweep across all 5 Academy components plus art-styler/image-upload, checked against the project's own list of previously-fixed bug classes to avoid duplicates.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZGd5oGEkr4VdQF6v9z75b)_