### PR TITLE
Fix LTX video prompt provenance validation

### DIFF
--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -113,11 +113,11 @@ export function buildLtxImageToVideoWorkflow(
       _meta: { title: 'Load LoRA' },
     },
 
-    // --- Prompt conditioning ------------------------------------------------
+    // --- Prompt conditioning -----------------------------------------------
     '319': {
       inputs: { value: input.prompt },
       class_type: 'PrimitiveStringMultiline',
-      _meta: { title: 'Prompt' },
+      _meta: { title: 'Prompt', prompt: input.prompt },
     },
     '306': {
       inputs: { text: ['319', 0], clip: ['318', 0] },
@@ -139,7 +139,7 @@ export function buildLtxImageToVideoWorkflow(
       _meta: { title: 'LTXVConditioning' },
     },
 
-    // --- Image conditioning (the i2v part) ----------------------------------
+    // --- Image conditioning (the i2v part) ---------------------------------
     // First frame: load the still, encode it, and seed the video latent from it.
     img_first: {
       inputs: { image: input.firstImageName },
@@ -222,7 +222,7 @@ export function buildLtxImageToVideoWorkflow(
     latentRef = ['ltxv_guide', 2]
   }
 
-  // --- Sampling -------------------------------------------------------------
+  // --- Sampling ------------------------------------------------------------
   workflow['286'] = {
     inputs: { noise_seed: seed },
     class_type: 'RandomNoise',


### PR DESCRIPTION
## What changed

Expose the LTX motion prompt as `_meta.prompt` on the existing `PrimitiveStringMultiline` prompt node.

## Root cause

The LTX workflow stores its actual positive prompt in `inputs.value`. The ArtJob provenance scanner deliberately recognizes prompt-bearing keys such as `prompt`, `text`, `wildcard_text`, and `populated_text`, but not a generic `value` field. As a result, the workflow contained the correct motion prompt for ComfyUI while provenance could only see the negative prompt, causing the queued job to fail before claim with:

> COMFY workflow prompt does not match the top-level promptString.

WAN was not affected because its positive conditioning node uses `inputs.text`.

## Impact

LTX image-to-video jobs from `/video-generator` can pass prompt provenance validation and be claimed by the relay. The render graph and node inputs are otherwise unchanged.

## Validation

- Confirmed the provenance traversal recursively inspects `_meta` and accepts the `prompt` key.
- Confirmed the metadata value is sourced from the same `input.prompt` used by the LTX workflow node.
- Reviewed the branch diff to ensure no runtime Comfy node inputs changed.

Automated repository checks were not run from the connector environment.