### PR TITLE
taskmaster: point dashboard-tab/tutorial art at dedicated assets

### DIFF
--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -917,8 +917,7 @@ export const dashboardConfigs = {
         icon: 'kind-icon:gearhammer',
         title: 'Taskmaster',
         summary: 'Turn real objectives into a choice-driven adventure.',
-        // Shared temporarily until the dedicated Taskmaster art set lands.
-        image: tabImage('scenario', 'storymaker'),
+        image: tabImage('scenario', 'taskmaster'),
         narrative:
           'Taskmaster wraps real work in a second-person quest while keeping the actual objective visible and every write-back explicit.',
         route: '/taskmaster',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -135,8 +135,7 @@ export const tutorialChannels = {
         key: 'taskmaster',
         title: 'Taskmaster',
         body: 'Choose a project or enter an objective, select narrative ingredients, and advance real work through a playful second-person quest. Taskmaster directs story art automatically and never applies real-world changes without review.',
-        // Shared temporarily until the dedicated Taskmaster tutorial art lands.
-        image: tutorialImage('scenario', 'storymaker'),
+        image: tutorialImage('scenario', 'taskmaster'),
       },
       {
         key: 'storymaker',


### PR DESCRIPTION
### Task
conductor `taskmaster/t-003`: Polish and upgrade Taskmaster front-end surface (kind: software)

### What changed / what I produced
- `stores/helpers/dashboardHelper.ts`: Taskmaster's dashboard tab now points at `tabImage('scenario', 'taskmaster')` instead of borrowing Storymaker's art, and removed the "Shared temporarily" comment.
- `stores/helpers/tutorialCards.ts`: Taskmaster's tutorial section now points at `tutorialImage('scenario', 'taskmaster')`, same cleanup.
- On the conductor side (companion PR): queued the dedicated dashboard-tab (`public/images/dashboard-tabs/scenario/taskmaster.webp`, 512×512) and tutorial (`public/images/tutorials/scenario/taskmaster.webp`, 800×600) art through the live ArtJob relay (jobs 2849/2850), plus taskmaster's project icon/card/hero (jobs 2846–2848, `projects/images/taskmaster-{icon,card,hero}.webp`).
- Verified `project-overrides.yaml`'s taskmaster `liveUrl`/`channelKey`/`tabKey` already match `utils/projectPlacements.ts`'s `PROJECT_PLACEMENTS.taskmaster` entry, and confirmed via `scripts/sync_projects.py` that the live taskmaster Dream record is already in sync (`UNCHANGED`) — no admin Placements action needed.

### How I verified
- `npx eslint stores/helpers/dashboardHelper.ts stores/helpers/tutorialCards.ts` — clean.
- Full-project `vue-tsc --noEmit` — exit 0.

### Stakes
reversible

### Flags for Reviewer
- The queued art (jobs 2846–2850) renders asynchronously on the relay; images aren't committed yet. Until `distribute_images.py` places them, these two paths will 404 in the UI (same eventual-consistency tradeoff already accepted for model-builder's t-029 tab entry). A future cycle should run `distribute_images.py` (or confirm the distribute-images workflow already picked them up) once the renders land.
- taskmaster-page.vue/taskmasterStore.ts were already confirmed a mature, complete implementation in a prior cycle (not a scaffold) — this PR only covers the art-pointer half of t-003.

### Kaizen suggestion
Several other projects' recurring "Polish and upgrade X front-end surface" tasks (storymaker, coat-dance, wishmaster, ruler-hooked, etc.) are stuck at the identical dashboard-tab/tutorial-art step with notes saying it's "blocked on the art-generation relay." This session found the relay actually accepts live queueing via `consume_art_queue.py --live --no-wait` (jobs 2846–2850 above went through cleanly) — worth revisiting whether those other tasks are still genuinely blocked or just hadn't tried the live queue path.

### Notes for reviewer
No schema change. No live data mutated beyond queuing ArtJobs (pre-approved per AGENTS.md's "Generated art is pre-approved" rule).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBELZymLjAaXNLorXLVFGT)_