### PR TITLE
Fix Comfy validation failures for LTX and legacy retries

### DIFF
--- a/server/api/art/queue/[id]/requeue.post.ts
+++ b/server/api/art/queue/[id]/requeue.post.ts
@@ -10,6 +10,11 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
+import {
+  parseArtJobPayload,
+  serializeArtJobPayload,
+} from '../../../../utils/artJobPayload'
+import { applyArtJobOverrides } from '../../../../utils/artJobRetry'
 
 type RequeueBody = {
   resetAttempts?: boolean
@@ -33,7 +38,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const body = (await readBody(event).catch(() => null)) as RequeueBody | null
-    const resetAttempts = body?.resetAttempts !== false // default true
+    const resetAttempts = body?.resetAttempts !== false
 
     const job = await prisma.artJob.findUnique({ where: { id } })
 
@@ -48,9 +53,14 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    const payload = applyArtJobOverrides(
+      structuredClone(parseArtJobPayload(job.payload)),
+      null,
+    )
     const updated = await prisma.artJob.update({
       where: { id },
       data: {
+        payload: serializeArtJobPayload(payload),
         status: 'PENDING',
         claimedAt: null,
         claimedBy: null,

--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -148,15 +148,13 @@ export function buildLtxImageToVideoWorkflow(
     },
     img_scale: {
       inputs: {
+        image: ['img_first', 0],
+        upscale_method: 'lanczos',
         width,
         height,
-        interpolation: 'lanczos',
-        method: 'stretch',
-        condition: 'always',
-        multiple_of: 0,
-        image: ['img_first', 0],
+        crop: 'disabled',
       },
-      class_type: 'ImageResize+',
+      class_type: 'ImageScale',
       _meta: { title: 'Resize First Image' },
     },
     // LTXVImgToVideo bakes the start frame into the latent + conditioning.
@@ -192,15 +190,13 @@ export function buildLtxImageToVideoWorkflow(
     }
     workflow['img_last_scale'] = {
       inputs: {
+        image: ['img_last', 0],
+        upscale_method: 'lanczos',
         width,
         height,
-        interpolation: 'lanczos',
-        method: 'stretch',
-        condition: 'always',
-        multiple_of: 0,
-        image: ['img_last', 0],
+        crop: 'disabled',
       },
-      class_type: 'ImageResize+',
+      class_type: 'ImageScale',
       _meta: { title: 'Resize Last Image' },
     }
     workflow['ltxv_guide'] = {

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -174,6 +174,18 @@ function normalizeLegacyComfyWorkflow(
     const record = asRecord(node)
     const classType = stringValue(record.class_type)
     const inputs = asRecord(record.inputs)
+    const meta = asRecord(record._meta)
+
+    if (
+      classType === 'PrimitiveStringMultiline' &&
+      stringValue(meta.title).toLowerCase() === 'prompt'
+    ) {
+      const prompt = stringValue(inputs.value) || stringValue(payload.promptString)
+      if (prompt) {
+        meta.prompt = prompt
+        record._meta = meta
+      }
+    }
 
     if (classType === 'ImageResize+') {
       record.class_type = 'ImageScale'

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -14,6 +14,8 @@ export const ART_JOB_RETRY_MODES = new Set<ArtJobRetryMode>([
 ])
 
 const SEED_KEYS = new Set(['seed', 'noise_seed'])
+const CURRENT_FLUX_T5 = 't5xxl_fp8_e4m3fn_scaled.safetensors'
+const CURRENT_FLUX_CLIP_L = 'clip_l.safetensors'
 
 function asRecord(value: unknown): ArtJobPayloadRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
@@ -113,6 +115,7 @@ const VIDEO_NODE_TYPES = new Set([
   'LTXVImgToVideo',
   'WanImageToVideo',
   'ImageResize+',
+  'ImageScale',
   'CreateVideo',
 ])
 
@@ -161,10 +164,48 @@ function workflowVideoNumber(
   return null
 }
 
+function normalizeLegacyComfyWorkflow(
+  payload: ArtJobPayloadRecord,
+): ArtJobPayloadRecord {
+  const workflow = asRecord(payload.workflow)
+  if (!Object.keys(workflow).length) return payload
+
+  for (const node of Object.values(workflow)) {
+    const record = asRecord(node)
+    const classType = stringValue(record.class_type)
+    const inputs = asRecord(record.inputs)
+
+    if (classType === 'ImageResize+') {
+      record.class_type = 'ImageScale'
+      record.inputs = {
+        image: inputs.image,
+        upscale_method: stringValue(inputs.interpolation) || 'lanczos',
+        width: num(inputs.width) ?? 0,
+        height: num(inputs.height) ?? 0,
+        crop: 'disabled',
+      }
+      continue
+    }
+
+    if (
+      classType === 'DualCLIPLoader' &&
+      stringValue(inputs.type).toLowerCase() === 'flux'
+    ) {
+      inputs.clip_name1 = CURRENT_FLUX_T5
+      inputs.clip_name2 = CURRENT_FLUX_CLIP_L
+      record.inputs = inputs
+    }
+  }
+
+  payload.workflow = workflow
+  return payload
+}
+
 export function applyArtJobOverrides(
   payload: ArtJobPayloadRecord,
   overrides: ArtJobOverrides | null | undefined,
 ): ArtJobPayloadRecord {
+  normalizeLegacyComfyWorkflow(payload)
   if (!overrides) return payload
 
   const promptString =
@@ -336,7 +377,9 @@ export function prepareArtJobRetryPayload(
   mode: ArtJobRetryMode,
   refreshSeed: boolean,
 ): ArtJobPayloadRecord {
-  const cloned = structuredClone(parseArtJobPayload(rawPayload))
+  const cloned = normalizeLegacyComfyWorkflow(
+    structuredClone(parseArtJobPayload(rawPayload)),
+  )
   const previousRetry = asRecord(cloned.retry)
   const rootJobId = Number(previousRetry.rootJobId) || sourceJobId
 


### PR DESCRIPTION
## What changed

- Replace the LTX queue workflow's unavailable `ImageResize+` custom node with ComfyUI's core `ImageScale` node.
- Apply the same core resize node to optional LTX end frames.
- Repair existing queued/retried workflows that still contain `ImageResize+` before they are sent back to ComfyUI.
- Restore prompt metadata on legacy LTX jobs created before the provenance fix.
- Refresh legacy Flux `DualCLIPLoader` inputs to the current T5 XXL and CLIP-L files during edit, re-enqueue, or plain requeue.
- Persist the repaired payload when the dashboard's normal requeue button is used.
- Keep video width/height overrides compatible with both legacy and current resize nodes.

## Root cause

The LTX image-to-video graph assumed `ImageResize+` was installed, but the home ComfyUI instance does not provide that custom node. Comfy therefore rejected the workflow before execution. Separately, old LTX and Flux jobs retain obsolete workflow metadata and model inputs when requeued because recovery previously replayed the original graph unchanged.

## Impact

- New LTX video jobs use only the core image resize node.
- Requeueing failed LTX job #2735 repairs its workflow instead of replaying the missing-node failure.
- Requeueing historical LTX job #2734 restores its prompt provenance metadata.
- Requeueing old Flux jobs such as #2017 and #2086 updates their text encoders instead of replaying the stale T5 shape mismatch.
- Edit, new-output, overwrite, bulk retry, and plain requeue recovery paths all share the repair logic.

## Not included

The invalid Kontext LoRA paths are a separate inventory-reconciliation issue. Conductor task `ai-art-academy/t-044` already provides an offline comparator against ComfyUI's authoritative `LoraLoaderModelOnly` dropdown. This PR intentionally does not guess private LoRA folder paths.

## Validation

- Confirmed `ImageScale` and its `image`, `upscale_method`, `width`, `height`, and `crop` inputs are core ComfyUI nodes.
- Reviewed the diff to keep changes limited to the LTX builder and ArtJob recovery normalization.
- Automated checks run on this draft PR.