### PR TITLE
storymaker/t-010: surface scenarioStore init errors on /storymaker

### DIFF
--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -21,6 +21,14 @@
           {{ totalScenarios }} scenario{{ totalScenarios === 1 ? '' : 's' }}
           ready to weave into a story right now.
         </p>
+        <div
+          v-if="initError"
+          role="alert"
+          class="alert alert-warning rounded-2xl text-sm"
+        >
+          <Icon name="kind-icon:warning" class="size-5" />
+          <span>{{ initError }}</span>
+        </div>
         <ul v-if="recentScenarios.length" class="flex flex-col gap-1">
           <li v-for="scenario in recentScenarios" :key="scenario.id">
             <button
@@ -67,6 +75,7 @@ onMounted(() => {
 
 const totalScenarios = computed(() => scenarioStore.totalScenarios)
 const recentScenarios = computed(() => scenarioStore.scenarios.slice(0, 3))
+const initError = computed(() => scenarioStore.lastError)
 
 /**
  * The Stories manager resolves its dashboard tab from content frontmatter


### PR DESCRIPTION
### Task
conductor `storymaker/t-010`: Polish and upgrade Storymaker front-end surface (step 4 follow-on)

### What changed
`scenarioStore.initialize()` already sets `lastError` via `setLastError(error, 'Failed to initialize scenario store')` on failure (`stores/scenarioStore.ts`), but `components/conductor/storymaker-page.vue` never read it. A failed init left `totalScenarios`/`recentScenarios` at 0, visually indistinguishable from the legitimate "no scenarios yet" empty state — no signal to the user that anything went wrong.

Added a computed `initError` reading `scenarioStore.lastError` and an alert block using the exact same pattern `challenge-center-page.vue` already uses elsewhere in the same directory (`role="alert"`, `alert alert-warning rounded-2xl text-sm`, `kind-icon:warning`). No store changes needed — the field already existed and was already exported.

### How I verified
- `npx eslint components/conductor/storymaker-page.vue` — clean.
- `npx prettier --check components/conductor/storymaker-page.vue` — clean.
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0.
- Live browser smoke deferred — no reachable `DATABASE_URL` in this sandbox, same class of blocker every prior cycle on this task has recorded.

### Stakes
reversible — additive template/computed only, no store or API changes.

### Flags for Reviewer
None.

### Notes for reviewer
Small, scoped polish; storymaker/t-010's dashboard-tab/tutorial art substep remains separately blocked on the art-generation relay and is untouched by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZZR2YfskKeWVzzkChUcjy)_