### PR TITLE
fix(facets): serialize seed writes by target slug

### DIFF
--- a/.github/workflows/facet-catalog-contract.yml
+++ b/.github/workflows/facet-catalog-contract.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Verify Facet seed policy
         run: node utils/scripts/verifyFacetCatalogSeedPolicy.mjs
 
+      - name: Verify Facet seed target-slug serialization
+        run: npx tsx utils/scripts/verifyFacetSeedSlugSerialization.ts
+
       - name: Verify retired Facet sources
         run: |
           node utils/scripts/verifyFacetLegacySeedSnapshots.mjs

--- a/utils/scripts/facetSeedConcurrency.ts
+++ b/utils/scripts/facetSeedConcurrency.ts
@@ -1,0 +1,53 @@
+// /utils/scripts/facetSeedConcurrency.ts
+export async function runWithKeyedConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  keyFor: (item: T) => string,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new RangeError('limit must be a positive integer')
+  }
+
+  const groups = new Map<string, T[]>()
+  for (const item of items) {
+    const key = keyFor(item)
+    const group = groups.get(key)
+    if (group) group.push(item)
+    else groups.set(key, [item])
+  }
+
+  const groupedItems = Array.from(groups.values())
+  let cursor = 0
+  const errors: unknown[] = []
+
+  async function lane(): Promise<void> {
+    while (cursor < groupedItems.length) {
+      const group = groupedItems[cursor]
+      cursor++
+      if (!group) continue
+
+      for (const item of group) {
+        try {
+          await worker(item)
+        } catch (error) {
+          errors.push(error)
+        }
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(limit, groupedItems.length) },
+      () => lane(),
+    ),
+  )
+
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors,
+      `${errors.length} of ${items.length} item(s) failed`,
+    )
+  }
+}

--- a/utils/scripts/seedFacetCatalog.ts
+++ b/utils/scripts/seedFacetCatalog.ts
@@ -19,6 +19,7 @@ import {
   normalizeFacetLookupKey,
   prepareUniqueFacetAliases,
 } from './../facetAliases'
+import { runWithKeyedConcurrency } from './facetSeedConcurrency'
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) throw new Error('DATABASE_URL is missing')
@@ -816,8 +817,11 @@ async function main(): Promise<void> {
   }
 
   const state = await loadCatalogState()
-  await runWithConcurrency(catalog, WRITE_CONCURRENCY, (candidate) =>
-    saveCandidate(candidate, state),
+  await runWithKeyedConcurrency(
+    catalog,
+    WRITE_CONCURRENCY,
+    (candidate) => slugify(candidate.title),
+    (candidate) => saveCandidate(candidate, state),
   )
   const characterLinks = await backfillCharacterLinks(state)
 

--- a/utils/scripts/verifyFacetSeedSlugSerialization.ts
+++ b/utils/scripts/verifyFacetSeedSlugSerialization.ts
@@ -1,0 +1,85 @@
+// /utils/scripts/verifyFacetSeedSlugSerialization.ts
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { runWithKeyedConcurrency } from './facetSeedConcurrency'
+
+type TestItem = {
+  id: string
+  targetSlug: string
+}
+
+const items: TestItem[] = [
+  { id: 'alpha-1', targetSlug: 'shared-alpha' },
+  { id: 'alpha-2', targetSlug: 'shared-alpha' },
+  { id: 'beta-1', targetSlug: 'shared-beta' },
+  { id: 'beta-2', targetSlug: 'shared-beta' },
+]
+
+const activeBySlug = new Map<string, number>()
+const maxActiveBySlug = new Map<string, number>()
+const completionOrder: string[] = []
+let activeOverall = 0
+let maxActiveOverall = 0
+let firstWaveStarted = 0
+let releaseFirstWave!: () => void
+const firstWave = new Promise<void>((resolve) => {
+  releaseFirstWave = resolve
+})
+const fallback = setTimeout(releaseFirstWave, 250)
+
+await runWithKeyedConcurrency(
+  items,
+  2,
+  (item) => item.targetSlug,
+  async (item) => {
+    const activeForSlug = (activeBySlug.get(item.targetSlug) ?? 0) + 1
+    activeBySlug.set(item.targetSlug, activeForSlug)
+    maxActiveBySlug.set(
+      item.targetSlug,
+      Math.max(maxActiveBySlug.get(item.targetSlug) ?? 0, activeForSlug),
+    )
+    activeOverall++
+    maxActiveOverall = Math.max(maxActiveOverall, activeOverall)
+
+    if (++firstWaveStarted === 2) releaseFirstWave()
+    await firstWave
+    await Promise.resolve()
+
+    completionOrder.push(item.id)
+    activeOverall--
+    activeBySlug.set(item.targetSlug, activeForSlug - 1)
+  },
+)
+clearTimeout(fallback)
+
+assert.equal(maxActiveBySlug.get('shared-alpha'), 1)
+assert.equal(maxActiveBySlug.get('shared-beta'), 1)
+assert.equal(
+  maxActiveOverall,
+  2,
+  'unrelated target slugs should retain bounded parallelism',
+)
+assert.ok(
+  completionOrder.indexOf('alpha-1') < completionOrder.indexOf('alpha-2'),
+  'same-slug candidates should retain source order',
+)
+assert.ok(
+  completionOrder.indexOf('beta-1') < completionOrder.indexOf('beta-2'),
+  'same-slug candidates should retain source order',
+)
+
+await assert.rejects(
+  runWithKeyedConcurrency(items, 0, (item) => item.targetSlug, async () => {}),
+  RangeError,
+)
+
+const seedSource = readFileSync(
+  fileURLToPath(new URL('./seedFacetCatalog.ts', import.meta.url)),
+  'utf8',
+)
+assert.match(seedSource, /runWithKeyedConcurrency\(/)
+assert.match(seedSource, /\(candidate\) => slugify\(candidate\.title\)/)
+assert.match(seedSource, /\(candidate\) => saveCandidate\(candidate, state\)/)
+
+console.log('Facet seed target-slug serialization verified.')


### PR DESCRIPTION
## Root cause
`seedFacetCatalog.ts` runs candidates through eight concurrent lanes. Two distinct source titles can normalize to the same target slug, and both lanes can resolve different existing Facet rows before either lane updates the shared in-memory catalog state. Both then attempt to rename their selected row to the same slug, so the second update loses to the database unique constraint with `P2002` on `Facet_slug_key`.

## What changed
- Added a reusable keyed-concurrency runner that groups work by target key.
- The Facet seed now keys candidate writes by `slugify(candidate.title)`, processing each target slug serially while retaining bounded concurrency across unrelated slugs.
- Added a deterministic contract proving same-slug work never overlaps, unrelated slugs still run concurrently, source order is preserved, invalid limits fail closed, and the canonical seed is wired to the keyed runner.
- Added the contract to the existing Facet Catalog workflow.

## Safety
- No schema or migration changes.
- No production data mutation was run from this branch.
- No Facet maintenance or one-shot art sweep was triggered.
- Existing queued and retryable ArtJobs are untouched.
- MariaDB's unique slug constraint remains the final arbiter.

## Verification
GitHub Actions will run the focused Facet Catalog contract, TypeScript, and the repository's normal PR checks before merge.

Closes #1276