### PR TITLE
scripts: checkpoint audit --files mode (files on a different box than the DB)

### DIFF
--- a/utils/scripts/auditCheckpointResources.ts
+++ b/utils/scripts/auditCheckpointResources.ts
@@ -4,16 +4,30 @@
 // files on disk, to answer "are our checkpoints double-listed or incomplete?".
 // READ-ONLY — it never writes to the database.
 //
-// Run on the box that has both the DB and the ComfyUI models dir:
-//   npm run audit:checkpoints                       # default dir + text report
+// Run on the box that has the DB (Silas-PC/WSL); the files can live elsewhere.
+//   npm run audit:checkpoints                       # scan default dir
 //   npm run audit:checkpoints -- --dir=/path/to/checkpoints
+//   npm run audit:checkpoints -- --files=list.txt   # use a pre-made file list
 //   npm run audit:checkpoints -- --json             # machine-readable
+//
+// --files decouples "where the checkpoints live" from "where node + the DB
+// run" — handy when the models sit on another box (e.g. alexandria) that the
+// WSL box only sees as an unmounted network drive. Generate the list WHERE the
+// files are, then feed it here:
+//   # on the box that has the files:
+//   find /mnt/user/pc/ai/models/checkpoints -type f \
+//     \( -name '*.safetensors' -o -name '*.ckpt' -o -name '*.pt' \
+//        -o -name '*.gguf' -o -name '*.sft' \) -printf '%P\n' > ckpts.txt
+//   # then, on the DB box:
+//   npm run audit:checkpoints -- --files=ckpts.txt
+// Each line may be a bare `%P` relative path, a full absolute path, or a `ls`
+// line — anything after the last `.../checkpoints/` is taken as the real path.
 //
 // Matching is by filename (basename), because a Resource's stored folder may
 // differ from where the file actually lives — that mismatch is itself a finding
 // (ComfyUI needs the subfolder-qualified path, e.g. `SDXL/foo.safetensors`).
 import 'dotenv/config'
-import { readdir } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { join, posix } from 'node:path'
 import { PrismaClient } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
@@ -25,6 +39,9 @@ const DEFAULT_DIR =
 const args = process.argv.slice(2)
 const asJson = args.includes('--json')
 const dirArg = args.find((a) => a.startsWith('--dir='))?.slice('--dir='.length)
+const filesArg = args
+  .find((a) => a.startsWith('--files='))
+  ?.slice('--files='.length)
 const rootDir = (dirArg || DEFAULT_DIR).replace(/\/+$/, '')
 
 function normalizePath(value: unknown): string {
@@ -40,6 +57,29 @@ function basenameOf(path: string): string {
 function hasCheckpointExt(name: string): boolean {
   const lower = name.toLowerCase()
   return CHECKPOINT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+// Reduce an arbitrary path/line to the subfolder-qualified path ComfyUI would
+// list: strip everything through the last `.../checkpoints/`, else keep the
+// relative remainder. Handles bare `%P` output, absolute paths, and `ls` lines.
+function toCheckpointRelPath(line: string): string {
+  const normalized = line.trim().replaceAll('\\', '/')
+  const marker = '/checkpoints/'
+  const idx = normalized.toLowerCase().lastIndexOf(marker)
+  const rel = idx >= 0 ? normalized.slice(idx + marker.length) : normalized
+  return rel.replace(/^\/+/, '')
+}
+
+// Parse a newline-delimited file list (from `find … -printf '%P\n'`, `ls`, etc.)
+// into subfolder-qualified checkpoint paths.
+async function readCheckpointFileList(path: string): Promise<string[]> {
+  const raw = await readFile(path, 'utf8')
+  const seen = new Set<string>()
+  for (const line of raw.split(/\r?\n/)) {
+    const rel = toCheckpointRelPath(line)
+    if (rel && hasCheckpointExt(rel)) seen.add(rel)
+  }
+  return [...seen]
 }
 
 // Recursively list checkpoint files as subfolder-qualified, posix-style paths
@@ -72,13 +112,24 @@ async function main(): Promise<void> {
   if (!databaseUrl) throw new Error('DATABASE_URL is not set.')
 
   let files: string[]
-  try {
-    files = await listCheckpointFiles(rootDir)
-  } catch (error) {
-    throw new Error(
-      `Could not read checkpoints dir "${rootDir}": ${(error as Error).message}. ` +
-        `Pass --dir=/actual/path or set COMFY_CHECKPOINTS_DIR.`,
-    )
+  if (filesArg) {
+    try {
+      files = await readCheckpointFileList(filesArg)
+    } catch (error) {
+      throw new Error(
+        `Could not read file list "${filesArg}": ${(error as Error).message}.`,
+      )
+    }
+  } else {
+    try {
+      files = await listCheckpointFiles(rootDir)
+    } catch (error) {
+      throw new Error(
+        `Could not read checkpoints dir "${rootDir}": ${(error as Error).message}. ` +
+          `Pass --dir=/actual/path, --files=list.txt, or set COMFY_CHECKPOINTS_DIR. ` +
+          `(On WSL a mapped network drive like Z: often isn't under /mnt — use --files.)`,
+      )
+    }
   }
 
   const prisma = new PrismaClient({
@@ -149,11 +200,13 @@ async function main(): Promise<void> {
     (f) => /\s/.test(basenameOf(f)) || basenameOf(f) !== basenameOf(f).trim(),
   )
 
+  const source = filesArg ? `file list: ${filesArg}` : rootDir
+
   if (asJson) {
     console.log(
       JSON.stringify(
         {
-          rootDir,
+          source,
           counts: {
             filesOnDisk: files.length,
             resourcesTotal: resources.length,
@@ -185,9 +238,9 @@ async function main(): Promise<void> {
   }
 
   const line = (s: string) => console.log(s)
-  line(`\n📦 Checkpoint audit — ${rootDir}`)
+  line(`\n📦 Checkpoint audit — ${source}`)
   line(
-    `   ${files.length} files on disk · ${resources.length} CHECKPOINT resources ` +
+    `   ${files.length} files listed · ${resources.length} CHECKPOINT resources ` +
       `(${resources.filter((r) => r.isActive).length} active)\n`,
   )
 


### PR DESCRIPTION
## Why

The checkpoints live on **alexandria** (`/mnt/user/pc/ai/models/checkpoints`), but `npm`/the DB run on **Silas-PC (WSL)**, where that path is a mapped `Z:` network drive that isn't mounted under `/mnt` — so a directory scan `ENOENT`s regardless of how the path is spelled (`Z:/…`, `/mnt/z/…`, `/mnt/user/…` all failed).

## Fix

`--files=list.txt` reads a pre-generated newline list instead of scanning the filesystem, decoupling *where the files are* from *where node + the DB run*:

```bash
# on the box that HAS the files (alexandria):
find /mnt/user/pc/ai/models/checkpoints -type f \
  \( -name '*.safetensors' -o -name '*.ckpt' -o -name '*.pt' \
     -o -name '*.gguf' -o -name '*.sft' \) -printf '%P\n' > ckpts.txt

# on the DB box (Silas-PC), with ckpts.txt copied over:
npm run audit:checkpoints -- --files=ckpts.txt
```

Each line may be a bare `%P` relative path, an absolute path, or an `ls` line — anything after the last `.../checkpoints/` is taken as the real subfolder-qualified path. The report header names the actual source, and the dir-scan error now points at `--files` and the WSL network-drive gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_