### PR TITLE
Facet closure: order art-prompt Facet entries by taxonomy

### DIFF
--- a/utils/artFacetPrompt.ts
+++ b/utils/artFacetPrompt.ts
@@ -12,11 +12,59 @@ export function artFacetPromptValue(entry: ArtFacetPromptEntry): string {
   return String(entry.artPrompt || entry.canonicalValue || entry.title).trim()
 }
 
+// Order facets so a composed prompt reads coherently: subject/identity first,
+// then descriptive qualities, then stylistic direction, and enhancement/quality
+// tags last (where diffusion models weight them best). Unlisted taxonomies keep
+// their original relative position in the middle band.
+const TAXONOMY_PROMPT_PRIORITY: Record<string, number> = {
+  SPECIES: 10,
+  ANIMAL: 10,
+  ARCHETYPE: 11,
+  OCCUPATION: 11,
+  ROLE: 11,
+  CORE: 12,
+  GENDER: 13,
+  ALIGNMENT: 14,
+  PERSONALITY: 15,
+  QUIRK: 16,
+  BACKSTORY: 17,
+  GENRE: 20,
+  THEME: 21,
+  SETTING: 22,
+  MOOD: 23,
+  COLOR: 24,
+  MATERIAL: 25,
+  STYLE: 30,
+  ART_DIRECTION: 31,
+  PROMPT_ENHANCEMENT: 90,
+}
+const DEFAULT_TAXONOMY_PRIORITY = 50
+
+function taxonomyPriority(taxonomy: string): number {
+  return (
+    TAXONOMY_PROMPT_PRIORITY[String(taxonomy || '').toUpperCase()] ??
+    DEFAULT_TAXONOMY_PRIORITY
+  )
+}
+
+export function orderArtFacetEntries(
+  entries: readonly ArtFacetPromptEntry[],
+): ArtFacetPromptEntry[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort(
+      (a, b) =>
+        taxonomyPriority(a.entry.taxonomy) - taxonomyPriority(b.entry.taxonomy) ||
+        a.index - b.index,
+    )
+    .map((item) => item.entry)
+}
+
 export function buildArtFacetPromptAddon(
   entries: readonly ArtFacetPromptEntry[],
 ): string {
   const values = Array.from(
-    new Set(entries.map(artFacetPromptValue).filter(Boolean)),
+    new Set(orderArtFacetEntries(entries).map(artFacetPromptValue).filter(Boolean)),
   )
   return values.length ? `Facet direction: ${values.join(', ')}` : ''
 }


### PR DESCRIPTION
## Summary

Small refinement to how selected Facets compose into the art-generation prompt. The art maker already flows Facet selections into prompt-building (`art-facet-selector` → `artFacetDraftStore` → `composeArtPromptWithFacets`), but the facets were joined in selection order. Now they're ordered by taxonomy so the composed string reads coherently for diffusion models.

Part of the broader Facet vision (art-generator integration); follows #1038/#1039/#1041.

## Change

`utils/artFacetPrompt.ts`:
- Add `orderArtFacetEntries()` — sorts by a taxonomy priority: subject/identity (SPECIES, ARCHETYPE, GENDER, ALIGNMENT, PERSONALITY…) → descriptors (GENRE, THEME, SETTING, MOOD, COLOR, MATERIAL) → stylistic (STYLE, ART_DIRECTION) → enhancement/quality tags (PROMPT_ENHANCEMENT) last. Unlisted taxonomies keep their original relative position in the middle band (stable sort).
- `buildArtFacetPromptAddon()` applies the ordering before dedup/join. Output structure is otherwise unchanged.

Example: selecting `{PROMPT_ENHANCEMENT: Hyperdetailed, STYLE: Watercolor, ANIMAL: Fox, MOOD: Melancholy, GENRE: Cyberpunk}` now composes as
`… Facet direction: Fox, Cyberpunk, Melancholy, Watercolor, Hyperdetailed`.

## Verification

- Standalone run confirms the ordering and composed output.
- `npm run test:prompt-variants` still passes.
- Pure TS util, no Prisma dependency; project typecheck runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw)_