### PR TITLE
fix(cypress): bound raw fetch() timeout in multipart upload helpers

### DIFF
--- a/cypress/e2e/api/art-image-collection-connections.cy.ts
+++ b/cypress/e2e/api/art-image-collection-connections.cy.ts
@@ -1,6 +1,7 @@
 import {
   bearerHeaders,
   createLoggedInTestUser,
+  fetchWithTimeout,
   getApiEnv,
   type TestUserAuth,
 } from '../../support/api-auth'
@@ -37,7 +38,7 @@ function uploadImage(apiBase: string, user: TestUserAuth) {
     formData.append('image', pngBlob(), 'connection-owner.png')
     formData.append('galleryName', 'cypressConnections')
 
-    const response = await fetch(`${apiBase}/art/upload`, {
+    const response = await fetchWithTimeout(`${apiBase}/art/upload`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${user.token}`,

--- a/cypress/e2e/api/art-upload.cy.ts
+++ b/cypress/e2e/api/art-upload.cy.ts
@@ -1,6 +1,7 @@
 import {
   bearerHeaders,
   createLoggedInTestUser,
+  fetchWithTimeout,
   getApiEnv,
   type TestUserAuth,
 } from '../../support/api-auth'
@@ -47,7 +48,7 @@ function uploadMultipart<T>(
       formData.append(name, value)
     }
 
-    const response = await fetch(`${apiBase}/art/upload`, {
+    const response = await fetchWithTimeout(`${apiBase}/art/upload`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/cypress/support/api-auth.ts
+++ b/cypress/support/api-auth.ts
@@ -74,6 +74,35 @@ const bodyNumber = (value: unknown): number | undefined => {
 
 export const resetSeedUserCursor = () => {}
 
+// `cy.then(async () => { await fetch(...) })` is a documented Cypress gotcha:
+// Cypress does not apply any command timeout to a promise returned from a
+// `.then()` callback, so a raw `fetch()` inside one can hang the entire spec
+// (and, in CI, the whole 30-minute job) if the endpoint stalls. Bound it
+// explicitly so a stall fails fast with a clear error instead of a silent
+// hang. Used by the two specs that upload multipart images via raw `fetch`
+// (Cypress's own `cy.request()` doesn't support browser `FormData`/`Blob`
+// bodies) — see art-upload.cy.ts and art-image-collection-connections.cy.ts.
+export async function fetchWithTimeout(
+  input: string,
+  init: RequestInit = {},
+  timeoutMs = 45_000,
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(input, { ...init, signal: controller.signal })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Request to ${input} timed out after ${timeoutMs}ms`, {
+        cause: error,
+      })
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export const getApiEnv = () =>
   cy
     .env(['API_KEY', 'BETA_ADMIN_TOKEN', 'ADMIN_TOKEN', 'BASE_API_URL'])


### PR DESCRIPTION
### What changed
`cy.then(async () => { await fetch(...) })` is a documented Cypress gotcha: Cypress applies no command timeout to a promise returned from a `.then()` callback. The raw `fetch()` calls in `uploadImage()` (`art-image-collection-connections.cy.ts`) and `uploadMultipart()` (`art-upload.cy.ts`) had no timeout of their own, so a stalled `/art/upload` could hang the entire spec — and, in CI, the whole job — with zero diagnostics until GitHub Actions' hard job timeout killed it.

- Adds `fetchWithTimeout()` (AbortController, 45s default) to `cypress/support/api-auth.ts`.
- Switches both upload helpers to it.

### Why
ci-janitor filed 4 duplicate HIGH-priority Todos (#1003–#1006) for `Cypress Tests` runs on `main` that all ended `cancelled`. Investigation (GitHub Actions job logs via the MCP tools) showed six consecutive scheduled runs between 2026-07-31 00:06 UTC and 15:03 UTC each hung ~27 minutes at the exact same spot — mid-`before()` hook in `art-image-collection-connections.cy.ts`, right after `cy.task('cypressSeed:get')`, immediately before/during the raw-`fetch()` image upload — until the workflow's `timeout-minutes: 30` cancelled the job (runs `30592571651`, `30603071073`, `30612641605`, `30622419984`, `30630735658`, `30641260379`). Todo #986 is unrelated (a stale Cypress-binary-cache miss from an isolated run).

The underlying stall has since **self-resolved** — main has been green every run since `30646489817` (16:17 UTC), with no code change in between — so this PR doesn't fix a product regression. It fixes the test contract: the identical unbounded-`fetch`-in-`cy.then` pattern will hang again, uninformatively, the next time `/art/upload` stalls for any reason. Bounding it means a future stall fails fast with a clear timeout error instead of silently burning a 30-minute CI job.

### How I verified
- `npx eslint` on the three changed files — clean except two pre-existing `no-unused-expressions` errors on chai `expect()` statements already present on `main` before this change (unrelated, not introduced by this PR).
- `npx vue-tsc --noEmit` across the full project — exit 0, no errors.
- Confirmed via GitHub Actions job logs that the hang happens before Cypress's own `responseTimeout`-bounded `cy.request()` calls are even reached, so this is specifically the unbounded raw-`fetch` gap.

### Stakes
reversible

### Flags for Reviewer
- I did not chase the server-side cause of the original ~15-hour stall (00:06–15:03 UTC) since it already self-resolved and isn't reproducible from here (this is a test/CI-side fix, not a backend fix).
- Todos #1003–#1006 will be marked done; #986 is unrelated and pre-existing before this incident.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvGEe2wvHquf6geNS5mwv5)_