### PR TITLE
fix(model-builder): reject writes to a cancelled build run server-side

### DIFF
--- a/server/api/model-builder/items/[id].patch.ts
+++ b/server/api/model-builder/items/[id].patch.ts
@@ -6,6 +6,7 @@ import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
   assertRunAccess,
+  assertRunWritable,
   getItemId,
   prepareItemUpdate,
   type ItemPatchBody,
@@ -24,7 +25,7 @@ export default defineEventHandler(async (event) => {
 
     const existing = await prisma.modelBuildItem.findUnique({
       where: { id },
-      include: { Run: { select: { userId: true } } },
+      include: { Run: { select: { userId: true, status: true } } },
     })
     if (!existing) {
       event.node.res.statusCode = 404
@@ -35,6 +36,7 @@ export default defineEventHandler(async (event) => {
       }
     }
     assertRunAccess(existing.Run, auth.user)
+    assertRunWritable(existing.Run)
 
     const body = await readBody<ItemPatchBody>(event)
     if (body.artImageId !== undefined) {

--- a/server/api/model-builder/items/[id]/artifacts.post.ts
+++ b/server/api/model-builder/items/[id]/artifacts.post.ts
@@ -4,7 +4,12 @@ import type { ModelBuildReviewState } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
-import { assertRunAccess, getItemId, normalizeNullableId } from '../../runs/index'
+import {
+  assertRunAccess,
+  assertRunWritable,
+  getItemId,
+  normalizeNullableId,
+} from '../../runs/index'
 import { assertArtImageAttachable } from '../../relations'
 
 const reviewStates = new Set<ModelBuildReviewState>([
@@ -47,7 +52,7 @@ export default defineEventHandler(async (event) => {
 
     const item = await prisma.modelBuildItem.findUnique({
       where: { id: itemId },
-      include: { Run: { select: { userId: true } } },
+      include: { Run: { select: { userId: true, status: true } } },
     })
     if (!item) {
       event.node.res.statusCode = 404
@@ -58,6 +63,7 @@ export default defineEventHandler(async (event) => {
       }
     }
     assertRunAccess(item.Run, auth.user)
+    assertRunWritable(item.Run)
 
     const body = await readBody<ArtifactBody>(event)
     if (typeof body.kind !== 'string' || !body.kind.trim()) {

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -5,7 +5,12 @@ import type { DreamType, Rarity, RewardType } from '~/prisma/generated/prisma/cl
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
-import { assertRunAccess, getItemId, parseStoredJson } from '../../runs/index'
+import {
+  assertRunAccess,
+  assertRunWritable,
+  getItemId,
+  parseStoredJson,
+} from '../../runs/index'
 import { CREATE_TARGETS, fieldSpecFor } from '~/stores/helpers/modelBuilderFields'
 import { BUILD_STAGES } from '~/stores/helpers/modelBuilderRecipes'
 import { syncCharacterFacetsInTransaction } from '~/server/utils/characterFacetSync'
@@ -513,13 +518,16 @@ export default defineEventHandler(async (event) => {
 
     const item = await prisma.modelBuildItem.findUnique({
       where: { id },
-      include: { Run: { select: { userId: true, sourceType: true, sourceId: true } } },
+      include: {
+        Run: { select: { userId: true, sourceType: true, sourceId: true, status: true } },
+      },
     })
     if (!item) {
       event.node.res.statusCode = 404
       return { success: false, message: 'Build item not found.', statusCode: 404 }
     }
     assertRunAccess(item.Run, auth.user)
+    assertRunWritable(item.Run)
 
     // The front-end only ever calls commitItem() once COMMIT has unlocked,
     // which approveStage only does after PITCH, FIELDS_AND_PROMPTS, and

--- a/server/api/model-builder/items/batch.patch.ts
+++ b/server/api/model-builder/items/batch.patch.ts
@@ -12,6 +12,7 @@ import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
   assertRunAccess,
+  assertRunWritable,
   prepareItemUpdate,
   type ItemPatchBody,
 } from '../runs/index'
@@ -82,7 +83,7 @@ export default defineEventHandler(async (event) => {
 
         const existing = await prisma.modelBuildItem.findUnique({
           where: { id },
-          include: { Run: { select: { userId: true } } },
+          include: { Run: { select: { userId: true, status: true } } },
         })
         if (!existing) {
           throw createError({
@@ -91,6 +92,7 @@ export default defineEventHandler(async (event) => {
           })
         }
         assertRunAccess(existing.Run, auth.user)
+        assertRunWritable(existing.Run)
 
         if (entry.artImageId !== undefined) {
           await assertArtImageAttachable(

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -61,6 +61,28 @@ export function assertRunAccess(
   }
 }
 
+// cancelRun() marks a run CANCELLED specifically so no further work lands on
+// it — but that intent is enforced only client-side, and only for the one
+// store instance that issued the cancellation: modelBuilderStore.ts's
+// cancelledRunIds is an in-memory Set that guards a single tab's own
+// in-flight calls racing the exact moment of cancellation, and cancelRun()
+// only clears that tab's remembered-run localStorage key when the cancelled
+// run happens to be the one currently open in that same tab. A second
+// browser tab (or a later page load reading a stale `modelBuilder:runId`
+// left behind because the cancellation happened in a different tab) has no
+// way to learn the run was cancelled and would otherwise keep editing
+// fields, generating assets, and even durably committing records into a run
+// the user already told the app to abandon. Every write-capable item route
+// must refuse once the run itself says it's done.
+export function assertRunWritable(run: { status: ModelBuildStatus }): void {
+  if (run.status === 'CANCELLED') {
+    throw createError({
+      statusCode: 409,
+      message: 'This build run was cancelled and can no longer be modified.',
+    })
+  }
+}
+
 export function normalizeText(value: unknown): string | null | undefined {
   if (value === undefined) return undefined
   if (value === null) return null


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software, recurring)

### What changed / what I produced
- Added `assertRunWritable(run)` in `server/api/model-builder/runs/index.ts`, which throws a 409 if `run.status === 'CANCELLED'`.
- Called it (after the existing `assertRunAccess` ownership check) in the four write-capable item routes: `items/[id].patch.ts`, `items/batch.patch.ts`, `items/[id]/artifacts.post.ts`, `items/[id]/commit.post.ts`.

### The bug
`cancelRun()` marks a `ModelBuildRun` `CANCELLED` server-side specifically so no further work lands on it, but that intent was enforced only client-side, and only within the single Pinia store instance that issued the cancellation (`cancelledRunIds` is an in-memory `Set`, wiped on reload; `cancelRun()` only clears the *current* tab's own `modelBuilder:runId` localStorage key). A second tab — or a tab reloaded later with a stale `modelBuilder:runId` — has no way to learn the run was cancelled elsewhere, and could keep editing fields, generating art, and calling `commitItem()` (which durably creates/links/promotes a canonical record) against a run the user already told the app to abandon. None of the write routes checked `Run.status` at all, only ownership.

This gap was actually already implicitly acknowledged by two existing regression-guard comments in this codebase (`utils/scripts/verifyModelBuilderCommitCancelledRunGuard.ts`: "The commit POST durably creates/links/promotes the target server-side regardless -- that can't be undone from here") — those guards cover the client-side toast/reattachment behavior after cancellation, not the fact that the server never refused the write in the first place. This PR closes that root gap.

### How I verified
- `npx eslint` on all 5 changed files: clean.
- `npx vue-tsc --noEmit -p tsconfig.json` (full project): exit 0.
- `npx prettier --check` on the changed files: pre-existing drift only, confirmed identical with/without this diff via `git stash` (matches this task's established convention of not blanket-reformatting unrelated lines).
- Manual read confirming `assertRunWritable` is called after `assertRunAccess` in all four write routes, with `status: true` added to each route's `Run` select so the field is available.
- No database access in this sandbox, so no live end-to-end run/cancel/write test — relying on kind_robots CI for that.

### Stakes
reversible

### Flags for Reviewer
- Did not add a dedicated `utils/scripts/verifyModelBuilder*.ts` textual regression guard for this fix (several sibling fixes in this task's history did add one). Kept the diff minimal instead; a follow-up guard script would need `npm run test:...` + `contract-tests.yml` wiring, which felt like more scope than this single-session cycle should add unverified. Flagging as the kaizen suggestion below instead.

### Kaizen suggestion
Add `utils/scripts/verifyModelBuilderRunWritableGuard.ts` (+ `.test.ts` + `contract-tests.yml` step), mirroring `verifyModelBuilderItemPatchStageGuard.ts`'s pattern, asserting `assertRunWritable(...)` is called in all four write routes — so a future refactor can't silently drop the check the way the client-only `cancelledRunIds` gap sat unfixed for this long.

### Notes for reviewer
Step (1) of t-029 (dashboard-tab + tutorial `.webp` art) remains the sole outstanding original deliverable of that task, still blocked on the external art-generation relay this sandbox can't reach — unrelated to this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T6yFH4Dfna7yW8D1XMLVpt)_