### PR TITLE
model-builder/t-036: static regression guard for GENERATE_ASSETS-style completion-write races

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -139,6 +139,12 @@ jobs:
       - name: Model Builder link-coverage contract
         run: npm run test:model-builder-link-coverage
 
+      - name: Model Builder completion-gate checker self-test
+        run: npm run test:model-builder-completion-gate-selftest
+
+      - name: Model Builder completion-gate contract
+        run: npm run test:model-builder-completion-gate
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "test:newsfeed-perspective-balance": "tsx utils/scripts/verifyNewsfeedPerspectiveBalance.ts",
     "test:tutorial-channel-resolver": "tsx utils/scripts/verifyTutorialChannelResolver.ts",
     "test:model-builder-link-coverage": "tsx utils/scripts/verifyModelBuilderLinkCoverage.ts",
+    "test:model-builder-completion-gate-selftest": "tsx utils/scripts/verifyModelBuilderCompletionGate.test.ts",
+    "test:model-builder-completion-gate": "tsx utils/scripts/verifyModelBuilderCompletionGate.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -696,6 +696,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     }
   }
 
+  // Same race as finishGenerateAssets, applied to COMMIT: commitItem's POST
+  // can be in flight when an upstream edit reopens an earlier stage, which
+  // marks COMMIT 'stale' via markDownstreamStale. The commit response landing
+  // afterward must not silently overwrite that back to 'approved' — the
+  // record it just wrote reflects the pre-edit fields, so 'stale' (needing
+  // re-review) is the correct outcome, not a false 'approved'.
+  function finishCommit(item: BuildItem, next: StageState): void {
+    if (item.stages.COMMIT.status === 'in-progress') {
+      item.stages.COMMIT = next
+    }
+  }
+
   // Stale-invalidation: editing an upstream stage marks every downstream stage
   // stale (unless still locked). Commit is always downstream of everything.
   function markDownstreamStale(item: BuildItem, fromStage: BuildStageKey): void {
@@ -1199,6 +1211,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
     committingItemSingleton.claim(item.id)
     item.error = null
+    item.stages.COMMIT = { status: 'in-progress' }
     clearStatus()
 
     try {
@@ -1217,10 +1230,10 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       }
 
       const target = response.data?.target ?? null
-      item.stages.COMMIT = {
+      finishCommit(item, {
         status: 'approved',
         note: target ? `Committed → ${target.type} #${target.id}` : 'Committed.',
-      }
+      })
       if (target) {
         item.targetType = target.type
         item.targetId = target.id
@@ -1235,6 +1248,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     } catch (error) {
       handleError(error, 'committing build item')
       item.error = error instanceof Error ? error.message : 'Commit failed.'
+      finishCommit(item, { status: 'ready', note: item.error })
       setStatus('error', item.error)
       return false
     } finally {

--- a/utils/scripts/verifyModelBuilderCompletionGate.test.ts
+++ b/utils/scripts/verifyModelBuilderCompletionGate.test.ts
@@ -1,0 +1,131 @@
+// /utils/scripts/verifyModelBuilderCompletionGate.test.ts
+//
+// Regression test for findUngatedCompletionWrites() in
+// verifyModelBuilderCompletionGate.ts (model-builder/t-036). Exercises the
+// real extraction/scan logic -- not a reimplementation -- against a
+// synthetic store-shaped fixture covering: a gated write via a named helper
+// call, a gated inline guard, an unguarded post-await write (the exact bug
+// class t-029/PR #1114 fixed ad hoc), a pre-await write (never a race, must
+// not be flagged), and a synchronous function with no `await` at all (must
+// not be flagged even though it writes item.stages unconditionally, matching
+// approveStage/rejectStage/reopenStage's real shape).
+import assert from 'node:assert/strict'
+
+import {
+  extractFunctionBodies,
+  findGuardIntervals,
+  findUngatedCompletionWrites,
+} from './verifyModelBuilderCompletionGate.js'
+
+const FIXTURE = `
+  function finishGenerateAssets(item: BuildItem, next: StageState): void {
+    if (item.stages.GENERATE_ASSETS.status === 'in-progress') {
+      item.stages.GENERATE_ASSETS = next
+    }
+  }
+
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item) return false
+
+    if (item.generation !== 'image') {
+      item.stages.GENERATE_ASSETS = { status: 'ready' }
+      return false
+    }
+
+    item.stages.GENERATE_ASSETS = { status: 'in-progress' }
+
+    try {
+      const result = await artStore.generateCurrentArt({ promptString: 'x' })
+      item.artImageId = result.data.id
+      finishGenerateAssets(item, { status: 'ready' })
+      return true
+    } catch (error) {
+      finishGenerateAssets(item, { status: 'ready' })
+      return false
+    }
+  }
+
+  async function commitItemInlineGuard(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item) return false
+    item.stages.COMMIT = { status: 'in-progress' }
+    const response = await performFetch('/x', {})
+    if (item.stages.COMMIT.status === 'in-progress') {
+      item.stages.COMMIT = { status: 'approved' }
+    }
+    return true
+  }
+
+  async function commitItemBuggy(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item) return false
+    const response = await performFetch('/x', {})
+    item.stages.COMMIT = { status: 'approved' }
+    return true
+  }
+`
+
+const functions = extractFunctionBodies(FIXTURE)
+assert.equal(
+  functions.map((f) => f.name).join(','),
+  'finishGenerateAssets,approveStage,generateItemAsset,commitItemInlineGuard,commitItemBuggy',
+  `expected all 5 fixture functions to be extracted in order, got: ${functions
+    .map((f) => f.name)
+    .join(',')}`,
+)
+assert.equal(functions[2]!.isAsync, true)
+assert.equal(functions[1]!.isAsync, false)
+
+const generateAssetsGuards = findGuardIntervals(functions[0]!.body)
+assert.equal(
+  generateAssetsGuards.length,
+  1,
+  "expected finishGenerateAssets' own body to contain exactly one guard interval",
+)
+assert.equal(generateAssetsGuards[0]!.key, 'GENERATE_ASSETS')
+
+const violations = findUngatedCompletionWrites(FIXTURE)
+
+assert.equal(
+  violations.length,
+  1,
+  `expected exactly 1 ungated post-await write, got ${violations.length}: ${JSON.stringify(violations)}`,
+)
+assert.equal(violations[0]!.functionName, 'commitItemBuggy')
+assert.equal(violations[0]!.key, 'COMMIT')
+
+// approveStage writes item.stages unconditionally with no await anywhere in
+// its body -- never a completion-write race, must never be flagged.
+assert.ok(
+  !violations.some((v) => v.functionName === 'approveStage'),
+  'a synchronous function with no await must never be flagged',
+)
+
+// generateItemAsset's early-return write (before its own first await) and
+// its two finishGenerateAssets(...) calls (after the await, but gated via
+// the named-helper idiom) must never be flagged.
+assert.ok(
+  !violations.some((v) => v.functionName === 'generateItemAsset'),
+  'a pre-await write and gated post-await writes via a named helper must never be flagged',
+)
+
+// commitItemInlineGuard's post-await write is gated by its own inline
+// `if (item.stages.COMMIT.status === 'in-progress')` guard -- must clear.
+assert.ok(
+  !violations.some((v) => v.functionName === 'commitItemInlineGuard'),
+  'a post-await write wrapped in an equivalent inline guard must never be flagged',
+)
+
+console.log(
+  'Model Builder completion-gate checker verified: flags an unguarded ' +
+    'post-await stage-status write, clears the named-helper and inline-' +
+    'guard shapes, and never flags a pre-await write or a synchronous ' +
+    'function with no await.',
+)

--- a/utils/scripts/verifyModelBuilderCompletionGate.ts
+++ b/utils/scripts/verifyModelBuilderCompletionGate.ts
@@ -1,0 +1,236 @@
+// /utils/scripts/verifyModelBuilderCompletionGate.ts
+//
+// Regression guard (model-builder/t-036, kaizen from t-029 / kind_robots PR
+// #1114 -- a GENERATE_ASSETS render completion handler unconditionally
+// overwrote the stage status on completion, silently clobbering a concurrent
+// upstream reopen's 'stale' marker; fixed ad hoc with
+// finishGenerateAssets(item, next), which only writes if the stage is still
+// 'in-progress'). This is the third distinct "review/re-review gate silently
+// bypassed" bug class found by manual read-through in modelBuilderStore.ts
+// (after canApproveAssets and the batch-editor stage-approval-gate fixes).
+//
+// This walks every `async function` in modelBuilderStore.ts and flags any
+// direct `item.stages.<KEY> = ...` write that occurs after that function's
+// own first `await` and is not wrapped in an enclosing
+// `if (item.stages.<KEY>.status === '...') { ... }` guard for the SAME key
+// -- the shape finishGenerateAssets/finishCommit both use, whether reached
+// via a named helper call or an inline guard. A write reachable only across
+// an await suspension point can race a concurrent edit that changed the
+// stage's status while the await was pending; an unguarded write silently
+// discards whatever that concurrent edit recorded (e.g. 'stale').
+//
+// Deliberately scoped to modelBuilderStore.ts's own idiom -- guard
+// conditions are matched as literal `item.stages.KEY.status === 'VALUE'`
+// text (dot notation, literal key), mirroring
+// verifyModelBuilderLinkCoverage.ts's preference for explicit regex
+// extraction over a full parser. A dynamic bracket-key write
+// (`item.stages[someVar] = ...`) is out of scope -- none exist in the store
+// today, and this deliberately fails loudly (via extractFunctionBodies not
+// finding a matching function) rather than silently passing if the file's
+// shape changes in ways this script doesn't understand.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+export interface FunctionBody {
+  name: string
+  isAsync: boolean
+  bodyStart: number
+  bodyEnd: number
+  body: string
+}
+
+// Finds every top-level `function NAME(` / `async function NAME(` declared
+// at 2-space indent (this store's setup-function convention) and extracts
+// its body via paren-matching (to skip past a parameter list, which may
+// itself contain `{ ... }` object-type braces) followed by brace-matching
+// from the body's own opening `{`.
+export function extractFunctionBodies(content: string): FunctionBody[] {
+  const functions: FunctionBody[] = []
+  const signaturePattern = /^ {2}(async )?function (\w+)\s*\(/gm
+
+  for (const match of content.matchAll(signaturePattern)) {
+    const isAsync = Boolean(match[1])
+    const name = match[2]!
+    const parenOpen = match.index + match[0].length - 1
+
+    let parenDepth = 0
+    let i = parenOpen
+    for (; i < content.length; i++) {
+      if (content[i] === '(') parenDepth++
+      else if (content[i] === ')') {
+        parenDepth--
+        if (parenDepth === 0) break
+      }
+    }
+    if (parenDepth !== 0) {
+      throw new Error(
+        `Could not find the closing ')' of ${name}'s parameter list -- has ` +
+          "modelBuilderStore.ts's function-declaration shape changed?",
+      )
+    }
+
+    const braceOpen = content.indexOf('{', i)
+    if (braceOpen === -1) {
+      throw new Error(
+        `Could not find the opening '{' of ${name}'s body -- has ` +
+          "modelBuilderStore.ts's function-declaration shape changed?",
+      )
+    }
+
+    let braceDepth = 0
+    let j = braceOpen
+    for (; j < content.length; j++) {
+      if (content[j] === '{') braceDepth++
+      else if (content[j] === '}') {
+        braceDepth--
+        if (braceDepth === 0) break
+      }
+    }
+    if (braceDepth !== 0) {
+      throw new Error(
+        `Could not find the closing '}' of ${name}'s body -- has ` +
+          "modelBuilderStore.ts's function-declaration shape changed?",
+      )
+    }
+
+    functions.push({
+      name,
+      isAsync,
+      bodyStart: braceOpen + 1,
+      bodyEnd: j,
+      body: content.slice(braceOpen + 1, j),
+    })
+  }
+
+  return functions
+}
+
+export interface GuardInterval {
+  key: string
+  start: number
+  end: number
+}
+
+// Every `if (item.stages.KEY.status === 'VALUE') { ... }` block in `body`,
+// as a [start, end) offset interval spanning its own braces -- covers both
+// the named-helper idiom (finishGenerateAssets/finishCommit's own bodies)
+// and an inline guard written directly in an async function.
+export function findGuardIntervals(body: string): GuardInterval[] {
+  const intervals: GuardInterval[] = []
+  const guardPattern = /if \(item\.stages\.(\w+)\.status === '[\w-]+'\) \{/g
+
+  for (const match of body.matchAll(guardPattern)) {
+    const key = match[1]!
+    const braceOpen = match.index + match[0].length - 1
+    let depth = 0
+    let k = braceOpen
+    for (; k < body.length; k++) {
+      if (body[k] === '{') depth++
+      else if (body[k] === '}') {
+        depth--
+        if (depth === 0) break
+      }
+    }
+    if (depth !== 0) {
+      throw new Error(
+        `Unbalanced braces scanning a status guard for '${key}' -- has ` +
+          "modelBuilderStore.ts's guard shape changed?",
+      )
+    }
+    intervals.push({ key, start: braceOpen, end: k })
+  }
+
+  return intervals
+}
+
+export interface UngatedWrite {
+  functionName: string
+  key: string
+  offset: number
+  line: number
+}
+
+// Every `item.stages.KEY = ` write in `fn`'s body that occurs after its own
+// first `await` and falls outside every guard interval for that same key.
+export function findUngatedWritesInFunction(
+  fn: FunctionBody,
+  fullContent: string,
+): UngatedWrite[] {
+  if (!fn.isAsync) return []
+
+  const awaitMatch = /\bawait\b/.exec(fn.body)
+  if (!awaitMatch) return []
+  const afterAwait = awaitMatch.index
+
+  const guards = findGuardIntervals(fn.body)
+  const writePattern = /item\.stages\.(\w+)\s*=(?!=)/g
+  const violations: UngatedWrite[] = []
+
+  for (const match of fn.body.matchAll(writePattern)) {
+    if (match.index < afterAwait) continue
+    const key = match[1]!
+    const gated = guards.some(
+      (g) => g.key === key && match.index >= g.start && match.index < g.end,
+    )
+    if (gated) continue
+
+    const absoluteOffset = fn.bodyStart + match.index
+    const line = fullContent.slice(0, absoluteOffset).split('\n').length
+    violations.push({
+      functionName: fn.name,
+      key,
+      offset: absoluteOffset,
+      line,
+    })
+  }
+
+  return violations
+}
+
+export function findUngatedCompletionWrites(content: string): UngatedWrite[] {
+  const functions = extractFunctionBodies(content)
+  return functions.flatMap((fn) => findUngatedWritesInFunction(fn, content))
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const violations = findUngatedCompletionWrites(content)
+
+  if (violations.length) {
+    console.error(
+      `Model Builder completion-gate contract failed: ${violations.length} ` +
+        'stage-status write(s) in modelBuilderStore.ts happen after an ' +
+        '`await` with no guard against a concurrent status change:',
+    )
+    for (const v of violations) {
+      console.error(
+        `- ${v.functionName}() line ${v.line}: writes item.stages.${v.key} ` +
+          'after an await with no enclosing `if (item.stages.' +
+          `${v.key}.status === '...')\` guard. A concurrent edit that ` +
+          "changed this stage's status while the await was pending (e.g. " +
+          "markDownstreamStale marking it 'stale') would be silently " +
+          'overwritten. Route the write through a gate helper (see ' +
+          'finishGenerateAssets/finishCommit) or wrap it in an equivalent ' +
+          'inline guard.',
+      )
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder completion-gate contract passed: every post-await ' +
+      'item.stages write in modelBuilderStore.ts is guarded against a ' +
+      'concurrent status change.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
conductor model-builder/t-036: Add a lint/regression guard for GENERATE_ASSETS-style completion-write races in modelBuilderStore.ts (kind: software)

### What changed / what I produced
- New `utils/scripts/verifyModelBuilderCompletionGate.ts`: walks every `async function` in `stores/modelBuilderStore.ts`, finds any `item.stages.<KEY> = ...` write occurring after that function's own first `await`, and fails if it isn't wrapped (directly or via a named helper like `finishGenerateAssets`) in an `if (item.stages.<KEY>.status === '...')` guard for the same key — the exact shape that would have caught t-029's original GENERATE_ASSETS bug (PR #1114).
- New `utils/scripts/verifyModelBuilderCompletionGate.test.ts`: self-test exercising the real extraction/scan functions against a synthetic fixture (named-helper gate, inline gate, unguarded write, pre-await write, sync-function-with-no-await), mirroring `verifyCaptureGroupGuards.test.ts`'s pattern.
- Wired both into `package.json` (`test:model-builder-completion-gate[-selftest]`) and `.github/workflows/contract-tests.yml` (two new steps after the existing Model Builder link-coverage contract).
- **Ran the new checker against the store before writing any fix** and it immediately found a real, previously-unfixed instance of the same bug class in `commitItem()`: the `COMMIT` stage write after the commit POST resolves was unconditional, so an upstream edit landing while the request was in flight would silently overwrite a `markDownstreamStale`-set `'stale'` marker back to `'approved'` — even though the just-committed record reflects the pre-edit fields. Fixed by adding `finishCommit` (mirroring `finishGenerateAssets` exactly), marking `COMMIT` `'in-progress'` for the duration of the request, and resetting it via the same gate on failure.

### How I verified
- `npx tsx utils/scripts/verifyModelBuilderCompletionGate.test.ts` — self-test passes.
- `npx tsx utils/scripts/verifyModelBuilderCompletionGate.ts` — contract passes against the fixed store.
- Confirmed the checker is a real regression guard, not vacuous: `git stash` the `commitItem` fix and re-ran the checker directly against the pre-fix file — it correctly flagged exactly the one violation (`commitItem() line 1220`, `COMMIT` key) that this PR fixes.
- `npx eslint` clean on all touched/new files (2 pre-existing `no-empty` errors in `modelBuilderStore.ts` confirmed via `git stash` to predate this change).
- `npx prettier --check` clean on all touched/new files.
- Full-project `vue-tsc --noEmit` — exit 0.
- Confirmed generically-rendered `'in-progress'` stage status (already used for `GENERATE_ASSETS`) requires no UI changes: `model-builder-progress-matrix.vue`'s `statusClass`/`statusIcon` and `model-builder-item-panel.vue`'s equivalent switch on `StageStatus` generically across all stages, and the commit button is already separately guarded by the `committingItemSingleton`-derived `isCommitting`, so adding `'in-progress'` for `COMMIT` doesn't change any existing gating.

### Stakes
reversible

### Flags for Reviewer
- The checker's guard-matching is deliberately scoped to this store's actual idiom (literal `item.stages.KEY.status === 'VALUE'` dot-notation text), not a full parser — same trade-off `verifyModelBuilderLinkCoverage.ts` makes. A dynamic bracket-key write (`item.stages[someVar] = ...`) is out of scope; none exist in the store today.

### Kaizen suggestion
None new this cycle — this task was itself a kaizen from t-029.

### Notes for reviewer
Front-end/test-only change, no schema change, no backend change.

---
_Generated by [Claude Code](https://claude.ai/code/session_012i5DfbkP7vkRL5kuAKeM1W)_