### PR TITLE
academy-timeline.vue: fix a11y regression vs styles-browser's #1000 fix

### DIFF
--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -75,15 +75,18 @@
               {{ style.recognitionCues[0] }}
             </span>
           </span>
-          <Icon
-            v-if="academyStore.viewedLessons.includes(style.slug)"
-            name="kind-icon:check"
-            class="h-4 w-4 shrink-0 text-success"
-            title="Lesson explored"
-          />
+          <template v-if="academyStore.viewedLessons.includes(style.slug)">
+            <Icon
+              name="kind-icon:check"
+              class="h-4 w-4 shrink-0 text-success"
+              aria-hidden="true"
+            />
+            <span class="sr-only">Lesson explored</span>
+          </template>
           <Icon
             name="mdi:chevron-down"
             class="h-4 w-4 shrink-0 text-base-content/40 group-hover:text-primary"
+            aria-hidden="true"
           />
         </button>
 


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor): Academy continuous improvement pass, option (a) front-end polish/accessibility

### What changed / what I produced
- `components/academy/academy-timeline.vue`: the "lesson explored" checkmark icon and the chevron icon were never updated to match the accessibility fix PR #1000 applied to the sibling `academy-styles-browser.vue` component. The checkmark relied on a `title` tooltip (unreliable for screen readers/keyboard/touch users) instead of visible `sr-only` text, and neither icon was hidden from assistive tech via `aria-hidden`.
- Mirrored `academy-styles-browser.vue`'s already-fixed pattern exactly: wrapped the checkmark in a `v-if` template with `aria-hidden="true"` on the icon and an adjacent `<span class="sr-only">Lesson explored</span>`, and added `aria-hidden="true"` to the decorative chevron icon.

### How I verified
- `npx prettier --check components/academy/academy-timeline.vue` — clean
- No `node_modules` installed in this sandbox (same limitation noted in prior Academy PRs, e.g. #1017) — relying on kind_robots CI for TypeScript/ESLint/contract checks
- Manually diffed against `academy-styles-browser.vue`'s equivalent markup to confirm the fix matches the established pattern exactly (same classes, same `sr-only` text)
- Change is template-attribute-only — no logic, props, or store interactions touched

### Stakes
reversible

### Notes for reviewer
This is the recurring `ai-art-academy/t-010` "continuous improvement" task's front-end-polish lane (lane 1 in the 1→2→3→4 rotation). Full context and prior-fix exclusion list in `projects/ai-art-academy/docs/continuous-improvement-run-log.md` in the conductor repo.

### Kaizen suggestion
Since this exact bug class (title-tooltip + unhidden decorative icon) has now been fixed twice in the same feature across two sibling components, worth a quick grep across the rest of the Academy/art-styler surfaces for any other un-migrated `title="..."` status-icon patterns in a future lane-1 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ukdhg5AZvuVu3MPwLB3Fqy)_