### PR TITLE
Keep fading startup controls interactive

### DIFF
--- a/assets/css/startup-cover.css
+++ b/assets/css/startup-cover.css
@@ -25,11 +25,16 @@
  */
 html.kr-startup-fading .loading-overlay,
 html.kr-startup-fading .startup-animation__stage,
-html.kr-startup-fading .startup-animation__controls,
-html:has(.loading-overlay--fade) .startup-animation__stage,
-html:has(.loading-overlay--fade) .startup-animation__controls {
+html:has(.loading-overlay--fade) .startup-animation__stage {
   opacity: 0 !important;
   pointer-events: none !important;
+  transition: opacity 650ms ease !important;
+}
+
+html.kr-startup-fading .startup-animation__controls,
+html:has(.loading-overlay--fade) .startup-animation__controls {
+  opacity: 0.55 !important;
+  pointer-events: auto !important;
   transition: opacity 650ms ease !important;
 }
 

--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -116,6 +116,23 @@ function emitHiddenOnce() {
   emit('hidden')
 }
 
+function cancelFade() {
+  if (!fadeOverlay.value) return
+
+  if (fallbackFadeTimeoutId) {
+    clearTimeout(fallbackFadeTimeoutId)
+    fallbackFadeTimeoutId = null
+  }
+
+  hiddenEmitted.value = false
+  fadeOverlay.value = false
+  loadStore.resetRevealState()
+
+  if (import.meta.client) {
+    document.documentElement.classList.remove(FADING_CLASS)
+  }
+}
+
 function doFade() {
   if (destroyed || fadeOverlay.value) return
 
@@ -196,6 +213,7 @@ watch(
   (immersive) => {
     if (immersive) {
       clearFadeTimers()
+      cancelFade()
       return
     }
 

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -35,6 +35,7 @@
         'startup-animation__controls--compact': !startupStore.controlsActive,
         'startup-animation__controls--fading': isFading,
       }"
+      @pointerdown.capture="restoreFromFade"
     >
       <template v-if="startupStore.controlsActive">
         <span class="startup-animation__name">{{ displayEffectLabel }}</span>
@@ -233,6 +234,19 @@ function selectRandomEffect(): void {
   setEffect(pool[index] ?? ids[0] ?? null)
 }
 
+function restoreFromFade(): void {
+  if (!isFading.value) return
+
+  clearFadeTimer()
+  isFading.value = false
+
+  if (import.meta.client) {
+    document.documentElement.classList.remove('kr-startup-fading')
+  }
+
+  startupStore.enterControlMode()
+}
+
 function fadeOut(): void {
   if (!renderEffect.value || isFading.value) return
 
@@ -326,8 +340,8 @@ onBeforeUnmount(() => {
 
 .startup-animation__controls {
   position: fixed;
-  bottom: 1rem;
-  left: 1rem;
+  top: max(1rem, env(safe-area-inset-top, 0px));
+  right: 1rem;
   z-index: 60;
   display: flex;
   width: fit-content;
@@ -348,8 +362,8 @@ onBeforeUnmount(() => {
 }
 
 .startup-animation__controls--fading {
-  opacity: 0;
-  pointer-events: none;
+  opacity: 0.55;
+  pointer-events: auto;
 }
 
 .startup-animation__controls--compact {
@@ -400,12 +414,14 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 639px) {
-  .startup-animation__controls--active {
+  .startup-animation__controls {
+    top: max(0.75rem, env(safe-area-inset-top, 0px));
     right: 0.75rem;
-    bottom: 0.75rem;
-    left: 0.75rem;
-    justify-content: center;
     max-width: calc(100vw - 1.5rem);
+  }
+
+  .startup-animation__controls--active {
+    justify-content: flex-end;
   }
 
   .startup-animation__name {

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -191,6 +191,20 @@ assert.ok(
 )
 
 assert.ok(
+  /\.startup-animation__controls\s*\{[^}]*top:\s*max\(1rem, env\(safe-area-inset-top, 0px\)\);[^}]*right:\s*1rem;/s.test(startupAnimation),
+  'The animation controls must occupy the top-right corner, away from loading messages.',
+)
+
+assert.ok(
+  startupAnimation.includes('@pointerdown.capture="restoreFromFade"') &&
+    /\.startup-animation__controls--fading\s*\{[^}]*pointer-events:\s*auto;/s.test(startupAnimation) &&
+    startupCoverCss.includes('pointer-events: auto !important') &&
+    loadingMessages.includes('function cancelFade()') &&
+    loadingMessages.includes('hiddenEmitted.value = false'),
+  'A fading control panel must remain tappable and cancel pending startup cleanup when explore mode is restored.',
+)
+
+assert.ok(
   startupLaunch.includes('export function markAppReady') &&
     kindLoader.includes('markAppReady()'),
   'The app must signal readiness so the boot cover can retire early.',


### PR DESCRIPTION
## What changed

- Moves the startup animation control panel to the top-right on desktop and mobile.
- Keeps the panel on the pointer interaction plane while the rest of startup fades.
- Lets a tap during the fade cancel pending loader cleanup and restore full immersive animation mode.
- Adds startup contract assertions for placement and fade-time recovery.

## Root cause

The shared startup fade CSS applied `pointer-events: none !important` to the still-visible control panel. Taps therefore passed through to links on the hydrated site. The loader also retained a pending hidden callback, so restoring only the animation state would still have allowed the parent to unmount.

## Validation

GitHub Actions will run TypeScript, the Startup Handoff Contract, and the full contract suite on the final branch head.