### PR TITLE
interface-vision (t-055): kr-gallery degrades, Facets adopts it, and six copies of one chain collapse

### DIFF
--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -150,6 +150,7 @@ import {
 } from '@/stores/facetCatalogStore'
 import { useFacetArtRequestStore } from '@/stores/facetArtRequestStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
 const props = withDefaults(
   defineProps<{
@@ -266,7 +267,7 @@ async function requestArtwork(facet: FacetCatalogEntry): Promise<void> {
 }
 
 function facetArtwork(facet: FacetCatalogEntry): string | null {
-  return facet.cardPath || facet.imagePath || facet.heroPath || null
+  return resolveEntityArtwork(facet)
 }
 
 function taxonomyLabel(taxonomy: string): string {

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -108,6 +108,7 @@ import {
 } from '@/stores/facetStore'
 import { useCharacterFacetStore } from '@/stores/characterFacetStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
 const props = withDefaults(
   defineProps<{
@@ -156,7 +157,7 @@ const searchResults = computed(() => {
 })
 
 function artwork(facet: FacetWithAliases): string | null {
-  return facet.cardPath || facet.imagePath || facet.heroPath || null
+  return resolveEntityArtwork(facet)
 }
 
 async function loadAssigned(): Promise<void> {

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -67,69 +67,16 @@
         <span class="badge badge-secondary badge-sm">{{ group.entries.length }}</span>
       </div>
 
-      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-        <article
-          v-for="facet in group.entries"
-          :key="facet.id"
-          class="group overflow-hidden rounded-2xl border border-base-300 bg-base-100 transition-all hover:shadow-lg"
-        >
-          <div class="relative flex h-40 items-center justify-center bg-base-200">
-            <img
-              v-if="facetArtwork(facet)"
-              :src="facetArtwork(facet) || ''"
-              :alt="`${facet.title} artwork`"
-              class="size-full object-cover"
-              loading="lazy"
-            />
-            <div
-              v-else
-              class="flex size-full flex-col items-center justify-center gap-1 bg-gradient-to-br from-base-200 to-base-300 text-base-content/40"
-            >
-              <Icon
-                :name="iconName(facet)"
-                class="size-8"
-              />
-              <span class="text-[10px] uppercase tracking-wide">
-                {{ facet.artRequired ? 'art pending' : 'no art' }}
-              </span>
-            </div>
-          </div>
-
-          <div class="space-y-1.5 p-3">
-            <div class="flex flex-wrap items-center gap-1">
-              <span class="badge badge-outline badge-xs">
-                {{ taxonomyLabel(facet.taxonomy) }}
-              </span>
-              <span v-if="facet.groupLabel" class="badge badge-ghost badge-xs">
-                {{ facet.groupLabel }}
-              </span>
-            </div>
-            <h3 class="truncate text-sm font-bold" :title="facet.title">
-              {{ facet.title }}
-            </h3>
-            <p
-              v-if="facet.description"
-              class="line-clamp-2 text-xs text-base-content/60"
-            >
-              {{ facet.description }}
-            </p>
-            <p
-              v-else-if="facet.flavorText"
-              class="line-clamp-2 text-xs italic text-base-content/50"
-            >
-              {{ facet.flavorText }}
-            </p>
-            <p
-              v-if="facet.aliases.length"
-              class="truncate text-[11px] text-base-content/35"
-              :title="facet.aliases.join(' · ')"
-            >
-              {{ facet.aliases.join(' · ') }}
-            </p>
-
-          </div>
-        </article>
-      </div>
+      <!-- One kr-gallery per taxonomy group. The shell owns no scroll region,
+           so mounting it N times is structurally fine, and `:modes="[]"` drops
+           the view-mode bar -- this gallery is a fixed-shape taxonomy showcase,
+           not a mode-switching browser. -->
+      <kr-gallery
+        :items="group.entries.map(toGalleryItem)"
+        mode="cards"
+        :modes="[]"
+        empty-label="facets"
+      />
     </div>
 
     <p
@@ -150,6 +97,8 @@ import {
   type FacetTaxonomy,
 } from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+import { resolveArtVariantSrc } from '@/utils/artImageSrc'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 
 const catalog = useFacetCatalogStore()
 
@@ -158,13 +107,48 @@ const taxonomyFilter = ref<FacetTaxonomy | null>(null)
 const artOnly = ref(false)
 const errorMessage = ref('')
 
+/*
+ * Kept for the `artOnly` filter below, which needs to know whether a facet has
+ * ANY art regardless of which variant the current view would pick. Rendering no
+ * longer uses it -- kr-gallery resolves the variant itself from `source`, so
+ * this file no longer carries its own copy of the cardPath||imagePath||heroPath
+ * chain that six components were each repeating.
+ */
 function facetArtwork(facet: FacetCatalogEntry): string | null {
-  return facet.cardPath || facet.imagePath || facet.heroPath || facet.iconPath || null
+  // Checks all three variants, not just the one the card view renders: the old
+  // hand-rolled chain was `cardPath || imagePath || heroPath || iconPath`, so a
+  // facet illustrated ONLY at hero or icon size counted as having art. Asking
+  // resolveArtVariantSrc for 'card' alone would have silently dropped those
+  // from the filter.
+  return (
+    resolveArtVariantSrc(facet, 'card') ||
+    resolveArtVariantSrc(facet, 'hero') ||
+    resolveArtVariantSrc(facet, 'icon') ||
+    null
+  )
 }
 
 function iconName(facet: FacetCatalogEntry): string {
   const icon = facet.icon?.trim()
   return icon && icon.includes(':') ? icon : 'kind-icon:tag'
+}
+
+function toGalleryItem(facet: FacetCatalogEntry): GalleryItem {
+  const badges = [{ label: taxonomyLabel(facet.taxonomy), class: 'badge-outline' }]
+  if (facet.groupLabel) badges.push({ label: facet.groupLabel, class: 'badge-ghost' })
+
+  return {
+    id: facet.id,
+    title: facet.title,
+    description: facet.description || facet.flavorText || '',
+    source: facet,
+    badges,
+    meta: facet.aliases.length ? facet.aliases.join(' · ') : '',
+    placeholderIcon: iconName(facet),
+    // Distinguishes "queued for art" from "never getting art" — the catalog
+    // marks which facets are meant to be illustrated.
+    placeholderLabel: facet.artRequired ? 'art pending' : 'no art',
+  }
 }
 
 function taxonomyLabel(taxonomy: FacetTaxonomy): string {

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -97,7 +97,7 @@ import {
   type FacetTaxonomy,
 } from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
-import { resolveArtVariantSrc } from '@/utils/artImageSrc'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 
 const catalog = useFacetCatalogStore()
@@ -114,18 +114,10 @@ const errorMessage = ref('')
  * this file no longer carries its own copy of the cardPath||imagePath||heroPath
  * chain that six components were each repeating.
  */
+// Feeds the "illustrated only" filter, which needs to know whether a facet has
+// ANY art rather than whether the card view happens to resolve one.
 function facetArtwork(facet: FacetCatalogEntry): string | null {
-  // Checks all three variants, not just the one the card view renders: the old
-  // hand-rolled chain was `cardPath || imagePath || heroPath || iconPath`, so a
-  // facet illustrated ONLY at hero or icon size counted as having art. Asking
-  // resolveArtVariantSrc for 'card' alone would have silently dropped those
-  // from the filter.
-  return (
-    resolveArtVariantSrc(facet, 'card') ||
-    resolveArtVariantSrc(facet, 'hero') ||
-    resolveArtVariantSrc(facet, 'icon') ||
-    null
-  )
+  return resolveEntityArtwork(facet)
 }
 
 function iconName(facet: FacetCatalogEntry): string {

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -255,6 +255,7 @@ import {
   facetToProfileForm,
   type FacetProfileForm,
 } from '@/utils/facetProfileForm'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
 const facetStore = useFacetStore()
 const search = ref('')
@@ -320,7 +321,7 @@ function taxonomyLabel(taxonomy: FacetTaxonomy): string {
 }
 
 function facetArtwork(facet: FacetWithAliases): string | null {
-  return facet.cardPath || facet.imagePath || facet.heroPath || facet.iconPath || null
+  return resolveEntityArtwork(facet)
 }
 
 function setError(error: unknown, fallback: string): void {

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -164,6 +164,7 @@ import {
   type FacetTaxonomy,
 } from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
 const props = withDefaults(
   defineProps<{
@@ -260,7 +261,7 @@ function taxonomyLabel(taxonomy: FacetTaxonomy): string {
 }
 
 function facetArtwork(facet: FacetWithAliases): string | null {
-  return facet.cardPath || facet.imagePath || facet.heroPath || null
+  return resolveEntityArtwork(facet)
 }
 
 function facetTitle(facet: FacetWithAliases): string {

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -48,10 +48,25 @@
       >
         <div class="relative overflow-hidden" :class="imageWrapClass">
           <img
+            v-if="displayImage(item)"
             :src="displayImage(item)"
             :alt="item.title"
             class="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105"
           />
+          <!-- Art-absent placeholder. Without this an unillustrated row renders
+               <img src="">, which browsers treat as "reload the current page"
+               and paint as a broken image. Galleries whose rows are routinely
+               unillustrated (facets, where art is queued rather than required)
+               could not adopt this shell at all until it degraded properly. -->
+          <div
+            v-else
+            class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-linear-to-br from-base-200 to-base-300 text-base-content/40"
+          >
+            <Icon :name="item.placeholderIcon || 'kind-icon:image'" class="size-8" />
+            <span v-if="item.placeholderLabel" class="text-[10px] uppercase tracking-wide">
+              {{ item.placeholderLabel }}
+            </span>
+          </div>
           <div class="absolute inset-0 bg-linear-to-t from-base-300/90 via-transparent to-transparent" />
           <div v-if="item.badges?.length" class="absolute left-2 top-2 flex gap-1">
             <span v-for="badge in item.badges" :key="badge.label" class="badge badge-xs" :class="badge.class">
@@ -90,6 +105,11 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import {
+  resolveArtVariantSrc,
+  type ArtImageSrcLike,
+  type ArtVariant,
+} from '@/utils/artImageSrc'
 
 export type GalleryMode = 'cards' | 'heroes' | 'icons' | 'list'
 
@@ -103,12 +123,28 @@ export interface GalleryItem {
   id: string | number
   title: string
   description?: string
+  /*
+   * Pre-resolved variant URLs. Use these when the caller's resolution is
+   * genuinely domain-specific -- conductor-project-gallery-page.vue, for one,
+   * merges a remote conductor record, detects canonical paths and appends a
+   * cache-busting revision, none of which a generic resolver can do.
+   */
   icon?: string
   card?: string
   hero?: string
+  /*
+   * The raw record instead, for the ordinary case. kr-gallery resolves it
+   * through resolveArtVariantSrc, so a consumer stops hand-rolling the
+   * cardPath || imagePath || heroPath || iconPath chain -- six components were
+   * each carrying their own copy of exactly that when this was added.
+   */
+  source?: ArtImageSrcLike
   meta?: string
   progressPercent?: number
   badges?: Array<{ label: string; class?: string }>
+  /** Shown when nothing resolves. Defaults to a generic image glyph. */
+  placeholderIcon?: string
+  placeholderLabel?: string
 }
 
 const props = withDefaults(
@@ -160,8 +196,30 @@ const imageWrapClass = computed(() =>
         ? 'min-h-40'
         : 'aspect-[4/3]',
 )
+/*
+ * Which art variant this mode wants. Heroes and list are wide, icons is square,
+ * cards is the 4:3 default.
+ */
+const modeVariant = computed<ArtVariant>(() =>
+  props.mode === 'heroes' || props.mode === 'list'
+    ? 'hero'
+    : props.mode === 'icons'
+      ? 'icon'
+      : 'card',
+)
+
 function displayImage(item: GalleryItem): string {
-  const variant = props.mode === 'heroes' || props.mode === 'list' ? item.hero : props.mode === 'icons' ? item.icon : item.card
-  return variant || item.card || item.icon || item.hero || ''
+  const preResolved =
+    modeVariant.value === 'hero'
+      ? item.hero
+      : modeVariant.value === 'icon'
+        ? item.icon
+        : item.card
+
+  // A caller that pre-resolved wins outright; only fall back across variants
+  // for callers that pre-resolved SOME of them.
+  if (preResolved) return preResolved
+  if (item.source) return resolveArtVariantSrc(item.source, modeVariant.value)
+  return item.card || item.icon || item.hero || ''
 }
 </script>

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -108,6 +108,7 @@ import {
 } from '@/stores/facetStore'
 import { useRewardFacetStore } from '@/stores/rewardFacetStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
 const props = withDefaults(
   defineProps<{
@@ -154,7 +155,7 @@ const searchResults = computed(() => {
 })
 
 function artwork(facet: FacetWithAliases): string | null {
-  return facet.cardPath || facet.imagePath || facet.heroPath || null
+  return resolveEntityArtwork(facet)
 }
 
 async function loadAssigned(): Promise<void> {

--- a/utils/artImageSrc.ts
+++ b/utils/artImageSrc.ts
@@ -94,6 +94,33 @@ export function resolveArtVariantSrc(
   return resolveArtImageSrc(image, fallback)
 }
 
+/**
+ * Card-first display artwork for any entity that carries art, or null.
+ *
+ * This chain -- `cardPath || imagePath || heroPath [|| iconPath]` -- had been
+ * hand-written SIX times: utils/narrativeIngredients.ts, facet-gallery.vue,
+ * facet-manager.vue, facet-picker.vue, character-facet-picker.vue,
+ * reward-facet-picker.vue and art-facet-selector.vue each carried their own
+ * copy. They had already drifted: some included iconPath, some did not.
+ *
+ * Ordering is preserved rather than "improved". Asking resolveArtVariantSrc for
+ * each variant in turn yields cardPath -> cardData -> imagePath -> imageData ->
+ * heroPath -> ... -> iconPath, so the relative precedence of the three path
+ * fields matches every copy this replaces; the base64 fallbacks are a superset,
+ * reachable only where a path was absent and the old chain returned null.
+ *
+ * Returns null, not '', because every caller tested truthiness to decide
+ * between an <img> and a placeholder.
+ */
+export function resolveEntityArtwork(image: ArtImageSrcLike): string | null {
+  return (
+    resolveArtVariantSrc(image, 'card') ||
+    resolveArtVariantSrc(image, 'hero') ||
+    resolveArtVariantSrc(image, 'icon') ||
+    null
+  )
+}
+
 // Renderable source for a thumbnail. Prefers thumbnailPath, then the full-size
 // path, then inline thumbnail/full base64, then `fallback`.
 export function resolveArtImageThumbSrc(

--- a/utils/narrativeIngredients.ts
+++ b/utils/narrativeIngredients.ts
@@ -1,5 +1,7 @@
 // /utils/narrativeIngredients.ts
 
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
+
 export type NarrativeIngredientOption = {
   id?: number | string
   slug: string
@@ -13,15 +15,12 @@ export type NarrativeIngredientOption = {
   badge?: string | null
 }
 
+// Kept as a named export because verifyNarrativePrimitives.ts pins it and the
+// ingredient pickers read better for it; the chain itself now lives in one place.
 export function narrativeIngredientArtwork(
   ingredient: NarrativeIngredientOption,
 ): string | null {
-  return (
-    ingredient.cardPath ||
-    ingredient.imagePath ||
-    ingredient.heroPath ||
-    null
-  )
+  return resolveEntityArtwork(ingredient)
 }
 
 export function narrativeIngredientSummary(

--- a/utils/scripts/verifyFacetArtworkMigration.ts
+++ b/utils/scripts/verifyFacetArtworkMigration.ts
@@ -239,7 +239,10 @@ async function main(): Promise<void> {
     'cardPath: editForm.cardPath.trim() || null',
     'heroPath: editForm.heroPath.trim() || null',
     'artPrompt: editForm.artPrompt.trim() || null',
-    'return facet.cardPath || facet.imagePath || facet.heroPath || null',
+    // Was the literal chain `facet.cardPath || facet.imagePath || facet.heroPath`.
+    // That chain lived in six files and now lives in one (resolveEntityArtwork,
+    // utils/artImageSrc.ts), so this asserts the call rather than the copy.
+    'resolveEntityArtwork(facet)',
   ]) {
     requireText('components/facets/facet-manager.vue', facetManager, field)
   }


### PR DESCRIPTION
Two commits. First of the seven core-object galleries, plus the duplication it exposed.

---

# 1. Teach kr-gallery to degrade, and move Facets onto it

## Why the shell couldn't absorb anything yet

`kr-gallery` rendered ``'&lt;img :src="displayImage(item)"&gt;'`` unconditionally. An unillustrated row produced `<img src="">`, which browsers resolve as *"re-request the current page"* and paint as a broken image.

Any gallery whose rows are routinely unillustrated couldn't adopt the shell without regressing — and the Facet catalog is exactly that, since it marks which facets are *meant* to be illustrated (`artRequired`) and leaves the rest bare. There's now a placeholder branch with an optional per-item icon and label, so Facets keeps saying **"art pending"** vs **"no art"**.

Second: `displayImage()` was itself a hand-rolled copy of the `cardPath`/`heroPath`/`iconPath` chain — the duplication `resolveArtVariantSrc` exists to end, sitting inside the component meant to end it. `GalleryItem` now takes an optional `source` which the shell resolves.

Pre-resolved `card`/`hero`/`icon` **stay** and are still preferred. `conductor-project-gallery-page.vue` merges a remote conductor record, detects canonical paths and appends a cache-busting revision — no generic resolver can do that. `source` is a fallback, not a replacement.

## Facets

Adopted **per taxonomy group**, not one flat grid: `verifyFacetGallery.ts` pins this as a read-only grouped catalog showcase. kr-gallery owns no scroll region, so mounting it per group is fine; `:modes="[]"` drops the mode bar.

**A behaviour difference caught before committing:** `facetArtwork()` feeds the "illustrated only" filter as well as rendering. Asking the resolver for `'card'` alone would have silently dropped facets illustrated *only* at hero or icon size out of that filter.

233 → 207 lines. Counter moves **1/7 → 2/7**.

---

# 2. Collapse six copies of the facet artwork chain

`cardPath || imagePath || heroPath [|| iconPath]` was hand-written **six times**:

| File | Helper |
|---|---|
| `utils/narrativeIngredients.ts` | `narrativeIngredientArtwork()` |
| `components/facets/facet-manager.vue` | `facetArtwork()` |
| `components/facets/facet-picker.vue` | `facetArtwork()` |
| `components/characters/character-facet-picker.vue` | `artwork()` |
| `components/rewards/reward-facet-picker.vue` | `artwork()` |
| `components/art/art-facet-selector.vue` | `facetArtwork()` |

**They had already drifted** — facet-manager's copy included `iconPath`, the other five didn't. That's the failure mode a shared resolver prevents, and `resolveArtVariantSrc` has existed since t-007; these six just never used it.

`resolveEntityArtwork()` is now the single implementation. `narrativeIngredientArtwork` keeps its name and export (`verifyNarrativePrimitives.mjs` pins it); only its body moved.

**Ordering deliberately preserved, not "improved."** Asking for card → hero → icon yields `cardPath → cardData → imagePath → imageData → heroPath → … → iconPath`, so the relative precedence of the three path fields matches every copy replaced. The base64 fallbacks are a strict superset, reachable only where a path was absent and the old chain returned null.

---

## Two things found and NOT fixed — both pre-existing

`verifyFacetArtworkMigration.ts` asserted the literal old chain, so I updated that one assertion rather than leave a contract pinning text this PR deleted. But **it was already failing before this change**, on an unrelated assertion (`v-model="newImagePath"`) — confirmed by stashing and re-running against a clean tree.

The reason nobody noticed is worse: its CI step runs `npx tsx … 2>&1 | tee report.txt`, so the step's exit code is `tee`'s and **the check can never fail**. Filed as conductor **t-061** (fix the pipeline first, then the contract).

Also filed **t-062**: the remaining five galleries can't adopt kr-gallery as it stands — they delegate to rich per-object cards and use a horizontal-scroller row layout kr-gallery has no equivalent for. That's a product decision, not effort.

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean
- `npx nuxi build` — both bundles compile; prerender needs a `JWT_SECRET` this environment lacks
- `test:facet-gallery`, `test:facet-catalog`, `test:facet-aliases`, `test:gallery-adoption`, `test:layout-contract`, `verifyNarrativePrimitives` — all pass
- Line endings audited on all touched files
- **Not opened in a browser.** `/facets` is worth a look — a grouped grid is exactly what a source-text contract can't judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd