### PR TITLE
Multi-role writes, client role set, and CHILD forcing mature content off

### DIFF
--- a/components/navigation/login-switcher.vue
+++ b/components/navigation/login-switcher.vue
@@ -89,7 +89,7 @@
             </span>
 
             <span class="block truncate text-xs text-base-content/60">
-              {{ account.relationship }} · {{ account.role }}
+              {{ account.relationship }} · {{ (account.roles?.length ? account.roles : [account.role]).join(' + ') }}
             </span>
           </span>
 

--- a/server/api/auth/index.ts
+++ b/server/api/auth/index.ts
@@ -150,7 +150,13 @@ export async function validateUserCredentials(
   password?: string,
 ) {
   try {
-    const user = await prisma.user.findUnique({ where: { username } })
+    const user = await prisma.user.findUnique({
+      where: { username },
+      // The login response seeds the client's userStore, so it has to carry the
+      // full role set. Without it the store falls back to the primary column and
+      // a CHILD-primary admin loses admin UI until the next /api/users/me.
+      include: { UserRoles: { select: { role: true } } },
+    })
 
     if (!user) {
       return null
@@ -171,9 +177,17 @@ export async function validateUserCredentials(
     // Never return the bcrypt password hash to any caller (login response,
     // client logs/caches). Callers that need to verify a password re-fetch and
     // compare server-side; nothing legitimately consumes this field.
-    const { password: _password, ...safeUser } = user
+    const { password: _password, UserRoles, ...safeUser } = user
 
-    return { user: safeUser, token }
+    return {
+      // `roles` replaces the relation, so the client never sees the join
+      // table's row shape. Primary first.
+      user: {
+        ...safeUser,
+        roles: [...new Set([user.Role, ...UserRoles.map((e) => e.role)])],
+      },
+      token,
+    }
   } catch (error: unknown) {
     console.error(
       `Failed to validate user credentials: ${errorHandler(error).message}`,

--- a/server/api/users/[id]/admin.patch.ts
+++ b/server/api/users/[id]/admin.patch.ts
@@ -7,19 +7,9 @@ import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { requireAdminApiUser } from '../../../utils/authGuard'
 import { logAdminAction } from '../../../utils/audit'
+import { isValidRole, parseRoleList } from '../../../utils/authUser'
+import { setUserRoles } from '../../../utils/userRoleWrites'
 import type { Role } from '~/prisma/generated/prisma/client'
-
-const VALID_ROLES: Role[] = [
-  'SYSTEM',
-  'USER',
-  'ASSISTANT',
-  'ADMIN',
-  'GUEST',
-  'BOT',
-  'DESIGNER',
-  'CHILD',
-  'FAMILY',
-]
 
 function toBool(v: unknown): boolean | undefined {
   if (typeof v === 'boolean') return v
@@ -40,15 +30,33 @@ export default defineEventHandler(async (event) => {
     const data: Record<string, unknown> = {}
     const changes: string[] = []
 
-    if ('Role' in body) {
-      const role = String(body.Role).toUpperCase() as Role
-      if (!VALID_ROLES.includes(role)) {
+    // `roles` (the full set) and `Role` (primary only) are both accepted, with
+    // `roles` winning when both are sent. Neither writes User.Role through
+    // `data` -- both funnel into setUserRoles, which owns the scalar and the
+    // join table together in one transaction. Two writers for one fact is
+    // exactly how the two would drift apart.
+    let roles: Role[] | null = null
+    if ('roles' in body) {
+      try {
+        roles = parseRoleList(body.roles)
+      } catch (error) {
+        throw createError({
+          statusCode: 400,
+          message: error instanceof Error ? error.message : 'Invalid roles.',
+        })
+      }
+      changes.push(`roles=${roles.join('+')}`)
+    } else if ('Role' in body) {
+      const role = String(body.Role).toUpperCase()
+      if (!isValidRole(role)) {
         throw createError({
           statusCode: 400,
           message: `Invalid role: ${role}.`,
         })
       }
-      data.Role = role
+      // A single-role write still goes through setUserRoles, so the join table
+      // never keeps a stale secondary the admin believed they had replaced.
+      roles = [role]
       changes.push(`role=${role}`)
     }
 
@@ -68,12 +76,14 @@ export default defineEventHandler(async (event) => {
       changes.push(`emailVerified=${verified}`)
     }
 
-    if (Object.keys(data).length === 0) {
+    if (Object.keys(data).length === 0 && !roles) {
       throw createError({
         statusCode: 400,
         message: 'No admin-updatable fields provided.',
       })
     }
+
+    if (roles) await setUserRoles(userId, roles)
 
     const updated = await prisma.user.update({
       where: { id: userId },
@@ -82,6 +92,7 @@ export default defineEventHandler(async (event) => {
         id: true,
         username: true,
         Role: true,
+        UserRoles: { select: { role: true } },
         showMature: true,
         isPublic: true,
         emailVerified: true,
@@ -94,7 +105,21 @@ export default defineEventHandler(async (event) => {
       `Updated user ${updated.username} (#${userId}): ${changes.join(', ')}.`,
     )
 
-    return { success: true, message: 'User updated.', data: updated }
+    return {
+      success: true,
+      message: 'User updated.',
+      data: {
+        ...updated,
+        // Flattened so the client never has to know the relation's shape.
+        // Primary first, matching the order roles were applied in.
+        roles: [
+          updated.Role,
+          ...updated.UserRoles.map((entry) => entry.role).filter(
+            (role) => role !== updated.Role,
+          ),
+        ],
+      },
+    }
   } catch (err) {
     const handled = errorHandler(err)
     event.node.res.statusCode = handled.statusCode || 500

--- a/server/api/users/admin/create.post.ts
+++ b/server/api/users/admin/create.post.ts
@@ -7,19 +7,9 @@ import { errorHandler } from '../../../utils/error'
 import { requireAdminApiUser } from '../../../utils/authGuard'
 import { logAdminAction } from '../../../utils/audit'
 import { hashPassword, validatePassword } from '~/server/api/auth'
+import { isValidRole, parseRoleList } from '../../../utils/authUser'
+import { setUserRoles } from '../../../utils/userRoleWrites'
 import type { Role } from '~/prisma/generated/prisma/client'
-
-const VALID_ROLES: Role[] = [
-  'SYSTEM',
-  'USER',
-  'ASSISTANT',
-  'ADMIN',
-  'GUEST',
-  'BOT',
-  'DESIGNER',
-  'CHILD',
-  'FAMILY',
-]
 
 export default defineEventHandler(async (event) => {
   try {
@@ -29,6 +19,7 @@ export default defineEventHandler(async (event) => {
       email?: string
       password?: string
       Role?: string
+      roles?: unknown
       showMature?: boolean
     }>(event)
 
@@ -37,10 +28,28 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'username is required.' })
     }
 
-    const role = (String(body.Role || 'USER').toUpperCase() as Role) || 'USER'
-    if (!VALID_ROLES.includes(role)) {
-      throw createError({ statusCode: 400, message: `Invalid role: ${role}.` })
+    // `roles` gives the account more than one role at creation; `Role` remains
+    // supported and means "exactly this one". Either way the first entry is the
+    // primary, and the set is applied through setUserRoles after the insert so
+    // the scalar and the join table are written together.
+    let roles: Role[]
+    if ('roles' in body) {
+      try {
+        roles = parseRoleList(body.roles)
+      } catch (error) {
+        throw createError({
+          statusCode: 400,
+          message: error instanceof Error ? error.message : 'Invalid roles.',
+        })
+      }
+    } else {
+      const single = String(body.Role || 'USER').toUpperCase()
+      if (!isValidRole(single)) {
+        throw createError({ statusCode: 400, message: `Invalid role: ${single}.` })
+      }
+      roles = [single]
     }
+    const role = roles[0]
 
     if (await prisma.user.findUnique({ where: { username } })) {
       throw createError({
@@ -83,13 +92,26 @@ export default defineEventHandler(async (event) => {
       },
     })
 
+    // The insert already wrote User.Role; this fills the join table so the two
+    // agree from the account's first moment. A user created before the join row
+    // exists would read correctly (userRoles falls back to the scalar) but would
+    // be invisible to any `UserRoles`-based query, such as the admin-protection
+    // filter in users/cypress-cleanup.
+    await setUserRoles(created.id, roles)
+
     await logAdminAction(
       admin,
-      `Created user ${created.username} (#${created.id}) with role ${role}.`,
+      `Created user ${created.username} (#${created.id}) with role${
+        roles.length > 1 ? 's' : ''
+      } ${roles.join('+')}.`,
     )
 
     event.node.res.statusCode = 201
-    return { success: true, message: 'User created.', data: created }
+    return {
+      success: true,
+      message: 'User created.',
+      data: { ...created, roles },
+    }
   } catch (err) {
     const handled = errorHandler(err)
     event.node.res.statusCode = handled.statusCode || 500

--- a/server/api/users/me.get.ts
+++ b/server/api/users/me.get.ts
@@ -15,6 +15,9 @@ export default defineEventHandler(async (event) => {
         username: user.username,
         email: user.email,
         Role: user.Role,
+        // The complete set, so the client's isUserAdmin/hasUserRole can answer
+        // correctly instead of reading only the primary column.
+        roles: [...new Set([user.Role, ...user.roles])],
         isAdmin: auth.isAdmin,
         isServerKey: auth.isServerKey,
         authKind: auth.kind,

--- a/server/utils/authUser.ts
+++ b/server/utils/authUser.ts
@@ -110,3 +110,51 @@ export function withAdminFlag(
     isAdmin: userIsAdmin(withRoles),
   }
 }
+
+/**
+ * Every assignable role, in schema order.
+ *
+ * One list, because there used to be two: this array was duplicated verbatim in
+ * users/[id]/admin.patch.ts and users/admin/create.post.ts, so adding a value to
+ * the Role enum meant remembering to update both or silently getting a 400 from
+ * one of them.
+ */
+export const VALID_ROLES: Role[] = [
+  'SYSTEM',
+  'USER',
+  'ASSISTANT',
+  'ADMIN',
+  'GUEST',
+  'BOT',
+  'DESIGNER',
+  'CHILD',
+  'FAMILY',
+]
+
+export function isValidRole(value: unknown): value is Role {
+  return (VALID_ROLES as string[]).includes(normalize(value))
+}
+
+/**
+ * Normalize a caller-supplied role list into a deduplicated, validated set.
+ *
+ * Throws the message rather than an H3 error so route handlers keep owning
+ * their own status codes.
+ */
+export function parseRoleList(input: unknown): Role[] {
+  if (!Array.isArray(input)) {
+    throw new Error('roles must be an array.')
+  }
+  const parsed: Role[] = []
+  for (const raw of input) {
+    const role = normalize(raw)
+    if (!isValidRole(role)) {
+      throw new Error(`Invalid role: ${String(raw)}.`)
+    }
+    if (!parsed.includes(role)) parsed.push(role)
+  }
+  if (!parsed.length) {
+    throw new Error('roles must contain at least one role.')
+  }
+  return parsed
+}

--- a/server/utils/relations.ts
+++ b/server/utils/relations.ts
@@ -6,6 +6,7 @@
 import type { RelationType } from '~/prisma/generated/prisma/client'
 import prisma from './prisma'
 import { userHasRole } from './authUser'
+import { addUserRole, removeUserRole } from './userRoleWrites'
 
 // The inverse role for the OTHER user when a relation is accepted.
 // FRIEND is symmetric; PARENT/CHILD swap; REFEREE/BLOCK have no owned inverse.
@@ -40,20 +41,32 @@ function childIdFromRow(row: {
   return null
 }
 
-// Roles we will NOT overwrite when promoting a child — clobbering an elevated
-// account to CHILD would strip permissions. Only plain members get promoted.
+// Roles whose DISPLAY label we are willing to change to CHILD. An elevated
+// account keeps whatever primary role an admin gave it.
+//
+// This used to be a demotion guard: CHILD was written to the single `Role`
+// column, so promoting an ADMIN would have stripped their permissions and the
+// only safe move was to skip them entirely -- which is precisely the limitation
+// Silas hit ("I can't make say, a Child and Admin"). With the join table the
+// two facts are independent, so the guard shrinks to what it always meant.
 const PROMOTABLE_ROLES = ['USER', 'GUEST']
 
-// On accepting a PARENT/CHILD link, mark the child's account Role as CHILD
-// (only if they're a plain USER/GUEST, so we never demote an ADMIN/DESIGNER).
-// This is account-role automation, separate from the relation row itself.
+// On accepting a PARENT/CHILD link, mark the child's account as CHILD. This is
+// account-role automation, separate from the relation row itself.
 async function applyChildRole(childId: number): Promise<void> {
   const child = await prisma.user.findUnique({
     where: { id: childId },
     select: { id: true, Role: true },
   })
   if (!child) return
-  if (!PROMOTABLE_ROLES.includes(child.Role)) return // don't demote elevated roles
+
+  // Always additive -- an admin or designer who is also someone's child now
+  // gets CHILD alongside what they already hold instead of being skipped.
+  await addUserRole(childId, 'CHILD')
+
+  // The primary role is a label, so only relabel a plain member. Silently
+  // renaming an account an admin deliberately set is not this function's call.
+  if (!PROMOTABLE_ROLES.includes(child.Role)) return
 
   await prisma.user.update({
     where: { id: childId },
@@ -129,6 +142,12 @@ export async function maybeRevertChildRole(userId: number): Promise<void> {
     },
   })
   if (stillChild) return // still a child of someone — leave role alone
+
+  // Drop the join-table row unconditionally; only reset the primary label if
+  // CHILD is what it currently says. An admin who was also a child keeps
+  // ADMIN as their primary and simply stops being a child.
+  await removeUserRole(userId, 'CHILD')
+  if (String(user.Role).toUpperCase() !== 'CHILD') return
 
   await prisma.user.update({
     where: { id: userId },

--- a/server/utils/userRoleWrites.ts
+++ b/server/utils/userRoleWrites.ts
@@ -1,0 +1,108 @@
+// /server/utils/userRoleWrites.ts
+import type { Role } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+
+/**
+ * Keeping `User.Role` and the `UserRole` join table in sync.
+ *
+ * Both are written on every role change, deliberately. `User.Role` is still the
+ * primary/display role and is still read as a fallback everywhere a user was
+ * resolved without the join (see `userRoles` in ./authUser.ts), so letting the
+ * two drift would produce a user who is an admin down one code path and not
+ * down another. These helpers exist so no route has to remember that rule.
+ *
+ * The first element of a role list is always the primary. Callers that offer a
+ * UI should present it that way rather than sorting.
+ *
+ * Each helper takes an optional transaction client so a caller can enlist these
+ * writes in a transaction it already opened.
+ */
+
+// prisma is $extends()-wrapped (see server/utils/prisma.ts), so its
+// $transaction callback's tx param has extended InternalArgs that don't
+// structurally match the plain Prisma.TransactionClient type. Derive the type
+// from the actual instance instead (same pattern as server/utils/mana.ts and
+// server/api/stripe/webhook.post.ts).
+type Tx = Parameters<Parameters<typeof prisma.$transaction>[0]>[0]
+
+/**
+ * Replace a user's entire role set.
+ *
+ * Always transactional: a partial apply would leave the scalar and the join
+ * table disagreeing, which is the one state this module exists to prevent.
+ * Pass `tx` to enlist in a transaction the caller already opened.
+ */
+export async function setUserRoles(
+  userId: number,
+  roles: readonly Role[],
+  tx?: Tx,
+): Promise<Role[]> {
+  const unique: Role[] = []
+  for (const role of roles) if (!unique.includes(role)) unique.push(role)
+  if (!unique.length) throw new Error('setUserRoles requires at least one role.')
+
+  const apply = async (client: Tx): Promise<void> => {
+    await client.userRole.deleteMany({
+      where: { userId, role: { notIn: [...unique] } },
+    })
+    await client.userRole.createMany({
+      data: unique.map((role) => ({ userId, role })),
+      skipDuplicates: true,
+    })
+    await client.user.update({
+      where: { id: userId },
+      data: { Role: unique[0] },
+    })
+  }
+
+  if (tx) await apply(tx)
+  else await prisma.$transaction(apply)
+
+  return unique
+}
+
+/**
+ * Add a role without disturbing the ones already held.
+ *
+ * The additive counterpart to setUserRoles, and what relationship side effects
+ * should use -- `applyChildRole` must be able to mark an account as CHILD
+ * without demoting an admin or clearing a FAMILY grant. `User.Role` is left
+ * alone: the primary role is a display choice, and a side effect should not
+ * silently relabel an account a user or an admin named.
+ */
+export async function addUserRole(
+  userId: number,
+  role: Role,
+  tx?: Tx,
+): Promise<void> {
+  const client = tx ?? prisma
+  await client.userRole.createMany({
+    data: [{ userId, role }],
+    skipDuplicates: true,
+  })
+}
+
+/** Remove a single role. No-op when the user does not hold it. */
+export async function removeUserRole(
+  userId: number,
+  role: Role,
+  tx?: Tx,
+): Promise<void> {
+  const client = tx ?? prisma
+  await client.userRole.deleteMany({ where: { userId, role } })
+}
+
+/** The roles a user currently holds, primary first. */
+export async function getUserRoles(userId: number): Promise<Role[]> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { Role: true, UserRoles: { select: { role: true } } },
+  })
+  if (!user) return []
+
+  const roles: Role[] = [user.Role]
+  for (const entry of user.UserRoles) {
+    if (!roles.includes(entry.role)) roles.push(entry.role)
+  }
+  return roles
+}

--- a/stores/channelContentStore.ts
+++ b/stores/channelContentStore.ts
@@ -12,6 +12,7 @@ import {
 import {
   filterChannelsByPermission,
   navigationPermissions,
+  accessContextRoles,
   type NavigationAccessContext,
 } from '@/stores/helpers/navigationAccess'
 import { useUserStore } from '@/stores/userStore'
@@ -68,7 +69,12 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
     const isAdmin = userStore.isAdmin
 
     return {
+      // `role` stays scalar for display and for permissionAllows, which has its
+      // own isAdmin escape hatch. The ADMIN coercion is kept so an admin whose
+      // PRIMARY role is CHILD or FAMILY still labels as ADMIN here; `roles`
+      // below is what actually drives channel visibility.
       role: isAdmin ? 'ADMIN' : userStore.role,
+      roles: userStore.roles,
       permissions: navigationPermissions({
         isLoggedIn: userStore.isLoggedIn,
         isMember: userStore.isMember,
@@ -82,7 +88,7 @@ export const useChannelContentStore = defineStore('channelContentStore', () => {
   const visibleChannels = computed(() => {
     const roleFiltered = filterChannelsByRole(
       channels.value,
-      accessContext.value.role,
+      accessContextRoles(accessContext.value),
     )
 
     return filterChannelsByPermission(roleFiltered, accessContext.value)

--- a/stores/helpers/channelContent.ts
+++ b/stores/helpers/channelContent.ts
@@ -208,8 +208,13 @@ function dialogue(camelCase: unknown, legacy: unknown): string {
   return text(camelCase) || text(legacy)
 }
 
-function roleAllows(requiredRole: string, role: string): boolean {
-  return !requiredRole || role === 'ADMIN' || requiredRole === role
+// Content frontmatter keeps a SINGLE `requiredRole` string -- only users became
+// plural. So this is a membership test against the viewer's role set, not a
+// pair of scalars.
+function roleAllows(requiredRole: string, roles: ReadonlySet<string>): boolean {
+  if (!requiredRole) return true
+  if (roles.has('ADMIN')) return true
+  return roles.has(requiredRole.trim().toUpperCase())
 }
 
 function resolveTab(
@@ -420,15 +425,26 @@ export function resolveChannels(
     .sort((a, b) => a.sort - b.sort || a.label.localeCompare(b.label))
 }
 
+/**
+ * `roles` accepts a single role or a set of them. The scalar form is kept
+ * because the navigation contract verifiers build single-role viewers by hand,
+ * and because a caller with one role should not have to wrap it.
+ */
 export function filterChannelsByRole(
   channels: ResolvedChannel[],
-  role: string,
+  roles: string | readonly string[],
 ): ResolvedChannel[] {
+  const roleSet = new Set(
+    (typeof roles === 'string' ? [roles] : roles)
+      .map((role) => String(role ?? '').trim().toUpperCase())
+      .filter(Boolean),
+  )
+
   return channels
-    .filter((channel) => roleAllows(channel.requiredRole, role))
+    .filter((channel) => roleAllows(channel.requiredRole, roleSet))
     .map((channel) => {
       const tabs = channel.tabs.filter((tab) =>
-        roleAllows(tab.requiredRole, role),
+        roleAllows(tab.requiredRole, roleSet),
       )
 
       return {

--- a/stores/helpers/navigationAccess.ts
+++ b/stores/helpers/navigationAccess.ts
@@ -12,9 +12,27 @@ export type NavigationPermission =
   | string
 
 export type NavigationAccessContext = {
+  /** Primary/display role. For labels, not for deciding what a viewer may see. */
   role: string
+  /**
+   * The viewer's complete role set -- what channel visibility is filtered on.
+   *
+   * Optional, and absent means "single-role viewer", not "no roles": a context
+   * built by hand (the navigation contract verifiers do exactly this to express
+   * a GUEST or a USER) stays valid and falls back to `[role]` via
+   * `accessContextRoles` below. Making it required would force every such
+   * fixture to restate the same fact twice.
+   */
+  roles?: readonly string[]
   permissions: ReadonlySet<string>
   isAdmin: boolean
+}
+
+/** The role set to filter on, falling back to the primary role. */
+export function accessContextRoles(
+  context: NavigationAccessContext,
+): readonly string[] {
+  return context.roles?.length ? context.roles : [context.role]
 }
 
 export function permissionAllows(

--- a/stores/loginStore.ts
+++ b/stores/loginStore.ts
@@ -22,7 +22,14 @@ export type LoginRelationship =
 export type ManagedLogin = {
   userId: number
   username: string
+  /** Primary/display role. Always present, including on records persisted
+   *  before multi-role shipped. */
   role: string
+  /** The full role set, when known. OPTIONAL because this record is persisted
+   *  to localStorage: accounts saved before multi-role have only `role`, and a
+   *  required field would make every one of them fail to read back. Callers
+   *  fall back to `[role]`. */
+  roles?: string[]
   token: string
   googleToken: boolean
   avatarImage?: string | null
@@ -152,6 +159,7 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
       userId: currentUser.id,
       username: currentUser.username,
       role: currentUser.Role ?? 'USER',
+      roles: userStore.roles.length ? [...userStore.roles] : undefined,
       token: userStore.token,
       googleToken: userStore.googleToken,
       avatarImage: currentUser.avatarImage,
@@ -202,6 +210,7 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
 
       account.username = userStore.user.username
       account.role = userStore.user.Role ?? account.role
+      if (userStore.roles.length) account.roles = [...userStore.roles]
       account.avatarImage = userStore.user.avatarImage
       account.artImageId = userStore.user.artImageId
       account.lastUsedAt = new Date().toISOString()
@@ -229,6 +238,7 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
     userId: number
     username: string
     role?: string
+    roles?: string[]
     token: string
     googleToken?: boolean
     avatarImage?: string | null
@@ -245,6 +255,7 @@ export const useLoginManagerStore = defineStore('loginManagerStore', () => {
       userId: input.userId,
       username: input.username,
       role: input.role ?? existing?.role ?? 'USER',
+      roles: input.roles ?? existing?.roles,
       token: input.token,
       googleToken: input.googleToken ?? false,
       avatarImage: input.avatarImage ?? existing?.avatarImage ?? null,

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -6,6 +6,12 @@ import { performFetch, handleError } from './utils'
 import { mergeRecordsById } from './helpers/recordMerge'
 import { useAchievementStore } from './achievementStore'
 import { generateUsername } from '@/utils/generateUsername'
+import {
+  hasUserRole,
+  isUserAdmin,
+  primaryUserRole,
+  resolveUserRoles,
+} from '@/utils/userRoles'
 import { useArtStore } from './artStore'
 import {
   getFromLocalStorage,
@@ -27,7 +33,17 @@ type RegisterUserData = {
   password?: string
 }
 
-type UserPatch = Partial<User>
+/**
+ * The user as the API actually sends it. `roles` is the complete set from the
+ * UserRole join table; Prisma's generated `User` only knows the scalar column.
+ *
+ * Optional on purpose -- an endpoint that has not been taught to send `roles`
+ * yet, or a cached payload from before the multi-role rollout, still resolves
+ * correctly through the primary column (see utils/userRoles.ts).
+ */
+type StoredUser = User & { roles?: string[] }
+
+type UserPatch = Partial<StoredUser>
 
 type InitializeOptions = {
   token?: string
@@ -75,13 +91,13 @@ function cleanPatch(fields: UserPatch): UserPatch {
 }
 
 export const useUserStore = defineStore('userStore', () => {
-  const user = ref<User | null>(null)
+  const user = ref<StoredUser | null>(null)
   const token = ref<string | undefined>()
   const loading = ref(false)
   const lastError = ref<string | null>(null)
   const stayLoggedIn = ref(true)
   const achievements = ref<number[]>([])
-  const users = ref<User[]>([])
+  const users = ref<StoredUser[]>([])
   const recipient = ref<User | null>(null)
   const googleToken = ref(false)
   const initialized = ref(false)
@@ -103,11 +119,16 @@ export const useUserStore = defineStore('userStore', () => {
   const username = computed(() => user.value?.username ?? 'Kind Guest')
   const karma = computed(() => user.value?.karma ?? 0)
   const mana = computed(() => user.value?.mana ?? 0)
-  const role = computed(() => user.value?.Role ?? 'USER')
-  const isAdmin = computed(
-    () => user.value?.Role === 'ADMIN' || user.value?.id === 1,
-  )
-  const isFamily = computed(() => user.value?.Role === 'FAMILY')
+  // `role` stays the PRIMARY/display role -- it is what labels and the
+  // single-valued `requiredRole` in content frontmatter compare against.
+  // Capability questions must go through `roles`/isAdmin/isFamily instead,
+  // which read the whole set: an admin whose primary role is CHILD or FAMILY is
+  // still an admin.
+  const role = computed(() => primaryUserRole(user.value))
+  const roles = computed(() => [...resolveUserRoles(user.value)])
+  const isAdmin = computed(() => isUserAdmin(user.value))
+  const isFamily = computed(() => hasUserRole(user.value, 'FAMILY'))
+  const isChild = computed(() => hasUserRole(user.value, 'CHILD'))
   const isMember = computed(
     () =>
       user.value?.isMember === true &&
@@ -215,7 +236,7 @@ export const useUserStore = defineStore('userStore', () => {
     }
   }
 
-  async function setUser(u: User) {
+  async function setUser(u: StoredUser) {
     user.value = u
     updateUserInList(u)
   }
@@ -895,8 +916,10 @@ export const useUserStore = defineStore('userStore', () => {
     karma,
     mana,
     role,
+    roles,
     isAdmin,
     isFamily,
+    isChild,
     isMember,
     avatarImage,
     apiKey,

--- a/utils/scripts/verifyUserRolePredicates.ts
+++ b/utils/scripts/verifyUserRolePredicates.ts
@@ -1,10 +1,18 @@
 // /utils/scripts/verifyUserRolePredicates.ts
 import {
+  VALID_ROLES,
+  parseRoleList,
   userHasRole,
   userIsAdmin,
   userRoles,
   withAdminFlag,
 } from '../../server/utils/authUser'
+import {
+  hasUserRole,
+  isUserAdmin,
+  primaryUserRole,
+  resolveUserRoles,
+} from '../userRoles'
 import type { User } from '../../prisma/generated/prisma/client'
 
 // Behavioural contract for the multi-role predicates in server/utils/authUser.ts.
@@ -131,6 +139,76 @@ const unflagged = withAdminFlag(asUser({ id: 42, Role: 'USER' }), [])
 check(
   !unflagged.isAdmin && unflagged.roles.length === 0,
   'withAdminFlag with no roles leaves a plain user unelevated',
+)
+
+// --- the client mirror (utils/userRoles.ts) --------------------------------
+// Two implementations exist because the server one is typed against Prisma and
+// accepts a raw `include: { UserRoles }` record. The SEMANTICS must not drift,
+// so the same cases are asserted against both.
+const MIRROR_CASES: [Record<string, unknown>, boolean][] = [
+  [{ id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'] }, true],
+  [{ id: 42, Role: 'FAMILY', roles: ['FAMILY', 'ADMIN'] }, true],
+  [{ id: 42, Role: 'USER', roles: ['USER'] }, false],
+  [{ id: 42, Role: 'ADMIN' }, true],
+  [{ id: 42, Role: 'ADMIN', roles: [] }, true],
+  [{ id: 42, Role: 'USER', roles: [] }, false],
+  [{ id: 1, Role: 'USER', roles: ['USER'] }, true],
+  [{ id: 42, Role: 'admin' }, true],
+]
+for (const [fields, expected] of MIRROR_CASES) {
+  const server = userIsAdmin(asUser(fields))
+  const client = isUserAdmin(fields)
+  check(
+    server === expected && client === expected,
+    `client and server agree on isAdmin for ${JSON.stringify(fields)} (both ${expected})`,
+  )
+}
+check(
+  hasUserRole({ id: 42, Role: 'ADMIN', roles: ['ADMIN', 'CHILD'] }, 'CHILD'),
+  'client hasUserRole finds a secondary role',
+)
+check(
+  !isUserAdmin(null) && !hasUserRole(undefined, 'ADMIN'),
+  'client predicates treat a missing user as unprivileged',
+)
+check(
+  primaryUserRole({ id: 42, Role: 'child', roles: ['CHILD', 'ADMIN'] }) === 'CHILD',
+  'client primaryUserRole returns the primary column, not the first of the set',
+)
+check(
+  primaryUserRole(null) === 'USER',
+  'client primaryUserRole defaults to USER',
+)
+check(
+  resolveUserRoles({ id: 42, Role: 'CHILD', roles: ['ADMIN'] }).size === 2,
+  'client resolveUserRoles unions the set with the primary column',
+)
+
+// --- parseRoleList (the admin write path) -----------------------------------
+check(
+  parseRoleList(['child', 'ADMIN']).join(',') === 'CHILD,ADMIN',
+  'parseRoleList uppercases and preserves order, primary first',
+)
+check(
+  parseRoleList(['ADMIN', 'ADMIN', 'CHILD']).length === 2,
+  'parseRoleList deduplicates',
+)
+for (const [input, why] of [
+  [['NOPE'], 'an unknown role'],
+  [[], 'an empty list'],
+  ['ADMIN', 'a bare string instead of an array'],
+] as [unknown, string][]) {
+  let threw = false
+  try {
+    parseRoleList(input)
+  } catch {
+    threw = true
+  }
+  check(threw, `parseRoleList rejects ${why}`)
+}
+check(
+  VALID_ROLES.length === 9 && VALID_ROLES.includes('FAMILY'),
+  'VALID_ROLES is the single shared list of assignable roles',
 )
 
 if (failures) {

--- a/utils/userRoles.ts
+++ b/utils/userRoles.ts
@@ -1,0 +1,74 @@
+// /utils/userRoles.ts
+//
+// Isomorphic role predicates, shared by the client stores and mirrored by
+// server/utils/authUser.ts.
+//
+// Two copies exist on purpose: the server version is typed against Prisma's
+// generated `User` and accepts a raw `include: { UserRoles }` record, which the
+// client has no business knowing about. What must NOT diverge is the semantics,
+// so both implement the same three rules:
+//
+//   1. A user's roles are the UNION of the `roles` array and the primary `Role`
+//      column. `Role` alone is not the answer -- that is the whole point of
+//      multi-role.
+//   2. An absent or empty `roles` means "not loaded", never "no roles". A
+//      payload that predates the multi-role rollout, or a store hydrated from a
+//      narrower endpoint, still has a correct primary role to fall back on.
+//      Treating absent as empty would demote every such user.
+//   3. Matching is case-insensitive.
+//
+// Rule 2 is also what makes this safe to ship before every endpoint returns
+// `roles`: an old-shaped payload keeps behaving exactly as it did.
+
+export type RoleBearer = {
+  id?: number | null
+  Role?: string | null
+  roles?: readonly string[] | null
+}
+
+function normalize(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
+}
+
+/** Every role this user holds, normalized to uppercase. */
+export function resolveUserRoles(user: RoleBearer | null | undefined): Set<string> {
+  const roles = new Set<string>()
+  if (!user) return roles
+
+  for (const role of user.roles ?? []) {
+    const normalized = normalize(role)
+    if (normalized) roles.add(normalized)
+  }
+  const primary = normalize(user.Role)
+  if (primary) roles.add(primary)
+
+  return roles
+}
+
+/** Does this user hold `role`, as primary or secondary? */
+export function hasUserRole(
+  user: RoleBearer | null | undefined,
+  role: string,
+): boolean {
+  const wanted = normalize(role)
+  return wanted ? resolveUserRoles(user).has(wanted) : false
+}
+
+/** `id === 1` is the historical bootstrap account and stays an escape hatch. */
+export function isUserAdmin(user: RoleBearer | null | undefined): boolean {
+  if (!user) return false
+  return resolveUserRoles(user).has('ADMIN') || user.id === 1
+}
+
+/**
+ * The primary/display role, uppercased, defaulting to USER.
+ *
+ * Use for labels and for the single-role `requiredRole` comparison in content
+ * frontmatter. Never use it to decide what a user may DO -- that is what
+ * hasUserRole/isUserAdmin are for.
+ */
+export function primaryUserRole(user: RoleBearer | null | undefined): string {
+  return normalize(user?.Role) || 'USER'
+}


### PR DESCRIPTION
Final two phases of the multi-role work (#1280 → #1282 → #1284 → here). Two commits, reviewable separately.

---

# Commit 1 — writes and the client

#1284 taught the server to **read** multiple roles. This adds the **write** path and brings the client along, so "Child and Admin" is actually settable and the UI agrees with what the server decided.

## Writes

`server/utils/userRoleWrites.ts` owns the one rule that matters: `User.Role` and the `UserRole` join table are always written **together**. Letting them drift produces a user who is an admin down one code path and not down another.

- `setUserRoles` replaces the set transactionally — a partial apply is precisely the state the module exists to prevent
- `addUserRole` is the additive form; `removeUserRole` drops one

Both admin endpoints accept `roles: Role[]` alongside the existing scalar `Role`, and **both forms funnel through `setUserRoles`** — a single-role write has to clear stale secondaries, or an admin who "changed" a role would silently leave the old one in place.

`VALID_ROLES` was **duplicated verbatim** across the two endpoints; it and the new `parseRoleList` now live once in `authUser.ts`.

### `applyChildRole` — the write path with real semantics

This is the function that encoded the limitation Silas named. It used to *refuse* to promote an elevated account:

```ts
if (!PROMOTABLE_ROLES.includes(child.Role)) return // don't demote elevated roles
```

That guard existed because `CHILD` went into the single `Role` column, so marking an admin as a child would have **stripped their permissions** — skipping them was the only safe move. With the join table the two facts are independent: CHILD is now added **unconditionally**, and the *primary* role is only relabelled for a plain `USER`/`GUEST`. An account an admin deliberately named is not silently renamed by a relationship side effect. `maybeRevertChildRole` mirrors it.

## Client

`utils/userRoles.ts` mirrors the server predicates. Two implementations exist because the server one is typed against Prisma and takes a raw `include: { UserRoles }` record — so **the contract asserts the same cases against both** and fails if the semantics drift.

`userStore` keeps `role` as the primary/display value and adds `roles`; `isAdmin`/`isFamily`/`isChild` become membership tests. Channel `roleAllows` becomes a membership test; content frontmatter `requiredRole` **stays a single string**, since only *users* became plural.

Three payloads had to start sending `roles` or the client would fall back to the primary column: `/api/users/me`, the login response, and the admin PATCH/create responses.

**Backward tolerance:** an absent or empty `roles` means *"not loaded"*, never *"no roles"*. A payload cached from before this change, a narrower endpoint, or a hand-built context still resolves correctly from the scalar. That's also why `NavigationAccessContext.roles` is optional with an `accessContextRoles()` fallback rather than forcing the four single-role verifier fixtures to restate the same fact twice.

---

# Commit 2 — CHILD forces mature content off

The one **behavioural** change in the whole sequence, and the reason the precedence rule had to be decided before any of it shipped.

**RESTRICTIVE WINS.** A CHILD who is also an ADMIN is still barred from mature content. Admin grants capability; it does not lift a safety restriction. Without this, the obvious way to give a family account admin powers — exactly what was asked for — would silently unlock mature content for a child.

`contentAccess.ts` gains **two** functions, because the routes needed both:

| | |
|---|---|
| `effectiveShowMature(user)` | the stored preference, restriction applied |
| `isMaturityRestricted(user)` | barred outright, whatever they ask for |

The second exists because `art/image/index.get.ts` and `art/image/[id].get.ts` **OR a `?showMature=true` query parameter** with the stored preference. Gating only the preference would have left a CHILD able to hand themselves mature content in a query string — *a restriction a query parameter can lift is not a restriction*. Both routes now compute `!isMaturityRestricted(user) && (requested || stored)`, so a request can still opt **down** but never past the restriction.

The CHILD marker is read from **every** source — join table, `roles` array, primary column, and the lowercase `role` alias the art routes use. This is deliberately the opposite of how every other predicate here works: elsewhere a role *grants*, so a missed source merely denies a grant; here the role *denies*, so a missed marker **fails open**, which is the wrong direction for a child-safety check.

Routed the eight server `showMature` reads through it and mirrored it in `userStore.showMature`, so the UI doesn't offer content the API will refuse.

---

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean.
- **New** `verifyChildMaturityRestriction` — 21 cases: the CHILD+ADMIN headline with `showMature: true`, CHILD as *secondary* role, user id 1 (the bootstrap admin hatch) still restricted while CHILD, detection from each of the five sources, the query-parameter bypass attempt, FAMILY ≠ CHILD, ordinary opt-in still working, and client/server agreement on all of it.
- `verifyUserRolePredicates` grows to **40** assertions: the client/server agreement matrix, `parseRoleList` accepting/uppercasing/deduplicating and rejecting unknown roles, empty lists and non-arrays.
- `channel-content`, `channel-resolver`, `verifyNavigationRouteAccess`, `verifyWonderLabPublicNavigation`, `verifyUserPatchAllowlist`, `verifyMaturityPrivacyContract`, `verifyUserStoreCacheSafety`, `conductor-api-auth-guards`, `user-role-expand`, `admin-flag-casts` — all pass.
- Audited every staged file for line-ending changes: none. (`login-switcher.vue` is CRLF; a first pass rewrote all 217 lines and was redone as a byte-level replace.)