### PR TITLE
ai-art-academy/t-010: fix unset upload target in Style Lab tab

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -97,11 +97,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import { useArtStore } from '@/stores/artStore'
 import { useNavStore } from '@/stores/navStore'
 import { useServerStore } from '@/stores/serverStore'
+import { useUploadStore } from '@/stores/uploadStore'
 
 type AcademyTab = 'timeline' | 'styles' | 'remix' | 'stylelab'
 
@@ -109,6 +110,7 @@ const academyStore = useAcademyStore()
 const artStore = useArtStore()
 const navStore = useNavStore()
 const serverStore = useServerStore()
+const uploadStore = useUploadStore()
 
 const defaultDashboardKey = 'academy'
 const defaultTab: AcademyTab = 'timeline'
@@ -136,6 +138,38 @@ function goToRemix(styleSlug: string) {
   academyStore.selectStyle(styleSlug)
   navStore.setDashboardTab(dashboardKey.value, 'remix', 'academy remix CTA')
 }
+
+// The stylelab tab renders a bare <image-upload> alongside art-styler for
+// general gallery uploads. uploadStore.activeTarget is an app-lifetime Pinia
+// singleton that only other pages (add-bot, add-character, art-maker, ...)
+// ever write -- none of them clear it on unmount -- so without setting our
+// own target here, entering this tab either finds no target (upload button
+// permanently disabled) or inherits a stale one from whatever page ran last
+// (e.g. a Bot edit target, silently applying an Academy upload to that bot).
+// Mirrors art-maker.vue's configureArtImageUpload() pattern.
+function configureStyleLabUploadTarget() {
+  uploadStore.setTarget({
+    model: 'ArtImage',
+    modelId: null,
+    galleryName: 'artImageUploads',
+    collectionLabel: 'image uploads',
+    promptString: '[UploadedArtImage]',
+    path: '[UploadedArtImage]',
+    buttonLabel: 'Upload image',
+    icon: 'kind-icon:image',
+    showPreview: true,
+  })
+}
+
+watch(
+  activeTab,
+  (tab) => {
+    if (tab === 'stylelab') {
+      configureStyleLabUploadTarget()
+    }
+  },
+  { immediate: true },
+)
 
 async function loadManagerData(force = false) {
   isLoadingManager.value = true


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass, lane 1 (front-end style/polish)  (kind: software)

### What changed / what I produced
- `components/academy/academy-manager.vue`: the Style Lab tab renders `<image-upload>` alongside `art-styler`, but never called `uploadStore.setTarget()`. `uploadStore.activeTarget` is an app-lifetime Pinia singleton only other pages (`add-bot.vue`, `add-character.vue`, `add-reward.vue`, `add-scenario.vue`, `dream-manager.vue`, `art-maker.vue`) ever write, and none of them clear it on unmount.
- Concretely, this produced two reachable bugs:
  1. **Dead button**: opening Academy → Style Lab in a fresh session left `activeTarget` `null`, so `image-upload.vue`'s `hasActiveTarget` guard permanently disabled the upload button ("No upload target configured").
  2. **Cross-feature data corruption**: if the user had previously opened e.g. `add-bot.vue` in edit mode (which sets a target whose `applyImage` callback calls `botStore.updateCurrentBot()`), then visited Academy → Style Lab and uploaded an image there, the stale Bot target was still active — silently overwriting that unrelated bot's avatar with whatever was just uploaded in the Academy.
- Fixed by adding a `configureStyleLabUploadTarget()` function (mirrors `art-maker.vue`'s existing `configureArtImageUpload()` pattern) and a `watch(activeTab, ..., { immediate: true })` that sets a dedicated `ArtImage`-model target the moment the `stylelab` tab becomes active — before the upload widget is interactive, closing both failure modes.

### How I verified
- `npx eslint components/academy/academy-manager.vue` — clean
- `npm run test` (`vue-tsc --noEmit`, full project) — exit 0, zero errors
- `npx prettier --check components/academy/academy-manager.vue` — clean
- Traced the bug end-to-end in code: confirmed no other consumer of `image-upload.vue` in the Academy stylelab tab ever calls `setTarget`, confirmed `art-styler.vue`'s own upload widget is fully self-contained (`processUploadedFile`, no `uploadStore` involvement) so this fix only affects the separate sidebar `<image-upload>` widget, and confirmed `art-maker.vue`'s `configureArtImageUpload()` as the established in-codebase pattern this change mirrors.

### Stakes
reversible

### Flags for Reviewer
- The broader "no page ever calls `uploadStore.clearTarget()` on unmount" pattern is pre-existing and out of scope here — this fix closes the two concrete, reachable failure modes in the Academy Style Lab specifically (matching the existing `art-maker.vue` precedent of each consumer setting its own fresh target), without attempting the larger refactor of adding unmount-time clearing app-wide.

### Kaizen suggestion
A future pass could add `uploadStore.clearTarget()` calls on unmount to every page/component that calls `setTarget()`, closing the underlying stale-global-singleton pattern at its root instead of each consumer re-asserting its own target defensively. Not done here to keep this fix scoped to the concrete bug found.

### Notes for reviewer
Found via an Explore-agent investigation of `ai-art-academy/t-010`'s recurring lane-1 (front-end polish) rotation, cross-checked against the project's existing long exclusion list of already-fixed bug classes (PRs #275-#622, #1000, #1015, #1017, #1027, #1037, #1040) to avoid duplicating prior work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UU4Hgs4GPE7eYqxuomytgC)_