### PR TITLE
Fix kr-gallery compiler-hoisted prop default

### DIFF
--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -111,13 +111,6 @@ export interface GalleryItem {
   badges?: Array<{ label: string; class?: string }>
 }
 
-const DEFAULT_GALLERY_MODES: GalleryModeOption[] = [
-  { value: 'cards', label: 'Cards', abbr: 'C' },
-  { value: 'heroes', label: 'Heroes', abbr: 'H' },
-  { value: 'icons', label: 'Icons', abbr: 'I' },
-  { value: 'list', label: 'List', abbr: 'L' },
-]
-
 const props = withDefaults(
   defineProps<{
     items: GalleryItem[]
@@ -130,7 +123,12 @@ const props = withDefaults(
   }>(),
   {
     mode: 'cards',
-    modes: () => DEFAULT_GALLERY_MODES,
+    modes: () => [
+      { value: 'cards', label: 'Cards', abbr: 'C' },
+      { value: 'heroes', label: 'Heroes', abbr: 'H' },
+      { value: 'icons', label: 'Icons', abbr: 'I' },
+      { value: 'list', label: 'List', abbr: 'L' },
+    ],
     loading: false,
     error: '',
     emptyLabel: 'items',


### PR DESCRIPTION
## Root cause
The production Nuxt build for main commit `d1b652e` failed because `withDefaults(defineProps(...))` is compiler-hoisted, but the `modes` default referenced the locally declared `DEFAULT_GALLERY_MODES` constant.

## Fix
Inline the typed default-mode array inside the prop default factory so the Vue SFC compiler can safely hoist it. Runtime behavior is unchanged.

## Verification
The production failure is isolated to `components/gallery/kr-gallery.vue`; CI and Vercel should exercise the compiler path on this PR.
