### PR TITLE
lora-catalog: recognize .gguf so quantized models get cataloged

### DIFF
--- a/scripts/lora-catalog/scan_loras.py
+++ b/scripts/lora-catalog/scan_loras.py
@@ -74,7 +74,11 @@ from typing import Any, Optional
 # Config / constants
 # ----------------------------------------------------------------------------
 
-LORA_EXTENSIONS = {".safetensors", ".pt", ".ckpt", ".pth", ".bin"}
+# .gguf (quantized unets/checkpoints, loaded via UnetLoaderGGUF in ComfyUI) has
+# no safetensors header — build_entry()/scan_models.build_entry() already gate
+# header reads on `.suffix == ".safetensors"`, so it's handled the same way
+# .bin/.ckpt/.pth already are: hashed and classified, metadata just skipped.
+LORA_EXTENSIONS = {".safetensors", ".pt", ".ckpt", ".pth", ".bin", ".gguf"}
 CIVITAI_BY_HASH = "https://civitai.com/api/v1/model-versions/by-hash/{hash}"
 CIVARCHIVE_BY_HASH = "https://civitaiarchive.com/api/sha256/{hash}"
 HASH_CHUNK = 1 << 20  # 1 MiB


### PR DESCRIPTION
## Why

Silas: "gguf checkpoint(s) never made it to the Resource db."

## Root cause

`LORA_EXTENSIONS` in `scripts/lora-catalog/scan_loras.py` — shared by both `scan_loras.py` and `scan_models.py` via `enumerate_files()` — didn't include `.gguf`:

```python
LORA_EXTENSIONS = {".safetensors", ".pt", ".ckpt", ".pth", ".bin"}
```

So every `.gguf` file was filtered out at the very first directory-walk step, before hashing, classification, or the `/api/resources/batch` POST ever ran — regardless of resourceType or folder placement. GGUF is already a first-class, actively-used loader convention on the *generation* side (Flux/Kontext/Flux2 Klein/Krea2 workflow builders all default to `UnetLoaderGGUF`), but that awareness was never wired into the Python cataloger.

## Fix

Added `.gguf` to the shared extension set. Both scanners' `build_entry()` already gate safetensors-header reads on `suffix == '.safetensors'`, so a `.gguf` file is handled exactly like the existing `.bin`/`.ckpt`/`.pth` cases: hashed, classified by folder (`scan_models.py`'s `FOLDER_RULES` already maps `unet`/`diffusion_models` folders to `DIFFUSION_MODEL`), just without embedded metadata. No other code needed changing — this was a single-point filter gap, not a design gap.

## Follow-up for Silas

This only fixes **new** scans going forward. Any GGUF files already sitting on disk need `scan_models.py` → `import_catalog.py` re-run to actually create their `Resource` rows. `repairCheckpointResources.ts` already lists `.gguf` in its own extension set, but it only reconciles rows that already exist — it has no `prisma.resource.create()` call, so it can't backfill a missing row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_