### PR TITLE
Expand narrative art to selective milestones

### DIFF
--- a/.github/workflows/narrative-art-milestone-contract.yml
+++ b/.github/workflows/narrative-art-milestone-contract.yml
@@ -1,0 +1,56 @@
+name: Narrative Art Milestone Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: narrative-art-milestones-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Narrative art milestone classifier
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Verify milestone classifier
+        run: npx tsx utils/scripts/verifyNarrativeArtMilestones.ts
+
+      - name: Verify coordinator boundary
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs')
+          const plugin = fs.readFileSync('plugins/narrative-milestone-art.client.ts', 'utf8')
+          for (const token of [
+            'selectStorymakerArtMilestone',
+            'selectTaskmasterArtMilestone',
+            'seenStoryBeats',
+            'seenTaskBeats',
+            "{ flush: 'post' }",
+            'if (!beat.art) requestStoryArt(beat)',
+            'if (!beat.art) requestTaskArt(beat)',
+          ]) {
+            if (!plugin.includes(token)) throw new Error(`Missing coordinator boundary: ${token}`)
+          }
+          if (plugin.includes('immediate: true')) {
+            throw new Error('Milestone coordinator must not retroactively generate art on restore')
+          }
+          console.log('Narrative milestone coordinator boundary passed.')
+          NODE

--- a/plugins/narrative-milestone-art.client.ts
+++ b/plugins/narrative-milestone-art.client.ts
@@ -1,0 +1,167 @@
+// /plugins/narrative-milestone-art.client.ts
+import { watch } from 'vue'
+import { useNarrativeArtJobs } from '@/composables/useNarrativeArtJobs'
+import {
+  useStorymakerStore,
+  type StorymakerBeat,
+  type StorymakerIngredient,
+} from '@/stores/storymakerStore'
+import {
+  useTaskmasterStore,
+  type TaskmasterBeat,
+  type TaskmasterIngredient,
+} from '@/stores/taskmasterStore'
+import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
+import {
+  selectStorymakerArtMilestone,
+  selectTaskmasterArtMilestone,
+} from '@/utils/narrativeArtMilestones'
+
+const STORYMAKER_STORAGE_KEY = 'storymaker-session'
+const TASKMASTER_STORAGE_KEY = 'taskmaster-session'
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function describeIngredient(
+  ingredient: StorymakerIngredient | TaskmasterIngredient,
+): string {
+  return [ingredient.title, ingredient.description, ingredient.flavorText]
+    .filter(Boolean)
+    .join(' — ')
+}
+
+function persistSession(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // Narrative text remains usable if private browsing or a quota blocks storage.
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  const storyStore = useStorymakerStore()
+  const taskStore = useTaskmasterStore()
+  const artJobs = useNarrativeArtJobs()
+  const seenStoryBeats = new Map<string, Set<string>>()
+  const seenTaskBeats = new Map<string, Set<string>>()
+
+  function updateStoryArt(beatId: string, art: NarrativeArtJobState): void {
+    const active = storyStore.session
+    const beat = active?.beats.find((entry) => entry.id === beatId)
+    if (!active || !beat) return
+    beat.art = art
+    active.updatedAt = nowIso()
+    persistSession(STORYMAKER_STORAGE_KEY, active)
+  }
+
+  function updateTaskArt(beatId: string, art: NarrativeArtJobState): void {
+    const active = taskStore.session
+    const beat = active?.beats.find((entry) => entry.id === beatId)
+    if (!active || !beat) return
+    beat.art = art
+    active.updatedAt = nowIso()
+    persistSession(TASKMASTER_STORAGE_KEY, active)
+  }
+
+  function requestStoryArt(beat: StorymakerBeat): void {
+    const active = storyStore.session
+    if (!active) return
+    const moment = selectStorymakerArtMilestone(active, beat)
+    if (!moment) return
+
+    void artJobs.enqueue(
+      {
+        product: 'storymaker',
+        sessionId: active.id,
+        beatId: beat.id,
+        moment,
+        narrative: beat.narrative,
+        title: active.bible.title,
+        location: active.bible.location
+          ? describeIngredient(active.bible.location)
+          : null,
+        cast: active.bible.cast.map(describeIngredient),
+        facets: active.bible.facets.map(describeIngredient),
+      },
+      (art) => updateStoryArt(beat.id, art),
+    )
+  }
+
+  function requestTaskArt(beat: TaskmasterBeat): void {
+    const active = taskStore.session
+    if (!active) return
+    const moment = selectTaskmasterArtMilestone(active, beat)
+    if (!moment) return
+
+    void artJobs.enqueue(
+      {
+        product: 'taskmaster',
+        sessionId: active.id,
+        beatId: beat.id,
+        moment,
+        narrative: beat.narrative,
+        title: active.seed.taskTitle || 'Taskmaster quest',
+        objective: active.seed.taskTitle,
+        location: active.location ? describeIngredient(active.location) : null,
+        facets: [
+          active.genre ? describeIngredient(active.genre) : '',
+          ...active.seed.vibeTags,
+        ].filter(Boolean),
+      },
+      (art) => updateTaskArt(beat.id, art),
+    )
+  }
+
+  function scanStoryBeats(): void {
+    const active = storyStore.session
+    if (!active) return
+    let seen = seenStoryBeats.get(active.id)
+    if (!seen) {
+      seen = new Set(active.beats.map((beat) => beat.id))
+      seenStoryBeats.set(active.id, seen)
+      return
+    }
+
+    for (const beat of active.beats) {
+      if (seen.has(beat.id)) continue
+      seen.add(beat.id)
+      if (!beat.art) requestStoryArt(beat)
+    }
+  }
+
+  function scanTaskBeats(): void {
+    const active = taskStore.session
+    if (!active) return
+    let seen = seenTaskBeats.get(active.id)
+    if (!seen) {
+      seen = new Set(active.beats.map((beat) => beat.id))
+      seenTaskBeats.set(active.id, seen)
+      return
+    }
+
+    for (const beat of active.beats) {
+      if (seen.has(beat.id)) continue
+      seen.add(beat.id)
+      if (!beat.art) requestTaskArt(beat)
+    }
+  }
+
+  watch(
+    () =>
+      `${storyStore.session?.id || ''}:${storyStore.session?.beats
+        .map((beat) => beat.id)
+        .join(',') || ''}`,
+    scanStoryBeats,
+    { flush: 'post' },
+  )
+  watch(
+    () =>
+      `${taskStore.session?.id || ''}:${taskStore.session?.beats
+        .map((beat) => beat.id)
+        .join(',') || ''}`,
+    scanTaskBeats,
+    { flush: 'post' },
+  )
+})

--- a/utils/narrativeArtMilestones.ts
+++ b/utils/narrativeArtMilestones.ts
@@ -1,0 +1,151 @@
+// /utils/narrativeArtMilestones.ts
+import type {
+  StorymakerBeat,
+  StorymakerSession,
+  StorymakerStateDelta,
+} from '@/stores/storymakerStore'
+import type {
+  TaskmasterBeat,
+  TaskmasterCheckpointStatus,
+  TaskmasterSession,
+} from '@/stores/taskmasterStore'
+import type { NarrativeArtMoment } from '@/utils/narrativeArtProfiles'
+
+export const STORYMAKER_INTERMEDIATE_ART_LIMIT = 2
+export const TASKMASTER_INTERMEDIATE_ART_LIMIT = 1
+export const MIN_BEATS_BETWEEN_ART = 2
+
+const LOCATION_TRANSITION_PATTERN =
+  /\b(arriv(?:e|ed|ing)|enter(?:ed|ing)?|reach(?:ed|ing)?|cross(?:ed|ing)? into|step(?:ped|ping)? into|emerg(?:e|ed|ing) into|descend(?:ed|ing)? into|climb(?:ed|ing)? into)\b/i
+
+function hasMeaningfulStateDelta(delta: StorymakerStateDelta): boolean {
+  return Boolean(
+    delta.consequences.length ||
+      delta.relationshipShifts.length ||
+      delta.inventoryAdd.length ||
+      delta.inventoryRemove.length,
+  )
+}
+
+function intermediateArtCount(beats: { art?: { moment: NarrativeArtMoment } }[]): number {
+  return beats.filter(
+    (beat) =>
+      beat.art && beat.art.moment !== 'opening' && beat.art.moment !== 'finale',
+  ).length
+}
+
+function lastIllustratedBeatIndex(
+  beats: { art?: { moment: NarrativeArtMoment } }[],
+  beforeIndex: number,
+): number {
+  for (let index = Math.min(beforeIndex - 1, beats.length - 1); index >= 0; index--) {
+    if (beats[index]?.art) return index
+  }
+  return -1
+}
+
+function hasArtCooldown(
+  beats: { art?: { moment: NarrativeArtMoment } }[],
+  beatIndex: number,
+): boolean {
+  const lastIndex = lastIllustratedBeatIndex(beats, beatIndex)
+  return lastIndex < 0 || beatIndex - lastIndex >= MIN_BEATS_BETWEEN_ART
+}
+
+function normalizedText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function newlyIntroducedCast(
+  session: StorymakerSession,
+  beat: StorymakerBeat,
+  beatIndex: number,
+): boolean {
+  const current = normalizedText(beat.narrative)
+  const previous = normalizedText(
+    session.beats
+      .slice(0, beatIndex)
+      .map((entry) => entry.narrative)
+      .join(' '),
+  )
+
+  return session.bible.cast.some((member) => {
+    const title = normalizedText(member.title)
+    return title.length >= 3 && current.includes(title) && !previous.includes(title)
+  })
+}
+
+function storyChapterBoundary(session: StorymakerSession, beatIndex: number): boolean {
+  const sceneNumber = beatIndex + 1
+  if (session.bible.structure === 'chaptered') return sceneNumber >= 4 && sceneNumber % 3 === 1
+  if (session.bible.structure === 'episodic') return sceneNumber >= 5 && sceneNumber % 4 === 1
+  return false
+}
+
+export function selectStorymakerArtMilestone(
+  session: StorymakerSession,
+  beat: StorymakerBeat,
+): NarrativeArtMoment | null {
+  if (beat.art || session.status !== 'active') return null
+  const beatIndex = session.beats.findIndex((entry) => entry.id === beat.id)
+  if (beatIndex <= 0) return null
+  if (intermediateArtCount(session.beats) >= STORYMAKER_INTERMEDIATE_ART_LIMIT) {
+    return null
+  }
+  if (!hasArtCooldown(session.beats, beatIndex)) return null
+
+  if (hasMeaningfulStateDelta(beat.stateDelta)) return 'pivotal-event'
+  if (newlyIntroducedCast(session, beat, beatIndex)) return 'character-introduction'
+  if (storyChapterBoundary(session, beatIndex)) return 'chapter'
+  if (LOCATION_TRANSITION_PATTERN.test(beat.narrative)) return 'location'
+  return null
+}
+
+function isDifficultCheckpointOutcome(
+  status: TaskmasterCheckpointStatus | undefined,
+): boolean {
+  return status === 'blocked' || status === 'needs-info'
+}
+
+export function selectTaskmasterArtMilestone(
+  session: TaskmasterSession,
+  beat: TaskmasterBeat,
+): NarrativeArtMoment | null {
+  if (beat.art || session.status !== 'active') return null
+  const beatIndex = session.beats.findIndex((entry) => entry.id === beat.id)
+  if (beatIndex <= 0) return null
+  if (intermediateArtCount(session.beats) >= TASKMASTER_INTERMEDIATE_ART_LIMIT) {
+    return null
+  }
+  if (!hasArtCooldown(session.beats, beatIndex)) return null
+
+  const previousBeat = session.beats[beatIndex - 1]
+  const previousCheckpoint = previousBeat?.question.checkpointId
+    ? session.checkpoints.find(
+        (checkpoint) => checkpoint.id === previousBeat.question.checkpointId,
+      )
+    : null
+  if (isDifficultCheckpointOutcome(previousCheckpoint?.status)) {
+    return 'pivotal-event'
+  }
+
+  const previousCheckpointId = previousBeat?.question.checkpointId
+  const currentCheckpointId = beat.question.checkpointId
+  if (
+    beatIndex >= 2 &&
+    previousCheckpointId &&
+    currentCheckpointId &&
+    previousCheckpointId !== currentCheckpointId
+  ) {
+    return 'chapter'
+  }
+
+  if (session.location && LOCATION_TRANSITION_PATTERN.test(beat.narrative)) {
+    return 'location'
+  }
+  return null
+}

--- a/utils/scripts/verifyNarrativeArtMilestones.ts
+++ b/utils/scripts/verifyNarrativeArtMilestones.ts
@@ -1,0 +1,251 @@
+// /utils/scripts/verifyNarrativeArtMilestones.ts
+import assert from 'node:assert/strict'
+import type {
+  StorymakerBeat,
+  StorymakerSession,
+  StorymakerStateDelta,
+} from '../../stores/storymakerStore'
+import type {
+  TaskmasterBeat,
+  TaskmasterCheckpoint,
+  TaskmasterSession,
+} from '../../stores/taskmasterStore'
+import {
+  MIN_BEATS_BETWEEN_ART,
+  STORYMAKER_INTERMEDIATE_ART_LIMIT,
+  TASKMASTER_INTERMEDIATE_ART_LIMIT,
+  selectStorymakerArtMilestone,
+  selectTaskmasterArtMilestone,
+} from '../narrativeArtMilestones'
+
+const emptyDelta = (): StorymakerStateDelta => ({
+  consequences: [],
+  relationshipShifts: [],
+  inventoryAdd: [],
+  inventoryRemove: [],
+})
+
+function storyBeat(
+  id: string,
+  narrative: string,
+  options: {
+    artMoment?: 'opening' | 'chapter' | 'location' | 'character-introduction' | 'pivotal-event' | 'finale'
+    delta?: StorymakerStateDelta
+  } = {},
+): StorymakerBeat {
+  return {
+    id,
+    sessionId: 'story-session',
+    narrative,
+    question: 'What now?',
+    stateDelta: options.delta ?? emptyDelta(),
+    art: options.artMoment
+      ? ({ moment: options.artMoment } as StorymakerBeat['art'])
+      : undefined,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+function storySession(beats: StorymakerBeat[]): StorymakerSession {
+  return {
+    id: 'story-session',
+    userId: 1,
+    bible: {
+      title: 'Milestone Test',
+      premise: 'A careful test of selective illustrations.',
+      narratorStyle: 'cinematic',
+      structure: 'chaptered',
+      cast: [{ slug: 'mara-vale', title: 'Mara Vale' }],
+      facets: [],
+      rewards: [],
+      createdAt: new Date().toISOString(),
+    },
+    beats,
+    branchHistory: [],
+    consequences: [],
+    inventory: [],
+    stateVersion: 1,
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+const opening = storyBeat('s0', 'The story opens.', { artMoment: 'opening' })
+const quiet = storyBeat('s1', 'The path continues without a major turn.')
+const pivotal = storyBeat('s2', 'The bridge collapses behind them.', {
+  delta: {
+    ...emptyDelta(),
+    consequences: ['The bridge is gone.'],
+  },
+})
+let story = storySession([opening, quiet, pivotal])
+assert.equal(
+  selectStorymakerArtMilestone(story, pivotal),
+  'pivotal-event',
+  'A state-changing beat should qualify after the cooldown',
+)
+
+const tooSoon = storyBeat('s1b', 'A consequence arrives immediately.', {
+  delta: { ...emptyDelta(), consequences: ['Too soon.'] },
+})
+story = storySession([opening, tooSoon])
+assert.equal(
+  selectStorymakerArtMilestone(story, tooSoon),
+  null,
+  'Opening art must enforce the minimum beat cooldown',
+)
+
+const castIntro = storyBeat('s2c', 'Mara Vale steps from the smoke and raises a lantern.')
+story = storySession([opening, quiet, castIntro])
+assert.equal(
+  selectStorymakerArtMilestone(story, castIntro),
+  'character-introduction',
+  'A selected cast member appearing for the first time should qualify',
+)
+
+const chapterBeat = storyBeat('s3', 'A new chapter begins beneath a colder moon.')
+story = storySession([
+  opening,
+  quiet,
+  storyBeat('s2q', 'The road bends.'),
+  chapterBeat,
+])
+assert.equal(
+  selectStorymakerArtMilestone(story, chapterBeat),
+  'chapter',
+  'A deterministic chapter boundary should qualify',
+)
+
+const locationBeat = storyBeat('s2l', 'They enter the observatory beyond the ridge.')
+story = storySession([opening, quiet, locationBeat])
+assert.equal(
+  selectStorymakerArtMilestone(story, locationBeat),
+  'location',
+  'A clear location transition should qualify when no stronger event applies',
+)
+
+const capped = storyBeat('s5', 'Another bridge falls.', {
+  delta: { ...emptyDelta(), consequences: ['A third pivot.'] },
+})
+story = storySession([
+  opening,
+  quiet,
+  storyBeat('s2a', 'First pivot.', { artMoment: 'pivotal-event' }),
+  storyBeat('s3q', 'A quiet interval.'),
+  storyBeat('s4a', 'Second pivot.', { artMoment: 'chapter' }),
+  capped,
+])
+assert.equal(
+  selectStorymakerArtMilestone(story, capped),
+  null,
+  'Storymaker must respect its intermediate-art limit',
+)
+assert.equal(STORYMAKER_INTERMEDIATE_ART_LIMIT, 2)
+assert.equal(MIN_BEATS_BETWEEN_ART, 2)
+
+function checkpoint(
+  id: string,
+  status: TaskmasterCheckpoint['status'],
+): TaskmasterCheckpoint {
+  return {
+    id,
+    title: `Checkpoint ${id}`,
+    sourceKind: 'direct-task',
+    status,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+function taskBeat(
+  id: string,
+  checkpointId: string,
+  options: { artMoment?: 'opening' | 'chapter' | 'location' | 'pivotal-event' | 'finale' } = {},
+): TaskmasterBeat {
+  return {
+    id,
+    sessionId: 'task-session',
+    narrative: 'The practical quest continues.',
+    question: {
+      prompt: 'What happened?',
+      realWorldKind: 'direct-task',
+      checkpointId,
+    },
+    art: options.artMoment
+      ? ({ moment: options.artMoment } as TaskmasterBeat['art'])
+      : undefined,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+function taskSession(
+  beats: TaskmasterBeat[],
+  checkpoints: TaskmasterCheckpoint[],
+): TaskmasterSession {
+  return {
+    id: 'task-session',
+    userId: 1,
+    seed: {
+      userId: 1,
+      taskTitle: 'Finish the practical test',
+      vibeTags: [],
+      tone: 'adventurous',
+      surprise: false,
+    },
+    checkpoints,
+    beats,
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+const taskOpening = taskBeat('t0', 'cp1', { artMoment: 'opening' })
+const taskMiddle = taskBeat('t1', 'cp1')
+const blockedTurn = taskBeat('t2', 'cp2')
+let task = taskSession(
+  [taskOpening, taskMiddle, blockedTurn],
+  [checkpoint('cp1', 'blocked'), checkpoint('cp2', 'active')],
+)
+assert.equal(
+  selectTaskmasterArtMilestone(task, blockedTurn),
+  'pivotal-event',
+  'A blocked prior checkpoint should create the one Taskmaster pivot image',
+)
+
+const chapterTurn = taskBeat('t2c', 'cp2')
+task = taskSession(
+  [taskOpening, taskMiddle, chapterTurn],
+  [checkpoint('cp1', 'completed'), checkpoint('cp2', 'active')],
+)
+assert.equal(
+  selectTaskmasterArtMilestone(task, chapterTurn),
+  'chapter',
+  'A new checkpoint after the cooldown should create a chapter image',
+)
+
+const taskCapped = taskBeat('t4', 'cp3')
+task = taskSession(
+  [
+    taskOpening,
+    taskMiddle,
+    taskBeat('t2a', 'cp2', { artMoment: 'chapter' }),
+    taskBeat('t3', 'cp2'),
+    taskCapped,
+  ],
+  [
+    checkpoint('cp1', 'completed'),
+    checkpoint('cp2', 'completed'),
+    checkpoint('cp3', 'active'),
+  ],
+)
+assert.equal(
+  selectTaskmasterArtMilestone(task, taskCapped),
+  null,
+  'Taskmaster must respect its single intermediate-art limit',
+)
+assert.equal(TASKMASTER_INTERMEDIATE_ART_LIMIT, 1)
+
+console.log(
+  'Narrative art milestone classifier passed: deterministic evidence, cooldowns, and hard product limits are enforced.',
+)


### PR DESCRIPTION
## What changed

- Add a deterministic milestone classifier shared by Storymaker and Taskmaster.
- Keep opening and finale behavior unchanged.
- Allow Storymaker up to two intermediate illustrations and Taskmaster up to one.
- Require at least two beats between illustrations.
- Classify Storymaker state-changing consequences as pivotal events.
- Detect first appearances of selected cast members, deterministic chapter boundaries, and explicit location transitions.
- Classify blocked or needs-information Taskmaster outcomes as pivotal events and new checkpoint transitions as chapter moments.
- Add a client-only coordinator that watches only newly added beats and never retroactively generates art when restoring an older session.
- Reuse the existing durable narrative ArtJob queue, dedupe, persistence, retry, and transcript rendering paths.
- Add executable classifier coverage and a coordinator boundary check.

## Boundaries

- No Storymaker or Taskmaster store rewrite.
- No generated image for every beat.
- No retroactive generation on session restore or direct-open.
- Existing `beat.art` state remains the sole per-beat generation/deduplication guard.
- Failed artwork never blocks narrative progress.

## Verification

- TypeScript Type Check: passed.
- Contract Tests: passed.
- Facet Catalog Contract: passed.
- Narrative Primitives Contract: passed.
- Storymaker Studio Contract: passed.
- Storymaker Branch State Contract: passed.
- Storymaker Session Library Contract: passed.
- Taskmaster Checkpoint Engine Contract: passed.
- Narrative Art Persistence Contract: passed.
- Narrative Art Milestone Contract: passed, including executable classifier tests for evidence ordering, cooldowns, caps, and restore safety.
- Exact-head Vercel deployment for `9a8b03c`: READY.
- `/storymaker` and `/taskmaster` both returned HTTP 200 on the exact deployment.
- The PR contains exactly four additive files and no product-store rewrites.
- No review submissions or unresolved review threads are present.
- Protected-preview interactive Chromium remains unavailable from this execution environment, so deployment/SSR and executable classifier verification are recorded without claiming a real image-generation click-through.

Tracks #1073.