### PR TITLE
fix(layout): mark Superkate receipt page as unbound

### DIFF
--- a/components/pages/super-form.vue
+++ b/components/pages/super-form.vue
@@ -1,7 +1,7 @@
 <!-- /components/pages/super-form.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 items-center justify-center overflow-y-auto overscroll-contain p-3 sm:p-6"
+    class="kr-unbound flex h-full min-h-0 items-center justify-center overflow-y-auto overscroll-contain p-3 sm:p-6"
   >
     <div
       class="w-full max-w-xl rounded-2xl border border-base-300 bg-base-100 p-4 shadow-xl sm:p-6"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -40,7 +40,6 @@
       "components/pages/appmaker-page.vue",
       "components/pages/conductor-page.vue",
       "components/pages/memory-dungeon.vue",
-      "components/pages/super-form.vue",
       "components/pages/wishmaster-page.vue",
       "components/user/registration-page.vue",
       "pages/[...slug].vue",


### PR DESCRIPTION
## Summary
- add the non-opinionated `kr-unbound` root marker to `components/pages/super-form.vue`
- preserve its existing self-owned scroll and centered receipt layout
- ratchet the `root-surface` layout-contract baseline from 11 entries to 10

## Conductor
- project: `interface-vision`
- task: `t-017`
- session: `2026-08-03T061500Z-interface-vision-t-017-q6m4`
- task review event queued on Conductor main

## Verification
- GitHub Actions must complete successfully before merge
- focused change only, no production data or outward-facing action