### PR TITLE
build: pin the client target to es2020 instead of esnext

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -184,7 +184,7 @@ export default defineNuxtConfig({
       },
     },
     build: {
-      target: 'esnext',
+      target: 'es2020',
       minify: 'esbuild',
       chunkSizeWarningLimit: 500,
     },


### PR DESCRIPTION
One line in `nuxt.config.ts`. Re-done on a fresh branch off current `main` — the earlier attempt was stranded on the already-merged #1211 branch and never reached `main`, so `esnext` is still live today.

## What the setting does

`vite.build.target` tells the bundler **which vintage of JavaScript to assume visitors' browsers understand.**

`esnext` means *"assume the newest — convert nothing."* The risk is that syntax a browser cannot parse fails the **whole file** rather than degrading: a blank page with nothing running. That's the same shape as the startup bug that prompted this thread.

## Measured, not assumed

Built both ways on this exact base:

| target | entry chunk |
|---|---|
| `esnext` | 761,827 bytes |
| `es2020` | 762,800 bytes |

**+973 bytes (0.13%).** The output contains no post-ES2020 syntax either way — no `??=`, `||=`, `&&=`, or class static blocks. That's *why* the difference is noise: this codebase and its bundled dependencies already sit at ES2020, so the setting hasn't been doing anything in either direction.

## Why bother then

Cheap insurance, not a fix. If newer syntax lands here later it gets compiled down, instead of silently shipping something older engines cannot parse. Nothing about today's output meaningfully changes.

Note this covers *syntax*. The polyfill added earlier covers missing *methods* (`.at`, `Object.hasOwn`, etc.) — different mechanism, both now handled.

Reasonable to decline: 973 bytes for a hypothetical is a real trade, and if you'd rather keep `esnext` and revisit only if it bites, that's a defensible call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9HNdfh9HAYppqpW51BQBH)_