### PR TITLE
Dreams: four real views, and unbreak the one labelled List

### DIFF
--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -17,13 +17,16 @@
     reaction-category="DREAM"
     :target-title="dreamTitle"
     :earned-karma="earnedKarma"
-    :card-class="['h-full min-h-0 bg-base-100 shadow-sm hover:-translate-y-0.5 hover:shadow-xl', cardClass]"
+    :card-class="[
+      'h-full min-h-0 bg-base-100 shadow-sm hover:-translate-y-0.5 hover:shadow-xl',
+      cardClass,
+    ]"
     @select="emit('choose', dream)"
   >
     <figure
       v-if="showImage"
-      class="relative h-full min-h-64 w-full overflow-hidden bg-base-300"
-      :class="compact ? 'aspect-video' : 'aspect-4/5'"
+      class="relative w-full overflow-hidden bg-base-300"
+      :class="figureClass"
     >
       <img
         v-if="previewImage"
@@ -161,6 +164,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 import type { DreamWithRelations } from '@/stores/dreamStore'
+import type { ArtVariant } from '@/utils/galleryVocabulary'
 import { useArtStore } from '@/stores/artStore'
 import { useCollectionStore } from '@/stores/collectionStore'
 
@@ -179,6 +183,13 @@ const props = withDefaults(
     allowEdit?: boolean
     allowDelete?: boolean
     imageFit?: 'cover' | 'contain'
+    /**
+     * Which stored art to show, and at what aspect — the shared card/hero/icon
+     * vocabulary (utils/galleryVocabulary.ts). This is what makes the gallery's
+     * Cards/Heroes/Icons toggle mean something; without it every mode rendered
+     * an identical portrait poster.
+     */
+    variant?: ArtVariant
     /** Total karma this Dream has earned from reactions (see
      *  server/api/economy/karma-earned.post.ts). Omit/undefined renders no
      *  badge — see components/wonderlab/reactable-card.vue. */
@@ -197,6 +208,7 @@ const props = withDefaults(
     allowEdit: true,
     allowDelete: false,
     imageFit: 'cover',
+    variant: 'card',
     earnedKarma: undefined,
   },
 )
@@ -265,8 +277,7 @@ const collectionStoreArt = computed<Partial<ArtImage>[]>(() => {
   for (const collectionId of dreamCollectionIds.value) {
     const images =
       (collectionStore.getCollectionImages?.(collectionId) as
-        | Partial<ArtImage>[]
-        | undefined) ?? []
+        Partial<ArtImage>[] | undefined) ?? []
     for (const image of images) {
       if (image?.id) seen.set(image.id, image)
     }
@@ -311,13 +322,41 @@ const primaryArt = computed<Partial<ArtImage> | null>(() => {
   return null
 })
 
+/**
+ * The variant's own stored path first, then the generic ones. Half the Dreams
+ * have no cardPath at all, so the chain past the first entry is the common
+ * case rather than the exception — a mode must still render something when its
+ * dedicated art was never generated.
+ *
+ * There is deliberately no `icon` branch: unlike Bot, Character, Reward and
+ * Scenario, the Dream model never got an `iconPath` column (`icon` on Dream is
+ * a name, not a path — see the split in #1258). Icons mode therefore shows
+ * card art cropped square, which is why it is a real mode rather than a broken
+ * one. Giving Dream an iconPath is a schema change, tracked separately.
+ */
 const explicitDreamImagePath = computed(() => {
+  const variantPath =
+    props.variant === 'hero' ? props.dream.heroPath : props.dream.cardPath
+
   return (
+    normalizeImagePath(variantPath) ||
     normalizeImagePath(props.dream.cardPath) ||
     normalizeImagePath(props.dream.imagePath) ||
     normalizeImagePath(props.dream.highlightImage) ||
     ''
   )
+})
+
+/**
+ * Aspect per variant, matching kr-gallery's imageWrapClass so a Dream in
+ * Heroes mode is the same shape as a Project in Heroes mode. `compact` is the
+ * embedded-strip case and keeps its own 16:9 regardless.
+ */
+const figureClass = computed(() => {
+  if (props.compact) return 'aspect-video h-full min-h-64'
+  if (props.variant === 'hero') return 'aspect-video h-full min-h-64'
+  if (props.variant === 'icon') return 'aspect-square h-full'
+  return 'aspect-4/5 h-full min-h-64'
 })
 
 const fallbackCollectionArt = computed<Partial<ArtImage> | null>(() => {

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -9,10 +9,14 @@
     >
       <!-- Wraps, rather than scrolling sideways. This row used to be
            `overflow-x-auto whitespace-nowrap` with shrink-0 controls, so on a
-           tablet the layout picker (Grid/Row/Reel/Hero/Swipe) sat off the right
-           edge behind a scrollbar nobody found -- Silas reviewed /dreams and
-           reported the view control as "cut off on the right side" without
-           knowing the modes existed. A hidden control is a missing control. -->
+           tablet the view picker sat off the right edge behind a scrollbar
+           nobody found -- Silas reviewed /dreams and reported the control as
+           "cut off on the right side" without knowing the modes existed. A
+           hidden control is a missing control.
+
+           The picker is a button group rather than a <select> for the same
+           reason: a dropdown hides every option but one, and the four views
+           are the point. -->
       <div class="kr-toolbar min-w-0">
         <div
           v-if="showHeader"
@@ -64,16 +68,25 @@
           </option>
         </select>
 
-        <select
+        <div
           v-if="showControls"
-          v-model="galleryMode"
-          class="select select-bordered select-sm h-9 w-28 shrink-0 rounded-2xl bg-base-200"
-          aria-label="Dream gallery layout"
+          class="flex shrink-0 gap-0.5"
+          role="group"
+          aria-label="Dream gallery view"
         >
-          <option v-for="mode in modeOptions" :key="mode.value" :value="mode.value">
+          <button
+            v-for="mode in modeOptions"
+            :key="mode.value"
+            type="button"
+            class="btn btn-sm h-9 rounded-2xl px-3"
+            :class="galleryMode === mode.value ? 'btn-primary' : 'btn-ghost'"
+            :title="mode.label"
+            :aria-pressed="galleryMode === mode.value"
+            @click="galleryMode = mode.value"
+          >
             {{ mode.label }}
-          </option>
-        </select>
+          </button>
+        </div>
 
         <button
           v-if="showControls"
@@ -338,6 +351,7 @@
             :selected="dreamStore.selectedDream?.id === dream.id"
             :is-selected="dreamStore.selectedDream?.id === dream.id"
             :compact="isCompact"
+            :variant="modeVariant"
             :show-image="showImages"
             :show-actions="showCardActions"
             :show-description="showDescriptions"
@@ -355,7 +369,6 @@
             @delete="handleDreamDeleted"
           />
         </div>
-
       </div>
     </section>
   </section>
@@ -369,7 +382,12 @@ import type {
   Reward,
   Scenario,
 } from '~/prisma/generated/prisma/client'
-import { GALLERY_MODES, type GalleryMode } from '@/utils/galleryVocabulary'
+import {
+  GALLERY_MODES,
+  MODE_GRID_CLASS,
+  MODE_VARIANT,
+  type GalleryMode,
+} from '@/utils/galleryVocabulary'
 import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
 import { useNavStore } from '@/stores/navStore'
 import { useUserStore } from '@/stores/userStore'
@@ -462,21 +480,13 @@ const searchQuery = ref('')
 const showMineOnly = ref(false)
 const showArchived = ref(false)
 const isLoading = ref(false)
-const galleryMode = ref<GalleryMode>(props.variant === 'row' ? 'list' : 'cards')
+const galleryMode = ref<GalleryMode>('cards')
 
-/**
- * Dreams offers only the two modes it can currently honour. `heroes` and
- * `icons` are held back because dream-card takes no variant/shape prop yet and
- * would render them identically to `cards` — a label that lies about what it
- * does, which is the whole reason this vocabulary was consolidated. When
- * dream-card moves onto kr-entity-card-body it inherits variant support, and
- * this filter is what gets deleted to expand the control to all four.
- */
-const modeOptions = computed(() =>
-  GALLERY_MODES.filter(
-    (mode) => mode.value === 'cards' || mode.value === 'list',
-  ),
-)
+/** All four. dream-card honours each via its `variant` prop. */
+const modeOptions = GALLERY_MODES
+
+/** Which stored art the current mode asks dream-card for. */
+const modeVariant = computed(() => MODE_VARIANT[galleryMode.value])
 const earnedKarmaByDreamId = ref<Record<number, number>>({})
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
@@ -494,11 +504,20 @@ const isCompact = computed(() => {
   return props.compact || props.variant === 'row' || isDropdownMode.value
 })
 
-const layoutClass = computed(() => {
-  return galleryMode.value === 'list' || props.variant === 'row'
-    ? 'dream-row'
-    : 'dream-grid'
-})
+/**
+ * `dream-row` is a horizontal scroll-snap FILMSTRIP, and it exists only for the
+ * embedded `variant="row"` prop — a Dream strip sitting inside another page.
+ * It is not a view mode and must never be reachable from the mode toggle: an
+ * earlier pass wired `list` to it on the assumption that "row" and "list" were
+ * the same idea, which put a horizontal carousel behind a button labelled List
+ * and left the rest of an xl viewport empty.
+ *
+ * The four real modes lay out through the shared MODE_GRID_CLASS, so Dreams
+ * matches the Project gallery exactly.
+ */
+const layoutClass = computed(() =>
+  props.variant === 'row' ? 'dream-row' : MODE_GRID_CLASS[galleryMode.value],
+)
 
 const currentUserId = computed(() => {
   return userStore.userId ?? userStore.user?.id ?? null
@@ -594,12 +613,15 @@ async function refreshEarnedKarma() {
     return
   }
 
-  const res = await performFetch<KarmaEarnedRow[]>('/api/economy/karma-earned', {
-    method: 'POST',
-    body: JSON.stringify({
-      items: ids.map((id) => ({ refType: 'dream', refId: id })),
-    }),
-  })
+  const res = await performFetch<KarmaEarnedRow[]>(
+    '/api/economy/karma-earned',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        items: ids.map((id) => ({ refType: 'dream', refId: id })),
+      }),
+    },
+  )
 
   if (!res.success || !Array.isArray(res.data)) return
 
@@ -1053,15 +1075,18 @@ function uniqueById<T extends { id?: number | null }>(items: T[]) {
 </script>
 
 <style scoped>
+/* Retained for callers asking for the legacy grid directly; the mode toggle
+   now lays out through the shared MODE_GRID_CLASS instead. Widened from 220px,
+   which read as cramped on a wide screen. */
 .dream-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
   gap: 1rem;
   align-items: stretch;
 }
 
 .dream-grid > * {
-  min-height: 20rem;
+  min-height: 24rem;
 }
 
 .dream-row {

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -23,16 +23,29 @@
       </button>
     </div>
 
-    <div v-if="loading && !items.length" class="grid grid-cols-2 gap-3 lg:grid-cols-4">
-      <div v-for="n in skeletonCount" :key="n" class="h-56 animate-pulse rounded-2xl bg-base-200" />
+    <div
+      v-if="loading && !items.length"
+      class="grid grid-cols-2 gap-3 lg:grid-cols-4"
+    >
+      <div
+        v-for="n in skeletonCount"
+        :key="n"
+        class="h-56 animate-pulse rounded-2xl bg-base-200"
+      />
     </div>
 
-    <div v-else-if="error" class="flex min-h-64 flex-col items-center justify-center gap-2 text-error">
+    <div
+      v-else-if="error"
+      class="flex min-h-64 flex-col items-center justify-center gap-2 text-error"
+    >
       <Icon name="kind-icon:warning" class="size-10" />
       <b>{{ error }}</b>
     </div>
 
-    <div v-else-if="!items.length" class="flex min-h-64 flex-col items-center justify-center text-center">
+    <div
+      v-else-if="!items.length"
+      class="flex min-h-64 flex-col items-center justify-center text-center"
+    >
       <Icon name="kind-icon:cards" class="size-12 text-base-content/20" />
       <b>No {{ emptyLabel }}.</b>
     </div>
@@ -62,14 +75,30 @@
             v-else
             class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-linear-to-br from-base-200 to-base-300 text-base-content/40"
           >
-            <Icon :name="item.placeholderIcon || 'kind-icon:image'" class="size-8" />
-            <span v-if="item.placeholderLabel" class="text-[10px] uppercase tracking-wide">
+            <Icon
+              :name="item.placeholderIcon || 'kind-icon:image'"
+              class="size-8"
+            />
+            <span
+              v-if="item.placeholderLabel"
+              class="text-[10px] uppercase tracking-wide"
+            >
               {{ item.placeholderLabel }}
             </span>
           </div>
-          <div class="absolute inset-0 bg-linear-to-t from-base-300/90 via-transparent to-transparent" />
-          <div v-if="item.badges?.length" class="absolute left-2 top-2 flex gap-1">
-            <span v-for="badge in item.badges" :key="badge.label" class="badge badge-xs" :class="badge.class">
+          <div
+            class="absolute inset-0 bg-linear-to-t from-base-300/90 via-transparent to-transparent"
+          />
+          <div
+            v-if="item.badges?.length"
+            class="absolute left-2 top-2 flex gap-1"
+          >
+            <span
+              v-for="badge in item.badges"
+              :key="badge.label"
+              class="badge badge-xs"
+              :class="badge.class"
+            >
               {{ badge.label }}
             </span>
           </div>
@@ -81,21 +110,35 @@
           />
         </div>
         <div class="p-3" :class="mode === 'icons' ? 'text-center' : ''">
-          <div class="flex items-start gap-2" :class="mode === 'icons' ? 'justify-center' : ''">
+          <div
+            class="flex items-start gap-2"
+            :class="mode === 'icons' ? 'justify-center' : ''"
+          >
             <div class="min-w-0 flex-1">
               <h2 class="truncate font-black">{{ item.title }}</h2>
-              <p v-if="mode !== 'icons' && item.description" class="line-clamp-2 text-xs text-base-content/55">
+              <p
+                v-if="mode !== 'icons' && item.description"
+                class="line-clamp-2 text-xs text-base-content/55"
+              >
                 {{ item.description }}
               </p>
             </div>
             <slot name="item-trailing" :item="item" />
           </div>
-          <p v-if="mode !== 'icons' && item.meta" class="mt-2 text-xs text-base-content/45">{{ item.meta }}</p>
+          <p
+            v-if="mode !== 'icons' && item.meta"
+            class="mt-2 text-xs text-base-content/45"
+          >
+            {{ item.meta }}
+          </p>
           <div
             v-if="mode !== 'icons' && item.progressPercent !== undefined"
             class="mt-1.5 h-1 overflow-hidden rounded-full bg-base-content/10"
           >
-            <div class="h-full bg-primary" :style="{ width: `${item.progressPercent}%` }" />
+            <div
+              class="h-full bg-primary"
+              :style="{ width: `${item.progressPercent}%` }"
+            />
           </div>
         </div>
       </button>
@@ -118,6 +161,8 @@ import {
 // working; new code should import from the util directly.
 import {
   GALLERY_MODES,
+  MODE_GRID_CLASS,
+  MODE_VARIANT,
   type GalleryMode,
   type GalleryModeOption,
 } from '@/utils/galleryVocabulary'
@@ -177,16 +222,10 @@ const emit = defineEmits<{
   'update:mode': [mode: GalleryMode]
 }>()
 
-const gridClass = computed(() =>
-  props.mode === 'list'
-    ? 'flex flex-col gap-2'
-    : props.mode === 'heroes'
-      ? 'grid gap-4 lg:grid-cols-2'
-      : props.mode === 'icons'
-        ? 'grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5'
-        : 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+const gridClass = computed(() => MODE_GRID_CLASS[props.mode])
+const itemClass = computed(() =>
+  props.mode === 'list' ? 'grid md:grid-cols-[12rem_1fr]' : '',
 )
-const itemClass = computed(() => (props.mode === 'list' ? 'grid md:grid-cols-[12rem_1fr]' : ''))
 const imageWrapClass = computed(() =>
   props.mode === 'heroes'
     ? 'min-h-64'
@@ -196,17 +235,7 @@ const imageWrapClass = computed(() =>
         ? 'min-h-40'
         : 'aspect-[4/3]',
 )
-/*
- * Which art variant this mode wants. Heroes and list are wide, icons is square,
- * cards is the 4:3 default.
- */
-const modeVariant = computed<ArtVariant>(() =>
-  props.mode === 'heroes' || props.mode === 'list'
-    ? 'hero'
-    : props.mode === 'icons'
-      ? 'icon'
-      : 'card',
-)
+const modeVariant = computed<ArtVariant>(() => MODE_VARIANT[props.mode])
 
 function displayImage(item: GalleryItem): string {
   const preResolved =

--- a/utils/galleryVocabulary.ts
+++ b/utils/galleryVocabulary.ts
@@ -62,12 +62,29 @@ export const GALLERY_MODES: readonly GalleryModeOption[] = [
 export const IS_GALLERY_MODE = (value: string): value is GalleryMode =>
   GALLERY_MODES.some((mode) => mode.value === value)
 
-/** The variant a given mode should ask kr-art-plate to load. */
+/**
+ * Which stored art a given mode should load. `list` takes hero art because its
+ * row is a wide 12rem-art strip, not a portrait card — this mirrors kr-gallery,
+ * which is the proven implementation and the authority here.
+ */
 export const MODE_VARIANT: Record<GalleryMode, ArtVariant> = {
   cards: 'card',
   heroes: 'hero',
   icons: 'icon',
-  list: 'card',
+  list: 'hero',
+}
+
+/**
+ * The grid/stack each mode lays its items out in. Lifted verbatim from
+ * kr-gallery so a gallery that cannot yet adopt the whole shell still lays out
+ * identically to one that has. `list` is a VERTICAL stack — a horizontal
+ * scrolling strip is a different thing entirely and is never a mode.
+ */
+export const MODE_GRID_CLASS: Record<GalleryMode, string> = {
+  cards: 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+  heroes: 'grid gap-4 lg:grid-cols-2',
+  icons: 'grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5',
+  list: 'flex flex-col gap-2',
 }
 
 /**


### PR DESCRIPTION
Fixes what Silas found reviewing `/dreams` on an xl screen. All three of his points were right, and the third is the root cause of the other two.

## The List bug

`.dream-row` is a horizontal scroll-snap **filmstrip**, built for the embedded `variant="row"` prop — a Dream strip sitting inside another page. My previous pass wired the `list` mode to it, on the assumption that "row" and "list" were the same idea.

They aren't. And the assumption was never checked against what the class *does* — only against my own claim that grid and row "differ only by a CSS class," which is true and useless. The result was a horizontal carousel behind a button labelled **List**, leaving most of a wide viewport empty. Exactly the "label that lies about its content" failure the previous PR claimed to be fixing.

`dream-row` is now reachable **only** from the prop and can no longer be selected as a view.

## The root cause

> "why are we making it like this when we have the Project model: Card, Hero, Icon views already decided?"

Because `kr-gallery` already implements all four correctly — and Dreams wasn't using any of it:

| Asked for | `kr-gallery` already had |
|---|---|
| Card/Hero/Icon like Projects | `cards` 4-col `aspect-[4/3]`, `heroes` 2-col `min-h-64`, `icons` 5-col `size-24` |
| A real list | `flex flex-col gap-2`, rows of `grid md:grid-cols-[12rem_1fr]` — **vertical** |
| Toggles, not a dropdown | a button group keyed on each mode's `abbr` |
| Art often missing | a built-in art-absent placeholder |

The previous change consolidated the *vocabulary* and stopped short of the *adoption*, so Dreams kept a hand-rolled two-mode grid. Hence "a lot of work happened but I just see two variations on the same look" — an accurate description of what shipped.

## What changed

- `MODE_GRID_CLASS` and `MODE_VARIANT` move into `galleryVocabulary.ts`; **`kr-gallery` now consumes them** instead of holding private copies. Dreams lays out through the same constants, so a Dream in Heroes is the same shape as a Project in Heroes.
- **`dream-card` takes a `variant` prop** driving both aspect and which stored path it loads. This is what makes the toggle mean anything — without it every mode rendered an identical portrait poster, which is why I previously *hid* Heroes/Icons instead of fixing them. Hiding them was the wrong call; you were right to push back.
- The `<select>` becomes a labelled button group.
- Cards widened from 220px/20rem to **280px/24rem**.

### A self-inflicted one, fixed

My `MODE_VARIANT` mapped `list → card` while `kr-gallery`'s own computed mapped `list → hero`. I added a constant that duplicated existing logic *and disagreed with it*, inside the module whose entire purpose was to stop that. `kr-gallery`'s mapping wins — list art is a wide 12rem strip, not a portrait card.

### A schema gap worth knowing about

**Dream has no `iconPath` column.** Bot, Character, Reward and Scenario all got card/hero/icon fields; Dream was left out, and `icon` on Dream is a *name*, not a path. So Icons mode shows card art cropped square rather than dedicated icon art. Documented at the fallback chain. This is also why "half our dreams are missing card images" doesn't block the feature — the chain falls through and the placeholder catches the rest.

## Verification

- `vue-tsc` clean; `test:gallery-adoption`, `test:layout-contract`, `test:channel-content`, `test:nav-manifest` pass; prettier clean.
- Asserted directly that the four modes map to **four distinct** layouts, that `list` is `flex-col`, and that **no** mode resolves to an `overflow-x` strip.

**Not verified: rendered output.** There's no `.env`/DB in this environment, so `/dreams` can't be loaded here. The layout strings are the ones `kr-gallery` already ships on the Projects gallery — but my last mistake was reasoning about CSS without looking at it, so this needs preview eyes before it's believed.

Pre-existing lint left alone: three `unified-signatures` errors on `dream-gallery`'s emit overloads and one `no-empty` in `dream-card`, all confirmed present on `main` by stashing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_