### PR TITLE
ai-art-academy/t-010: accessibility polish on Academy lesson UI

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -47,7 +47,7 @@
           v-else
           class="flex min-h-40 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6 text-center"
         >
-          <span class="text-3xl">🏛️</span>
+          <span class="text-3xl" aria-hidden="true">🏛️</span>
           <p class="text-sm font-semibold text-base-content/60">
             Select a style to see its story
           </p>

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -6,7 +6,7 @@
     <header class="flex flex-wrap items-start justify-between gap-2">
       <div class="flex min-w-0 flex-col gap-1">
         <div class="flex flex-wrap items-center gap-2">
-          <span class="text-2xl leading-none">🏛️</span>
+          <span class="text-2xl leading-none" aria-hidden="true">🏛️</span>
           <h3 class="text-lg font-black text-base-content">
             {{ lesson.name }}
           </h3>
@@ -29,6 +29,7 @@
         type="button"
         class="btn btn-circle btn-ghost btn-sm"
         title="Close lesson"
+        aria-label="Close lesson"
         @click="emit('close')"
       >
         <Icon name="mdi:close" class="h-4 w-4" />

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -61,7 +61,7 @@
           :aria-controls="`academy-style-detail-${style.slug}`"
           @click="expandedSlug = style.slug"
         >
-          <span class="text-xl leading-none">🏛️</span>
+          <span class="text-xl leading-none" aria-hidden="true">🏛️</span>
           <span class="flex min-w-0 flex-1 flex-col">
             <span class="flex flex-wrap items-baseline gap-2">
               <span


### PR DESCRIPTION
## What changed
- `components/academy/academy-style-detail.vue` — decorative 🏛️ emoji now has `aria-hidden="true"`; the icon-only close button now has an explicit `aria-label="Close lesson"` alongside its existing `title`.
- `components/academy/academy-timeline.vue` — same `aria-hidden="true"` fix on its 🏛️ emoji.
- `components/academy/academy-remix.vue` — same `aria-hidden="true"` fix on its empty-state 🏛️ emoji.

`academy-styles-browser.vue` already had `aria-hidden="true"` on its own copy of the same emoji; this brings the other three call sites in line with that existing, correct pattern instead of introducing a new one.

## Why
Screen readers were announcing "classical building" on three of the four occurrences of a purely decorative placeholder icon, and the reusable lesson-detail close button relied on `title` alone rather than an explicit `aria-label`.

## Verification
- `npx eslint components/academy/academy-style-detail.vue components/academy/academy-timeline.vue components/academy/academy-remix.vue` — clean
- `npx prettier --check` on the same three files — clean
- `npm run test` (vue-tsc --noEmit) — exit 0
- `node utils/scripts/verifyAcademyStyleDetailCallers.ts` — the caller-list contract for `academy-style-detail.vue` still verifies (3 callers, unchanged)

## Stakes
reversible

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01SXG7cKKL1Cv9F2efVfKgN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXG7cKKL1Cv9F2efVfKgN4)_