### PR TITLE
ai-art-academy/t-010: guard stale source-image write in runStyleTransfer

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1473,7 +1473,17 @@ async function runStyleTransfer(): Promise<void> {
           thumbnailData?: string | null
           negativePrompt?: string | null
         }
-        selectedSourceImage.value = fetched
+        // Only reflect the freshly-fetched image data back into the visible
+        // selection if the user hasn't since picked a different source or
+        // started a newer generation -- this is the one write to
+        // selectedSourceImage in the whole file that wasn't token-guarded,
+        // so a slow-but-successful lazy fetch from a superseded request
+        // could silently revert a newer pick back to the stale image it was
+        // still processing (same pattern as the resultImage/successMessage
+        // guard below).
+        if (token === generationToken) {
+          selectedSourceImage.value = fetched
+        }
       }
     }
 


### PR DESCRIPTION
## Bug

`art-styler.vue`'s `runStyleTransfer()` lazily fetches full `imageData` for the selected source image whenever it only has `thumbnailData` — which is the normal case for any gallery-selected image, since `selectGalleryImage()` explicitly fetches with `includeImageData: false`. So this lazy-fetch branch runs on essentially every "Apply Style" click against a gallery-picked source.

While that fetch is in flight, nothing in the UI blocks the user from picking a different source image, switching tabs, or clearing the selection — that's an intentional design choice elsewhere in this file, backed by `generationToken`/`sourceSelectionToken` guards on every other write to `selectedSourceImage`. But this one write, `selectedSourceImage.value = fetched`, was the sole exception: it ran unconditionally once the fetch resolved.

**Result:** if the user switches to a different source image while an older generation's lazy image-data fetch is still in flight, and that fetch later resolves successfully, it silently reverts the visible selection back to the stale image the old (superseded) request was processing — even though the user has already moved on.

## Fix

Gate the write with `if (token === generationToken)`, matching the exact token-guard pattern already used a few lines below for `resultImage`/`successMessage` in the same function. Minimal, one-file change (11 insertions, 1 deletion).

## Verification

- `npx eslint components/art/art-styler.vue` — clean
- `npx prettier --check components/art/art-styler.vue` — reports pre-existing drift, confirmed via `git stash` to fire identically before this change too (unrelated, matches the repo's known prettier-version-mismatch noted in prior `ai-art-academy/t-010` cycles)
- `npm run test` (`vue-tsc --noEmit`) — passes, no errors

Part of the recurring `ai-art-academy/t-010` continuous-improvement rotation (lane 1: front-end polish).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfJfmDMnUvsGJRrnsBoYwB)_