### PR TITLE
Fix two dead admin bypasses caused by isAdmin type assertions

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Prisma JSON-cast contract
         run: npm run test:no-prisma-json-cast
 
+      - name: Admin-flag cast contract
+        run: npm run test:admin-flag-casts
+
       - name: Unquoted reserved-word table identifier contract
         run: npm run test:no-unquoted-reserved-word-tables
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "test:deploy-wait-ancestry": "tsx utils/scripts/verifyDeployWaitAncestry.ts",
     "test:deploy-wait-noop": "tsx utils/scripts/verifyDeployWaitNoOp.ts",
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
+    "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
     "test:fetch-generic-pinning": "tsx utils/scripts/verifyFetchGenericPinning.ts",
     "test:existing-owner-id-nullability": "tsx utils/scripts/verifyExistingOwnerIdNullability.ts",

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -279,7 +279,7 @@ export default defineEventHandler(async (event) => {
       frames: videoFrames,
       serverId: body?.serverId ?? null,
     })
-    const isAdmin = Boolean((gate.user as { isAdmin?: boolean }).isAdmin)
+    const isAdmin = gate.isAdmin
     const entityArt = body?.entityArt
       ? await prepareEntityArtEnqueue(event, prisma, body.entityArt, {
           user: { id: gate.user.id },

--- a/server/api/chats/user/human/[id].get.ts
+++ b/server/api/chats/user/human/[id].get.ts
@@ -8,6 +8,7 @@ import {
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { validateApiKey } from '../../../../utils/validateKey'
+import { userIsAdmin } from '../../../../utils/authUser'
 
 function fail(
   event: Parameters<Parameters<typeof defineEventHandler>[0]>[0],
@@ -59,9 +60,9 @@ export default defineEventHandler(async (event) => {
       )
     }
 
-    const authUser = user as { id: number; isAdmin?: boolean }
-
-    if (authUser.id !== requestedUserId && !authUser.isAdmin) {
+    // validateApiKey returns `{ id, Role }` and never an `isAdmin` flag, so the
+    // admin branch has to be derived from Role through the canonical predicate.
+    if (user.id !== requestedUserId && !userIsAdmin(user)) {
       return fail(
         event,
         new Error('You can only fetch your own human chats.'),

--- a/server/utils/comfyGate.ts
+++ b/server/utils/comfyGate.ts
@@ -25,6 +25,12 @@ interface ComfyGateInput {
 
 interface ComfyGateResult {
   user: { id: number }
+  // Carried through from requireMachineUser. Routes that need an admin bypass
+  // (entity-art ownership, LoRA visibility, mature Facet selection) must read
+  // THIS, never `gate.user`: the user object here is deliberately narrowed to
+  // `{ id }`, so casting it to something carrying `isAdmin` yields a
+  // permanently-false value that the typechecker cannot catch.
+  isAdmin: boolean
   cost: number
   free: boolean
   commit: (
@@ -48,7 +54,7 @@ export async function authAndGate(
   event: H3Event,
   input: ComfyGateInput,
 ): Promise<ComfyGateResult> {
-  const { user } = await requireMachineUser(event)
+  const { user, isAdmin } = await requireMachineUser(event)
 
   const gate = await manaGate(event, {
     kind: 'art',
@@ -64,6 +70,7 @@ export async function authAndGate(
 
   return {
     user: { id: user.id },
+    isAdmin,
     cost: gate.cost,
     free: gate.free,
     commit: gate.commit,

--- a/server/utils/textGate.ts
+++ b/server/utils/textGate.ts
@@ -14,6 +14,9 @@ type TextGateResult = {
   user: {
     id: number
   }
+  // See comfyGate.ts: `user` is narrowed to `{ id }`, so admin checks must read
+  // this flag rather than casting `gate.user` to a shape it does not have.
+  isAdmin: boolean
   cost: number
   free: boolean
   commit: (
@@ -29,7 +32,7 @@ export async function authAndTextGate(
   // t-015: shared machine auth (session JWT, user apiKey, or beta admin
   // token) via requireMachineUser, replacing the inline apiKey-only lookup.
   // Mirrors comfyGate.authAndGate.
-  const { user } = await requireMachineUser(event)
+  const { user, isAdmin } = await requireMachineUser(event)
 
   const gate = await manaGate(event, {
     kind: 'text',
@@ -43,6 +46,7 @@ export async function authAndTextGate(
 
   return {
     user: { id: user.id },
+    isAdmin,
     cost: gate.cost,
     free: gate.free,
     commit: gate.commit,

--- a/utils/scripts/verifyAdminFlagCasts.ts
+++ b/utils/scripts/verifyAdminFlagCasts.ts
@@ -1,0 +1,121 @@
+// /utils/scripts/verifyAdminFlagCasts.ts
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Regression guard for a silent authorization failure.
+//
+// server/api/art/enqueue.post.ts used to read its admin flag like this:
+//
+//   const isAdmin = Boolean((gate.user as { isAdmin?: boolean }).isAdmin)
+//
+// `gate.user` is deliberately narrowed to `{ id: number }` by
+// server/utils/comfyGate.ts, so that property never existed and `isAdmin` was
+// permanently false. The admin bypass in assertEntityArtAccess
+// (server/utils/entityArt.ts) was therefore dead code, and on 2026-08-01 it
+// rejected 131 of 1,824 entity-art enqueues by the site owner's own admin
+// token with "You cannot edit artwork for this item."
+//
+// The cast is what made it invisible: `as` ASSERTS a shape rather than reading
+// one, so the typechecker had nothing to complain about. A structurally
+// identical instance existed at server/api/chats/user/human/[id].get.ts, where
+// validateApiKey returns `{ id, Role }` and never `isAdmin`.
+//
+// Rule: never assert `isAdmin` onto a value. Either the type genuinely carries
+// it (AuthGuardResult.isAdmin, ComfyGateResult.isAdmin, TextGateResult.isAdmin,
+// AuthUser.isAdmin) and no cast is needed, or it does not — in which case
+// derive it from Role through userIsAdmin() in server/utils/authUser.ts.
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+const SCAN_EXTENSIONS = ['.ts', '.tsx', '.vue', '.js', '.mjs', '.cjs']
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.nuxt',
+  '.output',
+  '.vercel',
+  'node_modules',
+  'dist',
+  'coverage',
+  'cypress',
+  'prisma/generated',
+])
+// This file documents the exact pattern it scans for -- exclude it from its own
+// scan rather than obscuring the pattern to dodge a self-match.
+const EXCLUDED_FILES = new Set(['utils/scripts/verifyAdminFlagCasts.ts'])
+
+// Matches an inline object-type assertion that introduces an `isAdmin` member:
+//   as { isAdmin?: boolean }
+//   as unknown as { id: number; isAdmin?: boolean }
+// Deliberately does NOT match `as AuthUser` / `as AuthGuardResult` -- casting to
+// a named type that really declares the field is not this bug.
+const BAD_CAST_PATTERN = /\bas\s+(?:unknown\s+as\s+)?\{[^{}]*\bisAdmin\b/
+
+function isExcluded(relativePath: string): boolean {
+  if (EXCLUDED_FILES.has(relativePath)) return true
+  return [...EXCLUDED_DIRECTORIES].some(
+    (excluded) =>
+      relativePath === excluded || relativePath.startsWith(`${excluded}/`),
+  )
+}
+
+function listSourceFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name)
+    const relativePath = relative(repositoryRoot, path)
+    if (isExcluded(relativePath)) continue
+
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(path))
+      continue
+    }
+
+    if (entry.isFile() && SCAN_EXTENSIONS.some((ext) => path.endsWith(ext))) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function main(): void {
+  const files = listSourceFiles(repositoryRoot)
+  const errors: string[] = []
+
+  for (const file of files) {
+    const relativeFile = relative(repositoryRoot, file)
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/)
+
+    lines.forEach((line, index) => {
+      if (BAD_CAST_PATTERN.test(line)) {
+        errors.push(
+          `${relativeFile}:${index + 1}: asserts an inline object type ` +
+            'carrying `isAdmin`. The cast cannot make the property exist -- if ' +
+            'the value never had it, the check is permanently false and the ' +
+            'admin bypass silently dies. Read a declared flag ' +
+            '(AuthGuardResult/ComfyGateResult/TextGateResult/AuthUser `.isAdmin`) ' +
+            'or derive it with userIsAdmin() from server/utils/authUser.ts.',
+        )
+      }
+    })
+  }
+
+  if (errors.length) {
+    console.error(
+      `Admin-flag cast contract failed with ${errors.length} error(s):`,
+    )
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `Admin-flag cast contract passed: ${files.length} source file(s) checked, ` +
+      'no inline `as { ... isAdmin ... }` assertions found.',
+  )
+}
+
+main()


### PR DESCRIPTION
## What

Two authorization checks were silently dead. Both were the same defect: code used `as { isAdmin?: boolean }` to **assert** a property onto a value that never carried it, so the flag read permanently `false` and the admin branch behind it never executed. `as` asserts a shape rather than reading one — which is exactly why the typechecker stayed quiet about a constant.

### 1. `server/api/art/enqueue.post.ts:282`

```ts
const isAdmin = Boolean((gate.user as { isAdmin?: boolean }).isAdmin)
```

`comfyGate.authAndGate` destructures a full `AuthUser` from `requireMachineUser` — carrying `Role` **and** `isAdmin` — then returns `user: { id: user.id }`, discarding the flag it had already resolved.

Consequence: the admin bypass in `assertEntityArtAccess` (`server/utils/entityArt.ts:393`) was unreachable. On 2026-08-01 it rejected **131 of 1,824** entity-art enqueues made with the site owner's own ADMIN token — every one against the 43 Scenarios owned by `userId: 9` — with *"You cannot edit artwork for this item."*

The same permanently-false value also flowed into `resolveEnqueueLoraResource` (`:351`) and `resolveArtFacetSelection` (`:363`), silently narrowing LoRA visibility and mature Facet selection for admins.

### 2. `server/api/chats/user/human/[id].get.ts:62`

```ts
const authUser = user as { id: number; isAdmin?: boolean }
if (authUser.id !== requestedUserId && !authUser.isAdmin) { /* 403 */ }
```

`validateApiKey` returns `{ id, Role }` and never `isAdmin`, so `!authUser.isAdmin` was always true and admins were wrongly denied other users' human chats — with `Role` sitting right there on the object, unread. Now derived through the canonical `userIsAdmin()` predicate in `server/utils/authUser.ts`.

## The fix

- `comfyGate.ts` and `textGate.ts` return the resolved `isAdmin` alongside the narrowed `user`, with a comment on the field explaining why the narrowing makes a cast dangerous. `textGate` has no live consumer yet — giving it the passthrough now keeps it from becoming a third instance.
- `enqueue.post.ts` reads `gate.isAdmin`; the cast is deleted.
- `chats/user/human/[id].get.ts` uses `userIsAdmin(user)`.
- New `utils/scripts/verifyAdminFlagCasts.ts` fails CI on any inline `as { ... isAdmin ... }` assertion. It deliberately does **not** match casts to named types that genuinely declare the field, so `AuthUser` / `AuthGuardResult` stay legal. Wired into `contract-tests.yml` next to the existing `no-prisma-json-cast` guard, which it is modelled on.

## Root cause

Two auth resolvers with incompatible user shapes — `authGuard` returns the full user plus `isAdmin`; `validateKey` returns `{ id, Role }` — bridged at the gate layer by `as` casts instead of by data. The verifier closes the class; a follow-up will consolidate the 49 inline `user.Role === 'ADMIN'` comparisons onto `userIsAdmin`.

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean.
- `test:admin-flag-casts` — passes over 1,663 files; regex unit-checked against both real instances (matches) and `as AuthUser` / `gate.isAdmin` / `auth.isAdmin` (no match).
- `test:no-prisma-json-cast`, `verifyEntityArtManager`, `test:conductor-api-auth-guards` — all pass.
- **Against production, pre-fix**, at zero mana cost: `POST /api/art/enqueue` with `mode: recreate` + `engine: kontext` for scenario 61 (owned by user 9) returns

  ```
  {"success":false,"message":"You cannot edit artwork for this item.","statusCode":403}
  ```

  That request is rejected at the access check. Once this deploys it should instead return the 400 raised immediately past it (*"Entity recreation requires a prompt-only engine such as Krea 2."*) — proving the admin branch fires, without queueing a job or spending mana. Will re-run the probe and then the 131 rejected jobs after merge.

No schema change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_