### PR TITLE
Finish narrative accessibility and acceptance coverage

### DIFF
--- a/.github/workflows/narrative-accessibility-acceptance.yml
+++ b/.github/workflows/narrative-accessibility-acceptance.yml
@@ -1,0 +1,98 @@
+name: Narrative Accessibility Acceptance
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/narrative-accessibility-acceptance.yml'
+      - 'components/narrative/**'
+      - 'cypress/public/narrative-accessibility.cy.ts'
+      - 'utils/scripts/verifyNarrativeAccessibility.mjs'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/narrative-accessibility-acceptance.yml'
+      - 'components/narrative/**'
+      - 'cypress/public/narrative-accessibility.cy.ts'
+      - 'utils/scripts/verifyNarrativeAccessibility.mjs'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Deployed base URL to verify'
+        required: false
+        default: 'https://kind-robots.vercel.app'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: narrative-accessibility-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  accessibility-contract:
+    name: Narrative accessibility contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify shared accessibility and read-only journey boundary
+        run: node utils/scripts/verifyNarrativeAccessibility.mjs
+
+      - name: Verify public Cypress configuration
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs')
+          const assert = require('node:assert').strict
+          const config = fs.readFileSync('cypress.public.config.ts', 'utf8')
+          assert.match(config, /process\.env\.CYPRESS_BASE_URL/)
+          assert.match(config, /specPattern:\s*'cypress\/public\/\*\*\/\*\.cy\.ts'/)
+          assert.match(config, /supportFile:\s*false/)
+          console.log('Public Cypress configuration boundary passed.')
+          NODE
+
+  deployed-browser:
+    name: Deployed narrative keyboard and resume acceptance
+    if: github.event_name == 'workflow_dispatch'
+    needs: accessibility-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run read-only narrative acceptance
+        uses: cypress-io/github-action@v6
+        with:
+          install: false
+          browser: chrome
+          config-file: cypress.public.config.ts
+          spec: cypress/public/narrative-accessibility.cy.ts
+        env:
+          CYPRESS_BASE_URL: ${{ inputs.base_url || 'https://kind-robots.vercel.app' }}
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: narrative-accessibility-screenshots
+          path: cypress/screenshots
+          if-no-files-found: ignore

--- a/components/narrative/narrative-art-status.vue
+++ b/components/narrative/narrative-art-status.vue
@@ -3,7 +3,11 @@
   <section
     v-if="art"
     class="ml-2 overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm sm:ml-6"
-    :aria-busy="art.status === 'queueing' || art.status === 'queued' || art.status === 'rendering'"
+    :role="isFailure ? 'alert' : 'status'"
+    aria-live="polite"
+    aria-atomic="true"
+    :aria-label="statusMessage"
+    :aria-busy="isBusy"
   >
     <img
       v-if="art.status === 'done' && art.imagePath"
@@ -14,23 +18,18 @@
     />
 
     <div
-      v-else-if="art.status === 'queueing' || art.status === 'queued' || art.status === 'rendering'"
+      v-else-if="isBusy"
       class="flex min-h-28 items-center justify-center gap-3 bg-base-200/50 p-4 text-sm text-base-content/60"
     >
-      <span class="loading loading-spinner loading-sm" />
-      <span>
-        {{
-          art.status === 'rendering'
-            ? 'The scene illustration is rendering…'
-            : art.status === 'queued'
-              ? 'The scene illustration is queued…'
-              : 'Preparing the scene illustration…'
-        }}
-      </span>
+      <span
+        class="loading loading-spinner loading-sm motion-reduce:hidden"
+        aria-hidden="true"
+      />
+      <span>{{ statusMessage }}</span>
     </div>
 
     <div
-      v-else-if="art.status === 'failed' || art.status === 'cancelled'"
+      v-else-if="isFailure"
       class="flex min-h-24 flex-wrap items-center justify-between gap-3 bg-error/5 p-4"
     >
       <div class="min-w-0 flex-1">
@@ -41,16 +40,26 @@
           {{ art.error || 'The story continues without blocking. You can retry this image.' }}
         </p>
       </div>
-      <button type="button" class="btn btn-error btn-outline btn-xs rounded-xl" @click="$emit('retry')">
+      <button
+        type="button"
+        class="btn btn-error btn-outline btn-xs rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-error/70 motion-reduce:transform-none motion-reduce:transition-none"
+        @click="$emit('retry')"
+      >
         Retry image
       </button>
     </div>
 
-    <div v-else class="flex min-h-20 items-center justify-center p-4 text-xs text-base-content/50">
-      Illustration #{{ art.artImageId }} is ready.
+    <div
+      v-else
+      class="flex min-h-20 items-center justify-center p-4 text-xs text-base-content/50"
+    >
+      {{ statusMessage }}
     </div>
 
-    <footer class="flex items-center justify-between gap-2 border-t border-base-300 px-3 py-2 text-[0.68rem] text-base-content/45">
+    <footer
+      class="flex items-center justify-between gap-2 border-t border-base-300 px-3 py-2 text-[0.68rem] text-base-content/45"
+      aria-hidden="true"
+    >
       <span class="capitalize">{{ art.moment.replace(/-/g, ' ') }}</span>
       <span>Automatic story art</span>
     </footer>
@@ -70,7 +79,32 @@ defineEmits<{
   retry: []
 }>()
 
-const altText = computed(
-  () => props.label || `Illustration for this ${props.art?.moment.replace(/-/g, ' ') || 'story'} moment`,
+const isBusy = computed(
+  () =>
+    props.art?.status === 'queueing' ||
+    props.art?.status === 'queued' ||
+    props.art?.status === 'rendering',
 )
+const isFailure = computed(
+  () => props.art?.status === 'failed' || props.art?.status === 'cancelled',
+)
+const altText = computed(
+  () =>
+    props.label ||
+    `Illustration for this ${props.art?.moment.replace(/-/g, ' ') || 'story'} moment`,
+)
+const statusMessage = computed(() => {
+  const art = props.art
+  if (!art) return ''
+  if (art.status === 'rendering') return 'The scene illustration is rendering.'
+  if (art.status === 'queued') return 'The scene illustration is queued.'
+  if (art.status === 'queueing') return 'Preparing the scene illustration.'
+  if (art.status === 'failed') {
+    return art.error || 'The scene illustration failed. The story can continue.'
+  }
+  if (art.status === 'cancelled') return 'The scene illustration was cancelled.'
+  return art.imagePath
+    ? 'The scene illustration is ready.'
+    : `Illustration ${art.artImageId || ''} is ready.`.trim()
+})
 </script>

--- a/components/narrative/narrative-ingredient-card.vue
+++ b/components/narrative/narrative-ingredient-card.vue
@@ -2,7 +2,7 @@
 <template>
   <button
     type="button"
-    class="group relative flex min-h-32 w-full overflow-hidden rounded-2xl border text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50"
+    class="group relative flex min-h-32 w-full overflow-hidden rounded-2xl border text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none"
     :class="
       selected
         ? 'border-secondary bg-secondary/10 ring-1 ring-secondary/40'
@@ -10,17 +10,19 @@
     "
     :aria-pressed="selected"
     :aria-label="`${selected ? 'Selected' : 'Select'} ${item.title}`"
+    :aria-describedby="descriptionId"
     :disabled="disabled"
     @click="emit('select', item.slug)"
   >
     <span
       class="relative flex w-28 shrink-0 items-center justify-center overflow-hidden bg-base-200 sm:w-32"
+      aria-hidden="true"
     >
       <img
         v-if="artwork"
         :src="artwork"
-        :alt="`${item.title} artwork`"
-        class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105"
+        alt=""
+        class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105 motion-reduce:transform-none motion-reduce:transition-none"
       />
       <Icon
         v-else
@@ -44,15 +46,17 @@
           v-if="selected"
           name="kind-icon:check"
           class="mt-0.5 size-4 shrink-0 text-secondary"
+          aria-hidden="true"
         />
       </span>
       <span
         v-if="summary"
+        :id="descriptionId"
         class="line-clamp-3 text-xs leading-relaxed text-base-content/60"
       >
         {{ summary }}
       </span>
-      <span v-else class="text-xs text-base-content/35">
+      <span v-else :id="descriptionId" class="text-xs text-base-content/35">
         Add this ingredient to the narrative.
       </span>
     </span>
@@ -60,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useId } from 'vue'
 import {
   narrativeIngredientArtwork,
   narrativeIngredientSummary,
@@ -83,6 +87,8 @@ const emit = defineEmits<{
   select: [slug: string]
 }>()
 
+const cardId = useId()
+const descriptionId = `${cardId}-description`
 const artwork = computed(() => narrativeIngredientArtwork(props.item))
 const summary = computed(() => narrativeIngredientSummary(props.item))
 </script>

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -1,26 +1,56 @@
 <!-- /components/narrative/narrative-ingredient-multi-picker.vue -->
 <template>
-  <section class="space-y-3">
+  <section
+    class="space-y-3"
+    role="group"
+    :aria-labelledby="headingId"
+    :aria-describedby="describedBy"
+    :aria-busy="loading"
+  >
     <div class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
-        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+        <h3
+          :id="headingId"
+          class="text-xs font-bold uppercase tracking-wide text-base-content/55"
+        >
           {{ label }}
         </h3>
-        <p v-if="helper" class="mt-1 text-xs leading-relaxed text-base-content/45">
+        <p
+          v-if="helper"
+          :id="helperId"
+          class="mt-1 text-xs leading-relaxed text-base-content/45"
+        >
           {{ helper }}
         </p>
       </div>
-      <span v-if="loading" class="loading loading-spinner loading-sm" />
-      <span v-else class="badge badge-ghost badge-sm rounded-xl">
+      <span
+        v-if="loading"
+        class="loading loading-spinner loading-sm motion-reduce:hidden"
+        aria-hidden="true"
+      />
+      <span
+        v-else
+        :id="countId"
+        class="badge badge-ghost badge-sm rounded-xl"
+        aria-live="polite"
+      >
         {{ modelValue.length }} / {{ maxSelections }} selected
       </span>
     </div>
+
+    <p v-if="atLimit" class="sr-only" role="status" aria-live="polite">
+      Maximum selections reached. Remove one selection before choosing another.
+    </p>
 
     <label
       v-if="items.length > initialLimit"
       class="input input-bordered input-sm flex w-full items-center gap-2 rounded-xl bg-base-100"
     >
-      <Icon name="kind-icon:search" class="size-4 text-base-content/45" />
+      <Icon
+        name="kind-icon:search"
+        class="size-4 text-base-content/45"
+        aria-hidden="true"
+      />
       <input
         v-model="query"
         type="search"
@@ -36,19 +66,29 @@
       role="alert"
       class="flex items-start gap-2 rounded-2xl border border-error/30 bg-error/5 p-3 text-xs text-error"
     >
-      <Icon name="kind-icon:alert" class="mt-0.5 size-4 shrink-0" />
+      <Icon
+        name="kind-icon:alert"
+        class="mt-0.5 size-4 shrink-0"
+        aria-hidden="true"
+      />
       <span>{{ error }}</span>
     </div>
 
     <div
       v-else-if="loading"
+      role="status"
       class="flex min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100/60"
     >
-      <span class="loading loading-dots loading-md text-secondary" />
+      <span
+        class="loading loading-dots loading-md text-secondary motion-reduce:hidden"
+        aria-hidden="true"
+      />
+      <span class="sr-only">Loading {{ label.toLowerCase() }}.</span>
     </div>
 
     <div
       v-else-if="!items.length"
+      role="status"
       class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-4 text-center text-xs text-base-content/50"
     >
       {{ emptyState }}
@@ -56,6 +96,7 @@
 
     <p
       v-else-if="query.trim() && !filteredItems.length"
+      role="status"
       class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
     >
       No matching {{ label.toLowerCase() }}.
@@ -78,13 +119,15 @@
     <div v-if="showToggle" class="flex justify-center">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transform-none motion-reduce:transition-none"
         :disabled="disabled"
+        :aria-expanded="expanded"
         @click="expanded = !expanded"
       >
         <Icon
           :name="expanded ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
           class="size-4"
+          aria-hidden="true"
         />
         {{ expanded ? 'Show fewer' : `Show all ${filteredItems.length}` }}
       </button>
@@ -93,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useId, watch } from 'vue'
 import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
 
 const props = withDefaults(
@@ -124,8 +167,17 @@ const emit = defineEmits<{
   'update:modelValue': [value: string[]]
 }>()
 
+const pickerId = useId()
+const headingId = `${pickerId}-heading`
+const helperId = `${pickerId}-helper`
+const countId = `${pickerId}-count`
 const query = ref('')
 const expanded = ref(false)
+
+const atLimit = computed(() => props.modelValue.length >= props.maxSelections)
+const describedBy = computed(() =>
+  [props.helper ? helperId : '', countId].filter(Boolean).join(' '),
+)
 
 const filteredItems = computed(() => {
   const needle = query.value.trim().toLowerCase()

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -1,18 +1,39 @@
 <!-- /components/narrative/narrative-ingredient-picker.vue -->
 <template>
-  <section class="space-y-3">
+  <section
+    class="space-y-3"
+    role="group"
+    :aria-labelledby="headingId"
+    :aria-describedby="helper ? helperId : undefined"
+    :aria-busy="loading"
+  >
     <div class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
-        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+        <h3
+          :id="headingId"
+          class="text-xs font-bold uppercase tracking-wide text-base-content/55"
+        >
           {{ label }}
         </h3>
-        <p v-if="helper" class="mt-1 text-xs leading-relaxed text-base-content/45">
+        <p
+          v-if="helper"
+          :id="helperId"
+          class="mt-1 text-xs leading-relaxed text-base-content/45"
+        >
           {{ helper }}
         </p>
       </div>
-      <span v-if="loading" class="loading loading-spinner loading-sm" />
-      <span v-else class="badge badge-ghost badge-sm rounded-xl">
-        {{ items.length }}
+      <span
+        v-if="loading"
+        class="loading loading-spinner loading-sm motion-reduce:hidden"
+        aria-hidden="true"
+      />
+      <span
+        v-else
+        class="badge badge-ghost badge-sm rounded-xl"
+        aria-live="polite"
+      >
+        {{ items.length }} options
       </span>
     </div>
 
@@ -20,7 +41,11 @@
       v-if="items.length > initialLimit"
       class="input input-bordered input-sm flex w-full items-center gap-2 rounded-xl bg-base-100"
     >
-      <Icon name="kind-icon:search" class="size-4 text-base-content/45" />
+      <Icon
+        name="kind-icon:search"
+        class="size-4 text-base-content/45"
+        aria-hidden="true"
+      />
       <input
         v-model="query"
         type="search"
@@ -33,6 +58,7 @@
 
     <p
       v-if="query.trim() && !filteredItems.length"
+      role="status"
       class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
     >
       No matching {{ label.toLowerCase() }}. Clear the search or leave the
@@ -44,19 +70,29 @@
       role="alert"
       class="flex items-start gap-2 rounded-2xl border border-error/30 bg-error/5 p-3 text-xs text-error"
     >
-      <Icon name="kind-icon:alert" class="mt-0.5 size-4 shrink-0" />
+      <Icon
+        name="kind-icon:alert"
+        class="mt-0.5 size-4 shrink-0"
+        aria-hidden="true"
+      />
       <span>{{ error }}</span>
     </div>
 
     <div
       v-else-if="loading"
+      role="status"
       class="flex min-h-32 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100/60"
     >
-      <span class="loading loading-dots loading-md text-secondary" />
+      <span
+        class="loading loading-dots loading-md text-secondary motion-reduce:hidden"
+        aria-hidden="true"
+      />
+      <span class="sr-only">Loading {{ label.toLowerCase() }}.</span>
     </div>
 
     <div
       v-else-if="!items.length"
+      role="status"
       class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-4 text-center text-xs text-base-content/50"
     >
       {{ emptyState }}
@@ -66,18 +102,21 @@
       <button
         v-if="allowEmpty"
         type="button"
-        class="flex min-h-32 w-full overflow-hidden rounded-2xl border text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50"
+        class="flex min-h-32 w-full overflow-hidden rounded-2xl border text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none"
         :class="
           modelValue === null
             ? 'border-secondary bg-secondary/10 ring-1 ring-secondary/40'
             : 'border-base-300 bg-base-100 hover:border-secondary/40'
         "
         :aria-pressed="modelValue === null"
+        :aria-label="`${modelValue === null ? 'Selected' : 'Select'} ${emptyLabel}`"
+        :aria-describedby="emptyDescriptionId"
         :disabled="disabled"
         @click="select(null)"
       >
         <span
           class="flex w-28 shrink-0 items-center justify-center bg-base-200 sm:w-32"
+          aria-hidden="true"
         >
           <Icon :name="emptyIcon" class="size-8 text-base-content/35" />
         </span>
@@ -90,9 +129,13 @@
               v-if="modelValue === null"
               name="kind-icon:check"
               class="mt-0.5 size-4 shrink-0 text-secondary"
+              aria-hidden="true"
             />
           </span>
-          <span class="text-xs leading-relaxed text-base-content/55">
+          <span
+            :id="emptyDescriptionId"
+            class="text-xs leading-relaxed text-base-content/55"
+          >
             {{ emptyDescription }}
           </span>
         </span>
@@ -111,13 +154,15 @@
     <div v-if="showToggle" class="flex justify-center">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl border border-base-300"
+        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transform-none motion-reduce:transition-none"
         :disabled="disabled"
+        :aria-expanded="expanded"
         @click="expanded = !expanded"
       >
         <Icon
           :name="expanded ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
           class="size-4"
+          aria-hidden="true"
         />
         {{ expanded ? 'Show fewer' : `Show all ${filteredItems.length}` }}
       </button>
@@ -126,7 +171,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useId, watch } from 'vue'
 import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
 
 const props = withDefaults(
@@ -163,6 +208,10 @@ const emit = defineEmits<{
   'update:modelValue': [value: string | null]
 }>()
 
+const pickerId = useId()
+const headingId = `${pickerId}-heading`
+const helperId = `${pickerId}-helper`
+const emptyDescriptionId = `${pickerId}-empty-description`
 const query = ref('')
 const expanded = ref(false)
 

--- a/components/narrative/narrative-response-composer.vue
+++ b/components/narrative/narrative-response-composer.vue
@@ -2,49 +2,70 @@
 <template>
   <form
     class="space-y-2 rounded-2xl border border-base-300 bg-base-200/50 p-3"
+    :aria-busy="loading"
     @submit.prevent="submit()"
   >
-    <div v-if="options.length" class="flex flex-wrap gap-2">
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {{ loading ? 'Generating the next scene.' : 'The response field is ready.' }}
+    </p>
+
+    <fieldset v-if="options.length" class="flex flex-wrap gap-2">
+      <legend class="sr-only">Suggested responses</legend>
       <button
         v-for="option in options"
         :key="option"
         type="button"
-        class="btn btn-sm rounded-xl border border-secondary/30 bg-secondary/10 text-left normal-case hover:border-secondary/60 hover:bg-secondary/20"
+        class="btn btn-sm rounded-xl border border-secondary/30 bg-secondary/10 text-left normal-case hover:border-secondary/60 hover:bg-secondary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transform-none motion-reduce:transition-none"
         :disabled="disabled || loading"
         @click="submit(option)"
       >
         {{ option }}
       </button>
-    </div>
+    </fieldset>
 
     <div class="flex items-end gap-2">
+      <label :for="textareaId" class="sr-only">Your response</label>
       <textarea
+        :id="textareaId"
+        ref="textareaElement"
         :value="modelValue"
         rows="2"
-        class="textarea textarea-bordered min-h-0 w-full flex-1 rounded-xl text-sm leading-relaxed"
+        class="textarea textarea-bordered min-h-0 w-full flex-1 rounded-xl text-sm leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70"
         :placeholder="placeholder"
         :disabled="disabled || loading"
+        :aria-describedby="hint ? hintId : undefined"
         @input="updateValue"
         @keydown.enter.exact.prevent="submit()"
       />
       <button
         type="submit"
-        class="btn btn-secondary rounded-xl"
+        class="btn btn-secondary rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transform-none motion-reduce:transition-none"
         :disabled="disabled || loading || !modelValue.trim()"
+        :aria-label="buttonLabel"
       >
-        <span v-if="loading" class="loading loading-spinner loading-sm" />
-        <Icon v-else :name="icon" class="size-4" />
+        <span
+          v-if="loading"
+          class="loading loading-spinner loading-sm motion-reduce:hidden"
+          aria-hidden="true"
+        />
+        <Icon v-else :name="icon" class="size-4" aria-hidden="true" />
         <span class="hidden sm:inline">{{ buttonLabel }}</span>
       </button>
     </div>
 
-    <p v-if="hint" class="text-[0.7rem] leading-relaxed text-base-content/45">
+    <p
+      v-if="hint"
+      :id="hintId"
+      class="text-[0.7rem] leading-relaxed text-base-content/45"
+    >
       {{ hint }}
     </p>
   </form>
 </template>
 
 <script setup lang="ts">
+import { nextTick, ref, useId, watch } from 'vue'
+
 const props = withDefaults(
   defineProps<{
     modelValue: string
@@ -71,6 +92,21 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
   submit: [value: string]
 }>()
+
+const fieldId = useId()
+const textareaId = `${fieldId}-response`
+const hintId = `${fieldId}-hint`
+const textareaElement = ref<HTMLTextAreaElement | null>(null)
+
+watch(
+  () => [props.loading, props.disabled] as const,
+  async ([loading, disabled], previous) => {
+    const wasLoading = previous?.[0] ?? false
+    if (!wasLoading || loading || disabled) return
+    await nextTick()
+    textareaElement.value?.focus({ preventScroll: true })
+  },
+)
 
 function updateValue(event: Event) {
   emit('update:modelValue', (event.target as HTMLTextAreaElement).value)

--- a/components/narrative/narrative-transcript.vue
+++ b/components/narrative/narrative-transcript.vue
@@ -1,6 +1,14 @@
 <!-- /components/narrative/narrative-transcript.vue -->
 <template>
-  <section class="space-y-3" aria-live="polite" :aria-busy="isStreaming">
+  <section
+    class="space-y-3"
+    :aria-label="label"
+    :aria-busy="isStreaming"
+  >
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {{ statusAnnouncement }}
+    </p>
+
     <div
       v-if="!beats.length && !isStreaming"
       class="rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
@@ -8,7 +16,15 @@
       {{ emptyLabel }}
     </div>
 
-    <article v-for="beat in beats" :key="beat.id" class="space-y-2">
+    <article
+      v-for="(beat, index) in beats"
+      :key="beat.id"
+      class="space-y-2"
+      :aria-labelledby="sceneHeadingId(index)"
+    >
+      <h3 :id="sceneHeadingId(index)" class="sr-only">
+        Scene {{ index + 1 }}
+      </h3>
       <div
         class="whitespace-pre-line rounded-2xl border border-base-300 bg-base-200/60 p-4 text-sm leading-relaxed"
       >
@@ -18,7 +34,7 @@
         v-if="beat.answer?.text"
         class="ml-4 rounded-2xl border border-secondary/30 bg-secondary/10 p-3 text-sm leading-relaxed sm:ml-8"
       >
-        {{ beat.answer.text }}
+        <span class="sr-only">Your response: </span>{{ beat.answer.text }}
       </div>
       <slot name="after-beat" :beat="beat" />
     </article>
@@ -26,10 +42,14 @@
     <div
       v-if="isStreaming"
       class="whitespace-pre-line rounded-2xl border border-dashed border-secondary/40 bg-base-200/40 p-4 text-sm leading-relaxed"
+      aria-hidden="true"
     >
       <template v-if="visibleStreamingText">{{ visibleStreamingText }}</template>
       <span v-else class="flex items-center gap-2 text-base-content/60">
-        <span class="loading loading-dots loading-sm" />
+        <span
+          class="loading loading-dots loading-sm motion-reduce:hidden"
+          aria-hidden="true"
+        />
         {{ streamingLabel }}
       </span>
     </div>
@@ -37,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useId } from 'vue'
 import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
 
 const props = withDefaults(
@@ -52,14 +72,18 @@ const props = withDefaults(
     streamingText?: string
     streamingLabel?: string
     emptyLabel?: string
+    label?: string
   }>(),
   {
     isStreaming: false,
     streamingText: '',
     streamingLabel: 'The narrator is building the next scene…',
     emptyLabel: 'The story will appear here once it begins.',
+    label: 'Story transcript',
   },
 )
+
+const transcriptId = useId()
 
 const visibleStreamingText = computed(() => {
   const text = props.streamingText
@@ -74,4 +98,16 @@ const visibleStreamingText = computed(() => {
   }
   return text
 })
+
+const statusAnnouncement = computed(() => {
+  if (props.isStreaming) return props.streamingLabel
+  if (props.beats.length) {
+    return `Scene ${props.beats.length} is ready. Continue to the response field when you are ready.`
+  }
+  return props.emptyLabel
+})
+
+function sceneHeadingId(index: number): string {
+  return `${transcriptId}-scene-${index + 1}`
+}
 </script>

--- a/cypress/public/narrative-accessibility.cy.ts
+++ b/cypress/public/narrative-accessibility.cy.ts
@@ -1,0 +1,218 @@
+/// <reference types="cypress" />
+
+type Viewport = {
+  name: string
+  width: number
+  height: number
+}
+
+const viewports: Viewport[] = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 390, height: 844 },
+]
+
+const timestamp = '2026-07-28T20:00:00.000Z'
+
+const storyOne = {
+  id: 'story-accessibility-one',
+  userId: null,
+  bible: {
+    title: 'The Lantern Archive',
+    premise: 'A librarian follows a lantern into a forgotten wing.',
+    narratorStyle: 'cinematic',
+    structure: 'chaptered',
+    cast: [],
+    facets: [],
+    rewards: [],
+    createdAt: timestamp,
+  },
+  beats: [
+    {
+      id: 'story-beat-one',
+      sessionId: 'story-accessibility-one',
+      narrative:
+        'The lantern pauses before a sealed brass door, warming the old letters carved into its frame.',
+      question: 'Do you open the door or inspect the letters first?',
+      stateDelta: {
+        consequences: [],
+        relationshipShifts: [],
+        inventoryAdd: [],
+        inventoryRemove: [],
+      },
+      createdAt: timestamp,
+    },
+  ],
+  branchHistory: [],
+  consequences: [],
+  inventory: [],
+  stateVersion: 1,
+  status: 'active',
+  createdAt: timestamp,
+  updatedAt: timestamp,
+}
+
+const storyTwo = {
+  ...storyOne,
+  id: 'story-accessibility-two',
+  bible: {
+    ...storyOne.bible,
+    title: 'The Clockwork Orchard',
+    premise: 'A mechanical orchard grows one impossible fruit each night.',
+  },
+  beats: [
+    {
+      ...storyOne.beats[0],
+      id: 'story-beat-two',
+      sessionId: 'story-accessibility-two',
+      narrative:
+        'At midnight, every brass branch turns toward a single silver pear humming in the rain.',
+      question: 'Who should pick the pear?',
+    },
+  ],
+}
+
+const taskSession = {
+  id: 'task-accessibility-one',
+  userId: null,
+  seed: {
+    userId: null,
+    taskTitle: 'Sort the donation boxes',
+    vibeTags: ['warm', 'adventurous'],
+    tone: 'adventurous',
+    surprise: false,
+  },
+  checkpoints: [
+    {
+      id: 'checkpoint-one',
+      title: 'Label the three donation boxes',
+      detail: 'Use keep, donate, and recycle labels.',
+      sourceKind: 'direct-task',
+      status: 'active',
+      updatedAt: timestamp,
+    },
+  ],
+  beats: [
+    {
+      id: 'task-beat-one',
+      sessionId: 'task-accessibility-one',
+      narrative:
+        'Three supply crates wait beneath the guild banner, each ready for an honest label.',
+      question: {
+        prompt: 'What happened when you labeled the boxes?',
+        realWorldKind: 'direct-task',
+        checkpointId: 'checkpoint-one',
+      },
+      createdAt: timestamp,
+    },
+  ],
+  status: 'active',
+  createdAt: timestamp,
+  updatedAt: timestamp,
+}
+
+Cypress.on('uncaught:exception', (error) => {
+  if (
+    /ResizeObserver loop completed with undelivered notifications/i.test(
+      error.message,
+    )
+  ) {
+    return false
+  }
+})
+
+function expectNoHorizontalOverflow(): void {
+  cy.document().then((document) => {
+    const root = document.documentElement
+    expect(
+      root.scrollWidth,
+      `document width ${root.scrollWidth}px at ${root.clientWidth}px viewport`,
+    ).to.be.at.most(root.clientWidth + 2)
+  })
+}
+
+function preloadStorymaker(window: Window): void {
+  window.localStorage.setItem('storymaker-session', JSON.stringify(storyOne))
+  window.localStorage.setItem(
+    'storymaker-session-library-v1',
+    JSON.stringify([storyOne, storyTwo]),
+  )
+}
+
+function preloadTaskmaster(window: Window): void {
+  window.localStorage.setItem('taskmaster-session', JSON.stringify(taskSession))
+}
+
+function expectAccessibleTranscript(): void {
+  cy.get('section[aria-label="Story transcript"]', { timeout: 30_000 })
+    .should('exist')
+    .and('have.attr', 'aria-busy')
+  cy.get('section[aria-label="Story transcript"] [role="status"]')
+    .should('have.attr', 'aria-live', 'polite')
+    .and('have.attr', 'aria-atomic', 'true')
+  cy.get('article[aria-labelledby]').first().should('exist')
+  cy.get('article[aria-labelledby] h3.sr-only').first().should('contain.text', 'Scene 1')
+}
+
+describe('Narrative accessibility and resume acceptance', () => {
+  for (const viewport of viewports) {
+    it(`resumes Storymaker with labeled transcript and response controls on ${viewport.name}`, () => {
+      cy.viewport(viewport.width, viewport.height)
+      cy.visit('/storymaker', { onBeforeLoad: preloadStorymaker })
+
+      cy.contains('The lantern pauses before a sealed brass door', {
+        timeout: 30_000,
+      }).should('be.visible')
+      expectAccessibleTranscript()
+
+      cy.get('label.sr-only').contains('Your response').should('exist')
+      cy.get('textarea')
+        .should('not.be.disabled')
+        .and('have.attr', 'aria-describedby')
+        .focus()
+        .should('have.focus')
+      cy.get('button[aria-label="Continue"]').should('be.disabled')
+      cy.get('.motion-reduce\\:transition-none').should('exist')
+      expectNoHorizontalOverflow()
+    })
+  }
+
+  it('opens a saved Storymaker branch directly from the URL', () => {
+    cy.viewport(1280, 800)
+    cy.visit('/storymaker?story=story-accessibility-two', {
+      onBeforeLoad: preloadStorymaker,
+    })
+
+    cy.contains('At midnight, every brass branch turns toward a single silver pear', {
+      timeout: 30_000,
+    }).should('be.visible')
+    cy.url().should('include', 'story=story-accessibility-two')
+    cy.contains('button', 'Recent stories').click()
+    cy.contains('The Clockwork Orchard').should('be.visible')
+    cy.contains('The Lantern Archive').should('be.visible')
+    expectNoHorizontalOverflow()
+  })
+
+  for (const viewport of viewports) {
+    it(`shows Taskmaster checkpoint outcomes and accessible response controls on ${viewport.name}`, () => {
+      cy.viewport(viewport.width, viewport.height)
+      cy.visit('/taskmaster', { onBeforeLoad: preloadTaskmaster })
+
+      cy.contains('Current action: Label the three donation boxes', {
+        timeout: 30_000,
+      }).should('be.visible')
+      cy.contains('Three supply crates wait beneath the guild banner').should(
+        'be.visible',
+      )
+      expectAccessibleTranscript()
+
+      cy.contains('What happened in the real world?').should('be.visible')
+      cy.contains('button', 'Blocked')
+        .should('have.attr', 'aria-pressed', 'false')
+        .click()
+        .should('have.attr', 'aria-pressed', 'true')
+      cy.get('label.sr-only').contains('Your response').should('exist')
+      cy.get('textarea').should('not.be.disabled').focus().should('have.focus')
+      expectNoHorizontalOverflow()
+    })
+  }
+})

--- a/utils/scripts/verifyNarrativeAccessibility.mjs
+++ b/utils/scripts/verifyNarrativeAccessibility.mjs
@@ -1,0 +1,133 @@
+// /utils/scripts/verifyNarrativeAccessibility.mjs
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function source(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+function includesAll(path, values) {
+  const contents = source(path)
+  for (const value of values) {
+    assert.ok(contents.includes(value), `${path} must include ${value}`)
+  }
+}
+
+const transcriptPath = 'components/narrative/narrative-transcript.vue'
+const composerPath = 'components/narrative/narrative-response-composer.vue'
+const cardPath = 'components/narrative/narrative-ingredient-card.vue'
+const pickerPath = 'components/narrative/narrative-ingredient-picker.vue'
+const multiPickerPath =
+  'components/narrative/narrative-ingredient-multi-picker.vue'
+const artStatusPath = 'components/narrative/narrative-art-status.vue'
+const specPath = 'cypress/public/narrative-accessibility.cy.ts'
+
+const transcript = source(transcriptPath)
+const composer = source(composerPath)
+const spec = source(specPath)
+
+includesAll(transcriptPath, [
+  ':aria-label="label"',
+  ':aria-busy="isStreaming"',
+  'role="status" aria-live="polite" aria-atomic="true"',
+  ':aria-labelledby="sceneHeadingId(index)"',
+  'Scene {{ index + 1 }}',
+  '<span class="sr-only">Your response: </span>',
+  'aria-hidden="true"',
+  'statusAnnouncement',
+])
+assert.ok(
+  !transcript.includes(
+    '<section class="space-y-3" aria-live="polite"',
+  ),
+  'The entire streaming transcript must not be a live region',
+)
+assert.ok(
+  transcript.includes('visibleStreamingText') &&
+    transcript.includes("const marker = '[STORY_STATE]'"),
+  'Accessibility work must retain hidden Storymaker state filtering',
+)
+
+includesAll(composerPath, [
+  '<fieldset v-if="options.length"',
+  '<legend class="sr-only">Suggested responses</legend>',
+  '<label :for="textareaId" class="sr-only">Your response</label>',
+  ':aria-describedby="hint ? hintId : undefined"',
+  ':aria-label="buttonLabel"',
+  'textareaElement.value?.focus({ preventScroll: true })',
+  'const wasLoading = previous?.[0] ?? false',
+  'role="status" aria-live="polite" aria-atomic="true"',
+])
+
+for (const path of [cardPath, pickerPath, multiPickerPath, artStatusPath]) {
+  includesAll(path, ['motion-reduce:transition-none'])
+}
+
+includesAll(cardPath, [
+  ':aria-pressed="selected"',
+  ':aria-describedby="descriptionId"',
+  'alt=""',
+  'focus-visible:ring-2',
+])
+includesAll(pickerPath, [
+  'role="group"',
+  ':aria-labelledby="headingId"',
+  ':aria-describedby="helper ? helperId : undefined"',
+  ':aria-expanded="expanded"',
+  'role="alert"',
+  'role="status"',
+])
+includesAll(multiPickerPath, [
+  'role="group"',
+  ':aria-labelledby="headingId"',
+  ':aria-describedby="describedBy"',
+  'Maximum selections reached.',
+  ':aria-expanded="expanded"',
+  'aria-live="polite"',
+])
+includesAll(artStatusPath, [
+  ":role=\"isFailure ? 'alert' : 'status'\"",
+  'aria-live="polite"',
+  'aria-atomic="true"',
+  ':aria-label="statusMessage"',
+  ':aria-busy="isBusy"',
+  'Retry image',
+])
+
+includesAll(specPath, [
+  '/storymaker',
+  '/storymaker?story=story-accessibility-two',
+  '/taskmaster',
+  '1440',
+  '390',
+  'storymaker-session',
+  'storymaker-session-library-v1',
+  'taskmaster-session',
+  'expectAccessibleTranscript',
+  'expectNoHorizontalOverflow',
+  'Current action: Label the three donation boxes',
+  'What happened in the real world?',
+  'aria-pressed',
+  'have.focus',
+])
+
+for (const forbidden of [
+  'cy.request',
+  'cypressSeed',
+  'cypressCleanup',
+  'CYPRESS_API_KEY',
+  'CYPRESS_BETA_ADMIN_TOKEN',
+  "method: 'POST'",
+  "method: 'PATCH'",
+  "method: 'DELETE'",
+]) {
+  assert.ok(
+    !spec.includes(forbidden),
+    `Narrative public acceptance crossed the read-only boundary: ${forbidden}`,
+  )
+}
+
+console.log(
+  'Narrative accessibility contract passed: concise live announcements, labeled controls, focus recovery, reduced motion, and read-only desktop/mobile journeys are present.',
+)


### PR DESCRIPTION
## What changed

- Replace the transcript-wide live region with concise, atomic generation/scene-ready announcements so screen readers do not read every streaming fragment.
- Add explicit transcript labels, per-scene headings, response prefixes, and busy state.
- Add labeled response fields, suggested-response fieldsets, accessible submit names, generation status, and focus recovery after a scene finishes.
- Add labeled single- and multi-select ingredient groups, helper/count descriptions, loading/empty/error statuses, expanded state, and maximum-selection announcements.
- Treat ingredient artwork as decorative within already-labeled buttons and connect card summaries through `aria-describedby`.
- Add alert/status semantics and concise announcements for queued, rendering, completed, failed, and cancelled scene art.
- Add reduced-motion and visible-focus behavior across shared narrative controls.
- Add read-only public Cypress journeys for Storymaker resume/direct-open and Taskmaster checkpoint interaction at desktop and mobile widths.
- Add a dedicated Narrative Accessibility Acceptance workflow: static contract on PRs and an explicit deployed-browser run through the existing public Cypress configuration.

## Boundaries

- No API writes, seeded users, cleanup mutations, or admin credentials in the public browser spec.
- No Storymaker or Taskmaster state-machine changes.
- Streaming prose remains visually available while concise status text handles announcements.
- Existing hidden Storymaker state filtering is preserved.

## Verification

- All 12 pull-request workflow runs passed, including TypeScript, Contract Tests, Narrative Accessibility Acceptance, Storymaker/Taskmaster contracts, and narrative-art persistence/milestone contracts.
- Exact-head Vercel deployment for `a796832e` is READY.
- No review submissions or unresolved review threads are present.
- The public Cypress journey remains read-only and the deployed-browser job remains explicit workflow-dispatch-only; this merge does not claim a live authenticated image-generation click-through.

Tracks #1073.