### PR TITLE
interface-vision (t-031): Dreams onto the shared card shell, gaining reactions

### DIFF
--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -1,9 +1,23 @@
 <!-- /components/dreams/dream-card.vue -->
 <template>
-  <article
-    class="group relative flex h-full min-h-0 cursor-pointer overflow-hidden rounded-2xl border bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl"
-    :class="cardClass"
-    @click="$emit('choose', dream)"
+  <!-- The shared card shell (interface-vision t-031). Dreams were the only one
+       of the five object cards still rolling their own <article>, which is why
+       they had no reaction or review affordance at all while Bot, Character,
+       Reward and Scenario did -- `dream` has been a valid ReactionTargetType and
+       `DREAM` a valid category the whole time; nothing ever wired it up.
+       :padded="false" keeps the full-bleed poster look this card is built
+       around; the other four inset their art and take the default padding. -->
+  <reactable-card
+    :selected="activeSelected"
+    :compact="compact"
+    :padded="false"
+    :allow-reviews="dream.allowReviews"
+    :target-id="dream.id"
+    target-type="dream"
+    reaction-category="DREAM"
+    :target-title="dreamTitle"
+    :card-class="['h-full min-h-0 bg-base-100 shadow-sm hover:-translate-y-0.5 hover:shadow-xl', cardClass]"
+    @select="emit('choose', dream)"
   >
     <figure
       v-if="showImage"
@@ -44,7 +58,7 @@
       </div>
 
       <div
-        v-if="selected || isSelected"
+        v-if="activeSelected"
         class="absolute right-2 top-2 rounded-full border border-primary/40 bg-base-100/90 p-2 text-primary shadow backdrop-blur"
       >
         <Icon name="kind-icon:check" class="h-4 w-4" />
@@ -105,31 +119,27 @@
       </p>
     </section>
 
-    <div
-      v-if="showActions && (allowEdit || allowDelete)"
-      class="pointer-events-none absolute right-2 top-2 flex gap-1 opacity-0 transition group-hover:pointer-events-auto group-hover:opacity-100"
-      @click.stop
-    >
+    <template #actions>
       <button
-        v-if="allowEdit"
+        v-if="showActions && allowEdit"
         type="button"
         class="btn btn-circle btn-sm border-base-300 bg-base-100/90 shadow backdrop-blur"
         title="Edit Dream"
-        @click="$emit('edit', dream.id)"
+        @click="emit('edit', dream.id)"
       >
         <Icon name="kind-icon:edit" class="h-4 w-4" />
       </button>
 
       <button
-        v-if="allowDelete"
+        v-if="showActions && allowDelete"
         type="button"
         class="btn btn-circle btn-sm border-base-300 bg-base-100/90 text-error shadow backdrop-blur"
         title="Archive Dream"
-        @click="$emit('delete', dream.id)"
+        @click="emit('delete', dream.id)"
       >
         <Icon name="kind-icon:archive" class="h-4 w-4" />
       </button>
-    </div>
+    </template>
 
     <details
       v-if="showDebug"
@@ -143,7 +153,7 @@
         debugInfo
       }}</pre>
     </details>
-  </article>
+  </reactable-card>
 </template>
 
 <script setup lang="ts">
@@ -185,10 +195,10 @@ const props = withDefaults(
   },
 )
 
-defineEmits<{
-  (event: 'choose', dream: DreamWithRelations): void
-  (event: 'edit', id: number): void
-  (event: 'delete', id: number): void
+const emit = defineEmits<{
+  choose: [dream: DreamWithRelations]
+  edit: [id: number]
+  delete: [id: number]
 }>()
 
 const dreamTitle = computed(() => {
@@ -550,16 +560,25 @@ const artCount = computed(() => {
   return props.dream._count?.ArtImages ?? collectionArt.value.length
 })
 
+/*
+ * `selected` and `isSelected` are two props for one state -- they were declared
+ * separately and then always read together (`selected || isSelected`) in both
+ * the template and cardClass. Collapsed to one computed rather than removing a
+ * prop, because callers pass both spellings and dropping either would silently
+ * stop working at a call site vue-tsc cannot see through a template.
+ */
+const activeSelected = computed(() => props.selected || props.isSelected)
+
 const cardClass = computed(() => {
-  if (props.selected || props.isSelected) {
-    return 'border-primary ring-2 ring-primary/30'
-  }
+  // reactable-card draws the selected border and tint itself; this only adds
+  // the ring on top, and the inactive-dream treatment.
+  if (activeSelected.value) return 'ring-2 ring-primary/30'
 
   if (props.dream.isActive === false) {
-    return 'border-base-300 opacity-70 grayscale-[35%]'
+    return 'opacity-70 grayscale-[35%]'
   }
 
-  return 'border-base-300'
+  return ''
 })
 
 function dreamTypeLabel(type?: string | null) {

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -7,7 +7,13 @@
     data-art-context
     :class="[
       'group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border bg-base-200 transition-all hover:shadow-lg',
-      compact ? 'gap-2 p-3' : 'gap-4 p-4',
+      // Panel cards (bot, character, reward, scenario) inset their art and want
+      // the padding. Poster cards (dream) run their art edge-to-edge with the
+      // title overlaid, and padding would frame it in a way the design does not
+      // want. A typed prop rather than a `p-0!` override in cardClass, because
+      // nothing else in this repo uses Tailwind's important modifier and a
+      // class-string fight is a worse contract than a boolean.
+      padded ? (compact ? 'gap-2 p-3' : 'gap-4 p-4') : 'gap-0 p-0',
       selected ? 'border-primary bg-primary/10' : 'border-base-300',
       normalizedCardClass,
     ]"
@@ -88,6 +94,8 @@ const props = withDefaults(
   defineProps<{
     selected?: boolean
     compact?: boolean
+    /** False for full-bleed poster cards whose art reaches the card edge. */
+    padded?: boolean
     showReaction?: boolean
     allowReviews?: boolean | null
     targetId?: number | null
@@ -103,6 +111,7 @@ const props = withDefaults(
   {
     selected: false,
     compact: false,
+    padded: true,
     showReaction: true,
     allowReviews: true,
     targetId: null,


### PR DESCRIPTION
> *"the final version obviously is wanting a single display that is consistent across galleries, all with those bells and whistles."* — Silas, 2026-08-02

Investigating that turned up something better than expected.

## Four of five cards already share a shell

`bot-card`, `character-card`, `reward-card` and `scenario-card` all wrap `components/wonderlab/reactable-card.vue`, which owns the `<article>`, selected border, karma badge, reaction button and review panel. **`dream-card` was the only holdout**, still rolling its own `<article>`.

That's why Dreams have no reaction or review affordance at all. It was never a data problem — `dream` has been a valid `ReactionTargetType` since reactions shipped, `DREAM` is in `reactionCategories`, `reactionStore` already maps `dream → dreamId`, and `Dream.allowReviews` is in the schema. Every piece was in place; nothing was wired to it.

*(This also corrects what I filed in t-062, which said "five bespoke cards." Wrong — what's actually duplicated is the card **body**, not the shell.)*

## What changed

`dream-card` now wraps `reactable-card`. Its hover action bar becomes the `#actions` slot, which the shell already positions and stop-propagates, so that absolutely-positioned wrapper div is gone.

**One addition to the shared component: a `padded` prop.** The four panel cards inset their art and want the padding; Dreams runs art edge-to-edge with the title overlaid, where padding would frame it wrongly. A typed boolean rather than a `p-0!` string in `cardClass` — nothing in this repo uses Tailwind's important modifier, and a class-string fight is a worse contract. **Defaults true, so all fourteen existing `reactable-card` consumers are unaffected.**

Also collapsed `selected || isSelected` into one `activeSelected` computed — two props for one state, declared separately and then always read together. **Both props are kept**, not deduplicated away: callers pass both spellings and dropping either would silently stop working at a call site `vue-tsc` can't see through a template. `character-card` has the same pair; left alone here.

`cardClass` no longer sets the selected or base border — the shell draws those — so it contributes only the ring and the inactive-dream treatment.

## A correction to my own earlier reading

I recorded that `dream-card` fired three events it never declared. **It declares them** — my pattern matched only the shorthand `event: [args]` form and missed the call-signature `(event: 'x', …): void` form. I briefly added a duplicate `defineEmits` on that mistaken basis and removed it. The file now has exactly one declaration, converted to the shorthand the other four use.

## Visual change, flagged

Dream cards gain a reaction button (when selected, and when the Dream allows reviews) and the karma badge. The card itself *should* look the same — `padded: false` preserves the full-bleed figure and I matched the ring/border split deliberately — but "should" is doing work there. **`/dreams` wants a look on the preview.**

## Verification

- `npm run test` (`vue-tsc --noEmit`) — clean
- `npx nuxi build` — both bundles compile; prerender needs a `JWT_SECRET` this environment lacks
- `test:layout-contract`, `test:gallery-adoption`, `test:facet-gallery`, WonderLab UI fixture contract — pass
- Line endings checked against `HEAD` on both files

Rebased onto current `main`: #1334's squash captured its first two commits, and this one was pushed after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_