### PR TITLE
layout: adopt kr-surface/kr-scroll on memory-dungeon.vue

### DIFF
--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -1,12 +1,7 @@
 <!-- /components/content/story/memory-dungeon.vue -->
+<!-- root div -->
 <template>
-  <!-- root div -->
-  <div
-    class="flex h-full min-h-[80vh] select-none flex-col bg-base-200"
-    :class="
-      gameStarted ? 'overflow-hidden' : 'overflow-y-auto overscroll-contain'
-    "
-  >
+  <div class="kr-surface min-h-[80vh] select-none gap-0 bg-base-200">
     <header
       v-if="gameStarted"
       class="z-10 flex shrink-0 flex-wrap items-center justify-between gap-3 bg-base-300 px-4 pb-3 pt-4 shadow-md"
@@ -153,7 +148,7 @@
     <!-- ─── SPLASH SCREEN (pre-game takeover) ───────────────── -->
     <div
       v-if="!gameStarted"
-      class="splash-screen relative flex min-h-full flex-1 flex-col overflow-visible bg-black"
+      class="splash-screen kr-scroll relative flex min-h-full flex-col bg-black"
     >
       <div
         class="splash-hero relative flex min-h-[58svh] flex-col overflow-hidden sm:min-h-[64svh] lg:min-h-[70svh]"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -36,8 +36,6 @@
     "one-mdc": [],
     "ghost-prop": [],
     "zero-scroll": [],
-    "root-surface": [
-      "components/pages/memory-dungeon.vue"
-    ]
+    "root-surface": []
   }
 }


### PR DESCRIPTION
### Task
interface-vision/t-017: Sweep the layout-contract allow-list to zero, daily-drivers first, admin last (kind: software)

### What changed / what I produced
- `components/pages/memory-dungeon.vue`'s root div previously mixed bounding and scroll ownership on the same element, toggling `overflow-hidden`/`overflow-y-auto overscroll-contain` based on `gameStarted`. Its only mount site — `lab-manager.vue`'s dashboard-tab wrapper (`<memory-dungeon class="h-full min-h-0 flex-1 overflow-hidden" />`) — already applies a fallthrough `overflow-hidden` with no scroll delegation, so the pre-existing conditional binding on the root was fighting that fallthrough class rather than cooperating with it.
- Root now stays unconditionally `kr-surface` (bounded, never scrolls) — `min-h-[80vh]` and `gap-0` added alongside it to preserve the original min-height and (lack of) inter-child spacing exactly.
- The splash-screen child (the pre-game takeover, the one region that needs to grow past the viewport) becomes the `kr-scroll` owner instead of `overflow-visible`, replacing the ambiguous root-level toggle with an unambiguous, self-contained scroll owner.
- The in-game board+log layout already owns its own scroll further down the tree (`boardPanel`/`logPanel`/action-log footer) and is untouched.
- Moved the `<!-- root div -->` comment from between `<template>` and the root tag to above `<template>` — it was defeating `verifyLayoutContract.ts`'s literal-first-tag `root-surface` check, the exact footgun documented on interface-vision/t-067.
- `root-surface: 1 -> 0` via `--update`. This was the last non-`one-scroll` entry in the layout-contract allow-list; `one-scroll` (27) remains, tracked separately per interface-vision/t-047's correction (most of that bucket needs either a verifier fix for false-positive mutually-exclusive-branch detection or a new two-column-scroll primitive, not a per-file conversion).

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint components/pages/memory-dungeon.vue` — same 5 pre-existing errors present on `main` via `git stash` (unused import/duplicate import/unused var), none introduced by this change
- `npm run test:layout-contract` — holds, root-surface -1, all other buckets unchanged; ran `--update` to ratchet the baseline
- `npx tsx utils/scripts/verifyMdcScrollOwnership.ts` — holds, 22 existing violations, no new ones across 59 mounted component tags
- Confirmed `memory-dungeon.vue` has exactly one mount site repo-wide (`content/play/memory.md` → `lab-manager.vue`'s `dashboardTab: memory-dungeon` branch) before relying on that context's `overflow-hidden` wrapper in the reasoning above — the same "grep every importer, not just the one MDC mount" check interface-vision/t-070's lesson calls for after PR #1357's revert.

### Stakes
reversible

### Kaizen suggestion
`interface-vision/t-047`'s correction found the `one-scroll` bucket's SHAPE A group (~10 files with mutually-exclusive `v-if`/`v-else-if`/`v-show` tab branches, each declaring its own scroll but only ever one mounted at a time, `art-manager.vue` the type specimen) is a static-regex false positive, not a runtime bug — fixable by hoisting one shared `.kr-scroll` above the branch. No task currently tracks this fix; worth filing one.

### Notes for reviewer
This is the twenty-fifth sweep in interface-vision/t-017's series (conductor roadmap has the full history). This was the one entry three prior sessions explicitly deferred pending real visual verification / due to connector whole-file-replacement limits on a 1750-line component — this session had full local git/shell access to kind_robots, which is what made the careful CSS-cascade reasoning above (rather than a guess) practical.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CytmXsQ7AWy4UKSUQUVdV)_