### PR TITLE
docs: remove stale deleted-gallery reference

### DIFF
--- a/components/conductor/projectFront.ts
+++ b/components/conductor/projectFront.ts
@@ -6,9 +6,8 @@
 // page always renders something styled even when no public DB row exists yet.
 //
 // Conventions verified against ecosystem-map/TAB-INTEGRATION.md and
-// kind_robots/sample/new-section.md. Art paths mirror
-// conductor-overview-gallery-page.vue (local public asset first, conductor repo
-// raw asset as the fallback).
+// kind_robots/sample/new-section.md. Art paths mirror the canonical project
+// gallery fallback chain (local public asset first, conductor repo raw asset).
 
 const CONDUCTOR_IMAGE_BASE =
   'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
@@ -46,7 +45,6 @@ export type ProjectFrontSection = {
 export type ProjectFrontStat = {
   label: string
   value: string
-  icon?: string
 }
 
 /**

--- a/components/conductor/projectFront.ts
+++ b/components/conductor/projectFront.ts
@@ -45,6 +45,7 @@ export type ProjectFrontSection = {
 export type ProjectFrontStat = {
   label: string
   value: string
+  icon?: string
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace the stale `conductor-overview-gallery-page.vue` comment reference after that dead component was deleted
- describe the actual canonical project-gallery fallback behavior instead

## Verification
- compared branch to current `main`; diff is comment-only in `components/conductor/projectFront.ts`
- no runtime behavior or types changed

Rotating maintenance audit area: stale component/import references and dead aliases.