### PR TITLE
Fix stale dashboard tab hints in content navigation

### DIFF
--- a/content/channels/home/account.md
+++ b/content/channels/home/account.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: home
 tabKey: account
 dashboardKey: user
-dashboardTab: account
+dashboardTab: profile
 label: Account
 title: Account & Privacy
 subtitle: Your settings, your consent

--- a/content/channels/home/messages.md
+++ b/content/channels/home/messages.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: home
 tabKey: messages
 dashboardKey: user
-dashboardTab: messages
+dashboardTab: chats
 label: Messages
 title: Direct Messages
 subtitle: Your conversations

--- a/content/channels/play/facets.md
+++ b/content/channels/play/facets.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: play
 tabKey: facets
 dashboardKey: facets
-dashboardTab: facets
+dashboardTab: library
 label: Facets
 title: Facets
 subtitle: Browse the reusable flavor of the ecosystem

--- a/content/channels/sanctuary/about.md
+++ b/content/channels/sanctuary/about.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: sanctuary
 tabKey: about
 dashboardKey: giftshop
-dashboardTab: about
+dashboardTab: community
 label: About
 title: About Kind Robots
 subtitle: Humans and robots building a kinder future

--- a/content/channels/sanctuary/butterflies.md
+++ b/content/channels/sanctuary/butterflies.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: sanctuary
 tabKey: sanctuary
 dashboardKey: giftshop
-dashboardTab: sanctuary
+dashboardTab: community
 label: Butterflies
 title: Butterfly Sanctuary
 subtitle: Play with AMI's digital recreations

--- a/content/channels/sanctuary/giving.md
+++ b/content/channels/sanctuary/giving.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: sanctuary
 tabKey: giving
 dashboardKey: giftshop
-dashboardTab: giving
+dashboardTab: community
 label: Giving
 title: Give Directly to Against Malaria
 subtitle: We never touch the money

--- a/content/channels/sanctuary/subscriptions.md
+++ b/content/channels/sanctuary/subscriptions.md
@@ -3,7 +3,7 @@ contentType: tab
 channelKey: sanctuary
 tabKey: subscriptions
 dashboardKey: giftshop
-dashboardTab: subscriptions
+dashboardTab: community
 label: Support Plans
 title: Support Kind Robots Monthly
 subtitle: Power our circuits


### PR DESCRIPTION
### Task
interface-vision/t-041: audit the nine stale `dashboardTab` warnings (kind: software)

### What changed / what I produced
- Corrected seven content frontmatter hints to tabs that actually exist:
  - Home account → `user/profile`
  - Home messages → `user/chats`
  - Facets → `facets/library`
  - About, Butterfly Sanctuary, Giving, and Support Plans → `giftshop/community`
- These mappings match the pages' current semantic dashboard homes and replace silent fallback behavior with explicit valid tab keys.
- Left Music Mentor (`scenario/music-mentor`) and Video Generator (`art/video`) unchanged because neither dashboard has a matching tab. Resolving those requires a product decision: add real dashboard tabs, choose a different dashboard, or intentionally remove the tab hint.

### How I verified
- Audited each warning against current `dashboardConfigs` on `main`.
- Diff is seven one-line frontmatter substitutions only.
- GitHub Actions will run `test:nav-manifest`, channel/content contracts, TypeScript, and the normal PR suite.

### Stakes
reversible

### Flags for Reviewer
- Expected warning count after this PR: 2, both deliberately retained and documented above.

### Kaizen suggestion
Teach `verifyNavManifest.ts` to distinguish a missing hint that merely falls back from one that changes the intended surface, so future warnings carry a suggested canonical tab when the match is unambiguous.
