### PR TITLE
Force startup animation and eliminate black handoff

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -6,9 +6,29 @@ html.kr-full-startup::before {
   position: fixed;
   inset: 0;
   z-index: 2147483646;
-  background: #000;
+  background-color: #000;
+  background-image:
+    url('/images/startup-animations/launch-04.webp'),
+    url('/images/kindlogo_new.webp');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: clamp(16rem, 58vw, 34rem) auto;
   content: '';
   pointer-events: none;
+}
+
+html.kr-full-startup .loader-root {
+  z-index: 2147483647;
+}
+
+.loading-logo-frame {
+  background-color: #000;
+  background-image:
+    url('/images/startup-animations/launch-04.webp'),
+    url('/images/kindlogo_new.webp');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: clamp(16rem, 58vw, 34rem) auto;
 }
 
 .kr-boot-curtain {

--- a/components/admin/startup-intro-visual.vue
+++ b/components/admin/startup-intro-visual.vue
@@ -1,5 +1,6 @@
 <template>
   <img
+    ref="imageElement"
     :key="visualSrc"
     :src="visualSrc"
     alt="Kind Robots"
@@ -16,11 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
-
-interface StartupAnimationsResponse {
-  animations?: string[]
-}
+import { onMounted, ref } from 'vue'
 
 type IntroVisualKind = 'logo' | 'animation'
 
@@ -28,144 +25,39 @@ const emit = defineEmits<{
   settled: [kind: IntroVisualKind]
 }>()
 
+const ANIMATION_SRC = '/images/startup-animations/launch-04.webp'
 const LOGO_SRC = '/images/kindlogo_new.webp'
-const ANIMATION_CHANCE = 0.5
-const REQUEST_TIMEOUT_MS = 3_500
-const IMAGE_LOAD_TIMEOUT_MS = 8_000
 
-const shouldTryAnimation = import.meta.client && Math.random() < ANIMATION_CHANCE
-const visualSrc = ref(LOGO_SRC)
+const imageElement = ref<HTMLImageElement | null>(null)
+const visualSrc = ref(ANIMATION_SRC)
 const visualReady = ref(false)
 
-let destroyed = false
-let animationAttemptPending = shouldTryAnimation
 let settledEmitted = false
-let requestController: AbortController | null = null
-let cancelPreload: (() => void) | null = null
 
 function emitSettled(kind: IntroVisualKind): void {
-  if (destroyed || settledEmitted) return
+  if (settledEmitted) return
   settledEmitted = true
   emit('settled', kind)
 }
 
-function setVisual(src: string): void {
-  if (destroyed || visualSrc.value === src) return
-  visualReady.value = false
-  visualSrc.value = src
-}
-
-function settleOnLogo(): void {
-  animationAttemptPending = false
-  if (visualSrc.value !== LOGO_SRC) setVisual(LOGO_SRC)
-  if (visualReady.value) emitSettled('logo')
+function handleVisualLoad(): void {
+  visualReady.value = true
+  emitSettled(visualSrc.value === ANIMATION_SRC ? 'animation' : 'logo')
 }
 
 function useLogoFallback(): void {
-  settleOnLogo()
-}
-
-function handleVisualLoad(): void {
-  visualReady.value = true
-
-  if (visualSrc.value !== LOGO_SRC) {
-    animationAttemptPending = false
-    emitSettled('animation')
+  if (visualSrc.value === LOGO_SRC) {
+    emitSettled('logo')
     return
   }
 
-  if (!animationAttemptPending) emitSettled('logo')
-}
-
-function preloadAnimation(src: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const image = new Image()
-    let settled = false
-
-    const finish = (loaded: boolean) => {
-      if (settled) return
-      settled = true
-      window.clearTimeout(timeoutId)
-      image.onload = null
-      image.onerror = null
-      if (cancelPreload === cancel) cancelPreload = null
-      resolve(loaded)
-    }
-
-    const cancel = () => finish(false)
-    const timeoutId = window.setTimeout(cancel, IMAGE_LOAD_TIMEOUT_MS)
-
-    cancelPreload = cancel
-    image.onload = () => finish(true)
-    image.onerror = cancel
-    image.src = src
-  })
-}
-
-async function selectAnimation(): Promise<void> {
-  requestController = new AbortController()
-  const requestTimeout = window.setTimeout(
-    () => requestController?.abort(),
-    REQUEST_TIMEOUT_MS,
-  )
-
-  try {
-    const fetchResponse = await fetch('/api/startup/animations', {
-      cache: 'force-cache',
-      headers: { Accept: 'application/json' },
-      signal: requestController.signal,
-    })
-    if (!fetchResponse.ok) {
-      throw new Error(`Animation catalog ${fetchResponse.status}`)
-    }
-
-    const response = (await fetchResponse.json()) as StartupAnimationsResponse
-    if (destroyed) return
-
-    const animations = (response.animations || []).filter((url) =>
-      /^\/images\/startup-animations\/launch-[a-z0-9][a-z0-9-]*\.webp$/i.test(
-        url,
-      ),
-    )
-    if (!animations.length) {
-      settleOnLogo()
-      return
-    }
-
-    const selected = animations[Math.floor(Math.random() * animations.length)]
-    if (!selected) {
-      settleOnLogo()
-      return
-    }
-
-    const loaded = await preloadAnimation(selected)
-    if (!loaded || destroyed) {
-      settleOnLogo()
-      return
-    }
-
-    setVisual(selected)
-  } catch {
-    settleOnLogo()
-  } finally {
-    window.clearTimeout(requestTimeout)
-    requestController = null
-  }
+  visualReady.value = false
+  visualSrc.value = LOGO_SRC
 }
 
 onMounted(() => {
-  if (shouldTryAnimation) {
-    void selectAnimation()
-  } else if (visualReady.value) {
-    emitSettled('logo')
+  if (imageElement.value?.complete && imageElement.value.naturalWidth > 0) {
+    handleVisualLoad()
   }
-})
-
-onBeforeUnmount(() => {
-  destroyed = true
-  requestController?.abort()
-  requestController = null
-  cancelPreload?.()
-  cancelPreload = null
 })
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,15 +32,16 @@ const buildId =
   process.env.NUXT_PUBLIC_BUILD_ID ||
   'development'
 
+const startupAnimationSrc = '/images/startup-animations/launch-04.webp'
+
 const startupPrehydrateScript = `(() => {
   const FORCE_KEY = 'kind-robots-force-full-startup-v1'
   const SEEN_KEY = 'kind-robots-startup-build-v1'
   const COVER_CLASS = 'kr-full-startup'
-  const BUILD_ID = ${JSON.stringify(buildId)}
+  const ANIMATION_SRC = ${JSON.stringify(startupAnimationSrc)}
 
   let forced = false
   let reloading = false
-  let shouldCover = false
 
   try {
     forced = sessionStorage.getItem(FORCE_KEY) === '1'
@@ -51,18 +52,23 @@ const startupPrehydrateScript = `(() => {
     reloading = navigation?.type === 'reload'
   } catch {}
 
-  if (forced) {
-    shouldCover = true
-  } else if (!reloading) {
-    try {
-      shouldCover = localStorage.getItem(SEEN_KEY) !== BUILD_ID
-    } catch {
-      shouldCover = true
-    }
-  }
+  const shouldCover = forced || !reloading
 
   if (shouldCover) {
+    if (!reloading) {
+      try {
+        localStorage.removeItem(SEEN_KEY)
+      } catch {}
+    }
+
     document.documentElement.classList.add(COVER_CLASS)
+
+    const preload = document.createElement('link')
+    preload.rel = 'preload'
+    preload.as = 'image'
+    preload.href = ANIMATION_SRC
+    preload.fetchPriority = 'high'
+    document.head.appendChild(preload)
   }
 })()`
 


### PR DESCRIPTION
## What changed

- forces `/images/startup-animations/launch-04.webp` for every full startup so the test is deterministic
- starts preloading that WebP synchronously from the document head
- renders the same animation in the pre-hydration cover instead of a black-only curtain
- keeps the Kind Robots logo underneath as an immediate visible fallback while the WebP downloads
- keeps the Vue loader above the pre-hydration cover so headings and loading messages can appear immediately after hydration
- uses the same forced animation as the loader-frame background for a continuous handoff
- treats every non-reload document navigation as a full startup
- keeps ordinary browser reloads animation-free
- keeps the dashboard launch-refresh button as an explicit full-startup override

## Expected behavior

- first direct load/new tab/navigation: `launch-04.webp` startup intro
- F5/Ctrl+R/browser reload: no startup intro
- dashboard launch-refresh icon: the animation appears immediately before reload and continues into the full startup
- no long pure-black interval while waiting for Vue or the animation catalog

## Why

The previous implementation still placed a black pre-hydration curtain above the Vue loader, then waited for hydration before removing it. It also selected media only after client startup. This patch moves the forced media request and presentation ahead of hydration, removes the random/catalog variables from the test, and leaves the logo visible beneath the WebP while it loads.

## Validation

- branch starts from current `main`, is behind by zero commits, and is mergeable
- final Vercel preview is READY
- preview HTML contains the forced `launch-04.webp` source and high-priority preload in the document head before application markup
- preview HTML uses `forced || !reloading`, so direct/non-reload loads start the intro and true browser reloads skip it
- TypeScript Type Check passed
- Contract Tests passed
- every focused contract workflow passed

A literal timed browser recording was not available in this environment, so the final visual/handoff timing still needs a human preview check before merge.