### PR TITLE
Fix frontend crash from gallery art context plugin

### DIFF
--- a/plugins/gallery-art-model-context.client.ts
+++ b/plugins/gallery-art-model-context.client.ts
@@ -49,10 +49,10 @@ function facetImageField(facet: FacetCatalogEntry, source: string): string {
 
 export default defineNuxtPlugin({
   name: 'gallery-art-model-context',
-  enforce: 'pre',
-  setup() {
+  setup(nuxtApp) {
     const dreamStore = useDreamStore()
     const facetStore = useFacetCatalogStore()
+    let observer: MutationObserver | null = null
 
     function decorate(img: HTMLImageElement): void {
       if (img.dataset.artModel || img.closest('[data-art-model]')) return
@@ -108,21 +108,28 @@ export default defineNuxtPlugin({
       for (const img of node.querySelectorAll<HTMLImageElement>('img')) decorate(img)
     }
 
-    window.addEventListener(
-      'error',
-      (event) => {
-        if (event.target instanceof HTMLImageElement) decorate(event.target)
-      },
-      true,
-    )
+    function handleImageError(event: Event): void {
+      if (event.target instanceof HTMLImageElement) decorate(event.target)
+    }
 
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        for (const node of mutation.addedNodes) decorateTree(node)
-      }
+    function start(): void {
+      const root = document.documentElement
+      if (!root) return
+
+      window.addEventListener('error', handleImageError, true)
+      observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes) decorateTree(node)
+        }
+      })
+      observer.observe(root, { childList: true, subtree: true })
+      decorateTree(root)
+    }
+
+    nuxtApp.hook('app:mounted', start)
+    nuxtApp.hook('app:beforeUnmount', () => {
+      observer?.disconnect()
+      window.removeEventListener('error', handleImageError, true)
     })
-
-    observer.observe(document.documentElement, { childList: true, subtree: true })
-    decorateTree(document.documentElement)
   },
 })


### PR DESCRIPTION
## Problem
The gallery art context plugin introduced in #1150 starts as an `enforce: 'pre'` client plugin and immediately reads `document.documentElement`, constructs a `MutationObserver`, and walks the DOM during plugin setup.

That can run before Nuxt has mounted the client app and produce Safari's generic `undefined is not an object` runtime failure even though the Vercel build succeeds.

## Fix
- Remove `enforce: 'pre'`.
- Start DOM observation from Nuxt's `app:mounted` hook.
- Guard the document root.
- Disconnect the observer and remove the capture listener before unmount.

This keeps the model-context decoration behavior while moving it to a safe lifecycle boundary.