### PR TITLE
fix(model-builder): block Auto from racing a manual action on the same item

### DIFF
--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -11,7 +11,7 @@
       <button
         type="button"
         class="btn btn-xs btn-ghost ml-auto gap-1 rounded-lg text-primary"
-        :disabled="isAutoBuilding"
+        :disabled="isAutoBuilding || isManualActionInFlight"
         title="Draft, generate, and commit this item automatically"
         @click="store.autoBuildItem(item.id)"
       >
@@ -362,6 +362,19 @@ function isDrafting(field: DraftField): boolean {
     store.draftingField?.field === field
   )
 }
+
+// A manual single-stage action already in flight for this item blocks Auto
+// too -- the store's autoBuildItem guard mirrors this, but the button must
+// disable in step or a click here is silently swallowed with no feedback.
+const isManualActionInFlight = computed(
+  () =>
+    isGenerating.value ||
+    isQueued.value ||
+    isCommitting.value ||
+    isDrafting('pitch') ||
+    isDrafting('fields') ||
+    isDrafting('artPrompt'),
+)
 
 function draft(field: DraftField): void {
   store.draftText(props.itemId, field)

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1374,6 +1374,20 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
 
     if (state.autoBuildingItemId === item.id) return false
 
+    // A manual single-stage action (Generate candidate / Draft with AI /
+    // Execute commit) already in flight for this item must block Auto too --
+    // otherwise Auto walks straight into the same stage and fires a second,
+    // concurrent request (generateItemAsset's own approved-stage guard only
+    // catches the case where the first call already resolved to approved; it
+    // does nothing while both calls are still racing mid-flight).
+    if (
+      state.generatingItemId === item.id ||
+      state.committingItemId === item.id ||
+      draftingField.value?.itemId === item.id
+    ) {
+      return false
+    }
+
     const isAsset = item.action === 'ASSET_ONLY'
     const wantArt = state.includeArt && item.generation === 'image'
 

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
@@ -57,6 +57,14 @@ const FIXED_FIXTURE = `
 
     if (state.autoBuildingItemId === item.id) return false
 
+    if (
+      state.generatingItemId === item.id ||
+      state.committingItemId === item.id ||
+      draftingField.value?.itemId === item.id
+    ) {
+      return false
+    }
+
     const isAsset = item.action === 'ASSET_ONLY'
     const wantArt = state.includeArt && item.generation === 'image'
 
@@ -111,10 +119,11 @@ const MISSING_FIXTURE = `
 const buggyErrors = checkAutoBuildDraftGate(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  4,
+  5,
   'expected the pre-fix shape (three discarded draftText results plus the ' +
-    'missing same-item reentrancy guard) to raise 4 errors, got ' +
-    `${buggyErrors.length}: ${JSON.stringify(buggyErrors)}`,
+    'missing same-item reentrancy guard plus the missing manual-action-in-' +
+    `flight guard) to raise 5 errors, got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
 )
 assert.ok(
   buggyErrors.some((e) => e.includes("'pitch'") && e.includes('discarded')),
@@ -131,6 +140,12 @@ assert.ok(
 assert.ok(
   buggyErrors.some((e) => e.includes('autoBuildingItemId')),
   'expected a violation for the missing same-item reentrancy guard',
+)
+assert.ok(
+  buggyErrors.some(
+    (e) => e.includes('generatingItemId') && e.includes('manual'),
+  ),
+  'expected a violation for the missing manual-action-in-flight guard',
 )
 
 const fixedErrors = checkAutoBuildDraftGate(FIXED_FIXTURE)
@@ -151,6 +166,30 @@ assert.equal(
   'expected exactly one violation when only the same-item reentrancy guard is missing',
 )
 assert.ok(reentrantErrors[0]!.includes('autoBuildingItemId'))
+
+const NO_MANUAL_GUARD_FIXTURE = FIXED_FIXTURE.replace(
+  `
+    if (
+      state.generatingItemId === item.id ||
+      state.committingItemId === item.id ||
+      draftingField.value?.itemId === item.id
+    ) {
+      return false
+    }
+`,
+  '',
+)
+const noManualGuardErrors = checkAutoBuildDraftGate(NO_MANUAL_GUARD_FIXTURE)
+assert.equal(
+  noManualGuardErrors.length,
+  1,
+  'expected exactly one violation when only the manual-action-in-flight guard is missing, got ' +
+    JSON.stringify(noManualGuardErrors),
+)
+assert.ok(
+  noManualGuardErrors[0]!.includes('generatingItemId') &&
+    noManualGuardErrors[0]!.includes('manual'),
+)
 
 const missingFnErrors = checkAutoBuildDraftGate(MISSING_FIXTURE)
 assert.equal(

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
@@ -28,6 +28,15 @@
 // deliberately scoped to this one function/bug, mirroring
 // verifyModelBuilderCompletionGate.ts's preference for explicit, narrow
 // textual checks over a general-purpose static analyzer.
+//
+// Also asserts a second, adjacent guard (same task, later cycle): before
+// claiming autoBuildingItemSingleton, autoBuildItem() must bail out if a
+// manual single-stage action (generatingItemId/committingItemId/
+// draftingField) is already in flight for this item. Without it, clicking
+// "Auto" while a manual "Generate candidate"/"Draft with AI"/"Execute
+// commit" click is still running fires a second, concurrent request for the
+// same stage -- the GENERATE_ASSETS case burns a real duplicate art
+// generation call, since neither call's in-flight state blocks the other.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -81,6 +90,27 @@ export function checkAutoBuildDraftGate(content: string): string[] {
         'that entry guard, the item-level Auto action can overlap with batch ' +
         'or run-level auto-build for the same item and duplicate draft, render, ' +
         'or commit work.',
+    )
+  }
+
+  const manualActionGuard =
+    /state\.generatingItemId\s*===\s*item\.id[\s\S]{0,200}state\.committingItemId\s*===\s*item\.id[\s\S]{0,200}draftingField\.value\?\.itemId\s*===\s*item\.id[\s\S]{0,80}return false/.exec(
+      fn.body,
+    )
+  if (
+    claimIndex < 0 ||
+    !manualActionGuard ||
+    manualActionGuard.index > claimIndex
+  ) {
+    errors.push(
+      `${FN_NAME}() must return false when a manual single-stage action ` +
+        '(state.generatingItemId, state.committingItemId, or ' +
+        "draftingField.value's itemId already matching item.id) is in " +
+        'flight for this item, before claiming autoBuildingItemSingleton. ' +
+        'Without that guard, clicking Auto while a manual "Generate ' +
+        'candidate" / "Draft with AI" / "Execute commit" is still running ' +
+        'fires a second, concurrent request for the same stage -- for ' +
+        'GENERATE_ASSETS this burns a real duplicate art-generation call.',
     )
   }
 


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: `autoBuildItem()` only guarded against overlapping *itself* (`state.autoBuildingItemId`). It never checked whether a manual single-stage action — Generate candidate, Draft with AI, or Execute commit — was already in flight for the same item. Added a guard (`generatingItemId`/`committingItemId`/`draftingField`) before the singleton claim, so Auto bails out instead of firing a second, concurrent request for a stage that's already mid-flight.
- `components/model-builder/model-builder-item-panel.vue`: the "Auto" button only disabled on `isAutoBuilding`, unlike every other button in the same panel. Added `isManualActionInFlight` (mirrors the store guard) to its `:disabled` so the UI stays in step with the new store behavior instead of silently swallowing the click.
- `utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts` / `.test.ts`: extended the existing textual regression checker (added in PR #1223 for the same-item reentrancy guard) to also assert this new guard's shape stays in place, with fixture coverage for buggy/fixed/guard-missing states.

### Failure scenario this closes
1. An item has PITCH/FIELDS_AND_PROMPTS approved, GENERATE_ASSETS ready.
2. User clicks "Generate candidate" — stage flips to in-progress, the manual button correctly disables, but "Auto" stays clickable.
3. User clicks "Auto" while the first render is still in flight — `autoBuildItem` sees GENERATE_ASSETS isn't `approved` yet and fires `generateItemAsset` a *second* time for the same item: a real duplicate call to the (paid) art-generation backend, both calls racing to write `artImageId`/`imagePath`.

The same shape applies to PITCH/FIELDS_AND_PROMPTS drafting and COMMIT, just lower-stakes than the art-generation case.

### How I verified
- `npx eslint` on all 4 changed files: clean (the store's 2 pre-existing `no-empty` errors confirmed unrelated via `git stash` diff).
- `npx prettier --check` on all 4 changed files: clean (pre-existing drift on the two non-utils files confirmed via `git stash`).
- `npx vue-tsc --noEmit -p tsconfig.json`: exit 0, full project.
- `npx tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts`: passes, including 3 new assertions for the added guard.
- `npx tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts`: passes against the real store file.
- Both are already wired into `.github/workflows/contract-tests.yml`.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The same in-flight-check gap likely exists on the *manual* side too (nothing stops clicking "Generate candidate" and "Draft with AI" back-to-back for a different stage — that's fine, different stages — but there's no cross-check preventing `batchAutoBuild`/`autoBuildRun` from racing a manual click on an item they're not currently processing yet). Worth a future pass specifically auditing `batchAutoBuild`/`autoBuildRun` against manual per-item actions, not just `autoBuildItem` against itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_018z4856VVDVV1gT8RkspQUm)_