### PR TITLE
fix(academy): update stale curriculum endpoint text

### DIFF
--- a/content/academy.md
+++ b/content/academy.md
@@ -2,7 +2,7 @@
 title: 'Art Academy'
 room: 'Art Academy'
 subtitle: 'Learn the styles. Meet the masters. Remix everything.'
-description: Explore thirty-three centuries of public-domain art history, then remix your own images in any style you learn — from Greek vases to Bauhaus grids.
+description: Explore thirty-three centuries of public-domain art history, then remix your own images in any style you learn — from Ancient Egyptian tomb painting to 1920s American Regionalism.
 image: 'background/artgallery.webp'
 icon: kind-icon:palette
 tooltip: Art history lessons with a remix button. The masters would approve. Probably.

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -216,7 +216,7 @@ export const dashboardConfigs = {
           'Walk thirty-three centuries of art history, one style at a time.',
         image: tabImage('academy', 'timeline'),
         narrative:
-          'Walk the timeline from Greek vases to De Stijl grids, meet the long-departed masters, and learn why every era thought the previous one was doing it wrong.',
+          'Walk the timeline from Ancient Egypt to American Regionalism, meet the long-departed masters, and learn why every era thought the previous one was doing it wrong.',
         route: '/academy',
       },
       {


### PR DESCRIPTION
### Task
ai-art-academy/t-010: Academy continuous improvement pass (lane 1: front-end polish)

### What changed / what I produced
- `stores/helpers/dashboardHelper.ts` — the Academy dashboard tile's `narrative` text said "from Greek vases to De Stijl grids." De Stijl hasn't been the latest movement since Bauhaus was added (2026-07-16), and Greek Vase Painting hasn't been the earliest since Ancient Egyptian Painting was added (2026-07-28).
- `content/academy.md` — the room description said "from Greek vases to Bauhaus grids." This was correctly updated to Bauhaus in PR #332 (2026-07-17) but has drifted stale again since.
- Both now read "from Ancient Egypt to American Regionalism" / "Ancient Egyptian tomb painting to 1920s American Regionalism" — verified against the live `stores/seeds/academyStyles.ts` data: earliest = `egyptian-painting` (sortYear -1390), latest = `american-regionalism` (sortYear 1928), across all 41 entries.

### How I verified
- Parsed `academyStyles.ts` directly (Node script) to confirm current earliest/latest by `sortYear` rather than trusting either file's existing claim.
- `npx eslint stores/helpers/dashboardHelper.ts` clean.
- Full-project `npm run test` (`vue-tsc --noEmit`, via `provision_kind_robots_deps.sh`): only the 2 pre-existing `videoStore` errors remain (unrelated, present on `main`).

### Stakes
reversible (text-only content fix, no logic change)

### Flags for Reviewer
- This is the second time this exact drift class has recurred (PR #1155, 2026-07-29, fixed the "twenty-five/thirty-three centuries" count using this same min/max data but explicitly left the named-endpoint phrasing untouched). Worth considering dropping the named-endpoint phrasing entirely in favor of the already-generic "thirty-three centuries" claim so it stops drifting every time a new earliest/latest movement is added — noting as a design call, not doing it in this scoped fix.

### Kaizen suggestion
Add a lightweight contract test (similar to the existing `verifyAcademyExamplesManifest.ts` pattern) that asserts the curriculum's "from X to Y" marketing strings match the true min/max `sortYear` entries in `academyStyles.ts`, so this class of drift fails CI instead of silently going stale a third time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwtQ7B4xLs2KGN2z5RcDA5)_