### PR TITLE
layout: adopt kr-unbound on rebel-button.vue

### DIFF
--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/weird/rebel-button.vue -->
 <template>
-  <main>
+  <main class="kr-unbound">
     <div
       class="hero flex flex-col items-center justify-center bg-base-300 rounded-2xl border m-2 min-h-full w-full"
     >

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -40,7 +40,6 @@
       "components/pages/appmaker-page.vue",
       "components/pages/conductor-page.vue",
       "components/pages/memory-dungeon.vue",
-      "components/pages/rebel-button.vue",
       "components/pages/super-form.vue",
       "components/pages/wishmaster-page.vue",
       "components/user/registration-page.vue",


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

### What changed / what I produced
- Twenty-first scoped layout-contract sweep. `components/pages/rebel-button.vue` (MDC-mounted from `content/button.md`, reachable via the "Rebel Button Room" route, confirmed live not orphaned) declares zero scroll regions of its own, so `pages/[...slug].vue`'s ContentRenderer host already owns scroll for it — same shape as the `giving-page`/`mermaids-page`/`privacy-page` fix in PR #1343. Added `kr-unbound` to the component's actual template root (`<main>`), which had no class at all previously — the nested `<div>` that visually looks like the "root" carries the real layout classes but isn't what `verifyLayoutContract.ts`'s root-tag regex checks.
- Ratcheted `utils/scripts/layout-contract-baseline.json` root-surface: 12 → 11 via `--update`. All other buckets unchanged (one-scroll 27, its own task t-047/t-053).

### How I verified
- `npx eslint components/pages/rebel-button.vue` — clean
- `npx vue-tsc --noEmit` — clean, no new errors
- `npx tsx utils/scripts/verifyLayoutContract.ts --report` — root-surface 12→11, all other buckets unchanged
- `npx tsx utils/scripts/verifyMdcScrollOwnership.ts` — holds, 24 existing violations, no new ones across 59 mounted component tags
- Confirmed `rebel-button.vue` is genuinely reachable/live (not the orphan case earlier sweeps found for other files): mounted via `content/button.md`'s `:rebel-button` directive, referenced by `training/achievementData.ts` and `utils/scripts/verifyAchievementCatalog.ts`

### Stakes
reversible

### Kaizen suggestion
`verifyLayoutContract.ts`'s `rootClassList` reads the literal first tag after `<template>`, which can silently differ from the visually "main" wrapper div nested one level in (as happened here — `<main>` had no class, the styled `<div>` right under it did). A short doc comment in the script noting this footgun would save the next sweep a wasted first attempt.

### Notes for reviewer
Remaining root-surface entries (11): `super-form.vue`, `wishmaster-page.vue`, `registration-page.vue`, `memory-dungeon.vue`, `appmaker-page.vue` (5 MDC-mounted pages still needing visual verification before a safe kr-unbound/kr-surface call — several already declare their own overflow/height classes, so it's a real behavior change, not a pure rename), `conductor-page.vue` (its own tracked task, t-061), `pages/[...slug].vue` (the ContentRenderer host itself), and 4 admin `wonderlab-review-*.vue` pages (deliberately last per this task's own title).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UaZsVmZJ2QAHhrGPqJpUEd)_