### PR TITLE
perf(art): serve entity art as webp, ~8x smaller, from the existing endpoint

### DIFF
--- a/server/api/art/images/[id]/file.get.ts
+++ b/server/api/art/images/[id]/file.get.ts
@@ -7,6 +7,7 @@ import {
   sendRedirect,
   setHeader,
 } from 'h3'
+import sharp from 'sharp'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { validateApiKey } from '~/server/utils/validateKey'
@@ -18,6 +19,14 @@ const CONTENT_TYPES: Record<string, string> = {
   jpg: 'image/jpeg',
   webp: 'image/webp',
 }
+
+// Formats worth converting. Stored webp is already small, and anything else
+// is an unknown container sharp may not decode.
+const TRANSCODABLE_TYPES = new Set(['png', 'jpeg', 'jpg'])
+
+// 82 measured 8.3x smaller than the source PNG with no visible artefacts at
+// card size; q90 only reached 6.3x for a much larger file.
+const WEBP_QUALITY = 82
 
 export default defineEventHandler(async (event) => {
   try {
@@ -72,11 +81,8 @@ export default defineEventHandler(async (event) => {
     }
 
     const fileType = String(image.fileType || '').toLowerCase()
-    setHeader(
-      event,
-      'Content-Type',
-      CONTENT_TYPES[fileType] || 'application/octet-stream',
-    )
+    const original = Buffer.from(image.imageData, 'base64')
+
     setHeader(
       event,
       'Cache-Control',
@@ -85,7 +91,53 @@ export default defineEventHandler(async (event) => {
         : 'private, max-age=3600',
     )
     setHeader(event, 'X-Content-Type-Options', 'nosniff')
-    return Buffer.from(image.imageData, 'base64')
+
+    /*
+     * Entity art is stored as base64 PNG in the ArtImage row and served from
+     * here verbatim, so a card is ~575KB on the wire (measured: 512x768 PNG,
+     * 588,351 bytes; 496KB mean over nine live cards). A 213-card character
+     * gallery therefore ships ~103MB. The same file at webp q82 is 69KB --
+     * 8.3x smaller -- and the dimensions are already card-sized, so this is
+     * purely a container-format cost with no resizing involved.
+     *
+     * Transcoding HERE rather than in the render queue means no migration, no
+     * backfill, no re-render and no client change, and every gallery benefits
+     * at once. The Cache-Control above is immutable for public art, so an
+     * image converts once and is then served from CDN cache.
+     */
+    const wantsWebp = (getHeader(event, 'accept') || '').includes('image/webp')
+    const canTranscode = TRANSCODABLE_TYPES.has(fileType)
+
+    // The response body now depends on Accept, so caches must key on it.
+    setHeader(event, 'Vary', 'Accept')
+
+    if (wantsWebp && canTranscode) {
+      /*
+       * Deliberate degradation, not error handling: any sharp failure (a
+       * corrupt row, an unavailable native binding) must fall through to the
+       * original bytes rather than 500. Serving a large image is always
+       * better than serving none.
+       */
+      try {
+        const webp = await sharp(original).webp({ quality: WEBP_QUALITY }).toBuffer()
+
+        // A transcode that grew the file helps nobody — keep the original.
+        if (webp.length < original.length) {
+          setHeader(event, 'Content-Type', 'image/webp')
+          return webp
+        }
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(`❌ webp transcode failed for ArtImage ${id}: ${message}`)
+      }
+    }
+
+    setHeader(
+      event,
+      'Content-Type',
+      CONTENT_TYPES[fileType] || 'application/octet-stream',
+    )
+    return original
   } catch (error: unknown) {
     const handled = errorHandler(error)
     event.node.res.statusCode = handled.statusCode || 500


### PR DESCRIPTION
`interface-vision/t-052`. A 213-card character gallery ships **~103 MB** today. This makes it **~12 MB** — with no migration, no backfill, no re-render, and no client change.

## Measured, not estimated

| | |
|---|---|
| Real card from production | **512×768 PNG, 588,351 bytes** |
| Mean over nine live cards | **496 KB** |
| Characters with a `cardPath` | **213 of 219** |

The task's original 37 MB figure was for a 68-card gallery.

## The task's framing was wrong twice, and both errors implied more machinery than this needs

1. **Not a missing-thumbnail problem.** The card variant is *already* 512×768, so nothing needs resizing — the entire cost is PNG-vs-webp.
2. **There is no separate card file to write a thumbnail beside.** A character's `cardPath` is `/api/art/images/<id>/file`, and this handler returns `Buffer.from(image.imageData, 'base64')` straight out of a MySQL column. The card variant **is** the stored original.

So the cheapest correct place to fix it is where the bytes are already served. **One file**, and every entity gallery benefits at once rather than just characters.

## How it works

Negotiates on `Accept: image/webp`, sets `Vary: Accept` so caches key on it. `Cache-Control` was already `immutable` for public art, so an image converts once and is then served from CDN.

Three guards, because this sits in front of every image on the site:

- Only `png`/`jpeg`/`jpg` are converted — stored webp is already small, and anything else is a container sharp may not decode.
- **Any sharp failure is caught and falls through to the original bytes.** Deliberate degradation, not error handling: a large image beats no image.
- A transcode that somehow *grew* the file is discarded.

The early `sendRedirect` for images whose `imagePath` points elsewhere is untouched — that path serves no bytes.

## Verification

Against the real production card above:

```
original PNG : 588,351 bytes
webp q82     :  70,492 bytes  -> 8.3x smaller
size guard   : webp smaller -> serve webp
webp valid   : webp 512x768 (dimensions preserved)
corrupt input: throws as expected -> caught, falls back to original
```

`npm run test` (vue-tsc) exit 0; `npx eslint` clean.

## What I could not prove from the sandbox

That **sharp's native binding bundles into the Nitro server on Vercel**. That's the one real risk here, and it's deployment-shaped rather than logic-shaped. The preview deployment for this PR is the check — if it bundles, images load; if it doesn't, the preview fails and nothing reaches `main`.

**Worth a glance on the preview**: any entity gallery (`/characters` is the densest) should look identical but weigh roughly an eighth as much. DevTools → Network → filter images will show `image/webp` and the smaller sizes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_