### PR TITLE
feat: materialize Conductor coordination in Kind Robots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,10 @@ section docs. Prefer, in order:
 4. A new top-level channel — **only with Silas's approval.**
 
 Avoid duplicate or decorative routes, tabs, pages, and managers. A surface isn't finished
-when it renders: it may also need dashboard/tutorial registration, artwork,
-`liveUrl`/`channelKey`/`tabKey` set, Conductor sync, and direct-load, refresh, mobile,
-typecheck, and preview checks.
+when it renders: it may also need dashboard/tutorial registration, artwork, and the matching
+Kind Robots `Project.liveUrl` / `channelKey` / `tabKey` presentation fields, plus direct-load,
+refresh, mobile, typecheck, and preview checks. These presentation fields belong here, not in
+Conductor's lifecycle registry.
 
 ## Art generation
 
@@ -110,12 +111,44 @@ near-copy. Highest-risk areas:
 - stores
 - API contracts
 
-## Project identity
+## Project identity and source of truth
 
-Every Conductor project has a matching Kind Robots `Project` record, joined by
-`Project.conductorSlug`. The Conductor `roadmap.yaml` is the authoritative task record; the
-Kind Robots `Project` is the authoritative display/identity record. Don't add redundant FK
-fields and don't create a second source of project truth.
+Read `docs/conductor-projection.md` before changing cross-repository project data.
+
+Every Conductor project has a matching Kind Robots `Project` record, joined only by
+`Project.conductorSlug`. Do not add a redundant cross-repository foreign key.
+
+**Conductor owns coordination:**
+
+- lifecycle and coordination priority;
+- roadmap tasks and milestones;
+- dependencies, claims, owners, notes, and passes;
+- human gates and approvals;
+- pitches and coordination provenance.
+
+**Kind Robots owns presentation and application state:**
+
+- Project title and user-facing description;
+- route, channel, tab, live URL, and displayed repository URL;
+- project artwork;
+- user state, conversations, runtime queues, ArtJobs, payments, grants, and all other
+  application data.
+
+Kind Robots stores Conductor coordination as a commit-stamped materialized read projection.
+The projection is a cache, not a second authority. Never write projected task or milestone
+state directly in this database. Human actions from the Kind Robots UI must emit a Conductor
+task event or pitch update; canonical completion occurs only after Conductor commits the
+change and the next projection sync returns that exact commit.
+
+The projection sync may update only coordination fields on an existing `Project`: status,
+priority, `conductorSlug` when missing, and `lastSyncedAt`. It must not overwrite title,
+description, routes, placement, URLs, or artwork. Legacy presentation values in Conductor
+`project-overrides.yaml` are bootstrap fallbacks for missing Project rows only. Do not add new
+`liveUrl`, `channelKey`, `tabKey`, or `repoUrl` values there.
+
+When the repositories disagree, Conductor wins for coordination fields and Kind Robots wins
+for presentation/application fields. Repair the event or projection path instead of editing
+both sides until they happen to match.
 
 ## Verifying your work
 

--- a/docs/conductor-projection.md
+++ b/docs/conductor-projection.md
@@ -1,0 +1,76 @@
+# Conductor projection in Kind Robots
+
+Kind Robots does not independently own roadmap or human-gate state. It stores a materialized read projection of the canonical Conductor repository so application pages can read coordination data quickly and reliably without fetching dozens of GitHub files on every request.
+
+## Authority
+
+| Data | Authority |
+|---|---|
+| Project lifecycle and coordination priority | Conductor |
+| Roadmap tasks, milestones, dependencies, claims, gates, notes, and pitches | Conductor |
+| Project title, description, route, channel, tab, URLs, and artwork | Kind Robots `Project` |
+| User state, runtime queues, ArtJobs, payments, grants, and application data | Kind Robots |
+
+`Project.conductorSlug` is the cross-repository join key.
+
+## Data flow
+
+```text
+Conductor main commit
+  -> scripts/sync_kind_robots_projection.py
+  -> POST /api/conductor/sync
+  -> ConductorProjection singleton row
+  -> GET /api/conductor/projects
+  -> For You and project planning surfaces
+```
+
+The snapshot contains the exact source commit SHA, lifecycle registry, raw roadmap text, pitch text, and image versions. Kind Robots validates the complete payload before replacing the last known good snapshot.
+
+Human decisions travel back as commands, not database edits:
+
+```text
+Kind Robots human action
+  -> Conductor task event or pitch update
+  -> committed Conductor state
+  -> next projection snapshot
+  -> Kind Robots read view
+```
+
+An optimistic browser update is temporary feedback. It is not canonical completion until Conductor commits the transition and that commit is projected back.
+
+## Project update behavior
+
+The sync endpoint updates only coordination fields on an existing `Project`:
+
+- `conductorSlug`, when missing;
+- `status`;
+- `priority`;
+- `lastSyncedAt`.
+
+It never overwrites an existing Project's title, description, route, channel, tab, URLs, or artwork.
+
+For a missing Project row, legacy presentation values from Conductor may seed the new record once. After creation, Kind Robots owns those fields. Do not add new presentation metadata to Conductor `project-overrides.yaml`.
+
+## Storage
+
+`ConductorProjection` is an additive singleton table created by migration `20260803113000_add_conductor_projection`. It is intentionally accessed through parameterized raw Prisma queries rather than generated Prisma models. This keeps the projection isolated from the application's domain schema and makes its cache status explicit.
+
+The stored payload is versioned. A future payload change must increment the version and preserve a deliberate compatibility path.
+
+## Failure behavior
+
+- A rejected or failed sync leaves the previous projection intact.
+- If no projection exists yet, `/api/conductor/projects` returns no live coordination data and the existing static fallback cards remain available.
+- Kind Robots must not fall back to live GitHub fan-out, because that would create a second runtime path with different freshness and failure semantics.
+- A stale projection is diagnosed by comparing `projection.sourceCommitSha` with Conductor `main` and inspecting the `Sync Kind Robots projection` workflow.
+- Repair the sync or event path. Never patch projected roadmap state directly in the Kind Robots database.
+
+## Agent rules
+
+Before changing cross-repository project data:
+
+1. Identify the owning repository from the table above.
+2. Make the change only at the authority.
+3. For Conductor coordination changes, verify the projection workflow accepted the exact commit SHA.
+4. For Kind Robots presentation changes, do not mirror the change into Conductor.
+5. For Kind Robots human actions, verify event processing and the subsequent projection round trip.

--- a/docs/conductor-projection.md
+++ b/docs/conductor-projection.md
@@ -53,7 +53,7 @@ For a missing Project row, legacy presentation values from Conductor may seed th
 
 ## Storage
 
-`ConductorProjection` is an additive singleton table created by migration `20260803113000_add_conductor_projection`. It is intentionally accessed through parameterized raw Prisma queries rather than generated Prisma models. This keeps the projection isolated from the application's domain schema and makes its cache status explicit.
+`ConductorProjection` is an additive singleton table created by migration `20260803113000_add_conductor_projection`. Application code intentionally accesses it through parameterized raw Prisma queries rather than a generated delegate. The table is still represented by the ignored `prisma/conductorProjection.prisma` model so future migration diffs know it is intentional and do not propose dropping it as orphaned drift.
 
 The stored payload is versioned. A future payload change must increment the version and preserve a deliberate compatibility path.
 

--- a/prisma/conductorProjection.prisma
+++ b/prisma/conductorProjection.prisma
@@ -1,0 +1,18 @@
+/// Commit-stamped materialized read model for Conductor coordination state.
+///
+/// Application code intentionally uses parameterized raw queries rather than a
+/// generated delegate. Keeping the ignored model in the schema prevents future
+/// migrations from interpreting the projection table as orphaned database drift.
+model ConductorProjection {
+  id              Int      @id
+  sourceRepo      String   @db.VarChar(255)
+  sourceRef       String   @db.VarChar(255)
+  sourceCommitSha String   @db.VarChar(64)
+  payload         String   @db.LongText
+  generatedAt     DateTime @db.DateTime(3)
+  syncedAt        DateTime @default(now()) @db.DateTime(3)
+  updatedAt       DateTime @default(now()) @updatedAt @db.DateTime(3)
+
+  @@index([sourceCommitSha])
+  @@ignore
+}

--- a/prisma/migrations/20260803113000_add_conductor_projection/migration.sql
+++ b/prisma/migrations/20260803113000_add_conductor_projection/migration.sql
@@ -1,0 +1,20 @@
+-- Materialized read model for Conductor coordination state.
+--
+-- This table is intentionally unmanaged by Prisma's generated model layer. The
+-- application accesses it through parameterized raw queries in
+-- server/utils/conductorProjectionDb.ts so the projection can land without a
+-- broad schema rewrite. Conductor remains authoritative; this row is replaced
+-- only by authenticated one-way syncs from the Conductor repository.
+CREATE TABLE `ConductorProjection` (
+  `id` INTEGER NOT NULL,
+  `sourceRepo` VARCHAR(255) NOT NULL,
+  `sourceRef` VARCHAR(255) NOT NULL,
+  `sourceCommitSha` VARCHAR(64) NOT NULL,
+  `payload` LONGTEXT NOT NULL,
+  `generatedAt` DATETIME(3) NOT NULL,
+  `syncedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (`id`),
+  INDEX `ConductorProjection_sourceCommitSha_idx` (`sourceCommitSha`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20260803113000_add_conductor_projection/migration.sql
+++ b/prisma/migrations/20260803113000_add_conductor_projection/migration.sql
@@ -1,10 +1,10 @@
 -- Materialized read model for Conductor coordination state.
 --
--- This table is intentionally unmanaged by Prisma's generated model layer. The
--- application accesses it through parameterized raw queries in
--- server/utils/conductorProjectionDb.ts so the projection can land without a
--- broad schema rewrite. Conductor remains authoritative; this row is replaced
--- only by authenticated one-way syncs from the Conductor repository.
+-- Application code accesses this table through parameterized raw queries in
+-- server/utils/conductorProjectionDb.ts. The matching ignored model in
+-- prisma/conductorProjection.prisma keeps migration history aware of the table
+-- without exposing a normal generated application delegate. Conductor remains
+-- authoritative; this row is replaced only by authenticated one-way syncs.
 CREATE TABLE `ConductorProjection` (
   `id` INTEGER NOT NULL,
   `sourceRepo` VARCHAR(255) NOT NULL,

--- a/server/api/conductor/projects.get.ts
+++ b/server/api/conductor/projects.get.ts
@@ -1,276 +1,77 @@
 // server/api/conductor/projects.get.ts
-// Conductor's project-overrides.yaml is the lifecycle registry; roadmap.yaml is
-// the task/progress source. This endpoint joins both without inventing projects
-// from every historical directory in the repository.
+//
+// Conductor remains the coordination source of truth. This endpoint serves the
+// latest authenticated one-way projection stored in the Kind Robots database,
+// then overlays Kind Robots-owned presentation fields from Project records.
 import { createError, defineEventHandler, setHeader } from 'h3'
+import prisma from '@/server/utils/prisma'
 import {
-  conductorPriorityToProjectPriority,
-  conductorStatusToProjectStatus,
-  parseConductorProjectOverrides,
-  type ConductorProjectPriority,
-  type ConductorProjectStatus,
-  type ProjectLifecyclePriority,
-  type ProjectLifecycleStatus,
-} from '@/server/utils/conductorProjectRegistry'
-import {
-  computeProgress,
-  parseRoadmapYaml,
+  buildConductorData,
+  missingConductorData,
+  type ConductorData,
   type ConductorMilestone,
+  type ConductorPitch,
+  type ConductorProject,
+  type ConductorProjectDisplay,
   type ConductorTask,
-  type ParsedRoadmap,
-} from '@/server/utils/conductorRoadmap'
+} from '@/server/utils/conductorProjection'
+import { readConductorProjection } from '@/server/utils/conductorProjectionDb'
 
-const GITHUB_API = 'https://api.github.com'
-const OWNER = 'silasfelinus'
-const REPO = 'conductor'
-const CONDUCTOR_RAW_BASE = `https://raw.githubusercontent.com/${OWNER}/${REPO}/main`
-const PROJECT_IMAGE_BASE = `${CONDUCTOR_RAW_BASE}/projects/images`
-
-// Re-exported so existing consumers keep importing these from the endpoint
-// module they already reference (conductor-page.vue, the gallery pages).
-export type { ConductorMilestone, ConductorTask }
-
-export interface ConductorProjectAssets {
-  imagePath: string
-  cardPath: string
-  heroPath: string
-}
-
-export interface ConductorProject {
-  slug: string
-  name: string
-  kind: string
-  status?: ProjectLifecycleStatus
-  priority?: ProjectLifecyclePriority
-  conductorStatus?: ConductorProjectStatus
-  conductorPriority?: ConductorProjectPriority
-  milestones: ConductorMilestone[]
-  tasks: ConductorTask[]
-  progress: number
-  imagePath: string
-  cardPath: string
-  heroPath: string
-  notesFromSilas?: string
-  goal?: string
-  liveUrl?: string
-  channelKey?: string
-  tabKey?: string
-  repoUrl?: string
-}
-
-export interface ConductorPitch {
-  slug: string
-  date: string
-  title: string
-  status: string
-  projectTarget: string
-  idea: string
-  whyDoIt: string
-  effort: string
-}
-
-export interface ConductorData {
-  projects: ConductorProject[]
-  pitches: ConductorPitch[]
-  fetchedAt: string
-  registryCount: number
-}
-
-type GithubContentEntry = {
-  name: string
-  type: string
-  sha?: string
-  content?: string
-}
-
-async function githubFetch(path: string): Promise<unknown> {
-  const token = process.env.GITHUB_TOKEN
-  const res = await fetch(
-    `${GITHUB_API}/repos/${OWNER}/${REPO}/contents/${path}`,
-    {
-      headers: {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'kind-robots-workspace/2.0',
-        ...(token ? { Authorization: `token ${token}` } : {}),
-      },
-    },
-  )
-  if (!res.ok) throw new Error(`GitHub ${res.status} for ${path}`)
-  return res.json()
-}
-
-function b64decode(b64: string): string {
-  return Buffer.from(b64.replace(/\n/g, ''), 'base64').toString('utf-8')
-}
-
-function versionedImageUrl(
-  filename: string,
-  imageShas: ReadonlyMap<string, string>,
-): string {
-  const base = `${PROJECT_IMAGE_BASE}/${filename}`
-  const sha = imageShas.get(filename)
-  return sha ? `${base}?v=${sha.slice(0, 12)}` : base
-}
-
-function conductorProjectAssets(
-  slug: string,
-  imageShas: ReadonlyMap<string, string>,
-): ConductorProjectAssets {
-  return {
-    imagePath: versionedImageUrl(`${slug}-icon.webp`, imageShas),
-    cardPath: versionedImageUrl(`${slug}-card.webp`, imageShas),
-    heroPath: versionedImageUrl(`${slug}-hero.webp`, imageShas),
-  }
-}
-
-function parsePitch(filename: string, text: string): ConductorPitch {
-  const date = filename.match(/^(\d{4}-\d{2}-\d{2})-/)?.[1] ?? ''
-  const slug = filename.replace(/\.md$/, '')
-  let title = slug
-  let status = 'awaiting-silas'
-  let projectTarget = ''
-  let idea = ''
-  let whyDoIt = ''
-  let effort = ''
-  let section = ''
-
-  for (const line of text.split('\n')) {
-    if (/^#\s*Pitch:/.test(line)) {
-      title = line.replace(/^#\s*Pitch:\s*/, '').trim()
-      continue
-    }
-    if (/^project-target:/.test(line)) {
-      projectTarget = line.replace(/^project-target:\s*/, '').trim()
-      continue
-    }
-    if (/^status:/.test(line)) {
-      status = line
-        .replace(/^status:\s*/, '')
-        .replace(/#.*/, '')
-        .trim()
-      continue
-    }
-    if (/^##\s*The idea/i.test(line)) section = 'idea'
-    else if (/^##\s*Why/i.test(line)) section = 'why'
-    else if (/^##\s*Rough effort/i.test(line)) section = 'effort'
-    else if (/^##/.test(line)) section = ''
-    else if (section === 'idea' && line.trim())
-      idea += `${idea ? ' ' : ''}${line.trim()}`
-    else if (section === 'why' && line.trim())
-      whyDoIt += `${whyDoIt ? ' ' : ''}${line.trim()}`
-    else if (section === 'effort' && line.trim()) {
-      effort = line.trim()
-      section = ''
-    }
-  }
-
-  return { slug, date, title, status, projectTarget, idea, whyDoIt, effort }
+export type {
+  ConductorData,
+  ConductorMilestone,
+  ConductorPitch,
+  ConductorProject,
+  ConductorTask,
 }
 
 export default defineEventHandler(async (event): Promise<ConductorData> => {
   try {
-    const [overrideFile, pitchesDir, imagesDir] = await Promise.all([
-      githubFetch('project-overrides.yaml') as Promise<GithubContentEntry>,
-      githubFetch('pitches') as Promise<GithubContentEntry[]>,
-      githubFetch('projects/images') as Promise<GithubContentEntry[]>,
-    ])
+    const stored = await readConductorProjection()
+    if (!stored) {
+      setHeader(event, 'Cache-Control', 'private, no-store')
+      return missingConductorData()
+    }
 
-    if (!overrideFile.content)
-      throw new Error('project-overrides.yaml is empty')
-    const registry = parseConductorProjectOverrides(
-      b64decode(overrideFile.content),
+    const coordination = buildConductorData(
+      stored.snapshot,
+      new Map(),
+      stored.syncedAt,
     )
-    const imageShas = new Map(
-      imagesDir
-        .filter((entry) => entry.type === 'file' && entry.sha)
-        .map((entry) => [entry.name, entry.sha!] as const),
-    )
-    const pitchFilenames = pitchesDir
-      .filter(
-        (entry) =>
-          entry.type === 'file' &&
-          entry.name.endsWith('.md') &&
-          entry.name !== 'README.md',
-      )
-      .map((entry) => entry.name)
+    const slugs = coordination.projects.map((project) => project.slug)
+    const displayRows = slugs.length
+      ? await prisma.project.findMany({
+          where: { conductorSlug: { in: slugs } },
+          select: {
+            conductorSlug: true,
+            title: true,
+            imagePath: true,
+            cardPath: true,
+            heroPath: true,
+            liveUrl: true,
+            channelKey: true,
+            tabKey: true,
+            repoUrl: true,
+          },
+        })
+      : []
 
-    const [rawProjects, rawPitches] = await Promise.all([
-      Promise.all(
-        registry.map(async (override) => {
-          let parsed: ParsedRoadmap = {
-            name: '',
-            kind: override.kind || 'software',
-            goal: undefined,
-            milestones: [],
-            tasks: [],
-            notesFromSilas: undefined,
-          }
-          try {
-            const file = (await githubFetch(
-              `projects/${override.slug}/roadmap.yaml`,
-            )) as GithubContentEntry
-            if (file.content) parsed = parseRoadmapYaml(b64decode(file.content))
-          } catch {
-            // A lifecycle entry remains visible even if its historical roadmap
-            // is absent; the registry, not directory existence, defines projects.
-          }
-
-          return {
-            slug: override.slug,
-            name: parsed.name || override.slug,
-            kind: override.kind || parsed.kind || 'software',
-            status: conductorStatusToProjectStatus(override.status),
-            priority: conductorPriorityToProjectPriority(override.priority),
-            conductorStatus: override.status,
-            conductorPriority: override.priority,
-            milestones: parsed.milestones,
-            tasks: parsed.tasks,
-            progress: computeProgress(parsed.milestones, parsed.tasks),
-            ...conductorProjectAssets(override.slug, imageShas),
-            ...(parsed.notesFromSilas
-              ? { notesFromSilas: parsed.notesFromSilas }
-              : {}),
-            ...(parsed.goal ? { goal: parsed.goal } : {}),
-            ...(override.liveUrl ? { liveUrl: override.liveUrl } : {}),
-            ...(override.channelKey ? { channelKey: override.channelKey } : {}),
-            ...(override.tabKey ? { tabKey: override.tabKey } : {}),
-            ...(override.repoUrl ? { repoUrl: override.repoUrl } : {}),
-          } satisfies ConductorProject
-        }),
-      ),
-      Promise.all(
-        pitchFilenames.map(async (filename) => {
-          try {
-            const file = (await githubFetch(
-              `pitches/${filename}`,
-            )) as GithubContentEntry
-            return file.content
-              ? parsePitch(filename, b64decode(file.content))
-              : null
-          } catch {
-            return null
-          }
-        }),
-      ),
-    ])
+    const displays = new Map<string, ConductorProjectDisplay>()
+    for (const row of displayRows) {
+      if (!row.conductorSlug) continue
+      displays.set(row.conductorSlug, row)
+    }
 
     setHeader(
       event,
       'Cache-Control',
-      'private, max-age=15, stale-while-revalidate=45',
+      'private, max-age=30, stale-while-revalidate=120',
     )
-    return {
-      projects: rawProjects,
-      pitches: rawPitches.filter(
-        (pitch): pitch is ConductorPitch => pitch !== null,
-      ),
-      fetchedAt: new Date().toISOString(),
-      registryCount: registry.length,
-    }
+    return buildConductorData(stored.snapshot, displays, stored.syncedAt)
   } catch (error) {
     throw createError({
       statusCode: 502,
-      message: `Conductor fetch failed: ${
+      message: `Conductor projection read failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     })

--- a/server/api/conductor/sync.post.ts
+++ b/server/api/conductor/sync.post.ts
@@ -1,0 +1,138 @@
+import type {
+  ProjectPriority,
+  ProjectStatus,
+} from '~/prisma/generated/prisma/client'
+import { createError, defineEventHandler, readBody } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { requireAdminApiUser } from '@/server/utils/authGuard'
+import {
+  assertConductorProjectionSnapshot,
+  buildConductorData,
+  type ConductorProjectionSnapshot,
+} from '@/server/utils/conductorProjection'
+
+const MAX_PROJECTION_BYTES = 4_000_000
+
+export default defineEventHandler(async (event) => {
+  await requireAdminApiUser(event)
+  const body: unknown = await readBody(event)
+
+  try {
+    assertConductorProjectionSnapshot(body)
+  } catch (cause) {
+    throw createError({
+      statusCode: 400,
+      statusMessage:
+        cause instanceof Error ? cause.message : 'Invalid Conductor projection',
+    })
+  }
+
+  const snapshot = body as ConductorProjectionSnapshot
+  const payload = JSON.stringify(snapshot)
+  const payloadBytes = Buffer.byteLength(payload, 'utf8')
+  if (payloadBytes > MAX_PROJECTION_BYTES) {
+    throw createError({
+      statusCode: 413,
+      statusMessage: `Conductor projection exceeds ${MAX_PROJECTION_BYTES} bytes`,
+    })
+  }
+
+  const syncedAt = new Date()
+  const generatedAt = new Date(snapshot.generatedAt)
+  const normalized = buildConductorData(
+    snapshot,
+    new Map(),
+    syncedAt.toISOString(),
+  )
+  let createdProjects = 0
+  let updatedProjects = 0
+
+  await prisma.$transaction(async (tx) => {
+    for (const project of normalized.projects) {
+      const existing = await tx.project.findFirst({
+        where: {
+          OR: [{ conductorSlug: project.slug }, { slug: project.slug }],
+        },
+        select: { id: true, conductorSlug: true },
+      })
+
+      if (existing) {
+        await tx.project.update({
+          where: { id: existing.id },
+          data: {
+            conductorSlug: existing.conductorSlug ?? project.slug,
+            status: project.status as ProjectStatus,
+            priority: project.priority as ProjectPriority,
+            lastSyncedAt: syncedAt,
+          },
+        })
+        updatedProjects += 1
+        continue
+      }
+
+      await tx.project.create({
+        data: {
+          title: project.name,
+          slug: project.slug,
+          conductorSlug: project.slug,
+          description: project.notesFromSilas ?? project.goal,
+          goal: project.goal,
+          status: project.status as ProjectStatus,
+          priority: project.priority as ProjectPriority,
+          repoUrl: project.repoUrl,
+          liveUrl: project.liveUrl,
+          channelKey: project.channelKey,
+          tabKey: project.tabKey,
+          imagePath: project.imagePath,
+          cardPath: project.cardPath,
+          heroPath: project.heroPath,
+          lastSyncedAt: syncedAt,
+          designer: 'conductor-projection',
+          isPublic: true,
+          isActive: true,
+        },
+      })
+      createdProjects += 1
+    }
+
+    await tx.$executeRaw`
+      INSERT INTO ConductorProjection (
+        id,
+        sourceRepo,
+        sourceRef,
+        sourceCommitSha,
+        payload,
+        generatedAt,
+        syncedAt
+      ) VALUES (
+        1,
+        ${snapshot.sourceRepo},
+        ${snapshot.sourceRef},
+        ${snapshot.sourceCommitSha},
+        ${payload},
+        ${generatedAt},
+        ${syncedAt}
+      )
+      ON DUPLICATE KEY UPDATE
+        sourceRepo = VALUES(sourceRepo),
+        sourceRef = VALUES(sourceRef),
+        sourceCommitSha = VALUES(sourceCommitSha),
+        payload = VALUES(payload),
+        generatedAt = VALUES(generatedAt),
+        syncedAt = VALUES(syncedAt)
+    `
+  })
+
+  return {
+    success: true,
+    data: {
+      sourceCommitSha: snapshot.sourceCommitSha,
+      registryCount: normalized.registryCount,
+      pitchCount: normalized.pitches.length,
+      createdProjects,
+      updatedProjects,
+      payloadBytes,
+      syncedAt: syncedAt.toISOString(),
+    },
+  }
+})

--- a/server/api/conductor/sync.post.ts
+++ b/server/api/conductor/sync.post.ts
@@ -12,6 +12,7 @@ import {
 } from '@/server/utils/conductorProjection'
 
 const MAX_PROJECTION_BYTES = 4_000_000
+const SYNC_TRANSACTION_TIMEOUT_MS = 60_000
 
 export default defineEventHandler(async (event) => {
   await requireAdminApiUser(event)
@@ -47,81 +48,109 @@ export default defineEventHandler(async (event) => {
   let createdProjects = 0
   let updatedProjects = 0
 
-  await prisma.$transaction(async (tx) => {
-    for (const project of normalized.projects) {
-      const existing = await tx.project.findFirst({
-        where: {
-          OR: [{ conductorSlug: project.slug }, { slug: project.slug }],
-        },
-        select: { id: true, conductorSlug: true },
-      })
+  await prisma.$transaction(
+    async (tx) => {
+      const slugs = normalized.projects.map((project) => project.slug)
+      const existingProjects = slugs.length
+        ? await tx.project.findMany({
+            where: {
+              OR: [
+                { conductorSlug: { in: slugs } },
+                { slug: { in: slugs } },
+              ],
+            },
+            select: { id: true, slug: true, conductorSlug: true },
+          })
+        : []
 
-      if (existing) {
-        await tx.project.update({
-          where: { id: existing.id },
+      for (const project of normalized.projects) {
+        const matches = existingProjects.filter(
+          (entry) =>
+            entry.conductorSlug === project.slug || entry.slug === project.slug,
+        )
+        if (matches.length > 1) {
+          throw createError({
+            statusCode: 409,
+            statusMessage: `Multiple Project rows match Conductor slug: ${project.slug}`,
+          })
+        }
+
+        const existing = matches[0]
+        if (existing?.conductorSlug && existing.conductorSlug !== project.slug) {
+          throw createError({
+            statusCode: 409,
+            statusMessage: `Project slug ${project.slug} is already linked to ${existing.conductorSlug}`,
+          })
+        }
+
+        if (existing) {
+          await tx.project.update({
+            where: { id: existing.id },
+            data: {
+              conductorSlug: existing.conductorSlug ?? project.slug,
+              status: project.status as ProjectStatus,
+              priority: project.priority as ProjectPriority,
+              lastSyncedAt: syncedAt,
+            },
+          })
+          updatedProjects += 1
+          continue
+        }
+
+        await tx.project.create({
           data: {
-            conductorSlug: existing.conductorSlug ?? project.slug,
+            title: project.name,
+            slug: project.slug,
+            conductorSlug: project.slug,
+            description: project.notesFromSilas ?? project.goal,
+            goal: project.goal,
             status: project.status as ProjectStatus,
             priority: project.priority as ProjectPriority,
+            repoUrl: project.repoUrl,
+            liveUrl: project.liveUrl,
+            channelKey: project.channelKey,
+            tabKey: project.tabKey,
+            imagePath: project.imagePath,
+            cardPath: project.cardPath,
+            heroPath: project.heroPath,
             lastSyncedAt: syncedAt,
+            designer: 'conductor-projection',
+            isPublic: true,
+            isActive: true,
           },
         })
-        updatedProjects += 1
-        continue
+        createdProjects += 1
       }
 
-      await tx.project.create({
-        data: {
-          title: project.name,
-          slug: project.slug,
-          conductorSlug: project.slug,
-          description: project.notesFromSilas ?? project.goal,
-          goal: project.goal,
-          status: project.status as ProjectStatus,
-          priority: project.priority as ProjectPriority,
-          repoUrl: project.repoUrl,
-          liveUrl: project.liveUrl,
-          channelKey: project.channelKey,
-          tabKey: project.tabKey,
-          imagePath: project.imagePath,
-          cardPath: project.cardPath,
-          heroPath: project.heroPath,
-          lastSyncedAt: syncedAt,
-          designer: 'conductor-projection',
-          isPublic: true,
-          isActive: true,
-        },
-      })
-      createdProjects += 1
-    }
-
-    await tx.$executeRaw`
-      INSERT INTO ConductorProjection (
-        id,
-        sourceRepo,
-        sourceRef,
-        sourceCommitSha,
-        payload,
-        generatedAt,
-        syncedAt
-      ) VALUES (
-        1,
-        ${snapshot.sourceRepo},
-        ${snapshot.sourceRef},
-        ${snapshot.sourceCommitSha},
-        ${payload},
-        ${generatedAt},
-        ${syncedAt}
-      )
-      ON DUPLICATE KEY UPDATE
-        sourceRepo = VALUES(sourceRepo),
-        sourceRef = VALUES(sourceRef),
-        sourceCommitSha = VALUES(sourceCommitSha),
-        payload = VALUES(payload),
-        generatedAt = VALUES(generatedAt),
-        syncedAt = VALUES(syncedAt)
-    `
-  })
+      await tx.$executeRaw`
+        INSERT INTO ConductorProjection (
+          id,
+          sourceRepo,
+          sourceRef,
+          sourceCommitSha,
+          payload,
+          generatedAt,
+          syncedAt
+        ) VALUES (
+          1,
+          ${snapshot.sourceRepo},
+          ${snapshot.sourceRef},
+          ${snapshot.sourceCommitSha},
+          ${payload},
+          ${generatedAt},
+          ${syncedAt}
+        )
+        ON DUPLICATE KEY UPDATE
+          sourceRepo = VALUES(sourceRepo),
+          sourceRef = VALUES(sourceRef),
+          sourceCommitSha = VALUES(sourceCommitSha),
+          payload = VALUES(payload),
+          generatedAt = VALUES(generatedAt),
+          syncedAt = VALUES(syncedAt)
+      `
+    },
+    { maxWait: 10_000, timeout: SYNC_TRANSACTION_TIMEOUT_MS },
+  )
 
   return {
     success: true,

--- a/server/utils/conductorProjection.ts
+++ b/server/utils/conductorProjection.ts
@@ -253,10 +253,14 @@ export function buildConductorData(
     const parsed = parsedRoadmap(snapshot, override.slug)
     const display = displays.get(override.slug)
     const fallbackAssets = conductorProjectAssets(snapshot, override.slug)
+    const liveUrl = defined(display?.liveUrl) ?? defined(override.liveUrl)
+    const channelKey = defined(display?.channelKey) ?? defined(override.channelKey)
+    const tabKey = defined(display?.tabKey) ?? defined(override.tabKey)
+    const repoUrl = defined(display?.repoUrl) ?? defined(override.repoUrl)
 
     return {
       slug: override.slug,
-      name: defined(display?.title) ?? parsed.name || override.slug,
+      name: defined(display?.title) ?? defined(parsed.name) ?? override.slug,
       kind: override.kind || parsed.kind || 'software',
       status: conductorStatusToProjectStatus(override.status),
       priority: conductorPriorityToProjectPriority(override.priority),
@@ -272,18 +276,10 @@ export function buildConductorData(
         ? { notesFromSilas: parsed.notesFromSilas }
         : {}),
       ...(parsed.goal ? { goal: parsed.goal } : {}),
-      ...(defined(display?.liveUrl) ?? override.liveUrl
-        ? { liveUrl: defined(display?.liveUrl) ?? override.liveUrl }
-        : {}),
-      ...(defined(display?.channelKey) ?? override.channelKey
-        ? { channelKey: defined(display?.channelKey) ?? override.channelKey }
-        : {}),
-      ...(defined(display?.tabKey) ?? override.tabKey
-        ? { tabKey: defined(display?.tabKey) ?? override.tabKey }
-        : {}),
-      ...(defined(display?.repoUrl) ?? override.repoUrl
-        ? { repoUrl: defined(display?.repoUrl) ?? override.repoUrl }
-        : {}),
+      ...(liveUrl ? { liveUrl } : {}),
+      ...(channelKey ? { channelKey } : {}),
+      ...(tabKey ? { tabKey } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
     } satisfies ConductorProject
   })
 
@@ -308,7 +304,9 @@ export function buildConductorData(
   }
 }
 
-export function missingConductorData(now = new Date().toISOString()): ConductorData {
+export function missingConductorData(
+  now = new Date().toISOString(),
+): ConductorData {
   return {
     projects: [],
     pitches: [],

--- a/server/utils/conductorProjection.ts
+++ b/server/utils/conductorProjection.ts
@@ -1,0 +1,326 @@
+import {
+  conductorPriorityToProjectPriority,
+  conductorStatusToProjectStatus,
+  parseConductorProjectOverrides,
+  type ConductorProjectPriority,
+  type ConductorProjectStatus,
+  type ProjectLifecyclePriority,
+  type ProjectLifecycleStatus,
+} from '@/server/utils/conductorProjectRegistry'
+import {
+  computeProgress,
+  parseRoadmapYaml,
+  type ConductorMilestone,
+  type ConductorTask,
+  type ParsedRoadmap,
+} from '@/server/utils/conductorRoadmap'
+
+export type { ConductorMilestone, ConductorTask }
+
+const DEFAULT_SOURCE_REPO = 'silasfelinus/conductor'
+const DEFAULT_SOURCE_REF = 'main'
+const PROJECT_IMAGE_DIRECTORY = 'projects/images'
+
+export interface ConductorProjectionSnapshot {
+  version: 1
+  sourceRepo: string
+  sourceRef: string
+  sourceCommitSha: string
+  generatedAt: string
+  registryYaml: string
+  roadmaps: Record<string, string>
+  pitches: Record<string, string>
+  imageVersions: Record<string, string>
+}
+
+export interface ConductorProjectDisplay {
+  title?: string | null
+  imagePath?: string | null
+  cardPath?: string | null
+  heroPath?: string | null
+  liveUrl?: string | null
+  channelKey?: string | null
+  tabKey?: string | null
+  repoUrl?: string | null
+}
+
+export interface ConductorProjectAssets {
+  imagePath: string
+  cardPath: string
+  heroPath: string
+}
+
+export interface ConductorProject {
+  slug: string
+  name: string
+  kind: string
+  status?: ProjectLifecycleStatus
+  priority?: ProjectLifecyclePriority
+  conductorStatus?: ConductorProjectStatus
+  conductorPriority?: ConductorProjectPriority
+  milestones: ConductorMilestone[]
+  tasks: ConductorTask[]
+  progress: number
+  imagePath: string
+  cardPath: string
+  heroPath: string
+  notesFromSilas?: string
+  goal?: string
+  liveUrl?: string
+  channelKey?: string
+  tabKey?: string
+  repoUrl?: string
+}
+
+export interface ConductorPitch {
+  slug: string
+  date: string
+  title: string
+  status: string
+  projectTarget: string
+  idea: string
+  whyDoIt: string
+  effort: string
+}
+
+export interface ConductorProjectionMeta {
+  sourceRepo: string
+  sourceRef: string
+  sourceCommitSha: string
+  generatedAt: string
+  syncedAt: string
+  status: 'ready' | 'missing'
+}
+
+export interface ConductorData {
+  projects: ConductorProject[]
+  pitches: ConductorPitch[]
+  fetchedAt: string
+  registryCount: number
+  projection: ConductorProjectionMeta
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === 'string')
+  )
+}
+
+export function assertConductorProjectionSnapshot(
+  value: unknown,
+): asserts value is ConductorProjectionSnapshot {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Conductor projection payload must be an object')
+  }
+
+  const source = value as Record<string, unknown>
+  if (source.version !== 1) {
+    throw new Error('Conductor projection version must be 1')
+  }
+  if (source.sourceRepo !== DEFAULT_SOURCE_REPO) {
+    throw new Error(`Conductor projection sourceRepo must be ${DEFAULT_SOURCE_REPO}`)
+  }
+  if (source.sourceRef !== DEFAULT_SOURCE_REF) {
+    throw new Error(`Conductor projection sourceRef must be ${DEFAULT_SOURCE_REF}`)
+  }
+  if (
+    typeof source.sourceCommitSha !== 'string' ||
+    !/^[a-f0-9]{7,64}$/i.test(source.sourceCommitSha)
+  ) {
+    throw new Error('Conductor projection sourceCommitSha is invalid')
+  }
+  if (
+    typeof source.generatedAt !== 'string' ||
+    !Number.isFinite(Date.parse(source.generatedAt))
+  ) {
+    throw new Error('Conductor projection generatedAt is invalid')
+  }
+  if (typeof source.registryYaml !== 'string' || !source.registryYaml.trim()) {
+    throw new Error('Conductor projection registryYaml is required')
+  }
+  if (!isStringRecord(source.roadmaps)) {
+    throw new Error('Conductor projection roadmaps must be a string map')
+  }
+  if (!isStringRecord(source.pitches)) {
+    throw new Error('Conductor projection pitches must be a string map')
+  }
+  if (!isStringRecord(source.imageVersions)) {
+    throw new Error('Conductor projection imageVersions must be a string map')
+  }
+}
+
+function projectImageBase(snapshot: ConductorProjectionSnapshot): string {
+  return `https://raw.githubusercontent.com/${snapshot.sourceRepo}/${snapshot.sourceRef}/${PROJECT_IMAGE_DIRECTORY}`
+}
+
+function versionedImageUrl(
+  snapshot: ConductorProjectionSnapshot,
+  filename: string,
+): string {
+  const base = `${projectImageBase(snapshot)}/${filename}`
+  const version = snapshot.imageVersions[filename]
+  return version ? `${base}?v=${version.slice(0, 12)}` : base
+}
+
+function conductorProjectAssets(
+  snapshot: ConductorProjectionSnapshot,
+  slug: string,
+): ConductorProjectAssets {
+  return {
+    imagePath: versionedImageUrl(snapshot, `${slug}-icon.webp`),
+    cardPath: versionedImageUrl(snapshot, `${slug}-card.webp`),
+    heroPath: versionedImageUrl(snapshot, `${slug}-hero.webp`),
+  }
+}
+
+function parsePitch(filename: string, text: string): ConductorPitch {
+  const date = filename.match(/^(\d{4}-\d{2}-\d{2})-/)?.[1] ?? ''
+  const slug = filename.replace(/\.md$/, '')
+  let title = slug
+  let status = 'awaiting-silas'
+  let projectTarget = ''
+  let idea = ''
+  let whyDoIt = ''
+  let effort = ''
+  let section = ''
+
+  for (const line of text.split('\n')) {
+    if (/^#\s*Pitch:/.test(line)) {
+      title = line.replace(/^#\s*Pitch:\s*/, '').trim()
+      continue
+    }
+    if (/^project-target:/.test(line)) {
+      projectTarget = line.replace(/^project-target:\s*/, '').trim()
+      continue
+    }
+    if (/^status:/.test(line)) {
+      status = line
+        .replace(/^status:\s*/, '')
+        .replace(/#.*/, '')
+        .trim()
+      continue
+    }
+    if (/^##\s*The idea/i.test(line)) section = 'idea'
+    else if (/^##\s*Why/i.test(line)) section = 'why'
+    else if (/^##\s*Rough effort/i.test(line)) section = 'effort'
+    else if (/^##/.test(line)) section = ''
+    else if (section === 'idea' && line.trim())
+      idea += `${idea ? ' ' : ''}${line.trim()}`
+    else if (section === 'why' && line.trim())
+      whyDoIt += `${whyDoIt ? ' ' : ''}${line.trim()}`
+    else if (section === 'effort' && line.trim()) {
+      effort = line.trim()
+      section = ''
+    }
+  }
+
+  return { slug, date, title, status, projectTarget, idea, whyDoIt, effort }
+}
+
+function parsedRoadmap(
+  snapshot: ConductorProjectionSnapshot,
+  slug: string,
+): ParsedRoadmap {
+  const roadmap = snapshot.roadmaps[slug]
+  if (!roadmap) {
+    return {
+      name: '',
+      kind: 'software',
+      goal: undefined,
+      milestones: [],
+      tasks: [],
+      notesFromSilas: undefined,
+    }
+  }
+  return parseRoadmapYaml(roadmap)
+}
+
+function defined(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed || undefined
+}
+
+export function buildConductorData(
+  snapshot: ConductorProjectionSnapshot,
+  displays: ReadonlyMap<string, ConductorProjectDisplay> = new Map(),
+  syncedAt = snapshot.generatedAt,
+): ConductorData {
+  const registry = parseConductorProjectOverrides(snapshot.registryYaml)
+  const projects = registry.map((override) => {
+    const parsed = parsedRoadmap(snapshot, override.slug)
+    const display = displays.get(override.slug)
+    const fallbackAssets = conductorProjectAssets(snapshot, override.slug)
+
+    return {
+      slug: override.slug,
+      name: defined(display?.title) ?? parsed.name || override.slug,
+      kind: override.kind || parsed.kind || 'software',
+      status: conductorStatusToProjectStatus(override.status),
+      priority: conductorPriorityToProjectPriority(override.priority),
+      conductorStatus: override.status,
+      conductorPriority: override.priority,
+      milestones: parsed.milestones,
+      tasks: parsed.tasks,
+      progress: computeProgress(parsed.milestones, parsed.tasks),
+      imagePath: defined(display?.imagePath) ?? fallbackAssets.imagePath,
+      cardPath: defined(display?.cardPath) ?? fallbackAssets.cardPath,
+      heroPath: defined(display?.heroPath) ?? fallbackAssets.heroPath,
+      ...(parsed.notesFromSilas
+        ? { notesFromSilas: parsed.notesFromSilas }
+        : {}),
+      ...(parsed.goal ? { goal: parsed.goal } : {}),
+      ...(defined(display?.liveUrl) ?? override.liveUrl
+        ? { liveUrl: defined(display?.liveUrl) ?? override.liveUrl }
+        : {}),
+      ...(defined(display?.channelKey) ?? override.channelKey
+        ? { channelKey: defined(display?.channelKey) ?? override.channelKey }
+        : {}),
+      ...(defined(display?.tabKey) ?? override.tabKey
+        ? { tabKey: defined(display?.tabKey) ?? override.tabKey }
+        : {}),
+      ...(defined(display?.repoUrl) ?? override.repoUrl
+        ? { repoUrl: defined(display?.repoUrl) ?? override.repoUrl }
+        : {}),
+    } satisfies ConductorProject
+  })
+
+  const pitches = Object.entries(snapshot.pitches)
+    .filter(([filename]) => filename.endsWith('.md') && filename !== 'README.md')
+    .map(([filename, text]) => parsePitch(filename, text))
+    .sort((left, right) => right.date.localeCompare(left.date))
+
+  return {
+    projects,
+    pitches,
+    fetchedAt: syncedAt,
+    registryCount: registry.length,
+    projection: {
+      sourceRepo: snapshot.sourceRepo,
+      sourceRef: snapshot.sourceRef,
+      sourceCommitSha: snapshot.sourceCommitSha,
+      generatedAt: snapshot.generatedAt,
+      syncedAt,
+      status: 'ready',
+    },
+  }
+}
+
+export function missingConductorData(now = new Date().toISOString()): ConductorData {
+  return {
+    projects: [],
+    pitches: [],
+    fetchedAt: now,
+    registryCount: 0,
+    projection: {
+      sourceRepo: DEFAULT_SOURCE_REPO,
+      sourceRef: DEFAULT_SOURCE_REF,
+      sourceCommitSha: '',
+      generatedAt: now,
+      syncedAt: now,
+      status: 'missing',
+    },
+  }
+}

--- a/server/utils/conductorProjectionDb.ts
+++ b/server/utils/conductorProjectionDb.ts
@@ -16,9 +16,9 @@ type ProjectionRow = {
 
 export async function readConductorProjection(): Promise<StoredConductorProjection | null> {
   const rows = await prisma.$queryRaw<ProjectionRow[]>`
-    SELECT `payload`, `syncedAt`
-    FROM `ConductorProjection`
-    WHERE `id` = 1
+    SELECT payload, syncedAt
+    FROM ConductorProjection
+    WHERE id = 1
     LIMIT 1
   `
   const row = rows[0]

--- a/server/utils/conductorProjectionDb.ts
+++ b/server/utils/conductorProjectionDb.ts
@@ -1,0 +1,33 @@
+import prisma from '@/server/utils/prisma'
+import {
+  assertConductorProjectionSnapshot,
+  type ConductorProjectionSnapshot,
+} from '@/server/utils/conductorProjection'
+
+export interface StoredConductorProjection {
+  snapshot: ConductorProjectionSnapshot
+  syncedAt: string
+}
+
+type ProjectionRow = {
+  payload: string
+  syncedAt: Date | string
+}
+
+export async function readConductorProjection(): Promise<StoredConductorProjection | null> {
+  const rows = await prisma.$queryRaw<ProjectionRow[]>`
+    SELECT `payload`, `syncedAt`
+    FROM `ConductorProjection`
+    WHERE `id` = 1
+    LIMIT 1
+  `
+  const row = rows[0]
+  if (!row) return null
+
+  const snapshot: unknown = JSON.parse(row.payload)
+  assertConductorProjectionSnapshot(snapshot)
+  return {
+    snapshot,
+    syncedAt: new Date(row.syncedAt).toISOString(),
+  }
+}

--- a/utils/scripts/verifyConductorProjectRegistry.ts
+++ b/utils/scripts/verifyConductorProjectRegistry.ts
@@ -160,12 +160,23 @@ const migration = readFileSync(
   resolve('prisma/migrations/20260803113000_add_conductor_projection/migration.sql'),
   'utf8',
 )
+const ignoredModel = readFileSync(resolve('prisma/conductorProjection.prisma'), 'utf8')
 const agents = readFileSync(resolve('AGENTS.md'), 'utf8')
+const updateStart = syncRoute.indexOf('await tx.project.update')
+const updateEnd = syncRoute.indexOf('updatedProjects += 1')
+const existingProjectUpdate = syncRoute.slice(updateStart, updateEnd)
 check('sync route requires an admin API user', syncRoute.includes('requireAdminApiUser(event)'))
-check('sync route preserves existing presentation fields', !/project\.update\([\s\S]*channelKey: project\.channelKey/.test(syncRoute))
+check('existing Project update block is found', updateStart >= 0 && updateEnd > updateStart)
+check(
+  'sync route preserves existing presentation fields',
+  !['title:', 'description:', 'liveUrl:', 'channelKey:', 'tabKey:', 'repoUrl:', 'imagePath:', 'cardPath:', 'heroPath:'].some(
+    (field) => existingProjectUpdate.includes(field),
+  ),
+)
 check('read route uses local projection storage', readRoute.includes('readConductorProjection()'))
 check('read route no longer fetches GitHub content', !readRoute.includes('api.github.com'))
 check('projection table migration is additive', migration.includes('CREATE TABLE `ConductorProjection`'))
+check('projection table is protected from future migration drift', ignoredModel.includes('model ConductorProjection') && ignoredModel.includes('@@ignore'))
 check('agent contract names one-way projection authority', agents.includes('commit-stamped materialized read projection'))
 
 console.log('')

--- a/utils/scripts/verifyConductorProjectRegistry.ts
+++ b/utils/scripts/verifyConductorProjectRegistry.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import {
   conductorPriorityToProjectPriority,
   conductorStatusToProjectStatus,
@@ -6,6 +8,11 @@ import {
   projectStatusToConductorStatus,
   updateConductorProjectOverride,
 } from '../../server/utils/conductorProjectRegistry'
+import {
+  assertConductorProjectionSnapshot,
+  buildConductorData,
+  type ConductorProjectionSnapshot,
+} from '../../server/utils/conductorProjection'
 
 let failures = 0
 
@@ -24,7 +31,9 @@ overrides:
     status: active
     priority: high
     kind: software
-    liveUrl: /active
+    liveUrl: /legacy-active
+    channelKey: legacy-channel
+    tabKey: legacy-tab
   - slug: paused-project
     status: paused # tabled by Silas
     priority: low
@@ -57,7 +66,7 @@ const updated = updateConductorProjectOverride(fixture, 'paused-project', {
 check('status is replaced', /slug: paused-project[\s\S]*status: active # tabled by Silas/.test(updated))
 check('priority is replaced', /slug: paused-project[\s\S]*priority: urgent/.test(updated))
 check('inline human note is preserved', updated.includes('# tabled by Silas'))
-check('unrelated placement survives', updated.includes('liveUrl: /active'))
+check('unrelated placement survives', updated.includes('liveUrl: /legacy-active'))
 check('registry remains one overrides document', (updated.match(/^overrides:/gm) ?? []).length === 1)
 
 const appended = updateConductorProjectOverride(fixture, 'new-project', {
@@ -66,6 +75,98 @@ const appended = updateConductorProjectOverride(fixture, 'new-project', {
 })
 check('missing project can be appended', appended.includes('  - slug: new-project'))
 check('appended lifecycle is explicit', /slug: new-project\n    status: paused\n    priority: normal/.test(appended))
+
+console.log('Conductor materialized projection')
+const snapshot: ConductorProjectionSnapshot = {
+  version: 1,
+  sourceRepo: 'silasfelinus/conductor',
+  sourceRef: 'main',
+  sourceCommitSha: 'a'.repeat(40),
+  generatedAt: '2026-08-03T11:30:00Z',
+  registryYaml: fixture,
+  roadmaps: {
+    'active-project': `project: Roadmap title
+kind: software
+goal: Ship the coordination layer
+milestones:
+  - id: m1
+    title: Coordination
+    weight: 100
+    status: in-progress
+tasks:
+  - id: t-001
+    milestone: m1
+    title: Await decision
+    status: needs-human
+    gate_human: true
+`,
+  },
+  pitches: {
+    '2026-08-03-projection.md': `# Pitch: Projection contract
+status: awaiting-silas
+project-target: conductor
+## The idea
+Use one-way authority.
+## Why do it
+Avoid split-brain state.
+## Rough effort
+Small
+`,
+  },
+  imageVersions: {
+    'active-project-card.webp': 'b'.repeat(64),
+  },
+}
+assertConductorProjectionSnapshot(snapshot)
+const data = buildConductorData(
+  snapshot,
+  new Map([
+    [
+      'active-project',
+      {
+        title: 'Kind Robots title',
+        liveUrl: '/projects/active',
+        channelKey: 'plan',
+        tabKey: 'projects',
+        cardPath: '/media/projects/active-card.webp',
+      },
+    ],
+  ]),
+  '2026-08-03T11:31:00Z',
+)
+const active = data.projects.find((project) => project.slug === 'active-project')!
+check('coordination status comes from Conductor', active.conductorStatus === 'active')
+check('coordination priority comes from Conductor', active.conductorPriority === 'high')
+check('roadmap task state comes from Conductor', active.tasks[0]?.status === 'needs-human')
+check('Kind Robots title wins over roadmap title', active.name === 'Kind Robots title')
+check('Kind Robots route wins over legacy registry route', active.liveUrl === '/projects/active')
+check('Kind Robots placement wins over legacy registry placement', active.channelKey === 'plan' && active.tabKey === 'projects')
+check('Kind Robots artwork wins over projected fallback', active.cardPath === '/media/projects/active-card.webp')
+check('projection carries exact source SHA', data.projection.sourceCommitSha === 'a'.repeat(40))
+check('pitches are projected', data.pitches[0]?.title === 'Projection contract')
+
+let invalidSourceRejected = false
+try {
+  assertConductorProjectionSnapshot({ ...snapshot, sourceRef: 'feature-branch' })
+} catch {
+  invalidSourceRejected = true
+}
+check('non-main projections are rejected', invalidSourceRejected)
+
+console.log('Projection wiring')
+const syncRoute = readFileSync(resolve('server/api/conductor/sync.post.ts'), 'utf8')
+const readRoute = readFileSync(resolve('server/api/conductor/projects.get.ts'), 'utf8')
+const migration = readFileSync(
+  resolve('prisma/migrations/20260803113000_add_conductor_projection/migration.sql'),
+  'utf8',
+)
+const agents = readFileSync(resolve('AGENTS.md'), 'utf8')
+check('sync route requires an admin API user', syncRoute.includes('requireAdminApiUser(event)'))
+check('sync route preserves existing presentation fields', !/project\.update\([\s\S]*channelKey: project\.channelKey/.test(syncRoute))
+check('read route uses local projection storage', readRoute.includes('readConductorProjection()'))
+check('read route no longer fetches GitHub content', !readRoute.includes('api.github.com'))
+check('projection table migration is additive', migration.includes('CREATE TABLE `ConductorProjection`'))
+check('agent contract names one-way projection authority', agents.includes('commit-stamped materialized read projection'))
 
 console.log('')
 if (failures) {


### PR DESCRIPTION
## Summary

- replace per-request GitHub fan-out with a commit-stamped Conductor projection stored in MariaDB
- add an authenticated `/api/conductor/sync` endpoint for one-way Conductor snapshots
- preserve Kind Robots ownership of Project presentation fields while syncing only lifecycle, priority, join identity, and sync provenance
- keep human decisions flowing through Conductor task events rather than editing projected state
- add the additive projection table migration and a missing-snapshot fallback
- document the source-of-truth contract for every Kind Robots agent
- extend the existing Conductor registry contract verifier with projection, ownership, auth, storage, and wiring checks

## Authority contract

Conductor remains canonical for lifecycle, roadmaps, tasks, milestones, claims, human gates, and pitches. Kind Robots owns project titles, routes, channel/tab placement, URLs, artwork, user state, and runtime/application data.

Existing presentation values in Conductor are bootstrap fallback data only. Existing Kind Robots Project presentation fields are never overwritten by projection syncs.

## Deployment order

This PR should merge and deploy before the matching Conductor PR. The Vercel deploy creates the projection table and exposes the authenticated sync endpoint; only then should Conductor begin posting snapshots.

## Verification

- TypeScript and repository contract checks in CI
- the existing `test:conductor-api-auth-guards` command now also validates projection authority and wiring
- production migration, route smoke, and runtime logs will be checked after merge