### PR TITLE
fix(home): keep Daily Dream bundle compact responsively

### DIFF
--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -20,19 +20,21 @@
       </span>
     </header>
 
-    <div class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-6">
+    <div
+      class="mt-3 flex snap-x snap-mandatory gap-2 overflow-x-auto overscroll-x-contain pb-1 lg:grid lg:grid-cols-6 lg:overflow-visible lg:pb-0"
+    >
       <article
         v-for="item in items"
         :key="item.key"
-        class="group min-w-0 overflow-hidden rounded-xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:border-primary/35 hover:shadow-md"
+        class="group min-w-40 snap-start overflow-hidden rounded-xl border border-base-300 bg-base-100 shadow-sm transition hover:-translate-y-0.5 hover:border-primary/35 hover:shadow-md sm:min-w-44 lg:min-w-0"
       >
         <button
           type="button"
-          class="flex min-h-36 w-full flex-col text-left xl:min-h-32"
+          class="flex min-h-32 w-full flex-col text-left"
           :aria-label="`Open ${item.title}`"
           @click="selectedItem = item"
         >
-          <figure class="relative h-20 shrink-0 overflow-hidden bg-base-200 xl:h-16">
+          <figure class="relative h-16 shrink-0 overflow-hidden bg-base-200">
             <img
               v-if="item.image"
               :src="item.image"

--- a/utils/scripts/verifyDailyDreamArchiveWorkbench.ts
+++ b/utils/scripts/verifyDailyDreamArchiveWorkbench.ts
@@ -16,8 +16,11 @@ function expectContains(path: string, needles: string[]): void {
 expectContains('components/dreams/daily-digest-object-gallery.vue', [
   '<daily-digest-object-dialog',
   'Open details',
-  'xl:grid-cols-6',
-  'xl:min-h-32',
+  'overflow-x-auto',
+  'snap-mandatory',
+  'lg:grid-cols-6',
+  'lg:min-w-0',
+  'min-h-32',
   'item.meta.slice(0, 1)',
   "makeItem('dream', 'World'",
   "makeItem('character', 'Cast'",


### PR DESCRIPTION
## Summary
- keep the Daily Dream object bundle in a single row at every viewport width
- use a compact snap-scrolling strip on phones and tablets instead of a 2×3 or 3×2 stacked grid
- switch to six visible columns at the `lg` breakpoint, rather than waiting for `xl`
- retain the complete object details, editing, and artwork dialog
- update the archive contract check to guard the responsive behavior

## Context
The previous patch correctly slimmed the reporter's XL desktop view, but its fallback grid still consumed several rows on narrower screens. This follows the original intent across the whole responsive range.