### PR TITLE
Refresh LoRA resources on Resume unchanged ArtJob retries

### DIFF
--- a/server/api/art/queue/[id]/edit.post.ts
+++ b/server/api/art/queue/[id]/edit.post.ts
@@ -10,13 +10,13 @@ import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
 import {
   decodeArtJobPayload,
-  parseArtJobPayload,
   serializeArtJobPayload,
 } from '../../../../utils/artJobPayload'
 import {
   applyArtJobOverrides,
   type ArtJobOverrides,
 } from '../../../../utils/artJobRetry'
+import { refreshArtJobLoraResources } from '../../../../utils/artJobResourceRefresh'
 import { applyArtJobVisibility } from '../../../../utils/artJobVisibility'
 import {
   applyArtFacetsToPayload,
@@ -75,7 +75,8 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const payload = structuredClone(parseArtJobPayload(source.payload))
+    const resourceRefresh = await refreshArtJobLoraResources(source.payload)
+    const payload = resourceRefresh.payload
     const currentRequest = extractRenderRequest(payload)
     const currentBasePrompt = cleanArtPrompt(payload.basePromptString)
     const requestedBasePrompt = cleanArtPrompt(
@@ -141,6 +142,9 @@ export default defineEventHandler(async (event) => {
       editedAt: new Date().toISOString(),
       editedByUserId: auth.user.id,
       preset: presetEngine ?? 'keep',
+      loraPathChanged: resourceRefresh.changed,
+      loraResourceIds: resourceRefresh.loraResourceIds,
+      loraNames: resourceRefresh.loraNames,
     }
 
     const updated = await prisma.artJob.update({
@@ -158,7 +162,9 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      message: `Updated job ${id} and returned it to PENDING.`,
+      message: resourceRefresh.changed
+        ? `Updated job ${id}, refreshed its LoRA Resource path, and returned it to PENDING.`
+        : `Updated job ${id} and returned it to PENDING.`,
       data: { job: decodeArtJobPayload(updated) },
       statusCode: 200,
     }

--- a/server/api/art/queue/[id]/requeue.post.ts
+++ b/server/api/art/queue/[id]/requeue.post.ts
@@ -10,11 +10,8 @@ import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { requireMachineUser } from '../../../../utils/authGuard'
-import {
-  parseArtJobPayload,
-  serializeArtJobPayload,
-} from '../../../../utils/artJobPayload'
-import { applyArtJobOverrides } from '../../../../utils/artJobRetry'
+import { serializeArtJobPayload } from '../../../../utils/artJobPayload'
+import { refreshArtJobLoraResources } from '../../../../utils/artJobResourceRefresh'
 
 type RequeueBody = {
   resetAttempts?: boolean
@@ -53,10 +50,15 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const payload = applyArtJobOverrides(
-      structuredClone(parseArtJobPayload(job.payload)),
-      null,
-    )
+    const resourceRefresh = await refreshArtJobLoraResources(job.payload)
+    const payload = resourceRefresh.payload
+    payload.queueRepair = {
+      repairedAt: new Date().toISOString(),
+      loraPathChanged: resourceRefresh.changed,
+      loraResourceIds: resourceRefresh.loraResourceIds,
+      loraNames: resourceRefresh.loraNames,
+    }
+
     const updated = await prisma.artJob.update({
       where: { id },
       data: {
@@ -71,8 +73,15 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      message: `Job ${id} requeued (attempts ${updated.attempts}).`,
-      data: { job: updated },
+      message: resourceRefresh.changed
+        ? `Job ${id} repaired from its current LoRA Resource and requeued (attempts ${updated.attempts}).`
+        : `Job ${id} requeued (attempts ${updated.attempts}).`,
+      data: {
+        job: updated,
+        loraPathChanged: resourceRefresh.changed,
+        loraResourceIds: resourceRefresh.loraResourceIds,
+        loraNames: resourceRefresh.loraNames,
+      },
       statusCode: 200,
     }
   } catch (error: unknown) {

--- a/utils/scripts/verifyArtJobLoraOverride.ts
+++ b/utils/scripts/verifyArtJobLoraOverride.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { applyArtJobOverrides } from '../../server/utils/artJobRetry'
 import { applyResolvedLoraResourceToArtJobPayload } from '../../server/utils/artJobResourceRefresh'
 
@@ -196,6 +197,27 @@ import { applyResolvedLoraResourceToArtJobPayload } from '../../server/utils/art
   )
   assert.ok(!JSON.stringify(refresh.payload).includes('FLUX/'))
   assert.ok(!JSON.stringify(refresh.payload).includes('\\\\'))
+}
+
+// 8. Every route that returns an existing ArtJob to PENDING must refresh the
+//    current Resource path first. This guards the dashboard's "Resume unchanged"
+//    route, which was separate from the two re-enqueue routes.
+{
+  const routes = [
+    '../../server/api/art/queue/[id]/requeue.post.ts',
+    '../../server/api/art/queue/[id]/edit.post.ts',
+    '../../server/api/art/queue/[id]/reenqueue.post.ts',
+    '../../server/api/art/queue/reenqueue-failed.post.ts',
+  ]
+
+  for (const route of routes) {
+    const source = readFileSync(new URL(route, import.meta.url), 'utf8')
+    assert.match(
+      source,
+      /await refreshArtJobLoraResources\(/,
+      `${route} must refresh LoRA Resources before queueing`,
+    )
+  }
 }
 
 console.log('✅ verifyArtJobLoraOverride: all assertions passed')


### PR DESCRIPTION
## Root cause

The previous fix covered `/api/art/queue/:id/reenqueue` and the bulk failed-job route, but the ArtJob dashboard's **Resume unchanged** button calls a separate endpoint: `/api/art/queue/:id/requeue`.

That endpoint only parsed the existing payload and reset the job to `PENDING`. It never called `refreshArtJobLoraResources`, so job 2615 kept the stale `FLUX\\impressionist.safetensors` workflow value and failed again under the same job ID.

## Fix

- Refresh the current LoRA Resource path before the `requeue` endpoint returns an existing job to `PENDING`.
- Record the repaired Resource IDs and names in `queueRepair` and return them in the response.
- Apply the same refresh before `Edit & queue`, so editing an existing failed or cancelled job cannot preserve a renamed LoRA path either.
- Keep individual re-enqueue and bulk recovery on the same shared refresh helper.

## Regression guard

The focused ArtJob LoRA contract now reads all four queue-return route files and requires each to call `await refreshArtJobLoraResources(...)`:

- `requeue.post.ts` — Resume unchanged
- `edit.post.ts` — Edit & queue
- `reenqueue.post.ts` — create retry output
- `reenqueue-failed.post.ts` — bulk failed recovery

This closes the exact route gap that allowed job 2615 to fail again after PR #1163.