### PR TITLE
fix(layout): reduce About page to one MDC mount

### DIFF
--- a/components/pages/sponsor-page.vue
+++ b/components/pages/sponsor-page.vue
@@ -1,6 +1,8 @@
 <!-- /components/content/butterfly/sponsor-page.vue -->
 <template>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div
+    class="h-full min-h-0 overflow-y-auto max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
+  >
     <div
       class="bg-base-300 p-6 rounded-lg shadow-xl text-center text-default space-y-6"
     >

--- a/content/about.md
+++ b/content/about.md
@@ -18,4 +18,3 @@ refreshLabel: Refresh mission statement
 ---
 
 :about-page
-:sponsor-page

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -40,7 +40,6 @@
     ],
     "no-viewport": [],
     "one-mdc": [
-      "content/about.md",
       "content/conductor.md",
       "content/plan/wonderlab.md"
     ],


### PR DESCRIPTION
## Summary
- remove the secondary `:sponsor-page` mount from `content/about.md`
- keep the About route focused on its canonical About page component
- ratchet the layout-contract `one-mdc` allow-list from 3 entries to 2

## Why
The shared content host owns page composition and the layout contract requires one mounted component per MDC page. About was mounting two independent full-page components, creating competing page layouts inside one shell.

## Validation
- Layout Contract
- TypeScript
- Contract Tests
- standard repository PR checks

Conductor: `interface-vision/t-017`
Session: `2026-08-02T112810Z-interface-vision-t-017-r4n8`