### PR TITLE
Make the role predicates multi-role aware and consolidate 48 inline checks

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -107,6 +107,9 @@ jobs:
       - name: UserRole expand migration contract
         run: npm run test:user-role-expand
 
+      - name: UserRole predicate contract
+        run: npm run test:user-role-predicates
+
       - name: Unquoted reserved-word table identifier contract
         run: npm run test:no-unquoted-reserved-word-tables
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:no-prisma-json-cast": "tsx utils/scripts/verifyNoPrismaJsonCast.ts",
     "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",
     "test:user-role-expand": "tsx utils/scripts/verifyUserRoleExpand.ts",
+    "test:user-role-predicates": "tsx utils/scripts/verifyUserRolePredicates.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
     "test:fetch-generic-pinning": "tsx utils/scripts/verifyFetchGenericPinning.ts",
     "test:existing-owner-id-nullability": "tsx utils/scripts/verifyExistingOwnerIdNullability.ts",

--- a/server/api/appmaker/github/create-app.post.ts
+++ b/server/api/appmaker/github/create-app.post.ts
@@ -10,6 +10,7 @@ import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import { enforceProjectCap } from '@/server/utils/projectCap'
 import { listInstallationRepositories } from '@/server/utils/appmakerGithub'
+import { userIsAdmin, userRoles } from '@/server/utils/authUser'
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,40}$/
 
@@ -140,8 +141,12 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
-    await enforceProjectCap({ userId: user.id, userRole: user.Role, isAdmin })
+    const isAdmin = userIsAdmin(user)
+    await enforceProjectCap({
+      userId: user.id,
+      userRoles: [...userRoles(user)],
+      isAdmin,
+    })
 
     const { project, appRepo, todo } = await prisma.$transaction(async (tx) => {
       const project = await tx.project.create({

--- a/server/api/appmaker/scaffold-request.post.ts
+++ b/server/api/appmaker/scaffold-request.post.ts
@@ -7,6 +7,7 @@ import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import { enforceProjectCap } from '@/server/utils/projectCap'
+import { userIsAdmin, userRoles } from '@/server/utils/authUser'
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,40}$/
 
@@ -85,8 +86,12 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 409, message: `Slug '${slug}' is already taken.` })
     }
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
-    await enforceProjectCap({ userId: user.id, userRole: user.Role, isAdmin })
+    const isAdmin = userIsAdmin(user)
+    await enforceProjectCap({
+      userId: user.id,
+      userRoles: [...userRoles(user)],
+      isAdmin,
+    })
 
     const scaffoldCommand =
       `python scripts/new_app.py ${slug} --title ${shellSingleQuote(title)}` +

--- a/server/api/art/image/[id].get.ts
+++ b/server/api/art/image/[id].get.ts
@@ -4,6 +4,7 @@ import type { ArtImage, Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { validateApiKey } from '../../../utils/validateKey'
+import { userRoles } from '../../../utils/authUser'
 
 type QueryValue = string | number | boolean | null | undefined | QueryValue[]
 
@@ -11,6 +12,7 @@ type ValidatedUser = {
   id?: number | null
   Role?: string | null
   role?: string | null
+  roles?: string[] | null
   isAdmin?: boolean | null
   showMature?: boolean | null
 }
@@ -42,12 +44,21 @@ function readBoolean(value: unknown, fallback = false): boolean {
   return fallback
 }
 
+// SYSTEM is treated as admin here (and only here) so internal render callbacks
+// can read any image. That extra grant is preserved; the ADMIN half now goes
+// through the canonical predicate so a user who holds ADMIN as a secondary role
+// -- their primary being CHILD or FAMILY -- is not silently denied.
 function isAdminUser(user: ValidatedUser | null | undefined): boolean {
   if (!user) return false
+  if (user.isAdmin) return true
 
-  const role = String(user.Role || user.role || '').toLowerCase()
+  const roles = userRoles({
+    id: user.id ?? 0,
+    Role: user.Role ?? user.role,
+    roles: user.roles,
+  })
 
-  return Boolean(user.isAdmin || role === 'admin' || role === 'system')
+  return roles.has('ADMIN') || roles.has('SYSTEM')
 }
 
 async function getAccessContext(event: H3Event): Promise<AccessContext> {

--- a/server/api/art/image/index.get.ts
+++ b/server/api/art/image/index.get.ts
@@ -4,6 +4,7 @@ import type { Prisma } from '~/prisma/generated/prisma/client'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { validateApiKey } from '../../../utils/validateKey'
+import { userRoles } from '../../../utils/authUser'
 
 type QueryValue = string | number | boolean | null | undefined | QueryValue[]
 
@@ -11,6 +12,7 @@ type ValidatedUser = {
   id?: number | null
   Role?: string | null
   role?: string | null
+  roles?: string[] | null
   isAdmin?: boolean | null
   showMature?: boolean | null
 }
@@ -34,12 +36,20 @@ function readBoolean(value: unknown, fallback = false): boolean {
   return fallback
 }
 
+// The sibling route (art/image/[id].get.ts) also grants SYSTEM; this one used
+// to accept 'superadmin', which is not a value in the Role enum and so never
+// matched anything. Dropping that dead branch rather than porting it. The ADMIN
+// half now goes through the canonical predicate so a user holding ADMIN as a
+// secondary role is not silently denied.
 function isAdminUser(user: ValidatedUser | null | undefined): boolean {
   if (!user) return false
+  if (user.isAdmin) return true
 
-  const role = String(user.Role || user.role || '').toLowerCase()
-
-  return Boolean(user.isAdmin || role === 'admin' || role === 'superadmin')
+  return userRoles({
+    id: user.id ?? 0,
+    Role: user.Role ?? user.role,
+    roles: user.roles,
+  }).has('ADMIN')
 }
 
 async function getArtImageAccessContext(

--- a/server/api/art/images/[id]/file.get.ts
+++ b/server/api/art/images/[id]/file.get.ts
@@ -10,6 +10,7 @@ import {
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
+import { userIsAdmin } from '../../../../utils/authUser'
 
 const CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -51,7 +52,7 @@ export default defineEventHandler(async (event) => {
         mayView = Boolean(
           auth.isValid &&
             auth.user &&
-            (auth.user.Role === 'ADMIN' || auth.user.id === image.userId),
+            (userIsAdmin(auth.user) || auth.user.id === image.userId),
         )
       } catch {
         mayView = false

--- a/server/api/bots/[id].delete.ts
+++ b/server/api/bots/[id].delete.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError, getRouterParam } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -40,7 +41,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
+    const isAdmin = Boolean(user && userIsAdmin(user))
     const isOwner = user?.id === bot.userId
 
     if (!isAdmin && !isServerKey && !isOwner) {

--- a/server/api/bots/[id].patch.ts
+++ b/server/api/bots/[id].patch.ts
@@ -9,6 +9,7 @@ import { syncBotFacetsInTransaction } from '../../utils/botFacetSync'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { botMutationSelect } from './selects'
 import { assertBotRelationsAttachable } from './relations'
+import { userIsAdmin } from '../../utils/authUser'
 
 type BotPatchBody = Partial<Omit<Bot, 'userId'>> &
   Record<string, unknown> & {
@@ -159,7 +160,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
+    const isAdmin = Boolean(user && userIsAdmin(user))
     const isOwner = user?.id === existingBot.userId
 
     if (!isAdmin && !isServerKey && !isOwner) {

--- a/server/api/bots/batch.post.ts
+++ b/server/api/bots/batch.post.ts
@@ -6,6 +6,7 @@ import { validateApiKey } from '../../utils/validateKey'
 import { syncBotFacetsInTransaction } from '../../utils/botFacetSync'
 import type { Bot, Prisma } from '~/prisma/generated/prisma/client'
 import { assertBotRelationsAttachable } from './relations'
+import { userIsAdmin } from '../../utils/authUser'
 
 type BotBatchPatch = Partial<Omit<Bot, 'userId'>> &
   Record<string, unknown> & {
@@ -273,7 +274,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
+    const isAdmin = Boolean(user && userIsAdmin(user))
 
     const forbiddenIds = existingBots
       .filter((bot) => !isAdmin && !isServerKey && user?.id !== bot.userId)

--- a/server/api/bots/expressions.post.ts
+++ b/server/api/bots/expressions.post.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import type { ExpressionMedia, Prisma } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../utils/authUser'
 
 export const config = {
   maxDuration: 60,
@@ -208,7 +209,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
+    const isAdmin = Boolean(user && userIsAdmin(user))
 
     if (!isAdmin && !isServerKey) {
       throw createError({

--- a/server/api/bots/threads.post.ts
+++ b/server/api/bots/threads.post.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { validateApiKey } from '../../utils/validateKey'
 import { errorHandler } from '../../utils/error'
+import { userIsAdmin } from '../../utils/authUser'
 
 export const config = {
   maxDuration: 60,
@@ -53,7 +54,7 @@ export default defineEventHandler(async (event) => {
     // NarratorThread rows are global, non-user-owned content. Match the sibling
     // transitions/expressions routes: only admins or server keys may write them.
     const isServerKey = auth.kind === 'server'
-    const isAdmin = auth.user?.Role === 'ADMIN' || auth.user?.id === 1
+    const isAdmin = Boolean(auth.user && userIsAdmin(auth.user))
     if (!isAdmin && !isServerKey) {
       event.node.res.statusCode = 403
       return {

--- a/server/api/bots/topics.post.ts
+++ b/server/api/bots/topics.post.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, readBody } from 'h3'
 import prisma from '../../utils/prisma'
 import { validateApiKey } from '../../utils/validateKey'
 import { errorHandler } from '../../utils/error'
+import { userIsAdmin } from '../../utils/authUser'
 
 type TopicInput = {
   slug: string
@@ -38,7 +39,7 @@ export default defineEventHandler(async (event) => {
     // NarratorTopic rows are global, non-user-owned content. Match the sibling
     // transitions/expressions routes: only admins or server keys may write them.
     const isServerKey = auth.kind === 'server'
-    const isAdmin = auth.user?.Role === 'ADMIN' || auth.user?.id === 1
+    const isAdmin = Boolean(auth.user && userIsAdmin(auth.user))
     if (!isAdmin && !isServerKey) {
       event.node.res.statusCode = 403
       return {

--- a/server/api/bots/transitions.post.ts
+++ b/server/api/bots/transitions.post.ts
@@ -7,6 +7,7 @@ import type {
   ExpressionTransition,
   Prisma,
 } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../utils/authUser'
 
 // Allow up to 60s on Vercel (Pro). Harmless on platforms that ignore it.
 export const config = {
@@ -142,7 +143,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user?.Role === 'ADMIN' || user?.id === 1
+    const isAdmin = Boolean(user && userIsAdmin(user))
 
     if (!isAdmin && !isServerKey) {
       throw createError({

--- a/server/api/challenges/variants.post.ts
+++ b/server/api/challenges/variants.post.ts
@@ -13,6 +13,7 @@ import {
   extractPlaceholderKeys,
   normalizeVariantKey,
 } from '~/server/utils/promptVariants'
+import { userIsAdmin } from '../../utils/authUser'
 
 type VariantsBody = {
   basePrompt?: unknown
@@ -120,7 +121,7 @@ export default defineEventHandler(async (event) => {
         taxonomies: requestedFacetTaxonomies,
         randomizableOnly: true,
         userId: auth.user.id,
-        isAdmin: auth.user.Role === 'ADMIN' || auth.user.id === 1,
+        isAdmin: userIsAdmin(auth.user),
       })
 
       for (const [placeholder, taxonomies] of Object.entries(

--- a/server/api/characters/[id].patch.ts
+++ b/server/api/characters/[id].patch.ts
@@ -18,6 +18,7 @@ import {
   stripCharacterCompatibilityFields,
 } from './compatibility'
 import { characterMutationSelect } from './selects'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -57,7 +58,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const isOwner = existingCharacter.userId === user.id
 
     if (!isAdmin && !isServerKey && !isOwner) {

--- a/server/api/characters/batch.post.ts
+++ b/server/api/characters/batch.post.ts
@@ -21,6 +21,7 @@ import {
   characterMutationSelect,
   type CharacterMutationResult,
 } from './selects'
+import { userIsAdmin } from '../../utils/authUser'
 
 const transactionMaxWaitMs = 10_000
 const transactionTimeoutMs = 30_000
@@ -173,7 +174,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const slugs = await resolveCharacterSlugs(characters, user.id)
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const createInputs = await Promise.all(
       characters.map(async (characterData, index) => {
         await assertCharacterRelationsAttachable(

--- a/server/api/characters/index.post.ts
+++ b/server/api/characters/index.post.ts
@@ -21,6 +21,7 @@ import {
   stripCharacterCompatibilityFields,
 } from './compatibility'
 import { characterMutationSelect } from './selects'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -42,7 +43,7 @@ export default defineEventHandler(async (event) => {
     assertCharacterCreateCompatibility(rawBody)
 
     const body = stripCharacterCompatibilityFields(rawBody)
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
 
     await assertCharacterRelationsAttachable(body, user.id, isAdmin)
 

--- a/server/api/chats/user/inbox/[id].get.ts
+++ b/server/api/chats/user/inbox/[id].get.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, getRouterParam } from 'h3'
 import prisma from '../../../../utils/prisma'
 import { errorHandler } from '../../../../utils/error'
 import { validateApiKey } from '../../../../utils/validateKey'
+import { userIsAdmin } from '../../../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -26,7 +27,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
 
     if (!isAdmin && user.id !== id) {
       return errorHandler({

--- a/server/api/chats/welcome.post.ts
+++ b/server/api/chats/welcome.post.ts
@@ -8,6 +8,7 @@ import {
   WELCOME_TITLE,
   sendWelcomeMessage,
 } from '../../utils/welcomeMessage'
+import { userIsAdmin } from '../../utils/authUser'
 
 type WelcomeBody = {
   markAsRead?: boolean
@@ -26,7 +27,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const isServerKey = kind === 'server'
 
     if (!isAdmin && !isServerKey) {

--- a/server/api/icons/[id].delete.ts
+++ b/server/api/icons/[id].delete.ts
@@ -3,6 +3,7 @@ import { createError, defineEventHandler } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id = 0
@@ -38,7 +39,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (icon.userId !== user.id && user.Role !== 'ADMIN') {
+    if (icon.userId !== user.id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You are not authorized to delete this SmartIcon.',

--- a/server/api/icons/[id].patch.ts
+++ b/server/api/icons/[id].patch.ts
@@ -8,6 +8,7 @@ import {
   findExistingSmartIcon,
   hasSmartIconUpdate,
 } from './create'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id = 0
@@ -50,7 +51,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (existingIcon.userId !== user.id && user.Role !== 'ADMIN') {
+    if (existingIcon.userId !== user.id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to update this SmartIcon.',

--- a/server/api/karma/[id].get.ts
+++ b/server/api/karma/[id].get.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError } from 'h3'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id
@@ -26,7 +27,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // You can only read your own karma — unless you're ADMIN.
-    if (user.id !== id && user.Role !== 'ADMIN') {
+    if (user.id !== id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to view this karma balance.',

--- a/server/api/mana/[id].get.ts
+++ b/server/api/mana/[id].get.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { maybeRefill } from '../../utils/refill'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id
@@ -27,7 +28,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // You can only read your own wallet — unless you're ADMIN.
-    if (user.id !== id && user.Role !== 'ADMIN') {
+    if (user.id !== id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to view this wallet.',

--- a/server/api/model-builder/items/[id]/commit.post.ts
+++ b/server/api/model-builder/items/[id]/commit.post.ts
@@ -22,6 +22,7 @@ import {
   legacyFacetKindForTaxonomy,
   normalizeFacetTaxonomy,
 } from '~/server/utils/facetProfileInput'
+import { userIsAdmin } from '../../../../utils/authUser'
 
 type TransactionClient = Parameters<
   Parameters<typeof prisma.$transaction>[0]
@@ -513,7 +514,7 @@ export default defineEventHandler(async (event) => {
     const dryRun = body?.dryRun === true
     const syncOptions: SyncOptions = {
       userId: auth.user.id,
-      isAdmin: auth.user.Role === 'ADMIN' || auth.user.id === 1,
+      isAdmin: userIsAdmin(auth.user),
     }
 
     const item = await prisma.modelBuildItem.findUnique({

--- a/server/api/model-builder/runs/index.ts
+++ b/server/api/model-builder/runs/index.ts
@@ -6,6 +6,7 @@ import type {
   ModelBuildStatus,
   ModelBuildItem,
 } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../../utils/authUser'
 
 export const modelBuildStatuses = new Set<ModelBuildStatus>([
   'DRAFT',
@@ -53,7 +54,7 @@ export function assertRunAccess(
   run: { userId: number | null },
   user: { id: number; Role?: string | null },
 ): void {
-  if (user.Role !== 'ADMIN' && run.userId !== user.id) {
+  if (!userIsAdmin(user) && run.userId !== user.id) {
     throw createError({
       statusCode: 403,
       message: 'You do not have permission to modify this build run.',

--- a/server/api/projects/[id].get.ts
+++ b/server/api/projects/[id].get.ts
@@ -4,6 +4,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
 import { projectInclude } from './index'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -27,7 +28,7 @@ export default defineEventHandler(async (event) => {
         const auth = await validateApiKey(event)
         if (auth.isValid && auth.user) {
           userId = auth.user.id
-          isAdmin = auth.user.Role === 'ADMIN'
+          isAdmin = userIsAdmin(auth.user)
         }
       } catch {}
     }

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -23,6 +23,7 @@ import {
   projectStatuses,
 } from './index'
 import { projectMutationSelect } from './selects'
+import { userRoles } from '~/server/utils/authUser'
 
 type ProjectPatchBody = Record<string, unknown>
 
@@ -67,7 +68,7 @@ export default defineEventHandler(async (event) => {
     ) {
       await enforceProjectCap({
         userId: auth.user.id,
-        userRole: auth.user.Role,
+        userRoles: [...userRoles(auth.user)],
         isAdmin: auth.isAdmin || auth.user.id === 1,
       })
     }

--- a/server/api/projects/[id]/art/index.get.ts
+++ b/server/api/projects/[id]/art/index.get.ts
@@ -8,6 +8,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
 import { getProjectId } from '../../index'
+import { userIsAdmin } from '../../../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -52,7 +53,7 @@ export default defineEventHandler(async (event) => {
         mayView = Boolean(
           auth.isValid &&
             auth.user &&
-            (auth.user.Role === 'ADMIN' || auth.user.id === project.userId),
+            (userIsAdmin(auth.user) || auth.user.id === project.userId),
         )
       } catch {
         mayView = false

--- a/server/api/projects/index.get.ts
+++ b/server/api/projects/index.get.ts
@@ -5,6 +5,7 @@ import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
 import { projectInclude, projectPriorities, projectStatuses } from './index'
+import { userIsAdmin } from '../../utils/authUser'
 
 type ProjectListQuery = {
   take?: string
@@ -40,7 +41,7 @@ export default defineEventHandler(async (event) => {
         const auth = await validateApiKey(event)
         if (auth.isValid && auth.user) {
           userId = auth.user.id
-          isAdmin = auth.user.Role === 'ADMIN'
+          isAdmin = userIsAdmin(auth.user)
         }
       } catch {
         userId = null

--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -22,6 +22,7 @@ import {
   projectStatuses,
 } from './index'
 import { projectMutationSelect } from './selects'
+import { userRoles } from '~/server/utils/authUser'
 
 type ProjectCreateBody = {
   title?: unknown
@@ -123,7 +124,7 @@ export default defineEventHandler(async (event) => {
     if (isActive && (status === 'ACTIVE' || status === 'PAUSED')) {
       await enforceProjectCap({
         userId: auth.user.id,
-        userRole: auth.user.Role,
+        userRoles: [...userRoles(auth.user)],
         isAdmin: auth.isAdmin || auth.user.id === 1,
       })
     }

--- a/server/api/projects/index.ts
+++ b/server/api/projects/index.ts
@@ -7,6 +7,7 @@ import type {
   ProjectStatus,
 } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
+import { userIsAdmin } from '../../utils/authUser'
 
 export const projectStatuses = new Set<ProjectStatus>([
   'ACTIVE',
@@ -192,7 +193,7 @@ export function assertProjectAccess(
   project: { userId: number | null },
   user: { id: number; Role?: string | null },
 ): void {
-  if (user.Role !== 'ADMIN' && project.userId !== user.id) {
+  if (!userIsAdmin(user) && project.userId !== user.id) {
     throw createError({
       statusCode: 403,
       message: 'You do not have permission to modify this Project.',

--- a/server/api/prompts/generate.post.ts
+++ b/server/api/prompts/generate.post.ts
@@ -13,6 +13,7 @@ import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { resolveServer, getServerEndpoint } from '../../utils/serverResolver'
 import { awardKarma } from '../../utils/karma'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -34,7 +35,7 @@ export default defineEventHandler(async (event) => {
     // Only the prompt owner, an admin, or the render relay (server key) may drive
     // this prompt through the art state machine and rebind its artImageId.
     const isServerKey = kind === 'server'
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     if (!isAdmin && !isServerKey && prompt.userId !== user.id) {
       throw createError({
         statusCode: 403,

--- a/server/api/reactions/dream/[id].patch.ts
+++ b/server/api/reactions/dream/[id].patch.ts
@@ -9,6 +9,7 @@ import {
   Reaction_reactionCategory,
   type Prisma,
 } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../../utils/authUser'
 
 type DreamReactionPatchBody = {
   reactionType?: unknown
@@ -78,7 +79,7 @@ export default defineEventHandler(async (event) => {
 
     // The target Dream must exist and be public or owned by the reacting user
     // (admins bypass), matching POST /api/reactions (audit F-2 residual).
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const targetDreamId: number = dreamId
     await assertReactionContentTargetAccessible({
       find: () =>

--- a/server/api/reactions/index.post.ts
+++ b/server/api/reactions/index.post.ts
@@ -9,6 +9,7 @@ import {
   Reaction_reactionCategory,
   type Prisma,
 } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../utils/authUser'
 
 type ReactionBody = Record<string, unknown> & {
   reactionType?: unknown
@@ -400,7 +401,7 @@ export default defineEventHandler(async (event) => {
     const targets = getTargetFields(body)
     const targetWhere = buildTargetWhere(reactionCategory, targets)
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     await assertReactionTargetAccessible(
       reactionCategory,
       targets,

--- a/server/api/resources/[id].patch.ts
+++ b/server/api/resources/[id].patch.ts
@@ -7,6 +7,7 @@ import { validateApiKey } from '../../utils/validateKey'
 import { resourceMutationSelect } from './selects'
 import { assertOwnershipIsUnchanged } from './compatibility'
 import type { Prisma, Resource } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../utils/authUser'
 
 type ResourcePatchBody = Partial<Omit<Resource, 'userId'>> &
   Record<string, unknown> & {
@@ -62,7 +63,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isOwner = existingResource.userId === user.id
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
 
     if (!isOwner && !isAdmin) {
       throw createError({

--- a/server/api/rewards/[id].patch.ts
+++ b/server/api/rewards/[id].patch.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { updateRewardById, type RewardMutationInput } from './index'
 import { assertRewardMutationInput, rewardPatchFields } from './mutation'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   const rewardId = Number(event.context.params?.id)
@@ -41,7 +42,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (existingReward.userId !== user.id && user.Role !== 'ADMIN') {
+    if (existingReward.userId !== user.id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to update this reward.',
@@ -80,7 +81,7 @@ export default defineEventHandler(async (event) => {
       requireNonEmpty: true,
     })
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const data = await updateRewardById(rewardId, rewardData, user.id, isAdmin)
 
     event.node.res.statusCode = 200

--- a/server/api/rewards/batch.post.ts
+++ b/server/api/rewards/batch.post.ts
@@ -8,6 +8,7 @@ import {
   rewardBatchCreateFields,
   REWARD_BATCH_LIMIT,
 } from './mutation'
+import { userIsAdmin } from '../../utils/authUser'
 
 type RewardBatchBody =
   | RewardMutationInput[]
@@ -91,7 +92,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const { count, rewards, errors } = await createRewardsBatch(
       rewardsData,
       user.id,

--- a/server/api/rewards/index.post.ts
+++ b/server/api/rewards/index.post.ts
@@ -4,6 +4,7 @@ import { errorHandler } from '../../utils/error'
 import { validateApiKey } from '../../utils/validateKey'
 import { createReward, type RewardMutationInput } from './'
 import { assertRewardMutationInput, rewardCreateFields } from './mutation'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -46,7 +47,7 @@ export default defineEventHandler(async (event) => {
       context: 'Reward create payload',
     })
 
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
     const data = await createReward(rewardData, user.id, isAdmin)
 
     event.node.res.statusCode = 201

--- a/server/api/sheets/[id].delete.ts
+++ b/server/api/sheets/[id].delete.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id = 0
@@ -40,7 +41,7 @@ export default defineEventHandler(async (event) => {
       existing.userId === user.id ||
       existing.Dream?.userId === user.id ||
       existing.Project?.userId === user.id
-    if (user.Role !== 'ADMIN' && !isOwner) {
+    if (!userIsAdmin(user) && !isOwner) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to delete this PitchSheet.',

--- a/server/api/sheets/[id].get.ts
+++ b/server/api/sheets/[id].get.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id = 0
@@ -54,7 +55,7 @@ export default defineEventHandler(async (event) => {
 
     if (
       !canView &&
-      (!isValid || !user || (user.Role !== 'ADMIN' && !isOwner))
+      (!isValid || !user || (!userIsAdmin(user) && !isOwner))
     ) {
       throw createError({
         statusCode: 403,

--- a/server/api/sheets/[id].patch.ts
+++ b/server/api/sheets/[id].patch.ts
@@ -8,6 +8,7 @@ import {
   sanitizePitchSheetPayload,
 } from '@/server/utils/pitchSheets/payload'
 import { pitchSheetMutationSelect } from './selects'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id = 0
@@ -48,7 +49,7 @@ export default defineEventHandler(async (event) => {
       existing.Dream?.userId === user.id ||
       existing.Project?.userId === user.id
 
-    if (user.Role !== 'ADMIN' && !isOwner) {
+    if (!userIsAdmin(user) && !isOwner) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to update this PitchSheet.',

--- a/server/api/sheets/batch.post.ts
+++ b/server/api/sheets/batch.post.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
 import { buildPitchSheetFromDream } from '@/server/utils/pitchSheets/defaults'
 import type { DreamType, Prisma } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export const config = {
   maxDuration: 60,
@@ -140,7 +141,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isServerKey = kind === 'server'
-    const isAdmin = user.Role === 'ADMIN' || user.id === 1
+    const isAdmin = userIsAdmin(user)
 
     if (!isAdmin && !isServerKey) {
       throw createError({

--- a/server/api/sheets/by-dream/[dreamId].get.ts
+++ b/server/api/sheets/by-dream/[dreamId].get.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { validateApiKey } from '@/server/utils/validateKey'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let dreamId = 0
@@ -42,7 +43,7 @@ export default defineEventHandler(async (event) => {
     const canView =
       data.isPublic &&
       (data.Dream?.isPublic ?? data.Project?.isPublic ?? false)
-    if (!canView && (!isValid || !user || (user.Role !== 'ADMIN' && !isOwner))) {
+    if (!canView && (!isValid || !user || (!userIsAdmin(user) && !isOwner))) {
       throw createError({ statusCode: 403, message: 'You are not authorized to view this PitchSheet.' })
     }
 

--- a/server/api/sheets/by-dream/[dreamId].post.ts
+++ b/server/api/sheets/by-dream/[dreamId].post.ts
@@ -9,6 +9,7 @@ import {
   sanitizePitchSheetPayload,
 } from '@/server/utils/pitchSheets/payload'
 import { pitchSheetMutationSelect } from '../selects'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let dreamId = 0
@@ -33,7 +34,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    if (dream.userId !== user.id && user.Role !== 'ADMIN') {
+    if (dream.userId !== user.id && !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: `You are not authorized to create a PitchSheet for Dream ${dreamId}.`,

--- a/server/api/themes/[id].delete.ts
+++ b/server/api/themes/[id].delete.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, createError } from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -31,7 +32,7 @@ export default defineEventHandler(async (event) => {
     if (
       existing.userId != null &&
       existing.userId !== user.id &&
-      user.Role !== 'ADMIN'
+      !userIsAdmin(user)
     ) {
       throw createError({
         statusCode: 403,

--- a/server/api/themes/[id].patch.ts
+++ b/server/api/themes/[id].patch.ts
@@ -6,6 +6,7 @@ import { validateApiKey } from '~/server/utils/validateKey'
 import { stringifyValues, parseTheme } from '@/server/api/themes/index'
 import { assertThemeMutationInput, themePatchFields } from './mutation'
 import type { Prisma } from '~/prisma/generated/prisma/client'
+import { userIsAdmin } from '../../utils/authUser'
 
 export default defineEventHandler(async (event) => {
   let id: number | undefined
@@ -41,7 +42,7 @@ export default defineEventHandler(async (event) => {
     if (
       existing.userId != null &&
       existing.userId !== user.id &&
-      user.Role !== 'ADMIN'
+      !userIsAdmin(user)
     ) {
       throw createError({ statusCode: 403, message: 'Unauthorized.' })
     }

--- a/server/api/todos/index.post.ts
+++ b/server/api/todos/index.post.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
 import { assertOnlyFields } from '@/server/utils/chatApi'
 import { todoMutationFields } from './mutation'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 const todoPriorities = ['LOW', 'NORMAL', 'HIGH'] as const
 const todoCategories = [
@@ -96,7 +97,7 @@ export default defineEventHandler(async (event) => {
         throw createError({ statusCode: 404, message: 'Project not found.' })
       }
 
-      if (auth.user.Role !== 'ADMIN' && project.userId !== userId) {
+      if (!userIsAdmin(auth.user) && project.userId !== userId) {
         throw createError({
           statusCode: 403,
           message: 'You do not have permission to add Todos to this Project.',
@@ -114,7 +115,7 @@ export default defineEventHandler(async (event) => {
         throw createError({ statusCode: 404, message: 'Dream not found.' })
       }
 
-      if (auth.user.Role !== 'ADMIN' && dream.userId !== userId) {
+      if (!userIsAdmin(auth.user) && dream.userId !== userId) {
         throw createError({
           statusCode: 403,
           message: 'You do not have permission to add Todos to this Dream.',

--- a/server/api/todos/project/[projectId].get.ts
+++ b/server/api/todos/project/[projectId].get.ts
@@ -4,6 +4,7 @@ import { createError, defineEventHandler, H3Error } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
 import { requireApiUser } from '@/server/utils/authGuard'
+import { userIsAdmin } from '@/server/utils/authUser'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -23,7 +24,7 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 404, message: 'Project not found.' })
     }
 
-    if (auth.user.Role !== 'ADMIN' && project.userId !== auth.user.id) {
+    if (!userIsAdmin(auth.user) && project.userId !== auth.user.id) {
       throw createError({
         statusCode: 403,
         message: 'You do not have permission to view this Project.',

--- a/server/api/users/[id].delete.ts
+++ b/server/api/users/[id].delete.ts
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
     const requestingUserId = user?.id
     const isSelf = requestingUserId === targetUserId
     const isAdmin = Boolean(
-      user && userIsAdmin({ id: user.id, Role: user.Role }),
+      user && userIsAdmin(user),
     )
 
     if (!isValid || (!isSelf && !isAdmin)) {
@@ -34,9 +34,13 @@ export default defineEventHandler(async (event) => {
       })
     }
 
+    // UserRoles is required, not optional: this is the guard that stops one
+    // admin deleting another, so it must see an ADMIN that exists only in the
+    // join table. Selecting `Role` alone would silently leave such an account
+    // unprotected.
     const targetUser = await prisma.user.findUnique({
       where: { id: targetUserId },
-      select: { id: true, Role: true },
+      select: { id: true, Role: true, UserRoles: { select: { role: true } } },
     })
 
     if (!targetUser) {

--- a/server/api/users/cypress-cleanup.post.ts
+++ b/server/api/users/cypress-cleanup.post.ts
@@ -25,7 +25,7 @@ const clampInteger = (
 export default defineEventHandler(async (event) => {
   try {
     const { isValid, user } = await validateApiKey(event)
-    if (!isValid || !user || !userIsAdmin({ id: user.id, Role: user.Role })) {
+    if (!isValid || !user || !userIsAdmin(user)) {
       throw createError({
         statusCode: 403,
         message: 'Administrator access is required for Cypress cleanup.',
@@ -55,13 +55,21 @@ export default defineEventHandler(async (event) => {
       ? 1
       : clampInteger(body?.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
     const cutoff = new Date(Date.now() - maxAgeMs)
+    // Both halves of the admin guard are required. `Role` is only the PRIMARY
+    // role, so on its own it would happily match -- and therefore delete -- a
+    // user whose admin-ness lives in the UserRole join table. This is the
+    // protective direction of the check, so it has to be the stricter one.
+    const NOT_ADMIN: Prisma.UserWhereInput = {
+      Role: { not: 'ADMIN' },
+      UserRoles: { none: { role: 'ADMIN' } },
+    }
     const where: Prisma.UserWhereInput = exactUsername
       ? {
-          Role: { not: 'ADMIN' },
+          ...NOT_ADMIN,
           username: exactUsername,
         }
       : {
-          Role: { not: 'ADMIN' },
+          ...NOT_ADMIN,
           createdAt: { lte: cutoff },
           OR: [
             { username: { startsWith: 'cypress-' } },

--- a/server/utils/authGuard.ts
+++ b/server/utils/authGuard.ts
@@ -51,12 +51,20 @@ function getBetaAdminUserId(): number {
   return Number.isInteger(raw) && raw > 0 ? raw : 1
 }
 
+// Every user-resolving path here loads the UserRole join table alongside the
+// user, so `AuthUser.roles` is the complete set and downstream guards never
+// have to issue a second query to answer "is this user an admin". The include
+// is the reason `userIsAdmin` can stay synchronous and no call site signature
+// had to change when roles went plural.
+const WITH_ROLES = { UserRoles: { select: { role: true } } } as const
+
 async function getUserById(id: number): Promise<AuthUser | null> {
   const user = await prisma.user.findUnique({
     where: { id },
+    include: WITH_ROLES,
   })
 
-  return user ? withAdminFlag(user) : null
+  return user ? withAdminFlag(user, user.UserRoles) : null
 }
 
 async function validateJwtAuth(token: string): Promise<AuthGuardResult | null> {
@@ -110,11 +118,12 @@ async function validateUserApiKeyAuth(
 
   const user = await prisma.user.findFirst({
     where: { apiKey: token },
+    include: WITH_ROLES,
   })
 
   if (!user || user.isActive === false) return null
 
-  const authUser = withAdminFlag(user)
+  const authUser = withAdminFlag(user, user.UserRoles)
 
   return {
     user: authUser,

--- a/server/utils/authUser.ts
+++ b/server/utils/authUser.ts
@@ -1,21 +1,112 @@
 // /server/utils/authUser.ts
-import type { User } from '~/prisma/generated/prisma/client'
+import type { Role, User } from '~/prisma/generated/prisma/client'
 
+/**
+ * The authenticated user, plus the two derived facts every guard needs.
+ *
+ * `roles` is the user's COMPLETE role set, read from the UserRole join table.
+ * Every user was backfilled with a row matching their `User.Role`, so this
+ * array alone is a correct answer -- a caller never has to consult both.
+ * `User.Role` remains as the primary/display role and is still written.
+ */
 export type AuthUser = User & {
   isAdmin: boolean
+  roles: Role[]
 }
 
-type AdminCheckUser = Pick<User, 'id'> & {
+/**
+ * The minimum shape the role predicates below can answer questions about.
+ *
+ * Deliberately loose: `validateApiKey` (server/utils/validateKey.ts) resolves a
+ * user through a different path and returns only `{ id, Role }`, with no join
+ * table load. Both resolvers must be able to reach these predicates, so `roles`
+ * is optional and the legacy scalar is always consulted as a fallback.
+ */
+type RoleCheckUser = Pick<User, 'id'> & {
   Role?: User['Role'] | string | null
+  roles?: readonly (Role | string)[] | null
+  // Accepted so a Prisma record loaded with `include: { UserRoles: ... }` can be
+  // passed straight in. Without this every call site would hand-map the
+  // relation to `roles`, and the one that forgets gets a silent demotion rather
+  // than a type error.
+  UserRoles?: readonly { role: Role | string }[] | null
 }
 
-export function userIsAdmin(user: AdminCheckUser): boolean {
-  return String(user.Role || '').toUpperCase() === 'ADMIN' || user.id === 1
+function normalize(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
 }
 
-export function withAdminFlag(user: User): AuthUser {
+/**
+ * Every role this user holds, as a normalized uppercase set.
+ *
+ * Dual-read on purpose. The join table is authoritative once loaded, but the
+ * scalar column is included unconditionally so that a caller who resolved the
+ * user without the join (validateKey, a narrow Prisma `select`, a test fixture
+ * built by hand) still gets a correct answer instead of a silently empty set.
+ * An empty `roles` array therefore means "not loaded", never "no roles" --
+ * conflating those is what turns a missing include into a privilege bug.
+ */
+export function userRoles(user: RoleCheckUser): Set<string> {
+  const roles = new Set<string>()
+  for (const role of user.roles ?? []) {
+    const normalized = normalize(role)
+    if (normalized) roles.add(normalized)
+  }
+  for (const entry of user.UserRoles ?? []) {
+    const normalized = normalize(entry?.role)
+    if (normalized) roles.add(normalized)
+  }
+  const primary = normalize(user.Role)
+  if (primary) roles.add(primary)
+  return roles
+}
+
+/**
+ * Does this user hold `role`? Case-insensitive, and true if the role appears
+ * EITHER in the join table or in the legacy primary column.
+ *
+ * Use this instead of `user.Role === 'FAMILY'`. An inline comparison against
+ * the scalar reads only the primary role, so it silently returns false for a
+ * user who holds that role as a secondary -- which is the entire point of
+ * multi-role.
+ */
+export function userHasRole(user: RoleCheckUser, role: Role | string): boolean {
+  const wanted = normalize(role)
+  return wanted ? userRoles(user).has(wanted) : false
+}
+
+/**
+ * The canonical admin predicate. `id === 1` is the historical bootstrap
+ * account and stays an escape hatch.
+ *
+ * Prefer this over `user.Role === 'ADMIN'`. The inline form was never
+ * consistent with this one anyway -- some sites included the `|| id === 1`
+ * escape hatch and some did not, and this predicate uppercases where the inline
+ * sites compared raw -- and under multi-role it is now also wrong, because an
+ * admin whose PRIMARY role is CHILD or FAMILY reads as non-admin.
+ */
+export function userIsAdmin(user: RoleCheckUser): boolean {
+  return userRoles(user).has('ADMIN') || user.id === 1
+}
+
+/**
+ * Attach the derived flags to a freshly-loaded user.
+ *
+ * `roles` comes from the `UserRoles` relation when the caller included it. Pass
+ * it explicitly rather than letting it default: an omitted include yields an
+ * empty array, which `userRoles` deliberately treats as "not loaded" and covers
+ * by falling back to the scalar column.
+ */
+export function withAdminFlag(
+  user: User,
+  roles?: readonly { role: Role }[] | null,
+): AuthUser {
+  const resolved = (roles ?? []).map((entry) => entry.role)
+  const withRoles = { ...user, roles: resolved }
   return {
-    ...user,
-    isAdmin: userIsAdmin(user),
+    ...withRoles,
+    isAdmin: userIsAdmin(withRoles),
   }
 }

--- a/server/utils/charge.ts
+++ b/server/utils/charge.ts
@@ -1,6 +1,7 @@
 // /server/utils/charge.ts
 import { applyMana, usdToMana } from './mana'
 import type { Role } from '~/prisma/generated/prisma/client'
+import { userIsAdmin, userHasRole } from './authUser'
 
 type Plan = 'community' | 'byok' | 'local' | 'family'
 
@@ -16,7 +17,7 @@ export async function chargeForGeneration(opts: {
   const reason = kind === 'art' ? 'GENERATION_ART' : 'GENERATION_TEXT'
 
   // FAMILY: free on admin token, logged at zero for visibility
-  if (user.Role === 'FAMILY' || plan === 'family') {
+  if (userHasRole(user, 'FAMILY') || plan === 'family') {
     await applyMana({
       userId: user.id,
       amount: 0,
@@ -55,7 +56,7 @@ export async function chargeForGeneration(opts: {
   })
 
   // ADMIN: refund immediately so the test shows real cost but doesn't drain
-  if (user.Role === 'ADMIN') {
+  if (userIsAdmin(user)) {
     await applyMana({
       userId: user.id,
       amount: cost,

--- a/server/utils/manaGate.ts
+++ b/server/utils/manaGate.ts
@@ -2,7 +2,7 @@
 import { createError, type H3Event } from 'h3'
 import prisma from './prisma'
 import { requireApiUser } from './authGuard'
-import { userIsAdmin } from './authUser'
+import { userIsAdmin, userRoles } from './authUser'
 import { applyMana } from './mana'
 import type { ManaReason } from './mana'
 import { resolveManaGateTarget } from './manaGateTarget'
@@ -92,7 +92,7 @@ export async function manaGate(
     // account, or every cross-app charge would silently cost nothing.
     isAdmin: onBehalfOfOtherUser ? userIsAdmin(user) : auth.isAdmin,
     isServerKey: onBehalfOfOtherUser ? false : auth.isServerKey,
-    userRole: user.Role,
+    userRoles: [...userRoles(user)],
     kind: input.kind,
   })
 
@@ -144,14 +144,23 @@ async function isFreeGeneration(input: {
   useOwnResource: boolean
   isAdmin: boolean
   isServerKey: boolean
-  userRole?: string | null
+  // The COMPLETE role set, not just the primary column. FAMILY is a permissive
+  // grant, so reading only `User.Role` would quietly start charging a user who
+  // holds FAMILY as a secondary role.
+  userRoles?: readonly string[] | null
   kind: ManaGateKind
 }): Promise<boolean> {
   if (input.kind === 'free') return true
   if (input.useOwnResource) return true
   if (input.isAdmin) return true
   if (input.isServerKey) return true
-  if (String(input.userRole ?? '').toUpperCase() === 'FAMILY') return true
+  if (
+    (input.userRoles ?? []).some(
+      (role) => String(role).toUpperCase() === 'FAMILY',
+    )
+  ) {
+    return true
+  }
 
   return await isFreeServerForUser({
     userId: input.userId,

--- a/server/utils/projectCap.ts
+++ b/server/utils/projectCap.ts
@@ -6,16 +6,22 @@ export const FREE_PROJECT_LIMIT = 2
 
 /**
  * Throws HTTP 403 if the user has reached the free project cap.
- * No-op for admins (id=1 or Role=ADMIN), FAMILY role, and active members.
+ * No-op for admins (id=1 or ADMIN), FAMILY accounts, and active members.
+ *
+ * `userRoles` is the COMPLETE role set, not just `User.Role`. Both exemptions
+ * here are permissive, so reading only the primary column would start capping a
+ * user who holds ADMIN or FAMILY as a secondary role.
  */
 export async function enforceProjectCap(input: {
   userId: number
-  userRole: string | null | undefined
+  userRoles: readonly string[] | null | undefined
   isAdmin: boolean
 }): Promise<void> {
   if (input.isAdmin) return
-  const role = String(input.userRole ?? '').toUpperCase()
-  if (role === 'ADMIN' || role === 'FAMILY') return
+  const roles = new Set(
+    (input.userRoles ?? []).map((role) => String(role).toUpperCase()),
+  )
+  if (roles.has('ADMIN') || roles.has('FAMILY')) return
 
   const userRecord = await prisma.user.findUnique({
     where: { id: input.userId },

--- a/server/utils/relations.ts
+++ b/server/utils/relations.ts
@@ -5,6 +5,7 @@
 
 import type { RelationType } from '~/prisma/generated/prisma/client'
 import prisma from './prisma'
+import { userHasRole } from './authUser'
 
 // The inverse role for the OTHER user when a relation is accepted.
 // FRIEND is symmetric; PARENT/CHILD swap; REFEREE/BLOCK have no owned inverse.
@@ -108,11 +109,14 @@ export async function acceptPair(rowId: number) {
 // their CHILD role back to USER. Safe with multiple parents: only reverts
 // once the last family link is gone. Never touches non-CHILD roles.
 export async function maybeRevertChildRole(userId: number): Promise<void> {
+  // UserRoles is included so a user who holds CHILD only as a secondary role
+  // -- the whole point of multi-role -- is still seen here. Selecting `Role`
+  // alone would skip the revert and strand them as a child forever.
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { id: true, Role: true },
+    select: { id: true, Role: true, UserRoles: { select: { role: true } } },
   })
-  if (!user || user.Role !== 'CHILD') return
+  if (!user || !userHasRole(user, 'CHILD')) return
 
   // Any remaining accepted link where this user is the child?
   const stillChild = await prisma.userRelation.findFirst({

--- a/server/utils/validateKey.ts
+++ b/server/utils/validateKey.ts
@@ -6,7 +6,11 @@ import { userIsAdmin } from './authUser'
 
 export type ValidateResult = {
   isValid: boolean
-  user?: { id: number; Role: string }
+  // `roles` is the complete set from the UserRole join table; `Role` remains
+  // the primary/display role. Callers must ask through userIsAdmin/userHasRole
+  // (server/utils/authUser.ts) rather than comparing `Role` directly -- an
+  // admin whose primary role is CHILD or FAMILY only appears in `roles`.
+  user?: { id: number; Role: string; roles: string[] }
   kind?: 'jwt' | 'user-api-key' | 'beta-admin-token' | 'server'
 }
 
@@ -48,10 +52,27 @@ function getBetaAdminUserId(): number {
   return Number.isInteger(raw) && raw > 0 ? raw : 1
 }
 
+// Mirrors authGuard.WITH_ROLES. This resolver uses explicit selects rather than
+// full-row loads, so the join table has to be named here too -- omitting it
+// would leave `roles` empty and quietly demote any user whose admin-ness lives
+// only in the join table.
+const ROLE_SELECT = {
+  id: true,
+  Role: true,
+  isActive: true,
+  UserRoles: { select: { role: true } },
+} as const
+
+function flattenRoles(user: {
+  UserRoles?: { role: string }[] | null
+}): string[] {
+  return (user.UserRoles ?? []).map((entry) => String(entry.role))
+}
+
 async function getAuthUser(id: number) {
   const user = await prisma.user.findUnique({
     where: { id },
-    select: { id: true, Role: true, isActive: true },
+    select: ROLE_SELECT,
   })
 
   if (!user || !user.isActive) return null
@@ -75,7 +96,7 @@ async function validateJwtString(
 
     return {
       isValid: true,
-      user: { id: user.id, Role: user.Role },
+      user: { id: user.id, Role: user.Role, roles: flattenRoles(user) },
       kind: 'jwt',
     }
   } catch {
@@ -90,14 +111,14 @@ async function validateUserApiKeyString(
 
   const user = await prisma.user.findFirst({
     where: { apiKey: token },
-    select: { id: true, Role: true, isActive: true },
+    select: ROLE_SELECT,
   })
 
   if (!user || !user.isActive) return null
 
   return {
     isValid: true,
-    user: { id: user.id, Role: user.Role },
+    user: { id: user.id, Role: user.Role, roles: flattenRoles(user) },
     kind: 'user-api-key',
   }
 }
@@ -115,7 +136,7 @@ async function validateBetaAdminString(
 
   return {
     isValid: true,
-    user: { id: user.id, Role: user.Role },
+    user: { id: user.id, Role: user.Role, roles: flattenRoles(user) },
     kind: 'beta-admin-token',
   }
 }

--- a/utils/scripts/verifyUserRolePredicates.ts
+++ b/utils/scripts/verifyUserRolePredicates.ts
@@ -1,0 +1,141 @@
+// /utils/scripts/verifyUserRolePredicates.ts
+import {
+  userHasRole,
+  userIsAdmin,
+  userRoles,
+  withAdminFlag,
+} from '../../server/utils/authUser'
+import type { User } from '../../prisma/generated/prisma/client'
+
+// Behavioural contract for the multi-role predicates in server/utils/authUser.ts.
+//
+// Silas, 2026-08-01: "I can't make say, a Child and Admin, or Family an Admin."
+// The whole point of the change is that a user's PRIMARY role no longer decides
+// what they may do. These assertions pin the cases that make that true, and the
+// ones where getting it wrong is a privilege bug rather than a cosmetic one:
+//
+//   - CHILD primary + ADMIN secondary must read as admin. This is the case the
+//     49 migrated inline `user.Role === 'ADMIN'` comparisons all got wrong.
+//   - An empty/absent `roles` must mean "not loaded", NOT "no roles". Callers
+//     that resolve a user through validateApiKey or a narrow Prisma select get
+//     no join table, and must still be judged correctly from the scalar column.
+//     Treating absent as empty is how a missing `include` becomes a silent
+//     demotion.
+//   - Matching is case-insensitive, because the pre-existing call sites were
+//     split between raw comparison, `.toUpperCase()`, and `.toLowerCase()`.
+
+let failures = 0
+
+function check(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`ok - ${message}`)
+    return
+  }
+  failures += 1
+  console.error(`FAIL - ${message}`)
+}
+
+/** A user carrying only the fields the predicates read. */
+function asUser(fields: Record<string, unknown>): User & {
+  roles?: string[]
+  UserRoles?: { role: string }[]
+} {
+  return fields as unknown as User & {
+    roles?: string[]
+    UserRoles?: { role: string }[]
+  }
+}
+
+// --- the headline case -------------------------------------------------------
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'] })),
+  'a CHILD whose secondary role is ADMIN reads as admin',
+)
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'FAMILY', roles: ['FAMILY', 'ADMIN'] })),
+  'a FAMILY account that is also ADMIN reads as admin',
+)
+check(
+  userHasRole(asUser({ id: 42, Role: 'ADMIN', roles: ['ADMIN', 'CHILD'] }), 'CHILD'),
+  'an ADMIN whose secondary role is CHILD still holds CHILD',
+)
+
+// --- negatives ---------------------------------------------------------------
+check(
+  !userIsAdmin(asUser({ id: 42, Role: 'USER', roles: ['USER'] })),
+  'a plain USER does not read as admin',
+)
+check(
+  !userIsAdmin(asUser({ id: 42, Role: 'CHILD', roles: ['CHILD', 'DESIGNER'] })),
+  'holding some other secondary role does not confer admin',
+)
+check(
+  !userHasRole(asUser({ id: 42, Role: 'USER', roles: ['USER'] }), 'FAMILY'),
+  'a plain USER does not hold FAMILY',
+)
+check(
+  !userHasRole(asUser({ id: 42, Role: 'USER' }), ''),
+  'an empty role name matches nothing',
+)
+
+// --- absent vs empty ---------------------------------------------------------
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'ADMIN' })),
+  'an ADMIN resolved WITHOUT the join table still reads as admin (absent roles falls back to the scalar)',
+)
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'ADMIN', roles: [] })),
+  'an empty roles array means not-loaded, not no-roles, so the scalar still decides',
+)
+check(
+  !userIsAdmin(asUser({ id: 42, Role: 'USER', roles: [] })),
+  'an empty roles array does not invent an admin',
+)
+
+// --- the bootstrap escape hatch ---------------------------------------------
+check(
+  userIsAdmin(asUser({ id: 1, Role: 'USER', roles: ['USER'] })),
+  'user id 1 remains admin regardless of role (historical bootstrap account)',
+)
+
+// --- case insensitivity ------------------------------------------------------
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'admin' })),
+  'a lowercase primary role still matches',
+)
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'user', roles: ['Admin'] })),
+  'a mixed-case secondary role still matches',
+)
+
+// --- the raw Prisma relation shape ------------------------------------------
+check(
+  userIsAdmin(asUser({ id: 42, Role: 'CHILD', UserRoles: [{ role: 'ADMIN' }] })),
+  'a Prisma record loaded with `include: { UserRoles }` is accepted directly',
+)
+check(
+  userRoles(asUser({ id: 42, Role: 'CHILD', UserRoles: [{ role: 'ADMIN' }] })).size === 2,
+  'userRoles unions the join table with the primary column',
+)
+
+// --- withAdminFlag -----------------------------------------------------------
+const flagged = withAdminFlag(asUser({ id: 42, Role: 'CHILD' }), [
+  { role: 'CHILD' } as { role: User['Role'] },
+  { role: 'ADMIN' } as { role: User['Role'] },
+])
+check(
+  flagged.isAdmin && flagged.roles.length === 2,
+  'withAdminFlag derives isAdmin from the join table and exposes the full set',
+)
+const unflagged = withAdminFlag(asUser({ id: 42, Role: 'USER' }), [])
+check(
+  !unflagged.isAdmin && unflagged.roles.length === 0,
+  'withAdminFlag with no roles leaves a plain user unelevated',
+)
+
+if (failures) {
+  console.error(`\nUserRole predicate contract failed with ${failures} error(s).`)
+  process.exitCode = 1
+} else {
+  console.log('\nUserRole predicate contract passed: all cases behaved as expected.')
+}


### PR DESCRIPTION
## Why

This is the phase that actually makes multi-role work server-side. Until it lands, the `UserRole` table added in #1282 is **inert** — a user whose primary `Role` is `CHILD` and whose secondary is `ADMIN` still reads as non-admin at every one of 47 files.

This PR contains nothing else, so it bisects cleanly.

## The seam

`server/utils/authUser.ts`. Roles are loaded **at auth time**, so the predicates stay synchronous and **no call site signature had to change**:

- `getOptionalApiUser` (`authGuard.ts`) **and** `validateApiKey` (`validateKey.ts`) both include the join table. Both resolvers had to be updated — they return different user shapes, and updating only one would leave half the routes reading the scalar alone. That split is exactly what produced the dead admin bypasses fixed in #1280.
- `AuthUser` gains `roles: Role[]`.
- `userRoles()` unions the join table with the legacy column.
- `userHasRole(user, role)` added for non-admin checks; `userIsAdmin()` now reads the set.
- Both accept a raw `include: { UserRoles }` record directly, so no call site hand-maps the relation — the one that forgot would have been silently demoted with no type error.

### Absent ≠ empty

`roles` being absent or `[]` means **"not loaded"**, never **"no roles"**. A caller that resolved a user through a narrow Prisma `select`, a test fixture, or `validateApiKey` still gets a correct answer from the scalar fallback instead of a silent demotion. Conflating those two is how a forgotten `include` becomes a privilege bug, so it's asserted explicitly.

## The 48 inline comparisons

They were never consistent with each other:

- some carried the `|| user.id === 1` escape hatch, some didn't
- `userIsAdmin` uppercased; the inline sites compared raw
- the two `art/image` routes **lowercased** — one granting `SYSTEM`, the other granting `'superadmin'`, which is not a value in the `Role` enum and therefore never matched anything

`SYSTEM` is preserved (internal render callbacks depend on it); the dead `superadmin` branch is dropped rather than ported.

## Four sites that needed more than a mechanical swap

Reading only the primary column at these is a real bug, not a missed grant:

| Site | Why |
|---|---|
| `users/cypress-cleanup.post.ts` | `Role: { not: 'ADMIN' }` exists to avoid **deleting** admins. On its own it now matches — and removes — an account whose admin-ness lives only in the join table. Paired with `UserRoles: { none: { role: 'ADMIN' } }`. |
| `users/[id].delete.ts` | Guards one admin deleting another, but selected `Role` alone. Now includes the relation. |
| `relations.maybeRevertChildRole` | Would skip a secondary-CHILD user and strand them as a child forever. |
| `manaGate` + `projectCap` | The FAMILY free-generation grant and the ADMIN/FAMILY project-cap exemptions each took a single role string. Both now take the full set, so a secondary-FAMILY user isn't quietly charged or capped. |

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean.
- **New** `verifyUserRolePredicates.ts` — 17 assertions covering the headline `CHILD` primary + `ADMIN` secondary case, `FAMILY`+`ADMIN`, the absent-vs-empty distinction in both directions, case insensitivity, the `id === 1` bootstrap hatch, and the raw Prisma relation shape.
- Full authorization-adjacent contract suite, all passing: `conductor-api-auth-guards`, `channel-content`, `channel-resolver`, `challenge-center`, `mana-gate-on-behalf-of-target`, `verifyNavigationRouteAccess`, `verifyMaturityPrivacyContract`, `verifyUserPatchAllowlist`, `verifyAuditAccessChecks`, `verifyUserStoreCacheSafety`, `ownership-nullability`, `existing-owner-id-nullability`.
- Moves *toward* `verifyConductorApiAuthGuards.ts`, which greps for `userIsAdmin\s*\(`.

## Deliberately out of scope

- The two remaining raw-SQL `u.Role AS userRole` reads are display-only (a user card rendered next to a reaction), not authorization.
- Client-side single-role assumptions and the multi-role **write** path (`admin.patch.ts` accepting `roles: Role[]`) are the next PR.
- `contentAccess`'s maturity rule — CHILD forcing mature content off, restrictive-wins — is the one after that, and is the only behavioural change in the whole sequence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_