### PR TITLE
iOS Safari cannot touch-scroll a pointer-events:none scroller

### DIFF
--- a/components/admin/loading-messages.vue
+++ b/components/admin/loading-messages.vue
@@ -21,11 +21,7 @@
         </span>
 
         <transition name="loader-message" mode="out-in">
-          <div
-            :key="messageKey"
-            class="loading-message"
-            aria-live="polite"
-          >
+          <div :key="messageKey" class="loading-message" aria-live="polite">
             {{ currentMessage }}
           </div>
         </transition>
@@ -287,7 +283,16 @@ onBeforeUnmount(() => {
   display: grid;
   width: min(98vw, 64rem);
   height: min(92vh, 52rem);
-  grid-template-rows: minmax(3.75rem, auto) minmax(0, 1fr) 8rem;
+  /*
+   * The heading row is deeper than the heading so the heading can sit at its
+   * BOTTOM (see .loading-heading align-self) rather than at the top of the
+   * screen. startup-animation's controls are `position: fixed; top: 1rem`
+   * with z-index 60, and on a phone the "Love Bomb / Pause & explore" pill is
+   * nearly the full width -- so a top-anchored heading rendered underneath it
+   * and both became unreadable. Silas: "it should be an easy fix to lower the
+   * message nearer the logo."
+   */
+  grid-template-rows: minmax(7rem, auto) minmax(0, 1fr) 8rem;
   place-items: center;
   opacity: 1;
   transform: scale(1);
@@ -329,6 +334,9 @@ onBeforeUnmount(() => {
   font-size: clamp(1.2rem, 2.25vw, 2rem);
   font-weight: 800;
   letter-spacing: 0.02em;
+  /* Bottom of its row, so it sits just above the logo instead of up in the
+     band the fixed animation controls occupy. */
+  align-self: end;
 }
 
 .loading-logo-frame {
@@ -355,8 +363,16 @@ onBeforeUnmount(() => {
 .loading-logo-frame::before {
   border-radius: 46% 54% 61% 39% / 57% 41% 59% 43%;
   background:
-    radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.2), transparent 42%),
-    radial-gradient(circle at 64% 68%, rgba(129, 230, 217, 0.16), transparent 46%),
+    radial-gradient(
+      circle at 35% 30%,
+      rgba(255, 255, 255, 0.2),
+      transparent 42%
+    ),
+    radial-gradient(
+      circle at 64% 68%,
+      rgba(129, 230, 217, 0.16),
+      transparent 46%
+    ),
     radial-gradient(circle, rgba(255, 255, 255, 0.08), transparent 68%);
   filter: blur(1.8rem);
   opacity: 0.88;

--- a/components/navigation/workspace-hand.vue
+++ b/components/navigation/workspace-hand.vue
@@ -9,7 +9,7 @@
 
     <div
       ref="scrollEl"
-      class="workspace-hand-scroll pointer-events-none absolute inset-x-0 bottom-0 flex touch-pan-x items-end overflow-x-auto overscroll-x-contain overflow-y-visible"
+      class="workspace-hand-scroll pointer-events-auto absolute inset-x-0 bottom-0 flex touch-pan-x items-end overflow-x-auto overscroll-x-contain overflow-y-visible"
       :style="scrollFrameStyle"
     >
       <div
@@ -134,6 +134,8 @@ const handEl = ref<HTMLElement | null>(null)
 const scrollEl = ref<HTMLElement | null>(null)
 const stripEl = ref<HTMLElement | null>(null)
 const handWidth = ref(0)
+/** The strip's real rendered height, used to size the scroll box. */
+const measuredStripHeightPx = ref(0)
 const selectedCardKey = ref('')
 
 const CARD_BACKS = [1, 2, 3, 4, 5] as const
@@ -331,10 +333,36 @@ const handFrameStyle = computed<CSSProperties>(() => {
   }
 })
 
+/**
+ * The scroller is exactly as tall as the cards at rest — NOT the expanded
+ * hover-zoom height.
+ *
+ * It used to be the expanded height (447px at four cards) with the difference
+ * as paddingTop (295px), so the cards sat at the bottom of a mostly-empty box.
+ * That oversized box then had to be `pointer-events-none` or it would have
+ * swallowed clicks on the page behind it — and THAT is what stopped iOS Safari
+ * scrolling the hand by touch. Safari will not touch-scroll an
+ * `overflow-x: auto` element with `pointer-events: none`, even when its
+ * children are `pointer-events: auto`; Chromium will, which is why every
+ * headless test passed while Silas's iPhone could not drag the cards
+ * (2026-08-04, three cards visible with the third clipped mid-card).
+ *
+ * `overflow-y: visible` is what makes this safe: the 2.1x zoom still paints
+ * outside the box, so the headroom was never needed for painting — only the
+ * height was, and only because the box was the wrong size. Sizing it to the
+ * cards lets it be pointer-events-auto without covering anything.
+ */
 const scrollFrameStyle = computed<CSSProperties>(() => {
+  /*
+   * MEASURED height, with the formula only as the first-paint fallback.
+   * restingHandHeightPx overshoots what the cards actually render by ~23px
+   * (measured 212 vs 189 at four cards) — harmless when this box was
+   * pointer-events-none, but now that it is interactive that overhang would
+   * sit over page content and swallow clicks meant for it. Same lesson as the
+   * page-padding reservation: read offsetHeight, do not compute it.
+   */
   return {
-    height: `${expandedHandHeightPx.value}px`,
-    paddingTop: `${expandedHandHeightPx.value - restingHandHeightPx.value}px`,
+    height: `${measuredStripHeightPx.value || restingHandHeightPx.value}px`,
   }
 })
 
@@ -361,9 +389,11 @@ function publishHeight(): void {
    * own offsetHeight is the truth; `transform: scale` on hover does not affect
    * it, so this stays the resting height even mid-zoom.
    */
+  measuredStripHeightPx.value = stripEl.value?.offsetHeight ?? 0
+
   emit(
     'resting-height',
-    stripEl.value?.offsetHeight || restingHandHeightPx.value,
+    measuredStripHeightPx.value || restingHandHeightPx.value,
   )
 }
 


### PR DESCRIPTION
> "Only seeing a few cards, cut off, can't scroll."

Three cards visible with the third clipped mid-card — so content genuinely overflowed and the drag still did nothing. My earlier "four cards just fit" theory was wrong.

## Why three rounds of verification missed it

All three were worthless, and it's worth naming how:

1. **Programmatic `scrollLeft`** — proves geometry, not input. Not a test of scrolling.
2. **CDP `synthesizeScrollGesture` with touch** — *appeared* to prove touch was broken. It was the **instrument**: the control couldn't scroll a 2,972px vertical region either. I nearly reported that as the diagnosis.
3. **`dispatchTouchEvent`, validated against that control first.** Sound — and it scrolls, at 428/768/820/1024. **In Chromium.**

You're on **iOS Safari**. Safari will not touch-scroll an `overflow-x: auto` element carrying `pointer-events: none`, even when its children are `pointer-events: auto`. Chromium will. That is exactly why every headless test was green while your phone couldn't drag the cards.

## Why it was `pointer-events: none`

The scroller was sized to the **expanded hover-zoom height** (447px at four cards) with the difference as `paddingTop` (295px), so the cards sat at the bottom of a mostly-empty box. Interactive, that box would have swallowed clicks on the page behind it — so it was made click-through, and *that* is what broke scrolling.

The headroom was never needed for painting: `overflow-y: visible` already lets the 2.1× zoom paint outside the box. So the box is now exactly as tall as the cards and `pointer-events: auto`, covering nothing it shouldn't.

**Measured after: scroller 711/189, cards 711/189 — identical, no overhang.**

Height is **measured** (`stripEl.offsetHeight`), not the `restingHandHeightPx` formula, which overshoots by ~23px. Harmless while the box was click-through; now that it's interactive that overhang would sit over page content and eat clicks. Same lesson as the page padding: read `offsetHeight`, don't compute it.

## The loader

"Building Kind Robots…" rendered underneath `startup-animation`'s fixed control tray (`top: 1rem`, `z-index: 60`), which on a phone is nearly full width — so both were unreadable.

The heading row is deeper and the heading is `align-self: end`, so it sits just above the logo instead of up in the tray's band. That reads better at every width, not only where they collided.

## Verification

`vue-tsc` clean; touch swipe still scrolls in Chromium after the change (275px); scroller covers only the cards; `test:layout-contract`, `test:channel-content`, `test:nav-manifest`, `test:gallery-adoption` pass. `eslint` clean apart from a pre-existing `no-empty`.

## Not verified — and this one matters

**iOS Safari itself**, which this environment cannot run. The `pointer-events` cause is a documented Safari behaviour and is consistent with every observation — fails on your device, passes in Chromium, content genuinely overflows — but it stays a **hypothesis until you retest on the phone**.

If it still fails, the next suspect is the `-webkit-overflow-scrolling` / compositing path, not the geometry. Please don't take a green CI here as proof; CI only runs Chromium, which never reproduced this in the first place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_