### PR TITLE
fix(model-builder): guard generateItemAsset against overwriting an approved candidate

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1030,6 +1030,24 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // run, where the candidate should still be saved.
       if (cancelledRunIds.has(runId)) return false
 
+      // generateItemAsset holds only its original item reference across the
+      // above awaits, same as pollAsyncArtJob (the async sibling). Two calls
+      // can be in flight for the same item (e.g. an item's own "Auto" button
+      // and a run-level "Auto-build all" both reaching this item concurrently
+      // -- generatingItemSingleton only guards a *different* owner overwriting
+      // this one, not two calls sharing the same item id). If the user already
+      // approved the earlier call's candidate while this one was still
+      // rendering, applying this render's image unconditionally would silently
+      // replace what was just approved, with no re-review. Mirrors
+      // pollAsyncArtJob's identical guard.
+      if (item.stages.GENERATE_ASSETS.status === 'approved') {
+        setStatus(
+          'error',
+          `${item.label} finished generating after its candidate was already approved — discarded to avoid silently replacing it.`,
+        )
+        return false
+      }
+
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null

--- a/utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderApprovedAssetGuard.test.ts
@@ -2,16 +2,18 @@
 //
 // Regression test for checkApprovedAssetGuard() in
 // verifyModelBuilderApprovedAssetGuard.ts (model-builder/t-029). Exercises
-// the real check against synthetic store-shaped fixtures covering: the
-// pre-fix shape (no `GENERATE_ASSETS.status === 'approved'` guard before the
-// artImageId write -- the exact bug found by manual read-through), and the
-// fixed shape (the guard checked and returned on between the result branch
-// and the write).
+// the real check against synthetic store-shaped fixtures covering both
+// pollAsyncArtJob and generateItemAsset: the pre-fix shape (no
+// `GENERATE_ASSETS.status === 'approved'` guard before the artImageId write
+// -- the exact bug found by manual read-through, present independently in
+// each function), and the fixed shape (the guard checked and returned on
+// between the result branch and the write).
 import assert from 'node:assert/strict'
 
 import { checkApprovedAssetGuard } from './verifyModelBuilderApprovedAssetGuard.js'
 
-const BUGGY_FIXTURE = `
+function pollAsyncArtJobBody(guarded: boolean): string {
+  return `
   async function pollAsyncArtJob(
     item: BuildItem,
     jobId: number,
@@ -45,60 +47,16 @@ const BUGGY_FIXTURE = `
         setStatus('error', item.error)
         return
       }
-
-      const image = result.data as { id: number; imagePath?: string | null }
-      item.artImageId = image.id
-      item.imagePath = image.imagePath ?? null
-      finishGenerateAssets(item, { status: 'ready' })
-
-      await recordArtifact(item, image, output, prompt, dims)
-      pushItem(item, { stageStatuses: item.stages, artImageId: item.artImageId })
-      setStatus('success', 'Generated a candidate.')
-      return
-    }
-  }
-`
-
-const FIXED_FIXTURE = `
-  async function pollAsyncArtJob(
-    item: BuildItem,
-    jobId: number,
-    generateData: GenerateArtData,
-    output: BuildOutputConfig | undefined,
-    prompt: string,
-    dims: { width: number; height: number },
-    runId: string,
-  ): Promise<void> {
-    const artStore = useArtStore()
-
-    while (item.artJobId === jobId) {
-      const job = await artStore.getArtJobStatus(jobId)
-      if (item.artJobId !== jobId) return
-
-      if (!job || job.status === 'PENDING') {
-        await new Promise((resolve) => setTimeout(resolve, 5000))
-        continue
-      }
-
-      item.artJobId = null
-      item.queueState = null
-
-      const result = await artStore.finalizeQueuedArtImage(job, generateData)
-
-      if (cancelledRunIds.has(runId)) return
-
-      if (!result.success || !result.data) {
-        item.error = result.message || 'failed'
-        finishGenerateAssets(item, { status: 'ready', note: item.error })
-        setStatus('error', item.error)
-        return
-      }
-
+      ${
+        guarded
+          ? `
       if (item.stages.GENERATE_ASSETS.status === 'approved') {
         setStatus('error', 'discarded to avoid silently replacing it')
         return
       }
-
+      `
+          : ''
+      }
       const image = result.data as { id: number; imagePath?: string | null }
       item.artImageId = image.id
       item.imagePath = image.imagePath ?? null
@@ -111,6 +69,53 @@ const FIXED_FIXTURE = `
     }
   }
 `
+}
+
+function generateItemAssetBody(guarded: boolean): string {
+  return `
+  async function generateItemAsset(itemId: string): Promise<boolean> {
+    const item = findItem(itemId)
+    if (!item || !state.run) return false
+    const runId = state.run.id
+    const artStore = useArtStore()
+
+    generatingItemSingleton.claim(item.id)
+    try {
+      const result = await artStore.generateCurrentArt({})
+
+      if (!result.success || !result.data) {
+        throw new Error(result.message || 'Generation failed.')
+      }
+
+      if (cancelledRunIds.has(runId)) return false
+      ${
+        guarded
+          ? `
+      if (item.stages.GENERATE_ASSETS.status === 'approved') {
+        setStatus('error', 'discarded to avoid silently replacing it')
+        return false
+      }
+      `
+          : ''
+      }
+      const image = result.data as { id: number; imagePath?: string | null }
+      item.artImageId = image.id
+      item.imagePath = image.imagePath ?? null
+      finishGenerateAssets(item, { status: 'ready' })
+
+      setStatus('success', \`Generated a candidate for \${item.label}.\`)
+      return true
+    } finally {
+      generatingItemSingleton.release(item.id)
+    }
+  }
+`
+}
+
+const BUGGY_FIXTURE = pollAsyncArtJobBody(false) + generateItemAssetBody(false)
+const FIXED_FIXTURE = pollAsyncArtJobBody(true) + generateItemAssetBody(true)
+const PARTIALLY_FIXED_FIXTURE =
+  pollAsyncArtJobBody(true) + generateItemAssetBody(false)
 
 const MISSING_FIXTURE = `
   function approveStage(itemId: string, stageKey: BuildStageKey): void {
@@ -123,14 +128,25 @@ const MISSING_FIXTURE = `
 const buggyErrors = checkApprovedAssetGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  1,
-  `expected the pre-fix shape (missing approved-stage guard) to raise 1 ` +
-    `error, got ${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+  2,
+  `expected the pre-fix shape (missing approved-stage guard in both ` +
+    `functions) to raise 2 errors, got ${buggyErrors.length}: ` +
+    `${JSON.stringify(buggyErrors)}`,
 )
 assert.ok(
-  buggyErrors[0]!.includes("GENERATE_ASSETS.status === 'approved'"),
-  'expected a violation naming the missing approved-stage guard',
+  buggyErrors.every((e) => e.includes("GENERATE_ASSETS.status === 'approved'")),
+  'expected both violations to name the missing approved-stage guard',
 )
+
+const partiallyFixedErrors = checkApprovedAssetGuard(PARTIALLY_FIXED_FIXTURE)
+assert.equal(
+  partiallyFixedErrors.length,
+  1,
+  `expected fixing only pollAsyncArtJob to leave 1 error (generateItemAsset ` +
+    `still unguarded), got ${partiallyFixedErrors.length}: ` +
+    `${JSON.stringify(partiallyFixedErrors)}`,
+)
+assert.ok(partiallyFixedErrors[0]!.includes('generateItemAsset'))
 
 const fixedErrors = checkApprovedAssetGuard(FIXED_FIXTURE)
 assert.equal(
@@ -142,13 +158,16 @@ assert.equal(
 const missingFnErrors = checkApprovedAssetGuard(MISSING_FIXTURE)
 assert.equal(
   missingFnErrors.length,
-  1,
-  'expected a single "function not found" violation when pollAsyncArtJob is absent',
+  2,
+  'expected a "function not found" violation for each of pollAsyncArtJob ' +
+    'and generateItemAsset when both are absent',
 )
-assert.ok(missingFnErrors[0]!.includes('pollAsyncArtJob'))
+assert.ok(missingFnErrors.some((e) => e.includes('pollAsyncArtJob')))
+assert.ok(missingFnErrors.some((e) => e.includes('generateItemAsset')))
 
 console.log(
   'Model Builder approved-asset guard checker verified: flags the pre-fix ' +
-    'shape (missing approved-stage guard before the artImageId write), ' +
-    'clears the fixed shape, and flags pollAsyncArtJob being absent entirely.',
+    'shape (missing approved-stage guard before the artImageId write) in ' +
+    'either function independently, clears the fixed shape, and flags ' +
+    'either function being absent entirely.',
 )

--- a/utils/scripts/verifyModelBuilderApprovedAssetGuard.ts
+++ b/utils/scripts/verifyModelBuilderApprovedAssetGuard.ts
@@ -23,13 +23,22 @@
 // alone on purpose -- that's the existing, intended way to flag "re-review
 // this candidate," and should still receive the image.
 //
-// This asserts the textual shape of that fix stays in place: pollAsyncArtJob
-// checks `item.stages.GENERATE_ASSETS.status === 'approved'` strictly
-// between the `if (!result.success` branch and the `item.artImageId =`
-// write that follows it in the same function body -- deliberately scoped to
-// this one function/bug, mirroring
-// verifyModelBuilderCancelledRunGuard.ts's preference for explicit, narrow
-// textual checks over a general-purpose static analyzer.
+// generateItemAsset (the synchronous sibling) had the identical gap: two
+// calls can be in flight for the same item id at once (an item's own "Auto"
+// button and a run-level "Auto-build all" both reaching the same item
+// concurrently -- generatingItemSingleton only guards a *different* owner
+// overwriting this one, not two calls sharing the same item id), so an
+// earlier-started call finishing after the user approved a sibling call's
+// candidate would silently overwrite it. Fixed with the exact same guard,
+// so this checker covers both functions.
+//
+// This asserts the textual shape of that fix stays in place in each function:
+// `item.stages.GENERATE_ASSETS.status === 'approved'` strictly between the
+// `if (!result.success` branch and the `item.artImageId =` write that
+// follows it in the same function body -- deliberately scoped to this one
+// bug shape, mirroring verifyModelBuilderCancelledRunGuard.ts's preference
+// for explicit, narrow textual checks over a general-purpose static
+// analyzer.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -41,61 +50,63 @@ const repositoryRoot = resolve(scriptDirectory, '../..')
 
 const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
 
-const FN_NAME = 'pollAsyncArtJob'
+const FN_NAMES = ['pollAsyncArtJob', 'generateItemAsset']
 const RESULT_BRANCH = 'if (!result.success'
 const IMAGE_WRITE = 'item.artImageId = image.id'
 const GUARD = "item.stages.GENERATE_ASSETS.status === 'approved'"
 
 // Checks the fix's exact shape against the full source text of a file
-// containing a `pollAsyncArtJob`-named async function. Exported (rather than
-// only exercised via main()) so the self-test below can run it against
-// synthetic buggy/fixed fixtures without touching the real store file.
+// containing `pollAsyncArtJob`/`generateItemAsset`-named async functions.
+// Exported (rather than only exercised via main()) so the self-test below
+// can run it against synthetic buggy/fixed fixtures without touching the
+// real store file.
 export function checkApprovedAssetGuard(content: string): string[] {
   const errors: string[] = []
-
   const functions = extractFunctionBodies(content)
-  const fn = functions.find((f) => f.name === FN_NAME)
-  if (!fn) {
-    errors.push(
-      `Could not find an async function named ${FN_NAME}() -- has it been ` +
-        'renamed, removed, or inlined? If so, this guard (and the bug it ' +
-        'protects against) needs to move with it.',
-    )
-    return errors
-  }
 
-  const resultBranchIndex = fn.body.indexOf(RESULT_BRANCH)
-  if (resultBranchIndex === -1) {
-    errors.push(
-      `${FN_NAME}() no longer branches on ${RESULT_BRANCH} -- this guard's ` +
-        'anchor point has moved.',
-    )
-    return errors
-  }
+  for (const fnName of FN_NAMES) {
+    const fn = functions.find((f) => f.name === fnName)
+    if (!fn) {
+      errors.push(
+        `Could not find an async function named ${fnName}() -- has it been ` +
+          'renamed, removed, or inlined? If so, this guard (and the bug it ' +
+          'protects against) needs to move with it.',
+      )
+      continue
+    }
 
-  const imageWriteIndex = fn.body.indexOf(IMAGE_WRITE, resultBranchIndex)
-  if (imageWriteIndex === -1) {
-    errors.push(
-      `${FN_NAME}() no longer writes \`${IMAGE_WRITE}\` after its ` +
-        `${RESULT_BRANCH} branch -- this guard's anchor point has moved; ` +
-        're-check where the finished render gets applied to the item.',
-    )
-    return errors
-  }
+    const resultBranchIndex = fn.body.indexOf(RESULT_BRANCH)
+    if (resultBranchIndex === -1) {
+      errors.push(
+        `${fnName}() no longer branches on ${RESULT_BRANCH} -- this guard's ` +
+          'anchor point has moved.',
+      )
+      continue
+    }
 
-  const guardIndex = fn.body.indexOf(GUARD, resultBranchIndex)
-  if (guardIndex === -1 || guardIndex >= imageWriteIndex) {
-    errors.push(
-      `${FN_NAME}() does not check \`${GUARD}\` between its ${RESULT_BRANCH} ` +
-        `branch and the ${IMAGE_WRITE} write. item.artJobId is cleared ` +
-        "before this function's own finalizeQueuedArtImage await, so the " +
-        "item panel's canApproveAssets can briefly return true on a " +
-        'regenerate (using the prior artImageId) while this render is still ' +
-        'finishing, letting a premature approve lock in the OLD image. ' +
-        'Without this check, the render that finishes afterward silently ' +
-        'overwrites the already-approved artImageId/imagePath with no ' +
-        're-review.',
-    )
+    const imageWriteIndex = fn.body.indexOf(IMAGE_WRITE, resultBranchIndex)
+    if (imageWriteIndex === -1) {
+      errors.push(
+        `${fnName}() no longer writes \`${IMAGE_WRITE}\` after its ` +
+          `${RESULT_BRANCH} branch -- this guard's anchor point has moved; ` +
+          're-check where the finished render gets applied to the item.',
+      )
+      continue
+    }
+
+    const guardIndex = fn.body.indexOf(GUARD, resultBranchIndex)
+    if (guardIndex === -1 || guardIndex >= imageWriteIndex) {
+      errors.push(
+        `${fnName}() does not check \`${GUARD}\` between its ${RESULT_BRANCH} ` +
+          `branch and the ${IMAGE_WRITE} write. Two calls can complete for ` +
+          'the same item (regenerate-while-queued for pollAsyncArtJob, or ' +
+          'two entry points reaching the same item concurrently for ' +
+          'generateItemAsset), so without this check a render that finishes ' +
+          'after the user already approved a sibling candidate silently ' +
+          'overwrites the already-approved artImageId/imagePath with no ' +
+          're-review.',
+      )
+    }
   }
 
   return errors
@@ -107,8 +118,7 @@ function main(): void {
 
   if (errors.length) {
     console.error(
-      'Model Builder approved-asset guard contract failed for ' +
-        `${FN_NAME}() in modelBuilderStore.ts:`,
+      'Model Builder approved-asset guard contract failed in modelBuilderStore.ts:',
     )
     for (const error of errors) console.error(`- ${error}`)
     process.exitCode = 1
@@ -116,9 +126,9 @@ function main(): void {
   }
 
   console.log(
-    `Model Builder approved-asset guard contract passed: ${FN_NAME}() ` +
-      'refuses to overwrite an already-approved candidate with a render ' +
-      'that finishes after the fact.',
+    'Model Builder approved-asset guard contract passed: ' +
+      `${FN_NAMES.map((n) => `${n}()`).join(' and ')} refuse to overwrite ` +
+      'an already-approved candidate with a render that finishes after the fact.',
   )
 }
 


### PR DESCRIPTION
### Task
conductor/model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `generateItemAsset()` (the synchronous "Generate candidate" art-render path) now checks `item.stages.GENERATE_ASSETS.status === 'approved'` immediately before writing `item.artImageId`/`item.imagePath`, discarding the finished render instead of silently applying it. This mirrors the identical guard `pollAsyncArtJob` (the async job-queue path) already has.
- `utils/scripts/verifyModelBuilderApprovedAssetGuard.ts` + `.test.ts`: extended the existing regression checker to assert the guard's textual shape in **both** `pollAsyncArtJob` and `generateItemAsset`, not just the former.

### Root cause
Two calls into `generateItemAsset` can be in flight for the same item concurrently — e.g. an item's own "Auto" button (`autoBuildItem`) and a run-level "Auto-build all" (`autoBuildRun`) both reaching the same item. `generatingItemSingleton` (the `createOwnedSingleton` claim/release pattern) only protects against a *different* owner value overwriting the current one; it does not — and by its own doc comment, cannot — detect two calls sharing the *identical* item id.

Concrete failure: call A starts rendering item X, then call B (from a different entry point) also starts rendering item X before A resolves. A resolves first, writes its image, and the user approves it via "Keep this asset." B then resolves afterward and — with no check on the stage's current status — unconditionally overwrote `artImageId`/`imagePath` with its own (different) image, leaving the "approved" badge showing while the underlying image had silently changed to something the user never reviewed.

### How I verified
- Read `generateItemAsset`, `pollAsyncArtJob`, `autoBuildItem`, `autoBuildRun`, and `batchAutoBuild` directly to confirm the concurrent-entry-point path is real and reachable through normal UI actions, not just a hypothetical.
- `npx eslint stores/modelBuilderStore.ts` — only the 2 pre-existing `no-empty` errors (lines 203/210), confirmed present on unmodified `main` via `git stash`.
- `npx prettier --check` — drift on `modelBuilderStore.ts` confirmed pre-existing via the same `git stash` comparison (consistent with every prior cycle's documented prettier-version-mismatch note).
- `npx vue-tsc --noEmit -p tsconfig.json` — exit 0, no errors.
- New/updated regression test (`verifyModelBuilderApprovedAssetGuard.test.ts`): flags the pre-fix shape independently in either function, a partially-fixed state (only one function guarded), the fixed shape (0 errors), and either function being absent entirely.
- `git status --porcelain` — exactly the 3 intended files touched.

### Stakes
reversible

### Kaizen suggestion
The three auto-build entry points (`autoBuildItem` via its own button, `batchAutoBuild`, `autoBuildRun`) have no reentrancy check against each other for the same item id — they rely on the singleton claim/release fields as if they were mutexes, but those only ever protected against *different*-owner overwrites. A real fix would give `autoBuildItem` an early-return guard (`if (state.generatingItemId === itemId || ...) return false`) so a second concurrent path skips an item already being processed, rather than launching a redundant render that this PR's fix now just discards on completion. Left for a future cycle since it's a broader behavioral change beyond this bug's immediate data-loss fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDF3EpyGLrwEtvyR22bR9B)_