### PR TITLE
Route achievement artwork through Comfy instead of A1111

### DIFF
--- a/scripts/generate_achievement_art.ts
+++ b/scripts/generate_achievement_art.ts
@@ -12,6 +12,8 @@
 
 import 'dotenv/config'
 import { fileURLToPath } from 'node:url'
+import { buildKrea2WorkflowFromRequest } from '../server/api/comfy/krea2/utils/workflow'
+import { enrichArtJobPayload } from '../server/utils/artJobProvenance'
 import {
   createScriptPrismaClient,
   withDatabaseRetry,
@@ -19,10 +21,16 @@ import {
 
 const PROJECT_SLUG = 'achievements'
 const SEED_USER_ID = 10
-const ACTIVE_JOB_STATUSES = ['PENDING', 'RUNNING'] as const
+
+export const ACHIEVEMENT_ART_ENGINE = 'COMFY' as const
+export const ACHIEVEMENT_ART_VERSION = 'comfy-krea2-v1'
 
 export function achievementEntityMarker(achievementId: number): string {
   return `"entityType":"achievement","entityId":${achievementId},`
+}
+
+export function achievementArtVersionMarker(): string {
+  return `"achievementArtVersion":"${ACHIEVEMENT_ART_VERSION}"`
 }
 
 export function buildAchievementArtPayload(achievement: {
@@ -35,30 +43,51 @@ export function buildAchievementArtPayload(achievement: {
     throw new Error(`Achievement ${achievement.id} has no artPrompt`)
   }
 
-  return {
-    promptString,
-    negativePrompt:
-      'readable text, caption, watermark, signature, logo, UI, frame, border',
+  const negativePrompt =
+    'readable text, caption, watermark, signature, logo, UI, frame, border'
+  const { workflow, seed } = buildKrea2WorkflowFromRequest({
+    prompt: promptString,
+    negativePrompt,
     width: 1024,
     height: 1024,
-    steps: 28,
-    cfg: 3,
-    save: {
-      isPublic: true,
-      isMature: false,
-      designer: 'achievement-catalog',
+    steps: 8,
+    cfg: 1,
+  })
+
+  return enrichArtJobPayload(
+    ACHIEVEMENT_ART_ENGINE,
+    {
+      promptString,
+      negativePrompt,
+      width: 1024,
+      height: 1024,
+      steps: 8,
+      cfg: 1,
+      seed,
+      workflow,
+      save: {
+        isPublic: true,
+        isMature: false,
+        designer: 'achievement-catalog',
+      },
+      entityArt: {
+        entityType: 'achievement',
+        entityId: achievement.id,
+        field: 'imagePath',
+        preserveOriginal: true,
+        mode: 'recreate',
+      },
+      achievementArtVersion: ACHIEVEMENT_ART_VERSION,
+      achievement: {
+        triggerCode: achievement.triggerCode,
+      },
     },
-    entityArt: {
-      entityType: 'achievement',
-      entityId: achievement.id,
-      field: 'imagePath',
-      preserveOriginal: true,
-      mode: 'recreate',
+    {
+      projectSlug: PROJECT_SLUG,
+      idempotencyKey: `achievement:${achievement.id}:${ACHIEVEMENT_ART_VERSION}`,
+      requireCompletionProof: true,
     },
-    achievement: {
-      triggerCode: achievement.triggerCode,
-    },
-  }
+  ).payload
 }
 
 async function main() {
@@ -91,8 +120,10 @@ async function main() {
           where: {
             projectSlug: PROJECT_SLUG,
             userId: SEED_USER_ID,
-            status: { in: [...ACTIVE_JOB_STATUSES] },
-            payload: { contains: achievementEntityMarker(achievement.id) },
+            AND: [
+              { payload: { contains: achievementEntityMarker(achievement.id) } },
+              { payload: { contains: achievementArtVersionMarker() } },
+            ],
           },
           orderBy: { createdAt: 'desc' },
         })
@@ -100,7 +131,7 @@ async function main() {
         if (existing) {
           reused += 1
           console.log(
-            `  reuse ArtJob ${existing.id}: ${achievement.triggerCode} — ${achievement.label}`,
+            `  reuse ArtJob ${existing.id} (${existing.status}): ${achievement.triggerCode} — ${achievement.label}`,
           )
           continue
         }
@@ -114,7 +145,7 @@ async function main() {
 
         const job = await prisma.artJob.create({
           data: {
-            engine: 'A1111',
+            engine: ACHIEVEMENT_ART_ENGINE,
             userId: SEED_USER_ID,
             projectSlug: PROJECT_SLUG,
             priority: 5,
@@ -130,8 +161,8 @@ async function main() {
 
       console.log(
         WRITE
-          ? `Achievement art: ${queued} queued, ${reused} active job(s) reused, ${achievements.length} missing image(s) inspected.`
-          : `[dry run] ${achievements.length - reused} job(s) would be queued; ${reused} active job(s) already exist.`,
+          ? `Achievement art: ${queued} queued, ${reused} same-version job(s) reused, ${achievements.length} missing image(s) inspected.`
+          : `[dry run] ${achievements.length - reused} job(s) would be queued; ${reused} same-version job(s) already exist.`,
       )
     } finally {
       await prisma.$disconnect()

--- a/utils/scripts/verifyAchievementArtJobDedupe.ts
+++ b/utils/scripts/verifyAchievementArtJobDedupe.ts
@@ -1,21 +1,47 @@
 import assert from 'node:assert/strict'
 import {
+  ACHIEVEMENT_ART_ENGINE,
+  ACHIEVEMENT_ART_VERSION,
+  achievementArtVersionMarker,
   achievementEntityMarker,
   buildAchievementArtPayload,
 } from '../../scripts/generate_achievement_art'
 
 const payloadFor = (id: number) =>
-  JSON.stringify(
-    buildAchievementArtPayload({
-      id,
-      triggerCode: `achievement-${id}`,
-      artPrompt: 'A friendly robot achievement emblem',
-    }),
-  )
+  buildAchievementArtPayload({
+    id,
+    triggerCode: `achievement-${id}`,
+    artPrompt: 'A friendly robot achievement emblem',
+  })
 
-assert.ok(payloadFor(9).includes(achievementEntityMarker(9)))
-assert.ok(!payloadFor(978).includes(achievementEntityMarker(9)))
-assert.ok(!payloadFor(10).includes(achievementEntityMarker(1)))
-assert.ok(payloadFor(978).includes(achievementEntityMarker(978)))
+const serializedPayloadFor = (id: number) => JSON.stringify(payloadFor(id))
 
-console.log('Achievement ArtJob exact-ID dedupe contract passed.')
+assert.ok(serializedPayloadFor(9).includes(achievementEntityMarker(9)))
+assert.ok(!serializedPayloadFor(978).includes(achievementEntityMarker(9)))
+assert.ok(!serializedPayloadFor(10).includes(achievementEntityMarker(1)))
+assert.ok(serializedPayloadFor(978).includes(achievementEntityMarker(978)))
+assert.ok(serializedPayloadFor(9).includes(achievementArtVersionMarker()))
+
+const payload = payloadFor(9)
+const workflow = payload.workflow as Record<
+  string,
+  { class_type?: string; inputs?: Record<string, unknown> }
+>
+const provenance = payload.provenance as Record<string, unknown>
+
+assert.equal(ACHIEVEMENT_ART_ENGINE, 'COMFY')
+assert.equal(payload.achievementArtVersion, ACHIEVEMENT_ART_VERSION)
+assert.equal(workflow['1']?.class_type, 'UnetLoaderGGUF')
+assert.equal(workflow['1']?.inputs?.unet_name, 'Krea-2-Turbo-Q5_K_S.gguf')
+assert.equal(workflow['2']?.inputs?.clip_name, 'qwen3vl_4b_fp8_scaled.safetensors')
+assert.equal(workflow['5']?.inputs?.vae_name, 'qwen_image_vae.safetensors')
+assert.equal(workflow['9']?.class_type, 'SaveImage')
+assert.equal(provenance.requireCompletionProof, true)
+assert.equal(provenance.workflowPromptMatches, true)
+assert.equal(
+  provenance.idempotencyKey,
+  `achievement:9:${ACHIEVEMENT_ART_VERSION}`,
+)
+assert.ok(String(payload.attemptFingerprint || '').length > 0)
+
+console.log('Achievement ArtJob Comfy + exact-ID dedupe contract passed.')


### PR DESCRIPTION
## Root cause

The new achievement artwork seeder created raw `A1111` ArtJobs. The home relay and ComfyUI were healthy, but those jobs were sent to the separate Stable Diffusion WebUI endpoint. They exhausted three fast attempts, and the production build then queued another full set because dedupe only considered PENDING/RUNNING jobs.

Observed production batches:
- ArtJobs 2920-2944 queued by the first achievement deployment
- ArtJobs 2945-2969 queued again by the next deployment after the first batch failed
- Jobs 2964-2969 each reported three failed attempts while the relay continued polling normally

## Changes

- Build a real Krea 2 Turbo COMFY workflow for every achievement image
- Enrich jobs with strict workflow/prompt provenance required by the relay
- Version the achievement art pipeline (`comfy-krea2-v1`)
- Deduplicate same-version jobs across every status, preventing failed jobs from cloning themselves on later deploys
- Expand the existing contract verifier to assert COMFY engine, installed model filenames, workflow output, provenance, versioning, and exact entity-ID matching

## Verification

CI should run the existing achievement ArtJob dedupe contract plus the repository's normal TypeScript, contract, and build checks.