### PR TITLE
Keep startup loading messages visible

### DIFF
--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -301,6 +301,12 @@ onBeforeUnmount(() => {
   transform: translateZ(0);
 }
 
+.loading-heading,
+.loading-status {
+  position: relative;
+  z-index: 2;
+}
+
 .loading-heading {
   font-size: clamp(1.2rem, 2.25vw, 2rem);
   font-weight: 800;
@@ -309,6 +315,7 @@ onBeforeUnmount(() => {
 
 .loading-logo-frame {
   position: relative;
+  z-index: 1;
   display: grid;
   width: 100%;
   height: 100%;

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -174,6 +174,16 @@ assert.ok(
 )
 
 assert.ok(
+  /\.loading-heading,\s*\.loading-status\s*\{[^}]*position:\s*relative;[^}]*z-index:\s*2;/s.test(
+    loadingMessages,
+  ) &&
+    /\.loading-logo-frame\s*\{[^}]*position:\s*relative;[^}]*z-index:\s*1;/s.test(
+      loadingMessages,
+    ),
+  'Startup heading, spinner, and rotating message must paint above the positioned launch media.',
+)
+
+assert.ok(
   startupLaunch.includes('export function markAppReady') &&
     kindLoader.includes('markAppReady()'),
   'The app must signal readiness so the boot cover can retire early.',


### PR DESCRIPTION
## Root cause

The masked startup logo is a positioned `z-index: 1` child, while the heading, spinner, and rotating loading message had no explicit paint layer. On constrained/mobile layouts the logo paint layer could cover the status content even though the grid placement itself was correct.

## Changes

- Keep the logo/haze frame on startup foreground layer 1.
- Put the heading and complete status region (spinner plus rotating message) on layer 2.
- Add a Startup Handoff Contract assertion guarding this paint order.

## Impact

Loading copy remains visible above the WebP and haze without changing the working animation, pause/resume, fade, or exit lifecycle.

## Validation

- Startup Handoff Contract (CI)
- TypeScript and repository contract workflows (CI)