### PR TITLE
model-builder: guard autoBuildRun against mid-loop run switches

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1269,10 +1269,22 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.autoBuilding = true
     clearStatus()
 
+    // Captured so this loop can tell "the user switched to a different run
+    // via History mid-auto-build" apart from "still the same run" across each
+    // item's awaited work. Without this check the loop keeps walking the
+    // original run's items (autoBuildItem's own findItem lookup just fails
+    // fast against the newly-active run, so no wrong data is written — but
+    // state.autoBuilding is a store-wide flag, not per-run, so it stays true
+    // and keeps the newly-opened run's "Auto-build all" button disabled until
+    // the abandoned run's in-flight item finishes; the final status message
+    // would then also overwrite whatever the user is now looking at with a
+    // completed count for a run they've navigated away from).
+    const runId = state.run.id
     const items = [...state.run.items]
     let committed = 0
     try {
       for (const item of items) {
+        if (state.run?.id !== runId) return
         if (item.stages.COMMIT.status === 'approved') {
           committed++
           continue
@@ -1280,10 +1292,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         const ok = await autoBuildItem(item.id)
         if (ok) committed++
       }
-      setStatus(
-        'success',
-        `Auto-build finished: ${committed}/${items.length} committed.`,
-      )
+      if (state.run?.id === runId) {
+        setStatus(
+          'success',
+          `Auto-build finished: ${committed}/${items.length} committed.`,
+        )
+      }
     } finally {
       state.autoBuilding = false
     }


### PR DESCRIPTION
### Task
model-builder/t-029 (conductor recurring maintenance task, kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `autoBuildRun()` now captures the active run's id before its item loop and re-checks it on every iteration (and before the completion status message), so switching to a different run via History mid-auto-build stops the loop from continuing to walk the abandoned run's items.

### Bug
`autoBuildRun()` looped over a snapshot of `state.run.items`, awaiting `autoBuildItem()` per item, without re-checking whether `state.run` was still the same run across each await. `state.autoBuilding` is a store-wide (not per-run) flag and nothing in the UI gates run-switching on it, so a user could open a different run via History mid-auto-build. The loop's later iterations would fail fast (no data corruption — `findItem` just can't find the old run's item ids in the new run), but `state.autoBuilding` stayed `true` — keeping the newly-opened run's "Auto-build all" button disabled until the abandoned run's in-flight item resolved — and the final `setStatus('success', ...)` call would then overwrite whatever the user's current run was showing with a completed-count message describing the abandoned run.

This is the run-level counterpart of already-fixed item-level singleton races in this same store (`generatingItemId`, `committingItemId`, etc.).

### How I verified
- `npx eslint stores/modelBuilderStore.ts` — 2 pre-existing `no-empty` errors (lines 203/210, unrelated `safeSet`/`safeRemove` catch blocks), confirmed identical on unmodified `main` via `git stash`. No new errors.
- `npx vue-tsc --noEmit` (full project) — 0 errors, both before and after the change.

### Stakes
reversible

### Notes for reviewer
Part of the conductor-tracked recurring task model-builder/t-029 (front-end polish/bugfix pass). Roadmap task rearmed to `ready` after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KpZo9LjjbcjuGMZ1q9nXnt)_