### PR TITLE
model-builder: fix committingItemId singleton race in commitItem

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1155,7 +1155,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       setStatus('error', item.error)
       return false
     } finally {
-      state.committingItemId = null
+      // state.committingItemId is a store-wide singleton (not per-item), same
+      // shape as generatingItemId/autoBuildingItemId above: clicking "Commit"
+      // on a different row while this call is awaiting performFetch() and
+      // starting its own commitItem() overwrites committingItemId to that
+      // item's id, and this call's finally would then null it out from under
+      // the still-running commit the moment this call resolves — silently
+      // clearing its in-flight/disabled state. Only clear the flag if it's
+      // still ours.
+      if (state.committingItemId === item.id) state.committingItemId = null
     }
   }
 


### PR DESCRIPTION
### Task
conductor/model-builder t-029 (polish/bug-hunt cycle): fix a real race in `commitItem`.

### What changed
`stores/modelBuilderStore.ts`'s `commitItem` cleared the store-wide `state.committingItemId` singleton unconditionally in its `finally` block. Clicking "Commit" on a different row while another item's commit request is still in flight (up to 60s) overwrites `committingItemId` to the new row's id; when the first call resolves, its `finally` then nulls the flag out from under the still-running commit — silently dropping its committing/disabled UI state and allowing a duplicate click.

This is the identical shape as the already-fixed `generatingItemId` (PR #948) and `autoBuildingItemId` (PR #951) singleton races on this same store — this exact instance had been spotted in a prior cycle's audit but only logged as a known duplicate, not actually fixed in code.

Fix: only clear the flag if it's still ours, mirroring the existing `generatingItemId`/`autoBuildingItemId` pattern exactly (`if (state.committingItemId === item.id) state.committingItemId = null`).

### How I verified
- `npx eslint stores/modelBuilderStore.ts` — 2 pre-existing `no-empty` errors (lines 203/210), confirmed present via `git stash` with and without this change; no new lint issues.
- `npm run test` (`vue-tsc --noEmit` full project) — clean, exit 0.

### Stakes
reversible

---
_Generated by [Claude Code](https://claude.ai/code/session_013eaeb9zoXtZz4cgVvcsspo)_