### PR TITLE
model-builder: guard draftText() against approval-while-drafting race

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -151,6 +151,12 @@ jobs:
       - name: Model Builder commit cancelled-run guard contract
         run: npm run test:model-builder-commit-cancelled-run-guard
 
+      - name: Model Builder draft approval guard checker self-test
+        run: npm run test:model-builder-draft-approval-guard-selftest
+
+      - name: Model Builder draft approval guard contract
+        run: npm run test:model-builder-draft-approval-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,8 @@
     "test:model-builder-approved-asset-guard": "tsx utils/scripts/verifyModelBuilderApprovedAssetGuard.ts",
     "test:model-builder-commit-cancelled-run-guard-selftest": "tsx utils/scripts/verifyModelBuilderCommitCancelledRunGuard.test.ts",
     "test:model-builder-commit-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts",
+    "test:model-builder-draft-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.test.ts",
+    "test:model-builder-draft-approval-guard": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -795,6 +795,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
   // --- AI drafting: reuse the existing /api/suggest text generator -----------
 
+  // Which build stage a draft field's content lives under -- pitch under
+  // PITCH; fields/artPrompt both under FIELDS_AND_PROMPTS (see
+  // model-builder-item-panel.vue's stage sections). Shared by draftText
+  // (guards against the stage having been approved while its own draft was
+  // in flight) and batchDraftField (skips already-approved items up front).
+  function stageForDraftField(field: DraftField): BuildStageKey {
+    return field === 'pitch' ? 'PITCH' : 'FIELDS_AND_PROMPTS'
+  }
+
   async function draftText(
     itemId: string,
     field: DraftField,
@@ -889,6 +898,25 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         setStatus(
           'error',
           `${item.label} was edited while drafting — draft discarded to avoid overwriting your changes.`,
+        )
+        return false
+      }
+
+      // The stage this field belongs to may also have been approved while the
+      // draft was in flight -- the Approve button for PITCH/FIELDS_AND_PROMPTS
+      // has no isDrafting gate of its own (unlike the Draft button next to
+      // it), so a user can click Draft then Approve before the response
+      // lands. Applying the draft afterward would silently rewrite an
+      // approved stage's content while its badge keeps showing 'approved' --
+      // the same review-gate-bypass class isStageEditable already guards for
+      // batchDraftField/batchSetField, just missing here for the single-item
+      // path (updatePitch/updateFields/updatePrompt assume they're always
+      // called from behind the UI's editable gate, which is true for a
+      // synchronous @change edit but not for this async draft's completion).
+      if (!isStageEditable(item, stageForDraftField(field))) {
+        setStatus(
+          'error',
+          `${item.label} was approved while drafting — draft discarded to avoid overwriting the approved content.`,
         )
         return false
       }
@@ -1460,10 +1488,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   ): Promise<void> {
     const items = groupItems(outputKey)
     if (!items.length) return
-    // pitch lives under PITCH; fields/artPrompt both live under
-    // FIELDS_AND_PROMPTS (see model-builder-item-panel.vue's stage sections).
-    const stageKey: BuildStageKey =
-      field === 'pitch' ? 'PITCH' : 'FIELDS_AND_PROMPTS'
+    const stageKey = stageForDraftField(field)
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
     let drafted = 0

--- a/utils/scripts/verifyModelBuilderDraftApprovalGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderDraftApprovalGuard.test.ts
@@ -1,0 +1,150 @@
+// /utils/scripts/verifyModelBuilderDraftApprovalGuard.test.ts
+//
+// Regression test for checkDraftApprovalGuard() in
+// verifyModelBuilderDraftApprovalGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (no isStageEditable check between the /api/suggest response
+// landing and the draft being applied via updatePitch/updateFields/
+// updatePrompt -- the exact bug found by manual read-through), and the fixed
+// shape.
+import assert from 'node:assert/strict'
+
+import { checkDraftApprovalGuard } from './verifyModelBuilderDraftApprovalGuard.js'
+
+const BUGGY_FIXTURE = `
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    const current =
+      field === 'pitch' ? item.pitch : field === 'fields' ? item.fieldsDraft : item.promptDraft
+
+    draftingFieldSingleton.claim({ itemId, field })
+    clearStatus()
+
+    try {
+      const result = await performFetch('/api/suggest', { method: 'POST' }, 2, 60_000)
+
+      if (!result.success || !result.data?.value) {
+        throw new Error(result.message || 'The model returned nothing useful.')
+      }
+
+      const value = result.data.value.trim()
+
+      const liveValue =
+        field === 'pitch' ? item.pitch : field === 'fields' ? item.fieldsDraft : item.promptDraft
+      if (liveValue !== current) {
+        setStatus('error', 'edited while drafting')
+        return false
+      }
+
+      if (field === 'pitch') updatePitch(itemId, value)
+      else if (field === 'fields') updateFields(itemId, value)
+      else updatePrompt(itemId, value)
+
+      setStatus('success', 'drafted')
+      return true
+    } catch (error) {
+      handleError(error, 'drafting model builder text')
+      return false
+    } finally {
+      draftingFieldSingleton.release({ itemId, field })
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function draftText(
+    itemId: string,
+    field: DraftField,
+    instruction?: string,
+  ): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    const current =
+      field === 'pitch' ? item.pitch : field === 'fields' ? item.fieldsDraft : item.promptDraft
+
+    draftingFieldSingleton.claim({ itemId, field })
+    clearStatus()
+
+    try {
+      const result = await performFetch('/api/suggest', { method: 'POST' }, 2, 60_000)
+
+      if (!result.success || !result.data?.value) {
+        throw new Error(result.message || 'The model returned nothing useful.')
+      }
+
+      const value = result.data.value.trim()
+
+      const liveValue =
+        field === 'pitch' ? item.pitch : field === 'fields' ? item.fieldsDraft : item.promptDraft
+      if (liveValue !== current) {
+        setStatus('error', 'edited while drafting')
+        return false
+      }
+
+      if (!isStageEditable(item, stageForDraftField(field))) {
+        setStatus('error', 'approved while drafting')
+        return false
+      }
+
+      if (field === 'pitch') updatePitch(itemId, value)
+      else if (field === 'fields') updateFields(itemId, value)
+      else updatePrompt(itemId, value)
+
+      setStatus('success', 'drafted')
+      return true
+    } catch (error) {
+      handleError(error, 'drafting model builder text')
+      return false
+    } finally {
+      draftingFieldSingleton.release({ itemId, field })
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkDraftApprovalGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  1,
+  `expected the pre-fix shape (missing isStageEditable check) to raise 1 ` +
+    `error, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors[0]!.includes('isStageEditable'),
+  'expected a violation naming the missing isStageEditable guard',
+)
+
+const fixedErrors = checkDraftApprovalGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkDraftApprovalGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when draftText is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('draftText'))
+
+console.log(
+  'Model Builder draft approval guard checker verified: flags the pre-fix ' +
+    'shape (missing post-response isStageEditable check), clears the fixed ' +
+    'shape, and flags draftText being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderDraftApprovalGuard.ts
+++ b/utils/scripts/verifyModelBuilderDraftApprovalGuard.ts
@@ -1,0 +1,122 @@
+// /utils/scripts/verifyModelBuilderDraftApprovalGuard.ts
+//
+// Regression guard (model-builder/t-029) -- draftText() is the single-item AI
+// drafting path behind model-builder-item-panel.vue's "Draft with AI"
+// buttons. Its own success path already discards a draft that lands after
+// the user hand-edited the same field mid-flight (the `liveValue !==
+// current` check), but had no equivalent check for the field's *stage*
+// having been approved mid-flight. The item panel's Approve button for
+// PITCH/FIELDS_AND_PROMPTS has no `isDrafting` gate of its own (unlike the
+// Draft button right next to it, which does) -- `:disabled="isLocked('PITCH')
+// || !pitch.trim()"` for pitch, `:disabled="isLocked('FIELDS_AND_PROMPTS')"`
+// for fields/prompt -- so a user can click Draft, then Approve (pitch/fields
+// already non-empty), before the draft response lands. Before this fix,
+// draftText then unconditionally wrote the stale draft into item.pitch /
+// item.fieldsDraft / item.promptDraft via updatePitch/updateFields/
+// updatePrompt, silently rewriting an already-'approved' stage's content
+// while its badge kept showing 'approved' -- no re-review. This is the same
+// review-gate-bypass class isStageEditable already guards for
+// batchDraftField/batchSetField, just missing here for the single-item path
+// those batch functions call into.
+//
+// This asserts the textual shape of the fix stays in place: draftText checks
+// `isStageEditable(item, stageForDraftField(field))` after its
+// `result.success` branch and before it applies the draft via
+// updatePitch/updateFields/updatePrompt. Deliberately scoped to this one
+// function/bug, mirroring verifyModelBuilderCommitCancelledRunGuard.ts's
+// preference for explicit, narrow textual checks over a general-purpose
+// static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'draftText'
+const RESULT_CHECK = 'if (!result.success'
+const APPLY_SETTER = "if (field === 'pitch') updatePitch(itemId, value)"
+const GUARD = 'isStageEditable(item, stageForDraftField(field))'
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `draftText`-named async function. Exported (rather than only
+// exercised via main()) so the self-test below can run it against synthetic
+// buggy/fixed fixtures without touching the real store file.
+export function checkDraftApprovalGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  const resultCheckIndex = fn.body.indexOf(RESULT_CHECK)
+  if (resultCheckIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer branches on ${RESULT_CHECK} -- this guard's ` +
+        'anchor point has moved; re-check where the /api/suggest response ' +
+        'is validated.',
+    )
+    return errors
+  }
+
+  const setterIndex = fn.body.indexOf(APPLY_SETTER, resultCheckIndex)
+  if (setterIndex === -1) {
+    errors.push(
+      `${FN_NAME}() no longer applies the draft via \`${APPLY_SETTER}\` -- ` +
+        "this guard's anchor point has moved; re-check where the draft is " +
+        'routed through updatePitch/updateFields/updatePrompt.',
+    )
+    return errors
+  }
+
+  const guardIndex = fn.body.indexOf(GUARD, resultCheckIndex)
+  if (guardIndex === -1 || guardIndex >= setterIndex) {
+    errors.push(
+      `${FN_NAME}() does not check \`${GUARD}\` between its ${RESULT_CHECK} ` +
+        `branch and ${APPLY_SETTER}. The Approve button for PITCH / ` +
+        'FIELDS_AND_PROMPTS has no isDrafting gate, so a user can approve ' +
+        "the stage while this function's own /api/suggest await is still " +
+        'pending. Without this check, the draft that lands afterward ' +
+        "silently rewrites the now-approved stage's content with no " +
+        "re-review, even though its badge keeps showing 'approved'.",
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkDraftApprovalGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder draft approval guard contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder draft approval guard contract passed: ${FN_NAME}() ` +
+      'refuses to apply a draft whose stage was approved while the draft ' +
+      'was still in flight.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary

conductor `model-builder/t-029` (recurring polish task) follow-on — each cycle reads the model-builder store + components in full looking for a genuine, previously-unfixed bug.

`draftText()` is the single-item AI drafting path behind `model-builder-item-panel.vue`'s "Draft with AI" buttons. It already discards a draft that lands after the user hand-edited the same field mid-flight (`liveValue !== current`), but had no equivalent check for the field's *stage* having been **approved** mid-flight.

**The race:** the Approve button for `PITCH`/`FIELDS_AND_PROMPTS` has no `isDrafting` gate of its own — unlike the Draft button right next to it (`:disabled="isDrafting('pitch')"` etc.). Its disabled condition is only `isLocked('PITCH') || !pitch.trim()` (line 76) / `isLocked('FIELDS_AND_PROMPTS')` (line 158) in `model-builder-item-panel.vue`. So: click Draft → click Approve (pitch/fields already non-empty) → draft response lands. Before this fix, `draftText` wrote the resolved draft straight into `item.pitch`/`fieldsDraft`/`promptDraft` via `updatePitch`/`updateFields`/`updatePrompt` regardless, silently rewriting the now-approved stage's content while its badge kept showing "approved" — no re-review. This is the exact review-gate-bypass class `isStageEditable` already guards for `batchDraftField`/`batchSetField`; it was just missing on the single-item path those batch functions call into.

## Fix

- Extracted the field→stage mapping into `stageForDraftField()` (previously duplicated inline in `batchDraftField`).
- `draftText()` now checks `isStageEditable(item, stageForDraftField(field))` right after the `/api/suggest` response resolves, before applying it via the updater functions. Sets a clear error status and discards the stale draft instead.

## Regression coverage

Added `verifyModelBuilderDraftApprovalGuard.ts` (+ `.test.ts` self-test), wired into `contract-tests.yml`, following the exact existing pattern of `verifyModelBuilderCommitCancelledRunGuard.ts` — a narrow textual checker asserting the guard call sits between the `/api/suggest` result check and the `updatePitch`/`updateFields`/`updatePrompt` application, not a general static analyzer.

## Verification

- `npm run test:model-builder-draft-approval-guard-selftest` — pass
- `npm run test:model-builder-draft-approval-guard` — pass
- `npx eslint stores/modelBuilderStore.ts` — 2 pre-existing `no-empty` errors at lines 203/210, confirmed via `git stash` to exist identically on `main` (unrelated to this diff, far from the changed lines)
- `npx prettier --check stores/modelBuilderStore.ts` — pre-existing formatting drift, likewise confirmed via `git stash` to exist on `main`; new files (`verifyModelBuilderDraftApprovalGuard.ts`/`.test.ts`) are prettier-clean
- `npx vue-tsc --noEmit -p .` (full project) — clean, 0 errors

## Flags for Reviewer

- Scope is intentionally narrow: one guard check + its dedicated regression checker, matching this recurring task's established convention exactly.
- Steps (1) art generation and (3) liveUrl backfill for this project remain genuinely blocked (art-gen backend / admin action) per prior cycles' notes — not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KtB2ZVUJW2eb6fK4QibbyU)_