### PR TITLE
fix(model-builder): guard approved GENERATE_ASSETS candidate against a late async completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "test:model-builder-completion-gate": "tsx utils/scripts/verifyModelBuilderCompletionGate.ts",
     "test:model-builder-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderCancelledRunGuard.test.ts",
     "test:model-builder-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCancelledRunGuard.ts",
+    "test:model-builder-approved-asset-guard-selftest": "tsx utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts",
+    "test:model-builder-approved-asset-guard": "tsx utils/scripts/verifyModelBuilderApprovedAssetGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1099,6 +1099,30 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         return
       }
 
+      // item.artJobId was cleared above, before this function's own await --
+      // that's what the item panel's isQueued reads, so for the exact span
+      // between that clear and finalizeQueuedArtImage resolving, isQueued is
+      // false while GENERATE_ASSETS is still 'in-progress'. On a regenerate
+      // (item.artImageId already holds a prior candidate), the panel's
+      // canApproveAssets briefly evaluates true during that span -- neither
+      // isGenerating nor isQueued nor isLocked block it -- letting the user
+      // click "Keep this asset" using the OLD image; approveStage writes
+      // 'approved' straight through with no gate of its own. Applying this
+      // render's NEW image unconditionally below would then silently swap
+      // what the just-approved stage points at, with no re-review. Mirrors
+      // finishGenerateAssets' "only write if nothing else touched the stage
+      // while we were awaiting" rule, extended to the image itself -- but
+      // only for 'approved': a concurrent upstream edit marking this stage
+      // 'stale' while the job was in flight is the existing, intended way to
+      // flag "re-review this candidate," and should still receive the image.
+      if (item.stages.GENERATE_ASSETS.status === 'approved') {
+        setStatus(
+          'error',
+          `${item.label} finished generating after its candidate was already approved — discarded to avoid silently replacing it.`,
+        )
+        return
+      }
+
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null

--- a/utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts
@@ -1,0 +1,154 @@
+// /utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts
+//
+// Regression test for checkApprovedAssetGuard() in
+// verifyModelBuilderApprovedAssetGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (no `GENERATE_ASSETS.status === 'approved'` guard before the
+// artImageId write -- the exact bug found by manual read-through), and the
+// fixed shape (the guard checked and returned on between the result branch
+// and the write).
+import assert from 'node:assert/strict'
+
+import { checkApprovedAssetGuard } from './verifyModelBuilderApprovedAssetGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    generateData: GenerateArtData,
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+    runId: string,
+  ): Promise<void> {
+    const artStore = useArtStore()
+
+    while (item.artJobId === jobId) {
+      const job = await artStore.getArtJobStatus(jobId)
+      if (item.artJobId !== jobId) return
+
+      if (!job || job.status === 'PENDING') {
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        continue
+      }
+
+      item.artJobId = null
+      item.queueState = null
+
+      const result = await artStore.finalizeQueuedArtImage(job, generateData)
+
+      if (cancelledRunIds.has(runId)) return
+
+      if (!result.success || !result.data) {
+        item.error = result.message || 'failed'
+        finishGenerateAssets(item, { status: 'ready', note: item.error })
+        setStatus('error', item.error)
+        return
+      }
+
+      const image = result.data as { id: number; imagePath?: string | null }
+      item.artImageId = image.id
+      item.imagePath = image.imagePath ?? null
+      finishGenerateAssets(item, { status: 'ready' })
+
+      await recordArtifact(item, image, output, prompt, dims)
+      pushItem(item, { stageStatuses: item.stages, artImageId: item.artImageId })
+      setStatus('success', 'Generated a candidate.')
+      return
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function pollAsyncArtJob(
+    item: BuildItem,
+    jobId: number,
+    generateData: GenerateArtData,
+    output: BuildOutputConfig | undefined,
+    prompt: string,
+    dims: { width: number; height: number },
+    runId: string,
+  ): Promise<void> {
+    const artStore = useArtStore()
+
+    while (item.artJobId === jobId) {
+      const job = await artStore.getArtJobStatus(jobId)
+      if (item.artJobId !== jobId) return
+
+      if (!job || job.status === 'PENDING') {
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        continue
+      }
+
+      item.artJobId = null
+      item.queueState = null
+
+      const result = await artStore.finalizeQueuedArtImage(job, generateData)
+
+      if (cancelledRunIds.has(runId)) return
+
+      if (!result.success || !result.data) {
+        item.error = result.message || 'failed'
+        finishGenerateAssets(item, { status: 'ready', note: item.error })
+        setStatus('error', item.error)
+        return
+      }
+
+      if (item.stages.GENERATE_ASSETS.status === 'approved') {
+        setStatus('error', 'discarded to avoid silently replacing it')
+        return
+      }
+
+      const image = result.data as { id: number; imagePath?: string | null }
+      item.artImageId = image.id
+      item.imagePath = image.imagePath ?? null
+      finishGenerateAssets(item, { status: 'ready' })
+
+      await recordArtifact(item, image, output, prompt, dims)
+      pushItem(item, { stageStatuses: item.stages, artImageId: item.artImageId })
+      setStatus('success', 'Generated a candidate.')
+      return
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkApprovedAssetGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape (missing approved-stage guard) to raise 1 ` +
+    `error, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors[0]!.includes("GENERATE_ASSETS.status === 'approved'"),
+  'expected a violation naming the missing approved-stage guard',
+)
+
+const fixedErrors = checkApprovedAssetGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkApprovedAssetGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when pollAsyncArtJob is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('pollAsyncArtJob'))
+
+console.log(
+  'Model Builder approved-asset guard checker verified: flags the pre-fix ' +
+    'shape (missing approved-stage guard before the artImageId write), ' +
+    'clears the fixed shape, and flags pollAsyncArtJob being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderApprovedAssetGuard.ts
+++ b/utils/scripts/verifyModelBuilderApprovedAssetGuard.ts
@@ -1,0 +1,127 @@
+// /utils/scripts/verifyModelBuilderApprovedAssetGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- pollAsyncArtJob clears
+// item.artJobId/queueState before awaiting artStore.finalizeQueuedArtImage(),
+// a real network round-trip. The item panel's canApproveAssets computed
+// reads item.artJobId (via isQueued) as its only "is a render still
+// happening" signal alongside isGenerating/isLocked -- none of which are
+// true during that exact span, so on a REGENERATE (item.artImageId already
+// holds a prior candidate) canApproveAssets briefly evaluates true, letting
+// the user click "Keep this asset" using the OLD image while
+// GENERATE_ASSETS is still nominally 'in-progress'. approveStage writes
+// 'approved' straight through with no gate of its own. Before this fix, the
+// completion handler then unconditionally overwrote item.artImageId /
+// item.imagePath with the NEW image once finalizeQueuedArtImage resolved --
+// silently swapping what an already-'approved' stage points at, with no
+// re-review, directly contradicting the file's own stale-invalidation
+// philosophy (isStageEditable's doc comment: "the review gate would be
+// lying about what's actually stored"). Fixed by checking
+// `item.stages.GENERATE_ASSETS.status === 'approved'` right before the
+// artImageId/imagePath write and discarding the finished render instead of
+// applying it when the stage was approved out from under the poll. A
+// concurrent 'stale' (upstream edit reopening an earlier stage) is left
+// alone on purpose -- that's the existing, intended way to flag "re-review
+// this candidate," and should still receive the image.
+//
+// This asserts the textual shape of that fix stays in place: pollAsyncArtJob
+// checks `item.stages.GENERATE_ASSETS.status === 'approved'` strictly
+// between the `if (!result.success` branch and the `item.artImageId =`
+// write that follows it in the same function body -- deliberately scoped to
+// this one function/bug, mirroring
+// verifyModelBuilderCancelledRunGuard.ts's preference for explicit, narrow
+// textual checks over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'pollAsyncArtJob'
+const RESULT_BRANCH = 'if (!result.success'
+const IMAGE_WRITE = 'item.artImageId = image.id'
+const GUARD = "item.stages.GENERATE_ASSETS.status === 'approved'"
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `pollAsyncArtJob`-named async function. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkApprovedAssetGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const resultBranchIndex = fn.body.indexOf(RESULT_BRANCH)
+  if (resultBranchIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer branches on ${RESULT_BRANCH} -- this guard's ` +
+        'anchor point has moved.',
+    )
+    return errors
+  }
+
+  const imageWriteIndex = fn.body.indexOf(IMAGE_WRITE, resultBranchIndex)
+  if (imageWriteIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer writes \`${IMAGE_WRITE}\` after its ` +
+        `${RESULT_BRANCH} branch -- this guard's anchor point has moved; ` +
+        're-check where the finished render gets applied to the item.',
+    )
+    return errors
+  }
+
+  const guardIndex = fn.body.indexOf(GUARD, resultBranchIndex)
+  if (guardIndex === -1 || guardIndex >= imageWriteIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`${GUARD}\` between its ${RESULT_BRANCH} ` +
+        `branch and the ${IMAGE_WRITE} write. item.artJobId is cleared ` +
+        "before this function's own finalizeQueuedArtImage await, so the " +
+        "item panel's canApproveAssets can briefly return true on a " +
+        'regenerate (using the prior artImageId) while this render is still ' +
+        'finishing, letting a premature approve lock in the OLD image. ' +
+        'Without this check, the render that finishes afterward silently ' +
+        'overwrites the already-approved artImageId/imagePath with no ' +
+        're-review.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkApprovedAssetGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder approved-asset guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder approved-asset guard contract passed: ${FN_NAME}() ` +
+      'refuses to overwrite an already-approved candidate with a render ' +
+      'that finishes after the fact.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

- `pollAsyncArtJob` (async art-generation completion handler, added in t-025/t-029) clears `item.artJobId`/`queueState` *before* its own `finalizeQueuedArtImage` await — a real network round-trip. The item panel's `canApproveAssets` computed reads `item.artJobId` (via `isQueued`) as its only "still working" signal alongside `isGenerating`/`isLocked`, none of which are true during that span. On a **regenerate** (the item already has a prior `artImageId`), `canApproveAssets` briefly evaluates `true` while `GENERATE_ASSETS` is still `'in-progress'`, so a click on "Keep this asset" during that narrow window locks the stage to `'approved'` using the **old** image. The render that finishes afterward then unconditionally overwrote `item.artImageId`/`imagePath` with the **new** image — silently changing what an already-`'approved'` stage pointed at, with no re-review.
- Fixed by checking `item.stages.GENERATE_ASSETS.status === 'approved'` right before the image write and discarding the finished render (with a status message) instead of silently applying it. A concurrent `'stale'` transition (an upstream edit reopening an earlier stage while the render is in flight) is left alone on purpose — that's the existing, intended way to flag "re-review this candidate."
- Added `utils/scripts/verifyModelBuilderApprovedAssetGuard.ts` + `.test.ts` (mirrors the existing `verifyModelBuilderCancelledRunGuard.ts` convention: a narrow textual regression check + a self-test against synthetic buggy/fixed fixtures) plus two `package.json` script entries.

## Verification

- `npx eslint stores/modelBuilderStore.ts` shows only the 2 pre-existing `no-empty` errors at lines 203/210 (confirmed via `git stash` before/after — unrelated to this change).
- `npx eslint` on both new files: clean.
- Full-project `npx vue-tsc --noEmit`: exit 0.
- `npx prettier --check` drift on the store file confirmed pre-existing via the same stash comparison; new files clean.
- `git status --porcelain` shows only the 4 intended files touched.
- Both existing model-builder regression checkers (`cancelled-run-guard`, `completion-gate`) still pass unchanged.
- The new checker's self-test fails against the pre-fix shape and passes after (and against a `pollAsyncArtJob`-absent fixture).

## Flags for Reviewer

- Step (1) of t-029's original scope (dashboard-tab + tutorial `.webp` art) remains blocked on the external art-generation relay, unchanged from the prior cycle — not addressed by this PR.
- This is a client-only race-condition fix; there's no reachable local render backend in this sandbox to exercise the actual UI click sequence live, so verification is via the static regression checker plus eslint/vue-tsc/prettier, matching this file's established verification convention for its prior three bug fixes (`canApproveAssets`, batch-editor stage-approval gate, cancelled-run guard).

conductor: model-builder/t-029 (recurring — rearms to `ready` after this PR)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XoLSU855zcGypoxNqrCC9S)_