### PR TITLE
academy: fix stale "twenty-five centuries" copy to thirty-three

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -41,7 +41,7 @@
         />
         <p class="text-sm text-base-content/70">
           Dusting off the timeline, warming up the remix engine, and politely
-          waking twenty-five centuries of dead masters...
+          waking thirty-three centuries of dead masters...
         </p>
       </div>
     </div>

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -12,8 +12,8 @@
           The Art History Timeline
         </h2>
         <p class="text-sm text-base-content/70">
-          Twenty-five centuries of style, all public domain, all remixable. Pick
-          an era and see what the masters were up to.
+          Thirty-three centuries of style, all public domain, all remixable.
+          Pick an era and see what the masters were up to.
         </p>
       </div>
       <div

--- a/content/academy.md
+++ b/content/academy.md
@@ -2,7 +2,7 @@
 title: 'Art Academy'
 room: 'Art Academy'
 subtitle: 'Learn the styles. Meet the masters. Remix everything.'
-description: Explore twenty-five centuries of public-domain art history, then remix your own images in any style you learn — from Greek vases to Bauhaus grids.
+description: Explore thirty-three centuries of public-domain art history, then remix your own images in any style you learn — from Greek vases to Bauhaus grids.
 image: 'background/artgallery.webp'
 icon: kind-icon:palette
 tooltip: Art history lessons with a remix button. The masters would approve. Probably.

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -213,7 +213,7 @@ export const dashboardConfigs = {
         icon: 'kind-icon:map',
         title: 'Art History Timeline',
         summary:
-          'Walk twenty-five centuries of art history, one style at a time.',
+          'Walk thirty-three centuries of art history, one style at a time.',
         image: tabImage('academy', 'timeline'),
         narrative:
           'Walk the timeline from Greek vases to De Stijl grids, meet the long-departed masters, and learn why every era thought the previous one was doing it wrong.',


### PR DESCRIPTION
### Task
ai-art-academy/t-010 (lane 1, front-end polish) — recurring never-idle Academy continuous-improvement pass

### What changed / what I produced
- Fixed stale "Twenty-five centuries" marketing copy in 4 places: `components/academy/academy-timeline.vue`, `components/academy/academy-manager.vue` (loading state), `content/academy.md` (page description), `stores/helpers/dashboardHelper.ts` (Timeline tab summary).

### How I verified
- Confirmed the actual span with the seed data: earliest curriculum entry is Ancient Egyptian Painting (`sortYear: -1390`, i.e. c. 1390 BCE) and the latest is American Regionalism (era ends 1935) — a ~3,325-year span, ≈33 centuries. "Twenty-five centuries" matched the span back when Ancient Greek Vase Painting (c. 600 BCE) was the earliest entry; it went stale once Egyptian Painting was added later without these 4 copy spots being updated.
- `grep -rn "wenty-five centuries"` repo-wide (excluding node_modules) confirms no remaining stale occurrences.
- `npx eslint` on the 3 changed non-markdown files: clean.
- `npx vue-tsc --noEmit`: clean, no new errors.
- `npx prettier --check` on all 4 files: `stores/helpers/dashboardHelper.ts` has a pre-existing formatting warning unrelated to my one-line change (confirmed via `git stash` — the warning exists on `main` before this diff too); left untouched to keep the diff scoped.

### Stakes
reversible

### Kaizen suggestion
The "centuries" figure is hand-maintained prose that silently drifts every time a new earliest/latest curriculum entry is added (this is the second time this exact class of drift has happened per the project's continuous-improvement notes). A future cycle could compute this from `academyTimeline`'s min/max `sortYear` in the two Vue components that already have store access (`academy-timeline.vue`, `academy-manager.vue`), removing the two hardcoded numbers there permanently. `content/academy.md` and `dashboardHelper.ts` are static config/content without reactive store access, so a full fix there would need a build-time or content-hook approach — better scoped as its own task than folded into this one.

### Notes for reviewer
Small, text-only, no logic changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKo8qPbnJvTYxKVsDfeX1m)_