### PR TITLE
Fix email confirmation links and landing flow

### DIFF
--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -1,0 +1,119 @@
+<template>
+  <main class="flex min-h-full w-full items-center justify-center p-4 sm:p-8">
+    <section class="kr-panel flex w-full max-w-2xl flex-col items-center gap-5 p-6 text-center sm:p-10">
+      <div
+        class="flex h-16 w-16 items-center justify-center rounded-full"
+        :class="result.ok ? 'bg-success/15 text-success' : 'bg-warning/15 text-warning'"
+      >
+        <Icon
+          :name="result.ok ? 'kind-icon:check' : 'kind-icon:alert'"
+          class="h-9 w-9"
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <p class="text-xs font-black uppercase tracking-[0.2em] text-base-content/50">
+          Email confirmation
+        </p>
+        <h1 class="text-3xl font-black sm:text-4xl">{{ result.title }}</h1>
+        <p class="mx-auto max-w-xl text-base text-base-content/70">
+          {{ result.message }}
+        </p>
+      </div>
+
+      <div
+        class="kr-note w-full"
+        :class="result.ok ? 'kr-note-success' : 'kr-note-warning'"
+      >
+        {{ result.detail }}
+      </div>
+
+      <div class="flex flex-wrap justify-center gap-3">
+        <NuxtLink to="/account" class="btn btn-primary rounded-xl">
+          Open account settings
+        </NuxtLink>
+        <NuxtLink to="/" class="btn btn-outline rounded-xl">
+          Return home
+        </NuxtLink>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from '#app'
+
+type EmailActionResult = {
+  ok: boolean
+  title: string
+  message: string
+  detail: string
+}
+
+const route = useRoute()
+
+function queryValue(value: unknown): string {
+  if (Array.isArray(value)) return String(value[0] || '')
+  return typeof value === 'string' ? value : ''
+}
+
+const action = computed(() => queryValue(route.query.action))
+const status = computed(() => queryValue(route.query.status))
+
+const result = computed<EmailActionResult>(() => {
+  const succeeded = status.value === 'success'
+
+  if (action.value === 'newsletter') {
+    return succeeded
+      ? {
+          ok: true,
+          title: "You're subscribed",
+          message:
+            "Your notification preference was confirmed. We'll only send the updates you selected.",
+          detail:
+            'The confirmation is complete, even if you opened this link in a browser where you are not signed in.',
+        }
+      : {
+          ok: false,
+          title: 'That confirmation link is no longer valid',
+          message:
+            'The link may have expired or already been used. Your existing notification settings were not changed by this attempt.',
+          detail:
+            'Open account settings to choose a notification frequency and request a fresh confirmation email.',
+        }
+  }
+
+  if (action.value === 'email-verification') {
+    return succeeded
+      ? {
+          ok: true,
+          title: 'Email verified',
+          message:
+            'Your email address is now verified and connected to your Kind Robots account.',
+          detail:
+            'You can safely close this page or continue to your account settings.',
+        }
+      : {
+          ok: false,
+          title: 'That verification link is no longer valid',
+          message:
+            'The link may have expired or already been used. You can request another verification email from your account settings.',
+          detail:
+            'No account information was changed by this attempt.',
+        }
+  }
+
+  return {
+    ok: false,
+    title: 'This email link is incomplete',
+    message:
+      'Open the full link from the Kind Robots email so we can show the correct confirmation result.',
+    detail: 'No account information was changed.',
+  }
+})
+
+useHead(() => ({
+  title: `${result.value.title} | Kind Robots`,
+}))
+</script>

--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -1,42 +1,54 @@
 <template>
-  <main class="flex min-h-full w-full items-center justify-center p-4 sm:p-8">
-    <section class="kr-panel flex w-full max-w-2xl flex-col items-center gap-5 p-6 text-center sm:p-10">
-      <div
-        class="flex h-16 w-16 items-center justify-center rounded-full"
-        :class="result.ok ? 'bg-success/15 text-success' : 'bg-warning/15 text-warning'"
-      >
-        <Icon
-          :name="result.ok ? 'kind-icon:check' : 'kind-icon:alert'"
-          class="h-9 w-9"
-        />
-      </div>
+  <main class="kr-surface">
+    <div class="kr-scroll">
+      <div class="flex min-h-full w-full items-center justify-center p-4 sm:p-8">
+        <section
+          class="kr-panel flex w-full max-w-2xl flex-col items-center gap-5 p-6 text-center sm:p-10"
+        >
+          <div
+            class="flex h-16 w-16 items-center justify-center rounded-full"
+            :class="
+              result.ok
+                ? 'bg-success/15 text-success'
+                : 'bg-warning/15 text-warning'
+            "
+          >
+            <Icon
+              :name="result.ok ? 'kind-icon:check' : 'kind-icon:alert'"
+              class="h-9 w-9"
+            />
+          </div>
 
-      <div class="flex flex-col gap-2">
-        <p class="text-xs font-black uppercase tracking-[0.2em] text-base-content/50">
-          Email confirmation
-        </p>
-        <h1 class="text-3xl font-black sm:text-4xl">{{ result.title }}</h1>
-        <p class="mx-auto max-w-xl text-base text-base-content/70">
-          {{ result.message }}
-        </p>
-      </div>
+          <div class="flex flex-col gap-2">
+            <p
+              class="text-xs font-black uppercase tracking-[0.2em] text-base-content/50"
+            >
+              Email confirmation
+            </p>
+            <p class="text-3xl font-black sm:text-4xl">{{ result.title }}</p>
+            <p class="mx-auto max-w-xl text-base text-base-content/70">
+              {{ result.message }}
+            </p>
+          </div>
 
-      <div
-        class="kr-note w-full"
-        :class="result.ok ? 'kr-note-success' : 'kr-note-warning'"
-      >
-        {{ result.detail }}
-      </div>
+          <div
+            class="kr-note w-full"
+            :class="result.ok ? 'kr-note-success' : 'kr-note-warning'"
+          >
+            {{ result.detail }}
+          </div>
 
-      <div class="flex flex-wrap justify-center gap-3">
-        <NuxtLink to="/account" class="btn btn-primary rounded-xl">
-          Open account settings
-        </NuxtLink>
-        <NuxtLink to="/" class="btn btn-outline rounded-xl">
-          Return home
-        </NuxtLink>
+          <div class="flex flex-wrap justify-center gap-3">
+            <NuxtLink to="/account" class="btn btn-primary rounded-xl">
+              Open account settings
+            </NuxtLink>
+            <NuxtLink to="/" class="btn btn-outline rounded-xl">
+              Return home
+            </NuxtLink>
+          </div>
+        </section>
       </div>
-    </section>
+    </div>
   </main>
 </template>
 
@@ -99,8 +111,7 @@ const result = computed<EmailActionResult>(() => {
           title: 'That verification link is no longer valid',
           message:
             'The link may have expired or already been used. You can request another verification email from your account settings.',
-          detail:
-            'No account information was changed by this attempt.',
+          detail: 'No account information was changed by this attempt.',
         }
   }
 

--- a/server/api/auth/email/verify.get.ts
+++ b/server/api/auth/email/verify.get.ts
@@ -1,7 +1,6 @@
 // /server/api/auth/email/verify.get.ts
 // Public: consume an EMAIL_VERIFY token (?token=) and stamp User.emailVerified.
-// Redirects to a friendly landing page rather than returning raw JSON, since
-// this URL is opened directly from an email client.
+// Redirects to a public landing page rather than an authenticated account surface.
 import { defineEventHandler, getQuery, sendRedirect } from 'h3'
 import prisma from '../../../utils/prisma'
 import { appBaseUrl } from '../../../utils/email'
@@ -13,7 +12,11 @@ export default defineEventHandler(async (event) => {
 
   const result = await consumeAuthToken(token, 'EMAIL_VERIFY')
   if (!result.ok) {
-    return sendRedirect(event, `${base}/account?verify=invalid`, 302)
+    return sendRedirect(
+      event,
+      `${base}/email-confirmation?action=email-verification&status=invalid`,
+      302,
+    )
   }
 
   await prisma.user.update({
@@ -21,5 +24,9 @@ export default defineEventHandler(async (event) => {
     data: { emailVerified: new Date() },
   })
 
-  return sendRedirect(event, `${base}/account?verify=success`, 302)
+  return sendRedirect(
+    event,
+    `${base}/email-confirmation?action=email-verification&status=success`,
+    302,
+  )
 })

--- a/server/api/newsletter/confirm.get.ts
+++ b/server/api/newsletter/confirm.get.ts
@@ -13,7 +13,11 @@ export default defineEventHandler(async (event) => {
 
   const result = await consumeAuthToken(token, 'NEWSLETTER_CONFIRM')
   if (!result.ok) {
-    return sendRedirect(event, `${base}/account?newsletter=invalid`, 302)
+    return sendRedirect(
+      event,
+      `${base}/email-confirmation?action=newsletter&status=invalid`,
+      302,
+    )
   }
 
   const updated = await prisma.user.update({
@@ -32,5 +36,9 @@ export default defineEventHandler(async (event) => {
 
   await syncBrevoContact(updated)
 
-  return sendRedirect(event, `${base}/account?newsletter=success`, 302)
+  return sendRedirect(
+    event,
+    `${base}/email-confirmation?action=newsletter&status=success`,
+    302,
+  )
 })

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -1,11 +1,15 @@
 // /server/utils/email.ts
 // Brevo (Sendinblue) transactional email. All sends go through
-// `sendTransactionalEmail`, which never throws — a mail outage must never turn
-// an account action (register, password change, restrict) into a 500. Callers
-// get `{ sent: boolean }` and can log/ignore as appropriate.
-// `useRuntimeConfig` is auto-imported by Nitro (see server/utils/authGuard.ts).
+// `sendTransactionalEmail`, which never throws. A mail outage must never turn
+// an account action into a 500. Callers get `{ sent: boolean }` and can
+// log or ignore the result as appropriate.
 
 const BREVO_ENDPOINT = 'https://api.brevo.com/v3/smtp/email'
+const DEFAULT_APP_BASE_URL = 'https://kind-robots.vercel.app'
+const LEGACY_APP_BASE_URLS = new Set([
+  'http://kindrobots.org',
+  'https://kindrobots.org',
+])
 
 export type SendEmailInput = {
   to: string
@@ -21,19 +25,28 @@ export type SendEmailResult = {
   error?: string
 }
 
+function normalizeAppBaseUrl(value: string): string {
+  const normalized = value.trim().replace(/\/$/, '')
+
+  if (!normalized || LEGACY_APP_BASE_URLS.has(normalized)) {
+    return DEFAULT_APP_BASE_URL
+  }
+
+  return normalized
+}
+
 function brevoConfig() {
   const config = useRuntimeConfig()
   return {
     apiKey: String(config.brevoApiKey || ''),
     senderEmail: String(config.brevoSenderEmail || 'hello@kindrobots.org'),
     senderName: String(config.brevoSenderName || 'Kind Robots'),
-    baseUrl: String(config.public?.appBaseUrl || 'https://kindrobots.org'),
+    baseUrl: normalizeAppBaseUrl(String(config.public?.appBaseUrl || '')),
   }
 }
 
-/** Public base URL used to build links inside emails. */
 export function appBaseUrl(): string {
-  return brevoConfig().baseUrl.replace(/\/$/, '')
+  return brevoConfig().baseUrl
 }
 
 export async function sendTransactionalEmail(
@@ -42,7 +55,7 @@ export async function sendTransactionalEmail(
   const { apiKey, senderEmail, senderName } = brevoConfig()
 
   if (!apiKey) {
-    console.warn('[email] BREVO_API_KEY not set — skipping send to', input.to)
+    console.warn('[email] BREVO_API_KEY not set, skipping send to', input.to)
     return { sent: false, skipped: true }
   }
 
@@ -84,8 +97,6 @@ function stripHtml(html: string): string {
     .trim()
 }
 
-// --- Shared shell ---------------------------------------------------------
-
 function shell(title: string, bodyHtml: string): string {
   return `<!doctype html><html><body style="margin:0;background:#f4f4f7;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#1f2430;">
   <div style="max-width:520px;margin:0 auto;padding:32px 16px;">
@@ -103,8 +114,6 @@ function button(href: string, label: string): string {
   return `<p style="margin:24px 0;"><a href="${href}" style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;padding:12px 22px;border-radius:12px;font-weight:600;">${label}</a></p>
   <p style="font-size:13px;color:#8a8f9c;margin:0;">Or paste this link into your browser:<br><span style="word-break:break-all;">${href}</span></p>`
 }
-
-// --- Named helpers --------------------------------------------------------
 
 export function sendVerificationEmail(to: string, name: string, token: string) {
   const url = `${appBaseUrl()}/api/auth/email/verify?token=${encodeURIComponent(token)}`


### PR DESCRIPTION
## Root cause

Notification confirmation tokens were consumed successfully, but the handler redirected to `/account`, an authenticated surface. Email clients often open in a browser without the user's active session, so the success banner was hidden behind the sign-in state. Email links also inherited the legacy `kindrobots.org` runtime default, whose API paths are not the canonical production surface.

## What changed

- add a public `/email-confirmation` result page for success, expired, reused, and incomplete links
- redirect newsletter confirmations to the public result page
- apply the same fix to email-address verification, which shared the faulty landing behavior
- normalize legacy or missing email base URLs to `https://kind-robots.vercel.app`

## Verification

- TypeScript Type Check passed
- Layout Contract passed
- Contract Tests passed, including navigation route access and capture-group guards
- all eight focused narrative, Storymaker, Taskmaster, and Facet contract workflows passed
- complete PR diff reviewed against current `main`
- Vercel did not emit a PR preview deployment for this branch; production route verification will be performed immediately after the green merge

## Flags for reviewer

This is a reversible routing/UI fix. It does not change token consumption, subscription semantics, Brevo list synchronization, database schema, or production data.