### PR TITLE
media-watchlist/t-015: add unfiltered "Recent entries" list to watchlist-browse.vue

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -15,6 +15,10 @@
   The "most active month" line (media-watchlist/t-013, BROWSE-UX.md §1) reuses
   the same stats.get.ts countByMonth breakdown that already powers the Month
   filter chips -- no backend change needed, just picking the max and naming it.
+  "Recent entries" (media-watchlist/t-015, BROWSE-UX.md §1's last gap) is a
+  fixed, unfiltered global view -- a separate GET /api/media-entries?take=10&
+  sort=date_desc call that ignores the active search/year/type/starred/month/
+  season state entirely, per that spec.
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -37,6 +41,34 @@
         You consumed the most in {{ mostActiveMonth.label }}:
         {{ mostActiveMonth.count }} entries
       </p>
+
+      <!-- Recent entries (BROWSE-UX.md §1) -- fixed global view, no filters -->
+      <div
+        v-if="recentEntries.length"
+        class="rounded-3xl border border-base-300 bg-base-100 p-4"
+      >
+        <p class="mb-2 text-xs font-semibold uppercase text-base-content/50">
+          Recent entries
+        </p>
+        <ul class="flex flex-col gap-1">
+          <li
+            v-for="entry in recentEntries"
+            :key="`recent-${entry.id}`"
+            class="flex items-center gap-2 text-sm"
+          >
+            <Icon
+              :name="MEDIA_TYPE_ICON[entry.mediaType]"
+              class="size-3.5 shrink-0 text-base-content/50"
+            />
+            <span class="truncate font-semibold text-base-content">{{
+              entry.title
+            }}</span>
+            <span class="ml-auto shrink-0 text-xs text-base-content/50">{{
+              formatDate(entry)
+            }}</span>
+          </li>
+        </ul>
+      </div>
 
       <!-- Stats strip -->
       <div
@@ -400,6 +432,26 @@ const MEDIA_TYPE_CHIPS: { value: MediaType; label: string }[] = [
   { value: 'VIDEO_GAME', label: 'Games' },
 ]
 
+// Recent-entries grouping (media-watchlist/t-015, BROWSE-UX.md §1). Covers
+// every MediaType (not just the MEDIA_TYPE_CHIPS subset), grouping the rarer
+// types under the closest visual sibling since there's no dedicated icon:
+// NOVELLA -> book, ANIME -> video (TV), PODCAST -> microphone (AUDIOBOOK),
+// SHORT -> movie, VIDEO_GAME_SHORT -> dice (VIDEO_GAME).
+const MEDIA_TYPE_ICON: Record<MediaType, string> = {
+  MOVIE: 'kind-icon:movie',
+  TV: 'kind-icon:video',
+  BOOK: 'kind-icon:book',
+  NOVELLA: 'kind-icon:book',
+  AUDIOBOOK: 'kind-icon:microphone',
+  COMIC: 'kind-icon:menu-book',
+  VIDEO_GAME: 'kind-icon:dice',
+  ANIME: 'kind-icon:video',
+  PODCAST: 'kind-icon:microphone',
+  THEATRE: 'kind-icon:theater',
+  SHORT: 'kind-icon:movie',
+  VIDEO_GAME_SHORT: 'kind-icon:dice',
+}
+
 const MONTH_LABELS: { value: number; label: string }[] = [
   { value: 1, label: 'Jan' },
   { value: 2, label: 'Feb' },
@@ -436,6 +488,7 @@ const isLoading = ref(false)
 const errorMessage = ref('')
 const stats = ref<MediaEntryStats | null>(null)
 const selectedId = ref<number | null>(null)
+const recentEntries = ref<MediaEntrySummary[]>([])
 
 // BROWSE-UX.md §1: "Most active month: 'You consumed the most in [Month]: N
 // entries'". countByMonth is keyed by month number as a string (1-12); pick
@@ -478,6 +531,16 @@ function handleEntryUpdated(updated: MediaEntryDetail) {
   const index = entries.value.findIndex((entry) => entry.id === updated.id)
   if (index !== -1)
     entries.value[index] = { ...entries.value[index], ...updated }
+
+  const recentIndex = recentEntries.value.findIndex(
+    (entry) => entry.id === updated.id,
+  )
+  if (recentIndex !== -1) {
+    recentEntries.value[recentIndex] = {
+      ...recentEntries.value[recentIndex],
+      ...updated,
+    }
+  }
 }
 
 function toggleType(type: MediaType) {
@@ -512,6 +575,20 @@ async function loadStats(): Promise<void> {
     if (res?.success) stats.value = res.data
   } catch {
     /* stats strip is non-critical; leave it hidden on failure */
+  }
+}
+
+// Fixed global view (BROWSE-UX.md §1) -- intentionally ignores the active
+// search/year/type/starred/month/season filters, unlike loadEntries().
+async function loadRecentEntries(): Promise<void> {
+  try {
+    const res = await $fetch<MediaEntriesResponse, string>(
+      '/api/media-entries',
+      { query: { take: 10, sort: 'date_desc' } },
+    )
+    if (res?.success) recentEntries.value = res.data
+  } catch {
+    /* recent-entries strip is non-critical; leave it hidden on failure */
   }
 }
 
@@ -619,5 +696,6 @@ onMounted(() => {
   if (!isAdmin.value) return
   void loadStats()
   void loadEntries()
+  void loadRecentEntries()
 })
 </script>


### PR DESCRIPTION
### Task
media-watchlist/t-015: Add a "Recent entries" list (last 10, reverse-chronological, grouped by media-type icon) to watchlist-browse.vue (kind: software)

### What changed / what I produced
- Added a "Recent entries" section to `components/watchlist/watchlist-browse.vue`, shown above the Stats strip.
- Fetches via a separate, unfiltered `GET /api/media-entries?take=10&sort=date_desc` call that intentionally ignores the active search/year/type/starred/month/season filter state, per BROWSE-UX.md §1's spec for a fixed global view (distinct from the main filtered `loadEntries()` call).
- Added a `MEDIA_TYPE_ICON` map covering all 12 `MediaType` enum values (not just the 6 in `MEDIA_TYPE_CHIPS`) so each recent entry renders with an icon: MOVIE/SHORT → movie, TV/ANIME → video, BOOK/NOVELLA → book, COMIC → menu-book, AUDIOBOOK/PODCAST → microphone, VIDEO_GAME/VIDEO_GAME_SHORT → dice, THEATRE → theater.
- `handleEntryUpdated` now also patches the recent-entries list so an edit made via the detail panel stays in sync in both places.
- No backend/route change — confirmed `GET /api/media-entries` already supports an unfiltered `take`/`sort` call with no `year`/`type`/`month`/`season` set.

### How I verified
- `npx eslint components/watchlist/watchlist-browse.vue` — clean.
- `npx prettier --check components/watchlist/watchlist-browse.vue` — clean.
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0. (This caught the initial 6-key icon map as incomplete against `Record<MediaType, string>` — fixed by covering all 12 enum values.)
- No local live browser smoke test — this sandbox has no reachable `DATABASE_URL` (dummy MariaDB host), same limitation documented on every other front-end task in this project's roadmap history.

### Stakes
reversible

### Flags for Reviewer
- No live/visual smoke test was possible in this sandbox (see above) — logic was verified by type/lint checks and reading the existing filtered-query pattern (`loadEntries`) to confirm the unfiltered variant is structured correctly.
- The rarer `MediaType` values (NOVELLA, ANIME, PODCAST, SHORT, VIDEO_GAME_SHORT) don't have dedicated icons in `assets/icons/`, so they're grouped under the closest visual sibling — a judgment call, easy to swap later if a better icon is added.

### Kaizen suggestion
`MEDIA_TYPE_CHIPS` (the filter-chip list) still only covers 6 of the 12 `MediaType` values — the other 6 (NOVELLA, ANIME, PODCAST, THEATRE, SHORT, VIDEO_GAME_SHORT) can't be filtered on directly even though they can now be seen (via Recent entries) and stored. Worth a small follow-up task to either extend the chip list or fold the rare types into their nearest sibling chip.

### Notes for reviewer
Conductor task: `projects/media-watchlist/roadmap.yaml` t-015, set to `status: review` this cycle.


---
_Generated by [Claude Code](https://claude.ai/code/session_018YHjhtS5h8QMeeTJjDeCM3)_