### PR TITLE
media-watchlist/t-006: add "Related entries" to the Entry Detail panel

### DIFF
--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -155,6 +155,41 @@
       <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
     </div>
 
+    <!-- Related entries -->
+    <div class="flex flex-col gap-1">
+      <h3
+        class="text-xs font-black uppercase tracking-wide text-base-content/60"
+      >
+        Related entries
+      </h3>
+      <p v-if="isLoadingRelated" class="text-xs text-base-content/45">
+        Loading…
+      </p>
+      <p
+        v-else-if="!relatedEntries.length"
+        class="text-xs text-base-content/45"
+      >
+        None
+      </p>
+      <ul v-else class="flex flex-col gap-1">
+        <li
+          v-for="related in relatedEntries"
+          :key="related.id"
+          class="flex items-center gap-2 text-xs text-base-content/70"
+        >
+          <Icon
+            v-if="related.starred"
+            name="kind-icon:star"
+            class="size-3 shrink-0 text-warning"
+          />
+          <span class="badge badge-ghost badge-sm rounded-lg">{{
+            related.mediaType
+          }}</span>
+          <span>{{ related.year ?? 'Year unknown' }}</span>
+        </li>
+      </ul>
+    </div>
+
     <!-- External links -->
     <div v-if="entry.externalUrl" class="flex flex-col gap-1">
       <h3
@@ -175,7 +210,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import type { MediaType } from '~/prisma/generated/prisma/client'
 
 export type MediaEntryDetail = {
@@ -194,9 +229,24 @@ export type MediaEntryDetail = {
   externalUrl: string | null
 }
 
+type RelatedEntry = {
+  id: number
+  title: string
+  mediaType: MediaType
+  year: number | null
+  starred: boolean
+  watchedMonth: number | null
+  watchedDay: number | null
+}
+
 type MediaEntryPatchResponse = {
   success: boolean
   data: MediaEntryDetail
+}
+
+type MediaEntryRelatedResponse = {
+  success: boolean
+  data: RelatedEntry[]
 }
 
 const props = defineProps<{ entry: MediaEntryDetail }>()
@@ -208,14 +258,36 @@ const isPublishing = ref(false)
 const isSavingStar = ref(false)
 const isSavingRating = ref(false)
 const errorMessage = ref('')
+const relatedEntries = ref<RelatedEntry[]>([])
+const isLoadingRelated = ref(false)
+
+async function fetchRelated(id: number) {
+  isLoadingRelated.value = true
+  try {
+    const res = await $fetch<MediaEntryRelatedResponse, string>(
+      `/api/media-entries/${id}/related`,
+    )
+    relatedEntries.value = res?.success ? res.data : []
+  } catch {
+    // Related entries are non-critical; leave the section empty on failure.
+    relatedEntries.value = []
+  } finally {
+    isLoadingRelated.value = false
+  }
+}
+
+onMounted(() => {
+  void fetchRelated(props.entry.id)
+})
 
 // Reset local draft state whenever a different entry is selected.
 watch(
   () => props.entry.id,
-  () => {
+  (id) => {
     draft.value = props.entry.review ?? ''
     saveState.value = 'idle'
     errorMessage.value = ''
+    void fetchRelated(id)
   },
 )
 

--- a/server/api/media-entries/[id]/related.get.ts
+++ b/server/api/media-entries/[id]/related.get.ts
@@ -1,0 +1,54 @@
+// GET /api/media-entries/:id/related
+//
+// "Related entries — same title, other years or formats" for the Entry
+// Detail panel (media-watchlist/t-006, BROWSE-UX.md §3). Admin-gated, same
+// convention as the other media-entries routes.
+import { defineEventHandler, getRouterParam, createError } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireAdminApiUser } from '~/server/utils/authGuard'
+
+const RELATED_LIMIT = 10
+
+export default defineEventHandler(async (event) => {
+  try {
+    await requireAdminApiUser(event)
+
+    const rawId = getRouterParam(event, 'id')
+    const id = Number(rawId)
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid media entry id.' })
+    }
+
+    const entry = await prisma.mediaEntry.findUnique({
+      where: { id },
+      select: { title: true },
+    })
+    if (!entry) {
+      throw createError({ statusCode: 404, message: 'Media entry not found.' })
+    }
+
+    const related = await prisma.mediaEntry.findMany({
+      where: { title: entry.title, id: { not: id } },
+      select: {
+        id: true,
+        title: true,
+        mediaType: true,
+        year: true,
+        starred: true,
+        watchedMonth: true,
+        watchedDay: true,
+      },
+      orderBy: [
+        { year: 'desc' },
+        { watchedMonth: 'desc' },
+        { watchedDay: 'desc' },
+      ],
+      take: RELATED_LIMIT,
+    })
+
+    return { success: true, data: related }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})


### PR DESCRIPTION
### Task
media-watchlist/t-006: Polish and upgrade Media Watchlist front-end surface (kind: software, recurring)

### What changed / what I produced
BROWSE-UX.md §3 specs an Entry Detail "Related entries — same title, other years or formats" section that was never built (checked directly against `watchlist-entry-detail.vue` — no such section existed). This cycle's slice of the recurring polish task closes that gap:
- `server/api/media-entries/[id]/related.get.ts` (new): admin-gated route that looks up other `MediaEntry` rows sharing the current entry's title, excluding itself, ordered newest-first (year, then month, then day), capped at 10.
- `components/watchlist/watchlist-entry-detail.vue`: fetches related entries on mount and whenever the selected entry changes, and renders them as a small non-interactive list between the Review editor and External links sections (mirrors the badge/star styling the browse list's entry cards already use). Shows "None" when there are no other entries with the same title.

### How I verified
- `npx eslint` clean on both changed files.
- `npx prettier --check` clean (ran `--write` once to match house style).
- Full-project `vue-tsc --noEmit`: 0 errors.
- Live browser smoke deferred — no reachable `DATABASE_URL` in this sandbox (same class of blocker as several prior tasks on this exact task line, e.g. PR #1051/#1057).

### Stakes
reversible

### Flags for Reviewer
- Related entries are matched on exact title equality (same convention `index.get.ts`'s search filter and this DB's collation already rely on — no `mode: 'insensitive'`, MySQL's default collation is case-insensitive).
- Kept the list read-only/non-interactive rather than wiring click-to-select-that-entry: the currently-selected entry lives in the parent `watchlist-browse.vue`'s paginated `entries` array, and a related entry can easily fall outside the currently loaded page — selecting it would need a new "fetch entry by id" path that's out of scope for this slice.

### Notes for reviewer
Session-directed run (conductor scheduled burst-mode rotation) — claimed via `claim_task.py media-watchlist t-006`, roadmap flipped to `status: review` before opening this PR. This is a recurring "Polish and upgrade" task; other BROWSE-UX.md gaps (dashboard-tab/tutorial art, admin Placements click) remain the same open items as every prior cycle and are unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FR1N5FtXb8WPs4J2JQQNv8)_