### PR TITLE
fix(layout): zero the zero-scroll layout-contract bucket

### DIFF
--- a/.github/workflows/entity-art-manager-contract.yml
+++ b/.github/workflows/entity-art-manager-contract.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - 'components/art/entity-art-manager.vue'
-      - 'components/pages/conductor-art-gallery.vue'
+      - 'components/conductor/conductor-art-gallery.vue'
       - 'components/bots/bot-interact.vue'
       - 'components/characters/character-interact.vue'
       - 'components/scenarios/scenario-interact.vue'

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="mx-auto flex h-full min-h-0 w-full max-w-6xl flex-col gap-4 overflow-y-auto overscroll-contain p-3"
+    class="mx-auto flex w-full max-w-6xl flex-col gap-4 p-3"
   >
     <header class="flex flex-wrap items-center justify-between gap-2">
       <div>

--- a/components/conductor/conductor-art-gallery.vue
+++ b/components/conductor/conductor-art-gallery.vue
@@ -1,4 +1,4 @@
-<!-- /components/pages/conductor-art-gallery.vue -->
+<!-- /components/conductor/conductor-art-gallery.vue -->
 <template>
   <section
     class="flex min-h-0 min-w-0 flex-col gap-3 overflow-x-hidden rounded-2xl border border-base-300 bg-base-100 p-4"

--- a/components/conductor/kaizen-popup.vue
+++ b/components/conductor/kaizen-popup.vue
@@ -1,4 +1,4 @@
-<!-- /components/pages/kaizen-popup.vue -->
+<!-- /components/conductor/kaizen-popup.vue -->
 <!-- A small trigger chip + modal explaining the Kaizen principle the
      project system is founded on. Drop-in anywhere on the conductor pages. -->
 <template>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -1393,9 +1393,9 @@ import {
   placementLiveUrl,
 } from '~/utils/projectPlacements'
 import type { BuilderCard } from '@/stores/helpers/builderCards'
-import ConductorArtGallery from '@/components/pages/conductor-art-gallery.vue'
+import ConductorArtGallery from '@/components/conductor/conductor-art-gallery.vue'
 import ConductorProjectChat from '@/components/pages/conductor-project-chat.vue'
-import KaizenPopup from '@/components/pages/kaizen-popup.vue'
+import KaizenPopup from '@/components/conductor/kaizen-popup.vue'
 import SnapshotModeBanner from '@/components/navigation/snapshot-mode-banner.vue'
 
 type ProjectStatus = 'ACTIVE' | 'PAUSED' | 'DONE' | 'ARCHIVED' | 'BRAINSTORM'

--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -1,129 +1,139 @@
 <!-- /components/content/weird/rebel-button.vue -->
 <template>
-  <div
-    class="hero flex flex-col items-center justify-center bg-base-300 rounded-2xl border m-2 h-full w-full"
-  >
-    <div
-      class="flex flex-col md:flex-row items-center justify-center w-full h-full space-y-4 md:space-y-0 md:space-x-4"
-    >
-      <!-- Left Section -->
-      <div class="flex flex-col items-center w-full md:w-1/3 space-y-4 m-2 p-2">
-        <div class="bg-base-300 p-4 rounded-lg shadow-lg">
-          <click-leaderboard class="rounded-2xl m-2 p-2" />
-        </div>
-        <transition name="slide-fade-slow">
-          <div
-            v-if="state.topScore >= 100"
-            class="bg-base-300 p-4 rounded-lg shadow-lg"
-          ></div>
-        </transition>
-        <transition name="slide-fade">
-          <div
-            v-if="state.topScore >= 20 && state.pressCount >= 1"
-            class="bg-accent p-4 rounded-lg shadow-lg border m-2"
-          >
-            <h2 class="text-xl">Last Achievement</h2>
-            <p class="text-lg">
-              {{ state.lastAchievement }}
-            </p>
-          </div>
-        </transition>
-        <transition name="slide-fade-slow">
-          <div
-            v-if="state.topScore >= 21 && state.pressCount >= 1"
-            class="bg-base-300 p-4 rounded-lg shadow-lg border m-2"
-          >
-            <p class="text-lg">Previous message: {{ state.previousMessage }}</p>
-          </div>
-        </transition>
-      </div>
-
-      <!-- Center Section -->
-      <div class="flex flex-col items-center w-full md:w-1/3 space-y-4">
+  <main class="kr-surface">
+    <div class="kr-scroll">
+      <div
+        class="hero flex flex-col items-center justify-center bg-base-300 rounded-2xl border m-2 min-h-full w-full"
+      >
         <div
-          ref="buttonRef"
-          :class="`button w-full h-60 rounded-lg flex items-center justify-center transition text-2xl border font-bold shadow-lg p-2 ${
-            state.pressed ? 'bg-accent text-default' : 'bg-primary text-default'
-          }`"
-          @click="pressedButton"
+          class="flex flex-col md:flex-row items-center justify-center w-full h-full space-y-4 md:space-y-0 md:space-x-4"
         >
-          {{ state.buttonText }}
-        </div>
-        <div v-if="state.pressed" class="text-center">
-          <button
-            class="text-blue-500 p-2 rounded-lg mb-4"
-            @click="openResetPopup"
+          <!-- Left Section -->
+          <div
+            class="flex flex-col items-center w-full md:w-1/3 space-y-4 m-2 p-2"
           >
-            Reset
-          </button>
-          <p class="text-lg">
-            Button has been pressed {{ state.pressCount }} times.
-          </p>
-        </div>
-      </div>
+            <div class="bg-base-300 p-4 rounded-lg shadow-lg">
+              <click-leaderboard class="rounded-2xl m-2 p-2" />
+            </div>
+            <transition name="slide-fade-slow">
+              <div
+                v-if="state.topScore >= 100"
+                class="bg-base-300 p-4 rounded-lg shadow-lg"
+              ></div>
+            </transition>
+            <transition name="slide-fade">
+              <div
+                v-if="state.topScore >= 20 && state.pressCount >= 1"
+                class="bg-accent p-4 rounded-lg shadow-lg border m-2"
+              >
+                <h2 class="text-xl">Last Achievement</h2>
+                <p class="text-lg">
+                  {{ state.lastAchievement }}
+                </p>
+              </div>
+            </transition>
+            <transition name="slide-fade-slow">
+              <div
+                v-if="state.topScore >= 21 && state.pressCount >= 1"
+                class="bg-base-300 p-4 rounded-lg shadow-lg border m-2"
+              >
+                <p class="text-lg">
+                  Previous message: {{ state.previousMessage }}
+                </p>
+              </div>
+            </transition>
+          </div>
 
-      <!-- Right Section -->
-      <div class="flex flex-col items-center w-full md:w-1/3 space-y-4">
+          <!-- Center Section -->
+          <div class="flex flex-col items-center w-full md:w-1/3 space-y-4">
+            <div
+              ref="buttonRef"
+              :class="`button w-full h-60 rounded-lg flex items-center justify-center transition text-2xl border font-bold shadow-lg p-2 ${
+                state.pressed
+                  ? 'bg-accent text-default'
+                  : 'bg-primary text-default'
+              }`"
+              @click="pressedButton"
+            >
+              {{ state.buttonText }}
+            </div>
+            <div v-if="state.pressed" class="text-center">
+              <button
+                class="text-blue-500 p-2 rounded-lg mb-4"
+                @click="openResetPopup"
+              >
+                Reset
+              </button>
+              <p class="text-lg">
+                Button has been pressed {{ state.pressCount }} times.
+              </p>
+            </div>
+          </div>
+
+          <!-- Right Section -->
+          <div class="flex flex-col items-center w-full md:w-1/3 space-y-4">
+            <transition name="slide-fade">
+              <div
+                v-if="state.showLeaderboard && state.topScore >= 10"
+                class="bg-accent p-4 rounded-lg shadow-lg border m-2"
+              >
+                <h2 class="text-2xl mb-2">Leaderboard</h2>
+                <p class="text-lg">Top Score: {{ state.topScore }}</p>
+              </div>
+            </transition>
+            <transition name="slide-fade-slow">
+              <div
+                v-if="state.topScore >= 30"
+                class="bg-base-300 p-4 rounded-lg shadow-lg border m-2"
+              >
+                <!-- Butterfly Toggle Component -->
+                You've unlocked our mascot AMI - The Anti-Malaria Intelligence.
+                AMI's job is to flutter around (for now), but eventually she'll
+                help raise funds to fight malaria.
+                <swarm-icon />
+              </div>
+            </transition>
+            <transition name="slide-fade-slow">
+              <div
+                v-if="state.topScore >= 40"
+                class="bg-base-300 p-4 rounded-lg shadow-lg border m-2"
+              >
+                <!-- Theme Select -->
+                Feel free to change the theme!
+                <theme-toggle />
+              </div>
+            </transition>
+          </div>
+        </div>
+        <!-- Reset Popup -->
         <transition name="slide-fade">
           <div
-            v-if="state.showLeaderboard && state.topScore >= 10"
-            class="bg-accent p-4 rounded-lg shadow-lg border m-2"
+            v-if="state.showResetPopup"
+            class="fixed top-0 left-0 w-full h-full flex items-center justify-center bg-opacity-50 bg-black"
+            @click.self="state.showResetPopup = false"
           >
-            <h2 class="text-2xl mb-2">Leaderboard</h2>
-            <p class="text-lg">Top Score: {{ state.topScore }}</p>
-          </div>
-        </transition>
-        <transition name="slide-fade-slow">
-          <div
-            v-if="state.topScore >= 30"
-            class="bg-base-300 p-4 rounded-lg shadow-lg border m-2"
-          >
-            <!-- Butterfly Toggle Component -->
-            You've unlocked our mascot AMI - The Anti-Malaria Intelligence.
-            AMI's job is to flutter around (for now), but eventually she'll help
-            raise funds to fight malaria.
-            <swarm-icon />
-          </div>
-        </transition>
-        <transition name="slide-fade-slow">
-          <div
-            v-if="state.topScore >= 40"
-            class="bg-base-300 p-4 rounded-lg shadow-lg border m-2"
-          >
-            <!-- Theme Select -->
-            Feel free to change the theme!
-            <theme-toggle />
+            <div class="bg-white p-4 rounded-lg">
+              <p>Are you sure you want to reset the leaderboard?</p>
+              <div class="flex justify-end space-x-4 mt-4">
+                <button
+                  class="bg-red-500 text-white px-4 py-2 rounded-lg"
+                  @click="state.showResetPopup = false"
+                >
+                  Cancel
+                </button>
+                <button
+                  class="bg-green-500 text-white px-4 py-2 rounded-lg"
+                  @click="reset"
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
           </div>
         </transition>
       </div>
     </div>
-    <!-- Reset Popup -->
-    <transition name="slide-fade">
-      <div
-        v-if="state.showResetPopup"
-        class="fixed top-0 left-0 w-full h-full flex items-center justify-center bg-opacity-50 bg-black"
-        @click.self="state.showResetPopup = false"
-      >
-        <div class="bg-white p-4 rounded-lg">
-          <p>Are you sure you want to reset the leaderboard?</p>
-          <div class="flex justify-end space-x-4 mt-4">
-            <button
-              class="bg-red-500 text-white px-4 py-2 rounded-lg"
-              @click="state.showResetPopup = false"
-            >
-              Cancel
-            </button>
-            <button
-              class="bg-green-500 text-white px-4 py-2 rounded-lg"
-              @click="reset"
-            >
-              Confirm
-            </button>
-          </div>
-        </div>
-      </div>
-    </transition>
-  </div>
+  </main>
 </template>
 
 <script setup lang="ts">

--- a/components/pages/social-page.vue
+++ b/components/pages/social-page.vue
@@ -1,4 +1,8 @@
 <!-- /components/content/pages/social-page.vue -->
 <template>
-  <kofi-link />
+  <main class="kr-surface">
+    <div class="kr-scroll">
+      <kofi-link />
+    </div>
+  </main>
 </template>

--- a/pages/auth/google.vue
+++ b/pages/auth/google.vue
@@ -1,6 +1,14 @@
 <!-- /pages/auth/google.vue -->
 <template>
-  <div class="text-center p-6 text-info">Logging you in via Google…</div>
+  <main class="kr-surface">
+    <div class="kr-scroll">
+      <div
+        class="flex min-h-full items-center justify-center p-6 text-center text-info"
+      >
+        Logging you in via Google…
+      </div>
+    </div>
+  </main>
 </template>
 
 <script setup lang="ts">

--- a/pages/build-bench.vue
+++ b/pages/build-bench.vue
@@ -4,7 +4,11 @@
   Thin wrapper around <BuildBench>; the whole surface is the two-panel bench.
 -->
 <template>
-  <BuildBench />
+  <main class="kr-surface">
+    <div class="kr-scroll">
+      <BuildBench />
+    </div>
+  </main>
 </template>
 
 <script setup lang="ts">

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -39,13 +39,6 @@
     "no-viewport": [],
     "one-mdc": [],
     "ghost-prop": [],
-    "zero-scroll": [
-      "components/pages/conductor-art-gallery.vue",
-      "components/pages/kaizen-popup.vue",
-      "components/pages/rebel-button.vue",
-      "components/pages/social-page.vue",
-      "pages/auth/google.vue",
-      "pages/build-bench.vue"
-    ]
+    "zero-scroll": []
   }
 }

--- a/utils/scripts/verifyEntityArtManager.ts
+++ b/utils/scripts/verifyEntityArtManager.ts
@@ -41,7 +41,7 @@ expectContains('server/utils/entityArt.ts', [
   'entityArtHistoryPrefix',
 ])
 
-expectContains('components/pages/conductor-art-gallery.vue', [
+expectContains('components/conductor/conductor-art-gallery.vue', [
   "'/api/art/enqueue'",
   "entityType: 'project'",
   'queued as ArtJob',
@@ -51,7 +51,7 @@ expectContains('components/pages/conductor-art-gallery.vue', [
   '/api/art/entities/project/${projectId}/replace',
 ])
 
-const projectGallerySource = read('components/pages/conductor-art-gallery.vue')
+const projectGallerySource = read('components/conductor/conductor-art-gallery.vue')
 for (const obsolete of [
   "'/api/conductor/art-request'",
   '/art/prepare-generation',

--- a/utils/scripts/verifyProjectArtPromptSuggest.ts
+++ b/utils/scripts/verifyProjectArtPromptSuggest.ts
@@ -13,7 +13,7 @@ function expectContains(path: string, needles: string[]): void {
   }
 }
 
-expectContains('components/pages/conductor-art-gallery.vue', [
+expectContains('components/conductor/conductor-art-gallery.vue', [
   'maxlength="4000"',
   'generationPrompt',
   'imagePath',


### PR DESCRIPTION
### Task
interface-vision/t-017: tenth scoped layout-contract sweep — zero the `zero-scroll` bucket (kind: software)

### What changed / what I produced
- `pages/auth/google.vue`, `pages/build-bench.vue`, `components/pages/social-page.vue`, `components/pages/rebel-button.vue`: each standalone page component now owns a real `kr-surface`/`kr-scroll` region instead of zero scroll declarations, matching the `email-confirmation.vue` precedent.
- `pages/build-bench.vue` / `components/art/build-bench.vue`: moved scroll ownership up to the page (the page was previously a bare wrapper around `BuildBench`, which owned the only scroll region itself) so there's exactly one scroll owner, not a redundant nested one.
- `components/pages/kaizen-popup.vue` → `components/conductor/kaizen-popup.vue` and `components/pages/conductor-art-gallery.vue` → `components/conductor/conductor-art-gallery.vue`: both are embedded widgets mounted inside `conductor-page.vue`, not standalone routed pages — they were only flagged because they lived under `components/pages/`. Relocated to `components/conductor/`, matching the convention `plan-projects-grid.vue` already established in an earlier t-017 sweep. Updated the import paths in `conductor-page.vue`, the two verifier scripts that reference the old path (`verifyEntityArtManager.ts`, `verifyProjectArtPromptSuggest.ts`), and the CI path filter in `entity-art-manager-contract.yml`.
- Ratcheted `zero-scroll` in `utils/scripts/layout-contract-baseline.json` from 6 → 0 via `--update`. All other buckets unchanged (`one-scroll` 31, tracked separately by its own task t-047).

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npm run test:layout-contract` — holds, zero-scroll 6 → 0, no new violations in any bucket
- `npx tsx utils/scripts/verifyEntityArtManager.ts` — passes (path update didn't break the contract check)
- `npx tsx utils/scripts/verifyProjectArtPromptSuggest.ts` — passes
- `npx tsx utils/scripts/verifyWonderLabCoverageClosureFixtures.ts` — passes (fixture registry keys on basename, unaffected by the directory move)
- `npx tsx utils/scripts/verifyAchievementCatalog.ts` — passes (confirms `rebel-button.vue` is still tracked correctly after its template edit)
- `npx eslint` on every touched file — clean
- Confirmed no other live code references the old `components/pages/{kaizen-popup,conductor-art-gallery}.vue` paths (two `config/wonderlab-voice-polish-batch-*.json` files cite the old path as a historical review-batch `sourceKey` snapshot — archival editorial data, not a live import, intentionally left as-is)

### Stakes
reversible

### Flags for Reviewer
- While investigating the zero-scroll bucket I noticed `components/pages/rebel-button.vue` isn't mounted anywhere reachable — `content/button.md` (the "Rebel Button Room" content page) currently mounts `:lab-manager` instead, and no other content file, route, or WonderLab exhibit registry references it. It's still referenced by `training/achievementData.ts`/`verifyAchievementCatalog.ts` (an achievement trigger code) and by historical WonderLab review-batch data. I fixed its layout-contract violation regardless (safe either way), but didn't investigate or fix the apparent orphan/reachability status — that felt like a separate discovery outside this sweep's scope. Worth a follow-up task if it's a real drift bug (achievement `rebel-button` may now be permanently unreachable).

### Kaizen suggestion
File a task to investigate whether `components/pages/rebel-button.vue` is genuinely reachable in the live app (see the flag above) — if it's dead, it should either be re-mounted on `content/button.md` or cleaned up like the other confirmed orphans t-018 removed.

### Notes for reviewer
This is the tenth scoped sweep on the t-017 umbrella task. Remaining non-zero buckets: `one-scroll` (31 entries, has its own task t-047).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FML9umAMpusjmQcCizGfva)_