### PR TITLE
model-builder: fix batchingOutputKey ownership race in batch ops

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1325,7 +1325,14 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const label = field === 'artPrompt' ? 'prompt' : field
       setStatus('success', `Drafted ${label} for ${drafted}/${items.length} items.`)
     } finally {
-      state.batchingOutputKey = null
+      // state.batchingOutputKey is a store-wide singleton, same shape as
+      // generatingItemId/committingItemId/autoBuildingItemId above: selecting a
+      // different group and starting its own batch op while this one is still
+      // awaiting draftText() overwrites batchingOutputKey to that group's key,
+      // and this call's finally would then null it out from under the
+      // still-running batch — re-enabling that group's batch buttons mid-flight
+      // and allowing a duplicate concurrent batch op. Only clear if it's ours.
+      if (state.batchingOutputKey === outputKey) state.batchingOutputKey = null
     }
   }
 
@@ -1395,7 +1402,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         `Auto-built ${committed}/${items.length} in this group.`,
       )
     } finally {
-      state.batchingOutputKey = null
+      // Same ownership-check reasoning as batchDraftField above.
+      if (state.batchingOutputKey === outputKey) state.batchingOutputKey = null
     }
   }
 


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `batchDraftField` and `batchAutoBuild` each write the store-wide singleton `state.batchingOutputKey` and previously cleared it unconditionally in their `finally` block. Every sibling store-wide singleton in this file (`generatingItemId`, `committingItemId`, `autoBuildingItemId`, `draftingField`) already has an "only clear if it's still ours" ownership check — `batchingOutputKey` was the one instance of that pattern that got missed.
- Failure scenario: start "Auto-build group" (or a batch draft) on group A, then — while A is still running — select a different group B and start its own batch op. `model-builder-batch-editor.vue`'s `batching` computed gates every button off `store.batchingOutputKey === props.outputKey`, and the progress-matrix has no lock preventing mid-flight group switches. When A's loop finishes first, its `finally` unconditionally nulled `batchingOutputKey`, flipping B's `batching` computed to false while B's loop was still actually running — re-enabling B's buttons and allowing a second concurrent batch op over the same items (duplicate AI drafts / duplicate art-generation requests).
- Fix mirrors the exact pattern and comment style already used for the other four singletons: `if (state.batchingOutputKey === outputKey) state.batchingOutputKey = null`.

### How I verified
- `npx eslint stores/modelBuilderStore.ts`: only the 2 pre-existing `no-empty` errors (lines 203/210), confirmed present with and without this diff via `git stash`.
- `npm run test` (`vue-tsc --noEmit`, after provisioning deps via conductor's `provision_kind_robots_deps.sh`): no new errors introduced by this change. The run does show 3 pre-existing errors in unrelated files (`server/utils/facetCatalog.ts`, `utils/scripts/seedBotFacetCatalog.ts`, all `Property 'botFacet' does not exist`) — confirmed via `git stash` that these are present on `main` too (checked-in `prisma/generated/prisma/*` predates the `BotFacet` model added to `prisma/facet-catalog.prisma` in a recent commit); unrelated to this change, relying on CI's own fresh Prisma generation.
- Reverted the locally-regenerated `prisma/generated/prisma/*` files back to their committed state before committing, so this diff is scoped to the one intended file.

### Stakes
reversible

### Flags for Reviewer
- None — straightforward, scoped fix following an established pattern in this same file.

### Kaizen suggestion
The store now has 5 near-identical "store-wide singleton with ownership-check" implementations (`generatingItemId`, `committingItemId`, `autoBuildingItemId`, `draftingField`, `batchingOutputKey`). A small `createOwnedSingleton()` helper (set/clear-if-mine) could collapse the duplicated comment+conditional into one reusable primitive and make it structurally impossible to add a 6th one without the guard.

### Notes for reviewer
Found via the established "read the whole surface against the exclusion list of prior fixes" pattern for this recurring task (see roadmap note history on `model-builder/t-029`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GvB6J9UhGDqJ4rwtWXYpwx)_