### PR TITLE
Guarantee startup exit and soften launch media edges

### DIFF
--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -1,4 +1,5 @@
 import { useButterflyStore } from '@/stores/butterflyStore'
+import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 
 const ACTIVE_CLASS = 'kr-startup-active'
 const FADING_CLASS = 'kr-startup-fading'
@@ -13,6 +14,7 @@ const FADE_CLEANUP_MS = 700
 export default defineNuxtPlugin((nuxtApp) => {
   const root = document.documentElement
   const butterflyStore = useButterflyStore()
+  const startupStore = useStartupAnimationStore()
 
   let sawLoader = false
   let cleanupTimer: number | null = null
@@ -103,6 +105,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const elapsedSinceNavigation = performance.now()
   emergencyFadeTimer = window.setTimeout(() => {
     emergencyFadeTimer = null
+    if (startupStore.immersive) return
     beginFade()
   }, Math.max(0, EMERGENCY_FADE_AT_MS - elapsedSinceNavigation))
 

--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -1,3 +1,5 @@
+import { useButterflyStore } from '@/stores/butterflyStore'
+
 const ACTIVE_CLASS = 'kr-startup-active'
 const FADING_CLASS = 'kr-startup-fading'
 const COVER_CLASS = 'kr-full-startup'
@@ -5,10 +7,16 @@ const HANDOFF_CLASS = 'kr-startup-handoff'
 const EFFECT_READY_CLASS = 'kr-startup-effect-ready'
 const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
 
+const EMERGENCY_FADE_AT_MS = 6000
+const FADE_CLEANUP_MS = 700
+
 export default defineNuxtPlugin((nuxtApp) => {
   const root = document.documentElement
+  const butterflyStore = useButterflyStore()
+
   let sawLoader = false
   let cleanupTimer: number | null = null
+  let emergencyFadeTimer: number | null = null
 
   function clearCleanupTimer(): void {
     if (cleanupTimer === null) return
@@ -16,8 +24,28 @@ export default defineNuxtPlugin((nuxtApp) => {
     cleanupTimer = null
   }
 
+  function clearEmergencyFadeTimer(): void {
+    if (emergencyFadeTimer === null) return
+    window.clearTimeout(emergencyFadeTimer)
+    emergencyFadeTimer = null
+  }
+
+  function beginFade(): void {
+    const startupActive =
+      root.classList.contains(ACTIVE_CLASS) ||
+      root.classList.contains(COVER_CLASS)
+
+    if (!startupActive) return
+
+    clearEmergencyFadeTimer()
+    root.classList.add(FADING_CLASS)
+    butterflyStore.setShowSwarm(false)
+  }
+
   function cleanup(): void {
     clearCleanupTimer()
+    clearEmergencyFadeTimer()
+    butterflyStore.setShowSwarm(false)
     root.classList.remove(
       ACTIVE_CLASS,
       FADING_CLASS,
@@ -35,7 +63,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       cleanupTimer = null
       cleanup()
       observer.disconnect()
-    }, 700)
+    }, FADE_CLEANUP_MS)
   }
 
   function syncCompositionState(): void {
@@ -52,10 +80,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     }
 
     if (overlay?.classList.contains('loading-overlay--fade')) {
-      root.classList.add(FADING_CLASS)
+      beginFade()
     }
 
     if (sawLoader && !loader && !overlay) {
+      beginFade()
       scheduleCleanup()
     }
   }
@@ -70,6 +99,12 @@ export default defineNuxtPlugin((nuxtApp) => {
   })
 
   syncCompositionState()
+
+  const elapsedSinceNavigation = performance.now()
+  emergencyFadeTimer = window.setTimeout(() => {
+    emergencyFadeTimer = null
+    beginFade()
+  }, Math.max(0, EMERGENCY_FADE_AT_MS - elapsedSinceNavigation))
 
   nuxtApp.hook('app:mounted', syncCompositionState)
   window.addEventListener('pagehide', cleanup, { once: true })

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -19,11 +19,43 @@ export default defineNitroPlugin((nitroApp) => {
           display: block;
         }
 
+        .kr-prehydrate-media,
+        .loading-logo {
+          -webkit-mask-image: radial-gradient(
+            ellipse 47% 52% at 48% 49%,
+            #000 0%,
+            #000 42%,
+            rgba(0, 0, 0, 0.94) 57%,
+            rgba(0, 0, 0, 0.62) 73%,
+            rgba(0, 0, 0, 0.18) 88%,
+            transparent 100%
+          ) !important;
+          mask-image: radial-gradient(
+            ellipse 47% 52% at 48% 49%,
+            #000 0%,
+            #000 42%,
+            rgba(0, 0, 0, 0.94) 57%,
+            rgba(0, 0, 0, 0.62) 73%,
+            rgba(0, 0, 0, 0.18) 88%,
+            transparent 100%
+          ) !important;
+          -webkit-mask-position: center;
+          mask-position: center;
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+          -webkit-mask-size: 112% 108%;
+          mask-size: 112% 108%;
+        }
+
         html.kr-startup-fading .kr-startup-black-base,
         html:has(.loading-overlay--fade) .kr-startup-black-base {
           opacity: 0;
         }
 
+        html.kr-startup-fading .loading-overlay,
+        html.kr-startup-fading .kr-prehydrate-effect,
+        html.kr-startup-fading .kr-prehydrate-content,
+        html.kr-startup-fading .kr-prehydrate-controls,
         html.kr-startup-fading .startup-animation__stage,
         html.kr-startup-fading .startup-animation__controls,
         html:has(.loading-overlay--fade) .startup-animation__stage,
@@ -35,6 +67,10 @@ export default defineNitroPlugin((nitroApp) => {
 
         @media (prefers-reduced-motion: reduce) {
           .kr-startup-black-base,
+          html.kr-startup-fading .loading-overlay,
+          html.kr-startup-fading .kr-prehydrate-effect,
+          html.kr-startup-fading .kr-prehydrate-content,
+          html.kr-startup-fading .kr-prehydrate-controls,
           html.kr-startup-fading .startup-animation__stage,
           html.kr-startup-fading .startup-animation__controls,
           html:has(.loading-overlay--fade) .startup-animation__stage,


### PR DESCRIPTION
## What changed

- adds a six-second emergency fade guard that only runs when the normal startup fade never begins
- uses the existing `kr-startup-fading` composition state so black, launch media, copy, spinner, bridge effect, real Screen FX, and controls still fade together
- explicitly disables the startup butterfly/Screen FX store during either normal or emergency fade
- treats unexpected loader removal as a fade trigger before cleaning up startup classes
- preserves deliberate **Pause & explore** mode rather than applying the emergency exit while the user is inspecting the animation
- adds a soft, off-center radial mask to both the pre-hydration WebP and the hydrated `.loading-logo`, removing the harsh square edge without turning it into a clean geometric circle

## Root cause

The app-level eight-second failsafe unmounted the loader directly. That bypassed `loading-messages`' normal `hiding` event, so the startup Screen FX store could remain active after the loader disappeared. The previous composition cleanup removed CSS classes but did not guarantee the rendered effect itself was switched off.

## Expected behavior

- launch-in remains unchanged: every visible layer appears together over black
- normal successful initialization exits exactly as before
- if store initialization stalls, the complete composition begins its shared fade at six seconds instead of remaining indefinitely
- the existing app failsafe can then remove the invisible loader without leaving Screen FX behind
- **Pause & explore** still keeps the animation open intentionally
- the WebP blends into the surrounding haze with an irregular, feathered edge

## Validation

- final head: `9dd75a5230d5013a4cc2ac253e8e2613e6486bcb`
- TypeScript Type Check passed
- Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel deployment `dpl_33ELrdc8gB1Gsd9SBMhDDjtnir2Y` is READY and built from the final head
- preview root returned HTTP 200
- delivered HTML contains the feathered mask for both `.kr-prehydrate-media` and `.loading-logo`
- delivered CSS places the black base, loader overlay, pre-hydration effect/content/controls, real Screen FX stage, and controls under the same 650 ms fade state
- delivered Nuxt public build ID matches the final head

A literal frame-by-frame dashboard-refresh recording is not available in this environment. The remaining check is the visual refresh click.