### PR TITLE
Card hand: drop touch-action pan-x and the :active magnify

### DIFF
--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -80,7 +80,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 import type { DreamWithRelations } from '@/stores/dreamStore'
-import type { ArtVariant } from '@/utils/galleryVocabulary'
+import type { ArtVariant } from '@/utils/artImageSrc'
 import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 import { useArtStore } from '@/stores/artStore'
 import { useCollectionStore } from '@/stores/collectionStore'

--- a/components/navigation/workspace-hand.vue
+++ b/components/navigation/workspace-hand.vue
@@ -7,9 +7,36 @@
   >
     <fx-region region="hand" />
 
+    <!--
+      Two things are deliberately ABSENT here, both of which broke touch
+      scrolling on iOS while measuring perfectly fine in Chromium:
+
+      1. `touch-pan-x`. touch-action: pan-x is a strict directional gate — a
+         gesture whose opening vector falls outside the horizontal cone is
+         dropped outright rather than interpreted. This hand sits on the bottom
+         edge, so it is driven by a thumb, and a thumb arcs. The default
+         (`auto`) lets the browser route the horizontal component to this
+         scroller and the vertical component to the page, with the tolerance it
+         already ships. `overscroll-x-contain` stays: it stops a swipe from
+         chaining into browser back-navigation.
+
+      2. `active:` variants on the cards (see the button below). Tailwind v4
+         gates `hover:` behind @media (hover: hover), so on a touch device only
+         `:active` ever matched — and :active fires on finger-DOWN. Measured
+         with CSS.forcePseudoState on an emulated touch device, the card went
+         112px -> 235px and z-10 -> z-40 the instant it was pressed, mid-gesture
+         and mid-200ms-transition. Desktop loses nothing by dropping it: `hover:`
+         already applies the identical values with a real pointer.
+
+      overflow-y is `hidden`, not `visible`: both engines were already coercing
+      it to `auto` (per spec, once one axis is non-visible the other computes to
+      auto), so `visible` described something the browser never did — and the
+      `auto` it silently became gave the strip a second scroll axis to compete
+      for the same gesture.
+    -->
     <div
       ref="scrollEl"
-      class="workspace-hand-scroll pointer-events-auto absolute inset-x-0 bottom-0 flex touch-pan-x items-end overflow-x-auto overscroll-x-contain overflow-y-visible"
+      class="workspace-hand-scroll pointer-events-auto absolute inset-x-0 bottom-0 flex items-end overflow-x-auto overscroll-x-contain overflow-y-hidden"
       :style="scrollFrameStyle"
     >
       <div
@@ -22,7 +49,7 @@
           v-for="(card, index) in handCards"
           :key="card.key"
           type="button"
-          class="group pointer-events-auto relative flex shrink-0 flex-col overflow-visible rounded-2xl border transition-all duration-200 hover:z-40 hover:-translate-y-2 hover:scale-[2.1] active:z-40 active:-translate-y-2 active:scale-[2.1]"
+          class="group pointer-events-auto relative flex shrink-0 flex-col overflow-visible rounded-2xl border transition-all duration-200 hover:z-40 hover:-translate-y-2 hover:scale-[2.1]"
           :class="[
             thumbClass(card.key),
             originClass(index),
@@ -519,7 +546,11 @@ onMounted(() => {
     if (CARD_BACKS.includes(parsed as CardBack)) {
       cardBack.value = parsed as CardBack
     }
-  } catch {}
+  } catch {
+    // localStorage can throw in private mode / blocked-cookie contexts. The
+    // card back is cosmetic, so falling back to the default is the whole
+    // recovery.
+  }
 
   publishHeight()
 
@@ -568,7 +599,9 @@ onBeforeUnmount(() => {
 .workspace-hand-scroll {
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
-  touch-action: pan-x;
+  /* No touch-action here — see the note in the template. It was set in BOTH
+     this block and a `touch-pan-x` utility on the element, so removing only the
+     utility changed nothing and measured as still `pan-x`. */
   cursor: grab;
 }
 

--- a/utils/galleryVocabulary.ts
+++ b/utils/galleryVocabulary.ts
@@ -27,9 +27,10 @@
 // New presentation ideas belong on one of these axes. Inventing a fourth
 // vocabulary is how five values became eight.
 
+// Imported for use in the maps below, but deliberately NOT re-exported:
+// artImageSrc.ts is the canonical home, and a second auto-importable
+// declaration makes Nuxt pick a winner and warn about the one it dropped.
 import type { ArtVariant } from './artImageSrc'
-
-export type { ArtVariant }
 
 /**
  * What a gallery is currently showing: exactly the plural of ArtVariant, one


### PR DESCRIPTION
Fourth attempt at the card hand's touch scrolling. The previous three were
guesses; this one is measured, and it explains why the earlier ones did nothing.

## Why the last fix landed without changing anything

`touch-action: pan-x` was set **twice** — a `touch-pan-x` utility on the element
*and* a rule in the component's scoped `<style>` block. Removing only the utility
left the computed value at `pan-x`. I confirmed this by removing the class and
re-measuring: still `ta=pan-x`.

## The two defects

**1. `touch-action: pan-x`.** A strict directional gate — a gesture whose opening
vector falls outside the horizontal cone is dropped outright rather than
interpreted as a pan. The hand sits on the bottom edge, so it is driven by a
thumb, and a thumb arcs. The default `auto` routes the horizontal component to
the scroller and the vertical component to the page, with the tolerance the
browser already ships. `overscroll-x-contain` stays, so a swipe still cannot
chain into browser back-navigation.

**2. `active:scale-[2.1]` on the cards.** Tailwind v4 gates `hover:` behind
`@media (hover: hover)`, so on a touch device `:active` was the only variant that
ever matched — and `:active` fires on finger-**down**. Forcing the pseudo-state
on an emulated touch device:

| state | rendered width | z-index |
|---|---|---|
| baseline | 112px | 10 |
| `:hover` | 112px (correctly gated off) | 10 |
| `:active` | **235px** | **40** |

The card balloons 2.1× under the finger the instant it lands, mid-gesture and
mid-200ms-transition. That also matches the reported symptom of a few cards
looking "cut off".

Desktop loses nothing — verified at 1440px with a fine pointer, `:hover` still
gives 235px / z-40. The `active:` variants were only ever duplicating values
`hover:` already applied.

**3. `overflow-y: visible` → `hidden`.** Both engines were already coercing it to
`auto` (per spec, once one axis is non-visible the other computes to `auto`), so
`visible` described something no browser did — and the `auto` it silently became
gave the strip a second scroll axis competing for the same gesture.

## How this was actually diagnosed

I installed WebKit (Safari's engine) rather than continuing to reason about
Chromium, and measured both engines side by side. Ruled out, all clean and
identical across engines:

- scrollable overflow — 1000px of range at 428px, >0 at every width 390–1180
- hit-testing — 20 sample points across the strip, nothing painted over it
- `touch-action` / `pointer-events` / `transform` up the full ancestor chain to `<html>`
- whether any handler cancels `touchmove` — nothing calls `preventDefault`
- programmatic `scrollLeft` — moves fine

Everything else being correct is what narrowed it to these two.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run test:layout-contract` — holds, no new violations
- `npm run test:gallery-adoption`, `test:channel-content`, `test:nav-manifest` — pass
- `npx eslint` + `prettier --check` on touched files — clean

## Honest caveat

Headless WebKit on Linux is Safari's engine but not iOS's gesture pipeline, so I
cannot fully reproduce Silas's device. Both defects are real and measured, and
each is worth fixing on its own merits — but confirmation that the hand now
scrolls needs a thumb on the actual iPad.

## Drive-by

Stopped re-exporting `ArtVariant` from `galleryVocabulary.ts`. `artImageSrc.ts`
is its canonical home, and the second auto-importable declaration made Nuxt warn
on every build about the one it dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_