### PR TITLE
Fade the complete startup composition together

### DIFF
--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -8,7 +8,7 @@ const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
 export default defineNuxtPlugin((nuxtApp) => {
   const root = document.documentElement
   let sawLoader = false
-  let cleanupTimer: ReturnType<typeof window.setTimeout> | null = null
+  let cleanupTimer: number | null = null
 
   function clearCleanupTimer(): void {
     if (cleanupTimer === null) return

--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -1,0 +1,76 @@
+const ACTIVE_CLASS = 'kr-startup-active'
+const FADING_CLASS = 'kr-startup-fading'
+const COVER_CLASS = 'kr-full-startup'
+const HANDOFF_CLASS = 'kr-startup-handoff'
+const EFFECT_READY_CLASS = 'kr-startup-effect-ready'
+const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const root = document.documentElement
+  let sawLoader = false
+  let cleanupTimer: ReturnType<typeof window.setTimeout> | null = null
+
+  function clearCleanupTimer(): void {
+    if (cleanupTimer === null) return
+    window.clearTimeout(cleanupTimer)
+    cleanupTimer = null
+  }
+
+  function cleanup(): void {
+    clearCleanupTimer()
+    root.classList.remove(
+      ACTIVE_CLASS,
+      FADING_CLASS,
+      COVER_CLASS,
+      HANDOFF_CLASS,
+      EFFECT_READY_CLASS,
+      CONTROLS_READY_CLASS,
+    )
+  }
+
+  function scheduleCleanup(): void {
+    if (cleanupTimer !== null) return
+
+    cleanupTimer = window.setTimeout(() => {
+      cleanupTimer = null
+      cleanup()
+      observer.disconnect()
+    }, 700)
+  }
+
+  function syncCompositionState(): void {
+    if (root.classList.contains(COVER_CLASS)) {
+      root.classList.add(ACTIVE_CLASS, HANDOFF_CLASS)
+    }
+
+    const loader = document.querySelector('.loader-root')
+    const overlay = document.querySelector('.loading-overlay')
+
+    if (loader || overlay) {
+      sawLoader = true
+      clearCleanupTimer()
+    }
+
+    if (overlay?.classList.contains('loading-overlay--fade')) {
+      root.classList.add(FADING_CLASS)
+    }
+
+    if (sawLoader && !loader && !overlay) {
+      scheduleCleanup()
+    }
+  }
+
+  const observer = new MutationObserver(syncCompositionState)
+
+  observer.observe(document.documentElement, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  })
+
+  syncCompositionState()
+
+  nuxtApp.hook('app:mounted', syncCompositionState)
+  window.addEventListener('pagehide', cleanup, { once: true })
+})

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -1,0 +1,59 @@
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:html', (html) => {
+    html.bodyPrepend.unshift(`
+      <style>
+        .kr-startup-black-base {
+          display: none;
+          position: fixed;
+          inset: 0;
+          z-index: 47;
+          background: #000;
+          opacity: 1;
+          pointer-events: none;
+          transition: opacity 650ms ease;
+          will-change: opacity;
+        }
+
+        html.kr-full-startup .kr-startup-black-base,
+        html.kr-startup-active .kr-startup-black-base {
+          display: block;
+        }
+
+        html.kr-startup-fading .kr-startup-black-base,
+        html:has(.loading-overlay--fade) .kr-startup-black-base {
+          opacity: 0;
+        }
+
+        html.kr-startup-fading .startup-animation__stage,
+        html.kr-startup-fading .startup-animation__controls,
+        html:has(.loading-overlay--fade) .startup-animation__stage,
+        html:has(.loading-overlay--fade) .startup-animation__controls {
+          opacity: 0 !important;
+          transition: opacity 650ms ease !important;
+          pointer-events: none;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .kr-startup-black-base,
+          html.kr-startup-fading .startup-animation__stage,
+          html.kr-startup-fading .startup-animation__controls,
+          html:has(.loading-overlay--fade) .startup-animation__stage,
+          html:has(.loading-overlay--fade) .startup-animation__controls {
+            transition: none !important;
+          }
+        }
+      </style>
+
+      <script>
+        (() => {
+          const root = document.documentElement
+          if (!root.classList.contains('kr-full-startup')) return
+
+          root.classList.add('kr-startup-active', 'kr-startup-handoff')
+        })()
+      </script>
+
+      <div class="kr-startup-black-base" aria-hidden="true"></div>
+    `)
+  })
+})


### PR DESCRIPTION
## What changed

- adds an explicit fixed black startup base at `z-index: 47`, below the animation and above the desktop
- activates the existing startup handoff before the server-rendered loader shell is parsed, so black, animation bridge, launch media, messages, spinner, and controls paint in the same first frame
- keeps the black base alive after the pre-hydration media hands off to Vue
- treats `.loading-overlay--fade` as the single exit signal for the black base, real startup effect, and animation controls
- applies the same 650 ms opacity transition to the full composition
- cleans all temporary startup classes after the real loader leaves the DOM

## Root cause

The pre-hydration image was keyed directly to `kr-full-startup`, but the animation bridge and controls waited for a body script to add `kr-startup-handoff`. The black layer was also the short-lived Vue boot curtain, which intentionally disappeared before the loader sequence ended. That allowed the image to paint over the already-rendered dashboard.

At exit, the loader, Screen FX wrapper, controls, and black layer were governed by separate state changes. Even when their nominal durations matched, their clocks did not share one DOM signal.

## Expected behavior

- first frame: black base + animation bridge + launch WebP + loading copy/spinner + controls
- handoff: real Screen FX replaces the bridge while the black base remains
- exit: black base, real effect, media/copy/spinner, and controls all begin the same 650 ms fade together
- desktop is revealed only through that unified fade

## Validation

- final head: `d24f72ad60e42db8956003c8ea5e0730d0eff010`
- TypeScript Type Check passed
- Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel deployment `dpl_HeQmVpyJTEfqS7cNoof7Rcy38cR7` is READY and built from the final head
- preview root returned HTTP 200
- delivered HTML places the inline startup style and activation script first in the body, followed by `.kr-startup-black-base`, then the existing animation/media loader shell, all before `#__nuxt`
- delivered CSS ties the black base, real Screen FX stage, and real controls to the same `.loading-overlay--fade` state and 650 ms transition
- delivered Nuxt public build ID matches the final head

A literal frame-by-frame click recording is not available in this environment. The server response, first-paint order, shared fade contract, compiled build, deployment, and CI have been validated; the remaining check is the visual dashboard refresh click.