### PR TITLE
Fix startup animation loading and reload order

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -1,0 +1,20 @@
+html.kr-full-startup {
+  background: #000;
+}
+
+html.kr-full-startup::before {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483646;
+  background: #000;
+  content: '';
+  pointer-events: none;
+}
+
+.kr-boot-curtain {
+  display: none !important;
+}
+
+html.kr-full-startup .kr-boot-curtain {
+  display: block !important;
+}

--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -40,6 +40,7 @@ import { useButterflyStore } from '@/stores/butterflyStore'
 import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 import { ensureBuildersRegistered } from '@/stores/registerBuilderStore'
 import {
+  clearStartupCover,
   consumeForcedFullStartup,
   isBrowserReload,
 } from '@/utils/startupLaunch'
@@ -121,13 +122,25 @@ if (startupMode.value === 'full') {
   markStartupSequenceSeen()
 }
 
+function releasePrehydrateCover(): void {
+  if (!import.meta.client) return
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      clearStartupCover()
+    })
+  })
+}
+
 function handleOverlayCovered() {
   if (coveredEmitted.value) return
   coveredEmitted.value = true
   emit('covered')
+  releasePrehydrateCover()
 }
 
 function handleOverlayHiding() {
+  clearStartupCover()
   butterflyStore.setShowSwarm(false)
 }
 
@@ -291,10 +304,6 @@ onMounted(() => {
 
 :global(.kr-shell.bg-black) {
   background-color: transparent !important;
-}
-
-:global(.kr-boot-curtain) {
-  display: none !important;
 }
 
 :global(.loading-overlay),

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -12,7 +12,7 @@
       <div class="loading-heading">Building Kind Robots...</div>
 
       <div class="loading-logo-frame">
-        <startup-intro-visual />
+        <startup-intro-visual @settled="handleIntroVisualSettled" />
       </div>
 
       <div class="loading-status">
@@ -53,6 +53,8 @@ const currentMessage = ref('Wiring robots for suspicious levels of charm...')
 const messageKey = ref(0)
 const fadeOverlay = ref(false)
 const minimumSequenceComplete = ref(false)
+const introVisualSettled = ref(false)
+const introVisualKind = ref<'logo' | 'animation'>('logo')
 const hiddenEmitted = ref(false)
 const exitRequested = ref(false)
 
@@ -60,6 +62,7 @@ const EXTRA_MESSAGE_COUNT = 2
 const EXTRA_MESSAGE_MS = 1250
 const ROTATING_MESSAGE_MS = 1600
 const READY_HOLD_MS = 450
+const ANIMATION_VISIBLE_HOLD_MS = 1500
 const MIN_TOTAL_MS =
   (EXTRA_MESSAGE_COUNT + 1) * EXTRA_MESSAGE_MS + READY_HOLD_MS
 const OVERLAY_FADE_MS = 650
@@ -128,6 +131,7 @@ function doFade() {
 function scheduleFade() {
   if (!props.storesReady) return
   if (!minimumSequenceComplete.value) return
+  if (!introVisualSettled.value) return
   if (fadeOverlay.value) return
   if (startupStore.immersive) return
   if (readyHoldTimeoutId) return
@@ -135,13 +139,22 @@ function scheduleFade() {
   clearRotation()
 
   const elapsed = Date.now() - startTime
+  const minimumRemaining = Math.max(READY_HOLD_MS, MIN_TOTAL_MS - elapsed)
   const holdNeeded = exitRequested.value
     ? 0
-    : Math.max(READY_HOLD_MS, MIN_TOTAL_MS - elapsed)
+    : introVisualKind.value === 'animation'
+      ? Math.max(ANIMATION_VISIBLE_HOLD_MS, minimumRemaining)
+      : minimumRemaining
 
   readyHoldTimeoutId = setTimeout(() => {
     doFade()
   }, holdNeeded)
+}
+
+function handleIntroVisualSettled(kind: 'logo' | 'animation') {
+  introVisualKind.value = kind
+  introVisualSettled.value = true
+  scheduleFade()
 }
 
 function handleTransitionEnd(event: TransitionEvent) {
@@ -159,7 +172,7 @@ async function runVisualSequence() {
 
   minimumSequenceComplete.value = true
 
-  if (props.storesReady) {
+  if (props.storesReady && introVisualSettled.value) {
     scheduleFade()
     return
   }
@@ -167,7 +180,7 @@ async function runVisualSequence() {
   rotationIntervalId = setInterval(() => {
     if (destroyed) return
     nextMessage()
-    if (props.storesReady) scheduleFade()
+    if (props.storesReady && introVisualSettled.value) scheduleFade()
   }, ROTATING_MESSAGE_MS)
 }
 
@@ -331,7 +344,7 @@ onBeforeUnmount(() => {
   animation: loading-logo-wobble 10s ease-in-out infinite alternate;
 }
 
-.loading-logo {
+:deep(.loading-logo) {
   position: relative;
   z-index: 1;
   width: clamp(16rem, 58vw, 34rem);
@@ -359,12 +372,12 @@ onBeforeUnmount(() => {
   will-change: opacity, transform;
 }
 
-.loading-logo--ready {
+:deep(.loading-logo--ready) {
   opacity: 1;
   transform: translateY(0) scale(1);
 }
 
-.loading-overlay--fade .loading-logo {
+.loading-overlay--fade :deep(.loading-logo) {
   opacity: 0;
   transform: translateY(-0.5rem) scale(1.04);
   transition-duration: 650ms;
@@ -438,7 +451,7 @@ onBeforeUnmount(() => {
 
 @media (prefers-reduced-motion: reduce) {
   .loading-content,
-  .loading-logo,
+  :deep(.loading-logo),
   .loading-logo-frame::before,
   .loading-logo-frame::after {
     animation: none;

--- a/components/admin/startup-intro-visual.vue
+++ b/components/admin/startup-intro-visual.vue
@@ -10,30 +10,44 @@
     loading="eager"
     fetchpriority="high"
     decoding="async"
-    @load="visualReady = true"
+    @load="handleVisualLoad"
     @error="useLogoFallback"
   />
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 interface StartupAnimationsResponse {
   animations?: string[]
 }
 
+type IntroVisualKind = 'logo' | 'animation'
+
+const emit = defineEmits<{
+  settled: [kind: IntroVisualKind]
+}>()
+
 const LOGO_SRC = '/images/kindlogo_new.webp'
 const ANIMATION_CHANCE = 0.5
-const REQUEST_TIMEOUT_MS = 2_800
-const IMAGE_LOAD_TIMEOUT_MS = 3_200
+const REQUEST_TIMEOUT_MS = 3_500
+const IMAGE_LOAD_TIMEOUT_MS = 8_000
 
 const shouldTryAnimation = import.meta.client && Math.random() < ANIMATION_CHANCE
 const visualSrc = ref(LOGO_SRC)
 const visualReady = ref(false)
 
 let destroyed = false
+let animationAttemptPending = shouldTryAnimation
+let settledEmitted = false
 let requestController: AbortController | null = null
 let cancelPreload: (() => void) | null = null
+
+function emitSettled(kind: IntroVisualKind): void {
+  if (destroyed || settledEmitted) return
+  settledEmitted = true
+  emit('settled', kind)
+}
 
 function setVisual(src: string): void {
   if (destroyed || visualSrc.value === src) return
@@ -41,9 +55,26 @@ function setVisual(src: string): void {
   visualSrc.value = src
 }
 
+function settleOnLogo(): void {
+  animationAttemptPending = false
+  if (visualSrc.value !== LOGO_SRC) setVisual(LOGO_SRC)
+  if (visualReady.value) emitSettled('logo')
+}
+
 function useLogoFallback(): void {
-  if (visualSrc.value === LOGO_SRC) return
-  setVisual(LOGO_SRC)
+  settleOnLogo()
+}
+
+function handleVisualLoad(): void {
+  visualReady.value = true
+
+  if (visualSrc.value !== LOGO_SRC) {
+    animationAttemptPending = false
+    emitSettled('animation')
+    return
+  }
+
+  if (!animationAttemptPending) emitSettled('logo')
 }
 
 function preloadAnimation(src: string): Promise<boolean> {
@@ -96,26 +127,39 @@ async function selectAnimation(): Promise<void> {
         url,
       ),
     )
-    if (!animations.length) return
+    if (!animations.length) {
+      settleOnLogo()
+      return
+    }
 
     const selected = animations[Math.floor(Math.random() * animations.length)]
-    if (!selected) return
+    if (!selected) {
+      settleOnLogo()
+      return
+    }
 
     const loaded = await preloadAnimation(selected)
-    if (!loaded || destroyed) return
+    if (!loaded || destroyed) {
+      settleOnLogo()
+      return
+    }
 
     setVisual(selected)
   } catch {
-    // The logo remains visible when catalog discovery or preloading fails.
+    settleOnLogo()
   } finally {
     window.clearTimeout(requestTimeout)
     requestController = null
   }
 }
 
-if (shouldTryAnimation) {
-  void selectAnimation()
-}
+onMounted(() => {
+  if (shouldTryAnimation) {
+    void selectAnimation()
+  } else if (visualReady.value) {
+    emitSettled('logo')
+  }
+})
 
 onBeforeUnmount(() => {
   destroyed = true

--- a/components/admin/startup-intro-visual.vue
+++ b/components/admin/startup-intro-visual.vue
@@ -1,6 +1,5 @@
 <template>
   <img
-    v-if="visualSrc"
     :key="visualSrc"
     :src="visualSrc"
     alt="Kind Robots"
@@ -17,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeUnmount, ref } from 'vue'
 
 interface StartupAnimationsResponse {
   animations?: string[]
@@ -25,87 +24,104 @@ interface StartupAnimationsResponse {
 
 const LOGO_SRC = '/images/kindlogo_new.webp'
 const ANIMATION_CHANCE = 0.5
-const FALLBACK_WAIT_MS = 900
-const REQUEST_TIMEOUT_MS = 1_800
+const REQUEST_TIMEOUT_MS = 2_800
+const IMAGE_LOAD_TIMEOUT_MS = 3_200
 
 const shouldTryAnimation = import.meta.client && Math.random() < ANIMATION_CHANCE
-const visualSrc = ref(shouldTryAnimation ? '' : LOGO_SRC)
+const visualSrc = ref(LOGO_SRC)
 const visualReady = ref(false)
 
 let destroyed = false
-let fallbackCommitted = false
-let fallbackTimer: ReturnType<typeof setTimeout> | null = null
 let requestController: AbortController | null = null
+let cancelPreload: (() => void) | null = null
 
 function setVisual(src: string): void {
-  if (destroyed) return
+  if (destroyed || visualSrc.value === src) return
   visualReady.value = false
   visualSrc.value = src
 }
 
-function commitLogoFallback(): void {
-  fallbackCommitted = true
+function useLogoFallback(): void {
+  if (visualSrc.value === LOGO_SRC) return
   setVisual(LOGO_SRC)
 }
 
-function useLogoFallback(): void {
-  if (visualSrc.value === LOGO_SRC) return
-  commitLogoFallback()
-}
+function preloadAnimation(src: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const image = new Image()
+    let settled = false
 
-function clearFallbackTimer(): void {
-  if (!fallbackTimer) return
-  clearTimeout(fallbackTimer)
-  fallbackTimer = null
+    const finish = (loaded: boolean) => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeoutId)
+      image.onload = null
+      image.onerror = null
+      if (cancelPreload === cancel) cancelPreload = null
+      resolve(loaded)
+    }
+
+    const cancel = () => finish(false)
+    const timeoutId = window.setTimeout(cancel, IMAGE_LOAD_TIMEOUT_MS)
+
+    cancelPreload = cancel
+    image.onload = () => finish(true)
+    image.onerror = cancel
+    image.src = src
+  })
 }
 
 async function selectAnimation(): Promise<void> {
-  fallbackTimer = setTimeout(commitLogoFallback, FALLBACK_WAIT_MS)
   requestController = new AbortController()
-  const requestTimeout = setTimeout(
+  const requestTimeout = window.setTimeout(
     () => requestController?.abort(),
     REQUEST_TIMEOUT_MS,
   )
 
   try {
     const fetchResponse = await fetch('/api/startup/animations', {
+      cache: 'force-cache',
       headers: { Accept: 'application/json' },
       signal: requestController.signal,
     })
-    if (!fetchResponse.ok) throw new Error(`Animation catalog ${fetchResponse.status}`)
+    if (!fetchResponse.ok) {
+      throw new Error(`Animation catalog ${fetchResponse.status}`)
+    }
 
     const response = (await fetchResponse.json()) as StartupAnimationsResponse
-    if (destroyed || fallbackCommitted) return
+    if (destroyed) return
 
     const animations = (response.animations || []).filter((url) =>
       /^\/images\/startup-animations\/launch-[a-z0-9][a-z0-9-]*\.webp$/i.test(
         url,
       ),
     )
-    if (!animations.length) {
-      commitLogoFallback()
-      return
-    }
+    if (!animations.length) return
 
-    clearFallbackTimer()
     const selected = animations[Math.floor(Math.random() * animations.length)]
-    setVisual(selected || LOGO_SRC)
+    if (!selected) return
+
+    const loaded = await preloadAnimation(selected)
+    if (!loaded || destroyed) return
+
+    setVisual(selected)
   } catch {
-    if (!fallbackCommitted) commitLogoFallback()
+    // The logo remains visible when catalog discovery or preloading fails.
   } finally {
-    clearTimeout(requestTimeout)
+    window.clearTimeout(requestTimeout)
     requestController = null
   }
 }
 
-onMounted(() => {
-  if (shouldTryAnimation) void selectAnimation()
-})
+if (shouldTryAnimation) {
+  void selectAnimation()
+}
 
 onBeforeUnmount(() => {
   destroyed = true
-  clearFallbackTimer()
   requestController?.abort()
   requestController = null
+  cancelPreload?.()
+  cancelPreload = null
 })
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,10 +32,54 @@ const buildId =
   process.env.NUXT_PUBLIC_BUILD_ID ||
   'development'
 
+const startupPrehydrateScript = `(() => {
+  const FORCE_KEY = 'kind-robots-force-full-startup-v1'
+  const SEEN_KEY = 'kind-robots-startup-build-v1'
+  const COVER_CLASS = 'kr-full-startup'
+  const BUILD_ID = ${JSON.stringify(buildId)}
+
+  let forced = false
+  let reloading = false
+  let shouldCover = false
+
+  try {
+    forced = sessionStorage.getItem(FORCE_KEY) === '1'
+  } catch {}
+
+  try {
+    const navigation = performance.getEntriesByType('navigation')[0]
+    reloading = navigation?.type === 'reload'
+  } catch {}
+
+  if (forced) {
+    shouldCover = true
+  } else if (!reloading) {
+    try {
+      shouldCover = localStorage.getItem(SEEN_KEY) !== BUILD_ID
+    } catch {
+      shouldCover = true
+    }
+  }
+
+  if (shouldCover) {
+    document.documentElement.classList.add(COVER_CLASS)
+  }
+})()`
+
 generateWonderLabComponentMetadata()
 
 export default defineNuxtConfig({
   compatibilityDate: '2026-06-01',
+  app: {
+    head: {
+      script: [
+        {
+          innerHTML: startupPrehydrateScript,
+          tagPosition: 'head',
+        },
+      ],
+    },
+  },
   content: {
     experimental: {
       sqliteConnector: 'native',
@@ -107,7 +151,7 @@ export default defineNuxtConfig({
     },
   },
 
-  css: ['~/assets/css/tailwind.css'],
+  css: ['~/assets/css/startup-cover.css', '~/assets/css/tailwind.css'],
 
   runtimeConfig: {
     openaiApiKey: process.env.OPENAI_API_KEY || '',

--- a/server/api/startup/animations.get.ts
+++ b/server/api/startup/animations.get.ts
@@ -1,18 +1,74 @@
-import { defineEventHandler, setHeader } from 'h3'
+import { defineEventHandler, getQuery, setHeader } from 'h3'
 import { listStartupAnimationUrls } from '@/server/utils/startupAnimations'
+
+const DEFAULT_MEDIA_ORIGIN = 'https://media.acrocatranch.com'
+const DIAGNOSTIC_TIMEOUT_MS = 4_000
+
+export interface StartupAnimationDiagnostic {
+  url: string
+  status: number | null
+  bytes: number | null
+  contentType: string | null
+  elapsedMs: number
+}
 
 export interface StartupAnimationsResponse {
   animations: string[]
+  diagnostics?: StartupAnimationDiagnostic[]
+}
+
+async function inspectAnimation(url: string): Promise<StartupAnimationDiagnostic> {
+  const origin = (process.env.MEDIA_ORIGIN || DEFAULT_MEDIA_ORIGIN).replace(/\/+$/, '')
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), DIAGNOSTIC_TIMEOUT_MS)
+  const startedAt = Date.now()
+
+  try {
+    const response = await fetch(`${origin}${url}`, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+    })
+    const rawLength = response.headers.get('content-length')
+    const parsedLength = rawLength ? Number(rawLength) : Number.NaN
+
+    return {
+      url,
+      status: response.status,
+      bytes: Number.isFinite(parsedLength) ? parsedLength : null,
+      contentType: response.headers.get('content-type'),
+      elapsedMs: Date.now() - startedAt,
+    }
+  } catch {
+    return {
+      url,
+      status: null,
+      bytes: null,
+      contentType: null,
+      elapsedMs: Date.now() - startedAt,
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 export default defineEventHandler(async (event): Promise<StartupAnimationsResponse> => {
+  const diagnosticsRequested = getQuery(event).diagnostics === '1'
+
   setHeader(
     event,
     'Cache-Control',
-    'public, max-age=60, s-maxage=60, stale-while-revalidate=300',
+    diagnosticsRequested
+      ? 'private, no-store'
+      : 'public, max-age=60, s-maxage=60, stale-while-revalidate=300',
   )
 
+  const animations = await listStartupAnimationUrls()
+
   return {
-    animations: await listStartupAnimationUrls(),
+    animations,
+    ...(diagnosticsRequested
+      ? { diagnostics: await Promise.all(animations.map(inspectAnimation)) }
+      : {}),
   }
 })

--- a/utils/startupLaunch.ts
+++ b/utils/startupLaunch.ts
@@ -1,4 +1,10 @@
 export const FORCE_FULL_STARTUP_KEY = 'kind-robots-force-full-startup-v1'
+export const STARTUP_COVER_CLASS = 'kr-full-startup'
+
+export function clearStartupCover(): void {
+  if (!import.meta.client) return
+  document.documentElement.classList.remove(STARTUP_COVER_CLASS)
+}
 
 export function requestFullStartupReload(): void {
   if (!import.meta.client) return
@@ -9,7 +15,20 @@ export function requestFullStartupReload(): void {
     // Reload anyway; the next visit may fall back to normal startup detection.
   }
 
-  window.location.reload()
+  document.documentElement.classList.add(STARTUP_COVER_CLASS)
+
+  let reloadStarted = false
+  const reload = () => {
+    if (reloadStarted) return
+    reloadStarted = true
+    window.location.reload()
+  }
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(reload)
+  })
+
+  window.setTimeout(reload, 180)
 }
 
 export function consumeForcedFullStartup(): boolean {


### PR DESCRIPTION
## What changed

- keeps the merged startup animation controls on `main`; does not revive the deleted historical branch
- adds a synchronous pre-hydration startup decision in the document head
- paints a black cover before the dashboard launch-refresh begins navigation
- preserves that cover across the reload and removes it only after the Vue startup overlay is mounted
- keeps ordinary browser refreshes free of startup presentation
- removes the global rule that hid the boot curtain before the overlay was ready
- replaces the 900 ms permanent logo fallback with catalog loading plus animated-WebP preloading
- keeps the logo visible while discovery/preloading fails or times out, then swaps only after the selected animation is fully loadable
- when animation is selected, waits up to eight seconds for it to become displayable and keeps it visible for at least 1.5 seconds
- adds opt-in media diagnostics at `/api/startup/animations?diagnostics=1`

## Root causes

1. The loader globally forced `.kr-boot-curtain` to `display: none`, so a dashboard-triggered reload could paint the refreshed page before Vue mounted the dark startup overlay.
2. The animation picker permanently committed to the logo after 900 ms. A cold Vercel function discovering files on the external media origin could exceed that window even when the files were healthy.
3. The animation assets are also large enough that waiting for a complete image load needs to be treated as real media loading rather than an icon fetch.

## Measured startup assets

Final Vercel preview diagnostics returned HTTP 200 and `image/webp` for every file:

| File | Bytes | Approx. MiB | HEAD latency |
| --- | ---: | ---: | ---: |
| `launch-01.webp` | 8,570,198 | 8.17 | 95 ms |
| `launch-02.webp` | 8,514,526 | 8.12 | 269 ms |
| `launch-03.webp` | 8,990,472 | 8.57 | 269 ms |
| `launch-04.webp` | 4,667,228 | 4.45 | 271 ms |

The files are healthy and the media origin is responsive, but 4.45–8.57 MiB is heavier than ideal for startup artwork. Re-encoding them closer to 1–3 MiB remains worthwhile, especially for mobile users.

## Expected behavior

- normal browser refresh: refreshed page appears directly, with no launch sequence
- header launch-refresh: current page covers immediately, navigation occurs behind the cover, then the full intro begins without exposing the refreshed dashboard first
- full intro media: 50% logo and 50% random animated WebP; the logo remains the safe fallback
- the intro does not reveal the dashboard before the selected visual has settled

## Validation

- branch starts from current `main`, is behind by zero commits, and is mergeable
- final Vercel preview is READY
- final preview SSR contains the synchronous `kr-full-startup` decision script in `<head>` before application markup
- diagnostics discovered all four network-drive WebPs with successful status and correct content type
- TypeScript Type Check passed
- Contract Tests passed
- all focused contract workflows passed

A literal automated dashboard-button click remains unverified because the browser-automation binary is unavailable in this environment. The deployed ordering mechanism, media discovery, asset health, build, and CI were verified directly.