### PR TITLE
Facet closure: add public Facet Gallery surface

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Verify enum-backed system option Facets
         run: npx tsx utils/scripts/verifySystemOptionFacetCutover.ts
 
+      - name: Verify Facet gallery surface
+        run: npm run test:facet-gallery
+
       - name: Verify Facet taxonomy authority
         run: npx tsx utils/scripts/verifyFacetTaxonomyAuthority.ts
 

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -1,0 +1,266 @@
+<!-- /components/facets/facet-gallery.vue -->
+<template>
+  <section class="mx-auto w-full max-w-7xl space-y-6 p-4">
+    <header
+      class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
+    >
+      <Icon name="kind-icon:tag" class="size-6 text-secondary" />
+      <div class="min-w-0 flex-1">
+        <h1 class="text-xl font-black">Facet Gallery</h1>
+        <p class="text-sm text-base-content/60">
+          Browse the canonical creative building blocks — genres, species,
+          archetypes, moods, styles and more — shared across Characters, Bots,
+          Dreams, Scenarios, and Art.
+        </p>
+      </div>
+      <span
+        v-if="catalog.loading"
+        class="loading loading-spinner loading-sm"
+        aria-label="Loading facets"
+      />
+      <span class="badge badge-ghost">{{ visibleCount }} shown</span>
+    </header>
+
+    <div class="flex flex-wrap items-center gap-2">
+      <input
+        v-model="search"
+        type="search"
+        class="input input-bordered input-sm w-full max-w-sm rounded-xl bg-base-200"
+        placeholder="Search title, alias, description, or taxonomy..."
+        aria-label="Search facets"
+      />
+      <select
+        v-model="taxonomyFilter"
+        class="select select-bordered select-sm rounded-xl"
+        aria-label="Filter by taxonomy"
+      >
+        <option :value="null">All taxonomies ({{ totalCount }})</option>
+        <option
+          v-for="taxonomy in populatedTaxonomies"
+          :key="taxonomy"
+          :value="taxonomy"
+        >
+          {{ taxonomyLabel(taxonomy) }} ({{ counts[taxonomy] || 0 }})
+        </option>
+      </select>
+      <label
+        class="ml-auto flex items-center gap-2 text-xs text-base-content/60"
+      >
+        <input
+          v-model="artOnly"
+          type="checkbox"
+          class="toggle toggle-secondary toggle-xs"
+        />
+        Illustrated only
+      </label>
+    </div>
+
+    <p v-if="errorMessage" class="text-sm text-error">{{ errorMessage }}</p>
+
+    <div
+      v-for="group in groups"
+      :key="group.taxonomy"
+      class="space-y-3"
+    >
+      <div class="flex items-baseline gap-2">
+        <h2 class="text-lg font-black">{{ taxonomyLabel(group.taxonomy) }}</h2>
+        <span class="badge badge-secondary badge-sm">{{ group.entries.length }}</span>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        <article
+          v-for="facet in group.entries"
+          :key="facet.id"
+          class="group overflow-hidden rounded-2xl border border-base-300 bg-base-100 transition-all hover:shadow-lg"
+        >
+          <div class="relative flex h-40 items-center justify-center bg-base-200">
+            <img
+              v-if="facetArtwork(facet)"
+              :src="facetArtwork(facet) || ''"
+              :alt="`${facet.title} artwork`"
+              class="size-full object-cover"
+              loading="lazy"
+            />
+            <div
+              v-else
+              class="flex size-full flex-col items-center justify-center gap-1 bg-gradient-to-br from-base-200 to-base-300 text-base-content/40"
+            >
+              <Icon
+                :name="iconName(facet)"
+                class="size-8"
+              />
+              <span class="text-[10px] uppercase tracking-wide">
+                {{ facet.artRequired ? 'art pending' : 'no art' }}
+              </span>
+            </div>
+          </div>
+
+          <div class="space-y-1.5 p-3">
+            <div class="flex flex-wrap items-center gap-1">
+              <span class="badge badge-outline badge-xs">
+                {{ taxonomyLabel(facet.taxonomy) }}
+              </span>
+              <span v-if="facet.groupLabel" class="badge badge-ghost badge-xs">
+                {{ facet.groupLabel }}
+              </span>
+            </div>
+            <h3 class="truncate text-sm font-bold" :title="facet.title">
+              {{ facet.title }}
+            </h3>
+            <p
+              v-if="facet.description"
+              class="line-clamp-2 text-xs text-base-content/60"
+            >
+              {{ facet.description }}
+            </p>
+            <p
+              v-else-if="facet.flavorText"
+              class="line-clamp-2 text-xs italic text-base-content/50"
+            >
+              {{ facet.flavorText }}
+            </p>
+            <p
+              v-if="facet.aliases.length"
+              class="truncate text-[11px] text-base-content/35"
+              :title="facet.aliases.join(' · ')"
+            >
+              {{ facet.aliases.join(' · ') }}
+            </p>
+
+            <button
+              v-if="canRequestArt && facet.artRequired && !facetArtwork(facet)"
+              type="button"
+              class="btn btn-outline btn-accent btn-xs w-full rounded-lg"
+              :disabled="artRequestStore.requesting[facet.id]"
+              @click="requestArt(facet)"
+            >
+              <span
+                v-if="artRequestStore.requesting[facet.id]"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:palette" class="size-3.5" />
+              {{
+                artRequestStore.requested[facet.id]
+                  ? 'Artwork requested'
+                  : 'Request artwork'
+              }}
+            </button>
+          </div>
+        </article>
+      </div>
+    </div>
+
+    <p
+      v-if="!catalog.loading && !groups.length"
+      class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50"
+    >
+      No facets match these filters.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  FACET_TAXONOMIES,
+  useFacetCatalogStore,
+  type FacetCatalogEntry,
+  type FacetTaxonomy,
+} from '@/stores/facetCatalogStore'
+import { useFacetArtRequestStore } from '@/stores/facetArtRequestStore'
+import { useUserStore } from '@/stores/userStore'
+import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+
+const catalog = useFacetCatalogStore()
+const artRequestStore = useFacetArtRequestStore()
+const userStore = useUserStore()
+
+const search = ref('')
+const taxonomyFilter = ref<FacetTaxonomy | null>(null)
+const artOnly = ref(false)
+const errorMessage = ref('')
+
+const canRequestArt = computed(() => userStore.isAdmin)
+
+function facetArtwork(facet: FacetCatalogEntry): string | null {
+  return facet.cardPath || facet.imagePath || facet.heroPath || null
+}
+
+function iconName(facet: FacetCatalogEntry): string {
+  const icon = facet.icon?.trim()
+  return icon && icon.includes(':') ? icon : 'kind-icon:tag'
+}
+
+function taxonomyLabel(taxonomy: FacetTaxonomy): string {
+  return taxonomy
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function matchesSearch(facet: FacetCatalogEntry, needle: string): boolean {
+  if (!needle) return true
+  const values = [
+    facet.title,
+    facet.canonicalValue,
+    facet.taxonomy,
+    facet.groupLabel,
+    facet.description,
+    facet.flavorText,
+    ...facet.aliases,
+  ]
+  return values.some((value) =>
+    normalizeFacetLookupKey(value || '').includes(needle),
+  )
+}
+
+const counts = computed(() => {
+  const result: Partial<Record<FacetTaxonomy, number>> = {}
+  for (const [taxonomy, entries] of catalog.byTaxonomy) {
+    result[taxonomy] = entries.length
+  }
+  return result
+})
+
+const totalCount = computed(() => catalog.entries.length)
+
+const populatedTaxonomies = computed(() =>
+  FACET_TAXONOMIES.filter((taxonomy) => (counts.value[taxonomy] || 0) > 0),
+)
+
+const groups = computed(() => {
+  const needle = normalizeFacetLookupKey(search.value)
+  const result: { taxonomy: FacetTaxonomy; entries: FacetCatalogEntry[] }[] = []
+  for (const taxonomy of FACET_TAXONOMIES) {
+    if (taxonomyFilter.value && taxonomy !== taxonomyFilter.value) continue
+    const entries = (catalog.byTaxonomy.get(taxonomy) || []).filter((facet) => {
+      if (artOnly.value && !facetArtwork(facet)) return false
+      return matchesSearch(facet, needle)
+    })
+    if (entries.length) result.push({ taxonomy, entries })
+  }
+  return result
+})
+
+const visibleCount = computed(() =>
+  groups.value.reduce((sum, group) => sum + group.entries.length, 0),
+)
+
+async function requestArt(facet: FacetCatalogEntry): Promise<void> {
+  errorMessage.value = ''
+  const path = await artRequestStore.requestPrimaryArtwork(facet)
+  if (!path && artRequestStore.errors[facet.id]) {
+    errorMessage.value =
+      artRequestStore.errors[facet.id] || 'Artwork request failed.'
+  }
+}
+
+onMounted(async () => {
+  try {
+    await catalog.fetchCatalog({ take: 1000 })
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Facets could not be loaded.'
+  }
+})
+</script>

--- a/content/channels/play/facet-gallery.md
+++ b/content/channels/play/facet-gallery.md
@@ -1,0 +1,16 @@
+---
+contentType: tab
+channelKey: play
+tabKey: facet-gallery
+dashboardKey: facets
+dashboardTab: gallery
+label: Facet Gallery
+title: Facet Gallery
+subtitle: The shared creative building blocks, on display
+description: Explore the canonical genres, species, archetypes, moods, styles, and settings that Characters, Bots, Dreams, Scenarios, and Art all draw from.
+icon: kind-icon:tag
+route: /facet-gallery
+sort: 71
+---
+
+A read-only showcase of the reusable Facet catalog, grouped by taxonomy and shown with artwork, descriptions, and aliases.

--- a/content/facet-gallery.md
+++ b/content/facet-gallery.md
@@ -1,0 +1,18 @@
+---
+title: Facet Gallery
+room: 'Facet Gallery'
+subtitle: The shared creative building blocks, on display
+description: Browse the canonical genres, species, archetypes, moods, styles, and settings that Characters, Bots, Dreams, Scenarios, and Art all draw from.
+image: nav/heroes/facets.webp
+icon: kind-icon:tag
+tooltip: Explore the reusable Facet catalog by taxonomy.
+sort: gallery
+channelKey: play
+tabKey: facet-gallery
+dashboardKey: facets
+dashboardTab: gallery
+loadingMessage: Loading the Facet gallery...
+refreshLabel: Refresh Facets
+---
+
+:facet-gallery

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "test:facet-catalog": "prisma validate && tsx utils/scripts/verifyFacetCatalogCutover.ts && tsx utils/scripts/verifyFacetCanonicalMerges.ts && tsx utils/scripts/verifyDailyDreamFacets.ts",
     "test:facet-closure": "tsx utils/scripts/verifyFacetClosure.ts",
+    "test:facet-gallery": "tsx utils/scripts/verifyFacetGallery.ts",
     "test:daily-dream-facets": "prisma validate && tsx utils/scripts/verifyDailyDreamFacets.ts",
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
     "test:challenge-center": "tsx utils/scripts/verifyChallengeCenter.ts",

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -616,6 +616,18 @@ export const dashboardConfigs = {
           'Facets are the small reusable building blocks — genres, animals, colors, themes, cores, moods, styles, settings, and art direction — that Dreams, Scenarios, and Art share. Browse the library, refine titles and aliases, and keep the flavor vocabulary tidy.',
         route: '/facets',
       },
+      {
+        key: 'gallery',
+        label: 'Gallery',
+        icon: 'kind-icon:tag',
+        title: 'Facet Gallery',
+        summary:
+          'Explore the canonical Facet catalog by taxonomy, with artwork.',
+        image: tabImage('facets', 'gallery'),
+        narrative:
+          'A read-only showcase of the shared creative building blocks — genres, species, archetypes, moods, styles, and settings — grouped by taxonomy and shown with their artwork, descriptions, and aliases. The browse-and-admire companion to the editable Library.',
+        route: '/facet-gallery',
+      },
     ],
   },
 

--- a/utils/scripts/verifyFacetGallery.ts
+++ b/utils/scripts/verifyFacetGallery.ts
@@ -1,0 +1,74 @@
+// Static contract for the public Facet Gallery surface.
+//
+// The gallery is a read-only, taxonomy-grouped showcase built on the canonical
+// Facet catalog. It must source from facetCatalogStore.byTaxonomy, stay
+// read-only, and gate any art-request affordance behind admin + the shared
+// facetArtRequestStore rather than inventing a new request path.
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+
+async function source(path: string): Promise<string> {
+  return readFile(resolve(root, path), 'utf8')
+}
+
+function requireText(path: string, text: string, fragment: string): void {
+  if (!text.includes(fragment)) {
+    throw new Error(`${path} is missing Facet gallery contract text: ${fragment}`)
+  }
+}
+
+function forbidText(path: string, text: string, fragment: string): void {
+  if (text.includes(fragment)) {
+    throw new Error(`${path} contains forbidden Facet gallery text: ${fragment}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const files = {
+    gallery: 'components/facets/facet-gallery.vue',
+    content: 'content/facet-gallery.md',
+  } as const
+
+  const text = Object.fromEntries(
+    await Promise.all(
+      Object.entries(files).map(
+        async ([key, path]) => [key, await source(path)] as const,
+      ),
+    ),
+  ) as Record<keyof typeof files, string>
+
+  // The gallery reads the canonical catalog grouped by taxonomy.
+  requireText(files.gallery, text.gallery, 'useFacetCatalogStore')
+  requireText(files.gallery, text.gallery, 'byTaxonomy')
+  requireText(files.gallery, text.gallery, 'FACET_TAXONOMIES')
+
+  // Art requests reuse the shared store and are gated behind admin.
+  requireText(files.gallery, text.gallery, 'useFacetArtRequestStore')
+  requireText(files.gallery, text.gallery, 'requestPrimaryArtwork')
+  requireText(files.gallery, text.gallery, 'canRequestArt')
+  requireText(files.gallery, text.gallery, 'userStore.isAdmin')
+
+  // The gallery is a read-only showcase: it must not mutate the catalog.
+  for (const mutation of [
+    'createFacet',
+    'updateFacet',
+    'archiveFacet',
+    'FacetProfileEditor',
+  ]) {
+    forbidText(files.gallery, text.gallery, mutation)
+  }
+
+  // The content route mounts the gallery component.
+  requireText(files.content, text.content, ':facet-gallery')
+
+  process.stdout.write(
+    'Facet gallery verified: read-only taxonomy showcase on the canonical catalog with admin-gated art requests.\n',
+  )
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

Adds the **public, taxonomy-grouped Facet Gallery** — the "front end Facet gallery" the migration was missing. Until now the only Facet UI was the admin CRUD tool (`facet-manager`, at `/facets`); this adds a browse-and-explore experience for everyone, built directly on the canonical catalog.

Part of the Facet post-op closure (#1035). Follows #1038 (seed media-existence fix).

## What's included

- **`components/facets/facet-gallery.vue`** — read-only showcase over `facetCatalogStore.byTaxonomy`. Sections per taxonomy, with:
  - search (title / alias / description / taxonomy)
  - taxonomy filter (only populated taxonomies, with counts)
  - "illustrated only" toggle
  - cards showing artwork (`cardPath` → `imagePath` → `heroPath` fallback), title, description/flavor text, group label, and aliases
  - graceful placeholder for missing art; an admin-only **Request artwork** action that reuses the existing `facetArtRequestStore` (the `/api/conductor/art-request` endpoint is admin-gated, so the affordance is behind `userStore.isAdmin`)
- **`content/facet-gallery.md`** — mounts `:facet-gallery` at `/facet-gallery`.
- **`utils/scripts/verifyFacetGallery.ts`** + `test:facet-gallery` script + a CI step in the Facet Catalog Contract — a static contract asserting the gallery reads the canonical catalog, stays read-only (no `createFacet`/`updateFacet`/`archiveFacet`/`FacetProfileEditor`), and keeps art requests admin-gated.

## Design notes

- Reuses `facetCatalogStore.byTaxonomy` (a `Map<FacetTaxonomy, FacetCatalogEntry[]>`) — no new data plumbing.
- Renders `/images/...` paths directly, matching the sibling `facet-manager.vue` (the app resolves them to the media host).
- Does not mutate the catalog; the admin CRUD tool remains the place to edit.

## Verification

- `npm run test` (nuxi prepare + vue-tsc project typecheck) passes.
- `npm run test:facet-gallery` passes locally; now runs in CI.
- Recommend a visual pass at `/facet-gallery` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw)_