### PR TITLE
Limit startup media to verified launch-04

### DIFF
--- a/utils/scripts/verify-startup-handoff.mjs
+++ b/utils/scripts/verify-startup-handoff.mjs
@@ -169,12 +169,19 @@ assert.ok(
 )
 
 assert.ok(
-  startupAnimations.includes('{ length: 12 }') &&
-    startupAnimations.includes("padStart(2, '0')") &&
-    bootCover.includes('Math.floor(Math.random() * STARTUP_ANIMATION_SOURCES.length)') &&
-    bootCover.includes('markup.replaceAll(DEFAULT_STARTUP_ANIMATION_SRC, launchSrc)') &&
+  startupAnimations.includes(
+    "'/images/startup-animations/launch-04.webp'",
+  ) &&
+    !startupAnimations.includes('{ length: 12 }') &&
+    !startupAnimations.includes("padStart(2, '0')") &&
+    bootCover.includes(
+      'Math.floor(Math.random() * STARTUP_ANIMATION_SOURCES.length)',
+    ) &&
+    bootCover.includes(
+      'markup.replaceAll(DEFAULT_STARTUP_ANIMATION_SRC, launchSrc)',
+    ) &&
     bootCover.includes('STARTUP_ANIMATION_META_NAME'),
-  'All 12 launch WebPs must be eligible, and the preload, boot cameo, SSR intro, and hydrated intro must share one random choice.',
+  'Only verified launch WebPs may be eligible, and the preload, boot cameo, SSR intro, and hydrated intro must share the selected file.',
 )
 
 assert.ok(

--- a/utils/startupAnimations.ts
+++ b/utils/startupAnimations.ts
@@ -1,6 +1,6 @@
-export const STARTUP_ANIMATION_SOURCES = [
+export const STARTUP_ANIMATION_SOURCES: readonly string[] = [
   '/images/startup-animations/launch-04.webp',
-] as const
+]
 
 export const DEFAULT_STARTUP_ANIMATION_SRC = STARTUP_ANIMATION_SOURCES[0]!
 export const STARTUP_ANIMATION_META_NAME = 'kind-robots-startup-animation'

--- a/utils/startupAnimations.ts
+++ b/utils/startupAnimations.ts
@@ -1,8 +1,6 @@
-export const STARTUP_ANIMATION_SOURCES = Array.from(
-  { length: 12 },
-  (_, index) =>
-    `/images/startup-animations/launch-${String(index + 1).padStart(2, '0')}.webp`,
-)
+export const STARTUP_ANIMATION_SOURCES = [
+  '/images/startup-animations/launch-04.webp',
+] as const
 
 export const DEFAULT_STARTUP_ANIMATION_SRC = STARTUP_ANIMATION_SOURCES[0]!
 export const STARTUP_ANIMATION_META_NAME = 'kind-robots-startup-animation'


### PR DESCRIPTION
## What changed

- Replace the fabricated `launch-01.webp` through `launch-12.webp` generator with an explicit startup-media manifest.
- Keep only the verified `/images/startup-animations/launch-04.webp` entry.
- Update the startup handoff contract to reject restoration of the assumed numbered sequence.

## Why

The external startup media directory is not stored in GitHub and its deployed discovery endpoint currently exposes only `launch-04.webp`. The previous implementation inferred filenames that were never confirmed, causing requests for nonexistent media.

The existing single-selection path remains intact, so the preload, refresh cameo, SSR intro, and hydrated Vue intro still share one selected file. Additional verified filenames can be added to this manifest later.

## Validation

- Diff is limited to the startup media manifest and startup handoff contract.
- GitHub Actions will validate the final PR head.