### PR TITLE
Keep mobile startup messages clear of animation controls

### DIFF
--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -464,6 +464,22 @@ onBeforeUnmount(() => {
   }
 }
 
+@media (max-width: 639px) {
+  /*
+   * The animation controls are teleported to <body>, so they do not reserve
+   * space in this grid. Pin the status above the compact tray explicitly;
+   * z-index alone cannot prevent two opaque elements occupying the same pixels.
+   */
+  .loading-status {
+    position: fixed;
+    right: 0.75rem;
+    bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+    left: 0.75rem;
+    z-index: 2;
+    width: auto;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .loading-content,
   :deep(.loading-logo),

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -184,6 +184,13 @@ assert.ok(
 )
 
 assert.ok(
+  /@media \(max-width: 639px\)\s*\{[\s\S]*?\.loading-status\s*\{[^}]*position:\s*fixed;[^}]*bottom:\s*calc\(4\.5rem \+ env\(safe-area-inset-bottom, 0px\)\);/s.test(
+    loadingMessages,
+  ),
+  'Mobile startup status must reserve physical clearance above the teleported animation controls.',
+)
+
+assert.ok(
   startupLaunch.includes('export function markAppReady') &&
     kindLoader.includes('markAppReady()'),
   'The app must signal readiness so the boot cover can retire early.',


### PR DESCRIPTION
## Root cause

The previous startup fix gave the messages a higher paint layer, but the animation controls are teleported to `body` and therefore reserve no space in the loader grid. On mobile, the opaque control tray and the bottom status row still occupied the same physical pixels, so the loading message was covered despite the correct internal z-index.

## Changes

- Pin the mobile loading status above the compact animation control tray.
- Include the device safe-area inset for iPhone/iPad layouts.
- Add a startup contract assertion that guards physical mobile clearance.
- Leave desktop layout, startup timing, animation lifecycle, masks, and pause/exit behavior unchanged.

## Validation

- Startup handoff contract will run in GitHub Actions.
- TypeScript and aggregate contract workflows will validate the final branch head.