### PR TITLE
video: selectable output format (webp/mp4/webm), default to animated WebP

### DIFF
--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -150,6 +150,24 @@
       :disabled="videoStore.isBusy"
     />
 
+    <!-- Output format -->
+    <section class="space-y-2">
+      <label class="font-semibold">Output format</label>
+      <div class="flex gap-2">
+        <button
+          v-for="opt in outputFormats"
+          :key="opt.value"
+          type="button"
+          class="btn btn-sm"
+          :class="outputFormat === opt.value ? 'btn-accent' : 'btn-outline'"
+          @click="outputFormat = opt.value"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+      <p class="text-xs opacity-60">{{ activeOutputFormat.hint }}</p>
+    </section>
+
     <!-- Controls -->
     <section class="grid gap-4 sm:grid-cols-3">
       <div class="space-y-1">
@@ -265,7 +283,14 @@
     <!-- Result -->
     <section v-if="videoStore.state.videoSrc" class="space-y-2">
       <h2 class="font-semibold">Result</h2>
+      <img
+        v-if="videoStore.resultIsImage"
+        :src="videoStore.state.videoSrc"
+        class="w-full rounded-lg border border-base-300 bg-black object-contain"
+        alt="Generated clip"
+      />
       <video
+        v-else
         :src="videoStore.state.videoSrc"
         class="w-full rounded-lg border border-base-300 bg-black"
         :loop="loop"
@@ -276,7 +301,7 @@
       />
       <a
         :href="videoStore.state.videoSrc"
-        download="kindrobots-clip"
+        :download="downloadFilename"
         class="btn btn-sm btn-outline"
       >
         ⬇ Download clip
@@ -287,7 +312,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useVideoStore } from '@/stores/videoStore'
+import { useVideoStore, type VideoOutputFormat } from '@/stores/videoStore'
 import { useUserStore } from '@/stores/userStore'
 
 const LOGO_SRC = '/images/kindlogo_new.webp'
@@ -319,6 +344,29 @@ const activeEngine = computed(
   () => engines.find((e) => e.value === engine.value) ?? engines[0]!,
 )
 
+const outputFormats = [
+  {
+    value: 'webp' as const,
+    label: 'WebP',
+    hint: 'Animated image, loops natively — smallest file, best default for web display (e.g. a randomized loading animation).',
+  },
+  {
+    value: 'mp4' as const,
+    label: 'MP4',
+    hint: 'Real video container — best for longer or more complex motion, plays with controls.',
+  },
+  {
+    value: 'webm' as const,
+    label: 'WebM',
+    hint: 'Real video container, open codec — similar use case to MP4.',
+  },
+]
+
+const outputFormat = ref<VideoOutputFormat>('webp')
+const activeOutputFormat = computed(
+  () => outputFormats.find((f) => f.value === outputFormat.value) ?? outputFormats[0]!,
+)
+
 const firstImage = ref('')
 const secondImage = ref('')
 const prompt = ref(WINK_PRESET)
@@ -336,6 +384,10 @@ const seedInput = ref<number | string>('')
 
 const estimatedFrames = computed(() =>
   Math.max(2, Math.round((durationSeconds.value || 0) * (fps.value || 0)) + 1),
+)
+
+const downloadFilename = computed(
+  () => `kindrobots-clip.${videoStore.state.fileType || outputFormat.value}`,
 )
 
 const canGenerate = computed(
@@ -410,6 +462,7 @@ async function generate() {
     width: width.value,
     height: height.value,
     seed,
+    outputFormat: outputFormat.value,
     loraResourceIds: loraResourceId.value ? [loraResourceId.value] : undefined,
     loraStrength: loraResourceId.value ? loraStrength.value : undefined,
     isMature: isMature.value,

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -23,6 +23,7 @@ import {
   LTX_DEFAULT_DURATION,
   LTX_DEFAULT_FRAME_RATE,
 } from '../comfy/ltx/utils/imageToVideoWorkflow'
+import { normalizeVideoOutputFormat } from '../comfy/utils/videoOutput'
 import {
   buildWanImageToVideoWorkflow,
   wanFrameCount,
@@ -101,6 +102,8 @@ type ArtEnqueueRequest = {
   fps?: number | null
   frameRate?: number | null
   loop?: boolean | null
+  // 'webp' (default) | 'mp4' | 'webm' — see server/api/comfy/utils/videoOutput.
+  outputFormat?: string | null
   workflow?: Record<string, unknown> | null
 }
 
@@ -666,6 +669,7 @@ function buildVideoJobPayload(
   }
 
   const loop = Boolean(body.loop)
+  const outputFormat = normalizeVideoOutputFormat(body.outputFormat)
   const frames = isWan
     ? wanFrameCount(duration, frameRate)
     : ltxFrameCount(duration, frameRate)
@@ -686,6 +690,7 @@ function buildVideoJobPayload(
         scheduler: body.scheduler ?? null,
         loraName,
         loraStrength,
+        outputFormat,
       })
     : buildLtxImageToVideoWorkflow({
         prompt: promptString,
@@ -702,6 +707,7 @@ function buildVideoJobPayload(
         sampler: body.sampler ?? null,
         styleLoraName: loraName,
         styleLoraStrength: loraStrength,
+        outputFormat,
       })
 
   return {
@@ -723,6 +729,7 @@ function buildVideoJobPayload(
         hasLastImage: Boolean(lastImageName),
         hasLora: Boolean(loraName),
         loraStrength,
+        outputFormat,
       },
       save,
     },

--- a/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/ltx/utils/imageToVideoWorkflow.ts
@@ -13,6 +13,12 @@
 // array; the home relay uploads those to Comfy before running the graph, so the
 // LoadImage nodes resolve. This is the same contract the kontext queue path uses.
 
+import {
+  buildVideoOutputNodes,
+  normalizeVideoOutputFormat,
+  type VideoOutputFormat,
+} from '../../utils/videoOutput'
+
 export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
 
 export type ComfyWorkflowNode = {
@@ -47,6 +53,7 @@ export type LtxImageToVideoInput = {
   temporalSize?: number | null
   temporalOverlap?: number | null
   filenamePrefix?: string | null
+  outputFormat?: VideoOutputFormat | string | null
 }
 
 // Defaults match the proven text2video route so a queued clip renders with the
@@ -288,22 +295,15 @@ export function buildLtxImageToVideoWorkflow(
     class_type: 'VAEDecodeTiled',
     _meta: { title: 'VAE Decode Tiled' },
   }
-  workflow['312'] = {
-    inputs: { fps: frameRate, images: ['316', 0] },
-    class_type: 'CreateVideo',
-    _meta: { title: 'Create Video' },
-  }
-  workflow['341'] = {
-    inputs: {
-      filename_prefix:
-        input.filenamePrefix ?? 'video/kindrobots_ltx_image2video',
-      format: 'auto',
-      codec: 'auto',
-      video: ['312', 0],
-    },
-    class_type: 'SaveVideo',
-    _meta: { title: 'Save Video' },
-  }
+  Object.assign(
+    workflow,
+    buildVideoOutputNodes({
+      format: normalizeVideoOutputFormat(input.outputFormat),
+      imagesRef: ['316', 0],
+      fps: frameRate,
+      filenamePrefix: input.filenamePrefix ?? 'video/kindrobots_ltx_image2video',
+    }),
+  )
 
   return workflow
 }

--- a/server/api/comfy/utils/videoOutput.ts
+++ b/server/api/comfy/utils/videoOutput.ts
@@ -1,0 +1,81 @@
+// /server/api/comfy/utils/videoOutput.ts
+//
+// Shared "how does a queued image-to-video workflow save its result" tail,
+// used by both the WAN and LTX builders. Two shapes:
+//   - webp: the decoded IMAGE batch goes straight into SaveAnimatedWEBP (a
+//     native ComfyUI node — no CreateVideo/SaveVideo, no custom node install).
+//     ComfyUI has no native GIF encoder, so animated WebP is the actual best
+//     "works well on the web" default: smaller + higher quality than GIF for
+//     a short looping clip, and the site already uses .webp for the static
+//     logo. Renders as a plain <img>, loops natively.
+//   - mp4 / webm: the existing CreateVideo -> SaveVideo path, with the
+//     container driven by the requested format instead of a fixed 'auto'.
+//
+// SaveAnimatedWEBP's input names (images/filename_prefix/fps/lossless/quality/
+// method) match ComfyUI core's long-stable node signature but are unverified
+// against this specific install — flag if the first webp render errors.
+
+export type VideoOutputFormat = 'webp' | 'mp4' | 'webm'
+
+export const DEFAULT_VIDEO_OUTPUT_FORMAT: VideoOutputFormat = 'webp'
+
+const VALID_VIDEO_OUTPUT_FORMATS: readonly VideoOutputFormat[] = [
+  'webp',
+  'mp4',
+  'webm',
+]
+
+export function normalizeVideoOutputFormat(value: unknown): VideoOutputFormat {
+  const candidate = String(value ?? '').toLowerCase()
+  return (VALID_VIDEO_OUTPUT_FORMATS as readonly string[]).includes(candidate)
+    ? (candidate as VideoOutputFormat)
+    : DEFAULT_VIDEO_OUTPUT_FORMAT
+}
+
+type VideoOutputNode = {
+  class_type?: string
+  inputs?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+export function buildVideoOutputNodes(input: {
+  format: VideoOutputFormat
+  imagesRef: [string, number]
+  fps: number
+  filenamePrefix: string
+}): Record<string, VideoOutputNode> {
+  if (input.format === 'webp') {
+    return {
+      save_output: {
+        inputs: {
+          images: input.imagesRef,
+          filename_prefix: input.filenamePrefix,
+          fps: input.fps,
+          lossless: false,
+          quality: 90,
+          method: 'default',
+        },
+        class_type: 'SaveAnimatedWEBP',
+        _meta: { title: 'Save Animated WebP' },
+      },
+    }
+  }
+
+  return {
+    create_video_output: {
+      inputs: { fps: input.fps, images: input.imagesRef },
+      class_type: 'CreateVideo',
+      _meta: { title: 'Create Video' },
+    },
+    save_output: {
+      inputs: {
+        filename_prefix: input.filenamePrefix,
+        format: input.format === 'webm' ? 'webm' : 'auto',
+        codec: 'auto',
+        video: ['create_video_output', 0],
+      },
+      class_type: 'SaveVideo',
+      _meta: { title: 'Save Video' },
+    },
+  }
+}

--- a/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
+++ b/server/api/comfy/wan/utils/imageToVideoWorkflow.ts
@@ -18,6 +18,12 @@
 // 2026-07) and centralised as constants so the operator can retune a different
 // WAN build without touching the graph.
 
+import {
+  buildVideoOutputNodes,
+  normalizeVideoOutputFormat,
+  type VideoOutputFormat,
+} from '../../utils/videoOutput'
+
 export type ComfyWorkflow = Record<string, ComfyWorkflowNode>
 
 export type ComfyWorkflowNode = {
@@ -46,6 +52,7 @@ export type WanImageToVideoInput = {
   // low-noise expert takes over (0–1). Defaults to WAN_DEFAULT_BOUNDARY.
   boundary?: number | null
   filenamePrefix?: string | null
+  outputFormat?: VideoOutputFormat | string | null
 }
 
 export const WAN_DEFAULT_WIDTH = 832
@@ -252,28 +259,21 @@ export function buildWanImageToVideoWorkflow(
     _meta: { title: 'KSampler Advanced (Low Noise)' },
   }
 
-  // --- Decode + encode video ----------------------------------------------
+  // --- Decode + save output ------------------------------------------------
   workflow['decode'] = {
     inputs: { samples: ['sampler_low', 0], vae: ['vae', 0] },
     class_type: 'VAEDecode',
     _meta: { title: 'VAE Decode' },
   }
-  workflow['create_video'] = {
-    inputs: { fps: frameRate, images: ['decode', 0] },
-    class_type: 'CreateVideo',
-    _meta: { title: 'Create Video' },
-  }
-  workflow['save_video'] = {
-    inputs: {
-      filename_prefix:
-        input.filenamePrefix ?? 'video/kindrobots_wan_image2video',
-      format: 'auto',
-      codec: 'auto',
-      video: ['create_video', 0],
-    },
-    class_type: 'SaveVideo',
-    _meta: { title: 'Save Video' },
-  }
+  Object.assign(
+    workflow,
+    buildVideoOutputNodes({
+      format: normalizeVideoOutputFormat(input.outputFormat),
+      imagesRef: ['decode', 0],
+      fps: frameRate,
+      filenamePrefix: input.filenamePrefix ?? 'video/kindrobots_wan_image2video',
+    }),
+  )
 
   return workflow
 }

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -13,6 +13,11 @@ import { performFetch } from '@/stores/utils'
 
 export type VideoEngine = 'ltx' | 'wan'
 
+// 'webp' (default) — native ComfyUI SaveAnimatedWEBP, smaller/better quality
+// than GIF for a short looping clip, renders as <img>. 'mp4'/'webm' render as
+// <video> and suit longer or more complex motion.
+export type VideoOutputFormat = 'webp' | 'mp4' | 'webm'
+
 export type VideoJobStatus = 'idle' | 'queued' | 'rendering' | 'done' | 'error'
 
 export interface GenerateVideoParams {
@@ -30,6 +35,7 @@ export interface GenerateVideoParams {
   seed?: number | null
   loraResourceIds?: number[]
   loraStrength?: number | null
+  outputFormat?: VideoOutputFormat
   isPublic?: boolean
   isMature?: boolean
   designer?: string | null
@@ -50,18 +56,30 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-// Resolve a finished ArtImage (fileType mp4/webm/gif) into a playable src.
-// Handles inline base64 clips and stored paths, same shape as artImageToSrc but
-// video-aware (data:video/... and /video/... paths).
+// webp/gif clips are animated *images* (render as <img>, loop natively);
+// mp4/webm are real video containers (render as <video>).
+const IMAGE_CLIP_TYPES = new Set(['webp', 'gif'])
+
+export function isImageClipFileType(fileType: string | null | undefined): boolean {
+  return IMAGE_CLIP_TYPES.has((fileType || '').toLowerCase())
+}
+
+// Resolve a finished ArtImage (fileType webp/gif/mp4/webm) into a playable
+// src. Handles inline base64 clips and stored paths, same shape as
+// artImageToSrc but clip-aware (data:video/... , data:image/... , and
+// /video/... or /image/... paths).
 function artImageToVideoSrc(image: ArtImage | null | undefined): string {
   if (!image) return ''
   const fileType = (image.fileType || 'mp4').toLowerCase()
   const raw = (image.imageData || '').trim()
+  const mime = isImageClipFileType(fileType)
+    ? `image/${fileType}`
+    : `video/${fileType === 'webm' ? 'webm' : 'mp4'}`
 
   if (raw) {
     if (raw.startsWith('data:')) return raw
     if (!raw.startsWith('/') && !raw.startsWith('http')) {
-      return `data:video/${fileType === 'webm' ? 'webm' : 'mp4'};base64,${raw}`
+      return `data:${mime};base64,${raw}`
     }
   }
 
@@ -77,6 +95,7 @@ export const useVideoStore = defineStore('videoStore', () => {
     status: 'idle' as VideoJobStatus,
     jobId: null as number | null,
     videoSrc: '',
+    fileType: '',
     artImageId: null as number | null,
     message: '',
     error: '',
@@ -87,10 +106,14 @@ export const useVideoStore = defineStore('videoStore', () => {
     () => state.status === 'queued' || state.status === 'rendering',
   )
 
+  // webp/gif clips render as <img> (loop natively); mp4/webm render as <video>.
+  const resultIsImage = computed(() => isImageClipFileType(state.fileType))
+
   function reset(): void {
     state.status = 'idle'
     state.jobId = null
     state.videoSrc = ''
+    state.fileType = ''
     state.artImageId = null
     state.message = ''
     state.error = ''
@@ -113,6 +136,7 @@ export const useVideoStore = defineStore('videoStore', () => {
         ? params.loraResourceIds
         : undefined,
       loraStrength: params.loraStrength ?? undefined,
+      outputFormat: params.outputFormat ?? undefined,
       isPublic: params.isPublic ?? true,
       isMature: params.isMature ?? false,
       designer: params.designer ?? undefined,
@@ -183,6 +207,7 @@ export const useVideoStore = defineStore('videoStore', () => {
     }
 
     state.videoSrc = artImageToVideoSrc(res.data)
+    state.fileType = (res.data.fileType || '').toLowerCase()
   }
 
   // Full orchestration: enqueue → poll → resolve. Sets status/error along the
@@ -219,5 +244,5 @@ export const useVideoStore = defineStore('videoStore', () => {
     }
   }
 
-  return { state, isBusy, reset, generate }
+  return { state, isBusy, resultIsImage, reset, generate }
 })


### PR DESCRIPTION
## Why

Silas: "I would prefer the default output was whatever works best for web display (gif?)... it should be an option to select the output type anyway."

Research: ComfyUI has no native GIF encoder (would need a custom-node install on the home server), but it does ship `SaveAnimatedWEBP` natively — smaller and higher quality than GIF for a short looping clip, and the site already uses `.webp` for the static logo. Silas confirmed: **animated WebP default**, mp4/webm stay selectable.

## What

- **`server/api/comfy/utils/videoOutput.ts`** (new, shared): the output-tail builder used by both WAN and LTX. `webp` bypasses `CreateVideo`/`SaveVideo` entirely — `SaveAnimatedWEBP` takes the decoded `IMAGE` batch directly. `mp4`/`webm` keep the existing `CreateVideo` → `SaveVideo` path, with the container driven by the request instead of a fixed `'auto'`.
- **WAN + LTX workflow builders**: `outputFormat` field, wired through the shared helper instead of each hardcoding its own `SaveVideo` tail.
- **`enqueue.post.ts`**: `outputFormat` on `ArtEnqueueRequest`, threaded to both builders and into the ArtJob's `video` metadata block.
- **`videoStore.ts`**: `outputFormat` on `GenerateVideoParams`; `artImageToVideoSrc` now branches on `fileType` for the correct `data:` mime (`image/webp` vs `video/mp4`); tracks `fileType` so the page knows whether to render `<img>` or `<video>`; new `resultIsImage` computed.
- **`video-generator.vue`**: output format selector (WebP default / MP4 / WebM); Result section renders `<img>` for webp/gif, `<video>` for mp4/webm; download link filename now carries the real extension.

## Cross-repo dependency

**Requires conductor PR #1459** (adds `.webp` to the relay's `VIDEO_EXTENSIONS`). Without it, the relay's `find_output_file()` would reject the `SaveAnimatedWEBP` output for a video-type ArtJob and report "no output found" even though ComfyUI succeeded — confirmed by reading `relay_agent.py`'s `extract_comfy_output`/`find_output_file`/`is_video_filename` chain directly.

## Also confirmed (no code change needed)

Silas asked whether WAN's high/low-noise (mixture-of-experts) dual-stage sampling is our default. **Yes** — `server/api/comfy/wan/utils/imageToVideoWorkflow.ts` already builds two `UNETLoader`s + a two-stage `KSamplerAdvanced` handoff, matching his tested ComfyUI workflow's architecture exactly. Separately: his test workflow used a lightx2v 4-step speed-LoRA **pair** (two distinct files, one per expert) — our builder currently applies one shared LoRA to both stages. Silas asked for that as a follow-up, not in this PR.

## Verification

- `npx prisma generate && npm run test` (vue-tsc typecheck) — exit 0, zero errors.
- `SaveAnimatedWEBP`'s input names (`images`/`filename_prefix`/`fps`/`lossless`/`quality`/`method`) match ComfyUI core's long-stable node signature but are **unverified against this specific install** — flag if the first webp render errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnHcbLnpJtpSvw27YsM5M)_