### PR TITLE
ai-art-academy/t-019: wire previewImageSrc for greek-vase-painting, render style-browser thumbnails

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -74,7 +74,27 @@
         :aria-controls="`academy-style-detail-${style.slug}`"
         @click="expandedSlug = expandedSlug === style.slug ? null : style.slug"
       >
-        <div class="flex items-center justify-between gap-2">
+        <div
+          v-if="style.previewImageSrc"
+          class="relative -mx-4 -mt-4 w-[calc(100%+2rem)] overflow-hidden rounded-t-xl"
+          style="aspect-ratio: 16 / 9"
+        >
+          <img
+            :src="style.previewImageSrc"
+            :alt="style.name"
+            loading="lazy"
+            class="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+          />
+          <template v-if="academyStore.viewedLessons.includes(style.slug)">
+            <Icon
+              name="kind-icon:check"
+              class="absolute right-1.5 top-1.5 h-4 w-4 rounded-full bg-base-100/80 p-0.5 text-success"
+              aria-hidden="true"
+            />
+            <span class="sr-only">Lesson explored</span>
+          </template>
+        </div>
+        <div v-else class="flex items-center justify-between gap-2">
           <span class="text-2xl leading-none" aria-hidden="true">🏛️</span>
           <template v-if="academyStore.viewedLessons.includes(style.slug)">
             <Icon

--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -87,6 +87,7 @@ export const academyStyles: AcademyStyle[] = [
     name: 'Greek Vase Painting',
     era: 'c. 600–300 BCE',
     sortYear: -600,
+    previewImageSrc: '/images/academy/styles/greek-vase-painting.webp',
     region: 'Ancient Greece',
     keyIdeas:
       'Storytelling wrapped around everyday objects: gods, athletes, and heroes rendered in bold silhouette on clay. Black-figure and later red-figure techniques turned pottery into a portable gallery, and the strict two-tone palette forced artists to say everything with contour and gesture.',


### PR DESCRIPTION
### Task
ai-art-academy/t-019: wire academyStyles.ts previewImageSrc + render thumbnails in the style browser (kind: software)

### What changed / what I produced
- Set `previewImageSrc: '/images/academy/styles/greek-vase-painting.webp'` on the `greek-vase-painting` entry in `stores/seeds/academyStyles.ts` — the one curriculum movement with a confirmed-live thumbnail after conductor PR #1215 fixed the `distribute_images.py` prune bug.
- `components/academy/academy-styles-browser.vue`: the style grid card now renders a 16:9 thumbnail when `style.previewImageSrc` is set (with the "lesson explored" checkmark overlaid on the image), and falls back to the existing 🏛️ emoji placeholder for every style without one yet (32 of 33 currently).
- `art-styler.vue` / `academy-remix.vue` already handled `previewImageSrc` on the remix side, so no changes were needed there.

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean, no errors.
- `npx eslint` and `npx prettier --check` on both changed files — clean.
- `curl -sS -o /dev/null -w "HTTP %{http_code}"` against `https://media.acrocatranch.com/images/academy/styles/greek-vase-painting.webp` — confirmed `200`, so the image the new field points at is actually live in production.
- Could not visually screenshot the style browser (no reachable local dev server / DB in this sandbox), but the fallback branch (`v-else`) preserves the exact previous markup/behavior for styles without a `previewImageSrc`, so there's no regression risk for the other 32 styles.

### Stakes
reversible

### Flags for Reviewer
- Only 1 of 33 curriculum styles has a thumbnail right now (see ai-art-academy/t-035, currently claimed by another in-flight session, which re-queues the other 32). This PR intentionally wires only the one that's actually live, per the task note's explicit scope.

### Kaizen suggestion
Once t-035 lands more thumbnails, a follow-up pass could add a `srcset`/blur-placeholder for the style-browser images so the grid doesn't visibly pop between emoji and photo as thumbnails roll in over multiple cycles.

### Notes for reviewer
Conductor roadmap task ai-art-academy/t-019 set to `status: review` in companion conductor PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSyFXfPgsavnw3cBaHqejM)_