### PR TITLE
media-watchlist/t-006: wire Year filter + fill out Stats view

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -7,7 +7,10 @@
   log) -- renders a locked notice for any non-admin viewer instead of erroring.
   Selecting an entry opens watchlist-entry-detail.vue (BROWSE-UX.md §3/§5).
   Export downloads GET /api/media-entries/export (media-watchlist/t-006),
-  honoring the current search/type/starred/sort filters.
+  honoring the current search/year/type/starred/sort filters. The Year pill
+  selector and the two extra stats tiles (comics read, TV seasons) close the
+  remaining BROWSE-UX.md §2/§4 gaps -- the API already computed/accepted this
+  data, it just wasn't wired into the UI yet (media-watchlist/t-006).
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -25,7 +28,7 @@
       <!-- Stats strip -->
       <div
         v-if="stats"
-        class="grid grid-cols-2 gap-2 rounded-3xl border border-base-300 bg-base-100 p-4 sm:grid-cols-4"
+        class="grid grid-cols-2 gap-2 rounded-3xl border border-base-300 bg-base-100 p-4 sm:grid-cols-3 lg:grid-cols-6"
       >
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -67,6 +70,26 @@
             >pages read</span
           >
         </div>
+        <div
+          class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
+        >
+          <span class="text-lg font-black text-base-content">{{
+            stats.comicIssuesRead
+          }}</span>
+          <span class="text-xs font-semibold text-base-content/50"
+            >comics read</span
+          >
+        </div>
+        <div
+          class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
+        >
+          <span class="text-lg font-black text-base-content">{{
+            stats.tvSeasonCount
+          }}</span>
+          <span class="text-xs font-semibold text-base-content/50"
+            >TV seasons ({{ stats.tvShowCount }} shows)</span
+          >
+        </div>
       </div>
 
       <!-- Filters -->
@@ -79,6 +102,36 @@
           placeholder="Search title or author…"
           class="input input-sm input-bordered w-full rounded-xl sm:w-56"
         />
+
+        <button
+          v-if="stats?.years.length"
+          type="button"
+          class="btn btn-sm gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          :class="
+            activeYear === null
+              ? 'btn-primary'
+              : 'btn-ghost border border-base-300'
+          "
+          :aria-pressed="activeYear === null"
+          @click="activeYear = null"
+        >
+          All years
+        </button>
+        <button
+          v-for="yearOption in stats?.years ?? []"
+          :key="yearOption"
+          type="button"
+          class="btn btn-sm gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          :class="
+            activeYear === yearOption
+              ? 'btn-primary'
+              : 'btn-ghost border border-base-300'
+          "
+          :aria-pressed="activeYear === yearOption"
+          @click="activeYear = activeYear === yearOption ? null : yearOption"
+        >
+          {{ yearOption }}
+        </button>
 
         <button
           v-for="type in MEDIA_TYPE_CHIPS"
@@ -256,10 +309,14 @@ type MediaEntriesResponse = {
 }
 
 type MediaEntryStats = {
+  years: number[]
   totalCount: number
   starredCount: number
   audiobookHours: number
   pagesRead: number
+  comicIssuesRead: number
+  tvShowCount: number
+  tvSeasonCount: number
 }
 
 type MediaEntryStatsResponse = {
@@ -280,6 +337,7 @@ const userStore = useUserStore()
 const isAdmin = computed(() => userStore.isAdmin === true)
 
 const search = ref('')
+const activeYear = ref<number | null>(null)
 const activeTypes = ref<Set<MediaType>>(new Set())
 const starredOnly = ref(false)
 const sort = ref<
@@ -326,6 +384,7 @@ async function loadStats(): Promise<void> {
   try {
     const res = await $fetch<MediaEntryStatsResponse, string>(
       '/api/media-entries/stats',
+      { query: { year: activeYear.value || undefined } },
     )
     if (res?.success) stats.value = res.data
   } catch {
@@ -343,6 +402,7 @@ async function loadEntries(): Promise<void> {
       {
         query: {
           search: search.value || undefined,
+          year: activeYear.value || undefined,
           mediaType: activeTypes.value.size
             ? Array.from(activeTypes.value).join(',')
             : undefined,
@@ -383,6 +443,14 @@ watch([activeTypes, starredOnly, sort], () => {
   void loadEntries()
 })
 
+// Year is the one filter the Stats strip itself also respects (BROWSE-UX.md
+// §4's "year switcher"), so changing it reloads both entries and stats.
+watch(activeYear, () => {
+  skip.value = 0
+  void loadEntries()
+  void loadStats()
+})
+
 function showMore() {
   skip.value += take
   void loadEntries()
@@ -391,6 +459,7 @@ function showMore() {
 function exportCsv() {
   const params = new URLSearchParams()
   if (search.value) params.set('search', search.value)
+  if (activeYear.value) params.set('year', String(activeYear.value))
   if (activeTypes.value.size) {
     params.set('mediaType', Array.from(activeTypes.value).join(','))
   }

--- a/server/api/media-entries/export.get.ts
+++ b/server/api/media-entries/export.get.ts
@@ -8,6 +8,9 @@
 // parsing in index.get.ts but skips pagination (an export is the whole
 // filtered set, not one page of it). Admin-gated, same as every other
 // media-entries route.
+//
+// Query: search, mediaType, starred, sort, year (all optional, same
+// semantics as index.get.ts).
 import { defineEventHandler, getQuery, setHeader } from 'h3'
 import type { MediaEntry, Prisma } from '~/prisma/generated/prisma/client'
 import { MediaType } from '~/prisma/generated/prisma/client'
@@ -99,6 +102,11 @@ export default defineEventHandler(async (event) => {
     const query = getQuery(event)
 
     const andFilters: Prisma.MediaEntryWhereInput[] = []
+
+    const parsedYear = Number(query.year)
+    if (Number.isInteger(parsedYear) && parsedYear > 0) {
+      andFilters.push({ year: parsedYear })
+    }
 
     const mediaTypes =
       typeof query.mediaType === 'string'

--- a/server/api/media-entries/stats.get.ts
+++ b/server/api/media-entries/stats.get.ts
@@ -29,6 +29,7 @@ export default defineEventHandler(async (event) => {
       pagesRead,
       comicIssues,
       tvSeasons,
+      yearRows,
     ] = await Promise.all([
       prisma.mediaEntry.count({ where }),
       prisma.mediaEntry.groupBy({
@@ -65,6 +66,14 @@ export default defineEventHandler(async (event) => {
         _count: { _all: true },
         _sum: { season: true },
       }),
+      // Unfiltered by `year` -- this powers the Year pill selector itself
+      // (BROWSE-UX.md §2), so it must list every year regardless of which
+      // one is currently selected.
+      prisma.mediaEntry.findMany({
+        distinct: ['year'],
+        select: { year: true },
+        orderBy: { year: 'desc' },
+      }),
     ])
 
     const countByType = byMediaType.reduce<Record<string, number>>(
@@ -89,6 +98,7 @@ export default defineEventHandler(async (event) => {
       success: true,
       data: {
         year: year ?? null,
+        years: yearRows.map((row) => row.year),
         totalCount,
         countByType,
         countByMonth,


### PR DESCRIPTION
### Task
media-watchlist/t-006: Polish and upgrade Media Watchlist front-end surface (kind: software) — conductor rotation pick

### What changed / what I produced
- `server/api/media-entries/stats.get.ts`: added a `years: number[]` field (distinct years, descending, unfiltered by the `year` query param) so the front end can render a Year selector without a new endpoint.
- `server/api/media-entries/export.get.ts`: added `year` filter support, matching the pattern already used in `index.get.ts` — so a CSV export now respects the Year filter the same way it respects search/type/starred.
- `components/watchlist/watchlist-browse.vue`:
  - Year pill selector ("All years" + one pill per year with data), wired into the browse query, the stats query, and the CSV export params.
  - Two new stats-strip tiles: comics read, TV seasons (`N seasons (M shows)`) — data the stats API already computed but the UI never surfaced.

This closes the remaining gaps between `projects/media-watchlist/BROWSE-UX.md` §2 (Year filter) and §4 (Stats view: comics read, TV seasons) and what was actually wired up — the backend already had all of this data computed/accepted, it just wasn't reachable from the UI.

### How I verified
- `npx eslint` on all three changed files: clean.
- `npx prettier --check`: clean (ran `--write` once to fix the new template block, then reverified clean).
- Full-project `npm run test` (`vue-tsc --noEmit`): exit 0, no new errors.

### Stakes
reversible

### Flags for Reviewer
- Did not add the Month/Season filters from BROWSE-UX.md §2 (also API-supported, UI-missing) — kept this PR scoped to Year + the two stats tiles rather than growing it further; left as a natural follow-up if wanted.
- Live browser smoke-test not possible in this sandbox (no reachable `DATABASE_URL`), same constraint noted on other media-watchlist/storymaker/model-builder cycles — verification here is typecheck + lint only.

### Kaizen suggestion
Wire the remaining BROWSE-UX.md §2 filters (Month multi-select, Season for TV) the same way — the API (`index.get.ts`) already accepts both `month` and `season` query params; only the UI is missing.

### Notes for reviewer
Conductor task media-watchlist/t-006 claimed as `worker` this session (`claude-conductor-burst-20260727T141647Z-mw-t006`); roadmap will be set to `status: review` right after this PR opens, per AGENTS.md.


---
_Generated by [Claude Code](https://claude.ai/code/session_013eCsfvZYS8Z185J5vzrpAP)_