### PR TITLE
Fix karma data-integrity bugs; add karma UI (wallet page, header widget)

### DIFF
--- a/components/navigation/karma-widget.vue
+++ b/components/navigation/karma-widget.vue
@@ -1,0 +1,125 @@
+<template>
+  <div ref="root" class="karma-widget relative">
+    <button
+      class="btn btn-sm btn-ghost gap-1 rounded-xl px-2"
+      type="button"
+      title="Karma"
+      @click="toggle"
+    >
+      <span class="karma-icon text-lg leading-none">✨</span>
+      <span class="font-semibold tabular-nums">{{ karmaStore.balance }}</span>
+    </button>
+
+    <Transition name="fade">
+      <div
+        v-if="open"
+        class="absolute right-0 z-50 mt-2 w-72 space-y-3 rounded-2xl border border-base-content/10 bg-base-100 p-4 shadow-xl"
+      >
+        <div class="flex items-baseline justify-between">
+          <span class="text-sm font-medium text-base-content/70">
+            {{ userStore.username }}'s Karma
+          </span>
+          <span class="text-2xl font-extrabold tabular-nums text-primary">
+            {{ karmaStore.balance }}
+          </span>
+        </div>
+
+        <p class="text-xs text-base-content/60">
+          Earned by reacting, creating, sharing, and helping other Kind Robots
+          users. A measure of community contribution.
+        </p>
+
+        <ul
+          v-if="karmaStore.transactions.length"
+          class="max-h-40 space-y-1 overflow-y-auto text-xs"
+        >
+          <li
+            v-for="txn in karmaStore.transactions"
+            :key="txn.id"
+            class="flex justify-between text-base-content/70"
+          >
+            <span class="truncate">{{ formatReason(txn.reason) }}</span>
+            <span
+              class="tabular-nums"
+              :class="txn.amount >= 0 ? 'text-success' : 'text-error'"
+            >
+              {{ txn.amount >= 0 ? '+' : '' }}{{ txn.amount }}
+            </span>
+          </li>
+        </ul>
+
+        <NuxtLink
+          to="/wallet"
+          class="btn btn-sm btn-outline btn-primary rounded-xl"
+          @click="open = false"
+        >
+          View wallet
+        </NuxtLink>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useKarmaStore } from '@/stores/karmaStore'
+import { useUserStore } from '@/stores/userStore'
+
+const karmaStore = useKarmaStore()
+const userStore = useUserStore()
+
+const open = ref(false)
+const root = ref<HTMLElement | null>(null)
+
+function toggle(): void {
+  open.value = !open.value
+}
+
+function formatReason(reason: string): string {
+  return reason
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function onDocumentClick(event: MouseEvent): void {
+  if (!open.value) return
+
+  if (root.value && !root.value.contains(event.target as Node)) {
+    open.value = false
+  }
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    open.value = false
+  }
+}
+
+onMounted(() => {
+  karmaStore.fetch()
+  document.addEventListener('click', onDocumentClick)
+  document.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocumentClick)
+  document.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -89,6 +89,7 @@
         />
         <notification-bell class="shrink-0" />
         <login-switcher class="header-control-item min-w-0" />
+        <karma-widget class="shrink-0" />
         <mana-widget class="shrink-0" />
       </section>
     </div>
@@ -290,7 +291,8 @@ function goBack(): void {
   padding-right: 0;
 }
 
-.header-control-strip :deep(.mana-widget .btn) {
+.header-control-strip :deep(.mana-widget .btn),
+.header-control-strip :deep(.karma-widget .btn) {
   width: auto;
   min-width: 2.25rem;
   padding-left: 0.5rem;
@@ -307,7 +309,8 @@ function goBack(): void {
     width: 2.75rem;
   }
 
-  .header-control-strip :deep(.mana-widget .btn) {
+  .header-control-strip :deep(.mana-widget .btn),
+  .header-control-strip :deep(.karma-widget .btn) {
     width: auto;
     min-width: 2.75rem;
     padding-left: 0.625rem;

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="w-full max-w-3xl mx-auto p-6 space-y-8">
+    <div
+      v-if="userStore.isGuest"
+      class="rounded-2xl border border-accent/30 bg-base-200 p-6 text-center space-y-3"
+    >
+      <p class="text-base-content/80">
+        You're browsing as a guest. Sign up to keep a karma and mana balance
+        that follows your account. ✨
+      </p>
+      <NuxtLink to="/register" class="btn btn-accent rounded-xl"
+        >Create an account</NuxtLink
+      >
+    </div>
+
+    <template v-else>
+      <section
+        class="rounded-2xl border border-primary/20 bg-base-100 shadow-lg p-6 space-y-4"
+      >
+        <div class="flex items-end justify-between">
+          <div>
+            <h2 class="text-sm text-base-content/60">Karma</h2>
+            <div class="text-5xl font-extrabold text-primary tabular-nums">
+              {{ karmaStore.balance }}
+            </div>
+          </div>
+          <button
+            class="btn btn-ghost btn-sm rounded-xl"
+            :disabled="karmaStore.loading"
+            @click="karmaStore.fetch()"
+          >
+            Refresh
+          </button>
+        </div>
+
+        <p class="text-sm text-base-content/60">
+          Earned by reacting, creating, sharing, and helping other Kind Robots
+          users — a running score of your community contribution.
+        </p>
+
+        <div v-if="karmaStore.loading" class="text-base-content/50 text-sm">
+          Loading…
+        </div>
+        <div
+          v-else-if="!karmaStore.transactions.length"
+          class="text-base-content/50 text-sm"
+        >
+          No karma activity yet. Go react, create, and share! 🌱
+        </div>
+        <ul
+          v-else
+          class="divide-y divide-base-content/10 rounded-xl border border-base-content/10 overflow-hidden"
+        >
+          <li
+            v-for="txn in karmaStore.transactions"
+            :key="txn.id"
+            class="flex items-center justify-between px-4 py-3 bg-base-100"
+          >
+            <div class="space-y-0.5">
+              <div class="text-sm font-medium">
+                {{ formatReason(txn.reason) }}
+              </div>
+              <div class="text-xs text-base-content/50">
+                {{ formatWhen(txn.createdAt) }}
+              </div>
+            </div>
+            <span
+              class="font-bold tabular-nums"
+              :class="txn.amount >= 0 ? 'text-success' : 'text-error'"
+            >
+              {{ txn.amount >= 0 ? '+' : '' }}{{ txn.amount }}
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <mana-wallet />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useKarmaStore } from '@/stores/karmaStore'
+import { useUserStore } from '@/stores/userStore'
+
+const karmaStore = useKarmaStore()
+const userStore = useUserStore()
+
+function formatReason(reason: string): string {
+  return reason
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+onMounted(() => {
+  karmaStore.fetch()
+})
+</script>

--- a/content/channels/home/wallet.md
+++ b/content/channels/home/wallet.md
@@ -1,0 +1,17 @@
+---
+contentType: tab
+channelKey: home
+tabKey: wallet
+dashboardKey: user
+dashboardTab: dashboard
+label: Wallet
+title: Wallet
+subtitle: Your karma and mana, in one place
+description: Check your karma balance, mana balance, and recent activity for both.
+icon: kind-icon:bag
+route: /wallet
+sort: 75
+requiredPermission: authenticated
+---
+
+Karma and mana balances belong in the user's Home channel.

--- a/content/wallet.md
+++ b/content/wallet.md
@@ -1,0 +1,18 @@
+---
+title: 'Wallet'
+room: 'Wallet'
+subtitle: 'Your karma and mana, in one place'
+description: Check your karma balance, mana balance, and recent activity for both.
+image: splash/dashboard.png
+icon: kind-icon:bag
+tooltip: Your karma and mana balances, and how you earned them.
+dottiTip: Karma tracks how much good you've done here; mana is what you spend to make things.
+amiTip: One tracks kindness, the other tracks fuel. Neither one runs out if you keep showing up.
+channelKey: home
+tabKey: wallet
+requiredPermission: authenticated
+loadingMessage: Loading wallet...
+refreshLabel: Refresh wallet
+---
+
+:wallet-page

--- a/content/wallet.md
+++ b/content/wallet.md
@@ -10,6 +10,8 @@ dottiTip: Karma tracks how much good you've done here; mana is what you spend to
 amiTip: One tracks kindness, the other tracks fuel. Neither one runs out if you keep showing up.
 channelKey: home
 tabKey: wallet
+dashboardKey: user
+dashboardTab: dashboard
 requiredPermission: authenticated
 loadingMessage: Loading wallet...
 refreshLabel: Refresh wallet

--- a/server/api/karma/[id].get.ts
+++ b/server/api/karma/[id].get.ts
@@ -1,0 +1,75 @@
+// /server/api/karma/[id].get.ts
+import { defineEventHandler, createError } from 'h3'
+import prisma from '../../utils/prisma'
+import { errorHandler } from '../../utils/error'
+import { validateApiKey } from '../../utils/validateKey'
+
+export default defineEventHandler(async (event) => {
+  let id
+  let response
+
+  try {
+    id = Number(event.context.params?.id)
+    if (isNaN(id) || id <= 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid user ID. It must be a positive integer.',
+      })
+    }
+
+    const { isValid, user } = await validateApiKey(event)
+    if (!isValid || !user) {
+      throw createError({
+        statusCode: 401,
+        message: 'Invalid or expired token.',
+      })
+    }
+
+    // You can only read your own karma — unless you're ADMIN.
+    if (user.id !== id && user.Role !== 'ADMIN') {
+      throw createError({
+        statusCode: 403,
+        message: 'You do not have permission to view this karma balance.',
+      })
+    }
+
+    const karmaUser = await prisma.user.findUnique({
+      where: { id },
+      select: { karma: true },
+    })
+    if (!karmaUser) {
+      throw createError({
+        statusCode: 404,
+        message: 'User not found.',
+      })
+    }
+
+    const transactions = await prisma.karmaTransaction.findMany({
+      where: { userId: id },
+      orderBy: { createdAt: 'desc' },
+      take: 15,
+    })
+
+    response = {
+      success: true,
+      message: 'Karma loaded successfully.',
+      data: {
+        balance: karmaUser.karma,
+        transactions,
+      },
+      statusCode: 200,
+    }
+    event.node.res.statusCode = 200
+  } catch (error: unknown) {
+    const handledError = errorHandler(error)
+    event.node.res.statusCode = handledError.statusCode || 500
+    response = {
+      success: false,
+      message:
+        handledError.message || `Failed to load karma for user ID ${id}.`,
+      statusCode: event.node.res.statusCode,
+    }
+  }
+
+  return response
+})

--- a/stores/karmaStore.ts
+++ b/stores/karmaStore.ts
@@ -1,0 +1,61 @@
+// /stores/karmaStore.ts
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import { performFetch, handleError } from './utils'
+
+interface KarmaTxn {
+  id: number
+  createdAt: string
+  amount: number
+  reason: string
+  balanceAfter: number
+  refId?: string | null
+  note?: string | null
+}
+
+export const useKarmaStore = defineStore('karmaStore', () => {
+  const userStore = useUserStore()
+
+  const transactions = ref<KarmaTxn[]>([])
+  const loading = ref(false)
+  const error = ref('')
+
+  // Balance mirrors userStore.user.karma — single source of truth stays on the user.
+  const balance = computed(() => userStore.user?.karma ?? 0)
+  const isGuest = computed(() => userStore.isGuest)
+
+  async function fetch() {
+    const id = userStore.user?.id
+    if (!id || userStore.isGuest) return
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await performFetch<{
+        balance: number
+        transactions: KarmaTxn[]
+      }>(`/api/karma/${id}`)
+
+      if (res.success && res.data) {
+        transactions.value = res.data.transactions
+        if (userStore.user) userStore.user.karma = res.data.balance
+      } else {
+        error.value = res.message || 'Failed to load karma.'
+      }
+    } catch (err) {
+      handleError(err, 'karmaStore.fetch')
+      error.value = 'Failed to load karma.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    transactions,
+    loading,
+    error,
+    balance,
+    isGuest,
+    fetch,
+  }
+})

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -101,7 +101,7 @@ export const useUserStore = defineStore('userStore', () => {
     isLoggedIn.value ? (user.value?.id ?? null) : null,
   )
   const username = computed(() => user.value?.username ?? 'Kind Guest')
-  const karma = computed(() => user.value?.karma ?? 1000)
+  const karma = computed(() => user.value?.karma ?? 0)
   const mana = computed(() => user.value?.mana ?? 0)
   const role = computed(() => user.value?.Role ?? 'USER')
   const isAdmin = computed(
@@ -834,27 +834,27 @@ export const useUserStore = defineStore('userStore', () => {
       ])
 
       const count = achievementStore.achievementCountForUser
-      const updatedKarma = count * 1000
       const updatedMana = count
 
+      // Karma is no longer set here: it is owned entirely by the server-side
+      // KarmaTransaction ledger (server/utils/karma.ts). Overwriting it with
+      // achievementCount * 1000 bypassed that ledger and contradicted it.
       const latestUser = await flushSpecificUserPatch({
-        karma: updatedKarma,
         mana: updatedMana,
       } as UserPatch)
 
       if (latestUser) {
         users.value = updateUserFields(users.value, currentUserId, {
-          karma: updatedKarma,
           mana: updatedMana,
         })
 
-        return { success: true, message: 'Karma and mana updated.' }
+        return { success: true, message: 'Mana updated.' }
       }
 
-      throw new Error('Failed to update karma and mana.')
+      throw new Error('Failed to update mana.')
     } catch (error) {
       handleError(error, 'updateKarmaAndMana')
-      return { success: false, message: 'Failed to update karma and mana.' }
+      return { success: false, message: 'Failed to update mana.' }
     }
   }
 


### PR DESCRIPTION
### Task
conductor: interface-vision/t-010 — fix the two karma data-integrity bugs, then make karma and mana visible.

### What changed
- **`stores/userStore.ts`**: `updateKarmaAndMana()` no longer overwrites `karma` with `achievementCount * 1000` — that bypassed the real `KarmaTransaction` ledger (`server/utils/karma.ts`) and contradicted it. Mana continues to update as before (unchanged — not one of the two flagged bugs).
- **`stores/userStore.ts`**: `karma` computed default changed from `?? 1000` to `?? 0`, matching the schema default (an unloaded user previously showed a fabricated 1000 balance).
- **`server/api/karma/[id].get.ts`** (new): mirrors the existing `GET /api/mana/[id]` route — same auth shape (own-wallet-or-admin read), returns karma balance + last 15 `KarmaTransaction` rows.
- **`stores/karmaStore.ts`** (new): mirrors `manaStore.ts`.
- **`components/navigation/karma-widget.vue`** (new): sibling to `mana-widget.vue`, wired into `workspace-header.vue` next to the mana widget (plus matching responsive `.btn` sizing rules).
- **`components/pages/wallet-page.vue`** + **`content/wallet.md`** (new): `mana-widget.vue` already links to `/wallet`, which 404s since neither existed. The new page shows karma balance/history and reuses the existing `components/giftshop/mana-wallet.vue` for mana (no new `<h1>` — `wallet-page.vue` relies on the shell header per the one-header rule).

### How I verified
- `npm run test:layout-contract` — 0 new violations (29/36/9/4/7, all unchanged from baseline).
- `npm run test` (`vue-tsc --noEmit`) — exits clean, 0 errors.
- `eslint` on every touched/new file — 0 errors (`stores/userStore.ts` has one pre-existing, unrelated error at line 613 — `no-dynamic-delete` — confirmed present on `main` before this change via `git stash`).
- `prettier --check` on every touched/new file — passes (two new files needed `--write`, applied).
- No live browser/Vercel-preview pass this session — verification is static (typecheck, lint, the layout-contract ratchet, direct reading of the new components against the existing `mana-widget.vue`/`mana-wallet.vue` patterns they mirror).

### Stakes
reversible

### Flags for Reviewer
- Deliberately left the *mana* half of `updateKarmaAndMana()`'s client-side overwrite untouched. It arguably has the same "bypasses the ledger" shape as the karma bug, but the task's bug list named only karma, and mana already has its own real ledger/refill/charge system elsewhere — didn't want to change mana-earning behavior on achievement-confirm without it being an explicitly named bug.
- The task's last bullet, "show earned/spent on object cards," is **not** done here — split into a new roadmap follow-up (interface-vision/t-019) since no object currently has a per-item earned-karma/mana aggregate field; it needs its own design pass (which card component, which aggregation query) rather than folding into this bug-fix PR.
- A worth-a-look nit noticed in passing, not touched: `components/giftshop/mana-wallet.vue`'s script has a stale `// /pages/wallet.vue` path comment from before it moved into `components/giftshop/`.

### Kaizen suggestion
Wire achievement confirmation into the real `awardKarma()`/`applyMana()` ledgers server-side (there is currently no `KarmaReason` for achievements at all, so confirming an achievement grants zero ledger-tracked karma or mana) — a natural follow-up now that the client-side placeholder is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYTxcbqE5Wz8uLB995VZHL)_