### PR TITLE
fix(art): bulk cancel failed queue jobs

### DIFF
--- a/components/art/artjob-failed-page-requeue.vue
+++ b/components/art/artjob-failed-page-requeue.vue
@@ -8,7 +8,8 @@
       <div class="min-w-0">
         <h3 class="text-sm font-semibold">Failed-job recovery</h3>
         <p class="mt-1 text-xs text-base-content/60">
-          Only the failed jobs currently loaded on page {{ artJobStore.jobPage }}
+          Only the failed jobs currently loaded on page
+          {{ artJobStore.jobPage }}
           are eligible. Historical failures on other pages are untouched.
         </p>
       </div>
@@ -133,21 +134,21 @@ async function cancelFailedOnPage(): Promise<void> {
   hasFailures.value = false
 
   try {
-    const results = await Promise.all(
-      jobIds.map((id) =>
-        performFetch(`/api/art/queue/${id}/cancel`, {
-          method: 'POST',
-          body: JSON.stringify({
-            reason: 'Cleared from failed queue by admin.',
-          }),
-        }),
-      ),
-    )
-    const failedCount = results.filter((response) => !response.success).length
-    hasFailures.value = failedCount > 0
-    message.value = failedCount
-      ? `Cleared ${jobIds.length - failedCount} of ${jobIds.length} failed ArtJobs. ${failedCount} could not be cleared.`
-      : `Cleared ${jobIds.length} failed ArtJobs from this page.`
+    const response = await performFetch<{
+      cancelledCount: number
+      skippedCount: number
+    }>('/api/art/queue/cancel-failed', {
+      method: 'POST',
+      body: JSON.stringify({
+        jobIds,
+        reason: 'Cleared from failed queue by admin.',
+      }),
+    })
+
+    hasFailures.value = !response.success
+    message.value = response.success
+      ? response.message
+      : response.message || 'Failed to clear selected failed ArtJobs.'
     await Promise.all([artJobStore.fetchJobs(), artJobStore.fetchStats()])
   } finally {
     submitting.value = false

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:art-request-yaml": "tsx utils/scripts/verifyArtRequestYaml.ts && tsx utils/scripts/verifyArtAssetSuggest.ts",
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:art-asset-suggest": "tsx utils/scripts/verifyArtAssetSuggest.ts",
-    "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts",
+    "test:artjob-bulk-scope": "tsx utils/scripts/verifyArtJobBulkScope.ts && tsx utils/scripts/verifyArtJobBulkCancel.ts",
     "test:artjob-lora-override": "tsx utils/scripts/verifyArtJobLoraOverride.ts",
     "test:comfy-model-paths": "tsx utils/scripts/verifyComfyModelPaths.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",

--- a/server/api/art/queue/cancel-failed.post.ts
+++ b/server/api/art/queue/cancel-failed.post.ts
@@ -1,0 +1,75 @@
+// /server/api/art/queue/cancel-failed.post.ts
+//
+// Admin action: cancel an explicit, page-sized selection of FAILED ArtJobs in
+// one database operation. Keeping this bulk avoids saturating the connection
+// pool with one simultaneous request per row from the dashboard.
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '../../../utils/prisma'
+import { errorHandler } from '../../../utils/error'
+import { requireMachineUser } from '../../../utils/authGuard'
+import { normalizeFailedArtJobIds } from '../../../utils/failedArtJobScope'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireMachineUser(event)
+
+    if (!auth.isAdmin && !auth.isServerKey) {
+      throw createError({
+        statusCode: 403,
+        message: 'Admin access required to cancel failed jobs.',
+      })
+    }
+
+    const body = await readBody<{ jobIds?: unknown; reason?: unknown }>(event)
+    const scope = normalizeFailedArtJobIds(body?.jobIds, 'cancel')
+
+    if (!scope.ok) {
+      throw createError({ statusCode: 400, message: scope.message })
+    }
+
+    const reason =
+      typeof body.reason === 'string' && body.reason.trim()
+        ? body.reason.trim().slice(0, 4000)
+        : 'Cleared from failed queue by admin.'
+
+    const result = await prisma.artJob.updateMany({
+      where: {
+        id: { in: scope.ids },
+        status: 'FAILED',
+      },
+      data: {
+        status: 'CANCELLED',
+        claimedAt: null,
+        claimedBy: null,
+        error: reason,
+      },
+    })
+
+    const skippedCount = scope.ids.length - result.count
+
+    return {
+      success: true,
+      message:
+        skippedCount > 0
+          ? `Cancelled ${result.count} failed ArtJobs. ${skippedCount} selected jobs were skipped because they were missing or no longer failed.`
+          : `Cancelled ${result.count} failed ArtJobs.`,
+      data: {
+        selectedCount: scope.ids.length,
+        cancelledCount: result.count,
+        skippedCount,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to cancel selected failed ArtJobs.',
+      statusCode,
+    }
+  }
+})

--- a/server/utils/failedArtJobScope.ts
+++ b/server/utils/failedArtJobScope.ts
@@ -1,24 +1,23 @@
 export const MAX_FAILED_ART_JOB_REQUEUE_IDS = 100
 
 export type FailedArtJobScopeResult =
-  | { ok: true; ids: number[] }
-  | { ok: false; message: string }
+  { ok: true; ids: number[] } | { ok: false; message: string }
 
 export function normalizeFailedArtJobIds(
   value: unknown,
+  action = 'requeue',
 ): FailedArtJobScopeResult {
   if (!Array.isArray(value)) {
     return {
       ok: false,
-      message:
-        'Provide jobIds with the explicit failed ArtJobs to requeue. Global failed-job retry is disabled.',
+      message: `Provide jobIds with the explicit failed ArtJobs to ${action}. Global failed-job actions are disabled.`,
     }
   }
 
   if (value.length === 0) {
     return {
       ok: false,
-      message: 'Select at least one failed ArtJob to requeue.',
+      message: `Select at least one failed ArtJob to ${action}.`,
     }
   }
 

--- a/utils/scripts/verifyArtJobBulkCancel.ts
+++ b/utils/scripts/verifyArtJobBulkCancel.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const route = await readFile(
+  new URL('../../server/api/art/queue/cancel-failed.post.ts', import.meta.url),
+  'utf8',
+)
+const component = await readFile(
+  new URL(
+    '../../components/art/artjob-failed-page-requeue.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
+
+assert.match(route, /prisma\.artJob\.updateMany/)
+assert.match(route, /status: 'FAILED'/)
+assert.match(route, /status: 'CANCELLED'/)
+assert.match(component, /\/api\/art\/queue\/cancel-failed/)
+assert.doesNotMatch(component, /jobIds\.map\([\s\S]*\/cancel/)
+
+console.log('Failed ArtJob bulk cancellation checks passed.')

--- a/utils/scripts/verifyArtJobBulkScope.ts
+++ b/utils/scripts/verifyArtJobBulkScope.ts
@@ -7,7 +7,7 @@ import {
 assert.deepEqual(normalizeFailedArtJobIds(undefined), {
   ok: false,
   message:
-    'Provide jobIds with the explicit failed ArtJobs to requeue. Global failed-job retry is disabled.',
+    'Provide jobIds with the explicit failed ArtJobs to requeue. Global failed-job actions are disabled.',
 })
 
 assert.deepEqual(normalizeFailedArtJobIds([]), {
@@ -23,6 +23,11 @@ assert.deepEqual(normalizeFailedArtJobIds([12, 12, 27]), {
 assert.equal(normalizeFailedArtJobIds([1, '2']).ok, false)
 assert.equal(normalizeFailedArtJobIds([0]).ok, false)
 assert.equal(normalizeFailedArtJobIds([1.5]).ok, false)
+
+assert.deepEqual(normalizeFailedArtJobIds([], 'cancel'), {
+  ok: false,
+  message: 'Select at least one failed ArtJob to cancel.',
+})
 
 const maximumPage = Array.from(
   { length: MAX_FAILED_ART_JOB_REQUEUE_IDS },


### PR DESCRIPTION
### Task
Silas-directed production bug: failed ArtJob cancellation times out (kind: software)

### What changed / what I produced
- Replaced the failed-page UI's one-request-per-job cancellation fan-out with one page-scoped bulk request.
- Added an admin/server-key protected `POST /api/art/queue/cancel-failed` route.
- Cancels only the explicit selected IDs that are still `FAILED`, capped at 100, in one conditional `updateMany`.
- Preserves the existing single-job cancel route.
- Added a bulk-cancellation contract check alongside the existing failed-job scope test.

### How I verified
- `node --import tsx utils/scripts/verifyArtJobBulkScope.ts` — passed.
- `node --import tsx utils/scripts/verifyArtJobBulkCancel.ts` — passed.
- `npm test` — Nuxt prepare and full Vue TypeScript check passed.
- `git diff --check` — passed.

### Stakes
reversible

### Kaizen suggestion
Give bulk queue mutations a shared server helper and prohibit unbounded per-row HTTP fan-out in queue-manager components.

### Notes for reviewer
Root cause: clearing a page of failed jobs launched up to 100 simultaneous HTTP requests; each individual route did a lookup plus update, saturating the production DB pool until the generic 10-second client timeout aborted requests. This changes that page action to one HTTP request and one DB update.