### PR TITLE
Add optional dashboard maturity toggle

### DIFF
--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -1,0 +1,62 @@
+<!-- /components/navigation/maturity-toggle.vue -->
+<template>
+  <button
+    v-if="userStore.isLoggedIn"
+    type="button"
+    class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border"
+    :class="
+      showMature
+        ? 'border-warning/60 bg-warning/15 text-warning'
+        : 'border-base-300 bg-base-100 text-base-content/60'
+    "
+    :aria-label="buttonLabel"
+    :aria-pressed="showMature"
+    :title="buttonTitle"
+    :disabled="isUpdating"
+    @click="toggleMature"
+  >
+    <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
+    <Icon
+      v-else
+      :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"
+      class="h-5 w-5"
+    />
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useAccountStore } from '@/stores/accountStore'
+import { useUserStore } from '@/stores/userStore'
+
+const accountStore = useAccountStore()
+const userStore = useUserStore()
+
+const isUpdating = ref(false)
+const updateError = ref('')
+
+const showMature = computed(() => userStore.showMature)
+const buttonLabel = computed(() =>
+  showMature.value ? 'Hide mature content' : 'Show mature content',
+)
+const buttonTitle = computed(() => updateError.value || buttonLabel.value)
+
+async function toggleMature(): Promise<void> {
+  if (isUpdating.value) return
+
+  isUpdating.value = true
+  updateError.value = ''
+
+  try {
+    const result = await accountStore.updateConsent({
+      showMature: !showMature.value,
+    })
+
+    if (!result.success) {
+      updateError.value = result.message || 'Could not update mature content.'
+    }
+  } finally {
+    isUpdating.value = false
+  }
+}
+</script>

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -84,6 +84,9 @@
         </button>
 
         <server-selector class="header-control-item min-w-0" />
+        <maturity-toggle
+          v-if="showDashboardMaturityToggle && userStore.isLoggedIn"
+        />
         <notification-bell class="shrink-0" />
         <login-switcher class="header-control-item min-w-0" />
         <mana-widget class="shrink-0" />
@@ -93,23 +96,31 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { ResolvedTab } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
+import { useMaturityPreferenceStore } from '@/stores/maturityPreferenceStore'
 import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
+import { useUserStore } from '@/stores/userStore'
 import { requestFullStartupReload } from '@/utils/startupLaunch'
 
 const fallbackIcon = 'kind-icon:sparkles'
 
 const channelContentStore = useChannelContentStore()
+const maturityPreferenceStore = useMaturityPreferenceStore()
 const navStore = useNavStore()
 const pageStore = usePageStore()
+const userStore = useUserStore()
 const router = useRouter()
 const route = useRoute()
 
 await channelContentStore.initialize()
+
+const showDashboardMaturityToggle = computed(
+  () => maturityPreferenceStore.showDashboardMaturityToggle,
+)
 
 const requestedTabKey = computed(() => {
   return typeof route.query.tab === 'string' ? route.query.tab.trim() : ''
@@ -215,6 +226,10 @@ watch(
   },
   { immediate: true },
 )
+
+onMounted(() => {
+  maturityPreferenceStore.initialize()
+})
 
 function goBack(): void {
   const path = navStore.backPath

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -123,6 +123,36 @@
 
         <animation-selector />
 
+        <label
+          v-if="!isGuest"
+          class="flex cursor-pointer items-center justify-between gap-4 rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
+        >
+          <span class="flex min-w-0 items-center gap-3">
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-warning/15 text-warning"
+            >
+              <Icon name="kind-icon:eye" class="h-5 w-5" />
+            </span>
+
+            <span class="min-w-0">
+              <span class="block font-black text-base-content">
+                Dashboard maturity toggle
+              </span>
+              <span class="block text-xs text-base-content/55">
+                Show a quick 18+ visibility control in the workspace header. This
+                preference stays in this browser.
+              </span>
+            </span>
+          </span>
+
+          <input
+            type="checkbox"
+            class="toggle toggle-warning shrink-0"
+            :checked="showDashboardMaturityToggle"
+            @change="onDashboardMaturityToggleChange"
+          />
+        </label>
+
         <div
           v-if="!isGuest"
           class="grid grid-cols-1 gap-4 2xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]"
@@ -161,14 +191,19 @@
 
 <script lang="ts" setup>
 import { computed, onMounted, onUnmounted, watch } from 'vue'
-import { useUserStore } from '@/stores/userStore'
+import { useMaturityPreferenceStore } from '@/stores/maturityPreferenceStore'
 import { useUploadStore } from '@/stores/uploadStore'
+import { useUserStore } from '@/stores/userStore'
 
+const maturityPreferenceStore = useMaturityPreferenceStore()
 const userStore = useUserStore()
 const imageUploadStore = useUploadStore()
 
 const user = computed(() => userStore.user)
 const isGuest = computed(() => userStore.isGuest)
+const showDashboardMaturityToggle = computed(
+  () => maturityPreferenceStore.showDashboardMaturityToggle,
+)
 
 const displayName = computed(() => {
   return isGuest.value ? 'Kind Guest' : user.value?.username || 'Kind User'
@@ -186,7 +221,14 @@ function configureUserImageUpload() {
   imageUploadStore.setAvatarTarget({ userId: userStore.user.id })
 }
 
+function onDashboardMaturityToggleChange(event: Event): void {
+  maturityPreferenceStore.setShowDashboardMaturityToggle(
+    (event.target as HTMLInputElement).checked,
+  )
+}
+
 onMounted(() => {
+  maturityPreferenceStore.initialize()
   configureUserImageUpload()
 })
 
@@ -198,7 +240,7 @@ watch(
   () => userStore.user?.id,
   () => {
     configureUserImageUpload()
-  }
+  },
 )
 
 const logout = async () => {

--- a/stores/maturityPreferenceStore.ts
+++ b/stores/maturityPreferenceStore.ts
@@ -1,0 +1,37 @@
+// /stores/maturityPreferenceStore.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'showDashboardMaturityToggle'
+
+export const useMaturityPreferenceStore = defineStore(
+  'maturityPreferenceStore',
+  () => {
+    const showDashboardMaturityToggle = ref(false)
+    const initialized = ref(false)
+
+    function initialize(): void {
+      if (typeof window === 'undefined' || initialized.value) return
+
+      showDashboardMaturityToggle.value =
+        window.localStorage.getItem(STORAGE_KEY) === 'true'
+      initialized.value = true
+    }
+
+    function setShowDashboardMaturityToggle(value: boolean): void {
+      showDashboardMaturityToggle.value = value
+      initialized.value = true
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, value.toString())
+      }
+    }
+
+    return {
+      showDashboardMaturityToggle,
+      initialized,
+      initialize,
+      setShowDashboardMaturityToggle,
+    }
+  },
+)


### PR DESCRIPTION
## What changed

- adds a compact maturity control to the workspace header
- keeps the header control hidden by default
- adds a User Dashboard preference for showing the control
- stores only the control-visibility preference in `localStorage`
- updates the persisted user `showMature` consent setting through the existing account consent API when the header control is clicked

## Behavior

- missing local preference defaults to `false`, so existing users do not see a new header control unexpectedly
- the local preference is browser-specific
- the mature-content state remains user-backed and continues to affect existing gallery/content filters
- guest users never see the control

## Validation

- TypeScript Type Check passed
- Contract Tests passed
- all triggered focused contract workflows passed
- reviewed the branch diff against `main`
- verified the implementation reuses `/api/users/me/consent` through `accountStore.updateConsent`
- verified all `localStorage` access is client-guarded