### PR TITLE
refactor(cards): extract kr-entity-card-body, migrate scenario-card

### DIFF
--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -1,0 +1,215 @@
+<!-- /components/gallery/kr-entity-card-body.vue -->
+<!--
+  The inside of an object card.
+
+  Silas, 2026-08-02: "the custom cards are a big aspect to the ui refactor,
+  while they all do have custom fields, a lot of the customization is the same
+  stuff with variations for the schema objects. the final version obviously is
+  wanting a single display that is consistent across galleries, all with those
+  bells and whistles."
+
+  The bells and whistles were already shared -- fourteen cards wrap
+  wonderlab/reactable-card.vue, which owns the <article>, the selected border,
+  the karma badge, the reaction button and the review panel. What stayed
+  copy-pasted was the BODY inside it, and it is the same body five times over:
+
+      art plate, with badges over one corner and the title in a scrim
+      a no-art fallback carrying the same title and chips
+      a description block
+      a row of meta chips
+      then whatever that object alone needs
+
+  scenario-card.vue:81's scrim class string was character-for-character
+  identical to kr-art-plate.vue:41, and both scenario-card and character-card
+  already imported resolveArtVariantSrc and then hand-rolled the frame around
+  it anyway.
+
+  So this is the body, parameterised. Everything genuinely per-object -- a bot's
+  personality panel, a reward's stat block, a scenario's inspirations -- goes in
+  the default slot, below. What the objects share is settled here so it stops
+  drifting apart one card at a time.
+
+  TWO CONVERGENCE DECISIONS worth naming, because they change how a card looks
+  rather than just where its markup lives:
+
+  1. Badges all sit top-LEFT. scenario-card used to split them, "Yours" left and
+     "Mature" right -- but reactable-card puts the actions row and the karma
+     badge top-right, so anything else there is one prop away from colliding
+     with them. Left is the only corner a card body actually owns.
+  2. The selected check sits below that actions row (top-9, not top-2) for the
+     same reason.
+-->
+<template>
+  <div class="flex w-full flex-col">
+    <kr-art-plate
+      v-if="showImage"
+      :source="source"
+      :variant="variant"
+      :fallback="fallback"
+      :alt="title"
+      :shape="compact ? compactShape : shape"
+      frame="none"
+      hover-zoom
+      :placeholder-icon="placeholderIcon"
+      class="rounded-xl"
+    >
+      <template #caption>
+        <h2
+          :class="[
+            'font-black leading-tight text-white drop-shadow',
+            compact ? 'line-clamp-1 text-base' : 'line-clamp-2 text-lg',
+          ]"
+          :title="title"
+        >
+          {{ title }}
+        </h2>
+
+        <p
+          v-if="subtitle"
+          class="mt-0.5 line-clamp-1 text-xs font-medium text-white/75"
+        >
+          {{ subtitle }}
+        </p>
+      </template>
+
+      <template #overlay>
+        <div
+          v-if="badges.length"
+          class="absolute left-2 top-2 flex flex-wrap gap-1"
+        >
+          <span
+            v-for="badge in badges"
+            :key="badge.label"
+            class="badge badge-sm rounded-xl shadow"
+            :class="badge.class || 'badge-primary'"
+          >
+            {{ badge.label }}
+          </span>
+        </div>
+
+        <!-- top-9, clearing reactable-card's actions row. See the note above. -->
+        <div
+          v-if="selected"
+          class="absolute right-2 top-9 rounded-full bg-primary p-1.5 text-primary-content shadow-lg"
+        >
+          <Icon name="kind-icon:check" class="h-4 w-4" aria-hidden="true" />
+        </div>
+      </template>
+    </kr-art-plate>
+
+    <!-- No art: the same title and chips, without the frame. Cards used to
+         repeat these two branches in full; the difference between them is
+         genuinely just the scrim and the aspect box. -->
+    <div v-else class="flex items-start justify-between gap-2">
+      <div class="min-w-0">
+        <h2
+          class="line-clamp-2 text-base font-black leading-tight text-base-content"
+          :title="title"
+        >
+          {{ title }}
+        </h2>
+
+        <p
+          v-if="subtitle"
+          class="mt-0.5 line-clamp-1 text-xs font-medium text-base-content/60"
+        >
+          {{ subtitle }}
+        </p>
+
+        <div v-if="badges.length" class="mt-1.5 flex flex-wrap gap-1">
+          <span
+            v-for="badge in badges"
+            :key="badge.label"
+            class="badge badge-sm"
+            :class="badge.class || 'badge-primary'"
+          >
+            {{ badge.label }}
+          </span>
+        </div>
+      </div>
+
+      <Icon
+        v-if="selected"
+        name="kind-icon:check"
+        class="h-5 w-5 shrink-0 text-primary"
+        aria-hidden="true"
+      />
+    </div>
+
+    <div v-if="showDescription && !compact" class="px-0.5 pt-2.5">
+      <p class="line-clamp-3 text-sm leading-relaxed text-base-content/70">
+        {{ description || descriptionFallback }}
+      </p>
+    </div>
+
+    <div v-if="meta.length" class="flex flex-wrap gap-1.5 px-0.5 pt-2">
+      <span
+        v-for="chip in meta"
+        :key="chip.label"
+        class="badge badge-sm max-w-full truncate"
+        :class="chip.class || 'badge-ghost'"
+        :title="chip.title || chip.label"
+      >
+        <Icon v-if="chip.icon" :name="chip.icon" class="mr-1 h-3 w-3" />
+        {{ chip.label }}
+      </span>
+    </div>
+
+    <!-- Whatever this object alone needs. -->
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ArtImageSrcLike, ArtVariant } from '@/utils/artImageSrc'
+
+export type EntityCardChip = {
+  label: string
+  /** daisyUI badge modifier(s). Falls back to a sensible default per row. */
+  class?: string
+  icon?: string
+  title?: string
+}
+
+withDefaults(
+  defineProps<{
+    title: string
+    subtitle?: string
+    description?: string
+    descriptionFallback?: string
+    /** Any record carrying imagePath / cardPath / heroPath / iconPath. */
+    source?: ArtImageSrcLike
+    variant?: ArtVariant
+    /** Used when the source resolves to nothing at all. */
+    fallback?: string
+    showImage?: boolean
+    showDescription?: boolean
+    compact?: boolean
+    selected?: boolean
+    /** Corner badges over the art (state: Yours, Mature, Public, Building...). */
+    badges?: EntityCardChip[]
+    /** Chips below the art, on the card surface. */
+    meta?: EntityCardChip[]
+    shape?: 'card' | 'hero' | 'wide' | 'plate'
+    compactShape?: 'card' | 'hero' | 'wide' | 'plate'
+    placeholderIcon?: string
+  }>(),
+  {
+    subtitle: '',
+    description: '',
+    descriptionFallback: 'No description yet.',
+    source: null,
+    variant: 'card',
+    fallback: '',
+    showImage: true,
+    showDescription: true,
+    compact: false,
+    selected: false,
+    badges: () => [],
+    meta: () => [],
+    shape: 'wide',
+    compactShape: 'hero',
+    placeholderIcon: 'kind-icon:image',
+  },
+)
+</script>

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -22,7 +22,10 @@
       v-if="src"
       :src="src"
       :alt="alt"
-      class="h-full w-full object-cover"
+      :class="[
+        'h-full w-full object-cover',
+        hoverZoom ? 'transition-transform duration-300 group-hover:scale-105' : '',
+      ]"
       :loading="eager ? 'eager' : 'lazy'"
       @error="onError"
     />
@@ -65,8 +68,11 @@ const props = withDefaults(
     /** Used when the source resolves to nothing at all. */
     fallback?: string
     alt?: string
-    /** card is 2:3 portrait, hero 16:9, icon square, plate the 3:2 mockup shape. */
-    shape?: 'card' | 'hero' | 'icon' | 'plate' | 'fill'
+    /**
+     * card is 2:3 portrait, hero 16:9, wide 4:3, icon square, plate the 3:2
+     * mockup shape.
+     */
+    shape?: 'card' | 'hero' | 'wide' | 'icon' | 'plate' | 'fill'
     /**
      * 'plate' is the white tipped-photo border the aesthetic is named for.
      * 'thin' is a plain hairline for inline thumbnails.
@@ -75,6 +81,8 @@ const props = withDefaults(
      * so "unframed" has to mean genuinely unframed, not thinly framed.
      */
     frame?: 'plate' | 'thin' | 'none'
+    /** The gallery-card lift: art scales slightly on the ancestor's :hover. */
+    hoverZoom?: boolean
     eager?: boolean
     placeholderIcon?: string
   }>(),
@@ -85,6 +93,7 @@ const props = withDefaults(
     alt: '',
     shape: 'plate',
     frame: 'plate',
+    hoverZoom: false,
     eager: false,
     placeholderIcon: 'kind-icon:image',
   },
@@ -132,6 +141,8 @@ const aspectClass = computed(() => {
       return 'aspect-2/3 w-full'
     case 'hero':
       return 'aspect-video w-full'
+    case 'wide':
+      return 'aspect-4/3 w-full'
     case 'icon':
       return 'aspect-square'
     case 'fill':

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -43,104 +43,23 @@
       </button>
     </template>
 
-    <div class="flex w-full flex-col">
-      <figure
-        v-if="showImage"
-        :class="[
-          'relative w-full overflow-hidden rounded-xl bg-base-300',
-          compact ? 'aspect-video' : 'aspect-4/3',
-        ]"
-      >
-        <img
-          :src="computedScenarioImage"
-          :alt="scenarioTitle"
-          class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-          loading="lazy"
-        />
-
-        <div
-          class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-2"
-        >
-          <span
-            v-if="scenario.userId === userStore.userId"
-            class="badge badge-primary badge-sm shadow"
-          >
-            Yours
-          </span>
-          <span v-else />
-
-          <span
-            v-if="scenario.isMature"
-            class="badge badge-warning badge-sm shadow"
-          >
-            Mature
-          </span>
-        </div>
-
-        <figcaption
-          class="absolute inset-x-0 bottom-0 bg-linear-to-t from-black/85 via-black/45 to-transparent px-3 pb-3 pt-12"
-        >
-          <h2
-            :class="[
-              'font-black leading-tight text-white drop-shadow',
-              compact ? 'line-clamp-1 text-base' : 'line-clamp-2 text-lg',
-            ]"
-            :title="scenarioTitle"
-          >
-            {{ scenarioTitle }}
-          </h2>
-
-          <p
-            v-if="scenario.genres"
-            class="mt-0.5 line-clamp-1 text-xs font-medium text-white/75"
-          >
-            {{ scenario.genres }}
-          </p>
-        </figcaption>
-
-        <div
-          v-if="activeSelected"
-          class="absolute right-2 top-9 rounded-full bg-primary p-1.5 text-primary-content shadow-lg"
-        >
-          <Icon name="kind-icon:check" class="h-4 w-4" />
-        </div>
-      </figure>
-
-      <div v-else class="flex items-start justify-between gap-2">
-        <h2
-          class="line-clamp-2 text-base font-black leading-tight text-base-content"
-        >
-          {{ scenarioTitle }}
-        </h2>
-
-        <Icon
-          v-if="activeSelected"
-          name="kind-icon:check"
-          class="h-5 w-5 shrink-0 text-primary"
-        />
-      </div>
-
-      <div v-if="showDescription && !compact" class="px-0.5 pt-2.5">
-        <p class="line-clamp-3 text-sm leading-relaxed text-base-content/70">
-          {{ scenario.description || 'No description yet.' }}
-        </p>
-      </div>
-
-      <div v-if="showMeta" class="flex flex-wrap gap-1.5 px-0.5 pt-2">
-        <span
-          v-if="scenario.locations"
-          class="badge badge-ghost badge-sm max-w-full truncate"
-          :title="scenario.locations"
-        >
-          <Icon name="kind-icon:map" class="mr-1 h-3 w-3" />
-          {{ scenario.locations }}
-        </span>
-
-        <span v-if="introCount" class="badge badge-outline badge-sm">
-          {{ introCount }} {{ introCount === 1 ? 'opening' : 'openings' }}
-        </span>
-      </div>
-
+    <kr-entity-card-body
+      :title="scenarioTitle"
+      :subtitle="scenario.genres || ''"
+      :description="scenario.description"
+      description-fallback="No description yet."
+      :source="scenario"
+      variant="card"
+      :fallback="artFallbackSrc"
+      :show-image="showImage"
+      :show-description="showDescription"
+      :compact="compact"
+      :selected="activeSelected"
+      :badges="badges"
+      :meta="showMeta ? metaChips : []"
+      placeholder-icon="kind-icon:map"
+    >
+      <!-- The one genuinely Scenario-shaped thing on the card. -->
       <div
         v-if="showInspirations && scenario.inspirations && !compact"
         class="mx-0.5 mt-2.5 rounded-xl border border-base-300 bg-base-100 p-2.5"
@@ -157,7 +76,7 @@
           {{ scenario.inspirations }}
         </p>
       </div>
-    </div>
+    </kr-entity-card-body>
   </reactable-card>
 </template>
 
@@ -165,7 +84,8 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Scenario } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
-import { resolveArtImageSrc, resolveArtVariantSrc } from '@/utils/artImageSrc'
+import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useUserStore } from '@/stores/userStore'
 import { parseScenarioIntros } from '@/stores/helpers/scenarioHelper'
@@ -239,23 +159,51 @@ const canDelete = computed(() => {
   )
 })
 
-const computedScenarioImage = computed(() =>
-  // The scenario's own purpose-built card art wins: it is rendered at card
-  // aspect for exactly this slot, where imagePath is the wide primary image.
-  // Falls through to the old chain (art image path, its base64, imagePath,
-  // fallback) for scenarios whose cardPath has not rendered yet.
-  resolveArtVariantSrc(
-    props.scenario,
-    'card',
-    resolveArtImageSrc(
-      artImage.value,
-      props.scenario.imagePath || props.fallbackImage,
-    ),
+/*
+ * What the card body falls back to when the Scenario has no card variant yet:
+ * the linked ArtImage's path or base64, then the wide primary imagePath, then
+ * the shipped placeholder. kr-entity-card-body (via kr-art-plate) applies the
+ * cardPath/heroPath/iconPath half of the chain itself, so this file no longer
+ * carries its own copy of resolveArtVariantSrc's variant branch.
+ */
+const artFallbackSrc = computed(() =>
+  resolveArtImageSrc(
+    artImage.value,
+    props.scenario.imagePath || props.fallbackImage,
   ),
 )
 
 const introCount = computed(() => {
   return parseScenarioIntros(props.scenario.intros).length
+})
+
+const badges = computed<EntityCardChip[]>(() => {
+  const result: EntityCardChip[] = []
+  if (props.scenario.userId === userStore.userId) {
+    result.push({ label: 'Yours', class: 'badge-primary' })
+  }
+  if (props.scenario.isMature) {
+    result.push({ label: 'Mature', class: 'badge-warning' })
+  }
+  return result
+})
+
+const metaChips = computed<EntityCardChip[]>(() => {
+  const result: EntityCardChip[] = []
+  if (props.scenario.locations) {
+    result.push({
+      label: props.scenario.locations,
+      class: 'badge-ghost',
+      icon: 'kind-icon:map',
+    })
+  }
+  if (introCount.value) {
+    result.push({
+      label: `${introCount.value} ${introCount.value === 1 ? 'opening' : 'openings'}`,
+      class: 'badge-outline',
+    })
+  }
+  return result
 })
 
 async function selectScenario() {

--- a/utils/scripts/verifyGalleryAdoption.ts
+++ b/utils/scripts/verifyGalleryAdoption.ts
@@ -313,6 +313,57 @@ for (const path of CORE_OBJECT_GALLERIES) {
  * neither an interact nor a gallery and scored 3/10 on review while Dreams,
  * which has both, scored 7.5.
  */
+/*
+ * THE CARD BODY, counted for the same reason the gallery shell is.
+ *
+ * Silas named a single consistent card display as the destination for this
+ * refactor. The shell half is already there -- fourteen cards wrap
+ * wonderlab/reactable-card.vue -- but the BODY inside it was copy-pasted five
+ * times, which is why scenario-card's scrim was character-for-character
+ * identical to kr-art-plate's. components/gallery/kr-entity-card-body.vue is
+ * the shared body; this number is what stops it going the way of `global-ui`,
+ * whose design system sat at ~7% adoption with every task marked done.
+ */
+const CARD_BODY = 'components/gallery/kr-entity-card-body.vue'
+const OBJECT_CARDS = [
+  'components/bots/bot-card.vue',
+  'components/characters/character-card.vue',
+  'components/dreams/dream-card.vue',
+  'components/rewards/reward-card.vue',
+  'components/scenarios/scenario-card.vue',
+]
+const CARD_BODY_USE = /kr-entity-card-body|KrEntityCardBody/
+
+const cardBodyAdopters = OBJECT_CARDS.filter((path) => {
+  try {
+    return CARD_BODY_USE.test(templateOf(read(path)))
+  } catch {
+    return false
+  }
+})
+
+console.log(
+  `\ninfo - object cards on ${basename(CARD_BODY)}: ${cardBodyAdopters.length}/${OBJECT_CARDS.length}`,
+)
+for (const path of OBJECT_CARDS) {
+  const name = basename(path, '.vue')
+  console.log(
+    `       ${cardBodyAdopters.includes(path) ? '✓' : '·'} ${basename(path).padEnd(22)} ${
+      reachable.has(name)
+        ? `reached from ${reachable.get(name)}`
+        : 'UNREACHABLE — no content route renders it'
+    }`,
+  )
+}
+
+// The shared body is only droppable into five different object cards while it
+// stays presentational. A store import here is the same mistake kr-gallery is
+// guarded against above.
+check(
+  !/from '@\/stores\//.test(read(CARD_BODY)),
+  'kr-entity-card-body imports no store (the card owns its data)',
+)
+
 const MODELS = ['bot', 'character', 'dream', 'facet', 'reward', 'scenario']
 console.log('\ninfo - manager → interact → gallery, per model:')
 for (const model of MODELS) {


### PR DESCRIPTION
## Why

> "the custom cards are a big aspect to the ui refactor, while they all do have custom fields, a lot of the customization is the same stuff with variations for the schema objects. the final version obviously is wanting a single display that is consistent across galleries, all with those bells and whistles." — Silas, 2026-08-02

**The bells and whistles were already shared.** Fourteen cards wrap `wonderlab/reactable-card.vue`, which owns the `<article>`, the selected border, the karma badge, the reaction button and the review panel. What stayed copy-pasted is the **body inside it**, and it is the same body five times over:

```
art plate, with badges over one corner and the title in a scrim
a no-art fallback carrying the same title and chips
a description block
a row of meta chips
then whatever that object alone needs
```

`scenario-card.vue:81`'s scrim class string was **character-for-character identical** to `kr-art-plate.vue:41`, and both `scenario-card` and `character-card` already imported `resolveArtVariantSrc` and then hand-rolled the frame around it anyway.

## What changed

- **`components/gallery/kr-entity-card-body.vue` (new)** — the body, parameterised. Per-object extras go in the default slot.
- **`scenario-card`** — 300 → 248 lines, and it no longer carries its own copy of `resolveArtVariantSrc`'s variant branch. Its consumers (`scenario-gallery`, `scenario-relationship-gallery`, `dream-list`) pass exactly the same props.
- **`kr-art-plate`** gains `shape="wide"` (4:3 — what the panel cards use) and an opt-in `hoverZoom`. Both are things the migration actually needed.
- **`verifyGalleryAdoption`** now prints *object cards on kr-entity-card-body: 1/5*, each with its route. That number is the whole point — the conversation kit is the piece that moved this week because `verifyNarrativeKit` had been printing its count since it shipped.

## Two decisions that change how a card *looks*

Both are noted in the component, because they're not pure code motion:

1. **Badges all sit top-left.** `scenario-card` used to split them — "Yours" left, "Mature" right — but `reactable-card` puts the actions row and karma badge top-right, so anything else there is one prop away from colliding. Left is the only corner a card body actually owns.
2. **The selected check sits below that actions row** (`top-9`, not `top-2`), same reason.

## Deliberately not shipped

A caption-meta row and a surface-toned scrim, written for `bot-card`'s footer-chips layout — then removed before commit. Nothing exercises them until bot migrates, and an unexercised prop is a guess about a migration that hasn't happened yet. They go in with the consumer that needs them.

## Verification

- `npm run test` (vue-tsc) — clean
- `test:layout-contract`, `test:gallery-adoption`, `test:narrative-kit` — pass; layout contract unchanged at 8
- `npx nuxi build` — compiles; prerender stops at the missing `JWT_SECRET` in this environment, which is the documented expected condition here, not a code failure
- Line-ending audit against `HEAD` — no CRLF drift

## Needs eyes

**`/scenarios` (and the Scenario picker inside `dream-list`) want a look on the preview.** The two badge/check decisions above are visible changes, and no source-text contract can judge a card's look.

Remaining on this thread: bot, character, dream and reward cards, tracked as `interface-vision/t-064`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_