### PR TITLE
CHILD forces mature content off, even when the user is also an admin

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -110,6 +110,9 @@ jobs:
       - name: UserRole predicate contract
         run: npm run test:user-role-predicates
 
+      - name: CHILD maturity restriction contract
+        run: npm run test:child-maturity
+
       - name: Unquoted reserved-word table identifier contract
         run: npm run test:no-unquoted-reserved-word-tables
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",
     "test:user-role-expand": "tsx utils/scripts/verifyUserRoleExpand.ts",
     "test:user-role-predicates": "tsx utils/scripts/verifyUserRolePredicates.ts",
+    "test:child-maturity": "tsx utils/scripts/verifyChildMaturityRestriction.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
     "test:fetch-generic-pinning": "tsx utils/scripts/verifyFetchGenericPinning.ts",
     "test:existing-owner-id-nullability": "tsx utils/scripts/verifyExistingOwnerIdNullability.ts",

--- a/server/api/art/image/[id].get.ts
+++ b/server/api/art/image/[id].get.ts
@@ -5,6 +5,7 @@ import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { validateApiKey } from '../../../utils/validateKey'
 import { userRoles } from '../../../utils/authUser'
+import { isMaturityRestricted } from '../../../utils/contentAccess'
 
 type QueryValue = string | number | boolean | null | undefined | QueryValue[]
 
@@ -75,9 +76,12 @@ async function getAccessContext(event: H3Event): Promise<AccessContext> {
       false,
     )
 
-    const showMature = isAuthenticated
-      ? requestedMature || Boolean(user?.showMature)
-      : false
+    // See the sibling route: the request can opt DOWN but never past the
+    // restriction, or ?showMature=true would defeat it.
+    const showMature =
+      isAuthenticated &&
+      !isMaturityRestricted(user) &&
+      (requestedMature || user?.showMature === true)
 
     return {
       userId: isAuthenticated ? Number(user?.id) : null,

--- a/server/api/art/image/index.get.ts
+++ b/server/api/art/image/index.get.ts
@@ -5,6 +5,7 @@ import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
 import { validateApiKey } from '../../../utils/validateKey'
 import { userRoles } from '../../../utils/authUser'
+import { isMaturityRestricted } from '../../../utils/contentAccess'
 
 type QueryValue = string | number | boolean | null | undefined | QueryValue[]
 
@@ -68,10 +69,13 @@ async function getArtImageAccessContext(
       false,
     )
 
-    const userAllowsMature = Boolean(user?.showMature)
-    const showMature = isAuthenticated
-      ? requestedMature || userAllowsMature
-      : false
+    // isMaturityRestricted, not effectiveShowMature: `requestedMature` is a
+    // query parameter, so gating only the stored preference would let a CHILD
+    // opt themselves back in with ?showMature=true.
+    const showMature =
+      isAuthenticated &&
+      !isMaturityRestricted(user) &&
+      (requestedMature || user?.showMature === true)
 
     return {
       userId: isAuthenticated ? Number(user?.id) : null,

--- a/server/api/dreams/daily.post.ts
+++ b/server/api/dreams/daily.post.ts
@@ -8,6 +8,7 @@ import {
   buildDailyDreamFacetBlueprint,
   type DailyDreamBlueprint,
 } from '~/server/utils/dailyDreamFacetBlueprint'
+import { effectiveShowMature } from '~/server/utils/contentAccess'
 
 type DailyDreamRequest = {
   dateKey?: string | null
@@ -58,7 +59,7 @@ export default defineEventHandler(async (event) => {
     const blueprintOptions = {
       userId: auth.user.id,
       isAdmin: auth.isAdmin,
-      includeMature: Boolean(body?.isMature && auth.user.showMature),
+      includeMature: Boolean(body?.isMature && effectiveShowMature(auth.user)),
       dateKey,
     }
     const blueprint = await buildDailyDreamFacetBlueprint({
@@ -107,7 +108,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const isPublic = body?.isPublic ?? false
-    const isMature = Boolean(body?.isMature && auth.user.showMature)
+    const isMature = Boolean(body?.isMature && effectiveShowMature(auth.user))
 
     let created
     try {

--- a/server/api/lora/browse.get.ts
+++ b/server/api/lora/browse.get.ts
@@ -13,6 +13,7 @@ import { ofetch } from 'ofetch'
 import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { requireApiUser } from '../../utils/authGuard'
+import { effectiveShowMature } from '~/server/utils/contentAccess'
 
 const CIVITAI_MODELS_URL = 'https://civitai.com/api/v1/models'
 const CIVARCHIVE_MODEL_URL = 'https://civitaiarchive.com/api/models'
@@ -296,7 +297,7 @@ export default defineEventHandler(async (event) => {
     const q = String(query.q ?? '').trim()
     const source = String(query.source ?? 'civitai').toLowerCase()
     const type = normalizeBrowseType(query.type)
-    const allowMature = Boolean(auth.user.showMature)
+    const allowMature = effectiveShowMature(auth.user)
 
     let result: { cards: BrowseCard[]; nextCursor: string | null }
 

--- a/server/api/resources/[id].get.ts
+++ b/server/api/resources/[id].get.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/prisma'
 import { errorHandler } from '../../utils/error'
 import { getOptionalApiUser } from '../../utils/authGuard'
 import { resourceGallerySelect, resourceGalleryWhere } from './gallery'
+import { effectiveShowMature } from '~/server/utils/contentAccess'
 
 export default defineEventHandler(async (event) => {
   const resourceId = Number(event.context.params?.id)
@@ -27,7 +28,7 @@ export default defineEventHandler(async (event) => {
           resourceGalleryWhere({
             userId: auth?.user.id ?? null,
             isAdmin: auth?.isAdmin ?? false,
-            showMature: Boolean(auth?.user.showMature),
+            showMature: effectiveShowMature(auth?.user),
           }),
         ],
       },

--- a/server/api/resources/[id]/generate-preview.post.ts
+++ b/server/api/resources/[id]/generate-preview.post.ts
@@ -11,6 +11,7 @@ import { requireMachineUser } from '~/server/utils/authGuard'
 import { manaGate } from '~/server/utils/manaGate'
 import { estimateArtCostUsd } from '~/server/utils/manaCost'
 import { resourceGallerySelect, resourceGalleryWhere } from '../gallery'
+import { effectiveShowMature } from '~/server/utils/contentAccess'
 
 const A1111_RESOURCE_FAMILIES: SupportedServer[] = [
   SupportedServer.SD15,
@@ -85,7 +86,7 @@ export default defineEventHandler(async (event) => {
           resourceGalleryWhere({
             userId: auth.user.id,
             isAdmin: auth.isAdmin,
-            showMature: Boolean(auth.user.showMature),
+            showMature: effectiveShowMature(auth.user),
           }),
         ],
       },

--- a/server/api/resources/index.get.ts
+++ b/server/api/resources/index.get.ts
@@ -8,6 +8,7 @@ import {
   resourceGalleryWhere,
   type ResourceGalleryRecord,
 } from './gallery'
+import { effectiveShowMature } from '~/server/utils/contentAccess'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -16,7 +17,7 @@ export default defineEventHandler(async (event) => {
       where: resourceGalleryWhere({
         userId: auth?.user.id ?? null,
         isAdmin: auth?.isAdmin ?? false,
-        showMature: Boolean(auth?.user.showMature),
+        showMature: effectiveShowMature(auth?.user),
       }),
       select: resourceGallerySelect,
       orderBy: [{ customLabel: 'asc' }, { name: 'asc' }],

--- a/server/api/users/[id]/admin.patch.ts
+++ b/server/api/users/[id]/admin.patch.ts
@@ -105,16 +105,20 @@ export default defineEventHandler(async (event) => {
       `Updated user ${updated.username} (#${userId}): ${changes.join(', ')}.`,
     )
 
+    // UserRoles is destructured OUT, not just supplemented: returning both it
+    // and `roles` invites a client to read the raw relation shape, which is the
+    // coupling `roles` exists to avoid.
+    const { UserRoles, ...rest } = updated
+
     return {
       success: true,
       message: 'User updated.',
       data: {
-        ...updated,
-        // Flattened so the client never has to know the relation's shape.
+        ...rest,
         // Primary first, matching the order roles were applied in.
         roles: [
           updated.Role,
-          ...updated.UserRoles.map((entry) => entry.role).filter(
+          ...UserRoles.map((entry) => entry.role).filter(
             (role) => role !== updated.Role,
           ),
         ],

--- a/server/utils/contentAccess.ts
+++ b/server/utils/contentAccess.ts
@@ -28,6 +28,76 @@ type AccessUser = {
   isAdmin?: boolean
 }
 
+/**
+ * Shape needed to decide whether a user may see mature content.
+ * `roles`/`UserRoles` are optional for the same reason they are everywhere
+ * else: absent means "not loaded", so the primary column still answers.
+ */
+type MaturityUser = {
+  id?: number | null
+  Role?: string | null
+  role?: string | null
+  roles?: readonly string[] | null
+  UserRoles?: readonly { role: string }[] | null
+  showMature?: boolean | null
+}
+
+/**
+ * Whether this user may be shown mature content.
+ *
+ * RESTRICTIVE WINS. This is the precedence rule for the whole multi-role
+ * system, and mature content is where it first bites: a CHILD who is also an
+ * ADMIN is still maturity-restricted. Admin grants capability; it does not lift
+ * a safety restriction, and a role added for convenience must never be able to
+ * unlock something a role added for protection closed.
+ *
+ * Silas, 2026-08-01, on wanting exactly that combination: "I can't make say, a
+ * Child and Admin, or Family an Admin."
+ *
+ * Note the asymmetry with every other predicate here: elsewhere holding a role
+ * GRANTS something, so any source of the role is enough. Here holding CHILD
+ * DENIES something, so this deliberately consults the join table AND the legacy
+ * column AND the lowercase `role` alias -- missing a CHILD marker in any of
+ * them would fail open, which is the wrong direction for a child-safety check.
+ *
+ * A user with no `showMature` set is treated as not opted in.
+ */
+export function effectiveShowMature(
+  user: MaturityUser | null | undefined,
+): boolean {
+  if (isMaturityRestricted(user)) return false
+  return user?.showMature === true
+}
+
+/**
+ * Is this user barred from mature content outright, whatever they ask for?
+ *
+ * The companion to effectiveShowMature, and the one that has to gate a
+ * PER-REQUEST opt-in. Several routes accept `?showMature=true` and OR it with
+ * the stored preference, so checking only the preference would let a CHILD
+ * hand themselves mature content in a query string. A restriction that a query
+ * parameter can lift is not a restriction.
+ */
+export function isMaturityRestricted(
+  user: MaturityUser | null | undefined,
+): boolean {
+  if (!user) return true
+
+  const roles = new Set<string>()
+  for (const role of user.roles ?? []) roles.add(normalizeRole(role))
+  for (const entry of user.UserRoles ?? []) roles.add(normalizeRole(entry?.role))
+  roles.add(normalizeRole(user.Role))
+  roles.add(normalizeRole(user.role))
+
+  return roles.has('CHILD')
+}
+
+function normalizeRole(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
+}
+
 const GRANT_LEVEL_RANK: Record<GrantLevel, number> = {
   [GrantLevel.VIEW]: 1,
   [GrantLevel.ADMIN]: 2,

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -7,7 +7,9 @@ import { mergeRecordsById } from './helpers/recordMerge'
 import { useAchievementStore } from './achievementStore'
 import { generateUsername } from '@/utils/generateUsername'
 import {
+  effectiveShowMature,
   hasUserRole,
+  isMaturityRestricted as clientIsMaturityRestricted,
   isUserAdmin,
   primaryUserRole,
   resolveUserRoles,
@@ -137,7 +139,11 @@ export const useUserStore = defineStore('userStore', () => {
   )
   const avatarImage = computed(() => user.value?.avatarImage ?? 'default')
   const apiKey = computed(() => user.value?.apiKey ?? null)
-  const showMature = computed(() => user.value?.showMature ?? false)
+  // Restriction applied: a CHILD reads false even with showMature set, and even
+  // when they are also an ADMIN. Mirrors the server's effectiveShowMature so the
+  // UI does not offer content the API will refuse.
+  const showMature = computed(() => effectiveShowMature(user.value))
+  const isMaturityRestricted = computed(() => clientIsMaturityRestricted(user.value))
   const matchRecord = computed(() => user.value?.matchRecord ?? 0)
   const clickRecord = computed(() => user.value?.clickRecord ?? 0)
 
@@ -920,6 +926,7 @@ export const useUserStore = defineStore('userStore', () => {
     isAdmin,
     isFamily,
     isChild,
+    isMaturityRestricted,
     isMember,
     avatarImage,
     apiKey,

--- a/utils/scripts/verifyChildMaturityRestriction.ts
+++ b/utils/scripts/verifyChildMaturityRestriction.ts
@@ -1,0 +1,148 @@
+// /utils/scripts/verifyChildMaturityRestriction.ts
+import {
+  effectiveShowMature,
+  isMaturityRestricted,
+} from '../../server/utils/contentAccess'
+import {
+  effectiveShowMature as clientEffectiveShowMature,
+  isMaturityRestricted as clientIsMaturityRestricted,
+} from '../userRoles'
+
+// The one behavioural change in the multi-role sequence, so it gets its own
+// contract.
+//
+// RESTRICTIVE WINS. When two roles disagree, the restriction holds: a CHILD who
+// is also an ADMIN is still barred from mature content. Admin grants
+// capability; it does not lift a safety restriction. Without this rule the
+// obvious way to give a family account admin powers -- exactly what Silas asked
+// for on 2026-08-01 ("I can't make say, a Child and Admin") -- would silently
+// unlock mature content for a child.
+//
+// Two properties matter and are easy to lose:
+//
+//   1. The CHILD marker is honoured from EVERY source. Every other predicate in
+//      this system uses a role to GRANT something, so missing one source just
+//      denies a grant. Here the role DENIES, so a missed marker fails OPEN.
+//   2. A per-request `?showMature=true` cannot lift it. Several art routes OR
+//      the query parameter with the stored preference, so a rule that only
+//      gated the preference would be defeated by a query string.
+
+let failures = 0
+
+function check(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`ok - ${message}`)
+    return
+  }
+  failures += 1
+  console.error(`FAIL - ${message}`)
+}
+
+// --- the headline case -------------------------------------------------------
+check(
+  !effectiveShowMature({
+    id: 42,
+    Role: 'CHILD',
+    roles: ['CHILD', 'ADMIN'],
+    showMature: true,
+  }),
+  'a CHILD who is ALSO an ADMIN, with showMature explicitly true, is still denied',
+)
+check(
+  isMaturityRestricted({ id: 42, Role: 'ADMIN', roles: ['ADMIN', 'CHILD'] }),
+  'the restriction holds when CHILD is the SECONDARY role, not the primary',
+)
+check(
+  !effectiveShowMature({ id: 1, Role: 'CHILD', showMature: true }),
+  'even user id 1 -- the bootstrap admin escape hatch -- is restricted while CHILD',
+)
+
+// --- the marker is honoured from every source --------------------------------
+const CHILD_SHAPES: [Record<string, unknown>, string][] = [
+  [{ id: 42, Role: 'CHILD' }, 'the primary Role column'],
+  [{ id: 42, Role: 'USER', roles: ['CHILD'] }, 'the roles array'],
+  [{ id: 42, Role: 'USER', UserRoles: [{ role: 'CHILD' }] }, 'a raw Prisma UserRoles include'],
+  [{ id: 42, Role: 'USER', role: 'child' }, 'the lowercase `role` alias used by the art routes'],
+  [{ id: 42, Role: 'child' }, 'a lowercase primary role'],
+]
+for (const [shape, source] of CHILD_SHAPES) {
+  check(
+    isMaturityRestricted(shape) &&
+      !effectiveShowMature({ ...shape, showMature: true }),
+    `CHILD is detected via ${source} (a missed marker would fail OPEN)`,
+  )
+}
+
+// --- non-children are unaffected --------------------------------------------
+check(
+  effectiveShowMature({ id: 42, Role: 'USER', showMature: true }),
+  'an ordinary user who opted in still sees mature content',
+)
+check(
+  effectiveShowMature({ id: 42, Role: 'FAMILY', roles: ['FAMILY', 'ADMIN'], showMature: true }),
+  'FAMILY is not CHILD -- a family account that opted in is not restricted',
+)
+check(
+  !effectiveShowMature({ id: 42, Role: 'USER', showMature: false }),
+  'a user who did not opt in sees nothing mature',
+)
+check(
+  !effectiveShowMature({ id: 42, Role: 'ADMIN' }),
+  'an unset showMature is not an opt-in, even for an admin',
+)
+check(
+  isMaturityRestricted(null) && !effectiveShowMature(undefined),
+  'an anonymous viewer is restricted by default',
+)
+
+// --- the per-request opt-in cannot lift it -----------------------------------
+// Mirrors what art/image/index.get.ts and art/image/[id].get.ts compute:
+//   isAuthenticated && !isMaturityRestricted(user) && (requested || stored)
+function routeShowMature(
+  user: Parameters<typeof isMaturityRestricted>[0] & { showMature?: boolean },
+  requestedMature: boolean,
+): boolean {
+  const isAuthenticated = true
+  return (
+    isAuthenticated &&
+    !isMaturityRestricted(user) &&
+    (requestedMature || user?.showMature === true)
+  )
+}
+
+check(
+  !routeShowMature({ id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'] }, true),
+  'a CHILD passing ?showMature=true is still denied (a restriction a query string can lift is not a restriction)',
+)
+check(
+  routeShowMature({ id: 42, Role: 'USER' }, true),
+  'an ordinary user can still opt in per request without a stored preference',
+)
+
+// --- client and server must not drift ---------------------------------------
+const MIRROR: Record<string, unknown>[] = [
+  { id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'], showMature: true },
+  { id: 42, Role: 'ADMIN', roles: ['ADMIN', 'CHILD'], showMature: true },
+  { id: 42, Role: 'USER', showMature: true },
+  { id: 42, Role: 'FAMILY', roles: ['FAMILY', 'ADMIN'], showMature: true },
+  { id: 42, Role: 'USER', showMature: false },
+  { id: 1, Role: 'CHILD', showMature: true },
+]
+for (const shape of MIRROR) {
+  check(
+    effectiveShowMature(shape) === clientEffectiveShowMature(shape) &&
+      isMaturityRestricted(shape) === clientIsMaturityRestricted(shape),
+    `client and server agree for ${JSON.stringify(shape)}`,
+  )
+}
+
+if (failures) {
+  console.error(
+    `\nCHILD maturity restriction contract failed with ${failures} error(s).`,
+  )
+  process.exitCode = 1
+} else {
+  console.log(
+    '\nCHILD maturity restriction contract passed: all cases behaved as expected.',
+  )
+}

--- a/utils/scripts/verifyChildMaturityRestriction.ts
+++ b/utils/scripts/verifyChildMaturityRestriction.ts
@@ -1,12 +1,18 @@
 // /utils/scripts/verifyChildMaturityRestriction.ts
 import {
-  effectiveShowMature,
-  isMaturityRestricted,
-} from '../../server/utils/contentAccess'
-import {
   effectiveShowMature as clientEffectiveShowMature,
   isMaturityRestricted as clientIsMaturityRestricted,
 } from '../userRoles'
+
+// contentAccess also owns database-backed grant helpers, so importing it initializes
+// the Prisma adapter even though this contract only exercises its pure maturity
+// predicates. Give module initialization a syntactically valid, never-connected URL;
+// production and database-backed workflows keep supplying their real URL.
+process.env.DATABASE_URL ??= 'mysql://contract:contract@127.0.0.1:3306/contract'
+const {
+  effectiveShowMature,
+  isMaturityRestricted,
+} = await import('../../server/utils/contentAccess')
 
 // The one behavioural change in the multi-role sequence, so it gets its own
 // contract.
@@ -61,8 +67,14 @@ check(
 const CHILD_SHAPES: [Record<string, unknown>, string][] = [
   [{ id: 42, Role: 'CHILD' }, 'the primary Role column'],
   [{ id: 42, Role: 'USER', roles: ['CHILD'] }, 'the roles array'],
-  [{ id: 42, Role: 'USER', UserRoles: [{ role: 'CHILD' }] }, 'a raw Prisma UserRoles include'],
-  [{ id: 42, Role: 'USER', role: 'child' }, 'the lowercase `role` alias used by the art routes'],
+  [
+    { id: 42, Role: 'USER', UserRoles: [{ role: 'CHILD' }] },
+    'a raw Prisma UserRoles include',
+  ],
+  [
+    { id: 42, Role: 'USER', role: 'child' },
+    'the lowercase `role` alias used by the art routes',
+  ],
   [{ id: 42, Role: 'child' }, 'a lowercase primary role'],
 ]
 for (const [shape, source] of CHILD_SHAPES) {
@@ -79,7 +91,12 @@ check(
   'an ordinary user who opted in still sees mature content',
 )
 check(
-  effectiveShowMature({ id: 42, Role: 'FAMILY', roles: ['FAMILY', 'ADMIN'], showMature: true }),
+  effectiveShowMature({
+    id: 42,
+    Role: 'FAMILY',
+    roles: ['FAMILY', 'ADMIN'],
+    showMature: true,
+  }),
   'FAMILY is not CHILD -- a family account that opted in is not restricted',
 )
 check(
@@ -111,7 +128,10 @@ function routeShowMature(
 }
 
 check(
-  !routeShowMature({ id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'] }, true),
+  !routeShowMature(
+    { id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'] },
+    true,
+  ),
   'a CHILD passing ?showMature=true is still denied (a restriction a query string can lift is not a restriction)',
 )
 check(
@@ -124,7 +144,12 @@ const MIRROR: Record<string, unknown>[] = [
   { id: 42, Role: 'CHILD', roles: ['CHILD', 'ADMIN'], showMature: true },
   { id: 42, Role: 'ADMIN', roles: ['ADMIN', 'CHILD'], showMature: true },
   { id: 42, Role: 'USER', showMature: true },
-  { id: 42, Role: 'FAMILY', roles: ['FAMILY', 'ADMIN'], showMature: true },
+  {
+    id: 42,
+    Role: 'FAMILY',
+    roles: ['FAMILY', 'ADMIN'],
+    showMature: true,
+  },
   { id: 42, Role: 'USER', showMature: false },
   { id: 1, Role: 'CHILD', showMature: true },
 ]

--- a/utils/userRoles.ts
+++ b/utils/userRoles.ts
@@ -72,3 +72,33 @@ export function isUserAdmin(user: RoleBearer | null | undefined): boolean {
 export function primaryUserRole(user: RoleBearer | null | undefined): string {
   return normalize(user?.Role) || 'USER'
 }
+
+/**
+ * Is this user barred from mature content, whatever they ask for?
+ *
+ * RESTRICTIVE WINS -- the precedence rule for the whole multi-role system. A
+ * CHILD who is also an ADMIN is still maturity-restricted: admin grants
+ * capability, it does not lift a safety restriction.
+ *
+ * Note the asymmetry with hasUserRole/isUserAdmin above. There, holding a role
+ * GRANTS something, so any source of it is enough. Here holding CHILD DENIES
+ * something, so a missed marker fails OPEN -- the wrong direction for a
+ * child-safety check. `resolveUserRoles` already unions every source, which is
+ * exactly what this needs.
+ *
+ * Mirrors isMaturityRestricted in server/utils/contentAccess.ts.
+ */
+export function isMaturityRestricted(
+  user: RoleBearer | null | undefined,
+): boolean {
+  if (!user) return true
+  return resolveUserRoles(user).has('CHILD')
+}
+
+/** The user's effective mature-content preference, restriction applied. */
+export function effectiveShowMature(
+  user: (RoleBearer & { showMature?: boolean | null }) | null | undefined,
+): boolean {
+  if (isMaturityRestricted(user)) return false
+  return user?.showMature === true
+}


### PR DESCRIPTION
## Why this is a separate PR

This work was pushed to #1286 but **did not merge with it** — the squash captured only that PR's first commit, so `main` ended up with the multi-role write path and none of the maturity rule. Re-applied here onto current `main` as a fresh change, per the merged-PR-is-finished rule. Also carries a one-line follow-up spotted while verifying against production.

The multi-role sequence so far: #1280 (dead admin bypasses) → #1282 (`UserRole` table) → #1284 (read path) → #1286 (write path + client) → **here**.

---

## The rule

**RESTRICTIVE WINS.** When two roles disagree, the restriction holds: a CHILD who is also an ADMIN is still barred from mature content. Admin grants capability; it does not lift a safety restriction.

This is the one *behavioural* change in the whole sequence, and the reason the precedence rule had to be decided before any of it shipped. Without it, the obvious way to give a family account admin powers — exactly what was asked for — would silently unlock mature content for a child.

`server/utils/contentAccess.ts` gains **two** functions, because the routes needed both:

| | |
|---|---|
| `effectiveShowMature(user)` | the stored preference, restriction applied |
| `isMaturityRestricted(user)` | barred outright, whatever they ask for |

### Why the second one exists

`art/image/index.get.ts` and `art/image/[id].get.ts` **OR a `?showMature=true` query parameter** with the stored preference:

```ts
const showMature = isAuthenticated ? requestedMature || Boolean(user?.showMature) : false
```

Gating only the preference would have left a CHILD able to hand themselves mature content in a query string. *A restriction a query parameter can lift is not a restriction.* Both routes now compute:

```ts
isAuthenticated && !isMaturityRestricted(user) && (requestedMature || user?.showMature === true)
```

so a request can still opt **down**, but never past the restriction.

### Why the CHILD marker is read from every source

Join table, `roles` array, primary `Role` column, and the lowercase `role` alias the art routes use.

This is deliberately the **opposite** of how every other predicate in this system works. Elsewhere a role *grants* something, so a missed source merely denies a grant. Here the role *denies*, so a missed marker **fails open** — the wrong direction for a child-safety check.

Routed the eight server `showMature` reads through it and mirrored it in `userStore.showMature`, so the UI doesn't offer content the API will refuse.

---

## Also included

The admin PATCH response carried both `roles` and the raw `UserRoles: [{ role }]` relation. `roles` exists precisely so no client has to know the join table's row shape; shipping both invites one to depend on it. `UserRoles` is now destructured out.

---

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean.
- `verifyChildMaturityRestriction` — **21 cases**: the CHILD+ADMIN headline with `showMature: true`, CHILD as *secondary* role, user id 1 (the bootstrap admin hatch) still restricted while CHILD, detection from each of the five sources, the query-parameter bypass attempt, FAMILY ≠ CHILD, ordinary opt-in still working, and client/server agreement on all of it.
- `verifyUserRolePredicates`, `verifyMaturityPrivacyContract` — pass.

### Verified end-to-end against production

After #1286 deployed, the migration and backfill were confirmed live (`/api/users/me` returns `roles: ["ADMIN"]` from the join table). Then, on a disposable account:

- created with `roles: ["CHILD", "ADMIN"]` — **the combination that was impossible before this work** — and confirmed both persisted and round-tripped
- confirmed a later single-role write correctly cleared **both** stale secondaries, which is what `setUserRoles` exists for
- deleted the account

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_