### PR TITLE
media-watchlist: wire "most active month" stat into browse UI

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -12,6 +12,9 @@
   (TV only), and the two extra stats tiles (comics read, TV seasons) close
   the BROWSE-UX.md §2/§4 gaps -- the API already computed/accepted this
   data, it just wasn't wired into the UI yet (media-watchlist/t-006, t-012).
+  The "most active month" line (media-watchlist/t-013, BROWSE-UX.md §1) reuses
+  the same stats.get.ts countByMonth breakdown that already powers the Month
+  filter chips -- no backend change needed, just picking the max and naming it.
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -26,6 +29,15 @@
     </div>
 
     <template v-else>
+      <!-- Most active month (BROWSE-UX.md §1) -->
+      <p
+        v-if="mostActiveMonth"
+        class="rounded-2xl border border-base-300 bg-base-100 px-4 py-2 text-center text-sm font-semibold text-base-content/70"
+      >
+        You consumed the most in {{ mostActiveMonth.label }}:
+        {{ mostActiveMonth.count }} entries
+      </p>
+
       <!-- Stats strip -->
       <div
         v-if="stats"
@@ -366,6 +378,7 @@ type MediaEntryStats = {
   years: number[]
   totalCount: number
   starredCount: number
+  countByMonth: Record<string, number>
   audiobookHours: number
   pagesRead: number
   comicIssuesRead: number
@@ -423,6 +436,28 @@ const isLoading = ref(false)
 const errorMessage = ref('')
 const stats = ref<MediaEntryStats | null>(null)
 const selectedId = ref<number | null>(null)
+
+// BROWSE-UX.md §1: "Most active month: 'You consumed the most in [Month]: N
+// entries'". countByMonth is keyed by month number as a string (1-12); pick
+// the highest count and name it. No entry -> hide the line rather than
+// showing a false "January: 0".
+const mostActiveMonth = computed(() => {
+  const counts = stats.value?.countByMonth
+  if (!counts) return null
+  let bestMonth: number | null = null
+  let bestCount = 0
+  for (const [monthKey, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      bestCount = count
+      bestMonth = Number(monthKey)
+    }
+  }
+  if (bestMonth === null) return null
+  const label = new Date(2000, bestMonth - 1, 1).toLocaleString('en-US', {
+    month: 'long',
+  })
+  return { label, count: bestCount }
+})
 
 const canShowMore = computed(() => entries.value.length < total.value)
 const selectedEntry = computed(


### PR DESCRIPTION
### Task
media-watchlist/t-013: Wire the "most active month" home-dashboard stat from BROWSE-UX.md §1 into the UI (kind: software)

### What changed / what I produced
- `components/watchlist/watchlist-browse.vue`: added a `countByMonth` field to the `MediaEntryStats` frontend type (the backend `stats.get.ts` already computed this — no server change needed), a `mostActiveMonth` computed property that picks the month with the highest count, and a single-line stat above the existing stats strip: "You consumed the most in [Month]: N entries" per BROWSE-UX.md §1's exact spec. Hidden entirely when there's no data, so it never shows a false "January: 0".

### How I verified
- `npx eslint components/watchlist/watchlist-browse.vue` — clean
- `npx prettier --check components/watchlist/watchlist-browse.vue` — clean
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0
- No live browser smoke test — no reachable `DATABASE_URL` in this sandbox (same recurring blocker as every prior cycle on this file, see t-006/t-010/t-012 TALKBACK entries).

### Stakes
reversible

### Flags for Reviewer
- Placed the stat as its own line above the stats grid rather than as a 7th tile in the `lg:grid-cols-6` grid, since the spec's full sentence ("You consumed the most in [Month]: N entries") doesn't fit the short-pill format of the other tiles. Open to a different placement if Reviewer disagrees.

### Kaizen suggestion
BROWSE-UX.md §1 also specs "Recent entries (last 10, reverse-chronological; grouped by media type icon)" and "Quick filter chips" for a dedicated Home/Summary Dashboard view — currently `/watchlist` only renders the Browse view (`watchlist-browse.vue`), there's no separate Home dashboard page at all. Worth a future task to scope whether §1 needs its own route/component, since three stats-bar items now exist in the Browse view but the other §1 elements (recent entries list, quick filter chips as a distinct affordance) still don't exist anywhere.

### Notes for reviewer
This is the fourth consecutive cycle on this file (t-006, t-010, t-012, now t-013) finding already-computed server data that just needed front-end wiring — same recurring pattern documented in prior TALKBACK entries.


---
_Generated by [Claude Code](https://claude.ai/code/session_017DDv2LE7pxqddfekxwkj19)_