### PR TITLE
Make Resource maturity controls account-consistent

### DIFF
--- a/components/art/art-maker.vue
+++ b/components/art/art-maker.vue
@@ -4,8 +4,9 @@
     <div
       class="mx-auto flex min-h-full w-full max-w-6xl flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4 sm:p-6"
     >
-      <!-- ── Header ───────────────────────────────────────────────────── -->
-      <header class="rounded-2xl border border-base-300 bg-base-100 p-4 sm:p-5">
+      <header
+        class="rounded-2xl border border-base-300 bg-base-100 p-4 sm:p-5"
+      >
         <div
           class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
         >
@@ -13,7 +14,10 @@
             <span
               class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15"
             >
-              <icon name="kind-icon:paintbrush" class="h-7 w-7 text-primary" />
+              <icon
+                name="kind-icon:paintbrush"
+                class="h-7 w-7 text-primary"
+              />
             </span>
             <div>
               <h1 class="text-2xl font-black text-primary sm:text-3xl">
@@ -33,7 +37,6 @@
         </div>
       </header>
 
-      <!-- Generation message -->
       <div
         v-if="artStore.generationMessage"
         class="flex items-start gap-2 rounded-2xl border p-3 text-sm font-semibold"
@@ -54,18 +57,17 @@
         {{ artStore.generationMessage }}
       </div>
 
-      <!-- ── Step 1-3: Server / Model / Collection ─────────────────────── -->
       <section
         class="grid grid-cols-1 gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 lg:grid-cols-3"
       >
-        <!-- Step badge helper: reused via local style -->
         <label class="form-control">
           <span class="label">
             <span class="label-text flex items-center gap-2 font-bold">
               <span
                 class="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[0.65rem] font-black text-primary-content"
-                >1</span
               >
+                1
+              </span>
               Server
             </span>
           </span>
@@ -86,22 +88,30 @@
           </select>
 
           <span class="label">
-            <span class="label-text-alt text-base-content/55">{{
-              selectedServerSummary
-            }}</span>
+            <span class="label-text-alt text-base-content/55">
+              {{ selectedServerSummary }}
+            </span>
           </span>
         </label>
 
-        <label class="form-control">
-          <span class="label">
+        <div class="form-control gap-2">
+          <span class="label pb-0">
             <span class="label-text flex items-center gap-2 font-bold">
               <span
                 class="flex h-5 w-5 items-center justify-center rounded-full bg-secondary text-[0.65rem] font-black text-secondary-content"
-                >2</span
               >
+                2
+              </span>
               Model
             </span>
           </span>
+
+          <maturity-toggle
+            variant="resource"
+            label="Mature checkpoint models"
+            visible-text="Mature checkpoints are available in this selector."
+            hidden-text="Mature checkpoints are hidden from this selector."
+          />
 
           <select
             v-model="selectedCheckpointName"
@@ -122,20 +132,21 @@
             </option>
           </select>
 
-          <span class="label">
+          <span class="label pt-0">
             <span class="label-text-alt text-base-content/55">
               Active: {{ checkpointStore.currentApiModel || 'unknown' }}
             </span>
           </span>
-        </label>
+        </div>
 
         <div class="form-control">
           <span class="label">
             <span class="label-text flex items-center gap-2 font-bold">
               <span
                 class="flex h-5 w-5 items-center justify-center rounded-full bg-accent text-[0.65rem] font-black text-accent-content"
-                >3</span
               >
+                3
+              </span>
               Collection
             </span>
           </span>
@@ -172,11 +183,9 @@
         </div>
       </section>
 
-      <!-- ── Prompt + Options ──────────────────────────────────────────── -->
       <section
         class="grid grid-cols-1 gap-4 rounded-2xl border border-base-300 bg-base-100 p-4 xl:grid-cols-[minmax(0,1fr)_320px]"
       >
-        <!-- Left: prompts + randomizers -->
         <div class="flex min-h-0 flex-col gap-4">
           <label class="form-control">
             <span class="label">
@@ -206,9 +215,9 @@
 
           <label class="form-control">
             <span class="label">
-              <span class="label-text font-bold text-base-content/70"
-                >Negative Prompt</span
-              >
+              <span class="label-text font-bold text-base-content/70">
+                Negative Prompt
+              </span>
             </span>
 
             <textarea
@@ -225,15 +234,14 @@
                 <icon name="kind-icon:dice" class="h-4 w-4" />
                 Randomizers
               </span>
-              <span class="text-xs text-base-content/50"
-                >Optional prompt seasoning</span
-              >
+              <span class="text-xs text-base-content/50">
+                Optional prompt seasoning
+              </span>
             </div>
             <art-randomizer />
           </div>
         </div>
 
-        <!-- Right: generation options -->
         <aside class="flex flex-col gap-4">
           <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
             <h2
@@ -266,9 +274,9 @@
 
               <div class="grid grid-cols-2 gap-3">
                 <label class="form-control">
-                  <span class="label"
-                    ><span class="label-text font-bold">Steps</span></span
-                  >
+                  <span class="label">
+                    <span class="label-text font-bold">Steps</span>
+                  </span>
                   <input
                     v-model.number="artStore.artForm.steps"
                     class="input input-bordered rounded-2xl bg-base-100"
@@ -279,9 +287,9 @@
                   />
                 </label>
                 <label class="form-control">
-                  <span class="label"
-                    ><span class="label-text font-bold">CFG</span></span
-                  >
+                  <span class="label">
+                    <span class="label-text font-bold">CFG</span>
+                  </span>
                   <input
                     v-model.number="artStore.artForm.cfg"
                     class="input input-bordered rounded-2xl bg-base-100"
@@ -294,9 +302,9 @@
               </div>
 
               <label class="form-control">
-                <span class="label"
-                  ><span class="label-text font-bold">Seed</span></span
-                >
+                <span class="label">
+                  <span class="label-text font-bold">Seed</span>
+                </span>
                 <input
                   v-model.number="seedInput"
                   class="input input-bordered rounded-2xl bg-base-100"
@@ -344,7 +352,9 @@
             </div>
           </div>
 
-          <details class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <details
+            class="rounded-2xl border border-base-300 bg-base-200 p-4"
+          >
             <summary
               class="flex cursor-pointer list-none items-center gap-2 text-base font-bold text-primary"
             >
@@ -364,7 +374,6 @@
         </aside>
       </section>
 
-      <!-- ── Latest Result ─────────────────────────────────────────────── -->
       <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
         <div
           class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
@@ -400,7 +409,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted, watch } from 'vue'
 import type { Server } from '~/prisma/generated/prisma/client'
 import type { ArtCollection } from '@/stores/helpers/collectionHelper'
 import type { Resource } from '@/stores/resourceStore'
@@ -475,16 +484,17 @@ const selectedServerSummary = computed(() => {
 const checkpointOptions = computed<CheckpointResource[]>(() => {
   const checkpoints = checkpointStore.visibleCheckpoints
   if (!Array.isArray(checkpoints)) return []
-  return (checkpoints as CheckpointResource[]).filter((checkpoint) => {
-    if (checkpoint.isMature && !artStore.showMature) return false
-    return Boolean(safeText(checkpoint.name).trim())
-  })
+
+  return (checkpoints as CheckpointResource[]).filter((checkpoint) =>
+    Boolean(safeText(checkpoint.name).trim()),
+  )
 })
 
 function safeText(value: unknown): string {
   if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean')
+  if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value)
+  }
   return ''
 }
 
@@ -500,7 +510,7 @@ function getCheckpointLabel(checkpoint: CheckpointResource): string {
   )
 }
 
-function configureArtImageUpload() {
+function configureArtImageUpload(): void {
   uploadStore.setTarget({
     model: 'ArtImage',
     modelId: null,
@@ -514,7 +524,7 @@ function configureArtImageUpload() {
   })
 }
 
-function handleCollectionCreated(collection: ArtCollection) {
+function handleCollectionCreated(collection: ArtCollection): void {
   artStore.selectGenerationCollection(collection.id)
   artStore.setGenerationMessage(
     'success',
@@ -522,27 +532,43 @@ function handleCollectionCreated(collection: ArtCollection) {
   )
 }
 
-function handleCollectionSelected(collection: ArtCollection) {
+function handleCollectionSelected(collection: ArtCollection): void {
   artStore.selectGenerationCollection(collection.id)
 }
 
-function clearPrompt() {
+function clearPrompt(): void {
   promptStore.promptField = ''
   artStore.setArtForm({ promptString: '', negativePrompt: '' })
   artStore.clearGenerationMessage()
 }
 
-function goToSelectedTab() {
+function goToSelectedTab(): void {
   navStore.setDashboardTab(dashboardKey, 'selected')
 }
 
-function handleRemixUploaded() {
+function handleRemixUploaded(): void {
   artStore.setGenerationMessage(
     'success',
     'Remix image uploaded. Opening selected image.',
   )
   goToSelectedTab()
 }
+
+watch(
+  checkpointOptions,
+  (options) => {
+    const selectedName = selectedCheckpointName.value
+    if (
+      selectedName &&
+      !options.some(
+        (checkpoint) => safeText(checkpoint.name).trim() === selectedName,
+      )
+    ) {
+      selectedCheckpointName.value = safeText(options[0]?.name).trim()
+    }
+  },
+  { immediate: true },
+)
 
 onMounted(async () => {
   const result = await artStore.prepareArtGenerator()

--- a/components/art/lora-picker.vue
+++ b/components/art/lora-picker.vue
@@ -16,14 +16,12 @@
                         for the parent to append to the prompt if desired.
 -->
 <script setup lang="ts">
-import type { Resource } from '~/stores/resourceStore'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useResourceStore, type Resource } from '~/stores/resourceStore'
 
 const props = withDefaults(
   defineProps<{
     modelValue?: number[]
-    // Optional base-model filter, e.g. 'Pony' | 'SDXL' | 'Flux' — matches the
-    // Resource.generation / supportedServer so a picker can be scoped to the
-    // checkpoint the user is rendering with.
     baseFilter?: string | null
   }>(),
   { modelValue: () => [], baseFilter: null },
@@ -31,58 +29,78 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   'update:modelValue': [ids: number[]]
-  change: [payload: { loraResourceIds: number[]; loraName: string | null; triggers: string }]
+  change: [
+    payload: {
+      loraResourceIds: number[]
+      loraName: string | null
+      triggers: string
+    },
+  ]
 }>()
 
 const resourceStore = useResourceStore()
-const artStore = useArtStore()
-
 const query = ref('')
 
-const loras = computed<Resource[]>(() => {
-  const q = query.value.trim().toLowerCase()
+const availableLoras = computed<Resource[]>(() => {
   const base = props.baseFilter?.toLowerCase() ?? null
-  return resourceStore.resources
-    .filter((r) => r.resourceType === 'LORA' || r.resourceType === 'LYCORIS')
-    .filter((r) => (r.isMature ? artStore.showMature : true))
-    .filter((r) =>
-      base
-        ? (r.generation ?? '').toLowerCase().includes(base) ||
-          (r.supportedServer ?? '').toLowerCase().includes(base)
-        : true,
-    )
-    .filter((r) =>
-      q
-        ? [r.customLabel, r.name, r.generation, r.triggerWords]
+
+  return resourceStore.visibleLoras.filter((resource) =>
+    base
+      ? (resource.generation ?? '').toLowerCase().includes(base) ||
+        (resource.supportedServer ?? '').toLowerCase().includes(base)
+      : true,
+  )
+})
+
+const loras = computed<Resource[]>(() => {
+  const search = query.value.trim().toLowerCase()
+
+  return availableLoras.value
+    .filter((resource) =>
+      search
+        ? [
+            resource.customLabel,
+            resource.name,
+            resource.generation,
+            resource.triggerWords,
+          ]
             .filter(Boolean)
-            .some((v) => String(v).toLowerCase().includes(q))
+            .some((value) => String(value).toLowerCase().includes(search))
         : true,
     )
     .sort((a, b) =>
-      (a.customLabel || a.name || '').localeCompare(b.customLabel || b.name || ''),
+      (a.customLabel || a.name || '').localeCompare(
+        b.customLabel || b.name || '',
+      ),
     )
 })
 
-const selected = computed<Resource[]>(() =>
-  props.modelValue
-    .map((id) => resourceStore.resources.find((r) => r.id === id))
-    .filter((r): r is Resource => Boolean(r)),
+const availableLoraIds = computed(
+  () => new Set(availableLoras.value.map((resource) => resource.id)),
 )
 
-function engineName(r: Resource): string {
-  return r.localPath || r.name || r.customLabel || ''
+const selected = computed<Resource[]>(() =>
+  props.modelValue
+    .map((id) => availableLoras.value.find((resource) => resource.id === id))
+    .filter((resource): resource is Resource => Boolean(resource)),
+)
+
+function engineName(resource: Resource): string {
+  return resource.localPath || resource.name || resource.customLabel || ''
 }
 
-function emitChange(ids: number[]) {
+function emitChange(ids: number[]): void {
   emit('update:modelValue', ids)
+
   const chosen = ids
-    .map((id) => resourceStore.resources.find((r) => r.id === id))
-    .filter((r): r is Resource => Boolean(r))
+    .map((id) => availableLoras.value.find((resource) => resource.id === id))
+    .filter((resource): resource is Resource => Boolean(resource))
   const primary = chosen.at(0)
   const triggers = chosen
-    .map((r) => r.defaultTrigger || r.triggerWords || '')
+    .map((resource) => resource.defaultTrigger || resource.triggerWords || '')
     .filter(Boolean)
     .join(', ')
+
   emit('change', {
     loraResourceIds: ids,
     loraName: primary ? engineName(primary) : null,
@@ -90,37 +108,71 @@ function emitChange(ids: number[]) {
   })
 }
 
-function toggle(r: Resource) {
-  const ids = props.modelValue.includes(r.id)
-    ? props.modelValue.filter((id) => id !== r.id)
-    : [...props.modelValue, r.id]
+function toggle(resource: Resource): void {
+  const ids = props.modelValue.includes(resource.id)
+    ? props.modelValue.filter((id) => id !== resource.id)
+    : [...props.modelValue, resource.id]
+
   emitChange(ids)
 }
 
-function isSelected(r: Resource): boolean {
-  return props.modelValue.includes(r.id)
+function isSelected(resource: Resource): boolean {
+  return props.modelValue.includes(resource.id)
 }
+
+watch(
+  [() => props.modelValue, () => resourceStore.hasLoaded, availableLoraIds],
+  () => {
+    if (!resourceStore.hasLoaded) return
+
+    const visibleIds = props.modelValue.filter((id) =>
+      availableLoraIds.value.has(id),
+    )
+
+    if (
+      visibleIds.length !== props.modelValue.length ||
+      visibleIds.some((id, index) => id !== props.modelValue[index])
+    ) {
+      emitChange(visibleIds)
+    }
+  },
+  { immediate: true },
+)
+
+onMounted(async () => {
+  if (!resourceStore.hasLoaded) {
+    await resourceStore.getResources()
+  }
+})
 </script>
 
 <template>
   <div class="flex flex-col gap-2">
     <div class="flex items-center gap-2">
       <span class="text-sm font-medium">LoRAs</span>
-      <span v-if="selected.length" class="badge badge-sm badge-primary">{{ selected.length }}</span>
+      <span v-if="selected.length" class="badge badge-sm badge-primary">
+        {{ selected.length }}
+      </span>
     </div>
 
-    <!-- selected chips -->
+    <maturity-toggle
+      variant="resource"
+      label="Mature LoRAs"
+      visible-text="Mature image LoRAs are available in this selector."
+      hidden-text="Mature image LoRAs are hidden from this selector."
+    />
+
     <div v-if="selected.length" class="flex flex-wrap gap-1">
       <button
-        v-for="r in selected"
-        :key="r.id"
+        v-for="resource in selected"
+        :key="resource.id"
         type="button"
         class="badge badge-outline gap-1 rounded-xl"
-        :title="r.triggerWords || ''"
-        @click="toggle(r)"
+        :title="resource.triggerWords || ''"
+        @click="toggle(resource)"
       >
-        {{ r.customLabel || r.name }}
-        <span v-if="r.isMature" class="text-error">·18+</span>
+        {{ resource.customLabel || resource.name }}
+        <span v-if="resource.isMature" class="text-error">·18+</span>
         ✕
       </button>
     </div>
@@ -132,23 +184,28 @@ function isSelected(r: Resource): boolean {
       class="input input-bordered input-xs rounded-lg"
     />
 
-    <!-- results -->
-    <ul class="menu menu-xs max-h-56 flex-nowrap overflow-y-auto rounded-lg bg-base-200 p-1">
+    <ul
+      class="menu menu-xs max-h-56 flex-nowrap overflow-y-auto rounded-lg bg-base-200 p-1"
+    >
       <li v-if="!loras.length" class="disabled px-2 py-1 text-xs opacity-60">
         No matching LoRAs.
       </li>
-      <li v-for="r in loras" :key="r.id">
+      <li v-for="resource in loras" :key="resource.id">
         <button
           type="button"
           class="flex items-center justify-between gap-2"
-          :class="{ 'bg-primary/20': isSelected(r) }"
-          @click="toggle(r)"
+          :class="{ 'bg-primary/20': isSelected(resource) }"
+          @click="toggle(resource)"
         >
           <span class="truncate">
-            <span :class="{ 'font-semibold': isSelected(r) }">{{ r.customLabel || r.name }}</span>
-            <span v-if="r.isMature" class="ml-1 text-error">18+</span>
+            <span :class="{ 'font-semibold': isSelected(resource) }">
+              {{ resource.customLabel || resource.name }}
+            </span>
+            <span v-if="resource.isMature" class="ml-1 text-error">18+</span>
           </span>
-          <span class="shrink-0 text-[10px] opacity-60">{{ r.generation || r.supportedServer }}</span>
+          <span class="shrink-0 text-[10px] opacity-60">
+            {{ resource.generation || resource.supportedServer }}
+          </span>
         </button>
       </li>
     </ul>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -7,8 +7,12 @@
   opt-in; "hide owned" filters rows you already have.
 -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3">
-    <header class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
       <div class="min-w-0">
         <h2 class="truncate text-lg font-bold text-base-content">
           Discover {{ discoverType === 'CHECKPOINT' ? 'Checkpoints' : 'LoRAs' }}
@@ -59,26 +63,25 @@
           <option value="Illustrious">Illustrious</option>
         </select>
 
-        <button class="btn btn-primary rounded-xl" type="submit" :disabled="loading">
+        <button
+          class="btn btn-primary rounded-xl"
+          type="submit"
+          :disabled="loading"
+        >
           <span v-if="loading" class="loading loading-spinner loading-sm" />
           <Icon v-else name="kind-icon:search" class="h-4 w-4" />
           {{ source === 'civarchive' ? 'Look up' : 'Search' }}
         </button>
       </form>
 
-      <div class="flex flex-wrap items-center gap-4">
-        <label
-          v-if="canShowMature"
-          class="label cursor-pointer justify-start gap-2 p-0"
-        >
-          <input
-            v-model="includeMature"
-            type="checkbox"
-            class="toggle toggle-warning toggle-sm"
-          />
-          <span class="label-text text-sm">Include mature</span>
-        </label>
+      <maturity-toggle
+        variant="resource"
+        label="Mature discovery results"
+        visible-text="Mature LoRAs and checkpoints are included in searches."
+        hidden-text="Mature LoRAs and checkpoints are excluded from searches."
+      />
 
+      <div class="flex flex-wrap items-center gap-4">
         <label class="label cursor-pointer justify-start gap-2 p-0">
           <input
             v-model="hideOwned"
@@ -144,7 +147,9 @@
             class="btn btn-sm mt-auto rounded-xl"
             :class="downloadButtonClass(card)"
             type="button"
-            :disabled="!canQueue(card) || queuing === card.civitaiModelVersionId"
+            :disabled="
+              !canQueue(card) || queuing === card.civitaiModelVersionId
+            "
             @click="queueDownload(card)"
           >
             <span
@@ -183,7 +188,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { performFetch } from '@/stores/utils'
 import { useUserStore } from '@/stores/userStore'
 
@@ -214,7 +219,6 @@ const query = ref('')
 const discoverType = ref<'LORA' | 'CHECKPOINT'>('LORA')
 const source = ref<'civitai' | 'civarchive'>('civitai')
 const baseModel = ref('')
-const includeMature = ref(false)
 const hideOwned = ref(false)
 
 const cards = ref<DiscoverCard[]>([])
@@ -223,8 +227,6 @@ const loading = ref(false)
 const error = ref('')
 const queuing = ref<number | null>(null)
 const queuedIds = ref<Set<number>>(new Set())
-
-const canShowMature = computed(() => userStore.showMature)
 
 const visibleCards = computed(() => {
   if (!hideOwned.value) return cards.value
@@ -235,8 +237,6 @@ function isQueued(card: DiscoverCard): boolean {
   return queuedIds.value.has(card.civitaiModelVersionId)
 }
 
-// Civitai cards are always downloadable (the agent builds the by-version URL);
-// CivArchive cards need an explicit downloadUrl from the archive.
 function isDownloadable(card: DiscoverCard): boolean {
   return card.source === 'CIVITAI' || Boolean(card.downloadUrl)
 }
@@ -267,7 +267,7 @@ function downloadButtonLabel(card: DiscoverCard): string {
   return 'Download'
 }
 
-async function runSearch(reset: boolean) {
+async function runSearch(reset: boolean): Promise<void> {
   if (loading.value) return
 
   loading.value = true
@@ -285,7 +285,7 @@ async function runSearch(reset: boolean) {
     if (query.value.trim()) params.set('q', query.value.trim())
     if (source.value === 'civitai') {
       if (baseModel.value) params.set('baseModel', baseModel.value)
-      if (includeMature.value && canShowMature.value) params.set('nsfw', 'true')
+      if (userStore.showMature) params.set('nsfw', 'true')
       if (!reset && nextCursor.value) params.set('cursor', nextCursor.value)
     }
 
@@ -299,14 +299,14 @@ async function runSearch(reset: boolean) {
 
     cards.value = reset ? res.data.items : [...cards.value, ...res.data.items]
     nextCursor.value = res.data.nextCursor
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Search failed.'
+  } catch (cause) {
+    error.value = cause instanceof Error ? cause.message : 'Search failed.'
   } finally {
     loading.value = false
   }
 }
 
-async function queueDownload(card: DiscoverCard) {
+async function queueDownload(card: DiscoverCard): Promise<void> {
   if (card.owned || isQueued(card) || queuing.value) return
 
   queuing.value = card.civitaiModelVersionId
@@ -333,13 +333,24 @@ async function queueDownload(card: DiscoverCard) {
       throw new Error(res.message || 'Could not queue the download.')
     }
 
-    // Mark queued (or owned) so the button reflects state immediately.
-    queuedIds.value = new Set(queuedIds.value).add(card.civitaiModelVersionId)
+    queuedIds.value = new Set(queuedIds.value).add(
+      card.civitaiModelVersionId,
+    )
     if (res.data?.alreadyOwned) card.owned = true
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Could not queue the download.'
+  } catch (cause) {
+    error.value =
+      cause instanceof Error ? cause.message : 'Could not queue the download.'
   } finally {
     queuing.value = null
   }
 }
+
+watch(
+  () => userStore.showMature,
+  () => {
+    if (cards.value.length || query.value.trim()) {
+      void runSearch(true)
+    }
+  },
+)
 </script>

--- a/components/lora/lora-gallery.vue
+++ b/components/lora/lora-gallery.vue
@@ -7,8 +7,12 @@
   both route through <add-lora>.
 -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3">
-    <header class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <h2 class="truncate text-lg font-bold text-base-content">
@@ -29,6 +33,13 @@
         </button>
       </div>
 
+      <maturity-toggle
+        variant="resource"
+        label="Mature LoRAs"
+        visible-text="Mature LoRAs are included in your library."
+        hidden-text="Mature LoRAs are hidden from your library."
+      />
+
       <div class="grid gap-2 md:grid-cols-[1fr_auto_auto_auto]">
         <input
           v-model="searchQuery"
@@ -36,14 +47,20 @@
           placeholder="Search name, label, trigger, path"
         />
 
-        <select v-model="selectedBase" class="select select-bordered rounded-xl">
+        <select
+          v-model="selectedBase"
+          class="select select-bordered rounded-xl"
+        >
           <option value="all">All bases</option>
           <option v-for="base in baseOptions" :key="base" :value="base">
             {{ base }}
           </option>
         </select>
 
-        <select v-model="maturityFilter" class="select select-bordered rounded-xl">
+        <select
+          v-model="maturityFilter"
+          class="select select-bordered rounded-xl"
+        >
           <option value="all">All ratings</option>
           <option value="sfw">SFW only</option>
           <option value="mature">Mature only</option>
@@ -66,7 +83,11 @@
 
     <div
       class="grid gap-3"
-      :class="compact ? 'grid-cols-2 sm:grid-cols-3' : 'grid-cols-2 sm:grid-cols-3 xl:grid-cols-4'"
+      :class="
+        compact
+          ? 'grid-cols-2 sm:grid-cols-3'
+          : 'grid-cols-2 sm:grid-cols-3 xl:grid-cols-4'
+      "
     >
       <lora-card
         v-for="lora in pageItems"
@@ -241,7 +262,6 @@ const summaryText = computed(() => {
   return `${shown} of ${total} LoRAs`
 })
 
-// Any filter change resets to page 1; clamp if the list shrinks under us.
 watch([searchQuery, selectedBase, maturityFilter, sortBy], () => {
   page.value = 1
 })
@@ -250,22 +270,22 @@ watch(pageCount, (count) => {
   if (page.value > count) page.value = count
 })
 
-function openAdd() {
+function openAdd(): void {
   editing.value = null
   showForm.value = true
 }
 
-function openEdit(lora: Partial<Resource>) {
+function openEdit(lora: Partial<Resource>): void {
   editing.value = lora
   showForm.value = true
 }
 
-function closeForm() {
+function closeForm(): void {
   showForm.value = false
   editing.value = null
 }
 
-function handleSaved() {
+function handleSaved(): void {
   closeForm()
 }
 

--- a/components/model/model-gallery.vue
+++ b/components/model/model-gallery.vue
@@ -8,8 +8,12 @@
   all (no pagination).
 -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-3 overflow-y-auto rounded-2xl bg-base-300 p-3">
-    <header class="sticky top-0 z-10 flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-y-auto rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      class="sticky top-0 z-10 flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <h2 class="truncate text-lg font-bold text-base-content">
@@ -30,6 +34,13 @@
         </button>
       </div>
 
+      <maturity-toggle
+        variant="resource"
+        label="Mature checkpoint models"
+        visible-text="Mature checkpoint models are included in this gallery."
+        hidden-text="Mature checkpoint models are hidden from this gallery."
+      />
+
       <div class="grid gap-2 md:grid-cols-[1fr_auto_auto_auto]">
         <input
           v-model="searchQuery"
@@ -37,14 +48,20 @@
           placeholder="Search name, label, path"
         />
 
-        <select v-model="selectedBase" class="select select-bordered rounded-xl">
+        <select
+          v-model="selectedBase"
+          class="select select-bordered rounded-xl"
+        >
           <option value="all">All bases</option>
           <option v-for="base in baseOptions" :key="base" :value="base">
             {{ base }}
           </option>
         </select>
 
-        <select v-model="maturityFilter" class="select select-bordered rounded-xl">
+        <select
+          v-model="maturityFilter"
+          class="select select-bordered rounded-xl"
+        >
           <option value="all">All ratings</option>
           <option value="sfw">SFW only</option>
           <option value="mature">Mature only</option>
@@ -70,22 +87,19 @@
     >
       <p class="font-bold">No models found.</p>
       <p class="text-sm text-base-content/60">
-        {{
-          resourceStore.isLoading
-            ? 'Loading models…'
-            : 'Try another filter.'
-        }}
+        {{ resourceStore.isLoading ? 'Loading models…' : 'Try another filter.' }}
       </p>
     </div>
 
     <template v-else>
-      <!-- Image base models, grouped -->
       <div
         v-for="group in imageGroups"
         :key="`img-${group.base}`"
         class="flex flex-col gap-2"
       >
-        <h3 class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80">
+        <h3
+          class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80"
+        >
           <span class="badge badge-secondary badge-sm">{{ group.base }}</span>
           <span class="text-base-content/45">{{ group.items.length }}</span>
         </h3>
@@ -101,7 +115,6 @@
         </div>
       </div>
 
-      <!-- Non-image checkpoints (3D / Audio / Video) in their own section -->
       <template v-if="nonImageGroups.length">
         <div class="divider text-xs font-bold uppercase text-base-content/50">
           Other · non-image models
@@ -112,7 +125,9 @@
           :key="`other-${group.base}`"
           class="flex flex-col gap-2"
         >
-          <h3 class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80">
+          <h3
+            class="flex items-center gap-2 px-1 text-sm font-bold text-base-content/80"
+          >
             <span class="badge badge-ghost badge-sm">{{ group.base }}</span>
             <span class="text-base-content/45">{{ group.items.length }}</span>
           </h3>
@@ -150,7 +165,6 @@ const editing = ref<Partial<Resource> | null>(null)
 
 const showMature = computed(() => userStore.showMature)
 
-// Base models that are not still-image checkpoints — grouped separately.
 const NON_IMAGE_BASES = new Set(['3D', 'AUDIO', 'VIDEO'])
 
 function safeText(value: unknown): string {
@@ -162,10 +176,10 @@ function safeText(value: unknown): string {
   return ''
 }
 
-// Base model: prefer the checkpoint's top folder (reliable post-repair), then
-// the tagged generation / supportedServer.
 function baseOf(model: Partial<Resource>): string {
-  const path = safeText(model.localPath).replaceAll('\\', '/').replace(/^\/+/, '')
+  const path = safeText(model.localPath)
+    .replaceAll('\\', '/')
+    .replace(/^\/+/, '')
   const folder = path.includes('/') ? path.split('/')[0] : ''
 
   return (
@@ -234,7 +248,6 @@ const grouped = computed<ModelGroup[]>(() => {
     ),
   }))
 
-  // Image bases first (alpha), non-image bases last (alpha).
   return groups.sort(
     (a, b) =>
       Number(a.isNonImage) - Number(b.isNonImage) ||
@@ -242,8 +255,12 @@ const grouped = computed<ModelGroup[]>(() => {
   )
 })
 
-const imageGroups = computed(() => grouped.value.filter((g) => !g.isNonImage))
-const nonImageGroups = computed(() => grouped.value.filter((g) => g.isNonImage))
+const imageGroups = computed(() =>
+  grouped.value.filter((group) => !group.isNonImage),
+)
+const nonImageGroups = computed(() =>
+  grouped.value.filter((group) => group.isNonImage),
+)
 
 const summaryText = computed(() => {
   const total = resourceStore.visibleCheckpoints.length
@@ -253,22 +270,22 @@ const summaryText = computed(() => {
   return `${shown} of ${total} models`
 })
 
-function openAdd() {
+function openAdd(): void {
   editing.value = null
   showForm.value = true
 }
 
-function openEdit(model: Partial<Resource>) {
+function openEdit(model: Partial<Resource>): void {
   editing.value = model
   showForm.value = true
 }
 
-function closeForm() {
+function closeForm(): void {
   showForm.value = false
   editing.value = null
 }
 
-function handleSaved() {
+function handleSaved(): void {
   closeForm()
 }
 

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -1,78 +1,80 @@
 <!-- /components/navigation/maturity-toggle.vue -->
 <template>
   <div
-    v-if="userStore.isLoggedIn && variant === 'resource'"
-    class="space-y-1"
+    v-if="userStore.isLoggedIn"
+    :class="variant === 'resource' ? 'space-y-1' : 'contents'"
   >
-    <label
-      class="flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
-      :title="buttonTitle"
-    >
-      <span class="flex min-w-0 items-center gap-3">
-        <span
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
-          :class="
-            showMature
-              ? 'bg-warning/15 text-warning'
-              : 'bg-base-200 text-base-content/55'
-          "
-        >
-          <Icon
-            :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"
-            class="h-5 w-5"
+    <template v-if="variant === 'resource'">
+      <label
+        class="flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
+        :title="buttonTitle"
+      >
+        <span class="flex min-w-0 items-center gap-3">
+          <span
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+            :class="
+              showMature
+                ? 'bg-warning/15 text-warning'
+                : 'bg-base-200 text-base-content/55'
+            "
+          >
+            <Icon
+              :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"
+              class="h-5 w-5"
+            />
+          </span>
+
+          <span class="min-w-0">
+            <span class="block text-sm font-bold text-base-content">
+              {{ label }}
+            </span>
+            <span class="block text-xs text-base-content/55">
+              {{ showMature ? visibleText : hiddenText }}
+            </span>
+          </span>
+        </span>
+
+        <span class="flex shrink-0 items-center gap-2">
+          <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
+          <input
+            type="checkbox"
+            class="toggle toggle-warning toggle-sm"
+            :checked="showMature"
+            :disabled="isUpdating"
+            :aria-label="buttonLabel"
+            @change="onToggleChange"
           />
         </span>
+      </label>
 
-        <span class="min-w-0">
-          <span class="block text-sm font-bold text-base-content">
-            {{ label }}
-          </span>
-          <span class="block text-xs text-base-content/55">
-            {{ showMature ? visibleText : hiddenText }}
-          </span>
-        </span>
-      </span>
+      <p v-if="updateError" class="px-1 text-xs text-error">
+        {{ updateError }}
+      </p>
+    </template>
 
-      <span class="flex shrink-0 items-center gap-2">
-        <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
-        <input
-          type="checkbox"
-          class="toggle toggle-warning toggle-sm"
-          :checked="showMature"
-          :disabled="isUpdating"
-          :aria-label="buttonLabel"
-          @change="onToggleChange"
-        />
-      </span>
-    </label>
-
-    <p v-if="updateError" class="px-1 text-xs text-error">
-      {{ updateError }}
-    </p>
-  </div>
-
-  <button
-    v-else-if="userStore.isLoggedIn"
-    type="button"
-    class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border"
-    :class="
-      showMature
-        ? 'border-warning/60 bg-warning/15 text-warning'
-        : 'border-base-300 bg-base-100 text-base-content/60'
-    "
-    :aria-label="buttonLabel"
-    :aria-pressed="showMature"
-    :title="buttonTitle"
-    :disabled="isUpdating"
-    @click="setShowMature(!showMature)"
-  >
-    <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
-    <Icon
+    <button
       v-else
-      :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"
-      class="h-5 w-5"
-    />
-  </button>
+      type="button"
+      class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border"
+      :class="
+        showMature
+          ? 'border-warning/60 bg-warning/15 text-warning'
+          : 'border-base-300 bg-base-100 text-base-content/60'
+      "
+      :aria-label="buttonLabel"
+      :aria-pressed="showMature"
+      :title="buttonTitle"
+      :disabled="isUpdating"
+      @click="setShowMature(!showMature)"
+    >
+      <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
+      <Icon
+        v-else
+        :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"
+        class="h-5 w-5"
+      />
+    </button>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -1,7 +1,58 @@
 <!-- /components/navigation/maturity-toggle.vue -->
 <template>
+  <div
+    v-if="userStore.isLoggedIn && variant === 'resource'"
+    class="space-y-1"
+  >
+    <label
+      class="flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 px-3 py-2"
+      :title="buttonTitle"
+    >
+      <span class="flex min-w-0 items-center gap-3">
+        <span
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+          :class="
+            showMature
+              ? 'bg-warning/15 text-warning'
+              : 'bg-base-200 text-base-content/55'
+          "
+        >
+          <Icon
+            :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"
+            class="h-5 w-5"
+          />
+        </span>
+
+        <span class="min-w-0">
+          <span class="block text-sm font-bold text-base-content">
+            {{ label }}
+          </span>
+          <span class="block text-xs text-base-content/55">
+            {{ showMature ? visibleText : hiddenText }}
+          </span>
+        </span>
+      </span>
+
+      <span class="flex shrink-0 items-center gap-2">
+        <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
+        <input
+          type="checkbox"
+          class="toggle toggle-warning toggle-sm"
+          :checked="showMature"
+          :disabled="isUpdating"
+          :aria-label="buttonLabel"
+          @change="onToggleChange"
+        />
+      </span>
+    </label>
+
+    <p v-if="updateError" class="px-1 text-xs text-error">
+      {{ updateError }}
+    </p>
+  </div>
+
   <button
-    v-if="userStore.isLoggedIn"
+    v-else-if="userStore.isLoggedIn"
     type="button"
     class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border"
     :class="
@@ -13,7 +64,7 @@
     :aria-pressed="showMature"
     :title="buttonTitle"
     :disabled="isUpdating"
-    @click="toggleMature"
+    @click="setShowMature(!showMature)"
   >
     <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
     <Icon
@@ -29,28 +80,47 @@ import { computed, ref } from 'vue'
 import { useAccountStore } from '@/stores/accountStore'
 import { useUserStore } from '@/stores/userStore'
 
+type MaturityToggleVariant = 'icon' | 'resource'
+
+const props = withDefaults(
+  defineProps<{
+    variant?: MaturityToggleVariant
+    label?: string
+    visibleText?: string
+    hiddenText?: string
+  }>(),
+  {
+    variant: 'icon',
+    label: 'Mature resources',
+    visibleText: 'Mature LoRAs and checkpoints are visible.',
+    hiddenText: 'Mature LoRAs and checkpoints are hidden.',
+  },
+)
+
 const accountStore = useAccountStore()
 const userStore = useUserStore()
 
 const isUpdating = ref(false)
 const updateError = ref('')
 
+const variant = computed(() => props.variant)
+const label = computed(() => props.label)
+const visibleText = computed(() => props.visibleText)
+const hiddenText = computed(() => props.hiddenText)
 const showMature = computed(() => userStore.showMature)
 const buttonLabel = computed(() =>
   showMature.value ? 'Hide mature content' : 'Show mature content',
 )
 const buttonTitle = computed(() => updateError.value || buttonLabel.value)
 
-async function toggleMature(): Promise<void> {
-  if (isUpdating.value) return
+async function setShowMature(value: boolean): Promise<void> {
+  if (isUpdating.value || value === showMature.value) return
 
   isUpdating.value = true
   updateError.value = ''
 
   try {
-    const result = await accountStore.updateConsent({
-      showMature: !showMature.value,
-    })
+    const result = await accountStore.updateConsent({ showMature: value })
 
     if (!result.success) {
       updateError.value = result.message || 'Could not update mature content.'
@@ -58,5 +128,9 @@ async function toggleMature(): Promise<void> {
   } finally {
     isUpdating.value = false
   }
+}
+
+function onToggleChange(event: Event): void {
+  void setShowMature((event.target as HTMLInputElement).checked)
 }
 </script>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -28,7 +28,6 @@ const messageTone = ref<'success' | 'error'>('success')
 const activePreviewResourceId = ref<number | null>(null)
 const activeUploadResourceId = ref<number | null>(null)
 
-// Add/edit: only CHECKPOINT and LORA/LYCORIS have a dedicated form today.
 const showAddChoice = ref(false)
 const showForm = ref(false)
 const formKind = ref<'CHECKPOINT' | 'LORA'>('CHECKPOINT')
@@ -54,7 +53,8 @@ function startAdd(kind: 'CHECKPOINT' | 'LORA'): void {
 }
 
 function openEdit(resource: ResourceGalleryRecord): void {
-  formKind.value = resource.resourceType === RESOURCE_TYPE.CHECKPOINT ? 'CHECKPOINT' : 'LORA'
+  formKind.value =
+    resource.resourceType === RESOURCE_TYPE.CHECKPOINT ? 'CHECKPOINT' : 'LORA'
   editing.value = resource
   showForm.value = true
 }
@@ -66,15 +66,16 @@ function closeForm(): void {
 }
 
 async function handleSaved(resource: Resource): Promise<void> {
-  // Re-fetch by id so the gallery card gets the full shape (ArtImage preview,
-  // usage counts) the plain resourceStore save response doesn't carry.
   await resourceGalleryStore.getResource(resource.id)
   closeForm()
 }
 
 const resourceTypes = computed(() => {
-  return [...new Set(resourceGalleryStore.resources.map((entry) => entry.resourceType))]
-    .sort()
+  return [
+    ...new Set(
+      resourceGalleryStore.resources.map((entry) => entry.resourceType),
+    ),
+  ].sort()
 })
 
 const generations = computed(() => {
@@ -91,7 +92,10 @@ const filteredResources = computed(() => {
   const search = query.value.trim().toLowerCase()
 
   return resourceGalleryStore.resources.filter((entry) => {
-    if (resourceType.value !== 'ALL' && entry.resourceType !== resourceType.value) {
+    if (
+      resourceType.value !== 'ALL' &&
+      entry.resourceType !== resourceType.value
+    ) {
       return false
     }
 
@@ -127,7 +131,9 @@ function resourceEngineName(resource: ResourceGalleryRecord): string {
 }
 
 function triggerText(resource: ResourceGalleryRecord): string {
-  return resource.defaultTrigger || resource.triggerWords || resource.artPrompt || ''
+  return (
+    resource.defaultTrigger || resource.triggerWords || resource.artPrompt || ''
+  )
 }
 
 function previewSrc(resource: ResourceGalleryRecord): string {
@@ -208,7 +214,9 @@ function startGeneration(resource: ResourceGalleryRecord): void {
   )
 }
 
-async function generatePreview(resource: ResourceGalleryRecord): Promise<void> {
+async function generatePreview(
+  resource: ResourceGalleryRecord,
+): Promise<void> {
   activePreviewResourceId.value = resource.id
   message.value = ''
 
@@ -236,7 +244,9 @@ function readFileAsDataUrl(file: File): Promise<string> {
   })
 }
 
-async function choosePreviewFile(resource: ResourceGalleryRecord): Promise<void> {
+async function choosePreviewFile(
+  resource: ResourceGalleryRecord,
+): Promise<void> {
   const input = document.createElement('input')
   input.type = 'file'
   input.accept = 'image/png,image/jpeg,image/webp,image/avif'
@@ -281,14 +291,18 @@ onMounted(async () => {
 
 <template>
   <section class="flex min-h-full w-full flex-col gap-4">
-    <header class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm">
-      <div class="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+    <header
+      class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm"
+    >
+      <div
+        class="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between"
+      >
         <div>
           <h2 class="text-2xl font-bold">Resource Gallery</h2>
           <p class="max-w-3xl text-sm text-base-content/65">
-            Browse checkpoints, LoRAs, embeddings, and generation tools. Add one to
-            the current build, start fresh, or manufacture a preview when the catalog
-            arrived wearing a paper bag over its head.
+            Browse checkpoints, LoRAs, embeddings, and generation tools. Add one
+            to the current build, start fresh, or manufacture a preview when the
+            catalog arrived wearing a paper bag over its head.
           </p>
         </div>
 
@@ -318,6 +332,14 @@ onMounted(async () => {
         </div>
       </div>
 
+      <maturity-toggle
+        class="mt-4"
+        variant="resource"
+        label="Mature Resources"
+        visible-text="Mature LoRAs and checkpoint models are included."
+        hidden-text="Mature LoRAs and checkpoint models are hidden."
+      />
+
       <div class="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
         <label class="form-control">
           <span class="label-text text-xs">Search</span>
@@ -331,7 +353,10 @@ onMounted(async () => {
 
         <label class="form-control">
           <span class="label-text text-xs">Type</span>
-          <select v-model="resourceType" class="select select-bordered rounded-2xl">
+          <select
+            v-model="resourceType"
+            class="select select-bordered rounded-2xl"
+          >
             <option value="ALL">All types</option>
             <option v-for="type in resourceTypes" :key="type" :value="type">
               {{ type }}
@@ -341,7 +366,10 @@ onMounted(async () => {
 
         <label class="form-control">
           <span class="label-text text-xs">Base model</span>
-          <select v-model="generation" class="select select-bordered rounded-2xl">
+          <select
+            v-model="generation"
+            class="select select-bordered rounded-2xl"
+          >
             <option value="ALL">All base models</option>
             <option v-for="base in generations" :key="base" :value="base">
               {{ base }}
@@ -351,7 +379,10 @@ onMounted(async () => {
 
         <label class="form-control">
           <span class="label-text text-xs">Maturity</span>
-          <select v-model="maturity" class="select select-bordered rounded-2xl">
+          <select
+            v-model="maturity"
+            class="select select-bordered rounded-2xl"
+          >
             <option value="ALL">Visible Resources</option>
             <option value="SAFE">Safe only</option>
             <option value="MATURE">Mature only</option>
@@ -423,7 +454,10 @@ onMounted(async () => {
     </div>
 
     <div
-      v-if="resourceGalleryStore.isLoading && !resourceGalleryStore.resources.length"
+      v-if="
+        resourceGalleryStore.isLoading &&
+        !resourceGalleryStore.resources.length
+      "
       class="flex min-h-72 items-center justify-center rounded-2xl border border-base-300 bg-base-100"
     >
       <span class="loading loading-spinner loading-lg text-primary" />
@@ -454,11 +488,18 @@ onMounted(async () => {
           />
 
           <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-            <span class="badge badge-primary badge-sm">{{ resource.resourceType }}</span>
-            <span v-if="resource.generation" class="badge badge-neutral badge-sm">
+            <span class="badge badge-primary badge-sm">
+              {{ resource.resourceType }}
+            </span>
+            <span
+              v-if="resource.generation"
+              class="badge badge-neutral badge-sm"
+            >
               {{ resource.generation }}
             </span>
-            <span v-if="resource.isMature" class="badge badge-error badge-sm">18+</span>
+            <span v-if="resource.isMature" class="badge badge-error badge-sm">
+              18+
+            </span>
           </div>
 
           <div

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -1,7 +1,12 @@
 <!-- /components/content/art/checkpoint-gallery.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3">
-    <header v-if="showHeader" class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section
+    class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
+  >
+    <header
+      v-if="showHeader"
+      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+    >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <h2 class="truncate text-lg font-bold text-base-content">
@@ -23,14 +28,20 @@
         </button>
       </div>
 
-      <div v-if="showControls" class="grid gap-2 md:grid-cols-[1fr_auto_auto]">
+      <div
+        v-if="showControls"
+        class="grid gap-2 md:grid-cols-[1fr_auto_auto]"
+      >
         <input
           v-model="searchQuery"
           class="input input-bordered rounded-xl"
           placeholder="Search checkpoints"
         />
 
-        <select v-model="selectedFamily" class="select select-bordered rounded-xl">
+        <select
+          v-model="selectedFamily"
+          class="select select-bordered rounded-xl"
+        >
           <option value="all">All</option>
           <option value="A1111">A1111</option>
           <option value="COMFY">COMFY</option>
@@ -51,11 +62,21 @@
       </div>
     </header>
 
+    <maturity-toggle
+      variant="resource"
+      label="Mature checkpoint models"
+      visible-text="Mature checkpoint models are available for selection."
+      hidden-text="Mature checkpoint models are hidden from selection."
+    />
+
     <add-checkpoint v-if="showAdd" />
 
     <server-status v-if="showStatus" compact />
 
-    <div v-if="showSampler" class="rounded-2xl border border-base-300 bg-base-100 p-3">
+    <div
+      v-if="showSampler"
+      class="rounded-2xl border border-base-300 bg-base-100 p-3"
+    >
       <label class="form-control">
         <span class="label-text font-bold">Sampler</span>
         <select
@@ -75,7 +96,10 @@
       </label>
     </div>
 
-    <div class="grid gap-3" :class="compact ? 'grid-cols-1' : 'sm:grid-cols-2 xl:grid-cols-3'">
+    <div
+      class="grid gap-3"
+      :class="compact ? 'grid-cols-1' : 'sm:grid-cols-2 xl:grid-cols-3'"
+    >
       <checkpoint-card
         v-for="checkpoint in filteredCheckpoints"
         :key="checkpoint.id || checkpoint.name"
@@ -89,7 +113,10 @@
       />
     </div>
 
-    <div v-if="!filteredCheckpoints.length" class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center">
+    <div
+      v-if="!filteredCheckpoints.length"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-200 p-6 text-center"
+    >
       <p class="font-bold">No checkpoints found.</p>
       <p class="text-sm text-base-content/60">
         Try another filter or add a checkpoint.
@@ -105,7 +132,13 @@ import { useCheckpointStore } from '@/stores/checkpointStore'
 import { useServerStore } from '@/stores/serverStore'
 
 type CheckpointGalleryVariant = 'dashboard' | 'compact' | 'selector'
-type CheckpointModelFamily = 'all' | 'A1111' | 'COMFY' | 'FLUX' | 'KONTEXT' | 'SDXL'
+type CheckpointModelFamily =
+  | 'all'
+  | 'A1111'
+  | 'COMFY'
+  | 'FLUX'
+  | 'KONTEXT'
+  | 'SDXL'
 
 const props = withDefaults(
   defineProps<{
@@ -160,7 +193,9 @@ const title = computed(() => props.title)
 const subtitleText = computed(() => {
   if (props.subtitle) return props.subtitle
   const server = serverStore.activeArtServer
-  return server ? `Active server: ${server.label || server.title} · ${server.serverType}` : 'Checkpoint choices are resources, not server capabilities.'
+  return server
+    ? `Active server: ${server.label || server.title} · ${server.serverType}`
+    : 'Checkpoint choices are resources, not server capabilities.'
 })
 
 const compact = computed(() => props.compact || props.variant === 'compact')
@@ -170,9 +205,15 @@ const filteredCheckpoints = computed<Partial<Resource>[]>(() => {
 
   return checkpointStore.visibleCheckpoints.filter((checkpoint) => {
     const family = selectedFamily.value
-    const supportedServer = String(checkpoint.supportedServer || checkpoint.generation || '').toUpperCase()
+    const supportedServer = String(
+      checkpoint.supportedServer || checkpoint.generation || '',
+    ).toUpperCase()
 
-    if (family !== 'all' && supportedServer && !supportedServer.includes(family)) {
+    if (
+      family !== 'all' &&
+      supportedServer &&
+      !supportedServer.includes(family)
+    ) {
       return false
     }
 
@@ -191,12 +232,12 @@ const filteredCheckpoints = computed<Partial<Resource>[]>(() => {
   })
 })
 
-function selectSampler(event: Event) {
+function selectSampler(event: Event): void {
   const target = event.target as HTMLSelectElement
   checkpointStore.selectSamplerByName(target.value)
 }
 
-async function refreshStatus() {
+async function refreshStatus(): Promise<void> {
   await checkpointStore.checkActiveModel()
 }
 

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -213,6 +213,8 @@ onMounted(async () => {
 watch(
   [() => props.engine, compatibleResources],
   () => {
+    if (!resourceStore.hasLoaded) return
+
     if (props.modelValue && !selectedResource.value) {
       emit('update:modelValue', null)
     }

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -20,6 +20,13 @@
       </button>
     </div>
 
+    <maturity-toggle
+      variant="resource"
+      label="Mature LoRAs"
+      visible-text="Mature video LoRAs are available in this selector."
+      hidden-text="Mature video LoRAs are hidden from this selector."
+    />
+
     <div
       v-if="resourceStore.isLoading && !resourceStore.hasLoaded"
       class="flex min-h-28 items-center justify-center rounded-lg bg-base-200"
@@ -147,7 +154,6 @@
 
 <script setup lang="ts">
 import { computed, onMounted, watch } from 'vue'
-import { useArtStore } from '@/stores/artStore'
 import { useResourceStore } from '@/stores/resourceStore'
 import type { VideoEngine } from '@/stores/videoStore'
 import type { Resource } from '~/prisma/generated/prisma/client'
@@ -173,22 +179,20 @@ const emit = defineEmits<{
   'update:strength': [value: number]
 }>()
 
-const artStore = useArtStore()
 const resourceStore = useResourceStore()
 
 const compatibleResources = computed<VideoLoraResource[]>(() => {
   const supportedServer = props.engine.toUpperCase()
 
-  return (resourceStore.resources as VideoLoraResource[]).filter((resource) => {
-    return (
-      (resource.resourceType === 'LORA' ||
-        resource.resourceType === 'LYCORIS') &&
-      Boolean(resource.localPath?.trim()) &&
-      (!resource.isMature || artStore.showMature) &&
-      (resource.supportedServer === supportedServer ||
-        resource.supportedServer === 'GENERIC')
-    )
-  })
+  return (resourceStore.visibleLoras as VideoLoraResource[]).filter(
+    (resource) => {
+      return (
+        Boolean(resource.localPath?.trim()) &&
+        (resource.supportedServer === supportedServer ||
+          resource.supportedServer === 'GENERIC')
+      )
+    },
+  )
 })
 
 const selectedResource = computed(

--- a/stores/accountStore.ts
+++ b/stores/accountStore.ts
@@ -51,6 +51,23 @@ export const useAccountStore = defineStore('accountStore', () => {
     }
   }
 
+  async function refreshMaturityResources(): Promise<void> {
+    try {
+      const [{ useResourceStore }, { useResourceGalleryStore }] =
+        await Promise.all([
+          import('./resourceStore'),
+          import('./resourceGalleryStore'),
+        ])
+
+      await Promise.all([
+        useResourceStore().getResources(true),
+        useResourceGalleryStore().loadResources(),
+      ])
+    } catch (error) {
+      handleError(error, 'refreshing maturity-filtered Resources')
+    }
+  }
+
   async function run(
     label: string,
     url: string,
@@ -115,7 +132,15 @@ export const useAccountStore = defineStore('accountStore', () => {
       patch as Record<string, unknown>,
       'PATCH',
     )
-    if (result.success) patchLocalUser(patch as Record<string, unknown>)
+
+    if (result.success) {
+      patchLocalUser(patch as Record<string, unknown>)
+
+      if (typeof patch.showMature === 'boolean') {
+        await refreshMaturityResources()
+      }
+    }
+
     return result
   }
 

--- a/stores/accountStore.ts
+++ b/stores/accountStore.ts
@@ -38,6 +38,19 @@ export type ConsentPatch = {
 
 type ActionResult = { success: boolean; message: string }
 
+type ResourceLike = {
+  id: number
+  name?: string | null
+  customLabel?: string | null
+  localPath?: string | null
+  resourceType?: string | null
+  isMature?: boolean | null
+}
+
+function resourceEngineName(resource: ResourceLike | undefined): string {
+  return resource?.localPath || resource?.name || resource?.customLabel || ''
+}
+
 export const useAccountStore = defineStore('accountStore', () => {
   const userStore = useUserStore()
 
@@ -51,17 +64,92 @@ export const useAccountStore = defineStore('accountStore', () => {
     }
   }
 
-  async function refreshMaturityResources(): Promise<void> {
+  async function refreshMaturityResources(showMature: boolean): Promise<void> {
     try {
-      const [{ useResourceStore }, { useResourceGalleryStore }] =
-        await Promise.all([
-          import('./resourceStore'),
-          import('./resourceGalleryStore'),
-        ])
+      const [
+        { useResourceStore },
+        { useResourceGalleryStore },
+        { useCheckpointStore },
+        { useArtStore },
+      ] = await Promise.all([
+        import('./resourceStore'),
+        import('./resourceGalleryStore'),
+        import('./checkpointStore'),
+        import('./artStore'),
+      ])
+
+      const resourceStore = useResourceStore()
+      const resourceGalleryStore = useResourceGalleryStore()
+      const checkpointStore = useCheckpointStore()
+      const artStore = useArtStore()
+
+      if (!showMature) {
+        const currentResources = resourceStore.resources as ResourceLike[]
+        const matureResources = currentResources.filter(
+          (resource) => resource.isMature === true,
+        )
+        const matureIds = new Set(matureResources.map((resource) => resource.id))
+        const matureLoraNames = new Set(
+          matureResources
+            .filter((resource) => {
+              const type = String(resource.resourceType || '').toUpperCase()
+              return type === 'LORA' || type === 'LYCORIS'
+            })
+            .map(resourceEngineName)
+            .filter(Boolean),
+        )
+        const matureCheckpointNames = new Set(
+          matureResources
+            .filter(
+              (resource) =>
+                String(resource.resourceType || '').toUpperCase() ===
+                'CHECKPOINT',
+            )
+            .map(resourceEngineName)
+            .filter(Boolean),
+        )
+
+        const currentLoraIds = artStore.artForm.loraResourceIds ?? []
+        const visibleLoraIds = currentLoraIds.filter((id) => !matureIds.has(id))
+        const loraSelectionChanged =
+          visibleLoraIds.length !== currentLoraIds.length
+        const primaryVisibleLora = currentResources.find(
+          (resource) => resource.id === visibleLoraIds[0],
+        )
+        const checkpointHidden =
+          (artStore.artForm.checkpointResourceId != null &&
+            matureIds.has(artStore.artForm.checkpointResourceId)) ||
+          matureCheckpointNames.has(artStore.artForm.checkpoint || '')
+        const namedLoraHidden = matureLoraNames.has(
+          artStore.artForm.loraName || '',
+        )
+
+        artStore.setArtForm({
+          ...(loraSelectionChanged
+            ? {
+                loraResourceIds: visibleLoraIds,
+                loraName: primaryVisibleLora
+                  ? resourceEngineName(primaryVisibleLora)
+                  : null,
+              }
+            : namedLoraHidden
+              ? { loraName: null }
+              : {}),
+          ...(checkpointHidden
+            ? { checkpointResourceId: null, checkpoint: '' }
+            : {}),
+        })
+
+        if (checkpointStore.selectedCheckpoint?.isMature) {
+          checkpointStore.selectCheckpointByName(
+            checkpointStore.visibleCheckpoints[0]?.name || '',
+          )
+        }
+      }
 
       await Promise.all([
-        useResourceStore().getResources(true),
-        useResourceGalleryStore().loadResources(),
+        resourceStore.getResources(true),
+        resourceGalleryStore.loadResources(),
       ])
     } catch (error) {
       handleError(error, 'refreshing maturity-filtered Resources')
@@ -94,7 +182,6 @@ export const useAccountStore = defineStore('accountStore', () => {
     }
   }
 
-  // ── Password ───────────────────────────────────────────────────────────────
   function changePassword(
     newPassword: string,
     currentPassword?: string,
@@ -119,12 +206,10 @@ export const useAccountStore = defineStore('accountStore', () => {
     })
   }
 
-  // ── Email verification ───────────────────────────────────────────────────────
   function sendVerificationEmail(): Promise<ActionResult> {
     return run('sendVerificationEmail', '/api/auth/email/send-verification', {})
   }
 
-  // ── Consent / privacy ────────────────────────────────────────────────────────
   async function updateConsent(patch: ConsentPatch): Promise<ActionResult> {
     const result = await run(
       'updateConsent',
@@ -137,14 +222,13 @@ export const useAccountStore = defineStore('accountStore', () => {
       patchLocalUser(patch as Record<string, unknown>)
 
       if (typeof patch.showMature === 'boolean') {
-        await refreshMaturityResources()
+        await refreshMaturityResources(patch.showMature)
       }
     }
 
     return result
   }
 
-  // ── Newsletter (double opt-in) ────────────────────────────────────────────────
   async function setNewsletterFrequency(
     frequency: NewsletterFrequency,
   ): Promise<ActionResult> {
@@ -156,7 +240,6 @@ export const useAccountStore = defineStore('accountStore', () => {
       },
     )
     if (result.success) {
-      // Frequency is stored immediately; confirmation clears the opt-in gate.
       patchLocalUser({
         newsletterFrequency: frequency,
         ...(frequency === 'NEVER' ? { newsletterConfirmedAt: null } : {}),

--- a/utils/scripts/verifyMaturityPrivacyContract.ts
+++ b/utils/scripts/verifyMaturityPrivacyContract.ts
@@ -49,6 +49,60 @@ assert.ok(videoGenerator.includes('<content-visibility-controls'))
 assert.ok(videoGenerator.includes('isMature: isMature.value'))
 assert.ok(videoGenerator.includes('isPublic: isPublic.value'))
 
+const videoLoraPicker = readFileSync(
+  'components/video-lora-picker.vue',
+  'utf8',
+)
+assert.ok(videoLoraPicker.includes('<maturity-toggle'))
+assert.ok(videoLoraPicker.includes('resourceStore.visibleLoras'))
+assert.ok(!videoLoraPicker.includes('artStore.showMature'))
+
+const artLoraPicker = readFileSync('components/art/lora-picker.vue', 'utf8')
+assert.ok(artLoraPicker.includes('<maturity-toggle'))
+assert.ok(artLoraPicker.includes('resourceStore.visibleLoras'))
+assert.ok(artLoraPicker.includes('availableLoraIds'))
+assert.ok(!artLoraPicker.includes('artStore.showMature'))
+
+const artMaker = readFileSync('components/art/art-maker.vue', 'utf8')
+assert.ok(artMaker.includes('label="Mature checkpoint models"'))
+assert.ok(artMaker.includes('checkpointStore.visibleCheckpoints'))
+assert.ok(!artMaker.includes('artStore.showMature'))
+
+for (const file of [
+  'components/lora/lora-gallery.vue',
+  'components/model/model-gallery.vue',
+  'components/servers/checkpoint-gallery.vue',
+  'components/resources/resource-gallery.vue',
+]) {
+  const source = readFileSync(file, 'utf8')
+  assert.ok(source.includes('<maturity-toggle'), `${file} needs maturity toggle`)
+}
+
+const loraDiscover = readFileSync(
+  'components/lora/lora-discover.vue',
+  'utf8',
+)
+assert.ok(loraDiscover.includes('<maturity-toggle'))
+assert.ok(
+  loraDiscover.includes("if (userStore.showMature) params.set('nsfw', 'true')"),
+)
+assert.ok(!loraDiscover.includes('includeMature'))
+
+const maturityToggle = readFileSync(
+  'components/navigation/maturity-toggle.vue',
+  'utf8',
+)
+assert.ok(maturityToggle.includes("variant === 'resource'"))
+assert.ok(maturityToggle.includes('accountStore.updateConsent'))
+assert.ok(maturityToggle.includes('showMature: value'))
+
+const accountStore = readFileSync('stores/accountStore.ts', 'utf8')
+assert.ok(accountStore.includes('refreshMaturityResources'))
+assert.ok(accountStore.includes('resourceStore.getResources(true)'))
+assert.ok(accountStore.includes('resourceGalleryStore.loadResources()'))
+assert.ok(accountStore.includes('loraResourceIds: visibleLoraIds'))
+assert.ok(accountStore.includes('checkpointResourceId: null'))
+
 const queueEditor = readFileSync('components/art/artjob-editor.vue', 'utf8')
 assert.ok(queueEditor.includes('v-model:is-mature="form.isMature"'))
 assert.ok(queueEditor.includes('isMature: form.isMature'))


### PR DESCRIPTION
## What changed

- adds a reusable labeled maturity control for Resource selectors and galleries
- puts the control directly above the video-generator LoRA selector
- switches video and image LoRA pickers to `resourceStore.visibleLoras`
- switches the main image checkpoint selector to `checkpointStore.visibleCheckpoints` without the redundant art-store flag
- adds the same account-backed control to LoRA, checkpoint, model, discovery, and generic Resource galleries
- makes Discover include mature Civitai results directly from the user's persisted `showMature` setting
- refreshes server-filtered Resource catalogs whenever `showMature` changes
- clears mature LoRA/checkpoint selections when mature Resources are hidden
- adds maturity contract checks covering the selectors, galleries, refresh, and selection cleanup

## Behavior

- guests still do not receive a maturity control
- the persisted user field remains `showMature`
- mature Resources are excluded both by the API and by client-side visible collections
- turning mature Resources off immediately removes hidden choices and prevents stale selected Resource IDs from remaining active

## Validation

- TypeScript Type Check: passed
- Contract Tests: passed
- Taskmaster Checkpoint Engine Contract: passed
- Narrative Art Persistence Contract: passed
- Narrative Primitives Contract: passed
- Storymaker contracts: passed
- Facet Catalog Contract: passed
- API Client Follow-ups Contract: passed