### PR TITLE
ai-art-academy/t-047: clear uploadStore target on unmount

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import { useArtStore } from '@/stores/artStore'
 import { useNavStore } from '@/stores/navStore'
@@ -198,5 +198,9 @@ async function loadManagerData(force = false) {
 onMounted(() => {
   academyStore.hydrate()
   void loadManagerData()
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 </script>

--- a/components/art/art-maker.vue
+++ b/components/art/art-maker.vue
@@ -400,7 +400,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import type { Server } from '~/prisma/generated/prisma/client'
 import type { ArtCollection } from '@/stores/helpers/collectionHelper'
 import type { Resource } from '@/stores/resourceStore'
@@ -553,5 +553,9 @@ onMounted(async () => {
       result.message || 'Failed to load image generator.',
     )
   }
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 </script>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -493,7 +493,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useBotStore, type BotForm } from '@/stores/botStore'
 import { useArtStore } from '@/stores/artStore'
 import { useUserStore } from '@/stores/userStore'
@@ -693,6 +693,10 @@ onMounted(async () => {
 
   await prepareForm()
   configureBotImageUpload()
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 
 watch(

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -496,7 +496,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { Rarity } from '~/prisma/generated/prisma/client'
 import { useArtStore } from '@/stores/artStore'
 import { useCharacterStore, type Character } from '@/stores/characterStore'
@@ -672,6 +672,10 @@ onMounted(async () => {
 
   await prepareForm()
   configureCharacterImageUpload()
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 
 watch(

--- a/components/dreams/dream-manager.vue
+++ b/components/dreams/dream-manager.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useArtStore } from '@/stores/artStore'
 import { useCollectionStore } from '@/stores/collectionStore'
 import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
@@ -258,5 +258,9 @@ watch(
 
 onMounted(async () => {
   await loadManagerData()
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 </script>

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -271,7 +271,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useArtStore } from '@/stores/artStore'
 import { useChoiceStore } from '@/stores/choiceStore'
 import {
@@ -350,6 +350,10 @@ const resolvedActiveImage = computed(() => {
 onMounted(async () => {
   await prepareForm()
   configureRewardImageUpload()
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 
 watch(

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -292,7 +292,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useArtStore } from '@/stores/artStore'
 import { useChoiceStore } from '@/stores/choiceStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
@@ -368,6 +368,10 @@ const resolvedActiveImage = computed(() => {
 onMounted(async () => {
   await prepareForm()
   configureScenarioImageUpload()
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 
 watch(


### PR DESCRIPTION
### Task
ai-art-academy/t-047: kind_robots consumers of `uploadStore` should clear their target on unmount (kind: software)

### What changed / what I produced
`uploadStore.activeTarget` (`stores/uploadStore.ts`) is an app-lifetime Pinia singleton. Every current caller of `uploadStore.setTarget()` set a target on mount/tab-open but none called `uploadStore.clearTarget()` on unmount — so a consumer that doesn't defensively re-set its own target on (re-)entry could silently inherit a stale target (including its `applyImage` callback) left by whichever page the user visited last in the same session.

Added `onUnmounted(() => uploadStore.clearTarget())` to all 7 consumers:
- `components/academy/academy-manager.vue`
- `components/art/art-maker.vue`
- `components/bots/add-bot.vue`
- `components/characters/add-character.vue`
- `components/rewards/add-reward.vue`
- `components/scenarios/add-scenario.vue`
- `components/dreams/dream-manager.vue`

### How I verified
- Investigated whether clearing on unmount could break anything relying on the target surviving past a component's lifetime: `uploadForActiveTarget()`/`uploadBatchForActiveTarget()` (`stores/uploadStore.ts`) capture `activeTarget` into a local `const` at call start, so clearing the store mid-upload doesn't affect an in-flight upload already running. Grepped the whole codebase for `activeTarget` and `applyImage` usage — no global toast/progress-indicator/retry mechanism reads it, and no consumer expects the target to persist past its own unmount.
- `npx eslint` on all 7 changed files: clean (2 pre-existing `no-extra-boolean-cast` errors in `add-bot.vue`/`add-character.vue` confirmed present before this diff too — untouched lines, not introduced by this change).
- `npx prettier --check` on all 7: 3 files (`add-bot.vue`, `add-character.vue`, `dream-manager.vue`) show pre-existing formatting drift, confirmed present before this diff too (same prettier-version-mismatch pattern documented elsewhere in this repo's history) — no blanket reformat.
- Full-project `npm run test` (`vue-tsc --noEmit`): exit clean, no errors.

### Stakes
reversible

### Flags for Reviewer
- `add-bot.vue`, `add-character.vue`, `add-reward.vue`, `add-scenario.vue` are all rendered inside their respective `*-manager.vue`'s conditional tab branch, so they mount/unmount on every internal tab switch (not just full-page navigation) — intentional/desirable per the investigation, just noting the frequency is higher than "once per page visit."
- `dream-manager.vue`'s upload target currently has no consuming `<image-upload>` component wired to it yet (dead/ahead-of-feature wiring) — the fix is still correct/harmless there, just noting nothing exercises it today.
- Two other consumers of the same `setTarget`/no-clear pattern exist outside this task's listed scope (`components/user/avatar-picker.vue`, `components/user/user-dashboard.vue`, via `setAvatarTarget`) — left untouched per scope discipline; flagging in case a follow-up task is worth filing.

### Kaizen suggestion
File a small follow-up task for the two out-of-scope `avatar-picker.vue`/`user-dashboard.vue` consumers found during this task's investigation — same latent stale-target bug, same fix shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsWrd5kVwiYY7z2HrFBKaW)_