### PR TITLE
ai-art-academy/t-010: add Fauvism curriculum entry

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -1787,6 +1787,48 @@ export const academyStyles: AcademyStyle[] = [
         "Recompose this image to depict dynamism and motion in the Italian Futurist manner: overlapping, semi-transparent repetitions of the subject's form suggesting successive instants of movement, sharp diagonal force lines, and fragmented crystalline facets organized around implied energy rather than a fixed viewpoint, and preserve the source subject's identity and general pose",
     },
   },
+  {
+    slug: 'fauvism',
+    name: 'Fauvism',
+    era: 'c. 1904–1908',
+    sortYear: 1904,
+    previewImageSrc: '/images/academy/styles/fauvism.webp',
+    region: 'France',
+    keyIdeas:
+      'Named in 1905 when a critic, startled by a room of canvases at the Salon d\'Automne, called their painters "les fauves" ("the wild beasts"), Fauvism pushed color entirely free of description: a face could be painted green, a tree trunk orange, a sky yellow-green, with no attempt to record local color at all. The lesson gives learners a clean contrast against `impressionism` and `post-impressionism` already in the curriculum: where those movements still built color from observed light, Fauvism used raw, unmixed, high-key pigment straight from the tube as an expressive end in itself, applied in loose, visibly brushy patches with heavy black or dark contour outlines holding the composition together. The movement was brief — most sources place its core years at 1904–1908, after which Matisse, Derain, and others each moved on to different concerns — but its central idea (that color can carry emotional force independent of naturalistic description) fed directly into Expressionism and much of the century that followed.',
+    recognitionCues: [
+      'Unmixed, high-key primary and secondary colors applied straight from the tube, with no attempt at naturalistic local color',
+      'Loose, visibly brushy patches of paint rather than smooth blending',
+      'Bold dark contour outlines (often black or deep blue) holding flat color areas together',
+      'Warm and cool colors placed in direct, high-contrast juxtaposition rather than gradually blended',
+      'Simplified, often flattened forms with minimal interior shading or modeling',
+      'Everyday subjects — portraits, landscapes, harbor and window views — rendered with startling, non-naturalistic color rather than exotic or literary subject matter',
+    ],
+    artists: [
+      {
+        name: 'Henri Matisse',
+        years: '1869–1954',
+        note: "The movement's central figure; Fauvism's defining works (Woman with a Hat, The Green Line, Open Window, Collioure) all fall within the movement's brief pre-1930 core period, distinct from Matisse's later, larger post-1930 body of work.",
+      },
+      {
+        name: 'André Derain',
+        years: '1880–1954',
+        note: "Painted alongside Matisse at Collioure in 1905, the summer usually credited with founding the style; his high-key harbor and London-bridge views are among the movement's most recognizable canvases.",
+      },
+      {
+        name: 'Raoul Dufy',
+        years: '1877–1953',
+        note: "Joined the group after seeing Matisse's work at the 1905 Salon; later developed his own lighter, calligraphic variant, but his Fauvist-period harbor and beach scenes belong squarely to this lesson.",
+      },
+    ],
+    failureMode:
+      'Likely under-cooks toward a generic "colorful painting" filter that brightens the source palette without committing to unmixed, non-naturalistic color choices (a green face, an orange tree trunk); lean on the remix template\'s explicit instruction to break local color entirely rather than just increasing saturation, and keep the bold dark contour outlines that Fauvist paintings almost always use to hold flat color areas together',
+    remix: {
+      mode: 'prompt',
+      template:
+        'Recompose this image as an early Fauvist painting: unmixed, high-key non-naturalistic color applied in loose visible brushstrokes with no attempt at local color accuracy, bold dark contour outlines holding flat color areas together, warm and cool colors in direct high-contrast juxtaposition, and preserve the source composition and subject',
+    },
+  },
 ]
 
 export const academyStylesBySlug: Record<string, AcademyStyle> = Object.assign(


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software, recurring/never-idle)

This cycle picked option (d) — expand the curriculum with a new movement entry, respecting `PUBLIC-DOMAIN-POLICY.md`. Today's earlier lanes on this same recurring task already covered options (a) front-end polish, (b) roadmap accuracy, and (c) inspiration assets, so this lane fills the one menu option not yet run today.

### What changed / what I produced
- `stores/seeds/academyStyles.ts`: added a `fauvism` entry (Fauvism, c. 1904–1908) — key ideas contrasting it with the already-present `impressionism`/`post-impressionism` entries, six recognition cues, three named artists, a failure-mode note, and a prompt-mode remix template. No LoRA dependency.

### How I verified
- **Public-domain policy (§1.3, both prongs)**: checked each named artist's death year against the 2026 cutoff (died before 1956). Matisse (1869–1954), Derain (1880–1954), and Dufy (1877–1953) all pass; the movement's core works (1904–1908) are well clear of the 1930 publication cutoff. Maurice de Vlaminck (d. 1958) was deliberately excluded — same pattern the existing `italian-futurism` entry uses for Balla/Carrà/Severini.
- `npx eslint stores/seeds/academyStyles.ts` — clean
- `npx prettier --check stores/seeds/academyStyles.ts` — clean
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0
- `npx tsx utils/scripts/verifyAcademyStyleDetailCallers.ts` — passed (3 callers still match)
- `npx tsx utils/scripts/verifyAcademyStarterManifest.ts` — passed (21 starter entries still validate against the policy)
- Confirmed no duplicate `fauvism` slug exists in the file.
- No preview image generated yet (`previewImageSrc` points at `/images/academy/styles/fauvism.webp`, not yet created) — same precedent as the three most recently added entries (`pre-raphaelite`, `arts-and-crafts`, `italian-futurism`), which also shipped curriculum-only and pick up art in a later option-(c) cycle.

### Stakes
reversible

### Flags for Reviewer
- This is a same-session self-review: I claimed t-010 as Worker and am merging as Reviewer within the same run, per AGENTS.md's allowance for a session to hold both roles when it finishes reviewing before picking up new work.

### Kaizen suggestion
A future option-(c) cycle should generate preview thumbnails for the four movements added today/recently without one yet (`pre-raphaelite`, `arts-and-crafts`, `italian-futurism`, `fauvism`) in one batch rather than one-at-a-time, since they're all currently falling back to the placeholder image.

### Notes for reviewer
Roadmap task `ai-art-academy/t-010` is `recurring: true` and re-arms to `ready` after this PR merges, per AGENTS.md's recurring-task rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqkm88pnP3qup3PTpMaD53)_