### PR TITLE
clean retired facets and queue audited artwork

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Verify final Facet catalog directives
         run: npx tsx utils/scripts/verifyFacetCatalogDirectives.ts
 
+      - name: Verify retired Facet cleanup and artwork queue
+        run: npx tsx utils/scripts/verifyFacetCatalogMaintenance.ts
+
       - name: Verify whole-catalog Facet audit
         run: npx tsx utils/scripts/verifyFacetCatalogAudit.ts
 

--- a/scripts/generate_facet_art.ts
+++ b/scripts/generate_facet_art.ts
@@ -1,0 +1,567 @@
+// /scripts/generate_facet_art.ts
+//
+// Audits the complete active Facet catalog and creates durable, deduplicated
+// primary-image ArtJobs for entries that are clean enough to illustrate.
+// Structural oddities are reported and skipped rather than rewarded with art.
+// This intentionally queues only imagePath. Card, hero, and future icon slots
+// belong to the upcoming multi-art schema migration.
+//
+// Usage:
+//   npx tsx scripts/generate_facet_art.ts
+//   npx tsx scripts/generate_facet_art.ts --write
+
+import 'dotenv/config'
+import { fileURLToPath } from 'node:url'
+import { buildKrea2WorkflowFromRequest } from '../server/api/comfy/krea2/utils/workflow'
+import { enrichArtJobPayload } from '../server/utils/artJobProvenance'
+import {
+  auditFacetCatalog,
+  type FacetAuditInput,
+} from '../utils/facetCatalogAudit'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from './lib/databaseRetry'
+
+const WRITE = process.argv.includes('--write')
+const PROJECT_SLUG = 'facet-catalog'
+const PRIMARY_FIELD = 'imagePath'
+const FACET_ART_VERSION = 'facet-primary-krea2-v1'
+const NEGATIVE_PROMPT =
+  'readable text, caption, watermark, signature, logo, UI, frame, border, duplicate subject, cropped subject, illegible anatomy'
+
+const BLOCKING_REASON_CODES = new Set([
+  'missing-profile',
+  'duplicate-title',
+  'prompt-cargo-cult',
+  'parenthetical-genre',
+  'composite-genre',
+  'setting-shaped-genre',
+  'subject-shaped-genre',
+  'occupation-shaped-personality',
+  'worldview-shaped-personality',
+  'quirk-shaped-backstory',
+  'sentence-title',
+  'underspecified-title',
+  'unreviewed-legacy-record',
+])
+
+type JsonObject = Record<string, unknown>
+
+type FacetRow = {
+  id: number
+  title: string
+  slug: string | null
+  kind: string
+  description: string | null
+  flavorText: string | null
+  examples: string | null
+  artPrompt: string | null
+  imagePath: string | null
+  cardPath: string | null
+  heroPath: string | null
+  icon: string | null
+  artImageId: number | null
+  artCollectionId: number | null
+  userId: number
+  isPublic: boolean
+  isMature: boolean
+}
+
+type ProfileRow = {
+  facetId: number
+  taxonomy: string
+  canonicalValue: string | null
+  groupKey: string | null
+  groupLabel: string | null
+  isRandomizable: boolean
+  randomWeight: number
+  artRequired: boolean
+  sourceRank: number
+  metadata: string | null
+}
+
+type FacetSnapshot = {
+  id: number
+  title: string
+  slug: string | null
+  taxonomy: string
+  canonicalValue: string | null
+  artPrompt: string | null
+  imagePath: string | null
+  cardPath: string | null
+  heroPath: string | null
+}
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonObject)
+    : {}
+}
+
+function parseMetadata(value: string | null | undefined): JsonObject {
+  if (!value) return {}
+  try {
+    return asObject(JSON.parse(value))
+  } catch {
+    return {}
+  }
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function compactLines(values: unknown[]): string[] {
+  return values.map(clean).filter(Boolean)
+}
+
+function metadataArtworkPrompt(metadata: JsonObject): string {
+  const direct = clean(metadata.artworkPrompt)
+  if (direct) return direct
+
+  const artBuilder = asObject(metadata.artBuilder)
+  const hints: string[] = []
+  for (const value of Object.values(artBuilder)) {
+    const hint = clean(asObject(value).promptHint)
+    if (hint) hints.push(hint)
+  }
+  return [...new Set(hints)].join(', ')
+}
+
+function taxonomyGuidance(taxonomy: string): string {
+  switch (taxonomy) {
+    case 'ANIMAL':
+    case 'SPECIES':
+      return 'Show one unmistakable full creature with recognizable anatomy, personality, and habitat cues.'
+    case 'GENRE':
+    case 'THEME':
+    case 'SETTING':
+      return 'Build one iconic scene that communicates the concept through subject, environment, action, and atmosphere.'
+    case 'PERSONALITY':
+    case 'ALIGNMENT':
+    case 'QUIRK':
+    case 'BACKSTORY':
+      return 'Use a character-centered visual metaphor with a clear emotional read and no written explanation.'
+    case 'COLOR':
+    case 'MATERIAL':
+      return 'Make the palette or material behavior unmistakable through lighting, texture, and a strong central form.'
+    case 'STYLE':
+    case 'ART_DIRECTION':
+    case 'PROMPT_ENHANCEMENT':
+      return 'Demonstrate the visual treatment directly in a polished sample image rather than depicting a label for it.'
+    case 'OCCUPATION':
+    case 'ARCHETYPE':
+    case 'ROLE':
+      return 'Show a single distinctive figure performing or embodying the role, with readable tools and silhouette.'
+    case 'RARITY':
+    case 'REWARD_TYPE':
+      return 'Create a premium collectible emblem or object with a strong rarity read and clean silhouette.'
+    default:
+      return 'Use a single clear subject or emblem that makes the concept understandable at thumbnail size.'
+  }
+}
+
+export function facetEntityMarker(facetId: number): string {
+  return `\"entityType\":\"facet\",\"entityId\":${facetId},`
+}
+
+export function facetArtVersionMarker(): string {
+  return `\"facetArtworkVersion\":\"${FACET_ART_VERSION}\"`
+}
+
+export function buildFacetIdentityPrompt(
+  facet: FacetRow,
+  profile: ProfileRow,
+): string {
+  const existing = clean(facet.artPrompt)
+  if (existing) return existing
+
+  const metadata = parseMetadata(profile.metadata)
+  const metadataPrompt = metadataArtworkPrompt(metadata)
+  const scientificName = clean(metadata.scientificName)
+  const category = clean(metadata.category)
+  const prose = compactLines([
+    facet.description,
+    facet.flavorText,
+    facet.examples,
+    metadataPrompt,
+  ])
+
+  return [
+    `Illustrate the Facet concept “${facet.title}”.`,
+    scientificName ? `Scientific identity: ${scientificName}.` : '',
+    category ? `Catalog category: ${category}.` : '',
+    ...prose,
+    taxonomyGuidance(profile.taxonomy),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function buildFacetPrimaryPrompt(
+  facet: FacetRow,
+  profile: ProfileRow,
+  identityPrompt: string,
+): string {
+  const label = profile.groupLabel || profile.taxonomy.replaceAll('_', ' ')
+  return [
+    identityPrompt,
+    `Create this as the primary square catalog artwork for Kind Robots ${label}: ${facet.title}.`,
+    'One decisive composition, polished fantasy-software illustration, excellent thumbnail readability, rich controlled lighting, crisp subject separation, no text, no logo, no watermark.',
+  ].join('\n\n')
+}
+
+function facetSnapshot(
+  facet: FacetRow,
+  profile: ProfileRow,
+  artPrompt: string,
+): FacetSnapshot {
+  return {
+    id: facet.id,
+    title: facet.title,
+    slug: facet.slug,
+    taxonomy: profile.taxonomy,
+    canonicalValue: profile.canonicalValue,
+    artPrompt,
+    imagePath: facet.imagePath,
+    cardPath: facet.cardPath,
+    heroPath: facet.heroPath,
+  }
+}
+
+export function buildFacetArtPayload(
+  facet: FacetRow,
+  profile: ProfileRow,
+  identityPrompt: string,
+) {
+  const promptString = buildFacetPrimaryPrompt(facet, profile, identityPrompt)
+  const { workflow, seed } = buildKrea2WorkflowFromRequest({
+    prompt: promptString,
+    negativePrompt: NEGATIVE_PROMPT,
+    width: 1024,
+    height: 1024,
+    steps: 8,
+    cfg: 1,
+  })
+
+  return enrichArtJobPayload(
+    'COMFY',
+    {
+      promptString,
+      basePromptString: identityPrompt,
+      negativePrompt: NEGATIVE_PROMPT,
+      width: 1024,
+      height: 1024,
+      steps: 8,
+      cfg: 1,
+      seed,
+      workflow,
+      save: {
+        isPublic: facet.isPublic,
+        isMature: facet.isMature,
+        designer: 'facet-catalog',
+      },
+      facets: [facetSnapshot(facet, profile, identityPrompt)],
+      entityArt: {
+        entityType: 'facet',
+        entityId: facet.id,
+        field: PRIMARY_FIELD,
+        preserveOriginal: true,
+        mode: 'recreate',
+      },
+      facetArtworkVersion: FACET_ART_VERSION,
+      facetCatalog: {
+        taxonomy: profile.taxonomy,
+        groupKey: profile.groupKey,
+        sourceRank: profile.sourceRank,
+      },
+    },
+    {
+      projectSlug: PROJECT_SLUG,
+      idempotencyKey: `facet:${facet.id}:${PRIMARY_FIELD}:${FACET_ART_VERSION}`,
+      requireCompletionProof: true,
+    },
+  ).payload
+}
+
+function priorityFor(profile: ProfileRow): number {
+  if (profile.sourceRank <= 10) return -10
+  if (profile.sourceRank <= 30) return -15
+  return -20
+}
+
+async function runWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0
+  async function lane(): Promise<void> {
+    while (cursor < items.length) {
+      const item = items[cursor]
+      cursor += 1
+      if (item !== undefined) await worker(item)
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => lane()),
+  )
+}
+
+async function main(): Promise<void> {
+  await withDatabaseRetry('Facet artwork queue', async () => {
+    const prisma = createScriptPrismaClient()
+    try {
+      const [facets, profiles, aliases, artImageLinks, artCollectionLinks, jobs] =
+        await Promise.all([
+          prisma.facet.findMany({
+            where: { isActive: true },
+            orderBy: { id: 'asc' },
+            select: {
+              id: true,
+              title: true,
+              slug: true,
+              kind: true,
+              description: true,
+              flavorText: true,
+              examples: true,
+              artPrompt: true,
+              imagePath: true,
+              cardPath: true,
+              heroPath: true,
+              icon: true,
+              artImageId: true,
+              artCollectionId: true,
+              userId: true,
+              isPublic: true,
+              isMature: true,
+            },
+          }),
+          prisma.facetProfile.findMany({
+            select: {
+              facetId: true,
+              taxonomy: true,
+              canonicalValue: true,
+              groupKey: true,
+              groupLabel: true,
+              isRandomizable: true,
+              randomWeight: true,
+              artRequired: true,
+              sourceRank: true,
+              metadata: true,
+            },
+          }),
+          prisma.facetAlias.findMany({
+            where: { isActive: true },
+            select: { facetId: true, alias: true },
+          }),
+          prisma.facetArtImage.findMany({ select: { facetId: true } }),
+          prisma.facetArtCollection.findMany({ select: { facetId: true } }),
+          prisma.artJob.findMany({
+            where: {
+              projectSlug: PROJECT_SLUG,
+              status: { in: ['PENDING', 'RUNNING'] },
+              payload: { contains: facetArtVersionMarker() },
+            },
+            select: { id: true, status: true, payload: true },
+          }),
+        ])
+
+      const profileByFacet = new Map(
+        profiles.map((profile) => [profile.facetId, profile as ProfileRow]),
+      )
+      const aliasesByFacet = new Map<number, string[]>()
+      for (const alias of aliases) {
+        const entries = aliasesByFacet.get(alias.facetId) ?? []
+        entries.push(alias.alias)
+        aliasesByFacet.set(alias.facetId, entries)
+      }
+      const linkedPrimaryArt = new Set(artImageLinks.map((link) => link.facetId))
+      const linkedCollections = new Set(
+        artCollectionLinks.map((link) => link.facetId),
+      )
+      const pendingFacetIds = new Set<number>()
+      for (const job of jobs) {
+        const match = job.payload.match(
+          /\"entityType\":\"facet\",\"entityId\":(\d+),/,
+        )
+        const id = Number(match?.[1])
+        if (Number.isInteger(id) && id > 0) pendingFacetIds.add(id)
+      }
+
+      const auditInputs: FacetAuditInput[] = (facets as FacetRow[]).map(
+        (facet) => {
+          const profile = profileByFacet.get(facet.id)
+          return {
+            id: facet.id,
+            title: facet.title,
+            slug: facet.slug,
+            taxonomy: (profile?.taxonomy as FacetAuditInput['taxonomy']) ?? null,
+            groupKey: profile?.groupKey ?? null,
+            groupLabel: profile?.groupLabel ?? null,
+            isRandomizable: profile?.isRandomizable ?? false,
+            randomWeight: profile?.randomWeight ?? 0,
+            sourceRank: profile?.sourceRank ?? null,
+            description: facet.description,
+            flavorText: facet.flavorText,
+            examples: facet.examples,
+            artPrompt: facet.artPrompt,
+            aliases: aliasesByFacet.get(facet.id) ?? [],
+            artBacked: Boolean(
+              facet.imagePath ||
+                facet.cardPath ||
+                facet.heroPath ||
+                facet.icon ||
+                facet.artImageId !== null ||
+                facet.artCollectionId !== null ||
+                linkedPrimaryArt.has(facet.id) ||
+                linkedCollections.has(facet.id),
+            ),
+          }
+        },
+      )
+      const audit = auditFacetCatalog(auditInputs)
+      const blockersByFacet = new Map<number, string[]>()
+      for (const candidate of audit.candidates) {
+        const blockers = candidate.reasons
+          .map((reason) => reason.code)
+          .filter((code) => BLOCKING_REASON_CODES.has(code))
+        if (blockers.length) blockersByFacet.set(candidate.id, blockers)
+      }
+
+      const available: number[] = []
+      const notRequired: number[] = []
+      const reused: number[] = []
+      const blocked: Array<{ id: number; title: string; reasons: string[] }> = []
+      const queue: Array<{
+        facet: FacetRow
+        profile: ProfileRow
+        identityPrompt: string
+      }> = []
+
+      for (const facet of facets as FacetRow[]) {
+        const profile = profileByFacet.get(facet.id)
+        if (!profile) {
+          blocked.push({
+            id: facet.id,
+            title: facet.title,
+            reasons: ['missing-profile'],
+          })
+          continue
+        }
+        if (!profile.artRequired) {
+          notRequired.push(facet.id)
+          continue
+        }
+
+        // A card, hero, or emoji icon does not satisfy the primary image slot.
+        const primaryArtBacked = Boolean(
+          facet.imagePath ||
+            facet.artImageId !== null ||
+            linkedPrimaryArt.has(facet.id),
+        )
+        if (primaryArtBacked) {
+          available.push(facet.id)
+          continue
+        }
+
+        const blockers = blockersByFacet.get(facet.id) ?? []
+        if (blockers.length) {
+          blocked.push({ id: facet.id, title: facet.title, reasons: blockers })
+          continue
+        }
+        if (pendingFacetIds.has(facet.id)) {
+          reused.push(facet.id)
+          continue
+        }
+
+        queue.push({
+          facet,
+          profile,
+          identityPrompt: buildFacetIdentityPrompt(facet, profile),
+        })
+      }
+
+      if (WRITE) {
+        const promptUpdates = queue.filter(
+          (entry) => !clean(entry.facet.artPrompt),
+        )
+        await runWithConcurrency(promptUpdates, 8, async (entry) => {
+          await prisma.facet.update({
+            where: { id: entry.facet.id },
+            data: { artPrompt: entry.identityPrompt },
+          })
+        })
+
+        const jobRows = queue.map((entry) => ({
+          engine: 'COMFY' as const,
+          userId: entry.facet.userId,
+          projectSlug: PROJECT_SLUG,
+          priority: priorityFor(entry.profile),
+          payload: JSON.stringify(
+            buildFacetArtPayload(
+              entry.facet,
+              entry.profile,
+              entry.identityPrompt,
+            ),
+          ),
+        }))
+
+        let inserted = 0
+        for (let index = 0; index < jobRows.length; index += 25) {
+          const chunk = jobRows.slice(index, index + 25)
+          if (!chunk.length) continue
+          const result = await prisma.artJob.createMany({ data: chunk })
+          inserted += result.count
+        }
+
+        console.log(
+          `Facet art: ${inserted} queued, ${reused.length} pending job(s) reused, ${available.length} primary image(s) already available, ${blocked.length} entry/entries held for catalog review.`,
+        )
+      }
+
+      console.log(
+        JSON.stringify(
+          {
+            mode: WRITE ? 'write' : 'dry-run',
+            projectSlug: PROJECT_SLUG,
+            version: FACET_ART_VERSION,
+            primaryField: PRIMARY_FIELD,
+            totals: {
+              active: facets.length,
+              available: available.length,
+              notRequired: notRequired.length,
+              pendingReused: reused.length,
+              queued: queue.length,
+              blocked: blocked.length,
+            },
+            audit: audit.totals,
+            blocked: blocked.slice(0, 100),
+            policy: {
+              qualityGate:
+                'Do not generate art for duplicate, malformed, composite, taxonomy-leaking, cargo-cult, or unreviewed legacy Facets.',
+              scope:
+                'Queue primary imagePath art only. Card, hero, and icon variants wait for the multi-art schema.',
+              dedupe:
+                'Reuse current-version PENDING or RUNNING jobs; a missing image after a completed job may be repaired by a new job.',
+            },
+          },
+          null,
+          2,
+        ),
+      )
+    } finally {
+      await prisma.$disconnect()
+    }
+  })
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -134,12 +134,29 @@ if (!isVercelBuild || isProductionDeployment) {
     'Applying final Facet catalog directives and deleting historical shells',
   )
 
+  // Older merge scripts may encounter pre-existing rows and temporarily mark them
+  // inactive. Move every remaining edge and artwork reference, then remove those
+  // shells and transient recipe records completely.
+  run(
+    tsxBinary,
+    ['utils/scripts/cleanupRetiredFacetShells.ts', '--apply'],
+    'Migrating and deleting all retired Facet shells',
+  )
+
   // Read the entire post-curation catalog and print a ranked next-batch queue.
   // This never mutates data or blocks deployment while cleanup is still in motion.
   run(
     tsxBinary,
     ['utils/scripts/auditFacetCatalogOddities.ts', '--top=60'],
     'Auditing the complete Facet catalog for remaining oddities',
+  )
+
+  // Queue one primary square artwork only for clean, active, art-required Facets.
+  // Card, hero, and icon variants wait for the multi-art schema migration.
+  run(
+    tsxBinary,
+    ['scripts/generate_facet_art.ts', '--write'],
+    'Queueing missing primary Facet artwork after the full catalog audit',
   )
 
   run(

--- a/utils/scripts/cleanupRetiredFacetShells.ts
+++ b/utils/scripts/cleanupRetiredFacetShells.ts
@@ -1,0 +1,628 @@
+// /utils/scripts/cleanupRetiredFacetShells.ts
+//
+// Removes obsolete Facet rows after every curation/merge pass. Retired merge
+// shells are not history records: all live edges, aliases, artwork, and queued
+// entity-art jobs are moved to the canonical Facet, then the shell is deleted.
+// Genre-recipe rows are transient migration scaffolding and are deleted outright.
+
+import 'dotenv/config'
+import { fileURLToPath } from 'node:url'
+import type { PrismaClient } from './../../prisma/generated/prisma/client'
+import {
+  parseArtJobPayload,
+  serializeArtJobPayload,
+} from './../../server/utils/artJobPayload'
+import { normalizeFacetLookupKey } from './../facetAliases'
+import {
+  createScriptPrismaClient,
+  withDatabaseRetry,
+} from './../../scripts/lib/databaseRetry'
+
+const APPLY = process.argv.includes('--apply')
+const BATCH_ID = '2026-08-01-retired-facet-cleanup-10'
+const MERGED_SLUG_PATTERN = /-merged-\d+$/
+
+type JsonObject = Record<string, unknown>
+type Db = PrismaClient
+
+type FacetRecord = Awaited<ReturnType<Db['facet']['findUnique']>>
+
+type CleanupResult = {
+  id: number
+  title: string
+  action: string
+  canonicalId?: number
+  canonicalTitle?: string
+  artImageLinks?: number
+  artCollectionLinks?: number
+  artJobs?: number
+}
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonObject)
+    : {}
+}
+
+function parseMetadata(value: string | null | undefined): JsonObject {
+  if (!value) return {}
+  try {
+    return asObject(JSON.parse(value))
+  } catch {
+    return {}
+  }
+}
+
+function positiveInteger(value: unknown): number | null {
+  const numberValue = Number(value)
+  return Number.isInteger(numberValue) && numberValue > 0 ? numberValue : null
+}
+
+function stripRetiredMergeMetadata(value: JsonObject): JsonObject {
+  const cleaned = { ...value }
+  for (const key of [
+    'mergedFacetSources',
+    'mergedArtworkPaths',
+    'mergedDuplicateFacetId',
+    'mergedDuplicateSlug',
+    'mergedIntoFacetId',
+    'canonicalFacetId',
+    'duplicateFacetId',
+    'canonicalSlug',
+    'duplicateSlug',
+  ]) {
+    delete cleaned[key]
+  }
+  return cleaned
+}
+
+async function installAlias(
+  prisma: Db,
+  facetId: number,
+  aliasValue: string | null | undefined,
+): Promise<void> {
+  const alias = String(aliasValue || '').trim()
+  const lookupKey = normalizeFacetLookupKey(alias)
+  if (!alias || !lookupKey || !APPLY) return
+
+  const conflict = await prisma.facetAlias.findUnique({ where: { lookupKey } })
+  if (conflict && conflict.facetId !== facetId) {
+    await prisma.facetAlias.delete({ where: { lookupKey } })
+  }
+
+  await prisma.facetAlias.upsert({
+    where: { lookupKey },
+    create: {
+      facetId,
+      alias,
+      lookupKey,
+      isCanonical: false,
+      isActive: true,
+    },
+    update: {
+      facetId,
+      alias,
+      isCanonical: false,
+      isActive: true,
+    },
+  })
+}
+
+async function findCanonicalFacet(
+  prisma: Db,
+  duplicate: NonNullable<FacetRecord>,
+): Promise<NonNullable<FacetRecord> | null> {
+  const profile = await prisma.facetProfile.findUnique({
+    where: { facetId: duplicate.id },
+  })
+  const metadata = parseMetadata(profile?.metadata)
+  const canonicalId =
+    positiveInteger(metadata.mergedIntoFacetId) ??
+    positiveInteger(metadata.canonicalFacetId)
+
+  if (canonicalId && canonicalId !== duplicate.id) {
+    const byId = await prisma.facet.findUnique({ where: { id: canonicalId } })
+    if (byId) return byId
+  }
+
+  const canonicalSlug = String(metadata.canonicalSlug || '').trim()
+  if (canonicalSlug) {
+    const bySlug = await prisma.facet.findUnique({ where: { slug: canonicalSlug } })
+    if (bySlug && bySlug.id !== duplicate.id) return bySlug
+  }
+
+  return null
+}
+
+function replaceFacetJobPayload(
+  rawPayload: string,
+  duplicate: NonNullable<FacetRecord>,
+  canonical: NonNullable<FacetRecord>,
+): string | null {
+  const payload = parseArtJobPayload(rawPayload)
+  let changed = false
+
+  const entityArt = asObject(payload.entityArt)
+  if (
+    entityArt.entityType === 'facet' &&
+    Number(entityArt.entityId) === duplicate.id
+  ) {
+    payload.entityArt = { ...entityArt, entityId: canonical.id }
+    changed = true
+  }
+
+  if (Array.isArray(payload.facets)) {
+    payload.facets = payload.facets.map((entry) => {
+      const facet = asObject(entry)
+      if (Number(facet.id) !== duplicate.id) return entry
+      changed = true
+      return {
+        ...facet,
+        id: canonical.id,
+        title: canonical.title,
+        slug: canonical.slug,
+        artPrompt: canonical.artPrompt,
+        imagePath: canonical.imagePath,
+        cardPath: canonical.cardPath,
+        heroPath: canonical.heroPath,
+      }
+    })
+  }
+
+  const provenance = asObject(payload.provenance)
+  if (typeof provenance.idempotencyKey === 'string') {
+    const updated = provenance.idempotencyKey.replace(
+      `facet:${duplicate.id}:`,
+      `facet:${canonical.id}:`,
+    )
+    if (updated !== provenance.idempotencyKey) {
+      payload.provenance = { ...provenance, idempotencyKey: updated }
+      changed = true
+    }
+  }
+
+  return changed ? serializeArtJobPayload(payload) : null
+}
+
+async function migrateArtJobs(
+  prisma: Db,
+  duplicate: NonNullable<FacetRecord>,
+  canonical: NonNullable<FacetRecord>,
+): Promise<number> {
+  const jobs = await prisma.artJob.findMany({
+    where: {
+      payload: {
+        contains: `\"entityType\":\"facet\",\"entityId\":${duplicate.id},`,
+      },
+    },
+    select: { id: true, payload: true },
+  })
+
+  let updated = 0
+  for (const job of jobs) {
+    const payload = replaceFacetJobPayload(job.payload, duplicate, canonical)
+    if (!payload) continue
+    if (APPLY) {
+      await prisma.artJob.update({ where: { id: job.id }, data: { payload } })
+    }
+    updated += 1
+  }
+  return updated
+}
+
+async function migrateMergedShell(
+  prisma: Db,
+  duplicate: NonNullable<FacetRecord>,
+  canonical: NonNullable<FacetRecord>,
+): Promise<CleanupResult> {
+  const [
+    canonicalProfile,
+    duplicateProfile,
+    aliases,
+    characterLinks,
+    botLinks,
+    rewardLinks,
+    dreamLinks,
+    scenarioLinks,
+    artImageLinks,
+    artCollectionLinks,
+    relations,
+    artJobs,
+  ] = await Promise.all([
+    prisma.facetProfile.findUnique({ where: { facetId: canonical.id } }),
+    prisma.facetProfile.findUnique({ where: { facetId: duplicate.id } }),
+    prisma.facetAlias.findMany({ where: { facetId: duplicate.id } }),
+    prisma.characterFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: {
+        characterId: true,
+        fieldKey: true,
+        sortOrder: true,
+        weight: true,
+        source: true,
+      },
+    }),
+    prisma.botFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: {
+        botId: true,
+        fieldKey: true,
+        sortOrder: true,
+        weight: true,
+        source: true,
+      },
+    }),
+    prisma.rewardFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: {
+        rewardId: true,
+        fieldKey: true,
+        sortOrder: true,
+        weight: true,
+        source: true,
+      },
+    }),
+    prisma.dreamFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: { dreamId: true },
+    }),
+    prisma.scenarioFacet.findMany({
+      where: { facetId: duplicate.id },
+      select: { scenarioId: true },
+    }),
+    prisma.facetArtImage.findMany({
+      where: { facetId: duplicate.id },
+      select: { artImageId: true },
+    }),
+    prisma.facetArtCollection.findMany({
+      where: { facetId: duplicate.id },
+      select: { artCollectionId: true },
+    }),
+    prisma.facetRelation.findMany({
+      where: {
+        OR: [{ fromFacetId: duplicate.id }, { toFacetId: duplicate.id }],
+      },
+      select: {
+        fromFacetId: true,
+        toFacetId: true,
+        relationType: true,
+        note: true,
+      },
+    }),
+    migrateArtJobs(prisma, duplicate, canonical),
+  ])
+
+  if (APPLY) {
+    if (characterLinks.length) {
+      await prisma.characterFacet.createMany({
+        data: characterLinks.map((link) => ({ ...link, facetId: canonical.id })),
+        skipDuplicates: true,
+      })
+    }
+    if (botLinks.length) {
+      await prisma.botFacet.createMany({
+        data: botLinks.map((link) => ({ ...link, facetId: canonical.id })),
+        skipDuplicates: true,
+      })
+    }
+    if (rewardLinks.length) {
+      await prisma.rewardFacet.createMany({
+        data: rewardLinks.map((link) => ({ ...link, facetId: canonical.id })),
+        skipDuplicates: true,
+      })
+    }
+    if (dreamLinks.length) {
+      await prisma.dreamFacet.createMany({
+        data: dreamLinks.map((link) => ({ ...link, facetId: canonical.id })),
+        skipDuplicates: true,
+      })
+    }
+    if (scenarioLinks.length) {
+      await prisma.scenarioFacet.createMany({
+        data: scenarioLinks.map((link) => ({ ...link, facetId: canonical.id })),
+        skipDuplicates: true,
+      })
+    }
+
+    const artImageIds = new Set([
+      ...artImageLinks.map((link) => link.artImageId),
+      ...(duplicate.artImageId ? [duplicate.artImageId] : []),
+    ])
+    if (artImageIds.size) {
+      await prisma.facetArtImage.createMany({
+        data: [...artImageIds].map((artImageId) => ({
+          facetId: canonical.id,
+          artImageId,
+        })),
+        skipDuplicates: true,
+      })
+    }
+
+    const artCollectionIds = new Set([
+      ...artCollectionLinks.map((link) => link.artCollectionId),
+      ...(duplicate.artCollectionId ? [duplicate.artCollectionId] : []),
+    ])
+    if (artCollectionIds.size) {
+      await prisma.facetArtCollection.createMany({
+        data: [...artCollectionIds].map((artCollectionId) => ({
+          facetId: canonical.id,
+          artCollectionId,
+        })),
+        skipDuplicates: true,
+      })
+    }
+
+    const mappedRelations = relations
+      .map((relation) => ({
+        ...relation,
+        fromFacetId:
+          relation.fromFacetId === duplicate.id
+            ? canonical.id
+            : relation.fromFacetId,
+        toFacetId:
+          relation.toFacetId === duplicate.id
+            ? canonical.id
+            : relation.toFacetId,
+      }))
+      .filter((relation) => relation.fromFacetId !== relation.toFacetId)
+    if (mappedRelations.length) {
+      await prisma.facetRelation.createMany({
+        data: mappedRelations,
+        skipDuplicates: true,
+      })
+    }
+
+    await prisma.reaction.updateMany({
+      where: { facetId: duplicate.id },
+      data: { facetId: canonical.id },
+    })
+
+    await prisma.facet.update({
+      where: { id: canonical.id },
+      data: {
+        description: canonical.description || duplicate.description,
+        flavorText: canonical.flavorText || duplicate.flavorText,
+        examples: canonical.examples || duplicate.examples,
+        artPrompt: canonical.artPrompt || duplicate.artPrompt,
+        imagePath: canonical.imagePath || duplicate.imagePath,
+        cardPath: canonical.cardPath || duplicate.cardPath,
+        heroPath: canonical.heroPath || duplicate.heroPath,
+        icon: canonical.icon || duplicate.icon,
+        artImageId: canonical.artImageId ?? duplicate.artImageId,
+        artCollectionId:
+          canonical.artCollectionId ?? duplicate.artCollectionId,
+        isActive: true,
+      },
+    })
+
+    const canonicalMetadata = stripRetiredMergeMetadata(
+      parseMetadata(canonicalProfile?.metadata),
+    )
+    const duplicateMetadata = stripRetiredMergeMetadata(
+      parseMetadata(duplicateProfile?.metadata),
+    )
+    if (canonicalProfile || duplicateProfile) {
+      await prisma.facetProfile.upsert({
+        where: { facetId: canonical.id },
+        create: {
+          facetId: canonical.id,
+          taxonomy: canonicalProfile?.taxonomy ?? duplicateProfile?.taxonomy ?? 'OTHER',
+          canonicalValue:
+            canonicalProfile?.canonicalValue ??
+            duplicateProfile?.canonicalValue ??
+            canonical.title,
+          groupKey: canonicalProfile?.groupKey ?? duplicateProfile?.groupKey,
+          groupLabel: canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel,
+          sortOrder: canonicalProfile?.sortOrder ?? duplicateProfile?.sortOrder ?? 0,
+          isRandomizable:
+            canonicalProfile?.isRandomizable ??
+            duplicateProfile?.isRandomizable ??
+            true,
+          randomWeight: Math.max(
+            canonicalProfile?.randomWeight ?? 0,
+            duplicateProfile?.randomWeight ?? 0,
+          ),
+          artRequired:
+            canonicalProfile?.artRequired ?? duplicateProfile?.artRequired ?? true,
+          sourceRank: Math.min(
+            canonicalProfile?.sourceRank ?? 100,
+            duplicateProfile?.sourceRank ?? 100,
+          ),
+          metadata: JSON.stringify({
+            ...duplicateMetadata,
+            ...canonicalMetadata,
+            catalogCleanup: { batchId: BATCH_ID, action: 'merged-shell-removed' },
+          }),
+        },
+        update: {
+          metadata: JSON.stringify({
+            ...duplicateMetadata,
+            ...canonicalMetadata,
+            catalogCleanup: { batchId: BATCH_ID, action: 'merged-shell-removed' },
+          }),
+        },
+      })
+    }
+
+    await Promise.all([
+      prisma.characterFacet.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.botFacet.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.rewardFacet.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.dreamFacet.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.scenarioFacet.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.facetArtImage.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.facetArtCollection.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.facetRelation.deleteMany({
+        where: {
+          OR: [{ fromFacetId: duplicate.id }, { toFacetId: duplicate.id }],
+        },
+      }),
+      prisma.facetAlias.deleteMany({ where: { facetId: duplicate.id } }),
+      prisma.facetProfile.deleteMany({ where: { facetId: duplicate.id } }),
+    ])
+    await prisma.facet.delete({ where: { id: duplicate.id } })
+
+    for (const alias of new Set([
+      duplicate.title,
+      duplicate.slug || '',
+      ...aliases.map((entry) => entry.alias),
+    ])) {
+      await installAlias(prisma, canonical.id, alias)
+    }
+  }
+
+  return {
+    id: duplicate.id,
+    title: duplicate.title,
+    canonicalId: canonical.id,
+    canonicalTitle: canonical.title,
+    artImageLinks: artImageLinks.length + (duplicate.artImageId ? 1 : 0),
+    artCollectionLinks:
+      artCollectionLinks.length + (duplicate.artCollectionId ? 1 : 0),
+    artJobs,
+    action: APPLY ? 'migrated-and-deleted' : 'would-migrate-and-delete',
+  }
+}
+
+async function deleteFacetCompletely(
+  prisma: Db,
+  facet: NonNullable<FacetRecord>,
+): Promise<void> {
+  if (!APPLY) return
+  await Promise.all([
+    prisma.characterFacet.deleteMany({ where: { facetId: facet.id } }),
+    prisma.botFacet.deleteMany({ where: { facetId: facet.id } }),
+    prisma.rewardFacet.deleteMany({ where: { facetId: facet.id } }),
+    prisma.dreamFacet.deleteMany({ where: { facetId: facet.id } }),
+    prisma.scenarioFacet.deleteMany({ where: { facetId: facet.id } }),
+    prisma.facetArtImage.deleteMany({ where: { facetId: facet.id } }),
+    prisma.facetArtCollection.deleteMany({ where: { facetId: facet.id } }),
+    prisma.facetRelation.deleteMany({
+      where: { OR: [{ fromFacetId: facet.id }, { toFacetId: facet.id }] },
+    }),
+    prisma.facetAlias.deleteMany({ where: { facetId: facet.id } }),
+    prisma.facetProfile.deleteMany({ where: { facetId: facet.id } }),
+    prisma.reaction.deleteMany({ where: { facetId: facet.id } }),
+  ])
+  await prisma.facet.delete({ where: { id: facet.id } })
+}
+
+async function stripHistoricalMetadata(prisma: Db): Promise<number> {
+  const profiles = await prisma.facetProfile.findMany({
+    where: {
+      OR: [
+        { metadata: { contains: 'mergedFacetSources' } },
+        { metadata: { contains: 'mergedArtworkPaths' } },
+        { metadata: { contains: 'mergedDuplicateFacetId' } },
+        { metadata: { contains: 'mergedIntoFacetId' } },
+      ],
+    },
+    select: { facetId: true, metadata: true },
+  })
+
+  let changed = 0
+  for (const profile of profiles) {
+    const original = parseMetadata(profile.metadata)
+    const cleaned = stripRetiredMergeMetadata(original)
+    if (JSON.stringify(original) === JSON.stringify(cleaned)) continue
+    if (APPLY) {
+      await prisma.facetProfile.update({
+        where: { facetId: profile.facetId },
+        data: { metadata: JSON.stringify(cleaned) },
+      })
+    }
+    changed += 1
+  }
+  return changed
+}
+
+async function main(): Promise<void> {
+  await withDatabaseRetry('retired Facet cleanup', async () => {
+    const prisma = createScriptPrismaClient()
+    try {
+      const mergedShells = await prisma.facet.findMany({
+        where: {
+          OR: [
+            { designer: 'facet-catalog-merged' },
+            { slug: { contains: '-merged-' } },
+          ],
+        },
+        orderBy: { id: 'asc' },
+      })
+
+      const merged: CleanupResult[] = []
+      for (const shell of mergedShells) {
+        if (!shell.slug || !MERGED_SLUG_PATTERN.test(shell.slug)) {
+          // The designer marker is authoritative even if a legacy script used a
+          // different slug suffix. Canonical metadata must still resolve it.
+        }
+        const canonical = await findCanonicalFacet(prisma, shell)
+        if (!canonical) {
+          throw new Error(
+            `Retired merged Facet ${shell.id} (${shell.title}) has no canonical target.`,
+          )
+        }
+        merged.push(await migrateMergedShell(prisma, shell, canonical))
+      }
+
+      const recipeProfiles = await prisma.facetProfile.findMany({
+        where: { groupKey: 'genre-recipe' },
+        select: { facetId: true },
+      })
+      const recipes: CleanupResult[] = []
+      for (const profile of recipeProfiles) {
+        const facet = await prisma.facet.findUnique({
+          where: { id: profile.facetId },
+        })
+        if (!facet) continue
+        if (APPLY) await deleteFacetCompletely(prisma, facet)
+        recipes.push({
+          id: facet.id,
+          title: facet.title,
+          action: APPLY ? 'deleted-recipe-shell' : 'would-delete-recipe-shell',
+        })
+      }
+
+      const metadataCleaned = await stripHistoricalMetadata(prisma)
+      const [remainingMergedShells, remainingRecipeProfiles] = await Promise.all([
+        prisma.facet.count({
+          where: {
+            OR: [
+              { designer: 'facet-catalog-merged' },
+              { slug: { contains: '-merged-' } },
+            ],
+          },
+        }),
+        prisma.facetProfile.count({ where: { groupKey: 'genre-recipe' } }),
+      ])
+
+      const report = {
+        mode: APPLY ? 'apply' : 'dry-run',
+        batchId: BATCH_ID,
+        merged,
+        recipes,
+        metadataCleaned,
+        remainingMergedShells,
+        remainingRecipeProfiles,
+        policy:
+          'Retired Facet shells are migration scaffolding, not historical records. Migrate live data, then physically delete them.',
+      }
+      console.log(JSON.stringify(report, null, 2))
+
+      if (APPLY && (remainingMergedShells || remainingRecipeProfiles)) {
+        throw new Error(
+          `Facet cleanup incomplete: ${remainingMergedShells} merged shell(s), ${remainingRecipeProfiles} recipe shell(s).`,
+        )
+      }
+    } finally {
+      await prisma.$disconnect()
+    }
+  })
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -1,0 +1,106 @@
+// /utils/scripts/verifyFacetCatalogMaintenance.ts
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const cleanupPath = path.join(
+  root,
+  'utils/scripts/cleanupRetiredFacetShells.ts',
+)
+const artPath = path.join(root, 'scripts/generate_facet_art.ts')
+const buildPath = path.join(root, 'scripts/vercel-build.mjs')
+
+const cleanup = fs.readFileSync(cleanupPath, 'utf8')
+const art = fs.readFileSync(artPath, 'utf8')
+const build = fs.readFileSync(buildPath, 'utf8')
+
+for (const required of [
+  "designer: 'facet-catalog-merged'",
+  "groupKey: 'genre-recipe'",
+  'mergedIntoFacetId',
+  'canonicalFacetId',
+  'characterFacet.createMany',
+  'botFacet.createMany',
+  'rewardFacet.createMany',
+  'dreamFacet.createMany',
+  'scenarioFacet.createMany',
+  'facetArtImage.createMany',
+  'facetArtCollection.createMany',
+  'facetRelation.createMany',
+  'reaction.updateMany',
+  'migrateArtJobs',
+  "action: 'migrated-and-deleted'",
+  'await prisma.facet.delete',
+  'remainingMergedShells',
+  'remainingRecipeProfiles',
+  'stripRetiredMergeMetadata',
+]) {
+  assert.ok(cleanup.includes(required), `Missing cleanup contract: ${required}`)
+}
+
+assert.ok(
+  cleanup.includes('Retired Facet shells are migration scaffolding, not historical records.'),
+  'Cleanup policy must reject inactive merge shells as stored history.',
+)
+assert.ok(
+  !cleanup.includes('preservedForArt'),
+  'Artwork must be migrated to the canonical Facet, not used to preserve a retired shell.',
+)
+
+for (const required of [
+  'auditFacetCatalog',
+  'BLOCKING_REASON_CODES',
+  "'duplicate-title'",
+  "'composite-genre'",
+  "'unreviewed-legacy-record'",
+  'profile.artRequired',
+  'primaryArtBacked',
+  "const PRIMARY_FIELD = 'imagePath'",
+  "const PROJECT_SLUG = 'facet-catalog'",
+  "const FACET_ART_VERSION = 'facet-primary-krea2-v1'",
+  'buildKrea2WorkflowFromRequest',
+  "entityType: 'facet'",
+  'field: PRIMARY_FIELD',
+  'requireCompletionProof: true',
+  'facets: [facetSnapshot',
+  'priorityFor',
+  'artPrompt: entry.identityPrompt',
+]) {
+  assert.ok(art.includes(required), `Missing Facet art contract: ${required}`)
+}
+
+assert.ok(
+  art.includes('Card, hero, and icon variants wait for the multi-art schema.'),
+  'Current queue must remain primary-image-only until the multi-art schema lands.',
+)
+assert.ok(
+  art.includes('status: { in: [\'PENDING\', \'RUNNING\'] }'),
+  'Current-version queued or running jobs must be reused.',
+)
+
+const directivesHook =
+  "['utils/scripts/applyFacetCatalogDirectives.ts', '--apply']"
+const cleanupHook =
+  "['utils/scripts/cleanupRetiredFacetShells.ts', '--apply']"
+const auditHook = "['utils/scripts/auditFacetCatalogOddities.ts', '--top=60']"
+const artHook = "['scripts/generate_facet_art.ts', '--write']"
+
+for (const hook of [directivesHook, cleanupHook, auditHook, artHook]) {
+  assert.ok(build.includes(hook), `Production build is missing ${hook}.`)
+}
+
+assert.ok(
+  build.indexOf(directivesHook) < build.indexOf(cleanupHook),
+  'Final curation directives must run before retired shell cleanup.',
+)
+assert.ok(
+  build.indexOf(cleanupHook) < build.indexOf(auditHook),
+  'Retired shell cleanup must finish before the whole-catalog audit.',
+)
+assert.ok(
+  build.indexOf(auditHook) < build.indexOf(artHook),
+  'The whole-catalog audit must run before Facet artwork is queued.',
+)
+
+console.log('Facet catalog maintenance and artwork queue contract verified.')

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -30,7 +30,7 @@ for (const required of [
   'facetRelation.createMany',
   'reaction.updateMany',
   'migrateArtJobs',
-  "action: 'migrated-and-deleted'",
+  "'migrated-and-deleted'",
   'await prisma.facet.delete',
   'remainingMergedShells',
   'remainingRecipeProfiles',
@@ -75,7 +75,7 @@ assert.ok(
   'Current queue must remain primary-image-only until the multi-art schema lands.',
 )
 assert.ok(
-  art.includes('status: { in: [\'PENDING\', \'RUNNING\'] }'),
+  art.includes("status: { in: ['PENDING', 'RUNNING'] }"),
   'Current-version queued or running jobs must be reused.',
 )
 


### PR DESCRIPTION
## What changed

- Added a final retired-Facet cleanup pass that migrates assignments, aliases, reactions, relations, artwork links, primary art fields, and queued entity-art jobs to the canonical Facet before physically deleting merge shells.
- Deletes transient `genre-recipe` rows instead of retaining them as historical records.
- Removes obsolete merge-history metadata from active Facet profiles.
- Added a complete active-catalog art sweep. It reruns the Facet audit, blocks structurally questionable entries, creates a durable art prompt when needed, and queues one deduplicated low-priority Krea 2 primary-image job for each clean art-required Facet without primary artwork.
- Explicitly limits this pass to `imagePath`; card, hero, and icon variants wait for the multi-art schema.
- Added contract verification and production build hooks in the required order: curation, shell cleanup, full audit, artwork queue.

## Why

Retired duplicate rows were still being kept when they contained artwork, even though the live concept had already moved to a canonical Facet. The catalog should converge to canonical rows rather than storing inactive migration scaffolding. Separately, valid Facets without artwork should enter the existing ArtJob pipeline, while odd or under-reviewed records should remain blocked for curation.

## Validation

- Facet Catalog Contract now verifies the cleanup and artwork-queue contracts.
- Production execution is idempotent through current-version ArtJob reuse and canonical-target cleanup assertions.
- The cleanup build step fails if merged shells or genre-recipe profiles remain.
