### PR TITLE
Run one-shot Facet artwork sweep

### DIFF
--- a/.github/facet-art-sweep-trigger
+++ b/.github/facet-art-sweep-trigger
@@ -1,0 +1,1 @@
+2026-08-01 facet icon/card/hero sweep after PR 1273

--- a/.github/workflows/facet-catalog-maintenance.yml
+++ b/.github/workflows/facet-catalog-maintenance.yml
@@ -36,6 +36,10 @@ name: Facet Catalog Maintenance
 #   TS_OAUTH_SECRET
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/facet-art-sweep-trigger'
   schedule:
     - cron: '41 10 * * 1' # Mondays, 10:41 UTC ≈ 2:41am Pacific
   workflow_dispatch:


### PR DESCRIPTION
Adds a path-scoped one-shot push trigger for the existing serialized Facet catalog maintenance workflow and touches that trigger path once.

This exists only because the connected GitHub worker can inspect/rerun workflows but cannot dispatch a workflow_dispatch run. The maintenance job uses the existing database/Tailscale secrets, named lock, quality audit, retired-shell cleanup, and deduplicated four-variant ArtJob queue from #1273.

After the run starts, the trigger and push hook will be removed in a cleanup PR.