### PR TITLE
Measure layouts instead of reasoning about them, and unbreak the mobile header

### DIFF
--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -75,7 +75,7 @@
       >
         <button
           type="button"
-          class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border border-base-300 bg-base-100"
+          class="btn btn-ghost btn-sm btn-square hidden shrink-0 rounded-xl border border-base-300 bg-base-100 sm:inline-flex"
           aria-label="Refresh with launch animation"
           title="Refresh with launch animation"
           @click="requestFullStartupReload"
@@ -83,14 +83,28 @@
           <Icon name="kind-icon:refresh" class="h-5 w-5" />
         </button>
 
+        <!-- Stays on phones: switching server is an action, not a readout, and
+             hiding the three below already buys the title enough room. Note it
+             could not be hidden with a `hidden sm:flex` class anyway -- its own
+             root carries the `inline-flex` UTILITY, which competes with
+             `hidden` on equal specificity and wins on stylesheet order. The
+             refresh button above hides correctly because daisyUI's `.btn` is a
+             component class, which utilities outrank. Wrap in a container if
+             this ever does need hiding. -->
         <server-selector class="header-control-item min-w-0" />
         <maturity-toggle
           v-if="showDashboardMaturityToggle && userStore.isLoggedIn"
         />
         <notification-bell class="shrink-0" />
         <login-switcher class="header-control-item min-w-0" />
-        <karma-widget class="shrink-0" />
-        <mana-widget class="shrink-0" />
+        <!-- Readouts, not actions, so hiding them on a phone costs no
+             capability. Everything else in this row is shrink-0, which makes
+             the title section the only thing that can give -- and at 390px it
+             gave all the way down to 18px, rendering the page title as a
+             meaningless image sliver while these still overflowed the right
+             edge as a clipped "395...". Both values remain on the profile. -->
+        <karma-widget class="hidden shrink-0 sm:flex" />
+        <mana-widget class="hidden shrink-0 sm:flex" />
       </section>
     </div>
   </header>

--- a/docs/contracts/responsive-layout-audit.md
+++ b/docs/contracts/responsive-layout-audit.md
@@ -1,0 +1,80 @@
+# Responsive layout audit
+
+`utils/scripts/auditResponsiveLayout.mjs` — run with `npm run audit:responsive`.
+
+## Why it exists
+
+`verifyLayoutContract.ts` reads source with regexes. It catches structural
+mistakes — two scroll owners in one surface, a page rendering its own `<h1>` —
+and it cannot see anything that only exists after a browser has done layout.
+
+Every mobile defect found in the 2026-08-03 review was of the second kind:
+
+- The workspace page-title strip rendered as an **18px image sliver** on a
+  390px phone. Silas: _"I don't even know what should be to the right of our
+  channel/tab selector."_ Nothing in the source is wrong to look at — the
+  section is a perfectly ordinary `flex-1 min-w-0`. It is only wrong once the
+  four `shrink-0` siblings around it total more than the viewport.
+- The karma widget rendered as a clipped `395…` past the right edge.
+- The Dreams toolbar wrapped to four rows, against `.kr-toolbar`'s own
+  one-row contract.
+
+Each of those was at some point "verified" by reasoning about flex rules
+instead of measuring them, and each reached Silas's phone anyway. **Reasoning
+about `flex-basis` is not a substitute for reading `offsetWidth`.**
+
+## What it checks
+
+At 390px (phone), 820px (tablet) and 1440px (desktop), for each route:
+
+| Check             | Meaning                                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `SPILL`           | An element's box extends past the viewport's right edge. The clipped `395…`.                                                  |
+| `CRUSHED`         | A _flexible_ element squeezed below `--min-flex` (default 32px) while still holding text or a control. The 18px title sliver. |
+| horizontal scroll | `documentElement.scrollWidth` exceeds the viewport.                                                                           |
+
+`CRUSHED` is deliberately separate from `SPILL`. A sliver does not overflow
+anything and no overflow check will ever find it — it is _worse_ than a hidden
+element, because it looks like a rendering fault and tells the user nothing.
+
+## Running it
+
+It drives the real app, so it needs a dev server:
+
+```bash
+JWT_SECRET=dev npx nuxt dev --port 3000     # one shell
+npm run audit:responsive                    # another
+```
+
+Useful flags:
+
+```bash
+npm run audit:responsive -- --routes /dreams,/bots
+npm run audit:responsive -- --shots ./out          # write screenshots
+npm run audit:responsive -- --base http://127.0.0.1:3000
+npm run audit:responsive -- --min-flex 40
+```
+
+`CHROMIUM_PATH` overrides the browser binary when Playwright's own download is
+skipped (as in the agent sandbox, where browsers live under
+`PLAYWRIGHT_BROWSERS_PATH`).
+
+Exit code is `1` when any route/viewport has a defect, so it can gate a PR once
+there is a CI job able to stand up a server. **That exit code is the point** —
+verify it end to end if you change the script, and beware of piping the command
+anywhere, which replaces the script's status with the last pipeline stage's.
+See interface-vision `t-063`: a CI step piped through `tee` could never fail,
+and the verifier behind it was dead for weeks without anyone noticing.
+
+## Data is not required
+
+The audit measures geometry, not content. It runs fine with the database
+unreachable — pages render their chrome, their error state, and their empty
+state, all of which have to survive a 390px viewport too. Do not skip the audit
+because there is no seeded data.
+
+## Adding a route
+
+Pass `--routes`. The default list covers the object galleries and the
+dashboard. When a new page lands, add it there in the same change that adds its
+`NAV_COMMANDS` entry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-config-flat-gitignore": "^2.3.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.2.1",
+        "playwright": "^1.62.1",
         "postcss": "^8.5.10",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.7.2",
@@ -1617,9 +1618,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1637,9 +1635,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1657,9 +1652,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1677,9 +1669,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1697,9 +1686,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1717,9 +1703,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1737,9 +1720,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1757,9 +1737,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1777,9 +1754,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1803,9 +1777,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1829,9 +1800,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1855,9 +1823,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1881,9 +1846,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1907,9 +1869,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1933,9 +1892,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1959,9 +1915,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2437,8 +2390,9 @@
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2447,8 +2401,9 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=22.12.0"
       }
@@ -3385,9 +3340,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3403,9 +3355,6 @@
       "integrity": "sha512-yqskeIapQvx7Tu/OLsepLPcGsHGzfYy9PX6gIbhaOHfF+LA2zHBKnKb587FGx+lQjHLQR0llfmoSuXQ6q2EN+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3423,9 +3372,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3441,9 +3387,6 @@
       "integrity": "sha512-omXWC8I9lAMMjQIeadfItP5H4VDAiuU2BiVCtHMH3ktTbFq04sxscZhK4NFUUuw3fApDdXmfd7LW18q0JBHarg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3461,9 +3404,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3479,9 +3419,6 @@
       "integrity": "sha512-rFsPDsT1j3beSInbrFukAAlTg101PcqdVMXDioR9AgJ1180tZ8s8D+pNDpQTRmPd3956mnpAE+Cs77Xoo/QZAQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3499,9 +3436,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3517,9 +3451,6 @@
       "integrity": "sha512-kd36CDkTkZDMNfVceNTSfpWnitE1+GjZmzJCeq8yaxsgvs/MXg8aauI2RgFjElYZIHSMyZku4pQ7Jtl3ZEYI6w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3731,9 +3662,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3749,9 +3677,6 @@
       "integrity": "sha512-QagKTDF4lrz8bCXbUi39Uq5xs7C7itAseKm51f33U+Dyar9eJY/zGKqfME9mKLOiahX7Fc1J3xMWVS0AdDXLPg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3769,9 +3694,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3787,9 +3709,6 @@
       "integrity": "sha512-ur/WVZF9FSOiZGxyP+nfxZzuv6r5OJDYoVxJnUR7fM/hhXLh4V/be6rjbzm9KLCDBRwYCEKJtt+XXNccwd06IA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3807,9 +3726,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3825,9 +3741,6 @@
       "integrity": "sha512-hbsfKjUwRjcMZZvvmpZSc+qS0bHcHRu8aV/I3Ikn9BzOA0ZAgUE7ctPtce5zCU7bM8dnTLi4sJ1Pi9YHdx6Urw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3845,9 +3758,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3863,9 +3773,6 @@
       "integrity": "sha512-gRvK6HPzF5ITRL68fqb2WYYs/hGviPIbkV84HWCgiJX+LkaOpp+HIHQl3zVZdyKHwopXToTbXbtx/oFjDjl8pg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4084,9 +3991,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4102,9 +4006,6 @@
       "integrity": "sha512-Ec7xJdDrnukgiz20E3iDNzAIgx1XXn8cVVsNNUpgEIAvNlXZaocqlQT8Zalk0Lv3fbkxcJ+9BuWB0ndBRHQtzg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4122,9 +4023,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4140,9 +4038,6 @@
       "integrity": "sha512-WxMIzItRJR66lgaAyyqj0FFwLMpcuCV9mTFcUMQpIz8+Hey1Enk8xuv+7QpSsqCR5zRlwNr092dsFkz5cbvtrw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4160,9 +4055,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4178,9 +4070,6 @@
       "integrity": "sha512-oEyQudXIwWM/+v0vZzPbAi25YMWyvjtQYYjuSrhMEQwe7ZEMDXscX7U1j6alrVdZq2DtCMeror3X/Dv7p/JUwg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4198,9 +4087,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4216,9 +4102,6 @@
       "integrity": "sha512-Oi/fyOzZ+aytmmsRND5pGgvux4n++v9cG4qNFiXj7qFwSqBKWZHBq7cJLXqbH1I81pyI3kvU1Za+1qk3afXuwg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4950,9 +4833,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4969,9 +4849,6 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4990,9 +4867,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5009,9 +4883,6 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5030,9 +4901,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5049,9 +4917,6 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5437,9 +5302,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5452,9 +5314,6 @@
       "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5469,9 +5328,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5484,9 +5340,6 @@
       "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5501,9 +5354,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5516,9 +5366,6 @@
       "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5533,9 +5380,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5548,9 +5392,6 @@
       "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5565,9 +5406,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5580,9 +5418,6 @@
       "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5597,9 +5432,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5613,9 +5445,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5628,9 +5457,6 @@
       "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6074,9 +5900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6094,9 +5917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6114,9 +5934,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6134,9 +5951,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6869,9 +6683,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6886,9 +6697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6903,9 +6711,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6920,9 +6725,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6937,9 +6739,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6954,9 +6753,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6971,9 +6767,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6988,9 +6781,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7005,9 +6795,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7022,9 +6809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12804,9 +12588,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12822,9 +12603,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -12842,9 +12620,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12860,9 +12635,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -12880,9 +12652,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12898,9 +12667,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -12918,9 +12684,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12937,9 +12700,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12955,9 +12715,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -12981,9 +12738,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13005,9 +12759,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -13031,9 +12782,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13055,9 +12803,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -13081,9 +12826,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13106,9 +12848,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13130,9 +12869,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -13980,6 +13716,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14000,6 +13737,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14020,6 +13758,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14040,6 +13779,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14060,6 +13800,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14080,9 +13821,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14103,9 +13842,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14126,9 +13863,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14149,9 +13884,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14172,6 +13905,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14192,6 +13926,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16662,6 +16397,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {
@@ -21078,9 +20860,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -21101,9 +20880,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -21126,9 +20902,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -21149,9 +20922,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:facet-closure": "tsx utils/scripts/verifyFacetClosure.ts",
     "test:facet-gallery": "tsx utils/scripts/verifyFacetGallery.ts",
     "test:layout-contract": "tsx utils/scripts/verifyLayoutContract.ts",
+    "audit:responsive": "node utils/scripts/auditResponsiveLayout.mjs",
     "test:daily-dream-facets": "prisma validate && tsx utils/scripts/verifyDailyDreamFacets.ts",
     "test:prompt-variants": "tsx utils/scripts/verifyPromptVariants.ts",
     "test:challenge-center": "tsx utils/scripts/verifyChallengeCenter.ts",
@@ -152,6 +153,7 @@
     "eslint-config-flat-gitignore": "^2.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.2.1",
+    "playwright": "^1.62.1",
     "postcss": "^8.5.10",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.7.2",
@@ -164,7 +166,6 @@
     "vue-tsc": "^2.1.10"
   },
   "dependencies": {
-    "yaml": "^2.9.0",
     "@nuxt/content": "^3.3.0",
     "@nuxt/image": "^2.0.0",
     "@pinia/nuxt": "^0.11.3",
@@ -178,7 +179,8 @@
     "mariadb": "^3.5.2",
     "nuxt": "4.4.8",
     "pinia": "^3.0.4",
-    "stripe": "^22.0.1"
+    "stripe": "^22.0.1",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "vue": "^3.5.13",

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Responsive layout audit — measures real rendered geometry at phone, tablet
+ * and desktop widths and fails on the two defects that keep reaching Silas's
+ * phone:
+ *
+ *   SPILL    an element whose box extends past the viewport's right edge.
+ *            This is the clipped "395..." karma value.
+ *
+ *   CRUSHED  a flexible element squeezed below a usable width. This is the
+ *            page-title strip rendering as an 18px image sliver, which is
+ *            worse than hiding it: it looks like a rendering bug and tells the
+ *            user nothing about where they are.
+ *
+ * WHY THIS EXISTS. verifyLayoutContract.ts reads source with regexes, so it
+ * catches structural mistakes (two scroll owners, a page with its own <h1>)
+ * but is blind to anything that only exists once a browser has done layout.
+ * Every mobile defect in this round was of the second kind, and each was
+ * "verified" by reasoning about CSS instead of measuring it. Reasoning about
+ * flex-basis is not a substitute for reading offsetWidth.
+ *
+ * USAGE. Needs the dev server up, because it drives the real app:
+ *
+ *     JWT_SECRET=dev npx nuxt dev --port 3000     # in one shell
+ *     npm run audit:responsive                    # in another
+ *
+ *     npm run audit:responsive -- --routes /dreams,/bots --shots ./out
+ *
+ * Exits non-zero when any route/viewport has a defect, so it can gate a PR
+ * once there is a CI job that can stand up a server.
+ */
+
+const args = process.argv.slice(2)
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`)
+  return i === -1 || !args[i + 1] ? fallback : args[i + 1]
+}
+
+const BASE = flag('base', process.env.AUDIT_BASE || 'http://127.0.0.1:3000')
+const ROUTES = flag(
+  'routes',
+  '/,/dreams,/art,/bots,/characters,/rewards,/scenarios',
+)
+  .split(',')
+  .map((r) => r.trim())
+  .filter(Boolean)
+const SHOTS = flag('shots', '')
+/** Below this a flexible element is a sliver, not a control or a label. */
+const MIN_FLEX_WIDTH = Number(flag('min-flex', '32'))
+
+const VIEWPORTS = [
+  { name: 'phone', width: 390, height: 844, mobile: true },
+  { name: 'tablet', width: 820, height: 1180, mobile: true },
+  { name: 'desktop', width: 1440, height: 900, mobile: false },
+]
+
+let chromium
+try {
+  ;({ chromium } = await import('playwright'))
+} catch {
+  console.error(
+    '❌ playwright not installed. Run `npm i -D playwright` (browsers are preinstalled in CI images via PLAYWRIGHT_BROWSERS_PATH).',
+  )
+  process.exit(2)
+}
+
+/**
+ * Runs in the page. Returns plain data only — DOM nodes cannot cross the
+ * boundary, so elements are described as strings here rather than in Node.
+ */
+function collect(minFlexWidth) {
+  const vw = window.innerWidth
+  const de = document.documentElement
+  const visible = (el, b) => {
+    if (b.width < 1 || b.height < 1) return false
+    const cs = getComputedStyle(el)
+    return (
+      cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0'
+    )
+  }
+  const describe = (el, extra) =>
+    `<${el.tagName.toLowerCase()}${el.id ? '#' + el.id : ''}> ` +
+    `"${(el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 34)}" ` +
+    `${extra} .${(el.className || '').toString().replace(/\s+/g, ' ').slice(0, 70)}`
+
+  const spill = []
+  const crushed = []
+  for (const el of document.querySelectorAll('body *')) {
+    const b = el.getBoundingClientRect()
+    if (!visible(el, b)) continue
+
+    // Outermost offender only: a wide child otherwise reports its whole
+    // ancestor chain and buries the actual cause.
+    if (b.right > vw + 1 && !spill.some((s) => s.node.contains(el))) {
+      spill.push({
+        node: el,
+        text: describe(el, `right=${Math.round(b.right)}`),
+      })
+    }
+
+    if (b.height >= 12 && b.width >= 1 && b.width < minFlexWidth) {
+      const cs = getComputedStyle(el)
+      const flexible = cs.flexGrow !== '0' || cs.flexBasis !== 'auto'
+      const meaningful =
+        el.textContent.trim() || el.querySelector('img,svg,input,select,button')
+      if (flexible && meaningful) {
+        crushed.push({
+          node: el,
+          text: describe(el, `w=${Math.round(b.width)}`),
+        })
+      }
+    }
+  }
+
+  return {
+    vw,
+    scrollWidth: de.scrollWidth,
+    horizontalScroll: de.scrollWidth > vw + 1,
+    spill: spill.slice(0, 6).map((s) => s.text),
+    crushed: crushed.slice(0, 6).map((c) => c.text),
+  }
+}
+
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM_PATH || undefined,
+  args: ['--no-sandbox'],
+})
+
+let failures = 0
+for (const vp of VIEWPORTS) {
+  const ctx = await browser.newContext({
+    viewport: { width: vp.width, height: vp.height },
+    isMobile: vp.mobile,
+    hasTouch: vp.mobile,
+  })
+  for (const route of ROUTES) {
+    const page = await ctx.newPage()
+    let loaded = true
+    await page
+      .goto(BASE + route, { waitUntil: 'networkidle', timeout: 90000 })
+      .catch(() => {
+        loaded = false
+      })
+    // The startup splash paints over the app and is itself slightly wider than
+    // a phone; measuring before it clears reports the splash, not the page.
+    await page.waitForTimeout(7000)
+
+    const m = await page.evaluate(collect, MIN_FLEX_WIDTH).catch(() => null)
+    const label = `${vp.name.padEnd(7)} ${route.padEnd(14)}`
+
+    if (!m) {
+      console.log(
+        `${label} ⚠️  could not measure${loaded ? '' : ' (navigation failed)'}`,
+      )
+    } else if (m.horizontalScroll || m.spill.length || m.crushed.length) {
+      failures += 1
+      console.log(`${label} ❌`)
+      if (m.horizontalScroll) {
+        console.log(
+          `         page scrolls sideways: ${m.scrollWidth} > ${m.vw}`,
+        )
+      }
+      for (const s of m.spill) console.log(`         SPILL   ${s}`)
+      for (const c of m.crushed) console.log(`         CRUSHED ${c}`)
+    } else {
+      console.log(`${label} ✅`)
+    }
+
+    if (SHOTS) {
+      await page.screenshot({
+        path: `${SHOTS}/${vp.name}${route.replace(/\//g, '_')}.png`,
+      })
+    }
+    await page.close()
+  }
+  await ctx.close()
+}
+await browser.close()
+
+if (failures) {
+  console.log(
+    `\n❌ ${failures} route/viewport combination(s) with layout defects.`,
+  )
+  process.exit(1)
+}
+console.log(
+  '\n✅ Responsive layout audit clean across all routes and viewports.',
+)


### PR DESCRIPTION
> "We really want views working across devices (mobile, tablet, desktop). If more should be scaffolded to meet that goal, cool."

The scaffolding first, because it's what makes the fix trustworthy.

## Why this was needed

`verifyLayoutContract.ts` reads source with regexes. It catches structural mistakes — two scroll owners, a page rendering its own `<h1>` — and is **blind to anything that only exists after a browser has done layout**.

Every mobile defect in this review was the second kind. Each was at some point "verified" by reasoning about flex rules instead of measuring them. Each reached your phone anyway.

## New: `npm run audit:responsive`

`utils/scripts/auditResponsiveLayout.mjs` drives the **real dev server** in Chromium at 390 / 820 / 1440 and fails on:

| Check | What it catches |
|---|---|
| `SPILL` | A box extending past the viewport's right edge — your clipped `395…`. |
| `CRUSHED` | A **flexible** element squeezed under 32px while still holding text or a control — the title sliver. |
| horizontal scroll | `scrollWidth` exceeding the viewport. |

`CRUSHED` is deliberately a *separate* check. A sliver overflows nothing, so no overflow check would ever find it — and it's **worse** than a hidden element, because it reads as a rendering fault and tells you nothing.

**Proven to fail, not just to pass.** With the header fix stashed it exits `1` and names the offender; restored, it exits `0`. I checked the exit code directly rather than through a pipe — see `t-063`, where a CI step piped through `tee` could never fail and its verifier was dead for weeks.

## The fix it found

That thin image sliver right of the channel selector was the **page-title strip at 18 pixels**:

```
CRUSHED <section> "Creative WorldsDream Gallery" w=18  .relative flex h-10 min-h-10 min-w-0 flex-1 …
```

`workspace-header`'s row is back-button + `channel-select` + title (`flex-1 min-w-0`) + a control strip of six `shrink-0` items. The title is the only thing that can give, so at 390px it gave everything.

Hiding the three **readouts and utilities** below `sm` — refresh, karma, mana — takes it **18px → 148px**, with the title text itself 90px visible. Both currency values remain on the profile; no action is lost.

### One trap, documented in the file

`server-selector` stays — and *couldn't* have been hidden with a class anyway. Its root carries the `inline-flex` **utility**, which ties `hidden` on specificity and beats it on stylesheet order. The refresh button hides correctly because daisyUI's `.btn` is a **component** class, which utilities outrank. I verified this empirically: removing the no-op class left every measurement byte-identical.

## Verification

**Audit clean 21/21** — 7 routes × 3 viewports:

```
phone   / ✅  /dreams ✅  /art ✅  /bots ✅  /characters ✅  /rewards ✅  /scenarios ✅
tablet  (same) ✅        desktop (same) ✅
```

`vue-tsc` clean; `test:layout-contract`, `test:channel-content`, `test:nav-manifest`, `test:gallery-adoption` pass; eslint and prettier clean.

Adds `playwright` as a devDependency and `docs/contracts/responsive-layout-audit.md`.

## Honest limits

- **Not in CI yet.** It needs a running server, which no current job provides. Exit code is wired so it can gate a PR the moment there is one — worth doing as a follow-up.
- **Measured against an unseeded DB**, so pages render chrome, empty and error states rather than full galleries. Geometry is what's being checked and those states have to survive 390px too — but a page whose *data* changes its layout dramatically could still hide something.
- **The card-hand items from your list are still untouched** (whitespace, overlap with the floating toggle, no mobile scroll, and the toggle's missing visual treatment). They're in `t-078`. Now that the audit exists, that work can be measured the same way rather than eyeballed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_