### PR TITLE
coloring: preserve print-package book order

### DIFF
--- a/server/utils/coloringBookPackage.ts
+++ b/server/utils/coloringBookPackage.ts
@@ -48,6 +48,12 @@ function scalar(block: string, key: string, spaces: number): string | null {
   )
 }
 
+function listItemScalar(block: string, key: string): string | null {
+  return yamlValue(
+    capture(block, new RegExp(`^-\\s+${key}:\\s*(.*?)\\s*$`, 'm')),
+  )
+}
+
 function yamlNumber(value: string | null, fallback = 0): number {
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : fallback
@@ -150,7 +156,7 @@ function readinessBook(block: string): ColoringBookPackageBook {
   const sourceBlock = nestedSection(block, 'source_issues', 2)
   const exportBlock = nestedSection(block, 'export_exists', 2)
   return {
-    order: yamlNumber(scalar(block, 'order', 0), 999),
+    order: yamlNumber(listItemScalar(block, 'order'), 999),
     slug: scalar(block, 'slug', 2) ?? '',
     title: scalar(block, 'title', 2) ?? '',
     status: statusValue(scalar(block, 'status', 2)),
@@ -203,7 +209,7 @@ function packageBook(block: string, expectedInteriors: number): ColoringBookPack
     (field) => scalar(exportsBlock, field, 4) === null,
   )
   return {
-    order: yamlNumber(scalar(block, 'order', 0), 999),
+    order: yamlNumber(listItemScalar(block, 'order'), 999),
     slug: scalar(block, 'slug', 2) ?? '',
     title: scalar(block, 'title', 2) ?? '',
     status: 'source-production',

--- a/utils/scripts/verifyColoringBookPackage.ts
+++ b/utils/scripts/verifyColoringBookPackage.ts
@@ -46,6 +46,7 @@ books:
 const fallback = parseColoringBookPackageData(null, packageYaml)
 assert.equal(fallback.generated, false)
 assert.equal(fallback.books.length, 1)
+assert.equal(fallback.books[0]?.order, 1)
 assert.equal(fallback.books[0]?.slug, 'kind-robots')
 assert.equal(fallback.books[0]?.missingLayoutFields.length, 11)
 assert.equal(fallback.books[0]?.missingExportFields.length, 3)
@@ -97,6 +98,7 @@ all_package_ready: false
 
 const generated = parseColoringBookPackageData(readinessYaml, packageYaml)
 assert.equal(generated.generated, true)
+assert.equal(generated.books[0]?.order, 1)
 assert.equal(generated.books[0]?.status, 'exports-needed')
 assert.equal(generated.books[0]?.sourceReady, true)
 assert.equal(generated.books[0]?.sourceIssues.coverNotFinal, false)


### PR DESCRIPTION
## Root cause

The package YAML stores each book as a sequence item beginning with `- order: N`. The parser handled indented scalar fields but attempted to read `order` as a normal root scalar, so the deployed API returned `order: 0` for all three books.

## Fix

- adds an explicit YAML sequence-item scalar reader
- parses both canonical package configuration and generated readiness book order correctly
- adds regression assertions for fallback and generated readiness inputs

## Validation

Ready for TypeScript, the Coloring Book Production Contract, and normal repository CI, then immediate merge to `main`.