### PR TITLE
fix(academy): keep expanded lesson's tile visible under New/Explored filter

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -290,6 +290,7 @@ const filteredStyles = computed<AcademyStyle[]>(() => {
   return academyStore.timeline.filter((style) => {
     const isViewed = academyStore.viewedLessons.includes(style.slug)
     const matchesProgress =
+      style.slug === expandedSlug.value ||
       lessonFilter.value === 'all' ||
       (lessonFilter.value === 'explored' && isViewed) ||
       (lessonFilter.value === 'new' && !isViewed)


### PR DESCRIPTION
## Summary

- ai-art-academy/t-010 continuous-improvement cycle, lane 1 (front-end polish).
- `academy-styles-browser.vue`'s grid (`filteredStyles`) and its detail panel (`expandedStyle`) read progress from two independent sources. `academy-style-detail.vue` marks a lesson viewed as soon as it mounts (`allowMarkViewed` defaults to `true`, never overridden here).
- Failure scenario: under the "New" filter, clicking a still-unviewed lesson mounts its detail panel, which immediately marks it viewed — on the next reactive tick, `filteredStyles`' progress check re-evaluates to `false` for that slug, so its own grid tile vanishes while the user is still reading its detail panel, and the grid reflows around the gap.
- This also broke `closeStyle()`'s focus restoration: `gridRefs.get(slug)` was already `undefined` once the tile unmounted (the `:ref` callback fires with `null` on removal), so focus silently fell back to the search input instead of the button the user actually clicked.
- Fix: keep the currently-expanded style's tile in `filteredStyles` regardless of the progress filter — it now only leaves the "New" list once the user closes it, and `closeStyle()`'s focus restoration works correctly again.

## How I verified

- `npx vue-tsc --noEmit` — no errors.
- `npx prettier --check` — clean (reverted an unrelated pre-existing formatting drift that `--write` also touched, to keep the diff to the one intended line).
- Traced the exact reactive chain (`onMounted` → `markLessonViewed` → `filteredStyles` recompute → tile removal → `gridRefs` entry gone) to confirm the mechanism before writing the fix.

## Stakes

reversible

## Notes for reviewer

Conductor task: `ai-art-academy/t-010` (recurring continuous-improvement task, lane 1). Roadmap/run-log update to follow in a separate conductor-repo PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L732M2QHQmsgF1nrwocqzv)_