### PR TITLE
Share comment-aware source scanning for verifier contracts

### DIFF
--- a/utils/scripts/lib/sourceText.ts
+++ b/utils/scripts/lib/sourceText.ts
@@ -1,0 +1,10 @@
+export function stripComments(text: string): string {
+  return text
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, '$1')
+}
+
+export function containsCode(text: string, fragment: string): boolean {
+  return stripComments(text).includes(fragment)
+}

--- a/utils/scripts/verifyFacetClosure.ts
+++ b/utils/scripts/verifyFacetClosure.ts
@@ -2,6 +2,7 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { FACET_EMERGENCY_FALLBACKS } from '../facetEmergencyFallbacks'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -16,7 +17,7 @@ function requireText(path: string, text: string, fragment: string): void {
 }
 
 function forbidText(path: string, text: string, fragment: string): void {
-  if (text.includes(fragment)) {
+  if (containsCode(text, fragment)) {
     throw new Error(`${path} contains retired Facet closure text: ${fragment}`)
   }
 }

--- a/utils/scripts/verifyFacetGallery.ts
+++ b/utils/scripts/verifyFacetGallery.ts
@@ -6,6 +6,7 @@
 // entity-art flow rather than exposing a second request backend here.
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { containsCode } from './lib/sourceText'
 
 const root = process.cwd()
 
@@ -19,28 +20,8 @@ function requireText(path: string, text: string, fragment: string): void {
   }
 }
 
-/*
- * Comments are stripped before every forbid- scan.
- *
- * A contract that a doc comment can fail is a contract that punishes explaining
- * it. This file already did that once: a comment in facet-gallery.vue naming the
- * very helpers this contract forbids -- so a reader would know why the picker
- * emits a selection instead of mutating anything -- failed the build, while the
- * forbidden call itself was nowhere in the file. Same class of bug as the
- * `role="log"` comment that tripped verifyNarrativeAccessibility.mjs.
- *
- * Only forbid- scans strip. requireText keeps reading the raw source, so a
- * required token cannot be satisfied by a comment claiming it is there.
- */
-function stripComments(text: string): string {
-  return text
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, '$1')
-}
-
 function forbidText(path: string, text: string, fragment: string): void {
-  if (stripComments(text).includes(fragment)) {
+  if (containsCode(text, fragment)) {
     throw new Error(`${path} contains forbidden Facet gallery text: ${fragment}`)
   }
 }

--- a/utils/scripts/verifySourceTextComments.test.ts
+++ b/utils/scripts/verifySourceTextComments.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { containsCode, stripComments } from './lib/sourceText'
+
+const forbidden = 'updateFacet('
+
+const commented = [
+  `<!-- ${forbidden} is intentionally unavailable here -->`,
+  `/* ${forbidden} is intentionally unavailable here */`,
+  `// ${forbidden} is intentionally unavailable here`,
+].join('\n')
+
+assert.equal(containsCode(commented, forbidden), false)
+assert.equal(containsCode(`const result = ${forbidden}input)`, forbidden), true)
+assert.equal(stripComments(`const url = 'https://example.com/${forbidden}'`).includes(forbidden), true)
+
+process.stdout.write('Comment-aware source scanning verified.\n')


### PR DESCRIPTION
## Summary
- extract the existing comment stripper into `utils/scripts/lib/sourceText.ts`
- migrate the Facet Gallery and Facet Closure forbid scans to the shared helper
- add a focused self-test proving comments are ignored while executable occurrences remain detectable

## Conductor
- project: `interface-vision`
- task: `t-068`
- session: `2026-08-04T061213Z-interface-vision-t-068-k9v4`
- roadmap state was verified as `review` before opening this PR

## Scope
This is a bounded first migration slice. It establishes and tests the shared primitive without pretending the remaining verifier scripts have already been converted. After merge, the task returns to `ready` for the mechanical follow-through.

## Verification
CI must complete successfully before merge. Local execution was unavailable because the runtime could not resolve `github.com`, so no local command result is claimed.