### PR TITLE
scenario-gallery: fix Cast grid rendering the wrong character

### DIFF
--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -176,10 +176,15 @@
           </div>
 
           <div class="character-card-grid">
-            <CharacterFlipCard
-              v-for="character in selectedScenarioCharacters"
+            <character-card
+              v-for="character in castCharacters"
               :key="character.id"
               :character="character"
+              :compact="true"
+              :show-image="showImages"
+              :show-actions="false"
+              :show-reaction="false"
+              :show-meta="showMeta"
             />
           </div>
         </section>
@@ -253,7 +258,7 @@
               </h3>
 
               <p class="truncate text-sm text-base-content/60">
-                Tap a card to flip between portrait and character data.
+                Character cards connected to this scenario.
               </p>
             </div>
 
@@ -263,10 +268,15 @@
           </div>
 
           <div class="character-card-grid">
-            <CharacterFlipCard
-              v-for="character in selectedScenarioCharacters"
+            <character-card
+              v-for="character in castCharacters"
               :key="character.id"
               :character="character"
+              :compact="true"
+              :show-image="showImages"
+              :show-actions="false"
+              :show-reaction="false"
+              :show-meta="showMeta"
             />
           </div>
         </section>
@@ -277,6 +287,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import type { Character } from '~/prisma/generated/prisma/client'
 import type { ScenarioWithRelations } from '@/stores/scenarioStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useUserStore } from '@/stores/userStore'
@@ -416,6 +427,18 @@ const filteredScenarios = computed<ScenarioWithRelations[]>(() => {
 const selectedScenarioCharacters = computed(() => {
   return scenarioStore.selectedScenario?.Characters ?? []
 })
+
+/*
+ * scenarioStore's Characters relation is a curated Pick<Character, ...> of safe
+ * display fields (see ScenarioCharacter in stores/scenarioStore.ts) -- it omits
+ * userId and allowReviews, which character-card.vue's full Character prop type
+ * technically requires. Both cast-grid renders below pass show-actions="false"
+ * and show-reaction="false", so neither omitted field is ever read; the cast is
+ * safe under that configuration.
+ */
+const castCharacters = computed(
+  () => selectedScenarioCharacters.value as unknown as Character[],
+)
 
 const selectedScenarioTitle = computed(() => {
   return scenarioStore.selectedScenario?.title || 'Selected Scenario'


### PR DESCRIPTION
### Task
conductor interface-vision/t-076: CharacterFlipCard silently ignores its `character` prop, rendering the wrong character in scenario-gallery.vue cast grids.

### What changed / what I produced
`components/characters/character-flip-card.vue` has zero `defineProps` in its `<script setup>` — it never reads a `character` prop at all, and always renders `characterStore.selectedCharacter`'s full "Character Interact" dashboard (900+ lines: chat/adventure/prompt/debug tabs) internally. Both cast-grid `v-for` loops in `components/scenarios/scenario-gallery.vue` (previously ~179 and ~266) passed `:character="character"` expecting a distinct per-character summary card and silently got an identical copy of the same globally-selected character's dashboard in every grid cell instead.

- Swapped both call sites from `<CharacterFlipCard>` to `<character-card>`, which already declares and correctly reads a real `character` prop (`components/characters/character-card.vue`), has no side-effecting global store initialization, and is already proven in grid usage at `character-gallery.vue:240`.
- Configured `:compact="true" :show-actions="false" :show-reaction="false"` to match the summary-card intent of a small cast listing (180px grid tiles), rather than pulling in edit/clone/delete controls or reaction UI that weren't there before either.
- Updated the stale "Tap a card to flip between portrait and character data." copy (no longer accurate) to match the other, now-identical section's copy.
- `scenarioStore`'s `Characters` relation is a curated `Pick<Character, ...>` of display-safe fields (see `ScenarioCharacter` in `stores/scenarioStore.ts`) that omits `userId`/`allowReviews` — both fields `character-card.vue`'s full `Character` prop type technically requires but neither is read once `show-actions`/`show-reaction` are off. Added a documented, scoped cast (`castCharacters` computed) rather than widening the shared prop type or the backend `select` clause, which would be real scope creep for this bug fix.

**Left alone on purpose:** `character-interact.vue:57` also renders `<CharacterFlipCard>` (a separate, independent bug — nesting one full dashboard inside a small sidebar "cockpit" panel of another). That file is currently claimed by a concurrent session for interface-vision/t-051's kr-chat-window migration, so touching it here risked a collision. `character-flip-card.vue` itself is untouched and still has that one real call site.

### How I verified
- `npx vue-tsc --noEmit -p tsconfig.json` — clean (this surfaced and required fixing a genuine type mismatch between the curated `Pick<Character,...>` relation and `character-card`'s full `Character` prop, invisible before because `CharacterFlipCard` had no prop typing at all).
- `npx eslint components/scenarios/scenario-gallery.vue` — clean.
- `npx tsx utils/scripts/verifyGalleryAdoption.ts` — passed ("Gallery adoption contract passed").
- `npx tsx utils/scripts/verifyNarrativeKit.ts` — passed.
- `npx tsx utils/scripts/verifyLayoutContract.ts` — passed, no new violations.
- No local dev server / DB in this sandbox (documented kind_robots sandbox limitation) — visual confirmation on the Vercel preview for this branch is still worth a look before merge, though the change is a straightforward component swap with the same grid CSS class and no template restructuring.

### Stakes
reversible

### Flags for Reviewer
- The `castCharacters` type assertion is a deliberate, narrow scope call — see the inline comment at its definition in `scenario-gallery.vue`. If a future task wants `character-card.vue` to formally accept a narrower `Pick`, that's a separate, larger change touching a shared component.
- `character-flip-card.vue` is now down to a single remaining call site (`character-interact.vue:57`) — noted in the conductor roadmap task for whoever picks up t-051 next.

### Kaizen suggestion
`character-flip-card.vue` having zero `defineProps` while still accepting `:character="..."` at three call sites for presumably a long time is exactly the kind of bug a lint rule (`vue/require-explicit-props` or a stricter unused-attribute check) would catch immediately. Worth checking whether the current eslint config could flag "prop passed to a component but never declared" repo-wide.

### Notes for reviewer
Companion conductor PR (interface-vision/t-076 roadmap close-out) will follow once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_011ZKMxtUz6qFF6WjHNVacSq)_