### PR TITLE
fix(model-builder): distinguish skipped-vs-failed items in auto-build summaries

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1365,14 +1365,24 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.includeArt = typeof value === 'boolean' ? value : !state.includeArt
   }
 
+  // 'skipped' means auto-build never attempted the item this call because
+  // another in-flight action (itself or a manual single-stage action) owns
+  // it right now -- the item is still buildable, just not yet. 'failed'
+  // means auto-build attempted a stage and it did not succeed (or the item
+  // isn't eligible, e.g. asset-only with art off). Callers that tally
+  // progress across many items (autoBuildRun, batchAutoBuild) need this
+  // distinction so a busy-but-fine item doesn't read the same as a broken one.
+  type AutoBuildOutcome = 'committed' | 'skipped' | 'failed'
+
   // Run one item through every gate automatically with sensible defaults: draft
   // what's empty, generate art only when wanted, and commit. "Create directly"
-  // for CREATE/UPDATE items when art is off. Returns whether it committed.
-  async function autoBuildItem(itemId: string): Promise<boolean> {
+  // for CREATE/UPDATE items when art is off. Returns the outcome so batch/run
+  // callers can tell a busy skip apart from a real failure.
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
     const item = findItem(itemId)
-    if (!item || !state.run) return false
+    if (!item || !state.run) return 'failed'
 
-    if (state.autoBuildingItemId === item.id) return false
+    if (state.autoBuildingItemId === item.id) return 'skipped'
 
     // A manual single-stage action (Generate candidate / Draft with AI /
     // Execute commit) already in flight for this item must block Auto too --
@@ -1385,7 +1395,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       state.committingItemId === item.id ||
       draftingField.value?.itemId === item.id
     ) {
-      return false
+      return 'skipped'
     }
 
     const isAsset = item.action === 'ASSET_ONLY'
@@ -1397,7 +1407,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         'error',
         `${item.label} is asset-only — enable art to auto-build it.`,
       )
-      return false
+      return 'failed'
     }
 
     autoBuildingItemSingleton.claim(item.id)
@@ -1414,7 +1424,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           // impossible (`:disabled="isLocked('PITCH') || !pitch.trim()"`), so
           // auto-build must not produce a state the manual UI itself refuses.
           const drafted = await draftText(itemId, 'pitch')
-          if (!drafted) return false
+          if (!drafted) return 'failed'
         }
         approveStage(itemId, 'PITCH')
       }
@@ -1422,11 +1432,11 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
         if (!isAsset) {
           const drafted = await draftText(itemId, 'fields')
-          if (!drafted) return false
+          if (!drafted) return 'failed'
         }
         if (wantArt) {
           const drafted = await draftText(itemId, 'artPrompt')
-          if (!drafted) return false
+          if (!drafted) return 'failed'
         }
         approveStage(itemId, 'FIELDS_AND_PROMPTS')
       }
@@ -1434,15 +1444,15 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       if (item.stages.GENERATE_ASSETS.status !== 'approved') {
         if (wantArt) {
           const generated = await generateItemAsset(itemId)
-          if (!generated) return false
+          if (!generated) return 'failed'
         }
         approveStage(itemId, 'GENERATE_ASSETS')
       }
 
       if (item.stages.COMMIT.status !== 'approved') {
-        return await commitItem(itemId)
+        return (await commitItem(itemId)) ? 'committed' : 'failed'
       }
-      return true
+      return 'committed'
     } finally {
       autoBuildingItemSingleton.release(item.id)
     }
@@ -1467,6 +1477,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     const runId = state.run.id
     const items = [...state.run.items]
     let committed = 0
+    let skipped = 0
     try {
       for (const item of items) {
         if (state.run?.id !== runId) return
@@ -1474,13 +1485,17 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
           committed++
           continue
         }
-        const ok = await autoBuildItem(item.id)
-        if (ok) committed++
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
       }
       if (state.run?.id === runId) {
+        const skippedNote = skipped
+          ? ` (${skipped} skipped — manual action in progress, retry after it finishes)`
+          : ''
         setStatus(
           'success',
-          `Auto-build finished: ${committed}/${items.length} committed.`,
+          `Auto-build finished: ${committed}/${items.length} committed${skippedNote}.`,
         )
       }
     } finally {
@@ -1621,18 +1636,23 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     batchingOutputSingleton.claim(outputKey)
     clearStatus()
     let committed = 0
+    let skipped = 0
     try {
       for (const item of items) {
         if (item.stages.COMMIT.status === 'approved') {
           committed++
           continue
         }
-        const ok = await autoBuildItem(item.id)
-        if (ok) committed++
+        const outcome = await autoBuildItem(item.id)
+        if (outcome === 'committed') committed++
+        else if (outcome === 'skipped') skipped++
       }
+      const skippedNote = skipped
+        ? ` (${skipped} skipped — manual action in progress, retry after it finishes)`
+        : ''
       setStatus(
         'success',
-        `Auto-built ${committed}/${items.length} in this group.`,
+        `Auto-built ${committed}/${items.length} in this group${skippedNote}.`,
       )
     } finally {
       batchingOutputSingleton.release(outputKey)

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts
@@ -51,18 +51,18 @@ const BUGGY_FIXTURE = `
 `
 
 const FIXED_FIXTURE = `
-  async function autoBuildItem(itemId: string): Promise<boolean> {
+  async function autoBuildItem(itemId: string): Promise<AutoBuildOutcome> {
     const item = findItem(itemId)
-    if (!item || !state.run) return false
+    if (!item || !state.run) return 'failed'
 
-    if (state.autoBuildingItemId === item.id) return false
+    if (state.autoBuildingItemId === item.id) return 'skipped'
 
     if (
       state.generatingItemId === item.id ||
       state.committingItemId === item.id ||
       draftingField.value?.itemId === item.id
     ) {
-      return false
+      return 'skipped'
     }
 
     const isAsset = item.action === 'ASSET_ONLY'
@@ -73,7 +73,7 @@ const FIXED_FIXTURE = `
       if (item.stages.PITCH.status !== 'approved') {
         if (!item.pitch.trim()) {
           const drafted = await draftText(itemId, 'pitch')
-          if (!drafted) return false
+          if (!drafted) return 'failed'
         }
         approveStage(itemId, 'PITCH')
       }
@@ -81,11 +81,11 @@ const FIXED_FIXTURE = `
       if (item.stages.FIELDS_AND_PROMPTS.status !== 'approved') {
         if (!isAsset) {
           const drafted = await draftText(itemId, 'fields')
-          if (!drafted) return false
+          if (!drafted) return 'failed'
         }
         if (wantArt) {
           const drafted = await draftText(itemId, 'artPrompt')
-          if (!drafted) return false
+          if (!drafted) return 'failed'
         }
         approveStage(itemId, 'FIELDS_AND_PROMPTS')
       }
@@ -93,15 +93,15 @@ const FIXED_FIXTURE = `
       if (item.stages.GENERATE_ASSETS.status !== 'approved') {
         if (wantArt) {
           const generated = await generateItemAsset(itemId)
-          if (!generated) return false
+          if (!generated) return 'failed'
         }
         approveStage(itemId, 'GENERATE_ASSETS')
       }
 
       if (item.stages.COMMIT.status !== 'approved') {
-        return await commitItem(itemId)
+        return (await commitItem(itemId)) ? 'committed' : 'failed'
       }
-      return true
+      return 'committed'
     } finally {
       autoBuildingItemSingleton.release(item.id)
     }
@@ -156,7 +156,7 @@ assert.equal(
 )
 
 const REENTRANT_FIXTURE = FIXED_FIXTURE.replace(
-  '    if (state.autoBuildingItemId === item.id) return false\n\n',
+  "    if (state.autoBuildingItemId === item.id) return 'skipped'\n\n",
   '',
 )
 const reentrantErrors = checkAutoBuildDraftGate(REENTRANT_FIXTURE)
@@ -174,7 +174,7 @@ const NO_MANUAL_GUARD_FIXTURE = FIXED_FIXTURE.replace(
       state.committingItemId === item.id ||
       draftingField.value?.itemId === item.id
     ) {
-      return false
+      return 'skipped'
     }
 `,
   '',

--- a/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts
@@ -17,13 +17,13 @@
 // approval-while-drafting guard) -- just reached via a discarded return value
 // instead of a concurrency race. The GENERATE_ASSETS stage two lines below
 // already gets this right (`const generated = await generateItemAsset(itemId
-// ); if (!generated) return false`), which is exactly the shape this checker
-// requires for the PITCH and FIELDS_AND_PROMPTS drafts too.
+// ); if (!generated) return 'failed'`), which is exactly the shape this
+// checker requires for the PITCH and FIELDS_AND_PROMPTS drafts too.
 //
 // This asserts the textual shape of the fix stays in place: every
 // `await draftText(itemId, 'FIELD')` call inside autoBuildItem() is assigned
 // to a local (not a bare/discarded statement), and an `if (!VAR) return
-// false` guard on that same local appears strictly between the draftText
+// 'failed'` guard on that same local appears strictly between the draftText
 // call and the next call to approveStage() for that field's stage --
 // deliberately scoped to this one function/bug, mirroring
 // verifyModelBuilderCompletionGate.ts's preference for explicit, narrow
@@ -37,6 +37,9 @@
 // commit" click is still running fires a second, concurrent request for the
 // same stage -- the GENERATE_ASSETS case burns a real duplicate art
 // generation call, since neither call's in-flight state blocks the other.
+// Both of these entry guards return 'skipped' (not 'failed') -- t-037 gave
+// autoBuildItem() a three-way outcome ('committed' | 'skipped' | 'failed') so
+// batchAutoBuild/autoBuildRun can tell "busy, try again" apart from "broken."
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -76,7 +79,7 @@ export function checkAutoBuildDraftGate(content: string): string[] {
 
   const claimIndex = fn.body.indexOf('autoBuildingItemSingleton.claim(item.id)')
   const reentrancyGuard =
-    /if\s*\(\s*state\.autoBuildingItemId\s*===\s*item\.id\s*\)\s*return false/.exec(
+    /if\s*\(\s*state\.autoBuildingItemId\s*===\s*item\.id\s*\)\s*return 'skipped'/.exec(
       fn.body,
     )
   if (
@@ -85,16 +88,16 @@ export function checkAutoBuildDraftGate(content: string): string[] {
     reentrancyGuard.index > claimIndex
   ) {
     errors.push(
-      `${FN_NAME}() must return false when state.autoBuildingItemId already ` +
-        'equals item.id before claiming autoBuildingItemSingleton. Without ' +
-        'that entry guard, the item-level Auto action can overlap with batch ' +
-        'or run-level auto-build for the same item and duplicate draft, render, ' +
-        'or commit work.',
+      `${FN_NAME}() must return 'skipped' when state.autoBuildingItemId ` +
+        'already equals item.id before claiming autoBuildingItemSingleton. ' +
+        'Without that entry guard, the item-level Auto action can overlap ' +
+        'with batch or run-level auto-build for the same item and duplicate ' +
+        'draft, render, or commit work.',
     )
   }
 
   const manualActionGuard =
-    /state\.generatingItemId\s*===\s*item\.id[\s\S]{0,200}state\.committingItemId\s*===\s*item\.id[\s\S]{0,200}draftingField\.value\?\.itemId\s*===\s*item\.id[\s\S]{0,80}return false/.exec(
+    /state\.generatingItemId\s*===\s*item\.id[\s\S]{0,200}state\.committingItemId\s*===\s*item\.id[\s\S]{0,200}draftingField\.value\?\.itemId\s*===\s*item\.id[\s\S]{0,80}return 'skipped'/.exec(
       fn.body,
     )
   if (
@@ -103,14 +106,17 @@ export function checkAutoBuildDraftGate(content: string): string[] {
     manualActionGuard.index > claimIndex
   ) {
     errors.push(
-      `${FN_NAME}() must return false when a manual single-stage action ` +
+      `${FN_NAME}() must return 'skipped' when a manual single-stage action ` +
         '(state.generatingItemId, state.committingItemId, or ' +
         "draftingField.value's itemId already matching item.id) is in " +
         'flight for this item, before claiming autoBuildingItemSingleton. ' +
         'Without that guard, clicking Auto while a manual "Generate ' +
         'candidate" / "Draft with AI" / "Execute commit" is still running ' +
         'fires a second, concurrent request for the same stage -- for ' +
-        'GENERATE_ASSETS this burns a real duplicate art-generation call.',
+        'GENERATE_ASSETS this burns a real duplicate art-generation call. ' +
+        "Returning 'skipped' (not 'failed') here also matters for " +
+        'batchAutoBuild/autoBuildRun: it lets them report this item as busy ' +
+        'rather than broken.',
     )
   }
 
@@ -152,10 +158,10 @@ export function checkAutoBuildDraftGate(content: string): string[] {
     }
     const between = fn.body.slice(callEnd, callEnd + approveMatch.index)
 
-    const guardPattern = new RegExp(`if \\(!${varName}\\)\\s*return false`)
+    const guardPattern = new RegExp(`if \\(!${varName}\\)\\s*return 'failed'`)
     if (!guardPattern.test(between)) {
       errors.push(
-        `${FN_NAME}() does not check \`if (!${varName}) return false\` ` +
+        `${FN_NAME}() does not check \`if (!${varName}) return 'failed'\` ` +
           `between drafting '${field}' and approveStage(itemId, ` +
           `'${stageKey}'). Without this guard, a failed '${field}' draft ` +
           '(network error, "the model returned nothing useful", or an ' +


### PR DESCRIPTION
### Task
model-builder/t-037: Cross-check batchAutoBuild/autoBuildRun against a manual per-item action before processing that item (kind: software)

### What changed
- `autoBuildItem()` now returns a three-way outcome (`'committed' | 'skipped' | 'failed'`) instead of a boolean. The two entry guards added in #1223/#1224 (same-item reentrancy, manual-action-in-flight) now return `'skipped'`; a failed draft/generate/commit returns `'failed'`; completing (or already complete) returns `'committed'`.
- `batchAutoBuild` and `autoBuildRun` tally `skipped` separately from `committed`/`failed` and append a `(N skipped — manual action in progress, retry after it finishes)` note to their status message when nonzero, so a stalled batch item reads as "busy" instead of silently looking the same as a real failure.
- Extended `verifyModelBuilderAutoBuildDraftGate.ts`'s textual checks (and its self-test fixtures) to require the new `'skipped'`/`'failed'` return values at the same anchor points the prior `return false` checks used.

### How I verified
- `npx eslint stores/modelBuilderStore.ts utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts` — 2 pre-existing `no-empty` errors in the store, confirmed via `git stash` unrelated to this change; both new/touched files clean.
- `npx prettier --check` — same file shows pre-existing drift (confirmed via `git stash`) at unrelated lines; diffed `prettier`'s own reformat against the working tree and none of the drift falls inside the functions this PR touches.
- `npx vue-tsc --noEmit -p tsconfig.json` — clean, full project.
- `npm run test:model-builder-auto-build-draft-gate-selftest` and `npm run test:model-builder-auto-build-draft-gate` — both pass.

### Stakes
reversible

### Flags for Reviewer
- Scoped this to reporting the distinction, not auto-requeuing skipped items — the task note explicitly flagged requeue as optional/investigate, and requeuing from inside the same loop risks re-racing the same still-in-flight manual action if the loop reaches the item again too soon.

### Kaizen suggestion
The `isManualActionInFlight` computed in `model-builder-item-panel.vue` only gates the single-item Auto button; `batchAutoBuild`/`autoBuildRun`'s own triggering buttons (batch editor / progress matrix) have no equivalent "N items busy" indicator before the run starts, so a user only learns about a manual conflict from the after-the-fact skipped count. A pre-run advisory (not a hard block) could save a wasted auto-build pass.

### Notes for reviewer
Continues directly from model-builder/t-029 (PR #1224), merged just before this one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgdsqUfwhCxx8wzq2X4Q29)_