### PR TITLE
chore(test): remove dead entity-art source dump

### DIFF
--- a/utils/scripts/verifyEntityArtManager.ts
+++ b/utils/scripts/verifyEntityArtManager.ts
@@ -1,6 +1,5 @@
 // /utils/scripts/verifyEntityArtManager.ts
 import { readFileSync } from 'node:fs'
-import { gzipSync } from 'node:zlib'
 
 function read(path: string): string {
   return readFileSync(path, 'utf8')
@@ -13,74 +12,6 @@ function expectContains(path: string, needles: string[]): void {
       throw new Error(`${path} is missing required entity-art contract: ${needle}`)
     }
   }
-}
-
-function correctedComponent(source: string): string {
-  const presetAnchor = `const recreatePresets: GenerationPreset[] = [
-  {
-    key: 'quality',
-    label: 'Quality default',
-    description: 'Uses the current quality-focused workflow defaults.',
-  },
-`
-  const presetReplacement = `const qualityPreset: GenerationPreset = {
-  key: 'quality',
-  label: 'Quality default',
-  description: 'Uses the current quality-focused workflow defaults.',
-}
-const recreatePresets: GenerationPreset[] = [
-  qualityPreset,
-`
-  const selectedAnchor = `const selectedPreset = computed(
-  () =>
-    availablePresets.value.find((preset) => preset.key === presetKey.value) ||
-    availablePresets.value[0] ||
-    recreatePresets[0],
-)
-`
-  const selectedReplacement = `const selectedPreset = computed<GenerationPreset>(
-  () =>
-    availablePresets.value.find((preset) => preset.key === presetKey.value) ??
-    availablePresets.value[0] ??
-    qualityPreset,
-)
-`
-  if (!source.includes(presetAnchor) || !source.includes(selectedAnchor)) {
-    throw new Error('Entity art component TypeScript correction anchors changed.')
-  }
-  return source
-    .replace(presetAnchor, presetReplacement)
-    .replace(selectedAnchor, selectedReplacement)
-}
-
-function correctedService(source: string): string {
-  const importAnchor = `import type {
-  Prisma,
-  PrismaClient,
-} from '~/prisma/generated/prisma/client'
-`
-  const importReplacement = `import type { Prisma } from '~/prisma/generated/prisma/client'
-import type prisma from '~/server/utils/prisma'
-`
-  const dbAnchor = 'type EntityArtDb = PrismaClient | Prisma.TransactionClient\n'
-  const dbReplacement = `type EntityArtDb = Pick<
-  typeof prisma,
-  | 'bot'
-  | 'character'
-  | 'scenario'
-  | 'reward'
-  | 'facet'
-  | 'project'
-  | 'projectArtImage'
-  | 'artImage'
->
-`
-  if (!source.includes(importAnchor) || !source.includes(dbAnchor)) {
-    throw new Error('Entity art service TypeScript correction anchors changed.')
-  }
-  return source
-    .replace(importAnchor, importReplacement)
-    .replace(dbAnchor, dbReplacement)
 }
 
 expectContains('components/art/entity-art-manager.vue', [
@@ -164,17 +95,4 @@ for (const path of [
   expectContains(path, ['<EntityArtManager'])
 }
 
-const sourceBundle = gzipSync(
-  Buffer.from(
-    JSON.stringify({
-      component: correctedComponent(read('components/art/entity-art-manager.vue')),
-      service: correctedService(read('server/utils/entityArt.ts')),
-    }),
-  ),
-).toString('base64')
-const chunkSize = 2000
-for (let offset = 0, index = 0; offset < sourceBundle.length; offset += chunkSize, index += 1) {
-  console.log(`ENTITY_ART_SOURCE_${String(index).padStart(3, '0')}=${sourceBundle.slice(offset, offset + chunkSize)}`)
-}
-console.log(`ENTITY_ART_SOURCE_CHUNKS=${Math.ceil(sourceBundle.length / chunkSize)}`)
 console.log('Entity art manager contract verified.')


### PR DESCRIPTION
### Task
interface-vision/t-039: Clean up debug stdout noise in verifyEntityArtManager.ts (kind: software)

### What changed / what I produced
- Removed the unused gzip/base64 source-bundle construction and ENTITY_ART_SOURCE_* log output.
- Removed the correction helpers that existed only to build that unconsumed dump.
- Preserved every live entity-art assertion and the final verified signal.

### How I verified
- CI will run the entity-art manager contract, TypeScript, and the repository's required PR checks.

### Stakes
reversible

### Kaizen suggestion
Add a lightweight verifier-output convention so contract scripts emit one concise success line unless diagnostics are explicitly requested.

### Notes for reviewer
The removed payload was not consumed by the workflow or any comparison step; only the verifier exit code and assertions are operational.