### PR TITLE
Kill List, make the title a tab selector, free the hand from the dock

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -96,7 +96,6 @@
             <NuxtPage />
           </div>
         </main>
-
       </section>
     </section>
 
@@ -119,10 +118,9 @@
       <div
         class="pointer-events-auto fixed bottom-3 right-3 z-40 flex items-end gap-2"
       >
-
         <button
           type="button"
-          class="kr-workspace-dock group relative shrink-0 overflow-hidden rounded-full border-2 border-primary/40 bg-base-300/95 shadow-2xl transition duration-200 hover:scale-105 hover:border-primary/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          class="kr-workspace-dock group relative shrink-0 overflow-hidden rounded-full border-2 border-primary/70 bg-base-100 shadow-2xl ring-2 ring-base-100/80 transition duration-200 hover:scale-105 hover:border-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           :aria-label="bottomDockLabel"
           :title="bottomDockLabel"
           :aria-expanded="handOpen"
@@ -211,7 +209,6 @@ function syncBreakpoints(): void {
   if (xlMedia) isXl.value = xlMedia.matches
 }
 
-
 const SHEET_W_MD = '20rem'
 const SHEET_W_XL = '24rem'
 const DOCK_CIRCLE_MD = '4.5rem'
@@ -250,11 +247,23 @@ const shellVars = computed<CSSProperties>(() => {
 const footerVars = computed<CSSProperties>(() => {
   return {
     left: 'var(--sheet-w)',
-    right: '0px',
+    /*
+     * Stop the hand before the dock button instead of running underneath it.
+     * The dock is a sibling overlay pinned bottom-right, so a footer ending at
+     * right:0 necessarily passes behind it — measured at 390px, the hand's
+     * right edge was 382 while the dock started at 294, so 88px of cards sat
+     * under the button and the last card could not be reached. Silas: "the
+     * toggle is still over the hand display ... [it] should stop horizontally
+     * before it hits the toggle."
+     *
+     * --dock-circle is the button's own size and 0.75rem matches its `right-3`
+     * inset, so this tracks the dock at every breakpoint rather than hardcoding
+     * a width that would drift the moment the button is resized.
+     */
+    right: 'calc(var(--dock-circle) + 0.75rem + 0.5rem)',
     height: 'var(--footer-h)',
   } as CSSProperties
 })
-
 
 const bottomDockLabel = computed(() =>
   handOpen.value ? 'Hide cards' : 'Show cards',
@@ -263,7 +272,6 @@ const bottomDockLabel = computed(() =>
 const bottomDockActionIcon = computed(() =>
   handOpen.value ? 'kind-icon:close' : 'kind-icon:card',
 )
-
 
 function toggleCards(): void {
   handOpen.value = !handOpen.value
@@ -279,9 +287,8 @@ watch(
     navStore.recordVisit(path)
 
     if (previousPath !== undefined) {
-      void import('@/stores/achievementStore').then(
-        ({ useAchievementStore }) =>
-          useAchievementStore().rewardAchievementForPath(path),
+      void import('@/stores/achievementStore').then(({ useAchievementStore }) =>
+        useAchievementStore().rewardAchievementForPath(path),
       )
     }
   },
@@ -348,7 +355,6 @@ onBeforeUnmount(() => {
   width: var(--dock-circle);
 }
 
-
 @media (min-width: 768px) {
   .kr-main {
     padding-left: var(--sheet-w);
@@ -370,7 +376,6 @@ onBeforeUnmount(() => {
 
 .kr-hand-slide-enter-active,
 .kr-hand-slide-leave-active,
-
 @media (prefers-reduced-motion: reduce) {
   .kr-workspace-dock,
   .kr-hand-slide-enter-active,

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -563,12 +563,12 @@ const isCompact = computed(() => {
 /**
  * `dream-row` is a horizontal scroll-snap FILMSTRIP, and it exists only for the
  * embedded `variant="row"` prop — a Dream strip sitting inside another page.
- * It is not a view mode and must never be reachable from the mode toggle: an
- * earlier pass wired `list` to it on the assumption that "row" and "list" were
- * the same idea, which put a horizontal carousel behind a button labelled List
- * and left the rest of an xl viewport empty.
+ * It is not a view mode and must never be reachable from the mode toggle. A
+ * previous pass wired the old `list` mode to it, which put a horizontal
+ * carousel behind a button labelled List; `list` has since been removed
+ * entirely, but the rule outlives it — a layout is not a mode.
  *
- * The four real modes lay out through the shared MODE_GRID_CLASS, so Dreams
+ * The three real modes lay out through the shared MODE_GRID_CLASS, so Dreams
  * matches the Project gallery exactly.
  */
 const layoutClass = computed(() =>

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -11,7 +11,9 @@
       <Icon name="kind-icon:tag" class="size-5 text-secondary" />
       <div class="min-w-0 flex-1">
         <p class="font-black">{{ title }}</p>
-        <p v-if="subtitle" class="text-xs text-base-content/55">{{ subtitle }}</p>
+        <p v-if="subtitle" class="text-xs text-base-content/55">
+          {{ subtitle }}
+        </p>
       </div>
       <span
         v-if="catalog.loading"
@@ -62,7 +64,11 @@
         class="select select-bordered select-sm shrink-0 rounded-xl"
         aria-label="Facet gallery layout"
       >
-        <option v-for="entry in GALLERY_MODES" :key="entry.value" :value="entry.value">
+        <option
+          v-for="entry in GALLERY_MODES"
+          :key="entry.value"
+          :value="entry.value"
+        >
           {{ entry.label }}
         </option>
       </select>
@@ -74,9 +80,15 @@
 
     <!-- THE one scroll region. Everything above pins. -->
     <div class="kr-scroll space-y-6">
-      <div v-for="group in visibleGroups" :key="group.taxonomy" class="space-y-3">
+      <div
+        v-for="group in visibleGroups"
+        :key="group.taxonomy"
+        class="space-y-3"
+      >
         <div class="flex items-baseline gap-2">
-          <h2 class="text-lg font-black">{{ taxonomyLabel(group.taxonomy) }}</h2>
+          <h2 class="text-lg font-black">
+            {{ taxonomyLabel(group.taxonomy) }}
+          </h2>
           <span class="badge badge-secondary badge-sm">{{ group.total }}</span>
         </div>
 
@@ -98,8 +110,10 @@
           class="btn btn-ghost btn-sm w-full rounded-xl border border-base-300"
           @click="showMore(group.taxonomy)"
         >
-          Show more {{ taxonomyLabel(group.taxonomy) }}
-          ({{ group.entries.length }} of {{ group.total }})
+          Show more {{ taxonomyLabel(group.taxonomy) }} ({{
+            group.entries.length
+          }}
+          of {{ group.total }})
         </button>
       </div>
 
@@ -123,10 +137,8 @@ import {
 } from '@/stores/facetCatalogStore'
 import { normalizeFacetLookupKey } from '@/utils/facetAliases'
 import { resolveEntityArtwork } from '@/utils/artImageSrc'
-import type {
-  GalleryItem,
-  GalleryMode,
-} from '@/components/gallery/kr-gallery.vue'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { GALLERY_MODES, type GalleryMode } from '@/utils/galleryVocabulary'
 
 withDefaults(
   defineProps<{
@@ -153,12 +165,10 @@ const emit = defineEmits<{ select: [facet: FacetCatalogEntry] }>()
 
 const catalog = useFacetCatalogStore()
 
-const GALLERY_MODES = [
-  { value: 'cards' as const, label: 'Cards' },
-  { value: 'heroes' as const, label: 'Heroes' },
-  { value: 'icons' as const, label: 'Icons' },
-  { value: 'list' as const, label: 'List' },
-]
+// Was a private copy of the mode list — the ninth such duplicate, and the one
+// that survived the 2026-08-03 consolidation because it lived under a local
+// name rather than a shared type. Importing it is what keeps `list`'s removal
+// from having to be repeated per gallery.
 
 const search = ref('')
 const taxonomyFilter = ref<FacetTaxonomy | null>(null)
@@ -206,8 +216,11 @@ function iconName(facet: FacetCatalogEntry): string {
 }
 
 function toGalleryItem(facet: FacetCatalogEntry): GalleryItem {
-  const badges = [{ label: taxonomyLabel(facet.taxonomy), class: 'badge-outline' }]
-  if (facet.groupLabel) badges.push({ label: facet.groupLabel, class: 'badge-ghost' })
+  const badges = [
+    { label: taxonomyLabel(facet.taxonomy), class: 'badge-outline' },
+  ]
+  if (facet.groupLabel)
+    badges.push({ label: facet.groupLabel, class: 'badge-ghost' })
 
   return {
     id: facet.id,

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -56,7 +56,6 @@
         :key="item.id"
         type="button"
         class="group overflow-hidden rounded-2xl border border-base-300 bg-base-200 text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"
-        :class="itemClass"
         @click="emit('open', item)"
       >
         <div class="relative overflow-hidden" :class="imageWrapClass">
@@ -223,17 +222,12 @@ const emit = defineEmits<{
 }>()
 
 const gridClass = computed(() => MODE_GRID_CLASS[props.mode])
-const itemClass = computed(() =>
-  props.mode === 'list' ? 'grid md:grid-cols-[12rem_1fr]' : '',
-)
 const imageWrapClass = computed(() =>
   props.mode === 'heroes'
     ? 'min-h-64'
     : props.mode === 'icons'
       ? 'mx-auto mt-3 size-24 rounded-2xl'
-      : props.mode === 'list'
-        ? 'min-h-40'
-        : 'aspect-[4/3]',
+      : 'aspect-[4/3]',
 )
 const modeVariant = computed<ArtVariant>(() => MODE_VARIANT[props.mode])
 

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -4,7 +4,12 @@
     <button
       tabindex="0"
       type="button"
-      class="flex h-10 min-h-10 shrink-0 items-center gap-2 overflow-hidden rounded-xl border border-base-300 bg-base-100 px-2 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14 xl:gap-2.5 xl:px-3"
+      class="flex h-full min-h-10 shrink-0 items-center gap-2 overflow-hidden px-2 transition-all xl:gap-2.5 xl:px-3"
+      :class="
+        seamless
+          ? 'hover:bg-base-200'
+          : 'h-10 rounded-xl border border-base-300 bg-base-100 shadow-sm hover:-translate-y-0.5 hover:shadow-md sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14'
+      "
       :title="`Navigate ${activeChannel.label}`"
       aria-haspopup="menu"
       @click="scheduleChannelMenuViewportUpdate"
@@ -19,16 +24,13 @@
         />
       </span>
 
-      <span class="flex min-w-0 flex-col items-start leading-tight">
-        <span class="truncate text-sm font-black sm:text-base xl:text-lg">
-          {{ activeChannel.label }}
-        </span>
-        <span
-          v-if="activeTab"
-          class="hidden max-w-32 truncate text-[0.62rem] font-bold text-base-content/55 sm:block xl:max-w-40 xl:text-xs"
-        >
-          {{ activeTab.label }}
-        </span>
+      <!-- Channel only. The active tab used to be stacked underneath here,
+           which both duplicated the title section beside it and gave the
+           control the two-line drop Silas called awkward. The tab strip in
+           workspace-header now names the tab, and is selectable rather than
+           merely descriptive. -->
+      <span class="min-w-0 truncate text-sm font-black sm:text-base xl:text-lg">
+        {{ activeChannel.label }}
       </span>
 
       <Icon
@@ -255,6 +257,19 @@ import type {
 } from '@/stores/helpers/channelContent'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { usePageStore } from '@/stores/pageStore'
+import { tabSharesRoute } from '@/utils/tabNavigation'
+
+withDefaults(
+  defineProps<{
+    /**
+     * Drop this control's own border, rounding and shadow so it can sit inside
+     * a shared shell with the tab strip and read as one bar. The standalone
+     * (framed) form is still the default for any other mount.
+     */
+    seamless?: boolean
+  }>(),
+  { seamless: false },
+)
 
 type SubmenuMode = 'flyout' | 'inline'
 
@@ -503,10 +518,6 @@ function handleChannelMenuScroll(): void {
   if (submenuMode.value === 'flyout') {
     closeChannelTabs()
   }
-}
-
-function tabSharesRoute(channel: ResolvedChannel, tab: ResolvedTab): boolean {
-  return channel.tabs.filter((item) => item.route === tab.route).length > 1
 }
 
 function navigateToTab(channel: ResolvedChannel, tab: ResolvedTab): void {

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -19,56 +19,60 @@
         <Icon name="kind-icon:arrow-left" class="h-5 w-5" />
       </button>
 
-      <channel-select class="shrink-0" />
-
-      <section
-        class="relative flex h-10 min-h-10 min-w-0 flex-1 items-center gap-2 overflow-hidden rounded-xl border border-base-300 bg-base-100 px-2 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14 xl:gap-2.5 xl:px-3"
+      <!-- Channel picker and tab strip share one bordered shell so they read as
+           a single control. Silas: "We are using the title section as a title
+           section, when it really should be a tab selector for the current
+           channel ... integrating together so it looks more seamless and the
+           channel selector doesn't drop awkwardly below the current tab
+           title." Nothing is lost by dropping the old title: the active tab's
+           own label WAS the title, and it is now something you can act on. -->
+      <div
+        class="flex h-10 min-h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-xl border border-base-300 bg-base-100 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14"
       >
-        <img
-          v-if="activeTabConfig.image"
-          :src="activeTabConfig.image"
-          :alt="activeTabConfig.title || activeTabConfig.label"
-          class="absolute inset-0 -z-10 h-full w-full object-cover opacity-15 xl:opacity-20"
-        />
+        <channel-select seamless class="shrink-0" />
 
-        <span
-          class="absolute inset-0 -z-10 bg-linear-to-r from-base-100/95 via-base-100/80 to-base-100/40"
-        />
-
-        <span
-          class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
+        <nav
+          v-if="resolvedTabs.length"
+          class="tab-strip flex min-w-0 flex-1 items-stretch gap-0.5 overflow-x-auto border-l border-base-300 px-1"
+          aria-label="Channel tabs"
         >
-          <img
-            v-if="activeTabConfig.image"
-            :src="activeTabConfig.image"
-            :alt="activeTabConfig.title || activeTabConfig.label"
-            class="h-full w-full object-cover"
-          />
-          <span
-            class="absolute inset-0 flex items-center justify-center bg-base-content/20"
+          <button
+            v-for="tab in resolvedTabs"
+            :key="tab.tabKey"
+            type="button"
+            class="relative my-1 flex shrink-0 items-center gap-1.5 rounded-lg px-2 text-xs font-black transition xl:text-sm"
+            :class="
+              tab.tabKey === activeTabKey
+                ? 'bg-primary text-primary-content shadow-sm'
+                : 'text-base-content/60 hover:bg-base-200 hover:text-base-content'
+            "
+            :aria-current="tab.tabKey === activeTabKey ? 'page' : undefined"
+            :title="tab.tooltip || tab.title || tab.label"
+            @click="goToTab(tab)"
           >
             <Icon
-              :name="activeTabConfig.icon || fallbackIcon"
-              class="h-4 w-4 text-base-100 drop-shadow xl:h-5 xl:w-5"
+              :name="tab.icon || fallbackIcon"
+              class="h-3.5 w-3.5 shrink-0 xl:h-4 xl:w-4"
             />
-          </span>
-        </span>
+            <span class="max-w-28 truncate xl:max-w-40">{{ tab.label }}</span>
+          </button>
+        </nav>
 
-        <span class="flex min-w-0 flex-1 flex-col items-start leading-tight">
-          <span
-            v-if="shellTitle"
-            class="max-w-full truncate text-[0.58rem] font-black uppercase tracking-wide text-primary/70"
-          >
-            {{ shellTitle }}
-          </span>
-
-          <span
-            class="max-w-full truncate text-sm font-black sm:text-base xl:text-lg"
-          >
+        <!-- No tabs resolved (a bare route, or content still loading): fall
+             back to naming the page rather than rendering an empty bar. -->
+        <div
+          v-else
+          class="flex min-w-0 flex-1 items-center gap-2 border-l border-base-300 px-2"
+        >
+          <Icon
+            :name="activeTabConfig.icon || fallbackIcon"
+            class="h-4 w-4 shrink-0 text-primary/70"
+          />
+          <span class="min-w-0 truncate text-sm font-black xl:text-base">
             {{ activeTitle }}
           </span>
-        </span>
-      </section>
+        </div>
+      </div>
 
       <section
         class="header-control-strip flex shrink-0 items-center gap-1 sm:gap-1.5"
@@ -120,6 +124,7 @@ import { useNavStore } from '@/stores/navStore'
 import { usePageStore } from '@/stores/pageStore'
 import { useUserStore } from '@/stores/userStore'
 import { requestFullStartupReload } from '@/utils/startupLaunch'
+import { tabRouteTarget } from '@/utils/tabNavigation'
 
 const fallbackIcon = 'kind-icon:sparkles'
 
@@ -144,13 +149,9 @@ const requestedTabKey = computed(() => {
 const resolvedChannel = computed(() => pageStore.resolvedChannel)
 const resolvedTabs = computed(() => resolvedChannel.value?.tabs ?? [])
 
-const shellTitle = computed(
-  () =>
-    resolvedChannel.value?.room ||
-    pageStore.room ||
-    pageStore.title ||
-    'Kind Robots',
-)
+// The room label this fed ("CREATIVE WORLDS") sat above the page title in the
+// old title section. The channel name in channel-select says the same thing one
+// control to the left, so the tab strip that replaced it does not repeat it.
 
 const shellSummary = computed(
   () => pageStore.subtitle || pageStore.description || '',
@@ -227,6 +228,27 @@ const activeTitle = computed(
     activeTabConfig.value.label ||
     pageStore.title,
 )
+
+/**
+ * Navigates the tab strip. Routes through the shared tabRouteTarget so this
+ * agrees with channel-select's dropdown, which reaches the same tabs — several
+ * tabs in a channel can share one route and are disambiguated by `?tab=`, and
+ * a second hand-rolled copy of that rule would drift.
+ */
+function goToTab(tab: ResolvedTab): void {
+  const channel = resolvedChannel.value
+  if (!channel) return
+
+  const target = tabRouteTarget(channel, tab)
+  if (!target) return
+
+  // Already here — pushing again would add a redundant history entry the back
+  // button then has to be pressed twice to escape.
+  const sameQuery = (target.query?.tab ?? '') === requestedTabKey.value
+  if (route.path === target.path && sameQuery) return
+
+  void router.push(target)
+}
 
 watch(
   () => ({

--- a/components/pages/conductor-manager.vue
+++ b/components/pages/conductor-manager.vue
@@ -10,7 +10,13 @@
     />
     <ConductorProjectGalleryPage v-else-if="showConductorGallery" />
     <ConductorPage v-else />
-    <PlanProjectsGrid />
+    <!-- PlanProjectsGrid ("Projects in progress") was mounted here
+         unconditionally, so it appended a second project list below EVERY
+         Conductor view including the project gallery itself. Silas: "unneeded
+         and distracting, and I don't want you to get the impression that we
+         want something equivalent on other pages." A page shows its own
+         content; it does not also get a digest of the same records stapled
+         underneath. -->
   </div>
 </template>
 
@@ -20,7 +26,6 @@ import AppmakerPage from '@/components/pages/appmaker-page.vue'
 import ConductorProjectGalleryPage from '@/components/pages/conductor-project-gallery-page.vue'
 import ConductorPage from '@/components/pages/conductor-page.vue'
 import ConductorPitchManager from '@/components/pages/conductor-pitch-manager.vue'
-import PlanProjectsGrid from '@/components/conductor/plan-projects-grid.vue'
 import PortosPage from '@/components/pages/portos-page.vue'
 import TabScrollRegion from '@/components/conductor/tab-scroll-region.vue'
 import WishmasterPage from '@/components/pages/wishmaster-page.vue'
@@ -42,6 +47,8 @@ const needsScrollWrap = computed(() => {
 })
 
 const showConductorGallery = computed(() => {
-  return !pageStore.workspaceCardKey || pageStore.workspaceCardKey === 'overview'
+  return (
+    !pageStore.workspaceCardKey || pageStore.workspaceCardKey === 'overview'
+  )
 })
 </script>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -196,33 +196,6 @@
             </div>
           </div>
           <div
-            v-else-if="projectGalleryMode === 'list'"
-            class="flex flex-col gap-2"
-          >
-            <div
-              v-for="project in projectStore.publicProjects"
-              :key="project.id"
-              class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-            >
-              <img
-                :src="projectIconPath(project.slug)"
-                :alt="project.title"
-                class="size-9 shrink-0 rounded-xl border border-base-300 object-cover"
-              />
-              <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-bold">{{ project.title }}</p>
-                <p class="truncate text-xs text-base-content/50">
-                  {{ project.flavorText }}
-                </p>
-              </div>
-              <span
-                v-if="project.status"
-                class="badge badge-xs shrink-0 opacity-60"
-                >{{ project.status }}</span
-              >
-            </div>
-          </div>
-          <div
             v-else-if="projectGalleryMode === 'heroes'"
             class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4"
           >
@@ -1526,12 +1499,10 @@ const sortedActiveProjects = computed(() =>
     }
     const pa =
       (projectRecordForSlug(a.slug)?.priority as
-        | ProjectPriorityLevel
-        | undefined) ?? 'NORMAL'
+        ProjectPriorityLevel | undefined) ?? 'NORMAL'
     const pb =
       (projectRecordForSlug(b.slug)?.priority as
-        | ProjectPriorityLevel
-        | undefined) ?? 'NORMAL'
+        ProjectPriorityLevel | undefined) ?? 'NORMAL'
     return (order[pa] ?? 1) - (order[pb] ?? 1)
   }),
 )

--- a/utils/galleryVocabulary.ts
+++ b/utils/galleryVocabulary.ts
@@ -32,13 +32,26 @@ import type { ArtVariant } from './artImageSrc'
 export type { ArtVariant }
 
 /**
- * What a gallery is currently showing. The first three are the plural of
- * ArtVariant and MUST stay in lockstep with it; `list` is a layout.
+ * What a gallery is currently showing: exactly the plural of ArtVariant, one
+ * mode per stored image, and nothing else.
+ *
+ * There used to be a fourth, `list`. Silas killed it 2026-08-03 after seeing
+ * it live: "List is the odd duck out ... the current List page is a GIGANTIC
+ * display of individual images, with each dream taking up more than a page ...
+ * confirmed that on small, the line and hero displays look identical. kill
+ * line." Both observations follow from what it was — a layout wearing a mode's
+ * clothes. It loaded hero art (so it WAS heroes once a phone dropped its
+ * two-column grid) at a 12rem row that a full card overflowed. A mode that is
+ * a layout rather than an image cannot stay in lockstep with the schema, which
+ * is the whole point of this vocabulary.
+ *
+ * `list` is deliberately NOT re-added as an alias. IS_GALLERY_MODE rejects the
+ * stored string and callers fall back to `cards`, which is the migration.
  *
  * These strings are persisted to localStorage and to the gallery-preference
  * store, so renaming a value is a data migration, not a rename.
  */
-export type GalleryMode = 'cards' | 'heroes' | 'icons' | 'list'
+export type GalleryMode = 'cards' | 'heroes' | 'icons'
 
 export interface GalleryModeOption {
   value: GalleryMode
@@ -51,7 +64,6 @@ export const GALLERY_MODES: readonly GalleryModeOption[] = [
   { value: 'cards', label: 'Cards', abbr: 'C' },
   { value: 'heroes', label: 'Heroes', abbr: 'H' },
   { value: 'icons', label: 'Icons', abbr: 'I' },
-  { value: 'list', label: 'List', abbr: 'L' },
 ]
 
 /**
@@ -62,29 +74,27 @@ export const GALLERY_MODES: readonly GalleryModeOption[] = [
 export const IS_GALLERY_MODE = (value: string): value is GalleryMode =>
   GALLERY_MODES.some((mode) => mode.value === value)
 
-/**
- * Which stored art a given mode should load. `list` takes hero art because its
- * row is a wide 12rem-art strip, not a portrait card — this mirrors kr-gallery,
- * which is the proven implementation and the authority here.
- */
+/** Which stored art a given mode loads. One mode, one column, no exceptions. */
 export const MODE_VARIANT: Record<GalleryMode, ArtVariant> = {
   cards: 'card',
   heroes: 'hero',
   icons: 'icon',
-  list: 'hero',
 }
 
 /**
- * The grid/stack each mode lays its items out in. Lifted verbatim from
- * kr-gallery so a gallery that cannot yet adopt the whole shell still lays out
- * identically to one that has. `list` is a VERTICAL stack — a horizontal
- * scrolling strip is a different thing entirely and is never a mode.
+ * The grid each mode lays its items out in. Lifted verbatim from kr-gallery so
+ * a gallery that cannot yet adopt the whole shell still lays out identically
+ * to one that has.
+ *
+ * Every entry is a GRID. That is not incidental: the one entry that was not
+ * (`list`, a flex column) is the one that had to be removed, because a mode
+ * whose identity is its layout rather than its image duplicates whichever grid
+ * happens to collapse to one column at that width.
  */
 export const MODE_GRID_CLASS: Record<GalleryMode, string> = {
   cards: 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
   heroes: 'grid gap-4 lg:grid-cols-2',
   icons: 'grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5',
-  list: 'flex flex-col gap-2',
 }
 
 /**

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -83,6 +83,30 @@ function collect(minFlexWidth) {
     `"${(el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 34)}" ` +
     `${extra} .${(el.className || '').toString().replace(/\s+/g, ' ').slice(0, 70)}`
 
+  /**
+   * Content inside a horizontally scrollable container is SUPPOSED to extend
+   * past the viewport — that is what scrolling means. A tab strip or a card
+   * hand would otherwise report every off-screen item as a defect, which is
+   * how a checker earns the right to be ignored.
+   *
+   * The excuse is conditional: it only applies when the scroller ITSELF fits.
+   * A scroller that overflows is a genuine defect and is still reported, on
+   * the scroller, where the fix belongs.
+   */
+  const insideFittingScrollerX = (el) => {
+    for (
+      let p = el.parentElement;
+      p && p !== document.body;
+      p = p.parentElement
+    ) {
+      const cs = getComputedStyle(p)
+      if (cs.overflowX === 'auto' || cs.overflowX === 'scroll') {
+        return p.getBoundingClientRect().right <= vw + 1
+      }
+    }
+    return false
+  }
+
   const spill = []
   const crushed = []
   for (const el of document.querySelectorAll('body *')) {
@@ -91,7 +115,11 @@ function collect(minFlexWidth) {
 
     // Outermost offender only: a wide child otherwise reports its whole
     // ancestor chain and buries the actual cause.
-    if (b.right > vw + 1 && !spill.some((s) => s.node.contains(el))) {
+    if (
+      b.right > vw + 1 &&
+      !insideFittingScrollerX(el) &&
+      !spill.some((s) => s.node.contains(el))
+    ) {
       spill.push({
         node: el,
         text: describe(el, `right=${Math.round(b.right)}`),

--- a/utils/tabNavigation.ts
+++ b/utils/tabNavigation.ts
@@ -1,0 +1,42 @@
+// /utils/tabNavigation.ts
+//
+// One way to answer "where does this tab go?".
+//
+// Several tabs in a channel can share a single route — the page then decides
+// what to render from the `?tab=` query. So a tab link is NOT simply its
+// `route`: for a shared route the query is load-bearing, and for an exclusive
+// route appending it would leave a stale query behind on the next navigation.
+//
+// This was previously private to channel-select.vue. It is shared now because
+// workspace-header's tab strip navigates to exactly the same tabs, and a second
+// copy of this rule would drift — the shared-route case is subtle enough that
+// a reimplementation would very likely just push `tab.route` and quietly break
+// every channel whose tabs share one.
+
+import type {
+  ResolvedChannel,
+  ResolvedTab,
+} from '@/stores/helpers/channelContent'
+
+/** True when more than one of the channel's tabs resolve to the same route. */
+export function tabSharesRoute(
+  channel: ResolvedChannel,
+  tab: ResolvedTab,
+): boolean {
+  return channel.tabs.filter((item) => item.route === tab.route).length > 1
+}
+
+/**
+ * The router target for a tab, or `null` when it has no route to go to.
+ * Callers push this; deciding whether the push is a no-op is theirs, since
+ * that depends on the current route which this stays ignorant of.
+ */
+export function tabRouteTarget(
+  channel: ResolvedChannel,
+  tab: ResolvedTab,
+): { path: string; query?: Record<string, string> } | null {
+  if (!tab.route) return null
+  return tabSharesRoute(channel, tab)
+    ? { path: tab.route, query: { tab: tab.tabKey } }
+    : { path: tab.route }
+}


### PR DESCRIPTION
Four asks from the live review, each measured rather than eyeballed.

## 1 — Kill List

> "List is the odd duck out ... the current List page is a GIGANTIC display of individual images, with each dream taking up more than a page ... confirmed that on small, the line and hero displays look identical. kill line."

Both symptoms follow from what it was: **a layout wearing a mode's clothes.** It loaded *hero* art — so it genuinely *was* Heroes the moment a phone collapsed the two-column grid — at a 12rem row a full card overflowed. A mode whose identity is its layout rather than its image can't stay in lockstep with the schema, which is the whole point of this vocabulary.

`GalleryMode` is now exactly the plural of `ArtVariant`: **cards, heroes, icons** — one mode per stored column, matching "three display options that match our three image types."

`list` is deliberately *not* kept as an alias. `IS_GALLERY_MODE` rejects the stored string and callers fall back to `cards` — that **is** the migration.

`facet-gallery` turned out to be carrying a **ninth** private copy of the mode list, which survived the earlier consolidation by living under a local name. It imports the shared one now, so this removal didn't have to be repeated per gallery.

## 2 — "Projects in progress" is gone

> "unneeded and distracting, and I don't want you to get the impression that we want something equivalent on other pages."

`PlanProjectsGrid` was mounted **unconditionally** in `conductor-manager`, so it stapled a second project list under *every* Conductor view — including the project gallery itself.

## 3 — The title section is now a tab selector

> "it really should be a tab selector for the current channel ... integrating together so it looks more seamless and the channel selector doesn't drop awkwardly below the current tab title."

`channel-select` and a new tab strip share one bordered shell and read as a single bar (`channel-select` gained a `seamless` prop that drops its own frame for that mount). The tab label it used to stack *under* the channel name is gone — that line both duplicated the title beside it and caused the awkward two-line drop.

Nothing is lost: the active tab's label **was** the title. It's now selectable rather than merely descriptive.

Navigation goes through a new `utils/tabNavigation.ts` rather than a second copy of the rule — tabs in a channel can share one route and are disambiguated by `?tab=`, and a reimplementation would very likely just push `tab.route` and quietly break every channel whose tabs share one.

## 4 — The hand is free of the dock

> "the toggle is still over the hand display"

The dock is a sibling overlay pinned bottom-right, so a footer ending at `right:0` necessarily ran beneath it. **Measured at 390px: the hand's right edge was 382, the dock started at 294 — 88px of cards underneath the button.**

The footer now reserves the dock's own width via `--dock-circle`, tracking the button at every breakpoint instead of hardcoding a figure that would drift. **After: hand ends 278, dock starts 294, 16px clear.**

### That also explains "we can't scroll on mobile"

It was never a touch-handling bug. The hand was **374px wide holding 324px of cards** — `scrollWidth < clientWidth`, so there was genuinely nothing to scroll — while the last card sat hidden *under* the dock, making it look like unreachable content. At 286px the same cards now overflow and scroll properly (verified: `scrollWidth 324 > clientWidth 286`, `scrollLeft` moves).

The dock also went opaque with a stronger border and ring; it read as a washed-out translucent blob over the card art.

## The audit caught me, and it was wrong

The tab strip made `auditResponsiveLayout` report six `SPILL` failures. **The tool was wrong, not the code** — content inside an `overflow-x` container is *supposed* to extend past the viewport.

It now excuses descendants of a horizontal scroller, but **only when the scroller itself fits**; an overflowing scroller is a real defect and is still reported, on the scroller. A checker that cries wolf is a checker that gets ignored.

## Verification

- **Audit clean 21/21** (7 routes × 3 viewports), plus before/after measurement for every geometry claim above.
- `vue-tsc` clean; `test:layout-contract`, `test:channel-content`, `test:nav-manifest`, `test:gallery-adoption`, `test:facet-gallery` pass.
- `eslint` clean apart from a pre-existing `@pageReady` hyphenation warning in `app.vue`.

## Not verified

The hand and dock were exercised **as a guest** — this environment has no seeded login. The card hand's internal spacing (the "awkward empty space" you also noted) couldn't be reproduced and stays open in `t-078`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_