### PR TITLE
fix(layout): remove duplicate WonderLab review generator header

### DIFF
--- a/pages/admin/wonderlab-review-generator.vue
+++ b/pages/admin/wonderlab-review-generator.vue
@@ -7,7 +7,7 @@
       <p class="text-xs font-black uppercase tracking-widest text-primary">
         WonderLab Editorial
       </p>
-      <h1 class="mt-2 text-3xl font-black">Generate a personality review draft</h1>
+      <p class="mt-2 text-3xl font-black">Generate a personality review draft</p>
       <p class="mt-2 text-sm leading-relaxed text-base-content/60">
         This creates a proposed draft only. A curator must review, approve, and separately
         publish it from the curator workspace.

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -5,7 +5,6 @@
     "one-header": [
       "components/pages/registration-form.vue",
       "components/pages/serendipity-page.vue",
-      "pages/admin/wonderlab-review-generator.vue",
       "pages/admin/wonderlab-review-plan.vue",
       "pages/admin/wonderlab-review-rollout.vue",
       "pages/admin/wonderlab-reviews.vue"


### PR DESCRIPTION
### Task
interface-vision/t-017: continue shrinking the layout-contract allow-list (kind: software)

### What changed
- Demoted the WonderLab review generator's decorative page title from `<h1>` to `<p>` while preserving its visual classes.
- Ratcheted the `one-header` allow-list from 6 entries to 5.

### How I verified
- Inspected the complete diff against current main: exactly one tag swap and one baseline deletion.
- GitHub Actions will run the layout contract, TypeScript, and normal repository checks before merge.

### Stakes
reversible

### Kaizen suggestion
Add a tiny source contract that requires admin pages to rely on the workspace shell title unless explicitly exempted.

### Notes for reviewer
This is an intentionally small second pass of recurring task t-017. The task will re-arm after merge because the allow-list is not yet zero.