### PR TITLE
Add direct Project image upload and replacement controls

### DIFF
--- a/components/pages/conductor-art-gallery.vue
+++ b/components/pages/conductor-art-gallery.vue
@@ -5,23 +5,41 @@
     @mouseenter="paused = true"
     @mouseleave="paused = false"
   >
-    <div class="flex min-w-0 items-center gap-2">
+    <div class="flex min-w-0 flex-wrap items-center gap-2">
       <Icon name="kind-icon:image" class="size-4 text-secondary" />
       <h4
         class="min-w-0 truncate text-xs font-bold uppercase tracking-wide text-base-content/60"
       >
-        Inspiration Gallery
+        Project Images
       </h4>
       <span
         v-if="matchedCollection"
         class="badge badge-secondary badge-xs shrink-0"
         :title="`Art collection: ${matchedCollection.label}`"
       >
-        {{ collectionSlideCount }} from collection
+        {{ collectionSlideCount }} collection
       </span>
-      <span v-if="slides.length" class="ml-auto shrink-0 text-xs text-base-content/40">
+      <span
+        v-if="projectSlides.length"
+        class="badge badge-accent badge-xs shrink-0"
+      >
+        {{ projectSlides.length }} inspiration
+      </span>
+      <span
+        v-if="slides.length"
+        class="ml-auto shrink-0 text-xs text-base-content/40"
+      >
         {{ activeIndex + 1 }} / {{ slides.length }}
       </span>
+      <button
+        v-if="canEdit && projectId"
+        type="button"
+        class="btn btn-primary btn-xs gap-1 rounded-lg"
+        @click="openReplaceForm"
+      >
+        <Icon name="kind-icon:upload" class="size-3" />
+        Submit new image
+      </button>
     </div>
 
     <div
@@ -38,11 +56,22 @@
         />
       </Transition>
 
-      <span
-        class="absolute bottom-2 left-2 badge badge-sm border-0 bg-base-100/80 font-semibold backdrop-blur"
-      >
-        {{ activeSlide.label }}
-      </span>
+      <div class="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-linear-to-t from-base-300/85 to-transparent p-3 pt-10">
+        <span
+          class="badge badge-sm border-0 bg-base-100/85 font-semibold backdrop-blur"
+        >
+          {{ activeSlide.label }}
+        </span>
+        <button
+          v-if="canEdit && projectId && activeSlide.field"
+          type="button"
+          class="btn btn-sm gap-1 rounded-lg border-0 bg-base-100/85 shadow backdrop-blur hover:bg-base-100"
+          @click="openReplaceForm(activeSlide.field)"
+        >
+          <Icon name="kind-icon:upload" class="size-3.5" />
+          Replace {{ activeSlide.label }}
+        </button>
+      </div>
 
       <template v-if="slides.length > 1">
         <button
@@ -70,14 +99,121 @@
     >
       <Icon name="kind-icon:image" class="size-8 text-base-content/20" />
       <p class="text-xs font-semibold text-base-content/50">
-        No inspiration art yet.
+        No project images yet.
       </p>
-      <p class="max-w-xs text-xs text-base-content/35">
-        Give an art collection the slug (or name)
-        <strong class="text-base-content/60">{{ slug }}</strong> and its images
-        will slideshow here.
-      </p>
+      <button
+        v-if="canEdit && projectId"
+        type="button"
+        class="btn btn-primary btn-sm gap-1 rounded-xl"
+        @click="openReplaceForm"
+      >
+        <Icon name="kind-icon:upload" class="size-4" />
+        Submit first image
+      </button>
     </div>
+
+    <form
+      v-if="showReplaceForm"
+      class="space-y-3 rounded-xl border border-primary/25 bg-primary/5 p-3"
+      @submit.prevent="submitReplacement"
+    >
+      <div class="flex items-center gap-2">
+        <div>
+          <p class="text-sm font-bold">Upload and replace</p>
+          <p class="text-xs text-base-content/50">
+            The new image becomes the selected Project asset immediately.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs ml-auto rounded-lg"
+          :disabled="replacing"
+          @click="closeReplaceForm"
+        >
+          <Icon name="kind-icon:x" class="size-3" />
+        </button>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-2">
+        <label class="form-control gap-1">
+          <span class="text-xs font-semibold text-base-content/60">Replace</span>
+          <select
+            v-model="replacementField"
+            class="select select-bordered select-sm rounded-xl"
+            :disabled="replacing"
+          >
+            <option value="imagePath">Icon</option>
+            <option value="cardPath">Card</option>
+            <option value="heroPath">Hero</option>
+          </select>
+        </label>
+        <label class="form-control gap-1">
+          <span class="text-xs font-semibold text-base-content/60">New image</span>
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            class="file-input file-input-bordered file-input-sm w-full rounded-xl"
+            :disabled="replacing"
+            @change="handleFileChange"
+          />
+        </label>
+      </div>
+
+      <fieldset class="space-y-1">
+        <legend class="text-xs font-semibold text-base-content/60">
+          Previous image
+        </legend>
+        <label class="flex cursor-pointer items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-base-100/60">
+          <input
+            v-model="preserveOriginal"
+            type="radio"
+            :value="true"
+            class="radio radio-primary radio-sm mt-0.5"
+            :disabled="replacing"
+          />
+          <span>
+            <span class="block text-sm font-semibold">Keep as inspiration</span>
+            <span class="block text-xs text-base-content/45">
+              The previous version remains in this Project gallery.
+            </span>
+          </span>
+        </label>
+        <label class="flex cursor-pointer items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-base-100/60">
+          <input
+            v-model="preserveOriginal"
+            type="radio"
+            :value="false"
+            class="radio radio-primary radio-sm mt-0.5"
+            :disabled="replacing"
+          />
+          <span>
+            <span class="block text-sm font-semibold">Remove from Project</span>
+            <span class="block text-xs text-base-content/45">
+              The previous image is not retained as an inspiration item.
+            </span>
+          </span>
+        </label>
+      </fieldset>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <p
+          v-if="replacementMessage"
+          class="min-w-0 flex-1 text-xs"
+          :class="replacementError ? 'text-error' : 'text-success'"
+        >
+          {{ replacementMessage }}
+        </p>
+        <button
+          type="submit"
+          class="btn btn-primary btn-sm ml-auto gap-1.5 rounded-xl"
+          :disabled="!replacementFile || replacing"
+        >
+          <span v-if="replacing" class="loading loading-spinner loading-xs" />
+          <Icon v-else name="kind-icon:upload" class="size-4" />
+          Upload & replace
+        </button>
+      </div>
+    </form>
 
     <div
       v-if="slides.length > 1"
@@ -93,7 +229,8 @@
             ? 'border-primary ring-2 ring-primary/40'
             : 'border-base-300 opacity-60 hover:opacity-100'
         "
-        :aria-label="`Show image ${index + 1}`"
+        :aria-label="`Show ${slide.label}`"
+        :title="slide.label"
         @click="activeIndex = index"
       >
         <img
@@ -109,21 +246,50 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useCollectionStore } from '@/stores/collectionStore'
+import { performFetch } from '@/stores/utils'
+
+type ProjectArtField = 'imagePath' | 'cardPath' | 'heroPath'
+type Slide = {
+  src: string
+  label: string
+  field?: ProjectArtField
+}
+type ProjectArtLink = {
+  createdAt: string | Date
+  ArtImage: {
+    id: number
+    imagePath?: string | null
+    path?: string | null
+    fileName?: string | null
+    fileType?: string | null
+  }
+}
 
 const props = defineProps<{
   slug: string
+  projectId?: number | null
+  canEdit?: boolean
   heroPath?: string
   cardPath?: string
   iconPath?: string
 }>()
 
-type Slide = { src: string; label: string }
+const emit = defineEmits<{
+  replaced: [field: ProjectArtField]
+}>()
 
 const collectionStore = useCollectionStore()
-
 const activeIndex = ref(0)
 const paused = ref(false)
 const failedSrcs = ref<Set<string>>(new Set())
+const projectArtLinks = ref<ProjectArtLink[]>([])
+const showReplaceForm = ref(false)
+const replacementField = ref<ProjectArtField>('cardPath')
+const replacementFile = ref<File | null>(null)
+const preserveOriginal = ref(true)
+const replacing = ref(false)
+const replacementMessage = ref('')
+const replacementError = ref(false)
 
 function normalizeImageSrc(value: string | null | undefined): string {
   if (!value) return ''
@@ -142,10 +308,18 @@ function normalizeImageSrc(value: string | null | undefined): string {
   return `/images/${clean}`
 }
 
-// Prefer the stable slug binding; the store helper falls back to a slugified
-// label match so unslugged legacy collections still show.
+function dedupeKey(src: string): string {
+  return src.replace(/([?&])v=[^&]+(&|$)/, '$1').replace(/[?&]$/, '')
+}
+
+function artImageSrc(link: ProjectArtLink): string {
+  const image = link.ArtImage
+  return normalizeImageSrc(
+    image.imagePath || `/api/art/images/${image.id}/file`,
+  )
+}
+
 const matchedCollection = computed(() => {
-  // Touch collections so this recomputes when fetchCollections resolves.
   void collectionStore.collections
   return collectionStore.findCollectionBySlug?.(props.slug) ?? null
 })
@@ -161,35 +335,48 @@ const collectionSlides = computed<Slide[]>(() => {
           (image as { path?: string | null }).path ||
           image.fileName,
       ),
-      label: `Inspiration ${index + 1}`,
+      label: `Collection ${index + 1}`,
     }))
     .filter((slide) => Boolean(slide.src))
 })
 
 const collectionSlideCount = computed(() => collectionSlides.value.length)
 
+const projectSlides = computed<Slide[]>(() =>
+  projectArtLinks.value
+    .map((link, index) => ({
+      src: artImageSrc(link),
+      label: link.ArtImage.fileName || `Inspiration ${index + 1}`,
+    }))
+    .filter((slide) => Boolean(slide.src)),
+)
+
 const slides = computed<Slide[]>(() => {
   const out: Slide[] = []
   const seen = new Set<string>()
-  const push = (src: string | null | undefined, label: string) => {
+  const push = (
+    src: string | null | undefined,
+    label: string,
+    field?: ProjectArtField,
+  ) => {
     const normalized = normalizeImageSrc(src)
-    if (!normalized || seen.has(normalized) || failedSrcs.value.has(normalized))
-      return
-    seen.add(normalized)
-    out.push({ src: normalized, label })
+    const key = dedupeKey(normalized)
+    if (!normalized || seen.has(key) || failedSrcs.value.has(normalized)) return
+    seen.add(key)
+    out.push({ src: normalized, label, field })
   }
+
+  push(props.heroPath, 'Hero', 'heroPath')
+  push(props.cardPath, 'Card', 'cardPath')
+  push(props.iconPath, 'Icon', 'imagePath')
+  for (const slide of projectSlides.value) push(slide.src, slide.label)
   for (const slide of collectionSlides.value) push(slide.src, slide.label)
-  push(props.heroPath, 'Hero')
-  push(props.cardPath, 'Card')
-  push(props.iconPath, 'Icon')
   return out
 })
 
-const activeSlide = computed<Slide>(() => {
-  return (
-    slides.value[activeIndex.value] ?? slides.value[0] ?? { src: '', label: '' }
-  )
-})
+const activeSlide = computed<Slide>(() =>
+  slides.value[activeIndex.value] ?? slides.value[0] ?? { src: '', label: '' },
+)
 
 function step(direction: number) {
   const count = slides.value.length
@@ -201,11 +388,85 @@ function dropSlide(src: string) {
   failedSrcs.value = new Set([...failedSrcs.value, src])
 }
 
+function openReplaceForm(field?: ProjectArtField) {
+  replacementField.value = field || activeSlide.value.field || 'cardPath'
+  replacementMessage.value = ''
+  replacementError.value = false
+  showReplaceForm.value = true
+  paused.value = true
+}
+
+function closeReplaceForm() {
+  if (replacing.value) return
+  showReplaceForm.value = false
+  replacementFile.value = null
+  replacementMessage.value = ''
+  replacementError.value = false
+}
+
+function handleFileChange(event: Event) {
+  const input = event.target as HTMLInputElement | null
+  replacementFile.value = input?.files?.[0] ?? null
+  replacementMessage.value = ''
+  replacementError.value = false
+}
+
+async function fetchProjectArt(force = false) {
+  if (!props.projectId) {
+    projectArtLinks.value = []
+    return
+  }
+  const query = force ? `?refresh=${Date.now()}` : ''
+  const response = await performFetch<ProjectArtLink[]>(
+    `/api/projects/${props.projectId}/art${query}`,
+    force ? { cache: 'no-store' } : {},
+  )
+  if (response.success) projectArtLinks.value = response.data ?? []
+}
+
+async function submitReplacement() {
+  if (!props.projectId || !replacementFile.value || replacing.value) return
+  replacing.value = true
+  replacementMessage.value = ''
+  replacementError.value = false
+
+  try {
+    const form = new FormData()
+    form.append('file', replacementFile.value)
+    form.append('field', replacementField.value)
+    form.append('preserveOriginal', String(preserveOriginal.value))
+
+    const response = await performFetch(
+      `/api/projects/${props.projectId}/art/replace`,
+      { method: 'POST', body: form },
+      1,
+      30_000,
+    )
+    if (!response.success) {
+      throw new Error(response.message || 'Project image replacement failed.')
+    }
+
+    replacementMessage.value =
+      response.message || 'Project image replaced successfully.'
+    replacementFile.value = null
+    await fetchProjectArt(true)
+    emit('replaced', replacementField.value)
+  } catch (error) {
+    replacementError.value = true
+    replacementMessage.value =
+      error instanceof Error ? error.message : 'Project image replacement failed.'
+  } finally {
+    replacing.value = false
+  }
+}
+
 watch(
   () => props.slug,
   () => {
     activeIndex.value = 0
     failedSrcs.value = new Set()
+    closeReplaceForm()
+    void fetchProjectArt(true)
   },
 )
 
@@ -217,14 +478,13 @@ let advanceTimer: ReturnType<typeof setInterval> | null = null
 
 onMounted(async () => {
   advanceTimer = setInterval(() => {
-    if (!paused.value && slides.value.length > 1) step(1)
+    if (!paused.value && !showReplaceForm.value && slides.value.length > 1) step(1)
   }, 6000)
 
-  try {
-    await collectionStore.fetchCollections()
-  } catch {
-    // Collections are decorative here — the static hero/card art still shows.
-  }
+  await Promise.allSettled([
+    collectionStore.fetchCollections(),
+    fetchProjectArt(),
+  ])
 })
 
 onBeforeUnmount(() => {

--- a/components/pages/conductor-art-gallery.vue
+++ b/components/pages/conductor-art-gallery.vue
@@ -5,42 +5,30 @@
     @mouseenter="paused = true"
     @mouseleave="paused = false"
   >
-    <div class="flex min-w-0 flex-wrap items-center gap-2">
+    <header class="flex min-w-0 flex-wrap items-center gap-2">
       <Icon name="kind-icon:image" class="size-4 text-secondary" />
-      <h4
-        class="min-w-0 truncate text-xs font-bold uppercase tracking-wide text-base-content/60"
-      >
+      <h4 class="truncate text-xs font-bold uppercase tracking-wide text-base-content/60">
         Project Images
       </h4>
-      <span
-        v-if="matchedCollection"
-        class="badge badge-secondary badge-xs shrink-0"
-        :title="`Art collection: ${matchedCollection.label}`"
-      >
-        {{ collectionSlideCount }} collection
+      <span v-if="matchedCollection" class="badge badge-secondary badge-xs">
+        {{ collectionSlides.length }} collection
       </span>
-      <span
-        v-if="projectSlides.length"
-        class="badge badge-accent badge-xs shrink-0"
-      >
+      <span v-if="projectSlides.length" class="badge badge-accent badge-xs">
         {{ projectSlides.length }} inspiration
       </span>
-      <span
-        v-if="slides.length"
-        class="ml-auto shrink-0 text-xs text-base-content/40"
-      >
+      <span v-if="slides.length" class="ml-auto text-xs text-base-content/40">
         {{ activeIndex + 1 }} / {{ slides.length }}
       </span>
       <button
-        v-if="canEdit && projectId"
+        v-if="mayEdit && resolvedProjectId"
         type="button"
         class="btn btn-primary btn-xs gap-1 rounded-lg"
-        @click="openReplaceForm"
+        @click="openReplaceForm()"
       >
         <Icon name="kind-icon:upload" class="size-3" />
         Submit new image
       </button>
-    </div>
+    </header>
 
     <div
       v-if="slides.length"
@@ -56,14 +44,14 @@
         />
       </Transition>
 
-      <div class="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-linear-to-t from-base-300/85 to-transparent p-3 pt-10">
-        <span
-          class="badge badge-sm border-0 bg-base-100/85 font-semibold backdrop-blur"
-        >
+      <div
+        class="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-linear-to-t from-base-300/90 to-transparent p-3 pt-10"
+      >
+        <span class="badge badge-sm border-0 bg-base-100/85 font-semibold backdrop-blur">
           {{ activeSlide.label }}
         </span>
         <button
-          v-if="canEdit && projectId && activeSlide.field"
+          v-if="mayEdit && resolvedProjectId && activeSlide.field"
           type="button"
           class="btn btn-sm gap-1 rounded-lg border-0 bg-base-100/85 shadow backdrop-blur hover:bg-base-100"
           @click="openReplaceForm(activeSlide.field)"
@@ -76,7 +64,7 @@
       <template v-if="slides.length > 1">
         <button
           type="button"
-          class="btn btn-circle btn-sm absolute left-2 top-1/2 -translate-y-1/2 border-0 bg-base-100/70 opacity-0 shadow transition-opacity hover:bg-base-100 group-hover:opacity-100"
+          class="btn btn-circle btn-sm absolute left-2 top-1/2 -translate-y-1/2 border-0 bg-base-100/70 opacity-0 shadow group-hover:opacity-100"
           aria-label="Previous image"
           @click="step(-1)"
         >
@@ -84,7 +72,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-circle btn-sm absolute right-2 top-1/2 -translate-y-1/2 border-0 bg-base-100/70 opacity-0 shadow transition-opacity hover:bg-base-100 group-hover:opacity-100"
+          class="btn btn-circle btn-sm absolute right-2 top-1/2 -translate-y-1/2 border-0 bg-base-100/70 opacity-0 shadow group-hover:opacity-100"
           aria-label="Next image"
           @click="step(1)"
         >
@@ -98,14 +86,12 @@
       class="flex min-h-[14rem] flex-1 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-base-300 bg-base-200/50 p-4 text-center"
     >
       <Icon name="kind-icon:image" class="size-8 text-base-content/20" />
-      <p class="text-xs font-semibold text-base-content/50">
-        No project images yet.
-      </p>
+      <p class="text-xs font-semibold text-base-content/50">No project images yet.</p>
       <button
-        v-if="canEdit && projectId"
+        v-if="mayEdit && resolvedProjectId"
         type="button"
         class="btn btn-primary btn-sm gap-1 rounded-xl"
-        @click="openReplaceForm"
+        @click="openReplaceForm()"
       >
         <Icon name="kind-icon:upload" class="size-4" />
         Submit first image
@@ -117,11 +103,11 @@
       class="space-y-3 rounded-xl border border-primary/25 bg-primary/5 p-3"
       @submit.prevent="submitReplacement"
     >
-      <div class="flex items-center gap-2">
+      <div class="flex items-start gap-2">
         <div>
           <p class="text-sm font-bold">Upload and replace</p>
           <p class="text-xs text-base-content/50">
-            The new image becomes the selected Project asset immediately.
+            Choose the Project asset and what happens to the previous version.
           </p>
         </div>
         <button
@@ -160,9 +146,7 @@
       </div>
 
       <fieldset class="space-y-1">
-        <legend class="text-xs font-semibold text-base-content/60">
-          Previous image
-        </legend>
+        <legend class="text-xs font-semibold text-base-content/60">Previous image</legend>
         <label class="flex cursor-pointer items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-base-100/60">
           <input
             v-model="preserveOriginal"
@@ -233,11 +217,7 @@
         :title="slide.label"
         @click="activeIndex = index"
       >
-        <img
-          :src="slide.src"
-          :alt="slide.label"
-          class="h-full w-full object-cover"
-        />
+        <img :src="slide.src" :alt="slide.label" class="h-full w-full object-cover" />
       </button>
     </div>
   </section>
@@ -246,20 +226,17 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useCollectionStore } from '@/stores/collectionStore'
+import { useProjectStore } from '@/stores/projectStore'
+import { useUserStore } from '@/stores/userStore'
 import { performFetch } from '@/stores/utils'
 
 type ProjectArtField = 'imagePath' | 'cardPath' | 'heroPath'
-type Slide = {
-  src: string
-  label: string
-  field?: ProjectArtField
-}
+type Slide = { src: string; label: string; field?: ProjectArtField }
 type ProjectArtLink = {
   createdAt: string | Date
   ArtImage: {
     id: number
     imagePath?: string | null
-    path?: string | null
     fileName?: string | null
     fileType?: string | null
   }
@@ -274,11 +251,9 @@ const props = defineProps<{
   iconPath?: string
 }>()
 
-const emit = defineEmits<{
-  replaced: [field: ProjectArtField]
-}>()
-
 const collectionStore = useCollectionStore()
+const projectStore = useProjectStore()
+const userStore = useUserStore()
 const activeIndex = ref(0)
 const paused = ref(false)
 const failedSrcs = ref<Set<string>>(new Set())
@@ -291,17 +266,15 @@ const replacing = ref(false)
 const replacementMessage = ref('')
 const replacementError = ref(false)
 
+const resolvedProject = computed(() => projectStore.projectForSlug(props.slug))
+const resolvedProjectId = computed(() => props.projectId ?? resolvedProject.value?.id ?? null)
+const mayEdit = computed(() => props.canEdit ?? userStore.isAdmin)
+
 function normalizeImageSrc(value: string | null | undefined): string {
   if (!value) return ''
   const trimmed = value.trim()
   if (!trimmed || trimmed.toLowerCase() === 'undefined') return ''
-  if (
-    trimmed.startsWith('http://') ||
-    trimmed.startsWith('https://') ||
-    trimmed.startsWith('data:image/')
-  ) {
-    return trimmed
-  }
+  if (/^(https?:|data:image\/)/.test(trimmed)) return trimmed
   const clean = trimmed.replace(/^\/?(app\/)?public\/+/, '')
   if (clean.startsWith('/')) return clean
   if (clean.startsWith('images/')) return `/${clean}`
@@ -312,13 +285,6 @@ function dedupeKey(src: string): string {
   return src.replace(/([?&])v=[^&]+(&|$)/, '$1').replace(/[?&]$/, '')
 }
 
-function artImageSrc(link: ProjectArtLink): string {
-  const image = link.ArtImage
-  return normalizeImageSrc(
-    image.imagePath || `/api/art/images/${image.id}/file`,
-  )
-}
-
 const matchedCollection = computed(() => {
   void collectionStore.collections
   return collectionStore.findCollectionBySlug?.(props.slug) ?? null
@@ -326,26 +292,23 @@ const matchedCollection = computed(() => {
 
 const collectionSlides = computed<Slide[]>(() => {
   if (!matchedCollection.value) return []
-  const images =
-    collectionStore.getCollectionImages?.(matchedCollection.value.id) ?? []
+  const images = collectionStore.getCollectionImages?.(matchedCollection.value.id) ?? []
   return images
     .map((image, index) => ({
       src: normalizeImageSrc(
-        image.imagePath ||
-          (image as { path?: string | null }).path ||
-          image.fileName,
+        image.imagePath || (image as { path?: string | null }).path || image.fileName,
       ),
       label: `Collection ${index + 1}`,
     }))
     .filter((slide) => Boolean(slide.src))
 })
 
-const collectionSlideCount = computed(() => collectionSlides.value.length)
-
 const projectSlides = computed<Slide[]>(() =>
   projectArtLinks.value
     .map((link, index) => ({
-      src: artImageSrc(link),
+      src: normalizeImageSrc(
+        link.ArtImage.imagePath || `/api/art/images/${link.ArtImage.id}/file`,
+      ),
       label: link.ArtImage.fileName || `Inspiration ${index + 1}`,
     }))
     .filter((slide) => Boolean(slide.src)),
@@ -380,8 +343,7 @@ const activeSlide = computed<Slide>(() =>
 
 function step(direction: number) {
   const count = slides.value.length
-  if (!count) return
-  activeIndex.value = (activeIndex.value + direction + count) % count
+  if (count) activeIndex.value = (activeIndex.value + direction + count) % count
 }
 
 function dropSlide(src: string) {
@@ -412,20 +374,22 @@ function handleFileChange(event: Event) {
 }
 
 async function fetchProjectArt(force = false) {
-  if (!props.projectId) {
+  const projectId = resolvedProjectId.value
+  if (!projectId) {
     projectArtLinks.value = []
     return
   }
   const query = force ? `?refresh=${Date.now()}` : ''
   const response = await performFetch<ProjectArtLink[]>(
-    `/api/projects/${props.projectId}/art${query}`,
+    `/api/projects/${projectId}/art${query}`,
     force ? { cache: 'no-store' } : {},
   )
   if (response.success) projectArtLinks.value = response.data ?? []
 }
 
 async function submitReplacement() {
-  if (!props.projectId || !replacementFile.value || replacing.value) return
+  const projectId = resolvedProjectId.value
+  if (!projectId || !replacementFile.value || replacing.value) return
   replacing.value = true
   replacementMessage.value = ''
   replacementError.value = false
@@ -437,7 +401,7 @@ async function submitReplacement() {
     form.append('preserveOriginal', String(preserveOriginal.value))
 
     const response = await performFetch(
-      `/api/projects/${props.projectId}/art/replace`,
+      `/api/projects/${projectId}/art/replace`,
       { method: 'POST', body: form },
       1,
       30_000,
@@ -446,11 +410,12 @@ async function submitReplacement() {
       throw new Error(response.message || 'Project image replacement failed.')
     }
 
-    replacementMessage.value =
-      response.message || 'Project image replaced successfully.'
+    await Promise.all([
+      projectStore.fetchProject(projectId),
+      fetchProjectArt(true),
+    ])
+    replacementMessage.value = response.message || 'Project image replaced successfully.'
     replacementFile.value = null
-    await fetchProjectArt(true)
-    emit('replaced', replacementField.value)
   } catch (error) {
     replacementError.value = true
     replacementMessage.value =
@@ -461,7 +426,7 @@ async function submitReplacement() {
 }
 
 watch(
-  () => props.slug,
+  [() => props.slug, resolvedProjectId],
   () => {
     activeIndex.value = 0
     failedSrcs.value = new Set()
@@ -475,16 +440,11 @@ watch(slides, (next) => {
 })
 
 let advanceTimer: ReturnType<typeof setInterval> | null = null
-
 onMounted(async () => {
   advanceTimer = setInterval(() => {
     if (!paused.value && !showReplaceForm.value && slides.value.length > 1) step(1)
   }, 6000)
-
-  await Promise.allSettled([
-    collectionStore.fetchCollections(),
-    fetchProjectArt(),
-  ])
+  await Promise.allSettled([collectionStore.fetchCollections(), fetchProjectArt()])
 })
 
 onBeforeUnmount(() => {
@@ -497,7 +457,6 @@ onBeforeUnmount(() => {
 .conductor-slide-fade-leave-active {
   transition: opacity 400ms ease;
 }
-
 .conductor-slide-fade-enter-from,
 .conductor-slide-fade-leave-to {
   opacity: 0;

--- a/server/api/art/images/[id]/file.get.ts
+++ b/server/api/art/images/[id]/file.get.ts
@@ -1,0 +1,97 @@
+// /server/api/art/images/[id]/file.get.ts
+import {
+  createError,
+  defineEventHandler,
+  getHeader,
+  getRouterParam,
+  sendRedirect,
+  setHeader,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { validateApiKey } from '~/server/utils/validateKey'
+
+const CONTENT_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  webp: 'image/webp',
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = Number(getRouterParam(event, 'id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid ArtImage ID.' })
+    }
+
+    const image = await prisma.artImage.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+        imageData: true,
+        imagePath: true,
+        fileType: true,
+        isPublic: true,
+        isMature: true,
+        isActive: true,
+        updatedAt: true,
+      },
+    })
+
+    if (!image || image.isActive === false) {
+      throw createError({ statusCode: 404, message: 'Art image not found.' })
+    }
+
+    let mayView = image.isPublic === true && image.isMature !== true
+    if (!mayView && getHeader(event, 'authorization')?.startsWith('Bearer ')) {
+      try {
+        const auth = await validateApiKey(event)
+        mayView = Boolean(
+          auth.isValid &&
+            auth.user &&
+            (auth.user.Role === 'ADMIN' || auth.user.id === image.userId),
+        )
+      } catch {
+        mayView = false
+      }
+    }
+
+    if (!mayView) {
+      throw createError({ statusCode: 403, message: 'You cannot view this image.' })
+    }
+
+    if (image.imagePath && !image.imagePath.includes(`/api/art/images/${id}/file`)) {
+      return sendRedirect(event, image.imagePath, 302)
+    }
+
+    if (!image.imageData) {
+      throw createError({ statusCode: 404, message: 'Image bytes are unavailable.' })
+    }
+
+    const fileType = String(image.fileType || '').toLowerCase()
+    setHeader(
+      event,
+      'Content-Type',
+      CONTENT_TYPES[fileType] || 'application/octet-stream',
+    )
+    setHeader(
+      event,
+      'Cache-Control',
+      image.isPublic
+        ? 'public, max-age=31536000, immutable'
+        : 'private, max-age=3600',
+    )
+    setHeader(event, 'X-Content-Type-Options', 'nosniff')
+    return Buffer.from(image.imageData, 'base64')
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to load art image.',
+    }
+  }
+})

--- a/server/api/projects/[id]/art/index.get.ts
+++ b/server/api/projects/[id]/art/index.get.ts
@@ -1,0 +1,83 @@
+// /server/api/projects/[id]/art/index.get.ts
+import {
+  createError,
+  defineEventHandler,
+  getHeader,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { validateApiKey } from '~/server/utils/validateKey'
+import { getProjectId } from '../../index'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const id = getProjectId(event)
+    const project = await prisma.project.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+        isActive: true,
+        isPublic: true,
+        isMature: true,
+        ArtImageLinks: {
+          orderBy: { createdAt: 'desc' },
+          take: 40,
+          select: {
+            createdAt: true,
+            ArtImage: {
+              select: {
+                id: true,
+                imagePath: true,
+                path: true,
+                fileName: true,
+                fileType: true,
+                isActive: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    if (!project) {
+      throw createError({ statusCode: 404, message: 'Project not found.' })
+    }
+
+    let mayView =
+      project.isActive && project.isPublic && project.isMature !== true
+    if (!mayView && getHeader(event, 'authorization')?.startsWith('Bearer ')) {
+      try {
+        const auth = await validateApiKey(event)
+        mayView = Boolean(
+          auth.isValid &&
+            auth.user &&
+            (auth.user.Role === 'ADMIN' || auth.user.id === project.userId),
+        )
+      } catch {
+        mayView = false
+      }
+    }
+
+    if (!mayView) {
+      throw createError({ statusCode: 403, message: 'You cannot view this project art.' })
+    }
+
+    return {
+      success: true,
+      data: project.ArtImageLinks.filter(
+        (link) => link.ArtImage.isActive !== false,
+      ),
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      data: [],
+      statusCode: handled.statusCode || 500,
+      message: handled.message || 'Failed to load project art.',
+    }
+  }
+})

--- a/server/api/projects/[id]/art/replace.post.ts
+++ b/server/api/projects/[id]/art/replace.post.ts
@@ -1,0 +1,219 @@
+// /server/api/projects/[id]/art/replace.post.ts
+import {
+  createError,
+  defineEventHandler,
+  getHeader,
+  readMultipartFormData,
+} from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import { uploadArtImage } from '~/server/utils/UploadArtImage'
+import {
+  assertProjectAccess,
+  getProjectId,
+  projectInclude,
+} from '../../index'
+
+const MAX_IMAGE_BYTES = 15 * 1024 * 1024
+const MAX_REQUEST_BYTES = MAX_IMAGE_BYTES + 1024 * 1024
+const IMAGE_TYPES: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpeg',
+  'image/webp': 'webp',
+}
+const PROJECT_ART_FIELDS = new Set(['imagePath', 'cardPath', 'heroPath'])
+
+type ProjectArtField = 'imagePath' | 'cardPath' | 'heroPath'
+
+type MultipartForm = Awaited<ReturnType<typeof readMultipartFormData>>
+
+function formValue(form: MultipartForm, name: string): string {
+  return form?.find((entry) => entry.name === name)?.data?.toString().trim() || ''
+}
+
+function parseBoolean(value: string, fallback: boolean): boolean {
+  if (!value) return fallback
+  if (['true', '1', 'yes', 'on'].includes(value.toLowerCase())) return true
+  if (['false', '0', 'no', 'off'].includes(value.toLowerCase())) return false
+  throw createError({ statusCode: 400, message: 'Invalid boolean value.' })
+}
+
+function imageIdFromApiPath(value: string | null): number | null {
+  const match = value?.match(/\/api\/art\/images\/(\d+)\/file/)
+  const id = Number(match?.[1])
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+function extensionFromPath(value: string): string {
+  const match = value.match(/\.([a-z0-9]+)(?:[?#].*)?$/i)
+  const extension = match?.[1]?.toLowerCase()
+  return extension && ['png', 'jpeg', 'jpg', 'webp'].includes(extension)
+    ? extension
+    : 'webp'
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const contentLength = Number(getHeader(event, 'content-length') || 0)
+    if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+      throw createError({
+        statusCode: 413,
+        message: 'Image upload is too large. Maximum image size is 15 MB.',
+      })
+    }
+
+    const id = getProjectId(event)
+    const auth = await requireApiUser(event)
+    const project = await prisma.project.findUnique({ where: { id } })
+    if (!project) {
+      throw createError({ statusCode: 404, message: 'Project not found.' })
+    }
+    assertProjectAccess(project, auth.user)
+
+    const form = await readMultipartFormData(event)
+    const imageFile = form?.find(
+      (entry) => entry.name === 'file' || entry.name === 'image',
+    )
+    if (!imageFile?.data?.length) {
+      throw createError({ statusCode: 400, message: 'Choose an image to upload.' })
+    }
+    if (imageFile.data.length > MAX_IMAGE_BYTES) {
+      throw createError({
+        statusCode: 413,
+        message: 'Image upload is too large. Maximum image size is 15 MB.',
+      })
+    }
+
+    const mimeType = String(imageFile.type || '').toLowerCase()
+    const fileType = IMAGE_TYPES[mimeType]
+    if (!fileType) {
+      throw createError({
+        statusCode: 415,
+        message: 'Only PNG, JPEG, and WebP images are supported.',
+      })
+    }
+
+    const field = formValue(form, 'field') as ProjectArtField
+    if (!PROJECT_ART_FIELDS.has(field)) {
+      throw createError({
+        statusCode: 400,
+        message: 'Choose Icon, Card, or Hero as the image target.',
+      })
+    }
+
+    const preserveOriginal = parseBoolean(
+      formValue(form, 'preserveOriginal'),
+      true,
+    )
+    const slug = project.conductorSlug || project.slug || `project-${project.id}`
+    const label = field === 'imagePath' ? 'icon' : field === 'cardPath' ? 'card' : 'hero'
+    const currentPath = project[field]
+
+    const uploaded = await uploadArtImage({
+      uploadedFile: {
+        data: imageFile.data,
+        filename: imageFile.filename || `${slug}-${label}.${fileType}`,
+      },
+      userId: auth.user.id,
+      galleryName: `project-${slug}`,
+      fileType,
+      fileName: `${slug}-${label}`,
+      path: `project:${project.id}:${field}`,
+      artPrompt: `Uploaded replacement ${label} for ${project.title}`,
+      designer: auth.user.username || `User ${auth.user.id}`,
+      isPublic: project.isPublic,
+      isMature: project.isMature,
+    })
+
+    const newPath = `/api/art/images/${uploaded.id}/file?v=${encodeURIComponent(
+      uploaded.updatedAt?.toISOString() || uploaded.createdAt.toISOString(),
+    )}`
+
+    const updated = await prisma.$transaction(async (tx) => {
+      let oldImageId = imageIdFromApiPath(currentPath)
+      if (!oldImageId && currentPath) {
+        const existing = await tx.artImage.findFirst({
+          where: {
+            OR: [{ imagePath: currentPath }, { path: currentPath }],
+          },
+          select: { id: true },
+        })
+        oldImageId = existing?.id ?? null
+      }
+
+      if (preserveOriginal && currentPath) {
+        if (!oldImageId) {
+          const previous = await tx.artImage.create({
+            data: {
+              userId: project.userId || auth.user.id,
+              fileName: `${slug}-${label}-previous`,
+              fileType: extensionFromPath(currentPath),
+              imagePath: currentPath,
+              path: `project:${project.id}:${field}:previous`,
+              artPrompt: `Previous ${label} retained from ${project.title}`,
+              designer: project.designer || auth.user.username || 'Kind Robots',
+              isPublic: project.isPublic,
+              isMature: project.isMature,
+              isActive: true,
+            },
+            select: { id: true },
+          })
+          oldImageId = previous.id
+        }
+
+        await tx.projectArtImage.upsert({
+          where: {
+            projectId_artImageId: { projectId: project.id, artImageId: oldImageId },
+          },
+          create: { projectId: project.id, artImageId: oldImageId },
+          update: {},
+        })
+      } else if (oldImageId) {
+        await tx.projectArtImage.deleteMany({
+          where: { projectId: project.id, artImageId: oldImageId },
+        })
+      }
+
+      await tx.projectArtImage.upsert({
+        where: {
+          projectId_artImageId: {
+            projectId: project.id,
+            artImageId: uploaded.id,
+          },
+        },
+        create: { projectId: project.id, artImageId: uploaded.id },
+        update: {},
+      })
+
+      await tx.project.update({
+        where: { id: project.id },
+        data: { [field]: newPath },
+      })
+
+      return tx.project.findUnique({
+        where: { id: project.id },
+        include: projectInclude,
+      })
+    })
+
+    event.node.res.statusCode = 201
+    return {
+      success: true,
+      message: preserveOriginal
+        ? `${label} replaced; the previous image was kept as inspiration.`
+        : `${label} replaced; the previous project reference was removed.`,
+      data: updated,
+      statusCode: 201,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return {
+      success: false,
+      message: handled.message || 'Failed to replace project art.',
+      data: null,
+      statusCode: handled.statusCode || 500,
+    }
+  }
+})


### PR DESCRIPTION
## What this adds
- A simple **Submit new image** control inside each individual Project image gallery.
- Choose the target asset: Icon, Card, or Hero.
- Upload PNG, JPEG, or WebP up to 15 MB.
- Choose whether the previous image is retained as Project inspiration or removed from the Project gallery.
- Immediate Project refresh after replacement, using a new versioned ArtImage content URL so the browser does not keep showing the old file.

## Data behavior
- Uploaded replacements use the existing authenticated ArtImage upload/storage model.
- Current and retained versions use the existing `ProjectArtImage` relation; no new gallery schema is introduced.
- Keeping the old image creates/reuses an ArtImage metadata record and links it to the Project.
- Removing the old image deletes its Project inspiration association; it does not destructively delete an externally hosted GitHub/media source.

## API additions
- `POST /api/projects/:id/art/replace`
- `GET /api/projects/:id/art`
- `GET /api/art/images/:id/file`

## Safety
- Project ownership/admin access is enforced on replacement.
- Private or mature uploaded images require owner/admin authorization when streamed.
- File type and 15 MB size limits are enforced server-side.