### PR TITLE
fix(model-builder): close the approve-assets gate during the async queue window

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -352,7 +352,7 @@ watch(
 )
 
 const isGenerating = computed(() => store.generatingItemId === props.itemId)
-const isQueued = computed(() => Boolean(item.value?.artJobId))
+const isQueued = computed(() => Boolean(item.value?.queueState))
 const isCommitting = computed(() => store.committingItemId === props.itemId)
 const isAutoBuilding = computed(() => store.autoBuildingItemId === props.itemId)
 


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
`canApproveAssets()` in `model-builder-item-panel.vue` is meant to block approving a stale candidate while a regenerate is in flight (`isGenerating || isQueued`), but `isQueued` read `item.artJobId` — which `generateItemAssetAsync` in `stores/modelBuilderStore.ts` only sets *after* `prepareArtGenerator()` and `enqueueCurrentArt()` resolve (two network round-trips). In the window between clicking the async "regenerate" (clock icon) button and that resolving, `item.queueState` is already `'queued'` (set synchronously, one line above `GENERATE_ASSETS.status = 'in-progress'`) while `artJobId` is still `null`, so `isQueued` read `false` and "Keep this asset" stayed enabled against the item's stale prior `artImageId` during a genuine in-flight regenerate — exactly what the code's own adjacent comment says must be blocked.

- `isQueued` now reads `item.queueState` instead of `item.artJobId`, matching the field the store itself documents as the async-progress signal.
- Also fixes a secondary cosmetic bug: the "Queued…" indicator (`v-if="isQueued"`) didn't appear during that same initial window either, since it depended on the same computed.

### How I verified
- Read `generateItemAssetAsync` and `pollAsyncArtJob` in full to confirm `queueState`'s set/clear lifecycle (`'queued'` → `'rendering'` → `null` on terminal status or error), and confirmed nothing else in the panel depends on the old `artJobId`-based semantics.
- `eslint` clean on the changed file.
- `vue-tsc --noEmit` — 0 errors.

### Stakes
reversible

### Kaizen suggestion
None beyond this task's scope.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcKZhfCVRBdXj2x2h6SinG)_