### PR TITLE
refactor: hoist avatar-picker tab scrolling into one shared kr-scroll

### DIFF
--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -84,7 +84,7 @@
     </Transition>
 
     <!-- ── Body ────────────────────────────────────────────────────────── -->
-    <div class="min-h-0 flex-1 overflow-hidden">
+    <div class="kr-scroll">
       <!-- GALLERY TAB -->
       <div
         v-show="activeTab === 'gallery'"
@@ -197,17 +197,14 @@
       </div>
 
       <!-- UPLOAD TAB -->
-      <div
-        v-show="activeTab === 'upload'"
-        class="h-full min-h-0 overflow-y-auto rounded-xl"
-      >
+      <div v-show="activeTab === 'upload'" class="h-full min-h-0 rounded-xl">
         <image-upload />
       </div>
 
       <!-- GENERATE TAB -->
       <div
         v-show="activeTab === 'generate'"
-        class="h-full min-h-0 overflow-y-auto rounded-xl bg-base-100 p-3"
+        class="h-full min-h-0 rounded-xl bg-base-100 p-3"
       >
         <generate-button
           :show-result="true"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -23,7 +23,6 @@
       "components/servers/server-manager.vue",
       "components/stages/stage-manager.vue",
       "components/themes/theme-gallery.vue",
-      "components/user/avatar-picker.vue",
       "components/user/chat-gallery.vue",
       "components/user/messenger.vue",
       "components/user/user-galleries.vue",


### PR DESCRIPTION
### Task
interface-vision/t-073: Fix the one-scroll SHAPE A false positives by hoisting a shared kr-scroll above mutually-exclusive tab branches (kind: software)

### What changed
- `components/user/avatar-picker.vue`'s gallery/upload/generate tabs are toggled with `v-show` on a single `activeTab` ref — mutually exclusive at runtime (only one is ever the visible one), but upload and generate each declared their own `overflow-y-auto` while gallery declared none.
- Replaced the body wrapper's `overflow-hidden` with the shared `.kr-scroll` primitive and dropped the two per-tab `overflow-y-auto` declarations. `v-show` keeps hidden siblings in the DOM but `display:none` excludes them from contributing to scroll height, so the single shared scroll region behaves identically to the three independent ones for the active tab.
- Ratcheted `utils/scripts/layout-contract-baseline.json`'s `one-scroll` bucket 26 → 25.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint components/user/avatar-picker.vue` — clean
- `npm run test:layout-contract` — holds, `one-scroll` -1, ratcheted via `--update`
- `npx tsx utils/scripts/verifyMdcScrollOwnership.ts` — holds, 22 existing violations, no new ones across 59 mounted component tags
- Checked avatar-picker's one mount site (`user-manager.vue`'s avatars tab, itself already inside a `.kr-scroll` from t-047): avatar-picker's root is `h-full` inside that already-bounded region, so its own internal kr-scroll only activates for its own tab content — no double-scrollbar behavior.

### Stakes
reversible

### Notes for reviewer
Also inspected `mural-manager.vue` (three panes visible simultaneously — genuine Shape B, not a hoist) and `butterfly-flip.vue` (front/back panels can both be mounted at once when `useFlipEffect` is false — not safe to merge). Left both alone; the remaining `one-scroll` bucket (25) is a mix of further Shape A tab-switchers and genuine Shape B concurrent panes that each need their own read before converting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzaFQqfFzh6vBnoprEmTLZ)_