### PR TITLE
wishmaster: add tutorial section under conductor channel

### DIFF
--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -540,6 +540,12 @@ export const tutorialChannels = {
         image: `images/tutorials/conductor/conductor.webp`,
       },
       {
+        key: 'wishmaster',
+        title: 'Wishmaster',
+        body: 'Turn a raw wish into a scoped, buildable project seed — the front door where a "wouldn\'t it be nice" becomes an actual plan, tracked as a Dream until it\'s ready to grow into real infrastructure.',
+        image: tutorialImage('conductor', 'wishmaster'),
+      },
+      {
         key: 'appmaker',
         title: 'AppMaker',
         body: 'The app factory — browse the fleet of apps already built, or spin up a new one from a name and a one-line description. Every app is a workspace folder, a project roadmap, and a Dream sharing one slug, so it plugs straight into the rest of Kind Robots.',


### PR DESCRIPTION
## Summary
- Wishmaster is live at `/wishmaster` (dashboard tab, conductor tabs/cards, nav cards, project placements) but had no matching `tutorialChannels.conductor.sections` entry, so the tutorial flyer never explained it alongside its sibling conductor-channel surfaces (Conductor, PortOS, AppMaker).
- Adds a `wishmaster` section to `stores/helpers/tutorialCards.ts` following the exact same shape/tone as its siblings. Image resolves via `tutorialImage('conductor', 'wishmaster')`; the actual `.webp` asset is queued through the normal self-draining art pipeline (like every other tutorial image before its art lands).

Corresponds to `conductor/wishmaster/t-003` step 2 ("add a matching section for 'wishmaster' under `tutorialChannels.conductor.sections`").

## Test plan
- [x] Reviewed diff — purely additive object literal matching sibling entries' shape, validated by the file's `satisfies Record<TutorialChannelKey, TutorialChannel>` assertion
- [ ] CI (TypeScript, lint, etc.)


---
_Generated by [Claude Code](https://claude.ai/code/session_013RNU7Z969e5r8DDf17s2e5)_