### PR TITLE
model-builder/t-029: guard generateItemAsset's error path against cancelled runs

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1016,6 +1016,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       setStatus('success', `Generated a candidate for ${item.label}.`)
       return true
     } catch (error) {
+      // Mirror the success path's cancelledRunIds guard above: a render that
+      // fails after the user has cancelled this run shouldn't surface a stray
+      // error banner for a run the user no longer has open.
+      if (cancelledRunIds.has(runId)) return false
+
       handleError(error, 'generating model builder asset')
       item.error = error instanceof Error ? error.message : 'Generation failed.'
       finishGenerateAssets(item, { status: 'ready', note: item.error })


### PR DESCRIPTION
## Summary
- `generateItemAsset`'s success path already checks `cancelledRunIds` before persisting a candidate for a run the user has since cancelled, but the `catch` block had no equivalent check.
- A render that rejects (network drop, provider timeout, etc.) after the user cancels its run still called `setStatus('error', ...)` unconditionally, surfacing a stray error banner unrelated to whatever the user is currently looking at.
- Fixed by mirroring the success path's guard: `if (cancelledRunIds.has(runId)) return false` at the top of the `catch` block, before any store-wide side effects.

## Failure scenario
1. User opens run R, selects an item, clicks "Generate candidate" — `generateItemAsset` starts awaiting the render.
2. While in flight, user cancels run R via Run History. This adds `R` to `cancelledRunIds` and returns the user to the source/recipe picker.
3. The awaited render subsequently rejects (a plausible outcome for a long-running call).
4. The `catch` block ran unconditionally, popping a red "Generation failed" banner for a run the user explicitly abandoned and no longer has open.

## Test plan
- [x] `npx eslint stores/modelBuilderStore.ts` — only the 2 pre-existing `no-empty` errors at lines 203/210 (confirmed via `git stash` with/without this diff)
- [x] `npx vue-tsc --noEmit` — exit 0
- [x] `npx prettier --check stores/modelBuilderStore.ts` — drift confirmed pre-existing via `git stash` (same warning with and without this diff)
- [x] `git status --porcelain` — only this one file touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01WcjWLqA3X51X8YybF2FtPT)_