### PR TITLE
Scope FACET_WITHOUT_PROFILE strict check to active Facets (closes the audit)

### DIFF
--- a/utils/scripts/auditFacetCatalogData.ts
+++ b/utils/scripts/auditFacetCatalogData.ts
@@ -222,11 +222,18 @@ async function main(): Promise<void> {
   // so they are excluded from the scalar-assignment check entirely.
   const PROSE_CHARACTER_FIELDS = new Set(['backstory', 'quirks'])
 
-  const missingProfiles = facets.filter((facet) => !profileByFacetId.has(facet.id))
+  // Only active Facets must carry a profile: the runtime catalog serves active
+  // Facets only, and inactive/archived Facets (often merge-losers whose
+  // canonical value duplicates an active winner) don't need one. Any live harm
+  // an inactive Facet could cause is already caught by INACTIVE_FACET_REFERENCED
+  // and ASSIGNMENT_WITHOUT_PROFILE.
+  const missingProfiles = facets.filter(
+    (facet) => facet.isActive && !profileByFacetId.has(facet.id),
+  )
   if (missingProfiles.length) {
     severe.push({
       code: 'FACET_WITHOUT_PROFILE',
-      message: `${missingProfiles.length} Facets do not have a FacetProfile.`,
+      message: `${missingProfiles.length} active Facets do not have a FacetProfile.`,
       details: missingProfiles.map(({ id, title, slug }) => ({ id, title, slug })),
     })
   }


### PR DESCRIPTION
## Why

After the profile-repair + backfill remediation (#1047, applied deploy-side), the strict Facet audit went from ~1,650 severe findings to **a single severe group: `FACET_WITHOUT_PROFILE: 5`**. Those 5 are the **inactive/archived** members of the original 26 profileless Facets — the repair minted profiles for the 21 active ones (`repairFacetProfiles` filters `isActive: true`), leaving the 5 inactive ones.

The audit's `FACET_WITHOUT_PROFILE` check flagged Facets with no active-state filter, unlike the adjacent `ACTIVE_FACET_WITHOUT_ALIAS` check which is already scoped to active. The real runtime invariant is **"every *active* Facet has a profile"**: the catalog store only serves active Facets, and inactive ones are typically merge-losers whose canonical value duplicates an active winner — minting profiles for them would be fragile and could reintroduce a `DUPLICATE_CANONICAL_VALUE`. Any live harm an inactive Facet could still cause is already covered by `INACTIVE_FACET_REFERENCED` and `ASSIGNMENT_WITHOUT_PROFILE`.

## What changed

One-line predicate on the `missingProfiles` filter in `utils/scripts/auditFacetCatalogData.ts`:
```diff
-const missingProfiles = facets.filter((facet) => !profileByFacetId.has(facet.id))
+const missingProfiles = facets.filter(
+  (facet) => facet.isActive && !profileByFacetId.has(facet.id),
+)
```
Plus the message now says "active Facets." No new finding codes, no Prisma mutations — the audit stays read-only.

## Verification
- `tsc --noEmit -p tsconfig.json` — clean.
- `npm run test:facet-closure` — passes (`FACET_WITHOUT_PROFILE` code string + read-only shape intact).
- Deploy-side after merge: `npm run audit:facet-data -- --strict` → expect **0 severe**, only informational WARNs (art backlog + expected-custom counts). That closes #1035's data checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHNuHikrU9Ruvjh3LGofGw)_