### PR TITLE
Fix ArtJob queue image-load request flood

### DIFF
--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -210,6 +210,11 @@ type ArtJobState = {
 }
 
 const MAX_JOB_IMAGES = 240
+// Loading the queue used to fire every image request at once with Promise.all.
+// A full trainer page can contain hundreds of DB-backed image blobs, so that
+// burst exhausted the per-instance MariaDB pool and returned 503s. Keep the
+// browser below the gallery's established concurrency of four.
+const JOB_IMAGE_LOAD_CONCURRENCY = 4
 const DEFAULT_JOB_PAGE_SIZE = 20
 const MAX_JOB_PAGE_SIZE = 100
 
@@ -428,8 +433,12 @@ export const useArtJobStore = defineStore('artJobStore', () => {
 
     if (!ids.length) return
 
-    await Promise.all(
-      ids.map(async (id) => {
+    let nextIndex = 0
+    const worker = async () => {
+      while (nextIndex < ids.length) {
+        const id = ids[nextIndex]
+        nextIndex += 1
+
         const res = await performFetch<ArtImage>(
           `/api/art/image/${id}?includeImageData=true`,
           { method: 'GET' },
@@ -441,7 +450,14 @@ export const useArtJobStore = defineStore('artJobStore', () => {
           state.imageInfoById[id] = info
           state.imageSrcById[id] = info.src
         }
-      }),
+      }
+    }
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(JOB_IMAGE_LOAD_CONCURRENCY, ids.length) },
+        worker,
+      ),
     )
   }
 

--- a/stores/artJobStore.ts
+++ b/stores/artJobStore.ts
@@ -438,6 +438,7 @@ export const useArtJobStore = defineStore('artJobStore', () => {
       while (nextIndex < ids.length) {
         const id = ids[nextIndex]
         nextIndex += 1
+        if (id === undefined) return
 
         const res = await performFetch<ArtImage>(
           `/api/art/image/${id}?includeImageData=true`,


### PR DESCRIPTION
## What changed

Limits ArtJob queue and trainer image hydration to four concurrent requests instead of launching up to 240 full image-blob requests at once.

## Root cause

`loadJobImages()` capped the total item count but used `Promise.all(ids.map(...))`, producing the captured burst of `/api/art/image/:id?includeImageData=true` requests. ProxySQL can pool database connections, but it cannot make dozens of simultaneous large MariaDB blob reads inexpensive; requests exhausted or stalled behind the per-instance pool and returned 503s.

## Impact

Opening or refreshing the ArtJob queue now keeps database pressure bounded while still loading all requested images progressively.

## Validation

- `npm test` (Nuxt prepare + Vue TypeScript check) — passed
- `git diff --check` — passed
- File-scoped ESLint reaches two pre-existing `no-dynamic-delete` violations at lines 332–333; the new code adds no lint findings.