### PR TITLE
fix(layout): zero the one-mdc layout-contract bucket

### DIFF
--- a/components/conductor/plan-projects-grid.vue
+++ b/components/conductor/plan-projects-grid.vue
@@ -1,9 +1,10 @@
-<!-- /components/pages/plan-projects-grid.vue -->
+<!-- /components/conductor/plan-projects-grid.vue -->
 <!--
   In-page directory of the Plan → Projects sub-items (the third nav level).
   Sourced directly from the content pages under /plan/projects/, so adding or
   removing a pitch page is the single source of truth — no separate registry.
-  Embedded via the `:plan-projects-grid` MDC directive in content/conductor.md.
+  Nested inside components/pages/conductor-manager.vue (the sole MDC mount for
+  content/conductor.md — see interface-vision/t-017's one-mdc sweep).
 -->
 <template>
   <section v-if="projects.length" class="mt-6 flex w-full flex-col gap-3">

--- a/components/pages/conductor-manager.vue
+++ b/components/pages/conductor-manager.vue
@@ -8,6 +8,7 @@
     />
     <ConductorProjectGalleryPage v-else-if="showConductorGallery" />
     <ConductorPage v-else />
+    <PlanProjectsGrid />
   </div>
 </template>
 
@@ -17,6 +18,7 @@ import AppmakerPage from '@/components/pages/appmaker-page.vue'
 import ConductorProjectGalleryPage from '@/components/pages/conductor-project-gallery-page.vue'
 import ConductorPage from '@/components/pages/conductor-page.vue'
 import ConductorPitchManager from '@/components/pages/conductor-pitch-manager.vue'
+import PlanProjectsGrid from '@/components/conductor/plan-projects-grid.vue'
 import PortosPage from '@/components/pages/portos-page.vue'
 import WishmasterPage from '@/components/pages/wishmaster-page.vue'
 import { usePageStore } from '@/stores/pageStore'

--- a/components/wonderlab/lab-manager.vue
+++ b/components/wonderlab/lab-manager.vue
@@ -1,5 +1,7 @@
 <template>
   <section class="flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <ComponentRegistryHealth v-if="isWonderlabRoute" class="shrink-0" />
+
     <section
       v-if="activeTab === 'memory-dungeon'"
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
@@ -50,6 +52,7 @@ import { useRoute } from 'vue-router'
 import { useNavStore } from '@/stores/navStore'
 
 import AnimationManager from '@/components/animation/animation-manager.vue'
+import ComponentRegistryHealth from '@/components/wonderlab/component-registry-health.vue'
 import LabInteract from '@/components/wonderlab/lab-interact.vue'
 import MemoryDungeon from '@/components/pages/memory-dungeon.vue'
 import ScreenFx from '@/components/screenfx/screen-fx.vue'
@@ -87,4 +90,15 @@ const activeTab = computed<LabTab>(() => {
 
   return fallbackTab
 })
+
+/*
+ * component-registry-health is content/plan/wonderlab.md's own museum-page
+ * panel, not a generic lab-manager feature — the other four content pages
+ * that mount :lab-manager (memory, screenfx, animation-manager, button) never
+ * showed it. Gate on the explicit route, not activeTab, so an unmapped page
+ * that happens to fall back to the 'wonder-lab' tab doesn't pick it up too.
+ */
+const isWonderlabRoute = computed(
+  () => route.path.replace(/\/+$/, '') === '/plan/wonderlab',
+)
 </script>

--- a/content/conductor.md
+++ b/content/conductor.md
@@ -17,5 +17,3 @@ refreshLabel: Refresh Plan
 ---
 
 :conductor-manager
-
-:plan-projects-grid

--- a/content/plan/wonderlab.md
+++ b/content/plan/wonderlab.md
@@ -18,6 +18,4 @@ loadingMessage: Loading the museum...
 refreshLabel: Refresh Museum
 ---
 
-:component-registry-health
-
 :lab-manager

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -37,10 +37,7 @@
       "components/wonderlab/wonderlab-preview-host.vue"
     ],
     "no-viewport": [],
-    "one-mdc": [
-      "content/conductor.md",
-      "content/plan/wonderlab.md"
-    ],
+    "one-mdc": [],
     "ghost-prop": [],
     "zero-scroll": [
       "components/pages/conductor-art-gallery.vue",

--- a/utils/scripts/verifyWonderLabRegistryHealth.ts
+++ b/utils/scripts/verifyWonderLabRegistryHealth.ts
@@ -143,12 +143,21 @@ assert.match(healthSource, /entriesBySourceKey/)
 assert.match(healthSource, /entriesBySourcePath/)
 assert.match(healthSource, /canonicalEntry \|\|/)
 
+// Semantic identity assertion, not an exact-mount lock: the layout-contract
+// (interface-vision/t-017, one-mdc rule) forbids a content page from mounting
+// more than one MDC component, so component-registry-health is nested inside
+// lab-manager.vue's own template (gated to the /plan/wonderlab route, since
+// lab-manager is reused by four other content pages that never showed it)
+// rather than mounted a second time directly from the .md file.
 const contentSource = await readFile('content/plan/wonderlab.md', 'utf8')
-assert.match(contentSource, /:component-registry-health/)
 assert.match(contentSource, /:lab-manager/)
-assert.ok(
-  contentSource.indexOf(':component-registry-health') <
-    contentSource.indexOf(':lab-manager'),
+assert.doesNotMatch(contentSource, /:component-registry-health/)
+
+const labManagerSource = await readFile(
+  'components/wonderlab/lab-manager.vue',
+  'utf8',
 )
+assert.match(labManagerSource, /ComponentRegistryHealth/)
+assert.match(labManagerSource, /\/plan\/wonderlab/)
 
 console.log('WonderLab canonical registry health verification passed.')


### PR DESCRIPTION
### Task
interface-vision/t-017: ninth scoped layout-contract sweep — zero the `one-mdc` bucket (kind: software)

### What changed / what I produced
- `content/conductor.md` mounted both `:conductor-manager` and `:plan-projects-grid`. Moved `plan-projects-grid.vue` out of `components/pages/` (so it's no longer classified as a standalone "page" component by the layout-contract verifier) into `components/conductor/`, and nested it inside `conductor-manager.vue`'s own template instead of a second top-level MDC directive. Behavior is unchanged — it's still rendered unconditionally below whichever sub-view `conductor-manager` shows.
- `content/plan/wonderlab.md` mounted both `:component-registry-health` and `:lab-manager`. Nested `component-registry-health.vue` inside `lab-manager.vue`, gated on the literal `/plan/wonderlab` route (not just the `wonder-lab` tab) since `lab-manager.vue` is reused by four other content pages (`memory`, `screenfx`, `animation-manager`, `button`) that never showed that panel — gating on the explicit route reproduces the exact prior scoping.
- Ratcheted `utils/scripts/layout-contract-baseline.json`: `one-mdc` 2 → 0. All other buckets unchanged (`one-scroll` 31, `zero-scroll` 6).

### How I verified
- `npm run test:layout-contract -- --report` (locally provisioned deps): `one-mdc` 0, no other bucket regressed.
- `npx vue-tsc --noEmit`: clean.
- `npx eslint` on all touched files: 0 errors.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`one-scroll` (31 entries) is by far the largest remaining bucket and already has its own tracking task (interface-vision/t-047) — no new suggestion needed here.

### Notes for reviewer
Companion conductor PR tracks the roadmap `status: review` update for interface-vision/t-017.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBncnKe2fs1dQf2c3MLM78)_