### PR TITLE
Randomize all startup launch WebPs

### DIFF
--- a/components/admin/startup-intro-visual.vue
+++ b/components/admin/startup-intro-visual.vue
@@ -18,6 +18,7 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { getStartupAnimationSrc } from '~/utils/startupAnimations'
 
 type IntroVisualKind = 'logo' | 'animation'
 
@@ -25,7 +26,7 @@ const emit = defineEmits<{
   settled: [kind: IntroVisualKind]
 }>()
 
-const ANIMATION_SRC = '/images/startup-animations/launch-04.webp'
+const ANIMATION_SRC = getStartupAnimationSrc()
 const LOGO_SRC = '/images/kindlogo_new.webp'
 
 const imageElement = ref<HTMLImageElement | null>(null)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,7 @@
 // /nuxt.config.ts
 import { execFileSync } from 'node:child_process'
 import tailwindcss from '@tailwindcss/vite'
+import { DEFAULT_STARTUP_ANIMATION_SRC } from './utils/startupAnimations'
 
 const requireEnv = (key: string) => {
   const value = process.env[key]
@@ -32,7 +33,7 @@ const buildId =
   process.env.NUXT_PUBLIC_BUILD_ID ||
   'development'
 
-const startupAnimationSrc = '/images/startup-animations/launch-04.webp'
+const startupAnimationSrc = DEFAULT_STARTUP_ANIMATION_SRC
 
 /*
  * The build targets 'esnext', so nothing lowers syntax and nothing polyfills

--- a/server/plugins/00-startup-composition-shell.ts
+++ b/server/plugins/00-startup-composition-shell.ts
@@ -24,11 +24,37 @@
  * and starts only once the app is actually running.
  */
 
+import {
+  DEFAULT_STARTUP_ANIMATION_SRC,
+  STARTUP_ANIMATION_META_NAME,
+  STARTUP_ANIMATION_SOURCES,
+} from '../../utils/startupAnimations'
+
 const RELEASE_DELAY_MS = 6000
 const RELEASE_FADE_MS = 500
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', (html) => {
+    const launchSrc =
+      STARTUP_ANIMATION_SOURCES[
+        Math.floor(Math.random() * STARTUP_ANIMATION_SOURCES.length)
+      ] ?? DEFAULT_STARTUP_ANIMATION_SRC
+
+    // Nuxt has already rendered the Vue intro with the deterministic default.
+    // Replace it in the completed response and publish the same choice in a
+    // meta tag so hydration initializes with the identical image. The preload,
+    // boot cameo, and Vue intro therefore never disagree or flash two launches.
+    const useSelectedLaunch = (markup: string) =>
+      markup.replaceAll(DEFAULT_STARTUP_ANIMATION_SRC, launchSrc)
+
+    html.head = html.head.map(useSelectedLaunch)
+    html.body = html.body.map(useSelectedLaunch)
+    html.bodyAppend = html.bodyAppend.map(useSelectedLaunch)
+    html.bodyPrepend = html.bodyPrepend.map(useSelectedLaunch)
+    html.head.push(
+      `<meta name="${STARTUP_ANIMATION_META_NAME}" content="${launchSrc}">`,
+    )
+
     html.bodyPrepend.unshift(`
       <style>
         .kr-boot-cover {
@@ -146,7 +172,7 @@ export default defineNitroPlugin((nitroApp) => {
 
           <div class="kr-boot-cover__media-frame">
             <img
-              src="/images/startup-animations/launch-04.webp"
+              src="${launchSrc}"
               alt=""
               class="kr-boot-cover__media"
               width="720"

--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -28,6 +28,7 @@ const [
   loadingMessages,
   startupAnimation,
   startupLaunch,
+  startupAnimations,
   app,
 ] = await Promise.all([
   readFile('server/plugins/00-startup-composition-shell.ts', 'utf8'),
@@ -36,6 +37,7 @@ const [
   readFile('components/admin/loading-messages.vue', 'utf8'),
   readFile('components/screenfx/startup-animation.vue', 'utf8'),
   readFile('utils/startupLaunch.ts', 'utf8'),
+  readFile('utils/startupAnimations.ts', 'utf8'),
   readFile('app.vue', 'utf8'),
 ])
 
@@ -164,6 +166,15 @@ assert.ok(
     !startupCoverCss.includes("url('/images/startup-animations/launch-04.webp')") &&
     !startupCoverCss.includes("url('/images/kindlogo_new.webp')"),
   'The Vue intro frame must not paint duplicate startup WebPs behind the actual masked visual.',
+)
+
+assert.ok(
+  startupAnimations.includes('{ length: 12 }') &&
+    startupAnimations.includes("padStart(2, '0')") &&
+    bootCover.includes('Math.floor(Math.random() * STARTUP_ANIMATION_SOURCES.length)') &&
+    bootCover.includes('markup.replaceAll(DEFAULT_STARTUP_ANIMATION_SRC, launchSrc)') &&
+    bootCover.includes('STARTUP_ANIMATION_META_NAME'),
+  'All 12 launch WebPs must be eligible, and the preload, boot cameo, SSR intro, and hydrated intro must share one random choice.',
 )
 
 assert.ok(

--- a/utils/startupAnimations.ts
+++ b/utils/startupAnimations.ts
@@ -1,0 +1,24 @@
+export const STARTUP_ANIMATION_SOURCES = Array.from(
+  { length: 12 },
+  (_, index) =>
+    `/images/startup-animations/launch-${String(index + 1).padStart(2, '0')}.webp`,
+)
+
+export const DEFAULT_STARTUP_ANIMATION_SRC = STARTUP_ANIMATION_SOURCES[0]!
+export const STARTUP_ANIMATION_META_NAME = 'kind-robots-startup-animation'
+
+export function getStartupAnimationSrc(): string {
+  if (import.meta.client) {
+    const selected = document
+      .querySelector<HTMLMetaElement>(
+        `meta[name="${STARTUP_ANIMATION_META_NAME}"]`,
+      )
+      ?.content.trim()
+
+    if (selected && STARTUP_ANIMATION_SOURCES.includes(selected)) {
+      return selected
+    }
+  }
+
+  return DEFAULT_STARTUP_ANIMATION_SRC
+}


### PR DESCRIPTION
## What changed

- adds a shared launch animation config for `launch-01.webp` through `launch-12.webp`
- selects one random launch WebP per rendered page
- synchronizes that choice across the preload, refresh cameo, SSR intro, and hydrated Vue intro
- adds a startup contract assertion protecting the 12-item pool and single-image handoff

## Why

Startup was intentionally pinned to `launch-04.webp` while the launch sequence was stabilized. There are now twelve available launch animations, so the startup can rotate again without reintroducing the prior double-image flash.

## Validation

- `node utils/scripts/verify-startup-handoff.mjs`
- `git diff --check`
- full repository checks run on this PR