### PR TITLE
fix duplicate Nuxt auto-imported type exports

### DIFF
--- a/stores/videoStore.ts
+++ b/stores/videoStore.ts
@@ -16,8 +16,6 @@ import type {
   VideoPresetId,
 } from '@/utils/videoPresets'
 
-export type { VideoEngine, VideoOutputFormat, VideoPresetId }
-
 export type VideoJobStatus = 'idle' | 'queued' | 'rendering' | 'done' | 'error'
 
 export interface GenerateVideoParams {

--- a/utils/artImageSrc.ts
+++ b/utils/artImageSrc.ts
@@ -6,7 +6,7 @@
 // written to a path. This keeps upload/save flows working while letting the API
 // stop shipping (and eventually storing) heavy base64 blobs for pathed art.
 
-export type ArtImageLike =
+export type ArtImageSrcLike =
   | {
       imagePath?: string | null
       path?: string | null
@@ -44,7 +44,7 @@ export function toArtDataUri(
 // Renderable source for a full-size ArtImage. Prefers imagePath / path; falls
 // back to inline base64 only when no path exists; then to `fallback`.
 export function resolveArtImageSrc(
-  image: ArtImageLike,
+  image: ArtImageSrcLike,
   fallback = '',
 ): string {
   const path = cleanValue(image?.imagePath) || cleanValue(image?.path)
@@ -55,7 +55,7 @@ export function resolveArtImageSrc(
 // Renderable source for a thumbnail. Prefers thumbnailPath, then the full-size
 // path, then inline thumbnail/full base64, then `fallback`.
 export function resolveArtImageThumbSrc(
-  image: ArtImageLike,
+  image: ArtImageSrcLike,
   fallback = '',
 ): string {
   const path =


### PR DESCRIPTION
## What changed

- Removed the redundant `VideoEngine`, `VideoOutputFormat`, and `VideoPresetId` re-exports from `stores/videoStore.ts`.
- Kept `utils/videoPresets.ts` as the single canonical export location for those video types.
- Renamed the path-first resolver type in `utils/artImageSrc.ts` from `ArtImageLike` to `ArtImageSrcLike` and updated its two internal consumers.
- Kept `utils/artImageSource.ts` as the canonical owner of its distinct diagnostic resolver's `ArtImageLike` type.

## Root cause

Nuxt scans exported symbols for auto-imports. The store re-exported three types already exported by `utils/videoPresets.ts`, while two separate art utilities exported different types under the same `ArtImageLike` name. Nuxt therefore had to ignore one definition from each duplicate pair and emitted warnings during startup.

## Impact

This removes the four duplicate-import warnings without changing runtime video generation or art source resolution behavior.

## Validation

- Audited the branch diff against `main`: only `stores/videoStore.ts` and `utils/artImageSrc.ts` changed.
- Confirmed the video change is a two-line deletion only.
- Confirmed the art change is a type-only rename at the declaration and its two function parameters.
- Local dependency-based checks were not available through the connector environment; CI should provide the full Nuxt/TypeScript validation.