### PR TITLE
art-styler: use the resource's real LoRA path (drop the FLUX/ prefix hack)

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1371,19 +1371,29 @@ async function hydrateFromResourceStore(): Promise<void> {
 
     if (!dbLoras.length) return
 
-    const builtinPaths = new Set(
-      styles.value
-        .map((style) => style.loraPath)
-        .filter((path): path is string => !!path),
+    // Match by filename stem (case/slash-insensitive), NOT by the full stored
+    // path — the builtins hardcode legacy `FLUX/...` strings that no longer
+    // exist on the art server, so the real match lives at a different folder
+    // (`Kontext/SFW/...`, `Flux/SFW/...`). We adopt the resource's actual
+    // localPath below so the workflow gets a name ComfyUI can resolve.
+    const stemOf = (path?: string | null): string =>
+      path
+        ?.replace(/\\/g, '/')
+        .split('/')
+        .pop()
+        ?.replace(/\.safetensors$/i, '')
+        .toLowerCase() || ''
+
+    const builtinStems = new Set(
+      styles.value.map((style) => stemOf(style.loraPath)).filter(Boolean),
     )
 
     const updated = styles.value.map((style) => {
-      const stem =
-        style.loraPath?.split('/').pop()?.replace('.safetensors', '') || ''
+      const stem = stemOf(style.loraPath)
 
       const match = dbLoras.find((resource) => {
         return (
-          (stem && resource.localPath?.includes(stem)) ||
+          (stem && stemOf(resource.localPath) === stem) ||
           resource.name?.toLowerCase().includes(style.label.toLowerCase())
         )
       })
@@ -1392,6 +1402,8 @@ async function hydrateFromResourceStore(): Promise<void> {
 
       return {
         ...style,
+        // Use the resource's real path, not the builtin's legacy `FLUX/...`.
+        loraPath: match.localPath || style.loraPath,
         resourceId: match.id,
         previewImageSrc: style.previewImageSrc || match.imagePath || undefined,
       }
@@ -1400,18 +1412,13 @@ async function hydrateFromResourceStore(): Promise<void> {
     const newFromDb = dbLoras
       .filter((resource) => {
         if (!resource.localPath) return false
-
-        const fullPath = resource.localPath.startsWith('FLUX/')
-          ? resource.localPath
-          : `FLUX/${resource.localPath}`
-
-        return !builtinPaths.has(fullPath)
+        // Dedupe against builtins by filename stem (a builtin already covers
+        // this LoRA under a legacy path); the DB path is used verbatim.
+        return !builtinStems.has(stemOf(resource.localPath))
       })
       .map((resource): StyleEntry => {
         return {
-          loraPath: resource.localPath!.startsWith('FLUX/')
-            ? resource.localPath!
-            : `FLUX/${resource.localPath}`,
+          loraPath: resource.localPath!,
           loraWeight: 1,
           triggerPhrase:
             resource.artPrompt || resource.customLabel || resource.name,


### PR DESCRIPTION
## Summary

The art-styler baked broken `lora_name` strings because it (1) hardcoded legacy `FLUX/<file>.safetensors` paths in its builtin styles and (2) **prepended `FLUX/`** to every DB-hydrated resource path. After the LoRAs were migrated to their real folders (`Kontext/SFW/…`, `Flux/SFW/…`), those old `FLUX/` strings no longer exist on the art server — so restyles 400'd with `value_not_in_list`, and a correct `Kontext/SFW/x.safetensors` resource was mangled into `FLUX/Kontext/SFW/x.safetensors`. This is the frontend source of the `FLUX/…` bad names.

## Changes (`components/art/art-styler.vue`)

- Match builtin styles to DB resources by **filename stem** (case/slash-insensitive) instead of the full legacy path, and **adopt the matched resource's real `localPath`** as the LoRA path.
- Use `resource.localPath` **verbatim** for DB-only styles — the `FLUX/`-prepend is gone.
- Dedupe builtins vs DB by stem.

## Context

Pairs with deleting the 21 redundant early `FLUX/…` LoRA resources (ids 45–74, minus the still-valid #48 and the checkpoints) so the matcher can only land on the correctly-located newer entries. The builtin styles keep their curated preview/logo art; only the resolved LoRA path changes.

Still to come (separate work): making the styler engine-agnostic with an SDXL-default img2img path and Kontext as a dedicated tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_