### PR TITLE
Start Screen FX and controls with the loader

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -1,30 +1,95 @@
-html.kr-full-startup {
+html.kr-full-startup,
+html.kr-startup-handoff {
   background: #000;
 }
 
-html.kr-full-startup::before {
-  position: fixed;
-  inset: 0;
-  z-index: 2147483646;
-  background-color: #000;
-  background-image:
-    url('/images/startup-animations/launch-04.webp'),
-    url('/images/kindlogo_new.webp');
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: clamp(16rem, 58vw, 34rem) auto;
-  content: '';
-  pointer-events: none;
+.kr-prehydrate-loader {
+  display: contents;
 }
 
-.kr-prehydrate-loader {
+.kr-prehydrate-effect,
+.kr-prehydrate-content,
+.kr-prehydrate-controls {
   display: none;
 }
 
-html.kr-full-startup .kr-prehydrate-loader {
+html.kr-startup-handoff .kr-prehydrate-effect {
   position: fixed;
   inset: 0;
-  z-index: 2147483647;
+  z-index: 48;
+  display: block;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 48%, rgba(58, 85, 112, 0.2), transparent 34%),
+    radial-gradient(circle at 18% 24%, rgba(125, 211, 252, 0.11), transparent 26%),
+    radial-gradient(circle at 82% 72%, rgba(216, 180, 254, 0.1), transparent 30%);
+  opacity: 1;
+  pointer-events: none;
+  transition: opacity 320ms ease;
+  isolation: isolate;
+}
+
+html.kr-startup-effect-ready .kr-prehydrate-effect {
+  opacity: 0;
+}
+
+.kr-prehydrate-effect__glow {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(86vmax, 72rem);
+  aspect-ratio: 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 42% 58% 61% 39% / 56% 43% 57% 44%;
+  background:
+    conic-gradient(
+      from 20deg,
+      transparent,
+      rgba(103, 232, 249, 0.08),
+      transparent 31%,
+      rgba(232, 121, 249, 0.07),
+      transparent 67%,
+      rgba(147, 197, 253, 0.08),
+      transparent
+    );
+  filter: blur(1.2rem);
+  opacity: 0.9;
+  transform: translate(-50%, -50%);
+  animation: kr-prehydrate-effect-turn 16s linear infinite;
+}
+
+.kr-prehydrate-effect__particles,
+.kr-prehydrate-effect__particles i {
+  position: absolute;
+}
+
+.kr-prehydrate-effect__particles {
+  inset: 0;
+}
+
+.kr-prehydrate-effect__particles i {
+  top: var(--kr-y);
+  left: var(--kr-x);
+  width: var(--kr-size);
+  height: var(--kr-size);
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  border-radius: 42% 58% 68% 32% / 64% 38% 62% 36%;
+  background:
+    radial-gradient(circle at 35% 30%, #fff, rgba(147, 197, 253, 0.78) 34%, rgba(99, 102, 241, 0.15) 72%, transparent 76%);
+  box-shadow:
+    0 0 0.8rem rgba(125, 211, 252, 0.45),
+    0 0 1.8rem rgba(129, 140, 248, 0.18);
+  opacity: 0;
+  animation:
+    kr-prehydrate-effect-drift var(--kr-duration) linear var(--kr-delay) infinite,
+    kr-prehydrate-effect-flutter 1.1s ease-in-out var(--kr-delay) infinite alternate;
+  will-change: transform, opacity;
+}
+
+html.kr-full-startup .kr-prehydrate-content {
+  position: fixed;
+  inset: 0;
+  z-index: 55;
   display: grid;
   padding: 1rem;
   place-items: center;
@@ -33,9 +98,8 @@ html.kr-full-startup .kr-prehydrate-loader {
 }
 
 .kr-prehydrate-content {
-  display: grid;
-  width: min(98vw, 64rem);
-  height: min(92vh, 52rem);
+  width: 100%;
+  height: 100%;
   grid-template-rows: minmax(3.75rem, auto) minmax(0, 1fr) 8rem;
   place-items: center;
 }
@@ -54,6 +118,7 @@ html.kr-full-startup .kr-prehydrate-loader {
   font-weight: 700;
   text-align: center;
   box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(0.35rem);
 }
 
 .kr-prehydrate-heading {
@@ -64,9 +129,11 @@ html.kr-full-startup .kr-prehydrate-loader {
 
 .kr-prehydrate-visual {
   position: relative;
-  width: 100%;
+  display: grid;
+  width: min(98vw, 64rem);
   height: 100%;
   min-height: 0;
+  place-items: center;
   isolation: isolate;
 }
 
@@ -103,6 +170,18 @@ html.kr-full-startup .kr-prehydrate-loader {
   filter: blur(0.65rem);
   opacity: 0.72;
   animation: kr-prehydrate-logo-wobble 10s ease-in-out infinite alternate;
+}
+
+.kr-prehydrate-media {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: clamp(16rem, 58vw, 34rem);
+  height: auto;
+  max-height: 100%;
+  object-fit: contain;
+  opacity: 1;
+  filter: drop-shadow(0 1rem 2.5rem rgba(0, 0, 0, 0.48));
 }
 
 .kr-prehydrate-status {
@@ -202,12 +281,68 @@ html.kr-full-startup .kr-prehydrate-loader {
   animation-delay: 2.5s;
 }
 
-html.kr-full-startup .loader-root {
-  z-index: 2147483647;
+html.kr-startup-handoff .kr-prehydrate-controls {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 61;
+  display: flex;
+  width: fit-content;
+  max-width: calc(100vw - 2rem);
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.35rem 0.3rem 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  box-shadow: 0 0.65rem 1.75rem rgba(0, 0, 0, 0.42);
+  opacity: 1;
+  pointer-events: auto;
+  backdrop-filter: blur(0.7rem);
+  transition: opacity 180ms ease;
+}
+
+html.kr-startup-controls-ready .kr-prehydrate-controls {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.kr-prehydrate-controls__name {
+  overflow: hidden;
+  max-width: min(12rem, 42vw);
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kr-prehydrate-controls__button {
+  display: inline-flex;
+  min-height: 1.5rem;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.45rem;
+  padding: 0.2rem 0.45rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.kr-prehydrate-controls__button:hover,
+.kr-prehydrate-controls__button:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  outline: none;
 }
 
 .loading-logo-frame {
-  background-color: #000;
+  background-color: transparent;
   background-image:
     url('/images/startup-animations/launch-04.webp'),
     url('/images/kindlogo_new.webp');
@@ -222,6 +357,52 @@ html.kr-full-startup .loader-root {
 
 html.kr-full-startup .kr-boot-curtain {
   display: block !important;
+}
+
+@keyframes kr-prehydrate-effect-turn {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg) scale(0.94);
+  }
+
+  50% {
+    transform: translate(-50%, -50%) rotate(180deg) scale(1.04);
+  }
+
+  to {
+    transform: translate(-50%, -50%) rotate(360deg) scale(0.94);
+  }
+}
+
+@keyframes kr-prehydrate-effect-drift {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0) rotate(-8deg) scale(0.72);
+  }
+
+  16% {
+    opacity: 0.72;
+  }
+
+  78% {
+    opacity: 0.62;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--kr-drift-x), var(--kr-drift-y), 0) rotate(34deg) scale(1.24);
+  }
+}
+
+@keyframes kr-prehydrate-effect-flutter {
+  from {
+    border-radius: 42% 58% 68% 32% / 64% 38% 62% 36%;
+    filter: brightness(0.82);
+  }
+
+  to {
+    border-radius: 66% 34% 38% 62% / 36% 68% 32% 64%;
+    filter: brightness(1.24);
+  }
 }
 
 @keyframes kr-prehydrate-logo-haze {
@@ -273,12 +454,29 @@ html.kr-full-startup .kr-boot-curtain {
   }
 }
 
+@media (max-width: 639px) {
+  html.kr-startup-handoff .kr-prehydrate-controls {
+    right: 0.75rem;
+    bottom: 0.75rem;
+    left: 0.75rem;
+    justify-content: center;
+    width: auto;
+    max-width: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .kr-prehydrate-effect__glow,
+  .kr-prehydrate-effect__particles i,
   .kr-prehydrate-visual::before,
   .kr-prehydrate-visual::after,
   .kr-prehydrate-spinner i,
   .kr-prehydrate-message span {
     animation: none;
+  }
+
+  .kr-prehydrate-effect__particles i {
+    display: none;
   }
 
   .kr-prehydrate-message span:first-child {

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -3,102 +3,113 @@
   <Teleport to="body">
     <div
       v-if="renderEffect && currentComponent"
-      class="startup-animation"
-      :class="{ 'startup-animation--fading': isFading }"
+      class="startup-animation__stage"
+      :class="{
+        'startup-animation__stage--ready': effectReady,
+        'startup-animation__stage--fading': isFading,
+      }"
     >
-      <component
-        :is="currentComponent"
-        :key="resolvedEffectId"
-        class="startup-animation__effect"
-        aria-hidden="true"
-      />
+      <Suspense :key="resolvedEffectId" @resolve="handleEffectReady">
+        <component
+          :is="currentComponent"
+          :key="resolvedEffectId"
+          class="startup-animation__effect"
+          aria-hidden="true"
+        />
 
-      <div
-        class="startup-animation__controls"
-        :class="{
-          'startup-animation__controls--active': startupStore.controlsActive,
-          'startup-animation__controls--compact': !startupStore.controlsActive,
-        }"
-      >
-        <template v-if="startupStore.controlsActive">
-          <span class="startup-animation__name">{{ currentEffectLabel }}</span>
-
-          <div class="startup-animation__button-group">
-            <button
-              type="button"
-              class="btn btn-xs btn-ghost btn-square text-white"
-              title="Previous animation"
-              aria-label="Previous animation"
-              @click="selectPreviousEffect"
-            >
-              <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
-            </button>
-
-            <button
-              type="button"
-              class="btn btn-xs btn-ghost gap-1 text-white"
-              title="Choose another random animation"
-              @click="selectRandomEffect"
-            >
-              <Icon name="kind-icon:sparkles" class="h-4 w-4" />
-              <span class="hidden sm:inline">Random</span>
-            </button>
-
-            <button
-              type="button"
-              class="btn btn-xs btn-ghost btn-square text-white"
-              title="Next animation"
-              aria-label="Next animation"
-              @click="selectNextEffect"
-            >
-              <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
-            </button>
-          </div>
-
-          <div class="startup-animation__divider" />
-
-          <button
-            type="button"
-            class="btn btn-xs border-white/20 bg-white/10 text-white hover:bg-white/20"
-            title="Restore the launch screen and continue loading"
-            @click="startupStore.leaveControlMode()"
-          >
-            Resume
-          </button>
-
-          <button
-            type="button"
-            class="btn btn-xs btn-square border-white/20 bg-black/30 text-white hover:bg-error/70"
-            title="Leave startup animation"
-            aria-label="Leave startup animation"
-            @click="startupStore.requestExit()"
-          >
-            <Icon name="kind-icon:x" class="h-4 w-4" />
-          </button>
+        <template #fallback>
+          <span class="startup-animation__effect-placeholder" aria-hidden="true" />
         </template>
+      </Suspense>
+    </div>
 
-        <template v-else>
-          <span class="startup-animation__compact-name">
-            {{ currentEffectLabel }}
-          </span>
+    <div
+      v-if="renderEffect && currentComponent"
+      class="startup-animation__controls"
+      :class="{
+        'startup-animation__controls--active': startupStore.controlsActive,
+        'startup-animation__controls--compact': !startupStore.controlsActive,
+        'startup-animation__controls--fading': isFading,
+      }"
+    >
+      <template v-if="startupStore.controlsActive">
+        <span class="startup-animation__name">{{ currentEffectLabel }}</span>
+
+        <div class="startup-animation__button-group">
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost btn-square text-white"
+            title="Previous animation"
+            aria-label="Previous animation"
+            @click="selectPreviousEffect"
+          >
+            <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+          </button>
 
           <button
             type="button"
-            class="btn btn-xs border-white/20 bg-white/10 text-white hover:bg-white/20"
-            title="Pause the launch and explore animations"
-            @click="startupStore.enterControlMode()"
+            class="btn btn-xs btn-ghost gap-1 text-white"
+            title="Choose another random animation"
+            @click="selectRandomEffect"
           >
             <Icon name="kind-icon:sparkles" class="h-4 w-4" />
-            <span>Pause &amp; explore</span>
+            <span class="hidden sm:inline">Random</span>
           </button>
-        </template>
-      </div>
+
+          <button
+            type="button"
+            class="btn btn-xs btn-ghost btn-square text-white"
+            title="Next animation"
+            aria-label="Next animation"
+            @click="selectNextEffect"
+          >
+            <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+          </button>
+        </div>
+
+        <div class="startup-animation__divider" />
+
+        <button
+          type="button"
+          class="btn btn-xs border-white/20 bg-white/10 text-white hover:bg-white/20"
+          title="Restore the launch screen and continue loading"
+          @click="startupStore.leaveControlMode()"
+        >
+          Resume
+        </button>
+
+        <button
+          type="button"
+          class="btn btn-xs btn-square border-white/20 bg-black/30 text-white hover:bg-error/70"
+          title="Leave startup animation"
+          aria-label="Leave startup animation"
+          @click="startupStore.requestExit()"
+        >
+          <Icon name="kind-icon:x" class="h-4 w-4" />
+        </button>
+      </template>
+
+      <template v-else>
+        <span class="startup-animation__compact-name">
+          {{ currentEffectLabel }}
+        </span>
+
+        <button
+          type="button"
+          class="btn btn-xs border-white/20 bg-white/10 text-white hover:bg-white/20"
+          title="Pause the launch and explore animations"
+          @click="startupStore.enterControlMode()"
+        >
+          <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+          <span>Pause &amp; explore</span>
+        </button>
+      </template>
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { getAnimationEffectComponent } from '@/components/screenfx/effect-component-registry'
 import type { AnimationEffectId } from '@/stores/animationCatalog'
 import { useAnimationStore } from '@/stores/animationStore'
@@ -108,6 +119,23 @@ import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 
 defineOptions({ inheritAttrs: false })
 
+type StartupBridgeAction =
+  | 'explore'
+  | 'previous'
+  | 'random'
+  | 'next'
+  | 'resume'
+  | 'exit'
+
+type StartupBridgeWindow = Window & {
+  __KR_STARTUP_ACTION_QUEUE__?: string[]
+}
+
+const HANDOFF_CLASS = 'kr-startup-handoff'
+const EFFECT_READY_CLASS = 'kr-startup-effect-ready'
+const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
+const BRIDGE_EVENT = 'kr-startup-action'
+
 const animationStore = useAnimationStore()
 const preferenceStore = useAnimationPreferenceStore()
 const butterflyStore = useButterflyStore()
@@ -115,11 +143,14 @@ const startupStore = useStartupAnimationStore()
 
 const resolvedEffectId = ref<AnimationEffectId | null>(null)
 const renderEffect = ref(false)
+const effectReady = ref(false)
 const isFading = ref(false)
 
 const FADE_MS = 650
+const HANDOFF_FADE_MS = 340
 
 let fadeTimer: ReturnType<typeof setTimeout> | null = null
+let handoffTimer: ReturnType<typeof setTimeout> | null = null
 
 const availableEffectIds = computed(() => {
   return animationStore.safeEffects
@@ -151,10 +182,51 @@ function clearFadeTimer(): void {
   fadeTimer = null
 }
 
+function clearHandoffTimer(): void {
+  if (!handoffTimer) return
+  clearTimeout(handoffTimer)
+  handoffTimer = null
+}
+
+function finishHandoffIfReady(): void {
+  if (!import.meta.client) return
+
+  const root = document.documentElement
+  if (!root.classList.contains(EFFECT_READY_CLASS)) return
+  if (!root.classList.contains(CONTROLS_READY_CLASS)) return
+  if (!root.classList.contains(HANDOFF_CLASS)) return
+
+  clearHandoffTimer()
+  handoffTimer = setTimeout(() => {
+    root.classList.remove(HANDOFF_CLASS)
+    handoffTimer = null
+  }, HANDOFF_FADE_MS)
+}
+
+function markControlsReady(): void {
+  if (!import.meta.client) return
+  document.documentElement.classList.add(CONTROLS_READY_CLASS)
+  finishHandoffIfReady()
+}
+
+function handleEffectReady(): void {
+  effectReady.value = true
+
+  if (!import.meta.client) return
+  document.documentElement.classList.add(EFFECT_READY_CLASS)
+  finishHandoffIfReady()
+}
+
 function setEffect(effectId: AnimationEffectId | null): void {
   resolvedEffectId.value = effectId
   renderEffect.value = Boolean(effectId)
+  effectReady.value = false
   isFading.value = false
+
+  if (!effectId && import.meta.client) {
+    document.documentElement.classList.add(EFFECT_READY_CLASS)
+    finishHandoffIfReady()
+  }
 }
 
 function selectEffect(): void {
@@ -194,6 +266,45 @@ function selectRandomEffect(): void {
   setEffect(pool[index] ?? ids[0] ?? null)
 }
 
+function applyBridgeAction(action: string): void {
+  switch (action as StartupBridgeAction) {
+    case 'explore':
+      startupStore.enterControlMode()
+      break
+    case 'previous':
+      selectPreviousEffect()
+      break
+    case 'random':
+      selectRandomEffect()
+      break
+    case 'next':
+      selectNextEffect()
+      break
+    case 'resume':
+      startupStore.leaveControlMode()
+      break
+    case 'exit':
+      startupStore.requestExit()
+      break
+  }
+}
+
+function handleBridgeEvent(event: Event): void {
+  const action = (event as CustomEvent<string>).detail
+  if (typeof action !== 'string') return
+  applyBridgeAction(action)
+}
+
+function consumeBridgeQueue(): void {
+  if (!import.meta.client) return
+
+  const bridgeWindow = window as StartupBridgeWindow
+  const queue = bridgeWindow.__KR_STARTUP_ACTION_QUEUE__ ?? []
+  bridgeWindow.__KR_STARTUP_ACTION_QUEUE__ = []
+
+  queue.forEach(applyBridgeAction)
+}
+
 function fadeOut(): void {
   if (!renderEffect.value || isFading.value) return
 
@@ -226,27 +337,42 @@ watch(
   },
 )
 
+onMounted(() => {
+  window.addEventListener(BRIDGE_EVENT, handleBridgeEvent)
+  markControlsReady()
+  consumeBridgeQueue()
+})
+
 onBeforeUnmount(() => {
   clearFadeTimer()
+  clearHandoffTimer()
+
+  if (import.meta.client) {
+    window.removeEventListener(BRIDGE_EVENT, handleBridgeEvent)
+  }
 })
 </script>
 
 <style scoped>
-.startup-animation {
+.startup-animation__stage {
   position: fixed;
   inset: 0;
   z-index: 49;
   overflow: hidden;
-  background: #000;
   pointer-events: none;
-  opacity: 1;
-  transition: opacity 650ms ease;
+  opacity: 0;
+  transition: opacity 320ms ease;
   isolation: isolate;
   will-change: opacity;
 }
 
-.startup-animation--fading {
+.startup-animation__stage--ready {
+  opacity: 1;
+}
+
+.startup-animation__stage--fading {
   opacity: 0;
+  transition-duration: 650ms;
 }
 
 .startup-animation__effect {
@@ -256,11 +382,16 @@ onBeforeUnmount(() => {
   height: 100%;
 }
 
-.startup-animation__controls {
+.startup-animation__effect-placeholder {
   position: absolute;
+  inset: 0;
+}
+
+.startup-animation__controls {
+  position: fixed;
   bottom: 1rem;
   left: 1rem;
-  z-index: 100;
+  z-index: 60;
   display: flex;
   width: fit-content;
   max-width: calc(100vw - 2rem);
@@ -270,11 +401,18 @@ onBeforeUnmount(() => {
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(0, 0, 0, 0.7);
   box-shadow: 0 0.65rem 1.75rem rgba(0, 0, 0, 0.42);
+  opacity: 1;
   backdrop-filter: blur(0.7rem);
   transition:
+    opacity 180ms ease,
     border-radius 180ms ease,
     padding 180ms ease,
     gap 180ms ease;
+}
+
+.startup-animation__controls--fading {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .startup-animation__controls--compact {
@@ -346,7 +484,7 @@ onBeforeUnmount(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .startup-animation,
+  .startup-animation__stage,
   .startup-animation__controls {
     transition: none;
   }

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -9,7 +9,10 @@
         'startup-animation__stage--fading': isFading,
       }"
     >
-      <Suspense :key="resolvedEffectId" @resolve="handleEffectReady">
+      <Suspense
+        :key="resolvedEffectId ?? 'startup-effect'"
+        @resolve="handleEffectReady"
+      >
         <component
           :is="currentComponent"
           :key="resolvedEffectId"

--- a/server/plugins/startup-loader-shell.ts
+++ b/server/plugins/startup-loader-shell.ts
@@ -1,26 +1,119 @@
+const startupParticles = [
+  ['8%', '18%', '1.05rem', '8.2s', '-5.4s', '8vw', '-14vh'],
+  ['16%', '72%', '0.55rem', '10.4s', '-2.1s', '-6vw', '-18vh'],
+  ['24%', '42%', '0.8rem', '7.6s', '-4.8s', '10vw', '-10vh'],
+  ['31%', '84%', '0.45rem', '9.8s', '-7.2s', '-8vw', '-20vh'],
+  ['39%', '12%', '0.7rem', '11.2s', '-1.5s', '7vw', '-13vh'],
+  ['47%', '64%', '1.15rem', '8.8s', '-6.1s', '-10vw', '-16vh'],
+  ['54%', '30%', '0.5rem', '9.3s', '-3.7s', '9vw', '-19vh'],
+  ['61%', '78%', '0.85rem', '10.8s', '-8.4s', '-7vw', '-12vh'],
+  ['68%', '16%', '0.48rem', '7.9s', '-2.8s', '11vw', '-17vh'],
+  ['74%', '54%', '1rem', '9.6s', '-5.9s', '-9vw', '-15vh'],
+  ['82%', '86%', '0.62rem', '11.6s', '-9.1s', '6vw', '-21vh'],
+  ['90%', '34%', '0.76rem', '8.5s', '-4.2s', '-11vw', '-11vh'],
+  ['12%', '92%', '0.42rem', '12.1s', '-10.2s', '8vw', '-22vh'],
+  ['28%', '24%', '0.58rem', '9.1s', '-6.7s', '-6vw', '-14vh'],
+  ['44%', '90%', '0.72rem', '10.1s', '-3.3s', '10vw', '-18vh'],
+  ['58%', '48%', '0.4rem', '8.1s', '-7.5s', '-8vw', '-12vh'],
+  ['72%', '68%', '0.66rem', '11s', '-1.9s', '7vw', '-20vh'],
+  ['86%', '8%', '0.52rem', '9.4s', '-5.1s', '-10vw', '-16vh'],
+]
+
+function renderParticles(): string {
+  return startupParticles
+    .map(
+      ([x, y, size, duration, delay, driftX, driftY]) =>
+        `<i style="--kr-x:${x};--kr-y:${y};--kr-size:${size};--kr-duration:${duration};--kr-delay:${delay};--kr-drift-x:${driftX};--kr-drift-y:${driftY}"></i>`,
+    )
+    .join('')
+}
+
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', (html) => {
     html.bodyPrepend.push(`
-      <div class="kr-prehydrate-loader" aria-hidden="true">
+      <div class="kr-prehydrate-loader">
+        <div class="kr-prehydrate-effect" aria-hidden="true">
+          <div class="kr-prehydrate-effect__glow"></div>
+          <div class="kr-prehydrate-effect__particles">${renderParticles()}</div>
+        </div>
+
         <div class="kr-prehydrate-content">
           <div class="kr-prehydrate-heading">Building Kind Robots...</div>
 
-          <div class="kr-prehydrate-visual"></div>
+          <div class="kr-prehydrate-visual">
+            <img
+              src="/images/startup-animations/launch-04.webp"
+              alt="Kind Robots"
+              class="kr-prehydrate-media"
+              width="720"
+              height="720"
+              fetchpriority="high"
+              decoding="async"
+            />
+          </div>
 
           <div class="kr-prehydrate-status">
-            <span class="kr-prehydrate-spinner">
+            <span class="kr-prehydrate-spinner" aria-hidden="true">
               <i></i><i></i><i></i><i></i>
               <i></i><i></i><i></i><i></i>
             </span>
 
-            <div class="kr-prehydrate-message">
+            <div class="kr-prehydrate-message" aria-live="polite">
               <span>Wiring robots for suspicious levels of charm...</span>
               <span>Downloading charm...</span>
               <span>Releasing digital butterflies...</span>
             </div>
           </div>
         </div>
+
+        <div class="kr-prehydrate-controls">
+          <span class="kr-prehydrate-controls__name">Startup animation</span>
+          <button
+            type="button"
+            class="kr-prehydrate-controls__button"
+            data-kr-startup-action="explore"
+          >
+            <span aria-hidden="true">✦</span>
+            <span>Pause &amp; explore</span>
+          </button>
+        </div>
       </div>
+
+      <script>
+        (() => {
+          const root = document.documentElement
+          if (!root.classList.contains('kr-full-startup')) return
+
+          root.classList.add('kr-startup-handoff')
+          const queue = window.__KR_STARTUP_ACTION_QUEUE__ || []
+          window.__KR_STARTUP_ACTION_QUEUE__ = queue
+
+          document.addEventListener('click', (event) => {
+            const source = event.target
+            if (!(source instanceof Element)) return
+            const control = source.closest('[data-kr-startup-action]')
+            if (!(control instanceof HTMLElement)) return
+
+            const action = control.dataset.krStartupAction
+            if (!action) return
+
+            event.preventDefault()
+
+            if (root.classList.contains('kr-startup-controls-ready')) {
+              window.dispatchEvent(
+                new CustomEvent('kr-startup-action', { detail: action }),
+              )
+              return
+            }
+
+            queue.push(action)
+          })
+
+          window.setTimeout(() => {
+            root.classList.remove('kr-startup-handoff')
+          }, 8000)
+        })()
+      </script>
     `)
   })
 })


### PR DESCRIPTION
## What changed

- replaces the single opaque maximum-z startup cover with explicit layers
- keeps the black startup base at the bottom
- starts a lightweight animated effect bridge immediately above the black base
- keeps the launch WebP, heading, spinner, and rotating messages above the animation
- renders the compact animation control immediately and queues an early `Pause & explore` click until Vue is ready
- splits the real startup Screen FX stage from its controls so the effect remains below loader content while controls remain above it
- fades the bridge only after the selected Vue effect resolves, and fades the temporary control only after the real control mounts
- includes an eight-second handoff failsafe so no pre-hydration layer can remain stuck

## Layer order

1. black base
2. pre-hydration effect bridge (`z-index: 48`)
3. real startup Screen FX (`z-index: 49`)
4. loader media, heading, spinner, and messages (`z-index: 50–55`)
5. real and pre-hydration animation controls (`z-index: 60–61`)

## Why

The launch WebP and black background were previously fused into one pseudo-element at `z-index: 2147483646`. That element necessarily hid the actual Screen FX stage and its controls until the cover class was removed. The messages could be server-rendered early, but the true animation system still had no visible layer to occupy.

## Handoff behavior

- the temporary CSS effect starts in the initial server-rendered frame
- the actual selected Vue Screen FX loads beneath the foreground loader
- the temporary effect remains visible until the selected Vue effect resolves through `Suspense`
- the pre-hydration control remains visible until the real Vue control mounts
- early `Pause & explore` clicks are queued and replayed after the real control becomes available
- the bridge and real effect cross-fade without exposing an empty black-only frame

## Validation

- final head: `baa26b0b7eedc0b93a899ff80a5843964e7ec119`
- TypeScript Type Check passed
- full Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel deployment is READY and built from the final head
- preview root returned HTTP 200
- delivered HTML contains the effect bridge, launch WebP, spinner, rotating messages, and pre-hydration control before `#__nuxt`
- delivered HTML reports the final build ID `baa26b0b7eedc0b93a899ff80a5843964e7ec119`
- old maximum-z startup pseudo-cover has been removed from source
- PR is mergeable

The remaining validation is the real visual launch-refresh click, particularly the cross-fade from the temporary effect into whichever random Screen FX is selected.