### PR TITLE
Resolve Resource LoRAs and add WAN/LTX video support

### DIFF
--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -1,0 +1,238 @@
+<template>
+  <section class="space-y-3 rounded-lg border border-base-300 p-3">
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div>
+        <h2 class="font-semibold">LoRA <span class="opacity-50">(optional)</span></h2>
+        <p class="text-xs opacity-60">
+          {{ engine.toUpperCase() }}-compatible Resources only. Preview images come from the Resource record.
+        </p>
+      </div>
+      <button
+        v-if="modelValue"
+        type="button"
+        class="btn btn-xs btn-ghost"
+        @click="emit('update:modelValue', null)"
+      >
+        Clear LoRA
+      </button>
+    </div>
+
+    <div
+      v-if="resourceStore.isLoading && !resourceStore.hasLoaded"
+      class="flex min-h-28 items-center justify-center rounded-lg bg-base-200"
+    >
+      <span class="loading loading-spinner loading-sm" />
+    </div>
+
+    <div
+      v-else-if="!compatibleResources.length"
+      class="rounded-lg border border-dashed border-base-300 bg-base-200/50 p-4 text-center text-sm opacity-70"
+    >
+      No active {{ engine.toUpperCase() }} LoRA Resources are available.
+    </div>
+
+    <div v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <button
+        v-for="resource in compatibleResources"
+        :key="resource.id"
+        type="button"
+        class="overflow-hidden rounded-lg border text-left transition"
+        :class="
+          modelValue === resource.id
+            ? 'border-accent bg-accent/10 ring-2 ring-accent/20'
+            : 'border-base-300 bg-base-100 hover:border-accent/60'
+        "
+        :aria-pressed="modelValue === resource.id"
+        @click="selectResource(resource.id)"
+      >
+        <div
+          v-if="previewImages(resource).length"
+          class="grid aspect-video w-full overflow-hidden bg-base-200"
+          :class="previewImages(resource).length > 1 ? 'grid-cols-2' : 'grid-cols-1'"
+        >
+          <img
+            v-for="src in previewImages(resource)"
+            :key="src"
+            :src="src"
+            :alt="`${resourceLabel(resource)} preview`"
+            class="h-full min-h-0 w-full object-cover"
+            loading="lazy"
+            @error="hideBrokenImage"
+          />
+        </div>
+        <div
+          v-else
+          class="flex aspect-video items-center justify-center bg-base-200 text-3xl opacity-30"
+          aria-hidden="true"
+        >
+          🎞️
+        </div>
+
+        <div class="space-y-1 p-3">
+          <div class="flex items-start justify-between gap-2">
+            <span class="font-semibold leading-tight">{{ resourceLabel(resource) }}</span>
+            <span
+              v-if="modelValue === resource.id"
+              class="badge badge-accent badge-sm shrink-0"
+            >
+              Selected
+            </span>
+          </div>
+          <p class="truncate text-xs opacity-60" :title="resource.localPath || ''">
+            {{ resource.localPath }}
+          </p>
+          <p v-if="resource.defaultTrigger || resource.triggerWords" class="line-clamp-2 text-xs opacity-70">
+            {{ resource.defaultTrigger || resource.triggerWords }}
+          </p>
+        </div>
+      </button>
+    </div>
+
+    <div
+      v-if="selectedResource"
+      class="grid gap-3 rounded-lg bg-base-200 p-3 sm:grid-cols-[1fr_7rem] sm:items-end"
+    >
+      <label class="space-y-1">
+        <span class="text-sm font-semibold">LoRA strength: {{ normalizedStrength.toFixed(2) }}</span>
+        <input
+          :value="normalizedStrength"
+          type="range"
+          min="-2"
+          max="2"
+          step="0.05"
+          class="range range-accent range-sm w-full"
+          @input="updateStrength"
+        />
+      </label>
+      <input
+        :value="normalizedStrength"
+        type="number"
+        min="-2"
+        max="2"
+        step="0.05"
+        class="input input-bordered input-sm w-full"
+        aria-label="LoRA strength"
+        @input="updateStrength"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue'
+import { useResourceStore } from '@/stores/resourceStore'
+import type { VideoEngine } from '@/stores/videoStore'
+import type { Resource } from '~/prisma/generated/prisma/client'
+
+type PreviewArtImage = {
+  imagePath?: string | null
+  path?: string | null
+  thumbnailPath?: string | null
+}
+
+type VideoLoraResource = Resource & {
+  ArtImage?: PreviewArtImage | null
+}
+
+const props = defineProps<{
+  modelValue: number | null
+  strength: number
+  engine: VideoEngine
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number | null]
+  'update:strength': [value: number]
+}>()
+
+const resourceStore = useResourceStore()
+
+const compatibleResources = computed<VideoLoraResource[]>(() => {
+  const supportedServer = props.engine.toUpperCase()
+
+  return (resourceStore.resources as VideoLoraResource[]).filter((resource) => {
+    return (
+      (resource.resourceType === 'LORA' || resource.resourceType === 'LYCORIS') &&
+      Boolean(resource.localPath?.trim()) &&
+      (resource.supportedServer === supportedServer ||
+        resource.supportedServer === 'GENERIC')
+    )
+  })
+})
+
+const selectedResource = computed(
+  () =>
+    compatibleResources.value.find(
+      (resource) => resource.id === props.modelValue,
+    ) ?? null,
+)
+
+const normalizedStrength = computed(() => clampStrength(props.strength))
+
+onMounted(async () => {
+  if (!resourceStore.hasLoaded) {
+    await resourceStore.getResources()
+  }
+})
+
+watch(
+  [() => props.engine, compatibleResources],
+  () => {
+    if (props.modelValue && !selectedResource.value) {
+      emit('update:modelValue', null)
+    }
+  },
+  { immediate: true },
+)
+
+function resourceLabel(resource: VideoLoraResource): string {
+  return resource.customLabel?.trim() || resource.name
+}
+
+function normalizeImagePath(value: string | null | undefined): string {
+  const path = String(value || '').trim()
+  if (!path) return ''
+  if (
+    path.startsWith('http://') ||
+    path.startsWith('https://') ||
+    path.startsWith('data:') ||
+    path.startsWith('blob:') ||
+    path.startsWith('/')
+  ) {
+    return path
+  }
+  return `/${path.replace(/^\/+/, '')}`
+}
+
+function previewImages(resource: VideoLoraResource): string[] {
+  return [
+    resource.previewImageUrl,
+    resource.imagePath,
+    resource.MediaPath,
+    resource.ArtImage?.thumbnailPath,
+    resource.ArtImage?.imagePath,
+    resource.ArtImage?.path,
+  ]
+    .map(normalizeImagePath)
+    .filter((path, index, paths) => Boolean(path) && paths.indexOf(path) === index)
+}
+
+function selectResource(resourceId: number): void {
+  emit('update:modelValue', props.modelValue === resourceId ? null : resourceId)
+}
+
+function clampStrength(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 1
+  return Math.min(2, Math.max(-2, parsed))
+}
+
+function updateStrength(event: Event): void {
+  const target = event.target as HTMLInputElement
+  emit('update:strength', clampStrength(target.value))
+}
+
+function hideBrokenImage(event: Event): void {
+  ;(event.target as HTMLImageElement).style.display = 'none'
+}
+</script>

--- a/pages/video-generator.vue
+++ b/pages/video-generator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-6 space-y-6 max-w-5xl mx-auto">
+  <div class="mx-auto max-w-5xl space-y-6 p-6">
     <header class="space-y-1">
       <h1 class="text-2xl font-bold">🎬 Video Generator</h1>
       <p class="text-sm opacity-70">
@@ -35,7 +35,7 @@
     <!-- Images -->
     <section class="grid gap-4 md:grid-cols-2">
       <!-- First image (required) -->
-      <div class="space-y-2 p-3 rounded-lg border border-base-300">
+      <div class="space-y-2 rounded-lg border border-base-300 p-3">
         <div class="flex items-center justify-between">
           <label class="font-semibold"
             >First image <span class="text-error">*</span></label
@@ -51,17 +51,17 @@
         <input
           type="file"
           accept="image/*"
-          class="file-input file-input-sm file-input-bordered w-full"
+          class="file-input file-input-bordered file-input-sm w-full"
           @change="(e) => onFileChange(e, 'first')"
         />
         <div
           v-if="firstImage"
-          class="relative aspect-video bg-base-200 rounded overflow-hidden flex items-center justify-center"
+          class="relative flex aspect-video items-center justify-center overflow-hidden rounded bg-base-200"
         >
           <img :src="firstImage" class="max-h-full max-w-full object-contain" />
           <button
             type="button"
-            class="btn btn-xs btn-circle btn-error absolute top-1 right-1"
+            class="btn btn-circle btn-error btn-xs absolute top-1 right-1"
             title="Clear"
             @click="firstImage = ''"
           >
@@ -74,19 +74,19 @@
       </div>
 
       <!-- Second image (optional) -->
-      <div class="space-y-2 p-3 rounded-lg border border-base-300">
+      <div class="space-y-2 rounded-lg border border-base-300 p-3">
         <label class="font-semibold"
           >End image <span class="opacity-50">(optional)</span></label
         >
         <input
           type="file"
           accept="image/*"
-          class="file-input file-input-sm file-input-bordered w-full"
+          class="file-input file-input-bordered file-input-sm w-full"
           @change="(e) => onFileChange(e, 'second')"
         />
         <div
           v-if="secondImage"
-          class="relative aspect-video bg-base-200 rounded overflow-hidden flex items-center justify-center"
+          class="relative flex aspect-video items-center justify-center overflow-hidden rounded bg-base-200"
         >
           <img
             :src="secondImage"
@@ -94,7 +94,7 @@
           />
           <button
             type="button"
-            class="btn btn-xs btn-circle btn-error absolute top-1 right-1"
+            class="btn btn-circle btn-error btn-xs absolute top-1 right-1"
             title="Clear"
             @click="secondImage = ''"
           >
@@ -132,16 +132,22 @@
         <textarea
           v-model="negativePrompt"
           rows="2"
-          class="textarea textarea-bordered w-full mt-2"
+          class="textarea textarea-bordered mt-2 w-full"
           placeholder="Leave blank for the sensible default."
         />
       </details>
     </section>
 
+    <video-lora-picker
+      v-model="loraResourceId"
+      v-model:strength="loraStrength"
+      :engine="engine"
+    />
+
     <!-- Controls -->
     <section class="grid gap-4 sm:grid-cols-3">
       <div class="space-y-1">
-        <label class="font-semibold text-sm">Time (seconds)</label>
+        <label class="text-sm font-semibold">Time (seconds)</label>
         <input
           v-model.number="durationSeconds"
           type="number"
@@ -152,7 +158,7 @@
         />
       </div>
       <div class="space-y-1">
-        <label class="font-semibold text-sm">FPS</label>
+        <label class="text-sm font-semibold">FPS</label>
         <input
           v-model.number="fps"
           type="number"
@@ -163,8 +169,8 @@
         />
       </div>
       <div class="space-y-1">
-        <label class="font-semibold text-sm">Loop</label>
-        <label class="cursor-pointer flex items-center gap-2 h-12">
+        <label class="text-sm font-semibold">Loop</label>
+        <label class="flex h-12 cursor-pointer items-center gap-2">
           <input v-model="loop" type="checkbox" class="toggle toggle-accent" />
           <span class="text-sm opacity-70">{{
             loop ? 'Seamless loop' : 'Play once'
@@ -177,7 +183,7 @@
       <summary class="cursor-pointer opacity-70">
         Advanced (size &amp; seed)
       </summary>
-      <div class="grid gap-4 sm:grid-cols-3 mt-2">
+      <div class="mt-2 grid gap-4 sm:grid-cols-3">
         <div class="space-y-1">
           <label class="text-sm">Width</label>
           <input
@@ -210,7 +216,7 @@
           />
         </div>
       </div>
-      <p class="text-xs opacity-50 mt-1">
+      <p class="mt-1 text-xs opacity-50">
         Estimated frames: {{ estimatedFrames }} ({{ durationSeconds }}s ×
         {{ fps }}fps)
       </p>
@@ -233,7 +239,7 @@
 
       <div
         v-if="videoStore.state.message"
-        class="text-sm opacity-70 text-center"
+        class="text-center text-sm opacity-70"
       >
         {{ videoStore.state.message }}
         <span v-if="videoStore.state.jobId" class="opacity-50">
@@ -274,7 +280,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useVideoStore } from '@/stores/videoStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -311,6 +317,8 @@ const firstImage = ref('')
 const secondImage = ref('')
 const prompt = ref(WINK_PRESET)
 const negativePrompt = ref('')
+const loraResourceId = ref<number | null>(null)
+const loraStrength = ref(1)
 const durationSeconds = ref(4)
 const fps = ref(24)
 const loop = ref(true)
@@ -394,6 +402,8 @@ async function generate() {
     width: width.value,
     height: height.value,
     seed,
+    loraResourceIds: loraResourceId.value ? [loraResourceId.value] : undefined,
+    loraStrength: loraResourceId.value ? loraStrength.value : undefined,
   })
 }
 </script>

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -499,6 +499,10 @@ function buildVideoJobPayload(
     30,
   )
   const negativePrompt = body.negativePrompt?.trim() || DEFAULT_VIDEO_NEGATIVE
+  const loraName = body.loraName?.trim() || null
+  const loraStrength = loraName
+    ? clampNumber(body.loraStrength, 1, -2, 2)
+    : null
   const images: QueuedImage[] = []
   let firstImageName: string | null = null
   let lastImageName: string | null = null
@@ -539,6 +543,8 @@ function buildVideoJobPayload(
         cfg: body.cfg ?? null,
         sampler: body.sampler ?? null,
         scheduler: body.scheduler ?? null,
+        loraName,
+        loraStrength,
       })
     : buildLtxImageToVideoWorkflow({
         prompt: promptString,
@@ -553,6 +559,8 @@ function buildVideoJobPayload(
         steps: body.steps ?? null,
         cfg: body.cfg ?? null,
         sampler: body.sampler ?? null,
+        styleLoraName: loraName,
+        styleLoraStrength: loraStrength,
       })
 
   return {
@@ -572,6 +580,8 @@ function buildVideoJobPayload(
         height,
         hasFirstImage: Boolean(firstImageName),
         hasLastImage: Boolean(lastImageName),
+        hasLora: Boolean(loraName),
+        loraStrength,
       },
       save,
     },

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -3,6 +3,7 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { authAndGate } from '../../utils/comfyGate'
+import { resolveEnqueueLoraResource } from '../../utils/artLoraResource'
 import { buildDefaultComfyWorkflow } from '../comfy/sdxl/utils/workflow'
 import { buildFluxWorkflowFromRequest } from '../comfy/flux/utils/workflow'
 import { buildKrea2WorkflowFromRequest } from '../comfy/krea2/utils/workflow'
@@ -177,7 +178,10 @@ export default defineEventHandler(async (event) => {
       body?.promptString || body?.artPrompt || body?.prompt || '',
     ).trim()
     if (!requestedPrompt) {
-      throw createError({ statusCode: 400, message: 'Missing required field: "promptString".' })
+      throw createError({
+        statusCode: 400,
+        message: 'Missing required field: "promptString".',
+      })
     }
 
     const videoFrames = VIDEO_ENGINES.has(engine)
@@ -191,20 +195,28 @@ export default defineEventHandler(async (event) => {
       frames: videoFrames,
       serverId: body?.serverId ?? null,
     })
+    const isAdmin = Boolean((gate.user as { isAdmin?: boolean }).isAdmin)
+    const resolvedLora = await resolveEnqueueLoraResource({
+      body: (body ?? {}) as ArtEnqueueRequest & Record<string, unknown>,
+      engine,
+      userId: gate.user.id,
+      isAdmin,
+    })
+    const resolvedBody = resolvedLora.body as ArtEnqueueRequest
 
-    const requestedFacets = facetRequest(body)
+    const requestedFacets = facetRequest(resolvedBody)
     const basePromptString = requestedFacets.basePromptString || requestedPrompt
     const facets = await resolveArtFacetSelection({
       facetIds: requestedFacets.facetIds,
       userId: gate.user.id,
-      isAdmin: Boolean((gate.user as { isAdmin?: boolean }).isAdmin),
-      includeMature: Boolean(body?.isMature),
+      isAdmin,
+      includeMature: Boolean(resolvedBody.isMature),
     })
 
     const save = {
-      isPublic: body?.isPublic ?? true,
-      isMature: body?.isMature ?? false,
-      designer: body?.designer?.trim() || null,
+      isPublic: resolvedBody.isPublic ?? true,
+      isMature: resolvedBody.isMature ?? false,
+      designer: resolvedBody.designer?.trim() || null,
     }
     const previewPayload: Record<string, unknown> = {}
     const promptString = applyArtFacetsToPayload(
@@ -213,14 +225,17 @@ export default defineEventHandler(async (event) => {
       facets,
     )
 
-    const projectSlug = body?.projectSlug?.trim().toLowerCase() || null
+    const projectSlug =
+      resolvedBody.projectSlug?.trim().toLowerCase() || null
     if (projectSlug && !SLUG_PATTERN.test(projectSlug)) {
       throw createError({ statusCode: 400, message: 'Invalid projectSlug.' })
     }
-    const priority = Number.isInteger(body?.priority) ? Number(body?.priority) : 0
+    const priority = Number.isInteger(resolvedBody.priority)
+      ? Number(resolvedBody.priority)
+      : 0
 
     const { jobEngine, payload } = buildJobPayload(engine, {
-      body: body ?? {},
+      body: resolvedBody,
       promptString,
       save,
     })
@@ -228,21 +243,13 @@ export default defineEventHandler(async (event) => {
 
     const provenanceResources = {
       checkpointResourceId:
-        Number.isInteger(body?.checkpointResourceId) &&
-        Number(body?.checkpointResourceId) > 0
-          ? Number(body?.checkpointResourceId)
+        Number.isInteger(resolvedBody.checkpointResourceId) &&
+        Number(resolvedBody.checkpointResourceId) > 0
+          ? Number(resolvedBody.checkpointResourceId)
           : null,
-      loraResourceIds: Array.isArray(body?.loraResourceIds)
-        ? [
-            ...new Set(
-              body.loraResourceIds
-                .map(Number)
-                .filter((id) => Number.isInteger(id) && id > 0),
-            ),
-          ]
-        : [],
-      checkpointName: body?.checkpoint?.trim() || null,
-      loraNames: body?.loraName?.trim() ? [body.loraName.trim()] : [],
+      loraResourceIds: resolvedLora.resourceIds,
+      checkpointName: resolvedBody.checkpoint?.trim() || null,
+      loraNames: resolvedLora.resourceName ? [resolvedLora.resourceName] : [],
     }
     if (
       provenanceResources.checkpointResourceId ||
@@ -308,7 +315,9 @@ function buildJobPayload(
       },
     }
   }
-  if (engine === 'ltx' || engine === 'wan') return buildVideoJobPayload(engine, ctx)
+  if (engine === 'ltx' || engine === 'wan') {
+    return buildVideoJobPayload(engine, ctx)
+  }
 
   if (engine === 'flux') {
     const { workflow } = buildFluxWorkflowFromRequest({

--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -37,7 +37,11 @@ export type LtxImageToVideoInput = {
   cfg?: number | null
   sampler?: string | null
   sigmas?: string | null
+  // Strength for LTX's required distilled acceleration LoRA.
   loraStrength?: number | null
+  // Optional user-selected Resource LoRA, applied after the required LTX LoRA.
+  styleLoraName?: string | null
+  styleLoraStrength?: number | null
   tileSize?: number | null
   tileOverlap?: number | null
   temporalSize?: number | null
@@ -110,7 +114,7 @@ export function buildLtxImageToVideoWorkflow(
         model: ['317', 0],
       },
       class_type: 'LoraLoaderModelOnly',
-      _meta: { title: 'Load LoRA' },
+      _meta: { title: 'Load Required LTX Distilled LoRA' },
     },
 
     // --- Prompt conditioning -----------------------------------------------
@@ -175,6 +179,21 @@ export function buildLtxImageToVideoWorkflow(
     },
   }
 
+  let sampledModelRef: [string, number] = ['293', 0]
+  const styleLoraName = input.styleLoraName?.trim()
+  if (styleLoraName) {
+    workflow['video_lora'] = {
+      inputs: {
+        lora_name: styleLoraName,
+        strength_model: input.styleLoraStrength ?? 1,
+        model: sampledModelRef,
+      },
+      class_type: 'LoraLoaderModelOnly',
+      _meta: { title: 'Load Selected LTX LoRA' },
+    }
+    sampledModelRef = ['video_lora', 0]
+  }
+
   // Node ids that feed the sampler. Default: straight off LTXVImgToVideo.
   let positiveRef: [string, number] = ['ltxv_i2v', 0]
   let negativeRef: [string, number] = ['ltxv_i2v', 1]
@@ -237,7 +256,7 @@ export function buildLtxImageToVideoWorkflow(
   workflow['315'] = {
     inputs: {
       cfg: input.cfg ?? LTX_DEFAULT_CFG,
-      model: ['293', 0],
+      model: sampledModelRef,
       positive: positiveRef,
       negative: negativeRef,
     },

--- a/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
@@ -40,6 +40,8 @@ export type WanImageToVideoInput = {
   cfg?: number | null
   sampler?: string | null
   scheduler?: string | null
+  loraName?: string | null
+  loraStrength?: number | null
   // Fraction of the total steps handled by the high-noise expert before the
   // low-noise expert takes over (0–1). Defaults to WAN_DEFAULT_BOUNDARY.
   boundary?: number | null
@@ -152,6 +154,32 @@ export function buildWanImageToVideoWorkflow(
     },
   }
 
+  let highModelRef: [string, number] = ['unet_high', 0]
+  let lowModelRef: [string, number] = ['unet_low', 0]
+  const loraName = input.loraName?.trim()
+  if (loraName) {
+    workflow['lora_high'] = {
+      inputs: {
+        lora_name: loraName,
+        strength_model: input.loraStrength ?? 1,
+        model: highModelRef,
+      },
+      class_type: 'LoraLoaderModelOnly',
+      _meta: { title: 'Load Selected WAN LoRA (High Noise)' },
+    }
+    workflow['lora_low'] = {
+      inputs: {
+        lora_name: loraName,
+        strength_model: input.loraStrength ?? 1,
+        model: lowModelRef,
+      },
+      class_type: 'LoraLoaderModelOnly',
+      _meta: { title: 'Load Selected WAN LoRA (Low Noise)' },
+    }
+    highModelRef = ['lora_high', 0]
+    lowModelRef = ['lora_low', 0]
+  }
+
   // WanImageToVideo emits conditioning + the seed latent from the start frame.
   // An optional end frame (WAN 2.2 first-last-frame) pins the final frame.
   const i2vInputs: Record<string, unknown> = {
@@ -194,7 +222,7 @@ export function buildWanImageToVideoWorkflow(
       start_at_step: 0,
       end_at_step: split,
       return_with_leftover_noise: 'enable',
-      model: ['unet_high', 0],
+      model: highModelRef,
       positive: ['wan_i2v', 0],
       negative: ['wan_i2v', 1],
       latent_image: ['wan_i2v', 2],
@@ -215,7 +243,7 @@ export function buildWanImageToVideoWorkflow(
       start_at_step: split,
       end_at_step: 10_000,
       return_with_leftover_noise: 'disable',
-      model: ['unet_low', 0],
+      model: lowModelRef,
       positive: ['wan_i2v', 0],
       negative: ['wan_i2v', 1],
       latent_image: ['sampler_high', 0],

--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -23,10 +23,18 @@ type LoraResourceRecord = {
 }
 
 const LORA_TYPES = [ResourceType.LORA, ResourceType.LYCORIS]
-const RESOURCE_RESOLVED_ENGINES = new Set(['kontext', 'krea2', 'flux2'])
+const RESOURCE_RESOLVED_ENGINES = new Set([
+  'kontext',
+  'krea2',
+  'flux2',
+  'ltx',
+  'wan',
+])
 
 function normalizeText(value: unknown): string {
-  return typeof value === 'string' ? value.trim().replaceAll('\\', '/').toLowerCase() : ''
+  return typeof value === 'string'
+    ? value.trim().replaceAll('\\', '/').toLowerCase()
+    : ''
 }
 
 function pathBasename(value: unknown): string {
@@ -79,10 +87,12 @@ function matchingResources(
   if (exactIdentity.length) return exactIdentity
 
   const exactSource = resources.filter((resource) =>
-    [resource.customUrl, resource.civitaiUrl, resource.huggingUrl].some((value) => {
-      const normalized = normalizeText(value)
-      return normalized === requested || normalized.endsWith(`/${requested}`)
-    }),
+    [resource.customUrl, resource.civitaiUrl, resource.huggingUrl].some(
+      (value) => {
+        const normalized = normalizeText(value)
+        return normalized === requested || normalized.endsWith(`/${requested}`)
+      },
+    ),
   )
   if (exactSource.length) return exactSource
 
@@ -125,6 +135,16 @@ function compatibilityRank(
   if (engine === 'krea2' || engine === 'flux2') {
     if (resource.supportedServer === SupportedServer.FLUX) return 30
     if (resource.supportedServer === SupportedServer.KONTEXT) return 20
+    if (resource.supportedServer === SupportedServer.GENERIC) return 10
+  }
+
+  if (engine === 'ltx') {
+    if (resource.supportedServer === SupportedServer.LTX) return 30
+    if (resource.supportedServer === SupportedServer.GENERIC) return 10
+  }
+
+  if (engine === 'wan') {
+    if (resource.supportedServer === SupportedServer.WAN) return 30
     if (resource.supportedServer === SupportedServer.GENERIC) return 10
   }
 
@@ -248,6 +268,16 @@ export async function resolveEnqueueLoraResource(input: {
         message: `LoRA "${requestedName}" does not resolve to an active Resource.`,
       })
     }
+  }
+
+  if (
+    (input.engine === 'ltx' || input.engine === 'wan') &&
+    compatibilityRank(resource, input.engine) === 0
+  ) {
+    throw createError({
+      statusCode: 409,
+      message: `LoRA Resource ${resource.id} is marked ${resource.supportedServer}, not ${input.engine.toUpperCase()}-compatible.`,
+    })
   }
 
   const localPath = String(resource.localPath || '').trim()

--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -1,0 +1,270 @@
+// /server/utils/artLoraResource.ts
+import { createError } from 'h3'
+import {
+  ResourceType,
+  SupportedServer,
+} from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+
+export type LoraAwareEnqueueBody = {
+  loraName?: string | null
+  loraResourceIds?: number[] | null
+} & Record<string, unknown>
+
+type LoraResourceRecord = {
+  id: number
+  name: string
+  customLabel: string | null
+  localPath: string | null
+  customUrl: string | null
+  civitaiUrl: string | null
+  huggingUrl: string | null
+  supportedServer: SupportedServer
+}
+
+const LORA_TYPES = [ResourceType.LORA, ResourceType.LYCORIS]
+const RESOURCE_RESOLVED_ENGINES = new Set(['kontext', 'krea2', 'flux2'])
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim().replaceAll('\\', '/').toLowerCase() : ''
+}
+
+function pathBasename(value: unknown): string {
+  const normalized = normalizeText(value).replace(/^\/+|\/+$/g, '')
+  return normalized.split('/').pop() || ''
+}
+
+function pathStem(value: unknown): string {
+  return pathBasename(value).replace(/\.(safetensors|ckpt|pt|bin)$/i, '')
+}
+
+function normalizeIds(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+  return [
+    ...new Set(
+      value
+        .map(Number)
+        .filter((id) => Number.isInteger(id) && id > 0),
+    ),
+  ]
+}
+
+function uniqueMatch(
+  resources: LoraResourceRecord[],
+  predicate: (resource: LoraResourceRecord) => boolean,
+): LoraResourceRecord | null {
+  const matches = resources.filter(predicate)
+  return matches.length === 1 ? matches[0]! : null
+}
+
+function matchingResources(
+  resources: LoraResourceRecord[],
+  requestedName: string,
+): LoraResourceRecord[] {
+  const requested = normalizeText(requestedName)
+  const requestedBase = pathBasename(requestedName)
+  const requestedStem = pathStem(requestedName)
+
+  const exactLocal = uniqueMatch(
+    resources,
+    (resource) => normalizeText(resource.localPath) === requested,
+  )
+  if (exactLocal) return [exactLocal]
+
+  const exactIdentity = resources.filter((resource) =>
+    [resource.name, resource.customLabel].some(
+      (value) => normalizeText(value) === requested,
+    ),
+  )
+  if (exactIdentity.length) return exactIdentity
+
+  const exactSource = resources.filter((resource) =>
+    [resource.customUrl, resource.civitaiUrl, resource.huggingUrl].some((value) => {
+      const normalized = normalizeText(value)
+      return normalized === requested || normalized.endsWith(`/${requested}`)
+    }),
+  )
+  if (exactSource.length) return exactSource
+
+  if (requestedBase) {
+    const basenameMatches = resources.filter(
+      (resource) => pathBasename(resource.localPath) === requestedBase,
+    )
+    if (basenameMatches.length) return basenameMatches
+  }
+
+  if (requestedStem) {
+    return resources.filter((resource) => {
+      const identities = [
+        pathStem(resource.localPath),
+        normalizeText(resource.name),
+        normalizeText(resource.customLabel),
+      ].filter(Boolean)
+      return identities.some(
+        (identity) =>
+          identity === requestedStem ||
+          identity.includes(requestedStem) ||
+          requestedStem.includes(identity),
+      )
+    })
+  }
+
+  return []
+}
+
+function compatibilityRank(
+  resource: LoraResourceRecord,
+  engine: string,
+): number {
+  if (engine === 'kontext') {
+    if (resource.supportedServer === SupportedServer.KONTEXT) return 30
+    if (resource.supportedServer === SupportedServer.FLUX) return 20
+    if (resource.supportedServer === SupportedServer.GENERIC) return 10
+  }
+
+  if (engine === 'krea2' || engine === 'flux2') {
+    if (resource.supportedServer === SupportedServer.FLUX) return 30
+    if (resource.supportedServer === SupportedServer.KONTEXT) return 20
+    if (resource.supportedServer === SupportedServer.GENERIC) return 10
+  }
+
+  return 0
+}
+
+function chooseCompatibleMatch(
+  resources: LoraResourceRecord[],
+  engine: string,
+  requestedName: string,
+): LoraResourceRecord | null {
+  const matches = matchingResources(resources, requestedName)
+  if (!matches.length) return null
+  if (matches.length === 1) return matches[0]!
+
+  const ranked = matches
+    .map((resource) => ({ resource, rank: compatibilityRank(resource, engine) }))
+    .sort((a, b) => b.rank - a.rank || a.resource.id - b.resource.id)
+
+  if (ranked.length > 1 && ranked[0]!.rank === ranked[1]!.rank) {
+    throw createError({
+      statusCode: 409,
+      message: `LoRA "${requestedName}" matches multiple Resources (${ranked
+        .map(({ resource }) => resource.id)
+        .join(', ')}). Select a Resource explicitly.`,
+    })
+  }
+
+  return ranked[0]!.resource
+}
+
+export async function resolveEnqueueLoraResource(input: {
+  body: LoraAwareEnqueueBody
+  engine: string
+  userId: number
+  isAdmin: boolean
+}): Promise<{
+  body: LoraAwareEnqueueBody
+  resourceIds: number[]
+  resourceName: string | null
+}> {
+  const resourceIds = normalizeIds(input.body.loraResourceIds)
+  const requestedName = String(input.body.loraName || '').trim()
+
+  if (!RESOURCE_RESOLVED_ENGINES.has(input.engine)) {
+    return {
+      body: input.body,
+      resourceIds,
+      resourceName: requestedName || null,
+    }
+  }
+
+  if (!resourceIds.length && !requestedName) {
+    return { body: input.body, resourceIds: [], resourceName: null }
+  }
+
+  if (resourceIds.length > 1) {
+    throw createError({
+      statusCode: 400,
+      message: `${input.engine} workflows currently support one LoRA Resource per job.`,
+    })
+  }
+
+  const visibility = input.isAdmin
+    ? {}
+    : {
+        OR: [{ isPublic: true }, { userId: input.userId }],
+      }
+
+  const select = {
+    id: true,
+    name: true,
+    customLabel: true,
+    localPath: true,
+    customUrl: true,
+    civitaiUrl: true,
+    huggingUrl: true,
+    supportedServer: true,
+  } as const
+
+  let resource: LoraResourceRecord | null = null
+
+  if (resourceIds.length) {
+    resource = await prisma.resource.findFirst({
+      where: {
+        AND: [
+          {
+            id: resourceIds[0],
+            isActive: true,
+            resourceType: { in: LORA_TYPES },
+          },
+          visibility,
+        ],
+      },
+      select,
+    })
+
+    if (!resource) {
+      throw createError({
+        statusCode: 404,
+        message: `LoRA Resource ${resourceIds[0]} was not found or is not accessible.`,
+      })
+    }
+  } else {
+    const resources = await prisma.resource.findMany({
+      where: {
+        AND: [
+          { isActive: true, resourceType: { in: LORA_TYPES } },
+          visibility,
+        ],
+      },
+      select,
+      orderBy: { id: 'asc' },
+    })
+
+    resource = chooseCompatibleMatch(resources, input.engine, requestedName)
+
+    if (!resource) {
+      throw createError({
+        statusCode: 409,
+        message: `LoRA "${requestedName}" does not resolve to an active Resource.`,
+      })
+    }
+  }
+
+  const localPath = String(resource.localPath || '').trim()
+  if (!localPath) {
+    throw createError({
+      statusCode: 409,
+      message: `LoRA Resource ${resource.id} does not have a localPath for ComfyUI.`,
+    })
+  }
+
+  return {
+    body: {
+      ...input.body,
+      loraName: localPath,
+      loraResourceIds: [resource.id],
+    },
+    resourceIds: [resource.id],
+    resourceName: localPath,
+  }
+}

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -28,6 +28,8 @@ export interface GenerateVideoParams {
   width?: number | null
   height?: number | null
   seed?: number | null
+  loraResourceIds?: number[]
+  loraStrength?: number | null
   isPublic?: boolean
   isMature?: boolean
   designer?: string | null
@@ -107,6 +109,10 @@ export const useVideoStore = defineStore('videoStore', () => {
       width: params.width ?? undefined,
       height: params.height ?? undefined,
       seed: params.seed ?? undefined,
+      loraResourceIds: params.loraResourceIds?.length
+        ? params.loraResourceIds
+        : undefined,
+      loraStrength: params.loraStrength ?? undefined,
       isPublic: params.isPublic ?? true,
       isMature: params.isMature ?? false,
       designer: params.designer ?? undefined,


### PR DESCRIPTION
## What changed

### Resource-authoritative LoRA resolution

- Resolve queued Kontext, Krea2, Flux2, LTX, and WAN LoRAs through active accessible `Resource` rows before building the Comfy workflow.
- Treat an explicit `loraResourceIds` value as authoritative and replace any stale caller-provided `loraName` with that Resource's exact `localPath`.
- For legacy callers that only send a name/path, resolve against Resource `localPath`, name, label, source URLs, or a unique basename/stem match.
- Reject inaccessible, inactive, ambiguous, pathless, or engine-incompatible Resource selections before Comfy receives an invalid workflow.
- Preserve the resolved Resource ID and exact local path in ArtJob provenance.

### Video generator LoRAs

- Add an optional single-select LoRA picker to `/video-generator`.
- Filter the picker to Resources marked for the active `LTX` or `WAN` engine, plus `GENERIC` Resources.
- Display all unique preview sources already present on the Resource: `previewImageUrl`, `imagePath`, `MediaPath`, and linked preview `ArtImage` paths.
- Add a -2 to 2 LoRA strength control and send the selected Resource ID through the video store.
- Apply a selected LTX LoRA after the required distilled acceleration LoRA.
- Apply a selected WAN LoRA to both the high-noise and low-noise expert models.
- Record LoRA presence and strength in the video payload while retaining normal Resource provenance.

## Root cause

The enqueue route previously built LoRA loader nodes from the caller's raw `loraName`, then attached `loraResourceIds` only as provenance after the graph already existed. Video workflows did not accept a selected Resource LoRA at all. The UI could therefore identify a Resource while Comfy still received a stale path, and WAN/LTX had no Resource-backed picker or graph wiring.

## Impact

- The Resource database is now the source of truth for Comfy LoRA filenames across the supported image and video engines.
- Existing WAN- and LTX-compatible Resource rows can be selected directly in the video generator.
- Resource preview imagery is reused instead of generating or maintaining a separate LoRA-thumbnail catalog.
- Invalid catalog relationships fail with a useful API error rather than a delayed Comfy HTTP 400.

## Validation

- TypeScript Type Check: passed.
- Contract Tests: passed.
- API Client Follow-ups, Facet Catalog, Narrative Primitives, and Storymaker Studio contracts: passed.
