### PR TITLE
coloring: adopt visible legacy candidates from the production studio

### DIFF
--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -13,7 +13,7 @@
         </div>
         <h3 class="mt-2 text-xl font-black">{{ proposal.title }}</h3>
         <p class="mt-1 max-w-3xl text-sm text-base-content/55">
-          Human decisions and counterpart generation now write directly to the canonical
+          Human decisions and counterpart generation write directly to the canonical
           Conductor ledger. Generation may suggest. Only these controls accept.
         </p>
       </div>
@@ -45,7 +45,7 @@
       />
       <ProductionStageCard
         label="B&W candidate"
-        :done="Boolean(production?.bwRenderedPath)"
+        :done="Boolean(production?.bwRenderedPath || proposal.bwPath)"
         :detail="bwCandidateDetail"
         icon-name="kind-icon:pencil"
       />
@@ -64,6 +64,17 @@
     </div>
 
     <div
+      v-if="colorUsesLegacyAsset || bwUsesLegacyAsset"
+      class="alert alert-info rounded-2xl"
+    >
+      <icon name="kind-icon:archive" class="size-5" />
+      <span>
+        The displayed {{ legacyAssetLabel }} predates the current ArtJob queue. Adopting it
+        keeps the existing Conductor file and does not fabricate missing generation metadata.
+      </span>
+    </div>
+
+    <div
       v-if="production?.bwUrl || proposal.bwUrl"
       class="grid gap-4 rounded-2xl border border-base-300 bg-base-200/40 p-4 lg:grid-cols-[10rem_minmax(0,1fr)]"
     >
@@ -75,7 +86,12 @@
       <div class="flex flex-col gap-2">
         <h4 class="font-black">Current B&amp;W production candidate</h4>
         <p class="break-all text-xs text-base-content/50">
-          {{ production?.bwRenderedPath || proposal.accepted.bw || proposal.final.bw }}
+          {{
+            production?.bwRenderedPath ||
+            proposal.bwPath ||
+            proposal.accepted.bw ||
+            proposal.final.bw
+          }}
         </p>
         <div class="flex flex-wrap gap-2 text-xs">
           <span v-if="hasBwScore" class="badge badge-info rounded-2xl">
@@ -109,8 +125,8 @@
 
       <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <ProductionActionButton
-          label="Accept color master"
-          confirm-label="Confirm color acceptance"
+          :label="colorUsesLegacyAsset ? 'Adopt displayed color' : 'Accept color master'"
+          :confirm-label="colorUsesLegacyAsset ? 'Confirm legacy color adoption' : 'Confirm color acceptance'"
           icon-name="kind-icon:palette"
           :enabled="canAcceptColor"
           :armed="armedAction === 'accept-color'"
@@ -131,8 +147,8 @@
         </button>
 
         <ProductionActionButton
-          label="Accept B&W master"
-          confirm-label="Confirm B&W acceptance"
+          :label="bwUsesLegacyAsset ? 'Adopt displayed B&W' : 'Accept B&W master'"
+          :confirm-label="bwUsesLegacyAsset ? 'Confirm legacy B&W adoption' : 'Confirm B&W acceptance'"
           icon-name="kind-icon:check"
           :enabled="canAcceptBw"
           :armed="armedAction === 'accept-bw'"
@@ -199,12 +215,57 @@ const hasBwScore = computed(
   () => typeof production.value?.bwSemanticScore === 'number',
 )
 
+function adoptablePath(value: string | null | undefined): string {
+  const path = String(value || '').trim().replace(/\\/g, '/')
+  if (
+    !path ||
+    path.startsWith('/') ||
+    path.includes(':') ||
+    path.split('/').includes('..') ||
+    !/\.(?:webp|png|jpe?g)$/i.test(path)
+  ) {
+    return ''
+  }
+  return path
+}
+
+const colorAcceptanceSource = computed(() => {
+  if (proposal.value?.queue.status === 'done' && proposal.value.queue.renderedPath) {
+    return ''
+  }
+  return adoptablePath(proposal.value?.colorPath)
+})
+
+const bwAcceptanceSource = computed(() => {
+  if (
+    production.value?.bwStatus === 'done' &&
+    production.value.bwRenderedPath
+  ) {
+    return ''
+  }
+  return adoptablePath(proposal.value?.bwPath)
+})
+
+const colorUsesLegacyAsset = computed(
+  () => Boolean(!proposal.value?.accepted.color && colorAcceptanceSource.value),
+)
+
+const bwUsesLegacyAsset = computed(
+  () => Boolean(!proposal.value?.accepted.bw && bwAcceptanceSource.value),
+)
+
+const legacyAssetLabel = computed(() => {
+  if (colorUsesLegacyAsset.value && bwUsesLegacyAsset.value) return 'color and B&W files'
+  if (colorUsesLegacyAsset.value) return 'color file'
+  return 'B&W file'
+})
+
 const canAcceptColor = computed(() =>
   Boolean(
     proposal.value &&
       !proposal.value.accepted.color &&
       proposal.value.colorUrl &&
-      proposal.value.queue.status === 'done',
+      (proposal.value.queue.status === 'done' || colorAcceptanceSource.value),
   ),
 )
 
@@ -223,10 +284,11 @@ const canReviseBw = computed(() => {
 
 const canAcceptBw = computed(() =>
   Boolean(
-    proposal.value &&
+    proposal.value?.accepted.color &&
       !proposal.value.accepted.bw &&
-      production.value?.bwStatus === 'done' &&
-      production.value.bwRenderedPath,
+      ((production.value?.bwStatus === 'done' &&
+        production.value.bwRenderedPath) ||
+        bwAcceptanceSource.value),
   ),
 )
 
@@ -240,6 +302,7 @@ const canFinalizePair = computed(() =>
 
 const colorCandidateDetail = computed(() => {
   if (proposal.value?.accepted.color) return 'Accepted master recorded'
+  if (colorUsesLegacyAsset.value) return 'Existing Conductor set asset'
   if (typeof proposal.value?.queue.semanticScore === 'number') {
     return `Semantic score ${proposal.value.queue.semanticScore}`
   }
@@ -248,6 +311,7 @@ const colorCandidateDetail = computed(() => {
 
 const bwCandidateDetail = computed(() => {
   if (proposal.value?.accepted.bw) return 'Accepted master recorded'
+  if (bwUsesLegacyAsset.value) return 'Existing Conductor set asset'
   if (typeof production.value?.bwSemanticScore === 'number') {
     return `Pair score ${production.value.bwSemanticScore}`
   }
@@ -269,8 +333,15 @@ async function runHumanAction(
     armedAction.value = operation
     return
   }
+  const sourcePath =
+    operation === 'accept-color'
+      ? colorAcceptanceSource.value
+      : operation === 'accept-bw'
+        ? bwAcceptanceSource.value
+        : ''
   const success = await studio.requestProductionAction(operation, {
     note: actionNote.value,
+    sourcePath,
   })
   if (success) {
     armedAction.value = null

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -67,7 +67,7 @@
       v-if="colorUsesLegacyAsset || bwUsesLegacyAsset"
       class="alert alert-info rounded-2xl"
     >
-      <icon name="kind-icon:archive" class="size-5" />
+      <icon name="kind-icon:gallery" class="size-5" />
       <span>
         The displayed {{ legacyAssetLabel }} predates the current ArtJob queue. Adopting it
         keeps the existing Conductor file and does not fabricate missing generation metadata.
@@ -217,11 +217,16 @@ const hasBwScore = computed(
 
 function adoptablePath(value: string | null | undefined): string {
   const path = String(value || '').trim().replace(/\\/g, '/')
+  const prefix = book.value
+    ? `projects/coloring-book/sets/${book.value.slug}/`
+    : ''
   if (
     !path ||
     path.startsWith('/') ||
     path.includes(':') ||
+    path.startsWith('user-attachment') ||
     path.split('/').includes('..') ||
+    (path.startsWith('projects/') && (!prefix || !path.startsWith(prefix))) ||
     !/\.(?:webp|png|jpe?g)$/i.test(path)
   ) {
     return ''

--- a/server/api/conductor/coloring-books/index.get.ts
+++ b/server/api/conductor/coloring-books/index.get.ts
@@ -1,4 +1,8 @@
 import { defineEventHandler } from 'h3'
+import type {
+  ColoringBookProposal,
+  ColoringBookVariant,
+} from '~/types/coloringBookStudio'
 import { errorHandler } from '@/server/utils/error'
 import { conductorGet } from '@/server/utils/conductor-github'
 import {
@@ -6,6 +10,22 @@ import {
   COLORING_BOOK_CONFIG,
   COLORING_BOOK_QUEUE_PATH,
 } from '@/server/utils/coloringBookStudio'
+
+function selectedAssetPath(
+  proposal: ColoringBookProposal,
+  variant: ColoringBookVariant,
+): string | null {
+  const explicit = proposal.final[variant] || proposal.accepted[variant]
+  if (explicit) return explicit
+  if (variant === 'color' && proposal.queue.renderedPath) {
+    return proposal.queue.renderedPath
+  }
+  return (
+    proposal.inspirations.find((asset) =>
+      asset.kind.toLowerCase().includes(variant),
+    )?.path ?? null
+  )
+}
 
 export default defineEventHandler(async (event) => {
   try {
@@ -38,6 +58,13 @@ export default defineEventHandler(async (event) => {
         sourcePairs.map(({ config, prompt }) => [config.slug, prompt]),
       ),
     })
+
+    for (const book of data.books) {
+      for (const proposal of book.proposals) {
+        proposal.colorPath = selectedAssetPath(proposal, 'color')
+        proposal.bwPath = selectedAssetPath(proposal, 'bw')
+      }
+    }
 
     return {
       success: true,

--- a/server/api/conductor/coloring-books/request.post.ts
+++ b/server/api/conductor/coloring-books/request.post.ts
@@ -31,6 +31,8 @@ const OPERATION_LABELS: Record<ColoringBookStudioOperation, string> = {
   'finalize-pair': 'pair finalization',
 }
 
+const IMAGE_PATH = /\.(?:webp|png|jpe?g)$/i
+
 function compact(value: string): string {
   return value.replace(/\r/g, '').replace(/\s+/g, ' ').trim()
 }
@@ -41,6 +43,40 @@ function normalizeOperation(value: unknown): ColoringBookStudioOperation {
     throw createError({ statusCode: 400, message: 'Invalid coloring-book operation.' })
   }
   return operation as ColoringBookStudioOperation
+}
+
+function normalizeSourcePath(
+  value: unknown,
+  bookSlug: string,
+  operation: ColoringBookStudioOperation,
+): string | null {
+  const raw = String(value || '').trim().replace(/\\/g, '/')
+  if (!raw) return null
+  if (operation !== 'accept-color' && operation !== 'accept-bw') {
+    throw createError({
+      statusCode: 400,
+      message: 'Existing asset paths are supported only for color or B&W acceptance.',
+    })
+  }
+
+  const prefix = `projects/coloring-book/sets/${bookSlug}/`
+  const path = raw.startsWith(prefix) ? raw.slice(prefix.length) : raw
+  if (raw.startsWith('projects/') && !raw.startsWith(prefix)) {
+    throw createError({ statusCode: 400, message: 'The selected asset belongs to another set.' })
+  }
+  if (
+    !path ||
+    path.startsWith('/') ||
+    path.includes(':') ||
+    path.split('/').includes('..') ||
+    !IMAGE_PATH.test(path)
+  ) {
+    throw createError({
+      statusCode: 400,
+      message: 'The selected asset path is not a safe image inside this book set.',
+    })
+  }
+  return path
 }
 
 export default defineEventHandler(async (event) => {
@@ -56,10 +92,17 @@ export default defineEventHandler(async (event) => {
     if (!coloringBookConfig(bookSlug) || !proposalBelongsToBook(bookSlug, proposalId)) {
       throw createError({ statusCode: 400, message: 'Invalid book or proposal id.' })
     }
+    const sourcePath = normalizeSourcePath(body?.sourcePath, bookSlug, operation)
     if (force && operation !== 'generate-color-proposals' && operation !== 'generate-bw') {
       throw createError({
         statusCode: 400,
         message: 'Forced revisions are supported only for color and B&W generation.',
+      })
+    }
+    if (force && sourcePath) {
+      throw createError({
+        statusCode: 400,
+        message: 'Existing asset adoption cannot be combined with a forced revision.',
       })
     }
 
@@ -79,15 +122,17 @@ export default defineEventHandler(async (event) => {
     const suffix = randomUUID().slice(0, 8)
     const path = `color-art-events/${stamp}-${proposalId}-${operation}-${suffix}.yaml`
     const label = OPERATION_LABELS[operation]
+    const sourceLabel = sourcePath ? ` from ${sourcePath}` : ''
     const defaultNote = force
       ? `${proposalId} ${label} revision requested from the production studio.`
-      : `${proposalId} ${label} requested from the production studio.`
+      : `${proposalId} ${label}${sourceLabel} requested from the production studio.`
     const content = [
       'version: 1',
       `operation: ${operation}`,
       `book: ${bookSlug}`,
       'proposal_ids:',
       `  - ${proposalId}`,
+      ...(sourcePath ? [`source_path: ${JSON.stringify(sourcePath)}`] : []),
       'timeout: 600',
       `force: ${force ? 'true' : 'false'}`,
       'requested_by: kind-robots-coloring-studio',
@@ -99,13 +144,20 @@ export default defineEventHandler(async (event) => {
     await conductorPut(
       path,
       content,
-      `coloring-book: request ${proposalId} ${label}${force ? ' revision' : ''}`,
+      `coloring-book: request ${proposalId} ${label}${force ? ' revision' : sourceLabel}`,
     )
 
     return {
       success: true,
-      message: `${proposalId} ${label}${force ? ' revision' : ''} queued in Conductor.`,
-      data: { operation, bookSlug, proposalId, force, eventPath: path },
+      message: `${proposalId} ${label}${force ? ' revision' : sourceLabel} queued in Conductor.`,
+      data: {
+        operation,
+        bookSlug,
+        proposalId,
+        sourcePath,
+        force,
+        eventPath: path,
+      },
       statusCode: 201,
     }
   } catch (error: unknown) {

--- a/stores/coloringBookStudioStore.ts
+++ b/stores/coloringBookStudioStore.ts
@@ -169,7 +169,7 @@ export const useColoringBookStudioStore = defineStore(
 
     async function requestProductionAction(
       operation: ColoringBookStudioOperation,
-      options: { force?: boolean; note?: string } = {},
+      options: { force?: boolean; note?: string; sourcePath?: string } = {},
     ): Promise<boolean> {
       const book = selectedBook.value
       const proposal = selectedProposal.value
@@ -183,6 +183,7 @@ export const useColoringBookStudioStore = defineStore(
           operation,
           bookSlug: book.slug,
           proposalId: proposal.id,
+          sourcePath: options.sourcePath || undefined,
           force: options.force === true,
           note: options.note || '',
         }
@@ -207,16 +208,16 @@ export const useColoringBookStudioStore = defineStore(
       return requestProductionAction('generate-color-proposals', { force, note })
     }
 
-    function acceptColor(note = ''): Promise<boolean> {
-      return requestProductionAction('accept-color', { note })
+    function acceptColor(note = '', sourcePath = ''): Promise<boolean> {
+      return requestProductionAction('accept-color', { note, sourcePath })
     }
 
     function requestBw(force = false, note = ''): Promise<boolean> {
       return requestProductionAction('generate-bw', { force, note })
     }
 
-    function acceptBw(note = ''): Promise<boolean> {
-      return requestProductionAction('accept-bw', { note })
+    function acceptBw(note = '', sourcePath = ''): Promise<boolean> {
+      return requestProductionAction('accept-bw', { note, sourcePath })
     }
 
     function finalizePair(note = ''): Promise<boolean> {

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -91,9 +91,9 @@ export type ColoringBookProposal = {
   final: ColoringBookPair
   notes: string[]
   queue: ColoringBookQueueState
-  colorPath: string | null
+  colorPath?: string | null
   colorUrl: string | null
-  bwPath: string | null
+  bwPath?: string | null
   bwUrl: string | null
 }
 

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -91,7 +91,9 @@ export type ColoringBookProposal = {
   final: ColoringBookPair
   notes: string[]
   queue: ColoringBookQueueState
+  colorPath: string | null
   colorUrl: string | null
+  bwPath: string | null
   bwUrl: string | null
 }
 
@@ -140,6 +142,7 @@ export type ColoringBookRenderRequest = {
   operation?: ColoringBookStudioOperation
   bookSlug: string
   proposalId: string
+  sourcePath?: string
   force?: boolean
   note?: string
 }


### PR DESCRIPTION
## What changed

- enriches each proposal with the exact color and B&W path currently displayed by the studio
- extends the Pinia production action request with an optional existing `sourcePath`
- labels legacy acceptance explicitly as “Adopt displayed” rather than implying a current ArtJob render
- enables acceptance for set-local approved/generated candidates that predate the durable queue
- keeps fresh queue candidates on the normal acceptance path with their existing provenance
- prevents external references, connector attachments, cross-set paths, traversal, and non-image paths from becoming adoptable controls
- explains in the UI that legacy adoption preserves the existing file and does not fabricate missing generation metadata

## Backend contract

Conductor PR #1312 is merged to `main`. It validates the exact source path, mechanically checks the selected file, pair-validates adopted B&W assets, and writes the accepted ledger path without inventing ArtJob metadata.

## Why

The studio could already display many Monster Recast legacy and approved-directory candidates, but the acceptance controls required a current queue `rendered_path`. This closes that production dead end.

## Safety

- admin-only writes
- two-click human confirmation remains in place
- only files inside the selected canonical Conductor set can be adopted
- adopted B&W files still require an accepted color master and pair-fidelity review

## Validation

Ready for normal TypeScript and contract CI, then merge to `main`.