### PR TITLE
interface-vision/t-006: narrator stage on Storymaker and Taskmaster

### DIFF
--- a/components/conductor/storymaker-page.vue
+++ b/components/conductor/storymaker-page.vue
@@ -1,25 +1,23 @@
 <!-- /components/conductor/storymaker-page.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="kr-surface gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
   >
-    <header class="flex flex-wrap items-start gap-3">
+    <header class="flex shrink-0 flex-wrap items-start gap-3">
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary"
       >
         <Icon name="kind-icon:book" class="size-6" />
       </div>
       <div class="min-w-0 flex-1">
-        <p class="text-xs font-bold uppercase tracking-wide text-primary/70">
-          Storymaker
-        </p>
         <p class="text-2xl font-black leading-tight">
           Build a world, then step inside it
         </p>
         <p class="mt-1 max-w-3xl text-sm leading-relaxed text-base-content/65">
           Shape a premise, gather reusable Kind Robots characters and Facets,
-          review the story bible, and let a dedicated narrator carry your choices
-          forward. Storymaker creates fiction; it never turns the tale into a task list.
+          review the story bible, and let a dedicated narrator carry your
+          choices forward. Storymaker creates fiction; it never turns the tale
+          into a task list.
         </p>
       </div>
       <div v-if="store.session" class="flex shrink-0 flex-wrap gap-2">
@@ -54,366 +52,429 @@
       </div>
     </header>
 
-    <div v-if="!store.session" class="space-y-4">
-      <nav
-        class="grid grid-cols-2 gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-2 sm:grid-cols-4"
-        aria-label="Story setup progress"
-      >
-        <button
-          v-for="(item, index) in setupSteps"
-          :key="item.label"
-          type="button"
-          class="flex items-center gap-2 rounded-xl px-3 py-2 text-left text-xs font-bold transition"
-          :class="
-            setupStep === index
-              ? 'bg-primary text-primary-content shadow-sm'
-              : index < setupStep
-                ? 'bg-success/10 text-success'
-                : 'text-base-content/45'
-          "
-          :disabled="index > furthestStep"
-          @click="setupStep = index"
+    <LazyKrNarratorStage :stage-image="tabImage" class="shrink-0" />
+
+    <div class="kr-scroll space-y-4">
+      <div v-if="!store.session" class="space-y-4">
+        <nav
+          class="grid grid-cols-2 gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-2 sm:grid-cols-4"
+          aria-label="Story setup progress"
         >
-          <span
-            class="flex size-6 shrink-0 items-center justify-center rounded-full border border-current/25"
+          <button
+            v-for="(item, index) in setupSteps"
+            :key="item.label"
+            type="button"
+            class="flex items-center gap-2 rounded-xl px-3 py-2 text-left text-xs font-bold transition"
+            :class="
+              setupStep === index
+                ? 'bg-primary text-primary-content shadow-sm'
+                : index < setupStep
+                  ? 'bg-success/10 text-success'
+                  : 'text-base-content/45'
+            "
+            :disabled="index > furthestStep"
+            @click="setupStep = index"
+          >
+            <span
+              class="flex size-6 shrink-0 items-center justify-center rounded-full border border-current/25"
+            >
+              <Icon
+                v-if="index < setupStep"
+                name="kind-icon:check"
+                class="size-3.5"
+              />
+              <span v-else>{{ index + 1 }}</span>
+            </span>
+            <span class="truncate">{{ item.label }}</span>
+          </button>
+        </nav>
+
+        <section
+          v-if="setupStep === 0"
+          class="space-y-5 rounded-2xl border border-primary/20 bg-primary/5 p-4"
+        >
+          <div>
+            <h2 class="text-lg font-black">The spark</h2>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Begin with the promise of the story. A sentence is enough; a
+              strange paragraph is welcome.
+            </p>
+          </div>
+
+          <label class="form-control w-full">
+            <span
+              class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+            >
+              Working title (optional)
+            </span>
+            <input
+              v-model="store.setupDraft.title"
+              type="text"
+              class="input input-bordered w-full rounded-xl bg-base-100"
+              placeholder="The Clockwork Orchard"
+            />
+          </label>
+
+          <label class="form-control w-full">
+            <span
+              class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+            >
+              Premise
+            </span>
+            <textarea
+              v-model="store.setupDraft.premise"
+              rows="5"
+              class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
+              placeholder="Every midnight, the town's abandoned observatory receives a letter from a star that should not exist…"
+            />
+            <span class="mt-1 text-[0.7rem] text-base-content/45">
+              This is creative direction, not a prompt for model or generator
+              settings.
+            </span>
+          </label>
+
+          <div class="space-y-2">
+            <h3
+              class="text-xs font-bold uppercase tracking-wide text-base-content/55"
+            >
+              Narrator voice
+            </h3>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="style in STORYMAKER_NARRATOR_STYLES"
+                :key="style"
+                type="button"
+                class="btn btn-sm rounded-xl capitalize"
+                :class="
+                  store.setupDraft.narratorStyle === style
+                    ? 'btn-primary'
+                    : 'btn-ghost border border-base-300 bg-base-100'
+                "
+                :aria-pressed="store.setupDraft.narratorStyle === style"
+                @click="store.setupDraft.narratorStyle = style"
+              >
+                {{ style }}
+              </button>
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <h3
+              class="text-xs font-bold uppercase tracking-wide text-base-content/55"
+            >
+              Shape of the tale
+            </h3>
+            <div class="grid gap-2 md:grid-cols-3">
+              <button
+                v-for="structure in STORYMAKER_STRUCTURES"
+                :key="structure.value"
+                type="button"
+                class="rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-sm"
+                :class="
+                  store.setupDraft.structure === structure.value
+                    ? 'border-primary bg-primary/10 ring-1 ring-primary/30'
+                    : 'border-base-300 bg-base-100'
+                "
+                :aria-pressed="store.setupDraft.structure === structure.value"
+                @click="store.setupDraft.structure = structure.value"
+              >
+                <span class="text-sm font-black">{{ structure.label }}</span>
+                <span
+                  class="mt-1 block text-xs leading-relaxed text-base-content/55"
+                >
+                  {{ structure.description }}
+                </span>
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section
+          v-else-if="setupStep === 1"
+          class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
+        >
+          <div>
+            <h2 class="text-lg font-black">The cast</h2>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Choose up to five existing characters. Leaving the cast empty lets
+              Storymaker invent whoever the premise requires.
+            </p>
+          </div>
+          <NarrativeIngredientMultiPicker
+            v-model="store.setupDraft.castSlugs"
+            :items="characterOptions"
+            label="Characters"
+            helper="Existing character art and personality travel into the story bible."
+            empty-state="No characters are available yet. Storymaker can still invent a cast from the premise."
+            :loading="characterStore.loading || characterStore.isInitializing"
+            :error="characterStore.error"
+            :initial-limit="9"
+            :max-selections="5"
+          />
+        </section>
+
+        <section
+          v-else-if="setupStep === 2"
+          class="space-y-5 rounded-2xl border border-primary/20 bg-primary/5 p-4"
+        >
+          <div>
+            <h2 class="text-lg font-black">The world and its flavor</h2>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Use canonical Dreams, Facets, and Rewards as ingredients. Their
+              artwork becomes part of the setup surface while technical art
+              direction remains automatic.
+            </p>
+          </div>
+
+          <NarrativeIngredientPicker
+            v-model="store.setupDraft.locationSlug"
+            :items="locationOptions"
+            label="Primary setting"
+            helper="Choose one reusable LOCATION Dream, or let the premise decide."
+            empty-label="Invent a new place"
+            empty-description="Storymaker will derive the setting from the premise and selected Facets."
+            empty-icon="kind-icon:moon"
+            empty-state="No LOCATION Dreams are available yet."
+            :loading="dreamStore.loading"
+            :error="dreamStore.error"
+            :initial-limit="6"
+          />
+
+          <NarrativeIngredientMultiPicker
+            v-model="store.setupDraft.facetSlugs"
+            :items="facetOptions"
+            label="Creative Facets"
+            helper="Mix genre, mood, theme, style, and art direction without exposing generator controls."
+            empty-state="No active creative Facets are available yet."
+            :loading="facetStore.loading"
+            :error="facetStore.error"
+            :initial-limit="9"
+            :max-selections="5"
+          />
+
+          <NarrativeIngredientMultiPicker
+            v-model="store.setupDraft.rewardSlugs"
+            :items="rewardOptions"
+            label="Possible story Rewards"
+            helper="Choose up to three reusable Rewards the fiction may discover, grant, spend, or lose."
+            empty-state="No active Rewards are available yet. The story can continue without inventory."
+            :loading="rewardStore.isLoading || rewardStore.isInitializing"
+            :error="rewardStore.error"
+            :initial-limit="9"
+            :max-selections="3"
+          />
+
+          <label class="form-control w-full">
+            <span
+              class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+            >
+              Extra story direction (optional)
+            </span>
+            <textarea
+              v-model="store.setupDraft.notes"
+              rows="3"
+              class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
+              placeholder="Keep the rivalry affectionate. Let every machine feel slightly alive. Avoid a chosen-one prophecy."
+            />
+          </label>
+        </section>
+
+        <section
+          v-else
+          class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
+        >
+          <div>
+            <h2 class="text-lg font-black">Story bible</h2>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Review the creative contract before Storymaker writes the opening
+              scene.
+            </p>
+          </div>
+
+          <dl class="grid gap-3 md:grid-cols-2">
+            <div
+              class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
+            >
+              <dt
+                class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70"
+              >
+                {{ reviewTitle }}
+              </dt>
+              <dd class="mt-2 whitespace-pre-line text-sm leading-relaxed">
+                {{ store.setupDraft.premise }}
+              </dd>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <dt class="text-xs font-bold text-base-content/55">Narration</dt>
+              <dd class="mt-1 text-sm capitalize">
+                {{ store.setupDraft.narratorStyle }} · {{ structureLabel }}
+              </dd>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <dt class="text-xs font-bold text-base-content/55">Setting</dt>
+              <dd class="mt-1 text-sm">
+                {{ selectedLocation?.title || 'Invented from the premise' }}
+              </dd>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <dt class="text-xs font-bold text-base-content/55">Cast</dt>
+              <dd class="mt-1 text-sm">
+                {{
+                  selectedCast.length
+                    ? selectedCast.map((item) => item.title).join(', ')
+                    : 'Invented as needed'
+                }}
+              </dd>
+            </div>
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <dt class="text-xs font-bold text-base-content/55">Facets</dt>
+              <dd class="mt-1 text-sm">
+                {{
+                  selectedFacets.length
+                    ? selectedFacets.map((item) => item.title).join(', ')
+                    : 'None selected'
+                }}
+              </dd>
+            </div>
+            <div
+              class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
+            >
+              <dt class="text-xs font-bold text-base-content/55">
+                Possible Rewards
+              </dt>
+              <dd class="mt-1 text-sm">
+                {{
+                  selectedRewards.length
+                    ? selectedRewards.map((item) => item.title).join(', ')
+                    : 'No curated inventory pool'
+                }}
+              </dd>
+            </div>
+            <div
+              v-if="store.setupDraft.notes.trim()"
+              class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
+            >
+              <dt class="text-xs font-bold text-base-content/55">
+                Additional direction
+              </dt>
+              <dd class="mt-1 whitespace-pre-line text-sm leading-relaxed">
+                {{ store.setupDraft.notes }}
+              </dd>
+            </div>
+          </dl>
+
+          <div
+            class="flex items-start gap-2 rounded-2xl border border-info/30 bg-info/5 p-3 text-xs leading-relaxed"
           >
             <Icon
-              v-if="index < setupStep"
-              name="kind-icon:check"
-              class="size-3.5"
+              name="kind-icon:palette"
+              class="mt-0.5 size-4 shrink-0 text-info"
             />
-            <span v-else>{{ index + 1 }}</span>
-          </span>
-          <span class="truncate">{{ item.label }}</span>
-        </button>
-      </nav>
+            <span>
+              Scene art will be directed from this bible automatically.
+              Storymaker will not ask for a model, sampler, dimensions, or step
+              count.
+            </span>
+          </div>
+        </section>
 
-      <section
-        v-if="setupStep === 0"
-        class="space-y-5 rounded-2xl border border-primary/20 bg-primary/5 p-4"
-      >
-        <div>
-          <h2 class="text-lg font-black">The spark</h2>
-          <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-            Begin with the promise of the story. A sentence is enough; a strange
-            paragraph is welcome.
-          </p>
-        </div>
+        <p v-if="store.errorMessage" class="text-xs text-error">
+          {{ store.errorMessage }}
+        </p>
 
-        <label class="form-control w-full">
-          <span class="label-text mb-1 text-xs font-bold uppercase tracking-wide">
-            Working title (optional)
-          </span>
-          <input
-            v-model="store.setupDraft.title"
-            type="text"
-            class="input input-bordered w-full rounded-xl bg-base-100"
-            placeholder="The Clockwork Orchard"
-          />
-        </label>
-
-        <label class="form-control w-full">
-          <span class="label-text mb-1 text-xs font-bold uppercase tracking-wide">
-            Premise
-          </span>
-          <textarea
-            v-model="store.setupDraft.premise"
-            rows="5"
-            class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
-            placeholder="Every midnight, the town's abandoned observatory receives a letter from a star that should not exist…"
-          />
-          <span class="mt-1 text-[0.7rem] text-base-content/45">
-            This is creative direction, not a prompt for model or generator settings.
-          </span>
-        </label>
-
-        <div class="space-y-2">
-          <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
-            Narrator voice
-          </h3>
+        <footer class="flex flex-wrap items-center justify-between gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost rounded-xl border border-base-300"
+            :disabled="setupStep === 0 || store.isWeaving"
+            @click="setupStep -= 1"
+          >
+            <Icon name="kind-icon:chevron-left" class="size-4" /> Back
+          </button>
           <div class="flex flex-wrap gap-2">
             <button
-              v-for="style in STORYMAKER_NARRATOR_STYLES"
-              :key="style"
               type="button"
-              class="btn btn-sm rounded-xl capitalize"
-              :class="
-                store.setupDraft.narratorStyle === style
-                  ? 'btn-primary'
-                  : 'btn-ghost border border-base-300 bg-base-100'
-              "
-              :aria-pressed="store.setupDraft.narratorStyle === style"
-              @click="store.setupDraft.narratorStyle = style"
+              class="btn btn-ghost rounded-xl"
+              :disabled="store.isWeaving"
+              @click="clearDraft"
             >
-              {{ style }}
+              Clear draft
             </button>
-          </div>
-        </div>
-
-        <div class="space-y-2">
-          <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
-            Shape of the tale
-          </h3>
-          <div class="grid gap-2 md:grid-cols-3">
             <button
-              v-for="structure in STORYMAKER_STRUCTURES"
-              :key="structure.value"
+              v-if="setupStep < setupSteps.length - 1"
               type="button"
-              class="rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-sm"
-              :class="
-                store.setupDraft.structure === structure.value
-                  ? 'border-primary bg-primary/10 ring-1 ring-primary/30'
-                  : 'border-base-300 bg-base-100'
-              "
-              :aria-pressed="store.setupDraft.structure === structure.value"
-              @click="store.setupDraft.structure = structure.value"
+              class="btn btn-primary rounded-xl"
+              :disabled="!canAdvance"
+              @click="advanceSetup"
             >
-              <span class="text-sm font-black">{{ structure.label }}</span>
-              <span class="mt-1 block text-xs leading-relaxed text-base-content/55">
-                {{ structure.description }}
-              </span>
+              Continue <Icon name="kind-icon:chevron-right" class="size-4" />
+            </button>
+            <button
+              v-else
+              type="button"
+              class="btn btn-primary rounded-xl"
+              :disabled="!canBegin || store.isWeaving"
+              @click="beginStory"
+            >
+              <span
+                v-if="store.isWeaving"
+                class="loading loading-dots loading-sm"
+              />
+              <template v-else>
+                <Icon name="kind-icon:sparkles" class="size-4" /> Write the
+                opening scene
+              </template>
             </button>
           </div>
-        </div>
-      </section>
+        </footer>
+      </div>
 
-      <section
-        v-else-if="setupStep === 1"
-        class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
-      >
-        <div>
-          <h2 class="text-lg font-black">The cast</h2>
-          <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-            Choose up to five existing characters. Leaving the cast empty lets
-            Storymaker invent whoever the premise requires.
-          </p>
-        </div>
-        <NarrativeIngredientMultiPicker
-          v-model="store.setupDraft.castSlugs"
-          :items="characterOptions"
-          label="Characters"
-          helper="Existing character art and personality travel into the story bible."
-          empty-state="No characters are available yet. Storymaker can still invent a cast from the premise."
-          :loading="characterStore.loading || characterStore.isInitializing"
-          :error="characterStore.error"
-          :initial-limit="9"
-          :max-selections="5"
-        />
-      </section>
-
-      <section
-        v-else-if="setupStep === 2"
-        class="space-y-5 rounded-2xl border border-primary/20 bg-primary/5 p-4"
-      >
-        <div>
-          <h2 class="text-lg font-black">The world and its flavor</h2>
-          <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-            Use canonical Dreams, Facets, and Rewards as ingredients. Their artwork
-            becomes part of the setup surface while technical art direction remains automatic.
-          </p>
-        </div>
-
-        <NarrativeIngredientPicker
-          v-model="store.setupDraft.locationSlug"
-          :items="locationOptions"
-          label="Primary setting"
-          helper="Choose one reusable LOCATION Dream, or let the premise decide."
-          empty-label="Invent a new place"
-          empty-description="Storymaker will derive the setting from the premise and selected Facets."
-          empty-icon="kind-icon:moon"
-          empty-state="No LOCATION Dreams are available yet."
-          :loading="dreamStore.loading"
-          :error="dreamStore.error"
-          :initial-limit="6"
-        />
-
-        <NarrativeIngredientMultiPicker
-          v-model="store.setupDraft.facetSlugs"
-          :items="facetOptions"
-          label="Creative Facets"
-          helper="Mix genre, mood, theme, style, and art direction without exposing generator controls."
-          empty-state="No active creative Facets are available yet."
-          :loading="facetStore.loading"
-          :error="facetStore.error"
-          :initial-limit="9"
-          :max-selections="5"
-        />
-
-        <NarrativeIngredientMultiPicker
-          v-model="store.setupDraft.rewardSlugs"
-          :items="rewardOptions"
-          label="Possible story Rewards"
-          helper="Choose up to three reusable Rewards the fiction may discover, grant, spend, or lose."
-          empty-state="No active Rewards are available yet. The story can continue without inventory."
-          :loading="rewardStore.isLoading || rewardStore.isInitializing"
-          :error="rewardStore.error"
-          :initial-limit="9"
-          :max-selections="3"
-        />
-
-        <label class="form-control w-full">
-          <span class="label-text mb-1 text-xs font-bold uppercase tracking-wide">
-            Extra story direction (optional)
-          </span>
-          <textarea
-            v-model="store.setupDraft.notes"
-            rows="3"
-            class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
-            placeholder="Keep the rivalry affectionate. Let every machine feel slightly alive. Avoid a chosen-one prophecy."
-          />
-        </label>
-      </section>
-
-      <section
-        v-else
-        class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
-      >
-        <div>
-          <h2 class="text-lg font-black">Story bible</h2>
-          <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-            Review the creative contract before Storymaker writes the opening scene.
-          </p>
-        </div>
-
-        <dl class="grid gap-3 md:grid-cols-2">
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2">
-            <dt class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70">
-              {{ reviewTitle }}
-            </dt>
-            <dd class="mt-2 whitespace-pre-line text-sm leading-relaxed">
-              {{ store.setupDraft.premise }}
-            </dd>
+      <template v-else>
+        <details class="rounded-2xl border border-primary/25 bg-primary/5 p-3">
+          <summary class="cursor-pointer text-sm font-black text-primary">
+            {{ store.session.bible.title }} · Story bible
+          </summary>
+          <div class="mt-3 grid gap-2 text-xs leading-relaxed sm:grid-cols-2">
+            <p
+              class="rounded-xl border border-base-300 bg-base-100 p-3 sm:col-span-2"
+            >
+              {{ store.session.bible.premise }}
+            </p>
+            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+              <span class="font-bold">Cast:</span>
+              {{
+                store.session.bible.cast.map((item) => item.title).join(', ') ||
+                'Invented as needed'
+              }}
+            </p>
+            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+              <span class="font-bold">World:</span>
+              {{
+                store.session.bible.location?.title ||
+                'Invented from the premise'
+              }}
+            </p>
+            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+              <span class="font-bold">Facets:</span>
+              {{
+                store.session.bible.facets
+                  .map((item) => item.title)
+                  .join(', ') || 'None selected'
+              }}
+            </p>
+            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+              <span class="font-bold">Reward pool:</span>
+              {{
+                store.session.bible.rewards
+                  .map((item) => item.title)
+                  .join(', ') || 'None selected'
+              }}
+            </p>
           </div>
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
-            <dt class="text-xs font-bold text-base-content/55">Narration</dt>
-            <dd class="mt-1 text-sm capitalize">
-              {{ store.setupDraft.narratorStyle }} · {{ structureLabel }}
-            </dd>
-          </div>
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
-            <dt class="text-xs font-bold text-base-content/55">Setting</dt>
-            <dd class="mt-1 text-sm">
-              {{ selectedLocation?.title || 'Invented from the premise' }}
-            </dd>
-          </div>
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
-            <dt class="text-xs font-bold text-base-content/55">Cast</dt>
-            <dd class="mt-1 text-sm">
-              {{ selectedCast.length ? selectedCast.map((item) => item.title).join(', ') : 'Invented as needed' }}
-            </dd>
-          </div>
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
-            <dt class="text-xs font-bold text-base-content/55">Facets</dt>
-            <dd class="mt-1 text-sm">
-              {{ selectedFacets.length ? selectedFacets.map((item) => item.title).join(', ') : 'None selected' }}
-            </dd>
-          </div>
-          <div class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2">
-            <dt class="text-xs font-bold text-base-content/55">Possible Rewards</dt>
-            <dd class="mt-1 text-sm">
-              {{ selectedRewards.length ? selectedRewards.map((item) => item.title).join(', ') : 'No curated inventory pool' }}
-            </dd>
-          </div>
-          <div
-            v-if="store.setupDraft.notes.trim()"
-            class="rounded-2xl border border-base-300 bg-base-100 p-3 md:col-span-2"
-          >
-            <dt class="text-xs font-bold text-base-content/55">Additional direction</dt>
-            <dd class="mt-1 whitespace-pre-line text-sm leading-relaxed">
-              {{ store.setupDraft.notes }}
-            </dd>
-          </div>
-        </dl>
+        </details>
 
-        <div
-          class="flex items-start gap-2 rounded-2xl border border-info/30 bg-info/5 p-3 text-xs leading-relaxed"
-        >
-          <Icon name="kind-icon:palette" class="mt-0.5 size-4 shrink-0 text-info" />
-          <span>
-            Scene art will be directed from this bible automatically. Storymaker
-            will not ask for a model, sampler, dimensions, or step count.
-          </span>
-        </div>
-      </section>
+        <StorymakerStatePanel :session="store.session" />
 
-      <p v-if="store.errorMessage" class="text-xs text-error">
-        {{ store.errorMessage }}
-      </p>
-
-      <footer class="flex flex-wrap items-center justify-between gap-2">
-        <button
-          type="button"
-          class="btn btn-ghost rounded-xl border border-base-300"
-          :disabled="setupStep === 0 || store.isWeaving"
-          @click="setupStep -= 1"
-        >
-          <Icon name="kind-icon:chevron-left" class="size-4" /> Back
-        </button>
-        <div class="flex flex-wrap gap-2">
-          <button
-            type="button"
-            class="btn btn-ghost rounded-xl"
-            :disabled="store.isWeaving"
-            @click="clearDraft"
-          >
-            Clear draft
-          </button>
-          <button
-            v-if="setupStep < setupSteps.length - 1"
-            type="button"
-            class="btn btn-primary rounded-xl"
-            :disabled="!canAdvance"
-            @click="advanceSetup"
-          >
-            Continue <Icon name="kind-icon:chevron-right" class="size-4" />
-          </button>
-          <button
-            v-else
-            type="button"
-            class="btn btn-primary rounded-xl"
-            :disabled="!canBegin || store.isWeaving"
-            @click="beginStory"
-          >
-            <span v-if="store.isWeaving" class="loading loading-dots loading-sm" />
-            <template v-else>
-              <Icon name="kind-icon:sparkles" class="size-4" /> Write the opening scene
-            </template>
-          </button>
-        </div>
-      </footer>
-    </div>
-
-    <div v-else class="flex min-h-0 flex-1 flex-col gap-3">
-      <details class="rounded-2xl border border-primary/25 bg-primary/5 p-3">
-        <summary class="cursor-pointer text-sm font-black text-primary">
-          {{ store.session.bible.title }} · Story bible
-        </summary>
-        <div class="mt-3 grid gap-2 text-xs leading-relaxed sm:grid-cols-2">
-          <p class="rounded-xl border border-base-300 bg-base-100 p-3 sm:col-span-2">
-            {{ store.session.bible.premise }}
-          </p>
-          <p class="rounded-xl border border-base-300 bg-base-100 p-3">
-            <span class="font-bold">Cast:</span>
-            {{ store.session.bible.cast.map((item) => item.title).join(', ') || 'Invented as needed' }}
-          </p>
-          <p class="rounded-xl border border-base-300 bg-base-100 p-3">
-            <span class="font-bold">World:</span>
-            {{ store.session.bible.location?.title || 'Invented from the premise' }}
-          </p>
-          <p class="rounded-xl border border-base-300 bg-base-100 p-3">
-            <span class="font-bold">Facets:</span>
-            {{ store.session.bible.facets.map((item) => item.title).join(', ') || 'None selected' }}
-          </p>
-          <p class="rounded-xl border border-base-300 bg-base-100 p-3">
-            <span class="font-bold">Reward pool:</span>
-            {{ store.session.bible.rewards.map((item) => item.title).join(', ') || 'None selected' }}
-          </p>
-        </div>
-      </details>
-
-      <StorymakerStatePanel :session="store.session" />
-
-      <div class="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         <NarrativeTranscript
           :beats="store.session.beats"
           :is-streaming="store.isWeaving"
@@ -440,22 +501,26 @@
         >
           <p class="font-black text-success">The tale rests here</p>
           <p class="mt-1 text-xs text-base-content/55">
-            The completed session remains saved in this browser until you begin another.
+            The completed session remains saved in this browser until you begin
+            another.
           </p>
         </div>
-      </div>
-
-      <NarrativeResponseComposer
-        v-if="!store.isComplete"
-        v-model="answerInput"
-        :disabled="!store.awaitingAnswer"
-        :loading="store.isWeaving"
-        :placeholder="store.awaitingAnswer ? 'What happens next?' : 'Storymaker is weaving…'"
-        button-label="Continue story"
-        hint="Your response changes this fictional branch. It does not update projects or real-world tasks."
-        @submit="submitAnswer"
-      />
+      </template>
     </div>
+
+    <NarrativeResponseComposer
+      v-if="store.session && !store.isComplete"
+      v-model="answerInput"
+      class="shrink-0"
+      :disabled="!store.awaitingAnswer"
+      :loading="store.isWeaving"
+      :placeholder="
+        store.awaitingAnswer ? 'What happens next?' : 'Storymaker is weaving…'
+      "
+      button-label="Continue story"
+      hint="Your response changes this fictional branch. It does not update projects or real-world tasks."
+      @submit="submitAnswer"
+    />
   </section>
 </template>
 
@@ -464,6 +529,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useFacetStore } from '@/stores/facetStore'
+import { getDashboardTabImagePath } from '@/stores/helpers/dashboardHelper'
 import { useRewardStore } from '@/stores/rewardStore'
 import {
   STORYMAKER_NARRATOR_STYLES,
@@ -478,6 +544,10 @@ const characterStore = useCharacterStore()
 const dreamStore = useDreamStore()
 const facetStore = useFacetStore()
 const rewardStore = useRewardStore()
+
+const tabImage = computed(() =>
+  getDashboardTabImagePath('scenario', 'storymaker'),
+)
 
 const setupStep = ref(0)
 const furthestStep = ref(0)
@@ -613,9 +683,7 @@ function rarityLabel(value: string): string {
 }
 
 function toIngredient(option: NarrativeIngredientOption): StorymakerIngredient {
-  const reward = rewardStore.rewards.find(
-    (item) => item.slug === option.slug,
-  )
+  const reward = rewardStore.rewards.find((item) => item.slug === option.slug)
   return {
     id: option.id,
     slug: option.slug,

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -1,0 +1,168 @@
+<!-- /components/narrative/kr-narrator-stage.vue -->
+<!-- The narrator as a first-class region rather than an overlay drawer.
+     Large art plate (page art + narrator portrait), a generous narration
+     window styled as narration, and a pinned action rail with quick topic
+     choices plus free-text input. Mount lazily (LazyKrNarratorStage) so
+     narratorStore's eager store composition never enters a page's
+     first-paint bundle — see components/dreams/dream-interact.vue. -->
+<template>
+  <section
+    class="kr-narrator-stage kr-stage gap-3 rounded-3xl border border-primary/15 bg-base-200/40 p-3 sm:p-4"
+  >
+    <div
+      class="grid min-h-0 flex-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)]"
+    >
+      <div
+        class="relative min-h-40 overflow-hidden rounded-3xl border border-primary/20 bg-base-300 shadow-inner md:min-h-0"
+      >
+        <img
+          v-if="props.stageImage"
+          :src="props.stageImage"
+          :alt="stageAlt"
+          class="absolute inset-0 h-full w-full object-cover opacity-70"
+          loading="lazy"
+        />
+        <div
+          class="absolute inset-0 bg-linear-to-t from-base-300/90 via-base-300/10 to-transparent"
+        />
+
+        <div class="absolute inset-x-3 bottom-3 flex items-center gap-2">
+          <img
+            v-if="narratorImage"
+            :src="narratorImage"
+            :alt="narratorName"
+            class="h-12 w-12 shrink-0 rounded-full border-2 border-primary/40 bg-base-100 object-cover shadow-lg"
+            loading="lazy"
+          />
+          <div
+            class="min-w-0 rounded-2xl border border-primary/20 bg-base-100/90 px-3 py-1.5 backdrop-blur"
+          >
+            <p
+              class="truncate text-sm font-black leading-tight text-base-content"
+            >
+              {{ narratorName }}
+            </p>
+            <p
+              class="truncate text-[0.65rem] font-black uppercase tracking-widest text-primary/75"
+            >
+              {{ currentEmotionLabel }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="flex min-h-0 flex-col justify-center rounded-3xl border border-primary/15 bg-base-100/70 p-4"
+      >
+        <p
+          class="narration-text whitespace-pre-wrap font-serif text-sm italic leading-relaxed text-base-content/85 line-clamp-6"
+        >
+          {{ narrationText }}
+        </p>
+      </div>
+    </div>
+
+    <div class="kr-toolbar flex-wrap gap-2 border-t border-primary/10 pt-3">
+      <button
+        v-for="topic in topicButtons"
+        :key="topic.key"
+        type="button"
+        class="btn btn-outline btn-xs rounded-2xl"
+        :disabled="isNarratorResponding"
+        @click="selectTopic(topic)"
+      >
+        <Icon :name="topic.icon" class="h-3.5 w-3.5" />
+        {{ topic.title }}
+      </button>
+
+      <div class="flex min-w-0 flex-1 items-center gap-2">
+        <input
+          v-model="narratorMessage"
+          type="text"
+          class="input input-bordered input-sm min-w-0 flex-1 rounded-2xl bg-base-100 text-sm"
+          :placeholder="narratorPlaceholder"
+          :disabled="!canUseNarrator || isNarratorResponding"
+          @keydown.enter.prevent="sendNarratorMessage"
+        />
+        <button
+          type="button"
+          class="btn btn-primary btn-sm shrink-0 rounded-2xl text-white"
+          :disabled="!canSendNarrator"
+          @click="sendNarratorMessage"
+        >
+          <span
+            v-if="isNarratorResponding"
+            class="loading loading-spinner loading-xs"
+          />
+          <Icon v-else name="kind-icon:send" class="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useNarratorStore } from '@/stores/narratorStore'
+
+const props = defineProps<{
+  stageImage?: string | null
+}>()
+
+const narratorStore = useNarratorStore()
+
+const {
+  narratorName,
+  currentEmotionLabel,
+  narratorImage,
+  narratorIntro,
+  narratorThreads,
+  narratorSession,
+  narratorMessage,
+  isNarratorResponding,
+  canUseNarrator,
+  canSendNarrator,
+  narratorPlaceholder,
+} = storeToRefs(narratorStore)
+
+const { initialize, sendNarratorMessage, disposeTimers, teardownLiveness } =
+  narratorStore
+
+const stageAlt = computed(() => `${narratorName.value}'s stage`)
+
+const narrationText = computed(() => {
+  const lastReply = [...narratorSession.value]
+    .reverse()
+    .find((chat) => chat.botResponse)?.botResponse
+
+  return lastReply || narratorIntro.value
+})
+
+const topicButtons = computed(() => {
+  return narratorThreads.value.slice(0, 4).map((thread) => {
+    const topic = thread.Topic
+    return {
+      key: `thread-${thread.id}`,
+      title: thread.title || topic?.title || 'Narrator thread',
+      icon: topic?.icon || 'kind-icon:message',
+      prompt: topic?.sampleUserPrompt || topic?.prompt || thread.guidance || '',
+    }
+  })
+})
+
+function selectTopic(topic: { prompt: string }): void {
+  if (topic.prompt) {
+    narratorMessage.value = topic.prompt
+  }
+}
+
+onMounted(async () => {
+  await initialize()
+})
+
+onBeforeUnmount(() => {
+  disposeTimers()
+  teardownLiveness()
+})
+</script>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -4,18 +4,15 @@
      users choose story ingredients, never image-model settings. -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4"
+    class="kr-surface gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
   >
-    <header class="flex items-start gap-3">
+    <header class="flex shrink-0 items-start gap-3">
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-secondary/30 bg-secondary/10 text-secondary"
       >
         <Icon name="kind-icon:gearhammer" class="size-6" />
       </div>
       <div class="min-w-0 flex-1">
-        <p class="text-xs font-bold uppercase tracking-wide text-secondary/70">
-          Taskmaster
-        </p>
         <h2 class="text-2xl font-black leading-tight">
           Turn the next real thing into an adventure
         </h2>
@@ -48,232 +45,235 @@
       </div>
     </header>
 
-    <div
-      v-if="!store.session"
-      class="space-y-5 rounded-2xl border border-secondary/20 bg-secondary/5 p-4"
-    >
-      <div>
-        <h3 class="text-xs font-bold uppercase tracking-wide text-secondary/70">
-          Build the quest
-        </h3>
-        <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-          Story choices direct the art automatically. Model, sampler, step-count,
-          and other generator controls stay out of the way.
-        </p>
-      </div>
+    <LazyKrNarratorStage :stage-image="tabImage" class="shrink-0" />
 
-      <label class="form-control w-full">
-        <div class="label py-1">
-          <span class="label-text text-xs font-bold uppercase tracking-wide">
-            What do you need to accomplish?
-          </span>
-        </div>
-        <textarea
-          v-model="taskInput"
-          rows="2"
-          class="textarea textarea-bordered w-full rounded-xl text-sm leading-relaxed"
-          placeholder="Clean the garage, finish the proposal, decide which feature ships next…"
-          :disabled="store.isWeaving"
-        />
-        <div class="label py-1">
-          <span class="label-text-alt text-base-content/45">
-            You can enter a task directly, link a project below, or use both.
-          </span>
-        </div>
-      </label>
+    <div class="kr-scroll space-y-4">
+      <template v-if="!store.session">
+        <TaskmasterSampleTasks />
 
-      <label class="form-control w-full max-w-xl">
-        <div class="label py-1">
-          <span class="label-text text-xs font-bold uppercase tracking-wide">
-            Project or task source (optional)
-          </span>
+        <div class="space-y-5 rounded-2xl border border-secondary/20 bg-secondary/5 p-4">
+          <div>
+            <h3 class="text-xs font-bold uppercase tracking-wide text-secondary/70">
+              Build the quest
+            </h3>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Story choices direct the art automatically. Model, sampler, step-count,
+              and other generator controls stay out of the way.
+            </p>
+          </div>
+
+          <label class="form-control w-full">
+            <div class="label py-1">
+              <span class="label-text text-xs font-bold uppercase tracking-wide">
+                What do you need to accomplish?
+              </span>
+            </div>
+            <textarea
+              v-model="taskInput"
+              rows="2"
+              class="textarea textarea-bordered w-full rounded-xl text-sm leading-relaxed"
+              placeholder="Clean the garage, finish the proposal, decide which feature ships next…"
+              :disabled="store.isWeaving"
+            />
+            <div class="label py-1">
+              <span class="label-text-alt text-base-content/45">
+                You can enter a task directly, link a project below, or use both.
+              </span>
+            </div>
+          </label>
+
+          <label class="form-control w-full max-w-xl">
+            <div class="label py-1">
+              <span class="label-text text-xs font-bold uppercase tracking-wide">
+                Project or task source (optional)
+              </span>
+            </div>
+            <select
+              v-model="selectedProjectSlug"
+              class="select select-bordered w-full rounded-xl"
+              :disabled="store.isWeaving"
+            >
+              <option value="">No linked project</option>
+              <option
+                v-for="project in projectStore.activeProjects"
+                :key="project.slug ?? project.id"
+                :value="project.slug"
+              >
+                {{ project.title || project.slug }}
+              </option>
+            </select>
+          </label>
+
+          <div class="space-y-2">
+            <p class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+              Tone
+            </p>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="tone in TASKMASTER_TONES"
+                :key="tone"
+                type="button"
+                class="btn btn-sm rounded-xl capitalize"
+                :class="
+                  tone === selectedTone
+                    ? 'btn-secondary'
+                    : 'btn-ghost border border-base-300 bg-base-100'
+                "
+                :aria-pressed="tone === selectedTone"
+                @click="selectedTone = tone"
+              >
+                {{ tone }}
+              </button>
+            </div>
+          </div>
+
+          <NarrativeIngredientPicker
+            v-model="selectedLocationSlug"
+            :items="locationOptions"
+            label="Setting"
+            helper="Choose a reusable LOCATION Dream. Artwork is shown when the location already has it."
+            empty-label="Anywhere"
+            empty-description="Let Taskmaster choose a setting that fits the objective and tone."
+            empty-icon="kind-icon:dream"
+            empty-state="No active LOCATION Dreams are available yet."
+            :disabled="store.isWeaving"
+            :loading="dreamStore.loading"
+            :error="dreamStore.error"
+            :initial-limit="5"
+          />
+
+          <NarrativeIngredientPicker
+            v-model="selectedGrammarSlug"
+            :items="grammarOptions"
+            label="Genre, mood, and style"
+            helper="Choose from the canonical Facet library. Cards use Facet artwork first and fall back to the Facet icon."
+            empty-label="Any adventure"
+            empty-description="Let Taskmaster choose the genre and story grammar automatically."
+            empty-icon="kind-icon:story"
+            empty-state="No active narrative Facets are available yet."
+            :disabled="store.isWeaving"
+            :loading="facetStore.loading"
+            :error="facetStore.error"
+            :initial-limit="8"
+          />
+
+          <label class="form-control w-full">
+            <div class="label py-1">
+              <span class="label-text text-xs font-bold uppercase tracking-wide">
+                Extra flavor (optional)
+              </span>
+            </div>
+            <input
+              v-model="vibeInput"
+              type="text"
+              placeholder="storm-lit, clockwork, defiant"
+              class="input input-bordered w-full rounded-xl bg-base-100"
+              :disabled="store.isWeaving"
+            />
+          </label>
+
+          <p v-if="store.errorMessage" class="text-xs text-error">
+            {{ store.errorMessage }}
+          </p>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              class="btn btn-secondary rounded-xl"
+              :disabled="store.isWeaving || !canBegin"
+              @click="begin(false)"
+            >
+              <span
+                v-if="store.isWeaving"
+                class="loading loading-dots loading-sm"
+              />
+              <template v-else>
+                <Icon name="kind-icon:gearhammer" class="size-4" /> Begin quest
+              </template>
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
+              :disabled="store.isWeaving || !canBegin"
+              @click="begin(true)"
+            >
+              <Icon name="kind-icon:wand" class="size-4" /> Surprise me
+            </button>
+            <p v-if="!canBegin" class="text-xs text-base-content/50">
+              Enter an objective or choose a linked project to begin.
+            </p>
+          </div>
         </div>
-        <select
-          v-model="selectedProjectSlug"
-          class="select select-bordered w-full rounded-xl"
-          :disabled="store.isWeaving"
+      </template>
+
+      <div
+        v-else-if="store.session.status === 'draft'"
+        class="space-y-4 rounded-2xl border border-secondary/25 bg-secondary/5 p-4"
+      >
+        <div>
+          <p class="text-xs font-bold uppercase tracking-wide text-secondary/70">
+            Review the practical plan
+          </p>
+          <h3 class="mt-1 text-xl font-black">The quest starts with real checkpoints</h3>
+          <p class="mt-1 text-sm leading-relaxed text-base-content/60">
+            Taskmaster will weave these actions into the fiction in order. The plan is
+            saved before narration begins, and no external task changes happen without
+            an explicit Apply action.
+          </p>
+        </div>
+        <article
+          v-for="(checkpoint, index) in store.session.checkpoints"
+          :key="checkpoint.id"
+          class="rounded-2xl border border-base-300 bg-base-100 p-3"
         >
-          <option value="">No linked project</option>
-          <option
-            v-for="project in projectStore.activeProjects"
-            :key="project.slug ?? project.id"
-            :value="project.slug"
-          >
-            {{ project.title || project.slug }}
-          </option>
-        </select>
-      </label>
-
-      <div class="space-y-2">
-        <p class="text-xs font-bold uppercase tracking-wide text-base-content/55">
-          Tone
-        </p>
+          <div class="flex items-start gap-3">
+            <span class="badge badge-secondary badge-sm mt-0.5 rounded-xl">
+              {{ index + 1 }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="font-bold">{{ checkpoint.title }}</p>
+              <p v-if="checkpoint.detail" class="mt-1 text-xs text-base-content/55">
+                {{ checkpoint.detail }}
+              </p>
+              <p class="mt-1 text-[0.7rem] uppercase tracking-wide text-base-content/40">
+                {{ checkpoint.sourceKind.replace('-', ' ') }}
+              </p>
+            </div>
+          </div>
+        </article>
         <div class="flex flex-wrap gap-2">
           <button
-            v-for="tone in TASKMASTER_TONES"
-            :key="tone"
             type="button"
-            class="btn btn-sm rounded-xl capitalize"
-            :class="
-              tone === selectedTone
-                ? 'btn-secondary'
-                : 'btn-ghost border border-base-300 bg-base-100'
-            "
-            :aria-pressed="tone === selectedTone"
-            @click="selectedTone = tone"
+            class="btn btn-secondary rounded-xl"
+            :disabled="store.isWeaving || !store.session.checkpoints.length"
+            @click="store.startQuest()"
           >
-            {{ tone }}
+            <Icon name="kind-icon:story" class="size-4" /> Start the adventure
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
+            :disabled="store.isWeaving"
+            @click="startOver"
+          >
+            Edit setup
           </button>
         </div>
       </div>
 
-      <NarrativeIngredientPicker
-        v-model="selectedLocationSlug"
-        :items="locationOptions"
-        label="Setting"
-        helper="Choose a reusable LOCATION Dream. Artwork is shown when the location already has it."
-        empty-label="Anywhere"
-        empty-description="Let Taskmaster choose a setting that fits the objective and tone."
-        empty-icon="kind-icon:dream"
-        empty-state="No active LOCATION Dreams are available yet."
-        :disabled="store.isWeaving"
-        :loading="dreamStore.loading"
-        :error="dreamStore.error"
-        :initial-limit="5"
-      />
-
-      <NarrativeIngredientPicker
-        v-model="selectedGrammarSlug"
-        :items="grammarOptions"
-        label="Genre, mood, and style"
-        helper="Choose from the canonical Facet library. Cards use Facet artwork first and fall back to the Facet icon."
-        empty-label="Any adventure"
-        empty-description="Let Taskmaster choose the genre and story grammar automatically."
-        empty-icon="kind-icon:story"
-        empty-state="No active narrative Facets are available yet."
-        :disabled="store.isWeaving"
-        :loading="facetStore.loading"
-        :error="facetStore.error"
-        :initial-limit="8"
-      />
-
-      <label class="form-control w-full">
-        <div class="label py-1">
-          <span class="label-text text-xs font-bold uppercase tracking-wide">
-            Extra flavor (optional)
-          </span>
+      <template v-else>
+        <div
+          v-if="store.session.seed.taskTitle"
+          class="rounded-2xl border border-info/30 bg-info/5 p-3"
+        >
+          <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/80">
+            Real objective
+          </p>
+          <p class="mt-1 text-sm font-semibold">
+            {{ store.session.seed.taskTitle }}
+          </p>
         </div>
-        <input
-          v-model="vibeInput"
-          type="text"
-          placeholder="storm-lit, clockwork, defiant"
-          class="input input-bordered w-full rounded-xl bg-base-100"
-          :disabled="store.isWeaving"
-        />
-      </label>
 
-      <p v-if="store.errorMessage" class="text-xs text-error">
-        {{ store.errorMessage }}
-      </p>
-
-      <div class="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          class="btn btn-secondary rounded-xl"
-          :disabled="store.isWeaving || !canBegin"
-          @click="begin(false)"
-        >
-          <span
-            v-if="store.isWeaving"
-            class="loading loading-dots loading-sm"
-          />
-          <template v-else>
-            <Icon name="kind-icon:gearhammer" class="size-4" /> Begin quest
-          </template>
-        </button>
-        <button
-          type="button"
-          class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
-          :disabled="store.isWeaving || !canBegin"
-          @click="begin(true)"
-        >
-          <Icon name="kind-icon:wand" class="size-4" /> Surprise me
-        </button>
-        <p v-if="!canBegin" class="text-xs text-base-content/50">
-          Enter an objective or choose a linked project to begin.
-        </p>
-      </div>
-    </div>
-
-    <div
-      v-else-if="store.session.status === 'draft'"
-      class="space-y-4 rounded-2xl border border-secondary/25 bg-secondary/5 p-4"
-    >
-      <div>
-        <p class="text-xs font-bold uppercase tracking-wide text-secondary/70">
-          Review the practical plan
-        </p>
-        <h3 class="mt-1 text-xl font-black">The quest starts with real checkpoints</h3>
-        <p class="mt-1 text-sm leading-relaxed text-base-content/60">
-          Taskmaster will weave these actions into the fiction in order. The plan is
-          saved before narration begins, and no external task changes happen without
-          an explicit Apply action.
-        </p>
-      </div>
-      <article
-        v-for="(checkpoint, index) in store.session.checkpoints"
-        :key="checkpoint.id"
-        class="rounded-2xl border border-base-300 bg-base-100 p-3"
-      >
-        <div class="flex items-start gap-3">
-          <span class="badge badge-secondary badge-sm mt-0.5 rounded-xl">
-            {{ index + 1 }}
-          </span>
-          <div class="min-w-0 flex-1">
-            <p class="font-bold">{{ checkpoint.title }}</p>
-            <p v-if="checkpoint.detail" class="mt-1 text-xs text-base-content/55">
-              {{ checkpoint.detail }}
-            </p>
-            <p class="mt-1 text-[0.7rem] uppercase tracking-wide text-base-content/40">
-              {{ checkpoint.sourceKind.replace('-', ' ') }}
-            </p>
-          </div>
-        </div>
-      </article>
-      <div class="flex flex-wrap gap-2">
-        <button
-          type="button"
-          class="btn btn-secondary rounded-xl"
-          :disabled="store.isWeaving || !store.session.checkpoints.length"
-          @click="store.startQuest()"
-        >
-          <Icon name="kind-icon:story" class="size-4" /> Start the adventure
-        </button>
-        <button
-          type="button"
-          class="btn btn-ghost rounded-xl border border-base-300 bg-base-100"
-          :disabled="store.isWeaving"
-          @click="startOver"
-        >
-          Edit setup
-        </button>
-      </div>
-    </div>
-
-    <div v-else class="flex min-h-0 flex-1 flex-col gap-3">
-      <div
-        v-if="store.session.seed.taskTitle"
-        class="rounded-2xl border border-info/30 bg-info/5 p-3"
-      >
-        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/80">
-          Real objective
-        </p>
-        <p class="mt-1 text-sm font-semibold">
-          {{ store.session.seed.taskTitle }}
-        </p>
-      </div>
-
-      <div class="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         <section
           v-if="store.session.checkpoints.length"
           class="space-y-3 rounded-2xl border border-secondary/20 bg-secondary/5 p-3"
@@ -442,76 +442,88 @@
             </div>
           </article>
         </div>
-      </div>
-
-      <section
-        v-if="!store.isComplete && store.awaitingAnswer && store.currentCheckpoint"
-        class="space-y-2 rounded-2xl border border-info/25 bg-info/5 p-3"
-      >
-        <div>
-          <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/75">
-            What happened in the real world?
-          </p>
-          <p class="mt-1 text-xs text-base-content/55">
-            Choose the honest checkpoint outcome, then describe what happened below.
-          </p>
-        </div>
-        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-          <button
-            v-for="outcome in checkpointOutcomes"
-            :key="outcome.value"
-            type="button"
-            class="rounded-xl border p-2 text-left text-xs transition"
-            :class="
-              selectedOutcome === outcome.value
-                ? 'border-info bg-info text-info-content'
-                : 'border-base-300 bg-base-100 hover:border-info/50'
-            "
-            :aria-pressed="selectedOutcome === outcome.value"
-            @click="selectedOutcome = outcome.value"
-          >
-            <span class="font-bold">{{ outcome.label }}</span>
-            <span class="mt-0.5 block opacity-70">{{ outcome.helper }}</span>
-          </button>
-        </div>
-      </section>
-
-      <section
-        v-if="store.canClose"
-        class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-success/30 bg-success/5 p-3"
-      >
-        <div>
-          <p class="text-sm font-bold text-success">All checkpoints have an outcome</p>
-          <p class="mt-0.5 text-xs text-base-content/55">
-            Finish the quest for a practical recap of completed, blocked, deferred,
-            and missing-information items.
-          </p>
-        </div>
-        <button
-          type="button"
-          class="btn btn-success btn-sm rounded-xl"
-          @click="store.closeStory()"
-        >
-          Finish the quest
-        </button>
-      </section>
-
-      <NarrativeResponseComposer
-        v-if="!store.isComplete && !store.canClose"
-        v-model="answerInput"
-        :options="store.currentBeat?.question.options ?? []"
-        :disabled="!store.awaitingAnswer"
-        :loading="store.isWeaving"
-        :placeholder="
-          store.awaitingAnswer
-            ? 'What do you do?'
-            : 'Taskmaster is building the next scene…'
-        "
-        button-label="Continue"
-        hint="Story answers become proposed progress first. Real task changes still require an explicit Apply action."
-        @submit="submitAnswer"
-      />
+      </template>
     </div>
+
+    <section
+      v-if="
+        store.session &&
+        store.session.status !== 'draft' &&
+        !store.isComplete &&
+        store.awaitingAnswer &&
+        store.currentCheckpoint
+      "
+      class="shrink-0 space-y-2 rounded-2xl border border-info/25 bg-info/5 p-3"
+    >
+      <div>
+        <p class="text-[0.7rem] font-bold uppercase tracking-wide text-info/75">
+          What happened in the real world?
+        </p>
+        <p class="mt-1 text-xs text-base-content/55">
+          Choose the honest checkpoint outcome, then describe what happened below.
+        </p>
+      </div>
+      <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <button
+          v-for="outcome in checkpointOutcomes"
+          :key="outcome.value"
+          type="button"
+          class="rounded-xl border p-2 text-left text-xs transition"
+          :class="
+            selectedOutcome === outcome.value
+              ? 'border-info bg-info text-info-content'
+              : 'border-base-300 bg-base-100 hover:border-info/50'
+          "
+          :aria-pressed="selectedOutcome === outcome.value"
+          @click="selectedOutcome = outcome.value"
+        >
+          <span class="font-bold">{{ outcome.label }}</span>
+          <span class="mt-0.5 block opacity-70">{{ outcome.helper }}</span>
+        </button>
+      </div>
+    </section>
+
+    <section
+      v-if="store.session && store.session.status !== 'draft' && store.canClose"
+      class="flex shrink-0 flex-wrap items-center justify-between gap-3 rounded-2xl border border-success/30 bg-success/5 p-3"
+    >
+      <div>
+        <p class="text-sm font-bold text-success">All checkpoints have an outcome</p>
+        <p class="mt-0.5 text-xs text-base-content/55">
+          Finish the quest for a practical recap of completed, blocked, deferred,
+          and missing-information items.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-success btn-sm rounded-xl"
+        @click="store.closeStory()"
+      >
+        Finish the quest
+      </button>
+    </section>
+
+    <NarrativeResponseComposer
+      v-if="
+        store.session &&
+        store.session.status !== 'draft' &&
+        !store.isComplete &&
+        !store.canClose
+      "
+      v-model="answerInput"
+      class="shrink-0"
+      :options="store.currentBeat?.question.options ?? []"
+      :disabled="!store.awaitingAnswer"
+      :loading="store.isWeaving"
+      :placeholder="
+        store.awaitingAnswer
+          ? 'What do you do?'
+          : 'Taskmaster is building the next scene…'
+      "
+      button-label="Continue"
+      hint="Story answers become proposed progress first. Real task changes still require an explicit Apply action."
+      @submit="submitAnswer"
+    />
   </section>
 </template>
 
@@ -519,6 +531,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useDreamStore } from '@/stores/dreamStore'
 import { useFacetStore } from '@/stores/facetStore'
+import { getDashboardTabImagePath } from '@/stores/helpers/dashboardHelper'
 import { useProjectStore } from '@/stores/projectStore'
 import {
   TASKMASTER_TONES,
@@ -537,6 +550,10 @@ const store = useTaskmasterStore()
 const dreamStore = useDreamStore()
 const facetStore = useFacetStore()
 const projectStore = useProjectStore()
+
+const tabImage = computed(() =>
+  getDashboardTabImagePath('scenario', 'taskmaster'),
+)
 
 const taskInput = ref('')
 const selectedTone = ref<TaskmasterTone>('adventurous')

--- a/content/taskmaster.md
+++ b/content/taskmaster.md
@@ -14,6 +14,4 @@ dashboardTab: taskmaster
 cards: navCards
 ---
 
-:taskmaster-sample-tasks
-
 :taskmaster-page

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -26,7 +26,6 @@
       "components/butterfly/butterfly-sanctuary.vue",
       "components/characters/character-flip-card.vue",
       "components/characters/character-interact.vue",
-      "components/conductor/storymaker-page.vue",
       "components/dreams/dream-brainstorm.vue",
       "components/giftshop/giftshop-manager.vue",
       "components/navigation/channel-select.vue",
@@ -34,7 +33,6 @@
       "components/pages/conductor-page.vue",
       "components/pages/memory-dungeon.vue",
       "components/pages/serendipity-page.vue",
-      "components/pages/taskmaster-page.vue",
       "components/rewards/reward-interact.vue",
       "components/scenarios/scenario-gallery.vue",
       "components/scenarios/scenario-interact.vue",
@@ -57,8 +55,7 @@
     "one-mdc": [
       "content/about.md",
       "content/conductor.md",
-      "content/plan/wonderlab.md",
-      "content/taskmaster.md"
+      "content/plan/wonderlab.md"
     ],
     "ghost-prop": [
       "components/art/art-manager.vue → <art-gallery>",

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -179,7 +179,20 @@ function collect(): Record<RuleId, string[]> {
       violations['one-header'].push(r)
     }
 
-    const scrollers = countMatches(template, /overflow-y-auto|overflow-auto/g)
+    /*
+     * .kr-scroll (interface-vision t-004) is the primitive's own scroll-owner
+     * class (`min-h-0 flex-1 overflow-y-auto overscroll-contain`) — a page
+     * that adopts it declares its scroll region through the class, not a raw
+     * overflow-y-auto utility string. Count both so pages can actually adopt
+     * the primitive without reading as zero-scroll (t-004 shipped the class
+     * before this file was updated to recognize it). Only match `kr-scroll`
+     * inside an actual class attribute, not a `.kr-scroll` mention in style-
+     * guide documentation prose (e.g. components/ui/ui-gallery.vue's <code>
+     * reference to the class name).
+     */
+    const scrollers =
+      countMatches(template, /overflow-y-auto|overflow-auto/g) +
+      countMatches(template, /class="[^"]*\bkr-scroll\b[^"]*"/g)
     if (scrollers > 1) violations['one-scroll'].push(r)
     if (
       scrollers === 0 &&

--- a/utils/scripts/verifyTaskmasterSampleTasks.mjs
+++ b/utils/scripts/verifyTaskmasterSampleTasks.mjs
@@ -6,8 +6,15 @@ const samples = fs.readFileSync(
   'components/taskmaster/taskmaster-sample-tasks.vue',
   'utf8',
 )
+const page = fs.readFileSync('components/pages/taskmaster-page.vue', 'utf8')
 
-assert.match(content, /:taskmaster-sample-tasks\s+\n:taskmaster-page/)
+// interface-vision/t-006: content/taskmaster.md now mounts exactly one
+// top-level MDC component (:taskmaster-page) to satisfy the layout
+// contract's one-mdc rule. TaskmasterSampleTasks is composed inside
+// taskmaster-page.vue instead of as a second sibling MDC block.
+assert.match(content, /^:taskmaster-page\s*$/m)
+assert.doesNotMatch(content, /:taskmaster-sample-tasks/)
+assert.match(page, /<TaskmasterSampleTasks/)
 assert.match(
   samples,
   /Look at my conductor repo and help me clear any current human gates\./,


### PR DESCRIPTION
### Task
interface-vision/t-006: Build the narrator stage and restore narrators to Storymaker and Taskmaster (kind: software)

### What changed / what I produced
- New `components/narrative/kr-narrator-stage.vue`: the narrator as a first-class in-flow region — large art plate (page art + narrator portrait/mood), a narration window, and a pinned action rail with topic quick-buttons + free-text input — instead of the existing `pointer-events-none absolute inset-y-0 right-0 z-40` overlay drawer (`workspace-narrator.vue`, left untouched, still used by `dream-interact.vue`).
- Mounted via `<LazyKrNarratorStage>` on both `storymaker-page.vue` and `taskmaster-page.vue`, matching the existing `dream-interact.vue` Lazy-mount precedent so `narratorStore`'s eager 9-store composition stays out of these pages' first-paint bundle.
- Wired `dashboardHelper`'s existing `scenario/taskmaster` and `scenario/storymaker` tab images into the stage's art plate (previously only used as a faint ambient background in `workspace-header.vue`, never rendered as real page content — both pages rendered zero `<img>` before this).
- Collapsed both pages from 2 scroll regions to 1: header + narrator stage are `shrink-0`, all wizard/session states share one `.kr-scroll` region, and the response composer / outcome actions are pinned outside it as the persistent action rail.
- Removed the redundant "Taskmaster"/"Storymaker" eyebrow `<p>` label in each page's header (the shell already renders the page title from content frontmatter via `workspace-header.vue`).
- Collapsed `content/taskmaster.md`'s duplicate MDC mount to one (`:taskmaster-page`); `TaskmasterSampleTasks` now composes inside `taskmaster-page.vue` rather than as a sibling top-level MDC block. Updated `verifyTaskmasterSampleTasks.mjs`'s contract assertion accordingly — it previously hard-locked the two-block content structure.
- Fixed `verifyLayoutContract.ts`'s `one-scroll`/`zero-scroll` detection to also recognize the `.kr-scroll` primitive class (shipped in t-004, after this verifier was built in t-005) as a real scroll region, not just the raw `overflow-y-auto` string — otherwise no page could ever adopt the primitive without reading as `zero-scroll`. Scoped narrowly to an actual `class="..."` attribute so `.kr-scroll` mentioned in `ui-gallery.vue`'s style-guide documentation isn't miscounted as usage.
- Ratcheted the layout-contract baseline down (`one-scroll` -2, `one-mdc` -1).

### How I verified
- `npm run test` (vue-tsc --noEmit) — clean.
- `npx eslint` on all changed files — clean.
- `npx prettier --check` on all changed files — clean (confirmed via `git stash` that the pre-existing long-line drift in `taskmaster-page.vue`/`storymaker-page.vue` predates this PR; only my own new lines needed formatting, plus a necessary whole-file reindent in `storymaker-page.vue` from the new wrapper div, sanity-diffed with `-b -w` to confirm it's whitespace-only).
- `npm run test:layout-contract` — holds, no new violations, baseline ratcheted down.
- `node utils/scripts/verifyTaskmasterSampleTasks.mjs` — passes against the updated contract.
- `npm run test:channel-content` — passes (content/taskmaster.md still resolves).
- All Storymaker/Taskmaster/narrative contract verifiers pass: `verifyNarrativePrimitives`, `verifyStorymakerBranchState`, `verifyStorymakerSessionLibrary`, `verifyStorymakerStudio`, `verifyTaskmasterCheckpointEngine`, `verifyNarrativeArtPersistence`, `verifyFacetTaxonomyAuthority`.
- Sandbox has no DB, so no live/Vercel-preview visual check yet — flagged below.

### Stakes
reversible

### Flags for Reviewer
- No Vercel preview check performed (this session's sandbox route). Worth a visual pass on phone/tablet/desktop widths per the task's own exit note before considering this fully verified — layout-contract and the contract scripts confirm structure/composition, not visual polish.
- `kr-narrator-stage.vue`'s free-text/topic-button rail talks to `narratorStore`'s own side chat (the same one the drawer uses), not the page's own story-session engine (`storymakerStore`/`taskmasterStore`, driven separately by `NarrativeResponseComposer`). This matches how the store is actually built (there's no other narrator-chat channel to attach to) but is worth a second look — Silas's own framing ("narrator carries your choices forward") could be read as wanting the narrator itself to host the story session rather than a separate side-conversation next to it.
- Did not restructure either page's containers onto `.kr-surface`/`.kr-toolbar` primitives beyond what was needed for the scroll-region collapse — left as future adoption work, consistent with t-004's own note that full primitive adoption needs live-preview verification this sandbox can't do.
- Did not attempt the narrator's full topic/thread chat UI (flip-card portrait, emoji bursts, musing toasts) — kept the new stage's own scope small and robust; the overlay drawer's much larger state machine stays exactly where it is for dream contexts.

### Kaizen suggestion
Now that a second `.kr-scroll` consumer exists (this PR) beyond the original primitive-authoring task, add a `.kr-surface`-root-class conformance check to `verifyLayoutContract.ts` (t-005's own note flagged this as never implemented since t-004 hadn't shipped yet) — worth doing now that there's real usage to validate against, rather than continuing to defer it.

### Notes for reviewer
Companion conductor task: interface-vision/t-006 (roadmap.yaml), claimed this session (`claude-agentrun-2026-08-01T18:26:55-t006`). Will close it out to `done` in a separate conductor PR once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYAzJ24AtG44Ky6s9vj1N9)_