### PR TITLE
Extract the shared conversation kit: chat window, choice list, art plate

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -113,6 +113,9 @@ jobs:
       - name: CHILD maturity restriction contract
         run: npm run test:child-maturity
 
+      - name: Narrative conversation kit contract
+        run: npm run test:narrative-kit
+
       - name: Unquoted reserved-word table identifier contract
         run: npm run test:no-unquoted-reserved-word-tables
 

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -1,0 +1,132 @@
+<!-- /components/narrative/kr-art-plate.vue -->
+<!--
+  The framed image plate — "a plate tipped into warm paper", the gesture the
+  whole Storybook aesthetic is named for.
+
+  Extracted because five interact surfaces each hand-rolled an <img> with their
+  own aspect box, their own gradient scrim and their own fallback chain. The
+  fallback chain in particular is worth centralising: cardPath/heroPath/iconPath
+  shipped in t-007 and sat invisible for a day precisely because each surface
+  had its own idea of which field to read.
+
+  Uses resolveArtVariantSrc (utils/artImageSrc.ts) rather than re-implementing
+  that chain. Pass an entity (Bot, Character, Reward, Scenario, Dream…) and the
+  variant you want; it degrades variant path -> variant base64 -> full-size ->
+  fallback, so a slot the render queue has not reached yet still shows something.
+-->
+<template>
+  <figure
+    :class="[
+      'relative overflow-hidden bg-base-300',
+      framed
+        ? 'rounded-2xl border-[6px] border-base-100 shadow-[0_18px_44px_-18px_rgba(58,49,40,0.5)]'
+        : 'rounded-2xl border border-base-300',
+      aspectClass,
+    ]"
+  >
+    <img
+      v-if="src"
+      :src="src"
+      :alt="alt"
+      class="h-full w-full object-cover"
+      :loading="eager ? 'eager' : 'lazy'"
+      @error="onError"
+    />
+
+    <div
+      v-else
+      class="flex h-full w-full items-center justify-center text-base-content/40"
+    >
+      <Icon :name="placeholderIcon" class="size-8" aria-hidden="true" />
+    </div>
+
+    <!-- Scrim only when there is a caption to keep legible. An unconditional
+         gradient dims art that has nothing sitting on top of it. -->
+    <div
+      v-if="$slots.caption"
+      class="absolute inset-x-0 bottom-0 bg-linear-to-t from-black/85 via-black/45 to-transparent px-3 pb-3 pt-12"
+    >
+      <figcaption>
+        <slot name="caption" />
+      </figcaption>
+    </div>
+
+    <slot name="overlay" />
+  </figure>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import {
+  resolveArtVariantSrc,
+  type ArtVariant,
+  type ArtImageSrcLike,
+} from '@/utils/artImageSrc'
+
+const props = withDefaults(
+  defineProps<{
+    /** Any record carrying imagePath / cardPath / heroPath / iconPath. */
+    source?: ArtImageSrcLike
+    variant?: ArtVariant
+    /** Used when the source resolves to nothing at all. */
+    fallback?: string
+    alt?: string
+    /** card is 2:3 portrait, hero 16:9, icon square, plate the 3:2 mockup shape. */
+    shape?: 'card' | 'hero' | 'icon' | 'plate' | 'fill'
+    /** The white "tipped photo" border. Off for inline thumbnails. */
+    framed?: boolean
+    eager?: boolean
+    placeholderIcon?: string
+  }>(),
+  {
+    source: null,
+    variant: 'card',
+    fallback: '',
+    alt: '',
+    shape: 'plate',
+    framed: true,
+    eager: false,
+    placeholderIcon: 'kind-icon:image',
+  },
+)
+
+// A broken URL should fall back rather than leave a dead frame. Reset whenever
+// the source changes, or one bad image would poison every later one.
+const failed = ref(false)
+watch(
+  () => [props.source, props.variant, props.fallback],
+  () => {
+    failed.value = false
+  },
+)
+
+function onError(): void {
+  failed.value = true
+}
+
+const src = computed(() => {
+  const resolved = resolveArtVariantSrc(
+    props.source,
+    props.variant,
+    props.fallback,
+  )
+  if (!failed.value) return resolved
+  // Only fall back if the fallback is not itself the thing that just failed.
+  return resolved === props.fallback ? '' : props.fallback
+})
+
+const aspectClass = computed(() => {
+  switch (props.shape) {
+    case 'card':
+      return 'aspect-2/3 w-full'
+    case 'hero':
+      return 'aspect-video w-full'
+    case 'icon':
+      return 'aspect-square'
+    case 'fill':
+      return 'h-full w-full'
+    default:
+      return 'aspect-3/2 w-full'
+  }
+})
+</script>

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -1,0 +1,205 @@
+<!-- /components/narrative/kr-chat-window.vue -->
+<!--
+  The scrolling message list, shared by every conversational surface.
+
+  Two implementations of this existed: narrative-transcript.vue (Storymaker,
+  Taskmaster) and workspace-narrator.vue's `seededMessages` loop (Dreams). They
+  disagreed on everything cosmetic and agreed on the substance — a list of
+  turns, a speaker, an optional portrait, an optional set of follow-up choices,
+  and a streaming placeholder while the model is still writing.
+
+  SCROLL OWNERSHIP (interface-vision t-003/t-004): this component owns exactly
+  ONE scroll region and nothing inside it scrolls. That is why the layout
+  contract's `one-scroll` count should fall as surfaces adopt it — the surfaces
+  it replaces each declared several. Give it a bounded height from the parent;
+  it will not grow the page.
+
+  Purely presentational. Streaming state, sending and choice handling all belong
+  to the caller, so this drops into a narrator stage, a slide-out dock, or a bot
+  chat without dragging a store with it.
+-->
+<template>
+  <div
+    ref="scrollEl"
+    class="kr-scroll flex flex-col gap-4"
+    :aria-label="label"
+    :aria-busy="isStreaming"
+    role="log"
+  >
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {{ statusAnnouncement }}
+    </p>
+
+    <div
+      v-if="!turns.length && !isStreaming"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
+    >
+      {{ emptyLabel }}
+    </div>
+
+    <article
+      v-for="(turn, index) in turns"
+      :key="turn.id"
+      :class="['flex gap-2', turn.from === 'user' ? 'flex-row-reverse' : '']"
+      :aria-labelledby="turnHeadingId(index)"
+    >
+      <h3 :id="turnHeadingId(index)" class="sr-only">
+        {{ turn.from === 'user' ? 'Your response' : `Scene ${index + 1}` }}
+      </h3>
+
+      <img
+        v-if="turn.portrait && turn.from !== 'user'"
+        :src="turn.portrait"
+        :alt="turn.speaker || 'Narrator'"
+        class="size-8 shrink-0 rounded-full border border-base-300 bg-base-300 object-cover"
+        loading="lazy"
+      />
+
+      <div
+        :class="[
+          'min-w-0 max-w-[92%] rounded-2xl px-4 py-3 text-sm leading-relaxed',
+          turn.from === 'user'
+            ? 'rounded-br-sm border border-secondary/30 bg-secondary/10'
+            : 'rounded-bl-sm border border-base-300 bg-base-100 shadow-sm',
+        ]"
+      >
+        <p
+          v-if="turn.speaker && turn.from !== 'user'"
+          class="text-[0.65rem] font-black uppercase tracking-wide text-primary/70"
+        >
+          {{ turn.speaker }}
+        </p>
+
+        <p
+          :class="[
+            'whitespace-pre-wrap text-base-content/85',
+            turn.speaker && turn.from !== 'user' ? 'mt-1' : '',
+            prose ? 'kr-prose' : '',
+          ]"
+        >
+          {{ turn.text }}
+        </p>
+
+        <kr-choice-list
+          v-if="turn.choices?.length"
+          class="mt-3"
+          layout="row"
+          :choices="turn.choices"
+          :disabled="isStreaming"
+          :show-index="false"
+          @select="emit('choose', $event, turn)"
+        />
+
+        <slot name="after-turn" :turn="turn" :index="index" />
+      </div>
+    </article>
+
+    <div
+      v-if="isStreaming"
+      class="whitespace-pre-wrap rounded-2xl rounded-bl-sm border border-dashed border-secondary/40 bg-base-200/40 px-4 py-3 text-sm leading-relaxed"
+      aria-hidden="true"
+    >
+      <template v-if="visibleStreamingText">{{ visibleStreamingText }}</template>
+      <span v-else class="flex items-center gap-2 text-base-content/60">
+        <span
+          class="loading loading-dots loading-sm motion-reduce:hidden"
+          aria-hidden="true"
+        />
+        {{ streamingLabel }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, useId, watch } from 'vue'
+import type { NarrativeChoice } from './kr-choice-list.vue'
+
+export type NarrativeTurn = {
+  id: string
+  text: string
+  /** 'narrator' renders left with a portrait; 'user' renders right. */
+  from?: 'narrator' | 'user'
+  speaker?: string
+  portrait?: string | null
+  choices?: NarrativeChoice[]
+}
+
+const props = withDefaults(
+  defineProps<{
+    turns: NarrativeTurn[]
+    isStreaming?: boolean
+    streamingText?: string
+    streamingLabel?: string
+    emptyLabel?: string
+    label?: string
+    /** Apply the 65ch reading measure. On for narration, off for chat chatter. */
+    prose?: boolean
+    autoScroll?: boolean
+  }>(),
+  {
+    isStreaming: false,
+    streamingText: '',
+    streamingLabel: 'The narrator is building the next scene…',
+    emptyLabel: 'The story will appear here once it begins.',
+    label: 'Conversation',
+    prose: true,
+    autoScroll: true,
+  },
+)
+
+const emit = defineEmits<{
+  choose: [choice: NarrativeChoice, turn: NarrativeTurn]
+}>()
+
+const windowId = useId()
+const scrollEl = ref<HTMLElement | null>(null)
+
+/*
+ * Hide the machine-readable state block while it is still arriving.
+ *
+ * Carried over from narrative-transcript.vue: the model emits a [STORY_STATE]
+ * marker after the prose, and mid-stream the reader would otherwise watch a
+ * half-typed `[STORY_ST` appear and disappear. Also trims a partial line that
+ * is a prefix of the marker, which is the case the naive indexOf misses.
+ */
+const visibleStreamingText = computed(() => {
+  const text = props.streamingText
+  const marker = '[STORY_STATE]'
+  const markerIndex = text.indexOf(marker)
+  if (markerIndex >= 0) return text.slice(0, markerIndex).trimEnd()
+
+  const lastLineBreak = text.lastIndexOf('\n')
+  const partialLine = text.slice(lastLineBreak + 1).trim()
+  if (partialLine.startsWith('[') && marker.startsWith(partialLine)) {
+    return text.slice(0, Math.max(0, lastLineBreak)).trimEnd()
+  }
+  return text
+})
+
+const statusAnnouncement = computed(() => {
+  if (props.isStreaming) return props.streamingLabel
+  if (props.turns.length) {
+    return `${props.turns.length} message${
+      props.turns.length === 1 ? '' : 's'
+    }. Continue to the response field when you are ready.`
+  }
+  return props.emptyLabel
+})
+
+function turnHeadingId(index: number): string {
+  return `${windowId}-turn-${index + 1}`
+}
+
+// Follow the conversation as it grows. Guarded on autoScroll so a surface that
+// wants the reader to stay put (reviewing an old scene) can opt out.
+watch(
+  () => [props.turns.length, props.streamingText],
+  async () => {
+    if (!props.autoScroll) return
+    await nextTick()
+    const el = scrollEl.value
+    if (el) el.scrollTop = el.scrollHeight
+  },
+)
+</script>

--- a/components/narrative/kr-choice-list.vue
+++ b/components/narrative/kr-choice-list.vue
@@ -1,0 +1,112 @@
+<!-- /components/narrative/kr-choice-list.vue -->
+<!--
+  One pick-one list, shared by every conversational surface.
+
+  Silas, 2026-08-02: "a lot of these are just going to be variations of each
+  other, so the more we can work on modular pieces for things like chat windows,
+  multiple choice returns, and image presentations, the better."
+
+  This replaces at least three separate implementations of the same idea:
+  kr-narrator-stage's quick-topic buttons, workspace-narrator's per-message
+  `followups` row, and the scenarios choice-* trio. They differed in styling and
+  in nothing else that mattered.
+
+  Purely presentational — it owns no store and no fetch, so it drops into a
+  narrator stage, a chat bubble, or a scenario editor without dragging state
+  along. All colour comes from daisyUI semantic tokens, so it inherits whichever
+  reading mode the surrounding subtree declares (see useStorymakerMode) with no
+  per-mode branching here.
+-->
+<template>
+  <div
+    v-if="choices.length"
+    :class="[
+      'flex gap-2',
+      layout === 'stack' ? 'flex-col' : 'flex-wrap items-center',
+    ]"
+    role="group"
+    :aria-label="label"
+  >
+    <p v-if="heading" class="w-full text-sm font-bold text-base-content/70">
+      {{ heading }}
+    </p>
+
+    <button
+      v-for="(choice, index) in choices"
+      :key="choice.key"
+      type="button"
+      :class="[
+        'flex items-center gap-3 rounded-xl border-2 border-base-300 bg-base-100 text-left transition',
+        'hover:-translate-y-0.5 hover:border-primary/50',
+        'disabled:pointer-events-none disabled:opacity-50',
+        layout === 'stack' ? 'w-full px-4 py-3' : 'px-3 py-2',
+        selectedKey === choice.key ? 'border-primary ring-2 ring-primary/30' : '',
+      ]"
+      :disabled="disabled || choice.disabled"
+      :aria-pressed="selectedKey === choice.key"
+      @click="emit('select', choice)"
+    >
+      <!-- The index badge is the storybook gesture: a numbered choice reads as
+           a page you turn to, not a form control. Hidden in row layout, where
+           the buttons sit inline as quick topics. -->
+      <span
+        v-if="layout === 'stack' && showIndex"
+        class="grid size-7 shrink-0 place-items-center rounded-full bg-primary/12 text-sm font-bold text-primary"
+        aria-hidden="true"
+      >
+        {{ index + 1 }}
+      </span>
+
+      <Icon
+        v-else-if="choice.icon"
+        :name="choice.icon"
+        class="size-4 shrink-0 text-primary"
+      />
+
+      <span class="min-w-0">
+        <span class="block text-sm font-semibold text-base-content">
+          {{ choice.label }}
+        </span>
+        <span
+          v-if="choice.hint"
+          class="mt-0.5 block text-sm italic text-base-content/55"
+        >
+          {{ choice.hint }}
+        </span>
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+export type NarrativeChoice = {
+  key: string
+  label: string
+  hint?: string
+  icon?: string
+  disabled?: boolean
+}
+
+withDefaults(
+  defineProps<{
+    choices: NarrativeChoice[]
+    /** 'stack' for a narration's numbered options, 'row' for inline quick topics. */
+    layout?: 'stack' | 'row'
+    heading?: string
+    selectedKey?: string | null
+    disabled?: boolean
+    showIndex?: boolean
+    label?: string
+  }>(),
+  {
+    layout: 'stack',
+    heading: '',
+    selectedKey: null,
+    disabled: false,
+    showIndex: true,
+    label: 'Choices',
+  },
+)
+
+const emit = defineEmits<{ select: [choice: NarrativeChoice] }>()
+</script>

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -63,17 +63,19 @@
     </div>
 
     <div class="kr-toolbar flex-wrap gap-2 border-t border-primary/10 pt-3">
-      <button
-        v-for="topic in topicButtons"
-        :key="topic.key"
-        type="button"
-        class="btn btn-outline btn-xs rounded-2xl"
+      <!-- The quick topics were the seed for kr-choice-list: the same
+           pick-one-from-a-few idea that workspace-narrator and the scenarios
+           choice-* trio each re-implemented. Adopting it here puts the shared
+           component in Storymaker's and Taskmaster's real render path at once,
+           since both mount this stage. -->
+      <kr-choice-list
+        layout="row"
+        :choices="topicChoices"
         :disabled="isNarratorResponding"
-        @click="selectTopic(topic)"
-      >
-        <Icon :name="topic.icon" class="h-3.5 w-3.5" />
-        {{ topic.title }}
-      </button>
+        :show-index="false"
+        label="Narrator topics"
+        @select="selectTopicByKey"
+      />
 
       <div class="flex min-w-0 flex-1 items-center gap-2">
         <input
@@ -139,6 +141,7 @@ const narrationText = computed(() => {
   return lastReply || narratorIntro.value
 })
 
+
 const topicButtons = computed(() => {
   return narratorThreads.value.slice(0, 4).map((thread) => {
     const topic = thread.Topic
@@ -150,6 +153,24 @@ const topicButtons = computed(() => {
     }
   })
 })
+
+/*
+ * kr-choice-list speaks {key,label,hint,icon}; the narrator's threads speak
+ * {key,title,icon}. Adapt here rather than reshaping narratorStore, so the
+ * shared component never has to learn a store's vocabulary.
+ */
+const topicChoices = computed(() =>
+  topicButtons.value.map((topic) => ({
+    key: topic.key,
+    label: topic.title,
+    icon: topic.icon,
+  })),
+)
+
+function selectTopicByKey(choice: { key: string }): void {
+  const topic = topicButtons.value.find((entry) => entry.key === choice.key)
+  if (topic) selectTopic(topic)
+}
 
 function selectTopic(topic: { prompt: string }): void {
   if (topic.prompt) {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "test:admin-flag-casts": "tsx utils/scripts/verifyAdminFlagCasts.ts",
     "test:user-role-expand": "tsx utils/scripts/verifyUserRoleExpand.ts",
     "test:user-role-predicates": "tsx utils/scripts/verifyUserRolePredicates.ts",
+    "test:narrative-kit": "tsx utils/scripts/verifyNarrativeKit.ts",
     "test:child-maturity": "tsx utils/scripts/verifyChildMaturityRestriction.ts",
     "test:no-unquoted-reserved-word-tables": "tsx utils/scripts/verifyNoUnquotedReservedWordTables.ts",
     "test:fetch-generic-pinning": "tsx utils/scripts/verifyFetchGenericPinning.ts",

--- a/utils/scripts/verifyNarrativeKit.ts
+++ b/utils/scripts/verifyNarrativeKit.ts
@@ -1,0 +1,183 @@
+// /utils/scripts/verifyNarrativeKit.ts
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Contract for the shared conversation kit (interface-vision, 2026-08-02).
+//
+// Silas: "a lot of these are just going to be variations of each other, so the
+// more we can work on modular pieces for things like chat windows, multiple
+// choice returns, and image presentations, the better."
+//
+// The kit already failed once by being ignored. components/narrative/ has
+// existed for a while and was adopted by exactly TWO of seven conversational
+// surfaces; meanwhile workspace-narrator.vue grew its own 1,477-line copy of
+// the same three ideas. Shared components do not stay shared on their own.
+//
+// So this pins the properties that make the kit worth adopting, and — as
+// surfaces migrate — the fact that they stay migrated. It is a source-text
+// contract, so it needs no DOM and no database and can gate every PR.
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const root = resolve(scriptDirectory, '../..')
+
+let failures = 0
+
+function check(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`ok - ${message}`)
+    return
+  }
+  failures += 1
+  console.error(`FAIL - ${message}`)
+}
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(root, relativePath), 'utf8')
+}
+
+const CHAT = 'components/narrative/kr-chat-window.vue'
+const CHOICE = 'components/narrative/kr-choice-list.vue'
+const PLATE = 'components/narrative/kr-art-plate.vue'
+
+const chat = read(CHAT)
+const choice = read(CHOICE)
+const plate = read(PLATE)
+
+// --- one scroll owner --------------------------------------------------------
+// The layout contract counts components declaring more than one scroll region.
+// The chat window exists partly to REMOVE those, so it must not add one: every
+// surface that adopts it should shed scroll regions, never gain them.
+const scrollRegions = (chat.match(/kr-scroll|overflow-y-auto|overflow-auto/g) ?? [])
+  .length
+check(
+  scrollRegions === 1,
+  `the chat window declares exactly one scroll region (found ${scrollRegions})`,
+)
+check(
+  /ref="scrollEl"/.test(chat) && /scrollHeight/.test(chat),
+  'the chat window follows the conversation as it grows',
+)
+check(
+  /autoScroll/.test(chat),
+  'auto-scroll is opt-out, so a reader reviewing an earlier scene can stay put',
+)
+
+// --- no store coupling -------------------------------------------------------
+// The kit is presentational. The moment one of these imports a store it stops
+// being droppable into a bot chat, a dock and a scenario editor alike, which is
+// the entire reason for extracting them.
+for (const [path, source] of [
+  [CHAT, chat],
+  [CHOICE, choice],
+  [PLATE, plate],
+] as const) {
+  check(
+    !/from '@\/stores\//.test(source) && !/useNarratorStore|storeToRefs/.test(source),
+    `${path.split('/').pop()} imports no store (stays droppable anywhere)`,
+  )
+}
+
+// --- the art plate must not re-roll the fallback chain -----------------------
+// cardPath/heroPath/iconPath shipped in t-007 and stayed invisible for a day
+// because every surface had its own idea of which field to read. One resolver.
+check(
+  /resolveArtVariantSrc/.test(plate),
+  'the art plate resolves through resolveArtVariantSrc rather than its own chain',
+)
+check(
+  !/\.cardPath|\.heroPath|\.iconPath/.test(plate),
+  'the art plate reads no variant field directly (that is the resolver\'s job)',
+)
+
+// --- theme-agnostic ----------------------------------------------------------
+// All three must inherit whatever reading mode their subtree declares. A
+// hardcoded colour would survive a theme switch and break Classic mode, which
+// exists precisely to defer to the reader's own theme.
+const HEX = /#[0-9a-fA-F]{6}\b/
+for (const [path, source] of [
+  [CHAT, chat],
+  [CHOICE, choice],
+  [PLATE, plate],
+] as const) {
+  // The plate's ink-tinted drop shadow is an rgba() on purpose; only flat hex
+  // palette values are the problem.
+  check(
+    !HEX.test(source.replace(/rgba\([^)]*\)/g, '')),
+    `${path.split('/').pop()} hardcodes no palette hex (inherits the active theme)`,
+  )
+}
+
+// --- adoption ratchet --------------------------------------------------------
+// Purely informational today, and deliberately so: failing on non-adoption
+// before the surfaces have migrated would just block every unrelated PR. The
+// count is printed so the next phase can see the needle move, and so a
+// REGRESSION (a surface dropping back to a hand-rolled loop) is visible in CI
+// output rather than silent.
+const SURFACES = [
+  'components/conductor/storymaker-page.vue',
+  'components/pages/taskmaster-page.vue',
+  'components/bots/bot-interact.vue',
+  'components/rewards/reward-interact.vue',
+  'components/characters/character-interact.vue',
+  'components/scenarios/scenario-interact.vue',
+  'components/dreams/dream-interact.vue',
+]
+const existing = SURFACES.filter((path) => {
+  try {
+    readFileSync(resolve(root, path))
+    return true
+  } catch {
+    return false
+  }
+})
+const KIT_USE =
+  /kr-chat-window|KrChatWindow|kr-choice-list|KrChoiceList|kr-art-plate|KrArtPlate/
+
+/*
+ * Count TRANSITIVE adoption, one level deep.
+ *
+ * Storymaker and Taskmaster reach the kit through kr-narrator-stage rather than
+ * mounting it themselves, and a counter that missed that would report 0/7 while
+ * the components were demonstrably live in both render paths -- understating
+ * progress and, worse, hiding a regression if the stage stopped using them.
+ */
+const INTERMEDIARIES = ['components/narrative/kr-narrator-stage.vue']
+const liveIntermediaries = INTERMEDIARIES.filter((path) => KIT_USE.test(read(path)))
+
+function adopts(path: string): boolean {
+  const source = read(path)
+  if (KIT_USE.test(source)) return true
+  return liveIntermediaries.some((intermediary) => {
+    const name = intermediary.split('/').pop()?.replace('.vue', '') ?? ''
+    const pascal = name.replace(/(^|-)([a-z])/g, (_, __, c) => c.toUpperCase())
+    return new RegExp(`${name}|${pascal}|Lazy${pascal}`).test(source)
+  })
+}
+
+const adopters = existing.filter(adopts)
+console.log(
+  `\ninfo - conversation kit adopted by ${adopters.length}/${existing.length} surface(s) ` +
+    `(directly or via ${liveIntermediaries.length} shared stage)`,
+)
+for (const path of existing) {
+  console.log(
+    `       ${adopters.includes(path) ? '✓' : '·'} ${path.split('/').pop()}`,
+  )
+}
+
+// The kit lives in one directory; a fourth piece landing elsewhere is how a
+// shared kit quietly becomes two.
+const kitFiles = readdirSync(resolve(root, 'components/narrative'))
+check(
+  kitFiles.includes('kr-chat-window.vue') &&
+    kitFiles.includes('kr-choice-list.vue') &&
+    kitFiles.includes('kr-art-plate.vue'),
+  'all three shared pieces live together in components/narrative/',
+)
+
+if (failures) {
+  console.error(`\nNarrative kit contract failed with ${failures} error(s).`)
+  process.exitCode = 1
+} else {
+  console.log('\nNarrative kit contract passed: all checks behaved as expected.')
+}


### PR DESCRIPTION
## Why

> *"a lot of these are just going to be variations of each other, so the more we can work on modular pieces for things like chat windows, multiple choice returns, and image presentations, the better."*
> — Silas, 2026-08-02

Groundwork for giving every LLM surface the deluxe treatment **without doing it seven times.**

### What the survey found

`components/narrative/` already existed — 7 components, 1,079 lines — and was adopted by **exactly two of seven** conversational surfaces. Meanwhile `workspace-narrator.vue` grew its own **1,477-line** copy of the same three ideas for Dreams.

| Surface | Lines | On the kit? |
|---|---|---|
| storymaker-page | 784 | yes |
| taskmaster-page | 741 | yes |
| bot-interact | 782 | no |
| reward-interact | 1,183 | no |
| character-interact | 945 | no |
| scenario-interact | 632 | no |
| dream-interact | 56 | no — delegates to the 1,477-line second narrator |

Shared components don't stay shared on their own. That's the problem this PR is designed around.

## The three pieces

None imports a store, so each drops into a narrator stage, a slide-out dock or a bot chat alike.

| Component | Absorbs | Note |
|---|---|---|
| **`kr-chat-window`** | `narrative-transcript` + workspace-narrator's `seededMessages` loop | Declares **exactly one** scroll region — adopting it should make the layout contract's `one-scroll` count *fall*. Keeps the `[STORY_STATE]` mid-stream trimming, including the partial-line case a naive `indexOf` misses. |
| **`kr-choice-list`** | narrator quick-topics + workspace-narrator `followups` + the scenarios `choice-*` trio | Three implementations of pick-one, collapsed. |
| **`kr-art-plate`** | the `<img>` blocks duplicated across five interact files | Resolves through `resolveArtVariantSrc` rather than its own chain — `cardPath`/`heroPath`/`iconPath` shipped in t-007 and stayed **invisible for a day** precisely because each surface had its own idea of which field to read. |

All three take colour from daisyUI semantic tokens only, so they inherit whichever reading mode their subtree declares with no per-mode branching.

## Adopted immediately, on purpose

`kr-choice-list` is wired into `kr-narrator-stage` in this PR rather than shipping three components with no consumers — *that is exactly how the existing kit ended up at 2/7*. Because both Storymaker and Taskmaster mount that stage, this puts the shared component into two real render paths with no data reshaping (the narrator's `{key,title,icon}` maps 1:1, adapted at the call site so the shared component never learns a store's vocabulary).

I deliberately did **not** force `kr-chat-window` into Storymaker yet: a `beat` is a *paired* turn (narrative + answer), so mapping it to the flat `turns` shape is a real transformation and changes the `after-beat` slot's meaning. Not worth risking a working surface to move a counter — that's Phase 3.

## The contract

`verifyNarrativeKit.ts` pins what makes the kit worth adopting: one scroll owner, no store imports, no hardcoded palette hex, and the art plate deferring to the resolver.

It also **prints adoption** — `2/7` today, counted **transitively** through the shared stage — so later phases can see the needle move and a regression shows up in CI output rather than silently. Informational rather than failing: failing on non-adoption before the migration would block every unrelated PR.

## Correction to the plan

**`narrative-ingredient-card.vue` is NOT unused** — both ingredient pickers mount it. My earlier grep excluded `components/narrative/`, which hid its real callers; deleting it as planned would have broken both pickers. Not deleted.

`narrator-chat.vue`, the genuine orphan, turned out to have already been removed by t-018 in #1298.

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean.
- **An actual `nuxi build`** — client compiles. (Its prerender step fails on a missing `JWT_SECRET`, a sandbox env limitation, not the change.)
- `test:layout-contract` holds, no new violations — the new chat window adds none.
- `test:narrative-kit` — 12 assertions pass.
- Confirmed `aspect-2/3` / `aspect-3/2` are already in use elsewhere in the repo before relying on them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_