### PR TITLE
ai-art-academy/t-010: add American Luminism curriculum entry

### DIFF
--- a/stores/seeds/academyStyles.ts
+++ b/stores/seeds/academyStyles.ts
@@ -1932,6 +1932,46 @@ export const academyStyles: AcademyStyle[] = [
         'Repaint this image as a Barbizon School landscape: a muted, earthy palette of greens, browns, and greys, loose but controlled brushwork, soft overcast or late-day atmospheric light, direct unidealized observation of a specific rural landscape, and a quiet, humble mood with no academic or mythological staging. Preserve the source composition and subject.',
     },
   },
+  {
+    slug: 'american-luminism',
+    name: 'American Luminism',
+    era: 'c. 1850–1875',
+    sortYear: 1850,
+    previewImageSrc: '/images/academy/styles/american-luminism.webp',
+    region: 'United States',
+    keyIdeas:
+      "American Luminism gives the curriculum a third lens on the same 19th-century American landscape tradition already taught through the Hudson River School (§32) and Tonalism (§39), and is deliberately distinct from both. Where Hudson River School painters build panoramic, geologically detailed drama and Tonalism dissolves the scene into a single muted, blurred tone, Luminist painters do the opposite of both: they render an exceptionally calm, glassy stretch of water or sky in crisp, almost invisible brushwork, so smooth the paint surface itself seems to disappear, and study the precise, still gradation of natural light at a specific moment — dawn haze, a becalmed noon, or the last low sun before a storm — with near-scientific clarity rather than blur or theatrical intensity. Many Luminist canvases (Heade's marsh and thunderstorm scenes especially) hold a hushed, almost eerie stillness, often with a single sailboat or salt-marsh haystack as the only mark of human presence in an otherwise silent, mirror-flat expanse. The movement was not named or grouped by its own painters — 'Luminism' is a mid-20th-century art-historical label applied retroactively to a shared sensibility among painters working independently along the American coast and inland waterways.",
+    recognitionCues: [
+      'Smooth, meticulously blended brushwork with the paint surface itself nearly invisible — the opposite of Impressionist or Barbizon visible touch',
+      'A perfectly calm, mirror-flat or glassy body of water or sky, often reflecting the sky’s exact gradation',
+      'Precise, almost scientific rendering of a specific quality of light (dawn haze, still midday heat, or pre-storm low sun) rather than dramatic theatrical illumination',
+      'A hushed, motionless, sometimes eerie stillness; time itself feels suspended',
+      'Minimal, incidental human presence — a single small sailboat, a distant figure, or a salt-marsh haystack, never the focus',
+      'Coastal, marsh, or inland-waterway subject matter far more often than mountain or forest interior scenes',
+    ],
+    artists: [
+      {
+        name: 'Fitz Henry Lane',
+        years: '1804–1865',
+        note: 'A Gloucester, Massachusetts marine painter and this lesson’s clearest generation-style anchor; his harbor and coastal scenes define the glassy-water, still-light Luminist signature.',
+      },
+      {
+        name: 'Martin Johnson Heade',
+        years: '1819–1904',
+        note: 'Known for salt-marsh haystack scenes and pre-storm coastal light studies with an unusually hushed, still-air quality even at the edge of a storm.',
+      },
+      {
+        name: 'John Frederick Kensett',
+        years: '1816–1872',
+        note: 'Painted calm inland lake and shoreline scenes (Lake George, Newport) with the same smooth, light-precise handling.',
+      },
+    ],
+    remix: {
+      mode: 'prompt',
+      template:
+        'Repaint this image in the American Luminist style: extremely smooth, near-invisible brushwork, a perfectly calm glassy body of water or sky reflecting a precise gradation of still natural light (dawn haze, quiet midday, or pre-storm low sun), a hushed and motionless mood, and minimal incidental human presence. Preserve the source composition and subject.',
+    },
+  },
 ]
 
 export const academyStylesBySlug: Record<string, AcademyStyle> = Object.assign(


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass, lane 4 (curriculum depth)  (kind: software)

### What changed / what I produced
- Added a new Academy curriculum movement, `american-luminism`, to `stores/seeds/academyStyles.ts`: era, region, key ideas, recognition cues, three verified artists (Fitz Henry Lane, Martin Johnson Heade, John Frederick Kensett), and a remix prompt template.
- No candidate file existed in conductor's `docs/curriculum-candidates/` for this movement (the only remaining unresolved candidate is Harlem Renaissance, correctly held at `ai-art-academy/t-043` pending Silas's cultural-framing call) — researched and written fresh this cycle, matching the pattern used for Italian Futurism / Ancient Egyptian Painting / Barbizon School.
- It gives the curriculum a third distinct lens on 19th-century American landscape painting alongside the already-contrasted Hudson River School (panoramic drama) and Tonalism (muted blur) entries, rather than restating either.
- Full lesson prose, recognition cues, artist notes, and example-work citations live in conductor's `docs/curriculum-outline.md` §41 (v1.21 addition) and its machine-readable skeleton.

### How I verified
- All three artists (Lane d. 1865, Heade d. 1904, Kensett d. 1872) clear PUBLIC-DOMAIN-POLICY.md §1.3's both-prongs rule (death >70 years ago, work published ≤1930) with wide margin.
- Verified all three example works directly against the Met Collection API (`collectionapi.metmuseum.org`), each returning `isPublicDomain: true`: object 11396 (*Stage Fort across Gloucester Harbor*, 1862), object 11050 (*Approaching Thunder Storm*, 1859), object 11311 (*Lake George*, 1869).
- `npm run test` (vue-tsc --noEmit) exit 0.
- `npx eslint stores/seeds/academyStyles.ts` clean.
- `npx prettier --check stores/seeds/academyStyles.ts` clean.

### Stakes
reversible

### Flags for Reviewer
- `previewImageSrc` points at `/images/academy/styles/american-luminism.webp`, which doesn't exist yet — same not-yet-delivered-asset pattern as every recent addition (fauvism, tonalism, barbizon-school). Image generation/delivery is a separate lane-3 follow-up.
- `exampleWorks` (the structured provenance array with accession IDs/license URLs) is intentionally omitted for now, matching the pattern of every curriculum-outline.md addition since §36 — it gets backfilled in a later pass alongside image delivery.

### Kaizen suggestion
`scripts/consume_art_requests.py`-style tooling could auto-check `previewImageSrc` files' HTTP status for every academy style on a schedule, instead of each lane-4/lane-3 cycle re-deriving the same manual curl check — would close the loop between "curriculum entry added" and "asset actually delivered" faster.

### Notes for reviewer
Companion conductor PR (docs/roadmap update) tracks this same t-010 cycle and closes out the roadmap task.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RXcUNckuSgUgnLKTpdArdm)_