### PR TITLE
Rename Storymaker to Storybook, route and data included

### DIFF
--- a/.github/workflows/narrative-art-milestone-contract.yml
+++ b/.github/workflows/narrative-art-milestone-contract.yml
@@ -39,7 +39,7 @@ jobs:
           const fs = require('node:fs')
           const plugin = fs.readFileSync('plugins/narrative-milestone-art.client.ts', 'utf8')
           for (const token of [
-            'selectStorymakerArtMilestone',
+            'selectStorybookArtMilestone',
             'selectTaskmasterArtMilestone',
             'seenStoryBeats',
             'seenTaskBeats',

--- a/.github/workflows/serendipity-route-contract.yml
+++ b/.github/workflows/serendipity-route-contract.yml
@@ -10,7 +10,7 @@ on:
       - 'components/pages/serendipity-page.vue'
       - 'components/conductor/voice-lab-page.vue'
       - 'stores/helpers/dashboardHelper.ts'
-      - 'docs/products/storymaker-taskmaster-boundary.md'
+      - 'docs/products/storybook-taskmaster-boundary.md'
       - 'docs/contracts/serendipity-route-contract.md'
       - 'utils/scripts/verifySerendipityRouteCutover.mjs'
   pull_request:
@@ -22,7 +22,7 @@ on:
       - 'components/pages/serendipity-page.vue'
       - 'components/conductor/voice-lab-page.vue'
       - 'stores/helpers/dashboardHelper.ts'
-      - 'docs/products/storymaker-taskmaster-boundary.md'
+      - 'docs/products/storybook-taskmaster-boundary.md'
       - 'docs/contracts/serendipity-route-contract.md'
       - 'utils/scripts/verifySerendipityRouteCutover.mjs'
   workflow_dispatch:

--- a/.github/workflows/storybook-branch-state-contract.yml
+++ b/.github/workflows/storybook-branch-state-contract.yml
@@ -1,4 +1,4 @@
-name: Storymaker Session Library Contract
+name: Storybook Branch State Contract
 
 on:
   push:
@@ -8,12 +8,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: storymaker-session-library-${{ github.ref }}
+  group: storybook-branch-state-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   verify:
-    name: Storymaker session library contract
+    name: Storybook fictional state contract
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -26,5 +26,5 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Verify Storymaker session library
-        run: node utils/scripts/verifyStorymakerSessionLibrary.mjs
+      - name: Verify Storybook branch state
+        run: node utils/scripts/verifyStorybookBranchState.mjs

--- a/.github/workflows/storybook-session-library-contract.yml
+++ b/.github/workflows/storybook-session-library-contract.yml
@@ -1,4 +1,4 @@
-name: Storymaker Branch State Contract
+name: Storybook Session Library Contract
 
 on:
   push:
@@ -8,12 +8,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: storymaker-branch-state-${{ github.ref }}
+  group: storybook-session-library-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   verify:
-    name: Storymaker fictional state contract
+    name: Storybook session library contract
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -26,5 +26,5 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Verify Storymaker branch state
-        run: node utils/scripts/verifyStorymakerBranchState.mjs
+      - name: Verify Storybook session library
+        run: node utils/scripts/verifyStorybookSessionLibrary.mjs

--- a/.github/workflows/storybook-studio-contract.yml
+++ b/.github/workflows/storybook-studio-contract.yml
@@ -1,4 +1,4 @@
-name: Storymaker Studio Contract
+name: Storybook Studio Contract
 
 on:
   push:
@@ -8,12 +8,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: storymaker-studio-${{ github.ref }}
+  group: storybook-studio-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   verify:
-    name: Dedicated Storymaker studio contract
+    name: Dedicated Storybook studio contract
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -26,5 +26,5 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Verify Storymaker studio
-        run: node utils/scripts/verifyStorymakerStudio.mjs
+      - name: Verify Storybook studio
+        run: node utils/scripts/verifyStorybookStudio.mjs

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -5,18 +5,17 @@
 }
 
 /*
- * ── STORYMAKER — the house aesthetic (interface-vision t-002) ───────────
+ * ── STORYBOOK — the house aesthetic (interface-vision t-002) ───────────
  *
- * Silas, 2026-08-02: "Let's run with Storybook as the design." Then, refining:
- * "the story maker should let the user pick from all three, but I would call
- * them Classic (daisy ui defaults), story maker, and story maker-dark."
+ * Silas, 2026-08-02, settling the name after trying it both ways: "I actually
+ * really like the Storybook theme, and think that it makes a better name than
+ * Storymaker, lets go with Storybook as the name of the route/app."
  *
- * So the warm-paper direction (mockup B, briefly shipped as `storybook`) is
- * both the app-wide default AND the middle of three READING MODES offered on
- * the Storymaker surface. Renamed to match what he calls it. The brief
- * describes it as "a plate tipped into warm paper": light printed ground,
- * generous margins, illustration-forward, serif text that reads as caption to
- * picture.
+ * The warm-paper direction (mockup B) is both the app-wide default AND the
+ * middle of three READING MODES on the Storybook surface — Classic (the
+ * reader's own daisyUI theme), Storybook, Storybook Dark. The brief describes
+ * it as "a plate tipped into warm paper": light printed ground, generous
+ * margins, illustration-forward, serif text that reads as caption to picture.
  *
  * This is a daisyUI THEME rather than a pile of component overrides, and that
  * is the whole leverage. Every .kr-* primitive below is written against the
@@ -26,12 +25,12 @@
  * into these tokens so the palette lives in exactly one place.
  *
  * Theme SWITCHING stays — theme-gallery, the Theme model, and per-user themes
- * are a real feature. Storymaker is the default and the design reference, not
+ * are a real feature. Storybook is the default and the design reference, not
  * the only option. `default: true` sets it as daisyUI's fallback; the runtime
  * default lives in stores/themeStore.ts and must agree.
  */
 @plugin "daisyui/theme" {
-  name: 'storymaker';
+  name: 'storybook';
   default: true;
   prefersdark: false;
   color-scheme: light;
@@ -76,7 +75,7 @@
 }
 
 /*
- * STORYMAKER-DARK — the same story surface after the house lights drop.
+ * STORYBOOK-DARK — the same story surface after the house lights drop.
  *
  * Mockup A ("a lit stage in a dark house") renamed per Silas. Not an inverted
  * palette: the hues are held and the LIGHTNESS is inverted, so terracotta stays
@@ -87,7 +86,7 @@
  * dark, which is the honest default for a reading surface.
  */
 @plugin "daisyui/theme" {
-  name: 'storymaker-dark';
+  name: 'storybook-dark';
   default: false;
   prefersdark: true;
   color-scheme: dark;
@@ -196,7 +195,7 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
 
 @layer base {
   /*
-   * Storymaker's type. The mockup set `font-serif` per element; promoting it to
+   * Storybook's type. The mockup set `font-serif` per element; promoting it to
    * the body means prose reads as printed matter everywhere without each
    * component opting in. UI chrome that should stay sans — buttons, inputs,
    * badges, code — is exempted below rather than the other way round, because

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -1,9 +1,9 @@
-<!-- /components/conductor/storymaker-page.vue -->
+<!-- /components/conductor/storybook-page.vue -->
 <template>
   <!-- data-theme scopes the reading mode to THIS subtree, so picking
-       Storymaker Dark here does not hijack the rest of the app. Classic binds
+       Storybook Dark here does not hijack the rest of the app. Classic binds
        undefined, which Vue drops entirely, leaving the reader's global theme
-       in charge — see composables/useStorymakerMode.ts. -->
+       in charge — see composables/useStorybookMode.ts. -->
   <section
     :data-theme="dataTheme"
     class="kr-surface gap-4 rounded-2xl border border-base-300 bg-base-100 p-4"
@@ -21,7 +21,7 @@
         <p class="mt-1 max-w-3xl text-sm leading-relaxed text-base-content/65">
           Shape a premise, gather reusable Kind Robots characters and Facets,
           review the story bible, and let a dedicated narrator carry your
-          choices forward. Storymaker creates fiction; it never turns the tale
+          choices forward. Storybook creates fiction; it never turns the tale
           into a task list.
         </p>
       </div>
@@ -169,7 +169,7 @@
             </h3>
             <div class="flex flex-wrap gap-2">
               <button
-                v-for="style in STORYMAKER_NARRATOR_STYLES"
+                v-for="style in STORYBOOK_NARRATOR_STYLES"
                 :key="style"
                 type="button"
                 class="btn btn-sm rounded-xl capitalize"
@@ -194,7 +194,7 @@
             </h3>
             <div class="grid gap-2 md:grid-cols-3">
               <button
-                v-for="structure in STORYMAKER_STRUCTURES"
+                v-for="structure in STORYBOOK_STRUCTURES"
                 :key="structure.value"
                 type="button"
                 class="rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-sm"
@@ -225,7 +225,7 @@
             <h2 class="text-lg font-black">The cast</h2>
             <p class="mt-1 text-xs leading-relaxed text-base-content/55">
               Choose up to five existing characters. Leaving the cast empty lets
-              Storymaker invent whoever the premise requires.
+              Storybook invent whoever the premise requires.
             </p>
           </div>
           <NarrativeIngredientMultiPicker
@@ -233,7 +233,7 @@
             :items="characterOptions"
             label="Characters"
             helper="Existing character art and personality travel into the story bible."
-            empty-state="No characters are available yet. Storymaker can still invent a cast from the premise."
+            empty-state="No characters are available yet. Storybook can still invent a cast from the premise."
             :loading="characterStore.loading || characterStore.isInitializing"
             :error="characterStore.error"
             :initial-limit="9"
@@ -260,7 +260,7 @@
             label="Primary setting"
             helper="Choose one reusable LOCATION Dream, or let the premise decide."
             empty-label="Invent a new place"
-            empty-description="Storymaker will derive the setting from the premise and selected Facets."
+            empty-description="Storybook will derive the setting from the premise and selected Facets."
             empty-icon="kind-icon:moon"
             empty-state="No LOCATION Dreams are available yet."
             :loading="dreamStore.loading"
@@ -314,7 +314,7 @@
           <div>
             <h2 class="text-lg font-black">Story bible</h2>
             <p class="mt-1 text-xs leading-relaxed text-base-content/55">
-              Review the creative contract before Storymaker writes the opening
+              Review the creative contract before Storybook writes the opening
               scene.
             </p>
           </div>
@@ -400,7 +400,7 @@
             />
             <span>
               Scene art will be directed from this bible automatically.
-              Storymaker will not ask for a model, sampler, dimensions, or step
+              Storybook will not ask for a model, sampler, dimensions, or step
               count.
             </span>
           </div>
@@ -501,14 +501,14 @@
           </div>
         </details>
 
-        <StorymakerStatePanel :session="store.session" />
+        <StorybookStatePanel :session="store.session" />
 
         <NarrativeTranscript
           :beats="store.session.beats"
           :is-streaming="store.isWeaving"
           :streaming-text="store.streamingText"
-          streaming-label="Storymaker is weaving the next scene…"
-          empty-label="Storymaker is preparing the opening scene."
+          streaming-label="Storybook is weaving the next scene…"
+          empty-label="Storybook is preparing the opening scene."
         >
           <template #after-beat="{ beat }">
             <NarrativeArtStatus
@@ -543,7 +543,7 @@
       :disabled="!store.awaitingAnswer"
       :loading="store.isWeaving"
       :placeholder="
-        store.awaitingAnswer ? 'What happens next?' : 'Storymaker is weaving…'
+        store.awaitingAnswer ? 'What happens next?' : 'Storybook is weaving…'
       "
       button-label="Continue story"
       hint="Your response changes this fictional branch. It does not update projects or real-world tasks."
@@ -560,23 +560,23 @@ import { useFacetStore } from '@/stores/facetStore'
 import { getDashboardTabImagePath } from '@/stores/helpers/dashboardHelper'
 import { useRewardStore } from '@/stores/rewardStore'
 import {
-  STORYMAKER_NARRATOR_STYLES,
-  STORYMAKER_STRUCTURES,
-  useStorymakerStore,
-  type StorymakerIngredient,
-} from '@/stores/storymakerStore'
+  STORYBOOK_NARRATOR_STYLES,
+  STORYBOOK_STRUCTURES,
+  useStorybookStore,
+  type StorybookIngredient,
+} from '@/stores/storybookStore'
 import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
 
-const { mode, setMode, dataTheme, modes } = useStorymakerMode()
+const { mode, setMode, dataTheme, modes } = useStorybookMode()
 
-const store = useStorymakerStore()
+const store = useStorybookStore()
 const characterStore = useCharacterStore()
 const dreamStore = useDreamStore()
 const facetStore = useFacetStore()
 const rewardStore = useRewardStore()
 
 const tabImage = computed(() =>
-  getDashboardTabImagePath('scenario', 'storymaker'),
+  getDashboardTabImagePath('scenario', 'storybook'),
 )
 
 const setupStep = ref(0)
@@ -692,7 +692,7 @@ const reviewTitle = computed(
 )
 const structureLabel = computed(
   () =>
-    STORYMAKER_STRUCTURES.find(
+    STORYBOOK_STRUCTURES.find(
       (item) => item.value === store.setupDraft.structure,
     )?.label || store.setupDraft.structure,
 )
@@ -712,7 +712,7 @@ function rarityLabel(value: string): string {
   return value.toLowerCase().replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
-function toIngredient(option: NarrativeIngredientOption): StorymakerIngredient {
+function toIngredient(option: NarrativeIngredientOption): StorybookIngredient {
   const reward = rewardStore.rewards.find((item) => item.slug === option.slug)
   return {
     id: option.id,

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -2,7 +2,7 @@
 <!--
   The scrolling message list, shared by every conversational surface.
 
-  Two implementations of this existed: narrative-transcript.vue (Storymaker,
+  Two implementations of this existed: narrative-transcript.vue (Storybook,
   Taskmaster) and workspace-narrator.vue's `seededMessages` loop (Dreams). They
   disagreed on everything cosmetic and agreed on the substance — a list of
   turns, a speaker, an optional portrait, an optional set of follow-up choices,

--- a/components/narrative/kr-choice-list.vue
+++ b/components/narrative/kr-choice-list.vue
@@ -14,7 +14,7 @@
   Purely presentational — it owns no store and no fetch, so it drops into a
   narrator stage, a chat bubble, or a scenario editor without dragging state
   along. All colour comes from daisyUI semantic tokens, so it inherits whichever
-  reading mode the surrounding subtree declares (see useStorymakerMode) with no
+  reading mode the surrounding subtree declares (see useStorybookMode) with no
   per-mode branching here.
 -->
 <template>

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -66,7 +66,7 @@
       <!-- The quick topics were the seed for kr-choice-list: the same
            pick-one-from-a-few idea that workspace-narrator and the scenarios
            choice-* trio each re-implemented. Adopting it here puts the shared
-           component in Storymaker's and Taskmaster's real render path at once,
+           component in Storybook's and Taskmaster's real render path at once,
            since both mount this stage. -->
       <kr-choice-list
         layout="row"

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -1,4 +1,4 @@
-<!-- /components/pages/storymaker-library-page.vue -->
+<!-- /components/pages/storybook-library-page.vue -->
 <template>
   <section class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden">
     <header
@@ -155,13 +155,13 @@
       >
         <p class="font-bold">No saved stories yet</p>
         <p class="mt-1 text-xs text-base-content/50">
-          Your first Storymaker session will appear here automatically.
+          Your first Storybook session will appear here automatically.
         </p>
       </div>
     </section>
 
     <div class="min-h-0 flex-1 overflow-hidden">
-      <StorymakerPage />
+      <StorybookPage />
     </div>
   </section>
 </template>
@@ -169,11 +169,11 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useStorymakerLibrary } from '@/composables/useStorymakerLibrary'
-import { useStorymakerStore } from '@/stores/storymakerStore'
+import { useStorybookLibrary } from '@/composables/useStorybookLibrary'
+import { useStorybookStore } from '@/stores/storybookStore'
 
-const storyStore = useStorymakerStore()
-const library = useStorymakerLibrary()
+const storyStore = useStorybookStore()
+const library = useStorybookLibrary()
 const route = useRoute()
 const router = useRouter()
 

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -169,7 +169,7 @@ async function refreshManagerData() {
 onMounted(async () => {
   await loadManagerData()
 
-  // Deep-link support: a caller (e.g. the storymaker front page's "Start a
+  // Deep-link support: a caller (e.g. the storybook front page's "Start a
   // new scenario" CTA) can land here with ?scenario=new to jump straight to
   // the add tab. This must run *after* loadManagerData, since the page's
   // own content frontmatter (dashboardTab: scenarios) already resolved the

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -1,4 +1,4 @@
-<!-- /components/storymaker/storymaker-state-panel.vue -->
+<!-- /components/storybook/storybook-state-panel.vue -->
 <template>
   <details
     class="rounded-2xl border border-secondary/25 bg-secondary/5 p-3"
@@ -103,10 +103,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { StorymakerSession } from '@/stores/storymakerStore'
+import type { StorybookSession } from '@/stores/storybookStore'
 
 const props = defineProps<{
-  session: StorymakerSession
+  session: StorybookSession
 }>()
 
 const recentConsequences = computed(() =>

--- a/composables/useStorybookLibrary.ts
+++ b/composables/useStorybookLibrary.ts
@@ -1,19 +1,19 @@
-// /composables/useStorymakerLibrary.ts
+// /composables/useStorybookLibrary.ts
 import { computed, proxyRefs, ref, watch } from 'vue'
 import {
-  useStorymakerStore,
-  type StorymakerBible,
-  type StorymakerSession,
-} from '@/stores/storymakerStore'
+  useStorybookStore,
+  type StorybookBible,
+  type StorybookSession,
+} from '@/stores/storybookStore'
 import { useUserStore } from '@/stores/userStore'
 
-export type StorymakerLibraryExport = {
+export type StorybookLibraryExport = {
   filename: string
   mimeType: 'text/markdown' | 'application/json'
   content: string
 }
 
-const LIBRARY_STORAGE_KEY = 'storymaker-session-library-v1'
+const LIBRARY_STORAGE_KEY = 'storybook-session-library-v1'
 const MAX_LIBRARY_SESSIONS = 20
 
 function nowIso(): string {
@@ -23,11 +23,11 @@ function nowIso(): string {
 function makeId(): string {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
-    : `storymaker-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+    : `storybook-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 }
 
-function cloneSession(value: StorymakerSession): StorymakerSession {
-  const copy = JSON.parse(JSON.stringify(value)) as StorymakerSession
+function cloneSession(value: StorybookSession): StorybookSession {
+  const copy = JSON.parse(JSON.stringify(value)) as StorybookSession
   return {
     ...copy,
     bible: {
@@ -48,10 +48,10 @@ function exportFilename(title: string, extension: 'md' | 'json'): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 72)
-  return `${slug || 'storymaker-story'}.${extension}`
+  return `${slug || 'storybook-story'}.${extension}`
 }
 
-function restartInput(bible: StorymakerBible) {
+function restartInput(bible: StorybookBible) {
   return {
     title: bible.title,
     premise: bible.premise,
@@ -65,10 +65,10 @@ function restartInput(bible: StorymakerBible) {
   }
 }
 
-export function useStorymakerLibrary() {
-  const storyStore = useStorymakerStore()
+export function useStorybookLibrary() {
+  const storyStore = useStorybookStore()
   const userStore = useUserStore()
-  const library = ref<StorymakerSession[]>([])
+  const library = ref<StorybookSession[]>([])
   const initialized = ref(false)
 
   const recentStories = computed(() => {
@@ -83,11 +83,11 @@ export function useStorymakerLibrary() {
     try {
       localStorage.setItem(LIBRARY_STORAGE_KEY, JSON.stringify(library.value))
     } catch {
-      // A storage quota should not break the active Storymaker session.
+      // A storage quota should not break the active Storybook session.
     }
   }
 
-  function upsert(value: StorymakerSession): void {
+  function upsert(value: StorybookSession): void {
     const copy = cloneSession(value)
     library.value = [
       copy,
@@ -103,7 +103,7 @@ export function useStorymakerLibrary() {
     try {
       const raw = localStorage.getItem(LIBRARY_STORAGE_KEY)
       if (raw) {
-        const parsed = JSON.parse(raw) as StorymakerSession[]
+        const parsed = JSON.parse(raw) as StorybookSession[]
         library.value = Array.isArray(parsed)
           ? parsed
               .map(cloneSession)
@@ -119,7 +119,7 @@ export function useStorymakerLibrary() {
     if (storyStore.session) upsert(storyStore.session)
   }
 
-  function findStory(sessionId: string): StorymakerSession | null {
+  function findStory(sessionId: string): StorybookSession | null {
     return recentStories.value.find((entry) => entry.id === sessionId) ?? null
   }
 
@@ -131,7 +131,7 @@ export function useStorymakerLibrary() {
     return true
   }
 
-  function remapDuplicate(source: StorymakerSession): StorymakerSession {
+  function remapDuplicate(source: StorybookSession): StorybookSession {
     const duplicate = cloneSession(source)
     const createdAt = nowIso()
     const sessionId = makeId()
@@ -215,7 +215,7 @@ export function useStorymakerLibrary() {
   function buildExport(
     sessionId = storyStore.session?.id,
     format: 'markdown' | 'json' = 'markdown',
-  ): StorymakerLibraryExport | null {
+  ): StorybookLibraryExport | null {
     if (!sessionId) return null
     const source =
       storyStore.session?.id === sessionId

--- a/composables/useStorybookMode.ts
+++ b/composables/useStorybookMode.ts
@@ -1,8 +1,8 @@
-// /composables/useStorymakerMode.ts
+// /composables/useStorybookMode.ts
 import { computed, ref } from 'vue'
 
 /**
- * The reading mode for the Storymaker surface.
+ * The reading mode for the Storybook surface.
  *
  * Silas, 2026-08-02: "the story maker should let the user pick from all three,
  * but I would call them Classic (daisy ui defaults), story maker, and story
@@ -16,8 +16,8 @@ import { computed, ref } from 'vue'
  *                   reader picked globally, with standard app components. This
  *                   is the one that must NOT pin a theme, or it stops meaning
  *                   "daisyUI defaults" the moment someone changes theirs.
- *   storymaker      mockup B, the warm-paper plate. Default.
- *   storymaker-dark mockup A, the lit stage in a dark house.
+ *   storybook      mockup B, the warm-paper plate. Default.
+ *   storybook-dark mockup A, the lit stage in a dark house.
  *
  * The two non-classic modes are applied as `data-theme` on the story SUBTREE
  * rather than on <html>, so choosing one does not hijack the rest of the app --
@@ -25,10 +25,10 @@ import { computed, ref } from 'vue'
  * That is also why this is a separate preference from themeStore rather than a
  * second writer to it: two writers to `data-theme` on the root would race.
  */
-export type StorymakerMode = 'classic' | 'storymaker' | 'storymaker-dark'
+export type StorybookMode = 'classic' | 'storybook' | 'storybook-dark'
 
-export const STORYMAKER_MODES: {
-  key: StorymakerMode
+export const STORYBOOK_MODES: {
+  key: StorybookMode
   label: string
   hint: string
 }[] = [
@@ -38,30 +38,30 @@ export const STORYMAKER_MODES: {
     hint: 'Your own theme, standard layout',
   },
   {
-    key: 'storymaker',
-    label: 'Storymaker',
+    key: 'storybook',
+    label: 'Storybook',
     hint: 'Warm paper, serif narration',
   },
   {
-    key: 'storymaker-dark',
-    label: 'Storymaker Dark',
+    key: 'storybook-dark',
+    label: 'Storybook Dark',
     hint: 'A lit stage in a dark house',
   },
 ]
 
-const STORAGE_KEY = 'storymakerMode'
-const DEFAULT_MODE: StorymakerMode = 'storymaker'
+const STORAGE_KEY = 'storybookMode'
+const DEFAULT_MODE: StorybookMode = 'storybook'
 
-function isMode(value: unknown): value is StorymakerMode {
-  return STORYMAKER_MODES.some((mode) => mode.key === value)
+function isMode(value: unknown): value is StorybookMode {
+  return STORYBOOK_MODES.some((mode) => mode.key === value)
 }
 
-// Module-level so every Storymaker surface on the page agrees, and so the
+// Module-level so every Storybook surface on the page agrees, and so the
 // choice survives navigating between them within a session.
-const mode = ref<StorymakerMode>(DEFAULT_MODE)
+const mode = ref<StorybookMode>(DEFAULT_MODE)
 let hydrated = false
 
-function read(): StorymakerMode {
+function read(): StorybookMode {
   if (typeof window === 'undefined') return DEFAULT_MODE
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
@@ -71,7 +71,7 @@ function read(): StorymakerMode {
   }
 }
 
-export function useStorymakerMode() {
+export function useStorybookMode() {
   // Hydrate lazily rather than at module scope: this file is imported during
   // SSR, where localStorage does not exist, and reading it at import time would
   // also bake the first visitor's choice into the module for the whole process.
@@ -80,7 +80,7 @@ export function useStorymakerMode() {
     hydrated = true
   }
 
-  function setMode(next: StorymakerMode): void {
+  function setMode(next: StorybookMode): void {
     if (!isMode(next)) return
     mode.value = next
     if (typeof window === 'undefined') return
@@ -107,5 +107,5 @@ export function useStorymakerMode() {
   /** True when the reader wants the bespoke narrative treatment. */
   const isStoryStyled = computed(() => mode.value !== 'classic')
 
-  return { mode, setMode, dataTheme, isStoryStyled, modes: STORYMAKER_MODES }
+  return { mode, setMode, dataTheme, isStoryStyled, modes: STORYBOOK_MODES }
 }

--- a/content/channels/play/storybook.md
+++ b/content/channels/play/storybook.md
@@ -1,15 +1,15 @@
 ---
 contentType: tab
 channelKey: play
-tabKey: storymaker
+tabKey: storybook
 dashboardKey: scenario
-dashboardTab: storymaker
-label: Storymaker
-title: Storymaker
+dashboardTab: storybook
+label: Storybook
+title: Storybook
 subtitle: Weave a story from reusable ingredients
 description: Combine characters, places, rewards, art, and prompts into an unfolding narrative.
 icon: kind-icon:book
-route: /storymaker
+route: /storybook
 sort: 90
 ---
 

--- a/content/storybook.md
+++ b/content/storybook.md
@@ -1,18 +1,18 @@
 ---
-title: 'Storymaker'
-room: 'Storymaker'
+title: 'Storybook'
+room: 'Storybook'
 subtitle: 'Bring everything into one unfolding story.'
 description: Weave characters, places, and treasures into a collaborative, narrated story.
 image: nav/heroes/scenario.webp
 icon: kind-icon:story
 tooltip: Weave your cast and settings into one story.
 channelKey: play
-tabKey: storymaker
+tabKey: storybook
 dashboardKey: scenario
-dashboardTab: storymaker
+dashboardTab: storybook
 cards: navCards
 loadingMessage: Threading the loom...
-refreshLabel: Refresh Storymaker
+refreshLabel: Refresh Storybook
 ---
 
-:storymaker-library-page
+:storybook-library-page

--- a/cypress/public/narrative-accessibility.cy.ts
+++ b/cypress/public/narrative-accessibility.cy.ts
@@ -130,10 +130,10 @@ function expectNoHorizontalOverflow(): void {
   })
 }
 
-function preloadStorymaker(window: Window): void {
-  window.localStorage.setItem('storymaker-session', JSON.stringify(storyOne))
+function preloadStorybook(window: Window): void {
+  window.localStorage.setItem('storybook-session', JSON.stringify(storyOne))
   window.localStorage.setItem(
-    'storymaker-session-library-v1',
+    'storybook-session-library-v1',
     JSON.stringify([storyOne, storyTwo]),
   )
 }
@@ -155,9 +155,9 @@ function expectAccessibleTranscript(): void {
 
 describe('Narrative accessibility and resume acceptance', () => {
   for (const viewport of viewports) {
-    it(`resumes Storymaker with labeled transcript and response controls on ${viewport.name}`, () => {
+    it(`resumes Storybook with labeled transcript and response controls on ${viewport.name}`, () => {
       cy.viewport(viewport.width, viewport.height)
-      cy.visit('/storymaker', { onBeforeLoad: preloadStorymaker })
+      cy.visit('/storybook', { onBeforeLoad: preloadStorybook })
 
       cy.contains('The lantern pauses before a sealed brass door', {
         timeout: 30_000,
@@ -176,10 +176,10 @@ describe('Narrative accessibility and resume acceptance', () => {
     })
   }
 
-  it('opens a saved Storymaker branch directly from the URL', () => {
+  it('opens a saved Storybook branch directly from the URL', () => {
     cy.viewport(1280, 800)
-    cy.visit('/storymaker?story=story-accessibility-two', {
-      onBeforeLoad: preloadStorymaker,
+    cy.visit('/storybook?story=story-accessibility-two', {
+      onBeforeLoad: preloadStorybook,
     })
 
     cy.contains('At midnight, every brass branch turns toward a single silver pear', {

--- a/docs/notes/davinci-play-loop-api.md
+++ b/docs/notes/davinci-play-loop-api.md
@@ -59,5 +59,5 @@ math. A dimension with no stat row fails by default.
 ## Boundary
 
 Everything stays inside the `Life*` models — no shared session tables with
-Storymaker (see `projects/davinci/docs/storymaker-boundary-comparison.md`
+Storybook (see `projects/davinci/docs/storybook-boundary-comparison.md`
 in the conductor repo).

--- a/docs/products/storybook-taskmaster-boundary.md
+++ b/docs/products/storybook-taskmaster-boundary.md
@@ -1,14 +1,14 @@
-# Storymaker and Taskmaster product boundary
+# Storybook and Taskmaster product boundary
 
 This boundary is intentional and permanent.
 
-## Storymaker
+## Storybook
 
-**Storymaker creates stories.**
+**Storybook creates stories.**
 
-Storymaker is the deluxe creative storytelling studio. It owns imaginative setup, story bibles, narrators, casts, worlds, branching choices, persistent narrative state, inventory and rewards, save/resume, and automatically directed illustrations.
+Storybook is the deluxe creative storytelling studio. It owns imaginative setup, story bibles, narrators, casts, worlds, branching choices, persistent narrative state, inventory and rewards, save/resume, and automatically directed illustrations.
 
-Storymaker must not inherit HONEYDO completion, project-task write-back, needs-human decisions, or practical task checkpoint behavior.
+Storybook must not inherit HONEYDO completion, project-task write-back, needs-human decisions, or practical task checkpoint behavior.
 
 ## Taskmaster
 
@@ -16,7 +16,7 @@ Storymaker must not inherit HONEYDO completion, project-task write-back, needs-h
 
 Taskmaster owns direct objective entry, project and HONEYDO selection, practical checkpoints, narrative framing, blocked/deferred outcomes, explicit progress review, and confirmed write-back.
 
-Taskmaster may reuse narrative presentation primitives, Facet selectors, entity cards, transcript components, and art infrastructure, but its store and state machine remain separate from Storymaker.
+Taskmaster may reuse narrative presentation primitives, Facet selectors, entity cards, transcript components, and art infrastructure, but its store and state machine remain separate from Storybook.
 
 ## Permanent implementation invariants
 
@@ -40,7 +40,7 @@ The application is still in alpha. Temporary development paths are not compatibi
 
 ## Automatic art direction
 
-Neither Storymaker nor Taskmaster asks the user to choose an art engine, model, sampler, scheduler, step count, CFG, denoise value, or dimensions.
+Neither Storybook nor Taskmaster asks the user to choose an art engine, model, sampler, scheduler, step count, CFG, denoise value, or dimensions.
 
 Product code selects a centralized narrative art profile and derives the prompt from:
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -267,6 +267,21 @@ export default defineNuxtConfig({
   devtools: {
     enabled: false,
   },
+
+  /*
+   * Storymaker was renamed to Storybook on 2026-08-02 (interface-vision t-002).
+   * The old path was a real, linkable route, so it redirects rather than 404s —
+   * a rename the user chose should not cost them their bookmarks or break any
+   * link already shared.
+   *
+   * 301 rather than 302 because this is permanent: there is no plan to bring
+   * /storymaker back, and a permanent code lets crawlers and browsers stop
+   * asking.
+   */
+  routeRules: {
+    '/storymaker': { redirect: { to: '/storybook', statusCode: 301 } },
+  },
+
   nitro: {
     prerender: {
       crawlLinks: false,

--- a/plugins/narrative-milestone-art.client.ts
+++ b/plugins/narrative-milestone-art.client.ts
@@ -2,10 +2,10 @@
 import { watch } from 'vue'
 import { useNarrativeArtJobs } from '@/composables/useNarrativeArtJobs'
 import {
-  useStorymakerStore,
-  type StorymakerBeat,
-  type StorymakerIngredient,
-} from '@/stores/storymakerStore'
+  useStorybookStore,
+  type StorybookBeat,
+  type StorybookIngredient,
+} from '@/stores/storybookStore'
 import {
   useTaskmasterStore,
   type TaskmasterBeat,
@@ -13,11 +13,11 @@ import {
 } from '@/stores/taskmasterStore'
 import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
 import {
-  selectStorymakerArtMilestone,
+  selectStorybookArtMilestone,
   selectTaskmasterArtMilestone,
 } from '@/utils/narrativeArtMilestones'
 
-const STORYMAKER_STORAGE_KEY = 'storymaker-session'
+const STORYBOOK_STORAGE_KEY = 'storybook-session'
 const TASKMASTER_STORAGE_KEY = 'taskmaster-session'
 
 function nowIso(): string {
@@ -25,7 +25,7 @@ function nowIso(): string {
 }
 
 function describeIngredient(
-  ingredient: StorymakerIngredient | TaskmasterIngredient,
+  ingredient: StorybookIngredient | TaskmasterIngredient,
 ): string {
   return [ingredient.title, ingredient.description, ingredient.flavorText]
     .filter(Boolean)
@@ -41,7 +41,7 @@ function persistSession(key: string, value: unknown): void {
 }
 
 export default defineNuxtPlugin(() => {
-  const storyStore = useStorymakerStore()
+  const storyStore = useStorybookStore()
   const taskStore = useTaskmasterStore()
   const artJobs = useNarrativeArtJobs()
   const seenStoryBeats = new Map<string, Set<string>>()
@@ -53,7 +53,7 @@ export default defineNuxtPlugin(() => {
     if (!active || !beat) return
     beat.art = art
     active.updatedAt = nowIso()
-    persistSession(STORYMAKER_STORAGE_KEY, active)
+    persistSession(STORYBOOK_STORAGE_KEY, active)
   }
 
   function updateTaskArt(beatId: string, art: NarrativeArtJobState): void {
@@ -65,15 +65,15 @@ export default defineNuxtPlugin(() => {
     persistSession(TASKMASTER_STORAGE_KEY, active)
   }
 
-  function requestStoryArt(beat: StorymakerBeat): void {
+  function requestStoryArt(beat: StorybookBeat): void {
     const active = storyStore.session
     if (!active) return
-    const moment = selectStorymakerArtMilestone(active, beat)
+    const moment = selectStorybookArtMilestone(active, beat)
     if (!moment) return
 
     void artJobs.enqueue(
       {
-        product: 'storymaker',
+        product: 'storybook',
         sessionId: active.id,
         beatId: beat.id,
         moment,

--- a/prisma/migrations/20260802090000_storybook_project_rename/migration.sql
+++ b/prisma/migrations/20260802090000_storybook_project_rename/migration.sql
@@ -1,0 +1,59 @@
+-- Storymaker becomes Storybook: the one persisted row that names the PRODUCT.
+--
+-- Silas, 2026-08-02: "I actually really like the Storybook theme, and think
+-- that it makes a better name than Storymaker, lets go with Storybook as the
+-- name of the route/app."
+--
+-- The code rename ships in the same commit as this migration, deliberately.
+-- utils/projectPlacements.ts now keys the placement on slug 'storybook', so a
+-- deploy where new code met an un-migrated row would simply fail to find the
+-- project. Shipping them together means there is no window where they disagree.
+--
+-- WHAT WAS COUNTED FIRST (and what is deliberately NOT touched)
+--
+-- Every persisted place the old name could appear was queried against
+-- production before writing this:
+--
+--   ArtJob.projectSlug = 'storymaker'      0 rows  -> nothing to migrate
+--   Chat.channel       = 'storymaker'      0 rows  -> nothing to migrate
+--   Project.slug       = 'storymaker'      1 row   -> THIS migration
+--   ArtImage.designer LIKE '%storymaker%'  4 rows  -> deliberately left alone
+--   ArtCollection.slug = 'storymaker'      1 row   -> deliberately left alone
+--
+-- The last two are PROVENANCE, not product naming. Those four ArtImages carry
+-- `designer = 'folder-sync:storymaker'`, which server/utils/syncFolderCollection.ts
+-- derives from the collection slug, which in turn mirrors a real directory:
+-- their imagePath values are /images/artcollections/storymaker/*.webp and the
+-- files physically exist there. Renaming those fields would make them describe
+-- a folder that does not exist, and would not move a single byte. If the media
+-- folder is ever renamed on the server, THAT is when those rows should follow —
+-- as a separate, deliberate change.
+--
+-- FIVE COLUMNS, NOT TWO. The row carries the old name in more places than the
+-- obvious one, and a partial rename is worse than none:
+--
+--   slug           the lookup key
+--   conductorSlug  what conductor's sync_projects.py matches on. Left stale, a
+--                  later sync would look up 'storybook', miss, and CREATE A
+--                  SECOND project rather than update this one.
+--   title          display
+--   tabKey         frontend placement — stale, it points at a dashboard tab
+--                  that no longer exists after the content rename
+--   liveUrl        stale, it points at the 301 instead of the real route
+--
+-- The matching conductor registry entry (project-overrides.yaml) is renamed in
+-- the same change, because that entry is what sync_projects.py writes FROM —
+-- migrating the row without it would simply be undone by the next sync.
+--
+-- SAFETY: one UPDATE, scoped by slug, touching one row. Idempotent — re-running
+-- it matches nothing, because the slug it looks for is gone after the first
+-- run. Reversible by hand with the inverse UPDATE. No schema change, no DDL,
+-- nothing dropped.
+
+UPDATE `Project`
+SET `slug` = 'storybook',
+    `conductorSlug` = 'storybook',
+    `title` = 'Storybook',
+    `tabKey` = 'storybook',
+    `liveUrl` = '/storybook'
+WHERE `slug` = 'storymaker';

--- a/prisma/seeds/inspiration-prompts.ts
+++ b/prisma/seeds/inspiration-prompts.ts
@@ -45,7 +45,12 @@ const INSPIRATIONS: InspirationEntry[] = [
     imagePath: 'public/images/artcollections/art-generator-connect/art-generator-connect-inspiration-03.webp',
     artPrompt: t('A calm operations desk where failed placeholders are transformed into finished art assets by small robot technicians and luminous validation rails, crisp studio illustration, no text, no collage'),
   },
-  // storymaker
+  // storymaker — NOT renamed with the product (interface-vision t-002).
+  // These paths are where the files physically live on disk, under
+  // public/images/artcollections/storymaker/. ArtCollection.slug and the
+  // `folder-sync:storymaker` designer on the synced ArtImages mirror the same
+  // folder. Renaming the product does not move the bytes, and rewriting these
+  // would make the paths point at nothing.
   {
     imagePath: 'public/images/artcollections/storymaker/storymaker-inspiration-01.webp',
     artPrompt: t('A tabletop map blooming into multiple possible scenes at once: forest, airship, castle, sea cave, and dragon trail, with players shaping the story through glowing choice tokens, high-end cozy fantasy game art, no text, no collage'),

--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -59,7 +59,7 @@ type EnqueueEngine =
 type JsonRecord = Record<string, unknown>
 
 type NarrativeEnqueueContext = {
-  product: 'storymaker' | 'taskmaster'
+  product: 'storybook' | 'taskmaster'
   sessionId: string
   beatId: string
   moment: string
@@ -178,7 +178,7 @@ function narrativeRequest(
     'finale',
   ])
 
-  if (product !== 'storymaker' && product !== 'taskmaster') {
+  if (product !== 'storybook' && product !== 'taskmaster') {
     throw createError({ statusCode: 400, message: 'Invalid narrative product.' })
   }
   if (!sessionId || sessionId.length > 160 || !beatId || beatId.length > 160) {

--- a/server/api/art/queue/narrative.get.ts
+++ b/server/api/art/queue/narrative.get.ts
@@ -5,7 +5,7 @@ import { errorHandler } from '../../../utils/error'
 import { requireMachineUser } from '../../../utils/authGuard'
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
-const ALLOWED_PRODUCTS = new Set(['storymaker', 'taskmaster'])
+const ALLOWED_PRODUCTS = new Set(['storybook', 'taskmaster'])
 const ALLOWED_MOMENTS = new Set([
   'opening',
   'chapter',

--- a/server/utils/davinci.ts
+++ b/server/utils/davinci.ts
@@ -254,7 +254,7 @@ export async function resolveLifeRunEnding(
 // The durable-state substrate the Chat narrator will call later: create a run,
 // record a choice with its stat effects, and read a run back for resume. AI
 // narration is out of scope — these endpoints own state, not prose. Per the
-// Storymaker boundary doc, this stays inside the Life* models; no shared
+// Storybook boundary doc, this stays inside the Life* models; no shared
 // session tables.
 
 function withStatusCode(message: string, statusCode: number): Error {

--- a/stores/artStore.ts
+++ b/stores/artStore.ts
@@ -108,7 +108,7 @@ export type QueuedArtJob = {
 }
 
 export type NarrativeArtEnqueueContext = {
-  product: 'storymaker' | 'taskmaster'
+  product: 'storybook' | 'taskmaster'
   sessionId: string
   beatId: string
   moment: string

--- a/stores/helpers/conductorCards.ts
+++ b/stores/helpers/conductorCards.ts
@@ -176,8 +176,8 @@ export const CONDUCTOR_CARDS: ConductorCard[] = [
     9,
   ),
   card(
-    'storymaker',
-    'Storymaker',
+    'storybook',
+    'Storybook',
     'kind-icon:book',
     'Structured story creation',
     'A software surface for drafting, organizing, and expanding story ideas into reusable narrative artifacts.',

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -900,16 +900,16 @@ export const dashboardConfigs = {
         route: '/stories',
       },
       {
-        key: 'storymaker',
-        label: 'Storymaker',
+        key: 'storybook',
+        label: 'Storybook',
         icon: 'kind-icon:story',
-        title: 'Storymaker',
+        title: 'Storybook',
         summary:
           'Weave characters, places, and treasures into a collaborative unfolding story.',
-        image: tabImage('scenario', 'storymaker'),
+        image: tabImage('scenario', 'storybook'),
         narrative:
-          'Storymaker is the long-form loom: bring your cast, settings, and rewards together and let the narrator help you spin a collaborative story that actually goes somewhere.',
-        route: '/storymaker',
+          'Storybook is the long-form loom: bring your cast, settings, and rewards together and let the narrator help you spin a collaborative story that actually goes somewhere.',
+        route: '/storybook',
       },
       {
         key: 'taskmaster',

--- a/stores/helpers/themeHelper.ts
+++ b/stores/helpers/themeHelper.ts
@@ -47,7 +47,7 @@ export const extraVars = [
 /**
  * Every theme name the app will apply to `data-theme`.
  *
- * The two `storymaker*` entries come FIRST because they are the house
+ * The two `storybook*` entries come FIRST because they are the house
  * aesthetic (interface-vision t-002), not stock daisyUI themes — both are
  * defined by `@plugin "daisyui/theme"` blocks in assets/css/tailwind.css. They
  * have to be listed here or setActiveTheme rejects them as "not found in
@@ -55,8 +55,8 @@ export const extraVars = [
  * are daisyUI's built-ins, kept so users can still theme-switch.
  */
 export const daisyuiThemes = [
-  'storymaker',
-  'storymaker-dark',
+  'storybook',
+  'storybook-dark',
   'light',
   'dark',
   'cupcake',

--- a/stores/helpers/tutorialCards.ts
+++ b/stores/helpers/tutorialCards.ts
@@ -138,10 +138,10 @@ export const tutorialChannels = {
         image: tutorialImage('scenario', 'taskmaster'),
       },
       {
-        key: 'storymaker',
-        title: 'Storymaker',
+        key: 'storybook',
+        title: 'Storybook',
         body: 'Bring your characters, settings, and rewards together and let the narrator turn choices into consequences with teeth — the long-form loom that gathers everything else into one unfolding story.',
-        image: tutorialImage('scenario', 'storymaker'),
+        image: tutorialImage('scenario', 'storybook'),
       },
     ],
   },

--- a/stores/storybookStore.ts
+++ b/stores/storybookStore.ts
@@ -1,5 +1,5 @@
-// /stores/storymakerStore.ts
-// Storymaker owns creative story sessions. It never imports Taskmaster state or
+// /stores/storybookStore.ts
+// Storybook owns creative story sessions. It never imports Taskmaster state or
 // task write-back behavior; the two products share presentation only.
 import { computed, ref, watch } from 'vue'
 import { defineStore } from 'pinia'
@@ -9,19 +9,19 @@ import { useUserStore } from '@/stores/userStore'
 import type { NarrativeArtJobState } from '@/utils/narrativeArtJobs'
 import type { NarrativeArtMoment } from '@/utils/narrativeArtProfiles'
 
-export type StorymakerStructure = 'short-story' | 'chaptered' | 'episodic'
-export type StorymakerNarratorStyle =
+export type StorybookStructure = 'short-story' | 'chaptered' | 'episodic'
+export type StorybookNarratorStyle =
   | 'cinematic'
   | 'playful'
   | 'storybook'
   | 'mysterious'
   | 'intimate'
 
-export type StorymakerSetupDraft = {
+export type StorybookSetupDraft = {
   title: string
   premise: string
-  narratorStyle: StorymakerNarratorStyle
-  structure: StorymakerStructure
+  narratorStyle: StorybookNarratorStyle
+  structure: StorybookStructure
   castSlugs: string[]
   locationSlug: string | null
   facetSlugs: string[]
@@ -29,7 +29,7 @@ export type StorymakerSetupDraft = {
   notes: string
 }
 
-export type StorymakerIngredient = {
+export type StorybookIngredient = {
   id?: number | string
   slug: string
   title: string
@@ -41,43 +41,43 @@ export type StorymakerIngredient = {
   effect?: string | null
 }
 
-export type StorymakerBible = {
+export type StorybookBible = {
   title: string
   premise: string
-  narratorStyle: StorymakerNarratorStyle
-  structure: StorymakerStructure
-  cast: StorymakerIngredient[]
-  location?: StorymakerIngredient
-  facets: StorymakerIngredient[]
-  rewards: StorymakerIngredient[]
+  narratorStyle: StorybookNarratorStyle
+  structure: StorybookStructure
+  cast: StorybookIngredient[]
+  location?: StorybookIngredient
+  facets: StorybookIngredient[]
+  rewards: StorybookIngredient[]
   notes?: string
   createdAt: string
 }
 
-export type StorymakerAnswer = {
+export type StorybookAnswer = {
   text: string
   capturedAt: string
 }
 
-export type StorymakerStateDelta = {
+export type StorybookStateDelta = {
   consequences: string[]
   relationshipShifts: string[]
   inventoryAdd: string[]
   inventoryRemove: string[]
 }
 
-export type StorymakerBeat = {
+export type StorybookBeat = {
   id: string
   sessionId: string
   narrative: string
   question: string
-  answer?: StorymakerAnswer
+  answer?: StorybookAnswer
   art?: NarrativeArtJobState
-  stateDelta: StorymakerStateDelta
+  stateDelta: StorybookStateDelta
   createdAt: string
 }
 
-export type StorymakerBranchChoice = {
+export type StorybookBranchChoice = {
   id: string
   beatId: string
   question: string
@@ -85,7 +85,7 @@ export type StorymakerBranchChoice = {
   createdAt: string
 }
 
-export type StorymakerConsequence = {
+export type StorybookConsequence = {
   id: string
   beatId: string
   kind: 'consequence' | 'relationship'
@@ -93,45 +93,45 @@ export type StorymakerConsequence = {
   createdAt: string
 }
 
-export type StorymakerInventoryItem = {
-  ingredient: StorymakerIngredient
+export type StorybookInventoryItem = {
+  ingredient: StorybookIngredient
   beatId: string
   acquiredAt: string
 }
 
-export type StorymakerSession = {
+export type StorybookSession = {
   id: string
   userId: number | null
-  bible: StorymakerBible
-  beats: StorymakerBeat[]
-  branchHistory: StorymakerBranchChoice[]
-  consequences: StorymakerConsequence[]
-  inventory: StorymakerInventoryItem[]
+  bible: StorybookBible
+  beats: StorybookBeat[]
+  branchHistory: StorybookBranchChoice[]
+  consequences: StorybookConsequence[]
+  inventory: StorybookInventoryItem[]
   stateVersion: 1
   status: 'active' | 'complete'
   createdAt: string
   updatedAt: string
 }
 
-export type StorymakerStartInput = {
+export type StorybookStartInput = {
   title?: string
   premise: string
-  narratorStyle: StorymakerNarratorStyle
-  structure: StorymakerStructure
-  cast: StorymakerIngredient[]
-  location?: StorymakerIngredient
-  facets: StorymakerIngredient[]
-  rewards: StorymakerIngredient[]
+  narratorStyle: StorybookNarratorStyle
+  structure: StorybookStructure
+  cast: StorybookIngredient[]
+  location?: StorybookIngredient
+  facets: StorybookIngredient[]
+  rewards: StorybookIngredient[]
   notes?: string
 }
 
-const STORAGE_KEY = 'storymaker-session'
-const DRAFT_STORAGE_KEY = 'storymaker-setup-draft'
+const STORAGE_KEY = 'storybook-session'
+const DRAFT_STORAGE_KEY = 'storybook-setup-draft'
 const STATE_OPEN = '[STORY_STATE]'
 const STATE_CLOSE = '[/STORY_STATE]'
 const MAX_STATE_ITEMS = 3
 
-export const STORYMAKER_NARRATOR_STYLES: StorymakerNarratorStyle[] = [
+export const STORYBOOK_NARRATOR_STYLES: StorybookNarratorStyle[] = [
   'cinematic',
   'playful',
   'storybook',
@@ -139,8 +139,8 @@ export const STORYMAKER_NARRATOR_STYLES: StorymakerNarratorStyle[] = [
   'intimate',
 ]
 
-export const STORYMAKER_STRUCTURES: {
-  value: StorymakerStructure
+export const STORYBOOK_STRUCTURES: {
+  value: StorybookStructure
   label: string
   description: string
 }[] = [
@@ -161,7 +161,7 @@ export const STORYMAKER_STRUCTURES: {
   },
 ]
 
-const PERSONA = `You are Storymaker, a generous fiction narrator inside Kind Robots.
+const PERSONA = `You are Storybook, a generous fiction narrator inside Kind Robots.
 You create an original second-person story from a story bible supplied by the reader.
 The reader is the protagonist unless the premise clearly says otherwise.
 
@@ -184,7 +184,7 @@ short strings. Inventory arrays may contain only exact Reward slugs listed in th
 story bible. Use empty arrays when nothing changes. The state block is not prose
 and must never be described to the reader.`
 
-function emptyStateDelta(): StorymakerStateDelta {
+function emptyStateDelta(): StorybookStateDelta {
   return {
     consequences: [],
     relationshipShifts: [],
@@ -193,7 +193,7 @@ function emptyStateDelta(): StorymakerStateDelta {
   }
 }
 
-function defaultDraft(): StorymakerSetupDraft {
+function defaultDraft(): StorybookSetupDraft {
   return {
     title: '',
     premise: '',
@@ -214,7 +214,7 @@ function nowIso(): string {
 function makeId(): string {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
-    : `storymaker-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+    : `storybook-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 function cleanStateStrings(value: unknown): string[] {
@@ -246,7 +246,7 @@ function derivedTitle(premise: string): string {
   return first.length > 54 ? `${first.slice(0, 51).trim()}…` : first
 }
 
-function ingredientDescription(ingredient: StorymakerIngredient): string {
+function ingredientDescription(ingredient: StorybookIngredient): string {
   return [
     ingredient.title,
     ingredient.description,
@@ -258,7 +258,7 @@ function ingredientDescription(ingredient: StorymakerIngredient): string {
     .join(' — ')
 }
 
-function normalizeRestoredSession(value: StorymakerSession): StorymakerSession {
+function normalizeRestoredSession(value: StorybookSession): StorybookSession {
   const bible = {
     ...value.bible,
     rewards: Array.isArray(value.bible?.rewards) ? value.bible.rewards : [],
@@ -279,13 +279,13 @@ function normalizeRestoredSession(value: StorymakerSession): StorymakerSession {
   }
 }
 
-export const useStorymakerStore = defineStore('storymakerStore', () => {
+export const useStorybookStore = defineStore('storybookStore', () => {
   const chatStore = useChatStore()
   const userStore = useUserStore()
   const narrativeArtJobs = useNarrativeArtJobs()
 
-  const setupDraft = ref<StorymakerSetupDraft>(defaultDraft())
-  const session = ref<StorymakerSession | null>(null)
+  const setupDraft = ref<StorybookSetupDraft>(defaultDraft())
+  const session = ref<StorybookSession | null>(null)
   const isWeaving = ref(false)
   const errorMessage = ref('')
 
@@ -334,12 +334,12 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
       if (draftRaw) {
         setupDraft.value = {
           ...defaultDraft(),
-          ...(JSON.parse(draftRaw) as Partial<StorymakerSetupDraft>),
+          ...(JSON.parse(draftRaw) as Partial<StorybookSetupDraft>),
         }
       }
       if (sessionRaw && !session.value) {
         session.value = normalizeRestoredSession(
-          JSON.parse(sessionRaw) as StorymakerSession,
+          JSON.parse(sessionRaw) as StorybookSession,
         )
         resumeNarrativeArtJobs()
       }
@@ -358,13 +358,13 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
   }
 
   function narrativeArtContext(
-    beat: StorymakerBeat,
+    beat: StorybookBeat,
     moment: NarrativeArtMoment,
   ) {
     const active = session.value
     if (!active) return null
     return {
-      product: 'storymaker' as const,
+      product: 'storybook' as const,
       sessionId: active.id,
       beatId: beat.id,
       moment,
@@ -379,7 +379,7 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
   }
 
   function requestBeatArt(
-    beat: StorymakerBeat,
+    beat: StorybookBeat,
     moment: NarrativeArtMoment,
   ): void {
     if (beat.art) return
@@ -413,7 +413,7 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
     persist()
   }
 
-  function buildBible(input: StorymakerStartInput): StorymakerBible {
+  function buildBible(input: StorybookStartInput): StorybookBible {
     return {
       title: input.title?.trim() || derivedTitle(input.premise),
       premise: input.premise.trim(),
@@ -428,7 +428,7 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
     }
   }
 
-  function biblePrompt(bible: StorymakerBible): string {
+  function biblePrompt(bible: StorybookBible): string {
     const parts = [
       `Title: ${bible.title}`,
       `Premise: ${bible.premise}`,
@@ -477,7 +477,7 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
       .join('\n\n')
   }
 
-  function statePrompt(active: StorymakerSession): string {
+  function statePrompt(active: StorybookSession): string {
     const inventory = active.inventory.length
       ? active.inventory.map((item) => item.ingredient.slug).join(', ')
       : 'empty'
@@ -504,8 +504,8 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
 
   function parseGeneratedBeat(
     rawText: string,
-    bible: StorymakerBible,
-  ): { narrative: string; stateDelta: StorymakerStateDelta } {
+    bible: StorybookBible,
+  ): { narrative: string; stateDelta: StorybookStateDelta } {
     const start = rawText.lastIndexOf(STATE_OPEN)
     const end = rawText.lastIndexOf(STATE_CLOSE)
     if (start < 0 || end <= start) {
@@ -538,9 +538,9 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
   }
 
   function applyStateDelta(
-    active: StorymakerSession,
+    active: StorybookSession,
     beatId: string,
-    delta: StorymakerStateDelta,
+    delta: StorybookStateDelta,
   ) {
     const createdAt = nowIso()
     const existingTexts = new Set(
@@ -607,12 +607,12 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
         active.bible,
       )
       if (!parsed.narrative) {
-        errorMessage.value = 'Storymaker went quiet. Try the scene again.'
+        errorMessage.value = 'Storybook went quiet. Try the scene again.'
         return false
       }
 
       const beatId = makeId()
-      const beat: StorymakerBeat = {
+      const beat: StorybookBeat = {
         id: beatId,
         sessionId: active.id,
         narrative: parsed.narrative,
@@ -642,7 +642,7 @@ export const useStorymakerStore = defineStore('storymakerStore', () => {
     }
   }
 
-  async function beginStory(input: StorymakerStartInput): Promise<boolean> {
+  async function beginStory(input: StorybookStartInput): Promise<boolean> {
     if (!input.premise.trim() || isWeaving.value) return false
     const createdAt = nowIso()
     const bible = buildBible(input)

--- a/stores/themeStore.ts
+++ b/stores/themeStore.ts
@@ -44,29 +44,33 @@ type ThemeInitializeOptions = {
   fetchShared?: boolean
 }
 
-// STORYMAKER is the house aesthetic (interface-vision t-002), defined as a
+// STORYBOOK is the house aesthetic (interface-vision t-002), defined as a
 // daisyUI theme in assets/css/tailwind.css. That definition carries
 // `default: true`; this constant is the RUNTIME default and the two must agree,
 // or a user with no stored preference gets daisyUI's fallback while the store
-// reports something else. Was 'retro' — a stock theme that happened to be
-// cream-ish, which is why parts of the app already half-looked right. Now it is
-// deliberate. Theme switching is unaffected: this is the default, not the only
-// option.
-const defaultThemeName = 'storymaker'
+// reports something else. It was 'retro' before t-002 — a stock theme that
+// happened to be cream-ish, which is why parts of the app already half-looked
+// right; now it is deliberate. Theme switching is unaffected: this is the
+// default, not the only option.
+const defaultThemeName = 'storybook'
 
 /**
  * Theme names that were renamed after shipping, mapped to what they are now.
  *
- * `storybook` was live for a few hours on 2026-08-02 before Silas renamed the
- * aesthetic to match what he calls it. Anyone who loaded the site in that
- * window has the old name in localStorage, and without this map they would fail
- * the daisyuiThemes check and get silently reset to the default — losing an
- * explicit choice if they had also picked something else since. Cheap to keep,
- * and the only cost of removing it later is that a handful of stale entries
- * fall back to the default anyway.
+ * The house theme was named twice on 2026-08-02: shipped as `storybook`,
+ * renamed to `storymaker` a few hours later, then settled back on `storybook`
+ * once Silas decided it "makes a better name". Anyone who loaded the site
+ * inside the middle window has `storymaker` in localStorage; without this map
+ * they fail the daisyuiThemes check and get silently reset, losing an explicit
+ * choice if they had picked something else since.
+ *
+ * Only the middle name needs mapping — `storybook` is a valid name again, so it
+ * resolves to itself with no entry. A self-mapping entry would be a no-op that
+ * looks like protection, which is worse than none.
  */
 const RENAMED_THEMES: Record<string, string> = {
-  storybook: 'storymaker',
+  storymaker: 'storybook',
+  'storymaker-dark': 'storybook-dark',
 }
 
 function resolveStoredThemeName(stored: string): string {

--- a/utils/http/createNewProjects.http
+++ b/utils/http/createNewProjects.http
@@ -23,14 +23,14 @@ Authorization: Bearer {{token}}
 }
 
 ###
-# 2. Storymaker
+# 2. Storybook
 POST {{baseUrl}}/api/dreams
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
 {
-  "title": "Storymaker",
-  "slug": "storymaker",
+  "title": "Storybook",
+  "slug": "storybook",
   "dreamType": "PROJECT",
   "projectStatus": "BRAINSTORM",
   "description": "Phase 3 of Kind Robots: a full collaborative storytelling engine built on Bots, Characters, Dreams, Rewards, Scenarios, and Chats. Two modes: Exquisite Corpse (async turn-taking) and Guided Adventure (LLM-narrated multi-stage journey). Solo or group play, branching choices, character stat spends, unlockable rewards.",

--- a/utils/narrativeArtMilestones.ts
+++ b/utils/narrativeArtMilestones.ts
@@ -1,9 +1,9 @@
 // /utils/narrativeArtMilestones.ts
 import type {
-  StorymakerBeat,
-  StorymakerSession,
-  StorymakerStateDelta,
-} from '@/stores/storymakerStore'
+  StorybookBeat,
+  StorybookSession,
+  StorybookStateDelta,
+} from '@/stores/storybookStore'
 import type {
   TaskmasterBeat,
   TaskmasterCheckpointStatus,
@@ -11,14 +11,14 @@ import type {
 } from '@/stores/taskmasterStore'
 import type { NarrativeArtMoment } from '@/utils/narrativeArtProfiles'
 
-export const STORYMAKER_INTERMEDIATE_ART_LIMIT = 2
+export const STORYBOOK_INTERMEDIATE_ART_LIMIT = 2
 export const TASKMASTER_INTERMEDIATE_ART_LIMIT = 1
 export const MIN_BEATS_BETWEEN_ART = 2
 
 const LOCATION_TRANSITION_PATTERN =
   /\b(arriv(?:e|ed|ing)|enter(?:ed|ing)?|reach(?:ed|ing)?|cross(?:ed|ing)? into|step(?:ped|ping)? into|emerg(?:e|ed|ing) into|descend(?:ed|ing)? into|climb(?:ed|ing)? into)\b/i
 
-function hasMeaningfulStateDelta(delta: StorymakerStateDelta): boolean {
+function hasMeaningfulStateDelta(delta: StorybookStateDelta): boolean {
   return Boolean(
     delta.consequences.length ||
       delta.relationshipShifts.length ||
@@ -61,8 +61,8 @@ function normalizedText(value: string): string {
 }
 
 function newlyIntroducedCast(
-  session: StorymakerSession,
-  beat: StorymakerBeat,
+  session: StorybookSession,
+  beat: StorybookBeat,
   beatIndex: number,
 ): boolean {
   const current = normalizedText(beat.narrative)
@@ -79,21 +79,21 @@ function newlyIntroducedCast(
   })
 }
 
-function storyChapterBoundary(session: StorymakerSession, beatIndex: number): boolean {
+function storyChapterBoundary(session: StorybookSession, beatIndex: number): boolean {
   const sceneNumber = beatIndex + 1
   if (session.bible.structure === 'chaptered') return sceneNumber >= 4 && sceneNumber % 3 === 1
   if (session.bible.structure === 'episodic') return sceneNumber >= 5 && sceneNumber % 4 === 1
   return false
 }
 
-export function selectStorymakerArtMilestone(
-  session: StorymakerSession,
-  beat: StorymakerBeat,
+export function selectStorybookArtMilestone(
+  session: StorybookSession,
+  beat: StorybookBeat,
 ): NarrativeArtMoment | null {
   if (beat.art || session.status !== 'active') return null
   const beatIndex = session.beats.findIndex((entry) => entry.id === beat.id)
   if (beatIndex <= 0) return null
-  if (intermediateArtCount(session.beats) >= STORYMAKER_INTERMEDIATE_ART_LIMIT) {
+  if (intermediateArtCount(session.beats) >= STORYBOOK_INTERMEDIATE_ART_LIMIT) {
     return null
   }
   if (!hasArtCooldown(session.beats, beatIndex)) return null

--- a/utils/narrativeArtProfiles.ts
+++ b/utils/narrativeArtProfiles.ts
@@ -1,11 +1,11 @@
 // /utils/narrativeArtProfiles.ts
 //
-// Storymaker creates stories. Taskmaster uses stories to finish tasks.
+// Storybook creates stories. Taskmaster uses stories to finish tasks.
 // Neither experience asks the user to configure image-generation internals.
 // Product code selects one of these centralized profiles and derives the prompt
 // from narrative state, Facets, characters, locations, and the target surface.
 
-export type NarrativeProduct = 'storymaker' | 'taskmaster'
+export type NarrativeProduct = 'storybook' | 'taskmaster'
 
 export type NarrativeArtMoment =
   | 'opening'
@@ -45,17 +45,17 @@ export const NARRATIVE_ART_PROFILES: Record<
   NarrativeProduct,
   NarrativeArtProfile
 > = {
-  storymaker: {
-    key: 'storymaker-narrative-krea4',
-    product: 'storymaker',
+  storybook: {
+    key: 'storybook-narrative-krea4',
+    product: 'storybook',
     engine: 'krea2',
     steps: 4,
     cfg: 1,
     sampler: 'euler',
     scheduler: 'simple',
     denoise: 1,
-    designer: 'storymaker-auto-director',
-    projectSlug: 'storymaker',
+    designer: 'storybook-auto-director',
+    projectSlug: 'storybook',
     defaultSurface: 'scene-landscape',
     styleDirective:
       'cinematic illustrated-story moment, expressive characters, strong environmental storytelling, polished composition, coherent visual continuity',

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -52,10 +52,10 @@ export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
     tabKey: 'model-builder',
     route: '/model-builder',
   },
-  storymaker: {
+  storybook: {
     channelKey: 'play',
-    tabKey: 'storymaker',
-    route: '/storymaker',
+    tabKey: 'storybook',
+    route: '/storybook',
   },
   sketchy: {
     channelKey: 'plan',

--- a/utils/scripts/verifyNarrativeAccessibility.mjs
+++ b/utils/scripts/verifyNarrativeAccessibility.mjs
@@ -46,7 +46,7 @@ assert.ok(
 assert.ok(
   transcript.includes('visibleStreamingText') &&
     transcript.includes("const marker = '[STORY_STATE]'"),
-  'Accessibility work must retain hidden Storymaker state filtering',
+  'Accessibility work must retain hidden Storybook state filtering',
 )
 
 includesAll(composerPath, [
@@ -96,13 +96,13 @@ includesAll(artStatusPath, [
 ])
 
 includesAll(specPath, [
-  '/storymaker',
-  '/storymaker?story=story-accessibility-two',
+  '/storybook',
+  '/storybook?story=story-accessibility-two',
   '/taskmaster',
   '1440',
   '390',
-  'storymaker-session',
-  'storymaker-session-library-v1',
+  'storybook-session',
+  'storybook-session-library-v1',
   'taskmaster-session',
   'expectAccessibleTranscript',
   'expectNoHorizontalOverflow',

--- a/utils/scripts/verifyNarrativeArtMilestones.ts
+++ b/utils/scripts/verifyNarrativeArtMilestones.ts
@@ -1,10 +1,10 @@
 // /utils/scripts/verifyNarrativeArtMilestones.ts
 import assert from 'node:assert/strict'
 import type {
-  StorymakerBeat,
-  StorymakerSession,
-  StorymakerStateDelta,
-} from '../../stores/storymakerStore'
+  StorybookBeat,
+  StorybookSession,
+  StorybookStateDelta,
+} from '../../stores/storybookStore'
 import type {
   TaskmasterBeat,
   TaskmasterCheckpoint,
@@ -12,13 +12,13 @@ import type {
 } from '../../stores/taskmasterStore'
 import {
   MIN_BEATS_BETWEEN_ART,
-  STORYMAKER_INTERMEDIATE_ART_LIMIT,
+  STORYBOOK_INTERMEDIATE_ART_LIMIT,
   TASKMASTER_INTERMEDIATE_ART_LIMIT,
-  selectStorymakerArtMilestone,
+  selectStorybookArtMilestone,
   selectTaskmasterArtMilestone,
 } from '../narrativeArtMilestones'
 
-const emptyDelta = (): StorymakerStateDelta => ({
+const emptyDelta = (): StorybookStateDelta => ({
   consequences: [],
   relationshipShifts: [],
   inventoryAdd: [],
@@ -30,9 +30,9 @@ function storyBeat(
   narrative: string,
   options: {
     artMoment?: 'opening' | 'chapter' | 'location' | 'character-introduction' | 'pivotal-event' | 'finale'
-    delta?: StorymakerStateDelta
+    delta?: StorybookStateDelta
   } = {},
-): StorymakerBeat {
+): StorybookBeat {
   return {
     id,
     sessionId: 'story-session',
@@ -40,13 +40,13 @@ function storyBeat(
     question: 'What now?',
     stateDelta: options.delta ?? emptyDelta(),
     art: options.artMoment
-      ? ({ moment: options.artMoment } as StorymakerBeat['art'])
+      ? ({ moment: options.artMoment } as StorybookBeat['art'])
       : undefined,
     createdAt: new Date().toISOString(),
   }
 }
 
-function storySession(beats: StorymakerBeat[]): StorymakerSession {
+function storySession(beats: StorybookBeat[]): StorybookSession {
   return {
     id: 'story-session',
     userId: 1,
@@ -81,7 +81,7 @@ const pivotal = storyBeat('s2', 'The bridge collapses behind them.', {
 })
 let story = storySession([opening, quiet, pivotal])
 assert.equal(
-  selectStorymakerArtMilestone(story, pivotal),
+  selectStorybookArtMilestone(story, pivotal),
   'pivotal-event',
   'A state-changing beat should qualify after the cooldown',
 )
@@ -91,7 +91,7 @@ const tooSoon = storyBeat('s1b', 'A consequence arrives immediately.', {
 })
 story = storySession([opening, tooSoon])
 assert.equal(
-  selectStorymakerArtMilestone(story, tooSoon),
+  selectStorybookArtMilestone(story, tooSoon),
   null,
   'Opening art must enforce the minimum beat cooldown',
 )
@@ -99,7 +99,7 @@ assert.equal(
 const castIntro = storyBeat('s2c', 'Mara Vale steps from the smoke and raises a lantern.')
 story = storySession([opening, quiet, castIntro])
 assert.equal(
-  selectStorymakerArtMilestone(story, castIntro),
+  selectStorybookArtMilestone(story, castIntro),
   'character-introduction',
   'A selected cast member appearing for the first time should qualify',
 )
@@ -112,7 +112,7 @@ story = storySession([
   chapterBeat,
 ])
 assert.equal(
-  selectStorymakerArtMilestone(story, chapterBeat),
+  selectStorybookArtMilestone(story, chapterBeat),
   'chapter',
   'A deterministic chapter boundary should qualify',
 )
@@ -120,7 +120,7 @@ assert.equal(
 const locationBeat = storyBeat('s2l', 'They enter the observatory beyond the ridge.')
 story = storySession([opening, quiet, locationBeat])
 assert.equal(
-  selectStorymakerArtMilestone(story, locationBeat),
+  selectStorybookArtMilestone(story, locationBeat),
   'location',
   'A clear location transition should qualify when no stronger event applies',
 )
@@ -137,11 +137,11 @@ story = storySession([
   capped,
 ])
 assert.equal(
-  selectStorymakerArtMilestone(story, capped),
+  selectStorybookArtMilestone(story, capped),
   null,
-  'Storymaker must respect its intermediate-art limit',
+  'Storybook must respect its intermediate-art limit',
 )
-assert.equal(STORYMAKER_INTERMEDIATE_ART_LIMIT, 2)
+assert.equal(STORYBOOK_INTERMEDIATE_ART_LIMIT, 2)
 assert.equal(MIN_BEATS_BETWEEN_ART, 2)
 
 function checkpoint(

--- a/utils/scripts/verifyNarrativeArtPersistence.mjs
+++ b/utils/scripts/verifyNarrativeArtPersistence.mjs
@@ -20,11 +20,11 @@ const controllerPath = 'composables/useNarrativeArtJobs.ts'
 const artStorePath = 'stores/artStore.ts'
 const enqueuePath = 'server/api/art/enqueue.post.ts'
 const recoveryPath = 'server/api/art/queue/narrative.get.ts'
-const storyStorePath = 'stores/storymakerStore.ts'
+const storyStorePath = 'stores/storybookStore.ts'
 const taskStorePath = 'stores/taskmasterStore.ts'
 const transcriptPath = 'components/narrative/narrative-transcript.vue'
 const statusPath = 'components/narrative/narrative-art-status.vue'
-const storyPagePath = 'components/conductor/storymaker-page.vue'
+const storyPagePath = 'components/conductor/storybook-page.vue'
 const taskPagePath = 'components/pages/taskmaster-page.vue'
 
 const profiles = source(profilesPath)
@@ -37,16 +37,16 @@ includesAll(profilesPath, [
   'steps: 4',
   "sampler: 'euler'",
   "scheduler: 'simple'",
-  "key: 'storymaker-narrative-krea4'",
-  "product: 'storymaker'",
-  "projectSlug: 'storymaker'",
+  "key: 'storybook-narrative-krea4'",
+  "product: 'storybook'",
+  "projectSlug: 'storybook'",
   "key: 'taskmaster-narrative-krea4'",
   "product: 'taskmaster'",
   "projectSlug: 'taskmaster'",
 ])
 
-const storymakerProfile = profiles.slice(
-  profiles.indexOf('  storymaker: {'),
+const storybookProfile = profiles.slice(
+  profiles.indexOf('  storybook: {'),
   profiles.indexOf('  taskmaster: {'),
 )
 const taskmasterProfile = profiles.slice(
@@ -54,7 +54,7 @@ const taskmasterProfile = profiles.slice(
   profiles.indexOf('\n  },\n}', profiles.indexOf('  taskmaster: {')) + 5,
 )
 for (const [label, profile] of [
-  ['Storymaker', storymakerProfile],
+  ['Storybook', storybookProfile],
   ['Taskmaster', taskmasterProfile],
 ]) {
   assert.ok(

--- a/utils/scripts/verifyNarrativeKit.ts
+++ b/utils/scripts/verifyNarrativeKit.ts
@@ -114,7 +114,7 @@ for (const [path, source] of [
 // REGRESSION (a surface dropping back to a hand-rolled loop) is visible in CI
 // output rather than silent.
 const SURFACES = [
-  'components/conductor/storymaker-page.vue',
+  'components/conductor/storybook-page.vue',
   'components/pages/taskmaster-page.vue',
   'components/bots/bot-interact.vue',
   'components/rewards/reward-interact.vue',
@@ -136,7 +136,7 @@ const KIT_USE =
 /*
  * Count TRANSITIVE adoption, one level deep.
  *
- * Storymaker and Taskmaster reach the kit through kr-narrator-stage rather than
+ * Storybook and Taskmaster reach the kit through kr-narrator-stage rather than
  * mounting it themselves, and a counter that missed that would report 0/7 while
  * the components were demonstrably live in both render paths -- understating
  * progress and, worse, hiding a regression if the stage stopped using them.

--- a/utils/scripts/verifyNarrativePrimitives.mjs
+++ b/utils/scripts/verifyNarrativePrimitives.mjs
@@ -62,14 +62,14 @@ assert.ok(
 )
 
 const taskmasterStore = source('stores/taskmasterStore.ts')
-const storymakerPage = source('components/conductor/storymaker-page.vue')
+const storybookPage = source('components/conductor/storybook-page.vue')
 assert.ok(
   taskmasterStore.includes("defineStore('taskmasterStore'"),
   'Taskmaster must retain its own product store',
 )
 assert.ok(
-  !storymakerPage.includes('useTaskmasterStore'),
-  'Storymaker must not inherit the Taskmaster state machine',
+  !storybookPage.includes('useTaskmasterStore'),
+  'Storybook must not inherit the Taskmaster state machine',
 )
 
 console.log(

--- a/utils/scripts/verifySerendipityRouteCutover.mjs
+++ b/utils/scripts/verifySerendipityRouteCutover.mjs
@@ -22,7 +22,7 @@ const channel = fs.readFileSync(channelPath, 'utf8')
 const component = fs.readFileSync(componentPath, 'utf8')
 const dashboard = fs.readFileSync('stores/helpers/dashboardHelper.ts', 'utf8')
 const voiceLab = fs.readFileSync('components/conductor/voice-lab-page.vue', 'utf8')
-const boundary = fs.readFileSync('docs/products/storymaker-taskmaster-boundary.md', 'utf8')
+const boundary = fs.readFileSync('docs/products/storybook-taskmaster-boundary.md', 'utf8')
 
 assert.match(root, /^title: Serendipity$/m)
 assert.match(root, /^tabKey: serendipity$/m)

--- a/utils/scripts/verifyStorybookBranchState.mjs
+++ b/utils/scripts/verifyStorybookBranchState.mjs
@@ -1,4 +1,4 @@
-// /utils/scripts/verifyStorymakerBranchState.mjs
+// /utils/scripts/verifyStorybookBranchState.mjs
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -14,17 +14,17 @@ function includesAll(path, values) {
   }
 }
 
-const storePath = 'stores/storymakerStore.ts'
-const pagePath = 'components/conductor/storymaker-page.vue'
-const panelPath = 'components/storymaker/storymaker-state-panel.vue'
+const storePath = 'stores/storybookStore.ts'
+const pagePath = 'components/conductor/storybook-page.vue'
+const panelPath = 'components/storybook/storybook-state-panel.vue'
 const transcriptPath = 'components/narrative/narrative-transcript.vue'
 const store = source(storePath)
 const page = source(pagePath)
 
 includesAll(storePath, [
-  'StorymakerBranchChoice',
-  'StorymakerConsequence',
-  'StorymakerInventoryItem',
+  'StorybookBranchChoice',
+  'StorybookConsequence',
+  'StorybookInventoryItem',
   'branchHistory: []',
   'consequences: []',
   'inventory: []',
@@ -46,15 +46,15 @@ includesAll(storePath, [
 
 assert.ok(
   !store.includes('useTaskmasterStore'),
-  'Storymaker state must remain independent from Taskmaster',
+  'Storybook state must remain independent from Taskmaster',
 )
 assert.ok(
   !store.includes('useTodoStore'),
-  'Storymaker inventory and consequences must remain fictional',
+  'Storybook inventory and consequences must remain fictional',
 )
 assert.ok(
   !store.includes("performFetch('/api/conductor"),
-  'Storymaker choices must not write to Conductor',
+  'Storybook choices must not write to Conductor',
 )
 
 includesAll(pagePath, [
@@ -62,7 +62,7 @@ includesAll(pagePath, [
   'store.setupDraft.rewardSlugs',
   'Possible story Rewards',
   'rewardStore.initialize({ fetchRemote: true })',
-  '<StorymakerStatePanel',
+  '<StorybookStatePanel',
   'rewards: selectedRewards.value.map(toIngredient)',
 ])
 
@@ -82,11 +82,11 @@ includesAll(transcriptPath, [
 
 assert.ok(
   !page.includes('applyWriteBack'),
-  'Storymaker state UI must not expose Taskmaster write-back controls',
+  'Storybook state UI must not expose Taskmaster write-back controls',
 )
 
 console.log(
-  'Storymaker branch-state contract passed: reader choices, constrained ' +
+  'Storybook branch-state contract passed: reader choices, constrained ' +
     'fictional consequences, selected Reward inventory, saved-session migration, ' +
     'hidden state metadata, and the Taskmaster/write-back boundary are present.',
 )

--- a/utils/scripts/verifyStorybookSessionLibrary.mjs
+++ b/utils/scripts/verifyStorybookSessionLibrary.mjs
@@ -1,4 +1,4 @@
-// /utils/scripts/verifyStorymakerSessionLibrary.mjs
+// /utils/scripts/verifyStorybookSessionLibrary.mjs
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -14,17 +14,17 @@ function includesAll(path, values) {
   }
 }
 
-const libraryPath = 'composables/useStorymakerLibrary.ts'
-const shellPath = 'components/pages/storymaker-library-page.vue'
-const contentPath = 'content/storymaker.md'
-const storePath = 'stores/storymakerStore.ts'
+const libraryPath = 'composables/useStorybookLibrary.ts'
+const shellPath = 'components/pages/storybook-library-page.vue'
+const contentPath = 'content/storybook.md'
+const storePath = 'stores/storybookStore.ts'
 
 const library = source(libraryPath)
 const shell = source(shellPath)
 const store = source(storePath)
 
 includesAll(libraryPath, [
-  "const LIBRARY_STORAGE_KEY = 'storymaker-session-library-v1'",
+  "const LIBRARY_STORAGE_KEY = 'storybook-session-library-v1'",
   'const MAX_LIBRARY_SESSIONS = 20',
   'entry.userId === userId',
   'function openStory(',
@@ -64,11 +64,11 @@ assert.ok(
   !library.includes('useTaskmasterStore') &&
     !library.includes('useTodoStore') &&
     !library.includes('useConductorStore'),
-  'Storymaker lifecycle management must remain fiction-only',
+  'Storybook lifecycle management must remain fiction-only',
 )
 
 includesAll(shellPath, [
-  '<StorymakerPage />',
+  '<StorybookPage />',
   'Story library',
   'Recent stories',
   'library.openStory(',
@@ -82,23 +82,23 @@ includesAll(shellPath, [
   'library.archiveCurrent()',
 ])
 
-includesAll(contentPath, [':storymaker-library-page'])
+includesAll(contentPath, [':storybook-library-page'])
 assert.ok(
-  !source(contentPath).includes(':storymaker-page\n'),
+  !source(contentPath).includes(':storybook-page\n'),
   'The route must mount the lifecycle shell instead of bypassing it',
 )
 
 includesAll(storePath, [
-  "defineStore('storymakerStore'",
+  "defineStore('storybookStore'",
   'resumeNarrativeArtJobs',
   'retryBeatArt',
   'beginStory',
 ])
 assert.ok(
-  !store.includes('storymaker-session-library-v1'),
+  !store.includes('storybook-session-library-v1'),
   'The proven generation store must remain independent from library presentation state',
 )
 
 console.log(
-  'Storymaker session-library contract passed: account-scoped recent stories, direct-open, safe duplicate identities, restart, export, and generation-store separation are present.',
+  'Storybook session-library contract passed: account-scoped recent stories, direct-open, safe duplicate identities, restart, export, and generation-store separation are present.',
 )

--- a/utils/scripts/verifyStorybookStudio.mjs
+++ b/utils/scripts/verifyStorybookStudio.mjs
@@ -1,4 +1,4 @@
-// /utils/scripts/verifyStorymakerStudio.mjs
+// /utils/scripts/verifyStorybookStudio.mjs
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -14,8 +14,8 @@ function includesAll(path, values) {
   }
 }
 
-const pagePath = 'components/conductor/storymaker-page.vue'
-const storePath = 'stores/storymakerStore.ts'
+const pagePath = 'components/conductor/storybook-page.vue'
+const storePath = 'stores/storybookStore.ts'
 const page = source(pagePath)
 const store = source(storePath)
 
@@ -32,23 +32,23 @@ includesAll(pagePath, [
 
 assert.ok(
   !page.includes('<ProjectFrontPage'),
-  'Storymaker must be a dedicated studio rather than a project landing card',
+  'Storybook must be a dedicated studio rather than a project landing card',
 )
 assert.ok(
   !page.includes("navigateTo('/stories"),
-  'Storymaker must not forward its primary flow to the generic Stories studio',
+  'Storybook must not forward its primary flow to the generic Stories studio',
 )
 assert.ok(
   !page.includes('useTaskmasterStore'),
-  'Storymaker must not import Taskmaster state',
+  'Storybook must not import Taskmaster state',
 )
 
 includesAll(storePath, [
-  "defineStore('storymakerStore'",
-  "const STORAGE_KEY = 'storymaker-session'",
-  "const DRAFT_STORAGE_KEY = 'storymaker-setup-draft'",
-  'StorymakerSetupDraft',
-  'StorymakerBible',
+  "defineStore('storybookStore'",
+  "const STORAGE_KEY = 'storybook-session'",
+  "const DRAFT_STORAGE_KEY = 'storybook-setup-draft'",
+  'StorybookSetupDraft',
+  'StorybookBible',
   'beginStory',
   'answerCurrentBeat',
   'finishStory',
@@ -57,15 +57,15 @@ includesAll(storePath, [
 
 assert.ok(
   !store.includes('useTaskmasterStore'),
-  'Storymaker store must not depend on Taskmaster',
+  'Storybook store must not depend on Taskmaster',
 )
 assert.ok(
   !store.includes('useTodoStore'),
-  'Storymaker store must not inherit task write-back behavior',
+  'Storybook store must not inherit task write-back behavior',
 )
 assert.ok(
   !store.includes('useConductorStore'),
-  'Storymaker store must not treat roadmap tasks as story state',
+  'Storybook store must not treat roadmap tasks as story state',
 )
 
 includesAll('components/narrative/narrative-ingredient-multi-picker.vue', [
@@ -75,7 +75,7 @@ includesAll('components/narrative/narrative-ingredient-multi-picker.vue', [
 ])
 
 console.log(
-  'Storymaker studio contract passed: dedicated progressive setup, reusable ' +
+  'Storybook studio contract passed: dedicated progressive setup, reusable ' +
     'creative entities, story-bible review, persistent independent sessions, ' +
     'shared narrative presentation, and no Taskmaster/task-write boundary leak.',
 )


### PR DESCRIPTION
## Why

> *"I actually really like the Storybook theme, and think that it makes a better name than Storymaker, lets go with Storybook as the name of the route/app, that prolly means changing project name."*
> — Silas, 2026-08-02

Full rename, with the data **migrated** rather than aliased — his call when asked.

Conductor side: silasfelinus/conductor#…, opened alongside.

## What was counted first

Every persisted place the old name could appear was queried against production **before** writing the migration:

| | rows | |
|---|---|---|
| `ArtJob.projectSlug` | 0 | nothing to migrate |
| `Chat.channel` | 0 | nothing to migrate |
| `Project.slug` | **1** | **migrated** |
| `ArtImage.designer` | 4 | deliberately **not** migrated |
| `ArtCollection.slug` | 1 | deliberately **not** migrated |

The last two are **provenance, not product naming.** Those ArtImages carry `designer = 'folder-sync:storymaker'`, which `syncFolderCollection` derives from the collection slug, which mirrors a real directory — their `imagePath` values are `/images/artcollections/storymaker/*.webp` and the files physically exist there. Renaming those fields would make them describe a folder that doesn't exist without moving a single byte. `prisma/seeds/inspiration-prompts.ts` is left alone for the same reason and now says so in a comment.

If that media folder is ever renamed on the server, *that's* when those rows should follow — as a separate, deliberate change.

## The migration touches five columns, not two

Besides the obvious `slug` and `title`, the row carried the old name in three more places, and a partial rename would be worse than none:

- **`conductorSlug`** — what conductor's `sync_projects.py` matches on. Left stale, the next sync would look up `storybook`, miss, and **create a second project** rather than update this one.
- **`tabKey`** — points at a dashboard tab that the content rename removes.
- **`liveUrl`** — points at the redirect instead of the real route.

The conductor registry entry is renamed in the same change, because that entry is what the sync writes *from*.

**Rename and migration ship together on purpose:** `projectPlacements.ts` now keys on slug `storybook`, so a deploy where new code met an un-migrated row would simply fail to find the project. There's no window where they disagree.

## Route

`/storymaker` **301s** to `/storybook` via `routeRules`. The path was real and linkable; a rename shouldn't cost a bookmark.

## One thing the bulk substitution broke

It rewrote `RENAMED_THEMES` into `storybook: 'storybook'` — a self-mapping no-op that *also* dropped the `storymaker` entry now required, since the theme was named twice today (shipped `storybook` → renamed `storymaker` → back to `storybook`). Repaired by hand: it now maps `storymaker → storybook` and `storymaker-dark → storybook-dark`, with **no self-entry**, because a self-mapping looks like protection while providing none.

## Deliberately untouched

- **`apps/storymaker/`** — a separate Flutter app whose Android package is `org.kindrobots.storymaker`. Renaming that is an app-identity change with store implications, not a web route rename.
- `archives/`, `artifacts/`, generated wonderlab batches — records of what happened, skipped rather than falsified. The wonderlab manifest regenerates itself at build and already came back clean.

## Verification

- `vue-tsc --noEmit` — clean.
- **A real `nuxi build`** — both `[data-theme=storybook]` and `[data-theme=storybook-dark]` compile, **zero** stale `storymaker` selectors.
- `prisma migrate diff` against the pre-change schema returns *"This is an empty migration"* — confirming this is data-only, no DDL.
- `layout-contract` holds (one-header now down to **1**).
- `nav-manifest`, `channel-content`, `channel-resolver`, `data-surface-manifest`, `narrative-kit`, the three renamed Storybook contracts, narrative-art milestones, conductor registry and progress parity — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_