### PR TITLE
style: turn For You into a visual attention workspace

### DIFF
--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -1,0 +1,327 @@
+<template>
+  <section
+    class="relative isolate overflow-hidden rounded-[2rem] border border-primary/20 bg-base-100 shadow-sm"
+  >
+    <div
+      v-if="loading"
+      class="grid min-h-[24rem] animate-pulse lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]"
+    >
+      <div class="min-h-64 bg-base-300" />
+      <div class="space-y-4 p-6 sm:p-8">
+        <div class="h-5 w-32 rounded-full bg-base-300" />
+        <div class="h-10 w-4/5 rounded-2xl bg-base-300" />
+        <div class="h-24 rounded-2xl bg-base-200" />
+        <div class="grid grid-cols-2 gap-3">
+          <div class="h-28 rounded-2xl bg-base-200" />
+          <div class="h-28 rounded-2xl bg-base-200" />
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="grid min-h-[24rem] lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]"
+    >
+      <figure class="relative min-h-72 overflow-hidden bg-primary/10 lg:min-h-[29rem]">
+        <img
+          :src="displayImage"
+          :alt="activeDream ? `${activeDream.title} artwork` : 'Ami butterfly logo'"
+          class="absolute inset-0 size-full"
+          :class="hasDreamArtwork ? 'object-cover' : 'object-contain p-12 sm:p-16'"
+          @error="imageFailed = true"
+        />
+        <div
+          class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-content/75 via-base-content/5 to-transparent"
+        />
+
+        <div class="absolute inset-x-0 top-0 flex flex-wrap items-center gap-2 p-4 sm:p-5">
+          <span class="badge badge-primary gap-1 rounded-xl shadow-sm">
+            <Icon name="kind-icon:moon" class="size-3.5" />
+            Daily digest
+          </span>
+          <span v-if="activeDate" class="badge badge-neutral rounded-xl shadow-sm">
+            {{ formatDate(activeDate) }}
+          </span>
+          <span
+            v-if="digestDreams.length"
+            class="badge badge-ghost rounded-xl border-base-100/40 bg-base-100/80 text-base-content shadow-sm backdrop-blur"
+          >
+            {{ activeIndex + 1 }} of {{ digestDreams.length }}
+          </span>
+        </div>
+
+        <div class="absolute inset-x-0 bottom-0 p-5 text-base-100 sm:p-7">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-base-100/70">
+            {{ activeDream ? 'A world from the archive' : 'The archive is waking up' }}
+          </p>
+          <h2 class="mt-1 text-2xl font-black leading-tight sm:text-3xl">
+            {{ activeDream?.title || 'Fresh worlds will gather here' }}
+          </h2>
+        </div>
+      </figure>
+
+      <div class="flex min-w-0 flex-col p-5 sm:p-7">
+        <template v-if="activeDream">
+          <p class="text-sm leading-relaxed text-base-content/75">
+            {{ activeDream.pitch || activeDream.description || digestFallback }}
+          </p>
+
+          <div class="mt-5 grid gap-3 sm:grid-cols-2">
+            <div class="rounded-2xl border border-base-300 bg-base-200/55 p-4">
+              <div class="flex items-center gap-2">
+                <Icon name="kind-icon:users" class="size-4 text-primary" />
+                <h3 class="text-xs font-black uppercase tracking-wide text-base-content/55">
+                  Cast
+                </h3>
+              </div>
+              <div v-if="activeCharacters.length" class="mt-3 space-y-2">
+                <div
+                  v-for="character in activeCharacters"
+                  :key="character.id"
+                  class="flex items-center gap-2"
+                >
+                  <div class="avatar placeholder">
+                    <div class="size-9 rounded-xl bg-base-300 text-base-content/60">
+                      <img
+                        v-if="character.imagePath"
+                        :src="character.imagePath"
+                        :alt="character.name"
+                        loading="lazy"
+                      />
+                      <Icon v-else name="kind-icon:character" class="size-4" />
+                    </div>
+                  </div>
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-bold">{{ character.name }}</p>
+                    <p class="truncate text-[11px] text-base-content/50">
+                      {{ character.species || character.class || 'Dream traveler' }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <p v-else class="mt-3 text-xs text-base-content/45">
+                The cast is still assembling.
+              </p>
+            </div>
+
+            <div class="rounded-2xl border border-base-300 bg-base-200/55 p-4">
+              <div class="flex items-center gap-2">
+                <Icon name="kind-icon:gift" class="size-4 text-secondary" />
+                <h3 class="text-xs font-black uppercase tracking-wide text-base-content/55">
+                  Discoveries
+                </h3>
+              </div>
+              <div v-if="activeRewards.length" class="mt-3 space-y-2">
+                <div
+                  v-for="reward in activeRewards"
+                  :key="reward.id"
+                  class="rounded-xl bg-base-100 px-3 py-2"
+                >
+                  <p class="truncate text-sm font-bold">{{ reward.name }}</p>
+                  <p class="truncate text-[11px] text-base-content/50">
+                    {{ reward.rewardType || 'Reward' }}
+                    <span v-if="reward.rarity"> · {{ reward.rarity }}</span>
+                  </p>
+                </div>
+              </div>
+              <p v-else class="mt-3 text-xs text-base-content/45">
+                Its treasures are still being catalogued.
+              </p>
+            </div>
+          </div>
+        </template>
+
+        <div v-else class="flex flex-1 flex-col justify-center py-5">
+          <p class="text-lg font-black">No Daily Dreams have landed yet.</p>
+          <p class="mt-2 max-w-xl text-sm leading-relaxed text-base-content/60">
+            This space follows the current Daily Dream model. As the backlog is built and
+            artwork finishes rendering, each day will appear here with its world, cast,
+            discoveries, and images.
+          </p>
+        </div>
+
+        <div
+          class="mt-auto flex flex-col gap-3 border-t border-base-300 pt-5 sm:flex-row sm:items-center"
+        >
+          <div class="join shrink-0">
+            <button
+              type="button"
+              class="btn join-item btn-sm"
+              :disabled="!canGoOlder"
+              aria-label="Show the previous daily digest"
+              @click="showOlder"
+            >
+              <Icon name="kind-icon:chevron-left" class="size-4" />
+              Previous
+            </button>
+            <button
+              type="button"
+              class="btn join-item btn-sm"
+              :disabled="!canGoNewer"
+              aria-label="Show the next daily digest"
+              @click="showNewer"
+            >
+              Next
+              <Icon name="kind-icon:chevron-right" class="size-4" />
+            </button>
+          </div>
+
+          <select
+            v-if="digestDreams.length"
+            v-model.number="selectedDreamId"
+            class="select select-bordered select-sm min-w-0 flex-1 rounded-xl"
+            aria-label="Choose a daily digest"
+          >
+            <option v-for="dream in digestDreams" :key="dream.id" :value="dream.id">
+              {{ formatDate(dateKey(dream)) }} · {{ dream.title }}
+            </option>
+          </select>
+
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm shrink-0 rounded-xl"
+            :disabled="loading"
+            @click="loadDigests"
+          >
+            <Icon name="kind-icon:refresh-cw" class="size-4" />
+            Refresh archive
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
+
+type DigestDream = DreamWithRelations & {
+  PitchSheet?: { imagePath?: string | null } | null
+}
+
+const dreamStore = useDreamStore()
+const selectedDreamId = ref<number | null>(null)
+const loading = ref(true)
+const imageFailed = ref(false)
+
+const digestDreams = computed<DigestDream[]>(() =>
+  dreamStore.dreams
+    .filter(
+      (dream) =>
+        dream.designer === 'Daily Dream Facet Engine' ||
+        String(dream.slug || '').startsWith('daily-dream-'),
+    )
+    .sort((left, right) => {
+      const dateOrder = dateKey(right).localeCompare(dateKey(left))
+      return dateOrder || right.id - left.id
+    }),
+)
+
+const activeIndex = computed(() => {
+  const index = digestDreams.value.findIndex(
+    (dream) => dream.id === selectedDreamId.value,
+  )
+  return index >= 0 ? index : 0
+})
+
+const activeDream = computed<DigestDream | null>(
+  () => digestDreams.value[activeIndex.value] ?? null,
+)
+const activeDate = computed(() =>
+  activeDream.value ? dateKey(activeDream.value) : '',
+)
+const activeCharacters = computed(() => activeDream.value?.Characters?.slice(0, 3) ?? [])
+const activeRewards = computed(() => activeDream.value?.Rewards?.slice(0, 3) ?? [])
+const canGoOlder = computed(() => activeIndex.value < digestDreams.value.length - 1)
+const canGoNewer = computed(() => activeIndex.value > 0)
+
+const activeArtwork = computed(() => {
+  const dream = activeDream.value
+  if (!dream) return ''
+  return (
+    resolveEntityArtwork(dream.ArtImage) ||
+    resolveEntityArtwork(dream.ArtImages?.[0]) ||
+    resolveEntityArtwork(dream.ArtCollection) ||
+    resolveEntityArtwork(dream.ArtCollections?.[0]?.ArtImages?.[0]) ||
+    resolveEntityArtwork(dream.ArtCollections?.[0]) ||
+    dream.PitchSheet?.imagePath ||
+    resolveEntityArtwork(dream) ||
+    ''
+  )
+})
+
+const hasDreamArtwork = computed(() => Boolean(activeArtwork.value && !imageFailed.value))
+const displayImage = computed(() =>
+  hasDreamArtwork.value ? activeArtwork.value : '/images/amilogo.webp',
+)
+
+const digestFallback =
+  'A freshly assembled world from the Daily Dream engine, waiting for its story to unfold.'
+
+function dateKey(dream: DigestDream): string {
+  const slugDate = String(dream.slug || '').match(
+    /^daily-dream-(\d{4}-\d{2}-\d{2})-/,
+  )?.[1]
+  if (slugDate) return slugDate
+  return String(dream.createdAt || '').slice(0, 10)
+}
+
+function formatDate(value: string): string {
+  if (!value) return 'Undated dream'
+  const date = new Date(`${value}T12:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)
+}
+
+function showOlder(): void {
+  const dream = digestDreams.value[activeIndex.value + 1]
+  if (dream) selectedDreamId.value = dream.id
+}
+
+function showNewer(): void {
+  const dream = digestDreams.value[activeIndex.value - 1]
+  if (dream) selectedDreamId.value = dream.id
+}
+
+async function loadDigests(): Promise<void> {
+  loading.value = true
+  try {
+    await dreamStore.fetchDreams({
+      userOnly: true,
+      search: 'Daily Dream Facet Engine',
+      limit: 100,
+    })
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  digestDreams,
+  (dreams) => {
+    if (!dreams.length) {
+      selectedDreamId.value = null
+      return
+    }
+    if (!dreams.some((dream) => dream.id === selectedDreamId.value)) {
+      selectedDreamId.value = dreams[0]?.id ?? null
+    }
+  },
+  { immediate: true },
+)
+
+watch(activeArtwork, () => {
+  imageFailed.value = false
+})
+
+onMounted(() => {
+  void loadDigests()
+})
+</script>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -1,268 +1,377 @@
 <!-- /components/pages/for-you-manager.vue -->
 <template>
-  <section
-    class="kr-surface flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden p-1.5 sm:p-2.5"
-  >
-    <div class="rounded-2xl border border-accent/20 bg-accent/5 px-4 py-3">
-      <div class="flex flex-wrap items-start justify-between gap-2">
-        <div>
-          <p class="text-xs font-semibold text-accent/80">✨ For You</p>
-          <p class="mt-0.5 text-xs text-base-content/55">
-            Decisions, proposals, and personal follow-ups that need a human hand.
-          </p>
-        </div>
-        <button
-          v-if="userStore.isAdmin"
-          class="btn btn-ghost btn-xs"
-          :disabled="conductorStore.pending"
-          @click="conductorStore.fetchProjects(true)"
-        >
-          <span
-            v-if="conductorStore.pending"
-            class="loading loading-spinner loading-xs"
-          />
-          Refresh
-        </button>
-      </div>
-      <p
-        v-if="urgentCount > 0"
-        class="mt-1 text-xs font-semibold text-error"
+  <section class="kr-surface flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <div class="kr-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain">
+      <div
+        class="mx-auto w-full max-w-[1800px] space-y-6 p-2 pb-8 sm:p-4 sm:pb-10 xl:p-6"
       >
-        {{ urgentCount }} item{{ urgentCount === 1 ? '' : 's' }} need a decision.
-      </p>
-    </div>
+        <daily-digest-browser />
 
-    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-      <div class="space-y-4 pb-4">
+        <header
+          class="kr-toolbar flex flex-col gap-4 rounded-2xl border border-accent/20 bg-accent/5 p-4 shadow-sm lg:flex-row lg:items-center lg:justify-between"
+        >
+          <div class="min-w-0">
+            <div class="flex items-center gap-2 text-accent">
+              <Icon name="kind-icon:sparkles" class="size-5" />
+              <p class="text-xs font-black uppercase tracking-[0.18em]">For You</p>
+            </div>
+            <h1 class="mt-1 text-xl font-black sm:text-2xl">Your attention desk</h1>
+            <p class="mt-1 max-w-3xl text-sm text-base-content/60">
+              Decisions, proposals, and follow-ups gathered into one human-sized place.
+            </p>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <span
+              v-if="userStore.isAdmin"
+              class="badge badge-warning h-auto gap-1 rounded-xl px-3 py-2"
+            >
+              <Icon name="kind-icon:lock" class="size-3.5" />
+              {{ conductorStore.humanGates.length }} gate{{
+                conductorStore.humanGates.length === 1 ? '' : 's'
+              }}
+            </span>
+            <span
+              v-if="userStore.isAdmin"
+              class="badge badge-secondary h-auto gap-1 rounded-xl px-3 py-2"
+            >
+              <Icon name="kind-icon:lightbulb" class="size-3.5" />
+              {{ conductorStore.pendingPitches.length }} pitch{{
+                conductorStore.pendingPitches.length === 1 ? '' : 'es'
+              }}
+            </span>
+            <span class="badge badge-accent h-auto gap-1 rounded-xl px-3 py-2">
+              <Icon name="kind-icon:check-square" class="size-3.5" />
+              {{ todoStore.honeyDoTodos.length }} follow-up{{
+                todoStore.honeyDoTodos.length === 1 ? '' : 's'
+              }}
+            </span>
+            <button
+              v-if="userStore.isAdmin"
+              type="button"
+              class="btn btn-ghost btn-sm rounded-xl"
+              :disabled="conductorStore.pending"
+              @click="conductorStore.fetchProjects(true)"
+            >
+              <span
+                v-if="conductorStore.pending"
+                class="loading loading-spinner loading-xs"
+              />
+              <Icon v-else name="kind-icon:refresh-cw" class="size-4" />
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        <p
+          v-if="urgentCount > 0"
+          class="rounded-2xl border border-error/20 bg-error/5 px-4 py-3 text-sm font-semibold text-error"
+        >
+          {{ urgentCount }} item{{ urgentCount === 1 ? '' : 's' }} need a decision.
+        </p>
+
         <template v-if="userStore.isAdmin">
-          <section class="space-y-2">
-            <div class="flex items-center justify-between gap-2 px-1">
+          <section class="space-y-3">
+            <div class="flex flex-wrap items-end justify-between gap-3 px-1">
               <div>
-                <h2 class="text-sm font-black">Conductor human gates</h2>
-                <p class="text-xs text-base-content/50">
-                  Approvals and questions currently blocking agent work.
+                <p class="text-xs font-black uppercase tracking-[0.16em] text-warning">
+                  Conductor
+                </p>
+                <h2 class="text-xl font-black">Human gates</h2>
+                <p class="text-sm text-base-content/55">
+                  Approvals and questions currently waiting on your judgment.
                 </p>
               </div>
-              <span class="badge badge-warning badge-sm">
-                {{ conductorStore.humanGates.length }}
+              <span class="badge badge-warning rounded-xl">
+                {{ conductorStore.humanGates.length }} waiting
               </span>
             </div>
 
             <div
               v-if="conductorStore.pending && !conductorStore.hasLiveData"
-              class="h-28 animate-pulse rounded-2xl border border-base-300 bg-base-200"
-            />
-
-            <article
-              v-for="gate in conductorStore.humanGates"
-              :key="`${gate.project.slug}/${gate.task.id}`"
-              class="rounded-2xl border border-warning/30 bg-warning/5 p-3 shadow-sm"
+              class="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3"
             >
-              <div class="flex flex-wrap items-start justify-between gap-2">
-                <div class="min-w-0 flex-1">
-                  <button
-                    class="text-left text-xs font-bold text-primary hover:underline"
-                    @click="viewConductorProject(gate.project.slug)"
-                  >
-                    {{ gate.project.name }} · {{ gate.task.id }}
-                  </button>
-                  <h3 class="mt-0.5 text-sm font-black leading-tight">
-                    {{ gate.task.title }}
-                  </h3>
-                </div>
-                <div class="flex flex-wrap gap-1">
-                  <span
-                    class="badge badge-sm"
-                    :class="gate.task.softGate ? 'badge-info' : 'badge-error'"
-                  >
-                    {{ gate.task.softGate ? 'soft gate' : 'human gate' }}
-                  </span>
-                  <span v-if="gate.task.stakes" class="badge badge-ghost badge-sm">
-                    {{ gate.task.stakes }}
-                  </span>
-                </div>
-              </div>
-
-              <details v-if="gate.task.note" class="mt-2 text-xs">
-                <summary class="cursor-pointer font-semibold text-base-content/65">
-                  Context from Conductor
-                </summary>
-                <p class="mt-2 whitespace-pre-wrap text-base-content/70">
-                  {{ gate.task.note }}
-                </p>
-              </details>
-
-              <textarea
-                v-model="gateMessages[gateKey(gate.project.slug, gate.task.id)]"
-                class="textarea textarea-bordered mt-3 min-h-20 w-full text-sm"
-                placeholder="Add context, requested changes, or an approval note…"
-                :disabled="taskIsUpdating(gate.project.slug, gate.task.id)"
+              <div
+                v-for="n in 3"
+                :key="n"
+                class="h-64 animate-pulse rounded-2xl border border-base-300 bg-base-200"
               />
-
-              <div class="mt-2 flex flex-wrap gap-2">
-                <button
-                  class="btn btn-success btn-sm"
-                  :disabled="taskIsUpdating(gate.project.slug, gate.task.id)"
-                  @click="actOnGate(gate.project.slug, gate.task.id, 'approve')"
-                >
-                  <span
-                    v-if="taskIsUpdating(gate.project.slug, gate.task.id)"
-                    class="loading loading-spinner loading-xs"
-                  />
-                  Approve
-                </button>
-                <button
-                  class="btn btn-error btn-outline btn-sm"
-                  :disabled="
-                    taskIsUpdating(gate.project.slug, gate.task.id) ||
-                    !gateMessage(gate.project.slug, gate.task.id).trim()
-                  "
-                  @click="actOnGate(gate.project.slug, gate.task.id, 'reject')"
-                >
-                  Send back
-                </button>
-                <button
-                  class="btn btn-ghost btn-sm"
-                  :disabled="
-                    taskIsUpdating(gate.project.slug, gate.task.id) ||
-                    !gateMessage(gate.project.slug, gate.task.id).trim()
-                  "
-                  @click="actOnGate(gate.project.slug, gate.task.id, 'comment')"
-                >
-                  Send note
-                </button>
-              </div>
-            </article>
+            </div>
 
             <div
-              v-if="
-                conductorStore.hasLiveData &&
-                !conductorStore.pending &&
-                !conductorStore.humanGates.length
-              "
-              class="rounded-2xl border border-success/20 bg-success/5 px-4 py-5 text-center"
+              v-else-if="conductorStore.humanGates.length"
+              class="grid items-start gap-4 lg:grid-cols-2 2xl:grid-cols-3"
+            >
+              <article
+                v-for="gate in conductorStore.humanGates"
+                :key="`${gate.project.slug}/${gate.task.id}`"
+                class="flex h-full min-w-0 flex-col rounded-2xl border border-warning/30 bg-base-100 p-4 shadow-sm transition-shadow hover:shadow-md"
+              >
+                <div class="flex flex-wrap items-start justify-between gap-2">
+                  <div class="min-w-0 flex-1">
+                    <button
+                      type="button"
+                      class="max-w-full truncate text-left text-xs font-bold text-primary hover:underline"
+                      @click="viewConductorProject(gate.project.slug)"
+                    >
+                      {{ gate.project.name }} · {{ gate.task.id }}
+                    </button>
+                    <h3 class="mt-1 text-base font-black leading-snug">
+                      {{ gate.task.title }}
+                    </h3>
+                  </div>
+                  <span
+                    class="badge badge-sm shrink-0 rounded-xl"
+                    :class="gate.task.softGate ? 'badge-info' : 'badge-error'"
+                  >
+                    {{ gate.task.softGate ? 'question' : 'approval' }}
+                  </span>
+                </div>
+
+                <div class="mt-3 flex flex-wrap gap-1.5">
+                  <span v-if="gate.task.stakes" class="badge badge-ghost badge-sm rounded-xl">
+                    {{ gate.task.stakes }}
+                  </span>
+                  <span v-if="!gate.task.softGate" class="badge badge-outline badge-sm rounded-xl">
+                    blocking work
+                  </span>
+                </div>
+
+                <details
+                  v-if="gate.task.note"
+                  class="group mt-3 rounded-xl border border-base-300 bg-base-200/50"
+                >
+                  <summary
+                    class="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2 text-xs font-bold text-base-content/65 marker:hidden"
+                  >
+                    Context from Conductor
+                    <Icon
+                      name="kind-icon:chevron-down"
+                      class="size-4 transition-transform group-open:rotate-180"
+                    />
+                  </summary>
+                  <p
+                    class="max-h-48 overflow-y-auto whitespace-pre-wrap border-t border-base-300 px-3 py-3 text-xs leading-relaxed text-base-content/70"
+                  >
+                    {{ gate.task.note }}
+                  </p>
+                </details>
+
+                <div class="mt-auto flex flex-wrap items-center gap-2 pt-4">
+                  <button
+                    type="button"
+                    class="btn btn-success btn-sm rounded-xl"
+                    :disabled="taskIsUpdating(gate.project.slug, gate.task.id)"
+                    @click="actOnGate(gate.project.slug, gate.task.id, 'approve')"
+                  >
+                    <span
+                      v-if="taskIsUpdating(gate.project.slug, gate.task.id)"
+                      class="loading loading-spinner loading-xs"
+                    />
+                    <Icon v-else name="kind-icon:check" class="size-4" />
+                    Approve
+                  </button>
+
+                  <details class="group min-w-[12rem] flex-1">
+                    <summary
+                      class="btn btn-outline btn-sm w-full list-none rounded-xl marker:hidden"
+                    >
+                      <Icon name="kind-icon:message-square" class="size-4" />
+                      Reply or send back
+                      <Icon
+                        name="kind-icon:chevron-down"
+                        class="ml-auto size-4 transition-transform group-open:rotate-180"
+                      />
+                    </summary>
+                    <div
+                      class="mt-3 rounded-2xl border border-base-300 bg-base-200/60 p-3"
+                    >
+                      <textarea
+                        v-model="gateMessages[gateKey(gate.project.slug, gate.task.id)]"
+                        class="textarea textarea-bordered min-h-24 w-full rounded-xl bg-base-100 text-sm"
+                        placeholder="Add context, requested changes, or a note…"
+                        :disabled="taskIsUpdating(gate.project.slug, gate.task.id)"
+                      />
+                      <div class="mt-2 flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          class="btn btn-error btn-outline btn-sm rounded-xl"
+                          :disabled="
+                            taskIsUpdating(gate.project.slug, gate.task.id) ||
+                            !gateMessage(gate.project.slug, gate.task.id).trim()
+                          "
+                          @click="actOnGate(gate.project.slug, gate.task.id, 'reject')"
+                        >
+                          Send back
+                        </button>
+                        <button
+                          type="button"
+                          class="btn btn-ghost btn-sm rounded-xl"
+                          :disabled="
+                            taskIsUpdating(gate.project.slug, gate.task.id) ||
+                            !gateMessage(gate.project.slug, gate.task.id).trim()
+                          "
+                          @click="actOnGate(gate.project.slug, gate.task.id, 'comment')"
+                        >
+                          Send note
+                        </button>
+                      </div>
+                    </div>
+                  </details>
+                </div>
+              </article>
+            </div>
+
+            <div
+              v-else-if="conductorStore.hasLiveData && !conductorStore.pending"
+              class="rounded-2xl border border-success/20 bg-success/5 px-5 py-8 text-center"
             >
               <Icon
                 name="kind-icon:check-circle"
-                class="mx-auto mb-1 size-7 text-success/50"
+                class="mx-auto mb-2 size-9 text-success/55"
               />
-              <p class="text-sm font-semibold text-base-content/55">
-                No Conductor gates are waiting on you.
-              </p>
+              <p class="font-black">No Conductor gates are waiting on you.</p>
+              <p class="mt-1 text-sm text-base-content/50">The robots may proceed.</p>
             </div>
           </section>
 
-          <section class="space-y-2">
-            <div class="flex items-center justify-between gap-2 px-1">
+          <section class="space-y-3">
+            <div class="flex flex-wrap items-end justify-between gap-3 px-1">
               <div>
-                <h2 class="text-sm font-black">Pitch proposals</h2>
-                <p class="text-xs text-base-content/50">
-                  New ideas awaiting approval or rejection.
+                <p class="text-xs font-black uppercase tracking-[0.16em] text-secondary">
+                  Possibilities
+                </p>
+                <h2 class="text-xl font-black">Pitch proposals</h2>
+                <p class="text-sm text-base-content/55">
+                  New ideas waiting for a green light or a merciful trapdoor.
                 </p>
               </div>
-              <span class="badge badge-secondary badge-sm">
-                {{ conductorStore.pendingPitches.length }}
+              <span class="badge badge-secondary rounded-xl">
+                {{ conductorStore.pendingPitches.length }} waiting
               </span>
             </div>
 
-            <article
-              v-for="pitch in conductorStore.pendingPitches"
-              :key="pitch.slug"
-              class="rounded-2xl border border-secondary/25 bg-secondary/5 p-3"
+            <div
+              v-if="conductorStore.pendingPitches.length"
+              class="grid items-start gap-4 md:grid-cols-2 2xl:grid-cols-3"
             >
-              <div class="flex flex-wrap items-start justify-between gap-2">
-                <div class="min-w-0 flex-1">
-                  <p class="text-xs font-semibold text-secondary/80">
-                    {{ pitch.projectTarget || 'General' }}
-                    <span v-if="pitch.date"> · {{ pitch.date }}</span>
-                  </p>
-                  <h3 class="text-sm font-black leading-tight">{{ pitch.title }}</h3>
+              <article
+                v-for="pitch in conductorStore.pendingPitches"
+                :key="pitch.slug"
+                class="flex h-full min-w-0 flex-col rounded-2xl border border-secondary/25 bg-base-100 p-4 shadow-sm transition-shadow hover:shadow-md"
+              >
+                <div class="flex flex-wrap items-start justify-between gap-2">
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate text-xs font-bold text-secondary/80">
+                      {{ pitch.projectTarget || 'General' }}
+                      <span v-if="pitch.date"> · {{ pitch.date }}</span>
+                    </p>
+                    <h3 class="mt-1 text-base font-black leading-snug">{{ pitch.title }}</h3>
+                  </div>
+                  <span v-if="pitch.effort" class="badge badge-ghost badge-sm rounded-xl">
+                    {{ pitch.effort }}
+                  </span>
                 </div>
-                <span v-if="pitch.effort" class="badge badge-ghost badge-sm">
-                  {{ pitch.effort }}
-                </span>
-              </div>
-              <p v-if="pitch.idea" class="mt-2 text-xs text-base-content/70">
-                {{ pitch.idea }}
-              </p>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <button
-                  class="btn btn-success btn-sm"
-                  :disabled="pitchIsUpdating(pitch.slug)"
-                  @click="conductorStore.updatePitchStatus(pitch.slug, 'approved')"
+
+                <p
+                  v-if="pitch.idea"
+                  class="mt-3 line-clamp-5 text-sm leading-relaxed text-base-content/70"
                 >
-                  Approve pitch
-                </button>
-                <button
-                  class="btn btn-error btn-outline btn-sm"
-                  :disabled="pitchIsUpdating(pitch.slug)"
-                  @click="conductorStore.updatePitchStatus(pitch.slug, 'rejected')"
-                >
-                  Reject
-                </button>
-                <button
-                  class="btn btn-ghost btn-sm"
-                  @click="navigateTo('/conductor')"
-                >
-                  Full review
-                </button>
-              </div>
-            </article>
+                  {{ pitch.idea }}
+                </p>
+
+                <div class="mt-auto flex flex-wrap gap-2 pt-4">
+                  <button
+                    type="button"
+                    class="btn btn-success btn-sm rounded-xl"
+                    :disabled="pitchIsUpdating(pitch.slug)"
+                    @click="conductorStore.updatePitchStatus(pitch.slug, 'approved')"
+                  >
+                    Approve pitch
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-error btn-outline btn-sm rounded-xl"
+                    :disabled="pitchIsUpdating(pitch.slug)"
+                    @click="conductorStore.updatePitchStatus(pitch.slug, 'rejected')"
+                  >
+                    Reject
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm rounded-xl"
+                    @click="navigateTo('/conductor')"
+                  >
+                    Full review
+                  </button>
+                </div>
+              </article>
+            </div>
 
             <div
-              v-if="
-                conductorStore.hasLiveData &&
-                !conductorStore.pending &&
-                !conductorStore.pendingPitches.length
-              "
-              class="rounded-2xl border border-base-300 bg-base-100 px-4 py-4 text-center text-sm text-base-content/50"
+              v-else-if="conductorStore.hasLiveData && !conductorStore.pending"
+              class="rounded-2xl border border-base-300 bg-base-100 px-5 py-7 text-center"
             >
-              No new pitches are waiting.
+              <Icon name="kind-icon:lightbulb" class="mx-auto mb-2 size-8 text-secondary/45" />
+              <p class="font-bold text-base-content/65">No new pitches are waiting.</p>
             </div>
           </section>
         </template>
 
-        <section class="space-y-2">
-          <div class="flex items-center justify-between gap-2 px-1">
+        <section class="space-y-3">
+          <div class="flex flex-wrap items-end justify-between gap-3 px-1">
             <div>
-              <h2 class="text-sm font-black">Personal follow-ups</h2>
-              <p class="text-xs text-base-content/50">
-                Your existing Kind Robots task reminders.
+              <p class="text-xs font-black uppercase tracking-[0.16em] text-accent">
+                Kind Robots
+              </p>
+              <h2 class="text-xl font-black">Personal follow-ups</h2>
+              <p class="text-sm text-base-content/55">
+                Your existing reminders, arranged for an actual human screen.
               </p>
             </div>
-            <span class="badge badge-accent badge-sm">
-              {{ todoStore.honeyDoTodos.length }}
+            <span class="badge badge-accent rounded-xl">
+              {{ todoStore.honeyDoTodos.length }} waiting
             </span>
           </div>
 
-          <template v-if="todoStore.loading && !todoStore.honeyDoTodos.length">
+          <div
+            v-if="todoStore.loading && !todoStore.honeyDoTodos.length"
+            class="grid gap-4 md:grid-cols-2 2xl:grid-cols-3"
+          >
             <div
-              v-for="n in 2"
+              v-for="n in 3"
               :key="n"
-              class="h-16 animate-pulse rounded-2xl border border-base-300 bg-base-200"
+              class="h-28 animate-pulse rounded-2xl border border-base-300 bg-base-200"
             />
-          </template>
-
-          <honeydo-card
-            v-for="todo in todoStore.honeyDoTodos"
-            :key="todo.id"
-            :todo="todo"
-            :project="relatedProject(todo)"
-            @toggle-done="todoStore.toggleDone(todo)"
-            @view-project="viewProject"
-          />
+          </div>
 
           <div
-            v-if="!todoStore.loading && !todoStore.honeyDoTodos.length"
-            class="rounded-2xl border border-base-300 bg-base-100 px-4 py-4 text-center text-sm text-base-content/50"
+            v-else-if="todoStore.honeyDoTodos.length"
+            class="grid items-start gap-4 md:grid-cols-2 2xl:grid-cols-3"
           >
-            No personal follow-ups are waiting.
+            <honeydo-card
+              v-for="todo in todoStore.honeyDoTodos"
+              :key="todo.id"
+              class="h-full"
+              :todo="todo"
+              :project="relatedProject(todo)"
+              @toggle-done="todoStore.toggleDone(todo)"
+              @view-project="viewProject"
+            />
+          </div>
+
+          <div
+            v-else
+            class="rounded-2xl border border-base-300 bg-base-100 px-5 py-7 text-center"
+          >
+            <Icon name="kind-icon:check-circle" class="mx-auto mb-2 size-8 text-success/45" />
+            <p class="font-bold text-base-content/65">No personal follow-ups are waiting.</p>
           </div>
         </section>
 
         <p
           v-if="conductorStore.taskUpdateError || conductorStore.pitchUpdateError"
-          class="rounded-xl bg-error/10 px-3 py-2 text-xs text-error"
+          class="rounded-2xl border border-error/20 bg-error/10 px-4 py-3 text-sm text-error"
         >
           {{ conductorStore.taskUpdateError || conductorStore.pitchUpdateError }}
         </p>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -1,7 +1,7 @@
 <!-- /components/pages/for-you-manager.vue -->
 <template>
   <section class="kr-surface flex h-full min-h-0 w-full flex-col overflow-hidden">
-    <div class="kr-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain">
+    <div class="kr-scroll min-h-0 flex-1 overscroll-contain">
       <div
         class="mx-auto w-full max-w-[1800px] space-y-6 p-2 pb-8 sm:p-4 sm:pb-10 xl:p-6"
       >

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -15,7 +15,7 @@
               <Icon name="kind-icon:sparkles" class="size-5" />
               <p class="text-xs font-black uppercase tracking-[0.18em]">For You</p>
             </div>
-            <h1 class="mt-1 text-xl font-black sm:text-2xl">Your attention desk</h1>
+            <h2 class="mt-1 text-xl font-black sm:text-2xl">Your attention desk</h2>
             <p class="mt-1 max-w-3xl text-sm text-base-content/60">
               Decisions, proposals, and follow-ups gathered into one human-sized place.
             </p>
@@ -151,7 +151,7 @@
                     />
                   </summary>
                   <p
-                    class="max-h-48 overflow-y-auto whitespace-pre-wrap border-t border-base-300 px-3 py-3 text-xs leading-relaxed text-base-content/70"
+                    class="whitespace-pre-wrap border-t border-base-300 px-3 py-3 text-xs leading-relaxed text-base-content/70"
                   >
                     {{ gate.task.note }}
                   </p>


### PR DESCRIPTION
## User request
Silas asked for a style pass on Home / For You: use wide screens instead of one giant vertical list, make the page pleasant to visit, open with imagery, and revive the useful shape of the former Daily Dream digest with day-by-day browsing.

## What changed
- adds a wide Daily Digest stage at the top of For You
- discovers the current `Daily Dream Facet Engine` Dream records through the canonical Dream store
- defaults to the newest digest and adds Previous, Next, and day-picker navigation
- uses real Dream artwork when available, with the existing Ami logo as a friendly fallback while the art backlog drains
- shows each digest's pitch, cast, and rewards from the real Dream relations
- converts human gates into responsive 2-column / 3-column cards on large and extra-wide displays
- moves note and rejection controls into an expandable response panel, leaving approval one click away without rendering a textarea on every card
- converts pitches and personal follow-ups to responsive grids
- keeps mobile as a single-column layout and preserves the page's one-scroll-owner contract

## Architecture
- no new API or duplicate digest model
- components continue to dispatch through Pinia stores; the new browser calls `dreamStore.fetchDreams()` rather than fetching directly
- Conductor decisions remain authoritative task events through the existing store
- no schema or migration changes

## Verification
CI TypeScript, layout, navigation, and project contracts. Then Vercel preview at phone, desktop, and extra-wide widths before merge.

## Stakes
Reversible UI and read-only digest browsing.