### PR TITLE
art-styler: batch-hydrate gallery thumbnails past the first 24

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -860,6 +860,11 @@ const isDragging = ref(false)
 const gallerySearch = ref('')
 const galleryThumbs = ref<Record<number, string>>({})
 const isLoadingGallery = ref(false)
+// getArtImageById failures (404, network, no thumbnail/imagePath in the
+// response) are excluded from future hydrateGalleryThumbs() batches so a
+// permanently-unfetchable image can't keep the recursive drain below running
+// forever.
+const failedGalleryThumbIds = new Set<number>()
 // Shared across all three source tabs (upload/gallery/starters), not just
 // gallery-to-gallery: an in-flight starter or upload read can otherwise
 // resolve after a later selection on a different tab and silently overwrite
@@ -1258,7 +1263,10 @@ function clearSourceImage() {
 
 async function hydrateGalleryThumbs() {
   const missing = galleryImages.value
-    .filter((img) => !galleryThumbs.value[img.id])
+    .filter(
+      (img) =>
+        !galleryThumbs.value[img.id] && !failedGalleryThumbIds.has(img.id),
+    )
     .slice(0, 24)
 
   if (!missing.length) return
@@ -1275,7 +1283,8 @@ async function hydrateGalleryThumbs() {
           })
 
           const hydrated = fetched as
-            (ArtImage & { thumbnailData?: string | null }) | null
+            | (ArtImage & { thumbnailData?: string | null })
+            | null
 
           if (hydrated?.thumbnailData) {
             galleryThumbs.value = {
@@ -1287,14 +1296,28 @@ async function hydrateGalleryThumbs() {
               ...galleryThumbs.value,
               [img.id]: hydrated.imagePath,
             }
+          } else {
+            failedGalleryThumbIds.add(img.id)
           }
         } catch {
-          return
+          failedGalleryThumbIds.add(img.id)
         }
       }),
     )
   } finally {
     isLoadingGallery.value = false
+  }
+
+  // galleryImages.value shows up to 48 entries but each batch only fetches
+  // 24; without this, everything past the first batch stayed a permanent
+  // placeholder unless a search happened to narrow the list further.
+  if (
+    galleryImages.value.some(
+      (img) =>
+        !galleryThumbs.value[img.id] && !failedGalleryThumbIds.has(img.id),
+    )
+  ) {
+    void hydrateGalleryThumbs()
   }
 }
 


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (conductor): Academy continuous-improvement, lane 1 (front-end polish)  (kind: software)

### What changed / what I produced
- `components/art/art-styler.vue`: `hydrateGalleryThumbs()` in the Remix Studio "Gallery" source tab only ever fetched thumbnail data for the first 24 missing images per invocation (tab-open or search-change), while `galleryImages` shows up to 48. Any user with more than 24 images in their gallery saw everything past #24 permanently stuck on the gray placeholder icon (still selectable, just no thumbnail).
- Fixed by recursing after each batch completes, draining the remaining missing thumbnails automatically.
- Added a `failedGalleryThumbIds` Set so an image that fails to fetch (404 / network error / no thumbnail or imagePath in the response) is excluded from future batches — otherwise a permanently-unfetchable image would keep the new recursion running forever.

### How I verified
- `npx eslint components/art/art-styler.vue` — clean
- `npm run test` (`vue-tsc --noEmit`) — exit 0
- `npx prettier --write` — applied (pre-existing formatting only touched the changed hunk)
- Read the full surrounding gallery-tab logic (`galleryImages` computed, `watch(sourceTab)`, `watch(gallerySearch)`) to confirm no other trigger already covered this.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Same shape as the earlier `hydrateGalleryThumbs` cap issue: any place in the app that paginates a "show up to N" computed list but only hydrates a fixed sub-batch on a fixed set of triggers is worth a quick grep for the same bug (e.g. a similar starters/example-works picker, if one exists).

### Notes for reviewer
Conductor roadmap: `ai-art-academy/t-010` (recurring continuous-improvement task) — will be rearmed to `ready` after this merges, per the project's standing convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WMn8kX1XUd1v3FaWda9m3j)_