### PR TITLE
Make startup exit and animation controls deterministic

### DIFF
--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -8,7 +8,7 @@ const HANDOFF_CLASS = 'kr-startup-handoff'
 const EFFECT_READY_CLASS = 'kr-startup-effect-ready'
 const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
 
-const EMERGENCY_FADE_AT_MS = 6000
+const EMERGENCY_EXIT_AT_MS = 6000
 const FADE_CLEANUP_MS = 700
 
 export default defineNuxtPlugin((nuxtApp) => {
@@ -18,7 +18,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   let sawLoader = false
   let cleanupTimer: number | null = null
-  let emergencyFadeTimer: number | null = null
+  let emergencyExitTimer: number | null = null
 
   function clearCleanupTimer(): void {
     if (cleanupTimer === null) return
@@ -26,10 +26,10 @@ export default defineNuxtPlugin((nuxtApp) => {
     cleanupTimer = null
   }
 
-  function clearEmergencyFadeTimer(): void {
-    if (emergencyFadeTimer === null) return
-    window.clearTimeout(emergencyFadeTimer)
-    emergencyFadeTimer = null
+  function clearEmergencyExitTimer(): void {
+    if (emergencyExitTimer === null) return
+    window.clearTimeout(emergencyExitTimer)
+    emergencyExitTimer = null
   }
 
   function beginFade(): void {
@@ -39,14 +39,14 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     if (!startupActive) return
 
-    clearEmergencyFadeTimer()
+    clearEmergencyExitTimer()
     root.classList.add(FADING_CLASS)
     butterflyStore.setShowSwarm(false)
   }
 
   function cleanup(): void {
     clearCleanupTimer()
-    clearEmergencyFadeTimer()
+    clearEmergencyExitTimer()
     butterflyStore.setShowSwarm(false)
     root.classList.remove(
       ACTIVE_CLASS,
@@ -66,6 +66,14 @@ export default defineNuxtPlugin((nuxtApp) => {
       cleanup()
       observer.disconnect()
     }, FADE_CLEANUP_MS)
+  }
+
+  function requestEmergencyExit(): void {
+    if (startupStore.immersive) return
+
+    beginFade()
+    startupStore.requestExit()
+    scheduleCleanup()
   }
 
   function syncCompositionState(): void {
@@ -103,11 +111,10 @@ export default defineNuxtPlugin((nuxtApp) => {
   syncCompositionState()
 
   const elapsedSinceNavigation = performance.now()
-  emergencyFadeTimer = window.setTimeout(() => {
-    emergencyFadeTimer = null
-    if (startupStore.immersive) return
-    beginFade()
-  }, Math.max(0, EMERGENCY_FADE_AT_MS - elapsedSinceNavigation))
+  emergencyExitTimer = window.setTimeout(() => {
+    emergencyExitTimer = null
+    requestEmergencyExit()
+  }, Math.max(0, EMERGENCY_EXIT_AT_MS - elapsedSinceNavigation))
 
   nuxtApp.hook('app:mounted', syncCompositionState)
   window.addEventListener('pagehide', cleanup, { once: true })

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -19,6 +19,24 @@ export default defineNitroPlugin((nitroApp) => {
           display: block;
         }
 
+        html.kr-startup-handoff .kr-prehydrate-controls,
+        .startup-animation__controls {
+          z-index: 2147483000 !important;
+          isolation: isolate;
+        }
+
+        html.kr-startup-handoff .kr-prehydrate-controls,
+        .startup-animation__controls,
+        html.kr-startup-handoff .kr-prehydrate-controls button,
+        .startup-animation__controls button {
+          pointer-events: auto !important;
+          touch-action: manipulation;
+        }
+
+        html.kr-startup-controls-ready .kr-prehydrate-controls {
+          pointer-events: none !important;
+        }
+
         .kr-prehydrate-media,
         .loading-logo {
           -webkit-mask-image: radial-gradient(
@@ -62,7 +80,7 @@ export default defineNitroPlugin((nitroApp) => {
         html:has(.loading-overlay--fade) .startup-animation__controls {
           opacity: 0 !important;
           transition: opacity 650ms ease !important;
-          pointer-events: none;
+          pointer-events: none !important;
         }
 
         @media (prefers-reduced-motion: reduce) {

--- a/server/plugins/startup-loader-shell.ts
+++ b/server/plugins/startup-loader-shell.ts
@@ -98,6 +98,7 @@ export default defineNitroPlugin((nitroApp) => {
             if (!action) return
 
             event.preventDefault()
+            event.stopPropagation()
 
             if (root.classList.contains('kr-startup-controls-ready')) {
               window.dispatchEvent(
@@ -107,7 +108,7 @@ export default defineNitroPlugin((nitroApp) => {
             }
 
             queue.push(action)
-          })
+          }, true)
 
           window.setTimeout(() => {
             root.classList.remove('kr-startup-handoff')


### PR DESCRIPTION
## What changed

- changes the six-second startup safeguard from a CSS-only fade into the loader's real `startupStore.requestExit()` path
- schedules composition cleanup at the same time, so stale root startup classes cannot keep the document black
- preserves **Pause & explore** by skipping the emergency exit while immersive mode is active
- raises both pre-hydration and hydrated animation controls above all Screen FX and animation status layers
- explicitly keeps visible control buttons pointer-active and disables them only during the real exit fade
- captures the pre-hydration **Pause & explore** click before another overlay can intercept or stop it

## Root cause

The previous emergency guard only added `kr-startup-fading` and disabled the Screen FX. It did not notify `kind-loader` to remove the overlay or emit `pageReady`. Because the app-level eight-second failsafe is registered only after `await navStore.initialize()`, a stalled nav initialization meant that failsafe might never exist. The document could therefore remain in startup state indefinitely, with the emergency fade also making the controls non-interactive.

## Expected behavior

- the normal synchronized startup remains unchanged
- a stalled startup exits through the same store signal as the close control at six seconds
- the loader emits `pageReady`, the desktop appears, and startup root classes are cleaned up
- **Pause & explore** can be clicked immediately, before or after hydration
- previous/random/next/resume/close controls remain above all visual effect layers
- intentionally paused exploration is not auto-closed

## Validation

- final head: `8a45557a332ff588de257c367070776718537474`
- TypeScript Type Check passed
- Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel deployment `dpl_4g9Ho7aKNzKS5nrSEMKKYPFLC1KZ` is READY and built from the final head
- preview root returned HTTP 200
- delivered HTML gives both pre-hydration and hydrated control trays a z-index above Screen FX and animation status layers
- delivered HTML keeps controls pointer-active until the actual exit fade
- delivered pre-hydration listener handles clicks in capture phase and stops competing propagation
- delivered Nuxt public build ID matches the final head

The browser runner in this environment is blocked from reaching the deployment, so a literal click-through recording was not possible. The remaining check is the real dashboard refresh: confirm automatic exit, then relaunch and confirm **Pause & explore**, previous/random/next, resume, and close.