### PR TITLE
collapse facet duplicates and retire global moods

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Verify Personality semantic families
         run: npx tsx utils/scripts/verifyFacetPersonalityFamilies.ts
 
+      - name: Verify final Facet catalog directives
+        run: npx tsx utils/scripts/verifyFacetCatalogDirectives.ts
+
       - name: Verify whole-catalog Facet audit
         run: npx tsx utils/scripts/verifyFacetCatalogAudit.ts
 

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -113,6 +113,15 @@ if (!isVercelBuild || isProductionDeployment) {
     'Repairing subject themes and remaining genre hybrids',
   )
 
+  // Apply the user-reviewed catalog model last: merge specialist duplicates into
+  // canonical aliases, make punk families genres, remove global MOOD Facets, and
+  // physically delete migrated duplicate and recipe-shell records.
+  run(
+    tsxBinary,
+    ['utils/scripts/applyFacetCatalogDirectives.ts', '--apply'],
+    'Applying final Facet catalog directives and deleting historical shells',
+  )
+
   // Read the entire post-curation catalog and print a ranked next-batch queue.
   // This never mutates data or blocks deployment while cleanup is still in motion.
   run(

--- a/utils/scripts/applyFacetCatalogDirectives.ts
+++ b/utils/scripts/applyFacetCatalogDirectives.ts
@@ -20,17 +20,16 @@ type JsonObject = Record<string, unknown>
 
 type MergeDefinition = {
   canonicalSlug: string
+  finalSlug?: string
   duplicateSlugs: readonly string[]
   aliases: readonly string[]
   title?: string
-  slug?: string
   taxonomy: FacetTaxonomy
   canonicalValue?: string
   groupKey: string
   groupLabel: string
   randomWeight: number
   description?: string
-  cardPathFromSlug?: string
 }
 
 type AtmosphereDefinition = {
@@ -113,6 +112,7 @@ const MERGES: readonly MergeDefinition[] = [
   },
   {
     canonicalSlug: 'circuscore',
+    finalSlug: 'circus',
     duplicateSlugs: ['art-punk-carnivalpunk', 'carnival', 'dark-carnival'],
     aliases: [
       'CircusCore',
@@ -125,7 +125,6 @@ const MERGES: readonly MergeDefinition[] = [
       'Dark Carnival',
     ],
     title: 'Circus',
-    slug: 'circus',
     taxonomy: 'GENRE',
     canonicalValue: 'Circus',
     groupKey: 'genre',
@@ -133,7 +132,6 @@ const MERGES: readonly MergeDefinition[] = [
     randomWeight: 1.5,
     description:
       'Circus and carnival stories built from spectacle, performance, impossible attractions, faded glamour, dangerous wonder, and the suspicion that the show has been waiting for you.',
-    cardPathFromSlug: 'carnival',
   },
 ]
 
@@ -188,6 +186,16 @@ function legacyKindForTaxonomy(
   }
 }
 
+async function findCanonical(definition: MergeDefinition) {
+  const finalSlug = definition.finalSlug ?? definition.canonicalSlug
+  return (
+    (await prisma.facet.findUnique({ where: { slug: finalSlug } })) ??
+    (await prisma.facet.findUnique({
+      where: { slug: definition.canonicalSlug },
+    }))
+  )
+}
+
 async function hasArtwork(facet: {
   id: number
   imagePath: string | null
@@ -222,6 +230,14 @@ async function installAliases(facetId: number, aliases: readonly string[]): Prom
     const lookupKey = normalizeFacetLookupKey(alias)
     if (!lookupKey) continue
 
+    const conflict = await prisma.facetAlias.findUnique({
+      where: { lookupKey },
+      select: { facetId: true },
+    })
+    if (conflict && conflict.facetId !== facetId) {
+      await prisma.facetAlias.delete({ where: { lookupKey } })
+    }
+
     await prisma.facetAlias.upsert({
       where: { lookupKey },
       create: {
@@ -241,21 +257,23 @@ async function installAliases(facetId: number, aliases: readonly string[]): Prom
   }
 }
 
-async function moveDuplicateIntoCanonical(
-  canonicalSlug: string,
+async function migrateDuplicate(
+  definition: MergeDefinition,
   duplicateSlug: string,
 ): Promise<object> {
-  const canonical = await prisma.facet.findUnique({
-    where: { slug: canonicalSlug },
-  })
-  if (!canonical) throw new Error(`Missing canonical Facet ${canonicalSlug}.`)
+  const canonical = await findCanonical(definition)
+  if (!canonical) {
+    throw new Error(
+      `Missing canonical Facet ${definition.finalSlug ?? definition.canonicalSlug}.`,
+    )
+  }
 
   const duplicate = await prisma.facet.findUnique({
     where: { slug: duplicateSlug },
   })
-  if (!duplicate) {
+  if (!duplicate || duplicate.id === canonical.id) {
     return {
-      canonicalSlug,
+      canonicalId: canonical.id,
       duplicateSlug,
       action: 'already-merged',
     }
@@ -340,7 +358,6 @@ async function moveDuplicateIntoCanonical(
 
   const report = {
     canonicalId: canonical.id,
-    canonicalSlug,
     duplicateId: duplicate.id,
     duplicateSlug,
     characterLinks: characterLinks.length,
@@ -388,13 +405,13 @@ async function moveDuplicateIntoCanonical(
     })
   }
 
-  const allArtImageIds = new Set([
+  const artImageIds = new Set([
     ...artImageLinks.map((link) => link.artImageId),
     ...(duplicate.artImageId ? [duplicate.artImageId] : []),
   ])
-  if (allArtImageIds.size) {
+  if (artImageIds.size) {
     await prisma.facetArtImage.createMany({
-      data: [...allArtImageIds].map((artImageId) => ({
+      data: [...artImageIds].map((artImageId) => ({
         facetId: canonical.id,
         artImageId,
       })),
@@ -402,13 +419,13 @@ async function moveDuplicateIntoCanonical(
     })
   }
 
-  const allArtCollectionIds = new Set([
+  const artCollectionIds = new Set([
     ...artCollectionLinks.map((link) => link.artCollectionId),
     ...(duplicate.artCollectionId ? [duplicate.artCollectionId] : []),
   ])
-  if (allArtCollectionIds.size) {
+  if (artCollectionIds.size) {
     await prisma.facetArtCollection.createMany({
-      data: [...allArtCollectionIds].map((artCollectionId) => ({
+      data: [...artCollectionIds].map((artCollectionId) => ({
         facetId: canonical.id,
         artCollectionId,
       })),
@@ -444,17 +461,24 @@ async function moveDuplicateIntoCanonical(
   const priorMergedSources = Array.isArray(canonicalMetadata.mergedFacetSources)
     ? canonicalMetadata.mergedFacetSources
     : []
+  const priorArtworkPaths = Array.isArray(canonicalMetadata.mergedArtworkPaths)
+    ? canonicalMetadata.mergedArtworkPaths.filter(
+        (value): value is string => typeof value === 'string',
+      )
+    : []
   const mergedArtworkPaths = uniqueStrings([
-    ...(Array.isArray(canonicalMetadata.mergedArtworkPaths)
-      ? canonicalMetadata.mergedArtworkPaths.filter(
-          (value): value is string => typeof value === 'string',
-        )
-      : []),
+    ...priorArtworkPaths,
     duplicate.imagePath,
     duplicate.cardPath,
     duplicate.heroPath,
     duplicate.icon,
   ])
+
+  const circusCardPath =
+    (definition.finalSlug ?? definition.canonicalSlug) === 'circus' &&
+    duplicateSlug === 'carnival'
+      ? duplicate.imagePath
+      : null
 
   await prisma.facet.update({
     where: { id: canonical.id },
@@ -464,7 +488,7 @@ async function moveDuplicateIntoCanonical(
       examples: canonical.examples || duplicate.examples,
       artPrompt: canonical.artPrompt || duplicate.artPrompt,
       imagePath: canonical.imagePath || duplicate.imagePath,
-      cardPath: canonical.cardPath || duplicate.cardPath,
+      cardPath: canonical.cardPath || circusCardPath || duplicate.cardPath,
       heroPath: canonical.heroPath || duplicate.heroPath,
       icon: canonical.icon || duplicate.icon,
       artImageId: canonical.artImageId ?? duplicate.artImageId,
@@ -474,13 +498,32 @@ async function moveDuplicateIntoCanonical(
     },
   })
 
+  const mergedMetadata = JSON.stringify({
+    ...duplicateMetadata,
+    ...canonicalMetadata,
+    mergedArtworkPaths,
+    mergedFacetSources: [
+      ...priorMergedSources,
+      {
+        batchId: BATCH_ID,
+        facetId: duplicate.id,
+        slug: duplicate.slug,
+        title: duplicate.title,
+        taxonomy: duplicateProfile?.taxonomy,
+        metadata: duplicateMetadata,
+      },
+    ],
+  })
+
   await prisma.facetProfile.upsert({
     where: { facetId: canonical.id },
     create: {
       facetId: canonical.id,
       taxonomy: canonicalProfile?.taxonomy ?? duplicateProfile?.taxonomy ?? 'GENRE',
       canonicalValue:
-        canonicalProfile?.canonicalValue ?? duplicateProfile?.canonicalValue ?? canonical.title,
+        canonicalProfile?.canonicalValue ??
+        duplicateProfile?.canonicalValue ??
+        canonical.title,
       groupKey: canonicalProfile?.groupKey ?? duplicateProfile?.groupKey,
       groupLabel: canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel,
       sortOrder: canonicalProfile?.sortOrder ?? duplicateProfile?.sortOrder ?? 0,
@@ -496,44 +539,14 @@ async function moveDuplicateIntoCanonical(
         canonicalProfile?.sourceRank ?? 100,
         duplicateProfile?.sourceRank ?? 100,
       ),
-      metadata: JSON.stringify({
-        ...duplicateMetadata,
-        ...canonicalMetadata,
-        mergedArtworkPaths,
-        mergedFacetSources: [
-          ...priorMergedSources,
-          {
-            batchId: BATCH_ID,
-            facetId: duplicate.id,
-            slug: duplicate.slug,
-            title: duplicate.title,
-            taxonomy: duplicateProfile?.taxonomy,
-            metadata: duplicateMetadata,
-          },
-        ],
-      }),
+      metadata: mergedMetadata,
     },
     update: {
       sourceRank: Math.min(
         canonicalProfile?.sourceRank ?? 100,
         duplicateProfile?.sourceRank ?? 100,
       ),
-      metadata: JSON.stringify({
-        ...duplicateMetadata,
-        ...canonicalMetadata,
-        mergedArtworkPaths,
-        mergedFacetSources: [
-          ...priorMergedSources,
-          {
-            batchId: BATCH_ID,
-            facetId: duplicate.id,
-            slug: duplicate.slug,
-            title: duplicate.title,
-            taxonomy: duplicateProfile?.taxonomy,
-            metadata: duplicateMetadata,
-          },
-        ],
-      }),
+      metadata: mergedMetadata,
     },
   })
 
@@ -553,7 +566,6 @@ async function moveDuplicateIntoCanonical(
     prisma.facetAlias.deleteMany({ where: { facetId: duplicate.id } }),
     prisma.facetProfile.deleteMany({ where: { facetId: duplicate.id } }),
   ])
-
   await prisma.facet.delete({ where: { id: duplicate.id } })
 
   await installAliases(canonical.id, [
@@ -566,30 +578,31 @@ async function moveDuplicateIntoCanonical(
 }
 
 async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
-  const facet = await prisma.facet.findUnique({
-    where: { slug: definition.canonicalSlug },
-  })
-  if (!facet) throw new Error(`Missing canonical Facet ${definition.canonicalSlug}.`)
+  const facet = await findCanonical(definition)
+  if (!facet) {
+    throw new Error(
+      `Missing canonical Facet ${definition.finalSlug ?? definition.canonicalSlug}.`,
+    )
+  }
   const profile = await prisma.facetProfile.findUnique({
     where: { facetId: facet.id },
   })
-
-  const requestedCardPath = definition.cardPathFromSlug
-    ? await prisma.facet.findUnique({
-        where: { slug: definition.cardPathFromSlug },
-        select: { imagePath: true },
-      })
-    : null
+  const finalSlug = definition.finalSlug ?? definition.canonicalSlug
+  const finalTitle = definition.title ?? facet.title
 
   if (apply) {
+    const conflict = await prisma.facet.findUnique({ where: { slug: finalSlug } })
+    if (conflict && conflict.id !== facet.id) {
+      throw new Error(`Final slug ${finalSlug} is still owned by Facet ${conflict.id}.`)
+    }
+
     await prisma.facet.update({
       where: { id: facet.id },
       data: {
-        title: definition.title ?? facet.title,
-        slug: definition.slug ?? facet.slug,
+        title: finalTitle,
+        slug: finalSlug,
         kind: legacyKindForTaxonomy(definition.taxonomy),
         description: definition.description ?? facet.description,
-        cardPath: facet.cardPath || requestedCardPath?.imagePath || null,
         isActive: true,
       },
     })
@@ -599,8 +612,7 @@ async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
       create: {
         facetId: facet.id,
         taxonomy: definition.taxonomy,
-        canonicalValue:
-          definition.canonicalValue ?? definition.title ?? facet.title,
+        canonicalValue: definition.canonicalValue ?? finalTitle,
         groupKey: definition.groupKey,
         groupLabel: definition.groupLabel,
         sortOrder: profile?.sortOrder ?? 0,
@@ -619,8 +631,7 @@ async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
       },
       update: {
         taxonomy: definition.taxonomy,
-        canonicalValue:
-          definition.canonicalValue ?? definition.title ?? facet.title,
+        canonicalValue: definition.canonicalValue ?? finalTitle,
         groupKey: definition.groupKey,
         groupLabel: definition.groupLabel,
         isRandomizable: true,
@@ -639,9 +650,9 @@ async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
 
     await installAliases(facet.id, [
       definition.canonicalSlug,
+      finalSlug,
       facet.title,
-      definition.slug,
-      definition.title,
+      finalTitle,
       ...definition.aliases,
     ])
   }
@@ -649,8 +660,8 @@ async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
   return {
     facetId: facet.id,
     fromSlug: definition.canonicalSlug,
-    toSlug: definition.slug ?? definition.canonicalSlug,
-    title: definition.title ?? facet.title,
+    toSlug: finalSlug,
+    title: finalTitle,
     taxonomy: definition.taxonomy,
     action: apply ? 'canonicalized' : 'would-canonicalize',
   }
@@ -659,12 +670,12 @@ async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
 async function applyMergeDefinition(definition: MergeDefinition): Promise<object> {
   const duplicateResults = []
   for (const duplicateSlug of definition.duplicateSlugs) {
-    duplicateResults.push(
-      await moveDuplicateIntoCanonical(definition.canonicalSlug, duplicateSlug),
-    )
+    duplicateResults.push(await migrateDuplicate(definition, duplicateSlug))
   }
-  const canonical = await finalizeCanonical(definition)
-  return { canonical, duplicates: duplicateResults }
+  return {
+    canonical: await finalizeCanonical(definition),
+    duplicates: duplicateResults,
+  }
 }
 
 async function reclassifyArtAtmospheres(): Promise<object[]> {
@@ -806,8 +817,10 @@ async function reclassifyNarrativeTones(): Promise<object[]> {
 }
 
 async function renameDevotedPersonality(): Promise<object> {
-  const facet = await prisma.facet.findUnique({
-    where: { slug: 'personality-loyal' },
+  const facet = await prisma.facet.findFirst({
+    where: {
+      OR: [{ slug: 'personality-loyal' }, { title: 'Devoted' }],
+    },
   })
   if (!facet) return { action: 'missing' }
   const profile = await prisma.facetProfile.findUnique({
@@ -830,9 +843,28 @@ async function renameDevotedPersonality(): Promise<object> {
         isActive: true,
       },
     })
-    await prisma.facetProfile.update({
+    await prisma.facetProfile.upsert({
       where: { facetId: facet.id },
-      data: {
+      create: {
+        facetId: facet.id,
+        taxonomy: 'PERSONALITY',
+        canonicalValue: 'devoted',
+        groupKey: profile?.groupKey ?? 'personality',
+        groupLabel: profile?.groupLabel ?? 'Personality',
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: profile?.isRandomizable ?? true,
+        randomWeight: profile?.randomWeight ?? 1,
+        artRequired: profile?.artRequired ?? true,
+        sourceRank: profile?.sourceRank ?? 25,
+        metadata: JSON.stringify({
+          ...parseMetadata(profile?.metadata),
+          catalogDirective: {
+            batchId: BATCH_ID,
+            action: 'rename-loyal-personality-to-devoted',
+          },
+        }),
+      },
+      update: {
         taxonomy: 'PERSONALITY',
         canonicalValue: 'devoted',
         metadata: JSON.stringify({
@@ -1012,9 +1044,12 @@ async function main(): Promise<void> {
         historicalShells,
         remainingMoodCount,
         policy: {
-          duplicates: 'Migrate every known edge and artwork reference, then physically delete the duplicate row.',
-          moods: 'No global MOOD Facets remain. Art atmosphere is ART_DIRECTION; story tone is THEME.',
-          punks: 'Punk families are canonical GENRE Facets. Former style rows become aliases and metadata on the genre.',
+          duplicates:
+            'Migrate every known edge and artwork reference, then physically delete the duplicate row.',
+          moods:
+            'No global MOOD Facets remain. Art atmosphere is ART_DIRECTION; story tone is THEME.',
+          punks:
+            'Punk families are canonical GENRE Facets. Former style rows become aliases and metadata on the genre.',
         },
       },
       null,

--- a/utils/scripts/applyFacetCatalogDirectives.ts
+++ b/utils/scripts/applyFacetCatalogDirectives.ts
@@ -1,0 +1,1037 @@
+// /utils/scripts/applyFacetCatalogDirectives.ts
+import 'dotenv/config'
+import {
+  PrismaClient,
+  type FacetTaxonomy,
+} from './../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { normalizeFacetLookupKey } from './../facetAliases'
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+const prisma = new PrismaClient({
+  adapter: createDatabaseAdapter(databaseUrl),
+})
+const apply = process.argv.includes('--apply')
+const BATCH_ID = '2026-08-01-catalog-directives-09'
+
+type JsonObject = Record<string, unknown>
+
+type MergeDefinition = {
+  canonicalSlug: string
+  duplicateSlugs: readonly string[]
+  aliases: readonly string[]
+  title?: string
+  slug?: string
+  taxonomy: FacetTaxonomy
+  canonicalValue?: string
+  groupKey: string
+  groupLabel: string
+  randomWeight: number
+  description?: string
+  cardPathFromSlug?: string
+}
+
+type AtmosphereDefinition = {
+  slug: string
+  title: string
+}
+
+const MERGES: readonly MergeDefinition[] = [
+  {
+    canonicalSlug: 'afrofuturism',
+    duplicateSlugs: ['africanfuturism'],
+    aliases: ['Africanfuturism', 'African Futurism'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Afrofuturism',
+    groupKey: 'cultural-genre',
+    groupLabel: 'Cultural Genres',
+    randomWeight: 1.5,
+    description:
+      'Speculative work expressed through African and Black cultural lenses, including Africa-centered and diasporic futures shaped by identity, agency, freedom, technology, history, art, and liberated possibility.',
+  },
+  {
+    canonicalSlug: 'biopunk',
+    duplicateSlugs: ['art-punk-biopunk'],
+    aliases: ['Biopunk Aesthetic', 'Biopunk Style'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Biopunk',
+    groupKey: 'genre',
+    groupLabel: 'Genres',
+    randomWeight: 1.5,
+  },
+  {
+    canonicalSlug: 'dieselpunk',
+    duplicateSlugs: ['art-punk-dieselpunk'],
+    aliases: ['Dieselpunk Aesthetic', 'Dieselpunk Style'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Dieselpunk',
+    groupKey: 'genre',
+    groupLabel: 'Genres',
+    randomWeight: 1.5,
+  },
+  {
+    canonicalSlug: 'mythpunk',
+    duplicateSlugs: ['art-punk-mythpunk'],
+    aliases: ['Mythpunk Aesthetic', 'Mythpunk Style'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Mythpunk',
+    groupKey: 'cultural-genre',
+    groupLabel: 'Cultural Genres',
+    randomWeight: 1.5,
+  },
+  {
+    canonicalSlug: 'nanopunk',
+    duplicateSlugs: ['art-punk-nanopunk'],
+    aliases: ['Nanopunk Aesthetic', 'Nanopunk Style'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Nanopunk',
+    groupKey: 'genre',
+    groupLabel: 'Genres',
+    randomWeight: 1.5,
+  },
+  {
+    canonicalSlug: 'solarpunk',
+    duplicateSlugs: ['art-punk-solarpunk'],
+    aliases: ['Solarpunk Aesthetic', 'Solarpunk Style'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Solarpunk',
+    groupKey: 'genre',
+    groupLabel: 'Genres',
+    randomWeight: 1.5,
+  },
+  {
+    canonicalSlug: 'steampunk',
+    duplicateSlugs: ['art-punk-steampunk'],
+    aliases: ['Steampunk Aesthetic', 'Steampunk Style'],
+    taxonomy: 'GENRE',
+    canonicalValue: 'Steampunk',
+    groupKey: 'genre',
+    groupLabel: 'Genres',
+    randomWeight: 1.5,
+  },
+  {
+    canonicalSlug: 'circuscore',
+    duplicateSlugs: ['art-punk-carnivalpunk', 'carnival', 'dark-carnival'],
+    aliases: [
+      'CircusCore',
+      'Circuscore',
+      'Circuspunk',
+      'Circus Punk',
+      'Carnivalpunk',
+      'Carnival Punk',
+      'Carnival',
+      'Dark Carnival',
+    ],
+    title: 'Circus',
+    slug: 'circus',
+    taxonomy: 'GENRE',
+    canonicalValue: 'Circus',
+    groupKey: 'genre',
+    groupLabel: 'Genres',
+    randomWeight: 1.5,
+    description:
+      'Circus and carnival stories built from spectacle, performance, impossible attractions, faded glamour, dangerous wonder, and the suspicion that the show has been waiting for you.',
+    cardPathFromSlug: 'carnival',
+  },
+]
+
+const ART_ATMOSPHERES: readonly AtmosphereDefinition[] = [
+  { slug: 'art-art-mood-serene', title: 'Serene Atmosphere' },
+  { slug: 'art-art-mood-joyful', title: 'Joyful Atmosphere' },
+  { slug: 'art-art-mood-melancholy', title: 'Melancholy Atmosphere' },
+  { slug: 'art-art-mood-ominous', title: 'Ominous Atmosphere' },
+  { slug: 'art-art-mood-epic', title: 'Grand Scale' },
+  { slug: 'art-art-mood-whimsical', title: 'Whimsical Atmosphere' },
+  { slug: 'art-art-mood-tense', title: 'Tense Atmosphere' },
+  { slug: 'art-art-mood-dreamy', title: 'Dreamlike Atmosphere' },
+]
+
+const NARRATIVE_TONES = [
+  'candlelit-intimacy',
+  'emotionally-intimate',
+  'tender',
+  'whimsical-tone',
+] as const
+
+function parseMetadata(value: string | null | undefined): JsonObject {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))]
+}
+
+function legacyKindForTaxonomy(
+  taxonomy: FacetTaxonomy,
+): 'GENRE' | 'THEME' | 'STYLE' | 'ART_DIRECTION' | 'OTHER' {
+  switch (taxonomy) {
+    case 'GENRE':
+      return 'GENRE'
+    case 'THEME':
+      return 'THEME'
+    case 'STYLE':
+      return 'STYLE'
+    case 'ART_DIRECTION':
+      return 'ART_DIRECTION'
+    default:
+      return 'OTHER'
+  }
+}
+
+async function hasArtwork(facet: {
+  id: number
+  imagePath: string | null
+  cardPath: string | null
+  heroPath: string | null
+  icon: string | null
+  artImageId: number | null
+  artCollectionId: number | null
+}): Promise<boolean> {
+  if (
+    facet.imagePath ||
+    facet.cardPath ||
+    facet.heroPath ||
+    facet.icon ||
+    facet.artImageId !== null ||
+    facet.artCollectionId !== null
+  ) {
+    return true
+  }
+
+  const [imageLinks, collectionLinks] = await Promise.all([
+    prisma.facetArtImage.count({ where: { facetId: facet.id } }),
+    prisma.facetArtCollection.count({ where: { facetId: facet.id } }),
+  ])
+  return imageLinks > 0 || collectionLinks > 0
+}
+
+async function installAliases(facetId: number, aliases: readonly string[]): Promise<void> {
+  if (!apply) return
+
+  for (const alias of uniqueStrings([...aliases])) {
+    const lookupKey = normalizeFacetLookupKey(alias)
+    if (!lookupKey) continue
+
+    await prisma.facetAlias.upsert({
+      where: { lookupKey },
+      create: {
+        facetId,
+        alias,
+        lookupKey,
+        isCanonical: false,
+        isActive: true,
+      },
+      update: {
+        facetId,
+        alias,
+        isCanonical: false,
+        isActive: true,
+      },
+    })
+  }
+}
+
+async function moveDuplicateIntoCanonical(
+  canonicalSlug: string,
+  duplicateSlug: string,
+): Promise<object> {
+  const canonical = await prisma.facet.findUnique({
+    where: { slug: canonicalSlug },
+  })
+  if (!canonical) throw new Error(`Missing canonical Facet ${canonicalSlug}.`)
+
+  const duplicate = await prisma.facet.findUnique({
+    where: { slug: duplicateSlug },
+  })
+  if (!duplicate) {
+    return {
+      canonicalSlug,
+      duplicateSlug,
+      action: 'already-merged',
+    }
+  }
+
+  const [
+    canonicalProfile,
+    duplicateProfile,
+    duplicateAliases,
+    characterLinks,
+    botLinks,
+    rewardLinks,
+    dreamLinks,
+    scenarioLinks,
+    artImageLinks,
+    artCollectionLinks,
+    relations,
+    reactionCount,
+  ] = await Promise.all([
+    prisma.facetProfile.findUnique({ where: { facetId: canonical.id } }),
+    prisma.facetProfile.findUnique({ where: { facetId: duplicate.id } }),
+    prisma.facetAlias.findMany({ where: { facetId: duplicate.id } }),
+    prisma.characterFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: {
+        characterId: true,
+        fieldKey: true,
+        sortOrder: true,
+        weight: true,
+        source: true,
+      },
+    }),
+    prisma.botFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: {
+        botId: true,
+        fieldKey: true,
+        sortOrder: true,
+        weight: true,
+        source: true,
+      },
+    }),
+    prisma.rewardFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: {
+        rewardId: true,
+        fieldKey: true,
+        sortOrder: true,
+        weight: true,
+        source: true,
+      },
+    }),
+    prisma.dreamFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: { dreamId: true },
+    }),
+    prisma.scenarioFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: { scenarioId: true },
+    }),
+    prisma.facetArtImage.findMany({
+      where: { facetId: duplicate.id },
+      select: { artImageId: true },
+    }),
+    prisma.facetArtCollection.findMany({
+      where: { facetId: duplicate.id },
+      select: { artCollectionId: true },
+    }),
+    prisma.facetRelation.findMany({
+      where: {
+        OR: [{ fromFacetId: duplicate.id }, { toFacetId: duplicate.id }],
+      },
+      select: {
+        fromFacetId: true,
+        toFacetId: true,
+        relationType: true,
+        note: true,
+      },
+    }),
+    prisma.reaction.count({ where: { facetId: duplicate.id } }),
+  ])
+
+  const report = {
+    canonicalId: canonical.id,
+    canonicalSlug,
+    duplicateId: duplicate.id,
+    duplicateSlug,
+    characterLinks: characterLinks.length,
+    botLinks: botLinks.length,
+    rewardLinks: rewardLinks.length,
+    dreamLinks: dreamLinks.length,
+    scenarioLinks: scenarioLinks.length,
+    artImageLinks: artImageLinks.length + (duplicate.artImageId ? 1 : 0),
+    artCollectionLinks:
+      artCollectionLinks.length + (duplicate.artCollectionId ? 1 : 0),
+    relations: relations.length,
+    reactions: reactionCount,
+    action: apply ? 'merged-and-deleted' : 'would-merge-and-delete',
+  }
+  if (!apply) return report
+
+  if (characterLinks.length) {
+    await prisma.characterFacet.createMany({
+      data: characterLinks.map((link) => ({ ...link, facetId: canonical.id })),
+      skipDuplicates: true,
+    })
+  }
+  if (botLinks.length) {
+    await prisma.botFacet.createMany({
+      data: botLinks.map((link) => ({ ...link, facetId: canonical.id })),
+      skipDuplicates: true,
+    })
+  }
+  if (rewardLinks.length) {
+    await prisma.rewardFacet.createMany({
+      data: rewardLinks.map((link) => ({ ...link, facetId: canonical.id })),
+      skipDuplicates: true,
+    })
+  }
+  if (dreamLinks.length) {
+    await prisma.dreamFacet.createMany({
+      data: dreamLinks.map((link) => ({ ...link, facetId: canonical.id })),
+      skipDuplicates: true,
+    })
+  }
+  if (scenarioLinks.length) {
+    await prisma.scenarioFacet.createMany({
+      data: scenarioLinks.map((link) => ({ ...link, facetId: canonical.id })),
+      skipDuplicates: true,
+    })
+  }
+
+  const allArtImageIds = new Set([
+    ...artImageLinks.map((link) => link.artImageId),
+    ...(duplicate.artImageId ? [duplicate.artImageId] : []),
+  ])
+  if (allArtImageIds.size) {
+    await prisma.facetArtImage.createMany({
+      data: [...allArtImageIds].map((artImageId) => ({
+        facetId: canonical.id,
+        artImageId,
+      })),
+      skipDuplicates: true,
+    })
+  }
+
+  const allArtCollectionIds = new Set([
+    ...artCollectionLinks.map((link) => link.artCollectionId),
+    ...(duplicate.artCollectionId ? [duplicate.artCollectionId] : []),
+  ])
+  if (allArtCollectionIds.size) {
+    await prisma.facetArtCollection.createMany({
+      data: [...allArtCollectionIds].map((artCollectionId) => ({
+        facetId: canonical.id,
+        artCollectionId,
+      })),
+      skipDuplicates: true,
+    })
+  }
+
+  const mappedRelations = relations
+    .map((relation) => ({
+      ...relation,
+      fromFacetId:
+        relation.fromFacetId === duplicate.id
+          ? canonical.id
+          : relation.fromFacetId,
+      toFacetId:
+        relation.toFacetId === duplicate.id ? canonical.id : relation.toFacetId,
+    }))
+    .filter((relation) => relation.fromFacetId !== relation.toFacetId)
+  if (mappedRelations.length) {
+    await prisma.facetRelation.createMany({
+      data: mappedRelations,
+      skipDuplicates: true,
+    })
+  }
+
+  await prisma.reaction.updateMany({
+    where: { facetId: duplicate.id },
+    data: { facetId: canonical.id },
+  })
+
+  const canonicalMetadata = parseMetadata(canonicalProfile?.metadata)
+  const duplicateMetadata = parseMetadata(duplicateProfile?.metadata)
+  const priorMergedSources = Array.isArray(canonicalMetadata.mergedFacetSources)
+    ? canonicalMetadata.mergedFacetSources
+    : []
+  const mergedArtworkPaths = uniqueStrings([
+    ...(Array.isArray(canonicalMetadata.mergedArtworkPaths)
+      ? canonicalMetadata.mergedArtworkPaths.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : []),
+    duplicate.imagePath,
+    duplicate.cardPath,
+    duplicate.heroPath,
+    duplicate.icon,
+  ])
+
+  await prisma.facet.update({
+    where: { id: canonical.id },
+    data: {
+      description: canonical.description || duplicate.description,
+      flavorText: canonical.flavorText || duplicate.flavorText,
+      examples: canonical.examples || duplicate.examples,
+      artPrompt: canonical.artPrompt || duplicate.artPrompt,
+      imagePath: canonical.imagePath || duplicate.imagePath,
+      cardPath: canonical.cardPath || duplicate.cardPath,
+      heroPath: canonical.heroPath || duplicate.heroPath,
+      icon: canonical.icon || duplicate.icon,
+      artImageId: canonical.artImageId ?? duplicate.artImageId,
+      artCollectionId:
+        canonical.artCollectionId ?? duplicate.artCollectionId,
+      isActive: true,
+    },
+  })
+
+  await prisma.facetProfile.upsert({
+    where: { facetId: canonical.id },
+    create: {
+      facetId: canonical.id,
+      taxonomy: canonicalProfile?.taxonomy ?? duplicateProfile?.taxonomy ?? 'GENRE',
+      canonicalValue:
+        canonicalProfile?.canonicalValue ?? duplicateProfile?.canonicalValue ?? canonical.title,
+      groupKey: canonicalProfile?.groupKey ?? duplicateProfile?.groupKey,
+      groupLabel: canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel,
+      sortOrder: canonicalProfile?.sortOrder ?? duplicateProfile?.sortOrder ?? 0,
+      isRandomizable:
+        canonicalProfile?.isRandomizable ?? duplicateProfile?.isRandomizable ?? true,
+      randomWeight: Math.max(
+        canonicalProfile?.randomWeight ?? 0,
+        duplicateProfile?.randomWeight ?? 0,
+      ),
+      artRequired:
+        canonicalProfile?.artRequired ?? duplicateProfile?.artRequired ?? true,
+      sourceRank: Math.min(
+        canonicalProfile?.sourceRank ?? 100,
+        duplicateProfile?.sourceRank ?? 100,
+      ),
+      metadata: JSON.stringify({
+        ...duplicateMetadata,
+        ...canonicalMetadata,
+        mergedArtworkPaths,
+        mergedFacetSources: [
+          ...priorMergedSources,
+          {
+            batchId: BATCH_ID,
+            facetId: duplicate.id,
+            slug: duplicate.slug,
+            title: duplicate.title,
+            taxonomy: duplicateProfile?.taxonomy,
+            metadata: duplicateMetadata,
+          },
+        ],
+      }),
+    },
+    update: {
+      sourceRank: Math.min(
+        canonicalProfile?.sourceRank ?? 100,
+        duplicateProfile?.sourceRank ?? 100,
+      ),
+      metadata: JSON.stringify({
+        ...duplicateMetadata,
+        ...canonicalMetadata,
+        mergedArtworkPaths,
+        mergedFacetSources: [
+          ...priorMergedSources,
+          {
+            batchId: BATCH_ID,
+            facetId: duplicate.id,
+            slug: duplicate.slug,
+            title: duplicate.title,
+            taxonomy: duplicateProfile?.taxonomy,
+            metadata: duplicateMetadata,
+          },
+        ],
+      }),
+    },
+  })
+
+  await Promise.all([
+    prisma.characterFacet.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.botFacet.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.rewardFacet.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.dreamFacet.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.scenarioFacet.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.facetArtImage.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.facetArtCollection.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.facetRelation.deleteMany({
+      where: {
+        OR: [{ fromFacetId: duplicate.id }, { toFacetId: duplicate.id }],
+      },
+    }),
+    prisma.facetAlias.deleteMany({ where: { facetId: duplicate.id } }),
+    prisma.facetProfile.deleteMany({ where: { facetId: duplicate.id } }),
+  ])
+
+  await prisma.facet.delete({ where: { id: duplicate.id } })
+
+  await installAliases(canonical.id, [
+    duplicateSlug,
+    duplicate.title,
+    ...duplicateAliases.map((alias) => alias.alias),
+  ])
+
+  return report
+}
+
+async function finalizeCanonical(definition: MergeDefinition): Promise<object> {
+  const facet = await prisma.facet.findUnique({
+    where: { slug: definition.canonicalSlug },
+  })
+  if (!facet) throw new Error(`Missing canonical Facet ${definition.canonicalSlug}.`)
+  const profile = await prisma.facetProfile.findUnique({
+    where: { facetId: facet.id },
+  })
+
+  const requestedCardPath = definition.cardPathFromSlug
+    ? await prisma.facet.findUnique({
+        where: { slug: definition.cardPathFromSlug },
+        select: { imagePath: true },
+      })
+    : null
+
+  if (apply) {
+    await prisma.facet.update({
+      where: { id: facet.id },
+      data: {
+        title: definition.title ?? facet.title,
+        slug: definition.slug ?? facet.slug,
+        kind: legacyKindForTaxonomy(definition.taxonomy),
+        description: definition.description ?? facet.description,
+        cardPath: facet.cardPath || requestedCardPath?.imagePath || null,
+        isActive: true,
+      },
+    })
+
+    await prisma.facetProfile.upsert({
+      where: { facetId: facet.id },
+      create: {
+        facetId: facet.id,
+        taxonomy: definition.taxonomy,
+        canonicalValue:
+          definition.canonicalValue ?? definition.title ?? facet.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        sortOrder: profile?.sortOrder ?? 0,
+        isRandomizable: true,
+        randomWeight: definition.randomWeight,
+        artRequired: profile?.artRequired ?? true,
+        sourceRank: 1,
+        metadata: JSON.stringify({
+          ...parseMetadata(profile?.metadata),
+          catalogDirective: {
+            batchId: BATCH_ID,
+            action: 'canonicalize-and-delete-duplicates',
+            aliases: definition.aliases,
+          },
+        }),
+      },
+      update: {
+        taxonomy: definition.taxonomy,
+        canonicalValue:
+          definition.canonicalValue ?? definition.title ?? facet.title,
+        groupKey: definition.groupKey,
+        groupLabel: definition.groupLabel,
+        isRandomizable: true,
+        randomWeight: definition.randomWeight,
+        sourceRank: 1,
+        metadata: JSON.stringify({
+          ...parseMetadata(profile?.metadata),
+          catalogDirective: {
+            batchId: BATCH_ID,
+            action: 'canonicalize-and-delete-duplicates',
+            aliases: definition.aliases,
+          },
+        }),
+      },
+    })
+
+    await installAliases(facet.id, [
+      definition.canonicalSlug,
+      facet.title,
+      definition.slug,
+      definition.title,
+      ...definition.aliases,
+    ])
+  }
+
+  return {
+    facetId: facet.id,
+    fromSlug: definition.canonicalSlug,
+    toSlug: definition.slug ?? definition.canonicalSlug,
+    title: definition.title ?? facet.title,
+    taxonomy: definition.taxonomy,
+    action: apply ? 'canonicalized' : 'would-canonicalize',
+  }
+}
+
+async function applyMergeDefinition(definition: MergeDefinition): Promise<object> {
+  const duplicateResults = []
+  for (const duplicateSlug of definition.duplicateSlugs) {
+    duplicateResults.push(
+      await moveDuplicateIntoCanonical(definition.canonicalSlug, duplicateSlug),
+    )
+  }
+  const canonical = await finalizeCanonical(definition)
+  return { canonical, duplicates: duplicateResults }
+}
+
+async function reclassifyArtAtmospheres(): Promise<object[]> {
+  const results = []
+  for (const definition of ART_ATMOSPHERES) {
+    const facet = await prisma.facet.findUnique({
+      where: { slug: definition.slug },
+    })
+    if (!facet) {
+      results.push({ slug: definition.slug, action: 'missing' })
+      continue
+    }
+    const profile = await prisma.facetProfile.findUnique({
+      where: { facetId: facet.id },
+    })
+
+    if (apply) {
+      await prisma.facetAlias.deleteMany({ where: { facetId: facet.id } })
+      await prisma.facet.update({
+        where: { id: facet.id },
+        data: {
+          title: definition.title,
+          kind: 'ART_DIRECTION',
+          isActive: true,
+        },
+      })
+      await prisma.facetProfile.upsert({
+        where: { facetId: facet.id },
+        create: {
+          facetId: facet.id,
+          taxonomy: 'ART_DIRECTION',
+          canonicalValue: profile?.canonicalValue ?? definition.title,
+          groupKey: 'art-atmosphere',
+          groupLabel: 'Art Atmosphere',
+          sortOrder: profile?.sortOrder ?? 0,
+          isRandomizable: false,
+          randomWeight: 0,
+          artRequired: profile?.artRequired ?? true,
+          sourceRank: profile?.sourceRank ?? 8,
+          metadata: JSON.stringify({
+            ...parseMetadata(profile?.metadata),
+            catalogDirective: {
+              batchId: BATCH_ID,
+              action: 'move-mood-to-art-direction',
+            },
+          }),
+        },
+        update: {
+          taxonomy: 'ART_DIRECTION',
+          groupKey: 'art-atmosphere',
+          groupLabel: 'Art Atmosphere',
+          isRandomizable: false,
+          randomWeight: 0,
+          metadata: JSON.stringify({
+            ...parseMetadata(profile?.metadata),
+            catalogDirective: {
+              batchId: BATCH_ID,
+              action: 'move-mood-to-art-direction',
+            },
+          }),
+        },
+      })
+      await installAliases(facet.id, [definition.slug, definition.title])
+    }
+
+    results.push({
+      facetId: facet.id,
+      slug: definition.slug,
+      title: definition.title,
+      action: apply ? 'moved-to-art-direction' : 'would-move-to-art-direction',
+    })
+  }
+  return results
+}
+
+async function reclassifyNarrativeTones(): Promise<object[]> {
+  const results = []
+  for (const slug of NARRATIVE_TONES) {
+    const facet = await prisma.facet.findUnique({ where: { slug } })
+    if (!facet) {
+      results.push({ slug, action: 'missing' })
+      continue
+    }
+    const profile = await prisma.facetProfile.findUnique({
+      where: { facetId: facet.id },
+    })
+
+    if (apply) {
+      await prisma.facet.update({
+        where: { id: facet.id },
+        data: { kind: 'THEME', isActive: true },
+      })
+      await prisma.facetProfile.upsert({
+        where: { facetId: facet.id },
+        create: {
+          facetId: facet.id,
+          taxonomy: 'THEME',
+          canonicalValue: profile?.canonicalValue ?? facet.title,
+          groupKey: 'narrative-tone',
+          groupLabel: 'Narrative Tone',
+          sortOrder: profile?.sortOrder ?? 0,
+          isRandomizable: true,
+          randomWeight: 0.5,
+          artRequired: profile?.artRequired ?? false,
+          sourceRank: 1,
+          metadata: JSON.stringify({
+            ...parseMetadata(profile?.metadata),
+            catalogDirective: {
+              batchId: BATCH_ID,
+              action: 'move-mood-to-narrative-theme',
+            },
+          }),
+        },
+        update: {
+          taxonomy: 'THEME',
+          groupKey: 'narrative-tone',
+          groupLabel: 'Narrative Tone',
+          isRandomizable: true,
+          randomWeight: 0.5,
+          sourceRank: 1,
+          metadata: JSON.stringify({
+            ...parseMetadata(profile?.metadata),
+            catalogDirective: {
+              batchId: BATCH_ID,
+              action: 'move-mood-to-narrative-theme',
+            },
+          }),
+        },
+      })
+    }
+
+    results.push({
+      facetId: facet.id,
+      slug,
+      action: apply ? 'moved-to-theme' : 'would-move-to-theme',
+    })
+  }
+  return results
+}
+
+async function renameDevotedPersonality(): Promise<object> {
+  const facet = await prisma.facet.findUnique({
+    where: { slug: 'personality-loyal' },
+  })
+  if (!facet) return { action: 'missing' }
+  const profile = await prisma.facetProfile.findUnique({
+    where: { facetId: facet.id },
+  })
+
+  if (apply) {
+    await prisma.facetAlias.deleteMany({
+      where: {
+        facetId: facet.id,
+        lookupKey: normalizeFacetLookupKey('Loyal'),
+      },
+    })
+    await prisma.facet.update({
+      where: { id: facet.id },
+      data: {
+        title: 'Devoted',
+        description:
+          'Commitment as a defining trait. Stays close, follows through, and treats a person, cause, or duty as part of who they are. Can become overprotective without replacing the moral-allegiance concept represented by Loyal alignment.',
+        isActive: true,
+      },
+    })
+    await prisma.facetProfile.update({
+      where: { facetId: facet.id },
+      data: {
+        taxonomy: 'PERSONALITY',
+        canonicalValue: 'devoted',
+        metadata: JSON.stringify({
+          ...parseMetadata(profile?.metadata),
+          catalogDirective: {
+            batchId: BATCH_ID,
+            action: 'rename-loyal-personality-to-devoted',
+          },
+        }),
+      },
+    })
+    await installAliases(facet.id, [
+      'personality-loyal',
+      'Devoted',
+      'Dedicated',
+      'Loyal Personality',
+    ])
+  }
+
+  return {
+    facetId: facet.id,
+    from: facet.title,
+    to: 'Devoted',
+    action: apply ? 'renamed' : 'would-rename',
+  }
+}
+
+async function qualifyStructuralTitles(): Promise<object[]> {
+  const definitions = [
+    { slug: 'bot-type-narrator', title: 'Narrator Bot Type' },
+    { slug: 'dream-type-narrator', title: 'Narrator Dream Type' },
+    { slug: 'bot-type-promptbot', title: 'Prompt Bot Type' },
+    { slug: 'dream-type-promptbot', title: 'Prompt Bot Dream Type' },
+  ] as const
+
+  const results = []
+  for (const definition of definitions) {
+    const facet = await prisma.facet.findUnique({
+      where: { slug: definition.slug },
+    })
+    if (!facet) {
+      results.push({ slug: definition.slug, action: 'missing' })
+      continue
+    }
+    if (apply) {
+      await prisma.facet.update({
+        where: { id: facet.id },
+        data: { title: definition.title },
+      })
+      await installAliases(facet.id, [definition.slug, definition.title])
+    }
+    results.push({
+      facetId: facet.id,
+      slug: definition.slug,
+      title: definition.title,
+      action: apply ? 'qualified' : 'would-qualify',
+    })
+  }
+  return results
+}
+
+async function reserveEpicForRarity(): Promise<object> {
+  const rarity = await prisma.facet.findUnique({
+    where: { slug: 'rarity-epic' },
+  })
+  if (!rarity) return { action: 'missing-rarity' }
+
+  if (apply) {
+    const lookupKey = normalizeFacetLookupKey('Epic')
+    await prisma.facetAlias.deleteMany({
+      where: {
+        lookupKey,
+        NOT: { facetId: rarity.id },
+      },
+    })
+    await installAliases(rarity.id, ['rarity-epic', 'Epic'])
+  }
+
+  return {
+    facetId: rarity.id,
+    action: apply ? 'epic-reserved-for-rarity' : 'would-reserve-epic-for-rarity',
+  }
+}
+
+async function deleteFacetCompletely(facetId: number): Promise<void> {
+  if (!apply) return
+  await Promise.all([
+    prisma.characterFacet.deleteMany({ where: { facetId } }),
+    prisma.botFacet.deleteMany({ where: { facetId } }),
+    prisma.rewardFacet.deleteMany({ where: { facetId } }),
+    prisma.dreamFacet.deleteMany({ where: { facetId } }),
+    prisma.scenarioFacet.deleteMany({ where: { facetId } }),
+    prisma.facetArtImage.deleteMany({ where: { facetId } }),
+    prisma.facetArtCollection.deleteMany({ where: { facetId } }),
+    prisma.facetRelation.deleteMany({
+      where: { OR: [{ fromFacetId: facetId }, { toFacetId: facetId }] },
+    }),
+    prisma.facetAlias.deleteMany({ where: { facetId } }),
+    prisma.facetProfile.deleteMany({ where: { facetId } }),
+    prisma.reaction.deleteMany({ where: { facetId } }),
+  ])
+  await prisma.facet.delete({ where: { id: facetId } })
+}
+
+async function deleteHistoricalShells(): Promise<object> {
+  const [recipeProfiles, mergedFacets] = await Promise.all([
+    prisma.facetProfile.findMany({
+      where: { groupKey: 'genre-recipe' },
+      select: { facetId: true },
+    }),
+    prisma.facet.findMany({
+      where: { designer: 'facet-catalog-merged' },
+    }),
+  ])
+
+  const candidateIds = new Set([
+    ...recipeProfiles.map((profile) => profile.facetId),
+    ...mergedFacets.map((facet) => facet.id),
+  ])
+  const deleted: Array<{ id: number; title: string }> = []
+  const preservedForArt: Array<{ id: number; title: string }> = []
+
+  for (const facetId of candidateIds) {
+    const facet = await prisma.facet.findUnique({ where: { id: facetId } })
+    if (!facet) continue
+    if (await hasArtwork(facet)) {
+      preservedForArt.push({ id: facet.id, title: facet.title })
+      continue
+    }
+    if (apply) await deleteFacetCompletely(facet.id)
+    deleted.push({ id: facet.id, title: facet.title })
+  }
+
+  return {
+    action: apply ? 'deleted' : 'would-delete',
+    deleted,
+    preservedForArt,
+  }
+}
+
+async function main(): Promise<void> {
+  const merges = []
+  for (const definition of MERGES) {
+    merges.push(await applyMergeDefinition(definition))
+  }
+
+  const [
+    artAtmospheres,
+    narrativeTones,
+    devotedPersonality,
+    structuralTitles,
+    epicRarity,
+  ] = await Promise.all([
+    reclassifyArtAtmospheres(),
+    reclassifyNarrativeTones(),
+    renameDevotedPersonality(),
+    qualifyStructuralTitles(),
+    reserveEpicForRarity(),
+  ])
+
+  const historicalShells = await deleteHistoricalShells()
+  const remainingMoodCount = await prisma.facetProfile.count({
+    where: { taxonomy: 'MOOD' },
+  })
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: apply ? 'apply' : 'dry-run',
+        batchId: BATCH_ID,
+        merges,
+        artAtmospheres,
+        narrativeTones,
+        devotedPersonality,
+        structuralTitles,
+        epicRarity,
+        historicalShells,
+        remainingMoodCount,
+        policy: {
+          duplicates: 'Migrate every known edge and artwork reference, then physically delete the duplicate row.',
+          moods: 'No global MOOD Facets remain. Art atmosphere is ART_DIRECTION; story tone is THEME.',
+          punks: 'Punk families are canonical GENRE Facets. Former style rows become aliases and metadata on the genre.',
+        },
+      },
+      null,
+      2,
+    ),
+  )
+
+  if (apply && remainingMoodCount !== 0) {
+    throw new Error(`Expected zero MOOD profiles, found ${remainingMoodCount}.`)
+  }
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/utils/scripts/verifyFacetCatalogDirectives.ts
+++ b/utils/scripts/verifyFacetCatalogDirectives.ts
@@ -25,6 +25,7 @@ for (const required of [
   "canonicalSlug: 'solarpunk'",
   "canonicalSlug: 'steampunk'",
   "canonicalSlug: 'circuscore'",
+  "finalSlug: 'circus'",
   "title: 'Circus'",
   "'Circuspunk'",
   "'Carnivalpunk'",
@@ -34,8 +35,10 @@ for (const required of [
   "taxonomy: 'ART_DIRECTION'",
   "taxonomy: 'THEME'",
   "where: { taxonomy: 'MOOD' }",
+  "'merged-and-deleted'",
   'prisma.facet.delete',
   "groupKey: 'genre-recipe'",
+  "duplicateSlug === 'carnival'",
 ]) {
   assert.ok(directive.includes(required), `Missing directive contract: ${required}`)
 }
@@ -45,7 +48,7 @@ assert.ok(
   'Africanfuturism must be an alias of Afrofuturism.',
 )
 assert.ok(
-  directive.includes("action: 'merged-and-deleted'"),
+  directive.includes('await prisma.facet.delete({ where: { id: duplicate.id } })'),
   'Duplicate merges must physically delete old records.',
 )
 assert.ok(

--- a/utils/scripts/verifyFacetCatalogDirectives.ts
+++ b/utils/scripts/verifyFacetCatalogDirectives.ts
@@ -1,0 +1,71 @@
+// /utils/scripts/verifyFacetCatalogDirectives.ts
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const directivePath = path.join(
+  root,
+  'utils/scripts/applyFacetCatalogDirectives.ts',
+)
+const buildPath = path.join(root, 'scripts/vercel-build.mjs')
+
+const directive = fs.readFileSync(directivePath, 'utf8')
+const build = fs.readFileSync(buildPath, 'utf8')
+
+for (const required of [
+  "canonicalSlug: 'afrofuturism'",
+  "duplicateSlugs: ['africanfuturism']",
+  "'African Futurism'",
+  "canonicalSlug: 'biopunk'",
+  "duplicateSlugs: ['art-punk-biopunk']",
+  "canonicalSlug: 'dieselpunk'",
+  "canonicalSlug: 'mythpunk'",
+  "canonicalSlug: 'nanopunk'",
+  "canonicalSlug: 'solarpunk'",
+  "canonicalSlug: 'steampunk'",
+  "canonicalSlug: 'circuscore'",
+  "title: 'Circus'",
+  "'Circuspunk'",
+  "'Carnivalpunk'",
+  "'Dark Carnival'",
+  "title: 'Grand Scale'",
+  "title: 'Devoted'",
+  "taxonomy: 'ART_DIRECTION'",
+  "taxonomy: 'THEME'",
+  "where: { taxonomy: 'MOOD' }",
+  'prisma.facet.delete',
+  "groupKey: 'genre-recipe'",
+]) {
+  assert.ok(directive.includes(required), `Missing directive contract: ${required}`)
+}
+
+assert.ok(
+  directive.includes("aliases: ['Africanfuturism', 'African Futurism']"),
+  'Africanfuturism must be an alias of Afrofuturism.',
+)
+assert.ok(
+  directive.includes("action: 'merged-and-deleted'"),
+  'Duplicate merges must physically delete old records.',
+)
+assert.ok(
+  directive.includes('Expected zero MOOD profiles'),
+  'The directive must enforce removal of MOOD as a global taxonomy.',
+)
+assert.ok(
+  directive.includes("'Loyal Personality'"),
+  'Devoted must retain a compatibility alias for Loyal Personality.',
+)
+assert.ok(
+  !directive.includes("title: 'Epic Atmosphere'"),
+  'Epic must remain a rarity, not survive as an atmosphere title.',
+)
+
+const hook = "['utils/scripts/applyFacetCatalogDirectives.ts', '--apply']"
+assert.ok(build.includes(hook), 'Production build must apply catalog directives.')
+assert.ok(
+  build.indexOf(hook) < build.indexOf('auditFacetCatalogOddities.ts'),
+  'Catalog directives must run before the whole-catalog audit.',
+)
+
+console.log('Facet catalog directive contract verified.')


### PR DESCRIPTION
## User-directed Facet cleanup

This pass applies the revised public-catalog model rather than preserving specialist or historical distinctions that do not help ordinary selection.

### Canonical merges

- Africanfuturism is merged into Afrofuturism and retained as an alias.
- Biopunk, Dieselpunk, Mythpunk, Nanopunk, Solarpunk, and Steampunk are canonical genres. Their art-builder style rows are migrated into the genre records and deleted.
- CircusCore, Carnivalpunk, Carnival, and Dark Carnival become one art-backed Circus genre with all former names as aliases.

Every merge migrates character, bot, reward, dream, scenario, reaction, relationship, alias, ArtImage, ArtCollection, and direct artwork references before physically deleting the duplicate row. The old art-builder metadata remains on the canonical genre.

### Mood retirement

MOOD is removed as a global Facet taxonomy.

- art-builder mood controls become nonrandom ART_DIRECTION records under Art Atmosphere
- narrative tone records become THEME records under Narrative Tone
- Epic mood becomes Grand Scale art direction
- the build fails if any MOOD profiles remain

### Character semantics

- Loyal alignment remains unchanged as allegiance to an entity over abstract ideals.
- Loyal personality becomes Devoted, with compatibility aliases for Dedicated and Loyal Personality.
- Epic remains the canonical rarity and owns the plain Epic alias.

### Historical cleanup

- migrated duplicate rows are physically deleted
- non-art-backed genre recipe shells are physically deleted
- art-backed historical rows remain protected

### Durability

The directive runs after all legacy seed and curation passes, before the whole-catalog audit. It is idempotent, including the Circus slug transition, and preserves the custom CircusCore image plus the former Carnival scenario image as the canonical Circus card artwork.

### Validation

- dedicated Facet catalog directive contract
- TypeScript type check
- Facet Catalog Contract
- full repository contract suite
