### PR TITLE
Facet closure: fix seed art-existence check to see media-host assets

### DIFF
--- a/utils/scripts/seedBotFacetCatalog.ts
+++ b/utils/scripts/seedBotFacetCatalog.ts
@@ -9,6 +9,7 @@ import {
   BOT_TYPES,
 } from './../../stores/helpers/botCards'
 import { BOT_TYPE_ARTWORK_TARGETS } from './../seeds/facetBotTypeArtwork'
+import { imageSrcToMediaPath, mediaAssetExists } from './mediaContractSource'
 import {
   normalizeFacetLookupKey,
   prepareUniqueFacetAliases,
@@ -53,26 +54,32 @@ function slugify(value: string): string {
     .slice(0, 220)
 }
 
-function existingPublicImagePath(value: unknown): {
+async function existingPublicImagePath(value: unknown): Promise<{
   imagePath?: string
   requestedImagePath?: string
-} {
+}> {
   const requestedImagePath = clean(value)
   if (!requestedImagePath) return {}
   if (!requestedImagePath.startsWith('/images/')) return { requestedImagePath }
-  return existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1)))
+  // public/images/** is git-ignored and served from the media host, so a local
+  // existsSync check reports live art as missing in CI/production. Treat the
+  // asset as present if it exists locally OR on the media mount.
+  const exists =
+    existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1))) ||
+    (await mediaAssetExists(imageSrcToMediaPath(requestedImagePath)))
+  return exists
     ? { imagePath: requestedImagePath, requestedImagePath }
     : { requestedImagePath }
 }
 
-function collectCandidates(): BotFacetCandidate[] {
+async function collectCandidates(): Promise<BotFacetCandidate[]> {
   const candidates: BotFacetCandidate[] = []
 
   for (const [sortOrder, option] of BOT_TYPES.entries()) {
     const builderValue = clean(option.value)
     const title = clean(option.label) || builderValue
     if (!builderValue || !title) continue
-    const artwork = existingPublicImagePath(option.image)
+    const artwork = await existingPublicImagePath(option.image)
     const artworkTarget = BOT_TYPE_ARTWORK_TARGETS.find(
       (target) => target.value === builderValue,
     )
@@ -382,7 +389,7 @@ async function backfillBots(): Promise<number> {
 }
 
 async function main(): Promise<void> {
-  const candidates = collectCandidates()
+  const candidates = await collectCandidates()
   const byTaxonomy = candidates.reduce<Record<string, number>>((counts, candidate) => {
     counts[candidate.taxonomy] = (counts[candidate.taxonomy] ?? 0) + 1
     return counts

--- a/utils/scripts/seedGenderFacetCatalog.ts
+++ b/utils/scripts/seedGenderFacetCatalog.ts
@@ -11,6 +11,7 @@ import {
   normalizeFacetLookupKey,
   prepareUniqueFacetAliases,
 } from './../facetAliases'
+import { imageSrcToMediaPath, mediaAssetExists } from './mediaContractSource'
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) throw new Error('DATABASE_URL is missing')
@@ -56,23 +57,28 @@ function titleCase(value: string): string {
     .join(' ')
 }
 
-function existingPublicImagePath(value: unknown): {
+async function existingPublicImagePath(value: unknown): Promise<{
   imagePath?: string
   requestedImagePath?: string
-} {
+}> {
   const requestedImagePath = clean(value)
   if (!requestedImagePath) return {}
   if (!requestedImagePath.startsWith('/images/')) {
     return { requestedImagePath }
   }
 
-  const exists = existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1)))
+  // public/images/** is git-ignored and served from the media host, so the
+  // local existsSync check alone reports live art as missing in CI/production.
+  // Treat the asset as present if it exists locally OR on the media mount.
+  const exists =
+    existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1))) ||
+    (await mediaAssetExists(imageSrcToMediaPath(requestedImagePath)))
   return exists
     ? { imagePath: requestedImagePath, requestedImagePath }
     : { requestedImagePath }
 }
 
-function collectGenderCandidates(): GenderCandidate[] {
+async function collectGenderCandidates(): Promise<GenderCandidate[]> {
   const candidates = new Map<string, GenderCandidate>()
   const genderCard = ADVENTURE_CARDS.find((card) => card.key === 'gender')
 
@@ -88,7 +94,7 @@ function collectGenderCandidates(): GenderCandidate[] {
 
       const key = normalizeFacetLookupKey(canonicalValue)
       if (!key) continue
-      const artwork = existingPublicImagePath(choice.image)
+      const artwork = await existingPublicImagePath(choice.image)
       const artworkTarget = GENDER_ARTWORK_TARGETS.find(
         (target) => target.path === artwork.requestedImagePath,
       )
@@ -271,7 +277,7 @@ async function backfillCharacterGender(
 }
 
 async function main(): Promise<void> {
-  const candidates = collectGenderCandidates()
+  const candidates = await collectGenderCandidates()
   const directArtwork = candidates.filter((candidate) => candidate.imagePath).length
   const missingRequiredArt = candidates.length - directArtwork
   const missingSourceArtwork = candidates

--- a/utils/scripts/seedScenarioGenreFacetCatalog.ts
+++ b/utils/scripts/seedScenarioGenreFacetCatalog.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 import { PrismaClient } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
 import { SCENARIO_CARDS } from './../../stores/helpers/scenarioCards'
+import { imageSrcToMediaPath, mediaAssetExists } from './mediaContractSource'
 import {
   normalizeFacetLookupKey,
   prepareUniqueFacetAliases,
@@ -46,21 +47,27 @@ function slugify(value: string): string {
     .slice(0, 255)
 }
 
-function existingPublicImagePath(value: unknown): {
+async function existingPublicImagePath(value: unknown): Promise<{
   imagePath?: string
   requestedImagePath?: string
-} {
+}> {
   const requestedImagePath = clean(value)
   if (!requestedImagePath) return {}
   if (!requestedImagePath.startsWith('/images/')) {
     return { requestedImagePath }
   }
-  return existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1)))
+  // public/images/** is git-ignored and served from the media host, so a local
+  // existsSync check reports live art as missing in CI/production. Treat the
+  // asset as present if it exists locally OR on the media mount.
+  const exists =
+    existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1))) ||
+    (await mediaAssetExists(imageSrcToMediaPath(requestedImagePath)))
+  return exists
     ? { imagePath: requestedImagePath, requestedImagePath }
     : { requestedImagePath }
 }
 
-function collectScenarioGenreCandidates(): ScenarioGenreCandidate[] {
+async function collectScenarioGenreCandidates(): Promise<ScenarioGenreCandidate[]> {
   const candidates = new Map<string, ScenarioGenreCandidate>()
   const genreCard = SCENARIO_CARDS.find((card) => card.key === 'genre')
   let order = 0
@@ -100,7 +107,7 @@ function collectScenarioGenreCandidates(): ScenarioGenreCandidate[] {
       const builderLabel = clean(choice.label) || canonicalValue
       const key = normalizeFacetLookupKey(canonicalValue)
       if (!canonicalValue || !builderLabel || !key) continue
-      const artwork = existingPublicImagePath(choice.image)
+      const artwork = await existingPublicImagePath(choice.image)
       candidates.set(key, {
         title: canonicalValue,
         canonicalValue,
@@ -314,7 +321,7 @@ async function backfillScenarioGenres(state: CatalogState): Promise<number> {
 }
 
 async function main(): Promise<void> {
-  const candidates = collectScenarioGenreCandidates()
+  const candidates = await collectScenarioGenreCandidates()
   const missingSourceArtwork = candidates
     .filter((candidate) => candidate.requestedImagePath && !candidate.imagePath)
     .map((candidate) => candidate.requestedImagePath)

--- a/utils/scripts/seedSystemOptionFacets.ts
+++ b/utils/scripts/seedSystemOptionFacets.ts
@@ -12,6 +12,7 @@ import {
   type SystemOptionFacetTarget,
 } from './../seeds/facetSystemOptionArtwork'
 import { prepareUniqueFacetAliases } from './../facetAliases'
+import { imageSrcToMediaPath, mediaAssetExists } from './mediaContractSource'
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) throw new Error('DATABASE_URL is missing')
@@ -34,14 +35,18 @@ function taxonomyPrefix(target: SystemOptionFacetTarget): string {
   return target.taxonomy.toLowerCase().replaceAll('_', '-')
 }
 
-function imageState(path: string): {
+async function imageState(path: string): Promise<{
   imagePath?: string
   requestedImagePath: string
   artworkStatus: 'available' | 'missing'
-} {
+}> {
+  // public/images/** is git-ignored and served from the media host, so a local
+  // existsSync check reports live art as missing in CI/production. Treat the
+  // asset as present if it exists locally OR on the media mount.
   const available =
     path.startsWith('/images/') &&
-    existsSync(resolve(process.cwd(), 'public', path.slice(1)))
+    (existsSync(resolve(process.cwd(), 'public', path.slice(1))) ||
+      (await mediaAssetExists(imageSrcToMediaPath(path))))
   return {
     imagePath: available ? path : undefined,
     requestedImagePath: path,
@@ -52,7 +57,7 @@ function imageState(path: string): {
 async function saveTarget(target: SystemOptionFacetTarget): Promise<'created' | 'updated'> {
   const prefix = taxonomyPrefix(target)
   const slug = `${prefix}-${slugify(target.enumValue)}`
-  const art = imageState(target.path)
+  const art = await imageState(target.path)
   const metadata = JSON.stringify({
     source: 'system-builder',
     structuralEnum: true,
@@ -158,8 +163,11 @@ async function main(): Promise<void> {
     counts.set(target.taxonomy, (counts.get(target.taxonomy) ?? 0) + 1)
   }
 
+  const artStates = await Promise.all(
+    SYSTEM_OPTION_FACET_TARGETS.map((target) => imageState(target.path)),
+  )
   const missingArtwork = SYSTEM_OPTION_FACET_TARGETS.filter(
-    (target) => imageState(target.path).artworkStatus === 'missing',
+    (_, index) => artStates[index]!.artworkStatus === 'missing',
   )
 
   process.stdout.write(


### PR DESCRIPTION
## Summary

Working the Facet post-op closure (#1035). This is the first, highest-leverage change: a root-cause fix for the "missing Builder artwork" debt tracked in #1022 / #1024 / #1026.

## Root cause

The Gender, Bot Type, Scenario Genre, and System Option catalog seeds decided whether a curated Builder image "exists" using a **local filesystem** check:

```js
existsSync(resolve(process.cwd(), 'public', requestedImagePath.slice(1)))
```

But `public/images/**` is git-ignored and served from the self-hosted media host (`media.acrocatranch.com`), so that check is **always false in CI and on Vercel**. The seeds therefore persisted these Facets with a null `imagePath` and `artworkStatus: "missing"` — even when the artwork is live on the media mount. This is what generated most of the reported art-debt.

Probing the media host directly confirms the real state: **26 of the 28 manifest-declared assets already exist** on `media.acrocatranch.com`. Only two were genuinely missing:

- `bots/type/character.webp`
- `scenarios/genre/infinite-archive.webp`

Both have now been queued through the Conductor art pipeline (`/api/conductor/art-request` → `projects/art-prompts.yaml`).

## The fix

Use the repo's existing media-aware primitive `mediaAssetExists()` (from `utils/scripts/mediaContractSource.ts` — it honors `MEDIA_ROOT` for a local mount, otherwise HEADs the media host, with caching) **in addition to** the local `existsSync` fast-path. The four existence helpers become `async` and their call sites `await`; behavior is otherwise unchanged. No regression risk to local dev (the `existsSync` path is preserved as an OR).

Files:
- `utils/scripts/seedGenderFacetCatalog.ts`
- `utils/scripts/seedBotFacetCatalog.ts`
- `utils/scripts/seedScenarioGenreFacetCatalog.ts`
- `utils/scripts/seedSystemOptionFacets.ts`

## Verification

- `npm run test` (nuxi prepare + vue-tsc project typecheck) passes.
- CI `Facet Catalog Contract` runs the manifest-based verify scripts (not the seeds themselves), so the async refactor introduces no new network calls in CI.

## Follow-up (not in this PR)

1. Re-run the production catalog seed (`npm run facet:catalog:apply`) so `imagePath` populates for the 26 assets already on media — this is a deploy-side step (needs the production `DATABASE_URL`).
2. Let Conductor render the 2 queued assets.
3. Re-run `npm run audit:facet-data -- --strict` and update #1035 + close #1022/#1024/#1026.

Note: issues #1022/#1024/#1026 describe "commit the WebPs to the repo," but the real flow is media-host-based (`public/images/**` is git-ignored) — the assets are served from `media.acrocatranch.com`, not committed. Will annotate those issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw)_