### PR TITLE
Add suggested prompts to Project art generation

### DIFF
--- a/.github/workflows/entity-art-manager-contract.yml
+++ b/.github/workflows/entity-art-manager-contract.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'components/art/entity-art-manager.vue'
+      - 'components/pages/conductor-art-gallery.vue'
       - 'components/bots/bot-interact.vue'
       - 'components/characters/character-interact.vue'
       - 'components/scenarios/scenario-interact.vue'
       - 'components/rewards/reward-interact.vue'
       - 'components/facets/facet-manager.vue'
       - 'plugins/entity-art-prompt-suggest.client.ts'
+      - 'plugins/project-art-prompt-suggest.client.ts'
       - 'stores/helpers/artAssetSuggest.ts'
       - 'server/api/suggest.post.ts'
       - 'server/utils/suggest/sheets/artAssetSuggest.ts'
@@ -19,6 +21,7 @@ on:
       - 'server/utils/entityArt.ts'
       - 'utils/scripts/verifyEntityArtManager.ts'
       - 'utils/scripts/verifyEntityArtPromptSuggest.ts'
+      - 'utils/scripts/verifyProjectArtPromptSuggest.ts'
       - '.github/workflows/entity-art-manager-contract.yml'
   workflow_dispatch:
 
@@ -37,3 +40,4 @@ jobs:
       - run: npx prisma generate
       - run: npx tsx utils/scripts/verifyEntityArtManager.ts
       - run: npx tsx utils/scripts/verifyEntityArtPromptSuggest.ts
+      - run: npx tsx utils/scripts/verifyProjectArtPromptSuggest.ts

--- a/plugins/project-art-prompt-suggest.client.ts
+++ b/plugins/project-art-prompt-suggest.client.ts
@@ -1,0 +1,211 @@
+import { suggestArtAssetPrompt } from '@/stores/helpers/artAssetSuggest'
+
+type VueInstanceLike = {
+  props?: Record<string, unknown>
+  parent?: VueInstanceLike | null
+}
+
+type VueElement = HTMLElement & {
+  __vueParentComponent?: VueInstanceLike | null
+}
+
+type ProjectContext = {
+  id?: number
+  slug: string
+  title: string
+}
+
+type ProjectArtField = 'imagePath' | 'cardPath' | 'heroPath'
+
+type ProjectArtMeta = {
+  label: string
+  variant: 'icon' | 'card' | 'hero'
+  width: number
+  height: number
+}
+
+const FIELD_META: Record<ProjectArtField, ProjectArtMeta> = {
+  imagePath: { label: 'Icon', variant: 'icon', width: 256, height: 256 },
+  cardPath: { label: 'Card', variant: 'card', width: 512, height: 768 },
+  heroPath: { label: 'Hero', variant: 'hero', width: 1280, height: 720 },
+}
+
+const attached = new WeakSet<HTMLTextAreaElement>()
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const number = Number(value)
+  return Number.isInteger(number) && number > 0 ? number : undefined
+}
+
+function projectContext(element: HTMLElement): ProjectContext | null {
+  let instance: VueInstanceLike | null | undefined =
+    (element as VueElement).__vueParentComponent
+
+  while (instance) {
+    const props = instance.props ?? {}
+    const slug = cleanString(props.slug)
+    const id = positiveInteger(props.projectId)
+    const isProjectGallery =
+      slug &&
+      ('heroPath' in props || 'cardPath' in props || 'iconPath' in props)
+
+    if (isProjectGallery) {
+      return {
+        ...(id ? { id } : {}),
+        slug,
+        title:
+          cleanString(document.querySelector('h1')?.textContent) ||
+          cleanString(document.title) ||
+          slug,
+      }
+    }
+
+    instance = instance.parent
+  }
+
+  return null
+}
+
+function selectedField(form: HTMLFormElement): ProjectArtField {
+  const select = Array.from(
+    form.querySelectorAll<HTMLSelectElement>('select'),
+  ).find((candidate) =>
+    Array.from(candidate.options).some((option) => option.value === 'heroPath'),
+  )
+  const value = select?.value
+  return value === 'imagePath' || value === 'heroPath' ? value : 'cardPath'
+}
+
+function currentImageSource(form: HTMLFormElement): string | undefined {
+  const image = form.closest('section')?.querySelector<HTMLImageElement>('img')
+  return cleanString(image?.currentSrc || image?.src) || undefined
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value',
+  )?.set
+  if (setter) setter.call(textarea, value)
+  else textarea.value = value
+  textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  textarea.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+function addSuggestButton(textarea: HTMLTextAreaElement): void {
+  if (attached.has(textarea)) return
+  const form = textarea.closest<HTMLFormElement>('form')
+  if (!form) return
+  const context = projectContext(textarea)
+  if (!context) return
+
+  const hasProjectTarget = Array.from(
+    form.querySelectorAll<HTMLSelectElement>('select'),
+  ).some((select) =>
+    Array.from(select.options).some((option) => option.value === 'heroPath'),
+  )
+  if (!hasProjectTarget) return
+
+  attached.add(textarea)
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.dataset.projectArtPromptSuggest = 'true'
+  button.className =
+    'btn btn-ghost btn-xs w-fit gap-1 rounded-lg border border-secondary/30'
+  button.textContent = '✨ Suggest prompt'
+  button.title = 'Generate an editable art prompt from the canonical Project record'
+  textarea.insertAdjacentElement('beforebegin', button)
+
+  button.addEventListener('click', async () => {
+    if (button.dataset.loading === 'true') return
+    const currentContext = projectContext(textarea)
+    if (!currentContext) return
+
+    const field = selectedField(form)
+    const meta = FIELD_META[field]
+    const initialLabel = button.textContent || '✨ Suggest prompt'
+    button.dataset.loading = 'true'
+    button.disabled = true
+    button.textContent = 'Suggesting…'
+
+    try {
+      const suggestion = await suggestArtAssetPrompt({
+        subject: currentContext.title,
+        purpose: `Fresh ${meta.label} replacement for ${currentContext.title}, grounded in the canonical Project record and what the project actually does.`,
+        current: textarea.value,
+        entityRef: {
+          modelType: 'project',
+          ...(currentContext.id ? { id: currentContext.id } : {}),
+          slug: currentContext.slug,
+        },
+        asset: {
+          source: currentImageSource(form),
+          role: field,
+          variant: meta.variant,
+          size: `${meta.width}x${meta.height}`,
+          description: `Create a prompt-driven replacement for the Project ${meta.label.toLowerCase()} slot.`,
+        },
+        page: {
+          url: window.location.href,
+          title: document.title,
+          heading: cleanString(document.querySelector('h1')?.textContent),
+          localText: cleanString(form.innerText).slice(0, 900),
+        },
+        maxTokens: meta.variant === 'icon' ? 300 : 500,
+      })
+
+      if (!suggestion) throw new Error('The suggestion endpoint returned no prompt.')
+      setTextareaValue(textarea, suggestion)
+      textarea.focus()
+      button.textContent = 'Prompt suggested ✓'
+      window.setTimeout(() => {
+        button.textContent = initialLabel
+      }, 1800)
+    } catch (error) {
+      button.textContent = 'Suggestion failed'
+      button.title =
+        error instanceof Error ? error.message : 'Prompt suggestion failed.'
+      window.setTimeout(() => {
+        button.textContent = initialLabel
+        button.title =
+          'Generate an editable art prompt from the canonical Project record'
+      }, 2600)
+    } finally {
+      button.dataset.loading = 'false'
+      button.disabled = textarea.disabled
+    }
+  })
+}
+
+function scan(root: ParentNode = document): void {
+  for (const textarea of root.querySelectorAll<HTMLTextAreaElement>(
+    'textarea[maxlength="4000"]',
+  )) {
+    addSuggestButton(textarea)
+  }
+}
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('app:mounted', () => {
+    scan()
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (!(node instanceof Element)) continue
+          if (node.matches('textarea[maxlength="4000"]')) {
+            addSuggestButton(node as HTMLTextAreaElement)
+          }
+          scan(node)
+        }
+      }
+    })
+    observer.observe(document.body, { childList: true, subtree: true })
+    window.addEventListener('beforeunload', () => observer.disconnect(), {
+      once: true,
+    })
+  })
+})

--- a/utils/scripts/verifyProjectArtPromptSuggest.ts
+++ b/utils/scripts/verifyProjectArtPromptSuggest.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8')
+}
+
+function expectContains(path: string, needles: string[]): void {
+  const source = read(path)
+  for (const needle of needles) {
+    if (!source.includes(needle)) {
+      throw new Error(`${path} is missing Project prompt suggestion contract: ${needle}`)
+    }
+  }
+}
+
+expectContains('components/pages/conductor-art-gallery.vue', [
+  'maxlength="4000"',
+  'generationPrompt',
+  'imagePath',
+  'cardPath',
+  'heroPath',
+])
+
+expectContains('plugins/project-art-prompt-suggest.client.ts', [
+  "suggestArtAssetPrompt",
+  "modelType: 'project'",
+  'props.projectId',
+  'props.slug',
+  "textarea[maxlength=\"4000\"]",
+  "imagePath: { label: 'Icon', variant: 'icon', width: 256, height: 256 }",
+  "cardPath: { label: 'Card', variant: 'card', width: 512, height: 768 }",
+  "heroPath: { label: 'Hero', variant: 'hero', width: 1280, height: 720 }",
+  "button.textContent = '✨ Suggest prompt'",
+  'current: textarea.value',
+  'setTextareaValue(textarea, suggestion)',
+])
+
+expectContains('stores/helpers/artAssetSuggest.ts', [
+  "builder: 'art-asset'",
+  "field: 'prompt'",
+  'entityRef: input.entityRef',
+])
+
+expectContains('server/utils/suggest/sheets/artAssetSuggest.ts', [
+  'Projects: communicate what the project actually does',
+  "modelType: 'project'",
+])
+
+console.log('Project art prompt suggestion contract verified.')

--- a/utils/scripts/verifyProjectArtPromptSuggest.ts
+++ b/utils/scripts/verifyProjectArtPromptSuggest.ts
@@ -22,11 +22,11 @@ expectContains('components/pages/conductor-art-gallery.vue', [
 ])
 
 expectContains('plugins/project-art-prompt-suggest.client.ts', [
-  "suggestArtAssetPrompt",
+  'suggestArtAssetPrompt',
   "modelType: 'project'",
   'props.projectId',
   'props.slug',
-  "textarea[maxlength=\"4000\"]",
+  'textarea[maxlength="4000"]',
   "imagePath: { label: 'Icon', variant: 'icon', width: 256, height: 256 }",
   "cardPath: { label: 'Card', variant: 'card', width: 512, height: 768 }",
   "heroPath: { label: 'Hero', variant: 'hero', width: 1280, height: 720 }",
@@ -43,7 +43,8 @@ expectContains('stores/helpers/artAssetSuggest.ts', [
 
 expectContains('server/utils/suggest/sheets/artAssetSuggest.ts', [
   'Projects: communicate what the project actually does',
-  "modelType: 'project'",
 ])
+
+expectContains('utils/artModelContext.ts', ["'project'"])
 
 console.log('Project art prompt suggestion contract verified.')


### PR DESCRIPTION
## Goal
Give the Project-specific artwork gallery the same model-aware **Suggest prompt** action already available for Bots, Characters, Scenarios, Rewards, and Facets.

## What changed
- Adds a Project-specific client integration for the existing `suggestArtAssetPrompt()` helper.
- Detects the Project gallery through its `slug`, `projectId`, and image-slot props.
- Supports Project Icon, Card, and Hero targets with their canonical dimensions.
- Sends the canonical Project ID/slug, selected slot, current image, current draft prompt, and page context to `/api/suggest` using the existing `art-asset` sheet.
- Inserts the returned prompt through the textarea's normal `v-model` input path so it remains editable before queueing.
- Adds a focused Project prompt-suggestion contract to the Entity Art Manager workflow.

## Validation
- Project Art Prompt Suggestion Contract
- Entity Art Manager Contract
- TypeScript Type Check
- Full Contract Tests