### PR TITLE
feat(home): show complete Daily Dream object bundles

### DIFF
--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -18,175 +18,199 @@
       </div>
     </div>
 
-    <div
-      v-else
-      class="grid min-h-[24rem] lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]"
-    >
-      <figure class="relative min-h-72 overflow-hidden bg-primary/10 lg:min-h-[29rem]">
-        <img
-          :src="displayImage"
-          :alt="activeDream ? `${activeDream.title} artwork` : 'Ami butterfly logo'"
-          class="absolute inset-0 size-full"
-          :class="hasDreamArtwork ? 'object-cover' : 'object-contain p-12 sm:p-16'"
-          @error="imageFailed = true"
-        />
-        <div
-          class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-content/75 via-base-content/5 to-transparent"
-        />
-
-        <div class="absolute inset-x-0 top-0 flex flex-wrap items-center gap-2 p-4 sm:p-5">
-          <span class="badge badge-primary gap-1 rounded-xl shadow-sm">
-            <Icon name="kind-icon:moon" class="size-3.5" />
-            Daily digest
-          </span>
-          <span v-if="activeDate" class="badge badge-neutral rounded-xl shadow-sm">
-            {{ formatDate(activeDate) }}
-          </span>
-          <span
-            v-if="digestDreams.length"
-            class="badge badge-ghost rounded-xl border-base-100/40 bg-base-100/80 text-base-content shadow-sm backdrop-blur"
-          >
-            {{ activeIndex + 1 }} of {{ digestDreams.length }}
-          </span>
-        </div>
-
-        <div class="absolute inset-x-0 bottom-0 p-5 text-base-100 sm:p-7">
-          <p class="text-xs font-black uppercase tracking-[0.18em] text-base-100/70">
-            {{ activeDream ? 'A world from the archive' : 'The archive is waking up' }}
-          </p>
-          <h2 class="mt-1 text-2xl font-black leading-tight sm:text-3xl">
-            {{ activeDream?.title || 'Fresh worlds will gather here' }}
-          </h2>
-        </div>
-      </figure>
-
-      <div class="flex min-w-0 flex-col p-5 sm:p-7">
-        <template v-if="activeDream">
-          <p class="text-sm leading-relaxed text-base-content/75">
-            {{ activeDream.pitch || activeDream.description || digestFallback }}
-          </p>
-
-          <div class="mt-5 grid gap-3 sm:grid-cols-2">
-            <div class="rounded-2xl border border-base-300 bg-base-200/55 p-4">
-              <div class="flex items-center gap-2">
-                <Icon name="kind-icon:users" class="size-4 text-primary" />
-                <h3 class="text-xs font-black uppercase tracking-wide text-base-content/55">
-                  Cast
-                </h3>
-              </div>
-              <div v-if="activeCharacters.length" class="mt-3 space-y-2">
-                <div
-                  v-for="character in activeCharacters"
-                  :key="character.id"
-                  class="flex items-center gap-2"
-                >
-                  <div class="avatar placeholder">
-                    <div class="size-9 rounded-xl bg-base-300 text-base-content/60">
-                      <img
-                        v-if="character.imagePath"
-                        :src="character.imagePath"
-                        :alt="character.name"
-                        loading="lazy"
-                      />
-                      <Icon v-else name="kind-icon:character" class="size-4" />
-                    </div>
-                  </div>
-                  <div class="min-w-0">
-                    <p class="truncate text-sm font-bold">{{ character.name }}</p>
-                    <p class="truncate text-[11px] text-base-content/50">
-                      {{ character.species || character.class || 'Dream traveler' }}
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <p v-else class="mt-3 text-xs text-base-content/45">
-                The cast is still assembling.
-              </p>
-            </div>
-
-            <div class="rounded-2xl border border-base-300 bg-base-200/55 p-4">
-              <div class="flex items-center gap-2">
-                <Icon name="kind-icon:gift" class="size-4 text-secondary" />
-                <h3 class="text-xs font-black uppercase tracking-wide text-base-content/55">
-                  Discoveries
-                </h3>
-              </div>
-              <div v-if="activeRewards.length" class="mt-3 space-y-2">
-                <div
-                  v-for="reward in activeRewards"
-                  :key="reward.id"
-                  class="rounded-xl bg-base-100 px-3 py-2"
-                >
-                  <p class="truncate text-sm font-bold">{{ reward.name }}</p>
-                  <p class="truncate text-[11px] text-base-content/50">
-                    {{ reward.rewardType || 'Reward' }}
-                    <span v-if="reward.rarity"> · {{ reward.rarity }}</span>
-                  </p>
-                </div>
-              </div>
-              <p v-else class="mt-3 text-xs text-base-content/45">
-                Its treasures are still being catalogued.
-              </p>
-            </div>
-          </div>
-        </template>
-
-        <div v-else class="flex flex-1 flex-col justify-center py-5">
-          <p class="text-lg font-black">No Daily Dreams have landed yet.</p>
-          <p class="mt-2 max-w-xl text-sm leading-relaxed text-base-content/60">
-            This space follows the current Daily Dream model. As the backlog is built and
-            artwork finishes rendering, each day will appear here with its world, cast,
-            discoveries, and images.
-          </p>
-        </div>
-
-        <div
-          class="mt-auto flex flex-col gap-3 border-t border-base-300 pt-5 sm:flex-row sm:items-center"
+    <div v-else class="min-h-[24rem]">
+      <div
+        class="grid lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]"
+      >
+        <figure
+          class="relative min-h-72 overflow-hidden bg-primary/10 lg:min-h-[29rem]"
         >
-          <div class="join shrink-0">
-            <button
-              type="button"
-              class="btn join-item btn-sm"
-              :disabled="!canGoOlder"
-              aria-label="Show the previous daily digest"
-              @click="showOlder"
+          <img
+            :src="displayImage"
+            :alt="activeDream ? `${activeDream.title} artwork` : 'Ami butterfly logo'"
+            class="absolute inset-0 size-full"
+            :class="hasDreamArtwork ? 'object-cover' : 'object-contain p-12 sm:p-16'"
+            @error="imageFailed = true"
+          />
+          <div
+            class="pointer-events-none absolute inset-0 bg-gradient-to-t from-base-content/75 via-base-content/5 to-transparent"
+          />
+
+          <div
+            class="absolute inset-x-0 top-0 flex flex-wrap items-center gap-2 p-4 sm:p-5"
+          >
+            <span class="badge badge-primary gap-1 rounded-xl shadow-sm">
+              <Icon name="kind-icon:moon" class="size-3.5" />
+              Daily digest
+            </span>
+            <span
+              v-if="activeDate"
+              class="badge badge-neutral rounded-xl shadow-sm"
             >
-              <Icon name="kind-icon:chevron-left" class="size-4" />
-              Previous
-            </button>
-            <button
-              type="button"
-              class="btn join-item btn-sm"
-              :disabled="!canGoNewer"
-              aria-label="Show the next daily digest"
-              @click="showNewer"
+              {{ formatDate(activeDate) }}
+            </span>
+            <span
+              v-if="digestDreams.length"
+              class="badge badge-ghost rounded-xl border-base-100/40 bg-base-100/80 text-base-content shadow-sm backdrop-blur"
             >
-              Next
-              <Icon name="kind-icon:chevron-right" class="size-4" />
-            </button>
+              {{ activeIndex + 1 }} of {{ digestDreams.length }}
+            </span>
           </div>
 
-          <select
-            v-if="digestDreams.length"
-            v-model.number="selectedDreamId"
-            class="select select-bordered select-sm min-w-0 flex-1 rounded-xl"
-            aria-label="Choose a daily digest"
-          >
-            <option v-for="dream in digestDreams" :key="dream.id" :value="dream.id">
-              {{ formatDate(dateKey(dream)) }} · {{ dream.title }}
-            </option>
-          </select>
+          <div class="absolute inset-x-0 bottom-0 p-5 text-base-100 sm:p-7">
+            <p
+              class="text-xs font-black uppercase tracking-[0.18em] text-base-100/70"
+            >
+              {{
+                activeDream
+                  ? 'A world from the archive'
+                  : 'The archive is waking up'
+              }}
+            </p>
+            <h2 class="mt-1 text-2xl font-black leading-tight sm:text-3xl">
+              {{ activeDream?.title || 'Fresh worlds will gather here' }}
+            </h2>
+          </div>
+        </figure>
 
+        <div class="flex min-w-0 flex-col justify-center p-5 sm:p-7">
+          <template v-if="activeDream">
+            <span
+              v-if="activeDream.PitchSheet?.hook"
+              class="badge badge-accent mb-4 h-auto w-fit rounded-xl px-3 py-2 text-left"
+            >
+              {{ activeDream.PitchSheet.hook }}
+            </span>
+
+            <p
+              v-if="activeDream.PitchSheet?.subtitle"
+              class="mb-3 text-sm font-bold leading-relaxed text-primary"
+            >
+              {{ activeDream.PitchSheet.subtitle }}
+            </p>
+
+            <p class="text-sm leading-relaxed text-base-content/75">
+              {{
+                activeDream.pitch ||
+                activeDream.description ||
+                activeDream.flavorText ||
+                digestFallback
+              }}
+            </p>
+
+            <div class="mt-5 flex flex-wrap gap-2">
+              <span
+                v-if="relatedDreamCount"
+                class="badge badge-outline gap-1 rounded-xl"
+              >
+                <Icon name="kind-icon:map" class="size-3.5" />
+                {{ relatedDreamCount }} place{{ relatedDreamCount === 1 ? '' : 's' }}
+              </span>
+              <span
+                v-if="activeDream.Characters.length"
+                class="badge badge-outline gap-1 rounded-xl"
+              >
+                <Icon name="kind-icon:users" class="size-3.5" />
+                {{ activeDream.Characters.length }} cast
+              </span>
+              <span
+                v-if="activeDream.Rewards.length"
+                class="badge badge-outline gap-1 rounded-xl"
+              >
+                <Icon name="kind-icon:gift" class="size-3.5" />
+                {{ activeDream.Rewards.length }} discoveries
+              </span>
+              <span
+                v-if="activeDream.Scenarios.length"
+                class="badge badge-outline gap-1 rounded-xl"
+              >
+                <Icon name="kind-icon:story" class="size-3.5" />
+                {{ activeDream.Scenarios.length }} scenario{{
+                  activeDream.Scenarios.length === 1 ? '' : 's'
+                }}
+              </span>
+              <span
+                v-if="activeDream.Bots.length"
+                class="badge badge-outline gap-1 rounded-xl"
+              >
+                <Icon name="kind-icon:robot" class="size-3.5" />
+                {{ activeDream.Bots.length }} narrator{{
+                  activeDream.Bots.length === 1 ? '' : 's'
+                }}
+              </span>
+            </div>
+          </template>
+
+          <div v-else class="py-5">
+            <p class="text-lg font-black">No Daily Dreams have landed yet.</p>
+            <p
+              class="mt-2 max-w-xl text-sm leading-relaxed text-base-content/60"
+            >
+              This space follows the current Daily Dream model. As the backlog is
+              built and artwork finishes rendering, each day will appear here with
+              its world, cast, discoveries, scenarios, and images.
+            </p>
+            <p
+              v-if="archiveStore.lastError"
+              class="mt-3 rounded-xl border border-error/30 bg-error/10 px-3 py-2 text-xs text-error"
+            >
+              {{ archiveStore.lastError }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <daily-digest-object-gallery
+        v-if="activeDream"
+        :dream="activeDream"
+      />
+
+      <div
+        class="flex flex-col gap-3 border-t border-base-300 p-5 sm:flex-row sm:items-center sm:p-7"
+      >
+        <div class="join shrink-0">
           <button
             type="button"
-            class="btn btn-ghost btn-sm shrink-0 rounded-xl"
-            :disabled="loading"
-            @click="loadDigests"
+            class="btn join-item btn-sm"
+            :disabled="!canGoOlder"
+            aria-label="Show the previous daily digest"
+            @click="showOlder"
           >
-            <Icon name="kind-icon:refresh-cw" class="size-4" />
-            Refresh archive
+            <Icon name="kind-icon:chevron-left" class="size-4" />
+            Previous
+          </button>
+          <button
+            type="button"
+            class="btn join-item btn-sm"
+            :disabled="!canGoNewer"
+            aria-label="Show the next daily digest"
+            @click="showNewer"
+          >
+            Next
+            <Icon name="kind-icon:chevron-right" class="size-4" />
           </button>
         </div>
+
+        <select
+          v-if="digestDreams.length"
+          v-model.number="selectedDreamId"
+          class="select select-bordered select-sm min-w-0 flex-1 rounded-xl"
+          aria-label="Choose a daily digest"
+        >
+          <option v-for="dream in digestDreams" :key="dream.id" :value="dream.id">
+            {{ formatDate(dateKey(dream)) }} · {{ dream.title }}
+          </option>
+        </select>
+
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm shrink-0 rounded-xl"
+          :disabled="loading"
+          @click="loadDigests"
+        >
+          <Icon name="kind-icon:refresh-cw" class="size-4" />
+          Refresh archive
+        </button>
       </div>
     </div>
   </section>
@@ -194,41 +218,22 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { useDreamStore, type DreamWithRelations } from '@/stores/dreamStore'
+import {
+  useDailyDreamArchiveStore,
+  type DailyDreamArchiveEntry,
+} from '@/stores/dailyDreamArchiveStore'
 import { resolveEntityArtwork } from '@/utils/artImageSrc'
 
-type DigestDream = DreamWithRelations & {
-  PitchSheet?: { imagePath?: string | null } | null
-}
-
-const dreamStore = useDreamStore()
+const archiveStore = useDailyDreamArchiveStore()
 const selectedDreamId = ref<number | null>(null)
 const loading = ref(true)
 const imageFailed = ref(false)
 
-const CURRENT_DAILY_DREAM_DESIGNER = 'dream-cycle'
-const LEGACY_DAILY_DREAM_DESIGNER = 'Daily Dream Facet Engine'
-
-function isDailyDreamArchiveEntry(dream: DigestDream): boolean {
-  if (dream.dreamType !== 'PITCH') return false
-
-  if (dream.designer === CURRENT_DAILY_DREAM_DESIGNER) {
-    return Boolean(dream.PitchSheet)
-  }
-
-  return (
-    dream.designer === LEGACY_DAILY_DREAM_DESIGNER ||
-    String(dream.slug || '').startsWith('daily-dream-')
-  )
-}
-
-const digestDreams = computed<DigestDream[]>(() =>
-  dreamStore.dreams
-    .filter(isDailyDreamArchiveEntry)
-    .sort((left, right) => {
-      const dateOrder = dateKey(right).localeCompare(dateKey(left))
-      return dateOrder || right.id - left.id
-    }),
+const digestDreams = computed<DailyDreamArchiveEntry[]>(() =>
+  [...archiveStore.dreams].sort((left, right) => {
+    const dateOrder = dateKey(right).localeCompare(dateKey(left))
+    return dateOrder || right.id - left.id
+  }),
 )
 
 const activeIndex = computed(() => {
@@ -238,15 +243,24 @@ const activeIndex = computed(() => {
   return index >= 0 ? index : 0
 })
 
-const activeDream = computed<DigestDream | null>(
+const activeDream = computed<DailyDreamArchiveEntry | null>(
   () => digestDreams.value[activeIndex.value] ?? null,
 )
 const activeDate = computed(() =>
   activeDream.value ? dateKey(activeDream.value) : '',
 )
-const activeCharacters = computed(() => activeDream.value?.Characters?.slice(0, 3) ?? [])
-const activeRewards = computed(() => activeDream.value?.Rewards?.slice(0, 3) ?? [])
-const canGoOlder = computed(() => activeIndex.value < digestDreams.value.length - 1)
+const relatedDreamCount = computed(() => {
+  const dream = activeDream.value
+  if (!dream) return 0
+
+  return new Set([
+    ...dream.RelationsFrom.map((relation) => relation.ToDream.id),
+    ...dream.RelationsTo.map((relation) => relation.FromDream.id),
+  ]).size
+})
+const canGoOlder = computed(
+  () => activeIndex.value < digestDreams.value.length - 1,
+)
 const canGoNewer = computed(() => activeIndex.value > 0)
 
 const activeArtwork = computed(() => {
@@ -264,7 +278,9 @@ const activeArtwork = computed(() => {
   )
 })
 
-const hasDreamArtwork = computed(() => Boolean(activeArtwork.value && !imageFailed.value))
+const hasDreamArtwork = computed(() =>
+  Boolean(activeArtwork.value && !imageFailed.value),
+)
 const displayImage = computed(() =>
   hasDreamArtwork.value ? activeArtwork.value : '/images/amilogo.webp',
 )
@@ -272,7 +288,7 @@ const displayImage = computed(() =>
 const digestFallback =
   'A freshly assembled world from the Daily Dream engine, waiting for its story to unfold.'
 
-function dateKey(dream: DigestDream): string {
+function dateKey(dream: DailyDreamArchiveEntry): string {
   const slugDate = String(dream.slug || '').match(
     /^daily-dream-(\d{4}-\d{2}-\d{2})-/,
   )?.[1]
@@ -305,18 +321,7 @@ function showNewer(): void {
 async function loadDigests(): Promise<void> {
   loading.value = true
   try {
-    await Promise.all([
-      dreamStore.fetchDreams({
-        search: CURRENT_DAILY_DREAM_DESIGNER,
-        dreamType: 'PITCH',
-        limit: 100,
-      }),
-      dreamStore.fetchDreams({
-        search: LEGACY_DAILY_DREAM_DESIGNER,
-        dreamType: 'PITCH',
-        limit: 100,
-      }),
-    ])
+    await archiveStore.fetchArchive(true)
   } finally {
     loading.value = false
   }

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -1,0 +1,173 @@
+<template>
+  <section v-if="objectCount" class="border-t border-base-300 bg-base-200/25 p-5 sm:p-7">
+    <header class="flex flex-wrap items-end justify-between gap-3">
+      <div>
+        <p class="text-xs font-black uppercase tracking-[0.16em] text-primary">
+          Complete bundle
+        </p>
+        <h3 class="mt-1 text-xl font-black">Objects in this Daily Dream</h3>
+        <p class="mt-1 max-w-3xl text-sm text-base-content/55">
+          The real shared cards, with their descriptions, metadata, artwork, and graceful
+          placeholders when an older object is still waiting on generated art.
+        </p>
+      </div>
+      <span class="badge badge-primary rounded-xl">{{ objectCount }} objects</span>
+    </header>
+
+    <div class="mt-6 space-y-7">
+      <section v-if="relatedDreams.length" class="space-y-3">
+        <div class="flex items-center gap-2 px-1">
+          <Icon name="kind-icon:map" class="size-4 text-accent" />
+          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
+            Places & companion dreams
+          </h4>
+        </div>
+        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <dream-card
+            v-for="relatedDream in relatedDreams"
+            :key="relatedDream.id"
+            :dream="relatedDream"
+            :show-actions="false"
+            :show-description="true"
+            :allow-edit="false"
+            :allow-delete="false"
+          />
+        </div>
+      </section>
+
+      <section v-if="dream.Characters.length" class="space-y-3">
+        <div class="flex items-center gap-2 px-1">
+          <Icon name="kind-icon:users" class="size-4 text-primary" />
+          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
+            Cast
+          </h4>
+        </div>
+        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <character-card
+            v-for="character in dream.Characters"
+            :key="character.id"
+            :character="character"
+            :show-actions="false"
+            :show-description="true"
+            :show-reaction="false"
+            :show-mode-buttons="false"
+            :show-inline-interact="false"
+            :allow-edit="false"
+            :allow-clone="false"
+            :allow-delete="false"
+          />
+        </div>
+      </section>
+
+      <section v-if="dream.Rewards.length" class="space-y-3">
+        <div class="flex items-center gap-2 px-1">
+          <Icon name="kind-icon:gift" class="size-4 text-secondary" />
+          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
+            Discoveries
+          </h4>
+        </div>
+        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <reward-card
+            v-for="reward in dream.Rewards"
+            :key="reward.id"
+            :reward="reward"
+            :show-actions="false"
+            :show-description="true"
+            :show-reaction="false"
+            :show-select-button="false"
+            :allow-edit="false"
+            :allow-delete="false"
+          />
+        </div>
+      </section>
+
+      <section v-if="dream.Scenarios.length" class="space-y-3">
+        <div class="flex items-center gap-2 px-1">
+          <Icon name="kind-icon:story" class="size-4 text-info" />
+          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
+            Scenarios
+          </h4>
+        </div>
+        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <scenario-card
+            v-for="scenario in dream.Scenarios"
+            :key="scenario.id"
+            :scenario="scenario"
+            :show-actions="false"
+            :show-description="true"
+            :show-reaction="false"
+            :show-inspirations="false"
+            :allow-edit="false"
+            :allow-clone="false"
+            :allow-delete="false"
+          />
+        </div>
+      </section>
+
+      <section v-if="dream.Bots.length" class="space-y-3">
+        <div class="flex items-center gap-2 px-1">
+          <Icon name="kind-icon:robot" class="size-4 text-warning" />
+          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
+            Narrators
+          </h4>
+        </div>
+        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <bot-card
+            v-for="bot in dream.Bots"
+            :key="bot.id"
+            :bot="bot"
+            :show-actions="false"
+            :show-description="true"
+            :show-personality="true"
+            :show-prompt-preview="false"
+            :show-launch-button="false"
+            :show-reaction="false"
+            :allow-edit="false"
+            :allow-clone="false"
+            :allow-delete="false"
+          />
+        </div>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DreamWithRelations } from '@/stores/dreamStore'
+import type {
+  DailyDreamArchiveEntry,
+  DailyDreamRelatedDream,
+} from '@/stores/dailyDreamArchiveStore'
+
+const props = defineProps<{
+  dream: DailyDreamArchiveEntry
+}>()
+
+const relatedDreams = computed<DreamWithRelations[]>(() => {
+  const found = new Map<number, DailyDreamRelatedDream>()
+
+  for (const relation of props.dream.RelationsFrom) {
+    if (relation.ToDream.id !== props.dream.id) {
+      found.set(relation.ToDream.id, relation.ToDream)
+    }
+  }
+
+  for (const relation of props.dream.RelationsTo) {
+    if (relation.FromDream.id !== props.dream.id) {
+      found.set(relation.FromDream.id, relation.FromDream)
+    }
+  }
+
+  return Array.from(found.values()) as unknown as DreamWithRelations[]
+})
+
+const objectCount = computed(
+  () =>
+    relatedDreams.value.length +
+    props.dream.Characters.length +
+    props.dream.Rewards.length +
+    props.dream.Scenarios.length +
+    props.dream.Bots.length,
+)
+</script>

--- a/server/api/dreams/daily-archive.get.ts
+++ b/server/api/dreams/daily-archive.get.ts
@@ -1,0 +1,157 @@
+import { defineEventHandler } from 'h3'
+import prisma from '@/server/utils/prisma'
+import { errorHandler } from '@/server/utils/error'
+
+const archiveArtSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  fileName: true,
+  fileType: true,
+  path: true,
+  imagePath: true,
+  thumbnailPath: true,
+  cardPath: true,
+  heroPath: true,
+  iconPath: true,
+  artPrompt: true,
+  promptString: true,
+  userId: true,
+  isPublic: true,
+  isMature: true,
+} as const
+
+const archiveCollectionSelect = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  label: true,
+  description: true,
+  imagePath: true,
+  isPublic: true,
+  isMature: true,
+  isActive: true,
+  artPrompt: true,
+  ArtImages: {
+    take: 6,
+    orderBy: { createdAt: 'desc' as const },
+    select: archiveArtSelect,
+  },
+} as const
+
+const publicArchiveObjectWhere = {
+  isActive: true,
+  isPublic: true,
+  isMature: false,
+} as const
+
+const relatedDreamInclude = {
+  PitchSheet: true,
+  ArtImage: { select: archiveArtSelect },
+  ArtImages: {
+    take: 1,
+    orderBy: { createdAt: 'desc' as const },
+    select: archiveArtSelect,
+  },
+  ArtCollection: { select: archiveCollectionSelect },
+  ArtCollections: {
+    take: 1,
+    orderBy: { updatedAt: 'desc' as const },
+    select: archiveCollectionSelect,
+  },
+} as const
+
+export default defineEventHandler(async (event) => {
+  try {
+    const data = await prisma.dream.findMany({
+      where: {
+        dreamType: 'PITCH',
+        isActive: true,
+        isPublic: true,
+        isMature: false,
+        OR: [
+          {
+            designer: 'dream-cycle',
+            PitchSheet: { isNot: null },
+          },
+          { designer: 'Daily Dream Facet Engine' },
+          { slug: { startsWith: 'daily-dream-' } },
+        ],
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 100,
+      include: {
+        PitchSheet: true,
+        ArtImage: { select: archiveArtSelect },
+        ArtImages: {
+          take: 6,
+          orderBy: { createdAt: 'desc' },
+          select: archiveArtSelect,
+        },
+        ArtCollection: { select: archiveCollectionSelect },
+        ArtCollections: {
+          take: 3,
+          orderBy: { updatedAt: 'desc' },
+          select: archiveCollectionSelect,
+        },
+        Characters: {
+          where: publicArchiveObjectWhere,
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        },
+        Rewards: {
+          where: publicArchiveObjectWhere,
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        },
+        Scenarios: {
+          where: publicArchiveObjectWhere,
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        },
+        Bots: {
+          where: publicArchiveObjectWhere,
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        },
+        RelationsFrom: {
+          where: {
+            ToDream: {
+              is: publicArchiveObjectWhere,
+            },
+          },
+          include: {
+            ToDream: { include: relatedDreamInclude },
+          },
+        },
+        RelationsTo: {
+          where: {
+            FromDream: {
+              is: publicArchiveObjectWhere,
+            },
+          },
+          include: {
+            FromDream: { include: relatedDreamInclude },
+          },
+        },
+      },
+    })
+
+    event.node.res.statusCode = 200
+    return {
+      success: true,
+      message: 'Daily Dream archive loaded successfully.',
+      data,
+      count: data.length,
+      statusCode: 200,
+    }
+  } catch (error) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+
+    return {
+      success: false,
+      message: handled.message || 'Failed to load the Daily Dream archive.',
+      data: [],
+      count: 0,
+      statusCode,
+    }
+  }
+})

--- a/stores/dailyDreamArchiveStore.ts
+++ b/stores/dailyDreamArchiveStore.ts
@@ -1,0 +1,126 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type {
+  ArtCollection,
+  ArtImage,
+  Bot,
+  Character,
+  Dream,
+  DreamRelation,
+  PitchSheet,
+  Reward,
+  Scenario,
+} from '~/prisma/generated/prisma/client'
+import { performFetch } from '@/stores/utils'
+
+export type DailyDreamArchiveArt = Pick<
+  ArtImage,
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'fileName'
+  | 'fileType'
+  | 'path'
+  | 'imagePath'
+  | 'thumbnailPath'
+  | 'cardPath'
+  | 'heroPath'
+  | 'iconPath'
+  | 'artPrompt'
+  | 'promptString'
+  | 'userId'
+  | 'isPublic'
+  | 'isMature'
+>
+
+export type DailyDreamArchiveCollection = Pick<
+  ArtCollection,
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'label'
+  | 'description'
+  | 'imagePath'
+  | 'isPublic'
+  | 'isMature'
+  | 'isActive'
+  | 'artPrompt'
+> & {
+  ArtImages: DailyDreamArchiveArt[]
+}
+
+export type DailyDreamRelatedDream = Dream & {
+  PitchSheet: PitchSheet | null
+  ArtImage: DailyDreamArchiveArt | null
+  ArtImages: DailyDreamArchiveArt[]
+  ArtCollection: DailyDreamArchiveCollection | null
+  ArtCollections: DailyDreamArchiveCollection[]
+}
+
+export type DailyDreamArchiveEntry = Dream & {
+  PitchSheet: PitchSheet | null
+  ArtImage: DailyDreamArchiveArt | null
+  ArtImages: DailyDreamArchiveArt[]
+  ArtCollection: DailyDreamArchiveCollection | null
+  ArtCollections: DailyDreamArchiveCollection[]
+  Characters: Character[]
+  Rewards: Reward[]
+  Scenarios: Scenario[]
+  Bots: Bot[]
+  RelationsFrom: Array<
+    DreamRelation & {
+      ToDream: DailyDreamRelatedDream
+    }
+  >
+  RelationsTo: Array<
+    DreamRelation & {
+      FromDream: DailyDreamRelatedDream
+    }
+  >
+}
+
+export const useDailyDreamArchiveStore = defineStore(
+  'daily-dream-archive',
+  () => {
+    const dreams = ref<DailyDreamArchiveEntry[]>([])
+    const loading = ref(false)
+    const loaded = ref(false)
+    const lastError = ref('')
+
+    async function fetchArchive(force = false): Promise<boolean> {
+      if (loading.value) return false
+      if (loaded.value && !force) return true
+
+      loading.value = true
+      lastError.value = ''
+
+      try {
+        const response = await performFetch<DailyDreamArchiveEntry[]>(
+          '/api/dreams/daily-archive',
+          {},
+          2,
+          30_000,
+        )
+
+        if (!response.success || !Array.isArray(response.data)) {
+          lastError.value = response.message || 'Daily Dream archive could not be loaded.'
+          return false
+        }
+
+        dreams.value = response.data
+        loaded.value = true
+        return true
+      } finally {
+        loading.value = false
+      }
+    }
+
+    return {
+      dreams,
+      loading,
+      loaded,
+      lastError,
+      fetchArchive,
+    }
+  },
+)


### PR DESCRIPTION
### Task
`dream-cycle/t-006`, directed by Silas: expand Home / For You's Daily Dream slideshow from one hero plus flattened name rows into a complete object display using the existing canonical model cards.

### Root cause
The slideshow queried a lightweight general Dream list and then bypassed the shared object cards with hand-written mini rows. That discarded the rich Character, Reward, Scenario, Bot, and related-Dream fields already stored in production, omitted scenarios entirely, and could not surface each object's own art path.

### What changed
- Added `/api/dreams/daily-archive`, a focused public/non-mature archive feed containing full scalar records for the Daily Dream bundle, related Dreams, and lightweight cover-art relations.
- Added a dedicated Pinia archive store so components continue to consume APIs through stores.
- Replaced the hand-built Cast and Discoveries summaries with the actual shared `dream-card`, `character-card`, `reward-card`, `scenario-card`, and `bot-card` components.
- Added related places/companion Dreams, scenarios, and narrators to the display.
- Moved archive navigation below the full bundle so cards can use the page width in responsive grids.
- Kept the large world hero and added PitchSheet hook/subtitle plus object counts.

### Data reality verified in production
Current and historical Daily Dream objects already contain rich descriptions, character drives/backstories, reward effects/flavor, scenario locations/openings, and narrator personalities. Many historical object rows still have no linked art ID or image path; their canonical cards deliberately render stable placeholders and will automatically show individual images wherever the art pipeline has attached card art.

### Stakes
Reversible read-only query and presentation changes. No database writes, schema changes, generated content, billing, secrets, DNS, or outward-facing messages.

### Verification plan
- TypeScript and repository contracts in GitHub Actions.
- Inspect the final four-file diff and review threads.
- After green merge, verify the exact production deployment and the new archive API payload through Vercel. Worker branches do not receive preview deployments by repository policy.