### PR TITLE
fix(layout): resolve the two no-viewport layout-contract violations

### DIFF
--- a/components/servers/chat-test.vue
+++ b/components/servers/chat-test.vue
@@ -480,7 +480,7 @@ function clear() {
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
   background: var(--bg);
   color: var(--text);
-  min-height: 100vh;
+  min-height: 480px;
   display: flex;
   flex-direction: column;
 }

--- a/components/wonderlab/new-eyeball.vue
+++ b/components/wonderlab/new-eyeball.vue
@@ -122,7 +122,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="flex items-center justify-center h-screen">
+  <div class="flex h-full min-h-[320px] items-center justify-center">
     <div
       class="bg-white rounded-full overflow-hidden shadow relative aspect-w-1 aspect-h-1"
       :style="eyeballStyle"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -38,23 +38,20 @@
       "components/wonderlab/mural-manager.vue",
       "components/wonderlab/wonderlab-preview-host.vue"
     ],
-    "no-viewport": [
-      "components/servers/chat-test.vue",
-      "components/wonderlab/new-eyeball.vue"
-    ],
+    "no-viewport": [],
     "one-mdc": [
       "content/about.md",
       "content/conductor.md",
       "content/plan/wonderlab.md"
     ],
     "ghost-prop": [
-      "components/art/art-manager.vue \u2192 <art-gallery>",
-      "components/art/art-manager.vue \u2192 <art-test>",
-      "components/user/user-manager.vue \u2192 <chat-gallery>",
-      "components/user/user-manager.vue \u2192 <theme-gallery>",
-      "components/wonderlab/lab-manager.vue \u2192 <lab-interact>",
-      "components/wonderlab/lab-manager.vue \u2192 <memory-dungeon>",
-      "components/wonderlab/lab-manager.vue \u2192 <screen-fx>"
+      "components/art/art-manager.vue → <art-gallery>",
+      "components/art/art-manager.vue → <art-test>",
+      "components/user/user-manager.vue → <chat-gallery>",
+      "components/user/user-manager.vue → <theme-gallery>",
+      "components/wonderlab/lab-manager.vue → <lab-interact>",
+      "components/wonderlab/lab-manager.vue → <memory-dungeon>",
+      "components/wonderlab/lab-manager.vue → <screen-fx>"
     ],
     "zero-scroll": [
       "components/pages/conductor-art-gallery.vue",


### PR DESCRIPTION
### Task
interface-vision/t-017: sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software) — seventh scoped sweep

### What changed / what I produced
- `components/wonderlab/new-eyeball.vue`: replaced `h-screen` with `h-full min-h-[320px]` on the root wrapper.
- `components/servers/chat-test.vue`: replaced `min-height: 100vh` with a fixed `min-height: 480px` on `.stream-test`.
- Ratcheted `utils/scripts/layout-contract-baseline.json`'s `no-viewport` bucket from 2 → 0.

### How I verified
- Confirmed both components are NOT dead code before touching them: they're registered WonderLab "exhibit" components (`sourceKey` entries in `config/wonderlab-voice-polish-batch-*.json`) rendered dynamically and inline (not in an iframe) by `components/wonderlab/wonderlab-preview-host.vue`'s `<component :is="dynamicComponent">`. That harness wraps the mounted component in an auto-sized (`overflow-auto`, no fixed height) container, so a raw `h-screen`/`100vh` inside it fights the surrounding page's own `h-dvh` shell instead of sizing to its actual host — exactly the bug this rule exists to catch.
- `npx vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: no-viewport 2 → 0, all other buckets unchanged, contract holds.
- `npx eslint` on both changed files: pre-existing warnings/1 pre-existing error (`no-empty` in `chat-test.vue`) confirmed unrelated via `git stash` — untouched by this diff, out of scope for this sweep.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`ghost-prop` (7 entries) is the next smallest, easily-scoped remaining bucket after this sweep and after `one-mdc` (3) — both are single-digit and haven't been touched by any prior t-017 pass yet, unlike `one-scroll` which already has its own dedicated batch task (t-047).

### Notes for reviewer
`one-scroll` (33) is intentionally left alone here — it's the scope of the separate `interface-vision/t-047` batch task, not this sweep.


---
_Generated by [Claude Code](https://claude.ai/code/session_013rPDUa7GDr9CgyyndkzPh2)_