### PR TITLE
facets: consolidate FacetKind derivation onto legacyFacetKindForTaxonomy (t-016)

### DIFF
--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -666,7 +666,7 @@ const locationOptions = computed<NarrativeIngredientOption[]>(() =>
     })),
 )
 
-const creativeFacetKinds = new Set([
+const creativeFacetTaxonomies = new Set([
   'GENRE',
   'CORE',
   'THEME',
@@ -676,7 +676,7 @@ const creativeFacetKinds = new Set([
 ])
 const facetOptions = computed<NarrativeIngredientOption[]>(() =>
   facetStore.activeFacets
-    .filter((facet) => creativeFacetKinds.has(facet.kind) && facet.slug)
+    .filter((facet) => creativeFacetTaxonomies.has(facet.taxonomy) && facet.slug)
     .map((facet) => ({
       id: facet.id,
       slug: facet.slug || String(facet.id),

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -659,10 +659,10 @@ const locationOptions = computed<NarrativeIngredientOption[]>(() =>
   })),
 )
 
-const storyGrammarKinds = new Set(['GENRE', 'CORE', 'THEME', 'MOOD', 'STYLE'])
+const storyGrammarTaxonomies = new Set(['GENRE', 'CORE', 'THEME', 'MOOD', 'STYLE'])
 const grammarFacets = computed(() =>
   facetStore.activeFacets.filter(
-    (facet) => storyGrammarKinds.has(facet.kind) && facet.slug,
+    (facet) => storyGrammarTaxonomies.has(facet.taxonomy) && facet.slug,
   ),
 )
 

--- a/stores/facetStore.ts
+++ b/stores/facetStore.ts
@@ -11,7 +11,6 @@ export type FacetWithAliases = Pick<
   | 'id'
   | 'title'
   | 'slug'
-  | 'kind'
   | 'description'
   | 'flavorText'
   | 'examples'

--- a/utils/scripts/applyFacetCatalogDirectives.ts
+++ b/utils/scripts/applyFacetCatalogDirectives.ts
@@ -5,6 +5,7 @@ import {
   type FacetTaxonomy,
 } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { legacyFacetKindForTaxonomy } from './../../server/utils/facetProfileInput'
 import { normalizeFacetLookupKey } from './../facetAliases'
 
 const databaseUrl = process.env.DATABASE_URL
@@ -702,7 +703,7 @@ async function reclassifyArtAtmospheres(): Promise<object[]> {
         where: { id: facet.id },
         data: {
           title: definition.title,
-          kind: 'ART_DIRECTION',
+          kind: legacyFacetKindForTaxonomy('ART_DIRECTION'),
           isActive: true,
         },
       })
@@ -770,7 +771,7 @@ async function reclassifyNarrativeTones(): Promise<object[]> {
     if (apply) {
       await prisma.facet.update({
         where: { id: facet.id },
-        data: { kind: 'THEME', isActive: true },
+        data: { kind: legacyFacetKindForTaxonomy('THEME'), isActive: true },
       })
       await prisma.facetProfile.upsert({
         where: { facetId: facet.id },

--- a/utils/scripts/curateFacetCatalog.ts
+++ b/utils/scripts/curateFacetCatalog.ts
@@ -6,6 +6,7 @@ import {
   type FacetTaxonomy,
 } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { legacyFacetKindForTaxonomy } from './../../server/utils/facetProfileInput'
 import {
   FACET_CURATION_BATCHES,
   type CuratedFacetDefinition,
@@ -106,22 +107,6 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 255)
-}
-
-function legacyKind(taxonomy: FacetTaxonomy): FacetKind {
-  const direct: Partial<Record<FacetTaxonomy, FacetKind>> = {
-    GENRE: 'GENRE',
-    ANIMAL: 'ANIMAL',
-    COLOR: 'COLOR',
-    THEME: 'THEME',
-    CORE: 'CORE',
-    MOOD: 'MOOD',
-    STYLE: 'STYLE',
-    SETTING: 'SETTING',
-    ART_DIRECTION: 'ART_DIRECTION',
-    PROMPT_ENHANCEMENT: 'ART_DIRECTION',
-  }
-  return direct[taxonomy] ?? 'OTHER'
 }
 
 function parseMetadata(value: string | null | undefined): JsonObject {
@@ -299,7 +284,7 @@ async function ensureFacet(
       data: {
         title: definition.title,
         slug: definition.slug,
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         description: definition.description,
         designer: 'facet-curation',
         creationSource: 'HUMAN',
@@ -320,7 +305,7 @@ async function ensureFacet(
     facet = await prisma.facet.update({
       where: { id: facet.id },
       data: {
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         description: facet.description || definition.description,
         designer: facet.designer || 'facet-curation',
         isActive: true,
@@ -425,7 +410,7 @@ async function applyTransform(
     facet = await prisma.facet.update({
       where: { id: facet.id },
       data: {
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         designer: facet.designer || 'facet-curation',
         isActive: true,
       },

--- a/utils/scripts/curateFacetGenreLeaks.ts
+++ b/utils/scripts/curateFacetGenreLeaks.ts
@@ -6,6 +6,7 @@ import {
   type FacetTaxonomy,
 } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { legacyFacetKindForTaxonomy } from './../../server/utils/facetProfileInput'
 import { normalizeFacetLookupKey } from './../facetAliases'
 
 const databaseUrl = process.env.DATABASE_URL
@@ -132,22 +133,6 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 255)
-}
-
-function legacyKind(taxonomy: FacetTaxonomy): FacetKind {
-  const direct: Partial<Record<FacetTaxonomy, FacetKind>> = {
-    GENRE: 'GENRE',
-    ANIMAL: 'ANIMAL',
-    COLOR: 'COLOR',
-    THEME: 'THEME',
-    CORE: 'CORE',
-    MOOD: 'MOOD',
-    STYLE: 'STYLE',
-    SETTING: 'SETTING',
-    ART_DIRECTION: 'ART_DIRECTION',
-    PROMPT_ENHANCEMENT: 'ART_DIRECTION',
-  }
-  return direct[taxonomy] ?? 'OTHER'
 }
 
 function parseMetadata(value: string | null | undefined): JsonObject {
@@ -354,7 +339,7 @@ async function ensureComponent(definition: EnsureDefinition): Promise<FacetRow |
       data: {
         title: definition.title,
         slug: definition.slug,
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         description: definition.description,
         designer: 'facet-curation',
         creationSource: 'HUMAN',
@@ -375,7 +360,7 @@ async function ensureComponent(definition: EnsureDefinition): Promise<FacetRow |
       where: { id: facet.id },
       data: {
         title: definition.title,
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         description: facet.description || definition.description,
         isActive: true,
       },

--- a/utils/scripts/curateFacetTaxonomyLeaks.ts
+++ b/utils/scripts/curateFacetTaxonomyLeaks.ts
@@ -6,6 +6,7 @@ import {
   type FacetTaxonomy,
 } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { legacyFacetKindForTaxonomy } from './../../server/utils/facetProfileInput'
 import { normalizeFacetLookupKey } from './../facetAliases'
 
 const databaseUrl = process.env.DATABASE_URL
@@ -148,22 +149,6 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 255)
-}
-
-function legacyKind(taxonomy: FacetTaxonomy): FacetKind {
-  const direct: Partial<Record<FacetTaxonomy, FacetKind>> = {
-    GENRE: 'GENRE',
-    ANIMAL: 'ANIMAL',
-    COLOR: 'COLOR',
-    THEME: 'THEME',
-    CORE: 'CORE',
-    MOOD: 'MOOD',
-    STYLE: 'STYLE',
-    SETTING: 'SETTING',
-    ART_DIRECTION: 'ART_DIRECTION',
-    PROMPT_ENHANCEMENT: 'ART_DIRECTION',
-  }
-  return direct[taxonomy] ?? 'OTHER'
 }
 
 function parseMetadata(value: string | null | undefined): JsonObject {
@@ -328,7 +313,7 @@ async function transformFacet(definition: TransformDefinition): Promise<object> 
   if (apply) {
     await prisma.facet.update({
       where: { id: facet.id },
-      data: { kind: legacyKind(definition.taxonomy), isActive: true },
+      data: { kind: legacyFacetKindForTaxonomy(definition.taxonomy), isActive: true },
     })
     await writeProfile({
       facet,
@@ -398,7 +383,7 @@ async function ensureExactFacet(definition: EnsureDefinition): Promise<FacetRow 
       data: {
         title: definition.title,
         slug: definition.slug,
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         designer: 'facet-curation',
         creationSource: 'HUMAN',
         userId: 1,
@@ -418,7 +403,7 @@ async function ensureExactFacet(definition: EnsureDefinition): Promise<FacetRow 
       where: { id: facet.id },
       data: {
         title: definition.title,
-        kind: legacyKind(definition.taxonomy),
+        kind: legacyFacetKindForTaxonomy(definition.taxonomy),
         isActive: true,
       },
     })

--- a/utils/scripts/seedArtBuilderFacetCatalog.ts
+++ b/utils/scripts/seedArtBuilderFacetCatalog.ts
@@ -2,8 +2,9 @@
 import 'dotenv/config'
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { PrismaClient, type FacetKind } from './../../prisma/generated/prisma/client'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { legacyFacetKindForTaxonomy } from './../../server/utils/facetProfileInput'
 import { ART_CARDS } from './../../stores/helpers/artCards'
 import type { BuilderChoice } from './../../stores/helpers/builderCards'
 import {
@@ -73,12 +74,6 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 180)
-}
-
-function legacyKind(taxonomy: Taxonomy): FacetKind {
-  if (taxonomy === 'ART_DIRECTION') return 'ART_DIRECTION'
-  if (taxonomy === 'STYLE') return 'STYLE'
-  return 'MOOD'
 }
 
 function metadataRecord(value: unknown): Record<string, unknown> {
@@ -302,7 +297,7 @@ async function saveCandidate(candidate: Candidate, state: CatalogState): Promise
         data: {
           title: candidate.title,
           slug,
-          kind: legacyKind(candidate.taxonomy),
+          kind: legacyFacetKindForTaxonomy(candidate.taxonomy),
           description: candidate.description,
           imagePath: candidate.imagePath,
           designer: 'facet-catalog',

--- a/utils/scripts/seedFacetCatalog.ts
+++ b/utils/scripts/seedFacetCatalog.ts
@@ -1,10 +1,8 @@
 // /utils/scripts/seedFacetCatalog.ts
 import 'dotenv/config'
-import {
-  PrismaClient,
-  type FacetKind,
-} from './../../prisma/generated/prisma/client'
+import { PrismaClient } from './../../prisma/generated/prisma/client'
 import { createDatabaseAdapter } from './../../server/utils/databaseAdapterConfig'
+import { legacyFacetKindForTaxonomy } from './../../server/utils/facetProfileInput'
 import { ADVENTURE_CARDS } from './../../stores/helpers/adventureCards'
 import { animalDataList } from './../../stores/utils/animalData'
 import { artListPresets } from './../../stores/seeds/artList'
@@ -87,22 +85,6 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 255)
-}
-
-function legacyKind(taxonomy: Taxonomy): FacetKind {
-  const direct: Partial<Record<Taxonomy, FacetKind>> = {
-    GENRE: 'GENRE',
-    ANIMAL: 'ANIMAL',
-    COLOR: 'COLOR',
-    THEME: 'THEME',
-    CORE: 'CORE',
-    MOOD: 'MOOD',
-    STYLE: 'STYLE',
-    SETTING: 'SETTING',
-    ART_DIRECTION: 'ART_DIRECTION',
-    PROMPT_ENHANCEMENT: 'ART_DIRECTION',
-  }
-  return direct[taxonomy] ?? 'OTHER'
 }
 
 function classTaxonomy(value: string): Taxonomy {
@@ -541,7 +523,7 @@ async function createOrRecoverFacet(
       data: {
         title: candidate.title,
         slug,
-        kind: legacyKind(candidate.taxonomy),
+        kind: legacyFacetKindForTaxonomy(candidate.taxonomy),
         description: candidate.description,
         imagePath: candidate.imagePath,
         icon: candidate.icon,
@@ -569,7 +551,7 @@ async function createOrRecoverFacet(
       where: { id: winner.id },
       data: {
         title: candidate.title,
-        kind: legacyKind(candidate.taxonomy),
+        kind: legacyFacetKindForTaxonomy(candidate.taxonomy),
         description: candidate.description || winner.description,
         imagePath: candidate.imagePath || winner.imagePath,
         icon: candidate.icon || winner.icon,
@@ -599,7 +581,7 @@ async function saveCandidate(
         data: {
           title: candidate.title,
           slug,
-          kind: legacyKind(candidate.taxonomy),
+          kind: legacyFacetKindForTaxonomy(candidate.taxonomy),
           description: candidate.description || existingFacet.description,
           imagePath: candidate.imagePath || existingFacet.imagePath,
           icon: candidate.icon || existingFacet.icon,

--- a/utils/scripts/verifyFacetTaxonomyAuthority.ts
+++ b/utils/scripts/verifyFacetTaxonomyAuthority.ts
@@ -122,15 +122,8 @@ async function main(): Promise<void> {
   requireText(files.manager, text.manager, 'taxonomyLabel(facet.taxonomy)')
   forbidText(files.manager, text.manager, 'facet.kind')
 
-  // One bounded compatibility consumer remains until the physical Facet.kind
-  // column is dropped: Taskmaster uses only five broad values for which the
-  // server-derived compatibility kind is exactly equal to taxonomy.
-  requireText(
-    files.taskmaster,
-    text.taskmaster,
-    "const storyGrammarKinds = new Set(['GENRE', 'CORE', 'THEME', 'MOOD', 'STYLE'])",
-  )
-  requireText(files.taskmaster, text.taskmaster, 'storyGrammarKinds.has(facet.kind)')
+  requireText(files.taskmaster, text.taskmaster, 'storyGrammarTaxonomies.has(facet.taxonomy)')
+  forbidText(files.taskmaster, text.taskmaster, 'facet.kind')
   forbidText(files.taskmaster, text.taskmaster, 'serendipity')
 
   process.stdout.write(


### PR DESCRIPTION
### Task
interface-vision/t-016: Decide FacetKind vs FacetTaxonomy (kind: software)

Silas decided FacetTaxonomy is canonical (2026-08-03). A prior PR already made
`FacetProfile.taxonomy` authoritative and turned `Facet.kind` into a
write-derived compatibility column (`legacyFacetKindForTaxonomy` in
`server/utils/facetProfileInput.ts`) — API routes already derive `kind` from
`taxonomy` and reject client-supplied `kind`. What remained was narrower than
the task description implied: finish consolidating the last few call sites
that reimplemented or hardcoded the derivation instead of using the shared
helper.

### What changed / what I produced
- `curateFacetGenreLeaks.ts`, `curateFacetTaxonomyLeaks.ts`,
  `curateFacetCatalog.ts`, `seedFacetCatalog.ts`,
  `seedArtBuilderFacetCatalog.ts`: dropped 5 duplicated local `legacyKind()`
  functions (three byte-identical, two narrower subsets), all now import and
  call `legacyFacetKindForTaxonomy` from `facetProfileInput.ts`.
- `applyFacetCatalogDirectives.ts`: the two hardcoded literal writes
  (`kind: 'ART_DIRECTION'`, `kind: 'THEME'`) now derive via
  `legacyFacetKindForTaxonomy(...)` instead of bypassing the mapping entirely.
- `storybook-page.vue`, `taskmaster-page.vue`: the last two front-end
  consumers branching directly on `facet.kind` (`creativeFacetKinds`,
  `storyGrammarKinds`) now filter on `facet.taxonomy` instead — identical
  value sets, since `kind === taxonomy` for every value either set checks.
- `stores/facetStore.ts`: `FacetWithAliases` no longer `Pick`s the deprecated
  `kind` column (no remaining client consumer needs it).
- `verifyFacetTaxonomyAuthority.ts`: dropped the now-obsolete Taskmaster
  compatibility carve-out (it required the exact old `facet.kind` text to
  exist) and asserts the new taxonomy-based text instead.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on all 10 touched files — clean.
- Ran the full `facet-catalog-contract.yml` script sequence locally against a
  local MariaDB (via `provision_kind_robots_deps.sh`): `test:facet-catalog`
  (prisma validate + cutover + canonical-merges + daily-dream-facets),
  `verifyFacetTaxonomyAuthority`, `verifyFacetCatalogCutover`,
  `verifyModelBuilderFacetSync`, `verifyFacetCuration`,
  `verifyFacetHouseGenres`, `verifyFacetCulturalGenres`,
  `verifyFacetPersonalitySynonyms`, `verifyFacetTaxonomyLeaks`,
  `verifyFacetGenreLeaks`, `verifyFacetPersonalityFamilies`,
  `verifyFacetCatalogDirectives`, `verifyFacetCatalogMaintenance`,
  `verifyFacetCatalogAudit`, `verifyFacetSeedSlugSerialization`,
  `verifyScenarioGenreFacetCutover`, `verifyBotFacetCutover`,
  `verifySystemOptionFacetCutover`, `test:facet-gallery`,
  `test:facet-closure` — all pass (the three genre/bot/reward cutover scripts
  print a pre-existing, unrelated "known artwork debt" list of missing
  `public/images/*` files — exit 0, reproduces on a clean checkout since
  `public/images/` is empty in this sandbox).
- `grep -rn "facet\.kind\b"` across the repo confirms no remaining front-end
  or store consumer reads `.kind` directly; the only surviving raw-column
  reads are legitimate audit/repair tooling (`triageFacetAudit.ts`,
  `repairFacetProfiles.ts`) and the server-side read layer
  (`facetCatalog.ts`, `facetAssignments.ts`'s missing-`FacetProfile`
  fallback), none of which this PR touches.

### Stakes
reversible

### Flags for Reviewer
- This is the **low-risk half only**. Dropping the physical `Facet.kind`
  column/index (`schema.prisma:478`, migration modeled on
  `20260727022500_facet_taxonomy_authority`) is a separate, higher-risk
  production `DROP COLUMN` migration that needs a live DB check first (every
  `Facet` row must have a `FacetProfile`, via `repairFacetProfiles.ts`) —
  filed as a follow-up task rather than attempted here, since I have no
  production DB access from this sandbox to verify that precondition.
- Not run: `verifyFacetBuilderCoverage.ts` / `verifyFacetArtworkMigration.ts`
  (the two CI steps gated on real art assets) — unrelated to this diff and
  meaningless against an empty local DB/`public/images/`, left for CI.

### Kaizen suggestion
File the column-drop as its own gated task once `repairFacetProfiles.ts
--apply` has been confirmed run in production (or a migration-time backfill
is added) — that's the actual precondition for ever trusting a pure
`taxonomy -> kind` derivation with the physical column gone.

### Notes for reviewer
Merging this closes out interface-vision/t-016's remaining scope; the
column-drop follow-up will be filed as a new task rather than folded back
into t-016.


---
_Generated by [Claude Code](https://claude.ai/code/session_012FFSRUAtZU9w2GWWVNLhqT)_