### PR TITLE
Make startup control handoff state-driven

### DIFF
--- a/.github/workflows/startup-handoff-contract.yml
+++ b/.github/workflows/startup-handoff-contract.yml
@@ -1,0 +1,42 @@
+name: Startup Handoff Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'components/screenfx/startup-animation.vue'
+      - 'plugins/startup-composition.client.ts'
+      - 'server/plugins/startup-loader-shell.ts'
+      - 'utils/scripts/verify-startup-handoff.mjs'
+      - '.github/workflows/startup-handoff-contract.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'components/screenfx/startup-animation.vue'
+      - 'plugins/startup-composition.client.ts'
+      - 'server/plugins/startup-loader-shell.ts'
+      - 'utils/scripts/verify-startup-handoff.mjs'
+      - '.github/workflows/startup-handoff-contract.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: startup-handoff-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  startup-handoff:
+    name: Verify startup handoff lifecycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Verify startup handoff
+        run: node utils/scripts/verify-startup-handoff.mjs

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -27,7 +27,8 @@
     </div>
 
     <div
-      v-if="renderEffect && currentComponent"
+      v-if="showControls"
+      ref="controlsElement"
       class="startup-animation__controls"
       :class="{
         'startup-animation__controls--active': startupStore.controlsActive,
@@ -36,7 +37,7 @@
       }"
     >
       <template v-if="startupStore.controlsActive">
-        <span class="startup-animation__name">{{ currentEffectLabel }}</span>
+        <span class="startup-animation__name">{{ displayEffectLabel }}</span>
 
         <div class="startup-animation__button-group">
           <button
@@ -44,6 +45,7 @@
             class="btn btn-xs btn-ghost btn-square text-white"
             title="Previous animation"
             aria-label="Previous animation"
+            :disabled="!hasSelectableEffects"
             @click="selectPreviousEffect"
           >
             <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
@@ -53,6 +55,7 @@
             type="button"
             class="btn btn-xs btn-ghost gap-1 text-white"
             title="Choose another random animation"
+            :disabled="!hasSelectableEffects"
             @click="selectRandomEffect"
           >
             <Icon name="kind-icon:sparkles" class="h-4 w-4" />
@@ -64,6 +67,7 @@
             class="btn btn-xs btn-ghost btn-square text-white"
             title="Next animation"
             aria-label="Next animation"
+            :disabled="!hasSelectableEffects"
             @click="selectNextEffect"
           >
             <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
@@ -94,7 +98,7 @@
 
       <template v-else>
         <span class="startup-animation__compact-name">
-          {{ currentEffectLabel }}
+          {{ displayEffectLabel }}
         </span>
 
         <button
@@ -112,7 +116,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from 'vue'
 import { getAnimationEffectComponent } from '@/components/screenfx/effect-component-registry'
 import type { AnimationEffectId } from '@/stores/animationCatalog'
 import { useAnimationStore } from '@/stores/animationStore'
@@ -144,6 +155,7 @@ const preferenceStore = useAnimationPreferenceStore()
 const butterflyStore = useButterflyStore()
 const startupStore = useStartupAnimationStore()
 
+const controlsElement = ref<HTMLElement | null>(null)
 const resolvedEffectId = ref<AnimationEffectId | null>(null)
 const renderEffect = ref(false)
 const effectReady = ref(false)
@@ -164,6 +176,8 @@ const availableEffectIds = computed(() => {
     .map((effect) => effect.id)
 })
 
+const hasSelectableEffects = computed(() => availableEffectIds.value.length > 0)
+
 const currentComponent = computed(() => {
   if (!resolvedEffectId.value) return null
   return getAnimationEffectComponent(resolvedEffectId.value)
@@ -176,6 +190,19 @@ const currentEffectLabel = computed(() => {
     animationStore.effects.find(
       (effect) => effect.id === resolvedEffectId.value,
     )?.label ?? resolvedEffectId.value
+  )
+})
+
+const displayEffectLabel = computed(
+  () => currentEffectLabel.value || 'Preparing animation…',
+)
+
+const showControls = computed(() => {
+  return (
+    butterflyStore.showSwarm ||
+    renderEffect.value ||
+    startupStore.immersive ||
+    isFading.value
   )
 })
 
@@ -212,11 +239,25 @@ function markControlsReady(): void {
   finishHandoffIfReady()
 }
 
+async function syncControlsHandoff(): Promise<void> {
+  if (!import.meta.client) return
+  if (!showControls.value) return
+  if (!resolvedEffectId.value) return
+  if (!currentComponent.value) return
+  if (!currentEffectLabel.value) return
+
+  await nextTick()
+  if (!controlsElement.value) return
+
+  markControlsReady()
+}
+
 function handleEffectReady(): void {
   effectReady.value = true
 
   if (!import.meta.client) return
   document.documentElement.classList.add(EFFECT_READY_CLASS)
+  void syncControlsHandoff()
   finishHandoffIfReady()
 }
 
@@ -227,8 +268,7 @@ function setEffect(effectId: AnimationEffectId | null): void {
   isFading.value = false
 
   if (!effectId && import.meta.client) {
-    document.documentElement.classList.add(EFFECT_READY_CLASS)
-    finishHandoffIfReady()
+    document.documentElement.classList.remove(CONTROLS_READY_CLASS)
   }
 }
 
@@ -323,13 +363,9 @@ function fadeOut(): void {
 
 startupStore.reset()
 
-if (import.meta.client && butterflyStore.showSwarm) {
-  selectEffect()
-}
-
 watch(
-  () => butterflyStore.showSwarm,
-  (visible) => {
+  [() => butterflyStore.showSwarm, availableEffectIds],
+  ([visible]) => {
     if (visible) {
       clearFadeTimer()
       selectEffect()
@@ -338,12 +374,20 @@ watch(
 
     fadeOut()
   },
+  { immediate: true },
+)
+
+watch(
+  [showControls, resolvedEffectId, currentComponent, currentEffectLabel],
+  () => {
+    void syncControlsHandoff()
+  },
 )
 
 onMounted(() => {
   window.addEventListener(BRIDGE_EVENT, handleBridgeEvent)
-  markControlsReady()
   consumeBridgeQueue()
+  void syncControlsHandoff()
 })
 
 onBeforeUnmount(() => {

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -143,6 +143,7 @@ type StartupBridgeAction =
 
 type StartupBridgeWindow = Window & {
   __KR_STARTUP_ACTION_QUEUE__?: string[]
+  __KR_STARTUP_BRIDGE_READY__?: boolean
 }
 
 const HANDOFF_CLASS = 'kr-startup-handoff'
@@ -385,7 +386,10 @@ watch(
 )
 
 onMounted(() => {
+  const bridgeWindow = window as StartupBridgeWindow
+
   window.addEventListener(BRIDGE_EVENT, handleBridgeEvent)
+  bridgeWindow.__KR_STARTUP_BRIDGE_READY__ = true
   consumeBridgeQueue()
   void syncControlsHandoff()
 })
@@ -395,6 +399,8 @@ onBeforeUnmount(() => {
   clearHandoffTimer()
 
   if (import.meta.client) {
+    const bridgeWindow = window as StartupBridgeWindow
+    bridgeWindow.__KR_STARTUP_BRIDGE_READY__ = false
     window.removeEventListener(BRIDGE_EVENT, handleBridgeEvent)
   }
 })

--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -68,8 +68,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     }, FADE_CLEANUP_MS)
   }
 
+  function hasUsableImmersiveControls(): boolean {
+    return (
+      root.classList.contains(CONTROLS_READY_CLASS) &&
+      Boolean(document.querySelector('.startup-animation__controls'))
+    )
+  }
+
   function requestEmergencyExit(): void {
-    if (startupStore.immersive) return
+    if (startupStore.immersive && hasUsableImmersiveControls()) return
 
     beginFade()
     startupStore.requestExit()

--- a/server/plugins/startup-loader-shell.ts
+++ b/server/plugins/startup-loader-shell.ts
@@ -109,10 +109,6 @@ export default defineNitroPlugin((nitroApp) => {
 
             queue.push(action)
           }, true)
-
-          window.setTimeout(() => {
-            root.classList.remove('kr-startup-handoff')
-          }, 8000)
         })()
       </script>
     `)

--- a/server/plugins/startup-loader-shell.ts
+++ b/server/plugins/startup-loader-shell.ts
@@ -100,7 +100,7 @@ export default defineNitroPlugin((nitroApp) => {
             event.preventDefault()
             event.stopPropagation()
 
-            if (root.classList.contains('kr-startup-controls-ready')) {
+            if (window.__KR_STARTUP_BRIDGE_READY__) {
               window.dispatchEvent(
                 new CustomEvent('kr-startup-action', { detail: action }),
               )

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const [startupComponent, startupPlugin, startupShell] = await Promise.all([
+  readFile('components/screenfx/startup-animation.vue', 'utf8'),
+  readFile('plugins/startup-composition.client.ts', 'utf8'),
+  readFile('server/plugins/startup-loader-shell.ts', 'utf8'),
+])
+
+assert.ok(
+  startupComponent.includes('v-if="showControls"') &&
+    startupComponent.includes('ref="controlsElement"'),
+  'Hydrated startup controls must render independently and expose a mounted element ref.',
+)
+
+assert.ok(
+  startupComponent.includes("currentEffectLabel.value || 'Preparing animation…'") ||
+    startupComponent.includes("currentEffectLabel.value || 'Preparing animation…'"),
+  'The control tray must never present a blank animation-name slot.',
+)
+
+const handoffGuard = startupComponent.slice(
+  startupComponent.indexOf('async function syncControlsHandoff'),
+  startupComponent.indexOf('function handleEffectReady'),
+)
+
+for (const requiredGuard of [
+  'showControls.value',
+  'resolvedEffectId.value',
+  'currentComponent.value',
+  'currentEffectLabel.value',
+  'controlsElement.value',
+  'markControlsReady()',
+]) {
+  assert.ok(
+    handoffGuard.includes(requiredGuard),
+    `Hydrated handoff is missing required readiness guard: ${requiredGuard}`,
+  )
+}
+
+assert.ok(
+  !/onMounted\([\s\S]*?markControlsReady\(\)/.test(startupComponent),
+  'Controls must not be declared ready merely because the component mounted.',
+)
+
+assert.ok(
+  !/setTimeout\([\s\S]*?remove\(['"]kr-startup-handoff['"]\)/.test(
+    startupShell,
+  ),
+  'The server-rendered control must not disappear on an unconditional timer.',
+)
+
+assert.ok(
+  startupPlugin.includes(
+    'startupStore.immersive && hasUsableImmersiveControls()',
+  ),
+  'Immersive mode may suppress emergency exit only when hydrated controls are usable.',
+)
+
+assert.ok(
+  startupPlugin.includes(
+    "document.querySelector('.startup-animation__controls')",
+  ),
+  'The emergency guard must verify that the hydrated controls exist in the DOM.',
+)
+
+console.log('Startup handoff contract passed.')

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -14,8 +14,7 @@ assert.ok(
 )
 
 assert.ok(
-  startupComponent.includes("currentEffectLabel.value || 'Preparing animation…'") ||
-    startupComponent.includes("currentEffectLabel.value || 'Preparing animation…'"),
+  startupComponent.includes("currentEffectLabel.value || 'Preparing animation…'"),
   'The control tray must never present a blank animation-name slot.',
 )
 
@@ -48,6 +47,24 @@ assert.ok(
     startupShell,
   ),
   'The server-rendered control must not disappear on an unconditional timer.',
+)
+
+assert.ok(
+  startupComponent.includes('__KR_STARTUP_BRIDGE_READY__ = true') &&
+    startupComponent.includes('__KR_STARTUP_BRIDGE_READY__ = false'),
+  'The hydrated component must explicitly publish and clear bridge-listener readiness.',
+)
+
+assert.ok(
+  startupShell.includes('if (window.__KR_STARTUP_BRIDGE_READY__)'),
+  'Server control clicks must dispatch as soon as the Vue event bridge is listening.',
+)
+
+assert.ok(
+  !startupShell.includes(
+    "if (root.classList.contains('kr-startup-controls-ready'))",
+  ),
+  'Click dispatch must not wait for the visual control-panel handoff.',
 )
 
 assert.ok(


### PR DESCRIPTION
## What changed

- keeps the server-rendered **Pause & explore** control alive until the hydrated animation panel has actually rendered
- removes the unconditional eight-second handoff timeout that was hiding the only available control
- renders the hydrated control tray independently from the effect component, so Pause/Resume/Close remain available while an effect is still resolving
- requires a resolved effect component, non-empty animation label, and mounted controls element before declaring the visual handoff ready
- shows `Preparing animation…` instead of a blank animation-name slot during resolution
- disables only previous/random/next while no selectable effect exists; Resume and Close remain actionable
- only preserves immersive mode past the six-second emergency boundary when a usable hydrated controls element exists
- separates Vue event-listener readiness from visual control-panel readiness, so clicks during hydration dispatch immediately instead of entering a queue that has already been consumed
- adds a focused Startup Handoff Contract to prevent the same lifecycle races from returning

## Root cause

There were two overlapping handoff races:

1. The server control was removed after eight seconds regardless of whether a hydrated replacement existed. Meanwhile, `startup-animation.vue` declared controls ready merely because it mounted, even though its real tray was still behind effect-component resolution. An early click could set `immersive=true`, suppress emergency exit, and leave no real panel or animation name.
2. Vue consumed the pre-hydration action queue once on mount. During the interval after that mount but before the visual panel was marked ready, the server listener still queued clicks. Those later clicks were never consumed, producing a hover response with no click action.

Together these caused the exact hover-then-dead, blank-name, infinite-startup behavior.

## Expected behavior

- the server button remains visible and clickable until a named hydrated panel genuinely exists
- clicks before Vue mounts are queued and consumed
- clicks after Vue begins listening dispatch immediately, even before the visual crossfade finishes
- the hydrated panel always provides Pause/Resume/Close while startup is active
- a failed effect resolution cannot strand the loader in immersive mode
- a deliberate pause is preserved only when the user has a real panel they can operate
- normal startup still exits automatically

## Validation

- final head: `a64207e6ae4af6c6e07aabd3f0a0f8572b07d647`
- TypeScript Type Check passed
- full Contract Tests passed, including all 88 contract steps
- dedicated Startup Handoff Contract passed
- all focused GitHub Actions workflows passed
- final Vercel deployment `dpl_67jDdQGxxg55a2ZjgRxVUooAt2mn` is READY from the final head
- preview root returned HTTP 200
- delivered Nuxt public build ID matches the final head
- delivered server shell uses `__KR_STARTUP_BRIDGE_READY__` for live click dispatch instead of waiting for visual controls readiness
- delivered server shell contains no unconditional handoff-removal timer

A literal browser click-through could not be automated from this environment. The remaining validation is the real refresh test: confirm the startup exits normally, then relaunch and click **Pause & explore** both immediately and during the server-to-Vue transition; verify the animation name, previous/random/next, Resume, and Close.