### PR TITLE
fix(vercel): keep Personality Facet curation out of production deploys

### DIFF
--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -113,14 +113,6 @@ if (!isVercelBuild || isProductionDeployment) {
     'Repairing subject themes and remaining genre hybrids',
   )
 
-  // Near-neighbor Personality Facets remain distinct, but share explicit semantic
-  // families and reduced secondary weights so crowded wording does not dominate.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetPersonalityFamilies.ts', '--apply'],
-    'Organizing related Personality Facets without false aliases',
-  )
-
   // Read the entire post-curation catalog and print a ranked next-batch queue.
   // This never mutates data or blocks deployment while cleanup is still in motion.
   run(

--- a/utils/scripts/verifyFacetPersonalityFamilies.ts
+++ b/utils/scripts/verifyFacetPersonalityFamilies.ts
@@ -14,16 +14,9 @@ function requireText(path: string, text: string, value: string): void {
   }
 }
 
-function requireOrder(
-  path: string,
-  text: string,
-  before: string,
-  after: string,
-): void {
-  const beforeIndex = text.indexOf(before)
-  const afterIndex = text.indexOf(after)
-  if (beforeIndex < 0 || afterIndex < 0 || beforeIndex >= afterIndex) {
-    throw new Error(`${path} must run ${after} after ${before}`)
+function forbidText(path: string, text: string, value: string): void {
+  if (text.includes(value)) {
+    throw new Error(`${path} must not contain production mutation hook: ${value}`)
   }
 }
 
@@ -85,19 +78,7 @@ async function main(): Promise<void> {
     }
   }
 
-  requireText(buildPath, build, 'curateFacetPersonalityFamilies.ts')
-  requireOrder(
-    buildPath,
-    build,
-    'curateFacetGenreLeaks.ts',
-    'curateFacetPersonalityFamilies.ts',
-  )
-  requireOrder(
-    buildPath,
-    build,
-    'curateFacetPersonalityFamilies.ts',
-    'auditFacetCatalogOddities.ts',
-  )
+  forbidText(buildPath, build, 'curateFacetPersonalityFamilies.ts')
   requireText(workflowPath, workflow, 'Verify Personality semantic families')
   requireText(workflowPath, workflow, 'verifyFacetPersonalityFamilies.ts')
 


### PR DESCRIPTION
## Root cause
The production deployment for `987b618` failed inside `curateFacetPersonalityFamilies.ts --apply`. The interactive Prisma transaction exceeded its 5-second lifetime, then failed while rolling back (`P2028`, 5525ms elapsed).

This curation pass is reviewed maintenance tooling, not a prerequisite for serving the app. Coupling it to every production deploy makes a taxonomy maintenance transaction capable of taking the whole site build down and crosses the existing boundary against automatic production curation writes.

## Fix
- Remove `curateFacetPersonalityFamilies.ts --apply` from `scripts/vercel-build.mjs`.
- Keep the curator intact for explicit dry-run/manual application.
- Change its contract verifier to forbid reintroducing the production-build mutation hook while retaining all semantic-family and CI checks.

## Verification
GitHub Actions should run TypeScript, Facet Catalog Contract, Contract Tests, and the narrative contracts. A successful production deployment after merge is the final health check.

Vercel deployment: `dpl_7r5bhohJ4gir5NmD7kmLJe8BfQaT`