### PR TITLE
Fix missing Project Suggest prompt button

### DIFF
--- a/plugins/project-art-prompt-suggest.client.ts
+++ b/plugins/project-art-prompt-suggest.client.ts
@@ -41,7 +41,7 @@ function positiveInteger(value: unknown): number | undefined {
   return Number.isInteger(number) && number > 0 ? number : undefined
 }
 
-function projectContext(element: HTMLElement): ProjectContext | null {
+function projectContextFromVue(element: HTMLElement): ProjectContext | null {
   let instance: VueInstanceLike | null | undefined =
     (element as VueElement).__vueParentComponent
 
@@ -70,6 +70,41 @@ function projectContext(element: HTMLElement): ProjectContext | null {
   return null
 }
 
+function projectSlugFromTarget(form: HTMLFormElement): string {
+  const target = Array.from(form.querySelectorAll<HTMLElement>('code'))
+    .map((element) => cleanString(element.textContent))
+    .find((value) => value.includes('/projects/images/'))
+
+  const match = target?.match(
+    /\/projects\/images\/(.+)-(?:icon|card|hero)\.webp(?:[?#].*)?$/i,
+  )
+  if (match?.[1]) return decodeURIComponent(match[1])
+
+  const params = new URLSearchParams(window.location.search)
+  return cleanString(
+    params.get('projectSlug') || params.get('project') || params.get('slug'),
+  )
+}
+
+function projectContext(
+  element: HTMLElement,
+  form: HTMLFormElement,
+): ProjectContext | null {
+  const vueContext = projectContextFromVue(element)
+  if (vueContext) return vueContext
+
+  const slug = projectSlugFromTarget(form)
+  if (!slug) return null
+
+  return {
+    slug,
+    title:
+      cleanString(document.querySelector('h1')?.textContent) ||
+      cleanString(document.title) ||
+      slug,
+  }
+}
+
 function selectedField(form: HTMLFormElement): ProjectArtField {
   const select = Array.from(
     form.querySelectorAll<HTMLSelectElement>('select'),
@@ -78,6 +113,15 @@ function selectedField(form: HTMLFormElement): ProjectArtField {
   )
   const value = select?.value
   return value === 'imagePath' || value === 'heroPath' ? value : 'cardPath'
+}
+
+function hasProjectTarget(form: HTMLFormElement): boolean {
+  return Array.from(form.querySelectorAll<HTMLSelectElement>('select')).some(
+    (select) =>
+      ['imagePath', 'cardPath', 'heroPath'].every((field) =>
+        Array.from(select.options).some((option) => option.value === field),
+      ),
+  )
 }
 
 function currentImageSource(form: HTMLFormElement): string | undefined {
@@ -99,16 +143,7 @@ function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
 function addSuggestButton(textarea: HTMLTextAreaElement): void {
   if (attached.has(textarea)) return
   const form = textarea.closest<HTMLFormElement>('form')
-  if (!form) return
-  const context = projectContext(textarea)
-  if (!context) return
-
-  const hasProjectTarget = Array.from(
-    form.querySelectorAll<HTMLSelectElement>('select'),
-  ).some((select) =>
-    Array.from(select.options).some((option) => option.value === 'heroPath'),
-  )
-  if (!hasProjectTarget) return
+  if (!form || !hasProjectTarget(form)) return
 
   attached.add(textarea)
   const button = document.createElement('button')
@@ -122,12 +157,19 @@ function addSuggestButton(textarea: HTMLTextAreaElement): void {
 
   button.addEventListener('click', async () => {
     if (button.dataset.loading === 'true') return
-    const currentContext = projectContext(textarea)
-    if (!currentContext) return
+    const currentContext = projectContext(textarea, form)
+    const initialLabel = button.textContent || '✨ Suggest prompt'
+
+    if (!currentContext) {
+      button.textContent = 'Could not identify Project'
+      window.setTimeout(() => {
+        button.textContent = initialLabel
+      }, 2400)
+      return
+    }
 
     const field = selectedField(form)
     const meta = FIELD_META[field]
-    const initialLabel = button.textContent || '✨ Suggest prompt'
     button.dataset.loading = 'true'
     button.disabled = true
     button.textContent = 'Suggesting…'

--- a/utils/scripts/verifyProjectArtPromptSuggest.ts
+++ b/utils/scripts/verifyProjectArtPromptSuggest.ts
@@ -19,13 +19,16 @@ expectContains('components/pages/conductor-art-gallery.vue', [
   'imagePath',
   'cardPath',
   'heroPath',
+  'generationTargetUrl',
 ])
 
 expectContains('plugins/project-art-prompt-suggest.client.ts', [
   'suggestArtAssetPrompt',
   "modelType: 'project'",
-  'props.projectId',
-  'props.slug',
+  'projectContextFromVue',
+  'projectSlugFromTarget',
+  "value.includes('/projects/images/')",
+  'hasProjectTarget(form)',
   'textarea[maxlength="4000"]',
   "imagePath: { label: 'Icon', variant: 'icon', width: 256, height: 256 }",
   "cardPath: { label: 'Card', variant: 'card', width: 512, height: 768 }",
@@ -34,6 +37,25 @@ expectContains('plugins/project-art-prompt-suggest.client.ts', [
   'current: textarea.value',
   'setTextareaValue(textarea, suggestion)',
 ])
+
+const plugin = read('plugins/project-art-prompt-suggest.client.ts')
+const attachIndex = plugin.indexOf('attached.add(textarea)')
+const clickIndex = plugin.indexOf("button.addEventListener('click'")
+const contextIndex = plugin.indexOf('projectContext(textarea, form)')
+if (attachIndex < 0 || clickIndex < 0 || contextIndex < clickIndex) {
+  throw new Error(
+    'Project Suggest prompt must attach from the explicit Project form before resolving context on click.',
+  )
+}
+
+const representativeTarget =
+  'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images/coloring-book-card.webp'
+const slugMatch = representativeTarget.match(
+  /\/projects\/images\/(.+)-(?:icon|card|hero)\.webp(?:[?#].*)?$/i,
+)
+if (slugMatch?.[1] !== 'coloring-book') {
+  throw new Error('Project target URL fallback did not preserve a hyphenated slug.')
+}
 
 expectContains('stores/helpers/artAssetSuggest.ts', [
   "builder: 'art-asset'",


### PR DESCRIPTION
## Root cause
The Project-specific prompt suggestion plugin required access to Vue's private `__vueParentComponent` props before it would attach the button. That lookup is not reliable on the rendered Project textarea, so the plugin silently returned and no **Suggest prompt** control appeared.

## Fix
- Identify the Project generation form from its explicit Icon/Card/Hero target selector.
- Attach **Suggest prompt** immediately without depending on private Vue internals.
- Resolve canonical Project context when clicked.
- Prefer component props when available, then recover the Project slug from the displayed canonical target URL, preserving hyphenated slugs.
- Keep the existing `/api/suggest` `art-asset` flow and editable textarea behavior unchanged.

## Validation
- Strengthened Project Art Prompt Suggestion Contract to verify attach-before-context behavior and target URL slug parsing.
- TypeScript Type Check
- Full Contract Tests
- Entity Art Manager Contract