### PR TITLE
Fix the small-card/dead-mode-bar defects, contract them, and adopt bot-gallery (4/7)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Gallery adoption contract
         run: npm run test:gallery-adoption
 
+      - name: Gallery consistency contract
+        run: npm run test:gallery-consistency
+
       - name: Data surface manifest contract
         run: npm run test:data-surface-manifest
 

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -50,7 +50,7 @@
         :title="botTitle"
         :subtitle="bot.subtitle || ''"
         :source="bot"
-        variant="card"
+        :variant="variant"
         :fallback="artFallbackSrc"
         :show-image="showImage"
         :show-description="false"
@@ -167,6 +167,7 @@ import type { Bot } from '~/prisma/generated/prisma/client'
 import { useBotStore } from '@/stores/botStore'
 import { useNavStore } from '@/stores/navStore'
 import { useUserStore } from '@/stores/userStore'
+import type { ArtVariant } from '@/utils/artImageSrc'
 import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 
 const props = withDefaults(
@@ -187,8 +188,16 @@ const props = withDefaults(
     allowClone?: boolean
     allowDelete?: boolean
     fallbackImage?: string
+    /**
+     * Which stored art to show, and at what aspect — the shared card/hero/icon
+     * vocabulary. Hardcoding this made the gallery's mode bar decorative:
+     * every mode rendered the identical portrait card. See
+     * utils/scripts/verifyGalleryConsistency.ts.
+     */
+    variant?: ArtVariant
   }>(),
   {
+    variant: 'card',
     selected: false,
     compact: false,
     showImage: true,

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -306,23 +306,15 @@
         </button>
       </div>
 
-      <div v-else :class="layoutClass">
+      <!-- Row stays bespoke: a horizontal filmstrip is not one of kr-gallery's
+           cards/heroes/icons grids. -->
+      <div v-else-if="isRowMode" :class="layoutClass">
         <bot-card
           v-for="bot in filteredBots"
           :key="bot.id"
           :bot="bot"
           :selected="botStore.currentBot?.id === bot.id"
-          :compact="isCompact"
-          :show-image="showImages"
-          :show-actions="showCardActions"
-          :show-description="showDescriptions"
-          :show-meta="showMeta"
-          :show-personality="showPersonality"
-          :show-launch-button="showLaunchButton"
-          :show-debug="showDebug"
-          :allow-edit="allowEdit"
-          :allow-clone="allowClone"
-          :allow-delete="allowDelete"
+          v-bind="botCardProps"
           @select="selectBot"
           @edit="startEditingBotById"
           @clone="cloneBotById"
@@ -330,6 +322,33 @@
           @launch="launchBotById"
         />
       </div>
+
+      <!-- t-060: the shared shell owns the grid and the Cards/Heroes/Icons bar;
+           bot-card stays the card. The mode is bound both ways and fed through
+           MODE_VARIANT into the card's `variant`, which is the pairing
+           verifyGalleryConsistency.ts exists to enforce. -->
+      <kr-gallery
+        v-else
+        :items="galleryItems"
+        :mode="galleryMode"
+        empty-label="bots"
+        @update:mode="galleryMode = $event"
+      >
+        <template #item="{ item }">
+          <bot-card
+            v-if="botById.get(Number(item.id))"
+            :bot="botById.get(Number(item.id))!"
+            :selected="botStore.currentBot?.id === item.id"
+            :variant="MODE_VARIANT[galleryMode]"
+            v-bind="botCardProps"
+            @select="selectBot"
+            @edit="startEditingBotById"
+            @clone="cloneBotById"
+            @delete="handleBotDeleted"
+            @launch="launchBotById"
+          />
+        </template>
+      </kr-gallery>
     </section>
   </section>
 </template>
@@ -337,6 +356,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import type { Bot } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import { useBotStore } from '@/stores/botStore'
 import { useNavStore } from '@/stores/navStore'
 import { useUserStore } from '@/stores/userStore'
@@ -400,6 +421,10 @@ const showBotForm = ref(false)
 const formMode = ref<'add' | 'edit'>('add')
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
+const isRowMode = computed(() => props.variant === 'row')
+
+/** Which of Cards/Heroes/Icons the shared grid is showing. */
+const galleryMode = ref<GalleryMode>('cards')
 
 const isCompact = computed(() => {
   return props.compact || props.variant === 'row' || isDropdownMode.value
@@ -495,6 +520,43 @@ const galleryBots = computed<Bot[]>(() => {
 
   return bots
 })
+
+/*
+ * interface-vision t-060 — the grid variant renders through the shared
+ * kr-gallery shell while bot-card stays the card, via kr-gallery's `item` slot.
+ * Adopting the shell must not cost the reactions, karma and edit/clone/launch
+ * actions that t-064 put on kr-entity-card-body.
+ */
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredBots.value.map((bot) => ({
+    id: bot.id,
+    title: bot.name || `Bot ${bot.id}`,
+    source: bot,
+  })),
+)
+
+/** Slot props give back a GalleryItem, so map the id to the real record. */
+const botById = computed(
+  () => new Map(filteredBots.value.map((b) => [b.id, b])),
+)
+
+/**
+ * The card's shared props in one place, so the bespoke row layout and the
+ * kr-gallery slot cannot drift when one of them gains a tenth prop.
+ */
+const botCardProps = computed(() => ({
+  compact: isCompact.value,
+  showImage: props.showImages,
+  showActions: props.showCardActions,
+  showDescription: props.showDescriptions,
+  showMeta: props.showMeta,
+  showPersonality: props.showPersonality,
+  showLaunchButton: props.showLaunchButton,
+  showDebug: props.showDebug,
+  allowEdit: props.allowEdit,
+  allowClone: props.allowClone,
+  allowDelete: props.allowDelete,
+}))
 
 const filteredBots = computed<Bot[]>(() => {
   let bots = galleryBots.value

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -46,7 +46,7 @@
     <kr-entity-card-body
       :title="displayName"
       :source="character"
-      variant="card"
+      :variant="variant"
       :fallback="artFallbackSrc"
       :show-image="showImage"
       :show-description="false"
@@ -160,7 +160,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Character } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
-import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import { resolveArtImageSrc, type ArtVariant } from '@/utils/artImageSrc'
 import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useUserStore } from '@/stores/userStore'
@@ -196,8 +196,16 @@ const props = withDefaults(
     allowDelete?: boolean
     fallbackImage?: string
     imageFit?: 'contain' | 'cover'
+    /**
+     * Which stored art to show, and at what aspect — the shared card/hero/icon
+     * vocabulary. Hardcoding this made the gallery's mode bar decorative:
+     * every mode rendered the identical portrait card. See
+     * utils/scripts/verifyGalleryConsistency.ts.
+     */
+    variant?: ArtVariant
   }>(),
   {
+    variant: 'card',
     selected: false,
     isSelected: false,
     compact: false,

--- a/components/rewards/reward-card.vue
+++ b/components/rewards/reward-card.vue
@@ -50,7 +50,7 @@
       :description="reward.effect || reward.description || ''"
       description-fallback="No effect described yet."
       :source="reward"
-      variant="card"
+      :variant="variant"
       :fallback="artFallbackSrc"
       :show-image="showImage"
       :show-description="showDescription"
@@ -123,6 +123,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Reward } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
+import type { ArtVariant } from '@/utils/artImageSrc'
 import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 import { useRewardStore } from '@/stores/rewardStore'
 
@@ -156,8 +157,16 @@ const props = withDefaults(
     /** Total karma this reward has earned from reactions to it. Omit/undefined
      *  renders no badge — see components/wonderlab/reactable-card.vue. */
     earnedKarma?: number | null
+    /**
+     * Which stored art to show, and at what aspect — the shared card/hero/icon
+     * vocabulary. Hardcoding this made the gallery's mode bar decorative:
+     * every mode rendered the identical portrait card. See
+     * utils/scripts/verifyGalleryConsistency.ts.
+     */
+    variant?: ArtVariant
   }>(),
   {
+    variant: 'card',
     selected: false,
     showImage: true,
     compact: false,

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -49,7 +49,7 @@
       :description="scenario.description"
       description-fallback="No description yet."
       :source="scenario"
-      variant="card"
+      :variant="variant"
       :fallback="artFallbackSrc"
       :show-image="showImage"
       :show-description="showDescription"
@@ -84,7 +84,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Scenario } from '~/prisma/generated/prisma/client'
 import { useArtStore, type ArtImage } from '@/stores/artStore'
-import { resolveArtImageSrc } from '@/utils/artImageSrc'
+import { resolveArtImageSrc, type ArtVariant } from '@/utils/artImageSrc'
 import type { EntityCardChip } from '@/components/gallery/kr-entity-card-body.vue'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useUserStore } from '@/stores/userStore'
@@ -105,6 +105,13 @@ const props = withDefaults(
     allowDelete?: boolean
     allowClone?: boolean
     fallbackImage?: string
+    /**
+     * Which stored art to show, and at what aspect — the shared card/hero/icon
+     * vocabulary. This was hardcoded `variant="card"` on the body below, which
+     * is why a gallery mode switch changed nothing visible: every mode rendered
+     * the identical portrait card. Same prop, same default, as dream-card.
+     */
+    variant?: ArtVariant
   }>(),
   {
     selected: false,
@@ -118,6 +125,7 @@ const props = withDefaults(
     allowEdit: true,
     allowDelete: true,
     allowClone: true,
+    variant: 'card',
     fallbackImage: '/images/scenarios/space.webp',
   },
 )

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -241,20 +241,24 @@
           />
         </div>
 
-        <!-- t-060: the shared shell owns the grid; ScenarioCard stays the card.
-             :modes="[]" drops kr-gallery's own mode bar, because this gallery
-             already has its own controls in the header above. -->
+        <!-- t-060: the shared shell owns the grid AND the Cards/Heroes/Icons
+             bar; ScenarioCard stays the card. The mode is bound both ways and
+             fed through MODE_VARIANT into the card's `variant`, because a mode
+             bar that does not reach the card is the defect Silas found on the
+             first pass: "no different layouts". -->
         <kr-gallery
           v-else
           :items="galleryItems"
-          :modes="[]"
+          :mode="galleryMode"
           empty-label="scenarios"
+          @update:mode="galleryMode = $event"
         >
           <template #item="{ item }">
             <ScenarioCard
               v-if="scenarioById.get(Number(item.id))"
               :scenario="scenarioById.get(Number(item.id))!"
               :selected="scenarioStore.selectedScenario?.id === item.id"
+              :variant="MODE_VARIANT[galleryMode]"
               v-bind="scenarioCardProps"
               @edit="startEditingScenarioById"
               @clone="cloneScenarioById"
@@ -305,6 +309,7 @@
 import { computed, onMounted, ref } from 'vue'
 import type { Character } from '~/prisma/generated/prisma/client'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import type { ScenarioWithRelations } from '@/stores/scenarioStore'
 import { useScenarioStore } from '@/stores/scenarioStore'
 import { useUserStore } from '@/stores/userStore'
@@ -415,6 +420,9 @@ const galleryScenarios = computed<ScenarioWithRelations[]>(() => {
  * <select> are not grids, and forcing them through a grid shell would be
  * adoption for the counter's sake rather than for the user's.
  */
+/** Which of Cards/Heroes/Icons the grid is showing. */
+const galleryMode = ref<GalleryMode>('cards')
+
 const galleryItems = computed<GalleryItem[]>(() =>
   filteredScenarios.value.map((scenario) => ({
     id: scenario.id,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:comfy-model-paths": "tsx utils/scripts/verifyComfyModelPaths.ts",
     "test:channel-content": "tsx utils/scripts/verifyChannelContent.ts",
     "test:gallery-adoption": "tsx utils/scripts/verifyGalleryAdoption.ts",
+    "test:gallery-consistency": "tsx utils/scripts/verifyGalleryConsistency.ts",
     "test:channel-resolver": "tsx utils/scripts/verifyChannelResolver.ts",
     "test:data-surface-manifest": "tsx utils/scripts/verifyDataSurfaceManifest.ts",
     "test:nav-manifest": "tsx utils/scripts/verifyNavManifest.ts",

--- a/utils/galleryVocabulary.ts
+++ b/utils/galleryVocabulary.ts
@@ -92,10 +92,31 @@ export const MODE_VARIANT: Record<GalleryMode, ArtVariant> = {
  * whose identity is its layout rather than its image duplicates whichever grid
  * happens to collapse to one column at that width.
  */
+/*
+ * CONTAINER-responsive, deliberately — no sm:/lg:/xl: breakpoints.
+ *
+ * These grids were `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`
+ * and similar, which key off the VIEWPORT. Galleries here are mounted inside
+ * manager panels, not at full page width, so on a wide screen `xl:grid-cols-4`
+ * fired while the actual container was narrow — four columns crammed into a
+ * panel. Silas, 2026-08-04, on scenario-gallery: "the individual scenarios are
+ * appearing but with formatting that is awkward (small card, excessive
+ * padding, no different layouts)."
+ *
+ * scenario-gallery's own pre-adoption CSS had this right:
+ * `repeat(auto-fill, minmax(min(180px, 100%), 1fr))`. auto-fill + minmax needs
+ * no breakpoints at all — it fills whatever width it is actually given and
+ * degrades to a single column when that width is below the minimum, which is
+ * what `min(..., 100%)` guarantees. Adopting the shared shell must not cost a
+ * gallery the sizing it already had.
+ */
 export const MODE_GRID_CLASS: Record<GalleryMode, string> = {
-  cards: 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
-  heroes: 'grid gap-4 lg:grid-cols-2',
-  icons: 'grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5',
+  cards:
+    'grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(min(11rem,100%),1fr))]',
+  heroes:
+    'grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(20rem,100%),1fr))]',
+  icons:
+    'grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(min(7rem,100%),1fr))]',
 }
 
 /**

--- a/utils/scripts/verifyGalleryConsistency.ts
+++ b/utils/scripts/verifyGalleryConsistency.ts
@@ -1,0 +1,206 @@
+// /utils/scripts/verifyGalleryConsistency.ts
+//
+// The three ways a gallery adoption silently fails to look consistent.
+//
+// Silas, 2026-08-04, after the first scenario-gallery adoption landed:
+//
+//   "I do not actually see a difference, the individual scenarios are appearing
+//    but with formatting that is awkward (small card, excessive padding, no
+//    different layouts). Why am I asked to vet this when it isn't up to
+//    standard?"
+//
+// and then, on the remaining four galleries:
+//
+//   "can we make sure that when we do the other models we aren't repeating this
+//    error. we are trying to create a consistent look, but seem to keep hitting
+//    the same walls because we aren't expecting a consistent style"
+//
+// That is the right diagnosis: the defects were not carelessness, they were
+// UNEXPECTED. Nothing in the repo said what a consistent gallery owes the user,
+// so each adoption rediscovered the same three walls. verifyGalleryAdoption.ts
+// counts WHETHER a gallery adopted the shell; this asserts the adoption is
+// worth having.
+//
+// Every check below is a defect that actually shipped, not a hypothetical.
+
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const failures: string[] = []
+const notes: string[] = []
+
+/**
+ * Strip comments before any forbid-scan.
+ *
+ * interface-vision t-068: "a doc comment can fail 29 source-text contracts".
+ * This contract proved it on its own first run — scenario-card.vue was flagged
+ * for hardcoding `variant="card"` when the only occurrence left was inside the
+ * doc comment explaining that it USED to. A contract that punishes you for
+ * documenting the thing it asked you to fix trains people to delete comments.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/<!--[\s\S]*?-->/g, '') // template
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1') // line, sparing protocol slashes
+}
+
+const fail = (msg: string) => failures.push(msg)
+const ok = (msg: string) => notes.push(`ok - ${msg}`)
+
+/* ------------------------------------------------------------------ *
+ * 1. Gallery grids must be CONTAINER-responsive, never viewport-keyed.
+ * ------------------------------------------------------------------ */
+//
+// MODE_GRID_CLASS shipped as `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3
+// xl:grid-cols-4`. Tailwind breakpoints key off the VIEWPORT, but these
+// galleries mount inside manager panels. On a 1440px screen `xl:grid-cols-4`
+// fired while the container was 320px wide: four columns, 71px cards.
+//
+// Measured, viewport pinned at 1440px, only the container varying:
+//   panel 320px -> before 4 cols/71px   after 1 col /320px
+//   panel 480px -> before 4 cols/111px  after 2 cols/234px
+//
+// auto-fill + minmax needs no breakpoints: it fills the width it is actually
+// given, and min(..., 100%) guarantees it collapses to one column rather than
+// overflowing when that width is below the minimum.
+const VIEWPORT_PREFIX = /\b(sm|md|lg|xl|2xl):/
+
+const vocabSrc = stripComments(
+  await readFile('utils/galleryVocabulary.ts', 'utf8'),
+)
+const gridBlock = vocabSrc.match(
+  /export const MODE_GRID_CLASS[\s\S]*?\n\}/,
+)?.[0]
+
+if (!gridBlock) {
+  fail(
+    'utils/galleryVocabulary.ts: MODE_GRID_CLASS not found. If it moved, update this contract.',
+  )
+} else {
+  const offenders = gridBlock
+    .split('\n')
+    .filter((line) => VIEWPORT_PREFIX.test(line))
+    .map((line) => line.trim())
+
+  if (offenders.length) {
+    fail(
+      'MODE_GRID_CLASS uses VIEWPORT breakpoints. Galleries mount inside panels, ' +
+        'so sm:/lg:/xl: sizes columns by the screen while the container is narrow ' +
+        '-- this is the "small card" defect (4 columns of 71px in a 320px panel). ' +
+        'Use repeat(auto-fill, minmax(min(<rem>,100%),1fr)) instead:\n' +
+        offenders.map((o) => `           ${o}`).join('\n'),
+    )
+  } else if (!gridBlock.includes('auto-fill')) {
+    fail(
+      'MODE_GRID_CLASS no longer uses auto-fill. Container-responsive sizing is ' +
+        'the contract; a fixed column count cannot adapt to the panel it is in.',
+    )
+  } else {
+    ok(
+      'gallery grids are container-responsive (auto-fill, no viewport breakpoints)',
+    )
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * 2. An object card must accept `variant` — never hardcode it.
+ * ------------------------------------------------------------------ */
+//
+// scenario-card.vue passed `variant="card"` as a literal to
+// kr-entity-card-body and exposed no prop, so the gallery's Cards/Heroes/Icons
+// bar changed nothing visible: every mode rendered the identical portrait card.
+// That is half of "no different layouts". A card that cannot be told which
+// variant to render makes the whole vocabulary decorative.
+const CARD_FILES = [
+  'components/bots/bot-card.vue',
+  'components/characters/character-card.vue',
+  'components/dreams/dream-card.vue',
+  'components/rewards/reward-card.vue',
+  'components/scenarios/scenario-card.vue',
+]
+
+for (const file of CARD_FILES) {
+  const src = await readFile(file, 'utf8').catch(() => '')
+  if (!src) {
+    fail(`${file}: not found. If the card moved, update this contract.`)
+    continue
+  }
+  if (!src.includes('kr-entity-card-body')) continue
+
+  const code = stripComments(src)
+  const hardcoded = code.match(/\bvariant="(card|hero|icon)"/)
+  if (hardcoded) {
+    fail(
+      `${file}: hardcodes ${hardcoded[0]} on kr-entity-card-body, so a gallery ` +
+        'mode switch cannot reach the art. Take a `variant?: ArtVariant` prop ' +
+        "(default 'card') and bind it, as dream-card and scenario-card do.",
+    )
+  } else if (!/variant\?:\s*ArtVariant/.test(code)) {
+    fail(
+      `${file}: renders kr-entity-card-body but declares no ` +
+        '`variant?: ArtVariant` prop, so it cannot follow the gallery mode.',
+    )
+  }
+}
+if (!failures.length) ok(`${CARD_FILES.length} object cards accept a variant`)
+
+/* ------------------------------------------------------------------ *
+ * 3. A kr-gallery mount that shows a mode bar must bind :mode.
+ * ------------------------------------------------------------------ */
+//
+// The other half of "no different layouts": scenario-gallery mounted
+// <kr-gallery> and never bound :mode, so the shell sat on its default 'cards'
+// forever. A mode bar the parent never reads is a control that does nothing.
+//
+// `:modes="[]"` is the legitimate opt-out -- it hides the bar entirely, which
+// facet-gallery uses because a picker above drives every group at once.
+const COMPONENT_ROOTS = ['components']
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) yield* walk(path)
+    else if (entry.name.endsWith('.vue')) yield path
+  }
+}
+
+let mountCount = 0
+for (const root of COMPONENT_ROOTS) {
+  for await (const file of walk(root)) {
+    const src = stripComments(await readFile(file, 'utf8'))
+    if (!src.includes('<kr-gallery')) continue
+
+    // Each mount, from the tag through its closing bracket.
+    for (const mount of src.match(/<kr-gallery[\s\S]*?>/g) ?? []) {
+      mountCount += 1
+      const hidesBar = /:modes="\[\]"/.test(mount)
+      const bindsMode = /:mode="/.test(mount)
+
+      if (!hidesBar && !bindsMode) {
+        fail(
+          `${file}: mounts <kr-gallery> showing its mode bar but never binds ` +
+            ':mode, so the shell stays on its default and the buttons do ' +
+            'nothing. Bind :mode + @update:mode, or pass :modes="[]" to hide ' +
+            'the bar deliberately.',
+        )
+      }
+    }
+  }
+}
+ok(`${mountCount} kr-gallery mount(s) either bind :mode or opt out of the bar`)
+
+/* ------------------------------------------------------------------ */
+
+for (const note of notes) console.log(note)
+
+if (failures.length) {
+  console.error('\nGallery consistency contract FAILED:\n')
+  for (const f of failures) console.error(`  ✗ ${f}\n`)
+  process.exit(1)
+}
+
+console.log(
+  '\nGallery consistency contract passed: grids size to their container, cards ' +
+    'follow the gallery mode, and every mode bar is wired to something.',
+)

--- a/utils/scripts/verifyGalleryConsistency.ts
+++ b/utils/scripts/verifyGalleryConsistency.ts
@@ -132,7 +132,7 @@ for (const file of CARD_FILES) {
   const hardcoded = code.match(/\bvariant="(card|hero|icon)"/)
   if (hardcoded) {
     fail(
-      `${file}: hardcodes ${hardcoded[0]} on kr-entity-card-body, so a gallery ` +
+      `${file}: hardcodes ${hardcoded?.[0] ?? 'a literal variant'} on kr-entity-card-body, so a gallery ` +
         'mode switch cannot reach the art. Take a `variant?: ArtVariant` prop ' +
         "(default 'card') and bind it, as dream-card and scenario-card do.",
     )


### PR DESCRIPTION
Three commits. Safe to merge at any point — each is independently complete.

**#1414 merged at its first commit only**, so its two follow-ups never reached
`main`. The gallery Silas looked at was the broken version. Commits 1–2 are that
fix; commit 3 is the next gallery.

---

## 1. The three defects — `8741fc0`

> *"small card, excessive padding, no different layouts"*

**Small cards, the root cause.** `MODE_GRID_CLASS` used Tailwind **viewport**
breakpoints. These galleries mount inside **manager panels**, so on a 1440px
screen `xl:grid-cols-4` fired while the container was 320px. Measured, viewport
pinned at 1440px, only the container varying:

| panel | before | after |
| --- | --- | --- |
| 320px | **4 cols / 71px cards** | 1 col / 320px |
| 480px | 4 cols / 111px | 2 cols / 234px |
| 1100px | 4 cols / 266px | 5 cols / 210px |

Now `auto-fill` + `minmax`, which needs no breakpoints. Also silently fixes
`facet-gallery` and `conductor-project-gallery-page`, already on the shell and
suffering the same thing.

**No different layouts** — two breaks: `scenario-card` hardcoded `variant="card"`
with no prop, and I bound `:modes="[]"` while never binding `:mode`.

**Padding** — cards grid `gap-4` → `gap-3`.

## 2. The guard — `eb41d31`

> *"can we make sure that when we do the other models we aren't repeating this
> error… we seem to keep hitting the same walls because we aren't expecting a
> consistent style"*

`verifyGalleryConsistency.ts`, wired into `contract-tests.yml`:

| # | check |
| --- | --- |
| 1 | grids stay container-responsive (no `sm:`/`lg:`/`xl:`, keeps `auto-fill`) |
| 2 | object cards accept `variant`, never hardcode it |
| 3 | a visible mode bar is actually bound to `:mode` |

`verifyGalleryAdoption` counts *whether* a gallery adopted the shell; this
asserts the adoption is **worth having**.

**It earned itself twice.** Check 2 caught `bot-card`, `character-card` and
`reward-card` all hardcoding `variant="card"` — the identical defect already
waiting in three of the four remaining galleries. And it caught its own first
bug: flagging `scenario-card` for a `variant="card"` that existed only in the doc
comment explaining it *used to* — interface-vision **t-068** live, so every scan
strips comments first.

## 3. bot-gallery adopts — `1d348e7` — **3/7 → 4/7**

Grid variant through kr-gallery, `bot-card` kept via the `item` slot, `row` and
`dropdown` left bespoke. Mode bound both ways and fed through `MODE_VARIANT`.

That last part **only works because check 2 had already fixed `bot-card`** —
wiring a mode bar into a card that ignores it is precisely the dead control from
the first pass. This time the check ran before the PR instead of after.

---

## Verification

- `npm run test` (vue-tsc) — **exit 0**
- `test:gallery-consistency` — passes, 4 kr-gallery mounts all bind `:mode` or opt out
- `test:gallery-adoption` — **4/7**, `bot-gallery` reached from `/academy`
- `test:layout-contract` — holds · `test:workflow-paths` — 720 refs across 62 workflows
- `eslint` + `prettier` clean (the `contract-tests.yml` prettier warning is pre-existing — fails on clean `HEAD` too)

Remaining: `character-gallery` (717) · `reward-gallery` (741) · `dream-gallery` (1035).