### PR TITLE
interface-vision t-051: character-interact onto kr-chat-window

### DIFF
--- a/components/characters/character-interact.vue
+++ b/components/characters/character-interact.vue
@@ -225,56 +225,19 @@
               </button>
             </div>
 
-            <div
-              class="mb-3 flex max-h-96 min-h-40 flex-col gap-3 overflow-y-auto rounded-2xl border border-base-300 bg-base-200 p-3"
-            >
-              <div
-                v-if="chatMessages.length === 0"
-                class="flex h-full min-h-32 items-center justify-center text-center text-sm text-base-content/60"
-              >
-                No messages yet. The void is listening, but it keeps forgetting
-                its password.
-              </div>
-
-              <div
-                v-for="messageItem in chatMessages"
-                :key="messageItem.id"
-                class="flex"
-                :class="
-                  messageItem.role === 'user' ? 'justify-end' : 'justify-start'
-                "
-              >
-                <div
-                  class="max-w-[85%] rounded-2xl border p-3 text-sm shadow-sm"
-                  :class="
-                    messageItem.role === 'user'
-                      ? 'border-primary/30 bg-primary text-primary-content'
-                      : 'border-base-300 bg-base-100 text-base-content'
-                  "
-                >
-                  <p class="mb-1 text-xs font-bold opacity-70">
-                    {{
-                      messageItem.role === 'user'
-                        ? 'You'
-                        : selectedCharacterName
-                    }}
-                  </p>
-
-                  <p class="whitespace-pre-wrap">
-                    {{ messageItem.content }}
-                  </p>
-                </div>
-              </div>
-
-              <div v-if="isSendingChat" class="flex justify-start">
-                <div
-                  class="rounded-2xl border border-base-300 bg-base-100 p-3 text-sm text-base-content/70 shadow-sm"
-                >
-                  <span class="loading loading-dots loading-sm text-primary" />
-                  Thinking in character...
-                </div>
-              </div>
-            </div>
+            <!-- The character chat log is kr-chat-window (interface-vision
+                 Phase 5). This surface had no scroll helper at all -- it
+                 never auto-scrolled -- so adopting the shared window fixes a
+                 live bug, not just a duplication. -->
+            <kr-chat-window
+              class="mb-3 max-h-96 min-h-40 rounded-2xl border border-base-300 bg-base-200 p-3"
+              :turns="chatTurns"
+              :label="`${selectedCharacterName} conversation`"
+              :is-streaming="isSendingChat"
+              streaming-label="Thinking in character..."
+              empty-label="No messages yet. The void is listening, but it keeps forgetting its password."
+              :prose="false"
+            />
 
             <div class="mb-3 grid grid-cols-1 gap-2 md:grid-cols-2">
               <button
@@ -521,6 +484,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import type { NarrativeTurn } from '@/components/narrative/kr-chat-window.vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useChatStore } from '@/stores/chatStore'
 import { useRewardStore } from '@/stores/rewardStore'
@@ -648,6 +612,19 @@ const canSendChat = computed(() => {
     !isSendingChat.value,
   )
 })
+
+/* chatMessages as kr-chat-window turns. Each local message already carries
+   its own role, so the mapping is direct -- no pairing needed the way a
+   stored chat record (one row per exchange) requires elsewhere. */
+const chatTurns = computed<NarrativeTurn[]>(() =>
+  chatMessages.value.map((messageItem) => ({
+    id: messageItem.id,
+    text: messageItem.content,
+    from: messageItem.role === 'user' ? 'user' : 'narrator',
+    speaker:
+      messageItem.role === 'user' ? undefined : selectedCharacterName.value,
+  })),
+)
 
 function setStatus(message: string, tone: 'success' | 'error' = 'success') {
   statusMessage.value = message


### PR DESCRIPTION
### Task
`interface-vision/t-051`: Phase 5 of the shared-conversation-kit adoption — the four remaining interact surfaces onto `kr-chat-window`/`kr-choice-list`/`kr-art-plate`. This PR covers the `character-interact.vue` slice; `reward-interact.vue` (1183 lines) and `scenario-interact.vue` (632 lines) remain and are left for follow-up passes (see the roadmap task note).

### What changed / what I produced
- Replaced `character-interact.vue`'s hand-rolled message list (bubbles keyed by role, a "thinking" indicator, no scroll handling) with `kr-chat-window`.
- Added a `chatTurns` computed mapping the existing `chatMessages` (`{id, role, content}`) directly to `NarrativeTurn[]` — no pairing logic needed since each local message already carries its own side of the exchange (unlike `bot-interact.vue`'s stored-chat-record shape).
- This is a genuine bug fix, not just deduplication: the old markup had **no auto-scroll at all**, called out explicitly in the task note. `kr-chat-window` follows the conversation by default.
- Preserved the original bounded-height container styling (`max-h-96 min-h-40 ... bg-base-200 p-3`) per the component's own doc comment ("give it a bounded height from the parent").

### How I verified
- `npm run test` (`vue-tsc --noEmit`) — clean.
- `npx eslint components/characters/character-interact.vue` — one pre-existing unused-var error (`userStore`), confirmed present on `main` before this change (unrelated to this diff).
- `npm run test:layout-contract` — holds, no new violations.
- `npm run test:narrative-kit` — all checks pass; `character-interact.vue` now counted as adopted (**5/7, up from 4/7**).
- Not yet visually verified in a browser (no local dev server in this sandbox — `DATABASE_URL` points at an unreachable dummy host). The chat-turn mapping is a straightforward 1:1 field rename, and `kr-chat-window` is already proven in production via `bot-interact.vue`, `storybook-page.vue`, and `taskmaster-page.vue`, so the risk here is low, but a preview/production click-through is still worth doing before fully trusting the rendered output.

### Stakes
reversible

### Flags for Reviewer
- Scope is intentionally narrow: only the chat-log transcript. The preset-prompt and getting-to-know-you buttons below it are still hand-rolled `<button>` grids, not `kr-choice-list` — I left those alone since the task's flagged duplicate was specifically the transcript/scroll behavior, and folding those in too would have made this diff much larger without a corresponding contract win.
- `reward-interact.vue` and `scenario-interact.vue` are unstarted. `scenario-interact.vue` in particular needs a `kr-choice-list` extension (eyebrow field or non-italic hint variant) per the task note before its intro picker can migrate cleanly — worth its own task/PR.

### Kaizen suggestion
`reward-interact.vue` and `scenario-interact.vue` are large enough (1183 and 632 lines) that they deserve their own dedicated conductor tasks rather than continuing to live as sub-scope inside t-051 — splitting them out would let the roadmap track partial progress instead of one task note growing indefinitely.

### Notes for reviewer
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DBjapXTXU54dYbGPnNHPbd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBjapXTXU54dYbGPnNHPbd)_