### PR TITLE
Improve startup animation gating and controls

### DIFF
--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 // /components/content/story/kind-loader.vue
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeMount, onMounted, ref } from 'vue'
 import { useErrorStore, ErrorType } from '@/stores/errorStore'
 import { useUserStore } from '@/stores/userStore'
 import { useArtStore } from '@/stores/artStore'
@@ -37,6 +37,7 @@ import { useServerStore } from '@/stores/serverStore'
 import { useCheckpointStore } from '@/stores/checkpointStore'
 import { useThemeStore } from '@/stores/themeStore'
 import { useButterflyStore } from '@/stores/butterflyStore'
+import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
 
 const errorStore = useErrorStore()
@@ -63,17 +64,66 @@ const randomStore = useRandomStore()
 const navStore = useNavStore()
 const themeStore = useThemeStore()
 const butterflyStore = useButterflyStore()
+const startupStore = useStartupAnimationStore()
 
 const emit = defineEmits<{
   covered: []
   pageReady: [boolean]
 }>()
 
-const showOverlay = ref(true)
+const STARTUP_STORAGE_KEY = 'kind-robots-last-startup-animation-v1'
+const STARTUP_STALE_MS = 12 * 60 * 60 * 1000
+
+function isReloadNavigation(): boolean {
+  if (!import.meta.client) return false
+
+  const navigation = performance.getEntriesByType(
+    'navigation',
+  )[0] as PerformanceNavigationTiming | undefined
+
+  return navigation?.type === 'reload'
+}
+
+function shouldShowStartupSequence(): boolean {
+  if (!import.meta.client) return true
+
+  try {
+    const stored = localStorage.getItem(STARTUP_STORAGE_KEY)
+    if (!stored) return !isReloadNavigation()
+
+    const lastShownAt = Number(stored)
+    if (!Number.isFinite(lastShownAt)) return true
+
+    return Date.now() - lastShownAt >= STARTUP_STALE_MS
+  } catch {
+    return !isReloadNavigation()
+  }
+}
+
+function markStartupSequenceSeen(): void {
+  if (!import.meta.client) return
+
+  try {
+    localStorage.setItem(STARTUP_STORAGE_KEY, String(Date.now()))
+  } catch {
+    return
+  }
+}
+
+const showStartupSequence = ref(shouldShowStartupSequence())
+const showOverlay = ref(showStartupSequence.value)
 const storesReady = ref(false)
 const pageReadyEmitted = ref(false)
-
 const coveredEmitted = ref(false)
+
+let initializationPromise: Promise<void> | null = null
+
+startupStore.reset()
+butterflyStore.setShowSwarm(showStartupSequence.value)
+
+if (showStartupSequence.value) {
+  markStartupSequenceSeen()
+}
 
 function handleOverlayCovered() {
   if (coveredEmitted.value) return
@@ -97,8 +147,6 @@ function handleOverlayHidden() {
   emitReadyOnce()
 }
 
-// Run a batch of store inits in parallel. allSettled (not all) so one
-// rejecting store never aborts its siblings or the rest of the boot.
 async function runWave(
   label: string,
   tasks: Array<Promise<unknown> | void | undefined>,
@@ -125,8 +173,6 @@ async function runWave(
 }
 
 async function initializeServerAndCheckpoints() {
-  // Servers must fully load before checkpoints can resolve their active server.
-  // This is the single place both are initialized — galleries must not re-fetch.
   await errorStore.handleError(
     async () => {
       if (
@@ -141,7 +187,6 @@ async function initializeServerAndCheckpoints() {
     'Error initializing server store',
   )
 
-  // Checkpoints depend on servers being present so they can resolve activeArtServer.
   await errorStore.handleError(
     async () => {
       checkpointStore.initialize()
@@ -153,8 +198,6 @@ async function initializeServerAndCheckpoints() {
 
 async function initializeStores() {
   try {
-    // Synchronous, order-independent: only touches the module-level builder
-    // registry. Done first so any builder UI in the first paint has configs.
     ensureBuildersRegistered()
 
     if (!displayStore.isInitialized) {
@@ -165,8 +208,6 @@ async function initializeStores() {
       )
     }
 
-    // First wave: user identity (session-restore from stored token) and UI
-    // chrome. Everything downstream depends on these.
     await runWave('identity + chrome', [
       userStore.initialize?.(),
       pageStore.initialize?.(),
@@ -180,17 +221,14 @@ async function initializeStores() {
       themeStore.initialize({ fetchShared: true }),
     ])
 
-    // Servers + checkpoints are sequential: checkpoints need a loaded server array.
     await initializeServerAndCheckpoints()
 
-    // Second wave: content stores that may reference servers but don't block server init.
     await runWave('content stores', [
       artStore.initialize?.(),
       botStore.initialize?.(),
       chatStore.initialize?.(),
     ])
 
-    // Third wave: everything else.
     await runWave('remaining stores', [
       characterStore.initialize?.(),
       promptStore.initialize?.(),
@@ -214,12 +252,25 @@ async function initializeStores() {
   }
 }
 
-onMounted(async () => {
-  await initializeStores()
+function ensureStoresInitialized(): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = initializeStores()
+  }
+
+  return initializationPromise
+}
+
+onBeforeMount(() => {
+  if (showStartupSequence.value) return
+
+  void ensureStoresInitialized()
+  handleOverlayCovered()
+  emitReadyOnce()
 })
 
-onBeforeUnmount(() => {
-  displayStore.removeViewportWatcher()
+onMounted(async () => {
+  if (!showStartupSequence.value) return
+  await ensureStoresInitialized()
 })
 </script>
 

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -5,7 +5,10 @@
     :class="{ 'loading-overlay--fade': fadeOverlay }"
     @transitionend="handleTransitionEnd"
   >
-    <div class="loading-content">
+    <div
+      class="loading-content"
+      :class="{ 'loading-content--hidden': startupStore.immersive }"
+    >
       <div class="loading-heading">Building Kind Robots...</div>
 
       <div class="loading-logo-frame">
@@ -48,6 +51,7 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useLoadStore } from '../../stores/loadStore'
+import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 
 const props = defineProps<{ storesReady: boolean }>()
 const emit = defineEmits<{
@@ -57,6 +61,7 @@ const emit = defineEmits<{
 }>()
 
 const loadStore = useLoadStore()
+const startupStore = useStartupAnimationStore()
 
 const currentMessage = ref('Wiring robots for suspicious levels of charm...')
 const messageKey = ref(0)
@@ -64,6 +69,7 @@ const fadeOverlay = ref(false)
 const minimumSequenceComplete = ref(false)
 const logoLoaded = ref(false)
 const hiddenEmitted = ref(false)
+const exitRequested = ref(false)
 
 const EXTRA_MESSAGE_COUNT = 2
 const EXTRA_MESSAGE_MS = 1250
@@ -104,6 +110,12 @@ function clearRotation() {
   rotationIntervalId = null
 }
 
+function clearReadyHold() {
+  if (!readyHoldTimeoutId) return
+  clearTimeout(readyHoldTimeoutId)
+  readyHoldTimeoutId = null
+}
+
 function emitHiddenOnce() {
   if (hiddenEmitted.value) return
   hiddenEmitted.value = true
@@ -114,6 +126,7 @@ function doFade() {
   if (destroyed || fadeOverlay.value) return
 
   clearRotation()
+  clearReadyHold()
   loadStore.revealDesktop()
   emit('hiding')
   fadeOverlay.value = true
@@ -131,12 +144,15 @@ function scheduleFade() {
   if (!props.storesReady) return
   if (!minimumSequenceComplete.value) return
   if (fadeOverlay.value) return
+  if (startupStore.immersive) return
   if (readyHoldTimeoutId) return
 
   clearRotation()
 
   const elapsed = Date.now() - startTime
-  const holdNeeded = Math.max(READY_HOLD_MS, MIN_TOTAL_MS - elapsed)
+  const holdNeeded = exitRequested.value
+    ? 0
+    : Math.max(READY_HOLD_MS, MIN_TOTAL_MS - elapsed)
 
   readyHoldTimeoutId = setTimeout(() => {
     doFade()
@@ -173,7 +189,37 @@ async function runVisualSequence() {
 watch(
   () => props.storesReady,
   (ready) => {
-    if (ready) scheduleFade()
+    if (!ready) return
+
+    if (exitRequested.value) {
+      doFade()
+      return
+    }
+
+    scheduleFade()
+  },
+)
+
+watch(
+  () => startupStore.immersive,
+  (immersive) => {
+    if (immersive) {
+      clearReadyHold()
+      return
+    }
+
+    scheduleFade()
+  },
+)
+
+watch(
+  () => startupStore.exitRequest,
+  () => {
+    exitRequested.value = true
+
+    if (props.storesReady) {
+      doFade()
+    }
   },
 )
 
@@ -185,15 +231,11 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   destroyed = true
   clearRotation()
+  clearReadyHold()
 
   if (fallbackFadeTimeoutId) {
     clearTimeout(fallbackFadeTimeoutId)
     fallbackFadeTimeoutId = null
-  }
-
-  if (readyHoldTimeoutId) {
-    clearTimeout(readyHoldTimeoutId)
-    readyHoldTimeoutId = null
   }
 })
 </script>
@@ -225,6 +267,17 @@ onBeforeUnmount(() => {
   height: min(92vh, 52rem);
   grid-template-rows: minmax(3.75rem, auto) minmax(0, 1fr) 8rem;
   place-items: center;
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    opacity 320ms ease,
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.loading-content--hidden {
+  opacity: 0;
+  transform: scale(0.97);
+  pointer-events: none;
 }
 
 .loading-heading,
@@ -251,14 +304,51 @@ onBeforeUnmount(() => {
 }
 
 .loading-logo-frame {
+  position: relative;
   display: grid;
   width: 100%;
   height: 100%;
   min-height: 0;
   place-items: center;
+  isolation: isolate;
+}
+
+.loading-logo-frame::before,
+.loading-logo-frame::after {
+  position: absolute;
+  z-index: 0;
+  width: clamp(17rem, 60vw, 36rem);
+  aspect-ratio: 1;
+  content: '';
+  pointer-events: none;
+}
+
+.loading-logo-frame::before {
+  border-radius: 46% 54% 61% 39% / 57% 41% 59% 43%;
+  background:
+    radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.2), transparent 42%),
+    radial-gradient(circle at 64% 68%, rgba(129, 230, 217, 0.16), transparent 46%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.08), transparent 68%);
+  filter: blur(1.8rem);
+  opacity: 0.88;
+  animation: loading-logo-haze 8s ease-in-out infinite alternate;
+}
+
+.loading-logo-frame::after {
+  width: clamp(15rem, 54vw, 32rem);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 58% 42% 47% 53% / 43% 62% 38% 57%;
+  box-shadow:
+    0 0 2.5rem rgba(255, 255, 255, 0.12),
+    inset 0 0 2.25rem rgba(255, 255, 255, 0.08);
+  filter: blur(0.65rem);
+  opacity: 0.72;
+  animation: loading-logo-wobble 10s ease-in-out infinite alternate;
 }
 
 .loading-logo {
+  position: relative;
+  z-index: 1;
   width: clamp(16rem, 58vw, 34rem);
   max-height: 100%;
   height: auto;
@@ -269,6 +359,18 @@ onBeforeUnmount(() => {
     opacity 900ms ease,
     transform 1100ms cubic-bezier(0.22, 1, 0.36, 1);
   filter: drop-shadow(0 1.5rem 3rem rgba(255, 255, 255, 0.2));
+  -webkit-mask-image: radial-gradient(
+    ellipse 54% 54% at center,
+    #000 58%,
+    rgba(0, 0, 0, 0.96) 70%,
+    transparent 100%
+  );
+  mask-image: radial-gradient(
+    ellipse 54% 54% at center,
+    #000 58%,
+    rgba(0, 0, 0, 0.96) 70%,
+    transparent 100%
+  );
   will-change: opacity, transform;
 }
 
@@ -323,5 +425,39 @@ onBeforeUnmount(() => {
 .loader-message-leave-to {
   opacity: 0;
   transform: translateY(5px);
+}
+
+@keyframes loading-logo-haze {
+  0% {
+    border-radius: 46% 54% 61% 39% / 57% 41% 59% 43%;
+    transform: rotate(-2deg) scale(0.96);
+  }
+
+  100% {
+    border-radius: 57% 43% 39% 61% / 44% 58% 42% 56%;
+    transform: rotate(3deg) scale(1.05);
+  }
+}
+
+@keyframes loading-logo-wobble {
+  0% {
+    border-radius: 58% 42% 47% 53% / 43% 62% 38% 57%;
+    transform: rotate(2deg) scale(1.02);
+  }
+
+  100% {
+    border-radius: 42% 58% 55% 45% / 61% 39% 57% 43%;
+    transform: rotate(-3deg) scale(0.95);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-content,
+  .loading-logo,
+  .loading-logo-frame::before,
+  .loading-logo-frame::after {
+    animation: none;
+    transition: none;
+  }
 }
 </style>

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -4,7 +4,10 @@
     <div
       v-if="renderEffect && currentComponent"
       class="startup-animation"
-      :class="{ 'startup-animation--fading': isFading }"
+      :class="{
+        'startup-animation--fading': isFading,
+        'startup-animation--immersive': startupStore.immersive,
+      }"
     >
       <component
         :is="currentComponent"
@@ -13,8 +16,70 @@
         aria-hidden="true"
       />
 
-      <div v-if="currentEffectLabel" class="startup-animation__label">
-        Animation: {{ currentEffectLabel }}
+      <div class="startup-animation__controls">
+        <div class="startup-animation__identity">
+          <span class="startup-animation__eyebrow">Animation</span>
+          <span class="startup-animation__name">{{ currentEffectLabel }}</span>
+        </div>
+
+        <div class="startup-animation__button-group">
+          <button
+            type="button"
+            class="btn btn-sm btn-ghost btn-square text-white"
+            title="Previous animation"
+            aria-label="Previous animation"
+            @click="selectPreviousEffect"
+          >
+            <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+          </button>
+
+          <button
+            type="button"
+            class="btn btn-sm btn-ghost gap-1 text-white"
+            title="Choose another random animation"
+            @click="selectRandomEffect"
+          >
+            <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+            <span class="hidden sm:inline">Random</span>
+          </button>
+
+          <button
+            type="button"
+            class="btn btn-sm btn-ghost btn-square text-white"
+            title="Next animation"
+            aria-label="Next animation"
+            @click="selectNextEffect"
+          >
+            <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+          </button>
+        </div>
+
+        <div class="startup-animation__divider" />
+
+        <button
+          type="button"
+          class="btn btn-sm border-white/20 bg-white/10 text-white hover:bg-white/20"
+          :class="{ 'border-primary/70 bg-primary/25': startupStore.immersive }"
+          :aria-pressed="startupStore.immersive"
+          :title="
+            startupStore.immersive
+              ? 'Restore the logo and loading messages'
+              : 'Hide the logo and loading messages'
+          "
+          @click="startupStore.toggleImmersive()"
+        >
+          {{ startupStore.immersive ? 'Show launch UI' : 'Animation only' }}
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-sm btn-square border-white/20 bg-black/30 text-white hover:bg-error/70"
+          title="Leave startup animation"
+          aria-label="Leave startup animation"
+          @click="startupStore.requestExit()"
+        >
+          <Icon name="kind-icon:x" class="h-4 w-4" />
+        </button>
       </div>
     </div>
   </Teleport>
@@ -27,12 +92,14 @@ import type { AnimationEffectId } from '@/stores/animationCatalog'
 import { useAnimationStore } from '@/stores/animationStore'
 import { useAnimationPreferenceStore } from '@/stores/animationPreferenceStore'
 import { useButterflyStore } from '@/stores/butterflyStore'
+import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 
 defineOptions({ inheritAttrs: false })
 
 const animationStore = useAnimationStore()
 const preferenceStore = useAnimationPreferenceStore()
 const butterflyStore = useButterflyStore()
+const startupStore = useStartupAnimationStore()
 
 const resolvedEffectId = ref<AnimationEffectId | null>(null)
 const renderEffect = ref(false)
@@ -41,6 +108,15 @@ const isFading = ref(false)
 const FADE_MS = 650
 
 let fadeTimer: ReturnType<typeof setTimeout> | null = null
+
+const availableEffectIds = computed(() => {
+  return animationStore.safeEffects
+    .filter(
+      (effect) =>
+        !effect.blocksInput && Boolean(getAnimationEffectComponent(effect.id)),
+    )
+    .map((effect) => effect.id)
+})
 
 const currentComponent = computed(() => {
   if (!resolvedEffectId.value) return null
@@ -63,19 +139,47 @@ function clearFadeTimer(): void {
   fadeTimer = null
 }
 
+function setEffect(effectId: AnimationEffectId | null): void {
+  resolvedEffectId.value = effectId
+  renderEffect.value = Boolean(effectId)
+  isFading.value = false
+}
+
 function selectEffect(): void {
   preferenceStore.initialize()
+  setEffect(preferenceStore.resolveStartupEffect(availableEffectIds.value))
+}
 
-  const availableIds = animationStore.safeEffects
-    .filter(
-      (effect) =>
-        !effect.blocksInput && Boolean(getAnimationEffectComponent(effect.id)),
-    )
-    .map((effect) => effect.id)
+function selectRelativeEffect(direction: -1 | 1): void {
+  const ids = availableEffectIds.value
+  if (!ids.length) return
 
-  resolvedEffectId.value = preferenceStore.resolveStartupEffect(availableIds)
-  renderEffect.value = Boolean(resolvedEffectId.value)
-  isFading.value = false
+  const currentIndex = resolvedEffectId.value
+    ? ids.indexOf(resolvedEffectId.value)
+    : -1
+  const safeIndex = currentIndex < 0 ? 0 : currentIndex
+  const nextIndex = (safeIndex + direction + ids.length) % ids.length
+
+  setEffect(ids[nextIndex] ?? ids[0] ?? null)
+}
+
+function selectPreviousEffect(): void {
+  selectRelativeEffect(-1)
+}
+
+function selectNextEffect(): void {
+  selectRelativeEffect(1)
+}
+
+function selectRandomEffect(): void {
+  const ids = availableEffectIds.value
+  if (!ids.length) return
+
+  const alternatives = ids.filter((id) => id !== resolvedEffectId.value)
+  const pool = alternatives.length ? alternatives : ids
+  const index = Math.floor(Math.random() * pool.length)
+
+  setEffect(pool[index] ?? ids[0] ?? null)
 }
 
 function fadeOut(): void {
@@ -105,7 +209,11 @@ watch(
 )
 
 onMounted(() => {
-  selectEffect()
+  startupStore.reset()
+
+  if (butterflyStore.showSwarm) {
+    selectEffect()
+  }
 })
 
 onBeforeUnmount(() => {
@@ -138,25 +246,87 @@ onBeforeUnmount(() => {
   height: 100%;
 }
 
-.startup-animation__label {
+.startup-animation__controls {
   position: absolute;
+  right: 1rem;
   bottom: 1rem;
   left: 1rem;
   z-index: 100;
+  display: flex;
+  width: fit-content;
   max-width: calc(100vw - 2rem);
-  overflow: hidden;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem;
   border: 1px solid rgba(255, 255, 255, 0.24);
-  border-radius: 9999px;
-  padding: 0.45rem 0.8rem;
+  border-radius: 1rem;
   background: rgba(0, 0, 0, 0.72);
   color: #fff;
-  font-size: 0.75rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  text-overflow: ellipsis;
+  pointer-events: auto;
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(0.75rem);
+}
+
+.startup-animation__identity {
+  display: flex;
+  min-width: 10rem;
+  max-width: min(18rem, 55vw);
+  flex-direction: column;
+  padding: 0 0.45rem;
+  line-height: 1.1;
+}
+
+.startup-animation__eyebrow {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+.startup-animation__name {
+  overflow: hidden;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 850;
+  text-overflow: ellipsis;
   white-space: nowrap;
-  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(0.5rem);
+}
+
+.startup-animation__button-group {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.startup-animation__divider {
+  width: 1px;
+  height: 1.75rem;
+  margin: 0 0.15rem;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+@media (max-width: 639px) {
+  .startup-animation__controls {
+    justify-content: center;
+  }
+
+  .startup-animation__identity {
+    width: 100%;
+    max-width: 100%;
+    align-items: center;
+    text-align: center;
+  }
+
+  .startup-animation__divider {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .startup-animation {
+    transition: none;
+  }
 }
 </style>

--- a/stores/startupAnimationStore.ts
+++ b/stores/startupAnimationStore.ts
@@ -1,0 +1,38 @@
+// /stores/startupAnimationStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useStartupAnimationStore = defineStore(
+  'startupAnimationStore',
+  () => {
+    const immersive = ref(false)
+    const exitRequest = ref(0)
+
+    function setImmersive(value: boolean): void {
+      immersive.value = value
+    }
+
+    function toggleImmersive(): void {
+      immersive.value = !immersive.value
+    }
+
+    function requestExit(): void {
+      immersive.value = false
+      exitRequest.value += 1
+    }
+
+    function reset(): void {
+      immersive.value = false
+      exitRequest.value = 0
+    }
+
+    return {
+      immersive,
+      exitRequest,
+      setImmersive,
+      toggleImmersive,
+      requestExit,
+      reset,
+    }
+  },
+)


### PR DESCRIPTION
## What changed

- suppresses the startup curtain, logo, messages, spinner, and random effect on ordinary refreshes
- shows the launch sequence again after 12 hours, treating the site as stale enough for a fresh entrance
- keeps store initialization running in the background when the visual sequence is skipped
- upgrades the startup animation label into a responsive control panel with previous, random, next, animation-only, and exit controls
- pauses the automatic loader exit while animation-only mode is active
- adds shared startup presentation state without coupling it to generation animations
- softens the square logo boundary with a radial mask, animated irregular haze, and a subtle wobbling halo
- preserves reduced-motion behavior by disabling the new haze motion when requested

## Why

The launch treatment is fun as an entrance but repetitive on refresh. The animation label also exposed the active effect without giving users meaningful control, and the square logo edge looked pasted over the background rather than emerging from it.

## Validation

- reviewed the branch diff against `main`
- verified the skipped visual path starts store initialization before releasing the loader
- verified startup effects do not mount when the launch sequence is skipped
- verified animation-only mode cancels pending automatic fades and remains active until the user restores the launch UI or exits
- local typecheck/build could not be run because this environment does not have a repository checkout or GitHub CLI; CI should run the repository checks on this draft PR

## Deferred

- animated/random logo imagery remains intentionally out of scope for the next phase