### PR TITLE
media-watchlist/t-006: add Year-over-year comparison to Stats view

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -19,6 +19,11 @@
   fixed, unfiltered global view -- a separate GET /api/media-entries?take=10&
   sort=date_desc call that ignores the active search/year/type/starred/month/
   season state entirely, per that spec.
+  "Year over year" (media-watchlist/t-006, BROWSE-UX.md §4's last gap) is a
+  side-by-side per-year table (totals by media type, most-watched month),
+  gated to 2+ years of data; rides along on the existing loadStats() call --
+  stats.get.ts's new yearComparison field is unfiltered by the active year,
+  same as the years list.
 -->
 <template>
   <section class="flex flex-col gap-4">
@@ -135,6 +140,70 @@
             >TV seasons ({{ stats.tvShowCount }} shows)</span
           >
         </div>
+      </div>
+
+      <!-- Year-over-year comparison (BROWSE-UX.md §4) -->
+      <div
+        v-if="stats && showYearComparison"
+        class="overflow-x-auto rounded-3xl border border-base-300 bg-base-100 p-4"
+      >
+        <p class="mb-2 text-xs font-semibold uppercase text-base-content/50">
+          Year over year
+        </p>
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th></th>
+              <th
+                v-for="row in stats.yearComparison"
+                :key="row.year"
+                class="text-right"
+              >
+                {{ row.year }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="chip in MEDIA_TYPE_CHIPS" :key="chip.value">
+              <td class="font-semibold text-base-content/70">
+                {{ chip.label }}
+              </td>
+              <td
+                v-for="row in stats.yearComparison"
+                :key="row.year"
+                class="text-right"
+              >
+                {{ countForChipGroup(row, chip.group) }}
+              </td>
+            </tr>
+            <tr class="font-semibold">
+              <td>Total</td>
+              <td
+                v-for="row in stats.yearComparison"
+                :key="row.year"
+                class="text-right"
+              >
+                {{ row.totalCount }}
+              </td>
+            </tr>
+            <tr>
+              <td class="font-semibold text-base-content/70">
+                Most watched month
+              </td>
+              <td
+                v-for="row in stats.yearComparison"
+                :key="row.year"
+                class="text-right"
+              >
+                {{
+                  row.mostWatchedMonth
+                    ? monthLabel(row.mostWatchedMonth.month)
+                    : '—'
+                }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
 
       <!-- Filters -->
@@ -406,6 +475,13 @@ type MediaEntriesResponse = {
   total: number
 }
 
+type YearComparisonRow = {
+  year: number
+  totalCount: number
+  countByType: Record<string, number>
+  mostWatchedMonth: { month: number; count: number } | null
+}
+
 type MediaEntryStats = {
   years: number[]
   totalCount: number
@@ -416,6 +492,7 @@ type MediaEntryStats = {
   comicIssuesRead: number
   tvShowCount: number
   tvSeasonCount: number
+  yearComparison: YearComparisonRow[]
 }
 
 type MediaEntryStatsResponse = {
@@ -509,6 +586,12 @@ const stats = ref<MediaEntryStats | null>(null)
 const selectedId = ref<number | null>(null)
 const recentEntries = ref<MediaEntrySummary[]>([])
 
+function monthLabel(month: number): string {
+  return new Date(2000, month - 1, 1).toLocaleString('en-US', {
+    month: 'long',
+  })
+}
+
 // BROWSE-UX.md §1: "Most active month: 'You consumed the most in [Month]: N
 // entries'". countByMonth is keyed by month number as a string (1-12); pick
 // the highest count and name it. No entry -> hide the line rather than
@@ -525,11 +608,14 @@ const mostActiveMonth = computed(() => {
     }
   }
   if (bestMonth === null) return null
-  const label = new Date(2000, bestMonth - 1, 1).toLocaleString('en-US', {
-    month: 'long',
-  })
-  return { label, count: bestCount }
+  return { label: monthLabel(bestMonth), count: bestCount }
 })
+
+// Year-over-year comparison (BROWSE-UX.md §4) only makes sense with 2+ years
+// of data to compare.
+const showYearComparison = computed(
+  () => (stats.value?.yearComparison.length ?? 0) >= 2,
+)
 
 const canShowMore = computed(() => entries.value.length < total.value)
 const selectedEntry = computed(
@@ -560,6 +646,12 @@ function handleEntryUpdated(updated: MediaEntryDetail) {
       ...updated,
     }
   }
+}
+
+// Sums a year-comparison row's per-type counts across a chip's full group
+// (e.g. TV chip = TV + ANIME), same fold-in as expandActiveTypes() below.
+function countForChipGroup(row: YearComparisonRow, group: MediaType[]): number {
+  return group.reduce((sum, type) => sum + (row.countByType[type] ?? 0), 0)
 }
 
 function toggleType(type: MediaType) {

--- a/server/api/media-entries/stats.get.ts
+++ b/server/api/media-entries/stats.get.ts
@@ -30,6 +30,8 @@ export default defineEventHandler(async (event) => {
       comicIssues,
       tvSeasons,
       yearRows,
+      yearTypeRows,
+      yearMonthRows,
     ] = await Promise.all([
       prisma.mediaEntry.count({ where }),
       prisma.mediaEntry.groupBy({
@@ -74,6 +76,18 @@ export default defineEventHandler(async (event) => {
         select: { year: true },
         orderBy: { year: 'desc' },
       }),
+      // Also unfiltered by `year` -- the Year-over-year comparison
+      // (BROWSE-UX.md §4) is inherently cross-year, same precedent as
+      // `yearRows` above.
+      prisma.mediaEntry.groupBy({
+        by: ['year', 'mediaType'],
+        _count: { _all: true },
+      }),
+      prisma.mediaEntry.groupBy({
+        by: ['year', 'watchedMonth'],
+        where: { watchedMonth: { not: null } },
+        _count: { _all: true },
+      }),
     ])
 
     const countByType = byMediaType.reduce<Record<string, number>>(
@@ -94,6 +108,50 @@ export default defineEventHandler(async (event) => {
       {},
     )
 
+    // Year-over-year comparison (BROWSE-UX.md §4): per-year totals by media
+    // type plus each year's most-watched month, for a side-by-side table.
+    type YearComparisonRow = {
+      year: number
+      totalCount: number
+      countByType: Record<string, number>
+      mostWatchedMonth: { month: number; count: number } | null
+    }
+    const comparisonByYear = new Map<number, YearComparisonRow>()
+    function getComparisonRow(entryYear: number): YearComparisonRow {
+      let row = comparisonByYear.get(entryYear)
+      if (!row) {
+        row = {
+          year: entryYear,
+          totalCount: 0,
+          countByType: {},
+          mostWatchedMonth: null,
+        }
+        comparisonByYear.set(entryYear, row)
+      }
+      return row
+    }
+    for (const group of yearTypeRows) {
+      const row = getComparisonRow(group.year)
+      row.countByType[group.mediaType] = group._count._all
+      row.totalCount += group._count._all
+    }
+    for (const group of yearMonthRows) {
+      if (group.watchedMonth == null) continue
+      const row = getComparisonRow(group.year)
+      if (
+        !row.mostWatchedMonth ||
+        group._count._all > row.mostWatchedMonth.count
+      ) {
+        row.mostWatchedMonth = {
+          month: group.watchedMonth,
+          count: group._count._all,
+        }
+      }
+    }
+    const yearComparison = Array.from(comparisonByYear.values()).sort(
+      (a, b) => b.year - a.year,
+    )
+
     return {
       success: true,
       data: {
@@ -109,6 +167,7 @@ export default defineEventHandler(async (event) => {
         comicIssuesRead: comicIssues._sum.issueCount ?? 0,
         tvShowCount: tvSeasons._count._all,
         tvSeasonCount: tvSeasons._sum.season ?? 0,
+        yearComparison,
       },
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Closes BROWSE-UX.md §4's last open gap: Year-over-year comparison in the Media Watchlist Stats view.
- `server/api/media-entries/stats.get.ts` now also returns `yearComparison`: per-year totals by media type plus each year's most-watched month, unfiltered by the active `?year=` filter (same precedent as the existing `years` list, since a year-over-year comparison is inherently cross-year).
- `components/watchlist/watchlist-browse.vue` renders this as a side-by-side DaisyUI table (year columns × media-type rows + Total + Most watched month), gated to only show when 2+ years of data exist. Reuses the existing `MEDIA_TYPE_CHIPS`/`CHIP_GROUP_BY_VALUE` fold-in logic and factors the month-name formatting into a small shared `monthLabel()` helper.
- No new fetch call, no new route, no new library — rides along on the existing `loadStats()` call.

## Test plan
- [x] `eslint` clean on both changed files
- [x] `prettier --check` clean on both changed files
- [x] Full-project `vue-tsc --noEmit` exits 0
- [ ] CI checks (watching)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0155gxAG7FiaihJSEYkxT3VZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0155gxAG7FiaihJSEYkxT3VZ)_