### PR TITLE
fix(model-builder): gate artImageId PATCH behind GENERATE_ASSETS stage status

### DIFF
--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -162,11 +162,22 @@ export type PreparedItemUpdate = {
 // 'approved' — the same "review gate would be lying about what's actually
 // stored" outcome commit.post.ts's own stage-approval gate exists to prevent,
 // just reached through the item-edit route instead of the commit route.
+//
+// The same gap existed for artImageId against GENERATE_ASSETS: the store's
+// own generateItemAsset/pollAsyncArtJob already refuse to overwrite an
+// approved candidate mid-flight (verifyModelBuilderApprovedAssetGuard.ts),
+// but that guard lives entirely client-side too, and this route applied
+// body.artImageId unconditionally regardless of the item's actual
+// GENERATE_ASSETS status. A direct PATCH for an item whose GENERATE_ASSETS
+// is already 'approved' could silently repoint the item at a different
+// ArtImage (any the caller may attach per assertArtImageAttachable — their
+// own or public) with no re-review, while the stage badge kept showing
+// 'approved' for the old, actually-reviewed image.
 const CONTENT_STAGE_EDITABLE_STATUSES = new Set(['ready', 'stale', 'rejected'])
 
 function assertContentStageEditable(
   stageStatuses: unknown,
-  stageKey: 'PITCH' | 'FIELDS_AND_PROMPTS',
+  stageKey: 'PITCH' | 'FIELDS_AND_PROMPTS' | 'GENERATE_ASSETS',
   fieldLabel: string,
 ): void {
   const stages = parseStoredJson<Record<string, { status?: string }>>(
@@ -231,8 +242,14 @@ export function prepareItemUpdate(
   if (body.staleReason !== undefined)
     data.staleReason = normalizeText(body.staleReason)
   if (body.error !== undefined) data.error = normalizeText(body.error)
-  if (body.artImageId !== undefined)
+  if (body.artImageId !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'GENERATE_ASSETS',
+      'Art image',
+    )
     data.artImageId = normalizeNullableId(body.artImageId)
+  }
   if (body.targetType !== undefined)
     data.targetType = normalizeText(body.targetType)
   if (body.targetId !== undefined)

--- a/utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts
@@ -5,8 +5,9 @@
 // the real check against synthetic route-shaped fixtures covering: the
 // pre-fix shape (no assertContentStageEditable calls -- the exact bug found
 // by manual read-through), the fixed shape (a guard call ahead of each
-// content-field assignment), a partially-fixed shape (only PITCH guarded),
-// and the function being absent entirely.
+// content-field assignment, including artImageId/GENERATE_ASSETS), a
+// partially-fixed shape (only PITCH guarded), and the function being absent
+// entirely.
 import assert from 'node:assert/strict'
 
 import { checkItemPatchStageGuard } from './verifyModelBuilderItemPatchStageGuard.js'
@@ -28,6 +29,8 @@ export function prepareItemUpdate(
     data.fieldsDraft = normalizeText(body.fieldsDraft)
   if (body.promptDraft !== undefined)
     data.promptDraft = normalizeText(body.promptDraft)
+  if (body.artImageId !== undefined)
+    data.artImageId = normalizeNullableId(body.artImageId)
 
   return { data, revision: null }
 }
@@ -65,6 +68,14 @@ export function prepareItemUpdate(
     )
     data.promptDraft = normalizeText(body.promptDraft)
   }
+  if (body.artImageId !== undefined) {
+    assertContentStageEditable(
+      existing.stageStatuses,
+      'GENERATE_ASSETS',
+      'Art image',
+    )
+    data.artImageId = normalizeNullableId(body.artImageId)
+  }
 
   return { data, revision: null }
 }
@@ -86,6 +97,8 @@ export function prepareItemUpdate(
     data.fieldsDraft = normalizeText(body.fieldsDraft)
   if (body.promptDraft !== undefined)
     data.promptDraft = normalizeText(body.promptDraft)
+  if (body.artImageId !== undefined)
+    data.artImageId = normalizeNullableId(body.artImageId)
 
   return { data, revision: null }
 }
@@ -100,14 +113,16 @@ export function getRunId(event: H3Event): number {
 const buggyErrors = checkItemPatchStageGuard(BUGGY_FIXTURE)
 assert.equal(
   buggyErrors.length,
-  3,
-  `expected the pre-fix shape (no guard calls at all) to raise 3 errors ` +
-    `(pitch, fieldsDraft, promptDraft), got ${buggyErrors.length}: ` +
+  4,
+  `expected the pre-fix shape (no guard calls at all) to raise 4 errors ` +
+    `(pitch, fieldsDraft, promptDraft, artImageId), got ${buggyErrors.length}: ` +
     JSON.stringify(buggyErrors),
 )
 assert.ok(buggyErrors.some((e) => e.includes("'PITCH'")))
 assert.ok(buggyErrors.some((e) => e.includes('body.fieldsDraft')))
 assert.ok(buggyErrors.some((e) => e.includes('body.promptDraft')))
+assert.ok(buggyErrors.some((e) => e.includes('body.artImageId')))
+assert.ok(buggyErrors.some((e) => e.includes("'GENERATE_ASSETS'")))
 
 const fixedErrors = checkItemPatchStageGuard(FIXED_FIXTURE)
 assert.equal(
@@ -119,12 +134,17 @@ assert.equal(
 const partialErrors = checkItemPatchStageGuard(PARTIAL_FIXTURE)
 assert.equal(
   partialErrors.length,
-  2,
+  3,
   `expected the partially-fixed shape (PITCH guarded, FIELDS_AND_PROMPTS ` +
-    `not) to raise 2 errors, got ${partialErrors.length}: ` +
+    `and GENERATE_ASSETS not) to raise 3 errors, got ${partialErrors.length}: ` +
     JSON.stringify(partialErrors),
 )
-assert.ok(partialErrors.every((e) => e.includes('FIELDS_AND_PROMPTS')))
+assert.ok(
+  partialErrors.some((e) => e.includes('body.fieldsDraft')) &&
+    partialErrors.some((e) => e.includes('body.promptDraft')),
+)
+assert.ok(partialErrors.some((e) => e.includes('body.artImageId')))
+assert.ok(!partialErrors.some((e) => e.includes("'PITCH'")))
 
 const missingFnErrors = checkItemPatchStageGuard(MISSING_FIXTURE)
 assert.equal(

--- a/utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
+++ b/utils/scripts/verifyModelBuilderItemPatchStageGuard.ts
@@ -19,14 +19,24 @@
 // content server-side while its badge kept showing 'approved' client-side --
 // no re-review, the review gate lying about what's actually stored.
 //
+// The identical gap existed one field over: body.artImageId (gated against
+// GENERATE_ASSETS) was applied unconditionally too, so a direct PATCH for an
+// item whose GENERATE_ASSETS was already 'approved' could silently repoint
+// it at a different ArtImage (any the caller may attach at all, per
+// assertArtImageAttachable -- their own or public) with no re-review, while
+// the client-side guards for this exact class of overwrite
+// (verifyModelBuilderApprovedAssetGuard.ts's generateItemAsset/
+// pollAsyncArtJob checks) only ever run inside the store, never here.
+//
 // This asserts the textual shape of the fix stays in place: prepareItemUpdate
 // calls assertContentStageEditable(existing.stageStatuses, 'PITCH', ...)
-// before assigning data.pitch, and assertContentStageEditable(existing.
+// before assigning data.pitch, assertContentStageEditable(existing.
 // stageStatuses, 'FIELDS_AND_PROMPTS', ...) before assigning both
-// data.fieldsDraft and data.promptDraft -- deliberately scoped to this one
-// function/bug, mirroring verifyModelBuilderCommitCancelledRunGuard.ts's
-// preference for explicit, narrow textual checks over a general-purpose
-// static analyzer.
+// data.fieldsDraft and data.promptDraft, and assertContentStageEditable(
+// existing.stageStatuses, 'GENERATE_ASSETS', ...) before assigning
+// data.artImageId -- deliberately scoped to this one function/bug shape,
+// mirroring verifyModelBuilderCommitCancelledRunGuard.ts's preference for
+// explicit, narrow textual checks over a general-purpose static analyzer.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -63,6 +73,11 @@ const GATES: GateCheck[] = [
     field: 'promptDraft',
     assignment: 'data.promptDraft = normalizeText(body.promptDraft)',
     stageKey: 'FIELDS_AND_PROMPTS',
+  },
+  {
+    field: 'artImageId',
+    assignment: 'data.artImageId = normalizeNullableId(body.artImageId)',
+    stageKey: 'GENERATE_ASSETS',
   },
 ]
 
@@ -174,8 +189,9 @@ function main(): void {
 
   console.log(
     `Model Builder item-patch stage guard contract passed: ${FN_NAME}() ` +
-      'refuses to overwrite pitch/fieldsDraft/promptDraft while their stage ' +
-      "is not ready/stale/rejected, per the item's server-stored stage status.",
+      'refuses to overwrite pitch/fieldsDraft/promptDraft/artImageId while ' +
+      "their stage is not ready/stale/rejected, per the item's server-stored " +
+      'stage status.',
   )
 }
 


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `prepareItemUpdate()` in `server/api/model-builder/runs/index.ts` (shared by `items/[id].patch.ts` and `items/batch.patch.ts`) applied `body.artImageId` to the Prisma update unconditionally, with no server-side check against the item's actual `GENERATE_ASSETS` stage status — the same "server-side mirror of a client-side gate" class PR #1227 fixed for `pitch`/`fieldsDraft`/`promptDraft`, but it missed `artImageId`.
- Concrete failure: a direct `PATCH /api/model-builder/items/:id` (replayed/retried request, stale client state, or a raw curl call) with `{ artImageId: <someId> }` for an item whose `GENERATE_ASSETS` stage was already `'approved'` could silently repoint the item at a different `ArtImage` with no re-review, while the stage badge kept showing `'approved'` for content the user never actually reviewed.
- Fix: extended `assertContentStageEditable`'s `stageKey` union to accept `'GENERATE_ASSETS'` and call it before `data.artImageId = normalizeNullableId(body.artImageId)`, mirroring the existing pitch/fields/prompt gates exactly.
- Extended `utils/scripts/verifyModelBuilderItemPatchStageGuard.ts` + its `.test.ts` to cover the new `artImageId`/`GENERATE_ASSETS` gate.

### How I verified
- `npx eslint` on all 3 changed files — clean
- `npx prettier --check` on all 3 changed files — clean
- `npx vue-tsc --noEmit -p tsconfig.json` — exit 0, full project
- `npx tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts` — passes
- `npx tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.ts` — passes against the fixed store
- Confirmed the guard catches the pre-fix state via `git stash` (fails with the expected message), then passes post-fix
- Ran all 9 pre-existing `test:model-builder-*` guard/selftest scripts — no regressions

### Stakes
reversible

### Flags for Reviewer
- None

### Kaizen suggestion
None new this cycle — this closes the one remaining field-level gap in `prepareItemUpdate()`'s stage-approval mirror (pitch/fieldsDraft/promptDraft/artImageId are now all covered).

### Notes for reviewer
Conductor project: model-builder, task t-029 (recurring). Rearming to `ready` after merge per the recurring-task rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DyHkv2m44dDEyo1Kjgmuw)_