### PR TITLE
model-builder/t-035: catch join-table-only relation eligibility bugs

### DIFF
--- a/utils/scripts/verifyModelBuilderLinkCoverage.ts
+++ b/utils/scripts/verifyModelBuilderLinkCoverage.ts
@@ -193,11 +193,13 @@ export function extractOutputCatalogEntries(
   for (const objMatch of match[1]!.matchAll(/\{[^{}]*\}/g)) {
     const obj = objMatch[0]
     const keyMatch = obj.match(/key:\s*'([\w-]+)'/)
+    if (!keyMatch) continue
     const actionMatch = obj.match(/action:\s*'(\w+)'/)
-    if (!keyMatch || !actionMatch) continue
+    if (!actionMatch) continue
     const sourceTypesMatch = obj.match(/sourceTypes:\s*\[([^\]]*)\]/)
-    const sourceTypes = sourceTypesMatch
-      ? [...sourceTypesMatch[1]!.matchAll(/'(\w+)'/g)].map((m) => m[1]!)
+    const sourceTypesRaw = sourceTypesMatch?.[1] ?? null
+    const sourceTypes = sourceTypesRaw
+      ? [...sourceTypesRaw.matchAll(/'(\w+)'/g)].map((m) => m[1]!)
       : null
     entries.push({ key: keyMatch[1]!, action: actionMatch[1]!, sourceTypes })
   }

--- a/utils/scripts/verifyModelBuilderLinkCoverage.ts
+++ b/utils/scripts/verifyModelBuilderLinkCoverage.ts
@@ -26,6 +26,10 @@ const COMMIT_ROUTE_PATH = join(
   repositoryRoot,
   'server/api/model-builder/items/[id]/commit.post.ts',
 )
+const MODEL_BUILDER_RECIPES_PATH = join(
+  repositoryRoot,
+  'stores/helpers/modelBuilderRecipes.ts',
+)
 
 export interface LinkPair {
   sourceType: string
@@ -142,14 +146,165 @@ export function findMissingLinkPairs(
   return expected.filter((pair) => !covered.has(pairKey(pair)))
 }
 
+// key -> target model, same object findMissingLinkPairs reads via
+// extractCreateTargetTypes, but keeping the key so a claimed-eligible pair can
+// be traced back to the OUTPUT_CATALOG entry that made the claim.
+export function extractCreateTargetMap(
+  fieldsFileContent: string,
+): Record<string, string> {
+  const match = fieldsFileContent.match(
+    /CREATE_TARGETS:\s*Record<string,\s*SourceTypeKey>\s*=\s*\{([\s\S]*?)\n\}/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find CREATE_TARGETS object literal in modelBuilderFields.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+  const map: Record<string, string> = {}
+  for (const m of match[1]!.matchAll(/'([\w-]+)':\s*'(\w+)'/g)) {
+    map[m[1]!] = m[2]!
+  }
+  return map
+}
+
+interface OutputCatalogEntry {
+  key: string
+  action: string
+  sourceTypes: string[] | null
+}
+
+// Every entry object literal in OUTPUT_CATALOG (modelBuilderRecipes.ts),
+// independent of field order within the object -- 'action' and 'sourceTypes'
+// are read separately rather than assumed adjacent.
+export function extractOutputCatalogEntries(
+  recipesFileContent: string,
+): OutputCatalogEntry[] {
+  const match = recipesFileContent.match(
+    /OUTPUT_CATALOG:\s*BuildOutputConfig\[\]\s*=\s*\[([\s\S]*?)\n\]/,
+  )
+  if (!match) {
+    throw new Error(
+      'Could not find OUTPUT_CATALOG array literal in modelBuilderRecipes.ts ' +
+        '-- has its shape changed?',
+    )
+  }
+  const entries: OutputCatalogEntry[] = []
+  for (const objMatch of match[1]!.matchAll(/\{[^{}]*\}/g)) {
+    const obj = objMatch[0]
+    const keyMatch = obj.match(/key:\s*'([\w-]+)'/)
+    const actionMatch = obj.match(/action:\s*'(\w+)'/)
+    if (!keyMatch || !actionMatch) continue
+    const sourceTypesMatch = obj.match(/sourceTypes:\s*\[([^\]]*)\]/)
+    const sourceTypes = sourceTypesMatch
+      ? [...sourceTypesMatch[1]!.matchAll(/'(\w+)'/g)].map((m) => m[1]!)
+      : null
+    entries.push({ key: keyMatch[1]!, action: actionMatch[1]!, sourceTypes })
+  }
+  return entries
+}
+
+// True if some OTHER model in the schema is a genuine explicit join table
+// connecting modelA and modelB -- e.g. DreamFacet connecting Dream and Facet
+// via two singular FKs under a composite primary key -- rather than either
+// model holding a direct field pointing at the other. This is a
+// tag-attachment/many-to-many join, not a parent->child creation link
+// linkSourceToTarget can commit through. Returns the join model's name, or
+// null if no such model exists.
+//
+// Deliberately requires the `@@id([...])` composite-key shape every real
+// join table in this schema uses (DreamFacet, ScenarioFacet, FacetArtImage,
+// FacetArtCollection, ProjectArtImage, ProjectArtCollection) -- a looser
+// "any model with fields of both types" check false-positives on broad hub
+// models like ArtImage, which holds list-type back-references
+// (`Characters Character[]`, `FacetsPrimary Facet[]`) to dozens of unrelated
+// models without being a join table for any pair of them.
+export function schemaHasJoinTableRelation(
+  schema: string,
+  modelA: string,
+  modelB: string,
+): string | null {
+  const singularFieldPattern = (target: string) =>
+    new RegExp(`^\\s*\\w+\\s+${target}(\\?)?\\s`, 'm')
+  const compositeIdPattern = /@@id\(\[\w+,\s*\w+\]\)/
+  for (const m of schema.matchAll(/^model\s+(\w+)\s*\{/gm)) {
+    const joinModelName = m[1]!
+    if (joinModelName === modelA || joinModelName === modelB) continue
+    const block = findModelBlock(schema, joinModelName)
+    if (!block) continue
+    if (!compositeIdPattern.test(block)) continue
+    if (
+      singularFieldPattern(modelA).test(block) &&
+      singularFieldPattern(modelB).test(block)
+    ) {
+      return joinModelName
+    }
+  }
+  return null
+}
+
+export interface JoinTableOnlyPair extends LinkPair {
+  key: string
+  joinModel: string
+}
+
+// Every (sourceType, targetType) pair that an OUTPUT_CATALOG CREATE output
+// restricts to specific sourceTypes (model-builder/t-033's eligibility gate)
+// where the schema has NO direct relation between the two models but DOES
+// have a join-table-only relation -- the exact config bug t-032/t-033/t-034
+// took three cycles to find manually (Facet listed as eligible to
+// CREATE-link Dream/Scenario when DreamFacet/ScenarioFacet are tag-attachment
+// joins, not a creation link). Distinct from findMissingLinkPairs, which only
+// checks pairs the schema itself says ARE directly linkable.
+export function findJoinTableOnlyEligibilityPairs(
+  schema: string,
+  fieldsFileContent: string,
+  recipesFileContent: string,
+): JoinTableOnlyPair[] {
+  const targetMap = extractCreateTargetMap(fieldsFileContent)
+  const outputs = extractOutputCatalogEntries(recipesFileContent)
+  const found: JoinTableOnlyPair[] = []
+  const seen = new Set<string>()
+
+  for (const output of outputs) {
+    if (output.action !== 'CREATE' || !output.sourceTypes) continue
+    const targetType = targetMap[output.key]
+    if (!targetType) continue
+
+    for (const sourceType of output.sourceTypes) {
+      if (sourceType === targetType) continue
+      const dedupeKey = `${output.key}:${pairKey({ sourceType, targetType })}`
+      if (seen.has(dedupeKey)) continue
+      if (schemaHasRelation(schema, sourceType, targetType)) continue
+
+      const joinModel = schemaHasJoinTableRelation(schema, sourceType, targetType)
+      if (joinModel) {
+        seen.add(dedupeKey)
+        found.push({ sourceType, targetType, key: output.key, joinModel })
+      }
+    }
+  }
+
+  return found
+}
+
 function main(): void {
   const schema = readFileSync(SCHEMA_PATH, 'utf8')
   const fieldsFileContent = readFileSync(MODEL_BUILDER_FIELDS_PATH, 'utf8')
   const commitRouteContent = readFileSync(COMMIT_ROUTE_PATH, 'utf8')
+  const recipesFileContent = readFileSync(MODEL_BUILDER_RECIPES_PATH, 'utf8')
 
   const missing = findMissingLinkPairs(schema, fieldsFileContent, commitRouteContent)
+  const joinTableOnly = findJoinTableOnlyEligibilityPairs(
+    schema,
+    fieldsFileContent,
+    recipesFileContent,
+  )
+
+  let failed = false
 
   if (missing.length) {
+    failed = true
     console.error(
       `Model Builder link-coverage contract failed: ${missing.length} ` +
         '(sourceType, targetType) pair(s) have a real Prisma relation but no ' +
@@ -165,6 +320,29 @@ function main(): void {
           `'${pair.sourceType}' && targetType === '${pair.targetType}')\` case.`,
       )
     }
+  }
+
+  if (joinTableOnly.length) {
+    failed = true
+    console.error(
+      `Model Builder link-coverage contract failed: ${joinTableOnly.length} ` +
+        'OUTPUT_CATALOG sourceTypes entry(s) claim CREATE-link eligibility ' +
+        'for a pair only connected by a join table (modelBuilderRecipes.ts):',
+    )
+    for (const pair of joinTableOnly) {
+      console.error(
+        `- '${pair.key}' lists ${pair.sourceType} as an eligible source, but ` +
+          `${pair.sourceType} and ${pair.targetType} have no direct Prisma ` +
+          `relation -- only ${pair.joinModel}, a tag-attachment join table. ` +
+          `A CREATE commit from a ${pair.sourceType} source using '${pair.key}' ` +
+          `has no real parent->child link to its new ${pair.targetType}. Remove ` +
+          `${pair.sourceType} from '${pair.key}'\`s sourceTypes (see ` +
+          'model-builder/t-034 for the same fix applied to Facet).',
+      )
+    }
+  }
+
+  if (failed) {
     process.exitCode = 1
     return
   }
@@ -172,7 +350,8 @@ function main(): void {
   console.log(
     'Model Builder link-coverage contract passed: every CREATE_TARGETS ' +
       'output type with a real schema relation to a possible source type is ' +
-      'handled by linkSourceToTarget.',
+      'handled by linkSourceToTarget, and no OUTPUT_CATALOG sourceTypes ' +
+      'entry claims eligibility for a join-table-only pair.',
   )
 }
 


### PR DESCRIPTION
### Task
model-builder/t-035: verifyModelBuilderLinkCoverage.ts doesn't catch join-table-only relations, letting non-functional recipe entries ship silently (kind: software)

### What changed / what I produced
- `utils/scripts/verifyModelBuilderLinkCoverage.ts`:
  - `extractCreateTargetMap` — key -> target model mapping from `CREATE_TARGETS` (keeps the key, unlike the existing `extractCreateTargetTypes`).
  - `extractOutputCatalogEntries` — parses each `OUTPUT_CATALOG` entry's `key`/`action`/`sourceTypes`, field-order-independent.
  - `schemaHasJoinTableRelation` — detects a genuine explicit join table connecting two models (requires the `@@id([...])` composite-key shape every real join table in this schema uses — `DreamFacet`, `ScenarioFacet`, `FacetArtImage`, `FacetArtCollection`, `ProjectArtImage`, `ProjectArtCollection` — to avoid false-positiving on broad hub models like `ArtImage` that hold list-type back-references to dozens of unrelated models).
  - `findJoinTableOnlyEligibilityPairs` — cross-references each CREATE output's `sourceTypes` restriction against the schema; flags a pair with no direct relation but a join-table-only relation.
  - `main()` now reports both categories of failure (existing missing-link-case check, plus the new join-table-only-eligibility check).

### How I verified
- `npx tsx utils/scripts/verifyModelBuilderLinkCoverage.ts` passes cleanly on current config (no regressions).
- Simulated the exact t-032/t-033/t-034 bug class by temporarily re-adding `'Facet'` to `expand-scenarios`'s `sourceTypes` (Facet -> Scenario is join-table-only via `ScenarioFacet`) — the guard now correctly fails with a clear message naming the join model. Reverted before committing.
- Also tried a non-join pair (Facet -> Character, no relation of any kind) to confirm the new check doesn't misfire — confirmed the tightened `schemaHasJoinTableRelation` (composite-key requirement) avoids the false positive an earlier looser version of this check produced against the `ArtImage` hub model.
- `npm run test` (full `vue-tsc --noEmit`) — clean, no errors.
- `npx eslint utils/scripts/verifyModelBuilderLinkCoverage.ts` — clean.

### Stakes
reversible

### Flags for Reviewer
- None — front-end/test-only change, no schema change, matches the task note's expected scope exactly.

### Kaizen suggestion
None beyond this task — it directly closes the gap its own note describes.

### Notes for reviewer
Conductor roadmap task `model-builder/t-035` tracks this; will flip to `done` after this PR merges green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc9Uh8Mmefz7R3QDFCVWDu)_