### PR TITLE
fix(screenfx): clamp ripple/spark radius against negative-progress races

### DIFF
--- a/components/screenfx/clockwork-greenhouse.vue
+++ b/components/screenfx/clockwork-greenhouse.vue
@@ -411,12 +411,16 @@ function nearestBloomTarget(
   return closest
 }
 
-function spawnSpark(x: number, y: number, hue: number): void {
+function spawnSpark(x: number, y: number, hue: number, now: number): void {
   if (sparks.length >= 4) sparks.shift()
-  sparks.push({ x, y, startedAt: performance.now(), hue })
+  sparks.push({ x, y, startedAt: now, hue })
 }
 
-function updatePollinator(pollinator: Pollinator, delta: number): void {
+function updatePollinator(
+  pollinator: Pollinator,
+  delta: number,
+  now: number,
+): void {
   pollinator.angle += delta * pollinator.spinSpeed * (reducedMotion ? 0.3 : 1)
 
   const target =
@@ -447,7 +451,7 @@ function updatePollinator(pollinator: Pollinator, delta: number): void {
   const distance = Math.sqrt(dx * dx + dy * dy)
 
   if (distance < 6) {
-    spawnSpark(pollinator.x, pollinator.y, current.hue)
+    spawnSpark(pollinator.x, pollinator.y, current.hue, now)
     const next = nearestBloomTarget(pollinator, current.id)
     pollinator.targetId = next ? next.id : null
     return
@@ -494,7 +498,7 @@ function drawSpark(spark: Spark, timestamp: number): boolean {
   const life = 550
   if (age >= life) return false
 
-  const progress = age / life
+  const progress = Math.max(0, age / life)
   const radius = 3 + progress * 14
 
   context.save()
@@ -545,7 +549,7 @@ function renderFrame(timestamp: number): void {
   }
 
   for (const pollinator of pollinators) {
-    updatePollinator(pollinator, delta)
+    updatePollinator(pollinator, delta, timestamp)
     drawPollinator(pollinator)
   }
 

--- a/components/screenfx/koi-memory-pond.vue
+++ b/components/screenfx/koi-memory-pond.vue
@@ -290,21 +290,22 @@ function spawnRipple(
   y: number,
   strength: number,
   duration: number,
+  now: number,
 ): void {
   if (ripples.length >= MAX_RIPPLES) ripples.shift()
-  ripples.push({ x, y, startedAt: performance.now(), duration, strength })
+  ripples.push({ x, y, startedAt: now, duration, strength })
 }
 
 function handlePointerDown(event: PointerEvent): void {
   const point = canvasPoint(event.clientX, event.clientY)
   if (!point) return
 
-  spawnRipple(point.x, point.y, 1, 1400)
+  const now = performance.now()
+  spawnRipple(point.x, point.y, 1, 1400, now)
 
   if (reducedMotion) return
 
   const attractRadius = 220
-  const now = performance.now()
   for (const self of fish) {
     if (Math.hypot(self.x - point.x, self.y - point.y) < attractRadius) {
       self.foodX = point.x
@@ -515,6 +516,7 @@ function drawRipples(now: number): void {
       ripples.splice(i, 1)
       continue
     }
+    if (progress <= 0) continue
 
     const radius = progress * 70 * ripple.strength
     const alpha = (1 - progress) * 0.35 * ripple.strength
@@ -537,6 +539,7 @@ function maybeSpawnAmbientRipple(now: number): void {
     randomBetween(height * 0.1, height * 0.9),
     0.6,
     1800,
+    now,
   )
   nextAmbientRippleAt =
     now +


### PR DESCRIPTION
## Summary

- ci-janitor Todo #867 flagged a red main-branch Cypress run ([30303424283](https://github.com/silasfelinus/kind_robots/actions/runs/30303424283)) with an uncaught browser exception during an unauthenticated homepage visit: `IndexSizeError: Failed to execute 'arc' on 'CanvasRenderingContext2D': The radius provided (-0.00233333) is negative.`
- `app.vue` always mounts `butterfly-layer.vue`, which always mounts `startup-animation.vue`, which picks a random ambient screensaver effect on every unauthenticated page load — matching the failing test's plain `before()` visit. The crash depends on which effect gets randomly selected.
- Root cause: `koi-memory-pond.vue`'s `spawnRipple()` stamped a ripple's `startedAt` with a fresh `performance.now()` call instead of reusing the timestamp already captured at the top of `renderFrame()`. Because `maybeSpawnAmbientRipple()` runs immediately before `drawRipples()` in the same animation-frame tick, an ambient ripple born mid-frame could get a `startedAt` microseconds later than the older `now` used to draw it one line later — making `progress = (now - startedAt) / duration` briefly negative and `radius = progress * 70 * strength` negative. The math lines up almost exactly with the observed `-0.00233333`.
- Fix: thread the caller's `now`/`timestamp` through `spawnRipple()` instead of taking a fresh `performance.now()` snapshot (matching the pattern `paper-lantern-weather.vue` already uses correctly), plus a `progress <= 0` guard in `drawRipples()` for defense in depth.
- Also hardened `clockwork-greenhouse.vue`'s structurally identical (currently latent, absorbed by a `+3` radius floor) `spawnSpark()`/`drawSpark()` pair the same way, since it has the same same-frame timestamp-source mismatch and lacked the explicit age guard `magnetic-sand-garden.vue` already has for the same pattern.

## How I verified

- `npx vue-tsc --noEmit` — no errors in either touched file.
- A subsequent main-branch Cypress run ([30309807836](https://github.com/silasfelinus/kind_robots/actions/actions/runs/30309807836)) on a later commit already completed green, consistent with a rare, timing-dependent, non-deterministic crash rather than a persistent regression.
- No test was skipped, weakened, or deleted, per CI-JANITOR.md's operating contract.

## Stakes

reversible

## Notes for reviewer

This is CI-JANITOR incident-routing work (Todo #867), not a roadmap task — closing the Todo via `scripts/complete_todo.py` once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L732M2QHQmsgF1nrwocqzv)_