### PR TITLE
Route project cover requests through Flux

### DIFF
--- a/server/utils/artRequestYaml.ts
+++ b/server/utils/artRequestYaml.ts
@@ -32,6 +32,7 @@ export type ArtQueueEntry = {
   size: string
   label: string
   prompt: string
+  engine?: string
   project_id?: number
   project_slug?: string
   project_field?: string
@@ -51,18 +52,24 @@ export function yamlFolded(
   return `${key}: >\n${indent}${clean}`
 }
 
+function normalizedEngine(entry: ArtQueueEntry): string | undefined {
+  const explicit = entry.engine?.trim()
+  if (explicit) return explicit
+  return entry.variant === 'image' ? undefined : 'flux'
+}
+
 export function normalizeArtQueueEntry(entry: ArtQueueEntry): ArtQueueEntry {
-  if (entry.target_repo !== KIND_ROBOTS_REPO) {
-    return {
-      ...entry,
-      prompt: replaceVagueArtDirection(entry.prompt),
-    }
+  const normalized = {
+    ...entry,
+    engine: normalizedEngine(entry),
+    prompt: replaceVagueArtDirection(entry.prompt),
   }
 
+  if (entry.target_repo !== KIND_ROBOTS_REPO) return normalized
+
   return {
-    ...entry,
+    ...normalized,
     image_path: normalizeKindRobotsImagePath(entry.image_path),
-    prompt: replaceVagueArtDirection(entry.prompt),
   }
 }
 
@@ -83,6 +90,8 @@ export function renderRequestEntry(entry: ArtQueueEntry): string {
     lines.push(`  page_url: ${yamlQuoted(normalized.page_url)}`)
   }
   lines.push(`  variant: ${yamlQuoted(normalized.variant)}`)
+  if (normalized.engine)
+    lines.push(`  engine: ${yamlQuoted(normalized.engine)}`)
   if (normalized.size) lines.push(`  size: ${yamlQuoted(normalized.size)}`)
   if (normalized.label) lines.push(`  label: ${yamlQuoted(normalized.label)}`)
   if (normalized.project_id)

--- a/utils/scripts/verifyArtRequestYaml.ts
+++ b/utils/scripts/verifyArtRequestYaml.ts
@@ -62,9 +62,6 @@ console.log('renderRequestEntry indentation')
   )
   check('no line contains a tab character', !rendered.includes('\t'))
 
-  // Every non-first, non-empty line is either a 2-space key or the 4-space
-  // folded-scalar body line for `prompt: >`. Nothing may sit at column 0
-  // except the leading `- ` marker, and no key may be indented 4+ spaces.
   let sawFoldedHeader = false
   let indentationOk = true
   let badLine = ''
@@ -75,7 +72,6 @@ console.log('renderRequestEntry indentation')
       sawFoldedHeader = true
       continue
     }
-    // The single folded body line sits at 4 spaces directly after the header.
     if (sawFoldedHeader && /^ {4}\S/.test(line)) {
       sawFoldedHeader = false
       continue
@@ -98,6 +94,23 @@ console.log('renderRequestEntry indentation')
   check(
     'prompt folds newlines into a single line',
     !/\n {4}\S.*\n {4}\S/.test(rendered),
+  )
+}
+
+// --- project art engine defaults ---------------------------------------------
+console.log('project art engine defaults')
+{
+  const icon = renderRequestEntry(sampleEntry())
+  const hero = renderRequestEntry(sampleEntry({ variant: 'hero' }))
+  const image = renderRequestEntry(sampleEntry({ variant: 'image' }))
+  const explicit = renderRequestEntry(sampleEntry({ engine: 'flux2-klein' }))
+
+  check('icon requests default to Flux', icon.includes('  engine: "flux"'))
+  check('hero requests default to Flux', hero.includes('  engine: "flux"'))
+  check('generic image requests do not force an engine', !image.includes('  engine:'))
+  check(
+    'explicit engine overrides the project default',
+    explicit.includes('  engine: "flux2-klein"'),
   )
 }
 
@@ -144,7 +157,6 @@ console.log('appendRequest into each requests: shape')
     intoBare,
   )
 
-  // idempotency: same entry twice must not duplicate (dedup by id / image_path)
   const once = appendRequest('requests: []\n', entry)
   const twice = appendRequest(once, entry)
   check('appendRequest is idempotent by id', once === twice)


### PR DESCRIPTION
## What changed
- Default missing-image requests for `icon`, `card`, and `hero` variants to `engine: flux`.
- Preserve explicit engine overrides.
- Leave generic `image` requests on their existing engine behavior.
- Add regression checks for the serialized YAML engine field.

## Why
The recent project-cover batch was submitted without an engine, so Conductor used its Krea 2 Turbo filler-art default. The resulting assets repeatedly drifted into unrelated male-face compositions despite object-focused prompts.

## Impact
Future project covers created through the Kind Robots missing-image reporter will carry an explicit Flux engine instead of inheriting the filler-art model.

## Validation
- Inspected the generated diff and YAML serialization contract changes.
- CI should run the existing `test:art-request-yaml` contract check.