### PR TITLE
fix(startup): never raise a second launch screen after the shell gives up

### DIFF
--- a/components/admin/kind-loader.vue
+++ b/components/admin/kind-loader.vue
@@ -43,6 +43,7 @@ import {
   clearStartupCover,
   consumeForcedFullStartup,
   isBrowserReload,
+  startupWasAbandoned,
 } from '@/utils/startupLaunch'
 
 const errorStore = useErrorStore()
@@ -84,6 +85,16 @@ const buildId = String(runtimeConfig.public.buildId || 'development')
 
 function shouldShowFullStartupSequence(): boolean {
   if (!import.meta.client) return true
+
+  /*
+   * Checked before anything else, including the forced-reload flag: if the
+   * shell already tore the launch screen down we must not raise a second one,
+   * no matter how we got here. Reveal the site instead.
+   */
+  if (startupWasAbandoned()) {
+    consumeForcedFullStartup()
+    return false
+  }
 
   if (consumeForcedFullStartup()) return true
   if (isBrowserReload()) return false

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -321,6 +321,16 @@ export default defineNitroPlugin((nitroApp) => {
             }
 
             window.__KR_STARTUP_USER_EXPLORE__ = false
+            /*
+             * Startup is over as far as this page load is concerned. On a slow
+             * device the app can hydrate long after this runs; without this
+             * flag kind-loader would mount and start a brand new startup
+             * sequence on top of the one we just tore down — and every safety
+             * net (this watchdog, the CSS hard stop) is gated on classes we are
+             * about to remove, so that second sequence would have none. That is
+             * the "animation loops forever" report.
+             */
+            window.__KR_STARTUP_ABANDONED__ = true
             root.classList.remove('kr-startup-user-explore')
             root.classList.add('kr-startup-fading')
             record('shell:begin-exit', { reason })

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -10,6 +10,8 @@ const [
   startupStore,
   traceEndpoint,
   appShell,
+  startupLaunch,
+  kindLoader,
 ] = await Promise.all([
   readFile('components/screenfx/startup-animation.vue', 'utf8'),
   readFile('plugins/startup-composition.client.ts', 'utf8'),
@@ -19,6 +21,8 @@ const [
   readFile('stores/startupAnimationStore.ts', 'utf8'),
   readFile('server/api/startup/trace.post.ts', 'utf8'),
   readFile('app.vue', 'utf8'),
+  readFile('utils/startupLaunch.ts', 'utf8'),
+  readFile('components/admin/kind-loader.vue', 'utf8'),
 ])
 
 assert.ok(
@@ -128,6 +132,25 @@ assert.ok(
   compositionShell.includes("sessionStorage.removeItem(FORCE_KEY)") &&
     compositionShell.includes("sessionStorage.removeItem(STARTED_AT_KEY)"),
   'The JS hard stop must clear sticky forced-startup session state.',
+)
+
+/*
+ * A late hydration must never raise a second launch screen. When the shell's
+ * watchdog fires it removes the very classes every safety net is gated on, so
+ * a startup sequence started after that point runs with no watchdog and no CSS
+ * hard stop — it simply never ends. Observed directly: shell:watchdog-fire at
+ * 9.3s, shell:exit-cleanup at 10.0s, then client:app-mounted at 13.8s followed
+ * by client:loader-observed starting the whole sequence over again.
+ */
+assert.ok(
+  compositionShell.includes('window.__KR_STARTUP_ABANDONED__ = true'),
+  'The shell must record that it abandoned startup before tearing it down.',
+)
+
+assert.ok(
+  startupLaunch.includes('export function startupWasAbandoned') &&
+    kindLoader.includes('startupWasAbandoned()'),
+  'kind-loader must skip the startup sequence when the shell already abandoned it.',
 )
 
 /*

--- a/utils/startupLaunch.ts
+++ b/utils/startupLaunch.ts
@@ -72,6 +72,24 @@ export function consumeForcedFullStartup(): boolean {
   }
 }
 
+/*
+ * True once the server-rendered startup shell has given up on this page load
+ * (its watchdog fired, or the user pressed exit/resume before hydration).
+ *
+ * Set in server/plugins/00-startup-composition-shell.ts. The app can hydrate
+ * seconds after that happens on a slow device, and starting a second startup
+ * sequence at that point leaves it running with no watchdog and no CSS hard
+ * stop, because both are gated on classes the shell already removed.
+ */
+export function startupWasAbandoned(): boolean {
+  if (!import.meta.client) return false
+
+  return (
+    (window as Window & { __KR_STARTUP_ABANDONED__?: boolean })
+      .__KR_STARTUP_ABANDONED__ === true
+  )
+}
+
 export function isBrowserReload(): boolean {
   if (!import.meta.client) return false
 


### PR DESCRIPTION
## The loop, captured

One page load against the current production build, console trace:

```
309ms    shell:init
9317ms   shell:watchdog-fire       ← shell gives up waiting for hydration
10019ms  shell:exit-cleanup        ← removes kr-full-startup and friends
13760ms  client:plugin-init        ← Vue only starts here
13797ms  client:app-mounted
13874ms  client:loader-observed    ← startup sequence begins AGAIN
```

The app hydrates ~4s *after* the shell has already torn the launch screen down. `kind-loader` then mounts and starts a brand new startup sequence — and that second sequence has **no safety net whatsoever**:

- the shell watchdog has already fired and will not fire again
- the CSS hard stop, and every startup style rule, are gated on `kr-full-startup` / `kr-startup-handoff`, which `shell:exit-cleanup` just removed

So nothing left in the system can end it. That is the "animation loops forever" report, and it reproduces on any device where hydration takes longer than the 9s watchdog.

## The fix

The shell sets `window.__KR_STARTUP_ABANDONED__` before tearing down. `kind-loader` checks it **first** — ahead of the forced-reload flag, so a pending dashboard-refresh request can't resurrect the sequence either. If the shell gave up, the app reveals the site rather than starting over.

Guarded by a new assertion in `verify-startup-handoff.mjs` so it can't silently regress.

## What this does *not* fix

Hydration taking ~13.8s. That's the underlying pathology and it's still open. This PR removes the mechanism that converts a slow hydration into a launch screen with no exit; it does not make hydration fast.

Worth noting what the trace rules out about that 13.8s: the shell's own `setTimeout` snapshots fire on schedule throughout (1814 / 3814 / 6314 / 9314ms), so the main thread is **not** blocked — the module graph is waiting on something, not computing. All `_nuxt` chunks finish downloading inside the first ~400ms.

## Verification honesty

The trace above is real and reproducible. The fix itself is verified only by the contract test — the sandbox's browser automation degraded mid-session to where `page.evaluate` hangs on builds that worked earlier, so I could not get a trustworthy before/after on the fix in a live browser. The mechanism is directly evidenced by the trace; the fix's effect is not independently confirmed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9HNdfh9HAYppqpW51BQBH)_