### PR TITLE
fix(facets): put /facets on the manager → interact → gallery pattern

### DIFF
--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -7,9 +7,13 @@
       v-if="showToolbar && !isDropdownMode"
       class="shrink-0 rounded-2xl border border-base-300 bg-base-100/95 px-2 py-2 shadow-sm backdrop-blur"
     >
-      <div
-        class="flex min-w-0 items-center gap-2 overflow-x-auto whitespace-nowrap dream-toolbar-scroll"
-      >
+      <!-- Wraps, rather than scrolling sideways. This row used to be
+           `overflow-x-auto whitespace-nowrap` with shrink-0 controls, so on a
+           tablet the layout picker (Grid/Row/Reel/Hero/Swipe) sat off the right
+           edge behind a scrollbar nobody found -- Silas reviewed /dreams and
+           reported the view control as "cut off on the right side" without
+           knowing the modes existed. A hidden control is a missing control. -->
+      <div class="kr-toolbar min-w-0">
         <div
           v-if="showHeader"
           class="flex min-w-0 shrink-0 items-center gap-1.5 pr-1"
@@ -1067,10 +1071,6 @@ function uniqueById<T extends { id?: number | null }>(items: T[]) {
 </script>
 
 <style scoped>
-.dream-toolbar-scroll {
-  scrollbar-width: thin;
-}
-
 .dream-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -1,27 +1,30 @@
 <!-- /components/facets/facet-gallery.vue -->
 <template>
-  <section class="mx-auto w-full max-w-7xl space-y-6 p-4">
+  <section class="kr-surface">
+    <!-- The shell renders the page title from content frontmatter (the brief's
+         one-header rule), so this only carries the count and the loading state.
+         showHeader lets a host that wants nothing at all drop even that. -->
     <header
-      class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
+      v-if="showHeader"
+      class="kr-toolbar shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3"
     >
-      <Icon name="kind-icon:tag" class="size-6 text-secondary" />
+      <Icon name="kind-icon:tag" class="size-5 text-secondary" />
       <div class="min-w-0 flex-1">
-        <h1 class="text-xl font-black">Facets</h1>
-        <p class="text-sm text-base-content/60">
-          Browse the canonical creative building blocks — genres, species,
-          archetypes, moods, styles and more — shared across Characters, Bots,
-          Dreams, Scenarios, and Art.
-        </p>
+        <p class="font-black">{{ title }}</p>
+        <p v-if="subtitle" class="text-xs text-base-content/55">{{ subtitle }}</p>
       </div>
       <span
         v-if="catalog.loading"
         class="loading loading-spinner loading-sm"
         aria-label="Loading facets"
       />
-      <span class="badge badge-ghost">{{ visibleCount }} shown</span>
+      <span class="badge badge-ghost shrink-0">{{ visibleCount }} shown</span>
     </header>
 
-    <div class="flex flex-wrap items-center gap-2">
+    <!-- Controls WRAP. dream-gallery's toolbar is `overflow-x-auto` with
+         shrink-0 children, which is why its layout picker scrolls off the right
+         edge on an iPad and Silas could not find it (2026-08-02 review). -->
+    <div v-if="showControls" class="kr-toolbar shrink-0">
       <input
         v-model="search"
         type="search"
@@ -53,43 +56,65 @@
         />
         Illustrated only
       </label>
+
+      <select
+        v-model="mode"
+        class="select select-bordered select-sm shrink-0 rounded-xl"
+        aria-label="Facet gallery layout"
+      >
+        <option v-for="entry in GALLERY_MODES" :key="entry.value" :value="entry.value">
+          {{ entry.label }}
+        </option>
+      </select>
     </div>
 
-    <p v-if="errorMessage" class="text-sm text-error">{{ errorMessage }}</p>
+    <p v-if="errorMessage" class="shrink-0 text-sm text-error">
+      {{ errorMessage }}
+    </p>
 
-    <div
-      v-for="group in groups"
-      :key="group.taxonomy"
-      class="space-y-3"
-    >
-      <div class="flex items-baseline gap-2">
-        <h2 class="text-lg font-black">{{ taxonomyLabel(group.taxonomy) }}</h2>
-        <span class="badge badge-secondary badge-sm">{{ group.entries.length }}</span>
+    <!-- THE one scroll region. Everything above pins. -->
+    <div class="kr-scroll space-y-6">
+      <div v-for="group in visibleGroups" :key="group.taxonomy" class="space-y-3">
+        <div class="flex items-baseline gap-2">
+          <h2 class="text-lg font-black">{{ taxonomyLabel(group.taxonomy) }}</h2>
+          <span class="badge badge-secondary badge-sm">{{ group.total }}</span>
+        </div>
+
+        <!-- One kr-gallery per taxonomy group. The shell owns no scroll region,
+             so mounting it N times is structurally fine, and `:modes="[]"` drops
+             its own mode bar -- the picker above drives every group at once, so
+             the groups stay visually consistent instead of drifting apart. -->
+        <kr-gallery
+          :items="group.entries.map(toGalleryItem)"
+          :mode="mode"
+          :modes="[]"
+          empty-label="facets"
+          @open="selectFacet"
+        />
+
+        <button
+          v-if="group.entries.length < group.total"
+          type="button"
+          class="btn btn-ghost btn-sm w-full rounded-xl border border-base-300"
+          @click="showMore(group.taxonomy)"
+        >
+          Show more {{ taxonomyLabel(group.taxonomy) }}
+          ({{ group.entries.length }} of {{ group.total }})
+        </button>
       </div>
 
-      <!-- One kr-gallery per taxonomy group. The shell owns no scroll region,
-           so mounting it N times is structurally fine, and `:modes="[]"` drops
-           the view-mode bar -- this gallery is a fixed-shape taxonomy showcase,
-           not a mode-switching browser. -->
-      <kr-gallery
-        :items="group.entries.map(toGalleryItem)"
-        mode="cards"
-        :modes="[]"
-        empty-label="facets"
-      />
+      <p
+        v-if="!catalog.loading && !visibleGroups.length"
+        class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50"
+      >
+        No facets match these filters.
+      </p>
     </div>
-
-    <p
-      v-if="!catalog.loading && !groups.length"
-      class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50"
-    >
-      No facets match these filters.
-    </p>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import {
   FACET_TAXONOMIES,
   useFacetCatalogStore,
@@ -98,14 +123,69 @@ import {
 } from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 import { resolveEntityArtwork } from '@/utils/artImageSrc'
-import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import type {
+  GalleryItem,
+  GalleryMode,
+} from '@/components/gallery/kr-gallery.vue'
+
+withDefaults(
+  defineProps<{
+    title?: string
+    subtitle?: string
+    showHeader?: boolean
+    showControls?: boolean
+  }>(),
+  {
+    title: 'Facets',
+    subtitle: 'The reusable building blocks every other object draws from.',
+    showHeader: true,
+    showControls: true,
+  },
+)
+
+/*
+ * Read-only by contract. utils/scripts/verifyFacetGallery.ts forbids
+ * createFacet / updateFacet / archiveFacet / FacetProfileEditor in this file --
+ * this is the picker, and editing belongs to the detail view it opens. Emitting
+ * a selection rather than mutating anything is what keeps that true.
+ */
+const emit = defineEmits<{ select: [facet: FacetCatalogEntry] }>()
 
 const catalog = useFacetCatalogStore()
+
+const GALLERY_MODES = [
+  { value: 'cards' as const, label: 'Cards' },
+  { value: 'heroes' as const, label: 'Heroes' },
+  { value: 'icons' as const, label: 'Icons' },
+  { value: 'list' as const, label: 'List' },
+]
 
 const search = ref('')
 const taxonomyFilter = ref<FacetTaxonomy | null>(null)
 const artOnly = ref(false)
 const errorMessage = ref('')
+const mode = ref<GalleryMode>('cards')
+
+/*
+ * WINDOWING. The Facet catalog is ~1611 rows and the old /facets surface
+ * rendered every one of them in a single pass, which is the first thing Silas
+ * flagged on review (2026-08-02). Cap each taxonomy group and let the reader ask
+ * for more, so the initial paint is bounded no matter how far the catalog grows.
+ */
+const PAGE = 24
+const shown = ref<Partial<Record<FacetTaxonomy, number>>>({})
+
+function showMore(taxonomy: FacetTaxonomy): void {
+  shown.value = {
+    ...shown.value,
+    [taxonomy]: (shown.value[taxonomy] ?? PAGE) + PAGE,
+  }
+}
+
+function selectFacet(item: { id: string | number }): void {
+  const facet = catalog.entries.find((entry) => entry.id === Number(item.id))
+  if (facet) emit('select', facet)
+}
 
 /*
  * Kept for the `artOnly` filter below, which needs to know whether a facet has
@@ -194,9 +274,24 @@ const groups = computed(() => {
   return result
 })
 
+/* Each group capped to what has been asked for. `total` is the full match count,
+   so the button can say "24 of 310" and the badge stays honest. */
+const visibleGroups = computed(() =>
+  groups.value.map((group) => ({
+    taxonomy: group.taxonomy,
+    total: group.entries.length,
+    entries: group.entries.slice(0, shown.value[group.taxonomy] ?? PAGE),
+  })),
+)
+
 const visibleCount = computed(() =>
   groups.value.reduce((sum, group) => sum + group.entries.length, 0),
 )
+
+// A new search or filter should start from the top of every group again.
+watch([search, taxonomyFilter, artOnly], () => {
+  shown.value = {}
+})
 
 onMounted(async () => {
   try {

--- a/components/facets/facet-interact.vue
+++ b/components/facets/facet-interact.vue
@@ -1,0 +1,161 @@
+<!-- /components/facets/facet-interact.vue -->
+<!--
+  The Facet working surface, and the tier Facets was missing.
+
+  Every other model follows the same shape -- content/<model>.md mounts
+  :<model>-manager, which routes to <model>-interact, which shows a gallery until
+  you pick something and a workspace once you have:
+
+    bot-interact    <bot-gallery   v-if="!botStore.currentBot">   ... else the chat
+    dream-interact  <dream-gallery v-if="!selectedDream">  <dream-workspace v-else>
+
+  Facets had neither tier. facet-manager rendered all ~1611 rows itself and
+  expanded an editor INSIDE the grid cell, which is why selecting one felt wrong
+  and why /facets scored 3/10 on review while Dreams, which follows the pattern,
+  scored 7.5.
+
+  Selection lives in the URL rather than in local state, per the house rule that
+  every view is linkable (the same shape as /storybook?story=...). That also
+  means the browser back button does the obvious thing, which was the other half
+  of what made the inline editor feel wrong.
+-->
+<template>
+  <facet-gallery
+    v-if="!selectedFacet"
+    :show-header="showHeader"
+    title="Facets"
+    subtitle="Pick a Facet to open its profile."
+    @select="openFacet"
+  />
+
+  <section v-else class="kr-surface">
+    <header class="kr-toolbar shrink-0 rounded-2xl border border-base-300 bg-base-100 p-3">
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm rounded-xl"
+        @click="closeFacet"
+      >
+        <Icon name="kind-icon:chevron-left" class="size-4" /> All Facets
+      </button>
+
+      <div class="min-w-0 flex-1">
+        <p class="truncate font-black">{{ selectedFacet.title }}</p>
+        <p class="truncate text-xs text-base-content/55">
+          {{ taxonomyLabel(selectedFacet.taxonomy) }}
+          <template v-if="selectedFacet.groupLabel">
+            · {{ selectedFacet.groupLabel }}
+          </template>
+        </p>
+      </div>
+
+      <span class="badge badge-outline badge-sm shrink-0">
+        {{ selectedFacet.canonicalValue }}
+      </span>
+    </header>
+
+    <div class="kr-scroll space-y-4">
+      <div class="grid gap-4 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
+        <kr-art-plate
+          :source="selectedFacet"
+          variant="card"
+          shape="card"
+          :alt="`${selectedFacet.title} artwork`"
+          :placeholder-icon="iconName(selectedFacet)"
+        />
+
+        <div class="space-y-3">
+          <p v-if="selectedFacet.description" class="kr-prose leading-relaxed">
+            {{ selectedFacet.description }}
+          </p>
+          <p
+            v-if="selectedFacet.flavorText"
+            class="kr-prose italic text-base-content/65"
+          >
+            {{ selectedFacet.flavorText }}
+          </p>
+
+          <div v-if="selectedFacet.aliases.length" class="flex flex-wrap gap-1.5">
+            <span
+              v-for="alias in selectedFacet.aliases"
+              :key="alias"
+              class="badge badge-ghost badge-sm"
+            >
+              {{ alias }}
+            </span>
+          </div>
+
+          <div class="flex flex-wrap gap-1.5 text-xs">
+            <span class="badge badge-sm">order {{ selectedFacet.sortOrder }}</span>
+            <span class="badge badge-sm">weight {{ selectedFacet.randomWeight }}</span>
+            <span v-if="selectedFacet.isRandomizable" class="badge badge-sm">
+              randomizable
+            </span>
+            <span v-if="selectedFacet.artRequired" class="badge badge-warning badge-sm">
+              art expected
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <slot name="detail" :facet="selectedFacet" />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  useFacetCatalogStore,
+  type FacetCatalogEntry,
+} from '@/stores/facetCatalogStore'
+
+withDefaults(defineProps<{ showHeader?: boolean }>(), { showHeader: true })
+
+const route = useRoute()
+const router = useRouter()
+const catalog = useFacetCatalogStore()
+
+/* Resolved from the URL, so a Facet page can be linked, bookmarked and
+   back-buttoned. Falls back to null when the slug names nothing, which keeps a
+   stale link on the gallery rather than on a broken detail view. */
+const selectedFacet = computed<FacetCatalogEntry | null>(() => {
+  const slug = route.query.facet
+  if (typeof slug !== 'string' || !slug) return null
+  return catalog.entries.find((entry) => entry.slug === slug) ?? null
+})
+
+function openFacet(facet: FacetCatalogEntry): void {
+  if (!facet.slug) return
+  void router.push({ query: { ...route.query, facet: facet.slug } })
+}
+
+function closeFacet(): void {
+  const query = { ...route.query }
+  delete query.facet
+  void router.push({ query })
+}
+
+function taxonomyLabel(taxonomy: string): string {
+  return taxonomy
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function iconName(facet: FacetCatalogEntry): string {
+  const icon = facet.icon?.trim()
+  return icon && icon.includes(':') ? icon : 'kind-icon:tag'
+}
+
+/*
+ * The gallery fetches the catalog on mount, but a deep link to ?facet=<slug>
+ * renders the detail branch instead and would otherwise resolve against an empty
+ * store -- landing the visitor back on the gallery for a link that was perfectly
+ * valid. fetchCatalog no-ops once loaded, so this costs nothing on the normal
+ * browse-then-select path.
+ */
+onMounted(() => {
+  if (!catalog.loaded) void catalog.fetchCatalog()
+})
+</script>

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -1,6 +1,18 @@
 <!-- /components/facets/facet-manager.vue -->
+<!--
+  Tab router for the Facets dashboard, matching every other model manager
+  (bot-manager, dream-manager, reward-manager...). It was the odd one out: it
+  rendered all ~1611 catalog rows itself with an editor that expanded INSIDE the
+  grid cell, and never used the two tabs stores/helpers/dashboardHelper.ts has
+  defined for it all along.
+
+  gallery -> facet-interact  browse, then open one (the house pattern)
+  library -> the admin list below, unchanged: create, edit, archive, art
+-->
 <template>
-  <section class="mx-auto w-full max-w-7xl space-y-4 p-4">
+  <facet-interact v-if="activeTab === 'gallery'" class="h-full min-h-0" />
+
+  <section v-else class="mx-auto w-full max-w-7xl space-y-4 p-4">
     <header
       class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100 p-4"
     >
@@ -243,6 +255,11 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useNavStore } from '@/stores/navStore'
+import {
+  getDashboardDefaultTab,
+  isDashboardTabKey,
+} from '@/stores/helpers/dashboardHelper'
 import { useFacetStore, type FacetWithAliases } from '@/stores/facetStore'
 import {
   FACET_TAXONOMIES,
@@ -256,6 +273,19 @@ import {
   type FacetProfileForm,
 } from '@/utils/facetProfileForm'
 import { resolveEntityArtwork } from '@/utils/artImageSrc'
+
+const dashboardKey = 'facets'
+const navStore = useNavStore()
+
+/* Same derivation every other manager uses: the nav store owns the selected tab
+   and the dashboard definition owns the default, so a bad or absent value falls
+   back rather than rendering nothing. */
+const activeTab = computed(() => {
+  const selected = navStore.getDashboardTab(dashboardKey)
+  return isDashboardTabKey(dashboardKey, selected)
+    ? selected
+    : getDashboardDefaultTab(dashboardKey)
+})
 
 const facetStore = useFacetStore()
 const search = ref('')

--- a/components/navigation/swipe-deck.vue
+++ b/components/navigation/swipe-deck.vue
@@ -1,7 +1,19 @@
 <!-- /components/navigation/swipe-deck.vue
      Tinder-style art-first swipe deck. Art fills the card in portrait orientation.
-     Drag/swipe right = select, left = skip. Touch and mouse pointer events both work.
-     Cards behind the active one are visible as a depth stack. -->
+     Drag/swipe right = open, left = skip. Touch and mouse pointer events both work.
+     Cards behind the active one are visible as a depth stack.
+
+     NOTHING HERE DELETES ANYTHING. It only changes which card you are looking at,
+     and the deck resets on reload. That was not legible: the controls used to be a
+     bare red ✕ beside a green ✓ with the drag captions "Nope" and "Like", which is
+     the vocabulary of accept/reject, so Silas reviewed /dreams and read it as
+     "makes me think I'm at risk of deleting something instead of navigating"
+     (2026-08-02). The gesture is fine; the affordance was lying about the stakes.
+
+     So: the actions are named Skip and Open, in words, in neutral and primary
+     rather than error and success -- and a skip can be taken back, which is the
+     part that actually settles the question. A control you can undo cannot be the
+     dangerous one. -->
 <template>
   <div class="flex h-full min-h-[32rem] flex-col items-center gap-4 overflow-hidden rounded-2xl bg-base-300/40 p-4 sm:p-6">
     <!-- ── Card stack ────────────────────────────────────────────────── -->
@@ -43,21 +55,21 @@
         @pointerup="onPointerUp"
         @pointercancel="onPointerUp"
       >
-        <!-- LIKE indicator (right swipe) -->
+        <!-- Drag captions. They say what the gesture DOES ("Open" / "Skip"),
+             not how the deck feels about the card ("Like" / "Nope"). -->
         <div
-          class="absolute left-4 top-4 z-10 rounded-xl border-2 border-success px-3 py-1 text-lg font-black uppercase text-success transition-opacity duration-75"
-          :style="{ opacity: likeOpacity }"
+          class="absolute left-4 top-4 z-10 rounded-xl border-2 border-primary px-3 py-1 text-lg font-black uppercase text-primary transition-opacity duration-75"
+          :style="{ opacity: openOpacity }"
           aria-hidden="true"
         >
-          Like
+          Open
         </div>
-        <!-- NOPE indicator (left swipe) -->
         <div
-          class="absolute right-4 top-4 z-10 rounded-xl border-2 border-error px-3 py-1 text-lg font-black uppercase text-error transition-opacity duration-75"
-          :style="{ opacity: nopeOpacity }"
+          class="absolute right-4 top-4 z-10 rounded-xl border-2 border-base-content/40 px-3 py-1 text-lg font-black uppercase text-base-content/60 transition-opacity duration-75"
+          :style="{ opacity: skipOpacity }"
           aria-hidden="true"
         >
-          Nope
+          Skip
         </div>
 
         <!-- Art (portrait orientation) -->
@@ -110,35 +122,38 @@
     </div>
 
     <!-- ── Action buttons ────────────────────────────────────────────── -->
-    <div v-if="currentItem" class="flex shrink-0 items-center gap-5">
-      <!-- Skip -->
+    <!-- Labelled in words. An unlabelled ✕/✓ pair is the accept/reject idiom,
+         and neither of these is that. -->
+    <div v-if="currentItem" class="flex shrink-0 flex-wrap items-center justify-center gap-3">
       <button
         type="button"
-        class="flex h-14 w-14 items-center justify-center rounded-full border-2 border-error/40 bg-base-100 shadow transition hover:border-error hover:bg-error/10 hover:shadow-md"
-        aria-label="Skip"
+        class="btn btn-ghost btn-sm rounded-2xl border border-base-300"
+        :disabled="!canUndo"
+        :title="canUndo ? 'Bring back the card you just skipped' : 'Nothing skipped yet'"
+        @click="undoSkip"
+      >
+        <Icon name="kind-icon:refresh" class="h-4 w-4" />
+        Undo
+      </button>
+
+      <button
+        type="button"
+        class="btn btn-outline btn-sm rounded-2xl"
+        aria-label="Skip this one and show the next card"
         @click="swipeLeft"
       >
-        <Icon name="kind-icon:x" class="h-6 w-6 text-error" />
+        <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+        Skip
       </button>
 
-      <!-- Info / open -->
       <button
         type="button"
-        class="flex h-10 w-10 items-center justify-center rounded-full border border-base-300 bg-base-100 shadow transition hover:border-primary/60 hover:bg-primary/10"
-        aria-label="Open"
-        @click="onInfoClick"
-      >
-        <Icon name="kind-icon:info" class="h-5 w-5 text-base-content/60" />
-      </button>
-
-      <!-- Select / like -->
-      <button
-        type="button"
-        class="flex h-14 w-14 items-center justify-center rounded-full border-2 border-success/40 bg-base-100 shadow transition hover:border-success hover:bg-success/10 hover:shadow-md"
-        aria-label="Select"
+        class="btn btn-primary btn-sm rounded-2xl text-white"
+        aria-label="Open this one"
         @click="swipeRight"
       >
-        <Icon name="kind-icon:check" class="h-6 w-6 text-success" />
+        <Icon name="kind-icon:eye" class="h-4 w-4" />
+        Open
       </button>
     </div>
 
@@ -257,8 +272,8 @@ function depthCardStyle(depth: number): CSSProperties {
 }
 
 // ── Indicators ────────────────────────────────────────────────────────
-const likeOpacity = computed(() => Math.max(0, Math.min(1, dragX.value / SWIPE_THRESHOLD)))
-const nopeOpacity = computed(() => Math.max(0, Math.min(1, -dragX.value / SWIPE_THRESHOLD)))
+const openOpacity = computed(() => Math.max(0, Math.min(1, dragX.value / SWIPE_THRESHOLD)))
+const skipOpacity = computed(() => Math.max(0, Math.min(1, -dragX.value / SWIPE_THRESHOLD)))
 
 // ── Pointer handlers ──────────────────────────────────────────────────
 function onPointerDown(e: PointerEvent) {
@@ -313,9 +328,15 @@ function swipeRight() {
   flyOff('right', true)
 }
 
-function onInfoClick() {
-  if (currentItem.value) emit('select', { id: currentItem.value.id })
-  flyOff('right', false)
+/* The recovery half of the affordance. Skipping is the only action that moves
+   the deck without opening anything, so it is the only one worth taking back --
+   Open already hands the reader somewhere they can navigate away from. */
+const canUndo = computed(() => swipedCount.value > 0 && !isFlying.value)
+
+function undoSkip() {
+  if (!canUndo.value) return
+  swipedCount.value--
+  dragX.value = 0
 }
 
 function reset() {

--- a/content/facet-gallery.md
+++ b/content/facet-gallery.md
@@ -10,7 +10,7 @@ sort: gallery
 channelKey: play
 tabKey: facets
 dashboardKey: facets
-dashboardTab: facets
+dashboardTab: gallery
 loadingMessage: Loading Facets...
 refreshLabel: Refresh Facets
 redirect: /facets

--- a/content/facets.md
+++ b/content/facets.md
@@ -10,7 +10,7 @@ sort: utility
 channelKey: play
 tabKey: facets
 dashboardKey: facets
-dashboardTab: library
+dashboardTab: gallery
 loadingMessage: Loading facets...
 refreshLabel: Refresh Facets
 ---

--- a/stores/helpers/dashboardHelper.ts
+++ b/stores/helpers/dashboardHelper.ts
@@ -602,7 +602,11 @@ export const dashboardConfigs = {
   facets: {
     key: 'facets',
     label: 'Facets',
-    defaultTab: 'library',
+    // Browse first, edit second -- the same default every other model dashboard
+    // uses (bots, characters, dreams, rewards, scenarios all land on their
+    // browse tab). Facets defaulted to the admin Library, so arriving at /facets
+    // meant landing on 1611 editable rows rather than on the catalog.
+    defaultTab: 'gallery',
     tabs: [
       {
         key: 'library',
@@ -626,7 +630,12 @@ export const dashboardConfigs = {
         image: tabImage('facets', 'gallery'),
         narrative:
           'A read-only showcase of the shared creative building blocks — genres, species, archetypes, moods, styles, and settings — grouped by taxonomy and shown with their artwork, descriptions, and aliases. The browse-and-admire companion to the editable Library.',
-        route: '/facet-gallery',
+        // Both Facet tabs live on /facets and switch through navStore, the same
+        // way /bots switches between its tabs. This pointed at /facet-gallery,
+        // which is a legacy stub that redirects straight back here -- so the
+        // Gallery tab was unreachable, and facet-gallery.vue was mounted by
+        // nothing at all.
+        route: '/facets',
       },
     ],
   },

--- a/utils/scripts/verifyFacetGallery.ts
+++ b/utils/scripts/verifyFacetGallery.ts
@@ -19,8 +19,28 @@ function requireText(path: string, text: string, fragment: string): void {
   }
 }
 
+/*
+ * Comments are stripped before every forbid- scan.
+ *
+ * A contract that a doc comment can fail is a contract that punishes explaining
+ * it. This file already did that once: a comment in facet-gallery.vue naming the
+ * very helpers this contract forbids -- so a reader would know why the picker
+ * emits a selection instead of mutating anything -- failed the build, while the
+ * forbidden call itself was nowhere in the file. Same class of bug as the
+ * `role="log"` comment that tripped verifyNarrativeAccessibility.mjs.
+ *
+ * Only forbid- scans strip. requireText keeps reading the raw source, so a
+ * required token cannot be satisfied by a comment claiming it is there.
+ */
+function stripComments(text: string): string {
+  return text
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, '$1')
+}
+
 function forbidText(path: string, text: string, fragment: string): void {
-  if (text.includes(fragment)) {
+  if (stripComments(text).includes(fragment)) {
     throw new Error(`${path} contains forbidden Facet gallery text: ${fragment}`)
   }
 }


### PR DESCRIPTION
## Why

`/facets` scored **3/10** on review, `/dreams` **7.5/10** — for the same job. Every complaint traced to one cause: **Facets was the only model not on the house front-end pattern.**

```
content/<model>.md  →  :<model>-manager   tab router, the primary mount
                    →  <model>-interact   the working surface
                    →  <model>-gallery    inset picker
```

`facet-manager.vue` had neither of the lower tiers. It rendered all ~1611 catalog rows itself, in one pass, with no view modes, and an editor that expanded *inside* the grid cell. That is all four review complaints in one component.

And the reason it went unnoticed: `facet-gallery.vue` — the file I put `kr-gallery` into last round — **was mounted by nothing**. Its only would-be route (`content/facet-gallery.md`) is a redirect stub. No visible change was ever possible, and the adoption counter scored it as progress because it matched a filename. That counter now checks reachability (landed separately) and reports `facet-gallery.vue  reached from /facets` honestly for the first time.

## What changed

**Facets**

- **`components/facets/facet-interact.vue` (new)** — the missing tier. Gallery until you pick one, detail after. Selection lives in `?facet=<slug>`, so a Facet is linkable and the back button does the obvious thing — the other half of why inline expansion felt wrong.
- **`facet-gallery.vue`** — redeemed from orphan into the inset picker it should always have been: `kr-surface` / one `kr-scroll`, a **wrapping** toolbar, the cards/heroes/icons/list view select, **windowed at 24 per taxonomy** with a "show more", and a `select` emit instead of local editing.
- **`facet-manager.vue`** — derives `activeTab` from `navStore` like every other manager, and routes `gallery → facet-interact`. The admin Library list is unchanged, one tab away.
- The **Gallery tab pointed at `/facet-gallery`**, a stub that redirects straight back to `/facets` — so the tab was unreachable *and* the component was mounted by nothing. Both tabs now live on `/facets`, and **`/facets` lands on Gallery**: browse first, edit second, the same default bots, characters, dreams, rewards and scenarios all use.

**Also from the same review**

- **`dream-gallery.vue`** — the toolbar wraps (`.kr-toolbar`) instead of scrolling sideways. It was `overflow-x-auto whitespace-nowrap` with `shrink-0` children, so the layout picker (Grid/Row/Reel/Hero/Swipe) sat off the right edge behind a scrollbar nobody found. A hidden control is a missing control.
- **`swipe-deck.vue`** — says **Skip** and **Open**, in words, in neutral and primary rather than a red ✕ beside a green ✓, and **a skip can be undone**. Nothing in the deck ever deleted anything; the affordance was lying about the stakes.

**And the contract that made this round necessary twice over**

`verifyFacetGallery.ts` now strips comments before its forbid- scans. A comment naming the helpers the contract forbids — written so a reader knows *why* the picker only emits — failed the build while no such call existed anywhere in the file. Same class of bug as the `role="log"` comment that tripped `verifyNarrativeAccessibility.mjs`. Only forbid- scans strip; `requireText` still reads raw source, so a required token can't be satisfied by a comment claiming it's there.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:facet-gallery`, `test:facet-catalog`, `test:gallery-adoption`, `test:layout-contract`, `test:channel-content`, `test:nav-manifest`, `test:data-surface-manifest` — all pass
- Layout contract: **8 violations, unchanged** — no new ones
- `npx nuxi build` — completes
- Line-ending audit against `HEAD` on all 8 modified files — no CRLF drift
- **The comment-stripping fix proved both ways:** the doc comment passes; an injected `updateFacet` call still fails the contract

## Needs eyes before this is called done

**`/facets` and `/dreams` need visual confirmation on the Vercel preview.** This entire round exists because a source-text contract said a change landed and the live page disagreed — a green CI run is not evidence here.

One behaviour change worth naming: `content/facets.md` frontmatter is enforced on every page load, so a reload of `/facets` now returns to the Gallery tab rather than Library. Switching tabs within a session works normally; it is the reload that resets. That was true before in the other direction (reload always returned to Library) — this just points it at the browse surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_