### PR TITLE
model-builder: fix previewCommit showing wrong target model for CREATE items

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1137,14 +1137,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   function previewCommit(itemId: string): CommitPreview | null {
     const item = findItem(itemId)
     if (!item || !state.run) return null
+    const targetType =
+      item.action === 'ASSET_ONLY'
+        ? 'ArtImage'
+        : resolveTargetModel(item.action, item.outputKey, state.run.sourceType)
     return {
       itemId: item.id,
       action: item.action,
-      targetType: item.action === 'ASSET_ONLY' ? 'ArtImage' : state.run.sourceType,
+      targetType,
       summary:
         item.action === 'ASSET_ONLY'
           ? `Promote generated asset for ${item.label} to ${state.run.sourceLabel}.`
-          : `${item.action} ${state.run.sourceType} from ${item.label}.`,
+          : `${item.action} ${targetType} from ${item.label}.`,
       fields: item.fieldsDraft,
       artImageId: item.artImageId,
     }


### PR DESCRIPTION
### Task
conductor model-builder/t-029 (recurring polish task): read the full Model Builder surface, find and fix one real bug.

### What changed
`previewCommit()` in `stores/modelBuilderStore.ts` always labeled the commit-preview `targetType`/summary with `state.run.sourceType`. That's correct for `UPDATE` items (which always write back to the run's own source model), but wrong for every `CREATE` relationship-expansion output (`expand-characters`, `expand-rewards`, `expand-scenarios`, `expand-narrator-bot`, `expand-manager-bot`, `expand-signature-rewards`).

Concrete failure: run "Relationship Expansion" on a Dream, pick the "Narrator bot" CREATE item. The Commit stage — whose entire purpose is a human-reviewable preview before an irreversible write — showed:

```
CREATE → Dream
CREATE Dream from Narrator bot.
```

when the actual target (and what the server-side `commit.post.ts` correctly creates/links via `Dream.narratorId`) is a new `Bot` record. No data corruption occurred since the server resolves the target correctly, but the review UI was lying about what was about to be created, defeating the point of the human-gate. Every other CREATE output had the same wrong-label bug.

### Fix
`previewCommit` now calls the store's existing `resolveTargetModel(action, outputKey, sourceType)` helper — already used correctly at 3 other call sites (`startRun`, `draftText`, `itemGroups`) — instead of hardcoding `state.run.sourceType`.

### How I verified
- `npx eslint stores/modelBuilderStore.ts` — 2 pre-existing `no-empty` errors at lines 203/210, confirmed present on `main` via `git stash` (identical with/without this diff).
- Full-project `npm run test` (`vue-tsc --noEmit`) — clean, exit 0.
- Diff is a single 8-line change to one file.

### Stakes
reversible

### Notes for reviewer
Continuation of the recurring `model-builder/t-029` "polish and upgrade" task — this cycle's bug pick per its established read-everything-find-one-bug pattern.


---
_Generated by [Claude Code](https://claude.ai/code/session_015wBX3Hx6UVRnAz32VDMtNa)_