### PR TITLE
model-builder: preserve stale GENERATE_ASSETS status through in-flight render completion

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -683,6 +683,19 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     return status === 'ready' || status === 'stale' || status === 'rejected'
   }
 
+  // A GENERATE_ASSETS render (sync or async) can be reopened upstream — and
+  // therefore marked 'stale' by markDownstreamStale — while it's still in
+  // flight. The render's own completion handler (success or failure) must not
+  // blindly overwrite that back to 'ready': it would silently erase the
+  // "needs re-review" signal for a candidate that was actually produced from
+  // an outdated prompt. Only apply the completion status if nothing else
+  // touched the stage while we were awaiting.
+  function finishGenerateAssets(item: BuildItem, next: StageState): void {
+    if (item.stages.GENERATE_ASSETS.status === 'in-progress') {
+      item.stages.GENERATE_ASSETS = next
+    }
+  }
+
   // Stale-invalidation: editing an upstream stage marks every downstream stage
   // stale (unless still locked). Commit is always downstream of everything.
   function markDownstreamStale(item: BuildItem, fromStage: BuildStageKey): void {
@@ -980,7 +993,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null
-      item.stages.GENERATE_ASSETS = { status: 'ready' }
+      finishGenerateAssets(item, { status: 'ready' })
 
       await recordArtifact(item, image, output, prompt, dims)
       pushItem(item, {
@@ -993,7 +1006,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     } catch (error) {
       handleError(error, 'generating model builder asset')
       item.error = error instanceof Error ? error.message : 'Generation failed.'
-      item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
       setStatus('error', item.error)
       return false
     } finally {
@@ -1035,10 +1048,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
       if (!job || job.status === 'PENDING' || job.status === 'RUNNING') {
         item.queueState = job?.status === 'RUNNING' ? 'rendering' : 'queued'
-        item.stages.GENERATE_ASSETS = {
+        finishGenerateAssets(item, {
           status: 'in-progress',
           note: item.queueState,
-        }
+        })
         await new Promise((resolve) => setTimeout(resolve, ASYNC_ART_POLL_MS))
         continue
       }
@@ -1051,7 +1064,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
       if (!result.success || !result.data) {
         item.error = result.message || `Art job ${jobId} did not complete.`
-        item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+        finishGenerateAssets(item, { status: 'ready', note: item.error })
         setStatus('error', item.error)
         return
       }
@@ -1059,7 +1072,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null
-      item.stages.GENERATE_ASSETS = { status: 'ready' }
+      finishGenerateAssets(item, { status: 'ready' })
 
       await recordArtifact(item, image, output, prompt, dims)
       pushItem(item, {
@@ -1132,7 +1145,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       handleError(error, 'queueing model builder asset')
       item.error =
         error instanceof Error ? error.message : 'Failed to queue generation.'
-      item.stages.GENERATE_ASSETS = { status: 'ready', note: item.error }
+      finishGenerateAssets(item, { status: 'ready', note: item.error })
       item.queueState = null
       item.artJobId = null
       setStatus('error', item.error)


### PR DESCRIPTION
## Summary
- A GENERATE_ASSETS render (sync `generateItemAsset` or async `pollAsyncArtJob`/`generateItemAssetAsync`) can be reopened upstream while still in flight, which correctly marks `GENERATE_ASSETS` `'stale'` via `markDownstreamStale`.
- The render's completion handler held only its original `item` reference and had no idea this happened — it unconditionally overwrote the stage status back to `'ready'` (or re-asserted `'in-progress'` on every 5s poll tick), silently erasing the "needs re-review" signal for a candidate that was actually produced from a now-outdated prompt.
- Added `finishGenerateAssets(item, next)`, which only applies a completion status write if the stage is still `'in-progress'` — i.e. nothing else (a reopen) touched it while the async call was awaiting. Applied it at all six race-prone write sites in `generateItemAsset`, `pollAsyncArtJob`, and `generateItemAssetAsync`'s enqueue catch.
- This is the same "review gate bypassed" bug class as the prior `canApproveAssets` (#1102 area) and batch-operation stage-editability (#1111) fixes, just in the render-completion path instead of the approval-gating or batch-write paths.

## Test plan
- [x] `npx vue-tsc --noEmit` — clean
- [x] `npx eslint stores/modelBuilderStore.ts` — only the 2 pre-existing `no-empty` errors at lines 203/210 (confirmed present on `main` via `git stash`, unrelated to this change)
- [x] `npx prettier --check stores/modelBuilderStore.ts` — same drift confirmed pre-existing on `main` via `git stash`
- [ ] Live smoke test of the actual race (reopen PITCH mid-render, confirm GENERATE_ASSETS stays `stale` after the render resolves) — no reachable render backend from this sandbox; logic verified by code trace instead

---
_Generated by [Claude Code](https://claude.ai/code/session_012mxsEh3Xe5XZzDcinVjDKh)_