### PR TITLE
fix(model-builder): enforce stage-approval gate server-side on item PATCH

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "test:model-builder-draft-approval-guard": "tsx utils/scripts/verifyModelBuilderDraftApprovalGuard.ts",
     "test:model-builder-auto-build-draft-gate-selftest": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.test.ts",
     "test:model-builder-auto-build-draft-gate": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts",
+    "test:model-builder-item-patch-stage-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts",
+    "test:model-builder-item-patch-stage-guard": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -151,6 +151,37 @@ export type PreparedItemUpdate = {
   } | null
 }
 
+// A stage's content is only safe to overwrite while it is workable — ready,
+// stale, or rejected. Mirrors modelBuilderStore.ts's isStageEditable, which
+// the client uses to gate every content-editing call site (updatePitch/
+// updateFields/updatePrompt, batchSetField). That gate is client-side only:
+// this route trusted the client to have gotten there, so a direct PATCH (bad
+// client state, a retried/replayed request, or just curl) for an item whose
+// PITCH or FIELDS_AND_PROMPTS stage is already 'approved' (or still 'locked')
+// could silently overwrite reviewed content while its badge keeps showing
+// 'approved' — the same "review gate would be lying about what's actually
+// stored" outcome commit.post.ts's own stage-approval gate exists to prevent,
+// just reached through the item-edit route instead of the commit route.
+const CONTENT_STAGE_EDITABLE_STATUSES = new Set(['ready', 'stale', 'rejected'])
+
+function assertContentStageEditable(
+  stageStatuses: unknown,
+  stageKey: 'PITCH' | 'FIELDS_AND_PROMPTS',
+  fieldLabel: string,
+): void {
+  const stages = parseStoredJson<Record<string, { status?: string }>>(
+    stageStatuses,
+    {},
+  )
+  const status = stages[stageKey]?.status
+  if (status !== undefined && !CONTENT_STAGE_EDITABLE_STATUSES.has(status)) {
+    throw createError({
+      statusCode: 400,
+      message: `${fieldLabel} cannot be edited while its stage is ${status}. Reopen the stage first.`,
+    })
+  }
+}
+
 // Shared by the single-item and batch PATCH routes: validates/normalizes an
 // ItemPatchBody against an existing item and builds the Prisma update input
 // plus (when editable content changed) the revision-history entry to record
@@ -174,11 +205,26 @@ export function prepareItemUpdate(
     const stageStatuses = normalizeJson(body.stageStatuses)
     if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
   }
-  if (body.pitch !== undefined) data.pitch = normalizeText(body.pitch)
-  if (body.fieldsDraft !== undefined)
+  if (body.pitch !== undefined) {
+    assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
+    data.pitch = normalizeText(body.pitch)
+  }
+  if (body.fieldsDraft !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'FIELDS_AND_PROMPTS',
+      'Fields',
+    )
     data.fieldsDraft = normalizeText(body.fieldsDraft)
-  if (body.promptDraft !== undefined)
+  }
+  if (body.promptDraft !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'FIELDS_AND_PROMPTS',
+      'Prompt',
+    )
     data.promptDraft = normalizeText(body.promptDraft)
+  }
   const relationshipDraft = normalizeJson(body.relationshipDraft)
   if (relationshipDraft !== undefined)
     data.relationshipDraft = relationshipDraft

--- a/utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
@@ -1,0 +1,142 @@
+// /utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
+//
+// Regression test for checkItemPatchStageGuard() in
+// verifyModelBuilderItemPatchStageGuard.ts (model-builder/t-029). Exercises
+// the real check against synthetic route-shaped fixtures covering: the
+// pre-fix shape (no assertContentStageEditable calls -- the exact bug found
+// by manual read-through), the fixed shape (a guard call ahead of each
+// content-field assignment), a partially-fixed shape (only PITCH guarded),
+// and the function being absent entirely.
+import assert from 'node:assert/strict'
+
+import { checkItemPatchStageGuard } from './verifyModelBuilderItemPatchStageGuard.js'
+
+const BUGGY_FIXTURE = `
+export function prepareItemUpdate(
+  existing: Pick<ModelBuildItem, 'pitch' | 'fieldsDraft' | 'promptDraft' | 'stageStatuses' | 'relationshipDraft'>,
+  body: ItemPatchBody,
+  actor: string,
+): PreparedItemUpdate {
+  const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
+
+  if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
+    const stageStatuses = normalizeJson(body.stageStatuses)
+    if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
+  }
+  if (body.pitch !== undefined) data.pitch = normalizeText(body.pitch)
+  if (body.fieldsDraft !== undefined)
+    data.fieldsDraft = normalizeText(body.fieldsDraft)
+  if (body.promptDraft !== undefined)
+    data.promptDraft = normalizeText(body.promptDraft)
+
+  return { data, revision: null }
+}
+`
+
+const FIXED_FIXTURE = `
+export function prepareItemUpdate(
+  existing: Pick<ModelBuildItem, 'pitch' | 'fieldsDraft' | 'promptDraft' | 'stageStatuses' | 'relationshipDraft'>,
+  body: ItemPatchBody,
+  actor: string,
+): PreparedItemUpdate {
+  const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
+
+  if (body.stageStatuses !== undefined && body.stageStatuses !== null) {
+    const stageStatuses = normalizeJson(body.stageStatuses)
+    if (typeof stageStatuses === 'string') data.stageStatuses = stageStatuses
+  }
+  if (body.pitch !== undefined) {
+    assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
+    data.pitch = normalizeText(body.pitch)
+  }
+  if (body.fieldsDraft !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'FIELDS_AND_PROMPTS',
+      'Fields',
+    )
+    data.fieldsDraft = normalizeText(body.fieldsDraft)
+  }
+  if (body.promptDraft !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'FIELDS_AND_PROMPTS',
+      'Prompt',
+    )
+    data.promptDraft = normalizeText(body.promptDraft)
+  }
+
+  return { data, revision: null }
+}
+`
+
+const PARTIAL_FIXTURE = `
+export function prepareItemUpdate(
+  existing: Pick<ModelBuildItem, 'pitch' | 'fieldsDraft' | 'promptDraft' | 'stageStatuses' | 'relationshipDraft'>,
+  body: ItemPatchBody,
+  actor: string,
+): PreparedItemUpdate {
+  const data: Prisma.ModelBuildItemUncheckedUpdateInput = {}
+
+  if (body.pitch !== undefined) {
+    assertContentStageEditable(existing.stageStatuses, 'PITCH', 'Pitch')
+    data.pitch = normalizeText(body.pitch)
+  }
+  if (body.fieldsDraft !== undefined)
+    data.fieldsDraft = normalizeText(body.fieldsDraft)
+  if (body.promptDraft !== undefined)
+    data.promptDraft = normalizeText(body.promptDraft)
+
+  return { data, revision: null }
+}
+`
+
+const MISSING_FIXTURE = `
+export function getRunId(event: H3Event): number {
+  return 1
+}
+`
+
+const buggyErrors = checkItemPatchStageGuard(BUGGY_FIXTURE)
+assert.equal(
+  buggyErrors.length,
+  3,
+  `expected the pre-fix shape (no guard calls at all) to raise 3 errors ` +
+    `(pitch, fieldsDraft, promptDraft), got ${buggyErrors.length}: ` +
+    JSON.stringify(buggyErrors),
+)
+assert.ok(buggyErrors.some((e) => e.includes("'PITCH'")))
+assert.ok(buggyErrors.some((e) => e.includes('body.fieldsDraft')))
+assert.ok(buggyErrors.some((e) => e.includes('body.promptDraft')))
+
+const fixedErrors = checkItemPatchStageGuard(FIXED_FIXTURE)
+assert.equal(
+  fixedErrors.length,
+  0,
+  `expected the fixed shape to raise no errors, got: ${JSON.stringify(fixedErrors)}`,
+)
+
+const partialErrors = checkItemPatchStageGuard(PARTIAL_FIXTURE)
+assert.equal(
+  partialErrors.length,
+  2,
+  `expected the partially-fixed shape (PITCH guarded, FIELDS_AND_PROMPTS ` +
+    `not) to raise 2 errors, got ${partialErrors.length}: ` +
+    JSON.stringify(partialErrors),
+)
+assert.ok(partialErrors.every((e) => e.includes('FIELDS_AND_PROMPTS')))
+
+const missingFnErrors = checkItemPatchStageGuard(MISSING_FIXTURE)
+assert.equal(
+  missingFnErrors.length,
+  1,
+  'expected a single "function not found" violation when prepareItemUpdate is absent',
+)
+assert.ok(missingFnErrors[0]!.includes('prepareItemUpdate'))
+
+console.log(
+  'Model Builder item-patch stage guard checker verified: flags the pre-fix ' +
+    'shape (no server-side stage gate on content edits), a partially-fixed ' +
+    'shape (only PITCH guarded), clears the fully-fixed shape, and flags ' +
+    'prepareItemUpdate being absent entirely.',
+)

--- a/utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
+++ b/utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
@@ -1,0 +1,184 @@
+// /utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
+//
+// Regression guard (model-builder/t-029, kaizen) -- prepareItemUpdate() in
+// server/api/model-builder/runs/index.ts is the shared body behind both
+// items/[id].patch.ts and items/batch.patch.ts. modelBuilderStore.ts's
+// isStageEditable gate (ready/stale/rejected only) governs every content-
+// editing call site client-side -- updatePitch/updateFields/updatePrompt,
+// batchSetField -- but until this fix, prepareItemUpdate itself applied
+// body.pitch/body.fieldsDraft/body.promptDraft unconditionally, with no
+// check against the item's actual (server-stored) stage status. The client
+// UI never sends such a request while a stage is 'approved' (the textarea is
+// disabled), but this route trusted the client to have gotten there --
+// exactly the same "silently rewrites a canonical model" gap
+// items/[id]/commit.post.ts's own stage-approval gate exists to close for
+// the commit route (kind_robots PR #1139), just reached through the item-
+// edit route instead: a direct PATCH (bad client state, a retried/replayed
+// request, or curl) for an item whose PITCH or FIELDS_AND_PROMPTS stage is
+// already 'approved' (or still 'locked') could silently overwrite reviewed
+// content server-side while its badge kept showing 'approved' client-side --
+// no re-review, the review gate lying about what's actually stored.
+//
+// This asserts the textual shape of the fix stays in place: prepareItemUpdate
+// calls assertContentStageEditable(existing.stageStatuses, 'PITCH', ...)
+// before assigning data.pitch, and assertContentStageEditable(existing.
+// stageStatuses, 'FIELDS_AND_PROMPTS', ...) before assigning both
+// data.fieldsDraft and data.promptDraft -- deliberately scoped to this one
+// function/bug, mirroring verifyModelBuilderCommitCancelledRunGuard.ts's
+// preference for explicit, narrow textual checks over a general-purpose
+// static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/model-builder/runs/index.ts',
+)
+
+const FN_NAME = 'prepareItemUpdate'
+const GUARD_FN = 'assertContentStageEditable'
+
+interface GateCheck {
+  field: string
+  assignment: string
+  stageKey: string
+}
+
+const GATES: GateCheck[] = [
+  {
+    field: 'pitch',
+    assignment: 'data.pitch = normalizeText(body.pitch)',
+    stageKey: 'PITCH',
+  },
+  {
+    field: 'fieldsDraft',
+    assignment: 'data.fieldsDraft = normalizeText(body.fieldsDraft)',
+    stageKey: 'FIELDS_AND_PROMPTS',
+  },
+  {
+    field: 'promptDraft',
+    assignment: 'data.promptDraft = normalizeText(body.promptDraft)',
+    stageKey: 'FIELDS_AND_PROMPTS',
+  },
+]
+
+// Extracts the body of `export function prepareItemUpdate(...): PreparedItemUpdate {
+// ... }` via paren/brace matching -- this file's functions are top-level
+// `export function NAME(` (0-indent), a different shape than
+// modelBuilderStore.ts's 2-space-indented setup-function convention, so this
+// doesn't reuse verifyModelBuilderCompletionGate.ts's extractFunctionBodies.
+export function extractPrepareItemUpdateBody(content: string): string | null {
+  const signature = new RegExp(`export function ${FN_NAME}\\(`)
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const parenOpen = match.index + match[0].length - 1
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') {
+      parenDepth--
+      if (parenDepth === 0) break
+    }
+  }
+  if (parenDepth !== 0) return null
+
+  const braceOpen = content.indexOf('{', i)
+  if (braceOpen === -1) return null
+
+  let braceDepth = 0
+  let j = braceOpen
+  for (; j < content.length; j++) {
+    if (content[j] === '{') braceDepth++
+    else if (content[j] === '}') {
+      braceDepth--
+      if (braceDepth === 0) break
+    }
+  }
+  if (braceDepth !== 0) return null
+
+  return content.slice(braceOpen + 1, j)
+}
+
+// Checks the fix's exact shape against the full source text of a file
+// containing a `prepareItemUpdate`-named exported function. Exported (rather
+// than only exercised via main()) so the self-test below can run it against
+// synthetic buggy/fixed fixtures without touching the real route file.
+export function checkItemPatchStageGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const body = extractPrepareItemUpdateBody(content)
+  if (body === null) {
+    errors.push(
+      `Could not find an exported function named ${FN_NAME}() -- has it ` +
+        'been renamed, removed, or inlined? If so, this guard (and the bug ' +
+        'it protects against) needs to move with it.',
+    )
+    return errors
+  }
+
+  for (const { field, assignment, stageKey } of GATES) {
+    const assignmentIndex = body.indexOf(assignment)
+    if (assignmentIndex === -1) {
+      errors.push(
+        `${FN_NAME}() no longer contains \`${assignment}\` -- this guard's ` +
+          `anchor point has moved; re-check where body.${field} is applied ` +
+          'to the Prisma update input.',
+      )
+      continue
+    }
+
+    // Prettier may wrap a 3-arg call across multiple lines once it exceeds
+    // the line-length limit (which the FIELDS_AND_PROMPTS calls, with their
+    // longer stage-key literal, do) -- match tolerant of whitespace/newlines
+    // between arguments rather than requiring one contiguous line.
+    const guardPattern = new RegExp(
+      `${GUARD_FN}\\(\\s*existing\\.stageStatuses,\\s*'${stageKey}'`,
+    )
+    const guardMatch = guardPattern.exec(body)
+    const guardDisplay = `${GUARD_FN}(existing.stageStatuses, '${stageKey}', ...)`
+    if (!guardMatch || guardMatch.index >= assignmentIndex) {
+      errors.push(
+        `${FN_NAME}() does not call \`${guardDisplay}\` before \`${assignment}\`. ` +
+          `The client only ever sends body.${field} while '${stageKey}' is ` +
+          "ready/stale/rejected (modelBuilderStore.ts's isStageEditable " +
+          'gate), but that gate is client-side only -- without this ' +
+          `server-side check, a direct PATCH can silently overwrite an ` +
+          `already-'approved' (or still-'locked') stage's content while its ` +
+          'badge keeps showing the old status, with no re-review.',
+      )
+    }
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(ROUTE_PATH, 'utf8')
+  const errors = checkItemPatchStageGuard(content)
+
+  if (errors.length) {
+    console.error(
+      'Model Builder item-patch stage guard contract failed for ' +
+        `${FN_NAME}() in server/api/model-builder/runs/index.ts:`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Model Builder item-patch stage guard contract passed: ${FN_NAME}() ` +
+      'refuses to overwrite pitch/fieldsDraft/promptDraft while their stage ' +
+      "is not ready/stale/rejected, per the item's server-stored stage status.",
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Bug

`prepareItemUpdate()` in `server/api/model-builder/runs/index.ts` — the shared body behind both `items/[id].patch.ts` and `items/batch.patch.ts` — applied `body.pitch` / `body.fieldsDraft` / `body.promptDraft` unconditionally, with no check against the item's actual (server-stored) stage status.

`modelBuilderStore.ts`'s `isStageEditable` gate (ready/stale/rejected only) governs every content-editing call site client-side (`updatePitch`/`updateFields`/`updatePrompt`, `batchSetField`) and the item panel disables the textarea once a stage is approved — but that gate was **client-side only**. This route trusted the client to have gotten there, so a direct PATCH (bad client state, a retried/replayed request, or curl) for an item whose `PITCH` or `FIELDS_AND_PROMPTS` stage is already `'approved'` (or still `'locked'`) could silently overwrite reviewed content server-side, with the badge still showing `'approved'` client-side — no re-review. Same gap *class* as `commit.post.ts`'s own stage-approval gate (PR #1139: "server-side commit.post.ts didn't enforce stage-approval gate before writing"), just reached through the item-edit route instead of commit, which had never gotten the equivalent check.

## Fix

Added `assertContentStageEditable()` in `server/api/model-builder/runs/index.ts`, which parses the item's server-stored `stageStatuses` and throws a 400 unless the relevant stage (`PITCH` for pitch, `FIELDS_AND_PROMPTS` for fieldsDraft/promptDraft) is `ready`/`stale`/`rejected`. Called from `prepareItemUpdate()` right before each content field is assigned onto the Prisma update input — since both `items/[id].patch.ts` and `items/batch.patch.ts` route through this one shared helper, both routes are covered by the single fix.

Scope is narrow: only the three content fields (`pitch`, `fieldsDraft`, `promptDraft`) are gated; `stageStatuses`, `artImageId`, `targetType`/`targetId`, `error`, `staleReason`, `relationshipDraft` writes are untouched, since those are exactly the fields the client's own stage-transition functions (`approveStage`/`rejectStage`/`reopenStage`) legitimately write outside the content-editable window.

## New regression guard

Added `utils/scripts/verifyModelBuilderItemPatchStageGuard.ts` (+ `.test.ts` self-test), following this codebase's established narrow-textual-check convention for `utils/scripts/verifyModelBuilder*.ts` (mirrors `verifyModelBuilderCommitCancelledRunGuard.ts`). It asserts `prepareItemUpdate()` calls `assertContentStageEditable(existing.stageStatuses, 'PITCH', ...)` / `'FIELDS_AND_PROMPTS'` before each of the three content-field assignments, tolerant of Prettier's multi-line call wrapping. Wired into `package.json` as `test:model-builder-item-patch-stage-guard` and `-selftest`, matching the existing sibling scripts' naming.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts` — pass (flags pre-fix/partial shapes, clears the fixed shape, flags the function being absent)
- `npx tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.ts` — pass against the real fixed file
- All 6 pre-existing model-builder verify scripts + their selftests (link-coverage, completion-gate, cancelled-run-guard, approved-asset-guard, commit-cancelled-run-guard, draft-approval-guard, auto-build-draft-gate) — all still pass, confirming no regression
- `npx eslint server/api/model-builder/runs/index.ts utils/scripts/verifyModelBuilderItemPatchStageGuard.ts utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts` — clean, no output
- `npx prettier --check` on the same three files plus `package.json` — "All matched files use Prettier code style!"
- `npm run test` (full-project `vue-tsc --noEmit` typecheck via `tsconfig.json`) — exit code 0, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d7H1v2NmQhvGDcJMMVFFh

---
_Generated by [Claude Code](https://claude.ai/code/session_012d7H1v2NmQhvGDcJMMVFFh)_