### PR TITLE
Keep Daily Dream and Reward Facet requests behind Pinia stores

### DIFF
--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -127,33 +127,17 @@
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import { ref } from 'vue'
-import { performFetch } from '@/stores/utils'
+import { useDailyDreamStore } from '@/stores/dailyDreamStore'
 import type { DreamWithRelations } from '@/stores/dreamStore'
 
-type Blueprint = {
-  title: string
-  pitch: string
-  characters: Array<{
-    name: string
-    species: string
-    characterClass: string
-    alignment: string
-  }>
-  rewards: Array<{ name: string; rarity: string }>
-}
-
-type DailyDreamResponse = {
-  dream: DreamWithRelations
-  blueprint: Blueprint
-  reused: boolean
-}
-
 const emit = defineEmits<{ created: [dream: DreamWithRelations] }>()
-const loading = ref(false)
+const dailyDreamStore = useDailyDreamStore()
+const { isCreating: loading, lastBlueprint: blueprint } =
+  storeToRefs(dailyDreamStore)
 const message = ref('')
 const error = ref(false)
-const blueprint = ref<Blueprint | null>(null)
 const characterCount = ref(2)
 const rewardCount = ref(2)
 const today = new Date()
@@ -164,33 +148,25 @@ const dateKey = [
 ].join('-')
 
 async function createDailyDream(): Promise<void> {
-  loading.value = true
   message.value = ''
   error.value = false
-  try {
-    const response = await performFetch<DailyDreamResponse>('/api/dreams/daily', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        dateKey,
-        characterCount: characterCount.value,
-        rewardCount: rewardCount.value,
-        isPublic: false,
-        isMature: false,
-      }),
-    })
-    if (!response.success || !response.data) {
-      throw new Error(response.message || 'Daily Dream could not be created.')
-    }
-    blueprint.value = response.data.blueprint
-    message.value = response.message || 'Daily Dream ready.'
-    emit('created', response.data.dream)
-  } catch (cause) {
+  dailyDreamStore.clearDailyDream()
+
+  const result = await dailyDreamStore.createDailyDream({
+    dateKey,
+    characterCount: characterCount.value,
+    rewardCount: rewardCount.value,
+    isPublic: false,
+    isMature: false,
+  })
+
+  if (!result.success || !result.data) {
     error.value = true
-    message.value =
-      cause instanceof Error ? cause.message : 'Daily Dream could not be created.'
-  } finally {
-    loading.value = false
+    message.value = result.message || 'Daily Dream could not be created.'
+    return
   }
+
+  message.value = result.message || 'Daily Dream ready.'
+  emit('created', result.data.dream)
 }
 </script>

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -102,11 +102,11 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { performFetch } from '@/stores/utils'
 import {
   useFacetStore,
   type FacetWithAliases,
 } from '@/stores/facetStore'
+import { useRewardFacetStore } from '@/stores/rewardFacetStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 
 const props = withDefaults(
@@ -119,12 +119,15 @@ const props = withDefaults(
 
 const emit = defineEmits<{ 'update:modelValue': [value: number[]] }>()
 const facetStore = useFacetStore()
-const loading = ref(false)
-const saving = ref(false)
+const rewardFacetStore = useRewardFacetStore()
 const search = ref('')
 const showResults = ref(false)
 const errorMessage = ref('')
 
+const loading = computed(() =>
+  rewardFacetStore.isLoadingReward(props.rewardId),
+)
+const saving = computed(() => rewardFacetStore.isSavingReward(props.rewardId))
 const selectedIds = computed(() => new Set(props.modelValue))
 const selectedFacets = computed(() =>
   props.modelValue
@@ -156,53 +159,37 @@ function artwork(facet: FacetWithAliases): string | null {
 
 async function loadAssigned(): Promise<void> {
   if (!props.rewardId || props.rewardId <= 0) return
-  loading.value = true
   errorMessage.value = ''
-  try {
-    const response = await performFetch<FacetWithAliases[]>(
-      `/api/rewards/${props.rewardId}/facets`,
-    )
-    if (!response.success) {
-      throw new Error(response.message || 'Reward Facets could not be loaded.')
-    }
-    const facets = response.data ?? []
-    for (const facet of facets) {
-      const index = facetStore.facets.findIndex((entry) => entry.id === facet.id)
-      if (index >= 0) facetStore.facets[index] = facet
-      else facetStore.facets.push(facet)
-    }
-    emit('update:modelValue', facets.map((facet) => facet.id))
-  } catch (cause) {
-    errorMessage.value =
-      cause instanceof Error ? cause.message : 'Reward Facets could not be loaded.'
-  } finally {
-    loading.value = false
+
+  const result = await rewardFacetStore.fetchRewardFacets(props.rewardId)
+  if (!result.success || !result.data) {
+    errorMessage.value = result.message || 'Reward Facets could not be loaded.'
+    return
   }
+
+  emit(
+    'update:modelValue',
+    result.data.map((facet) => facet.id),
+  )
 }
 
 async function persist(next: number[]): Promise<void> {
+  const previous = [...props.modelValue]
   emit('update:modelValue', next)
   if (!props.rewardId || props.rewardId <= 0) return
-  saving.value = true
   errorMessage.value = ''
-  try {
-    const response = await performFetch<FacetWithAliases[]>(
-      `/api/rewards/${props.rewardId}/facets`,
-      {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ facetIds: next }),
-      },
-    )
-    if (!response.success) {
-      throw new Error(response.message || 'Reward Facets could not be saved.')
-    }
-  } catch (cause) {
-    errorMessage.value =
-      cause instanceof Error ? cause.message : 'Reward Facets could not be saved.'
-  } finally {
-    saving.value = false
+
+  const result = await rewardFacetStore.replaceRewardFacets(props.rewardId, next)
+  if (!result.success || !result.data) {
+    emit('update:modelValue', previous)
+    errorMessage.value = result.message || 'Reward Facets could not be saved.'
+    return
   }
+
+  emit(
+    'update:modelValue',
+    result.data.map((facet) => facet.id),
+  )
 }
 
 async function addFacet(facetId: number): Promise<void> {

--- a/stores/dailyDreamStore.ts
+++ b/stores/dailyDreamStore.ts
@@ -1,0 +1,102 @@
+// /stores/dailyDreamStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { handleError, performFetch } from '@/stores/utils'
+import type { DreamWithRelations } from '@/stores/dreamStore'
+
+export type DailyDreamBlueprint = {
+  title: string
+  pitch: string
+  characters: Array<{
+    name: string
+    species: string
+    characterClass: string
+    alignment: string
+  }>
+  rewards: Array<{
+    name: string
+    rarity: string
+  }>
+}
+
+export type DailyDreamRequest = {
+  dateKey: string
+  characterCount: number
+  rewardCount: number
+  isPublic: boolean
+  isMature: boolean
+}
+
+export type DailyDreamResponse = {
+  dream: DreamWithRelations
+  blueprint: DailyDreamBlueprint
+  reused: boolean
+}
+
+export type DailyDreamResult = {
+  success: boolean
+  data?: DailyDreamResponse
+  message?: string
+}
+
+export const useDailyDreamStore = defineStore('dailyDreamStore', () => {
+  const isCreating = ref(false)
+  const error = ref<string | null>(null)
+  const lastBlueprint = ref<DailyDreamBlueprint | null>(null)
+  const lastDream = ref<DreamWithRelations | null>(null)
+  const lastReused = ref(false)
+
+  async function createDailyDream(
+    request: DailyDreamRequest,
+  ): Promise<DailyDreamResult> {
+    isCreating.value = true
+    error.value = null
+
+    try {
+      const response = await performFetch<DailyDreamResponse>('/api/dreams/daily', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Daily Dream could not be created.')
+      }
+
+      lastBlueprint.value = response.data.blueprint
+      lastDream.value = response.data.dream
+      lastReused.value = response.data.reused
+
+      return {
+        success: true,
+        data: response.data,
+        message: response.message || 'Daily Dream ready.',
+      }
+    } catch (cause) {
+      const message =
+        cause instanceof Error ? cause.message : 'Daily Dream could not be created.'
+      error.value = message
+      handleError(cause, 'creating daily Facet Dream')
+      return { success: false, message }
+    } finally {
+      isCreating.value = false
+    }
+  }
+
+  function clearDailyDream(): void {
+    error.value = null
+    lastBlueprint.value = null
+    lastDream.value = null
+    lastReused.value = false
+  }
+
+  return {
+    isCreating,
+    error,
+    lastBlueprint,
+    lastDream,
+    lastReused,
+    createDailyDream,
+    clearDailyDream,
+  }
+})

--- a/stores/rewardFacetStore.ts
+++ b/stores/rewardFacetStore.ts
@@ -1,0 +1,146 @@
+// /stores/rewardFacetStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { handleError, performFetch } from '@/stores/utils'
+import {
+  useFacetStore,
+  type FacetWithAliases,
+} from '@/stores/facetStore'
+
+export type RewardFacetResult = {
+  success: boolean
+  data?: FacetWithAliases[]
+  message?: string
+}
+
+function normalizeRewardId(value: unknown): number | null {
+  const id = Number(value)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+function normalizeFacetIds(values: number[]): number[] {
+  return Array.from(
+    new Set(values.map(Number).filter((id) => Number.isInteger(id) && id > 0)),
+  )
+}
+
+export const useRewardFacetStore = defineStore('rewardFacetStore', () => {
+  const facetStore = useFacetStore()
+  const assignmentsByRewardId = ref<Record<number, number[]>>({})
+  const loadingByRewardId = ref<Record<number, boolean>>({})
+  const savingByRewardId = ref<Record<number, boolean>>({})
+  const errorsByRewardId = ref<Record<number, string>>({})
+
+  function mergeFacets(facets: FacetWithAliases[]): void {
+    for (const facet of facets) {
+      const index = facetStore.facets.findIndex((entry) => entry.id === facet.id)
+      if (index >= 0) facetStore.facets[index] = facet
+      else facetStore.facets.push(facet)
+    }
+  }
+
+  function isLoadingReward(rewardId?: number | null): boolean {
+    const id = normalizeRewardId(rewardId)
+    return id ? Boolean(loadingByRewardId.value[id]) : false
+  }
+
+  function isSavingReward(rewardId?: number | null): boolean {
+    const id = normalizeRewardId(rewardId)
+    return id ? Boolean(savingByRewardId.value[id]) : false
+  }
+
+  function errorForReward(rewardId?: number | null): string {
+    const id = normalizeRewardId(rewardId)
+    return id ? errorsByRewardId.value[id] || '' : ''
+  }
+
+  async function fetchRewardFacets(rewardId: number): Promise<RewardFacetResult> {
+    const id = normalizeRewardId(rewardId)
+    if (!id) return { success: false, message: 'Invalid Reward ID.' }
+
+    loadingByRewardId.value[id] = true
+    errorsByRewardId.value[id] = ''
+
+    try {
+      const response = await performFetch<FacetWithAliases[]>(
+        `/api/rewards/${id}/facets`,
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Reward Facets could not be loaded.')
+      }
+
+      mergeFacets(response.data)
+      assignmentsByRewardId.value[id] = response.data.map((facet) => facet.id)
+
+      return {
+        success: true,
+        data: response.data,
+        message: response.message || 'Reward Facets loaded.',
+      }
+    } catch (cause) {
+      const message =
+        cause instanceof Error ? cause.message : 'Reward Facets could not be loaded.'
+      errorsByRewardId.value[id] = message
+      handleError(cause, `loading Facets for Reward ${id}`)
+      return { success: false, message }
+    } finally {
+      loadingByRewardId.value[id] = false
+    }
+  }
+
+  async function replaceRewardFacets(
+    rewardId: number,
+    facetIds: number[],
+  ): Promise<RewardFacetResult> {
+    const id = normalizeRewardId(rewardId)
+    if (!id) return { success: false, message: 'Invalid Reward ID.' }
+
+    savingByRewardId.value[id] = true
+    errorsByRewardId.value[id] = ''
+
+    try {
+      const response = await performFetch<FacetWithAliases[]>(
+        `/api/rewards/${id}/facets`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ facetIds: normalizeFacetIds(facetIds) }),
+        },
+      )
+
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Reward Facets could not be saved.')
+      }
+
+      mergeFacets(response.data)
+      assignmentsByRewardId.value[id] = response.data.map((facet) => facet.id)
+
+      return {
+        success: true,
+        data: response.data,
+        message: response.message || 'Reward Facets updated.',
+      }
+    } catch (cause) {
+      const message =
+        cause instanceof Error ? cause.message : 'Reward Facets could not be saved.'
+      errorsByRewardId.value[id] = message
+      handleError(cause, `saving Facets for Reward ${id}`)
+      return { success: false, message }
+    } finally {
+      savingByRewardId.value[id] = false
+    }
+  }
+
+  return {
+    assignmentsByRewardId,
+    loadingByRewardId,
+    savingByRewardId,
+    errorsByRewardId,
+    isLoadingReward,
+    isSavingReward,
+    errorForReward,
+    fetchRewardFacets,
+    replaceRewardFacets,
+  }
+})

--- a/utils/scripts/verifyDailyDreamFacets.ts
+++ b/utils/scripts/verifyDailyDreamFacets.ts
@@ -14,6 +14,12 @@ function requireText(path: string, text: string, value: string): void {
   }
 }
 
+function forbidText(path: string, text: string, value: string): void {
+  if (text.includes(value)) {
+    throw new Error(`${path} contains forbidden component request text: ${value}`)
+  }
+}
+
 async function main(): Promise<void> {
   const files = {
     schema: 'prisma/facet-catalog.prisma',
@@ -21,11 +27,13 @@ async function main(): Promise<void> {
       'prisma/migrations/20260726061000_reward_facet_daily_dream/migration.sql',
     blueprint: 'server/utils/dailyDreamFacetBlueprint.ts',
     endpoint: 'server/api/dreams/daily.post.ts',
+    dailyStore: 'stores/dailyDreamStore.ts',
     generator: 'components/dreams/daily-dream-generator.vue',
     dreamManager: 'components/dreams/dream-manager.vue',
     rewardHelper: 'server/utils/rewardFacetCatalog.ts',
     rewardGet: 'server/api/rewards/[id]/facets.get.ts',
     rewardPut: 'server/api/rewards/[id]/facets.put.ts',
+    rewardFacetStore: 'stores/rewardFacetStore.ts',
     rewardPicker: 'components/rewards/reward-facet-picker.vue',
     rewardManager: 'components/rewards/reward-manager.vue',
     rewardMerge: 'utils/scripts/mergeRewardFacetDuplicateLinks.ts',
@@ -66,9 +74,16 @@ async function main(): Promise<void> {
   requireText(files.endpoint, text.endpoint, 'PrismaClientKnownRequestError')
   requireText(files.endpoint, text.endpoint, 'reused: true')
 
-  requireText(files.generator, text.generator, '/api/dreams/daily')
+  requireText(files.dailyStore, text.dailyStore, 'defineStore')
+  requireText(files.dailyStore, text.dailyStore, "'/api/dreams/daily'")
+  requireText(files.dailyStore, text.dailyStore, 'performFetch<DailyDreamResponse>')
+  requireText(files.dailyStore, text.dailyStore, 'lastBlueprint.value')
+  requireText(files.generator, text.generator, 'useDailyDreamStore')
+  requireText(files.generator, text.generator, 'dailyDreamStore.createDailyDream')
   requireText(files.generator, text.generator, 'characterCount')
   requireText(files.generator, text.generator, 'rewardCount')
+  forbidText(files.generator, text.generator, '/api/dreams/daily')
+  forbidText(files.generator, text.generator, 'performFetch')
   requireText(
     files.dreamManager,
     text.dreamManager,
@@ -81,7 +96,27 @@ async function main(): Promise<void> {
   requireText(files.rewardPut, text.rewardPut, 'tx.rewardFacet.deleteMany')
   requireText(files.rewardPut, text.rewardPut, 'tx.rewardFacet.createMany')
   requireText(files.rewardPut, text.rewardPut, 'rewardFacetFieldKey(facet.taxonomy)')
-  requireText(files.rewardPicker, text.rewardPicker, '/api/rewards/${props.rewardId}/facets')
+  requireText(files.rewardFacetStore, text.rewardFacetStore, 'useFacetStore')
+  requireText(files.rewardFacetStore, text.rewardFacetStore, 'fetchRewardFacets')
+  requireText(files.rewardFacetStore, text.rewardFacetStore, 'replaceRewardFacets')
+  requireText(
+    files.rewardFacetStore,
+    text.rewardFacetStore,
+    '`/api/rewards/${id}/facets`',
+  )
+  requireText(files.rewardPicker, text.rewardPicker, 'useRewardFacetStore')
+  requireText(
+    files.rewardPicker,
+    text.rewardPicker,
+    'rewardFacetStore.fetchRewardFacets',
+  )
+  requireText(
+    files.rewardPicker,
+    text.rewardPicker,
+    'rewardFacetStore.replaceRewardFacets',
+  )
+  forbidText(files.rewardPicker, text.rewardPicker, '/api/rewards/')
+  forbidText(files.rewardPicker, text.rewardPicker, 'performFetch')
   requireText(files.rewardManager, text.rewardManager, 'reward-facet-picker')
   requireText(files.rewardManager, text.rewardManager, 'rewardFacetIds')
 


### PR DESCRIPTION
## Facet handoff cleanup

The merged Facet work completed the canonical catalog, Daily Dream graph, RewardFacet APIs, and advanced Library surface, but two newly added components still called API routes directly.

## Change

- adds `dailyDreamStore` as the owner of `/api/dreams/daily` requests and response state
- adds `rewardFacetStore` as the owner of Reward Facet reads/replacements and catalog merging
- makes `daily-dream-generator.vue` call the Daily Dream store only
- makes `reward-facet-picker.vue` call the Reward Facet store only
- rolls the picker back to its previous exact set when persistence fails
- extends the Daily Dream Facet contract to forbid direct API requests from both components

## Why

This restores the project boundary: components render and dispatch actions; Pinia stores own API interaction and shared state. It also makes Facet request behavior reusable outside these two components.

## Scope

No schema, migration, route, seed, catalog, or generated Prisma changes. The existing endpoint behavior and exact-set semantics remain unchanged.

## Verification

The branch is based on current `main` and the contract now explicitly checks the new store ownership. GitHub CI should run the Daily Dream Facet contract, TypeScript check, and the existing project contract suite.