### PR TITLE
repair high-confidence Facet taxonomy leaks

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Verify Personality synonym merges
         run: npx tsx utils/scripts/verifyFacetPersonalitySynonyms.ts
 
+      - name: Verify Facet taxonomy leak repairs
+        run: npx tsx utils/scripts/verifyFacetTaxonomyLeaks.ts
+
       - name: Verify Facet seed policy
         run: node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
 

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -97,6 +97,14 @@ if (!isVercelBuild || isProductionDeployment) {
     'Merging exact Personality Facet synonyms',
   )
 
+  // Repair high-confidence classification leaks and remove prompt cargo cult from
+  // random selection without deleting manually useful legacy records.
+  run(
+    tsxBinary,
+    ['utils/scripts/curateFacetTaxonomyLeaks.ts', '--apply'],
+    'Repairing Facet taxonomy leaks and low-value random controls',
+  )
+
   run(
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],

--- a/utils/scripts/curateFacetTaxonomyLeaks.ts
+++ b/utils/scripts/curateFacetTaxonomyLeaks.ts
@@ -53,13 +53,21 @@ type TransformDefinition = {
   groupKey: string
   groupLabel: string
   randomWeight: number
-  isRandomizable?: boolean
   note: string
 }
 
 type SuppressDefinition = {
   lookup: readonly string[]
   note: string
+}
+
+type EnsureDefinition = {
+  slug: string
+  title: string
+  taxonomy: FacetTaxonomy
+  groupKey: string
+  groupLabel: string
+  randomWeight: number
 }
 
 const TRANSFORMS: readonly TransformDefinition[] = [
@@ -117,7 +125,7 @@ const SUPPRESS: readonly SuppressDefinition[] = [
     note: 'Resolution cargo-cult wording adds no reliable creative direction.',
   },
   {
-    lookup: ['award-winning', 'award-winning'],
+    lookup: ['award-winning'],
     note: 'Quality-claim wording is not a useful randomized creative control.',
   },
   {
@@ -212,10 +220,10 @@ function curatedMetadata(options: {
 
 async function findFacet(lookups: readonly string[]): Promise<FacetRow | null> {
   for (const lookup of lookups) {
-    const direct = await prisma.facet.findUnique({
+    const bySlug = await prisma.facet.findUnique({
       where: { slug: slugify(lookup) },
     })
-    if (direct) return direct
+    if (bySlug) return bySlug
 
     const lookupKey = normalizeFacetLookupKey(lookup)
     if (!lookupKey) continue
@@ -256,6 +264,56 @@ async function hasArtwork(facet: FacetRow): Promise<boolean> {
   return imageLinks > 0 || collectionLinks > 0
 }
 
+async function writeProfile(options: {
+  facet: FacetRow
+  profile: ProfileRow | null
+  taxonomy: FacetTaxonomy
+  groupKey: string | null
+  groupLabel: string | null
+  isRandomizable: boolean
+  randomWeight: number
+  artBacked: boolean
+  action: 'taxonomy-repair' | 'suppress-low-value' | 'decompose-recipe'
+  note: string
+}): Promise<void> {
+  const metadata = curatedMetadata({
+    previous: options.profile?.metadata,
+    action: options.action,
+    title: options.facet.title,
+    previousTaxonomy: options.profile?.taxonomy,
+    taxonomy: options.taxonomy,
+    artBacked: options.artBacked,
+    note: options.note,
+  })
+
+  await prisma.facetProfile.upsert({
+    where: { facetId: options.facet.id },
+    create: {
+      facetId: options.facet.id,
+      taxonomy: options.taxonomy,
+      canonicalValue: options.facet.title,
+      groupKey: options.groupKey,
+      groupLabel: options.groupLabel,
+      sortOrder: options.profile?.sortOrder ?? 0,
+      isRandomizable: options.isRandomizable,
+      randomWeight: options.randomWeight,
+      artRequired: options.profile?.artRequired ?? options.artBacked,
+      sourceRank: CURATION_SOURCE_RANK,
+      metadata,
+    },
+    update: {
+      taxonomy: options.taxonomy,
+      canonicalValue: options.facet.title,
+      groupKey: options.groupKey,
+      groupLabel: options.groupLabel,
+      isRandomizable: options.isRandomizable,
+      randomWeight: options.randomWeight,
+      sourceRank: CURATION_SOURCE_RANK,
+      metadata,
+    },
+  })
+}
+
 async function transformFacet(definition: TransformDefinition): Promise<object> {
   const facet = await findFacet(definition.lookup)
   if (!facet) return { lookup: definition.lookup, action: 'missing' }
@@ -268,53 +326,19 @@ async function transformFacet(definition: TransformDefinition): Promise<object> 
   if (apply) {
     await prisma.facet.update({
       where: { id: facet.id },
-      data: {
-        kind: legacyKind(definition.taxonomy),
-        isActive: true,
-      },
+      data: { kind: legacyKind(definition.taxonomy), isActive: true },
     })
-
-    await prisma.facetProfile.upsert({
-      where: { facetId: facet.id },
-      create: {
-        facetId: facet.id,
-        taxonomy: definition.taxonomy,
-        canonicalValue: facet.title,
-        groupKey: definition.groupKey,
-        groupLabel: definition.groupLabel,
-        sortOrder: profile?.sortOrder ?? 0,
-        isRandomizable: definition.isRandomizable ?? true,
-        randomWeight: definition.randomWeight,
-        artRequired: profile?.artRequired ?? artBacked,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: curatedMetadata({
-          previous: profile?.metadata,
-          action: 'taxonomy-repair',
-          title: facet.title,
-          previousTaxonomy: profile?.taxonomy,
-          taxonomy: definition.taxonomy,
-          artBacked,
-          note: definition.note,
-        }),
-      },
-      update: {
-        taxonomy: definition.taxonomy,
-        canonicalValue: facet.title,
-        groupKey: definition.groupKey,
-        groupLabel: definition.groupLabel,
-        isRandomizable: definition.isRandomizable ?? true,
-        randomWeight: definition.randomWeight,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: curatedMetadata({
-          previous: profile?.metadata,
-          action: 'taxonomy-repair',
-          title: facet.title,
-          previousTaxonomy: profile?.taxonomy,
-          taxonomy: definition.taxonomy,
-          artBacked,
-          note: definition.note,
-        }),
-      },
+    await writeProfile({
+      facet,
+      profile,
+      taxonomy: definition.taxonomy,
+      groupKey: definition.groupKey,
+      groupLabel: definition.groupLabel,
+      isRandomizable: true,
+      randomWeight: definition.randomWeight,
+      artBacked,
+      action: 'taxonomy-repair',
+      note: definition.note,
     })
   }
 
@@ -337,45 +361,20 @@ async function suppressFacet(definition: SuppressDefinition): Promise<object> {
     getProfile(facet.id),
     hasArtwork(facet),
   ])
+  const taxonomy = profile?.taxonomy ?? 'OTHER'
 
   if (apply) {
-    await prisma.facetProfile.upsert({
-      where: { facetId: facet.id },
-      create: {
-        facetId: facet.id,
-        taxonomy: profile?.taxonomy ?? 'OTHER',
-        canonicalValue: profile?.canonicalValue ?? facet.title,
-        groupKey: profile?.groupKey,
-        groupLabel: profile?.groupLabel,
-        sortOrder: profile?.sortOrder ?? 0,
-        isRandomizable: false,
-        randomWeight: 0,
-        artRequired: profile?.artRequired ?? artBacked,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: curatedMetadata({
-          previous: profile?.metadata,
-          action: 'suppress-low-value',
-          title: facet.title,
-          previousTaxonomy: profile?.taxonomy,
-          taxonomy: profile?.taxonomy,
-          artBacked,
-          note: definition.note,
-        }),
-      },
-      update: {
-        isRandomizable: false,
-        randomWeight: 0,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: curatedMetadata({
-          previous: profile?.metadata,
-          action: 'suppress-low-value',
-          title: facet.title,
-          previousTaxonomy: profile?.taxonomy,
-          taxonomy: profile?.taxonomy,
-          artBacked,
-          note: definition.note,
-        }),
-      },
+    await writeProfile({
+      facet,
+      profile,
+      taxonomy,
+      groupKey: profile?.groupKey ?? null,
+      groupLabel: profile?.groupLabel ?? null,
+      isRandomizable: false,
+      randomWeight: 0,
+      artBacked,
+      action: 'suppress-low-value',
+      note: definition.note,
     })
   }
 
@@ -383,28 +382,21 @@ async function suppressFacet(definition: SuppressDefinition): Promise<object> {
     facetId: facet.id,
     title: facet.title,
     action: apply ? 'suppressed-from-random' : 'would-suppress-from-random',
-    taxonomy: profile?.taxonomy ?? null,
+    taxonomy,
     artBacked,
   }
 }
 
-async function ensureRecipeTarget(options: {
-  slug: string
-  title: string
-  taxonomy: FacetTaxonomy
-  groupKey: string
-  groupLabel: string
-  randomWeight: number
-}): Promise<FacetRow | null> {
-  let facet = await findFacet([options.slug, options.title])
+async function ensureExactFacet(definition: EnsureDefinition): Promise<FacetRow | null> {
+  let facet = await prisma.facet.findUnique({ where: { slug: definition.slug } })
   if (!facet && !apply) return null
 
   if (!facet) {
     facet = await prisma.facet.create({
       data: {
-        title: options.title,
-        slug: options.slug,
-        kind: legacyKind(options.taxonomy),
+        title: definition.title,
+        slug: definition.slug,
+        kind: legacyKind(definition.taxonomy),
         designer: 'facet-curation',
         creationSource: 'HUMAN',
         userId: 1,
@@ -415,35 +407,34 @@ async function ensureRecipeTarget(options: {
     })
   }
 
-  const profile = await getProfile(facet.id)
+  const [profile, artBacked] = await Promise.all([
+    getProfile(facet.id),
+    hasArtwork(facet),
+  ])
   if (apply) {
-    await prisma.facetProfile.upsert({
-      where: { facetId: facet.id },
-      create: {
-        facetId: facet.id,
-        taxonomy: options.taxonomy,
-        canonicalValue: options.title,
-        groupKey: options.groupKey,
-        groupLabel: options.groupLabel,
-        sortOrder: profile?.sortOrder ?? 0,
-        isRandomizable: true,
-        randomWeight: options.randomWeight,
-        artRequired: profile?.artRequired ?? true,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: profile?.metadata,
-      },
-      update: {
-        taxonomy: options.taxonomy,
-        canonicalValue: options.title,
-        groupKey: options.groupKey,
-        groupLabel: options.groupLabel,
-        isRandomizable: true,
-        randomWeight: options.randomWeight,
-        sourceRank: CURATION_SOURCE_RANK,
+    await prisma.facet.update({
+      where: { id: facet.id },
+      data: {
+        title: definition.title,
+        kind: legacyKind(definition.taxonomy),
+        isActive: true,
       },
     })
+    await writeProfile({
+      facet: { ...facet, title: definition.title },
+      profile,
+      taxonomy: definition.taxonomy,
+      groupKey: definition.groupKey,
+      groupLabel: definition.groupLabel,
+      isRandomizable: true,
+      randomWeight: definition.randomWeight,
+      artBacked,
+      action: 'taxonomy-repair',
+      note: 'Reusable component created for a decomposed genre recipe.',
+    })
   }
-  return facet
+
+  return { ...facet, title: definition.title }
 }
 
 async function decomposeWhimsicalStew(): Promise<object> {
@@ -454,15 +445,15 @@ async function decomposeWhimsicalStew(): Promise<object> {
     getProfile(recipe.id),
     hasArtwork(recipe),
   ])
-  const whimsical = await ensureRecipeTarget({
+  const whimsicalTone = await ensureExactFacet({
     slug: 'whimsical-tone',
-    title: 'Whimsical',
+    title: 'Whimsical Tone',
     taxonomy: 'MOOD',
     groupKey: 'mood',
     groupLabel: 'Moods',
     randomWeight: 1,
   })
-  const culinary = await ensureRecipeTarget({
+  const culinaryFantasy = await ensureExactFacet({
     slug: 'culinary-fantasy',
     title: 'Culinary Fantasy',
     taxonomy: 'GENRE',
@@ -476,49 +467,21 @@ async function decomposeWhimsicalStew(): Promise<object> {
       where: { id: recipe.id },
       data: { kind: 'THEME', isActive: true },
     })
-    await prisma.facetProfile.upsert({
-      where: { facetId: recipe.id },
-      create: {
-        facetId: recipe.id,
-        taxonomy: 'THEME',
-        canonicalValue: recipe.title,
-        groupKey: 'genre-recipe',
-        groupLabel: 'Genre Recipes',
-        sortOrder: profile?.sortOrder ?? 0,
-        isRandomizable: false,
-        randomWeight: 0,
-        artRequired: profile?.artRequired ?? artBacked,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: curatedMetadata({
-          previous: profile?.metadata,
-          action: 'decompose-recipe',
-          title: recipe.title,
-          previousTaxonomy: profile?.taxonomy,
-          taxonomy: 'THEME',
-          artBacked,
-          note: 'Decomposed into reusable Whimsical mood and Culinary Fantasy genre.',
-        }),
-      },
-      update: {
-        taxonomy: 'THEME',
-        groupKey: 'genre-recipe',
-        groupLabel: 'Genre Recipes',
-        isRandomizable: false,
-        randomWeight: 0,
-        sourceRank: CURATION_SOURCE_RANK,
-        metadata: curatedMetadata({
-          previous: profile?.metadata,
-          action: 'decompose-recipe',
-          title: recipe.title,
-          previousTaxonomy: profile?.taxonomy,
-          taxonomy: 'THEME',
-          artBacked,
-          note: 'Decomposed into reusable Whimsical mood and Culinary Fantasy genre.',
-        }),
-      },
+    await writeProfile({
+      facet: recipe,
+      profile,
+      taxonomy: 'THEME',
+      groupKey: 'genre-recipe',
+      groupLabel: 'Genre Recipes',
+      isRandomizable: false,
+      randomWeight: 0,
+      artBacked,
+      action: 'decompose-recipe',
+      note:
+        'Decomposed into reusable Whimsical Tone mood and Culinary Fantasy genre.',
     })
 
-    for (const target of [whimsical, culinary]) {
+    for (const target of [whimsicalTone, culinaryFantasy]) {
       if (!target || target.id === recipe.id) continue
       await prisma.facetRelation.upsert({
         where: {
@@ -546,7 +509,7 @@ async function decomposeWhimsicalStew(): Promise<object> {
     title: recipe.title,
     action: apply ? 'decomposed' : 'would-decompose',
     artBacked,
-    components: ['Whimsical', 'Culinary Fantasy'],
+    components: ['Whimsical Tone', 'Culinary Fantasy'],
   }
 }
 

--- a/utils/scripts/curateFacetTaxonomyLeaks.ts
+++ b/utils/scripts/curateFacetTaxonomyLeaks.ts
@@ -1,0 +1,590 @@
+// /utils/scripts/curateFacetTaxonomyLeaks.ts
+import 'dotenv/config'
+import {
+  PrismaClient,
+  type FacetKind,
+  type FacetTaxonomy,
+} from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { normalizeFacetLookupKey } from './../facetAliases'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({
+  adapter: createDatabaseAdapter(databaseUrl),
+})
+const apply = process.argv.includes('--apply')
+const BATCH_ID = '2026-08-01-taxonomy-leaks-05'
+const CURATION_SOURCE_RANK = 1
+
+type JsonObject = Record<string, unknown>
+
+type FacetRow = {
+  id: number
+  title: string
+  slug: string | null
+  kind: FacetKind
+  description: string | null
+  imagePath: string | null
+  cardPath: string | null
+  heroPath: string | null
+  icon: string | null
+  artImageId: number | null
+  artCollectionId: number | null
+}
+
+type ProfileRow = {
+  taxonomy: FacetTaxonomy
+  canonicalValue: string | null
+  groupKey: string | null
+  groupLabel: string | null
+  sortOrder: number
+  isRandomizable: boolean
+  randomWeight: number
+  artRequired: boolean
+  sourceRank: number
+  metadata: string | null
+}
+
+type TransformDefinition = {
+  lookup: readonly string[]
+  taxonomy: FacetTaxonomy
+  groupKey: string
+  groupLabel: string
+  randomWeight: number
+  isRandomizable?: boolean
+  note: string
+}
+
+type SuppressDefinition = {
+  lookup: readonly string[]
+  note: string
+}
+
+const TRANSFORMS: readonly TransformDefinition[] = [
+  {
+    lookup: ['Creative Writer', 'creative-writer'],
+    taxonomy: 'OCCUPATION',
+    groupKey: 'occupation',
+    groupLabel: 'Occupations',
+    randomWeight: 1,
+    note: 'An occupation and creative practice, not a personality trait.',
+  },
+  {
+    lookup: ["Believes They're Psychic", 'believes-they-re-psychic'],
+    taxonomy: 'QUIRK',
+    groupKey: 'quirk',
+    groupLabel: 'Quirks',
+    randomWeight: 1,
+    note: 'A belief-shaped character quirk, not a personality trait.',
+  },
+  {
+    lookup: ['Animist', 'animist'],
+    taxonomy: 'THEME',
+    groupKey: 'worldview',
+    groupLabel: 'Worldviews',
+    randomWeight: 0.75,
+    note: 'A worldview and relationship to the living world, not a temperament.',
+  },
+  {
+    lookup: [
+      'Can only sleep standing up, and only on moving trains.',
+      'can-only-sleep-standing-up-and-only-on-moving-trains',
+    ],
+    taxonomy: 'QUIRK',
+    groupKey: 'quirk',
+    groupLabel: 'Quirks',
+    randomWeight: 0.5,
+    note: 'A highly specific behavioral quirk rather than prior history.',
+  },
+  {
+    lookup: [
+      'Cursed to speak only in riddles… but only on Tuesdays.',
+      'cursed-to-speak-only-in-riddles-but-only-on-tuesdays',
+    ],
+    taxonomy: 'QUIRK',
+    groupKey: 'quirk',
+    groupLabel: 'Quirks',
+    randomWeight: 0.5,
+    note: 'An ongoing speech constraint rather than prior history.',
+  },
+]
+
+const SUPPRESS: readonly SuppressDefinition[] = [
+  {
+    lookup: ['4k render', '4k-render'],
+    note: 'Resolution cargo-cult wording adds no reliable creative direction.',
+  },
+  {
+    lookup: ['award-winning', 'award-winning'],
+    note: 'Quality-claim wording is not a useful randomized creative control.',
+  },
+  {
+    lookup: ['award-winning concept art', 'award-winning-concept-art'],
+    note: 'Quality-claim wording is not a useful randomized creative control.',
+  },
+  {
+    lookup: ['Ambiguous', 'ambiguous'],
+    note: 'Too underspecified to provide a dependable personality instruction.',
+  },
+]
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 255)
+}
+
+function legacyKind(taxonomy: FacetTaxonomy): FacetKind {
+  const direct: Partial<Record<FacetTaxonomy, FacetKind>> = {
+    GENRE: 'GENRE',
+    ANIMAL: 'ANIMAL',
+    COLOR: 'COLOR',
+    THEME: 'THEME',
+    CORE: 'CORE',
+    MOOD: 'MOOD',
+    STYLE: 'STYLE',
+    SETTING: 'SETTING',
+    ART_DIRECTION: 'ART_DIRECTION',
+    PROMPT_ENHANCEMENT: 'ART_DIRECTION',
+  }
+  return direct[taxonomy] ?? 'OTHER'
+}
+
+function parseMetadata(value: string | null | undefined): JsonObject {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function curatedMetadata(options: {
+  previous: string | null | undefined
+  action: 'taxonomy-repair' | 'suppress-low-value' | 'decompose-recipe'
+  title: string
+  previousTaxonomy?: FacetTaxonomy | null
+  taxonomy?: FacetTaxonomy
+  artBacked: boolean
+  note: string
+}): string {
+  const metadata = parseMetadata(options.previous)
+  const history = Array.isArray(metadata.catalogCurationHistory)
+    ? metadata.catalogCurationHistory.filter(
+        (entry) =>
+          !(
+            entry &&
+            typeof entry === 'object' &&
+            'batchId' in entry &&
+            entry.batchId === BATCH_ID &&
+            'action' in entry &&
+            entry.action === options.action
+          ),
+      )
+    : []
+
+  return JSON.stringify({
+    ...metadata,
+    catalogCurationHistory: [
+      ...history,
+      {
+        batchId: BATCH_ID,
+        action: options.action,
+        title: options.title,
+        previousTaxonomy: options.previousTaxonomy,
+        taxonomy: options.taxonomy,
+        artBacked: options.artBacked,
+        note: options.note,
+      },
+    ],
+  })
+}
+
+async function findFacet(lookups: readonly string[]): Promise<FacetRow | null> {
+  for (const lookup of lookups) {
+    const direct = await prisma.facet.findUnique({
+      where: { slug: slugify(lookup) },
+    })
+    if (direct) return direct
+
+    const lookupKey = normalizeFacetLookupKey(lookup)
+    if (!lookupKey) continue
+    const alias = await prisma.facetAlias.findUnique({
+      where: { lookupKey },
+      select: { facetId: true },
+    })
+    if (!alias) continue
+
+    const aliased = await prisma.facet.findUnique({
+      where: { id: alias.facetId },
+    })
+    if (aliased) return aliased
+  }
+  return null
+}
+
+async function getProfile(facetId: number): Promise<ProfileRow | null> {
+  return prisma.facetProfile.findUnique({ where: { facetId } })
+}
+
+async function hasArtwork(facet: FacetRow): Promise<boolean> {
+  if (
+    facet.imagePath ||
+    facet.cardPath ||
+    facet.heroPath ||
+    facet.icon ||
+    facet.artImageId !== null ||
+    facet.artCollectionId !== null
+  ) {
+    return true
+  }
+
+  const [imageLinks, collectionLinks] = await Promise.all([
+    prisma.facetArtImage.count({ where: { facetId: facet.id } }),
+    prisma.facetArtCollection.count({ where: { facetId: facet.id } }),
+  ])
+  return imageLinks > 0 || collectionLinks > 0
+}
+
+async function transformFacet(definition: TransformDefinition): Promise<object> {
+  const facet = await findFacet(definition.lookup)
+  if (!facet) return { lookup: definition.lookup, action: 'missing' }
+
+  const [profile, artBacked] = await Promise.all([
+    getProfile(facet.id),
+    hasArtwork(facet),
+  ])
+
+  if (apply) {
+    await prisma.facet.update({
+      where: { id: facet.id },
+      data: {
+        kind: legacyKind(definition.taxonomy),
+        isActive: true,
+      },
+    })
+
+    await prisma.facetProfile.upsert({
+      where: { facetId: facet.id },
+      create: {
+        facetId: facet.id,
+        taxonomy: definition.taxonomy,
+        canonicalValue: facet.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: definition.isRandomizable ?? true,
+        randomWeight: definition.randomWeight,
+        artRequired: profile?.artRequired ?? artBacked,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          action: 'taxonomy-repair',
+          title: facet.title,
+          previousTaxonomy: profile?.taxonomy,
+          taxonomy: definition.taxonomy,
+          artBacked,
+          note: definition.note,
+        }),
+      },
+      update: {
+        taxonomy: definition.taxonomy,
+        canonicalValue: facet.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        isRandomizable: definition.isRandomizable ?? true,
+        randomWeight: definition.randomWeight,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          action: 'taxonomy-repair',
+          title: facet.title,
+          previousTaxonomy: profile?.taxonomy,
+          taxonomy: definition.taxonomy,
+          artBacked,
+          note: definition.note,
+        }),
+      },
+    })
+  }
+
+  return {
+    facetId: facet.id,
+    title: facet.title,
+    action: apply ? 'transformed' : 'would-transform',
+    previousTaxonomy: profile?.taxonomy ?? null,
+    taxonomy: definition.taxonomy,
+    artBacked,
+    randomWeight: definition.randomWeight,
+  }
+}
+
+async function suppressFacet(definition: SuppressDefinition): Promise<object> {
+  const facet = await findFacet(definition.lookup)
+  if (!facet) return { lookup: definition.lookup, action: 'missing' }
+
+  const [profile, artBacked] = await Promise.all([
+    getProfile(facet.id),
+    hasArtwork(facet),
+  ])
+
+  if (apply) {
+    await prisma.facetProfile.upsert({
+      where: { facetId: facet.id },
+      create: {
+        facetId: facet.id,
+        taxonomy: profile?.taxonomy ?? 'OTHER',
+        canonicalValue: profile?.canonicalValue ?? facet.title,
+        groupKey: profile?.groupKey,
+        groupLabel: profile?.groupLabel,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: false,
+        randomWeight: 0,
+        artRequired: profile?.artRequired ?? artBacked,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          action: 'suppress-low-value',
+          title: facet.title,
+          previousTaxonomy: profile?.taxonomy,
+          taxonomy: profile?.taxonomy,
+          artBacked,
+          note: definition.note,
+        }),
+      },
+      update: {
+        isRandomizable: false,
+        randomWeight: 0,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          action: 'suppress-low-value',
+          title: facet.title,
+          previousTaxonomy: profile?.taxonomy,
+          taxonomy: profile?.taxonomy,
+          artBacked,
+          note: definition.note,
+        }),
+      },
+    })
+  }
+
+  return {
+    facetId: facet.id,
+    title: facet.title,
+    action: apply ? 'suppressed-from-random' : 'would-suppress-from-random',
+    taxonomy: profile?.taxonomy ?? null,
+    artBacked,
+  }
+}
+
+async function ensureRecipeTarget(options: {
+  slug: string
+  title: string
+  taxonomy: FacetTaxonomy
+  groupKey: string
+  groupLabel: string
+  randomWeight: number
+}): Promise<FacetRow | null> {
+  let facet = await findFacet([options.slug, options.title])
+  if (!facet && !apply) return null
+
+  if (!facet) {
+    facet = await prisma.facet.create({
+      data: {
+        title: options.title,
+        slug: options.slug,
+        kind: legacyKind(options.taxonomy),
+        designer: 'facet-curation',
+        creationSource: 'HUMAN',
+        userId: 1,
+        isPublic: true,
+        isMature: false,
+        isActive: true,
+      },
+    })
+  }
+
+  const profile = await getProfile(facet.id)
+  if (apply) {
+    await prisma.facetProfile.upsert({
+      where: { facetId: facet.id },
+      create: {
+        facetId: facet.id,
+        taxonomy: options.taxonomy,
+        canonicalValue: options.title,
+        groupKey: options.groupKey,
+        groupLabel: options.groupLabel,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: true,
+        randomWeight: options.randomWeight,
+        artRequired: profile?.artRequired ?? true,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: profile?.metadata,
+      },
+      update: {
+        taxonomy: options.taxonomy,
+        canonicalValue: options.title,
+        groupKey: options.groupKey,
+        groupLabel: options.groupLabel,
+        isRandomizable: true,
+        randomWeight: options.randomWeight,
+        sourceRank: CURATION_SOURCE_RANK,
+      },
+    })
+  }
+  return facet
+}
+
+async function decomposeWhimsicalStew(): Promise<object> {
+  const recipe = await findFacet(['Whimsical Stew', 'whimsical-stew'])
+  if (!recipe) return { title: 'Whimsical Stew', action: 'missing' }
+
+  const [profile, artBacked] = await Promise.all([
+    getProfile(recipe.id),
+    hasArtwork(recipe),
+  ])
+  const whimsical = await ensureRecipeTarget({
+    slug: 'whimsical-tone',
+    title: 'Whimsical',
+    taxonomy: 'MOOD',
+    groupKey: 'mood',
+    groupLabel: 'Moods',
+    randomWeight: 1,
+  })
+  const culinary = await ensureRecipeTarget({
+    slug: 'culinary-fantasy',
+    title: 'Culinary Fantasy',
+    taxonomy: 'GENRE',
+    groupKey: 'curated-genre',
+    groupLabel: 'Curated Genres',
+    randomWeight: 1.5,
+  })
+
+  if (apply) {
+    await prisma.facet.update({
+      where: { id: recipe.id },
+      data: { kind: 'THEME', isActive: true },
+    })
+    await prisma.facetProfile.upsert({
+      where: { facetId: recipe.id },
+      create: {
+        facetId: recipe.id,
+        taxonomy: 'THEME',
+        canonicalValue: recipe.title,
+        groupKey: 'genre-recipe',
+        groupLabel: 'Genre Recipes',
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: false,
+        randomWeight: 0,
+        artRequired: profile?.artRequired ?? artBacked,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          action: 'decompose-recipe',
+          title: recipe.title,
+          previousTaxonomy: profile?.taxonomy,
+          taxonomy: 'THEME',
+          artBacked,
+          note: 'Decomposed into reusable Whimsical mood and Culinary Fantasy genre.',
+        }),
+      },
+      update: {
+        taxonomy: 'THEME',
+        groupKey: 'genre-recipe',
+        groupLabel: 'Genre Recipes',
+        isRandomizable: false,
+        randomWeight: 0,
+        sourceRank: CURATION_SOURCE_RANK,
+        metadata: curatedMetadata({
+          previous: profile?.metadata,
+          action: 'decompose-recipe',
+          title: recipe.title,
+          previousTaxonomy: profile?.taxonomy,
+          taxonomy: 'THEME',
+          artBacked,
+          note: 'Decomposed into reusable Whimsical mood and Culinary Fantasy genre.',
+        }),
+      },
+    })
+
+    for (const target of [whimsical, culinary]) {
+      if (!target || target.id === recipe.id) continue
+      await prisma.facetRelation.upsert({
+        where: {
+          fromFacetId_toFacetId_relationType: {
+            fromFacetId: recipe.id,
+            toFacetId: target.id,
+            relationType: 'CONTAINS',
+          },
+        },
+        create: {
+          fromFacetId: recipe.id,
+          toFacetId: target.id,
+          relationType: 'CONTAINS',
+          note: `Reusable component of the former composite genre. Curated by ${BATCH_ID}.`,
+        },
+        update: {
+          note: `Reusable component of the former composite genre. Curated by ${BATCH_ID}.`,
+        },
+      })
+    }
+  }
+
+  return {
+    facetId: recipe.id,
+    title: recipe.title,
+    action: apply ? 'decomposed' : 'would-decompose',
+    artBacked,
+    components: ['Whimsical', 'Culinary Fantasy'],
+  }
+}
+
+async function main(): Promise<void> {
+  const transformed = []
+  for (const definition of TRANSFORMS) {
+    transformed.push(await transformFacet(definition))
+  }
+
+  const suppressed = []
+  for (const definition of SUPPRESS) {
+    suppressed.push(await suppressFacet(definition))
+  }
+
+  const whimsicalStew = await decomposeWhimsicalStew()
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        mode: apply ? 'apply' : 'dry-run',
+        batchId: BATCH_ID,
+        transformed,
+        suppressed,
+        whimsicalStew,
+        artPolicy:
+          'Taxonomy repairs preserve stable Facet rows, titles, prose, prompt fields, and all direct or joined artwork. Low-value controls remain manually available but leave random selection.',
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/verifyFacetTaxonomyLeaks.ts
+++ b/utils/scripts/verifyFacetTaxonomyLeaks.ts
@@ -1,0 +1,94 @@
+// /utils/scripts/verifyFacetTaxonomyLeaks.ts
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+
+async function read(path: string): Promise<string> {
+  return readFile(resolve(root, path), 'utf8')
+}
+
+function requireText(path: string, text: string, value: string): void {
+  if (!text.includes(value)) {
+    throw new Error(`${path} is missing required contract text: ${value}`)
+  }
+}
+
+function requireOrder(
+  path: string,
+  text: string,
+  before: string,
+  after: string,
+): void {
+  const beforeIndex = text.indexOf(before)
+  const afterIndex = text.indexOf(after)
+  if (beforeIndex < 0 || afterIndex < 0 || beforeIndex >= afterIndex) {
+    throw new Error(`${path} must run ${after} after ${before}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const curatorPath = 'utils/scripts/curateFacetTaxonomyLeaks.ts'
+  const buildPath = 'scripts/vercel-build.mjs'
+  const workflowPath = '.github/workflows/facet-catalog-contract.yml'
+  const [curator, build, workflow] = await Promise.all([
+    read(curatorPath),
+    read(buildPath),
+    read(workflowPath),
+  ])
+
+  const taxonomyContracts: ReadonlyArray<readonly [string, string]> = [
+    ['Creative Writer', "taxonomy: 'OCCUPATION'"],
+    ["Believes They're Psychic", "taxonomy: 'QUIRK'"],
+    ['Animist', "taxonomy: 'THEME'"],
+    ['Can only sleep standing up', "taxonomy: 'QUIRK'"],
+    ['Cursed to speak only in riddles', "taxonomy: 'QUIRK'"],
+  ]
+  for (const [title, taxonomy] of taxonomyContracts) {
+    requireText(curatorPath, curator, title)
+    requireText(curatorPath, curator, taxonomy)
+  }
+
+  for (const suppressed of [
+    '4k render',
+    'award-winning',
+    'award-winning concept art',
+    'Ambiguous',
+  ]) {
+    requireText(curatorPath, curator, suppressed)
+  }
+  requireText(curatorPath, curator, 'isRandomizable: false')
+  requireText(curatorPath, curator, 'randomWeight: 0')
+
+  requireText(curatorPath, curator, 'Whimsical Stew')
+  requireText(curatorPath, curator, "title: 'Whimsical'")
+  requireText(curatorPath, curator, "title: 'Culinary Fantasy'")
+  requireText(curatorPath, curator, "relationType: 'CONTAINS'")
+  requireText(curatorPath, curator, "groupKey: 'genre-recipe'")
+
+  requireText(curatorPath, curator, 'facetArtImage.count')
+  requireText(curatorPath, curator, 'facetArtCollection.count')
+  requireText(curatorPath, curator, 'catalogCurationHistory')
+  requireText(
+    curatorPath,
+    curator,
+    'Taxonomy repairs preserve stable Facet rows',
+  )
+
+  requireText(buildPath, build, 'curateFacetTaxonomyLeaks.ts')
+  requireOrder(
+    buildPath,
+    build,
+    'mergeFacetPersonalitySynonyms.ts',
+    'curateFacetTaxonomyLeaks.ts',
+  )
+  requireText(workflowPath, workflow, 'Verify Facet taxonomy leak repairs')
+  requireText(workflowPath, workflow, 'verifyFacetTaxonomyLeaks.ts')
+
+  process.stdout.write('Facet taxonomy leak repair contract verified.\n')
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/utils/scripts/verifyFacetTaxonomyLeaks.ts
+++ b/utils/scripts/verifyFacetTaxonomyLeaks.ts
@@ -61,8 +61,10 @@ async function main(): Promise<void> {
   requireText(curatorPath, curator, 'randomWeight: 0')
 
   requireText(curatorPath, curator, 'Whimsical Stew')
-  requireText(curatorPath, curator, "title: 'Whimsical'")
+  requireText(curatorPath, curator, "slug: 'whimsical-tone'")
+  requireText(curatorPath, curator, "title: 'Whimsical Tone'")
   requireText(curatorPath, curator, "title: 'Culinary Fantasy'")
+  requireText(curatorPath, curator, 'findUnique({ where: { slug: definition.slug } })')
   requireText(curatorPath, curator, "relationType: 'CONTAINS'")
   requireText(curatorPath, curator, "groupKey: 'genre-recipe'")
 


### PR DESCRIPTION
## Batch 5

This batch repairs records whose creative content is useful but whose taxonomy is clearly wrong.

### Reclassified in place

- Creative Writer: PERSONALITY → OCCUPATION
- Believes They're Psychic: PERSONALITY → QUIRK
- Animist: PERSONALITY → THEME / Worldviews
- Can only sleep standing up, and only on moving trains: BACKSTORY → QUIRK
- Cursed to speak only in riddles, but only on Tuesdays: BACKSTORY → QUIRK

Stable IDs, titles, prose, image paths, direct artwork, and joined artwork remain unchanged.

### Removed from random selection, not deleted

- 4k render
- award-winning
- award-winning concept art
- Ambiguous

These records remain available for legacy/manual use, but no longer consume random-selection probability.

### Rebuilt rather than discarded

`Whimsical Stew` becomes a nonrandom genre-recipe THEME containing:

- Whimsical Tone, a reusable MOOD with its own collision-safe slug
- Culinary Fantasy, a reusable GENRE

The catalog's existing art-backed `Whimsical` PERSONALITY remains untouched.

### Durability

The repair runs after all seeds, curation passes, and exact synonym merges, preventing legacy source lists from restoring the old classifications.

### Validation

- dedicated `verifyFacetTaxonomyLeaks.ts` contract
- collision contract requires exact-slug lookup for recipe components
- production build ordering contract
- full TypeScript, Facet Catalog, and repository contract checks
