### PR TITLE
interface-vision/t-036: wire navigation-health.vue to navManifest.ts

### DIFF
--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -62,8 +62,19 @@
 
       <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
         <div class="stat-title">Legacy adapters</div>
-        <div class="stat-value text-warning">{{ legacyAdapterCount }}</div>
-        <div class="stat-desc">Tabs bridging old dashboards</div>
+        <div
+          class="stat-value"
+          :class="legacyAdapterFailureCount ? 'text-error' : 'text-warning'"
+        >
+          {{ legacyAdapterCount - legacyAdapterFailureCount }}/{{ legacyAdapterCount }}
+        </div>
+        <div class="stat-desc">
+          {{
+            legacyAdapterFailureCount
+              ? `${legacyAdapterFailureCount} failing navManifest validation`
+              : 'Tabs bridging old dashboards, all resolving'
+          }}
+        </div>
       </article>
 
       <article class="stat rounded-2xl border border-base-300 bg-base-100 shadow-sm">
@@ -94,6 +105,26 @@
           <span>({{ group.tabs.join(', ') }})</span>
         </span>
       </div>
+    </section>
+
+    <section
+      v-if="manifestIssues.length"
+      class="rounded-2xl border border-error/30 bg-error/5 p-4 shadow-sm"
+    >
+      <div class="flex items-center gap-2">
+        <Icon name="kind-icon:error" class="h-5 w-5 text-error" />
+        <h2 class="font-black">Nav manifest issues</h2>
+      </div>
+      <ul class="mt-3 flex flex-col gap-1.5">
+        <li
+          v-for="issue in manifestIssues"
+          :key="`${issue.channelKey}:${issue.tabKey}:${issue.message}`"
+          class="text-sm"
+          :class="issue.severity === 'error' ? 'text-error' : 'text-warning'"
+        >
+          <strong>{{ issue.channelKey }}/{{ issue.tabKey }}</strong>: {{ issue.message }}
+        </li>
+      </ul>
     </section>
 
     <section class="grid gap-4 xl:grid-cols-2">
@@ -206,6 +237,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useChannelContentStore } from '@/stores/channelContentStore'
+import { validateNavManifest, type NavManifestEntry } from '@/utils/navManifest'
 
 const channelContentStore = useChannelContentStore()
 const brokenImages = ref(new Set<string>())
@@ -216,12 +248,38 @@ const channels = computed(() => channelContentStore.channels)
 const totalTabs = computed(() =>
   channels.value.reduce((total, channel) => total + channel.tabs.length, 0),
 )
-const legacyAdapterCount = computed(() =>
-  channels.value.reduce(
-    (total, channel) =>
-      total + channel.tabs.filter((tab) => Boolean(tab.dashboardKey)).length,
-    0,
+
+const manifestEntries = computed<NavManifestEntry[]>(() =>
+  channels.value.flatMap((channel) =>
+    channel.tabs.map((tab) => ({
+      file: `${tab.channelKey}/${tab.tabKey}`,
+      channelKey: tab.channelKey,
+      tabKey: tab.tabKey,
+      dashboardKey: tab.dashboardKey,
+      dashboardTab: tab.dashboardTab,
+      cardsKey: typeof tab.cards === 'string' ? tab.cards : '',
+      route: tab.route,
+    })),
   ),
+)
+const manifestIssues = computed(() => validateNavManifest(manifestEntries.value))
+const manifestErrors = computed(() =>
+  manifestIssues.value.filter((issue) => issue.severity === 'error'),
+)
+
+const legacyAdapterTabs = computed(() =>
+  channels.value.flatMap((channel) =>
+    channel.tabs.filter((tab) => Boolean(tab.dashboardKey)),
+  ),
+)
+const legacyAdapterCount = computed(() => legacyAdapterTabs.value.length)
+const legacyAdapterFailureCount = computed(
+  () =>
+    legacyAdapterTabs.value.filter((tab) =>
+      manifestErrors.value.some(
+        (issue) => issue.channelKey === tab.channelKey && issue.tabKey === tab.tabKey,
+      ),
+    ).length,
 )
 const sharedRouteGroups = computed(() => {
   return channels.value.flatMap((channel) => {


### PR DESCRIPTION
### Task
interface-vision/t-036: Wire navigation-health.vue to navManifest.ts (kind: software)

### What changed / what I produced
- `components/navigation/navigation-health.vue` now builds a `NavManifestEntry` per resolved tab and runs `validateNavManifest()` (the same isomorphic validator `utils/scripts/verifyChannelContent.ts` runs in CI) client-side.
- The "Legacy adapters" stat is now a real pass/fail count (`passing/total`) instead of a raw tally — still scoped to the dashboardKey-bridging tabs it always described, but now cross-checked against `dashboardConfigs`/`modelCards.ts` instead of just counted.
- Added a "Nav manifest issues" section (shown only when issues exist) that lists each error/warning per channel/tab — the same messages `verifyNavManifest.ts` reports in CI, now surfaced live in the admin UI.
- Preserved the existing stat-grid/card-grid UI shape — this is a data-source swap plus real validation, not a rebuild.

### How I verified
- `npm run test:nav-manifest` — 0 nav manifest errors/warnings (matches this component's expected empty-issues state on current content).
- `npx vue-tsc --noEmit` — clean.
- `npx eslint components/navigation/navigation-health.vue` — clean.
- `navigation-health.vue` is gated `requiredRole: ADMIN`, so a live-preview visual check isn't feasible without admin credentials in this sandbox — flagging for reviewer below.

### Stakes
reversible

### Flags for Reviewer
- Couldn't visually verify on the Vercel preview since the page requires ADMIN role and I don't have credentials for that in this sandbox. The logic mirrors `verifyChannelContent.ts`'s manifest-entry construction exactly (same field mapping, same `validateNavManifest()` call), and `npm run test:nav-manifest` confirms 0 issues against current content, but an eyeball on `/admin/navigation-health` as an admin would be good before/after merge to confirm the new "Nav manifest issues" section and pass/fail stat render as expected (it should render nothing extra today, since there are 0 issues).

### Notes for reviewer
Split from t-012 (kind_robots PR #1272), sibling of t-035 (kind_robots PR #1389, merged this session) which wired `getModelCards()` into `pageStore.cards` — the same underlying registry `navManifest.ts` validates against.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyTgoWA9RPZFaXwMWYKzKP)_