### PR TITLE
refactor(cards): bot and character onto kr-entity-card-body (3/5)

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -46,136 +46,22 @@
         </button>
       </template>
 
-      <div
-        v-if="showImage"
-        :class="[
-          'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
-          compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
-        ]"
-      >
-        <img
-          :src="resolvedBotImage"
-          :alt="botTitle"
-          class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-          loading="lazy"
-        />
-
-        <div
-          class="pointer-events-none absolute inset-0 bg-linear-to-t from-base-300/95 via-base-300/25 to-base-300/5"
-        />
-
-        <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-          <span
-            class="badge badge-sm rounded-xl shadow"
-            :class="bot.isPublic ? 'badge-success' : 'badge-warning'"
-          >
-            {{ bot.isPublic ? 'Public' : 'Private' }}
-          </span>
-
-          <span
-            v-if="bot.underConstruction"
-            class="badge badge-error badge-sm rounded-xl shadow"
-          >
-            Building
-          </span>
-
-          <span
-            v-if="bot.BotType"
-            class="badge badge-primary badge-sm rounded-xl bg-primary/90 shadow"
-          >
-            {{ bot.BotType }}
-          </span>
-
-          <span
-            v-if="activeSelected"
-            class="badge badge-accent badge-sm rounded-xl shadow"
-          >
-            Selected
-          </span>
-        </div>
-
-        <div
-          v-if="activeSelected"
-          class="absolute right-2 top-2 rounded-full bg-primary p-2 text-primary-content shadow"
-        >
-          <Icon name="kind-icon:check" class="h-4 w-4" />
-        </div>
-
-        <footer class="absolute inset-x-0 bottom-0 p-3">
-          <h2
-            class="line-clamp-2 text-xl font-black leading-tight text-base-content drop-shadow"
-            :title="botTitle"
-          >
-            {{ botTitle }}
-          </h2>
-
-          <p
-            v-if="bot.subtitle"
-            class="mt-1 line-clamp-1 text-sm font-semibold italic text-base-content/70"
-          >
-            {{ bot.subtitle }}
-          </p>
-
-          <div v-if="showMeta" class="mt-2 flex flex-wrap gap-1">
-            <span
-              v-if="bot.theme"
-              class="badge badge-ghost badge-sm rounded-xl bg-base-100/85 shadow backdrop-blur"
-            >
-              {{ bot.theme }}
-            </span>
-
-            <span
-              v-if="bot.designer"
-              class="badge badge-outline badge-sm rounded-xl border-base-content/30 bg-base-100/85 shadow backdrop-blur"
-            >
-              {{ bot.designer }}
-            </span>
-
-            <span
-              v-if="bot.serverName"
-              class="badge badge-info badge-sm rounded-xl bg-info/90 shadow"
-            >
-              {{ bot.serverName }}
-            </span>
-          </div>
-        </footer>
-      </div>
-
-      <div
-        v-else
-        :class="[
-          'flex flex-col justify-end rounded-2xl border border-base-300 bg-linear-to-br from-primary/15 via-secondary/10 to-accent/15 p-3',
-          compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
-        ]"
-      >
-        <h2
-          class="line-clamp-2 text-xl font-black leading-tight text-base-content"
-          :title="botTitle"
-        >
-          {{ botTitle }}
-        </h2>
-
-        <p
-          v-if="bot.subtitle"
-          class="mt-1 line-clamp-1 text-sm font-semibold italic text-base-content/55"
-        >
-          {{ bot.subtitle }}
-        </p>
-
-        <div v-if="showMeta" class="mt-2 flex flex-wrap gap-1">
-          <span v-if="bot.BotType" class="badge badge-primary badge-sm">
-            {{ bot.BotType }}
-          </span>
-
-          <span v-if="bot.theme" class="badge badge-ghost badge-sm">
-            {{ bot.theme }}
-          </span>
-
-          <span v-if="bot.designer" class="badge badge-outline badge-sm">
-            {{ bot.designer }}
-          </span>
-        </div>
-      </div>
+      <kr-entity-card-body
+        :title="botTitle"
+        :subtitle="bot.subtitle || ''"
+        :source="bot"
+        variant="card"
+        :fallback="artFallbackSrc"
+        :show-image="showImage"
+        :show-description="false"
+        :compact="compact"
+        :selected="activeSelected"
+        :badges="badges"
+        :meta="showMeta ? metaChips : []"
+        shape="card"
+        compact-shape="hero"
+        placeholder-icon="kind-icon:robot"
+      />
 
       <section
         v-if="
@@ -281,6 +167,7 @@ import type { Bot } from '~/prisma/generated/prisma/client'
 import { useBotStore } from '@/stores/botStore'
 import { useNavStore } from '@/stores/navStore'
 import { useUserStore } from '@/stores/userStore'
+import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -353,14 +240,47 @@ const avatarFallback = computed(() => {
   return props.bot.avatarImage?.trim() || props.fallbackImage
 })
 
-const resolvedBotImage = computed(() => {
-  // The bot's own purpose-built card art wins over both the async-fetched
-  // ArtImage and the avatar. avatarImage is a portrait crop; cardPath is
-  // rendered at card aspect for exactly this slot. Bots whose cardPath has not
-  // rendered yet fall through to the previous behaviour unchanged.
-  return (
-    props.bot.cardPath?.trim() || loadedBotImage.value || avatarFallback.value
-  )
+/*
+ * What the shared card body falls back to once the Bot's own cardPath is out of
+ * the picture: the async-fetched ArtImage, then the avatar crop. kr-art-plate
+ * applies the cardPath/heroPath/iconPath half itself, so the explicit
+ * `bot.cardPath?.trim() ||` that used to lead this chain is now redundant --
+ * same order, one owner.
+ */
+const artFallbackSrc = computed(
+  () => loadedBotImage.value || avatarFallback.value,
+)
+
+const badges = computed<EntityCardChip[]>(() => {
+  const result: EntityCardChip[] = [
+    props.bot.isPublic
+      ? { label: 'Public', class: 'badge-success' }
+      : { label: 'Private', class: 'badge-warning' },
+  ]
+  if (props.bot.underConstruction) {
+    result.push({ label: 'Building', class: 'badge-error' })
+  }
+  if (props.bot.BotType) {
+    result.push({ label: props.bot.BotType, class: 'badge-primary' })
+  }
+  if (activeSelected.value) {
+    result.push({ label: 'Selected', class: 'badge-accent' })
+  }
+  return result
+})
+
+const metaChips = computed<EntityCardChip[]>(() => {
+  const result: EntityCardChip[] = []
+  if (props.bot.theme) {
+    result.push({ label: props.bot.theme, class: 'badge-ghost' })
+  }
+  if (props.bot.designer) {
+    result.push({ label: props.bot.designer, class: 'badge-outline' })
+  }
+  if (props.bot.serverName) {
+    result.push({ label: props.bot.serverName, class: 'badge-info' })
+  }
+  return result
 })
 
 const canEdit = computed(() => {

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -43,110 +43,22 @@
       </button>
     </template>
 
-    <div
-      v-if="showImage"
-      :class="[
-        'relative w-full overflow-hidden rounded-2xl border border-base-300 bg-base-300',
-        compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
-      ]"
-    >
-      <img
-        :src="computedCharacterImage"
-        :alt="displayName"
-        class="h-full w-full transition-transform duration-300 group-hover:scale-[1.03]"
-        :class="imageFitClass"
-        loading="lazy"
-        @error="handleImageError"
-      />
-
-      <div
-        class="pointer-events-none absolute inset-0 bg-linear-to-t from-base-300/95 via-base-300/25 to-base-300/5"
-      />
-
-      <div class="absolute left-2 top-2 flex flex-wrap gap-1">
-        <span
-          class="badge badge-sm rounded-xl shadow"
-          :class="character.isPublic ? 'badge-success' : 'badge-warning'"
-        >
-          {{ character.isPublic ? 'Public' : 'Private' }}
-        </span>
-
-        <span
-          v-if="activeSelected"
-          class="badge badge-primary badge-sm rounded-xl shadow"
-        >
-          Selected
-        </span>
-      </div>
-
-      <div
-        v-if="activeSelected"
-        class="absolute right-2 top-2 rounded-full bg-primary p-2 text-primary-content shadow"
-      >
-        <Icon name="kind-icon:check" class="h-4 w-4" />
-      </div>
-
-      <footer class="absolute inset-x-0 bottom-0 p-3">
-        <h2
-          class="line-clamp-2 text-xl font-black leading-tight text-base-content drop-shadow"
-          :title="displayName"
-        >
-          {{ displayName }}
-        </h2>
-
-        <div v-if="showMeta" class="mt-2 flex flex-wrap gap-1">
-          <span
-            v-if="character.class"
-            class="badge badge-outline badge-sm rounded-xl border-base-content/30 bg-base-100/85 shadow backdrop-blur"
-          >
-            {{ character.class }}
-          </span>
-
-          <span
-            v-if="character.species"
-            class="badge badge-ghost badge-sm rounded-xl bg-base-100/85 shadow backdrop-blur"
-          >
-            {{ character.species }}
-          </span>
-
-          <span
-            v-if="character.genre"
-            class="badge badge-primary badge-sm rounded-xl bg-primary/90 shadow"
-          >
-            {{ character.genre }}
-          </span>
-        </div>
-      </footer>
-    </div>
-
-    <div
-      v-else
-      :class="[
-        'flex flex-col justify-end rounded-2xl border border-base-300 bg-linear-to-br from-primary/15 via-secondary/10 to-accent/15 p-3',
-        compact ? 'h-44 sm:h-48' : 'aspect-[2/3]',
-      ]"
-    >
-      <h2
-        class="line-clamp-2 text-xl font-black leading-tight text-base-content"
-        :title="displayName"
-      >
-        {{ displayName }}
-      </h2>
-
-      <div v-if="showMeta" class="mt-2 flex flex-wrap gap-1">
-        <span v-if="character.class" class="badge badge-outline badge-sm">
-          {{ character.class }}
-        </span>
-
-        <span v-if="character.species" class="badge badge-ghost badge-sm">
-          {{ character.species }}
-        </span>
-
-        <span v-if="character.genre" class="badge badge-primary badge-sm">
-          {{ character.genre }}
-        </span>
-      </div>
-    </div>
+    <kr-entity-card-body
+      :title="displayName"
+      :source="character"
+      variant="card"
+      :fallback="artFallbackSrc"
+      :show-image="showImage"
+      :show-description="false"
+      :compact="compact"
+      :selected="activeSelected"
+      :badges="badges"
+      :meta="showMeta ? metaChips : []"
+      shape="card"
+      compact-shape="hero"
+      :fit="imageFit"
+      placeholder-icon="kind-icon:user"
+    />
 
     <section
       v-if="
@@ -248,7 +160,8 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Character } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
-import { resolveArtImageSrc, resolveArtVariantSrc } from '@/utils/artImageSrc'
+import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -319,7 +232,6 @@ const artStore = useArtStore()
 
 const artImage = ref<ArtImage | null>(null)
 const activeMode = ref<CharacterMode | null>(null)
-const hasImageError = ref(false)
 
 const activeSelected = computed(() => {
   return (
@@ -358,27 +270,46 @@ const rotatingFallbackImage = computed(() => {
   return CHARACTER_FALLBACK_IMAGES[stableIndex]
 })
 
-const imageFitClass = computed(() => {
-  return props.imageFit === 'cover' ? 'object-cover' : 'object-contain'
+/*
+ * What the shared card body falls back to when the Character has no card
+ * variant rendered yet: the linked ArtImage's path or base64, then imagePath,
+ * then this character's stable rotating alien. kr-art-plate applies the
+ * cardPath/heroPath/iconPath half itself and handles the broken-URL retreat,
+ * so this file no longer needs its own hasImageError flag -- a card whose art
+ * 404s now lands on this chain, and only shows the placeholder icon if the
+ * chain's own last entry fails too.
+ */
+const artFallbackSrc = computed(() =>
+  resolveArtImageSrc(
+    artImage.value,
+    props.character.imagePath || rotatingFallbackImage.value,
+  ),
+)
+
+const badges = computed<EntityCardChip[]>(() => {
+  const result: EntityCardChip[] = [
+    props.character.isPublic
+      ? { label: 'Public', class: 'badge-success' }
+      : { label: 'Private', class: 'badge-warning' },
+  ]
+  if (activeSelected.value) {
+    result.push({ label: 'Selected', class: 'badge-primary' })
+  }
+  return result
 })
 
-const computedCharacterImage = computed(() => {
-  if (hasImageError.value) {
-    return rotatingFallbackImage.value
+const metaChips = computed<EntityCardChip[]>(() => {
+  const result: EntityCardChip[] = []
+  if (props.character.class) {
+    result.push({ label: props.character.class, class: 'badge-outline' })
   }
-
-  // The character's own purpose-built card art wins: it is rendered at card
-  // aspect for exactly this slot. Falls through to the old chain (art image
-  // path, its base64, imagePath, rotating fallback) for characters whose
-  // cardPath has not rendered yet.
-  return resolveArtVariantSrc(
-    props.character,
-    'card',
-    resolveArtImageSrc(
-      artImage.value,
-      props.character.imagePath || rotatingFallbackImage.value,
-    ),
-  )
+  if (props.character.species) {
+    result.push({ label: props.character.species, class: 'badge-ghost' })
+  }
+  if (props.character.genre) {
+    result.push({ label: props.character.genre, class: 'badge-primary' })
+  }
+  return result
 })
 
 const statRows = computed(() => [
@@ -393,10 +324,6 @@ const statRows = computed(() => [
   { key: 'might', label: 'Might', value: props.character.might || 'COMMON' },
   { key: 'wits', label: 'Wits', value: props.character.wits || 'COMMON' },
 ])
-
-function handleImageError() {
-  hasImageError.value = true
-}
 
 async function selectCharacter() {
   await characterStore.selectCharacter(props.character.id)
@@ -424,7 +351,6 @@ function toggleMode(mode: CharacterMode) {
 
 async function loadCharacterImage() {
   artImage.value = null
-  hasImageError.value = false
 
   if (!props.character.artImageId || !props.showImage) return
 

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -49,6 +49,7 @@
       :alt="title"
       :shape="compact ? compactShape : shape"
       frame="none"
+      :fit="fit"
       hover-zoom
       :placeholder-icon="placeholderIcon"
       class="rounded-xl"
@@ -192,6 +193,8 @@ withDefaults(
     meta?: EntityCardChip[]
     shape?: 'card' | 'hero' | 'wide' | 'plate'
     compactShape?: 'card' | 'hero' | 'wide' | 'plate'
+    /** 'contain' for portrait art whose edges matter (Characters). */
+    fit?: 'cover' | 'contain'
     placeholderIcon?: string
   }>(),
   {
@@ -209,6 +212,7 @@ withDefaults(
     meta: () => [],
     shape: 'wide',
     compactShape: 'hero',
+    fit: 'cover',
     placeholderIcon: 'kind-icon:image',
   },
 )

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -23,7 +23,8 @@
       :src="src"
       :alt="alt"
       :class="[
-        'h-full w-full object-cover',
+        'h-full w-full',
+        fit === 'contain' ? 'object-contain' : 'object-cover',
         hoverZoom ? 'transition-transform duration-300 group-hover:scale-105' : '',
       ]"
       :loading="eager ? 'eager' : 'lazy'"
@@ -81,6 +82,13 @@ const props = withDefaults(
      * so "unframed" has to mean genuinely unframed, not thinly framed.
      */
     frame?: 'plate' | 'thin' | 'none'
+    /**
+     * Portrait art with meaningful edges (a Character's full figure) wants
+     * 'contain' so nothing is cropped away; scene art wants 'cover' so it
+     * fills the frame. character-gallery and character-interact both ask for
+     * contain, which is why this is a prop and not a constant.
+     */
+    fit?: 'cover' | 'contain'
     /** The gallery-card lift: art scales slightly on the ancestor's :hover. */
     hoverZoom?: boolean
     eager?: boolean
@@ -93,6 +101,7 @@ const props = withDefaults(
     alt: '',
     shape: 'plate',
     frame: 'plate',
+    fit: 'cover',
     hoverZoom: false,
     eager: false,
     placeholderIcon: 'kind-icon:image',


### PR DESCRIPTION
Follows `scenario-card` in #1352. **`bot-card` 479 → 399**, **`character-card` 449 → 375**, and neither carries its own copy of the `cardPath`/`heroPath`/`iconPath` chain any more. The counter reads **3/5**.

`kr-art-plate` gains `fit` (`cover` | `contain`). Not speculative — `character-gallery` and `character-interact` both ask for `contain`, because a Character's portrait has meaningful edges and cropping cuts the figure off.

## Visible changes — the point, not a side effect

You asked for *"a single display that is consistent across galleries"*, so where bot and character diverged from scenario, they converge **on** scenario:

| | before | after |
|---|---|---|
| compact art | fixed `h-44 sm:h-48` | 16:9, scales with its column |
| art dimming | full-cover base-300 gradient | shared bottom scrim — the top of the art is no longer dimmed |
| meta chips | inside the art footer | the row below the art, where scenario's already were |
| badges | top-left | top-left (unchanged) |
| selected check | `top-2` | `top-9` |

That last row was a **live bug**, not just an inconsistency: `reactable-card` renders its actions row at `top-2`, so a selected bot or character card with actions visible was already overlapping them.

`character-card`'s `hasImageError` flag is gone — `kr-art-plate` owns the broken-URL retreat now. A card whose art 404s lands on the ArtImage → `imagePath` → rotating-alien chain, and only reaches the placeholder icon if the chain's own last entry fails too.

## Not migrated, and not for lack of time

**`dream-card`** is the full-bleed poster (`padded=false`, title over edge-to-edge art). **`reward-card`** is an icon tile whose title sits *below* a fixed-height box that is usually a centred icon rather than art — a caption-over-art title would sit on a placeholder for most rewards.

Both need a **title-placement decision** in the shared body rather than a mechanical port. Guessing at that shape is exactly how the caption-meta props got written and then deleted in #1352, so I'd rather name it than bolt it on. Tracked under `interface-vision/t-064`.

## Verification

- `npm run test` (vue-tsc) — clean
- `eslint` on all five touched files — clean
- `test:layout-contract`, `test:gallery-adoption`, `test:narrative-kit`, `test:facet-gallery`, `test:channel-content`, `test:nav-manifest` — pass; layout contract unchanged
- `npx nuxi build` — compiles; prerender stops at the missing `JWT_SECRET` in this environment, the documented expected condition
- Line-ending audit against `HEAD` — no CRLF drift
- Checked for orphaned identifiers after the template swap (`avatarFallback`, `loadedBotImage`, `botTheme`, `rotatingFallbackImage`) — all still referenced

## Needs eyes

**`/bots` and `/characters` on the preview**, both grid and compact. The five rows in that table are visible changes and no source-text contract can judge them. If the compact aspect change reads badly in a dense picker, that's the one to say so about — it's a one-line revert per card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_