### PR TITLE
model-builder: guard commitItem against a cancelled run

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -145,6 +145,12 @@ jobs:
       - name: Model Builder completion-gate contract
         run: npm run test:model-builder-completion-gate
 
+      - name: Model Builder commit cancelled-run guard checker self-test
+        run: npm run test:model-builder-commit-cancelled-run-guard-selftest
+
+      - name: Model Builder commit cancelled-run guard contract
+        run: npm run test:model-builder-commit-cancelled-run-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
     "test:model-builder-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCancelledRunGuard.ts",
     "test:model-builder-approved-asset-guard-selftest": "tsx utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts",
     "test:model-builder-approved-asset-guard": "tsx utils/scripts/verifyModelBuilderApprovedAssetGuard.ts",
+    "test:model-builder-commit-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitCancelledRunGuard.test.ts",
+    "test:model-builder-commit-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1251,7 +1251,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // the asset, update the source, or create + link a new record — idempotently.
   async function commitItem(itemId: string): Promise<boolean> {
     const item = findItem(itemId)
-    if (!item) return false
+    if (!item || !state.run) return false
+    const runId = state.run.id
 
     committingItemSingleton.claim(item.id)
     item.error = null
@@ -1273,6 +1274,16 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         throw new Error(response.message || 'Commit failed.')
       }
 
+      // The commit POST durably creates/links/promotes the target server-side
+      // regardless of what happens next -- same as generateItemAsset's art
+      // render, this can't be undone from here. But unlike generateItemAsset,
+      // the server itself already wrote item.stageStatuses.COMMIT, so skipping
+      // the local mutations below on a cancelled run only avoids re-attaching
+      // a detached item object and popping a misleading "committed" success
+      // toast for a run the user already told the app to abandon. Mirrors the
+      // cancelledRunIds guard already used by generateItemAsset/pollAsyncArtJob.
+      if (cancelledRunIds.has(runId)) return false
+
       const target = response.data?.target ?? null
       finishCommit(item, {
         status: 'approved',
@@ -1290,6 +1301,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       )
       return true
     } catch (error) {
+      if (cancelledRunIds.has(runId)) return false
+
       handleError(error, 'committing build item')
       item.error = error instanceof Error ? error.message : 'Commit failed.'
       finishCommit(item, { status: 'ready', note: item.error })

--- a/utils/scripts/verifyModelBuilderCommitCancelledRunGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderCommitCancelledRunGuard.test.ts
@@ -1,0 +1,141 @@
+// /utils/scripts/verifyModelBuilderCommitCancelledRunGuard.test.ts
+//
+// Regression test for checkCommitCancelledRunGuard() in
+// verifyModelBuilderCommitCancelledRunGuard.ts (model-builder/t-029).
+// Exercises the real check against synthetic store-shaped fixtures covering:
+// the pre-fix shape (no `runId` capture, no cancelledRunIds check between the
+// commit POST resolving and its target read -- the exact bug found by manual
+// read-through), and the fixed shape.
+import assert from 'node:assert/strict'
+
+import { checkCommitCancelledRunGuard } from './verifyModelBuilderCommitCancelledRunGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item) return false
+
+    committingItemSingleton.claim(item.id)
+    item.error = null
+    item.stages.COMMIT = { status: 'in-progress' }
+    clearStatus()
+
+    try {
+      const response = await performFetch(
+        \`/api/model-builder/items/\${item.id}/commit\`,
+        { method: 'POST' },
+        1,
+        60_000,
+      )
+
+      if (!response.success) {
+        throw new Error(response.message || 'Commit failed.')
+      }
+
+      const target = response.data?.target ?? null
+      finishCommit(item, { status: 'approved', note: 'Committed.' })
+      if (target) {
+        item.targetType = target.type
+        item.targetId = target.id
+      }
+      setStatus('success', 'committed.')
+      return true
+    } catch (error) {
+      handleError(error, 'committing build item')
+      return false
+    } finally {
+      committingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function commitItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    const runId = state.run.id
+
+    committingItemSingleton.claim(item.id)
+    item.error = null
+    item.stages.COMMIT = { status: 'in-progress' }
+    clearStatus()
+
+    try {
+      const response = await performFetch(
+        \`/api/model-builder/items/\${item.id}/commit\`,
+        { method: 'POST' },
+        1,
+        60_000,
+      )
+
+      if (!response.success) {
+        throw new Error(response.message || 'Commit failed.')
+      }
+
+      if (cancelledRunIds.has(runId)) return false
+
+      const target = response.data?.target ?? null
+      finishCommit(item, { status: 'approved', note: 'Committed.' })
+      if (target) {
+        item.targetType = target.type
+        item.targetId = target.id
+      }
+      setStatus('success', 'committed.')
+      return true
+    } catch (error) {
+      if (cancelledRunIds.has(runId)) return false
+
+      handleError(error, 'committing build item')
+      return false
+    } finally {
+      committingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkCommitCancelledRunGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  2,
+  `expected the pre-fix shape (missing runId capture AND missing ` +
+    `cancelledRunIds check) to raise 2 errors, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('runId = state.run.id')),
+  'expected a violation for the missing runId capture',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes('cancelledRunIds')),
+  'expected a violation for the missing cancelledRunIds check',
+)
+
+const fixedErrors = checkCommitCancelledRunGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkCommitCancelledRunGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when commitItem is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('commitItem'))
+
+console.log(
+  'Model Builder commit cancelled-run guard checker verified: flags the ' +
+    'pre-fix shape (missing runId capture and missing post-commit ' +
+    'cancelledRunIds check), clears the fixed shape, and flags commitItem ' +
+    'being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts
+++ b/utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts
@@ -1,0 +1,123 @@
+// /utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- commitItem() is the only
+// stage-completion function in modelBuilderStore.ts that awaits a real
+// network round-trip (the commit POST, up to 60s) without checking
+// cancelledRunIds afterward, unlike its siblings generateItemAsset and
+// pollAsyncArtJob. The commit POST durably creates/links/promotes the target
+// server-side regardless -- that can't be undone from here, same as
+// generateItemAsset's art render -- but before this fix, the code after the
+// await unconditionally reattached the (possibly detached, cancelled-run)
+// item locally and popped a "committed" success toast for a run the user had
+// already told the app to abandon via cancelRun.
+//
+// This asserts the textual shape of that fix stays in place: commitItem
+// checks `cancelledRunIds.has(runId)` immediately after its commit POST
+// resolves, before either its success (`response.success` truthy) or catch
+// branch does anything else. Deliberately scoped to this one function/bug,
+// mirroring verifyModelBuilderCancelledRunGuard.ts's own narrow textual
+// check over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'commitItem'
+const RESPONSE_CHECK = 'if (!response.success)'
+const SUCCESS_BRANCH = 'const target = response.data?.target'
+const GUARD = 'cancelledRunIds.has(runId)'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `commitItem`-named async function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkCommitCancelledRunGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const runIdAssignment = fn.body.indexOf('const runId = state.run.id')
+  if (runIdAssignment === -1) {
+    errors.push(
+      `${FN_NAME}() no longer captures \`const runId = state.run.id\` at ` +
+        'the top of the function -- without it there is nothing stable to ' +
+        'check cancelledRunIds against once state.run may have changed ' +
+        'across the await.',
+    )
+  }
+
+  const responseCheckIndex = fn.body.indexOf(RESPONSE_CHECK)
+  if (responseCheckIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer checks ${RESPONSE_CHECK} -- this guard's ` +
+        'anchor point has moved; re-check where the commit POST response is ' +
+        'validated.',
+    )
+    return errors
+  }
+
+  const successBranchIndex = fn.body.indexOf(SUCCESS_BRANCH, responseCheckIndex)
+  if (successBranchIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer reads ${SUCCESS_BRANCH} after ${RESPONSE_CHECK} ` +
+        '-- this guard\'s anchor point has moved.',
+    )
+    return errors
+  }
+
+  const guardIndex = fn.body.indexOf(GUARD, responseCheckIndex)
+  if (guardIndex === -1 || guardIndex >= successBranchIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`${GUARD}\` between the commit POST ` +
+        `resolving (${RESPONSE_CHECK}) and reading its target ` +
+        `(${SUCCESS_BRANCH}). The commit POST is a network round-trip the ` +
+        'user can cancel this run during; without this check, a commit that ' +
+        'resolves after cancellation still reattaches the detached item and ' +
+        'pops a "committed" success toast for a run the user no longer has ' +
+        "open. Mirror generateItemAsset's own " +
+        '`if (cancelledRunIds.has(runId)) return false` guard.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkCommitCancelledRunGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder commit cancelled-run guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder commit cancelled-run guard contract passed: ${FN_NAME}() ` +
+      'checks cancelledRunIds after its own commit-POST await, before ' +
+      'reattaching the item or surfacing a success toast.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

- `commitItem()` in `stores/modelBuilderStore.ts` awaits a real network round-trip (the commit POST, up to 60s) but, unlike its siblings `generateItemAsset` and `pollAsyncArtJob`, never checked `cancelledRunIds` afterward.
- The commit POST durably creates/links/promotes the target server-side regardless of what happens next (same as `generateItemAsset`'s art render — that can't be undone from here), but without the guard, a commit that resolves after the user cancels the run still reattaches the detached item locally and pops a misleading "committed" success toast for a run they already told the app to abandon via `cancelRun()`.
- Fixed by capturing `runId` from `state.run` at the top of `commitItem` and checking `cancelledRunIds.has(runId)` right after the commit POST resolves (both success and catch branches), mirroring the existing guard already used by `generateItemAsset`/`pollAsyncArtJob`.
- Added a narrow textual regression checker (`verifyModelBuilderCommitCancelledRunGuard.ts`) plus its self-test, following the exact pattern of the existing `verifyModelBuilderCancelledRunGuard.ts` (which covers the sibling `pollAsyncArtJob` guard), and wired both into `contract-tests.yml` next to the Model Builder completion-gate check.

This is a continuation of conductor's `model-builder/t-029` recurring "polish and upgrade" task — each cycle re-reads the full model-builder surface for a genuinely new, previously-unfixed bug.

## Test plan

- [x] `npx eslint stores/modelBuilderStore.ts` — 2 pre-existing `no-empty` errors confirmed unrelated via `git stash` (present with and without this diff)
- [x] `npx prettier --check stores/modelBuilderStore.ts` — pre-existing drift confirmed unrelated via `git stash`
- [x] `node ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit -p tsconfig.json` — exit 0
- [x] `npm run test:model-builder-commit-cancelled-run-guard-selftest` — passes (flags the pre-fix shape, clears the fixed shape, flags the function being absent)
- [x] `npm run test:model-builder-commit-cancelled-run-guard` — passes against the real store file


---
_Generated by [Claude Code](https://claude.ai/code/session_01WD5VWitMn7hUxJxS2cEyU8)_