### PR TITLE
Synchronize startup video, copy, and sequence timing

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -17,6 +17,39 @@ html.kr-full-startup::before {
   pointer-events: none;
 }
 
+html.kr-full-startup body::before,
+html.kr-full-startup body::after {
+  position: fixed;
+  left: 50%;
+  z-index: 2147483647;
+  width: fit-content;
+  max-width: min(90vw, 44rem);
+  padding: 0.65rem 1.2rem;
+  border-radius: 0.25rem;
+  background: rgba(0, 0, 0, 0.78);
+  color: #fff;
+  font-weight: 700;
+  text-align: center;
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.42);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+html.kr-full-startup body::before {
+  top: max(1rem, 4vh);
+  content: 'Building Kind Robots...';
+  font-size: clamp(1.2rem, 2.25vw, 2rem);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+html.kr-full-startup body::after {
+  bottom: max(1.5rem, 5vh);
+  content: '●  ●  ●   Wiring robots for suspicious levels of charm...';
+  font-size: clamp(1rem, 1.8vw, 1.6rem);
+  animation: kr-prehydrate-status-pulse 1.15s ease-in-out infinite alternate;
+}
+
 html.kr-full-startup .loader-root {
   z-index: 2147483647;
 }
@@ -37,4 +70,22 @@ html.kr-full-startup .loader-root {
 
 html.kr-full-startup .kr-boot-curtain {
   display: block !important;
+}
+
+@keyframes kr-prehydrate-status-pulse {
+  from {
+    opacity: 0.72;
+    transform: translateX(-50%) translateY(0.2rem) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.kr-full-startup body::after {
+    animation: none;
+  }
 }

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -38,6 +38,7 @@
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useLoadStore } from '../../stores/loadStore'
 import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
+import { consumeStartupStartedAt } from '@/utils/startupLaunch'
 
 const props = defineProps<{ storesReady: boolean }>()
 const emit = defineEmits<{
@@ -67,7 +68,7 @@ const MIN_TOTAL_MS =
   (EXTRA_MESSAGE_COUNT + 1) * EXTRA_MESSAGE_MS + READY_HOLD_MS
 const OVERLAY_FADE_MS = 650
 
-const startTime = Date.now()
+const startTime = consumeStartupStartedAt()
 
 let destroyed = false
 let rotationIntervalId: ReturnType<typeof setInterval> | null = null
@@ -83,6 +84,10 @@ function wait(ms: number) {
 
     setTimeout(resolve, ms)
   })
+}
+
+function waitUntil(offsetMs: number) {
+  return wait(Math.max(0, startTime + offsetMs - Date.now()))
 }
 
 function nextMessage() {
@@ -140,11 +145,16 @@ function scheduleFade() {
 
   const elapsed = Date.now() - startTime
   const minimumRemaining = Math.max(READY_HOLD_MS, MIN_TOTAL_MS - elapsed)
+  const animationVisibleRemaining = Math.max(
+    0,
+    ANIMATION_VISIBLE_HOLD_MS - elapsed,
+  )
   const holdNeeded = exitRequested.value
     ? 0
-    : introVisualKind.value === 'animation'
-      ? Math.max(ANIMATION_VISIBLE_HOLD_MS, minimumRemaining)
-      : minimumRemaining
+    : Math.max(
+        minimumRemaining,
+        introVisualKind.value === 'animation' ? animationVisibleRemaining : 0,
+      )
 
   readyHoldTimeoutId = setTimeout(() => {
     doFade()
@@ -165,7 +175,7 @@ function handleTransitionEnd(event: TransitionEvent) {
 
 async function runVisualSequence() {
   for (let index = 0; index < EXTRA_MESSAGE_COUNT; index += 1) {
-    await wait(EXTRA_MESSAGE_MS)
+    await waitUntil((index + 1) * EXTRA_MESSAGE_MS)
     if (destroyed) return
     nextMessage()
   }

--- a/utils/startupLaunch.ts
+++ b/utils/startupLaunch.ts
@@ -1,5 +1,8 @@
 export const FORCE_FULL_STARTUP_KEY = 'kind-robots-force-full-startup-v1'
 export const STARTUP_COVER_CLASS = 'kr-full-startup'
+export const STARTUP_STARTED_AT_KEY = 'kind-robots-startup-started-at-v1'
+
+const MAX_STARTUP_AGE_MS = 30_000
 
 export function clearStartupCover(): void {
   if (!import.meta.client) return
@@ -11,6 +14,7 @@ export function requestFullStartupReload(): void {
 
   try {
     sessionStorage.setItem(FORCE_FULL_STARTUP_KEY, '1')
+    sessionStorage.setItem(STARTUP_STARTED_AT_KEY, String(Date.now()))
   } catch {
     // Reload anyway; the next visit may fall back to normal startup detection.
   }
@@ -29,6 +33,26 @@ export function requestFullStartupReload(): void {
   })
 
   window.setTimeout(reload, 180)
+}
+
+export function consumeStartupStartedAt(): number {
+  const fallback = Date.now()
+  if (!import.meta.client) return fallback
+
+  try {
+    const raw = sessionStorage.getItem(STARTUP_STARTED_AT_KEY)
+    sessionStorage.removeItem(STARTUP_STARTED_AT_KEY)
+    const startedAt = Number(raw)
+    const age = fallback - startedAt
+
+    if (Number.isFinite(startedAt) && age >= 0 && age <= MAX_STARTUP_AGE_MS) {
+      return startedAt
+    }
+  } catch {
+    return fallback
+  }
+
+  return fallback
 }
 
 export function consumeForcedFullStartup(): boolean {

--- a/utils/startupLaunch.ts
+++ b/utils/startupLaunch.ts
@@ -36,14 +36,19 @@ export function requestFullStartupReload(): void {
 }
 
 export function consumeStartupStartedAt(): number {
-  const fallback = Date.now()
-  if (!import.meta.client) return fallback
+  const now = Date.now()
+  if (!import.meta.client) return now
+
+  const navigationStartedAt = Number(performance.timeOrigin)
+  const fallback = Number.isFinite(navigationStartedAt)
+    ? navigationStartedAt
+    : now
 
   try {
     const raw = sessionStorage.getItem(STARTUP_STARTED_AT_KEY)
     sessionStorage.removeItem(STARTUP_STARTED_AT_KEY)
     const startedAt = Number(raw)
-    const age = fallback - startedAt
+    const age = now - startedAt
 
     if (Number.isFinite(startedAt) && age >= 0 && age <= MAX_STARTUP_AGE_MS) {
       return startedAt


### PR DESCRIPTION
## What changed

- paints the startup heading and animated status line in the pre-hydration cover at the same time as the animated WebP
- records the sequence start timestamp before the launch-refresh reload
- carries that timestamp through session storage into the Vue loader
- uses browser navigation start as the timestamp for ordinary first-load startup
- schedules message changes against absolute startup deadlines rather than starting fresh when the client component mounts
- measures the animation visibility hold from the actual visible start instead of the later Vue image-load event

## Root cause

The instant video and the rest of the loader were separate layers:

1. `startup-cover.css` could paint the WebP before Vue hydration.
2. `kind-loader` is intentionally inside `ClientOnly`, so the heading, bubble loader, and status text appeared only after the client application mounted.
3. `loading-messages.vue` then started its full minimum sequence from that late mount time.

That made the video loop by itself for several seconds and then added another complete loader sequence.

## Expected behavior

- the first visible startup frame contains the video, heading, and animated status together
- when the Vue loader mounts, it replaces the pre-hydration copy without visibly restarting the sequence
- message transitions catch up to elapsed startup time
- launch-refresh and cold first visits share the same absolute sequence clock
- when stores are ready, the sequence remains approximately 4.2 seconds total from the initial cover—not another 4.2 seconds after hydration

## Validation

- final head: `901eb53046d22f57cb2ec4d687a27eb62636a565`
- branch is based on current `main`, behind by zero commits, and mergeable
- TypeScript Type Check passed
- Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel preview is READY
- preview root returned HTTP 200 and identified the final head as its build ID
- compiled startup stylesheet contains the immediate animated WebP cover plus the pre-hydration heading/status rules

A literal automated click-and-frame timing test was not available because the browser automation binary is absent in this environment. The live deployment, delivered markup, compiled CSS, timing code, and CI were validated; the remaining check is a quick human launch-refresh click in the preview.