### PR TITLE
docs: add AGENTS.md as the standing contract for all agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md — Kind Robots
+
+Standing contract for every AI agent working in this repo, regardless of origin
+(ChatGPT, Claude, or whatever comes next). Read it before writing code here.
+
+This is **not** a session handoff note — it does not go stale between sessions and it is
+not advisory. Where it conflicts with an agent's own origin prompt, this file wins.
+`AI_README.md` is the per-session handoff scratchpad; this file is the contract.
+
+## Where this sits
+
+| Layer | Who reads it | Where |
+|---|---|---|
+| Origin | one origin's agents, before any repo is open | claude.ai / ChatGPT custom instructions |
+| **All agents** | **every agent, every origin** | **this file**, plus `conductor/AGENTS.md` and `conductor/CONTROL.md` |
+| Session notes | whoever is mid-task | `AI_README.md` |
+
+Coordination — task claiming, project kinds, roadmaps, PR/TALKBACK protocol, the security
+model, escalation — lives in the `conductor` repo's `AGENTS.md` and `CONTROL.md`. This file
+covers only what is true about *this codebase*. Don't restate coordination rules here.
+
+## Stack
+
+Nuxt 4, Vue 3, TypeScript (ES modules), Nitro/h3, Pinia, Tailwind + DaisyUI, Prisma,
+MariaDB. Deployed on Vercel.
+
+## Code conventions
+
+- `<script setup lang="ts">`, `computed`, `onMounted`. Components are auto-imported — don't
+  add explicit imports for them.
+- Avoid inline and template comments. Let naming carry the meaning.
+- Icons: `<icon name="kind-icon:[name]" class="..." />`
+- Styling: responsive Tailwind, flex/grid, borders, `rounded-2xl`, DaisyUI color tokens
+  rather than hard-coded colors.
+- Keep props and emits few. Shared state belongs in a Pinia store, not threaded through
+  component trees.
+- **Components never call APIs or localStorage directly.** Stores own API calls,
+  localStorage, and state. This is the rule most often broken by well-meaning edits — if a
+  component is reaching for `$fetch` or `localStorage`, the logic belongs in a store.
+- Async store actions check `success` before storing anything.
+- Server routes live under `server/api/`, one directory per model: `server/api/{model}/index.ts`
+  for collection routes, `{name}.{verb}.ts` for the rest (e.g. `art/enqueue.post.ts`,
+  `art/storefront-featured.get.ts`).
+- `errorHandler()` (`server/utils/error.ts`) returns `{ success, message, statusCode }`.
+  Route handlers funnel failures through it rather than throwing raw errors — it already
+  classifies Prisma, auth, and transient-database errors, and keeps 4xx out of Vercel's
+  error clusters.
+- Match the idiom of the file you're editing. Keep diffs small and reviewable.
+- When returning code in chat, return complete copy-paste-ready files or sections — never
+  placeholders or ellipses. In-repo, normal targeted edits are fine.
+
+## Database — standing rules from Silas (2026-07-02)
+
+The database holds real data.
+
+- **Never** run `prisma migrate reset`, or anything else that drops or recreates the
+  database. Resets happen only when Silas declares one explicitly in the session — never as
+  a convenience fix for drift or a failed migration.
+- **Never** rename or edit a migration that may have been applied anywhere (any dev machine
+  counts). Ship a new migration instead — e.g. `ALTER TABLE ... CHANGE COLUMN` — even for a
+  cosmetic rename.
+- To repair drift or a failed migration, prefer targeted, data-preserving steps:
+  `prisma db execute` for surgical SQL, fix `_prisma_migrations` bookkeeping, then
+  `prisma migrate resolve --applied <name>`. Explain what happened.
+- Prefer API writes over raw SQL when a route already exists.
+
+## Routes and surfaces
+
+Before adding a route, tab, page, or manager, inspect the Ecosystem Map and the relevant
+section docs. Prefer, in order:
+
+1. An existing stitched surface.
+2. An existing dashboard channel.
+3. WonderLab, if nothing fits.
+4. A new top-level channel — **only with Silas's approval.**
+
+Avoid duplicate or decorative routes, tabs, pages, and managers. A surface isn't finished
+when it renders: it may also need dashboard/tutorial registration, artwork,
+`liveUrl`/`channelKey`/`tabKey` set, Conductor sync, and direct-load, refresh, mobile,
+typecheck, and preview checks.
+
+## Art generation
+
+All generation runs through durable ArtJobs, normally `POST /api/art/enqueue`.
+
+    request → ArtJob → kr-relay → render → ArtImage → entity attach → delivery → final URL
+
+**Queued ≠ rendered ≠ delivered ≠ verified.** A request, a YAML entry, an HTTP 200, a queue
+row, and a `DONE` status are all upstream of a delivered asset. Check the final URL before
+calling it done.
+
+`kr-relay` owns durable rendering; browser polling is display-only. Preserve active and
+retryable jobs, reuse an ArtJob ID after a transient failure instead of enqueueing a
+duplicate, and pass exact repo/path/variant/dimensions/format/engine/entity metadata.
+
+## Shared behavior — audit siblings before you change one
+
+Much of this codebase has near-duplicate implementations of the same idea. When changing
+shared behavior, find the siblings first and prefer one shared implementation over another
+near-copy. Highest-risk areas:
+
+- maturity and resource filtering
+- LoRA and checkpoint handling
+- galleries
+- ArtJob routes and retry logic
+- entity art
+- navigation and tutorials
+- auth
+- project fields (`conductorSlug` is the join key to Conductor — see `CONTROL.md`)
+- stores
+- API contracts
+
+## Project identity
+
+Every Conductor project has a matching Kind Robots `Project` record, joined by
+`Project.conductorSlug`. The Conductor `roadmap.yaml` is the authoritative task record; the
+Kind Robots `Project` is the authoritative display/identity record. Don't add redundant FK
+fields and don't create a second source of project truth.
+
+## Verifying your work
+
+Typecheck, and run the tests that cover what you touched. Don't weaken, skip, or delete a
+legitimate test to manufacture a pass — fix the product, the test contract, the environment,
+or the workflow fault instead. If a check is red for reasons that predate your change, say
+so explicitly rather than quietly leaving it red.

--- a/AI_README.md
+++ b/AI_README.md
@@ -1,30 +1,14 @@
 # AI README for Kind Robots
 
-Last updated: 2026-06-23
+Last updated: 2026-07-31
 
-This file is a shared handoff note for future AI coding sessions helping Silas with Kind Robots.
+This file is the **session handoff note** — current focus, what's in flight, what the last
+session left behind. It goes stale on purpose.
 
-## Project conventions
-
-- Nuxt 4, Vue 3, TypeScript, Prisma, MariaDB.
-- Server routes live under `/server/api`.
-- Frontend state and data flow should go through Pinia stores.
-- Styling uses Tailwind and DaisyUI.
-- Prefer complete copy-pasteable code when requested.
-
-## Database migration rules (standing, from Silas 2026-07-02)
-
-- NEVER run `prisma migrate reset` or any command that drops/recreates the
-  database. The database contains real data. Resets happen only under specific
-  circumstances that Silas declares explicitly in the session — never as a
-  convenience fix for drift or a failed migration.
-- Never rename or edit a migration folder that may have been applied anywhere
-  (any dev machine counts). Ship a new migration instead (e.g.
-  `ALTER TABLE ... CHANGE COLUMN`), even for cosmetic renames.
-- To repair drift or a failed migration, prefer targeted, data-preserving
-  steps: `prisma db execute` for surgical SQL, fix `_prisma_migrations`
-  bookkeeping, then `prisma migrate resolve --applied <name>` — and explain
-  what happened.
+**The standing rules moved to [AGENTS.md](./AGENTS.md).** Read that first: stack, code
+conventions, database safety rules, routes/surfaces precedence, art pipeline, and the
+shared-behavior audit list. It applies to every agent regardless of origin and does not go
+stale. Don't restate its rules here — update them there.
 
 ## Current focus
 


### PR DESCRIPTION
Companion to silasfelinus/conductor#1471.

## Problem

Code conventions, database safety rules, routes/surfaces precedence, the art pipeline, and the shared-behavior audit list lived **only inside each agent's origin prompt** — ChatGPT's custom instructions and Claude's. Nothing in the repo held them, so:

- the two prompts could drift apart with no tiebreaker
- a new agent origin would start with none of them
- `AI_README.md` looked like it covered this ground but only carried four bullets and a stale todo list

## Change

`AGENTS.md` becomes the standing contract every agent reads before writing code here, regardless of origin, and authoritative over an origin prompt where they disagree. It covers stack, code conventions, database rules, routes/surfaces precedence, the ArtJob pipeline, the shared-behavior audit list, project identity, and verification expectations.

Coordination rules — task claiming, project kinds, security model, PR/TALKBACK protocol — stay in `conductor/AGENTS.md` and are referenced, not restated.

`AI_README.md` is reduced to what it actually is (a session handoff note) and points at `AGENTS.md` for the standing rules. Its database section moved rather than being dropped.

## Verified against the code, not transcribed from the prompt

- `errorHandler()` is `server/utils/error.ts:111` and does return `{ success, message, statusCode }`
- route layout is `server/api/{model}/index.ts` plus `{name}.{verb}.ts` (e.g. `art/enqueue.post.ts`)
- `POST /api/art/enqueue` exists
- Nuxt 4.4.8, Vue 3.5.13, Prisma 7.9.1, `@pinia/nuxt` 0.11.3 — corrected "Nuxt/Nitro" to Nuxt 4 explicitly
- `kind-icon:` icon naming confirmed in components

Docs-only; no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL1ZJB4oJVgWTdwbe5gYAP)_