### PR TITLE
academy: pair form labels with id on Style Lab select controls

### DIFF
--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -113,14 +113,18 @@
       >
         <!-- Collection selector -->
         <div class="flex flex-col gap-2">
-          <div class="flex items-center gap-1.5">
+          <label
+            class="flex items-center gap-1.5"
+            for="image-upload-collection"
+          >
             <icon name="kind-icon:folder" class="h-4 w-4 text-secondary" />
             <span class="text-xs font-bold text-base-content/70"
               >Add to collection</span
             >
-          </div>
+          </label>
 
           <select
+            id="image-upload-collection"
             v-model="selectedCollectionId"
             class="select select-bordered select-sm w-full"
             :disabled="isUploading"
@@ -335,14 +339,18 @@
 
       <!-- Model connect -->
       <div v-if="showModelConnect" class="flex flex-col gap-2">
-        <div class="flex items-center gap-1.5">
+        <label
+          class="flex items-center gap-1.5"
+          for="image-upload-model-connect"
+        >
           <icon name="kind-icon:link" class="h-4 w-4 text-accent" />
           <span class="text-xs font-bold text-base-content/70"
             >Link image owner to model</span
           >
-        </div>
+        </label>
 
         <select
+          id="image-upload-model-connect"
           v-model="connectedModelType"
           class="select select-bordered select-sm w-full"
           :disabled="isUploading"


### PR DESCRIPTION
### Task
conductor: ai-art-academy/t-010 continuous-improvement cycle, lane 1 (front-end polish)

### What changed
`components/art/image-upload.vue`'s two `<select>` controls in the Style Lab upload panel — "Add to collection" (`v-model="selectedCollectionId"`) and "Link image owner to model" (`v-model="connectedModelType"`) — had only a visually-styled `<div>`/`<span>` header with no `label[for]`/`id` pairing or `aria-label`. A screen reader announces both as unnamed comboboxes with no indication of what they control (WCAG 4.1.2). Every other field in this form (Designer, Genres, Prompt, Steps, flag toggles) already uses proper label association; these two were the outliers — exactly the pattern this repo's own `CLAUDE.md` calls out as mandatory ("Form labels need `htmlFor`/`id` pairing... the visual styling alone doesn't establish it").

Fix: converted each wrapping `<div>` header to a `<label for="...">` and added a matching `id` to each `<select>`. Pure markup change, no logic/styling/behavior touched.

### How I verified
- `npx eslint components/art/image-upload.vue` — clean
- `npx prettier --check components/art/image-upload.vue` — clean
- `npx vue-tsc --noEmit` — exit 0, no errors

### Stakes
Reversible — accessibility-only markup fix, no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfG7aQNchccQThdABeEuNK)_