### PR TITLE
Fix startup explore mode and logo handoff

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -8,14 +8,15 @@
  * stylesheet having loaded.
  */
 
+/*
+ * The Vue intro renders exactly one visual through <startup-intro-visual>.
+ * Do not paint launch-04.webp or kindlogo_new.webp behind it as CSS
+ * backgrounds: those duplicate images are unmasked and make the handoff look
+ * like a second, square logo load. startup-intro-visual already owns its own
+ * fallback from the launch animation to the static logo.
+ */
 .loading-logo-frame {
-  background-color: transparent;
-  background-image:
-    url('/images/startup-animations/launch-04.webp'),
-    url('/images/kindlogo_new.webp');
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: clamp(16rem, 58vw, 34rem) auto;
+  background: transparent;
 }
 
 /*

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -6,6 +6,7 @@
       class="startup-animation__stage"
       :class="{
         'startup-animation__stage--ready': effectReady,
+        'startup-animation__stage--immersive': startupStore.immersive,
         'startup-animation__stage--fading': isFading,
       }"
     >
@@ -246,16 +247,25 @@ function fadeOut(): void {
 }
 
 /*
- * Deliberately does NOT reset the startup store here. kind-loader owns that
- * lifecycle; resetting on this component's setup meant any remount silently
- * dropped the user out of explore mode.
+ * Explore mode belongs to this component, not to the loader backdrop. App.vue
+ * may finish booting underneath while the user browses startup effects. If the
+ * loader is retired by its outer failsafe, immersive mode must therefore keep
+ * both the selected effect and an opaque black stage alive until Resume/Exit.
  */
 watch(
-  [() => butterflyStore.showSwarm, availableEffectIds],
-  ([visible]) => {
-    if (visible) {
+  [
+    () => butterflyStore.showSwarm,
+    () => startupStore.immersive,
+    availableEffectIds,
+  ],
+  ([visible, immersive]) => {
+    if (visible || immersive) {
       clearFadeTimer()
-      selectEffect()
+
+      if (!renderEffect.value || !resolvedEffectId.value) {
+        selectEffect()
+      }
+
       return
     }
 
@@ -277,12 +287,23 @@ onBeforeUnmount(() => {
   overflow: hidden;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 320ms ease;
+  transition:
+    opacity 320ms ease,
+    background-color 180ms ease;
   isolation: isolate;
   will-change: opacity;
 }
 
 .startup-animation__stage--ready {
+  opacity: 1;
+}
+
+/*
+ * Once Pause & explore is active the stage becomes the screensaver surface.
+ * It must remain opaque even if the normal loader finishes underneath it.
+ */
+.startup-animation__stage--immersive {
+  background: #000;
   opacity: 1;
 }
 

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -37,8 +37,7 @@ export default defineNitroPlugin((nitroApp) => {
           z-index: 30;
           display: grid;
           place-items: center;
-          gap: 1.25rem;
-          grid-auto-flow: row;
+          padding: 1rem;
           background: #000;
           color: #fff;
           opacity: 1;
@@ -60,33 +59,69 @@ export default defineNitroPlugin((nitroApp) => {
           animation: none;
         }
 
+        /*
+         * Match loading-messages.vue closely enough that the boot-cover cameo
+         * and the real Vue intro occupy the same visual slots. On a normal
+         * launch the handoff should read as one continuous logo, not a second
+         * logo loading at a new size or position. On browser refresh, where the
+         * full intro is intentionally skipped, this is the brief logo cameo.
+         */
+        .kr-boot-cover__content {
+          display: grid;
+          width: min(98vw, 64rem);
+          height: min(92vh, 52rem);
+          grid-template-rows: minmax(3.75rem, auto) minmax(0, 1fr) 8rem;
+          place-items: center;
+        }
+
+        .kr-boot-cover__title {
+          display: flex;
+          width: fit-content;
+          max-width: min(90vw, 44rem);
+          min-height: 3.75rem;
+          align-items: center;
+          justify-content: center;
+          padding: 0.65rem 1.2rem;
+          background: rgba(0, 0, 0, 0.78);
+          color: #fff;
+          font-size: clamp(1.2rem, 2.25vw, 2rem);
+          font-weight: 800;
+          letter-spacing: 0.02em;
+          text-align: center;
+          box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.42);
+        }
+
+        .kr-boot-cover__media-frame {
+          display: grid;
+          width: 100%;
+          height: 100%;
+          min-height: 0;
+          place-items: center;
+        }
+
         .kr-boot-cover__media {
-          width: clamp(14rem, 52vw, 30rem);
-          max-width: 90vw;
+          width: clamp(16rem, 58vw, 34rem);
+          max-height: 100%;
           height: auto;
           object-fit: contain;
+          filter: drop-shadow(0 1.5rem 3rem rgba(255, 255, 255, 0.2));
           -webkit-mask-image: radial-gradient(
-            ellipse 47% 52% at 48% 49%,
-            #000 0%,
-            #000 42%,
-            rgba(0, 0, 0, 0.62) 73%,
+            ellipse 54% 54% at center,
+            #000 58%,
+            rgba(0, 0, 0, 0.96) 70%,
             transparent 100%
           );
           mask-image: radial-gradient(
-            ellipse 47% 52% at 48% 49%,
-            #000 0%,
-            #000 42%,
-            rgba(0, 0, 0, 0.62) 73%,
+            ellipse 54% 54% at center,
+            #000 58%,
+            rgba(0, 0, 0, 0.96) 70%,
             transparent 100%
           );
         }
 
-        .kr-boot-cover__title {
-          max-width: 90vw;
-          font-size: clamp(1.1rem, 2.2vw, 1.9rem);
-          font-weight: 800;
-          letter-spacing: 0.02em;
-          text-align: center;
+        .kr-boot-cover__status-spacer {
+          width: 100%;
+          min-height: 8rem;
         }
 
         @keyframes kr-boot-cover-release {
@@ -104,16 +139,23 @@ export default defineNitroPlugin((nitroApp) => {
       </style>
 
       <div class="kr-boot-cover" aria-hidden="true">
-        <img
-          src="/images/startup-animations/launch-04.webp"
-          alt=""
-          class="kr-boot-cover__media"
-          width="720"
-          height="720"
-          fetchpriority="high"
-          decoding="async"
-        />
-        <p class="kr-boot-cover__title">Building Kind Robots...</p>
+        <div class="kr-boot-cover__content">
+          <p class="kr-boot-cover__title">Building Kind Robots...</p>
+
+          <div class="kr-boot-cover__media-frame">
+            <img
+              src="/images/startup-animations/launch-04.webp"
+              alt=""
+              class="kr-boot-cover__media"
+              width="720"
+              height="720"
+              fetchpriority="high"
+              decoding="async"
+            />
+          </div>
+
+          <div class="kr-boot-cover__status-spacer"></div>
+        </div>
       </div>
     `)
   })

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -21,14 +21,21 @@ import { readFile } from 'node:fs/promises'
  * that needs no JavaScript to go away, and Vue owns the intro outright.
  */
 
-const [bootCover, kindLoader, loadingMessages, startupAnimation, startupLaunch] =
-  await Promise.all([
-    readFile('server/plugins/00-startup-composition-shell.ts', 'utf8'),
-    readFile('components/admin/kind-loader.vue', 'utf8'),
-    readFile('components/admin/loading-messages.vue', 'utf8'),
-    readFile('components/screenfx/startup-animation.vue', 'utf8'),
-    readFile('utils/startupLaunch.ts', 'utf8'),
-  ])
+const [
+  bootCover,
+  startupCoverCss,
+  kindLoader,
+  loadingMessages,
+  startupAnimation,
+  startupLaunch,
+] = await Promise.all([
+  readFile('server/plugins/00-startup-composition-shell.ts', 'utf8'),
+  readFile('assets/css/startup-cover.css', 'utf8'),
+  readFile('components/admin/kind-loader.vue', 'utf8'),
+  readFile('components/admin/loading-messages.vue', 'utf8'),
+  readFile('components/screenfx/startup-animation.vue', 'utf8'),
+  readFile('utils/startupLaunch.ts', 'utf8'),
+])
 
 /*
  * The single most important property: the cover must release itself with no JS
@@ -121,10 +128,51 @@ assert.ok(
   'The intro overlay must paint its own opaque backdrop.',
 )
 
+/*
+ * Pause & explore is allowed to outlive the loader itself. Store initialization
+ * and the app can finish underneath, but the selected startup effect must stay
+ * on an opaque screensaver surface until the user resumes or exits. Otherwise
+ * the control tray survives while the effect turns into a translucent overlay
+ * on top of the real site.
+ */
+assert.ok(
+  startupAnimation.includes("'startup-animation__stage--immersive': startupStore.immersive") &&
+    startupAnimation.includes('() => startupStore.immersive') &&
+    startupAnimation.includes('if (visible || immersive)'),
+  'Immersive mode must keep the startup effect alive independently of the loader/swarm lifecycle.',
+)
+
+assert.ok(
+  /\.startup-animation__stage--immersive\s*\{[^}]*background:\s*#000[^}]*opacity:\s*1/s.test(
+    startupAnimation,
+  ),
+  'Immersive mode must own an opaque black screensaver backdrop so the live site cannot bleed through.',
+)
+
+/*
+ * The intro visual is a real <img> with its own animation->logo fallback.
+ * Never paint additional WebPs behind it in CSS: those backgrounds bypass the
+ * radial mask and look like a second square logo load.
+ */
+assert.ok(
+  !startupCoverCss.includes('background-image:') &&
+    !startupCoverCss.includes("url('/images/startup-animations/launch-04.webp')") &&
+    !startupCoverCss.includes("url('/images/kindlogo_new.webp')"),
+  'The Vue intro frame must not paint duplicate startup WebPs behind the actual masked visual.',
+)
+
+assert.ok(
+  bootCover.includes('grid-template-rows: minmax(3.75rem, auto) minmax(0, 1fr) 8rem') &&
+    bootCover.includes('ellipse 54% 54% at center'),
+  'The server boot cameo must align with the Vue intro geometry and haze mask so their handoff reads as one logo.',
+)
+
 assert.ok(
   startupLaunch.includes('export function markAppReady') &&
     kindLoader.includes('markAppReady()'),
   'The app must signal readiness so the boot cover can retire early.',
 )
 
-console.log('Startup contract passed: server cover is JS-free, Vue owns the intro.')
+console.log(
+  'Startup contract passed: server cover is JS-free, Vue owns the intro, immersive mode stays opaque, and the logo is single-layered.',
+)


### PR DESCRIPTION
## What changed

- keep `Pause & explore` on its own opaque black Screen FX stage even if the normal loader finishes underneath
- keep the selected startup effect alive while immersive mode is active, instead of tying it only to the loader/swarm lifetime
- fade the startup effect normally when Resume/Exit leaves immersive mode
- remove duplicate CSS-painted `launch-04.webp` / `kindlogo_new.webp` backgrounds from the Vue logo frame
- align the server boot-cover cameo with the Vue intro's exact grid, size, and haze mask so the handoff reads as one logo rather than two loads
- extend the startup contract to cover immersive opacity and the single-layer logo invariant

## Root cause

The new post-hydration architecture fixed the looping loader, but two seams remained:

1. `Pause & explore` set `startupStore.immersive`, while the actual effect lifetime still depended only on `butterflyStore.showSwarm`. When the outer loader retired, the site could appear underneath while the control tray/effect survived, producing the translucent screensaver-over-site state.
2. `assets/css/startup-cover.css` painted both startup WebPs as unmasked CSS background images while `startup-intro-visual.vue` also rendered the real masked image. That was a literal duplicate visual layer and explains the square-looking logo.

The server cover is intentionally retained because a browser refresh briefly showing the logo is useful. Its media now matches the real Vue intro geometry/mask so the transition should be visually continuous.

## Expected behavior

- Pause & explore: normal boot may finish in the background, but the user continues to see an opaque black screensaver surface and working controls until Resume/Exit.
- Resume/Exit: effect and controls fade out to the already-loaded site.
- Normal launch: one hazy logo/animation surface, no square duplicate beneath it.
- Browser refresh: the brief boot logo cameo remains, but it should occupy the same position/shape as the real intro instead of looking like a separate second logo.

## Validation

Pending GitHub Actions on the final head.