### PR TITLE
Forward-slash LTX/hunyuan checkpoint paths + backslash regression guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts",
     "test:artjob-lora-override": "tsx utils/scripts/verifyArtJobLoraOverride.ts",
+    "test:comfy-model-paths": "tsx utils/scripts/verifyComfyModelPaths.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:data-surface-manifest": "tsx utils/scripts/verifyDataSurfaceManifest.ts",

--- a/server/api/comfy/hunyuan3d.post.ts
+++ b/server/api/comfy/hunyuan3d.post.ts
@@ -247,7 +247,7 @@ function buildHunyuan3dWorkflow(input: {
     },
     '54': {
       inputs: {
-        ckpt_name: '3d\\hunyuan_3d_v2.1.safetensors',
+        ckpt_name: '3d/hunyuan_3d_v2.1.safetensors',
       },
       class_type: 'ImageOnlyCheckpointLoader',
       _meta: {

--- a/server/api/comfy/ltx/image2Video.post.ts
+++ b/server/api/comfy/ltx/image2Video.post.ts
@@ -433,7 +433,7 @@ function buildLtxTextToVideoWorkflow(input: {
     },
     '340:317': {
       inputs: {
-        ckpt_name: 'ltx\\ltx-2.3-22b-dev-fp8.safetensors',
+        ckpt_name: 'ltx/ltx-2.3-22b-dev-fp8.safetensors',
       },
       class_type: 'CheckpointLoaderSimple',
       _meta: {
@@ -443,7 +443,7 @@ function buildLtxTextToVideoWorkflow(input: {
     '340:318': {
       inputs: {
         text_encoder: 'gemma_3_12B_it_fp4_mixed.safetensors',
-        ckpt_name: 'ltx\\ltx-2.3-22b-dev-fp8.safetensors',
+        ckpt_name: 'ltx/ltx-2.3-22b-dev-fp8.safetensors',
         device: 'default',
       },
       class_type: 'LTXAVTextEncoderLoader',

--- a/server/api/comfy/ltx/text2Video.post.ts
+++ b/server/api/comfy/ltx/text2Video.post.ts
@@ -436,7 +436,7 @@ function buildLtxTextToVideoWorkflow(input: {
     },
     '340:317': {
       inputs: {
-        ckpt_name: 'ltx\\ltx-2.3-22b-dev-fp8.safetensors',
+        ckpt_name: 'ltx/ltx-2.3-22b-dev-fp8.safetensors',
       },
       class_type: 'CheckpointLoaderSimple',
       _meta: {
@@ -446,7 +446,7 @@ function buildLtxTextToVideoWorkflow(input: {
     '340:318': {
       inputs: {
         text_encoder: 'gemma_3_12B_it_fp4_mixed.safetensors',
-        ckpt_name: 'ltx\\ltx-2.3-22b-dev-fp8.safetensors',
+        ckpt_name: 'ltx/ltx-2.3-22b-dev-fp8.safetensors',
         device: 'default',
       },
       class_type: 'LTXAVTextEncoderLoader',

--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -61,7 +61,7 @@ export const LTX_DEFAULT_SAMPLER = 'euler_ancestral_cfg_pp'
 export const LTX_DEFAULT_SIGMAS =
   '1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0'
 export const LTX_DEFAULT_LORA_STRENGTH = 0.5
-export const LTX_CHECKPOINT = 'ltx\\ltx-2.3-22b-dev-fp8.safetensors'
+export const LTX_CHECKPOINT = 'ltx/ltx-2.3-22b-dev-fp8.safetensors'
 export const LTX_TEXT_ENCODER = 'gemma_3_12B_it_fp4_mixed.safetensors'
 export const LTX_LORA = 'ltx-2.3-22b-distilled-lora-384.safetensors'
 

--- a/utils/scripts/verifyComfyModelPaths.ts
+++ b/utils/scripts/verifyComfyModelPaths.ts
@@ -1,0 +1,61 @@
+// /utils/scripts/verifyComfyModelPaths.ts
+//
+// Guard: no hardcoded model/LoRA/checkpoint filename in a Comfy workflow may
+// contain a backslash. ComfyUI matches subfolder paths with forward slashes on
+// every OS (even Windows), so a literal `ltx\ltx-...safetensors` is rejected
+// with value_not_in_list. This exact bug shipped, got fixed, then regressed
+// when the fix was dropped — this test keeps it dead.
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const comfyDir = resolve(scriptDir, '../../server/api/comfy')
+
+// Keys whose string values are Comfy filename combos (validated by ComfyUI).
+const NAME_KEYS = [
+  'ckpt_name',
+  'lora_name',
+  'unet_name',
+  'vae_name',
+  'clip_name',
+  'clip_name1',
+  'clip_name2',
+  'text_encoder',
+]
+// A single-quoted literal that carries a backslash, e.g. 'ltx\\ltx-....'
+// (one backslash in the actual string == '\\' in TS source).
+const BACKSLASH_LITERAL = /'[^']*\\\\[^']*'/
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...walk(full))
+    else if (full.endsWith('.ts') && !full.endsWith('.test.ts')) out.push(full)
+  }
+  return out
+}
+
+const offenders: string[] = []
+for (const file of walk(comfyDir)) {
+  const lines = readFileSync(file, 'utf8').split('\n')
+  lines.forEach((line, index) => {
+    if (!NAME_KEYS.some((key) => line.includes(`${key}:`) || line.includes(`${key} =`))) {
+      // Also catch exported constants like `LTX_CHECKPOINT = 'ltx\\...'`.
+      if (!/[A-Z_]+(?:CHECKPOINT|LORA|MODEL|UNET|VAE|ENCODER)\s*=/.test(line)) return
+    }
+    if (BACKSLASH_LITERAL.test(line)) {
+      offenders.push(`${relative(comfyDir, file)}:${index + 1}  ${line.trim()}`)
+    }
+  })
+}
+
+assert.equal(
+  offenders.length,
+  0,
+  `Comfy model names must use forward slashes, not backslashes:\n${offenders.join('\n')}`,
+)
+
+console.log('✅ verifyComfyModelPaths: no backslash model paths in server/api/comfy')


### PR DESCRIPTION
## Summary

The LTX workflows hardcoded `ckpt_name: 'ltx\ltx-2.3-22b-dev-fp8.safetensors'` (and hunyuan3d `3d\hunyuan_3d_v2.1.safetensors`) with **Windows backslashes**. ComfyUI matches subfolder model paths with forward slashes on every OS, so these are rejected with `value_not_in_list` and every LTX video job 400s before it starts. This was fixed once and **regressed** when the branch was trimmed — so this PR also adds a guard.

## Changes

- Flip all six hardcoded literals to forward slashes: `server/api/comfy/ltx/text2Video.post.ts` (×2), `ltx/image2Video.post.ts` (×2), the `LTX_CHECKPOINT` constant in `ltx/utils/imageToVideoWorkflow.ts`, and `hunyuan3d.post.ts`.
- **`utils/scripts/verifyComfyModelPaths.ts`** (`test:comfy-model-paths`): fails if any `ckpt_name`/`lora_name`/`unet_name`/`vae_name`/`clip_name`/`text_encoder` literal — or an exported `*_CHECKPOINT`/`*_LORA`/etc. constant — under `server/api/comfy` carries a backslash. Keeps the fix from silently regressing again.

## Scope

This fixes only **newly built** LTX workflows. Jobs already queued froze the backslash into their payload; those need the relay's live-list resolver (silasfelinus/conductor#1369) or an editor edit to correct.

The separate LoRA-name failures (`FLUX/` vs `Flux/`, stray backslashes on lora_name) are **stored Resource data**, not this code — no code injects those. Tracking that down against ComfyUI's actual list is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_