### PR TITLE
coloring: add whole-book print readiness dashboard

### DIFF
--- a/.github/workflows/coloring-book-readiness-contract.yml
+++ b/.github/workflows/coloring-book-readiness-contract.yml
@@ -1,0 +1,37 @@
+name: Coloring Book Readiness Contract
+
+on:
+  pull_request:
+    paths:
+      - "components/coloring/coloring-book-readiness.vue"
+      - "components/coloring/coloring-book-page.vue"
+      - "utils/coloringBookReadiness.ts"
+      - "utils/scripts/verifyColoringBookReadiness.ts"
+      - ".github/workflows/coloring-book-readiness-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "components/coloring/coloring-book-readiness.vue"
+      - "components/coloring/coloring-book-page.vue"
+      - "utils/coloringBookReadiness.ts"
+      - "utils/scripts/verifyColoringBookReadiness.ts"
+      - ".github/workflows/coloring-book-readiness-contract.yml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify readiness state machine
+        run: npx tsx utils/scripts/verifyColoringBookReadiness.ts

--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -7,7 +7,10 @@
   >
     <template #interactive>
       <div class="flex flex-col gap-5">
-        <coloring-book-production-toolbar />
+        <coloring-book-readiness />
+        <div id="coloring-production-actions">
+          <coloring-book-production-toolbar />
+        </div>
         <coloring-book-production-history />
         <coloring-book-studio />
       </div>
@@ -26,7 +29,7 @@ const config: ProjectFrontConfig = {
   icon: 'kind-icon:paintbrush',
   tagline: 'Build, review, pair, and color three living books.',
   description:
-    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Review all 36 proposal slots in each book, edit the canonical Conductor prompts, compare current color and black-and-white versions, request targeted candidates or revisions, accept working masters, confirm final pairs, inspect archived and rejected attempts, diagnose queue failures, and preview finished pages in the shared coloring engine.',
+    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Track the exact next action for all 108 interiors, review each 36-page ledger, edit canonical Conductor prompts, compare current and historical color and black-and-white versions, request targeted candidates or revisions, adopt legacy set assets, accept working masters, confirm final pairs, diagnose queue failures, and preview finished pages in the shared coloring engine.',
   sections: [
     {
       key: 'production',
@@ -36,9 +39,9 @@ const config: ProjectFrontConfig = {
     },
     {
       key: 'review',
-      title: 'Prompt, render, accept, and pair',
-      body: 'Select any proposal ID, inspect current and historical candidates, save the real production prompt, request exact renders, accept color and B&W masters, and finalize a mechanically and semantically validated matched pair.',
-      icon: 'kind-icon:sparkles',
+      title: 'Know the next action',
+      body: 'Every interior is classified as blocked, needing generation, waiting for human acceptance, ready to finalize, or final. Open any row directly into its production controls.',
+      icon: 'kind-icon:check',
     },
   ],
   deliverables: {
@@ -47,12 +50,14 @@ const config: ProjectFrontConfig = {
       'Three canonical 36-proposal production ledgers in Conductor',
       'Proposal-targeted color and B&W generation with human-gated acceptance',
       'Matched-pair validation and finalization controls',
+      'Legacy set-asset adoption without fabricated provenance',
       'Archived revision and rejection history browser',
+      'Whole-book interior readiness dashboard',
     ],
     next: [
-      'Cover production management',
-      'Print-readiness checks across all 36 interior pairs',
-      'Print-ready package and storefront hand-off',
+      'Canonical cover production management',
+      'Print package validation and export',
+      'Storefront hand-off',
     ],
   },
 }

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -1,0 +1,240 @@
+<template>
+  <section class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm">
+    <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <div class="flex items-center gap-2">
+          <icon name="kind-icon:check" class="size-6 text-success" />
+          <h3 class="text-2xl font-black">Book readiness</h3>
+        </div>
+        <p class="mt-1 max-w-3xl text-sm text-base-content/55">
+          Every interior page gets one explicit next action. Covers remain separate
+          production blockers until they have their own canonical workflow.
+        </p>
+      </div>
+      <span class="badge badge-outline rounded-2xl">
+        {{ totalFinalPairs }}/{{ totalInteriors }} final interior pairs
+      </span>
+    </header>
+
+    <div class="grid gap-3 lg:grid-cols-3">
+      <button
+        v-for="item in bookSummaries"
+        :key="item.book.slug"
+        type="button"
+        class="rounded-3xl border p-4 text-left transition hover:-translate-y-0.5 hover:shadow-md"
+        :class="
+          studio.selectedBookSlug === item.book.slug
+            ? 'border-primary bg-primary/10'
+            : 'border-base-300 bg-base-100'
+        "
+        @click="studio.selectBook(item.book.slug)"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              Book {{ item.book.order }}
+            </p>
+            <h4 class="text-xl font-black">{{ item.book.title }}</h4>
+          </div>
+          <span
+            class="badge rounded-2xl"
+            :class="item.summary.printReady ? 'badge-success' : 'badge-warning'"
+          >
+            {{ item.summary.printReady ? 'Print ready' : 'In production' }}
+          </span>
+        </div>
+
+        <progress
+          class="progress progress-primary my-3 w-full"
+          :value="item.summary.final"
+          :max="item.summary.total || 1"
+        />
+
+        <div class="grid grid-cols-4 gap-2 text-center text-xs">
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black">{{ item.summary.final }}</p>
+            <p class="text-base-content/45">Final</p>
+          </div>
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black">{{ item.summary.finalize }}</p>
+            <p class="text-base-content/45">Finalize</p>
+          </div>
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black">
+              {{ item.summary.acceptColor + item.summary.acceptBw }}
+            </p>
+            <p class="text-base-content/45">Accept</p>
+          </div>
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black text-error">{{ item.summary.blocked }}</p>
+            <p class="text-base-content/45">Blocked</p>
+          </div>
+        </div>
+
+        <div class="mt-3 flex items-center gap-2 text-xs font-semibold text-warning">
+          <icon name="kind-icon:book" class="size-4" />
+          Cover workflow not managed yet
+        </div>
+      </button>
+    </div>
+
+    <div v-if="selectedBook && selectedSummary" class="flex flex-col gap-4">
+      <div
+        class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4 lg:flex-row lg:items-center lg:justify-between"
+      >
+        <div>
+          <h4 class="text-xl font-black">{{ selectedBook.title }} interiors</h4>
+          <p class="text-sm text-base-content/50">
+            {{ selectedSummary.actionable }} pages still need an action;
+            {{ selectedSummary.final }} are finalized.
+          </p>
+        </div>
+        <select
+          v-model="filter"
+          class="select select-bordered rounded-2xl"
+          aria-label="Filter coloring-book readiness"
+        >
+          <option value="actionable">Actionable pages</option>
+          <option value="blocked">Blocked only</option>
+          <option value="accept">Waiting for acceptance</option>
+          <option value="generate">Waiting for generation</option>
+          <option value="finalize">Ready to finalize</option>
+          <option value="final">Final pages</option>
+          <option value="all">All pages</option>
+        </select>
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <button
+          v-for="entry in filteredEntries"
+          :key="entry.proposal.id"
+          type="button"
+          class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 text-left transition hover:-translate-y-0.5 hover:border-primary hover:shadow-md"
+          @click="openProposal(entry.proposal.id)"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+                Slot {{ entry.proposal.slot }} · {{ entry.proposal.id }}
+              </p>
+              <h5 class="font-black">{{ entry.proposal.title }}</h5>
+            </div>
+            <span class="badge badge-sm rounded-2xl" :class="readinessTone(entry.readiness.key)">
+              {{ entry.readiness.label }}
+            </span>
+          </div>
+
+          <p class="line-clamp-3 text-xs leading-relaxed text-base-content/55">
+            {{ entry.readiness.detail }}
+          </p>
+
+          <div class="mt-auto flex items-center justify-between gap-2 text-xs">
+            <span class="text-base-content/40">
+              {{ entry.proposal.accepted.color ? 'Color accepted' : 'Color pending' }} ·
+              {{ entry.proposal.accepted.bw ? 'B&W accepted' : 'B&W pending' }}
+            </span>
+            <span class="font-black text-primary">Open →</span>
+          </div>
+        </button>
+      </div>
+
+      <div
+        v-if="!filteredEntries.length"
+        class="flex min-h-28 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
+      >
+        No pages match this readiness filter.
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import type { ColoringBookProposal } from '~/types/coloringBookStudio'
+import {
+  proposalReadiness,
+  readinessTone,
+  summarizeBookReadiness,
+  type ColoringBookProposalReadiness,
+} from '@/utils/coloringBookReadiness'
+import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+
+type ReadinessFilter =
+  | 'actionable'
+  | 'blocked'
+  | 'accept'
+  | 'generate'
+  | 'finalize'
+  | 'final'
+  | 'all'
+
+type ReadinessEntry = {
+  proposal: ColoringBookProposal
+  readiness: ColoringBookProposalReadiness
+}
+
+const studio = useColoringBookStudioStore()
+const filter = ref<ReadinessFilter>('actionable')
+
+const bookSummaries = computed(() =>
+  studio.books.map((book) => ({
+    book,
+    summary: summarizeBookReadiness(book, studio.productionStates),
+  })),
+)
+
+const selectedBook = computed(() => studio.selectedBook)
+const selectedSummary = computed(() => {
+  const book = selectedBook.value
+  return book ? summarizeBookReadiness(book, studio.productionStates) : null
+})
+
+const totalInteriors = computed(() =>
+  bookSummaries.value.reduce((total, item) => total + item.summary.total, 0),
+)
+
+const totalFinalPairs = computed(() =>
+  bookSummaries.value.reduce((total, item) => total + item.summary.final, 0),
+)
+
+const selectedEntries = computed<ReadinessEntry[]>(() => {
+  const book = selectedBook.value
+  if (!book) return []
+  return book.proposals.map((proposal) => ({
+    proposal,
+    readiness: proposalReadiness(
+      book.slug,
+      proposal,
+      studio.productionStates[`${book.slug}:${proposal.id}`] ?? null,
+    ),
+  }))
+})
+
+const filteredEntries = computed(() =>
+  selectedEntries.value.filter((entry) => {
+    const key = entry.readiness.key
+    if (filter.value === 'all') return true
+    if (filter.value === 'actionable') return entry.readiness.actionable
+    if (filter.value === 'blocked') return key === 'blocked' || key === 'needs-prompt'
+    if (filter.value === 'accept') return key === 'accept-color' || key === 'accept-bw'
+    if (filter.value === 'generate') return key === 'needs-color' || key === 'needs-bw'
+    return key === filter.value
+  }),
+)
+
+watch(
+  () => studio.selectedBookSlug,
+  () => {
+    filter.value = 'actionable'
+  },
+)
+
+async function openProposal(proposalId: string): Promise<void> {
+  studio.selectProposal(proposalId)
+  await nextTick()
+  document.getElementById('coloring-production-actions')?.scrollIntoView({
+    behavior: 'smooth',
+    block: 'start',
+  })
+}
+</script>

--- a/utils/coloringBookReadiness.ts
+++ b/utils/coloringBookReadiness.ts
@@ -1,0 +1,225 @@
+import type {
+  ColoringBookProductionState,
+  ColoringBookProposal,
+  ColoringBookStudioBook,
+} from '~/types/coloringBookStudio'
+
+export type ColoringBookReadinessKey =
+  | 'blocked'
+  | 'needs-prompt'
+  | 'needs-color'
+  | 'accept-color'
+  | 'needs-bw'
+  | 'accept-bw'
+  | 'finalize'
+  | 'final'
+
+export type ColoringBookProposalReadiness = {
+  key: ColoringBookReadinessKey
+  label: string
+  detail: string
+  actionable: boolean
+}
+
+export type ColoringBookReadinessSummary = {
+  total: number
+  final: number
+  finalize: number
+  acceptColor: number
+  acceptBw: number
+  needsColor: number
+  needsBw: number
+  needsPrompt: number
+  blocked: number
+  actionable: number
+  coverPending: boolean
+  interiorReady: boolean
+  printReady: boolean
+}
+
+const IMAGE_PATH = /\.(?:webp|png|jpe?g)$/i
+
+function isSetAssetPath(
+  value: string | null | undefined,
+  bookSlug: string,
+): boolean {
+  const path = String(value || '').trim().replace(/\\/g, '/')
+  const prefix = `projects/coloring-book/sets/${bookSlug}/`
+  return Boolean(
+    path &&
+      !path.startsWith('/') &&
+      !path.includes(':') &&
+      !path.startsWith('user-attachment') &&
+      !path.split('/').includes('..') &&
+      (!path.startsWith('projects/') || path.startsWith(prefix)) &&
+      IMAGE_PATH.test(path),
+  )
+}
+
+function colorCandidateAvailable(
+  bookSlug: string,
+  proposal: ColoringBookProposal,
+): boolean {
+  if (proposal.queue.status === 'done' && proposal.queue.renderedPath) return true
+  return isSetAssetPath(proposal.colorPath, bookSlug)
+}
+
+function bwCandidateAvailable(
+  bookSlug: string,
+  proposal: ColoringBookProposal,
+  production: ColoringBookProductionState | null,
+): boolean {
+  if (production?.bwStatus === 'done' && production.bwRenderedPath) return true
+  return isSetAssetPath(proposal.bwPath, bookSlug)
+}
+
+function firstReason(reasons: string[] | undefined): string | null {
+  return reasons?.find((reason) => reason.trim())?.trim() ?? null
+}
+
+export function proposalReadiness(
+  bookSlug: string,
+  proposal: ColoringBookProposal,
+  production: ColoringBookProductionState | null,
+): ColoringBookProposalReadiness {
+  if (proposal.final.color && proposal.final.bw) {
+    return {
+      key: 'final',
+      label: 'Final pair',
+      detail: 'Color and black-and-white masters are finalized.',
+      actionable: false,
+    }
+  }
+
+  if (!proposal.accepted.color) {
+    if (!proposal.prompt.trim()) {
+      return {
+        key: 'needs-prompt',
+        label: 'Needs prompt',
+        detail: 'Write the canonical production prompt before generating art.',
+        actionable: true,
+      }
+    }
+    if (proposal.queue.status === 'needs_review' || proposal.queue.semanticGateError) {
+      return {
+        key: 'blocked',
+        label: 'Color blocked',
+        detail:
+          proposal.queue.semanticGateError ||
+          'The current color candidate needs human review.',
+        actionable: true,
+      }
+    }
+    if (colorCandidateAvailable(bookSlug, proposal)) {
+      return {
+        key: 'accept-color',
+        label: 'Accept color',
+        detail: 'A set-local color candidate is ready for human acceptance.',
+        actionable: true,
+      }
+    }
+    return {
+      key: 'needs-color',
+      label: 'Needs color',
+      detail: 'Generate or curate a full-color composition candidate.',
+      actionable: true,
+    }
+  }
+
+  if (!proposal.accepted.bw) {
+    if (production?.bwStatus === 'needs_review') {
+      return {
+        key: 'blocked',
+        label: 'B&W blocked',
+        detail:
+          firstReason(production.bwSemanticReasons) ||
+          'The current black-and-white candidate needs human review.',
+        actionable: true,
+      }
+    }
+    if (bwCandidateAvailable(bookSlug, proposal, production)) {
+      return {
+        key: 'accept-bw',
+        label: 'Accept B&W',
+        detail: 'A matched black-and-white candidate is ready for human acceptance.',
+        actionable: true,
+      }
+    }
+    return {
+      key: 'needs-bw',
+      label: 'Needs B&W',
+      detail:
+        production?.bwStatus === 'failed'
+          ? 'The previous B&W job failed; request a new counterpart.'
+          : 'Generate or adopt a faithful line-art counterpart.',
+      actionable: true,
+    }
+  }
+
+  if (production?.pairStatus === 'needs_review') {
+    return {
+      key: 'blocked',
+      label: 'Pair blocked',
+      detail:
+        firstReason(production.pairSemanticReasons) ||
+        'The accepted pair failed fidelity review.',
+      actionable: true,
+    }
+  }
+
+  return {
+    key: 'finalize',
+    label: 'Finalize pair',
+    detail: 'Both masters are accepted and ready for final pair validation.',
+    actionable: true,
+  }
+}
+
+export function summarizeBookReadiness(
+  book: ColoringBookStudioBook,
+  productionStates: Record<string, ColoringBookProductionState>,
+): ColoringBookReadinessSummary {
+  const summary: ColoringBookReadinessSummary = {
+    total: book.proposals.length,
+    final: 0,
+    finalize: 0,
+    acceptColor: 0,
+    acceptBw: 0,
+    needsColor: 0,
+    needsBw: 0,
+    needsPrompt: 0,
+    blocked: 0,
+    actionable: 0,
+    coverPending: book.coverIsSeparate,
+    interiorReady: false,
+    printReady: false,
+  }
+
+  for (const proposal of book.proposals) {
+    const production =
+      productionStates[`${book.slug}:${proposal.id}`] ?? null
+    const readiness = proposalReadiness(book.slug, proposal, production)
+    if (readiness.actionable) summary.actionable += 1
+    if (readiness.key === 'final') summary.final += 1
+    else if (readiness.key === 'finalize') summary.finalize += 1
+    else if (readiness.key === 'accept-color') summary.acceptColor += 1
+    else if (readiness.key === 'accept-bw') summary.acceptBw += 1
+    else if (readiness.key === 'needs-color') summary.needsColor += 1
+    else if (readiness.key === 'needs-bw') summary.needsBw += 1
+    else if (readiness.key === 'needs-prompt') summary.needsPrompt += 1
+    else summary.blocked += 1
+  }
+
+  summary.interiorReady = summary.total > 0 && summary.final === summary.total
+  summary.printReady = summary.interiorReady && !summary.coverPending
+  return summary
+}
+
+export function readinessTone(key: ColoringBookReadinessKey): string {
+  if (key === 'final') return 'badge-success'
+  if (key === 'finalize') return 'badge-primary'
+  if (key === 'accept-color' || key === 'accept-bw') return 'badge-secondary'
+  if (key === 'blocked') return 'badge-error'
+  if (key === 'needs-prompt') return 'badge-warning'
+  return 'badge-info'
+}

--- a/utils/scripts/verifyColoringBookReadiness.ts
+++ b/utils/scripts/verifyColoringBookReadiness.ts
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict'
+import type {
+  ColoringBookProductionState,
+  ColoringBookProposal,
+  ColoringBookStudioBook,
+} from '~/types/coloringBookStudio'
+import {
+  proposalReadiness,
+  summarizeBookReadiness,
+} from '@/utils/coloringBookReadiness'
+
+function proposal(
+  id: string,
+  overrides: Partial<ColoringBookProposal> = {},
+): ColoringBookProposal {
+  return {
+    slot: Number(id.match(/\d+/)?.[0] || 1),
+    id,
+    title: id,
+    prompt: 'A complete production prompt.',
+    promptRef: null,
+    promptSourcePath: 'projects/coloring-book/sets/kind-robots/proposals.yaml',
+    inspirations: [],
+    accepted: { color: null, bw: null },
+    final: { color: null, bw: null },
+    notes: [],
+    queue: {
+      status: 'pending',
+      imagePath: null,
+      renderedPath: null,
+      artImageId: null,
+      semanticScore: null,
+      semanticVerdict: null,
+      semanticAttempts: 0,
+      semanticGateError: null,
+      completedAt: null,
+      renderEngine: null,
+      revisionCount: 0,
+    },
+    colorPath: null,
+    colorUrl: null,
+    bwPath: null,
+    bwUrl: null,
+    ...overrides,
+  }
+}
+
+function production(
+  proposalId: string,
+  overrides: Partial<ColoringBookProductionState> = {},
+): ColoringBookProductionState {
+  return {
+    bookSlug: 'kind-robots',
+    proposalId,
+    colorStatus: 'pending',
+    colorRenderedPath: null,
+    colorArtImageId: null,
+    colorApprovedAt: null,
+    seedLocked: false,
+    bwStatus: 'missing',
+    bwRenderedPath: null,
+    bwUrl: null,
+    bwArtImageId: null,
+    bwSemanticScore: null,
+    bwSemanticVerdict: null,
+    bwSemanticReasons: [],
+    bwRejectedPath: null,
+    bwCompletedAt: null,
+    bwRevisionCount: 0,
+    pairStatus: null,
+    pairSemanticScore: null,
+    pairSemanticReasons: [],
+    pairFinalizedAt: null,
+    history: [],
+    ...overrides,
+  }
+}
+
+const legacyColor = proposal('kr-001', {
+  colorPath: 'approved/kr-001-color.webp',
+  colorUrl: 'https://example.test/kr-001-color.webp',
+})
+assert.equal(
+  proposalReadiness('kind-robots', legacyColor, null).key,
+  'accept-color',
+)
+
+const externalReference = proposal('kr-002', {
+  colorPath: 'projects/process/kr-002.webp',
+  colorUrl: 'https://example.test/kr-002.webp',
+})
+assert.equal(
+  proposalReadiness('kind-robots', externalReference, null).key,
+  'needs-color',
+)
+
+const acceptedColor = proposal('kr-003', {
+  accepted: { color: 'approved/kr-003-color.webp', bw: null },
+})
+assert.equal(
+  proposalReadiness('kind-robots', acceptedColor, null).key,
+  'needs-bw',
+)
+
+const bwCandidate = proposal('kr-004', {
+  accepted: { color: 'approved/kr-004-color.webp', bw: null },
+})
+assert.equal(
+  proposalReadiness(
+    'kind-robots',
+    bwCandidate,
+    production('kr-004', {
+      bwStatus: 'done',
+      bwRenderedPath: 'generated/bw/kr-004-bw.webp',
+    }),
+  ).key,
+  'accept-bw',
+)
+
+const acceptedPair = proposal('kr-005', {
+  accepted: {
+    color: 'approved/kr-005-color.webp',
+    bw: 'approved/kr-005-bw.webp',
+  },
+})
+assert.equal(
+  proposalReadiness('kind-robots', acceptedPair, production('kr-005')).key,
+  'finalize',
+)
+
+const finalPair = proposal('kr-006', {
+  accepted: {
+    color: 'approved/kr-006-color.webp',
+    bw: 'approved/kr-006-bw.webp',
+  },
+  final: {
+    color: 'approved/kr-006-color.webp',
+    bw: 'approved/kr-006-bw.webp',
+  },
+})
+assert.equal(
+  proposalReadiness('kind-robots', finalPair, production('kr-006')).key,
+  'final',
+)
+
+const blocked = proposal('kr-007', {
+  queue: {
+    ...proposal('kr-007').queue,
+    semanticGateError: 'Reviewer unavailable',
+  },
+})
+assert.equal(
+  proposalReadiness('kind-robots', blocked, null).key,
+  'blocked',
+)
+
+const book: ColoringBookStudioBook = {
+  order: 3,
+  slug: 'kind-robots',
+  title: 'Kind Robots',
+  status: 'in-production',
+  targetProposals: 7,
+  coverIsSeparate: true,
+  counts: {
+    total: 7,
+    prompts: 7,
+    pending: 0,
+    rendered: 0,
+    acceptedColor: 3,
+    acceptedPairs: 2,
+    finalPairs: 1,
+    needsReview: 1,
+    blocked: 1,
+  },
+  proposals: [
+    legacyColor,
+    externalReference,
+    acceptedColor,
+    bwCandidate,
+    acceptedPair,
+    finalPair,
+    blocked,
+  ],
+}
+const states = {
+  'kind-robots:kr-004': production('kr-004', {
+    bwStatus: 'done',
+    bwRenderedPath: 'generated/bw/kr-004-bw.webp',
+  }),
+  'kind-robots:kr-005': production('kr-005'),
+  'kind-robots:kr-006': production('kr-006'),
+}
+const summary = summarizeBookReadiness(book, states)
+assert.equal(summary.final, 1)
+assert.equal(summary.finalize, 1)
+assert.equal(summary.acceptColor, 1)
+assert.equal(summary.acceptBw, 1)
+assert.equal(summary.needsColor, 1)
+assert.equal(summary.needsBw, 1)
+assert.equal(summary.blocked, 1)
+assert.equal(summary.actionable, 6)
+assert.equal(summary.interiorReady, false)
+assert.equal(summary.coverPending, true)
+assert.equal(summary.printReady, false)
+
+console.log('Coloring Book readiness contract passed.')


### PR DESCRIPTION
## What changed

- adds a whole-book readiness dashboard above the selected-proposal controls
- classifies every interior into exactly one state: Blocked, Needs Prompt, Needs Color, Accept Color, Needs B&W, Accept B&W, Finalize Pair, or Final Pair
- summarizes all three books with final, finalize, acceptance, and blocker counts
- provides actionable filters for blocked, acceptance, generation, finalization, and completed pages
- opens any readiness card directly in the selected proposal’s production controls
- treats each separate cover as an explicit unresolved print blocker rather than hiding it outside the progress calculation
- distinguishes adoptable set-local candidates from external/reference-only images
- adds a dedicated state-machine contract and CI workflow

## Why

The studio can now manage individual proposals, but book-level progress still required mentally reconciling 36 rows, queue errors, accepted pairs, and legacy candidates. This turns the production ledger into an explicit next-action list.

## Readiness rules

- final pairs are complete
- accepted pairs are ready to finalize
- set-local or completed candidates wait for human acceptance
- accepted color without B&W waits for generation or adoption
- current semantic review failures are blocked at the stage where they matter
- cover readiness remains separate and currently unresolved

## Validation

Ready for TypeScript, the full contract suite, and the new Coloring Book Readiness Contract, then merge to `main`.