### PR TITLE
media-watchlist/t-012: wire Month and Season filters into watchlist-browse.vue

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -6,11 +6,12 @@
   projects/media-watchlist/BROWSE-UX.md. Admin-only (this is Silas's private
   log) -- renders a locked notice for any non-admin viewer instead of erroring.
   Selecting an entry opens watchlist-entry-detail.vue (BROWSE-UX.md §3/§5).
-  Export downloads GET /api/media-entries/export (media-watchlist/t-006),
-  honoring the current search/year/type/starred/sort filters. The Year pill
-  selector and the two extra stats tiles (comics read, TV seasons) close the
-  remaining BROWSE-UX.md §2/§4 gaps -- the API already computed/accepted this
-  data, it just wasn't wired into the UI yet (media-watchlist/t-006).
+  Export downloads GET /api/media-entries/export (media-watchlist/t-006,
+  t-012), honoring the current search/year/type/starred/month/season/sort
+  filters. The Year pill selector, Month multi-select, Season number filter
+  (TV only), and the two extra stats tiles (comics read, TV seasons) close
+  the BROWSE-UX.md §2/§4 gaps -- the API already computed/accepted this
+  data, it just wasn't wired into the UI yet (media-watchlist/t-006, t-012).
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -161,6 +162,59 @@
           <Icon name="kind-icon:star" class="size-3.5" />
           Starred
         </button>
+
+        <div class="dropdown">
+          <button
+            type="button"
+            tabindex="0"
+            class="btn btn-sm gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :class="
+              activeMonths.size
+                ? 'btn-primary'
+                : 'btn-ghost border border-base-300'
+            "
+            :aria-pressed="activeMonths.size > 0"
+          >
+            <Icon name="kind-icon:clock" class="size-3.5" />
+            {{ activeMonths.size ? `Month (${activeMonths.size})` : 'Month' }}
+          </button>
+          <div
+            tabindex="0"
+            class="dropdown-content z-10 mt-1 grid grid-cols-4 gap-1 rounded-2xl border border-base-300 bg-base-100 p-2 shadow-lg"
+          >
+            <button
+              v-for="monthOption in MONTH_LABELS"
+              :key="monthOption.value"
+              type="button"
+              class="btn btn-xs rounded-lg"
+              :class="
+                activeMonths.has(monthOption.value)
+                  ? 'btn-primary'
+                  : 'btn-ghost border border-base-300'
+              "
+              :aria-pressed="activeMonths.has(monthOption.value)"
+              @click="toggleMonth(monthOption.value)"
+            >
+              {{ monthOption.label }}
+            </button>
+          </div>
+        </div>
+
+        <label
+          v-if="showSeasonFilter"
+          class="flex items-center gap-1.5 text-xs font-semibold text-base-content/60"
+        >
+          Season
+          <input
+            v-model.number="season"
+            type="number"
+            min="1"
+            max="99"
+            placeholder="Any"
+            aria-label="Season number (TV only)"
+            class="input input-sm input-bordered w-16 rounded-xl"
+          />
+        </label>
 
         <select
           v-model="sort"
@@ -333,12 +387,29 @@ const MEDIA_TYPE_CHIPS: { value: MediaType; label: string }[] = [
   { value: 'VIDEO_GAME', label: 'Games' },
 ]
 
+const MONTH_LABELS: { value: number; label: string }[] = [
+  { value: 1, label: 'Jan' },
+  { value: 2, label: 'Feb' },
+  { value: 3, label: 'Mar' },
+  { value: 4, label: 'Apr' },
+  { value: 5, label: 'May' },
+  { value: 6, label: 'Jun' },
+  { value: 7, label: 'Jul' },
+  { value: 8, label: 'Aug' },
+  { value: 9, label: 'Sep' },
+  { value: 10, label: 'Oct' },
+  { value: 11, label: 'Nov' },
+  { value: 12, label: 'Dec' },
+]
+
 const userStore = useUserStore()
 const isAdmin = computed(() => userStore.isAdmin === true)
 
 const search = ref('')
 const activeYear = ref<number | null>(null)
 const activeTypes = ref<Set<MediaType>>(new Set())
+const activeMonths = ref<Set<number>>(new Set())
+const season = ref<number | null>(null)
 const starredOnly = ref(false)
 const sort = ref<
   'date_desc' | 'date_asc' | 'title_asc' | 'title_desc' | 'starred_first'
@@ -358,6 +429,16 @@ const selectedEntry = computed(
   () => entries.value.find((entry) => entry.id === selectedId.value) ?? null,
 )
 
+// Season (BROWSE-UX.md §2) only applies to TV entries, so only show/send it
+// when TV is the active filter or no type filter narrows the results away
+// from TV at all.
+const showSeasonFilter = computed(
+  () => activeTypes.value.size === 0 || activeTypes.value.has('TV'),
+)
+watch(showSeasonFilter, (visible) => {
+  if (!visible) season.value = null
+})
+
 function handleEntryUpdated(updated: MediaEntryDetail) {
   const index = entries.value.findIndex((entry) => entry.id === updated.id)
   if (index !== -1)
@@ -369,6 +450,13 @@ function toggleType(type: MediaType) {
   if (next.has(type)) next.delete(type)
   else next.add(type)
   activeTypes.value = next
+}
+
+function toggleMonth(month: number) {
+  const next = new Set(activeMonths.value)
+  if (next.has(month)) next.delete(month)
+  else next.add(month)
+  activeMonths.value = next
 }
 
 function formatDate(entry: MediaEntrySummary): string {
@@ -407,6 +495,13 @@ async function loadEntries(): Promise<void> {
             ? Array.from(activeTypes.value).join(',')
             : undefined,
           starred: starredOnly.value ? 'true' : undefined,
+          month: activeMonths.value.size
+            ? Array.from(activeMonths.value)
+                .sort((a, b) => a - b)
+                .join(',')
+            : undefined,
+          season:
+            showSeasonFilter.value && season.value ? season.value : undefined,
           sort: sort.value,
           take,
           skip: skip.value,
@@ -438,7 +533,7 @@ watch(search, () => {
   }, 300)
 })
 
-watch([activeTypes, starredOnly, sort], () => {
+watch([activeTypes, starredOnly, sort, activeMonths, season], () => {
   skip.value = 0
   void loadEntries()
 })
@@ -464,6 +559,17 @@ function exportCsv() {
     params.set('mediaType', Array.from(activeTypes.value).join(','))
   }
   if (starredOnly.value) params.set('starred', 'true')
+  if (activeMonths.value.size) {
+    params.set(
+      'month',
+      Array.from(activeMonths.value)
+        .sort((a, b) => a - b)
+        .join(','),
+    )
+  }
+  if (showSeasonFilter.value && season.value) {
+    params.set('season', String(season.value))
+  }
   params.set('sort', sort.value)
 
   const link = document.createElement('a')

--- a/server/api/media-entries/export.get.ts
+++ b/server/api/media-entries/export.get.ts
@@ -9,8 +9,8 @@
 // filtered set, not one page of it). Admin-gated, same as every other
 // media-entries route.
 //
-// Query: search, mediaType, starred, sort, year (all optional, same
-// semantics as index.get.ts).
+// Query: search, mediaType, starred, sort, year, month, season (all
+// optional, same semantics as index.get.ts).
 import { defineEventHandler, getQuery, setHeader } from 'h3'
 import type { MediaEntry, Prisma } from '~/prisma/generated/prisma/client'
 import { MediaType } from '~/prisma/generated/prisma/client'
@@ -27,6 +27,14 @@ const SORT_MODES = [
   'starred_first',
 ] as const
 type SortMode = (typeof SORT_MODES)[number]
+
+function parseIntList(value: unknown): number[] {
+  if (typeof value !== 'string' || !value.trim()) return []
+  return value
+    .split(',')
+    .map((entry) => Number(entry.trim()))
+    .filter((entry) => Number.isInteger(entry))
+}
 
 // Hard cap so a filterless export on a much larger future log can't build an
 // unbounded CSV in memory; the current log is ~2,440 entries total.
@@ -121,6 +129,14 @@ export default defineEventHandler(async (event) => {
 
     if (query.starred === 'true') {
       andFilters.push({ starred: true })
+    }
+
+    const months = parseIntList(query.month).filter((m) => m >= 1 && m <= 12)
+    if (months.length) andFilters.push({ watchedMonth: { in: months } })
+
+    const parsedSeason = Number(query.season)
+    if (Number.isInteger(parsedSeason) && parsedSeason > 0) {
+      andFilters.push({ season: parsedSeason })
     }
 
     const search = typeof query.search === 'string' ? query.search.trim() : ''


### PR DESCRIPTION
### Task
media-watchlist/t-012: Wire the Month and Season filters from BROWSE-UX.md §2 into watchlist-browse.vue (kind: software)

### What changed / what I produced
- `components/watchlist/watchlist-browse.vue`: adds a Month multi-select (Jan–Dec chips in a dropdown) and a Season number filter, threaded into `loadEntries()` and `exportCsv()`. Season is only shown/sent when TV is the active type filter, or no type filter narrows results away from TV (it resets when hidden).
- `server/api/media-entries/export.get.ts`: adds `month`/`season` query parsing (mirroring the existing pattern in `index.get.ts`, which already validated both) — the export route didn't accept either yet, so CSV export now matches whatever's on screen.

### How I verified
- `npx eslint` clean on both changed files.
- `npx prettier --check` clean (ran `--write` once to match house style after my initial edit).
- Full-project `vue-tsc --noEmit`: 0 errors.
- Live browser smoke deferred — no reachable `DATABASE_URL` in this sandbox (same class of blocker as several prior tasks, e.g. storymaker/t-010, model-builder/t-031).

### Stakes
reversible

### Flags for Reviewer
- Season UX is a single-number input (not a "range" as BROWSE-UX.md's prose loosely suggests) because the backend (`index.get.ts`, already shipped) only accepts a single `season: Int`, per the task note's explicit instruction that this is front-end wiring only, not new backend scope.
- Month dropdown uses a `.dropdown`/`.dropdown-content` pair (daisyUI convention already used elsewhere in the codebase) rather than 12 always-visible chips, to avoid cluttering the filter bar.

### Kaizen suggestion
BROWSE-UX.md §1 also mentions a "most active month" home-dashboard stat that isn't wired into any UI yet — a natural next continuous-improvement-style task for this project once a recurring polish task exists for it.

### Notes for reviewer
Session-directed run (conductor scheduled sweep) — claimed via `claim_task.py media-watchlist t-012`, roadmap flipped to `status: review` before opening this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBHK2mSRxe2gQEJvbh92HA)_