### PR TITLE
fix(conductor): stop the fallback icon covering every project thumbnail

### DIFF
--- a/components/conductor/plan-projects-grid.vue
+++ b/components/conductor/plan-projects-grid.vue
@@ -31,8 +31,15 @@
               loading="lazy"
               class="h-full w-full object-cover"
             />
+            <!--
+              Fallback only. This used to render unconditionally as an
+              `absolute inset-0` overlay, so a project WITH artwork got its
+              image permanently covered by a bg-base-content/15 wash and an
+              icon — the art was loaded, paid for, and then hidden.
+            -->
             <span
-              class="absolute inset-0 flex items-center justify-center bg-base-content/15"
+              v-else
+              class="flex h-full w-full items-center justify-center bg-base-content/15"
             >
               <Icon
                 :name="project.icon || 'kind-icon:sparkles'"


### PR DESCRIPTION
## The bug

`plan-projects-grid.vue` renders a project's image, then an overlay span carrying a `bg-base-content/15` wash and an icon:

```html
``&lt;img v-if="project.image" :src="project.image" class="h-full w-full object-cover" /&gt;``
<span class="absolute inset-0 ... bg-base-content/15">   ← no v-else
  <Icon :name="project.icon || 'kind-icon:sparkles'" />
</span>
```

That span has **no `v-else`**, so it rendered unconditionally. A project *with* artwork had its image fetched, decoded, and then completely hidden behind the placeholder that exists to stand in for a *missing* one.

## The fix

The icon becomes the fallback it was written to be (`v-else`). Since it no longer has to stack over the image, it fills normally instead of positioning absolutely.

## Provenance

**Pre-existing, not a regression.** The markup is identical in the version before #1317 moved this file out of `components/pages/` to zero the one-mdc bucket — I checked `f1ee985^:components/pages/plan-projects-grid.vue`.

Also confirmed while I was in here, so it doesn't get "fixed" by mistake later: `conductor-manager.vue` mounts `<PlanProjectsGrid />` **unconditionally**, outside the `v-if`/`v-else` chain, so it renders under every conductor tab. That looks wrong but is faithful — `content/conductor.md` used to mount it as a second page-level MDC component, and #1317 moved it inside to satisfy the one-mdc rule. Same visual result, intentionally.

## This is not t-069

Found while tracing what `/conductor` actually renders for `interface-vision/t-069`, but it is **not** that bug. t-069 reports project *description text* over *card artwork* in a gallery row; this is an *icon* over a 44px thumbnail in a different component. **t-069 stays open** and still needs a look at the real page — headless Chromium can't reach the network from the agent sandbox (it fails on `example.com` too), so the preview deployments help CI and human review but don't give an agent session screenshots.

## Verification

- `npx eslint components/conductor/plan-projects-grid.vue` — clean
- Template-only change (a `v-else` plus a class swap), so CI's TypeScript job is the typecheck of record
- **Worth a glance on the preview**: the project thumbnails under "Projects in progress" on `/conductor` should now show their actual artwork rather than a uniform grey icon tile

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_