### PR TITLE
interface-vision/t-032: owner-facing allowReviews toggle for Bot/Character/Reward/Scenario

### DIFF
--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -385,13 +385,24 @@
       </section>
 
       <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
-        <div class="mb-4">
-          <h2 class="text-xl font-bold text-base-content">Publishing</h2>
+        <div
+          class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <h2 class="text-xl font-bold text-base-content">Publishing</h2>
 
-          <p class="text-sm text-base-content/70">
-            Control visibility and construction status. The text engine is
-            chosen at chat time.
-          </p>
+            <p class="text-sm text-base-content/70">
+              Control visibility and construction status. The text engine is
+              chosen at chat time.
+            </p>
+          </div>
+
+          <allow-reviews-toggle
+            v-if="mode === 'edit' && botStore.currentBot"
+            :allow-reviews="botStore.currentBot.allowReviews"
+            :saving="reviewsSaving"
+            @toggle="toggleAllowReviews"
+          />
         </div>
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
@@ -526,6 +537,7 @@ const useGenerated = reactive<Record<string, boolean>>({})
 const isGeneratingFields = ref(false)
 const statusMessage = ref('')
 const statusTone = ref<'success' | 'error'>('success')
+const reviewsSaving = ref(false)
 
 const mode = computed(() => props.mode)
 
@@ -823,6 +835,32 @@ async function generateSelectedFields() {
       error instanceof Error ? error.message : 'Failed to generate bot fields.'
   } finally {
     isGeneratingFields.value = false
+  }
+}
+
+async function toggleAllowReviews() {
+  if (!botStore.currentBot) return
+
+  reviewsSaving.value = true
+  statusMessage.value = ''
+
+  try {
+    const updated = await botStore.patchBotField(botStore.currentBot.id, {
+      allowReviews: !botStore.currentBot.allowReviews,
+    })
+
+    if (!updated) {
+      statusTone.value = 'error'
+      statusMessage.value = botStore.lastError || 'Failed to update reviews.'
+      return
+    }
+
+    statusTone.value = 'success'
+    statusMessage.value = updated.allowReviews
+      ? 'Reviews enabled.'
+      : 'Reviews disabled.'
+  } finally {
+    reviewsSaving.value = false
   }
 }
 

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -398,7 +398,20 @@
       </section>
 
       <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
-        <h2 class="mb-3 text-xl font-bold text-base-content">Record Settings</h2>
+        <div
+          class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <h2 class="text-xl font-bold text-base-content">Record Settings</h2>
+
+          <allow-reviews-toggle
+            v-if="mode === 'edit' && characterStore.selectedCharacter"
+            :allow-reviews="
+              Boolean(characterStore.selectedCharacter.allowReviews)
+            "
+            :saving="reviewsSaving"
+            @toggle="toggleAllowReviews"
+          />
+        </div>
 
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
           <label class="form-control">
@@ -539,6 +552,7 @@ const isGeneratingFields = ref(false)
 const statusMessage = ref('')
 const statusTone = ref<'success' | 'error'>('success')
 const characterFacetIds = ref<number[]>([])
+const reviewsSaving = ref(false)
 
 const mode = computed(() => props.mode)
 const title = computed(() =>
@@ -862,6 +876,34 @@ async function generateSelectedFields(): Promise<void> {
         : 'Failed to generate character fields.'
   } finally {
     isGeneratingFields.value = false
+  }
+}
+
+async function toggleAllowReviews() {
+  const character = characterStore.selectedCharacter
+  if (!character) return
+
+  reviewsSaving.value = true
+  statusMessage.value = ''
+
+  try {
+    const updated = await characterStore.updateCharacter(character.id, {
+      allowReviews: !character.allowReviews,
+    })
+
+    if (!updated) {
+      statusTone.value = 'error'
+      statusMessage.value =
+        characterStore.lastError || 'Failed to update reviews.'
+      return
+    }
+
+    statusTone.value = 'success'
+    statusMessage.value = updated.allowReviews
+      ? 'Reviews enabled.'
+      : 'Reviews disabled.'
+  } finally {
+    reviewsSaving.value = false
   }
 }
 

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -735,23 +735,13 @@
                   linkedProject.isMature ? 'Mature' : 'Safe'
                 }}
               </button>
-              <button
-                type="button"
-                class="btn btn-sm gap-1.5 rounded-xl"
-                :class="
-                  linkedProject.allowReviews
-                    ? 'btn-accent'
-                    : 'btn-ghost border border-base-300'
-                "
-                :disabled="projectSaving"
-                @click="
+              <allow-reviews-toggle
+                :allow-reviews="Boolean(linkedProject.allowReviews)"
+                :saving="projectSaving"
+                @toggle="
                   patchProject({ allowReviews: !linkedProject.allowReviews })
                 "
-              >
-                <Icon name="kind-icon:chat" class="size-3.5" />{{
-                  linkedProject.allowReviews ? 'Reviews On' : 'Reviews Off'
-                }}
-              </button>
+              />
               <span
                 v-if="projectSaving"
                 class="loading loading-spinner loading-xs self-center text-primary"

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -21,6 +21,14 @@
     </div>
 
     <template v-else>
+      <div v-if="mode === 'edit'" class="flex justify-end">
+        <allow-reviews-toggle
+          :allow-reviews="Boolean(rewardStore.selectedReward?.allowReviews)"
+          :saving="reviewsSaving"
+          @toggle="toggleAllowReviews"
+        />
+      </div>
+
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <label class="form-control">
           <span class="label">
@@ -320,6 +328,7 @@ const uploadStore = useUploadStore()
 const isGeneratingArt = ref(false)
 const statusMessage = ref('')
 const statusTone = ref<'success' | 'error'>('success')
+const reviewsSaving = ref(false)
 
 const defaultPlaceholder = '/images/chest1.webp'
 
@@ -494,6 +503,34 @@ async function generateArtImage() {
       error instanceof Error ? error.message : 'Error generating reward art.'
   } finally {
     isGeneratingArt.value = false
+  }
+}
+
+async function toggleAllowReviews() {
+  const reward = rewardStore.selectedReward
+  if (!reward) return
+
+  reviewsSaving.value = true
+  statusMessage.value = ''
+
+  try {
+    const result = await rewardStore.updateReward(reward.id, {
+      ...reward,
+      allowReviews: !reward.allowReviews,
+    })
+
+    if (!result.success) {
+      statusTone.value = 'error'
+      statusMessage.value = result.message || 'Failed to update reviews.'
+      return
+    }
+
+    statusTone.value = 'success'
+    statusMessage.value = result.data?.allowReviews
+      ? 'Reviews enabled.'
+      : 'Reviews disabled.'
+  } finally {
+    reviewsSaving.value = false
   }
 }
 

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -21,6 +21,14 @@
     </div>
 
     <template v-else>
+      <div v-if="mode === 'edit'" class="flex justify-end">
+        <allow-reviews-toggle
+          :allow-reviews="Boolean(scenarioStore.selectedScenario?.allowReviews)"
+          :saving="reviewsSaving"
+          @toggle="toggleAllowReviews"
+        />
+      </div>
+
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <label class="form-control">
           <span class="label">
@@ -330,6 +338,7 @@ const statusMessage = ref('')
 const statusTone = ref<'success' | 'error'>('success')
 const uploadedPreviewImage = ref<string | null>(null)
 const facetIds = ref<number[]>([])
+const reviewsSaving = ref(false)
 
 const defaultPlaceholder = '/images/scenarios/space.webp'
 
@@ -609,6 +618,35 @@ async function generateArtImage() {
       error instanceof Error ? error.message : 'Error generating scenario art.'
   } finally {
     isGeneratingArt.value = false
+  }
+}
+
+async function toggleAllowReviews() {
+  const scenario = scenarioStore.selectedScenario
+  if (!scenario) return
+
+  reviewsSaving.value = true
+  statusMessage.value = ''
+
+  try {
+    const updated = await scenarioStore.updateScenario(scenario.id, {
+      ...scenario,
+      allowReviews: !scenario.allowReviews,
+    })
+
+    if (!updated) {
+      statusTone.value = 'error'
+      statusMessage.value =
+        scenarioStore.lastError || 'Failed to update reviews.'
+      return
+    }
+
+    statusTone.value = 'success'
+    statusMessage.value = updated.allowReviews
+      ? 'Reviews enabled.'
+      : 'Reviews disabled.'
+  } finally {
+    reviewsSaving.value = false
   }
 }
 

--- a/components/ui/allow-reviews-toggle.vue
+++ b/components/ui/allow-reviews-toggle.vue
@@ -1,0 +1,26 @@
+<!-- /components/ui/allow-reviews-toggle.vue -->
+<!-- Owner-facing allowReviews toggle, shared across Project/Bot/Character/Reward/Scenario edit surfaces. -->
+<template>
+  <button
+    type="button"
+    class="btn btn-sm gap-1.5 rounded-xl"
+    :class="allowReviews ? 'btn-accent' : 'btn-ghost border border-base-300'"
+    :disabled="saving"
+    @click="$emit('toggle')"
+  >
+    <Icon name="kind-icon:chat" class="size-3.5" />{{
+      allowReviews ? 'Reviews On' : 'Reviews Off'
+    }}
+  </button>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  allowReviews: boolean
+  saving?: boolean
+}>()
+
+defineEmits<{
+  toggle: []
+}>()
+</script>

--- a/stores/botStore.ts
+++ b/stores/botStore.ts
@@ -649,6 +649,31 @@ export const useBotStore = defineStore('botStore', () => {
     await updateCurrentBot()
   }
 
+  async function patchBotField(
+    id: number,
+    patch: Partial<Bot>,
+  ): Promise<Bot | null> {
+    try {
+      clearError()
+
+      const updated = await updateBot(id, patch)
+
+      if (updated) {
+        const merged = upsertBot(updated)
+        if (currentBot.value?.id === merged.id) {
+          botForm.value = toBotForm(merged)
+        }
+        return merged
+      }
+
+      return null
+    } catch (error: unknown) {
+      handleError(error, 'patchBotField')
+      setLastError(error, 'Failed to update bot')
+      return null
+    }
+  }
+
   async function saveBot(): Promise<BotSaveResult> {
     isSaving.value = true
 
@@ -983,6 +1008,7 @@ export const useBotStore = defineStore('botStore', () => {
 
     updateCurrentBot,
     saveUserIntro,
+    patchBotField,
     saveBot,
     deleteBotById,
     addBotsToStore,

--- a/stores/rewardStore.ts
+++ b/stores/rewardStore.ts
@@ -232,6 +232,7 @@ function toRewardPayload(form: RewardForm): Partial<Reward> {
     isMature: Boolean(normalized.isMature),
     isPublic: normalized.isPublic ?? true,
     isActive: normalized.isActive ?? true,
+    allowReviews: Boolean(normalized.allowReviews),
   }
 }
 


### PR DESCRIPTION
### Task
interface-vision/t-032: Add an owner-facing allowReviews toggle for Bot/Character/Reward/Scenario (kind: software)

### What changed / what I produced
- New `components/ui/allow-reviews-toggle.vue` — extracted `conductor-page.vue`'s inline Project `allowReviews` button (instant-click, `btn-accent`/`btn-ghost` styling) into a small reusable component. `conductor-page.vue` now uses it too, so there's one implementation instead of five near-duplicates.
- Wired the toggle into each entity's own owner-facing edit surface:
  - `components/bots/add-bot.vue` — Publishing section header. New `botStore.patchBotField(id, patch)` action (Bot had no lean single-field patch action; the existing `updateBot` helper is a plain spread so a partial patch is safe, but nothing synced it back into `bots`/`currentBot` local state).
  - `components/characters/add-character.vue` — Record Settings section header. Uses the already-exported `characterStore.updateCharacter(id, updates)`, safe with a partial patch since `toCharacterMutationPayload` is a plain destructure/spread.
  - `components/rewards/add-reward.vue` — top-right of the edit form. Uses `rewardStore.updateReward`.
  - `components/scenarios/add-scenario.vue` — top-right of the edit form. Uses `scenarioStore.updateScenario`.

### Correctness details worth flagging
- `rewardStore.toRewardPayload()` is an explicit field whitelist that was missing `allowReviews` entirely — the toggle would have silently no-op'd on save. Added `allowReviews: Boolean(normalized.allowReviews)`.
- `toRewardPayload()` and `toScenarioPayload()` both rebuild their *entire* PATCH payload from whatever `updates` object is passed in, filling in defaults for anything missing (e.g. `toRewardPayload` defaults a missing `name` to `''`; `toScenarioPayload` defaults missing `intros` to `'[]'`). Calling `updateReward`/`updateScenario` with only `{ allowReviews }` would have silently wiped the reward's name or the scenario's intros on toggle. Both call sites instead pass the full current entity (`{ ...reward, allowReviews: !reward.allowReviews }`) plus the flip, matching how `saveReward`/`saveScenario` already do full-form saves.
- Bot (`updateBot` helper) and Character (`toCharacterMutationPayload`) don't have this issue — both are plain spreads — so their toggles pass a lean single-field patch.

### How I verified
- `npm run test` (vue-tsc --noEmit) — clean, 0 errors.
- `npx eslint` on all touched files — 0 new errors. The 7 errors eslint reports across `add-bot.vue`/`botStore.ts`/`rewardStore.ts` are pre-existing (confirmed identical set, same rules, on `main` before this diff via `git stash`).
- `npx prettier --check` — clean on every touched file except the 4 that were already prettier-non-compliant on `main` before this diff (`conductor-page.vue`, `add-bot.vue`, `add-character.vue`, `botStore.ts` — confirmed via `git stash` + `--check` against `main`); left those files' pre-existing formatting untouched rather than reformatting unrelated code.

### Stakes
reversible

### Flags for Reviewer
- Placement of the toggle in each form is my own call (task note didn't specify exact placement) — a section header row next to the section title in each case, consistent with how it sits in the Publishing/toolbar area of `conductor-page.vue`.
- No local DB, so the actual PATCH round-trip couldn't be exercised end-to-end; verified via typecheck + reading each store action's existing, already-tested code path.

### Kaizen suggestion
`add-reward.vue` and `add-scenario.vue` have no `isPublic`/`isMature` UI at all today (only read-only badges elsewhere) — Reward and Scenario owners currently can't toggle those from their own edit surface either, same gap `t-032` just fixed for `allowReviews`. Worth a follow-up task mirroring this one for those two fields.

### Notes for reviewer
Companion conductor PR will set `interface-vision/t-032` to `status: review` and reference this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_013JiJHK9jshV2WE2W4wZUL6)_