### PR TITLE
Enforce maturity and privacy across generation and queue tools

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Database pool defaults contract
         run: npm run test:database-pool-defaults
 
+      - name: Maturity and privacy generation contract
+        run: npx tsx utils/scripts/verifyMaturityPrivacyContract.ts
+
       - name: Dream store fetch merge contract
         run: npx tsx utils/scripts/verifyDreamStoreFetchMerge.ts
 

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -224,6 +224,12 @@
               </dl>
             </div>
 
+            <content-visibility-controls
+              v-model:is-mature="form.isMature"
+              v-model:is-public="form.isPublic"
+              :disabled="saving"
+            />
+
             <div
               class="rounded-2xl border border-info/30 bg-info/10 p-3 text-xs leading-relaxed"
             >
@@ -247,6 +253,18 @@
                   {{ form.sampler || 'sampler default' }}
                 </span>
                 <span
+                  class="badge badge-sm rounded-2xl"
+                  :class="form.isMature ? 'badge-warning' : 'badge-outline'"
+                >
+                  {{ form.isMature ? 'Mature' : 'General' }}
+                </span>
+                <span
+                  class="badge badge-sm rounded-2xl"
+                  :class="form.isPublic ? 'badge-success badge-outline' : 'badge-neutral'"
+                >
+                  {{ form.isPublic ? 'Public' : 'Private' }}
+                </span>
+                <span
                   v-if="isVideoJob"
                   class="badge badge-accent badge-outline badge-sm rounded-2xl"
                 >
@@ -268,8 +286,8 @@
         class="flex flex-wrap items-center justify-between gap-3 border-t border-base-300 p-4"
       >
         <p class="text-xs text-base-content/50">
-          Blank seed creates a fresh random seed. Facets and video settings are
-          persisted as canonical ArtJob provenance.
+          Blank seed creates a fresh random seed. Facets, visibility, and video
+          settings are persisted as canonical ArtJob provenance.
         </p>
         <div class="flex gap-2">
           <button
@@ -325,6 +343,7 @@ import {
   type ArtJobRecord,
   type ArtJobRetryMode,
 } from '@/stores/artJobStore'
+import { resolveMaturityPrivacy } from '@/utils/maturityPrivacy'
 
 type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
 type JsonRecord = Record<string, unknown>
@@ -343,6 +362,8 @@ type FacetAwareOverrides = ArtJobOverrides & {
   durationSeconds?: number | null
   fps?: number | null
   loop?: boolean | null
+  isMature?: boolean | null
+  isPublic?: boolean | null
 }
 type Preset = {
   value: string
@@ -522,6 +543,7 @@ function resolveVideoModel(): VideoModel {
 }
 
 const payload = computed(() => asRecord(props.job.payload))
+const visibility = resolveMaturityPrivacy(asRecord(payload.value.save))
 const isVideoJob = computed(
   () =>
     String(payload.value.media || '').toLowerCase() === 'video' ||
@@ -558,6 +580,8 @@ const form = reactive({
   durationSeconds: videoScalar(['durationSeconds']) || '4',
   fps: videoScalar(['fps']) || '24',
   loop: booleanValue(asRecord(payload.value.video).loop, true),
+  isMature: visibility.isMature,
+  isPublic: visibility.isPublic,
 })
 
 const numericFields: Array<{
@@ -666,6 +690,8 @@ async function save(): Promise<void> {
     basePromptString: prompt,
     facetIds: [...facetIds.value],
     negativePrompt: form.negativePrompt.trim(),
+    isMature: form.isMature,
+    isPublic: form.isPublic,
   }
   const numeric: Array<[keyof ArtJobOverrides, string]> = [
     ['width', form.width],
@@ -687,7 +713,11 @@ async function save(): Promise<void> {
   if (isVideoJob.value) {
     const durationSeconds = numberValue(form.durationSeconds)
     const fps = numberValue(form.fps)
-    if (durationSeconds === null || durationSeconds < 0.25 || durationSeconds > 30) {
+    if (
+      durationSeconds === null ||
+      durationSeconds < 0.25 ||
+      durationSeconds > 30
+    ) {
       localError.value = 'Video duration must be between 0.25 and 30 seconds.'
       return
     }

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -346,7 +346,7 @@
           >
             <div class="flex min-w-0 gap-3">
               <a
-                v-if="jobImageSrc(job)"
+                v-if="jobImageSrc(job) && canShowJobContent(job)"
                 :href="jobImageSrc(job)"
                 target="_blank"
                 rel="noopener"
@@ -362,9 +362,9 @@
               </a>
               <div
                 v-else
-                class="flex h-28 w-24 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 text-center text-[10px] font-semibold uppercase text-base-content/40"
+                class="flex h-28 w-24 shrink-0 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100 px-2 text-center text-[10px] font-semibold uppercase text-base-content/40"
               >
-                {{ job.status }}
+                {{ canShowJobContent(job) ? job.status : 'Mature hidden' }}
               </div>
 
               <div class="min-w-0 flex-1">
@@ -382,6 +382,26 @@
                     job.engine
                   }}</span>
                   <span
+                    class="badge badge-xs rounded-2xl"
+                    :class="
+                      jobVisibility(job).isMature
+                        ? 'badge-warning'
+                        : 'badge-outline'
+                    "
+                  >
+                    {{ jobVisibility(job).isMature ? 'Mature' : 'General' }}
+                  </span>
+                  <span
+                    class="badge badge-xs rounded-2xl"
+                    :class="
+                      jobVisibility(job).isPublic
+                        ? 'badge-success badge-outline'
+                        : 'badge-neutral'
+                    "
+                  >
+                    {{ jobVisibility(job).isPublic ? 'Public' : 'Private' }}
+                  </span>
+                  <span
                     v-if="job.projectSlug"
                     class="badge badge-secondary badge-xs rounded-2xl"
                   >
@@ -389,9 +409,16 @@
                   </span>
                 </div>
                 <p
+                  v-if="canShowJobContent(job)"
                   class="mt-2 line-clamp-5 whitespace-pre-wrap text-sm font-medium leading-relaxed"
                 >
                   {{ jobPrompt(job) || 'Prompt unavailable.' }}
+                </p>
+                <p
+                  v-else
+                  class="mt-2 rounded-xl border border-warning/30 bg-warning/10 p-2 text-xs text-warning-content"
+                >
+                  Mature prompt and preview are hidden by your account setting.
                 </p>
                 <div class="mt-2 flex flex-wrap gap-1">
                   <span
@@ -423,35 +450,44 @@
               <div
                 class="flex flex-col gap-3 border-t border-base-300 p-3 text-xs"
               >
-                <div>
-                  <div
-                    class="font-semibold uppercase tracking-wide text-base-content/50"
-                  >
-                    Prompt
+                <div
+                  v-if="!canShowJobContent(job)"
+                  class="rounded-xl border border-warning/30 bg-warning/10 p-3 text-warning-content"
+                >
+                  Enable mature content in your account settings to view or edit
+                  this job's prompt and preview.
+                </div>
+                <template v-else>
+                  <div>
+                    <div
+                      class="font-semibold uppercase tracking-wide text-base-content/50"
+                    >
+                      Prompt
+                    </div>
+                    <p class="mt-1 whitespace-pre-wrap leading-relaxed">
+                      {{ jobPrompt(job) }}
+                    </p>
                   </div>
-                  <p class="mt-1 whitespace-pre-wrap leading-relaxed">
-                    {{ jobPrompt(job) }}
-                  </p>
-                </div>
-                <div>
-                  <div
-                    class="font-semibold uppercase tracking-wide text-base-content/50"
-                  >
-                    Negative prompt
+                  <div>
+                    <div
+                      class="font-semibold uppercase tracking-wide text-base-content/50"
+                    >
+                      Negative prompt
+                    </div>
+                    <p class="mt-1 whitespace-pre-wrap text-base-content/70">
+                      {{ jobNegativePrompt(job) || 'None' }}
+                    </p>
                   </div>
-                  <p class="mt-1 whitespace-pre-wrap text-base-content/70">
-                    {{ jobNegativePrompt(job) || 'None' }}
-                  </p>
-                </div>
-                <div class="flex flex-wrap gap-1">
-                  <span
-                    v-for="setting in jobSettings(job)"
-                    :key="setting"
-                    class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
-                  >
-                    {{ setting }}
-                  </span>
-                </div>
+                  <div class="flex flex-wrap gap-1">
+                    <span
+                      v-for="setting in jobSettings(job)"
+                      :key="setting"
+                      class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
+                    >
+                      {{ setting }}
+                    </span>
+                  </div>
+                </template>
               </div>
             </details>
 
@@ -459,7 +495,12 @@
               <button
                 type="button"
                 class="btn btn-ghost btn-xs rounded-2xl"
-                :disabled="!jobPrompt(job)"
+                :disabled="!jobPrompt(job) || !canShowJobContent(job)"
+                :title="
+                  canShowJobContent(job)
+                    ? 'Copy prompt'
+                    : 'Enable mature content to reveal this prompt'
+                "
                 @click="copyPrompt(job)"
               >
                 {{ copiedJobId === job.id ? 'Copied' : 'Copy prompt' }}
@@ -470,6 +511,7 @@
                   v-if="isEditableInPlace(job)"
                   type="button"
                   class="btn btn-primary btn-xs rounded-2xl"
+                  :disabled="!canShowJobContent(job)"
                   @click="openEditor(job, 'EDIT')"
                 >
                   Edit & queue
@@ -478,6 +520,7 @@
                   v-else-if="job.status === 'RUNNING'"
                   type="button"
                   class="btn btn-primary btn-xs rounded-2xl"
+                  :disabled="!canShowJobContent(job)"
                   @click="openEditor(job, 'NEW_OUTPUT')"
                 >
                   Edit as new job
@@ -486,6 +529,7 @@
                   v-if="job.status === 'DONE'"
                   type="button"
                   class="btn btn-primary btn-xs rounded-2xl"
+                  :disabled="!canShowJobContent(job)"
                   @click="openEditor(job, 'NEW_OUTPUT')"
                 >
                   Edited output
@@ -494,6 +538,7 @@
                   v-if="job.status === 'DONE' && job.artImageId"
                   type="button"
                   class="btn btn-warning btn-xs rounded-2xl"
+                  :disabled="!canShowJobContent(job)"
                   @click="openEditor(job, 'OVERWRITE')"
                 >
                   Edit & replace
@@ -510,7 +555,7 @@
                   v-if="job.status === 'DONE' && job.artImageId"
                   type="button"
                   class="btn btn-ghost btn-xs rounded-2xl"
-                  :disabled="curationRequested(job)"
+                  :disabled="curationRequested(job) || !canShowJobContent(job)"
                   @click="requestCuration(job)"
                 >
                   {{ curationRequested(job) ? 'Curation requested' : 'Curate' }}
@@ -588,14 +633,17 @@ import {
   type UptimeSample,
   type WeakPromptRepairResult,
 } from '@/stores/artJobStore'
+import { useArtStore } from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
+import { resolveMaturityPrivacy } from '@/utils/maturityPrivacy'
 import type { Server } from '@/stores/serverStore'
 
 type JsonRecord = Record<string, unknown>
 type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
 
 const artJobStore = useArtJobStore()
+const artStore = useArtStore()
 const serverStore = useServerStore()
 const userStore = useUserStore()
 
@@ -746,6 +794,14 @@ function jobNegativePrompt(job: ArtJobRecord): string {
   )
 }
 
+function jobVisibility(job: ArtJobRecord) {
+  return resolveMaturityPrivacy(asRecord(asRecord(job.payload).save))
+}
+
+function canShowJobContent(job: ArtJobRecord): boolean {
+  return !jobVisibility(job).isMature || artStore.showMature
+}
+
 function jobSettings(job: ArtJobRecord): string[] {
   const values = [
     [
@@ -877,6 +933,7 @@ function isEditableInPlace(job: ArtJobRecord): boolean {
 }
 
 function openEditor(job: ArtJobRecord, action: EditorAction): void {
+  if (!canShowJobContent(job)) return
   editorJob.value = job
   editorAction.value = action
 }
@@ -918,6 +975,7 @@ async function runWeakPromptRepair(): Promise<void> {
 }
 
 async function requestCuration(job: ArtJobRecord): Promise<void> {
+  if (!canShowJobContent(job)) return
   await artJobStore.requestCuration(job.id)
 }
 
@@ -929,6 +987,7 @@ function curationRequested(job: ArtJobRecord): boolean {
 }
 
 async function copyPrompt(job: ArtJobRecord): Promise<void> {
+  if (!canShowJobContent(job)) return
   const prompt = jobPrompt(job)
   if (!prompt || !navigator.clipboard) return
   await navigator.clipboard.writeText(prompt)

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -1,0 +1,92 @@
+<template>
+  <section class="space-y-2 rounded-2xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-wrap items-start justify-between gap-2">
+      <div>
+        <h3 class="text-sm font-bold">Content visibility</h3>
+        <p class="mt-0.5 text-xs text-base-content/55">
+          Mature work defaults private; general-audience work defaults public.
+          You can override privacy after choosing maturity.
+        </p>
+      </div>
+      <span
+        class="badge badge-sm rounded-xl"
+        :class="isPublic ? 'badge-success badge-outline' : 'badge-neutral'"
+      >
+        {{ isPublic ? 'Public' : 'Private' }}
+      </span>
+    </div>
+
+    <div class="grid gap-2 sm:grid-cols-2">
+      <label
+        class="flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-base-300 bg-base-200/50 px-3 py-2"
+      >
+        <span>
+          <span class="block text-sm font-semibold">Mature</span>
+          <span class="block text-[11px] text-base-content/55">18+ content</span>
+        </span>
+        <input
+          :checked="isMature"
+          type="checkbox"
+          class="toggle toggle-warning toggle-sm"
+          :disabled="disabled"
+          @change="onMatureChange"
+        />
+      </label>
+
+      <label
+        class="flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-base-300 bg-base-200/50 px-3 py-2"
+      >
+        <span>
+          <span class="block text-sm font-semibold">Public</span>
+          <span class="block text-[11px] text-base-content/55">
+            {{ isPublic ? 'Visible in public surfaces' : 'Owner/admin only' }}
+          </span>
+        </span>
+        <input
+          :checked="isPublic"
+          type="checkbox"
+          class="toggle toggle-success toggle-sm"
+          :disabled="disabled"
+          @change="onPublicChange"
+        />
+      </label>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { defaultPublicForMaturity } from '@/utils/maturityPrivacy'
+
+const props = withDefaults(
+  defineProps<{
+    isMature: boolean
+    isPublic: boolean
+    disabled?: boolean
+  }>(),
+  { disabled: false },
+)
+
+const emit = defineEmits<{
+  'update:isMature': [value: boolean]
+  'update:isPublic': [value: boolean]
+}>()
+
+// A non-default initial pair is already an explicit privacy choice.
+const privacyOverridden = ref(
+  props.isPublic !== defaultPublicForMaturity(props.isMature),
+)
+
+function onMatureChange(event: Event): void {
+  const isMature = (event.target as HTMLInputElement).checked
+  emit('update:isMature', isMature)
+  if (!privacyOverridden.value) {
+    emit('update:isPublic', defaultPublicForMaturity(isMature))
+  }
+}
+
+function onPublicChange(event: Event): void {
+  privacyOverridden.value = true
+  emit('update:isPublic', (event.target as HTMLInputElement).checked)
+}
+</script>

--- a/pages/video-generator.vue
+++ b/pages/video-generator.vue
@@ -144,6 +144,12 @@
       :engine="engine"
     />
 
+    <content-visibility-controls
+      v-model:is-mature="isMature"
+      v-model:is-public="isPublic"
+      :disabled="videoStore.isBusy"
+    />
+
     <!-- Controls -->
     <section class="grid gap-4 sm:grid-cols-3">
       <div class="space-y-1">
@@ -319,6 +325,8 @@ const prompt = ref(WINK_PRESET)
 const negativePrompt = ref('')
 const loraResourceId = ref<number | null>(null)
 const loraStrength = ref(1)
+const isMature = ref(false)
+const isPublic = ref(true)
 const durationSeconds = ref(4)
 const fps = ref(24)
 const loop = ref(true)
@@ -404,6 +412,8 @@ async function generate() {
     seed,
     loraResourceIds: loraResourceId.value ? [loraResourceId.value] : undefined,
     loraStrength: loraResourceId.value ? loraStrength.value : undefined,
+    isMature: isMature.value,
+    isPublic: isPublic.value,
   })
 }
 </script>

--- a/plugins/art-maturity-privacy.client.ts
+++ b/plugins/art-maturity-privacy.client.ts
@@ -1,0 +1,36 @@
+import { watch } from 'vue'
+import { defineNuxtPlugin } from '#app'
+import { useArtStore } from '@/stores/artStore'
+import { defaultPublicForMaturity } from '@/utils/maturityPrivacy'
+
+/**
+ * The image generator already exposes mature and public toggles. Link their
+ * defaults without taking away the user's ability to override privacy.
+ */
+export default defineNuxtPlugin(() => {
+  const artStore = useArtStore()
+  let writingDefault = false
+  let privacyOverridden =
+    Boolean(artStore.artForm.isPublic) !==
+    defaultPublicForMaturity(Boolean(artStore.artForm.isMature))
+
+  watch(
+    () => artStore.artForm.isPublic,
+    () => {
+      if (writingDefault) {
+        writingDefault = false
+        return
+      }
+      privacyOverridden = true
+    },
+  )
+
+  watch(
+    () => artStore.artForm.isMature,
+    (isMature) => {
+      if (privacyOverridden) return
+      writingDefault = true
+      artStore.artForm.isPublic = defaultPublicForMaturity(Boolean(isMature))
+    },
+  )
+})

--- a/plugins/art-maturity-privacy.client.ts
+++ b/plugins/art-maturity-privacy.client.ts
@@ -3,9 +3,16 @@ import { defineNuxtPlugin } from '#app'
 import { useArtStore } from '@/stores/artStore'
 import { defaultPublicForMaturity } from '@/utils/maturityPrivacy'
 
+const GENERATION_ACTIONS = new Set([
+  'buildGenerateArtData',
+  'generateArt',
+  'enqueueArtGeneration',
+])
+
 /**
  * The image generator already exposes mature and public toggles. Link their
- * defaults without taking away the user's ability to override privacy.
+ * defaults without taking away the user's ability to override privacy, and
+ * normalize programmatic generation calls that supply maturity without privacy.
  */
 export default defineNuxtPlugin(() => {
   const artStore = useArtStore()
@@ -33,4 +40,17 @@ export default defineNuxtPlugin(() => {
       artStore.artForm.isPublic = defaultPublicForMaturity(Boolean(isMature))
     },
   )
+
+  artStore.$onAction(({ name, args }) => {
+    if (!GENERATION_ACTIONS.has(name)) return
+    const request = args[0]
+    if (!request || typeof request !== 'object' || Array.isArray(request)) return
+    const record = request as Record<string, unknown>
+    if (
+      typeof record.isMature === 'boolean' &&
+      typeof record.isPublic !== 'boolean'
+    ) {
+      record.isPublic = defaultPublicForMaturity(record.isMature)
+    }
+  })
 })

--- a/server/api/art/queue/[id]/edit.post.ts
+++ b/server/api/art/queue/[id]/edit.post.ts
@@ -17,6 +17,7 @@ import {
   applyArtJobOverrides,
   type ArtJobOverrides,
 } from '../../../../utils/artJobRetry'
+import { applyArtJobVisibility } from '../../../../utils/artJobVisibility'
 import {
   applyArtFacetsToPayload,
   readArtFacetIds,
@@ -29,10 +30,15 @@ import {
   resolvePresetEngine,
 } from '../../../comfy/utils/engineWorkflow'
 
+type VisibilityOverrides = ArtJobOverrides & {
+  isMature?: boolean | null
+  isPublic?: boolean | null
+}
+
 type EditBody = {
   refreshSeed?: boolean
   preset?: string | null
-  overrides?: ArtJobOverrides | null
+  overrides?: VisibilityOverrides | null
 }
 
 function randomSeed(): number {
@@ -129,6 +135,7 @@ export default defineEventHandler(async (event) => {
     delete renderOverrides.facetIds
     delete renderOverrides.basePromptString
     const updatedPayload = applyArtJobOverrides(payload, renderOverrides)
+    applyArtJobVisibility(updatedPayload, body?.overrides)
     applyArtFacetsToPayload(updatedPayload, basePrompt, facets)
     updatedPayload.queueEdit = {
       editedAt: new Date().toISOString(),

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -19,6 +19,7 @@ import {
   type ArtJobOverrides,
   type ArtJobRetryMode,
 } from '../../../../utils/artJobRetry'
+import { applyArtJobVisibility } from '../../../../utils/artJobVisibility'
 import {
   applyArtFacetsToPayload,
   readArtFacetIds,
@@ -31,11 +32,16 @@ import {
   resolvePresetEngine,
 } from '../../../comfy/utils/engineWorkflow'
 
+type VisibilityOverrides = ArtJobOverrides & {
+  isMature?: boolean | null
+  isPublic?: boolean | null
+}
+
 type ReenqueueBody = {
   mode?: string | null
   refreshSeed?: boolean
   preset?: string | null
-  overrides?: ArtJobOverrides | null
+  overrides?: VisibilityOverrides | null
 }
 
 export default defineEventHandler(async (event) => {
@@ -145,6 +151,7 @@ export default defineEventHandler(async (event) => {
     delete renderOverrides.facetIds
     delete renderOverrides.basePromptString
     const payload = applyArtJobOverrides(prepared, renderOverrides)
+    applyArtJobVisibility(payload, body?.overrides)
     applyArtFacetsToPayload(payload, basePrompt, facets)
     const jobEngine = presetEngine ? 'COMFY' : source.engine
 

--- a/server/api/chats/openai/images/generate.post.ts
+++ b/server/api/chats/openai/images/generate.post.ts
@@ -6,6 +6,7 @@ import { errorHandler } from './../../../../utils/error'
 import { saveImage } from '../../../../utils/saveImage'
 import { manaGate } from '../../../../utils/manaGate'
 import { estimateArtCostUsd } from '../../../../utils/manaCost'
+import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
 import {
   type RequestData,
   validateAndLoadArtCollectionId,
@@ -156,6 +157,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    const visibility = resolveMaturityPrivacy(requestData)
     const updatedImage = await prisma.artImage.update({
       where: {
         id: savedImage.id,
@@ -175,8 +177,8 @@ export default defineEventHandler(async (event) => {
         promptString: prompt,
         artPrompt: prompt,
         negativePrompt: requestData.negativePrompt ?? null,
-        isPublic: requestData.isPublic ?? true,
-        isMature: requestData.isMature ?? false,
+        isPublic: visibility.isPublic,
+        isMature: visibility.isMature,
         userId: validatedData.userId ?? user.id,
         serverId: requestData.serverId ?? null,
         serverName: requestData.serverName || 'OpenAI Images',

--- a/server/utils/artJobVisibility.ts
+++ b/server/utils/artJobVisibility.ts
@@ -1,0 +1,41 @@
+import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
+import type { ArtJobPayloadRecord } from './artJobPayload'
+
+type VisibilityOverrides = {
+  isMature?: boolean | null
+  isPublic?: boolean | null
+}
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+/**
+ * Apply explicit queue-editor visibility values and normalize legacy payloads.
+ * Explicit privacy always wins; otherwise changing maturity adopts its default.
+ */
+export function applyArtJobVisibility(
+  payload: ArtJobPayloadRecord,
+  overrides?: VisibilityOverrides | null,
+): ArtJobPayloadRecord {
+  const save = asRecord(payload.save)
+  const current = resolveMaturityPrivacy(save)
+  const hasMatureOverride = typeof overrides?.isMature === 'boolean'
+  const hasPublicOverride = typeof overrides?.isPublic === 'boolean'
+  const isMature = hasMatureOverride
+    ? Boolean(overrides?.isMature)
+    : current.isMature
+  const isPublic = hasPublicOverride
+    ? Boolean(overrides?.isPublic)
+    : hasMatureOverride
+      ? !isMature
+      : current.isPublic
+
+  payload.save = {
+    ...save,
+    isMature,
+    isPublic,
+  }
+  return payload
+}

--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -4,6 +4,7 @@ import {
   ResourceType,
   SupportedServer,
 } from '~/prisma/generated/prisma/client'
+import { resolveMaturityPrivacy } from '~/utils/maturityPrivacy'
 import prisma from './prisma'
 
 export type LoraAwareEnqueueBody = {
@@ -186,19 +187,23 @@ export async function resolveEnqueueLoraResource(input: {
   resourceIds: number[]
   resourceName: string | null
 }> {
-  const resourceIds = normalizeIds(input.body.loraResourceIds)
-  const requestedName = String(input.body.loraName || '').trim()
+  const normalizedBody: LoraAwareEnqueueBody = {
+    ...input.body,
+    ...resolveMaturityPrivacy(input.body),
+  }
+  const resourceIds = normalizeIds(normalizedBody.loraResourceIds)
+  const requestedName = String(normalizedBody.loraName || '').trim()
 
   if (!RESOURCE_RESOLVED_ENGINES.has(input.engine)) {
     return {
-      body: input.body,
+      body: normalizedBody,
       resourceIds,
       resourceName: requestedName || null,
     }
   }
 
   if (!resourceIds.length && !requestedName) {
-    return { body: input.body, resourceIds: [], resourceName: null }
+    return { body: normalizedBody, resourceIds: [], resourceName: null }
   }
 
   if (resourceIds.length > 1) {
@@ -290,7 +295,7 @@ export async function resolveEnqueueLoraResource(input: {
 
   return {
     body: {
-      ...input.body,
+      ...normalizedBody,
       loraName: localPath,
       loraResourceIds: [resource.id],
     },

--- a/utils/maturityPrivacy.ts
+++ b/utils/maturityPrivacy.ts
@@ -8,6 +8,11 @@ export type MaturityPrivacy = {
   isPublic: boolean
 }
 
+function asInput(value: unknown): MaturityPrivacyInput {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as MaturityPrivacyInput
+}
+
 function booleanOrUndefined(value: unknown): boolean | undefined {
   return typeof value === 'boolean' ? value : undefined
 }
@@ -19,16 +24,18 @@ function booleanOrUndefined(value: unknown): boolean | undefined {
  * mature work defaults private and general-audience work defaults public.
  */
 export function resolveMaturityPrivacy(
-  input: MaturityPrivacyInput | null | undefined,
-  fallback?: MaturityPrivacyInput | null,
+  input: unknown,
+  fallback?: unknown,
 ): MaturityPrivacy {
+  const source = asInput(input)
+  const fallbackSource = asInput(fallback)
   const isMature =
-    booleanOrUndefined(input?.isMature) ??
-    booleanOrUndefined(fallback?.isMature) ??
+    booleanOrUndefined(source.isMature) ??
+    booleanOrUndefined(fallbackSource.isMature) ??
     false
   const isPublic =
-    booleanOrUndefined(input?.isPublic) ??
-    booleanOrUndefined(fallback?.isPublic) ??
+    booleanOrUndefined(source.isPublic) ??
+    booleanOrUndefined(fallbackSource.isPublic) ??
     !isMature
 
   return { isMature, isPublic }

--- a/utils/maturityPrivacy.ts
+++ b/utils/maturityPrivacy.ts
@@ -1,0 +1,39 @@
+export type MaturityPrivacyInput = {
+  isMature?: unknown
+  isPublic?: unknown
+}
+
+export type MaturityPrivacy = {
+  isMature: boolean
+  isPublic: boolean
+}
+
+function booleanOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+/**
+ * Resolve the visibility contract used by generated images, videos, and ArtJobs.
+ *
+ * Explicit values always win. When public/private was not explicitly supplied,
+ * mature work defaults private and general-audience work defaults public.
+ */
+export function resolveMaturityPrivacy(
+  input: MaturityPrivacyInput | null | undefined,
+  fallback?: MaturityPrivacyInput | null,
+): MaturityPrivacy {
+  const isMature =
+    booleanOrUndefined(input?.isMature) ??
+    booleanOrUndefined(fallback?.isMature) ??
+    false
+  const isPublic =
+    booleanOrUndefined(input?.isPublic) ??
+    booleanOrUndefined(fallback?.isPublic) ??
+    !isMature
+
+  return { isMature, isPublic }
+}
+
+export function defaultPublicForMaturity(isMature: boolean): boolean {
+  return !isMature
+}

--- a/utils/scripts/verifyMaturityPrivacyContract.ts
+++ b/utils/scripts/verifyMaturityPrivacyContract.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  defaultPublicForMaturity,
+  resolveMaturityPrivacy,
+} from '../../utils/maturityPrivacy'
+import { applyArtJobVisibility } from '../../server/utils/artJobVisibility'
+
+assert.deepEqual(resolveMaturityPrivacy(undefined), {
+  isMature: false,
+  isPublic: true,
+})
+assert.deepEqual(resolveMaturityPrivacy({ isMature: true }), {
+  isMature: true,
+  isPublic: false,
+})
+assert.deepEqual(resolveMaturityPrivacy({ isMature: true, isPublic: true }), {
+  isMature: true,
+  isPublic: true,
+})
+assert.deepEqual(resolveMaturityPrivacy({ isMature: false, isPublic: false }), {
+  isMature: false,
+  isPublic: false,
+})
+assert.equal(defaultPublicForMaturity(true), false)
+assert.equal(defaultPublicForMaturity(false), true)
+
+const legacyMature = applyArtJobVisibility({ save: { isMature: true } })
+assert.deepEqual(legacyMature.save, { isMature: true, isPublic: false })
+
+const explicitPublicMature = applyArtJobVisibility(
+  { save: { isMature: false, isPublic: true, designer: 'Ami' } },
+  { isMature: true, isPublic: true },
+)
+assert.deepEqual(explicitPublicMature.save, {
+  isMature: true,
+  isPublic: true,
+  designer: 'Ami',
+})
+
+const matureOnlyEdit = applyArtJobVisibility(
+  { save: { isMature: false, isPublic: false } },
+  { isMature: true },
+)
+assert.deepEqual(matureOnlyEdit.save, { isMature: true, isPublic: false })
+
+const videoGenerator = readFileSync('pages/video-generator.vue', 'utf8')
+assert.ok(videoGenerator.includes('<content-visibility-controls'))
+assert.ok(videoGenerator.includes('isMature: isMature.value'))
+assert.ok(videoGenerator.includes('isPublic: isPublic.value'))
+
+const queueEditor = readFileSync(
+  'components/art/artjob-editor.vue',
+  'utf8',
+)
+assert.ok(queueEditor.includes('v-model:is-mature="form.isMature"'))
+assert.ok(queueEditor.includes('isMature: form.isMature'))
+assert.ok(queueEditor.includes('isPublic: form.isPublic'))
+
+const queueBrowser = readFileSync(
+  'components/art/artjob-queue-browser.vue',
+  'utf8',
+)
+assert.ok(queueBrowser.includes('jobVisibility(job).isMature'))
+assert.ok(queueBrowser.includes('jobVisibility(job).isPublic'))
+assert.ok(queueBrowser.includes('canShowJobContent(job)'))
+assert.ok(queueBrowser.includes('Mature prompt and preview are hidden'))
+
+const enqueueResolver = readFileSync('server/utils/artLoraResource.ts', 'utf8')
+assert.ok(enqueueResolver.includes('resolveMaturityPrivacy(input.body)'))
+
+const openAiRoute = readFileSync(
+  'server/api/chats/openai/images/generate.post.ts',
+  'utf8',
+)
+assert.ok(openAiRoute.includes('resolveMaturityPrivacy(requestData)'))
+
+const artGeneratorPlugin = readFileSync(
+  'plugins/art-maturity-privacy.client.ts',
+  'utf8',
+)
+assert.ok(artGeneratorPlugin.includes('defaultPublicForMaturity'))
+assert.ok(artGeneratorPlugin.includes('enqueueArtGeneration'))
+
+console.log('Maturity and privacy generation contract passed.')


### PR DESCRIPTION
## What changed

- Add a shared maturity/privacy contract: mature content defaults private; general-audience content defaults public; explicit privacy choices always win.
- Link the existing art-generator Mature/Public controls while preserving manual privacy overrides.
- Add the same controls to the LTX/WAN video generator and submit them with queued clips.
- Normalize queued image/video requests server-side, including callers that omit privacy and LoRA-free requests.
- Apply the same defaults to synchronous OpenAI image generation.
- Add maturity/privacy controls to ArtJob edit, new-output, and overwrite flows, including video jobs and legacy payload normalization.
- Display Mature/General and Public/Private badges in the ArtJob queue.
- Hide mature thumbnails, prompts, detail panels, clipboard access, curation, and editing while the viewer's mature-content consent is disabled.
- Add a DB-free contract verifier and run it in the Contract Tests workflow.

## Behavior

- `isMature: true` + omitted `isPublic` → private.
- `isMature: false` + omitted `isPublic` → public.
- An explicit public mature job or private general-audience job remains allowed.
- Changing maturity in a generator/editor updates privacy only until the user manually overrides privacy.

## Validation

- TypeScript Type Check: passed.
- Contract Tests, including the new maturity/privacy generation contract: passed.
- ArtJob Provenance Contract: passed.
- Open Issue Repair, API Client Follow-ups, Facet Catalog, Narrative Primitives, and Storymaker Studio contracts: passed.