### PR TITLE
ci: retry Cypress API tests once against the live Vercel baseUrl

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -591,4 +591,18 @@ export default defineConfig({
   // videos" artifact step and Cypress Cloud recording) but skip compression,
   // which is the step that actually stalls.
   videoCompression: false,
+  // Same reasoning as cypress.public.config.ts: this suite's baseUrl is the
+  // live Vercel deployment, so an occasional cy.request() can hit a cold
+  // serverless function start or a momentary latency blip and blow the
+  // default 30s responseTimeout even though the endpoint itself is correct
+  // (seen twice against unrelated routes on 2026-07-28/29 -- POST
+  // /api/sheets/by-dream/:id and POST /api/art/image -- both single-run
+  // flakes with the very next scheduled run green). Retry once in CI so a
+  // genuine infra blip doesn't false-positive the whole suite; a real
+  // regression still fails after the retry. Local `cypress open` runs
+  // unaffected.
+  retries: {
+    runMode: 1,
+    openMode: 0,
+  },
 })


### PR DESCRIPTION
## Summary

Fixes a HIGH-priority `ci-janitor` Todo (#945): the `Cypress Tests` workflow went red on run [30470626056](https://github.com/silasfelinus/kind_robots/actions/runs/30470626056) — `POST /api/art/image` timed out waiting the default 30s `responseTimeout` for a response.

**Root cause is environmental, not a product bug:**
- The failing test only creates a lightweight metadata row (no image upload/generation), so a 30s timeout is not expected work time.
- The very next scheduled run (30477088734, ~1h24m later) was already green with no code changes in between.
- A second, unrelated single-run flake on 2026-07-28 (run 30399691261, `POST /api/sheets/by-dream/:id`) shows the identical shape — a different endpoint, same live host, one-off `cy.request()` timeout, green again on the next run.
- The pre-flight "Verify database readiness" step (3 consecutive pooled health checks + an 8-concurrent-request soak round) already passed before both flaky runs, ruling out a sustained DB problem.

This matches an occasional cold serverless start or latency blip against the live `kind-robots.vercel.app` deployment that the suite tests directly (`cypress.config.ts`'s `baseUrl`).

**Fix:** `cypress.public.config.ts` already sets `retries: { runMode: 1, openMode: 0 }` for exactly this reason (its `baseUrl` is also a live host). This PR applies the same retry config to `cypress.config.ts` (the API test suite `cypress.yml` actually runs), so one transient infra blip gets a single automatic retry in CI instead of failing the whole suite. Local `cypress open` is unaffected (`openMode: 0`). No assertions, timeouts, or test logic changed — a genuine regression still fails after the retry.

## Verification

- `npx vue-tsc --noEmit` — no errors in `cypress.config.ts`
- `npx eslint cypress.config.ts` — clean
- Confirmed via GitHub Actions run history that both flakes were isolated single-run failures on an otherwise-green `main` (not a persistent regression)

## Flags for Reviewer

- This is a conductor-originated cross-repo fix (Todo #945, HIGH priority) — no kind_robots roadmap task involved.
- Scope is intentionally narrow: config-only change, no product code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KtB2ZVUJW2eb6fK4QibbyU)_