### PR TITLE
fix(layout): batch-fix one-scroll manager tab-switchers and achievement grid

### DIFF
--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -9,90 +9,78 @@
       fetch (see loadManagerData). Keeping these two branches first ensures a
       failed or slow art-server call never hides tabs that don't depend on it.
     -->
-    <section
-      v-if="activeTab === 'timeline'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
-        <academy-timeline class="min-h-full w-full" @remix="goToRemix" />
-      </div>
-    </section>
-
-    <section
-      v-else-if="activeTab === 'styles'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
-        <academy-styles-browser class="min-h-full w-full" @remix="goToRemix" />
-      </div>
-    </section>
-
-    <div
-      v-else-if="isLoadingManager"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"
-    >
-      <div class="flex flex-col items-center gap-3 text-center">
-        <span
-          class="loading loading-spinner loading-lg text-primary"
-          aria-hidden="true"
+    <section class="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <div class="kr-scroll overscroll-contain p-3">
+        <academy-timeline
+          v-if="activeTab === 'timeline'"
+          class="min-h-full w-full"
+          @remix="goToRemix"
         />
-        <p class="text-sm text-base-content/70">
-          Dusting off the timeline, warming up the remix engine, and politely
-          waking thirty-three centuries of dead masters...
-        </p>
-      </div>
-    </div>
 
-    <div
-      v-else-if="managerError"
-      role="alert"
-      class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
-    >
-      <div class="flex flex-wrap items-center justify-between gap-3">
-        <span>{{ managerError }}</span>
-        <button
-          type="button"
-          class="btn btn-error btn-sm rounded-2xl"
-          @click="loadManagerData(true)"
-        >
-          Retry
-        </button>
-      </div>
-    </div>
+        <academy-styles-browser
+          v-else-if="activeTab === 'styles'"
+          class="min-h-full w-full"
+          @remix="goToRemix"
+        />
 
-    <section
-      v-else-if="activeTab === 'remix'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
-        <academy-remix class="min-h-full w-full" />
-      </div>
-    </section>
-
-    <section
-      v-else-if="activeTab === 'stylelab'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
         <div
+          v-else-if="isLoadingManager"
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"
+        >
+          <div class="flex flex-col items-center gap-3 text-center">
+            <span
+              class="loading loading-spinner loading-lg text-primary"
+              aria-hidden="true"
+            />
+            <p class="text-sm text-base-content/70">
+              Dusting off the timeline, warming up the remix engine, and
+              politely waking thirty-three centuries of dead masters...
+            </p>
+          </div>
+        </div>
+
+        <div
+          v-else-if="managerError"
+          role="alert"
+          class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-error/40 bg-error/10 p-4 text-error"
+        >
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <span>{{ managerError }}</span>
+            <button
+              type="button"
+              class="btn btn-error btn-sm rounded-2xl"
+              @click="loadManagerData(true)"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+
+        <academy-remix
+          v-else-if="activeTab === 'remix'"
+          class="min-h-full w-full"
+        />
+
+        <div
+          v-else-if="activeTab === 'stylelab'"
           class="grid min-h-full gap-3 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]"
         >
           <art-styler class="min-h-0" :show-close="false" />
 
           <image-upload class="min-h-0" :show-model-connect="false" />
         </div>
+
+        <div
+          v-else
+          class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
+        >
+          Unknown academy tab: {{ activeTab }}
+        </div>
       </div>
     </section>
-
-    <div
-      v-else
-      class="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-warning/40 bg-warning/10 p-4 text-warning"
-    >
-      Unknown academy tab: {{ activeTab }}
-    </div>
   </section>
 </template>
 

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -34,12 +34,12 @@
       </button>
     </header>
 
-    <!-- ── Three-column grid ────────────────────────────────────────────── -->
-    <div class="grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-3">
+    <!-- ── Three-column grid — one shared scroll owner for the whole grid,
+         columns grow to content height instead of scrolling independently
+         (interface-vision t-047: one-scroll) ─────────────────────────── -->
+    <div class="kr-scroll grid grid-cols-1 gap-4 lg:grid-cols-3">
       <!-- Earned -->
-      <div
-        class="flex min-h-0 flex-col rounded-2xl border border-base-300 bg-base-100"
-      >
+      <div class="flex flex-col rounded-2xl border border-base-300 bg-base-100">
         <div class="flex items-center gap-2 border-b border-base-300 px-4 py-3">
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-success/15 text-success"
@@ -51,7 +51,7 @@
             earnedAchievements.length
           }}</span>
         </div>
-        <div class="min-h-0 flex-1 overflow-y-auto p-3">
+        <div class="p-3">
           <div v-if="earnedAchievements.length" class="grid grid-cols-1 gap-2">
             <EarnedAchievementCard
               v-for="earnedAchievement in earnedAchievements"
@@ -71,9 +71,7 @@
       </div>
 
       <!-- Leaderboard -->
-      <div
-        class="flex min-h-0 flex-col rounded-2xl border border-base-300 bg-base-100"
-      >
+      <div class="flex flex-col rounded-2xl border border-base-300 bg-base-100">
         <div class="flex items-center gap-2 border-b border-base-300 px-4 py-3">
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-secondary/15 text-secondary"
@@ -82,15 +80,13 @@
           </span>
           <h2 class="text-sm font-black text-base-content">Leaderboard</h2>
         </div>
-        <div class="min-h-0 flex-1 overflow-y-auto p-3">
+        <div class="p-3">
           <achievement-leaderboard />
         </div>
       </div>
 
       <!-- Undiscovered -->
-      <div
-        class="flex min-h-0 flex-col rounded-2xl border border-base-300 bg-base-100"
-      >
+      <div class="flex flex-col rounded-2xl border border-base-300 bg-base-100">
         <div class="flex items-center gap-2 border-b border-base-300 px-4 py-3">
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-base-300 text-base-content/50"
@@ -102,7 +98,7 @@
             unearnedAchievements.length
           }}</span>
         </div>
-        <div class="min-h-0 flex-1 overflow-y-auto p-3">
+        <div class="p-3">
           <div
             v-if="unearnedAchievements.length"
             class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2"

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -30,12 +30,73 @@
 
     <section class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
       <section
-        v-if="activeTab === 'community'"
+        v-if="
+          activeTab === 'community' ||
+          activeTab === 'mana' ||
+          activeTab === 'forum'
+        "
         class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
       >
-        <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
-          <about-page />
-          <sponsor-page />
+        <div class="kr-scroll overscroll-contain p-4">
+          <template v-if="activeTab === 'community'">
+            <about-page />
+            <sponsor-page />
+          </template>
+
+          <div v-else-if="activeTab === 'mana'" class="flex flex-col gap-6">
+            <div
+              v-if="manaTopupNotice"
+              class="rounded-xl border p-3 text-center text-sm font-medium"
+              :class="
+                manaTopupNotice === 'success'
+                  ? 'border-success/40 bg-success/10 text-success'
+                  : 'border-warning/40 bg-warning/10 text-warning'
+              "
+            >
+              {{
+                manaTopupNotice === 'success'
+                  ? '⚡ Mana top-up complete — your balance updates below.'
+                  : 'Mana top-up cancelled. No charge was made.'
+              }}
+            </div>
+            <div
+              v-if="subscriptionNotice"
+              class="rounded-xl border p-3 text-center text-sm font-medium"
+              :class="
+                subscriptionNotice === 'success'
+                  ? 'border-success/40 bg-success/10 text-success'
+                  : 'border-warning/40 bg-warning/10 text-warning'
+              "
+            >
+              {{
+                subscriptionNotice === 'success'
+                  ? '🎫 Subscription active — thank you for supporting Kind Robots!'
+                  : 'Subscription checkout cancelled. No charge was made.'
+              }}
+            </div>
+            <mana-wallet />
+            <credit-purchase />
+            <subscription-manager />
+          </div>
+
+          <div
+            v-else
+            class="flex min-h-full flex-col items-center justify-center gap-3 text-center"
+          >
+            <Icon name="kind-icon:forum" class="h-12 w-12 text-primary" />
+
+            <div class="max-w-xl space-y-2">
+              <h2 class="text-2xl font-black text-base-content">
+                Giftshop Forum
+              </h2>
+
+              <p class="text-sm leading-relaxed text-base-content/70">
+                The butterflies are drafting community guidelines in glitter
+                ink. This tab is wired to the dashboard canon and ready for
+                the real forum component when it lands.
+              </p>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -44,68 +105,6 @@
         class="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
       >
         <giftshop-interact class="h-full min-h-0 flex-1 overflow-hidden" />
-      </section>
-
-      <section
-        v-else-if="activeTab === 'mana'"
-        class="flex h-full min-h-0 flex-1 flex-col gap-6 overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-4"
-      >
-        <div
-          v-if="manaTopupNotice"
-          class="rounded-xl border p-3 text-center text-sm font-medium"
-          :class="
-            manaTopupNotice === 'success'
-              ? 'border-success/40 bg-success/10 text-success'
-              : 'border-warning/40 bg-warning/10 text-warning'
-          "
-        >
-          {{
-            manaTopupNotice === 'success'
-              ? '⚡ Mana top-up complete — your balance updates below.'
-              : 'Mana top-up cancelled. No charge was made.'
-          }}
-        </div>
-        <div
-          v-if="subscriptionNotice"
-          class="rounded-xl border p-3 text-center text-sm font-medium"
-          :class="
-            subscriptionNotice === 'success'
-              ? 'border-success/40 bg-success/10 text-success'
-              : 'border-warning/40 bg-warning/10 text-warning'
-          "
-        >
-          {{
-            subscriptionNotice === 'success'
-              ? '🎫 Subscription active — thank you for supporting Kind Robots!'
-              : 'Subscription checkout cancelled. No charge was made.'
-          }}
-        </div>
-        <mana-wallet />
-        <credit-purchase />
-        <subscription-manager />
-      </section>
-
-      <section
-        v-else-if="activeTab === 'forum'"
-        class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
-      >
-        <div
-          class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-y-auto overscroll-contain p-6 text-center"
-        >
-          <Icon name="kind-icon:forum" class="h-12 w-12 text-primary" />
-
-          <div class="max-w-xl space-y-2">
-            <h2 class="text-2xl font-black text-base-content">
-              Giftshop Forum
-            </h2>
-
-            <p class="text-sm leading-relaxed text-base-content/70">
-              The butterflies are drafting community guidelines in glitter ink.
-              This tab is wired to the dashboard canon and ready for the real
-              forum component when it lands.
-            </p>
-          </div>
-        </div>
       </section>
 
       <div

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -83,34 +83,23 @@
     </section>
 
     <section
-      v-else-if="activeTab === 'avatars'"
+      v-else-if="
+        activeTab === 'avatars' ||
+        activeTab === 'friends' ||
+        activeTab === 'achievements'
+      "
       class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
     >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
+      <div class="kr-scroll overscroll-contain p-4">
         <avatar-picker
+          v-if="activeTab === 'avatars'"
           default-collection-label="avatars"
           :dismissible="true"
           @selected="onAvatarChosen"
           @close="closePicker"
         />
-      </div>
-    </section>
-
-    <section
-      v-else-if="activeTab === 'friends'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
-        <friend-gallery />
-      </div>
-    </section>
-
-    <section
-      v-else-if="activeTab === 'achievements'"
-      class="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-200"
-    >
-      <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
-        <achievement-gallery />
+        <friend-gallery v-else-if="activeTab === 'friends'" />
+        <achievement-gallery v-else />
       </div>
     </section>
 

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -4,8 +4,6 @@
   "violations": {
     "one-header": [],
     "one-scroll": [
-      "components/academy/academy-manager.vue",
-      "components/achievements/achievement-gallery.vue",
       "components/animation/animation-manager.vue",
       "components/art/art-gallery.vue",
       "components/art/art-interact.vue",
@@ -17,7 +15,6 @@
       "components/characters/character-flip-card.vue",
       "components/characters/character-interact.vue",
       "components/dreams/dream-brainstorm.vue",
-      "components/giftshop/giftshop-manager.vue",
       "components/navigation/channel-select.vue",
       "components/pages/conductor-page.vue",
       "components/pages/memory-dungeon.vue",
@@ -31,7 +28,6 @@
       "components/user/chat-gallery.vue",
       "components/user/messenger.vue",
       "components/user/user-galleries.vue",
-      "components/user/user-manager.vue",
       "components/wonderlab/lab-interact.vue",
       "components/wonderlab/mural-manager.vue",
       "components/wonderlab/wonderlab-preview-host.vue"


### PR DESCRIPTION
### Task
interface-vision/t-047: Batch-fix a handful of one-scroll offenders sharing the manager/interact-panel shape (kind: software)

### What changed / what I produced
- `components/user/user-manager.vue`: merged the `avatars`/`friends`/`achievements` tab branches (each previously wrapped its content in its own `overflow-y-auto` div) into one shared `.kr-scroll` region, switching the sub-component to render via inner `v-if`/`v-else-if`.
- `components/academy/academy-manager.vue`: merged all four tab branches (`timeline`, `styles`, `remix`, `stylelab`) plus the `isLoadingManager`/`managerError` states into one outer `.kr-scroll` div with inner conditional content, preserving the original ordering (timeline/styles are checked before the loading/error gate, exactly as before, since they don't depend on server data).
- `components/giftshop/giftshop-manager.vue`: merged the `community`/`mana`/`forum` tab branches (three independent scroll declarations) into one shared `.kr-scroll` region; the `giftshop` tab (delegates scrolling to `giftshop-interact`) stays a separate branch.
- `components/achievements/achievement-gallery.vue`: the three-column grid (Earned / Leaderboard / Undiscovered) previously gave each column its own independent `overflow-y-auto`; now the whole grid is the single scroll owner and the columns grow to their natural content height.
- Ratcheted `utils/scripts/layout-contract-baseline.json` via `--update`: `one-scroll` 31 → 27.

### How I verified
- `npx tsx utils/scripts/verifyLayoutContract.ts` — all four files clear the `one-scroll` rule, no new violations anywhere else, `-4 ✅`.
- `npm run test` (vue-tsc `--noEmit`) — clean, no type errors.
- `npx eslint` on the four changed files — 2 pre-existing errors only (`achievement-gallery.vue`'s `any` cast, `giftshop-manager.vue`'s unused `swarmMemo`), confirmed via `git stash` to predate this change; out of scope.

### Stakes
reversible

### Flags for Reviewer
- I did not visually verify via a Vercel preview deployment (no live preview available to me in this session). The changes are template-only restructuring — same components, same conditional logic, same primitive classes (`kr-scroll`) already adopted elsewhere in this codebase (t-004) — but please spot-check the preview for these four components before/while merging, per AGENTS.md's front-end verification note.
- `giftshop-manager.vue`'s forum tab padding changed from `p-6` to `p-4` (to share the outer wrapper's padding with the other two merged tabs) — minor visual nit, not a functional change.
- Left `art-manager.vue` and `server-manager.vue` out of this pass: `art-manager.vue`'s `artjob` tab has its own responsive (`2xl:`) scroll-management strategy that's explicitly in scope for the separate task t-044 (artjob-queue-browser restructure), and `server-manager.vue`/`lab-interact.vue`/`character-interact.vue`/`reward-interact.vue`/`scenario-interact.vue`/`stage-manager.vue`/`animation-manager.vue` have a genuinely different shape (simultaneously-visible dual-pane sidebar+content, not a mutually-exclusive tab switch) that needs its own design decision about which pane owns the scroll — left for a follow-up bounded sweep.

### Kaizen suggestion
The remaining `one-scroll` bucket (27) splits into at least two distinct shapes: (a) more tab-switchers like this PR fixed (worth grepping for the same `v-else-if="activeTab === ...”` + per-branch `overflow-y-auto` pattern), and (b) genuine simultaneous dual-pane layouts (`*-interact.vue` sidebar+main patterns: `character-interact.vue`, `reward-interact.vue`, `scenario-interact.vue`, `lab-interact.vue`, `server-manager.vue`, `stage-manager.vue`, `animation-manager.vue`) where the fix requires picking which pane is the scroll owner — a design decision, not a mechanical merge. A follow-up task should scope these as two separate sweeps rather than one, since (b) needs visual judgment call and (a) doesn't.

### Notes for reviewer
Roadmap task `interface-vision/t-047` set to `status: review` before opening this PR, per AGENTS.md step 7. Per t-017/t-047's own convention, this task will be closed `done` (not re-armed) since the note doesn't establish it as a recurring sweep — only t-017 (the umbrella) re-arms.


---
_Generated by [Claude Code](https://claude.ai/code/session_016BdB2AT1GbApNJtMbZXo4X)_