### PR TITLE
model-builder: restrict relationship-expansion CREATE outputs by source type

### DIFF
--- a/stores/helpers/modelBuilderRecipes.ts
+++ b/stores/helpers/modelBuilderRecipes.ts
@@ -111,6 +111,13 @@ export interface BuildOutputConfig {
   engine?: 'a1111' | 'comfy' | 'flux' | 'kontext' | 'openai'
   // Selected by default when the recipe is chosen.
   defaultOn?: boolean
+  // Restricts which source types may pick this output. Only meaningful for
+  // action: 'CREATE' outputs, where the created record links back to the
+  // source via a real Prisma relation (see linkSourceToTarget in
+  // server/api/model-builder/items/[id]/commit.post.ts and the coverage
+  // check in utils/scripts/verifyModelBuilderLinkCoverage.ts). Omit for
+  // outputs valid across every source type the recipe already allows.
+  sourceTypes?: SourceTypeKey[]
 }
 
 // ---------------------------------------------------------------------------
@@ -300,12 +307,21 @@ export const OUTPUT_CATALOG: BuildOutputConfig[] = [
   { key: 'missing-asset-repair', label: 'Missing-asset repair', recipe: 'art-upgrade', action: 'ASSET_ONLY', generation: 'image', description: 'Fill only the assets this model is missing.' },
 
   // Relationship Expansion ----------------------------------------------------
-  { key: 'expand-characters', label: 'Characters', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting characters, each an independent build item.' },
-  { key: 'expand-rewards', label: 'Rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting rewards.' },
-  { key: 'expand-scenarios', label: 'Scenarios', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting scenarios.' },
-  { key: 'expand-narrator-bot', label: 'Narrator bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'Optional narrator bot for a dream.' },
-  { key: 'expand-manager-bot', label: 'Manager bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'Optional manager bot for a project.' },
-  { key: 'expand-signature-rewards', label: 'Signature rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Signature rewards for a character.' },
+  // sourceTypes below mirror the real (sourceType, targetType) relation pairs
+  // linkSourceToTarget actually handles in
+  // server/api/model-builder/items/[id]/commit.post.ts (the same pairs t-032's
+  // utils/scripts/verifyModelBuilderLinkCoverage.ts derives from
+  // prisma/schema.prisma and asserts stay in sync with CREATE_TARGETS).
+  // expand-manager-bot / expand-narrator-bot both create a Bot, but link
+  // through different fields (Project.managerBotId vs Dream.narratorId), so
+  // each keeps only the source type its field actually applies to; expand-
+  // rewards / expand-signature-rewards are the same split for Reward.
+  { key: 'expand-characters', label: 'Characters', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting characters, each an independent build item.', sourceTypes: ['Dream', 'Reward', 'Scenario'] },
+  { key: 'expand-rewards', label: 'Rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting rewards.', sourceTypes: ['Dream', 'Character'] },
+  { key: 'expand-scenarios', label: 'Scenarios', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Create X fitting scenarios.', sourceTypes: ['Dream', 'Character'] },
+  { key: 'expand-narrator-bot', label: 'Narrator bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'Optional narrator bot for a dream.', sourceTypes: ['Dream'] },
+  { key: 'expand-manager-bot', label: 'Manager bot', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', description: 'Optional manager bot for a project.', sourceTypes: ['Project'] },
+  { key: 'expand-signature-rewards', label: 'Signature rewards', recipe: 'relationship-expansion', action: 'CREATE', generation: 'text', quantity: true, description: 'Signature rewards for a character.', sourceTypes: ['Character'] },
 ]
 
 // ---------------------------------------------------------------------------
@@ -328,8 +344,15 @@ export function getRecipesForSource(sourceKey: SourceTypeKey): RecipeConfig[] {
     .filter((recipe): recipe is RecipeConfig => Boolean(recipe))
 }
 
-export function getOutputsForRecipe(recipeKey: RecipeKey): BuildOutputConfig[] {
-  return OUTPUT_CATALOG.filter((output) => output.recipe === recipeKey)
+export function getOutputsForRecipe(
+  recipeKey: RecipeKey,
+  sourceType?: SourceTypeKey | null,
+): BuildOutputConfig[] {
+  return OUTPUT_CATALOG.filter((output) => {
+    if (output.recipe !== recipeKey) return false
+    if (!output.sourceTypes || !sourceType) return true
+    return output.sourceTypes.includes(sourceType)
+  })
 }
 
 export function getOutput(key: string): BuildOutputConfig | undefined {

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -412,7 +412,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   )
 
   const recipeOutputs = computed<BuildOutputConfig[]>(() =>
-    state.recipeKey ? getOutputsForRecipe(state.recipeKey) : [],
+    state.recipeKey ? getOutputsForRecipe(state.recipeKey, state.sourceType) : [],
   )
 
   const selectedOutputCount = computed(
@@ -505,7 +505,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   function selectRecipe(key: RecipeKey): void {
     state.recipeKey = key
     const selections: Record<string, OutputSelection> = {}
-    for (const output of getOutputsForRecipe(key)) {
+    for (const output of getOutputsForRecipe(key, state.sourceType)) {
       selections[output.key] = {
         on: Boolean(output.defaultOn),
         quantity: output.quantity ? 3 : 1,


### PR DESCRIPTION
### Task
conductor model-builder/t-033: Restrict relationship-expansion CREATE outputs to source types with a real relation

### What changed
- Added an optional `sourceTypes?: SourceTypeKey[]` field to `BuildOutputConfig` (`stores/helpers/modelBuilderRecipes.ts`).
- Populated it on each `relationship-expansion` `expand-*` output from the actual `(sourceType, targetType)` pairs `linkSourceToTarget` handles in `server/api/model-builder/items/[id]/commit.post.ts` — the same relation graph `verifyModelBuilderLinkCoverage.ts` (model-builder/t-032) already checks against `prisma/schema.prisma`:
  - `expand-characters` → `['Dream', 'Reward', 'Scenario']`
  - `expand-rewards` → `['Dream', 'Character']`
  - `expand-scenarios` → `['Dream', 'Character']`
  - `expand-narrator-bot` → `['Dream']` (links via `Dream.narratorId`)
  - `expand-manager-bot` → `['Project']` (links via `Project.managerBotId`)
  - `expand-signature-rewards` → `['Character']`
- `getOutputsForRecipe(recipeKey, sourceType?)` now filters by `sourceTypes` when both the output restricts and a source type is known; outputs without `sourceTypes` (every other recipe) are unaffected.
- `modelBuilderStore.ts`'s `recipeOutputs` computed and `selectRecipe()` both pass `state.sourceType` through, so `model-builder-recipe-selector.vue` (already driven by `store.recipeOutputs`) picks this up with no template change.

### Why
Before this change, `relationship-expansion`'s `sourceTypes` was recipe-level only (`Project, Character, Facet, Dream, Scenario, Reward`), so e.g. a `Reward` source could select "Manager bot" (target `Bot`), which has no Prisma relation to `Reward` — committing it creates an orphaned, unlinked `Bot`.

### Verified
- `npx tsx utils/scripts/verifyModelBuilderLinkCoverage.ts` still passes (this change doesn't touch `commit.post.ts` or the schema, just narrows the picker to match what already links).
- Manually traced every `expand-*` output against `commit.post.ts`'s `linkSourceToTarget` cases to build the `sourceTypes` lists above.
- Could not run the full `vue-tsc` typecheck locally (`node_modules` not installed in this sandbox) — relying on PR CI's TypeScript check as the verification gate, per this repo's established pattern for sandbox-constrained sessions.

### Note
`Facet` is still listed in `SOURCE_TYPES.recipes` as eligible for `relationship-expansion`, but has **no** `linkSourceToTarget` case at all — so after this change, a `Facet` source now sees zero available `expand-*` outputs for that recipe (previously it saw all 6, all of which would have orphaned on commit). That's a strict improvement (no more silently-broken creates), but the recipe is effectively non-functional for `Facet` until it gets real link cases. Filed as a kaizen follow-up in `conductor/projects/model-builder/roadmap.yaml`.

### Stakes
reversible — front-end/store only, no schema or API change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FVbX7gvvi9ojH3PwQdc8Cb)_