### PR TITLE
fix(layout): fifteenth root-surface sweep — coloring-page.vue and resources.vue

### DIFF
--- a/pages/coloring-page.vue
+++ b/pages/coloring-page.vue
@@ -7,32 +7,32 @@
   still lives in the Styler tab; this is the one-tap front door.
 -->
 <template>
-  <div
-    class="mx-auto flex h-full min-h-0 w-full max-w-4xl flex-col gap-4 overflow-y-auto overscroll-contain p-4 sm:p-6"
-  >
-    <header class="flex flex-col gap-2">
-      <div class="flex flex-wrap items-center gap-2">
-        <span class="text-3xl leading-none">🖍️</span>
-        <p class="text-2xl font-black text-base-content sm:text-3xl">
-          Coloring Page Maker
+  <div class="kr-surface mx-auto w-full max-w-4xl">
+    <div class="kr-scroll flex flex-col gap-4 p-4 sm:p-6">
+      <header class="flex flex-col gap-2">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-3xl leading-none">🖍️</span>
+          <p class="text-2xl font-black text-base-content sm:text-3xl">
+            Coloring Page Maker
+          </p>
+          <span class="badge badge-primary badge-sm font-bold">New</span>
+        </div>
+        <p class="max-w-2xl text-sm text-base-content/60">
+          Turn any photo or finished design into a printable black-and-white
+          coloring page. Upload an image or pick one from your gallery, choose
+          <b class="text-base-content/80">Coloring Page</b> for crisp line art or
+          <b class="text-base-content/80">Bold Coloring</b> for thick,
+          kid-friendly outlines, then generate, download, and print.
         </p>
-        <span class="badge badge-primary badge-sm font-bold">New</span>
-      </div>
-      <p class="max-w-2xl text-sm text-base-content/60">
-        Turn any photo or finished design into a printable black-and-white
-        coloring page. Upload an image or pick one from your gallery, choose
-        <b class="text-base-content/80">Coloring Page</b> for crisp line art or
-        <b class="text-base-content/80">Bold Coloring</b> for thick,
-        kid-friendly outlines, then generate, download, and print.
-      </p>
-    </header>
+      </header>
 
-    <art-styler
-      :styles="COLORING_STYLES"
-      :source-image-id="sourceImageId"
-      selected-style-key="coloring-page"
-      :show-close="false"
-    />
+      <art-styler
+        :styles="COLORING_STYLES"
+        :source-image-id="sourceImageId"
+        selected-style-key="coloring-page"
+        :show-close="false"
+      />
+    </div>
   </div>
 </template>
 

--- a/pages/resources.vue
+++ b/pages/resources.vue
@@ -8,7 +8,7 @@
     - Discover   browse Civitai / CivArchive + queue downloads (<lora-discover>)
 -->
 <template>
-  <div class="flex h-full min-h-0 w-full flex-col gap-3 p-3">
+  <div class="kr-surface p-3">
     <div role="tablist" class="tabs tabs-boxed w-fit self-center">
       <button
         v-for="tab in tabs"
@@ -24,7 +24,7 @@
       </button>
     </div>
 
-    <div class="min-h-0 flex-1 overflow-y-auto">
+    <div class="kr-scroll">
       <resource-gallery v-if="activeTab === 'library'" />
       <lora-discover v-else />
     </div>

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -57,9 +57,7 @@
       "pages/admin/wonderlab-review-generator.vue",
       "pages/admin/wonderlab-review-plan.vue",
       "pages/admin/wonderlab-review-rollout.vue",
-      "pages/admin/wonderlab-reviews.vue",
-      "pages/coloring-page.vue",
-      "pages/resources.vue"
+      "pages/admin/wonderlab-reviews.vue"
     ]
   }
 }


### PR DESCRIPTION
## Task
interface-vision/t-017 (conductor): "Sweep the layout-contract allow-list to zero, daily-drivers first, admin last" — fifteenth scoped sweep.

## What changed
- `pages/coloring-page.vue`: root div mixed centering (`mx-auto max-w-4xl`) with scroll ownership (`overflow-y-auto`) on the same element. Split into a `kr-surface` (bounded, keeps the centering) wrapping a `kr-scroll` (the one scroll region, keeps the gap/padding/content).
- `pages/resources.vue`: root div's own classes already matched `kr-surface`'s utility values almost exactly, and its inner div already matched `kr-scroll`'s — just not using the shared primitive classes, so the checker couldn't recognize it. Swapped both to the named classes with no visual/behavior change.
- `utils/scripts/layout-contract-baseline.json`: root-surface ratcheted 23 → 21 via `--update`.

Neither file is MDC-mounted (grepped `content/**/*.md` for both names), sidestepping the eleventh sweep's flagged risk of clipping long-form content under a `ContentRenderer` host that lacks a height context — these are real standalone routed pages, same class of fix as sweeps ten through fourteen.

## How I verified
- `npm run test:layout-contract` — root-surface 23 → 21, all other buckets unchanged, "Layout contract holds — no new violations."
- `npx vue-tsc --noEmit` — clean.
- `npx eslint pages/coloring-page.vue pages/resources.vue` — clean.

## Stakes
reversible

## Kaizen suggestion
The remaining root-surface entries (`about-page.vue`, `wallet-page.vue`, `wishmaster-page.vue`, etc.) are mostly MDC-mounted `-page.vue` components — the eleventh sweep flagged that converting them to `kr-surface` risks clipping content under `pages/[...slug].vue`'s `ContentRenderer` host, which gives no height context. A fifth "unbounded" primitive (a marker class with no overflow/height behavior) was proposed then but never built — that's the real blocker on the largest remaining chunk of this bucket.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MSoKYC1fx7aaCrMCqcHSr8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSoKYC1fx7aaCrMCqcHSr8)_