### PR TITLE
Facet audit closure: mappable-but-unlinked refinement + profile-repair & backfill scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "audit:channel-assets": "tsx utils/scripts/auditChannelAssets.ts",
     "audit:facet-data": "prisma generate && tsx utils/scripts/auditFacetCatalogData.ts",
     "triage:facet-audit": "prisma generate && tsx utils/scripts/triageFacetAudit.ts",
+    "repair:facet-profiles": "prisma generate && tsx utils/scripts/repairFacetProfiles.ts",
+    "backfill:facet-assignments": "prisma generate && tsx utils/scripts/backfillFacetAssignments.ts",
     "facet:alias": "prisma generate && tsx utils/scripts/setFacetAliases.ts",
     "facet:catalog:dry": "prisma generate && tsx utils/scripts/runFacetCatalogSeed.ts && tsx utils/scripts/mergeRewardFacetDuplicateLinks.ts && tsx utils/scripts/mergeCanonicalFacetDuplicates.ts",
     "facet:catalog:apply": "prisma generate && tsx utils/scripts/runFacetCatalogSeed.ts --apply && tsx utils/scripts/mergeRewardFacetDuplicateLinks.ts --apply && tsx utils/scripts/mergeCanonicalFacetDuplicates.ts --apply",

--- a/utils/scripts/auditFacetCatalogData.ts
+++ b/utils/scripts/auditFacetCatalogData.ts
@@ -195,6 +195,33 @@ async function main(): Promise<void> {
     aliasesByFacetId.set(alias.facetId, values)
   }
 
+  // lookupKey -> the taxonomies of the Facet(s) owning that alias. Used to
+  // decide whether a populated scalar value even maps to a canonical Facet: the
+  // scalar-assignment checks only treat a field as a strict error when a
+  // matching Facet exists but was never linked ("mappable but unlinked").
+  // Custom/free-text values (the point of a creative builder) have no canonical
+  // Facet and are reported as an informational warning, not a strict failure.
+  const taxonomiesByLookup = new Map<string, Set<string>>()
+  for (const alias of aliases) {
+    const taxonomy = profileByFacetId.get(alias.facetId)?.taxonomy
+    if (!taxonomy) continue
+    const set = taxonomiesByLookup.get(alias.lookupKey) ?? new Set<string>()
+    set.add(taxonomy)
+    taxonomiesByLookup.set(alias.lookupKey, set)
+  }
+  const valuesMapToAllowed = (
+    values: string[],
+    allowed: readonly string[],
+  ): boolean =>
+    values.some((value) => {
+      const owners = taxonomiesByLookup.get(normalizeFacetLookupKey(value))
+      return owners ? allowed.some((taxonomy) => owners.has(taxonomy)) : false
+    })
+
+  // backstory and quirks are narrative prose, not canonical concept references,
+  // so they are excluded from the scalar-assignment check entirely.
+  const PROSE_CHARACTER_FIELDS = new Set(['backstory', 'quirks'])
+
   const missingProfiles = facets.filter((facet) => !profileByFacetId.has(facet.id))
   if (missingProfiles.length) {
     severe.push({
@@ -378,29 +405,45 @@ async function main(): Promise<void> {
     fieldKey: string
     values: string[]
   }> = []
+  // Fields that are populated + unlinked but whose value(s) map to no canonical
+  // Facet: expected bespoke creative data (custom species, classes, freeform
+  // genres, prose). Counted as an informational warning, never a strict error.
+  let customCharacterFields = 0
   for (const character of characters) {
     for (const fieldKey of Object.keys(CHARACTER_FIELD_TAXONOMIES)) {
+      if (PROSE_CHARACTER_FIELDS.has(fieldKey)) continue
       const values = splitScalar(
         fieldKey,
         (character as Record<string, unknown>)[fieldKey],
       )
       if (
-        values.length &&
-        !characterLinksByOwnerField.has(`${character.id}:${fieldKey}`)
+        !values.length ||
+        characterLinksByOwnerField.has(`${character.id}:${fieldKey}`)
       ) {
+        continue
+      }
+      if (valuesMapToAllowed(values, CHARACTER_FIELD_TAXONOMIES[fieldKey]!)) {
         missingCharacterAssignments.push({
           characterId: character.id,
           fieldKey,
           values,
         })
+      } else {
+        customCharacterFields += 1
       }
     }
   }
   if (missingCharacterAssignments.length) {
     severe.push({
       code: 'CHARACTER_SCALAR_WITHOUT_ASSIGNMENT',
-      message: `${missingCharacterAssignments.length} populated Character fields have no canonical Facet assignment.`,
+      message: `${missingCharacterAssignments.length} populated Character fields map to a canonical Facet but have no assignment (mappable-but-unlinked).`,
       details: missingCharacterAssignments,
+    })
+  }
+  if (customCharacterFields) {
+    warnings.push({
+      code: 'CHARACTER_SCALAR_CUSTOM',
+      message: `${customCharacterFields} populated Character fields hold custom/free-text values with no canonical Facet (expected; excludes prose backstory/quirks).`,
     })
   }
 
@@ -412,22 +455,34 @@ async function main(): Promise<void> {
     fieldKey: string
     values: string[]
   }> = []
+  let customBotFields = 0
   for (const bot of bots) {
     for (const fieldKey of Object.keys(BOT_FIELD_TAXONOMIES)) {
       const values = splitScalar(
         fieldKey,
         (bot as Record<string, unknown>)[fieldKey],
       )
-      if (values.length && !botLinksByOwnerField.has(`${bot.id}:${fieldKey}`)) {
+      if (!values.length || botLinksByOwnerField.has(`${bot.id}:${fieldKey}`)) {
+        continue
+      }
+      if (valuesMapToAllowed(values, BOT_FIELD_TAXONOMIES[fieldKey]!)) {
         missingBotAssignments.push({ botId: bot.id, fieldKey, values })
+      } else {
+        customBotFields += 1
       }
     }
   }
   if (missingBotAssignments.length) {
     severe.push({
       code: 'BOT_SCALAR_WITHOUT_ASSIGNMENT',
-      message: `${missingBotAssignments.length} populated Bot fields have no canonical Facet assignment.`,
+      message: `${missingBotAssignments.length} populated Bot fields map to a canonical Facet but have no assignment (mappable-but-unlinked).`,
       details: missingBotAssignments,
+    })
+  }
+  if (customBotFields) {
+    warnings.push({
+      code: 'BOT_SCALAR_CUSTOM',
+      message: `${customBotFields} populated Bot fields hold custom/free-text values with no canonical Facet (expected).`,
     })
   }
 
@@ -441,18 +496,29 @@ async function main(): Promise<void> {
       .filter((link) => genreFacetIds.has(link.facetId))
       .map((link) => link.scenarioId),
   )
-  const missingScenarioGenreAssignments = scenarios
+  const scenarioGenreCandidates = scenarios
     .filter((scenario) => splitScalar('genres', scenario.genres).length)
     .filter((scenario) => !scenarioIdsWithGenreLinks.has(scenario.id))
     .map((scenario) => ({
       scenarioId: scenario.id,
       values: splitScalar('genres', scenario.genres),
     }))
+  const missingScenarioGenreAssignments = scenarioGenreCandidates.filter(
+    (scenario) => valuesMapToAllowed(scenario.values, ['GENRE']),
+  )
+  const customScenarioGenres =
+    scenarioGenreCandidates.length - missingScenarioGenreAssignments.length
   if (missingScenarioGenreAssignments.length) {
     severe.push({
       code: 'SCENARIO_GENRE_WITHOUT_ASSIGNMENT',
-      message: `${missingScenarioGenreAssignments.length} Scenarios have genre strings but no GENRE Facet links.`,
+      message: `${missingScenarioGenreAssignments.length} Scenarios have genre strings that map to a canonical GENRE Facet but no link (mappable-but-unlinked).`,
       details: missingScenarioGenreAssignments,
+    })
+  }
+  if (customScenarioGenres) {
+    warnings.push({
+      code: 'SCENARIO_GENRE_CUSTOM',
+      message: `${customScenarioGenres} Scenarios hold custom/free-text genre strings with no canonical GENRE Facet (expected).`,
     })
   }
 

--- a/utils/scripts/backfillFacetAssignments.ts
+++ b/utils/scripts/backfillFacetAssignments.ts
@@ -1,0 +1,327 @@
+// Backfill the *real* Facet-assignment debt the refined strict audit still
+// reports — the mappable-but-unlinked owner fields — and clean up the genuine
+// taxonomy mismatches. This is the small, surgical counterpart to the audit
+// refinement: the triage (triageFacetAudit.ts) showed the overwhelming majority
+// of "missing assignment" findings are expected bespoke creative data, so this
+// script only ever touches values that resolve to a real canonical Facet.
+//
+// Two ordered, independently-logged steps (run AFTER repairFacetProfiles.ts so
+// the profileless-cascade rows already carry a taxonomy):
+//
+//   (a) Delete genuine taxonomy mismatches — Character/Bot assignment rows whose
+//       linked Facet has a taxonomy that is NOT allowed for the field (e.g. a
+//       `class` field linked to a SPECIES Facet). These are wrong links from an
+//       earlier backfill; removing them lets step (b) recreate a correct link if
+//       the underlying value is mappable. Rows whose Facet still has no profile
+//       are left alone (those are the profile-repair's job, not a real mismatch).
+//
+//   (b) Create mappable-but-unlinked assignments — for every Character/Bot field
+//       and Scenario genre whose value(s) resolve via the alias table to a
+//       canonical Facet of the allowed taxonomy but have no link, insert the
+//       assignment row(s) (source = 'MIGRATION'). Prose Character fields
+//       (backstory, quirks) are skipped, matching the audit.
+//
+// Idempotent: every insert uses skipDuplicates against the owner's unique
+// constraint, and re-running after a clean run is a no-op.
+//
+// Usage:
+//   DATABASE_URL=... tsx utils/scripts/backfillFacetAssignments.ts          # dry-run
+//   DATABASE_URL=... tsx utils/scripts/backfillFacetAssignments.ts --apply  # write
+import 'dotenv/config'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { normalizeFacetLookupKey } from './../facetAliases'
+
+const databaseUrl: string = process.env.DATABASE_URL ?? ''
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
+const apply = process.argv.slice(2).includes('--apply')
+
+const CHARACTER_FIELD_TAXONOMIES: Record<string, readonly string[]> = {
+  genre: ['GENRE'],
+  species: ['ANIMAL', 'SPECIES'],
+  class: ['OCCUPATION', 'ARCHETYPE', 'ROLE'],
+  alignment: ['ALIGNMENT'],
+  gender: ['GENDER'],
+  personality: ['PERSONALITY'],
+  backstory: ['BACKSTORY'],
+  quirks: ['QUIRK'],
+  role: ['ROLE'],
+}
+const BOT_FIELD_TAXONOMIES: Record<string, readonly string[]> = {
+  BotType: ['BOT_TYPE'],
+  personality: ['PERSONALITY'],
+}
+// Narrative prose fields — never canonical concept references, excluded from
+// the scalar-assignment backfill (mirrors auditFacetCatalogData.ts).
+const PROSE_CHARACTER_FIELDS = new Set(['backstory', 'quirks'])
+
+function splitScalar(fieldKey: string, value: unknown): string[] {
+  if (typeof value !== 'string' || !value.trim()) return []
+  if (fieldKey === 'personality' || fieldKey === 'quirks' || fieldKey === 'genres') {
+    return value
+      .split(/\n---\n|\||\n|;|,/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  return [value.trim()]
+}
+
+async function main(): Promise<void> {
+  const [profiles, aliases, characterLinks, botLinks, scenarioLinks, characters, bots, scenarios] =
+    await Promise.all([
+      prisma.facetProfile.findMany({ select: { facetId: true, taxonomy: true } }),
+      prisma.facetAlias.findMany({
+        where: { isActive: true },
+        select: { facetId: true, lookupKey: true },
+      }),
+      prisma.characterFacet.findMany({
+        select: { characterId: true, facetId: true, fieldKey: true },
+      }),
+      prisma.botFacet.findMany({
+        select: { botId: true, facetId: true, fieldKey: true },
+      }),
+      prisma.scenarioFacet.findMany({
+        select: { scenarioId: true, facetId: true },
+      }),
+      prisma.character.findMany({
+        where: { isActive: true },
+        select: {
+          id: true,
+          genre: true,
+          species: true,
+          class: true,
+          alignment: true,
+          gender: true,
+          personality: true,
+          backstory: true,
+          quirks: true,
+          role: true,
+        },
+      }),
+      prisma.bot.findMany({
+        where: { isActive: true },
+        select: { id: true, BotType: true, personality: true },
+      }),
+      prisma.scenario.findMany({
+        where: { isActive: true },
+        select: { id: true, genres: true },
+      }),
+    ])
+
+  const taxonomyByFacetId = new Map(profiles.map((p) => [p.facetId, p.taxonomy]))
+  // lookupKey -> facets that own it, each with its taxonomy, sorted by facetId
+  // so resolution is deterministic when several facets share an alias.
+  const facetsByLookup = new Map<string, Array<{ facetId: number; taxonomy: string }>>()
+  for (const alias of aliases) {
+    const taxonomy = taxonomyByFacetId.get(alias.facetId)
+    if (!taxonomy) continue
+    const list = facetsByLookup.get(alias.lookupKey) ?? []
+    list.push({ facetId: alias.facetId, taxonomy })
+    facetsByLookup.set(alias.lookupKey, list)
+  }
+  for (const list of facetsByLookup.values()) {
+    list.sort((a, b) => a.facetId - b.facetId)
+  }
+
+  // Resolve a scalar value to the facetId of a canonical Facet whose taxonomy is
+  // allowed for the field, or null if the value is custom/unmappable.
+  function resolveFacet(value: string, allowed: readonly string[]): number | null {
+    const owners = facetsByLookup.get(normalizeFacetLookupKey(value))
+    if (!owners) return null
+    const match = owners.find((owner) => allowed.includes(owner.taxonomy))
+    return match ? match.facetId : null
+  }
+
+  // --- Step (a): genuine taxonomy-mismatch deletions ---
+  const charDeletes: Array<{ characterId: number; facetId: number; fieldKey: string }> = []
+  for (const link of characterLinks) {
+    const taxonomy = taxonomyByFacetId.get(link.facetId)
+    const allowed = CHARACTER_FIELD_TAXONOMIES[link.fieldKey]
+    if (taxonomy && allowed && !allowed.includes(taxonomy)) {
+      charDeletes.push(link)
+    }
+  }
+  const botDeletes: Array<{ botId: number; facetId: number; fieldKey: string }> = []
+  for (const link of botLinks) {
+    const taxonomy = taxonomyByFacetId.get(link.facetId)
+    const allowed = BOT_FIELD_TAXONOMIES[link.fieldKey]
+    if (taxonomy && allowed && !allowed.includes(taxonomy)) {
+      botDeletes.push(link)
+    }
+  }
+
+  // Rebuild "field is linked" sets excluding the rows step (a) removes, so a
+  // field freed by a mismatch delete becomes eligible for a correct backfill.
+  const deletedCharKeys = new Set(
+    charDeletes.map((d) => `${d.characterId}:${d.facetId}:${d.fieldKey}`),
+  )
+  const deletedBotKeys = new Set(
+    botDeletes.map((d) => `${d.botId}:${d.facetId}:${d.fieldKey}`),
+  )
+  const charLinkedField = new Set(
+    characterLinks
+      .filter((l) => !deletedCharKeys.has(`${l.characterId}:${l.facetId}:${l.fieldKey}`))
+      .map((l) => `${l.characterId}:${l.fieldKey}`),
+  )
+  const botLinkedField = new Set(
+    botLinks
+      .filter((l) => !deletedBotKeys.has(`${l.botId}:${l.facetId}:${l.fieldKey}`))
+      .map((l) => `${l.botId}:${l.fieldKey}`),
+  )
+  const scenarioLinkedFacet = new Set(
+    scenarioLinks.map((l) => `${l.scenarioId}:${l.facetId}`),
+  )
+
+  // --- Step (b): mappable-but-unlinked backfill ---
+  type CharacterFacetRow = {
+    characterId: number
+    facetId: number
+    fieldKey: string
+    sortOrder: number
+    source: string
+  }
+  type BotFacetRow = { botId: number; facetId: number; fieldKey: string; sortOrder: number; source: string }
+  type ScenarioFacetRow = { scenarioId: number; facetId: number }
+
+  const charInserts: CharacterFacetRow[] = []
+  for (const character of characters) {
+    for (const fieldKey of Object.keys(CHARACTER_FIELD_TAXONOMIES)) {
+      if (PROSE_CHARACTER_FIELDS.has(fieldKey)) continue
+      if (charLinkedField.has(`${character.id}:${fieldKey}`)) continue
+      const values = splitScalar(fieldKey, (character as Record<string, unknown>)[fieldKey])
+      if (!values.length) continue
+      const seen = new Set<number>()
+      let sortOrder = 0
+      for (const value of values) {
+        const facetId = resolveFacet(value, CHARACTER_FIELD_TAXONOMIES[fieldKey]!)
+        if (facetId === null || seen.has(facetId)) continue
+        seen.add(facetId)
+        charInserts.push({
+          characterId: character.id,
+          facetId,
+          fieldKey,
+          sortOrder: sortOrder++,
+          source: 'MIGRATION',
+        })
+      }
+    }
+  }
+
+  const botInserts: BotFacetRow[] = []
+  for (const bot of bots) {
+    for (const fieldKey of Object.keys(BOT_FIELD_TAXONOMIES)) {
+      if (botLinkedField.has(`${bot.id}:${fieldKey}`)) continue
+      const values = splitScalar(fieldKey, (bot as Record<string, unknown>)[fieldKey])
+      if (!values.length) continue
+      const seen = new Set<number>()
+      let sortOrder = 0
+      for (const value of values) {
+        const facetId = resolveFacet(value, BOT_FIELD_TAXONOMIES[fieldKey]!)
+        if (facetId === null || seen.has(facetId)) continue
+        seen.add(facetId)
+        botInserts.push({
+          botId: bot.id,
+          facetId,
+          fieldKey,
+          sortOrder: sortOrder++,
+          source: 'MIGRATION',
+        })
+      }
+    }
+  }
+
+  const scenarioInserts: ScenarioFacetRow[] = []
+  for (const scenario of scenarios) {
+    const values = splitScalar('genres', scenario.genres)
+    if (!values.length) continue
+    for (const value of values) {
+      const facetId = resolveFacet(value, ['GENRE'])
+      if (facetId === null) continue
+      if (scenarioLinkedFacet.has(`${scenario.id}:${facetId}`)) continue
+      scenarioLinkedFacet.add(`${scenario.id}:${facetId}`)
+      scenarioInserts.push({ scenarioId: scenario.id, facetId })
+    }
+  }
+
+  process.stdout.write(
+    [
+      `Facet assignment backfill — ${apply ? 'APPLY' : 'DRY-RUN'}`,
+      '',
+      'Step (a) genuine taxonomy-mismatch deletions:',
+      `  CharacterFacet rows: ${charDeletes.length}`,
+      `  BotFacet rows:       ${botDeletes.length}`,
+      ...charDeletes
+        .slice(0, 20)
+        .map((d) => `    - char ${d.characterId} field=${d.fieldKey} facet=${d.facetId} (${taxonomyByFacetId.get(d.facetId)})`),
+      charDeletes.length > 20 ? `    … +${charDeletes.length - 20} more` : '',
+      '',
+      'Step (b) mappable-but-unlinked backfill:',
+      `  CharacterFacet inserts: ${charInserts.length}`,
+      `  BotFacet inserts:       ${botInserts.length}`,
+      `  ScenarioFacet inserts:  ${scenarioInserts.length}`,
+      ...charInserts
+        .slice(0, 20)
+        .map((r) => `    + char ${r.characterId} field=${r.fieldKey} -> facet ${r.facetId}`),
+      charInserts.length > 20 ? `    … +${charInserts.length - 20} more` : '',
+    ]
+      .filter((line) => line !== '')
+      .join('\n') + '\n',
+  )
+
+  if (!apply) {
+    process.stdout.write('\nDry-run only. Re-run with --apply to write.\n')
+    return
+  }
+
+  let deleted = 0
+  for (const d of charDeletes) {
+    const result = await prisma.characterFacet.deleteMany({
+      where: { characterId: d.characterId, facetId: d.facetId, fieldKey: d.fieldKey },
+    })
+    deleted += result.count
+  }
+  for (const d of botDeletes) {
+    const result = await prisma.botFacet.deleteMany({
+      where: { botId: d.botId, facetId: d.facetId, fieldKey: d.fieldKey },
+    })
+    deleted += result.count
+  }
+
+  let inserted = 0
+  if (charInserts.length) {
+    const result = await prisma.characterFacet.createMany({
+      data: charInserts,
+      skipDuplicates: true,
+    })
+    inserted += result.count
+  }
+  if (botInserts.length) {
+    const result = await prisma.botFacet.createMany({
+      data: botInserts,
+      skipDuplicates: true,
+    })
+    inserted += result.count
+  }
+  if (scenarioInserts.length) {
+    const result = await prisma.scenarioFacet.createMany({
+      data: scenarioInserts,
+      skipDuplicates: true,
+    })
+    inserted += result.count
+  }
+
+  process.stdout.write(
+    `\nApplied: deleted ${deleted} mismatched rows, created ${inserted} assignment rows.\n`,
+  )
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/repairFacetProfiles.ts
+++ b/utils/scripts/repairFacetProfiles.ts
@@ -1,0 +1,287 @@
+// Repair legacy Facets that never received a FacetProfile during the Facet
+// migration. Each active Facet without a profile is flagged by the strict audit
+// as FACET_WITHOUT_PROFILE, and every assignment that references it cascades
+// into ASSIGNMENT_WITHOUT_PROFILE + CHARACTER/BOT taxonomy mismatches.
+//
+// The fix is deterministic: a Facet's dormant `kind` already records its
+// concept family (all 26 current legacy facets are kind=GENRE), so the profile
+// is minted with taxonomy = kind (validated against the FacetTaxonomy enum,
+// falling back to OTHER), canonicalValue = the Facet title, and grouping/render
+// metadata mirrored from an existing profile of the same taxonomy.
+//
+// Guards:
+//   - Skips any Facet that already has a profile (idempotent).
+//   - Skips (and reports for manual merge) any Facet whose (taxonomy,
+//     normalized canonicalValue) already belongs to another profile, so the
+//     repair can never introduce a DUPLICATE_CANONICAL_VALUE regression — use
+//     mergeCanonicalFacetDuplicates.ts for those.
+//   - Ensures each repaired Facet has an active canonical alias (creates one
+//     from the title only if the Facet has none), so the profile can't leave an
+//     ACTIVE_FACET_WITHOUT_ALIAS gap behind.
+//
+// Usage:
+//   DATABASE_URL=... tsx utils/scripts/repairFacetProfiles.ts            # dry-run
+//   DATABASE_URL=... tsx utils/scripts/repairFacetProfiles.ts --apply    # write
+import 'dotenv/config'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { normalizeFacetLookupKey } from './../facetAliases'
+
+const databaseUrl: string = process.env.DATABASE_URL ?? ''
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
+const apply = process.argv.slice(2).includes('--apply')
+
+const FACET_TAXONOMIES = new Set([
+  'GENRE',
+  'ANIMAL',
+  'COLOR',
+  'THEME',
+  'CORE',
+  'MOOD',
+  'STYLE',
+  'SETTING',
+  'ART_DIRECTION',
+  'SPECIES',
+  'OCCUPATION',
+  'ARCHETYPE',
+  'ROLE',
+  'ALIGNMENT',
+  'GENDER',
+  'BOT_TYPE',
+  'DREAM_TYPE',
+  'REWARD_TYPE',
+  'RARITY',
+  'PERSONALITY',
+  'BACKSTORY',
+  'QUIRK',
+  'MATERIAL',
+  'PROMPT_ENHANCEMENT',
+  'OTHER',
+])
+
+function taxonomyForKind(kind: unknown): string {
+  const normalized = typeof kind === 'string' ? kind.trim().toUpperCase() : ''
+  return FACET_TAXONOMIES.has(normalized) ? normalized : 'OTHER'
+}
+
+type ProfileTemplate = {
+  groupKey: string | null
+  groupLabel: string | null
+  artRequired: boolean
+  isRandomizable: boolean
+  randomWeight: number
+  sourceRank: number
+  maxSortOrder: number
+}
+
+async function main(): Promise<void> {
+  const [facets, profiles, aliases] = await Promise.all([
+    prisma.facet.findMany({
+      select: { id: true, title: true, slug: true, kind: true, isActive: true },
+    }),
+    prisma.facetProfile.findMany({
+      select: {
+        facetId: true,
+        taxonomy: true,
+        canonicalValue: true,
+        groupKey: true,
+        groupLabel: true,
+        artRequired: true,
+        isRandomizable: true,
+        randomWeight: true,
+        sourceRank: true,
+        sortOrder: true,
+      },
+    }),
+    prisma.facetAlias.findMany({
+      where: { isActive: true },
+      select: { facetId: true },
+    }),
+  ])
+
+  const profiledFacetIds = new Set(profiles.map((profile) => profile.facetId))
+  const facetById = new Map(facets.map((facet) => [facet.id, facet]))
+  const facetsWithAlias = new Set(aliases.map((alias) => alias.facetId))
+
+  // Existing (taxonomy, normalized canonicalValue) occupancy — mirrors the
+  // audit's DUPLICATE_CANONICAL_VALUE key so the repair can't collide.
+  const canonicalOccupied = new Set<string>()
+  // First profile encountered per taxonomy becomes the metadata template, and
+  // we track the running max sortOrder so new rows append after the deck.
+  const templateByTaxonomy = new Map<string, ProfileTemplate>()
+  for (const profile of profiles) {
+    const facet = facetById.get(profile.facetId)
+    const lookup = normalizeFacetLookupKey(
+      profile.canonicalValue || facet?.title || facet?.slug || '',
+    )
+    if (lookup) canonicalOccupied.add(`${profile.taxonomy}:${lookup}`)
+
+    const template = templateByTaxonomy.get(profile.taxonomy)
+    if (!template) {
+      templateByTaxonomy.set(profile.taxonomy, {
+        groupKey: profile.groupKey,
+        groupLabel: profile.groupLabel,
+        artRequired: profile.artRequired,
+        isRandomizable: profile.isRandomizable,
+        randomWeight: profile.randomWeight,
+        sourceRank: profile.sourceRank,
+        maxSortOrder: profile.sortOrder,
+      })
+    } else {
+      template.maxSortOrder = Math.max(template.maxSortOrder, profile.sortOrder)
+    }
+  }
+
+  const legacyFacets = facets.filter(
+    (facet) => facet.isActive && !profiledFacetIds.has(facet.id),
+  )
+
+  type PlannedProfile = {
+    facetId: number
+    title: string
+    taxonomy: string
+    canonicalValue: string
+    groupKey: string | null
+    groupLabel: string | null
+    sortOrder: number
+    artRequired: boolean
+    isRandomizable: boolean
+    randomWeight: number
+    sourceRank: number
+    needsAlias: boolean
+  }
+  const planned: PlannedProfile[] = []
+  const skippedDuplicates: Array<{ facetId: number; title: string; key: string }> =
+    []
+
+  for (const facet of legacyFacets) {
+    const taxonomy = taxonomyForKind(facet.kind)
+    const canonicalValue = (facet.title || facet.slug || '').trim()
+    const lookup = normalizeFacetLookupKey(canonicalValue)
+    const dupeKey = `${taxonomy}:${lookup}`
+    if (lookup && canonicalOccupied.has(dupeKey)) {
+      skippedDuplicates.push({
+        facetId: facet.id,
+        title: facet.title,
+        key: dupeKey,
+      })
+      continue
+    }
+    // Claim the slot so two legacy facets with the same title don't both mint.
+    if (lookup) canonicalOccupied.add(dupeKey)
+
+    const template = templateByTaxonomy.get(taxonomy)
+    const nextSortOrder = (template?.maxSortOrder ?? 0) + 1
+    if (template) template.maxSortOrder = nextSortOrder
+
+    planned.push({
+      facetId: facet.id,
+      title: facet.title,
+      taxonomy,
+      canonicalValue,
+      groupKey: template?.groupKey ?? taxonomy.toLowerCase(),
+      groupLabel:
+        template?.groupLabel ??
+        taxonomy
+          .toLowerCase()
+          .replace(/_/g, ' ')
+          .replace(/\b\w/g, (c) => c.toUpperCase()),
+      sortOrder: nextSortOrder,
+      artRequired: template?.artRequired ?? true,
+      isRandomizable: template?.isRandomizable ?? true,
+      randomWeight: template?.randomWeight ?? 1,
+      sourceRank: template?.sourceRank ?? 100,
+      needsAlias: !facetsWithAlias.has(facet.id),
+    })
+  }
+
+  const byTaxonomy = planned.reduce<Record<string, number>>((acc, item) => {
+    acc[item.taxonomy] = (acc[item.taxonomy] ?? 0) + 1
+    return acc
+  }, {})
+
+  process.stdout.write(
+    [
+      `Facet profile repair — ${apply ? 'APPLY' : 'DRY-RUN'}`,
+      `Active Facets without a profile: ${legacyFacets.length}`,
+      `Profiles to create: ${planned.length}  ${JSON.stringify(byTaxonomy)}`,
+      `Canonical aliases to backfill: ${planned.filter((p) => p.needsAlias).length}`,
+      `Skipped as duplicate canonical (merge manually): ${skippedDuplicates.length}`,
+      ...planned
+        .slice(0, 40)
+        .map(
+          (p) =>
+            `  + profile facet ${p.facetId} "${p.title}" -> ${p.taxonomy} (sort ${p.sortOrder}${p.needsAlias ? ', +alias' : ''})`,
+        ),
+      planned.length > 40 ? `  … +${planned.length - 40} more` : '',
+      ...skippedDuplicates.map(
+        (s) => `  ! skip facet ${s.facetId} "${s.title}" — ${s.key} already exists`,
+      ),
+    ]
+      .filter(Boolean)
+      .join('\n') + '\n',
+  )
+
+  if (!apply) {
+    process.stdout.write('\nDry-run only. Re-run with --apply to write.\n')
+    return
+  }
+  if (!planned.length) {
+    process.stdout.write('\nNothing to apply.\n')
+    return
+  }
+
+  let createdProfiles = 0
+  let createdAliases = 0
+  for (const item of planned) {
+    await prisma.facetProfile.create({
+      data: {
+        facetId: item.facetId,
+        taxonomy: item.taxonomy as never,
+        canonicalValue: item.canonicalValue || null,
+        groupKey: item.groupKey,
+        groupLabel: item.groupLabel,
+        sortOrder: item.sortOrder,
+        artRequired: item.artRequired,
+        isRandomizable: item.isRandomizable,
+        randomWeight: item.randomWeight,
+        sourceRank: item.sourceRank,
+      },
+    })
+    createdProfiles += 1
+
+    if (item.needsAlias && item.canonicalValue) {
+      const lookupKey = normalizeFacetLookupKey(item.canonicalValue)
+      if (lookupKey) {
+        const result = await prisma.facetAlias.createMany({
+          data: [
+            {
+              facetId: item.facetId,
+              alias: item.canonicalValue,
+              lookupKey,
+              isCanonical: true,
+              isActive: true,
+            },
+          ],
+          skipDuplicates: true,
+        })
+        createdAliases += result.count
+      }
+    }
+  }
+
+  process.stdout.write(
+    `\nApplied: created ${createdProfiles} profiles, ${createdAliases} canonical aliases.\n`,
+  )
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })


### PR DESCRIPTION
## Why

The strict Facet data-audit surfaced ~1,650 "severe" findings. The read-only triage tool (`npm run triage:facet-audit`, #1046) classified them: **only ~118 are real backfill work — ~1,209 are expected bespoke creative data** (custom species like "Anemonefolk", classes like "Marsupial Assassin", freeform genre combos, and prose `backstory`/`quirks`) that can never legitimately link to a canonical Facet. Forcing them to link would be wrong. So closure is an **audit correction + a small, surgical data repair**, not a mass migration. Direction confirmed with Silas.

| Group | Flagged | Real (fixable) | Expected (custom) |
|---|---|---|---|
| `CHARACTER_SCALAR` | 1255 | **118** (all `personality`) | 1137 |
| `BOT_SCALAR` | 11 | 0 | 11 |
| `SCENARIO_GENRE` | 61 | 0 | 61 |
| `FACET_WITHOUT_PROFILE` | 26 | 26 (legacy `kind=GENRE`) | — |
| `ASSIGNMENT_WITHOUT_PROFILE` | 223 | cascade of the 26 | — |
| `CHARACTER_TAXONOMY_MISMATCH` | 112 | 97 cascade + **15 genuine** | — |

## What changed

**1. Audit refinement — `utils/scripts/auditFacetCatalogData.ts`**
The three scalar-assignment checks now flag a field **only when its value(s) resolve to a canonical Facet of the allowed taxonomy but no assignment exists** ("mappable but unlinked"). Custom/free-text values become informational warnings (`CHARACTER_SCALAR_CUSTOM`, `BOT_SCALAR_CUSTOM`, `SCENARIO_GENRE_CUSTOM`) rather than strict errors, and prose `backstory`/`quirks` are excluded from the check entirely. This makes `--strict` green *honestly* on legitimately-custom data.
- No Prisma mutations added and every finding-code string is preserved, so `verifyFacetClosure.ts` (which pins the audit's read-only shape and code strings) passes unchanged — verified locally.

**2. `utils/scripts/repairFacetProfiles.ts` (new)** — `npm run repair:facet-profiles`
Mints a `FacetProfile` for each active Facet lacking one: `taxonomy` from the dormant `kind` (validated against `FacetTaxonomy`, all 26 are `GENRE`), `canonicalValue` from the title, grouping/render metadata mirrored from an existing profile of that taxonomy. Guards against a `DUPLICATE_CANONICAL_VALUE` regression (skips + reports collisions for `mergeCanonicalFacetDuplicates.ts`) and backfills a canonical alias only if the Facet has none. Clears `FACET_WITHOUT_PROFILE` (26), `ASSIGNMENT_WITHOUT_PROFILE` (223), and the 97 profileless-cascade mismatches. Dry-run by default; `--apply` to write; idempotent.

**3. `utils/scripts/backfillFacetAssignments.ts` (new)** — `npm run backfill:facet-assignments`
(a) Deletes the 15 genuine taxonomy mismatches (e.g. a `class` field linked to a SPECIES Facet), then (b) creates the mappable-but-unlinked Character/Bot/Scenario assignment rows (`source: 'MIGRATION'`). Reuses the audit's `splitScalar` + field-taxonomy maps so the two stay in lock-step. Dry-run by default; `--apply` to write; idempotent via `skipDuplicates`.

## Operator run order (deploy-side — needs a raw `mysql://` `DATABASE_URL`)
```
npm run repair:facet-profiles                 # dry-run preview
npm run repair:facet-profiles -- --apply
npm run backfill:facet-assignments            # dry-run preview
npm run backfill:facet-assignments -- --apply
npm run audit:facet-data -- --strict --output=artifacts/facet-data-audit.json   # expect: green
```
Each script prints its diff before writing. They can't run in this sandbox (no `mysql://` connection — the app API token isn't a DB connection), so they're run deploy-side or with a connection string.

## Verification
- `tsc --noEmit -p tsconfig.json` — clean on all three files.
- `npm run test:facet-closure` — passes (audit still read-only, all codes present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw)_