### PR TITLE
Prune deleted servers from the ArtJob dashboard

### DIFF
--- a/plugins/reconcile-server-cache.client.ts
+++ b/plugins/reconcile-server-cache.client.ts
@@ -1,0 +1,67 @@
+import { defineNuxtPlugin } from '#app'
+import { performFetch } from '@/stores/utils'
+import { useServerStore } from '@/stores/serverStore'
+import { reconcileServerRows } from '@/stores/helpers/serverReconcile'
+import type { Server } from '~/prisma/generated/prisma/client'
+
+type ServerListResponse = {
+  success: boolean
+  data?: Server[]
+  message?: string
+}
+
+/**
+ * The server store intentionally caches safe server rows so locally entered API
+ * keys can survive masked API responses. A full API refresh used to merge rows
+ * additively, though, which meant deleted database rows could live forever in
+ * localStorage. Reconcile once during client bootstrap so API membership is
+ * authoritative while matching cached fields remain available.
+ */
+export default defineNuxtPlugin(async () => {
+  const serverStore = useServerStore()
+
+  if (!serverStore.isInitialized) {
+    serverStore.loadFromLocalStorage()
+  }
+
+  const cachedIds = new Set(serverStore.servers.map((server) => server.id))
+  const response = (await performFetch('/api/server')) as ServerListResponse
+
+  if (!response.success || !Array.isArray(response.data)) return
+
+  const nextServers = reconcileServerRows(serverStore.servers, response.data)
+  const liveIds = new Set(nextServers.map((server) => server.id))
+  const removedIds = [...cachedIds].filter((id) => !liveIds.has(id))
+
+  serverStore.servers.splice(0, serverStore.servers.length, ...nextServers)
+
+  if (
+    serverStore.selectedServer &&
+    !liveIds.has(serverStore.selectedServer.id)
+  ) {
+    serverStore.selectedServer = null
+    serverStore.serverForm = {}
+  }
+
+  if (
+    typeof serverStore.activeArtServerId === 'number' &&
+    !liveIds.has(serverStore.activeArtServerId)
+  ) {
+    serverStore.activeArtServerId = null
+  }
+
+  if (
+    typeof serverStore.activeTextServerId === 'number' &&
+    !liveIds.has(serverStore.activeTextServerId)
+  ) {
+    serverStore.activeTextServerId = null
+  }
+
+  for (const id of removedIds) {
+    delete serverStore.healthResults[id]
+    serverStore.clearRuntimeReport(id)
+  }
+
+  serverStore.hasLoaded = true
+  serverStore.syncToLocalStorage()
+})

--- a/server/api/server/[id].delete.ts
+++ b/server/api/server/[id].delete.ts
@@ -5,7 +5,6 @@ import { errorHandler } from './../../utils/error'
 import {
   canDeleteServer,
   parseId,
-  readServerById,
   requireAuthUser,
 } from './../../utils/serverApi'
 
@@ -13,7 +12,20 @@ export default defineEventHandler(async (event) => {
   try {
     const id = parseId(getRouterParam(event, 'id'))
     const user = await requireAuthUser(event)
-    const server = await readServerById(id)
+    const server = await prisma.server.findUnique({ where: { id } })
+
+    // DELETE is idempotent. A browser may still hold a cached row after that
+    // database record was removed elsewhere (for example, Cypress cleanup).
+    // Returning success lets the client discard that stale local entry.
+    if (!server) {
+      event.node.res.statusCode = 200
+      return {
+        success: true,
+        message: 'Server was already removed.',
+        data: null,
+        statusCode: 200,
+      }
+    }
 
     if (!canDeleteServer(server, user)) {
       throw createError({

--- a/stores/helpers/serverReconcile.ts
+++ b/stores/helpers/serverReconcile.ts
@@ -1,0 +1,21 @@
+import type { Server } from '~/prisma/generated/prisma/client'
+import { mergeServerRecord, type SafeServerRow } from './serverMerge'
+
+/**
+ * Reconcile a complete server API response with locally cached server rows.
+ *
+ * The incoming list is authoritative for membership: cached IDs absent from the
+ * response are deleted. Matching rows are still merged so a locally cached,
+ * unmasked API key survives the safe/masked API representation returned to the
+ * browser.
+ */
+export function reconcileServerRows(
+  existing: Server[],
+  incoming: SafeServerRow[],
+): Server[] {
+  const cachedById = new Map(existing.map((server) => [server.id, server]))
+
+  return incoming.map((server) =>
+    mergeServerRecord(cachedById.get(server.id), server),
+  )
+}

--- a/utils/scripts/verifyServerStoreMergeSafety.ts
+++ b/utils/scripts/verifyServerStoreMergeSafety.ts
@@ -6,6 +6,7 @@ import {
   mergeServerRows,
   type SafeServerRow,
 } from '../../stores/helpers/serverMerge'
+import { reconcileServerRows } from '../../stores/helpers/serverReconcile'
 
 const cached = {
   id: 1,
@@ -35,27 +36,56 @@ const removedSecret = mergeServerRecord(cached, {
 })
 assert.equal(removedSecret.apiKey, null)
 
-const rows = mergeServerRows(
-  [cached, { ...cached, id: 2, title: 'Local-only server' }],
-  [maskedRemote, { ...maskedRemote, id: 3, title: 'New remote server' }],
-)
+const localOnly = { ...cached, id: 2, title: 'Local-only server' }
+const newRemote = { ...maskedRemote, id: 3, title: 'New remote server' }
+const rows = mergeServerRows([cached, localOnly], [maskedRemote, newRemote])
 assert.equal(rows.length, 3)
 assert.equal(rows.find((server) => server.id === 2)?.title, 'Local-only server')
 assert.equal(rows.find((server) => server.id === 3)?.title, 'New remote server')
 
+const reconciled = reconcileServerRows(
+  [cached, localOnly],
+  [maskedRemote, newRemote],
+)
+assert.equal(reconciled.length, 2)
+assert.equal(reconciled.some((server) => server.id === 2), false)
+assert.equal(reconciled.find((server) => server.id === 1)?.apiKey, 'local-secret')
+assert.equal(reconciled.find((server) => server.id === 3)?.title, 'New remote server')
+
 const source = readFileSync('stores/serverStore.ts', 'utf8')
 assert.ok(
   source.includes('servers.value = mergeServerRows(servers.value, incoming)'),
-  'serverStore must merge remote rows into cached rows.',
+  'serverStore must merge partial remote rows into cached rows.',
 )
 assert.ok(
   source.includes('mergeServers(res.data)') &&
     !source.includes('servers.value = res.data.slice().sort(sortServers)'),
-  'fetchAllServers must not replace locally loaded servers.',
+  'fetchAllServers must preserve locally cached safe fields.',
 )
 assert.ok(
   !source.includes('const fetchedServers = await fetchAllServers'),
   'initialize must not perform a redundant second merge.',
 )
 
-console.log('Server store merge safety contract passed.')
+const reconciliationPlugin = readFileSync(
+  'plugins/reconcile-server-cache.client.ts',
+  'utf8',
+)
+assert.ok(
+  reconciliationPlugin.includes(
+    'reconcileServerRows(serverStore.servers, response.data)',
+  ),
+  'client bootstrap must reconcile the complete API list authoritatively.',
+)
+assert.ok(
+  reconciliationPlugin.includes('serverStore.syncToLocalStorage()'),
+  'the pruned server list must replace the stale localStorage cache.',
+)
+
+const deleteEndpoint = readFileSync('server/api/server/[id].delete.ts', 'utf8')
+assert.ok(
+  deleteEndpoint.includes('Server was already removed.'),
+  'DELETE must succeed when a stale cached server no longer exists.',
+)
+
+console.log('Server store merge and reconciliation safety contract passed.')


### PR DESCRIPTION
## What changed

- Add client-side reconciliation for the complete `/api/server` response.
- Treat the database response as authoritative for server membership, removing cached IDs that no longer exist.
- Preserve locally cached safe fields, including an unmasked API key, for server IDs that still exist.
- Clear stale selected/default IDs, health results, and runtime reports when a server disappears.
- Make `DELETE /api/server/:id` idempotent so a stale cached row can be removed even when the database record is already gone.
- Extend the existing server-store merge safety contract with reconciliation and idempotent-delete coverage.

## Root cause

`serverStore` loads server rows from `localStorage` and merges the live API response additively. That merge intentionally protects cached secrets from masked API responses, but it also retained every cached ID absent from the database. Deleted Cypress fixtures and old local servers therefore remained visible in the ArtJob dashboard, while Remove failed because the API correctly could not find them.

## Expected result

After deployment and a page reload, `cypress-relationship-server-1784749186078` and `Lola Local` are pruned from the browser cache. The ArtJob private-server list should contain only servers currently returned by `/api/server`—in this case, the active Comfy server.

## Validation

- TypeScript Type Check: passed.
- Contract Tests: passed.
- Delete Response Envelope: passed.
- API Client Follow-ups, Facet Catalog, Narrative Primitives, and Storymaker Studio contracts: passed.