### PR TITLE
fix: adopt root surface on error page

### DIFF
--- a/pages/error.vue
+++ b/pages/error.vue
@@ -1,31 +1,33 @@
 <template>
   <div
-    class="flex h-full min-h-0 w-full items-center justify-center overflow-y-auto overscroll-contain bg-cover bg-center"
+    class="kr-surface bg-cover bg-center"
     style="background-image: url('/images/background/error.png')"
   >
-    <div class="rounded-2xl bg-base-100/60 p-8 text-center shadow-lg">
-      <p class="mb-4 text-4xl font-bold text-primary">Page Not Found</p>
+    <div class="kr-scroll flex items-center justify-center">
+      <div class="rounded-2xl bg-base-100/60 p-8 text-center shadow-lg">
+        <p class="mb-4 text-4xl font-bold text-primary">Page Not Found</p>
 
-      <p class="mb-8 text-secondary">
-        It looks like this page doesn't exist. Please use the buttons below to
-        navigate.
-      </p>
+        <p class="mb-8 text-secondary">
+          It looks like this page doesn't exist. Please use the buttons below to
+          navigate.
+        </p>
 
-      <div class="flex justify-center space-x-4">
-        <button
-          class="rounded-lg bg-primary px-4 py-2 text-white shadow-md transition-colors hover:bg-secondary"
-          @click="goBack"
-        >
-          Go Back
-        </button>
+        <div class="flex justify-center space-x-4">
+          <button
+            class="rounded-lg bg-primary px-4 py-2 text-white shadow-md transition-colors hover:bg-secondary"
+            @click="goBack"
+          >
+            Go Back
+          </button>
 
-        <button
-          class="flex items-center space-x-2 rounded-lg bg-primary px-4 py-2 text-white shadow-md transition-colors hover:bg-secondary"
-          @click="goHome"
-        >
-          <Icon name="kind-icon:home" class="h-5 w-5" />
-          <span>Go to Home</span>
-        </button>
+          <button
+            class="flex items-center space-x-2 rounded-lg bg-primary px-4 py-2 text-white shadow-md transition-colors hover:bg-secondary"
+            @click="goHome"
+          >
+            <Icon name="kind-icon:home" class="h-5 w-5" />
+            <span>Go to Home</span>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -63,7 +63,6 @@
       "pages/admin/wonderlab-review-rollout.vue",
       "pages/admin/wonderlab-reviews.vue",
       "pages/coloring-page.vue",
-      "pages/error.vue",
       "pages/resources.vue"
     ]
   }


### PR DESCRIPTION
## Summary
- convert `pages/error.vue` from a scrolling root to the shared `kr-surface` + `kr-scroll` contract
- preserve the centered error card and background image
- ratchet the `root-surface` layout-contract baseline from 28 to 27

## Conductor handoff
- project/task: `interface-vision/t-017`
- session: `2026-08-02T171512Z-interface-vision-t-017-r8k4`
- reversible, no database or outward-facing changes

## Verification
- CI must complete successfully before merge, including Layout Contract and TypeScript