### PR TITLE
Storybook becomes the house aesthetic, and the rendered card art becomes visible

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -4,6 +4,75 @@
   themes: all;
 }
 
+/*
+ * ── STORYBOOK — the house aesthetic (interface-vision t-002) ────────────
+ *
+ * Silas, 2026-08-02: "Let's run with Storybook as the design. I don't want to
+ * build three different layouts, we're already trying to make clear decisions
+ * and have VISION."
+ *
+ * Chosen from three mockups at /storymaker-mockups; Theater and Playground are
+ * retired, not kept as options. The brief calls it "a plate tipped into warm
+ * paper": light printed ground, generous margins, illustration-forward, serif
+ * text that reads as caption to picture.
+ *
+ * This is a daisyUI THEME rather than a pile of component overrides, and that
+ * is the whole leverage. Every .kr-* primitive below is written against the
+ * semantic tokens (base-200 canvas, base-100 raised surface, base-300 border,
+ * primary action), so defining them once here restyles the entire app without
+ * touching a single component. The mockup's hardcoded hex values were promoted
+ * into these tokens so the palette lives in exactly one place.
+ *
+ * Theme SWITCHING stays — theme-gallery, the Theme model, and per-user themes
+ * are a real feature. Storybook is the default and the design reference, not
+ * the only option. `default: true` sets it as daisyUI's fallback; the runtime
+ * default lives in stores/themeStore.ts and must agree.
+ */
+@plugin "daisyui/theme" {
+  name: 'storybook';
+  default: true;
+  prefersdark: false;
+  color-scheme: light;
+
+  /* Paper is the canvas; plate is anything raised onto it. */
+  --color-base-100: oklch(99% 0.008 85); /* plate — cards, panels, headers */
+  --color-base-200: oklch(95.2% 0.021 85); /* paper #f7f1e3 — page ground */
+  --color-base-300: oklch(89% 0.028 82); /* deckle edge — borders, dividers */
+  --color-base-content: oklch(31% 0.021 55); /* ink #3a3128 */
+
+  /* Terracotta: drop caps, speaker names, every primary action. */
+  --color-primary: oklch(57% 0.117 45); /* #b4653a */
+  --color-primary-content: oklch(95.2% 0.021 85);
+
+  /* Muted ink-wash for secondary chrome, sage for quiet accents. */
+  --color-secondary: oklch(47% 0.041 60);
+  --color-secondary-content: oklch(97% 0.014 85);
+  --color-accent: oklch(60% 0.068 145);
+  --color-accent-content: oklch(97% 0.014 85);
+  --color-neutral: oklch(31% 0.021 55);
+  --color-neutral-content: oklch(95.2% 0.021 85);
+
+  /* Status colors kept legible against paper rather than screen-bright. */
+  --color-info: oklch(56% 0.079 235);
+  --color-info-content: oklch(97% 0.014 85);
+  --color-success: oklch(56% 0.093 150);
+  --color-success-content: oklch(97% 0.014 85);
+  --color-warning: oklch(68% 0.124 70);
+  --color-warning-content: oklch(25% 0.021 55);
+  --color-error: oklch(52% 0.152 27);
+  --color-error-content: oklch(97% 0.014 85);
+
+  /* Printed matter: softly rounded plates, no hard chrome edges. */
+  --radius-selector: 0.75rem;
+  --radius-field: 0.75rem;
+  --radius-box: 1rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1.5px;
+  --depth: 1;
+  --noise: 0;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .no-scrollbar::-webkit-scrollbar {
   display: none;
@@ -90,8 +159,38 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
 }
 
 @layer base {
+  /*
+   * Storybook's type. The mockup set `font-serif` per element; promoting it to
+   * the body means prose reads as printed matter everywhere without each
+   * component opting in. UI chrome that should stay sans — buttons, inputs,
+   * badges, code — is exempted below rather than the other way round, because
+   * the reading surface is the majority case in this app.
+   */
   body {
     @apply text-sm md:text-base lg:text-lg xl:text-xl;
+    font-family: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+  }
+
+  /* Generous leading for narration; the 65ch measure lives on .kr-prose. */
+  p {
+    line-height: 1.8;
+  }
+
+  /* Controls and code stay sans — serif buttons read as a mistake, not a choice. */
+  button,
+  input,
+  optgroup,
+  select,
+  textarea,
+  code,
+  pre,
+  kbd,
+  samp,
+  .badge,
+  .btn,
+  .tab {
+    font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+      sans-serif;
   }
 
   button,
@@ -182,6 +281,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   /* A titled block of related content — consistent vertical rhythm. */
   .kr-section {
     @apply space-y-4;
+  }
+
+  /*
+   * Reading column (STORYBOOK, interface-vision t-002). Narration, descriptions
+   * and any long-form prose go here. The 65ch measure is the single most
+   * load-bearing typographic decision in the aesthetic — text set to the full
+   * width of a panel stops reading as a storybook page no matter what the
+   * palette does. Taken straight from the chosen mockup's narration block.
+   */
+  .kr-prose {
+    @apply max-w-[65ch] leading-[1.8];
+  }
+
+  /* The terracotta drop cap that opens a narration block. */
+  .kr-dropcap::first-letter {
+    @apply float-left mr-2 mt-1 font-bold leading-[0.8] text-primary;
+    font-size: 3.25rem;
   }
 
   /* The workhorse raised surface: cards, panels, form groups. */

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -354,7 +354,13 @@ const avatarFallback = computed(() => {
 })
 
 const resolvedBotImage = computed(() => {
-  return loadedBotImage.value || avatarFallback.value
+  // The bot's own purpose-built card art wins over both the async-fetched
+  // ArtImage and the avatar. avatarImage is a portrait crop; cardPath is
+  // rendered at card aspect for exactly this slot. Bots whose cardPath has not
+  // rendered yet fall through to the previous behaviour unchanged.
+  return (
+    props.bot.cardPath?.trim() || loadedBotImage.value || avatarFallback.value
+  )
 })
 
 const canEdit = computed(() => {

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -248,7 +248,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Character } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
-import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import { resolveArtImageSrc, resolveArtVariantSrc } from '@/utils/artImageSrc'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -367,11 +367,17 @@ const computedCharacterImage = computed(() => {
     return rotatingFallbackImage.value
   }
 
-  // Path-first: prefer the art image's path, then its inline base64, then the
-  // character's own imagePath, then the rotating fallback.
-  return resolveArtImageSrc(
-    artImage.value,
-    props.character.imagePath || rotatingFallbackImage.value,
+  // The character's own purpose-built card art wins: it is rendered at card
+  // aspect for exactly this slot. Falls through to the old chain (art image
+  // path, its base64, imagePath, rotating fallback) for characters whose
+  // cardPath has not rendered yet.
+  return resolveArtVariantSrc(
+    props.character,
+    'card',
+    resolveArtImageSrc(
+      artImage.value,
+      props.character.imagePath || rotatingFallbackImage.value,
+    ),
   )
 })
 

--- a/components/rewards/reward-card.vue
+++ b/components/rewards/reward-card.vue
@@ -284,6 +284,15 @@ const imageCandidates = computed<string[]>(() => {
   const candidates: string[] = []
   const image = embeddedArtImage.value || artImage.value
 
+  // The reward's own purpose-built card art leads the chain. It is rendered at
+  // card aspect for exactly this slot, so it should beat the generic ArtImage
+  // and the slug-derived guess. Rewards whose cardPath has not rendered yet
+  // simply start at the next candidate, and the onerror handler still advances
+  // through the rest if this one fails to load.
+  const cardPath = props.reward.cardPath?.trim()
+
+  if (cardPath) candidates.push(cardPath)
+
   // Path-first: try the art image's own path, the reward's imagePath, and the
   // slug-derived path before any inline base64. The <img> onerror handler
   // advances through this list, so base64 stays a graceful fallback.

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -165,7 +165,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Scenario } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
-import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import { resolveArtImageSrc, resolveArtVariantSrc } from '@/utils/artImageSrc'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useUserStore } from '@/stores/userStore'
 import { parseScenarioIntros } from '@/stores/helpers/scenarioHelper'
@@ -240,10 +240,17 @@ const canDelete = computed(() => {
 })
 
 const computedScenarioImage = computed(() =>
-  // Path-first: art image path, then its base64, then the scenario's imagePath.
-  resolveArtImageSrc(
-    artImage.value,
-    props.scenario.imagePath || props.fallbackImage,
+  // The scenario's own purpose-built card art wins: it is rendered at card
+  // aspect for exactly this slot, where imagePath is the wide primary image.
+  // Falls through to the old chain (art image path, its base64, imagePath,
+  // fallback) for scenarios whose cardPath has not rendered yet.
+  resolveArtVariantSrc(
+    props.scenario,
+    'card',
+    resolveArtImageSrc(
+      artImage.value,
+      props.scenario.imagePath || props.fallbackImage,
+    ),
   ),
 )
 

--- a/components/storymaker/storymaker-mockups.vue
+++ b/components/storymaker/storymaker-mockups.vue
@@ -26,22 +26,6 @@
       />
       <strong class="text-sm" :class="v.toolbarText">Aesthetic mockup</strong>
 
-      <div class="flex gap-1">
-        <button
-          v-for="option in variants"
-          :key="option.key"
-          type="button"
-          class="btn btn-xs rounded-lg px-2"
-          :class="
-            variant === option.key ? 'btn-primary' : 'btn-ghost opacity-70'
-          "
-          :title="option.label"
-          @click="variant = option.key"
-        >
-          {{ option.key.toUpperCase() }}
-        </button>
-      </div>
-
       <span class="truncate text-xs" :class="v.toolbarMuted">{{
         v.label
       }}</span>
@@ -184,13 +168,14 @@ import { computed, ref } from 'vue'
 
 /*
  * Disposable Phase 0 mockup for conductor interface-vision/t-001. Fixture data
- * only — no stores, no API, no DB (the sandbox has none). Deleted in t-003 once
- * Silas has picked a direction.
+ * only — no stores, no API, no DB (the sandbox has none). Kept past t-003 as
+ * the live reference for the chosen direction.
  *
- * ONE structure, THREE token sets. The six elements appear in the same order in
- * every variant so the comparison is fair, and so the point lands: the layout
- * contract is the structure, the aesthetic is the skin. Class maps follow the
- * house idiom from conductor-project-gallery-page.vue.
+ * Started life as one structure with three token sets; Storybook won (t-002)
+ * and the other two were deleted. What it demonstrates now is the same point
+ * from the other side: the layout contract is the structure, the theme is the
+ * skin, and this page proves the skin comes entirely from daisyUI semantic
+ * tokens — it holds no palette of its own.
  *
  * No <h1> here on purpose — workspace-header already renders the page title.
  */
@@ -201,9 +186,6 @@ const IMG =
 const sceneArt = `${IMG}/mermaids-of-venice-hero.webp`
 const narratorArt = `${IMG}/storymaker-card.webp`
 
-type VariantKey = 'a' | 'b' | 'c'
-
-const variant = ref<VariantKey>('a')
 const lightsDown = ref(false)
 const picked = ref<number | null>(null)
 const freeText = ref('')
@@ -239,180 +221,67 @@ const inventory = [
   },
 ]
 
-const variants = [
-  { key: 'a' as const, label: 'Theater — a lit stage in a dark house' },
-  { key: 'b' as const, label: 'Storybook — a plate tipped into warm paper' },
-  {
-    key: 'c' as const,
-    label: 'Playground — bright, chunky, unmistakably friendly',
-  },
-]
-
-const TOKENS: Record<VariantKey, Record<string, string>> = {
-  /* ── A · THEATER ────────────────────────────────────────────────────────
-   * Dark house, one lit stage. The art is the performer; chrome recedes to
-   * near-invisible. Narration reads as surtitles beneath the stage: serif,
-   * wide leading, warm cream. Choices are understated until you approach them.
-   */
-  a: {
-    label: 'Theater — a lit stage in a dark house',
-    shell: 'bg-[#0b0b0f] text-[#e8e2d6]',
-    vignette:
-      'bg-[radial-gradient(ellipse_at_50%_28%,rgba(255,190,110,0.16),transparent_58%)]',
-    toolbar: 'border-b border-white/8 bg-black/40 backdrop-blur',
-    toolbarIcon: 'text-amber-300/80',
-    toolbarText: 'font-semibold tracking-wide text-[#e8e2d6]',
-    toolbarMuted: 'text-[#e8e2d6]/40',
-    scrollPad: 'px-4 py-6 sm:px-8 sm:py-10',
-    column: 'max-w-4xl gap-8',
-    plate:
-      'aspect-video w-full rounded-sm shadow-[0_0_80px_-12px_rgba(255,180,90,0.35)] ring-1 ring-amber-200/15',
-    plateScrim:
-      'bg-[linear-gradient(to_top,rgba(11,11,15,0.92),rgba(11,11,15,0.12)_45%,transparent_70%)]',
-    plateCaption: 'text-[#e8e2d6]',
-    narrationRow: 'items-start',
-    portraitWrap: '',
-    portrait:
-      'h-28 w-20 rounded-sm object-top ring-1 ring-amber-200/25 shadow-[0_10px_30px_-10px_rgba(255,180,90,0.5)] sm:h-36 sm:w-24',
-    expression:
-      '-bottom-2 left-1/2 -translate-x-1/2 rounded-full border border-amber-200/30 bg-[#0b0b0f] px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.15em] text-amber-200/90',
-    speakerLabel:
-      'mb-2 text-[0.65rem] uppercase tracking-[0.3em] text-amber-200/60',
-    narrationBox: 'space-y-4',
-    narration:
-      'font-serif text-lg leading-[1.85] text-[#e8e2d6]/92 sm:text-xl sm:leading-[1.9]',
-    narrationSecond:
-      'font-serif text-lg italic leading-[1.85] text-amber-100/70 sm:text-xl',
-    dropCap: '',
-    choicesWrap: 'space-y-3',
-    choicesLabel: 'text-[0.65rem] uppercase tracking-[0.3em] text-[#e8e2d6]/35',
-    choicesGrid: 'flex flex-col gap-2',
-    choice:
-      'flex items-center gap-3 rounded-sm border border-white/10 bg-white/[0.02] px-4 py-3 transition duration-300 hover:border-amber-200/45 hover:bg-amber-100/[0.06] hover:shadow-[0_0_28px_-8px_rgba(255,190,110,0.45)]',
-    choiceIndex:
-      'grid size-6 shrink-0 place-items-center rounded-full border border-white/15 font-serif text-xs text-amber-200/70',
-    choiceLabel: 'block font-serif text-base text-[#e8e2d6]',
-    choiceHint: 'mt-0.5 block text-xs italic text-[#e8e2d6]/40',
-    inputWrap: 'flex items-center gap-2 border-t border-white/10 pt-4',
-    input:
-      'min-w-0 flex-1 border-0 border-b border-white/15 bg-transparent px-1 pb-2 font-serif text-base text-[#e8e2d6] placeholder:text-[#e8e2d6]/25 focus:border-amber-200/50 focus:outline-none',
-    placeholder: 'or say something of your own…',
-    send: 'flex shrink-0 items-center gap-1.5 rounded-sm border border-amber-200/30 px-3 py-1.5 text-sm text-amber-200/90 transition hover:bg-amber-100/10',
-    sendLabel: 'font-serif',
-    inventoryWrap: 'flex flex-wrap items-center gap-2 pt-2',
-    inventoryLabel:
-      'text-[0.6rem] uppercase tracking-[0.25em] text-[#e8e2d6]/30',
-    chip: 'flex items-center gap-1.5 rounded-sm border border-white/10 px-2 py-1 text-xs text-[#e8e2d6]/70',
-  },
-
-  /* ── B · STORYBOOK ──────────────────────────────────────────────────────
-   * Warm paper, generous margins, the art tipped in like a printed plate.
-   * Drop cap, display serif, ragged-right measure held near 65ch so it reads
-   * like a page rather than a panel. Buttons are ribbon tabs.
-   */
-  b: {
-    label: 'Storybook — a plate tipped into warm paper',
-    shell: 'bg-[#f7f1e3] text-[#3a3128]',
-    vignette:
-      'bg-[radial-gradient(ellipse_at_50%_0%,rgba(255,255,255,0.7),transparent_55%)]',
-    toolbar: 'border-b border-[#3a3128]/12 bg-[#f7f1e3]/90 backdrop-blur',
-    toolbarIcon: 'text-[#b4653a]',
-    toolbarText: 'font-semibold text-[#3a3128]',
-    toolbarMuted: 'text-[#3a3128]/45',
-    scrollPad: 'px-5 py-7 sm:px-10 sm:py-12',
-    column: 'max-w-3xl gap-9',
-    plate:
-      'aspect-[3/2] w-full rounded-2xl border-[6px] border-white shadow-[0_18px_44px_-18px_rgba(58,49,40,0.5)]',
-    plateScrim: '',
-    plateCaption: '',
-    narrationRow: 'items-start',
-    portraitWrap: '',
-    portrait:
-      'size-20 rounded-full border-[5px] border-white object-top shadow-[0_8px_20px_-8px_rgba(58,49,40,0.55)] sm:size-24',
-    expression:
-      '-bottom-1 left-1/2 -translate-x-1/2 rounded-full bg-[#b4653a] px-2 py-0.5 text-[0.6rem] font-semibold lowercase text-[#f7f1e3]',
-    speakerLabel: 'mb-1 font-serif text-lg font-bold text-[#b4653a]',
-    narrationBox: 'space-y-4',
-    narration:
-      'max-w-[65ch] font-serif text-[1.0625rem] leading-[1.8] text-[#3a3128] sm:text-lg sm:leading-[1.85]',
-    narrationSecond:
-      'max-w-[65ch] font-serif text-[1.0625rem] italic leading-[1.8] text-[#3a3128]/75 sm:text-lg',
-    dropCap:
-      'float-left mr-2 mt-1 font-serif text-[3.25rem] font-bold leading-[0.8] text-[#b4653a]',
-    choicesWrap: 'space-y-3',
-    choicesLabel: 'font-serif text-base font-bold text-[#3a3128]/70',
-    choicesGrid: 'flex flex-col gap-2.5',
-    choice:
-      'flex items-center gap-3 rounded-xl border-2 border-[#3a3128]/12 bg-white px-4 py-3 shadow-[0_3px_0_0_rgba(58,49,40,0.1)] transition hover:-translate-y-0.5 hover:border-[#b4653a]/50 hover:shadow-[0_6px_0_0_rgba(180,101,58,0.25)]',
-    choiceIndex:
-      'grid size-7 shrink-0 place-items-center rounded-full bg-[#b4653a]/12 font-serif text-sm font-bold text-[#b4653a]',
-    choiceLabel: 'block font-serif text-base font-semibold text-[#3a3128]',
-    choiceHint: 'mt-0.5 block font-serif text-sm italic text-[#3a3128]/55',
-    inputWrap: 'flex items-center gap-2',
-    input:
-      'min-w-0 flex-1 rounded-xl border-2 border-[#3a3128]/15 bg-white px-4 py-2.5 font-serif text-base text-[#3a3128] placeholder:text-[#3a3128]/35 focus:border-[#b4653a]/50 focus:outline-none',
-    placeholder: 'or write your own…',
-    send: 'flex shrink-0 items-center gap-1.5 rounded-xl bg-[#b4653a] px-4 py-2.5 text-sm font-bold text-[#f7f1e3] shadow-[0_3px_0_0_rgba(140,76,42,1)] transition hover:-translate-y-0.5',
-    sendLabel: 'font-serif',
-    inventoryWrap: 'flex flex-wrap items-center gap-2',
-    inventoryLabel: 'font-serif text-sm font-bold text-[#3a3128]/50',
-    chip: 'flex items-center gap-1.5 rounded-full border-2 border-[#3a3128]/12 bg-white px-2.5 py-1 font-serif text-sm text-[#3a3128]/75',
-  },
-
-  /* ── C · PLAYGROUND ─────────────────────────────────────────────────────
-   * Native daisyUI tokens so it inherits whatever theme the user picked.
-   * Chunky, saturated, unmistakably friendly and non-threatening. Everything
-   * is a big obvious target — the most accessible of the three on touch.
-   */
-  c: {
-    label: 'Playground — bright, chunky, unmistakably friendly',
-    shell: 'bg-base-200 text-base-content',
-    vignette: '',
-    toolbar: 'border-b-2 border-base-300 bg-base-100',
-    toolbarIcon: 'text-primary',
-    toolbarText: 'font-black text-base-content',
-    toolbarMuted: 'text-base-content/50',
-    scrollPad: 'px-4 py-5 sm:px-6 sm:py-7',
-    column: 'max-w-5xl gap-5',
-    plate:
-      'aspect-video w-full rounded-3xl border-4 border-primary/25 shadow-lg',
-    plateScrim: 'bg-[linear-gradient(to_top,rgba(0,0,0,0.35),transparent_45%)]',
-    plateCaption: 'text-white',
-    narrationRow: 'items-start',
-    portraitWrap: '',
-    portrait:
-      'size-20 rounded-2xl border-4 border-secondary/40 object-top shadow-md sm:size-24',
-    expression:
-      '-bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-secondary px-2.5 py-0.5 text-[0.65rem] font-black uppercase text-secondary-content shadow',
-    speakerLabel:
-      'mb-1.5 text-sm font-black uppercase tracking-wide text-secondary',
-    narrationBox:
-      'space-y-3 rounded-2xl border-l-8 border-primary bg-base-100 p-4 shadow-sm sm:p-5',
-    narration: 'text-base leading-relaxed text-base-content sm:text-lg',
-    narrationSecond:
-      'text-base font-semibold leading-relaxed text-primary sm:text-lg',
-    dropCap: '',
-    choicesWrap: 'space-y-2.5',
-    choicesLabel:
-      'text-sm font-black uppercase tracking-wide text-base-content/60',
-    choicesGrid: 'grid gap-2.5 md:grid-cols-3',
-    choice:
-      'flex items-start gap-2.5 rounded-2xl border-4 border-base-300 bg-base-100 p-3.5 transition hover:-translate-y-1 hover:border-primary hover:shadow-lg',
-    choiceIndex:
-      'grid size-7 shrink-0 place-items-center rounded-xl bg-primary text-sm font-black text-primary-content',
-    choiceLabel: 'block font-bold leading-snug text-base-content',
-    choiceHint: 'mt-1 block text-xs text-base-content/55',
-    inputWrap: 'flex items-center gap-2',
-    input: 'input input-bordered min-w-0 flex-1 rounded-2xl border-2 text-base',
-    placeholder: 'Or type your own idea…',
-    send: 'btn btn-primary flex shrink-0 items-center gap-1.5 rounded-2xl border-2',
-    sendLabel: 'font-black',
-    inventoryWrap: 'flex flex-wrap items-center gap-2',
-    inventoryLabel:
-      'text-xs font-black uppercase tracking-wide text-base-content/45',
-    chip: 'flex items-center gap-1.5 rounded-full border-2 border-base-300 bg-base-100 px-2.5 py-1 text-sm font-semibold',
-  },
+/*
+ * The STORYBOOK token set — the chosen direction (interface-vision t-002).
+ *
+ * Theater and Playground were deleted rather than kept behind a switcher:
+ * Silas, 2026-08-02, "I don't want to build three different layouts, we're
+ * already trying to make clear decisions and have VISION."
+ *
+ * These are now mostly daisyUI semantic tokens rather than the hex values the
+ * mockup originally hardcoded. The palette itself lives in ONE place — the
+ * `storybook` theme in assets/css/tailwind.css — so this page shows what the
+ * real app renders instead of a parallel copy that can drift from it.
+ */
+const v = {
+  label: 'Storybook — a plate tipped into warm paper',
+  shell: 'bg-base-200 text-base-content',
+  vignette:
+    'bg-[radial-gradient(ellipse_at_50%_0%,rgba(255,255,255,0.7),transparent_55%)]',
+  toolbar: 'border-b border-base-300 bg-base-200/90 backdrop-blur',
+  toolbarIcon: 'text-primary',
+  toolbarText: 'font-semibold text-base-content',
+  toolbarMuted: 'text-base-content/45',
+  scrollPad: 'px-5 py-7 sm:px-10 sm:py-12',
+  column: 'max-w-3xl gap-9',
+  // The white plate border is the "photo tipped into the page" gesture, so it
+  // is base-100 (the raised surface) rather than the paper ground.
+  plate:
+    'aspect-[3/2] w-full rounded-2xl border-[6px] border-base-100 shadow-[0_18px_44px_-18px_rgba(58,49,40,0.5)]',
+  plateScrim: '',
+  plateCaption: '',
+  narrationRow: 'items-start',
+  portraitWrap: '',
+  portrait:
+    'size-20 rounded-full border-[5px] border-base-100 object-top shadow-[0_8px_20px_-8px_rgba(58,49,40,0.55)] sm:size-24',
+  expression:
+    '-bottom-1 left-1/2 -translate-x-1/2 rounded-full bg-primary px-2 py-0.5 text-[0.6rem] font-semibold lowercase text-primary-content',
+  speakerLabel: 'mb-1 text-lg font-bold text-primary',
+  narrationBox: 'space-y-4',
+  // .kr-prose carries the 65ch measure and 1.8 leading; body type is already
+  // serif from the base layer, so neither is restated here.
+  narrationSecond: 'kr-prose italic text-base-content/75 sm:text-lg',
+  narration: 'kr-prose text-[1.0625rem] text-base-content sm:text-lg',
+  dropCap: 'kr-dropcap',
+  choicesWrap: 'space-y-3',
+  choicesLabel: 'text-base font-bold text-base-content/70',
+  choicesGrid: 'flex flex-col gap-2.5',
+  choice:
+    'flex items-center gap-3 rounded-xl border-2 border-base-300 bg-base-100 px-4 py-3 shadow-[0_3px_0_0_rgba(58,49,40,0.1)] transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-[0_6px_0_0_rgba(180,101,58,0.25)]',
+  choiceIndex:
+    'grid size-7 shrink-0 place-items-center rounded-full bg-primary/12 text-sm font-bold text-primary',
+  choiceLabel: 'block text-base font-semibold text-base-content',
+  choiceHint: 'mt-0.5 block text-sm italic text-base-content/55',
+  inputWrap: 'flex items-center gap-2',
+  input:
+    'min-w-0 flex-1 rounded-xl border-2 border-base-300 bg-base-100 px-4 py-2.5 text-base text-base-content placeholder:text-base-content/35 focus:border-primary/50 focus:outline-none',
+  placeholder: 'or write your own…',
+  send: 'flex shrink-0 items-center gap-1.5 rounded-xl bg-primary px-4 py-2.5 text-sm font-bold text-primary-content shadow-[0_3px_0_0_rgba(140,76,42,1)] transition hover:-translate-y-0.5',
+  sendLabel: '',
+  inventoryWrap: 'flex flex-wrap items-center gap-2',
+  inventoryLabel: 'text-sm font-bold text-base-content/50',
+  chip: 'flex items-center gap-1.5 rounded-full border-2 border-base-300 bg-base-100 px-2.5 py-1 text-sm text-base-content/75',
 }
 
-const v = computed(() => TOKENS[variant.value])
+
 </script>

--- a/stores/helpers/themeHelper.ts
+++ b/stores/helpers/themeHelper.ts
@@ -44,7 +44,18 @@ export const extraVars = [
   '--noise',
 ]
 
+/**
+ * Every theme name the app will apply to `data-theme`.
+ *
+ * `storybook` is FIRST because it is the house aesthetic (interface-vision
+ * t-002), not a stock daisyUI theme — it is defined by the
+ * `@plugin "daisyui/theme"` block in assets/css/tailwind.css. It has to be
+ * listed here or setActiveTheme rejects it as "not found in DaisyUI or shared
+ * themes" and the default silently fails to apply. The rest are daisyUI's
+ * built-ins, kept so users can still theme-switch.
+ */
 export const daisyuiThemes = [
+  'storybook',
   'light',
   'dark',
   'cupcake',

--- a/stores/themeStore.ts
+++ b/stores/themeStore.ts
@@ -44,7 +44,15 @@ type ThemeInitializeOptions = {
   fetchShared?: boolean
 }
 
-const defaultThemeName = 'retro'
+// STORYBOOK is the house aesthetic (interface-vision t-002) and is defined as a
+// daisyUI theme in assets/css/tailwind.css. That definition carries
+// `default: true`; this constant is the RUNTIME default and the two must agree,
+// or a user with no stored preference gets daisyUI's fallback while the store
+// reports something else. Was 'retro' — a stock theme that happened to be
+// cream-ish, which is why parts of the app already half-looked right. Now it is
+// deliberate. Theme switching is unaffected: this is the default, not the only
+// option.
+const defaultThemeName = 'storybook'
 const themeStorageKey = 'theme'
 const themeFormStorageKey = 'themeForm'
 const showCustomStorageKey = 'showCustom'

--- a/utils/artImageSrc.ts
+++ b/utils/artImageSrc.ts
@@ -52,6 +52,48 @@ export function resolveArtImageSrc(
   return toArtDataUri(image?.imageData, image?.fileType) || fallback
 }
 
+export type ArtVariant = 'card' | 'hero' | 'icon'
+
+const VARIANT_PATH_KEYS = {
+  card: 'cardPath',
+  hero: 'heroPath',
+  icon: 'iconPath',
+} as const
+
+const VARIANT_DATA_KEYS = {
+  card: 'cardData',
+  hero: 'heroData',
+  icon: 'iconData',
+} as const
+
+/**
+ * Renderable source for a purpose-built art variant.
+ *
+ * These three slots have existed on the type since the card/hero/icon migration
+ * (interface-vision t-007), but until now nothing read them: the only resolvers
+ * were the full-size and thumbnail ones, so every card fell back to the entity's
+ * avatar or primary image. That left hundreds of rendered card images sitting in
+ * the database, invisible.
+ *
+ * Degrades deliberately: variant path -> variant base64 -> the full-size
+ * resolver -> `fallback`. A slot that has not rendered yet therefore behaves
+ * exactly as it did before rather than leaving a hole, which is what lets this
+ * ship while the render queue is still draining.
+ */
+export function resolveArtVariantSrc(
+  image: ArtImageSrcLike,
+  variant: ArtVariant,
+  fallback = '',
+): string {
+  const path = cleanValue(image?.[VARIANT_PATH_KEYS[variant]])
+  if (path) return path
+
+  const data = toArtDataUri(image?.[VARIANT_DATA_KEYS[variant]], image?.fileType)
+  if (data) return data
+
+  return resolveArtImageSrc(image, fallback)
+}
+
 // Renderable source for a thumbnail. Prefers thumbnailPath, then the full-size
 // path, then inline thumbnail/full base64, then `fallback`.
 export function resolveArtImageThumbSrc(


### PR DESCRIPTION
Two commits, reviewable separately. They're paired on purpose: Storybook is *illustration-forward*, so applying it to imageless cards would have been judging the aesthetic on incomplete evidence.

---

# Commit 1 — Show the card art that was already rendered but invisible

The card/hero/icon migration (t-007) shipped the schema and the render pipeline, and the queue has been filling `cardPath` ever since — **bots are 68/68 and characters 201/213 today**, with ~1,500 more renders queued.

**None of it was ever visible.** `bot-card`, `character-card`, `reward-card` and `scenario-card` all resolve their image from `avatarImage` / `imagePath` / `artImageId`, and none reads `cardPath`. (The `field: 'cardPath'` references in the `*-interact` components are art-*request* targets, not display.)

So the fix for *"zero images on narrative pages"* was half-built: the data half shipped, the display half was never wired.

`utils/artImageSrc.ts` already declared the three variants on `ArtImageSrcLike` but no function read them. Adds `resolveArtVariantSrc(image, variant, fallback)`, degrading **variant path → variant base64 → the existing full-size resolver → fallback**. That degradation is the point — it lets this ship mid-queue, because an entity whose `cardPath` hasn't rendered yet behaves exactly as it does today rather than showing a hole.

Each card prefers its own `cardPath` ahead of its previous chain, following the pattern `dream-card.vue:299` already uses. `reward-card` keeps its ordered candidate list and leads with `cardPath`, so its `onerror` handler still advances through the rest.

**Untouched:** `facet-*` and `dream-card` already read these correctly. `heroPath`/`iconPath` have no data yet — the resolver covers all three, so they light up on their own with no further deploy.

---

# Commit 2 — Make Storybook the house aesthetic (t-002)

> *"Let's run with Storybook as the design. I don't want to build three different layouts, we're already trying to make clear decisions and have VISION."* — Silas, 2026-08-02

Theater and Playground are **deleted**, not kept behind a switcher.

## The leverage is architectural, not visual

Every `.kr-*` primitive in `tailwind.css` is already written against daisyUI's **semantic** tokens — `base-200` canvas, `base-100` raised surface, `base-300` border, `primary` action. So Storybook is one `@plugin "daisyui/theme"` block that restyles the whole app **without touching a single component**. A per-component restyle would have been hundreds of files and would drift immediately.

| Role | Token | Value |
|---|---|---|
| Page canvas | `base-200` | paper `#f7f1e3` → `oklch(95.2% 0.021 85)` |
| Raised surface | `base-100` | plate white → `oklch(99% 0.008 85)` |
| Borders | `base-300` | deckle edge |
| Text | `base-content` | ink `#3a3128` |
| Action, drop caps | `primary` | terracotta `#b4653a` |

Radius and border are tuned for printed matter: softly rounded plates, no hard chrome edges.

## Type

Serif body at `1.8` leading moves to `@layer base`, since prose is the majority surface here. Controls, code and badges are exempted **back** to sans — serif buttons read as a mistake rather than a choice.

Adds `.kr-prose` (the **`65ch` measure** — the single most load-bearing typographic decision in the aesthetic; full-panel-width text stops reading as a storybook page no matter what the palette does) and `.kr-dropcap`.

## Three places that must agree

`defaultThemeName` moves from `'retro'` to `'storybook'`, **and** `'storybook'` is added to `themeHelper`'s `daisyuiThemes` allow-list — without that entry `setActiveTheme` rejects it as *"not found in DaisyUI or shared themes"* and the default silently fails to apply. The theme block's `default: true` is the third.

(`retro` is a stock theme that happens to be cream-ish, which is why parts of the app already half-looked right. This makes it deliberate.)

Theme **switching is untouched** — `theme-gallery`, the `Theme` model and per-user themes are a real feature. Storybook is the default and the reference, not the only option.

## The mockup

Collapses 418 → 285 lines, keeping only the chosen direction. Its **19 hardcoded hex values are replaced by the semantic tokens**, so the palette lives in exactly one place and the page shows what the real app renders rather than a parallel copy that can drift.

---

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean.
- **An actual client build**, because `vue-tsc` does not compile CSS and a bad theme block would have passed it. The build succeeded and the compiled bundle carries `:where(:root),[data-theme=storybook]` with the mapped oklch tokens — confirming both that the syntax is valid and that `default: true` took effect. (The build's later prerender step fails on a missing `JWT_SECRET`, an env limitation of this sandbox, not the change.)
- `test:layout-contract` — holds, no new violations.
- `channel-content`, `nav-manifest`, `verifyMaturityPrivacyContract`, `verifyEntityArtManager` — pass. (`nav-manifest`'s two lines are the known t-034 warnings, identical on clean `main`.)
- **Commit 1 against production data:** `/api/bots` returns 68/68 with `cardPath`; bot 1's resolves to `/api/art/images/13858/file?v=…`, genuinely different from its `avatarImage` of `/images/bots/promptbots/ami-bot.webp`, and serves `HTTP 200 image/png` both authenticated and anonymous — which matters because galleries are public.

Decision recorded in conductor #1534.

## Follow-up worth filing

Entity art has no thumbnail variant — the ArtImage row carries `thumbnailPath: null`. That card PNG is **544KB**, so a 68-card gallery pulls ~37MB. Not a regression (the old fallback was full-size too), but far more visible now that cards actually use it. Worth a card-sized WebP before beta.