### PR TITLE
interface-vision/t-017: shrink layout-contract allow-list (one-header, one-scroll, zero-scroll)

### DIFF
--- a/components/pages/registration-form.vue
+++ b/components/pages/registration-form.vue
@@ -1,146 +1,149 @@
 <!-- /components/content/pages/registration-form.vue -->
 <template>
-  <div
-    class="bg-base-300 flex flex-col items-center rounded-2xl h-full p-4 sm:p-8"
-  >
-    <h1 class="text-6xl font-bold mb-6 text-center">Kind Robots</h1>
-    <div v-if="isLoggedIn" class="text-lg mb-6 text-center">
-      You are already logged in. Would you like to
-      <a href="/dashboard" class="text-info underline hover:text-info-focus">
-        go to the dashboard
-      </a>
-      or
-      <a
-        href="#"
-        class="text-info underline hover:text-info-focus"
-        @click="userStore.logout"
+  <div class="kr-surface bg-base-300 rounded-2xl p-4 sm:p-8">
+    <div class="kr-scroll flex flex-col items-center">
+      <p class="text-6xl font-bold mb-6 text-center">Kind Robots</p>
+      <div v-if="isLoggedIn" class="text-lg mb-6 text-center">
+        You are already logged in. Would you like to
+        <a href="/dashboard" class="text-info underline hover:text-info-focus">
+          go to the dashboard
+        </a>
+        or
+        <a
+          href="#"
+          class="text-info underline hover:text-info-focus"
+          @click="userStore.logout"
+        >
+          log out </a
+        >?
+      </div>
+      <form
+        class="space-y-6 w-full max-w-md mx-auto"
+        @submit.prevent="register"
       >
-        log out </a
-      >?
-    </div>
-    <form class="space-y-6 w-full max-w-md mx-auto" @submit.prevent="register">
-      <div v-if="step === 1">
-        <!-- Pick a Username Section -->
-        <h1 class="text-4xl font-bold mb-4 text-center">Pick a</h1>
-        <div class="text-primary font-semibold text-5xl text-center mb-2">
-          <adjective-flipper />
-        </div>
-        <h2 class="text-4xl text-center mb-6">username.</h2>
-        <div class="relative mb-6">
-          <input
-            v-model="username"
-            type="text"
-            placeholder="Username"
-            required
-            class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
-            aria-label="Username"
-            autocomplete="username"
-            @input="checkUsernameAvailability"
-          />
-          <p
-            v-if="usernameWarning"
-            class="absolute text-sm text-warning right-2 bottom-2"
+        <div v-if="step === 1">
+          <!-- Pick a Username Section -->
+          <p class="text-4xl font-bold mb-4 text-center">Pick a</p>
+          <div class="text-primary font-semibold text-5xl text-center mb-2">
+            <adjective-flipper />
+          </div>
+          <h2 class="text-4xl text-center mb-6">username.</h2>
+          <div class="relative mb-6">
+            <input
+              v-model="username"
+              type="text"
+              placeholder="Username"
+              required
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Username"
+              autocomplete="username"
+              @input="checkUsernameAvailability"
+            />
+            <p
+              v-if="usernameWarning"
+              class="absolute text-sm text-warning right-2 bottom-2"
+            >
+              Username already exists
+            </p>
+          </div>
+          <button
+            v-if="username && !usernameWarning"
+            type="button"
+            class="w-full bg-primary text-lg text-base-100 py-2 rounded hover:bg-primary-dark transition duration-300"
+            @click="goToStep(2)"
           >
-            Username already exists
-          </p>
+            That's my name!
+          </button>
         </div>
-        <button
-          v-if="username && !usernameWarning"
-          type="button"
-          class="w-full bg-primary text-lg text-base-100 py-2 rounded hover:bg-primary-dark transition duration-300"
-          @click="goToStep(2)"
-        >
-          That's my name!
-        </button>
-      </div>
 
-      <div v-if="step === 2">
-        <!-- Password and Confirmation Section -->
-        <h2 class="text-3xl font-semibold text-primary mb-4 text-center">
-          Welcome, {{ username }}!
-        </h2>
-        <button
-          type="button"
-          class="text-sm text-info underline mb-4 text-center"
-          @click="goToStep(1)"
-        >
-          I want a different username
-        </button>
-        <p class="text-lg mb-2">Optional details:</p>
-        <div class="relative group mb-4">
-          <input
-            v-model="email"
-            type="email"
-            placeholder="Email (optional)"
-            class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
-            aria-label="Email"
-            autocomplete="email"
-          />
-        </div>
-        <div class="relative group mb-4">
-          <input
-            v-model="password"
-            :type="showPassword ? 'text' : 'password'"
-            placeholder="Password (keep it blank if you prefer)"
-            class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
-            aria-label="Password"
-            autocomplete="new-password"
-            @input="validatePassword"
-          />
-          <div class="absolute inset-y-0 right-0 flex items-center pr-3">
-            <Icon
-              name="kind-icon:eye"
-              :class="
-                showPassword
-                  ? 'text-base-300 cursor-pointer hover:text-warning'
-                  : 'text-base-300 cursor-pointer hover:text-success'
-              "
-              title="Show/Hide Password"
-              @click="togglePasswordVisibility"
+        <div v-if="step === 2">
+          <!-- Password and Confirmation Section -->
+          <h2 class="text-3xl font-semibold text-primary mb-4 text-center">
+            Welcome, {{ username }}!
+          </h2>
+          <button
+            type="button"
+            class="text-sm text-info underline mb-4 text-center"
+            @click="goToStep(1)"
+          >
+            I want a different username
+          </button>
+          <p class="text-lg mb-2">Optional details:</p>
+          <div class="relative group mb-4">
+            <input
+              v-model="email"
+              type="email"
+              placeholder="Email (optional)"
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Email"
+              autocomplete="email"
             />
           </div>
-          <p v-if="passwordError" class="text-sm text-warning mt-2">
-            {{ passwordError }}
-          </p>
-        </div>
-
-        <div class="relative group mb-4">
-          <input
-            v-model="confirmPassword"
-            :type="showConfirmPassword ? 'text' : 'password'"
-            placeholder="Confirm Password"
-            class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
-            aria-label="Confirm Password"
-            autocomplete="new-password"
-            @input="validateConfirmPassword"
-          />
-          <div class="absolute inset-y-0 right-0 flex items-center pr-3">
-            <Icon
-              name="kind-icon:eye"
-              :class="
-                showConfirmPassword
-                  ? 'text-base-300 cursor-pointer hover:text-warning'
-                  : 'text-base-300 cursor-pointer hover:text-success'
-              "
-              title="Show/Hide Confirm Password"
-              @click="toggleConfirmPasswordVisibility"
+          <div class="relative group mb-4">
+            <input
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              placeholder="Password (keep it blank if you prefer)"
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Password"
+              autocomplete="new-password"
+              @input="validatePassword"
             />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+              <Icon
+                name="kind-icon:eye"
+                :class="
+                  showPassword
+                    ? 'text-base-300 cursor-pointer hover:text-warning'
+                    : 'text-base-300 cursor-pointer hover:text-success'
+                "
+                title="Show/Hide Password"
+                @click="togglePasswordVisibility"
+              />
+            </div>
+            <p v-if="passwordError" class="text-sm text-warning mt-2">
+              {{ passwordError }}
+            </p>
           </div>
-          <p v-if="confirmPasswordError" class="text-sm text-warning mt-2">
-            {{ confirmPasswordError }}
-          </p>
-        </div>
 
-        <button
-          type="submit"
-          :disabled="!isFormValid || isLoading"
-          class="w-full bg-primary text-lg text-base-100 py-2 rounded hover:bg-primary-dark transition duration-300"
-        >
-          <span v-if="isLoading">Registering...</span>
-          <span v-else>Register</span>
-        </button>
-      </div>
-    </form>
+          <div class="relative group mb-4">
+            <input
+              v-model="confirmPassword"
+              :type="showConfirmPassword ? 'text' : 'password'"
+              placeholder="Confirm Password"
+              class="w-full p-4 border rounded-lg text-lg bg-base-200 placeholder-base-content"
+              aria-label="Confirm Password"
+              autocomplete="new-password"
+              @input="validateConfirmPassword"
+            />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+              <Icon
+                name="kind-icon:eye"
+                :class="
+                  showConfirmPassword
+                    ? 'text-base-300 cursor-pointer hover:text-warning'
+                    : 'text-base-300 cursor-pointer hover:text-success'
+                "
+                title="Show/Hide Confirm Password"
+                @click="toggleConfirmPasswordVisibility"
+              />
+            </div>
+            <p v-if="confirmPasswordError" class="text-sm text-warning mt-2">
+              {{ confirmPasswordError }}
+            </p>
+          </div>
+
+          <button
+            type="submit"
+            :disabled="!isFormValid || isLoading"
+            class="w-full bg-primary text-lg text-base-100 py-2 rounded hover:bg-primary-dark transition duration-300"
+          >
+            <span v-if="isLoading">Registering...</span>
+            <span v-else>Register</span>
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
 </template>
 

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -8,7 +8,7 @@
 -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4 md:p-6"
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-4 md:p-6"
     data-animation-surface
   >
     <header class="flex flex-wrap items-center justify-between gap-3">
@@ -19,7 +19,7 @@
           <Icon name="kind-icon:butterfly" class="h-7 w-7" />
         </span>
         <div>
-          <h1 class="text-2xl font-black tracking-tight">Serendipity</h1>
+          <p class="text-2xl font-black tracking-tight">Serendipity</p>
           <p class="text-sm text-base-content/60">
             Talk to Kind Robots through your Amazon Echo.
           </p>
@@ -100,7 +100,7 @@
       </form>
     </div>
 
-    <div class="grid flex-1 gap-4 md:grid-cols-[1fr,16rem]">
+    <div class="grid min-h-0 flex-1 gap-4 md:grid-cols-[1fr,16rem]">
       <!-- Message feed -->
       <div
         class="flex min-h-48 flex-col rounded-xl border border-base-300 bg-base-100"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -3,8 +3,6 @@
   "recorded": "2026-08-02",
   "violations": {
     "one-header": [
-      "components/pages/registration-form.vue",
-      "components/pages/serendipity-page.vue",
       "pages/admin/wonderlab-review-plan.vue",
       "pages/admin/wonderlab-review-rollout.vue",
       "pages/admin/wonderlab-reviews.vue"
@@ -29,7 +27,6 @@
       "components/navigation/workspace-narrator.vue",
       "components/pages/conductor-page.vue",
       "components/pages/memory-dungeon.vue",
-      "components/pages/serendipity-page.vue",
       "components/rewards/reward-interact.vue",
       "components/scenarios/scenario-gallery.vue",
       "components/scenarios/scenario-interact.vue",
@@ -68,7 +65,6 @@
       "components/pages/kaizen-popup.vue",
       "components/pages/kind-prompts.vue",
       "components/pages/rebel-button.vue",
-      "components/pages/registration-form.vue",
       "components/pages/social-page.vue",
       "pages/auth/google.vue",
       "pages/build-bench.vue"

--- a/utils/scripts/verifySerendipityRouteCutover.mjs
+++ b/utils/scripts/verifySerendipityRouteCutover.mjs
@@ -37,7 +37,14 @@ assert.match(channel, /^title: Serendipity$/m)
 assert.match(channel, /^route: \/serendipity$/m)
 assert.doesNotMatch(channel, /^route: \/serendipity-voice$/m)
 
-assert.match(component, /<h1 class="text-2xl font-black tracking-tight">Serendipity<\/h1>/)
+// Semantic identity assertion, not an exact-tag lock: the layout-contract
+// (interface-vision/t-017) forbids page components from owning an <h1> — the
+// app shell renders the page title — so this only pins the visual identity
+// marker (bold text-2xl "Serendipity" label beside the icon), not its tag.
+assert.match(
+  component,
+  /<[a-z][a-z0-9]*[^>]*class="text-2xl font-black tracking-tight"[^>]*>Serendipity<\/[a-z][a-z0-9]*>/,
+)
 assert.doesNotMatch(component, /components\/pages\/serendipity-voice-page\.vue/)
 
 const serendipityTab = dashboard.match(


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

### What changed / what I produced
- `components/pages/registration-form.vue`: demoted both page-owned `<h1>`s to `<p>` (one-header), and gave the page a real scroll owner via the `kr-surface`/`kr-scroll` primitives (interface-vision/t-004) instead of relying on the shell (zero-scroll).
- `components/pages/serendipity-page.vue`: demoted its own `<h1>` to `<p>` (the shell already renders the page title) and removed the root section's `overflow-y-auto` so the existing message-feed `overflow-y-auto` is the page's one scroll owner (one-header, one-scroll). Added `min-h-0` to the grid wrapper so the feed panel still bounds correctly.
- `utils/scripts/verifySerendipityRouteCutover.mjs`: per the t-023 composition-lock audit (`projects/interface-vision/COMPOSITION-LOCK-AUDIT.md`), replaced the exact `<h1>` markup lock with a semantic identity assertion (bold `text-2xl font-black tracking-tight` "Serendipity" label, any tag) so the route-cutover contract survives the header demotion without weakening what it actually guards — route/tab/dashboard/obsolete-route assertions are untouched.
- `utils/scripts/layout-contract-baseline.json`: ratcheted down — one-header 5→3, one-scroll 34→33, zero-scroll 8→7. No rule regressed anywhere else.

### How I verified
- `npm run test:layout-contract -- --report` before and after: only the intended three counts dropped, nothing else changed.
- `npm run test:layout-contract -- --update`: baseline write succeeded (ratchet never grew).
- `node utils/scripts/verifySerendipityRouteCutover.mjs`: passes with the new semantic assertion.
- `npx vue-tsc --noEmit`: clean.
- `npx eslint` on both changed `.vue` files and the changed script: clean.

### Stakes
reversible

### Flags for Reviewer
- `components/pages/registration-form.vue` has no importers/tag references anywhere in the current tree that I could find (grepped for the tag and the filename) — it wasn't in t-018's confirmed-orphan list, so I fixed its layout violations in place rather than second-guessing that audit's scope here. Worth a follow-up orphan check if it's genuinely dead.
- Remaining one-header entries (`pages/admin/wonderlab-review-{plan,rollout,reviews}.vue`) are all admin-only, correctly left for last per the task's own instruction.

### Kaizen suggestion
The `one-scroll` category (33 entries) is by far the largest remaining bucket and mostly untouched — a follow-up task to batch-fix a handful of the `components/user/*` or `components/wonderlab/*` one-scroll offenders (many likely share the same manager/interact-panel shape) would make faster progress than picking one-header/zero-scroll stragglers one at a time.

### Notes for reviewer
Conductor roadmap task `interface-vision/t-017` is at `status: review`, claimed under session `20260802T073456Z-interface-vision-t-017-c9d2`. Re-armed to `ready` on merge per this project's recurring-sweep convention (allow-list not yet at zero).


---
_Generated by [Claude Code](https://claude.ai/code/session_017euNjNFKbioouCzjRLDiBV)_