### PR TITLE
refactor(rewards): reward-interact.vue onto the shared conversation kit

### DIFF
--- a/components/rewards/reward-interact.vue
+++ b/components/rewards/reward-interact.vue
@@ -163,143 +163,58 @@
           </div>
         </div>
 
-        <div ref="storyLogRef" class="min-h-0 overflow-y-auto bg-base-200 p-4">
-          <div
-            v-if="sessionChats.length === 0"
-            class="flex h-full min-h-72 flex-col items-center justify-center gap-3 text-center text-base-content/45"
-          >
-            <Icon name="kind-icon:magic" class="h-16 w-16 text-primary/60" />
-
-            <div>
-              <p class="text-lg font-bold">Start the encounter</p>
-              <p class="mt-1 text-sm">
-                Tune the premise on the right, then unleash the narrative
-                gremlin.
-              </p>
-            </div>
-          </div>
-
-          <div v-else class="flex flex-col gap-4">
-            <article
-              v-for="(chat, index) in sessionChats"
-              :key="chat.id"
-              class="flex flex-col gap-3"
-            >
-              <div class="flex flex-row-reverse gap-3">
-                <div
-                  class="max-w-[85%] rounded-2xl rounded-br-sm bg-primary px-4 py-3 text-sm leading-relaxed text-primary-content shadow-sm"
-                >
-                  <p class="whitespace-pre-wrap">
-                    {{ getPlayerDisplayText(chat, index) }}
-                  </p>
-                </div>
-              </div>
-
-              <div class="flex flex-row gap-3">
-                <div
-                  class="flex h-9 w-9 shrink-0 items-center justify-center self-end rounded-full border border-base-300 bg-base-100"
-                >
-                  <Icon
-                    name="kind-icon:reward"
-                    class="h-5 w-5 text-secondary"
-                  />
-                </div>
-
-                <div
-                  class="flex max-w-[90%] flex-col gap-3 rounded-2xl rounded-bl-sm bg-base-100 px-4 py-3 text-sm leading-relaxed shadow-sm"
-                >
+        <!-- The reward story log is kr-chat-window (interface-vision Phase 5,
+             the second of the two remaining surfaces from t-051 --
+             character-interact.vue's PR #1400 is the reference shape). This
+             also removes the bespoke .story-dot keyframes below in favor of
+             kr-chat-window's own built-in streaming placeholder. -->
+        <kr-chat-window
+          class="bg-base-200 p-4"
+          :turns="chatTurns"
+          :label="`${selectedRewardName} story`"
+          :is-streaming="isStarting"
+          :streaming-text="streamingBotText"
+          streaming-label="The narrative gremlin is writing..."
+          empty-label="Start the encounter, then unleash the narrative gremlin."
+          :prose="false"
+          @choose="handleChoiceSelected"
+        >
+          <template v-if="canShowCustomFollowup" #footer>
+            <div class="rounded-2xl border border-base-300 bg-base-100 p-3">
+              <label class="form-control">
+                <span class="label py-1">
                   <span
-                    v-if="!chat.botResponse"
-                    class="flex items-center gap-1 py-1 text-base-content/60"
+                    class="label-text text-xs font-bold uppercase tracking-wide text-base-content/50"
                   >
-                    <span class="story-dot" />
-                    <span class="story-dot delay-150" />
-                    <span class="story-dot delay-300" />
+                    Customize the next move
                   </span>
+                </span>
 
-                  <template v-else>
-                    <p class="whitespace-pre-wrap text-base-content/80">
-                      {{ getStoryScene(chat.botResponse) }}
-                    </p>
+                <textarea
+                  v-model="customFollowup"
+                  class="textarea textarea-bordered min-h-20 rounded-2xl bg-base-200"
+                  placeholder="Take one of the paths, remix it, or do something wildly inadvisable..."
+                  :disabled="isStarting"
+                  @keydown.enter.exact.prevent="continueWithCustomPath"
+                />
+              </label>
 
-                    <div
-                      v-if="getStoryChoices(chat.botResponse).length"
-                      class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200 p-3"
-                    >
-                      <p
-                        class="text-xs font-bold uppercase tracking-wide text-base-content/50"
-                      >
-                        Select a path
-                      </p>
-
-                      <button
-                        v-for="choice in getStoryChoices(chat.botResponse)"
-                        :key="choice.key"
-                        class="btn btn-sm h-auto min-h-10 justify-start rounded-2xl py-2 text-left normal-case"
-                        :class="
-                          selectedPath === choice.text
-                            ? 'btn-secondary'
-                            : 'btn-outline'
-                        "
-                        type="button"
-                        :disabled="
-                          isStarting || !isLatestRespondedChat(chat.id)
-                        "
-                        @click="continueWithPath(choice.text)"
-                      >
-                        <span class="badge badge-ghost badge-sm">
-                          {{ choice.label }}
-                        </span>
-                        <span
-                          class="min-w-0 flex-1 whitespace-normal text-left"
-                        >
-                          {{ choice.text }}
-                        </span>
-                      </button>
-                    </div>
-
-                    <div
-                      v-if="isLatestRespondedChat(chat.id)"
-                      class="rounded-2xl border border-base-300 bg-base-200 p-3"
-                    >
-                      <label class="form-control">
-                        <span class="label py-1">
-                          <span
-                            class="label-text text-xs font-bold uppercase tracking-wide text-base-content/50"
-                          >
-                            Customize the next move
-                          </span>
-                        </span>
-
-                        <textarea
-                          v-model="customFollowup"
-                          class="textarea textarea-bordered min-h-20 rounded-2xl bg-base-100"
-                          placeholder="Take one of the paths, remix it, or do something wildly inadvisable..."
-                          :disabled="isStarting"
-                          @keydown.enter.exact.prevent="continueWithCustomPath"
-                        />
-                      </label>
-
-                      <button
-                        class="btn btn-accent mt-3 w-full rounded-2xl"
-                        type="button"
-                        :disabled="!canContinueCustom"
-                        @click="continueWithCustomPath"
-                      >
-                        <span
-                          v-if="isStarting"
-                          class="loading loading-spinner loading-sm"
-                        />
-                        <Icon v-else name="kind-icon:wand" class="h-5 w-5" />
-                        Continue Custom Path
-                      </button>
-                    </div>
-                  </template>
-                </div>
-              </div>
-            </article>
-          </div>
-        </div>
+              <button
+                class="btn btn-accent mt-3 w-full rounded-2xl"
+                type="button"
+                :disabled="!canContinueCustom"
+                @click="continueWithCustomPath"
+              >
+                <span
+                  v-if="isStarting"
+                  class="loading loading-spinner loading-sm"
+                />
+                <Icon v-else name="kind-icon:wand" class="h-5 w-5" />
+                Continue Custom Path
+              </button>
+            </div>
+          </template>
+        </kr-chat-window>
 
         <div class="shrink-0 border-t border-base-300 bg-base-100 p-3">
           <div
@@ -581,7 +496,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useChatStore } from '@/stores/chatStore'
 import { useRewardStore } from '@/stores/rewardStore'
@@ -589,6 +504,8 @@ import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
 import type { ArtImage } from '@/stores/artStore'
 import type { Chat, Reward } from '~/prisma/generated/prisma/client'
+import type { NarrativeTurn } from '@/components/narrative/kr-chat-window.vue'
+import type { NarrativeChoice } from '@/components/narrative/kr-choice-list.vue'
 
 type ChatRuntimeInput = Parameters<
   ReturnType<typeof useChatStore>['addChat']
@@ -628,14 +545,12 @@ const selectedCharacterSummary = computed(() => {
   return `${selectedCharacterTitle.value} · ${species} / ${characterClass}`
 })
 
-const storyLogRef = ref<HTMLElement | null>(null)
 const encounterMode = ref<
   'discover' | 'use' | 'temptation' | 'consequence' | 'custom'
 >('discover')
 const tone = ref('whimsical')
 const customDirection = ref('')
 const customFollowup = ref('')
-const selectedPath = ref('')
 const userBackground = ref(userStore.user?.bio ?? '')
 const showCharacterPanel = ref(false)
 const showPromptPreview = ref(false)
@@ -832,14 +747,6 @@ function setStatus(messageText: string, tone: 'success' | 'error' = 'success') {
   statusTone.value = tone
 }
 
-function scrollToBottom() {
-  const el = storyLogRef.value
-
-  if (!el) return
-
-  el.scrollTop = el.scrollHeight
-}
-
 function isLatestRespondedChat(chatId: number) {
   return Boolean(
     latestSessionChat.value?.id === chatId &&
@@ -905,6 +812,64 @@ function getPlayerDisplayText(chat: Chat, index: number) {
   }
 
   return chat.content
+}
+
+/* Each session Chat becomes a user turn plus (once it has a response) a
+   narrator turn. The in-flight chat is deliberately withheld from `turns`
+   while it is still streaming -- its growing text surfaces through
+   kr-chat-window's own `streamingText` placeholder instead, matching the
+   built-in streaming contract rather than mutating a turn's text in place. */
+const chatTurns = computed<NarrativeTurn[]>(() => {
+  const chats = sessionChats.value
+  const turns: NarrativeTurn[] = []
+
+  chats.forEach((chat, index) => {
+    turns.push({
+      id: `user-${chat.id}`,
+      text: getPlayerDisplayText(chat, index),
+      from: 'user',
+    })
+
+    const inFlight = isStarting.value && latestSessionChat.value?.id === chat.id
+    if (!chat.botResponse || inFlight) return
+
+    const choices: NarrativeChoice[] = getStoryChoices(chat.botResponse).map(
+      (choice) => ({
+        key: choice.key,
+        label: choice.label,
+        hint: choice.text,
+        disabled: !isLatestRespondedChat(chat.id),
+      }),
+    )
+
+    turns.push({
+      id: `narrator-${chat.id}`,
+      text: getStoryScene(chat.botResponse),
+      from: 'narrator',
+      speaker: selectedRewardName.value,
+      choices: choices.length ? choices : undefined,
+    })
+  })
+
+  return turns
+})
+
+const streamingBotText = computed(() => {
+  if (!isStarting.value) return ''
+  const chat = latestSessionChat.value
+  return chat?.botResponse ? getStoryScene(chat.botResponse) : ''
+})
+
+// Same visibility rule the old inline textarea used: once the latest chat has
+// any response text, whether or not it has finished streaming.
+const canShowCustomFollowup = computed(() =>
+  Boolean(latestSessionChat.value?.botResponse),
+)
+
+function handleChoiceSelected(choice: NarrativeChoice) {
+  // getStoryChoices keys are `${1|2|3}-${text}`; recover the raw path text
+  // rather than repurposing the display label/hint, which are free to change.
+  continueWithPath(choice.key.replace(/^[1-3]-/, ''))
 }
 
 function buildMessagesForRewardResponse(): RewardStoryMessage[] {
@@ -1011,9 +976,6 @@ async function createRewardChat(content: string) {
   sessionChatIds.value.push(newChat.id)
   chatStore.selectedChat = newChat
 
-  await nextTick()
-  scrollToBottom()
-
   return newChat
 }
 
@@ -1030,9 +992,6 @@ async function streamRewardChat(chatId: number) {
     stream: true,
     messages: buildMessagesForRewardResponse(),
   })
-
-  await nextTick()
-  scrollToBottom()
 }
 
 async function startRewardStory() {
@@ -1045,7 +1004,6 @@ async function startRewardStory() {
 
   isStarting.value = true
   statusMessage.value = ''
-  selectedPath.value = ''
   customFollowup.value = ''
 
   try {
@@ -1066,7 +1024,6 @@ async function startRewardStory() {
 async function continueWithPath(path: string) {
   if (!path.trim() || isStarting.value) return
 
-  selectedPath.value = path
   customFollowup.value = path
 
   await continueRewardStory(path)
@@ -1076,8 +1033,6 @@ async function continueWithCustomPath() {
   const path = customFollowup.value.trim()
 
   if (!path || isStarting.value) return
-
-  selectedPath.value = path
 
   await continueRewardStory(path)
 }
@@ -1104,7 +1059,6 @@ async function continueRewardStory(path: string) {
 
 function newStory() {
   sessionChatIds.value = []
-  selectedPath.value = ''
   customFollowup.value = ''
   statusMessage.value = ''
 }
@@ -1119,7 +1073,6 @@ function clearPromptOptions() {
   tone.value = 'whimsical'
   customDirection.value = ''
   customFollowup.value = ''
-  selectedPath.value = ''
   userBackground.value = userStore.user?.bio ?? ''
   statusMessage.value = ''
 }
@@ -1139,45 +1092,4 @@ watch(
     heroImageIndex.value = 0
   },
 )
-
-watch(
-  () => sessionChats.value.map((chat) => chat.botResponse).join(''),
-  async () => {
-    await nextTick()
-    scrollToBottom()
-  },
-)
 </script>
-
-<style scoped>
-.story-dot {
-  display: inline-block;
-  height: 0.375rem;
-  width: 0.375rem;
-  border-radius: 9999px;
-  background: currentColor;
-  animation: story-bounce 1s ease-in-out infinite;
-}
-
-.delay-150 {
-  animation-delay: 150ms;
-}
-
-.delay-300 {
-  animation-delay: 300ms;
-}
-
-@keyframes story-bounce {
-  0%,
-  80%,
-  100% {
-    opacity: 0.4;
-    transform: scale(0.65);
-  }
-
-  40% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-</style>

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Layout-contract allow-list. RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLayoutContract.ts.",
-  "recorded": "2026-08-03",
+  "recorded": "2026-08-04",
   "violations": {
     "one-header": [],
     "one-scroll": [
@@ -11,7 +11,6 @@
       "components/dreams/dream-brainstorm.vue",
       "components/navigation/channel-select.vue",
       "components/pages/memory-dungeon.vue",
-      "components/rewards/reward-interact.vue",
       "components/scenarios/scenario-interact.vue",
       "components/servers/server-manager.vue",
       "components/stages/stage-manager.vue",


### PR DESCRIPTION
### Task
interface-vision/t-087: Phase 5, `reward-interact.vue` onto the shared conversation kit (kind: software)

Split from t-051 — the second of the two remaining surfaces from the original three-file scope (`character-interact.vue` already landed via PR #1400; `scenario-interact.vue` is the sibling task t-088). This is the largest of the three (1183 lines).

### What changed / what I produced
- The hand-rolled message-list (player bubble + bot bubble + inline "Select a path" choice buttons + inline custom-followup box, with its own scroll ref/`scrollToBottom()`) is now a single `<kr-chat-window>` driven by a `chatTurns` computed that maps each session `Chat` to a user turn and, once responded, a narrator turn carrying parsed choices.
- The in-flight chat's growing `botResponse` now surfaces through `kr-chat-window`'s built-in `streamingText`/`isStreaming` placeholder rather than a manually-toggled bubble — this also removes the bespoke `.story-dot` keyframes (`kr-chat-window` has its own `loading-dots` placeholder), which was the concrete duplication this task's note called out.
- The "Customize the next move" textarea + button move into `kr-chat-window`'s `#footer` slot — its documented extension point for conversation-level trailing content that must scroll with the transcript.
- `storyLogRef`/`scrollToBottom()` and all three call sites are gone; `kr-chat-window` owns its own auto-scroll (watches `turns.length`/`streamingText`).
- Dropped `selectedPath`, which only existed to drive a "highlight the last picked choice" class binding with no equivalent hook in the shared choice list — it became write-only dead state once the old template was removed.

### How I verified
- `vue-tsc --noEmit` — clean.
- `eslint components/rewards/reward-interact.vue` — clean.
- `npm run test:narrative-kit` — the conversation-kit adoption counter moves to 6/7 (`reward-interact.vue` now checked); all other assertions (single scroll region, footer slot, no duplicate transcript, etc.) pass.
- `npm run test:layout-contract` — the "components declaring more than one scroll region" count drops by 1 (confirms the duplicate scroll region is actually gone, not just relabeled); ratcheted the baseline down via `--update`.
- Did not have a working local `nuxt dev` (no DB in this sandbox) for interactive/Vercel-preview verification — noting per this project's own established caveat for this class of change (same as PR #1400's own note).

### Stakes
reversible

### Flags for Reviewer
- Two visual/UX simplifications from adopting the shared kit, both consistent with what PR #1400 already accepted for `character-interact.vue`: the empty-state loses its icon+heading+subtitle in favor of `kr-chat-window`'s single-line `emptyLabel`, and there's no more "highlighted last-picked choice" styling (no `selectedKey` pass-through from `kr-chat-window` down to its internal `kr-choice-list`). Neither seemed worth extending the shared component's API for in this task's scope.
- `kr-chat-window` hardcodes its embedded choice lists to `layout="row"` with `show-index="false"`, so I mapped `label` → the short Cautious/Bold/Weird category and `hint` → the full path text (rather than the reverse) to keep the inline pills reasonably compact. Worth a glance if it reads oddly in the actual UI.
- Not in scope per the task note, left alone: `conductor-project-chat.vue` (229 lines, flagged as "the purest duplicate in the repo"), `character-flip-card.vue`, and the human-to-human messenger/chat-gallery/stage-message/forum-thread tier.

### Kaizen suggestion
`kr-chat-window`/`kr-choice-list` have no way for a caller to pass a per-choice or per-turn `selectedKey`/highlight state through the embedded row-layout choice list. If a future narrative surface needs "show what was picked last" styling (this one used to have it), that's a small, well-scoped prop addition to `kr-chat-window` rather than another bespoke reimplementation.

### Notes for reviewer
Roadmap task `interface-vision/t-087` is at `status: review`, claimed by session `2026-08-04T055600Z-t087`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TaRK67TyfLGw6pjL1JkPP8)_