### PR TITLE
Fix red main CI: facet-assignments.cy.ts still sent deprecated Facet.kind

### DIFF
--- a/cypress/e2e/api/facet-assignments.cy.ts
+++ b/cypress/e2e/api/facet-assignments.cy.ts
@@ -29,7 +29,7 @@ describe('Dream and Scenario Facet assignments', () => {
       body: {
         title: `CowCore ${stamp}`,
         slug: facetSlug,
-        kind: 'CORE',
+        taxonomy: 'CORE',
         aliases: [cowAlias, cowsAlias],
         isPublic: false,
       },
@@ -254,7 +254,7 @@ describe('Dream and Scenario Facet assignments', () => {
       headers: { Authorization: `Bearer ${token}` },
       body: {
         description: 'Everything cows, updated.',
-        kind: 'THEME',
+        taxonomy: 'THEME',
         aliases: [cowAlias, bovineAlias],
       },
     }).then((response) => {


### PR DESCRIPTION
## Summary
- Main's scheduled Cypress run has been red since `e202b5a` ("Make Facet taxonomy authoritative") landed: `POST`/`PATCH /api/facets` now reject any request body containing `kind` with a 400 (`Facet kind is deprecated. Use taxonomy instead.`), but `cypress/e2e/api/facet-assignments.cy.ts` was never updated and still sent `kind: 'CORE'` / `kind: 'THEME'`.
- 6 of the spec's 7 tests were failing with `CypressError: cy.request() failed on... 400: Bad Request` (run [30236959387](https://github.com/silasfelinus/kind_robots/actions/runs/30236959387)).
- Switched both request bodies to `taxonomy: 'CORE'` / `taxonomy: 'THEME'`. The response assertion on the derived `kind` field (`response.body.data.kind`) is untouched — the server still returns `kind`, it just no longer accepts it as client input.

## Test plan
- [x] `npx eslint cypress/e2e/api/facet-assignments.cy.ts` — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — exit 0
- [x] `npx prettier --check` — clean
- [ ] Cypress run on `main` picks this up and goes green (can't run the full Cypress API suite in this sandbox — no Vercel-deployed target/DB)

ci-janitor:silasfelinus/kind_robots:cypress.yml:30236959387


---
_Generated by [Claude Code](https://claude.ai/code/session_01RrppCVpe3VYcpJNhb2JFpE)_