### PR TITLE
make scenario facet seeding safe across overlapping deploys

### DIFF
--- a/utils/scripts/seedScenarioGenreFacetCatalog.ts
+++ b/utils/scripts/seedScenarioGenreFacetCatalog.ts
@@ -205,8 +205,12 @@ async function saveCandidate(
           isActive: true,
         },
       })
-    : await prisma.facet.create({
-        data: {
+    : await prisma.facet.upsert({
+        // Production deployments can overlap. The catalog snapshot above may
+        // legitimately become stale before this write, so create-by-slug must
+        // be atomic rather than a read followed by an unguarded insert.
+        where: { slug },
+        create: {
           title: candidate.title,
           slug,
           kind: 'GENRE',
@@ -217,6 +221,14 @@ async function saveCandidate(
           userId: 1,
           isPublic: true,
           isMature: false,
+          isActive: true,
+        },
+        update: {
+          title: candidate.title,
+          kind: 'GENRE',
+          description: candidate.description,
+          imagePath: candidate.imagePath,
+          designer: 'facet-catalog',
           isActive: true,
         },
       })


### PR DESCRIPTION
## Fix

The production deployment for #1254 overlapped the preceding main deployment. Both loaded the same Scenario Genre Facet snapshot, then one inserted a slug before the other reached its create call. The second build failed with Prisma P2002 on `Facet_slug_key`.

Replace the stale-snapshot `facet.create()` path with an atomic slug `upsert()`. Concurrent seeders now converge on the same canonical row, after which the existing profile, alias, and ScenarioFacet upserts remain idempotent.

## Production evidence

Deployment `dpl_ADhHp3swG6QrHXJtSD3c8uV4ZwJZ` failed at `seedScenarioGenreFacetCatalog.ts:208` with `Unique constraint failed on Facet_slug_key` while deployment `dpl_6h9Mh7iWcFX2pUawQR2hTSYkborR` was running the same catalog seed.
