### PR TITLE
fix(home): restore Daily Dream slideshow history

### DIFF
--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -206,13 +206,25 @@ const selectedDreamId = ref<number | null>(null)
 const loading = ref(true)
 const imageFailed = ref(false)
 
+const CURRENT_DAILY_DREAM_DESIGNER = 'dream-cycle'
+const LEGACY_DAILY_DREAM_DESIGNER = 'Daily Dream Facet Engine'
+
+function isDailyDreamArchiveEntry(dream: DigestDream): boolean {
+  if (dream.dreamType !== 'PITCH') return false
+
+  if (dream.designer === CURRENT_DAILY_DREAM_DESIGNER) {
+    return Boolean(dream.PitchSheet)
+  }
+
+  return (
+    dream.designer === LEGACY_DAILY_DREAM_DESIGNER ||
+    String(dream.slug || '').startsWith('daily-dream-')
+  )
+}
+
 const digestDreams = computed<DigestDream[]>(() =>
   dreamStore.dreams
-    .filter(
-      (dream) =>
-        dream.designer === 'Daily Dream Facet Engine' ||
-        String(dream.slug || '').startsWith('daily-dream-'),
-    )
+    .filter(isDailyDreamArchiveEntry)
     .sort((left, right) => {
       const dateOrder = dateKey(right).localeCompare(dateKey(left))
       return dateOrder || right.id - left.id
@@ -293,11 +305,18 @@ function showNewer(): void {
 async function loadDigests(): Promise<void> {
   loading.value = true
   try {
-    await dreamStore.fetchDreams({
-      userOnly: true,
-      search: 'Daily Dream Facet Engine',
-      limit: 100,
-    })
+    await Promise.all([
+      dreamStore.fetchDreams({
+        search: CURRENT_DAILY_DREAM_DESIGNER,
+        dreamType: 'PITCH',
+        limit: 100,
+      }),
+      dreamStore.fetchDreams({
+        search: LEGACY_DAILY_DREAM_DESIGNER,
+        dreamType: 'PITCH',
+        limit: 100,
+      }),
+    ])
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
### Task
`dream-cycle/t-006`, directed by Silas: repair the Daily Dream slideshow in Home / For You, which falsely reported that no Daily Dreams existed.

### Root cause
The slideshow queried `/api/dreams` with `mine=true` and searched only for the retired designer marker `Daily Dream Facet Engine`. Current canonical builds are public Dreams owned by the production automation user, marked `designer: "dream-cycle"`, so the request returned zero rows. The client filter repeated the same obsolete assumption.

The live canonical query currently returns 13 PITCH candidates. Four are retired vibe shadow rows with no PitchSheet; nine are actual Daily Dream world builds.

### What changed
- Removed the current-user-only restriction.
- Load canonical `dream-cycle` PITCH records and retain the legacy Facet Engine query as a compatibility fallback.
- Recognize canonical world builds only when they have a PitchSheet, excluding retired vibe shadow rows from the slideshow.
- Preserve the existing legacy designer and `daily-dream-*` slug recognition.

### Verification
- Live production API: `search=dream-cycle&dreamType=PITCH` returns 13 candidates; the new world predicate selects the nine real builds.
- Live production API: the old `Daily Dream Facet Engine` search returns zero, reproducing the empty-state bug.
- Branch diff is one component file, 29 additions and 10 deletions.
- GitHub checks will be inspected and fixed before merge. This `worker/*` branch does not receive a Vercel preview by repository policy, so the rendered Home page will be verified on the production deployment after the green merge.

### Stakes
Reversible read/query and display filtering only. No database writes, schema changes, generated content, email sends, billing, secrets, or DNS changes.

### Flags for Reviewer
The shared Dream store continues to own all API calls. Filtered fetches only merge their returned rows, so the narrow slideshow query does not erase unrelated cached Dreams.