### PR TITLE
Match achievement ArtJobs by exact entity ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "seed:davinci:playloop-verify": "tsx utils/scripts/verifyDaVinciPlayLoop.ts",
     "test:davinci-narration": "tsx utils/scripts/verifyDaVinciNarration.ts",
     "test:achievement-store": "tsx utils/scripts/verifyAchievementStoreFetchSafety.ts",
-    "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
+    "test:achievement-catalog": "tsx utils/scripts/verifyDatabaseRetry.ts && tsx utils/scripts/verifyAchievementArtJobDedupe.ts && tsx utils/scripts/verifyAchievementCatalog.ts",
     "seed:achievements": "tsx scripts/seed_achievements.ts",
     "seed:resource-commercial-safe": "tsx scripts/seed_resource_commercial_safe.ts",
     "generate:achievement-art": "tsx scripts/generate_achievement_art.ts",

--- a/scripts/generate_achievement_art.ts
+++ b/scripts/generate_achievement_art.ts
@@ -21,8 +21,8 @@ const PROJECT_SLUG = 'achievements'
 const SEED_USER_ID = 10
 const ACTIVE_JOB_STATUSES = ['PENDING', 'RUNNING'] as const
 
-function entityMarker(achievementId: number): string {
-  return `"entityType":"achievement","entityId":${achievementId}`
+export function achievementEntityMarker(achievementId: number): string {
+  return `"entityType":"achievement","entityId":${achievementId},`
 }
 
 export function buildAchievementArtPayload(achievement: {
@@ -92,7 +92,7 @@ async function main() {
             projectSlug: PROJECT_SLUG,
             userId: SEED_USER_ID,
             status: { in: [...ACTIVE_JOB_STATUSES] },
-            payload: { contains: entityMarker(achievement.id) },
+            payload: { contains: achievementEntityMarker(achievement.id) },
           },
           orderBy: { createdAt: 'desc' },
         })

--- a/utils/scripts/verifyAchievementArtJobDedupe.ts
+++ b/utils/scripts/verifyAchievementArtJobDedupe.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import {
+  achievementEntityMarker,
+  buildAchievementArtPayload,
+} from '../../scripts/generate_achievement_art'
+
+const payloadFor = (id: number) =>
+  JSON.stringify(
+    buildAchievementArtPayload({
+      id,
+      triggerCode: `achievement-${id}`,
+      artPrompt: 'A friendly robot achievement emblem',
+    }),
+  )
+
+assert.ok(payloadFor(9).includes(achievementEntityMarker(9)))
+assert.ok(!payloadFor(978).includes(achievementEntityMarker(9)))
+assert.ok(!payloadFor(10).includes(achievementEntityMarker(1)))
+assert.ok(payloadFor(978).includes(achievementEntityMarker(978)))
+
+console.log('Achievement ArtJob exact-ID dedupe contract passed.')


### PR DESCRIPTION
## Outcome

Ensures every achievement gets its own durable ArtJob.

Production reconciliation showed Theme (entity ID 9) reusing Rebel's job (entity ID 978). The JSON substring marker ended immediately after the numeric ID, so `9` was a prefix match for `978`.

This adds the following JSON delimiter to the marker, exports it for testing, and verifies that IDs 1/10 and 9/978 cannot collide. The next production build will enqueue a replacement Theme job while reusing the other active achievement jobs.