### PR TITLE
layout: add kr-unbound root-surface primitive for MDC-mounted pages

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -267,7 +267,7 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   /*
    * ── Scroll-ownership primitives (interface-vision t-004) ─────────────
    * .kr-page has no height and no scroll ownership by design — it's a
-   * flow shell, not a scroll container. These four give a page an actual
+   * flow shell, not a scroll container. These five give a page an actual
    * bounded region with exactly one scroll owner, modeled on the proven
    * shape of components/pages/conductor-project-gallery-page.vue.
    */
@@ -300,6 +300,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
      grow past it. Most pages want .kr-scroll, not this. */
   .kr-stage {
     @apply flex min-h-0 flex-1 flex-col overflow-hidden;
+  }
+
+  /* Root-satisfying marker with NO overflow/height behavior of its own
+     (interface-vision t-057/t-059). For MDC-mounted -page.vue components
+     rendered inside pages/[...slug].vue's own scrolling content-host: that
+     host is the page's real scroll owner, and kr-surface/kr-stage's
+     overflow-hidden would clip long-form content the host relies on
+     growing past the viewport to show. Use this ONLY when a parent already
+     owns scroll for you — a standalone routed page still wants kr-surface
+     wrapping kr-scroll, never this. */
+  .kr-unbound {
+    @apply flex w-full flex-col;
   }
 
   /* Centered max-width column. Default reading/app width. */

--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/pages/about-page.vue -->
 <template>
-  <div class="flex flex-col items-center gap-4 bg-base-200 py-6 px-4">
+  <div class="kr-unbound items-center gap-4 bg-base-200 py-6 px-4">
     <div class="w-full max-w-2xl">
       <!-- Section header -->
       <div class="mb-6 flex flex-col items-center gap-2 text-center">

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -140,6 +140,12 @@
                 >
               </li>
               <li>
+                <code>.kr-unbound</code>
+                <span class="font-sans opacity-70"
+                  >— root-surface marker, no scroll/height of its own (MDC-mounted pages)</span
+                >
+              </li>
+              <li>
                 <code>.kr-container</code>
                 <span class="font-sans opacity-70"
                   >— centered max-w-6xl column</span

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Layout-contract allow-list. RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLayoutContract.ts.",
-  "recorded": "2026-08-02",
+  "recorded": "2026-08-03",
   "violations": {
     "one-header": [],
     "one-scroll": [
@@ -37,7 +37,6 @@
     "ghost-prop": [],
     "zero-scroll": [],
     "root-surface": [
-      "components/pages/about-page.vue",
       "components/pages/appmaker-page.vue",
       "components/pages/conductor-page.vue",
       "components/pages/for-you-manager.vue",

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -23,7 +23,7 @@
  *   3. no-viewport   — no h-screen/100vh inside a shell that is already h-dvh
  *   4. one-mdc       — a content page mounts one component, not several
  *   5. ghost-prop    — don't pass :show-header to a component that never declared it
- *   6. root-surface  — page components start with a shared kr-surface/kr-stage root
+ *   6. root-surface  — page components start with a shared kr-surface/kr-stage/kr-unbound root
  */
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join, relative, basename, extname } from 'node:path'
@@ -55,7 +55,7 @@ const RULE_TITLES: Record<RuleId, string> = {
   'zero-scroll':
     'standalone page components with no scroll region of their own (app.vue no longer scrolls for them)',
   'root-surface':
-    'page components whose root wrapper does not use kr-surface or kr-stage',
+    'page components whose root wrapper does not use kr-surface, kr-stage, or kr-unbound',
 }
 
 /* screenfx is full-viewport effect canvases by design — genuinely exempt. */
@@ -198,7 +198,7 @@ function collect(): Record<RuleId, string[]> {
       const rootClasses = rootClassList(template)
       if (
         rootClasses === null ||
-        !/(?:^|\s)kr-(?:surface|stage)(?:\s|$)/.test(rootClasses)
+        !/(?:^|\s)kr-(?:surface|stage|unbound)(?:\s|$)/.test(rootClasses)
       ) {
         violations['root-surface'].push(r)
       }


### PR DESCRIPTION
### Task
interface-vision/t-057 (duplicate: t-059 — same underlying kaizen filed twice from two different `t-017` sweeps; both note the same design question, this PR resolves both). kind: software

### What changed / what I produced
- `assets/css/tailwind.css`: new `.kr-unbound` class in the Scroll-ownership primitives block (`flex w-full flex-col`, deliberately no `overflow-*`/`h-*`/`min-h-*`) — a root-surface-satisfying marker with no scroll/height behavior of its own, for components whose parent already owns scroll.
- `utils/scripts/verifyLayoutContract.ts`: root-surface rule now accepts `kr-unbound` alongside `kr-surface`/`kr-stage`; updated the rule-list comment and violation description to match.
- `components/pages/about-page.vue`: adopted `kr-unbound` on the root as the verification case — a long-form MDC-mounted page, the exact shape this primitive exists for.
- `components/ui/ui-gallery.vue`: added a style-guide entry for the new class.
- `utils/scripts/layout-contract-baseline.json`: ratcheted `root-surface` 19 → 18 via `--update`.

### How I verified
- `npm run test:layout-contract -- --report` before/after: root-surface 19 → 18, all other buckets unchanged.
- `npm run test:layout-contract` (gate mode): passes, "Layout contract holds — no new violations."
- `npx eslint components/pages/about-page.vue components/ui/ui-gallery.vue utils/scripts/verifyLayoutContract.ts` — clean.
- `npx vue-tsc --noEmit` — clean, no new errors.
- Did NOT rely on the contract count alone per the task's own instruction ("clipping would only show up visually") — see Flags below for what's still needed.

### Stakes
reversible

### Flags for Reviewer
- **Visual verification still needed**: the task explicitly calls for checking about-page.vue against a Vercel preview to confirm no clipping, since `kr-unbound` deliberately omits the height/overflow constraint that would make clipping mechanically impossible to introduce. I don't have a rendered preview yet at PR-open time (Vercel builds it once this PR exists) — please check the preview URL for `/about` (or I'll follow up once the deployment is ready) before merging, or treat a green Vercel build + no console errors as sufficient if a full visual pass isn't practical.
- `about-page.vue`'s root gained `w-full` (not present before) as part of adopting `kr-unbound`'s bundled utilities — everything else on that element is unchanged (`items-center gap-4 bg-base-200 py-6 px-4` still there). Flagging in case that's an unintended width change on a page that previously relied on implicit block-level full width.
- This closes both interface-vision/t-057 and t-059 (duplicate kaizen tasks) — noting here since the conductor-side close-out will reference both ids.

### Kaizen suggestion
The remaining 11 MDC-mounted root-surface entries this unblocks (appmaker-page, for-you-manager, giving-page, mermaids-page, privacy-page, rebel-button, storybook-library-page, super-form, wallet-page, wishmaster-page, registration-page) are t-017's natural next bounded sweep — same "MDC-mounted, safe to adopt kr-unbound" shape as about-page.vue here, so should go quickly in a batch.

### Notes for reviewer
`components/pages/rebel-button.vue` is in this root-surface list but was flagged as possibly unreachable from any live route in an earlier t-017 sweep (interface-vision/t-053 closed that investigation — worth checking its resolution before including rebel-button.vue in the next batch).

---
_Generated by [Claude Code](https://claude.ai/code/session_014EtYyvxRNLHmbb8oZVPet8)_