### PR TITLE
fix(layout): wire up showHeader on 6 embedded components, zero ghost-prop

### DIFF
--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -5,6 +5,7 @@
   >
     <!-- ── Header ─────────────────────────────────────────────────────── -->
     <header
+      v-if="showHeader"
       class="shrink-0 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
     >
       <!-- Title + controls row -->
@@ -891,9 +892,11 @@ type GalleryCollection = ArtCollection & {
 const props = withDefaults(
   defineProps<{
     dropdownMode?: boolean
+    showHeader?: boolean
   }>(),
   {
     dropdownMode: false,
+    showHeader: true,
   },
 )
 

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -4,6 +4,8 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useArtStore } from '@/stores/artStore'
 import { useServerStore } from '@/stores/serverStore'
 
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
+
 type EndpointId = 'a1111' | 'sdxl' | 'flux' | 'kontext' | 'kombine'
 type EndpointMode = 'text' | 'remix' | 'combine'
 
@@ -710,6 +712,7 @@ onMounted(async () => {
 <template>
   <div class="flex min-h-full w-full flex-col gap-6">
     <div
+      v-if="showHeader"
       class="rounded-2xl border border-base-300 bg-base-200 p-4 shadow-lg md:p-6"
     >
       <div

--- a/components/screenfx/screen-fx.vue
+++ b/components/screenfx/screen-fx.vue
@@ -3,7 +3,7 @@
   <section class="screen-fx-shell">
     <div class="fx-panel">
       <div class="fx-header">
-        <div class="fx-title">
+        <div v-if="showHeader" class="fx-title">
           <span class="fx-logo">
             <Icon name="kind-icon:sparkles" class="h-7 w-7" />
           </span>
@@ -166,6 +166,8 @@ import {
   type FxPlacementState,
 } from '@/stores/animationStore'
 import type { AnimationEffectId, FxRegion } from '@/stores/animationCatalog'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
 
 const animationStore = useAnimationStore()
 

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -9,7 +9,7 @@
       <div
         class="flex flex-col gap-3 bg-linear-to-br from-primary/12 via-secondary/10 to-accent/10 p-3 lg:flex-row lg:items-center lg:justify-between"
       >
-        <div class="flex min-w-0 items-center gap-3">
+        <div v-if="showHeader" class="flex min-w-0 items-center gap-3">
           <span
             class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-primary/25 bg-primary/15 text-primary shadow-sm"
           >
@@ -397,6 +397,8 @@
 import { computed, onMounted, ref } from 'vue'
 import { useAchievementStore } from '@/stores/achievementStore'
 import { useThemeStore, type Theme } from '@/stores/themeStore'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
 
 type ThemeFilter = 'all' | 'default' | 'shared'
 

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -5,7 +5,7 @@
   >
     <header class="flex shrink-0 flex-col gap-3">
       <div class="flex items-start justify-between gap-3">
-        <div class="flex flex-col gap-1">
+        <div v-if="showHeader" class="flex flex-col gap-1">
           <p class="text-xs font-bold uppercase tracking-wide text-primary">
             Message Timeline
           </p>
@@ -300,6 +300,8 @@
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useChatStore } from '@/stores/chatStore'
 import { useUserStore } from '@/stores/userStore'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
 
 type ChatActorKind =
   'user' | 'bot' | 'character' | 'dream' | 'system' | 'unknown'

--- a/components/wonderlab/lab-interact.vue
+++ b/components/wonderlab/lab-interact.vue
@@ -6,7 +6,7 @@
     <header
       class="grid shrink-0 grid-cols-1 gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 xl:grid-cols-[auto_minmax(0,1fr)_auto]"
     >
-      <div class="flex items-center gap-3">
+      <div v-if="showHeader" class="flex items-center gap-3">
         <div
           class="flex h-14 w-14 items-center justify-center rounded-2xl border-2 border-accent bg-accent/10"
         >
@@ -542,6 +542,8 @@ import {
   type WonderLabReviewFilter,
   type WonderLabStatusFilter,
 } from '@/utils/wonderlab/museumQuery'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
 
 const statusOptions: Array<{
   value: ComponentStatus

--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -4,10 +4,7 @@
       v-if="activeTab === 'memory-dungeon'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
     >
-      <memory-dungeon
-        class="h-full min-h-0 flex-1 overflow-hidden"
-        :show-header="false"
-      />
+      <memory-dungeon class="h-full min-h-0 flex-1 overflow-hidden" />
     </section>
 
     <section

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -44,15 +44,7 @@
       "content/conductor.md",
       "content/plan/wonderlab.md"
     ],
-    "ghost-prop": [
-      "components/art/art-manager.vue → <art-gallery>",
-      "components/art/art-manager.vue → <art-test>",
-      "components/user/user-manager.vue → <chat-gallery>",
-      "components/user/user-manager.vue → <theme-gallery>",
-      "components/wonderlab/lab-manager.vue → <lab-interact>",
-      "components/wonderlab/lab-manager.vue → <memory-dungeon>",
-      "components/wonderlab/lab-manager.vue → <screen-fx>"
-    ],
+    "ghost-prop": [],
     "zero-scroll": [
       "components/pages/conductor-art-gallery.vue",
       "components/pages/kaizen-popup.vue",


### PR DESCRIPTION
### Task
interface-vision/t-017 (conductor): Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

### What changed / what I produced
- `art-manager.vue`, `user-manager.vue`, and `lab-manager.vue` pass `:show-header="false"` to six embedded components (`art-gallery`, `art-test`, `chat-gallery`, `theme-gallery`, `lab-interact`, `screen-fx`) when mounting them as manager tabs, but none of the six ever declared a `showHeader` prop. Vue silently drops undeclared props as fallthrough attributes, so each still rendered its own duplicate title bar inside the manager — a real bug, not just dead code.
- Added `showHeader?: boolean` (default `true`) to each of the six components and gated only the title-only portion of their headers behind it, leaving embedded functional controls (search inputs, the chat "Back" button, WonderLab stat cards, the admin "Reconcile" dropdown, the effect-count/"Manage builds" link) always visible.
- `memory-dungeon.vue`'s `:show-header="false"` pass was a different case: its `<header>` is a gameplay HUD gated on `gameStarted` (lives, score, difficulty picker, deck picker), not a duplicate title — the prop pass was genuinely dead. Removed it from `lab-manager.vue` rather than adding unrelated plumbing to fake-wire it.
- Ratcheted the layout-contract `ghost-prop` allow-list from 7 → 0 via `--update`.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npm run test:layout-contract` — holds, ghost-prop now 0, no other bucket regressed (one-scroll unchanged at 33, confirming no new overflow regions were added).
- `npx eslint` on every changed file — clean except two pre-existing `no-dynamic-delete` errors in `art-gallery.vue` that I confirmed are present on `origin/main` before my change (unrelated to this diff).
- Reverted an incidental `prisma/generated/prisma/internal/class.ts` diff produced by local `prisma generate` during dependency provisioning — not part of this change.

### Stakes
reversible

### Flags for Reviewer
- I split each flagged header into "title block" vs. "functional controls" rather than gating the whole `<header>`, since several (chat-gallery's back button + search, theme-gallery's search/filter row, lab-interact's stat cards + admin actions, screen-fx's effect count/manage-builds link) are real functionality that would otherwise disappear when embedded. Worth a second look that this split matches intent.
- No Vercel preview check this session (text-only layout change, verified via typecheck + the layout-contract script instead).

### Kaizen suggestion
The `one-scroll` bucket (33 entries) is now the largest remaining allow-list bucket and worth a dedicated future t-017 sweep — many entries look like the same "manager shell + one embedded gallery, both independently scrolling" shape seen here, which might fix in clusters rather than one-by-one.

### Notes for reviewer
Remaining after this PR: one-scroll (33), one-mdc (3), zero-scroll (7). one-header and no-viewport are already at 0 from prior sweeps. Conductor roadmap task interface-vision/t-017 will be updated to reflect this pass and re-armed to `ready` (recurring sweep, not yet at zero across all buckets).


---
_Generated by [Claude Code](https://claude.ai/code/session_012ytzMRJaw75c59AY7Nyzcs)_