### PR TITLE
Add ready-made Taskmaster sample quests

### DIFF
--- a/.github/workflows/taskmaster-sample-tasks-contract.yml
+++ b/.github/workflows/taskmaster-sample-tasks-contract.yml
@@ -1,0 +1,43 @@
+name: Taskmaster Sample Tasks Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/taskmaster-sample-tasks-contract.yml'
+      - 'components/taskmaster/taskmaster-sample-tasks.vue'
+      - 'content/taskmaster.md'
+      - 'utils/scripts/verifyTaskmasterSampleTasks.mjs'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/taskmaster-sample-tasks-contract.yml'
+      - 'components/taskmaster/taskmaster-sample-tasks.vue'
+      - 'content/taskmaster.md'
+      - 'utils/scripts/verifyTaskmasterSampleTasks.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: taskmaster-sample-tasks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Taskmaster sample-task contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify samples and human-gate boundary
+        run: node utils/scripts/verifyTaskmasterSampleTasks.mjs

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -63,7 +63,7 @@
               v-if="sample.id === 'conductor-gates' && gateProject"
               class="mt-2 block text-[0.68rem] font-bold uppercase tracking-wide text-warning"
             >
-              Starts with {{ gateProject.title }}
+              Starts with {{ gateProject.name }}
             </span>
           </span>
         </span>
@@ -77,7 +77,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useConductorStore } from '@/stores/conductorStore'
 import {
   useTaskmasterStore,
@@ -114,7 +114,7 @@ const sampleTasks: SampleTask[] = [
     id: 'ship-feature',
     task: 'Help me choose the next feature to ship and identify the smallest useful first step.',
     helper: 'Turn an open-ended product decision into a short, concrete sequence.',
-    icon: 'kind-icon:rocket',
+    icon: 'kind-icon:story',
     tone: 'mysterious',
     vibeTags: ['decisive', 'focused', 'small wins'],
   },
@@ -122,7 +122,7 @@ const sampleTasks: SampleTask[] = [
     id: 'reclaim-space',
     task: 'Help me turn the messiest corner of my home into a usable space.',
     helper: 'Break a physical cleanup project into approachable checkpoints.',
-    icon: 'kind-icon:home',
+    icon: 'kind-icon:dream',
     tone: 'cozy',
     vibeTags: ['gentle', 'visible progress', 'no shame'],
   },
@@ -130,14 +130,14 @@ const sampleTasks: SampleTask[] = [
     id: 'hard-conversation',
     task: 'Help me prepare for a conversation I have been putting off.',
     helper: 'Clarify the goal, gather the important facts, and plan the opening words.',
-    icon: 'kind-icon:chat',
+    icon: 'kind-icon:alert',
     tone: 'tender',
     vibeTags: ['honest', 'calm', 'respectful'],
   },
 ]
 
 const gateProject = computed(() => {
-  let best: { slug: string; title: string; gateCount: number } | null = null
+  let best: { slug: string; name: string; gateCount: number } | null = null
 
   for (const project of conductorStore.projects) {
     const gateCount = (project.tasks ?? []).filter(
@@ -148,7 +148,7 @@ const gateProject = computed(() => {
     }
     best = {
       slug: project.slug,
-      title: project.title || project.slug,
+      name: project.name || project.slug,
       gateCount,
     }
   }
@@ -156,13 +156,20 @@ const gateProject = computed(() => {
   return best
 })
 
+async function refreshConductorGates(): Promise<void> {
+  await conductorStore.fetchProjects(true)
+}
+
 async function useSample(sample: SampleTask): Promise<void> {
   if (startingId.value || taskmasterStore.isWeaving) return
 
   startingId.value = sample.id
   errorMessage.value = ''
   try {
-    await taskmasterStore.loadRealSurfaces()
+    await Promise.all([
+      taskmasterStore.loadRealSurfaces(),
+      sample.conductorGates ? refreshConductorGates() : Promise.resolve(),
+    ])
     const projectSlug = sample.conductorGates ? gateProject.value?.slug : undefined
     const prepared = await taskmasterStore.prepareQuest({
       tone: sample.tone,
@@ -185,4 +192,8 @@ async function useSample(sample: SampleTask): Promise<void> {
     startingId.value = null
   }
 }
+
+onMounted(() => {
+  void refreshConductorGates()
+})
 </script>

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -1,0 +1,188 @@
+<!-- /components/taskmaster/taskmaster-sample-tasks.vue -->
+<template>
+  <section
+    v-if="!taskmasterStore.session"
+    class="rounded-2xl border border-secondary/25 bg-secondary/5 p-4"
+    aria-labelledby="taskmaster-samples-heading"
+  >
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-secondary/75">
+          Try a sample task
+        </p>
+        <h2 id="taskmaster-samples-heading" class="mt-1 text-lg font-black">
+          Start with a ready-made quest
+        </h2>
+        <p class="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/55">
+          Pick an example to build a reviewable checkpoint plan. Nothing is applied or
+          marked complete automatically.
+        </p>
+      </div>
+      <span
+        v-if="gateProject"
+        class="badge badge-warning badge-sm rounded-xl"
+      >
+        {{ gateProject.gateCount }} current human
+        {{ gateProject.gateCount === 1 ? 'gate' : 'gates' }}
+      </span>
+    </div>
+
+    <div class="mt-3 grid gap-2 md:grid-cols-2">
+      <button
+        v-for="sample in sampleTasks"
+        :key="sample.id"
+        type="button"
+        class="group rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:border-secondary/50 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-wait disabled:opacity-60 motion-reduce:transform-none motion-reduce:transition-none"
+        :class="
+          sample.id === 'conductor-gates'
+            ? 'border-warning/40 bg-warning/5'
+            : 'border-base-300 bg-base-100'
+        "
+        :disabled="startingId !== null || taskmasterStore.isWeaving"
+        @click="useSample(sample)"
+      >
+        <span class="flex items-start gap-3">
+          <span
+            class="flex size-9 shrink-0 items-center justify-center rounded-xl border border-current/15 bg-base-100/70 text-secondary"
+            aria-hidden="true"
+          >
+            <span
+              v-if="startingId === sample.id"
+              class="loading loading-spinner loading-sm"
+            />
+            <Icon v-else :name="sample.icon" class="size-4" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="block text-sm font-black leading-snug">
+              {{ sample.task }}
+            </span>
+            <span class="mt-1 block text-xs leading-relaxed text-base-content/50">
+              {{ sample.helper }}
+            </span>
+            <span
+              v-if="sample.id === 'conductor-gates' && gateProject"
+              class="mt-2 block text-[0.68rem] font-bold uppercase tracking-wide text-warning"
+            >
+              Starts with {{ gateProject.title }}
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+
+    <p v-if="errorMessage" class="mt-3 text-xs text-error" role="alert">
+      {{ errorMessage }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useConductorStore } from '@/stores/conductorStore'
+import {
+  useTaskmasterStore,
+  type TaskmasterTone,
+} from '@/stores/taskmasterStore'
+
+type SampleTask = {
+  id: string
+  task: string
+  helper: string
+  icon: string
+  tone: TaskmasterTone
+  vibeTags: string[]
+  conductorGates?: boolean
+}
+
+const taskmasterStore = useTaskmasterStore()
+const conductorStore = useConductorStore()
+const startingId = ref<string | null>(null)
+const errorMessage = ref('')
+
+const sampleTasks: SampleTask[] = [
+  {
+    id: 'conductor-gates',
+    task: 'Look at my conductor repo and help me clear any current human gates.',
+    helper:
+      'Loads the current Conductor surface and scopes the checkpoint plan to the project with the most needs-human work.',
+    icon: 'kind-icon:gearhammer',
+    tone: 'adventurous',
+    vibeTags: ['clear-eyed', 'collaborative', 'practical'],
+    conductorGates: true,
+  },
+  {
+    id: 'ship-feature',
+    task: 'Help me choose the next feature to ship and identify the smallest useful first step.',
+    helper: 'Turn an open-ended product decision into a short, concrete sequence.',
+    icon: 'kind-icon:rocket',
+    tone: 'mysterious',
+    vibeTags: ['decisive', 'focused', 'small wins'],
+  },
+  {
+    id: 'reclaim-space',
+    task: 'Help me turn the messiest corner of my home into a usable space.',
+    helper: 'Break a physical cleanup project into approachable checkpoints.',
+    icon: 'kind-icon:home',
+    tone: 'cozy',
+    vibeTags: ['gentle', 'visible progress', 'no shame'],
+  },
+  {
+    id: 'hard-conversation',
+    task: 'Help me prepare for a conversation I have been putting off.',
+    helper: 'Clarify the goal, gather the important facts, and plan the opening words.',
+    icon: 'kind-icon:chat',
+    tone: 'tender',
+    vibeTags: ['honest', 'calm', 'respectful'],
+  },
+]
+
+const gateProject = computed(() => {
+  let best: { slug: string; title: string; gateCount: number } | null = null
+
+  for (const project of conductorStore.projects) {
+    const gateCount = (project.tasks ?? []).filter(
+      (task) => task.status === 'needs-human',
+    ).length
+    if (!project.slug || gateCount === 0 || gateCount <= (best?.gateCount ?? 0)) {
+      continue
+    }
+    best = {
+      slug: project.slug,
+      title: project.title || project.slug,
+      gateCount,
+    }
+  }
+
+  return best
+})
+
+async function useSample(sample: SampleTask): Promise<void> {
+  if (startingId.value || taskmasterStore.isWeaving) return
+
+  startingId.value = sample.id
+  errorMessage.value = ''
+  try {
+    await taskmasterStore.loadRealSurfaces()
+    const projectSlug = sample.conductorGates ? gateProject.value?.slug : undefined
+    const prepared = await taskmasterStore.prepareQuest({
+      tone: sample.tone,
+      taskTitle: sample.task,
+      vibeTags: sample.vibeTags,
+      projectSlug,
+      surprise: false,
+    })
+
+    if (!prepared) {
+      errorMessage.value =
+        'Taskmaster could not build a checkpoint plan for that example. Try entering it in the quest builder below.'
+    }
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error
+        ? error.message
+        : 'Taskmaster could not load that sample quest.'
+  } finally {
+    startingId.value = null
+  }
+}
+</script>

--- a/content/taskmaster.md
+++ b/content/taskmaster.md
@@ -14,4 +14,6 @@ dashboardTab: taskmaster
 cards: navCards
 ---
 
+:taskmaster-sample-tasks
+
 :taskmaster-page

--- a/docs/contracts/taskmaster-sample-tasks.md
+++ b/docs/contracts/taskmaster-sample-tasks.md
@@ -1,0 +1,14 @@
+# Taskmaster Sample Tasks Contract
+
+Taskmaster may offer ready-made task starters before a session exists.
+
+The featured Conductor starter must:
+
+- use the user-facing objective: “Look at my conductor repo and help me clear any current human gates.”
+- refresh the live Conductor surface before selecting a project
+- scope the draft to the project currently carrying the most `needs-human` tasks
+- fall back to the direct objective when no current human gate exists
+- prepare a reviewable checkpoint plan only
+- never start narration, clear a roadmap gate, set human approval, or apply a write-back automatically
+
+Other samples are ordinary direct-task starters and should cover a mix of product decisions, physical chores, and interpersonal preparation.

--- a/utils/scripts/verifyTaskmasterSampleTasks.mjs
+++ b/utils/scripts/verifyTaskmasterSampleTasks.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+const content = fs.readFileSync('content/taskmaster.md', 'utf8')
+const samples = fs.readFileSync(
+  'components/taskmaster/taskmaster-sample-tasks.vue',
+  'utf8',
+)
+
+assert.match(content, /:taskmaster-sample-tasks\s+\n:taskmaster-page/)
+assert.match(
+  samples,
+  /Look at my conductor repo and help me clear any current human gates\./,
+)
+assert.match(samples, /task\.status === 'needs-human'/)
+assert.match(samples, /conductorStore\.fetchProjects\(true\)/)
+assert.match(samples, /projectSlug,/)
+assert.match(samples, /taskmasterStore\.prepareQuest\(/)
+assert.doesNotMatch(samples, /taskmasterStore\.(?:startQuest|beginStory|applyWriteBack)\(/)
+assert.doesNotMatch(samples, /approved_by_human|approvedByHuman/)
+
+const sampleIds = [...samples.matchAll(/id: '([^']+)'/g)].map((match) => match[1])
+assert.deepEqual(sampleIds, [
+  'conductor-gates',
+  'ship-feature',
+  'reclaim-space',
+  'hard-conversation',
+])
+
+console.log('Taskmaster sample-task contract passed.')


### PR DESCRIPTION
## What changed

- Add a compact sample-task panel above the Taskmaster workspace.
- Feature the requested objective: “Look at my conductor repo and help me clear any current human gates.”
- Refresh live Conductor data and scope that starter to the project with the most `needs-human` tasks.
- Fall back to a direct-task checkpoint when no current human gate exists.
- Add three additional starters covering product prioritization, physical cleanup, and a difficult conversation.
- Prepare only a reviewable checkpoint draft; samples never start narration, clear gates, set human approval, or apply write-backs automatically.
- Add a focused contract and contract documentation.

## Verification

- All 12 pull-request workflows passed, including TypeScript, Contract Tests, Taskmaster Checkpoint Engine Contract, and the new Taskmaster Sample Tasks Contract.
- Exact-head Vercel deployment for `2116808d` is READY.
- `/taskmaster` returned HTTP 200 and rendered all four sample cards.
- The live Conductor sample detected one current human gate and scoped the preview draft to Humboldt Scoop CMS.
- No review submissions or unresolved review threads are present.
- Verification covers SSR and contract behavior; it does not claim a browser click-through or automatic clearing of any real gate.

Tracks #1073.