### PR TITLE
coloring: add revision and rejection history browser

### DIFF
--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -8,6 +8,7 @@
     <template #interactive>
       <div class="flex flex-col gap-5">
         <coloring-book-production-toolbar />
+        <coloring-book-production-history />
         <coloring-book-studio />
       </div>
     </template>
@@ -25,7 +26,7 @@ const config: ProjectFrontConfig = {
   icon: 'kind-icon:paintbrush',
   tagline: 'Build, review, pair, and color three living books.',
   description:
-    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Review all 36 proposal slots in each book, edit the canonical Conductor prompts, compare current color and black-and-white versions, request targeted candidates or revisions, accept working masters, confirm final pairs, inspect queue failures, and preview finished pages in the shared coloring engine.',
+    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Review all 36 proposal slots in each book, edit the canonical Conductor prompts, compare current color and black-and-white versions, request targeted candidates or revisions, accept working masters, confirm final pairs, inspect archived and rejected attempts, diagnose queue failures, and preview finished pages in the shared coloring engine.',
   sections: [
     {
       key: 'production',
@@ -36,7 +37,7 @@ const config: ProjectFrontConfig = {
     {
       key: 'review',
       title: 'Prompt, render, accept, and pair',
-      body: 'Select any proposal ID, inspect its current candidates, save the real production prompt, request exact renders, accept color and B&W masters, and finalize a mechanically and semantically validated matched pair.',
+      body: 'Select any proposal ID, inspect current and historical candidates, save the real production prompt, request exact renders, accept color and B&W masters, and finalize a mechanically and semantically validated matched pair.',
       icon: 'kind-icon:sparkles',
     },
   ],
@@ -46,10 +47,11 @@ const config: ProjectFrontConfig = {
       'Three canonical 36-proposal production ledgers in Conductor',
       'Proposal-targeted color and B&W generation with human-gated acceptance',
       'Matched-pair validation and finalization controls',
+      'Archived revision and rejection history browser',
     ],
     next: [
-      'Rejected and revision candidate history browser',
       'Cover production management',
+      'Print-readiness checks across all 36 interior pairs',
       'Print-ready package and storefront hand-off',
     ],
   },

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -1,0 +1,180 @@
+<template>
+  <section
+    v-if="proposal"
+    class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+  >
+    <header class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <div class="flex items-center gap-2">
+          <icon name="kind-icon:history" class="size-5 text-secondary" />
+          <h3 class="text-xl font-black">Candidate history</h3>
+        </div>
+        <p class="mt-1 text-sm text-base-content/55">
+          Archived revisions and rejected candidates for {{ proposal.id }}. Nothing
+          disappears merely because the next attempt has better cheekbones.
+        </p>
+      </div>
+      <div class="join self-start">
+        <button
+          v-for="option in filters"
+          :key="option.value"
+          type="button"
+          class="btn btn-sm join-item"
+          :class="filter === option.value ? 'btn-secondary' : 'btn-ghost'"
+          @click="filter = option.value"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="!filteredHistory.length"
+      class="flex min-h-28 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
+    >
+      No {{ filter === 'all' ? '' : `${filter} ` }}revision or rejection records yet.
+    </div>
+
+    <div v-else class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <article
+        v-for="item in filteredHistory"
+        :key="item.id"
+        class="overflow-hidden rounded-3xl border border-base-300 bg-base-100"
+      >
+        <a
+          v-if="item.url"
+          :href="item.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="block aspect-[2/3] bg-base-200"
+        >
+          <img
+            :src="item.url"
+            :alt="`${proposal.title} ${historyLabel(item.kind)}`"
+            class="size-full object-contain"
+            :class="item.variant === 'bw' ? 'grayscale' : ''"
+          />
+        </a>
+        <div
+          v-else
+          class="flex aspect-[2/3] items-center justify-center bg-base-200 text-base-content/30"
+        >
+          <icon name="kind-icon:image-off" class="size-12" />
+        </div>
+
+        <div class="flex flex-col gap-3 p-4">
+          <div class="flex flex-wrap items-center gap-2">
+            <span
+              class="badge rounded-2xl"
+              :class="item.variant === 'color' ? 'badge-primary' : 'badge-secondary'"
+            >
+              {{ item.variant === 'color' ? 'Color' : 'B&W' }}
+            </span>
+            <span class="badge badge-outline rounded-2xl">
+              {{ historyLabel(item.kind) }}
+            </span>
+            <span v-if="item.score !== null" class="badge badge-info rounded-2xl">
+              Score {{ item.score }}
+            </span>
+          </div>
+
+          <div>
+            <p class="text-sm font-black">
+              {{ item.status || item.verdict || historyLabel(item.kind) }}
+            </p>
+            <p v-if="item.createdAt" class="text-xs text-base-content/45">
+              {{ formatDate(item.createdAt) }}
+            </p>
+          </div>
+
+          <p v-if="item.path" class="break-all text-xs text-base-content/45">
+            {{ item.path }}
+          </p>
+
+          <div class="flex flex-wrap gap-2 text-xs">
+            <span v-if="item.artImageId" class="badge badge-ghost rounded-2xl">
+              ArtImage {{ item.artImageId }}
+            </span>
+            <span v-if="item.seed !== null" class="badge badge-ghost rounded-2xl">
+              Seed {{ item.seed }}
+            </span>
+            <span v-if="item.engine" class="badge badge-ghost rounded-2xl">
+              {{ item.engine }}
+            </span>
+            <span v-if="item.verdict" class="badge badge-ghost rounded-2xl">
+              {{ item.verdict }}
+            </span>
+          </div>
+
+          <ul
+            v-if="item.reasons.length"
+            class="list-disc space-y-1 pl-5 text-xs text-warning"
+          >
+            <li v-for="reason in item.reasons" :key="reason">
+              {{ reason }}
+            </li>
+          </ul>
+
+          <a
+            v-if="item.url"
+            :href="item.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn btn-outline btn-sm mt-auto rounded-2xl"
+          >
+            <icon name="kind-icon:external-link" class="size-4" />
+            Open archived image
+          </a>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type {
+  ColoringBookHistoryKind,
+  ColoringBookVariant,
+} from '~/types/coloringBookStudio'
+import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+
+type HistoryFilter = 'all' | ColoringBookVariant
+
+const studio = useColoringBookStudioStore()
+const filter = ref<HistoryFilter>('all')
+
+const filters: { label: string; value: HistoryFilter }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Color', value: 'color' },
+  { label: 'B&W', value: 'bw' },
+]
+
+const proposal = computed(() => studio.selectedProposal)
+const production = computed(() => studio.selectedProductionState)
+const filteredHistory = computed(() => {
+  const history = production.value?.history ?? []
+  return filter.value === 'all'
+    ? history
+    : history.filter((item) => item.variant === filter.value)
+})
+
+watch(
+  () => `${studio.selectedBookSlug}:${studio.selectedProposalId}`,
+  () => {
+    filter.value = 'all'
+  },
+)
+
+function historyLabel(kind: ColoringBookHistoryKind): string {
+  if (kind === 'semantic-rejection') return 'Semantic rejection'
+  if (kind === 'mechanical-rejection') return 'Mechanical rejection'
+  if (kind === 'unverified') return 'Unverified candidate'
+  return 'Archived revision'
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+</script>

--- a/server/utils/coloringBookProductionState.ts
+++ b/server/utils/coloringBookProductionState.ts
@@ -1,6 +1,9 @@
 import type {
+  ColoringBookHistoryItem,
+  ColoringBookHistoryKind,
   ColoringBookProductionState,
   ColoringBookProductionData,
+  ColoringBookVariant,
 } from '~/types/coloringBookStudio'
 import {
   COLORING_BOOK_REF,
@@ -55,15 +58,51 @@ function listValues(block: string, key: string): string[] {
     .filter(Boolean)
 }
 
-function historyCount(block: string, key: string): number {
+function historySection(block: string, key: string): string {
+  return (
+    capture(
+      block,
+      new RegExp(
+        `^    ${key}:\\s*(?:\\[\\])?\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`,
+        'm',
+      ),
+    ) ?? ''
+  )
+}
+
+function historyBlocks(block: string, key: string): string[] {
+  return historySection(block, key)
+    .split(/(?=^    - )/m)
+    .filter((entry) => entry.startsWith('    - '))
+}
+
+function historyScalar(block: string, key: string): string | null {
+  const first = capture(
+    block,
+    new RegExp(`^    - ${key}:\\s*(.*?)\\s*$`, 'm'),
+  )
+  if (first !== undefined) return yamlValue(first)
+  return yamlValue(
+    capture(block, new RegExp(`^      ${key}:\\s*(.*?)\\s*$`, 'm')),
+  )
+}
+
+function historyList(block: string, key: string): string[] {
   const section = capture(
     block,
     new RegExp(
-      `^    ${key}:\\s*$([\\s\\S]*?)(?=^    [a-z_]+:|$(?![\\s\\S]))`,
+      `^      ${key}:\\s*(?:\\[\\])?\\s*$([\\s\\S]*?)(?=^      [a-z_]+:|^    - |$(?![\\s\\S]))`,
       'm',
     ),
   )
-  return section ? [...section.matchAll(/requested_at:/g)].length : 0
+  if (!section) return []
+  return [...section.matchAll(/^\s*-\s*(.*?)\s*$/gm)]
+    .map((match) => yamlValue(match?.[1]) ?? '')
+    .filter(Boolean)
+}
+
+function historyCount(block: string, key: string): number {
+  return historyBlocks(block, key).length
 }
 
 function rawAssetUrl(path: string | null, bookSlug: string): string | null {
@@ -73,6 +112,102 @@ function rawAssetUrl(path: string | null, bookSlug: string): string | null {
     ? clean
     : `${COLORING_BOOK_ROOT}/sets/${bookSlug}/${clean.replace(/^\.\//, '')}`
   return `https://raw.githubusercontent.com/${COLORING_BOOK_REPO}/${COLORING_BOOK_REF}/${repoPath}`
+}
+
+function historyItems(
+  block: string,
+  key: string,
+  bookSlug: string,
+  variant: ColoringBookVariant,
+  kind: ColoringBookHistoryKind,
+): ColoringBookHistoryItem[] {
+  return historyBlocks(block, key).map((item, index) => {
+    const archivedPath = historyScalar(item, 'archived_path')
+    const rejectedPath = historyScalar(item, 'rejected_path')
+    const renderedPath = historyScalar(item, 'rendered_path')
+    const path = archivedPath || rejectedPath || renderedPath
+    const createdAt =
+      historyScalar(item, 'reviewed_at') || historyScalar(item, 'requested_at')
+    const attempt = historyScalar(item, 'attempt')
+    const status =
+      historyScalar(item, 'previous_status') ||
+      (attempt ? `attempt ${attempt}` : null)
+    const score = yamlNumber(historyScalar(item, 'score') || historyScalar(item, 'semantic_score'))
+    const artImageId = yamlNumber(historyScalar(item, 'art_image_id'))
+    const seed = yamlNumber(historyScalar(item, 'seed'))
+    const engine = historyScalar(item, 'engine')
+    const verdict = historyScalar(item, 'verdict')
+    const reasons = historyList(item, 'reasons')
+    return {
+      id: `${variant}:${kind}:${path || createdAt || index}`,
+      variant,
+      kind,
+      path,
+      url: rawAssetUrl(path, bookSlug),
+      createdAt,
+      status,
+      score,
+      verdict,
+      reasons,
+      artImageId,
+      seed,
+      engine,
+    }
+  })
+}
+
+function currentBwRejection(
+  block: string,
+  bookSlug: string,
+): ColoringBookHistoryItem | null {
+  const path = scalar(block, 'bw_rejected_path', 4)
+  if (!path) return null
+  const kind: ColoringBookHistoryKind = path.includes('/mechanical/')
+    ? 'mechanical-rejection'
+    : path.includes('/unverified/')
+      ? 'unverified'
+      : 'semantic-rejection'
+  return {
+    id: `bw:${kind}:${path}`,
+    variant: 'bw',
+    kind,
+    path,
+    url: rawAssetUrl(path, bookSlug),
+    createdAt: scalar(block, 'bw_completed_at', 4),
+    status: scalar(block, 'bw_status', 4),
+    score: yamlNumber(scalar(block, 'bw_semantic_score', 4)),
+    verdict: scalar(block, 'bw_semantic_verdict', 4),
+    reasons: listValues(block, 'bw_semantic_reasons'),
+    artImageId: yamlNumber(scalar(block, 'bw_art_image_id', 4)),
+    seed: null,
+    engine: 'kontext',
+  }
+}
+
+function collectHistory(
+  block: string,
+  bookSlug: string,
+): ColoringBookHistoryItem[] {
+  const items = [
+    ...historyItems(block, 'studio_revision_history', bookSlug, 'color', 'revision'),
+    ...historyItems(
+      block,
+      'semantic_rejections',
+      bookSlug,
+      'color',
+      'semantic-rejection',
+    ),
+    ...historyItems(block, 'bw_revision_history', bookSlug, 'bw', 'revision'),
+  ]
+  const currentBw = currentBwRejection(block, bookSlug)
+  if (currentBw && !items.some((item) => item.path === currentBw.path)) {
+    items.push(currentBw)
+  }
+  return items.sort((left, right) => {
+    const leftTime = Date.parse(left.createdAt || '') || 0
+    const rightTime = Date.parse(right.createdAt || '') || 0
+    return rightTime - leftTime
+  })
 }
 
 function emptyState(bookSlug: string, proposalId: string): ColoringBookProductionState {
@@ -98,6 +233,7 @@ function emptyState(bookSlug: string, proposalId: string): ColoringBookProductio
     pairSemanticScore: null,
     pairSemanticReasons: [],
     pairFinalizedAt: null,
+    history: [],
   }
 }
 
@@ -139,6 +275,7 @@ export function buildColoringBookProductionData(
       state.pairSemanticScore = yamlNumber(scalar(block, 'pair_semantic_score', 4))
       state.pairSemanticReasons = listValues(block, 'pair_semantic_reasons')
       state.pairFinalizedAt = scalar(block, 'pair_finalized_at', 4)
+      state.history = collectHistory(block, bookSlug)
       states[`${bookSlug}:${proposalId}`] = state
     }
   }

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -7,10 +7,32 @@ export type ColoringBookStudioOperation =
   | 'accept-bw'
   | 'finalize-pair'
 
+export type ColoringBookHistoryKind =
+  | 'revision'
+  | 'semantic-rejection'
+  | 'mechanical-rejection'
+  | 'unverified'
+
 export type ColoringBookAsset = {
   path: string
   kind: string
   url: string | null
+}
+
+export type ColoringBookHistoryItem = {
+  id: string
+  variant: ColoringBookVariant
+  kind: ColoringBookHistoryKind
+  path: string | null
+  url: string | null
+  createdAt: string | null
+  status: string | null
+  score: number | null
+  verdict: string | null
+  reasons: string[]
+  artImageId: number | null
+  seed: number | null
+  engine: string | null
 }
 
 export type ColoringBookPair = {
@@ -54,6 +76,7 @@ export type ColoringBookProductionState = {
   pairSemanticScore: number | null
   pairSemanticReasons: string[]
   pairFinalizedAt: string | null
+  history: ColoringBookHistoryItem[]
 }
 
 export type ColoringBookProposal = {


### PR DESCRIPTION
## What changed

- parses full color revision, color semantic-rejection, B&W revision, and current B&W rejection metadata from the canonical Conductor queue
- adds a selected-proposal history browser with Color / B&W filters
- shows archived image previews, timestamps, prior status, quality score, verdict, ArtImage ID, seed, engine, and rejection reasons
- links directly to the preserved Conductor image asset
- keeps history embedded in the existing production-state response and Pinia workflow

## Why

The studio previously exposed only a revision count and current error. Archived candidates and semantic evidence existed in Conductor but were practically invisible to the human reviewing the books.

## Data boundary

Conductor remains authoritative. This PR does not create an activity table, copy image records into Prisma, or infer missing history from filenames.

## Validation

Ready for normal TypeScript and contract CI, then merge to `main`.