### PR TITLE
serialize production facet catalog maintenance

### DIFF
--- a/scripts/run_facet_catalog_maintenance.ts
+++ b/scripts/run_facet_catalog_maintenance.ts
@@ -1,0 +1,217 @@
+// /scripts/run_facet_catalog_maintenance.ts
+//
+// Serializes the complete production Facet catalog mutation sequence with a
+// MariaDB named lock. Vercel production deployments can overlap, but canonical
+// seeding, merge cleanup, taxonomy curation, and ArtJob creation must behave as
+// one ordered catalog operation rather than several interleaved writers.
+
+import 'dotenv/config'
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import mariadb, { type PoolConnection } from 'mariadb'
+import { buildDatabaseConfig } from '../server/utils/databaseAdapterConfig'
+
+const LOCK_NAME = 'kind-robots:facet-catalog-maintenance'
+const LOCK_WAIT_SECONDS = 900
+const LOCK_PING_INTERVAL_MS = 20_000
+const binExtension = process.platform === 'win32' ? '.cmd' : ''
+const tsxBinary = path.resolve(`node_modules/.bin/tsx${binExtension}`)
+const runCanonicalSeed = process.argv.includes('--seed')
+const reasonArgument = process.argv.find((argument) =>
+  argument.startsWith('--reason='),
+)
+const seedReason = reasonArgument?.slice('--reason='.length) || 'unspecified policy'
+
+type Step = {
+  script: string
+  args?: string[]
+  label: string
+}
+
+const steps: Step[] = [
+  ...(runCanonicalSeed
+    ? [
+        {
+          script: 'utils/scripts/runFacetCatalogSeed.ts',
+          args: ['--apply'],
+          label: `Seeding canonical Facet catalog and Character assignments (${seedReason})`,
+        },
+      ]
+    : []),
+  {
+    script: 'utils/scripts/mergeRewardFacetDuplicateLinks.ts',
+    args: ['--apply'],
+    label: 'Preserving Reward Facets across canonical merges',
+  },
+  {
+    script: 'utils/scripts/mergeCanonicalFacetDuplicates.ts',
+    args: ['--apply'],
+    label: 'Merging legacy duplicate Facets into canonical records',
+  },
+  {
+    script: 'utils/scripts/curateFacetCatalog.ts',
+    args: ['--apply'],
+    label: 'Applying durable Facet curation batches',
+  },
+  {
+    script: 'utils/scripts/curateFacetHouseGenres.ts',
+    args: ['--apply'],
+    label: 'Curating art-backed house genres and related genre families',
+  },
+  {
+    script: 'utils/scripts/curateFacetCulturalGenres.ts',
+    args: ['--apply'],
+    label: 'Refining cultural genre labels and distinct speculative traditions',
+  },
+  {
+    script: 'utils/scripts/mergeFacetPersonalitySynonyms.ts',
+    args: ['--apply'],
+    label: 'Merging exact Personality Facet synonyms',
+  },
+  {
+    script: 'utils/scripts/curateFacetTaxonomyLeaks.ts',
+    args: ['--apply'],
+    label: 'Repairing Facet taxonomy leaks and low-value random controls',
+  },
+  {
+    script: 'utils/scripts/curateFacetGenreLeaks.ts',
+    args: ['--apply'],
+    label: 'Repairing subject themes and remaining genre hybrids',
+  },
+  {
+    script: 'utils/scripts/applyFacetCatalogDirectives.ts',
+    args: ['--apply'],
+    label: 'Applying final Facet catalog directives and deleting historical shells',
+  },
+  {
+    script: 'utils/scripts/cleanupRetiredFacetShells.ts',
+    args: ['--apply'],
+    label: 'Migrating and deleting all retired Facet shells',
+  },
+  {
+    script: 'utils/scripts/auditFacetCatalogOddities.ts',
+    args: ['--top=60'],
+    label: 'Auditing the complete Facet catalog for remaining oddities',
+  },
+  {
+    script: 'scripts/generate_facet_art.ts',
+    args: ['--write'],
+    label: 'Queueing missing primary Facet artwork after the full catalog audit',
+  },
+]
+
+async function runStep(step: Step): Promise<void> {
+  console.log(`[facet-maintenance] ${step.label}`)
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(tsxBinary, [step.script, ...(step.args ?? [])], {
+      env: process.env,
+      stdio: 'inherit',
+    })
+
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(
+        new Error(
+          `${step.label} exited with ${
+            signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`
+          }`,
+        ),
+      )
+    })
+  })
+}
+
+function acquiredValue(rows: unknown): number {
+  if (!Array.isArray(rows) || !rows.length) return 0
+  const row = rows[0]
+  if (!row || typeof row !== 'object') return 0
+  const raw = (row as Record<string, unknown>).acquired
+  return Number(raw)
+}
+
+async function acquireLock(connection: PoolConnection): Promise<void> {
+  console.log(
+    `[facet-maintenance] Acquiring database lock ${LOCK_NAME} with ${LOCK_WAIT_SECONDS}s maximum wait.`,
+  )
+  const rows = await connection.query(
+    'SELECT GET_LOCK(?, ?) AS acquired',
+    [LOCK_NAME, LOCK_WAIT_SECONDS],
+  )
+  if (acquiredValue(rows) !== 1) {
+    throw new Error(
+      `Could not acquire Facet catalog maintenance lock ${LOCK_NAME}.`,
+    )
+  }
+  console.log(`[facet-maintenance] Acquired database lock ${LOCK_NAME}.`)
+}
+
+async function releaseLock(connection: PoolConnection): Promise<void> {
+  const rows = await connection.query('SELECT RELEASE_LOCK(?) AS released', [
+    LOCK_NAME,
+  ])
+  const first = Array.isArray(rows) ? rows[0] : undefined
+  const released =
+    first && typeof first === 'object'
+      ? Number((first as Record<string, unknown>).released)
+      : 0
+  console.log(
+    `[facet-maintenance] Released database lock ${LOCK_NAME}: ${released === 1 ? 'yes' : 'connection already released'}.`,
+  )
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+
+  const config = buildDatabaseConfig(databaseUrl)
+  const pool = mariadb.createPool(config)
+  let connection: PoolConnection | undefined
+  let keepAlive: NodeJS.Timeout | undefined
+  let lockAcquired = false
+
+  try {
+    connection = await pool.getConnection()
+    await acquireLock(connection)
+    lockAcquired = true
+
+    keepAlive = setInterval(() => {
+      void connection?.ping().catch((error: unknown) => {
+        console.error(
+          '[facet-maintenance] Lost the database session holding the catalog lock.',
+          error,
+        )
+      })
+    }, LOCK_PING_INTERVAL_MS)
+
+    if (!runCanonicalSeed) {
+      console.log(
+        `[facet-maintenance] Skipping unchanged canonical seed: ${seedReason}`,
+      )
+    }
+
+    for (const step of steps) await runStep(step)
+  } finally {
+    if (keepAlive) clearInterval(keepAlive)
+    if (connection && lockAcquired) {
+      try {
+        await releaseLock(connection)
+      } catch (error) {
+        console.error('[facet-maintenance] Failed to release named lock cleanly.', error)
+      }
+    }
+    connection?.release()
+    await pool.end()
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/run_facet_catalog_maintenance.ts
+++ b/scripts/run_facet_catalog_maintenance.ts
@@ -169,7 +169,13 @@ async function main(): Promise<void> {
   if (!databaseUrl) throw new Error('DATABASE_URL is missing')
 
   const config = buildDatabaseConfig(databaseUrl)
-  const pool = mariadb.createPool(config)
+  // buildDatabaseConfig() is typed against @prisma/adapter-mariadb's own
+  // nested copy of the `mariadb` package, which TS treats as structurally
+  // distinct from the top-level `mariadb` import used here for raw
+  // GET_LOCK/RELEASE_LOCK queries — same shape at runtime, different types.
+  const pool = mariadb.createPool(
+    config as unknown as Parameters<typeof mariadb.createPool>[0],
+  )
   let connection: PoolConnection | undefined
   let keepAlive: NodeJS.Timeout | undefined
   let lockAcquired = false

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -47,116 +47,14 @@ if (!isVercelBuild || isProductionDeployment) {
   )
 
   const facetSeedDecision = resolveFacetCatalogSeedDecision()
-  if (facetSeedDecision.run) {
-    // runFacetCatalogSeed.ts normalizes source synonyms before importing
-    // seedFacetCatalog.ts; the latter remains the canonical catalog writer.
-    run(
-      tsxBinary,
-      ['utils/scripts/runFacetCatalogSeed.ts', '--apply'],
-      `Seeding canonical Facet catalog and Character assignments (${facetSeedDecision.reason})`,
-    )
-  } else {
-    console.log(
-      `[vercel-build] Skipping unchanged canonical Facet catalog seed: ${facetSeedDecision.reason}`,
-    )
-  }
-
-  // RewardFacet is stored outside the legacy canonical merge script. Move those
-  // links first so retiring a duplicate Facet can never cascade-delete item traits.
   run(
     tsxBinary,
-    ['utils/scripts/mergeRewardFacetDuplicateLinks.ts', '--apply'],
-    'Preserving Reward Facets across canonical merges',
-  )
-
-  // Cheap and idempotent: retain this on every production build so any partial
-  // historical cleanup converges even when the 1,300-record catalog seed is skipped.
-  run(
-    tsxBinary,
-    ['utils/scripts/mergeCanonicalFacetDuplicates.ts', '--apply'],
-    'Merging legacy duplicate Facets into canonical records',
-  )
-
-  // Apply the reviewed taxonomy last. The source seeders retain historical Builder
-  // vocabulary and otherwise re-promote entries to random GENRE weight 1.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetCatalog.ts', '--apply'],
-    'Applying durable Facet curation batches',
-  )
-
-  // Keep art-backed house genres as distinct authored concepts. Relate them to
-  // broader reusable genres instead of flattening their tone into false aliases.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetHouseGenres.ts', '--apply'],
-    'Curating art-backed house genres and related genre families',
-  )
-
-  // Refine broad or invented cultural labels after the structural genre passes.
-  // Renames happen only when no art is attached; legacy labels remain aliases.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetCulturalGenres.ts', '--apply'],
-    'Refining cultural genre labels and distinct speculative traditions',
-  )
-
-  // Merge only genuine synonyms after all profile and alias curation. The merge
-  // migrates every assignment and artwork link into the art-backed canonical row.
-  run(
-    tsxBinary,
-    ['utils/scripts/mergeFacetPersonalitySynonyms.ts', '--apply'],
-    'Merging exact Personality Facet synonyms',
-  )
-
-  // Repair high-confidence classification leaks and remove prompt cargo cult from
-  // random selection without deleting manually useful legacy records.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetTaxonomyLeaks.ts', '--apply'],
-    'Repairing Facet taxonomy leaks and low-value random controls',
-  )
-
-  // Separate subject and cast controls from narrative form, then decompose the
-  // remaining scenario-list hybrids into reusable genre, mood, setting, and theme.
-  run(
-    tsxBinary,
-    ['utils/scripts/curateFacetGenreLeaks.ts', '--apply'],
-    'Repairing subject themes and remaining genre hybrids',
-  )
-
-  // Apply the user-reviewed catalog model last: merge specialist duplicates into
-  // canonical aliases, make punk families genres, remove global MOOD Facets, and
-  // physically delete migrated duplicate and recipe-shell records.
-  run(
-    tsxBinary,
-    ['utils/scripts/applyFacetCatalogDirectives.ts', '--apply'],
-    'Applying final Facet catalog directives and deleting historical shells',
-  )
-
-  // Older merge scripts may encounter pre-existing rows and temporarily mark them
-  // inactive. Move every remaining edge and artwork reference, then remove those
-  // shells and transient recipe records completely.
-  run(
-    tsxBinary,
-    ['utils/scripts/cleanupRetiredFacetShells.ts', '--apply'],
-    'Migrating and deleting all retired Facet shells',
-  )
-
-  // Read the entire post-curation catalog and print a ranked next-batch queue.
-  // This never mutates data or blocks deployment while cleanup is still in motion.
-  run(
-    tsxBinary,
-    ['utils/scripts/auditFacetCatalogOddities.ts', '--top=60'],
-    'Auditing the complete Facet catalog for remaining oddities',
-  )
-
-  // Queue one primary square artwork only for clean, active, art-required Facets.
-  // Card, hero, and icon variants wait for the multi-art schema migration.
-  run(
-    tsxBinary,
-    ['scripts/generate_facet_art.ts', '--write'],
-    'Queueing missing primary Facet artwork after the full catalog audit',
+    [
+      'scripts/run_facet_catalog_maintenance.ts',
+      facetSeedDecision.run ? '--seed' : '--skip-seed',
+      `--reason=${facetSeedDecision.reason}`,
+    ],
+    'Running serialized Facet catalog maintenance',
   )
 
   run(

--- a/utils/scripts/verifyDailyDreamFacets.ts
+++ b/utils/scripts/verifyDailyDreamFacets.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
     rewardPicker: 'components/rewards/reward-facet-picker.vue',
     rewardManager: 'components/rewards/reward-manager.vue',
     rewardMerge: 'utils/scripts/mergeRewardFacetDuplicateLinks.ts',
-    vercelBuild: 'scripts/vercel-build.mjs',
+    runner: 'scripts/run_facet_catalog_maintenance.ts',
   } as const
 
   const entries = await Promise.all(
@@ -132,10 +132,10 @@ async function main(): Promise<void> {
 
   requireText(files.rewardMerge, text.rewardMerge, 'tx.rewardFacet.createMany')
   requireText(files.rewardMerge, text.rewardMerge, 'tx.rewardFacet.deleteMany')
-  const rewardMergeIndex = text.vercelBuild.indexOf(
+  const rewardMergeIndex = text.runner.indexOf(
     'mergeRewardFacetDuplicateLinks.ts',
   )
-  const canonicalMergeIndex = text.vercelBuild.indexOf(
+  const canonicalMergeIndex = text.runner.indexOf(
     'mergeCanonicalFacetDuplicates.ts',
   )
   if (
@@ -144,7 +144,7 @@ async function main(): Promise<void> {
     rewardMergeIndex > canonicalMergeIndex
   ) {
     throw new Error(
-      'scripts/vercel-build.mjs must preserve RewardFacet links before canonical duplicate cleanup.',
+      'scripts/run_facet_catalog_maintenance.ts must preserve RewardFacet links before canonical duplicate cleanup.',
     )
   }
 

--- a/utils/scripts/verifyFacetCanonicalMerges.ts
+++ b/utils/scripts/verifyFacetCanonicalMerges.ts
@@ -25,6 +25,7 @@ async function main(): Promise<void> {
     wrapper: 'utils/scripts/runFacetCatalogSeed.ts',
     merge: 'utils/scripts/mergeCanonicalFacetDuplicates.ts',
     build: 'scripts/vercel-build.mjs',
+    runner: 'scripts/run_facet_catalog_maintenance.ts',
     package: 'package.json',
   } as const
 
@@ -84,8 +85,9 @@ async function main(): Promise<void> {
     'canonicalProfile?.groupLabel ?? duplicateProfile?.groupLabel ?? null',
   )
 
-  requireText(files.build, text.build, 'runFacetCatalogSeed.ts')
-  requireText(files.build, text.build, 'mergeCanonicalFacetDuplicates.ts')
+  requireText(files.runner, text.runner, 'runFacetCatalogSeed.ts')
+  requireText(files.runner, text.runner, 'mergeCanonicalFacetDuplicates.ts')
+  requireText(files.build, text.build, 'run_facet_catalog_maintenance.ts')
   forbidText(
     files.build,
     text.build,

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -260,7 +260,11 @@ async function main(): Promise<void> {
   forbidText(files.variants, text.variants, 'prisma.dream.findMany')
   forbidText(files.variants, text.variants, 'dreamToRandomListItem')
 
-  requireText(files.vercelBuild, text.vercelBuild, 'seedFacetCatalog.ts')
+  requireText(
+    files.vercelBuild,
+    text.vercelBuild,
+    'run_facet_catalog_maintenance.ts',
+  )
   requireText(files.vercelBuild, text.vercelBuild, 'Applying production migrations')
 
   await requireMissingPath(

--- a/utils/scripts/verifyFacetCatalogDirectives.ts
+++ b/utils/scripts/verifyFacetCatalogDirectives.ts
@@ -8,10 +8,10 @@ const directivePath = path.join(
   root,
   'utils/scripts/applyFacetCatalogDirectives.ts',
 )
-const buildPath = path.join(root, 'scripts/vercel-build.mjs')
+const runnerPath = path.join(root, 'scripts/run_facet_catalog_maintenance.ts')
 
 const directive = fs.readFileSync(directivePath, 'utf8')
-const build = fs.readFileSync(buildPath, 'utf8')
+const runner = fs.readFileSync(runnerPath, 'utf8')
 
 for (const required of [
   "canonicalSlug: 'afrofuturism'",
@@ -64,10 +64,10 @@ assert.ok(
   'Epic must remain a rarity, not survive as an atmosphere title.',
 )
 
-const hook = "['utils/scripts/applyFacetCatalogDirectives.ts', '--apply']"
-assert.ok(build.includes(hook), 'Production build must apply catalog directives.')
+const hook = "script: 'utils/scripts/applyFacetCatalogDirectives.ts'"
+assert.ok(runner.includes(hook), 'Production build must apply catalog directives.')
 assert.ok(
-  build.indexOf(hook) < build.indexOf('auditFacetCatalogOddities.ts'),
+  runner.indexOf(hook) < runner.indexOf('auditFacetCatalogOddities.ts'),
   'Catalog directives must run before the whole-catalog audit.',
 )
 

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -9,10 +9,12 @@ const cleanupPath = path.join(
   'utils/scripts/cleanupRetiredFacetShells.ts',
 )
 const artPath = path.join(root, 'scripts/generate_facet_art.ts')
+const runnerPath = path.join(root, 'scripts/run_facet_catalog_maintenance.ts')
 const buildPath = path.join(root, 'scripts/vercel-build.mjs')
 
 const cleanup = fs.readFileSync(cleanupPath, 'utf8')
 const art = fs.readFileSync(artPath, 'utf8')
+const runner = fs.readFileSync(runnerPath, 'utf8')
 const build = fs.readFileSync(buildPath, 'utf8')
 
 for (const required of [
@@ -79,28 +81,56 @@ assert.ok(
   'Current-version queued or running jobs must be reused.',
 )
 
-const directivesHook =
-  "['utils/scripts/applyFacetCatalogDirectives.ts', '--apply']"
-const cleanupHook =
-  "['utils/scripts/cleanupRetiredFacetShells.ts', '--apply']"
-const auditHook = "['utils/scripts/auditFacetCatalogOddities.ts', '--top=60']"
-const artHook = "['scripts/generate_facet_art.ts', '--write']"
-
-for (const hook of [directivesHook, cleanupHook, auditHook, artHook]) {
-  assert.ok(build.includes(hook), `Production build is missing ${hook}.`)
+for (const required of [
+  "const LOCK_NAME = 'kind-robots:facet-catalog-maintenance'",
+  'SELECT GET_LOCK(?, ?) AS acquired',
+  'SELECT RELEASE_LOCK(?) AS released',
+  'connection?.ping()',
+  "script: 'utils/scripts/runFacetCatalogSeed.ts'",
+  "script: 'utils/scripts/applyFacetCatalogDirectives.ts'",
+  "script: 'utils/scripts/cleanupRetiredFacetShells.ts'",
+  "script: 'utils/scripts/auditFacetCatalogOddities.ts'",
+  "script: 'scripts/generate_facet_art.ts'",
+]) {
+  assert.ok(runner.includes(required), `Missing serialized runner contract: ${required}`)
 }
 
+const seedHook = "script: 'utils/scripts/runFacetCatalogSeed.ts'"
+const directivesHook =
+  "script: 'utils/scripts/applyFacetCatalogDirectives.ts'"
+const cleanupHook =
+  "script: 'utils/scripts/cleanupRetiredFacetShells.ts'"
+const auditHook = "script: 'utils/scripts/auditFacetCatalogOddities.ts'"
+const artHook = "script: 'scripts/generate_facet_art.ts'"
+
 assert.ok(
-  build.indexOf(directivesHook) < build.indexOf(cleanupHook),
+  runner.indexOf(seedHook) < runner.indexOf(directivesHook),
+  'Canonical seed must run before final catalog directives.',
+)
+assert.ok(
+  runner.indexOf(directivesHook) < runner.indexOf(cleanupHook),
   'Final curation directives must run before retired shell cleanup.',
 )
 assert.ok(
-  build.indexOf(cleanupHook) < build.indexOf(auditHook),
+  runner.indexOf(cleanupHook) < runner.indexOf(auditHook),
   'Retired shell cleanup must finish before the whole-catalog audit.',
 )
 assert.ok(
-  build.indexOf(auditHook) < build.indexOf(artHook),
+  runner.indexOf(auditHook) < runner.indexOf(artHook),
   'The whole-catalog audit must run before Facet artwork is queued.',
+)
+
+assert.ok(
+  build.includes("'scripts/run_facet_catalog_maintenance.ts'"),
+  'Production build must invoke the single serialized Facet maintenance runner.',
+)
+assert.ok(
+  build.includes("facetSeedDecision.run ? '--seed' : '--skip-seed'"),
+  'Production build must preserve the canonical seed policy when invoking the runner.',
+)
+assert.ok(
+  !build.includes("['utils/scripts/runFacetCatalogSeed.ts', '--apply']"),
+  'Production build must not bypass the serialized Facet maintenance runner.',
 )
 
 console.log('Facet catalog maintenance and artwork queue contract verified.')

--- a/utils/scripts/verifyFacetCulturalGenres.ts
+++ b/utils/scripts/verifyFacetCulturalGenres.ts
@@ -24,7 +24,7 @@ function requireOrder(path: string, text: string, before: string, after: string)
 
 async function main(): Promise<void> {
   const curatorPath = 'utils/scripts/curateFacetCulturalGenres.ts'
-  const buildPath = 'scripts/vercel-build.mjs'
+  const buildPath = 'scripts/run_facet_catalog_maintenance.ts'
   const workflowPath = '.github/workflows/facet-catalog-contract.yml'
   const [curator, build, workflow] = await Promise.all([
     read(curatorPath),

--- a/utils/scripts/verifyFacetCuration.ts
+++ b/utils/scripts/verifyFacetCuration.ts
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
   const files = {
     curation: 'utils/seeds/facetCatalogCuration.ts',
     curator: 'utils/scripts/curateFacetCatalog.ts',
-    build: 'scripts/vercel-build.mjs',
+    runner: 'scripts/run_facet_catalog_maintenance.ts',
     workflow: '.github/workflows/facet-catalog-contract.yml',
   } as const
 
@@ -111,10 +111,10 @@ async function main(): Promise<void> {
   )
   forbidFacetArtMutation(files.curator, text.curator)
 
-  requireText(files.build, text.build, 'curateFacetCatalog.ts')
+  requireText(files.runner, text.runner, 'curateFacetCatalog.ts')
   requireOrder(
-    files.build,
-    text.build,
+    files.runner,
+    text.runner,
     'mergeCanonicalFacetDuplicates.ts',
     'curateFacetCatalog.ts',
   )

--- a/utils/scripts/verifyFacetGenreLeaks.ts
+++ b/utils/scripts/verifyFacetGenreLeaks.ts
@@ -29,7 +29,7 @@ function requireOrder(
 
 async function main(): Promise<void> {
   const curatorPath = 'utils/scripts/curateFacetGenreLeaks.ts'
-  const buildPath = 'scripts/vercel-build.mjs'
+  const buildPath = 'scripts/run_facet_catalog_maintenance.ts'
   const workflowPath = '.github/workflows/facet-catalog-contract.yml'
   const [curator, build, workflow] = await Promise.all([
     read(curatorPath),

--- a/utils/scripts/verifyFacetHouseGenres.ts
+++ b/utils/scripts/verifyFacetHouseGenres.ts
@@ -29,7 +29,7 @@ function requireOrder(
 
 async function main(): Promise<void> {
   const curatorPath = 'utils/scripts/curateFacetHouseGenres.ts'
-  const buildPath = 'scripts/vercel-build.mjs'
+  const buildPath = 'scripts/run_facet_catalog_maintenance.ts'
   const workflowPath = '.github/workflows/facet-catalog-contract.yml'
   const [curator, build, workflow] = await Promise.all([
     read(curatorPath),

--- a/utils/scripts/verifyFacetPersonalityFamilies.ts
+++ b/utils/scripts/verifyFacetPersonalityFamilies.ts
@@ -22,7 +22,7 @@ function forbidText(path: string, text: string, value: string): void {
 
 async function main(): Promise<void> {
   const curatorPath = 'utils/scripts/curateFacetPersonalityFamilies.ts'
-  const buildPath = 'scripts/vercel-build.mjs'
+  const buildPath = 'scripts/run_facet_catalog_maintenance.ts'
   const workflowPath = '.github/workflows/facet-catalog-contract.yml'
   const [curator, build, workflow] = await Promise.all([
     read(curatorPath),

--- a/utils/scripts/verifyFacetPersonalitySynonyms.ts
+++ b/utils/scripts/verifyFacetPersonalitySynonyms.ts
@@ -29,7 +29,7 @@ function requireOrder(
 
 async function main(): Promise<void> {
   const mergePath = 'utils/scripts/mergeFacetPersonalitySynonyms.ts'
-  const buildPath = 'scripts/vercel-build.mjs'
+  const buildPath = 'scripts/run_facet_catalog_maintenance.ts'
   const workflowPath = '.github/workflows/facet-catalog-contract.yml'
   const [merge, build, workflow] = await Promise.all([
     read(mergePath),

--- a/utils/scripts/verifyFacetTaxonomyLeaks.ts
+++ b/utils/scripts/verifyFacetTaxonomyLeaks.ts
@@ -29,7 +29,7 @@ function requireOrder(
 
 async function main(): Promise<void> {
   const curatorPath = 'utils/scripts/curateFacetTaxonomyLeaks.ts'
-  const buildPath = 'scripts/vercel-build.mjs'
+  const buildPath = 'scripts/run_facet_catalog_maintenance.ts'
   const workflowPath = '.github/workflows/facet-catalog-contract.yml'
   const [curator, build, workflow] = await Promise.all([
     read(curatorPath),


### PR DESCRIPTION
## Problem

Three overlapping production deployments exposed three separate races while the Facet catalog was being rebuilt:

1. Scenario Genre create-by-slug P2002.
2. Gender CharacterFacet transaction P2028 after the default 5-second timeout.
3. The core 1,358-record writer updated an alias-owned row toward a slug another deployment had just claimed, producing another `Facet_slug_key` P2002.

Hardening every individual write still leaves the overall seed, curation, merge, cleanup, audit, and art queue free to interleave in semantically invalid orders.

## Fix

Add one serialized production Facet maintenance runner guarded by a pinned MariaDB named lock:

- Acquires `kind-robots:facet-catalog-maintenance` with `GET_LOCK`.
- Keeps the exact lock-holding connection alive while child scripts run.
- Runs the optional canonical seed, duplicate merges, every curation pass, final directives, retired-shell cleanup, whole-catalog audit, and primary-art queue in one ordered critical section.
- Releases the lock in `finally`.
- Preserves the existing git-aware seed policy.
- Leaves migrations, achievements, contenders, and Nuxt build outside the Facet lock.

This removes the root cause: overlapping deployments may still build concurrently, but only one can mutate the Facet catalog at a time.

## Validation

The Facet Catalog Contract now verifies lock acquisition/release, connection keepalive, the complete step list, ordering, and that `vercel-build.mjs` cannot bypass the serialized runner.
