### PR TITLE
Add Reward publishing toggles

### DIFF
--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -150,6 +150,39 @@
       </section>
 
       <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="mb-4">
+          <h2 class="text-xl font-bold text-base-content">Publishing</h2>
+          <p class="text-sm text-base-content/70">
+            Control who can discover this reward and whether mature-content filtering applies.
+          </p>
+        </div>
+
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label
+            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
+          >
+            <span class="label-text font-bold">Public</span>
+            <input
+              v-model="rewardStore.rewardForm.isPublic"
+              type="checkbox"
+              class="toggle toggle-success"
+            />
+          </label>
+
+          <label
+            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
+          >
+            <span class="label-text font-bold">Mature</span>
+            <input
+              v-model="rewardStore.rewardForm.isMature"
+              type="checkbox"
+              class="toggle toggle-warning"
+            />
+          </label>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
         <div
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >


### PR DESCRIPTION
## Summary
- add `isPublic` and `isMature` checkbox toggles to the Reward create/edit form
- mirror the established Bot/Character publishing-control pattern
- leave Scenario controls as the remaining bounded slice of interface-vision/t-080

## Conductor
- project: `interface-vision`
- task: `t-080`
- session: `2026-08-04T011347Z-interface-vision-t-080-r8m4`
- roadmap state verified at `review` before opening

## Validation
GitHub Actions must complete successfully before merge. The diff is template-only and uses fields already present in `RewardForm` and the existing reward payload whitelist.