### PR TITLE
Give missing-art suggestions real project context

### DIFF
--- a/plugins/missing-image-reporter.client.ts
+++ b/plugins/missing-image-reporter.client.ts
@@ -1,13 +1,35 @@
 import { watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useConductorStore } from '@/stores/conductorStore'
+import { useProjectStore } from '@/stores/projectStore'
+import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
 import { performFetch } from '@/stores/utils'
+
+type ProjectArtContext = {
+  id?: number
+  slug?: string
+  title?: string
+  kind?: string
+  status?: string
+  goal?: string
+  description?: string
+  flavorText?: string
+  notes?: string
+  milestones?: string[]
+  tasks?: string[]
+}
 
 type MissingImageReport = {
   src: string
   pageUrl: string
   alt?: string
   label?: string
+  subject?: string
+  purpose?: string
+  artDescription?: string
+  artStyle?: string
+  artExclusions?: string
   variant?: string
   size?: string
   pageTitle?: string
@@ -18,6 +40,11 @@ type MissingImageReport = {
   projectId?: number
   projectSlug?: string
   projectField?: string
+  project?: ProjectArtContext
+}
+
+type SuggestResult = {
+  value: string
 }
 
 const IMAGE_EXTENSIONS = ['.webp', '.png', '.jpg', '.jpeg', '.gif', '.svg']
@@ -110,10 +137,12 @@ function inferVariant(img: HTMLImageElement, src: string): string | undefined {
 
 function labelForImage(img: HTMLImageElement): string | undefined {
   const candidates = [
+    img.dataset.artSubject,
     img.alt,
     img.title,
     img.getAttribute('aria-label'),
     img.dataset.slug,
+    img.dataset.projectSlug,
   ]
 
   for (const candidate of candidates) {
@@ -131,7 +160,7 @@ function nearestHeading(img: HTMLImageElement): string | undefined {
     const heading = current.querySelector<HTMLElement>('h1, h2, h3, h4, h5, h6')
     const text = cleanString(heading?.textContent)
     if (text) return compact(text, 180)
-    if (current.matches('article, section, main')) break
+    if (current.matches('article, section, main, button, li, figure')) break
     current = current.parentElement
   }
 
@@ -141,19 +170,15 @@ function nearestHeading(img: HTMLImageElement): string | undefined {
 
 function nearbyText(img: HTMLImageElement): string | undefined {
   const container = img.closest<HTMLElement>(
-    'article, section, main, [role="main"], .card',
+    '[data-art-context], figure, article, li, button, .card, section',
   )
-  const text = compact(
-    container?.innerText || img.parentElement?.innerText,
-    700,
-  )
+  const text = compact(container?.innerText || img.parentElement?.innerText, 900)
   return text || undefined
 }
 
 function pageDescription(): string | undefined {
   const description = cleanString(
-    document.querySelector<HTMLMetaElement>('meta[name="description"]')
-      ?.content,
+    document.querySelector<HTMLMetaElement>('meta[name="description"]')?.content,
   )
   return description || undefined
 }
@@ -162,27 +187,181 @@ function shouldIgnoreImage(img: HTMLImageElement): boolean {
   if (img.dataset.missingImageReport === 'false') return true
 
   const label = cleanString(
-    img.alt || img.title || img.getAttribute('aria-label') || img.dataset.slug,
+    img.dataset.artSubject ||
+      img.alt ||
+      img.title ||
+      img.getAttribute('aria-label') ||
+      img.dataset.slug ||
+      img.dataset.projectSlug,
   )
 
   return Boolean(label && isGenericLabel(label))
 }
 
+function projectPurpose(report: MissingImageReport): string {
+  const title =
+    report.project?.title || report.subject || report.label || report.projectSlug
+  const subject = title ? `the ${title} project` : 'this project'
+
+  if (report.variant === 'icon') {
+    return `Square application icon that communicates the core function of ${subject}`
+  }
+  if (report.variant === 'card') {
+    return `Portrait project-card artwork that explains the purpose and personality of ${subject}`
+  }
+  if (report.variant === 'hero') {
+    return `Landscape hero artwork that visually introduces the purpose and working world of ${subject}`
+  }
+
+  return `Frontend illustration that communicates the purpose of ${subject}`
+}
+
 export default defineNuxtPlugin(() => {
   const route = useRoute()
+  const conductorStore = useConductorStore()
+  const projectStore = useProjectStore()
+  const serverStore = useServerStore()
   const userStore = useUserStore()
   const queued = new Map<string, MissingImageReport>()
   const submitted = new Set<string>()
+
+  function projectContext(report: MissingImageReport): ProjectArtContext | undefined {
+    const record =
+      (report.projectId
+        ? projectStore.projects.find((project) => project.id === report.projectId)
+        : null) || projectStore.projectForSlug(report.projectSlug)
+    const roadmap = conductorStore.projects.find(
+      (project) => project.slug === report.projectSlug,
+    )
+
+    if (!record && !roadmap && !report.projectSlug) return undefined
+
+    const tasks = roadmap?.tasks
+      .filter((task) => task.status !== 'done')
+      .slice(0, 10)
+      .map((task) =>
+        compact(
+          [task.title, task.stakes, task.note].filter(Boolean).join(' — '),
+          260,
+        ),
+      )
+      .filter(Boolean)
+
+    return {
+      ...(record?.id ? { id: record.id } : {}),
+      ...(report.projectSlug || record?.slug || record?.conductorSlug
+        ? { slug: report.projectSlug || record?.conductorSlug || record?.slug || '' }
+        : {}),
+      ...(record?.title || roadmap?.name
+        ? { title: record?.title || roadmap?.name }
+        : {}),
+      ...(roadmap?.kind ? { kind: roadmap.kind } : {}),
+      ...(record?.status ? { status: record.status } : {}),
+      ...(record?.goal ? { goal: compact(record.goal, 600) } : {}),
+      ...(record?.description
+        ? { description: compact(record.description, 900) }
+        : {}),
+      ...(record?.flavorText
+        ? { flavorText: compact(record.flavorText, 500) }
+        : {}),
+      ...(roadmap?.notesFromSilas
+        ? { notes: compact(roadmap.notesFromSilas, 900) }
+        : {}),
+      ...(roadmap?.milestones.length
+        ? {
+            milestones: roadmap.milestones
+              .slice(0, 10)
+              .map((milestone) => `${milestone.title} (${milestone.status})`),
+          }
+        : {}),
+      ...(tasks?.length ? { tasks } : {}),
+    }
+  }
+
+  function enrichReport(report: MissingImageReport): MissingImageReport {
+    const project = projectContext(report)
+    const subject =
+      report.subject || project?.title || report.label || report.projectSlug
+    const enriched = {
+      ...report,
+      ...(subject ? { subject } : {}),
+      ...(project ? { project } : {}),
+    }
+
+    return {
+      ...enriched,
+      purpose: report.purpose || projectPurpose(enriched),
+    }
+  }
+
+  async function suggestArtPrompt(report: MissingImageReport): Promise<string> {
+    const activeServer = serverStore.activeTextServer
+    const server = activeServer
+      ? {
+          serverType: activeServer.serverType ?? null,
+          baseUrl: activeServer.baseUrl ?? null,
+          endpointPath: activeServer.endpointPath ?? null,
+          model: activeServer.model ?? null,
+        }
+      : undefined
+
+    const result = await performFetch<SuggestResult>(
+      '/api/suggest',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          builder: 'art-asset',
+          field: 'prompt',
+          stepKey: 'missing-art',
+          current: '',
+          server,
+          maxTokens: 500,
+          context: {
+            subject: report.subject || report.label,
+            purpose: report.purpose,
+            asset: {
+              source: report.src,
+              role: report.projectField || report.variant || 'frontend image',
+              variant: report.variant,
+              size: report.size,
+              className: report.imageClass,
+              description: report.artDescription,
+              preferredStyle: report.artStyle,
+              exclusions: report.artExclusions,
+            },
+            project: report.project,
+            page: {
+              url: report.pageUrl,
+              title: report.pageTitle,
+              description: report.pageDescription,
+              heading: report.nearestHeading,
+              localText: report.nearbyText,
+            },
+          },
+        }),
+      },
+      1,
+      30000,
+    )
+
+    return result.success ? cleanString(result.data?.value) : ''
+  }
 
   async function submit(report: MissingImageReport) {
     if (submitted.has(report.src)) return
     submitted.add(report.src)
 
+    const enriched = enrichReport(report)
+    const prompt = await suggestArtPrompt(enriched).catch(() => '')
     const result = await performFetch(
       '/api/conductor/art-request',
       {
         method: 'POST',
-        body: JSON.stringify(report),
+        body: JSON.stringify({
+          ...enriched,
+          ...(prompt ? { prompt } : {}),
+        }),
       },
       1,
       15000,
@@ -214,6 +393,11 @@ export default defineNuxtPlugin(() => {
       pageUrl: window.location.href || route.fullPath,
       alt: label,
       label,
+      subject: cleanString(img.dataset.artSubject) || label,
+      purpose: cleanString(img.dataset.artPurpose) || undefined,
+      artDescription: cleanString(img.dataset.artDescription) || undefined,
+      artStyle: cleanString(img.dataset.artStyle) || undefined,
+      artExclusions: cleanString(img.dataset.artExclusions) || undefined,
       variant,
       size: variant ? VARIANT_SIZES[variant] : undefined,
       pageTitle: cleanString(document.title) || undefined,

--- a/server/utils/suggest/sheets/artAssetSuggest.ts
+++ b/server/utils/suggest/sheets/artAssetSuggest.ts
@@ -46,6 +46,9 @@ function buildArtContext(context: Record<string, unknown>): string[] {
   pushLine(lines, 'Variant', asset.variant)
   pushLine(lines, 'Dimensions', asset.size)
   pushLine(lines, 'Image class', asset.className)
+  pushLine(lines, 'Asset description', asset.description)
+  pushLine(lines, 'Preferred art direction', asset.preferredStyle)
+  pushLine(lines, 'Explicit exclusions', asset.exclusions)
 
   pushLine(lines, 'Project title', project.title)
   pushLine(lines, 'Project slug', project.slug)

--- a/server/utils/suggest/sheets/artAssetSuggest.ts
+++ b/server/utils/suggest/sheets/artAssetSuggest.ts
@@ -1,0 +1,115 @@
+// /server/utils/suggest/sheets/artAssetSuggest.ts
+import type { SuggestBody, SuggestSheet } from '../suggestTypes'
+
+function compact(value: unknown, maxLength = 700): string {
+  const text = typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+  if (text.length <= maxLength) return text
+  return `${text.slice(0, maxLength - 1).trim()}…`
+}
+
+function pushLine(lines: string[], label: string, value: unknown): void {
+  if (Array.isArray(value)) {
+    const text = value.map((entry) => compact(entry, 180)).filter(Boolean).join(' | ')
+    if (text) lines.push(`${label}: ${text}`)
+    return
+  }
+
+  if (value && typeof value === 'object') {
+    const text = compact(JSON.stringify(value), 900)
+    if (text) lines.push(`${label}: ${text}`)
+    return
+  }
+
+  const text = compact(value)
+  if (text) lines.push(`${label}: ${text}`)
+}
+
+function buildArtContext(context: Record<string, unknown>): string[] {
+  const lines: string[] = []
+  const asset =
+    context.asset && typeof context.asset === 'object'
+      ? (context.asset as Record<string, unknown>)
+      : {}
+  const project =
+    context.project && typeof context.project === 'object'
+      ? (context.project as Record<string, unknown>)
+      : {}
+  const page =
+    context.page && typeof context.page === 'object'
+      ? (context.page as Record<string, unknown>)
+      : {}
+
+  pushLine(lines, 'Requested subject', context.subject)
+  pushLine(lines, 'Image purpose', context.purpose)
+  pushLine(lines, 'Asset source', asset.source)
+  pushLine(lines, 'Asset role', asset.role)
+  pushLine(lines, 'Variant', asset.variant)
+  pushLine(lines, 'Dimensions', asset.size)
+  pushLine(lines, 'Image class', asset.className)
+
+  pushLine(lines, 'Project title', project.title)
+  pushLine(lines, 'Project slug', project.slug)
+  pushLine(lines, 'Project kind', project.kind)
+  pushLine(lines, 'Project goal', project.goal)
+  pushLine(lines, 'Project description', project.description)
+  pushLine(lines, 'Project flavor', project.flavorText)
+  pushLine(lines, 'Project notes', project.notes)
+  pushLine(lines, 'Major milestones', project.milestones)
+  pushLine(lines, 'Representative tasks', project.tasks)
+
+  pushLine(lines, 'Page title', page.title)
+  pushLine(lines, 'Page description', page.description)
+  pushLine(lines, 'Nearest heading', page.heading)
+  pushLine(lines, 'Local component text', page.localText)
+  pushLine(lines, 'Page URL', page.url)
+
+  return lines
+}
+
+function artInstruction(body: SuggestBody): string {
+  const context = body.context ?? {}
+  const asset =
+    context.asset && typeof context.asset === 'object'
+      ? (context.asset as Record<string, unknown>)
+      : {}
+  const variant = String(asset.variant || '').toLowerCase()
+
+  if (variant === 'icon') {
+    return 'Write one production-ready image-generation prompt for a square application icon. Use one immediately readable object, mechanism, or visual metaphor with a strong silhouette. Include concrete palette, material, lighting, depth, and rendering details in roughly 55–95 words.'
+  }
+
+  if (variant === 'card') {
+    return 'Write one production-ready image-generation prompt for a 2:3 portrait project card. Establish a clear foreground focal subject, supporting midground elements, atmospheric background, directional lighting, palette, materials, texture, and mood in roughly 100–170 words.'
+  }
+
+  if (variant === 'hero') {
+    return 'Write one production-ready image-generation prompt for a 16:9 landscape hero. Build a specific visual scene with strong left-to-right flow, layered depth, useful negative space, environment, lighting, palette, materials, texture, and mood in roughly 100–170 words.'
+  }
+
+  return 'Write one production-ready image-generation prompt for this missing frontend asset. Make the visible subject, setting, composition, lighting, palette, materials, texture, and mood unambiguous.'
+}
+
+const artAssetSuggest: SuggestSheet = {
+  builder: 'art-asset',
+  label: 'Missing Art Asset',
+  systemPrompt: `You are the production art director for Kind Robots. You turn structured frontend and project context into a single image-generation prompt for a missing visual asset.
+Rules:
+- Ground the prompt in the supplied project goal, description, notes, milestones, representative tasks, local component text, asset role, and requested variant.
+- Identify what the project actually does, then choose a concrete visible subject or visual metaphor that communicates that function.
+- For software projects, prefer tools, interfaces, workspaces, machines, diagrams, environments, or symbolic objects. Do not invent a person, face, portrait, mascot, or humanoid focal character unless the supplied context explicitly requires one.
+- Do not default to robots merely because the site is called Kind Robots.
+- Describe the focal subject, supporting elements, action or relationship, environment, spatial arrangement, composition or camera, lighting, palette, materials, texture, mood, and concrete rendering medium.
+- Respect the requested format: icon is square and simple; card is 2:3 portrait with layered depth; hero is 16:9 landscape with visual flow and negative space.
+- Never use vague phrases such as “Kind Robots style,” “cohesive visual style,” or “make it cinematic” without concrete visual details.
+- Avoid copyrighted characters, licensed artist styles, readable text, logos, watermarks, and collages.
+- Return exactly one prompt paragraph with no label, preamble, markdown, or quotation marks.
+- End with: no readable text, no logo, no watermark, no collage.`,
+  fieldPrompts: {
+    prompt:
+      'Create the final image-generation prompt for this missing frontend asset using all relevant supplied context.',
+  },
+  buildInstruction: artInstruction,
+  buildContext: buildArtContext,
+}
+
+export default artAssetSuggest

--- a/server/utils/suggest/sheets/index.ts
+++ b/server/utils/suggest/sheets/index.ts
@@ -7,6 +7,7 @@ import rewardSuggest from './rewardSuggest'
 import dreamSuggest from './dreamSuggest'
 import modelBuilderSuggest from './modelBuilderSuggest'
 import packmakerSuggest from './packmakerSuggest'
+import artAssetSuggest from './artAssetSuggest'
 import type { SuggestSheet } from '../suggestTypes'
 
 export const suggestSheets = [
@@ -18,4 +19,5 @@ export const suggestSheets = [
   dreamSuggest,
   modelBuilderSuggest,
   packmakerSuggest,
+  artAssetSuggest,
 ] satisfies SuggestSheet[]

--- a/utils/scripts/verifyArtAssetSuggest.ts
+++ b/utils/scripts/verifyArtAssetSuggest.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { buildSuggestUserPrompt } from '../../server/utils/suggest/suggestPrompt'
+import { getSuggestSheet } from '../../server/utils/suggest/suggestRegistry'
+
+const sheet = getSuggestSheet('art-asset')
+
+assert.equal(sheet.builder, 'art-asset')
+assert.match(sheet.systemPrompt, /project goal, description, notes, milestones/i)
+assert.match(sheet.systemPrompt, /Do not invent a person, face, portrait/i)
+assert.match(sheet.systemPrompt, /Do not default to robots/i)
+
+const prompt = buildSuggestUserPrompt(sheet, {
+  builder: 'art-asset',
+  field: 'prompt',
+  stepKey: 'missing-art',
+  context: {
+    subject: 'Model Builder',
+    purpose: 'Landscape hero artwork for a software model-building workspace',
+    asset: {
+      source: '/images/projects/model-builder-hero.webp',
+      role: 'heroPath',
+      variant: 'hero',
+      size: '1280x720',
+    },
+    project: {
+      title: 'Model Builder',
+      kind: 'software',
+      goal: 'Turn existing Kind Robots records into grounded new models.',
+      description:
+        'A guided workspace for selecting source canon, recipes, output fields, and generated art.',
+      milestones: ['Source selection', 'Recipe planning', 'Output validation'],
+      tasks: ['Build source-aware recipes', 'Generate schema-ready output'],
+    },
+    page: {
+      title: 'Kind Robots Projects',
+      heading: 'Model Builder',
+      localText: 'Model Builder — assemble new records from existing canon.',
+    },
+  },
+})
+
+assert.match(prompt, /16:9 landscape hero/i)
+assert.match(prompt, /Project goal: Turn existing Kind Robots records/i)
+assert.match(prompt, /Project description: A guided workspace/i)
+assert.match(prompt, /Major milestones: Source selection/i)
+assert.match(prompt, /Representative tasks: Build source-aware recipes/i)
+assert.match(prompt, /Local component text: Model Builder/i)
+assert.doesNotMatch(prompt, /Generate an appropriate value for/i)
+
+const iconPrompt = buildSuggestUserPrompt(sheet, {
+  builder: 'art-asset',
+  field: 'prompt',
+  context: {
+    subject: 'Animation Manager',
+    asset: { variant: 'icon', size: '256x256' },
+  },
+})
+
+assert.match(iconPrompt, /square application icon/i)
+assert.match(iconPrompt, /55–95 words/i)
+
+console.log('Missing-art suggest sheet and structured-context contract passed.')


### PR DESCRIPTION
## Root cause
The automatic missing-image path did not use `/api/suggest`. The browser sent a thin DOM report directly to `/api/conductor/art-request`, whose separate prompt writer attempted to infer the artwork. For project tiles, `nearbyText()` often climbed to the entire gallery `<main>` because each tile is a `<button>`, so context could blend several unrelated projects.

## What changed
- Added a dedicated `art-asset` sheet to the shared `/api/suggest` registry.
- The missing-image reporter now calls `/api/suggest` first and uses the currently selected text server, matching the rest of the frontend suggestion architecture.
- Sends structured context for the exact asset: source, role, variant, dimensions, class, optional art-direction attributes, page metadata, and local component text.
- Resolves project-specific context from the Project and Conductor stores: title, slug, kind, status, goal, description, flavor text, notes from Silas, milestones, and representative unfinished tasks.
- Fixed local text capture so a project `<button>` is treated as the context boundary instead of collecting text from the whole gallery.
- The art sheet produces format-aware icon/card/hero prompts with concrete composition, lighting, palette, materials, texture, and mood.
- Software projects explicitly prefer tools, interfaces, machines, environments, diagrams, or symbolic objects rather than invented portraits, faces, mascots, or default robots.
- The generated prompt is passed to `/api/conductor/art-request`; the existing direct writer remains only as a fallback if `/api/suggest` fails.

## Validation
- Added `verifyArtAssetSuggest.ts` covering sheet registration, structured project context, hero/icon format instructions, and anti-portrait/default-robot rules.
- TypeScript and repository contract checks should validate the client/store integration.