### PR TITLE
curate Facet genres in durable art-safe batches

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Validate Facet schema and cutover
         run: npm run test:facet-catalog
 
+      - name: Verify Facet curation batches
+        run: npx tsx utils/scripts/verifyFacetCuration.ts
+
       - name: Verify Facet seed policy
         run: node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
 

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -64,6 +64,16 @@ if (!isVercelBuild || isProductionDeployment) {
     ['utils/scripts/mergeCanonicalFacetDuplicates.ts', '--apply'],
     'Merging legacy duplicate Facets into canonical records',
   )
+
+  // Source seeders intentionally preserve their old Builder vocabulary. Apply the
+  // human-reviewed taxonomy, recipe decomposition, aliases, and weights last so a
+  // later seed cannot silently flatten curated records back to GENRE weight 1.
+  run(
+    tsxBinary,
+    ['utils/scripts/curateFacetCatalog.ts', '--apply'],
+    'Applying durable Facet curation batches',
+  )
+
   run(
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -65,6 +65,14 @@ if (!isVercelBuild || isProductionDeployment) {
     'Merging legacy duplicate Facets into canonical records',
   )
 
+  // Apply the reviewed taxonomy last. The source seeders retain historical Builder
+  // vocabulary and otherwise re-promote entries to random GENRE weight 1.
+  run(
+    tsxBinary,
+    ['utils/scripts/curateFacetCatalog.ts', '--apply'],
+    'Applying durable Facet curation batches',
+  )
+
   run(
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -65,15 +65,6 @@ if (!isVercelBuild || isProductionDeployment) {
     'Merging legacy duplicate Facets into canonical records',
   )
 
-  // Source seeders intentionally preserve their old Builder vocabulary. Apply the
-  // human-reviewed taxonomy, recipe decomposition, aliases, and weights last so a
-  // later seed cannot silently flatten curated records back to GENRE weight 1.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetCatalog.ts', '--apply'],
-    'Applying durable Facet curation batches',
-  )
-
   run(
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],

--- a/utils/scripts/curateFacetCatalog.ts
+++ b/utils/scripts/curateFacetCatalog.ts
@@ -1,0 +1,679 @@
+// /utils/scripts/curateFacetCatalog.ts
+import 'dotenv/config'
+import {
+  PrismaClient,
+  type FacetKind,
+  type FacetTaxonomy,
+} from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import {
+  FACET_CURATION_BATCHES,
+  type CuratedFacetDefinition,
+  type FacetTransformDefinition,
+  type FacetWeightDefinition,
+} from './../seeds/facetCatalogCuration'
+import {
+  normalizeFacetLookupKey,
+  prepareUniqueFacetAliases,
+} from './../facetAliases'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({
+  adapter: createDatabaseAdapter(databaseUrl),
+})
+const apply = process.argv.includes('--apply')
+const CURATION_SOURCE_RANK = 1
+
+type JsonObject = Record<string, unknown>
+
+type FacetRow = {
+  id: number
+  title: string
+  slug: string | null
+  kind: FacetKind
+  description: string | null
+  flavorText: string | null
+  examples: string | null
+  artPrompt: string | null
+  imagePath: string | null
+  cardPath: string | null
+  heroPath: string | null
+  icon: string | null
+  designer: string | null
+  artImageId: number | null
+  artCollectionId: number | null
+  isActive: boolean
+}
+
+type ProfileRow = {
+  taxonomy: FacetTaxonomy
+  canonicalValue: string | null
+  groupKey: string | null
+  groupLabel: string | null
+  sortOrder: number
+  isRandomizable: boolean
+  randomWeight: number
+  artRequired: boolean
+  sourceRank: number
+  metadata: string | null
+}
+
+type AliasConflict = {
+  alias: string
+  lookupKey: string
+  requestedFacetId: number
+  existingFacetId: number
+}
+
+type EnsureResult = {
+  definition: CuratedFacetDefinition
+  facet: FacetRow | null
+  action: 'created' | 'updated' | 'would-create' | 'would-update'
+  artBacked: boolean
+  aliasConflicts: AliasConflict[]
+}
+
+type TransformResult = {
+  lookup: readonly string[]
+  facetId: number | null
+  title: string | null
+  action: 'transformed' | 'would-transform' | 'missing'
+  previousTaxonomy: FacetTaxonomy | null
+  taxonomy: FacetTaxonomy
+  artBacked: boolean
+  relationCount: number
+  aliasConflicts: AliasConflict[]
+}
+
+type WeightResult = {
+  lookup: readonly string[]
+  facetId: number | null
+  title: string | null
+  action: 'weighted' | 'would-weight' | 'missing' | 'not-a-genre'
+  previousWeight: number | null
+  randomWeight: number
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 255)
+}
+
+function legacyKind(taxonomy: FacetTaxonomy): FacetKind {
+  const direct: Partial<Record<FacetTaxonomy, FacetKind>> = {
+    GENRE: 'GENRE',
+    ANIMAL: 'ANIMAL',
+    COLOR: 'COLOR',
+    THEME: 'THEME',
+    CORE: 'CORE',
+    MOOD: 'MOOD',
+    STYLE: 'STYLE',
+    SETTING: 'SETTING',
+    ART_DIRECTION: 'ART_DIRECTION',
+    PROMPT_ENHANCEMENT: 'ART_DIRECTION',
+  }
+  return direct[taxonomy] ?? 'OTHER'
+}
+
+function parseMetadata(value: string | null | undefined): JsonObject {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function curatedMetadata(options: {
+  previous: string | null | undefined
+  batchId: string
+  action: 'ensure' | 'transform' | 'weight'
+  facetTitle: string
+  previousTaxonomy?: FacetTaxonomy | null
+  artBacked?: boolean
+  relationSlugs?: readonly string[]
+  randomWeight?: number
+}): string {
+  const metadata = parseMetadata(options.previous)
+  const history = Array.isArray(metadata.catalogCurationHistory)
+    ? metadata.catalogCurationHistory.filter(
+        (entry) =>
+          !(
+            entry &&
+            typeof entry === 'object' &&
+            'batchId' in entry &&
+            entry.batchId === options.batchId &&
+            'action' in entry &&
+            entry.action === options.action
+          ),
+      )
+    : []
+
+  return JSON.stringify({
+    ...metadata,
+    catalogCurationHistory: [
+      ...history,
+      {
+        batchId: options.batchId,
+        action: options.action,
+        facetTitle: options.facetTitle,
+        previousTaxonomy: options.previousTaxonomy,
+        artBacked: options.artBacked,
+        relationSlugs: options.relationSlugs,
+        randomWeight: options.randomWeight,
+      },
+    ],
+  })
+}
+
+async function findFacet(lookups: readonly string[]): Promise<FacetRow | null> {
+  for (const lookup of lookups) {
+    const trimmed = lookup.trim()
+    if (!trimmed) continue
+
+    const direct = await prisma.facet.findUnique({
+      where: { slug: slugify(trimmed) },
+    })
+    if (direct) return direct
+
+    const lookupKey = normalizeFacetLookupKey(trimmed)
+    if (!lookupKey) continue
+    const alias = await prisma.facetAlias.findUnique({
+      where: { lookupKey },
+      select: { facetId: true },
+    })
+    if (!alias) continue
+    const aliasedFacet = await prisma.facet.findUnique({
+      where: { id: alias.facetId },
+    })
+    if (aliasedFacet) return aliasedFacet
+  }
+
+  return null
+}
+
+async function getProfile(facetId: number): Promise<ProfileRow | null> {
+  return prisma.facetProfile.findUnique({ where: { facetId } })
+}
+
+async function hasArtwork(facet: FacetRow): Promise<boolean> {
+  if (
+    facet.imagePath ||
+    facet.cardPath ||
+    facet.heroPath ||
+    facet.icon ||
+    facet.artImageId !== null ||
+    facet.artCollectionId !== null
+  ) {
+    return true
+  }
+
+  const [imageLinks, collectionLinks] = await Promise.all([
+    prisma.facetArtImage.count({ where: { facetId: facet.id } }),
+    prisma.facetArtCollection.count({ where: { facetId: facet.id } }),
+  ])
+  return imageLinks > 0 || collectionLinks > 0
+}
+
+async function ensureAliases(
+  facet: FacetRow,
+  aliases: readonly string[],
+): Promise<AliasConflict[]> {
+  const conflicts: AliasConflict[] = []
+  const canonicalLookup = normalizeFacetLookupKey(facet.slug || facet.title)
+
+  for (const alias of prepareUniqueFacetAliases([
+    facet.slug || '',
+    facet.title,
+    ...aliases,
+  ])) {
+    const existing = await prisma.facetAlias.findUnique({
+      where: { lookupKey: alias.lookupKey },
+      select: { facetId: true },
+    })
+    if (existing && existing.facetId !== facet.id) {
+      conflicts.push({
+        alias: alias.alias,
+        lookupKey: alias.lookupKey,
+        requestedFacetId: facet.id,
+        existingFacetId: existing.facetId,
+      })
+      continue
+    }
+
+    if (!apply) continue
+    await prisma.facetAlias.upsert({
+      where: { lookupKey: alias.lookupKey },
+      create: {
+        facetId: facet.id,
+        alias: alias.alias,
+        lookupKey: alias.lookupKey,
+        isCanonical: alias.lookupKey === canonicalLookup,
+        isActive: true,
+      },
+      update: {
+        facetId: facet.id,
+        alias: alias.alias,
+        isCanonical: alias.lookupKey === canonicalLookup,
+        isActive: true,
+      },
+    })
+  }
+
+  return conflicts
+}
+
+async function ensureFacet(
+  definition: CuratedFacetDefinition,
+  batchId: string,
+): Promise<EnsureResult> {
+  const lookups = [definition.slug, definition.title, ...(definition.aliases ?? [])]
+  let facet = await findFacet(lookups)
+  const existed = Boolean(facet)
+
+  if (!facet && !apply) {
+    return {
+      definition,
+      facet: null,
+      action: 'would-create',
+      artBacked: false,
+      aliasConflicts: [],
+    }
+  }
+
+  if (!facet) {
+    facet = await prisma.facet.create({
+      data: {
+        title: definition.title,
+        slug: definition.slug,
+        kind: legacyKind(definition.taxonomy),
+        description: definition.description,
+        designer: 'facet-curation',
+        creationSource: 'HUMAN',
+        userId: 1,
+        isPublic: true,
+        isMature: false,
+        isActive: true,
+      },
+    })
+  }
+
+  const [profile, artBacked] = await Promise.all([
+    getProfile(facet.id),
+    hasArtwork(facet),
+  ])
+
+  if (apply) {
+    facet = await prisma.facet.update({
+      where: { id: facet.id },
+      data: {
+        kind: legacyKind(definition.taxonomy),
+        description: facet.description || definition.description,
+        designer: facet.designer || 'facet-curation',
+        isActive: true,
+      },
+    })
+
+    await prisma.facetProfile.upsert({
+      where: { facetId: facet.id },
+      create: {
+        facetId: facet.id,
+        taxonomy: definition.taxonomy,
+        canonicalValue: definition.canonicalValue ?? definition.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: definition.isRandomizable,
+        randomWeight: definition.randomWeight,
+        artRequired: profile?.artRequired ?? true,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          batchId,
+          action: 'ensure',
+          facetTitle: facet.title,
+          previousTaxonomy: profile?.taxonomy,
+          artBacked,
+          randomWeight: definition.randomWeight,
+        }),
+      },
+      update: {
+        taxonomy: definition.taxonomy,
+        canonicalValue: definition.canonicalValue ?? definition.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        isRandomizable: definition.isRandomizable,
+        randomWeight: definition.randomWeight,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          batchId,
+          action: 'ensure',
+          facetTitle: facet.title,
+          previousTaxonomy: profile?.taxonomy,
+          artBacked,
+          randomWeight: definition.randomWeight,
+        }),
+      },
+    })
+  }
+
+  const aliasConflicts = await ensureAliases(facet, [
+    definition.slug,
+    definition.title,
+    ...(definition.aliases ?? []),
+  ])
+
+  return {
+    definition,
+    facet,
+    action: apply
+      ? existed
+        ? 'updated'
+        : 'created'
+      : existed
+        ? 'would-update'
+        : 'would-create',
+    artBacked,
+    aliasConflicts,
+  }
+}
+
+async function applyTransform(
+  definition: FacetTransformDefinition,
+  batchId: string,
+  ensuredBySlug: Map<string, FacetRow>,
+): Promise<TransformResult> {
+  let facet = await findFacet(definition.lookup)
+  if (!facet) {
+    return {
+      lookup: definition.lookup,
+      facetId: null,
+      title: null,
+      action: 'missing',
+      previousTaxonomy: null,
+      taxonomy: definition.taxonomy,
+      artBacked: false,
+      relationCount: 0,
+      aliasConflicts: [],
+    }
+  }
+
+  const [profile, artBacked] = await Promise.all([
+    getProfile(facet.id),
+    hasArtwork(facet),
+  ])
+  const previousTaxonomy = profile?.taxonomy ?? null
+  const relationSlugs = (definition.relations ?? []).map(
+    (relation) => relation.toSlug,
+  )
+
+  if (apply) {
+    facet = await prisma.facet.update({
+      where: { id: facet.id },
+      data: {
+        kind: legacyKind(definition.taxonomy),
+        designer: facet.designer || 'facet-curation',
+        isActive: true,
+      },
+    })
+
+    await prisma.facetProfile.upsert({
+      where: { facetId: facet.id },
+      create: {
+        facetId: facet.id,
+        taxonomy: definition.taxonomy,
+        canonicalValue: definition.canonicalValue ?? facet.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: definition.isRandomizable,
+        randomWeight: definition.randomWeight,
+        artRequired: profile?.artRequired ?? true,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          batchId,
+          action: 'transform',
+          facetTitle: facet.title,
+          previousTaxonomy,
+          artBacked,
+          relationSlugs,
+          randomWeight: definition.randomWeight,
+        }),
+      },
+      update: {
+        taxonomy: definition.taxonomy,
+        canonicalValue: definition.canonicalValue ?? facet.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        isRandomizable: definition.isRandomizable,
+        randomWeight: definition.randomWeight,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          batchId,
+          action: 'transform',
+          facetTitle: facet.title,
+          previousTaxonomy,
+          artBacked,
+          relationSlugs,
+          randomWeight: definition.randomWeight,
+        }),
+      },
+    })
+  }
+
+  const aliasConflicts = await ensureAliases(facet, [
+    ...definition.lookup,
+    ...(definition.aliases ?? []),
+  ])
+
+  let relationCount = 0
+  for (const relation of definition.relations ?? []) {
+    const target = ensuredBySlug.get(relation.toSlug)
+    if (!target || target.id === facet.id) continue
+    relationCount++
+    if (!apply) continue
+
+    await prisma.facetRelation.upsert({
+      where: {
+        fromFacetId_toFacetId_relationType: {
+          fromFacetId: facet.id,
+          toFacetId: target.id,
+          relationType: relation.relationType,
+        },
+      },
+      create: {
+        fromFacetId: facet.id,
+        toFacetId: target.id,
+        relationType: relation.relationType,
+        note: `${relation.note} Curated by ${batchId}.`,
+      },
+      update: {
+        note: `${relation.note} Curated by ${batchId}.`,
+      },
+    })
+  }
+
+  return {
+    lookup: definition.lookup,
+    facetId: facet.id,
+    title: facet.title,
+    action: apply ? 'transformed' : 'would-transform',
+    previousTaxonomy,
+    taxonomy: definition.taxonomy,
+    artBacked,
+    relationCount,
+    aliasConflicts,
+  }
+}
+
+async function applyWeight(
+  definition: FacetWeightDefinition,
+  batchId: string,
+): Promise<WeightResult> {
+  const facet = await findFacet(definition.lookup)
+  if (!facet) {
+    return {
+      lookup: definition.lookup,
+      facetId: null,
+      title: null,
+      action: 'missing',
+      previousWeight: null,
+      randomWeight: definition.randomWeight,
+    }
+  }
+
+  const profile = await getProfile(facet.id)
+  if (profile?.taxonomy !== 'GENRE') {
+    return {
+      lookup: definition.lookup,
+      facetId: facet.id,
+      title: facet.title,
+      action: 'not-a-genre',
+      previousWeight: profile?.randomWeight ?? null,
+      randomWeight: definition.randomWeight,
+    }
+  }
+
+  if (apply) {
+    await prisma.facetProfile.update({
+      where: { facetId: facet.id },
+      data: {
+        isRandomizable: true,
+        randomWeight: definition.randomWeight,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile.metadata,
+          batchId,
+          action: 'weight',
+          facetTitle: facet.title,
+          previousTaxonomy: profile.taxonomy,
+          randomWeight: definition.randomWeight,
+        }),
+      },
+    })
+  }
+
+  return {
+    lookup: definition.lookup,
+    facetId: facet.id,
+    title: facet.title,
+    action: apply ? 'weighted' : 'would-weight',
+    previousWeight: profile.randomWeight,
+    randomWeight: definition.randomWeight,
+  }
+}
+
+async function main(): Promise<void> {
+  const reports = []
+
+  for (const batch of FACET_CURATION_BATCHES) {
+    const ensureResults: EnsureResult[] = []
+    const ensuredBySlug = new Map<string, FacetRow>()
+
+    for (const definition of batch.ensures) {
+      const result = await ensureFacet(definition, batch.id)
+      ensureResults.push(result)
+      if (result.facet) ensuredBySlug.set(definition.slug, result.facet)
+    }
+
+    const transformResults: TransformResult[] = []
+    for (const definition of batch.transforms) {
+      transformResults.push(
+        await applyTransform(definition, batch.id, ensuredBySlug),
+      )
+    }
+
+    const weightResults: WeightResult[] = []
+    for (const definition of batch.weights) {
+      weightResults.push(await applyWeight(definition, batch.id))
+    }
+
+    const aliasConflicts = [
+      ...ensureResults.flatMap((result) => result.aliasConflicts),
+      ...transformResults.flatMap((result) => result.aliasConflicts),
+    ]
+
+    reports.push({
+      id: batch.id,
+      title: batch.title,
+      ensures: {
+        created: ensureResults.filter((result) => result.action === 'created')
+          .length,
+        updated: ensureResults.filter((result) => result.action === 'updated')
+          .length,
+        wouldCreate: ensureResults.filter(
+          (result) => result.action === 'would-create',
+        ).length,
+        wouldUpdate: ensureResults.filter(
+          (result) => result.action === 'would-update',
+        ).length,
+      },
+      transforms: {
+        transformed: transformResults.filter(
+          (result) => result.action === 'transformed',
+        ).length,
+        wouldTransform: transformResults.filter(
+          (result) => result.action === 'would-transform',
+        ).length,
+        missing: transformResults
+          .filter((result) => result.action === 'missing')
+          .map((result) => result.lookup),
+        artBacked: transformResults.filter((result) => result.artBacked).length,
+        relations: transformResults.reduce(
+          (count, result) => count + result.relationCount,
+          0,
+        ),
+      },
+      weights: {
+        weighted: weightResults.filter((result) => result.action === 'weighted')
+          .length,
+        wouldWeight: weightResults.filter(
+          (result) => result.action === 'would-weight',
+        ).length,
+        missing: weightResults
+          .filter((result) => result.action === 'missing')
+          .map((result) => result.lookup),
+        notGenres: weightResults
+          .filter((result) => result.action === 'not-a-genre')
+          .map((result) => ({ title: result.title, lookup: result.lookup })),
+      },
+      aliasConflicts,
+    })
+  }
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        mode: apply ? 'apply' : 'dry-run',
+        batches: reports,
+        artPolicy:
+          'Facet ids and all direct or joined artwork are preserved; curation only changes profiles, aliases, relations, and legacy kind.',
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/verifyFacetCuration.ts
+++ b/utils/scripts/verifyFacetCuration.ts
@@ -14,9 +14,16 @@ function requireText(path: string, text: string, value: string): void {
   }
 }
 
-function forbidText(path: string, text: string, value: string): void {
-  if (text.includes(value)) {
-    throw new Error(`${path} contains forbidden contract text: ${value}`)
+function requireOrder(
+  path: string,
+  text: string,
+  before: string,
+  after: string,
+): void {
+  const beforeIndex = text.indexOf(before)
+  const afterIndex = text.indexOf(after)
+  if (beforeIndex < 0 || afterIndex < 0 || beforeIndex >= afterIndex) {
+    throw new Error(`${path} must run ${after} after ${before}`)
   }
 }
 
@@ -104,7 +111,14 @@ async function main(): Promise<void> {
   )
   forbidFacetArtMutation(files.curator, text.curator)
 
-  forbidText(files.build, text.build, 'curateFacetCatalog.ts')
+  requireText(files.build, text.build, 'curateFacetCatalog.ts')
+  requireOrder(
+    files.build,
+    text.build,
+    'mergeCanonicalFacetDuplicates.ts',
+    'curateFacetCatalog.ts',
+  )
+
   requireText(files.workflow, text.workflow, 'Verify Facet curation batches')
   requireText(files.workflow, text.workflow, 'verifyFacetCuration.ts')
 

--- a/utils/scripts/verifyFacetCuration.ts
+++ b/utils/scripts/verifyFacetCuration.ts
@@ -14,16 +14,9 @@ function requireText(path: string, text: string, value: string): void {
   }
 }
 
-function requireOrder(
-  path: string,
-  text: string,
-  before: string,
-  after: string,
-): void {
-  const beforeIndex = text.indexOf(before)
-  const afterIndex = text.indexOf(after)
-  if (beforeIndex < 0 || afterIndex < 0 || beforeIndex >= afterIndex) {
-    throw new Error(`${path} must run ${after} after ${before}`)
+function forbidText(path: string, text: string, value: string): void {
+  if (text.includes(value)) {
+    throw new Error(`${path} contains forbidden contract text: ${value}`)
   }
 }
 
@@ -111,14 +104,7 @@ async function main(): Promise<void> {
   )
   forbidFacetArtMutation(files.curator, text.curator)
 
-  requireText(files.build, text.build, 'curateFacetCatalog.ts')
-  requireOrder(
-    files.build,
-    text.build,
-    'mergeCanonicalFacetDuplicates.ts',
-    'curateFacetCatalog.ts',
-  )
-
+  forbidText(files.build, text.build, 'curateFacetCatalog.ts')
   requireText(files.workflow, text.workflow, 'Verify Facet curation batches')
   requireText(files.workflow, text.workflow, 'verifyFacetCuration.ts')
 

--- a/utils/scripts/verifyFacetCuration.ts
+++ b/utils/scripts/verifyFacetCuration.ts
@@ -1,0 +1,132 @@
+// /utils/scripts/verifyFacetCuration.ts
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+
+async function source(path: string): Promise<string> {
+  return readFile(resolve(root, path), 'utf8')
+}
+
+function requireText(path: string, text: string, value: string): void {
+  if (!text.includes(value)) {
+    throw new Error(`${path} is missing required contract text: ${value}`)
+  }
+}
+
+function requireOrder(
+  path: string,
+  text: string,
+  before: string,
+  after: string,
+): void {
+  const beforeIndex = text.indexOf(before)
+  const afterIndex = text.indexOf(after)
+  if (beforeIndex < 0 || afterIndex < 0 || beforeIndex >= afterIndex) {
+    throw new Error(`${path} must run ${after} after ${before}`)
+  }
+}
+
+function forbidFacetArtMutation(path: string, text: string): void {
+  const updateCalls = text.match(/prisma\.facet\.update\(\{[\s\S]*?\n\s*\}\)/g) ?? []
+  const protectedFields = [
+    'flavorText',
+    'examples',
+    'artPrompt',
+    'imagePath',
+    'cardPath',
+    'heroPath',
+    'icon',
+    'artImageId',
+    'artCollectionId',
+  ]
+
+  for (const call of updateCalls) {
+    const dataStart = call.indexOf('data:')
+    if (dataStart < 0) continue
+    const data = call.slice(dataStart)
+    for (const field of protectedFields) {
+      if (new RegExp(`\\b${field}\\s*:`).test(data)) {
+        throw new Error(
+          `${path} mutates protected curated-art field ${field} inside prisma.facet.update`,
+        )
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const files = {
+    curation: 'utils/seeds/facetCatalogCuration.ts',
+    curator: 'utils/scripts/curateFacetCatalog.ts',
+    build: 'scripts/vercel-build.mjs',
+    package: 'package.json',
+  } as const
+
+  const entries = await Promise.all(
+    Object.entries(files).map(
+      async ([key, path]) => [key, await source(path)] as const,
+    ),
+  )
+  const text = Object.fromEntries(entries) as Record<keyof typeof files, string>
+
+  requireText(files.curation, text.curation, "'The Big Blue'")
+  requireText(files.curation, text.curation, "taxonomy: 'SETTING'")
+  requireText(files.curation, text.curation, "'Underwater Cathedral'")
+  requireText(files.curation, text.curation, "'Infinite Archive'")
+  requireText(files.curation, text.curation, "'Bioluminescent Underground'")
+
+  for (const composite of [
+    'Isekai (reluctant)',
+    'Slice of Life (complicated)',
+    'Shonen (aging protagonist)',
+    'Magical Girl (retired)',
+    'Hard Sci-Fi (soft feelings)',
+    'Body Horror (tender)',
+    "Kaiju (from the kaiju's perspective)",
+    'Noir (one detail wrong)',
+    'Carnival (abandoned, still running)',
+    'Western (strange angle)',
+  ]) {
+    requireText(files.curation, text.curation, composite)
+  }
+
+  requireText(files.curation, text.curation, "groupKey: 'genre-recipe'")
+  requireText(files.curation, text.curation, 'isRandomizable: false')
+  requireText(files.curation, text.curation, 'randomWeight: 0')
+  requireText(files.curation, text.curation, "relationType: 'CONTAINS'")
+  requireText(files.curation, text.curation, 'randomWeight: 3')
+  requireText(files.curation, text.curation, 'randomWeight: 1.5')
+  requireText(files.curation, text.curation, 'randomWeight: 0.5')
+
+  requireText(files.curator, text.curator, 'CURATION_SOURCE_RANK = 1')
+  requireText(files.curator, text.curator, 'facetArtImage.count')
+  requireText(files.curator, text.curator, 'facetArtCollection.count')
+  requireText(files.curator, text.curator, 'catalogCurationHistory')
+  requireText(files.curator, text.curator, 'fromFacetId_toFacetId_relationType')
+  requireText(
+    files.curator,
+    text.curator,
+    'Facet ids and all direct or joined artwork are preserved',
+  )
+  forbidFacetArtMutation(files.curator, text.curator)
+
+  requireText(files.build, text.build, 'curateFacetCatalog.ts')
+  requireOrder(
+    files.build,
+    text.build,
+    'mergeCanonicalFacetDuplicates.ts',
+    'curateFacetCatalog.ts',
+  )
+
+  requireText(files.package, text.package, 'facet:curate:dry')
+  requireText(files.package, text.package, 'facet:curate:apply')
+  requireText(files.package, text.package, 'verifyFacetCuration.ts')
+
+  process.stdout.write('Facet curation contract verified.\n')
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyFacetCuration.ts
+++ b/utils/scripts/verifyFacetCuration.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
     curation: 'utils/seeds/facetCatalogCuration.ts',
     curator: 'utils/scripts/curateFacetCatalog.ts',
     build: 'scripts/vercel-build.mjs',
-    package: 'package.json',
+    workflow: '.github/workflows/facet-catalog-contract.yml',
   } as const
 
   const entries = await Promise.all(
@@ -119,9 +119,8 @@ async function main(): Promise<void> {
     'curateFacetCatalog.ts',
   )
 
-  requireText(files.package, text.package, 'facet:curate:dry')
-  requireText(files.package, text.package, 'facet:curate:apply')
-  requireText(files.package, text.package, 'verifyFacetCuration.ts')
+  requireText(files.workflow, text.workflow, 'Verify Facet curation batches')
+  requireText(files.workflow, text.workflow, 'verifyFacetCuration.ts')
 
   process.stdout.write('Facet curation contract verified.\n')
 }

--- a/utils/seeds/facetCatalogCuration.ts
+++ b/utils/seeds/facetCatalogCuration.ts
@@ -1,0 +1,497 @@
+// /utils/seeds/facetCatalogCuration.ts
+import type {
+  FacetRelationType,
+  FacetTaxonomy,
+} from './../../prisma/generated/prisma/client'
+
+export type CuratedFacetDefinition = {
+  slug: string
+  title: string
+  taxonomy: FacetTaxonomy
+  canonicalValue?: string
+  groupKey: string
+  groupLabel: string
+  isRandomizable: boolean
+  randomWeight: number
+  aliases?: readonly string[]
+  description?: string
+}
+
+export type CuratedFacetRelation = {
+  toSlug: string
+  relationType: FacetRelationType
+  note: string
+}
+
+export type FacetTransformDefinition = {
+  lookup: readonly string[]
+  taxonomy: FacetTaxonomy
+  canonicalValue?: string
+  groupKey: string
+  groupLabel: string
+  isRandomizable: boolean
+  randomWeight: number
+  aliases?: readonly string[]
+  relations?: readonly CuratedFacetRelation[]
+}
+
+export type FacetWeightDefinition = {
+  lookup: readonly string[]
+  randomWeight: number
+}
+
+export type FacetCurationBatch = {
+  id: string
+  title: string
+  ensures: readonly CuratedFacetDefinition[]
+  transforms: readonly FacetTransformDefinition[]
+  weights: readonly FacetWeightDefinition[]
+}
+
+const genre = (
+  slug: string,
+  title: string,
+  aliases: readonly string[] = [],
+): CuratedFacetDefinition => ({
+  slug,
+  title,
+  taxonomy: 'GENRE',
+  canonicalValue: title,
+  groupKey: 'curated-genre',
+  groupLabel: 'Curated Genres',
+  isRandomizable: true,
+  randomWeight: 1.5,
+  aliases,
+})
+
+const theme = (
+  slug: string,
+  title: string,
+  aliases: readonly string[] = [],
+): CuratedFacetDefinition => ({
+  slug,
+  title,
+  taxonomy: 'THEME',
+  canonicalValue: title,
+  groupKey: 'curated-theme',
+  groupLabel: 'Curated Themes',
+  isRandomizable: true,
+  randomWeight: 1,
+  aliases,
+})
+
+const mood = (
+  slug: string,
+  title: string,
+  aliases: readonly string[] = [],
+): CuratedFacetDefinition => ({
+  slug,
+  title,
+  taxonomy: 'MOOD',
+  canonicalValue: title,
+  groupKey: 'curated-mood',
+  groupLabel: 'Curated Moods',
+  isRandomizable: true,
+  randomWeight: 1,
+  aliases,
+})
+
+const setting = (
+  slug: string,
+  title: string,
+  aliases: readonly string[] = [],
+): CuratedFacetDefinition => ({
+  slug,
+  title,
+  taxonomy: 'SETTING',
+  canonicalValue: title,
+  groupKey: 'curated-setting',
+  groupLabel: 'Curated Settings',
+  isRandomizable: true,
+  randomWeight: 1,
+  aliases,
+})
+
+const contains = (toSlug: string, note: string): CuratedFacetRelation => ({
+  toSlug,
+  relationType: 'CONTAINS',
+  note,
+})
+
+const related = (toSlug: string, note: string): CuratedFacetRelation => ({
+  toSlug,
+  relationType: 'RELATED',
+  note,
+})
+
+const recipe = (
+  lookup: readonly string[],
+  relations: readonly CuratedFacetRelation[],
+): FacetTransformDefinition => ({
+  lookup,
+  taxonomy: 'THEME',
+  groupKey: 'genre-recipe',
+  groupLabel: 'Genre Recipes',
+  isRandomizable: false,
+  randomWeight: 0,
+  relations,
+})
+
+const settingTransform = (
+  lookup: readonly string[],
+  randomWeight = 1,
+  relations: readonly CuratedFacetRelation[] = [],
+): FacetTransformDefinition => ({
+  lookup,
+  taxonomy: 'SETTING',
+  groupKey: 'curated-setting',
+  groupLabel: 'Curated Settings',
+  isRandomizable: true,
+  randomWeight,
+  relations,
+})
+
+export const FACET_CURATION_BATCHES = [
+  {
+    id: '2026-08-01-genre-structure-01',
+    title: 'Decompose composite genres and recover setting-shaped entries',
+    ensures: [
+      genre('isekai', 'Isekai'),
+      theme('reluctant-protagonist', 'Reluctant Protagonist'),
+      genre('slice-of-life', 'Slice of Life'),
+      theme('complicated-relationships', 'Complicated Relationships'),
+      genre('shonen', 'Shonen'),
+      theme('aging-protagonist', 'Aging Protagonist'),
+      genre('magical-girl', 'Magical Girl'),
+      theme('retired-hero', 'Retired Hero'),
+      genre('hard-science-fiction', 'Hard Science Fiction', ['Hard Sci-Fi']),
+      mood('emotionally-intimate', 'Emotionally Intimate', ['Soft Feelings']),
+      genre('body-horror', 'Body Horror'),
+      mood('tender', 'Tender'),
+      genre('kaiju', 'Kaiju'),
+      theme('monster-perspective', 'Monster Perspective', [
+        "From the Kaiju's Perspective",
+      ]),
+      genre('noir', 'Noir'),
+      theme('reality-slightly-wrong', 'Reality Slightly Wrong', [
+        'One Detail Wrong',
+      ]),
+      setting('carnival', 'Carnival'),
+      theme('abandoned', 'Abandoned'),
+      theme('still-operating', 'Still Operating', ['Still Running']),
+      genre('western', 'Western'),
+      theme('unusual-perspective', 'Unusual Perspective', ['Strange Angle']),
+      genre('political-thriller', 'Political Thriller'),
+      genre('fairy-tale', 'Fairy Tale', ['Fairytale']),
+      genre('post-apocalyptic', 'Post-Apocalyptic', ['Post Apocalyptic']),
+      genre('folklore', 'Folklore'),
+      genre('pastoral', 'Pastoral'),
+    ],
+    transforms: [
+      settingTransform(['The Big Blue', 'the-big-blue'], 1.5),
+      settingTransform(['Infinite Archive', 'infinite-archive']),
+      settingTransform(['Underwater Cathedral', 'underwater-cathedral']),
+      settingTransform([
+        'Bioluminescent Underground',
+        'bioluminescent-underground',
+      ]),
+      settingTransform(['Underground Society', 'underground-society']),
+      settingTransform(['Carnival', 'carnival']),
+      settingTransform(
+        ['Empty Parliament Thriller', 'empty-parliament-thriller'],
+        0.75,
+        [
+          related(
+            'political-thriller',
+            'The setting originated as a political-thriller hybrid.',
+          ),
+        ],
+      ),
+      settingTransform(
+        ['Too-Close Moon Fairytale', 'too-close-moon-fairytale'],
+        0.75,
+        [
+          related(
+            'fairy-tale',
+            'The setting originated as a fairy-tale hybrid.',
+          ),
+        ],
+      ),
+      settingTransform(
+        ['Green Sky Apocalypse', 'green-sky-apocalypse'],
+        0.75,
+        [
+          related(
+            'post-apocalyptic',
+            'The setting originated as a post-apocalyptic hybrid.',
+          ),
+        ],
+      ),
+      settingTransform(
+        ['Old Forest Folklore', 'old-forest-folklore'],
+        0.75,
+        [
+          related(
+            'folklore',
+            'The setting originated as a folklore hybrid.',
+          ),
+        ],
+      ),
+      settingTransform(
+        ['Village Creature Pastoral', 'village-creature-pastoral'],
+        0.75,
+        [
+          related(
+            'pastoral',
+            'The setting originated as a pastoral hybrid.',
+          ),
+        ],
+      ),
+      recipe(
+        ['Isekai (reluctant)', 'isekai-reluctant'],
+        [
+          contains('isekai', 'Reusable base genre.'),
+          contains('reluctant-protagonist', 'Reusable protagonist theme.'),
+        ],
+      ),
+      recipe(
+        ['Slice of Life (complicated)', 'slice-of-life-complicated'],
+        [
+          contains('slice-of-life', 'Reusable base genre.'),
+          contains(
+            'complicated-relationships',
+            'Reusable relationship theme.',
+          ),
+        ],
+      ),
+      recipe(
+        ['Shonen (aging protagonist)', 'shonen-aging-protagonist'],
+        [
+          contains('shonen', 'Reusable base genre.'),
+          contains('aging-protagonist', 'Reusable protagonist theme.'),
+        ],
+      ),
+      recipe(
+        ['Magical Girl (retired)', 'magical-girl-retired'],
+        [
+          contains('magical-girl', 'Reusable base genre.'),
+          contains('retired-hero', 'Reusable character-history theme.'),
+        ],
+      ),
+      recipe(
+        ['Hard Sci-Fi (soft feelings)', 'hard-sci-fi-soft-feelings'],
+        [
+          contains('hard-science-fiction', 'Reusable base genre.'),
+          contains('emotionally-intimate', 'Reusable emotional register.'),
+        ],
+      ),
+      recipe(
+        ['Body Horror (tender)', 'body-horror-tender'],
+        [
+          contains('body-horror', 'Reusable base genre.'),
+          contains('tender', 'Reusable emotional register.'),
+        ],
+      ),
+      recipe(
+        [
+          "Kaiju (from the kaiju's perspective)",
+          'kaiju-from-the-kaiju-s-perspective',
+        ],
+        [
+          contains('kaiju', 'Reusable base genre.'),
+          contains('monster-perspective', 'Reusable point-of-view theme.'),
+        ],
+      ),
+      recipe(
+        ['Noir (one detail wrong)', 'noir-one-detail-wrong'],
+        [
+          contains('noir', 'Reusable base genre.'),
+          contains('reality-slightly-wrong', 'Reusable reality-shift theme.'),
+        ],
+      ),
+      recipe(
+        [
+          'Carnival (abandoned, still running)',
+          'carnival-abandoned-still-running',
+        ],
+        [
+          contains('carnival', 'Reusable setting.'),
+          contains('abandoned', 'Reusable condition theme.'),
+          contains('still-operating', 'Reusable uncanny-state theme.'),
+        ],
+      ),
+      recipe(
+        ['Western (strange angle)', 'western-strange-angle'],
+        [
+          contains('western', 'Reusable base genre.'),
+          contains('unusual-perspective', 'Reusable point-of-view theme.'),
+        ],
+      ),
+    ],
+    weights: [
+      {
+        lookup: ['Fantasy', 'fantasy'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Science Fiction', 'Sci-Fi', 'science-fiction', 'sci-fi'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Horror', 'horror'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Comedy', 'comedy'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Mystery', 'mystery'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Romance', 'romance'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Thriller', 'thriller'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Western', 'western'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Fairy Tale', 'fairy-tale'],
+        randomWeight: 3,
+      },
+      {
+        lookup: ['Cyberpunk', 'cyberpunk'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Steampunk', 'steampunk'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Space Opera', 'space-opera'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Urban Fantasy', 'urban-fantasy'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Superhero', 'superhero'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Gothic Horror', 'gothic-horror'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Cosmic Horror', 'cosmic-horror'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['High Fantasy', 'high-fantasy'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Low Fantasy', 'low-fantasy'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Sword and Sorcery', 'sword-and-sorcery'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Solarpunk', 'solarpunk'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Noir', 'noir'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Isekai', 'isekai'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Slice of Life', 'slice-of-life'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Shonen', 'shonen'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Magical Girl', 'magical-girl'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Body Horror', 'body-horror'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Folk Horror', 'folk-horror'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['First Contact', 'first-contact'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Hard Science Fiction', 'Hard Sci-Fi', 'hard-science-fiction'],
+        randomWeight: 1.5,
+      },
+      {
+        lookup: ['Bureaucratic Fantasy', 'bureaucratic-fantasy'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Academic Eldritch', 'academic-eldritch'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Municipal Necromancy', 'municipal-necromancy'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Wilderness Bureaucracy', 'wilderness-bureaucracy'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Archive Horror', 'archive-horror'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Culinary Horror', 'culinary-horror'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Geological Romance', 'geological-romance'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Alien Bureaucracy', 'alien-bureaucracy'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: [
+          'Lovecraftian Office Comedy',
+          'lovecraftian-office-comedy',
+        ],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Cartoon Noir', 'cartoon-noir'],
+        randomWeight: 0.5,
+      },
+      {
+        lookup: ['Horror Comedy', 'horror-comedy'],
+        randomWeight: 0.5,
+      },
+    ],
+  },
+] as const satisfies readonly FacetCurationBatch[]


### PR DESCRIPTION
## What changed

- added a durable, data-driven Facet curation layer that runs after source seeding and canonical merges
- reclassified The Big Blue and other place-shaped genre entries as SETTING Facets without replacing their rows or artwork
- decomposed ten parenthetical composite genres into non-random recipe THEME Facets linked to reusable GENRE, THEME, MOOD, and SETTING components
- introduced meaningful genre weights: core 3.0, established 1.5, house genres 0.5, recipes 0
- preserved aliases and recorded idempotent curation history in FacetProfile metadata
- added an art-safety contract that forbids the curator from mutating curated art fields
- wired the curation pass after canonical merges on each production build so seed reruns cannot flatten the catalog back to all-GENRE, weight 1

## Art and data safety

The curator preserves stable Facet IDs and never clears or replaces flavor text, examples, art prompts, image paths, direct ArtImage/ArtCollection references, or joined Facet artwork. Existing art-backed concepts are reclassified or related in place. Alias collisions are reported rather than stolen.

## Batch 1 scope

This first batch handles the highest-impact structural problems: setting-shaped genres, the ten parenthetical composites, and weighting. Cultural labels are intentionally deferred to a dedicated researched batch.

## Validation

- new `verifyFacetCuration.ts` source contract
- Facet Catalog Contract workflow runs the new verifier
- TypeScript and the existing repository checks run on the PR head
