### PR TITLE
fix(academy): keep expanded lesson's tile visible under search filtering too

### DIFF
--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -370,6 +370,7 @@ const filteredStyles = computed<AcademyStyle[]>(() => {
       (lessonFilter.value === 'new' && !isViewed)
 
     if (!matchesProgress) return false
+    if (style.slug === expandedSlug.value) return true
     if (!query) return true
 
     return [


### PR DESCRIPTION
## Summary
- `ai-art-academy/t-010` continuous-improvement cycle, lane 1 (front-end polish).
- `academy-styles-browser.vue`'s `filteredStyles` computed already bypasses the New/Explored progress filter for the currently-expanded style (fixed in PR #1071), but the search-query check immediately after it had no equivalent bypass.
- Failure scenario: expand a style tile, then type a search query that doesn't match that style's text — its grid tile vanishes (and its `gridRefs` entry is removed on unmount) while the detail panel for it stays open above the now-inconsistent grid, and `resultSummary`/the empty-state message describe a list that excludes it. Closing it then falls back to focusing the search input instead of the button the user clicked — the same symptom PR #1071 fixed, caused by a second, unaddressed filter path.
- Fix: extend the existing `style.slug === expandedSlug.value` bypass to also short-circuit the search-query check, so an expanded tile can never be filtered out of `filteredStyles` by either control.

## How I verified
- `npx eslint components/academy/academy-styles-browser.vue` — clean
- `npx prettier --check` on the touched lines — clean (reverted one unrelated pre-existing formatting drift `--write` also touched elsewhere in the file, to keep the diff to the one intended line)
- `npm run test` (`vue-tsc --noEmit`, full project) — exit 0
- Traced the reactive chain directly (`filteredStyles` → `matchesProgress` bypass → un-bypassed `query` check → tile removal → `gridRefs` entry gone → focus-fallback) to confirm the mechanism before writing the fix

## Stakes
reversible

## Notes for reviewer
Conductor task: `ai-art-academy/t-010` (recurring continuous-improvement task, lane 1). Roadmap/run-log update follows in a separate conductor-repo PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014pcH1r5hNgDPjhbqwCARSu

---
_Generated by [Claude Code](https://claude.ai/code/session_014pcH1r5hNgDPjhbqwCARSu)_