### PR TITLE
docs(layout): clarify literal root-tag contract

### DIFF
--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -126,6 +126,10 @@ function countMatches(haystack: string, pattern: RegExp): number {
   return (haystack.match(pattern) ?? []).length
 }
 
+/*
+ * This checks the literal first element inside <template>, not whichever nested
+ * wrapper looks visually dominant. Put the kr-* marker on that opening tag.
+ */
 function rootClassList(template: string): string | null {
   const root = template.match(/<template\b[^>]*>([\s\S]*)<\/template>/)?.[1]?.trim()
   const openingTag = root?.match(/^<([a-z][\w-]*)\b([^>]*)>/)


### PR DESCRIPTION
## Summary
- document that `rootClassList()` inspects the literal first element inside `<template>`
- direct future layout sweeps to place the `kr-*` marker on that opening tag, not a visually dominant nested wrapper

## Conductor handoff
- Project: `interface-vision`
- Task: `t-067`
- Session: `2026-08-03T111341Z-interface-vision-t-067-b4n8`
- Scope is documentation-only inside the existing verifier; no runtime behavior changes.

## Verification
- CI should run TypeScript, Contract Tests, and Layout Contract on the exact PR head.