### PR TITLE
fix(startup): make the intro fade on time instead of on readiness

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -513,10 +513,16 @@ onMounted(async () => {
   mdMedia.addEventListener('change', syncBreakpoints)
   xlMedia.addEventListener('change', syncBreakpoints)
 
+  /*
+   * Last-resort only. The intro fades on its own by ~5.7s worst case
+   * (loading-messages.vue: INTRO_MAX_MS + the 650ms fade), so this must sit
+   * well clear of that — at 8s it used to rip the loader out mid-sequence and
+   * pre-empt the graceful fade on every slow load.
+   */
   failsafeTimeoutId = setTimeout(() => {
     showLoader.value = false
     failsafeTimeoutId = null
-  }, 8000)
+  }, 9000)
 })
 
 onBeforeUnmount(() => {

--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 // /components/content/story/kind-loader.vue
-import { onBeforeMount, onMounted, ref, watch } from 'vue'
+import { onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useErrorStore, ErrorType } from '@/stores/errorStore'
 import { useUserStore } from '@/stores/userStore'
 import { useArtStore } from '@/stores/artStore'
@@ -291,6 +291,16 @@ onBeforeMount(() => {
 onMounted(() => {
   if (startupMode.value !== 'full') return
   void ensureStoresInitialized()
+})
+
+/*
+ * If anything unmounts the loader before it finished fading (an app-level
+ * failsafe, a route teardown), the swarm flag would otherwise stay true and
+ * leave the startup effect stage and control tray stranded on top of the site
+ * with nothing left alive to remove them.
+ */
+onBeforeUnmount(() => {
+  handleOverlayHiding()
 })
 </script>
 

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -12,7 +12,7 @@
       <div class="loading-heading">Building Kind Robots...</div>
 
       <div class="loading-logo-frame">
-        <startup-intro-visual @settled="handleIntroVisualSettled" />
+        <startup-intro-visual />
       </div>
 
       <div class="loading-status">
@@ -53,43 +53,37 @@ const startupStore = useStartupAnimationStore()
 const currentMessage = ref('Wiring robots for suspicious levels of charm...')
 const messageKey = ref(0)
 const fadeOverlay = ref(false)
-const minimumSequenceComplete = ref(false)
-const introVisualSettled = ref(false)
-const introVisualKind = ref<'logo' | 'animation'>('logo')
 const hiddenEmitted = ref(false)
-const exitRequested = ref(false)
 
-const EXTRA_MESSAGE_COUNT = 2
-const EXTRA_MESSAGE_MS = 1250
-const ROTATING_MESSAGE_MS = 1600
-const READY_HOLD_MS = 450
-const ANIMATION_VISIBLE_HOLD_MS = 1500
-const MIN_TOTAL_MS =
-  (EXTRA_MESSAGE_COUNT + 1) * EXTRA_MESSAGE_MS + READY_HOLD_MS
+/*
+ * The intro is TIME-driven, never readiness-driven.
+ *
+ * It used to be gated on `storesReady` (≈25 sequential store initialize()
+ * calls, several of them network-bound with 10s timeouts of their own) and on
+ * the intro webp firing `load`. Both are unbounded, so on any slow or failing
+ * request the fade simply never ran and the only thing that ever cleared the
+ * launch screen was an emergency watchdog — a hard cut, not a fade.
+ *
+ * Now: fade at INTRO_BASE_MS once the stores are ready, and at INTRO_MAX_MS no
+ * matter what. Store readiness can only make the intro end *sooner*; it can
+ * never hold it open. Nothing else is allowed to gate the fade.
+ */
+const INTRO_BASE_MS = 3500
+const INTRO_MAX_MS = 5000
+const ROTATING_MESSAGE_MS = 1250
 const OVERLAY_FADE_MS = 650
-const HARD_EXIT_MS = 9000
 
-const startTime = consumeStartupStartedAt()
+const FADING_CLASS = 'kr-startup-fading'
 
 let destroyed = false
+let sequenceStartedAt = 0
 let rotationIntervalId: ReturnType<typeof setInterval> | null = null
 let fallbackFadeTimeoutId: ReturnType<typeof setTimeout> | null = null
-let readyHoldTimeoutId: ReturnType<typeof setTimeout> | null = null
-let hardExitTimeoutId: ReturnType<typeof setTimeout> | null = null
+let baseFadeTimeoutId: ReturnType<typeof setTimeout> | null = null
+let capFadeTimeoutId: ReturnType<typeof setTimeout> | null = null
 
-function wait(ms: number) {
-  return new Promise<void>((resolve) => {
-    if (destroyed) {
-      resolve()
-      return
-    }
-
-    setTimeout(resolve, ms)
-  })
-}
-
-function waitUntil(offsetMs: number) {
-  return wait(Math.max(0, startTime + offsetMs - Date.now()))
+function elapsed(): number {
+  return performance.now() - sequenceStartedAt
 }
 
 function nextMessage() {
@@ -105,16 +99,16 @@ function clearRotation() {
   rotationIntervalId = null
 }
 
-function clearReadyHold() {
-  if (!readyHoldTimeoutId) return
-  clearTimeout(readyHoldTimeoutId)
-  readyHoldTimeoutId = null
-}
+function clearFadeTimers() {
+  if (baseFadeTimeoutId) {
+    clearTimeout(baseFadeTimeoutId)
+    baseFadeTimeoutId = null
+  }
 
-function clearHardExit() {
-  if (!hardExitTimeoutId) return
-  clearTimeout(hardExitTimeoutId)
-  hardExitTimeoutId = null
+  if (capFadeTimeoutId) {
+    clearTimeout(capFadeTimeoutId)
+    capFadeTimeoutId = null
+  }
 }
 
 function emitHiddenOnce() {
@@ -127,11 +121,20 @@ function doFade() {
   if (destroyed || fadeOverlay.value) return
 
   clearRotation()
-  clearReadyHold()
-  clearHardExit()
+  clearFadeTimers()
   loadStore.revealDesktop()
   emit('hiding')
   fadeOverlay.value = true
+
+  /*
+   * Drive every startup surface off one class change so the webp, the loading
+   * messages, the animated background, the black base and the control tray all
+   * fade on the same 650ms curve instead of relying on the client plugin's
+   * MutationObserver noticing us first.
+   */
+  if (import.meta.client) {
+    document.documentElement.classList.add(FADING_CLASS)
+  }
 
   if (fallbackFadeTimeoutId) {
     clearTimeout(fallbackFadeTimeoutId)
@@ -142,56 +145,31 @@ function doFade() {
   }, OVERLAY_FADE_MS + 120)
 }
 
-function scheduleFade() {
-  if (!props.storesReady) return
-  if (!minimumSequenceComplete.value) return
-  if (!introVisualSettled.value) return
-  if (fadeOverlay.value) return
+/*
+ * Arms both deadlines against time already served, so this stays correct if it
+ * is ever re-armed rather than restarting the intro from zero.
+ */
+function armFadeTimers() {
+  clearFadeTimers()
+
+  if (destroyed || fadeOverlay.value) return
   if (startupStore.immersive) return
-  if (readyHoldTimeoutId) return
 
-  clearRotation()
-
-  const elapsed = Date.now() - startTime
-  const minimumRemaining = Math.max(READY_HOLD_MS, MIN_TOTAL_MS - elapsed)
-  const animationVisibleRemaining = Math.max(
-    0,
-    ANIMATION_VISIBLE_HOLD_MS - elapsed,
+  baseFadeTimeoutId = setTimeout(
+    () => {
+      baseFadeTimeoutId = null
+      if (props.storesReady) doFade()
+    },
+    Math.max(0, INTRO_BASE_MS - elapsed()),
   )
-  const holdNeeded = exitRequested.value
-    ? 0
-    : Math.max(
-        minimumRemaining,
-        introVisualKind.value === 'animation' ? animationVisibleRemaining : 0,
-      )
 
-  readyHoldTimeoutId = setTimeout(() => {
-    doFade()
-  }, holdNeeded)
-}
-
-function startHardExitWatchdog() {
-  const remaining = Math.max(0, startTime + HARD_EXIT_MS - Date.now())
-
-  hardExitTimeoutId = setTimeout(() => {
-    hardExitTimeoutId = null
-
-    if (
-      startupStore.controlsActive &&
-      document.querySelector('.startup-animation__controls--active')
-    ) {
-      return
-    }
-
-    exitRequested.value = true
-    doFade()
-  }, remaining)
-}
-
-function handleIntroVisualSettled(kind: 'logo' | 'animation') {
-  introVisualKind.value = kind
-  introVisualSettled.value = true
-  scheduleFade()
+  capFadeTimeoutId = setTimeout(
+    () => {
+      capFadeTimeoutId = null
+      doFade()
+    },
+    Math.max(0, INTRO_MAX_MS - elapsed()),
+  )
 }
 
 function handleTransitionEnd(event: TransitionEvent) {
@@ -200,72 +178,62 @@ function handleTransitionEnd(event: TransitionEvent) {
   emitHiddenOnce()
 }
 
-async function runVisualSequence() {
-  for (let index = 0; index < EXTRA_MESSAGE_COUNT; index += 1) {
-    await waitUntil((index + 1) * EXTRA_MESSAGE_MS)
-    if (destroyed) return
-    nextMessage()
-  }
-
-  minimumSequenceComplete.value = true
-
-  if (props.storesReady && introVisualSettled.value) {
-    scheduleFade()
-    return
-  }
-
-  rotationIntervalId = setInterval(() => {
-    if (destroyed) return
-    nextMessage()
-    if (props.storesReady && introVisualSettled.value) scheduleFade()
-  }, ROTATING_MESSAGE_MS)
-}
-
+// Stores becoming ready can only pull the fade in, never push it out.
 watch(
   () => props.storesReady,
   (ready) => {
-    if (!ready) return
-
-    if (exitRequested.value) {
-      doFade()
-      return
-    }
-
-    scheduleFade()
+    if (!ready || startupStore.immersive) return
+    if (elapsed() >= INTRO_BASE_MS) doFade()
   },
 )
 
+/*
+ * Explore mode holds the launch screen open for as long as the user wants.
+ * Leaving it fades immediately — per spec, unpausing goes straight to the site
+ * rather than resuming the remainder of the intro.
+ */
 watch(
   () => startupStore.immersive,
   (immersive) => {
     if (immersive) {
-      clearReadyHold()
+      clearFadeTimers()
       return
     }
 
-    scheduleFade()
-  },
-)
-
-watch(
-  () => startupStore.exitRequest,
-  () => {
-    exitRequested.value = true
     doFade()
   },
 )
 
-onMounted(async () => {
+// Resume and the close button both dismiss without waiting for anything.
+watch(
+  () => startupStore.exitRequest,
+  () => {
+    doFade()
+  },
+)
+
+onMounted(() => {
+  sequenceStartedAt = performance.now()
+
+  // Consumed purely to clear the sessionStorage handoff key; the intro no
+  // longer times itself from navigation start (performance.timeOrigin), which
+  // could already be seconds in the past by the time we mount.
+  consumeStartupStartedAt()
+
   emit('covered')
-  startHardExitWatchdog()
-  await runVisualSequence()
+
+  rotationIntervalId = setInterval(() => {
+    if (destroyed) return
+    nextMessage()
+  }, ROTATING_MESSAGE_MS)
+
+  armFadeTimers()
 })
 
 onBeforeUnmount(() => {
   destroyed = true
   clearRotation()
-  clearReadyHold()
-  clearHardExit()
+  clearFadeTimers()
 
   if (fallbackFadeTimeoutId) {
     clearTimeout(fallbackFadeTimeoutId)

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -362,8 +362,11 @@ function fadeOut(): void {
   }, FADE_MS)
 }
 
-startupStore.reset()
-
+/*
+ * Deliberately does NOT reset the startup store here. kind-loader owns that
+ * lifecycle; resetting on this component's setup meant any remount silently
+ * dropped the user out of explore mode.
+ */
 watch(
   [() => butterflyStore.showSwarm, availableEffectIds],
   ([visible]) => {

--- a/plugins/startup-composition.client.ts
+++ b/plugins/startup-composition.client.ts
@@ -1,3 +1,4 @@
+import { watch } from 'vue'
 import { useButterflyStore } from '@/stores/butterflyStore'
 import { useStartupAnimationStore } from '@/stores/startupAnimationStore'
 
@@ -188,12 +189,37 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const observer = new MutationObserver(syncCompositionState)
 
+  /*
+   * Scoped deliberately. This previously observed the whole document with
+   * `subtree: true` for both childList and class attributes, so every class
+   * toggle anywhere in the app re-ran syncCompositionState (which does four
+   * querySelector calls) — thousands of callbacks during hydration, competing
+   * with the very timers and click handlers the startup sequence depends on.
+   *
+   * All the state we actually care about lives in exactly two places: the
+   * startup classes on <html>, and the loader nodes being added/removed as
+   * direct children of <body> / the app root.
+   */
   observer.observe(document.documentElement, {
-    subtree: true,
-    childList: true,
+    childList: false,
     attributes: true,
     attributeFilter: ['class'],
   })
+
+  /*
+   * Teardown is driven by the store rather than by watching the DOM for the
+   * loader nodes disappearing. showSwarm going false is the authoritative
+   * "startup is over" signal (kind-loader sets it in handleOverlayHiding and
+   * on unmount), so we no longer need a subtree childList observer to infer it.
+   */
+  watch(
+    () => butterflyStore.showSwarm,
+    (visible, wasVisible) => {
+      if (visible || !wasVisible) return
+      beginFade('swarm-cleared')
+      scheduleCleanup('swarm-cleared')
+    },
+  )
 
   document.addEventListener('click', handleStartupControlClick, true)
 

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -118,13 +118,13 @@ export default defineNitroPlugin((nitroApp) => {
         html.kr-full-startup .loader-root,
         html.kr-full-startup .startup-animation__stage,
         html.kr-full-startup .startup-animation__controls {
-          animation: kr-startup-css-hard-stop 700ms ease 8300ms forwards !important;
+          animation: kr-startup-css-hard-stop 700ms ease 11500ms forwards !important;
         }
 
         html.kr-full-startup,
         html.kr-startup-handoff,
         html.kr-full-startup .kr-shell.bg-black {
-          animation: kr-startup-css-root-release 1ms linear 9000ms forwards !important;
+          animation: kr-startup-css-root-release 1ms linear 12200ms forwards !important;
         }
 
         html.kr-startup-user-explore,
@@ -216,7 +216,14 @@ export default defineNitroPlugin((nitroApp) => {
 
           const FORCE_KEY = 'kind-robots-force-full-startup-v1'
           const STARTED_AT_KEY = 'kind-robots-startup-started-at-v1'
-          const WATCHDOG_MS = 9000
+          /*
+           * Emergency only. The hydrated intro fades itself by ~5.7s worst case
+           * (loading-messages.vue INTRO_MAX_MS + fade), so this deadline must
+           * stay clear of it. At 9000ms this watchdog was firing *before* the
+           * normal fade could ever run on a slow load and hard-cutting the
+           * launch screen instead — which read as "the fade never happens".
+           */
+          const WATCHDOG_MS = 12000
           const FADE_MS = 700
           const BRIDGE_EVENT = 'kr-startup-action'
           const traceState = {
@@ -325,8 +332,15 @@ export default defineNitroPlugin((nitroApp) => {
             }, FADE_MS)
           }
 
+          /*
+           * True only once the real Vue control tray has mounted and can take
+           * over. Until then these server-rendered controls are on their own
+           * and must be able to finish the sequence without it.
+           */
+          const bridgeAlive = () => window.__KR_STARTUP_BRIDGE_READY__ === true
+
           const forwardBridgeAction = (action) => {
-            if (window.__KR_STARTUP_BRIDGE_READY__ === true) {
+            if (bridgeAlive()) {
               window.dispatchEvent(new CustomEvent(BRIDGE_EVENT, { detail: action }))
               return
             }
@@ -371,6 +385,15 @@ export default defineNitroPlugin((nitroApp) => {
                 setExploreMode(true)
               } else if (action === 'resume') {
                 setExploreMode(false)
+                /*
+                 * Resume previously only forwarded to Vue. With no hydrated
+                 * component to receive it the launch screen simply stayed up —
+                 * and because 'explore' had already suppressed every watchdog,
+                 * that was unrecoverable: a control tray that visibly responds
+                 * to hover but whose buttons do nothing. Finish it here when
+                 * nothing else can.
+                 */
+                if (!bridgeAlive()) beginShellExit('control-resume')
               } else if (action === 'exit') {
                 beginShellExit('control-exit')
               }
@@ -410,7 +433,13 @@ export default defineNitroPlugin((nitroApp) => {
           })
 
           window.__KR_STARTUP_SHELL_WATCHDOG__ = window.setTimeout(() => {
-            if (window.__KR_STARTUP_USER_EXPLORE__ === true) {
+            /*
+             * Explore mode may only suppress the hard stop while the hydrated
+             * controls are actually alive to end it. Honouring the flag
+             * unconditionally meant one click on the pre-hydration tray
+             * disarmed the last exit from a page that never hydrated.
+             */
+            if (window.__KR_STARTUP_USER_EXPLORE__ === true && bridgeAlive()) {
               record('shell:watchdog-preserved-user-explore')
               flush('watchdog-user-explore')
               return

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -70,7 +70,10 @@ assert.ok(
  */
 const readNumber = (source, pattern, label) => {
   const match = source.match(pattern)
-  assert.ok(match, `Could not read ${label} — the startup timing contract moved.`)
+  if (!match) {
+    assert.fail(`Could not read ${label} — the startup timing contract moved.`)
+  }
+
   return Number(match[1])
 }
 

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -9,6 +9,7 @@ const [
   loadingMessages,
   startupStore,
   traceEndpoint,
+  appShell,
 ] = await Promise.all([
   readFile('components/screenfx/startup-animation.vue', 'utf8'),
   readFile('plugins/startup-composition.client.ts', 'utf8'),
@@ -17,6 +18,7 @@ const [
   readFile('components/admin/loading-messages.vue', 'utf8'),
   readFile('stores/startupAnimationStore.ts', 'utf8'),
   readFile('server/api/startup/trace.post.ts', 'utf8'),
+  readFile('app.vue', 'utf8'),
 ])
 
 assert.ok(
@@ -46,16 +48,72 @@ assert.ok(
 
 assert.ok(
   compositionShell.includes('__KR_STARTUP_SHELL_WATCHDOG__') &&
-    compositionShell.includes('const WATCHDOG_MS = 9000'),
+    /const WATCHDOG_MS = \d+/.test(compositionShell),
   'The server-rendered startup cover must have a hydration-independent JS hard stop.',
 )
 
 assert.ok(
   compositionShell.includes('@keyframes kr-startup-css-hard-stop') &&
-    compositionShell.includes('8300ms forwards !important') &&
+    /kr-startup-css-hard-stop \d+ms ease \d+ms forwards !important/.test(
+      compositionShell,
+    ) &&
     compositionShell.includes('@keyframes kr-startup-css-root-release'),
   'The startup cover must also release through CSS when the main JS thread is blocked.',
 )
+
+/*
+ * The regression this guards against: every emergency deadline must sit
+ * strictly after the graceful fade's worst case. When the shell watchdog was
+ * 9000ms and the intro could not fade until ~25 network-bound store
+ * initialisations settled, the watchdog always won — so the launch screen was
+ * only ever hard-cut and the fade genuinely never ran.
+ */
+const readNumber = (source, pattern, label) => {
+  const match = source.match(pattern)
+  assert.ok(match, `Could not read ${label} — the startup timing contract moved.`)
+  return Number(match[1])
+}
+
+const introMaxMs = readNumber(
+  loadingMessages,
+  /const INTRO_MAX_MS = (\d+)/,
+  'INTRO_MAX_MS',
+)
+const overlayFadeMs = readNumber(
+  loadingMessages,
+  /const OVERLAY_FADE_MS = (\d+)/,
+  'OVERLAY_FADE_MS',
+)
+const gracefulWorstCaseMs = introMaxMs + overlayFadeMs
+
+const shellWatchdogMs = readNumber(
+  compositionShell,
+  /const WATCHDOG_MS = (\d+)/,
+  'shell WATCHDOG_MS',
+)
+const cssHardStopMs = readNumber(
+  compositionShell,
+  /kr-startup-css-hard-stop \d+ms ease (\d+)ms forwards/,
+  'CSS hard-stop delay',
+)
+const appFailsafeMs = readNumber(
+  appShell,
+  /showLoader\.value = false\s*\n\s*failsafeTimeoutId = null\s*\n\s*\}, (\d+)\)/,
+  'app.vue loader failsafe',
+)
+
+for (const [label, deadline] of [
+  ['shell JS watchdog', shellWatchdogMs],
+  ['CSS hard stop', cssHardStopMs],
+  ['app.vue loader failsafe', appFailsafeMs],
+]) {
+  assert.ok(
+    deadline > gracefulWorstCaseMs,
+    `${label} (${deadline}ms) must fire after the graceful fade completes ` +
+      `(${gracefulWorstCaseMs}ms). An emergency exit that pre-empts the normal ` +
+      `fade turns every slow load into a hard cut.`,
+  )
+}
 
 assert.ok(
   compositionShell.includes('.kr-boot-curtain') &&
@@ -67,6 +125,26 @@ assert.ok(
   compositionShell.includes("sessionStorage.removeItem(FORCE_KEY)") &&
     compositionShell.includes("sessionStorage.removeItem(STARTED_AT_KEY)"),
   'The JS hard stop must clear sticky forced-startup session state.',
+)
+
+/*
+ * The pre-hydration control tray must be able to finish the sequence entirely
+ * on its own. It is the only tray on screen until Vue mounts, and on a page
+ * that never hydrates it was previously a trap: 'explore' disarmed every
+ * watchdog and 'resume' only forwarded to a component that never arrived, so
+ * the launch screen responded to hover and nothing else, forever.
+ */
+assert.ok(
+  compositionShell.includes('const bridgeAlive = ()') &&
+    compositionShell.includes("if (!bridgeAlive()) beginShellExit('control-resume')"),
+  'Resume on the pre-hydration controls must dismiss the launch screen itself ' +
+    'when the hydrated controls never arrive.',
+)
+
+assert.ok(
+  /__KR_STARTUP_USER_EXPLORE__ === true && bridgeAlive\(\)/.test(compositionShell),
+  'Explore mode may only suppress the hard stop while the hydrated controls ' +
+    'are alive to end it.',
 )
 
 assert.ok(
@@ -86,21 +164,48 @@ assert.ok(
   'Mobile startup must report structured lifecycle snapshots and server-control presence.',
 )
 
+/*
+ * The intro must be time-driven. Store readiness and media load events may pull
+ * the fade in, never hold it open — that gating is what broke the sequence.
+ */
 assert.ok(
-  loadingMessages.includes('const HARD_EXIT_MS = 9000') &&
-    loadingMessages.includes('startHardExitWatchdog()'),
-  'The hydrated loading overlay must have its own hard exit deadline.',
+  loadingMessages.includes('capFadeTimeoutId = setTimeout(') &&
+    loadingMessages.includes('INTRO_MAX_MS - elapsed()'),
+  'The hydrated loading overlay must fade on an unconditional time cap.',
+)
+
+assert.ok(
+  !/if \(!props\.storesReady\) return/.test(loadingMessages) &&
+    !/if \(!introVisualSettled\.value\) return/.test(loadingMessages),
+  'The fade must not be gated on store readiness or the intro image loading; ' +
+    'both are unbounded and can never be allowed to block the sequence.',
+)
+
+assert.ok(
+  loadingMessages.includes("classList.add(FADING_CLASS)"),
+  'Fading must set the root startup class so every startup surface fades together.',
 )
 
 const exitRequestWatch = loadingMessages.slice(
   loadingMessages.indexOf('() => startupStore.exitRequest'),
-  loadingMessages.indexOf('onMounted(async'),
+  loadingMessages.indexOf('onMounted('),
 )
 
 assert.ok(
-  exitRequestWatch.includes('exitRequested.value = true') &&
-    exitRequestWatch.includes('doFade()'),
+  exitRequestWatch.includes('doFade()'),
   'Close and Resume requests must dismiss the overlay without waiting for stores or media.',
+)
+
+const immersiveWatch = loadingMessages.slice(
+  loadingMessages.indexOf('() => startupStore.immersive'),
+  loadingMessages.indexOf('() => startupStore.exitRequest'),
+)
+
+assert.ok(
+  immersiveWatch.includes('clearFadeTimers()') &&
+    immersiveWatch.includes('doFade()'),
+  'Explore mode must hold the launch screen open indefinitely, and leaving it ' +
+    'must fade straight into the site.',
 )
 
 assert.ok(


### PR DESCRIPTION
## The problem

The launch sequence never reached its fade. Reproduced in a real browser rather than inferred — the trace is decisive:

```
shell:init        12971ms
shell:snapshot    14479ms / 16479ms / 18981ms / 21979ms
shell:watchdog-fire 24983ms      ← the ONLY thing that ended it
[error] [facet-catalog] Canonical Facet hydration failed. Error: Request timed out after 10000ms
```

No fade event of any kind. The 9-second emergency watchdog was doing all the work, and it hard-cuts rather than fades. That is why adding more timer safeguards kept making it worse: the safeguards *were* the mechanism.

Two independent causes, both confirmed against a running app.

### 1. The fade was gated on work with no time bound

`scheduleFade()` required `storesReady` — ~25 sequential store `initialize()` calls, several network-bound (the facet catalog alone carries a 10s timeout) — **and** the intro webp firing `load` from the external media origin, with no timeout of its own. Either one stalling blocked the fade forever, and both reliably outlast the watchdog, so the watchdog always won the race.

### 2. The pre-hydration control tray was a trap on a page that never hydrates

`Pause & explore` set `__KR_STARTUP_USER_EXPLORE__`, which unconditionally disarmed *every* watchdog. `Resume` only forwarded the action to a Vue component that had not mounted. Hover is pure CSS so it kept responding; the buttons did nothing and the last exit was already disarmed — permanently stuck.

A/B verified against a non-hydrating page (`bridge: false`):

| | Resume clicked |
|---|---|
| before | `shell:control-action {"action":"resume"}`, then nothing — startup UI still up |
| after | `shell:begin-exit {"reason":"control-resume"}` → `shell:exit-cleanup` → cleared |

## The change

The intro is now **time-driven**. Fade at `INTRO_BASE_MS` (3.5s) once stores are ready, at `INTRO_MAX_MS` (5s) regardless. Readiness can only pull the fade in, never hold it open. `doFade()` sets `kr-startup-fading` directly so the webp, messages, animated background, black base and control tray all fade on one 650ms curve — genuinely simultaneous, rather than waiting for the client plugin's MutationObserver to notice.

Every emergency deadline now sits clear of that worst case, so they are last resorts again instead of the primary path:

| deadline | before | after |
|---|---|---|
| shell JS watchdog | 9000ms | 12000ms |
| CSS hard stop | 8300ms | 11500ms |
| `app.vue` loader failsafe | 8000ms | 9000ms |

`app.vue`'s failsafe was also unmounting the loader mid-sequence, stranding the effect stage and control tray on top of the site with nothing left alive to remove them; `kind-loader` now tears down on unmount.

Explore mode may only suppress the hard stop while the hydrated bridge is alive to end it, and Resume finishes the sequence itself when the bridge never arrives.

Also in scope:
- Narrowed the startup `MutationObserver`, which watched the entire document for every class change and re-ran four `querySelector` calls per mutation during hydration. Teardown now keys off the store instead of DOM snooping.
- Removed a `startupStore.reset()` in `startup-animation.vue` setup that dropped the user out of explore mode on any remount.

Behaviour unchanged: browser refresh still skips the sequence; the dashboard refresh button still forces the full intro.

## Verification

- `node utils/scripts/verify-startup-handoff.mjs` — passes
- `npm run test` (vue-tsc) — 37 errors, all pre-existing on `main` and none in the changed files
- `npx eslint` on changed files — 1 error + 1 warning, both pre-existing on `main` (confirmed via `git stash`)
- `prettier --check` — the same 5 files fail on `main`; left alone rather than inflating the diff
- Browser A/B of the explore/resume trap, above

The contract test previously asserted only that source files *contained certain strings*, so it passed green throughout. It now asserts the invariants that were actually violated: no readiness gating of the fade, and every emergency deadline strictly after the graceful fade completes.

**Not verified end-to-end:** the happy-path Vue-side fade timing. The sandbox could not hydrate the client bundle (`ERR_CONNECTION_RESET` on `_nuxt` chunks), so that path is covered by code review and the contract test, not observation. The pre-hydration fix is observed.

**Unrelated, worth knowing:** `npm ci` fails on the current lockfile — out of sync with `package.json` (missing `cac`, `commander`). The regenerated lockfile was reverted to keep this diff clean, but it will bite CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9HNdfh9HAYppqpW51BQBH)_