### PR TITLE
model-builder/t-034: drop relationship-expansion from Facet

### DIFF
--- a/stores/helpers/modelBuilderRecipes.ts
+++ b/stores/helpers/modelBuilderRecipes.ts
@@ -163,6 +163,10 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     blurb: 'Character deck with expressions, transitions, and an art upgrade.',
   },
   {
+    // No 'relationship-expansion' (model-builder/t-034): DreamFacet/ScenarioFacet are
+    // tag-attachment joins used to attach a Facet to *existing* Dreams/Scenarios
+    // (see server/api/{dreams,scenarios}/[id]/facets.put.ts), not a parent->child
+    // creation relation linkSourceToTarget could commit a newly-created record into.
     key: 'Facet',
     label: 'Facet',
     plural: 'Facets',
@@ -171,8 +175,8 @@ export const SOURCE_TYPES: SourceTypeConfig[] = [
     titleField: 'title',
     subtitleField: 'kind',
     defaultRecipe: 'art-upgrade',
-    recipes: ['art-upgrade', 'relationship-expansion'],
-    blurb: 'Art upgrade, or expand into fitting dreams, characters, or rewards.',
+    recipes: ['art-upgrade'],
+    blurb: 'Art upgrade only — Facets are reusable tags/attributes, not a relationship-expansion source.',
   },
   {
     key: 'Dream',
@@ -251,7 +255,7 @@ export const RECIPES: RecipeConfig[] = [
     label: 'Relationship Expansion',
     icon: 'kind-icon:link',
     summary: 'Create related records — each child is an independently gated build item.',
-    sourceTypes: ['Project', 'Character', 'Facet', 'Dream', 'Scenario', 'Reward'],
+    sourceTypes: ['Project', 'Character', 'Dream', 'Scenario', 'Reward'],
   },
 ]
 


### PR DESCRIPTION
## Summary

- Kaizen from t-033 (PR #1100): `SOURCE_TYPES['Facet'].recipes` in `stores/helpers/modelBuilderRecipes.ts` still listed `relationship-expansion` as eligible, but `commit.post.ts`'s `linkSourceToTarget` has no `sourceType === 'Facet'` case — every expand-* output was silently hidden (0 outputs shown) after t-033's per-output `sourceTypes` filter, leaving the recipe chip visibly selectable but functionally empty.
- Decided **(b)** from the conductor roadmap task: drop `relationship-expansion` from Facet's `SOURCE_TYPES.recipes` (and remove `'Facet'` from `relationship-expansion`'s own `sourceTypes` list) rather than wiring up a fake relation.
- Reasoning: Facet's only real schema relations to Dream/Scenario (`DreamFacet`, `ScenarioFacet`) are tag-attachment joins — they attach a Facet to an *existing* Dream/Scenario (see `server/api/{dreams,scenarios}/[id]/facets.put.ts`, `scenarioGenreFacetSync.ts`), the same shape used for genre/mood/theme tagging. That's structurally different from every other `linkSourceToTarget` case, which all link a newly-*created* child record back to its parent. There's no relation from Facet to Character or Reward at all. Facets keep `art-upgrade` only.
- `utils/scripts/verifyModelBuilderLinkCoverage.ts` (the t-032 coverage guard) still passes — it never flagged Facet since it only matches implicit direct-typed relation fields, not the explicit join-table pattern Facet uses.

## Test plan

- [x] `npx eslint stores/helpers/modelBuilderRecipes.ts` — clean
- [x] `npx tsx utils/scripts/verifyModelBuilderLinkCoverage.ts` — passes
- [x] `npm test` (`vue-tsc --noEmit`) — passes, no new errors

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GmdWvCiesq51U7dtN4PACJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmdWvCiesq51U7dtN4PACJ)_