### PR TITLE
Add LTX and WAN startup video presets

### DIFF
--- a/content/channels/play/video-generator.md
+++ b/content/channels/play/video-generator.md
@@ -7,11 +7,11 @@ dashboardTab: video
 label: Video Gen
 title: Video Generator
 subtitle: Animate a still into a short clip
-description: Turn a still image into a short looping clip with LTX or WAN, with an optional first-to-last morph and a motion prompt.
+description: Turn a still image into a short looping clip with LTX or WAN, with startup-ready WebP and WebM presets, custom controls, and an optional first-to-last morph.
 icon: kind-icon:video
 route: /play/video-generator
 sort: 150
 requiredRole: GUEST
 ---
 
-Feed in a still, describe the motion, and queue a short animated clip on the studio engine.
+Feed in a still, describe the motion, and queue a short animated clip on the studio engine. Choose a startup preset for 768×768, 2.5-second, 16 FPS output, or keep the controls fully custom.

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -24,12 +24,51 @@
           type="button"
           class="btn btn-sm"
           :class="engine === opt.value ? 'btn-accent' : 'btn-outline'"
-          @click="engine = opt.value"
+          @click="selectEngine(opt.value)"
         >
           {{ opt.label }}
         </button>
       </div>
       <p class="text-xs opacity-60">{{ activeEngine.hint }}</p>
+    </section>
+
+    <!-- Generation presets -->
+    <section class="space-y-2">
+      <label class="font-semibold">Preset</label>
+      <div class="grid gap-2 sm:grid-cols-3">
+        <button
+          type="button"
+          class="btn h-auto min-h-0 justify-start py-3 text-left"
+          :class="videoPresetId === '' ? 'btn-accent' : 'btn-outline'"
+          @click="selectVideoPreset('')"
+        >
+          <span class="flex flex-col items-start">
+            <span class="font-semibold">Custom</span>
+            <span class="text-xs font-normal opacity-70">
+              Keep the manual controls below.
+            </span>
+          </span>
+        </button>
+        <button
+          v-for="preset in availableVideoPresets"
+          :key="preset.id"
+          type="button"
+          class="btn h-auto min-h-0 justify-start py-3 text-left"
+          :class="videoPresetId === preset.id ? 'btn-accent' : 'btn-outline'"
+          @click="selectVideoPreset(preset.id)"
+        >
+          <span class="flex flex-col items-start">
+            <span class="font-semibold">{{ preset.label }}</span>
+            <span class="text-xs font-normal opacity-70">
+              {{ preset.description }}
+            </span>
+          </span>
+        </button>
+      </div>
+      <p class="text-xs opacity-60">
+        Presets fill the editable controls below; changing a value still
+        overrides the preset for this render.
+      </p>
     </section>
 
     <!-- Images -->
@@ -314,6 +353,12 @@
 import { computed, ref } from 'vue'
 import { useVideoStore, type VideoOutputFormat } from '@/stores/videoStore'
 import { useUserStore } from '@/stores/userStore'
+import {
+  getVideoPreset,
+  getVideoPresetsForEngine,
+  type VideoEngine,
+  type VideoPresetId,
+} from '@/utils/videoPresets'
 
 const LOGO_SRC = '/images/kindlogo_new.webp'
 
@@ -339,9 +384,13 @@ const engines = [
   },
 ]
 
-const engine = ref<'ltx' | 'wan'>('ltx')
+const engine = ref<VideoEngine>('ltx')
+const videoPresetId = ref<VideoPresetId | ''>('')
 const activeEngine = computed(
   () => engines.find((e) => e.value === engine.value) ?? engines[0]!,
+)
+const availableVideoPresets = computed(() =>
+  getVideoPresetsForEngine(engine.value),
 )
 
 const outputFormats = [
@@ -404,6 +453,26 @@ const generateLabel = computed(() => {
   return `Generate ${engine.value.toUpperCase()} clip`
 })
 
+function selectEngine(nextEngine: VideoEngine): void {
+  engine.value = nextEngine
+  videoPresetId.value = ''
+}
+
+function selectVideoPreset(nextPresetId: VideoPresetId | ''): void {
+  videoPresetId.value = nextPresetId
+  if (!nextPresetId) return
+
+  const preset = getVideoPreset(nextPresetId)
+  if (!preset || preset.engine !== engine.value) return
+
+  width.value = preset.width
+  height.value = preset.height
+  durationSeconds.value = preset.durationSeconds
+  fps.value = preset.fps
+  loop.value = preset.loop
+  outputFormat.value = preset.outputFormat
+}
+
 function fileToDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -452,6 +521,7 @@ async function generate() {
 
   await videoStore.generate({
     engine: engine.value,
+    presetId: videoPresetId.value || null,
     promptString: prompt.value.trim(),
     negativePrompt: negativePrompt.value.trim() || undefined,
     firstImageBase64: firstImage.value,

--- a/server/api/video/generate.post.ts
+++ b/server/api/video/generate.post.ts
@@ -1,0 +1,63 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import {
+  getVideoPreset,
+  type VideoEngine,
+} from '../../../utils/videoPresets'
+
+type VideoGenerateRequest = Record<string, unknown> & {
+  engine?: string | null
+  presetId?: string | null
+  width?: number | null
+  height?: number | null
+  durationSeconds?: number | null
+  fps?: number | null
+  frameRate?: number | null
+  loop?: boolean | null
+  outputFormat?: string | null
+}
+
+function normalizeEngine(value: unknown): VideoEngine {
+  const engine = String(value || '').trim().toLowerCase()
+  if (engine === 'ltx' || engine === 'wan') return engine
+  throw createError({
+    statusCode: 400,
+    message: 'Video generation requires engine "ltx" or "wan".',
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  const body = (await readBody(event)) as VideoGenerateRequest | null
+  const engine = normalizeEngine(body?.engine)
+  const presetId = body?.presetId?.trim() || null
+  const preset = getVideoPreset(presetId)
+
+  if (presetId && !preset) {
+    throw createError({
+      statusCode: 400,
+      message: `Unknown video preset "${presetId}".`,
+    })
+  }
+  if (preset && preset.engine !== engine) {
+    throw createError({
+      statusCode: 400,
+      message: `Video preset "${preset.id}" requires engine "${preset.engine}".`,
+    })
+  }
+
+  const resolvedBody: VideoGenerateRequest = {
+    ...(body ?? {}),
+    engine,
+    presetId,
+    width: body?.width ?? preset?.width,
+    height: body?.height ?? preset?.height,
+    durationSeconds: body?.durationSeconds ?? preset?.durationSeconds,
+    fps: body?.fps ?? body?.frameRate ?? preset?.fps,
+    loop: body?.loop ?? preset?.loop,
+    outputFormat: body?.outputFormat ?? preset?.outputFormat,
+  }
+
+  return event.$fetch('/api/art/enqueue', {
+    method: 'POST',
+    body: resolvedBody,
+  })
+})

--- a/server/api/video/generate.post.ts
+++ b/server/api/video/generate.post.ts
@@ -16,6 +16,13 @@ type VideoGenerateRequest = Record<string, unknown> & {
   outputFormat?: string | null
 }
 
+type VideoGenerateResponse = {
+  success: boolean
+  message: string
+  statusCode: number
+  data?: Record<string, unknown>
+}
+
 function normalizeEngine(value: unknown): VideoEngine {
   const engine = String(value || '').trim().toLowerCase()
   if (engine === 'ltx' || engine === 'wan') return engine
@@ -56,7 +63,7 @@ export default defineEventHandler(async (event) => {
     outputFormat: body?.outputFormat ?? preset?.outputFormat,
   }
 
-  return event.$fetch('/api/art/enqueue', {
+  return event.$fetch<VideoGenerateResponse, string>('/api/art/enqueue', {
     method: 'POST',
     body: resolvedBody,
   })

--- a/server/api/video/presets.get.ts
+++ b/server/api/video/presets.get.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler } from 'h3'
+import { VIDEO_PRESETS } from '../../../utils/videoPresets'
+
+export default defineEventHandler(() => ({
+  presets: VIDEO_PRESETS,
+}))

--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -1,7 +1,7 @@
 // /stores/videoStore.ts
 //
 // Front-end store for the video generator page. Enqueues an image-to-video
-// ArtJob (engine: 'ltx' | 'wan') via /api/art/enqueue, polls /api/art/queue/:id
+// ArtJob (engine: 'ltx' | 'wan') via /api/video/generate, polls /api/art/queue/:id
 // until the home relay renders + completes it, then resolves the finished
 // ArtImage into a playable video src. Mirrors the enqueue → poll → resolve
 // pattern in stores/artStore.ts, kept standalone so the video page has a small,
@@ -10,18 +10,19 @@ import { defineStore } from 'pinia'
 import { reactive, computed } from 'vue'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 import { performFetch } from '@/stores/utils'
+import type {
+  VideoEngine,
+  VideoOutputFormat,
+  VideoPresetId,
+} from '@/utils/videoPresets'
 
-export type VideoEngine = 'ltx' | 'wan'
-
-// 'webp' (default) — native ComfyUI SaveAnimatedWEBP, smaller/better quality
-// than GIF for a short looping clip, renders as <img>. 'mp4'/'webm' render as
-// <video> and suit longer or more complex motion.
-export type VideoOutputFormat = 'webp' | 'mp4' | 'webm'
+export type { VideoEngine, VideoOutputFormat, VideoPresetId }
 
 export type VideoJobStatus = 'idle' | 'queued' | 'rendering' | 'done' | 'error'
 
 export interface GenerateVideoParams {
   engine: VideoEngine
+  presetId?: VideoPresetId | null
   promptString: string
   negativePrompt?: string
   // Base64 data URLs (or raw base64). First is required, second optional.
@@ -122,6 +123,7 @@ export const useVideoStore = defineStore('videoStore', () => {
   async function enqueue(params: GenerateVideoParams): Promise<number> {
     const body = {
       engine: params.engine,
+      presetId: params.presetId ?? undefined,
       promptString: params.promptString,
       negativePrompt: params.negativePrompt ?? undefined,
       firstImageBase64: params.firstImageBase64,
@@ -144,7 +146,7 @@ export const useVideoStore = defineStore('videoStore', () => {
     }
 
     const res = await performFetch<{ jobId: number; status: string }>(
-      '/api/art/enqueue',
+      '/api/video/generate',
       { method: 'POST', body: JSON.stringify(body) },
       2,
       60_000,

--- a/utils/videoPresets.ts
+++ b/utils/videoPresets.ts
@@ -1,0 +1,81 @@
+export type VideoEngine = 'ltx' | 'wan'
+export type VideoOutputFormat = 'webp' | 'mp4' | 'webm'
+
+export type VideoPresetDefinition = {
+  id: string
+  engine: VideoEngine
+  label: string
+  description: string
+  width: number
+  height: number
+  durationSeconds: number
+  fps: number
+  loop: boolean
+  outputFormat: VideoOutputFormat
+}
+
+export const VIDEO_PRESETS = [
+  {
+    id: 'ltx-startup-webp',
+    engine: 'ltx',
+    label: 'Startup WebP',
+    description: '768×768, 2.5 seconds, 16 FPS, looping animated WebP.',
+    width: 768,
+    height: 768,
+    durationSeconds: 2.5,
+    fps: 16,
+    loop: true,
+    outputFormat: 'webp',
+  },
+  {
+    id: 'ltx-startup-webm',
+    engine: 'ltx',
+    label: 'Startup WebM',
+    description: '768×768, 2.5 seconds, 16 FPS, looping WebM video.',
+    width: 768,
+    height: 768,
+    durationSeconds: 2.5,
+    fps: 16,
+    loop: true,
+    outputFormat: 'webm',
+  },
+  {
+    id: 'wan-startup-webp',
+    engine: 'wan',
+    label: 'Startup WebP',
+    description: '768×768, 2.5 seconds, 16 FPS, looping animated WebP.',
+    width: 768,
+    height: 768,
+    durationSeconds: 2.5,
+    fps: 16,
+    loop: true,
+    outputFormat: 'webp',
+  },
+  {
+    id: 'wan-startup-webm',
+    engine: 'wan',
+    label: 'Startup WebM',
+    description: '768×768, 2.5 seconds, 16 FPS, looping WebM video.',
+    width: 768,
+    height: 768,
+    durationSeconds: 2.5,
+    fps: 16,
+    loop: true,
+    outputFormat: 'webm',
+  },
+] as const satisfies readonly VideoPresetDefinition[]
+
+export type VideoPresetId = (typeof VIDEO_PRESETS)[number]['id']
+
+export function getVideoPreset(
+  presetId: string | null | undefined,
+): (typeof VIDEO_PRESETS)[number] | null {
+  if (!presetId) return null
+  return VIDEO_PRESETS.find((preset) => preset.id === presetId) ?? null
+}
+
+export function getVideoPresetsForEngine(
+  engine: VideoEngine,
+): readonly (typeof VIDEO_PRESETS)[number][] {
+  return VIDEO_PRESETS.filter((preset) => preset.engine === engine)
+}


### PR DESCRIPTION
## What changed

- adds shared startup video presets for LTX and WAN
- provides both animated WebP and WebM variants for each engine
- adds `GET /api/video/presets` so clients can discover the supported presets
- adds `POST /api/video/generate` to validate and resolve presets before forwarding through the existing authenticated, mana-gated art queue
- routes the video store through the new video-specific generation endpoint
- adds Custom, Startup WebP, and Startup WebM choices to the Video Generator page
- keeps every populated preset value editable before generation
- updates the Video Generator channel description to mention the startup presets

## Preset settings

All four startup presets use:

- 768×768
- 2.5 seconds
- 16 FPS
- looping output

Available preset IDs:

- `ltx-startup-webp`
- `ltx-startup-webm`
- `wan-startup-webp`
- `wan-startup-webm`

## Behavior

- selecting a preset fills the existing width, height, duration, FPS, loop, and output controls
- changing those controls overrides the selected preset for that render
- selecting Custom preserves the manual workflow
- API clients may send only `engine`, `presetId`, and the required generation inputs; missing preset-controlled values are filled server-side
- engine/preset mismatches and unknown preset IDs return HTTP 400
- the resolved request still passes through the existing `/api/art/enqueue` authentication, mana calculation, and queue path

## Validation

- branch starts from current `main`, is behind by zero commits, and is mergeable
- final Vercel preview is READY at commit `16decb1b5590a2cd05db2e7e1c51449a05c46ec6`
- live `GET /api/video/presets` returned HTTP 200 with all four expected presets
- live `/play/video-generator` returned HTTP 200 and server-rendered Custom, Startup WebP, and Startup WebM controls
- TypeScript Type Check passed
- Contract Tests passed
- all focused contract workflows passed

The first Contract Tests run identified the repository's explicit `$fetch` generic-pinning requirement. The queue proxy was updated to use an explicit response type and route-string generic; the corrected final run passed.