### PR TITLE
Audit exact canonical Backstory and Quirk assignments

### DIFF
--- a/utils/scripts/auditFacetProseAssignments.ts
+++ b/utils/scripts/auditFacetProseAssignments.ts
@@ -1,0 +1,156 @@
+// Read-only audit for canonical BACKSTORY and QUIRK values embedded in prose fields.
+//
+// Arbitrary narrative prose remains valid and is ignored. A strict finding is
+// emitted only when an entire Backstory value, or an individual delimited Quirk,
+// exactly resolves to an active canonical Facet but the matching CharacterFacet
+// assignment row is absent.
+//
+// Usage:
+//   npx tsx utils/scripts/auditFacetProseAssignments.ts
+//   npx tsx utils/scripts/auditFacetProseAssignments.ts --strict
+//   npx tsx utils/scripts/auditFacetProseAssignments.ts --json
+import 'dotenv/config'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { normalizeFacetLookupKey } from './../facetAliases'
+
+const databaseUrl = process.env.DATABASE_URL ?? ''
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
+const args = new Set(process.argv.slice(2))
+const strict = args.has('--strict')
+const jsonOnly = args.has('--json')
+
+type Finding = {
+  characterId: number
+  fieldKey: 'backstory' | 'quirks'
+  value: string
+  facetId: number
+}
+
+function splitValues(fieldKey: 'backstory' | 'quirks', value: string | null): string[] {
+  const trimmed = String(value ?? '').trim()
+  if (!trimmed) return []
+  if (fieldKey === 'backstory') return [trimmed]
+  return trimmed
+    .split(/\n---\n|\||\n|;|,/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+async function main(): Promise<void> {
+  const [profiles, facets, aliases, characters, assignments] = await Promise.all([
+    prisma.facetProfile.findMany({
+      where: { taxonomy: { in: ['BACKSTORY', 'QUIRK'] } },
+      select: { facetId: true, taxonomy: true, canonicalValue: true },
+    }),
+    prisma.facet.findMany({
+      where: { isActive: true },
+      select: { id: true, title: true },
+    }),
+    prisma.facetAlias.findMany({
+      where: { isActive: true },
+      select: { facetId: true, lookupKey: true },
+    }),
+    prisma.character.findMany({
+      where: { isActive: true },
+      select: { id: true, backstory: true, quirks: true },
+    }),
+    prisma.characterFacet.findMany({
+      where: { fieldKey: { in: ['backstory', 'quirks'] } },
+      select: { characterId: true, facetId: true, fieldKey: true },
+    }),
+  ])
+
+  const activeFacetIds = new Set(facets.map((facet) => facet.id))
+  const taxonomyByFacetId = new Map(
+    profiles
+      .filter((profile) => activeFacetIds.has(profile.facetId))
+      .map((profile) => [profile.facetId, profile.taxonomy]),
+  )
+  const facetById = new Map(facets.map((facet) => [facet.id, facet]))
+  const lookup = {
+    BACKSTORY: new Map<string, number>(),
+    QUIRK: new Map<string, number>(),
+  }
+
+  for (const profile of profiles) {
+    const taxonomy = profile.taxonomy as 'BACKSTORY' | 'QUIRK'
+    const facet = facetById.get(profile.facetId)
+    if (!facet || !lookup[taxonomy]) continue
+    for (const value of [facet.title, profile.canonicalValue ?? '']) {
+      const key = normalizeFacetLookupKey(value)
+      if (key && !lookup[taxonomy].has(key)) {
+        lookup[taxonomy].set(key, profile.facetId)
+      }
+    }
+  }
+  for (const alias of aliases) {
+    const taxonomy = taxonomyByFacetId.get(alias.facetId) as
+      | 'BACKSTORY'
+      | 'QUIRK'
+      | undefined
+    if (!taxonomy) continue
+    if (!lookup[taxonomy].has(alias.lookupKey)) {
+      lookup[taxonomy].set(alias.lookupKey, alias.facetId)
+    }
+  }
+
+  const linked = new Set(
+    assignments.map(
+      (assignment) =>
+        `${assignment.characterId}:${assignment.fieldKey}:${assignment.facetId}`,
+    ),
+  )
+  const findings: Finding[] = []
+
+  for (const character of characters) {
+    for (const fieldKey of ['backstory', 'quirks'] as const) {
+      const taxonomy = fieldKey === 'backstory' ? 'BACKSTORY' : 'QUIRK'
+      for (const value of splitValues(fieldKey, character[fieldKey])) {
+        const facetId = lookup[taxonomy].get(normalizeFacetLookupKey(value))
+        if (!facetId) continue // bespoke prose remains intentionally unlinked
+        if (linked.has(`${character.id}:${fieldKey}:${facetId}`)) continue
+        findings.push({ characterId: character.id, fieldKey, value, facetId })
+      }
+    }
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    asOfDatabase: databaseUrl.replace(/:[^:@/]+@/, ':***@'),
+    checkedCharacters: characters.length,
+    canonicalProseFacets: profiles.length,
+    missingAssignments: findings.length,
+    findings,
+  }
+
+  if (jsonOnly) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+  } else {
+    process.stdout.write(
+      [
+        'Facet prose assignment audit',
+        `Characters checked: ${report.checkedCharacters}`,
+        `Canonical BACKSTORY/QUIRK Facets: ${report.canonicalProseFacets}`,
+        `Missing exact-match assignments: ${report.missingAssignments}`,
+        ...findings.map(
+          (finding) =>
+            `ERROR Character #${finding.characterId} ${finding.fieldKey} "${finding.value}" maps to Facet #${finding.facetId} but is unlinked.`,
+        ),
+      ].join('\n') + '\n',
+    )
+  }
+
+  if (strict && findings.length) process.exitCode = 1
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/verifyFacetClosure.ts
+++ b/utils/scripts/verifyFacetClosure.ts
@@ -26,6 +26,7 @@ async function main(): Promise<void> {
     generator: 'stores/generatorStore.ts',
     fallback: 'utils/facetEmergencyFallbacks.ts',
     audit: 'utils/scripts/auditFacetCatalogData.ts',
+    proseAudit: 'utils/scripts/auditFacetProseAssignments.ts',
     package: 'package.json',
     workflow: '.github/workflows/facet-catalog-contract.yml',
   } as const
@@ -106,8 +107,14 @@ async function main(): Promise<void> {
   requireText(files.audit, text.audit, 'if (strict && severe.length)')
   requireText(files.audit, text.audit, 'prisma.$disconnect()')
 
-  // The live audit is read-only. File-system writes are allowed only for the
-  // requested JSON report; Prisma mutations are not.
+  requireText(files.proseAudit, text.proseAudit, "taxonomy: { in: ['BACKSTORY', 'QUIRK'] }")
+  requireText(files.proseAudit, text.proseAudit, "fieldKey: { in: ['backstory', 'quirks'] }")
+  requireText(files.proseAudit, text.proseAudit, 'bespoke prose remains intentionally unlinked')
+  requireText(files.proseAudit, text.proseAudit, 'if (strict && findings.length)')
+  requireText(files.proseAudit, text.proseAudit, 'prisma.$disconnect()')
+
+  // Both live audits are read-only. File-system writes are allowed only for the
+  // primary audit's requested JSON report; Prisma mutations are not.
   for (const mutation of [
     'prisma.$transaction',
     '.create({',
@@ -119,6 +126,7 @@ async function main(): Promise<void> {
     '.deleteMany({',
   ]) {
     forbidText(files.audit, text.audit, mutation)
+    forbidText(files.proseAudit, text.proseAudit, mutation)
   }
 
   requireText(files.package, text.package, '"audit:facet-data"')
@@ -127,7 +135,7 @@ async function main(): Promise<void> {
   requireText(files.workflow, text.workflow, 'npm run test:facet-closure')
 
   process.stdout.write(
-    'Facet closure verified: creative generation is catalog-first, emergency pools are bounded, and the live audit is read-only.\n',
+    'Facet closure verified: creative generation is catalog-first, emergency pools are bounded, and live audits are read-only.\n',
   )
 }
 


### PR DESCRIPTION
## Why

The main Facet data audit intentionally excludes Character `backstory` and `quirks` from scalar-link enforcement because those fields commonly contain bespoke prose. That prevents false positives, but it also means an exact canonical BACKSTORY or QUIRK value can remain unlinked without any audit reporting it.

## What changed

- Added a focused, read-only production audit for active Characters’ Backstory and Quirk fields.
- Arbitrary prose remains ignored.
- A finding is emitted only when:
  - the complete Backstory value, or one delimited Quirk value,
  - exactly resolves through an active Facet title, canonical value, or alias,
  - has the appropriate BACKSTORY or QUIRK taxonomy,
  - and lacks the matching `CharacterFacet` assignment row.
- Supports human output, `--json`, and `--strict` failure mode.
- Extended the Facet closure contract to pin this audit’s taxonomy scope, exact-match behavior, strict mode, disconnect, and read-only Prisma shape.

## Operator command

```bash
npx tsx utils/scripts/auditFacetProseAssignments.ts --strict
```

This complements `npm run audit:facet-data -- --strict`; it does not change that report’s established custom-prose warning counts or output format.

## Validation

The existing Facet Catalog workflow runs `npm run test:facet-closure`, which now statically verifies the new audit and rejects any Prisma mutation calls.