### PR TITLE
model-builder: enforce stage approval server-side before commit

### DIFF
--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -7,6 +7,7 @@ import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import { assertRunAccess, getItemId, parseStoredJson } from '../../runs/index'
 import { CREATE_TARGETS, fieldSpecFor } from '~/stores/helpers/modelBuilderFields'
+import { BUILD_STAGES } from '~/stores/helpers/modelBuilderRecipes'
 import { syncCharacterFacetsInTransaction } from '~/server/utils/characterFacetSync'
 import { syncBotFacetsInTransaction } from '~/server/utils/botFacetSync'
 import type { FacetTaxonomy } from '~/server/utils/facetCatalog'
@@ -519,6 +520,34 @@ export default defineEventHandler(async (event) => {
       return { success: false, message: 'Build item not found.', statusCode: 404 }
     }
     assertRunAccess(item.Run, auth.user)
+
+    // The front-end only ever calls commitItem() once COMMIT has unlocked,
+    // which approveStage only does after PITCH, FIELDS_AND_PROMPTS, and
+    // GENERATE_ASSETS are each approved in turn — but that sequencing lives
+    // entirely in the client state machine. This route trusted the client to
+    // have gotten there, so a direct POST (bad client state, a retried/
+    // replayed request, or just curl) for an item still sitting at 'locked'/
+    // 'ready'/'rejected' could create/update/promote straight from an
+    // unreviewed draft — the exact "silently rewrites a canonical model"
+    // outcome this module's own header comment says COMMIT must never cause.
+    // dryRun previews the plan without writing, so it's exempt.
+    if (!dryRun) {
+      const currentStages = parseStoredJson<Record<string, { status?: string }>>(
+        item.stageStatuses,
+        {},
+      )
+      const unapprovedStage = BUILD_STAGES.find(
+        (stage) =>
+          stage.key !== 'COMMIT' &&
+          currentStages[stage.key]?.status !== 'approved',
+      )
+      if (unapprovedStage) {
+        throw createError({
+          statusCode: 400,
+          message: `${unapprovedStage.label} must be approved before committing.`,
+        })
+      }
+    }
 
     const sourceType = item.Run.sourceType
     if (!isSourceType(sourceType)) {


### PR DESCRIPTION
## Bug

`server/api/model-builder/items/[id]/commit.post.ts` executes the durable CREATE/UPDATE/ASSET_ONLY write for a build item without ever checking `item.stageStatuses`. The entire "human-gated" review flow the module's own header comment describes — a run resumes through PITCH → FIELDS_AND_PROMPTS → GENERATE_ASSETS → COMMIT, each gated behind explicit user approval — is enforced only client-side, in `stores/modelBuilderStore.ts`'s `approveStage`/`isLocked` logic (COMMIT only unlocks once GENERATE_ASSETS has been approved, which itself only unlocks once FIELDS_AND_PROMPTS was approved, etc.). The server route trusted that by the time a POST hit it, that sequence had happened.

**Concrete failure scenario:** a direct `POST /api/model-builder/items/{id}/commit` for an item still sitting at `'locked'`, `'ready'`, or `'rejected'` on PITCH/FIELDS_AND_PROMPTS/GENERATE_ASSETS — from a replayed/duplicated request, a client-state bug, or simply `curl` with a valid session — creates a Character/Reward/Scenario/Dream/Bot/Project/Facet record (or writes an UPDATE, or promotes an ArtImage) straight from an unreviewed draft. The item's own owner still owns the write (ownership is already checked via `assertRunAccess`), so this isn't a cross-user issue, but it defeats the entire point of the gated workflow: the module's own header comment states COMMIT must "never silently rewrite a canonical model," and an unapproved-draft commit is exactly that.

## Fix

Before executing the write (the `dryRun` preview path is unaffected, since it doesn't mutate anything), verify every non-COMMIT stage in `BUILD_STAGES` shows `status === 'approved'` in the item's persisted `stageStatuses`, and 400 with the first unapproved stage's label if not:

```ts
if (!dryRun) {
  const currentStages = parseStoredJson<Record<string, { status?: string }>>(
    item.stageStatuses,
    {},
  )
  const unapprovedStage = BUILD_STAGES.find(
    (stage) =>
      stage.key !== 'COMMIT' &&
      currentStages[stage.key]?.status !== 'approved',
  )
  if (unapprovedStage) {
    throw createError({
      statusCode: 400,
      message: `${unapprovedStage.label} must be approved before committing.`,
    })
  }
}
```

This reuses `parseStoredJson` (already imported in this file) and `BUILD_STAGES` (the same ordered stage list the client's `stageIndex`/`freshStages` are built from), so the server-side notion of "must be approved" stays in lockstep with the client's stage list if it ever changes.

## Verification

- `npx eslint "server/api/model-builder/items/[id]/commit.post.ts"` — clean, both before (`git stash`) and after the change.
- `npm run test` (`vue-tsc --noEmit` across the whole project, per `package.json`) — clean, no new errors.
- Manually re-read the full commit flow (client `commitItem()` → server route) plus the item panel's gating (`isLocked('COMMIT')`) to confirm the fix's approval requirement matches exactly what the UI already enforces client-side — so no legitimate, UI-driven commit is newly blocked.
- Confirmed this is a distinct gap from the existing `verifyModelBuilderCompletionGate.ts` / `verifyModelBuilderApprovedAssetGuard.ts` / `verifyModelBuilderCancelledRunGuard.ts` regression guards, which all cover client-side store races, not server-side stage-approval enforcement on the commit route itself.

Scope: touches only `server/api/model-builder/items/[id]/commit.post.ts` (Model Builder surface).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FE9acdcBxxy51x7TwjdssC)_