### PR TITLE
art: SDXL img2img restyle engine (sdxl-img2img)

### DIFF
--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -4,7 +4,10 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { authAndGate } from '../../utils/comfyGate'
 import { resolveEnqueueLoraResource } from '../../utils/artLoraResource'
-import { buildDefaultComfyWorkflow } from '../comfy/sdxl/utils/workflow'
+import {
+  buildDefaultComfyWorkflow,
+  buildSdxlImg2ImgWorkflow,
+} from '../comfy/sdxl/utils/workflow'
 import { buildFluxWorkflowFromRequest } from '../comfy/flux/utils/workflow'
 import { buildKrea2WorkflowFromRequest } from '../comfy/krea2/utils/workflow'
 import { buildFlux2KleinWorkflowFromRequest } from '../comfy/flux2/utils/workflow'
@@ -39,6 +42,7 @@ const ART_FACET_WORKFLOW_KEY = '__kindRobotsFacetSelection'
 type EnqueueEngine =
   | 'a1111'
   | 'comfy'
+  | 'sdxl-img2img'
   | 'flux'
   | 'krea2'
   | 'flux2'
@@ -73,6 +77,7 @@ type ArtEnqueueRequest = {
   guidance?: number | null
   denoise?: number | null
   seed?: number | null
+  originalWeight?: number | null
   width?: number | null
   height?: number | null
   variant?: 'dev' | 'schnell' | null
@@ -115,6 +120,9 @@ const ENGINE_ALIASES: Record<string, EnqueueEngine> = {
   'flux2-klein': 'flux2',
   'flux-2': 'flux2',
   sdxl: 'comfy',
+  'sdxl-restyle': 'sdxl-img2img',
+  'sdxl-i2i': 'sdxl-img2img',
+  'sdxl-image': 'sdxl-img2img',
 }
 const VIDEO_ENGINES = new Set<EnqueueEngine>(['ltx', 'wan'])
 const DEFAULT_VIDEO_NEGATIVE =
@@ -125,6 +133,7 @@ const GATE_ENGINE: Record<
 > = {
   a1111: 'comfy',
   comfy: 'comfy',
+  'sdxl-img2img': 'comfy',
   flux: 'flux',
   krea2: 'comfy',
   flux2: 'comfy',
@@ -211,6 +220,7 @@ function normalizeEngine(value: unknown): EnqueueEngine {
   if (
     engine === 'a1111' ||
     engine === 'comfy' ||
+    engine === 'sdxl-img2img' ||
     engine === 'flux' ||
     engine === 'krea2' ||
     engine === 'flux2' ||
@@ -464,6 +474,45 @@ function buildJobPayload(
       loraStrength: body.loraStrength ?? null,
     })
     return { jobEngine: 'COMFY', payload: { workflow, promptString, save } }
+  }
+
+  if (engine === 'sdxl-img2img') {
+    const imageData = body.sourceImageBase64?.trim()
+    if (!imageData) {
+      throw createError({
+        statusCode: 400,
+        message: 'SDXL img2img restyle requires "sourceImageBase64".',
+      })
+    }
+    const normalizedImageData = imageData.startsWith('data:image/')
+      ? imageData
+      : `data:image/png;base64,${imageData}`
+    const extension = getKontextImageExtension(normalizedImageData)
+    const imageName = `kr_sdxl_restyle_${crypto.randomUUID()}.${extension}`
+    const { workflow } = buildSdxlImg2ImgWorkflow({
+      prompt: promptString,
+      negativePrompt: body.negativePrompt ?? null,
+      imageName,
+      checkpoint: body.checkpoint ?? null,
+      cfgValue: body.cfg ?? null,
+      steps: body.steps ?? null,
+      seed: body.seed ?? null,
+      sampler: body.sampler ?? null,
+      scheduler: body.scheduler ?? null,
+      originalWeight: body.originalWeight ?? null,
+      denoise: body.denoise ?? null,
+      loraName: body.loraName ?? null,
+      loraStrength: body.loraStrength ?? null,
+    })
+    return {
+      jobEngine: 'COMFY',
+      payload: {
+        workflow,
+        promptString,
+        images: [{ name: imageName, imageData: normalizedImageData }],
+        save,
+      },
+    }
   }
 
   if (engine === 'kontext') {

--- a/server/api/comfy/sdxl/utils/workflow.ts
+++ b/server/api/comfy/sdxl/utils/workflow.ts
@@ -126,6 +126,165 @@ export function patchComfyWorkflow(
   }
 }
 
+export type SdxlImg2ImgInput = {
+  prompt: string
+  negativePrompt?: string | null
+  // Filename the relay uploads to Comfy's input folder (see the `images` payload
+  // the enqueue route builds), referenced by the LoadImage node below.
+  imageName: string
+  checkpoint?: string | null
+  cfgValue?: number | null
+  steps?: number | null
+  seed?: number | null
+  sampler?: string | null
+  scheduler?: string | null
+  // How much of the ORIGINAL image to preserve, 0..1. denoise = 1 - originalWeight
+  // (floored to MIN_SDXL_IMG2IMG_DENOISE), so a higher weight keeps more of the
+  // source composition/subject and gives the checkpoint + style LoRA less room to
+  // repaint. When omitted, an explicit `denoise` is used; when both are omitted a
+  // restyle-friendly default is applied.
+  originalWeight?: number | null
+  denoise?: number | null
+  // Optional style LoRA. Unlike the Flux/Kontext model-only splice, SDXL style
+  // LoRAs frequently carry text-encoder weights, so a full LoraLoader (model +
+  // clip) is used and the CLIP encoders read through it too.
+  loraName?: string | null
+  loraStrength?: number | null
+  filenamePrefix?: string | null
+}
+
+// Defaults tuned for the SDXL-Turbo base (dreamshaperXL_v21TurboDPMSDE): few
+// steps, low cfg, DPM++ SDE / Karras. A non-Turbo checkpoint still renders with
+// these but the UI is expected to expose step/cfg overrides.
+export const DEFAULT_SDXL_IMG2IMG_ORIGINAL_WEIGHT = 0.35
+const MIN_SDXL_IMG2IMG_DENOISE = 0.15
+const DEFAULT_SDXL_IMG2IMG_CHECKPOINT = 'dreamshaperXL_v21TurboDPMSDE.safetensors'
+
+function resolveSdxlSeed(seed?: number | null): number {
+  if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {
+    return Math.floor(seed)
+  }
+  return Math.floor(Math.random() * 2_147_483_647)
+}
+
+function clampUnit(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+// SDXL restyle: VAE-encode the source photo and sample from it at a reduced
+// denoise so the composition survives while the checkpoint (and optional style
+// LoRA) reinterpret the look. Mirrors the img2img shape of the Kontext builder,
+// but on a plain CheckpointLoaderSimple graph (baked CLIP + VAE).
+export function buildSdxlImg2ImgWorkflow(input: SdxlImg2ImgInput): {
+  workflow: ComfyWorkflow
+  seed: number
+  denoise: number
+} {
+  const seed = resolveSdxlSeed(input.seed)
+  const steps = input.steps ?? 8
+  const cfg = input.cfgValue || 2
+  const sampler = input.sampler
+    ? normalizeComfySampler(input.sampler)
+    : 'dpmpp_sde'
+  const scheduler = input.scheduler?.trim() || 'karras'
+  const checkpoint = input.checkpoint?.trim() || DEFAULT_SDXL_IMG2IMG_CHECKPOINT
+
+  const originalWeight =
+    typeof input.originalWeight === 'number' &&
+    Number.isFinite(input.originalWeight)
+      ? clampUnit(input.originalWeight)
+      : null
+  const denoise =
+    originalWeight !== null
+      ? Math.min(1, Math.max(MIN_SDXL_IMG2IMG_DENOISE, 1 - originalWeight))
+      : typeof input.denoise === 'number' && Number.isFinite(input.denoise)
+        ? Math.min(1, Math.max(MIN_SDXL_IMG2IMG_DENOISE, input.denoise))
+        : 1 - DEFAULT_SDXL_IMG2IMG_ORIGINAL_WEIGHT
+
+  const loraName = input.loraName?.trim() || ''
+  const loraStrength =
+    typeof input.loraStrength === 'number' && Number.isFinite(input.loraStrength)
+      ? input.loraStrength
+      : 1
+
+  // Model + CLIP sources flip to the LoRA loader when a style LoRA is applied.
+  const modelSource: [string, number] = loraName ? ['10', 0] : ['1', 0]
+  const clipSource: [string, number] = loraName ? ['10', 1] : ['1', 1]
+
+  const workflow: ComfyWorkflow = {
+    '1': {
+      class_type: 'CheckpointLoaderSimple',
+      inputs: { ckpt_name: checkpoint },
+      _meta: { title: 'Load Checkpoint' },
+    },
+    '2': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: input.prompt, clip: clipSource },
+      _meta: { title: 'Positive Prompt' },
+    },
+    '3': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: input.negativePrompt || '', clip: clipSource },
+      _meta: { title: 'Negative Prompt' },
+    },
+    '4': {
+      class_type: 'LoadImage',
+      inputs: { image: input.imageName },
+      _meta: { title: 'Load Source Image' },
+    },
+    '5': {
+      class_type: 'VAEEncode',
+      inputs: { pixels: ['4', 0], vae: ['1', 2] },
+      _meta: { title: 'VAE Encode (img2img init)' },
+    },
+    '6': {
+      class_type: 'KSampler',
+      inputs: {
+        seed,
+        steps,
+        cfg,
+        sampler_name: sampler,
+        scheduler,
+        denoise,
+        model: modelSource,
+        positive: ['2', 0],
+        negative: ['3', 0],
+        latent_image: ['5', 0],
+      },
+      _meta: { title: 'KSampler' },
+    },
+    '7': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['6', 0], vae: ['1', 2] },
+      _meta: { title: 'VAE Decode' },
+    },
+    '8': {
+      class_type: 'SaveImage',
+      inputs: {
+        filename_prefix: input.filenamePrefix || 'kindrobots_sdxl_restyle',
+        images: ['7', 0],
+      },
+      _meta: { title: 'Save Image' },
+    },
+  }
+
+  if (loraName) {
+    workflow['10'] = {
+      class_type: 'LoraLoader',
+      inputs: {
+        model: ['1', 0],
+        clip: ['1', 1],
+        lora_name: loraName,
+        strength_model: loraStrength,
+        strength_clip: loraStrength,
+      },
+      _meta: { title: 'Style LoRA' },
+    }
+  }
+
+  return { workflow, seed, denoise }
+}
+
 export function buildDefaultComfyWorkflow({
   prompt,
   negativePrompt,

--- a/server/api/comfy/sdxl/utils/workflow.ts
+++ b/server/api/comfy/sdxl/utils/workflow.ts
@@ -158,7 +158,12 @@ export type SdxlImg2ImgInput = {
 // these but the UI is expected to expose step/cfg overrides.
 export const DEFAULT_SDXL_IMG2IMG_ORIGINAL_WEIGHT = 0.35
 const MIN_SDXL_IMG2IMG_DENOISE = 0.15
-const DEFAULT_SDXL_IMG2IMG_CHECKPOINT = 'dreamshaperXL_v21TurboDPMSDE.safetensors'
+// Subfolder-qualified, matching how ComfyUI lists a recursive checkpoints dir
+// (files live under SDXL/, Flux/, … so a bare filename would not resolve). The
+// styler is expected to pass the checkpoint Resource's real localPath; this is
+// only the fallback when none is supplied.
+const DEFAULT_SDXL_IMG2IMG_CHECKPOINT =
+  'SDXL/dreamshaperXL_v21TurboDPMSDE.safetensors'
 
 function resolveSdxlSeed(seed?: number | null): number {
   if (typeof seed === 'number' && Number.isFinite(seed) && seed >= 0) {

--- a/server/utils/artLoraResource.ts
+++ b/server/utils/artLoraResource.ts
@@ -30,6 +30,7 @@ const RESOURCE_RESOLVED_ENGINES = new Set([
   'flux2',
   'ltx',
   'wan',
+  'sdxl-img2img',
 ])
 
 function normalizeText(value: unknown): string {
@@ -137,6 +138,14 @@ function compatibilityRank(
     if (resource.supportedServer === SupportedServer.FLUX) return 30
     if (resource.supportedServer === SupportedServer.KONTEXT) return 20
     if (resource.supportedServer === SupportedServer.GENERIC) return 10
+  }
+
+  if (engine === 'sdxl-img2img') {
+    if (resource.supportedServer === SupportedServer.SDXL) return 30
+    if (resource.supportedServer === SupportedServer.COMFY) return 15
+    if (resource.supportedServer === SupportedServer.GENERIC) return 10
+    // SD15 LoRAs are a different architecture and won't load on an SDXL
+    // checkpoint, so they stay rank 0 (blocked by the strict check below).
   }
 
   if (engine === 'ltx') {
@@ -276,7 +285,9 @@ export async function resolveEnqueueLoraResource(input: {
   }
 
   if (
-    (input.engine === 'ltx' || input.engine === 'wan') &&
+    (input.engine === 'ltx' ||
+      input.engine === 'wan' ||
+      input.engine === 'sdxl-img2img') &&
     compatibilityRank(resource, input.engine) === 0
   ) {
     throw createError({


### PR DESCRIPTION
## Summary

Adds a real **SDXL image-to-image restyle** backend. The SDXL engine was txt2img only (`EmptyLatentImage`), so restyling an existing image on an SDXL checkpoint had no path. This is the foundation for making the art-styler engine-agnostic (SDXL default + Kontext tab).

## What's new

**`buildSdxlImg2ImgWorkflow`** — `server/api/comfy/sdxl/utils/workflow.ts`
`CheckpointLoaderSimple → LoadImage → VAEEncode → KSampler(denoise<1) → VAEDecode → SaveImage`.
- `originalWeight` (0..1) → `denoise = 1 - originalWeight` (floored at 0.15): higher weight preserves more of the source composition/subject, lower lets the checkpoint + LoRA repaint more.
- Optional **full `LoraLoader` (model + clip)** — SDXL style LoRAs frequently carry text-encoder weights, so CLIP reads through the LoRA too (unlike the Flux/Kontext model-only splice).
- Turbo-friendly defaults (8 steps, cfg 2, `dpmpp_sde`/`karras`) for the default `dreamshaperXL_v21TurboDPMSDE` base; UI is expected to expose overrides.

**`sdxl-img2img` enqueue engine** — `server/api/art/enqueue.post.ts`
Aliases `sdxl-restyle` / `sdxl-i2i` / `sdxl-image`; gated as `comfy`; requires `sourceImageBase64`; uploads it via the same `images` payload Kontext/video already use (no relay change needed); carries `originalWeight`.

**LoRA resolution** — `server/utils/artLoraResource.ts`
`sdxl-img2img` now resolves `loraName`/`loraResourceIds` to the Resource's real `localPath` with SDXL ranking (**SDXL 30 > COMFY 15 > GENERIC 10**; SD15/Flux/Kontext stay rank 0 and are **refused as incompatible**), so a restyle can only ever bake a path ComfyUI can load.

## How to fire a test render (once merged)

```bash
curl -sX POST https://<host>/api/art/enqueue \
  -H 'Content-Type: application/json' -H 'Cookie: <auth>' \
  -d '{"engine":"sdxl-img2img","promptString":"<style prompt>",
       "checkpoint":"dreamshaperXL_v21TurboDPMSDE.safetensors",
       "loraResourceIds":[<sdxl-lora-id>],"originalWeight":0.35,
       "sourceImageBase64":"data:image/png;base64,..."}'
```

## Not in this PR (next step)

Wiring the art-styler UI to send `sdxl-img2img` with an engine picker / Kontext tab. This PR is the backend so the render path exists and is API-testable first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_