### PR TITLE
ai-art-academy: sync Ancient Egyptian Painting to academyStyles.ts

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -1788,6 +1788,38 @@ export const academyStyles: AcademyStyle[] = [
     },
   },
   {
+    slug: 'egyptian-painting',
+    name: 'Ancient Egyptian Painting',
+    era: 'c. 1390–950 BCE',
+    sortYear: -1390,
+    previewImageSrc: '/images/academy/styles/egyptian-painting.webp',
+    region: 'Ancient Egypt',
+    keyIdeas:
+      'Ancient Egyptian painting fixed a set of pictorial conventions — composite ("twisted") perspective, hierarchical scale, flat horizontal registers, and integrated hieroglyphic text — that were followed with remarkable consistency for well over two thousand years, making it the starting point of nearly every general art-history survey. Nothing else in the curriculum teaches this grammar: Fayum Mummy Portraits is a much later, Greco-Roman-influenced, naturalistically modeled Roman-Egypt style and is in most ways this entry\'s stylistic opposite. The style is unusually procedural rather than personal: no single named artist invented it, and its devices can be described and checked for as a repeatable visual system, closer in spirit to Byzantine Mosaic than to a single-artist movement. This lesson draws its verified examples from funerary papyri in the "Book of the Dead" tradition, a portable medium sharing every recognition cue below with tomb wall painting.',
+    recognitionCues: [
+      'Composite ("twisted") perspective on the human figure: head, legs, and feet in profile, with eye and shoulders/torso frontal',
+      'Hierarchical scale — the most important figure (a god, the pharaoh, the tomb owner) drawn noticeably larger than secondary figures',
+      'Registers: the composition divided into stacked horizontal ground-line bands, each its own self-contained scene',
+      'Flat, unmodeled color fill inside firm outlines, with no cast shadow and no atmospheric perspective',
+      'Integrated hieroglyphic-style caption marks worked directly into the composition rather than added as a separate label',
+      'Deities identifiable by attribute (animal heads, specific crowns, held symbols) within an otherwise human-scaled scene',
+    ],
+    artists: [
+      {
+        name: 'Anonymous Egyptian scribes and painters',
+        years: 'c. 1390–950 BCE',
+        note: "No papyrus or tomb painting in this tradition carries a signature in the modern sense, so this lesson credits the tradition to its anonymous scribes and painters — the same treatment already given to Byzantine Mosaic's anonymous Ravenna/Constantinople mosaicists and Fayum Mummy Portraits' anonymous encaustic painters.",
+      },
+    ],
+    failureMode:
+      'Likely collapses into a generic "hieroglyphics wallpaper" pattern that scatters symbol-like marks across the background without committing to the figure-level grammar, or drifts toward Fayum Mummy Portraits\' naturalistic modeling; lean on composite ("twisted") perspective on any human figure, stacked horizontal registers, hierarchical scale, and flat unmodeled color fill with firm outlines to keep the two Egypt-adjacent styles distinct',
+    remix: {
+      mode: 'prompt',
+      template:
+        'Recompose this image in the manner of ancient Egyptian tomb and papyrus painting: redraw any human figures using composite perspective (profile head, legs, and feet; frontal eye and shoulders), organize the composition into stacked horizontal register bands with a ground line, use flat unmodeled color fill inside firm dark outlines with no cast shadow, scale the most significant figure noticeably larger than secondary figures, and add small integrated hieroglyphic-style caption marks near key figures',
+    },
+  },
+  {
     slug: 'fauvism',
     name: 'Fauvism',
     era: 'c. 1904–1908',


### PR DESCRIPTION
## Summary
- Adds the `egyptian-painting` style entry to `stores/seeds/academyStyles.ts`, syncing curriculum-outline.md §37 (Ancient Egyptian Painting, promoted 2026-07-28) into the front-end seed — the last unsynced curriculum movement.
- Follows the exact established pattern used for every prior curriculum-outline.md → academyStyles.ts sync (name, era, region, key ideas, recognition cues, artists, failure mode, prompt-mode remix template), matching the anonymous-artisan treatment already given to Byzantine Mosaic and Fayum Mummy Portraits (no named individual artist — none survives in the historical record).
- `previewImageSrc` points at the conventional `/images/academy/styles/egyptian-painting.webp` path; the thumbnail itself is generated by a separate art-job cycle (same as every other style), so it 404s until that runs — consistent with existing entries like `fauvism`.

## Test plan
- [x] `tsc --noEmit` on the file (no syntax/type errors)
- [x] `prettier --check` passes (repo style: no semicolons, single quotes)
- [x] Confirmed `utils/scripts/verifyAcademyExamplesManifest.ts` only iterates `style.exampleWorks ?? []`, so a style with no `exampleWorks` (as here, matching most entries) is unaffected
- [x] Confirmed no test/validator asserts `previewImageSrc` file existence (matches `fauvism`'s current unsynced-thumbnail state)
- [ ] Full `npm test` / academy manifest CI (node_modules not installed in this sandbox — relying on PR CI)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017XiznES519JTo7LTA6CxWw

---
_Generated by [Claude Code](https://claude.ai/code/session_017XiznES519JTo7LTA6CxWw)_