### PR TITLE
models: checkpoint browser at /models (grouped by base, non-image own section)

### DIFF
--- a/components/model/model-card.vue
+++ b/components/model/model-card.vue
@@ -1,0 +1,244 @@
+<!-- /components/model/model-card.vue -->
+<!--
+  A single checkpoint (base model) in the model browser. Mirrors <lora-card>
+  (reactable-card + preview image + base-model badge + localPath health + Edit),
+  but for CHECKPOINT resources: no trigger words, and it shows the base model /
+  folder rather than a LoRA type. Maturity gating matches lora-card — a mature
+  row is hidden (image + details) when the viewer hasn't opted in.
+-->
+<template>
+  <reactable-card
+    :compact="compact"
+    :show-reaction="canReact"
+    :target-id="reactionTargetId"
+    target-type="resource"
+    reaction-category="RESOURCE"
+    :target-title="modelLabel"
+    :card-class="isHiddenMature ? 'opacity-75' : ''"
+    @select="emitEdit"
+  >
+    <template v-if="showEdit" #actions>
+      <button
+        class="rounded-full bg-base-100 p-2 text-primary shadow transition hover:bg-primary hover:text-primary-content"
+        type="button"
+        title="Edit model"
+        @click.stop="emitEdit"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+      </button>
+    </template>
+
+    <div
+      v-if="showImage"
+      :class="[
+        'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
+        imageHeightClass,
+      ]"
+    >
+      <img
+        v-if="imageSource && !isHiddenMature"
+        :src="imageSource"
+        :alt="modelLabel"
+        class="h-full w-full object-cover transition-transform group-hover:scale-105"
+        loading="lazy"
+        @error="imageFailed = true"
+      />
+
+      <div
+        v-else
+        class="flex h-full w-full items-center justify-center bg-base-200"
+      >
+        <div class="flex flex-col items-center gap-2 text-base-content/45">
+          <Icon
+            :name="isHiddenMature ? 'kind-icon:lock' : 'kind-icon:checkpoint'"
+            class="h-10 w-10"
+          />
+
+          <span class="text-xs font-bold">
+            {{ isHiddenMature ? 'Mature hidden' : 'No preview' }}
+          </span>
+        </div>
+      </div>
+
+      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
+        <span v-if="baseModel" class="badge badge-secondary badge-sm">
+          {{ baseModel }}
+        </span>
+
+        <span
+          v-if="model.isMature && showMatureBadge"
+          class="badge badge-warning badge-sm"
+        >
+          Mature
+        </span>
+      </div>
+
+      <div
+        v-if="!hasLocalPath"
+        class="absolute bottom-2 right-2 badge badge-error badge-sm shadow"
+        title="No localPath — this checkpoint can't be sent to a render until it is re-scanned."
+      >
+        needs re-scan
+      </div>
+    </div>
+
+    <div class="flex min-w-0 flex-1 flex-col gap-2 text-center">
+      <h3
+        :class="[
+          'font-black leading-tight text-base-content line-clamp-2',
+          compact ? 'text-sm' : 'text-base',
+        ]"
+        :title="modelLabel"
+      >
+        {{ modelLabel }}
+      </h3>
+
+      <p
+        v-if="showDescription && modelDescription && !isHiddenMature"
+        class="line-clamp-2 text-xs text-base-content/60"
+      >
+        {{ modelDescription }}
+      </p>
+
+      <p
+        v-if="hasLocalPath && !isHiddenMature"
+        class="line-clamp-1 font-mono text-[11px] text-base-content/45"
+        :title="localPathText"
+      >
+        {{ localPathText }}
+      </p>
+
+      <div v-if="showMeta" class="flex flex-wrap justify-center gap-2">
+        <span v-if="model.civitaiUrl" class="badge badge-outline badge-sm">
+          Civitai
+        </span>
+
+        <span v-if="model.hash" class="badge badge-outline badge-sm">
+          hashed
+        </span>
+      </div>
+
+      <button
+        v-if="showEdit"
+        class="btn btn-sm btn-outline mt-auto rounded-xl"
+        type="button"
+        @click.stop="emitEdit"
+      >
+        <Icon name="kind-icon:edit" class="h-4 w-4" />
+        Edit
+      </button>
+    </div>
+  </reactable-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Resource } from '@/stores/resourceStore'
+
+const props = withDefaults(
+  defineProps<{
+    model: Partial<Resource>
+    showMature?: boolean
+    compact?: boolean
+    showImage?: boolean
+    showDescription?: boolean
+    showMeta?: boolean
+    showMatureBadge?: boolean
+    showReaction?: boolean
+    showEdit?: boolean
+    imageHeightClass?: string
+  }>(),
+  {
+    showMature: false,
+    compact: false,
+    showImage: true,
+    showDescription: true,
+    showMeta: true,
+    showMatureBadge: true,
+    showReaction: false,
+    showEdit: true,
+    imageHeightClass: 'h-44',
+  },
+)
+
+const emit = defineEmits<{
+  edit: [model: Partial<Resource>]
+}>()
+
+const imageFailed = ref(false)
+
+function safeText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return ''
+}
+
+const isHiddenMature = computed(() => {
+  return Boolean(props.model.isMature && !props.showMature)
+})
+
+const modelLabel = computed(() => {
+  if (isHiddenMature.value) return 'Hidden model'
+
+  return (
+    safeText(props.model.customLabel).trim() ||
+    safeText(props.model.name).trim() ||
+    'Unnamed model'
+  )
+})
+
+const modelDescription = computed(() => {
+  return safeText(props.model.description).trim()
+})
+
+const localPathText = computed(() => {
+  return safeText(props.model.localPath).trim()
+})
+
+// Base model: prefer the checkpoint's folder (the reliable post-repair signal),
+// then the tagged generation / supportedServer.
+const baseModel = computed(() => {
+  const path = localPathText.value.replaceAll('\\', '/').replace(/^\/+/, '')
+  const folder = path.includes('/') ? path.split('/')[0] : ''
+
+  return (
+    folder ||
+    safeText(props.model.generation).trim() ||
+    safeText(props.model.supportedServer).trim()
+  ).toUpperCase()
+})
+
+const hasLocalPath = computed(() => {
+  return localPathText.value.length > 0
+})
+
+const imageSource = computed(() => {
+  if (isHiddenMature.value || imageFailed.value) return ''
+
+  return (
+    safeText(props.model.previewImageUrl).trim() ||
+    safeText(props.model.imagePath).trim() ||
+    safeText(props.model.MediaPath).trim() ||
+    ''
+  )
+})
+
+const reactionTargetId = computed(() => {
+  const id = Number(props.model.id)
+
+  return Number.isInteger(id) && id > 0 ? id : 0
+})
+
+const canReact = computed(() => {
+  return Boolean(props.showReaction && reactionTargetId.value > 0)
+})
+
+function emitEdit() {
+  if (!props.showEdit) return
+
+  emit('edit', props.model)
+}
+</script>

--- a/components/model/model-gallery.vue
+++ b/components/model/model-gallery.vue
@@ -1,0 +1,240 @@
+<!-- /components/model/model-gallery.vue -->
+<!--
+  Model (checkpoint) browser. Reads resourceStore.visibleCheckpoints (account
+  maturity already applied), then layers search + base-model + maturity filters
+  and sort on top. Cards are grouped by base model; the non-image checkpoints
+  (3D / Audio / Video) render in their own section below a divider. Mirrors
+  <lora-gallery>, but there are only a few dozen checkpoints so it renders them
+  all (no pagination).
+-->
+<template>
+  <section class="flex h-full min-h-0 w-full flex-col gap-3 overflow-y-auto rounded-2xl bg-base-300 p-3">
+    <header class="sticky top-0 z-10 flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <h2 class="truncate text-lg font-bold text-base-content">
+            Models
+          </h2>
+          <p class="text-sm text-base-content/60">
+            {{ summaryText }}
+          </p>
+        </div>
+      </div>
+
+      <div class="grid gap-2 md:grid-cols-[1fr_auto_auto_auto]">
+        <input
+          v-model="searchQuery"
+          class="input input-bordered rounded-xl"
+          placeholder="Search name, label, path"
+        />
+
+        <select v-model="selectedBase" class="select select-bordered rounded-xl">
+          <option value="all">All bases</option>
+          <option v-for="base in baseOptions" :key="base" :value="base">
+            {{ base }}
+          </option>
+        </select>
+
+        <select v-model="maturityFilter" class="select select-bordered rounded-xl">
+          <option value="all">All ratings</option>
+          <option value="sfw">SFW only</option>
+          <option value="mature">Mature only</option>
+        </select>
+
+        <select v-model="sortBy" class="select select-bordered rounded-xl">
+          <option value="name">Name A–Z</option>
+          <option value="newest">Newest</option>
+        </select>
+      </div>
+    </header>
+
+    <div
+      v-if="!filteredModels.length"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+    >
+      <p class="font-bold">No models found.</p>
+      <p class="text-sm text-base-content/60">
+        {{
+          resourceStore.isLoading
+            ? 'Loading models…'
+            : 'Try another filter.'
+        }}
+      </p>
+    </div>
+
+    <template v-else>
+      <!-- Image base models, grouped -->
+      <div
+        v-for="group in imageGroups"
+        :key="`img-${group.base}`"
+        class="flex flex-col gap-2"
+      >
+        <h3 class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80">
+          <span class="badge badge-secondary badge-sm">{{ group.base }}</span>
+          <span class="text-base-content/45">{{ group.items.length }}</span>
+        </h3>
+
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+          <model-card
+            v-for="model in group.items"
+            :key="model.id || model.name"
+            :model="model"
+            :show-mature="showMature"
+            :show-edit="false"
+          />
+        </div>
+      </div>
+
+      <!-- Non-image checkpoints (3D / Audio / Video) in their own section -->
+      <template v-if="nonImageGroups.length">
+        <div class="divider text-xs font-bold uppercase text-base-content/50">
+          Other · non-image models
+        </div>
+
+        <div
+          v-for="group in nonImageGroups"
+          :key="`other-${group.base}`"
+          class="flex flex-col gap-2"
+        >
+          <h3 class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80">
+            <span class="badge badge-ghost badge-sm">{{ group.base }}</span>
+            <span class="text-base-content/45">{{ group.items.length }}</span>
+          </h3>
+
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+            <model-card
+              v-for="model in group.items"
+              :key="model.id || model.name"
+              :model="model"
+              :show-mature="showMature"
+              :show-edit="false"
+            />
+          </div>
+        </div>
+      </template>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useResourceStore, type Resource } from '@/stores/resourceStore'
+import { useUserStore } from '@/stores/userStore'
+
+const resourceStore = useResourceStore()
+const userStore = useUserStore()
+
+const searchQuery = ref('')
+const selectedBase = ref<string>('all')
+const maturityFilter = ref<'all' | 'sfw' | 'mature'>('all')
+const sortBy = ref<'name' | 'newest'>('name')
+
+const showMature = computed(() => userStore.showMature)
+
+// Base models that are not still-image checkpoints — grouped separately.
+const NON_IMAGE_BASES = new Set(['3D', 'AUDIO', 'VIDEO'])
+
+function safeText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return ''
+}
+
+// Base model: prefer the checkpoint's top folder (reliable post-repair), then
+// the tagged generation / supportedServer.
+function baseOf(model: Partial<Resource>): string {
+  const path = safeText(model.localPath).replaceAll('\\', '/').replace(/^\/+/, '')
+  const folder = path.includes('/') ? path.split('/')[0] : ''
+
+  return (
+    folder ||
+    safeText(model.generation).trim() ||
+    safeText(model.supportedServer).trim() ||
+    'OTHER'
+  ).toUpperCase()
+}
+
+const baseOptions = computed(() => {
+  const seen = new Set<string>()
+  for (const model of resourceStore.visibleCheckpoints) {
+    seen.add(baseOf(model))
+  }
+
+  return Array.from(seen).sort(
+    (a, b) =>
+      Number(NON_IMAGE_BASES.has(a)) - Number(NON_IMAGE_BASES.has(b)) ||
+      a.localeCompare(b),
+  )
+})
+
+const filteredModels = computed<Partial<Resource>[]>(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  return resourceStore.visibleCheckpoints.filter((model) => {
+    if (selectedBase.value !== 'all' && baseOf(model) !== selectedBase.value) {
+      return false
+    }
+
+    if (maturityFilter.value === 'sfw' && model.isMature) return false
+    if (maturityFilter.value === 'mature' && !model.isMature) return false
+
+    if (!query) return true
+
+    return [model.name, model.customLabel, model.description, model.localPath]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(query))
+  })
+})
+
+type ModelGroup = {
+  base: string
+  isNonImage: boolean
+  items: Partial<Resource>[]
+}
+
+const grouped = computed<ModelGroup[]>(() => {
+  const map = new Map<string, Partial<Resource>[]>()
+  for (const model of filteredModels.value) {
+    const base = baseOf(model)
+    const bucket = map.get(base) ?? map.set(base, []).get(base)!
+    bucket.push(model)
+  }
+
+  const groups: ModelGroup[] = [...map.entries()].map(([base, items]) => ({
+    base,
+    isNonImage: NON_IMAGE_BASES.has(base),
+    items: [...items].sort((a, b) =>
+      sortBy.value === 'newest'
+        ? Number(b.id ?? 0) - Number(a.id ?? 0)
+        : safeText(a.customLabel || a.name).localeCompare(
+            safeText(b.customLabel || b.name),
+          ),
+    ),
+  }))
+
+  // Image bases first (alpha), non-image bases last (alpha).
+  return groups.sort(
+    (a, b) =>
+      Number(a.isNonImage) - Number(b.isNonImage) ||
+      a.base.localeCompare(b.base),
+  )
+})
+
+const imageGroups = computed(() => grouped.value.filter((g) => !g.isNonImage))
+const nonImageGroups = computed(() => grouped.value.filter((g) => g.isNonImage))
+
+const summaryText = computed(() => {
+  const total = resourceStore.visibleCheckpoints.length
+  const shown = filteredModels.value.length
+
+  if (shown === total) return `${total} model${total === 1 ? '' : 's'}`
+  return `${shown} of ${total} models`
+})
+
+onMounted(() => {
+  resourceStore.loadStore()
+})
+</script>

--- a/pages/models.vue
+++ b/pages/models.vue
@@ -1,0 +1,20 @@
+<!-- /pages/models.vue -->
+<!--
+  Model (checkpoint) browser — the sibling of /lora for base models. Browse /
+  filter / sort the installed checkpoints, grouped by base model with the
+  non-image checkpoints (3D / Audio / Video) in their own section.
+
+  Add / edit / Civitai discover + download land here next, mirroring the LoRA
+  rig (<add-lora>, <lora-discover>, server/api/lora/download).
+-->
+<template>
+  <div class="flex h-full min-h-0 w-full flex-col gap-3 p-3">
+    <div class="min-h-0 flex-1">
+      <model-gallery />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+useHead({ title: 'Model Library' })
+</script>

--- a/stores/resourceStore.ts
+++ b/stores/resourceStore.ts
@@ -671,9 +671,25 @@ export const useResourceStore = defineStore('resourceStore', () => {
     })
   })
 
+  // CHECKPOINT resources for the model browser, with the same account-level
+  // maturity gating as visibleLoras. This is the full DB set (distinct from
+  // checkpointStore.visibleCheckpoints, which is the art-picker's curated list).
+  const visibleCheckpoints = computed<Resource[]>(() => {
+    const userStore = useUserStore()
+    const showMature = userStore.showMature
+
+    return resources.value.filter((resource) => {
+      const type = String(resource.resourceType || '').toUpperCase()
+      if (type !== 'CHECKPOINT') return false
+      if (!showMature && (resource.isMature ?? false)) return false
+      return true
+    })
+  })
+
   return {
     resources,
     visibleLoras,
+    visibleCheckpoints,
     usingSnapshot,
     currentResource,
     isInitialized,


### PR DESCRIPTION
## Summary

The sibling of `/lora` for **base models**. Now that the checkpoint data is clean (in sync per `audit:checkpoints`), this adds a browsable, filterable, sortable model gallery — grouped by base model, with the **non-image checkpoints (3D / Audio / Video) in their own section** below a divider, as requested.

## Pieces

- **`resourceStore.visibleCheckpoints`** — `CHECKPOINT` resources with the same account-maturity gating as `visibleLoras` (the full DB set; distinct from `checkpointStore.visibleCheckpoints`, which is the art-picker's curated list).
- **`components/model/model-card.vue`** — mirrors `lora-card` (reactable-card, preview image, base-model badge, `localPath` health, maturity hide) for a checkpoint. Base model is derived from the `localPath` **folder** (the reliable post-repair signal: `SDXL/`, `Flux/`, `SD15/`, `Pony/`, `Illustrious/`, `ZImage/`, `Qwen/`, `Unknown/`, `3D/`, `Audio/`, `Video/`) with `generation`/`supportedServer` fallback.
- **`components/model/model-gallery.vue`** — search + base + maturity filters, sort (name / newest), grouped sections; image bases first, non-image (`3D`/`Audio`/`Video`) in their own block.
- **`pages/models.vue`** — the page, reachable by URL like `/lora` (route access default-allows routes outside the content-nav graph).

## Scope / next slice

This is the **browse** slice (the visible win on clean data). Add / edit / Civitai discover + download come next, mirroring the LoRA rig (`<add-lora>`, `<lora-discover>`, `server/api/lora/download`). Cards render with `show-edit=false` until that lands.

## Test
`nuxi prepare && vue-tsc --noEmit` (CI TypeScript Type Check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_