### PR TITLE
Add Storymaker branch consequences and Reward inventory

### DIFF
--- a/.github/workflows/storymaker-branch-state-contract.yml
+++ b/.github/workflows/storymaker-branch-state-contract.yml
@@ -1,0 +1,30 @@
+name: Storymaker Branch State Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storymaker-branch-state-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storymaker fictional state contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storymaker branch state
+        run: node utils/scripts/verifyStorymakerBranchState.mjs

--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -196,8 +196,8 @@
         <div>
           <h2 class="text-lg font-black">The world and its flavor</h2>
           <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-            Use canonical Dreams and Facets as ingredients. Their artwork becomes
-            part of the setup surface while technical art direction remains automatic.
+            Use canonical Dreams, Facets, and Rewards as ingredients. Their artwork
+            becomes part of the setup surface while technical art direction remains automatic.
           </p>
         </div>
 
@@ -225,6 +225,18 @@
           :error="facetStore.error"
           :initial-limit="9"
           :max-selections="5"
+        />
+
+        <NarrativeIngredientMultiPicker
+          v-model="store.setupDraft.rewardSlugs"
+          :items="rewardOptions"
+          label="Possible story Rewards"
+          helper="Choose up to three reusable Rewards the fiction may discover, grant, spend, or lose."
+          empty-state="No active Rewards are available yet. The story can continue without inventory."
+          :loading="rewardStore.isLoading || rewardStore.isInitializing"
+          :error="rewardStore.error"
+          :initial-limit="9"
+          :max-selections="3"
         />
 
         <label class="form-control w-full">
@@ -282,6 +294,12 @@
             <dt class="text-xs font-bold text-base-content/55">Facets</dt>
             <dd class="mt-1 text-sm">
               {{ selectedFacets.length ? selectedFacets.map((item) => item.title).join(', ') : 'None selected' }}
+            </dd>
+          </div>
+          <div class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2">
+            <dt class="text-xs font-bold text-base-content/55">Possible Rewards</dt>
+            <dd class="mt-1 text-sm">
+              {{ selectedRewards.length ? selectedRewards.map((item) => item.title).join(', ') : 'No curated inventory pool' }}
             </dd>
           </div>
           <div
@@ -370,12 +388,18 @@
             <span class="font-bold">World:</span>
             {{ store.session.bible.location?.title || 'Invented from the premise' }}
           </p>
-          <p class="rounded-xl border border-base-300 bg-base-100 p-3 sm:col-span-2">
+          <p class="rounded-xl border border-base-300 bg-base-100 p-3">
             <span class="font-bold">Facets:</span>
             {{ store.session.bible.facets.map((item) => item.title).join(', ') || 'None selected' }}
           </p>
+          <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+            <span class="font-bold">Reward pool:</span>
+            {{ store.session.bible.rewards.map((item) => item.title).join(', ') || 'None selected' }}
+          </p>
         </div>
       </details>
+
+      <StorymakerStatePanel :session="store.session" />
 
       <div class="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         <NarrativeTranscript
@@ -420,6 +444,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useFacetStore } from '@/stores/facetStore'
+import { useRewardStore } from '@/stores/rewardStore'
 import {
   STORYMAKER_NARRATOR_STYLES,
   STORYMAKER_STRUCTURES,
@@ -432,6 +457,7 @@ const store = useStorymakerStore()
 const characterStore = useCharacterStore()
 const dreamStore = useDreamStore()
 const facetStore = useFacetStore()
+const rewardStore = useRewardStore()
 
 const setupStep = ref(0)
 const furthestStep = ref(0)
@@ -505,6 +531,21 @@ const facetOptions = computed<NarrativeIngredientOption[]>(() =>
     })),
 )
 
+const rewardOptions = computed<NarrativeIngredientOption[]>(() =>
+  rewardStore.rewards
+    .filter((reward) => reward.isActive && reward.slug)
+    .map((reward) => ({
+      id: reward.id,
+      slug: reward.slug || String(reward.id),
+      title: reward.name || `Reward ${reward.id}`,
+      description: reward.description || reward.effect,
+      flavorText: reward.flavorText,
+      imagePath: reward.imagePath,
+      icon: reward.icon || 'kind-icon:gift',
+      badge: `${rarityLabel(reward.rarity)} ${reward.rewardType.toLowerCase()}`,
+    })),
+)
+
 const selectedCast = computed(() =>
   characterOptions.value.filter((item) =>
     store.setupDraft.castSlugs.includes(item.slug),
@@ -518,6 +559,11 @@ const selectedLocation = computed(() =>
 const selectedFacets = computed(() =>
   facetOptions.value.filter((item) =>
     store.setupDraft.facetSlugs.includes(item.slug),
+  ),
+)
+const selectedRewards = computed(() =>
+  rewardOptions.value.filter((item) =>
+    store.setupDraft.rewardSlugs.includes(item.slug),
   ),
 )
 const reviewTitle = computed(
@@ -541,7 +587,14 @@ function taxonomyLabel(value: string): string {
     .replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
+function rarityLabel(value: string): string {
+  return value.toLowerCase().replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
 function toIngredient(option: NarrativeIngredientOption): StorymakerIngredient {
+  const reward = rewardStore.rewards.find(
+    (item) => item.slug === option.slug,
+  )
   return {
     id: option.id,
     slug: option.slug,
@@ -549,6 +602,9 @@ function toIngredient(option: NarrativeIngredientOption): StorymakerIngredient {
     description: option.description,
     flavorText: option.flavorText,
     imagePath: option.cardPath || option.imagePath || option.heroPath || null,
+    icon: option.icon,
+    rarity: reward?.rarity || null,
+    effect: reward?.effect || null,
   }
 }
 
@@ -576,6 +632,7 @@ async function beginStory() {
       ? toIngredient(selectedLocation.value)
       : undefined,
     facets: selectedFacets.value.map(toIngredient),
+    rewards: selectedRewards.value.map(toIngredient),
     notes: store.setupDraft.notes,
   })
 }
@@ -602,5 +659,6 @@ onMounted(() => {
     void dreamStore.fetchDreams({ dreamType: 'LOCATION', limit: 200 })
   }
   if (!facetStore.loaded) void facetStore.fetchFacets({ take: 250 })
+  void rewardStore.initialize({ fetchRemote: true })
 })
 </script>

--- a/components/narrative/narrative-transcript.vue
+++ b/components/narrative/narrative-transcript.vue
@@ -27,7 +27,7 @@
       v-if="isStreaming"
       class="whitespace-pre-line rounded-2xl border border-dashed border-secondary/40 bg-base-200/40 p-4 text-sm leading-relaxed"
     >
-      <template v-if="streamingText">{{ streamingText }}</template>
+      <template v-if="visibleStreamingText">{{ visibleStreamingText }}</template>
       <span v-else class="flex items-center gap-2 text-base-content/60">
         <span class="loading loading-dots loading-sm" />
         {{ streamingLabel }}
@@ -37,7 +37,9 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(
+import { computed } from 'vue'
+
+const props = withDefaults(
   defineProps<{
     beats: {
       id: string
@@ -56,4 +58,18 @@ withDefaults(
     emptyLabel: 'The story will appear here once it begins.',
   },
 )
+
+const visibleStreamingText = computed(() => {
+  const text = props.streamingText
+  const marker = '[STORY_STATE]'
+  const markerIndex = text.indexOf(marker)
+  if (markerIndex >= 0) return text.slice(0, markerIndex).trimEnd()
+
+  const lastLineBreak = text.lastIndexOf('\n')
+  const partialLine = text.slice(lastLineBreak + 1).trim()
+  if (partialLine.startsWith('[') && marker.startsWith(partialLine)) {
+    return text.slice(0, Math.max(0, lastLineBreak)).trimEnd()
+  }
+  return text
+})
 </script>

--- a/components/storymaker/storymaker-state-panel.vue
+++ b/components/storymaker/storymaker-state-panel.vue
@@ -1,0 +1,118 @@
+<!-- /components/storymaker/storymaker-state-panel.vue -->
+<template>
+  <details
+    class="rounded-2xl border border-secondary/25 bg-secondary/5 p-3"
+    :open="session.branchHistory.length > 0 || session.inventory.length > 0"
+  >
+    <summary class="cursor-pointer text-sm font-black text-secondary">
+      Story state · {{ session.branchHistory.length }}
+      {{ session.branchHistory.length === 1 ? 'choice' : 'choices' }} ·
+      {{ session.inventory.length }}
+      {{ session.inventory.length === 1 ? 'reward' : 'rewards' }}
+    </summary>
+
+    <div class="mt-3 grid gap-3 lg:grid-cols-3">
+      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+          Inventory
+        </h3>
+        <div v-if="session.inventory.length" class="mt-2 space-y-2">
+          <article
+            v-for="item in session.inventory"
+            :key="item.ingredient.slug"
+            class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-200/40 p-2"
+          >
+            <span
+              class="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+            >
+              <img
+                v-if="item.ingredient.imagePath"
+                :src="item.ingredient.imagePath"
+                :alt="`${item.ingredient.title} artwork`"
+                class="absolute inset-0 size-full object-cover"
+              />
+              <Icon v-else name="kind-icon:gift" class="size-5 text-base-content/40" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate text-xs font-black">
+                {{ item.ingredient.title }}
+              </span>
+              <span
+                v-if="item.ingredient.flavorText || item.ingredient.description"
+                class="line-clamp-2 text-[0.68rem] leading-relaxed text-base-content/50"
+              >
+                {{ item.ingredient.flavorText || item.ingredient.description }}
+              </span>
+            </span>
+          </article>
+        </div>
+        <p v-else class="mt-2 text-xs leading-relaxed text-base-content/45">
+          The story has not placed a selected Reward in your hands yet.
+        </p>
+      </section>
+
+      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+          Consequences
+        </h3>
+        <ol v-if="recentConsequences.length" class="mt-2 space-y-2">
+          <li
+            v-for="item in recentConsequences"
+            :key="item.id"
+            class="flex items-start gap-2 text-xs leading-relaxed"
+          >
+            <Icon
+              :name="
+                item.kind === 'relationship'
+                  ? 'kind-icon:heart'
+                  : 'kind-icon:sparkles'
+              "
+              class="mt-0.5 size-3.5 shrink-0 text-secondary"
+            />
+            <span>{{ item.text }}</span>
+          </li>
+        </ol>
+        <p v-else class="mt-2 text-xs leading-relaxed text-base-content/45">
+          Consequences will accumulate as choices alter the story.
+        </p>
+      </section>
+
+      <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
+        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+          Branch path
+        </h3>
+        <ol v-if="recentBranches.length" class="mt-2 space-y-2">
+          <li
+            v-for="(branch, index) in recentBranches"
+            :key="branch.id"
+            class="rounded-xl border border-base-300 bg-base-200/40 p-2 text-xs leading-relaxed"
+          >
+            <p class="font-bold text-base-content/55">
+              Choice {{ session.branchHistory.length - recentBranches.length + index + 1 }}
+            </p>
+            <p class="mt-0.5 text-base-content/75">{{ branch.answer }}</p>
+          </li>
+        </ol>
+        <p v-else class="mt-2 text-xs leading-relaxed text-base-content/45">
+          Your first answer will begin this session’s branch history.
+        </p>
+      </section>
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { StorymakerSession } from '@/stores/storymakerStore'
+
+const props = defineProps<{
+  session: StorymakerSession
+}>()
+
+const recentConsequences = computed(() =>
+  props.session.consequences.slice(-6).reverse(),
+)
+const recentBranches = computed(() =>
+  props.session.branchHistory.slice(-5),
+)
+</script>

--- a/stores/storymakerStore.ts
+++ b/stores/storymakerStore.ts
@@ -22,6 +22,7 @@ export type StorymakerSetupDraft = {
   castSlugs: string[]
   locationSlug: string | null
   facetSlugs: string[]
+  rewardSlugs: string[]
   notes: string
 }
 
@@ -32,6 +33,9 @@ export type StorymakerIngredient = {
   description?: string | null
   flavorText?: string | null
   imagePath?: string | null
+  icon?: string | null
+  rarity?: string | null
+  effect?: string | null
 }
 
 export type StorymakerBible = {
@@ -42,6 +46,7 @@ export type StorymakerBible = {
   cast: StorymakerIngredient[]
   location?: StorymakerIngredient
   facets: StorymakerIngredient[]
+  rewards: StorymakerIngredient[]
   notes?: string
   createdAt: string
 }
@@ -51,13 +56,43 @@ export type StorymakerAnswer = {
   capturedAt: string
 }
 
+export type StorymakerStateDelta = {
+  consequences: string[]
+  relationshipShifts: string[]
+  inventoryAdd: string[]
+  inventoryRemove: string[]
+}
+
 export type StorymakerBeat = {
   id: string
   sessionId: string
   narrative: string
   question: string
   answer?: StorymakerAnswer
+  stateDelta: StorymakerStateDelta
   createdAt: string
+}
+
+export type StorymakerBranchChoice = {
+  id: string
+  beatId: string
+  question: string
+  answer: string
+  createdAt: string
+}
+
+export type StorymakerConsequence = {
+  id: string
+  beatId: string
+  kind: 'consequence' | 'relationship'
+  text: string
+  createdAt: string
+}
+
+export type StorymakerInventoryItem = {
+  ingredient: StorymakerIngredient
+  beatId: string
+  acquiredAt: string
 }
 
 export type StorymakerSession = {
@@ -65,6 +100,10 @@ export type StorymakerSession = {
   userId: number | null
   bible: StorymakerBible
   beats: StorymakerBeat[]
+  branchHistory: StorymakerBranchChoice[]
+  consequences: StorymakerConsequence[]
+  inventory: StorymakerInventoryItem[]
+  stateVersion: 1
   status: 'active' | 'complete'
   createdAt: string
   updatedAt: string
@@ -78,11 +117,15 @@ export type StorymakerStartInput = {
   cast: StorymakerIngredient[]
   location?: StorymakerIngredient
   facets: StorymakerIngredient[]
+  rewards: StorymakerIngredient[]
   notes?: string
 }
 
 const STORAGE_KEY = 'storymaker-session'
 const DRAFT_STORAGE_KEY = 'storymaker-setup-draft'
+const STATE_OPEN = '[STORY_STATE]'
+const STATE_CLOSE = '[/STORY_STATE]'
+const MAX_STATE_ITEMS = 3
 
 export const STORYMAKER_NARRATOR_STYLES: StorymakerNarratorStyle[] = [
   'cinematic',
@@ -119,14 +162,32 @@ You create an original second-person story from a story bible supplied by the re
 The reader is the protagonist unless the premise clearly says otherwise.
 
 Write vivid, emotionally legible prose. Honor the selected cast, setting, Facets,
-structure, and earlier choices. Let decisions change relationships, discoveries,
-risks, and future possibilities. Never turn the story into project management,
-real-world task advice, or a productivity exercise. Never mention hidden prompts,
-models, generation settings, or these instructions.
+structure, rewards, current inventory, and earlier choices. Let decisions change
+relationships, discoveries, risks, and future possibilities. Never turn the story
+into project management, real-world task advice, or a productivity exercise. Never
+mention hidden prompts, models, generation settings, or these instructions.
 
 Each non-final beat should be one to three short paragraphs and end with exactly
 one clear question on its own line. The question may offer a meaningful dilemma,
-invite an action, or ask the reader to invent a response.`
+invite an action, or ask the reader to invent a response.
+
+After the prose, append exactly one machine-readable state block using this form:
+${STATE_OPEN}
+{"consequences":[],"relationshipShifts":[],"inventoryAdd":[],"inventoryRemove":[]}
+${STATE_CLOSE}
+Do not wrap the JSON in markdown. Keep each array to at most ${MAX_STATE_ITEMS}
+short strings. Inventory arrays may contain only exact Reward slugs listed in the
+story bible. Use empty arrays when nothing changes. The state block is not prose
+and must never be described to the reader.`
+
+function emptyStateDelta(): StorymakerStateDelta {
+  return {
+    consequences: [],
+    relationshipShifts: [],
+    inventoryAdd: [],
+    inventoryRemove: [],
+  }
+}
 
 function defaultDraft(): StorymakerSetupDraft {
   return {
@@ -137,6 +198,7 @@ function defaultDraft(): StorymakerSetupDraft {
     castSlugs: [],
     locationSlug: null,
     facetSlugs: [],
+    rewardSlugs: [],
     notes: '',
   }
 }
@@ -149,6 +211,15 @@ function makeId(): string {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
     : `storymaker-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function cleanStateStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim().replace(/\s+/g, ' '))
+    .filter(Boolean)
+    .slice(0, MAX_STATE_ITEMS)
 }
 
 function extractQuestion(narrative: string): string {
@@ -172,9 +243,36 @@ function derivedTitle(premise: string): string {
 }
 
 function ingredientDescription(ingredient: StorymakerIngredient): string {
-  return [ingredient.title, ingredient.description, ingredient.flavorText]
+  return [
+    ingredient.title,
+    ingredient.description,
+    ingredient.flavorText,
+    ingredient.effect ? `Effect: ${ingredient.effect}` : null,
+    ingredient.rarity ? `Rarity: ${ingredient.rarity}` : null,
+  ]
     .filter(Boolean)
     .join(' — ')
+}
+
+function normalizeRestoredSession(value: StorymakerSession): StorymakerSession {
+  const bible = {
+    ...value.bible,
+    rewards: Array.isArray(value.bible?.rewards) ? value.bible.rewards : [],
+  }
+  return {
+    ...value,
+    bible,
+    beats: Array.isArray(value.beats)
+      ? value.beats.map((beat) => ({
+          ...beat,
+          stateDelta: beat.stateDelta ?? emptyStateDelta(),
+        }))
+      : [],
+    branchHistory: Array.isArray(value.branchHistory) ? value.branchHistory : [],
+    consequences: Array.isArray(value.consequences) ? value.consequences : [],
+    inventory: Array.isArray(value.inventory) ? value.inventory : [],
+    stateVersion: 1,
+  }
 }
 
 export const useStorymakerStore = defineStore('storymakerStore', () => {
@@ -235,7 +333,9 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
         }
       }
       if (sessionRaw && !session.value) {
-        session.value = JSON.parse(sessionRaw) as StorymakerSession
+        session.value = normalizeRestoredSession(
+          JSON.parse(sessionRaw) as StorymakerSession,
+        )
       }
     } catch {
       localStorage.removeItem(DRAFT_STORAGE_KEY)
@@ -264,6 +364,7 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
       cast: input.cast,
       location: input.location,
       facets: input.facets,
+      rewards: input.rewards,
       notes: input.notes?.trim() || undefined,
       createdAt: nowIso(),
     }
@@ -293,6 +394,16 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
           .join('\n')}`,
       )
     }
+    if (bible.rewards.length) {
+      parts.push(
+        `Available story Rewards (use exact slugs in state metadata):\n${bible.rewards
+          .map(
+            (reward) =>
+              `- slug=${reward.slug}; ${ingredientDescription(reward)}`,
+          )
+          .join('\n')}`,
+      )
+    }
     if (bible.notes) parts.push(`Additional direction: ${bible.notes}`)
     return parts.join('\n\n')
   }
@@ -308,6 +419,19 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
       .join('\n\n')
   }
 
+  function statePrompt(active: StorymakerSession): string {
+    const inventory = active.inventory.length
+      ? active.inventory.map((item) => item.ingredient.slug).join(', ')
+      : 'empty'
+    const consequences = active.consequences.length
+      ? active.consequences
+          .slice(-8)
+          .map((item) => `- ${item.text}`)
+          .join('\n')
+      : '- none yet'
+    return `CURRENT FICTIONAL STATE\nInventory slugs: ${inventory}\nRecent consequences and relationship shifts:\n${consequences}`
+  }
+
   function phaseGuidance(): string {
     const active = session.value
     const count = active?.beats.length ?? 0
@@ -318,6 +442,93 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
     }
     if (count <= 4) return 'Develop relationships, discoveries, and meaningful risk.'
     return 'Recombine earlier choices and open a surprising but coherent path.'
+  }
+
+  function parseGeneratedBeat(
+    rawText: string,
+    bible: StorymakerBible,
+  ): { narrative: string; stateDelta: StorymakerStateDelta } {
+    const start = rawText.lastIndexOf(STATE_OPEN)
+    const end = rawText.lastIndexOf(STATE_CLOSE)
+    if (start < 0 || end <= start) {
+      return { narrative: rawText.trim(), stateDelta: emptyStateDelta() }
+    }
+
+    const narrative = rawText.slice(0, start).trim()
+    const jsonText = rawText.slice(start + STATE_OPEN.length, end).trim()
+    let parsed: Record<string, unknown> = {}
+    try {
+      parsed = JSON.parse(jsonText) as Record<string, unknown>
+    } catch {
+      return { narrative, stateDelta: emptyStateDelta() }
+    }
+
+    const allowedRewards = new Set(bible.rewards.map((reward) => reward.slug))
+    return {
+      narrative,
+      stateDelta: {
+        consequences: cleanStateStrings(parsed.consequences),
+        relationshipShifts: cleanStateStrings(parsed.relationshipShifts),
+        inventoryAdd: cleanStateStrings(parsed.inventoryAdd).filter((slug) =>
+          allowedRewards.has(slug),
+        ),
+        inventoryRemove: cleanStateStrings(parsed.inventoryRemove).filter((slug) =>
+          allowedRewards.has(slug),
+        ),
+      },
+    }
+  }
+
+  function applyStateDelta(
+    active: StorymakerSession,
+    beatId: string,
+    delta: StorymakerStateDelta,
+  ) {
+    const createdAt = nowIso()
+    const existingTexts = new Set(
+      active.consequences.map((item) => item.text.toLowerCase()),
+    )
+
+    for (const text of delta.consequences) {
+      if (existingTexts.has(text.toLowerCase())) continue
+      active.consequences.push({
+        id: makeId(),
+        beatId,
+        kind: 'consequence',
+        text,
+        createdAt,
+      })
+      existingTexts.add(text.toLowerCase())
+    }
+    for (const text of delta.relationshipShifts) {
+      if (existingTexts.has(text.toLowerCase())) continue
+      active.consequences.push({
+        id: makeId(),
+        beatId,
+        kind: 'relationship',
+        text,
+        createdAt,
+      })
+      existingTexts.add(text.toLowerCase())
+    }
+
+    const removeSet = new Set(delta.inventoryRemove)
+    active.inventory = active.inventory.filter(
+      (item) => !removeSet.has(item.ingredient.slug),
+    )
+
+    const existingInventory = new Set(
+      active.inventory.map((item) => item.ingredient.slug),
+    )
+    for (const slug of delta.inventoryAdd) {
+      if (existingInventory.has(slug)) continue
+      const ingredient = active.bible.rewards.find(
+        (reward) => reward.slug === slug,
+      )
+      if (!ingredient) continue
+      active.inventory.push({ ingredient, beatId, acquiredAt: createdAt })
+      existingInventory.add(slug)
+    }
   }
 
   async function weaveBeat(prompt: string, closing = false): Promise<boolean> {
@@ -333,19 +544,25 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
         return false
       }
 
-      const narrative = (result.data.text ?? '').trim()
-      if (!narrative) {
+      const parsed = parseGeneratedBeat(
+        (result.data.text ?? '').trim(),
+        active.bible,
+      )
+      if (!parsed.narrative) {
         errorMessage.value = 'Storymaker went quiet. Try the scene again.'
         return false
       }
 
+      const beatId = makeId()
       active.beats.push({
-        id: makeId(),
+        id: beatId,
         sessionId: active.id,
-        narrative,
-        question: closing ? '' : extractQuestion(narrative),
+        narrative: parsed.narrative,
+        question: closing ? '' : extractQuestion(parsed.narrative),
+        stateDelta: parsed.stateDelta,
         createdAt: nowIso(),
       })
+      applyStateDelta(active, beatId, parsed.stateDelta)
       if (closing) active.status = 'complete'
       active.updatedAt = nowIso()
       persist()
@@ -368,6 +585,10 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
       userId: userStore.authenticatedUserId,
       bible,
       beats: [],
+      branchHistory: [],
+      consequences: [],
+      inventory: [],
+      stateVersion: 1,
       status: 'active',
       createdAt,
       updatedAt: createdAt,
@@ -383,17 +604,25 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
     const clean = answerText.trim()
     if (!active || !beat || beat.answer || !clean || isWeaving.value) return false
 
-    beat.answer = { text: clean, capturedAt: nowIso() }
-    active.updatedAt = nowIso()
+    const capturedAt = nowIso()
+    beat.answer = { text: clean, capturedAt }
+    active.branchHistory.push({
+      id: makeId(),
+      beatId: beat.id,
+      question: beat.question,
+      answer: clean,
+      createdAt: capturedAt,
+    })
+    active.updatedAt = capturedAt
     persist()
 
-    return weaveBeat(`${PERSONA}\n\nSTORY BIBLE\n${biblePrompt(active.bible)}\n\n${phaseGuidance()}\n\nSTORY SO FAR\n${buildRecap()}\n\nContinue the story from the reader's latest choice. Preserve continuity, create a fresh consequence or discovery, and end with one new question.`)
+    return weaveBeat(`${PERSONA}\n\nSTORY BIBLE\n${biblePrompt(active.bible)}\n\n${statePrompt(active)}\n\n${phaseGuidance()}\n\nSTORY SO FAR\n${buildRecap()}\n\nContinue the story from the reader's latest choice. Preserve continuity, apply a fresh consequence or discovery when earned, and end with one new question.`)
   }
 
   async function finishStory(): Promise<boolean> {
     const active = session.value
     if (!active || !canFinish.value) return false
-    return weaveBeat(`${PERSONA}\n\nSTORY BIBLE\n${biblePrompt(active.bible)}\n\nSTORY SO FAR\n${buildRecap()}\n\nWrite a satisfying finale for this session. Resolve the strongest active thread while leaving only intentional wonder. Do not end with a question.`, true)
+    return weaveBeat(`${PERSONA}\n\nSTORY BIBLE\n${biblePrompt(active.bible)}\n\n${statePrompt(active)}\n\nSTORY SO FAR\n${buildRecap()}\n\nWrite a satisfying finale for this session. Resolve the strongest active thread while leaving only intentional wonder. Do not end with a question.`, true)
   }
 
   watch(setupDraft, persist, { deep: true })

--- a/utils/scripts/verifyStorymakerBranchState.mjs
+++ b/utils/scripts/verifyStorymakerBranchState.mjs
@@ -1,0 +1,92 @@
+// /utils/scripts/verifyStorymakerBranchState.mjs
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+function includesAll(path, values) {
+  const contents = source(path)
+  for (const value of values) {
+    assert.ok(contents.includes(value), `${path} must include ${value}`)
+  }
+}
+
+const storePath = 'stores/storymakerStore.ts'
+const pagePath = 'components/conductor/storymaker-page.vue'
+const panelPath = 'components/storymaker/storymaker-state-panel.vue'
+const transcriptPath = 'components/narrative/narrative-transcript.vue'
+const store = source(storePath)
+const page = source(pagePath)
+
+includesAll(storePath, [
+  'StorymakerBranchChoice',
+  'StorymakerConsequence',
+  'StorymakerInventoryItem',
+  'branchHistory: []',
+  'consequences: []',
+  'inventory: []',
+  'stateVersion: 1',
+  'parseGeneratedBeat',
+  'applyStateDelta',
+  'allowedRewards.has(slug)',
+  'active.branchHistory.push',
+  'normalizeRestoredSession',
+])
+
+includesAll(storePath, [
+  "const STATE_OPEN = '[STORY_STATE]'",
+  "const STATE_CLOSE = '[/STORY_STATE]'",
+  'inventoryAdd',
+  'inventoryRemove',
+  'relationshipShifts',
+])
+
+assert.ok(
+  !store.includes('useTaskmasterStore'),
+  'Storymaker state must remain independent from Taskmaster',
+)
+assert.ok(
+  !store.includes('useTodoStore'),
+  'Storymaker inventory and consequences must remain fictional',
+)
+assert.ok(
+  !store.includes("performFetch('/api/conductor"),
+  'Storymaker choices must not write to Conductor',
+)
+
+includesAll(pagePath, [
+  'useRewardStore',
+  'store.setupDraft.rewardSlugs',
+  'Possible story Rewards',
+  'rewardStore.initialize({ fetchRemote: true })',
+  '<StorymakerStatePanel',
+  'rewards: selectedRewards.value.map(toIngredient)',
+])
+
+includesAll(panelPath, [
+  'session.inventory',
+  'session.consequences',
+  'session.branchHistory',
+  'Branch path',
+  'Inventory',
+])
+
+includesAll(transcriptPath, [
+  'visibleStreamingText',
+  "const marker = '[STORY_STATE]'",
+  'marker.startsWith(partialLine)',
+])
+
+assert.ok(
+  !page.includes('applyWriteBack'),
+  'Storymaker state UI must not expose Taskmaster write-back controls',
+)
+
+console.log(
+  'Storymaker branch-state contract passed: reader choices, constrained ' +
+    'fictional consequences, selected Reward inventory, saved-session migration, ' +
+    'hidden state metadata, and the Taskmaster/write-back boundary are present.',
+)


### PR DESCRIPTION
## What changed

- Add persistent reader-choice branch history to Storymaker sessions.
- Add fictional consequence and relationship-shift state that accumulates across generated beats.
- Add reusable Reward selection to the Storymaker story bible and setup surface.
- Add session-local Reward inventory that can only add or remove exact Reward slugs selected in the story bible.
- Parse a constrained machine-readable state footer from each generated scene, strip it from saved prose, and ignore malformed or unauthorized state changes.
- Hide Storymaker state metadata as soon as it begins arriving in the shared streaming transcript.
- Add a visible Storymaker state panel for inventory, recent consequences, and the reader’s branch path.
- Migrate older locally saved Storymaker drafts and sessions to the new state shape safely.
- Add a dedicated Storymaker Branch State Contract protecting the fictional-only state boundary.

## Boundary and safety

- Storymaker still does not import Taskmaster, Todo, or Conductor write-back state.
- Inventory and consequences live only inside the saved Storymaker session.
- Generated metadata cannot introduce arbitrary inventory records; only exact selected Reward slugs are accepted.
- No generated state block is presented as story prose.

## Verification

CI and exact-head Vercel preview inspection pending. This PR remains draft until TypeScript, all repository contracts, the new branch-state contract, and `/storymaker`/`/taskmaster` preview checks pass.

Tracks #1073.