### PR TITLE
fix: keep butterfly flip scrolling on the active face

### DIFF
--- a/components/butterfly/butterfly-flip.vue
+++ b/components/butterfly/butterfly-flip.vue
@@ -8,15 +8,17 @@
     >
       <div
         v-if="!isFlipped || !useFlipEffect"
-        class="flip-card-front w-full h-full backface-hidden overflow-y-auto"
+        class="flip-card-front w-full h-full backface-hidden"
         :class="{ fade: !useFlipEffect }"
+        :style="{ overflowY: isFlipped ? 'hidden' : 'auto' }"
       >
         <slot name="front"></slot>
       </div>
       <div
         v-if="isFlipped || !useFlipEffect"
-        class="flip-card-back w-full h-full backface-hidden transform-back overflow-y-auto"
+        class="flip-card-back w-full h-full backface-hidden transform-back"
         :class="{ fade: !useFlipEffect }"
+        :style="{ overflowY: isFlipped ? 'auto' : 'hidden' }"
       >
         <slot name="back"></slot>
       </div>

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -9,7 +9,6 @@
       "components/art/art-interact.vue",
       "components/art/art-styler.vue",
       "components/art/artjob-editor.vue",
-      "components/butterfly/butterfly-flip.vue",
       "components/butterfly/butterfly-sanctuary.vue",
       "components/characters/character-flip-card.vue",
       "components/characters/character-interact.vue",


### PR DESCRIPTION
## Summary
- keep vertical scrolling enabled only on the currently active butterfly-card face
- prevent overlapping front/back scroll regions when fade mode renders both faces
- ratchet the Interface Vision `one-scroll` baseline from 23 to 22

## Conductor
- project: `interface-vision`
- task: `t-017`
- session: `2026-08-03T171333Z-interface-vision-t-017-k9p4`

## Validation
- GitHub Actions required before merge
- focused diff: `components/butterfly/butterfly-flip.vue` and the shrink-only layout baseline
