### PR TITLE
feat(model-builder): pre-run "N busy" advisory for batch/run auto-build triggers

### DIFF
--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -95,10 +95,14 @@
           type="button"
           class="btn btn-xs btn-primary rounded-lg"
           :disabled="batching"
+          :title="autoBuildGroupTitle"
           @click="store.batchAutoBuild(group.outputKey)"
         >
           <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
           Auto-build group
+          <span v-if="busyCount" class="badge badge-xs badge-ghost"
+            >{{ busyCount }} busy</span
+          >
         </button>
       </div>
     </section>
@@ -215,6 +219,23 @@ const wantArt = computed(
 )
 const fields = computed(() =>
   group.value ? fieldSpecFor(group.value.targetModel) : [],
+)
+
+// Pre-run advisory (t-038): how many items in this group are mid-manual-action
+// right now, so a click on "Auto-build group" doesn't surprise the user with a
+// lower-than-expected committed count -- those items will just be skipped.
+const busyCount = computed(
+  () =>
+    group.value?.items.filter((item) =>
+      store.isItemManualActionInFlight(item.id),
+    ).length ?? 0,
+)
+const autoBuildGroupTitle = computed(() =>
+  busyCount.value
+    ? `${busyCount.value} item${busyCount.value === 1 ? '' : 's'} in this group ` +
+      `${busyCount.value === 1 ? 'has' : 'have'} a manual action in progress ` +
+      'right now and will be skipped this pass -- retry after it finishes.'
+    : undefined,
 )
 
 const onlyEmpty = ref(false)

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -15,13 +15,16 @@
           type="button"
           class="btn btn-xs btn-primary rounded-xl"
           :disabled="store.autoBuilding"
-          title="Draft, generate, and commit every item automatically"
+          :title="autoBuildAllTitle"
           @click="store.autoBuildRun()"
         >
           <span v-if="store.autoBuilding" class="loading loading-dots loading-xs" />
           <template v-else>
             <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
             Auto-build all
+            <span v-if="busyCount" class="badge badge-xs badge-ghost"
+              >{{ busyCount }} busy</span
+            >
           </template>
         </button>
         <button
@@ -158,6 +161,23 @@ const stages = BUILD_STAGES
 const run = computed(() => store.run)
 const recipeLabel = computed(() =>
   run.value ? getRecipe(run.value.recipeKey)?.label : '',
+)
+
+// Pre-run advisory (t-038): how many items in the whole run are mid-manual-
+// action right now, so a click on "Auto-build all" doesn't surprise the user
+// with a lower-than-expected committed count -- those items will just be
+// skipped this pass.
+const busyCount = computed(
+  () =>
+    run.value?.items.filter((item) => store.isItemManualActionInFlight(item.id))
+      .length ?? 0,
+)
+const autoBuildAllTitle = computed(() =>
+  busyCount.value
+    ? `${busyCount.value} item${busyCount.value === 1 ? '' : 's'} in this run ` +
+      `${busyCount.value === 1 ? 'has' : 'have'} a manual action in progress ` +
+      'right now and will be skipped this pass -- retry after it finishes.'
+    : 'Draft, generate, and commit every item automatically',
 )
 
 // The source record we're building from — snapshot survives resume; fall back to

--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -1374,6 +1374,21 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
   // distinction so a busy-but-fine item doesn't read the same as a broken one.
   type AutoBuildOutcome = 'committed' | 'skipped' | 'failed'
 
+  // Mirrors model-builder-item-panel.vue's per-item isManualActionInFlight
+  // computed (generating / queued / committing / drafting any field) so a
+  // batch or run trigger can show the same "N busy" signal *before* starting
+  // — those items would otherwise just silently come back 'skipped' from
+  // autoBuildItem below, with no feedback until the run/batch finishes (t-038).
+  function isItemManualActionInFlight(itemId: string): boolean {
+    const item = findItem(itemId)
+    return (
+      state.generatingItemId === itemId ||
+      Boolean(item?.queueState) ||
+      state.committingItemId === itemId ||
+      draftingField.value?.itemId === itemId
+    )
+  }
+
   // Run one item through every gate automatically with sensible defaults: draft
   // what's empty, generate art only when wanted, and commit. "Create directly"
   // for CREATE/UPDATE items when art is off. Returns the outcome so batch/run
@@ -1847,6 +1862,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     previewCommit,
     commitItem,
     toggleIncludeArt,
+    isItemManualActionInFlight,
     autoBuildItem,
     autoBuildRun,
     batchDraftField,


### PR DESCRIPTION
### Task
conductor model-builder/t-038: pre-run "N items busy" advisory for batchAutoBuild/autoBuildRun before starting.

### What changed
- `stores/modelBuilderStore.ts`: added `isItemManualActionInFlight(itemId)`, promoting the exact per-item check `model-builder-item-panel.vue` already used locally (generating / queued / committing / drafting any field) into the store so other components can reuse it. Exported from the store.
- `components/model-builder/model-builder-batch-editor.vue`: "Auto-build group" button now shows a `busyCount` badge + dynamic tooltip when items in the group currently have a manual action in flight.
- `components/model-builder/model-builder-progress-matrix.vue`: "Auto-build all" button gets the same treatment across the whole run.

This is advisory only — never a hard block, since a manual action can resolve mid-run (matching the task's explicit ask). `autoBuildItem()`'s own runtime guard (in `autoBuildRun`/`batchAutoBuild`) is unchanged; this just gives the user the same signal *before* clicking that they'd otherwise only get from the skipped-count message *after* the run finishes.

### How I verified
- `npx vue-tsc --noEmit` — clean, no errors.
- `npx eslint stores/modelBuilderStore.ts components/model-builder/model-builder-batch-editor.vue components/model-builder/model-builder-progress-matrix.vue` — only 2 pre-existing, unrelated `no-empty` errors at `modelBuilderStore.ts:203,210` (confirmed present on `main` before this change via `git stash`).
- `npx prettier --check` on the 3 touched files, diffed against pre-change content line-by-line: `model-builder-batch-editor.vue` is now fully prettier-clean; `modelBuilderStore.ts`'s and `model-builder-progress-matrix.vue`'s remaining prettier diffs are all pre-existing lines this change never touched (verified none of my added lines appear in the diff).

### Stakes
reversible — front-end/store-only, no schema change, no new API calls.

### Notes
No local `nuxt dev` render check (this sandbox's `DATABASE_URL` points at an unreachable dummy host, so SSR never reaches page markup — documented sandbox limitation). Type-check + lint are the verification available here; happy to have this checked against a Vercel preview during review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RYCxMtxGF1Q6NusdPz9s9H)_