### PR TITLE
layout: adopt kr-surface on storybook-library-page.vue

### DIFF
--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -1,6 +1,6 @@
 <!-- /components/pages/storybook-library-page.vue -->
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden">
+  <section class="kr-surface">
     <header
       class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100 p-3 shadow-sm"
     >

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -41,7 +41,6 @@
       "components/pages/conductor-page.vue",
       "components/pages/memory-dungeon.vue",
       "components/pages/rebel-button.vue",
-      "components/pages/storybook-library-page.vue",
       "components/pages/super-form.vue",
       "components/pages/wishmaster-page.vue",
       "components/user/registration-page.vue",


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

Twentieth scoped sweep.

### What changed / what I produced
- `components/pages/storybook-library-page.vue`: root wrapper's hand-rolled utility string (`flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden`) is byte-for-byte identical to the `.kr-surface` primitive's own `@apply` definition — swapped to the named class.
- Ratcheted `utils/scripts/layout-contract-baseline.json`'s `root-surface` bucket down via `--update`.

### How I verified
- `npm run test:layout-contract` — `root-surface: 13 -> 12`, all other buckets unchanged, "Layout contract holds — no new violations."
- `npx eslint components/pages/storybook-library-page.vue` — clean.
- `npx vue-tsc --noEmit` (full project) — clean, exit 0.

### Stakes
reversible

### Flags for Reviewer
- This component is MDC-mounted (`content/storybook.md` → `:storybook-library-page`) but, like `serendipity-page.vue` (PR #1336) before it, its root already forces `overflow-hidden` and manages its own bounded internal layout (a capped-height recent-stories panel plus a `flex-1 overflow-hidden` host for `<StorybookPage />`) rather than relying on the MDC content-host's own scroll — so `kr-surface` (not `kr-unbound`) is the correct primitive here, same reasoning as that precedent.
- Zero behavior change: the new class resolves to the exact same computed styles as the utility string it replaces.

### Kaizen suggestion
Most of the remaining 12 `root-surface` entries are still the MDC-mounted `-page.vue` components blocked on visual verification (`appmaker-page.vue`, `super-form.vue`, `wishmaster-page.vue`, `registration-page.vue`, `memory-dungeon.vue`, `rebel-button.vue`) plus `conductor-page.vue` (its own tracked conversion, t-061), `pages/[...slug].vue` (the ContentRenderer host itself), and the 4 admin `wonderlab-review-*.vue` pages (deliberately last). The next bounded sweep should pick one of these with a clear, low-risk shape (e.g. confirm `appmaker-page.vue`'s own `overflow-y-auto` is genuinely redundant with the content-host's scroll before converting it — that one needs a real behavior change, not just a class rename, so it deserves its own visual check first).

### Notes for reviewer
Session: conductor Agent run, interface-vision/t-017 (twentieth sweep). Conductor-side roadmap close-out will follow in a separate conductor PR per the cross-repo task convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DWGMfi4fZDbsbNu4enxVMd)_