### PR TITLE
Refresh LoRA resource paths when art jobs are re-enqueued

### DIFF
--- a/.github/workflows/artjob-provenance-contract.yml
+++ b/.github/workflows/artjob-provenance-contract.yml
@@ -7,7 +7,10 @@ on:
       - "server/api/art/queue/**"
       - "server/utils/artJobProvenance.ts"
       - "server/utils/artImageSeed.ts"
+      - "server/utils/artJobResourceRefresh.ts"
+      - "server/utils/artJobRetry.ts"
       - "utils/scripts/verifyArtJobProvenance.ts"
+      - "utils/scripts/verifyArtJobLoraOverride.ts"
       - ".github/workflows/artjob-provenance-contract.yml"
   pull_request:
     branches: [main]
@@ -15,7 +18,10 @@ on:
       - "server/api/art/queue/**"
       - "server/utils/artJobProvenance.ts"
       - "server/utils/artImageSeed.ts"
+      - "server/utils/artJobResourceRefresh.ts"
+      - "server/utils/artJobRetry.ts"
       - "utils/scripts/verifyArtJobProvenance.ts"
+      - "utils/scripts/verifyArtJobLoraOverride.ts"
       - ".github/workflows/artjob-provenance-contract.yml"
   workflow_dispatch:
 
@@ -43,6 +49,9 @@ jobs:
 
       - name: Verify prompt and output provenance
         run: npx tsx utils/scripts/verifyArtJobProvenance.ts
+
+      - name: Verify LoRA retry resource refresh
+        run: npm run test:artjob-lora-override
 
       - name: TypeScript check
         run: npm run test

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -19,6 +19,7 @@ import {
   type ArtJobOverrides,
   type ArtJobRetryMode,
 } from '../../../../utils/artJobRetry'
+import { refreshArtJobLoraResources } from '../../../../utils/artJobResourceRefresh'
 import { applyArtJobVisibility } from '../../../../utils/artJobVisibility'
 import {
   applyArtFacetsToPayload,
@@ -150,7 +151,9 @@ export default defineEventHandler(async (event) => {
     }
     delete renderOverrides.facetIds
     delete renderOverrides.basePromptString
-    const payload = applyArtJobOverrides(prepared, renderOverrides)
+    const overriddenPayload = applyArtJobOverrides(prepared, renderOverrides)
+    const resourceRefresh = await refreshArtJobLoraResources(overriddenPayload)
+    const payload = resourceRefresh.payload
     applyArtJobVisibility(payload, body?.overrides)
     applyArtFacetsToPayload(payload, basePrompt, facets)
     const jobEngine = presetEngine ? 'COMFY' : source.engine
@@ -178,6 +181,11 @@ export default defineEventHandler(async (event) => {
         sourceJobId: id,
         mode,
         targetArtImageId: mode === 'OVERWRITE' ? source.artImageId : null,
+        resourceRefresh: {
+          changed: resourceRefresh.changed,
+          loraResourceIds: resourceRefresh.loraResourceIds,
+          loraNames: resourceRefresh.loraNames,
+        },
       },
       statusCode: 201,
     }

--- a/server/api/art/queue/reenqueue-failed.post.ts
+++ b/server/api/art/queue/reenqueue-failed.post.ts
@@ -9,14 +9,13 @@ import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
 import { normalizeFailedArtJobIds } from '../../../utils/failedArtJobScope'
-import {
-  serializeArtJobPayload,
-} from '../../../utils/artJobPayload'
+import { serializeArtJobPayload } from '../../../utils/artJobPayload'
 import {
   enrichArtJobPayload,
   readArtJobProvenance,
 } from '../../../utils/artJobProvenance'
 import { normalizeQueuedArtJobPayload } from '../../../utils/artJobNormalization'
+import { refreshArtJobLoraResources } from '../../../utils/artJobResourceRefresh'
 
 const REQUEUE_CONCURRENCY = 10
 
@@ -31,14 +30,28 @@ type RequeueResult = {
   id: number
   imagePathChanged: boolean
   promptChanged: boolean
+  loraPathChanged: boolean
+  loraResourceIds: number[]
+  loraNames: string[]
+}
+
+type RequeueFailure = {
+  id: number
+  message: string
+}
+
+function failureMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return String(error || 'Unknown requeue failure.')
 }
 
 async function requeueFailedJob(source: FailedJobSource): Promise<RequeueResult> {
   const normalization = normalizeQueuedArtJobPayload(source.payload)
+  const resourceRefresh = await refreshArtJobLoraResources(normalization.payload)
   const priorProvenance = readArtJobProvenance(source.payload)
   const { payload } = enrichArtJobPayload(
     source.engine,
-    normalization.payload,
+    resourceRefresh.payload,
     {
       projectSlug: source.projectSlug,
       idempotencyKey: priorProvenance?.idempotencyKey,
@@ -50,6 +63,9 @@ async function requeueFailedJob(source: FailedJobSource): Promise<RequeueResult>
     repairedAt: new Date().toISOString(),
     imagePathChanged: normalization.imagePathChanged,
     promptChanged: normalization.promptChanged,
+    loraPathChanged: resourceRefresh.changed,
+    loraResourceIds: resourceRefresh.loraResourceIds,
+    loraNames: resourceRefresh.loraNames,
   }
 
   const updated = await prisma.artJob.updateMany({
@@ -75,6 +91,9 @@ async function requeueFailedJob(source: FailedJobSource): Promise<RequeueResult>
     id: source.id,
     imagePathChanged: normalization.imagePathChanged,
     promptChanged: normalization.promptChanged,
+    loraPathChanged: resourceRefresh.changed,
+    loraResourceIds: resourceRefresh.loraResourceIds,
+    loraNames: resourceRefresh.loraNames,
   }
 }
 
@@ -121,9 +140,10 @@ export default defineEventHandler(async (event) => {
     const skippedJobIds = selectedJobIds.filter((id) => !sourcesById.has(id))
 
     const requeuedJobIds: number[] = []
-    const failedSourceJobIds: number[] = []
+    const failedJobs: RequeueFailure[] = []
     let repairedImagePathCount = 0
     let repairedPromptCount = 0
+    let repairedLoraPathCount = 0
 
     for (let index = 0; index < sources.length; index += REQUEUE_CONCURRENCY) {
       const batch = sources.slice(index, index + REQUEUE_CONCURRENCY)
@@ -139,12 +159,17 @@ export default defineEventHandler(async (event) => {
           requeuedJobIds.push(result.value.id)
           if (result.value.imagePathChanged) repairedImagePathCount += 1
           if (result.value.promptChanged) repairedPromptCount += 1
+          if (result.value.loraPathChanged) repairedLoraPathCount += 1
         } else {
-          failedSourceJobIds.push(source.id)
+          failedJobs.push({
+            id: source.id,
+            message: failureMessage(result.reason),
+          })
         }
       })
     }
 
+    const failedSourceJobIds = failedJobs.map((failure) => failure.id)
     const selectedCount = selectedJobIds.length
     const requestedCount = sources.length
     const queuedCount = requeuedJobIds.length
@@ -169,11 +194,13 @@ export default defineEventHandler(async (event) => {
         skippedCount,
         repairedImagePathCount,
         repairedPromptCount,
+        repairedLoraPathCount,
         selectedJobIds,
         sourceJobIds: sources.map((source) => source.id),
         skippedJobIds,
         queuedSourceJobIds: requeuedJobIds,
         failedSourceJobIds,
+        failedJobs,
         createdJobIds: [],
         refreshSeed: false,
         requeuedJobIds,

--- a/server/utils/artJobResourceRefresh.ts
+++ b/server/utils/artJobResourceRefresh.ts
@@ -1,0 +1,141 @@
+// /server/utils/artJobResourceRefresh.ts
+import { createError } from 'h3'
+import { ResourceType } from '~/prisma/generated/prisma/client'
+import {
+  parseArtJobPayload,
+  type ArtJobPayloadRecord,
+} from './artJobPayload'
+import { applyArtJobOverrides } from './artJobRetry'
+import prisma from './prisma'
+
+const LORA_TYPES = [ResourceType.LORA, ResourceType.LYCORIS]
+
+function asRecord(value: unknown): ArtJobPayloadRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as ArtJobPayloadRecord
+}
+
+function normalizeResourceIds(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+  return [
+    ...new Set(
+      value
+        .map(Number)
+        .filter((id) => Number.isInteger(id) && id > 0),
+    ),
+  ]
+}
+
+function normalizeLocalPath(value: unknown): string {
+  return typeof value === 'string'
+    ? value.trim().replaceAll('\\', '/')
+    : ''
+}
+
+function currentLoraResourceIds(payload: ArtJobPayloadRecord): number[] {
+  const resources = asRecord(payload.resources)
+  const resourceIds = normalizeResourceIds(resources.loraResourceIds)
+  return resourceIds.length
+    ? resourceIds
+    : normalizeResourceIds(payload.loraResourceIds)
+}
+
+function currentLoraNames(payload: ArtJobPayloadRecord): string[] {
+  const resources = asRecord(payload.resources)
+  if (!Array.isArray(resources.loraNames)) return []
+  return resources.loraNames
+    .map(normalizeLocalPath)
+    .filter((name): name is string => Boolean(name))
+}
+
+export type ArtJobLoraResourceRefresh = {
+  payload: ArtJobPayloadRecord
+  changed: boolean
+  loraResourceIds: number[]
+  loraNames: string[]
+}
+
+export function applyResolvedLoraResourceToArtJobPayload(
+  rawPayload: unknown,
+  resource: { id: number; localPath: string },
+): ArtJobLoraResourceRefresh {
+  if (!Number.isInteger(resource.id) || resource.id <= 0) {
+    throw createError({ statusCode: 409, message: 'Invalid LoRA Resource id.' })
+  }
+
+  const localPath = normalizeLocalPath(resource.localPath)
+  if (!localPath) {
+    throw createError({
+      statusCode: 409,
+      message: `LoRA Resource ${resource.id} does not have a localPath for ComfyUI.`,
+    })
+  }
+
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const before = JSON.stringify(payload)
+  applyArtJobOverrides(payload, { loraName: localPath })
+
+  const resources = asRecord(payload.resources)
+  resources.loraResourceIds = [resource.id]
+  resources.loraNames = [localPath]
+  payload.resources = resources
+
+  if (Array.isArray(payload.loraResourceIds)) {
+    payload.loraResourceIds = [resource.id]
+  }
+
+  return {
+    payload,
+    changed: before !== JSON.stringify(payload),
+    loraResourceIds: [resource.id],
+    loraNames: [localPath],
+  }
+}
+
+export async function refreshArtJobLoraResources(
+  rawPayload: unknown,
+): Promise<ArtJobLoraResourceRefresh> {
+  const payload = structuredClone(parseArtJobPayload(rawPayload))
+  const loraResourceIds = currentLoraResourceIds(payload)
+
+  if (!loraResourceIds.length) {
+    return {
+      payload,
+      changed: false,
+      loraResourceIds: [],
+      loraNames: currentLoraNames(payload),
+    }
+  }
+
+  if (loraResourceIds.length > 1) {
+    throw createError({
+      statusCode: 409,
+      message: `ArtJob references multiple LoRA Resources (${loraResourceIds.join(', ')}), but queued workflows currently support one.`,
+    })
+  }
+
+  const resourceId = loraResourceIds[0]!
+  const resource = await prisma.resource.findFirst({
+    where: {
+      id: resourceId,
+      isActive: true,
+      resourceType: { in: LORA_TYPES },
+    },
+    select: {
+      id: true,
+      localPath: true,
+    },
+  })
+
+  if (!resource) {
+    throw createError({
+      statusCode: 409,
+      message: `LoRA Resource ${resourceId} is missing, inactive, or no longer a LoRA Resource.`,
+    })
+  }
+
+  return applyResolvedLoraResourceToArtJobPayload(payload, {
+    id: resource.id,
+    localPath: String(resource.localPath || ''),
+  })
+}

--- a/server/utils/artJobResourceRefresh.ts
+++ b/server/utils/artJobResourceRefresh.ts
@@ -6,7 +6,6 @@ import {
   type ArtJobPayloadRecord,
 } from './artJobPayload'
 import { applyArtJobOverrides } from './artJobRetry'
-import prisma from './prisma'
 
 const LORA_TYPES = [ResourceType.LORA, ResourceType.LYCORIS]
 
@@ -115,6 +114,7 @@ export async function refreshArtJobLoraResources(
   }
 
   const resourceId = loraResourceIds[0]!
+  const { default: prisma } = await import('./prisma')
   const resource = await prisma.resource.findFirst({
     where: {
       id: resourceId,

--- a/utils/scripts/verifyArtJobLoraOverride.ts
+++ b/utils/scripts/verifyArtJobLoraOverride.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { applyArtJobOverrides } from '../../server/utils/artJobRetry'
+import { applyResolvedLoraResourceToArtJobPayload } from '../../server/utils/artJobResourceRefresh'
 
 // Style-LoRA override: repoint a job's selected style LoRA without rebuilding
 // it. This is the in-place fix for a stored lora_name that no longer resolves
@@ -115,6 +116,86 @@ import { applyArtJobOverrides } from '../../server/utils/artJobRetry'
   const out = applyArtJobOverrides(payload, { loraName: 'x/y.safetensors' })
   assert.equal((out.workflow as any)['24'].inputs.unet_name, 'flux1-dev-Q8_0.gguf')
   assert.ok(!('lora_name' in (out.workflow as any)['24'].inputs))
+}
+
+// 6. Job 2615 refreshes Resource 4082 instead of preserving the stale payload.
+{
+  const refresh = applyResolvedLoraResourceToArtJobPayload(
+    {
+      loraName: 'FLUX\\impressionist.safetensors',
+      resources: {
+        loraResourceIds: [4082],
+        loraNames: ['FLUX\\impressionist.safetensors'],
+      },
+      workflow: {
+        '61': {
+          class_type: 'LoraLoaderModelOnly',
+          inputs: {
+            lora_name: 'FLUX\\impressionist.safetensors',
+            strength_model: 1,
+          },
+          _meta: { title: 'Style LoRA' },
+        },
+      },
+    },
+    {
+      id: 4082,
+      localPath: 'Flux/SFW/ume_classic_impressionist.safetensors',
+    },
+  )
+
+  assert.equal(refresh.changed, true)
+  assert.deepEqual(refresh.loraResourceIds, [4082])
+  assert.deepEqual(refresh.loraNames, [
+    'Flux/SFW/ume_classic_impressionist.safetensors',
+  ])
+  assert.equal(
+    (refresh.payload.workflow as any)['61'].inputs.lora_name,
+    'Flux/SFW/ume_classic_impressionist.safetensors',
+  )
+  assert.equal(
+    refresh.payload.loraName,
+    'Flux/SFW/ume_classic_impressionist.safetensors',
+  )
+  assert.deepEqual((refresh.payload.resources as any).loraNames, [
+    'Flux/SFW/ume_classic_impressionist.safetensors',
+  ])
+}
+
+// 7. Job 2621 keeps the Resource's Kontext folder and exact path casing.
+{
+  const refresh = applyResolvedLoraResourceToArtJobPayload(
+    {
+      resources: {
+        loraResourceIds: [1300],
+        loraNames: ['FLUX/manuscript_illustration_kontext.safetensors'],
+      },
+      workflow: {
+        '61': {
+          class_type: 'LoraLoaderModelOnly',
+          inputs: {
+            lora_name: 'FLUX/manuscript_illustration_kontext.safetensors',
+            strength_model: 1,
+          },
+          _meta: { title: 'Style LoRA' },
+        },
+      },
+    },
+    {
+      id: 1300,
+      localPath: 'Kontext\\SFW\\manuscript_illustration_kontext.safetensors',
+    },
+  )
+
+  assert.deepEqual(refresh.loraNames, [
+    'Kontext/SFW/manuscript_illustration_kontext.safetensors',
+  ])
+  assert.equal(
+    (refresh.payload.workflow as any)['61'].inputs.lora_name,
+    'Kontext/SFW/manuscript_illustration_kontext.safetensors',
+  )
+  assert.ok(!JSON.stringify(refresh.payload).includes('FLUX/'))
+  assert.ok(!JSON.stringify(refresh.payload).includes('\\\\'))
 }
 
 console.log('✅ verifyArtJobLoraOverride: all assertions passed')


### PR DESCRIPTION
## Root cause

Both art-job retry routes reused the failed job's serialized payload. They normalized image paths and prompts, but never re-resolved `payload.resources.loraResourceIds` against the current `Resource.localPath`. That made stale LoRA values survive every retry, including wrong folder casing, backslashes, renamed files, and obsolete shorthand names.

## Fix

- Resolve the stored LoRA Resource ID from the database every time an art job is re-enqueued.
- Treat the current `Resource.localPath` as canonical.
- Preserve database casing while normalizing `\\` to `/`.
- Rewrite the selected/style LoRA workflow node(s), top-level `loraName`, and `resources.loraNames` together.
- Leave required/base LoRA nodes unchanged.
- Apply the refresh to both individual retries and the selected failed-job bulk requeue.
- Refuse to requeue when the referenced Resource is missing, inactive, the wrong type, lacks a local path, or contains an unsupported multi-LoRA selection instead of submitting another doomed ComfyUI job.
- Return per-job failure messages and LoRA repair counts from the bulk endpoint.

## Regression coverage

`test:artjob-lora-override` now includes the two reported payloads:

- Job 2615 / Resource 4082 → `Flux/SFW/ume_classic_impressionist.safetensors`
- Job 2621 / Resource 1300 → `Kontext/SFW/manuscript_illustration_kontext.safetensors`

The second case also verifies slash normalization without lowercasing the path.

## Deployment note

After this is deployed, using the existing re-enqueue action for jobs 2615 and 2621 will refresh their payloads from Resources 4082 and 1300 before they return to the queue. This PR intentionally does not hardcode production job IDs or mutate production queue data during deployment.