### PR TITLE
Facet closure: enrich Daily Dream (narrator bot, 2 locations, typed SKILL/ITEM rewards)

### DIFF
--- a/server/api/dreams/daily.post.ts
+++ b/server/api/dreams/daily.post.ts
@@ -185,7 +185,7 @@ export default defineEventHandler(async (event) => {
               effect: reward.effect,
               flavorText: reward.flavorText,
               artPrompt: reward.artPrompt,
-              rewardType: 'ITEM',
+              rewardType: reward.rewardType,
               rarity: reward.rarity,
               collection: 'Daily Dream Objects',
               userId: auth.user.id,

--- a/server/utils/dailyDreamFacetBlueprint.ts
+++ b/server/utils/dailyDreamFacetBlueprint.ts
@@ -28,13 +28,39 @@ export type DailyDreamCharacterBlueprint = {
   facets: DailyDreamFacetUse[]
 }
 
+export type DailyDreamRewardType =
+  | 'SKILL'
+  | 'ITEM'
+  | 'POWER'
+  | 'PET'
+  | 'MAGIC'
+  | 'FAVOR'
+
 export type DailyDreamRewardBlueprint = {
   name: string
   description: string
   effect: string
   flavorText: string
   artPrompt: string
+  rewardType: DailyDreamRewardType
   rarity: 'COMMON' | 'UNCOMMON' | 'RARE'
+  facets: DailyDreamFacetUse[]
+}
+
+export type DailyDreamNarratorBlueprint = {
+  name: string
+  botType: string
+  personality: string
+  voice: string
+  artPrompt: string
+  facets: DailyDreamFacetUse[]
+}
+
+export type DailyDreamLocationBlueprint = {
+  name: string
+  setting: string
+  mood: string
+  description: string
   facets: DailyDreamFacetUse[]
 }
 
@@ -47,6 +73,8 @@ export type DailyDreamBlueprint = {
   flavorText: string
   artPrompt: string
   facets: DailyDreamFacetUse[]
+  narrator: DailyDreamNarratorBlueprint | null
+  locations: DailyDreamLocationBlueprint[]
   characters: DailyDreamCharacterBlueprint[]
   rewards: DailyDreamRewardBlueprint[]
 }
@@ -91,6 +119,19 @@ const ITEM_NOUNS = [
   'Locket',
   'Dice',
 ]
+const SKILL_NOUNS = [
+  'Technique',
+  'Gift',
+  'Knack',
+  'Art',
+  'Blessing',
+  'Discipline',
+  'Instinct',
+  'Sense',
+]
+// Default reward types after the opening SKILL + ITEM pair (spec: one SKILL,
+// one ITEM), so extra rewards still spread across the RewardType enum.
+const EXTRA_REWARD_TYPES = ['POWER', 'MAGIC', 'PET', 'FAVOR'] as const
 
 function hashSeed(input: string): number {
   let hash = 2166136261
@@ -238,14 +279,64 @@ export async function buildDailyDreamFacetBlueprint(options: {
   const titleCore = value(theme) || value(setting) || value(genre) || 'Daily Dream'
   const title = `${titleCore}: ${value(genre) || value(style) || 'A Strange Invitation'}`
 
+  const facetByEnum = (taxonomy: FacetTaxonomy, enumValue: string) =>
+    pool(taxonomy).find(
+      (entry) =>
+        String(
+          (entry.metadata as { enumValue?: unknown } | null)?.enumValue ?? '',
+        ).toUpperCase() === enumValue.toUpperCase(),
+    ) ?? null
+
+  // A narrator bot hosts every Dream (spec: 1 narrator bot).
+  const narratorBotType = one('BOT_TYPE')
+  const narratorPersonality = one('PERSONALITY')
+  const narratorName = `${pick(FIRST_NAMES, random) || 'Nim'} ${pick(LAST_NAMES, random) || 'Starling'}`
+  const narratorBotValue = value(narratorBotType) || 'Story Bot'
+  const narratorVoiceValue = value(narratorPersonality) || 'wry'
+  const narrator: DailyDreamNarratorBlueprint | null =
+    narratorBotType || narratorPersonality
+      ? {
+          name: narratorName,
+          botType: narratorBotValue,
+          personality: narratorVoiceValue,
+          voice: `${narratorName} narrates in a ${narratorVoiceValue.toLowerCase()} register`,
+          artPrompt: `${narratorName}, a ${narratorBotValue} narrating this Dream, ${narratorVoiceValue}, ${sentenceList(dreamValues)}, expressive mascot bot design`,
+          facets: [
+            use(narratorBotType, 'narratorBotType'),
+            use(narratorPersonality, 'narratorPersonality'),
+          ].filter((entry): entry is DailyDreamFacetUse => Boolean(entry)),
+        }
+      : null
+
+  // Two locations so a Dream spans more than one place (spec: 2 locations).
+  const locationEntries = weightedMany(pool('SETTING'), 2, random)
+  const locations: DailyDreamLocationBlueprint[] = locationEntries.map(
+    (entry, index) => {
+      const locationMood = index === 0 ? mood : one('MOOD')
+      const settingValue = value(entry) || 'A place that should not exist'
+      const moodValue = value(locationMood)
+      return {
+        name: settingValue,
+        setting: settingValue,
+        mood: moodValue,
+        description: `${settingValue}${moodValue ? `, ${moodValue.toLowerCase()}` : ''} — one of the two places this Dream unfolds.`,
+        facets: [
+          use(entry, 'location'),
+          use(locationMood, 'locationMood'),
+        ].filter((item): item is DailyDreamFacetUse => Boolean(item)),
+      }
+    },
+  )
+  const locationSummary = sentenceList(locations.map((place) => place.name))
+
   const characters: DailyDreamCharacterBlueprint[] = []
-  const characterCount = Math.min(4, Math.max(1, options.characterCount ?? 2))
+  const characterCount = Math.min(4, Math.max(1, options.characterCount ?? 3))
   for (let index = 0; index < characterCount; index++) {
     const species = one('ANIMAL', 'SPECIES')
     const characterClass = one('OCCUPATION', 'ARCHETYPE', 'ROLE')
     const alignment = one('ALIGNMENT')
     const personalities = weightedMany(pool('PERSONALITY'), 2, random)
-    const quirks = weightedMany(pool('QUIRK'), 1, random)
+    const quirks = weightedMany(pool('QUIRK'), 2, random)
     const backstory = one('BACKSTORY')
     const name = `${pick(FIRST_NAMES, random) || 'Mira'} ${pick(LAST_NAMES, random) || 'Voss'}`
     const classValue = value(characterClass) || 'Wanderer'
@@ -281,32 +372,58 @@ export async function buildDailyDreamFacetBlueprint(options: {
   const rewards: DailyDreamRewardBlueprint[] = []
   const rewardCount = Math.min(4, Math.max(1, options.rewardCount ?? 2))
   for (let index = 0; index < rewardCount; index++) {
+    // The first two rewards are always a SKILL and an ITEM (spec); any extras
+    // spread across the remaining RewardType enum values.
+    const rewardType: DailyDreamRewardType =
+      index === 0
+        ? 'SKILL'
+        : index === 1
+          ? 'ITEM'
+          : EXTRA_REWARD_TYPES[(index - 2) % EXTRA_REWARD_TYPES.length]!
+    const rewardTypeFacet = facetByEnum('REWARD_TYPE', rewardType)
     const material = one('MATERIAL')
     const rewardTheme = one('THEME') || theme
     const rewardColor = one('COLOR')
-    const noun = pick(ITEM_NOUNS, random) || 'Relic'
     const materialValue = value(material) || 'Impossible'
     const themeValue = value(rewardTheme)
     const colorValue = value(rewardColor)
-    const name = `${materialValue} ${noun}${themeValue ? ` of ${themeValue}` : ''}`
     const rarityRoll = random()
     const rarity =
       rarityRoll > 0.9 ? 'RARE' : rarityRoll > 0.6 ? 'UNCOMMON' : 'COMMON'
     const facetUses = [
+      use(rewardTypeFacet, 'rewardType'),
       use(material, 'material'),
       use(rewardTheme, 'theme'),
       use(rewardColor, 'color'),
     ].filter((entry): entry is DailyDreamFacetUse => Boolean(entry))
 
-    rewards.push({
-      name,
-      description: `A ${colorValue ? `${colorValue} ` : ''}${noun.toLowerCase()} made from ${materialValue}${themeValue ? ` and shaped by ${themeValue}` : ''}.`,
-      effect: `When introduced into a scene, the ${noun.toLowerCase()} changes what the characters believe is possible, but demands a choice that reflects the Dream's central conflict.`,
-      flavorText: 'It feels as though it remembers tomorrow.',
-      artPrompt: `${name}, singular magical reward item, ${colorValue}, ${sentenceList(dreamValues)}, readable silhouette, detailed object illustration`,
-      rarity,
-      facets: facetUses,
-    })
+    if (rewardType === 'SKILL') {
+      const skillNoun = pick(SKILL_NOUNS, random) || 'Technique'
+      const name = `The ${materialValue} ${skillNoun}${themeValue ? ` of ${themeValue}` : ''}`
+      rewards.push({
+        name,
+        description: `A learnable ${skillNoun.toLowerCase()} drawn from ${materialValue}${themeValue ? ` and ${themeValue.toLowerCase()}` : ''} — an ability a character carries out of the Dream.`,
+        effect: `Whoever masters the ${skillNoun.toLowerCase()} can bend the Dream's central rule once, but the Dream remembers who used it.`,
+        flavorText: 'You do not hold it; it holds you.',
+        artPrompt: `${name}, an ability manifesting as ${colorValue || 'luminous'} energy around a figure, ${sentenceList(dreamValues)}, dynamic skill aura, no object`,
+        rewardType,
+        rarity,
+        facets: facetUses,
+      })
+    } else {
+      const noun = pick(ITEM_NOUNS, random) || 'Relic'
+      const name = `${materialValue} ${noun}${themeValue ? ` of ${themeValue}` : ''}`
+      rewards.push({
+        name,
+        description: `A ${colorValue ? `${colorValue} ` : ''}${noun.toLowerCase()} made from ${materialValue}${themeValue ? ` and shaped by ${themeValue}` : ''}.`,
+        effect: `When introduced into a scene, the ${noun.toLowerCase()} changes what the characters believe is possible, but demands a choice that reflects the Dream's central conflict.`,
+        flavorText: 'It feels as though it remembers tomorrow.',
+        artPrompt: `${name}, singular magical reward item, ${colorValue}, ${sentenceList(dreamValues)}, readable silhouette, detailed object illustration`,
+        rewardType,
+        rarity,
+        facets: facetUses,
+      })
+    }
   }
 
   const castSummary = characters
@@ -316,8 +433,16 @@ export async function buildDailyDreamFacetBlueprint(options: {
     )
     .join('; ')
   const rewardSummary = rewards.map((reward) => reward.name).join('; ')
-  const description = `A ${sentenceList(dreamValues)} Dream. Its cast: ${castSummary}. Its consequential objects: ${rewardSummary}.`
-  const pitch = `The Dream begins when ${characters[0]?.name || 'a stranger'} discovers ${rewards[0]?.name || 'an impossible object'} and learns that ${value(theme) || 'the apparent theme'} is not a mood but a rule. Every character wants something different from that rule, and the objects inside the Dream can alter it.`
+  const placeClause = locationSummary
+    ? ` It moves between ${locationSummary}.`
+    : ''
+  const narratorClause = narrator
+    ? ` ${narrator.name}, a ${narrator.botType}, narrates.`
+    : ''
+  const description = `A ${sentenceList(dreamValues)} Dream. Its cast: ${castSummary}. Its consequential rewards: ${rewardSummary}.${placeClause}${narratorClause}`
+  const pitch = `${
+    narrator ? `${narrator.name} opens the Dream: ` : ''
+  }it begins when ${characters[0]?.name || 'a stranger'} discovers ${rewards[0]?.name || 'an impossible gift'} in ${locations[0]?.name || 'a place that should not exist'} and learns that ${value(theme) || 'the apparent theme'} is not a mood but a rule. Every character wants something different from that rule, and the rewards inside the Dream can alter it.`
 
   return {
     dateKey: options.dateKey,
@@ -326,8 +451,10 @@ export async function buildDailyDreamFacetBlueprint(options: {
     description,
     pitch,
     flavorText: `Generated as a nested Facet blueprint for ${options.dateKey}.`,
-    artPrompt: `${title}, ${description}, cinematic ensemble scene, characters interacting with visible reward objects, ${sentenceList(dreamValues)}, coherent visual storytelling`,
+    artPrompt: `${title}, ${description}, cinematic ensemble scene across ${locationSummary || 'a shifting dreamscape'}, characters interacting with visible rewards, ${sentenceList(dreamValues)}, coherent visual storytelling`,
     facets: uses(dreamEntries, 'dream'),
+    narrator,
+    locations,
     characters,
     rewards,
   }

--- a/utils/scripts/verifyDailyDreamFacets.ts
+++ b/utils/scripts/verifyDailyDreamFacets.ts
@@ -67,7 +67,17 @@ async function main(): Promise<void> {
   requireText(files.blueprint, text.blueprint, "one('MATERIAL')")
   requireText(files.blueprint, text.blueprint, "use(material, 'material')")
 
+  // A narrator bot, two locations, and typed rewards (spec: 3 characters,
+  // 2 locations, 1 narrator bot, 2 rewards — one SKILL, one ITEM).
+  requireText(files.blueprint, text.blueprint, "one('BOT_TYPE')")
+  requireText(files.blueprint, text.blueprint, "weightedMany(pool('SETTING'), 2, random)")
+  requireText(files.blueprint, text.blueprint, "facetByEnum('REWARD_TYPE', rewardType)")
+  requireText(files.blueprint, text.blueprint, "? 'SKILL'")
+  requireText(files.blueprint, text.blueprint, "? 'ITEM'")
+  requireText(files.blueprint, text.blueprint, "use(rewardTypeFacet, 'rewardType')")
+
   requireText(files.endpoint, text.endpoint, 'validDateKey(dateKey)')
+  requireText(files.endpoint, text.endpoint, 'rewardType: reward.rewardType')
   requireText(files.endpoint, text.endpoint, 'tx.dreamFacet.createMany')
   requireText(files.endpoint, text.endpoint, 'tx.characterFacet.createMany')
   requireText(files.endpoint, text.endpoint, 'tx.rewardFacet.createMany')


### PR DESCRIPTION
## Summary

Deepens the Facet-driven **Daily Dream** generation for more creative variety, toward the conductor spec (3 characters, 2 locations, 1 narrator bot, 2 rewards — one SKILL, one ITEM). Part of the broader Facet vision; follows #1038 and #1039.

Everything stays Facet-sourced and date-seed-deterministic, and the existing contract-pinned Facet draws (`one('ANIMAL','SPECIES')`, `one('OCCUPATION','ARCHETYPE','ROLE')`, `one('MATERIAL')`, `use(material,'material')`, the seed hash) are unchanged — the additions are additive.

## Changes

`server/utils/dailyDreamFacetBlueprint.ts`:
- **Narrator bot** drawn from `BOT_TYPE` + `PERSONALITY`, woven into the pitch/description and exposed as `blueprint.narrator`.
- **Two locations** drawn from `SETTING` (+ mood), exposed as `blueprint.locations` and woven into the description/art prompt.
- **Typed rewards** — the first two rewards are always a **SKILL** and an **ITEM** (extras spread across the remaining `RewardType` enum), each carrying its `REWARD_TYPE` presentation Facet. SKILL rewards get ability-flavored names/prompts instead of object nouns.
- Characters default to **3** and now carry **two quirks**.

`server/api/dreams/daily.post.ts`:
- Persist `reward.rewardType` instead of the previous hardcoded `'ITEM'` — a real fix, since every daily reward was being stored as ITEM regardless of content.

`utils/scripts/verifyDailyDreamFacets.ts`:
- Assert the new narrator/location/reward-type coverage.

## Verification

- `npm run test:daily-dream-facets` passes locally.
- The authoritative project typecheck runs in CI (the local Prisma client can't be regenerated here without `DATABASE_URL`; the changed files carry no type errors, and the reward-type union is structurally identical to the generated `RewardType` enum).
- Recommend a sample `POST /api/dreams/daily` after deploy to eyeball a generated Dream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw)_