### PR TITLE
layout: adopt kr-surface/kr-scroll on the 4 admin WonderLab review pages

### DIFF
--- a/pages/admin/wonderlab-review-generator.vue
+++ b/pages/admin/wonderlab-review-generator.vue
@@ -1,112 +1,112 @@
 <!-- /pages/admin/wonderlab-review-generator.vue -->
 <template>
-  <main
-    class="mx-auto h-full min-h-0 max-w-3xl space-y-4 overflow-y-auto overscroll-contain p-4 md:p-6"
-  >
-    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
-      <p class="text-xs font-black uppercase tracking-widest text-primary">
-        WonderLab Editorial
-      </p>
-      <p class="mt-2 text-3xl font-black">Generate a personality review draft</p>
-      <p class="mt-2 text-sm leading-relaxed text-base-content/60">
-        This creates a proposed draft only. A curator must review, approve, and separately
-        publish it from the curator workspace.
-      </p>
-      <div class="mt-4 flex flex-wrap gap-2">
-        <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-primary btn-sm">
-          Open curator workspace
-        </NuxtLink>
-        <NuxtLink to="/plan/wonderlab" class="btn btn-outline btn-sm">Open WonderLab</NuxtLink>
-      </div>
-    </header>
-
-    <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
-      <span class="loading loading-spinner loading-lg text-primary" />
-    </section>
-
-    <section v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
-      <h2 class="text-xl font-black">Administrator access required</h2>
-    </section>
-
-    <template v-else>
-      <form class="grid gap-4 rounded-3xl border border-base-300 bg-base-100 p-5" @submit.prevent="generate">
-        <div class="grid gap-3 sm:grid-cols-2">
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">Component ID</span>
-            <input v-model="form.componentId" required type="number" min="1" class="input input-bordered mt-1" />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">Reviewer kind</span>
-            <select v-model="form.authorKind" class="select select-bordered mt-1">
-              <option value="BOT">Bot</option>
-              <option value="CHARACTER">Character</option>
-            </select>
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">Reviewer ID</span>
-            <input v-model="form.authorId" required type="number" min="1" class="input input-bordered mt-1" />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">OpenAI model</span>
-            <input v-model="form.model" class="input input-bordered mt-1" placeholder="gpt-4o-mini" />
-          </label>
+  <main class="kr-surface mx-auto max-w-3xl">
+    <div class="kr-scroll space-y-4 p-4 md:p-6">
+      <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          WonderLab Editorial
+        </p>
+        <p class="mt-2 text-3xl font-black">Generate a personality review draft</p>
+        <p class="mt-2 text-sm leading-relaxed text-base-content/60">
+          This creates a proposed draft only. A curator must review, approve, and separately
+          publish it from the curator workspace.
+        </p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-primary btn-sm">
+            Open curator workspace
+          </NuxtLink>
+          <NuxtLink to="/plan/wonderlab" class="btn btn-outline btn-sm">Open WonderLab</NuxtLink>
         </div>
+      </header>
 
-        <label class="flex cursor-pointer items-start gap-3 rounded-2xl bg-base-200/70 p-4">
-          <input v-model="form.regenerate" type="checkbox" class="checkbox checkbox-primary mt-0.5" />
-          <span>
-            <strong class="block">Create a new generation attempt</strong>
-            <span class="text-sm text-base-content/60">
-              Without this, the endpoint reuses the latest draft for the same Component and reviewer.
-            </span>
-          </span>
-        </label>
+      <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+        <span class="loading loading-spinner loading-lg text-primary" />
+      </section>
 
-        <button class="btn btn-primary" :disabled="loading">
-          <span v-if="loading" class="loading loading-spinner loading-sm" />
-          Generate proposed draft
-        </button>
-      </form>
+      <section v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
+        <h2 class="text-xl font-black">Administrator access required</h2>
+      </section>
 
-      <p v-if="notice" class="rounded-2xl border p-4 text-sm" :class="failed ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'">
-        {{ notice }}
-      </p>
-
-      <article v-if="result" class="rounded-3xl border border-base-300 bg-base-100 p-5">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p class="text-xs font-black uppercase text-primary">{{ result.draft.author.kind }}</p>
-            <h2 class="text-2xl font-black">{{ result.draft.author.name }}</h2>
-            <p class="text-sm text-base-content/60">
-              {{ result.draft.componentTitle || result.draft.componentName }} · Draft #{{ result.draft.id }}
-            </p>
+      <template v-else>
+        <form class="grid gap-4 rounded-3xl border border-base-300 bg-base-100 p-5" @submit.prevent="generate">
+          <div class="grid gap-3 sm:grid-cols-2">
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Component ID</span>
+              <input v-model="form.componentId" required type="number" min="1" class="input input-bordered mt-1" />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Reviewer kind</span>
+              <select v-model="form.authorKind" class="select select-bordered mt-1">
+                <option value="BOT">Bot</option>
+                <option value="CHARACTER">Character</option>
+              </select>
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Reviewer ID</span>
+              <input v-model="form.authorId" required type="number" min="1" class="input input-bordered mt-1" />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">OpenAI model</span>
+              <input v-model="form.model" class="input input-bordered mt-1" placeholder="gpt-4o-mini" />
+            </label>
           </div>
-          <span class="badge" :class="result.draft.status === 'FAILED' ? 'badge-error' : 'badge-warning'">
-            {{ result.draft.status }}
-          </span>
-        </div>
 
-        <p class="mt-4 whitespace-pre-wrap leading-relaxed">{{ result.draft.generatedComment }}</p>
+          <label class="flex cursor-pointer items-start gap-3 rounded-2xl bg-base-200/70 p-4">
+            <input v-model="form.regenerate" type="checkbox" class="checkbox checkbox-primary mt-0.5" />
+            <span>
+              <strong class="block">Create a new generation attempt</strong>
+              <span class="text-sm text-base-content/60">
+                Without this, the endpoint reuses the latest draft for the same Component and reviewer.
+              </span>
+            </span>
+          </label>
 
-        <dl class="mt-4 grid gap-3 rounded-2xl bg-base-200/70 p-4 text-sm sm:grid-cols-2">
-          <div><dt class="font-black">Rating</dt><dd>{{ result.draft.rating }} / 5</dd></div>
-          <div><dt class="font-black">Confidence</dt><dd>{{ confidenceLabel }}</dd></div>
-          <div><dt class="font-black">Attempt</dt><dd>{{ result.draft.generationAttempt }}</dd></div>
-          <div><dt class="font-black">Model</dt><dd>{{ result.draft.generationModel }}</dd></div>
-        </dl>
+          <button class="btn btn-primary" :disabled="loading">
+            <span v-if="loading" class="loading loading-spinner loading-sm" />
+            Generate proposed draft
+          </button>
+        </form>
 
-        <div v-if="result.observations.length" class="mt-4">
-          <h3 class="font-black">Grounding observations</h3>
-          <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-base-content/70">
-            <li v-for="observation in result.observations" :key="observation">{{ observation }}</li>
-          </ul>
-        </div>
+        <p v-if="notice" class="rounded-2xl border p-4 text-sm" :class="failed ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'">
+          {{ notice }}
+        </p>
 
-        <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-secondary btn-sm mt-5">
-          Review this draft
-        </NuxtLink>
-      </article>
-    </template>
+        <article v-if="result" class="rounded-3xl border border-base-300 bg-base-100 p-5">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p class="text-xs font-black uppercase text-primary">{{ result.draft.author.kind }}</p>
+              <h2 class="text-2xl font-black">{{ result.draft.author.name }}</h2>
+              <p class="text-sm text-base-content/60">
+                {{ result.draft.componentTitle || result.draft.componentName }} · Draft #{{ result.draft.id }}
+              </p>
+            </div>
+            <span class="badge" :class="result.draft.status === 'FAILED' ? 'badge-error' : 'badge-warning'">
+              {{ result.draft.status }}
+            </span>
+          </div>
+
+          <p class="mt-4 whitespace-pre-wrap leading-relaxed">{{ result.draft.generatedComment }}</p>
+
+          <dl class="mt-4 grid gap-3 rounded-2xl bg-base-200/70 p-4 text-sm sm:grid-cols-2">
+            <div><dt class="font-black">Rating</dt><dd>{{ result.draft.rating }} / 5</dd></div>
+            <div><dt class="font-black">Confidence</dt><dd>{{ confidenceLabel }}</dd></div>
+            <div><dt class="font-black">Attempt</dt><dd>{{ result.draft.generationAttempt }}</dd></div>
+            <div><dt class="font-black">Model</dt><dd>{{ result.draft.generationModel }}</dd></div>
+          </dl>
+
+          <div v-if="result.observations.length" class="mt-4">
+            <h3 class="font-black">Grounding observations</h3>
+            <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-base-content/70">
+              <li v-for="observation in result.observations" :key="observation">{{ observation }}</li>
+            </ul>
+          </div>
+
+          <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-secondary btn-sm mt-5">
+            Review this draft
+          </NuxtLink>
+        </article>
+      </template>
+    </div>
   </main>
 </template>
 

--- a/pages/admin/wonderlab-review-plan.vue
+++ b/pages/admin/wonderlab-review-plan.vue
@@ -1,216 +1,216 @@
 <!-- /pages/admin/wonderlab-review-plan.vue -->
 <template>
-  <main
-    class="mx-auto h-full min-h-0 max-w-7xl space-y-4 overflow-y-auto overscroll-contain p-4 md:p-6"
-  >
-    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
-      <p class="text-xs font-black uppercase tracking-widest text-primary">
-        WonderLab Editorial
-      </p>
-      <p class="mt-2 text-3xl font-black">Personality review coverage plan</p>
-      <p class="mt-2 max-w-4xl text-sm leading-relaxed text-base-content/60">
-        Preview deterministic reviewer assignments and existing coverage before making
-        any model calls. Batch generation creates proposed drafts only; it never approves
-        or publishes them.
-      </p>
-      <div class="mt-4 flex flex-wrap gap-2">
-        <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-primary btn-sm">
-          Curator workspace
-        </NuxtLink>
-        <NuxtLink to="/admin/wonderlab-review-generator" class="btn btn-outline btn-sm">
-          Single-draft generator
-        </NuxtLink>
-        <NuxtLink to="/plan/wonderlab" class="btn btn-ghost btn-sm">WonderLab</NuxtLink>
-      </div>
-    </header>
-
-    <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
-      <span class="loading loading-spinner loading-lg text-primary" />
-    </section>
-
-    <section
-      v-else-if="!userStore.isAdmin"
-      class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center"
-    >
-      <h2 class="text-xl font-black">Administrator access required</h2>
-    </section>
-
-    <template v-else>
-      <section class="rounded-3xl border border-base-300 bg-base-100 p-5">
-        <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-          <label class="form-control xl:col-span-2">
-            <span class="label-text text-xs font-bold">Component IDs (optional)</span>
-            <input
-              v-model="form.componentIds"
-              class="input input-bordered input-sm mt-1"
-              placeholder="12, 18, 25"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">Component limit</span>
-            <input
-              v-model.number="form.limit"
-              type="number"
-              min="1"
-              max="10"
-              class="input input-bordered input-sm mt-1"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">Reviewers per exhibit</span>
-            <select v-model.number="form.reviewersPerComponent" class="select select-bordered select-sm mt-1">
-              <option :value="1">1 reviewer</option>
-              <option :value="2">2 reviewers</option>
-            </select>
-          </label>
-          <label class="form-control">
-            <span class="label-text text-xs font-bold">Minimum affinity</span>
-            <input
-              v-model.number="form.minimumScore"
-              type="number"
-              min="-100"
-              max="500"
-              class="input input-bordered input-sm mt-1"
-            />
-          </label>
-          <label class="form-control md:col-span-2 xl:col-span-3">
-            <span class="label-text text-xs font-bold">Generation model</span>
-            <input
-              v-model="form.model"
-              class="input input-bordered input-sm mt-1"
-              placeholder="gpt-4o-mini"
-            />
-          </label>
-          <label class="flex cursor-pointer items-center gap-3 rounded-2xl bg-base-200/70 p-3 md:col-span-2">
-            <input v-model="form.regenerate" type="checkbox" class="checkbox checkbox-warning" />
-            <span class="text-sm">
-              Include existing unpublished drafts as new regeneration attempts
-            </span>
-          </label>
-        </div>
-
+  <main class="kr-surface mx-auto max-w-7xl">
+    <div class="kr-scroll space-y-4 p-4 md:p-6">
+      <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+        <p class="text-xs font-black uppercase tracking-widest text-primary">
+          WonderLab Editorial
+        </p>
+        <p class="mt-2 text-3xl font-black">Personality review coverage plan</p>
+        <p class="mt-2 max-w-4xl text-sm leading-relaxed text-base-content/60">
+          Preview deterministic reviewer assignments and existing coverage before making
+          any model calls. Batch generation creates proposed drafts only; it never approves
+          or publishes them.
+        </p>
         <div class="mt-4 flex flex-wrap gap-2">
-          <button class="btn btn-outline btn-sm" :disabled="loading" @click="loadPlan">
-            <span v-if="loading" class="loading loading-spinner loading-xs" />
-            Preview plan
-          </button>
-          <button class="btn btn-ghost btn-sm" :disabled="loading" @click="runBatch(true)">
-            Verify dry run
-          </button>
+          <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-primary btn-sm">
+            Curator workspace
+          </NuxtLink>
+          <NuxtLink to="/admin/wonderlab-review-generator" class="btn btn-outline btn-sm">
+            Single-draft generator
+          </NuxtLink>
+          <NuxtLink to="/plan/wonderlab" class="btn btn-ghost btn-sm">WonderLab</NuxtLink>
         </div>
+      </header>
 
-        <label class="mt-4 flex cursor-pointer items-start gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-4">
-          <input v-model="executeEnabled" type="checkbox" class="checkbox checkbox-warning mt-0.5" />
-          <span>
-            <strong class="block">Enable model calls for this batch</strong>
-            <span class="text-sm text-base-content/65">
-              This may create proposed or failed drafts. It cannot approve or publish.
-            </span>
-          </span>
-        </label>
-        <button
-          class="btn btn-warning mt-3"
-          :disabled="loading || !executeEnabled || !plan?.missingCount && !form.regenerate"
-          @click="runBatch(false)"
-        >
-          Generate planned drafts
-        </button>
+      <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+        <span class="loading loading-spinner loading-lg text-primary" />
       </section>
 
-      <p
-        v-if="notice"
-        class="rounded-2xl border p-4 text-sm"
-        :class="noticeError ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'"
+      <section
+        v-else-if="!userStore.isAdmin"
+        class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center"
       >
-        {{ notice }}
-      </p>
-
-      <section v-if="plan" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div class="stat rounded-3xl border border-base-300 bg-base-100">
-          <div class="stat-title">Exhibits</div>
-          <div class="stat-value text-primary">{{ plan.componentCount }}</div>
-        </div>
-        <div class="stat rounded-3xl border border-base-300 bg-base-100">
-          <div class="stat-title">Missing</div>
-          <div class="stat-value text-warning">{{ plan.missingCount }}</div>
-        </div>
-        <div class="stat rounded-3xl border border-base-300 bg-base-100">
-          <div class="stat-title">Drafted</div>
-          <div class="stat-value text-secondary">{{ plan.draftedCount }}</div>
-        </div>
-        <div class="stat rounded-3xl border border-base-300 bg-base-100">
-          <div class="stat-title">Published</div>
-          <div class="stat-value text-success">{{ plan.publishedCount }}</div>
-        </div>
+        <h2 class="text-xl font-black">Administrator access required</h2>
       </section>
 
-      <section v-if="batchResults.length" class="rounded-3xl border border-base-300 bg-base-100 p-4">
-        <h2 class="text-xl font-black">Latest batch results</h2>
-        <div class="mt-3 grid gap-2">
-          <div
-            v-for="result in batchResults"
-            :key="`${result.componentId}-${result.reviewer.author.kind}-${result.reviewer.author.id}`"
-            class="flex flex-wrap items-center justify-between gap-2 rounded-2xl bg-base-200/70 p-3 text-sm"
-          >
+      <template v-else>
+        <section class="rounded-3xl border border-base-300 bg-base-100 p-5">
+          <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            <label class="form-control xl:col-span-2">
+              <span class="label-text text-xs font-bold">Component IDs (optional)</span>
+              <input
+                v-model="form.componentIds"
+                class="input input-bordered input-sm mt-1"
+                placeholder="12, 18, 25"
+              />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Component limit</span>
+              <input
+                v-model.number="form.limit"
+                type="number"
+                min="1"
+                max="10"
+                class="input input-bordered input-sm mt-1"
+              />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Reviewers per exhibit</span>
+              <select v-model.number="form.reviewersPerComponent" class="select select-bordered select-sm mt-1">
+                <option :value="1">1 reviewer</option>
+                <option :value="2">2 reviewers</option>
+              </select>
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs font-bold">Minimum affinity</span>
+              <input
+                v-model.number="form.minimumScore"
+                type="number"
+                min="-100"
+                max="500"
+                class="input input-bordered input-sm mt-1"
+              />
+            </label>
+            <label class="form-control md:col-span-2 xl:col-span-3">
+              <span class="label-text text-xs font-bold">Generation model</span>
+              <input
+                v-model="form.model"
+                class="input input-bordered input-sm mt-1"
+                placeholder="gpt-4o-mini"
+              />
+            </label>
+            <label class="flex cursor-pointer items-center gap-3 rounded-2xl bg-base-200/70 p-3 md:col-span-2">
+              <input v-model="form.regenerate" type="checkbox" class="checkbox checkbox-warning" />
+              <span class="text-sm">
+                Include existing unpublished drafts as new regeneration attempts
+              </span>
+            </label>
+          </div>
+
+          <div class="mt-4 flex flex-wrap gap-2">
+            <button class="btn btn-outline btn-sm" :disabled="loading" @click="loadPlan">
+              <span v-if="loading" class="loading loading-spinner loading-xs" />
+              Preview plan
+            </button>
+            <button class="btn btn-ghost btn-sm" :disabled="loading" @click="runBatch(true)">
+              Verify dry run
+            </button>
+          </div>
+
+          <label class="mt-4 flex cursor-pointer items-start gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-4">
+            <input v-model="executeEnabled" type="checkbox" class="checkbox checkbox-warning mt-0.5" />
             <span>
-              <strong>{{ result.reviewer.name }}</strong> on Component #{{ result.componentId }}
+              <strong class="block">Enable model calls for this batch</strong>
+              <span class="text-sm text-base-content/65">
+                This may create proposed or failed drafts. It cannot approve or publish.
+              </span>
             </span>
-            <span class="badge" :class="result.success ? 'badge-success' : 'badge-error'">
-              {{ result.message }}
-            </span>
-          </div>
-        </div>
-      </section>
+          </label>
+          <button
+            class="btn btn-warning mt-3"
+            :disabled="loading || !executeEnabled || !plan?.missingCount && !form.regenerate"
+            @click="runBatch(false)"
+          >
+            Generate planned drafts
+          </button>
+        </section>
 
-      <section v-if="plan" class="grid gap-4 lg:grid-cols-2">
-        <article
-          v-for="exhibit in plan.exhibits"
-          :key="exhibit.componentId"
-          class="rounded-3xl border border-base-300 bg-base-100 p-4"
+        <p
+          v-if="notice"
+          class="rounded-2xl border p-4 text-sm"
+          :class="noticeError ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'"
         >
-          <header class="flex flex-wrap items-start justify-between gap-2">
-            <div>
-              <h2 class="text-lg font-black">{{ exhibit.title || exhibit.componentName }}</h2>
-              <p class="text-sm text-base-content/55">
-                {{ exhibit.folderName }} · Component #{{ exhibit.componentId }}
-              </p>
-            </div>
-            <span class="badge badge-outline">{{ exhibit.status }}</span>
-          </header>
+          {{ notice }}
+        </p>
 
-          <div v-if="!exhibit.reviewers.length" class="mt-4 rounded-2xl bg-error/10 p-4 text-sm text-error">
-            No eligible voice-ready reviewer met this plan's constraints.
+        <section v-if="plan" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div class="stat rounded-3xl border border-base-300 bg-base-100">
+            <div class="stat-title">Exhibits</div>
+            <div class="stat-value text-primary">{{ plan.componentCount }}</div>
           </div>
+          <div class="stat rounded-3xl border border-base-300 bg-base-100">
+            <div class="stat-title">Missing</div>
+            <div class="stat-value text-warning">{{ plan.missingCount }}</div>
+          </div>
+          <div class="stat rounded-3xl border border-base-300 bg-base-100">
+            <div class="stat-title">Drafted</div>
+            <div class="stat-value text-secondary">{{ plan.draftedCount }}</div>
+          </div>
+          <div class="stat rounded-3xl border border-base-300 bg-base-100">
+            <div class="stat-title">Published</div>
+            <div class="stat-value text-success">{{ plan.publishedCount }}</div>
+          </div>
+        </section>
 
-          <div v-else class="mt-4 grid gap-3">
+        <section v-if="batchResults.length" class="rounded-3xl border border-base-300 bg-base-100 p-4">
+          <h2 class="text-xl font-black">Latest batch results</h2>
+          <div class="mt-3 grid gap-2">
             <div
-              v-for="reviewer in exhibit.reviewers"
-              :key="`${reviewer.author.kind}-${reviewer.author.id}`"
-              class="rounded-2xl border border-base-300 p-3"
+              v-for="result in batchResults"
+              :key="`${result.componentId}-${result.reviewer.author.kind}-${result.reviewer.author.id}`"
+              class="flex flex-wrap items-center justify-between gap-2 rounded-2xl bg-base-200/70 p-3 text-sm"
             >
-              <div class="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                  <p class="font-black">{{ reviewer.name }}</p>
-                  <p class="text-xs text-base-content/55">
-                    {{ reviewer.author.kind }} #{{ reviewer.author.id }} · affinity {{ reviewer.score }}
-                  </p>
-                </div>
-                <span class="badge" :class="coverageClass(reviewer.coverage)">
-                  {{ reviewer.coverage }}
-                </span>
-              </div>
-              <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-base-content/65">
-                <li v-for="reason in reviewer.reasons" :key="reason">{{ reason }}</li>
-              </ul>
-              <p v-if="reviewer.draftId || reviewer.reactionId" class="mt-2 text-xs text-base-content/50">
-                <span v-if="reviewer.draftId">Draft #{{ reviewer.draftId }} {{ reviewer.draftStatus }}</span>
-                <span v-if="reviewer.reactionId"> · Reaction #{{ reviewer.reactionId }}</span>
-              </p>
+              <span>
+                <strong>{{ result.reviewer.name }}</strong> on Component #{{ result.componentId }}
+              </span>
+              <span class="badge" :class="result.success ? 'badge-success' : 'badge-error'">
+                {{ result.message }}
+              </span>
             </div>
           </div>
-        </article>
-      </section>
-    </template>
+        </section>
+
+        <section v-if="plan" class="grid gap-4 lg:grid-cols-2">
+          <article
+            v-for="exhibit in plan.exhibits"
+            :key="exhibit.componentId"
+            class="rounded-3xl border border-base-300 bg-base-100 p-4"
+          >
+            <header class="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h2 class="text-lg font-black">{{ exhibit.title || exhibit.componentName }}</h2>
+                <p class="text-sm text-base-content/55">
+                  {{ exhibit.folderName }} · Component #{{ exhibit.componentId }}
+                </p>
+              </div>
+              <span class="badge badge-outline">{{ exhibit.status }}</span>
+            </header>
+
+            <div v-if="!exhibit.reviewers.length" class="mt-4 rounded-2xl bg-error/10 p-4 text-sm text-error">
+              No eligible voice-ready reviewer met this plan's constraints.
+            </div>
+
+            <div v-else class="mt-4 grid gap-3">
+              <div
+                v-for="reviewer in exhibit.reviewers"
+                :key="`${reviewer.author.kind}-${reviewer.author.id}`"
+                class="rounded-2xl border border-base-300 p-3"
+              >
+                <div class="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <p class="font-black">{{ reviewer.name }}</p>
+                    <p class="text-xs text-base-content/55">
+                      {{ reviewer.author.kind }} #{{ reviewer.author.id }} · affinity {{ reviewer.score }}
+                    </p>
+                  </div>
+                  <span class="badge" :class="coverageClass(reviewer.coverage)">
+                    {{ reviewer.coverage }}
+                  </span>
+                </div>
+                <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-base-content/65">
+                  <li v-for="reason in reviewer.reasons" :key="reason">{{ reason }}</li>
+                </ul>
+                <p v-if="reviewer.draftId || reviewer.reactionId" class="mt-2 text-xs text-base-content/50">
+                  <span v-if="reviewer.draftId">Draft #{{ reviewer.draftId }} {{ reviewer.draftStatus }}</span>
+                  <span v-if="reviewer.reactionId"> · Reaction #{{ reviewer.reactionId }}</span>
+                </p>
+              </div>
+            </div>
+          </article>
+        </section>
+      </template>
+    </div>
   </main>
 </template>
 

--- a/pages/admin/wonderlab-review-rollout.vue
+++ b/pages/admin/wonderlab-review-rollout.vue
@@ -1,85 +1,85 @@
 <!-- /pages/admin/wonderlab-review-rollout.vue -->
 <template>
-  <main
-    class="mx-auto h-full min-h-0 max-w-6xl space-y-4 overflow-y-auto overscroll-contain p-4 md:p-6"
-  >
-    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
-      <div class="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
-            WonderLab Operations
-          </p>
-          <p class="mt-2 text-3xl font-black">Personality review rollout audit</p>
-          <p class="mt-2 max-w-3xl text-sm text-base-content/60">
-            Read-only production checks for migrations, author identity, draft links,
-            and duplicate prevention. This page never generates, approves, or publishes.
-          </p>
-        </div>
-        <div class="flex flex-wrap gap-2">
-          <NuxtLink to="/admin/wonderlab-review-plan" class="btn btn-outline btn-sm">
-            Coverage plan
-          </NuxtLink>
-          <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-outline btn-sm">
-            Curator workspace
-          </NuxtLink>
-          <button class="btn btn-primary btn-sm" :disabled="loading" @click="loadAudit">
-            <span v-if="loading" class="loading loading-spinner loading-xs" />
-            Run audit
-          </button>
-        </div>
-      </div>
-    </header>
-
-    <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
-      <span class="loading loading-spinner loading-lg text-primary" />
-    </section>
-
-    <section v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
-      <h2 class="text-xl font-black">Administrator access required</h2>
-    </section>
-
-    <template v-else>
-      <p v-if="notice" class="rounded-2xl border border-error/40 bg-error/10 p-4 text-error">
-        {{ notice }}
-      </p>
-
-      <section v-if="audit" class="rounded-3xl border p-5" :class="audit.ready ? 'border-success/40 bg-success/10' : 'border-warning/40 bg-warning/10'">
-        <div class="flex flex-wrap items-center justify-between gap-3">
+  <main class="kr-surface mx-auto max-w-6xl">
+    <div class="kr-scroll space-y-4 p-4 md:p-6">
+      <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+        <div class="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p class="text-xs font-black uppercase tracking-widest">Rollout state</p>
-            <h2 class="mt-1 text-2xl font-black">
-              {{ audit.ready ? 'Ready' : 'Blocked' }}
-            </h2>
-            <p class="mt-1 text-sm text-base-content/60">
-              {{ audit.databaseName || 'No database' }} · checked {{ formatDate(audit.checkedAt) }}
+            <p class="text-xs font-black uppercase tracking-widest text-primary">
+              WonderLab Operations
+            </p>
+            <p class="mt-2 text-3xl font-black">Personality review rollout audit</p>
+            <p class="mt-2 max-w-3xl text-sm text-base-content/60">
+              Read-only production checks for migrations, author identity, draft links,
+              and duplicate prevention. This page never generates, approves, or publishes.
             </p>
           </div>
-          <Icon :name="audit.ready ? 'kind-icon:check' : 'kind-icon:warning'" class="size-12" />
+          <div class="flex flex-wrap gap-2">
+            <NuxtLink to="/admin/wonderlab-review-plan" class="btn btn-outline btn-sm">
+              Coverage plan
+            </NuxtLink>
+            <NuxtLink to="/admin/wonderlab-reviews" class="btn btn-outline btn-sm">
+              Curator workspace
+            </NuxtLink>
+            <button class="btn btn-primary btn-sm" :disabled="loading" @click="loadAudit">
+              <span v-if="loading" class="loading loading-spinner loading-xs" />
+              Run audit
+            </button>
+          </div>
         </div>
+      </header>
+
+      <section v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+        <span class="loading loading-spinner loading-lg text-primary" />
       </section>
 
-      <section v-if="audit" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        <div v-for="metric in metricCards" :key="metric.label" class="stat rounded-3xl border border-base-300 bg-base-100">
-          <div class="stat-title text-xs">{{ metric.label }}</div>
-          <div class="stat-value text-2xl">{{ metric.value }}</div>
-        </div>
+      <section v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
+        <h2 class="text-xl font-black">Administrator access required</h2>
       </section>
 
-      <section v-if="audit" class="grid gap-3 md:grid-cols-2">
-        <article v-for="entry in audit.checks" :key="entry.key" class="rounded-3xl border bg-base-100 p-4" :class="entry.ok ? 'border-success/30' : 'border-error/40'">
-          <div class="flex items-start gap-3">
-            <Icon :name="entry.ok ? 'kind-icon:check' : 'kind-icon:warning'" class="mt-0.5 size-5 shrink-0" :class="entry.ok ? 'text-success' : 'text-error'" />
-            <div class="min-w-0">
-              <h3 class="font-black">{{ entry.label }}</h3>
-              <p class="mt-1 text-sm text-base-content/65">{{ entry.detail }}</p>
-              <p class="mt-2 truncate font-mono text-xs text-base-content/45">
-                {{ entry.value }}
+      <template v-else>
+        <p v-if="notice" class="rounded-2xl border border-error/40 bg-error/10 p-4 text-error">
+          {{ notice }}
+        </p>
+
+        <section v-if="audit" class="rounded-3xl border p-5" :class="audit.ready ? 'border-success/40 bg-success/10' : 'border-warning/40 bg-warning/10'">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p class="text-xs font-black uppercase tracking-widest">Rollout state</p>
+              <h2 class="mt-1 text-2xl font-black">
+                {{ audit.ready ? 'Ready' : 'Blocked' }}
+              </h2>
+              <p class="mt-1 text-sm text-base-content/60">
+                {{ audit.databaseName || 'No database' }} · checked {{ formatDate(audit.checkedAt) }}
               </p>
             </div>
+            <Icon :name="audit.ready ? 'kind-icon:check' : 'kind-icon:warning'" class="size-12" />
           </div>
-        </article>
-      </section>
-    </template>
+        </section>
+
+        <section v-if="audit" class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          <div v-for="metric in metricCards" :key="metric.label" class="stat rounded-3xl border border-base-300 bg-base-100">
+            <div class="stat-title text-xs">{{ metric.label }}</div>
+            <div class="stat-value text-2xl">{{ metric.value }}</div>
+          </div>
+        </section>
+
+        <section v-if="audit" class="grid gap-3 md:grid-cols-2">
+          <article v-for="entry in audit.checks" :key="entry.key" class="rounded-3xl border bg-base-100 p-4" :class="entry.ok ? 'border-success/30' : 'border-error/40'">
+            <div class="flex items-start gap-3">
+              <Icon :name="entry.ok ? 'kind-icon:check' : 'kind-icon:warning'" class="mt-0.5 size-5 shrink-0" :class="entry.ok ? 'text-success' : 'text-error'" />
+              <div class="min-w-0">
+                <h3 class="font-black">{{ entry.label }}</h3>
+                <p class="mt-1 text-sm text-base-content/65">{{ entry.detail }}</p>
+                <p class="mt-2 truncate font-mono text-xs text-base-content/45">
+                  {{ entry.value }}
+                </p>
+              </div>
+            </div>
+          </article>
+        </section>
+      </template>
+    </div>
   </main>
 </template>
 

--- a/pages/admin/wonderlab-reviews.vue
+++ b/pages/admin/wonderlab-reviews.vue
@@ -1,162 +1,162 @@
 <!-- /pages/admin/wonderlab-reviews.vue -->
 <template>
-  <main
-    class="mx-auto h-full min-h-0 max-w-7xl space-y-4 overflow-y-auto overscroll-contain p-4 md:p-6"
-  >
-    <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
-      <div class="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
-            WonderLab Editorial
-          </p>
-          <p class="mt-2 text-3xl font-black">Personality review drafts</p>
-          <p class="mt-2 text-sm text-base-content/60">
-            Nothing on this page publishes automatically. Approval and publication are
-            separate curator actions.
-          </p>
-        </div>
-        <div class="flex gap-2">
-          <NuxtLink to="/plan/wonderlab" class="btn btn-outline btn-sm">WonderLab</NuxtLink>
-          <button class="btn btn-primary btn-sm" :disabled="loading" @click="loadDrafts">
-            <span v-if="loading" class="loading loading-spinner loading-xs" />
-            Refresh
-          </button>
-        </div>
-      </div>
-    </header>
-
-    <div v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
-      <span class="loading loading-spinner loading-lg text-primary" />
-    </div>
-
-    <div v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
-      <h2 class="text-xl font-black">Administrator access required</h2>
-      <p class="mt-2 text-sm">The server independently protects every editorial API.</p>
-    </div>
-
-    <template v-else>
-      <section class="grid gap-4 xl:grid-cols-[1fr_360px]">
-        <div class="rounded-3xl border border-base-300 bg-base-100 p-4">
-          <div class="grid gap-3 sm:grid-cols-3">
-            <label class="form-control">
-              <span class="label-text text-xs font-bold">Status</span>
-              <select v-model="statusFilter" class="select select-bordered select-sm mt-1">
-                <option value="">All statuses</option>
-                <option v-for="status in statuses" :key="status" :value="status">
-                  {{ label(status) }}
-                </option>
-              </select>
-            </label>
-            <label class="form-control">
-              <span class="label-text text-xs font-bold">Component ID</span>
-              <input v-model="componentFilter" type="number" min="1" class="input input-bordered input-sm mt-1" />
-            </label>
-            <label class="form-control">
-              <span class="label-text text-xs font-bold">Search loaded drafts</span>
-              <input v-model="search" type="search" class="input input-bordered input-sm mt-1" />
-            </label>
+  <main class="kr-surface mx-auto max-w-7xl">
+    <div class="kr-scroll space-y-4 p-4 md:p-6">
+      <header class="rounded-3xl border border-base-300 bg-base-100 p-5">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest text-primary">
+              WonderLab Editorial
+            </p>
+            <p class="mt-2 text-3xl font-black">Personality review drafts</p>
+            <p class="mt-2 text-sm text-base-content/60">
+              Nothing on this page publishes automatically. Approval and publication are
+              separate curator actions.
+            </p>
           </div>
-          <p class="mt-3 text-sm text-base-content/55">
-            {{ filteredDrafts.length }} of {{ drafts.length }} drafts
-          </p>
+          <div class="flex gap-2">
+            <NuxtLink to="/plan/wonderlab" class="btn btn-outline btn-sm">WonderLab</NuxtLink>
+            <button class="btn btn-primary btn-sm" :disabled="loading" @click="loadDrafts">
+              <span v-if="loading" class="loading loading-spinner loading-xs" />
+              Refresh
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div v-if="!ready" class="grid min-h-52 place-items-center rounded-3xl bg-base-100">
+        <span class="loading loading-spinner loading-lg text-primary" />
+      </div>
+
+      <div v-else-if="!userStore.isAdmin" class="rounded-3xl border border-error/40 bg-error/10 p-8 text-center">
+        <h2 class="text-xl font-black">Administrator access required</h2>
+        <p class="mt-2 text-sm">The server independently protects every editorial API.</p>
+      </div>
+
+      <template v-else>
+        <section class="grid gap-4 xl:grid-cols-[1fr_360px]">
+          <div class="rounded-3xl border border-base-300 bg-base-100 p-4">
+            <div class="grid gap-3 sm:grid-cols-3">
+              <label class="form-control">
+                <span class="label-text text-xs font-bold">Status</span>
+                <select v-model="statusFilter" class="select select-bordered select-sm mt-1">
+                  <option value="">All statuses</option>
+                  <option v-for="status in statuses" :key="status" :value="status">
+                    {{ label(status) }}
+                  </option>
+                </select>
+              </label>
+              <label class="form-control">
+                <span class="label-text text-xs font-bold">Component ID</span>
+                <input v-model="componentFilter" type="number" min="1" class="input input-bordered input-sm mt-1" />
+              </label>
+              <label class="form-control">
+                <span class="label-text text-xs font-bold">Search loaded drafts</span>
+                <input v-model="search" type="search" class="input input-bordered input-sm mt-1" />
+              </label>
+            </div>
+            <p class="mt-3 text-sm text-base-content/55">
+              {{ filteredDrafts.length }} of {{ drafts.length }} drafts
+            </p>
+          </div>
+
+          <details class="rounded-3xl border border-base-300 bg-base-100 p-4">
+            <summary class="cursor-pointer font-black">Create a curator-written draft</summary>
+            <form class="mt-4 grid gap-3" @submit.prevent="createDraft">
+              <div class="grid grid-cols-2 gap-2">
+                <input v-model="createForm.componentId" required type="number" min="1" class="input input-bordered input-sm" placeholder="Component ID" />
+                <select v-model="createForm.authorKind" class="select select-bordered select-sm">
+                  <option value="BOT">Bot</option>
+                  <option value="CHARACTER">Character</option>
+                </select>
+              </div>
+              <input v-model="createForm.authorId" required type="number" min="1" class="input input-bordered input-sm" placeholder="Reviewer ID" />
+              <textarea v-model="createForm.comment" required maxlength="20000" rows="4" class="textarea textarea-bordered" placeholder="Reviewer-specific museum commentary" />
+              <div class="grid grid-cols-2 gap-2">
+                <select v-model.number="createForm.rating" class="select select-bordered select-sm">
+                  <option v-for="rating in ratings" :key="rating" :value="rating">{{ rating }} stars</option>
+                </select>
+                <select v-model="createForm.reactionType" class="select select-bordered select-sm">
+                  <option value="">Automatic reaction</option>
+                  <option v-for="reaction in reactions" :key="reaction" :value="reaction">{{ reaction }}</option>
+                </select>
+              </div>
+              <button class="btn btn-secondary btn-sm" :disabled="creating">
+                <span v-if="creating" class="loading loading-spinner loading-xs" />
+                Create proposed draft
+              </button>
+            </form>
+          </details>
+        </section>
+
+        <p v-if="notice" class="rounded-2xl border p-3 text-sm" :class="noticeError ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'">
+          {{ notice }}
+        </p>
+
+        <div v-if="loading && !drafts.length" class="grid gap-4 md:grid-cols-2">
+          <div v-for="n in 4" :key="n" class="h-72 animate-pulse rounded-3xl bg-base-200" />
         </div>
 
-        <details class="rounded-3xl border border-base-300 bg-base-100 p-4">
-          <summary class="cursor-pointer font-black">Create a curator-written draft</summary>
-          <form class="mt-4 grid gap-3" @submit.prevent="createDraft">
-            <div class="grid grid-cols-2 gap-2">
-              <input v-model="createForm.componentId" required type="number" min="1" class="input input-bordered input-sm" placeholder="Component ID" />
-              <select v-model="createForm.authorKind" class="select select-bordered select-sm">
-                <option value="BOT">Bot</option>
-                <option value="CHARACTER">Character</option>
-              </select>
-            </div>
-            <input v-model="createForm.authorId" required type="number" min="1" class="input input-bordered input-sm" placeholder="Reviewer ID" />
-            <textarea v-model="createForm.comment" required maxlength="20000" rows="4" class="textarea textarea-bordered" placeholder="Reviewer-specific museum commentary" />
-            <div class="grid grid-cols-2 gap-2">
-              <select v-model.number="createForm.rating" class="select select-bordered select-sm">
+        <div v-else-if="!filteredDrafts.length" class="rounded-3xl border border-dashed border-base-300 bg-base-100 p-10 text-center">
+          <h2 class="text-xl font-black">No matching drafts</h2>
+        </div>
+
+        <section v-else class="grid gap-4 lg:grid-cols-2">
+          <article v-for="draft in filteredDrafts" :key="draft.id" class="rounded-3xl border border-base-300 bg-base-100 p-4">
+            <header class="flex items-start gap-3">
+              <div class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-2xl bg-primary/10">
+                <img v-if="draft.author.avatarImage" :src="imagePath(draft.author.avatarImage)" :alt="draft.author.name" class="size-full object-cover" />
+                <Icon v-else name="kind-icon:sparkles" class="size-5 text-primary" />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap justify-between gap-2">
+                  <div>
+                    <h2 class="font-black">{{ draft.author.name }}</h2>
+                    <p class="text-sm text-base-content/60">
+                      {{ draft.componentTitle || draft.componentName }} · #{{ draft.componentId }}
+                    </p>
+                  </div>
+                  <span class="badge" :class="statusClass(draft.status)">{{ label(draft.status) }}</span>
+                </div>
+                <p class="mt-1 text-xs text-base-content/50">
+                  {{ draft.author.kind }} · {{ draft.author.role }} · Draft #{{ draft.id }}
+                  <span v-if="draft.publishedReactionId"> · Reaction #{{ draft.publishedReactionId }}</span>
+                </p>
+              </div>
+            </header>
+
+            <textarea v-model="editor(draft).comment" rows="7" maxlength="20000" class="textarea textarea-bordered mt-4 w-full" :disabled="terminal(draft.status)" />
+
+            <details class="mt-3 rounded-2xl bg-base-200/60 p-3">
+              <summary class="cursor-pointer text-xs font-black uppercase">Original and provenance</summary>
+              <p class="mt-3 whitespace-pre-wrap text-sm">{{ draft.generatedComment }}</p>
+              <p class="mt-3 text-xs text-base-content/55">
+                {{ draft.promptVersion }} · {{ draft.generationProvider || 'Manual' }} ·
+                {{ draft.generationModel || 'Curator' }}
+              </p>
+            </details>
+
+            <div class="mt-3 grid grid-cols-2 gap-2">
+              <select v-model.number="editor(draft).rating" class="select select-bordered select-sm" :disabled="terminal(draft.status)">
                 <option v-for="rating in ratings" :key="rating" :value="rating">{{ rating }} stars</option>
               </select>
-              <select v-model="createForm.reactionType" class="select select-bordered select-sm">
+              <select v-model="editor(draft).reactionType" class="select select-bordered select-sm" :disabled="terminal(draft.status)">
                 <option value="">Automatic reaction</option>
                 <option v-for="reaction in reactions" :key="reaction" :value="reaction">{{ reaction }}</option>
               </select>
             </div>
-            <button class="btn btn-secondary btn-sm" :disabled="creating">
-              <span v-if="creating" class="loading loading-spinner loading-xs" />
-              Create proposed draft
-            </button>
-          </form>
-        </details>
-      </section>
 
-      <p v-if="notice" class="rounded-2xl border p-3 text-sm" :class="noticeError ? 'border-error/40 bg-error/10 text-error' : 'border-success/40 bg-success/10 text-success'">
-        {{ notice }}
-      </p>
-
-      <div v-if="loading && !drafts.length" class="grid gap-4 md:grid-cols-2">
-        <div v-for="n in 4" :key="n" class="h-72 animate-pulse rounded-3xl bg-base-200" />
-      </div>
-
-      <div v-else-if="!filteredDrafts.length" class="rounded-3xl border border-dashed border-base-300 bg-base-100 p-10 text-center">
-        <h2 class="text-xl font-black">No matching drafts</h2>
-      </div>
-
-      <section v-else class="grid gap-4 lg:grid-cols-2">
-        <article v-for="draft in filteredDrafts" :key="draft.id" class="rounded-3xl border border-base-300 bg-base-100 p-4">
-          <header class="flex items-start gap-3">
-            <div class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-2xl bg-primary/10">
-              <img v-if="draft.author.avatarImage" :src="imagePath(draft.author.avatarImage)" :alt="draft.author.name" class="size-full object-cover" />
-              <Icon v-else name="kind-icon:sparkles" class="size-5 text-primary" />
-            </div>
-            <div class="min-w-0 flex-1">
-              <div class="flex flex-wrap justify-between gap-2">
-                <div>
-                  <h2 class="font-black">{{ draft.author.name }}</h2>
-                  <p class="text-sm text-base-content/60">
-                    {{ draft.componentTitle || draft.componentName }} · #{{ draft.componentId }}
-                  </p>
-                </div>
-                <span class="badge" :class="statusClass(draft.status)">{{ label(draft.status) }}</span>
-              </div>
-              <p class="mt-1 text-xs text-base-content/50">
-                {{ draft.author.kind }} · {{ draft.author.role }} · Draft #{{ draft.id }}
-                <span v-if="draft.publishedReactionId"> · Reaction #{{ draft.publishedReactionId }}</span>
-              </p>
-            </div>
-          </header>
-
-          <textarea v-model="editor(draft).comment" rows="7" maxlength="20000" class="textarea textarea-bordered mt-4 w-full" :disabled="terminal(draft.status)" />
-
-          <details class="mt-3 rounded-2xl bg-base-200/60 p-3">
-            <summary class="cursor-pointer text-xs font-black uppercase">Original and provenance</summary>
-            <p class="mt-3 whitespace-pre-wrap text-sm">{{ draft.generatedComment }}</p>
-            <p class="mt-3 text-xs text-base-content/55">
-              {{ draft.promptVersion }} · {{ draft.generationProvider || 'Manual' }} ·
-              {{ draft.generationModel || 'Curator' }}
-            </p>
-          </details>
-
-          <div class="mt-3 grid grid-cols-2 gap-2">
-            <select v-model.number="editor(draft).rating" class="select select-bordered select-sm" :disabled="terminal(draft.status)">
-              <option v-for="rating in ratings" :key="rating" :value="rating">{{ rating }} stars</option>
-            </select>
-            <select v-model="editor(draft).reactionType" class="select select-bordered select-sm" :disabled="terminal(draft.status)">
-              <option value="">Automatic reaction</option>
-              <option v-for="reaction in reactions" :key="reaction" :value="reaction">{{ reaction }}</option>
-            </select>
-          </div>
-
-          <footer class="mt-4 flex flex-wrap gap-2 border-t border-base-300 pt-4">
-            <button v-if="!terminal(draft.status)" class="btn btn-outline btn-sm" :disabled="busy(draft.id)" @click="save(draft)">Save</button>
-            <button v-if="['PROPOSED', 'REJECTED', 'FAILED'].includes(draft.status)" class="btn btn-success btn-sm" :disabled="busy(draft.id)" @click="approve(draft)">Approve</button>
-            <button v-if="['PROPOSED', 'APPROVED', 'FAILED'].includes(draft.status)" class="btn btn-error btn-outline btn-sm" :disabled="busy(draft.id)" @click="changeStatus(draft, 'REJECTED')">Reject</button>
-            <button v-if="['REJECTED', 'FAILED', 'APPROVED'].includes(draft.status)" class="btn btn-warning btn-outline btn-sm" :disabled="busy(draft.id)" @click="changeStatus(draft, 'PROPOSED')">Reopen</button>
-            <button v-if="draft.status === 'APPROVED'" class="btn btn-primary btn-sm" :disabled="busy(draft.id)" @click="publishDraft(draft)">Publish approved review</button>
-          </footer>
-        </article>
-      </section>
-    </template>
+            <footer class="mt-4 flex flex-wrap gap-2 border-t border-base-300 pt-4">
+              <button v-if="!terminal(draft.status)" class="btn btn-outline btn-sm" :disabled="busy(draft.id)" @click="save(draft)">Save</button>
+              <button v-if="['PROPOSED', 'REJECTED', 'FAILED'].includes(draft.status)" class="btn btn-success btn-sm" :disabled="busy(draft.id)" @click="approve(draft)">Approve</button>
+              <button v-if="['PROPOSED', 'APPROVED', 'FAILED'].includes(draft.status)" class="btn btn-error btn-outline btn-sm" :disabled="busy(draft.id)" @click="changeStatus(draft, 'REJECTED')">Reject</button>
+              <button v-if="['REJECTED', 'FAILED', 'APPROVED'].includes(draft.status)" class="btn btn-warning btn-outline btn-sm" :disabled="busy(draft.id)" @click="changeStatus(draft, 'PROPOSED')">Reopen</button>
+              <button v-if="draft.status === 'APPROVED'" class="btn btn-primary btn-sm" :disabled="busy(draft.id)" @click="publishDraft(draft)">Publish approved review</button>
+            </footer>
+          </article>
+        </section>
+      </template>
+    </div>
   </main>
 </template>
 

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -40,11 +40,7 @@
       "components/pages/appmaker-page.vue",
       "components/pages/memory-dungeon.vue",
       "components/pages/wishmaster-page.vue",
-      "pages/[...slug].vue",
-      "pages/admin/wonderlab-review-generator.vue",
-      "pages/admin/wonderlab-review-plan.vue",
-      "pages/admin/wonderlab-review-rollout.vue",
-      "pages/admin/wonderlab-reviews.vue"
+      "pages/[...slug].vue"
     ]
   }
 }


### PR DESCRIPTION
### Task
interface-vision/t-017: sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

### What changed / what I produced
- `pages/admin/wonderlab-review-generator.vue`, `-plan.vue`, `-rollout.vue`, `pages/admin/wonderlab-reviews.vue`: each root `<main>` split into a `kr-surface` (bounded, non-scrolling) wrapper around a `kr-scroll` (the one scroll region) child — the same zero-behavior-change pattern used by earlier standalone-page sweeps (e.g. click-leaderboard.vue, coloring-page.vue). No markup or classes changed besides the root/scroll-owner split; all header/body content is unchanged, just reindented one level deeper.
- `utils/scripts/layout-contract-baseline.json`: ratcheted `root-surface` down from 8 to 4 via `--update`.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint` on all 4 touched files — clean (one pre-existing, unrelated `no-unused-expressions` error on `wonderlab-reviews.vue` line 243, confirmed present on `main` via `git stash`)
- `npm run test:layout-contract` — holds, no new violations; `root-surface: 8 → 4`, all other buckets unchanged
- `npx tsx utils/scripts/verifyMdcScrollOwnership.ts` — holds (24 existing violations, no new ones)
- Page-specific contract checks, all passed: `verifyReviewDraftCuratorUi.ts`, `verifyReviewDraftGeneration.ts`, `verifyWonderLabReviewBatchPlan.ts`, `verifyWonderLabReviewRolloutAudit.ts`

### Stakes
reversible

### Flags for Reviewer
- No visual/preview check was done (no reachable local dev DB in this sandbox); relying on the zero-behavior-change nature of the class swap (same computed styles, just split across two elements) plus the passing contract checks. Happy to have this checked against the PR's Vercel preview.

### Kaizen suggestion
The remaining root-surface entries (`appmaker-page.vue`, `wishmaster-page.vue`, `memory-dungeon.vue`, `pages/[...slug].vue`) all need real visual verification before converting — they each already declare their own scroll behavior on the root today, so a class swap would be a real behavior change, not a pure rename. Worth a dedicated follow-up sweep that uses the Vercel MCP connector to visually confirm each one before/after.

### Notes for reviewer
`interface-vision/t-017` is a long-running recurring sweep task (23+ prior cycles) — this is its next scoped, bounded pass. Task remains `ready` in the conductor roadmap for the next bounded sweep once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TDHVnFxCRbTHrNXSujBevD)_