### PR TITLE
fix(layout): remove WonderLab rollout duplicate title

### DIFF
--- a/pages/admin/wonderlab-review-rollout.vue
+++ b/pages/admin/wonderlab-review-rollout.vue
@@ -9,7 +9,7 @@
           <p class="text-xs font-black uppercase tracking-widest text-primary">
             WonderLab Operations
           </p>
-          <h1 class="mt-2 text-3xl font-black">Personality review rollout audit</h1>
+          <p class="mt-2 text-3xl font-black">Personality review rollout audit</p>
           <p class="mt-2 max-w-3xl text-sm text-base-content/60">
             Read-only production checks for migrations, author identity, draft links,
             and duplicate prevention. This page never generates, approves, or publishes.

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -3,7 +3,6 @@
   "recorded": "2026-08-02",
   "violations": {
     "one-header": [
-      "pages/admin/wonderlab-review-rollout.vue",
       "pages/admin/wonderlab-reviews.vue"
     ],
     "one-scroll": [


### PR DESCRIPTION
### Task
interface-vision/t-017: fifth scoped layout-contract sweep (kind: software)

### What changed
- Demoted the page-owned `Personality review rollout audit` heading from `<h1>` to a visually identical `<p>` because the shell owns the page title.
- Ratcheted the layout-contract `one-header` allow-list from two entries to one.

### How I verified
- Diff is limited to one semantic tag swap and one baseline deletion.
- GitHub Actions will run Layout Contract, TypeScript, Contract Tests, and the normal PR suite before merge.

### Stakes
reversible

### Flags for Reviewer
- Admin routes are deliberately last; this pass leaves only `pages/admin/wonderlab-reviews.vue` in the one-header bucket.

### Kaizen suggestion
Finish the final one-header entry, then move the recurring sweep to the largest remaining bucket (`one-scroll`).