### PR TITLE
Make Scenario Genre use canonical Facets

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -49,6 +49,9 @@ jobs:
           npx tsx utils/scripts/verifyDreamRandomCompatibility.ts
           npx tsx utils/scripts/verifyFacetLibraryAdvanced.ts
 
+      - name: Verify Scenario Genre Facet cutover
+        run: npx tsx utils/scripts/verifyScenarioGenreFacetCutover.ts
+
       - name: Verify illustrated Builder Facet coverage
         id: builder-coverage
         continue-on-error: true

--- a/plugins/20.facet-catalog.client.ts
+++ b/plugins/20.facet-catalog.client.ts
@@ -52,9 +52,6 @@ function hydrateBuilderCards(
           ]
         : []
 
-      // Rich Facets with art remain the primary gallery. Canonical entries that
-      // do not have artwork stay in the compact “More options” division. Custom
-      // entry remains available for one-off prose that should not become a Facet.
       step.choices = [...visualChoices, ...moreChoice, ...controls]
       step.listOptions = listChoices.map((choice) => choice.value)
       step.payload = {
@@ -67,6 +64,18 @@ function hydrateBuilderCards(
   }
 }
 
+function hydrateAdventureBuilder(
+  catalog: ReturnType<typeof useFacetCatalogStore>,
+): void {
+  hydrateBuilderCards(ADVENTURE_CARDS, catalog)
+}
+
+function hydrateScenarioBuilder(
+  catalog: ReturnType<typeof useFacetCatalogStore>,
+): void {
+  hydrateBuilderCards(SCENARIO_CARDS, catalog)
+}
+
 export default defineNuxtPlugin(async () => {
   const catalog = useFacetCatalogStore()
 
@@ -74,8 +83,8 @@ export default defineNuxtPlugin(async () => {
     await catalog.fetchCatalog({ includeMature: true, take: 1000 }, true)
     if (!catalog.entries.length) return
 
-    hydrateBuilderCards(ADVENTURE_CARDS, catalog)
-    hydrateBuilderCards(SCENARIO_CARDS, catalog)
+    hydrateAdventureBuilder(catalog)
+    hydrateScenarioBuilder(catalog)
 
     // Registration stores the same mutable card graphs. Re-register after the
     // async catalog fetch so mounted Builders observe canonical choices immediately.

--- a/plugins/20.facet-catalog.client.ts
+++ b/plugins/20.facet-catalog.client.ts
@@ -1,24 +1,31 @@
 // /plugins/20.facet-catalog.client.ts
 import { defineNuxtPlugin } from '#app'
 import { ADVENTURE_CARDS } from '@/stores/helpers/adventureCards'
-import type { BuilderChoice } from '@/stores/helpers/builderCards'
+import type {
+  BuilderCard,
+  BuilderChoice,
+  BuilderStep,
+} from '@/stores/helpers/builderCards'
+import { SCENARIO_CARDS } from '@/stores/helpers/scenarioCards'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
 import {
   CHARACTER_FIELD_TAXONOMIES,
   useFacetCatalogStore,
 } from '@/stores/facetCatalogStore'
 
-function fieldKeyForStep(cardKey: string, step: { field?: string; key: string }) {
+function facetFieldKey(cardKey: string, step: BuilderStep): string | null {
   const key = step.field || step.key || cardKey
+  if (key === 'genres') return 'genre'
   return CHARACTER_FIELD_TAXONOMIES[key] ? key : null
 }
 
-function hydrateAdventureBuilder(
+function hydrateBuilderCards(
+  cards: BuilderCard[],
   catalog: ReturnType<typeof useFacetCatalogStore>,
 ): void {
-  for (const card of ADVENTURE_CARDS) {
+  for (const card of cards) {
     for (const step of card.steps) {
-      const fieldKey = fieldKeyForStep(card.key, step)
+      const fieldKey = facetFieldKey(card.key, step)
       if (!fieldKey) continue
 
       const canonical = catalog.builderChoicesForField(fieldKey)
@@ -67,12 +74,12 @@ export default defineNuxtPlugin(async () => {
     await catalog.fetchCatalog({ includeMature: true, take: 1000 }, true)
     if (!catalog.entries.length) return
 
-    hydrateAdventureBuilder(catalog)
+    hydrateBuilderCards(ADVENTURE_CARDS, catalog)
+    hydrateBuilderCards(SCENARIO_CARDS, catalog)
 
-    // Registration stores the same mutable card graph. Re-register after the
-    // async catalog fetch so an already-mounted Character Builder observes the
-    // canonical choices immediately. Generator methods read this same catalog
-    // directly and need no runtime reassignment.
+    // Registration stores the same mutable card graphs. Re-register after the
+    // async catalog fetch so mounted Builders observe canonical choices immediately.
+    // Generator methods read this same catalog directly and need no reassignment.
     ensureBuildersRegistered(true)
   } catch (error) {
     console.error('[facet-catalog] Canonical Facet hydration failed.', error)

--- a/scripts/lib/facetCatalogSeedPolicy.mjs
+++ b/scripts/lib/facetCatalogSeedPolicy.mjs
@@ -21,6 +21,7 @@ const FACET_CATALOG_SOURCE_FILES = new Set([
   'utils/seeds/facetGenderValues.ts',
   'utils/seeds/facetLegacyCharacterLists.ts',
   'utils/seeds/facetLegacyCreativeLists.ts',
+  'utils/seeds/facetScenarioGenreArtwork.ts',
   'utils/scripts/runFacetCatalogSeed.ts',
   'utils/scripts/seedFacetCatalog.ts',
   'utils/scripts/seedGenderFacetCatalog.ts',

--- a/scripts/lib/facetCatalogSeedPolicy.mjs
+++ b/scripts/lib/facetCatalogSeedPolicy.mjs
@@ -6,6 +6,7 @@ const FACET_CATALOG_SOURCE_FILES = new Set([
   'prisma/facet-catalog.prisma',
   'prisma/schema.prisma',
   'stores/helpers/adventureCards.ts',
+  'stores/helpers/scenarioCards.ts',
   'stores/seeds/artList.ts',
   'stores/utils/animalData.ts',
   'stores/utils/randomBackstory.ts',
@@ -23,6 +24,7 @@ const FACET_CATALOG_SOURCE_FILES = new Set([
   'utils/scripts/runFacetCatalogSeed.ts',
   'utils/scripts/seedFacetCatalog.ts',
   'utils/scripts/seedGenderFacetCatalog.ts',
+  'utils/scripts/seedScenarioGenreFacetCatalog.ts',
 ])
 
 const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on'])
@@ -31,8 +33,6 @@ export function isFacetCatalogSourcePath(filePath) {
   const normalized = String(filePath ?? '').trim().replaceAll('\\', '/')
   if (!normalized) return false
   if (FACET_CATALOG_SOURCE_FILES.has(normalized)) return true
-  // A new database migration can change catalog constraints or data semantics;
-  // reseeding is the safe default even when the migration name is unfamiliar.
   return normalized.startsWith('prisma/migrations/')
 }
 
@@ -49,15 +49,12 @@ export function decideFacetCatalogSeed({
       reason: 'non-Vercel build preserves explicit local seed behavior',
     }
   }
-
   if (!isProductionDeployment) {
     return { run: false, reason: 'non-production Vercel deployment' }
   }
-
   if (TRUE_VALUES.has(String(forceValue ?? '').trim().toLowerCase())) {
     return { run: true, reason: 'FACET_CATALOG_SEED_ON_BUILD forced the seed' }
   }
-
   if (diffError) {
     return {
       run: true,
@@ -74,9 +71,6 @@ export function decideFacetCatalogSeed({
     }
   }
 
-  // mergeCanonicalFacetDuplicates.ts runs as its own production-build step after
-  // this decision. A merge-only code change therefore does not need to rewrite
-  // all source-backed Facets before exercising the updated merger.
   return {
     run: false,
     reason: 'no canonical Facet source, schema, or migration changed',
@@ -89,19 +83,13 @@ export function readVercelChangedFiles(env = process.env) {
   const currentSha = env.VERCEL_GIT_COMMIT_SHA?.trim()
 
   if (!previousSha || !currentSha) {
-    return {
-      changedFiles: [],
-      diffError: 'missing Vercel commit ancestry',
-    }
+    return { changedFiles: [], diffError: 'missing Vercel commit ancestry' }
   }
 
   const diff = spawnSync(
     'git',
     ['diff', '--name-only', '--diff-filter=ACMRTUXB', previousSha, currentSha],
-    {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
   )
 
   if (diff.status !== 0) {

--- a/server/api/scenarios/[id].patch.ts
+++ b/server/api/scenarios/[id].patch.ts
@@ -25,6 +25,7 @@ export default defineEventHandler(async (event) => {
         message: 'Invalid scenario ID. It must be a positive integer.',
       })
     }
+    const scenarioId = id
 
     const { isValid, user } = await validateApiKey(event)
 
@@ -36,7 +37,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const existingScenario = await prisma.scenario.findUnique({
-      where: { id },
+      where: { id: scenarioId },
       select: {
         id: true,
         userId: true,
@@ -65,7 +66,7 @@ export default defineEventHandler(async (event) => {
       context: 'Scenario patch payload',
       requireNonEmpty: true,
       authenticatedUserId: user.id,
-      routeId: id,
+      routeId: scenarioId,
     })
 
     await assertScenarioRelationsAttachable(body, user.id, isAdmin)
@@ -81,7 +82,7 @@ export default defineEventHandler(async (event) => {
 
     const updatedScenario = await prisma.$transaction(async (tx) => {
       const scenario = await tx.scenario.update({
-        where: { id },
+        where: { id: scenarioId },
         data,
         select: scenarioMutationSelect,
       })

--- a/server/api/scenarios/[id].patch.ts
+++ b/server/api/scenarios/[id].patch.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { userIsAdmin } from '../../utils/authUser'
+import { syncScenarioGenreFacetsInTransaction } from '../../utils/scenarioGenreFacetSync'
 import {
   assertScenarioMutationInput,
   assertScenarioRelationsAttachable,
@@ -49,7 +50,8 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (existingScenario.userId !== user.id && !userIsAdmin(user)) {
+    const isAdmin = userIsAdmin(user)
+    if (existingScenario.userId !== user.id && !isAdmin) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to update this scenario.',
@@ -66,7 +68,7 @@ export default defineEventHandler(async (event) => {
       routeId: id,
     })
 
-    await assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))
+    await assertScenarioRelationsAttachable(body, user.id, isAdmin)
 
     const data = await buildScenarioUpdateInput(body)
 
@@ -77,10 +79,19 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const updatedScenario = await prisma.scenario.update({
-      where: { id },
-      data,
-      select: scenarioMutationSelect,
+    const updatedScenario = await prisma.$transaction(async (tx) => {
+      const scenario = await tx.scenario.update({
+        where: { id },
+        data,
+        select: scenarioMutationSelect,
+      })
+      if ('genres' in data) {
+        await syncScenarioGenreFacetsInTransaction(tx, scenario, {
+          userId: user.id,
+          isAdmin,
+        })
+      }
+      return scenario
     })
 
     event.node.res.statusCode = 200

--- a/server/api/scenarios/batch.patch.ts
+++ b/server/api/scenarios/batch.patch.ts
@@ -8,6 +8,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { userIsAdmin } from '../../utils/authUser'
+import { syncScenarioGenreFacetsInTransaction } from '../../utils/scenarioGenreFacetSync'
 import {
   assertScenarioMutationInput,
   assertScenarioRelationsAttachable,
@@ -54,12 +55,6 @@ async function processEntry(
 
     id = candidateId
 
-    // Unlike the singular PATCH route, batch entries carry their own routing
-    // id in the body (there's no per-item URL). assertScenarioMutationInput's
-    // id handling rejects a bare `id` field unless told what it's allowed to
-    // match against, so pass the id we just validated as `routeId` -- this
-    // is the same "id must match the route" contract as [id].patch.ts, just
-    // with the entry itself acting as its own route.
     assertScenarioMutationInput(rawEntry, {
       allowedFields: scenarioBatchPatchFields,
       context: `Scenario batch update item ${index}`,
@@ -84,7 +79,8 @@ async function processEntry(
       })
     }
 
-    if (existingScenario.userId !== user.id && !userIsAdmin(user)) {
+    const isAdmin = userIsAdmin(user)
+    if (existingScenario.userId !== user.id && !isAdmin) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to update this scenario.',
@@ -101,7 +97,7 @@ async function processEntry(
       })
     }
 
-    await assertScenarioRelationsAttachable(fields, user.id, userIsAdmin(user))
+    await assertScenarioRelationsAttachable(fields, user.id, isAdmin)
 
     const data = await buildScenarioUpdateInput(fields)
 
@@ -112,10 +108,19 @@ async function processEntry(
       })
     }
 
-    const updatedScenario = await prisma.scenario.update({
-      where: { id },
-      data,
-      select: scenarioMutationSelect,
+    const updatedScenario = await prisma.$transaction(async (tx) => {
+      const scenario = await tx.scenario.update({
+        where: { id },
+        data,
+        select: scenarioMutationSelect,
+      })
+      if ('genres' in data) {
+        await syncScenarioGenreFacetsInTransaction(tx, scenario, {
+          userId: user.id,
+          isAdmin,
+        })
+      }
+      return scenario
     })
 
     return {

--- a/server/api/scenarios/batch.patch.ts
+++ b/server/api/scenarios/batch.patch.ts
@@ -59,13 +59,13 @@ async function processEntry(
       allowedFields: scenarioBatchPatchFields,
       context: `Scenario batch update item ${index}`,
       requireNonEmpty: true,
-      routeId: id,
+      routeId: candidateId,
     })
 
     const entry = rawEntry as ScenarioBatchEntry
 
     const existingScenario = await prisma.scenario.findUnique({
-      where: { id },
+      where: { id: candidateId },
       select: {
         id: true,
         userId: true,
@@ -110,7 +110,7 @@ async function processEntry(
 
     const updatedScenario = await prisma.$transaction(async (tx) => {
       const scenario = await tx.scenario.update({
-        where: { id },
+        where: { id: candidateId },
         data,
         select: scenarioMutationSelect,
       })
@@ -124,7 +124,7 @@ async function processEntry(
     })
 
     return {
-      id,
+      id: candidateId,
       success: true,
       message: 'Scenario updated successfully.',
       statusCode: 200,

--- a/server/api/scenarios/batch.post.ts
+++ b/server/api/scenarios/batch.post.ts
@@ -4,6 +4,7 @@ import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
 import { userIsAdmin } from '@/server/utils/authUser'
+import { syncScenarioGenreFacetsInTransaction } from '@/server/utils/scenarioGenreFacetSync'
 import {
   buildScenarioCreateInput,
   fallbackScenarioTitle,
@@ -53,6 +54,7 @@ export default defineEventHandler(async (event) => {
     const created: ScenarioMutationResult[] = []
     const skipped: SkippedScenario[] = []
     const failed: FailedScenario[] = []
+    const isAdmin = userIsAdmin(user)
 
     for (const rawScenarioData of body) {
       const scenarioData = rawScenarioData as ScenarioPostInput
@@ -62,7 +64,7 @@ export default defineEventHandler(async (event) => {
         await assertScenarioRelationsAttachable(
           scenarioData,
           user.id,
-          userIsAdmin(user),
+          isAdmin,
         )
 
         const createInput = await buildScenarioCreateInput(
@@ -84,9 +86,16 @@ export default defineEventHandler(async (event) => {
           continue
         }
 
-        const createdScenario = await prisma.scenario.create({
-          data: createInput,
-          select: scenarioMutationSelect,
+        const createdScenario = await prisma.$transaction(async (tx) => {
+          const scenario = await tx.scenario.create({
+            data: createInput,
+            select: scenarioMutationSelect,
+          })
+          await syncScenarioGenreFacetsInTransaction(tx, scenario, {
+            userId: user.id,
+            isAdmin,
+          })
+          return scenario
         })
 
         created.push(createdScenario)

--- a/server/api/scenarios/index.post.ts
+++ b/server/api/scenarios/index.post.ts
@@ -4,6 +4,7 @@ import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
 import { userIsAdmin } from '@/server/utils/authUser'
+import { syncScenarioGenreFacetsInTransaction } from '@/server/utils/scenarioGenreFacetSync'
 import {
   buildScenarioCreateInput,
   findExistingScenario,
@@ -33,7 +34,8 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    await assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))
+    const isAdmin = userIsAdmin(user)
+    await assertScenarioRelationsAttachable(body, user.id, isAdmin)
 
     const createInput = await buildScenarioCreateInput(body, user.id)
     const existingScenario = await findExistingScenario(
@@ -48,9 +50,16 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const data = await prisma.scenario.create({
-      data: createInput,
-      select: scenarioMutationSelect,
+    const data = await prisma.$transaction(async (tx) => {
+      const scenario = await tx.scenario.create({
+        data: createInput,
+        select: scenarioMutationSelect,
+      })
+      await syncScenarioGenreFacetsInTransaction(tx, scenario, {
+        userId: user.id,
+        isAdmin,
+      })
+      return scenario
     })
 
     event.node.res.statusCode = 201

--- a/server/utils/scenarioGenreFacetSync.ts
+++ b/server/utils/scenarioGenreFacetSync.ts
@@ -42,18 +42,20 @@ export async function syncScenarioGenreFacetsInTransaction(
   })
   const genreFacetIds = genreProfiles.map((profile) => profile.facetId)
 
-  await tx.scenarioFacet.deleteMany({
-    where: {
-      scenarioId: scenario.id,
-      ...(genreFacetIds.length ? { facetId: { in: genreFacetIds } } : {}),
-    },
-  })
+  if (genreFacetIds.length) {
+    await tx.scenarioFacet.deleteMany({
+      where: {
+        scenarioId: scenario.id,
+        facetId: { in: genreFacetIds },
+      },
+    })
+  }
 
   const values = splitScenarioGenres(scenario.genres)
   const lookupKeys = Array.from(
     new Set(values.map(normalizeFacetLookupKey).filter(Boolean)),
   )
-  if (!lookupKeys.length) return 0
+  if (!lookupKeys.length || !genreFacetIds.length) return 0
 
   const aliases = await tx.facetAlias.findMany({
     where: {

--- a/server/utils/scenarioGenreFacetSync.ts
+++ b/server/utils/scenarioGenreFacetSync.ts
@@ -1,0 +1,103 @@
+// /server/utils/scenarioGenreFacetSync.ts
+import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+
+type ScenarioGenreSource = {
+  id: number
+  genres?: string | null
+}
+
+type ScenarioGenreFacetSyncClient = {
+  facetAlias: {
+    findMany(args: unknown): PromiseLike<Array<{ lookupKey: string; facetId: number }>>
+  }
+  facetProfile: {
+    findMany(args: unknown): PromiseLike<Array<{ facetId: number; taxonomy: string }>>
+  }
+  facet: {
+    findMany(args: unknown): PromiseLike<Array<{ id: number }>>
+  }
+  scenarioFacet: {
+    deleteMany(args: unknown): PromiseLike<unknown>
+    createMany(args: unknown): PromiseLike<unknown>
+  }
+}
+
+function splitScenarioGenres(value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  return value
+    .split(/\||\n|;|,/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export async function syncScenarioGenreFacetsInTransaction(
+  txClient: unknown,
+  scenario: ScenarioGenreSource,
+  options: { userId: number; isAdmin: boolean },
+): Promise<number> {
+  const tx = txClient as ScenarioGenreFacetSyncClient
+  const genreProfiles = await tx.facetProfile.findMany({
+    where: { taxonomy: 'GENRE' },
+    select: { facetId: true, taxonomy: true },
+  })
+  const genreFacetIds = genreProfiles.map((profile) => profile.facetId)
+
+  await tx.scenarioFacet.deleteMany({
+    where: {
+      scenarioId: scenario.id,
+      ...(genreFacetIds.length ? { facetId: { in: genreFacetIds } } : {}),
+    },
+  })
+
+  const values = splitScenarioGenres(scenario.genres)
+  const lookupKeys = Array.from(
+    new Set(values.map(normalizeFacetLookupKey).filter(Boolean)),
+  )
+  if (!lookupKeys.length) return 0
+
+  const aliases = await tx.facetAlias.findMany({
+    where: {
+      lookupKey: { in: lookupKeys },
+      isActive: true,
+    },
+    select: { lookupKey: true, facetId: true },
+  })
+  const candidateFacetIds = Array.from(
+    new Set(
+      aliases
+        .map((alias) => alias.facetId)
+        .filter((facetId) => genreFacetIds.includes(facetId)),
+    ),
+  )
+  if (!candidateFacetIds.length) return 0
+
+  const visibleFacets = await tx.facet.findMany({
+    where: {
+      id: { in: candidateFacetIds },
+      isActive: true,
+      ...(options.isAdmin
+        ? {}
+        : { OR: [{ isPublic: true }, { userId: options.userId }] }),
+    },
+    select: { id: true },
+  })
+  const visibleIds = new Set(visibleFacets.map((facet) => facet.id))
+  const facetIdByLookupKey = new Map(
+    aliases
+      .filter((alias) => visibleIds.has(alias.facetId))
+      .map((alias) => [alias.lookupKey, alias.facetId]),
+  )
+  const facetIds = Array.from(
+    new Set(lookupKeys.map((key) => facetIdByLookupKey.get(key)).filter(Boolean)),
+  ) as number[]
+
+  if (!facetIds.length) return 0
+  await tx.scenarioFacet.createMany({
+    data: facetIds.map((facetId) => ({
+      scenarioId: scenario.id,
+      facetId,
+    })),
+    skipDuplicates: true,
+  })
+  return facetIds.length
+}

--- a/utils/scripts/runFacetCatalogSeed.ts
+++ b/utils/scripts/runFacetCatalogSeed.ts
@@ -53,3 +53,7 @@ await import('./seedGenderFacetCatalog')
 
 // seedFacetCatalog reads process.argv itself, so --apply passes through.
 await import('./seedFacetCatalog')
+
+// Scenario Genre is curated in its own Builder graph. Apply it after the broad
+// legacy gap-fill seed so its descriptions, artwork, grouping, and source rank win.
+await import('./seedScenarioGenreFacetCatalog')

--- a/utils/scripts/seedScenarioGenreFacetCatalog.ts
+++ b/utils/scripts/seedScenarioGenreFacetCatalog.ts
@@ -1,0 +1,369 @@
+// /utils/scripts/seedScenarioGenreFacetCatalog.ts
+import 'dotenv/config'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { SCENARIO_CARDS } from './../../stores/helpers/scenarioCards'
+import {
+  normalizeFacetLookupKey,
+  prepareUniqueFacetAliases,
+} from './../facetAliases'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({
+  adapter: createDatabaseAdapter(databaseUrl),
+})
+const apply = process.argv.includes('--apply')
+
+type ScenarioGenreCandidate = {
+  title: string
+  canonicalValue: string
+  builderLabel: string
+  description?: string
+  imagePath?: string
+  requestedImagePath?: string
+  sortOrder: number
+  sourceRank: number
+  aliases: Set<string>
+  metadata: Record<string, unknown>
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 255)
+}
+
+function existingPublicImagePath(value: unknown): {
+  imagePath?: string
+  requestedImagePath?: string
+} {
+  const requestedImagePath = clean(value)
+  if (!requestedImagePath) return {}
+  if (!requestedImagePath.startsWith('/images/')) {
+    return { requestedImagePath }
+  }
+  return existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1)))
+    ? { imagePath: requestedImagePath, requestedImagePath }
+    : { requestedImagePath }
+}
+
+function collectScenarioGenreCandidates(): ScenarioGenreCandidate[] {
+  const candidates = new Map<string, ScenarioGenreCandidate>()
+  const genreCard = SCENARIO_CARDS.find((card) => card.key === 'genre')
+  let order = 0
+
+  for (const step of genreCard?.steps ?? []) {
+    const fieldKey = clean(step.field) || clean(step.key)
+    if (fieldKey !== 'genres') continue
+
+    for (const choice of step.choices ?? []) {
+      if (choice.opensCustom) continue
+
+      if (choice.opensList) {
+        for (const rawOption of choice.listOptions ?? []) {
+          const canonicalValue = clean(rawOption)
+          const key = normalizeFacetLookupKey(canonicalValue)
+          if (!canonicalValue || !key || candidates.has(key)) continue
+          candidates.set(key, {
+            title: canonicalValue,
+            canonicalValue,
+            builderLabel: canonicalValue,
+            sortOrder: order++,
+            sourceRank: 30,
+            aliases: new Set([canonicalValue]),
+            metadata: {
+              source: 'scenario-builder-extended-list',
+              fieldKey: 'genres',
+              cardKey: genreCard?.key ?? 'genre',
+              stepKey: step.key,
+              artworkStatus: 'missing',
+            },
+          })
+        }
+        continue
+      }
+
+      const canonicalValue = clean(choice.value)
+      const builderLabel = clean(choice.label) || canonicalValue
+      const key = normalizeFacetLookupKey(canonicalValue)
+      if (!canonicalValue || !builderLabel || !key) continue
+      const artwork = existingPublicImagePath(choice.image)
+      candidates.set(key, {
+        title: canonicalValue,
+        canonicalValue,
+        builderLabel,
+        description: clean(choice.subtext) || undefined,
+        imagePath: artwork.imagePath,
+        requestedImagePath: artwork.requestedImagePath,
+        sortOrder: order++,
+        sourceRank: 8,
+        aliases: new Set([canonicalValue, builderLabel]),
+        metadata: {
+          source: 'scenario-builder',
+          fieldKey: 'genres',
+          cardKey: genreCard?.key ?? 'genre',
+          stepKey: step.key,
+          builderLabel,
+          requestedImagePath: artwork.requestedImagePath,
+          artworkStatus: artwork.imagePath ? 'available' : 'missing',
+        },
+      })
+    }
+  }
+
+  return Array.from(candidates.values()).sort(
+    (a, b) => a.sortOrder - b.sortOrder || a.title.localeCompare(b.title),
+  )
+}
+
+type CatalogState = {
+  aliasOwner: Map<string, number>
+  facetById: Map<
+    number,
+    {
+      id: number
+      slug: string | null
+      title: string
+      description: string | null
+      imagePath: string | null
+      designer: string | null
+    }
+  >
+  profileByFacetId: Map<number, { sourceRank: number }>
+}
+
+async function loadCatalogState(): Promise<CatalogState> {
+  const [aliases, facets, profiles] = await Promise.all([
+    prisma.facetAlias.findMany({ select: { lookupKey: true, facetId: true } }),
+    prisma.facet.findMany({
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        description: true,
+        imagePath: true,
+        designer: true,
+      },
+    }),
+    prisma.facetProfile.findMany({ select: { facetId: true, sourceRank: true } }),
+  ])
+  return {
+    aliasOwner: new Map(aliases.map((alias) => [alias.lookupKey, alias.facetId])),
+    facetById: new Map(facets.map((facet) => [facet.id, facet])),
+    profileByFacetId: new Map(
+      profiles.map((profile) => [profile.facetId, profile]),
+    ),
+  }
+}
+
+async function saveCandidate(
+  candidate: ScenarioGenreCandidate,
+  state: CatalogState,
+): Promise<number> {
+  const lookupKey = normalizeFacetLookupKey(candidate.canonicalValue)
+  const existingId = state.aliasOwner.get(lookupKey)
+  const existing = existingId ? state.facetById.get(existingId) : undefined
+  const slug = existing?.slug || slugify(candidate.canonicalValue)
+  const incomingWins =
+    candidate.sourceRank <=
+    (existingId ? state.profileByFacetId.get(existingId)?.sourceRank ?? 100 : 100)
+
+  const facet = existing
+    ? await prisma.facet.update({
+        where: { id: existing.id },
+        data: {
+          title: existing.title || candidate.title,
+          description:
+            incomingWins && candidate.description
+              ? candidate.description
+              : existing.description || candidate.description,
+          imagePath:
+            incomingWins && candidate.imagePath
+              ? candidate.imagePath
+              : existing.imagePath || candidate.imagePath,
+          designer: existing.designer || 'facet-catalog',
+          isActive: true,
+        },
+      })
+    : await prisma.facet.create({
+        data: {
+          title: candidate.title,
+          slug,
+          kind: 'GENRE',
+          description: candidate.description,
+          imagePath: candidate.imagePath,
+          designer: 'facet-catalog',
+          creationSource: 'HUMAN',
+          userId: 1,
+          isPublic: true,
+          isMature: false,
+          isActive: true,
+        },
+      })
+
+  state.facetById.set(facet.id, facet)
+  await prisma.facetProfile.upsert({
+    where: { facetId: facet.id },
+    create: {
+      facetId: facet.id,
+      taxonomy: 'GENRE',
+      canonicalValue: candidate.canonicalValue,
+      groupKey: 'scenario-genre',
+      groupLabel: 'Scenario Genres',
+      sortOrder: candidate.sortOrder,
+      isRandomizable: true,
+      randomWeight: 1,
+      artRequired: true,
+      sourceRank: candidate.sourceRank,
+      metadata: JSON.stringify(candidate.metadata),
+    },
+    update: incomingWins
+      ? {
+          taxonomy: 'GENRE',
+          canonicalValue: candidate.canonicalValue,
+          groupKey: 'scenario-genre',
+          groupLabel: 'Scenario Genres',
+          sortOrder: candidate.sortOrder,
+          isRandomizable: true,
+          artRequired: true,
+          sourceRank: candidate.sourceRank,
+          metadata: JSON.stringify(candidate.metadata),
+        }
+      : { taxonomy: 'GENRE' },
+  })
+  state.profileByFacetId.set(facet.id, {
+    sourceRank: incomingWins
+      ? candidate.sourceRank
+      : state.profileByFacetId.get(facet.id)?.sourceRank ?? candidate.sourceRank,
+  })
+
+  for (const alias of prepareUniqueFacetAliases([
+    slug,
+    candidate.title,
+    candidate.canonicalValue,
+    candidate.builderLabel,
+    ...candidate.aliases,
+  ])) {
+    const ownerId = state.aliasOwner.get(alias.lookupKey)
+    if (ownerId && ownerId !== facet.id) continue
+    await prisma.facetAlias.upsert({
+      where: { lookupKey: alias.lookupKey },
+      create: {
+        facetId: facet.id,
+        alias: alias.alias,
+        lookupKey: alias.lookupKey,
+        isCanonical: alias.lookupKey === normalizeFacetLookupKey(slug),
+        isActive: true,
+      },
+      update: {
+        facetId: facet.id,
+        alias: alias.alias,
+        isCanonical: alias.lookupKey === normalizeFacetLookupKey(slug),
+        isActive: true,
+      },
+    })
+    state.aliasOwner.set(alias.lookupKey, facet.id)
+  }
+
+  return facet.id
+}
+
+function splitGenres(value: string | null): string[] {
+  return String(value ?? '')
+    .split(/\||\n|;|,/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+async function backfillScenarioGenres(state: CatalogState): Promise<number> {
+  const scenarios = await prisma.scenario.findMany({
+    select: { id: true, genres: true },
+  })
+  let linked = 0
+  for (const scenario of scenarios) {
+    for (const value of splitGenres(scenario.genres)) {
+      const facetId = state.aliasOwner.get(normalizeFacetLookupKey(value))
+      if (!facetId) continue
+      await prisma.scenarioFacet.upsert({
+        where: {
+          scenarioId_facetId: {
+            scenarioId: scenario.id,
+            facetId,
+          },
+        },
+        create: { scenarioId: scenario.id, facetId },
+        update: {},
+      })
+      linked++
+    }
+  }
+  return linked
+}
+
+async function main(): Promise<void> {
+  const candidates = collectScenarioGenreCandidates()
+  const missingSourceArtwork = candidates
+    .filter((candidate) => candidate.requestedImagePath && !candidate.imagePath)
+    .map((candidate) => candidate.requestedImagePath)
+
+  if (!apply) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          mode: 'dry-run',
+          taxonomy: 'GENRE',
+          source: 'scenario-builder',
+          candidates: candidates.length,
+          illustrated: candidates.filter((candidate) => candidate.requestedImagePath)
+            .length,
+          missingSourceArtwork,
+          note: 'Run with --apply after the canonical Facet seed.',
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    return
+  }
+
+  const state = await loadCatalogState()
+  for (const candidate of candidates) await saveCandidate(candidate, state)
+  const scenarioLinks = await backfillScenarioGenres(state)
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        mode: 'apply',
+        taxonomy: 'GENRE',
+        source: 'scenario-builder',
+        candidates: candidates.length,
+        saved: candidates.length,
+        scenarioLinks,
+        missingSourceArtwork,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+await main()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
+++ b/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
@@ -10,6 +10,10 @@ assert.equal(isFacetCatalogSourcePath('stores/helpers/scenarioCards.ts'), true)
 assert.equal(isFacetCatalogSourcePath('stores/utils/animalData.ts'), true)
 assert.equal(isFacetCatalogSourcePath('utils/seeds/facetGenderArtwork.ts'), true)
 assert.equal(isFacetCatalogSourcePath('utils/seeds/facetGenderValues.ts'), true)
+assert.equal(
+  isFacetCatalogSourcePath('utils/seeds/facetScenarioGenreArtwork.ts'),
+  true,
+)
 assert.equal(isFacetCatalogSourcePath('utils/scripts/seedGenderFacetCatalog.ts'), true)
 assert.equal(
   isFacetCatalogSourcePath('utils/scripts/seedScenarioGenreFacetCatalog.ts'),
@@ -77,6 +81,7 @@ for (const source of [
   'stores/helpers/scenarioCards.ts',
   'utils/seeds/facetGenderArtwork.ts',
   'utils/seeds/facetGenderValues.ts',
+  'utils/seeds/facetScenarioGenreArtwork.ts',
   'utils/seeds/facetLegacyCharacterLists.ts',
   'utils/seeds/facetLegacyCreativeLists.ts',
   'utils/scripts/seedGenderFacetCatalog.ts',

--- a/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
+++ b/utils/scripts/verifyFacetCatalogSeedPolicy.mjs
@@ -6,10 +6,15 @@ import {
 } from '../../scripts/lib/facetCatalogSeedPolicy.mjs'
 
 assert.equal(isFacetCatalogSourcePath('stores/helpers/adventureCards.ts'), true)
+assert.equal(isFacetCatalogSourcePath('stores/helpers/scenarioCards.ts'), true)
 assert.equal(isFacetCatalogSourcePath('stores/utils/animalData.ts'), true)
 assert.equal(isFacetCatalogSourcePath('utils/seeds/facetGenderArtwork.ts'), true)
 assert.equal(isFacetCatalogSourcePath('utils/seeds/facetGenderValues.ts'), true)
 assert.equal(isFacetCatalogSourcePath('utils/scripts/seedGenderFacetCatalog.ts'), true)
+assert.equal(
+  isFacetCatalogSourcePath('utils/scripts/seedScenarioGenreFacetCatalog.ts'),
+  true,
+)
 assert.equal(
   isFacetCatalogSourcePath('utils/seeds/facetLegacyCharacterLists.ts'),
   true,
@@ -44,7 +49,7 @@ assert.deepEqual(
   decideFacetCatalogSeed({
     isVercelBuild: true,
     isProductionDeployment: false,
-    changedFiles: ['stores/helpers/adventureCards.ts'],
+    changedFiles: ['stores/helpers/scenarioCards.ts'],
   }).run,
   false,
 )
@@ -67,27 +72,21 @@ assert.deepEqual(
   false,
 )
 
-assert.deepEqual(
-  decideFacetCatalogSeed({
-    isVercelBuild: true,
-    isProductionDeployment: true,
-    changedFiles: ['stores/helpers/adventureCards.ts'],
-  }).run,
-  true,
-)
-
-for (const snapshot of [
+for (const source of [
+  'stores/helpers/adventureCards.ts',
+  'stores/helpers/scenarioCards.ts',
   'utils/seeds/facetGenderArtwork.ts',
   'utils/seeds/facetGenderValues.ts',
   'utils/seeds/facetLegacyCharacterLists.ts',
   'utils/seeds/facetLegacyCreativeLists.ts',
   'utils/scripts/seedGenderFacetCatalog.ts',
+  'utils/scripts/seedScenarioGenreFacetCatalog.ts',
 ]) {
   assert.deepEqual(
     decideFacetCatalogSeed({
       isVercelBuild: true,
       isProductionDeployment: true,
-      changedFiles: [snapshot],
+      changedFiles: [source],
     }).run,
     true,
   )

--- a/utils/scripts/verifyScenarioGenreFacetCutover.ts
+++ b/utils/scripts/verifyScenarioGenreFacetCutover.ts
@@ -85,6 +85,7 @@ async function main(): Promise<void> {
   requireText(files.wrapper, text.wrapper, "import('./seedScenarioGenreFacetCatalog')")
   requireText(files.plugin, text.plugin, 'SCENARIO_CARDS')
   requireText(files.plugin, text.plugin, "if (key === 'genres') return 'genre'")
+  requireText(files.plugin, text.plugin, 'hydrateScenarioBuilder')
   requireText(files.plugin, text.plugin, 'hydrateBuilderCards(SCENARIO_CARDS, catalog)')
   requireText(files.sync, text.sync, 'syncScenarioGenreFacetsInTransaction')
   requireText(files.sync, text.sync, "where: { taxonomy: 'GENRE' }")

--- a/utils/scripts/verifyScenarioGenreFacetCutover.ts
+++ b/utils/scripts/verifyScenarioGenreFacetCutover.ts
@@ -1,0 +1,113 @@
+// /utils/scripts/verifyScenarioGenreFacetCutover.ts
+import { access, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { SCENARIO_CARDS } from '../../stores/helpers/scenarioCards'
+
+const root = process.cwd()
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function requireText(path: string, text: string, fragment: string): void {
+  if (!text.includes(fragment)) {
+    throw new Error(`${path} is missing Scenario Genre Facet contract text: ${fragment}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const failures: string[] = []
+  const genreCard = SCENARIO_CARDS.find((card) => card.key === 'genre')
+  if (!genreCard) throw new Error('Scenario Genre Builder card is missing.')
+
+  const direct: Array<{ value: string; label: string; imagePath: string }> = []
+  const extended = new Set<string>()
+
+  for (const step of genreCard.steps) {
+    if ((clean(step.field) || clean(step.key)) !== 'genres') continue
+    for (const choice of step.choices ?? []) {
+      if (choice.opensCustom) continue
+      if (choice.opensList) {
+        for (const value of choice.listOptions ?? []) {
+          const cleaned = clean(value)
+          if (cleaned) extended.add(cleaned)
+        }
+        continue
+      }
+
+      const value = clean(choice.value)
+      const label = clean(choice.label) || value
+      const imagePath = clean(choice.image)
+      if (!value) continue
+      if (!imagePath) {
+        failures.push(`${label} is a direct Scenario Genre choice without artwork.`)
+        continue
+      }
+      direct.push({ value, label, imagePath })
+      try {
+        await access(resolve(root, 'public', imagePath.slice(1)))
+      } catch {
+        failures.push(`${label} references missing Scenario Genre artwork: public${imagePath}`)
+      }
+    }
+  }
+
+  if (direct.length < 10) {
+    failures.push(`Expected at least 10 illustrated Scenario Genres, found ${direct.length}.`)
+  }
+  if (extended.size < 40) {
+    failures.push(`Expected at least 40 extended Scenario Genres, found ${extended.size}.`)
+  }
+
+  const files = {
+    seed: 'utils/scripts/seedScenarioGenreFacetCatalog.ts',
+    wrapper: 'utils/scripts/runFacetCatalogSeed.ts',
+    plugin: 'plugins/20.facet-catalog.client.ts',
+    sync: 'server/utils/scenarioGenreFacetSync.ts',
+    create: 'server/api/scenarios/index.post.ts',
+    patch: 'server/api/scenarios/[id].patch.ts',
+    batch: 'server/api/scenarios/batch.post.ts',
+    policy: 'scripts/lib/facetCatalogSeedPolicy.mjs',
+  } as const
+  const entries = await Promise.all(
+    Object.entries(files).map(
+      async ([key, path]) => [key, await readFile(resolve(root, path), 'utf8')] as const,
+    ),
+  )
+  const text = Object.fromEntries(entries) as Record<keyof typeof files, string>
+
+  requireText(files.seed, text.seed, 'SCENARIO_CARDS')
+  requireText(files.seed, text.seed, "taxonomy: 'GENRE'")
+  requireText(files.seed, text.seed, "groupKey: 'scenario-genre'")
+  requireText(files.seed, text.seed, 'builderLabel')
+  requireText(files.seed, text.seed, 'backfillScenarioGenres')
+  requireText(files.seed, text.seed, 'existingPublicImagePath')
+  requireText(files.wrapper, text.wrapper, "import('./seedScenarioGenreFacetCatalog')")
+  requireText(files.plugin, text.plugin, 'SCENARIO_CARDS')
+  requireText(files.plugin, text.plugin, "if (key === 'genres') return 'genre'")
+  requireText(files.plugin, text.plugin, 'hydrateBuilderCards(SCENARIO_CARDS, catalog)')
+  requireText(files.sync, text.sync, 'syncScenarioGenreFacetsInTransaction')
+  requireText(files.sync, text.sync, "where: { taxonomy: 'GENRE' }")
+  requireText(files.sync, text.sync, 'facetId: { in: genreFacetIds }')
+  requireText(files.create, text.create, 'prisma.$transaction')
+  requireText(files.create, text.create, 'syncScenarioGenreFacetsInTransaction')
+  requireText(files.patch, text.patch, "if ('genres' in data)")
+  requireText(files.patch, text.patch, 'syncScenarioGenreFacetsInTransaction')
+  requireText(files.batch, text.batch, 'prisma.$transaction')
+  requireText(files.batch, text.batch, 'syncScenarioGenreFacetsInTransaction')
+  requireText(files.policy, text.policy, 'stores/helpers/scenarioCards.ts')
+  requireText(files.policy, text.policy, 'utils/scripts/seedScenarioGenreFacetCatalog.ts')
+
+  if (failures.length) {
+    throw new Error(`Scenario Genre Facet cutover failed:\n- ${failures.join('\n- ')}`)
+  }
+
+  process.stdout.write(
+    `Scenario Genre Facet cutover verified: ${direct.length} illustrated choices and ${extended.size} extended genres.\n`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyScenarioGenreFacetCutover.ts
+++ b/utils/scripts/verifyScenarioGenreFacetCutover.ts
@@ -2,6 +2,10 @@
 import { access, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { SCENARIO_CARDS } from '../../stores/helpers/scenarioCards'
+import {
+  SCENARIO_GENRE_ARTWORK_PATHS,
+  SCENARIO_GENRE_ARTWORK_TARGETS,
+} from '../seeds/facetScenarioGenreArtwork'
 
 const root = process.cwd()
 
@@ -15,8 +19,18 @@ function requireText(path: string, text: string, fragment: string): void {
   }
 }
 
+async function pathExists(imagePath: string): Promise<boolean> {
+  try {
+    await access(resolve(root, 'public', imagePath.slice(1)))
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function main(): Promise<void> {
   const failures: string[] = []
+  const missingArtwork: string[] = []
   const genreCard = SCENARIO_CARDS.find((card) => card.key === 'genre')
   if (!genreCard) throw new Error('Scenario Genre Builder card is missing.')
 
@@ -40,14 +54,18 @@ async function main(): Promise<void> {
       const imagePath = clean(choice.image)
       if (!value) continue
       if (!imagePath) {
-        failures.push(`${label} is a direct Scenario Genre choice without artwork.`)
+        failures.push(`${label} is a direct Scenario Genre choice without an artwork target.`)
         continue
       }
       direct.push({ value, label, imagePath })
-      try {
-        await access(resolve(root, 'public', imagePath.slice(1)))
-      } catch {
-        failures.push(`${label} references missing Scenario Genre artwork: public${imagePath}`)
+      if (!(await pathExists(imagePath))) {
+        if (SCENARIO_GENRE_ARTWORK_PATHS.has(imagePath)) {
+          missingArtwork.push(imagePath)
+        } else {
+          failures.push(
+            `${label} references untracked missing Scenario Genre artwork: public${imagePath}`,
+          )
+        }
       }
     }
   }
@@ -59,14 +77,25 @@ async function main(): Promise<void> {
     failures.push(`Expected at least 40 extended Scenario Genres, found ${extended.size}.`)
   }
 
+  const directPaths = new Set(direct.map((entry) => entry.imagePath))
+  for (const target of SCENARIO_GENRE_ARTWORK_TARGETS) {
+    if (!directPaths.has(target.path)) {
+      failures.push(
+        `Scenario Genre artwork manifest target ${target.path} is not represented by the Builder source.`,
+      )
+    }
+  }
+
   const files = {
     seed: 'utils/scripts/seedScenarioGenreFacetCatalog.ts',
+    artwork: 'utils/seeds/facetScenarioGenreArtwork.ts',
     wrapper: 'utils/scripts/runFacetCatalogSeed.ts',
     plugin: 'plugins/20.facet-catalog.client.ts',
     sync: 'server/utils/scenarioGenreFacetSync.ts',
     create: 'server/api/scenarios/index.post.ts',
     patch: 'server/api/scenarios/[id].patch.ts',
-    batch: 'server/api/scenarios/batch.post.ts',
+    batchCreate: 'server/api/scenarios/batch.post.ts',
+    batchPatch: 'server/api/scenarios/batch.patch.ts',
     policy: 'scripts/lib/facetCatalogSeedPolicy.mjs',
   } as const
   const entries = await Promise.all(
@@ -82,6 +111,7 @@ async function main(): Promise<void> {
   requireText(files.seed, text.seed, 'builderLabel')
   requireText(files.seed, text.seed, 'backfillScenarioGenres')
   requireText(files.seed, text.seed, 'existingPublicImagePath')
+  requireText(files.artwork, text.artwork, 'SCENARIO_GENRE_ARTWORK_TARGETS')
   requireText(files.wrapper, text.wrapper, "import('./seedScenarioGenreFacetCatalog')")
   requireText(files.plugin, text.plugin, 'SCENARIO_CARDS')
   requireText(files.plugin, text.plugin, "if (key === 'genres') return 'genre'")
@@ -90,13 +120,19 @@ async function main(): Promise<void> {
   requireText(files.sync, text.sync, 'syncScenarioGenreFacetsInTransaction')
   requireText(files.sync, text.sync, "where: { taxonomy: 'GENRE' }")
   requireText(files.sync, text.sync, 'facetId: { in: genreFacetIds }')
-  requireText(files.create, text.create, 'prisma.$transaction')
-  requireText(files.create, text.create, 'syncScenarioGenreFacetsInTransaction')
+  for (const [source, label] of [
+    [text.create, files.create],
+    [text.patch, files.patch],
+    [text.batchCreate, files.batchCreate],
+    [text.batchPatch, files.batchPatch],
+  ] as const) {
+    requireText(label, source, 'prisma.$transaction')
+    requireText(label, source, 'syncScenarioGenreFacetsInTransaction')
+  }
   requireText(files.patch, text.patch, "if ('genres' in data)")
-  requireText(files.patch, text.patch, 'syncScenarioGenreFacetsInTransaction')
-  requireText(files.batch, text.batch, 'prisma.$transaction')
-  requireText(files.batch, text.batch, 'syncScenarioGenreFacetsInTransaction')
+  requireText(files.batchPatch, text.batchPatch, "if ('genres' in data)")
   requireText(files.policy, text.policy, 'stores/helpers/scenarioCards.ts')
+  requireText(files.policy, text.policy, 'utils/seeds/facetScenarioGenreArtwork.ts')
   requireText(files.policy, text.policy, 'utils/scripts/seedScenarioGenreFacetCatalog.ts')
 
   if (failures.length) {
@@ -106,6 +142,14 @@ async function main(): Promise<void> {
   process.stdout.write(
     `Scenario Genre Facet cutover verified: ${direct.length} illustrated choices and ${extended.size} extended genres.\n`,
   )
+  const uniqueDebt = Array.from(new Set(missingArtwork)).sort()
+  if (uniqueDebt.length) {
+    process.stdout.write(
+      `Known Scenario Genre artwork debt (${uniqueDebt.length}; broken paths are not persisted):\n` +
+        uniqueDebt.map((path) => `- public${path}`).join('\n') +
+        '\n',
+    )
+  }
 }
 
 main().catch((error: unknown) => {

--- a/utils/scripts/verifyScenarioMutationInputParity.ts
+++ b/utils/scripts/verifyScenarioMutationInputParity.ts
@@ -32,149 +32,39 @@ const permissionSpec = read(
   'cypress/e2e/api/scenario-relation-permission.cy.ts',
 )
 
-requireText(
-  boundary,
-  'export const SCENARIO_RELATION_ID_LIMIT = 100',
-  'Scenario relation cap',
-)
-requireText(
-  boundary,
-  'export const SCENARIO_BATCH_LIMIT = 100',
-  'Scenario batch cap',
-)
-requireText(
-  boundary,
-  'const scenarioStoreCompatibilityFields = [',
-  'Scenario singular store compatibility stage',
-)
-requireText(
-  boundary,
-  "'facetIds',",
-  'Scenario Facet compatibility field',
-)
-requireText(
-  boundary,
-  'no writable ScenarioCreateInput/ScenarioUpdateInput relation',
-  'Scenario Facet write limitation documentation',
-)
-requireText(
-  boundary,
-  'export const scenarioBatchCreateFields = new Set<string>(scenarioMutationFields)',
-  'Scenario strict batch create fields',
-)
-requireText(
-  boundary,
-  'Unsupported Scenario ownership assignment. Ownership is server-owned.',
-  'Scenario ownership-match boundary',
-)
-requireText(
-  boundary,
-  'Scenario ID is immutable and must match the route.',
-  'Scenario route ID boundary',
-)
-requireText(
-  boundary,
-  'contains an invalid ID at index ${index}',
-  'Scenario invalid relation rejection',
-)
-forbidText(
-  boundary,
-  'data.Facets =',
-  'Unsupported Scenario Facet update write',
-)
-forbidText(
-  createHelper,
-  'Facets:',
-  'Unsupported Scenario Facet create write',
-)
+requireText(boundary, 'export const SCENARIO_RELATION_ID_LIMIT = 100', 'Scenario relation cap')
+requireText(boundary, 'export const SCENARIO_BATCH_LIMIT = 100', 'Scenario batch cap')
+requireText(boundary, 'const scenarioStoreCompatibilityFields = [', 'Scenario singular store compatibility stage')
+requireText(boundary, "'facetIds',", 'Scenario Facet compatibility field')
+requireText(boundary, 'no writable ScenarioCreateInput/ScenarioUpdateInput relation', 'Scenario Facet write limitation documentation')
+requireText(boundary, 'export const scenarioBatchCreateFields = new Set<string>(scenarioMutationFields)', 'Scenario strict batch create fields')
+requireText(boundary, 'Unsupported Scenario ownership assignment. Ownership is server-owned.', 'Scenario ownership-match boundary')
+requireText(boundary, 'Scenario ID is immutable and must match the route.', 'Scenario route ID boundary')
+requireText(boundary, 'contains an invalid ID at index ${index}', 'Scenario invalid relation rejection')
+forbidText(boundary, 'data.Facets =', 'Unsupported Scenario Facet update write')
+forbidText(createHelper, 'Facets:', 'Unsupported Scenario Facet create write')
 
-requireText(
-  createHelper,
-  'allowedFields: options.batch',
-  'Scenario singular/batch field selection',
-)
-requireText(
-  createHelper,
-  'Characters: characterIds?.length',
-  'Scenario Character create persistence',
-)
-requireText(
-  createRoute,
-  'await buildScenarioCreateInput(body, user.id)',
-  'Scenario singular create boundary',
-)
-requireText(
-  patchRoute,
-  'allowedFields: scenarioPatchFields',
-  'Scenario singular patch boundary',
-)
-requireText(
-  patchRoute,
-  'routeId: id',
-  'Scenario singular route ID validation',
-)
-requireText(
-  batchCreateRoute,
-  '{ batch: true }',
-  'Scenario strict batch create boundary',
-)
-requireText(
-  batchCreateRoute,
-  'body.length > SCENARIO_BATCH_LIMIT',
-  'Scenario batch create cap',
-)
-requireText(
-  batchPatchRoute,
-  'allowedFields: scenarioBatchPatchFields',
-  'Scenario batch patch item boundary',
-)
-requireText(
-  batchPatchRoute,
-  'record.updates.length > SCENARIO_BATCH_LIMIT',
-  'Scenario batch patch cap',
-)
-forbidText(
-  patchRoute,
-  'function normalizePositiveIdArray',
-  'Scenario duplicate singular normalizer',
-)
-forbidText(
-  batchPatchRoute,
-  'function normalizePositiveIdArray',
-  'Scenario duplicate batch normalizer',
-)
+requireText(createHelper, 'allowedFields: options.batch', 'Scenario singular/batch field selection')
+requireText(createHelper, 'Characters: characterIds?.length', 'Scenario Character create persistence')
+requireText(createRoute, 'await buildScenarioCreateInput(body, user.id)', 'Scenario singular create boundary')
+requireText(patchRoute, 'allowedFields: scenarioPatchFields', 'Scenario singular patch boundary')
+requireText(patchRoute, 'const scenarioId = id', 'Scenario validated route ID')
+requireText(patchRoute, 'routeId: scenarioId', 'Scenario singular route ID validation')
+requireText(batchCreateRoute, '{ batch: true }', 'Scenario strict batch create boundary')
+requireText(batchCreateRoute, 'body.length > SCENARIO_BATCH_LIMIT', 'Scenario batch create cap')
+requireText(batchPatchRoute, 'allowedFields: scenarioBatchPatchFields', 'Scenario batch patch item boundary')
+requireText(batchPatchRoute, 'routeId: candidateId', 'Scenario batch validated item ID')
+requireText(batchPatchRoute, 'record.updates.length > SCENARIO_BATCH_LIMIT', 'Scenario batch patch cap')
+forbidText(patchRoute, 'function normalizePositiveIdArray', 'Scenario duplicate singular normalizer')
+forbidText(batchPatchRoute, 'function normalizePositiveIdArray', 'Scenario duplicate batch normalizer')
 
-requireText(
-  cypressSpec,
-  'rejects unknown and spoofed fields on singular Scenario creation',
-  'Scenario singular deployed regression',
-)
-requireText(
-  cypressSpec,
-  'keeps singular ScenarioStore compatibility explicit and auth-bound',
-  'Scenario compatibility deployed regression',
-)
-requireText(
-  cypressSpec,
-  'rejects unknown, mismatched ID, and oversized PATCH fields',
-  'Scenario patch deployed regression',
-)
-requireText(
-  cypressSpec,
-  'keeps Scenario batch create and patch imports strict and bounded',
-  'Scenario batch deployed regression',
-)
+requireText(cypressSpec, 'rejects unknown and spoofed fields on singular Scenario creation', 'Scenario singular deployed regression')
+requireText(cypressSpec, 'keeps singular ScenarioStore compatibility explicit and auth-bound', 'Scenario compatibility deployed regression')
+requireText(cypressSpec, 'rejects unknown, mismatched ID, and oversized PATCH fields', 'Scenario patch deployed regression')
+requireText(cypressSpec, 'keeps Scenario batch create and patch imports strict and bounded', 'Scenario batch deployed regression')
 
-requireText(
-  boundary,
-  'export async function assertScenarioRelationsAttachable',
-  'Scenario relation permission gate',
-)
-requireText(
-  boundary,
-  'NOT: { OR: [{ userId }, { isPublic: true }] }',
-  'Scenario relation permission clause',
-)
+requireText(boundary, 'export async function assertScenarioRelationsAttachable', 'Scenario relation permission gate')
+requireText(boundary, 'NOT: { OR: [{ userId }, { isPublic: true }] }', 'Scenario relation permission clause')
 for (const [source, label] of [
   [createRoute, 'Scenario create relation permission wiring'],
   [patchRoute, 'Scenario patch relation permission wiring'],
@@ -183,29 +73,11 @@ for (const [source, label] of [
 ] as const) {
   requireText(source, 'assertScenarioRelationsAttachable(', label)
 }
-requireText(
-  permissionSpec,
-  'forbids attaching another user private Character on Scenario creation',
-  'Scenario relation permission deployed regression',
-)
+requireText(permissionSpec, 'forbids attaching another user private Character on Scenario creation', 'Scenario relation permission deployed regression')
 
-// Genre strings remain compatibility fields, while canonical ScenarioFacet links
-// are synchronized in the same transaction on every mutation path.
-requireText(
-  genreSync,
-  'export async function syncScenarioGenreFacetsInTransaction',
-  'Scenario Genre Facet synchronizer',
-)
-requireText(
-  genreSync,
-  "where: { taxonomy: 'GENRE' }",
-  'Scenario Genre taxonomy boundary',
-)
-requireText(
-  genreSync,
-  'facetId: { in: genreFacetIds }',
-  'Scenario Genre-only replacement boundary',
-)
+requireText(genreSync, 'export async function syncScenarioGenreFacetsInTransaction', 'Scenario Genre Facet synchronizer')
+requireText(genreSync, "where: { taxonomy: 'GENRE' }", 'Scenario Genre taxonomy boundary')
+requireText(genreSync, 'facetId: { in: genreFacetIds }', 'Scenario Genre-only replacement boundary')
 for (const [source, label] of [
   [createRoute, 'Scenario create Genre transaction'],
   [patchRoute, 'Scenario patch Genre transaction'],
@@ -215,15 +87,7 @@ for (const [source, label] of [
   requireText(source, 'prisma.$transaction', label)
   requireText(source, 'syncScenarioGenreFacetsInTransaction', label)
 }
-requireText(
-  patchRoute,
-  "if ('genres' in data)",
-  'Scenario patch conditional Genre sync',
-)
-requireText(
-  batchPatchRoute,
-  "if ('genres' in data)",
-  'Scenario batch patch conditional Genre sync',
-)
+requireText(patchRoute, "if ('genres' in data)", 'Scenario patch conditional Genre sync')
+requireText(batchPatchRoute, "if ('genres' in data)", 'Scenario batch patch conditional Genre sync')
 
 console.log('Scenario mutation input parity contract passed.')

--- a/utils/scripts/verifyScenarioMutationInputParity.ts
+++ b/utils/scripts/verifyScenarioMutationInputParity.ts
@@ -26,6 +26,7 @@ const createRoute = read('server/api/scenarios/index.post.ts')
 const patchRoute = read('server/api/scenarios/[id].patch.ts')
 const batchCreateRoute = read('server/api/scenarios/batch.post.ts')
 const batchPatchRoute = read('server/api/scenarios/batch.patch.ts')
+const genreSync = read('server/utils/scenarioGenreFacetSync.ts')
 const cypressSpec = read('cypress/e2e/api/scenario-input-boundary.cy.ts')
 const permissionSpec = read(
   'cypress/e2e/api/scenario-relation-permission.cy.ts',
@@ -164,8 +165,6 @@ requireText(
   'Scenario batch deployed regression',
 )
 
-// Phase 2: relation-connect targets must be public or owned by the caller (admins
-// bypass). The gate is wired into create, PATCH, and both batch routes.
 requireText(
   boundary,
   'export async function assertScenarioRelationsAttachable',
@@ -176,30 +175,55 @@ requireText(
   'NOT: { OR: [{ userId }, { isPublic: true }] }',
   'Scenario relation permission clause',
 )
-requireText(
-  createRoute,
-  'assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))',
-  'Scenario create relation permission wiring',
-)
-requireText(
-  patchRoute,
-  'assertScenarioRelationsAttachable(body, user.id, userIsAdmin(user))',
-  'Scenario patch relation permission wiring',
-)
-requireText(
-  batchCreateRoute,
-  'assertScenarioRelationsAttachable(',
-  'Scenario batch create relation permission wiring',
-)
-requireText(
-  batchPatchRoute,
-  'assertScenarioRelationsAttachable(fields, user.id, userIsAdmin(user))',
-  'Scenario batch patch relation permission wiring',
-)
+for (const [source, label] of [
+  [createRoute, 'Scenario create relation permission wiring'],
+  [patchRoute, 'Scenario patch relation permission wiring'],
+  [batchCreateRoute, 'Scenario batch create relation permission wiring'],
+  [batchPatchRoute, 'Scenario batch patch relation permission wiring'],
+] as const) {
+  requireText(source, 'assertScenarioRelationsAttachable(', label)
+}
 requireText(
   permissionSpec,
   'forbids attaching another user private Character on Scenario creation',
   'Scenario relation permission deployed regression',
+)
+
+// Genre strings remain compatibility fields, while canonical ScenarioFacet links
+// are synchronized in the same transaction on every mutation path.
+requireText(
+  genreSync,
+  'export async function syncScenarioGenreFacetsInTransaction',
+  'Scenario Genre Facet synchronizer',
+)
+requireText(
+  genreSync,
+  "where: { taxonomy: 'GENRE' }",
+  'Scenario Genre taxonomy boundary',
+)
+requireText(
+  genreSync,
+  'facetId: { in: genreFacetIds }',
+  'Scenario Genre-only replacement boundary',
+)
+for (const [source, label] of [
+  [createRoute, 'Scenario create Genre transaction'],
+  [patchRoute, 'Scenario patch Genre transaction'],
+  [batchCreateRoute, 'Scenario batch create Genre transaction'],
+  [batchPatchRoute, 'Scenario batch patch Genre transaction'],
+] as const) {
+  requireText(source, 'prisma.$transaction', label)
+  requireText(source, 'syncScenarioGenreFacetsInTransaction', label)
+}
+requireText(
+  patchRoute,
+  "if ('genres' in data)",
+  'Scenario patch conditional Genre sync',
+)
+requireText(
+  batchPatchRoute,
+  "if ('genres' in data)",
+  'Scenario batch patch conditional Genre sync',
 )
 
 console.log('Scenario mutation input parity contract passed.')

--- a/utils/seeds/facetScenarioGenreArtwork.ts
+++ b/utils/seeds/facetScenarioGenreArtwork.ts
@@ -1,0 +1,103 @@
+// /utils/seeds/facetScenarioGenreArtwork.ts
+//
+// Scenario Genre choices are curated visual Facets. This manifest records every
+// intended path and replacement prompt so missing repository media stays visible
+// without being persisted as a broken Facet image URL.
+
+export type ScenarioGenreArtworkTarget = {
+  value: string
+  label: string
+  path: string
+  prompt: string
+}
+
+export const SCENARIO_GENRE_ARTWORK_TARGETS: ScenarioGenreArtworkTarget[] = [
+  {
+    value: 'Gothic Comedy',
+    label: 'Gothic Comedy',
+    path: '/images/adventure/genre/gothic.webp',
+    prompt:
+      'Gothic comedy story-genre card, elegant decaying crypt interior with impeccable comedic timing, one specific visual joke, dramatic readable silhouette, no text.',
+  },
+  {
+    value: 'Cozy Horror',
+    label: 'Cozy Horror',
+    path: '/images/adventure/genre/cozy.webp',
+    prompt:
+      'Cozy horror story-genre card, warm lamplit room and tea while one unsettling presence waits outside the window, inviting and ominous at once, no text.',
+  },
+  {
+    value: 'Mythic Sci-Fi',
+    label: 'Mythic Sci-Fi',
+    path: '/images/adventure/genre/science-fiction.webp',
+    prompt:
+      'Mythic science-fiction story-genre card, ancient deity operating a monumental spacecraft with ritual technology, bold composition, no text.',
+  },
+  {
+    value: 'Cosmic Dread',
+    label: 'Cosmic Dread',
+    path: '/images/adventure/genre/cosmic.webp',
+    prompt:
+      'Cosmic dread story-genre card, tiny figure beneath an impossible moon containing a visible door, immense scale and precise eerie detail, no text.',
+  },
+  {
+    value: 'Fantasy',
+    label: 'Classic Fantasy',
+    path: '/images/adventure/genre/fantasy.webp',
+    prompt:
+      'Classic fantasy story-genre card, dragon perched on a castle calmly reading something important while adventure gathers below, colorful and specific, no text.',
+  },
+  {
+    value: 'Mystery',
+    label: 'Mystery',
+    path: '/images/adventure/genre/mystery.webp',
+    prompt:
+      'Mystery story-genre card, investigator scene with magnifying lens aimed directly toward the viewer and one concealed clue in plain sight, no text.',
+  },
+  {
+    value: 'Horror',
+    label: 'Horror',
+    path: '/images/adventure/genre/horror.webp',
+    prompt:
+      'Horror story-genre card, antique lantern emitting a reaching hand instead of light, focused unsettling scene, strong silhouette, no text.',
+  },
+  {
+    value: 'Romance',
+    label: 'Romance',
+    path: '/images/adventure/genre/romance.webp',
+    prompt:
+      'Romance story-genre card, two distinct figures almost touching while both watch the same mysterious third thing, emotional tension and specificity, no text.',
+  },
+  {
+    value: 'Comedy',
+    label: 'Comedy',
+    path: '/images/adventure/genre/comedy.webp',
+    prompt:
+      'Comedy story-genre card, energetic visual mishap with expressive motion and a clear punchline readable without captions, polished character animation style, no text.',
+  },
+  {
+    value: 'Pastoral Apocalypse',
+    label: 'Pastoral Apocalypse',
+    path: '/images/adventure/genre/apocalypse.webp',
+    prompt:
+      'Pastoral apocalypse story-genre card, peaceful laundry line and occupied farmhouse beneath an impossible green end-of-world sky, tender and strange, no text.',
+  },
+  {
+    value: 'Carnival',
+    label: 'Carnival',
+    path: '/images/adventure/genre/carnival.webp',
+    prompt:
+      'Carnival story-genre card, abandoned fairground still fully operating with a patient queue for nobody visible, colorful eerie atmosphere, no text.',
+  },
+  {
+    value: 'Infinite Archive',
+    label: 'Infinite Archive',
+    path: '/images/scenarios/genre/infinite-archive.webp',
+    prompt:
+      'Infinite archive story-genre card, endless shelves folding through impossible architecture while an open book visibly reads its observer back, no text.',
+  },
+]
+
+export const SCENARIO_GENRE_ARTWORK_PATHS = new Set(
+  SCENARIO_GENRE_ARTWORK_TARGETS.map((target) => target.path),
+)


### PR DESCRIPTION
## Why

Scenario Builder maintained a second illustrated Genre catalog after Facets became canonical. Its direct artwork, descriptions, extended genre list, and saved `Scenario.genres` strings could drift from the catalog and from `ScenarioFacet` assignments.

## Catalog cutover

- imports direct and extended Scenario Genre choices after the broad legacy gap-fill seed
- resolves identity from the canonical value, so `Classic Fantasy` enriches `Fantasy` instead of creating a duplicate concept
- preserves Scenario-specific Builder labels in metadata and aliases
- gives direct illustrated Scenario choices higher provenance than legacy string lists
- records requested artwork and missing-media status without writing broken paths
- backfills existing Scenario genre strings into `ScenarioFacet`

## Runtime cutover

- hydrates the Scenario Genre gallery and “More options” list from the same Facet catalog used by Character Builder
- preserves the existing Adventure Builder hydration seam
- synchronizes Genre Facets transactionally on singular create, singular patch, batch create, and batch patch
- removes/replaces only GENRE assignments, preserving unrelated Scenario Facets
- validates active/public/owned Facet visibility before linking

## Artwork defect discovered

The Scenario Builder declares twelve illustrated Genre paths, but at least Gothic Comedy and Cozy Horror are absent from `main`. The cutover does not persist nonexistent files.

`utils/seeds/facetScenarioGenreArtwork.ts` now records all twelve canonical values, Builder labels, paths, and replacement prompts. CI reports missing media as explicit debt, and #1024 tracks restoration or Conductor generation.

## Guardrails

- adds `verifyScenarioGenreFacetCutover.ts`
- checks direct and extended source coverage
- requires every direct path to be represented by the media manifest
- protects canonical identity, Builder hydration, all four mutation paths, Genre-only replacement, and production seed triggers
- extends Scenario mutation parity to require transactional Genre synchronization

## Validation

All required checks pass:

- Facet Catalog Contract
- Scenario Mutation Input Parity
- TypeScript Type Check
- Contract Tests

## Follow-up

- #1024 restores or generates missing Scenario Genre artwork and reruns the seed to populate valid image paths.
