### PR TITLE
feat(dreams): extend earned-karma card badges to the Dream gallery

### DIFF
--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -16,6 +16,7 @@
     target-type="dream"
     reaction-category="DREAM"
     :target-title="dreamTitle"
+    :earned-karma="earnedKarma"
     :card-class="['h-full min-h-0 bg-base-100 shadow-sm hover:-translate-y-0.5 hover:shadow-xl', cardClass]"
     @select="emit('choose', dream)"
   >
@@ -178,6 +179,10 @@ const props = withDefaults(
     allowEdit?: boolean
     allowDelete?: boolean
     imageFit?: 'cover' | 'contain'
+    /** Total karma this Dream has earned from reactions (see
+     *  server/api/economy/karma-earned.post.ts). Omit/undefined renders no
+     *  badge — see components/wonderlab/reactable-card.vue. */
+    earnedKarma?: number | null
   }>(),
   {
     selected: false,
@@ -192,6 +197,7 @@ const props = withDefaults(
     allowEdit: true,
     allowDelete: false,
     imageFit: 'cover',
+    earnedKarma: undefined,
   },
 )
 

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -348,6 +348,7 @@
             :show-pitch-sheet-preview="showPitchSheetPreview"
             :load-pitch-sheet-preview="autoLoadSheets"
             image-fit="cover"
+            :earned-karma="earnedKarmaByDreamId[dream.id]"
             @choose="selectDreamAndOpen"
             @edit="startEditingDreamById"
             @delete="handleDreamDeleted"
@@ -375,7 +376,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type {
   ArtImage,
   Character,
@@ -385,6 +386,23 @@ import type {
 import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
 import { useNavStore } from '@/stores/navStore'
 import { useUserStore } from '@/stores/userStore'
+import { performFetch } from '@/stores/utils'
+
+// interface-vision/t-048: batch-fetch earned karma for the broader visible
+// set (pre type/search refinement, same "don't re-fetch on every keystroke"
+// scoping as reward-gallery's reference wiring — see
+// components/rewards/reward-gallery.vue and
+// server/api/economy/karma-earned.post.ts for the endpoint). dream-gallery
+// has no paging concept (unlike art-gallery's pagedActiveImages), so the
+// broader galleryDreams set (filtered by ownership/mature/archived, not yet
+// by type/search) is the closest equivalent to a "rendered page".
+const KARMA_EARNED_BATCH_LIMIT = 200
+
+type KarmaEarnedRow = {
+  refType: string
+  refId: string
+  earnedKarma: number
+}
 
 type GalleryVariant = 'dashboard' | 'row' | 'dropdown'
 
@@ -460,6 +478,7 @@ const isLoading = ref(false)
 const layoutMode = ref<'grid' | 'row' | 'reel' | 'hero' | 'swipe'>(
   props.variant === 'row' ? 'row' : 'grid',
 )
+const earnedKarmaByDreamId = ref<Record<number, number>>({})
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
 
@@ -569,6 +588,52 @@ const galleryDreams = computed<DreamWithRelations[]>(() => {
 
   return dreams
 })
+
+// Pre search/type refinement — those filters only narrow an already-fetched
+// set, so re-fetching on every keystroke would be wasted work.
+const visibleDreamIdsKey = computed(() =>
+  galleryDreams.value
+    .slice(0, KARMA_EARNED_BATCH_LIMIT)
+    .map((dream) => dream.id)
+    .join(','),
+)
+
+async function refreshEarnedKarma() {
+  const ids = galleryDreams.value
+    .slice(0, KARMA_EARNED_BATCH_LIMIT)
+    .map((dream) => dream.id)
+
+  if (!ids.length) {
+    earnedKarmaByDreamId.value = {}
+    return
+  }
+
+  const res = await performFetch<KarmaEarnedRow[]>('/api/economy/karma-earned', {
+    method: 'POST',
+    body: JSON.stringify({
+      items: ids.map((id) => ({ refType: 'dream', refId: id })),
+    }),
+  })
+
+  if (!res.success || !Array.isArray(res.data)) return
+
+  const next: Record<number, number> = {}
+
+  for (const row of res.data) {
+    const id = Number(row.refId)
+    if (Number.isFinite(id)) next[id] = row.earnedKarma
+  }
+
+  earnedKarmaByDreamId.value = next
+}
+
+watch(
+  visibleDreamIdsKey,
+  () => {
+    void refreshEarnedKarma()
+  },
+  { immediate: true },
+)
 
 const dreamTypes = computed(() => {
   const set = new Set<string>()


### PR DESCRIPTION
### Task
interface-vision/t-048: Extend earned-karma card badges to the Dream gallery (kind: software)

### What changed / what I produced
- `components/dreams/dream-card.vue`: added an `earnedKarma` prop, passed through to `reactable-card`'s existing `earned-karma` badge (same contract as `image-card.vue` / `reward-card.vue`).
- `components/dreams/dream-gallery.vue`: batch-fetches `/api/economy/karma-earned` for the currently visible (pre type/search-filter) Dream set and passes the result into `dream-card`'s new prop — mirrors `reward-gallery.vue`'s reference wiring (the "simpler unpaged" reference this task's note pointed at, since `dream-gallery` has no paging concept like `art-gallery`'s `pagedActiveImages`).

### How I verified
- `npx vue-tsc --noEmit -p tsconfig.json` — clean, no errors.
- `npx eslint components/dreams/dream-card.vue components/dreams/dream-gallery.vue` — same 4 pre-existing errors as on `main` before this change (confirmed via `git stash` diff), none introduced by this diff.
- Read-through of `dream-card.vue` confirms it already wraps `reactable-card` (landed via PR #1338 / interface-vision t-031, merged 2026-08-02 19:15 -0700 — *after* this task's earlier claim was released as "stale" at 18:17 UTC same day, which is why the premise is valid again now).
- Did not have a working local `nuxt dev` (SSR 500s on the unreachable dummy `DATABASE_URL` in this sandbox, per repo convention) or Vercel preview at push time to visually confirm the badge renders; the wiring is a direct structural copy of the already-shipped, working `reward-gallery.vue` pattern.

### Stakes
reversible

### Flags for Reviewer
- No award-call-site backfill was needed for Dreams (unlike some other object types t-046's note flagged) — Dreams already earn real `REACTION_RECEIVED` karma via the generic target-field-derived `refType` tagging in `server/api/reactions/index.post.ts`.
- Recommend a quick Vercel-preview visual check (badge shows on a Dream card that has actually earned karma) before/at merge, since I could not do that locally.

### Kaizen suggestion
`reward-gallery.vue`'s comment says "the remaining eleven reactable-card consumers can copy this pattern" — a small follow-up task to sweep the rest (Bot, Character, Scenario galleries, etc.) and wire the same batch-fetch would finish rolling out t-019's earned-karma pattern site-wide.

### Notes for reviewer
Conductor task interface-vision/t-048 is at `status: review`, claimed by session `2026-08-03T033115Z-interface-vision-t-048-agentrun`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DvT1JMApXbKtcbGCq6PesN)_