### PR TITLE
fix(model-builder): suppress stale-run status toasts after navigating away

### DIFF
--- a/stores/modelBuilderStore.ts
+++ b/stores/modelBuilderStore.ts
@@ -448,6 +448,28 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
     state.statusMessage = ''
   }
 
+  // Only surface a status toast if the user is still looking at the run it's
+  // about. generateItemAsset/pollAsyncArtJob/generateItemAssetAsync/commitItem
+  // each capture their own `runId` up front and deliberately keep working
+  // (and persisting) against a run the user has since navigated away from via
+  // resetRun/resetAll/openRun — that's intended (see resetRun's doc comment:
+  // the run stays valid and resumable, unlike cancelRun). But leaving a run
+  // behind this way never adds it to cancelledRunIds, so without this check a
+  // slow render or commit that finishes after the user has moved on to (or
+  // started) a *different* run pops a misleading success/error toast in that
+  // other run's banner, about an item that isn't even part of what's on
+  // screen. Mirrors autoBuildRun's own `if (state.run?.id === runId)` gate on
+  // its final summary message — just applied to the per-item completion
+  // paths that feed into it, and to the same manual single-item actions on
+  // their own.
+  function setStatusForRun(
+    runId: string,
+    tone: 'success' | 'error',
+    message: string,
+  ): void {
+    if (state.run?.id === runId) setStatus(tone, message)
+  }
+
   // --- step 1: source type + records ---------------------------------------
 
   async function selectSourceType(key: SourceTypeKey): Promise<void> {
@@ -1041,7 +1063,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // replace what was just approved, with no re-review. Mirrors
       // pollAsyncArtJob's identical guard.
       if (item.stages.GENERATE_ASSETS.status === 'approved') {
-        setStatus(
+        setStatusForRun(
+          runId,
           'error',
           `${item.label} finished generating after its candidate was already approved — discarded to avoid silently replacing it.`,
         )
@@ -1059,7 +1082,18 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         artImageId: item.artImageId,
       })
 
-      setStatus('success', `Generated a candidate for ${item.label}.`)
+      // Gated by setStatusForRun, not a plain setStatus: the user may have
+      // navigated away to (or started) a different run via resetRun/resetAll/
+      // openRun without cancelling this one -- the render still finishes and
+      // still persists (the run stays valid and resumable), but a bare
+      // setStatus here would pop this success toast in whatever OTHER run's
+      // banner the user is now looking at, about an item that isn't even
+      // part of what's on screen.
+      setStatusForRun(
+        runId,
+        'success',
+        `Generated a candidate for ${item.label}.`,
+      )
       return true
     } catch (error) {
       // Mirror the success path's cancelledRunIds guard above: a render that
@@ -1070,7 +1104,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       handleError(error, 'generating model builder asset')
       item.error = error instanceof Error ? error.message : 'Generation failed.'
       finishGenerateAssets(item, { status: 'ready', note: item.error })
-      setStatus('error', item.error)
+      setStatusForRun(runId, 'error', item.error)
       return false
     } finally {
       // state.generatingItemId is a store-wide singleton (not per-item, unlike
@@ -1141,7 +1175,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       if (!result.success || !result.data) {
         item.error = result.message || `Art job ${jobId} did not complete.`
         finishGenerateAssets(item, { status: 'ready', note: item.error })
-        setStatus('error', item.error)
+        setStatusForRun(runId, 'error', item.error)
         return
       }
 
@@ -1162,7 +1196,8 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       // 'stale' while the job was in flight is the existing, intended way to
       // flag "re-review this candidate," and should still receive the image.
       if (item.stages.GENERATE_ASSETS.status === 'approved') {
-        setStatus(
+        setStatusForRun(
+          runId,
           'error',
           `${item.label} finished generating after its candidate was already approved — discarded to avoid silently replacing it.`,
         )
@@ -1180,7 +1215,13 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         artImageId: item.artImageId,
       })
 
-      setStatus('success', `Generated a candidate for ${item.label}.`)
+      // Gated by setStatusForRun -- see its doc comment (same reasoning as
+      // generateItemAsset's identical success-path gate above it).
+      setStatusForRun(
+        runId,
+        'success',
+        `Generated a candidate for ${item.label}.`,
+      )
       return
     }
   }
@@ -1250,7 +1291,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       finishGenerateAssets(item, { status: 'ready', note: item.error })
       item.queueState = null
       item.artJobId = null
-      setStatus('error', item.error)
+      setStatusForRun(runId, 'error', item.error)
       return false
     }
   }
@@ -1339,7 +1380,12 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
         item.targetType = target.type
         item.targetId = target.id
       }
-      setStatus(
+      // Gated by setStatusForRun -- see its doc comment. The commit itself
+      // already durably landed server-side regardless; this only suppresses
+      // a misleading "committed" toast if the user has since navigated away
+      // to (or started) a different run without cancelling this one.
+      setStatusForRun(
+        runId,
         'success',
         target
           ? `${item.label} committed → ${target.type} #${target.id}.`
@@ -1352,7 +1398,7 @@ export const useModelBuilderStore = defineStore('modelBuilderStore', () => {
       handleError(error, 'committing build item')
       item.error = error instanceof Error ? error.message : 'Commit failed.'
       finishCommit(item, { status: 'ready', note: item.error })
-      setStatus('error', item.error)
+      setStatusForRun(runId, 'error', item.error)
       return false
     } finally {
       committingItemSingleton.release(item.id)


### PR DESCRIPTION
### Task
model-builder/t-029: Polish and upgrade Model Builder front-end surface (kind: software)

### What changed / what I produced
- `stores/modelBuilderStore.ts`: added `setStatusForRun(runId, tone, message)`, a small helper that only writes to the store-wide status banner if `state.run?.id === runId`, mirroring `autoBuildRun`'s existing `state.run?.id === runId` gate on its own completion summary.
- Replaced every post-await success/error `setStatus(...)` call in `generateItemAsset`, `pollAsyncArtJob`, `generateItemAssetAsync`, and `commitItem` with `setStatusForRun(runId, ...)` (9 call sites). Pre-await synchronous validation `setStatus` calls were left untouched since no navigation can occur before those.

**Bug:** those four functions each capture their own `runId` up front and correctly keep working — and persisting — against a run the user has navigated away from via `resetRun` ("New run"), `resetAll`, or `openRun` to a different run in History (this is intentional; `resetRun`'s own doc comment says the abandoned run stays valid/resumable, unlike an explicit `cancelRun()`). But the bare `setStatus()` call after the long-running `await` still wrote to the store-wide status banner regardless, so a slow render or commit that finishes *after* the user has moved on pops a misleading success/error toast in whatever *other* run's banner they're currently looking at — naming an item that isn't even part of the current run.

Concrete repro: open a run, click "Generate candidate" on an item, then click "New run" before it finishes. Seconds later a "Generated a candidate for X." toast appears on top of the brand-new, unrelated run.

The actual persistence (`pushItem`/`recordArtifact`/the commit write) is unchanged — only the toast is suppressed, matching the intended "run stays resumable" behavior.

### How I verified
- `npx eslint stores/modelBuilderStore.ts` → 2 pre-existing `no-empty` errors only (lines 203/210, unrelated catch blocks — confirmed identical via `git stash` before/after), zero new errors.
- `npx prettier --check stores/modelBuilderStore.ts` → pre-existing drift only (confirmed via `git stash`); the new/changed lines themselves are prettier-clean.
- `vue-tsc --noEmit -p tsconfig.json` (full project) → exit 0, zero output.
- All 9 existing `utils/scripts/verifyModelBuilder*.ts` regression guards (+ their `.test.ts` self-tests via `tsx`) → all pass, confirming this change doesn't disturb any of the prior cycles' textually-anchored fixes.

### Stakes
reversible

### Flags for Reviewer
- No new regression-guard script added for this fix — the existing guards use narrow textual anchors ("a `cancelledRunIds.has(runId)` check between X and Y"), and this bug is best captured as "absence of a run-identity gate on `setStatus`" at the call-site level, which doesn't have a clean single-anchor shape the way the others do. Noted as a lower-value guard candidate rather than forced.

### Kaizen suggestion
Add `utils/scripts/verifyModelBuilderRunWritableGuard.ts` (+ `.test.ts`) asserting `assertRunWritable(...)` is called in all four write routes (`items/[id].patch.ts`, `items/batch.patch.ts`, `items/[id]/artifacts.post.ts`, `items/[id]/commit.post.ts`). This was PR #1239's explicitly-deferred kaizen; confirmed by reading all four routes that the actual `assertRunWritable` fix is already in place — only the regression guard itself is missing, same shape as the existing `verifyModelBuilderLinkCoverage.ts`.

### Notes for reviewer
Part of model-builder/t-029's recurring bug-hunt cycle (conductor repo) — this is roughly the 30th cycle of this task; see `projects/model-builder/roadmap.yaml` in the conductor repo for the full history of prior fixes this one was checked against.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BT5GWtgTLYf1C5Scvt7v6V)_