### PR TITLE
Make startup controls and exit independent of hydration

### DIFF
--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -32,6 +32,31 @@ export default defineNitroPlugin((nitroApp) => {
           touch-action: manipulation;
         }
 
+        .kr-prehydrate-controls__group {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.2rem;
+        }
+
+        .kr-prehydrate-controls__active-only {
+          display: none;
+        }
+
+        .kr-prehydrate-controls--active .kr-prehydrate-controls__active-only {
+          display: inline-flex;
+        }
+
+        .kr-prehydrate-controls--active .kr-prehydrate-controls__compact-only {
+          display: none;
+        }
+
+        .kr-prehydrate-controls__exit {
+          min-width: 1.65rem;
+          justify-content: center;
+          font-size: 1rem;
+          line-height: 1;
+        }
+
         .kr-prehydrate-media,
         .loading-logo {
           -webkit-mask-image: radial-gradient(
@@ -68,6 +93,7 @@ export default defineNitroPlugin((nitroApp) => {
         html.kr-startup-fading .loading-overlay,
         html.kr-startup-fading .kr-prehydrate-effect,
         html.kr-startup-fading .kr-prehydrate-content,
+        html.kr-startup-fading .kr-prehydrate-controls,
         html.kr-startup-fading .startup-animation__stage,
         html.kr-startup-fading .startup-animation__controls,
         html:has(.loading-overlay--fade) .startup-animation__stage,
@@ -75,6 +101,63 @@ export default defineNitroPlugin((nitroApp) => {
           opacity: 0 !important;
           transition: opacity 650ms ease !important;
           pointer-events: none !important;
+        }
+
+        /*
+         * This is intentionally CSS-driven. On the iPad failure the main JS
+         * thread stops servicing timers after hydration begins, while animated
+         * images and compositor animations continue. The startup cover must
+         * therefore become invisible without requiring another JS callback.
+         */
+        html.kr-full-startup .kr-startup-black-base,
+        html.kr-full-startup .kr-prehydrate-content,
+        html.kr-full-startup:not(.kr-startup-effect-ready) .kr-prehydrate-effect,
+        html.kr-full-startup:not(.kr-startup-controls-ready) .kr-prehydrate-controls,
+        html.kr-full-startup .kr-boot-curtain,
+        html.kr-full-startup .loading-overlay,
+        html.kr-full-startup .loader-root,
+        html.kr-full-startup .startup-animation__stage,
+        html.kr-full-startup .startup-animation__controls {
+          animation: kr-startup-css-hard-stop 700ms ease 8300ms forwards !important;
+        }
+
+        html.kr-full-startup,
+        html.kr-startup-handoff,
+        html.kr-full-startup .kr-shell.bg-black {
+          animation: kr-startup-css-root-release 1ms linear 9000ms forwards !important;
+        }
+
+        html.kr-startup-user-explore,
+        html.kr-startup-user-explore .kr-startup-black-base,
+        html.kr-startup-user-explore .kr-prehydrate-content,
+        html.kr-startup-user-explore .kr-prehydrate-effect,
+        html.kr-startup-user-explore .kr-prehydrate-controls,
+        html.kr-startup-user-explore .kr-boot-curtain,
+        html.kr-startup-user-explore .loading-overlay,
+        html.kr-startup-user-explore .loader-root,
+        html.kr-startup-user-explore .startup-animation__stage,
+        html.kr-startup-user-explore .startup-animation__controls,
+        html.kr-startup-user-explore .kr-shell.bg-black {
+          animation-play-state: paused !important;
+        }
+
+        @keyframes kr-startup-css-hard-stop {
+          from {
+            opacity: 1;
+            visibility: visible;
+          }
+
+          to {
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+          }
+        }
+
+        @keyframes kr-startup-css-root-release {
+          to {
+            background-color: transparent;
+          }
         }
 
         @media (max-width: 639px) {
@@ -105,6 +188,10 @@ export default defineNitroPlugin((nitroApp) => {
             max-width: calc(100vw - 1.5rem) !important;
             font-size: clamp(0.95rem, 4.5vw, 1.25rem) !important;
           }
+
+          .kr-prehydrate-controls__wide-label {
+            display: none;
+          }
         }
 
         @media (prefers-reduced-motion: reduce) {
@@ -112,6 +199,7 @@ export default defineNitroPlugin((nitroApp) => {
           html.kr-startup-fading .loading-overlay,
           html.kr-startup-fading .kr-prehydrate-effect,
           html.kr-startup-fading .kr-prehydrate-content,
+          html.kr-startup-fading .kr-prehydrate-controls,
           html.kr-startup-fading .startup-animation__stage,
           html.kr-startup-fading .startup-animation__controls,
           html:has(.loading-overlay--fade) .startup-animation__stage,
@@ -130,6 +218,7 @@ export default defineNitroPlugin((nitroApp) => {
           const STARTED_AT_KEY = 'kind-robots-startup-started-at-v1'
           const WATCHDOG_MS = 9000
           const FADE_MS = 700
+          const BRIDGE_EVENT = 'kr-startup-action'
           const traceState = {
             traceId:
               Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8),
@@ -145,6 +234,9 @@ export default defineNitroPlugin((nitroApp) => {
             dom: {
               prehydrate: Boolean(document.querySelector('.kr-prehydrate-loader')),
               blackBase: Boolean(document.querySelector('.kr-startup-black-base')),
+              prehydrateControls: Boolean(
+                document.querySelector('.kr-prehydrate-controls'),
+              ),
               loaderRoot: Boolean(document.querySelector('.loader-root')),
               overlay: Boolean(document.querySelector('.loading-overlay')),
               overlayFading: Boolean(
@@ -192,12 +284,102 @@ export default defineNitroPlugin((nitroApp) => {
             }).catch(() => {})
           }
 
+          const removeStartupNodes = () => {
+            document
+              .querySelectorAll(
+                '.kr-prehydrate-loader, .kr-startup-black-base, .loading-overlay, .loader-root',
+              )
+              .forEach((element) => element.remove())
+          }
+
+          const clearStartupClasses = () => {
+            root.classList.remove(
+              'kr-full-startup',
+              'kr-startup-active',
+              'kr-startup-handoff',
+              'kr-startup-fading',
+              'kr-startup-effect-ready',
+              'kr-startup-controls-ready',
+              'kr-startup-user-explore',
+            )
+          }
+
+          const beginShellExit = (reason) => {
+            if (
+              !root.classList.contains('kr-full-startup') &&
+              !root.classList.contains('kr-startup-active')
+            ) {
+              return
+            }
+
+            window.__KR_STARTUP_USER_EXPLORE__ = false
+            root.classList.remove('kr-startup-user-explore')
+            root.classList.add('kr-startup-fading')
+            record('shell:begin-exit', { reason })
+
+            window.setTimeout(() => {
+              clearStartupClasses()
+              removeStartupNodes()
+              record('shell:exit-cleanup', { reason })
+              flush('shell-exit-' + reason)
+            }, FADE_MS)
+          }
+
+          const forwardBridgeAction = (action) => {
+            if (window.__KR_STARTUP_BRIDGE_READY__ === true) {
+              window.dispatchEvent(new CustomEvent(BRIDGE_EVENT, { detail: action }))
+              return
+            }
+
+            const queue = window.__KR_STARTUP_ACTION_QUEUE__ || []
+            queue.push(action)
+            window.__KR_STARTUP_ACTION_QUEUE__ = queue
+          }
+
+          const setExploreMode = (enabled) => {
+            window.__KR_STARTUP_USER_EXPLORE__ = enabled
+            root.classList.toggle('kr-startup-user-explore', enabled)
+            document
+              .querySelector('.kr-prehydrate-controls')
+              ?.classList.toggle('kr-prehydrate-controls--active', enabled)
+          }
+
           window.__KR_STARTUP_TRACE__ = record
           window.__KR_STARTUP_TRACE_FLUSH__ = flush
           window.__KR_STARTUP_USER_EXPLORE__ = false
+          window.__KR_STARTUP_ACTION_QUEUE__ =
+            window.__KR_STARTUP_ACTION_QUEUE__ || []
 
           root.classList.add('kr-startup-active', 'kr-startup-handoff')
           record('shell:init')
+
+          document.addEventListener(
+            'click',
+            (event) => {
+              const target = event.target
+              if (!(target instanceof Element)) return
+
+              const button = target.closest('[data-kr-startup-action]')
+              if (!button) return
+
+              const action = button.getAttribute('data-kr-startup-action')
+              if (!action) return
+
+              record('shell:control-action', { action })
+
+              if (action === 'explore') {
+                setExploreMode(true)
+              } else if (action === 'resume') {
+                setExploreMode(false)
+              } else if (action === 'exit') {
+                beginShellExit('control-exit')
+              }
+
+              forwardBridgeAction(action)
+              flush('control-' + action)
+            },
+            true,
+          )
 
           ;[1500, 3500, 6000, 9000, 12000].forEach((delay) => {
             window.setTimeout(() => {
@@ -250,27 +432,7 @@ export default defineNitroPlugin((nitroApp) => {
               sessionStorage.removeItem(STARTED_AT_KEY)
             } catch {}
 
-            root.classList.add('kr-startup-fading')
-
-            window.setTimeout(() => {
-              root.classList.remove(
-                'kr-full-startup',
-                'kr-startup-active',
-                'kr-startup-handoff',
-                'kr-startup-fading',
-                'kr-startup-effect-ready',
-                'kr-startup-controls-ready',
-              )
-
-              document
-                .querySelectorAll(
-                  '.kr-prehydrate-loader, .kr-startup-black-base, .loading-overlay, .loader-root',
-                )
-                .forEach((element) => element.remove())
-
-              record('shell:watchdog-cleanup')
-              flush('watchdog-cleanup')
-            }, FADE_MS)
+            beginShellExit('watchdog')
           }, WATCHDOG_MS)
 
           window.addEventListener('pagehide', () => flush('pagehide'), {

--- a/server/plugins/startup-loader-shell.ts
+++ b/server/plugins/startup-loader-shell.ts
@@ -65,6 +65,59 @@ export default defineNitroPlugin((nitroApp) => {
             </div>
           </div>
         </div>
+
+        <div
+          class="kr-prehydrate-controls"
+          role="group"
+          aria-label="Startup animation controls"
+        >
+          <span class="kr-prehydrate-controls__name">Launch 04</span>
+
+          <div class="kr-prehydrate-controls__group kr-prehydrate-controls__active-only">
+            <button
+              type="button"
+              class="kr-prehydrate-controls__button"
+              data-kr-startup-action="previous"
+              title="Previous animation"
+              aria-label="Previous animation"
+            >←</button>
+            <button
+              type="button"
+              class="kr-prehydrate-controls__button"
+              data-kr-startup-action="random"
+              title="Choose another random animation"
+            >✨ <span class="kr-prehydrate-controls__wide-label">Random</span></button>
+            <button
+              type="button"
+              class="kr-prehydrate-controls__button"
+              data-kr-startup-action="next"
+              title="Next animation"
+              aria-label="Next animation"
+            >→</button>
+          </div>
+
+          <button
+            type="button"
+            class="kr-prehydrate-controls__button kr-prehydrate-controls__compact-only"
+            data-kr-startup-action="explore"
+            title="Pause the launch and explore animations"
+          >✨ Pause &amp; explore</button>
+
+          <button
+            type="button"
+            class="kr-prehydrate-controls__button kr-prehydrate-controls__active-only"
+            data-kr-startup-action="resume"
+            title="Restore the launch screen and continue loading"
+          >Resume</button>
+
+          <button
+            type="button"
+            class="kr-prehydrate-controls__button kr-prehydrate-controls__exit"
+            data-kr-startup-action="exit"
+            title="Leave startup animation"
+            aria-label="Leave startup animation"
+          >×</button>
+        </div>
       </div>
     `)
   })

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -31,25 +31,47 @@ assert.ok(
 )
 
 assert.ok(
-  !startupShell.includes('kr-prehydrate-controls') &&
-    !startupShell.includes('data-kr-startup-action'),
-  'The server shell must not render a fake control panel that can become an untappable ghost.',
+  startupShell.includes('kr-prehydrate-controls') &&
+    startupShell.includes('data-kr-startup-action="explore"') &&
+    startupShell.includes('data-kr-startup-action="exit"'),
+  'The server shell must render visible controls before Vue hydration.',
+)
+
+assert.ok(
+  compositionShell.includes('__KR_STARTUP_ACTION_QUEUE__') &&
+    compositionShell.includes("const BRIDGE_EVENT = 'kr-startup-action'") &&
+    compositionShell.includes('forwardBridgeAction(action)'),
+  'Pre-hydration controls must bridge queued actions into the real Vue controls.',
 )
 
 assert.ok(
   compositionShell.includes('__KR_STARTUP_SHELL_WATCHDOG__') &&
     compositionShell.includes('const WATCHDOG_MS = 9000'),
-  'The server-rendered startup cover must have a hydration-independent hard stop.',
+  'The server-rendered startup cover must have a hydration-independent JS hard stop.',
+)
+
+assert.ok(
+  compositionShell.includes('@keyframes kr-startup-css-hard-stop') &&
+    compositionShell.includes('8300ms forwards !important') &&
+    compositionShell.includes('@keyframes kr-startup-css-root-release'),
+  'The startup cover must also release through CSS when the main JS thread is blocked.',
+)
+
+assert.ok(
+  compositionShell.includes('.kr-boot-curtain') &&
+    compositionShell.includes('.kr-shell.bg-black'),
+  'The compositor hard stop must release both the boot curtain and black app shell.',
 )
 
 assert.ok(
   compositionShell.includes("sessionStorage.removeItem(FORCE_KEY)") &&
     compositionShell.includes("sessionStorage.removeItem(STARTED_AT_KEY)"),
-  'The hard stop must clear sticky forced-startup session state.',
+  'The JS hard stop must clear sticky forced-startup session state.',
 )
 
 assert.ok(
   compositionShell.includes('__KR_STARTUP_USER_EXPLORE__ === true') &&
+    compositionShell.includes('kr-startup-user-explore') &&
     !compositionShell.includes(
       "if (document.querySelector('.startup-animation__controls--active'))",
     ),
@@ -59,8 +81,9 @@ assert.ok(
 assert.ok(
   compositionShell.includes("fetch('/api/startup/trace'") &&
     compositionShell.includes("record('shell:snapshot'") &&
+    compositionShell.includes('prehydrateControls: Boolean') &&
     traceEndpoint.includes("console.info(`[startup-trace]"),
-  'Mobile startup must report structured lifecycle snapshots to production runtime logs.',
+  'Mobile startup must report structured lifecycle snapshots and server-control presence.',
 )
 
 assert.ok(
@@ -109,4 +132,4 @@ assert.ok(
   'Startup remounts must not erase an already-issued exit request.',
 )
 
-console.log('Startup trace and hard-stop contract passed.')
+console.log('Startup controls, telemetry, and hard-stop contract passed.')


### PR DESCRIPTION
## Evidence from the production iPad trace

Trace `ms8jfwxu-sle6ik` reached `document.readyState = complete`, but at both 1.5s and 3.5s had:

- pre-hydration shell present
- no `.loader-root`
- no hydrated overlay
- no Screen FX stage
- no hydrated controls

No 6s, 9s, or 12s timer reports arrived. The looping WebP continued, which indicates the browser compositor remained active while the main JS thread stopped servicing timers during startup hydration/import work.

The source also had styles for `.kr-prehydrate-controls`, plus a Vue action-queue consumer, but no server-rendered controls and no producer for that queue.

## Changes

- render the startup label and control tray in the server shell before hydration
- include Previous, Random, Next, Pause & explore, Resume, and Exit actions
- queue those actions and forward them to the existing Vue startup-control bridge when it mounts
- make Exit work directly from the server shell
- add a compositor-driven CSS hard stop at nine seconds
- release every startup layer, including the boot curtain and black app shell, without requiring JavaScript timers
- pause the CSS deadline only after an explicit Pause & explore click
- extend startup telemetry with pre-hydration-control presence
- update the startup contract to require this non-JS fallback

## Expected result

Even if the iPad main thread wedges at the same point:

1. the animation name and controls are visible immediately;
2. the startup cover fades away by nine seconds through CSS;
3. the page is revealed without depending on Vue mounting or a JS watchdog;
4. if Vue recovers, queued control actions hand off to the real Screen FX component.

## Validation

- final head: `a2fb1bf02976056a746bad3ec727af3a4947e62f`
- Startup Handoff Contract passed
- TypeScript Type Check passed
- full Contract Tests passed
- all focused GitHub Actions workflows passed
- final Vercel preview deployment `dpl_7F5apKmy1pWAMMMAryNfgrjAdZRf` is READY from the final head
- preview root returned HTTP 200
- delivered Nuxt public build ID matches the final head
- delivered HTML contains the real pre-hydration label and control tray
- delivered HTML contains Previous, Random, Next, Pause & explore, Resume, and Exit controls
- delivered HTML contains the control action queue/bridge
- delivered HTML contains the compositor-driven 8.3s fade and 9s root/background release
- delivered CSS releases the preloader, boot curtain, hydrated loader, Screen FX stage, controls, and black app shell without requiring a JavaScript timer

A literal reproduction of Safari's blocked-main-thread condition could not be automated here. The production trace identified that condition; source behavior, CI, compiled deployment, and delivered HTML were verified.