### PR TITLE
model-builder: link Character->Scenario on commit for expand-scenarios output

### DIFF
--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -481,6 +481,10 @@ async function linkSourceToTarget(
     await tx.scenario.update({ where: { id: sourceId }, data: { Characters: { connect: { id: targetId } } } })
     return true
   }
+  if (sourceType === 'Character' && targetType === 'Scenario') {
+    await tx.character.update({ where: { id: sourceId }, data: { Scenarios: { connect: { id: targetId } } } })
+    return true
+  }
   return false
 }
 


### PR DESCRIPTION
### Task
conductor model-builder/t-029 (recurring "Polish and upgrade Model Builder front-end surface"): kind: software

### What changed / what I produced
- `server/api/model-builder/items/[id]/commit.post.ts`: `linkSourceToTarget` handled `Scenario -> Character` (and its `Dream`/`Reward` siblings) but had no case for the reverse `Character -> Scenario` pairing, even though the Prisma schema models it as a genuine bidirectional many-to-many relation (`Character.Scenarios` / `Scenario.Characters`, `@relation("CharacterToScenario")`).
- A `Character` source running the `relationship-expansion` recipe with the `expand-scenarios` output reaches this path directly through the normal UI — `getOutputsForRecipe` filters only by recipe key, not source type, so nothing in the UI prevents this combination. Committing that item created the new `Scenario` row but silently returned `linked: false`, leaving the relation unpopulated with no indication to the user that the "expand into scenarios" link never happened.
- Fixed by mirroring the existing `Scenario -> Character` branch's shape: added a `Character -> Scenario` case that connects the new `Scenario` onto `Character.Scenarios`.

### How I verified
- Confirmed the missing case by reading `linkSourceToTarget`'s full switch directly (no `Character`/`Scenario` case existed before this change).
- Confirmed the relation exists and is bidirectional in `prisma/schema.prisma` (`Character.Scenarios @relation("CharacterToScenario")`, `Scenario.Characters @relation("CharacterToScenario")`).
- Confirmed the UI path is reachable: `getOutputsForRecipe` (`stores/helpers/modelBuilderRecipes.ts`) filters `OUTPUT_CATALOG` only by recipe key, and `Character` supports the `relationship-expansion` recipe with the `expand-scenarios` output enabled.
- `npx eslint "server/api/model-builder/items/[id]/commit.post.ts"` — clean.
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0.
- Diff scoped to exactly the one intended file (`git status --porcelain` before commit showed only this file changed).

### Stakes
reversible

### Flags for Reviewer
- Related, lower-confidence sibling gaps noticed but not fixed here (would need to verify a matching Prisma relation exists before treating as a bug): `Reward -> Character` is missing despite `Character -> Reward` existing and `Reward.Characters` existing in the schema; other `CREATE_TARGETS` pairs (`Project`/`Facet`/`Reward -> Scenario`, etc.) are also unhandled but I didn't confirm matching relations for all of them.

### Kaizen suggestion
Add a small dev-time consistency check (or a unit test) that walks every `CREATE_TARGETS` entry and asserts `linkSourceToTarget` has a matching case for `(sourceType, targetType)` wherever a bidirectional Prisma relation exists between the two models — would have caught this gap (and the earlier `Dream -> Bot` gap fixed in PR #1005) automatically instead of relying on a manual read-through each cycle.

### Notes for reviewer
This is model-builder/t-029's recurring bug-hunt cycle (conductor coordination repo) — same pattern as PRs #948/#951/#964/#1005/#1029/#1032/#1049/#1062. The recurring task's other outstanding step (generated dashboard/tutorial art) remains blocked on the external art-generation relay and is untouched here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LHjiaL6pXuVYivb7e2WMEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHjiaL6pXuVYivb7e2WMEi)_