### PR TITLE
media-watchlist/t-016: extend MEDIA_TYPE_CHIPS to cover all 12 MediaType values

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -423,13 +423,32 @@ type MediaEntryStatsResponse = {
   data: MediaEntryStats
 }
 
-const MEDIA_TYPE_CHIPS: { value: MediaType; label: string }[] = [
-  { value: 'MOVIE', label: 'Movies' },
-  { value: 'TV', label: 'TV' },
-  { value: 'BOOK', label: 'Books' },
-  { value: 'COMIC', label: 'Comics' },
-  { value: 'AUDIOBOOK', label: 'Audiobooks' },
-  { value: 'VIDEO_GAME', label: 'Games' },
+// media-watchlist/t-016: every chip's `group` is the full set of MediaType
+// values it filters for, so all 12 enum values are reachable from the Browse
+// filters -- not just the 6 that get their own chip. Grouping mirrors the
+// icon-sibling judgment calls in MEDIA_TYPE_ICON below (NOVELLA -> Books,
+// ANIME -> TV, PODCAST -> Audiobooks, SHORT -> Movies, VIDEO_GAME_SHORT ->
+// Games); THEATRE gets its own chip since it has no icon sibling.
+const MEDIA_TYPE_CHIPS: {
+  value: MediaType
+  label: string
+  group: MediaType[]
+}[] = [
+  { value: 'MOVIE', label: 'Movies', group: ['MOVIE', 'SHORT'] },
+  { value: 'TV', label: 'TV', group: ['TV', 'ANIME'] },
+  { value: 'BOOK', label: 'Books', group: ['BOOK', 'NOVELLA'] },
+  { value: 'COMIC', label: 'Comics', group: ['COMIC'] },
+  {
+    value: 'AUDIOBOOK',
+    label: 'Audiobooks',
+    group: ['AUDIOBOOK', 'PODCAST'],
+  },
+  {
+    value: 'VIDEO_GAME',
+    label: 'Games',
+    group: ['VIDEO_GAME', 'VIDEO_GAME_SHORT'],
+  },
+  { value: 'THEATRE', label: 'Theatre', group: ['THEATRE'] },
 ]
 
 // Recent-entries grouping (media-watchlist/t-015, BROWSE-UX.md §1). Covers
@@ -550,6 +569,22 @@ function toggleType(type: MediaType) {
   activeTypes.value = next
 }
 
+// media-watchlist/t-016: activeTypes stores chip values (e.g. 'TV'), but each
+// chip's group can cover more than one MediaType (e.g. TV + ANIME) -- expand
+// before sending to the API so a folded-in sibling type is actually matched.
+const CHIP_GROUP_BY_VALUE = new Map(
+  MEDIA_TYPE_CHIPS.map((chip) => [chip.value, chip.group]),
+)
+function expandActiveTypes(active: Set<MediaType>): MediaType[] {
+  const expanded = new Set<MediaType>()
+  for (const value of active) {
+    for (const type of CHIP_GROUP_BY_VALUE.get(value) ?? [value]) {
+      expanded.add(type)
+    }
+  }
+  return Array.from(expanded)
+}
+
 function toggleMonth(month: number) {
   const next = new Set(activeMonths.value)
   if (next.has(month)) next.delete(month)
@@ -604,7 +639,7 @@ async function loadEntries(): Promise<void> {
           search: search.value || undefined,
           year: activeYear.value || undefined,
           mediaType: activeTypes.value.size
-            ? Array.from(activeTypes.value).join(',')
+            ? expandActiveTypes(activeTypes.value).join(',')
             : undefined,
           starred: starredOnly.value ? 'true' : undefined,
           month: activeMonths.value.size
@@ -668,7 +703,7 @@ function exportCsv() {
   if (search.value) params.set('search', search.value)
   if (activeYear.value) params.set('year', String(activeYear.value))
   if (activeTypes.value.size) {
-    params.set('mediaType', Array.from(activeTypes.value).join(','))
+    params.set('mediaType', expandActiveTypes(activeTypes.value).join(','))
   }
   if (starredOnly.value) params.set('starred', 'true')
   if (activeMonths.value.size) {


### PR DESCRIPTION
### Task
media-watchlist/t-016: Extend MEDIA_TYPE_CHIPS to cover all 12 MediaType values (or fold the rare 6 into their nearest sibling chip) (kind: software)

### What changed / what I produced
- Kaizen follow-up from t-015 (PR #1115): `MEDIA_TYPE_CHIPS` only covered 6 of the 12 `MediaType` enum values, so 6 stored/visible types (via the new Recent entries list) couldn't be filtered on.
- Each chip in `MEDIA_TYPE_CHIPS` now carries a `group: MediaType[]` — the full set of enum values it filters for. Folded the 5 rare types into their nearest icon sibling (mirroring t-015's `MEDIA_TYPE_ICON` grouping): NOVELLA → Books, ANIME → TV, PODCAST → Audiobooks, SHORT → Movies, VIDEO_GAME_SHORT → Games. THEATRE gets its own new chip since it had no icon sibling in t-015.
- Added `expandActiveTypes()` — expands the toggled chip values (e.g. `TV`) into their full group (`TV, ANIME`) before building the `mediaType` query param, used by both the live filter (`loadEntries`) and CSV export (`exportCsv`).
- No backend/route change — `mediaType` already accepts a comma-separated list.

### How I verified
- `npx eslint` — clean.
- `npx prettier --check` — clean (ran `--write` once to match this repo's formatting for the new multi-line const).
- Full-project `npm run test` (`vue-tsc --noEmit`) — exit 0.
- No local live browser smoke test — same sandbox limitation as t-015 (no reachable `DATABASE_URL`).

### Stakes
reversible

### Flags for Reviewer
- The THEATRE-gets-its-own-chip vs. fold-into-something-else choice was a judgment call (task note left it open) — it has no natural sibling in the existing icon grouping, so a new chip seemed cleaner than forcing an arbitrary fold.
- No live/visual smoke test possible in this sandbox — verified by reading the existing single-value filter pattern and confirming the expansion helper is a pure, type-checked function.

### Kaizen suggestion
None new this cycle — this closes the gap its own predecessor task flagged.

### Notes for reviewer
Conductor task: `projects/media-watchlist/roadmap.yaml` t-016, set to `status: review` this cycle.


---
_Generated by [Claude Code](https://claude.ai/code/session_018YHjhtS5h8QMeeTJjDeCM3)_