### PR TITLE
academyStore: fix prototype-chain leak in slug validation

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -1526,8 +1526,10 @@ export const academyStyles: AcademyStyle[] = [
   },
 ]
 
-export const academyStylesBySlug: Record<string, AcademyStyle> =
-  Object.fromEntries(academyStyles.map((style) => [style.slug, style]))
+export const academyStylesBySlug: Record<string, AcademyStyle> = Object.assign(
+  Object.create(null),
+  Object.fromEntries(academyStyles.map((style) => [style.slug, style])),
+)
 
 export const academyTimeline: AcademyStyle[] = [...academyStyles].sort(
   (a, b) => a.sortYear - b.sortYear,


### PR DESCRIPTION
## Summary

`ai-art-academy/t-010` (conductor) continuous-improvement cycle, lane 1 (front-end polish). An Explore pass over the Academy/art-styler surfaces found a real robustness bug in `academyStore.ts`'s untrusted-state validation.

`academyStylesBySlug` (`stores/seeds/academyStyles.ts`) was built with `Object.fromEntries(...)`, a plain object with the normal `Object.prototype` chain. Every "is this a real curriculum slug" check in `academyStore.ts` uses the `in` operator against it — `slug in academyStylesBySlug` (used in `hydrate()`, `selectStyle()`, `markLessonViewed()`, `markStyleRemixed()`). `in` walks the prototype chain, so inherited keys like `"constructor"`, `"toString"`, `"valueOf"`, `"hasOwnProperty"` all evaluate as present even though no curriculum entry has that slug.

**Concrete failure:** `hydrate()` is the code path that reads client-writable `localStorage['kindRobotsAcademyState']`. If that value ever contains `{"selectedStyleSlug":"constructor"}` (hand-edited via devtools, a stray extension, or a future write path that skips validation), `hydrate()`'s `in` check passes, `selectedStyleSlug` becomes `"constructor"`, and the `selectedStyle` computed then does `academyStylesBySlug['constructor']` — which returns the real JS `Object` constructor function, not `undefined`. `academy-remix.vue` renders `academy-style-detail.vue` for any truthy `selectedStyle`, and that component unconditionally reads `lesson.remix.template`, which crashes with `TypeError: Cannot read properties of undefined (reading 'template')`.

Verified the mechanism directly (`'constructor' in {}` → `true`; `.remix.template` on the resulting value throws exactly this error).

## Fix

Give `academyStylesBySlug` a `null` prototype at its one definition site, so `in` can only ever match real, own curriculum slugs:

```ts
export const academyStylesBySlug: Record<string, AcademyStyle> = Object.assign(
  Object.create(null),
  Object.fromEntries(academyStyles.map((style) => [style.slug, style])),
)
```

This fixes all 7 call sites in `academyStore.ts` without touching each one individually.

## Verification

- `source scripts/provision_kind_robots_deps.sh` (conductor repo's sandbox provisioning helper) then `npm run test` (`nuxi prepare` + `vue-tsc --noEmit`) — clean, no errors.
- `npx eslint stores/seeds/academyStyles.ts` — clean.
- Standalone Node repro confirming `Object.assign(Object.create(null), ...)` blocks the prototype-chain match while preserving normal own-key lookups.

## Scope note

Blast radius today is narrower than a bug reachable through ordinary clicking — the only entry point is a corrupted/hand-crafted `kindRobotsAcademyState` localStorage value, since no current in-app code path passes unsanitized strings into `selectStyle`/`markLessonViewed`/`markStyleRemixed`. Still a genuine defect in the store's own trust-boundary validation for persisted state, and a one-line, fully reversible fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_015o4ajMEmCPympiHExPj6Em)_