### PR TITLE
layout: adopt shared root surface on wallet page

### DIFF
--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full max-w-3xl mx-auto p-6 space-y-8">
+  <div class="kr-unbound w-full max-w-3xl mx-auto p-6 space-y-8">
     <div
       v-if="userStore.isGuest"
       class="rounded-2xl border border-accent/30 bg-base-200 p-6 text-center space-y-3"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -47,7 +47,6 @@
       "components/pages/rebel-button.vue",
       "components/pages/storybook-library-page.vue",
       "components/pages/super-form.vue",
-      "components/pages/wallet-page.vue",
       "components/pages/wishmaster-page.vue",
       "components/user/registration-page.vue",
       "pages/[...slug].vue",


### PR DESCRIPTION
## Summary
- adopt `kr-unbound` on the wallet page root because its MDC host already owns scrolling
- shrink the Interface Vision `root-surface` baseline from 18 to 17

## Scope
Bounded pass for `interface-vision/t-017`. No API, database, routing, or outward-facing behavior changes.

## Validation
- Layout Contract
- TypeScript Type Check
- Contract Tests and repository-required PR workflows

Session: `2026-08-03T031330Z-interface-vision-t-017-a9k3`