### PR TITLE
t-060: kr-gallery gains item/empty slots; scenario-gallery adopts (2/7 → 3/7)

### DIFF
--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -42,17 +42,56 @@
       <b>{{ error }}</b>
     </div>
 
+    <!--
+      The empty state is slotted for the same reason `item` is: a generic
+      "No scenarios." is a downgrade for a gallery that had search-aware copy
+      and an Add call-to-action, and losing that to adopt the shell would make
+      adoption cost the user something. Callers with nothing special to say
+      omit the slot and get the default below.
+    -->
     <div
       v-else-if="!items.length"
       class="flex min-h-64 flex-col items-center justify-center text-center"
     >
-      <Icon name="kind-icon:cards" class="size-12 text-base-content/20" />
-      <b>No {{ emptyLabel }}.</b>
+      <slot name="empty">
+        <Icon name="kind-icon:cards" class="size-12 text-base-content/20" />
+        <b>No {{ emptyLabel }}.</b>
+      </slot>
     </div>
 
     <section v-else :class="gridClass">
+      <!--
+        An `item` slot, so a gallery can keep its own object card inside this
+        shell instead of trading it away to adopt the shell.
+
+        Without it the two halves of the design brief fight each other: t-064
+        put all five object cards on kr-entity-card-body (reactions, earned
+        karma, edit/archive actions), and t-060 wants all seven core objects on
+        one gallery. Adopting this shell with only the built-in rendering below
+        would have meant Dreams, Bots, Characters, Rewards and Scenarios losing
+        their reviews and actions -- a regression wearing an adoption's clothes.
+
+        So the split is: this component owns the SHELL (mode bar, grid, one
+        scroll owner, skeleton/error/empty, art fallback), and the caller owns
+        the CARD. Galleries whose rows have no reactable card -- facets,
+        projects -- pass no slot and keep the built-in rendering below
+        unchanged, which is why this is additive rather than a breaking change.
+      -->
+      <template v-if="$slots.item">
+        <slot
+          v-for="item in items"
+          :key="`slot-${item.id}`"
+          name="item"
+          :item="item"
+          :mode="mode"
+          :art-src="artSrc(item)"
+          :open="() => emit('open', item)"
+        />
+      </template>
+
       <button
         v-for="item in items"
+        v-else
         :key="item.id"
         type="button"
         class="group overflow-hidden rounded-2xl border border-base-300 bg-base-200 text-left transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-lg"

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -226,26 +226,42 @@
       </div>
 
       <div v-else class="flex min-h-0 flex-col gap-4">
-        <div :class="layoutClass">
+        <!-- Row stays bespoke: a horizontal filmstrip is not one of
+             kr-gallery's cards/heroes/icons grids. -->
+        <div v-if="isRowMode" :class="layoutClass">
           <ScenarioCard
             v-for="scenario in filteredScenarios"
             :key="scenario.id"
             :scenario="scenario"
             :selected="scenarioStore.selectedScenario?.id === scenario.id"
-            :show-image="showImages"
-            :compact="isCompact"
-            :show-actions="showCardActions"
-            :show-description="showDescriptions"
-            :show-meta="showMeta"
-            :show-inspirations="showInspirations"
-            :allow-edit="allowEdit"
-            :allow-delete="allowDelete"
-            :allow-clone="allowClone"
+            v-bind="scenarioCardProps"
             @edit="startEditingScenarioById"
             @clone="cloneScenarioById"
             @delete="handleScenarioDeleted"
           />
         </div>
+
+        <!-- t-060: the shared shell owns the grid; ScenarioCard stays the card.
+             :modes="[]" drops kr-gallery's own mode bar, because this gallery
+             already has its own controls in the header above. -->
+        <kr-gallery
+          v-else
+          :items="galleryItems"
+          :modes="[]"
+          empty-label="scenarios"
+        >
+          <template #item="{ item }">
+            <ScenarioCard
+              v-if="scenarioById.get(Number(item.id))"
+              :scenario="scenarioById.get(Number(item.id))!"
+              :selected="scenarioStore.selectedScenario?.id === item.id"
+              v-bind="scenarioCardProps"
+              @edit="startEditingScenarioById"
+              @clone="cloneScenarioById"
+              @delete="handleScenarioDeleted"
+            />
+          </template>
+        </kr-gallery>
 
         <section
           v-if="showSelectedCharacterCards"
@@ -288,6 +304,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import type { Character } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import type { ScenarioWithRelations } from '@/stores/scenarioStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useUserStore } from '@/stores/userStore'
@@ -385,6 +402,48 @@ const galleryScenarios = computed<ScenarioWithRelations[]>(() => {
 
   return scenarios
 })
+
+/*
+ * interface-vision t-060 — the grid variant renders through the shared
+ * kr-gallery shell (mode/skeleton/error/empty/grid) while keeping ScenarioCard
+ * as the card, via kr-gallery's `item` slot. Adopting the shell must not cost
+ * the reactions, earned karma and edit/clone/archive actions that t-064 put on
+ * kr-entity-card-body, which is exactly what the built-in item rendering would
+ * have traded away.
+ *
+ * `row` and `dropdown` stay bespoke on purpose: a horizontal filmstrip and a
+ * <select> are not grids, and forcing them through a grid shell would be
+ * adoption for the counter's sake rather than for the user's.
+ */
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredScenarios.value.map((scenario) => ({
+    id: scenario.id,
+    title: scenario.title || `Scenario ${scenario.id}`,
+    source: scenario,
+  })),
+)
+
+/** Slot props give back a GalleryItem, so map the id to the real record. */
+const scenarioById = computed(
+  () => new Map(filteredScenarios.value.map((s) => [s.id, s])),
+)
+
+/**
+ * The card's props in one place. Both the bespoke row layout and the
+ * kr-gallery slot render the same ScenarioCard, and a nine-prop list copied
+ * twice would drift the moment one of them gained a tenth.
+ */
+const scenarioCardProps = computed(() => ({
+  showImage: props.showImages,
+  compact: isCompact.value,
+  showActions: props.showCardActions,
+  showDescription: props.showDescriptions,
+  showMeta: props.showMeta,
+  showInspirations: props.showInspirations,
+  allowEdit: props.allowEdit,
+  allowDelete: props.allowDelete,
+  allowClone: props.allowClone,
+}))
 
 const filteredScenarios = computed<ScenarioWithRelations[]>(() => {
   const query = searchQuery.value.trim().toLowerCase()


### PR DESCRIPTION
First slice of the DESIGN-BRIEF beta gate, *"all seven core objects share one
gallery"*. **2/7 → 3/7.**

## The blocker this had to solve first

Adopting the shared shell must not cost the user anything — and as written, it
would have.

`kr-gallery` rendered its **own** item markup, with only an `item-trailing` slot.
So putting a core-object gallery on it meant *replacing* the object card. But
t-064 had just put all five object cards on `kr-entity-card-body` — which is where
reactions, earned karma and the edit/clone/archive actions live.

That's a regression wearing an adoption's clothes, and it pits two finished goals
against each other.

## Two additive slots

| slot | purpose |
| --- | --- |
| `item` | render your own card inside the shared shell. Slot props: the `GalleryItem`, the `mode`, the resolved `art-src`, and an `open()` helper. |
| `empty` | keep a gallery's own empty state — scenario-gallery's is search-aware and carries an **Add Scenario** CTA; a generic *"No scenarios."* is a downgrade. |

Both fall back to the existing built-in rendering when absent, so `facet-gallery`
and `conductor-project-gallery-page` are **untouched**.

**The split this settles:** kr-gallery owns the **shell** (mode bar, grid, one
scroll owner, skeleton/error/empty, art fallback); the caller owns the **card**.
Two shared pieces composing, rather than one replacing the other.

## scenario-gallery

Adopts the shell for the grid variant, keeping `ScenarioCard` through the slot.

`row` and `dropdown` stay bespoke **on purpose** — a horizontal filmstrip and a
`<select>` are not grids, and forcing them through a grid shell would be adoption
for the counter's sake rather than the user's.

A `scenarioCardProps` computed holds the card's nine shared props so the row and
grid call sites can't drift when one gains a tenth.

## ⚠️ Not visually verified yet — deliberately

The local database has no scenarios: the page renders **105 characters** of body
text with fetch failures for servers and components, so a local render measures
the empty state, not the gallery. Per the task note and AGENTS.md this needs
**preview eyes against the real database** before it's trusted — which is why this
PR exists before the check rather than after.

I'll verify on this PR's preview and report back before merging.

## Verification so far

- `npm run test` (vue-tsc) — **exit 0**
- `npm run test:gallery-adoption` — passes; reports `✓ scenario-gallery.vue reached from /academy`, core-object galleries **3/7**, overall **3/24**
- `eslint` + `prettier --check` — clean

## Remaining after this

`bot-gallery` (694) · `character-gallery` (717) · `reward-gallery` (741) ·
`dream-gallery` (1035) — all confirmed reachable from `/academy` with managers
routing to them, so the invisible-edit trap that cost a PR on Facets does not
apply. One PR each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_