### PR TITLE
feat: turn For You into a Conductor attention desk

### DIFF
--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -4,75 +4,335 @@
     class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden p-1.5 sm:p-2.5"
   >
     <div class="rounded-2xl border border-accent/20 bg-accent/5 px-4 py-3">
-      <p class="text-xs font-semibold text-accent/80">🍯 For You</p>
-      <p class="mt-0.5 text-xs text-base-content/50">
-        Action items your AI assigned to you. These help your projects along —
-        check them off as you go.
-      </p>
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p class="text-xs font-semibold text-accent/80">✨ For You</p>
+          <p class="mt-0.5 text-xs text-base-content/55">
+            Decisions, proposals, and personal follow-ups that need a human hand.
+          </p>
+        </div>
+        <button
+          v-if="userStore.isAdmin"
+          class="btn btn-ghost btn-xs"
+          :disabled="conductorStore.pending"
+          @click="conductorStore.fetchProjects(true)"
+        >
+          <span
+            v-if="conductorStore.pending"
+            class="loading loading-spinner loading-xs"
+          />
+          Refresh
+        </button>
+      </div>
       <p
-        v-if="highPriorityCount > 0"
+        v-if="urgentCount > 0"
         class="mt-1 text-xs font-semibold text-error"
       >
-        {{ highPriorityCount }} high-priority item{{
-          highPriorityCount > 1 ? 's' : ''
-        }}
-        need your attention.
+        {{ urgentCount }} item{{ urgentCount === 1 ? '' : 's' }} need a decision.
       </p>
     </div>
 
     <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-      <div class="space-y-2">
-        <template v-if="todoStore.loading && !todoStore.honeyDoTodos.length">
-          <div
-            v-for="n in 3"
-            :key="n"
-            class="h-16 animate-pulse rounded-2xl border border-base-300 bg-base-200"
-          />
+      <div class="space-y-4 pb-4">
+        <template v-if="userStore.isAdmin">
+          <section class="space-y-2">
+            <div class="flex items-center justify-between gap-2 px-1">
+              <div>
+                <h2 class="text-sm font-black">Conductor human gates</h2>
+                <p class="text-xs text-base-content/50">
+                  Approvals and questions currently blocking agent work.
+                </p>
+              </div>
+              <span class="badge badge-warning badge-sm">
+                {{ conductorStore.humanGates.length }}
+              </span>
+            </div>
+
+            <div
+              v-if="conductorStore.pending && !conductorStore.hasLiveData"
+              class="h-28 animate-pulse rounded-2xl border border-base-300 bg-base-200"
+            />
+
+            <article
+              v-for="gate in conductorStore.humanGates"
+              :key="`${gate.project.slug}/${gate.task.id}`"
+              class="rounded-2xl border border-warning/30 bg-warning/5 p-3 shadow-sm"
+            >
+              <div class="flex flex-wrap items-start justify-between gap-2">
+                <div class="min-w-0 flex-1">
+                  <button
+                    class="text-left text-xs font-bold text-primary hover:underline"
+                    @click="viewConductorProject(gate.project.slug)"
+                  >
+                    {{ gate.project.name }} · {{ gate.task.id }}
+                  </button>
+                  <h3 class="mt-0.5 text-sm font-black leading-tight">
+                    {{ gate.task.title }}
+                  </h3>
+                </div>
+                <div class="flex flex-wrap gap-1">
+                  <span
+                    class="badge badge-sm"
+                    :class="gate.task.softGate ? 'badge-info' : 'badge-error'"
+                  >
+                    {{ gate.task.softGate ? 'soft gate' : 'human gate' }}
+                  </span>
+                  <span v-if="gate.task.stakes" class="badge badge-ghost badge-sm">
+                    {{ gate.task.stakes }}
+                  </span>
+                </div>
+              </div>
+
+              <details v-if="gate.task.note" class="mt-2 text-xs">
+                <summary class="cursor-pointer font-semibold text-base-content/65">
+                  Context from Conductor
+                </summary>
+                <p class="mt-2 whitespace-pre-wrap text-base-content/70">
+                  {{ gate.task.note }}
+                </p>
+              </details>
+
+              <textarea
+                v-model="gateMessages[gateKey(gate.project.slug, gate.task.id)]"
+                class="textarea textarea-bordered mt-3 min-h-20 w-full text-sm"
+                placeholder="Add context, requested changes, or an approval note…"
+                :disabled="taskIsUpdating(gate.project.slug, gate.task.id)"
+              />
+
+              <div class="mt-2 flex flex-wrap gap-2">
+                <button
+                  class="btn btn-success btn-sm"
+                  :disabled="taskIsUpdating(gate.project.slug, gate.task.id)"
+                  @click="actOnGate(gate.project.slug, gate.task.id, 'approve')"
+                >
+                  <span
+                    v-if="taskIsUpdating(gate.project.slug, gate.task.id)"
+                    class="loading loading-spinner loading-xs"
+                  />
+                  Approve
+                </button>
+                <button
+                  class="btn btn-error btn-outline btn-sm"
+                  :disabled="
+                    taskIsUpdating(gate.project.slug, gate.task.id) ||
+                    !gateMessage(gate.project.slug, gate.task.id).trim()
+                  "
+                  @click="actOnGate(gate.project.slug, gate.task.id, 'reject')"
+                >
+                  Send back
+                </button>
+                <button
+                  class="btn btn-ghost btn-sm"
+                  :disabled="
+                    taskIsUpdating(gate.project.slug, gate.task.id) ||
+                    !gateMessage(gate.project.slug, gate.task.id).trim()
+                  "
+                  @click="actOnGate(gate.project.slug, gate.task.id, 'comment')"
+                >
+                  Send note
+                </button>
+              </div>
+            </article>
+
+            <div
+              v-if="
+                conductorStore.hasLiveData &&
+                !conductorStore.pending &&
+                !conductorStore.humanGates.length
+              "
+              class="rounded-2xl border border-success/20 bg-success/5 px-4 py-5 text-center"
+            >
+              <Icon
+                name="kind-icon:check-circle"
+                class="mx-auto mb-1 size-7 text-success/50"
+              />
+              <p class="text-sm font-semibold text-base-content/55">
+                No Conductor gates are waiting on you.
+              </p>
+            </div>
+          </section>
+
+          <section class="space-y-2">
+            <div class="flex items-center justify-between gap-2 px-1">
+              <div>
+                <h2 class="text-sm font-black">Pitch proposals</h2>
+                <p class="text-xs text-base-content/50">
+                  New ideas awaiting approval or rejection.
+                </p>
+              </div>
+              <span class="badge badge-secondary badge-sm">
+                {{ conductorStore.pendingPitches.length }}
+              </span>
+            </div>
+
+            <article
+              v-for="pitch in conductorStore.pendingPitches"
+              :key="pitch.slug"
+              class="rounded-2xl border border-secondary/25 bg-secondary/5 p-3"
+            >
+              <div class="flex flex-wrap items-start justify-between gap-2">
+                <div class="min-w-0 flex-1">
+                  <p class="text-xs font-semibold text-secondary/80">
+                    {{ pitch.projectTarget || 'General' }}
+                    <span v-if="pitch.date"> · {{ pitch.date }}</span>
+                  </p>
+                  <h3 class="text-sm font-black leading-tight">{{ pitch.title }}</h3>
+                </div>
+                <span v-if="pitch.effort" class="badge badge-ghost badge-sm">
+                  {{ pitch.effort }}
+                </span>
+              </div>
+              <p v-if="pitch.idea" class="mt-2 text-xs text-base-content/70">
+                {{ pitch.idea }}
+              </p>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <button
+                  class="btn btn-success btn-sm"
+                  :disabled="pitchIsUpdating(pitch.slug)"
+                  @click="conductorStore.updatePitchStatus(pitch.slug, 'approved')"
+                >
+                  Approve pitch
+                </button>
+                <button
+                  class="btn btn-error btn-outline btn-sm"
+                  :disabled="pitchIsUpdating(pitch.slug)"
+                  @click="conductorStore.updatePitchStatus(pitch.slug, 'rejected')"
+                >
+                  Reject
+                </button>
+                <button
+                  class="btn btn-ghost btn-sm"
+                  @click="navigateTo('/conductor')"
+                >
+                  Full review
+                </button>
+              </div>
+            </article>
+
+            <div
+              v-if="
+                conductorStore.hasLiveData &&
+                !conductorStore.pending &&
+                !conductorStore.pendingPitches.length
+              "
+              class="rounded-2xl border border-base-300 bg-base-100 px-4 py-4 text-center text-sm text-base-content/50"
+            >
+              No new pitches are waiting.
+            </div>
+          </section>
         </template>
 
-        <honeydo-card
-          v-for="todo in todoStore.honeyDoTodos"
-          :key="todo.id"
-          :todo="todo"
-          :project="relatedProject(todo)"
-          @toggle-done="todoStore.toggleDone(todo)"
-          @view-project="viewProject"
-        />
+        <section class="space-y-2">
+          <div class="flex items-center justify-between gap-2 px-1">
+            <div>
+              <h2 class="text-sm font-black">Personal follow-ups</h2>
+              <p class="text-xs text-base-content/50">
+                Your existing Kind Robots task reminders.
+              </p>
+            </div>
+            <span class="badge badge-accent badge-sm">
+              {{ todoStore.honeyDoTodos.length }}
+            </span>
+          </div>
 
-        <div
-          v-if="!todoStore.loading && !todoStore.honeyDoTodos.length"
-          class="py-8 text-center"
-        >
-          <Icon
-            name="kind-icon:check-circle"
-            class="mx-auto mb-2 size-8 text-success/40"
+          <template v-if="todoStore.loading && !todoStore.honeyDoTodos.length">
+            <div
+              v-for="n in 2"
+              :key="n"
+              class="h-16 animate-pulse rounded-2xl border border-base-300 bg-base-200"
+            />
+          </template>
+
+          <honeydo-card
+            v-for="todo in todoStore.honeyDoTodos"
+            :key="todo.id"
+            :todo="todo"
+            :project="relatedProject(todo)"
+            @toggle-done="todoStore.toggleDone(todo)"
+            @view-project="viewProject"
           />
-          <p class="text-sm font-semibold text-base-content/50">
-            Nothing needs your attention right now.
-          </p>
-        </div>
+
+          <div
+            v-if="!todoStore.loading && !todoStore.honeyDoTodos.length"
+            class="rounded-2xl border border-base-300 bg-base-100 px-4 py-4 text-center text-sm text-base-content/50"
+          >
+            No personal follow-ups are waiting.
+          </div>
+        </section>
+
+        <p
+          v-if="conductorStore.taskUpdateError || conductorStore.pitchUpdateError"
+          class="rounded-xl bg-error/10 px-3 py-2 text-xs text-error"
+        >
+          {{ conductorStore.taskUpdateError || conductorStore.pitchUpdateError }}
+        </p>
       </div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useTodoStore, type Todo } from '@/stores/todoStore'
 import {
   useProjectStore,
   type ProjectWithRelations,
 } from '@/stores/projectStore'
 import { usePageStore } from '@/stores/pageStore'
+import {
+  useConductorStore,
+  type ConductorTaskAction,
+} from '@/stores/conductorStore'
+import { useUserStore } from '@/stores/userStore'
 
 const todoStore = useTodoStore()
 const projectStore = useProjectStore()
 const pageStore = usePageStore()
+const conductorStore = useConductorStore()
+const userStore = useUserStore()
+const gateMessages = ref<Record<string, string>>({})
 
-const highPriorityCount = computed(
-  () =>
-    todoStore.honeyDoTodos.filter((todo) => todo.priority === 'HIGH').length,
-)
+const urgentCount = computed(() => {
+  const hardGates = userStore.isAdmin
+    ? conductorStore.humanGates.filter((gate) => !gate.task.softGate).length
+    : 0
+  const pitches = userStore.isAdmin ? conductorStore.pendingPitches.length : 0
+  const highTodos = todoStore.honeyDoTodos.filter(
+    (todo) => todo.priority === 'HIGH',
+  ).length
+  return hardGates + pitches + highTodos
+})
+
+function gateKey(projectSlug: string, taskId: string): string {
+  return `${projectSlug}/${taskId}`
+}
+
+function gateMessage(projectSlug: string, taskId: string): string {
+  return gateMessages.value[gateKey(projectSlug, taskId)] ?? ''
+}
+
+function taskIsUpdating(projectSlug: string, taskId: string): boolean {
+  return conductorStore.updatingTaskKeys.includes(gateKey(projectSlug, taskId))
+}
+
+function pitchIsUpdating(slug: string): boolean {
+  return conductorStore.updatingPitchSlugs.includes(slug)
+}
+
+async function actOnGate(
+  projectSlug: string,
+  taskId: string,
+  action: ConductorTaskAction,
+) {
+  const key = gateKey(projectSlug, taskId)
+  const completed = await conductorStore.submitTaskAction(
+    projectSlug,
+    taskId,
+    action,
+    gateMessages.value[key] ?? '',
+  )
+  if (completed) delete gateMessages.value[key]
+}
 
 function relatedProject(todo: Todo): ProjectWithRelations | null {
   if (!todo.projectId) return null
@@ -88,8 +348,14 @@ function viewProject(project: ProjectWithRelations) {
   navigateTo('/conductor')
 }
 
+function viewConductorProject(projectSlug: string) {
+  pageStore.setWorkspaceCardKey(projectSlug)
+  navigateTo('/conductor')
+}
+
 onMounted(() => {
   if (!todoStore.hasLoaded) void todoStore.fetchTodos()
   if (!projectStore.loaded) void projectStore.fetchProjects()
+  if (userStore.isAdmin) void conductorStore.fetchProjects()
 })
 </script>

--- a/content/channels/home/for-you.md
+++ b/content/channels/home/for-you.md
@@ -1,0 +1,15 @@
+---
+contentType: tab
+channelKey: home
+tabKey: for-you
+label: For You
+title: For You
+subtitle: Your attention desk
+description: Human gates, pitch proposals, notifications, and personal follow-ups that need your attention.
+icon: kind-icon:checklist
+route: /for-you
+sort: 15
+requiredPermission: authenticated
+---
+
+Decisions, proposals, and personal follow-ups gathered into one attention desk.

--- a/content/for-you.md
+++ b/content/for-you.md
@@ -1,11 +1,13 @@
 ---
 title: 'For You'
 room: 'For You'
-subtitle: 'Your action queue'
-description: Things your AI has flagged that need your attention, across every project.
+subtitle: 'Your attention desk'
+description: Human gates, pitch proposals, notifications, and personal follow-ups that need your attention.
 icon: kind-icon:checklist
-tooltip: Action items your AI assigned to you, in one place.
-loadingMessage: Loading your action queue...
+tooltip: Decisions and follow-ups gathered from Kind Robots and Conductor.
+channelKey: home
+tabKey: for-you
+loadingMessage: Loading your attention desk...
 refreshLabel: Refresh
 ---
 

--- a/plugins/conductor-admin-data.client.ts
+++ b/plugins/conductor-admin-data.client.ts
@@ -18,10 +18,13 @@ export default defineNuxtPlugin(() => {
     return (
       route.path === '/conductor' ||
       route.path === '/workspace' ||
+      route.path === '/for-you' ||
       (pageStore.dashboardKey === 'conductor' &&
         pageStore.dashboardTab === 'conductor') ||
       (pageStore.dashboardKey === 'wonder' &&
-        pageStore.dashboardTab === 'workspace')
+        pageStore.dashboardTab === 'workspace') ||
+      (pageStore.dashboardKey === 'home' &&
+        pageStore.dashboardTab === 'for-you')
     )
   })
 

--- a/server/api/conductor/task-action.post.ts
+++ b/server/api/conductor/task-action.post.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto'
+import { stringify as stringifyYaml } from 'yaml'
+import { createError, defineEventHandler, readBody } from 'h3'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import { conductorGet, conductorPut } from '@/server/utils/conductor-github'
+import { parseRoadmapYaml } from '@/server/utils/conductorRoadmap'
+
+const PROJECT_RE = /^[a-z0-9][a-z0-9-]*$/
+const TASK_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+const ACTIONS = new Set(['approve', 'reject', 'comment'] as const)
+type TaskAction = 'approve' | 'reject' | 'comment'
+
+type TaskActionBody = {
+  projectSlug?: string
+  taskId?: string
+  action?: string
+  message?: string
+}
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireAdminApiUser(event)
+  const body = await readBody<TaskActionBody>(event)
+  const projectSlug = body.projectSlug?.trim() ?? ''
+  const taskId = body.taskId?.trim() ?? ''
+  const action = body.action?.trim() as TaskAction
+  const message = body.message?.trim() ?? ''
+
+  if (!PROJECT_RE.test(projectSlug)) {
+    throw createError({ statusCode: 400, statusMessage: 'invalid projectSlug' })
+  }
+  if (!TASK_RE.test(taskId)) {
+    throw createError({ statusCode: 400, statusMessage: 'invalid taskId' })
+  }
+  if (!ACTIONS.has(action)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'action must be approve, reject, or comment',
+    })
+  }
+  if ((action === 'reject' || action === 'comment') && !message) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'message is required for reject and comment actions',
+    })
+  }
+
+  const roadmapPath = `projects/${projectSlug}/roadmap.yaml`
+  const roadmap = await conductorGet(roadmapPath)
+  if (!roadmap) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: `Conductor project not found: ${projectSlug}`,
+    })
+  }
+
+  const task = parseRoadmapYaml(roadmap.content).tasks.find(
+    (entry) => entry.id === taskId,
+  )
+  if (!task) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: `Conductor task not found: ${projectSlug}/${taskId}`,
+    })
+  }
+  if (task.status !== 'needs-human') {
+    throw createError({
+      statusCode: 409,
+      statusMessage: `Task is no longer waiting for human attention (status: ${task.status})`,
+    })
+  }
+
+  const actor = user.username || `user-${user.id}`
+  const timestamp = new Date().toISOString()
+  const eventPayload: Record<string, unknown> = {
+    version: 1,
+    project: projectSlug,
+    task: taskId,
+    updated: timestamp,
+  }
+
+  if (action === 'approve') {
+    eventPayload.operation = 'done'
+    eventPayload.approved_by_human = true
+    eventPayload.note = `APPROVED by ${actor} via Kind Robots For You.${message ? ` ${message}` : ''}`
+  } else if (action === 'reject') {
+    eventPayload.operation = 'ready'
+    eventPayload.approved_by_human = false
+    eventPayload.note = `SENT BACK by ${actor} via Kind Robots For You. ${message}`
+  } else {
+    eventPayload.operation = 'needs-human'
+    eventPayload.soft_gate = task.softGate
+    eventPayload.note = `HUMAN NOTE from ${actor} via Kind Robots For You. ${message}`
+  }
+
+  const stamp = timestamp.replace(/[-:.]/g, '')
+  const eventPath = `task-events/${stamp}-${projectSlug}-${taskId}-${action}-${randomUUID().slice(0, 8)}.yaml`
+  await conductorPut(
+    eventPath,
+    stringifyYaml(eventPayload, { lineWidth: 100 }),
+    `event: ${action} ${projectSlug}/${taskId} from For You`,
+  )
+
+  return {
+    success: true,
+    data: { eventPath, projectSlug, taskId, action, queuedAt: timestamp },
+  }
+})

--- a/server/utils/conductorRoadmap.ts
+++ b/server/utils/conductorRoadmap.ts
@@ -29,6 +29,7 @@ export interface ConductorTask {
   passes: number
   stakes?: string
   gateHuman: boolean
+  softGate: boolean
   note?: string
   dependsOn?: string | string[] | null
   approvedByHuman?: boolean
@@ -141,6 +142,7 @@ function toTask(raw: unknown): ConductorTask | null {
     passes: Number(source.passes) || 0,
     stakes: str(source.stakes),
     gateHuman: bool(pick(source, 'gateHuman', 'gate_human')),
+    softGate: bool(pick(source, 'softGate', 'soft_gate')),
     note: str(source.note),
     dependsOn: Array.isArray(rawDependsOn)
       ? rawDependsOn.map((entry) => String(entry).trim())

--- a/stores/conductorStore.ts
+++ b/stores/conductorStore.ts
@@ -5,6 +5,7 @@ import type {
   ConductorData,
   ConductorPitch,
   ConductorProject,
+  ConductorTask,
 } from '@/server/api/conductor/projects.get'
 import { CONDUCTOR_CARDS } from '@/stores/helpers/conductorCards'
 import { performFetch } from '@/stores/utils'
@@ -18,6 +19,12 @@ export type PitchStatus =
   | 'superseded'
   | 'archived'
 export type PitchBucket = 'review' | 'approved' | 'rejected' | 'archived'
+export type ConductorTaskAction = 'approve' | 'reject' | 'comment'
+
+export interface ConductorHumanGate {
+  project: ConductorProject
+  task: ConductorTask
+}
 
 const LEGACY_VOTE_KEY = 'kr.workspacePitchVotes'
 const CONDUCTOR_IMG_BASE =
@@ -43,6 +50,7 @@ const fallbackProjects: ConductorProject[] = CONDUCTOR_CARDS.map((card) => ({
       passes: 0,
       stakes: card.tagline,
       gateHuman: card.taskStatus === 'needs-human',
+      softGate: false,
       note: card.description,
       dependsOn: null,
       approvedByHuman: false,
@@ -93,7 +101,9 @@ export const useConductorStore = defineStore('conductor', () => {
   let inFlightFetch: Promise<void> | null = null
   const error = ref<string | null>(null)
   const pitchUpdateError = ref<string | null>(null)
+  const taskUpdateError = ref<string | null>(null)
   const updatingPitchSlugs = ref<string[]>([])
+  const updatingTaskKeys = ref<string[]>([])
   const optimisticPitchStatuses = ref<Record<string, PitchStatus>>({})
 
   const liveProjects = computed<ConductorProject[]>(
@@ -110,6 +120,23 @@ export const useConductorStore = defineStore('conductor', () => {
   const hasLiveData = computed(() => data.value !== null)
   const hasLoaded = computed(
     () => data.value !== null || fallbackProjects.length > 0,
+  )
+
+  const humanGates = computed<ConductorHumanGate[]>(() =>
+    liveProjects.value
+      .flatMap((project) =>
+        project.tasks
+          .filter((task) => task.status === 'needs-human')
+          .map((task) => ({ project, task })),
+      )
+      .sort((left, right) => {
+        if (left.task.softGate !== right.task.softGate) {
+          return left.task.softGate ? 1 : -1
+        }
+        return String(right.task.updated ?? '').localeCompare(
+          String(left.task.updated ?? ''),
+        )
+      }),
   )
 
   function pitchStatus(slug: string): PitchStatus {
@@ -190,6 +217,27 @@ export const useConductorStore = defineStore('conductor', () => {
     }
   }
 
+  function replaceTask(
+    projectSlug: string,
+    taskId: string,
+    replace: (task: ConductorTask) => ConductorTask,
+  ): void {
+    if (!data.value) return
+    data.value = {
+      ...data.value,
+      projects: data.value.projects.map((project) =>
+        project.slug === projectSlug
+          ? {
+              ...project,
+              tasks: project.tasks.map((task) =>
+                task.id === taskId ? replace(task) : task,
+              ),
+            }
+          : project,
+      ),
+    }
+  }
+
   async function updatePitchStatus(
     slug: string,
     status: PitchStatus,
@@ -230,6 +278,80 @@ export const useConductorStore = defineStore('conductor', () => {
     }
   }
 
+  async function submitTaskAction(
+    projectSlug: string,
+    taskId: string,
+    action: ConductorTaskAction,
+    message = '',
+  ): Promise<boolean> {
+    const key = `${projectSlug}/${taskId}`
+    if (updatingTaskKeys.value.includes(key)) return false
+
+    const trimmedMessage = message.trim()
+    if ((action === 'reject' || action === 'comment') && !trimmedMessage) {
+      taskUpdateError.value = 'Add a message before sending this action.'
+      return false
+    }
+
+    updatingTaskKeys.value = [...updatingTaskKeys.value, key]
+    taskUpdateError.value = null
+
+    try {
+      const response = await performFetch<{ eventPath: string }>(
+        '/api/conductor/task-action',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            projectSlug,
+            taskId,
+            action,
+            message: trimmedMessage,
+          }),
+        },
+      )
+      if (!response.success) {
+        throw new Error(response.message || 'Conductor task update failed')
+      }
+
+      const now = new Date().toISOString()
+      replaceTask(projectSlug, taskId, (task) => {
+        const note = trimmedMessage
+          ? `${task.note ? `${task.note}\n\n` : ''}${trimmedMessage}`
+          : task.note
+        if (action === 'approve') {
+          return {
+            ...task,
+            status: 'done',
+            approvedByHuman: true,
+            softGate: false,
+            note,
+            updated: now,
+          }
+        }
+        if (action === 'reject') {
+          return {
+            ...task,
+            status: 'ready',
+            approvedByHuman: false,
+            softGate: false,
+            note,
+            updated: now,
+          }
+        }
+        return { ...task, note, updated: now }
+      })
+      return true
+    } catch (cause) {
+      taskUpdateError.value =
+        cause instanceof Error ? cause.message : 'Conductor task update failed'
+      return false
+    } finally {
+      updatingTaskKeys.value = updatingTaskKeys.value.filter(
+        (entry) => entry !== key,
+      )
+    }
+  }
+
   function pitchVote(slug: string): PitchVote | null {
     const status = pitchStatus(slug)
     if (status === 'approved') return 'approved'
@@ -253,13 +375,16 @@ export const useConductorStore = defineStore('conductor', () => {
     pending,
     error,
     pitchUpdateError,
+    taskUpdateError,
     updatingPitchSlugs,
+    updatingTaskKeys,
     projects,
     pitches,
     fetchedAt,
     registryCount,
     hasLiveData,
     hasLoaded,
+    humanGates,
     pendingPitches,
     approvedPitches,
     rejectedPitches,
@@ -267,6 +392,7 @@ export const useConductorStore = defineStore('conductor', () => {
     fetchProjects,
     pitchStatus,
     updatePitchStatus,
+    submitTaskAction,
     pitchVote,
     voteOnPitch,
     clearVote,

--- a/stores/notificationStore.ts
+++ b/stores/notificationStore.ts
@@ -1,6 +1,8 @@
 // /stores/notificationStore.ts
 //
 // In-app notifications (new DM, friend request/accept, admin/system notices).
+// Conductor attention is projected into the same bell for admins without
+// duplicating roadmap state into the application database.
 //
 // API:
 //   GET  /api/notifications                 -> { items, unreadCount }
@@ -10,6 +12,8 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { performFetch, handleError } from './utils'
+import { useConductorStore } from '@/stores/conductorStore'
+import { useUserStore } from '@/stores/userStore'
 
 export type NotificationType =
   | 'MESSAGE'
@@ -30,21 +34,94 @@ export type AppNotification = {
   createdAt: string | Date
 }
 
+const CONDUCTOR_NOTIFICATION_ID = -1
+const CONDUCTOR_SEEN_KEY = 'kr.conductorAttentionSeenSignature'
+
+function readSeenSignature(): string {
+  if (!import.meta.client) return ''
+  try {
+    return localStorage.getItem(CONDUCTOR_SEEN_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function writeSeenSignature(signature: string): void {
+  if (!import.meta.client) return
+  try {
+    localStorage.setItem(CONDUCTOR_SEEN_KEY, signature)
+  } catch {}
+}
+
 export const useNotificationStore = defineStore('notificationStore', () => {
   const items = ref<AppNotification[]>([])
   const unreadCount = ref(0)
   const isLoading = ref(false)
+  const conductorAttentionSignature = ref('')
+
+  async function conductorNotification(): Promise<AppNotification | null> {
+    const userStore = useUserStore()
+    if (!userStore.isAdmin) return null
+
+    const conductorStore = useConductorStore()
+    await conductorStore.fetchProjects()
+    if (!conductorStore.hasLiveData) return null
+
+    const gateKeys = conductorStore.humanGates.map(
+      ({ project, task }) =>
+        `gate:${project.slug}/${task.id}:${task.updated ?? task.status}`,
+    )
+    const pitchKeys = conductorStore.pendingPitches.map(
+      (pitch) => `pitch:${pitch.slug}:${pitch.status}`,
+    )
+    const keys = [...gateKeys, ...pitchKeys].sort()
+    if (!keys.length) {
+      conductorAttentionSignature.value = ''
+      return null
+    }
+
+    const signature = JSON.stringify(keys)
+    conductorAttentionSignature.value = signature
+    const gateCount = conductorStore.humanGates.length
+    const pitchCount = conductorStore.pendingPitches.length
+    const parts = [
+      gateCount
+        ? `${gateCount} human gate${gateCount === 1 ? '' : 's'}`
+        : '',
+      pitchCount
+        ? `${pitchCount} pitch${pitchCount === 1 ? '' : 'es'}`
+        : '',
+    ].filter(Boolean)
+
+    return {
+      id: CONDUCTOR_NOTIFICATION_ID,
+      type: 'ADMIN',
+      title: 'Conductor needs your attention',
+      body: `${parts.join(' and ')} waiting in For You.`,
+      linkPath: '/for-you',
+      isRead: readSeenSignature() === signature,
+      createdAt: conductorStore.fetchedAt ?? new Date().toISOString(),
+    }
+  }
 
   async function load(): Promise<void> {
     isLoading.value = true
     try {
-      const res = await performFetch<{
-        items: AppNotification[]
-        unreadCount: number
-      }>('/api/notifications')
+      const [res, conductorItem] = await Promise.all([
+        performFetch<{
+          items: AppNotification[]
+          unreadCount: number
+        }>('/api/notifications'),
+        conductorNotification(),
+      ])
       if (res.success && res.data) {
-        items.value = res.data.items ?? []
-        unreadCount.value = res.data.unreadCount ?? 0
+        const databaseItems = res.data.items ?? []
+        items.value = conductorItem
+          ? [conductorItem, ...databaseItems]
+          : databaseItems
+        unreadCount.value =
+          (res.data.unreadCount ?? 0) +
+          (conductorItem && !conductorItem.isRead ? 1 : 0)
       }
     } catch (error) {
       handleError(error, 'loadNotifications')
@@ -54,14 +131,24 @@ export const useNotificationStore = defineStore('notificationStore', () => {
   }
 
   async function markRead(id: number): Promise<void> {
+    if (id === CONDUCTOR_NOTIFICATION_ID) {
+      writeSeenSignature(conductorAttentionSignature.value)
+      const notification = items.value.find((item) => item.id === id)
+      if (notification && !notification.isRead) {
+        notification.isRead = true
+        unreadCount.value = Math.max(0, unreadCount.value - 1)
+      }
+      return
+    }
+
     try {
       const res = await performFetch(`/api/notifications/${id}/read`, {
         method: 'POST',
       })
       if (res.success) {
-        const n = items.value.find((i) => i.id === id)
-        if (n && !n.isRead) {
-          n.isRead = true
+        const notification = items.value.find((item) => item.id === id)
+        if (notification && !notification.isRead) {
+          notification.isRead = true
           unreadCount.value = Math.max(0, unreadCount.value - 1)
         }
       }
@@ -76,7 +163,10 @@ export const useNotificationStore = defineStore('notificationStore', () => {
         method: 'POST',
       })
       if (res.success) {
-        items.value.forEach((i) => (i.isRead = true))
+        if (conductorAttentionSignature.value) {
+          writeSeenSignature(conductorAttentionSignature.value)
+        }
+        items.value.forEach((item) => (item.isRead = true))
         unreadCount.value = 0
       }
     } catch (error) {
@@ -87,6 +177,7 @@ export const useNotificationStore = defineStore('notificationStore', () => {
   function reset(): void {
     items.value = []
     unreadCount.value = 0
+    conductorAttentionSignature.value = ''
   }
 
   return { items, unreadCount, isLoading, load, markRead, markAllRead, reset }

--- a/utils/dataSurfaceManifest.ts
+++ b/utils/dataSurfaceManifest.ts
@@ -31,27 +31,10 @@ export type DataSurfaceEntry = {
 export const DATA_SURFACES: DataSurfaceEntry[] = [
   {
     id: 'honeydo-inbox',
-    label: 'Global honeydo queue',
-    dataSource: 'stores/todoStore.ts: todoStore.honeyDoTodos',
-    // Silas, 2026-08-02: "we have a just for you section in home that ostensibly
-    // is for ai deliverables? I don't know, it never has anything, just delete it
-    // unless it has a particular need [...] but if so, it should be completely
-    // hidden if it's not used."
-    //
-    // It never has anything because NOTHING EVER WRITES A HONEYDO TODO. The
-    // consumer half is real -- taskmasterStore.ts builds checkpoints from
-    // honeyDoTodos, and conductor-page.vue has a HONEYDO tab -- but the producer
-    // was never built: conductor's agents write `category: "AGENT"`
-    // (scripts/ci_janitor.py, scripts/new_app.py), and the only way a HONEYDO
-    // exists at all is a human picking it from conductor-page's dropdown. So the
-    // page's promise, "action items your AI assigned to you", has never been true.
-    //
-    // The /for-you route and this surface stay (deep-linkable, and honeydo keeps
-    // a home the moment a producer exists); the nav TAB is gone, which is the
-    // "completely hidden if it's not used" half of the instruction. Wire navEntry
-    // back the moment something writes a HONEYDO.
-    navEntry: null,
-    acknowledgedGap: 'interface-vision/t-056',
+    label: 'For You attention desk',
+    dataSource:
+      'stores/conductorStore.ts: humanGates + pendingPitches; stores/todoStore.ts: honeyDoTodos',
+    navEntry: { channelKey: 'home', tabKey: 'for-you' },
   },
   {
     id: 'video-generator',


### PR DESCRIPTION
## Root cause
The Home / For You surface only queried database Todos in the legacy `HONEYDO` category. Conductor human gates and pitch files already reached a separate store, but nothing joined those streams. The global Conductor loader also did not recognize `/for-you`. A recent cleanup then hid the Home tab because the legacy producer did not exist, leaving the route deep-link-only.

## What changed
- restore the Home / For You tab and its navigation/data-surface contracts
- show every live Conductor task in `needs-human`, with hard gates ranked before soft gates
- add admin actions for Approve, Send back, and Send note
- queue those decisions as Conductor `task-events` instead of editing roadmaps or keeping a second local state machine
- surface pending Conductor pitches directly in For You with approve/reject controls
- keep the existing personal HONEYDO Todo cards as a separate follow-up section
- load Conductor admin data on the For You route and dashboard tab
- project new human gates and pitches into the existing notification bell for admins, using a browser-local seen signature so repeated unchanged attention does not keep appearing new
- expose `soft_gate` from roadmap parsing so the UI can distinguish blocking human gates from soft questions

## Companion dependency
Depends on conductor PR #1591, which lets task events record `approved_by_human`. Merge conductor first, then this PR.

## Safety
- admin guard on the new write route
- validates project/task/action and re-reads the live roadmap before accepting an action
- refuses stale actions when the task is no longer `needs-human`
- writes a unique event file through the existing Conductor GitHub bridge
- no schema migration and no duplicate notification rows

## Verification
Repository CI plus Vercel deployment verification. The new endpoint is covered by the existing Conductor API auth-guard contract because it calls `requireAdminApiUser`. Vercel currently exposes no PR preview deployment for this branch, so the visual pass will use the production deployment immediately after merge.