### PR TITLE
build: enable Vercel previews for claude/* branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
   ],
   "git": {
     "deploymentEnabled": {
-      "claude/*": false,
+      "claude/*": true,
       "agent/*": false,
       "worker/*": false,
       "conductor/*": false


### PR DESCRIPTION
Silas, asked what he could do to unblock agent UI verification:

> "how do i flip it? I approve it happening"

## The problem

`vercel.json`'s `git.deploymentEnabled` had `claude/*` set to `false`, so **no preview deployment ever built for an agent-authored branch**. The practical effect is that front-end work could only be inspected *after* it merged to production — backwards for UI changes.

This has now cost real work. `interface-vision/t-069` (project description text rendering over the card art on `/conductor`, from the UI review screenshot) could not be visually checked at all this session, and went back unverified with only a list of ruled-out causes. Guessing at a CSS fix for the most-used page in the app wasn't an acceptable substitute.

## The change

One line: `claude/*` → `true`.

`agent/*`, `worker/*`, and `conductor/*` stay `false`, so the original cost saving is preserved for the prefixes that don't produce visual work. And `vercel.json`'s existing `ignoreCommand` (`scripts/vercel-ignore-build.mjs`) already skips any build whose changed files are all docs or tests — so this doesn't spend a build on log-only or roadmap-only branches either.

## Companion change

`AGENTS.md` in the conductor repo is corrected alongside this. It asserted "Vercel already builds a preview for every PR automatically", which was false for every agent branch and sent at least one session hunting for a deployment that could never exist. It now states that `git.deploymentEnabled` in this file — not Vercel's defaults — decides, names which prefixes are enabled, and documents the post-merge production fallback for the ones that aren't. `interface-vision/t-040`, which existed only to document the exclusion, closes as resolved-by-removing-the-cause.

Also recorded there: a docs-only merge shows as `CANCELED` rather than deploying, because of that same `ignoreCommand`. That's correct behavior, and it had already been misread as a failed deploy once.

## Verification

`vercel.json` parses as valid JSON. The real proof is this PR itself — if a preview deployment appears for it, the flag works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_