### PR TITLE
model-builder: guard autoBuildItem against silently approving failed drafts

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -157,6 +157,12 @@ jobs:
       - name: Model Builder draft approval guard contract
         run: npm run test:model-builder-draft-approval-guard
 
+      - name: Model Builder auto-build draft gate checker self-test
+        run: npm run test:model-builder-auto-build-draft-gate-selftest
+
+      - name: Model Builder auto-build draft gate contract
+        run: npm run test:model-builder-auto-build-draft-gate
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,8 @@
     "test:model-builder-commit-cancelled-run-guard": "tsx utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts",
     "test:model-builder-draft-approval-guard-selftest": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.test.ts",
     "test:model-builder-draft-approval-guard": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.ts",
+    "test:model-builder-auto-build-draft-gate-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts",
+    "test:model-builder-auto-build-draft-gate": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1369,13 +1369,31 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     autoBuildingItemSingleton.claim(item.id)
     try {
       if (item.stages.PITCH.status !== 'approved') {
-        if (!item.pitch.trim()) await draftText(itemId, 'pitch')
+        if (!item.pitch.trim()) {
+          // draftText can fail (network error, "the model returned nothing
+          // useful", or its own isStageEditable/live-value guards) and still
+          // leave item.pitch empty. Unlike GENERATE_ASSETS below -- whose
+          // `generated` result already gates its approveStage call -- this
+          // branch used to approve PITCH unconditionally afterward, which
+          // could silently mark an empty pitch 'approved'. The single-item
+          // Approve button in model-builder-item-panel.vue treats that as
+          // impossible (`:disabled="isLocked('PITCH') || !pitch.trim()"`), so
+          // auto-build must not produce a state the manual UI itself refuses.
+          const drafted = await draftText(itemId, 'pitch')
+          if (!drafted) return false
+        }
         approveStage(itemId, 'PITCH')
       }
 
       if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
-        if (!isAsset) await draftText(itemId, 'fields')
-        if (wantArt) await draftText(itemId, 'artPrompt')
+        if (!isAsset) {
+          const drafted = await draftText(itemId, 'fields')
+          if (!drafted) return false
+        }
+        if (wantArt) {
+          const drafted = await draftText(itemId, 'artPrompt')
+          if (!drafted) return false
+        }
         approveStage(itemId, 'FIELDS_AND_PROMPTS')
       }
 

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
@@ -1,0 +1,148 @@
+// /utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
+//
+// Regression test for checkAutoBuildDraftGate() in
+// verifyModelBuilderAutoBuildDraftGate.ts (model-builder/t-029). Exercises
+// the real check against synthetic store-shaped fixtures covering: the
+// pre-fix shape (draftText's result discarded, approveStage called
+// unconditionally -- the exact bug found by manual read-through), the fixed
+// shape (result captured and gated), and autoBuildItem being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkAutoBuildDraftGate } from './verifyModelBuilderAutoBuildDraftGate.js'
+
+const BUGGY_FIXTURE = `
+  async function autoBuildItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    const isAsset = item.action === 'ASSET_ONLY'
+    const wantArt = state.includeArt && item.generation === 'image'
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      if (item.stages.PITCH.status !== 'approved') {
+        if (!item.pitch.trim()) await draftText(itemId, 'pitch')
+        approveStage(itemId, 'PITCH')
+      }
+
+      if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
+        if (!isAsset) await draftText(itemId, 'fields')
+        if (wantArt) await draftText(itemId, 'artPrompt')
+        approveStage(itemId, 'FIELDS_AND_PROMPTS')
+      }
+
+      if (item.stages.GENERATE_ASSETS.status !== 'approved') {
+        if (wantArt) {
+          const generated = await generateItemAsset(itemId)
+          if (!generated) return false
+        }
+        approveStage(itemId, 'GENERATE_ASSETS')
+      }
+
+      if (item.stages.COMMIT.status !== 'approved') {
+        return await commitItem(itemId)
+      }
+      return true
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const FIXED_FIXTURE = `
+  async function autoBuildItem(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+
+    const isAsset = item.action === 'ASSET_ONLY'
+    const wantArt = state.includeArt && item.generation === 'image'
+
+    autoBuildingItemSingleton.claim(item.id)
+    try {
+      if (item.stages.PITCH.status !== 'approved') {
+        if (!item.pitch.trim()) {
+          const drafted = await draftText(itemId, 'pitch')
+          if (!drafted) return false
+        }
+        approveStage(itemId, 'PITCH')
+      }
+
+      if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
+        if (!isAsset) {
+          const drafted = await draftText(itemId, 'fields')
+          if (!drafted) return false
+        }
+        if (wantArt) {
+          const drafted = await draftText(itemId, 'artPrompt')
+          if (!drafted) return false
+        }
+        approveStage(itemId, 'FIELDS_AND_PROMPTS')
+      }
+
+      if (item.stages.GENERATE_ASSETS.status !== 'approved') {
+        if (wantArt) {
+          const generated = await generateItemAsset(itemId)
+          if (!generated) return false
+        }
+        approveStage(itemId, 'GENERATE_ASSETS')
+      }
+
+      if (item.stages.COMMIT.status !== 'approved') {
+        return await commitItem(itemId)
+      }
+      return true
+    } finally {
+      autoBuildingItemSingleton.release(item.id)
+    }
+  }
+`
+
+const MISSING_FIXTURE = `
+  function approveStage(itemId: string, stageKey: BuildStageKey): void {
+    const item = findItem(itemId)
+    if (!item) return
+    item.stages[stageKey] = { status: 'approved' }
+  }
+`
+
+const buggyErrors = checkAutoBuildDraftGate(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  3,
+  'expected the pre-fix shape (all three discarded draftText results) to ' +
+    `raise 3 errors, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("'pitch'") && e.includes('discarded')),
+  'expected a violation for the discarded pitch draft result',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("'fields'") && e.includes('discarded')),
+  'expected a violation for the discarded fields draft result',
+)
+assert.ok(
+  buggyErrors.some((e) => e.includes("'artPrompt'") && e.includes('discarded')),
+  'expected a violation for the discarded artPrompt draft result',
+)
+
+const fixedErrors = checkAutoBuildDraftGate(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const missingFnErrors = checkAutoBuildDraftGate(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when autoBuildItem is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('autoBuildItem'))
+
+console.log(
+  'Model Builder auto-build draft gate checker verified: flags the pre-fix ' +
+    'shape (discarded draftText results feeding straight into an ' +
+    'unconditional approveStage), clears the fixed shape, and flags ' +
+    'autoBuildItem being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
@@ -1,0 +1,146 @@
+// /utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
+//
+// Regression guard (model-builder/t-029) -- autoBuildItem() drives an item
+// through every stage "with sensible defaults": draft whatever's empty, then
+// approve. draftText() can fail (a thrown /api/suggest error, "the model
+// returned nothing useful", or its own isStageEditable/live-value guards) and
+// still leave the field's content unchanged (e.g. an empty pitch). Before
+// this fix, autoBuildItem awaited draftText() but discarded its boolean
+// result, then called approveStage() unconditionally right after -- silently
+// marking PITCH/FIELDS_AND_PROMPTS 'approved' even when the draft that was
+// supposed to fill them never landed. The single-item Approve button in
+// model-builder-item-panel.vue treats an approved-but-empty PITCH as
+// impossible (`:disabled="isLocked('PITCH') || !pitch.trim()"`), so
+// auto-build silently producing exactly that state is a real review-gate
+// bypass, the same class of bug this store has repeatedly needed to close
+// (canApproveAssets, batchDraftField/batchSetField, draftText's own
+// approval-while-drafting guard) -- just reached via a discarded return value
+// instead of a concurrency race. The GENERATE_ASSETS stage two lines below
+// already gets this right (`const generated = await generateItemAsset(itemId
+// ); if (!generated) return false`), which is exactly the shape this checker
+// requires for the PITCH and FIELDS_AND_PROMPTS drafts too.
+//
+// This asserts the textual shape of the fix stays in place: every
+// `await draftText(itemId, 'FIELD')` call inside autoBuildItem() is assigned
+// to a local (not a bare/discarded statement), and an `if (!VAR) return
+// false` guard on that same local appears strictly between the draftText
+// call and the next call to approveStage() for that field's stage --
+// deliberately scoped to this one function/bug, mirroring
+// verifyModelBuilderCompletionGate.ts's preference for explicit, narrow
+// textual checks over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFunctionBodies } from './verifyModelBuilderCompletionGate.js'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+
+const FN_NAME = 'autoBuildItem'
+
+const DRAFT_GATES = [
+  { field: 'pitch', stageKey: 'PITCH' },
+  { field: 'fields', stageKey: 'FIELDS_AND_PROMPTS' },
+  { field: 'artPrompt', stageKey: 'FIELDS_AND_PROMPTS' },
+] as const
+
+// Checks the fix's exact shape against the full source text of a file
+// containing an `autoBuildItem`-named async function. Exported (rather than
+// only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real store file.
+export function checkAutoBuildDraftGate(content: string): string[] {
+  const errors: string[] = []
+
+  const functions = extractFunctionBodies(content)
+  const fn = functions.find((f) => f.name === FN_NAME)
+  if (!fn) {
+    errors.push(
+      `Could not find an async function named ${FN_NAME}() -- has it been ` +
+        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+        'protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  for (const { field, stageKey } of DRAFT_GATES) {
+    const callPattern = new RegExp(
+      `(?:const\\s+(\\w+)\\s*=\\s*)?await draftText\\(itemId, '${field}'\\)`,
+    )
+    const callMatch = callPattern.exec(fn.body)
+    if (!callMatch) {
+      errors.push(
+        `${FN_NAME}() no longer calls await draftText(itemId, '${field}') -- ` +
+          "this guard's anchor point has moved; re-check how this stage is " +
+          'auto-drafted.',
+      )
+      continue
+    }
+
+    const varName = callMatch[1]
+    if (!varName) {
+      errors.push(
+        `${FN_NAME}() calls await draftText(itemId, '${field}') without ` +
+          'capturing its return value. draftText() can fail and leave the ' +
+          "field's content unchanged (e.g. an empty pitch); a discarded " +
+          `result means the '${stageKey}' stage below can still be ` +
+          'approved even though the draft never actually landed.',
+      )
+      continue
+    }
+
+    const callEnd = callMatch.index + callMatch[0].length
+    const approvePattern = new RegExp(`approveStage\\(itemId, '${stageKey}'\\)`)
+    const approveMatch = approvePattern.exec(fn.body.slice(callEnd))
+    if (!approveMatch) {
+      errors.push(
+        `${FN_NAME}() no longer calls approveStage(itemId, '${stageKey}') ` +
+          `after drafting '${field}' -- this guard's anchor point has moved.`,
+      )
+      continue
+    }
+    const between = fn.body.slice(callEnd, callEnd + approveMatch.index)
+
+    const guardPattern = new RegExp(`if \\(!${varName}\\)\\s*return false`)
+    if (!guardPattern.test(between)) {
+      errors.push(
+        `${FN_NAME}() does not check \`if (!${varName}) return false\` ` +
+          `between drafting '${field}' and approveStage(itemId, ` +
+          `'${stageKey}'). Without this guard, a failed '${field}' draft ` +
+          '(network error, "the model returned nothing useful", or an ' +
+          "approval/edit race caught by draftText's own guards) still lets " +
+          `'${stageKey}' be approved with the field's unchanged (possibly ` +
+          'empty) content -- a state the manual Approve button in ' +
+          'model-builder-item-panel.vue refuses to allow.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(STORE_PATH, 'utf8')
+  const errors = checkAutoBuildDraftGate(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder auto-build draft gate contract failed for ' +
+        `${FN_NAME}() in modelBuilderStore.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder auto-build draft gate contract passed: ${FN_NAME}() only ` +
+      'approves a stage after confirming its draft actually succeeded.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-029 (conductor recurring continuous-improvement task): find and fix one genuine bug in the Model Builder feature.

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `autoBuildItem()` previously discarded `draftText()`'s success/failure result and called `approveStage(itemId, 'PITCH')` / `approveStage(itemId, 'FIELDS_AND_PROMPTS')` unconditionally afterward. `draftText()` can fail (network error, "the model returned nothing useful", or its own approval/edit-race guards) and leave the field empty — so auto-build could silently mark a stage `'approved'` with empty content, a state the manual Approve button itself refuses (`:disabled="isLocked('PITCH') || !pitch.trim()"`). The `GENERATE_ASSETS` branch a few lines below already guarded this correctly (`const generated = await generateItemAsset(itemId); if (!generated) return false`); PITCH/FIELDS_AND_PROMPTS now follow the same shape.
- Added `utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts` + its self-test, following this project's established narrow-textual-regression-checker convention (see `verifyModelBuilderDraftApprovalGuard.ts` from PR #1161).
- Wired both into `package.json` scripts and `.github/workflows/contract-tests.yml`, matching the existing convention exactly.

### How I verified
- New checker's self-test passes; checker correctly flags 3 violations against the pre-fix store (verified via `git stash`) and passes clean post-fix.
- `npx vue-tsc --noEmit` — exit 0.
- `npx eslint` clean on all changed/new files (2 pre-existing `no-empty` errors in the store confirmed via `git stash` to predate this change, not introduced by it).
- `npx prettier --check` clean on all touched files.
- Independently re-read the diff against `draftText()`'s actual `Promise<boolean>` return type before trusting the fix.

### Stakes
reversible

### Flags for Reviewer
- Also investigated the specific kaizen lead flagged in the prior TALKBACK entry ("batchApproveStage isStageEditable guard, not yet ticketed") — confirmed it's already safe: `batchApproveStage` only flips stage status via `approveStage`, never writes drafted content, so the only real overwrite hazard is already covered by `draftText()`'s own guard (PR #1161) regardless of what triggered the approval. No fix needed there; documenting so a future cycle doesn't re-open it.

### Kaizen suggestion
`autoBuildRun()`/`batchAutoBuild()` (the callers of `autoBuildItem`) could surface a distinct per-item error/status when an auto-build stops early due to a failed draft, rather than the item just silently not progressing — worth a UX pass in a future cycle.

### Notes for reviewer
Conductor-side: this closes out `model-builder/t-029`'s recurring cycle; conductor roadmap/TALKBACK update will follow in a companion conductor PR after this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCxPs6kDYPE4M3r3GBhzxS)_