### PR TITLE
fix(layout): remove WonderLab review plan duplicate title

### DIFF
--- a/pages/admin/wonderlab-review-plan.vue
+++ b/pages/admin/wonderlab-review-plan.vue
@@ -7,7 +7,7 @@
       <p class="text-xs font-black uppercase tracking-widest text-primary">
         WonderLab Editorial
       </p>
-      <h1 class="mt-2 text-3xl font-black">Personality review coverage plan</h1>
+      <p class="mt-2 text-3xl font-black">Personality review coverage plan</p>
       <p class="mt-2 max-w-4xl text-sm leading-relaxed text-base-content/60">
         Preview deterministic reviewer assignments and existing coverage before making
         any model calls. Batch generation creates proposed drafts only; it never approves

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -3,7 +3,6 @@
   "recorded": "2026-08-02",
   "violations": {
     "one-header": [
-      "pages/admin/wonderlab-review-plan.vue",
       "pages/admin/wonderlab-review-rollout.vue",
       "pages/admin/wonderlab-reviews.vue"
     ],


### PR DESCRIPTION
### Task
interface-vision/t-017: fourth scoped layout-contract sweep (kind: software)

### What changed
- Demoted the WonderLab review plan page-owned `<h1>` to a visually identical `<p>` because the application shell already owns the page heading.
- Ratcheted the `one-header` allow-list from 3 entries to 2.
- Left the two remaining admin WonderLab review pages for later bounded passes; the overall layout allow-list is not yet zero.

### How I verified
- GitHub Actions will run the Layout Contract, TypeScript, Contract Tests, and normal repository PR checks.
- The diff is limited to one semantic tag change and one shrink-only baseline deletion.

### Stakes
reversible

### Kaizen suggestion
Keep the next pass equally narrow by removing one remaining admin duplicate title and ratcheting the baseline from 2 to 1.

### Notes for reviewer
No production data, ArtJobs, routes, APIs, or publishing behavior changed.