### PR TITLE
Migrate user patch forbid scans to shared source scanner

### DIFF
--- a/utils/scripts/verifyUserPatchAllowlist.ts
+++ b/utils/scripts/verifyUserPatchAllowlist.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { containsCode } from './lib/sourceText'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
@@ -15,7 +16,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }


### PR DESCRIPTION
## Summary
- route `verifyUserPatchAllowlist.ts` forbid checks through the shared `containsCode` helper
- keep require-style checks on raw source
- continue the bounded migration for Conductor `interface-vision/t-068`

## Validation
- shared helper behavior is covered by `verifySourceTextComments.test.ts`
- required repository checks must complete successfully before merge

Conductor session: `2026-08-04T071303Z-interface-vision-t-068-n4q7`