### PR TITLE
coloring: add acceptance and matched-pair controls

### DIFF
--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -6,7 +6,10 @@
     :show-deliverables="false"
   >
     <template #interactive>
-      <coloring-book-studio />
+      <div class="flex flex-col gap-5">
+        <coloring-book-production-toolbar />
+        <coloring-book-studio />
+      </div>
     </template>
   </ProjectFrontPage>
 </template>
@@ -22,30 +25,31 @@ const config: ProjectFrontConfig = {
   icon: 'kind-icon:paintbrush',
   tagline: 'Build, review, pair, and color three living books.',
   description:
-    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Review all 36 proposal slots in each book, edit the canonical Conductor prompts, compare current color and black-and-white versions, request targeted candidates or revisions, inspect queue failures, and preview finished pages in the shared coloring engine.',
+    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Review all 36 proposal slots in each book, edit the canonical Conductor prompts, compare current color and black-and-white versions, request targeted candidates or revisions, accept working masters, confirm final pairs, inspect queue failures, and preview finished pages in the shared coloring engine.',
   sections: [
     {
       key: 'production',
       title: 'One canonical production view',
-      body: 'The front end now reads the same proposal ledgers and color queue used by Conductor instead of maintaining unrelated prompt cards and gallery generations.',
+      body: 'The front end reads and updates the same proposal ledgers and production queue used by Conductor instead of maintaining unrelated prompt cards and gallery generations.',
       icon: 'kind-icon:book',
     },
     {
       key: 'review',
-      title: 'Prompt, render, and review by page',
-      body: 'Select any proposal ID, inspect its strongest color and line-art candidates, save the real production prompt, and send a proposal-targeted render request through the semantic-gated pipeline.',
+      title: 'Prompt, render, accept, and pair',
+      body: 'Select any proposal ID, inspect its current candidates, save the real production prompt, request exact renders, accept color and B&W masters, and finalize a mechanically and semantically validated matched pair.',
       icon: 'kind-icon:sparkles',
     },
   ],
   deliverables: {
     done: [
       'Shared coloring engine with region fill, flood fill, palette, undo, and export',
-      'Sampler and Cozy Corner end-user sets',
       'Three canonical 36-proposal production ledgers in Conductor',
+      'Proposal-targeted color and B&W generation with human-gated acceptance',
+      'Matched-pair validation and finalization controls',
     ],
     next: [
-      'Proposal-level acceptance and final-pair promotion controls',
-      'Targeted black-and-white conversion after color-master approval',
+      'Rejected and revision candidate history browser',
+      'Cover production management',
       'Print-ready package and storefront hand-off',
     ],
   },

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -1,0 +1,333 @@
+<template>
+  <section
+    v-if="proposal"
+    class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+  >
+    <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="badge badge-primary rounded-2xl">Production actions</span>
+          <span class="text-xs font-black uppercase tracking-widest text-base-content/40">
+            {{ book?.title }} · {{ proposal.id }}
+          </span>
+        </div>
+        <h3 class="mt-2 text-xl font-black">{{ proposal.title }}</h3>
+        <p class="mt-1 max-w-3xl text-sm text-base-content/55">
+          Human decisions and counterpart generation now write directly to the canonical
+          Conductor ledger. Generation may suggest. Only these controls accept.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <span class="badge badge-outline rounded-2xl">
+          Color {{ production?.colorStatus || proposal.queue.status }}
+        </span>
+        <span class="badge badge-outline rounded-2xl">
+          B&amp;W {{ production?.bwStatus || 'missing' }}
+        </span>
+        <span v-if="production?.pairStatus" class="badge badge-outline rounded-2xl">
+          Pair {{ production.pairStatus }}
+        </span>
+      </div>
+    </header>
+
+    <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+      <stage-card
+        label="Color candidate"
+        :done="Boolean(proposal.colorUrl)"
+        :detail="colorCandidateDetail"
+        icon="kind-icon:palette"
+      />
+      <stage-card
+        label="Accepted color"
+        :done="Boolean(proposal.accepted.color)"
+        :detail="proposal.accepted.color || 'Awaiting human acceptance'"
+        icon="kind-icon:check"
+      />
+      <stage-card
+        label="B&W candidate"
+        :done="Boolean(production?.bwRenderedPath)"
+        :detail="bwCandidateDetail"
+        icon="kind-icon:pencil"
+      />
+      <stage-card
+        label="Accepted B&W"
+        :done="Boolean(proposal.accepted.bw)"
+        :detail="proposal.accepted.bw || 'Awaiting human acceptance'"
+        icon="kind-icon:check"
+      />
+      <stage-card
+        label="Final pair"
+        :done="isFinalPair"
+        :detail="isFinalPair ? 'Confirmed print-ready pair' : 'Not finalized'"
+        icon="kind-icon:book"
+      />
+    </div>
+
+    <div
+      v-if="production?.bwUrl || proposal.bwUrl"
+      class="grid gap-4 rounded-2xl border border-base-300 bg-base-200/40 p-4 lg:grid-cols-[10rem_minmax(0,1fr)]"
+    >
+      <img
+        :src="production?.bwUrl || proposal.bwUrl || ''"
+        :alt="`${proposal.title} black-and-white candidate`"
+        class="aspect-[2/3] w-full rounded-2xl border border-base-300 bg-white object-contain"
+      />
+      <div class="flex flex-col gap-2">
+        <h4 class="font-black">Current B&amp;W production candidate</h4>
+        <p class="break-all text-xs text-base-content/50">
+          {{ production?.bwRenderedPath || proposal.accepted.bw || proposal.final.bw }}
+        </p>
+        <div class="flex flex-wrap gap-2 text-xs">
+          <span v-if="production?.bwSemanticScore !== null" class="badge badge-info rounded-2xl">
+            Pair score {{ production?.bwSemanticScore }}
+          </span>
+          <span v-if="production?.bwSemanticVerdict" class="badge badge-outline rounded-2xl">
+            {{ production.bwSemanticVerdict }}
+          </span>
+          <span v-if="production?.bwRevisionCount" class="badge badge-outline rounded-2xl">
+            {{ production.bwRevisionCount }} archived revision{{ production.bwRevisionCount === 1 ? '' : 's' }}
+          </span>
+        </div>
+        <ul
+          v-if="production?.bwSemanticReasons.length"
+          class="mt-1 list-disc space-y-1 pl-5 text-xs text-warning"
+        >
+          <li v-for="reason in production.bwSemanticReasons" :key="reason">
+            {{ reason }}
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div v-if="userStore.isAdmin" class="flex flex-col gap-3">
+      <input
+        v-model="actionNote"
+        type="text"
+        class="input input-bordered w-full rounded-2xl"
+        placeholder="Optional decision or revision note"
+      />
+
+      <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <action-button
+          label="Accept color master"
+          confirm-label="Confirm color acceptance"
+          icon="kind-icon:palette"
+          :enabled="canAcceptColor"
+          :armed="armedAction === 'accept-color'"
+          :busy="studio.requestingAction"
+          @click="runHumanAction('accept-color')"
+        />
+
+        <button
+          type="button"
+          class="btn rounded-2xl"
+          :class="canRequestBw ? 'btn-secondary' : 'btn-disabled'"
+          :disabled="!canRequestBw || studio.requestingAction"
+          @click="requestBw(false)"
+        >
+          <span v-if="studio.requestingAction" class="loading loading-spinner loading-sm" />
+          <icon v-else name="kind-icon:pencil" class="size-5" />
+          Generate B&amp;W counterpart
+        </button>
+
+        <action-button
+          label="Accept B&W master"
+          confirm-label="Confirm B&W acceptance"
+          icon="kind-icon:check"
+          :enabled="canAcceptBw"
+          :armed="armedAction === 'accept-bw'"
+          :busy="studio.requestingAction"
+          @click="runHumanAction('accept-bw')"
+        />
+
+        <action-button
+          label="Finalize matched pair"
+          confirm-label="Confirm final pair"
+          icon="kind-icon:book"
+          :enabled="canFinalizePair"
+          :armed="armedAction === 'finalize-pair'"
+          :busy="studio.requestingAction"
+          @click="runHumanAction('finalize-pair')"
+        />
+      </div>
+
+      <button
+        v-if="canReviseBw"
+        type="button"
+        class="btn btn-outline btn-warning self-start rounded-2xl"
+        :disabled="studio.requestingAction"
+        @click="requestBw(true)"
+      >
+        <icon name="kind-icon:refresh" class="size-5" />
+        Archive and regenerate B&amp;W
+      </button>
+
+      <p v-if="armedAction" class="text-xs font-semibold text-warning">
+        This writes a production decision to Conductor. Click the highlighted button again to confirm.
+      </p>
+    </div>
+
+    <div v-else class="alert rounded-2xl">
+      <icon name="kind-icon:lock" class="size-5" />
+      <span>Production decisions are visible to everyone and writable by admins.</span>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { ColoringBookStudioOperation } from '~/types/coloringBookStudio'
+import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+import { useUserStore } from '@/stores/userStore'
+
+const studio = useColoringBookStudioStore()
+const userStore = useUserStore()
+const actionNote = ref('')
+const armedAction = ref<ColoringBookStudioOperation | null>(null)
+
+const book = computed(() => studio.selectedBook)
+const proposal = computed(() => studio.selectedProposal)
+const production = computed(() => studio.selectedProductionState)
+
+const isFinalPair = computed(() =>
+  Boolean(proposal.value?.final.color && proposal.value?.final.bw),
+)
+
+const canAcceptColor = computed(() =>
+  Boolean(
+    proposal.value &&
+      !proposal.value.accepted.color &&
+      proposal.value.colorUrl &&
+      proposal.value.queue.status === 'done',
+  ),
+)
+
+const canRequestBw = computed(() => {
+  if (!proposal.value?.accepted.color || proposal.value.accepted.bw) return false
+  const status = production.value?.bwStatus || 'missing'
+  return !['running', 'done', 'approved', 'needs_review'].includes(status)
+})
+
+const canReviseBw = computed(() => {
+  if (!proposal.value?.accepted.color || proposal.value.accepted.bw) return false
+  return ['done', 'needs_review', 'failed'].includes(
+    production.value?.bwStatus || '',
+  )
+})
+
+const canAcceptBw = computed(() =>
+  Boolean(
+    proposal.value &&
+      !proposal.value.accepted.bw &&
+      production.value?.bwStatus === 'done' &&
+      production.value.bwRenderedPath,
+  ),
+)
+
+const canFinalizePair = computed(() =>
+  Boolean(
+    proposal.value?.accepted.color &&
+      proposal.value.accepted.bw &&
+      !isFinalPair.value,
+  ),
+)
+
+const colorCandidateDetail = computed(() => {
+  if (proposal.value?.accepted.color) return 'Accepted master recorded'
+  if (proposal.value?.queue.semanticScore !== null) {
+    return `Semantic score ${proposal.value?.queue.semanticScore}`
+  }
+  return proposal.value?.queue.status || 'No candidate'
+})
+
+const bwCandidateDetail = computed(() => {
+  if (proposal.value?.accepted.bw) return 'Accepted master recorded'
+  if (production.value?.bwSemanticScore !== null) {
+    return `Pair score ${production.value?.bwSemanticScore}`
+  }
+  return production.value?.bwStatus || 'No candidate'
+})
+
+watch(
+  () => `${studio.selectedBookSlug}:${studio.selectedProposalId}`,
+  () => {
+    armedAction.value = null
+    actionNote.value = ''
+  },
+)
+
+async function runHumanAction(
+  operation: 'accept-color' | 'accept-bw' | 'finalize-pair',
+): Promise<void> {
+  if (armedAction.value !== operation) {
+    armedAction.value = operation
+    return
+  }
+  const success = await studio.requestProductionAction(operation, {
+    note: actionNote.value,
+  })
+  if (success) {
+    armedAction.value = null
+    actionNote.value = ''
+  }
+}
+
+async function requestBw(force: boolean): Promise<void> {
+  armedAction.value = null
+  const success = await studio.requestBw(force, actionNote.value)
+  if (success) actionNote.value = ''
+}
+</script>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  components: {
+    StageCard: defineComponent({
+      props: {
+        label: { type: String, required: true },
+        detail: { type: String, required: true },
+        icon: { type: String, required: true },
+        done: { type: Boolean, default: false },
+      },
+      template: `
+        <article class="flex min-h-28 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3">
+          <div class="flex items-center justify-between gap-2">
+            <icon :name="icon" class="size-5" :class="done ? 'text-success' : 'text-base-content/40'" />
+            <span class="badge badge-sm rounded-2xl" :class="done ? 'badge-success' : 'badge-ghost'">
+              {{ done ? 'Ready' : 'Waiting' }}
+            </span>
+          </div>
+          <h4 class="text-sm font-black">{{ label }}</h4>
+          <p class="line-clamp-2 break-all text-xs text-base-content/50">{{ detail }}</p>
+        </article>
+      `,
+    }),
+    ActionButton: defineComponent({
+      emits: ['click'],
+      props: {
+        label: { type: String, required: true },
+        confirmLabel: { type: String, required: true },
+        icon: { type: String, required: true },
+        enabled: { type: Boolean, default: false },
+        armed: { type: Boolean, default: false },
+        busy: { type: Boolean, default: false },
+      },
+      template: `
+        <button
+          type="button"
+          class="btn rounded-2xl"
+          :class="armed ? 'btn-warning' : enabled ? 'btn-primary' : 'btn-disabled'"
+          :disabled="!enabled || busy"
+          @click="$emit('click')"
+        >
+          <span v-if="busy" class="loading loading-spinner loading-sm" />
+          <icon v-else :name="icon" class="size-5" />
+          {{ armed ? confirmLabel : label }}
+        </button>
+      `,
+    }),
+  },
+})
+</script>

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -31,35 +31,35 @@
     </header>
 
     <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-      <stage-card
+      <ProductionStageCard
         label="Color candidate"
         :done="Boolean(proposal.colorUrl)"
         :detail="colorCandidateDetail"
-        icon="kind-icon:palette"
+        icon-name="kind-icon:palette"
       />
-      <stage-card
+      <ProductionStageCard
         label="Accepted color"
         :done="Boolean(proposal.accepted.color)"
         :detail="proposal.accepted.color || 'Awaiting human acceptance'"
-        icon="kind-icon:check"
+        icon-name="kind-icon:check"
       />
-      <stage-card
+      <ProductionStageCard
         label="B&W candidate"
         :done="Boolean(production?.bwRenderedPath)"
         :detail="bwCandidateDetail"
-        icon="kind-icon:pencil"
+        icon-name="kind-icon:pencil"
       />
-      <stage-card
+      <ProductionStageCard
         label="Accepted B&W"
         :done="Boolean(proposal.accepted.bw)"
         :detail="proposal.accepted.bw || 'Awaiting human acceptance'"
-        icon="kind-icon:check"
+        icon-name="kind-icon:check"
       />
-      <stage-card
+      <ProductionStageCard
         label="Final pair"
         :done="isFinalPair"
         :detail="isFinalPair ? 'Confirmed print-ready pair' : 'Not finalized'"
-        icon="kind-icon:book"
+        icon-name="kind-icon:book"
       />
     </div>
 
@@ -78,7 +78,7 @@
           {{ production?.bwRenderedPath || proposal.accepted.bw || proposal.final.bw }}
         </p>
         <div class="flex flex-wrap gap-2 text-xs">
-          <span v-if="production?.bwSemanticScore !== null" class="badge badge-info rounded-2xl">
+          <span v-if="hasBwScore" class="badge badge-info rounded-2xl">
             Pair score {{ production?.bwSemanticScore }}
           </span>
           <span v-if="production?.bwSemanticVerdict" class="badge badge-outline rounded-2xl">
@@ -108,10 +108,10 @@
       />
 
       <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <action-button
+        <ProductionActionButton
           label="Accept color master"
           confirm-label="Confirm color acceptance"
-          icon="kind-icon:palette"
+          icon-name="kind-icon:palette"
           :enabled="canAcceptColor"
           :armed="armedAction === 'accept-color'"
           :busy="studio.requestingAction"
@@ -130,20 +130,20 @@
           Generate B&amp;W counterpart
         </button>
 
-        <action-button
+        <ProductionActionButton
           label="Accept B&W master"
           confirm-label="Confirm B&W acceptance"
-          icon="kind-icon:check"
+          icon-name="kind-icon:check"
           :enabled="canAcceptBw"
           :armed="armedAction === 'accept-bw'"
           :busy="studio.requestingAction"
           @click="runHumanAction('accept-bw')"
         />
 
-        <action-button
+        <ProductionActionButton
           label="Finalize matched pair"
           confirm-label="Confirm final pair"
-          icon="kind-icon:book"
+          icon-name="kind-icon:book"
           :enabled="canFinalizePair"
           :armed="armedAction === 'finalize-pair'"
           :busy="studio.requestingAction"
@@ -177,6 +177,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import type { ColoringBookStudioOperation } from '~/types/coloringBookStudio'
+import ProductionActionButton from './production-action-button.vue'
+import ProductionStageCard from './production-stage-card.vue'
 import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -191,6 +193,10 @@ const production = computed(() => studio.selectedProductionState)
 
 const isFinalPair = computed(() =>
   Boolean(proposal.value?.final.color && proposal.value?.final.bw),
+)
+
+const hasBwScore = computed(
+  () => typeof production.value?.bwSemanticScore === 'number',
 )
 
 const canAcceptColor = computed(() =>
@@ -234,16 +240,16 @@ const canFinalizePair = computed(() =>
 
 const colorCandidateDetail = computed(() => {
   if (proposal.value?.accepted.color) return 'Accepted master recorded'
-  if (proposal.value?.queue.semanticScore !== null) {
-    return `Semantic score ${proposal.value?.queue.semanticScore}`
+  if (typeof proposal.value?.queue.semanticScore === 'number') {
+    return `Semantic score ${proposal.value.queue.semanticScore}`
   }
   return proposal.value?.queue.status || 'No candidate'
 })
 
 const bwCandidateDetail = computed(() => {
   if (proposal.value?.accepted.bw) return 'Accepted master recorded'
-  if (production.value?.bwSemanticScore !== null) {
-    return `Pair score ${production.value?.bwSemanticScore}`
+  if (typeof production.value?.bwSemanticScore === 'number') {
+    return `Pair score ${production.value.bwSemanticScore}`
   }
   return production.value?.bwStatus || 'No candidate'
 })
@@ -277,57 +283,4 @@ async function requestBw(force: boolean): Promise<void> {
   const success = await studio.requestBw(force, actionNote.value)
   if (success) actionNote.value = ''
 }
-</script>
-
-<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  components: {
-    StageCard: defineComponent({
-      props: {
-        label: { type: String, required: true },
-        detail: { type: String, required: true },
-        icon: { type: String, required: true },
-        done: { type: Boolean, default: false },
-      },
-      template: `
-        <article class="flex min-h-28 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3">
-          <div class="flex items-center justify-between gap-2">
-            <icon :name="icon" class="size-5" :class="done ? 'text-success' : 'text-base-content/40'" />
-            <span class="badge badge-sm rounded-2xl" :class="done ? 'badge-success' : 'badge-ghost'">
-              {{ done ? 'Ready' : 'Waiting' }}
-            </span>
-          </div>
-          <h4 class="text-sm font-black">{{ label }}</h4>
-          <p class="line-clamp-2 break-all text-xs text-base-content/50">{{ detail }}</p>
-        </article>
-      `,
-    }),
-    ActionButton: defineComponent({
-      emits: ['click'],
-      props: {
-        label: { type: String, required: true },
-        confirmLabel: { type: String, required: true },
-        icon: { type: String, required: true },
-        enabled: { type: Boolean, default: false },
-        armed: { type: Boolean, default: false },
-        busy: { type: Boolean, default: false },
-      },
-      template: `
-        <button
-          type="button"
-          class="btn rounded-2xl"
-          :class="armed ? 'btn-warning' : enabled ? 'btn-primary' : 'btn-disabled'"
-          :disabled="!enabled || busy"
-          @click="$emit('click')"
-        >
-          <span v-if="busy" class="loading loading-spinner loading-sm" />
-          <icon v-else :name="icon" class="size-5" />
-          {{ armed ? confirmLabel : label }}
-        </button>
-      `,
-    }),
-  },
-})
 </script>

--- a/components/coloring/production-action-button.vue
+++ b/components/coloring/production-action-button.vue
@@ -1,0 +1,28 @@
+<template>
+  <button
+    type="button"
+    class="btn rounded-2xl"
+    :class="armed ? 'btn-warning' : enabled ? 'btn-primary' : 'btn-disabled'"
+    :disabled="!enabled || busy"
+    @click="emit('click')"
+  >
+    <span v-if="busy" class="loading loading-spinner loading-sm" />
+    <icon v-else :name="iconName" class="size-5" />
+    {{ armed ? confirmLabel : label }}
+  </button>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+  confirmLabel: string
+  iconName: string
+  enabled?: boolean
+  armed?: boolean
+  busy?: boolean
+}>()
+
+const emit = defineEmits<{
+  click: []
+}>()
+</script>

--- a/components/coloring/production-stage-card.vue
+++ b/components/coloring/production-stage-card.vue
@@ -1,0 +1,32 @@
+<template>
+  <article
+    class="flex min-h-28 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <icon
+        :name="iconName"
+        class="size-5"
+        :class="done ? 'text-success' : 'text-base-content/40'"
+      />
+      <span
+        class="badge badge-sm rounded-2xl"
+        :class="done ? 'badge-success' : 'badge-ghost'"
+      >
+        {{ done ? 'Ready' : 'Waiting' }}
+      </span>
+    </div>
+    <h4 class="text-sm font-black">{{ label }}</h4>
+    <p class="line-clamp-2 break-all text-xs text-base-content/50">
+      {{ detail }}
+    </p>
+  </article>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+  detail: string
+  iconName: string
+  done?: boolean
+}>()
+</script>

--- a/server/api/conductor/coloring-books/production.get.ts
+++ b/server/api/conductor/coloring-books/production.get.ts
@@ -1,0 +1,29 @@
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { conductorGet } from '@/server/utils/conductor-github'
+import { COLORING_BOOK_QUEUE_PATH } from '@/server/utils/coloringBookStudio'
+import { buildColoringBookProductionData } from '@/server/utils/coloringBookProductionState'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const queueFile = await conductorGet(COLORING_BOOK_QUEUE_PATH)
+    if (!queueFile) throw new Error('Canonical coloring-book queue was not found.')
+
+    const data = buildColoringBookProductionData(queueFile.content)
+    return {
+      success: true,
+      message: `${Object.keys(data.states).length} production records loaded from Conductor.`,
+      data,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to load coloring-book production state.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/conductor/coloring-books/request.post.ts
+++ b/server/api/conductor/coloring-books/request.post.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import { createError, defineEventHandler, readBody } from 'h3'
-import type { ColoringBookRenderRequest } from '~/types/coloringBookStudio'
+import type {
+  ColoringBookRenderRequest,
+  ColoringBookStudioOperation,
+} from '~/types/coloringBookStudio'
 import { requireAdminApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
 import {
@@ -12,14 +15,39 @@ import {
   proposalBelongsToBook,
 } from '@/server/utils/coloringBookStudio'
 
+const OPERATIONS = new Set<ColoringBookStudioOperation>([
+  'generate-color-proposals',
+  'accept-color',
+  'generate-bw',
+  'accept-bw',
+  'finalize-pair',
+])
+
+const OPERATION_LABELS: Record<ColoringBookStudioOperation, string> = {
+  'generate-color-proposals': 'color candidate',
+  'accept-color': 'color acceptance',
+  'generate-bw': 'B&W counterpart',
+  'accept-bw': 'B&W acceptance',
+  'finalize-pair': 'pair finalization',
+}
+
 function compact(value: string): string {
   return value.replace(/\r/g, '').replace(/\s+/g, ' ').trim()
+}
+
+function normalizeOperation(value: unknown): ColoringBookStudioOperation {
+  const operation = compact(String(value || 'generate-color-proposals')).toLowerCase()
+  if (!OPERATIONS.has(operation as ColoringBookStudioOperation)) {
+    throw createError({ statusCode: 400, message: 'Invalid coloring-book operation.' })
+  }
+  return operation as ColoringBookStudioOperation
 }
 
 export default defineEventHandler(async (event) => {
   try {
     await requireAdminApiUser(event)
     const body = (await readBody(event)) as Partial<ColoringBookRenderRequest> | null
+    const operation = normalizeOperation(body?.operation)
     const bookSlug = compact(String(body?.bookSlug || '')).toLowerCase()
     const proposalId = compact(String(body?.proposalId || '')).toLowerCase()
     const force = body?.force === true
@@ -27,6 +55,12 @@ export default defineEventHandler(async (event) => {
 
     if (!coloringBookConfig(bookSlug) || !proposalBelongsToBook(bookSlug, proposalId)) {
       throw createError({ statusCode: 400, message: 'Invalid book or proposal id.' })
+    }
+    if (force && operation !== 'generate-color-proposals' && operation !== 'generate-bw') {
+      throw createError({
+        statusCode: 400,
+        message: 'Forced revisions are supported only for color and B&W generation.',
+      })
     }
 
     const eventFiles = (await conductorList('color-art-events')) ?? []
@@ -36,17 +70,21 @@ export default defineEventHandler(async (event) => {
     if (alreadyQueued) {
       throw createError({
         statusCode: 409,
-        message: `${proposalId} already has a queued Coloring Book Studio request.`,
+        message: `${proposalId} already has a queued Coloring Book Studio action.`,
       })
     }
 
     const requestedAt = new Date()
     const stamp = requestedAt.toISOString().replace(/[-:.]/g, '').replace('Z', 'Z')
     const suffix = randomUUID().slice(0, 8)
-    const path = `color-art-events/${stamp}-${proposalId}-${suffix}.yaml`
+    const path = `color-art-events/${stamp}-${proposalId}-${operation}-${suffix}.yaml`
+    const label = OPERATION_LABELS[operation]
+    const defaultNote = force
+      ? `${proposalId} ${label} revision requested from the production studio.`
+      : `${proposalId} ${label} requested from the production studio.`
     const content = [
       'version: 1',
-      'operation: generate-color-proposals',
+      `operation: ${operation}`,
       `book: ${bookSlug}`,
       'proposal_ids:',
       `  - ${proposalId}`,
@@ -54,20 +92,20 @@ export default defineEventHandler(async (event) => {
       `force: ${force ? 'true' : 'false'}`,
       'requested_by: kind-robots-coloring-studio',
       'task: coloring-book/t-028',
-      `note: ${JSON.stringify(note || `${force ? 'Revision' : 'Color candidate'} requested from the production studio.`)}`,
+      `note: ${JSON.stringify(note || defaultNote)}`,
       '',
     ].join('\n')
 
     await conductorPut(
       path,
       content,
-      `coloring-book: request ${proposalId} ${force ? 'revision' : 'color candidate'}`,
+      `coloring-book: request ${proposalId} ${label}${force ? ' revision' : ''}`,
     )
 
     return {
       success: true,
-      message: `${proposalId} ${force ? 'revision' : 'color candidate'} queued in Conductor.`,
-      data: { bookSlug, proposalId, force, eventPath: path },
+      message: `${proposalId} ${label}${force ? ' revision' : ''} queued in Conductor.`,
+      data: { operation, bookSlug, proposalId, force, eventPath: path },
       statusCode: 201,
     }
   } catch (error: unknown) {
@@ -76,7 +114,7 @@ export default defineEventHandler(async (event) => {
     event.node.res.statusCode = statusCode
     return {
       success: false,
-      message: handled.message || 'Failed to request a coloring-book render.',
+      message: handled.message || 'Failed to request a coloring-book action.',
       statusCode,
     }
   }

--- a/server/utils/coloringBookProductionState.ts
+++ b/server/utils/coloringBookProductionState.ts
@@ -8,8 +8,6 @@ import {
   COLORING_BOOK_ROOT,
 } from '@/server/utils/coloringBookStudio'
 
-type JsonRecord = Record<string, unknown>
-
 function capture(text: string, pattern: RegExp, group = 1): string | undefined {
   return pattern.exec(text)?.[group]
 }
@@ -37,10 +35,7 @@ function yamlBoolean(value: string | null): boolean {
 
 function scalar(block: string, key: string, spaces = 4): string | null {
   return yamlValue(
-    capture(
-      block,
-      new RegExp(`^\\s{${spaces}}${key.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}:\\s*(.*?)\\s*$`, 'm'),
-    ),
+    capture(block, new RegExp(`^\\s{${spaces}}${key}:\\s*(.*?)\\s*$`, 'm')),
   )
 }
 
@@ -49,7 +44,10 @@ function listValues(block: string, key: string): string[] {
   if (inline === '[]') return []
   const section = capture(
     block,
-    new RegExp(`^    ${key}:\\s*(?:\\[\\])?\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`, 'm'),
+    new RegExp(
+      `^    ${key}:\\s*(?:\\[\\])?\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`,
+      'm',
+    ),
   )
   if (!section) return []
   return [...section.matchAll(/^\s*-\s*(.*?)\s*$/gm)]
@@ -60,7 +58,10 @@ function listValues(block: string, key: string): string[] {
 function historyCount(block: string, key: string): number {
   const section = capture(
     block,
-    new RegExp(`^    ${key}:\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`, 'm'),
+    new RegExp(
+      `^    ${key}:\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`,
+      'm',
+    ),
   )
   return section ? [...section.matchAll(/requested_at:/g)].length : 0
 }
@@ -146,10 +147,4 @@ export function buildColoringBookProductionData(
     states,
     fetchedAt: new Date().toISOString(),
   }
-}
-
-export function productionStateRecord(value: unknown): JsonRecord {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as JsonRecord)
-    : {}
 }

--- a/server/utils/coloringBookProductionState.ts
+++ b/server/utils/coloringBookProductionState.ts
@@ -1,0 +1,155 @@
+import type {
+  ColoringBookProductionState,
+  ColoringBookProductionData,
+} from '~/types/coloringBookStudio'
+import {
+  COLORING_BOOK_REF,
+  COLORING_BOOK_REPO,
+  COLORING_BOOK_ROOT,
+} from '@/server/utils/coloringBookStudio'
+
+type JsonRecord = Record<string, unknown>
+
+function capture(text: string, pattern: RegExp, group = 1): string | undefined {
+  return pattern.exec(text)?.[group]
+}
+
+function yamlValue(value: string | undefined): string | null {
+  const clean = String(value ?? '').trim()
+  if (!clean || clean === 'null' || clean === '~') return null
+  if (clean.startsWith('"')) {
+    try {
+      return String(JSON.parse(clean))
+    } catch {}
+  }
+  return clean.replace(/^['"]|['"]$/g, '')
+}
+
+function yamlNumber(value: string | null): number | null {
+  if (value === null) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function yamlBoolean(value: string | null): boolean {
+  return value === 'true' || value === 'yes' || value === '1'
+}
+
+function scalar(block: string, key: string, spaces = 4): string | null {
+  return yamlValue(
+    capture(
+      block,
+      new RegExp(`^\\s{${spaces}}${key.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}:\\s*(.*?)\\s*$`, 'm'),
+    ),
+  )
+}
+
+function listValues(block: string, key: string): string[] {
+  const inline = scalar(block, key, 4)
+  if (inline === '[]') return []
+  const section = capture(
+    block,
+    new RegExp(`^    ${key}:\\s*(?:\\[\\])?\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`, 'm'),
+  )
+  if (!section) return []
+  return [...section.matchAll(/^\s*-\s*(.*?)\s*$/gm)]
+    .map((match) => yamlValue(match?.[1]) ?? '')
+    .filter(Boolean)
+}
+
+function historyCount(block: string, key: string): number {
+  const section = capture(
+    block,
+    new RegExp(`^    ${key}:\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`, 'm'),
+  )
+  return section ? [...section.matchAll(/requested_at:/g)].length : 0
+}
+
+function rawAssetUrl(path: string | null, bookSlug: string): string | null {
+  const clean = String(path || '').trim()
+  if (!clean || clean.includes(':') || clean.startsWith('user-attachment')) return null
+  const repoPath = clean.startsWith('projects/')
+    ? clean
+    : `${COLORING_BOOK_ROOT}/sets/${bookSlug}/${clean.replace(/^\.\//, '')}`
+  return `https://raw.githubusercontent.com/${COLORING_BOOK_REPO}/${COLORING_BOOK_REF}/${repoPath}`
+}
+
+function emptyState(bookSlug: string, proposalId: string): ColoringBookProductionState {
+  return {
+    bookSlug,
+    proposalId,
+    colorStatus: 'missing',
+    colorRenderedPath: null,
+    colorArtImageId: null,
+    colorApprovedAt: null,
+    seedLocked: false,
+    bwStatus: 'missing',
+    bwRenderedPath: null,
+    bwUrl: null,
+    bwArtImageId: null,
+    bwSemanticScore: null,
+    bwSemanticVerdict: null,
+    bwSemanticReasons: [],
+    bwRejectedPath: null,
+    bwCompletedAt: null,
+    bwRevisionCount: 0,
+    pairStatus: null,
+    pairSemanticScore: null,
+    pairSemanticReasons: [],
+    pairFinalizedAt: null,
+  }
+}
+
+export function buildColoringBookProductionData(
+  queueContent: string,
+): ColoringBookProductionData {
+  const states: Record<string, ColoringBookProductionState> = {}
+  const bookBlocks = queueContent
+    .split(/(?=^- order:)/m)
+    .filter((block) => block.startsWith('- order:'))
+
+  for (const bookBlock of bookBlocks) {
+    const bookSlug = scalar(bookBlock, 'slug', 2)
+    if (!bookSlug) continue
+    const entryBlocks = bookBlock
+      .split(/(?=^  - slot:)/m)
+      .filter((block) => block.startsWith('  - slot:'))
+
+    for (const block of entryBlocks) {
+      const proposalId = scalar(block, 'id', 4)
+      if (!proposalId) continue
+      const state = emptyState(bookSlug, proposalId)
+      state.colorStatus = scalar(block, 'status', 4) ?? 'unknown'
+      state.colorRenderedPath = scalar(block, 'rendered_path', 4)
+      state.colorArtImageId = yamlNumber(scalar(block, 'art_image_id', 4))
+      state.colorApprovedAt = scalar(block, 'approved_at', 4)
+      state.seedLocked = yamlBoolean(scalar(block, 'lock_seed', 4))
+      state.bwStatus = scalar(block, 'bw_status', 4) ?? 'missing'
+      state.bwRenderedPath = scalar(block, 'bw_rendered_path', 4)
+      state.bwUrl = rawAssetUrl(state.bwRenderedPath, bookSlug)
+      state.bwArtImageId = yamlNumber(scalar(block, 'bw_art_image_id', 4))
+      state.bwSemanticScore = yamlNumber(scalar(block, 'bw_semantic_score', 4))
+      state.bwSemanticVerdict = scalar(block, 'bw_semantic_verdict', 4)
+      state.bwSemanticReasons = listValues(block, 'bw_semantic_reasons')
+      state.bwRejectedPath = scalar(block, 'bw_rejected_path', 4)
+      state.bwCompletedAt = scalar(block, 'bw_completed_at', 4)
+      state.bwRevisionCount = historyCount(block, 'bw_revision_history')
+      state.pairStatus = scalar(block, 'pair_status', 4)
+      state.pairSemanticScore = yamlNumber(scalar(block, 'pair_semantic_score', 4))
+      state.pairSemanticReasons = listValues(block, 'pair_semantic_reasons')
+      state.pairFinalizedAt = scalar(block, 'pair_finalized_at', 4)
+      states[`${bookSlug}:${proposalId}`] = state
+    }
+  }
+
+  return {
+    states,
+    fetchedAt: new Date().toISOString(),
+  }
+}
+
+export function productionStateRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {}
+}

--- a/stores/coloringBookStudioStore.ts
+++ b/stores/coloringBookStudioStore.ts
@@ -1,10 +1,13 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import type {
+  ColoringBookProductionData,
+  ColoringBookProductionState,
   ColoringBookPromptUpdate,
   ColoringBookRenderRequest,
   ColoringBookStudioBook,
   ColoringBookStudioData,
+  ColoringBookStudioOperation,
 } from '~/types/coloringBookStudio'
 import { performFetch } from '@/stores/utils'
 
@@ -12,11 +15,12 @@ export const useColoringBookStudioStore = defineStore(
   'coloringBookStudioStore',
   () => {
     const books = ref<ColoringBookStudioBook[]>([])
+    const productionStates = ref<Record<string, ColoringBookProductionState>>({})
     const selectedBookSlug = ref('monster-recast')
     const selectedProposalId = ref('')
     const loading = ref(false)
     const savingPrompt = ref(false)
-    const requestingRender = ref(false)
+    const requestingAction = ref(false)
     const error = ref<string | null>(null)
     const message = ref<string | null>(null)
     const fetchedAt = ref<string | null>(null)
@@ -40,14 +44,27 @@ export const useColoringBookStudioStore = defineStore(
       )
     })
 
+    const selectedProductionState = computed<ColoringBookProductionState | null>(() => {
+      const book = selectedBook.value
+      const proposal = selectedProposal.value
+      if (!book || !proposal) return null
+      return productionStates.value[`${book.slug}:${proposal.id}`] ?? null
+    })
+
+    const requestingRender = computed(() => requestingAction.value)
+
     const queueProblems = computed(() =>
       books.value.flatMap((book) =>
         book.proposals
-          .filter(
-            (proposal) =>
+          .filter((proposal) => {
+            const production = productionStates.value[`${book.slug}:${proposal.id}`]
+            return Boolean(
               proposal.queue.semanticGateError ||
-              proposal.queue.status === 'needs_review',
-          )
+                proposal.queue.status === 'needs_review' ||
+                production?.bwStatus === 'needs_review' ||
+                production?.pairStatus === 'needs_review',
+            )
+          })
           .map((proposal) => ({
             bookSlug: book.slug,
             bookTitle: book.title,
@@ -75,15 +92,26 @@ export const useColoringBookStudioStore = defineStore(
       loading.value = true
       error.value = null
       try {
-        const response = await performFetch<ColoringBookStudioData>(
-          '/api/conductor/coloring-books',
-        )
-        if (!response.success || !response.data) {
-          error.value = response.message || 'Failed to load the Coloring Book Studio.'
+        const [studioResponse, productionResponse] = await Promise.all([
+          performFetch<ColoringBookStudioData>('/api/conductor/coloring-books'),
+          performFetch<ColoringBookProductionData>(
+            '/api/conductor/coloring-books/production',
+          ),
+        ])
+        if (!studioResponse.success || !studioResponse.data) {
+          error.value =
+            studioResponse.message || 'Failed to load the Coloring Book Studio.'
           return false
         }
-        books.value = response.data.books
-        fetchedAt.value = response.data.fetchedAt
+        if (!productionResponse.success || !productionResponse.data) {
+          error.value =
+            productionResponse.message ||
+            'Failed to load coloring-book production actions.'
+          return false
+        }
+        books.value = studioResponse.data.books
+        productionStates.value = productionResponse.data.states
+        fetchedAt.value = studioResponse.data.fetchedAt
         if (
           !books.value.some((book) => book.slug === selectedBookSlug.value)
         ) {
@@ -139,39 +167,60 @@ export const useColoringBookStudioStore = defineStore(
       }
     }
 
-    async function requestColorRender(
-      force = false,
-      note = '',
+    async function requestProductionAction(
+      operation: ColoringBookStudioOperation,
+      options: { force?: boolean; note?: string } = {},
     ): Promise<boolean> {
       const book = selectedBook.value
       const proposal = selectedProposal.value
-      if (!book || !proposal || requestingRender.value) return false
+      if (!book || !proposal || requestingAction.value) return false
 
-      requestingRender.value = true
+      requestingAction.value = true
       error.value = null
       message.value = null
       try {
         const body: ColoringBookRenderRequest = {
+          operation,
           bookSlug: book.slug,
           proposalId: proposal.id,
-          force,
-          note,
+          force: options.force === true,
+          note: options.note || '',
         }
         const response = await performFetch<ColoringBookRenderRequest>(
           '/api/conductor/coloring-books/request',
           { method: 'POST', body: JSON.stringify(body) },
         )
         if (!response.success) {
-          error.value = response.message || 'Failed to request the render.'
+          error.value = response.message || 'Failed to request the production action.'
           return false
         }
         message.value =
-          response.message || `${proposal.id} render request queued.`
+          response.message || `${proposal.id} production action queued.`
         await fetchStudio()
         return true
       } finally {
-        requestingRender.value = false
+        requestingAction.value = false
       }
+    }
+
+    function requestColorRender(force = false, note = ''): Promise<boolean> {
+      return requestProductionAction('generate-color-proposals', { force, note })
+    }
+
+    function acceptColor(note = ''): Promise<boolean> {
+      return requestProductionAction('accept-color', { note })
+    }
+
+    function requestBw(force = false, note = ''): Promise<boolean> {
+      return requestProductionAction('generate-bw', { force, note })
+    }
+
+    function acceptBw(note = ''): Promise<boolean> {
+      return requestProductionAction('accept-bw', { note })
+    }
+
+    function finalizePair(note = ''): Promise<boolean> {
+      return requestProductionAction('finalize-pair', { note })
     }
 
     function clearNotice(): void {
@@ -181,13 +230,16 @@ export const useColoringBookStudioStore = defineStore(
 
     return {
       books,
+      productionStates,
       selectedBookSlug,
       selectedProposalId,
       selectedBook,
       selectedProposal,
+      selectedProductionState,
       queueProblems,
       loading,
       savingPrompt,
+      requestingAction,
       requestingRender,
       error,
       message,
@@ -196,7 +248,12 @@ export const useColoringBookStudioStore = defineStore(
       selectBook,
       selectProposal,
       savePrompt,
+      requestProductionAction,
       requestColorRender,
+      acceptColor,
+      requestBw,
+      acceptBw,
+      finalizePair,
       clearNotice,
     }
   },

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -1,5 +1,12 @@
 export type ColoringBookVariant = 'color' | 'bw'
 
+export type ColoringBookStudioOperation =
+  | 'generate-color-proposals'
+  | 'accept-color'
+  | 'generate-bw'
+  | 'accept-bw'
+  | 'finalize-pair'
+
 export type ColoringBookAsset = {
   path: string
   kind: string
@@ -23,6 +30,30 @@ export type ColoringBookQueueState = {
   completedAt: string | null
   renderEngine: string | null
   revisionCount: number
+}
+
+export type ColoringBookProductionState = {
+  bookSlug: string
+  proposalId: string
+  colorStatus: string
+  colorRenderedPath: string | null
+  colorArtImageId: number | null
+  colorApprovedAt: string | null
+  seedLocked: boolean
+  bwStatus: string
+  bwRenderedPath: string | null
+  bwUrl: string | null
+  bwArtImageId: number | null
+  bwSemanticScore: number | null
+  bwSemanticVerdict: string | null
+  bwSemanticReasons: string[]
+  bwRejectedPath: string | null
+  bwCompletedAt: string | null
+  bwRevisionCount: number
+  pairStatus: string | null
+  pairSemanticScore: number | null
+  pairSemanticReasons: string[]
+  pairFinalizedAt: string | null
 }
 
 export type ColoringBookProposal = {
@@ -71,6 +102,11 @@ export type ColoringBookStudioData = {
   sourceRef: string
 }
 
+export type ColoringBookProductionData = {
+  states: Record<string, ColoringBookProductionState>
+  fetchedAt: string
+}
+
 export type ColoringBookPromptUpdate = {
   bookSlug: string
   proposalId: string
@@ -78,6 +114,7 @@ export type ColoringBookPromptUpdate = {
 }
 
 export type ColoringBookRenderRequest = {
+  operation?: ColoringBookStudioOperation
   bookSlug: string
   proposalId: string
   force?: boolean


### PR DESCRIPTION
## What changed

- adds a production action toolbar tied to the currently selected coloring-book proposal
- exposes the complete human-gated sequence: Accept Color, Generate B&W, Accept B&W, Finalize Pair
- uses two-click confirmation for acceptance and finalization decisions
- displays B&W candidate path, preview, pair score, verdict, rejection reasons, and revision count
- adds a focused production-state endpoint over the canonical Conductor color queue
- generalizes the existing event request route to all five studio operations
- keeps every component interaction inside `coloringBookStudioStore`
- preserves the existing proposal editor, queue view, page ledger, and end-user Color Preview

## Backend contract

Conductor PR #1311 is merged to `main` and provides the corresponding acceptance, Kontext B&W conversion, mechanical line-art gate, pair-fidelity gate, revision archive, and finalization actions.

## Safety

- only admins can queue writes
- one action per proposal may be queued at a time
- color/B&W acceptance and finalization require a second confirming click
- generated candidates are never silently accepted

## Validation

Ready for normal repository CI. Per project workflow, this PR will be merged after checks pass and reviewed on the deployed `main` version.