### PR TITLE
Add Storymaker recent-story library shell

### DIFF
--- a/.github/workflows/storymaker-session-library-contract.yml
+++ b/.github/workflows/storymaker-session-library-contract.yml
@@ -1,0 +1,30 @@
+name: Storymaker Session Library Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: storymaker-session-library-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Storymaker session library contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify Storymaker session library
+        run: node utils/scripts/verifyStorymakerSessionLibrary.mjs

--- a/components/pages/storymaker-library-page.vue
+++ b/components/pages/storymaker-library-page.vue
@@ -1,0 +1,286 @@
+<!-- /components/pages/storymaker-library-page.vue -->
+<template>
+  <section class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden">
+    <header
+      class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm"
+    >
+      <div class="min-w-0">
+        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70">
+          Story library
+        </p>
+        <p class="mt-0.5 text-sm text-base-content/60">
+          {{ library.recentStories.length }} saved
+          {{ library.recentStories.length === 1 ? 'story' : 'stories' }} on this account
+        </p>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+          :aria-expanded="libraryOpen"
+          @click="libraryOpen = !libraryOpen"
+        >
+          <Icon name="kind-icon:book" class="size-4" />
+          {{ libraryOpen ? 'Hide library' : 'Recent stories' }}
+        </button>
+
+        <template v-if="storyStore.session">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+            :disabled="storyStore.isWeaving"
+            @click="duplicateCurrent"
+          >
+            <Icon name="kind-icon:copy" class="size-4" /> Duplicate
+          </button>
+
+          <details class="dropdown dropdown-end">
+            <summary class="btn btn-ghost btn-sm rounded-xl border border-base-300">
+              <Icon name="kind-icon:download" class="size-4" /> Export
+            </summary>
+            <ul
+              class="menu dropdown-content z-20 mt-2 w-44 rounded-2xl border border-base-300 bg-base-100 p-2 shadow-xl"
+            >
+              <li><button type="button" @click="downloadStory(undefined, 'markdown')">Markdown</button></li>
+              <li><button type="button" @click="downloadStory(undefined, 'json')">JSON</button></li>
+            </ul>
+          </details>
+
+          <button
+            v-if="!restartArmed"
+            type="button"
+            class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+            :disabled="storyStore.isWeaving"
+            @click="restartArmed = true"
+          >
+            <Icon name="kind-icon:refresh" class="size-4" /> Restart
+          </button>
+          <button
+            v-else
+            type="button"
+            class="btn btn-warning btn-sm rounded-xl"
+            :disabled="storyStore.isWeaving"
+            @click="restartCurrent"
+            @blur="restartArmed = false"
+          >
+            <Icon name="kind-icon:alert" class="size-4" /> Restart from the beginning?
+          </button>
+
+          <button
+            type="button"
+            class="btn btn-primary btn-sm rounded-xl"
+            :disabled="storyStore.isWeaving"
+            @click="startNewStory"
+          >
+            <Icon name="kind-icon:plus" class="size-4" /> New story
+          </button>
+        </template>
+      </div>
+    </header>
+
+    <section
+      v-if="libraryOpen"
+      class="max-h-[42dvh] shrink-0 space-y-3 overflow-y-auto rounded-2xl border border-primary/20 bg-primary/5 p-4"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 class="text-lg font-black">Recent stories</h2>
+          <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+            Open an existing branch, duplicate it safely, or export a portable copy.
+          </p>
+        </div>
+        <span class="badge badge-ghost rounded-xl">
+          Up to 20 recent sessions
+        </span>
+      </div>
+
+      <div
+        v-if="library.recentStories.length"
+        class="grid gap-3 md:grid-cols-2 xl:grid-cols-3"
+      >
+        <article
+          v-for="story in library.recentStories"
+          :key="story.id"
+          class="flex min-w-0 flex-col rounded-2xl border border-base-300 bg-base-100 p-3"
+        >
+          <div class="min-w-0 flex-1">
+            <div class="flex items-start justify-between gap-2">
+              <h3 class="truncate font-black">{{ story.bible.title }}</h3>
+              <span
+                class="badge badge-sm rounded-xl"
+                :class="story.status === 'complete' ? 'badge-success' : 'badge-primary'"
+              >
+                {{ story.status }}
+              </span>
+            </div>
+            <p class="mt-1 line-clamp-2 text-xs leading-relaxed text-base-content/55">
+              {{ story.bible.premise }}
+            </p>
+            <p class="mt-2 text-[0.68rem] text-base-content/40">
+              {{ story.beats.length }} scene{{ story.beats.length === 1 ? '' : 's' }} ·
+              updated {{ formatStoryDate(story.updatedAt) }}
+            </p>
+          </div>
+
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              class="btn btn-primary btn-xs rounded-xl"
+              @click="openStory(story.id)"
+            >
+              {{ story.status === 'complete' ? 'Open' : 'Resume' }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-xl border border-base-300"
+              @click="duplicateStory(story.id)"
+            >
+              Duplicate
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs rounded-xl border border-base-300"
+              @click="downloadStory(story.id, 'markdown')"
+            >
+              Export
+            </button>
+          </div>
+        </article>
+      </div>
+
+      <div
+        v-else
+        class="rounded-2xl border border-dashed border-base-300 bg-base-100/70 p-5 text-center"
+      >
+        <p class="font-bold">No saved stories yet</p>
+        <p class="mt-1 text-xs text-base-content/50">
+          Your first Storymaker session will appear here automatically.
+        </p>
+      </div>
+    </section>
+
+    <div class="min-h-0 flex-1 overflow-hidden">
+      <StorymakerPage />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useStorymakerLibrary } from '@/composables/useStorymakerLibrary'
+import { useStorymakerStore } from '@/stores/storymakerStore'
+
+const storyStore = useStorymakerStore()
+const library = useStorymakerLibrary()
+const route = useRoute()
+const router = useRouter()
+
+const libraryOpen = ref(false)
+const restartArmed = ref(false)
+
+function queryStoryId(): string | null {
+  return typeof route.query.story === 'string' ? route.query.story : null
+}
+
+function updateStoryQuery(sessionId: string | null): void {
+  const query = { ...route.query }
+  if (sessionId) query.story = sessionId
+  else delete query.story
+  void router.replace({ query })
+}
+
+function openStory(sessionId: string): void {
+  if (!library.openStory(sessionId)) return
+  libraryOpen.value = false
+  updateStoryQuery(sessionId)
+}
+
+function duplicateStory(sessionId: string): void {
+  const duplicateId = library.duplicateStory(sessionId)
+  if (!duplicateId) return
+  libraryOpen.value = false
+  updateStoryQuery(duplicateId)
+}
+
+function duplicateCurrent(): void {
+  const duplicateId = library.duplicateStory()
+  if (duplicateId) updateStoryQuery(duplicateId)
+}
+
+async function restartCurrent(): Promise<void> {
+  restartArmed.value = false
+  const restartedId = await library.restartStory()
+  if (restartedId) updateStoryQuery(restartedId)
+}
+
+function triggerDownload(payload: {
+  filename: string
+  mimeType: string
+  content: string
+}): void {
+  const blob = new Blob([payload.content], {
+    type: `${payload.mimeType};charset=utf-8`,
+  })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = payload.filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+function downloadStory(
+  sessionId?: string,
+  format: 'markdown' | 'json' = 'markdown',
+): void {
+  const payload = library.buildExport(sessionId, format)
+  if (payload) triggerDownload(payload)
+}
+
+function startNewStory(): void {
+  if (storyStore.isWeaving) return
+  library.archiveCurrent()
+  storyStore.resetSession()
+  libraryOpen.value = false
+  updateStoryQuery(null)
+}
+
+function formatStoryDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? 'recently'
+    : new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: date.getFullYear() === new Date().getFullYear() ? undefined : 'numeric',
+      }).format(date)
+}
+
+watch(
+  () => storyStore.session?.id ?? null,
+  (sessionId) => {
+    if (sessionId !== queryStoryId()) updateStoryQuery(sessionId)
+  },
+)
+
+watch(
+  () => route.query.story,
+  (value) => {
+    if (typeof value !== 'string' || value === storyStore.session?.id) return
+    openStory(value)
+  },
+)
+
+onMounted(() => {
+  storyStore.restoreFromLocalStorage()
+  library.initialize()
+  const directId = queryStoryId()
+  if (directId) library.openStory(directId)
+  libraryOpen.value = !storyStore.session && library.recentStories.length > 0
+  if (storyStore.session && !directId) updateStoryQuery(storyStore.session.id)
+})
+</script>

--- a/composables/useStorymakerLibrary.ts
+++ b/composables/useStorymakerLibrary.ts
@@ -1,5 +1,5 @@
 // /composables/useStorymakerLibrary.ts
-import { computed, ref, watch } from 'vue'
+import { computed, proxyRefs, ref, watch } from 'vue'
 import {
   useStorymakerStore,
   type StorymakerBible,
@@ -292,7 +292,7 @@ export function useStorymakerLibrary() {
     { deep: true },
   )
 
-  return {
+  return proxyRefs({
     library,
     recentStories,
     initialize,
@@ -301,5 +301,5 @@ export function useStorymakerLibrary() {
     duplicateStory,
     restartStory,
     buildExport,
-  }
+  })
 }

--- a/composables/useStorymakerLibrary.ts
+++ b/composables/useStorymakerLibrary.ts
@@ -3,10 +3,15 @@ import { computed, ref, watch } from 'vue'
 import {
   useStorymakerStore,
   type StorymakerBible,
-  type StorymakerExport,
   type StorymakerSession,
 } from '@/stores/storymakerStore'
 import { useUserStore } from '@/stores/userStore'
+
+export type StorymakerLibraryExport = {
+  filename: string
+  mimeType: 'text/markdown' | 'application/json'
+  content: string
+}
 
 const LIBRARY_STORAGE_KEY = 'storymaker-session-library-v1'
 const MAX_LIBRARY_SESSIONS = 20
@@ -210,7 +215,7 @@ export function useStorymakerLibrary() {
   function buildExport(
     sessionId = storyStore.session?.id,
     format: 'markdown' | 'json' = 'markdown',
-  ): StorymakerExport | null {
+  ): StorymakerLibraryExport | null {
     if (!sessionId) return null
     const source =
       storyStore.session?.id === sessionId
@@ -250,7 +255,9 @@ export function useStorymakerLibrary() {
       if (beat.art?.status === 'done' && beat.art.imagePath) {
         lines.push(`![Scene ${index + 1} illustration](${beat.art.imagePath})`, '')
       }
-      if (beat.answer?.text) lines.push(`**Reader choice:** ${beat.answer.text}`, '')
+      if (beat.answer?.text) {
+        lines.push(`**Reader choice:** ${beat.answer.text}`, '')
+      }
     })
 
     lines.push(

--- a/composables/useStorymakerLibrary.ts
+++ b/composables/useStorymakerLibrary.ts
@@ -1,0 +1,298 @@
+// /composables/useStorymakerLibrary.ts
+import { computed, ref, watch } from 'vue'
+import {
+  useStorymakerStore,
+  type StorymakerBible,
+  type StorymakerExport,
+  type StorymakerSession,
+} from '@/stores/storymakerStore'
+import { useUserStore } from '@/stores/userStore'
+
+const LIBRARY_STORAGE_KEY = 'storymaker-session-library-v1'
+const MAX_LIBRARY_SESSIONS = 20
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function makeId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `storymaker-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function cloneSession(value: StorymakerSession): StorymakerSession {
+  const copy = JSON.parse(JSON.stringify(value)) as StorymakerSession
+  return {
+    ...copy,
+    bible: {
+      ...copy.bible,
+      rewards: Array.isArray(copy.bible?.rewards) ? copy.bible.rewards : [],
+    },
+    beats: Array.isArray(copy.beats) ? copy.beats : [],
+    branchHistory: Array.isArray(copy.branchHistory) ? copy.branchHistory : [],
+    consequences: Array.isArray(copy.consequences) ? copy.consequences : [],
+    inventory: Array.isArray(copy.inventory) ? copy.inventory : [],
+    stateVersion: 1,
+  }
+}
+
+function exportFilename(title: string, extension: 'md' | 'json'): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 72)
+  return `${slug || 'storymaker-story'}.${extension}`
+}
+
+function restartInput(bible: StorymakerBible) {
+  return {
+    title: bible.title,
+    premise: bible.premise,
+    narratorStyle: bible.narratorStyle,
+    structure: bible.structure,
+    cast: bible.cast,
+    location: bible.location,
+    facets: bible.facets,
+    rewards: bible.rewards,
+    notes: bible.notes,
+  }
+}
+
+export function useStorymakerLibrary() {
+  const storyStore = useStorymakerStore()
+  const userStore = useUserStore()
+  const library = ref<StorymakerSession[]>([])
+  const initialized = ref(false)
+
+  const recentStories = computed(() => {
+    const userId = userStore.authenticatedUserId
+    return library.value
+      .filter((entry) => entry.userId === userId)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+  })
+
+  function persistLibrary(): void {
+    if (typeof localStorage === 'undefined') return
+    try {
+      localStorage.setItem(LIBRARY_STORAGE_KEY, JSON.stringify(library.value))
+    } catch {
+      // A storage quota should not break the active Storymaker session.
+    }
+  }
+
+  function upsert(value: StorymakerSession): void {
+    const copy = cloneSession(value)
+    library.value = [
+      copy,
+      ...library.value.filter((entry) => entry.id !== copy.id),
+    ]
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, MAX_LIBRARY_SESSIONS)
+    persistLibrary()
+  }
+
+  function initialize(): void {
+    if (initialized.value || typeof localStorage === 'undefined') return
+    try {
+      const raw = localStorage.getItem(LIBRARY_STORAGE_KEY)
+      if (raw) {
+        const parsed = JSON.parse(raw) as StorymakerSession[]
+        library.value = Array.isArray(parsed)
+          ? parsed
+              .map(cloneSession)
+              .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+              .slice(0, MAX_LIBRARY_SESSIONS)
+          : []
+      }
+    } catch {
+      localStorage.removeItem(LIBRARY_STORAGE_KEY)
+      library.value = []
+    }
+    initialized.value = true
+    if (storyStore.session) upsert(storyStore.session)
+  }
+
+  function findStory(sessionId: string): StorymakerSession | null {
+    return recentStories.value.find((entry) => entry.id === sessionId) ?? null
+  }
+
+  function openStory(sessionId: string): boolean {
+    const found = findStory(sessionId)
+    if (!found || storyStore.isWeaving) return false
+    storyStore.$patch({ session: cloneSession(found), errorMessage: '' })
+    storyStore.resumeNarrativeArtJobs()
+    return true
+  }
+
+  function remapDuplicate(source: StorymakerSession): StorymakerSession {
+    const duplicate = cloneSession(source)
+    const createdAt = nowIso()
+    const sessionId = makeId()
+    const beatIds = new Map<string, string>()
+    const beats = duplicate.beats.map((beat) => {
+      const beatId = makeId()
+      beatIds.set(beat.id, beatId)
+      const art =
+        beat.art?.status === 'done'
+          ? {
+              ...beat.art,
+              sessionId,
+              beatId,
+              dedupeKey: [beat.art.product, sessionId, beatId, beat.art.moment].join(':'),
+              jobId: undefined,
+              updatedAt: createdAt,
+            }
+          : undefined
+      return { ...beat, id: beatId, sessionId, art }
+    })
+    const mapBeatId = (beatId: string) => beatIds.get(beatId) ?? beatId
+
+    return {
+      ...duplicate,
+      id: sessionId,
+      userId: userStore.authenticatedUserId,
+      bible: {
+        ...duplicate.bible,
+        title: `Copy of ${duplicate.bible.title}`,
+        createdAt,
+      },
+      beats,
+      branchHistory: duplicate.branchHistory.map((choice) => ({
+        ...choice,
+        id: makeId(),
+        beatId: mapBeatId(choice.beatId),
+      })),
+      consequences: duplicate.consequences.map((item) => ({
+        ...item,
+        id: makeId(),
+        beatId: mapBeatId(item.beatId),
+      })),
+      inventory: duplicate.inventory.map((item) => ({
+        ...item,
+        beatId: mapBeatId(item.beatId),
+      })),
+      createdAt,
+      updatedAt: createdAt,
+    }
+  }
+
+  function duplicateStory(sessionId = storyStore.session?.id): string | null {
+    if (!sessionId || storyStore.isWeaving) return null
+    const source =
+      storyStore.session?.id === sessionId
+        ? storyStore.session
+        : findStory(sessionId)
+    if (!source) return null
+    const duplicate = remapDuplicate(source)
+    upsert(duplicate)
+    storyStore.$patch({ session: duplicate, errorMessage: '' })
+    return duplicate.id
+  }
+
+  async function restartStory(
+    sessionId = storyStore.session?.id,
+  ): Promise<string | null> {
+    if (!sessionId || storyStore.isWeaving) return null
+    const source =
+      storyStore.session?.id === sessionId
+        ? storyStore.session
+        : findStory(sessionId)
+    if (!source) return null
+    upsert(source)
+    const started = await storyStore.beginStory(restartInput(source.bible))
+    if (!started || !storyStore.session) return null
+    upsert(storyStore.session)
+    return storyStore.session.id
+  }
+
+  function buildExport(
+    sessionId = storyStore.session?.id,
+    format: 'markdown' | 'json' = 'markdown',
+  ): StorymakerExport | null {
+    if (!sessionId) return null
+    const source =
+      storyStore.session?.id === sessionId
+        ? storyStore.session
+        : findStory(sessionId)
+    if (!source) return null
+    const copy = cloneSession(source)
+
+    if (format === 'json') {
+      return {
+        filename: exportFilename(copy.bible.title, 'json'),
+        mimeType: 'application/json',
+        content: JSON.stringify(copy, null, 2),
+      }
+    }
+
+    const lines = [
+      `# ${copy.bible.title}`,
+      '',
+      `> ${copy.bible.premise}`,
+      '',
+      '## Story Bible',
+      '',
+      `- Narrator: ${copy.bible.narratorStyle}`,
+      `- Structure: ${copy.bible.structure}`,
+      `- Cast: ${copy.bible.cast.map((item) => item.title).join(', ') || 'Invented as needed'}`,
+      `- Setting: ${copy.bible.location?.title || 'Invented from the premise'}`,
+      `- Facets: ${copy.bible.facets.map((item) => item.title).join(', ') || 'None selected'}`,
+      `- Reward pool: ${copy.bible.rewards.map((item) => item.title).join(', ') || 'None selected'}`,
+      '',
+      '## Story',
+      '',
+    ]
+
+    copy.beats.forEach((beat, index) => {
+      lines.push(`### Scene ${index + 1}`, '', beat.narrative, '')
+      if (beat.art?.status === 'done' && beat.art.imagePath) {
+        lines.push(`![Scene ${index + 1} illustration](${beat.art.imagePath})`, '')
+      }
+      if (beat.answer?.text) lines.push(`**Reader choice:** ${beat.answer.text}`, '')
+    })
+
+    lines.push(
+      '## Story State',
+      '',
+      `- Inventory: ${copy.inventory.map((item) => item.ingredient.title).join(', ') || 'Empty'}`,
+      `- Branch choices: ${copy.branchHistory.length}`,
+      `- Status: ${copy.status}`,
+      '',
+      ...copy.consequences.map((item) => `- ${item.text}`),
+      '',
+    )
+
+    return {
+      filename: exportFilename(copy.bible.title, 'md'),
+      mimeType: 'text/markdown',
+      content: lines.join('\n'),
+    }
+  }
+
+  function archiveCurrent(): void {
+    if (storyStore.session) upsert(storyStore.session)
+  }
+
+  watch(
+    () => storyStore.session,
+    (next, previous) => {
+      if (!initialized.value) return
+      if (next) upsert(next)
+      else if (previous) upsert(previous)
+    },
+    { deep: true },
+  )
+
+  return {
+    library,
+    recentStories,
+    initialize,
+    archiveCurrent,
+    openStory,
+    duplicateStory,
+    restartStory,
+    buildExport,
+  }
+}

--- a/content/storymaker.md
+++ b/content/storymaker.md
@@ -15,4 +15,4 @@ loadingMessage: Threading the loom...
 refreshLabel: Refresh Storymaker
 ---
 
-:storymaker-page
+:storymaker-library-page

--- a/utils/scripts/verifyStorymakerSessionLibrary.mjs
+++ b/utils/scripts/verifyStorymakerSessionLibrary.mjs
@@ -1,0 +1,104 @@
+// /utils/scripts/verifyStorymakerSessionLibrary.mjs
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+function includesAll(path, values) {
+  const contents = source(path)
+  for (const value of values) {
+    assert.ok(contents.includes(value), `${path} must include ${value}`)
+  }
+}
+
+const libraryPath = 'composables/useStorymakerLibrary.ts'
+const shellPath = 'components/pages/storymaker-library-page.vue'
+const contentPath = 'content/storymaker.md'
+const storePath = 'stores/storymakerStore.ts'
+
+const library = source(libraryPath)
+const shell = source(shellPath)
+const store = source(storePath)
+
+includesAll(libraryPath, [
+  "const LIBRARY_STORAGE_KEY = 'storymaker-session-library-v1'",
+  'const MAX_LIBRARY_SESSIONS = 20',
+  'entry.userId === userId',
+  'function openStory(',
+  'function duplicateStory(',
+  'async function restartStory(',
+  'function buildExport(',
+  "format: 'markdown' | 'json'",
+  "mimeType: 'application/json'",
+  "mimeType: 'text/markdown'",
+  'archiveCurrent',
+])
+
+includesAll(libraryPath, [
+  'const sessionId = makeId()',
+  'const beatIds = new Map<string, string>()',
+  'const beatId = makeId()',
+  'sessionId,',
+  'beatId,',
+  "dedupeKey: [beat.art.product, sessionId, beatId, beat.art.moment].join(':')",
+  'jobId: undefined',
+  "beat.art?.status === 'done'",
+  'branchHistory: duplicate.branchHistory.map',
+  'consequences: duplicate.consequences.map',
+  'inventory: duplicate.inventory.map',
+])
+
+assert.ok(
+  !library.includes("beat.art?.status === 'queued'") &&
+    !library.includes("beat.art?.status === 'rendering'"),
+  'Duplicated stories must not carry resumable queued or rendering jobs from the source branch',
+)
+assert.ok(
+  library.indexOf('upsert(source)') < library.indexOf('storyStore.beginStory('),
+  'Restart must archive the source before creating a fresh opening',
+)
+assert.ok(
+  !library.includes('useTaskmasterStore') &&
+    !library.includes('useTodoStore') &&
+    !library.includes('useConductorStore'),
+  'Storymaker lifecycle management must remain fiction-only',
+)
+
+includesAll(shellPath, [
+  '<StorymakerPage />',
+  'Story library',
+  'Recent stories',
+  'library.openStory(',
+  'library.duplicateStory(',
+  'library.restartStory(',
+  'library.buildExport(',
+  "format: 'markdown' | 'json'",
+  'route.query.story',
+  'updateStoryQuery',
+  'URL.createObjectURL',
+  'library.archiveCurrent()',
+])
+
+includesAll(contentPath, [':storymaker-library-page'])
+assert.ok(
+  !source(contentPath).includes(':storymaker-page\n'),
+  'The route must mount the lifecycle shell instead of bypassing it',
+)
+
+includesAll(storePath, [
+  "defineStore('storymakerStore'",
+  'resumeNarrativeArtJobs',
+  'retryBeatArt',
+  'beginStory',
+])
+assert.ok(
+  !store.includes('storymaker-session-library-v1'),
+  'The proven generation store must remain independent from library presentation state',
+)
+
+console.log(
+  'Storymaker session-library contract passed: account-scoped recent stories, direct-open, safe duplicate identities, restart, export, and generation-store separation are present.',
+)


### PR DESCRIPTION
## What changed

- Add a bounded local recent-story library without modifying the proven Storymaker generation store.
- Scope visible stories to the active account on shared browsers.
- Wrap the existing Storymaker studio with a lifecycle shell rather than duplicating its setup or generation UI.
- Add stable direct-open/resume URLs through `?story=<session-id>`.
- Add safe duplication with new session, beat, branch, consequence, inventory, and narrative-art identities.
- Preserve only completed artwork references when duplicating; queued/rendering jobs are never inherited by the copy.
- Add restart from the same story bible while archiving the source branch first.
- Add Markdown and JSON export, including story bible, scenes, reader choices, completed illustration paths, inventory, branch count, status, and consequences.
- Add a dedicated Storymaker Session Library Contract.

## Boundary

The existing `storymakerStore`, generation prompts, state parser, branching behavior, and narrative-art queue remain unchanged. The new composable owns browser-library presentation and lifecycle actions only. No Taskmaster, Todo, or Conductor state is imported.

## Verification

- TypeScript Type Check: passed.
- Contract Tests: passed, including the full repository contract suite.
- Facet Catalog Contract: passed.
- API Client Follow-ups Contract: passed.
- Narrative Primitives Contract: passed.
- Storymaker Studio Contract: passed.
- Storymaker Branch State Contract: passed.
- Storymaker Session Library Contract: passed.
- Taskmaster Checkpoint Engine Contract: passed.
- Narrative Art Persistence Contract: passed.
- Exact-head Vercel deployment for `0c15903`: READY.
- `/storymaker` returned HTTP 200 and mounted the new Storymaker library shell around the existing studio.
- `/taskmaster` returned HTTP 200 on the same deployment and remained unchanged.
- The PR contains exactly five intended files and no temporary migration machinery.
- No review submissions or unresolved review threads are present.
- Protected-preview interactive Chromium remains unavailable from this execution environment, so deployment/SSR and focused contracts are recorded without claiming a full local-storage click-through test.

Supersedes the unmerged migration attempt in #1117.
Tracks #1073.