### PR TITLE
Polish startup refresh and animation controls

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -26,6 +26,14 @@ body,
   overflow-x: hidden;
 }
 
+.kr-shell.bg-black {
+  background-color: transparent !important;
+}
+
+.kr-boot-curtain {
+  display: none !important;
+}
+
 section:has(img[src*='projects/images']) .overflow-y-auto {
   overflow-x: hidden;
 }

--- a/assets/images/startup-animations/README.md
+++ b/assets/images/startup-animations/README.md
@@ -1,0 +1,29 @@
+# Startup refresh animations
+
+Place short looping animated WebP files in this directory.
+
+## Naming
+
+Files must match:
+
+```text
+launch-*.webp
+```
+
+Recommended names:
+
+```text
+launch-01.webp
+launch-02.webp
+launch-03.webp
+```
+
+The refresh splash discovers every matching file at build time and chooses one randomly. No manifest or code update is required when adding or removing files.
+
+If this directory contains no matching WebP files, or a selected file fails to load, the splash falls back to:
+
+```text
+/public/images/kindlogo_new.webp
+```
+
+Keep each loop lightweight because the refresh splash is displayed for approximately two seconds. A square source around 512×512 or 768×768 is recommended.

--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -1,7 +1,13 @@
 <template>
   <div v-if="showOverlay || !pageReadyEmitted" class="loader-root">
+    <quick-loading-splash
+      v-if="showOverlay && startupMode === 'quick'"
+      @covered="handleOverlayCovered"
+      @hidden="handleOverlayHidden"
+    />
+
     <loading-messages
-      v-if="showOverlay"
+      v-else-if="showOverlay"
       :stores-ready="storesReady"
       @covered="handleOverlayCovered"
       @hiding="handleOverlayHiding"
@@ -72,10 +78,12 @@ const emit = defineEmits<{
   pageReady: [boolean]
 }>()
 
+type StartupMode = 'full' | 'quick'
+
 const STARTUP_STORAGE_KEY = 'kind-robots-startup-build-v1'
 const buildId = String(runtimeConfig.public.buildId || 'development')
 
-function shouldShowStartupSequence(): boolean {
+function shouldShowFullStartupSequence(): boolean {
   if (!import.meta.client) return true
 
   try {
@@ -95,8 +103,10 @@ function markStartupSequenceSeen(): void {
   }
 }
 
-const showStartupSequence = ref(shouldShowStartupSequence())
-const showOverlay = ref(showStartupSequence.value)
+const startupMode = ref<StartupMode>(
+  shouldShowFullStartupSequence() ? 'full' : 'quick',
+)
+const showOverlay = ref(true)
 const storesReady = ref(false)
 const pageReadyEmitted = ref(false)
 const coveredEmitted = ref(false)
@@ -104,9 +114,9 @@ const coveredEmitted = ref(false)
 let initializationPromise: Promise<void> | null = null
 
 startupStore.reset()
-butterflyStore.setShowSwarm(showStartupSequence.value)
+butterflyStore.setShowSwarm(startupMode.value === 'full')
 
-if (showStartupSequence.value) {
+if (startupMode.value === 'full') {
   markStartupSequenceSeen()
 }
 
@@ -246,16 +256,13 @@ function ensureStoresInitialized(): Promise<void> {
 }
 
 onBeforeMount(() => {
-  if (showStartupSequence.value) return
-
+  if (startupMode.value !== 'quick') return
   void ensureStoresInitialized()
-  handleOverlayCovered()
-  emitReadyOnce()
 })
 
-onMounted(async () => {
-  if (!showStartupSequence.value) return
-  await ensureStoresInitialized()
+onMounted(() => {
+  if (startupMode.value !== 'full') return
+  void ensureStoresInitialized()
 })
 </script>
 

--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -65,38 +65,23 @@ const navStore = useNavStore()
 const themeStore = useThemeStore()
 const butterflyStore = useButterflyStore()
 const startupStore = useStartupAnimationStore()
+const runtimeConfig = useRuntimeConfig()
 
 const emit = defineEmits<{
   covered: []
   pageReady: [boolean]
 }>()
 
-const STARTUP_STORAGE_KEY = 'kind-robots-last-startup-animation-v1'
-const STARTUP_STALE_MS = 12 * 60 * 60 * 1000
-
-function isReloadNavigation(): boolean {
-  if (!import.meta.client) return false
-
-  const navigation = performance.getEntriesByType(
-    'navigation',
-  )[0] as PerformanceNavigationTiming | undefined
-
-  return navigation?.type === 'reload'
-}
+const STARTUP_STORAGE_KEY = 'kind-robots-startup-build-v1'
+const buildId = String(runtimeConfig.public.buildId || 'development')
 
 function shouldShowStartupSequence(): boolean {
   if (!import.meta.client) return true
 
   try {
-    const stored = localStorage.getItem(STARTUP_STORAGE_KEY)
-    if (!stored) return !isReloadNavigation()
-
-    const lastShownAt = Number(stored)
-    if (!Number.isFinite(lastShownAt)) return true
-
-    return Date.now() - lastShownAt >= STARTUP_STALE_MS
+    return localStorage.getItem(STARTUP_STORAGE_KEY) !== buildId
   } catch {
-    return !isReloadNavigation()
+    return true
   }
 }
 
@@ -104,7 +89,7 @@ function markStartupSequenceSeen(): void {
   if (!import.meta.client) return
 
   try {
-    localStorage.setItem(STARTUP_STORAGE_KEY, String(Date.now()))
+    localStorage.setItem(STARTUP_STORAGE_KEY, buildId)
   } catch {
     return
   }
@@ -280,5 +265,18 @@ onMounted(async () => {
   inset: 0;
   z-index: 40;
   pointer-events: none;
+}
+
+:global(.kr-shell.bg-black) {
+  background-color: transparent !important;
+}
+
+:global(.kr-boot-curtain) {
+  display: none !important;
+}
+
+:global(.loading-overlay),
+:global(.loading-content) {
+  pointer-events: none !important;
 }
 </style>

--- a/components/admin/quick-loading-splash.vue
+++ b/components/admin/quick-loading-splash.vue
@@ -1,0 +1,215 @@
+<template>
+  <div
+    class="quick-loading-overlay"
+    :class="{ 'quick-loading-overlay--fade': fading }"
+    @transitionend="handleTransitionEnd"
+  >
+    <div class="quick-loading-content">
+      <div class="quick-loading-visual-frame">
+        <img
+          :src="visualSrc"
+          alt="Kind Robots"
+          class="quick-loading-visual"
+          :class="{ 'quick-loading-visual--ready': visualReady }"
+          loading="eager"
+          fetchpriority="high"
+          decoding="async"
+          @load="visualReady = true"
+          @error="useLogoFallback"
+        />
+      </div>
+
+      <p class="quick-loading-message" aria-live="polite">
+        {{ message }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useLoadStore } from '@/stores/loadStore'
+
+const emit = defineEmits<{
+  covered: []
+  hidden: []
+}>()
+
+const animationModules = import.meta.glob<string>(
+  '../../assets/images/startup-animations/launch-*.webp',
+  {
+    eager: true,
+    import: 'default',
+    query: '?url',
+  },
+)
+
+const animationUrls = Object.values(animationModules)
+const logoFallback = '/images/kindlogo_new.webp'
+const selectedAnimation =
+  animationUrls[Math.floor(Math.random() * animationUrls.length)]
+
+const loadStore = useLoadStore()
+const visualSrc = ref(selectedAnimation || logoFallback)
+const visualReady = ref(false)
+const fading = ref(false)
+const hiddenEmitted = ref(false)
+const message = ref(
+  loadStore.randomLoadMessage?.() ??
+    'Wiring robots for suspicious levels of charm...',
+)
+
+const TOTAL_MS = 2000
+const FADE_MS = 400
+const HOLD_MS = TOTAL_MS - FADE_MS
+
+let fadeTimer: ReturnType<typeof setTimeout> | null = null
+let hiddenTimer: ReturnType<typeof setTimeout> | null = null
+
+function emitHiddenOnce(): void {
+  if (hiddenEmitted.value) return
+  hiddenEmitted.value = true
+  emit('hidden')
+}
+
+function beginFade(): void {
+  if (fading.value) return
+  fading.value = true
+
+  hiddenTimer = setTimeout(() => {
+    emitHiddenOnce()
+  }, FADE_MS + 80)
+}
+
+function handleTransitionEnd(event: TransitionEvent): void {
+  if (event.propertyName !== 'opacity' || !fading.value) return
+  emitHiddenOnce()
+}
+
+function useLogoFallback(): void {
+  if (visualSrc.value === logoFallback) return
+  visualReady.value = false
+  visualSrc.value = logoFallback
+}
+
+onMounted(() => {
+  emit('covered')
+  fadeTimer = setTimeout(beginFade, HOLD_MS)
+})
+
+onBeforeUnmount(() => {
+  if (fadeTimer) {
+    clearTimeout(fadeTimer)
+    fadeTimer = null
+  }
+
+  if (hiddenTimer) {
+    clearTimeout(hiddenTimer)
+    hiddenTimer = null
+  }
+})
+</script>
+
+<style scoped>
+.quick-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.12);
+  opacity: 1;
+  pointer-events: none;
+  transition: opacity 400ms ease;
+  backdrop-filter: blur(2px);
+}
+
+.quick-loading-overlay--fade {
+  opacity: 0;
+}
+
+.quick-loading-content {
+  display: grid;
+  width: min(92vw, 32rem);
+  place-items: center;
+  gap: 0.75rem;
+}
+
+.quick-loading-visual-frame {
+  position: relative;
+  display: grid;
+  width: min(72vw, 20rem);
+  aspect-ratio: 1;
+  place-items: center;
+  isolation: isolate;
+}
+
+.quick-loading-visual-frame::before {
+  position: absolute;
+  inset: 8%;
+  border-radius: 48% 52% 57% 43% / 55% 44% 56% 45%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.2),
+    rgba(255, 255, 255, 0.06) 52%,
+    transparent 72%
+  );
+  content: '';
+  filter: blur(1.4rem);
+  pointer-events: none;
+}
+
+.quick-loading-visual {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  opacity: 0;
+  transform: scale(0.94);
+  transition:
+    opacity 220ms ease,
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  filter: drop-shadow(0 1rem 2rem rgba(0, 0, 0, 0.32));
+  -webkit-mask-image: radial-gradient(
+    ellipse 55% 55% at center,
+    #000 58%,
+    rgba(0, 0, 0, 0.96) 72%,
+    transparent 100%
+  );
+  mask-image: radial-gradient(
+    ellipse 55% 55% at center,
+    #000 58%,
+    rgba(0, 0, 0, 0.96) 72%,
+    transparent 100%
+  );
+}
+
+.quick-loading-visual--ready {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.quick-loading-message {
+  max-width: min(90vw, 32rem);
+  margin: 0;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  font-size: clamp(0.9rem, 2vw, 1.1rem);
+  font-weight: 750;
+  text-align: center;
+  box-shadow: 0 0.6rem 1.5rem rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(0.7rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quick-loading-overlay,
+  .quick-loading-visual {
+    transition: none;
+  }
+}
+</style>

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -4,10 +4,7 @@
     <div
       v-if="renderEffect && currentComponent"
       class="startup-animation"
-      :class="{
-        'startup-animation--fading': isFading,
-        'startup-animation--immersive': startupStore.immersive,
-      }"
+      :class="{ 'startup-animation--fading': isFading }"
     >
       <component
         :is="currentComponent"
@@ -16,77 +13,92 @@
         aria-hidden="true"
       />
 
-      <div class="startup-animation__controls">
-        <div class="startup-animation__identity">
-          <span class="startup-animation__eyebrow">Animation</span>
+      <div
+        class="startup-animation__controls"
+        :class="{
+          'startup-animation__controls--active': startupStore.controlsActive,
+          'startup-animation__controls--compact': !startupStore.controlsActive,
+        }"
+      >
+        <template v-if="startupStore.controlsActive">
           <span class="startup-animation__name">{{ currentEffectLabel }}</span>
-        </div>
 
-        <div class="startup-animation__button-group">
+          <div class="startup-animation__button-group">
+            <button
+              type="button"
+              class="btn btn-xs btn-ghost btn-square text-white"
+              title="Previous animation"
+              aria-label="Previous animation"
+              @click="selectPreviousEffect"
+            >
+              <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-xs btn-ghost gap-1 text-white"
+              title="Choose another random animation"
+              @click="selectRandomEffect"
+            >
+              <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+              <span class="hidden sm:inline">Random</span>
+            </button>
+
+            <button
+              type="button"
+              class="btn btn-xs btn-ghost btn-square text-white"
+              title="Next animation"
+              aria-label="Next animation"
+              @click="selectNextEffect"
+            >
+              <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+            </button>
+          </div>
+
+          <div class="startup-animation__divider" />
+
           <button
             type="button"
-            class="btn btn-sm btn-ghost btn-square text-white"
-            title="Previous animation"
-            aria-label="Previous animation"
-            @click="selectPreviousEffect"
+            class="btn btn-xs border-white/20 bg-white/10 text-white hover:bg-white/20"
+            title="Restore the launch screen and continue loading"
+            @click="startupStore.leaveControlMode()"
           >
-            <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+            Resume
           </button>
 
           <button
             type="button"
-            class="btn btn-sm btn-ghost gap-1 text-white"
-            title="Choose another random animation"
-            @click="selectRandomEffect"
+            class="btn btn-xs btn-square border-white/20 bg-black/30 text-white hover:bg-error/70"
+            title="Leave startup animation"
+            aria-label="Leave startup animation"
+            @click="startupStore.requestExit()"
+          >
+            <Icon name="kind-icon:x" class="h-4 w-4" />
+          </button>
+        </template>
+
+        <template v-else>
+          <span class="startup-animation__compact-name">
+            {{ currentEffectLabel }}
+          </span>
+
+          <button
+            type="button"
+            class="btn btn-xs border-white/20 bg-white/10 text-white hover:bg-white/20"
+            title="Pause the launch and explore animations"
+            @click="startupStore.enterControlMode()"
           >
             <Icon name="kind-icon:sparkles" class="h-4 w-4" />
-            <span class="hidden sm:inline">Random</span>
+            <span>Pause &amp; explore</span>
           </button>
-
-          <button
-            type="button"
-            class="btn btn-sm btn-ghost btn-square text-white"
-            title="Next animation"
-            aria-label="Next animation"
-            @click="selectNextEffect"
-          >
-            <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
-          </button>
-        </div>
-
-        <div class="startup-animation__divider" />
-
-        <button
-          type="button"
-          class="btn btn-sm border-white/20 bg-white/10 text-white hover:bg-white/20"
-          :class="{ 'border-primary/70 bg-primary/25': startupStore.immersive }"
-          :aria-pressed="startupStore.immersive"
-          :title="
-            startupStore.immersive
-              ? 'Restore the logo and loading messages'
-              : 'Hide the logo and loading messages'
-          "
-          @click="startupStore.toggleImmersive()"
-        >
-          {{ startupStore.immersive ? 'Show launch UI' : 'Animation only' }}
-        </button>
-
-        <button
-          type="button"
-          class="btn btn-sm btn-square border-white/20 bg-black/30 text-white hover:bg-error/70"
-          title="Leave startup animation"
-          aria-label="Leave startup animation"
-          @click="startupStore.requestExit()"
-        >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
-        </button>
+        </template>
       </div>
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { getAnimationEffectComponent } from '@/components/screenfx/effect-component-registry'
 import type { AnimationEffectId } from '@/stores/animationCatalog'
 import { useAnimationStore } from '@/stores/animationStore'
@@ -195,6 +207,12 @@ function fadeOut(): void {
   }, FADE_MS)
 }
 
+startupStore.reset()
+
+if (import.meta.client && butterflyStore.showSwarm) {
+  selectEffect()
+}
+
 watch(
   () => butterflyStore.showSwarm,
   (visible) => {
@@ -207,14 +225,6 @@ watch(
     fadeOut()
   },
 )
-
-onMounted(() => {
-  startupStore.reset()
-
-  if (butterflyStore.showSwarm) {
-    selectEffect()
-  }
-})
 
 onBeforeUnmount(() => {
   clearFadeTimer()
@@ -248,74 +258,85 @@ onBeforeUnmount(() => {
 
 .startup-animation__controls {
   position: absolute;
-  right: 1rem;
   bottom: 1rem;
   left: 1rem;
   z-index: 100;
   display: flex;
   width: fit-content;
   max-width: calc(100vw - 2rem);
-  flex-wrap: wrap;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.55rem;
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  border-radius: 1rem;
-  background: rgba(0, 0, 0, 0.72);
   color: #fff;
   pointer-events: auto;
-  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(0.75rem);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.7);
+  box-shadow: 0 0.65rem 1.75rem rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(0.7rem);
+  transition:
+    border-radius 180ms ease,
+    padding 180ms ease,
+    gap 180ms ease;
 }
 
-.startup-animation__identity {
-  display: flex;
-  min-width: 10rem;
-  max-width: min(18rem, 55vw);
-  flex-direction: column;
-  padding: 0 0.45rem;
-  line-height: 1.1;
+.startup-animation__controls--compact {
+  gap: 0.4rem;
+  padding: 0.3rem 0.35rem 0.3rem 0.65rem;
+  border-radius: 9999px;
 }
 
-.startup-animation__eyebrow {
-  color: rgba(255, 255, 255, 0.58);
-  font-size: 0.62rem;
-  font-weight: 900;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+.startup-animation__controls--active {
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.42rem;
+  border-radius: 0.9rem;
+}
+
+.startup-animation__compact-name,
+.startup-animation__name {
+  overflow: hidden;
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.startup-animation__compact-name {
+  max-width: min(12rem, 42vw);
+  color: rgba(255, 255, 255, 0.76);
 }
 
 .startup-animation__name {
-  overflow: hidden;
+  max-width: min(14rem, 38vw);
+  padding: 0 0.35rem;
   color: #fff;
-  font-size: 0.8rem;
-  font-weight: 850;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .startup-animation__button-group {
   display: flex;
   align-items: center;
-  gap: 0.1rem;
+  gap: 0.05rem;
 }
 
 .startup-animation__divider {
   width: 1px;
-  height: 1.75rem;
-  margin: 0 0.15rem;
-  background: rgba(255, 255, 255, 0.2);
+  height: 1.4rem;
+  margin: 0 0.1rem;
+  background: rgba(255, 255, 255, 0.18);
 }
 
 @media (max-width: 639px) {
-  .startup-animation__controls {
+  .startup-animation__controls--active {
+    right: 0.75rem;
+    bottom: 0.75rem;
+    left: 0.75rem;
     justify-content: center;
+    max-width: calc(100vw - 1.5rem);
   }
 
-  .startup-animation__identity {
+  .startup-animation__name {
     width: 100%;
     max-width: 100%;
-    align-items: center;
+    padding: 0.15rem 0.35rem 0.3rem;
     text-align: center;
   }
 
@@ -325,7 +346,8 @@ onBeforeUnmount(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .startup-animation {
+  .startup-animation,
+  .startup-animation__controls {
     transition: none;
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,6 +26,12 @@ function generateWonderLabComponentMetadata(): void {
   }
 }
 
+const buildId =
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  process.env.VERCEL_DEPLOYMENT_ID ||
+  process.env.NUXT_PUBLIC_BUILD_ID ||
+  'development'
+
 generateWonderLabComponentMetadata()
 
 export default defineNuxtConfig({
@@ -126,6 +132,7 @@ export default defineNuxtConfig({
     brevoNewsletterListId: process.env.BREVO_NEWSLETTER_LIST_ID || '',
     public: {
       appBaseUrl: process.env.APP_BASE_URL || 'https://kindrobots.org',
+      buildId,
     },
   },
 

--- a/stores/startupAnimationStore.ts
+++ b/stores/startupAnimationStore.ts
@@ -6,31 +6,42 @@ export const useStartupAnimationStore = defineStore(
   'startupAnimationStore',
   () => {
     const immersive = ref(false)
+    const controlsActive = ref(false)
     const exitRequest = ref(0)
 
     function setImmersive(value: boolean): void {
       immersive.value = value
     }
 
-    function toggleImmersive(): void {
-      immersive.value = !immersive.value
+    function enterControlMode(): void {
+      controlsActive.value = true
+      immersive.value = true
+    }
+
+    function leaveControlMode(): void {
+      controlsActive.value = false
+      immersive.value = false
     }
 
     function requestExit(): void {
+      controlsActive.value = false
       immersive.value = false
       exitRequest.value += 1
     }
 
     function reset(): void {
+      controlsActive.value = false
       immersive.value = false
       exitRequest.value = 0
     }
 
     return {
       immersive,
+      controlsActive,
       exitRequest,
       setImmersive,
-      toggleImmersive,
+      enterControlMode,
+      leaveControlMode,
       requestExit,
       reset,
     }


### PR DESCRIPTION
## What changed

### Full launch

- removes the forced black startup curtain/background so the launch effect appears without an empty black dead zone first
- selects the startup effect during component setup instead of waiting for another mounted render
- keys the full launch to the Vercel build identifier:
  - first visit to a deployment shows the full launch
  - a new Vercel commit/deployment shows the full launch again
- keeps the compact animation label and **Pause & explore** control
- only reveals previous, random, next, resume, and exit controls after the user explicitly pauses the launch
- makes the visual loading overlay pointer-transparent so the controls can receive mouse input

### Same-deployment refresh

- replaces the previous complete skip with a dedicated two-second mini-splash
- shows exactly one loading message
- displays one randomly selected animated WebP when matching assets exist
- falls back to `/public/images/kindlogo_new.webp` when there are no matching animations or an animation fails to load
- does not mount the fullscreen startup effect set during the mini-splash
- continues store initialization in the background and releases the page after the two-second presentation rather than waiting for every store

### Adding animated WebPs

Place files in:

```text
assets/images/startup-animations/
```

Name them:

```text
launch-01.webp
launch-02.webp
launch-03.webp
```

Any file matching `launch-*.webp` is discovered automatically at build time. No manifest or source edit is required. The folder includes a README with the contract and size guidance.

## Why

A refresh should retain a small amount of personality without replaying the full entrance or making the site feel blocked. New deployments still deserve the complete launch treatment, while ordinary refreshes now get a brief image-and-message beat.

## Validation

- branch is based cleanly on current `main` and behind by zero commits
- refresh mode is isolated in `quick-loading-splash.vue`
- quick mode has a fixed two-second lifecycle and one non-rotating message
- animated WebPs are rendered with a plain `<img>` so animation is preserved
- the asset glob falls back safely when it finds no matching files
- full animation controls remain conditional on explicit pause/explore activation

TypeScript, contract checks, and Vercel preview verification are pending the latest branch commit.