### PR TITLE
Trace and eliminate the mobile startup race

### DIFF
--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -8,21 +8,33 @@ const HANDOFF_CLASS = 'kr-startup-handoff'
 const EFFECT_READY_CLASS = 'kr-startup-effect-ready'
 const CONTROLS_READY_CLASS = 'kr-startup-controls-ready'
 
-const EMERGENCY_EXIT_AT_MS = 6000
+const CLIENT_EMERGENCY_AFTER_MOUNT_MS = 9000
 const FADE_CLEANUP_MS = 700
 
 type StartupCompositionWindow = Window & {
-  __KR_STARTUP_SHELL_WATCHDOG__?: number
+  __KR_STARTUP_TRACE__?: (name: string, detail?: unknown) => void
+  __KR_STARTUP_TRACE_FLUSH__?: (reason: string) => void
+  __KR_STARTUP_USER_EXPLORE__?: boolean
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
   const root = document.documentElement
   const butterflyStore = useButterflyStore()
   const startupStore = useStartupAnimationStore()
+  const startupWindow = window as StartupCompositionWindow
 
   let sawLoader = false
+  let appMounted = false
   let cleanupTimer: number | null = null
   let emergencyExitTimer: number | null = null
+
+  function trace(name: string, detail?: unknown): void {
+    startupWindow.__KR_STARTUP_TRACE__?.(name, detail)
+  }
+
+  function flush(reason: string): void {
+    startupWindow.__KR_STARTUP_TRACE_FLUSH__?.(reason)
+  }
 
   function clearCleanupTimer(): void {
     if (cleanupTimer === null) return
@@ -36,19 +48,19 @@ export default defineNuxtPlugin((nuxtApp) => {
     emergencyExitTimer = null
   }
 
-  function clearShellWatchdog(): void {
-    const startupWindow = window as StartupCompositionWindow
-    const watchdog = startupWindow.__KR_STARTUP_SHELL_WATCHDOG__
-    if (typeof watchdog !== 'number') return
-
-    window.clearTimeout(watchdog)
-    delete startupWindow.__KR_STARTUP_SHELL_WATCHDOG__
-  }
-
-  function beginFade(): void {
+  function beginFade(reason: string): void {
     const startupActive =
       root.classList.contains(ACTIVE_CLASS) ||
       root.classList.contains(COVER_CLASS)
+
+    trace('client:begin-fade', {
+      reason,
+      startupActive,
+      appMounted,
+      immersive: startupStore.immersive,
+      controlsActive: startupStore.controlsActive,
+      showSwarm: butterflyStore.showSwarm,
+    })
 
     if (!startupActive) return
 
@@ -57,11 +69,19 @@ export default defineNuxtPlugin((nuxtApp) => {
     butterflyStore.setShowSwarm(false)
   }
 
-  function cleanup(): void {
+  function removeStartupNodes(): void {
+    document
+      .querySelectorAll(
+        '.kr-prehydrate-loader, .kr-startup-black-base, .loading-overlay, .loader-root',
+      )
+      .forEach((element) => element.remove())
+  }
+
+  function cleanup(reason: string): void {
     clearCleanupTimer()
     clearEmergencyExitTimer()
-    clearShellWatchdog()
     butterflyStore.setShowSwarm(false)
+    startupWindow.__KR_STARTUP_USER_EXPLORE__ = false
     root.classList.remove(
       ACTIVE_CLASS,
       FADING_CLASS,
@@ -70,31 +90,36 @@ export default defineNuxtPlugin((nuxtApp) => {
       EFFECT_READY_CLASS,
       CONTROLS_READY_CLASS,
     )
+    removeStartupNodes()
+    trace('client:cleanup', { reason })
+    flush('client-cleanup-' + reason)
   }
 
-  function scheduleCleanup(): void {
+  function scheduleCleanup(reason: string): void {
     if (cleanupTimer !== null) return
 
+    trace('client:schedule-cleanup', { reason })
     cleanupTimer = window.setTimeout(() => {
       cleanupTimer = null
-      cleanup()
-      observer.disconnect()
+      cleanup(reason)
     }, FADE_CLEANUP_MS)
   }
 
-  function hasUsableImmersiveControls(): boolean {
-    return (
-      root.classList.contains(CONTROLS_READY_CLASS) &&
-      Boolean(document.querySelector('.startup-animation__controls'))
-    )
+  function userDeliberatelyExploring(): boolean {
+    return startupWindow.__KR_STARTUP_USER_EXPLORE__ === true
   }
 
-  function requestEmergencyExit(): void {
-    if (startupStore.immersive && hasUsableImmersiveControls()) return
+  function requestEmergencyExit(reason: string): void {
+    if (userDeliberatelyExploring()) {
+      trace('client:emergency-preserved-user-explore', { reason })
+      flush('client-emergency-user-explore')
+      return
+    }
 
-    beginFade()
+    trace('client:emergency-fire', { reason })
+    beginFade(reason)
     startupStore.requestExit()
-    scheduleCleanup()
+    scheduleCleanup(reason)
   }
 
   function syncCompositionState(): void {
@@ -106,17 +131,23 @@ export default defineNuxtPlugin((nuxtApp) => {
     const overlay = document.querySelector('.loading-overlay')
 
     if (loader || overlay) {
+      if (!sawLoader) {
+        trace('client:loader-observed', {
+          loader: Boolean(loader),
+          overlay: Boolean(overlay),
+        })
+      }
       sawLoader = true
       clearCleanupTimer()
     }
 
     if (overlay?.classList.contains('loading-overlay--fade')) {
-      beginFade()
+      beginFade('overlay-class')
     }
 
     if (sawLoader && !loader && !overlay) {
-      beginFade()
-      scheduleCleanup()
+      beginFade('loader-removed')
+      scheduleCleanup('loader-removed')
     }
   }
 
@@ -129,14 +160,35 @@ export default defineNuxtPlugin((nuxtApp) => {
     attributeFilter: ['class'],
   })
 
+  trace('client:plugin-init', {
+    performanceNow: Math.round(performance.now()),
+    startupActive:
+      root.classList.contains(ACTIVE_CLASS) ||
+      root.classList.contains(COVER_CLASS),
+  })
   syncCompositionState()
 
-  const elapsedSinceNavigation = performance.now()
-  emergencyExitTimer = window.setTimeout(() => {
-    emergencyExitTimer = null
-    requestEmergencyExit()
-  }, Math.max(0, EMERGENCY_EXIT_AT_MS - elapsedSinceNavigation))
+  nuxtApp.hook('app:mounted', () => {
+    appMounted = true
+    trace('client:app-mounted')
+    syncCompositionState()
 
-  nuxtApp.hook('app:mounted', syncCompositionState)
-  window.addEventListener('pagehide', cleanup, { once: true })
+    clearEmergencyExitTimer()
+    emergencyExitTimer = window.setTimeout(() => {
+      emergencyExitTimer = null
+      requestEmergencyExit('client-post-mount-watchdog')
+    }, CLIENT_EMERGENCY_AFTER_MOUNT_MS)
+  })
+
+  window.addEventListener(
+    'pagehide',
+    () => {
+      trace('client:pagehide')
+      flush('client-pagehide')
+      clearCleanupTimer()
+      clearEmergencyExitTimer()
+      observer.disconnect()
+    },
+    { once: true },
+  )
 })

--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -151,6 +151,41 @@ export default defineNuxtPlugin((nuxtApp) => {
     }
   }
 
+  function handleStartupControlClick(event: Event): void {
+    const target = event.target
+    if (!(target instanceof Element)) return
+
+    const button = target.closest<HTMLButtonElement>(
+      '.startup-animation__controls button',
+    )
+    if (!button) return
+
+    const description = [
+      button.getAttribute('title'),
+      button.getAttribute('aria-label'),
+      button.textContent,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+
+    if (description.includes('pause') || description.includes('explore')) {
+      startupWindow.__KR_STARTUP_USER_EXPLORE__ = true
+      trace('client:user-entered-explore')
+      flush('user-entered-explore')
+      return
+    }
+
+    if (
+      description.includes('resume') ||
+      description.includes('leave startup') ||
+      description.includes('close')
+    ) {
+      startupWindow.__KR_STARTUP_USER_EXPLORE__ = false
+      trace('client:user-left-explore')
+    }
+  }
+
   const observer = new MutationObserver(syncCompositionState)
 
   observer.observe(document.documentElement, {
@@ -159,6 +194,8 @@ export default defineNuxtPlugin((nuxtApp) => {
     attributes: true,
     attributeFilter: ['class'],
   })
+
+  document.addEventListener('click', handleStartupControlClick, true)
 
   trace('client:plugin-init', {
     performanceNow: Math.round(performance.now()),
@@ -188,6 +225,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       clearCleanupTimer()
       clearEmergencyExitTimer()
       observer.disconnect()
+      document.removeEventListener('click', handleStartupControlClick, true)
     },
     { once: true },
   )

--- a/server/api/startup/trace.post.ts
+++ b/server/api/startup/trace.post.ts
@@ -1,0 +1,81 @@
+type StartupTraceEvent = {
+  at?: number
+  name?: string
+  detail?: unknown
+  snapshot?: unknown
+}
+
+type StartupTraceBody = {
+  traceId?: string
+  buildId?: string
+  reason?: string
+  events?: StartupTraceEvent[]
+  snapshot?: unknown
+  userAgent?: string
+}
+
+const MAX_EVENTS = 80
+const MAX_TEXT_LENGTH = 240
+
+function clampText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  return value.slice(0, MAX_TEXT_LENGTH)
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (depth > 3) return '[depth-limited]'
+
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number'
+  ) {
+    return value
+  }
+
+  if (typeof value === 'string') return value.slice(0, MAX_TEXT_LENGTH)
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 24).map((entry) => sanitizeValue(entry, depth + 1))
+  }
+
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .slice(0, 32)
+        .map(([key, entry]) => [
+          key.slice(0, 80),
+          sanitizeValue(entry, depth + 1),
+        ]),
+    )
+  }
+
+  return String(value).slice(0, MAX_TEXT_LENGTH)
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<StartupTraceBody>(event)
+  const events = Array.isArray(body?.events)
+    ? body.events.slice(-MAX_EVENTS).map((entry) => ({
+        at: typeof entry.at === 'number' ? Math.round(entry.at) : undefined,
+        name: clampText(entry.name),
+        detail: sanitizeValue(entry.detail),
+        snapshot: sanitizeValue(entry.snapshot),
+      }))
+    : []
+
+  const payload = {
+    traceId: clampText(body?.traceId) ?? 'unknown',
+    buildId: clampText(body?.buildId),
+    reason: clampText(body?.reason),
+    eventCount: events.length,
+    events,
+    snapshot: sanitizeValue(body?.snapshot),
+    userAgent:
+      clampText(body?.userAgent) ?? clampText(getRequestHeader(event, 'user-agent')),
+  }
+
+  console.info(`[startup-trace] ${JSON.stringify(payload)}`)
+
+  return { ok: true }
+})

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -21,6 +21,8 @@ export default defineNitroPlugin((nitroApp) => {
 
         .startup-animation__controls {
           z-index: 2147483000 !important;
+          display: flex !important;
+          visibility: visible !important;
           isolation: isolate;
         }
 
@@ -128,13 +130,120 @@ export default defineNitroPlugin((nitroApp) => {
           const STARTED_AT_KEY = 'kind-robots-startup-started-at-v1'
           const WATCHDOG_MS = 9000
           const FADE_MS = 700
+          const traceState = {
+            traceId:
+              Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8),
+            events: [],
+            sentCount: 0,
+          }
+
+          const snapshot = () => ({
+            readyState: document.readyState,
+            visibility: document.visibilityState,
+            classes: Array.from(root.classList),
+            viewport: [window.innerWidth, window.innerHeight],
+            dom: {
+              prehydrate: Boolean(document.querySelector('.kr-prehydrate-loader')),
+              blackBase: Boolean(document.querySelector('.kr-startup-black-base')),
+              loaderRoot: Boolean(document.querySelector('.loader-root')),
+              overlay: Boolean(document.querySelector('.loading-overlay')),
+              overlayFading: Boolean(
+                document.querySelector('.loading-overlay--fade'),
+              ),
+              stage: Boolean(document.querySelector('.startup-animation__stage')),
+              controls: Boolean(
+                document.querySelector('.startup-animation__controls'),
+              ),
+              controlsActive: Boolean(
+                document.querySelector('.startup-animation__controls--active'),
+              ),
+            },
+            userExplore: window.__KR_STARTUP_USER_EXPLORE__ === true,
+          })
+
+          const record = (name, detail) => {
+            const entry = {
+              at: Math.round(performance.now()),
+              name,
+              detail: detail || null,
+              snapshot: snapshot(),
+            }
+            traceState.events.push(entry)
+            console.info('[startup-trace]', entry)
+          }
+
+          const flush = (reason) => {
+            const events = traceState.events.slice(traceState.sentCount)
+            if (!events.length) return
+            traceState.sentCount = traceState.events.length
+
+            fetch('/api/startup/trace', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                traceId: traceState.traceId,
+                buildId: window.__NUXT__?.config?.public?.buildId,
+                reason,
+                events,
+                snapshot: snapshot(),
+                userAgent: navigator.userAgent,
+              }),
+              keepalive: true,
+            }).catch(() => {})
+          }
+
+          window.__KR_STARTUP_TRACE__ = record
+          window.__KR_STARTUP_TRACE_FLUSH__ = flush
+          window.__KR_STARTUP_USER_EXPLORE__ = false
 
           root.classList.add('kr-startup-active', 'kr-startup-handoff')
+          record('shell:init')
+
+          ;[1500, 3500, 6000, 9000, 12000].forEach((delay) => {
+            window.setTimeout(() => {
+              record('shell:snapshot', { delay })
+              flush('snapshot-' + delay)
+            }, delay)
+          })
+
+          window.addEventListener(
+            'error',
+            (event) => {
+              record('window:error', {
+                message: event.message,
+                source: event.filename,
+                line: event.lineno,
+                column: event.colno,
+              })
+              flush('window-error')
+            },
+            true,
+          )
+
+          window.addEventListener('unhandledrejection', (event) => {
+            record('window:unhandledrejection', {
+              reason: String(event.reason),
+            })
+            flush('unhandled-rejection')
+          })
 
           window.__KR_STARTUP_SHELL_WATCHDOG__ = window.setTimeout(() => {
-            if (document.querySelector('.startup-animation__controls--active')) {
+            if (window.__KR_STARTUP_USER_EXPLORE__ === true) {
+              record('shell:watchdog-preserved-user-explore')
+              flush('watchdog-user-explore')
               return
             }
+
+            if (
+              !root.classList.contains('kr-full-startup') &&
+              !root.classList.contains('kr-startup-active')
+            ) {
+              record('shell:watchdog-already-cleared')
+              flush('watchdog-already-cleared')
+              return
+            }
+
+            record('shell:watchdog-fire')
 
             try {
               sessionStorage.removeItem(FORCE_KEY)
@@ -154,10 +263,19 @@ export default defineNitroPlugin((nitroApp) => {
               )
 
               document
-                .querySelectorAll('.kr-prehydrate-loader, .kr-startup-black-base')
+                .querySelectorAll(
+                  '.kr-prehydrate-loader, .kr-startup-black-base, .loading-overlay, .loader-root',
+                )
                 .forEach((element) => element.remove())
+
+              record('shell:watchdog-cleanup')
+              flush('watchdog-cleanup')
             }, FADE_MS)
           }, WATCHDOG_MS)
+
+          window.addEventListener('pagehide', () => flush('pagehide'), {
+            once: true,
+          })
         })()
       </script>
 

--- a/stores/startupAnimationStore.ts
+++ b/stores/startupAnimationStore.ts
@@ -31,7 +31,6 @@ export const useStartupAnimationStore = defineStore(
     function reset(): void {
       controlsActive.value = false
       immersive.value = false
-      exitRequest.value = 0
     }
 
     return {

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -7,12 +7,16 @@ const [
   startupShell,
   compositionShell,
   loadingMessages,
+  startupStore,
+  traceEndpoint,
 ] = await Promise.all([
   readFile('components/screenfx/startup-animation.vue', 'utf8'),
   readFile('plugins/startup-composition.client.ts', 'utf8'),
   readFile('server/plugins/startup-loader-shell.ts', 'utf8'),
   readFile('server/plugins/00-startup-composition-shell.ts', 'utf8'),
   readFile('components/admin/loading-messages.vue', 'utf8'),
+  readFile('stores/startupAnimationStore.ts', 'utf8'),
+  readFile('server/api/startup/trace.post.ts', 'utf8'),
 ])
 
 assert.ok(
@@ -45,10 +49,18 @@ assert.ok(
 )
 
 assert.ok(
-  compositionShell.includes(
-    "document.querySelector('.startup-animation__controls--active')",
-  ),
-  'The shell hard stop may preserve startup only for a real active hydrated control panel.',
+  compositionShell.includes('__KR_STARTUP_USER_EXPLORE__ === true') &&
+    !compositionShell.includes(
+      "if (document.querySelector('.startup-animation__controls--active'))",
+    ),
+  'Only an explicit user explore action may preserve startup; invisible DOM state must not suppress the hard stop.',
+)
+
+assert.ok(
+  compositionShell.includes("fetch('/api/startup/trace'") &&
+    compositionShell.includes("record('shell:snapshot'") &&
+    traceEndpoint.includes("console.info(`[startup-trace]"),
+  'Mobile startup must report structured lifecycle snapshots to production runtime logs.',
 )
 
 assert.ok(
@@ -75,9 +87,26 @@ assert.ok(
 )
 
 assert.ok(
-  startupPlugin.includes('clearShellWatchdog()') &&
-    startupPlugin.includes("delete startupWindow.__KR_STARTUP_SHELL_WATCHDOG__"),
-  'Normal client cleanup must cancel the server shell watchdog.',
+  startupPlugin.includes("nuxtApp.hook('app:mounted'") &&
+    startupPlugin.includes('CLIENT_EMERGENCY_AFTER_MOUNT_MS') &&
+    !startupPlugin.includes('EMERGENCY_EXIT_AT_MS - elapsedSinceNavigation'),
+  'The client emergency exit must start after mount instead of firing into unmounted listeners on slow devices.',
 )
 
-console.log('Startup hard-stop contract passed.')
+assert.ok(
+  startupPlugin.includes("'.kr-prehydrate-loader, .kr-startup-black-base, .loading-overlay, .loader-root'") &&
+    startupPlugin.includes('removeStartupNodes()'),
+  'Client cleanup must remove startup DOM nodes, not only CSS classes.',
+)
+
+const resetBody = startupStore.slice(
+  startupStore.indexOf('function reset()'),
+  startupStore.indexOf('return {'),
+)
+
+assert.ok(
+  !resetBody.includes('exitRequest.value = 0'),
+  'Startup remounts must not erase an already-issued exit request.',
+)
+
+console.log('Startup trace and hard-stop contract passed.')


### PR DESCRIPTION
## What changed

- adds an early server-shell startup trace that works before Nuxt hydration
- reports lifecycle snapshots to `/api/startup/trace` at 1.5s, 3.5s, 6s, 9s, and 12s
- records root classes plus loader, overlay, animation stage, and control-panel DOM state
- captures browser errors and unhandled promise rejections in the same trace
- removes the client emergency race that could fire immediately on slow mobile hydration before loader watchers mounted
- starts the client emergency timer only after `app:mounted`
- makes the shell watchdog independent instead of cancelling it from client cleanup
- allows watchdog suppression only after a real click in the visible animation controls
- removes actual startup DOM nodes during cleanup instead of only removing CSS classes
- preserves monotonic exit requests across component remounts
- updates the startup contract so it rejects the old invisible-DOM suppression behavior

## Root cause found in source

The client emergency delay was calculated as `6000 - performance.now()`. On slow mobile hydration, the plugin could load after six seconds and fire immediately before `kind-loader` and `loading-messages` had mounted their watchers. It then applied the fading class, hiding the future control panel, and issued an exit request that later component `reset()` calls could erase. The old contract additionally required the shell watchdog to trust an active-control DOM class and required normal client cleanup to cancel the independent shell watchdog.

## Expected behavior

- startup cannot loop indefinitely unless the user actually taps **Pause & explore**
- invisible or stale control DOM cannot suppress the hard stop
- the real hydrated control panel remains visible and interactive before exit
- any remaining mobile failure automatically reports enough state to identify the exact transition where it stopped

## Validation

- final head: `3c22bc44abe16823d46513d7b137ca8604217a4d`
- Startup Handoff Contract passed
- TypeScript Type Check passed
- full 88-step Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel preview deployment `dpl_4XhUWXdnW4wuw7udwWfEWQXrbE1T` is READY from the final head
- preview root returned HTTP 200
- delivered Nuxt public build ID matches the final head
- delivered HTML contains the pre-hydration trace bootstrap and 1.5s / 3.5s / 6s / 9s / 12s snapshot schedule
- delivered HTML contains the explicit-click-only explore preservation rule and unconditional nine-second cleanup
- delivered cleanup removes the real startup DOM nodes

A literal mobile tap-through could not be automated from this environment. Source behavior, CI, the compiled deployment, and delivered HTML were verified.