### PR TITLE
feat(academy): add continue-learning progress prompt

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -74,6 +74,42 @@
     </header>
 
     <div
+      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-100 p-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-sm font-bold text-base-content">
+            {{ progressHeadline }}
+          </p>
+          <span class="text-xs font-semibold text-base-content/50">
+            {{ progressPercent }}%
+          </span>
+        </div>
+        <progress
+          class="progress progress-primary mt-2 w-full"
+          :value="academyStore.viewedLessons.length"
+          :max="academyStore.timeline.length || 1"
+          :aria-label="`${academyStore.viewedLessons.length} of ${academyStore.timeline.length} Academy lessons explored`"
+        />
+        <p class="mt-1 text-xs text-base-content/60">
+          {{ progressMessage }}
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-primary btn-sm shrink-0"
+        @click="openNextLesson"
+      >
+        <Icon
+          :name="nextLesson ? 'kind-icon:arrow-right' : 'kind-icon:refresh'"
+          class="h-4 w-4"
+          aria-hidden="true"
+        />
+        {{ nextLesson ? 'Continue learning' : 'Review from the start' }}
+      </button>
+    </div>
+
+    <div
       v-if="expandedStyle"
       :id="`academy-style-detail-${expandedStyle.slug}`"
       ref="detailPanelRef"
@@ -258,6 +294,13 @@ function resetFilters() {
   nextTick(() => searchInputRef.value?.focus())
 }
 
+function openNextLesson() {
+  searchQuery.value = ''
+  lessonFilter.value = 'all'
+  expandedSlug.value =
+    nextLesson.value?.slug ?? academyStore.timeline[0]?.slug ?? null
+}
+
 function onKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape' && expandedSlug.value) {
     closeStyle()
@@ -282,6 +325,37 @@ const expandedStyle = computed<AcademyStyle | null>(() => {
     academyStore.styles.find((style) => style.slug === expandedSlug.value) ??
     null
   )
+})
+
+const nextLesson = computed<AcademyStyle | null>(() => {
+  return (
+    academyStore.timeline.find(
+      (style) => !academyStore.viewedLessons.includes(style.slug),
+    ) ?? null
+  )
+})
+
+const progressPercent = computed(() => {
+  const total = academyStore.timeline.length
+  if (!total) return 0
+  return Math.round((academyStore.viewedLessons.length / total) * 100)
+})
+
+const progressHeadline = computed(() => {
+  if (!academyStore.timeline.length) return 'Lessons are loading'
+  if (!nextLesson.value) return 'Gallery complete'
+  if (!academyStore.viewedLessons.length) return 'Start your art-history tour'
+  return 'Keep your gallery streak going'
+})
+
+const progressMessage = computed(() => {
+  if (!academyStore.timeline.length) {
+    return 'The Academy is gathering its lesson collection.'
+  }
+  if (!nextLesson.value) {
+    return 'You explored every lesson. Revisit any movement whenever inspiration gets suspiciously quiet.'
+  }
+  return `Up next: ${nextLesson.value.name} · ${nextLesson.value.era}`
 })
 
 const filteredStyles = computed<AcademyStyle[]>(() => {

--- a/utils/scripts/verifyFacetGallery.ts
+++ b/utils/scripts/verifyFacetGallery.ts
@@ -39,18 +39,15 @@ async function main(): Promise<void> {
     ),
   ) as Record<keyof typeof files, string>
 
-  // The gallery reads the canonical catalog grouped by taxonomy.
   requireText(files.gallery, text.gallery, 'useFacetCatalogStore')
   requireText(files.gallery, text.gallery, 'byTaxonomy')
   requireText(files.gallery, text.gallery, 'FACET_TAXONOMIES')
 
-  // Art requests reuse the shared store and are gated behind admin.
   requireText(files.gallery, text.gallery, 'useFacetArtRequestStore')
   requireText(files.gallery, text.gallery, 'requestPrimaryArtwork')
   requireText(files.gallery, text.gallery, 'canRequestArt')
   requireText(files.gallery, text.gallery, 'userStore.isAdmin')
 
-  // The gallery is a read-only showcase: it must not mutate the catalog.
   for (const mutation of [
     'createFacet',
     'updateFacet',
@@ -60,8 +57,13 @@ async function main(): Promise<void> {
     forbidText(files.gallery, text.gallery, mutation)
   }
 
-  // The content route mounts the gallery component.
-  requireText(files.content, text.content, ':facet-gallery')
+  const mountsGallery = text.content.includes(':facet-gallery')
+  const redirectsToCanonicalGallery = text.content.includes('redirect: /facets')
+  if (!mountsGallery && !redirectsToCanonicalGallery) {
+    throw new Error(
+      `${files.content} must mount :facet-gallery or redirect to the canonical /facets route`,
+    )
+  }
 
   process.stdout.write(
     'Facet gallery verified: read-only taxonomy showcase on the canonical catalog with admin-gated art requests.\n',


### PR DESCRIPTION
## Summary
- add a compact Academy progress card above the Style Gallery
- show explored percentage and the next chronological unexplored lesson
- provide one-click continuation that clears filters and opens the correct lesson
- fall back to reviewing the first lesson once the gallery is complete
- repair the pre-existing Facet Gallery contract drift introduced when `content/facet-gallery.md` became a redirect to `/facets`

## Conductor
- Project/task: `ai-art-academy/t-010`
- Lane: front-end polish (lane 1)
- Session: `2026-07-28T013928Z-ai-art-academy-t-010-a31f`
- Roadmap verified at `status: review` before opening

## Validation
- complete two-file diff inspected
- PR CI is the strongest available validation in this connector-only run

## Stakes
Reversible, scoped front-end UX change plus a contract repair that preserves the existing Facet Gallery safeguard while accepting its canonical redirect route. No deployment, billing, secrets, production data, or outward publishing.

## Flags for reviewer
The first Facet Catalog run exposed a base-branch contract mismatch: the verifier still required `:facet-gallery`, while current `main` intentionally redirects the legacy content route to `/facets`. The repair accepts either the legacy mount or the canonical redirect and keeps every read-only/admin-gating assertion intact.

## Kaizen
A future test could assert that the continue action always selects the first timeline entry absent from `viewedLessons`.