### PR TITLE
Compact the video LoRA picker and respect maturity consent

### DIFF
--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -2,9 +2,12 @@
   <section class="space-y-3 rounded-lg border border-base-300 p-3">
     <div class="flex flex-wrap items-center justify-between gap-2">
       <div>
-        <h2 class="font-semibold">LoRA <span class="opacity-50">(optional)</span></h2>
+        <h2 class="font-semibold">
+          LoRA <span class="opacity-50">(optional)</span>
+        </h2>
         <p class="text-xs opacity-60">
-          {{ engine.toUpperCase() }}-compatible Resources only. Preview images come from the Resource record.
+          {{ engine.toUpperCase() }}-compatible Resources only. Preview images
+          come from the Resource record.
         </p>
       </div>
       <button
@@ -31,61 +34,83 @@
       No active {{ engine.toUpperCase() }} LoRA Resources are available.
     </div>
 
-    <div v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      <button
-        v-for="resource in compatibleResources"
-        :key="resource.id"
-        type="button"
-        class="overflow-hidden rounded-lg border text-left transition"
-        :class="
-          modelValue === resource.id
-            ? 'border-accent bg-accent/10 ring-2 ring-accent/20'
-            : 'border-base-300 bg-base-100 hover:border-accent/60'
-        "
-        :aria-pressed="modelValue === resource.id"
-        @click="selectResource(resource.id)"
-      >
-        <div
-          v-if="previewImages(resource).length"
-          class="grid aspect-video w-full overflow-hidden bg-base-200"
-          :class="previewImages(resource).length > 1 ? 'grid-cols-2' : 'grid-cols-1'"
+    <div v-else class="max-h-64 overflow-y-auto overscroll-contain pr-1">
+      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <button
+          v-for="resource in compatibleResources"
+          :key="resource.id"
+          type="button"
+          class="overflow-hidden rounded-lg border text-left transition"
+          :class="
+            modelValue === resource.id
+              ? 'border-accent bg-accent/10 ring-2 ring-accent/20'
+              : 'border-base-300 bg-base-100 hover:border-accent/60'
+          "
+          :aria-pressed="modelValue === resource.id"
+          @click="selectResource(resource.id)"
         >
-          <img
-            v-for="src in previewImages(resource)"
-            :key="src"
-            :src="src"
-            :alt="`${resourceLabel(resource)} preview`"
-            class="h-full min-h-0 w-full object-cover"
-            loading="lazy"
-            @error="hideBrokenImage"
-          />
-        </div>
-        <div
-          v-else
-          class="flex aspect-video items-center justify-center bg-base-200 text-3xl opacity-30"
-          aria-hidden="true"
-        >
-          🎞️
-        </div>
-
-        <div class="space-y-1 p-3">
-          <div class="flex items-start justify-between gap-2">
-            <span class="font-semibold leading-tight">{{ resourceLabel(resource) }}</span>
-            <span
-              v-if="modelValue === resource.id"
-              class="badge badge-accent badge-sm shrink-0"
-            >
-              Selected
-            </span>
+          <div
+            v-if="previewImages(resource).length"
+            class="grid aspect-video w-full overflow-hidden bg-base-200"
+            :class="
+              previewImages(resource).length > 1
+                ? 'grid-cols-2'
+                : 'grid-cols-1'
+            "
+          >
+            <img
+              v-for="src in previewImages(resource)"
+              :key="src"
+              :src="src"
+              :alt="`${resourceLabel(resource)} preview`"
+              class="h-full min-h-0 w-full object-cover"
+              loading="lazy"
+              @error="hideBrokenImage"
+            />
           </div>
-          <p class="truncate text-xs opacity-60" :title="resource.localPath || ''">
-            {{ resource.localPath }}
-          </p>
-          <p v-if="resource.defaultTrigger || resource.triggerWords" class="line-clamp-2 text-xs opacity-70">
-            {{ resource.defaultTrigger || resource.triggerWords }}
-          </p>
-        </div>
-      </button>
+          <div
+            v-else
+            class="flex aspect-video items-center justify-center bg-base-200 text-3xl opacity-30"
+            aria-hidden="true"
+          >
+            🎞️
+          </div>
+
+          <div class="space-y-1 p-3">
+            <div class="flex items-start justify-between gap-2">
+              <span class="font-semibold leading-tight">
+                {{ resourceLabel(resource) }}
+              </span>
+              <span class="flex shrink-0 items-center gap-1">
+                <span
+                  v-if="resource.isMature"
+                  class="badge badge-error badge-outline badge-sm"
+                >
+                  18+
+                </span>
+                <span
+                  v-if="modelValue === resource.id"
+                  class="badge badge-accent badge-sm"
+                >
+                  Selected
+                </span>
+              </span>
+            </div>
+            <p
+              class="truncate text-xs opacity-60"
+              :title="resource.localPath || ''"
+            >
+              {{ resource.localPath }}
+            </p>
+            <p
+              v-if="resource.defaultTrigger || resource.triggerWords"
+              class="line-clamp-2 text-xs opacity-70"
+            >
+              {{ resource.defaultTrigger || resource.triggerWords }}
+            </p>
+          </div>
+        </button>
+      </div>
     </div>
 
     <div
@@ -93,7 +118,9 @@
       class="grid gap-3 rounded-lg bg-base-200 p-3 sm:grid-cols-[1fr_7rem] sm:items-end"
     >
       <label class="space-y-1">
-        <span class="text-sm font-semibold">LoRA strength: {{ normalizedStrength.toFixed(2) }}</span>
+        <span class="text-sm font-semibold">
+          LoRA strength: {{ normalizedStrength.toFixed(2) }}
+        </span>
         <input
           :value="normalizedStrength"
           type="range"
@@ -120,6 +147,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, watch } from 'vue'
+import { useArtStore } from '@/stores/artStore'
 import { useResourceStore } from '@/stores/resourceStore'
 import type { VideoEngine } from '@/stores/videoStore'
 import type { Resource } from '~/prisma/generated/prisma/client'
@@ -145,6 +173,7 @@ const emit = defineEmits<{
   'update:strength': [value: number]
 }>()
 
+const artStore = useArtStore()
 const resourceStore = useResourceStore()
 
 const compatibleResources = computed<VideoLoraResource[]>(() => {
@@ -152,8 +181,10 @@ const compatibleResources = computed<VideoLoraResource[]>(() => {
 
   return (resourceStore.resources as VideoLoraResource[]).filter((resource) => {
     return (
-      (resource.resourceType === 'LORA' || resource.resourceType === 'LYCORIS') &&
+      (resource.resourceType === 'LORA' ||
+        resource.resourceType === 'LYCORIS') &&
       Boolean(resource.localPath?.trim()) &&
+      (!resource.isMature || artStore.showMature) &&
       (resource.supportedServer === supportedServer ||
         resource.supportedServer === 'GENERIC')
     )
@@ -214,7 +245,9 @@ function previewImages(resource: VideoLoraResource): string[] {
     resource.ArtImage?.path,
   ]
     .map(normalizeImagePath)
-    .filter((path, index, paths) => Boolean(path) && paths.indexOf(path) === index)
+    .filter(
+      (path, index, paths) => Boolean(path) && paths.indexOf(path) === index,
+    )
 }
 
 function selectResource(resourceId: number): void {


### PR DESCRIPTION
## What changed

- Cap the video-generator LoRA results at `max-h-64` and give the card grid its own vertical scroll area.
- Keep the picker header, clear action, and selected LoRA strength controls outside that scroll region.
- Filter mature LoRA/LoCon Resources through the existing `artStore.showMature` user-consent setting.
- Automatically clear a selected mature Resource if the user turns mature content off.
- Mark visible mature Resources with an `18+` badge when mature content is enabled.

## Why

The preview-rich cards were useful but allowed the LoRA section to dominate the video-generator page. The video picker also omitted the maturity filter already used by the general art LoRA picker.

## Validation

- TypeScript Type Check: passed.
- Contract Tests: passed.
- API Client Follow-ups, Facet Catalog, Narrative Primitives, and Storymaker Studio contracts: passed.