### PR TITLE
add a whole-catalog Facet curation audit gate

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Verify Facet genre leak repairs
         run: npx tsx utils/scripts/verifyFacetGenreLeaks.ts
 
+      - name: Verify whole-catalog Facet audit
+        run: npx tsx utils/scripts/verifyFacetCatalogAudit.ts
+
       - name: Verify Facet seed policy
         run: node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
 

--- a/docs/facet-catalog-curation-policy.md
+++ b/docs/facet-catalog-curation-policy.md
@@ -1,0 +1,87 @@
+# Facet catalog curation policy
+
+The Facet catalog is a creative vocabulary, not a landfill or a thesaurus. Curation should preserve useful specificity while keeping random generation legible, recombinable, and proportionate.
+
+## Core rules
+
+### Art-backed Facets
+
+An attached image, collection, card, hero, icon, prompt, or joined artwork record is evidence that the Facet was deliberately authored.
+
+- Keep the stable Facet id.
+- Keep the existing title when a rename would materially shift the art's tone.
+- Keep descriptions, examples, flavor text, prompts, and image relationships unless a human explicitly approves a rewrite.
+- Prefer taxonomy changes, aliases, RELATED links, and recipe decomposition over replacement.
+- A classification move such as GENRE to SETTING is normally safe because it preserves the authored concept.
+
+### Exact synonyms
+
+Merge only when two Facets are genuinely interchangeable in use, not merely adjacent.
+
+A safe merge must migrate:
+
+- Character, Bot, Reward, Dream, and Scenario assignments
+- Reactions
+- aliases
+- inbound and outbound Facet relationships
+- direct and joined artwork
+- profile metadata
+
+The richer or art-backed row should normally be canonical. The retired row should remain inactive with an audit marker.
+
+### Near synonyms
+
+Do not force aliases for concepts that can produce meaningfully different results.
+
+Examples such as Practical, Pragmatic, and Realistic should remain separate and may receive RELATED relationships. Alias resolution should never erase a useful shade of meaning.
+
+### Composite Facets
+
+A title that combines genre, mood, setting, perspective, character state, or premise should normally become a recipe.
+
+- Keep the historic composite row.
+- Mark it nonrandom with weight 0.
+- Create or reuse component Facets.
+- Link the recipe to its components with CONTAINS.
+
+This preserves old assignments while allowing future generation to recombine the parts.
+
+### Random weights
+
+Random selection should reflect breadth and reuse potential.
+
+- 3.0: foundational genres
+- 1.5: established subgenres and broadly reusable forms
+- 0.75 to 1.0: broad themes, settings, moods, and cultural umbrellas
+- 0.5: authored house genres and unusually specific concepts
+- 0: recipes, retired duplicates, and controls removed from random selection
+
+### Low-value prompt controls
+
+Resolution claims, quality incantations, and similarly vague prompt cargo should leave random selection before deletion is considered.
+
+Examples include `4k render`, `award-winning`, and `best quality`. Keeping the record nonrandom protects historical references without spending generation probability on empty wording.
+
+### Cultural labels
+
+Prefer precise traditions over continental shorthand, but retain broad umbrellas when they are genuinely useful.
+
+- Mark broad umbrellas as broad.
+- Downweight them.
+- Encourage pairing with a named culture, region, language, or tradition.
+- Do not collapse distinct established frameworks into aliases.
+- Preserve legacy labels as aliases when renaming an unillustrated record.
+
+## Batch order
+
+Production builds apply curation after all legacy source seeders and canonical duplicate repair:
+
+1. structural genre and setting repair
+2. art-backed house genre relationships
+3. cultural genre refinement
+4. exact synonym migration
+5. general taxonomy leak repair
+6. subject, cast, and remaining genre hybrid repair
+7. whole-catalog audit
+
+The final audit is read-only. It reports the next ranked candidates and never mutates production data.

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -113,6 +113,14 @@ if (!isVercelBuild || isProductionDeployment) {
     'Repairing subject themes and remaining genre hybrids',
   )
 
+  // Read the entire post-curation catalog and print a ranked next-batch queue.
+  // This never mutates data or blocks deployment while cleanup is still in motion.
+  run(
+    tsxBinary,
+    ['utils/scripts/auditFacetCatalogOddities.ts', '--top=60'],
+    'Auditing the complete Facet catalog for remaining oddities',
+  )
+
   run(
     tsxBinary,
     ['scripts/seed_contenders.ts', '--write'],

--- a/utils/facetCatalogAudit.ts
+++ b/utils/facetCatalogAudit.ts
@@ -1,0 +1,361 @@
+// /utils/facetCatalogAudit.ts
+import type { FacetTaxonomy } from './../prisma/generated/prisma/client'
+
+export type FacetAuditInput = {
+  id: number
+  title: string
+  slug: string | null
+  taxonomy: FacetTaxonomy | null
+  groupKey: string | null
+  groupLabel: string | null
+  isRandomizable: boolean
+  randomWeight: number
+  sourceRank: number | null
+  description: string | null
+  flavorText: string | null
+  examples: string | null
+  artPrompt: string | null
+  aliases: readonly string[]
+  artBacked: boolean
+}
+
+export type FacetAuditReason = {
+  code: string
+  score: number
+  detail: string
+}
+
+export type FacetAuditCandidate = FacetAuditInput & {
+  score: number
+  reasons: FacetAuditReason[]
+  actionHint:
+    | 'merge-exact-synonym'
+    | 'decompose-recipe'
+    | 'repair-taxonomy'
+    | 'suppress-random'
+    | 'review-quality'
+  preservationMode: 'preserve-row-and-art' | 'free-to-rebuild'
+}
+
+export type FacetAuditReport = {
+  totals: {
+    activeFacets: number
+    randomizableFacets: number
+    artBackedFacets: number
+    candidateFacets: number
+    criticalCandidates: number
+  }
+  byTaxonomy: Record<string, number>
+  byReason: Record<string, number>
+  duplicateClusters: Array<{
+    normalizedTitle: string
+    facetIds: number[]
+    titles: string[]
+  }>
+  candidates: FacetAuditCandidate[]
+}
+
+const CARGO_CULT_PATTERN =
+  /(?:^|\b)(?:4k|8k|16k|award[- ]winning|masterpiece|best quality|ultra[- ]detailed|highly detailed|trending on|octane render|unreal engine)(?:\b|$)/i
+const SETTING_SHAPED_GENRE_PATTERN =
+  /(?:cathedral|archive|library|parliament|village|forest|underground|underwater|sky|moon|island|city|station|market|hotel|school|academy|kingdom|empire|ocean|sea|desert|mountain|swamp|carnival|circus|museum|garden|sanctuary|court|castle|ruins?|wasteland|frontier|colony|society)$/i
+const SUBJECT_SHAPED_GENRE_PATTERN =
+  /(?:protagonists?|perspective|artificial intelligence|robots?|animals?|dragons?|vampires?|ghosts?|mythology|folklore|post[- ]humanism)$/i
+const OCCUPATION_SHAPED_PERSONALITY_PATTERN =
+  /(?:writer|artist|mechanic|detective|teacher|professor|doctor|nurse|scientist|engineer|librarian|chef|baker|merchant|soldier|knight|priest|farmer|pilot|captain|programmer|designer)$/i
+const WORLDVIEW_SHAPED_PERSONALITY_PATTERN =
+  /(?:animist|atheist|believer|psychic|spiritual|religious|metaphysical|superstitious)$/i
+const QUIRK_SHAPED_BACKSTORY_PATTERN =
+  /(?:\bcan only\b|\bmust always\b|\bnever\b|\bonly on\b|\bspeaks? only\b|\bsleeps?\b|\bcollects?\b|\brefuses? to\b)/i
+
+export function normalizeFacetAuditKey(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+function wordCount(value: string): number {
+  const normalized = normalizeFacetAuditKey(value)
+  return normalized ? normalized.split(' ').length : 0
+}
+
+function pushReason(
+  reasons: FacetAuditReason[],
+  code: string,
+  score: number,
+  detail: string,
+): void {
+  reasons.push({ code, score, detail })
+}
+
+function actionHintFor(reasons: readonly FacetAuditReason[]): FacetAuditCandidate['actionHint'] {
+  const codes = new Set(reasons.map((reason) => reason.code))
+  if (codes.has('duplicate-title')) return 'merge-exact-synonym'
+  if (codes.has('composite-genre') || codes.has('parenthetical-genre')) {
+    return 'decompose-recipe'
+  }
+  if (
+    codes.has('setting-shaped-genre') ||
+    codes.has('subject-shaped-genre') ||
+    codes.has('occupation-shaped-personality') ||
+    codes.has('worldview-shaped-personality') ||
+    codes.has('quirk-shaped-backstory')
+  ) {
+    return 'repair-taxonomy'
+  }
+  if (codes.has('prompt-cargo-cult') || codes.has('underspecified-title')) {
+    return 'suppress-random'
+  }
+  return 'review-quality'
+}
+
+function buildDuplicateMap(
+  facets: readonly FacetAuditInput[],
+): Map<string, FacetAuditInput[]> {
+  const byTitle = new Map<string, FacetAuditInput[]>()
+  for (const facet of facets) {
+    const key = normalizeFacetAuditKey(facet.title)
+    if (!key) continue
+    const entries = byTitle.get(key) ?? []
+    entries.push(facet)
+    byTitle.set(key, entries)
+  }
+  return new Map(
+    [...byTitle.entries()].filter(([, entries]) => entries.length > 1),
+  )
+}
+
+function scoreFacet(
+  facet: FacetAuditInput,
+  duplicates: Map<string, FacetAuditInput[]>,
+): FacetAuditCandidate | null {
+  const reasons: FacetAuditReason[] = []
+  const taxonomy = facet.taxonomy
+  const titleWords = wordCount(facet.title)
+  const normalizedTitle = normalizeFacetAuditKey(facet.title)
+
+  if (!taxonomy) {
+    pushReason(
+      reasons,
+      'missing-profile',
+      6,
+      'Active Facet has no authoritative taxonomy profile.',
+    )
+  }
+
+  if (duplicates.has(normalizedTitle)) {
+    const cluster = duplicates.get(normalizedTitle) ?? []
+    pushReason(
+      reasons,
+      'duplicate-title',
+      6,
+      `Normalized title is shared by Facet ids ${cluster
+        .map((entry) => entry.id)
+        .join(', ')}.`,
+    )
+  }
+
+  if (facet.isRandomizable && CARGO_CULT_PATTERN.test(facet.title)) {
+    pushReason(
+      reasons,
+      'prompt-cargo-cult',
+      7,
+      'Randomized prompt-control title is a quality or resolution incantation rather than creative direction.',
+    )
+  }
+
+  if (taxonomy === 'GENRE') {
+    if (/\([^)]{2,}\)/.test(facet.title)) {
+      pushReason(
+        reasons,
+        'parenthetical-genre',
+        5,
+        'Parenthetical genre likely combines a reusable base genre with a theme, mood, setting, or perspective.',
+      )
+    }
+    if (
+      /\b(?:with|from|but|and|in which|where)\b/i.test(facet.title) &&
+      titleWords >= 4
+    ) {
+      pushReason(
+        reasons,
+        'composite-genre',
+        4,
+        'Genre title reads as a sealed multi-Facet recipe.',
+      )
+    }
+    if (SETTING_SHAPED_GENRE_PATTERN.test(facet.title)) {
+      pushReason(
+        reasons,
+        'setting-shaped-genre',
+        4,
+        'Title primarily names a place, environment, institution, or world structure.',
+      )
+    }
+    if (SUBJECT_SHAPED_GENRE_PATTERN.test(facet.title)) {
+      pushReason(
+        reasons,
+        'subject-shaped-genre',
+        4,
+        'Title primarily names subject matter, cast, source tradition, or point of view.',
+      )
+    }
+    if (
+      facet.isRandomizable &&
+      facet.randomWeight === 1 &&
+      (facet.sourceRank ?? 100) >= 30
+    ) {
+      pushReason(
+        reasons,
+        'flat-legacy-genre-weight',
+        1,
+        'Legacy or generated genre still has the undifferentiated default weight of 1.',
+      )
+    }
+  }
+
+  if (
+    taxonomy === 'PERSONALITY' &&
+    OCCUPATION_SHAPED_PERSONALITY_PATTERN.test(facet.title)
+  ) {
+    pushReason(
+      reasons,
+      'occupation-shaped-personality',
+      4,
+      'Title names a role or profession rather than temperament.',
+    )
+  }
+
+  if (
+    taxonomy === 'PERSONALITY' &&
+    WORLDVIEW_SHAPED_PERSONALITY_PATTERN.test(facet.title)
+  ) {
+    pushReason(
+      reasons,
+      'worldview-shaped-personality',
+      3,
+      'Title names a worldview, belief, or claimed ability rather than temperament.',
+    )
+  }
+
+  if (
+    taxonomy === 'BACKSTORY' &&
+    QUIRK_SHAPED_BACKSTORY_PATTERN.test(facet.title)
+  ) {
+    pushReason(
+      reasons,
+      'quirk-shaped-backstory',
+      4,
+      'Title describes an ongoing behavior or constraint rather than prior history.',
+    )
+  }
+
+  if (titleWords >= 9) {
+    pushReason(
+      reasons,
+      'sentence-title',
+      2,
+      `Title contains ${titleWords} words and may be a one-off prompt rather than reusable taxonomy.`,
+    )
+  }
+
+  if (
+    facet.isRandomizable &&
+    titleWords <= 1 &&
+    facet.title.length <= 10 &&
+    !facet.description &&
+    !facet.flavorText &&
+    !facet.examples
+  ) {
+    pushReason(
+      reasons,
+      'underspecified-title',
+      2,
+      'Very short randomizable Facet has no prose explaining its creative effect.',
+    )
+  }
+
+  if (
+    facet.isRandomizable &&
+    !facet.description &&
+    !facet.flavorText &&
+    !facet.examples &&
+    !facet.artPrompt &&
+    !facet.artBacked &&
+    (facet.sourceRank ?? 100) >= 80
+  ) {
+    pushReason(
+      reasons,
+      'unreviewed-legacy-record',
+      2,
+      'Randomizable high-rank legacy record has no prose, prompt, or artwork.',
+    )
+  }
+
+  if (!reasons.length) return null
+
+  const score = reasons.reduce((total, reason) => total + reason.score, 0)
+  return {
+    ...facet,
+    score,
+    reasons,
+    actionHint: actionHintFor(reasons),
+    preservationMode: facet.artBacked
+      ? 'preserve-row-and-art'
+      : 'free-to-rebuild',
+  }
+}
+
+export function auditFacetCatalog(
+  facets: readonly FacetAuditInput[],
+): FacetAuditReport {
+  const duplicates = buildDuplicateMap(facets)
+  const candidates = facets
+    .map((facet) => scoreFacet(facet, duplicates))
+    .filter((facet): facet is FacetAuditCandidate => Boolean(facet))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score
+      if (a.artBacked !== b.artBacked) return a.artBacked ? 1 : -1
+      return a.title.localeCompare(b.title)
+    })
+
+  const byTaxonomy: Record<string, number> = {}
+  for (const facet of facets) {
+    const key = facet.taxonomy ?? 'MISSING_PROFILE'
+    byTaxonomy[key] = (byTaxonomy[key] ?? 0) + 1
+  }
+
+  const byReason: Record<string, number> = {}
+  for (const candidate of candidates) {
+    for (const reason of candidate.reasons) {
+      byReason[reason.code] = (byReason[reason.code] ?? 0) + 1
+    }
+  }
+
+  const duplicateClusters = [...duplicates.entries()]
+    .map(([normalizedTitle, entries]) => ({
+      normalizedTitle,
+      facetIds: entries.map((entry) => entry.id),
+      titles: entries.map((entry) => entry.title),
+    }))
+    .sort((a, b) => a.normalizedTitle.localeCompare(b.normalizedTitle))
+
+  return {
+    totals: {
+      activeFacets: facets.length,
+      randomizableFacets: facets.filter((facet) => facet.isRandomizable).length,
+      artBackedFacets: facets.filter((facet) => facet.artBacked).length,
+      candidateFacets: candidates.length,
+      criticalCandidates: candidates.filter((facet) => facet.score >= 6).length,
+    },
+    byTaxonomy,
+    byReason,
+    duplicateClusters,
+    candidates,
+  }
+}

--- a/utils/scripts/auditFacetCatalogOddities.ts
+++ b/utils/scripts/auditFacetCatalogOddities.ts
@@ -1,0 +1,172 @@
+// /utils/scripts/auditFacetCatalogOddities.ts
+import 'dotenv/config'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import {
+  auditFacetCatalog,
+  type FacetAuditInput,
+} from './../facetCatalogAudit'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({
+  adapter: createDatabaseAdapter(databaseUrl),
+})
+
+function numericArgument(name: string, fallback: number): number {
+  const prefix = `--${name}=`
+  const raw = process.argv.find((argument) => argument.startsWith(prefix))
+  if (!raw) return fallback
+  const value = Number.parseInt(raw.slice(prefix.length), 10)
+  return Number.isFinite(value) && value >= 0 ? value : fallback
+}
+
+const top = numericArgument('top', 60)
+const strict = process.argv.includes('--strict')
+
+async function main(): Promise<void> {
+  const [facets, profiles, aliases, artImageLinks, artCollectionLinks] =
+    await Promise.all([
+      prisma.facet.findMany({
+        where: { isActive: true },
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          description: true,
+          flavorText: true,
+          examples: true,
+          artPrompt: true,
+          imagePath: true,
+          cardPath: true,
+          heroPath: true,
+          icon: true,
+          artImageId: true,
+          artCollectionId: true,
+        },
+      }),
+      prisma.facetProfile.findMany({
+        select: {
+          facetId: true,
+          taxonomy: true,
+          groupKey: true,
+          groupLabel: true,
+          isRandomizable: true,
+          randomWeight: true,
+          sourceRank: true,
+        },
+      }),
+      prisma.facetAlias.findMany({
+        where: { isActive: true },
+        select: { facetId: true, alias: true },
+      }),
+      prisma.facetArtImage.findMany({ select: { facetId: true } }),
+      prisma.facetArtCollection.findMany({ select: { facetId: true } }),
+    ])
+
+  const profilesByFacet = new Map(
+    profiles.map((profile) => [profile.facetId, profile]),
+  )
+  const aliasesByFacet = new Map<number, string[]>()
+  for (const alias of aliases) {
+    const entries = aliasesByFacet.get(alias.facetId) ?? []
+    entries.push(alias.alias)
+    aliasesByFacet.set(alias.facetId, entries)
+  }
+  const artImageFacetIds = new Set(artImageLinks.map((link) => link.facetId))
+  const artCollectionFacetIds = new Set(
+    artCollectionLinks.map((link) => link.facetId),
+  )
+
+  const inputs: FacetAuditInput[] = facets.map((facet) => {
+    const profile = profilesByFacet.get(facet.id)
+    return {
+      id: facet.id,
+      title: facet.title,
+      slug: facet.slug,
+      taxonomy: profile?.taxonomy ?? null,
+      groupKey: profile?.groupKey ?? null,
+      groupLabel: profile?.groupLabel ?? null,
+      isRandomizable: profile?.isRandomizable ?? false,
+      randomWeight: profile?.randomWeight ?? 0,
+      sourceRank: profile?.sourceRank ?? null,
+      description: facet.description,
+      flavorText: facet.flavorText,
+      examples: facet.examples,
+      artPrompt: facet.artPrompt,
+      aliases: aliasesByFacet.get(facet.id) ?? [],
+      artBacked: Boolean(
+        facet.imagePath ||
+          facet.cardPath ||
+          facet.heroPath ||
+          facet.icon ||
+          facet.artImageId !== null ||
+          facet.artCollectionId !== null ||
+          artImageFacetIds.has(facet.id) ||
+          artCollectionFacetIds.has(facet.id),
+      ),
+    }
+  })
+
+  const report = auditFacetCatalog(inputs)
+  const critical = report.candidates.filter((candidate) => candidate.score >= 6)
+  const output = {
+    generatedAt: new Date().toISOString(),
+    mode: strict ? 'strict' : 'report',
+    policy: {
+      artBacked:
+        'Preserve the Facet row, artwork, prompt, and tone. Prefer reclassification, relationships, aliases, or recipe decomposition.',
+      exactSynonym:
+        'Merge only after migrating every assignment, reaction, alias, relation, and artwork edge.',
+      nearSynonym:
+        'Keep distinct and connect with RELATED rather than forcing an alias.',
+      composite:
+        'Keep the historic row as a nonrandom recipe and create reusable component Facets.',
+      lowValue:
+        'Remove from random selection before considering deletion.',
+    },
+    totals: report.totals,
+    byTaxonomy: report.byTaxonomy,
+    byReason: report.byReason,
+    duplicateClusters: report.duplicateClusters,
+    candidates: report.candidates.slice(0, top).map((candidate) => ({
+      id: candidate.id,
+      title: candidate.title,
+      slug: candidate.slug,
+      taxonomy: candidate.taxonomy,
+      score: candidate.score,
+      artBacked: candidate.artBacked,
+      preservationMode: candidate.preservationMode,
+      actionHint: candidate.actionHint,
+      isRandomizable: candidate.isRandomizable,
+      randomWeight: candidate.randomWeight,
+      sourceRank: candidate.sourceRank,
+      reasons: candidate.reasons,
+    })),
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+
+  if (strict) {
+    const missingProfiles = critical.filter((candidate) =>
+      candidate.reasons.some((reason) => reason.code === 'missing-profile'),
+    )
+    const duplicateTitles = report.duplicateClusters.length
+    if (missingProfiles.length || duplicateTitles) {
+      throw new Error(
+        `Strict Facet audit failed: ${missingProfiles.length} active Facets lack profiles and ${duplicateTitles} duplicate-title clusters remain.`,
+      )
+    }
+  }
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/verifyFacetCatalogAudit.ts
+++ b/utils/scripts/verifyFacetCatalogAudit.ts
@@ -1,0 +1,203 @@
+// /utils/scripts/verifyFacetCatalogAudit.ts
+import {
+  auditFacetCatalog,
+  type FacetAuditInput,
+} from './../facetCatalogAudit'
+
+function fixture(
+  overrides: Partial<FacetAuditInput> & Pick<FacetAuditInput, 'id' | 'title'>,
+): FacetAuditInput {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    slug: overrides.slug ?? overrides.title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    taxonomy: overrides.taxonomy ?? 'OTHER',
+    groupKey: overrides.groupKey ?? null,
+    groupLabel: overrides.groupLabel ?? null,
+    isRandomizable: overrides.isRandomizable ?? true,
+    randomWeight: overrides.randomWeight ?? 1,
+    sourceRank: overrides.sourceRank ?? 10,
+    description: overrides.description ?? 'Curated description.',
+    flavorText: overrides.flavorText ?? null,
+    examples: overrides.examples ?? null,
+    artPrompt: overrides.artPrompt ?? null,
+    aliases: overrides.aliases ?? [],
+    artBacked: overrides.artBacked ?? false,
+  }
+}
+
+function candidateById(
+  report: ReturnType<typeof auditFacetCatalog>,
+  id: number,
+) {
+  return report.candidates.find((candidate) => candidate.id === id)
+}
+
+function requireCondition(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+function hasReason(
+  candidate: NonNullable<ReturnType<typeof candidateById>>,
+  code: string,
+): boolean {
+  return candidate.reasons.some((reason) => reason.code === code)
+}
+
+function main(): void {
+  const report = auditFacetCatalog([
+    fixture({
+      id: 1,
+      title: 'The Big Blue',
+      taxonomy: 'SETTING',
+      randomWeight: 1.5,
+      sourceRank: 1,
+      artBacked: true,
+    }),
+    fixture({
+      id: 2,
+      title: 'Noir (one detail wrong)',
+      taxonomy: 'GENRE',
+      sourceRank: 30,
+    }),
+    fixture({
+      id: 3,
+      title: 'Creative Writer',
+      taxonomy: 'PERSONALITY',
+      artBacked: true,
+    }),
+    fixture({
+      id: 4,
+      title: '4k render',
+      taxonomy: 'PROMPT_ENHANCEMENT',
+      description: null,
+    }),
+    fixture({
+      id: 5,
+      title: 'Optimistic',
+      taxonomy: 'PERSONALITY',
+    }),
+    fixture({
+      id: 6,
+      title: 'Optimistic',
+      taxonomy: 'PERSONALITY',
+      artBacked: true,
+    }),
+    fixture({
+      id: 7,
+      title: 'Practical',
+      taxonomy: 'PERSONALITY',
+    }),
+    fixture({
+      id: 8,
+      title: 'Pragmatic',
+      taxonomy: 'PERSONALITY',
+    }),
+    fixture({
+      id: 9,
+      title: 'Can only sleep standing up, and only on moving trains.',
+      taxonomy: 'BACKSTORY',
+      sourceRank: 90,
+      description: null,
+    }),
+    fixture({
+      id: 10,
+      title: 'Underwater Cathedral',
+      taxonomy: 'GENRE',
+      sourceRank: 30,
+    }),
+    fixture({
+      id: 11,
+      title: 'Profileless',
+      taxonomy: null,
+    }),
+  ])
+
+  requireCondition(
+    !candidateById(report, 1),
+    'A curated art-backed SETTING must not be flagged merely because its title names a place.',
+  )
+
+  const composite = candidateById(report, 2)
+  requireCondition(composite, 'Composite GENRE must be audited.')
+  requireCondition(
+    hasReason(composite, 'parenthetical-genre'),
+    'Composite GENRE must carry the parenthetical reason.',
+  )
+  requireCondition(
+    composite.actionHint === 'decompose-recipe',
+    'Composite GENRE must recommend recipe decomposition.',
+  )
+
+  const occupation = candidateById(report, 3)
+  requireCondition(occupation, 'Occupation-shaped PERSONALITY must be audited.')
+  requireCondition(
+    occupation.actionHint === 'repair-taxonomy',
+    'Occupation-shaped PERSONALITY must recommend taxonomy repair.',
+  )
+  requireCondition(
+    occupation.preservationMode === 'preserve-row-and-art',
+    'Art-backed taxonomy leak must preserve its row and art.',
+  )
+
+  const cargoCult = candidateById(report, 4)
+  requireCondition(cargoCult, 'Prompt cargo cult must be audited.')
+  requireCondition(
+    hasReason(cargoCult, 'prompt-cargo-cult'),
+    'Prompt cargo cult reason is required.',
+  )
+  requireCondition(
+    cargoCult.actionHint === 'suppress-random',
+    'Prompt cargo cult must recommend random suppression.',
+  )
+
+  const duplicateA = candidateById(report, 5)
+  const duplicateB = candidateById(report, 6)
+  requireCondition(duplicateA && duplicateB, 'Exact duplicate titles must be audited.')
+  requireCondition(
+    duplicateA.actionHint === 'merge-exact-synonym' &&
+      duplicateB.actionHint === 'merge-exact-synonym',
+    'Exact duplicate titles must recommend merge review.',
+  )
+  requireCondition(
+    report.duplicateClusters.some(
+      (cluster) =>
+        cluster.normalizedTitle === 'optimistic' &&
+        cluster.facetIds.includes(5) &&
+        cluster.facetIds.includes(6),
+    ),
+    'Duplicate-title cluster must identify both Facets.',
+  )
+
+  requireCondition(
+    !report.duplicateClusters.some((cluster) =>
+      cluster.facetIds.some((id) => id === 7 || id === 8),
+    ),
+    'Near-neighbor traits must not be treated as exact aliases.',
+  )
+
+  const quirkBackstory = candidateById(report, 9)
+  requireCondition(quirkBackstory, 'Quirk-shaped BACKSTORY must be audited.')
+  requireCondition(
+    hasReason(quirkBackstory, 'quirk-shaped-backstory'),
+    'Quirk-shaped BACKSTORY must carry the taxonomy reason.',
+  )
+
+  const settingGenre = candidateById(report, 10)
+  requireCondition(settingGenre, 'Setting-shaped GENRE must be audited.')
+  requireCondition(
+    hasReason(settingGenre, 'setting-shaped-genre'),
+    'Setting-shaped GENRE must carry the taxonomy reason.',
+  )
+
+  const profileless = candidateById(report, 11)
+  requireCondition(profileless, 'Profileless Facet must be audited.')
+  requireCondition(
+    profileless.score >= 6 && hasReason(profileless, 'missing-profile'),
+    'Profileless Facet must be critical.',
+  )
+
+  process.stdout.write('Whole-catalog Facet audit behavior verified.\n')
+}
+
+main()

--- a/utils/scripts/verifyFacetCatalogAudit.ts
+++ b/utils/scripts/verifyFacetCatalogAudit.ts
@@ -11,7 +11,7 @@ function fixture(
     id: overrides.id,
     title: overrides.title,
     slug: overrides.slug ?? overrides.title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
-    taxonomy: overrides.taxonomy ?? 'OTHER',
+    taxonomy: overrides.taxonomy === undefined ? 'OTHER' : overrides.taxonomy,
     groupKey: overrides.groupKey ?? null,
     groupLabel: overrides.groupLabel ?? null,
     isRandomizable: overrides.isRandomizable ?? true,


### PR DESCRIPTION
## Batch 7: whole-catalog audit

This adds a read-only audit that runs after every production Facet curation pass and ranks the next cleanup candidates across the complete active catalog.

### Signals scored

- exact normalized duplicate titles
- missing taxonomy profiles
- parenthetical and sealed composite genres
- setting-shaped and subject-shaped genres
- occupation- or worldview-shaped personalities
- quirk-shaped backstories
- sentence-sized one-off titles
- prompt cargo-cult controls such as resolution and quality claims
- unreviewed legacy records with no prose, prompt, or art
- legacy GENRE records still using the undifferentiated default weight

### Art policy

Every candidate is labeled `preserve-row-and-art` or `free-to-rebuild`. Art detection includes direct image/card/hero/icon fields, direct ArtImage/ArtCollection ids, and joined Facet artwork records.

### Recommendations

The audit assigns one action hint: merge exact synonym, decompose recipe, repair taxonomy, suppress from random, or review quality. Near-neighbor concepts are not treated as exact duplicates.

### Deployment behavior

The production build runs the audit after all six mutation batches and prints the top 60 ranked candidates. It is report-only while cleanup is ongoing. Optional `--strict` mode can later block on missing profiles or exact duplicate-title clusters.

### Validation

Fixture-based behavior verifies that:

- The Big Blue is not flagged after becoming a SETTING
- composite genres recommend recipe decomposition
- art-backed taxonomy leaks preserve their row and art
- prompt cargo recommends random suppression
- exact duplicates form merge clusters
- Practical and Pragmatic are not falsely aliased
- quirk-shaped backstories and setting-shaped genres are detected
- missing profiles are critical

The operating rules are documented in `docs/facet-catalog-curation-policy.md`.