### PR TITLE
coloring: build ledger-backed production studio

### DIFF
--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -1,11 +1,4 @@
 <!-- /components/coloring/coloring-book-page.vue -->
-<!--
-  Public front page for the Coloring Book project. Wraps the shared
-  <project-front-page> shell and drops a five-mode studio into the interactive
-  slot: Color (the existing engine), Galleries (finished pages), Generate (make
-  more color / black-and-white line art), Proposals (pitch new books), and
-  Prompts (draft the prompts that feed generation).
--->
 <template>
   <ProjectFrontPage
     slug="coloring-book"
@@ -13,175 +6,13 @@
     :show-deliverables="false"
   >
     <template #interactive>
-      <section
-        class="rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm"
-      >
-        <!-- Studio sub-nav -->
-        <div role="tablist" class="tabs tabs-boxed mb-4 flex-wrap">
-          <button
-            v-for="mode in modes"
-            :key="mode.key"
-            type="button"
-            role="tab"
-            class="tab gap-1"
-            :class="activeMode === mode.key ? 'tab-active' : ''"
-            @click="activeMode = mode.key"
-          >
-            <Icon :name="mode.icon" class="size-4" />
-            {{ mode.label }}
-          </button>
-        </div>
-
-        <!-- COLOR: the existing engine -->
-        <div v-show="activeMode === 'color'">
-          <coloring-book-manager />
-        </div>
-
-        <!-- GALLERIES: finished / candidate pages -->
-        <div v-if="activeMode === 'galleries'" class="space-y-4">
-          <p class="text-sm text-base-content/60">
-            Finished pages and generated candidates. Pick one and it opens in
-            the Color studio.
-          </p>
-          <ProjectGalleryStrip
-            collection-label="coloring-book"
-            title="Coloring pages"
-          />
-          <art-gallery
-            class="min-h-[24rem]"
-            variant="dashboard"
-            :show-header="false"
-            :show-selected-panel="false"
-          />
-        </div>
-
-        <!-- GENERATE: more color or line art -->
-        <div v-if="activeMode === 'generate'" class="space-y-4">
-          <div class="grid gap-4 sm:grid-cols-2">
-            <div
-              class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/50 p-4"
-            >
-              <div class="flex items-center gap-2">
-                <Icon
-                  name="kind-icon:pencil"
-                  class="size-5 text-base-content/70"
-                />
-                <h4 class="font-black">Black &amp; white line art</h4>
-              </div>
-              <p class="text-xs text-base-content/60">
-                Clean, closed outlines ready to color. Describe a subject and
-                add it to the book.
-              </p>
-              <input
-                v-model="lineSubject"
-                type="text"
-                placeholder="e.g. a friendly robot watering a garden"
-                class="input input-bordered input-sm rounded-xl"
-              />
-              <generate-button
-                label="Generate line art"
-                busy-label="Drawing outlines..."
-                icon="kind-icon:pencil"
-                :overrides="lineArtOverrides"
-                @generated="onGenerated"
-              />
-            </div>
-
-            <div
-              class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/50 p-4"
-            >
-              <div class="flex items-center gap-2">
-                <Icon name="kind-icon:palette" class="size-5 text-primary" />
-                <h4 class="font-black">Full-color reference</h4>
-              </div>
-              <p class="text-xs text-base-content/60">
-                A colored version to guide palette choices, or a finished piece
-                for the gallery.
-              </p>
-              <input
-                v-model="colorSubject"
-                type="text"
-                placeholder="e.g. the same robot, richly colored"
-                class="input input-bordered input-sm rounded-xl"
-              />
-              <generate-button
-                label="Generate color art"
-                busy-label="Mixing colors..."
-                icon="kind-icon:palette"
-                :overrides="colorOverrides"
-                @generated="onGenerated"
-              />
-            </div>
-          </div>
-          <p class="text-xs text-base-content/40">
-            Generated images go to your art gallery and can be pulled into a
-            book.
-          </p>
-        </div>
-
-        <!-- PROPOSALS -->
-        <ProjectPitchBoard
-          v-if="activeMode === 'proposals'"
-          slug="coloring-book"
-          noun="proposal"
-          title="Proposed books &amp; pitches"
-          icon="kind-icon:book"
-          body-placeholder="Pitch a themed coloring book — the concept, the vibe, why it sings."
-          empty-text="No book pitches yet. Propose the next set."
-        />
-
-        <!-- PROMPTS -->
-        <ProjectPitchBoard
-          v-if="activeMode === 'prompts'"
-          slug="coloring-book"
-          noun="prompt"
-          title="Prompt drafts"
-          icon="kind-icon:prompt"
-          body-placeholder="Draft a generation prompt (subject, style, 'thick clean outlines, no shading')."
-          empty-text="No prompt drafts yet. Sketch one out."
-        />
-      </section>
+      <coloring-book-studio />
     </template>
   </ProjectFrontPage>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
 import type { ProjectFrontConfig } from '@/components/conductor/projectFront'
-
-type Mode = 'color' | 'galleries' | 'generate' | 'proposals' | 'prompts'
-
-const modes: { key: Mode; label: string; icon: string }[] = [
-  { key: 'color', label: 'Color', icon: 'kind-icon:paintbrush' },
-  { key: 'galleries', label: 'Galleries', icon: 'kind-icon:image' },
-  { key: 'generate', label: 'Generate', icon: 'kind-icon:sparkles' },
-  { key: 'proposals', label: 'Proposals', icon: 'kind-icon:book' },
-  { key: 'prompts', label: 'Prompts', icon: 'kind-icon:prompt' },
-]
-const activeMode = ref<Mode>('color')
-
-const lineSubject = ref('')
-const colorSubject = ref('')
-
-const LINE_STYLE =
-  'coloring book page, thick clean black outlines, line art, white background, no shading, no color, high contrast'
-const COLOR_STYLE = 'richly colored illustration, storybook art, soft shading'
-
-const lineArtOverrides = computed(() => ({
-  promptString: `${lineSubject.value || 'a whimsical scene'}, ${LINE_STYLE}`,
-  negativePrompt: 'color, grayscale, shading, gradient, photo, realistic',
-  collectionLabel: 'coloring-book',
-}))
-const colorOverrides = computed(() => ({
-  promptString: `${colorSubject.value || 'a whimsical scene'}, ${COLOR_STYLE}`,
-  negativePrompt: 'line art, sketch, monochrome, lowres',
-  collectionLabel: 'coloring-book',
-}))
-
-function onGenerated() {
-  // Nudge the user toward the freshly-filled gallery.
-  activeMode.value = 'galleries'
-}
 
 const config: ProjectFrontConfig = {
   slug: 'coloring-book',
@@ -189,31 +20,33 @@ const config: ProjectFrontConfig = {
   channelKey: 'art',
   tabKey: 'coloring',
   icon: 'kind-icon:paintbrush',
-  tagline: 'Color AI-generated pages, or conjure a whole new book.',
+  tagline: 'Build, review, pair, and color three living books.',
   description:
-    'A living coloring book. Open a page and tap regions to fill them, browse finished and candidate art, generate fresh line art or full-color references, and pitch entire themed books — Kind Robots, Monster Recast, and whatever the swarm dreams up next. Your palette saves itself as you go.',
+    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Review all 36 proposal slots in each book, edit the canonical Conductor prompts, compare current color and black-and-white versions, request targeted candidates or revisions, inspect queue failures, and preview finished pages in the shared coloring engine.',
   sections: [
     {
-      key: 'color',
-      title: 'Color anything',
-      body: 'Region-fill and flood modes, a savable palette, undo, and export to PNG or JSON. Walk away mid-masterpiece — it remembers.',
-      icon: 'kind-icon:paintbrush',
+      key: 'production',
+      title: 'One canonical production view',
+      body: 'The front end now reads the same proposal ledgers and color queue used by Conductor instead of maintaining unrelated prompt cards and gallery generations.',
+      icon: 'kind-icon:book',
     },
     {
-      key: 'generate',
-      title: 'Make more art',
-      body: 'Generate clean black-and-white line art to color, or full-color references, straight into your gallery via the shared art engine.',
+      key: 'review',
+      title: 'Prompt, render, and review by page',
+      body: 'Select any proposal ID, inspect its strongest color and line-art candidates, save the real production prompt, and send a proposal-targeted render request through the semantic-gated pipeline.',
       icon: 'kind-icon:sparkles',
     },
   ],
   deliverables: {
     done: [
-      'Shared coloring engine (region + flood fill, undo, palette, export)',
-      'Sampler and Cozy Corner sets live; Mural runs on the same engine',
+      'Shared coloring engine with region fill, flood fill, palette, undo, and export',
+      'Sampler and Cozy Corner end-user sets',
+      'Three canonical 36-proposal production ledgers in Conductor',
     ],
     next: [
-      'Generated Kind Robots and Monster Recast books',
-      'Print-on-demand hand-off to the storefront',
+      'Proposal-level acceptance and final-pair promotion controls',
+      'Targeted black-and-white conversion after color-master approval',
+      'Print-ready package and storefront hand-off',
     ],
   },
 }

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -1,0 +1,576 @@
+<template>
+  <section class="flex flex-col gap-5">
+    <div
+      class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm lg:flex-row lg:items-center lg:justify-between"
+    >
+      <div>
+        <div class="flex items-center gap-2">
+          <icon name="kind-icon:book" class="size-6 text-primary" />
+          <h3 class="text-2xl font-black">Coloring Book Production Studio</h3>
+        </div>
+        <p class="mt-1 max-w-3xl text-sm text-base-content/60">
+          The three canonical Conductor books, their 36 proposal slots, production
+          prompts, current color masters, black-and-white pairs, queue state, and
+          revision requests in one place.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        class="btn btn-outline rounded-2xl"
+        :disabled="studio.loading"
+        @click="studio.fetchStudio()"
+      >
+        <span v-if="studio.loading" class="loading loading-spinner loading-sm" />
+        <icon v-else name="kind-icon:refresh" class="size-5" />
+        Refresh Conductor
+      </button>
+    </div>
+
+    <div
+      v-if="studio.error"
+      class="alert alert-error rounded-2xl"
+      role="alert"
+    >
+      <icon name="kind-icon:alert" class="size-5" />
+      <span>{{ studio.error }}</span>
+      <button class="btn btn-ghost btn-sm" type="button" @click="studio.clearNotice()">
+        Dismiss
+      </button>
+    </div>
+
+    <div
+      v-if="studio.message"
+      class="alert alert-success rounded-2xl"
+      role="status"
+    >
+      <icon name="kind-icon:check" class="size-5" />
+      <span>{{ studio.message }}</span>
+      <button class="btn btn-ghost btn-sm" type="button" @click="studio.clearNotice()">
+        Dismiss
+      </button>
+    </div>
+
+    <div
+      v-if="studio.loading && !studio.books.length"
+      class="flex min-h-80 items-center justify-center rounded-3xl border border-base-300 bg-base-100"
+    >
+      <span class="loading loading-dots loading-lg" />
+    </div>
+
+    <template v-else>
+      <div class="grid gap-3 lg:grid-cols-3">
+        <button
+          v-for="book in studio.books"
+          :key="book.slug"
+          type="button"
+          class="flex flex-col gap-3 rounded-3xl border p-4 text-left transition hover:-translate-y-0.5 hover:shadow-md"
+          :class="
+            studio.selectedBookSlug === book.slug
+              ? 'border-primary bg-primary/10 shadow-sm'
+              : 'border-base-300 bg-base-100'
+          "
+          @click="studio.selectBook(book.slug)"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                Book {{ book.order }}
+              </p>
+              <h4 class="text-xl font-black">{{ book.title }}</h4>
+            </div>
+            <span class="badge badge-outline rounded-2xl">{{ book.status }}</span>
+          </div>
+
+          <progress
+            class="progress progress-primary w-full"
+            :value="book.counts.finalPairs"
+            :max="book.targetProposals"
+          />
+
+          <div class="grid grid-cols-4 gap-2 text-center text-xs">
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.prompts }}</strong>
+              prompts
+            </div>
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.rendered }}</strong>
+              rendered
+            </div>
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.acceptedPairs }}</strong>
+              accepted
+            </div>
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.finalPairs }}</strong>
+              final
+            </div>
+          </div>
+        </button>
+      </div>
+
+      <div role="tablist" class="tabs tabs-boxed flex-wrap rounded-2xl bg-base-200 p-1">
+        <button
+          v-for="mode in modes"
+          :key="mode.key"
+          type="button"
+          role="tab"
+          class="tab gap-2 rounded-xl"
+          :class="activeMode === mode.key ? 'tab-active' : ''"
+          @click="activeMode = mode.key"
+        >
+          <icon :name="mode.icon" class="size-4" />
+          {{ mode.label }}
+        </button>
+      </div>
+
+      <div v-if="activeMode === 'books'" class="grid gap-4 lg:grid-cols-3">
+        <article
+          v-for="book in studio.books"
+          :key="book.slug"
+          class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                {{ book.slug }}
+              </p>
+              <h4 class="text-2xl font-black">{{ book.title }}</h4>
+            </div>
+            <span class="badge badge-primary rounded-2xl">
+              {{ book.counts.total }}/{{ book.targetProposals }} slots
+            </span>
+          </div>
+
+          <dl class="grid grid-cols-2 gap-3 text-sm">
+            <div class="rounded-2xl bg-base-200 p-3">
+              <dt class="text-base-content/50">Color queue</dt>
+              <dd class="text-lg font-black">{{ book.counts.pending }} pending</dd>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3">
+              <dt class="text-base-content/50">Needs attention</dt>
+              <dd class="text-lg font-black">
+                {{ book.counts.needsReview + book.counts.blocked }}
+              </dd>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3">
+              <dt class="text-base-content/50">Accepted color</dt>
+              <dd class="text-lg font-black">{{ book.counts.acceptedColor }}</dd>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3">
+              <dt class="text-base-content/50">Final pairs</dt>
+              <dd class="text-lg font-black">{{ book.counts.finalPairs }}</dd>
+            </div>
+          </dl>
+
+          <button
+            type="button"
+            class="btn btn-primary mt-auto rounded-2xl"
+            @click="openBook(book.slug)"
+          >
+            <icon name="kind-icon:gallery" class="size-5" />
+            Open 36-page ledger
+          </button>
+        </article>
+      </div>
+
+      <div v-if="activeMode === 'pages'" class="flex flex-col gap-4">
+        <div
+          class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <h4 class="text-xl font-black">{{ studio.selectedBook?.title }}</h4>
+            <p class="text-sm text-base-content/50">
+              Every proposal slot, with its strongest current color and line-art version.
+            </p>
+          </div>
+          <select
+            v-model="pageFilter"
+            class="select select-bordered rounded-2xl"
+            aria-label="Filter coloring-book proposals"
+          >
+            <option value="all">All proposals</option>
+            <option value="pending">Pending color</option>
+            <option value="rendered">Rendered candidates</option>
+            <option value="review">Needs review</option>
+            <option value="paired">Accepted or final pairs</option>
+          </select>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <button
+            v-for="proposal in filteredProposals"
+            :key="proposal.id"
+            type="button"
+            class="overflow-hidden rounded-3xl border bg-base-100 text-left transition hover:-translate-y-0.5 hover:shadow-lg"
+            :class="
+              studio.selectedProposalId === proposal.id
+                ? 'border-primary ring-2 ring-primary/20'
+                : 'border-base-300'
+            "
+            @click="openProposal(proposal.id)"
+          >
+            <div class="grid aspect-[4/3] grid-cols-2 bg-base-200">
+              <div class="relative border-r border-base-300">
+                <img
+                  v-if="proposal.colorUrl"
+                  :src="proposal.colorUrl"
+                  :alt="`${proposal.title} color candidate`"
+                  class="size-full object-cover"
+                  loading="lazy"
+                />
+                <div v-else class="flex size-full items-center justify-center text-base-content/30">
+                  <icon name="kind-icon:palette" class="size-10" />
+                </div>
+                <span class="badge badge-sm absolute bottom-2 left-2 rounded-2xl">Color</span>
+              </div>
+              <div class="relative">
+                <img
+                  v-if="proposal.bwUrl"
+                  :src="proposal.bwUrl"
+                  :alt="`${proposal.title} black-and-white page`"
+                  class="size-full object-cover grayscale"
+                  loading="lazy"
+                />
+                <div v-else class="flex size-full items-center justify-center text-base-content/30">
+                  <icon name="kind-icon:pencil" class="size-10" />
+                </div>
+                <span class="badge badge-sm absolute bottom-2 left-2 rounded-2xl">B&amp;W</span>
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-2 p-4">
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                    Slot {{ proposal.slot }} · {{ proposal.id }}
+                  </p>
+                  <h5 class="font-black">{{ proposal.title }}</h5>
+                </div>
+                <span class="badge badge-sm rounded-2xl" :class="statusBadge(proposal.queue.status)">
+                  {{ proposal.queue.status }}
+                </span>
+              </div>
+              <p class="line-clamp-2 text-xs leading-relaxed text-base-content/55">
+                {{ proposal.prompt || 'No production prompt yet.' }}
+              </p>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-if="activeMode === 'editor' && studio.selectedProposal"
+        class="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(22rem,0.9fr)]"
+      >
+        <div class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                {{ studio.selectedBook?.title }} · Slot {{ studio.selectedProposal.slot }} ·
+                {{ studio.selectedProposal.id }}
+              </p>
+              <h4 class="text-2xl font-black">{{ studio.selectedProposal.title }}</h4>
+            </div>
+            <span
+              class="badge rounded-2xl"
+              :class="statusBadge(studio.selectedProposal.queue.status)"
+            >
+              {{ studio.selectedProposal.queue.status }}
+            </span>
+          </div>
+
+          <div class="grid gap-4 sm:grid-cols-2">
+            <figure class="overflow-hidden rounded-3xl border border-base-300 bg-base-200">
+              <div class="aspect-[2/3]">
+                <img
+                  v-if="studio.selectedProposal.colorUrl"
+                  :src="studio.selectedProposal.colorUrl"
+                  :alt="`${studio.selectedProposal.title} current color version`"
+                  class="size-full object-contain"
+                />
+                <div class="flex size-full flex-col items-center justify-center gap-2 text-base-content/35">
+                  <icon name="kind-icon:palette" class="size-14" />
+                  <span>No color candidate</span>
+                </div>
+              </div>
+              <figcaption class="border-t border-base-300 p-3 text-center font-black">
+                Current color master
+              </figcaption>
+            </figure>
+
+            <figure class="overflow-hidden rounded-3xl border border-base-300 bg-base-200">
+              <div class="aspect-[2/3]">
+                <img
+                  v-if="studio.selectedProposal.bwUrl"
+                  :src="studio.selectedProposal.bwUrl"
+                  :alt="`${studio.selectedProposal.title} current black-and-white version`"
+                  class="size-full object-contain grayscale"
+                />
+                <div class="flex size-full flex-col items-center justify-center gap-2 text-base-content/35">
+                  <icon name="kind-icon:pencil" class="size-14" />
+                  <span>No line-art pair</span>
+                </div>
+              </div>
+              <figcaption class="border-t border-base-300 p-3 text-center font-black">
+                Current black &amp; white
+              </figcaption>
+            </figure>
+          </div>
+
+          <div class="grid gap-3 sm:grid-cols-3">
+            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+              <span class="block text-xs text-base-content/45">Semantic score</span>
+              <strong>{{ studio.selectedProposal.queue.semanticScore ?? '—' }}</strong>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+              <span class="block text-xs text-base-content/45">Render engine</span>
+              <strong>{{ studio.selectedProposal.queue.renderEngine ?? '—' }}</strong>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+              <span class="block text-xs text-base-content/45">Archived revisions</span>
+              <strong>{{ studio.selectedProposal.queue.revisionCount }}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
+          <div>
+            <h4 class="text-xl font-black">Canonical production prompt</h4>
+            <p class="mt-1 break-all text-xs text-base-content/45">
+              {{ studio.selectedProposal.promptSourcePath }}
+            </p>
+            <p v-if="studio.selectedProposal.promptRef" class="mt-1 break-all text-xs text-info">
+              Queue reference: {{ studio.selectedProposal.promptRef }}
+            </p>
+          </div>
+
+          <textarea
+            v-model="promptDraft"
+            class="textarea textarea-bordered min-h-64 w-full rounded-2xl text-sm leading-relaxed"
+            :readonly="!userStore.isAdmin"
+            :placeholder="`Describe ${studio.selectedProposal.title} as a production-ready color master...`"
+          />
+
+          <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45">
+            <span>{{ promptDraft.length }} characters</span>
+            <span v-if="promptDirty" class="badge badge-warning badge-sm rounded-2xl">
+              Unsaved changes
+            </span>
+          </div>
+
+          <button
+            v-if="userStore.isAdmin"
+            type="button"
+            class="btn btn-primary rounded-2xl"
+            :disabled="!promptDirty || studio.savingPrompt || promptDraft.trim().length < 20"
+            @click="savePrompt"
+          >
+            <span v-if="studio.savingPrompt" class="loading loading-spinner loading-sm" />
+            <icon v-else name="kind-icon:save" class="size-5" />
+            Save canonical prompt
+          </button>
+
+          <div class="divider my-0">Render request</div>
+
+          <input
+            v-model="requestNote"
+            type="text"
+            class="input input-bordered rounded-2xl"
+            placeholder="Optional revision direction"
+            :readonly="!userStore.isAdmin"
+          />
+
+          <button
+            v-if="userStore.isAdmin"
+            type="button"
+            class="btn rounded-2xl"
+            :class="requestNeedsForce ? 'btn-secondary' : 'btn-accent'"
+            :disabled="studio.requestingRender || promptDirty"
+            @click="requestRender"
+          >
+            <span v-if="studio.requestingRender" class="loading loading-spinner loading-sm" />
+            <icon v-else name="kind-icon:sparkles" class="size-5" />
+            {{ requestNeedsForce ? 'Archive current and request revision' : 'Request this color candidate' }}
+          </button>
+
+          <div v-if="!userStore.isAdmin" class="alert rounded-2xl bg-base-200 text-sm">
+            <icon name="kind-icon:lock" class="size-5" />
+            <span>Production edits and render requests are admin-only.</span>
+          </div>
+
+          <div class="rounded-2xl border border-info/30 bg-info/10 p-3 text-xs leading-relaxed">
+            Black-and-white generation intentionally waits for an accepted color composition.
+            The studio shows existing pairs now; a proposal-targeted B&amp;W conversion action belongs
+            in the next pipeline slice rather than faking it with unrelated generic generation.
+          </div>
+        </div>
+      </div>
+
+      <div v-if="activeMode === 'queue'" class="flex flex-col gap-4">
+        <div class="rounded-3xl border border-base-300 bg-base-100 p-5">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h4 class="text-xl font-black">Queue &amp; review problems</h4>
+              <p class="text-sm text-base-content/50">
+                Semantic gate failures and proposals that exhausted automatic retries.
+              </p>
+            </div>
+            <span class="badge badge-warning rounded-2xl">
+              {{ studio.queueProblems.length }} need attention
+            </span>
+          </div>
+        </div>
+
+        <div
+          v-if="!studio.queueProblems.length"
+          class="rounded-3xl border border-success/30 bg-success/10 p-8 text-center"
+        >
+          <icon name="kind-icon:check" class="mx-auto size-10 text-success" />
+          <p class="mt-2 font-black">No queue problems currently reported.</p>
+        </div>
+
+        <button
+          v-for="problem in studio.queueProblems"
+          :key="`${problem.bookSlug}:${problem.proposal.id}`"
+          type="button"
+          class="flex flex-col gap-3 rounded-3xl border border-warning/40 bg-warning/10 p-4 text-left sm:flex-row sm:items-start sm:justify-between"
+          @click="openProblem(problem.bookSlug, problem.proposal.id)"
+        >
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest text-base-content/45">
+              {{ problem.bookTitle }} · {{ problem.proposal.id }}
+            </p>
+            <h5 class="font-black">{{ problem.proposal.title }}</h5>
+            <p class="mt-1 max-w-4xl text-sm text-base-content/65">
+              {{ problem.proposal.queue.semanticGateError || 'Automatic attempts exhausted; human review required.' }}
+            </p>
+          </div>
+          <div class="flex shrink-0 flex-wrap gap-2">
+            <span class="badge rounded-2xl" :class="statusBadge(problem.proposal.queue.status)">
+              {{ problem.proposal.queue.status }}
+            </span>
+            <span class="badge badge-outline rounded-2xl">
+              {{ problem.proposal.queue.semanticAttempts }} attempts
+            </span>
+          </div>
+        </button>
+      </div>
+
+      <div v-if="activeMode === 'color'" class="rounded-3xl border border-base-300 bg-base-100 p-4">
+        <div class="mb-4">
+          <h4 class="text-xl font-black">End-user coloring preview</h4>
+          <p class="text-sm text-base-content/50">
+            The existing coloring engine remains available here, but it is no longer pretending
+            to be the production manager.
+          </p>
+        </div>
+        <coloring-book-manager />
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+import { useUserStore } from '@/stores/userStore'
+
+type StudioMode = 'books' | 'pages' | 'editor' | 'queue' | 'color'
+type PageFilter = 'all' | 'pending' | 'rendered' | 'review' | 'paired'
+
+const studio = useColoringBookStudioStore()
+const userStore = useUserStore()
+const activeMode = ref<StudioMode>('books')
+const pageFilter = ref<PageFilter>('all')
+const promptDraft = ref('')
+const requestNote = ref('')
+
+const modes: { key: StudioMode; label: string; icon: string }[] = [
+  { key: 'books', label: 'Books', icon: 'kind-icon:book' },
+  { key: 'pages', label: 'Pages', icon: 'kind-icon:gallery' },
+  { key: 'editor', label: 'Prompt & Render', icon: 'kind-icon:prompt' },
+  { key: 'queue', label: 'Queue', icon: 'kind-icon:activity' },
+  { key: 'color', label: 'Color Preview', icon: 'kind-icon:paintbrush' },
+]
+
+const filteredProposals = computed(() => {
+  const proposals = studio.selectedBook?.proposals ?? []
+  if (pageFilter.value === 'pending') {
+    return proposals.filter((proposal) => proposal.queue.status === 'pending')
+  }
+  if (pageFilter.value === 'rendered') {
+    return proposals.filter((proposal) => Boolean(proposal.colorUrl))
+  }
+  if (pageFilter.value === 'review') {
+    return proposals.filter(
+      (proposal) =>
+        proposal.queue.status === 'needs_review' ||
+        Boolean(proposal.queue.semanticGateError),
+    )
+  }
+  if (pageFilter.value === 'paired') {
+    return proposals.filter(
+      (proposal) =>
+        Boolean(proposal.accepted.color && proposal.accepted.bw) ||
+        Boolean(proposal.final.color && proposal.final.bw),
+    )
+  }
+  return proposals
+})
+
+const promptDirty = computed(
+  () => promptDraft.value.trim() !== (studio.selectedProposal?.prompt ?? '').trim(),
+)
+
+const requestNeedsForce = computed(() => {
+  const proposal = studio.selectedProposal
+  if (!proposal) return false
+  return proposal.queue.status !== 'pending' || Boolean(proposal.colorUrl)
+})
+
+watch(
+  () => [studio.selectedProposal?.id, studio.selectedProposal?.prompt] as const,
+  () => {
+    promptDraft.value = studio.selectedProposal?.prompt ?? ''
+    requestNote.value = ''
+  },
+  { immediate: true },
+)
+
+onMounted(async () => {
+  if (!studio.books.length) await studio.fetchStudio()
+})
+
+function statusBadge(status: string): string {
+  if (status === 'done' || status === 'approved') return 'badge-success'
+  if (status === 'pending' || status === 'running') return 'badge-info'
+  if (status === 'needs_review') return 'badge-warning'
+  if (status === 'failed' || status === 'cancelled') return 'badge-error'
+  return 'badge-ghost'
+}
+
+function openBook(bookSlug: string): void {
+  studio.selectBook(bookSlug)
+  activeMode.value = 'pages'
+}
+
+function openProposal(proposalId: string): void {
+  studio.selectProposal(proposalId)
+  activeMode.value = 'editor'
+}
+
+function openProblem(bookSlug: string, proposalId: string): void {
+  studio.selectBook(bookSlug)
+  studio.selectProposal(proposalId)
+  activeMode.value = 'editor'
+}
+
+async function savePrompt(): Promise<void> {
+  await studio.savePrompt(promptDraft.value)
+}
+
+async function requestRender(): Promise<void> {
+  await studio.requestColorRender(requestNeedsForce.value, requestNote.value)
+}
+</script>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -9,11 +9,11 @@
           <h3 class="text-2xl font-black">Coloring Book Production Studio</h3>
         </div>
         <p class="mt-1 max-w-3xl text-sm text-base-content/60">
-          Three canonical books, 108 proposal slots, real Conductor prompts, paired
-          art, queue state, and targeted revision requests. Finally, the front end
-          knows what the backend is talking about.
+          Three canonical books, 108 proposal slots, real Conductor prompts,
+          paired art, queue state, and targeted revision requests.
         </p>
       </div>
+
       <button
         type="button"
         class="btn btn-outline rounded-2xl"
@@ -29,15 +29,27 @@
     <div v-if="studio.error" class="alert alert-error rounded-2xl" role="alert">
       <icon name="kind-icon:alert" class="size-5" />
       <span>{{ studio.error }}</span>
-      <button type="button" class="btn btn-ghost btn-sm" @click="studio.clearNotice()">
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm"
+        @click="studio.clearNotice()"
+      >
         Dismiss
       </button>
     </div>
 
-    <div v-if="studio.message" class="alert alert-success rounded-2xl" role="status">
+    <div
+      v-if="studio.message"
+      class="alert alert-success rounded-2xl"
+      role="status"
+    >
       <icon name="kind-icon:check" class="size-5" />
       <span>{{ studio.message }}</span>
-      <button type="button" class="btn btn-ghost btn-sm" @click="studio.clearNotice()">
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm"
+        @click="studio.clearNotice()"
+      >
         Dismiss
       </button>
     </div>
@@ -65,28 +77,47 @@
         >
           <div class="flex items-start justify-between gap-3">
             <div>
-              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              <p
+                class="text-xs font-black uppercase tracking-widest text-base-content/40"
+              >
                 Book {{ book.order }}
               </p>
               <h4 class="text-xl font-black">{{ book.title }}</h4>
             </div>
             <span class="badge badge-outline rounded-2xl">{{ book.status }}</span>
           </div>
+
           <progress
             class="progress progress-primary my-3 w-full"
             :value="book.counts.finalPairs"
             :max="book.targetProposals"
           />
+
           <div class="grid grid-cols-4 gap-2 text-center text-xs">
-            <metric-chip label="Prompts" :value="book.counts.prompts" />
-            <metric-chip label="Rendered" :value="book.counts.rendered" />
-            <metric-chip label="Pairs" :value="book.counts.acceptedPairs" />
-            <metric-chip label="Final" :value="book.counts.finalPairs" />
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.prompts }}</strong>
+              Prompts
+            </div>
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.rendered }}</strong>
+              Rendered
+            </div>
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.acceptedPairs }}</strong>
+              Pairs
+            </div>
+            <div class="rounded-2xl bg-base-200 p-2">
+              <strong class="block text-base">{{ book.counts.finalPairs }}</strong>
+              Final
+            </div>
           </div>
         </button>
       </div>
 
-      <div role="tablist" class="tabs tabs-boxed flex-wrap rounded-2xl bg-base-200 p-1">
+      <div
+        role="tablist"
+        class="tabs tabs-boxed flex-wrap rounded-2xl bg-base-200 p-1"
+      >
         <button
           v-for="mode in modes"
           :key="mode.key"
@@ -109,7 +140,9 @@
         >
           <div class="flex items-start justify-between gap-3">
             <div>
-              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              <p
+                class="text-xs font-black uppercase tracking-widest text-base-content/40"
+              >
                 {{ book.slug }}
               </p>
               <h4 class="text-2xl font-black">{{ book.title }}</h4>
@@ -161,6 +194,7 @@
               Side-by-side production candidates for every proposal slot.
             </p>
           </div>
+
           <select
             v-model="pageFilter"
             class="select select-bordered rounded-2xl"
@@ -188,33 +222,69 @@
             @click="openProposal(proposal.id)"
           >
             <div class="grid aspect-[4/3] grid-cols-2 bg-base-200">
-              <preview-cell
-                label="Color"
-                :url="proposal.colorUrl"
-                :alt="`${proposal.title} color candidate`"
-                icon="kind-icon:palette"
-              />
-              <preview-cell
-                label="B&W"
-                :url="proposal.bwUrl"
-                :alt="`${proposal.title} black-and-white page`"
-                icon="kind-icon:pencil"
-                grayscale
-              />
+              <div class="relative overflow-hidden border-r border-base-300">
+                <img
+                  v-if="proposal.colorUrl"
+                  :src="proposal.colorUrl"
+                  :alt="`${proposal.title} color candidate`"
+                  class="size-full object-cover"
+                  loading="lazy"
+                />
+                <div
+                  v-else
+                  class="flex size-full items-center justify-center text-base-content/30"
+                >
+                  <icon name="kind-icon:palette" class="size-10" />
+                </div>
+                <span
+                  class="badge badge-sm absolute bottom-2 left-2 rounded-2xl"
+                >
+                  Color
+                </span>
+              </div>
+
+              <div class="relative overflow-hidden">
+                <img
+                  v-if="proposal.bwUrl"
+                  :src="proposal.bwUrl"
+                  :alt="`${proposal.title} black-and-white page`"
+                  class="size-full object-cover grayscale"
+                  loading="lazy"
+                />
+                <div
+                  v-else
+                  class="flex size-full items-center justify-center text-base-content/30"
+                >
+                  <icon name="kind-icon:pencil" class="size-10" />
+                </div>
+                <span
+                  class="badge badge-sm absolute bottom-2 left-2 rounded-2xl"
+                >
+                  B&amp;W
+                </span>
+              </div>
             </div>
+
             <div class="flex flex-col gap-2 p-4">
               <div class="flex items-start justify-between gap-3">
                 <div>
-                  <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                  <p
+                    class="text-xs font-black uppercase tracking-widest text-base-content/40"
+                  >
                     Slot {{ proposal.slot }} · {{ proposal.id }}
                   </p>
                   <h5 class="font-black">{{ proposal.title }}</h5>
                 </div>
-                <span class="badge badge-sm rounded-2xl" :class="statusBadge(proposal.queue.status)">
+                <span
+                  class="badge badge-sm rounded-2xl"
+                  :class="statusBadge(proposal.queue.status)"
+                >
                   {{ proposal.queue.status }}
                 </span>
               </div>
-              <p class="line-clamp-2 text-xs leading-relaxed text-base-content/55">
+              <p
+                class="line-clamp-2 text-xs leading-relaxed text-base-content/55"
+              >
                 {{ proposal.prompt || 'No production prompt yet.' }}
               </p>
             </div>
@@ -226,61 +296,118 @@
         v-if="activeMode === 'editor' && studio.selectedProposal"
         class="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(22rem,0.9fr)]"
       >
-        <article class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <article
+          class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+        >
+          <div
+            class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+          >
             <div>
-              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
-                {{ studio.selectedBook?.title }} · Slot {{ studio.selectedProposal.slot }} ·
+              <p
+                class="text-xs font-black uppercase tracking-widest text-base-content/40"
+              >
+                {{ studio.selectedBook?.title }} · Slot
+                {{ studio.selectedProposal.slot }} ·
                 {{ studio.selectedProposal.id }}
               </p>
-              <h4 class="text-2xl font-black">{{ studio.selectedProposal.title }}</h4>
+              <h4 class="text-2xl font-black">
+                {{ studio.selectedProposal.title }}
+              </h4>
             </div>
-            <span class="badge rounded-2xl" :class="statusBadge(studio.selectedProposal.queue.status)">
+            <span
+              class="badge rounded-2xl"
+              :class="statusBadge(studio.selectedProposal.queue.status)"
+            >
               {{ studio.selectedProposal.queue.status }}
             </span>
           </div>
 
           <div class="grid gap-4 sm:grid-cols-2">
-            <preview-figure
-              title="Current color master"
-              :url="studio.selectedProposal.colorUrl"
-              :alt="`${studio.selectedProposal.title} current color version`"
-              icon="kind-icon:palette"
-              empty-text="No color candidate"
-            />
-            <preview-figure
-              title="Current black & white"
-              :url="studio.selectedProposal.bwUrl"
-              :alt="`${studio.selectedProposal.title} current black-and-white version`"
-              icon="kind-icon:pencil"
-              empty-text="No line-art pair"
-              grayscale
-            />
+            <figure
+              class="overflow-hidden rounded-3xl border border-base-300 bg-base-200"
+            >
+              <div class="aspect-[2/3]">
+                <img
+                  v-if="studio.selectedProposal.colorUrl"
+                  :src="studio.selectedProposal.colorUrl"
+                  :alt="`${studio.selectedProposal.title} current color version`"
+                  class="size-full object-contain"
+                />
+                <div
+                  v-else
+                  class="flex size-full flex-col items-center justify-center gap-2 text-base-content/35"
+                >
+                  <icon name="kind-icon:palette" class="size-14" />
+                  <span>No color candidate</span>
+                </div>
+              </div>
+              <figcaption
+                class="border-t border-base-300 p-3 text-center font-black"
+              >
+                Current color master
+              </figcaption>
+            </figure>
+
+            <figure
+              class="overflow-hidden rounded-3xl border border-base-300 bg-base-200"
+            >
+              <div class="aspect-[2/3]">
+                <img
+                  v-if="studio.selectedProposal.bwUrl"
+                  :src="studio.selectedProposal.bwUrl"
+                  :alt="`${studio.selectedProposal.title} current black-and-white version`"
+                  class="size-full object-contain grayscale"
+                />
+                <div
+                  v-else
+                  class="flex size-full flex-col items-center justify-center gap-2 text-base-content/35"
+                >
+                  <icon name="kind-icon:pencil" class="size-14" />
+                  <span>No line-art pair</span>
+                </div>
+              </div>
+              <figcaption
+                class="border-t border-base-300 p-3 text-center font-black"
+              >
+                Current black &amp; white
+              </figcaption>
+            </figure>
           </div>
 
           <div class="grid gap-3 sm:grid-cols-3">
-            <metric-card
-              label="Semantic score"
-              :value="studio.selectedProposal.queue.semanticScore ?? '—'"
-            />
-            <metric-card
-              label="Render engine"
-              :value="studio.selectedProposal.queue.renderEngine ?? '—'"
-            />
-            <metric-card
-              label="Archived revisions"
-              :value="studio.selectedProposal.queue.revisionCount"
-            />
+            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+              <span class="block text-xs text-base-content/45">Semantic score</span>
+              <strong>
+                {{ studio.selectedProposal.queue.semanticScore ?? '—' }}
+              </strong>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+              <span class="block text-xs text-base-content/45">Render engine</span>
+              <strong>
+                {{ studio.selectedProposal.queue.renderEngine ?? '—' }}
+              </strong>
+            </div>
+            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+              <span class="block text-xs text-base-content/45">
+                Archived revisions
+              </span>
+              <strong>{{ studio.selectedProposal.queue.revisionCount }}</strong>
+            </div>
           </div>
         </article>
 
-        <aside class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
+        <aside
+          class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+        >
           <div>
             <h4 class="text-xl font-black">Canonical production prompt</h4>
             <p class="mt-1 break-all text-xs text-base-content/45">
               {{ studio.selectedProposal.promptSourcePath }}
             </p>
-            <p v-if="studio.selectedProposal.promptRef" class="mt-1 break-all text-xs text-info">
+            <p
+              v-if="studio.selectedProposal.promptRef"
+              class="mt-1 break-all text-xs text-info"
+            >
               Queue reference: {{ studio.selectedProposal.promptRef }}
             </p>
           </div>
@@ -292,9 +419,14 @@
             :placeholder="`Describe ${studio.selectedProposal.title} as a production-ready color master...`"
           />
 
-          <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45">
+          <div
+            class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45"
+          >
             <span>{{ promptDraft.length }} characters</span>
-            <span v-if="promptDirty" class="badge badge-warning badge-sm rounded-2xl">
+            <span
+              v-if="promptDirty"
+              class="badge badge-warning badge-sm rounded-2xl"
+            >
               Unsaved changes
             </span>
           </div>
@@ -303,10 +435,17 @@
             v-if="userStore.isAdmin"
             type="button"
             class="btn btn-primary rounded-2xl"
-            :disabled="!promptDirty || studio.savingPrompt || promptDraft.trim().length < 20"
+            :disabled="
+              !promptDirty ||
+              studio.savingPrompt ||
+              promptDraft.trim().length < 20
+            "
             @click="savePrompt"
           >
-            <span v-if="studio.savingPrompt" class="loading loading-spinner loading-sm" />
+            <span
+              v-if="studio.savingPrompt"
+              class="loading loading-spinner loading-sm"
+            />
             <icon v-else name="kind-icon:save" class="size-5" />
             Save canonical prompt
           </button>
@@ -329,19 +468,32 @@
             :disabled="studio.requestingRender || promptDirty"
             @click="requestRender"
           >
-            <span v-if="studio.requestingRender" class="loading loading-spinner loading-sm" />
+            <span
+              v-if="studio.requestingRender"
+              class="loading loading-spinner loading-sm"
+            />
             <icon v-else name="kind-icon:sparkles" class="size-5" />
-            {{ requestNeedsForce ? 'Archive current and request revision' : 'Request this color candidate' }}
+            {{
+              requestNeedsForce
+                ? 'Archive current and request revision'
+                : 'Request this color candidate'
+            }}
           </button>
 
-          <div v-if="!userStore.isAdmin" class="alert rounded-2xl bg-base-200 text-sm">
+          <div
+            v-if="!userStore.isAdmin"
+            class="alert rounded-2xl bg-base-200 text-sm"
+          >
             <icon name="kind-icon:lock" class="size-5" />
             <span>Production edits and render requests are admin-only.</span>
           </div>
 
-          <div class="rounded-2xl border border-info/30 bg-info/10 p-3 text-xs leading-relaxed">
-            Black-and-white generation remains color-first. Existing pairs are visible now;
-            targeted B&amp;W conversion follows after a color composition is accepted.
+          <div
+            class="rounded-2xl border border-info/30 bg-info/10 p-3 text-xs leading-relaxed"
+          >
+            Black-and-white generation remains color-first. Existing pairs are
+            visible now; targeted B&amp;W conversion follows after a color
+            composition is accepted.
           </div>
         </aside>
       </div>
@@ -377,16 +529,24 @@
           @click="openProblem(problem.bookSlug, problem.proposal.id)"
         >
           <div>
-            <p class="text-xs font-black uppercase tracking-widest text-base-content/45">
+            <p
+              class="text-xs font-black uppercase tracking-widest text-base-content/45"
+            >
               {{ problem.bookTitle }} · {{ problem.proposal.id }}
             </p>
             <h5 class="font-black">{{ problem.proposal.title }}</h5>
             <p class="mt-1 max-w-4xl text-sm text-base-content/65">
-              {{ problem.proposal.queue.semanticGateError || 'Automatic attempts exhausted; human review required.' }}
+              {{
+                problem.proposal.queue.semanticGateError ||
+                'Automatic attempts exhausted; human review required.'
+              }}
             </p>
           </div>
           <div class="flex shrink-0 flex-wrap gap-2">
-            <span class="badge rounded-2xl" :class="statusBadge(problem.proposal.queue.status)">
+            <span
+              class="badge rounded-2xl"
+              :class="statusBadge(problem.proposal.queue.status)"
+            >
               {{ problem.proposal.queue.status }}
             </span>
             <span class="badge badge-outline rounded-2xl">
@@ -396,11 +556,15 @@
         </button>
       </div>
 
-      <div v-if="activeMode === 'color'" class="rounded-3xl border border-base-300 bg-base-100 p-4">
+      <div
+        v-if="activeMode === 'color'"
+        class="rounded-3xl border border-base-300 bg-base-100 p-4"
+      >
         <div class="mb-4">
           <h4 class="text-xl font-black">End-user coloring preview</h4>
           <p class="text-sm text-base-content/50">
-            The existing coloring engine lives here without pretending to be the production manager.
+            The existing coloring engine lives here without pretending to be the
+            production manager.
           </p>
         </div>
         <coloring-book-manager />
@@ -410,85 +574,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
 import { useUserStore } from '@/stores/userStore'
 
 type StudioMode = 'books' | 'pages' | 'editor' | 'queue' | 'color'
 type PageFilter = 'all' | 'pending' | 'rendered' | 'review' | 'paired'
-
-const MetricChip = defineComponent({
-  props: { label: { type: String, required: true }, value: { type: [String, Number], required: true } },
-  setup: (props) => () =>
-    h('div', { class: 'rounded-2xl bg-base-200 p-2' }, [
-      h('strong', { class: 'block text-base' }, String(props.value)),
-      props.label,
-    ]),
-})
-
-const MetricCard = defineComponent({
-  props: { label: { type: String, required: true }, value: { type: [String, Number], required: true } },
-  setup: (props) => () =>
-    h('div', { class: 'rounded-2xl bg-base-200 p-3 text-sm' }, [
-      h('span', { class: 'block text-xs text-base-content/45' }, props.label),
-      h('strong', String(props.value)),
-    ]),
-})
-
-const PreviewCell = defineComponent({
-  props: {
-    label: { type: String, required: true },
-    url: { type: String, default: '' },
-    alt: { type: String, required: true },
-    icon: { type: String, required: true },
-    grayscale: { type: Boolean, default: false },
-  },
-  setup: (props) => () =>
-    h('div', { class: 'relative overflow-hidden border-r border-base-300 last:border-r-0' }, [
-      props.url
-        ? h('img', {
-            src: props.url,
-            alt: props.alt,
-            loading: 'lazy',
-            class: ['size-full object-cover', props.grayscale ? 'grayscale' : ''],
-          })
-        : h('div', { class: 'flex size-full items-center justify-center text-base-content/30' }, [
-            h(resolveIcon(), { name: props.icon, class: 'size-10' }),
-          ]),
-      h('span', { class: 'badge badge-sm absolute bottom-2 left-2 rounded-2xl' }, props.label),
-    ]),
-})
-
-const PreviewFigure = defineComponent({
-  props: {
-    title: { type: String, required: true },
-    url: { type: String, default: '' },
-    alt: { type: String, required: true },
-    icon: { type: String, required: true },
-    emptyText: { type: String, required: true },
-    grayscale: { type: Boolean, default: false },
-  },
-  setup: (props) => () =>
-    h('figure', { class: 'overflow-hidden rounded-3xl border border-base-300 bg-base-200' }, [
-      h('div', { class: 'aspect-[2/3]' }, [
-        props.url
-          ? h('img', {
-              src: props.url,
-              alt: props.alt,
-              class: ['size-full object-contain', props.grayscale ? 'grayscale' : ''],
-            })
-          : h('div', { class: 'flex size-full flex-col items-center justify-center gap-2 text-base-content/35' }, [
-              h(resolveIcon(), { name: props.icon, class: 'size-14' }),
-              h('span', props.emptyText),
-            ]),
-      ]),
-      h('figcaption', { class: 'border-t border-base-300 p-3 text-center font-black' }, props.title),
-    ]),
-})
-
-function resolveIcon() {
-  return resolveComponent('icon')
-}
 
 const studio = useColoringBookStudioStore()
 const userStore = useUserStore()
@@ -507,11 +598,17 @@ const modes: { key: StudioMode; label: string; icon: string }[] = [
 
 const filteredProposals = computed(() => {
   const proposals = studio.selectedBook?.proposals ?? []
-  if (pageFilter.value === 'pending') return proposals.filter((proposal) => proposal.queue.status === 'pending')
-  if (pageFilter.value === 'rendered') return proposals.filter((proposal) => Boolean(proposal.colorUrl))
+  if (pageFilter.value === 'pending') {
+    return proposals.filter((proposal) => proposal.queue.status === 'pending')
+  }
+  if (pageFilter.value === 'rendered') {
+    return proposals.filter((proposal) => Boolean(proposal.colorUrl))
+  }
   if (pageFilter.value === 'review') {
     return proposals.filter(
-      (proposal) => proposal.queue.status === 'needs_review' || Boolean(proposal.queue.semanticGateError),
+      (proposal) =>
+        proposal.queue.status === 'needs_review' ||
+        Boolean(proposal.queue.semanticGateError),
     )
   }
   if (pageFilter.value === 'paired') {
@@ -525,12 +622,15 @@ const filteredProposals = computed(() => {
 })
 
 const promptDirty = computed(
-  () => promptDraft.value.trim() !== (studio.selectedProposal?.prompt ?? '').trim(),
+  () =>
+    promptDraft.value.trim() !== (studio.selectedProposal?.prompt ?? '').trim(),
 )
 
 const requestNeedsForce = computed(() => {
   const proposal = studio.selectedProposal
-  return Boolean(proposal && (proposal.queue.status !== 'pending' || proposal.colorUrl))
+  return Boolean(
+    proposal && (proposal.queue.status !== 'pending' || proposal.colorUrl),
+  )
 })
 
 watch(

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="flex flex-col gap-5">
-    <div
-      class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-4 shadow-sm lg:flex-row lg:items-center lg:justify-between"
+    <header
+      class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm lg:flex-row lg:items-center lg:justify-between"
     >
       <div>
         <div class="flex items-center gap-2">
@@ -9,12 +9,11 @@
           <h3 class="text-2xl font-black">Coloring Book Production Studio</h3>
         </div>
         <p class="mt-1 max-w-3xl text-sm text-base-content/60">
-          The three canonical Conductor books, their 36 proposal slots, production
-          prompts, current color masters, black-and-white pairs, queue state, and
-          revision requests in one place.
+          Three canonical books, 108 proposal slots, real Conductor prompts, paired
+          art, queue state, and targeted revision requests. Finally, the front end
+          knows what the backend is talking about.
         </p>
       </div>
-
       <button
         type="button"
         class="btn btn-outline rounded-2xl"
@@ -25,28 +24,20 @@
         <icon v-else name="kind-icon:refresh" class="size-5" />
         Refresh Conductor
       </button>
-    </div>
+    </header>
 
-    <div
-      v-if="studio.error"
-      class="alert alert-error rounded-2xl"
-      role="alert"
-    >
+    <div v-if="studio.error" class="alert alert-error rounded-2xl" role="alert">
       <icon name="kind-icon:alert" class="size-5" />
       <span>{{ studio.error }}</span>
-      <button class="btn btn-ghost btn-sm" type="button" @click="studio.clearNotice()">
+      <button type="button" class="btn btn-ghost btn-sm" @click="studio.clearNotice()">
         Dismiss
       </button>
     </div>
 
-    <div
-      v-if="studio.message"
-      class="alert alert-success rounded-2xl"
-      role="status"
-    >
+    <div v-if="studio.message" class="alert alert-success rounded-2xl" role="status">
       <icon name="kind-icon:check" class="size-5" />
       <span>{{ studio.message }}</span>
-      <button class="btn btn-ghost btn-sm" type="button" @click="studio.clearNotice()">
+      <button type="button" class="btn btn-ghost btn-sm" @click="studio.clearNotice()">
         Dismiss
       </button>
     </div>
@@ -64,7 +55,7 @@
           v-for="book in studio.books"
           :key="book.slug"
           type="button"
-          class="flex flex-col gap-3 rounded-3xl border p-4 text-left transition hover:-translate-y-0.5 hover:shadow-md"
+          class="rounded-3xl border p-4 text-left transition hover:-translate-y-0.5 hover:shadow-md"
           :class="
             studio.selectedBookSlug === book.slug
               ? 'border-primary bg-primary/10 shadow-sm'
@@ -81,30 +72,16 @@
             </div>
             <span class="badge badge-outline rounded-2xl">{{ book.status }}</span>
           </div>
-
           <progress
-            class="progress progress-primary w-full"
+            class="progress progress-primary my-3 w-full"
             :value="book.counts.finalPairs"
             :max="book.targetProposals"
           />
-
           <div class="grid grid-cols-4 gap-2 text-center text-xs">
-            <div class="rounded-2xl bg-base-200 p-2">
-              <strong class="block text-base">{{ book.counts.prompts }}</strong>
-              prompts
-            </div>
-            <div class="rounded-2xl bg-base-200 p-2">
-              <strong class="block text-base">{{ book.counts.rendered }}</strong>
-              rendered
-            </div>
-            <div class="rounded-2xl bg-base-200 p-2">
-              <strong class="block text-base">{{ book.counts.acceptedPairs }}</strong>
-              accepted
-            </div>
-            <div class="rounded-2xl bg-base-200 p-2">
-              <strong class="block text-base">{{ book.counts.finalPairs }}</strong>
-              final
-            </div>
+            <metric-chip label="Prompts" :value="book.counts.prompts" />
+            <metric-chip label="Rendered" :value="book.counts.rendered" />
+            <metric-chip label="Pairs" :value="book.counts.acceptedPairs" />
+            <metric-chip label="Final" :value="book.counts.finalPairs" />
           </div>
         </button>
       </div>
@@ -130,7 +107,7 @@
           :key="book.slug"
           class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
         >
-          <div class="flex items-center justify-between gap-3">
+          <div class="flex items-start justify-between gap-3">
             <div>
               <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
                 {{ book.slug }}
@@ -138,14 +115,14 @@
               <h4 class="text-2xl font-black">{{ book.title }}</h4>
             </div>
             <span class="badge badge-primary rounded-2xl">
-              {{ book.counts.total }}/{{ book.targetProposals }} slots
+              {{ book.counts.total }}/{{ book.targetProposals }}
             </span>
           </div>
 
           <dl class="grid grid-cols-2 gap-3 text-sm">
             <div class="rounded-2xl bg-base-200 p-3">
-              <dt class="text-base-content/50">Color queue</dt>
-              <dd class="text-lg font-black">{{ book.counts.pending }} pending</dd>
+              <dt class="text-base-content/50">Pending color</dt>
+              <dd class="text-lg font-black">{{ book.counts.pending }}</dd>
             </div>
             <div class="rounded-2xl bg-base-200 p-3">
               <dt class="text-base-content/50">Needs attention</dt>
@@ -169,7 +146,7 @@
             @click="openBook(book.slug)"
           >
             <icon name="kind-icon:gallery" class="size-5" />
-            Open 36-page ledger
+            Open page ledger
           </button>
         </article>
       </div>
@@ -181,7 +158,7 @@
           <div>
             <h4 class="text-xl font-black">{{ studio.selectedBook?.title }}</h4>
             <p class="text-sm text-base-content/50">
-              Every proposal slot, with its strongest current color and line-art version.
+              Side-by-side production candidates for every proposal slot.
             </p>
           </div>
           <select
@@ -211,34 +188,20 @@
             @click="openProposal(proposal.id)"
           >
             <div class="grid aspect-[4/3] grid-cols-2 bg-base-200">
-              <div class="relative border-r border-base-300">
-                <img
-                  v-if="proposal.colorUrl"
-                  :src="proposal.colorUrl"
-                  :alt="`${proposal.title} color candidate`"
-                  class="size-full object-cover"
-                  loading="lazy"
-                />
-                <div v-else class="flex size-full items-center justify-center text-base-content/30">
-                  <icon name="kind-icon:palette" class="size-10" />
-                </div>
-                <span class="badge badge-sm absolute bottom-2 left-2 rounded-2xl">Color</span>
-              </div>
-              <div class="relative">
-                <img
-                  v-if="proposal.bwUrl"
-                  :src="proposal.bwUrl"
-                  :alt="`${proposal.title} black-and-white page`"
-                  class="size-full object-cover grayscale"
-                  loading="lazy"
-                />
-                <div v-else class="flex size-full items-center justify-center text-base-content/30">
-                  <icon name="kind-icon:pencil" class="size-10" />
-                </div>
-                <span class="badge badge-sm absolute bottom-2 left-2 rounded-2xl">B&amp;W</span>
-              </div>
+              <preview-cell
+                label="Color"
+                :url="proposal.colorUrl"
+                :alt="`${proposal.title} color candidate`"
+                icon="kind-icon:palette"
+              />
+              <preview-cell
+                label="B&W"
+                :url="proposal.bwUrl"
+                :alt="`${proposal.title} black-and-white page`"
+                icon="kind-icon:pencil"
+                grayscale
+              />
             </div>
-
             <div class="flex flex-col gap-2 p-4">
               <div class="flex items-start justify-between gap-3">
                 <div>
@@ -263,7 +226,7 @@
         v-if="activeMode === 'editor' && studio.selectedProposal"
         class="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(22rem,0.9fr)]"
       >
-        <div class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
+        <article class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
               <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
@@ -272,69 +235,46 @@
               </p>
               <h4 class="text-2xl font-black">{{ studio.selectedProposal.title }}</h4>
             </div>
-            <span
-              class="badge rounded-2xl"
-              :class="statusBadge(studio.selectedProposal.queue.status)"
-            >
+            <span class="badge rounded-2xl" :class="statusBadge(studio.selectedProposal.queue.status)">
               {{ studio.selectedProposal.queue.status }}
             </span>
           </div>
 
           <div class="grid gap-4 sm:grid-cols-2">
-            <figure class="overflow-hidden rounded-3xl border border-base-300 bg-base-200">
-              <div class="aspect-[2/3]">
-                <img
-                  v-if="studio.selectedProposal.colorUrl"
-                  :src="studio.selectedProposal.colorUrl"
-                  :alt="`${studio.selectedProposal.title} current color version`"
-                  class="size-full object-contain"
-                />
-                <div class="flex size-full flex-col items-center justify-center gap-2 text-base-content/35">
-                  <icon name="kind-icon:palette" class="size-14" />
-                  <span>No color candidate</span>
-                </div>
-              </div>
-              <figcaption class="border-t border-base-300 p-3 text-center font-black">
-                Current color master
-              </figcaption>
-            </figure>
-
-            <figure class="overflow-hidden rounded-3xl border border-base-300 bg-base-200">
-              <div class="aspect-[2/3]">
-                <img
-                  v-if="studio.selectedProposal.bwUrl"
-                  :src="studio.selectedProposal.bwUrl"
-                  :alt="`${studio.selectedProposal.title} current black-and-white version`"
-                  class="size-full object-contain grayscale"
-                />
-                <div class="flex size-full flex-col items-center justify-center gap-2 text-base-content/35">
-                  <icon name="kind-icon:pencil" class="size-14" />
-                  <span>No line-art pair</span>
-                </div>
-              </div>
-              <figcaption class="border-t border-base-300 p-3 text-center font-black">
-                Current black &amp; white
-              </figcaption>
-            </figure>
+            <preview-figure
+              title="Current color master"
+              :url="studio.selectedProposal.colorUrl"
+              :alt="`${studio.selectedProposal.title} current color version`"
+              icon="kind-icon:palette"
+              empty-text="No color candidate"
+            />
+            <preview-figure
+              title="Current black & white"
+              :url="studio.selectedProposal.bwUrl"
+              :alt="`${studio.selectedProposal.title} current black-and-white version`"
+              icon="kind-icon:pencil"
+              empty-text="No line-art pair"
+              grayscale
+            />
           </div>
 
           <div class="grid gap-3 sm:grid-cols-3">
-            <div class="rounded-2xl bg-base-200 p-3 text-sm">
-              <span class="block text-xs text-base-content/45">Semantic score</span>
-              <strong>{{ studio.selectedProposal.queue.semanticScore ?? '—' }}</strong>
-            </div>
-            <div class="rounded-2xl bg-base-200 p-3 text-sm">
-              <span class="block text-xs text-base-content/45">Render engine</span>
-              <strong>{{ studio.selectedProposal.queue.renderEngine ?? '—' }}</strong>
-            </div>
-            <div class="rounded-2xl bg-base-200 p-3 text-sm">
-              <span class="block text-xs text-base-content/45">Archived revisions</span>
-              <strong>{{ studio.selectedProposal.queue.revisionCount }}</strong>
-            </div>
+            <metric-card
+              label="Semantic score"
+              :value="studio.selectedProposal.queue.semanticScore ?? '—'"
+            />
+            <metric-card
+              label="Render engine"
+              :value="studio.selectedProposal.queue.renderEngine ?? '—'"
+            />
+            <metric-card
+              label="Archived revisions"
+              :value="studio.selectedProposal.queue.revisionCount"
+            />
           </div>
-        </div>
+        </article>
 
-        <div class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
+        <aside class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5">
           <div>
             <h4 class="text-xl font-black">Canonical production prompt</h4>
             <p class="mt-1 break-all text-xs text-base-content/45">
@@ -400,26 +340,25 @@
           </div>
 
           <div class="rounded-2xl border border-info/30 bg-info/10 p-3 text-xs leading-relaxed">
-            Black-and-white generation intentionally waits for an accepted color composition.
-            The studio shows existing pairs now; a proposal-targeted B&amp;W conversion action belongs
-            in the next pipeline slice rather than faking it with unrelated generic generation.
+            Black-and-white generation remains color-first. Existing pairs are visible now;
+            targeted B&amp;W conversion follows after a color composition is accepted.
           </div>
-        </div>
+        </aside>
       </div>
 
       <div v-if="activeMode === 'queue'" class="flex flex-col gap-4">
-        <div class="rounded-3xl border border-base-300 bg-base-100 p-5">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h4 class="text-xl font-black">Queue &amp; review problems</h4>
-              <p class="text-sm text-base-content/50">
-                Semantic gate failures and proposals that exhausted automatic retries.
-              </p>
-            </div>
-            <span class="badge badge-warning rounded-2xl">
-              {{ studio.queueProblems.length }} need attention
-            </span>
+        <div
+          class="flex flex-col gap-2 rounded-3xl border border-base-300 bg-base-100 p-5 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <h4 class="text-xl font-black">Queue &amp; review problems</h4>
+            <p class="text-sm text-base-content/50">
+              Semantic gate failures and proposals that exhausted automatic retries.
+            </p>
           </div>
+          <span class="badge badge-warning rounded-2xl">
+            {{ studio.queueProblems.length }} need attention
+          </span>
         </div>
 
         <div
@@ -461,8 +400,7 @@
         <div class="mb-4">
           <h4 class="text-xl font-black">End-user coloring preview</h4>
           <p class="text-sm text-base-content/50">
-            The existing coloring engine remains available here, but it is no longer pretending
-            to be the production manager.
+            The existing coloring engine lives here without pretending to be the production manager.
           </p>
         </div>
         <coloring-book-manager />
@@ -472,12 +410,85 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, defineComponent, h, onMounted, ref, watch } from 'vue'
 import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
 import { useUserStore } from '@/stores/userStore'
 
 type StudioMode = 'books' | 'pages' | 'editor' | 'queue' | 'color'
 type PageFilter = 'all' | 'pending' | 'rendered' | 'review' | 'paired'
+
+const MetricChip = defineComponent({
+  props: { label: { type: String, required: true }, value: { type: [String, Number], required: true } },
+  setup: (props) => () =>
+    h('div', { class: 'rounded-2xl bg-base-200 p-2' }, [
+      h('strong', { class: 'block text-base' }, String(props.value)),
+      props.label,
+    ]),
+})
+
+const MetricCard = defineComponent({
+  props: { label: { type: String, required: true }, value: { type: [String, Number], required: true } },
+  setup: (props) => () =>
+    h('div', { class: 'rounded-2xl bg-base-200 p-3 text-sm' }, [
+      h('span', { class: 'block text-xs text-base-content/45' }, props.label),
+      h('strong', String(props.value)),
+    ]),
+})
+
+const PreviewCell = defineComponent({
+  props: {
+    label: { type: String, required: true },
+    url: { type: String, default: '' },
+    alt: { type: String, required: true },
+    icon: { type: String, required: true },
+    grayscale: { type: Boolean, default: false },
+  },
+  setup: (props) => () =>
+    h('div', { class: 'relative overflow-hidden border-r border-base-300 last:border-r-0' }, [
+      props.url
+        ? h('img', {
+            src: props.url,
+            alt: props.alt,
+            loading: 'lazy',
+            class: ['size-full object-cover', props.grayscale ? 'grayscale' : ''],
+          })
+        : h('div', { class: 'flex size-full items-center justify-center text-base-content/30' }, [
+            h(resolveIcon(), { name: props.icon, class: 'size-10' }),
+          ]),
+      h('span', { class: 'badge badge-sm absolute bottom-2 left-2 rounded-2xl' }, props.label),
+    ]),
+})
+
+const PreviewFigure = defineComponent({
+  props: {
+    title: { type: String, required: true },
+    url: { type: String, default: '' },
+    alt: { type: String, required: true },
+    icon: { type: String, required: true },
+    emptyText: { type: String, required: true },
+    grayscale: { type: Boolean, default: false },
+  },
+  setup: (props) => () =>
+    h('figure', { class: 'overflow-hidden rounded-3xl border border-base-300 bg-base-200' }, [
+      h('div', { class: 'aspect-[2/3]' }, [
+        props.url
+          ? h('img', {
+              src: props.url,
+              alt: props.alt,
+              class: ['size-full object-contain', props.grayscale ? 'grayscale' : ''],
+            })
+          : h('div', { class: 'flex size-full flex-col items-center justify-center gap-2 text-base-content/35' }, [
+              h(resolveIcon(), { name: props.icon, class: 'size-14' }),
+              h('span', props.emptyText),
+            ]),
+      ]),
+      h('figcaption', { class: 'border-t border-base-300 p-3 text-center font-black' }, props.title),
+    ]),
+})
+
+function resolveIcon() {
+  return resolveComponent('icon')
+}
 
 const studio = useColoringBookStudioStore()
 const userStore = useUserStore()
@@ -496,17 +507,11 @@ const modes: { key: StudioMode; label: string; icon: string }[] = [
 
 const filteredProposals = computed(() => {
   const proposals = studio.selectedBook?.proposals ?? []
-  if (pageFilter.value === 'pending') {
-    return proposals.filter((proposal) => proposal.queue.status === 'pending')
-  }
-  if (pageFilter.value === 'rendered') {
-    return proposals.filter((proposal) => Boolean(proposal.colorUrl))
-  }
+  if (pageFilter.value === 'pending') return proposals.filter((proposal) => proposal.queue.status === 'pending')
+  if (pageFilter.value === 'rendered') return proposals.filter((proposal) => Boolean(proposal.colorUrl))
   if (pageFilter.value === 'review') {
     return proposals.filter(
-      (proposal) =>
-        proposal.queue.status === 'needs_review' ||
-        Boolean(proposal.queue.semanticGateError),
+      (proposal) => proposal.queue.status === 'needs_review' || Boolean(proposal.queue.semanticGateError),
     )
   }
   if (pageFilter.value === 'paired') {
@@ -525,8 +530,7 @@ const promptDirty = computed(
 
 const requestNeedsForce = computed(() => {
   const proposal = studio.selectedProposal
-  if (!proposal) return false
-  return proposal.queue.status !== 'pending' || Boolean(proposal.colorUrl)
+  return Boolean(proposal && (proposal.queue.status !== 'pending' || proposal.colorUrl))
 })
 
 watch(

--- a/server/api/conductor/coloring-books/index.get.ts
+++ b/server/api/conductor/coloring-books/index.get.ts
@@ -1,0 +1,58 @@
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { conductorGet } from '@/server/utils/conductor-github'
+import {
+  buildColoringBookStudioData,
+  COLORING_BOOK_CONFIG,
+  COLORING_BOOK_QUEUE_PATH,
+} from '@/server/utils/coloringBookStudio'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const queueFile = await conductorGet(COLORING_BOOK_QUEUE_PATH)
+    if (!queueFile) throw new Error('Canonical coloring-book queue was not found.')
+
+    const sourcePairs = await Promise.all(
+      COLORING_BOOK_CONFIG.map(async (config) => {
+        const [ledger, promptSource] = await Promise.all([
+          conductorGet(config.ledgerPath),
+          config.promptPath === config.ledgerPath
+            ? Promise.resolve(null)
+            : conductorGet(config.promptPath),
+        ])
+        if (!ledger) throw new Error(`Coloring-book ledger was not found: ${config.ledgerPath}`)
+        return {
+          config,
+          ledger: ledger.content,
+          prompt: promptSource?.content ?? ledger.content,
+        }
+      }),
+    )
+
+    const data = buildColoringBookStudioData({
+      queue: queueFile.content,
+      ledgers: Object.fromEntries(
+        sourcePairs.map(({ config, ledger }) => [config.slug, ledger]),
+      ),
+      prompts: Object.fromEntries(
+        sourcePairs.map(({ config, prompt }) => [config.slug, prompt]),
+      ),
+    })
+
+    return {
+      success: true,
+      message: `${data.books.length} coloring books loaded from Conductor.`,
+      data,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to load the Coloring Book Studio.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/conductor/coloring-books/prompt.post.ts
+++ b/server/api/conductor/coloring-books/prompt.post.ts
@@ -1,0 +1,74 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import type { ColoringBookPromptUpdate } from '~/types/coloringBookStudio'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { conductorGet, conductorPut } from '@/server/utils/conductor-github'
+import {
+  coloringBookConfig,
+  proposalBelongsToBook,
+  replaceColoringBookPrompt,
+} from '@/server/utils/coloringBookStudio'
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const body = (await readBody(event)) as Partial<ColoringBookPromptUpdate> | null
+    const bookSlug = String(body?.bookSlug || '').trim().toLowerCase()
+    const proposalId = String(body?.proposalId || '').trim().toLowerCase()
+    const prompt = String(body?.prompt || '').replace(/\r/g, '').trim()
+    const config = coloringBookConfig(bookSlug)
+
+    if (!config || !proposalBelongsToBook(bookSlug, proposalId)) {
+      throw createError({ statusCode: 400, message: 'Invalid book or proposal id.' })
+    }
+    if (prompt.length < 20) {
+      throw createError({
+        statusCode: 400,
+        message: 'The production prompt must be at least 20 characters.',
+      })
+    }
+    if (prompt.length > 6000) {
+      throw createError({
+        statusCode: 400,
+        message: 'The production prompt must be 6000 characters or fewer.',
+      })
+    }
+
+    const source = await conductorGet(config.promptPath)
+    if (!source) {
+      throw createError({
+        statusCode: 404,
+        message: `Prompt source was not found: ${config.promptPath}`,
+      })
+    }
+
+    const content = replaceColoringBookPrompt(
+      config,
+      source.content,
+      proposalId,
+      prompt,
+    )
+    await conductorPut(
+      config.promptPath,
+      content,
+      `coloring-book: update ${proposalId} production prompt`,
+      source.sha,
+    )
+
+    return {
+      success: true,
+      message: `${proposalId} prompt saved to the canonical Conductor source.`,
+      data: { bookSlug, proposalId, prompt },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to update the coloring-book prompt.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/conductor/coloring-books/request.post.ts
+++ b/server/api/conductor/coloring-books/request.post.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from 'node:crypto'
+import { createError, defineEventHandler, readBody } from 'h3'
+import type { ColoringBookRenderRequest } from '~/types/coloringBookStudio'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import {
+  conductorList,
+  conductorPut,
+} from '@/server/utils/conductor-github'
+import {
+  coloringBookConfig,
+  proposalBelongsToBook,
+} from '@/server/utils/coloringBookStudio'
+
+function compact(value: string): string {
+  return value.replace(/\r/g, '').replace(/\s+/g, ' ').trim()
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const body = (await readBody(event)) as Partial<ColoringBookRenderRequest> | null
+    const bookSlug = compact(String(body?.bookSlug || '')).toLowerCase()
+    const proposalId = compact(String(body?.proposalId || '')).toLowerCase()
+    const force = body?.force === true
+    const note = compact(String(body?.note || '')).slice(0, 500)
+
+    if (!coloringBookConfig(bookSlug) || !proposalBelongsToBook(bookSlug, proposalId)) {
+      throw createError({ statusCode: 400, message: 'Invalid book or proposal id.' })
+    }
+
+    const eventFiles = (await conductorList('color-art-events')) ?? []
+    const alreadyQueued = eventFiles.some(
+      (entry) => entry.type === 'file' && entry.name.includes(`-${proposalId}-`),
+    )
+    if (alreadyQueued) {
+      throw createError({
+        statusCode: 409,
+        message: `${proposalId} already has a queued Coloring Book Studio request.`,
+      })
+    }
+
+    const requestedAt = new Date()
+    const stamp = requestedAt.toISOString().replace(/[-:.]/g, '').replace('Z', 'Z')
+    const suffix = randomUUID().slice(0, 8)
+    const path = `color-art-events/${stamp}-${proposalId}-${suffix}.yaml`
+    const content = [
+      'version: 1',
+      'operation: generate-color-proposals',
+      `book: ${bookSlug}`,
+      'proposal_ids:',
+      `  - ${proposalId}`,
+      'timeout: 600',
+      `force: ${force ? 'true' : 'false'}`,
+      'requested_by: kind-robots-coloring-studio',
+      'task: coloring-book/t-028',
+      `note: ${JSON.stringify(note || `${force ? 'Revision' : 'Color candidate'} requested from the production studio.`)}`,
+      '',
+    ].join('\n')
+
+    await conductorPut(
+      path,
+      content,
+      `coloring-book: request ${proposalId} ${force ? 'revision' : 'color candidate'}`,
+    )
+
+    return {
+      success: true,
+      message: `${proposalId} ${force ? 'revision' : 'color candidate'} queued in Conductor.`,
+      data: { bookSlug, proposalId, force, eventPath: path },
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to request a coloring-book render.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/coloringBookStudio.ts
+++ b/server/utils/coloringBookStudio.ts
@@ -12,7 +12,6 @@ export const COLORING_BOOK_REPO = 'silasfelinus/conductor'
 export const COLORING_BOOK_REF = 'main'
 export const COLORING_BOOK_ROOT = 'projects/coloring-book'
 export const COLORING_BOOK_QUEUE_PATH = `${COLORING_BOOK_ROOT}/color-art-jobs.yaml`
-export const COLORING_BOOK_WORKFLOW = 'process-color-art-events.yml'
 
 export const COLORING_BOOK_CONFIG = [
   {
@@ -50,12 +49,20 @@ type QueueEntry = ColoringBookQueueState & {
   sourceRef: string | null
 }
 
+function capture(
+  text: string,
+  pattern: RegExp,
+  group = 1,
+): string | undefined {
+  return pattern.exec(text)?.[group]
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function indentation(line: string): number {
-  return line.match(/^\s*/)?.[0].length ?? 0
+  return /^\s*/.exec(line)?.[0].length ?? 0
 }
 
 function yamlValue(value: string | undefined): string | null {
@@ -75,10 +82,12 @@ function yamlNumber(value: string | null, fallback = 0): number {
 }
 
 function scalar(block: string, key: string, spaces = 2): string | null {
-  const match = block.match(
-    new RegExp(`^\\s{${spaces}}${escapeRegExp(key)}:\\s*(.*?)\\s*$`, 'm'),
+  return yamlValue(
+    capture(
+      block,
+      new RegExp(`^\\s{${spaces}}${escapeRegExp(key)}:\\s*(.*?)\\s*$`, 'm'),
+    ),
   )
-  return yamlValue(match?.[1])
 }
 
 function collectYamlText(
@@ -88,7 +97,7 @@ function collectYamlText(
 ): string {
   const line = lines[index] ?? ''
   const colon = line.indexOf(':')
-  let first = colon >= 0 ? line.slice(colon + 1).trim() : ''
+  const first = colon >= 0 ? line.slice(colon + 1).trim() : ''
   const values: string[] = []
 
   if (first && first !== '>' && first !== '|') values.push(first)
@@ -105,13 +114,13 @@ function promptFromProposalBlock(block: string): {
   text: string
   ref: string | null
 } {
-  const inline = block.match(
-    /^  prompt:\s*\{text:\s*(.*?),\s*ref:\s*(.*?)\}\s*$/m,
-  )
-  if (inline) {
+  const inlinePattern =
+    /^  prompt:\s*\{text:\s*(.*?),\s*ref:\s*(.*?)\}\s*$/m
+  const inlineText = capture(block, inlinePattern, 1)
+  if (inlineText !== undefined) {
     return {
-      text: yamlValue(inline[1]) ?? '',
-      ref: yamlValue(inline[2]),
+      text: yamlValue(inlineText) ?? '',
+      ref: yamlValue(capture(block, inlinePattern, 2)),
     }
   }
 
@@ -128,27 +137,30 @@ function promptFromProposalBlock(block: string): {
 
   return {
     text: textIndex >= 0 ? collectYamlText(lines, textIndex, 4) : '',
-    ref: refIndex >= 0 ? yamlValue(lines[refIndex]?.split(':').slice(1).join(':')) : null,
+    ref:
+      refIndex >= 0
+        ? yamlValue(lines[refIndex]?.split(':').slice(1).join(':'))
+        : null,
   }
 }
 
 function parsePair(block: string, key: 'accepted' | 'final'): ColoringBookPair {
-  const inline = block.match(
-    new RegExp(
-      `^  ${key}:\\s*\\{color:\\s*(.*?),\\s*bw:\\s*(.*?)\\}\\s*$`,
-      'm',
-    ),
+  const inlinePattern = new RegExp(
+    `^  ${key}:\\s*\\{color:\\s*(.*?),\\s*bw:\\s*(.*?)\\}\\s*$`,
+    'm',
   )
-  if (inline) {
+  const inlineColor = capture(block, inlinePattern, 1)
+  if (inlineColor !== undefined) {
     return {
-      color: yamlValue(inline[1]),
-      bw: yamlValue(inline[2]),
+      color: yamlValue(inlineColor),
+      bw: yamlValue(capture(block, inlinePattern, 2)),
     }
   }
 
-  const section = block.match(
-    new RegExp(`^  ${key}:\\s*$([\\s\\S]*?)(?=^  [a-z_]+:|\\Z)`, 'm'),
-  )?.[1]
+  const section = capture(
+    block,
+    new RegExp(`^  ${key}:\\s*$([\\s\\S]*?)(?=^  [a-z_]+:|$(?![\\s\\S]))`, 'm'),
+  )
   if (!section) return { color: null, bw: null }
 
   return {
@@ -167,26 +179,28 @@ function rawAssetUrl(path: string, bookSlug: string): string | null {
 }
 
 function parseInspirations(block: string, bookSlug: string): ColoringBookAsset[] {
-  const section = block.match(
-    /^  inspirations:\s*(?:\[\])?\s*$([\s\S]*?)(?=^  accepted:|\Z)/m,
-  )?.[1]
+  const section = capture(
+    block,
+    /^  inspirations:\s*(?:\[\])?\s*$([\s\S]*?)(?=^  accepted:|$(?![\s\S]))/m,
+  )
   if (!section) return []
 
   const assets: ColoringBookAsset[] = []
-  for (const inline of section.matchAll(
+  for (const match of section.matchAll(
     /^  -\s*\{path:\s*([^,}]+),\s*kind:\s*([^}]+)\}\s*$/gm,
   )) {
-    const path = yamlValue(inline[1]) ?? ''
-    const kind = yamlValue(inline[2]) ?? 'inspiration'
+    const path = yamlValue(match?.[1]) ?? ''
+    const kind = yamlValue(match?.[2]) ?? 'inspiration'
     if (path) assets.push({ path, kind, url: rawAssetUrl(path, bookSlug) })
   }
 
-  const blocks = section
+  const entries = section
     .split(/(?=^  - path:)/m)
     .filter((entry) => entry.startsWith('  - path:'))
-  for (const entry of blocks) {
-    const path = yamlValue(entry.match(/^  - path:\s*(.*?)\s*$/m)?.[1]) ?? ''
-    const kind = yamlValue(entry.match(/^    kind:\s*(.*?)\s*$/m)?.[1]) ?? 'inspiration'
+  for (const entry of entries) {
+    const path = yamlValue(capture(entry, /^  - path:\s*(.*?)\s*$/m)) ?? ''
+    const kind =
+      yamlValue(capture(entry, /^    kind:\s*(.*?)\s*$/m)) ?? 'inspiration'
     if (path && !assets.some((asset) => asset.path === path && asset.kind === kind)) {
       assets.push({ path, kind, url: rawAssetUrl(path, bookSlug) })
     }
@@ -196,10 +210,10 @@ function parseInspirations(block: string, bookSlug: string): ColoringBookAsset[]
 }
 
 function parseNotes(block: string): string[] {
-  const section = block.match(/^  notes:\s*(?:\[\])?\s*$([\s\S]*?)\Z/m)?.[1]
-  if (!section) return []
-  return [...section.matchAll(/^  -\s*(.*?)\s*$/gm)]
-    .map((match) => yamlValue(match[1]) ?? '')
+  const notesStart = block.search(/^  notes:\s*(?:\[\])?\s*$/m)
+  if (notesStart < 0) return []
+  return [...block.slice(notesStart).matchAll(/^  -\s*(.*?)\s*$/gm)]
+    .map((match) => yamlValue(match?.[1]) ?? '')
     .filter(Boolean)
 }
 
@@ -210,7 +224,7 @@ function parseMonsterPromptMap(content: string): Record<string, string> {
     .filter((block) => block.startsWith('    - id:'))
 
   for (const block of blocks) {
-    const id = yamlValue(block.match(/^    - id:\s*(.*?)\s*$/m)?.[1])
+    const id = yamlValue(capture(block, /^    - id:\s*(.*?)\s*$/m))
     if (!id) continue
     const lines = block.split('\n')
     const promptIndex = lines.findIndex((line) => /^      prompt:/.test(line))
@@ -237,22 +251,22 @@ function parseQueue(content: string): Record<string, QueueEntry> {
       const id = scalar(block, 'id', 4)
       if (!id) continue
       const errorLines = block.split('\n')
-      const errorIndex = errorLines.findIndex((line) => /^    semantic_gate_error:/.test(line))
-      const revisionSection = block.match(
-        /^    studio_revision_history:\s*$([\s\S]*?)(?=^    [a-z_]+:|\Z)/m,
-      )?.[1]
+      const errorIndex = errorLines.findIndex((line) =>
+        /^    semantic_gate_error:/.test(line),
+      )
+      const revisionSection = capture(
+        block,
+        /^    studio_revision_history:\s*$([\s\S]*?)(?=^    [a-z_]+:|$(?![\s\S]))/m,
+      )
+      const artImageId = scalar(block, 'art_image_id', 4)
+      const semanticScore = scalar(block, 'semantic_score', 4)
       result[`${bookSlug}:${id}`] = {
         status: scalar(block, 'status', 4) ?? 'unknown',
         imagePath: scalar(block, 'image_path', 4),
         renderedPath: scalar(block, 'rendered_path', 4),
-        artImageId: (() => {
-          const value = scalar(block, 'art_image_id', 4)
-          return value === null ? null : yamlNumber(value, 0) || null
-        })(),
-        semanticScore: (() => {
-          const value = scalar(block, 'semantic_score', 4)
-          return value === null ? null : yamlNumber(value, 0)
-        })(),
+        artImageId: artImageId === null ? null : yamlNumber(artImageId, 0) || null,
+        semanticScore:
+          semanticScore === null ? null : yamlNumber(semanticScore, 0),
         semanticVerdict: scalar(block, 'semantic_verdict', 4),
         semanticAttempts: yamlNumber(scalar(block, 'semantic_attempts', 4), 0),
         semanticGateError:
@@ -287,16 +301,22 @@ function emptyQueueState(): ColoringBookQueueState {
 }
 
 function selectAssetPath(
-  proposal: Pick<ColoringBookProposal, 'final' | 'accepted' | 'inspirations' | 'queue'>,
+  proposal: Pick<
+    ColoringBookProposal,
+    'final' | 'accepted' | 'inspirations' | 'queue'
+  >,
   variant: 'color' | 'bw',
 ): string | null {
   const explicit = proposal.final[variant] || proposal.accepted[variant]
   if (explicit) return explicit
-  if (variant === 'color' && proposal.queue.renderedPath) return proposal.queue.renderedPath
-  const candidate = proposal.inspirations.find((asset) =>
-    asset.kind.toLowerCase().includes(variant),
+  if (variant === 'color' && proposal.queue.renderedPath) {
+    return proposal.queue.renderedPath
+  }
+  return (
+    proposal.inspirations.find((asset) =>
+      asset.kind.toLowerCase().includes(variant),
+    )?.path ?? null
   )
-  return candidate?.path ?? null
 }
 
 function countsFor(proposals: ColoringBookProposal[]): ColoringBookCounts {
@@ -312,9 +332,12 @@ function countsFor(proposals: ColoringBookProposal[]): ColoringBookCounts {
     finalPairs: proposals.filter(
       (proposal) => Boolean(proposal.final.color && proposal.final.bw),
     ).length,
-    needsReview: proposals.filter((proposal) => proposal.queue.status === 'needs_review')
-      .length,
-    blocked: proposals.filter((proposal) => Boolean(proposal.queue.semanticGateError)).length,
+    needsReview: proposals.filter(
+      (proposal) => proposal.queue.status === 'needs_review',
+    ).length,
+    blocked: proposals.filter((proposal) =>
+      Boolean(proposal.queue.semanticGateError),
+    ).length,
   }
 }
 
@@ -324,11 +347,15 @@ function parseLedger(
   promptContent: string,
   queue: Record<string, QueueEntry>,
 ): ColoringBookStudioBook {
-  const bookSection = content.match(/^book:\s*$([\s\S]*?)(?=^[a-z_]+:|\Z)/m)?.[1] ?? ''
+  const bookSection =
+    capture(content, /^book:\s*$([\s\S]*?)(?=^[a-z_]+:|$(?![\s\S]))/m) ?? ''
   const order = yamlNumber(scalar(bookSection, 'order', 2), config.order)
   const slug = scalar(bookSection, 'slug', 2) ?? config.slug
   const title = scalar(bookSection, 'title', 2) ?? config.title
-  const targetProposals = yamlNumber(scalar(bookSection, 'target_proposals', 2), 36)
+  const targetProposals = yamlNumber(
+    scalar(bookSection, 'target_proposals', 2),
+    36,
+  )
   const coverIsSeparate = scalar(bookSection, 'cover_is_separate', 2) !== 'false'
   const status = scalar(bookSection, 'status', 2) ?? 'unknown'
   const monsterPrompts =
@@ -339,10 +366,7 @@ function parseLedger(
     .filter((block) => block.startsWith('- slot:'))
 
   const proposals = proposalBlocks.map((block): ColoringBookProposal => {
-    const slot = yamlNumber(
-      yamlValue(block.match(/^- slot:\s*(.*?)\s*$/m)?.[1]),
-      0,
-    )
+    const slot = yamlNumber(yamlValue(capture(block, /^- slot:\s*(.*?)\s*$/m)), 0)
     const id = scalar(block, 'id', 2) ?? `${slug}-${slot}`
     const promptData = promptFromProposalBlock(block)
     const queueEntry = queue[`${slug}:${id}`]
@@ -364,14 +388,12 @@ function parseLedger(
     const inspirations = parseInspirations(block, slug)
     const accepted = parsePair(block, 'accepted')
     const final = parsePair(block, 'final')
-    const prompt = monsterPrompts[id] || promptData.text
-    const promptRef = queueEntry?.sourceRef || promptData.ref
     const proposal: ColoringBookProposal = {
       slot,
       id,
       title: scalar(block, 'title', 2) ?? id,
-      prompt,
-      promptRef,
+      prompt: monsterPrompts[id] || promptData.text,
+      promptRef: queueEntry?.sourceRef || promptData.ref,
       promptSourcePath: config.promptPath,
       inspirations,
       accepted,
@@ -450,11 +472,9 @@ export function replaceColoringBookPrompt(
   if (!cleanPrompt) throw new Error('Prompt cannot be empty.')
 
   if (config.slug === 'monster-recast') {
-    const startPattern = new RegExp(
-      `^    - id:\\s*${escapeRegExp(proposalId)}\\s*$`,
-      'm',
+    const start = content.search(
+      new RegExp(`^    - id:\\s*${escapeRegExp(proposalId)}\\s*$`, 'm'),
     )
-    const start = content.search(startPattern)
     if (start < 0) throw new Error(`Prompt source not found for ${proposalId}.`)
     const tail = content.slice(start)
     const next = tail.slice(1).search(/^    - id:/m)
@@ -462,10 +482,11 @@ export function replaceColoringBookPrompt(
     const block = content.slice(start, end)
     const promptMatch = /^      prompt:.*$/m.exec(block)
     if (!promptMatch) throw new Error(`Prompt field not found for ${proposalId}.`)
-    const promptStart = start + (promptMatch.index ?? 0)
-    const afterPromptLine = promptStart + promptMatch[0].length
+    const promptStart = start + (promptMatch?.index ?? 0)
+    const promptLineLength = promptMatch?.[0]?.length ?? 0
+    const afterPromptLine = promptStart + promptLineLength
     const remaining = content.slice(afterPromptLine, end)
-    const continuation = remaining.match(/^(?:\n        .*|\n\s*)*/)?.[0] ?? ''
+    const continuation = capture(remaining, /^((?:\n        .*|\n\s*)*)/) ?? ''
     const promptEnd = afterPromptLine + continuation.length
     const replacement = [
       '      prompt: >',
@@ -492,8 +513,8 @@ export function replaceColoringBookPrompt(
   if (!promptStartMatch || !inspirationMatch) {
     throw new Error(`Prompt section not found for ${proposalId}.`)
   }
-  const promptStart = start + (promptStartMatch.index ?? 0)
-  const promptEnd = start + (inspirationMatch.index ?? block.length)
+  const promptStart = start + (promptStartMatch?.index ?? 0)
+  const promptEnd = start + (inspirationMatch?.index ?? block.length)
   const current = promptFromProposalBlock(block)
   const ref = current.ref ? JSON.stringify(current.ref) : 'null'
   const replacement = [
@@ -510,7 +531,10 @@ export function coloringBookConfig(bookSlug: string): ColoringBookConfig | null 
   return COLORING_BOOK_CONFIG.find((config) => config.slug === bookSlug) ?? null
 }
 
-export function proposalBelongsToBook(bookSlug: string, proposalId: string): boolean {
+export function proposalBelongsToBook(
+  bookSlug: string,
+  proposalId: string,
+): boolean {
   if (bookSlug === 'monster-recast') {
     return /^(?:mr-\d{3}|mr-group-\d{3})$/.test(proposalId)
   }

--- a/server/utils/coloringBookStudio.ts
+++ b/server/utils/coloringBookStudio.ts
@@ -1,0 +1,520 @@
+import type {
+  ColoringBookAsset,
+  ColoringBookCounts,
+  ColoringBookPair,
+  ColoringBookProposal,
+  ColoringBookQueueState,
+  ColoringBookStudioBook,
+  ColoringBookStudioData,
+} from '~/types/coloringBookStudio'
+
+export const COLORING_BOOK_REPO = 'silasfelinus/conductor'
+export const COLORING_BOOK_REF = 'main'
+export const COLORING_BOOK_ROOT = 'projects/coloring-book'
+export const COLORING_BOOK_QUEUE_PATH = `${COLORING_BOOK_ROOT}/color-art-jobs.yaml`
+export const COLORING_BOOK_WORKFLOW = 'process-color-art-events.yml'
+
+export const COLORING_BOOK_CONFIG = [
+  {
+    order: 1,
+    slug: 'monster-recast',
+    title: 'Monster Recast',
+    ledgerPath: `${COLORING_BOOK_ROOT}/sets/monster-recast/proposals.yaml`,
+    promptPath: `${COLORING_BOOK_ROOT}/sets/monster-recast/art-modeler-request.yaml`,
+  },
+  {
+    order: 2,
+    slug: 'hollywood-recast',
+    title: 'Hollywood Recast',
+    ledgerPath: `${COLORING_BOOK_ROOT}/sets/hollywood-recast/proposals.yaml`,
+    promptPath: `${COLORING_BOOK_ROOT}/sets/hollywood-recast/proposals.yaml`,
+  },
+  {
+    order: 3,
+    slug: 'kind-robots',
+    title: 'Kind Robots',
+    ledgerPath: `${COLORING_BOOK_ROOT}/sets/kind-robots/proposals.yaml`,
+    promptPath: `${COLORING_BOOK_ROOT}/sets/kind-robots/proposals.yaml`,
+  },
+] as const
+
+export type ColoringBookConfig = (typeof COLORING_BOOK_CONFIG)[number]
+
+export type ColoringBookSourceFiles = {
+  queue: string
+  ledgers: Record<string, string>
+  prompts: Record<string, string>
+}
+
+type QueueEntry = ColoringBookQueueState & {
+  sourceRef: string | null
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function indentation(line: string): number {
+  return line.match(/^\s*/)?.[0].length ?? 0
+}
+
+function yamlValue(value: string | undefined): string | null {
+  const clean = String(value ?? '').trim()
+  if (!clean || clean === 'null' || clean === '~') return null
+  if (clean.startsWith('"')) {
+    try {
+      return String(JSON.parse(clean))
+    } catch {}
+  }
+  return clean.replace(/^['"]|['"]$/g, '')
+}
+
+function yamlNumber(value: string | null, fallback = 0): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function scalar(block: string, key: string, spaces = 2): string | null {
+  const match = block.match(
+    new RegExp(`^\\s{${spaces}}${escapeRegExp(key)}:\\s*(.*?)\\s*$`, 'm'),
+  )
+  return yamlValue(match?.[1])
+}
+
+function collectYamlText(
+  lines: string[],
+  index: number,
+  expectedIndent: number,
+): string {
+  const line = lines[index] ?? ''
+  const colon = line.indexOf(':')
+  let first = colon >= 0 ? line.slice(colon + 1).trim() : ''
+  const values: string[] = []
+
+  if (first && first !== '>' && first !== '|') values.push(first)
+  for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+    const next = lines[cursor] ?? ''
+    if (next.trim() && indentation(next) <= expectedIndent) break
+    if (next.trim()) values.push(next.trim())
+  }
+
+  return yamlValue(values.join(' ')) ?? ''
+}
+
+function promptFromProposalBlock(block: string): {
+  text: string
+  ref: string | null
+} {
+  const inline = block.match(
+    /^  prompt:\s*\{text:\s*(.*?),\s*ref:\s*(.*?)\}\s*$/m,
+  )
+  if (inline) {
+    return {
+      text: yamlValue(inline[1]) ?? '',
+      ref: yamlValue(inline[2]),
+    }
+  }
+
+  const lines = block.split('\n')
+  const promptIndex = lines.findIndex((line) => /^  prompt:\s*$/.test(line))
+  if (promptIndex < 0) return { text: '', ref: null }
+
+  const textIndex = lines.findIndex(
+    (line, index) => index > promptIndex && /^    text:/.test(line),
+  )
+  const refIndex = lines.findIndex(
+    (line, index) => index > promptIndex && /^    ref:/.test(line),
+  )
+
+  return {
+    text: textIndex >= 0 ? collectYamlText(lines, textIndex, 4) : '',
+    ref: refIndex >= 0 ? yamlValue(lines[refIndex]?.split(':').slice(1).join(':')) : null,
+  }
+}
+
+function parsePair(block: string, key: 'accepted' | 'final'): ColoringBookPair {
+  const inline = block.match(
+    new RegExp(
+      `^  ${key}:\\s*\\{color:\\s*(.*?),\\s*bw:\\s*(.*?)\\}\\s*$`,
+      'm',
+    ),
+  )
+  if (inline) {
+    return {
+      color: yamlValue(inline[1]),
+      bw: yamlValue(inline[2]),
+    }
+  }
+
+  const section = block.match(
+    new RegExp(`^  ${key}:\\s*$([\\s\\S]*?)(?=^  [a-z_]+:|\\Z)`, 'm'),
+  )?.[1]
+  if (!section) return { color: null, bw: null }
+
+  return {
+    color: scalar(section, 'color', 4),
+    bw: scalar(section, 'bw', 4),
+  }
+}
+
+function rawAssetUrl(path: string, bookSlug: string): string | null {
+  const clean = path.trim()
+  if (!clean || clean.includes(':') || clean.startsWith('user-attachment')) return null
+  const repoPath = clean.startsWith('projects/')
+    ? clean
+    : `${COLORING_BOOK_ROOT}/sets/${bookSlug}/${clean.replace(/^\.\//, '')}`
+  return `https://raw.githubusercontent.com/${COLORING_BOOK_REPO}/${COLORING_BOOK_REF}/${repoPath}`
+}
+
+function parseInspirations(block: string, bookSlug: string): ColoringBookAsset[] {
+  const section = block.match(
+    /^  inspirations:\s*(?:\[\])?\s*$([\s\S]*?)(?=^  accepted:|\Z)/m,
+  )?.[1]
+  if (!section) return []
+
+  const assets: ColoringBookAsset[] = []
+  for (const inline of section.matchAll(
+    /^  -\s*\{path:\s*([^,}]+),\s*kind:\s*([^}]+)\}\s*$/gm,
+  )) {
+    const path = yamlValue(inline[1]) ?? ''
+    const kind = yamlValue(inline[2]) ?? 'inspiration'
+    if (path) assets.push({ path, kind, url: rawAssetUrl(path, bookSlug) })
+  }
+
+  const blocks = section
+    .split(/(?=^  - path:)/m)
+    .filter((entry) => entry.startsWith('  - path:'))
+  for (const entry of blocks) {
+    const path = yamlValue(entry.match(/^  - path:\s*(.*?)\s*$/m)?.[1]) ?? ''
+    const kind = yamlValue(entry.match(/^    kind:\s*(.*?)\s*$/m)?.[1]) ?? 'inspiration'
+    if (path && !assets.some((asset) => asset.path === path && asset.kind === kind)) {
+      assets.push({ path, kind, url: rawAssetUrl(path, bookSlug) })
+    }
+  }
+
+  return assets
+}
+
+function parseNotes(block: string): string[] {
+  const section = block.match(/^  notes:\s*(?:\[\])?\s*$([\s\S]*?)\Z/m)?.[1]
+  if (!section) return []
+  return [...section.matchAll(/^  -\s*(.*?)\s*$/gm)]
+    .map((match) => yamlValue(match[1]) ?? '')
+    .filter(Boolean)
+}
+
+function parseMonsterPromptMap(content: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  const blocks = content
+    .split(/(?=^    - id:)/m)
+    .filter((block) => block.startsWith('    - id:'))
+
+  for (const block of blocks) {
+    const id = yamlValue(block.match(/^    - id:\s*(.*?)\s*$/m)?.[1])
+    if (!id) continue
+    const lines = block.split('\n')
+    const promptIndex = lines.findIndex((line) => /^      prompt:/.test(line))
+    result[id] = promptIndex >= 0 ? collectYamlText(lines, promptIndex, 6) : ''
+  }
+
+  return result
+}
+
+function parseQueue(content: string): Record<string, QueueEntry> {
+  const result: Record<string, QueueEntry> = {}
+  const bookBlocks = content
+    .split(/(?=^- order:)/m)
+    .filter((block) => block.startsWith('- order:'))
+
+  for (const bookBlock of bookBlocks) {
+    const bookSlug = scalar(bookBlock, 'slug', 2)
+    if (!bookSlug) continue
+    const entryBlocks = bookBlock
+      .split(/(?=^  - slot:)/m)
+      .filter((block) => block.startsWith('  - slot:'))
+
+    for (const block of entryBlocks) {
+      const id = scalar(block, 'id', 4)
+      if (!id) continue
+      const errorLines = block.split('\n')
+      const errorIndex = errorLines.findIndex((line) => /^    semantic_gate_error:/.test(line))
+      const revisionSection = block.match(
+        /^    studio_revision_history:\s*$([\s\S]*?)(?=^    [a-z_]+:|\Z)/m,
+      )?.[1]
+      result[`${bookSlug}:${id}`] = {
+        status: scalar(block, 'status', 4) ?? 'unknown',
+        imagePath: scalar(block, 'image_path', 4),
+        renderedPath: scalar(block, 'rendered_path', 4),
+        artImageId: (() => {
+          const value = scalar(block, 'art_image_id', 4)
+          return value === null ? null : yamlNumber(value, 0) || null
+        })(),
+        semanticScore: (() => {
+          const value = scalar(block, 'semantic_score', 4)
+          return value === null ? null : yamlNumber(value, 0)
+        })(),
+        semanticVerdict: scalar(block, 'semantic_verdict', 4),
+        semanticAttempts: yamlNumber(scalar(block, 'semantic_attempts', 4), 0),
+        semanticGateError:
+          errorIndex >= 0 ? collectYamlText(errorLines, errorIndex, 4) : null,
+        completedAt: scalar(block, 'completed_at', 4),
+        renderEngine: scalar(block, 'render_engine', 4),
+        revisionCount: revisionSection
+          ? [...revisionSection.matchAll(/requested_at:/g)].length
+          : 0,
+        sourceRef: scalar(block, 'source_ref', 4),
+      }
+    }
+  }
+
+  return result
+}
+
+function emptyQueueState(): ColoringBookQueueState {
+  return {
+    status: 'missing',
+    imagePath: null,
+    renderedPath: null,
+    artImageId: null,
+    semanticScore: null,
+    semanticVerdict: null,
+    semanticAttempts: 0,
+    semanticGateError: null,
+    completedAt: null,
+    renderEngine: null,
+    revisionCount: 0,
+  }
+}
+
+function selectAssetPath(
+  proposal: Pick<ColoringBookProposal, 'final' | 'accepted' | 'inspirations' | 'queue'>,
+  variant: 'color' | 'bw',
+): string | null {
+  const explicit = proposal.final[variant] || proposal.accepted[variant]
+  if (explicit) return explicit
+  if (variant === 'color' && proposal.queue.renderedPath) return proposal.queue.renderedPath
+  const candidate = proposal.inspirations.find((asset) =>
+    asset.kind.toLowerCase().includes(variant),
+  )
+  return candidate?.path ?? null
+}
+
+function countsFor(proposals: ColoringBookProposal[]): ColoringBookCounts {
+  return {
+    total: proposals.length,
+    prompts: proposals.filter((proposal) => proposal.prompt.trim()).length,
+    pending: proposals.filter((proposal) => proposal.queue.status === 'pending').length,
+    rendered: proposals.filter((proposal) => Boolean(proposal.queue.renderedPath)).length,
+    acceptedColor: proposals.filter((proposal) => Boolean(proposal.accepted.color)).length,
+    acceptedPairs: proposals.filter(
+      (proposal) => Boolean(proposal.accepted.color && proposal.accepted.bw),
+    ).length,
+    finalPairs: proposals.filter(
+      (proposal) => Boolean(proposal.final.color && proposal.final.bw),
+    ).length,
+    needsReview: proposals.filter((proposal) => proposal.queue.status === 'needs_review')
+      .length,
+    blocked: proposals.filter((proposal) => Boolean(proposal.queue.semanticGateError)).length,
+  }
+}
+
+function parseLedger(
+  config: ColoringBookConfig,
+  content: string,
+  promptContent: string,
+  queue: Record<string, QueueEntry>,
+): ColoringBookStudioBook {
+  const bookSection = content.match(/^book:\s*$([\s\S]*?)(?=^[a-z_]+:|\Z)/m)?.[1] ?? ''
+  const order = yamlNumber(scalar(bookSection, 'order', 2), config.order)
+  const slug = scalar(bookSection, 'slug', 2) ?? config.slug
+  const title = scalar(bookSection, 'title', 2) ?? config.title
+  const targetProposals = yamlNumber(scalar(bookSection, 'target_proposals', 2), 36)
+  const coverIsSeparate = scalar(bookSection, 'cover_is_separate', 2) !== 'false'
+  const status = scalar(bookSection, 'status', 2) ?? 'unknown'
+  const monsterPrompts =
+    slug === 'monster-recast' ? parseMonsterPromptMap(promptContent) : {}
+  const proposalSection = content.split(/^proposals:\s*$/m)[1] ?? ''
+  const proposalBlocks = proposalSection
+    .split(/(?=^- slot:)/m)
+    .filter((block) => block.startsWith('- slot:'))
+
+  const proposals = proposalBlocks.map((block): ColoringBookProposal => {
+    const slot = yamlNumber(
+      yamlValue(block.match(/^- slot:\s*(.*?)\s*$/m)?.[1]),
+      0,
+    )
+    const id = scalar(block, 'id', 2) ?? `${slug}-${slot}`
+    const promptData = promptFromProposalBlock(block)
+    const queueEntry = queue[`${slug}:${id}`]
+    const queueState: ColoringBookQueueState = queueEntry
+      ? {
+          status: queueEntry.status,
+          imagePath: queueEntry.imagePath,
+          renderedPath: queueEntry.renderedPath,
+          artImageId: queueEntry.artImageId,
+          semanticScore: queueEntry.semanticScore,
+          semanticVerdict: queueEntry.semanticVerdict,
+          semanticAttempts: queueEntry.semanticAttempts,
+          semanticGateError: queueEntry.semanticGateError,
+          completedAt: queueEntry.completedAt,
+          renderEngine: queueEntry.renderEngine,
+          revisionCount: queueEntry.revisionCount,
+        }
+      : emptyQueueState()
+    const inspirations = parseInspirations(block, slug)
+    const accepted = parsePair(block, 'accepted')
+    const final = parsePair(block, 'final')
+    const prompt = monsterPrompts[id] || promptData.text
+    const promptRef = queueEntry?.sourceRef || promptData.ref
+    const proposal: ColoringBookProposal = {
+      slot,
+      id,
+      title: scalar(block, 'title', 2) ?? id,
+      prompt,
+      promptRef,
+      promptSourcePath: config.promptPath,
+      inspirations,
+      accepted,
+      final,
+      notes: parseNotes(block),
+      queue: queueState,
+      colorUrl: null,
+      bwUrl: null,
+    }
+    const colorPath = selectAssetPath(proposal, 'color')
+    const bwPath = selectAssetPath(proposal, 'bw')
+    proposal.colorUrl = colorPath ? rawAssetUrl(colorPath, slug) : null
+    proposal.bwUrl = bwPath ? rawAssetUrl(bwPath, slug) : null
+    return proposal
+  })
+
+  proposals.sort((a, b) => a.slot - b.slot)
+  return {
+    order,
+    slug,
+    title,
+    status,
+    targetProposals,
+    coverIsSeparate,
+    counts: countsFor(proposals),
+    proposals,
+  }
+}
+
+export function buildColoringBookStudioData(
+  files: ColoringBookSourceFiles,
+): ColoringBookStudioData {
+  const queue = parseQueue(files.queue)
+  const books = COLORING_BOOK_CONFIG.map((config) =>
+    parseLedger(
+      config,
+      files.ledgers[config.slug] ?? '',
+      files.prompts[config.slug] ?? '',
+      queue,
+    ),
+  ).sort((a, b) => a.order - b.order)
+
+  return {
+    books,
+    fetchedAt: new Date().toISOString(),
+    sourceRepo: COLORING_BOOK_REPO,
+    sourceRef: COLORING_BOOK_REF,
+  }
+}
+
+function wrapYamlText(value: string, width = 100): string[] {
+  const words = value.replace(/\r/g, '').replace(/\s+/g, ' ').trim().split(' ')
+  const lines: string[] = []
+  let current = ''
+  for (const word of words) {
+    if (!word) continue
+    const next = current ? `${current} ${word}` : word
+    if (next.length > width && current) {
+      lines.push(current)
+      current = word
+    } else {
+      current = next
+    }
+  }
+  if (current) lines.push(current)
+  return lines.length ? lines : ['']
+}
+
+export function replaceColoringBookPrompt(
+  config: ColoringBookConfig,
+  content: string,
+  proposalId: string,
+  prompt: string,
+): string {
+  const cleanPrompt = prompt.replace(/\r/g, '').replace(/\s+/g, ' ').trim()
+  if (!cleanPrompt) throw new Error('Prompt cannot be empty.')
+
+  if (config.slug === 'monster-recast') {
+    const startPattern = new RegExp(
+      `^    - id:\\s*${escapeRegExp(proposalId)}\\s*$`,
+      'm',
+    )
+    const start = content.search(startPattern)
+    if (start < 0) throw new Error(`Prompt source not found for ${proposalId}.`)
+    const tail = content.slice(start)
+    const next = tail.slice(1).search(/^    - id:/m)
+    const end = next < 0 ? content.length : start + 1 + next
+    const block = content.slice(start, end)
+    const promptMatch = /^      prompt:.*$/m.exec(block)
+    if (!promptMatch) throw new Error(`Prompt field not found for ${proposalId}.`)
+    const promptStart = start + (promptMatch.index ?? 0)
+    const afterPromptLine = promptStart + promptMatch[0].length
+    const remaining = content.slice(afterPromptLine, end)
+    const continuation = remaining.match(/^(?:\n        .*|\n\s*)*/)?.[0] ?? ''
+    const promptEnd = afterPromptLine + continuation.length
+    const replacement = [
+      '      prompt: >',
+      ...wrapYamlText(cleanPrompt).map((line) => `        ${line}`),
+    ].join('\n')
+    return `${content.slice(0, promptStart)}${replacement}${content.slice(promptEnd)}`
+  }
+
+  const proposalStarts = [...content.matchAll(/^- slot:\s*\d+\s*$/gm)]
+  const matchIndex = proposalStarts.findIndex((match, index) => {
+    const start = match.index ?? 0
+    const end = proposalStarts[index + 1]?.index ?? content.length
+    return new RegExp(`^  id:\\s*${escapeRegExp(proposalId)}\\s*$`, 'm').test(
+      content.slice(start, end),
+    )
+  })
+  if (matchIndex < 0) throw new Error(`Proposal not found: ${proposalId}.`)
+
+  const start = proposalStarts[matchIndex]?.index ?? 0
+  const end = proposalStarts[matchIndex + 1]?.index ?? content.length
+  const block = content.slice(start, end)
+  const promptStartMatch = /^  prompt:.*$/m.exec(block)
+  const inspirationMatch = /^  inspirations:/m.exec(block)
+  if (!promptStartMatch || !inspirationMatch) {
+    throw new Error(`Prompt section not found for ${proposalId}.`)
+  }
+  const promptStart = start + (promptStartMatch.index ?? 0)
+  const promptEnd = start + (inspirationMatch.index ?? block.length)
+  const current = promptFromProposalBlock(block)
+  const ref = current.ref ? JSON.stringify(current.ref) : 'null'
+  const replacement = [
+    '  prompt:',
+    '    text: >',
+    ...wrapYamlText(cleanPrompt).map((line) => `      ${line}`),
+    `    ref: ${ref}`,
+  ].join('\n')
+
+  return `${content.slice(0, promptStart)}${replacement}\n${content.slice(promptEnd)}`
+}
+
+export function coloringBookConfig(bookSlug: string): ColoringBookConfig | null {
+  return COLORING_BOOK_CONFIG.find((config) => config.slug === bookSlug) ?? null
+}
+
+export function proposalBelongsToBook(bookSlug: string, proposalId: string): boolean {
+  if (bookSlug === 'monster-recast') {
+    return /^(?:mr-\d{3}|mr-group-\d{3})$/.test(proposalId)
+  }
+  if (bookSlug === 'hollywood-recast') return /^hwr-\d{3}$/.test(proposalId)
+  if (bookSlug === 'kind-robots') return /^kr-\d{3}$/.test(proposalId)
+  return false
+}

--- a/stores/coloringBookStudioStore.ts
+++ b/stores/coloringBookStudioStore.ts
@@ -1,0 +1,203 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import type {
+  ColoringBookPromptUpdate,
+  ColoringBookRenderRequest,
+  ColoringBookStudioBook,
+  ColoringBookStudioData,
+} from '~/types/coloringBookStudio'
+import { performFetch } from '@/stores/utils'
+
+export const useColoringBookStudioStore = defineStore(
+  'coloringBookStudioStore',
+  () => {
+    const books = ref<ColoringBookStudioBook[]>([])
+    const selectedBookSlug = ref('monster-recast')
+    const selectedProposalId = ref('')
+    const loading = ref(false)
+    const savingPrompt = ref(false)
+    const requestingRender = ref(false)
+    const error = ref<string | null>(null)
+    const message = ref<string | null>(null)
+    const fetchedAt = ref<string | null>(null)
+
+    const selectedBook = computed(
+      () =>
+        books.value.find((book) => book.slug === selectedBookSlug.value) ??
+        books.value[0] ??
+        null,
+    )
+
+    const selectedProposal = computed(() => {
+      const book = selectedBook.value
+      if (!book) return null
+      return (
+        book.proposals.find(
+          (proposal) => proposal.id === selectedProposalId.value,
+        ) ??
+        book.proposals[0] ??
+        null
+      )
+    })
+
+    const queueProblems = computed(() =>
+      books.value.flatMap((book) =>
+        book.proposals
+          .filter(
+            (proposal) =>
+              proposal.queue.semanticGateError ||
+              proposal.queue.status === 'needs_review',
+          )
+          .map((proposal) => ({
+            bookSlug: book.slug,
+            bookTitle: book.title,
+            proposal,
+          })),
+      ),
+    )
+
+    function keepSelectionValid(): void {
+      const book = selectedBook.value
+      if (!book) {
+        selectedProposalId.value = ''
+        return
+      }
+      if (
+        !book.proposals.some(
+          (proposal) => proposal.id === selectedProposalId.value,
+        )
+      ) {
+        selectedProposalId.value = book.proposals[0]?.id ?? ''
+      }
+    }
+
+    async function fetchStudio(): Promise<boolean> {
+      loading.value = true
+      error.value = null
+      try {
+        const response = await performFetch<ColoringBookStudioData>(
+          '/api/conductor/coloring-books',
+        )
+        if (!response.success || !response.data) {
+          error.value = response.message || 'Failed to load the Coloring Book Studio.'
+          return false
+        }
+        books.value = response.data.books
+        fetchedAt.value = response.data.fetchedAt
+        if (
+          !books.value.some((book) => book.slug === selectedBookSlug.value)
+        ) {
+          selectedBookSlug.value = books.value[0]?.slug ?? ''
+        }
+        keepSelectionValid()
+        return true
+      } finally {
+        loading.value = false
+      }
+    }
+
+    function selectBook(bookSlug: string): void {
+      selectedBookSlug.value = bookSlug
+      keepSelectionValid()
+      message.value = null
+      error.value = null
+    }
+
+    function selectProposal(proposalId: string): void {
+      selectedProposalId.value = proposalId
+      message.value = null
+      error.value = null
+    }
+
+    async function savePrompt(prompt: string): Promise<boolean> {
+      const book = selectedBook.value
+      const proposal = selectedProposal.value
+      if (!book || !proposal || savingPrompt.value) return false
+
+      savingPrompt.value = true
+      error.value = null
+      message.value = null
+      try {
+        const body: ColoringBookPromptUpdate = {
+          bookSlug: book.slug,
+          proposalId: proposal.id,
+          prompt,
+        }
+        const response = await performFetch<ColoringBookPromptUpdate>(
+          '/api/conductor/coloring-books/prompt',
+          { method: 'POST', body: JSON.stringify(body) },
+        )
+        if (!response.success) {
+          error.value = response.message || 'Failed to save the prompt.'
+          return false
+        }
+        message.value = response.message || `${proposal.id} prompt saved.`
+        await fetchStudio()
+        return true
+      } finally {
+        savingPrompt.value = false
+      }
+    }
+
+    async function requestColorRender(
+      force = false,
+      note = '',
+    ): Promise<boolean> {
+      const book = selectedBook.value
+      const proposal = selectedProposal.value
+      if (!book || !proposal || requestingRender.value) return false
+
+      requestingRender.value = true
+      error.value = null
+      message.value = null
+      try {
+        const body: ColoringBookRenderRequest = {
+          bookSlug: book.slug,
+          proposalId: proposal.id,
+          force,
+          note,
+        }
+        const response = await performFetch<ColoringBookRenderRequest>(
+          '/api/conductor/coloring-books/request',
+          { method: 'POST', body: JSON.stringify(body) },
+        )
+        if (!response.success) {
+          error.value = response.message || 'Failed to request the render.'
+          return false
+        }
+        message.value =
+          response.message || `${proposal.id} render request queued.`
+        await fetchStudio()
+        return true
+      } finally {
+        requestingRender.value = false
+      }
+    }
+
+    function clearNotice(): void {
+      error.value = null
+      message.value = null
+    }
+
+    return {
+      books,
+      selectedBookSlug,
+      selectedProposalId,
+      selectedBook,
+      selectedProposal,
+      queueProblems,
+      loading,
+      savingPrompt,
+      requestingRender,
+      error,
+      message,
+      fetchedAt,
+      fetchStudio,
+      selectBook,
+      selectProposal,
+      savePrompt,
+      requestColorRender,
+      clearNotice,
+    }
+  },
+)

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -1,0 +1,85 @@
+export type ColoringBookVariant = 'color' | 'bw'
+
+export type ColoringBookAsset = {
+  path: string
+  kind: string
+  url: string | null
+}
+
+export type ColoringBookPair = {
+  color: string | null
+  bw: string | null
+}
+
+export type ColoringBookQueueState = {
+  status: string
+  imagePath: string | null
+  renderedPath: string | null
+  artImageId: number | null
+  semanticScore: number | null
+  semanticVerdict: string | null
+  semanticAttempts: number
+  semanticGateError: string | null
+  completedAt: string | null
+  renderEngine: string | null
+  revisionCount: number
+}
+
+export type ColoringBookProposal = {
+  slot: number
+  id: string
+  title: string
+  prompt: string
+  promptRef: string | null
+  promptSourcePath: string
+  inspirations: ColoringBookAsset[]
+  accepted: ColoringBookPair
+  final: ColoringBookPair
+  notes: string[]
+  queue: ColoringBookQueueState
+  colorUrl: string | null
+  bwUrl: string | null
+}
+
+export type ColoringBookCounts = {
+  total: number
+  prompts: number
+  pending: number
+  rendered: number
+  acceptedColor: number
+  acceptedPairs: number
+  finalPairs: number
+  needsReview: number
+  blocked: number
+}
+
+export type ColoringBookStudioBook = {
+  order: number
+  slug: string
+  title: string
+  status: string
+  targetProposals: number
+  coverIsSeparate: boolean
+  counts: ColoringBookCounts
+  proposals: ColoringBookProposal[]
+}
+
+export type ColoringBookStudioData = {
+  books: ColoringBookStudioBook[]
+  fetchedAt: string
+  sourceRepo: string
+  sourceRef: string
+}
+
+export type ColoringBookPromptUpdate = {
+  bookSlug: string
+  proposalId: string
+  prompt: string
+}
+
+export type ColoringBookRenderRequest = {
+  bookSlug: string
+  proposalId: string
+  force?: boolean
+  note?: string
+}


### PR DESCRIPTION
## What changed

- replaces the generic Color / Galleries / Generate / Proposals / Prompts tabs with a production-focused studio
- loads Monster Recast, Hollywood Recast, and Kind Robots directly from their canonical Conductor proposal ledgers and color queue
- shows all proposal slots with current color and black-and-white candidates, prompt text, accepted/final pair state, semantic score, queue errors, and revision count
- adds a typed Pinia store so components never call API routes directly
- adds admin-only canonical prompt editing for the correct source file, including Monster Recast's referenced art-modeler prompts
- adds admin-only proposal-targeted color candidate and revision requests through Conductor's `color-art-events` bridge
- keeps the existing end-user coloring engine as a separate Color Preview tab

## Why

The existing front end was disconnected from the actual production model. Generic gallery generation and pitch cards did not know about the three books, their 36 proposal IDs, accepted masters, color/BW pair state, or Conductor queue failures. This makes the browser reflect the same source of truth used by backend automation and chat-driven production.

## Architecture

- Conductor remains authoritative; no Prisma coloring-book mirror is introduced.
- `coloringBookStudioStore` owns all component/API interaction.
- server routes read and update exact Conductor files through the existing GitHub adapter.
- render requests use the proposal-targeted event contract now merged to Conductor `main` in PR #1307.

## Deliberate next slice

This PR displays accepted/final state but does not yet add promotion controls or targeted B&W conversion. B&W remains color-first: approve a color composition, then derive its faithful line-art pair through a follow-up pipeline action.

## Validation

- TypeScript Type Check: passed
- Contract Tests: passed, including Conductor auth and capture-group safety
- Narrative Primitives Contract: passed
- Storymaker Studio Contract: passed
- Facet Catalog Contract: passed
- API Client Follow-ups Contract: passed

The PR remains draft for a browser/preview pass before merge.