### PR TITLE
Add regression guard for Model Builder's assertRunWritable() check

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -176,6 +176,12 @@ jobs:
       - name: Model Builder auto-build draft gate contract
         run: npm run test:model-builder-auto-build-draft-gate
 
+      - name: Model Builder run-writable guard checker self-test
+        run: npm run test:model-builder-run-writable-guard-selftest
+
+      - name: Model Builder run-writable guard contract
+        run: npm run test:model-builder-run-writable-guard
+
       - name: Kontext mask forwarding contract
         run: npm run test:kontext-mask-forwarding
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,8 @@
     "test:model-builder-auto-build-draft-gate": "tsx utils/scripts/verifyModelBuilderAutoBuildDraftGate.ts",
     "test:model-builder-item-patch-stage-guard-selftest": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.test.ts",
     "test:model-builder-item-patch-stage-guard": "tsx utils/scripts/verifyModelBuilderItemPatchStageGuard.ts",
+    "test:model-builder-run-writable-guard-selftest": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.test.ts",
+    "test:model-builder-run-writable-guard": "tsx utils/scripts/verifyModelBuilderRunWritableGuard.ts",
     "test:kontext-mask-forwarding": "tsx utils/scripts/verifyKontextMaskForwarding.ts",
     "test:mana-gate-on-behalf-of-target": "tsx utils/scripts/verifyManaGateOnBehalfOfTarget.ts",
     "audit:wonderlab-previews": "tsx utils/scripts/auditWonderLabPreviews.ts",

--- a/utils/scripts/verifyModelBuilderRunWritableGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.test.ts
@@ -1,0 +1,140 @@
+// /utils/scripts/verifyModelBuilderRunWritableGuard.test.ts
+//
+// Regression test for checkRunWritableGuard() in
+// verifyModelBuilderRunWritableGuard.ts (model-builder/t-039). Exercises the
+// real check against synthetic route-shaped fixtures covering: the pre-fix
+// shape (assertRunAccess present, assertRunWritable missing entirely -- the
+// exact gap PR #1239 closed), the fixed shape (assertRunWritable immediately
+// follows assertRunAccess for the same run reference), a reordered shape
+// (assertRunWritable present but before assertRunAccess, which this guard
+// still flags since the anchor is "immediately after"), and assertRunAccess
+// itself being absent entirely. Runs each fixture against two different
+// runVar shapes (existing.Run and item.Run) to confirm the dot-escaping in
+// the generated regex works for either.
+import assert from 'node:assert/strict'
+
+import { checkRunWritableGuard } from './verifyModelBuilderRunWritableGuard.js'
+
+const EXISTING_ROUTE = {
+  relativePath: 'server/api/model-builder/items/[id].patch.ts',
+  runVar: 'existing.Run',
+}
+
+const ITEM_ROUTE = {
+  relativePath: 'server/api/model-builder/items/[id]/commit.post.ts',
+  runVar: 'item.Run',
+}
+
+function buggyFixture(runVar: string): string {
+  return `
+export default defineEventHandler(async (event) => {
+  try {
+    const existing = await prisma.modelBuildItem.findUnique({ where: { id } })
+    assertRunAccess(${runVar}, auth.user)
+
+    const body = await readBody(event)
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error, event)
+  }
+})
+`
+}
+
+function fixedFixture(runVar: string): string {
+  return `
+export default defineEventHandler(async (event) => {
+  try {
+    const existing = await prisma.modelBuildItem.findUnique({ where: { id } })
+    assertRunAccess(${runVar}, auth.user)
+    assertRunWritable(${runVar})
+
+    const body = await readBody(event)
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error, event)
+  }
+})
+`
+}
+
+function reorderedFixture(runVar: string): string {
+  return `
+export default defineEventHandler(async (event) => {
+  try {
+    const existing = await prisma.modelBuildItem.findUnique({ where: { id } })
+    assertRunWritable(${runVar})
+    assertRunAccess(${runVar}, auth.user)
+
+    const body = await readBody(event)
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error, event)
+  }
+})
+`
+}
+
+const MISSING_ACCESS_FIXTURE = `
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody(event)
+    return { success: true }
+  } catch (error) {
+    return errorHandler(error, event)
+  }
+})
+`
+
+for (const route of [EXISTING_ROUTE, ITEM_ROUTE]) {
+  const buggyErrors = checkRunWritableGuard(buggyFixture(route.runVar), route)
+  assert.equal(
+    buggyErrors.length,
+    1,
+    `expected the pre-fix shape (assertRunAccess present, assertRunWritable ` +
+      `missing) for ${route.runVar} to raise 1 error, got ${buggyErrors.length}: ` +
+      JSON.stringify(buggyErrors),
+  )
+  assert.ok(buggyErrors[0]!.includes('assertRunWritable'))
+
+  const fixedErrors = checkRunWritableGuard(fixedFixture(route.runVar), route)
+  assert.equal(
+    fixedErrors.length,
+    0,
+    `expected the fixed shape for ${route.runVar} to raise no errors, got: ` +
+      JSON.stringify(fixedErrors),
+  )
+
+  const reorderedErrors = checkRunWritableGuard(
+    reorderedFixture(route.runVar),
+    route,
+  )
+  assert.equal(
+    reorderedErrors.length,
+    1,
+    `expected assertRunWritable appearing before assertRunAccess for ` +
+      `${route.runVar} to still raise 1 error (wrong anchor order), got ` +
+      `${reorderedErrors.length}: ${JSON.stringify(reorderedErrors)}`,
+  )
+
+  const missingAccessErrors = checkRunWritableGuard(
+    MISSING_ACCESS_FIXTURE,
+    route,
+  )
+  assert.equal(
+    missingAccessErrors.length,
+    1,
+    `expected assertRunAccess being absent entirely for ${route.runVar} to ` +
+      `raise 1 error, got ${missingAccessErrors.length}: ` +
+      JSON.stringify(missingAccessErrors),
+  )
+  assert.ok(missingAccessErrors[0]!.includes('assertRunAccess'))
+}
+
+console.log(
+  'Model Builder run-writable guard checker verified: flags the pre-fix ' +
+    'shape (assertRunAccess present, assertRunWritable missing), a ' +
+    'reordered shape (assertRunWritable before assertRunAccess), clears the ' +
+    'fully-fixed shape, and flags assertRunAccess being absent entirely -- ' +
+    'for both existing.Run and item.Run runVar shapes.',
+)

--- a/utils/scripts/verifyModelBuilderRunWritableGuard.ts
+++ b/utils/scripts/verifyModelBuilderRunWritableGuard.ts
@@ -1,0 +1,134 @@
+// /utils/scripts/verifyModelBuilderRunWritableGuard.ts
+//
+// Regression guard (model-builder/t-039, kaizen from t-029's 2026-08-01T08:29Z
+// cycle, kind_robots PR #1239) -- assertRunWritable() in
+// server/api/model-builder/runs/index.ts closes a gap none of the
+// write-capable item routes previously covered: cancelRun() marks a
+// ModelBuildRun CANCELLED specifically so no further work lands on it, but
+// until PR #1239 that intent was enforced only client-side (modelBuilderStore.ts's
+// in-memory cancelledRunIds Set, wiped on reload and scoped to the one tab
+// that issued the cancellation). A second tab, or a tab reloaded later
+// against a stale `modelBuilder:runId`, had no way to learn the run was
+// cancelled and could keep editing, generating, and durably committing into a
+// run the user had already abandoned.
+//
+// PR #1239 added assertRunWritable(run) next to the existing assertRunAccess()
+// call in all four write-capable item routes (items/[id].patch.ts,
+// items/batch.patch.ts, items/[id]/artifacts.post.ts, items/[id]/commit.post.ts),
+// but -- unlike every sibling client-side cancelledRunIds check -- shipped
+// without a dedicated textual regression guard, per that cycle's own
+// deferred kaizen note. A future refactor could silently drop the
+// assertRunWritable() call from any one of the four routes with nothing
+// failing except a live end-to-end test this sandbox can't run.
+//
+// This asserts the textual shape stays in place: each of the four routes
+// calls assertRunWritable(<run>) immediately after assertRunAccess(<run>,
+// auth.user) for the same run reference -- deliberately scoped to this one
+// bug shape, mirroring verifyModelBuilderItemPatchStageGuard.ts's and
+// verifyModelBuilderCommitCancelledRunGuard.ts's preference for explicit,
+// narrow textual checks over a general-purpose static analyzer.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+interface RouteCheck {
+  relativePath: string
+  runVar: string
+}
+
+const ROUTES: RouteCheck[] = [
+  {
+    relativePath: 'server/api/model-builder/items/[id].patch.ts',
+    runVar: 'existing.Run',
+  },
+  {
+    relativePath: 'server/api/model-builder/items/batch.patch.ts',
+    runVar: 'existing.Run',
+  },
+  {
+    relativePath: 'server/api/model-builder/items/[id]/artifacts.post.ts',
+    runVar: 'item.Run',
+  },
+  {
+    relativePath: 'server/api/model-builder/items/[id]/commit.post.ts',
+    runVar: 'item.Run',
+  },
+]
+
+// Checks the fix's exact shape against the full source text of one route
+// file. Exported (rather than only exercised via main()) so the self-test
+// below can run it against synthetic route-shaped fixtures without touching
+// the real route files.
+export function checkRunWritableGuard(
+  content: string,
+  route: RouteCheck,
+): string[] {
+  const errors: string[] = []
+  const escapedVar = route.runVar.replace(/\./g, '\\.')
+
+  const accessPattern = new RegExp(
+    `assertRunAccess\\(\\s*${escapedVar},\\s*auth\\.user\\s*\\)`,
+  )
+  const accessMatch = accessPattern.exec(content)
+  if (!accessMatch) {
+    errors.push(
+      `${route.relativePath} no longer contains ` +
+        `\`assertRunAccess(${route.runVar}, auth.user)\` -- this guard's ` +
+        'anchor point has moved; re-check how run ownership is verified here.',
+    )
+    return errors
+  }
+
+  // Tolerant of the whitespace/indentation between the two statements
+  // (each route indents this pair differently) rather than requiring an
+  // exact adjacent line.
+  const writablePattern = new RegExp(
+    `assertRunAccess\\(\\s*${escapedVar},\\s*auth\\.user\\s*\\)\\s*\\n\\s*` +
+      `assertRunWritable\\(\\s*${escapedVar}\\s*\\)`,
+  )
+  if (!writablePattern.test(content)) {
+    errors.push(
+      `${route.relativePath} does not call ` +
+        `\`assertRunWritable(${route.runVar})\` immediately after ` +
+        `\`assertRunAccess(${route.runVar}, auth.user)\`. cancelRun() marks ` +
+        'a run CANCELLED specifically to stop further writes landing on it, ' +
+        'but that intent is enforced client-side only by an in-memory Set ' +
+        'scoped to the tab that issued the cancellation -- without this ' +
+        'server-side check, a second tab or a stale reload can keep ' +
+        'editing, generating, or durably committing into an abandoned run.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const allErrors: string[] = []
+
+  for (const route of ROUTES) {
+    const filePath = join(repositoryRoot, route.relativePath)
+    const content = readFileSync(filePath, 'utf8')
+    allErrors.push(...checkRunWritableGuard(content, route))
+  }
+
+  if (allErrors.length) {
+    console.error('Model Builder run-writable guard contract failed:')
+    for (const error of allErrors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    'Model Builder run-writable guard contract passed: all four ' +
+      'write-capable item routes (item patch, batch patch, artifact post, ' +
+      'commit post) call assertRunWritable() immediately after ' +
+      'assertRunAccess(), refusing writes once a run is CANCELLED.',
+  )
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
model-builder/t-039: Add a `verifyModelBuilderRunWritableGuard.ts` regression guard for the new `assertRunWritable()` server-side cancelled-run check (kind: software)

### What changed / what I produced
- Added `utils/scripts/verifyModelBuilderRunWritableGuard.ts` (+ `.test.ts`), following the established narrow-textual-checker convention (same shape as `verifyModelBuilderItemPatchStageGuard.ts`).
- Asserts each of the four write-capable item routes — `items/[id].patch.ts`, `items/batch.patch.ts`, `items/[id]/artifacts.post.ts`, `items/[id]/commit.post.ts` — calls `assertRunWritable(<run>)` immediately after `assertRunAccess(<run>, auth.user)` for the same run reference.
- Wired into `package.json` (`test:model-builder-run-writable-guard[-selftest]`) and `.github/workflows/contract-tests.yml`, alongside the other Model Builder guard steps.

### Why
`assertRunWritable()` (added in kind_robots PR #1239) refuses writes to a `CANCELLED` `ModelBuildRun` in all four routes, but — unlike every sibling client-side `cancelledRunIds` check — shipped with no dedicated textual regression guard, per that cycle's own deferred kaizen note. A future refactor could silently drop the call from one of the four routes with nothing failing except a live end-to-end test this sandbox can't run.

### How I verified
- New checker + self-test both pass (`npm run test:model-builder-run-writable-guard[-selftest]`); self-test covers pre-fix (missing call), fixed, reordered (wrong anchor order), and `assertRunAccess`-absent shapes for both `existing.Run` and `item.Run` variable shapes.
- All 17 pre-existing + new `test:model-builder-*` verify/selftest scripts still pass — no regressions.
- `npx eslint` clean on both new files.
- `npx prettier --check` clean on new files and `package.json`; the one warning on `contract-tests.yml` is pre-existing drift, confirmed via `git stash` before this change.
- Full-project `npx vue-tsc --noEmit -p tsconfig.json` exit 0.
- `git status --porcelain` showed exactly the 4 intended files touched (no incidental Prisma-regeneration diff).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Two sibling Model Builder guard scripts already exist in `package.json` but aren't wired into `contract-tests.yml`: `test:model-builder-approved-asset-guard[-selftest]` and `test:model-builder-item-patch-stage-guard[-selftest]`. Left out of this diff to stay scoped to t-039's own guard — worth a follow-up task to wire both in.

### Notes for reviewer
model-builder/t-029's TALKBACK.md has the full history of this recurring task's ~25 prior cycles, including the 2026-08-01T08:29Z entry (PR #1239) that first flagged this gap.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Ex9LAtcCbTiShzQwwHmbWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ex9LAtcCbTiShzQwwHmbWZ)_