### PR TITLE
fix: keep Conductor roadmap types single-sourced

### DIFF
--- a/server/api/conductor/projects.get.ts
+++ b/server/api/conductor/projects.get.ts
@@ -9,13 +9,15 @@ import {
   buildConductorData,
   missingConductorData,
   type ConductorData,
-  type ConductorMilestone,
   type ConductorPitch,
   type ConductorProject,
   type ConductorProjectDisplay,
-  type ConductorTask,
 } from '@/server/utils/conductorProjection'
 import { readConductorProjection } from '@/server/utils/conductorProjectionDb'
+import type {
+  ConductorMilestone,
+  ConductorTask,
+} from '@/server/utils/conductorRoadmap'
 
 export type {
   ConductorData,

--- a/server/utils/conductorProjection.ts
+++ b/server/utils/conductorProjection.ts
@@ -15,8 +15,6 @@ import {
   type ParsedRoadmap,
 } from '@/server/utils/conductorRoadmap'
 
-export type { ConductorMilestone, ConductorTask }
-
 const DEFAULT_SOURCE_REPO = 'silasfelinus/conductor'
 const DEFAULT_SOURCE_REF = 'main'
 const PROJECT_IMAGE_DIRECTORY = 'projects/images'


### PR DESCRIPTION
## Summary

- remove duplicate type re-exports from the Conductor projection helper
- import and re-export `ConductorTask` and `ConductorMilestone` from their canonical roadmap module at the API boundary
- eliminate the new Nuxt duplicate-import warning observed in the production build for PR #1366

No runtime or data behavior changes.