### PR TITLE
academy: fix uploadStore target leak on Academy unmount

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -119,6 +119,7 @@ const validTabs: AcademyTab[] = ['timeline', 'styles', 'remix', 'stylelab']
 
 const isLoadingManager = ref(false)
 const managerError = ref<string | null>(null)
+const hasConfiguredUploadTarget = ref(false)
 
 const dashboardKey = computed(() => {
   return navStore.dashboardShell.dashboardKey || defaultDashboardKey
@@ -159,6 +160,7 @@ function configureStyleLabUploadTarget() {
     icon: 'kind-icon:image',
     showPreview: true,
   })
+  hasConfiguredUploadTarget.value = true
 }
 
 watch(
@@ -201,6 +203,12 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  uploadStore.clearTarget()
+  // Only clear the target if this component actually set one (i.e. the user
+  // opened the stylelab tab) -- otherwise leaving Academy without ever
+  // visiting Style Lab wipes out whatever unrelated page (add-bot,
+  // art-maker, ...) had configured before the user arrived here.
+  if (hasConfiguredUploadTarget.value) {
+    uploadStore.clearTarget()
+  }
 })
 </script>


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (kind: software) — lane 1, front-end polish

### What changed / what I produced
- `components/academy/academy-manager.vue`: `uploadStore.activeTarget` is an app-lifetime Pinia singleton. This component only *sets* it conditionally — the `watch(activeTab, ...)` calls `configureStyleLabUploadTarget()` solely when the user opens the `stylelab` tab (PR #1058) — but a later fix (t-047, PR #1063) added an unconditional `onUnmounted(() => uploadStore.clearTarget())`.
- Net effect: leaving Academy without ever visiting the Style Lab tab still wiped the upload target, silently breaking whatever unrelated page (`add-bot`, `art-maker`, ...) had configured it before the user arrived at Academy.
- Fix: track `hasConfiguredUploadTarget` and only call `clearTarget()` on unmount if this component actually set the target.

### How I verified
- `npx eslint components/academy/academy-manager.vue` — clean
- `npx prettier --check components/academy/academy-manager.vue` — clean
- `npm run test` (full-project `vue-tsc --noEmit`) — exit 0, no errors

### Stakes
reversible

### Flags for Reviewer
- Found via an Explore agent sweep of the Academy component family, cross-checked against this recurring task's run log to confirm this specific asymmetry (conditional set / unconditional clear) hadn't already been fixed — it's a genuine gap left by the interaction between PR #1058 and PR #1063, not a re-proposal of either.

### Kaizen suggestion
`uploadStore`'s `setTarget`/`clearTarget` pattern now has at least two consumers (this one, and the `t-047`/`t-048` family) that had to hand-roll "did I actually set it" tracking to clear safely. Worth considering a `uploadStore.setTarget(...)` variant that returns an idempotent unmount-cleanup handle, so future consumers can't reintroduce this same asymmetry.

### Notes for reviewer
Part of ai-art-academy/t-010's recurring lane-1 (front-end polish) rotation — see `projects/ai-art-academy/docs/continuous-improvement-run-log.md` for full cycle history.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TL1XHD6tRuwmyq1VgjhETi)_