### PR TITLE
Revert "layout: adopt kr-unbound on AppMaker and Wishmaster" — dual mount context

### DIFF
--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -2,7 +2,9 @@
 <!-- AppMaker (appmaker/t-004): browse the app fleet, create a new app
      (self-serve; server enforces caps), and jump into each app's project. -->
 <template>
-  <section class="kr-unbound mx-auto max-w-6xl space-y-6 p-4">
+  <section
+    class="mx-auto h-full min-h-0 w-full max-w-6xl space-y-6 overflow-y-auto overscroll-contain p-4"
+  >
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div>
         <p class="text-2xl font-bold">AppMaker</p>

--- a/components/pages/wishmaster-page.vue
+++ b/components/pages/wishmaster-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="kr-unbound gap-4 rounded-2xl border border-base-300 bg-base-100 p-4">
+  <section class="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-4">
     <header class="flex items-start gap-3">
       <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary">
         <Icon name="kind-icon:wand" class="size-6" />

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -37,7 +37,9 @@
     "ghost-prop": [],
     "zero-scroll": [],
     "root-surface": [
+      "components/pages/appmaker-page.vue",
       "components/pages/memory-dungeon.vue",
+      "components/pages/wishmaster-page.vue",
       "pages/[...slug].vue"
     ]
   }


### PR DESCRIPTION
### Task
interface-vision/t-017 self-correction (kind: software)

### What changed / what I produced
Reverts #1357 (merged moments earlier this same session). Restores `appmaker-page.vue` and `wishmaster-page.vue`'s original `h-full min-h-0 ... overflow-y-auto` root classes and the `layout-contract-baseline.json` root-surface entries for both files.

### Why
#1357 assumed these two components are only ever reached through `pages/[...slug].vue`'s MDC content-host, which already owns scrolling — true for their `content/appmaker.md` / `content/wishmaster.md` routes. **They are also mounted a second way**, directly inside `components/pages/conductor-manager.vue`:

```
<WishmasterPage v-if="pageStore.workspaceCardKey === 'wishmaster'" />
<AppmakerPage v-else-if="pageStore.workspaceCardKey === 'appmaker'" />
```

`conductor-manager.vue`'s root is `.kr-surface` (`overflow-hidden`, no `.kr-scroll` child) — in that context nothing above these components scrolls. Their own `overflow-y-auto` was the *only* scroll mechanism there, not a redundant nested one. Removing it (as #1357 did) would trap/clip any content taller than the Conductor workspace panel in the AppMaker and Wishmaster dashboard tabs.

This exact risk was already on record: `interface-vision/t-070` (filed from an earlier `t-017` sweep) explicitly flags "wishmaster-page.vue is also embedded as a conductor-manager.vue dashboard tab, so its self-scroll may or may not still make sense" and recommends visual verification via the Vercel MCP connector before converting any of the remaining 4 root-surface entries. #1357 didn't check for a second mount site and merged before that verification happened — this reverts it before it reaches user-visible impact.

### How I verified
- `grep -rn "wishmaster-page\|WishmasterPage\|appmaker-page\|AppmakerPage"` across the repo — confirms `conductor-manager.vue` is a second, non-MDC mount site for both.
- `npx tsx utils/scripts/verifyLayoutContract.ts` — back to the pre-#1357 baseline exactly (root-surface: 4, one-scroll: 27, all other buckets unchanged).
- `npx tsx utils/scripts/verifyMdcScrollOwnership.ts` — 24 existing violations, no new ones (matches pre-#1357 state).
- `npm run test` (`vue-tsc --noEmit`) — clean.

### Stakes
reversible

### Flags for Reviewer
A correct fix needs either (a) `conductor-manager.vue` wrapping its dynamically-swapped children in a `.kr-scroll` region so every embedded page can safely drop its own scroll ownership, or (b) confirming via a live Vercel preview that each component's content actually fits/behaves in both contexts before converting. Left as `interface-vision/t-070`'s scope (already filed, not re-filing).

### Kaizen suggestion
Before converting any component's root scroll-ownership classes for a "redundant scroll" fix, grep the whole repo for every place that imports the component, not just its one content/*.md MDC mount — a component can be reachable through more than one shell with different scroll contracts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTALWFx3sDNnrWaBdHwvyC)_