### PR TITLE
interface-vision/t-035: wire getModelCards() into pageStore.cards

### DIFF
--- a/stores/helpers/modelCards.ts
+++ b/stores/helpers/modelCards.ts
@@ -3,6 +3,7 @@ import type { BuilderCard } from '@/stores/helpers/builderCards'
 import { ADVENTURE_CARDS } from '@/stores/helpers/adventureCards'
 import { ART_CARDS } from '@/stores/helpers/artCards'
 import { BOT_CARDS } from '@/stores/helpers/botCards'
+import { CONDUCTOR_CARDS } from '@/stores/helpers/conductorCards'
 import { DREAM_CARDS } from '@/stores/helpers/dreamCards'
 import { LAB_CARDS } from '@/stores/helpers/labCards'
 import { NAV_CARDS } from '@/stores/helpers/navCards'
@@ -13,6 +14,7 @@ export type BuilderCardsKey =
   | 'adventureCards'
   | 'artCards'
   | 'botCards'
+  | 'conductorCards'
   | 'dreamCards'
   | 'labCards'
   | 'navCards'
@@ -24,6 +26,7 @@ export const modelCards: Partial<Record<BuilderCardsKey, BuilderCard[]>> = {
   adventureCards: ADVENTURE_CARDS,
   artCards: ART_CARDS,
   botCards: BOT_CARDS,
+  conductorCards: CONDUCTOR_CARDS,
   dreamCards: DREAM_CARDS,
   labCards: LAB_CARDS,
   navCards: NAV_CARDS,

--- a/stores/pageStore.ts
+++ b/stores/pageStore.ts
@@ -8,6 +8,7 @@ import {
   channelTabsToCards,
   navigationCardsToBuilderCards,
 } from '@/stores/helpers/channelCards'
+import { getModelCards } from '@/stores/helpers/modelCards'
 import { useChannelContentStore } from '@/stores/channelContentStore'
 import { useNavStore } from '@/stores/navStore'
 import { useSheetStore } from '@/stores/sheetStore'
@@ -206,6 +207,11 @@ export const usePageStore = defineStore('pageStore', () => {
     if (isBuilderCardArray(value)) return value
     if (isNavigationCardArray(value)) {
       return navigationCardsToBuilderCards(value)
+    }
+
+    if (typeof value === 'string') {
+      const registryCards = getModelCards(value)
+      if (registryCards.length) return registryCards
     }
 
     return resolvedChannel.value


### PR DESCRIPTION
### Task
interface-vision/t-035: Wire getModelCards() for real; derive card decks from navManifest.ts (kind: software)

### What changed / what I produced
- `stores/pageStore.ts`'s `cards` computed now resolves a string `cards:` frontmatter value through `getModelCards()` before falling back to `channelTabsToCards()`. Previously every `cards:` value except the literal `'builderCards'` sentinel (handled separately by `workspace-hand.vue`/`workspace-sheet.vue`) was decorative — `getModelCards()` existed but was never called, so the string was silently ignored and the channel-tab-derived deck was always used instead.
- `stores/helpers/modelCards.ts`: folded `conductorCards.ts`'s `CONDUCTOR_CARDS` into the `BuilderCardsKey` registry as `conductorCards`. `content/conductor.md` already declares `cards: conductorCards`; it had nowhere to resolve until now.
- Left `content/characters.md` on the generic `navCards` fallback rather than fabricating a `CHARACTER_CARDS` deck — same call t-012 made originally (no wizard content exists yet to back a dedicated deck).

### How I verified
- `npm run test:nav-manifest` — 0 nav manifest errors/warnings.
- `npx vue-tsc --noEmit` — clean.
- `npx eslint stores/helpers/modelCards.ts stores/pageStore.ts` — clean.
- Local SSR render-per-tab check is blocked in this sandbox (`DATABASE_URL is missing`, unrelated to this change — confirmed via direct curl of the 500 response body). Per the task note, final "cards actually render per tab" verification is expected against the Vercel preview for this PR.

### Stakes
reversible

### Flags for Reviewer
- This is a real behavior change for every page that already carried a `cards:` string (33 pages use `navCards`, plus one each for `labCards`/`artCards`/`dreamCards`/`scenarioCards`/`rewardCards`/`botCards`/`conductorCards`): they now render their named registry deck instead of the channel's own tab list. That's the intended fix per the task note ("today ... has zero runtime effect"), but it's worth an eyeball on the Vercel preview across a couple of `navCards` pages (e.g. `/dashboard`, `/characters`, `/conductor`) to confirm the decks read correctly before merge, since I couldn't render them locally.

### Notes for reviewer
Split from t-012 (kind_robots PR #1272). Task note called out `getModelCards()` as dead code; this wires it into the one call site (`pageStore.cards`) that was silently bypassing it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyTgoWA9RPZFaXwMWYKzKP)_