### PR TITLE
alexa-integration/t-015: fix voice relay poll race condition

### DIFF
--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -38,14 +38,21 @@
             type="text"
             placeholder="Serendipity: turn butterflies on"
             class="input input-bordered input-sm min-w-0 flex-1 rounded-xl"
+            :disabled="voice.sending"
           />
           <button
             type="submit"
             class="btn btn-primary btn-sm gap-1.5 rounded-xl"
-            :disabled="!tryText.trim()"
+            :disabled="!tryText.trim() || voice.sending"
           >
-            <Icon name="kind-icon:microphone" class="size-4" />
-            Try it
+            <Icon
+              :name="
+                voice.sending ? 'kind-icon:spinner' : 'kind-icon:microphone'
+              "
+              class="size-4"
+              :class="{ 'animate-spin': voice.sending }"
+            />
+            {{ voice.sending ? 'Sending…' : 'Try it' }}
           </button>
         </form>
 

--- a/stores/serendipityVoiceStore.ts
+++ b/stores/serendipityVoiceStore.ts
@@ -65,6 +65,8 @@ export const useSerendipityVoiceStore = defineStore(
     const relayBaseUrl = ref<string>(DEFAULT_RELAY_URL)
     const connected = ref(false)
     const polling = ref(false)
+    const pollInFlight = ref(false)
+    const sending = ref(false)
     const lastError = ref<string | null>(null)
     const lastAppliedText = ref<string | null>(null)
 
@@ -241,6 +243,12 @@ export const useSerendipityVoiceStore = defineStore(
 
     async function pollOnce(): Promise<void> {
       if (!isClient()) return
+      // Guard against overlap between the interval timer and a manual poll
+      // triggered by sendVoiceText — without this, two in-flight polls can
+      // both read the same cursor, both receive the same command batch, and
+      // both apply it (e.g. double-toggling an effect back off).
+      if (pollInFlight.value) return
+      pollInFlight.value = true
 
       try {
         const [commandsRes, messagesRes] = await Promise.all([
@@ -280,6 +288,8 @@ export const useSerendipityVoiceStore = defineStore(
         connected.value = false
         lastError.value =
           error instanceof Error ? error.message : 'Relay poll failed'
+      } finally {
+        pollInFlight.value = false
       }
     }
 
@@ -303,7 +313,8 @@ export const useSerendipityVoiceStore = defineStore(
     // Simulate an Echo utterance from the page: routes through the same relay
     // dispatcher the Alexa endpoint uses, so testing needs no physical device.
     async function sendVoiceText(text: string): Promise<void> {
-      if (!isClient() || !text.trim()) return
+      if (!isClient() || !text.trim() || sending.value) return
+      sending.value = true
 
       try {
         const response = await fetch(`${relayBaseUrl.value}/api/handle`, {
@@ -316,6 +327,8 @@ export const useSerendipityVoiceStore = defineStore(
         await pollOnce()
       } catch (error) {
         lastError.value = error instanceof Error ? error.message : 'Send failed'
+      } finally {
+        sending.value = false
       }
     }
 
@@ -336,6 +349,7 @@ export const useSerendipityVoiceStore = defineStore(
       relayBaseUrl,
       connected,
       polling,
+      sending,
       lastError,
       lastAppliedText,
       messages,


### PR DESCRIPTION
## Summary
- `serendipityVoiceStore.pollOnce()` had no re-entrancy guard: the interval-driven poll (every 1200ms) and the poll triggered by `sendVoiceText()` (the Voice Lab "Try it" button) could run concurrently, both reading the same `commandCursor`/`messageCursor` and both applying the same batch of commands/messages.
- Concrete failure: a `toggle` animation command applied twice self-cancels (effect flickers on then immediately off again), and duplicate message objects get pushed into the feed with colliding `:key="message.id"` values.
- Fix: added a `pollInFlight` guard around `pollOnce()`, plus a `sending` state around `sendVoiceText()` that disables the Voice Lab "Try it" input/button while a request is in flight (mirrors the pattern of other async-action disables in the app).

## Test plan
- [x] `npx eslint stores/serendipityVoiceStore.ts components/conductor/voice-lab-page.vue` — clean
- [x] `npx prettier --check` on both files — clean
- [x] `npm run test` (`vue-tsc --noEmit`) — exit 0

Conductor task: `alexa-integration/t-015` (Polish and upgrade Voice Lab front-end surface).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpLmpQfbZUm51Yyt8SEruh)_