### PR TITLE
interface-vision/t-046: extend earned-karma badges to the ArtImage gallery

### DIFF
--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -495,6 +495,7 @@
               :allow-edit="false"
               :auto-load-image="false"
               :size="viewSize"
+              :earned-karma="earnedKarmaByImageId[image.id]"
               @select="handleImageCardClick"
               @delete="handleImageDeleted"
             />
@@ -626,6 +627,7 @@ import { useArtStore } from '@/stores/artStore'
 import { useCollectionStore } from '@/stores/collectionStore'
 import { ErrorType, useErrorStore } from '@/stores/errorStore'
 import { useUserStore } from '@/stores/userStore'
+import { performFetch } from '@/stores/utils'
 
 type BatchFlagValue = 'keep' | 'true' | 'false'
 
@@ -936,6 +938,7 @@ const imagePage = ref(0)
 const folderPageSize = ref(24) // default 24
 const imagePageSize = ref(24)
 const hydratedImages = ref<Record<number, ArtImage>>({})
+const earnedKarmaByImageId = ref<Record<number, number>>({})
 const activeGroupKey = ref<string | null>(null)
 const selectedImageForOverlay = ref<ArtImage | null>(null)
 const viewSize = ref<ViewSize>('md')
@@ -1163,6 +1166,7 @@ async function refreshGallery() {
           }),
     ])
 
+    void refreshEarnedKarma()
     await hydrateVisibleImages()
     successMessage.value = 'Gallery refreshed.'
   } catch (error) {
@@ -1235,6 +1239,7 @@ watch(
     showMature.value,
   ],
   async () => {
+    void refreshEarnedKarma()
     await hydrateVisibleImages()
   },
 )
@@ -1271,6 +1276,7 @@ async function initializeGallery() {
       await fetchArtImagesSafely()
     }
 
+    void refreshEarnedKarma()
     await hydrateVisibleImages()
   } catch (error) {
     const message = getErrorMessage(error, 'Gallery failed to initialize.')
@@ -1481,6 +1487,40 @@ function clearSelectedImage() {
   selectedImageForOverlay.value = null
   if (typeof artStore.deselectArtImage === 'function')
     artStore.deselectArtImage()
+}
+
+// interface-vision/t-046: batch-fetch earned karma for the current visible
+// page only (not the whole gallery), same "fetch on the rendered page, not
+// every filter keystroke" scoping as hydrateVisibleImages -- see
+// components/rewards/reward-gallery.vue for the reference wiring this
+// mirrors and server/api/economy/karma-earned.post.ts for the endpoint.
+async function refreshEarnedKarma() {
+  const ids = pagedActiveImages.value.map((image) => image.id)
+
+  if (!ids.length) {
+    earnedKarmaByImageId.value = {}
+    return
+  }
+
+  const res = await performFetch<
+    Array<{ refType: string; refId: string; earnedKarma: number }>
+  >('/api/economy/karma-earned', {
+    method: 'POST',
+    body: JSON.stringify({
+      items: ids.map((id) => ({ refType: 'artImage', refId: id })),
+    }),
+  })
+
+  if (!res.success || !Array.isArray(res.data)) return
+
+  const next: Record<number, number> = {}
+
+  for (const row of res.data) {
+    const id = Number(row.refId)
+    if (Number.isFinite(id)) next[id] = row.earnedKarma
+  }
+
+  earnedKarmaByImageId.value = next
 }
 
 async function hydrateVisibleImages() {

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -8,6 +8,7 @@
     target-type="artImage"
     reaction-category="ART"
     :target-title="cardTitle"
+    :earned-karma="earnedKarma"
     @select="selectImage"
   >
     <template #actions>
@@ -338,6 +339,10 @@ const props = withDefaults(
     allowColoringPage?: boolean
     autoLoadImage?: boolean
     fallbackImage?: string
+    /** Total karma this image has earned from reactions/creation (see
+     *  server/api/economy/karma-earned.post.ts). Omit/undefined renders no
+     *  badge — see components/wonderlab/reactable-card.vue. */
+    earnedKarma?: number | null
   }>(),
   {
     selected: false,
@@ -359,6 +364,7 @@ const props = withDefaults(
     allowColoringPage: true,
     autoLoadImage: true,
     fallbackImage: '/images/backtree.webp',
+    earnedKarma: undefined,
   },
 )
 


### PR DESCRIPTION
### Task
interface-vision/t-046: Extend earned-karma card badges to the remaining reactable-card consumers (kind: software)

### What changed / what I produced
- `components/art/image-card.vue`: added an `earnedKarma?: number | null` prop, forwarded to `reactable-card`'s existing `earned-karma` prop (same contract `reward-card.vue` already uses — omit/undefined renders no badge).
- `components/art/art-gallery.vue`: added `earnedKarmaByImageId` state and a `refreshEarnedKarma()` function that batch-POSTs the currently *paged/visible* image ids to `/api/economy/karma-earned` with `refType: 'artImage'`, mirroring `reward-gallery.vue`'s reference wiring from t-019. Wired into the same three places the gallery already refreshes its visible page (`initializeGallery`, `refreshGallery`, and the watcher on `activeGroupKey`/`imagePage`/`imagePageSize`/`searchQuery`/`showMature`), and passed the resolved value into `image-card`'s new `earned-karma` prop.

ArtImage was picked as the next consumer (over the other 10) because its award call sites are already tagged: `REACTION_RECEIVED` tags `refType: 'artImage'` generically for any reacted-on image (via `server/api/reactions/index.post.ts`'s target-field-derived refType), and `CONTENT_CREATED_PUBLIC` explicitly tags `refType: 'artImage'` in `server/api/prompts/generate.post.ts`. So this gallery will show real, non-zero earned totals immediately rather than an always-empty badge. It's also the single largest/highest-traffic gallery component in the app (1600+ lines, the core art-generation surface).

### How I verified
- `npm run test` (vue-tsc `--noEmit`) — clean, no new errors.
- `npx eslint components/art/art-gallery.vue components/art/image-card.vue` — 2 pre-existing `no-dynamic-delete` errors at unrelated lines (860/1563 on `main`, confirmed via `git stash` + re-lint before my changes); nothing new introduced.
- `npm run test:layout-contract` — holds, no new violations (unaffected by this change).
- Read `server/api/economy/karma-earned.post.ts` and `server/api/reactions/index.post.ts` to confirm `artImage` is both in `ALLOWED_REF_TYPES` and actually gets tagged by real award call sites before wiring it (the task note explicitly calls this out as a required check).

### Stakes
reversible

### Flags for Reviewer
- The batch fetch is scoped to the current *paged* image set (same page size the gallery already renders, e.g. 24), not the full unfiltered gallery — matches the existing `hydrateVisibleImages` scoping precedent in the same file, so it doesn't add an unbounded fetch.
- Left the other 10 reactable-card consumers (Dream, Character, Bot, Scenario, Theme, Component, Chat, and the 3 `resource`-typed ones — checkpoint/model/lora) unwired, per the task note's "one at a time" instruction. Dream gallery is the next natural pick per the note if the Reviewer wants a scoping recommendation.

### Kaizen suggestion
Wire the same pattern into `components/dreams/dream-gallery.vue` / whatever its card component is next — Dream is the other gallery the task note explicitly named as a plausible next step, and dreams already get awarded karma via reactions the same way ArtImage does.

### Notes for reviewer
Conductor task interface-vision/t-046, set to `status: review` before opening this PR (conductor commit `1a909a8`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012QwTLWDN2ZEvDuyMe1EQxq)_