### PR TITLE
fix(startup): stop async client plugins from blocking app mount

### DIFF
--- a/components/pages/sponsor-page.vue
+++ b/components/pages/sponsor-page.vue
@@ -131,8 +131,11 @@
 </template>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
-
+/*
+ * Poppins is loaded non-blockingly from nuxt.config's head script. See the note
+ * in login-page.vue: a remote `@import` in a component style block lands in the
+ * render-blocking global CSS and stalls app hydration behind fonts.googleapis.com.
+ */
 :root {
   --base-color: #ffcc00; /* Placeholder, replace with your actual color */
   --accent-color: #ff5733; /* Placeholder, replace with your actual accent color */

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -320,8 +320,14 @@ function handleRetryLogin(): void {
 </script>
 
 <style scoped>
-@import url('https://fonts.googleapis.com/css2?family=Syne:wght@800&display=swap');
-
+/*
+ * The Syne webfont is loaded non-blockingly from nuxt.config's head script.
+ * It used to be an `@import url(...)` here, which Vite hoists into the bundled
+ * global CSS — and a pending stylesheet blocks script execution, so this one
+ * login-page font gated hydration of the entire app on a third-party request.
+ * Anyone whose network blocks or slows fonts.googleapis.com never got a
+ * working site. Do not reintroduce a remote @import in component styles.
+ */
 .font-display {
   font-family: 'Syne', sans-serif;
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -72,6 +72,50 @@ const startupPrehydrateScript = `(() => {
   }
 })()`
 
+/*
+ * Webfonts must never be able to stall the app.
+ *
+ * These were CSS \`@import url(...)\` statements inside component <style> blocks
+ * (login-page.vue, sponsor-page.vue). Vite hoists those into the bundled global
+ * stylesheet, and a pending stylesheet blocks script execution — so hydration of
+ * the whole application waited on fonts.googleapis.com. Measured at 12.7s in one
+ * environment, and unbounded for anyone whose network blocks Google Fonts
+ * (ad/tracker blockers, DNS filtering, school and corporate networks). The
+ * symptom is total: the startup animation never fades and its controls never
+ * become interactive, because no Vue ever mounts to run them.
+ *
+ * media="print" makes the browser fetch the sheet without treating it as
+ * render-blocking; the onload handler promotes it once it has arrived. If it
+ * never arrives, the app is entirely unaffected.
+ */
+const asyncFontHrefs = [
+  'https://fonts.googleapis.com/css2?family=Syne:wght@800&display=swap',
+  'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap',
+]
+
+const asyncFontScript = `(() => {
+  const HREFS = ${JSON.stringify(asyncFontHrefs)}
+
+  // Deliberately deferred to the load event. Appending a stylesheet from a
+  // parser-inserted script — even with media="print" — makes it a pending
+  // stylesheet that blocks the parser and every script after it, which is the
+  // exact failure being fixed here (measured: the renderer stayed blocked for
+  // as long as fonts.googleapis.com hung). After load, nothing is left to block.
+  const addFontLinks = () => {
+    for (const href of HREFS) {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'
+      link.href = href
+      link.media = 'print'
+      link.addEventListener('load', () => { link.media = 'all' }, { once: true })
+      document.head.appendChild(link)
+    }
+  }
+
+  if (document.readyState === 'complete') addFontLinks()
+  else window.addEventListener('load', addFontLinks, { once: true })
+})()`
+
 generateWonderLabComponentMetadata()
 
 export default defineNuxtConfig({
@@ -81,6 +125,10 @@ export default defineNuxtConfig({
       script: [
         {
           innerHTML: startupPrehydrateScript,
+          tagPosition: 'head',
+        },
+        {
+          innerHTML: asyncFontScript,
           tagPosition: 'head',
         },
       ],

--- a/plugins/20.facet-catalog.client.ts
+++ b/plugins/20.facet-catalog.client.ts
@@ -101,7 +101,9 @@ function hydrateBotBuilder(
         step.choices = [...canonical, ...controls]
         step.listOptions = canonical.map((choice) => choice.value)
       } else {
-        const visualChoices = canonical.filter((choice) => Boolean(choice.image))
+        const visualChoices = canonical.filter((choice) =>
+          Boolean(choice.image),
+        )
         const listChoices = canonical.filter((choice) => !choice.image)
         const moreChoice: BuilderChoice[] = listChoices.length
           ? [
@@ -223,25 +225,38 @@ function hydrateSystemBuilder(
   }
 }
 
-export default defineNuxtPlugin(async () => {
+/*
+ * MUST NOT be an async plugin. Nuxt awaits the promise a plugin returns before
+ * it mounts the Vue app, so awaiting this catalog fetch here held the entire
+ * application hostage to one network round trip — up to its own 10s timeout,
+ * and indefinitely if the request never settled. Nothing rendered in that
+ * window: no loading overlay, no startup controls, no site.
+ *
+ * The Builders this hydrates are re-registered when the fetch resolves, so
+ * running it in the background is correct; callers already tolerate an
+ * unpopulated catalog (the `!catalog.entries.length` bail below predates this).
+ */
+export default defineNuxtPlugin(() => {
   const catalog = useFacetCatalogStore()
 
-  try {
-    await catalog.fetchCatalog({ includeMature: true, take: 1000 }, true)
-    if (!catalog.entries.length) return
+  void (async () => {
+    try {
+      await catalog.fetchCatalog({ includeMature: true, take: 1000 }, true)
+      if (!catalog.entries.length) return
 
-    hydrateAdventureBuilder(catalog)
-    hydrateScenarioBuilder(catalog)
-    hydrateBotBuilder(catalog)
-    hydrateArtBuilder(catalog)
-    hydrateSystemBuilder(DREAM_CARDS, catalog)
-    hydrateSystemBuilder(REWARD_CARDS, catalog)
+      hydrateAdventureBuilder(catalog)
+      hydrateScenarioBuilder(catalog)
+      hydrateBotBuilder(catalog)
+      hydrateArtBuilder(catalog)
+      hydrateSystemBuilder(DREAM_CARDS, catalog)
+      hydrateSystemBuilder(REWARD_CARDS, catalog)
 
-    // Registration stores the same mutable card graphs. Re-register after the
-    // async catalog fetch so mounted Builders observe canonical choices immediately.
-    // Generator methods read this same catalog directly and need no runtime patching.
-    ensureBuildersRegistered(true)
-  } catch (error) {
-    console.error('[facet-catalog] Canonical Facet hydration failed.', error)
-  }
+      // Registration stores the same mutable card graphs. Re-register after the
+      // async catalog fetch so mounted Builders observe canonical choices immediately.
+      // Generator methods read this same catalog directly and need no runtime patching.
+      ensureBuildersRegistered(true)
+    } catch (error) {
+      console.error('[facet-catalog] Canonical Facet hydration failed.', error)
+    }
+  })()
 })

--- a/plugins/legacy-guest-session.client.ts
+++ b/plugins/legacy-guest-session.client.ts
@@ -1,11 +1,19 @@
 import { useUserStore } from '@/stores/userStore'
 
-export default defineNuxtPlugin(async () => {
+/*
+ * Not async: a plugin's returned promise is awaited before the Vue app mounts,
+ * so awaiting userStore.initialize() here blocked first paint of the entire
+ * app on a network call. Retiring the legacy guest session is not urgent
+ * enough to hold the app hostage.
+ */
+export default defineNuxtPlugin(() => {
   const userStore = useUserStore()
 
-  await userStore.initialize()
+  void (async () => {
+    await userStore.initialize()
 
-  if (userStore.user?.id === 10) {
-    userStore.logout()
-  }
+    if (userStore.user?.id === 10) {
+      userStore.logout()
+    }
+  })()
 })

--- a/plugins/reconcile-server-cache.client.ts
+++ b/plugins/reconcile-server-cache.client.ts
@@ -17,51 +17,59 @@ type ServerListResponse = {
  * localStorage. Reconcile once during client bootstrap so API membership is
  * authoritative while matching cached fields remain available.
  */
-export default defineNuxtPlugin(async () => {
+/*
+ * Not async at the plugin level: Nuxt awaits a plugin's returned promise before
+ * mounting the Vue app, so awaiting /api/server here blocked the whole app on a
+ * network call. The reconcile is a cache-correctness pass, not a prerequisite
+ * for rendering, so it runs in the background.
+ */
+export default defineNuxtPlugin(() => {
   const serverStore = useServerStore()
 
   if (!serverStore.isInitialized) {
     serverStore.loadFromLocalStorage()
   }
 
-  const cachedIds = new Set(serverStore.servers.map((server) => server.id))
-  const response = (await performFetch('/api/server')) as ServerListResponse
+  void (async () => {
+    const cachedIds = new Set(serverStore.servers.map((server) => server.id))
+    const response = (await performFetch('/api/server')) as ServerListResponse
 
-  if (!response.success || !Array.isArray(response.data)) return
+    if (!response.success || !Array.isArray(response.data)) return
 
-  const nextServers = reconcileServerRows(serverStore.servers, response.data)
-  const liveIds = new Set(nextServers.map((server) => server.id))
-  const removedIds = [...cachedIds].filter((id) => !liveIds.has(id))
+    const nextServers = reconcileServerRows(serverStore.servers, response.data)
+    const liveIds = new Set(nextServers.map((server) => server.id))
+    const removedIds = [...cachedIds].filter((id) => !liveIds.has(id))
 
-  serverStore.servers.splice(0, serverStore.servers.length, ...nextServers)
+    serverStore.servers.splice(0, serverStore.servers.length, ...nextServers)
 
-  if (
-    serverStore.selectedServer &&
-    !liveIds.has(serverStore.selectedServer.id)
-  ) {
-    serverStore.selectedServer = null
-    serverStore.serverForm = {}
-  }
+    if (
+      serverStore.selectedServer &&
+      !liveIds.has(serverStore.selectedServer.id)
+    ) {
+      serverStore.selectedServer = null
+      serverStore.serverForm = {}
+    }
 
-  if (
-    typeof serverStore.activeArtServerId === 'number' &&
-    !liveIds.has(serverStore.activeArtServerId)
-  ) {
-    serverStore.activeArtServerId = null
-  }
+    if (
+      typeof serverStore.activeArtServerId === 'number' &&
+      !liveIds.has(serverStore.activeArtServerId)
+    ) {
+      serverStore.activeArtServerId = null
+    }
 
-  if (
-    typeof serverStore.activeTextServerId === 'number' &&
-    !liveIds.has(serverStore.activeTextServerId)
-  ) {
-    serverStore.activeTextServerId = null
-  }
+    if (
+      typeof serverStore.activeTextServerId === 'number' &&
+      !liveIds.has(serverStore.activeTextServerId)
+    ) {
+      serverStore.activeTextServerId = null
+    }
 
-  for (const id of removedIds) {
-    delete serverStore.healthResults[id]
-    serverStore.clearRuntimeReport(id)
-  }
+    for (const id of removedIds) {
+      delete serverStore.healthResults[id]
+      serverStore.clearRuntimeReport(id)
+    }
 
-  serverStore.hasLoaded = true
-  serverStore.syncToLocalStorage()
+    serverStore.hasLoaded = true
+    serverStore.syncToLocalStorage()
+  })()
 })

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -118,13 +118,13 @@ export default defineNitroPlugin((nitroApp) => {
         html.kr-full-startup .loader-root,
         html.kr-full-startup .startup-animation__stage,
         html.kr-full-startup .startup-animation__controls {
-          animation: kr-startup-css-hard-stop 700ms ease 11500ms forwards !important;
+          animation: kr-startup-css-hard-stop 700ms ease 8300ms forwards !important;
         }
 
         html.kr-full-startup,
         html.kr-startup-handoff,
         html.kr-full-startup .kr-shell.bg-black {
-          animation: kr-startup-css-root-release 1ms linear 12200ms forwards !important;
+          animation: kr-startup-css-root-release 1ms linear 9000ms forwards !important;
         }
 
         html.kr-startup-user-explore,
@@ -217,13 +217,14 @@ export default defineNitroPlugin((nitroApp) => {
           const FORCE_KEY = 'kind-robots-force-full-startup-v1'
           const STARTED_AT_KEY = 'kind-robots-startup-started-at-v1'
           /*
-           * Emergency only. The hydrated intro fades itself by ~5.7s worst case
-           * (loading-messages.vue INTRO_MAX_MS + fade), so this deadline must
-           * stay clear of it. At 9000ms this watchdog was firing *before* the
-           * normal fade could ever run on a slow load and hard-cutting the
-           * launch screen instead — which read as "the fade never happens".
+           * Emergency only, and deliberately NOT pushed further out. The
+           * hydrated intro fades itself by ~5.7s worst case (loading-messages.vue
+           * INTRO_MAX_MS + fade), so 9s already clears it. When hydration blocks
+           * the main thread this watchdog and the CSS hard stop are the only
+           * things that still work, so delaying them only lengthens the time a
+           * user stares at a frozen launch screen.
            */
-          const WATCHDOG_MS = 12000
+          const WATCHDOG_MS = 9000
           const FADE_MS = 700
           const BRIDGE_EVENT = 'kr-startup-action'
           const traceState = {


### PR DESCRIPTION
Follow-up to #1203, which did not fix the reported problem because it addressed the wrong layer.

## What was actually wrong

Measured against a real production build (`npm run build` + `.output/server`), not a dev server:

```
vueApp: false            ← no Vue instance on #__nuxt
__KR_STARTUP_BRIDGE_READY__: undefined
appRootLen: 18479        ← SSR itself was fine
```

**The Vue app never mounted.** With no Vue there is no `loading-messages`, so none of the fade timers from #1203 ever ran, and the only control tray on screen was the server-rendered one — whose buttons need a hydrated bridge to do anything.

That is precisely the reported symptom: the animation runs forever, and the control panel responds to **hover** (pure CSS, no JS) but not to **clicks** (needs a mounted handler).

### Cause

Nuxt awaits the promise a plugin returns before mounting the app. Three client plugins were `async` and awaited network calls:

| plugin | awaited |
|---|---|
| `20.facet-catalog.client.ts` | `fetchCatalog({ take: 1000 })` — carries its own 10s timeout |
| `legacy-guest-session.client.ts` | `userStore.initialize()` |
| `reconcile-server-cache.client.ts` | `performFetch('/api/server')` |

So the whole application was gated on those round trips, and indefinitely if any never settled. We had already seen `[facet-catalog] Canonical Facet hydration failed. Error: Request timed out after 10000ms` in the console.

Each now kicks off its work and returns synchronously. All three are background concerns — cache reconciliation, retiring a legacy guest session, and hydrating Builder cards that re-register when they arrive — none is a prerequisite for rendering.

**After the change:** `vueApp: true`, `bridgeReady: true`.

## Also fixed: a webfont gating hydration

`login-page.vue` and `sponsor-page.vue` each had a remote `@import url('https://fonts.googleapis.com/...')` inside a component `<style>` block. Vite hoists those into the bundled global stylesheet, and **a pending stylesheet blocks script execution** — so one login-page font gated hydration of the entire app on a third-party host. Measured at 12.7s where that host was unreachable, and unbounded for anyone behind an ad blocker, DNS filter, or restrictive network.

They now load from the head script on the `load` event. Appending them earlier — even with `media="print"` — still blocked the parser (verified: the renderer stayed unresponsive), so the deferral is deliberate and commented as such.

## Reverts a regression from #1203

That PR pushed the emergency deadlines out (shell watchdog 9s→12s, CSS hard stop 8.3s→11.5s). That was wrong: the graceful fade completes by ~5.7s so 9s already clears it, and when hydration blocks the main thread those two are the only mechanisms still working. Delaying them only lengthens the freeze. Both restored.

## Verification

- Production build + real browser, before/after on app mount — the numbers above
- `node utils/scripts/verify-startup-handoff.mjs` — passes
- `npx eslint` on all changed files — 2 errors, both pre-existing on `main` (`requireEnv` unused in `nuxt.config.ts`, `no-dynamic-delete` in `reconcile-server-cache.client.ts`), confirmed via `git stash`

**Not verified end-to-end:** that this fully resolves it on the reporter's device. Once the app mounts, hydrating a tree this large is itself expensive, and while it runs the main thread cannot service clicks or timers — the same failure mode the existing CSS hard-stop comment describes for iPad. This PR removes the blockers that made mounting impossible; whether mount is then *fast enough* on a given device is a separate question, and the CSS hard stop (restored to 8.3s) remains the backstop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9HNdfh9HAYppqpW51BQBH)_