### PR TITLE
storymaker/t-010: arm-confirm the New story button

### DIFF
--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -31,13 +31,25 @@
         >
           <Icon name="kind-icon:moon" class="size-4" /> Finish this tale
         </button>
+        <!-- New story — arms on first click, fires on second, so an in-progress
+             or finished tale can't be discarded by a single stray click. -->
         <button
+          v-if="!newStoryArmed"
           type="button"
           class="btn btn-ghost btn-sm rounded-xl border border-base-300"
           :disabled="store.isWeaving"
-          @click="startAnother"
+          @click="newStoryArmed = true"
         >
           <Icon name="kind-icon:plus" class="size-4" /> New story
+        </button>
+        <button
+          v-else
+          type="button"
+          class="btn btn-warning btn-sm rounded-xl"
+          @click="startAnother"
+          @blur="newStoryArmed = false"
+        >
+          <Icon name="kind-icon:alert" class="size-4" /> Discard this tale?
         </button>
       </div>
     </header>
@@ -436,6 +448,7 @@ const facetStore = useFacetStore()
 const setupStep = ref(0)
 const furthestStep = ref(0)
 const answerInput = ref('')
+const newStoryArmed = ref(false)
 const setupSteps = [
   { label: 'Premise' },
   { label: 'Cast' },
@@ -587,6 +600,7 @@ async function submitAnswer(value: string) {
 
 function startAnother() {
   if (store.isWeaving) return
+  newStoryArmed.value = false
   store.resetSession()
   setupStep.value = 0
   furthestStep.value = 0


### PR DESCRIPTION
## Summary
- The dedicated Storymaker studio landed today in #1084. Its header "New story" button called `store.resetSession()` on a single click with no confirmation — discarding the current session (including a finished tale) with only a localStorage backup that the reset itself clears.
- Applied the same arm-on-first-click / confirm-on-second pattern already used by `art-interact.vue`'s delete button (per this repo's no-`window.confirm` convention): first click arms the button ("Discard this tale?"), second click confirms; losing focus disarms it.

## Test plan
- [x] `npx eslint components/conductor/storymaker-page.vue` — clean
- [x] `npx prettier --check components/conductor/storymaker-page.vue` — pre-existing drift confirmed unrelated to this diff via `git stash`
- [x] `npm run test` (vue-tsc --noEmit) — exit 0
- [x] `node utils/scripts/verifyStorymakerStudio.mjs` — contract still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019XoFpQQUEijqqopPohyP3V

---
_Generated by [Claude Code](https://claude.ai/code/session_019XoFpQQUEijqqopPohyP3V)_