### PR TITLE
Add the out-of-band Facet catalog maintenance workflow (t-051)

### DIFF
--- a/.github/workflows/facet-catalog-maintenance.yml
+++ b/.github/workflows/facet-catalog-maintenance.yml
@@ -1,0 +1,113 @@
+name: Facet Catalog Maintenance
+
+# Runs the serialized Facet catalog maintenance OUT OF BAND, off the deploy path.
+#
+# WHY THIS EXISTS (kind-robots/t-051)
+# Facet catalog maintenance used to run inside the Vercel production build, and
+# scripts/vercel-build.mjs treated a non-zero exit as fatal. Because `nuxt build`
+# runs last, a failure here meant the application was never even compiled — nine
+# consecutive production deploys died this way between 13:15 and 15:00 UTC on
+# 2026-08-01 while the live site sat frozen on PR #1253.
+#
+# The build no longer runs the maintenance at all; it just logs "run
+# scripts/run_facet_catalog_maintenance.ts explicitly". This workflow is the
+# thing that runs it. Without it that instruction points at nothing and the
+# catalog silently stops being maintained — utils/scripts/
+# verifyFacetCatalogMaintenance.ts asserts this file exists for exactly that
+# reason.
+#
+# The run still takes the MySQL named lock inside
+# run_facet_catalog_maintenance.ts, so a manual dispatch cannot collide with the
+# weekly schedule, with a second dispatch, or with anyone running the script by
+# hand. Deploys no longer contend for it.
+#
+# Required secrets (repository Actions secrets: Settings → Secrets and variables
+# → Actions → New repository secret) — identical to the nightly fallback
+# snapshot, which is the proven working pattern for reaching this database:
+#   DATABASE_URL            mysql://user:pass@host:port/db — host must be the
+#                           Unraid machine's TAILNET address, not its public
+#                           hostname. GitHub-hosted runner IPs cannot reach the
+#                           database directly.
+#   DATABASE_SSL_CA_BASE64  base64 PEM of the CA signing ProxySQL's cert (or
+#                           DATABASE_SSL_CA for the raw PEM). ProxySQL ENFORCES
+#                           TLS; without this the connection is refused with
+#                           "Access denied ... SSL is required".
+#   TS_OAUTH_CLIENT_ID      Tailscale OAuth client (scope: Auth Keys, tag:ci)
+#   TS_OAUTH_SECRET
+
+on:
+  schedule:
+    - cron: '41 10 * * 1' # Mondays, 10:41 UTC ≈ 2:41am Pacific
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: 'Run the canonical catalog seed as well as the curation steps'
+        type: boolean
+        default: true
+
+concurrency:
+  group: facet-catalog-maintenance
+  cancel-in-progress: false
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    # The full run is ~13 sequential child steps and has been observed taking
+    # ~45 minutes. Generous ceiling so a slow-but-healthy run is not killed.
+    timeout-minutes: 90
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
+      DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
+    steps:
+      - name: Require secrets
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL is empty. Add it as a REPOSITORY ACTIONS SECRET (Settings → Secrets and variables → Actions). Vercel env vars and .env files do not resolve here."
+            exit 1
+          fi
+          if [ -z "$TS_OAUTH_CLIENT_ID" ] || [ -z "$TS_OAUTH_SECRET" ]; then
+            echo "::error::TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET are empty. The database is not reachable from GitHub runner IPs without joining the tailnet."
+            exit 1
+          fi
+          if [ -z "$DATABASE_SSL_CA_BASE64" ] && [ -z "$DATABASE_SSL_CA" ]; then
+            echo "::warning::No database CA secret set. ProxySQL enforces TLS, so this run will likely fail with 'Access denied ... SSL is required'."
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      # Joined late so the tailnet session stays as short as possible.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Run serialized Facet catalog maintenance
+        run: |
+          if [ "${{ inputs.seed }}" = "false" ]; then
+            SEED_FLAG="--skip-seed"
+          else
+            SEED_FLAG="--seed"
+          fi
+          echo "Running with $SEED_FLAG"
+          npx tsx scripts/run_facet_catalog_maintenance.ts \
+            "$SEED_FLAG" \
+            "--reason=out-of-band ${{ github.event_name }} run"

--- a/scripts/run_facet_catalog_maintenance.ts
+++ b/scripts/run_facet_catalog_maintenance.ts
@@ -21,7 +21,8 @@ const runCanonicalSeed = process.argv.includes('--seed')
 const reasonArgument = process.argv.find((argument) =>
   argument.startsWith('--reason='),
 )
-const seedReason = reasonArgument?.slice('--reason='.length) || 'unspecified policy'
+const seedReason =
+  reasonArgument?.slice('--reason='.length) || 'unspecified policy'
 
 type Step = {
   script: string
@@ -82,7 +83,8 @@ const steps: Step[] = [
   {
     script: 'utils/scripts/applyFacetCatalogDirectives.ts',
     args: ['--apply'],
-    label: 'Applying final Facet catalog directives and deleting historical shells',
+    label:
+      'Applying final Facet catalog directives and deleting historical shells',
   },
   {
     script: 'utils/scripts/cleanupRetiredFacetShells.ts',
@@ -97,7 +99,8 @@ const steps: Step[] = [
   {
     script: 'scripts/generate_facet_art.ts',
     args: ['--write'],
-    label: 'Queueing missing primary Facet artwork after the full catalog audit',
+    label:
+      'Queueing missing primary Facet artwork after the full catalog audit',
   },
 ]
 
@@ -138,10 +141,10 @@ async function acquireLock(connection: PoolConnection): Promise<void> {
   console.log(
     `[facet-maintenance] Acquiring database lock ${LOCK_NAME} with ${LOCK_WAIT_SECONDS}s maximum wait.`,
   )
-  const rows = await connection.query(
-    'SELECT GET_LOCK(?, ?) AS acquired',
-    [LOCK_NAME, LOCK_WAIT_SECONDS],
-  )
+  const rows = await connection.query('SELECT GET_LOCK(?, ?) AS acquired', [
+    LOCK_NAME,
+    LOCK_WAIT_SECONDS,
+  ])
   if (acquiredValue(rows) !== 1) {
     throw new Error(
       `Could not acquire Facet catalog maintenance lock ${LOCK_NAME}.`,
@@ -179,17 +182,33 @@ async function main(): Promise<void> {
   let connection: PoolConnection | undefined
   let keepAlive: NodeJS.Timeout | undefined
   let lockAcquired = false
+  let lockSessionLost = false
 
   try {
     connection = await pool.getConnection()
     await acquireLock(connection)
     lockAcquired = true
 
+    /*
+     * The keepalive only reports; it deliberately never aborts the run. But it
+     * used to keep firing every 20s against an already-dead socket for the rest
+     * of a ~45 minute run, logging the same fatal error ~130 times and burying
+     * the step output that actually explains the failure. Stop after the first
+     * loss and record it, so teardown can skip a RELEASE_LOCK that cannot work.
+     * (A dead session releases its named lock automatically, so there is nothing
+     * to clean up on the server side.)
+     */
     keepAlive = setInterval(() => {
       void connection?.ping().catch((error: unknown) => {
+        if (lockSessionLost) return
+        lockSessionLost = true
+        if (keepAlive) clearInterval(keepAlive)
         console.error(
           '[facet-maintenance] Lost the database session holding the catalog lock.',
           error,
+        )
+        console.error(
+          '[facet-maintenance] Continuing without the lock. Remaining steps still run; concurrent maintenance is no longer excluded.',
         )
       })
     }, LOCK_PING_INTERVAL_MS)
@@ -203,15 +222,43 @@ async function main(): Promise<void> {
     for (const step of steps) await runStep(step)
   } finally {
     if (keepAlive) clearInterval(keepAlive)
-    if (connection && lockAcquired) {
+    if (connection && lockAcquired && !lockSessionLost) {
       try {
         await releaseLock(connection)
       } catch (error) {
-        console.error('[facet-maintenance] Failed to release named lock cleanly.', error)
+        console.error(
+          '[facet-maintenance] Failed to release named lock cleanly.',
+          error,
+        )
       }
     }
-    connection?.release()
-    await pool.end()
+    /*
+     * Teardown must never be able to fail the run on its own.
+     *
+     * These two calls used to be unguarded inside `finally`, so a throw from
+     * either -- which is exactly what a connection already destroyed by
+     * ER_CMD_CONNECTION_CLOSED produces -- propagated out of main() and became
+     * the process's exit code. That had two bad consequences: maintenance that
+     * had actually COMPLETED could still fail the production build, and the
+     * teardown error REPLACED the real step error in the logs, hiding the true
+     * cause. Both were live during the 2026-08-01 deploy outage.
+     */
+    try {
+      connection?.release()
+    } catch (error) {
+      console.error(
+        '[facet-maintenance] Ignoring connection release error during teardown.',
+        error,
+      )
+    }
+    try {
+      await pool.end()
+    } catch (error) {
+      console.error(
+        '[facet-maintenance] Ignoring pool shutdown error during teardown.',
+        error,
+      )
+    }
   }
 }
 

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -42,7 +42,9 @@ for (const required of [
 }
 
 assert.ok(
-  cleanup.includes('Retired Facet shells are migration scaffolding, not historical records.'),
+  cleanup.includes(
+    'Retired Facet shells are migration scaffolding, not historical records.',
+  ),
   'Cleanup policy must reject inactive merge shells as stored history.',
 )
 assert.ok(
@@ -92,14 +94,15 @@ for (const required of [
   "script: 'utils/scripts/auditFacetCatalogOddities.ts'",
   "script: 'scripts/generate_facet_art.ts'",
 ]) {
-  assert.ok(runner.includes(required), `Missing serialized runner contract: ${required}`)
+  assert.ok(
+    runner.includes(required),
+    `Missing serialized runner contract: ${required}`,
+  )
 }
 
 const seedHook = "script: 'utils/scripts/runFacetCatalogSeed.ts'"
-const directivesHook =
-  "script: 'utils/scripts/applyFacetCatalogDirectives.ts'"
-const cleanupHook =
-  "script: 'utils/scripts/cleanupRetiredFacetShells.ts'"
+const directivesHook = "script: 'utils/scripts/applyFacetCatalogDirectives.ts'"
+const cleanupHook = "script: 'utils/scripts/cleanupRetiredFacetShells.ts'"
 const auditHook = "script: 'utils/scripts/auditFacetCatalogOddities.ts'"
 const artHook = "script: 'scripts/generate_facet_art.ts'"
 
@@ -131,6 +134,24 @@ assert.ok(
 assert.ok(
   !build.includes("['utils/scripts/runFacetCatalogSeed.ts', '--apply']"),
   'Production build must not bypass the explicit Facet maintenance runner.',
+)
+
+/*
+ * kind-robots/t-051. The production build deliberately no longer runs Facet
+ * catalog maintenance (see the two assertions above) -- it was blocking deploys:
+ * nine consecutive production builds died there on 2026-08-01, and because
+ * `nuxt build` runs last in vercel-build.mjs the application was never compiled.
+ *
+ * But "the build must not run it" only makes sense paired with something that
+ * does. Without this workflow the build's own log line -- "run
+ * scripts/run_facet_catalog_maintenance.ts explicitly" -- points at nothing, and
+ * the catalog silently stops being maintained at all.
+ */
+assert.ok(
+  fs.existsSync(
+    path.join(root, '.github/workflows/facet-catalog-maintenance.yml'),
+  ),
+  'An out-of-band Facet catalog maintenance workflow must exist, because the production build no longer runs the maintenance itself.',
 )
 
 console.log('Facet catalog maintenance and artwork queue contract verified.')


### PR DESCRIPTION
Conflict resolved by rebasing onto #1269. **This PR is now much smaller than it was** — main solved the blocking problem better than I did, so most of my original change was dropped.

## What changed while this was open

Main **removed Facet catalog maintenance from the production build entirely**, rather than my approach of making it non-fatal. That's the better fix — it doesn't burn ~45 minutes on every deploy — and it already unblocked deploys.

`verifyFacetCatalogMaintenance.ts` on main now asserts the build must **not** invoke the runner, which is the direct opposite of my `{ fatal: false }` design. So that machinery is gone, and the seed-policy narrowing + force-OFF hatch went with it: `vercel-build.mjs` no longer imports `resolveFacetCatalogSeedDecision`, so both would be dead code carrying tests. **`facetCatalogSeedPolicy.mjs` and its verifier are back to main's versions, untouched.**

## What's still missing, and is all this PR now does

`vercel-build.mjs` logs *"run `scripts/run_facet_catalog_maintenance.ts` explicitly"* — and **nothing does.** Scanning every workflow on main for `run_facet_catalog_maintenance` / `runFacetCatalogSeed` / `facet:catalog:apply` returns **zero hits**. The catalog has simply stopped being maintained, and that log line points at nothing.

**1. `.github/workflows/facet-catalog-maintenance.yml`** — `workflow_dispatch` (with a seed toggle) plus a weekly schedule. Mirrors the nightly `fallback-snapshot` workflow exactly, because **the database is not reachable from GitHub runner IPs**: it needs the tailnet (`TS_OAUTH_*`) and the ProxySQL CA (`DATABASE_SSL_CA_BASE64`), or the connection is refused outright. 90-minute timeout, since the full run is 13 sequential steps observed at ~45 minutes.

**2. A contract assertion that the workflow exists.** Main's two new assertions say the build must not run the maintenance; on its own that's only half a contract. Pairing them means neither half can be dropped silently.

**3. Teardown can no longer fail the run** (`run_facet_catalog_maintenance.ts`). `connection.release()` and `pool.end()` sat **unguarded inside `finally`**, so a throw from either — exactly what a connection destroyed by `ER_CMD_CONNECTION_CLOSED` produces — propagated out of `main()` and became the exit code. Two consequences during the outage:
- maintenance that had **actually completed** still reported failure, and
- the teardown error **replaced** the real step error in the logs, hiding the cause.

This matters *more* now than before, because the runner is the primary path rather than a build step. The keepalive also stops after the first loss instead of re-pinging a dead socket every 20s for the rest of a ~45-minute run (~130 duplicate fatal errors burying the step output).

## Still not done — now safely contained

The lock-holder doesn't reconnect/reacquire on connection loss, and `LOCK_WAIT_SECONDS` (900s) is shorter than the ~45-minute run so two runs can't queue. Both need a live MySQL connection to exercise; this sandbox can't reach `:5544`.

The **~45-minute runtime is the real root cause** — 13 serial child processes, pipelining disabled so every statement is its own TLS round trip, and three fully-serial whole-table backfills inside the seed step. Worth its own task.

## Verification

`vue-tsc` ✅ · `verifyFacetCatalogMaintenance` ✅ · `FacetCatalogCutover` ✅ · `FacetCanonicalMerges` ✅ · `FacetCuration` ✅ · `FacetCatalogDirectives` ✅ · `DatabaseRetry` ✅ · `AchievementCatalog` ✅ · seed policy ✅ · layout contract ✅ · prettier + eslint clean on changed files · workflow YAML parses.

⚠️ **The workflow needs `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`, `DATABASE_URL` (tailnet address) and `DATABASE_SSL_CA_BASE64` as repository Actions secrets.** If `fallback-snapshot` already runs green, they're all present.