### PR TITLE
Clear failed ArtJobs and retire corrected sources

### DIFF
--- a/components/art/artjob-failed-page-requeue.vue
+++ b/components/art/artjob-failed-page-requeue.vue
@@ -17,7 +17,7 @@
         <button
           type="button"
           class="btn btn-outline btn-error btn-sm rounded-2xl"
-          :disabled="submitting"
+          :disabled="Boolean(submitting)"
           @click="cancelFailedOnPage"
         >
           <span
@@ -29,7 +29,7 @@
         <button
           type="button"
           class="btn btn-error btn-sm rounded-2xl"
-          :disabled="submitting"
+          :disabled="Boolean(submitting)"
           @click="requeueFailedOnPage"
         >
           <span

--- a/components/art/artjob-failed-page-requeue.vue
+++ b/components/art/artjob-failed-page-requeue.vue
@@ -13,16 +13,32 @@
         </p>
       </div>
 
-      <button
-        v-if="failedJobIds.length"
-        type="button"
-        class="btn btn-error btn-sm rounded-2xl"
-        :disabled="submitting"
-        @click="requeueFailedOnPage"
-      >
-        <span v-if="submitting" class="loading loading-spinner loading-xs" />
-        Requeue failed on this page ({{ failedJobIds.length }})
-      </button>
+      <div v-if="failedJobIds.length" class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn btn-outline btn-error btn-sm rounded-2xl"
+          :disabled="submitting"
+          @click="cancelFailedOnPage"
+        >
+          <span
+            v-if="submitting === 'cancel'"
+            class="loading loading-spinner loading-xs"
+          />
+          Clear failed on this page ({{ failedJobIds.length }})
+        </button>
+        <button
+          type="button"
+          class="btn btn-error btn-sm rounded-2xl"
+          :disabled="submitting"
+          @click="requeueFailedOnPage"
+        >
+          <span
+            v-if="submitting === 'requeue'"
+            class="loading loading-spinner loading-xs"
+          />
+          Requeue failed on this page ({{ failedJobIds.length }})
+        </button>
+      </div>
     </div>
 
     <p
@@ -56,7 +72,7 @@ type SelectedFailedRequeueResult = {
 }
 
 const artJobStore = useArtJobStore()
-const submitting = ref(false)
+const submitting = ref<false | 'cancel' | 'requeue'>(false)
 const message = ref('')
 const hasFailures = ref(false)
 
@@ -75,7 +91,7 @@ async function requeueFailedOnPage(): Promise<void> {
   )
   if (!confirmed) return
 
-  submitting.value = true
+  submitting.value = 'requeue'
   message.value = ''
   hasFailures.value = false
 
@@ -98,6 +114,40 @@ async function requeueFailedOnPage(): Promise<void> {
       response.data.failedCount > 0 || response.data.skippedCount > 0
     message.value = response.message
 
+    await Promise.all([artJobStore.fetchJobs(), artJobStore.fetchStats()])
+  } finally {
+    submitting.value = false
+  }
+}
+async function cancelFailedOnPage(): Promise<void> {
+  const jobIds = failedJobIds.value
+  if (!jobIds.length || submitting.value) return
+
+  const confirmed = window.confirm(
+    `Clear the ${jobIds.length} failed ArtJobs currently shown on page ${artJobStore.jobPage}? They will be marked cancelled and removed from the failed queue.`,
+  )
+  if (!confirmed) return
+
+  submitting.value = 'cancel'
+  message.value = ''
+  hasFailures.value = false
+
+  try {
+    const results = await Promise.all(
+      jobIds.map((id) =>
+        performFetch(`/api/art/queue/${id}/cancel`, {
+          method: 'POST',
+          body: JSON.stringify({
+            reason: 'Cleared from failed queue by admin.',
+          }),
+        }),
+      ),
+    )
+    const failedCount = results.filter((response) => !response.success).length
+    hasFailures.value = failedCount > 0
+    message.value = failedCount
+      ? `Cleared ${jobIds.length - failedCount} of ${jobIds.length} failed ArtJobs. ${failedCount} could not be cleared.`
+      : `Cleared ${jobIds.length} failed ArtJobs from this page.`
     await Promise.all([artJobStore.fetchJobs(), artJobStore.fetchStats()])
   } finally {
     submitting.value = false

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -552,12 +552,16 @@
                   Resume unchanged
                 </button>
                 <button
-                  v-if="job.status === 'PENDING' || job.status === 'RUNNING'"
+                  v-if="
+                    job.status === 'PENDING' ||
+                    job.status === 'RUNNING' ||
+                    job.status === 'FAILED'
+                  "
                   type="button"
                   class="btn btn-ghost btn-xs rounded-2xl text-error"
                   @click="artJobStore.cancelJob(job.id)"
                 >
-                  Cancel
+                  {{ job.status === 'FAILED' ? 'Clear failure' : 'Cancel' }}
                 </button>
               </div>
             </div>

--- a/server/api/art/queue/[id]/reenqueue.post.ts
+++ b/server/api/art/queue/[id]/reenqueue.post.ts
@@ -158,15 +158,31 @@ export default defineEventHandler(async (event) => {
     applyArtFacetsToPayload(payload, basePrompt, facets)
     const jobEngine = presetEngine ? 'COMFY' : source.engine
 
-    const job = await prisma.artJob.create({
-      data: {
-        engine: jobEngine,
-        payload: serializeArtJobPayload(payload),
-        priority: source.priority,
-        projectSlug: source.projectSlug,
-        projectId: source.projectId,
-        userId: source.userId,
-      },
+    const job = await prisma.$transaction(async (tx) => {
+      const created = await tx.artJob.create({
+        data: {
+          engine: jobEngine,
+          payload: serializeArtJobPayload(payload),
+          priority: source.priority,
+          projectSlug: source.projectSlug,
+          projectId: source.projectId,
+          userId: source.userId,
+        },
+      })
+
+      if (source.status === 'FAILED' && mode === 'NEW_OUTPUT') {
+        await tx.artJob.update({
+          where: { id: source.id },
+          data: {
+            status: 'CANCELLED',
+            claimedAt: null,
+            claimedBy: null,
+            error: `Superseded by corrected ArtJob ${created.id}.`,
+          },
+        })
+      }
+
+      return created
     })
 
     event.node.res.statusCode = 201


### PR DESCRIPTION
## What changed

- adds individual **Clear failure** controls to failed ArtJobs
- adds page-scoped batch clearing alongside page-scoped requeue
- marks a failed source `CANCELLED` when a corrected new-output ArtJob is created
- performs replacement creation and source retirement in one database transaction

## Root cause

The existing cancel endpoint accepted failed jobs, but the dashboard only exposed Cancel for pending and running rows. Batch recovery exposed only requeue. Separately, edited new-output retries created a replacement without retiring their failed source, leaving obsolete failures in the failure queue.

## Impact

Bad or superseded failures no longer remain indefinitely in the failed queue. Cancellation preserves terminal history while removing the jobs from active failure views.

## Validation

- `git diff --check` passed locally for the three changed files
- targeted ESLint could not run in the connector-only environment because `gh` and installed npm tooling are unavailable; GitHub checks remain authoritative