### PR TITLE
Fix startup effect layering and persistent logo haze

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -11,6 +11,12 @@
       aria-hidden="true"
     />
 
+    <div
+      v-if="showLoader"
+      class="pointer-events-none fixed inset-0 z-48 bg-black"
+      aria-hidden="true"
+    />
+
     <ClientOnly>
       <div v-if="showLoader" class="pointer-events-none fixed inset-0 z-50">
         <kind-loader

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -248,11 +248,11 @@ onBeforeUnmount(() => {
   place-items: center;
   padding: 1rem;
   /*
-   * Opaque on purpose. The intro used to sit on top of a separate
-   * server-rendered black base; now it owns its own backdrop, so it can never
-   * end up as text floating over a half-revealed site.
+   * The black base and Screen FX are sibling layers below this foreground.
+   * Painting black here would hide the effect because the loader lives in the
+   * z-50 stacking context while the effect stage lives at z-49.
    */
-  background: #000;
+  background: transparent;
   opacity: 1;
   transition: opacity 650ms ease;
   pointer-events: auto;
@@ -364,16 +364,18 @@ onBeforeUnmount(() => {
     transform 1100ms cubic-bezier(0.22, 1, 0.36, 1);
   filter: drop-shadow(0 1.5rem 3rem rgba(255, 255, 255, 0.2));
   -webkit-mask-image: radial-gradient(
-    ellipse 54% 54% at center,
-    #000 58%,
-    rgba(0, 0, 0, 0.96) 70%,
-    transparent 100%
+    ellipse 50% 47% at 52% 49%,
+    #000 42%,
+    rgba(0, 0, 0, 0.86) 58%,
+    rgba(0, 0, 0, 0.34) 76%,
+    transparent 96%
   );
   mask-image: radial-gradient(
-    ellipse 54% 54% at center,
-    #000 58%,
-    rgba(0, 0, 0, 0.96) 70%,
-    transparent 100%
+    ellipse 50% 47% at 52% 49%,
+    #000 42%,
+    rgba(0, 0, 0, 0.86) 58%,
+    rgba(0, 0, 0, 0.34) 76%,
+    transparent 96%
   );
   will-change: opacity, transform;
 }

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -155,7 +155,7 @@
 <script setup lang="ts">
 import { computed, onMounted, watch } from 'vue'
 import { useResourceStore } from '@/stores/resourceStore'
-import type { VideoEngine } from '@/stores/videoStore'
+import type { VideoEngine } from '@/utils/videoPresets'
 import type { Resource } from '~/prisma/generated/prisma/client'
 
 type PreviewArtImage = {

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -351,12 +351,13 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useVideoStore, type VideoOutputFormat } from '@/stores/videoStore'
+import { useVideoStore } from '@/stores/videoStore'
 import { useUserStore } from '@/stores/userStore'
 import {
   getVideoPreset,
   getVideoPresetsForEngine,
   type VideoEngine,
+  type VideoOutputFormat,
   type VideoPresetId,
 } from '@/utils/videoPresets'
 

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -106,16 +106,18 @@ export default defineNitroPlugin((nitroApp) => {
           object-fit: contain;
           filter: drop-shadow(0 1.5rem 3rem rgba(255, 255, 255, 0.2));
           -webkit-mask-image: radial-gradient(
-            ellipse 54% 54% at center,
-            #000 58%,
-            rgba(0, 0, 0, 0.96) 70%,
-            transparent 100%
+            ellipse 50% 47% at 52% 49%,
+            #000 42%,
+            rgba(0, 0, 0, 0.86) 58%,
+            rgba(0, 0, 0, 0.34) 76%,
+            transparent 96%
           );
           mask-image: radial-gradient(
-            ellipse 54% 54% at center,
-            #000 58%,
-            rgba(0, 0, 0, 0.96) 70%,
-            transparent 100%
+            ellipse 50% 47% at 52% 49%,
+            #000 42%,
+            rgba(0, 0, 0, 0.86) 58%,
+            rgba(0, 0, 0, 0.34) 76%,
+            transparent 96%
           );
         }
 

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -28,6 +28,7 @@ const [
   loadingMessages,
   startupAnimation,
   startupLaunch,
+  app,
 ] = await Promise.all([
   readFile('server/plugins/00-startup-composition-shell.ts', 'utf8'),
   readFile('assets/css/startup-cover.css', 'utf8'),
@@ -35,6 +36,7 @@ const [
   readFile('components/admin/loading-messages.vue', 'utf8'),
   readFile('components/screenfx/startup-animation.vue', 'utf8'),
   readFile('utils/startupLaunch.ts', 'utf8'),
+  readFile('app.vue', 'utf8'),
 ])
 
 /*
@@ -122,10 +124,13 @@ assert.ok(
   'Close and Resume must dismiss the intro without waiting for stores or media.',
 )
 
-// The intro owns its own backdrop now that the server no longer paints one.
+// Black, effect, and foreground must be separate sibling layers. If the
+// z-50 loader paints black, it hides the z-49 Screen FX along with the site.
 assert.ok(
-  /\.loading-overlay\s*\{[^}]*background:\s*#000/.test(loadingMessages),
-  'The intro overlay must paint its own opaque backdrop.',
+  /\.loading-overlay\s*\{[^}]*background:\s*transparent/.test(loadingMessages) &&
+    app.includes('fixed inset-0 z-48 bg-black') &&
+    app.includes('fixed inset-0 z-50'),
+  'Startup must stack a z-48 black base, z-49 Screen FX, and transparent z-50 loader foreground.',
 )
 
 /*
@@ -163,7 +168,8 @@ assert.ok(
 
 assert.ok(
   bootCover.includes('grid-template-rows: minmax(3.75rem, auto) minmax(0, 1fr) 8rem') &&
-    bootCover.includes('ellipse 54% 54% at center'),
+    bootCover.includes('ellipse 50% 47% at 52% 49%') &&
+    loadingMessages.includes('ellipse 50% 47% at 52% 49%'),
   'The server boot cameo must align with the Vue intro geometry and haze mask so their handoff reads as one logo.',
 )
 

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -222,7 +222,18 @@ async function main(): Promise<void> {
   requireText(files.generatorStore, text.generatorStore, 'entry.isRandomizable && entry.randomWeight > 0')
   forbidText(files.generatorStore, text.generatorStore, '__facetCatalogPatched')
 
-  requireText(files.builderPlugin, text.builderPlugin, 'hydrateAdventureBuilder')
+  requireText(files.builderPlugin, text.builderPlugin, "import('@/stores/helpers/adventureCards')")
+  requireText(files.builderPlugin, text.builderPlugin, "import('@/stores/helpers/scenarioCards')")
+  requireText(
+    files.builderPlugin,
+    text.builderPlugin,
+    'hydrateBuilderCards(ADVENTURE_CARDS, catalog)',
+  )
+  requireText(
+    files.builderPlugin,
+    text.builderPlugin,
+    'hydrateBuilderCards(SCENARIO_CARDS, catalog)',
+  )
   requireText(files.builderPlugin, text.builderPlugin, 'Generator methods read this same catalog')
   forbidText(files.builderPlugin, text.builderPlugin, 'patchGenerator')
   forbidText(files.builderPlugin, text.builderPlugin, '__facetCatalogPatched')

--- a/utils/scripts/verifyScenarioGenreFacetCutover.ts
+++ b/utils/scripts/verifyScenarioGenreFacetCutover.ts
@@ -115,7 +115,6 @@ async function main(): Promise<void> {
   requireText(files.wrapper, text.wrapper, "import('./seedScenarioGenreFacetCatalog')")
   requireText(files.plugin, text.plugin, 'SCENARIO_CARDS')
   requireText(files.plugin, text.plugin, "if (key === 'genres') return 'genre'")
-  requireText(files.plugin, text.plugin, 'hydrateScenarioBuilder')
   requireText(files.plugin, text.plugin, 'hydrateBuilderCards(SCENARIO_CARDS, catalog)')
   requireText(files.sync, text.sync, 'syncScenarioGenreFacetsInTransaction')
   requireText(files.sync, text.sync, "where: { taxonomy: 'GENRE' }")


### PR DESCRIPTION
## What changed

- split startup into a fixed black base at z-48, Screen FX at z-49, and a transparent loader foreground at z-50
- stop the loader overlay from painting black over the animation
- replace the nearly hard-edged logo mask with a broader, softly feathered, slightly offset elliptical haze
- use the same mask for the brief server-rendered refresh cameo and the Vue intro
- extend the startup handoff contract to lock in the three-layer invariant and matching masks

## Root cause

The loader lived inside a z-50 stacking context and painted its own opaque black full-screen background. The Screen FX stage was z-49, so it was correctly above the app but still behind the loader's black paint. The existing mask also remained almost fully opaque through 70% of the image, making most of the WebP read as a square rather than a diffuse shape.

## Expected behavior

Black remains the bottom startup layer, the animation is visible above it, and the WebP/messages/spinner/controls remain above the animation. The logo has a persistent soft organic edge during both the refresh cameo and full loader.

## Validation

- Startup Handoff Contract passed
- `git diff --check` passed
- full local TypeScript could not run because this clean checkout's dependency install hit the runtime npm cache restriction; GitHub Actions is the authoritative full check.