### PR TITLE
storymaker/t-010: deep-link recent scenarios into their configure phase

### DIFF
--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -23,12 +23,13 @@
         </p>
         <ul v-if="recentScenarios.length" class="flex flex-col gap-1">
           <li v-for="scenario in recentScenarios" :key="scenario.id">
-            <NuxtLink
-              to="/stories"
+            <button
+              type="button"
               class="text-sm text-primary hover:underline"
+              @click="openScenario(scenario.id)"
             >
               {{ scenario.title || 'Untitled scenario' }}
-            </NuxtLink>
+            </button>
           </li>
         </ul>
         <div class="flex flex-wrap gap-2">
@@ -77,6 +78,18 @@ const recentScenarios = computed(() => scenarioStore.scenarios.slice(0, 3))
  */
 function startNewScenario() {
   navigateTo('/stories?scenario=new')
+}
+
+/**
+ * Recent scenarios previously linked to the generic /stories browse view,
+ * leaving the visitor to re-find the scenario they just saw here. Selecting
+ * it first flips scenario-manager's phase straight to 'configure' for that
+ * scenario (storyStore.phase reacts to scenarioStore.selectedScenario), so
+ * the deep link actually lands on the scenario instead of losing it.
+ */
+async function openScenario(id: number) {
+  await scenarioStore.selectScenario(id)
+  navigateTo('/stories')
 }
 
 const config: ProjectFrontConfig = {


### PR DESCRIPTION
## Summary
- The storymaker front page's "recent scenarios" list linked to the generic `/stories` browse view, losing the scenario the visitor just saw.
- `openScenario(id)` now calls `scenarioStore.selectScenario(id)` before navigating — `storyStore.phase` reacts to `scenarioStore.selectedScenario`, so the link lands directly in that scenario's configure phase, mirroring the existing `?scenario=new` deep-link pattern already used by the "Start a new scenario" CTA.

## Test plan
- [x] `npx eslint components/conductor/storymaker-page.vue` — clean
- [x] `npx prettier --check components/conductor/storymaker-page.vue` — clean
- [x] `npm run test` (full-project `vue-tsc --noEmit`) — exit 0
- [ ] Live browser smoke — deferred, no reachable `DATABASE_URL` in this sandbox (same class of blocker as model-builder/t-031 and davinci/t-014)

Part of conductor project `storymaker/t-010`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013J219mUQDNpb81iXLk4waR

---
_Generated by [Claude Code](https://claude.ai/code/session_013J219mUQDNpb81iXLk4waR)_