### PR TITLE
fix: clear avatar upload targets on unmount

### DIFF
--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -223,7 +223,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { ArtImage, ArtCollection } from '@/stores/artStore'
 import { useArtStore } from '@/stores/artStore'
 import { useCollectionStore } from '@/stores/collectionStore'
@@ -563,6 +563,10 @@ onMounted(async () => {
   initPreview()
   configureUploadTarget()
   await refreshGallery(false)
+})
+
+onUnmounted(() => {
+  uploadStore.clearTarget()
 })
 
 watch(

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -160,7 +160,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { useUserStore } from '@/stores/userStore'
 import { useUploadStore } from '@/stores/uploadStore'
 
@@ -188,6 +188,10 @@ function configureUserImageUpload() {
 
 onMounted(() => {
   configureUserImageUpload()
+})
+
+onUnmounted(() => {
+  imageUploadStore.clearTarget()
 })
 
 watch(


### PR DESCRIPTION
## Summary
- clear `uploadStore.activeTarget` when `avatar-picker.vue` unmounts
- clear the same singleton target when `user-dashboard.vue` unmounts
- preserve existing upload and avatar-application behavior while preventing stale callbacks from leaking into later upload consumers

## Conductor handoff
- project/task: `ai-art-academy/t-048`
- conductor session: `20260727T211039Z-worker-ai-art-academy-t048-a31f`
- roadmap status verified at `review` before opening this PR
- branch: `worker/ai-art-academy-t-048-a31f`

## Validation
- connector diff inspection: exactly two lifecycle imports and two unmount cleanup hooks; 10 additions / 2 deletions total
- PR CI is the authoritative validation for TypeScript and contract coverage

No deploy, production mutation, or outward-facing action is included.