### PR TITLE
Header: unclip the channel menu, and make tabs read as buttons

### DIFF
--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -7,7 +7,7 @@
       class="flex h-full min-h-10 shrink-0 items-center gap-2 overflow-hidden px-2 transition-all xl:gap-2.5 xl:px-3"
       :class="
         seamless
-          ? 'hover:bg-base-200'
+          ? 'rounded-l-xl hover:bg-base-200'
           : 'h-10 rounded-xl border border-base-300 bg-base-100 shadow-sm hover:-translate-y-0.5 hover:shadow-md sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14'
       "
       :title="`Navigate ${activeChannel.label}`"

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -26,25 +26,33 @@
            channel selector doesn't drop awkwardly below the current tab
            title." Nothing is lost by dropping the old title: the active tab's
            own label WAS the title, and it is now something you can act on. -->
+      <!-- NO `overflow-hidden` on this shell, however much it wants it for the
+           seamless rounded join. channel-select's daisyUI dropdown menu is
+           absolutely positioned INSIDE here and is ~318px tall; this shell is
+           40px. Clipping it removed the channel list entirely — painted away
+           and un-hittable, so elementFromPoint at a menu row returned the page
+           <h1> behind it. Silas, 2026-08-04: "I can't actually select the
+           channel option anymore." The children round their own outer corners
+           instead. -->
       <div
-        class="flex h-10 min-h-10 min-w-0 flex-1 items-stretch overflow-hidden rounded-xl border border-base-300 bg-base-100 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14"
+        class="flex h-10 min-h-10 min-w-0 flex-1 items-stretch rounded-xl border border-base-300 bg-base-100 shadow-sm sm:h-11 sm:min-h-11 xl:h-14 xl:min-h-14"
       >
         <channel-select seamless class="shrink-0" />
 
         <nav
           v-if="resolvedTabs.length"
-          class="tab-strip flex min-w-0 flex-1 items-stretch gap-0.5 overflow-x-auto border-l border-base-300 px-1"
+          class="tab-strip flex min-w-0 flex-1 items-stretch gap-1 overflow-x-auto rounded-r-xl border-l border-base-300 px-1.5 sm:gap-1.5"
           aria-label="Channel tabs"
         >
           <button
             v-for="tab in resolvedTabs"
             :key="tab.tabKey"
             type="button"
-            class="relative my-1 flex shrink-0 items-center gap-1.5 rounded-lg px-2 text-xs font-black transition xl:text-sm"
+            class="relative my-1 flex shrink-0 items-center gap-1.5 rounded-lg border px-2 text-xs font-black transition xl:text-sm"
             :class="
               tab.tabKey === activeTabKey
-                ? 'bg-primary text-primary-content shadow-sm'
-                : 'text-base-content/60 hover:bg-base-200 hover:text-base-content'
+                ? 'border-primary bg-primary text-primary-content shadow-sm'
+                : 'border-base-300 bg-base-100 text-base-content/70 hover:border-base-content/30 hover:bg-base-200 hover:text-base-content'
             "
             :aria-current="tab.tabKey === activeTabKey ? 'page' : undefined"
             :title="tab.tooltip || tab.title || tab.label"


### PR DESCRIPTION
Two reports from Silas:

> I can't actually select the channel option anymore. Love love love the new tab
> selections, but if there is room, they should look like buttons, not just a
> string of strings with no divisions unless you hover

## 1. The channel menu was clipped to nothing — my regression

To make the channel picker and tab strip read as one control, I wrapped them in
a shared bordered div with `overflow-hidden`. channel-select's daisyUI dropdown
is absolutely positioned **inside** that shell and is ~318px tall. The shell is
**40px**. Everything below the first row was clipped away — not just invisible,
but un-hittable.

Measured on the running app before the fix:

```
menuFound:          true
menuVisible:        "visible"
menuRect:           352 x 318      <- laid out fine
firstItemRect:      262 x 48       <- real box
firstItemClickable: false          <- but nothing lands on it
firstItemHit:       h1.text-lg...  <- the page heading, behind the menu
clippingAncestors:  div.flex.h-10.min-h-10 overflow=hidden/hidden/hidden
```

The shell keeps its rounded border; the children round their own outer corners
instead (`rounded-l-xl` on channel-select when `seamless`, `rounded-r-xl` on the
tab strip).

**Verified end to end, not just by hit-test** — "the element is hittable" is not
"selecting a channel works":

- opening the picker and clicking "Plan / Projects" navigates to `/conductor`
- the channel button reads "Plan" afterwards, on both a direct load and an
  in-app navigation

## 2. Tabs read as run-on text

Inactive tabs had no resting affordance at all — no border, no background, only
`hover:bg-base-200`. So they looked like a string of words, and only looked
clickable once a pointer was on them, which on touch is never.

| | before | after |
|---|---|---|
| inactive | no border, transparent | 1px `base-300` on `base-100` |
| active | `bg-primary` | `border-primary bg-primary` |
| gap | `0.5` (2px) | `1` (4px), `1.5` at `sm` |

Costs 1px per tab. The responsive audit reports **0 SPILL / 0 CRUSHED / no
horizontal scroll** at 390, 820 and 1440 across `/`, `/conductor`, `/dreams`.

## Verification

- `npm run test` (vue-tsc) — clean
- `npm run test:layout-contract` — holds, no new violations
- `npm run test:channel-content` — 6 channels, 63 tabs, 0 nav manifest errors
- `npm run audit:responsive` — 0 real layout defects (remaining hits are the
  documented local-only BROKEN-ART noise from `public/images` not being in the repo)
- `npx eslint` + `prettier --check` on touched files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_