### PR TITLE
style: adopt kr-surface on For You manager

### DIFF
--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -1,7 +1,7 @@
 <!-- /components/pages/for-you-manager.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden p-1.5 sm:p-2.5"
+    class="kr-surface flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden p-1.5 sm:p-2.5"
   >
     <div class="rounded-2xl border border-accent/20 bg-accent/5 px-4 py-3">
       <div class="flex flex-wrap items-start justify-between gap-2">

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -39,7 +39,6 @@
     "root-surface": [
       "components/pages/appmaker-page.vue",
       "components/pages/conductor-page.vue",
-      "components/pages/for-you-manager.vue",
       "components/pages/memory-dungeon.vue",
       "components/pages/rebel-button.vue",
       "components/pages/storybook-library-page.vue",


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last  (kind: software)

### What changed / what I produced
- Added the shared `kr-surface` root marker to `components/pages/for-you-manager.vue` without changing its existing size, overflow, spacing, or scrolling behavior.
- Ratcheted the `root-surface` allow-list from 14 entries to 13.

### How I verified
- Inspected the complete branch diff against current `main`: two files, one class-token addition, one baseline deletion.
- CI is the authoritative verification for the layout contract and TypeScript in this connector-only run.

### Stakes
reversible

### Kaizen suggestion
Audit the remaining root-surface entries for simple marker-only conversions before attempting structural scroll changes.

### Notes for reviewer
The For You manager is already a bounded, overflow-hidden root with one child scroll owner, so adding `kr-surface` is contract adoption rather than a layout restructure.