### PR TITLE
Superseded: fix startup animation loading and reload order

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -1,0 +1,20 @@
+html.kr-full-startup {
+  background: #000;
+}
+
+html.kr-full-startup::before {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483646;
+  background: #000;
+  content: '';
+  pointer-events: none;
+}
+
+.kr-boot-curtain {
+  display: none !important;
+}
+
+html.kr-full-startup .kr-boot-curtain {
+  display: block !important;
+}

--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -40,6 +40,7 @@ import { useButterflyStore } from '@/stores/butterflyStore'
 import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
 import {
+  clearStartupCover,
   consumeForcedFullStartup,
   isBrowserReload,
 } from '@/utils/startupLaunch'
@@ -121,13 +122,25 @@ if (startupMode.value === 'full') {
   markStartupSequenceSeen()
 }
 
+function releasePrehydrateCover(): void {
+  if (!import.meta.client) return
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      clearStartupCover()
+    })
+  })
+}
+
 function handleOverlayCovered() {
   if (coveredEmitted.value) return
   coveredEmitted.value = true
   emit('covered')
+  releasePrehydrateCover()
 }
 
 function handleOverlayHiding() {
+  clearStartupCover()
   butterflyStore.setShowSwarm(false)
 }
 
@@ -291,10 +304,6 @@ onMounted(() => {
 
 :global(.kr-shell.bg-black) {
   background-color: transparent !important;
-}
-
-:global(.kr-boot-curtain) {
-  display: none !important;
 }
 
 :global(.loading-overlay),

--- a/components/admin/startup-intro-visual.vue
+++ b/components/admin/startup-intro-visual.vue
@@ -1,6 +1,5 @@
 <template>
   <img
-    v-if="visualSrc"
     :key="visualSrc"
     :src="visualSrc"
     alt="Kind Robots"
@@ -17,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeUnmount, ref } from 'vue'
 
 interface StartupAnimationsResponse {
   animations?: string[]
@@ -25,87 +24,104 @@ interface StartupAnimationsResponse {
 
 const LOGO_SRC = '/images/kindlogo_new.webp'
 const ANIMATION_CHANCE = 0.5
-const FALLBACK_WAIT_MS = 900
-const REQUEST_TIMEOUT_MS = 1_800
+const REQUEST_TIMEOUT_MS = 2_800
+const IMAGE_LOAD_TIMEOUT_MS = 3_200
 
 const shouldTryAnimation = import.meta.client && Math.random() < ANIMATION_CHANCE
-const visualSrc = ref(shouldTryAnimation ? '' : LOGO_SRC)
+const visualSrc = ref(LOGO_SRC)
 const visualReady = ref(false)
 
 let destroyed = false
-let fallbackCommitted = false
-let fallbackTimer: ReturnType<typeof setTimeout> | null = null
 let requestController: AbortController | null = null
+let cancelPreload: (() => void) | null = null
 
 function setVisual(src: string): void {
-  if (destroyed) return
+  if (destroyed || visualSrc.value === src) return
   visualReady.value = false
   visualSrc.value = src
 }
 
-function commitLogoFallback(): void {
-  fallbackCommitted = true
+function useLogoFallback(): void {
+  if (visualSrc.value === LOGO_SRC) return
   setVisual(LOGO_SRC)
 }
 
-function useLogoFallback(): void {
-  if (visualSrc.value === LOGO_SRC) return
-  commitLogoFallback()
-}
+function preloadAnimation(src: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const image = new Image()
+    let settled = false
 
-function clearFallbackTimer(): void {
-  if (!fallbackTimer) return
-  clearTimeout(fallbackTimer)
-  fallbackTimer = null
+    const finish = (loaded: boolean) => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeoutId)
+      image.onload = null
+      image.onerror = null
+      if (cancelPreload === cancel) cancelPreload = null
+      resolve(loaded)
+    }
+
+    const cancel = () => finish(false)
+    const timeoutId = window.setTimeout(cancel, IMAGE_LOAD_TIMEOUT_MS)
+
+    cancelPreload = cancel
+    image.onload = () => finish(true)
+    image.onerror = cancel
+    image.src = src
+  })
 }
 
 async function selectAnimation(): Promise<void> {
-  fallbackTimer = setTimeout(commitLogoFallback, FALLBACK_WAIT_MS)
   requestController = new AbortController()
-  const requestTimeout = setTimeout(
+  const requestTimeout = window.setTimeout(
     () => requestController?.abort(),
     REQUEST_TIMEOUT_MS,
   )
 
   try {
     const fetchResponse = await fetch('/api/startup/animations', {
+      cache: 'force-cache',
       headers: { Accept: 'application/json' },
       signal: requestController.signal,
     })
-    if (!fetchResponse.ok) throw new Error(`Animation catalog ${fetchResponse.status}`)
+    if (!fetchResponse.ok) {
+      throw new Error(`Animation catalog ${fetchResponse.status}`)
+    }
 
     const response = (await fetchResponse.json()) as StartupAnimationsResponse
-    if (destroyed || fallbackCommitted) return
+    if (destroyed) return
 
     const animations = (response.animations || []).filter((url) =>
       /^\/images\/startup-animations\/launch-[a-z0-9][a-z0-9-]*\.webp$/i.test(
         url,
       ),
     )
-    if (!animations.length) {
-      commitLogoFallback()
-      return
-    }
+    if (!animations.length) return
 
-    clearFallbackTimer()
     const selected = animations[Math.floor(Math.random() * animations.length)]
-    setVisual(selected || LOGO_SRC)
+    if (!selected) return
+
+    const loaded = await preloadAnimation(selected)
+    if (!loaded || destroyed) return
+
+    setVisual(selected)
   } catch {
-    if (!fallbackCommitted) commitLogoFallback()
+    // The logo remains visible when catalog discovery or preloading fails.
   } finally {
-    clearTimeout(requestTimeout)
+    window.clearTimeout(requestTimeout)
     requestController = null
   }
 }
 
-onMounted(() => {
-  if (shouldTryAnimation) void selectAnimation()
-})
+if (shouldTryAnimation) {
+  void selectAnimation()
+}
 
 onBeforeUnmount(() => {
   destroyed = true
-  clearFallbackTimer()
   requestController?.abort()
   requestController = null
+  cancelPreload?.()
+  cancelPreload = null
 })
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,10 +32,54 @@ const buildId =
   process.env.NUXT_PUBLIC_BUILD_ID ||
   'development'
 
+const startupPrehydrateScript = `(() => {
+  const FORCE_KEY = 'kind-robots-force-full-startup-v1'
+  const SEEN_KEY = 'kind-robots-startup-build-v1'
+  const COVER_CLASS = 'kr-full-startup'
+  const BUILD_ID = ${JSON.stringify(buildId)}
+
+  let forced = false
+  let reloading = false
+  let shouldCover = false
+
+  try {
+    forced = sessionStorage.getItem(FORCE_KEY) === '1'
+  } catch {}
+
+  try {
+    const navigation = performance.getEntriesByType('navigation')[0]
+    reloading = navigation?.type === 'reload'
+  } catch {}
+
+  if (forced) {
+    shouldCover = true
+  } else if (!reloading) {
+    try {
+      shouldCover = localStorage.getItem(SEEN_KEY) !== BUILD_ID
+    } catch {
+      shouldCover = true
+    }
+  }
+
+  if (shouldCover) {
+    document.documentElement.classList.add(COVER_CLASS)
+  }
+})()`
+
 generateWonderLabComponentMetadata()
 
 export default defineNuxtConfig({
   compatibilityDate: '2026-06-01',
+  app: {
+    head: {
+      script: [
+        {
+          innerHTML: startupPrehydrateScript,
+          tagPosition: 'head',
+        },
+      ],
+    },
+  },
   content: {
     experimental: {
       sqliteConnector: 'native',
@@ -107,7 +151,7 @@ export default defineNuxtConfig({
     },
   },
 
-  css: ['~/assets/css/tailwind.css'],
+  css: ['~/assets/css/startup-cover.css', '~/assets/css/tailwind.css'],
 
   runtimeConfig: {
     openaiApiKey: process.env.OPENAI_API_KEY || '',

--- a/server/api/startup/animations.get.ts
+++ b/server/api/startup/animations.get.ts
@@ -1,18 +1,74 @@
-import { defineEventHandler, setHeader } from 'h3'
+import { defineEventHandler, getQuery, setHeader } from 'h3'
 import { listStartupAnimationUrls } from '@/server/utils/startupAnimations'
+
+const DEFAULT_MEDIA_ORIGIN = 'https://media.acrocatranch.com'
+const DIAGNOSTIC_TIMEOUT_MS = 4_000
+
+export interface StartupAnimationDiagnostic {
+  url: string
+  status: number | null
+  bytes: number | null
+  contentType: string | null
+  elapsedMs: number
+}
 
 export interface StartupAnimationsResponse {
   animations: string[]
+  diagnostics?: StartupAnimationDiagnostic[]
+}
+
+async function inspectAnimation(url: string): Promise<StartupAnimationDiagnostic> {
+  const origin = (process.env.MEDIA_ORIGIN || DEFAULT_MEDIA_ORIGIN).replace(/\/+$/, '')
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), DIAGNOSTIC_TIMEOUT_MS)
+  const startedAt = Date.now()
+
+  try {
+    const response = await fetch(`${origin}${url}`, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+    })
+    const rawLength = response.headers.get('content-length')
+    const parsedLength = rawLength ? Number(rawLength) : Number.NaN
+
+    return {
+      url,
+      status: response.status,
+      bytes: Number.isFinite(parsedLength) ? parsedLength : null,
+      contentType: response.headers.get('content-type'),
+      elapsedMs: Date.now() - startedAt,
+    }
+  } catch {
+    return {
+      url,
+      status: null,
+      bytes: null,
+      contentType: null,
+      elapsedMs: Date.now() - startedAt,
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 export default defineEventHandler(async (event): Promise<StartupAnimationsResponse> => {
+  const diagnosticsRequested = getQuery(event).diagnostics === '1'
+
   setHeader(
     event,
     'Cache-Control',
-    'public, max-age=60, s-maxage=60, stale-while-revalidate=300',
+    diagnosticsRequested
+      ? 'private, no-store'
+      : 'public, max-age=60, s-maxage=60, stale-while-revalidate=300',
   )
 
+  const animations = await listStartupAnimationUrls()
+
   return {
-    animations: await listStartupAnimationUrls(),
+    animations,
+    ...(diagnosticsRequested
+      ? { diagnostics: await Promise.all(animations.map(inspectAnimation)) }
+      : {}),
   }
 })

--- a/utils/startupLaunch.ts
+++ b/utils/startupLaunch.ts
@@ -1,4 +1,10 @@
 export const FORCE_FULL_STARTUP_KEY = 'kind-robots-force-full-startup-v1'
+export const STARTUP_COVER_CLASS = 'kr-full-startup'
+
+export function clearStartupCover(): void {
+  if (!import.meta.client) return
+  document.documentElement.classList.remove(STARTUP_COVER_CLASS)
+}
 
 export function requestFullStartupReload(): void {
   if (!import.meta.client) return
@@ -9,7 +15,20 @@ export function requestFullStartupReload(): void {
     // Reload anyway; the next visit may fall back to normal startup detection.
   }
 
-  window.location.reload()
+  document.documentElement.classList.add(STARTUP_COVER_CLASS)
+
+  let reloadStarted = false
+  const reload = () => {
+    if (reloadStarted) return
+    reloadStarted = true
+    window.location.reload()
+  }
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(reload)
+  })
+
+  window.setTimeout(reload, 180)
 }
 
 export function consumeForcedFullStartup(): boolean {


### PR DESCRIPTION
Superseded by #1178. This identical patch was moved from `agent/*` to `fix/*` because `vercel.json` intentionally disables preview deployments for `agent/*` branches.