### PR TITLE
feat(home): add bespoke Daily Dream object workbench

### DIFF
--- a/.github/workflows/entity-art-manager-contract.yml
+++ b/.github/workflows/entity-art-manager-contract.yml
@@ -10,6 +10,11 @@ on:
       - 'components/scenarios/scenario-interact.vue'
       - 'components/rewards/reward-interact.vue'
       - 'components/facets/facet-manager.vue'
+      - 'components/dreams/daily-digest-object-gallery.vue'
+      - 'components/dreams/daily-digest-object-dialog.vue'
+      - 'components/dreams/daily-dream-object-art-workbench.vue'
+      - 'stores/dailyDreamArchiveStore.ts'
+      - 'server/api/dreams/daily-archive.get.ts'
       - 'plugins/entity-art-prompt-suggest.client.ts'
       - 'plugins/project-art-prompt-suggest.client.ts'
       - 'stores/helpers/artAssetSuggest.ts'
@@ -22,6 +27,7 @@ on:
       - 'server/utils/entityArt.ts'
       - 'utils/scripts/verifyArtQueueClaimFastPath.ts'
       - 'utils/scripts/verifyEntityArtManager.ts'
+      - 'utils/scripts/verifyDailyDreamArchiveWorkbench.ts'
       - 'utils/scripts/verifyEntityArtPromptSuggest.ts'
       - 'utils/scripts/verifyProjectArtPromptSuggest.ts'
       - '.github/workflows/entity-art-manager-contract.yml'
@@ -42,5 +48,6 @@ jobs:
       - run: npx prisma generate
       - run: npx tsx utils/scripts/verifyArtQueueClaimFastPath.ts
       - run: npx tsx utils/scripts/verifyEntityArtManager.ts
+      - run: npx tsx utils/scripts/verifyDailyDreamArchiveWorkbench.ts
       - run: npx tsx utils/scripts/verifyEntityArtPromptSuggest.ts
       - run: npx tsx utils/scripts/verifyProjectArtPromptSuggest.ts

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -1,0 +1,542 @@
+<template>
+  <Teleport to="body">
+    <dialog class="modal modal-open" aria-modal="true" @cancel.prevent="emit('close')">
+      <div
+        class="modal-box flex max-h-[94dvh] w-[min(96vw,80rem)] max-w-none flex-col overflow-hidden rounded-3xl border border-base-300 bg-base-100 p-0 shadow-2xl"
+      >
+        <header class="flex shrink-0 items-start gap-4 border-b border-base-300 bg-base-100/95 p-4 backdrop-blur sm:p-5">
+          <div
+            class="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-primary/10"
+          >
+            <Icon :name="typeIcon" class="size-6 text-primary" />
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="badge badge-primary badge-sm rounded-lg">{{ typeLabel }}</span>
+              <span class="badge badge-ghost badge-sm rounded-lg">#{{ entity.id }}</span>
+              <span v-if="entity.slug" class="badge badge-outline badge-sm max-w-full truncate rounded-lg">
+                {{ entity.slug }}
+              </span>
+            </div>
+            <h2 class="mt-1 truncate text-xl font-black sm:text-2xl">{{ title }}</h2>
+            <p class="mt-1 line-clamp-2 text-sm text-base-content/55">{{ summary }}</p>
+          </div>
+
+          <button
+            type="button"
+            class="btn btn-ghost btn-square btn-sm shrink-0 rounded-xl"
+            aria-label="Close object details"
+            @click="emit('close')"
+          >
+            <Icon name="kind-icon:x" class="size-4" />
+          </button>
+        </header>
+
+        <nav class="flex shrink-0 gap-1 overflow-x-auto border-b border-base-300 bg-base-200/40 px-4 py-2 sm:px-5" aria-label="Object details sections">
+          <button
+            v-for="tab in tabs"
+            :key="tab.key"
+            type="button"
+            class="btn btn-sm shrink-0 gap-1.5 rounded-xl"
+            :class="activeTab === tab.key ? 'btn-primary' : 'btn-ghost'"
+            @click="activeTab = tab.key"
+          >
+            <Icon :name="tab.icon" class="size-4" />
+            {{ tab.label }}
+          </button>
+        </nav>
+
+        <div class="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
+          <section
+            v-if="activeTab === 'overview'"
+            class="grid gap-5 lg:grid-cols-[minmax(17rem,0.8fr)_minmax(0,1.2fr)]"
+          >
+            <div class="space-y-3">
+              <figure
+                class="relative min-h-72 overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+              >
+                <img
+                  v-if="displayImage && !imageFailed"
+                  :src="displayImage"
+                  :alt="`${title} artwork`"
+                  class="absolute inset-0 size-full object-cover"
+                  @error="imageFailed = true"
+                />
+                <div
+                  v-else
+                  class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-base-content/35"
+                >
+                  <Icon :name="typeIcon" class="size-14 opacity-40" />
+                  <p class="font-bold">No attached artwork yet.</p>
+                </div>
+              </figure>
+
+              <div class="flex flex-wrap gap-2">
+                <span
+                  v-for="badge in badges"
+                  :key="badge"
+                  class="badge badge-outline rounded-xl"
+                >
+                  {{ badge }}
+                </span>
+              </div>
+            </div>
+
+            <div class="space-y-3">
+              <article
+                v-for="row in overviewRows"
+                :key="row.key"
+                class="rounded-2xl border border-base-300 bg-base-100 p-4 shadow-sm"
+              >
+                <p class="text-xs font-black uppercase tracking-[0.14em] text-primary/75">
+                  {{ row.label }}
+                </p>
+                <p class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-base-content/75">
+                  {{ row.value }}
+                </p>
+              </article>
+
+              <div
+                v-if="!overviewRows.length"
+                class="rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-8 text-center text-base-content/45"
+              >
+                This object has a name and excellent posture, but no descriptive fields yet.
+              </div>
+            </div>
+          </section>
+
+          <section v-else-if="activeTab === 'edit'" class="mx-auto max-w-4xl space-y-4">
+            <div
+              v-if="canEdit"
+              class="rounded-2xl border border-primary/25 bg-primary/5 p-4"
+            >
+              <p class="text-xs font-black uppercase tracking-[0.15em] text-primary">Object editor</p>
+              <h3 class="mt-1 text-lg font-black">Revise the useful fields</h3>
+              <p class="mt-1 text-sm leading-relaxed text-base-content/55">
+                These save directly to the existing {{ typeLabel.toLowerCase() }} record. System fields and relationships stay out of reach.
+              </p>
+            </div>
+
+            <form v-if="canEdit" class="grid gap-4" @submit.prevent="saveChanges">
+              <label
+                v-for="field in editFields"
+                :key="field.key"
+                class="form-control gap-1.5"
+              >
+                <span class="text-sm font-black">{{ field.label }}</span>
+                <textarea
+                  v-if="field.multiline"
+                  v-model="draft[field.key]"
+                  class="textarea textarea-bordered min-h-28 rounded-2xl leading-relaxed"
+                  :class="field.tall ? 'min-h-44' : ''"
+                  :placeholder="field.placeholder"
+                  :disabled="saving"
+                />
+                <input
+                  v-else
+                  v-model="draft[field.key]"
+                  type="text"
+                  class="input input-bordered rounded-2xl"
+                  :placeholder="field.placeholder"
+                  :disabled="saving"
+                />
+              </label>
+
+              <div class="sticky bottom-0 flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-lg backdrop-blur">
+                <p
+                  v-if="saveMessage"
+                  class="min-w-0 flex-1 text-sm"
+                  :class="saveError ? 'text-error' : 'text-success'"
+                >
+                  {{ saveMessage }}
+                </p>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-sm ml-auto rounded-xl"
+                  :disabled="saving || !hasChanges"
+                  @click="resetDraft"
+                >
+                  Reset
+                </button>
+                <button
+                  type="submit"
+                  class="btn btn-primary btn-sm gap-2 rounded-xl"
+                  :disabled="saving || !hasChanges || missingRequiredField"
+                >
+                  <span v-if="saving" class="loading loading-spinner loading-xs" />
+                  <Icon v-else name="kind-icon:save" class="size-4" />
+                  {{ saving ? 'Saving…' : 'Save changes' }}
+                </button>
+              </div>
+            </form>
+
+            <div
+              v-else
+              class="flex min-h-72 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-8 text-center"
+            >
+              <Icon name="kind-icon:lock" class="size-10 text-base-content/25" />
+              <p class="text-lg font-black text-base-content/65">This object is view-only.</p>
+              <p class="max-w-lg text-sm text-base-content/45">
+                Only its owner or an administrator can submit content changes.
+              </p>
+            </div>
+          </section>
+
+          <daily-dream-object-art-workbench
+            v-else
+            :object-type="objectType"
+            :entity="entity"
+            :slots="artSlots"
+            :can-edit="canEdit"
+            @updated="handleArtUpdated"
+          />
+        </div>
+      </div>
+
+      <form method="dialog" class="modal-backdrop bg-black/60" @submit.prevent="emit('close')">
+        <button type="button" aria-label="Close object details" @click="emit('close')">close</button>
+      </form>
+    </dialog>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+import {
+  useDailyDreamArchiveStore,
+  type DailyDreamArchiveObject,
+  type DailyDreamArchiveObjectType,
+  type DailyDreamArtSlot,
+} from '@/stores/dailyDreamArchiveStore'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
+
+type TabKey = 'overview' | 'edit' | 'art'
+type EditField = {
+  key: string
+  label: string
+  placeholder: string
+  multiline?: boolean
+  tall?: boolean
+  required?: boolean
+}
+
+type OverviewRow = {
+  key: string
+  label: string
+  value: string
+}
+
+const props = defineProps<{
+  objectType: DailyDreamArchiveObjectType
+  entity: DailyDreamArchiveObject
+}>()
+
+const emit = defineEmits<{
+  close: []
+  updated: []
+}>()
+
+const userStore = useUserStore()
+const archiveStore = useDailyDreamArchiveStore()
+const activeTab = ref<TabKey>('overview')
+const draft = ref<Record<string, string>>({})
+const saving = ref(false)
+const saveMessage = ref('')
+const saveError = ref(false)
+const imageFailed = ref(false)
+
+const tabs = [
+  { key: 'overview' as const, label: 'Details', icon: 'kind-icon:info' },
+  { key: 'edit' as const, label: 'Modify', icon: 'kind-icon:pencil' },
+  { key: 'art' as const, label: 'Artwork', icon: 'kind-icon:palette' },
+]
+
+const fieldConfig: Record<DailyDreamArchiveObjectType, EditField[]> = {
+  dream: [
+    { key: 'title', label: 'Title', placeholder: 'Dream title', required: true },
+    { key: 'pitch', label: 'Pitch', placeholder: 'What makes this world compelling?', multiline: true, tall: true },
+    { key: 'description', label: 'Description', placeholder: 'Describe the world and its central idea.', multiline: true, tall: true },
+    { key: 'flavorText', label: 'Flavor text', placeholder: 'A small atmospheric fragment.', multiline: true },
+    { key: 'examples', label: 'Examples', placeholder: 'Examples, touchstones, or possible moments.', multiline: true },
+    { key: 'artPrompt', label: 'Art prompt', placeholder: 'Primary visual direction for future generations.', multiline: true, tall: true },
+  ],
+  character: [
+    { key: 'name', label: 'Name', placeholder: 'Character name', required: true },
+    { key: 'honorific', label: 'Honorific', placeholder: 'Title or honorific' },
+    { key: 'role', label: 'Role', placeholder: 'Role in the Dream' },
+    { key: 'species', label: 'Species', placeholder: 'Species or nature' },
+    { key: 'class', label: 'Class', placeholder: 'Class or archetype' },
+    { key: 'presentation', label: 'Presentation', placeholder: 'How the character first appears.', multiline: true },
+    { key: 'personality', label: 'Personality', placeholder: 'Temperament, habits, and social texture.', multiline: true, tall: true },
+    { key: 'drive', label: 'Drive', placeholder: 'What they want and why.', multiline: true },
+    { key: 'backstory', label: 'Backstory', placeholder: 'Important history.', multiline: true, tall: true },
+    { key: 'quirks', label: 'Quirks', placeholder: 'Memorable oddities and behaviors.', multiline: true },
+    { key: 'artPrompt', label: 'Art prompt', placeholder: 'Primary visual direction for future generations.', multiline: true, tall: true },
+  ],
+  reward: [
+    { key: 'name', label: 'Name', placeholder: 'Reward name', required: true },
+    { key: 'description', label: 'Description', placeholder: 'What the discovery is.', multiline: true, tall: true },
+    { key: 'effect', label: 'Effect', placeholder: 'What changes when it is used.', multiline: true },
+    { key: 'flavorText', label: 'Flavor text', placeholder: 'A short in-world fragment.', multiline: true },
+    { key: 'artPrompt', label: 'Art prompt', placeholder: 'Primary visual direction for future generations.', multiline: true, tall: true },
+  ],
+  scenario: [
+    { key: 'title', label: 'Title', placeholder: 'Scenario title', required: true },
+    { key: 'description', label: 'Description', placeholder: 'The situation and central tension.', multiline: true, tall: true },
+    { key: 'intros', label: 'Opening ideas', placeholder: 'Possible openings or entry points.', multiline: true, tall: true },
+    { key: 'locations', label: 'Locations', placeholder: 'Important places.', multiline: true },
+    { key: 'genres', label: 'Genres', placeholder: 'Genre and tone.' },
+    { key: 'inspirations', label: 'Inspirations', placeholder: 'Creative touchstones.', multiline: true },
+    { key: 'cast', label: 'Cast notes', placeholder: 'Who belongs in the scene.', multiline: true },
+    { key: 'artPrompt', label: 'Art prompt', placeholder: 'Primary visual direction for future generations.', multiline: true, tall: true },
+  ],
+  bot: [
+    { key: 'name', label: 'Name', placeholder: 'Narrator name', required: true },
+    { key: 'subtitle', label: 'Subtitle', placeholder: 'Short role or identity' },
+    { key: 'tagline', label: 'Tagline', placeholder: 'One memorable line' },
+    { key: 'description', label: 'Description', placeholder: 'What this narrator is for.', multiline: true },
+    { key: 'personality', label: 'Personality', placeholder: 'Voice, temperament, and habits.', multiline: true, tall: true },
+    { key: 'prompt', label: 'System prompt', placeholder: 'Narrator instructions.', multiline: true, tall: true },
+    { key: 'botIntro', label: 'Introduction', placeholder: 'How the narrator greets the traveler.', multiline: true },
+    { key: 'narrativeVoice', label: 'Narrative voice', placeholder: 'Style and cadence.', multiline: true },
+    { key: 'artPrompt', label: 'Art prompt', placeholder: 'Primary visual direction for future generations.', multiline: true, tall: true },
+  ],
+}
+
+const overviewFieldConfig: Record<DailyDreamArchiveObjectType, Array<[string, string]>> = {
+  dream: [
+    ['pitch', 'Pitch'],
+    ['description', 'Description'],
+    ['flavorText', 'Flavor text'],
+    ['examples', 'Examples'],
+    ['artPrompt', 'Art prompt'],
+  ],
+  character: [
+    ['presentation', 'Presentation'],
+    ['personality', 'Personality'],
+    ['drive', 'Drive'],
+    ['backstory', 'Backstory'],
+    ['quirks', 'Quirks'],
+    ['artPrompt', 'Art prompt'],
+  ],
+  reward: [
+    ['description', 'Description'],
+    ['effect', 'Effect'],
+    ['flavorText', 'Flavor text'],
+    ['artPrompt', 'Art prompt'],
+  ],
+  scenario: [
+    ['description', 'Description'],
+    ['intros', 'Opening ideas'],
+    ['locations', 'Locations'],
+    ['cast', 'Cast notes'],
+    ['inspirations', 'Inspirations'],
+    ['artPrompt', 'Art prompt'],
+  ],
+  bot: [
+    ['description', 'Description'],
+    ['tagline', 'Tagline'],
+    ['personality', 'Personality'],
+    ['botIntro', 'Introduction'],
+    ['narrativeVoice', 'Narrative voice'],
+    ['prompt', 'System prompt'],
+    ['artPrompt', 'Art prompt'],
+  ],
+}
+
+const slotConfig: Record<DailyDreamArchiveObjectType, DailyDreamArtSlot[]> = {
+  dream: [
+    { field: 'imagePath', label: 'Image', aspect: '1 / 1', width: 1024, height: 1024 },
+    { field: 'cardPath', label: 'Card', aspect: '2 / 3', width: 512, height: 768 },
+    { field: 'heroPath', label: 'Hero', aspect: '16 / 9', width: 1280, height: 720 },
+  ],
+  character: [
+    { field: 'imagePath', label: 'Portrait', aspect: '1 / 1', width: 1024, height: 1024 },
+    { field: 'iconPath', label: 'Icon', aspect: '1 / 1', width: 256, height: 256 },
+    { field: 'cardPath', label: 'Card', aspect: '2 / 3', width: 512, height: 768 },
+    { field: 'heroPath', label: 'Hero', aspect: '16 / 9', width: 1280, height: 720 },
+  ],
+  reward: [
+    { field: 'imagePath', label: 'Reward', aspect: '1 / 1', width: 1024, height: 1024 },
+    { field: 'iconPath', label: 'Icon', aspect: '1 / 1', width: 256, height: 256 },
+    { field: 'cardPath', label: 'Card', aspect: '2 / 3', width: 512, height: 768 },
+    { field: 'heroPath', label: 'Hero', aspect: '16 / 9', width: 1280, height: 720 },
+  ],
+  scenario: [
+    { field: 'imagePath', label: 'Scene', aspect: '16 / 9', width: 1536, height: 864 },
+    { field: 'iconPath', label: 'Icon', aspect: '1 / 1', width: 256, height: 256 },
+    { field: 'cardPath', label: 'Card', aspect: '2 / 3', width: 512, height: 768 },
+    { field: 'heroPath', label: 'Hero', aspect: '16 / 9', width: 1280, height: 720 },
+  ],
+  bot: [
+    { field: 'avatarImage', label: 'Avatar', aspect: '1 / 1', width: 1024, height: 1024 },
+    { field: 'iconPath', label: 'Icon', aspect: '1 / 1', width: 256, height: 256 },
+    { field: 'cardPath', label: 'Card', aspect: '2 / 3', width: 512, height: 768 },
+    { field: 'heroPath', label: 'Hero', aspect: '16 / 9', width: 1280, height: 720 },
+  ],
+}
+
+const typeLabel = computed(() => {
+  if (props.objectType === 'bot') return 'Narrator'
+  return props.objectType.charAt(0).toUpperCase() + props.objectType.slice(1)
+})
+
+const typeIcon = computed(() => {
+  if (props.objectType === 'dream') return 'kind-icon:moon'
+  if (props.objectType === 'character') return 'kind-icon:user'
+  if (props.objectType === 'reward') return 'kind-icon:gift'
+  if (props.objectType === 'scenario') return 'kind-icon:story'
+  return 'kind-icon:robot'
+})
+
+const title = computed(() =>
+  String(
+    props.entity.title ||
+      props.entity.name ||
+      `${typeLabel.value} ${props.entity.id}`,
+  ),
+)
+
+const summary = computed(() => {
+  const candidates =
+    props.objectType === 'character'
+      ? [props.entity.presentation, props.entity.personality, props.entity.backstory]
+      : props.objectType === 'reward'
+        ? [props.entity.description, props.entity.effect, props.entity.flavorText]
+        : props.objectType === 'scenario'
+          ? [props.entity.description, props.entity.intros]
+          : props.objectType === 'bot'
+            ? [props.entity.subtitle, props.entity.tagline, props.entity.description]
+            : [props.entity.pitch, props.entity.description, props.entity.flavorText]
+
+  return (
+    candidates.find((value) => typeof value === 'string' && value.trim()) ||
+    'No summary has been written yet.'
+  ) as string
+})
+
+const canEdit = computed(
+  () =>
+    userStore.isAdmin ||
+    (Number(props.entity.userId) > 0 &&
+      Number(props.entity.userId) === Number(userStore.userId)),
+)
+
+const editFields = computed(() => fieldConfig[props.objectType])
+const artSlots = computed(() => slotConfig[props.objectType])
+
+const displayImage = computed(() => {
+  const nested = resolveEntityArtwork(props.entity.ArtImage)
+  const direct = resolveEntityArtwork(props.entity)
+  if (nested) return nested
+  if (direct) return direct
+  if (props.entity.artImageId) {
+    return `/api/art/images/${props.entity.artImageId}/file`
+  }
+  return ''
+})
+
+const overviewRows = computed<OverviewRow[]>(() =>
+  overviewFieldConfig[props.objectType].flatMap(([key, label]) => {
+    const value = props.entity[key]
+    const text = typeof value === 'string' ? value.trim() : ''
+    return text ? [{ key, label, value: text }] : []
+  }),
+)
+
+const badges = computed(() => {
+  const values: unknown[] = []
+  if (props.objectType === 'dream') {
+    values.push(props.entity.dreamType)
+  } else if (props.objectType === 'character') {
+    values.push(props.entity.species, props.entity.class, props.entity.role)
+  } else if (props.objectType === 'reward') {
+    values.push(props.entity.rewardType, props.entity.rarity)
+  } else if (props.objectType === 'scenario') {
+    values.push(props.entity.tier, props.entity.genres)
+    if (props.entity.difficulty) values.push(`Difficulty ${props.entity.difficulty}`)
+  } else {
+    values.push(props.entity.BotType, props.entity.subtitle)
+  }
+  return values
+    .filter((value): value is string | number =>
+      ['string', 'number'].includes(typeof value) && String(value).trim().length > 0,
+    )
+    .map(String)
+})
+
+const hasChanges = computed(() =>
+  editFields.value.some(
+    (field) => draft.value[field.key] !== stringValue(props.entity[field.key]),
+  ),
+)
+
+const missingRequiredField = computed(() =>
+  editFields.value.some(
+    (field) => field.required && !draft.value[field.key]?.trim(),
+  ),
+)
+
+function stringValue(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+function resetDraft(): void {
+  draft.value = Object.fromEntries(
+    editFields.value.map((field) => [field.key, stringValue(props.entity[field.key])]),
+  )
+  saveMessage.value = ''
+  saveError.value = false
+}
+
+async function saveChanges(): Promise<void> {
+  if (!canEdit.value || saving.value || !hasChanges.value) return
+
+  const patch = Object.fromEntries(
+    editFields.value.flatMap((field) => {
+      const next = draft.value[field.key] ?? ''
+      const current = stringValue(props.entity[field.key])
+      return next !== current ? [[field.key, next]] : []
+    }),
+  )
+
+  saving.value = true
+  saveMessage.value = ''
+  saveError.value = false
+  const result = await archiveStore.updateObject(
+    props.objectType,
+    props.entity.id,
+    patch,
+  )
+  saving.value = false
+  saveMessage.value = result.message
+  saveError.value = !result.success
+
+  if (result.success && result.data) {
+    Object.assign(props.entity, result.data)
+    resetDraft()
+    saveMessage.value = result.message
+    emit('updated')
+  }
+}
+
+async function handleArtUpdated(): Promise<void> {
+  await archiveStore.fetchArchive(true)
+  imageFailed.value = false
+  emit('updated')
+}
+
+watch(
+  () => [props.objectType, props.entity.id],
+  () => {
+    activeTab.value = 'overview'
+    imageFailed.value = false
+    resetDraft()
+  },
+  { immediate: true },
+)
+</script>

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -1,173 +1,265 @@
 <template>
-  <section v-if="objectCount" class="border-t border-base-300 bg-base-200/25 p-5 sm:p-7">
+  <section
+    v-if="items.length"
+    class="border-t border-base-300 bg-base-200/25 p-4 sm:p-6"
+  >
     <header class="flex flex-wrap items-end justify-between gap-3">
       <div>
         <p class="text-xs font-black uppercase tracking-[0.16em] text-primary">
           Complete bundle
         </p>
         <h3 class="mt-1 text-xl font-black">Objects in this Daily Dream</h3>
-        <p class="mt-1 max-w-3xl text-sm text-base-content/55">
-          The real shared cards, with their descriptions, metadata, artwork, and graceful
-          placeholders when an older object is still waiting on generated art.
+        <p class="mt-1 max-w-3xl text-sm leading-relaxed text-base-content/55">
+          A compact catalog of the world, place, cast, discoveries, and scenario. Open any object for its full information, editable fields, and artwork workbench.
         </p>
       </div>
-      <span class="badge badge-primary rounded-xl">{{ objectCount }} objects</span>
+      <span class="badge badge-primary h-auto rounded-xl px-3 py-2">
+        {{ items.length }} objects
+      </span>
     </header>
 
-    <div class="mt-6 space-y-7">
-      <section v-if="relatedDreams.length" class="space-y-3">
-        <div class="flex items-center gap-2 px-1">
-          <Icon name="kind-icon:map" class="size-4 text-accent" />
-          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
-            Places & companion dreams
-          </h4>
-        </div>
-        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          <dream-card
-            v-for="relatedDream in relatedDreams"
-            :key="relatedDream.id"
-            :dream="relatedDream"
-            :show-actions="false"
-            :show-description="true"
-            :allow-edit="false"
-            :allow-delete="false"
-          />
-        </div>
-      </section>
+    <div class="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      <article
+        v-for="item in items"
+        :key="item.key"
+        class="group overflow-hidden rounded-2xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:border-primary/35 hover:shadow-md"
+      >
+        <button
+          type="button"
+          class="grid h-full w-full grid-cols-[6.5rem_minmax(0,1fr)] text-left sm:grid-cols-[7.5rem_minmax(0,1fr)]"
+          :aria-label="`Open ${item.title}`"
+          @click="selectedItem = item"
+        >
+          <figure class="relative min-h-40 overflow-hidden bg-base-200">
+            <img
+              v-if="item.image"
+              :src="item.image"
+              :alt="`${item.title} artwork`"
+              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-[1.03]"
+            />
+            <div
+              v-else
+              class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-3 text-center text-base-content/30"
+            >
+              <Icon :name="item.icon" class="size-10 opacity-50" />
+              <span class="text-[0.68rem] font-bold uppercase tracking-wide">
+                Awaiting art
+              </span>
+            </div>
+            <span
+              class="badge badge-neutral badge-sm absolute left-2 top-2 max-w-[calc(100%-1rem)] truncate rounded-lg shadow"
+            >
+              {{ item.role }}
+            </span>
+          </figure>
 
-      <section v-if="dream.Characters.length" class="space-y-3">
-        <div class="flex items-center gap-2 px-1">
-          <Icon name="kind-icon:users" class="size-4 text-primary" />
-          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
-            Cast
-          </h4>
-        </div>
-        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          <character-card
-            v-for="character in dream.Characters"
-            :key="character.id"
-            :character="character"
-            :show-actions="false"
-            :show-description="true"
-            :show-reaction="false"
-            :show-mode-buttons="false"
-            :show-inline-interact="false"
-            :allow-edit="false"
-            :allow-clone="false"
-            :allow-delete="false"
-          />
-        </div>
-      </section>
+          <div class="flex min-w-0 flex-col p-3.5 sm:p-4">
+            <div class="flex items-start gap-2">
+              <div class="min-w-0 flex-1">
+                <p class="text-[0.68rem] font-black uppercase tracking-[0.13em] text-primary/70">
+                  {{ item.typeLabel }}
+                </p>
+                <h4 class="mt-0.5 line-clamp-2 text-base font-black leading-tight sm:text-lg">
+                  {{ item.title }}
+                </h4>
+              </div>
+              <Icon name="kind-icon:external-link" class="mt-1 size-4 shrink-0 text-base-content/30 transition group-hover:text-primary" />
+            </div>
 
-      <section v-if="dream.Rewards.length" class="space-y-3">
-        <div class="flex items-center gap-2 px-1">
-          <Icon name="kind-icon:gift" class="size-4 text-secondary" />
-          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
-            Discoveries
-          </h4>
-        </div>
-        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          <reward-card
-            v-for="reward in dream.Rewards"
-            :key="reward.id"
-            :reward="reward"
-            :show-actions="false"
-            :show-description="true"
-            :show-reaction="false"
-            :show-select-button="false"
-            :allow-edit="false"
-            :allow-delete="false"
-          />
-        </div>
-      </section>
+            <div v-if="item.meta.length" class="mt-2 flex flex-wrap gap-1.5">
+              <span
+                v-for="meta in item.meta"
+                :key="meta"
+                class="badge badge-ghost badge-sm max-w-full truncate rounded-lg"
+              >
+                {{ meta }}
+              </span>
+            </div>
 
-      <section v-if="dream.Scenarios.length" class="space-y-3">
-        <div class="flex items-center gap-2 px-1">
-          <Icon name="kind-icon:story" class="size-4 text-info" />
-          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
-            Scenarios
-          </h4>
-        </div>
-        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          <scenario-card
-            v-for="scenario in dream.Scenarios"
-            :key="scenario.id"
-            :scenario="scenario"
-            :show-actions="false"
-            :show-description="true"
-            :show-reaction="false"
-            :show-inspirations="false"
-            :allow-edit="false"
-            :allow-clone="false"
-            :allow-delete="false"
-          />
-        </div>
-      </section>
+            <p class="mt-2 line-clamp-3 text-xs leading-relaxed text-base-content/60 sm:text-sm">
+              {{ item.summary }}
+            </p>
 
-      <section v-if="dream.Bots.length" class="space-y-3">
-        <div class="flex items-center gap-2 px-1">
-          <Icon name="kind-icon:robot" class="size-4 text-warning" />
-          <h4 class="text-sm font-black uppercase tracking-wide text-base-content/60">
-            Narrators
-          </h4>
-        </div>
-        <div class="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          <bot-card
-            v-for="bot in dream.Bots"
-            :key="bot.id"
-            :bot="bot"
-            :show-actions="false"
-            :show-description="true"
-            :show-personality="true"
-            :show-prompt-preview="false"
-            :show-launch-button="false"
-            :show-reaction="false"
-            :allow-edit="false"
-            :allow-clone="false"
-            :allow-delete="false"
-          />
-        </div>
-      </section>
+            <span class="mt-auto inline-flex items-center gap-1.5 pt-3 text-xs font-black text-primary">
+              Open details
+              <Icon name="kind-icon:chevron-right" class="size-3.5" />
+            </span>
+          </div>
+        </button>
+      </article>
     </div>
+
+    <daily-digest-object-dialog
+      v-if="selectedItem"
+      :key="selectedItem.key"
+      :object-type="selectedItem.objectType"
+      :entity="selectedItem.entity"
+      @close="selectedItem = null"
+      @updated="handleUpdated"
+    />
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import type { DreamWithRelations } from '@/stores/dreamStore'
+import { computed, ref } from 'vue'
 import type {
   DailyDreamArchiveEntry,
+  DailyDreamArchiveObject,
+  DailyDreamArchiveObjectType,
   DailyDreamRelatedDream,
 } from '@/stores/dailyDreamArchiveStore'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
+
+type BundleItem = {
+  key: string
+  objectType: DailyDreamArchiveObjectType
+  role: string
+  typeLabel: string
+  icon: string
+  title: string
+  summary: string
+  image: string
+  meta: string[]
+  entity: DailyDreamArchiveObject
+}
 
 const props = defineProps<{
   dream: DailyDreamArchiveEntry
 }>()
 
-const relatedDreams = computed<DreamWithRelations[]>(() => {
-  const found = new Map<number, DailyDreamRelatedDream>()
+const selectedItem = ref<BundleItem | null>(null)
 
+function asEntity(value: unknown): DailyDreamArchiveObject {
+  return value as DailyDreamArchiveObject
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function titleFor(
+  objectType: DailyDreamArchiveObjectType,
+  entity: DailyDreamArchiveObject,
+): string {
+  if (objectType === 'bot') return text(entity.name) || 'Unnamed narrator'
+  if (objectType === 'character') return text(entity.name) || 'Unnamed character'
+  if (objectType === 'reward') return text(entity.name) || 'Unnamed discovery'
+  return text(entity.title) || `Untitled ${objectType}`
+}
+
+function summaryFor(
+  objectType: DailyDreamArchiveObjectType,
+  entity: DailyDreamArchiveObject,
+): string {
+  const candidates =
+    objectType === 'dream'
+      ? [entity.pitch, entity.description, entity.flavorText]
+      : objectType === 'character'
+        ? [entity.presentation, entity.personality, entity.drive, entity.backstory]
+        : objectType === 'reward'
+          ? [entity.description, entity.effect, entity.flavorText]
+          : objectType === 'scenario'
+            ? [entity.description, entity.intros]
+            : [entity.subtitle, entity.tagline, entity.description, entity.personality]
+
+  return (
+    candidates.map(text).find(Boolean) ||
+    'Open this object to inspect its complete record and artwork controls.'
+  )
+}
+
+function imageFor(entity: DailyDreamArchiveObject): string {
+  return (
+    resolveEntityArtwork(entity.ArtImage) ||
+    resolveEntityArtwork(entity) ||
+    text(entity.PitchSheet && (entity.PitchSheet as { imagePath?: unknown }).imagePath) ||
+    (entity.artImageId ? `/api/art/images/${entity.artImageId}/file` : '')
+  )
+}
+
+function metaFor(
+  objectType: DailyDreamArchiveObjectType,
+  entity: DailyDreamArchiveObject,
+): string[] {
+  const values: unknown[] = []
+  if (objectType === 'dream') {
+    values.push(entity.dreamType)
+  } else if (objectType === 'character') {
+    values.push(entity.species, entity.class, entity.role)
+  } else if (objectType === 'reward') {
+    values.push(entity.rewardType, entity.rarity)
+  } else if (objectType === 'scenario') {
+    values.push(entity.tier, entity.genres)
+  } else {
+    values.push(entity.BotType, entity.subtitle)
+  }
+
+  return values.map(text).filter(Boolean).slice(0, 3)
+}
+
+function makeItem(
+  objectType: DailyDreamArchiveObjectType,
+  role: string,
+  typeLabel: string,
+  icon: string,
+  entity: DailyDreamArchiveObject,
+): BundleItem {
+  return {
+    key: `${objectType}:${entity.id}`,
+    objectType,
+    role,
+    typeLabel,
+    icon,
+    title: titleFor(objectType, entity),
+    summary: summaryFor(objectType, entity),
+    image: imageFor(entity),
+    meta: metaFor(objectType, entity),
+    entity,
+  }
+}
+
+const relatedDreams = computed<DailyDreamRelatedDream[]>(() => {
+  const found = new Map<number, DailyDreamRelatedDream>()
   for (const relation of props.dream.RelationsFrom) {
     if (relation.ToDream.id !== props.dream.id) {
       found.set(relation.ToDream.id, relation.ToDream)
     }
   }
-
   for (const relation of props.dream.RelationsTo) {
     if (relation.FromDream.id !== props.dream.id) {
       found.set(relation.FromDream.id, relation.FromDream)
     }
   }
-
-  return Array.from(found.values()) as unknown as DreamWithRelations[]
+  return Array.from(found.values())
 })
 
-const objectCount = computed(
-  () =>
-    relatedDreams.value.length +
-    props.dream.Characters.length +
-    props.dream.Rewards.length +
-    props.dream.Scenarios.length +
-    props.dream.Bots.length,
-)
+const items = computed<BundleItem[]>(() => [
+  makeItem('dream', 'World', 'Dream', 'kind-icon:moon', asEntity(props.dream)),
+  ...relatedDreams.value.map((dream) =>
+    makeItem('dream', 'Place', 'Dream location', 'kind-icon:map', asEntity(dream)),
+  ),
+  ...props.dream.Characters.map((character) =>
+    makeItem('character', 'Cast', 'Character', 'kind-icon:user', asEntity(character)),
+  ),
+  ...props.dream.Rewards.map((reward) =>
+    makeItem('reward', 'Discovery', 'Reward', 'kind-icon:gift', asEntity(reward)),
+  ),
+  ...props.dream.Scenarios.map((scenario) =>
+    makeItem('scenario', 'Scenario', 'Scenario', 'kind-icon:story', asEntity(scenario)),
+  ),
+  ...props.dream.Bots.map((bot) =>
+    makeItem('bot', 'Narrator', 'Bot', 'kind-icon:robot', asEntity(bot)),
+  ),
+])
+
+function handleUpdated(): void {
+  if (!selectedItem.value) return
+  selectedItem.value = {
+    ...selectedItem.value,
+    title: titleFor(selectedItem.value.objectType, selectedItem.value.entity),
+    summary: summaryFor(selectedItem.value.objectType, selectedItem.value.entity),
+    image: imageFor(selectedItem.value.entity),
+    meta: metaFor(selectedItem.value.objectType, selectedItem.value.entity),
+  }
+}
 </script>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -412,6 +412,11 @@ function startPolling(jobId: number): void {
         }
       } else {
         await archiveStore.fetchArchive(true)
+        const refreshed = archiveStore.findObject(
+          props.objectType,
+          props.entity.id,
+        )
+        if (refreshed) Object.assign(props.entity, refreshed)
       }
 
       imageFailed.value = false

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -1,0 +1,475 @@
+<template>
+  <section class="space-y-4">
+    <div class="grid gap-4 lg:grid-cols-[minmax(15rem,0.85fr)_minmax(0,1.15fr)]">
+      <div class="space-y-3">
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="slot in slots"
+            :key="slot.field"
+            type="button"
+            class="btn btn-sm rounded-xl"
+            :class="selectedField === slot.field ? 'btn-secondary' : 'btn-ghost border border-base-300'"
+            @click="selectedField = slot.field"
+          >
+            {{ slot.label }}
+          </button>
+        </div>
+
+        <figure
+          class="relative min-h-64 overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+          :style="{ aspectRatio: selectedSlot.aspect }"
+        >
+          <img
+            v-if="currentSrc && !imageFailed"
+            :key="currentSrc"
+            :src="currentSrc"
+            :alt="`${title} ${selectedSlot.label}`"
+            class="absolute inset-0 size-full object-cover"
+            @error="imageFailed = true"
+          />
+          <div
+            v-else
+            class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-6 text-center text-base-content/40"
+          >
+            <Icon name="kind-icon:image" class="size-12 opacity-40" />
+            <p class="text-sm font-bold">
+              No {{ selectedSlot.label.toLowerCase() }} is attached yet.
+            </p>
+          </div>
+
+          <div
+            class="absolute inset-x-0 bottom-0 flex items-end justify-between gap-3 bg-linear-to-t from-base-300/95 to-transparent p-4 pt-14"
+          >
+            <span class="badge border-0 bg-base-100/90 font-bold backdrop-blur">
+              Current {{ selectedSlot.label }}
+            </span>
+            <span class="badge badge-ghost bg-base-100/85 backdrop-blur">
+              {{ selectedSlot.width }}×{{ selectedSlot.height }}
+            </span>
+          </div>
+        </figure>
+      </div>
+
+      <div
+        v-if="canEdit"
+        class="space-y-4 rounded-2xl border border-secondary/25 bg-secondary/5 p-4"
+      >
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-black uppercase tracking-[0.16em] text-secondary">
+              Art workbench
+            </p>
+            <h3 class="mt-1 text-lg font-black">
+              Rebuild or modify {{ selectedSlot.label.toLowerCase() }} art
+            </h3>
+            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+              Recreate starts from the prompt. Modify uses the current image as visual guidance.
+            </p>
+          </div>
+          <span class="badge badge-secondary rounded-xl">{{ typeLabel }}</span>
+        </div>
+
+        <div class="grid gap-3 sm:grid-cols-3">
+          <label class="form-control gap-1">
+            <span class="text-xs font-bold text-base-content/60">Method</span>
+            <select
+              v-model="mode"
+              class="select select-bordered select-sm rounded-xl"
+              :disabled="submitting"
+            >
+              <option value="recreate">Redo from prompt</option>
+              <option value="img2img" :disabled="!currentSrc">Modify current image</option>
+            </select>
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-bold text-base-content/60">Engine</span>
+            <select
+              v-model="engine"
+              class="select select-bordered select-sm rounded-xl"
+              :disabled="submitting"
+            >
+              <template v-if="mode === 'recreate'">
+                <option value="krea2">Krea 2</option>
+                <option value="comfy">SDXL</option>
+              </template>
+              <template v-else>
+                <option value="sdxl-img2img">SDXL img2img</option>
+                <option value="kontext">Kontext edit</option>
+              </template>
+            </select>
+          </label>
+
+          <label class="form-control gap-1">
+            <span class="text-xs font-bold text-base-content/60">Strength</span>
+            <select
+              v-model="presetKey"
+              class="select select-bordered select-sm rounded-xl"
+              :disabled="submitting"
+            >
+              <option
+                v-for="preset in availablePresets"
+                :key="preset.key"
+                :value="preset.key"
+              >
+                {{ preset.label }}
+              </option>
+            </select>
+          </label>
+        </div>
+
+        <label class="form-control gap-1">
+          <span class="text-xs font-bold text-base-content/60">Art prompt</span>
+          <textarea
+            v-model="prompt"
+            class="textarea textarea-bordered min-h-36 rounded-xl text-sm leading-relaxed"
+            maxlength="5000"
+            :placeholder="promptPlaceholder"
+            :disabled="submitting"
+          />
+          <span class="text-[0.68rem] leading-relaxed text-base-content/40">
+            The object record supplies supporting context. This prompt remains the primary direction.
+          </span>
+        </label>
+
+        <label class="flex cursor-pointer items-start gap-3 rounded-xl border border-base-300 bg-base-100/70 p-3">
+          <input
+            v-model="preserveOriginal"
+            type="checkbox"
+            class="checkbox checkbox-secondary checkbox-sm mt-0.5"
+            :disabled="submitting"
+          />
+          <span>
+            <span class="block text-sm font-bold">Keep the current version as inspiration</span>
+            <span class="block text-xs leading-relaxed text-base-content/45">
+              Preserve the previous image in object history before the replacement attaches.
+            </span>
+          </span>
+        </label>
+
+        <div class="rounded-xl bg-base-100/70 px-3 py-2 text-xs text-base-content/55">
+          <strong>{{ mode === 'recreate' ? 'Recreate' : 'Modify' }}:</strong>
+          {{ engineLabel }} · {{ selectedPreset.description }}
+        </div>
+
+        <div class="flex flex-wrap items-center gap-3">
+          <p
+            v-if="message"
+            class="min-w-0 flex-1 text-xs leading-relaxed"
+            :class="messageTone === 'error' ? 'text-error' : messageTone === 'success' ? 'text-success' : 'text-info'"
+          >
+            {{ message }}
+          </p>
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm ml-auto gap-2 rounded-xl"
+            :disabled="submitting || prompt.trim().length < 3 || (mode === 'img2img' && !currentSrc)"
+            @click="queueArt"
+          >
+            <span v-if="submitting" class="loading loading-spinner loading-xs" />
+            <Icon v-else name="kind-icon:sparkles" class="size-4" />
+            {{ submitting ? 'Queuing…' : `Queue ${selectedSlot.label}` }}
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="flex min-h-64 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6 text-center"
+      >
+        <Icon name="kind-icon:lock" class="size-8 text-base-content/25" />
+        <p class="font-black text-base-content/65">Artwork is view-only.</p>
+        <p class="max-w-md text-sm text-base-content/45">
+          Sign in as the owner or an administrator to queue a replacement or modification.
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import {
+  useDailyDreamArchiveStore,
+  type DailyDreamArchiveObject,
+  type DailyDreamArchiveObjectType,
+  type DailyDreamArtSlot,
+} from '@/stores/dailyDreamArchiveStore'
+import { resolveEntityArtwork } from '@/utils/artImageSrc'
+
+type Preset = {
+  key: string
+  label: string
+  description: string
+  denoise?: number
+  originalWeight?: number
+  steps?: number
+}
+
+const props = defineProps<{
+  objectType: DailyDreamArchiveObjectType
+  entity: DailyDreamArchiveObject
+  slots: DailyDreamArtSlot[]
+  canEdit: boolean
+}>()
+
+const emit = defineEmits<{
+  updated: []
+}>()
+
+const archiveStore = useDailyDreamArchiveStore()
+const selectedField = ref(props.slots[0]?.field || 'imagePath')
+const mode = ref<'recreate' | 'img2img'>('recreate')
+const engine = ref('krea2')
+const presetKey = ref('quality')
+const prompt = ref(String(props.entity.artPrompt || ''))
+const preserveOriginal = ref(true)
+const submitting = ref(false)
+const imageFailed = ref(false)
+const message = ref('')
+const messageTone = ref<'info' | 'success' | 'error'>('info')
+let pollTimer: ReturnType<typeof setTimeout> | null = null
+let activeJobId: number | null = null
+let stopped = false
+
+const recreatePresets: Preset[] = [
+  {
+    key: 'quality',
+    label: 'Quality default',
+    description: 'Use the current quality-focused workflow defaults.',
+  },
+  {
+    key: 'polished',
+    label: 'Polished',
+    description: 'Use a slightly longer quality pass.',
+    steps: 28,
+  },
+]
+
+const img2imgPresets: Preset[] = [
+  {
+    key: 'gentle',
+    label: 'Gentle refresh',
+    description: 'Keep most of the original composition.',
+    denoise: 0.35,
+    originalWeight: 0.75,
+  },
+  {
+    key: 'balanced',
+    label: 'Balanced edit',
+    description: 'Preserve identity while allowing visible changes.',
+    denoise: 0.55,
+    originalWeight: 0.55,
+  },
+  {
+    key: 'strong',
+    label: 'Strong redesign',
+    description: 'Use the source as guidance rather than a strict template.',
+    denoise: 0.75,
+    originalWeight: 0.35,
+  },
+]
+
+const selectedSlot = computed<DailyDreamArtSlot>(() =>
+  props.slots.find((slot) => slot.field === selectedField.value) ||
+  props.slots[0] || {
+    field: 'imagePath',
+    label: 'Image',
+    width: 1024,
+    height: 1024,
+    aspect: '1 / 1',
+  },
+)
+
+const title = computed(() =>
+  String(
+    props.entity.title ||
+      props.entity.name ||
+      `${typeLabel.value} ${props.entity.id}`,
+  ),
+)
+
+const typeLabel = computed(() =>
+  props.objectType.charAt(0).toUpperCase() + props.objectType.slice(1),
+)
+
+const currentSrc = computed(() => {
+  const direct = normalizeSource(props.entity[selectedSlot.value.field])
+  if (direct) return direct
+
+  if (
+    props.entity.artImageId &&
+    ['imagePath', 'avatarImage'].includes(selectedSlot.value.field)
+  ) {
+    return `/api/art/images/${props.entity.artImageId}/file`
+  }
+
+  if (props.objectType === 'dream') {
+    return resolveEntityArtwork(props.entity.ArtImage) || ''
+  }
+
+  return ''
+})
+
+const availablePresets = computed(() =>
+  mode.value === 'recreate' ? recreatePresets : img2imgPresets,
+)
+
+const selectedPreset = computed<Preset>(
+  () =>
+    availablePresets.value.find((preset) => preset.key === presetKey.value) ||
+    availablePresets.value[0] ||
+    recreatePresets[0]!,
+)
+
+const engineLabel = computed(() => {
+  if (engine.value === 'krea2') return 'Krea 2'
+  if (engine.value === 'sdxl-img2img') return 'SDXL img2img'
+  if (engine.value === 'kontext') return 'Kontext'
+  return 'SDXL'
+})
+
+const promptPlaceholder = computed(() =>
+  mode.value === 'recreate'
+    ? `Describe a new ${selectedSlot.value.label.toLowerCase()} for ${title.value}…`
+    : `Describe what should change while preserving the useful parts of the current ${selectedSlot.value.label.toLowerCase()}…`,
+)
+
+function normalizeSource(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.toLowerCase() === 'undefined') return ''
+  if (/^(https?:|data:image\/|\/)/.test(trimmed)) return trimmed
+  if (trimmed.startsWith('images/')) return `/${trimmed}`
+  return `/images/${trimmed}`
+}
+
+async function queueArt(): Promise<void> {
+  if (submitting.value || prompt.value.trim().length < 3) return
+
+  submitting.value = true
+  message.value = ''
+  messageTone.value = 'info'
+
+  const preset = selectedPreset.value
+  const result = await archiveStore.queueObjectArt({
+    objectType: props.objectType,
+    entity: props.entity,
+    slot: selectedSlot.value,
+    prompt: prompt.value.trim(),
+    mode: mode.value,
+    engine: engine.value,
+    preserveOriginal: preserveOriginal.value,
+    denoise: preset.denoise,
+    originalWeight: preset.originalWeight,
+    steps: preset.steps,
+  })
+
+  submitting.value = false
+
+  if (!result.success || !result.jobId) {
+    message.value = result.message
+    messageTone.value = 'error'
+    return
+  }
+
+  activeJobId = result.jobId
+  message.value = `${result.message} It will attach automatically when rendering finishes.`
+  startPolling(result.jobId)
+}
+
+function startPolling(jobId: number): void {
+  if (pollTimer) clearTimeout(pollTimer)
+
+  const poll = async () => {
+    if (stopped || activeJobId !== jobId) return
+
+    const result = await archiveStore.fetchArtJob(jobId)
+    const status = String(result.job?.status || '')
+
+    if (result.success && status === 'DONE') {
+      const artImageId = Number(result.job?.artImageId)
+      if (props.objectType === 'dream') {
+        if (!Number.isInteger(artImageId) || artImageId <= 0) {
+          message.value = `ArtJob ${jobId} finished without an attachable ArtImage.`
+          messageTone.value = 'error'
+          activeJobId = null
+          return
+        }
+
+        const applied = await archiveStore.applyDreamArt({
+          entity: props.entity,
+          slot: selectedSlot.value,
+          artImageId,
+          prompt: prompt.value,
+          preserveOriginal: preserveOriginal.value,
+        })
+        if (!applied.success) {
+          message.value = applied.message
+          messageTone.value = 'error'
+          activeJobId = null
+          return
+        }
+      } else {
+        await archiveStore.fetchArchive(true)
+      }
+
+      imageFailed.value = false
+      message.value = `ArtJob ${jobId} finished and the ${selectedSlot.value.label.toLowerCase()} was replaced.`
+      messageTone.value = 'success'
+      activeJobId = null
+      emit('updated')
+      return
+    }
+
+    if (status === 'FAILED' || status === 'CANCELLED') {
+      message.value = result.job?.error || `ArtJob ${jobId} ended as ${status}.`
+      messageTone.value = 'error'
+      activeJobId = null
+      return
+    }
+
+    if (result.success) {
+      message.value = `ArtJob ${jobId}: ${status || 'PENDING'}. The durable queue is still working.`
+      messageTone.value = 'info'
+    }
+
+    pollTimer = setTimeout(poll, 5000)
+  }
+
+  void poll()
+}
+
+watch(mode, (nextMode) => {
+  engine.value = nextMode === 'recreate' ? 'krea2' : 'sdxl-img2img'
+  presetKey.value = nextMode === 'recreate' ? 'quality' : 'balanced'
+})
+
+watch(selectedField, () => {
+  imageFailed.value = false
+})
+
+watch(
+  () => [props.objectType, props.entity.id],
+  () => {
+    selectedField.value = props.slots[0]?.field || 'imagePath'
+    mode.value = 'recreate'
+    engine.value = 'krea2'
+    presetKey.value = 'quality'
+    prompt.value = String(props.entity.artPrompt || '')
+    preserveOriginal.value = true
+    imageFailed.value = false
+    message.value = ''
+    activeJobId = null
+    if (pollTimer) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+  },
+)
+
+onBeforeUnmount(() => {
+  stopped = true
+  if (pollTimer) clearTimeout(pollTimer)
+})
+</script>

--- a/stores/dailyDreamArchiveStore.ts
+++ b/stores/dailyDreamArchiveStore.ts
@@ -90,6 +90,18 @@ export type DailyDreamArchiveObject = Record<string, unknown> & {
   id: number
   userId?: number | null
   artImageId?: number | null
+  title?: string | null
+  name?: string | null
+  slug?: string | null
+  artPrompt?: string | null
+  designer?: string | null
+  isPublic?: boolean | null
+  isMature?: boolean | null
+  imagePath?: string | null
+  avatarImage?: string | null
+  iconPath?: string | null
+  cardPath?: string | null
+  heroPath?: string | null
   ArtImage?: DailyDreamArchiveArt | null
   ArtImages?: DailyDreamArchiveArt[]
 }
@@ -251,6 +263,36 @@ export const useDailyDreamArchiveStore = defineStore(
         const found = collections[objectType]?.find((item) => item.id === objectId)
         if (found) Object.assign(found, update)
       }
+    }
+
+    function findObject(
+      objectType: DailyDreamArchiveObjectType,
+      objectId: number,
+    ): DailyDreamArchiveObject | null {
+      for (const dream of dreams.value) {
+        if (objectType === 'dream' && dream.id === objectId) {
+          return dream as unknown as DailyDreamArchiveObject
+        }
+        if (objectType === 'dream') {
+          const related = [
+            ...dream.RelationsFrom.map((relation) => relation.ToDream),
+            ...dream.RelationsTo.map((relation) => relation.FromDream),
+          ].find((item) => item.id === objectId)
+          if (related) return related as unknown as DailyDreamArchiveObject
+        }
+
+        const collections: Partial<
+          Record<DailyDreamArchiveObjectType, DailyDreamArchiveObject[]>
+        > = {
+          character: dream.Characters as unknown as DailyDreamArchiveObject[],
+          reward: dream.Rewards as unknown as DailyDreamArchiveObject[],
+          scenario: dream.Scenarios as unknown as DailyDreamArchiveObject[],
+          bot: dream.Bots as unknown as DailyDreamArchiveObject[],
+        }
+        const found = collections[objectType]?.find((item) => item.id === objectId)
+        if (found) return found
+      }
+      return null
     }
 
     async function fetchArchive(force = false): Promise<boolean> {
@@ -469,7 +511,11 @@ export const useDailyDreamArchiveStore = defineStore(
       }
 
       const result = await updateObject('dream', input.entity.id, patch)
-      if (result.success) await fetchArchive(true)
+      if (result.success) {
+        await fetchArchive(true)
+        const refreshed = findObject('dream', input.entity.id)
+        if (refreshed) Object.assign(input.entity, refreshed)
+      }
       return result
     }
 
@@ -479,6 +525,7 @@ export const useDailyDreamArchiveStore = defineStore(
       loaded,
       lastError,
       fetchArchive,
+      findObject,
       updateObject,
       queueObjectArt,
       fetchArtJob,

--- a/stores/dailyDreamArchiveStore.ts
+++ b/stores/dailyDreamArchiveStore.ts
@@ -79,6 +79,136 @@ export type DailyDreamArchiveEntry = Dream & {
   >
 }
 
+export type DailyDreamArchiveObjectType =
+  | 'dream'
+  | 'character'
+  | 'reward'
+  | 'scenario'
+  | 'bot'
+
+export type DailyDreamArchiveObject = Record<string, unknown> & {
+  id: number
+  userId?: number | null
+  artImageId?: number | null
+  ArtImage?: DailyDreamArchiveArt | null
+  ArtImages?: DailyDreamArchiveArt[]
+}
+
+export type DailyDreamArtSlot = {
+  field: string
+  label: string
+  width: number
+  height: number
+  aspect: string
+}
+
+export type DailyDreamArtQueueInput = {
+  objectType: DailyDreamArchiveObjectType
+  entity: DailyDreamArchiveObject
+  slot: DailyDreamArtSlot
+  prompt: string
+  mode: 'recreate' | 'img2img'
+  engine: string
+  preserveOriginal: boolean
+  denoise?: number
+  originalWeight?: number
+  steps?: number
+}
+
+type ArtQueueResult = {
+  jobId: number
+  status: string
+}
+
+type ArtQueueJob = {
+  id: number
+  status: string
+  artImageId?: number | null
+  error?: string | null
+}
+
+type MutationResult = {
+  success: boolean
+  message: string
+  data: DailyDreamArchiveObject | null
+}
+
+const endpointByType: Record<DailyDreamArchiveObjectType, string> = {
+  dream: 'dreams',
+  character: 'characters',
+  reward: 'rewards',
+  scenario: 'scenarios',
+  bot: 'bots',
+}
+
+function asObject(value: unknown): DailyDreamArchiveObject | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const id = Number((value as { id?: unknown }).id)
+  if (!Number.isInteger(id) || id <= 0) return null
+  return value as DailyDreamArchiveObject
+}
+
+function artImageIdFromPath(value: unknown): number | null {
+  if (typeof value !== 'string') return null
+  const id = Number(value.match(/\/api\/art\/images\/(\d+)\/file/)?.[1])
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+function normalizeImageSource(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.toLowerCase() === 'undefined') return ''
+  if (/^(https?:|data:image\/|\/)/.test(trimmed)) return trimmed
+  if (trimmed.startsWith('images/')) return `/${trimmed}`
+  return `/images/${trimmed}`
+}
+
+async function imageSourceToDataUri(source: string): Promise<string> {
+  if (source.startsWith('data:image/')) return source
+
+  const response = await fetch(source)
+  if (!response.ok) {
+    throw new Error(`Current image could not be loaded (${response.status}).`)
+  }
+
+  const blob = await response.blob()
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(new Error('Current image could not be read.'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+function dreamArtPrompt(
+  entity: DailyDreamArchiveObject,
+  slot: DailyDreamArtSlot,
+  prompt: string,
+): string {
+  const context = [
+    ['Title', entity.title],
+    ['Dream type', entity.dreamType],
+    ['Description', entity.description],
+    ['Pitch', entity.pitch],
+    ['Flavor text', entity.flavorText],
+    ['Examples', entity.examples],
+    ['Existing art prompt', entity.artPrompt],
+  ].flatMap(([label, value]) => {
+    const text = typeof value === 'string' ? value.trim() : ''
+    return text ? [`${label}: ${text}`] : []
+  })
+
+  return [
+    prompt.trim(),
+    '',
+    `Create this as the ${slot.label.toLowerCase()} artwork for the following dream.`,
+    ...context,
+    '',
+    'Treat the first paragraph as the primary art direction. Use the dream context for identity and continuity, not as text to render.',
+    'Do not add captions, labels, UI chrome, watermarks, signatures, or readable text unless the primary art direction explicitly requests them.',
+  ].join('\n')
+}
+
 export const useDailyDreamArchiveStore = defineStore(
   'daily-dream-archive',
   () => {
@@ -86,6 +216,42 @@ export const useDailyDreamArchiveStore = defineStore(
     const loading = ref(false)
     const loaded = ref(false)
     const lastError = ref('')
+
+    function mergeObject(
+      objectType: DailyDreamArchiveObjectType,
+      objectId: number,
+      update: DailyDreamArchiveObject,
+    ): void {
+      for (const dream of dreams.value) {
+        if (objectType === 'dream' && dream.id === objectId) {
+          Object.assign(dream, update)
+        }
+
+        if (objectType === 'dream') {
+          for (const relation of dream.RelationsFrom) {
+            if (relation.ToDream.id === objectId) {
+              Object.assign(relation.ToDream, update)
+            }
+          }
+          for (const relation of dream.RelationsTo) {
+            if (relation.FromDream.id === objectId) {
+              Object.assign(relation.FromDream, update)
+            }
+          }
+        }
+
+        const collections: Partial<
+          Record<DailyDreamArchiveObjectType, DailyDreamArchiveObject[]>
+        > = {
+          character: dream.Characters as unknown as DailyDreamArchiveObject[],
+          reward: dream.Rewards as unknown as DailyDreamArchiveObject[],
+          scenario: dream.Scenarios as unknown as DailyDreamArchiveObject[],
+          bot: dream.Bots as unknown as DailyDreamArchiveObject[],
+        }
+        const found = collections[objectType]?.find((item) => item.id === objectId)
+        if (found) Object.assign(found, update)
+      }
+    }
 
     async function fetchArchive(force = false): Promise<boolean> {
       if (loading.value) return false
@@ -97,22 +263,214 @@ export const useDailyDreamArchiveStore = defineStore(
       try {
         const response = await performFetch<DailyDreamArchiveEntry[]>(
           '/api/dreams/daily-archive',
-          {},
+          force ? { cache: 'no-store' } : {},
           2,
           30_000,
         )
 
         if (!response.success || !Array.isArray(response.data)) {
-          lastError.value = response.message || 'Daily Dream archive could not be loaded.'
+          lastError.value =
+            response.message || 'Daily Dream archive could not be loaded.'
           return false
         }
 
         dreams.value = response.data
         loaded.value = true
         return true
+      } catch (error) {
+        lastError.value =
+          error instanceof Error
+            ? error.message
+            : 'Daily Dream archive could not be loaded.'
+        return false
       } finally {
         loading.value = false
       }
+    }
+
+    async function updateObject(
+      objectType: DailyDreamArchiveObjectType,
+      objectId: number,
+      patch: Record<string, unknown>,
+    ): Promise<MutationResult> {
+      try {
+        const response = await performFetch<DailyDreamArchiveObject>(
+          `/api/${endpointByType[objectType]}/${objectId}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(patch),
+          },
+          1,
+          30_000,
+        )
+        const data = asObject(response.data)
+
+        if (!response.success || !data) {
+          return {
+            success: false,
+            message: response.message || 'The object could not be updated.',
+            data: null,
+          }
+        }
+
+        mergeObject(objectType, objectId, data)
+        return {
+          success: true,
+          message: response.message || 'Object updated.',
+          data,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          message:
+            error instanceof Error
+              ? error.message
+              : 'The object could not be updated.',
+          data: null,
+        }
+      }
+    }
+
+    async function queueObjectArt(
+      input: DailyDreamArtQueueInput,
+    ): Promise<{ success: boolean; message: string; jobId: number | null }> {
+      try {
+        const directSource = normalizeImageSource(input.entity[input.slot.field])
+        const nestedSource = normalizeImageSource(
+          input.entity.ArtImage?.imagePath || input.entity.ArtImage?.path,
+        )
+        const primarySource = input.entity.artImageId
+          ? `/api/art/images/${input.entity.artImageId}/file`
+          : input.entity.ArtImage?.id
+            ? `/api/art/images/${input.entity.ArtImage.id}/file`
+            : ''
+        const source = directSource || nestedSource || primarySource
+        const sourceImageBase64 =
+          input.objectType === 'dream' && input.mode === 'img2img'
+            ? await imageSourceToDataUri(source)
+            : undefined
+
+        const response = await performFetch<ArtQueueResult>(
+          '/api/art/enqueue',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              engine: input.engine,
+              promptString:
+                input.objectType === 'dream'
+                  ? dreamArtPrompt(input.entity, input.slot, input.prompt)
+                  : input.prompt.trim(),
+              width: input.slot.width,
+              height: input.slot.height,
+              isPublic: input.entity.isPublic ?? true,
+              isMature: input.entity.isMature ?? false,
+              designer: input.entity.designer || null,
+              ...(input.steps ? { steps: input.steps } : {}),
+              ...(input.denoise != null ? { denoise: input.denoise } : {}),
+              ...(input.originalWeight != null
+                ? { originalWeight: input.originalWeight }
+                : {}),
+              ...(sourceImageBase64 ? { sourceImageBase64 } : {}),
+              ...(input.objectType === 'dream'
+                ? {}
+                : {
+                    entityArt: {
+                      entityType: input.objectType,
+                      entityId: input.entity.id,
+                      field: input.slot.field,
+                      preserveOriginal: input.preserveOriginal,
+                      mode: input.mode,
+                    },
+                  }),
+            }),
+          },
+          1,
+          30_000,
+        )
+        const jobId = Number(response.data?.jobId)
+
+        if (!response.success || !Number.isInteger(jobId) || jobId <= 0) {
+          return {
+            success: false,
+            message: response.message || 'Art generation could not be queued.',
+            jobId: null,
+          }
+        }
+
+        return {
+          success: true,
+          message: `Queued as ArtJob ${jobId}.`,
+          jobId,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Art generation could not be queued.',
+          jobId: null,
+        }
+      }
+    }
+
+    async function fetchArtJob(
+      jobId: number,
+    ): Promise<{ success: boolean; message: string; job: ArtQueueJob | null }> {
+      try {
+        const response = await performFetch<{ job: ArtQueueJob }>(
+          `/api/art/queue/${jobId}`,
+          { cache: 'no-store' },
+        )
+        return {
+          success: response.success,
+          message: response.message || '',
+          job: response.data?.job || null,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          message: error instanceof Error ? error.message : 'Queue check failed.',
+          job: null,
+        }
+      }
+    }
+
+    async function applyDreamArt(input: {
+      entity: DailyDreamArchiveObject
+      slot: DailyDreamArtSlot
+      artImageId: number
+      prompt: string
+      preserveOriginal: boolean
+    }): Promise<MutationResult> {
+      const currentIds = new Set<number>()
+      for (const image of input.entity.ArtImages || []) {
+        if (Number.isInteger(image.id) && image.id > 0) currentIds.add(image.id)
+      }
+      if (input.entity.ArtImage?.id) currentIds.add(input.entity.ArtImage.id)
+      if (input.entity.artImageId) currentIds.add(input.entity.artImageId)
+      const previousSlotId = artImageIdFromPath(input.entity[input.slot.field])
+      if (previousSlotId) currentIds.add(previousSlotId)
+      currentIds.add(input.artImageId)
+
+      const imagePath = `/api/art/images/${input.artImageId}/file?v=${Date.now()}`
+      const patch: Record<string, unknown> = {
+        [input.slot.field]: imagePath,
+        artPrompt: input.prompt.trim(),
+      }
+
+      if (input.slot.field === 'imagePath') {
+        patch.artImageId = input.artImageId
+      }
+      if (input.preserveOriginal) {
+        patch.artImageIds = Array.from(currentIds)
+      }
+
+      const result = await updateObject('dream', input.entity.id, patch)
+      if (result.success) await fetchArchive(true)
+      return result
     }
 
     return {
@@ -121,6 +479,10 @@ export const useDailyDreamArchiveStore = defineStore(
       loaded,
       lastError,
       fetchArchive,
+      updateObject,
+      queueObjectArt,
+      fetchArtJob,
+      applyDreamArt,
     }
   },
 )

--- a/utils/scripts/verifyDailyDreamArchiveWorkbench.ts
+++ b/utils/scripts/verifyDailyDreamArchiveWorkbench.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8')
+}
+
+function expectContains(path: string, needles: string[]): void {
+  const source = read(path)
+  for (const needle of needles) {
+    if (!source.includes(needle)) {
+      throw new Error(`${path} is missing Daily Dream archive contract: ${needle}`)
+    }
+  }
+}
+
+expectContains('components/dreams/daily-digest-object-gallery.vue', [
+  '<daily-digest-object-dialog',
+  'Open details',
+  "makeItem('dream', 'World'",
+  "makeItem('character', 'Cast'",
+  "makeItem('reward', 'Discovery'",
+  "makeItem('scenario', 'Scenario'",
+])
+
+expectContains('components/dreams/daily-digest-object-dialog.vue', [
+  "type TabKey = 'overview' | 'edit' | 'art'",
+  '<daily-dream-object-art-workbench',
+  'archiveStore.updateObject(',
+  'Save changes',
+  'Art prompt',
+])
+
+expectContains('components/dreams/daily-dream-object-art-workbench.vue', [
+  'Redo from prompt',
+  'Modify current image',
+  '<option value="kontext">Kontext edit</option>',
+  'Keep the current version as inspiration',
+  'archiveStore.queueObjectArt({',
+  'archiveStore.fetchArtJob(jobId)',
+  'archiveStore.applyDreamArt({',
+])
+
+expectContains('stores/dailyDreamArchiveStore.ts', [
+  "'/api/art/enqueue'",
+  '`/api/art/queue/${jobId}`',
+  'entityArt:',
+  'async function updateObject(',
+  'async function queueObjectArt(',
+  'async function applyDreamArt(',
+  "await updateObject('dream'",
+])
+
+expectContains('server/api/dreams/daily-archive.get.ts', [
+  'Characters:',
+  'Rewards:',
+  'Scenarios:',
+  'Bots:',
+  'RelationsFrom:',
+  'RelationsTo:',
+])
+
+console.log('Daily Dream archive workbench contract verified.')


### PR DESCRIPTION
## What changed

- Replaced the oversized shared entity-card grid in the Daily Dream archive with compact object tiles for the world, related place, cast, discoveries, scenario, and narrator.
- Added a focused object popup with Details, Modify, and Artwork tabs.
- Added whitelisted record editing through the existing Dream, Character, Reward, Scenario, and Bot patch routes.
- Added an artwork workbench modeled on project icon/card/hero controls:
  - primary, icon, card, and hero slot selection where supported
  - prompt-led recreation with Krea 2 or SDXL
  - current-image modification with SDXL img2img or Kontext
  - gentle, balanced, and strong modification presets
  - preserve-current-image history control
  - durable ArtJob polling and automatic attachment
- Added a Dream-specific completion bridge because the generic entity-art completion contract currently covers Bot, Character, Scenario, Reward, Facet, Project, and Achievement but not Dream.
- Added a source contract and expanded the Entity Art Manager workflow to cover this archive workbench.

## Why

The shared gallery cards were designed for standalone galleries, not a six-object Daily Dream bundle. They consumed too much space, formatted inconsistently inside the slideshow, and provided no direct route to revise a generated object or its artwork.

## Validation

- TypeScript syntax pass over all new and changed scripts.
- Local strict type harness for the store and component scripts.
- New `verifyDailyDreamArchiveWorkbench.ts` contract included in CI.
- Exact diff reviewed against the current Daily Dream archive and entity-art queue contracts.

Conductor: `dream-cycle/t-006`
Session: `2026-08-04T041520Z-dream-cycle-t-006-bespoke-b7c9`