### PR TITLE
academy: stop Remix Studio style previews from marking lessons "explored"

### DIFF
--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -41,6 +41,7 @@
           :lesson="academyStore.selectedStyle"
           :show-close="false"
           :show-remix-button="false"
+          :allow-mark-viewed="false"
         />
 
         <div

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -196,9 +196,12 @@
 // subset — check all three before changing a prop's default or meaning:
 //   - academy-timeline.vue: default props (close+remix shown), expanded list item
 //   - academy-styles-browser.vue: default props (close+remix shown), grid detail panel
-//   - academy-remix.vue: showClose=false, showRemixButton=false — read-only style
-//     summary in the Remix Studio sidebar, where remixing is already the page's
-//     primary action (a stray showRemixButton no-op button here was PR #301's bug)
+//   - academy-remix.vue: showClose=false, showRemixButton=false, allowMarkViewed=false
+//     — read-only style summary in the Remix Studio sidebar, where remixing is
+//     already the page's primary action (a stray showRemixButton no-op button
+//     here was PR #301's bug); allowMarkViewed=false stops incidental style
+//     preview clicks from inflating the Timeline/Gallery "explored" progress,
+//     which is meant to reflect deliberate lesson-reading, not style browsing
 import { computed, onMounted } from 'vue'
 import { useAcademyStore } from '@/stores/academyStore'
 import type { AcademyStyle } from '@/stores/seeds/academyStyles'


### PR DESCRIPTION
## Summary

`academy-style-detail.vue`'s `allowMarkViewed` prop (default `true`) fires `markLessonViewed` on mount. `academy-remix.vue`'s read-only sidebar usage — shown whenever a style is selected in the Remix Studio's style-transfer grid — never passed `allow-mark-viewed="false"`, so simply clicking through style tiles to preview thumbnails/labels (no source image needed, no generation performed) silently counted toward the Timeline/Gallery "explored" progress bar and lesson-count badges. That metric is meant to reflect deliberate lesson-reading in the Timeline/Style Gallery, not incidental browsing in the Remix picker.

- Passed `:allow-mark-viewed="false"` on the `academy-remix.vue` call site (the other two callers — `academy-timeline.vue`, `academy-styles-browser.vue` — are unaffected and keep the default).
- Updated `academy-style-detail.vue`'s caller-list comment to document the new prop value for this call site.

## Verification

- `npx eslint components/academy/academy-remix.vue components/academy/academy-style-detail.vue` — clean
- `npx prettier --check` on both files — clean
- `npm run test` (`vue-tsc --noEmit`) — exit 0
- `node utils/scripts/verifyAcademyStyleDetailCallers.ts` — caller-list contract still verifies (3 callers, unchanged)

Part of ai-art-academy/t-010 (recurring Academy continuous-improvement pass, lane 1: front-end polish).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZitXeiZQMS5EVhhbJAm6K)_