### PR TITLE
fix(model-builder): guard async art-generation completion against a cancelled run

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "test:model-builder-link-coverage": "tsx utils/scripts/verifyModelBuilderLinkCoverage.ts",
     "test:model-builder-completion-gate-selftest": "tsx utils/scripts/verifyModelBuilderCompletionGate.test.ts",
     "test:model-builder-completion-gate": "tsx utils/scripts/verifyModelBuilderCompletionGate.ts",
+    "test:model-builder-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderCancelledRunGuard.test.ts",
+    "test:model-builder-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCancelledRunGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1052,6 +1052,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     output: BuildOutputConfig | undefined,
     prompt: string,
     dims: { width: number; height: number },
+    runId: string,
   ): Promise<void> {
     const artStore = useArtStore()
 
@@ -1078,6 +1079,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       item.queueState = null
 
       const result = await artStore.finalizeQueuedArtImage(job, generateData)
+
+      // finalizeQueuedArtImage is itself a network round-trip long enough for
+      // the user to cancel this exact run while it's in flight. By this point
+      // item.artJobId has already been cleared above (as part of normal
+      // terminal-status handling, not by cancellation), so the artJobId check
+      // above can no longer distinguish "cancelled" from "completing
+      // normally" -- cancelRun's own clearing of item.artJobId is a no-op
+      // here. Only cancelledRunIds still tells them apart. Mirrors
+      // generateItemAsset's cancelledRunIds guard: don't persist a candidate,
+      // PATCH/POST onto a cancelled run's item, or pop a misleading
+      // success/error toast for a run the user no longer has open.
+      if (cancelledRunIds.has(runId)) return
 
       if (!result.success || !result.data) {
         item.error = result.message || `Art job ${jobId} did not complete.`
@@ -1108,6 +1121,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   async function generateItemAssetAsync(itemId: string): Promise<boolean> {
     const item = findItem(itemId)
     if (!item || !state.run) return false
+    const runId = state.run.id
 
     if (item.generation !== 'image') {
       item.error = `${item.generation} generation is not wired into the front-end slice yet.`
@@ -1156,6 +1170,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         output,
         prompt,
         dims,
+        runId,
       )
       return true
     } catch (error) {

--- a/utils/scripts/verifyModelBuilderCancelledRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCancelledRunGuard.test.ts
@@ -1,0 +1,141 @@
+// /utils/scripts/verifyModelBuilderCancelledRunGuard.test.ts
+//
+// Regression test for checkCancelledRunGuard() in
+// verifyModelBuilderCancelledRunGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (no `runId` param, no cancelledRunIds check -- the exact bug
+// found by manual read-through), and the fixed shape (runId threaded
+// through, cancelledRunIds checked between finalizeQueuedArtImage resolving
+// and its result branch).
+import assert from 'node:assert/strict'
+
+import { checkCancelledRunGuard } from './verifyModelBuilderCancelledRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    generateData: GenerateArtData,
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+  ): Promise<void> {
+    const artStore = useArtStore()
+
+    while (item.artJobId === jobId) {
+      const job = await artStore.getArtJobStatus(jobId)
+      if (item.artJobId !== jobId) return
+
+      if (!job || job.status === 'PENDING') {
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        continue
+      }
+
+      item.artJobId = null
+      item.queueState = null
+
+      const result = await artStore.finalizeQueuedArtImage(job, generateData)
+
+      if (!result.success || !result.data) {
+        item.error = result.message || 'failed'
+        setStatus('error', item.error)
+        return
+      }
+
+      item.artImageId = result.data.id
+      await recordArtifact(item, result.data, output, prompt, dims)
+      pushItem(item, { artImageId: item.artImageId })
+      setStatus('success', 'Generated a candidate.')
+      return
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    generateData: GenerateArtData,
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+    runId: string,
+  ): Promise<void> {
+    const artStore = useArtStore()
+
+    while (item.artJobId === jobId) {
+      const job = await artStore.getArtJobStatus(jobId)
+      if (item.artJobId !== jobId) return
+
+      if (!job || job.status === 'PENDING') {
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        continue
+      }
+
+      item.artJobId = null
+      item.queueState = null
+
+      const result = await artStore.finalizeQueuedArtImage(job, generateData)
+
+      if (cancelledRunIds.has(runId)) return
+
+      if (!result.success || !result.data) {
+        item.error = result.message || 'failed'
+        setStatus('error', item.error)
+        return
+      }
+
+      item.artImageId = result.data.id
+      await recordArtifact(item, result.data, output, prompt, dims)
+      pushItem(item, { artImageId: item.artImageId })
+      setStatus('success', 'Generated a candidate.')
+      return
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkCancelledRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  `expected the pre-fix shape (missing runId param AND missing cancelledRunIds ` +
+    `check) to raise 2 errors, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('runId: string')),
+  'expected a violation for the missing runId parameter',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('cancelledRunIds')),
+  'expected a violation for the missing cancelledRunIds check',
+)
+
+const fixedErrors = checkCancelledRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkCancelledRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when pollAsyncArtJob is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('pollAsyncArtJob'))
+
+console.log(
+  'Model Builder cancelled-run guard checker verified: flags the pre-fix ' +
+    'shape (missing runId param and missing post-finalize cancelledRunIds ' +
+    'check), clears the fixed shape, and flags pollAsyncArtJob being ' +
+    'absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderCancelledRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderCancelledRunGuard.ts
@@ -1,0 +1,137 @@
+// /utils/scripts/verifyModelBuilderCancelledRunGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- pollAsyncArtJob's
+// terminal branch calls artStore.finalizeQueuedArtImage(), a real network
+// round-trip; the user can cancel this exact run (cancelRun) while that call
+// is in flight. Before this fix, the code after that await unconditionally
+// persisted the result (recordArtifact/pushItem) and popped a "Generated a
+// candidate" success toast even for a run the user had already cancelled --
+// despite cancelRun's own doc comment claiming to prevent exactly that
+// ("PATCHing/POSTing artifacts onto items that belong to a run the user just
+// cancelled"). cancelRun clears item.artJobId, and pollAsyncArtJob's while
+// loop and its one mid-loop check (`if (item.artJobId !== jobId) return`)
+// both key off that field -- but by the time finalizeQueuedArtImage is
+// called, the terminal branch has already zeroed item.artJobId itself as
+// part of normal (non-cancellation) processing, so that check can no longer
+// tell "cancelled" apart from "completing normally". generateItemAsset (the
+// synchronous sibling) already guards its own post-await completion writes
+// with `if (cancelledRunIds.has(runId)) return false`; pollAsyncArtJob was
+// missing the equivalent guard on its own await. Fixed by threading `runId`
+// through pollAsyncArtJob and checking `cancelledRunIds.has(runId)`
+// immediately after finalizeQueuedArtImage resolves, before either its
+// success or failure branch runs (both branches -- and everything they lead
+// to, including recordArtifact/pushItem/setStatus -- sit textually after
+// that check, so one guard covers all of them).
+//
+// This asserts the textual shape of that fix stays in place: pollAsyncArtJob
+// takes a `runId` parameter, and a `cancelledRunIds.has(runId)` check
+// appears strictly between the `finalizeQueuedArtImage(` call and the
+// `if (!result.success` branch that follows it in the same function body --
+// deliberately scoped to this one function/bug, mirroring
+// verifyModelBuilderCompletionGate.ts's preference for explicit, narrow
+// textual checks over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'pollAsyncArtJob'
+const FINALIZE_CALL = 'artStore.finalizeQueuedArtImage('
+const RESULT_BRANCH = 'if (!result.success'
+const GUARD = 'cancelledRunIds.has(runId)'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `pollAsyncArtJob`-named async function. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkCancelledRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const signatureMatch = new RegExp(
+    `async function ${FN_NAME}\\(([\\s\\S]*?)\\):\\s*Promise<void>\\s*\\{`,
+  ).exec(content)
+  const params = signatureMatch?.[1] ?? ''
+  if (!/\brunId\s*:\s*string\b/.test(params)) {
+    errors.push(
+      `${FN_NAME}() no longer takes a \`runId: string\` parameter -- ` +
+        'without it there is nothing to check cancelledRunIds against.',
+    )
+  }
+
+  const finalizeIndex = fn.body.indexOf(FINALIZE_CALL)
+  if (finalizeIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer calls ${FINALIZE_CALL} -- this guard's ` +
+        'anchor point has moved; re-check where the real network round-trip ' +
+        'that can outlast a cancellation now happens.',
+    )
+    return errors
+  }
+
+  const resultBranchIndex = fn.body.indexOf(RESULT_BRANCH, finalizeIndex)
+  if (resultBranchIndex === -1) {
+    errors.push(
+      `${FN_NAME}() calls ${FINALIZE_CALL} but no longer branches on ` +
+        `${RESULT_BRANCH} afterward -- this guard's anchor point has moved.`,
+    )
+    return errors
+  }
+
+  const guardIndex = fn.body.indexOf(GUARD, finalizeIndex)
+  if (guardIndex === -1 || guardIndex >= resultBranchIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`${GUARD}\` between ${FINALIZE_CALL} ` +
+        `resolving and its ${RESULT_BRANCH} branch. finalizeQueuedArtImage ` +
+        'is a network round-trip the user can cancel this run during; ' +
+        'without this check, a job that finishes after cancellation still ' +
+        'persists a candidate (recordArtifact/pushItem) and pops a ' +
+        '"Generated a candidate" success toast for a run the user no ' +
+        "longer has open. Mirror generateItemAsset's own " +
+        '`if (cancelledRunIds.has(runId)) return` guard.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkCancelledRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder cancelled-run guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder cancelled-run guard contract passed: ${FN_NAME}() checks ` +
+      'cancelledRunIds after its own async completion await, before ' +
+      'persisting a candidate or surfacing a status toast.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029: recurring UI polish/bug-hunt pass on the Model Builder front end (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `pollAsyncArtJob()` now takes a `runId` and checks `cancelledRunIds.has(runId)` immediately after `finalizeQueuedArtImage()` resolves, before persisting `item.artImageId`, calling `recordArtifact()`/`pushItem()`, or surfacing a success/error status.
  - **Bug:** `pollAsyncArtJob` clears `item.artJobId` as part of normal terminal-status handling *before* awaiting `finalizeQueuedArtImage()` (a real network round-trip). If the user cancels the run while that await is in flight, `cancelRun()`'s own `item.artJobId` clearing becomes a no-op (already cleared), and nothing else was checking `cancelledRunIds` on this path — so a cancelled run could still get its candidate persisted, an artifact PATCHed/POSTed onto the item, and a misleading success toast popped. This contradicts `cancelRun()`'s own doc comment, which explicitly claims to prevent exactly this. The synchronous sibling `generateItemAsset` already has this guard on both its success and catch paths (a prior fix); `pollAsyncArtJob` (used by the newer async `generateItemAssetAsync` path) never got the equivalent guard.
- Added `utils/scripts/verifyModelBuilderCancelledRunGuard.ts` + `.test.ts`, matching the existing static-regression-guard convention (`verifyModelBuilderCompletionGate.ts`), plus two `package.json` script entries.

### How I verified
- `npx eslint stores/modelBuilderStore.ts`: only the 2 pre-existing `no-empty` errors (confirmed identical via `git stash` before/after) — no new errors.
- `npx eslint` on both new files: 0 errors.
- `npx vue-tsc --noEmit` (whole project): 0 errors.
- `npx prettier --check`: pre-existing drift only on the store file (confirmed via `git stash`, none touches the added lines); new files and `package.json` clean.
- `git status --porcelain`: only the 4 intended files changed.
- New regression-guard script: fails against the pre-fix store (confirmed via `git stash`), passes after the fix; its own self-test passes standalone.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Model Builder's async art-generation path (`generateItemAssetAsync`/`pollAsyncArtJob`) still has no live-backend smoke test (tracked separately as model-builder/t-031) — worth prioritizing once the render backend is confirmed reachable from a session, since races like this one are hard to fully rule out via static trace alone.

https://claude.ai/code/session_01JgdrsYyVLV1xt8tAjJJbiW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgdrsYyVLV1xt8tAjJJbiW)_