### PR TITLE
Fix stale-model ArtJobs in place: LoRA override + raw JSON viewer/editor

### DIFF
--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -178,6 +178,38 @@
                 placeholder="Keep the current model or choose a preset"
               />
             </label>
+
+            <label v-if="form.loraName" class="flex flex-col gap-1 text-sm">
+              <span class="font-semibold">Style LoRA</span>
+              <input
+                v-model="form.loraName"
+                class="input input-bordered rounded-2xl font-mono text-xs"
+                placeholder="e.g. Kontext/SFW/impressionist.safetensors"
+              />
+              <span class="text-[11px] text-base-content/50">
+                Must match ComfyUI's list exactly (folder + case). Required/base
+                LoRAs aren't touched.
+              </span>
+            </label>
+
+            <details class="rounded-2xl border border-base-300 bg-base-200/40 p-3">
+              <summary
+                class="cursor-pointer text-sm font-semibold select-none"
+              >
+                Raw job JSON
+              </summary>
+              <button
+                type="button"
+                class="btn btn-xs rounded-xl mt-2"
+                @click="copyPayloadJson"
+              >
+                {{ copiedJson ? 'Copied' : 'Copy JSON' }}
+              </button>
+              <pre
+                class="mt-2 max-h-72 overflow-auto rounded-xl bg-base-100 p-3 text-[11px] leading-snug whitespace-pre"
+                >{{ prettyPayload }}</pre
+              >
+            </details>
           </div>
 
           <aside class="flex flex-col gap-3">
@@ -524,6 +556,26 @@ function workflowPrompt(kind: 'positive' | 'negative'): string {
   return ''
 }
 
+// The user-selected style LoRA baked into the workflow. Skips required/base
+// LoRAs (e.g. LTX's distilled acceleration LoRA) — builders title those
+// "... Required ..." — so the field shows the one that's actually overridable.
+function workflowStyleLora(): string {
+  const workflow = asRecord(asRecord(props.job.payload).workflow)
+  for (const value of Object.values(workflow)) {
+    const node = asRecord(value)
+    const classType = scalar(node.class_type)
+    if (classType !== 'LoraLoaderModelOnly' && classType !== 'LoraLoader') {
+      continue
+    }
+    if (scalar(asRecord(node._meta).title).toLowerCase().includes('required')) {
+      continue
+    }
+    const name = scalar(asRecord(node.inputs).lora_name)
+    if (name) return name
+  }
+  return ''
+}
+
 function payloadFacetIds(): number[] {
   const facets = asRecord(props.job.payload).facets
   if (!Array.isArray(facets)) return []
@@ -577,6 +629,7 @@ const form = reactive({
     'unet_name',
     'model_name',
   ]),
+  loraName: workflowStyleLora(),
   durationSeconds: videoScalar(['durationSeconds']) || '4',
   fps: videoScalar(['fps']) || '24',
   loop: booleanValue(asRecord(payload.value.video).loop, true),
@@ -677,6 +730,26 @@ function numberValue(value: string): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+const prettyPayload = computed(() => {
+  try {
+    return JSON.stringify(props.job.payload, null, 2)
+  } catch {
+    return String(props.job.payload)
+  }
+})
+const copiedJson = ref(false)
+async function copyPayloadJson(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(prettyPayload.value)
+    copiedJson.value = true
+    setTimeout(() => {
+      copiedJson.value = false
+    }, 1500)
+  } catch {
+    localError.value = 'Could not copy to clipboard.'
+  }
+}
+
 async function save(): Promise<void> {
   localError.value = ''
   const prompt = form.promptString.replace(/\s+/g, ' ').trim()
@@ -709,6 +782,7 @@ async function save(): Promise<void> {
   if (form.sampler.trim()) overrides.sampler = form.sampler.trim()
   if (form.scheduler.trim()) overrides.scheduler = form.scheduler.trim()
   if (form.checkpoint.trim()) overrides.checkpoint = form.checkpoint.trim()
+  if (form.loraName.trim()) overrides.loraName = form.loraName.trim()
 
   if (isVideoJob.value) {
     const durationSeconds = numberValue(form.durationSeconds)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts",
+    "test:artjob-lora-override": "tsx utils/scripts/verifyArtJobLoraOverride.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:data-surface-manifest": "tsx utils/scripts/verifyDataSurfaceManifest.ts",

--- a/server/utils/artJobRetry.ts
+++ b/server/utils/artJobRetry.ts
@@ -99,6 +99,12 @@ export type ArtJobOverrides = {
   sampler?: string | null
   scheduler?: string | null
   checkpoint?: string | null
+  // Swap the user-selected *style* LoRA on a queued/failed job. Patches the
+  // style LoraLoader node(s); required/base LoRAs (e.g. LTX's distilled
+  // acceleration LoRA) are left alone. Lets edit/requeue correct a job whose
+  // stored lora_name no longer resolves — without rebuilding it from scratch.
+  loraName?: string | null
+  loraStrength?: number | null
   durationSeconds?: number | null
   fps?: number | null
   loop?: boolean | null
@@ -110,6 +116,7 @@ const SAMPLER_NODE_TYPES = new Set([
   'SamplerCustom',
 ])
 const CHECKPOINT_KEYS = ['ckpt_name', 'unet_name', 'model_name']
+const LORA_NODE_TYPES = new Set(['LoraLoaderModelOnly', 'LoraLoader'])
 const VIDEO_NODE_TYPES = new Set([
   'LTXVConditioning',
   'LTXVImgToVideo',
@@ -236,6 +243,8 @@ export function applyArtJobOverrides(
   const sampler = overrides.sampler?.trim() || null
   const scheduler = overrides.scheduler?.trim() || null
   const checkpoint = overrides.checkpoint?.trim() || null
+  const loraName = overrides.loraName?.trim() || null
+  const loraStrength = num(overrides.loraStrength)
   const durationOverride = num(overrides.durationSeconds)
   const fpsOverride = num(overrides.fps)
   const loopOverride =
@@ -340,6 +349,25 @@ export function applyArtJobOverrides(
         }
       }
 
+      // Style-LoRA swap. Only the user-selected style LoRA is overridable;
+      // builders title the required/base ones "... Required ..." (e.g. LTX's
+      // distilled acceleration LoRA), so those are skipped and keep their
+      // pinned filename. Every WAN/kontext/flux "Selected"/"Style" LoRA node
+      // is repointed at the new file (WAN applies it to both expert passes).
+      if (
+        loraName &&
+        LORA_NODE_TYPES.has(classType) &&
+        'lora_name' in inputs &&
+        !String(meta.title || '')
+          .toLowerCase()
+          .includes('required')
+      ) {
+        inputs.lora_name = loraName
+        if (loraStrength !== null && 'strength_model' in inputs) {
+          inputs.strength_model = loraStrength
+        }
+      }
+
       if (
         negativePrompt !== null &&
         classType === 'CLIPTextEncode' &&
@@ -365,6 +393,17 @@ export function applyArtJobOverrides(
   if (sampler) payload.sampler = sampler
   if (scheduler) payload.scheduler = scheduler
   if (checkpoint) payload.checkpoint = checkpoint
+  if (loraName) {
+    payload.loraName = loraName
+    // Keep the resources metadata list in step with the workflow so a later
+    // read (or provenance recompute) reflects the swapped style LoRA.
+    const resources = asRecord(payload.resources)
+    if (Array.isArray(resources.loraNames) && resources.loraNames.length > 0) {
+      resources.loraNames = [loraName]
+      payload.resources = resources
+    }
+  }
+  if (loraStrength !== null) payload.loraStrength = loraStrength
   if (negativePrompt !== null) payload.negativePrompt = negativePrompt
 
   if (videoModel) {

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -32,6 +32,10 @@ export type ArtJobOverrides = {
   sampler?: string | null
   scheduler?: string | null
   checkpoint?: string | null
+  // Repoint the selected style LoRA (server skips required/base LoRAs). Lets the
+  // editor fix a job whose stored lora_name no longer matches ComfyUI's list.
+  loraName?: string | null
+  loraStrength?: number | null
 }
 
 export type ArtFeedbackSource = 'CURATOR' | 'HUMAN'

--- a/utils/scripts/verifyArtJobLoraOverride.ts
+++ b/utils/scripts/verifyArtJobLoraOverride.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import { applyArtJobOverrides } from '../../server/utils/artJobRetry'
+
+// Style-LoRA override: repoint a job's selected style LoRA without rebuilding
+// it. This is the in-place fix for a stored lora_name that no longer resolves
+// (e.g. an old HF repo-id like `UmeAiRT/FLUX.1-dev-LoRA-Impressionism`).
+
+// 1. Single style LoRA (kontext #2603 shape) is swapped; metadata follows.
+{
+  const payload: Record<string, unknown> = {
+    resources: { loraNames: ['UmeAiRT/FLUX.1-dev-LoRA-Impressionism'] },
+    workflow: {
+      '61': {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: {
+          model: ['59', 0],
+          lora_name: 'UmeAiRT/FLUX.1-dev-LoRA-Impressionism',
+          strength_model: 1,
+        },
+        _meta: { title: 'Style LoRA' },
+      },
+    },
+  }
+  const out = applyArtJobOverrides(payload, {
+    loraName: 'Flux/NSFW/ume_classic_impressionist.safetensors',
+    loraStrength: 0.8,
+  })
+  const node = (out.workflow as any)['61'].inputs
+  assert.equal(node.lora_name, 'Flux/NSFW/ume_classic_impressionist.safetensors')
+  assert.equal(node.strength_model, 0.8)
+  assert.equal(out.loraName, 'Flux/NSFW/ume_classic_impressionist.safetensors')
+  assert.equal(out.loraStrength, 0.8)
+  assert.deepEqual((out.resources as any).loraNames, [
+    'Flux/NSFW/ume_classic_impressionist.safetensors',
+  ])
+}
+
+// 2. Required/base LoRA is left alone; only the selected style LoRA moves
+//    (LTX: a distilled acceleration LoRA + a user style LoRA).
+{
+  const payload: Record<string, unknown> = {
+    workflow: {
+      '293': {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'ltx-2.3-22b-distilled-lora-384.safetensors', strength_model: 0.5 },
+        _meta: { title: 'Load Required LTX Distilled LoRA' },
+      },
+      video_lora: {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'old/style.safetensors', strength_model: 1 },
+        _meta: { title: 'Load Selected LTX LoRA' },
+      },
+    },
+  }
+  const out = applyArtJobOverrides(payload, { loraName: 'Video/SFW/new_style.safetensors' })
+  assert.equal(
+    (out.workflow as any)['293'].inputs.lora_name,
+    'ltx-2.3-22b-distilled-lora-384.safetensors',
+    'required distilled LoRA must not be overridden',
+  )
+  assert.equal(
+    (out.workflow as any).video_lora.inputs.lora_name,
+    'Video/SFW/new_style.safetensors',
+  )
+}
+
+// 3. WAN applies the style LoRA to both expert passes.
+{
+  const payload: Record<string, unknown> = {
+    workflow: {
+      lora_high: {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'a.safetensors', strength_model: 1 },
+        _meta: { title: 'Load Selected WAN LoRA (High Noise)' },
+      },
+      lora_low: {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'a.safetensors', strength_model: 1 },
+        _meta: { title: 'Load Selected WAN LoRA (Low Noise)' },
+      },
+    },
+  }
+  const out = applyArtJobOverrides(payload, { loraName: 'Video/SFW/b.safetensors' })
+  assert.equal((out.workflow as any).lora_high.inputs.lora_name, 'Video/SFW/b.safetensors')
+  assert.equal((out.workflow as any).lora_low.inputs.lora_name, 'Video/SFW/b.safetensors')
+}
+
+// 4. No loraName override -> the style LoRA is untouched.
+{
+  const payload: Record<string, unknown> = {
+    workflow: {
+      '61': {
+        class_type: 'LoraLoaderModelOnly',
+        inputs: { lora_name: 'keep/me.safetensors', strength_model: 1 },
+        _meta: { title: 'Style LoRA' },
+      },
+    },
+  }
+  const out = applyArtJobOverrides(payload, { seed: 42 })
+  assert.equal((out.workflow as any)['61'].inputs.lora_name, 'keep/me.safetensors')
+  assert.equal(out.loraName, undefined)
+}
+
+// 5. Non-LoRA nodes are never touched by a loraName override.
+{
+  const payload: Record<string, unknown> = {
+    workflow: {
+      '24': {
+        class_type: 'UnetLoaderGGUF',
+        inputs: { unet_name: 'flux1-dev-Q8_0.gguf' },
+        _meta: { title: 'Unet Loader (GGUF)' },
+      },
+    },
+  }
+  const out = applyArtJobOverrides(payload, { loraName: 'x/y.safetensors' })
+  assert.equal((out.workflow as any)['24'].inputs.unet_name, 'flux1-dev-Q8_0.gguf')
+  assert.ok(!('lora_name' in (out.workflow as any)['24'].inputs))
+}
+
+console.log('✅ verifyArtJobLoraOverride: all assertions passed')


### PR DESCRIPTION
## Summary

Failed ArtJobs whose baked `lora_name`/`ckpt_name` no longer matches ComfyUI's live model list couldn't be fixed from the app — requeue just replays the same frozen workflow, and `ArtJobOverrides` could swap the checkpoint but not the LoRA. The only recourse was hand-editing the DB or cloning the job. This adds an in-place fix path, end to end.

## Changes

**Backend — `loraName` override (`server/utils/artJobRetry.ts`)**
- `ArtJobOverrides` gains `loraName` (+ optional `loraStrength`). `applyArtJobOverrides` repoints every style `LoraLoaderModelOnly`/`LoraLoader` node's `lora_name` at the new file and syncs `payload.loraName` + `resources.loraNames`, mirroring the existing `checkpoint` handling.
- **Required/base LoRAs are skipped** — builders title those "… Required …" (e.g. LTX's distilled acceleration LoRA), so only the user-selected style LoRA moves. WAN's two expert passes both get repointed.
- The `edit` endpoint gains the capability for free (it forwards `ArtJobOverrides`); `requeue` is a no-override re-run by design.

**Frontend — visibility + fix field (`components/art/artjob-editor.vue`, `stores/artJobStore.ts`)**
- **Raw job JSON**: collapsible, scrollable, copy-to-clipboard view of the full payload — the exact baked workflow (`ckpt_name`/`lora_name`/`unet_name`) is now visible in the editor.
- **Style LoRA** field: prefilled from the job's selected style LoRA (required/base skipped), wired to the new override. With the existing Checkpoint field, a job whose model path drifted from ComfyUI's list can be corrected and requeued straight from the UI.
- Mirrors `loraName`/`loraStrength` into the client `ArtJobOverrides` type.

## Usage

```
POST /api/art/queue/<id>/edit  {"overrides":{"loraName":"Kontext/SFW/impressionist.safetensors"}}
```
…or just open the job in the editor, see the JSON, and edit the Style LoRA / Checkpoint field.

## Tests

`utils/scripts/verifyArtJobLoraOverride.ts` (wired as `test:artjob-lora-override`): single-style swap, required-LoRA skip, WAN dual-pass, no-op, and non-LoRA-node safety. All pass.

## Context

Companion to the conductor relay's live-list name resolver (silasfelinus/conductor#1369, merged): that fixes format/slash/case drift automatically on the box; this gives a manual, in-app fix for cases the resolver can't auto-resolve (e.g. picking the correct file when the name genuinely changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_