### PR TITLE
Remove consumed Facet artwork sweep trigger

### DIFF
--- a/.github/facet-art-sweep-trigger
+++ b/.github/facet-art-sweep-trigger
@@ -1,1 +1,0 @@
-2026-08-01 facet icon/card/hero sweep after PR 1273

--- a/.github/workflows/facet-catalog-maintenance.yml
+++ b/.github/workflows/facet-catalog-maintenance.yml
@@ -36,10 +36,6 @@ name: Facet Catalog Maintenance
 #   TS_OAUTH_SECRET
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '.github/facet-art-sweep-trigger'
   schedule:
     - cron: '41 10 * * 1' # Mondays, 10:41 UTC ≈ 2:41am Pacific
   workflow_dispatch:


### PR DESCRIPTION
Removes the temporary path-scoped push hook and trigger file added by #1274. The launched maintenance run uses its own immutable checkout and continues unaffected; the normal weekly/manual maintenance schedule remains.