### PR TITLE
coloring: add canonical cover production studio

### DIFF
--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -1,0 +1,378 @@
+<template>
+  <section
+    v-if="book && cover"
+    id="coloring-cover-studio"
+    class="flex flex-col gap-5 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+  >
+    <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="badge badge-accent rounded-2xl">Cover source art</span>
+          <span class="text-xs font-black uppercase tracking-widest text-base-content/40">
+            {{ book.title }}
+          </span>
+        </div>
+        <h3 class="mt-2 text-2xl font-black">Canonical cover production</h3>
+        <p class="mt-1 max-w-3xl text-sm text-base-content/55">
+          Generate, revise, adopt, accept, and finalize the portrait source illustration.
+          Title typography, spine, back cover, barcode space, bleed, and printer template
+          remain explicit packaging work after this stage.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <span class="badge rounded-2xl" :class="statusBadge">
+          {{ cover.status }}
+        </span>
+        <span v-if="cover.semanticScore !== null" class="badge badge-info rounded-2xl">
+          Score {{ cover.semanticScore }}
+        </span>
+        <span v-if="cover.revisionHistory.length" class="badge badge-outline rounded-2xl">
+          {{ cover.revisionHistory.length }} archived revision{{ cover.revisionHistory.length === 1 ? '' : 's' }}
+        </span>
+      </div>
+    </header>
+
+    <div class="grid gap-5 xl:grid-cols-[minmax(18rem,0.8fr)_minmax(0,1.2fr)]">
+      <article class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-200/40 p-4">
+        <div class="relative overflow-hidden rounded-2xl border border-base-300 bg-base-100">
+          <img
+            v-if="displayUrl"
+            :src="displayUrl"
+            :alt="`${book.title} cover source art`"
+            class="aspect-[2/3] size-full object-contain"
+          />
+          <div
+            v-else
+            class="flex aspect-[2/3] items-center justify-center text-base-content/30"
+          >
+            <icon name="kind-icon:book" class="size-20" />
+          </div>
+          <span
+            class="badge absolute left-3 top-3 rounded-2xl"
+            :class="displayLabel === 'Final' ? 'badge-success' : displayLabel === 'Accepted' ? 'badge-primary' : 'badge-ghost'"
+          >
+            {{ displayLabel }}
+          </span>
+        </div>
+
+        <p class="break-all text-xs text-base-content/45">
+          {{ displayPath || cover.imagePath }}
+        </p>
+
+        <div class="grid grid-cols-3 gap-2 text-center text-xs">
+          <div class="rounded-2xl bg-base-100 p-2">
+            <p class="font-black">{{ cover.artImageId || '—' }}</p>
+            <p class="text-base-content/45">ArtImage</p>
+          </div>
+          <div class="rounded-2xl bg-base-100 p-2">
+            <p class="font-black">{{ cover.renderSeed ?? '—' }}</p>
+            <p class="text-base-content/45">Seed</p>
+          </div>
+          <div class="rounded-2xl bg-base-100 p-2">
+            <p class="font-black">{{ cover.renderEngine || '—' }}</p>
+            <p class="text-base-content/45">Engine</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-4">
+        <div>
+          <h4 class="text-xl font-black">Cover art prompt</h4>
+          <p v-if="cover.sourceRef" class="mt-1 break-all text-xs text-base-content/45">
+            Historical source: {{ cover.sourceRef }}
+          </p>
+        </div>
+
+        <textarea
+          v-model="promptDraft"
+          class="textarea textarea-bordered min-h-72 w-full rounded-2xl text-sm leading-relaxed"
+          :readonly="!userStore.isAdmin"
+          placeholder="Describe a coherent ensemble front-cover illustration with a quiet title area..."
+        />
+
+        <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45">
+          <span>{{ promptDraft.length }} characters</span>
+          <span v-if="promptDirty" class="badge badge-warning badge-sm rounded-2xl">
+            Unsaved changes
+          </span>
+        </div>
+
+        <button
+          v-if="userStore.isAdmin"
+          type="button"
+          class="btn btn-primary rounded-2xl"
+          :disabled="!promptDirty || studio.savingCoverPrompt || promptDraft.trim().length < 40"
+          @click="savePrompt"
+        >
+          <span v-if="studio.savingCoverPrompt" class="loading loading-spinner loading-sm" />
+          <icon v-else name="kind-icon:save" class="size-5" />
+          Save canonical cover prompt
+        </button>
+
+        <div
+          v-if="cover.semanticReasons.length"
+          class="rounded-2xl border border-warning/40 bg-warning/10 p-3"
+        >
+          <p class="text-sm font-black text-warning">Latest review notes</p>
+          <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-warning">
+            <li v-for="reason in cover.semanticReasons" :key="reason">
+              {{ reason }}
+            </li>
+          </ul>
+        </div>
+
+        <template v-if="userStore.isAdmin">
+          <div class="divider my-0">Cover action</div>
+
+          <input
+            v-model="actionNote"
+            type="text"
+            class="input input-bordered rounded-2xl"
+            placeholder="Optional cover decision or revision note"
+          />
+
+          <div class="grid gap-3 sm:grid-cols-2">
+            <button
+              type="button"
+              class="btn btn-secondary rounded-2xl"
+              :disabled="!canGenerate || studio.requestingAction || promptDirty"
+              @click="requestCover(false)"
+            >
+              <span v-if="studio.requestingAction" class="loading loading-spinner loading-sm" />
+              <icon v-else name="kind-icon:sparkles" class="size-5" />
+              Generate cover candidate
+            </button>
+
+            <button
+              v-if="canRevise"
+              type="button"
+              class="btn btn-outline btn-warning rounded-2xl"
+              :disabled="studio.requestingAction || promptDirty"
+              @click="requestCover(true)"
+            >
+              <icon name="kind-icon:refresh" class="size-5" />
+              Archive and regenerate
+            </button>
+
+            <ProductionActionButton
+              label="Accept cover source"
+              confirm-label="Confirm cover acceptance"
+              icon-name="kind-icon:check"
+              :enabled="canAccept"
+              :armed="armedAction === 'accept-cover'"
+              :busy="studio.requestingAction"
+              @click="runHumanAction('accept-cover')"
+            />
+
+            <ProductionActionButton
+              label="Finalize cover source"
+              confirm-label="Confirm final cover source"
+              icon-name="kind-icon:book"
+              :enabled="canFinalize"
+              :armed="armedAction === 'finalize-cover'"
+              :busy="studio.requestingAction"
+              @click="runHumanAction('finalize-cover')"
+            />
+          </div>
+
+          <div class="rounded-2xl border border-base-300 bg-base-200/40 p-3">
+            <label class="form-control">
+              <div class="label py-1">
+                <span class="label-text text-xs font-black uppercase tracking-wide">
+                  Adopt an existing set-local cover file
+                </span>
+              </div>
+              <div class="flex flex-col gap-2 sm:flex-row">
+                <input
+                  v-model="legacyPath"
+                  type="text"
+                  class="input input-bordered w-full rounded-2xl"
+                  placeholder="approved/my-cover.webp"
+                />
+                <button
+                  type="button"
+                  class="btn btn-outline rounded-2xl"
+                  :disabled="!validLegacyPath || studio.requestingAction"
+                  @click="adoptExisting"
+                >
+                  <icon name="kind-icon:gallery" class="size-5" />
+                  Adopt exact file
+                </button>
+              </div>
+            </label>
+            <p class="mt-2 text-xs text-base-content/45">
+              The file must already exist inside this book’s Conductor set. Missing ArtJob metadata is preserved as missing, not creatively hallucinated.
+            </p>
+          </div>
+
+          <p v-if="promptDirty" class="text-xs font-semibold text-warning">
+            Save the prompt before requesting a render so the event uses the text shown here.
+          </p>
+          <p v-if="armedAction" class="text-xs font-semibold text-warning">
+            This writes a cover decision to Conductor. Click the highlighted button again to confirm.
+          </p>
+        </template>
+      </article>
+    </div>
+
+    <div v-if="cover.revisionHistory.length" class="flex flex-col gap-3">
+      <h4 class="font-black">Archived cover revisions</h4>
+      <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <a
+          v-for="revision in cover.revisionHistory"
+          :key="revision.id"
+          :href="revision.archivedUrl || undefined"
+          :target="revision.archivedUrl ? '_blank' : undefined"
+          rel="noopener noreferrer"
+          class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/40 p-3"
+          :class="revision.archivedUrl ? 'transition hover:border-primary hover:shadow-sm' : ''"
+        >
+          <img
+            v-if="revision.archivedUrl"
+            :src="revision.archivedUrl"
+            :alt="`${book.title} archived cover revision`"
+            class="aspect-[2/3] w-full rounded-xl bg-base-100 object-contain"
+          />
+          <p class="text-xs font-black">{{ revision.previousStatus || 'Archived revision' }}</p>
+          <p class="text-xs text-base-content/45">
+            {{ formatDate(revision.requestedAt) }}
+          </p>
+          <p v-if="revision.semanticScore !== null" class="text-xs text-base-content/55">
+            Semantic score {{ revision.semanticScore }}
+          </p>
+        </a>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { ColoringBookStudioOperation } from '~/types/coloringBookStudio'
+import ProductionActionButton from './production-action-button.vue'
+import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+import { useUserStore } from '@/stores/userStore'
+
+const studio = useColoringBookStudioStore()
+const userStore = useUserStore()
+const promptDraft = ref('')
+const actionNote = ref('')
+const legacyPath = ref('')
+const armedAction = ref<ColoringBookStudioOperation | null>(null)
+
+const book = computed(() => studio.selectedBook)
+const cover = computed(() => studio.selectedCover)
+const promptDirty = computed(
+  () => Boolean(cover.value && promptDraft.value.trim() !== cover.value.prompt.trim()),
+)
+const displayUrl = computed(
+  () =>
+    cover.value?.finalUrl ||
+    cover.value?.acceptedUrl ||
+    cover.value?.renderedUrl ||
+    cover.value?.rejectedUrl ||
+    null,
+)
+const displayPath = computed(
+  () =>
+    cover.value?.finalPath ||
+    cover.value?.acceptedPath ||
+    cover.value?.renderedPath ||
+    cover.value?.rejectedPath ||
+    null,
+)
+const displayLabel = computed(() => {
+  if (cover.value?.finalPath) return 'Final'
+  if (cover.value?.acceptedPath) return 'Accepted'
+  if (cover.value?.renderedPath) return 'Candidate'
+  if (cover.value?.rejectedPath) return 'Needs review'
+  return 'No candidate'
+})
+const statusBadge = computed(() => {
+  if (cover.value?.status === 'final') return 'badge-success'
+  if (cover.value?.status === 'approved') return 'badge-primary'
+  if (cover.value?.status === 'done') return 'badge-secondary'
+  if (cover.value?.status === 'needs_review' || cover.value?.status === 'failed') {
+    return 'badge-error'
+  }
+  return 'badge-ghost'
+})
+const canGenerate = computed(() =>
+  ['pending', 'failed', 'missing'].includes(cover.value?.status || 'missing'),
+)
+const canRevise = computed(() =>
+  ['done', 'needs_review', 'failed'].includes(cover.value?.status || ''),
+)
+const canAccept = computed(() =>
+  Boolean(cover.value?.status === 'done' && cover.value.renderedPath && !cover.value.acceptedPath),
+)
+const canFinalize = computed(() =>
+  Boolean(cover.value?.acceptedPath && !cover.value.finalPath),
+)
+const validLegacyPath = computed(() => {
+  const path = legacyPath.value.trim().replace(/\\/g, '/')
+  const prefix = book.value
+    ? `projects/coloring-book/sets/${book.value.slug}/`
+    : ''
+  return Boolean(
+    path &&
+      !path.startsWith('/') &&
+      !path.includes(':') &&
+      !path.split('/').includes('..') &&
+      (!path.startsWith('projects/') || path.startsWith(prefix)) &&
+      /\.(?:webp|png|jpe?g)$/i.test(path),
+  )
+})
+
+watch(
+  cover,
+  (value) => {
+    promptDraft.value = value?.prompt || ''
+    actionNote.value = ''
+    legacyPath.value = ''
+    armedAction.value = null
+  },
+  { immediate: true },
+)
+
+async function savePrompt(): Promise<void> {
+  await studio.saveCoverPrompt(promptDraft.value)
+}
+
+async function requestCover(force: boolean): Promise<void> {
+  armedAction.value = null
+  const success = await studio.requestCover(force, actionNote.value)
+  if (success) actionNote.value = ''
+}
+
+async function runHumanAction(
+  operation: 'accept-cover' | 'finalize-cover',
+): Promise<void> {
+  if (armedAction.value !== operation) {
+    armedAction.value = operation
+    return
+  }
+  const success = await studio.requestProductionAction(operation, {
+    note: actionNote.value,
+  })
+  if (success) {
+    armedAction.value = null
+    actionNote.value = ''
+  }
+}
+
+async function adoptExisting(): Promise<void> {
+  armedAction.value = null
+  const success = await studio.acceptCover(actionNote.value, legacyPath.value.trim())
+  if (success) {
+    actionNote.value = ''
+    legacyPath.value = ''
+  }
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Unknown time'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+</script>

--- a/server/api/conductor/coloring-books/cover-prompt.post.ts
+++ b/server/api/conductor/coloring-books/cover-prompt.post.ts
@@ -1,0 +1,113 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import type { ColoringBookCoverPromptUpdate } from '~/types/coloringBookStudio'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { errorHandler } from '@/server/utils/error'
+import { conductorGet, conductorPut } from '@/server/utils/conductor-github'
+import { coloringBookConfig } from '@/server/utils/coloringBookStudio'
+import { COLORING_BOOK_COVER_QUEUE_PATH } from '@/server/utils/coloringBookCoverState'
+
+function wrapYamlText(value: string, width = 100): string[] {
+  const words = value.replace(/\r/g, '').replace(/\s+/g, ' ').trim().split(' ')
+  const lines: string[] = []
+  let current = ''
+  for (const word of words) {
+    if (!word) continue
+    const next = current ? `${current} ${word}` : word
+    if (next.length > width && current) {
+      lines.push(current)
+      current = word
+    } else {
+      current = next
+    }
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+function replaceCoverPrompt(
+  content: string,
+  bookSlug: string,
+  prompt: string,
+): string {
+  const blocks = [...content.matchAll(/^- order:\s*\d+\s*$/gm)]
+  const index = blocks.findIndex((match, position) => {
+    const start = match.index ?? 0
+    const end = blocks[position + 1]?.index ?? content.length
+    return new RegExp(`^  book_slug:\s*${bookSlug}\s*$`, 'm').test(
+      content.slice(start, end),
+    )
+  })
+  if (index < 0) throw new Error(`Cover queue entry not found: ${bookSlug}`)
+
+  const start = blocks[index]?.index ?? 0
+  const end = blocks[index + 1]?.index ?? content.length
+  const block = content.slice(start, end)
+  const promptLine = /^  prompt:.*$/m.exec(block)
+  if (!promptLine) throw new Error(`Cover prompt field not found: ${bookSlug}`)
+  const promptStart = start + (promptLine.index ?? 0)
+  const afterLine = promptStart + promptLine[0].length
+  const continuation = content
+    .slice(afterLine, end)
+    .match(/^(?:\n(?: {4,}.*)?)*?\n(?=  [a-z_]+:)/)?.[0]
+  const promptEnd = continuation
+    ? afterLine + continuation.length - 1
+    : afterLine
+  const replacement = [
+    '  prompt: >',
+    ...wrapYamlText(prompt).map((line) => `    ${line}`),
+  ].join('\n')
+  return `${content.slice(0, promptStart)}${replacement}${content.slice(promptEnd)}`
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+    const body = (await readBody(event)) as Partial<ColoringBookCoverPromptUpdate> | null
+    const bookSlug = String(body?.bookSlug || '').trim().toLowerCase()
+    const prompt = String(body?.prompt || '').replace(/\r/g, '').trim()
+
+    if (!coloringBookConfig(bookSlug)) {
+      throw createError({ statusCode: 400, message: 'Invalid coloring-book slug.' })
+    }
+    if (prompt.length < 40) {
+      throw createError({
+        statusCode: 400,
+        message: 'The cover prompt must be at least 40 characters.',
+      })
+    }
+    if (prompt.length > 8000) {
+      throw createError({
+        statusCode: 400,
+        message: 'The cover prompt must be 8000 characters or fewer.',
+      })
+    }
+
+    const source = await conductorGet(COLORING_BOOK_COVER_QUEUE_PATH)
+    if (!source) {
+      throw createError({ statusCode: 404, message: 'Canonical cover queue was not found.' })
+    }
+    const content = replaceCoverPrompt(source.content, bookSlug, prompt)
+    await conductorPut(
+      COLORING_BOOK_COVER_QUEUE_PATH,
+      content,
+      `coloring-book: update ${bookSlug} cover prompt`,
+      source.sha,
+    )
+
+    return {
+      success: true,
+      message: `${bookSlug} cover prompt saved to the canonical Conductor queue.`,
+      data: { bookSlug, prompt },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to update the coloring-book cover prompt.',
+      statusCode,
+    }
+  }
+})

--- a/server/api/conductor/coloring-books/production.get.ts
+++ b/server/api/conductor/coloring-books/production.get.ts
@@ -2,17 +2,26 @@ import { defineEventHandler } from 'h3'
 import { errorHandler } from '@/server/utils/error'
 import { conductorGet } from '@/server/utils/conductor-github'
 import { COLORING_BOOK_QUEUE_PATH } from '@/server/utils/coloringBookStudio'
+import {
+  buildColoringBookCoverStates,
+  COLORING_BOOK_COVER_QUEUE_PATH,
+} from '@/server/utils/coloringBookCoverState'
 import { buildColoringBookProductionData } from '@/server/utils/coloringBookProductionState'
 
 export default defineEventHandler(async (event) => {
   try {
-    const queueFile = await conductorGet(COLORING_BOOK_QUEUE_PATH)
+    const [queueFile, coverQueueFile] = await Promise.all([
+      conductorGet(COLORING_BOOK_QUEUE_PATH),
+      conductorGet(COLORING_BOOK_COVER_QUEUE_PATH),
+    ])
     if (!queueFile) throw new Error('Canonical coloring-book queue was not found.')
+    if (!coverQueueFile) throw new Error('Canonical coloring-book cover queue was not found.')
 
     const data = buildColoringBookProductionData(queueFile.content)
+    data.covers = buildColoringBookCoverStates(coverQueueFile.content)
     return {
       success: true,
-      message: `${Object.keys(data.states).length} production records loaded from Conductor.`,
+      message: `${Object.keys(data.states).length} interior records and ${Object.keys(data.covers).length} cover records loaded from Conductor.`,
       data,
       statusCode: 200,
     }

--- a/server/api/conductor/coloring-books/request.post.ts
+++ b/server/api/conductor/coloring-books/request.post.ts
@@ -21,6 +21,15 @@ const OPERATIONS = new Set<ColoringBookStudioOperation>([
   'generate-bw',
   'accept-bw',
   'finalize-pair',
+  'generate-cover',
+  'accept-cover',
+  'finalize-cover',
+])
+
+const COVER_OPERATIONS = new Set<ColoringBookStudioOperation>([
+  'generate-cover',
+  'accept-cover',
+  'finalize-cover',
 ])
 
 const OPERATION_LABELS: Record<ColoringBookStudioOperation, string> = {
@@ -29,6 +38,9 @@ const OPERATION_LABELS: Record<ColoringBookStudioOperation, string> = {
   'generate-bw': 'B&W counterpart',
   'accept-bw': 'B&W acceptance',
   'finalize-pair': 'pair finalization',
+  'generate-cover': 'cover candidate',
+  'accept-cover': 'cover acceptance',
+  'finalize-cover': 'cover finalization',
 }
 
 const IMAGE_PATH = /\.(?:webp|png|jpe?g)$/i
@@ -52,10 +64,14 @@ function normalizeSourcePath(
 ): string | null {
   const raw = String(value || '').trim().replace(/\\/g, '/')
   if (!raw) return null
-  if (operation !== 'accept-color' && operation !== 'accept-bw') {
+  if (
+    operation !== 'accept-color' &&
+    operation !== 'accept-bw' &&
+    operation !== 'accept-cover'
+  ) {
     throw createError({
       statusCode: 400,
-      message: 'Existing asset paths are supported only for color or B&W acceptance.',
+      message: 'Existing asset paths are supported only for color, B&W, or cover acceptance.',
     })
   }
 
@@ -84,19 +100,36 @@ export default defineEventHandler(async (event) => {
     await requireAdminApiUser(event)
     const body = (await readBody(event)) as Partial<ColoringBookRenderRequest> | null
     const operation = normalizeOperation(body?.operation)
+    const coverOperation = COVER_OPERATIONS.has(operation)
     const bookSlug = compact(String(body?.bookSlug || '')).toLowerCase()
     const proposalId = compact(String(body?.proposalId || '')).toLowerCase()
     const force = body?.force === true
     const note = compact(String(body?.note || '')).slice(0, 500)
+    const config = coloringBookConfig(bookSlug)
 
-    if (!coloringBookConfig(bookSlug) || !proposalBelongsToBook(bookSlug, proposalId)) {
+    if (!config) {
+      throw createError({ statusCode: 400, message: 'Invalid coloring-book slug.' })
+    }
+    if (!coverOperation && !proposalBelongsToBook(bookSlug, proposalId)) {
       throw createError({ statusCode: 400, message: 'Invalid book or proposal id.' })
     }
-    const sourcePath = normalizeSourcePath(body?.sourcePath, bookSlug, operation)
-    if (force && operation !== 'generate-color-proposals' && operation !== 'generate-bw') {
+    if (coverOperation && proposalId) {
       throw createError({
         statusCode: 400,
-        message: 'Forced revisions are supported only for color and B&W generation.',
+        message: 'Cover operations target the selected book and do not accept a proposal id.',
+      })
+    }
+
+    const sourcePath = normalizeSourcePath(body?.sourcePath, bookSlug, operation)
+    if (
+      force &&
+      operation !== 'generate-color-proposals' &&
+      operation !== 'generate-bw' &&
+      operation !== 'generate-cover'
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: 'Forced revisions are supported only for color, B&W, and cover generation.',
       })
     }
     if (force && sourcePath) {
@@ -106,32 +139,32 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    const targetKey = coverOperation ? `${bookSlug}-cover` : proposalId
+    const targetLabel = coverOperation ? `${config.title} cover` : proposalId
     const eventFiles = (await conductorList('color-art-events')) ?? []
     const alreadyQueued = eventFiles.some(
-      (entry) => entry.type === 'file' && entry.name.includes(`-${proposalId}-`),
+      (entry) => entry.type === 'file' && entry.name.includes(`-${targetKey}-`),
     )
     if (alreadyQueued) {
       throw createError({
         statusCode: 409,
-        message: `${proposalId} already has a queued Coloring Book Studio action.`,
+        message: `${targetLabel} already has a queued Coloring Book Studio action.`,
       })
     }
 
-    const requestedAt = new Date()
-    const stamp = requestedAt.toISOString().replace(/[-:.]/g, '').replace('Z', 'Z')
+    const stamp = new Date().toISOString().replace(/[-:.]/g, '').replace('Z', 'Z')
     const suffix = randomUUID().slice(0, 8)
-    const path = `color-art-events/${stamp}-${proposalId}-${operation}-${suffix}.yaml`
+    const path = `color-art-events/${stamp}-${targetKey}-${operation}-${suffix}.yaml`
     const label = OPERATION_LABELS[operation]
     const sourceLabel = sourcePath ? ` from ${sourcePath}` : ''
     const defaultNote = force
-      ? `${proposalId} ${label} revision requested from the production studio.`
-      : `${proposalId} ${label}${sourceLabel} requested from the production studio.`
+      ? `${targetLabel} ${label} revision requested from the production studio.`
+      : `${targetLabel} ${label}${sourceLabel} requested from the production studio.`
     const content = [
       'version: 1',
       `operation: ${operation}`,
       `book: ${bookSlug}`,
-      'proposal_ids:',
-      `  - ${proposalId}`,
+      ...(!coverOperation ? ['proposal_ids:', `  - ${proposalId}`] : []),
       ...(sourcePath ? [`source_path: ${JSON.stringify(sourcePath)}`] : []),
       'timeout: 600',
       `force: ${force ? 'true' : 'false'}`,
@@ -144,16 +177,16 @@ export default defineEventHandler(async (event) => {
     await conductorPut(
       path,
       content,
-      `coloring-book: request ${proposalId} ${label}${force ? ' revision' : sourceLabel}`,
+      `coloring-book: request ${targetLabel} ${label}${force ? ' revision' : sourceLabel}`,
     )
 
     return {
       success: true,
-      message: `${proposalId} ${label}${force ? ' revision' : sourceLabel} queued in Conductor.`,
+      message: `${targetLabel} ${label}${force ? ' revision' : sourceLabel} queued in Conductor.`,
       data: {
         operation,
         bookSlug,
-        proposalId,
+        proposalId: coverOperation ? undefined : proposalId,
         sourcePath,
         force,
         eventPath: path,

--- a/server/utils/coloringBookCoverState.ts
+++ b/server/utils/coloringBookCoverState.ts
@@ -1,0 +1,168 @@
+import type {
+  ColoringBookCoverHistoryItem,
+  ColoringBookCoverState,
+} from '~/types/coloringBookStudio'
+import {
+  COLORING_BOOK_REF,
+  COLORING_BOOK_REPO,
+  COLORING_BOOK_ROOT,
+} from '@/server/utils/coloringBookStudio'
+
+export const COLORING_BOOK_COVER_QUEUE_PATH = `${COLORING_BOOK_ROOT}/cover-art-jobs.yaml`
+
+function capture(text: string, pattern: RegExp, group = 1): string | undefined {
+  return pattern.exec(text)?.[group]
+}
+
+function indentation(line: string): number {
+  return /^\s*/.exec(line)?.[0].length ?? 0
+}
+
+function yamlValue(value: string | undefined): string | null {
+  const clean = String(value ?? '').trim()
+  if (!clean || clean === 'null' || clean === '~') return null
+  if (clean.startsWith('"')) {
+    try {
+      return String(JSON.parse(clean))
+    } catch {}
+  }
+  return clean.replace(/^['"]|['"]$/g, '')
+}
+
+function yamlNumber(value: string | null): number | null {
+  if (value === null) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function scalar(block: string, key: string): string | null {
+  return yamlValue(
+    capture(block, new RegExp(`^  ${key}:\\s*(.*?)\\s*$`, 'm')),
+  )
+}
+
+function collectYamlText(block: string, key: string): string {
+  const lines = block.split('\n')
+  const index = lines.findIndex((line) => new RegExp(`^  ${key}:`).test(line))
+  if (index < 0) return ''
+  const line = lines[index] ?? ''
+  const colon = line.indexOf(':')
+  const first = colon >= 0 ? line.slice(colon + 1).trim() : ''
+  const values: string[] = []
+  if (first && first !== '>' && first !== '|') values.push(first)
+  for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+    const next = lines[cursor] ?? ''
+    if (next.trim() && indentation(next) <= 2) break
+    if (next.trim()) values.push(next.trim())
+  }
+  return yamlValue(values.join(' ')) ?? ''
+}
+
+function listValues(block: string, key: string): string[] {
+  const section = capture(
+    block,
+    new RegExp(
+      `^  ${key}:\\s*(?:\\[\\])?\\s*$([\\s\\S]*?)(?=^  [a-z_]+:|$(?![\\s\\S]))`,
+      'm',
+    ),
+  )
+  if (!section) return []
+  return [...section.matchAll(/^\s*-\s*(.*?)\s*$/gm)]
+    .map((match) => yamlValue(match?.[1]) ?? '')
+    .filter(Boolean)
+}
+
+function historyBlocks(block: string): string[] {
+  const section = capture(
+    block,
+    /^  revision_history:\s*(?:\[\])?\s*$([\s\S]*?)(?=^  [a-z_]+:|$(?![\s\S]))/m,
+  )
+  if (!section) return []
+  return section
+    .split(/(?=^  - )/m)
+    .filter((entry) => entry.startsWith('  - '))
+}
+
+function historyScalar(block: string, key: string): string | null {
+  const first = capture(block, new RegExp(`^  - ${key}:\\s*(.*?)\\s*$`, 'm'))
+  if (first !== undefined) return yamlValue(first)
+  return yamlValue(
+    capture(block, new RegExp(`^    ${key}:\\s*(.*?)\\s*$`, 'm')),
+  )
+}
+
+function rawAssetUrl(path: string | null, bookSlug: string): string | null {
+  const clean = String(path || '').trim()
+  if (!clean || clean.includes(':') || clean.startsWith('user-attachment')) return null
+  const repoPath = clean.startsWith('projects/')
+    ? clean
+    : `${COLORING_BOOK_ROOT}/sets/${bookSlug}/${clean.replace(/^\.\//, '')}`
+  return `https://raw.githubusercontent.com/${COLORING_BOOK_REPO}/${COLORING_BOOK_REF}/${repoPath}`
+}
+
+function historyItems(
+  block: string,
+  bookSlug: string,
+): ColoringBookCoverHistoryItem[] {
+  return historyBlocks(block).map((item, index) => {
+    const archivedPath = historyScalar(item, 'archived_path')
+    return {
+      id: `${bookSlug}:cover:${archivedPath || historyScalar(item, 'requested_at') || index}`,
+      archivedPath,
+      archivedUrl: rawAssetUrl(archivedPath, bookSlug),
+      requestedAt: historyScalar(item, 'requested_at'),
+      previousStatus: historyScalar(item, 'previous_status'),
+      artImageId: yamlNumber(historyScalar(item, 'art_image_id')),
+      semanticScore: yamlNumber(historyScalar(item, 'semantic_score')),
+    }
+  })
+}
+
+export function buildColoringBookCoverStates(
+  content: string,
+): Record<string, ColoringBookCoverState> {
+  const states: Record<string, ColoringBookCoverState> = {}
+  const coverSection = content.split(/^covers:\s*$/m)[1] ?? ''
+  const blocks = coverSection
+    .split(/(?=^- order:)/m)
+    .filter((block) => block.startsWith('- order:'))
+
+  for (const block of blocks) {
+    const bookSlug = scalar(block, 'book_slug')
+    if (!bookSlug) continue
+    const renderedPath = scalar(block, 'rendered_path')
+    const rejectedPath = scalar(block, 'rejected_path')
+    const acceptedPath = scalar(block, 'accepted_path')
+    const finalPath = scalar(block, 'final_path')
+    states[bookSlug] = {
+      order: yamlNumber(yamlValue(capture(block, /^- order:\s*(.*?)\s*$/m))) ?? 999,
+      bookSlug,
+      title: scalar(block, 'title') ?? bookSlug,
+      prompt: collectYamlText(block, 'prompt'),
+      sourceRef: scalar(block, 'source_ref'),
+      imagePath: scalar(block, 'image_path') ?? '',
+      status: scalar(block, 'status') ?? 'missing',
+      renderedPath,
+      renderedUrl: rawAssetUrl(renderedPath, bookSlug),
+      artImageId: yamlNumber(scalar(block, 'art_image_id')),
+      renderSeed: yamlNumber(scalar(block, 'render_seed')),
+      renderEngine: scalar(block, 'render_engine'),
+      completedAt: scalar(block, 'completed_at'),
+      semanticScore: yamlNumber(scalar(block, 'semantic_score')),
+      semanticVerdict: scalar(block, 'semantic_verdict'),
+      semanticReasons: listValues(block, 'semantic_reasons'),
+      rejectedPath,
+      rejectedUrl: rawAssetUrl(rejectedPath, bookSlug),
+      acceptedPath,
+      acceptedUrl: rawAssetUrl(acceptedPath, bookSlug),
+      approvedAt: scalar(block, 'approved_at'),
+      finalPath,
+      finalUrl: rawAssetUrl(finalPath, bookSlug),
+      finalizedAt: scalar(block, 'finalized_at'),
+      revisionHistory: historyItems(block, bookSlug),
+      notes: listValues(block, 'notes'),
+    }
+  }
+
+  return states
+}

--- a/stores/coloringBookStudioStore.ts
+++ b/stores/coloringBookStudioStore.ts
@@ -1,6 +1,8 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import type {
+  ColoringBookCoverPromptUpdate,
+  ColoringBookCoverState,
   ColoringBookProductionData,
   ColoringBookProductionState,
   ColoringBookPromptUpdate,
@@ -11,15 +13,23 @@ import type {
 } from '~/types/coloringBookStudio'
 import { performFetch } from '@/stores/utils'
 
+const COVER_OPERATIONS = new Set<ColoringBookStudioOperation>([
+  'generate-cover',
+  'accept-cover',
+  'finalize-cover',
+])
+
 export const useColoringBookStudioStore = defineStore(
   'coloringBookStudioStore',
   () => {
     const books = ref<ColoringBookStudioBook[]>([])
     const productionStates = ref<Record<string, ColoringBookProductionState>>({})
+    const coverStates = ref<Record<string, ColoringBookCoverState>>({})
     const selectedBookSlug = ref('monster-recast')
     const selectedProposalId = ref('')
     const loading = ref(false)
     const savingPrompt = ref(false)
+    const savingCoverPrompt = ref(false)
     const requestingAction = ref(false)
     const error = ref<string | null>(null)
     const message = ref<string | null>(null)
@@ -50,6 +60,12 @@ export const useColoringBookStudioStore = defineStore(
       if (!book || !proposal) return null
       return productionStates.value[`${book.slug}:${proposal.id}`] ?? null
     })
+
+    const selectedCover = computed<ColoringBookCoverState | null>(() =>
+      selectedBook.value
+        ? (coverStates.value[selectedBook.value.slug] ?? null)
+        : null,
+    )
 
     const requestingRender = computed(() => requestingAction.value)
 
@@ -111,6 +127,7 @@ export const useColoringBookStudioStore = defineStore(
         }
         books.value = studioResponse.data.books
         productionStates.value = productionResponse.data.states
+        coverStates.value = productionResponse.data.covers ?? {}
         fetchedAt.value = studioResponse.data.fetchedAt
         if (
           !books.value.some((book) => book.slug === selectedBookSlug.value)
@@ -167,13 +184,42 @@ export const useColoringBookStudioStore = defineStore(
       }
     }
 
+    async function saveCoverPrompt(prompt: string): Promise<boolean> {
+      const book = selectedBook.value
+      if (!book || savingCoverPrompt.value) return false
+
+      savingCoverPrompt.value = true
+      error.value = null
+      message.value = null
+      try {
+        const body: ColoringBookCoverPromptUpdate = {
+          bookSlug: book.slug,
+          prompt,
+        }
+        const response = await performFetch<ColoringBookCoverPromptUpdate>(
+          '/api/conductor/coloring-books/cover-prompt',
+          { method: 'POST', body: JSON.stringify(body) },
+        )
+        if (!response.success) {
+          error.value = response.message || 'Failed to save the cover prompt.'
+          return false
+        }
+        message.value = response.message || `${book.title} cover prompt saved.`
+        await fetchStudio()
+        return true
+      } finally {
+        savingCoverPrompt.value = false
+      }
+    }
+
     async function requestProductionAction(
       operation: ColoringBookStudioOperation,
       options: { force?: boolean; note?: string; sourcePath?: string } = {},
     ): Promise<boolean> {
       const book = selectedBook.value
       const proposal = selectedProposal.value
-      if (!book || !proposal || requestingAction.value) return false
+      const coverOperation = COVER_OPERATIONS.has(operation)
+      if (!book || (!coverOperation && !proposal) || requestingAction.value) return false
 
       requestingAction.value = true
       error.value = null
@@ -182,7 +228,7 @@ export const useColoringBookStudioStore = defineStore(
         const body: ColoringBookRenderRequest = {
           operation,
           bookSlug: book.slug,
-          proposalId: proposal.id,
+          proposalId: coverOperation ? undefined : proposal?.id,
           sourcePath: options.sourcePath || undefined,
           force: options.force === true,
           note: options.note || '',
@@ -196,7 +242,8 @@ export const useColoringBookStudioStore = defineStore(
           return false
         }
         message.value =
-          response.message || `${proposal.id} production action queued.`
+          response.message ||
+          `${coverOperation ? book.title : proposal?.id} production action queued.`
         await fetchStudio()
         return true
       } finally {
@@ -224,6 +271,18 @@ export const useColoringBookStudioStore = defineStore(
       return requestProductionAction('finalize-pair', { note })
     }
 
+    function requestCover(force = false, note = ''): Promise<boolean> {
+      return requestProductionAction('generate-cover', { force, note })
+    }
+
+    function acceptCover(note = '', sourcePath = ''): Promise<boolean> {
+      return requestProductionAction('accept-cover', { note, sourcePath })
+    }
+
+    function finalizeCover(note = ''): Promise<boolean> {
+      return requestProductionAction('finalize-cover', { note })
+    }
+
     function clearNotice(): void {
       error.value = null
       message.value = null
@@ -232,14 +291,17 @@ export const useColoringBookStudioStore = defineStore(
     return {
       books,
       productionStates,
+      coverStates,
       selectedBookSlug,
       selectedProposalId,
       selectedBook,
       selectedProposal,
       selectedProductionState,
+      selectedCover,
       queueProblems,
       loading,
       savingPrompt,
+      savingCoverPrompt,
       requestingAction,
       requestingRender,
       error,
@@ -249,12 +311,16 @@ export const useColoringBookStudioStore = defineStore(
       selectBook,
       selectProposal,
       savePrompt,
+      saveCoverPrompt,
       requestProductionAction,
       requestColorRender,
       acceptColor,
       requestBw,
       acceptBw,
       finalizePair,
+      requestCover,
+      acceptCover,
+      finalizeCover,
       clearNotice,
     }
   },

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -6,6 +6,9 @@ export type ColoringBookStudioOperation =
   | 'generate-bw'
   | 'accept-bw'
   | 'finalize-pair'
+  | 'generate-cover'
+  | 'accept-cover'
+  | 'finalize-cover'
 
 export type ColoringBookHistoryKind =
   | 'revision'
@@ -33,6 +36,16 @@ export type ColoringBookHistoryItem = {
   artImageId: number | null
   seed: number | null
   engine: string | null
+}
+
+export type ColoringBookCoverHistoryItem = {
+  id: string
+  archivedPath: string | null
+  archivedUrl: string | null
+  requestedAt: string | null
+  previousStatus: string | null
+  artImageId: number | null
+  semanticScore: number | null
 }
 
 export type ColoringBookPair = {
@@ -77,6 +90,35 @@ export type ColoringBookProductionState = {
   pairSemanticReasons: string[]
   pairFinalizedAt: string | null
   history: ColoringBookHistoryItem[]
+}
+
+export type ColoringBookCoverState = {
+  order: number
+  bookSlug: string
+  title: string
+  prompt: string
+  sourceRef: string | null
+  imagePath: string
+  status: string
+  renderedPath: string | null
+  renderedUrl: string | null
+  artImageId: number | null
+  renderSeed: number | null
+  renderEngine: string | null
+  completedAt: string | null
+  semanticScore: number | null
+  semanticVerdict: string | null
+  semanticReasons: string[]
+  rejectedPath: string | null
+  rejectedUrl: string | null
+  acceptedPath: string | null
+  acceptedUrl: string | null
+  approvedAt: string | null
+  finalPath: string | null
+  finalUrl: string | null
+  finalizedAt: string | null
+  revisionHistory: ColoringBookCoverHistoryItem[]
+  notes: string[]
 }
 
 export type ColoringBookProposal = {
@@ -129,6 +171,7 @@ export type ColoringBookStudioData = {
 
 export type ColoringBookProductionData = {
   states: Record<string, ColoringBookProductionState>
+  covers: Record<string, ColoringBookCoverState>
   fetchedAt: string
 }
 
@@ -138,10 +181,15 @@ export type ColoringBookPromptUpdate = {
   prompt: string
 }
 
+export type ColoringBookCoverPromptUpdate = {
+  bookSlug: string
+  prompt: string
+}
+
 export type ColoringBookRenderRequest = {
   operation?: ColoringBookStudioOperation
   bookSlug: string
-  proposalId: string
+  proposalId?: string
   sourcePath?: string
   force?: boolean
   note?: string

--- a/types/coloringBookStudio.ts
+++ b/types/coloringBookStudio.ts
@@ -171,7 +171,7 @@ export type ColoringBookStudioData = {
 
 export type ColoringBookProductionData = {
   states: Record<string, ColoringBookProductionState>
-  covers: Record<string, ColoringBookCoverState>
+  covers?: Record<string, ColoringBookCoverState>
   fetchedAt: string
 }
 

--- a/utils/coloringBookReadiness.ts
+++ b/utils/coloringBookReadiness.ts
@@ -1,4 +1,5 @@
 import type {
+  ColoringBookCoverState,
   ColoringBookProductionState,
   ColoringBookProposal,
   ColoringBookStudioBook,
@@ -32,7 +33,9 @@ export type ColoringBookReadinessSummary = {
   needsPrompt: number
   blocked: number
   actionable: number
+  coverStatus: string
   coverPending: boolean
+  coverActionable: boolean
   interiorReady: boolean
   printReady: boolean
 }
@@ -175,10 +178,23 @@ export function proposalReadiness(
   }
 }
 
+function coverStatusLabel(cover: ColoringBookCoverState | null): string {
+  if (!cover) return 'Not configured'
+  if (cover.finalPath || cover.status === 'final') return 'Final cover source'
+  if (cover.acceptedPath || cover.status === 'approved') return 'Finalize cover source'
+  if (cover.renderedPath || cover.status === 'done') return 'Accept cover source'
+  if (cover.status === 'needs_review') return 'Cover needs review'
+  if (cover.status === 'running') return 'Cover rendering'
+  if (cover.status === 'failed') return 'Cover generation failed'
+  return 'Generate cover source'
+}
+
 export function summarizeBookReadiness(
   book: ColoringBookStudioBook,
   productionStates: Record<string, ColoringBookProductionState>,
+  cover: ColoringBookCoverState | null = null,
 ): ColoringBookReadinessSummary {
+  const coverPending = book.coverIsSeparate && !cover?.finalPath && cover?.status !== 'final'
   const summary: ColoringBookReadinessSummary = {
     total: book.proposals.length,
     final: 0,
@@ -190,7 +206,9 @@ export function summarizeBookReadiness(
     needsPrompt: 0,
     blocked: 0,
     actionable: 0,
-    coverPending: book.coverIsSeparate,
+    coverStatus: coverStatusLabel(cover),
+    coverPending,
+    coverActionable: coverPending && cover?.status !== 'running',
     interiorReady: false,
     printReady: false,
   }

--- a/utils/scripts/verifyColoringBookCoverState.ts
+++ b/utils/scripts/verifyColoringBookCoverState.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { buildColoringBookCoverStates } from '@/server/utils/coloringBookCoverState'
+
+const source = `schema_version: 1
+defaults:
+  engine: krea2
+covers:
+- order: 1
+  book_slug: monster-recast
+  title: Monster Recast
+  source_ref: projects/coloring-book/sets/monster-recast/pages.yaml#cover
+  prompt: >
+    Original ensemble cover source illustration with a calm title area and many glamorous
+    reimagined monster archetypes in one coherent old-Hollywood premiere scene.
+  image_path: projects/coloring-book/sets/monster-recast/generated/cover/monster-recast-cover.webp
+  status: done
+  rendered_path: projects/coloring-book/sets/monster-recast/generated/cover/monster-recast-cover.webp
+  art_image_id: 501
+  render_seed: 123456
+  render_engine: krea2
+  completed_at: '2026-07-28T12:00:00Z'
+  semantic_score: 91
+  semantic_verdict: promote
+  semantic_reasons: []
+  rejected_path: null
+  accepted_path: null
+  approved_at: null
+  final_path: null
+  finalized_at: null
+  revision_history:
+  - requested_at: '2026-07-28T11:00:00Z'
+    previous_status: needs_review
+    art_image_id: 499
+    semantic_score: 62
+    archived_path: projects/coloring-book/sets/monster-recast/generated/cover/revisions/monster-recast-cover-old.webp
+  notes:
+  - Typography remains separate.
+- order: 2
+  book_slug: hollywood-recast
+  title: Hollywood Recast
+  source_ref: projects/coloring-book/sets/hollywood-recast/proposals.yaml#cover
+  prompt: 'Inclusive imaginary studio ensemble with varied performers, crisp color,
+    one coherent scene, and reserved title space.'
+  image_path: projects/coloring-book/sets/hollywood-recast/generated/cover/hollywood-recast-cover.webp
+  status: final
+  rendered_path: projects/coloring-book/sets/hollywood-recast/generated/cover/hollywood-recast-cover.webp
+  art_image_id: 502
+  render_seed: 789
+  render_engine: krea2
+  completed_at: '2026-07-28T12:30:00Z'
+  semantic_score: 94
+  semantic_verdict: promote
+  semantic_reasons:
+  - Strong ensemble hierarchy.
+  accepted_path: generated/cover/hollywood-recast-cover.webp
+  approved_at: '2026-07-28T12:40:00Z'
+  final_path: generated/cover/hollywood-recast-cover.webp
+  finalized_at: '2026-07-28T12:45:00Z'
+  revision_history: []
+  notes: []
+`
+
+const states = buildColoringBookCoverStates(source)
+assert.deepEqual(Object.keys(states), ['monster-recast', 'hollywood-recast'])
+
+const monster = states['monster-recast']
+assert.ok(monster)
+assert.equal(monster.order, 1)
+assert.match(monster.prompt, /calm title area/)
+assert.equal(monster.status, 'done')
+assert.equal(monster.artImageId, 501)
+assert.equal(monster.renderSeed, 123456)
+assert.equal(monster.semanticScore, 91)
+assert.equal(monster.renderedUrl?.includes('monster-recast-cover.webp'), true)
+assert.equal(monster.revisionHistory.length, 1)
+assert.equal(monster.revisionHistory[0]?.previousStatus, 'needs_review')
+assert.equal(monster.revisionHistory[0]?.artImageId, 499)
+assert.equal(monster.revisionHistory[0]?.semanticScore, 62)
+assert.equal(monster.revisionHistory[0]?.archivedUrl?.includes('/revisions/'), true)
+assert.deepEqual(monster.notes, ['Typography remains separate.'])
+
+const hollywood = states['hollywood-recast']
+assert.ok(hollywood)
+assert.match(hollywood.prompt, /Inclusive imaginary studio ensemble/)
+assert.equal(hollywood.status, 'final')
+assert.equal(hollywood.acceptedPath, 'generated/cover/hollywood-recast-cover.webp')
+assert.equal(hollywood.finalPath, 'generated/cover/hollywood-recast-cover.webp')
+assert.equal(hollywood.finalUrl?.includes('hollywood-recast-cover.webp'), true)
+assert.deepEqual(hollywood.semanticReasons, ['Strong ensemble hierarchy.'])
+
+console.log('Coloring Book cover-state contract passed.')


### PR DESCRIPTION
## What changed

- adds first-class cover production state for Monster Recast, Hollywood Recast, and Kind Robots
- loads the canonical Conductor cover queue alongside the existing 108 interior records
- adds an editable canonical cover prompt per book
- adds current, accepted, final, rejected, and archived-revision cover previews
- adds Generate Cover, Archive and Regenerate, Adopt Exact File, Accept Cover, and Finalize Cover controls
- keeps acceptance and finalization human-gated with two-click confirmation
- exposes cover semantic score, verdict, reasons, ArtImage ID, seed, engine, and history
- integrates final cover state into the whole-book print-readiness dashboard
- upgrades the dedicated Coloring Book contract to test both readiness and PyYAML-rewritten cover queue parsing

## Cover boundary

The managed asset is portrait front-cover source art with a reserved title area and no generated words. The UI explicitly keeps typography, spine, back cover, barcode space, bleed, and printer-template layout in the later packaging stage.

## Architecture

- Conductor remains canonical
- Pinia owns all component/API interaction
- cover state shares the existing production refresh
- cover actions emit book-level events without a fake proposal ID
- exact-file adoption accepts only set-local image paths and preserves missing provenance as missing

## Backend dependency

Conductor PR #1320 provides the matching cover queue, durable ArtJob consumer, semantic review, revision archive, acceptance, finalization, and ledger writes. Merge #1320 before this PR.

## Validation

Ready for TypeScript, the full contract suite, and the expanded Coloring Book Production Contract, then merge to `main`.