### PR TITLE
fix(davinci): remove duplicate auto-import exports

### DIFF
--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -11,21 +11,8 @@
 import prisma from './prisma'
 import {
   DAVINCI_DIMENSIONS,
-  DAVINCI_PASS_VALUE,
   resolveOutcomeKey,
-  type DaVinciDimension,
 } from './davinciDimensions'
-
-// The dimension vocabulary and outcome math live in ./davinciDimensions so
-// they can be imported without ./prisma, which throws at module load when
-// DATABASE_URL is unset (as it is in the contract-tests job). Re-exported here
-// so every existing importer of this module is unaffected.
-export {
-  DAVINCI_DIMENSIONS,
-  DAVINCI_PASS_VALUE,
-  resolveOutcomeKey,
-  type DaVinciDimension,
-}
 
 export interface ResolveLifeRunResult {
   outcomeKey: string

--- a/utils/scripts/verifyDaVinciPlayLoop.ts
+++ b/utils/scripts/verifyDaVinciPlayLoop.ts
@@ -25,12 +25,14 @@
 import 'dotenv/config'
 import prisma from '../../server/utils/prisma'
 import {
-  DAVINCI_DIMENSIONS,
   createLifeRun,
   recordLifeChoice,
   resolveLifeRunEnding,
-  resolveOutcomeKey,
 } from '../../server/utils/davinci'
+import {
+  DAVINCI_DIMENSIONS,
+  resolveOutcomeKey,
+} from '../../server/utils/davinciDimensions'
 
 const TEST_USERNAME = 'davinci-playloop-verify'
 


### PR DESCRIPTION
## Root cause
Nuxt auto-import scanning found the same Da Vinci dimension exports in both `server/utils/davinci.ts` and `server/utils/davinciDimensions.ts`. The compatibility re-export in the database-backed module made Nuxt ignore one provider and emit warnings during prepare/build.

## Fix
- Remove the four compatibility re-exports from `server/utils/davinci.ts`.
- Keep `davinci.ts` importing only the dimension helpers it actually uses internally.
- Update the headless play-loop verifier to import `DAVINCI_DIMENSIONS` and `resolveOutcomeKey` directly from the canonical `davinciDimensions.ts` module.

## Scope
Two files, no schema/data/API behavior change.

Closes #1241