### PR TITLE
Un-nest user dashboard tab and drop its duplicate header

### DIFF
--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -3,23 +3,6 @@
   <section
     class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto overscroll-contain rounded-2xl bg-base-200 p-3 sm:p-4"
   >
-    <header
-      class="flex shrink-0 items-center gap-3 rounded-2xl border border-base-300 bg-base-100 px-4 py-3"
-    >
-      <span
-        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary"
-      >
-        <Icon name="kind-icon:user" class="h-5 w-5" />
-      </span>
-
-      <div class="min-w-0">
-        <h1 class="text-xl font-black text-base-content">User Dashboard</h1>
-        <p class="truncate text-xs text-base-content/55">
-          Profile, avatar, settings, and your magnificent heap of creations.
-        </p>
-      </div>
-    </header>
-
     <div
       class="grid w-full grid-cols-1 gap-4 xl:grid-cols-[minmax(16rem,22rem)_minmax(0,1fr)]"
     >
@@ -139,8 +122,8 @@
                 Dashboard maturity toggle
               </span>
               <span class="block text-xs text-base-content/55">
-                Show a quick 18+ visibility control in the workspace header. This
-                preference stays in this browser.
+                Show a quick 18+ visibility control in the workspace header.
+                This preference stays in this browser.
               </span>
             </span>
           </span>

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -54,16 +54,19 @@
     </div>
 
     <section
-      v-if="activeTab === 'dashboard' && !isLoggedIn"
+      v-if="activeTab === 'profile' && !isLoggedIn"
       class="flex min-h-0 flex-1 flex-col items-center justify-center gap-6 rounded-2xl border border-base-300 bg-base-200 p-8"
     >
       <div class="flex flex-col items-center gap-3 text-center">
-        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary/15">
+        <div
+          class="flex h-16 w-16 items-center justify-center rounded-full bg-primary/15"
+        >
           <Icon name="kind-icon:user" class="h-8 w-8 text-primary" />
         </div>
         <h2 class="text-xl font-black text-base-content">Welcome, guest</h2>
         <p class="max-w-xs text-sm text-base-content/60">
-          Log in to save your progress, set an avatar, and access your full account.
+          Log in to save your progress, set an avatar, and access your full
+          account.
         </p>
       </div>
       <NuxtLink to="/login" class="btn btn-primary rounded-xl px-8">
@@ -73,7 +76,7 @@
     </section>
 
     <section
-      v-else-if="activeTab === 'dashboard'"
+      v-else-if="activeTab === 'profile'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
     >
       <user-dashboard class="min-h-0 flex-1" />
@@ -213,10 +216,10 @@ async function logout(): Promise<void> {
 }
 
 function onAvatarChosen(_artImage: ArtImage): void {
-  navStore.setDashboardTab(dashboardKey, 'dashboard', 'avatar chosen')
+  navStore.setDashboardTab(dashboardKey, 'profile', 'avatar chosen')
 }
 
 function closePicker(): void {
-  navStore.setDashboardTab(dashboardKey, 'dashboard', 'avatar picker closed')
+  navStore.setDashboardTab(dashboardKey, 'profile', 'avatar picker closed')
 }
 </script>

--- a/content/channels/home/navigation.md
+++ b/content/channels/home/navigation.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: home
 tabKey: navigation
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 label: Navigation
 title: Navigation Overview
 subtitle: Your personal roadmap

--- a/content/channels/home/registration.md
+++ b/content/channels/home/registration.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: home
 tabKey: registration
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 label: Register
 title: Join Kind Robots
 subtitle: Welcome to the community

--- a/content/channels/home/wallet.md
+++ b/content/channels/home/wallet.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: home
 tabKey: wallet
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 label: Wallet
 title: Wallet
 subtitle: Your karma and mana, in one place

--- a/content/channels/sanctuary/privacy.md
+++ b/content/channels/sanctuary/privacy.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: sanctuary
 tabKey: privacy
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 label: Privacy
 title: Privacy and Data Philosophy
 subtitle: Your data belongs to you

--- a/content/dashboard.md
+++ b/content/dashboard.md
@@ -11,7 +11,7 @@ amiTip: Even I've got a bungalow in the cloud where I unwind.
 channelKey: home
 tabKey: dashboard
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 cards: navCards
 loadingMessage: Loading user dashboard
 refreshLabel: Refresh dashboard

--- a/content/register.md
+++ b/content/register.md
@@ -12,7 +12,7 @@ dottiTip: If people register for an account, then we can customize their experie
 channelKey: home
 tabKey: registration
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 cards: navCards
 loadingMessage: Loading registration
 refreshLabel: Refresh registration

--- a/content/wallet.md
+++ b/content/wallet.md
@@ -11,7 +11,7 @@ amiTip: One tracks kindness, the other tracks fuel. Neither one runs out if you 
 channelKey: home
 tabKey: wallet
 dashboardKey: user
-dashboardTab: dashboard
+dashboardTab: profile
 requiredPermission: authenticated
 loadingMessage: Loading wallet...
 refreshLabel: Refresh wallet

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -1025,10 +1025,10 @@ export const dashboardConfigs = {
   user: {
     key: 'user',
     label: 'User',
-    defaultTab: 'dashboard',
+    defaultTab: 'profile',
     tabs: [
       {
-        key: 'dashboard',
+        key: 'profile',
         label: 'Dashboard',
         icon: 'kind-icon:dashboard',
         title: 'User Dashboard',
@@ -1147,7 +1147,8 @@ export const dashboardConfigs = {
         label: 'Anim. Manager',
         icon: 'kind-icon:trophy',
         title: 'Animation Manager',
-        summary: 'Gallery and promotion workspace for Screen FX build attempts.',
+        summary:
+          'Gallery and promotion workspace for Screen FX build attempts.',
         image: tabImage('wonder', 'animation-manager'),
         flourish: '✦',
         tagline: 'Preview, compare, promote, polish, or retire a build.',

--- a/stores/navStore.ts
+++ b/stores/navStore.ts
@@ -42,7 +42,6 @@ export interface DashboardShellState {
 }
 
 const fallbackDashboardKey = 'user'
-const fallbackDashboardTab = 'dashboard'
 
 function getFallbackDashboardKey(): DashboardKey {
   if (fallbackDashboardKey in dashboardConfigs) {
@@ -55,10 +54,6 @@ function getFallbackDashboardKey(): DashboardKey {
 }
 
 function getFallbackDashboardTab(dashboardKey: DashboardKey): string {
-  if (isDashboardTabKey(dashboardKey, fallbackDashboardTab)) {
-    return fallbackDashboardTab
-  }
-
   return dashboardConfigs[dashboardKey].defaultTab
 }
 


### PR DESCRIPTION
### Task
interface-vision/t-038: Un-nest user-manager -> user-dashboard and fix its duplicate profile-card header (kind: software)

### What changed / what I produced
- Every sibling dashboard (bots, characters, dreams, etc.) uses a real content-named default tab key (`bots`, `characters`, `overview`, ...); only `user` used the self-referential key `dashboard` for its default tab, which mounted a component literally named `user-dashboard.vue` — a dashboard-tab named dashboard inside a dashboard named dashboard. Renamed the tab key `dashboard` -> `profile` in `stores/helpers/dashboardHelper.ts` (`dashboardConfigs.user`), keeping the label ("Dashboard"), route (`/dashboard`), title, and component all unchanged — only the internal key changed.
- Propagated the rename to `components/user/user-manager.vue`'s `activeTab === 'dashboard'` checks and its two `setDashboardTab(dashboardKey, 'dashboard', ...)` calls, and to the six content pages whose frontmatter referenced `dashboardTab: dashboard` (`content/dashboard.md`, `content/register.md`, `content/wallet.md`, `content/channels/home/navigation.md`, `content/channels/home/registration.md`, `content/channels/home/wallet.md`, `content/channels/sanctuary/privacy.md`).
- Simplified `stores/navStore.ts`'s `getFallbackDashboardTab` — its special-case fallback to a literal `'dashboard'` tab key only ever matched the `user` dashboard's old key (no other dashboard has ever had a tab literally named `dashboard`), so after the rename it was dead code always falling through to `dashboardConfigs[dashboardKey].defaultTab` anyway. Removed the now-pointless intermediate check rather than leave a misleading dead special case behind.
- Removed `user-dashboard.vue`'s own icon+`<h1>User Dashboard</h1>`+subtitle header card (lines 6-21), which duplicated the global `workspace-header.vue` per t-004's one-header rule. Unlike the bare `<h1>` swaps t-004 already handled elsewhere in the app, this was a full styled card (avatar-style icon, title, subtitle) that t-004 explicitly deferred rather than guess at. Per the same precedent t-037 established (t-004's `.kr-surface`/one-header contract already answers this structural question, no mockup gate needed), removed it outright rather than keep a slimmed `kr-toolbar` version — the global header already shows this tab's icon/title from `dashboardHelper`, and the subtitle content was generic/redundant.

### How I verified
- `npm run test` (repo-wide `vue-tsc --noEmit`) — clean.
- `npm run test:nav-manifest` — 0 errors, same 9 pre-existing warnings as before this change (tracked by interface-vision/t-034; none reference any file this PR touches).
- `npm run test:channel-content` — passed (6 channels, 63 tabs, 61 placed pages unchanged).
- `npx eslint` on all 4 changed source files — clean (confirmed the 2 pre-existing `navStore.ts` errors on unrelated lines exist on `main` too, via `git stash`, before assuming they were mine).
- `npx prettier --write` on the 3 changed `.vue`/`.ts` files — picked up some pre-existing unrelated formatting drift (text reflow) alongside my edits; diffed with `git diff --ignore-all-space` to confirm it was formatting-only.
- Could not visually verify in a browser — no `DATABASE_URL` reachable in this sandbox, and `vercel.json` disables PR-preview deploys for `claude/*` branches (per t-037's TALKBACK note). Will need a post-merge production spot-check on `/dashboard`, `/register`, `/wallet`, `/navigation`, and `/privacy` (all six content pages whose `dashboardTab` frontmatter changed) — flagging this explicitly since it's the one thing I couldn't confirm myself before merging.

### Stakes
reversible

### Flags for Reviewer
- Chose the "rename the key" resolution over the task note's other named option ("always-shown default content with the other five as the actual tab strip") because renaming keeps `user` consistent with every sibling dashboard's pattern (a real, still-selectable, content-named default tab) with a much smaller/safer diff — removing `dashboard` as a selectable tab entirely would have required changing the `UserTab` type's fallback semantics and re-deriving what "always shown" means for the card-dock UI (`navCards`), which felt like real product/UX design work rather than the mechanical un-nesting this task asked for.
- Please do the post-merge production check described above (visual confirmation on the five affected routes) since I couldn't do it myself.

### Kaizen suggestion
`content/channels/sanctuary/butterflies.md` has `tabKey: sanctuary` but its frontmatter `dashboardTab` warning output showed the page itself as `(sanctuary/sanctuary)` — worth a follow-up task auditing the 9 pre-existing `test:nav-manifest` warnings tracked by t-034, since a couple (`sanctuary/about`, `sanctuary/giving`, `sanctuary/subscriptions`, `sanctuary/butterflies` all pointing `dashboardTab` at a `giftshop` dashboard that doesn't have those tabs) look like the same class of stale-reference bug this task fixed, just not yet scoped.

### Notes for reviewer
Scoped strictly to the two files named in the task plus the mechanical fallout of the key rename (6 content files + 1 navStore.ts simplification). No product/UX redesign beyond what t-004/t-037 already established as the contract.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EHWKgR9fzypUsVd11yZfA9)_