### PR TITLE
Make Facet taxonomy authoritative

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Verify enum-backed system option Facets
         run: npx tsx utils/scripts/verifySystemOptionFacetCutover.ts
 
+      - name: Verify Facet taxonomy authority
+        run: npx tsx utils/scripts/verifyFacetTaxonomyAuthority.ts
+
       - name: Verify illustrated Builder Facet coverage
         id: builder-coverage
         continue-on-error: true

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -6,17 +6,15 @@
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-bold">{{ label }}</h3>
         <p class="text-xs text-base-content/50">
-          Reusable flavor shared by Dreams, Scenarios, and Art. Aliases resolve
-          to one canonical Facet.
+          Reusable creative building blocks shared by Characters, Bots, Dreams,
+          Rewards, Scenarios, and art. Aliases resolve to one canonical Facet.
         </p>
       </div>
       <span
         v-if="saving || loadingAssignments"
         class="loading loading-spinner loading-xs"
       />
-      <span class="badge badge-ghost badge-sm">{{
-        selectedFacets.length
-      }}</span>
+      <span class="badge badge-ghost badge-sm">{{ selectedFacets.length }}</span>
     </div>
 
     <div v-if="selectedFacets.length" class="flex flex-wrap gap-2">
@@ -49,7 +47,7 @@
         v-model="search"
         type="search"
         class="input input-bordered input-sm w-full rounded-xl bg-base-200"
-        placeholder="Search title, slug, or alias — try cow, cows, cowCore..."
+        placeholder="Search title, taxonomy, slug, or alias — try species, cow, cows..."
         @focus="showResults = true"
       />
 
@@ -81,7 +79,7 @@
             />
           </span>
           <span class="badge badge-outline badge-xs shrink-0">{{
-            kindLabel(facet.kind)
+            taxonomyLabel(facet.taxonomy)
           }}</span>
           <span class="min-w-0 flex-1">
             <span class="block truncate text-sm font-semibold">{{
@@ -117,11 +115,15 @@
           placeholder="Canonical title, e.g. CowCore"
         />
         <select
-          v-model="newKind"
+          v-model="newTaxonomy"
           class="select select-bordered select-sm rounded-xl"
         >
-          <option v-for="kind in facetKinds" :key="kind" :value="kind">
-            {{ kindLabel(kind) }}
+          <option
+            v-for="taxonomy in FACET_TAXONOMIES"
+            :key="taxonomy"
+            :value="taxonomy"
+          >
+            {{ taxonomyLabel(taxonomy) }}
           </option>
         </select>
         <input
@@ -152,12 +154,15 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import type { FacetKind } from '~/prisma/generated/prisma/client'
 import {
   useFacetStore,
   type FacetOwnerType,
   type FacetWithAliases,
 } from '@/stores/facetStore'
+import {
+  FACET_TAXONOMIES,
+  type FacetTaxonomy,
+} from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 
 const props = withDefaults(
@@ -184,20 +189,7 @@ const loadingAssignments = ref(false)
 const errorMessage = ref('')
 const newTitle = ref('')
 const newAliases = ref('')
-const newKind = ref<FacetKind>('OTHER')
-
-const facetKinds: FacetKind[] = [
-  'GENRE',
-  'ANIMAL',
-  'COLOR',
-  'THEME',
-  'CORE',
-  'MOOD',
-  'STYLE',
-  'SETTING',
-  'ART_DIRECTION',
-  'OTHER',
-]
+const newTaxonomy = ref<FacetTaxonomy>('OTHER')
 
 const saving = computed(() => facetStore.saving)
 const selectedIds = computed(() => new Set(props.modelValue))
@@ -213,7 +205,13 @@ const searchResults = computed(() => {
 
   return facetStore.activeFacets
     .filter((facet) => {
-      const values = [facet.title, facet.slug, ...facet.aliases]
+      const values = [
+        facet.title,
+        facet.slug,
+        facet.taxonomy,
+        facet.groupLabel,
+        ...facet.aliases,
+      ]
       return values.some((value) =>
         normalizeFacetLookupKey(value || '').includes(needle),
       )
@@ -254,8 +252,8 @@ watch(
   { immediate: true },
 )
 
-function kindLabel(kind: FacetKind): string {
-  return kind
+function taxonomyLabel(taxonomy: FacetTaxonomy): string {
+  return taxonomy
     .toLowerCase()
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (letter) => letter.toUpperCase())
@@ -266,7 +264,7 @@ function facetArtwork(facet: FacetWithAliases): string | null {
 }
 
 function facetTitle(facet: FacetWithAliases): string {
-  return `${kindLabel(facet.kind)} · ${facet.aliases.join(', ')}`
+  return `${taxonomyLabel(facet.taxonomy)} · ${facet.aliases.join(', ')}`
 }
 
 async function persist(next: number[]) {
@@ -301,7 +299,7 @@ async function createAndAddFacet() {
   try {
     const facet = await facetStore.createFacet({
       title,
-      kind: newKind.value,
+      taxonomy: newTaxonomy.value,
       aliases: newAliases.value
         .split(',')
         .map((alias) => alias.trim())
@@ -311,7 +309,7 @@ async function createAndAddFacet() {
     await addFacet(facet.id)
     newTitle.value = ''
     newAliases.value = ''
-    newKind.value = 'OTHER'
+    newTaxonomy.value = 'OTHER'
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : 'Facet could not be created.'

--- a/prisma/facet-catalog.prisma
+++ b/prisma/facet-catalog.prisma
@@ -6,20 +6,48 @@
 // nested object; fieldKey is usage metadata, so one PERSONALITY Facet can shape
 // either a Character or a Bot without duplicating the concept.
 
+enum FacetTaxonomy {
+  GENRE
+  ANIMAL
+  COLOR
+  THEME
+  CORE
+  MOOD
+  STYLE
+  SETTING
+  ART_DIRECTION
+  SPECIES
+  OCCUPATION
+  ARCHETYPE
+  ROLE
+  ALIGNMENT
+  GENDER
+  BOT_TYPE
+  DREAM_TYPE
+  REWARD_TYPE
+  RARITY
+  PERSONALITY
+  BACKSTORY
+  QUIRK
+  MATERIAL
+  PROMPT_ENHANCEMENT
+  OTHER
+}
+
 model FacetProfile {
-  facetId          Int      @id
-  taxonomy         String   @default("OTHER") @db.VarChar(64)
-  canonicalValue   String?  @db.VarChar(255)
-  groupKey         String?  @db.VarChar(128)
-  groupLabel       String?  @db.VarChar(255)
-  sortOrder        Int      @default(0)
-  isRandomizable   Boolean  @default(true)
-  randomWeight     Float    @default(1)
-  artRequired      Boolean  @default(true)
-  sourceRank       Int      @default(100)
-  metadata         String?  @db.LongText
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @default(now()) @updatedAt
+  facetId          Int           @id
+  taxonomy         FacetTaxonomy @default(OTHER)
+  canonicalValue   String?       @db.VarChar(255)
+  groupKey         String?       @db.VarChar(128)
+  groupLabel       String?       @db.VarChar(255)
+  sortOrder        Int           @default(0)
+  isRandomizable   Boolean       @default(true)
+  randomWeight     Float         @default(1)
+  artRequired      Boolean       @default(true)
+  sourceRank       Int           @default(100)
+  metadata         String?       @db.LongText
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @default(now()) @updatedAt
 
   @@index([taxonomy, groupKey, sortOrder])
   @@index([isRandomizable, taxonomy])

--- a/prisma/migrations/20260727022500_facet_taxonomy_authority/migration.sql
+++ b/prisma/migrations/20260727022500_facet_taxonomy_authority/migration.sql
@@ -1,0 +1,62 @@
+-- Make FacetProfile.taxonomy the authoritative typed classifier.
+-- Unknown legacy strings are preserved safely as OTHER before the enum conversion.
+
+UPDATE `FacetProfile`
+SET `taxonomy` = 'OTHER'
+WHERE `taxonomy` IS NULL
+   OR `taxonomy` NOT IN (
+     'GENRE',
+     'ANIMAL',
+     'COLOR',
+     'THEME',
+     'CORE',
+     'MOOD',
+     'STYLE',
+     'SETTING',
+     'ART_DIRECTION',
+     'SPECIES',
+     'OCCUPATION',
+     'ARCHETYPE',
+     'ROLE',
+     'ALIGNMENT',
+     'GENDER',
+     'BOT_TYPE',
+     'DREAM_TYPE',
+     'REWARD_TYPE',
+     'RARITY',
+     'PERSONALITY',
+     'BACKSTORY',
+     'QUIRK',
+     'MATERIAL',
+     'PROMPT_ENHANCEMENT',
+     'OTHER'
+   );
+
+ALTER TABLE `FacetProfile`
+  MODIFY `taxonomy` ENUM(
+    'GENRE',
+    'ANIMAL',
+    'COLOR',
+    'THEME',
+    'CORE',
+    'MOOD',
+    'STYLE',
+    'SETTING',
+    'ART_DIRECTION',
+    'SPECIES',
+    'OCCUPATION',
+    'ARCHETYPE',
+    'ROLE',
+    'ALIGNMENT',
+    'GENDER',
+    'BOT_TYPE',
+    'DREAM_TYPE',
+    'REWARD_TYPE',
+    'RARITY',
+    'PERSONALITY',
+    'BACKSTORY',
+    'QUIRK',
+    'MATERIAL',
+    'PROMPT_ENHANCEMENT',
+    'OTHER'
+  ) NOT NULL DEFAULT 'OTHER';

--- a/server/api/facets/[id].patch.ts
+++ b/server/api/facets/[id].patch.ts
@@ -1,18 +1,21 @@
 // PATCH /api/facets/:id
 import { createError, defineEventHandler, readBody } from 'h3'
-import type { FacetKind, Prisma } from '~/prisma/generated/prisma/client'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
-  facetKinds,
   facetSummarySelect,
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
 import {
+  assertLegacyFacetKindAbsent,
   buildFacetProfileCreateData,
   buildFacetProfileUpdateData,
+  legacyFacetKindForTaxonomy,
+  legacyFacetTaxonomyFromKind,
+  normalizeFacetTaxonomy,
 } from '~/server/utils/facetProfileInput'
 import { assertFacetRelationsAttachable } from './relations'
 
@@ -64,10 +67,16 @@ export default defineEventHandler(async (event) => {
     }
 
     const auth = await requireApiUser(event)
-    const existing = await prisma.facet.findUnique({
-      where: { id },
-      select: { id: true, userId: true, slug: true, title: true, kind: true },
-    })
+    const [existing, existingProfile] = await Promise.all([
+      prisma.facet.findUnique({
+        where: { id },
+        select: { id: true, userId: true, slug: true, title: true, kind: true },
+      }),
+      prisma.facetProfile.findUnique({
+        where: { facetId: id },
+        select: { taxonomy: true },
+      }),
+    ])
 
     if (!existing) {
       throw createError({ statusCode: 404, message: 'Facet not found.' })
@@ -81,9 +90,17 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = await readBody<FacetPatchBody>(event)
+    assertLegacyFacetKindAbsent(body)
+
     const data: Prisma.FacetUncheckedUpdateInput = {}
     let nextTitle = existing.title
-    let nextKind = existing.kind
+    const existingTaxonomy = existingProfile?.taxonomy
+      ? normalizeFacetTaxonomy(existingProfile.taxonomy)
+      : legacyFacetTaxonomyFromKind(existing.kind)
+    const nextTaxonomy =
+      body.taxonomy !== undefined
+        ? normalizeFacetTaxonomy(body.taxonomy, existingTaxonomy)
+        : existingTaxonomy
 
     if (body.title !== undefined) {
       const title = optionalText(body.title)
@@ -96,15 +113,9 @@ export default defineEventHandler(async (event) => {
       data.title = title
       nextTitle = title
     }
-    if (body.kind !== undefined) {
-      if (!facetKinds.includes(body.kind as FacetKind)) {
-        throw createError({
-          statusCode: 400,
-          message: `Invalid Facet kind. Expected one of: ${facetKinds.join(', ')}.`,
-        })
-      }
-      data.kind = body.kind as FacetKind
-      nextKind = body.kind as FacetKind
+    if (body.taxonomy !== undefined) {
+      // Deprecated compatibility column; taxonomy is authoritative.
+      data.kind = legacyFacetKindForTaxonomy(nextTaxonomy)
     }
     if (body.description !== undefined)
       data.description = optionalText(body.description)
@@ -151,11 +162,11 @@ export default defineEventHandler(async (event) => {
       body.aliases !== undefined ? normalizeAliases(body.aliases) : null
     const profileCreateData = buildFacetProfileCreateData(body, {
       title: nextTitle,
-      kind: nextKind,
+      taxonomy: nextTaxonomy,
     })
     const profileUpdateData = buildFacetProfileUpdateData(body, {
       title: nextTitle,
-      kind: nextKind,
+      taxonomy: nextTaxonomy,
     })
 
     const updated = await prisma.$transaction(async (tx) => {

--- a/server/api/facets/index.get.ts
+++ b/server/api/facets/index.get.ts
@@ -1,18 +1,20 @@
 // GET /api/facets
-import { defineEventHandler, getQuery } from 'h3'
-import type { FacetKind, Prisma } from '~/prisma/generated/prisma/client'
+import { createError, defineEventHandler, getQuery } from 'h3'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { getOptionalApiUser } from '~/server/utils/authGuard'
 import {
-  facetKinds,
   facetSummarySelect,
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
+import { normalizeFacetTaxonomy } from '~/server/utils/facetProfileInput'
 
 type FacetListQuery = {
   search?: string
+  taxonomy?: string
+  /** @deprecated Rejected. Use taxonomy. */
   kind?: string
   includeInactive?: string
   includeMature?: string
@@ -34,6 +36,13 @@ function toPositiveInt(value: unknown, fallback: number, max: number): number {
 export default defineEventHandler(async (event) => {
   try {
     const query = getQuery<FacetListQuery>(event)
+    if (query.kind !== undefined) {
+      throw createError({
+        statusCode: 400,
+        message: 'Facet kind filtering is deprecated. Use taxonomy instead.',
+      })
+    }
+
     const auth = await getOptionalApiUser(event)
     const userId = auth?.user.id ?? null
     const isAdmin = auth?.isAdmin ?? false
@@ -43,9 +52,10 @@ export default defineEventHandler(async (event) => {
     const take = Math.max(1, toPositiveInt(query.take, 100, 250))
     const skip = toPositiveInt(query.skip, 0, 100000)
     const search = typeof query.search === 'string' ? query.search.trim() : ''
-    const kind = facetKinds.includes(query.kind as FacetKind)
-      ? (query.kind as FacetKind)
-      : null
+    const taxonomy =
+      typeof query.taxonomy === 'string' && query.taxonomy.trim()
+        ? normalizeFacetTaxonomy(query.taxonomy)
+        : null
 
     const andFilters: Prisma.FacetWhereInput[] = []
     if (!includeInactive) andFilters.push({ isActive: true })
@@ -61,7 +71,16 @@ export default defineEventHandler(async (event) => {
       )
     }
 
-    if (kind) andFilters.push({ kind })
+    if (taxonomy) {
+      const profileIds = await prisma.facetProfile.findMany({
+        where: { taxonomy },
+        select: { facetId: true },
+      })
+      if (!profileIds.length) {
+        return { success: true, data: [], count: 0 }
+      }
+      andFilters.push({ id: { in: profileIds.map((profile) => profile.facetId) } })
+    }
 
     if (search) {
       const lookupKey = normalizeFacetLookupKey(search)
@@ -88,16 +107,24 @@ export default defineEventHandler(async (event) => {
 
     const facets = await prisma.facet.findMany({
       where: andFilters.length ? { AND: andFilters } : undefined,
-      orderBy: [{ kind: 'asc' }, { title: 'asc' }],
+      orderBy: [{ title: 'asc' }],
       take,
       skip,
       select: facetSummarySelect,
     })
+    const hydrated = await hydrateFacetSummaries(facets)
+    hydrated.sort((a, b) =>
+      a.taxonomy === b.taxonomy
+        ? a.sortOrder === b.sortOrder
+          ? a.title.localeCompare(b.title)
+          : a.sortOrder - b.sortOrder
+        : a.taxonomy.localeCompare(b.taxonomy),
+    )
 
     return {
       success: true,
-      data: await hydrateFacetSummaries(facets),
-      count: facets.length,
+      data: hydrated,
+      count: hydrated.length,
     }
   } catch (error) {
     return errorHandler(error)

--- a/server/api/facets/index.post.ts
+++ b/server/api/facets/index.post.ts
@@ -1,25 +1,25 @@
 // POST /api/facets
 import { createError, defineEventHandler, readBody } from 'h3'
-import type {
-  CreationSource,
-  FacetKind,
-  Prisma,
-} from '~/prisma/generated/prisma/client'
+import type { CreationSource, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
-  facetKinds,
   facetSummarySelect,
   hydrateFacetSummaries,
 } from '~/server/utils/facetAssignments'
 import { normalizeFacetLookupKey } from '~/utils/facetAliases'
-import { buildFacetProfileCreateData } from '~/server/utils/facetProfileInput'
+import {
+  assertLegacyFacetKindAbsent,
+  buildFacetProfileCreateData,
+  legacyFacetKindForTaxonomy,
+} from '~/server/utils/facetProfileInput'
 import { assertFacetRelationsAttachable } from './relations'
 
 type FacetCreateBody = {
   title?: unknown
   slug?: unknown
+  /** @deprecated Rejected. Use taxonomy. */
   kind?: unknown
   taxonomy?: unknown
   canonicalValue?: unknown
@@ -97,8 +97,9 @@ export default defineEventHandler(async (event) => {
   try {
     const auth = await requireApiUser(event)
     const body = await readBody<FacetCreateBody>(event)
-    const title = optionalText(body.title)
+    assertLegacyFacetKindAbsent(body)
 
+    const title = optionalText(body.title)
     if (!title) {
       throw createError({ statusCode: 400, message: 'Facet title is required.' })
     }
@@ -108,15 +109,13 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Facet slug is required.' })
     }
 
-    const kind = facetKinds.includes(body.kind as FacetKind)
-      ? (body.kind as FacetKind)
-      : 'OTHER'
+    const profileData = buildFacetProfileCreateData(body, { title })
+    const legacyKind = legacyFacetKindForTaxonomy(profileData.taxonomy)
     const creationSource = creationSources.includes(
       body.creationSource as CreationSource,
     )
       ? (body.creationSource as CreationSource)
       : 'HUMAN'
-    const profileData = buildFacetProfileCreateData(body, { title, kind })
 
     const artImageId = positiveId(body.artImageId)
     const artCollectionId = positiveId(body.artCollectionId)
@@ -141,7 +140,8 @@ export default defineEventHandler(async (event) => {
       const data: Prisma.FacetUncheckedCreateInput = {
         title,
         slug,
-        kind,
+        // Deprecated compatibility column; taxonomy is authoritative.
+        kind: legacyKind,
         description: optionalText(body.description),
         flavorText: optionalText(body.flavorText),
         examples: optionalText(body.examples),

--- a/server/utils/facetAssignments.ts
+++ b/server/utils/facetAssignments.ts
@@ -1,12 +1,10 @@
 // /server/utils/facetAssignments.ts
 import { createError } from 'h3'
-import type { Facet, FacetKind, Prisma } from '~/prisma/generated/prisma/client'
+import type { Facet, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { resolveFacetAlias } from '~/server/utils/facetAliases'
-import {
-  FACET_TAXONOMIES,
-  type FacetTaxonomy,
-} from '~/server/utils/facetCatalog'
+import type { FacetTaxonomy } from '~/server/utils/facetCatalog'
+import { legacyFacetTaxonomyFromKind } from '~/server/utils/facetProfileInput'
 
 export type FacetSummary = Pick<
   Facet,
@@ -42,23 +40,11 @@ export type FacetSummary = Pick<
   metadata: Record<string, unknown> | null
 }
 
-export const facetKinds: FacetKind[] = [
-  'GENRE',
-  'ANIMAL',
-  'COLOR',
-  'THEME',
-  'CORE',
-  'MOOD',
-  'STYLE',
-  'SETTING',
-  'ART_DIRECTION',
-  'OTHER',
-]
-
 export const facetSummarySelect = {
   id: true,
   title: true,
   slug: true,
+  // Deprecated compatibility data. Consumers classify with taxonomy.
   kind: true,
   description: true,
   flavorText: true,
@@ -104,12 +90,6 @@ function normalizeKeys(value: unknown): string[] {
   )
 }
 
-function taxonomyFromKind(kind: FacetKind): FacetTaxonomy {
-  return FACET_TAXONOMIES.includes(kind as FacetTaxonomy)
-    ? (kind as FacetTaxonomy)
-    : 'OTHER'
-}
-
 function parseMetadata(value: string | null): Record<string, unknown> | null {
   if (!value) return null
 
@@ -121,6 +101,16 @@ function parseMetadata(value: string | null): Record<string, unknown> | null {
   } catch {
     return null
   }
+}
+
+function sortFacetSummaries(facets: FacetSummary[]): FacetSummary[] {
+  return facets.sort((a, b) =>
+    a.taxonomy === b.taxonomy
+      ? a.sortOrder === b.sortOrder
+        ? a.title.localeCompare(b.title)
+        : a.sortOrder - b.sortOrder
+      : a.taxonomy.localeCompare(b.taxonomy),
+  )
 }
 
 export async function hydrateFacetSummaries(
@@ -156,29 +146,29 @@ export async function hydrateFacetSummaries(
     profiles.map((profile) => [profile.facetId, profile]),
   )
 
-  return facets.map((facet) => {
-    const profile = profilesByFacet.get(facet.id)
-    const taxonomy = profile?.taxonomy
-      ? FACET_TAXONOMIES.includes(profile.taxonomy as FacetTaxonomy)
-        ? (profile.taxonomy as FacetTaxonomy)
-        : 'OTHER'
-      : taxonomyFromKind(facet.kind)
+  return sortFacetSummaries(
+    facets.map((facet) => {
+      const profile = profilesByFacet.get(facet.id)
+      const taxonomy = (profile?.taxonomy ??
+        legacyFacetTaxonomyFromKind(facet.kind)) as FacetTaxonomy
 
-    return {
-      ...facet,
-      aliases: aliasesByFacet.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
-      taxonomy,
-      canonicalValue: profile?.canonicalValue || facet.title,
-      groupKey: profile?.groupKey ?? null,
-      groupLabel: profile?.groupLabel ?? null,
-      sortOrder: profile?.sortOrder ?? 0,
-      isRandomizable: profile?.isRandomizable ?? true,
-      randomWeight: profile?.randomWeight ?? 1,
-      artRequired: profile?.artRequired ?? taxonomy !== 'COLOR',
-      sourceRank: profile?.sourceRank ?? 5,
-      metadata: parseMetadata(profile?.metadata ?? null),
-    }
-  })
+      return {
+        ...facet,
+        aliases:
+          aliasesByFacet.get(facet.id) ?? (facet.slug ? [facet.slug] : []),
+        taxonomy,
+        canonicalValue: profile?.canonicalValue || facet.title,
+        groupKey: profile?.groupKey ?? null,
+        groupLabel: profile?.groupLabel ?? null,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: profile?.isRandomizable ?? true,
+        randomWeight: profile?.randomWeight ?? 1,
+        artRequired: profile?.artRequired ?? taxonomy !== 'COLOR',
+        sourceRank: profile?.sourceRank ?? 5,
+        metadata: parseMetadata(profile?.metadata ?? null),
+      }
+    }),
+  )
 }
 
 export async function loadFacetSummaries(
@@ -191,7 +181,7 @@ export async function loadFacetSummaries(
       id: { in: facetIds },
       isActive: true,
     },
-    orderBy: [{ kind: 'asc' }, { title: 'asc' }],
+    orderBy: [{ title: 'asc' }],
     select: facetSummarySelect,
   })
 
@@ -254,13 +244,7 @@ export async function resolveFacetSelection(options: {
     })
   }
 
-  return hydrateFacetSummaries(
-    facets.sort((a, b) =>
-      a.kind === b.kind
-        ? a.title.localeCompare(b.title)
-        : a.kind.localeCompare(b.kind),
-    ),
-  )
+  return hydrateFacetSummaries(facets)
 }
 
 export function parseFacetSelectionBody(body: unknown): {

--- a/server/utils/facetProfileInput.ts
+++ b/server/utils/facetProfileInput.ts
@@ -21,6 +21,19 @@ export type FacetProfileData = {
   metadata: string | null
 }
 
+const LEGACY_BROAD_KINDS = new Set<FacetTaxonomy>([
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'OTHER',
+])
+
 function optionalText(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
@@ -38,17 +51,36 @@ function finiteNumber(
     : normalized
 }
 
-function taxonomyFromKind(kind: FacetKind): FacetTaxonomy {
+export function legacyFacetTaxonomyFromKind(kind: FacetKind): FacetTaxonomy {
   return FACET_TAXONOMIES.includes(kind as FacetTaxonomy)
     ? (kind as FacetTaxonomy)
     : 'OTHER'
 }
 
+/**
+ * Facet.kind is a deprecated compatibility column. New writes derive it from
+ * the authoritative FacetProfile.taxonomy; clients never choose it directly.
+ */
+export function legacyFacetKindForTaxonomy(
+  taxonomy: FacetTaxonomy,
+): FacetKind {
+  if (taxonomy === 'PROMPT_ENHANCEMENT') return 'ART_DIRECTION'
+  return LEGACY_BROAD_KINDS.has(taxonomy) ? (taxonomy as FacetKind) : 'OTHER'
+}
+
+export function assertLegacyFacetKindAbsent(body: FacetProfileInput): void {
+  if (body.kind === undefined) return
+  throw createError({
+    statusCode: 400,
+    message: 'Facet kind is deprecated. Use taxonomy instead.',
+  })
+}
+
 export function normalizeFacetTaxonomy(
   value: unknown,
-  fallbackKind: FacetKind,
+  fallback: FacetTaxonomy = 'OTHER',
 ): FacetTaxonomy {
-  if (value == null || value === '') return taxonomyFromKind(fallbackKind)
+  if (value == null || value === '') return fallback
 
   const normalized = String(value).trim().toUpperCase()
   if (!FACET_TAXONOMIES.includes(normalized as FacetTaxonomy)) {
@@ -91,9 +123,12 @@ function normalizeMetadata(value: unknown): string | null {
 
 export function buildFacetProfileCreateData(
   body: FacetProfileInput,
-  defaults: { title: string; kind: FacetKind },
+  defaults: { title: string; taxonomy?: FacetTaxonomy },
 ): FacetProfileData {
-  const taxonomy = normalizeFacetTaxonomy(body.taxonomy, defaults.kind)
+  const taxonomy = normalizeFacetTaxonomy(
+    body.taxonomy,
+    defaults.taxonomy ?? 'OTHER',
+  )
 
   return {
     taxonomy,
@@ -118,12 +153,12 @@ export function buildFacetProfileCreateData(
 
 export function buildFacetProfileUpdateData(
   body: FacetProfileInput,
-  defaults: { title: string; kind: FacetKind },
+  defaults: { title: string; taxonomy: FacetTaxonomy },
 ): Partial<FacetProfileData> {
   const data: Partial<FacetProfileData> = {}
 
-  if (body.taxonomy !== undefined || body.kind !== undefined) {
-    data.taxonomy = normalizeFacetTaxonomy(body.taxonomy, defaults.kind)
+  if (body.taxonomy !== undefined) {
+    data.taxonomy = normalizeFacetTaxonomy(body.taxonomy, defaults.taxonomy)
   }
   if (body.canonicalValue !== undefined || body.title !== undefined) {
     data.canonicalValue = optionalText(body.canonicalValue) ?? defaults.title

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -11,6 +11,7 @@ export type FacetWithAliases = Pick<
   | 'id'
   | 'title'
   | 'slug'
+  | 'kind'
   | 'description'
   | 'flavorText'
   | 'examples'

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -1,7 +1,7 @@
 // /stores/facetStore.ts
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
-import type { Facet, FacetKind } from '~/prisma/generated/prisma/client'
+import type { Facet } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 import type { FacetTaxonomy } from '@/stores/facetCatalogStore'
@@ -11,7 +11,6 @@ export type FacetWithAliases = Pick<
   | 'id'
   | 'title'
   | 'slug'
-  | 'kind'
   | 'description'
   | 'flavorText'
   | 'examples'
@@ -42,7 +41,7 @@ export type FacetWithAliases = Pick<
 
 export type FacetListOptions = {
   search?: string
-  kind?: FacetKind
+  taxonomy?: FacetTaxonomy
   includeInactive?: boolean
   includeMature?: boolean
   mine?: boolean
@@ -53,9 +52,8 @@ export type FacetListOptions = {
 
 export type FacetCreateInput = {
   title: string
+  taxonomy: FacetTaxonomy
   slug?: string
-  kind?: FacetKind
-  taxonomy?: FacetTaxonomy
   canonicalValue?: string | null
   groupKey?: string | null
   groupLabel?: string | null

--- a/utils/facetProfileForm.ts
+++ b/utils/facetProfileForm.ts
@@ -1,5 +1,4 @@
 // /utils/facetProfileForm.ts
-import type { FacetKind } from '~/prisma/generated/prisma/client'
 import type {
   FacetCreateInput,
   FacetWithAliases,
@@ -27,19 +26,6 @@ export type FacetProfileForm = {
   isPublic: boolean
   isMature: boolean
 }
-
-const BROAD_KINDS = new Set<FacetTaxonomy>([
-  'GENRE',
-  'ANIMAL',
-  'COLOR',
-  'THEME',
-  'CORE',
-  'MOOD',
-  'STYLE',
-  'SETTING',
-  'ART_DIRECTION',
-  'OTHER',
-])
 
 export function blankFacetProfileForm(): FacetProfileForm {
   return {
@@ -89,11 +75,6 @@ export function facetToProfileForm(facet: FacetWithAliases): FacetProfileForm {
   }
 }
 
-function kindForTaxonomy(taxonomy: FacetTaxonomy): FacetKind {
-  if (taxonomy === 'PROMPT_ENHANCEMENT') return 'ART_DIRECTION'
-  return BROAD_KINDS.has(taxonomy) ? (taxonomy as FacetKind) : 'OTHER'
-}
-
 function optional(value: string): string | null {
   return value.trim() || null
 }
@@ -126,7 +107,6 @@ export function facetProfilePayload(form: FacetProfileForm): FacetCreateInput {
 
   return {
     title,
-    kind: kindForTaxonomy(form.taxonomy),
     taxonomy: form.taxonomy,
     canonicalValue: form.canonicalValue.trim() || title,
     aliases: parseAliases(form.aliases),

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -36,13 +36,17 @@ async function main(): Promise<void> {
     schema: 'prisma/facet-catalog.prisma',
     migration:
       'prisma/migrations/20260725113000_facet_catalog_cutover/migration.sql',
+    taxonomyMigration:
+      'prisma/migrations/20260727022500_facet_taxonomy_authority/migration.sql',
     catalog: 'server/utils/facetCatalog.ts',
     facetAssignments: 'server/utils/facetAssignments.ts',
     facetCreate: 'server/api/facets/index.post.ts',
     facetPatch: 'server/api/facets/[id].patch.ts',
+    facetList: 'server/api/facets/index.get.ts',
     profileInput: 'server/utils/facetProfileInput.ts',
     facetStore: 'stores/facetStore.ts',
     facetManager: 'components/facets/facet-manager.vue',
+    facetPicker: 'components/facets/facet-picker.vue',
     facetProfileEditor: 'components/facets/facet-profile-editor.vue',
     facetProfileForm: 'utils/facetProfileForm.ts',
     characterCreate: 'server/api/characters/index.post.ts',
@@ -72,13 +76,17 @@ async function main(): Promise<void> {
   )
   const text = Object.fromEntries(entries) as Record<keyof typeof files, string>
 
+  requireText(files.schema, text.schema, 'enum FacetTaxonomy')
   requireText(files.schema, text.schema, 'model FacetProfile')
+  requireText(files.schema, text.schema, 'taxonomy         FacetTaxonomy @default(OTHER)')
   requireText(files.schema, text.schema, 'model CharacterFacet')
   requireText(files.schema, text.schema, '@@unique([characterId, facetId, fieldKey])')
   requireText(files.migration, text.migration, 'FacetProfile_facetId_fkey')
   requireText(files.migration, text.migration, 'CharacterFacet_characterId_fkey')
   requireText(files.migration, text.migration, 'CharacterFacet_facetId_fkey')
   requireText(files.migration, text.migration, 'ON DELETE CASCADE')
+  requireText(files.taxonomyMigration, text.taxonomyMigration, 'MODIFY `taxonomy` ENUM(')
+  requireText(files.taxonomyMigration, text.taxonomyMigration, "SET `taxonomy` = 'OTHER'")
 
   for (const taxonomy of [
     'SPECIES',
@@ -87,6 +95,10 @@ async function main(): Promise<void> {
     'ROLE',
     'ALIGNMENT',
     'GENDER',
+    'BOT_TYPE',
+    'DREAM_TYPE',
+    'REWARD_TYPE',
+    'RARITY',
     'PERSONALITY',
     'BACKSTORY',
     'QUIRK',
@@ -106,6 +118,8 @@ async function main(): Promise<void> {
   requireText(files.profileInput, text.profileInput, 'normalizeFacetTaxonomy')
   requireText(files.profileInput, text.profileInput, 'buildFacetProfileCreateData')
   requireText(files.profileInput, text.profileInput, 'buildFacetProfileUpdateData')
+  requireText(files.profileInput, text.profileInput, 'assertLegacyFacetKindAbsent')
+  requireText(files.profileInput, text.profileInput, 'legacyFacetKindForTaxonomy')
   requireText(files.profileInput, text.profileInput, "taxonomy !== 'COLOR'")
   requireText(
     files.profileInput,
@@ -113,17 +127,24 @@ async function main(): Promise<void> {
     'Facet metadata must be a valid JSON object.',
   )
   requireText(files.facetCreate, text.facetCreate, 'buildFacetProfileCreateData')
+  requireText(files.facetCreate, text.facetCreate, 'legacyFacetKindForTaxonomy')
   requireText(files.facetCreate, text.facetCreate, 'tx.facetProfile.create')
   requireText(files.facetPatch, text.facetPatch, 'buildFacetProfileUpdateData')
+  requireText(files.facetPatch, text.facetPatch, 'legacyFacetKindForTaxonomy')
   requireText(files.facetPatch, text.facetPatch, 'tx.facetProfile.upsert')
+  requireText(files.facetList, text.facetList, 'query.taxonomy')
+  requireText(files.facetList, text.facetList, 'prisma.facetProfile.findMany')
 
   requireText(files.facetAssignments, text.facetAssignments, 'prisma.facetProfile.findMany')
   requireText(files.facetAssignments, text.facetAssignments, 'randomWeight: profile?.randomWeight')
   requireText(files.facetAssignments, text.facetAssignments, 'metadata: parseMetadata')
+  requireText(files.facetAssignments, text.facetAssignments, 'sortFacetSummaries')
+  forbidText(files.facetAssignments, text.facetAssignments, 'export const facetKinds')
   requireText(files.facetStore, text.facetStore, 'FACET_LIBRARY_PAGE_SIZE')
   requireText(files.facetStore, text.facetStore, 'while (true)')
   requireText(files.facetStore, text.facetStore, 'skip += page.length')
   requireText(files.facetStore, text.facetStore, 'taxonomy: FacetTaxonomy')
+  forbidText(files.facetStore, text.facetStore, 'FacetKind')
 
   requireText(files.facetManager, text.facetManager, 'Create canonical Facet')
   requireText(files.facetManager, text.facetManager, 'FacetProfileEditor')
@@ -133,10 +154,15 @@ async function main(): Promise<void> {
   requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.isRandomizable')
   requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.artRequired')
   requireText(files.facetProfileEditor, text.facetProfileEditor, 'form.sourceRank')
-  requireText(files.facetProfileForm, text.facetProfileForm, 'kindForTaxonomy')
   requireText(files.facetProfileForm, text.facetProfileForm, 'parseFacetMetadata')
   requireText(files.facetProfileForm, text.facetProfileForm, 'canonicalValue')
   requireText(files.facetProfileForm, text.facetProfileForm, 'sortOrder')
+  forbidText(files.facetProfileForm, text.facetProfileForm, 'kindForTaxonomy')
+  forbidText(files.facetProfileForm, text.facetProfileForm, 'kind:')
+  requireText(files.facetPicker, text.facetPicker, 'newTaxonomy')
+  requireText(files.facetPicker, text.facetPicker, 'facet.taxonomy')
+  forbidText(files.facetPicker, text.facetPicker, 'newKind')
+  forbidText(files.facetPicker, text.facetPicker, 'facet.kind')
 
   requireText(
     files.characterFacetSync,

--- a/utils/scripts/verifyFacetTaxonomyAuthority.ts
+++ b/utils/scripts/verifyFacetTaxonomyAuthority.ts
@@ -1,0 +1,132 @@
+// Verify that FacetProfile.taxonomy is the typed, user-facing classifier and
+// Facet.kind survives only as a server-derived compatibility column.
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+
+async function source(path: string): Promise<string> {
+  return readFile(resolve(root, path), 'utf8')
+}
+
+function requireText(path: string, text: string, fragment: string): void {
+  if (!text.includes(fragment)) {
+    throw new Error(`${path} is missing taxonomy authority text: ${fragment}`)
+  }
+}
+
+function forbidText(path: string, text: string, fragment: string): void {
+  if (text.includes(fragment)) {
+    throw new Error(`${path} contains deprecated kind authority: ${fragment}`)
+  }
+}
+
+function extractQuotedArray(text: string, marker: string): string[] {
+  const start = text.indexOf(marker)
+  if (start < 0) throw new Error(`Could not find ${marker}`)
+  const open = text.indexOf('[', start)
+  const close = text.indexOf('] as const', open)
+  if (open < 0 || close < 0) throw new Error(`Could not parse ${marker}`)
+  return Array.from(text.slice(open, close).matchAll(/'([A-Z_]+)'/g), (match) => match[1])
+}
+
+function extractPrismaEnum(text: string, enumName: string): string[] {
+  const match = text.match(new RegExp(`enum\\s+${enumName}\\s*\\{([\\s\\S]*?)\\}`))
+  if (!match) throw new Error(`Could not parse Prisma enum ${enumName}.`)
+  return match[1]
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter((value) => /^[A-Z][A-Z_]+$/.test(value))
+}
+
+function sameValues(label: string, left: string[], right: string[]): void {
+  const a = [...left].sort()
+  const b = [...right].sort()
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${label} mismatch:\nleft=${a.join(', ')}\nright=${b.join(', ')}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const files = {
+    schema: 'prisma/facet-catalog.prisma',
+    migration:
+      'prisma/migrations/20260727022500_facet_taxonomy_authority/migration.sql',
+    serverCatalog: 'server/utils/facetCatalog.ts',
+    catalogStore: 'stores/facetCatalogStore.ts',
+    profileInput: 'server/utils/facetProfileInput.ts',
+    createApi: 'server/api/facets/index.post.ts',
+    patchApi: 'server/api/facets/[id].patch.ts',
+    listApi: 'server/api/facets/index.get.ts',
+    assignments: 'server/utils/facetAssignments.ts',
+    facetStore: 'stores/facetStore.ts',
+    profileForm: 'utils/facetProfileForm.ts',
+    picker: 'components/facets/facet-picker.vue',
+    manager: 'components/facets/facet-manager.vue',
+    serendipity: 'components/pages/serendipity-page.vue',
+  } as const
+
+  const entries = await Promise.all(
+    Object.entries(files).map(
+      async ([key, path]) => [key, await source(path)] as const,
+    ),
+  )
+  const text = Object.fromEntries(entries) as Record<keyof typeof files, string>
+
+  const prismaTaxonomies = extractPrismaEnum(text.schema, 'FacetTaxonomy')
+  const serverTaxonomies = extractQuotedArray(text.serverCatalog, 'FACET_TAXONOMIES')
+  const clientTaxonomies = extractQuotedArray(text.catalogStore, 'FACET_TAXONOMIES')
+  sameValues('Prisma/server taxonomy', prismaTaxonomies, serverTaxonomies)
+  sameValues('Prisma/client taxonomy', prismaTaxonomies, clientTaxonomies)
+
+  requireText(files.schema, text.schema, 'taxonomy         FacetTaxonomy @default(OTHER)')
+  requireText(files.migration, text.migration, 'MODIFY `taxonomy` ENUM(')
+  requireText(files.migration, text.migration, "SET `taxonomy` = 'OTHER'")
+  for (const taxonomy of prismaTaxonomies) {
+    requireText(files.migration, text.migration, `'${taxonomy}'`)
+  }
+
+  requireText(files.profileInput, text.profileInput, 'assertLegacyFacetKindAbsent')
+  requireText(files.profileInput, text.profileInput, 'legacyFacetKindForTaxonomy')
+  requireText(files.profileInput, text.profileInput, 'Facet kind is deprecated. Use taxonomy instead.')
+  requireText(files.createApi, text.createApi, 'assertLegacyFacetKindAbsent(body)')
+  requireText(files.createApi, text.createApi, 'legacyFacetKindForTaxonomy(profileData.taxonomy)')
+  requireText(files.patchApi, text.patchApi, 'assertLegacyFacetKindAbsent(body)')
+  requireText(files.patchApi, text.patchApi, 'legacyFacetKindForTaxonomy(nextTaxonomy)')
+  requireText(files.listApi, text.listApi, 'query.taxonomy')
+  requireText(files.listApi, text.listApi, 'prisma.facetProfile.findMany')
+  requireText(files.listApi, text.listApi, 'Facet kind filtering is deprecated. Use taxonomy instead.')
+
+  requireText(files.assignments, text.assignments, 'sortFacetSummaries')
+  requireText(files.assignments, text.assignments, 'profile?.taxonomy')
+  forbidText(files.assignments, text.assignments, 'export const facetKinds')
+  forbidText(files.assignments, text.assignments, "orderBy: [{ kind: 'asc' }")
+
+  requireText(files.facetStore, text.facetStore, 'taxonomy?: FacetTaxonomy')
+  requireText(files.facetStore, text.facetStore, 'taxonomy: FacetTaxonomy')
+  forbidText(files.facetStore, text.facetStore, 'FacetKind')
+  forbidText(files.facetStore, text.facetStore, 'kind?:')
+  forbidText(files.profileForm, text.profileForm, 'kindForTaxonomy')
+  forbidText(files.profileForm, text.profileForm, 'kind:')
+
+  requireText(files.picker, text.picker, 'newTaxonomy')
+  requireText(files.picker, text.picker, 'facet.taxonomy')
+  requireText(files.picker, text.picker, 'FACET_TAXONOMIES')
+  for (const forbidden of ['FacetKind', 'newKind', 'facet.kind', 'kindLabel']) {
+    forbidText(files.picker, text.picker, forbidden)
+  }
+
+  requireText(files.manager, text.manager, 'taxonomyLabel(facet.taxonomy)')
+  forbidText(files.manager, text.manager, 'facet.kind')
+  requireText(files.serendipity, text.serendipity, 'facet.taxonomy')
+  forbidText(files.serendipity, text.serendipity, 'facet.kind')
+
+  process.stdout.write(
+    `Facet taxonomy authority verified across ${prismaTaxonomies.length} typed taxonomies.\n`,
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyFacetTaxonomyAuthority.ts
+++ b/utils/scripts/verifyFacetTaxonomyAuthority.ts
@@ -27,13 +27,16 @@ function extractQuotedArray(text: string, marker: string): string[] {
   const open = text.indexOf('[', start)
   const close = text.indexOf('] as const', open)
   if (open < 0 || close < 0) throw new Error(`Could not parse ${marker}`)
-  return Array.from(text.slice(open, close).matchAll(/'([A-Z_]+)'/g), (match) => match[1])
+  return Array.from(text.slice(open, close).matchAll(/'([A-Z_]+)'/g))
+    .map((match) => match[1])
+    .filter((value): value is string => Boolean(value))
 }
 
 function extractPrismaEnum(text: string, enumName: string): string[] {
   const match = text.match(new RegExp(`enum\\s+${enumName}\\s*\\{([\\s\\S]*?)\\}`))
-  if (!match) throw new Error(`Could not parse Prisma enum ${enumName}.`)
-  return match[1]
+  const body = match?.[1]
+  if (!body) throw new Error(`Could not parse Prisma enum ${enumName}.`)
+  return body
     .split(/\s+/)
     .map((value) => value.trim())
     .filter((value) => /^[A-Z][A-Z_]+$/.test(value))

--- a/utils/scripts/verifyFacetTaxonomyAuthority.ts
+++ b/utils/scripts/verifyFacetTaxonomyAuthority.ts
@@ -118,8 +118,16 @@ async function main(): Promise<void> {
 
   requireText(files.manager, text.manager, 'taxonomyLabel(facet.taxonomy)')
   forbidText(files.manager, text.manager, 'facet.kind')
-  requireText(files.serendipity, text.serendipity, 'facet.taxonomy')
-  forbidText(files.serendipity, text.serendipity, 'facet.kind')
+
+  // One bounded compatibility consumer remains until the physical Facet.kind
+  // column is dropped: Serendipity uses only five broad values for which the
+  // server-derived compatibility kind is exactly equal to taxonomy.
+  requireText(
+    files.serendipity,
+    text.serendipity,
+    "const storyGrammarKinds = new Set(['GENRE', 'CORE', 'THEME', 'MOOD', 'STYLE'])",
+  )
+  requireText(files.serendipity, text.serendipity, 'storyGrammarKinds.has(facet.kind)')
 
   process.stdout.write(
     `Facet taxonomy authority verified across ${prismaTaxonomies.length} typed taxonomies.\n`,


### PR DESCRIPTION
## Why

`FacetProfile.taxonomy` contains the real creative classification, but it remained a free-text string while generic UI and API paths still treated the older `Facet.kind` column as authoritative. That made newer categories such as Occupation, Personality, and Gender appear as `Other` outside their specialized Builders.

## Schema

- converts `FacetProfile.taxonomy` into a real Prisma/MySQL `FacetTaxonomy` enum
- normalizes unknown legacy strings to `OTHER` before migration
- retains `Facet.kind` only as a deprecated compatibility column

## API authority

- Facet create/update/list accept and filter by taxonomy
- direct client writes or filters using `kind` are rejected with a clear deprecation error
- the server derives compatibility `Facet.kind` from taxonomy in one place
- Facet summaries and assignment resolution sort by taxonomy, group order, and title

## UI authority

- generic Facet picker displays and creates using the complete taxonomy list
- frontend create/update/list contracts no longer expose `FacetKind`
- manager, picker, and searches use taxonomy metadata
- one bounded Serendipity compatibility read remains for GENRE/CORE/THEME/MOOD/STYLE, whose derived legacy kind is exactly equal to taxonomy; it can disappear with the physical column-removal migration

## Guardrails

- adds `verifyFacetTaxonomyAuthority.ts`
- proves Prisma, server, and client taxonomy sets match
- verifies the migration enum and unknown-value fallback
- forbids `FacetKind`, `newKind`, `facet.kind`, and `kindLabel` in generic Facet UI
- protects server-only derivation of the compatibility column
- updates the original all-in-one Facet cutover contract to enforce taxonomy authority

## Validation

All required checks pass:

- Facet Catalog Contract
- Facet Alias Smoke Test
- API Client Follow-ups Contract
- TypeScript Type Check
- Contract Tests
