### PR TITLE
ai-art-academy lane-1 polish: image-upload.vue never emitted 'uploaded', so art-maker.vue's remix upload was silently dead

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -533,10 +533,20 @@ import { useRewardStore } from '@/stores/rewardStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useCollectionStore } from '@/stores/collectionStore'
 import { useServerStore } from '@/stores/serverStore'
+import type { ArtImage } from '~/prisma/generated/prisma/client'
 
 withDefaults(defineProps<{ showModelConnect?: boolean }>(), {
   showModelConnect: false,
 })
+
+// Consumers that only wire uploadStore.setTarget() (no per-image applyImage
+// callback -- e.g. art-maker.vue's remix-upload disclosure) have no other
+// way to learn a batch actually produced images: this component previously
+// had no defineEmits at all, so `@uploaded="..."` on <image-upload> anywhere
+// in the app was silently dead code -- the listener was simply never called.
+const emit = defineEmits<{
+  uploaded: [images: ArtImage[]]
+}>()
 
 type ImageUploadForm = {
   promptString: string
@@ -797,6 +807,15 @@ async function handleBatchUpload() {
     failedFiles.value = new Set(
       result.failed.map((r) => r.file).filter(Boolean) as File[],
     )
+
+    if (result.succeeded.length) {
+      emit(
+        'uploaded',
+        result.succeeded
+          .map((r) => r.artImage)
+          .filter((img): img is ArtImage => Boolean(img)),
+      )
+    }
 
     // Give the per-thumbnail success checkmark a frame to actually render
     // before its item is spliced out of the queue (or the whole queue is


### PR DESCRIPTION
## Bug

`components/art/art-maker.vue`'s "Remix Image" disclosure wires:

```vue
<image-upload @uploaded="handleRemixUploaded" />
```

and configures the upload target purely via `uploadStore.setTarget({...})` in `configureArtImageUpload()` — with **no** `applyImage` callback, which is the only other mechanism `stores/uploadStore.ts` offers for a consumer to learn a batch actually produced images (the mechanism `add-bot.vue`/`add-character.vue`/etc. use instead).

`components/art/image-upload.vue`'s `<script setup>` had **no `defineEmits()` call at all** — confirmed by grepping the file and its full git history (`git log -p --all -- components/art/image-upload.vue` never shows an `emit('uploaded', ...)` or `defineEmits` at any point). So `@uploaded="handleRemixUploaded"` in `art-maker.vue` was dead code from the moment it was written: the listener is never invoked. In practice, uploading a remix source image via that disclosure never showed "Remix image uploaded. Opening selected image." and never switched the dashboard to the Selected tab — even though the underlying upload itself succeeded and `image-upload.vue`'s own internal success banner rendered fine. Confirmed no other `<image-upload>` usage in the app relies on `@uploaded` either (checked all 9 usages via grep), so nothing else depends on the previous no-op behavior.

## How I found it

Read the full in-scope surface for this recurring lane-1 polish task (`art-styler.vue`, `image-upload.vue`, `art-maker.vue`, the four add-bot/add-character/add-reward/add-scenario components, `academyStyles.ts`) against the project's `continuous-improvement-checklist.md` exclusion list (15+ prior lane-1 fixes, none touching this). While reading `art-maker.vue`'s `handleRemixUploaded()`/`configureArtImageUpload()` and cross-checking `image-upload.vue`'s script setup, noticed the emit was listened for but never declared or fired anywhere in the component.

## Fix

Added a typed `uploaded` emit to `image-upload.vue` and fire it with the batch's succeeded `ArtImage` records once `uploadBatchForActiveTarget()` resolves with at least one success:

```ts
const emit = defineEmits<{
  uploaded: [images: ArtImage[]]
}>()
...
if (result.succeeded.length) {
  emit(
    'uploaded',
    result.succeeded
      .map((r) => r.artImage)
      .filter((img): img is ArtImage => Boolean(img)),
  )
}
```

Minimal diff, one file, 19 insertions, 0 deletions.

## Verification

- `npx prettier --check components/art/image-upload.vue`:
  ```
  Checking formatting...
  All matched files use Prettier code style!
  ```
- `npx eslint components/art/image-upload.vue` and `npm run test` (`vue-tsc --noEmit`): both fail in this sandbox with `Cannot resolve module "@nuxt/kit"` / `nuxi: not found` — there is no `node_modules` in this sandbox checkout at all (`ls node_modules` → "No such file or directory"). This matches the exact, repeatedly-documented limitation from ~15 prior lane-1 cycles in this same project's checklist ("no `node_modules`, `@nuxt/kit` unresolved — same known limitation as every prior lane-1/lane-3 cycle"). Relying on this repo's CI (TypeScript/vue-tsc, Contract verifiers, GitGuardian) to confirm, same as those prior cycles did.
- Manually reviewed the change for type correctness: `ArtImage` is imported from the same `~/prisma/generated/prisma/client` path already used by `art-styler.vue`; `defineEmits<{...}>()` syntax matches the existing typed-emit pattern already used in `art-styler.vue`; `ImageUploadResult.artImage` is typed `ArtImage | undefined` in `stores/uploadStore.ts`, matching the `(img): img is ArtImage => Boolean(img)` filter guard.
- Confirmed no test files reference `image-upload.vue` or `art-maker.vue` (`find` for both names under the repo returned only the source files themselves), so no existing test needed updating.

## Scope confirmation

Touched only `components/art/image-upload.vue` (in-scope per the lane-1 task). Did not touch `art-styler.vue`, `art-maker.vue`, any add-bot/add-character/add-reward/add-scenario component, or `academyStyles.ts`. Did not re-fix any bug class already documented in `continuous-improvement-checklist.md`'s rotation-state section (MIME-rejection message clearing, generation/selection token races, batch-upload re-entry/duplicate-upload guards, checkmark-timing, placeholder-path image src fallback, etc. — none of those relate to this missing-emit gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGbi8NBQzx6xAUaYMuV9ee


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGbi8NBQzx6xAUaYMuV9ee)_