### PR TITLE
coloring: finish cover and print-package production dashboard

### DIFF
--- a/.github/workflows/coloring-book-readiness-contract.yml
+++ b/.github/workflows/coloring-book-readiness-contract.yml
@@ -1,20 +1,36 @@
-name: Coloring Book Readiness Contract
+name: Coloring Book Production Contract
 
 on:
   pull_request:
     paths:
       - "components/coloring/coloring-book-readiness.vue"
+      - "components/coloring/coloring-book-package-readiness.vue"
+      - "components/coloring/coloring-book-cover-studio.vue"
       - "components/coloring/coloring-book-page.vue"
+      - "server/api/conductor/coloring-books/package.get.ts"
+      - "server/utils/coloringBookPackage.ts"
+      - "stores/coloringBookStudioStore.ts"
+      - "types/coloringBookPackage.ts"
       - "utils/coloringBookReadiness.ts"
+      - "utils/coloringBookPackage.ts"
       - "utils/scripts/verifyColoringBookReadiness.ts"
+      - "utils/scripts/verifyColoringBookPackage.ts"
       - ".github/workflows/coloring-book-readiness-contract.yml"
   push:
     branches: [main]
     paths:
       - "components/coloring/coloring-book-readiness.vue"
+      - "components/coloring/coloring-book-package-readiness.vue"
+      - "components/coloring/coloring-book-cover-studio.vue"
       - "components/coloring/coloring-book-page.vue"
+      - "server/api/conductor/coloring-books/package.get.ts"
+      - "server/utils/coloringBookPackage.ts"
+      - "stores/coloringBookStudioStore.ts"
+      - "types/coloringBookPackage.ts"
       - "utils/coloringBookReadiness.ts"
+      - "utils/coloringBookPackage.ts"
       - "utils/scripts/verifyColoringBookReadiness.ts"
+      - "utils/scripts/verifyColoringBookPackage.ts"
       - ".github/workflows/coloring-book-readiness-contract.yml"
 
 jobs:
@@ -33,5 +49,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify readiness state machine
+      - name: Verify interior and cover readiness
         run: npx tsx utils/scripts/verifyColoringBookReadiness.ts
+
+      - name: Verify print-package readiness
+        run: npx tsx utils/scripts/verifyColoringBookPackage.ts

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -1,0 +1,300 @@
+<template>
+  <section
+    v-if="packageData"
+    id="coloring-package-readiness"
+    class="flex flex-col gap-5 rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm"
+  >
+    <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="badge badge-primary rounded-2xl">Print package</span>
+          <span
+            v-if="!packageData.generated"
+            class="badge badge-warning badge-outline rounded-2xl"
+          >
+            Initial canonical refresh pending
+          </span>
+        </div>
+        <h3 class="mt-2 text-2xl font-black">Publishing readiness</h3>
+        <p class="mt-1 max-w-3xl text-sm text-base-content/55">
+          Source art, physical layout decisions, and export files are tracked as separate
+          gates. A finished illustration is not secretly a paperback wearing sunglasses.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <span class="badge badge-outline rounded-2xl">
+          {{ sourceReadyCount }}/{{ packageData.books.length }} source-ready
+        </span>
+        <span
+          class="badge rounded-2xl"
+          :class="packageData.allPackageReady ? 'badge-success' : 'badge-warning'"
+        >
+          {{ packageData.allPackageReady ? 'All packages ready' : 'Packaging in progress' }}
+        </span>
+      </div>
+    </header>
+
+    <div class="grid gap-3 lg:grid-cols-3">
+      <button
+        v-for="book in packageData.books"
+        :key="book.slug"
+        type="button"
+        class="rounded-3xl border p-4 text-left transition hover:-translate-y-0.5 hover:shadow-md"
+        :class="
+          studio.selectedBookSlug === book.slug
+            ? 'border-primary bg-primary/10'
+            : 'border-base-300 bg-base-100'
+        "
+        @click="studio.selectBook(book.slug)"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              Book {{ book.order }}
+            </p>
+            <h4 class="text-xl font-black">{{ book.title }}</h4>
+          </div>
+          <span class="badge rounded-2xl" :class="packageStatusTone(book.status)">
+            {{ statusLabel(book.status) }}
+          </span>
+        </div>
+
+        <progress
+          class="progress progress-primary my-3 w-full"
+          :value="book.finalPairCount"
+          :max="book.expectedInteriorCount || 1"
+        />
+
+        <div class="grid grid-cols-3 gap-2 text-center text-xs">
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black">
+              {{ book.finalPairCount }}/{{ book.expectedInteriorCount }}
+            </p>
+            <p class="text-base-content/45">Final pairs</p>
+          </div>
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black" :class="book.coverStatus === 'final' ? 'text-success' : ''">
+              {{ book.coverStatus }}
+            </p>
+            <p class="text-base-content/45">Cover</p>
+          </div>
+          <div class="rounded-2xl bg-base-200 p-2">
+            <p class="font-black">
+              {{ book.missingLayoutFields.length + book.missingExportFields.length }}
+            </p>
+            <p class="text-base-content/45">Package gaps</p>
+          </div>
+        </div>
+
+        <p class="mt-3 text-xs leading-relaxed text-base-content/55">
+          {{ book.nextAction }}
+        </p>
+      </button>
+    </div>
+
+    <div v-if="selectedPackage" class="flex flex-col gap-4">
+      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <article
+          v-for="stage in stages"
+          :key="stage.label"
+          class="rounded-2xl border border-base-300 bg-base-200/40 p-4"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <icon :name="stage.icon" class="size-6" :class="stage.ready ? 'text-success' : 'text-warning'" />
+            <span class="badge badge-sm rounded-2xl" :class="stage.ready ? 'badge-success' : 'badge-warning'">
+              {{ stage.ready ? 'Ready' : 'Pending' }}
+            </span>
+          </div>
+          <h4 class="mt-3 font-black">{{ stage.label }}</h4>
+          <p class="mt-1 text-xs leading-relaxed text-base-content/50">
+            {{ stage.detail }}
+          </p>
+        </article>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-2">
+        <article class="rounded-3xl border border-base-300 bg-base-100 p-4">
+          <h4 class="text-lg font-black">Source-production blockers</h4>
+          <p class="mt-1 text-xs text-base-content/50">
+            {{ selectedPackage.finalPairCount }}/{{ selectedPackage.expectedInteriorCount }} final pairs ·
+            cover {{ selectedPackage.coverStatus }}
+          </p>
+
+          <div v-if="sourceBlockers.length" class="mt-3 flex flex-col gap-3">
+            <div
+              v-for="blocker in sourceBlockers"
+              :key="blocker.label"
+              class="rounded-2xl bg-base-200/60 p-3"
+            >
+              <div class="flex items-center justify-between gap-2">
+                <span class="text-sm font-black">{{ blocker.label }}</span>
+                <span class="badge badge-error badge-sm rounded-2xl">
+                  {{ blocker.values.length }}
+                </span>
+              </div>
+              <p class="mt-1 break-words text-xs text-base-content/50">
+                {{ summarizeValues(blocker.values) }}
+              </p>
+            </div>
+          </div>
+          <div v-else class="alert alert-success mt-3 rounded-2xl">
+            <icon name="kind-icon:check" class="size-5" />
+            <span>All canonical source assets are complete and verified.</span>
+          </div>
+        </article>
+
+        <article class="rounded-3xl border border-base-300 bg-base-100 p-4">
+          <h4 class="text-lg font-black">Layout and export blockers</h4>
+          <p class="mt-1 text-xs text-base-content/50">
+            These fields stay unresolved until a printer, trim, binding, and template are chosen.
+          </p>
+
+          <div class="mt-4">
+            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              Missing layout decisions
+            </p>
+            <div class="mt-2 flex flex-wrap gap-2">
+              <span
+                v-for="field in selectedPackage.missingLayoutFields"
+                :key="field"
+                class="badge badge-warning badge-outline rounded-2xl"
+              >
+                {{ fieldLabel(field) }}
+              </span>
+              <span
+                v-if="!selectedPackage.missingLayoutFields.length"
+                class="badge badge-success rounded-2xl"
+              >
+                Layout configured
+              </span>
+            </div>
+          </div>
+
+          <div class="mt-4">
+            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              Missing exports
+            </p>
+            <div class="mt-2 flex flex-wrap gap-2">
+              <span
+                v-for="field in selectedPackage.missingExportFields"
+                :key="field"
+                class="badge badge-info badge-outline rounded-2xl"
+              >
+                {{ fieldLabel(field) }}
+              </span>
+              <span
+                v-if="!selectedPackage.missingExportFields.length"
+                class="badge badge-success rounded-2xl"
+              >
+                Export files verified
+              </span>
+            </div>
+          </div>
+
+          <p
+            v-if="selectedPackage.orderedInteriorManifest"
+            class="mt-4 break-all text-xs text-base-content/45"
+          >
+            Ordered manifest: {{ selectedPackage.orderedInteriorManifest }}
+          </p>
+        </article>
+      </div>
+
+      <div class="alert alert-info rounded-2xl">
+        <icon name="kind-icon:info" class="size-5" />
+        <span>
+          Canonical source art is {{ packageData.requirements.sourcePixelSize }} at
+          {{ packageData.requirements.sourceAspectRatio }}. It will not be cropped into a
+          printer template until the physical format is explicitly chosen.
+        </span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ColoringBookPackageStatus } from '~/types/coloringBookPackage'
+import {
+  packageStatusTone,
+} from '@/utils/coloringBookPackage'
+import { useColoringBookStudioStore } from '@/stores/coloringBookStudioStore'
+
+const studio = useColoringBookStudioStore()
+const packageData = computed(() => studio.packageData)
+const selectedPackage = computed(() => studio.selectedPackage)
+const sourceReadyCount = computed(
+  () => packageData.value?.books.filter((book) => book.sourceReady).length ?? 0,
+)
+
+const stages = computed(() => {
+  const book = selectedPackage.value
+  if (!book) return []
+  return [
+    {
+      label: 'Source assets',
+      ready: book.sourceReady,
+      detail: `${book.finalPairCount}/${book.expectedInteriorCount} final interior pairs; cover ${book.coverStatus}.`,
+      icon: 'kind-icon:gallery',
+    },
+    {
+      label: 'Print layout',
+      ready: book.layoutReady,
+      detail: book.layoutReady
+        ? 'Trim, bleed, binding, paper, color, and printer template are configured.'
+        : `${book.missingLayoutFields.length} physical-layout decisions remain.`,
+      icon: 'kind-icon:ruler',
+    },
+    {
+      label: 'Package exports',
+      ready: book.exportsReady,
+      detail: book.exportsReady
+        ? 'Interior PDF, cover-wrap PDF, and source archive exist.'
+        : `${book.missingExportFields.length} export files remain.`,
+      icon: 'kind-icon:download',
+    },
+    {
+      label: 'Publish package',
+      ready: book.packageReady,
+      detail: book.packageReady
+        ? 'Validated files are ready for the publishing hand-off.'
+        : book.nextAction,
+      icon: 'kind-icon:book',
+    },
+  ]
+})
+
+const sourceBlockers = computed(() => {
+  const issues = selectedPackage.value?.sourceIssues
+  if (!issues) return []
+  const blockers = [
+    { label: 'Missing slots', values: issues.missingSlots.map(String) },
+    { label: 'Duplicate slots', values: issues.duplicateSlots.map(String) },
+    { label: 'Missing prompts', values: issues.missingPrompts },
+    { label: 'Missing final color', values: issues.missingFinalColor },
+    { label: 'Missing final B&W', values: issues.missingFinalBw },
+    { label: 'Missing color files', values: issues.missingColorFiles },
+    { label: 'Missing B&W files', values: issues.missingBwFiles },
+    ...(issues.coverNotFinal ? [{ label: 'Cover source', values: ['not final'] }] : []),
+  ]
+  return blockers.filter((blocker) => blocker.values.length)
+})
+
+function statusLabel(status: ColoringBookPackageStatus): string {
+  if (status === 'package-ready') return 'Package ready'
+  if (status === 'exports-needed') return 'Exports needed'
+  if (status === 'layout-needed') return 'Layout needed'
+  return 'Source production'
+}
+
+function fieldLabel(field: string): string {
+  return field
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function summarizeValues(values: string[]): string {
+  if (values.length <= 8) return values.join(', ')
+  return `${values.slice(0, 8).join(', ')} +${values.length - 8} more`
+}
+</script>

--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -8,6 +8,8 @@
     <template #interactive>
       <div class="flex flex-col gap-5">
         <coloring-book-readiness />
+        <coloring-book-package-readiness />
+        <coloring-book-cover-studio />
         <div id="coloring-production-actions">
           <coloring-book-production-toolbar />
         </div>
@@ -27,20 +29,20 @@ const config: ProjectFrontConfig = {
   channelKey: 'art',
   tabKey: 'coloring',
   icon: 'kind-icon:paintbrush',
-  tagline: 'Build, review, pair, and color three living books.',
+  tagline: 'Build, review, pair, package, and color three living books.',
   description:
-    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Track the exact next action for all 108 interiors, review each 36-page ledger, edit canonical Conductor prompts, compare current and historical color and black-and-white versions, request targeted candidates or revisions, adopt legacy set assets, accept working masters, confirm final pairs, diagnose queue failures, and preview finished pages in the shared coloring engine.',
+    'A ledger-backed production studio for Monster Recast, Hollywood Recast, and Kind Robots. Track the exact next action for all 108 interiors and three covers, edit canonical Conductor prompts, compare current and historical color and black-and-white versions, request targeted candidates or revisions, adopt legacy set assets, accept working masters, confirm final pairs, inspect source and print-package readiness, diagnose queue failures, and preview finished pages in the shared coloring engine.',
   sections: [
     {
       key: 'production',
       title: 'One canonical production view',
-      body: 'The front end reads and updates the same proposal ledgers and production queue used by Conductor instead of maintaining unrelated prompt cards and gallery generations.',
+      body: 'The front end reads and updates the same proposal ledgers, cover queue, and package manifests used by Conductor instead of maintaining unrelated prompt cards and gallery generations.',
       icon: 'kind-icon:book',
     },
     {
       key: 'review',
       title: 'Know the next action',
-      body: 'Every interior is classified as blocked, needing generation, waiting for human acceptance, ready to finalize, or final. Open any row directly into its production controls.',
+      body: 'Every interior, cover, and publishing package is classified by its next required human or pipeline action, with source production kept separate from printer layout and export work.',
       icon: 'kind-icon:check',
     },
   ],
@@ -53,10 +55,12 @@ const config: ProjectFrontConfig = {
       'Legacy set-asset adoption without fabricated provenance',
       'Archived revision and rejection history browser',
       'Whole-book interior readiness dashboard',
+      'Canonical three-book cover source production',
+      'Vendor-neutral print-package readiness and ordered interior manifests',
     ],
     next: [
-      'Canonical cover production management',
-      'Print package validation and export',
+      'Choose printer, trim, binding, paper, bleed, and cover template',
+      'Generate interior PDFs, cover-wrap PDFs, and source archives',
       'Storefront hand-off',
     ],
   },

--- a/server/api/conductor/coloring-books/package.get.ts
+++ b/server/api/conductor/coloring-books/package.get.ts
@@ -1,0 +1,43 @@
+import { defineEventHandler } from 'h3'
+import { errorHandler } from '@/server/utils/error'
+import { conductorGet } from '@/server/utils/conductor-github'
+import {
+  COLORING_BOOK_PRINT_PACKAGE_PATH,
+  COLORING_BOOK_PRINT_READINESS_PATH,
+  parseColoringBookPackageData,
+} from '@/server/utils/coloringBookPackage'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const [packageFile, readinessFile] = await Promise.all([
+      conductorGet(COLORING_BOOK_PRINT_PACKAGE_PATH),
+      conductorGet(COLORING_BOOK_PRINT_READINESS_PATH),
+    ])
+    if (!packageFile) {
+      throw new Error('Canonical coloring-book print package manifest was not found.')
+    }
+
+    const data = parseColoringBookPackageData(
+      readinessFile?.content ?? null,
+      packageFile.content,
+    )
+
+    return {
+      success: true,
+      message: readinessFile
+        ? `${data.books.length} print-package records loaded from Conductor.`
+        : 'Print-package configuration loaded; generated readiness is awaiting refresh.',
+      data,
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to load coloring-book package readiness.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/coloringBookPackage.ts
+++ b/server/utils/coloringBookPackage.ts
@@ -1,0 +1,266 @@
+import type {
+  ColoringBookPackageBook,
+  ColoringBookPackageData,
+  ColoringBookPackageRequirements,
+  ColoringBookPackageStatus,
+  ColoringBookSourceIssues,
+} from '~/types/coloringBookPackage'
+
+export const COLORING_BOOK_PRINT_PACKAGE_PATH =
+  'projects/coloring-book/print-package.yaml'
+export const COLORING_BOOK_PRINT_READINESS_PATH =
+  'projects/coloring-book/print-readiness.yaml'
+
+const LAYOUT_FIELDS = [
+  'trim_width_inches',
+  'trim_height_inches',
+  'bleed_inches',
+  'binding',
+  'paper',
+  'interior_color_mode',
+  'cover_color_mode',
+  'printer_template',
+  'page_count_includes_blanks',
+  'inside_cover_printing',
+  'barcode_area_reserved',
+] as const
+
+const EXPORT_FIELDS = ['interior_pdf', 'cover_wrap_pdf', 'source_archive'] as const
+
+function capture(text: string, pattern: RegExp, group = 1): string | undefined {
+  return pattern.exec(text)?.[group]
+}
+
+function yamlValue(value: string | undefined): string | null {
+  const clean = String(value ?? '').trim()
+  if (!clean || clean === 'null' || clean === '~') return null
+  if (clean.startsWith('"')) {
+    try {
+      return String(JSON.parse(clean))
+    } catch {}
+  }
+  return clean.replace(/^['"]|['"]$/g, '')
+}
+
+function scalar(block: string, key: string, spaces: number): string | null {
+  return yamlValue(
+    capture(block, new RegExp(`^\\s{${spaces}}${key}:\\s*(.*?)\\s*$`, 'm')),
+  )
+}
+
+function yamlNumber(value: string | null, fallback = 0): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function yamlBoolean(value: string | null): boolean {
+  return value === 'true' || value === 'yes' || value === '1'
+}
+
+function listValues(block: string, key: string, spaces: number): string[] {
+  const inline = scalar(block, key, spaces)
+  if (inline === '[]') return []
+  if (inline?.startsWith('[') && inline.endsWith(']')) {
+    return inline
+      .slice(1, -1)
+      .split(',')
+      .map((value) => yamlValue(value) ?? '')
+      .filter(Boolean)
+  }
+  const section = capture(
+    block,
+    new RegExp(
+      `^\\s{${spaces}}${key}:\\s*$([\\s\\S]*?)(?=^\\s{0,${spaces}}[a-z_]+:|$(?![\\s\\S]))`,
+      'm',
+    ),
+  )
+  if (!section) return []
+  return [...section.matchAll(/^\s*-\s*(.*?)\s*$/gm)]
+    .map((match) => yamlValue(match?.[1]) ?? '')
+    .filter(Boolean)
+}
+
+function numberList(block: string, key: string, spaces: number): number[] {
+  return listValues(block, key, spaces)
+    .map((value) => Number(value))
+    .filter(Number.isFinite)
+}
+
+function nestedSection(block: string, key: string, spaces: number): string {
+  return (
+    capture(
+      block,
+      new RegExp(
+        `^\\s{${spaces}}${key}:\\s*$([\\s\\S]*?)(?=^\\s{0,${spaces}}[a-z_]+:|$(?![\\s\\S]))`,
+        'm',
+      ),
+    ) ?? ''
+  )
+}
+
+function requirementData(content: string): ColoringBookPackageRequirements {
+  const block = nestedSection(content, 'requirements', 0)
+  return {
+    interiorSlots: yamlNumber(scalar(block, 'interior_slots', 2), 36),
+    sourceOrientation: scalar(block, 'source_orientation', 2) ?? 'portrait',
+    sourceAspectRatio: scalar(block, 'source_aspect_ratio', 2) ?? '2:3',
+    sourcePixelSize: scalar(block, 'source_pixel_size', 2) ?? '1024x1536',
+    printInteriorVariant: scalar(block, 'print_interior_variant', 2) ?? 'bw',
+    archiveColorMasters: yamlBoolean(scalar(block, 'archive_color_masters', 2)),
+    finalCoverSourceRequired: yamlBoolean(
+      scalar(block, 'final_cover_source_required', 2),
+    ),
+    sourceReadyDefinition:
+      scalar(block, 'source_ready_definition', 2) ??
+      'All final interior pairs and the final cover source exist.',
+    packageReadyDefinition:
+      scalar(block, 'package_ready_definition', 2) ??
+      'Source assets, print layout, and export files are complete.',
+  }
+}
+
+function emptySourceIssues(): ColoringBookSourceIssues {
+  return {
+    missingSlots: [],
+    extraSlots: [],
+    duplicateSlots: [],
+    missingPrompts: [],
+    missingFinalColor: [],
+    missingFinalBw: [],
+    missingColorFiles: [],
+    missingBwFiles: [],
+    coverNotFinal: true,
+    coverFinalPath: null,
+    coverFinalExists: false,
+  }
+}
+
+function statusValue(value: string | null): ColoringBookPackageStatus {
+  if (
+    value === 'layout-needed' ||
+    value === 'exports-needed' ||
+    value === 'package-ready'
+  ) {
+    return value
+  }
+  return 'source-production'
+}
+
+function readinessBook(block: string): ColoringBookPackageBook {
+  const sourceBlock = nestedSection(block, 'source_issues', 2)
+  const exportBlock = nestedSection(block, 'export_exists', 2)
+  return {
+    order: yamlNumber(scalar(block, 'order', 0), 999),
+    slug: scalar(block, 'slug', 2) ?? '',
+    title: scalar(block, 'title', 2) ?? '',
+    status: statusValue(scalar(block, 'status', 2)),
+    nextAction: scalar(block, 'next_action', 2) ?? '',
+    sourceReady: yamlBoolean(scalar(block, 'source_ready', 2)),
+    layoutReady: yamlBoolean(scalar(block, 'layout_ready', 2)),
+    exportsReady: yamlBoolean(scalar(block, 'exports_ready', 2)),
+    packageReady: yamlBoolean(scalar(block, 'package_ready', 2)),
+    interiorCount: yamlNumber(scalar(block, 'interior_count', 2)),
+    expectedInteriorCount: yamlNumber(
+      scalar(block, 'expected_interior_count', 2),
+      36,
+    ),
+    finalPairCount: yamlNumber(scalar(block, 'final_pair_count', 2)),
+    coverStatus: scalar(block, 'cover_status', 2) ?? 'missing',
+    sourceIssues: {
+      missingSlots: numberList(sourceBlock, 'missing_slots', 4),
+      extraSlots: numberList(sourceBlock, 'extra_slots', 4),
+      duplicateSlots: numberList(sourceBlock, 'duplicate_slots', 4),
+      missingPrompts: listValues(sourceBlock, 'missing_prompts', 4),
+      missingFinalColor: listValues(sourceBlock, 'missing_final_color', 4),
+      missingFinalBw: listValues(sourceBlock, 'missing_final_bw', 4),
+      missingColorFiles: listValues(sourceBlock, 'missing_color_files', 4),
+      missingBwFiles: listValues(sourceBlock, 'missing_bw_files', 4),
+      coverNotFinal: yamlBoolean(scalar(sourceBlock, 'cover_not_final', 4)),
+      coverFinalPath: scalar(sourceBlock, 'cover_final_path', 4),
+      coverFinalExists: yamlBoolean(
+        scalar(sourceBlock, 'cover_final_exists', 4),
+      ),
+    },
+    missingLayoutFields: listValues(block, 'missing_layout_fields', 2),
+    missingExportFields: listValues(block, 'missing_export_fields', 2),
+    exportExists: Object.fromEntries(
+      EXPORT_FIELDS.map((field) => [
+        field,
+        yamlBoolean(scalar(exportBlock, field, 4)),
+      ]),
+    ),
+    orderedInteriorManifest: scalar(block, 'ordered_interior_manifest', 2),
+  }
+}
+
+function packageBook(block: string, expectedInteriors: number): ColoringBookPackageBook {
+  const layoutBlock = nestedSection(block, 'layout', 2)
+  const exportsBlock = nestedSection(block, 'exports', 2)
+  const missingLayoutFields = LAYOUT_FIELDS.filter(
+    (field) => scalar(layoutBlock, field, 4) === null,
+  )
+  const missingExportFields = EXPORT_FIELDS.filter(
+    (field) => scalar(exportsBlock, field, 4) === null,
+  )
+  return {
+    order: yamlNumber(scalar(block, 'order', 0), 999),
+    slug: scalar(block, 'slug', 2) ?? '',
+    title: scalar(block, 'title', 2) ?? '',
+    status: 'source-production',
+    nextAction: 'Finish and finalize missing interior pairs and cover source art.',
+    sourceReady: false,
+    layoutReady: missingLayoutFields.length === 0,
+    exportsReady: missingExportFields.length === 0,
+    packageReady: false,
+    interiorCount: expectedInteriors,
+    expectedInteriorCount: expectedInteriors,
+    finalPairCount: 0,
+    coverStatus: 'missing',
+    sourceIssues: emptySourceIssues(),
+    missingLayoutFields: [...missingLayoutFields],
+    missingExportFields: [...missingExportFields],
+    exportExists: Object.fromEntries(EXPORT_FIELDS.map((field) => [field, false])),
+    orderedInteriorManifest: scalar(
+      exportsBlock,
+      'ordered_interior_manifest',
+      4,
+    ),
+  }
+}
+
+function bookBlocks(content: string): string[] {
+  const books = content.split(/^books:\s*$/m)[1] ?? ''
+  return books
+    .split(/(?=^- order:)/m)
+    .filter((block) => block.startsWith('- order:'))
+}
+
+export function parseColoringBookPackageData(
+  readinessContent: string | null,
+  packageContent: string,
+): ColoringBookPackageData {
+  const requirements = requirementData(packageContent)
+  const generated = Boolean(readinessContent?.trim())
+  const content = generated ? String(readinessContent) : packageContent
+  const books = bookBlocks(content)
+    .map((block) =>
+      generated
+        ? readinessBook(block)
+        : packageBook(block, requirements.interiorSlots),
+    )
+    .filter((book) => book.slug)
+    .sort((left, right) => left.order - right.order)
+
+  return {
+    requirements,
+    books,
+    allSourceReady: generated
+      ? yamlBoolean(scalar(content, 'all_source_ready', 0))
+      : false,
+    allPackageReady: generated
+      ? yamlBoolean(scalar(content, 'all_package_ready', 0))
+      : false,
+    generated,
+    fetchedAt: new Date().toISOString(),
+  }
+}

--- a/stores/coloringBookStudioStore.ts
+++ b/stores/coloringBookStudioStore.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
+import type { ColoringBookPackageData } from '~/types/coloringBookPackage'
 import type {
   ColoringBookCoverPromptUpdate,
   ColoringBookCoverState,
@@ -12,6 +13,7 @@ import type {
   ColoringBookStudioOperation,
 } from '~/types/coloringBookStudio'
 import { performFetch } from '@/stores/utils'
+import { reconcileColoringBookPackageData } from '@/utils/coloringBookPackage'
 
 const COVER_OPERATIONS = new Set<ColoringBookStudioOperation>([
   'generate-cover',
@@ -25,6 +27,7 @@ export const useColoringBookStudioStore = defineStore(
     const books = ref<ColoringBookStudioBook[]>([])
     const productionStates = ref<Record<string, ColoringBookProductionState>>({})
     const coverStates = ref<Record<string, ColoringBookCoverState>>({})
+    const packageData = ref<ColoringBookPackageData | null>(null)
     const selectedBookSlug = ref('monster-recast')
     const selectedProposalId = ref('')
     const loading = ref(false)
@@ -65,6 +68,12 @@ export const useColoringBookStudioStore = defineStore(
       selectedBook.value
         ? (coverStates.value[selectedBook.value.slug] ?? null)
         : null,
+    )
+
+    const selectedPackage = computed(() =>
+      packageData.value?.books.find(
+        (book) => book.slug === selectedBookSlug.value,
+      ) ?? null,
     )
 
     const requestingRender = computed(() => requestingAction.value)
@@ -108,10 +117,13 @@ export const useColoringBookStudioStore = defineStore(
       loading.value = true
       error.value = null
       try {
-        const [studioResponse, productionResponse] = await Promise.all([
+        const [studioResponse, productionResponse, packageResponse] = await Promise.all([
           performFetch<ColoringBookStudioData>('/api/conductor/coloring-books'),
           performFetch<ColoringBookProductionData>(
             '/api/conductor/coloring-books/production',
+          ),
+          performFetch<ColoringBookPackageData>(
+            '/api/conductor/coloring-books/package',
           ),
         ])
         if (!studioResponse.success || !studioResponse.data) {
@@ -128,6 +140,15 @@ export const useColoringBookStudioStore = defineStore(
         books.value = studioResponse.data.books
         productionStates.value = productionResponse.data.states
         coverStates.value = productionResponse.data.covers ?? {}
+        packageData.value =
+          packageResponse.success && packageResponse.data
+            ? reconcileColoringBookPackageData(
+                packageResponse.data,
+                books.value,
+                coverStates.value,
+                productionStates.value,
+              )
+            : null
         fetchedAt.value = studioResponse.data.fetchedAt
         if (
           !books.value.some((book) => book.slug === selectedBookSlug.value)
@@ -292,12 +313,14 @@ export const useColoringBookStudioStore = defineStore(
       books,
       productionStates,
       coverStates,
+      packageData,
       selectedBookSlug,
       selectedProposalId,
       selectedBook,
       selectedProposal,
       selectedProductionState,
       selectedCover,
+      selectedPackage,
       queueProblems,
       loading,
       savingPrompt,

--- a/types/coloringBookPackage.ts
+++ b/types/coloringBookPackage.ts
@@ -1,0 +1,61 @@
+export type ColoringBookPackageStatus =
+  | 'source-production'
+  | 'layout-needed'
+  | 'exports-needed'
+  | 'package-ready'
+
+export type ColoringBookSourceIssues = {
+  missingSlots: number[]
+  extraSlots: number[]
+  duplicateSlots: number[]
+  missingPrompts: string[]
+  missingFinalColor: string[]
+  missingFinalBw: string[]
+  missingColorFiles: string[]
+  missingBwFiles: string[]
+  coverNotFinal: boolean
+  coverFinalPath: string | null
+  coverFinalExists: boolean
+}
+
+export type ColoringBookPackageBook = {
+  order: number
+  slug: string
+  title: string
+  status: ColoringBookPackageStatus
+  nextAction: string
+  sourceReady: boolean
+  layoutReady: boolean
+  exportsReady: boolean
+  packageReady: boolean
+  interiorCount: number
+  expectedInteriorCount: number
+  finalPairCount: number
+  coverStatus: string
+  sourceIssues: ColoringBookSourceIssues
+  missingLayoutFields: string[]
+  missingExportFields: string[]
+  exportExists: Record<string, boolean>
+  orderedInteriorManifest: string | null
+}
+
+export type ColoringBookPackageRequirements = {
+  interiorSlots: number
+  sourceOrientation: string
+  sourceAspectRatio: string
+  sourcePixelSize: string
+  printInteriorVariant: string
+  archiveColorMasters: boolean
+  finalCoverSourceRequired: boolean
+  sourceReadyDefinition: string
+  packageReadyDefinition: string
+}
+
+export type ColoringBookPackageData = {
+  requirements: ColoringBookPackageRequirements
+  books: ColoringBookPackageBook[]
+  allSourceReady: boolean
+  allPackageReady: boolean
+  generated: boolean
+  fetchedAt: string
+}

--- a/utils/coloringBookPackage.ts
+++ b/utils/coloringBookPackage.ts
@@ -1,0 +1,141 @@
+import type {
+  ColoringBookPackageBook,
+  ColoringBookPackageData,
+  ColoringBookPackageStatus,
+  ColoringBookSourceIssues,
+} from '~/types/coloringBookPackage'
+import type {
+  ColoringBookCoverState,
+  ColoringBookProductionState,
+  ColoringBookStudioBook,
+} from '~/types/coloringBookStudio'
+import { summarizeBookReadiness } from '@/utils/coloringBookReadiness'
+
+function statusFor(
+  sourceReady: boolean,
+  layoutReady: boolean,
+  exportsReady: boolean,
+): ColoringBookPackageStatus {
+  if (sourceReady && layoutReady && exportsReady) return 'package-ready'
+  if (sourceReady && layoutReady) return 'exports-needed'
+  if (sourceReady) return 'layout-needed'
+  return 'source-production'
+}
+
+function nextActionFor(status: ColoringBookPackageStatus): string {
+  if (status === 'package-ready') {
+    return 'Review and publish the validated print package.'
+  }
+  if (status === 'exports-needed') {
+    return 'Generate the ordered interior PDF, cover-wrap PDF, and source archive.'
+  }
+  if (status === 'layout-needed') {
+    return 'Choose the printer and complete trim, bleed, binding, color, and template fields.'
+  }
+  return 'Finish and finalize missing interior pairs and cover source art.'
+}
+
+function liveSourceIssues(
+  book: ColoringBookStudioBook,
+  cover: ColoringBookCoverState | null,
+): ColoringBookSourceIssues {
+  const slots = new Map<number, number>()
+  for (const proposal of book.proposals) {
+    slots.set(proposal.slot, (slots.get(proposal.slot) ?? 0) + 1)
+  }
+  const expected = new Set(
+    Array.from({ length: book.targetProposals }, (_, index) => index + 1),
+  )
+  const actual = new Set(slots.keys())
+  const finalCoverPath = cover?.finalPath ?? null
+  return {
+    missingSlots: [...expected].filter((slot) => !actual.has(slot)),
+    extraSlots: [...actual].filter((slot) => !expected.has(slot)),
+    duplicateSlots: [...slots.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([slot]) => slot),
+    missingPrompts: book.proposals
+      .filter((proposal) => !proposal.prompt.trim() && !proposal.promptRef)
+      .map((proposal) => proposal.id),
+    missingFinalColor: book.proposals
+      .filter((proposal) => !proposal.final.color)
+      .map((proposal) => proposal.id),
+    missingFinalBw: book.proposals
+      .filter((proposal) => !proposal.final.bw)
+      .map((proposal) => proposal.id),
+    missingColorFiles: [],
+    missingBwFiles: [],
+    coverNotFinal: !finalCoverPath && cover?.status !== 'final',
+    coverFinalPath: finalCoverPath,
+    coverFinalExists: Boolean(finalCoverPath),
+  }
+}
+
+function reconcileBook(
+  record: ColoringBookPackageBook,
+  book: ColoringBookStudioBook | null,
+  cover: ColoringBookCoverState | null,
+  productionStates: Record<string, ColoringBookProductionState>,
+  generated: boolean,
+): ColoringBookPackageBook {
+  if (!book) return record
+  const summary = summarizeBookReadiness(book, productionStates, cover)
+  const currentSourceReady = summary.interiorReady && !summary.coverPending
+  const sourceReady = currentSourceReady && (!generated || record.sourceReady)
+  const layoutReady = record.missingLayoutFields.length === 0
+  const exportsReady =
+    record.missingExportFields.length === 0 &&
+    Object.values(record.exportExists).every(Boolean)
+  const status = statusFor(sourceReady, layoutReady, exportsReady)
+
+  return {
+    ...record,
+    status,
+    nextAction: nextActionFor(status),
+    sourceReady,
+    layoutReady,
+    exportsReady,
+    packageReady: status === 'package-ready',
+    interiorCount: book.proposals.length,
+    expectedInteriorCount: book.targetProposals,
+    finalPairCount: summary.final,
+    coverStatus: cover?.status ?? record.coverStatus,
+    sourceIssues: generated ? record.sourceIssues : liveSourceIssues(book, cover),
+  }
+}
+
+export function reconcileColoringBookPackageData(
+  data: ColoringBookPackageData,
+  books: ColoringBookStudioBook[],
+  covers: Record<string, ColoringBookCoverState>,
+  productionStates: Record<string, ColoringBookProductionState>,
+): ColoringBookPackageData {
+  const studioBooks = new Map(books.map((book) => [book.slug, book]))
+  const reconciledBooks = data.books.map((record) =>
+    reconcileBook(
+      record,
+      studioBooks.get(record.slug) ?? null,
+      covers[record.slug] ?? null,
+      productionStates,
+      data.generated,
+    ),
+  )
+
+  return {
+    ...data,
+    books: reconciledBooks,
+    allSourceReady:
+      reconciledBooks.length > 0 &&
+      reconciledBooks.every((book) => book.sourceReady),
+    allPackageReady:
+      reconciledBooks.length > 0 &&
+      reconciledBooks.every((book) => book.packageReady),
+  }
+}
+
+export function packageStatusTone(status: ColoringBookPackageStatus): string {
+  if (status === 'package-ready') return 'badge-success'
+  if (status === 'exports-needed') return 'badge-primary'
+  if (status === 'layout-needed') return 'badge-warning'
+  return 'badge-info'
+}

--- a/utils/scripts/verifyColoringBookPackage.ts
+++ b/utils/scripts/verifyColoringBookPackage.ts
@@ -1,0 +1,211 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import type {
+  ColoringBookCoverState,
+  ColoringBookProposal,
+  ColoringBookStudioBook,
+} from '~/types/coloringBookStudio'
+import { parseColoringBookPackageData } from '@/server/utils/coloringBookPackage'
+import { reconcileColoringBookPackageData } from '@/utils/coloringBookPackage'
+
+const packageYaml = `schema_version: 1
+project: coloring-book
+requirements:
+  interior_slots: 1
+  source_orientation: portrait
+  source_aspect_ratio: '2:3'
+  source_pixel_size: 1024x1536
+  print_interior_variant: bw
+  archive_color_masters: true
+  final_cover_source_required: true
+  source_ready_definition: All final pairs and cover source exist.
+  package_ready_definition: Source, layout, and exports exist.
+books:
+- order: 1
+  slug: kind-robots
+  title: Kind Robots
+  layout:
+    trim_width_inches: null
+    trim_height_inches: null
+    bleed_inches: null
+    binding: null
+    paper: null
+    interior_color_mode: null
+    cover_color_mode: null
+    printer_template: null
+    page_count_includes_blanks: null
+    inside_cover_printing: null
+    barcode_area_reserved: null
+  exports:
+    ordered_interior_manifest: projects/coloring-book/packages/kind-robots/interiors.yaml
+    interior_pdf: null
+    cover_wrap_pdf: null
+    source_archive: null
+`
+
+const fallback = parseColoringBookPackageData(null, packageYaml)
+assert.equal(fallback.generated, false)
+assert.equal(fallback.books.length, 1)
+assert.equal(fallback.books[0]?.slug, 'kind-robots')
+assert.equal(fallback.books[0]?.missingLayoutFields.length, 11)
+assert.equal(fallback.books[0]?.missingExportFields.length, 3)
+assert.equal(fallback.requirements.sourcePixelSize, '1024x1536')
+
+const readinessYaml = `schema_version: 1
+project: coloring-book
+requirements:
+  interior_slots: 1
+books:
+- order: 1
+  slug: kind-robots
+  title: Kind Robots
+  status: exports-needed
+  next_action: Generate export files.
+  source_ready: true
+  layout_ready: true
+  exports_ready: false
+  package_ready: false
+  interior_count: 1
+  expected_interior_count: 1
+  final_pair_count: 1
+  cover_status: final
+  source_issues:
+    missing_slots: []
+    extra_slots: []
+    duplicate_slots: []
+    missing_prompts: []
+    missing_final_color: []
+    missing_final_bw: []
+    missing_color_files: []
+    missing_bw_files: []
+    cover_not_final: false
+    cover_final_path: generated/cover/kind-robots-cover.webp
+    cover_final_exists: true
+  missing_layout_fields: []
+  missing_export_fields:
+  - interior_pdf
+  - cover_wrap_pdf
+  - source_archive
+  export_exists:
+    interior_pdf: false
+    cover_wrap_pdf: false
+    source_archive: false
+  ordered_interior_manifest: projects/coloring-book/packages/kind-robots/interiors.yaml
+all_source_ready: true
+all_package_ready: false
+`
+
+const generated = parseColoringBookPackageData(readinessYaml, packageYaml)
+assert.equal(generated.generated, true)
+assert.equal(generated.books[0]?.status, 'exports-needed')
+assert.equal(generated.books[0]?.sourceReady, true)
+assert.equal(generated.books[0]?.sourceIssues.coverNotFinal, false)
+assert.deepEqual(generated.books[0]?.missingExportFields, [
+  'interior_pdf',
+  'cover_wrap_pdf',
+  'source_archive',
+])
+
+const proposal: ColoringBookProposal = {
+  slot: 1,
+  id: 'kr-001',
+  title: 'Final Page',
+  prompt: 'A complete production prompt.',
+  promptRef: null,
+  promptSourcePath: 'projects/coloring-book/sets/kind-robots/proposals.yaml',
+  inspirations: [],
+  accepted: {
+    color: 'approved/kr-001-color.webp',
+    bw: 'approved/kr-001-bw.webp',
+  },
+  final: {
+    color: 'approved/kr-001-color.webp',
+    bw: 'approved/kr-001-bw.webp',
+  },
+  notes: [],
+  queue: {
+    status: 'approved',
+    imagePath: null,
+    renderedPath: null,
+    artImageId: null,
+    semanticScore: null,
+    semanticVerdict: null,
+    semanticAttempts: 0,
+    semanticGateError: null,
+    completedAt: null,
+    renderEngine: null,
+    revisionCount: 0,
+  },
+  colorPath: 'approved/kr-001-color.webp',
+  colorUrl: null,
+  bwPath: 'approved/kr-001-bw.webp',
+  bwUrl: null,
+}
+
+const book: ColoringBookStudioBook = {
+  order: 1,
+  slug: 'kind-robots',
+  title: 'Kind Robots',
+  status: 'active-production',
+  targetProposals: 1,
+  coverIsSeparate: true,
+  counts: {
+    total: 1,
+    prompts: 1,
+    pending: 0,
+    rendered: 0,
+    acceptedColor: 1,
+    acceptedPairs: 1,
+    finalPairs: 1,
+    needsReview: 0,
+    blocked: 0,
+  },
+  proposals: [proposal],
+}
+
+const cover: ColoringBookCoverState = {
+  order: 1,
+  bookSlug: 'kind-robots',
+  title: 'Kind Robots',
+  prompt: 'A complete cover prompt.',
+  sourceRef: null,
+  imagePath: 'generated/cover/kind-robots-cover.webp',
+  status: 'final',
+  renderedPath: 'generated/cover/kind-robots-cover.webp',
+  renderedUrl: null,
+  artImageId: 1,
+  renderSeed: 2,
+  renderEngine: 'krea2',
+  completedAt: null,
+  semanticScore: 90,
+  semanticVerdict: 'promote',
+  semanticReasons: [],
+  rejectedPath: null,
+  rejectedUrl: null,
+  acceptedPath: 'generated/cover/kind-robots-cover.webp',
+  acceptedUrl: null,
+  approvedAt: null,
+  finalPath: 'generated/cover/kind-robots-cover.webp',
+  finalUrl: null,
+  finalizedAt: null,
+  revisionHistory: [],
+  notes: [],
+}
+
+const reconciled = reconcileColoringBookPackageData(
+  fallback,
+  [book],
+  { 'kind-robots': cover },
+  {},
+)
+assert.equal(reconciled.books[0]?.sourceReady, true)
+assert.equal(reconciled.books[0]?.status, 'layout-needed')
+assert.equal(reconciled.books[0]?.finalPairCount, 1)
+assert.equal(reconciled.allSourceReady, true)
+assert.equal(reconciled.allPackageReady, false)
+
+const page = readFileSync('components/coloring/coloring-book-page.vue', 'utf8')
+assert.match(page, /<coloring-book-package-readiness\s*\/>/)
+assert.match(page, /<coloring-book-cover-studio\s*\/>/)
+
+console.log('Coloring Book package contract passed.')


### PR DESCRIPTION
## What changed

- adds a canonical print-package endpoint backed by Conductor’s `print-package.yaml` and generated `print-readiness.yaml`
- provides a safe fallback while the first generated readiness snapshot is pending
- adds Pinia-owned package state and automatic refresh after every production action
- reconciles canonical layout/export validation with current final-pair and cover progress
- adds a three-book publishing dashboard for source assets, physical layout, exports, and package-ready state
- surfaces missing slots, prompts, final color/B&W assets, cover state, printer decisions, and export files
- mounts the previously merged cover production studio on the actual Coloring Book page
- updates the project completion/next-work copy to reflect the real packaging boundary
- expands the dedicated Coloring Book Production Contract with YAML parsing, fallback, transition, and component-mount regression tests

## Important boundary

This completes the software workflow, not the unresolved publishing choices. The dashboard deliberately refuses to invent trim size, bleed, binding, paper, printer template, barcode placement, or export files. Those remain explicit blockers until a printer and format are chosen.

## Backend dependency

Conductor PR #1322 already provides the vendor-neutral package manifest and readiness generator. Conductor PR #1354 keeps generated readiness synchronized with `[skip ci]` art-processing commits.

## Validation

Ready for TypeScript, the full contract suite, and the expanded Coloring Book Production Contract, then merge to `main`.