### PR TITLE
fix(layout): adopt kr-surface/kr-scroll on 8 root-surface offenders

### DIFF
--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -1,12 +1,14 @@
 <!-- /components/content/weird/click-leaderboard.vue -->
 <template>
-  <div class="h-full min-h-0 overflow-y-auto overscroll-contain p-4">
-    <p class="text-xl font-bold mb-4">Global Leaderboard</p>
-    <leaderboard-table
-      :rows="leaderboard"
-      score-label="Click Record"
-      score-key="clickRecord"
-    />
+  <div class="kr-surface">
+    <div class="kr-scroll p-4">
+      <p class="text-xl font-bold mb-4">Global Leaderboard</p>
+      <leaderboard-table
+        :rows="leaderboard"
+        score-label="Click Record"
+        score-key="clickRecord"
+      />
+    </div>
   </div>
 </template>
 

--- a/components/pages/sponsor-page.vue
+++ b/components/pages/sponsor-page.vue
@@ -1,10 +1,8 @@
 <!-- /components/content/butterfly/sponsor-page.vue -->
 <template>
-  <div
-    class="h-full min-h-0 overflow-y-auto max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
-  >
+  <div class="kr-surface">
     <div
-      class="bg-base-300 p-6 rounded-lg shadow-xl text-center text-default space-y-6"
+      class="kr-scroll max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 bg-base-300 p-6 rounded-lg shadow-xl text-center text-default space-y-6"
     >
       <p class="text-4xl font-semibold">
         Greetings, friends of all species and circuits!

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -1,137 +1,141 @@
 <template>
-  <div
-    class="h-full min-h-0 overflow-y-auto overscroll-contain p-6 space-y-6 max-w-3xl mx-auto"
-  >
-    <header class="space-y-1">
-      <p class="text-2xl font-bold">🎤 Music Mentor</p>
-      <p class="text-sm opacity-70">
-        Upload a recording of your sung medley and get honest, specific feedback
-        on the singing and the arrangement. Everything is analyzed
-        <strong>in your browser</strong> — the audio never leaves your device,
-        and nothing is stored.
-      </p>
-      <p class="text-xs opacity-60">
-        Honest heads-up: this measures the objective stuff (pitch, timing,
-        dynamics, structure) and reasons over your setlist. It can't judge tone,
-        emotion, or "is this a good voice" — that still needs a human ear.
-      </p>
-    </header>
+  <div class="kr-surface">
+    <div class="kr-scroll p-6 space-y-6 max-w-3xl mx-auto">
+      <header class="space-y-1">
+        <p class="text-2xl font-bold">🎤 Music Mentor</p>
+        <p class="text-sm opacity-70">
+          Upload a recording of your sung medley and get honest, specific
+          feedback on the singing and the arrangement. Everything is analyzed
+          <strong>in your browser</strong> — the audio never leaves your device,
+          and nothing is stored.
+        </p>
+        <p class="text-xs opacity-60">
+          Honest heads-up: this measures the objective stuff (pitch, timing,
+          dynamics, structure) and reasons over your setlist. It can't judge
+          tone, emotion, or "is this a good voice" — that still needs a human
+          ear.
+        </p>
+      </header>
 
-    <div v-if="!isLoggedIn" class="alert alert-warning text-sm" role="alert">
-      You need to be signed in to run an analysis — the coaching step is billed
-      to your account's mana.
-    </div>
-
-    <!-- File -->
-    <section class="space-y-2">
-      <label class="font-semibold">
-        Recording <span class="text-error">*</span>
-      </label>
-      <input
-        type="file"
-        accept="audio/*,video/*,.mp3,.m4a,.wav,.ogg,.mp4,.mov"
-        class="file-input file-input-bordered w-full"
-        @change="onFileChange"
-      />
-      <p v-if="fileName" class="text-xs opacity-70">
-        {{ fileName }} ({{ fileSizeMb }} MB) — only the audio track is read.
-      </p>
-      <p v-else class="text-xs opacity-50">
-        Audio or video is fine (mp3, m4a, wav, or an iPhone mp4/mov — we just
-        read the audio). Up to {{ MAX_MB }} MB.
-      </p>
-    </section>
-
-    <!-- Setlist -->
-    <section class="space-y-2">
-      <label class="font-semibold">Setlist / notes</label>
-      <textarea
-        v-model="setlist"
-        rows="4"
-        class="textarea textarea-bordered w-full"
-        placeholder="List the songs in your medley (and keys if you know them), plus anything you want feedback on. This sharpens the arrangement feedback."
-      />
-    </section>
-
-    <!-- Dimensions -->
-    <section class="space-y-2">
-      <label class="font-semibold">What should I listen for?</label>
-      <div class="flex flex-wrap gap-2">
-        <button
-          v-for="opt in DIMENSIONS"
-          :key="opt.value"
-          type="button"
-          class="btn btn-sm"
-          :class="selected.includes(opt.value) ? 'btn-accent' : 'btn-outline'"
-          @click="toggle(opt.value)"
-        >
-          {{ opt.label }}
-        </button>
-      </div>
-      <p class="text-xs opacity-60">
-        Pick at least one. All four selected by default.
-      </p>
-    </section>
-
-    <!-- Analyze -->
-    <section class="space-y-3">
-      <button
-        type="button"
-        class="btn btn-accent btn-lg w-full"
-        :disabled="!canAnalyze"
-        @click="run"
-      >
-        <span v-if="store.isBusy" class="loading loading-spinner loading-sm" />
-        {{ analyzeLabel }}
-      </button>
-
-      <div v-if="store.state.message" class="text-sm opacity-70 text-center">
-        {{ store.state.message }}
+      <div v-if="!isLoggedIn" class="alert alert-warning text-sm" role="alert">
+        You need to be signed in to run an analysis — the coaching step is
+        billed to your account's mana.
       </div>
 
-      <div
-        v-if="store.state.error"
-        class="alert alert-error text-sm"
-        role="alert"
-      >
-        {{ store.state.error }}
-      </div>
-    </section>
+      <!-- File -->
+      <section class="space-y-2">
+        <label class="font-semibold">
+          Recording <span class="text-error">*</span>
+        </label>
+        <input
+          type="file"
+          accept="audio/*,video/*,.mp3,.m4a,.wav,.ogg,.mp4,.mov"
+          class="file-input file-input-bordered w-full"
+          @change="onFileChange"
+        />
+        <p v-if="fileName" class="text-xs opacity-70">
+          {{ fileName }} ({{ fileSizeMb }} MB) — only the audio track is read.
+        </p>
+        <p v-else class="text-xs opacity-50">
+          Audio or video is fine (mp3, m4a, wav, or an iPhone mp4/mov — we just
+          read the audio). Up to {{ MAX_MB }} MB.
+        </p>
+      </section>
 
-    <!-- Feedback -->
-    <section v-if="store.state.feedback" class="space-y-2">
-      <h2 class="font-semibold">Mentor feedback</h2>
-      <div
-        class="whitespace-pre-line rounded-2xl border border-base-300 bg-base-200/60 p-4 text-sm leading-relaxed"
-      >
-        {{ store.state.feedback }}
-      </div>
-    </section>
+      <!-- Setlist -->
+      <section class="space-y-2">
+        <label class="font-semibold">Setlist / notes</label>
+        <textarea
+          v-model="setlist"
+          rows="4"
+          class="textarea textarea-bordered w-full"
+          placeholder="List the songs in your medley (and keys if you know them), plus anything you want feedback on. This sharpens the arrangement feedback."
+        />
+      </section>
 
-    <!-- Extracted features (transparency) -->
-    <details v-if="store.state.features" class="text-sm">
-      <summary class="cursor-pointer opacity-70">
-        What I measured (the numbers behind the feedback)
-      </summary>
-      <div class="mt-2 grid gap-2 sm:grid-cols-2">
-        <div
-          v-for="row in featureRows"
-          :key="row.label"
-          class="flex justify-between gap-3 rounded-lg border border-base-300 bg-base-100 px-3 py-2"
-        >
-          <span class="opacity-70">{{ row.label }}</span>
-          <span class="font-medium text-right">{{ row.value }}</span>
+      <!-- Dimensions -->
+      <section class="space-y-2">
+        <label class="font-semibold">What should I listen for?</label>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="opt in DIMENSIONS"
+            :key="opt.value"
+            type="button"
+            class="btn btn-sm"
+            :class="selected.includes(opt.value) ? 'btn-accent' : 'btn-outline'"
+            @click="toggle(opt.value)"
+          >
+            {{ opt.label }}
+          </button>
         </div>
-      </div>
-      <ul
-        v-if="store.state.features.notes.length"
-        class="mt-3 list-disc space-y-1 pl-5 text-xs opacity-70"
-      >
-        <li v-for="(note, i) in store.state.features.notes" :key="i">
-          {{ note }}
-        </li>
-      </ul>
-    </details>
+        <p class="text-xs opacity-60">
+          Pick at least one. All four selected by default.
+        </p>
+      </section>
+
+      <!-- Analyze -->
+      <section class="space-y-3">
+        <button
+          type="button"
+          class="btn btn-accent btn-lg w-full"
+          :disabled="!canAnalyze"
+          @click="run"
+        >
+          <span
+            v-if="store.isBusy"
+            class="loading loading-spinner loading-sm"
+          />
+          {{ analyzeLabel }}
+        </button>
+
+        <div v-if="store.state.message" class="text-sm opacity-70 text-center">
+          {{ store.state.message }}
+        </div>
+
+        <div
+          v-if="store.state.error"
+          class="alert alert-error text-sm"
+          role="alert"
+        >
+          {{ store.state.error }}
+        </div>
+      </section>
+
+      <!-- Feedback -->
+      <section v-if="store.state.feedback" class="space-y-2">
+        <h2 class="font-semibold">Mentor feedback</h2>
+        <div
+          class="whitespace-pre-line rounded-2xl border border-base-300 bg-base-200/60 p-4 text-sm leading-relaxed"
+        >
+          {{ store.state.feedback }}
+        </div>
+      </section>
+
+      <!-- Extracted features (transparency) -->
+      <details v-if="store.state.features" class="text-sm">
+        <summary class="cursor-pointer opacity-70">
+          What I measured (the numbers behind the feedback)
+        </summary>
+        <div class="mt-2 grid gap-2 sm:grid-cols-2">
+          <div
+            v-for="row in featureRows"
+            :key="row.label"
+            class="flex justify-between gap-3 rounded-lg border border-base-300 bg-base-100 px-3 py-2"
+          >
+            <span class="opacity-70">{{ row.label }}</span>
+            <span class="font-medium text-right">{{ row.value }}</span>
+          </div>
+        </div>
+        <ul
+          v-if="store.state.features.notes.length"
+          class="mt-3 list-disc space-y-1 pl-5 text-xs opacity-70"
+        >
+          <li v-for="(note, i) in store.state.features.notes" :key="i">
+            {{ note }}
+          </li>
+        </ul>
+      </details>
+    </div>
   </div>
 </template>
 

--- a/pages/plan/wonderlab/commentary-guide.vue
+++ b/pages/plan/wonderlab/commentary-guide.vue
@@ -1,8 +1,11 @@
 <!-- /pages/plan/wonderlab/commentary-guide.vue -->
 <template>
-  <section class="h-full min-h-0 overflow-y-auto p-4 sm:p-6">
-    <div class="mx-auto flex max-w-5xl flex-col gap-5">
-      <NuxtLink to="/plan/wonderlab" class="btn btn-ghost btn-sm w-fit rounded-xl">
+  <section class="kr-surface">
+    <div class="kr-scroll mx-auto flex max-w-5xl flex-col gap-5 p-4 sm:p-6">
+      <NuxtLink
+        to="/plan/wonderlab"
+        class="btn btn-ghost btn-sm w-fit rounded-xl"
+      >
         <Icon name="kind-icon:arrow-left" class="size-4" />
         Back to WonderLab
       </NuxtLink>
@@ -13,13 +16,17 @@
         <div
           class="bg-linear-to-br from-primary/20 via-secondary/10 to-accent/20 p-6 sm:p-8"
         >
-          <p class="text-xs font-black uppercase tracking-[0.22em] text-primary">
+          <p
+            class="text-xs font-black uppercase tracking-[0.22em] text-primary"
+          >
             WonderLab editorial playbook
           </p>
           <p class="mt-2 text-3xl font-black sm:text-5xl">
             Commentary Voice Guide
           </p>
-          <p class="mt-4 max-w-3xl text-base leading-relaxed text-base-content/70">
+          <p
+            class="mt-4 max-w-3xl text-base leading-relaxed text-base-content/70"
+          >
             Stars carry the evaluation. The words are a glimpse of the Bot or
             Character who left them.
           </p>
@@ -27,21 +34,25 @@
       </header>
 
       <section class="grid gap-4 lg:grid-cols-2">
-        <article class="rounded-3xl border border-success/35 bg-success/5 p-5 sm:p-6">
+        <article
+          class="rounded-3xl border border-success/35 bg-success/5 p-5 sm:p-6"
+        >
           <div class="flex items-center gap-3">
             <Icon name="kind-icon:star" class="size-7 text-success" />
             <h2 class="text-2xl font-black">What works</h2>
           </div>
-          <ul class="mt-4 space-y-3 text-sm leading-relaxed text-base-content/75">
+          <ul
+            class="mt-4 space-y-3 text-sm leading-relaxed text-base-content/75"
+          >
             <li>
-              <strong>Write the personality, not a report.</strong> Let the assigned
-              speaker joke, mutter, emote, misunderstand, notice one tiny detail,
-              or react without explaining the Component.
+              <strong>Write the personality, not a report.</strong> Let the
+              assigned speaker joke, mutter, emote, misunderstand, notice one
+              tiny detail, or react without explaining the Component.
             </li>
             <li>
-              <strong>Let verbosity belong to the speaker.</strong> One word, one
-              sentence, a stage direction, a compact observation, or an occasional
-              monologue are all valid.
+              <strong>Let verbosity belong to the speaker.</strong> One word,
+              one sentence, a stage direction, a compact observation, or an
+              occasional monologue are all valid.
             </li>
             <li>
               <strong>Use the exhibit as scenery.</strong> Ground the flavor in
@@ -49,26 +60,30 @@
               when that personality would naturally care about it.
             </li>
             <li>
-              <strong>Preserve the cast.</strong> Keep the chosen author and star
-              rating unless a curator explicitly changes the assignment or
+              <strong>Preserve the cast.</strong> Keep the chosen author and
+              star rating unless a curator explicitly changes the assignment or
               evaluation.
             </li>
           </ul>
         </article>
 
-        <article class="rounded-3xl border border-error/30 bg-error/5 p-5 sm:p-6">
+        <article
+          class="rounded-3xl border border-error/30 bg-error/5 p-5 sm:p-6"
+        >
           <div class="flex items-center gap-3">
             <Icon name="kind-icon:x" class="size-7 text-error" />
             <h2 class="text-2xl font-black">What reads wrong</h2>
           </div>
-          <ul class="mt-4 space-y-3 text-sm leading-relaxed text-base-content/75">
+          <ul
+            class="mt-4 space-y-3 text-sm leading-relaxed text-base-content/75"
+          >
             <li>
               Function lists, prop inventories, import summaries, and technical
               completeness disguised as dialogue.
             </li>
             <li>
-              A shared house voice, repeated templates, identical sentence shapes,
-              or comments padded to the same length.
+              A shared house voice, repeated templates, identical sentence
+              shapes, or comments padded to the same length.
             </li>
             <li>
               Explaining every visible behavior when the speaker would only care
@@ -82,61 +97,93 @@
         </article>
       </section>
 
-      <section class="rounded-3xl border border-base-300 bg-base-100 p-5 sm:p-7">
+      <section
+        class="rounded-3xl border border-base-300 bg-base-100 p-5 sm:p-7"
+      >
         <div class="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <p class="text-xs font-black uppercase tracking-widest text-primary">
+            <p
+              class="text-xs font-black uppercase tracking-widest text-primary"
+            >
               Deliberate range
             </p>
-            <h2 class="mt-1 text-2xl font-black">Different voices take different space</h2>
+            <h2 class="mt-1 text-2xl font-black">
+              Different voices take different space
+            </h2>
           </div>
-          <span class="badge badge-outline rounded-xl">Uniform length is a defect</span>
+          <span class="badge badge-outline rounded-xl"
+            >Uniform length is a defect</span
+          >
         </div>
 
         <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <blockquote class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <blockquote
+            class="rounded-2xl border border-base-300 bg-base-200 p-4"
+          >
             <p class="text-lg font-black italic">*purrs*</p>
-            <footer class="mt-3 text-xs text-base-content/50">Nonverbal flavor</footer>
+            <footer class="mt-3 text-xs text-base-content/50">
+              Nonverbal flavor
+            </footer>
           </blockquote>
-          <blockquote class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <blockquote
+            class="rounded-2xl border border-base-300 bg-base-200 p-4"
+          >
             <p class="text-lg font-black">Aisles clear.</p>
-            <footer class="mt-3 text-xs text-base-content/50">Micro commentary</footer>
+            <footer class="mt-3 text-xs text-base-content/50">
+              Micro commentary
+            </footer>
           </blockquote>
-          <blockquote class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <blockquote
+            class="rounded-2xl border border-base-300 bg-base-200 p-4"
+          >
             <p class="text-sm leading-relaxed">
               A title can wait here without being forgotten. Star it. Come back
               when the snow is quieter.
             </p>
-            <footer class="mt-3 text-xs text-base-content/50">Quiet character beat</footer>
+            <footer class="mt-3 text-xs text-base-content/50">
+              Quiet character beat
+            </footer>
           </blockquote>
-          <blockquote class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <blockquote
+            class="rounded-2xl border border-base-300 bg-base-200 p-4"
+          >
             <p class="text-sm leading-relaxed">
-              A theatrical, obsessive, or rambling personality may take the whole
-              stage when the longer performance is genuinely theirs.
+              A theatrical, obsessive, or rambling personality may take the
+              whole stage when the longer performance is genuinely theirs.
             </p>
-            <footer class="mt-3 text-xs text-base-content/50">Full voice performance</footer>
+            <footer class="mt-3 text-xs text-base-content/50">
+              Full voice performance
+            </footer>
           </blockquote>
         </div>
       </section>
 
-      <section class="rounded-3xl border border-accent/35 bg-accent/5 p-5 sm:p-7">
+      <section
+        class="rounded-3xl border border-accent/35 bg-accent/5 p-5 sm:p-7"
+      >
         <p class="text-xs font-black uppercase tracking-widest text-accent">
           Calibration rule
         </p>
-        <h2 class="mt-1 text-2xl font-black">Components are the rehearsal room</h2>
+        <h2 class="mt-1 text-2xl font-black">
+          Components are the rehearsal room
+        </h2>
         <p class="mt-3 max-w-4xl text-sm leading-relaxed text-base-content/70">
           WonderLab Components are intentionally the first commentary surface:
-          most visitors will never encounter this full museum, so the cast can be
-          tuned here before the same system expands to Bots, Characters, Dreams,
-          ArtImages, and other models. Carry the voice principles forward; do not
-          carry forward technical-review habits that happened to survive an early
-          batch.
+          most visitors will never encounter this full museum, so the cast can
+          be tuned here before the same system expands to Bots, Characters,
+          Dreams, ArtImages, and other models. Carry the voice principles
+          forward; do not carry forward technical-review habits that happened to
+          survive an early batch.
         </p>
       </section>
 
-      <section class="rounded-3xl border border-primary/30 bg-primary/5 p-5 sm:p-7">
+      <section
+        class="rounded-3xl border border-primary/30 bg-primary/5 p-5 sm:p-7"
+      >
         <h2 class="text-xl font-black text-primary">Before publishing</h2>
-        <ol class="mt-4 grid gap-3 text-sm leading-relaxed text-base-content/75 md:grid-cols-2">
+        <ol
+          class="mt-4 grid gap-3 text-sm leading-relaxed text-base-content/75 md:grid-cols-2"
+        >
           <li class="rounded-2xl bg-base-100 p-4">
             <strong>1. Read the assigned profile.</strong> Voice, personality,
             sample dialogue, and recurring obsessions matter more than coverage.
@@ -146,12 +193,12 @@
             this speaker would notice.
           </li>
           <li class="rounded-2xl bg-base-100 p-4">
-            <strong>3. Check the silhouette.</strong> The page should visibly mix
-            tiny, short, medium, and occasional long comments.
+            <strong>3. Check the silhouette.</strong> The page should visibly
+            mix tiny, short, medium, and occasional long comments.
           </li>
           <li class="rounded-2xl bg-base-100 p-4">
-            <strong>4. Remove the review voice.</strong> When the stars already say
-            whether it is good, the text is free to be alive.
+            <strong>4. Remove the review voice.</strong> When the stars already
+            say whether it is good, the text is free to be alive.
           </li>
         </ol>
       </section>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -1,8 +1,8 @@
 <template>
-  <main
-    class="h-full min-h-0 overflow-y-auto overscroll-contain bg-base-200/40 px-3 py-5 sm:px-6 sm:py-8"
-  >
-    <div class="mx-auto max-w-7xl space-y-5">
+  <main class="kr-surface bg-base-200/40">
+    <div
+      class="kr-scroll mx-auto max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+    >
       <nav class="flex flex-wrap items-center justify-between gap-3">
         <NuxtLink to="/play/challenges" class="btn btn-ghost btn-sm rounded-xl">
           <Icon name="kind-icon:arrow-left" class="size-4" />

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -1,8 +1,8 @@
 <template>
-  <main
-    class="h-full min-h-0 overflow-y-auto overscroll-contain bg-base-200/40 px-3 py-5 sm:px-6 sm:py-8"
-  >
-    <div class="mx-auto max-w-7xl space-y-5">
+  <main class="kr-surface bg-base-200/40">
+    <div
+      class="kr-scroll mx-auto max-w-7xl space-y-5 px-3 py-5 sm:px-6 sm:py-8"
+    >
       <nav class="flex flex-wrap items-center justify-between gap-3">
         <NuxtLink to="/play/challenges" class="btn btn-ghost btn-sm rounded-xl">
           <Icon name="kind-icon:arrow-left" class="size-4" />

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -1,352 +1,359 @@
 <template>
-  <div
-    class="mx-auto h-full min-h-0 max-w-5xl space-y-6 overflow-y-auto overscroll-contain p-6"
-  >
-    <header class="space-y-1">
-      <p class="text-sm opacity-70">
-        Animate a still into a short clip. Pick a first image (and an optional
-        end image), describe the motion, set the length, and queue it to the
-        Comfy studio engine.
-      </p>
-    </header>
-
-    <div v-if="!isLoggedIn" class="alert alert-warning text-sm" role="alert">
-      You need to be signed in to queue a clip — generation is billed to your
-      account's mana.
-    </div>
-
-    <!-- Engine selector -->
-    <section class="space-y-2">
-      <label class="font-semibold">Engine</label>
-      <div class="flex gap-2">
-        <button
-          v-for="opt in engines"
-          :key="opt.value"
-          type="button"
-          class="btn btn-sm"
-          :class="engine === opt.value ? 'btn-accent' : 'btn-outline'"
-          @click="selectEngine(opt.value)"
-        >
-          {{ opt.label }}
-        </button>
-      </div>
-      <p class="text-xs opacity-60">{{ activeEngine.hint }}</p>
-    </section>
-
-    <!-- Generation presets -->
-    <section class="space-y-2">
-      <label class="font-semibold">Preset</label>
-      <div class="grid gap-2 sm:grid-cols-3">
-        <button
-          type="button"
-          class="btn h-auto min-h-0 justify-start py-3 text-left"
-          :class="videoPresetId === '' ? 'btn-accent' : 'btn-outline'"
-          @click="selectVideoPreset('')"
-        >
-          <span class="flex flex-col items-start">
-            <span class="font-semibold">Custom</span>
-            <span class="text-xs font-normal opacity-70">
-              Keep the manual controls below.
-            </span>
-          </span>
-        </button>
-        <button
-          v-for="preset in availableVideoPresets"
-          :key="preset.id"
-          type="button"
-          class="btn h-auto min-h-0 justify-start py-3 text-left"
-          :class="videoPresetId === preset.id ? 'btn-accent' : 'btn-outline'"
-          @click="selectVideoPreset(preset.id)"
-        >
-          <span class="flex flex-col items-start">
-            <span class="font-semibold">{{ preset.label }}</span>
-            <span class="text-xs font-normal opacity-70">
-              {{ preset.description }}
-            </span>
-          </span>
-        </button>
-      </div>
-      <p class="text-xs opacity-60">
-        Presets fill the editable controls below; changing a value still
-        overrides the preset for this render.
-      </p>
-    </section>
-
-    <!-- Images -->
-    <section class="grid gap-4 md:grid-cols-2">
-      <!-- First image (required) -->
-      <div class="space-y-2 rounded-lg border border-base-300 p-3">
-        <div class="flex items-center justify-between">
-          <label class="font-semibold"
-            >First image <span class="text-error">*</span></label
-          >
-          <button
-            type="button"
-            class="btn btn-xs btn-outline"
-            @click="useLogoAsFirst"
-          >
-            Use logo
-          </button>
-        </div>
-        <input
-          type="file"
-          accept="image/*"
-          class="file-input file-input-bordered file-input-sm w-full"
-          @change="(e) => onFileChange(e, 'first')"
-        />
-        <div
-          v-if="firstImage"
-          class="relative flex aspect-video items-center justify-center overflow-hidden rounded bg-base-200"
-        >
-          <img :src="firstImage" class="max-h-full max-w-full object-contain" />
-          <button
-            type="button"
-            class="btn btn-circle btn-error btn-xs absolute top-1 right-1"
-            title="Clear"
-            @click="firstImage = ''"
-          >
-            ✕
-          </button>
-        </div>
-        <p v-else class="text-xs opacity-50">
-          Required — the clip starts from this frame.
+  <div class="kr-surface">
+    <div class="kr-scroll mx-auto max-w-5xl space-y-6 p-6">
+      <header class="space-y-1">
+        <p class="text-sm opacity-70">
+          Animate a still into a short clip. Pick a first image (and an optional
+          end image), describe the motion, set the length, and queue it to the
+          Comfy studio engine.
         </p>
+      </header>
+
+      <div v-if="!isLoggedIn" class="alert alert-warning text-sm" role="alert">
+        You need to be signed in to queue a clip — generation is billed to your
+        account's mana.
       </div>
 
-      <!-- Second image (optional) -->
-      <div class="space-y-2 rounded-lg border border-base-300 p-3">
-        <label class="font-semibold"
-          >End image <span class="opacity-50">(optional)</span></label
-        >
-        <input
-          type="file"
-          accept="image/*"
-          class="file-input file-input-bordered file-input-sm w-full"
-          @change="(e) => onFileChange(e, 'second')"
-        />
-        <div
-          v-if="secondImage"
-          class="relative flex aspect-video items-center justify-center overflow-hidden rounded bg-base-200"
-        >
-          <img
-            :src="secondImage"
-            class="max-h-full max-w-full object-contain"
+      <!-- Engine selector -->
+      <section class="space-y-2">
+        <label class="font-semibold">Engine</label>
+        <div class="flex gap-2">
+          <button
+            v-for="opt in engines"
+            :key="opt.value"
+            type="button"
+            class="btn btn-sm"
+            :class="engine === opt.value ? 'btn-accent' : 'btn-outline'"
+            @click="selectEngine(opt.value)"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+        <p class="text-xs opacity-60">{{ activeEngine.hint }}</p>
+      </section>
+
+      <!-- Generation presets -->
+      <section class="space-y-2">
+        <label class="font-semibold">Preset</label>
+        <div class="grid gap-2 sm:grid-cols-3">
+          <button
+            type="button"
+            class="btn h-auto min-h-0 justify-start py-3 text-left"
+            :class="videoPresetId === '' ? 'btn-accent' : 'btn-outline'"
+            @click="selectVideoPreset('')"
+          >
+            <span class="flex flex-col items-start">
+              <span class="font-semibold">Custom</span>
+              <span class="text-xs font-normal opacity-70">
+                Keep the manual controls below.
+              </span>
+            </span>
+          </button>
+          <button
+            v-for="preset in availableVideoPresets"
+            :key="preset.id"
+            type="button"
+            class="btn h-auto min-h-0 justify-start py-3 text-left"
+            :class="videoPresetId === preset.id ? 'btn-accent' : 'btn-outline'"
+            @click="selectVideoPreset(preset.id)"
+          >
+            <span class="flex flex-col items-start">
+              <span class="font-semibold">{{ preset.label }}</span>
+              <span class="text-xs font-normal opacity-70">
+                {{ preset.description }}
+              </span>
+            </span>
+          </button>
+        </div>
+        <p class="text-xs opacity-60">
+          Presets fill the editable controls below; changing a value still
+          overrides the preset for this render.
+        </p>
+      </section>
+
+      <!-- Images -->
+      <section class="grid gap-4 md:grid-cols-2">
+        <!-- First image (required) -->
+        <div class="space-y-2 rounded-lg border border-base-300 p-3">
+          <div class="flex items-center justify-between">
+            <label class="font-semibold"
+              >First image <span class="text-error">*</span></label
+            >
+            <button
+              type="button"
+              class="btn btn-xs btn-outline"
+              @click="useLogoAsFirst"
+            >
+              Use logo
+            </button>
+          </div>
+          <input
+            type="file"
+            accept="image/*"
+            class="file-input file-input-bordered file-input-sm w-full"
+            @change="(e) => onFileChange(e, 'first')"
           />
+          <div
+            v-if="firstImage"
+            class="relative flex aspect-video items-center justify-center overflow-hidden rounded bg-base-200"
+          >
+            <img
+              :src="firstImage"
+              class="max-h-full max-w-full object-contain"
+            />
+            <button
+              type="button"
+              class="btn btn-circle btn-error btn-xs absolute top-1 right-1"
+              title="Clear"
+              @click="firstImage = ''"
+            >
+              ✕
+            </button>
+          </div>
+          <p v-else class="text-xs opacity-50">
+            Required — the clip starts from this frame.
+          </p>
+        </div>
+
+        <!-- Second image (optional) -->
+        <div class="space-y-2 rounded-lg border border-base-300 p-3">
+          <label class="font-semibold"
+            >End image <span class="opacity-50">(optional)</span></label
+          >
+          <input
+            type="file"
+            accept="image/*"
+            class="file-input file-input-bordered file-input-sm w-full"
+            @change="(e) => onFileChange(e, 'second')"
+          />
+          <div
+            v-if="secondImage"
+            class="relative flex aspect-video items-center justify-center overflow-hidden rounded bg-base-200"
+          >
+            <img
+              :src="secondImage"
+              class="max-h-full max-w-full object-contain"
+            />
+            <button
+              type="button"
+              class="btn btn-circle btn-error btn-xs absolute top-1 right-1"
+              title="Clear"
+              @click="secondImage = ''"
+            >
+              ✕
+            </button>
+          </div>
+          <p v-else class="text-xs opacity-50">
+            If set, the clip morphs from the first image to this one.
+          </p>
+        </div>
+      </section>
+
+      <!-- Prompt -->
+      <section class="space-y-2">
+        <div class="flex items-center justify-between">
+          <label class="font-semibold">Motion prompt</label>
           <button
             type="button"
-            class="btn btn-circle btn-error btn-xs absolute top-1 right-1"
-            title="Clear"
-            @click="secondImage = ''"
+            class="btn btn-xs btn-ghost"
+            @click="prompt = WINK_PRESET"
           >
-            ✕
+            ✨ Wink &amp; grin preset
           </button>
         </div>
-        <p v-else class="text-xs opacity-50">
-          If set, the clip morphs from the first image to this one.
-        </p>
-      </div>
-    </section>
+        <textarea
+          v-model="prompt"
+          rows="3"
+          class="textarea textarea-bordered w-full"
+          placeholder="Describe how the image should move…"
+        />
+        <details class="text-sm">
+          <summary class="cursor-pointer opacity-70">
+            Negative prompt (optional)
+          </summary>
+          <textarea
+            v-model="negativePrompt"
+            rows="2"
+            class="textarea textarea-bordered mt-2 w-full"
+            placeholder="Leave blank for the sensible default."
+          />
+        </details>
+      </section>
 
-    <!-- Prompt -->
-    <section class="space-y-2">
-      <div class="flex items-center justify-between">
-        <label class="font-semibold">Motion prompt</label>
-        <button
-          type="button"
-          class="btn btn-xs btn-ghost"
-          @click="prompt = WINK_PRESET"
-        >
-          ✨ Wink &amp; grin preset
-        </button>
-      </div>
-      <textarea
-        v-model="prompt"
-        rows="3"
-        class="textarea textarea-bordered w-full"
-        placeholder="Describe how the image should move…"
+      <video-lora-picker
+        v-model="loraResourceId"
+        v-model:strength="loraStrength"
+        :engine="engine"
       />
+
+      <content-visibility-controls
+        v-model:is-mature="isMature"
+        v-model:is-public="isPublic"
+        :disabled="videoStore.isBusy"
+      />
+
+      <!-- Output format -->
+      <section class="space-y-2">
+        <label class="font-semibold">Output format</label>
+        <div class="flex gap-2">
+          <button
+            v-for="opt in outputFormats"
+            :key="opt.value"
+            type="button"
+            class="btn btn-sm"
+            :class="outputFormat === opt.value ? 'btn-accent' : 'btn-outline'"
+            @click="outputFormat = opt.value"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+        <p class="text-xs opacity-60">{{ activeOutputFormat.hint }}</p>
+      </section>
+
+      <!-- Controls -->
+      <section class="grid gap-4 sm:grid-cols-3">
+        <div class="space-y-1">
+          <label class="text-sm font-semibold">Time (seconds)</label>
+          <input
+            v-model.number="durationSeconds"
+            type="number"
+            min="0.5"
+            max="30"
+            step="0.5"
+            class="input input-bordered w-full"
+          />
+        </div>
+        <div class="space-y-1">
+          <label class="text-sm font-semibold">FPS</label>
+          <input
+            v-model.number="fps"
+            type="number"
+            min="1"
+            max="60"
+            step="1"
+            class="input input-bordered w-full"
+          />
+        </div>
+        <div class="space-y-1">
+          <label class="text-sm font-semibold">Loop</label>
+          <label class="flex h-12 cursor-pointer items-center gap-2">
+            <input
+              v-model="loop"
+              type="checkbox"
+              class="toggle toggle-accent"
+            />
+            <span class="text-sm opacity-70">{{
+              loop ? 'Seamless loop' : 'Play once'
+            }}</span>
+          </label>
+        </div>
+      </section>
+
       <details class="text-sm">
         <summary class="cursor-pointer opacity-70">
-          Negative prompt (optional)
+          Advanced (size &amp; seed)
         </summary>
-        <textarea
-          v-model="negativePrompt"
-          rows="2"
-          class="textarea textarea-bordered mt-2 w-full"
-          placeholder="Leave blank for the sensible default."
-        />
+        <div class="mt-2 grid gap-4 sm:grid-cols-3">
+          <div class="space-y-1">
+            <label class="text-sm">Width</label>
+            <input
+              v-model.number="width"
+              type="number"
+              min="64"
+              max="2048"
+              step="8"
+              class="input input-bordered input-sm w-full"
+            />
+          </div>
+          <div class="space-y-1">
+            <label class="text-sm">Height</label>
+            <input
+              v-model.number="height"
+              type="number"
+              min="64"
+              max="2048"
+              step="8"
+              class="input input-bordered input-sm w-full"
+            />
+          </div>
+          <div class="space-y-1">
+            <label class="text-sm">Seed (blank = random)</label>
+            <input
+              v-model="seedInput"
+              type="number"
+              min="0"
+              class="input input-bordered input-sm w-full"
+            />
+          </div>
+        </div>
+        <p class="mt-1 text-xs opacity-50">
+          Estimated frames: {{ estimatedFrames }} ({{ durationSeconds }}s ×
+          {{ fps }}fps)
+        </p>
       </details>
-    </section>
 
-    <video-lora-picker
-      v-model="loraResourceId"
-      v-model:strength="loraStrength"
-      :engine="engine"
-    />
-
-    <content-visibility-controls
-      v-model:is-mature="isMature"
-      v-model:is-public="isPublic"
-      :disabled="videoStore.isBusy"
-    />
-
-    <!-- Output format -->
-    <section class="space-y-2">
-      <label class="font-semibold">Output format</label>
-      <div class="flex gap-2">
+      <!-- Generate -->
+      <section class="space-y-3">
         <button
-          v-for="opt in outputFormats"
-          :key="opt.value"
           type="button"
-          class="btn btn-sm"
-          :class="outputFormat === opt.value ? 'btn-accent' : 'btn-outline'"
-          @click="outputFormat = opt.value"
+          class="btn btn-accent btn-lg w-full"
+          :disabled="!canGenerate"
+          @click="generate"
         >
-          {{ opt.label }}
+          <span
+            v-if="videoStore.isBusy"
+            class="loading loading-spinner loading-sm"
+          />
+          {{ generateLabel }}
         </button>
-      </div>
-      <p class="text-xs opacity-60">{{ activeOutputFormat.hint }}</p>
-    </section>
 
-    <!-- Controls -->
-    <section class="grid gap-4 sm:grid-cols-3">
-      <div class="space-y-1">
-        <label class="text-sm font-semibold">Time (seconds)</label>
-        <input
-          v-model.number="durationSeconds"
-          type="number"
-          min="0.5"
-          max="30"
-          step="0.5"
-          class="input input-bordered w-full"
-        />
-      </div>
-      <div class="space-y-1">
-        <label class="text-sm font-semibold">FPS</label>
-        <input
-          v-model.number="fps"
-          type="number"
-          min="1"
-          max="60"
-          step="1"
-          class="input input-bordered w-full"
-        />
-      </div>
-      <div class="space-y-1">
-        <label class="text-sm font-semibold">Loop</label>
-        <label class="flex h-12 cursor-pointer items-center gap-2">
-          <input v-model="loop" type="checkbox" class="toggle toggle-accent" />
-          <span class="text-sm opacity-70">{{
-            loop ? 'Seamless loop' : 'Play once'
-          }}</span>
-        </label>
-      </div>
-    </section>
-
-    <details class="text-sm">
-      <summary class="cursor-pointer opacity-70">
-        Advanced (size &amp; seed)
-      </summary>
-      <div class="mt-2 grid gap-4 sm:grid-cols-3">
-        <div class="space-y-1">
-          <label class="text-sm">Width</label>
-          <input
-            v-model.number="width"
-            type="number"
-            min="64"
-            max="2048"
-            step="8"
-            class="input input-bordered input-sm w-full"
-          />
+        <div
+          v-if="videoStore.state.message"
+          class="text-center text-sm opacity-70"
+        >
+          {{ videoStore.state.message }}
+          <span v-if="videoStore.state.jobId" class="opacity-50">
+            (job #{{ videoStore.state.jobId }})
+          </span>
         </div>
-        <div class="space-y-1">
-          <label class="text-sm">Height</label>
-          <input
-            v-model.number="height"
-            type="number"
-            min="64"
-            max="2048"
-            step="8"
-            class="input input-bordered input-sm w-full"
-          />
-        </div>
-        <div class="space-y-1">
-          <label class="text-sm">Seed (blank = random)</label>
-          <input
-            v-model="seedInput"
-            type="number"
-            min="0"
-            class="input input-bordered input-sm w-full"
-          />
-        </div>
-      </div>
-      <p class="mt-1 text-xs opacity-50">
-        Estimated frames: {{ estimatedFrames }} ({{ durationSeconds }}s ×
-        {{ fps }}fps)
-      </p>
-    </details>
 
-    <!-- Generate -->
-    <section class="space-y-3">
-      <button
-        type="button"
-        class="btn btn-accent btn-lg w-full"
-        :disabled="!canGenerate"
-        @click="generate"
-      >
-        <span
-          v-if="videoStore.isBusy"
-          class="loading loading-spinner loading-sm"
+        <div
+          v-if="videoStore.state.error"
+          class="alert alert-error text-sm"
+          role="alert"
+        >
+          {{ videoStore.state.error }}
+        </div>
+      </section>
+
+      <!-- Result -->
+      <section v-if="videoStore.state.videoSrc" class="space-y-2">
+        <h2 class="font-semibold">Result</h2>
+        <img
+          v-if="videoStore.resultIsImage"
+          :src="videoStore.state.videoSrc"
+          class="w-full rounded-lg border border-base-300 bg-black object-contain"
+          alt="Generated clip"
         />
-        {{ generateLabel }}
-      </button>
-
-      <div
-        v-if="videoStore.state.message"
-        class="text-center text-sm opacity-70"
-      >
-        {{ videoStore.state.message }}
-        <span v-if="videoStore.state.jobId" class="opacity-50">
-          (job #{{ videoStore.state.jobId }})
-        </span>
-      </div>
-
-      <div
-        v-if="videoStore.state.error"
-        class="alert alert-error text-sm"
-        role="alert"
-      >
-        {{ videoStore.state.error }}
-      </div>
-    </section>
-
-    <!-- Result -->
-    <section v-if="videoStore.state.videoSrc" class="space-y-2">
-      <h2 class="font-semibold">Result</h2>
-      <img
-        v-if="videoStore.resultIsImage"
-        :src="videoStore.state.videoSrc"
-        class="w-full rounded-lg border border-base-300 bg-black object-contain"
-        alt="Generated clip"
-      />
-      <video
-        v-else
-        :src="videoStore.state.videoSrc"
-        class="w-full rounded-lg border border-base-300 bg-black"
-        :loop="loop"
-        controls
-        autoplay
-        muted
-        playsinline
-      />
-      <a
-        :href="videoStore.state.videoSrc"
-        :download="downloadFilename"
-        class="btn btn-sm btn-outline"
-      >
-        ⬇ Download clip
-      </a>
-    </section>
+        <video
+          v-else
+          :src="videoStore.state.videoSrc"
+          class="w-full rounded-lg border border-base-300 bg-black"
+          :loop="loop"
+          controls
+          autoplay
+          muted
+          playsinline
+        />
+        <a
+          :href="videoStore.state.videoSrc"
+          :download="downloadFilename"
+          class="btn btn-sm btn-outline"
+        >
+          ⬇ Download clip
+        </a>
+      </section>
+    </div>
   </div>
 </template>
 
@@ -415,7 +422,9 @@ const outputFormats = [
 
 const outputFormat = ref<VideoOutputFormat>('webp')
 const activeOutputFormat = computed(
-  () => outputFormats.find((f) => f.value === outputFormat.value) ?? outputFormats[0]!,
+  () =>
+    outputFormats.find((f) => f.value === outputFormat.value) ??
+    outputFormats[0]!,
 )
 
 const firstImage = ref('')

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -1,7 +1,7 @@
 <!-- /pages/users/[id].vue -->
 <template>
-  <section class="h-full min-h-0 overflow-y-auto p-4 sm:p-6">
-    <div class="mx-auto max-w-2xl">
+  <section class="kr-surface">
+    <div class="kr-scroll mx-auto max-w-2xl p-4 sm:p-6">
       <NuxtLink
         to="/plan/wonderlab"
         class="btn btn-ghost btn-sm mb-4 rounded-xl"
@@ -14,7 +14,9 @@
         v-if="user"
         class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg"
       >
-        <div class="h-28 bg-linear-to-br from-primary/25 via-secondary/15 to-accent/20" />
+        <div
+          class="h-28 bg-linear-to-br from-primary/25 via-secondary/15 to-accent/20"
+        />
         <div class="px-5 pb-6 sm:px-8">
           <div
             class="-mt-14 flex size-28 items-center justify-center overflow-hidden rounded-3xl border-4 border-base-100 bg-base-200 shadow-md"
@@ -25,12 +27,18 @@
               :alt="displayName"
               class="h-full w-full object-cover"
             />
-            <Icon v-else name="kind-icon:user" class="size-12 text-primary/60" />
+            <Icon
+              v-else
+              name="kind-icon:user"
+              class="size-12 text-primary/60"
+            />
           </div>
 
           <div class="mt-4 flex flex-wrap items-start justify-between gap-3">
             <div class="min-w-0">
-              <p class="text-xs font-black uppercase tracking-widest text-primary">
+              <p
+                class="text-xs font-black uppercase tracking-widest text-primary"
+              >
                 Public Kind Robots profile
               </p>
               <p class="mt-1 break-words text-3xl font-black">
@@ -48,7 +56,9 @@
             </span>
           </div>
 
-          <p class="mt-5 rounded-2xl bg-base-200/70 p-4 text-sm leading-relaxed text-base-content/70">
+          <p
+            class="mt-5 rounded-2xl bg-base-200/70 p-4 text-sm leading-relaxed text-base-content/70"
+          >
             This member has chosen to make their Kind Robots profile public.
           </p>
         </div>
@@ -99,7 +109,9 @@ type PublicUserResponse = {
 
 const route = useRoute()
 const userId = computed(() => {
-  const raw = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id
+  const raw = Array.isArray(route.params.id)
+    ? route.params.id[0]
+    : route.params.id
   const parsed = Number(raw)
   return Number.isInteger(parsed) && parsed > 0 ? parsed : 0
 })
@@ -113,7 +125,9 @@ const { data, status } = await useAsyncData<PublicUserResponse>(
   },
 )
 
-const user = computed(() => (data.value?.success ? data.value.data ?? null : null))
+const user = computed(() =>
+  data.value?.success ? (data.value.data ?? null) : null,
+)
 const displayName = computed(
   () =>
     user.value?.designerName?.trim() ||

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -54,7 +54,6 @@
       "components/conductor/watchlist-page.vue",
       "components/pages/about-page.vue",
       "components/pages/appmaker-page.vue",
-      "components/pages/click-leaderboard.vue",
       "components/pages/conductor-page.vue",
       "components/pages/conductor-pitch-manager.vue",
       "components/pages/conductor-project-chat.vue",
@@ -66,7 +65,6 @@
       "components/pages/portos-page.vue",
       "components/pages/privacy-page.vue",
       "components/pages/serendipity-page.vue",
-      "components/pages/sponsor-page.vue",
       "components/pages/storybook-library-page.vue",
       "components/pages/super-form.vue",
       "components/pages/wallet-page.vue",
@@ -81,13 +79,7 @@
       "pages/admin/wonderlab-reviews.vue",
       "pages/coloring-page.vue",
       "pages/error.vue",
-      "pages/music-mentor.vue",
-      "pages/plan/wonderlab/commentary-guide.vue",
-      "pages/play/challenges/[slug].vue",
-      "pages/play/challenges/leaderboard.vue",
-      "pages/play/video-generator.vue",
-      "pages/resources.vue",
-      "pages/users/[id].vue"
+      "pages/resources.vue"
     ]
   }
 }


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

Eleventh scoped sweep. `root-surface` is a new rule added directly by Silas (#1320, 51-file baseline) that requires every page component's root wrapper to carry the `kr-surface`/`kr-stage` class. `one-scroll` (27 entries) is unchanged and tracked separately by its own task, t-047.

### What changed / what I produced
Restructured 8 standalone routed pages — confirmed via `content/**/*.md` scan that none are MDC-mounted, so each genuinely owns its own scroll region (not nested inside `pages/[...slug].vue`'s content-host scroll) — from a bare `h-full min-h-0 ... overflow-y-auto` root into a real `kr-surface` (non-scrolling bounded root) wrapping a `kr-scroll` (the one scroll region), per the primitive `interface-vision/t-004` established:
- `components/pages/click-leaderboard.vue`
- `components/pages/sponsor-page.vue`
- `pages/music-mentor.vue`
- `pages/plan/wonderlab/commentary-guide.vue`
- `pages/play/challenges/[slug].vue`
- `pages/play/challenges/leaderboard.vue`
- `pages/play/video-generator.vue`
- `pages/users/[id].vue`

Where a suitable single wrapper `<div>` already existed (commentary-guide, users/[id], challenges pages, sponsor-page), it was repurposed as the `kr-scroll` layer rather than adding an extra nesting level. Where the root itself held all content directly (click-leaderboard, music-mentor, video-generator), one new wrapping div was added. Ran `npx prettier --write` afterward, which reindents every descendant line under the new nesting — that's the bulk of the diff in `music-mentor.vue`/`video-generator.vue`/`commentary-guide.vue`; no content changed, only structure/indentation.

Ratcheted the baseline: `root-surface` 51 → 43 via `npm run test:layout-contract -- --update`. All other buckets unchanged.

### How I verified
- `npm run test:layout-contract -- --report`: root-surface 51 → 43, no new violations anywhere else, one-scroll unchanged at 27.
- `npx vue-tsc --noEmit`: clean, exit 0.
- `npx eslint` on all 8 changed files: no warnings/errors.
- Confirmed each file is NOT MDC-mounted (grepped `content/**/*.md` for a `:component-name` mount directive) before treating its root scroll as independently ownable rather than nested under the content-host's own scroll region.

### Stakes
reversible

### Flags for Reviewer
- Could not visually verify in a live preview (no Vercel deployment triggered from this sandbox mid-session); the restructuring is mechanical (root gets `kr-surface`, existing/new inner wrapper gets `kr-scroll` + the original padding/margin/max-width classes) and matches the pattern already used elsewhere in the codebase, but a Vercel-preview spot-check on 1-2 of these (e.g. `/play/video-generator`, `/users/[id]`) before or after merge would be good due diligence per AGENTS.md's front-end verification note.
- Left `error.vue` and `components/user/login-page.vue` out of this sweep — both center content with `items-center justify-center` on the same element that currently also scrolls, which needs a slightly different restructuring (move centering into the `kr-scroll` layer) than the simpler single-scroll-region pages here. Good candidates for the next scoped pass.
- Left `welcome-page.vue` out — grepped for importers/usages and found none outside its own file and generated registries; looks orphaned, better suited to an orphan-cleanup task (like t-018) than a real fix.
- MDC-mounted `-page.vue` components (e.g. `about-page.vue`, `registration-page.vue`, `wallet-page.vue`, `login-page.vue`) make up most of the remaining 43 root-surface entries. Their correct treatment is genuinely ambiguous: they're embedded in `pages/[...slug].vue`'s own scrolling content-host, so `kr-surface`'s `overflow-hidden` (or `kr-stage`'s, both of which clip content that would otherwise grow past the viewport) could regress pages with long-form content, since the wrapping `<ContentRenderer>` doesn't establish a flex context for the child to safely bound itself. Flagging for the Reviewer/Silas rather than guessing — may need a design call on whether these should get a third primitive (e.g. an unbounded `kr-content` class that's just a `kr-surface`/`kr-stage`-equivalent marker with no `overflow`/`h-full` behavior) before they can be swept safely.

### Kaizen suggestion
File a task to design (or confirm) the intended `root-surface` treatment for MDC-mounted `-page.vue` components — the largest remaining slice of the 43-entry bucket can't be swept with the existing `kr-surface`/`kr-stage` primitives without risking a scroll/clipping regression on long-form content pages.

### Notes for reviewer
Task claimed as `interface-vision/t-017` (session `claude-quirky-curie-20260802T152959Z-t017`). Will set `status: review` in conductor before merge and re-arm to `ready` after, per this task's own recurring-sweep convention (allow-list not yet zero).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsfrXZhSoU2qxS397vdzCY)_