### PR TITLE
interface-vision/t-017: sweep layout-contract one-header + gallery :has() overrides

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -34,30 +34,14 @@ body,
   display: none !important;
 }
 
-section:has(img[src*='projects/images']) .overflow-y-auto {
-  overflow-x: hidden;
-}
-
-section:has(img[src*='projects/images'])
-  .grid:has(> button[style*='aspect-ratio: 2/3']),
-section:has(img[src*='projects/images'])
-  .grid:has(> div[style*='aspect-ratio: 2/3']) {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
-}
-
-section:has(img[src*='projects/images'])
-  .grid:has(> button[style*='aspect-ratio: 16/9']),
-section:has(img[src*='projects/images'])
-  .grid:has(> div[style*='aspect-ratio: 16/9']) {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
-}
-
-section:has(img[src*='projects/images'])
-  .grid:has(> button > img[src*='-icon']),
-section:has(img[src*='projects/images']) .grid:has(> div > img[src*='-icon']) {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 8rem), 1fr));
-}
-
+/*
+ * interface-vision/t-017: the four :has() overrides that used to patch the
+ * public project gallery (components/pages/conductor-page.vue) are gone —
+ * that component now declares its auto-fit grid columns and overflow-x
+ * directly. The two remaining overrides below still patch the ADMIN project
+ * detail view in the same component, which is explicitly lowest priority
+ * (Silas, 2026-08-01: "admin based routes are last on priority").
+ */
 section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]']) {
   overflow-x: hidden;
   overflow-y: auto;

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -48,11 +48,11 @@
           </span>
         </div>
 
-        <h1
+        <p
           class="text-3xl font-black leading-tight text-base-content sm:text-5xl"
         >
           {{ view.title }}
-        </h1>
+        </p>
         <p
           v-if="view.tagline"
           class="max-w-2xl text-base font-semibold text-base-content/80 sm:text-lg"

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -156,7 +156,10 @@
     </div>
 
     <!-- NON-ADMIN: public project gallery -->
-    <div v-if="!userStore.isAdmin" class="flex min-h-0 flex-1 overflow-y-auto">
+    <div
+      v-if="!userStore.isAdmin"
+      class="flex min-h-0 flex-1 overflow-x-hidden overflow-y-auto"
+    >
       <div class="w-full pb-4">
         <div
           v-if="!projectStore.loaded"
@@ -171,7 +174,7 @@
         <template v-else>
           <div
             v-if="projectGalleryMode === 'icons'"
-            class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+            class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,8rem),1fr))] gap-3"
           >
             <div
               v-for="project in projectStore.publicProjects"
@@ -223,7 +226,7 @@
           </div>
           <div
             v-else-if="projectGalleryMode === 'heroes'"
-            class="grid gap-4 sm:grid-cols-2"
+            class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4"
           >
             <div
               v-for="project in projectStore.publicProjects"
@@ -246,7 +249,10 @@
               </div>
             </div>
           </div>
-          <div v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div
+            v-else
+            class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))] gap-4"
+          >
             <div
               v-for="project in projectStore.publicProjects"
               :key="project.id"

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -3,7 +3,6 @@
     class="mx-auto h-full min-h-0 max-w-5xl space-y-6 overflow-y-auto overscroll-contain p-6"
   >
     <header class="space-y-1">
-      <h1 class="text-2xl font-bold">🎬 Video Generator</h1>
       <p class="text-sm opacity-70">
         Animate a still into a short clip. Pick a first image (and an optional
         end image), describe the motion, set the length, and queue it to the

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -1,16 +1,14 @@
 {
   "note": "Layout-contract allow-list. RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLayoutContract.ts.",
-  "recorded": "2026-08-01",
+  "recorded": "2026-08-02",
   "violations": {
     "one-header": [
-      "components/conductor/project-front-page.vue",
       "components/pages/registration-form.vue",
       "components/pages/serendipity-page.vue",
       "pages/admin/wonderlab-review-generator.vue",
       "pages/admin/wonderlab-review-plan.vue",
       "pages/admin/wonderlab-review-rollout.vue",
-      "pages/admin/wonderlab-reviews.vue",
-      "pages/play/video-generator.vue"
+      "pages/admin/wonderlab-reviews.vue"
     ],
     "one-scroll": [
       "components/academy/academy-manager.vue",


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

### What changed / what I produced
- `pages/play/video-generator.vue` (daily-driver: video-gen): removed the redundant `<h1>🎬 Video Generator</h1>` that duplicated the workspace-header's tab title — the shell already renders "Video Generator" as the active tab title, so the page had it twice.
- `components/conductor/project-front-page.vue` (shared shell for 14 project pages, incl. newsfeed — another daily-driver): demoted the hero title from `<h1>` to `<p>`, same exact classes/visual, since a page component shouldn't own the page's `<h1>` per the layout contract's rule 1.
- `components/pages/conductor-page.vue` (Project gallery — one of Silas's most-used pages): the icons/heroes/cards grid modes now declare their auto-fit `grid-template-columns` and `overflow-x-hidden` directly via Tailwind arbitrary-value classes, computed to be pixel-identical to what the CSS `:has()` overrides were forcing before.
- `assets/css/tailwind.css`: removed the 4 `:has()` overrides that patched the public gallery (now redundant). Left the 2 remaining overrides that patch the *admin* project-detail view in the same component — admin routes are explicitly lowest priority per Silas's 2026-08-01 notes, so this is a deliberate stopping point, not an oversight.

### How I verified
- `npm run test:layout-contract` — one-header dropped 8 → 6 (both removed entries were the ones this PR targeted), no other category regressed. Baseline ratcheted down via `--update`.
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on all 4 changed source files — clean.
- Traced the `:has()` selectors by hand against `conductor-page.vue`'s actual markup (aspect-ratio styles, `-icon` image srcs, the `projects/images` substring only matches the GitHub-raw fallback path used by this component) to confirm the new arbitrary-value classes reproduce the exact same computed grid — no other component/page hits these selectors (project-front-page.vue's local image path is `/images/projects/...`, which doesn't match the `projects/images` substring the removed rule matched on).

### Stakes
reversible

### Flags for Reviewer
- I did not touch `pages/admin/wonderlab-review-*.vue`, `components/pages/registration-form.vue`, or `components/pages/serendipity-page.vue` (remaining one-header entries) — none are daily-driver tools, correctly deprioritized per the task's stated ordering.
- Did not touch `components/art/artjob-queue-browser.vue`'s magic-number/depth-12 nesting issue the task note calls out — it's not tracked by any of the six layout-contract categories (the ratchet doesn't move from fixing it), and at 1002 lines it's a large enough restructuring to warrant its own task rather than folding into this PR. Left as follow-up.
- The 2 remaining `:has()` overrides (admin project-detail view, `assets/css/tailwind.css`) are left in place — same reasoning (admin last).
- No visual/preview verification beyond hand-tracing the CSS selectors, since the sandbox has no working `nuxt dev` (no DB). Recommend a Vercel preview check on the gallery's three view modes (cards/heroes/icons) before merge if you want a visual confirmation, though the change is designed to be a pixel-identical refactor.

### Kaizen suggestion
`components/art/artjob-queue-browser.vue`'s 614-line depth-12 template with `min-h-[720px]`/`min-h-[560px]` magic numbers (called out in t-017's note as a daily-driver offender — artjob queue) isn't tracked by any layout-contract category, so the ratchet will never surface it. Worth a dedicated follow-up task to restructure it, since it's explicitly one of Silas's most-used pages.

### Notes for reviewer
Roadmap task `interface-vision/t-017` is `recurring`-shaped in spirit (the allow-list sweep continues across many PRs until zero) but is declared as a normal one-shot task; I've left it `status: review` rather than closing it, since 2 of 6 `:has()` overrides and 6 of 8 `one-header` entries remain. Suggest re-opening/re-arming it to `ready` after merge so the sweep continues, or splitting the remainder into a new task — Reviewer's call per AGENTS.md.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVg2dzDNK1BLfvPiB6eqRz)_