### PR TITLE
Hard-stop mobile startup and remove ghost controls

### DIFF
--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -67,6 +67,7 @@ const ANIMATION_VISIBLE_HOLD_MS = 1500
 const MIN_TOTAL_MS =
   (EXTRA_MESSAGE_COUNT + 1) * EXTRA_MESSAGE_MS + READY_HOLD_MS
 const OVERLAY_FADE_MS = 650
+const HARD_EXIT_MS = 9000
 
 const startTime = consumeStartupStartedAt()
 
@@ -74,6 +75,7 @@ let destroyed = false
 let rotationIntervalId: ReturnType<typeof setInterval> | null = null
 let fallbackFadeTimeoutId: ReturnType<typeof setTimeout> | null = null
 let readyHoldTimeoutId: ReturnType<typeof setTimeout> | null = null
+let hardExitTimeoutId: ReturnType<typeof setTimeout> | null = null
 
 function wait(ms: number) {
   return new Promise<void>((resolve) => {
@@ -109,6 +111,12 @@ function clearReadyHold() {
   readyHoldTimeoutId = null
 }
 
+function clearHardExit() {
+  if (!hardExitTimeoutId) return
+  clearTimeout(hardExitTimeoutId)
+  hardExitTimeoutId = null
+}
+
 function emitHiddenOnce() {
   if (hiddenEmitted.value) return
   hiddenEmitted.value = true
@@ -120,6 +128,7 @@ function doFade() {
 
   clearRotation()
   clearReadyHold()
+  clearHardExit()
   loadStore.revealDesktop()
   emit('hiding')
   fadeOverlay.value = true
@@ -159,6 +168,24 @@ function scheduleFade() {
   readyHoldTimeoutId = setTimeout(() => {
     doFade()
   }, holdNeeded)
+}
+
+function startHardExitWatchdog() {
+  const remaining = Math.max(0, startTime + HARD_EXIT_MS - Date.now())
+
+  hardExitTimeoutId = setTimeout(() => {
+    hardExitTimeoutId = null
+
+    if (
+      startupStore.controlsActive &&
+      document.querySelector('.startup-animation__controls--active')
+    ) {
+      return
+    }
+
+    exitRequested.value = true
+    doFade()
+  }, remaining)
 }
 
 function handleIntroVisualSettled(kind: 'logo' | 'animation') {
@@ -224,15 +251,13 @@ watch(
   () => startupStore.exitRequest,
   () => {
     exitRequested.value = true
-
-    if (props.storesReady) {
-      doFade()
-    }
+    doFade()
   },
 )
 
 onMounted(async () => {
   emit('covered')
+  startHardExitWatchdog()
   await runVisualSequence()
 })
 
@@ -240,6 +265,7 @@ onBeforeUnmount(() => {
   destroyed = true
   clearRotation()
   clearReadyHold()
+  clearHardExit()
 
   if (fallbackFadeTimeoutId) {
     clearTimeout(fallbackFadeTimeoutId)

--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -11,6 +11,10 @@ const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
 const EMERGENCY_EXIT_AT_MS = 6000
 const FADE_CLEANUP_MS = 700
 
+type StartupCompositionWindow = Window & {
+  __KR_STARTUP_SHELL_WATCHDOG__?: number
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   const root = document.documentElement
   const butterflyStore = useButterflyStore()
@@ -32,6 +36,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     emergencyExitTimer = null
   }
 
+  function clearShellWatchdog(): void {
+    const startupWindow = window as StartupCompositionWindow
+    const watchdog = startupWindow.__KR_STARTUP_SHELL_WATCHDOG__
+    if (typeof watchdog !== 'number') return
+
+    window.clearTimeout(watchdog)
+    delete startupWindow.__KR_STARTUP_SHELL_WATCHDOG__
+  }
+
   function beginFade(): void {
     const startupActive =
       root.classList.contains(ACTIVE_CLASS) ||
@@ -47,6 +60,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   function cleanup(): void {
     clearCleanupTimer()
     clearEmergencyExitTimer()
+    clearShellWatchdog()
     butterflyStore.setShowSwarm(false)
     root.classList.remove(
       ACTIVE_CLASS,

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -19,22 +19,15 @@ export default defineNitroPlugin((nitroApp) => {
           display: block;
         }
 
-        html.kr-startup-handoff .kr-prehydrate-controls,
         .startup-animation__controls {
           z-index: 2147483000 !important;
           isolation: isolate;
         }
 
-        html.kr-startup-handoff .kr-prehydrate-controls,
         .startup-animation__controls,
-        html.kr-startup-handoff .kr-prehydrate-controls button,
         .startup-animation__controls button {
           pointer-events: auto !important;
           touch-action: manipulation;
-        }
-
-        html.kr-startup-controls-ready .kr-prehydrate-controls {
-          pointer-events: none !important;
         }
 
         .kr-prehydrate-media,
@@ -73,7 +66,6 @@ export default defineNitroPlugin((nitroApp) => {
         html.kr-startup-fading .loading-overlay,
         html.kr-startup-fading .kr-prehydrate-effect,
         html.kr-startup-fading .kr-prehydrate-content,
-        html.kr-startup-fading .kr-prehydrate-controls,
         html.kr-startup-fading .startup-animation__stage,
         html.kr-startup-fading .startup-animation__controls,
         html:has(.loading-overlay--fade) .startup-animation__stage,
@@ -83,12 +75,41 @@ export default defineNitroPlugin((nitroApp) => {
           pointer-events: none !important;
         }
 
+        @media (max-width: 639px) {
+          .startup-animation__controls {
+            right: 0.75rem !important;
+            bottom: max(0.75rem, env(safe-area-inset-bottom)) !important;
+            left: 0.75rem !important;
+            max-width: calc(100vw - 1.5rem) !important;
+          }
+
+          .loading-content {
+            height: calc(100dvh - 1rem) !important;
+            max-height: none !important;
+            grid-template-rows:
+              minmax(3.25rem, auto)
+              minmax(0, 1fr)
+              14rem !important;
+          }
+
+          .loading-status {
+            box-sizing: border-box;
+            min-height: 14rem !important;
+            grid-template-rows: 4rem minmax(4rem, auto) !important;
+            padding-bottom: 6rem !important;
+          }
+
+          .loading-message {
+            max-width: calc(100vw - 1.5rem) !important;
+            font-size: clamp(0.95rem, 4.5vw, 1.25rem) !important;
+          }
+        }
+
         @media (prefers-reduced-motion: reduce) {
           .kr-startup-black-base,
           html.kr-startup-fading .loading-overlay,
           html.kr-startup-fading .kr-prehydrate-effect,
           html.kr-startup-fading .kr-prehydrate-content,
-          html.kr-startup-fading .kr-prehydrate-controls,
           html.kr-startup-fading .startup-animation__stage,
           html.kr-startup-fading .startup-animation__controls,
           html:has(.loading-overlay--fade) .startup-animation__stage,
@@ -103,7 +124,40 @@ export default defineNitroPlugin((nitroApp) => {
           const root = document.documentElement
           if (!root.classList.contains('kr-full-startup')) return
 
+          const FORCE_KEY = 'kind-robots-force-full-startup-v1'
+          const STARTED_AT_KEY = 'kind-robots-startup-started-at-v1'
+          const WATCHDOG_MS = 9000
+          const FADE_MS = 700
+
           root.classList.add('kr-startup-active', 'kr-startup-handoff')
+
+          window.__KR_STARTUP_SHELL_WATCHDOG__ = window.setTimeout(() => {
+            if (document.querySelector('.startup-animation__controls--active')) {
+              return
+            }
+
+            try {
+              sessionStorage.removeItem(FORCE_KEY)
+              sessionStorage.removeItem(STARTED_AT_KEY)
+            } catch {}
+
+            root.classList.add('kr-startup-fading')
+
+            window.setTimeout(() => {
+              root.classList.remove(
+                'kr-full-startup',
+                'kr-startup-active',
+                'kr-startup-handoff',
+                'kr-startup-fading',
+                'kr-startup-effect-ready',
+                'kr-startup-controls-ready',
+              )
+
+              document
+                .querySelectorAll('.kr-prehydrate-loader, .kr-startup-black-base')
+                .forEach((element) => element.remove())
+            }, FADE_MS)
+          }, WATCHDOG_MS)
         })()
       </script>
 

--- a/server/plugins/startup-loader-shell.ts
+++ b/server/plugins/startup-loader-shell.ts
@@ -65,52 +65,7 @@ export default defineNitroPlugin((nitroApp) => {
             </div>
           </div>
         </div>
-
-        <div class="kr-prehydrate-controls">
-          <span class="kr-prehydrate-controls__name">Startup animation</span>
-          <button
-            type="button"
-            class="kr-prehydrate-controls__button"
-            data-kr-startup-action="explore"
-          >
-            <span aria-hidden="true">✦</span>
-            <span>Pause &amp; explore</span>
-          </button>
-        </div>
       </div>
-
-      <script>
-        (() => {
-          const root = document.documentElement
-          if (!root.classList.contains('kr-full-startup')) return
-
-          root.classList.add('kr-startup-handoff')
-          const queue = window.__KR_STARTUP_ACTION_QUEUE__ || []
-          window.__KR_STARTUP_ACTION_QUEUE__ = queue
-
-          document.addEventListener('click', (event) => {
-            const source = event.target
-            if (!(source instanceof Element)) return
-            const control = source.closest('[data-kr-startup-action]')
-            if (!(control instanceof HTMLElement)) return
-
-            const action = control.dataset.krStartupAction
-            if (!action) return
-
-            event.preventDefault()
-            event.stopPropagation()
-
-            if (window.__KR_STARTUP_BRIDGE_READY__) {
-              window.dispatchEvent(
-                new CustomEvent('kr-startup-action', { detail: action }),
-              )
-              return
-            }
-
-            queue.push(action)
-          }, true)
-        })()
-      </script>
     `)
   })
 })

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -1,84 +1,83 @@
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 
-const [startupComponent, startupPlugin, startupShell] = await Promise.all([
+const [
+  startupComponent,
+  startupPlugin,
+  startupShell,
+  compositionShell,
+  loadingMessages,
+] = await Promise.all([
   readFile('components/screenfx/startup-animation.vue', 'utf8'),
   readFile('plugins/startup-composition.client.ts', 'utf8'),
   readFile('server/plugins/startup-loader-shell.ts', 'utf8'),
+  readFile('server/plugins/00-startup-composition-shell.ts', 'utf8'),
+  readFile('components/admin/loading-messages.vue', 'utf8'),
 ])
 
 assert.ok(
   startupComponent.includes('v-if="showControls"') &&
     startupComponent.includes('ref="controlsElement"'),
-  'Hydrated startup controls must render independently and expose a mounted element ref.',
+  'Hydrated startup controls must render from the real Vue component.',
 )
 
 assert.ok(
   startupComponent.includes("currentEffectLabel.value || 'Preparing animation…'"),
-  'The control tray must never present a blank animation-name slot.',
-)
-
-const handoffGuard = startupComponent.slice(
-  startupComponent.indexOf('async function syncControlsHandoff'),
-  startupComponent.indexOf('function handleEffectReady'),
-)
-
-for (const requiredGuard of [
-  'showControls.value',
-  'resolvedEffectId.value',
-  'currentComponent.value',
-  'currentEffectLabel.value',
-  'controlsElement.value',
-  'markControlsReady()',
-]) {
-  assert.ok(
-    handoffGuard.includes(requiredGuard),
-    `Hydrated handoff is missing required readiness guard: ${requiredGuard}`,
-  )
-}
-
-assert.ok(
-  !/onMounted\([\s\S]*?markControlsReady\(\)/.test(startupComponent),
-  'Controls must not be declared ready merely because the component mounted.',
+  'The hydrated control tray must never present a blank animation name.',
 )
 
 assert.ok(
-  !/setTimeout\([\s\S]*?remove\(['"]kr-startup-handoff['"]\)/.test(
-    startupShell,
+  !startupShell.includes('kr-prehydrate-controls') &&
+    !startupShell.includes('data-kr-startup-action'),
+  'The server shell must not render a fake control panel that can become an untappable ghost.',
+)
+
+assert.ok(
+  compositionShell.includes('__KR_STARTUP_SHELL_WATCHDOG__') &&
+    compositionShell.includes('const WATCHDOG_MS = 9000'),
+  'The server-rendered startup cover must have a hydration-independent hard stop.',
+)
+
+assert.ok(
+  compositionShell.includes("sessionStorage.removeItem(FORCE_KEY)") &&
+    compositionShell.includes("sessionStorage.removeItem(STARTED_AT_KEY)"),
+  'The hard stop must clear sticky forced-startup session state.',
+)
+
+assert.ok(
+  compositionShell.includes(
+    "document.querySelector('.startup-animation__controls--active')",
   ),
-  'The server-rendered control must not disappear on an unconditional timer.',
+  'The shell hard stop may preserve startup only for a real active hydrated control panel.',
 )
 
 assert.ok(
-  startupComponent.includes('__KR_STARTUP_BRIDGE_READY__ = true') &&
-    startupComponent.includes('__KR_STARTUP_BRIDGE_READY__ = false'),
-  'The hydrated component must explicitly publish and clear bridge-listener readiness.',
+  loadingMessages.includes('const HARD_EXIT_MS = 9000') &&
+    loadingMessages.includes('startHardExitWatchdog()'),
+  'The hydrated loading overlay must have its own hard exit deadline.',
+)
+
+const exitRequestWatch = loadingMessages.slice(
+  loadingMessages.indexOf('() => startupStore.exitRequest'),
+  loadingMessages.indexOf('onMounted(async'),
 )
 
 assert.ok(
-  startupShell.includes('if (window.__KR_STARTUP_BRIDGE_READY__)'),
-  'Server control clicks must dispatch as soon as the Vue event bridge is listening.',
+  exitRequestWatch.includes('exitRequested.value = true') &&
+    exitRequestWatch.includes('doFade()'),
+  'Close and Resume requests must dismiss the overlay without waiting for stores or media.',
 )
 
 assert.ok(
-  !startupShell.includes(
-    "if (root.classList.contains('kr-startup-controls-ready'))",
-  ),
-  'Click dispatch must not wait for the visual control-panel handoff.',
+  compositionShell.includes('.loading-status') &&
+    compositionShell.includes('padding-bottom: 6rem !important'),
+  'Mobile startup layout must reserve space above the control tray for loading messages.',
 )
 
 assert.ok(
-  startupPlugin.includes(
-    'startupStore.immersive && hasUsableImmersiveControls()',
-  ),
-  'Immersive mode may suppress emergency exit only when hydrated controls are usable.',
+  startupPlugin.includes('clearShellWatchdog()') &&
+    startupPlugin.includes("delete startupWindow.__KR_STARTUP_SHELL_WATCHDOG__"),
+  'Normal client cleanup must cancel the server shell watchdog.',
 )
 
-assert.ok(
-  startupPlugin.includes(
-    "document.querySelector('.startup-animation__controls')",
-  ),
-  'The emergency guard must verify that the hydrated controls exist in the DOM.',
-)
-
-console.log('Startup handoff contract passed.')
+console.log('Startup hard-stop contract passed.')


### PR DESCRIPTION
## What changed

- removes the server-rendered **Pause & explore** panel so users never see an untappable control that only resembles the hydrated Vue panel
- keeps the real hydrated animation controls as the only interactive startup controls
- adds a nine-second hard exit inside the hydrated loading overlay, independent of store initialization and intro-media settlement
- adds a second nine-second server-shell watchdog that can clear the black cover even if Nuxt hydration stalls completely
- clears forced-startup session state when the raw-shell watchdog fires, preventing repeated black refresh loops
- makes Close and Resume dismiss immediately instead of waiting for stores to finish
- reserves mobile-safe vertical space between the loading message and bottom control tray
- updates the focused startup contract around this simpler hard-stop architecture

## Root cause

The production loader still had two different control panels. The server-rendered one could remain visible during hydration but was not the actual Vue control surface, creating the mobile hover/tap-with-no-action behavior. Separately, normal dismissal depended on both store initialization and the intro visual emitting `settled`; if either never completed, only the hydrated emergency timer could recover. When hydration itself stalled, the black server cover and forced-startup session key had no independent escape path.

## Expected behavior

- before hydration, startup is visual-only with no fake button
- after hydration, the real named Vue control panel is tappable
- normal startup cannot remain onscreen longer than nine seconds unless the user intentionally entered a real active animation-control mode
- a failed hydration cannot leave the site black indefinitely or poison subsequent refreshes
- mobile loading text stays above the control tray

## Validation

- final head: `f1a61672994dff7066758af93395702d5252c337`
- TypeScript Type Check passed
- full Contract Tests passed
- updated Startup Handoff Contract passed
- all focused GitHub Actions workflows passed
- final Vercel preview deployment `dpl_XS5Gx8CW4CWWLLnrNPQuxjUNd3QU` is READY from the final head
- preview root returned HTTP 200
- delivered Nuxt public build ID matches the final head
- delivered server HTML contains no prehydration control panel or click bridge
- delivered server HTML contains the hydration-independent nine-second watchdog, sticky-session cleanup, and mobile spacing rules

A literal mobile tap-through could not be automated from this environment. Source behavior, CI, the compiled deployment, and delivered HTML were verified.