### PR TITLE
Fix production deploys blocked by Facet maintenance lock

### DIFF
--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,7 +1,6 @@
 // /scripts/vercel-build.mjs
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
-import { resolveFacetCatalogSeedDecision } from './lib/facetCatalogSeedPolicy.mjs'
 
 const binExtension = process.platform === 'win32' ? '.cmd' : ''
 const prismaBinary = path.resolve(`node_modules/.bin/prisma${binExtension}`)
@@ -46,15 +45,8 @@ if (!isVercelBuild || isProductionDeployment) {
     'Queueing missing Achievement artwork',
   )
 
-  const facetSeedDecision = resolveFacetCatalogSeedDecision()
-  run(
-    tsxBinary,
-    [
-      'scripts/run_facet_catalog_maintenance.ts',
-      facetSeedDecision.run ? '--seed' : '--skip-seed',
-      `--reason=${facetSeedDecision.reason}`,
-    ],
-    'Running serialized Facet catalog maintenance',
+  console.log(
+    '[vercel-build] Skipping Facet catalog maintenance during deployment; run scripts/run_facet_catalog_maintenance.ts explicitly so a long-lived database mutation session cannot block application delivery.',
   )
 
   run(

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -121,16 +121,16 @@ assert.ok(
 )
 
 assert.ok(
-  build.includes("'scripts/run_facet_catalog_maintenance.ts'"),
-  'Production build must invoke the single serialized Facet maintenance runner.',
+  !build.includes("'scripts/run_facet_catalog_maintenance.ts'"),
+  'Production deployment must not run long-lived Facet catalog mutations.',
 )
 assert.ok(
-  build.includes("facetSeedDecision.run ? '--seed' : '--skip-seed'"),
-  'Production build must preserve the canonical seed policy when invoking the runner.',
+  build.includes('Skipping Facet catalog maintenance during deployment'),
+  'Production build must explain how explicit Facet maintenance is separated from application delivery.',
 )
 assert.ok(
   !build.includes("['utils/scripts/runFacetCatalogSeed.ts', '--apply']"),
-  'Production build must not bypass the serialized Facet maintenance runner.',
+  'Production build must not bypass the explicit Facet maintenance runner.',
 )
 
 console.log('Facet catalog maintenance and artwork queue contract verified.')


### PR DESCRIPTION
## Root cause

PR #1259 held a MariaDB named lock on one ProxySQL session while the complete Facet catalog maintenance pipeline ran in child processes. The production build outlived that database session; ProxySQL closed it despite keepalive pings, the lock vanished, and the deployment failed with `ER_CMD_CONNECTION_CLOSED` before Nuxt could build.

## Fix

- Keep the serialized Facet maintenance runner available for explicit maintenance runs.
- Remove that long-running production mutation pipeline from `vercel-build.mjs`, so application delivery is no longer coupled to a fragile database session.
- Add a contract that forbids reconnecting the runner or raw canonical seed directly to the Vercel build.

This does not delete or weaken the catalog maintenance sequence. It separates maintenance from deployment, which is the boundary the failed production run proved necessary.

## Verification

CI should run TypeScript, Facet Catalog Contract, Contract Tests, and the existing narrative contracts. The production preview/deployment is the decisive regression check because the failure was specific to the Vercel + ProxySQL topology.