### PR TITLE
Responsive audit in CI, and make the card hand actually scroll

### DIFF
--- a/.github/workflows/responsive-layout-audit.yml
+++ b/.github/workflows/responsive-layout-audit.yml
@@ -1,0 +1,180 @@
+name: Responsive Layout Audit
+
+# Measures REAL rendered geometry at phone/tablet/desktop widths and fails on
+# elements that spill past the viewport or get crushed to a sliver. See
+# docs/contracts/responsive-layout-audit.md and
+# utils/scripts/auditResponsiveLayout.mjs.
+#
+# WHY IT RUNS ON A DEPLOYMENT rather than `pull_request`. The audit drives a
+# browser against a running app, and it is only worth anything against real
+# data: a gallery with no rows renders an empty state whose geometry says
+# nothing about the gallery. Standing up a server plus a seeded database inside
+# the job would be slow and would still measure fixture data, whereas Vercel has
+# already built a preview for the PR (enabled for claude/* branches in #1363)
+# that is backed by the real database. So this waits for that deployment and
+# audits it.
+#
+# The trade-off, stated plainly: this is a POST-DEPLOY gate, not a pre-merge
+# one. It reports against the commit, so a regression is caught within a
+# deploy's turnaround rather than blocked at push time. That is the same
+# trade-off cypress.yml already accepted for the same reason.
+
+# TWO TRIGGERS ON PURPOSE.
+#
+#   schedule          the guaranteed signal. cypress.yml already proves this
+#                     shape works on this repo: wait for production, then drive
+#                     it. If the deployment_status half below turns out never to
+#                     fire, this still catches every regression within the hour.
+#
+#   deployment_status  the better signal IF Vercel's GitHub integration emits
+#                     it here — it would audit each PR's own preview, against
+#                     the real database, before the change reaches main. No
+#                     other workflow in this repo uses this event, so it is
+#                     UNVERIFIED. It is additive: if it never fires, nothing is
+#                     lost that the schedule does not already cover. Check the
+#                     Actions tab for runs triggered by `deployment_status`; if
+#                     there are none after a few PRs, delete that trigger rather
+#                     than leaving a line that looks like a gate and is not.
+on:
+  schedule:
+    - cron: '41 * * * *'
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to audit (defaults to production)'
+        required: false
+        default: 'https://kind-robots.vercel.app'
+      routes:
+        description: 'Comma-separated routes to audit'
+        required: false
+        default: ''
+
+concurrency:
+  group: responsive-layout-audit-${{ github.event.deployment_status.target_url || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    # deployment_status fires for every state (pending, error, success); only a
+    # live deployment can be measured.
+    if: >-
+      github.event_name != 'deployment_status' ||
+      github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Install Chromium
+        # Only Chromium — the audit measures layout, not cross-browser
+        # behaviour, and pulling three engines would triple the install for no
+        # extra signal.
+        run: npx playwright install --with-deps chromium
+
+      - name: Resolve target URL
+        id: target
+        env:
+          DEPLOY_URL: ${{ github.event.deployment_status.target_url }}
+          INPUT_URL: ${{ github.event.inputs.base_url }}
+        run: |
+          set -euo pipefail
+          # A scheduled run has neither, and falls through to production —
+          # which is the point of the schedule trigger.
+          url="${INPUT_URL:-}"
+          if [ -z "$url" ]; then url="${DEPLOY_URL:-}"; fi
+          if [ -z "$url" ]; then url="https://kind-robots.vercel.app"; fi
+          url="${url%/}"
+          echo "url=$url" >>"$GITHUB_OUTPUT"
+          echo "Auditing $url"
+
+      - name: Wait for the deployment to answer
+        env:
+          BASE_URL: ${{ steps.target.outputs.url }}
+        run: |
+          set -euo pipefail
+          echo "Waiting up to 300s for ${BASE_URL} to return 200..."
+          deadline=$(( $(date +%s) + 300 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "${BASE_URL}/" || echo 000)"
+            case "$code" in
+              200)
+                echo "Deployment is answering."
+                exit 0
+                ;;
+              401|403)
+                # A protected preview would otherwise be "audited" as a login
+                # wall, which passes trivially and means nothing. Say so instead.
+                echo "::error::${BASE_URL} returned ${code} — the deployment is protected, so its pages cannot be measured. Disable Vercel deployment protection for previews, or run this workflow against production via workflow_dispatch."
+                exit 1
+                ;;
+            esac
+            echo "  got ${code}; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::${BASE_URL} never returned 200 within 300s."
+          exit 1
+
+      - name: Wait for the database
+        env:
+          BASE_URL: ${{ steps.target.outputs.url }}
+        run: |
+          set -euo pipefail
+          # An audit against an unreachable database measures empty and error
+          # states. Those still have to survive 390px, but they are NOT the
+          # galleries this is meant to check, and a pass against them would be
+          # a false all-clear. Three consecutive healthy checks, matching the
+          # pattern cypress.yml settled on.
+          echo "Waiting for three consecutive healthy database checks..."
+          deadline=$(( $(date +%s) + 180 ))
+          consecutive=0
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            if curl -sf --max-time 15 "${BASE_URL}/api/health/database" \
+                 | jq -e '.success == true and .statusCode == 200' >/dev/null 2>&1; then
+              consecutive=$(( consecutive + 1 ))
+              echo "  database healthy (${consecutive}/3)"
+              [ "$consecutive" -ge 3 ] && exit 0
+            else
+              consecutive=0
+              echo "  database unavailable; retrying in 5s..."
+            fi
+            sleep 5
+          done
+          echo "::error::Database was not healthy for three consecutive checks; an audit now would measure empty states rather than real galleries."
+          exit 1
+
+      - name: Audit responsive layout
+        env:
+          BASE_URL: ${{ steps.target.outputs.url }}
+          ROUTES: ${{ github.event.inputs.routes }}
+        run: |
+          set -euo pipefail
+          if [ -n "${ROUTES:-}" ]; then
+            npm run audit:responsive -- --base "$BASE_URL" --routes "$ROUTES" --shots audit-shots
+          else
+            npm run audit:responsive -- --base "$BASE_URL" --shots audit-shots
+          fi
+
+      - name: Upload screenshots
+        # Always: a failure is exactly when the pictures are worth having, and
+        # a pass is worth spot-checking against.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: responsive-audit-${{ github.run_id }}
+          path: audit-shots/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/app.vue
+++ b/app.vue
@@ -110,7 +110,7 @@
             class="pointer-events-auto min-w-0 w-full flex-1"
             :style="{ height: 'var(--hand-panel-h)' }"
           >
-            <LazyWorkspaceHand />
+            <LazyWorkspaceHand @resting-height="handRestingHeight = $event" />
           </div>
         </Transition>
       </section>
@@ -227,11 +227,20 @@ const sheetWidth = computed(() => {
 
 const footerOpen = computed(() => handOpen.value)
 
+/**
+ * What the hand reports it actually needs. HAND_PANEL_H is only the fallback
+ * for the frame or two before the first measurement lands — reserving a
+ * constant outright left a 67px dead band between the page content and the
+ * cards (measured at 428px: 129px of cards inside a 184px reservation), which
+ * is the empty space Silas photographed.
+ */
+const handRestingHeight = ref<number | null>(null)
+
 const footerHeight = computed(() => {
   if (!footerOpen.value) return '0px'
-  if (handOpen.value) return HAND_PANEL_H
+  if (!handOpen.value) return '0px'
 
-  return '0px'
+  return handRestingHeight.value ? `${handRestingHeight.value}px` : HAND_PANEL_H
 })
 
 const shellVars = computed<CSSProperties>(() => {
@@ -239,7 +248,10 @@ const shellVars = computed<CSSProperties>(() => {
     '--sheet-w': sheetWidth.value,
     '--dock-circle': dockCircle.value,
     '--footer-h': footerHeight.value,
-    '--hand-panel-h': handOpen.value ? HAND_PANEL_H : '0px',
+    // Same measured height as --footer-h: the slot the hand sits in and the
+    // padding the page reserves for it must be the same number, or the
+    // difference shows up as dead space.
+    '--hand-panel-h': handOpen.value ? footerHeight.value : '0px',
     '--footer-gap': '0px',
   } as CSSProperties
 })

--- a/components/navigation/workspace-hand.vue
+++ b/components/navigation/workspace-hand.vue
@@ -176,6 +176,12 @@ function sparkleStyle(n: number): CSSProperties {
 
 let observer: ResizeObserver | null = null
 
+/**
+ * The hand's resting height, so app.vue can reserve exactly that much page
+ * padding instead of a constant that drifts from what actually renders.
+ */
+const emit = defineEmits<{ 'resting-height': [px: number] }>()
+
 const gapPx = 8
 const horizontalPaddingPx = 16
 const minRestingCardWidthPx = 72
@@ -250,6 +256,26 @@ const maxRestingCardWidthPx = computed(() => {
   return 112
 })
 
+/**
+ * Cards keep a legible width and the strip SCROLLS when they do not fit. This
+ * used to divide the available width by the card count, which guaranteed they
+ * always fit — and produced the worst of both outcomes on a phone.
+ *
+ * Measured at 428px with four cards, before this change: ideal width came out
+ * at 71px, clamped up to the 72px floor, so the cards were at their smallest
+ * AND the strip was exactly as wide as its scroller — scrollWidth 324,
+ * clientWidth 324, scrollRange ZERO. Silas: "horizontal scrolling is still
+ * non-responsive, I can only see those four cards." There was nothing to
+ * scroll, by construction, and the cards were tiny for the privilege.
+ *
+ * A fit-to-count rule cannot win here: making four cards scroll requires them
+ * to be wider than a quarter of the screen, which is the opposite of what
+ * dividing by the count does. So size cards for legibility and let the
+ * overflow scroll — which is what a hand of cards should do anyway.
+ *
+ * The only clamp left is a safety one: a single card must never be wider than
+ * the hand itself.
+ */
 const restingCardWidthPx = computed(() => {
   const count = handCards.value.length
 
@@ -257,19 +283,12 @@ const restingCardWidthPx = computed(() => {
     return fallbackRestingCardWidthPx
   }
 
-  const totalGap = gapPx * Math.max(0, count - 1)
-
-  const availableWidth = Math.max(
+  const widest = Math.max(
     minRestingCardWidthPx,
-    handWidth.value - horizontalPaddingPx - totalGap,
+    handWidth.value - horizontalPaddingPx,
   )
 
-  const idealWidth = Math.floor(availableWidth / count)
-
-  return Math.min(
-    maxRestingCardWidthPx.value,
-    Math.max(minRestingCardWidthPx, idealWidth),
-  )
+  return Math.min(maxRestingCardWidthPx.value, widest)
 })
 
 const restingHandHeightPx = computed(() => {
@@ -322,10 +341,30 @@ const scrollFrameStyle = computed<CSSProperties>(() => {
 function publishHeight(): void {
   if (!import.meta.client) return
 
-  // Width drives card sizing. Height (--hand-h) is owned by app.vue now —
-  // the hand fills its footer slot rather than dictating the global var.
+  // Width drives card sizing.
   handWidth.value =
     scrollEl.value?.clientWidth ?? handEl.value?.clientWidth ?? 0
+
+  /*
+   * Height flows back up. app.vue reserves --footer-h as padding under the
+   * page, and it used to be a fixed 11.5rem that had no relationship to what
+   * the hand actually renders: measured at 428px, the cards came to 129px tall
+   * inside a 184px reservation, leaving a 67px dead band between the page
+   * content and the cards. Silas photographed exactly that gap.
+   *
+   * Reporting the resting height cannot loop, because card width depends on
+   * the hand's WIDTH and the count, never on its height.
+   *
+   * MEASURED, not computed. restingHandHeightPx is a formula
+   * (cardWidth * 1.5 + label + padding) and it overshoots what the cards
+   * actually render by ~23px, which is dead band by another name. The strip's
+   * own offsetHeight is the truth; `transform: scale` on hover does not affect
+   * it, so this stays the resting height even mid-zoom.
+   */
+  emit(
+    'resting-height',
+    stripEl.value?.offsetHeight || restingHandHeightPx.value,
+  )
 }
 
 function getCardPath(card: BuilderCard): string {
@@ -458,6 +497,21 @@ onMounted(() => {
 
   if (handEl.value) {
     observer.observe(handEl.value)
+  }
+
+  /*
+   * The strip too, not just the frame. The frame's height comes from the
+   * expandedHandHeightPx formula, so it does not change when the CARDS do —
+   * and the cards are what the reported resting height measures. Without this,
+   * the first measurement (taken before the art has loaded and the cards have
+   * reached full height) is the only one that ever lands, and the page reserves
+   * too little space: measured -54px, i.e. content running under the hand.
+   *
+   * No feedback loop: the reported height drives page padding and the footer
+   * slot, while card size derives from the hand's WIDTH.
+   */
+  if (stripEl.value) {
+    observer.observe(stripEl.value)
   }
 
   if (scrollEl.value) {

--- a/docs/contracts/responsive-layout-audit.md
+++ b/docs/contracts/responsive-layout-audit.md
@@ -59,19 +59,45 @@ npm run audit:responsive -- --min-flex 40
 skipped (as in the agent sandbox, where browsers live under
 `PLAYWRIGHT_BROWSERS_PATH`).
 
-Exit code is `1` when any route/viewport has a defect, so it can gate a PR once
-there is a CI job able to stand up a server. **That exit code is the point** —
-verify it end to end if you change the script, and beware of piping the command
-anywhere, which replaces the script's status with the last pipeline stage's.
-See interface-vision `t-063`: a CI step piped through `tee` could never fail,
-and the verifier behind it was dead for weeks without anyone noticing.
+Exit code is `1` when any route/viewport has a defect. **That exit code is the
+point** — verify it end to end if you change the script, and beware of piping
+the command anywhere, which replaces the script's status with the last pipeline
+stage's. See interface-vision `t-063`: a CI step piped through `tee` could never
+fail, and the verifier behind it was dead for weeks without anyone noticing.
 
-## Data is not required
+## In CI
 
-The audit measures geometry, not content. It runs fine with the database
-unreachable — pages render their chrome, their error state, and their empty
-state, all of which have to survive a 390px viewport too. Do not skip the audit
-because there is no seeded data.
+`.github/workflows/responsive-layout-audit.yml` audits a **deployed** app rather
+than standing up a server in the job. Two reasons:
+
+1. A gallery with no rows renders an empty state whose geometry says nothing
+   about the gallery. Vercel has already built a deployment backed by the real
+   database, so auditing it measures real content.
+2. cypress.yml already proves the wait-for-deploy shape works here.
+
+It runs hourly against production, and — if Vercel's GitHub integration emits
+the event on this repo — on each successful `deployment_status`, which would
+audit a PR's own preview before the change reaches `main`. **No other workflow
+here uses `deployment_status`, so that half is unverified.** It is additive: the
+schedule covers everything regardless. If the Actions tab shows no
+`deployment_status`-triggered runs after a few PRs, delete that trigger rather
+than leave a line that reads like a gate and isn't.
+
+The job refuses to measure a deployment whose database is unhealthy, and fails
+loudly on a `401`/`403` protected preview — both would otherwise "pass"
+trivially against an error page or a login wall, which is worse than not running.
+
+## Running it against something other than a dev server
+
+`--base` takes any URL, so the same command audits production or a preview:
+
+```bash
+npm run audit:responsive -- --base https://kind-robots.vercel.app
+```
+
+That is exactly what CI does. Locally, an unseeded database means you are
+measuring empty and error states — those still have to survive 390px, but they
+are not the galleries this is for, so do not read a local pass as an all-clear.
 
 ## Adding a route
 

--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -26,8 +26,17 @@
  *
  *     npm run audit:responsive -- --routes /dreams,/bots --shots ./out
  *
- * Exits non-zero when any route/viewport has a defect, so it can gate a PR
- * once there is a CI job that can stand up a server.
+ * Or against any deployment, which is what CI does — see
+ * .github/workflows/responsive-layout-audit.yml. Auditing a deployment rather
+ * than a local server is deliberate: it has the real database behind it, and a
+ * gallery with no rows renders an empty state whose geometry says nothing about
+ * the gallery.
+ *
+ *     npm run audit:responsive -- --base https://kind-robots.vercel.app
+ *
+ * Exits non-zero when any route/viewport has a defect. Do not pipe the command
+ * in CI — that replaces this exit status with the last pipeline stage's, which
+ * is how interface-vision t-063's verifier stayed dead for weeks.
  */
 
 const args = process.argv.slice(2)


### PR DESCRIPTION
Two commits.

---

# 1 — The responsive audit runs in CI

> "Let's get that audit in ci!"

## First, a correction

> "most of our objects should be public, so guest should be able to see virtually everything ... you should be seeing objects."

You're right, and my earlier reports were misleading. **This agent environment has no `DATABASE_URL` at all**, so every local audit measured an error state. A sandbox limitation, not a guest-visibility bug — and I should have said so plainly rather than the vaguer "unseeded database."

It also decides the workflow's shape: a local server would *always* measure empty states, so the job audits **a deployment**, which has the real database behind it. `cypress.yml` settled on this same shape for the same reason, so its wait-for-deploy and DB-readiness patterns are borrowed rather than reinvented.

## `deployment_status` fires here — confirmed

I shipped this with `schedule` (proven on this repo) *plus* `deployment_status` (no precedent, so unverified), specifically to avoid the `t-063` failure of a workflow that looks like a gate and fires never.

**It fired.** Run `30861958232`, `event: deployment_status`, triggered by `vercel[bot]`, auditing this PR's own preview. So this is a genuine per-PR gate against real data, not just an hourly sweep.

## Refuses to pass vacuously

- **Protected preview** (`401`/`403`) → fails loudly; a login wall would otherwise audit perfectly clean.
- **Unhealthy database** → fails before measuring, since an unreachable DB turns the audit into a test of error pages — exactly the false all-clear my local runs produced.
- Screenshots upload on success *and* failure.

---

# 2 — The card hand actually scrolls

> "Confirmed that the layout is now correct by conceding space to the toggle, but horizontal scrolling is still non-responsive, I can only see those four cards."

Both complaints were **one bug**, and worse than "barely scrolls." Measured at 428px with four cards:

| | before | after |
|---|---|---|
| scroll range | **0px** | **240px** |
| card width | 72px (the hard floor) | 132px |
| dead band | 67px | 12px (the footer's own `gap-2`) |
| page reservation | 184px (a constant) | 219px (the rendered height) |

`restingCardWidthPx` **divided available width by card count**, so cards were guaranteed to fit and therefore guaranteed *not* to scroll. Four cards gave an ideal width of 71px, clamped up to the 72px floor — the smallest cards allowed, in exchange for no scrolling at all.

A fit-to-count rule can't win here: making four cards scroll requires each to be wider than a quarter of the screen, the exact opposite of dividing by the count. Cards are now sized for legibility and the strip scrolls when they overflow.

**The dead band was the same mismatch from the other side.** `.kr-main` reserved padding from a fixed `11.5rem` while the cards rendered 129px tall. The hand now reports its height and app.vue reserves exactly that.

The reported height is **measured** (`stripEl.offsetHeight`), not computed — the formula overshoots real cards by ~23px, which is dead band by another name.

### Two mistakes on the way, both caught by measuring

1. Emitting the *computed* height left 35px of band.
2. Measuring instead **overcorrected to −54px** — content running *under* the cards — because the first measurement lands before the art loads and nothing re-fired it.

Fixed by observing `stripEl` as well as `handEl`: the ResizeObserver watched only the outer frame, whose height comes from the formula and so never changes when the *cards* do. No feedback loop — reported height drives page padding, card size derives from hand *width*.

---

## Verification

- `vue-tsc` clean; responsive audit clean **21/21**; `test:layout-contract`, `test:channel-content`, `test:nav-manifest`, `test:gallery-adoption` pass.
- Every geometry number above measured before and after.
- `eslint` clean apart from a pre-existing `no-empty` in `workspace-hand`, confirmed present on the base by stashing.

## Not verified

Still exercised **as a guest**, so the four cards measured are `pageStore`'s dashboard cards. The mechanism is count-independent, but a logged-in hand with a different card count is worth a look — and now that `deployment_status` works, the audit will be measuring the real thing on every PR.