### PR TITLE
feat(stripe): extend webhook fulfillment to DLC products (Entitlement + Grant)

### DIFF
--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -309,20 +309,61 @@ async function handleProductPurchase(session: Stripe.Checkout.Session) {
         `POD product "${slug}"`,
       )
     } else {
-      await tx.entitlement.create({
+      const entitlement = await tx.entitlement.create({
         data: {
           userId,
           productId: product.id,
           orderItemId: item.id,
         },
       })
+
+      if (product.type === 'DLC') {
+        // DLC products carry the Pack they unlock in metadata (same
+        // JSON-in-metadata convention as the POD branch's artImageId/
+        // printfulVariantId). Grant.level uses VIEW, not the "UNLOCK" level
+        // digital-storefront/t-026's original note named — GrantLevel only
+        // defines VIEW/ADMIN (kind-robots/t-037's "flat first cut" schema)
+        // and server/utils/contentAccess.ts already gates Pack-owned content
+        // on an active PACK Grant at GrantLevel.VIEW, so VIEW is the level
+        // that actually unlocks the pack's content for this user.
+        let dlcMetadata: { packId?: unknown } = {}
+        try {
+          dlcMetadata = product.metadata ? JSON.parse(product.metadata) : {}
+        } catch (error) {
+          console.error(
+            `⚠️ Stripe webhook: unparseable metadata on DLC product "${slug}"`,
+            error,
+          )
+        }
+
+        const packId = Number(dlcMetadata.packId)
+        if (Number.isInteger(packId) && packId > 0) {
+          await tx.grant.create({
+            data: {
+              granteeId: userId,
+              subjectType: 'PACK',
+              subjectId: packId,
+              level: 'VIEW',
+              source: 'PURCHASE',
+              refId: entitlement.id,
+              status: 'ACTIVE',
+            },
+          })
+        } else {
+          console.error(
+            `⚠️ Stripe webhook: DLC product "${slug}" missing/invalid packId metadata, skipping Grant creation`,
+          )
+        }
+      }
     }
   })
 
   console.log(
     product.type === 'POD'
       ? `🖨️ Created PrintJob for product "${slug}" (user ${userId}, session ${session.id})`
-      : `🎟️ Granted entitlement for product "${slug}" to user ${userId} (session ${session.id})`,
+      : product.type === 'DLC'
+        ? `🎟️📦 Granted entitlement + Pack unlock for product "${slug}" to user ${userId} (session ${session.id})`
+        : `🎟️ Granted entitlement for product "${slug}" to user ${userId} (session ${session.id})`,
   )
 }
 


### PR DESCRIPTION
### Task
digital-storefront/t-026: extend Stripe webhook fulfillment to DLC products (Entitlement + Grant) (kind: software)

### What changed / what I produced
- `server/api/stripe/webhook.post.ts`'s `handleProductPurchase` (the single-product-per-session `checkout.session.completed` branch) now also handles `Product.type = 'DLC'`: alongside the existing `Entitlement` row, it reads `packId` from the product's JSON `metadata` (same convention the POD branch already uses for `artImageId`/`printfulVariantId`) and creates a `Grant` row — `subjectType: PACK`, `subjectId: <packId>`, `level: VIEW`, `source: PURCHASE`, `refId: <entitlement.id>`, `status: ACTIVE`.
- Both writes happen inside the existing `prisma.$transaction` alongside the `Order`/`OrderItem` creation, so a DLC purchase's Entitlement + Grant land atomically with the Order record.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean, 0 errors.
- `npx eslint server/api/stripe/webhook.post.ts` — clean.
- `npx prettier --check server/api/stripe/webhook.post.ts` — clean.
- No live DB in this sandbox, so no integration test against a real Stripe session — same documented sandbox limitation as other recent digital-storefront/ai-art-academy cross-repo PRs.

### Stakes
outward-facing (real purchase-fulfillment logic touching Entitlement/Grant; `gate_human: true` on the conductor task)

### Flags for Reviewer
- **Level discrepancy**: the originating task note (digital-storefront/t-026, filed 2026-07-18) said `level: UNLOCK`, but `GrantLevel` only defines `VIEW`/`ADMIN` (kind-robots/t-037's "flat first cut" schema, approved 2026-07-25/26). `server/utils/contentAccess.ts` already gates Pack-owned content on an active `PACK` Grant at `GrantLevel.VIEW`, so I used `VIEW` — that's the level that actually unlocks the pack's content under the schema as built. Flagging in case Silas wants a distinct `UNLOCK` level added instead.
- **Unexercised until a companion piece lands**: no checkout-creation route yet produces a `DLC`-type `Product` with `packId` metadata — the packmaker admin generator (packmaker/t-004) builds `Pack` content bundles but not a purchasable `Product`/price wired to one. This PR is the fulfillment half only; a product-page/checkout-creation piece (parallel to digital-storefront/t-023's Mermaids PDF page) still needs to exist before a real DLC purchase can reach this code path.
- Scope: only `handleProductPurchase` (one Product per session via `metadata.productSlug`) was extended. The multi-item giftshop cart path (`handleGiftshopCartPurchase`) has no DLC entry in its `GIFTSHOP_TYPE_TO_PRODUCT_TYPE` map and was left untouched — out of this task's stated scope.
- Per `gate_human: true` on the conductor task, this PR is **not** self-merged — it's left open for Silas per the standing rule for real purchase-fulfillment logic, TEST MODE ONLY, no live Stripe keys touched.

### Kaizen suggestion
A follow-up task to build the DLC Product-creation path (packmaker admin panel → `Product` row with `type: DLC` and `metadata: { packId }`) would let this fulfillment logic actually be exercised end-to-end in test mode.

### Notes for reviewer
Conductor task: digital-storefront/t-026 (left at `needs-human` per `gate_human: true`, real purchase-fulfillment logic)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G43S9MU8EZnSw1SpZgpzoC)_