### PR TITLE
layout: adopt kr-unbound on AppMaker and Wishmaster, ratchet root-surface 4->2

### DIFF
--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -2,9 +2,7 @@
 <!-- AppMaker (appmaker/t-004): browse the app fleet, create a new app
      (self-serve; server enforces caps), and jump into each app's project. -->
 <template>
-  <section
-    class="mx-auto h-full min-h-0 w-full max-w-6xl space-y-6 overflow-y-auto overscroll-contain p-4"
-  >
+  <section class="kr-unbound mx-auto max-w-6xl space-y-6 p-4">
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div>
         <p class="text-2xl font-bold">AppMaker</p>

--- a/components/pages/wishmaster-page.vue
+++ b/components/pages/wishmaster-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="kr-unbound gap-4 rounded-2xl border border-base-300 bg-base-100 p-4">
     <header class="flex items-start gap-3">
       <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary">
         <Icon name="kind-icon:wand" class="size-6" />

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -37,9 +37,7 @@
     "ghost-prop": [],
     "zero-scroll": [],
     "root-surface": [
-      "components/pages/appmaker-page.vue",
       "components/pages/memory-dungeon.vue",
-      "components/pages/wishmaster-page.vue",
       "pages/[...slug].vue"
     ]
   }


### PR DESCRIPTION
### Task
interface-vision/t-017 (Conductor): sweep the layout-contract allow-list to zero, daily-drivers first, admin last. (kind: software)

### What changed / what I produced
- `components/pages/appmaker-page.vue` and `components/pages/wishmaster-page.vue`: swapped the root wrapper's own `h-full min-h-0 ... overflow-y-auto` classes for `kr-unbound`.
- Both are single-context MDC mounts (`content/appmaker.md` → `:appmaker-page`, `content/wishmaster.md` → `:wishmaster-page`), rendered inside `pages/[...slug].vue`'s `.content-host`, which already carries `overflow-y-auto` and is the real scroll owner. Each page's own `overflow-y-auto` was a second, stacked scroll region — the same shape the `wallet-page.vue`/`giving-page.vue`/`mermaids-page.vue` sweeps earlier in this series fixed by adopting `kr-unbound`.
- `utils/scripts/layout-contract-baseline.json`: ratcheted `root-surface` from 4 entries to 2 (`components/pages/memory-dungeon.vue` and `pages/[...slug].vue` remain — both intentionally left for a separate bounded pass given size/special-shell risk).

### How I verified
- `npx tsx utils/scripts/verifyLayoutContract.ts` — root-surface: 4 → 2, no new violations in any other bucket.
- `npm run test` (`vue-tsc --noEmit`) — clean.
- Manually diffed both edits: `kr-unbound` (`flex w-full flex-col`, no overflow/height) preserves the existing `flex`/`w-full` behavior each section relied on; `gap-4` (wishmaster) and `space-y-6` (appmaker) both keep working under a flex column root.
- Not verified live in a browser (no reachable Nuxt dev server / DB in this sandbox) — worth a click on the Vercel preview per the project's own convention.

### Stakes
reversible

### Flags for Reviewer
- `memory-dungeon.vue` (1750 lines) and `pages/[...slug].vue` (the content-host shell itself) are the two remaining root-surface entries — left out of this bounded sweep deliberately; `pages/[...slug].vue` in particular needs care since it's the shared MDC router, not an ordinary page.

### Kaizen suggestion
`one-scroll` is now the only nonzero bucket (27 entries). `components/pages/conductor-page.vue` was flagged in a prior sweep's kaizen as a daily-driver offender (2202 lines, carries both a root-surface — now presumably resolved separately — and a one-scroll violation) deliberately deferred for its size; worth a dedicated bounded pass rather than folding into the general one-scroll sweep.

### Notes for reviewer
Picked up via this session's `select_role.py` → `role: worker` recommendation, `interface-vision/t-017` (already `status: ready`, claimed by an earlier session today that released it back after its own bounded sweep).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTALWFx3sDNnrWaBdHwvyC)_