### PR TITLE
fix(deploy): retry MariaDB connection-capacity spikes

### DIFF
--- a/scripts/db-connection-retry.mjs
+++ b/scripts/db-connection-retry.mjs
@@ -6,26 +6,29 @@
 // runs a short sequence of idempotent, existence-guarded statements against
 // ProxySQL during `npm run vercel-build`. ProxySQL can drop a backend/frontend
 // connection mid-sequence (observed as MariaDB SQLState 08S01 / errno 45009,
-// "socket has unexpectedly been closed"), which fails the whole production
-// deploy even though nothing is logically wrong. Because every repair step is
-// idempotent, reconnecting and re-running the repair is safe, so we retry the
-// repair on connection-level (not query-logic) errors.
+// "socket has unexpectedly been closed"), or temporarily refuse a new session
+// when the shared application user reaches max_user_connections. Both fail the
+// whole production deploy even though nothing is logically wrong. Because every
+// repair step is idempotent, reconnecting and re-running the repair is safe.
 
 /**
  * Classifies whether an error is a transient *connection* failure that is safe
- * to retry with a fresh connection. Deliberately narrow: only socket/connection
- * level failures qualify. Logical errors (parse errors, constraint violations,
- * permission errors, etc.) are never retried — retrying those just wastes a
- * deploy and hides a real bug.
+ * to retry with a fresh connection. Deliberately narrow: socket/connection
+ * failures and temporary connection-capacity exhaustion qualify. Logical errors
+ * (parse errors, constraint violations, permission errors, etc.) are never
+ * retried — retrying those just wastes a deploy and hides a real bug.
  */
 export function isRetryableConnectionError(error) {
   if (!error) return false
 
   const code = typeof error.code === 'string' ? error.code : ''
+  const errno = Number.isFinite(error.errno) ? Number(error.errno) : 0
   if (
     code === 'ER_SOCKET_UNEXPECTED_CLOSE' ||
     code === 'ER_CONNECTION_ALREADY_CLOSED' ||
     code === 'ER_GET_CONNECTION_TIMEOUT' ||
+    code === 'ER_USER_LIMIT_REACHED' ||
+    errno === 1226 ||
     code === 'ECONNRESET' ||
     code === 'ECONNREFUSED' ||
     code === 'EPIPE' ||

--- a/scripts/prisma-migrate-deploy.mjs
+++ b/scripts/prisma-migrate-deploy.mjs
@@ -124,9 +124,10 @@ async function main() {
 
     // The repair runs a short sequence of idempotent, existence-guarded
     // statements against ProxySQL, which can drop the connection mid-sequence
-    // (SQLState 08S01, "socket has unexpectedly been closed"). Reconnect and
-    // re-run the repair on connection-level failures — safe because every step
-    // is idempotent — instead of failing the whole production deploy.
+    // (SQLState 08S01, "socket has unexpectedly been closed") or briefly refuse
+    // a new session while the shared user is at max_user_connections. Reconnect
+    // and re-run the repair on connection-level failures — safe because every
+    // step is idempotent — instead of failing the whole production deploy.
     await withConnectionRetry(
       async () => {
         let connection
@@ -142,6 +143,8 @@ async function main() {
         }
       },
       {
+        attempts: 6,
+        baseDelayMs: 3_000,
         onRetry: ({ attempt, attempts, error, backoff }) => {
           console.warn(
             `[database repair] Attempt ${attempt}/${attempts} hit a transient connection error (${

--- a/utils/scripts/verify-known-migration-repair.mjs
+++ b/utils/scripts/verify-known-migration-repair.mjs
@@ -168,13 +168,16 @@ assert.doesNotMatch(repairSource, /DELETE\s+FROM/i)
 assert.doesNotMatch(repairSource, /DROP\s+TABLE/i)
 assert.match(deploySource, /repairKnownFailedMigrations/)
 assert.match(deploySource, /await repairKnownFailedMigrations[\s\S]*await runPrismaMigrate/)
-// The repair must run inside the connection-retry wrapper so a transient
-// ProxySQL socket drop (SQLState 08S01) reconnects instead of failing the deploy.
+// The repair must run inside the connection-retry wrapper so transient
+// ProxySQL socket drops and temporary connection-capacity exhaustion wait for
+// a fresh session instead of failing the deployment immediately.
 assert.match(deploySource, /withConnectionRetry/)
 assert.match(
   deploySource,
   /withConnectionRetry[\s\S]*repairKnownFailedMigrations[\s\S]*await runPrismaMigrate/,
 )
+assert.match(deploySource, /attempts:\s*6/)
+assert.match(deploySource, /baseDelayMs:\s*3_000/)
 
 // Migrations must resolve the same URL Prisma uses (MIGRATION_DATABASE_URL ??
 // DATABASE_URL) and force SSL onto it — otherwise a MIGRATION_DATABASE_URL set
@@ -199,6 +202,16 @@ assert.equal(
 )
 assert.equal(isRetryableConnectionError({ sqlState: '08S01' }), true)
 assert.equal(isRetryableConnectionError({ code: 'ECONNRESET' }), true)
+assert.equal(
+  isRetryableConnectionError({
+    code: 'ER_USER_LIMIT_REACHED',
+    sqlState: '42000',
+    errno: 1226,
+    fatal: true,
+  }),
+  true,
+)
+assert.equal(isRetryableConnectionError({ errno: 1226 }), true)
 // ...but logical/query errors are not (retrying would hide a real bug).
 assert.equal(
   isRetryableConnectionError({ code: 'ER_PARSE_ERROR', sqlState: '42000' }),


### PR DESCRIPTION
## Summary
- classify MariaDB `ER_USER_LIMIT_REACHED` / errno 1226 as a transient connection-acquisition failure
- give the production migration preflight six bounded attempts with exponential backoff
- continue rejecting logical SQL, constraint, and permission failures immediately
- add contract coverage for the exact production error and retry budget

## Production incident
Two consecutive production deployments for PR #1409 failed before migration with:

`User 'kindrobot' has exceeded the 'max_user_connections' resource (current value: 200)`

The existing bootstrap already retries transient ProxySQL socket failures, but SQLState `42000` caused this capacity error to bypass that path. This extends the narrow connection retry classifier without weakening migration correctness.