### PR TITLE
ai-art-academy/t-010: validate starter-manifest file field

### DIFF
--- a/utils/scripts/verifyAcademyStarterManifest.ts
+++ b/utils/scripts/verifyAcademyStarterManifest.ts
@@ -26,6 +26,8 @@ import {
 const manifestRelativePath = 'academy/starters/starters.manifest.json'
 const manifestSource = mediaSourceDescription(manifestRelativePath)
 
+const REQUIRED_OWN_STRING_FIELDS = ['file'] as const
+
 async function main(): Promise<void> {
   const raw = await readMediaText(manifestRelativePath)
 
@@ -63,6 +65,13 @@ async function main(): Promise<void> {
       return
     }
     const record = entry as Record<string, unknown>
+
+    for (const field of REQUIRED_OWN_STRING_FIELDS) {
+      const value = record[field]
+      if (typeof value !== 'string' || value.trim() === '') {
+        errors.push(`${label}: missing or empty required field "${field}"`)
+      }
+    }
     validateProvenanceRecord(record, label, errors)
   })
 


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass — front-end polish lane (kind: software)

### What changed / what I produced
- `utils/scripts/verifyAcademyStarterManifest.ts` never validated the `file` field on starter-manifest entries — only the 8 shared provenance fields via `validateProvenanceRecord`. Its sibling `verifyAcademyExamplesManifest.ts` already guards this exact field via a `REQUIRED_OWN_STRING_FIELDS` check. Added the same check to the starter-manifest verifier.
- Found via an Explore-agent sweep over the Academy frontend, explicitly excluding every bug class already fixed in prior `ai-art-academy/t-010` cycles (documented in `projects/ai-art-academy/docs/continuous-improvement-run-log.md`).

### Why this matters
`starters.manifest.json` lives on the external media origin, edited independently of this repo. `art-styler.vue`'s `StarterEntry` interface declares `file: string` as required, but `starterEntries.value = (await response.json()) as StarterEntry[]` is a bare type assertion with zero runtime validation. Every entry renders eagerly (`v-for="entry in starterEntries"` → `:src="starterImageSrc(entry)"`) as soon as the Starters tab loads, and `starterImageSrc()` does `entry.file.replace(...)`. A manifest edit with a typo'd or missing `file` key (all other required fields present) currently passes `npm run test:academy-starter-manifest` — a required CI job (`.github/workflows/contract-tests.yml`) — and would throw `TypeError: Cannot read properties of undefined (reading 'replace')` for every user who opens the Starters tab, with no CI signal pointing at the cause.

### How I verified
- Reproduced the gap locally with `MEDIA_ROOT` pointing at a fixture manifest missing `file`: before the fix this would silently pass; after the fix it correctly reports `missing or empty required field "file"` (exit 1). Re-added `file` and confirmed the same fixture then passes (exit 0).
- `npx eslint utils/scripts/verifyAcademyStarterManifest.ts` — clean.
- `npm run test` (`vue-tsc --noEmit`) — exit 0.
- `npx prettier --check` on the changed file reports pre-existing drift unrelated to this change (confirmed via `git stash` — the same warning fires on the file before my edit too).

### Stakes
reversible

### Flags for Reviewer
- None — small, additive, mirrors an existing sibling pattern exactly.

### Kaizen suggestion
`academyProvenanceSchema.ts`'s shared `validateProvenanceRecord` only covers fields common to both manifests; each manifest's own required-own-fields list is hand-duplicated in its own verifier. Worth considering a shared `REQUIRED_OWN_STRING_FIELDS`-style helper parameterized per manifest so this class of gap (one verifier lacking a check the other already has) can't recur silently.

### Notes for reviewer
kind_robots-only change; no conductor code changes needed beyond the roadmap note this PR's merge will prompt.

---
_Generated by [Claude Code](https://claude.ai/code/session_015spfEPjzHYJWn8VCkxJVbC)_