### PR TITLE
Retry transient achievement deployment connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "seed:davinci:playloop-verify": "tsx utils/scripts/verifyDaVinciPlayLoop.ts",
     "test:davinci-narration": "tsx utils/scripts/verifyDaVinciNarration.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",
-    "test:achievement-catalog": "tsx utils/scripts/verifyAchievementCatalog.ts",
+    "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",
     "seed:resource-commercial-safe": "tsx scripts/seed_resource_commercial_safe.ts",
     "generate:achievement-art": "tsx scripts/generate_achievement_art.ts",

--- a/scripts/generate_achievement_art.ts
+++ b/scripts/generate_achievement_art.ts
@@ -13,17 +13,14 @@
 import 'dotenv/config'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '../prisma/generated/prisma/client'
-import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from './lib/databaseRetry'
 
 const PROJECT_SLUG = 'achievements'
 const SEED_USER_ID = 10
 const ACTIVE_JOB_STATUSES = ['PENDING', 'RUNNING'] as const
-
-function createSeedPrismaClient(): PrismaClient {
-  const databaseUrl = process.env.DATABASE_URL
-  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
-  return new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
-}
 
 function entityMarker(achievementId: number): string {
   return `"entityType":"achievement","entityId":${achievementId}`
@@ -67,78 +64,80 @@ export function buildAchievementArtPayload(achievement: {
 
 async function main() {
   const WRITE = process.argv.includes('--write')
-  const prisma = createSeedPrismaClient()
 
-  try {
-    const achievements = await prisma.achievement.findMany({
-      where: {
-        AND: [
-          { artPrompt: { not: null } },
-          { OR: [{ imagePath: null }, { imagePath: '' }] },
-        ],
-      },
-      orderBy: { id: 'asc' },
-      select: {
-        id: true,
-        label: true,
-        triggerCode: true,
-        artPrompt: true,
-      },
-    })
-
-    let queued = 0
-    let reused = 0
-
-    for (const achievement of achievements) {
-      const existing = await prisma.artJob.findFirst({
+  await withDatabaseRetry('achievement artwork queue', async () => {
+    const prisma = createScriptPrismaClient()
+    try {
+      const achievements = await prisma.achievement.findMany({
         where: {
-          projectSlug: PROJECT_SLUG,
-          userId: SEED_USER_ID,
-          status: { in: [...ACTIVE_JOB_STATUSES] },
-          payload: { contains: entityMarker(achievement.id) },
+          AND: [
+            { artPrompt: { not: null } },
+            { OR: [{ imagePath: null }, { imagePath: '' }] },
+          ],
         },
-        orderBy: { createdAt: 'desc' },
-      })
-
-      if (existing) {
-        reused += 1
-        console.log(
-          `  reuse ArtJob ${existing.id}: ${achievement.triggerCode} — ${achievement.label}`,
-        )
-        continue
-      }
-
-      if (!WRITE) {
-        console.log(
-          `  [dry run] queue: ${achievement.triggerCode} — ${achievement.label}`,
-        )
-        continue
-      }
-
-      const job = await prisma.artJob.create({
-        data: {
-          engine: 'A1111',
-          userId: SEED_USER_ID,
-          projectSlug: PROJECT_SLUG,
-          priority: 5,
-          payload: JSON.stringify(buildAchievementArtPayload(achievement)),
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          label: true,
+          triggerCode: true,
+          artPrompt: true,
         },
       })
 
-      queued += 1
+      let queued = 0
+      let reused = 0
+
+      for (const achievement of achievements) {
+        const existing = await prisma.artJob.findFirst({
+          where: {
+            projectSlug: PROJECT_SLUG,
+            userId: SEED_USER_ID,
+            status: { in: [...ACTIVE_JOB_STATUSES] },
+            payload: { contains: entityMarker(achievement.id) },
+          },
+          orderBy: { createdAt: 'desc' },
+        })
+
+        if (existing) {
+          reused += 1
+          console.log(
+            `  reuse ArtJob ${existing.id}: ${achievement.triggerCode} — ${achievement.label}`,
+          )
+          continue
+        }
+
+        if (!WRITE) {
+          console.log(
+            `  [dry run] queue: ${achievement.triggerCode} — ${achievement.label}`,
+          )
+          continue
+        }
+
+        const job = await prisma.artJob.create({
+          data: {
+            engine: 'A1111',
+            userId: SEED_USER_ID,
+            projectSlug: PROJECT_SLUG,
+            priority: 5,
+            payload: JSON.stringify(buildAchievementArtPayload(achievement)),
+          },
+        })
+
+        queued += 1
+        console.log(
+          `  queued ArtJob ${job.id}: ${achievement.triggerCode} — ${achievement.label}`,
+        )
+      }
+
       console.log(
-        `  queued ArtJob ${job.id}: ${achievement.triggerCode} — ${achievement.label}`,
+        WRITE
+          ? `Achievement art: ${queued} queued, ${reused} active job(s) reused, ${achievements.length} missing image(s) inspected.`
+          : `[dry run] ${achievements.length - reused} job(s) would be queued; ${reused} active job(s) already exist.`,
       )
+    } finally {
+      await prisma.$disconnect()
     }
-
-    console.log(
-      WRITE
-        ? `Achievement art: ${queued} queued, ${reused} active job(s) reused, ${achievements.length} missing image(s) inspected.`
-        : `[dry run] ${achievements.length - reused} job(s) would be queued; ${reused} active job(s) already exist.`,
-    )
-  } finally {
-    await prisma.$disconnect()
-  }
+  })
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/scripts/generate_achievement_art.ts
+++ b/scripts/generate_achievement_art.ts
@@ -12,7 +12,6 @@
 
 import 'dotenv/config'
 import { fileURLToPath } from 'node:url'
-import { PrismaClient } from '../prisma/generated/prisma/client'
 import {
   createScriptPrismaClient,
   withDatabaseRetry,

--- a/scripts/lib/databaseRetry.ts
+++ b/scripts/lib/databaseRetry.ts
@@ -44,6 +44,7 @@ export async function withDatabaseRetry<T>(
   label: string,
   operation: (attempt: number) => Promise<T>,
   maxAttempts = 3,
+  retryDelayMs = 2_000,
 ): Promise<T> {
   let lastError: unknown
 
@@ -56,7 +57,7 @@ export async function withDatabaseRetry<T>(
         throw error
       }
 
-      const delayMs = attempt * 2_000
+      const delayMs = attempt * retryDelayMs
       console.warn(
         `[database-retry] ${label} attempt ${attempt}/${maxAttempts} hit a transient connection error; retrying in ${delayMs}ms.`,
       )

--- a/scripts/lib/databaseRetry.ts
+++ b/scripts/lib/databaseRetry.ts
@@ -1,0 +1,68 @@
+// /scripts/lib/databaseRetry.ts
+//
+// Shared database client and bounded retry policy for idempotent production
+// maintenance scripts. ProxySQL can briefly have no connection available while
+// concurrent deployments are starting; a fresh client on retry avoids treating
+// that transient pool window as a permanent deployment failure.
+
+import { PrismaClient } from '../../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from '../../server/utils/databaseAdapterConfig'
+
+const TRANSIENT_CODES = new Set(['P1001', 'P1002', 'P1017', 'P2024'])
+
+export function createScriptPrismaClient(): PrismaClient {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+  return new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
+}
+
+export function isTransientDatabaseError(error: unknown): boolean {
+  const value = error as {
+    code?: unknown
+    message?: unknown
+    meta?: { message?: unknown; driverAdapterError?: { message?: unknown } }
+  }
+  const code = String(value?.code || '')
+  const message = [
+    value?.message,
+    value?.meta?.message,
+    value?.meta?.driverAdapterError?.message,
+    error,
+  ]
+    .map((part) => String(part || ''))
+    .join(' ')
+
+  return (
+    TRANSIENT_CODES.has(code) ||
+    /pool timeout|failed to retrieve a connection|connect(?:ion)? timeout|connection (?:closed|refused|reset)/i.test(
+      message,
+    )
+  )
+}
+
+export async function withDatabaseRetry<T>(
+  label: string,
+  operation: (attempt: number) => Promise<T>,
+  maxAttempts = 3,
+): Promise<T> {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation(attempt)
+    } catch (error) {
+      lastError = error
+      if (attempt >= maxAttempts || !isTransientDatabaseError(error)) {
+        throw error
+      }
+
+      const delayMs = attempt * 2_000
+      console.warn(
+        `[database-retry] ${label} attempt ${attempt}/${maxAttempts} hit a transient connection error; retrying in ${delayMs}ms.`,
+      )
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+
+  throw lastError
+}

--- a/scripts/seed_achievements.ts
+++ b/scripts/seed_achievements.ts
@@ -16,18 +16,15 @@
 import 'dotenv/config'
 import { fileURLToPath } from 'node:url'
 import { PrismaClient } from '../prisma/generated/prisma/client'
-import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from './lib/databaseRetry'
 import { achievementData } from '../training/achievementData'
 
 const LEGACY_TRIGGER_ALIASES: Record<string, string[]> = {
   'first-character': ['fate'],
   'achievement-tour': ['test'],
-}
-
-function createSeedPrismaClient(): PrismaClient {
-  const databaseUrl = process.env.DATABASE_URL
-  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
-  return new PrismaClient({ adapter: new PrismaMariaDb(databaseUrl) })
 }
 
 // The descriptive fields owned by the catalog. Generated `imagePath` and
@@ -109,23 +106,27 @@ async function main() {
     return
   }
 
-  const prisma = createSeedPrismaClient()
-  try {
-    const before = await prisma.achievement.count()
-    console.log(`Existing achievements in DB: ${before}`)
+  await withDatabaseRetry('achievement catalog reconciliation', async () => {
+    const prisma = createScriptPrismaClient()
+    try {
+      const before = await prisma.achievement.count()
+      console.log(`Existing achievements in DB: ${before}`)
 
-    let done = 0
-    for (const achievement of achievementData) {
-      await upsertAchievement(prisma, achievement)
-      done += 1
-      console.log(`  ...${done}/${achievementData.length} ${achievement.triggerCode}`)
+      let done = 0
+      for (const achievement of achievementData) {
+        await upsertAchievement(prisma, achievement)
+        done += 1
+        console.log(
+          `  ...${done}/${achievementData.length} ${achievement.triggerCode}`,
+        )
+      }
+
+      const after = await prisma.achievement.count()
+      console.log(`Done. Totals now: ${after} achievements.`)
+    } finally {
+      await prisma.$disconnect()
     }
-
-    const after = await prisma.achievement.count()
-    console.log(`Done. Totals now: ${after} achievements.`)
-  } finally {
-    await prisma.$disconnect()
-  }
+  })
 }
 
 // Run the CLI only when executed directly, not when imported.

--- a/utils/scripts/verifyAchievementCatalog.ts
+++ b/utils/scripts/verifyAchievementCatalog.ts
@@ -171,6 +171,15 @@ assert.ok(
   'Catalog reconciliation must preserve generated achievement art.',
 )
 
+const databaseRetry = source('scripts/lib/databaseRetry.ts')
+assert.ok(
+  databaseRetry.includes('createDatabaseAdapter') &&
+    databaseRetry.includes('isTransientDatabaseError') &&
+    seed.includes('withDatabaseRetry') &&
+    generator.includes('withDatabaseRetry'),
+  'Production achievement maintenance must use the shared adapter and bounded retries.',
+)
+
 const build = source('scripts/vercel-build.mjs')
 const seedIndex = build.indexOf("['scripts/seed_achievements.ts', '--write']")
 const artIndex = build.indexOf(

--- a/utils/scripts/verifyDatabaseRetry.ts
+++ b/utils/scripts/verifyDatabaseRetry.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import {
+  isTransientDatabaseError,
+  withDatabaseRetry,
+} from '../../scripts/lib/databaseRetry'
+
+assert.equal(isTransientDatabaseError({ code: 'P1001' }), true)
+assert.equal(
+  isTransientDatabaseError({
+    code: 'P2039',
+    message: 'pool timeout: failed to retrieve a connection',
+  }),
+  true,
+)
+assert.equal(
+  isTransientDatabaseError({ code: 'P2039', message: 'invalid query shape' }),
+  false,
+)
+
+let attempts = 0
+const result = await withDatabaseRetry(
+  'self-test',
+  async () => {
+    attempts += 1
+    if (attempts < 3) {
+      throw Object.assign(new Error('connection reset'), { code: 'P1017' })
+    }
+    return 'connected'
+  },
+  3,
+  0,
+)
+assert.equal(result, 'connected')
+assert.equal(attempts, 3)
+
+let permanentAttempts = 0
+await assert.rejects(
+  withDatabaseRetry(
+    'permanent self-test',
+    async () => {
+      permanentAttempts += 1
+      throw new Error('invalid query')
+    },
+    3,
+    0,
+  ),
+  /invalid query/,
+)
+assert.equal(permanentAttempts, 1)
+
+console.log('Database retry contract passed.')


### PR DESCRIPTION
## Outcome

Prevents a brief ProxySQL zero-connection window from aborting the production achievement reconciliation and artwork queue.

## Changes

- uses the repository's shared TLS/text-protocol database adapter in both achievement maintenance scripts
- retries only recognized transient connection and pool failures, up to three times with a fresh Prisma client
- keeps non-transient database errors fail-fast
- adds executable retry tests and extends the achievement integration contract

## Production evidence

The first deployment for #1246 failed before its initial `Achievement.count()` with Prisma P2039 / ProxySQL pool timeout (active=0, idle=0). No rows were mutated. The previous production deployment remains active.