### PR TITLE
fix(academy): scroll style detail panel into view on expand

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -43,6 +43,7 @@
     <div
       v-if="expandedStyle"
       :id="`academy-style-detail-${expandedStyle.slug}`"
+      ref="detailPanelRef"
     >
       <academy-style-detail
         :key="expandedStyle.slug"
@@ -124,6 +125,7 @@ import {
   onBeforeUnmount,
   onMounted,
   ref,
+  watch,
   type ComponentPublicInstance,
 } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
@@ -138,6 +140,21 @@ const academyStore = useAcademyStore()
 const searchQuery = ref('')
 const expandedSlug = ref<string | null>(null)
 const searchInputRef = ref<HTMLInputElement | null>(null)
+const detailPanelRef = ref<HTMLElement | null>(null)
+
+// The detail panel renders above the grid, so opening a style whose card sits
+// near the bottom of a long, scrolled grid pops the panel open off-screen —
+// the user sees no visible change and has to scroll up to find it. Bring it
+// into view whenever a style expands.
+watch(expandedSlug, (slug) => {
+  if (!slug) return
+  nextTick(() => {
+    detailPanelRef.value?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+    })
+  })
+})
 
 // The grid button stays mounted while its detail panel is open, but the
 // panel's own close button unmounts (v-if) the instant it's clicked — the


### PR DESCRIPTION
### Task
conductor ai-art-academy/t-010 (continuous-improvement pass, lane 1: front-end style/polish pass on Academy surfaces)

### What changed
`components/academy/academy-styles-browser.vue`'s detail panel renders above the grid. Expanding a style card near the bottom of a long, scrolled grid opened the panel off-screen — no visible change, and the user had to scroll up manually to find it. Added a `watch` on `expandedSlug` that scrolls the newly-opened panel into view (`scrollIntoView({ behavior: 'smooth', block: 'nearest' })`) via a new `detailPanelRef`.

### Verification
- `npx prettier --check components/academy/academy-styles-browser.vue` — clean.
- Full project `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — exit 0, zero TypeScript errors.
- Scoped, single-file, additive change (no existing behavior removed).

### Stakes
reversible

### Notes
Filed and self-merging under conductor task ai-art-academy/t-010 (recurring continuous-improvement task; re-arms to `ready` after this cycle).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8SyGUBKHNtt5gw84hMqHL)_