### PR TITLE
docs: component-deletion checklist for DOM-scraping/workflow-path deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,26 @@ near-copy. Highest-risk areas:
 - stores
 - API contracts
 
+## Deleting a superseded component
+
+A plain "who imports this `.vue` file" grep misses real dependents. When t-026 deleted
+`conductor-art-gallery.vue` in favor of `entity-art-manager.vue` (kind_robots PR #1405), an
+import-site search missed two live dependents: a plugin that DOM-scraped the deleted
+component's specific rendered markup, and a CI workflow that named the file directly in its
+trigger path list. Neither shows up in a normal import/component-usage search. Before
+deleting a superseded component:
+
+1. Grep the deleted filename (not just import statements) across the whole repo — `.yml`
+   workflow files and DOM-scraping plugins are real dependents too, and they only show up
+   on a plain filename search.
+2. Check `.github/workflows/*.yml` `paths:` trigger blocks specifically for the filename.
+3. Check `plugins/*.client.ts` for selector strings that could key off the deleted
+   component's specific rendered markup (an attribute, class, or DOM structure), not just
+   its component name.
+4. If the component has published WonderLab museum reviews, read
+   `docs/wonderlab-component-retirement-policy.md` first — reviews survive retirement by
+   design and are never a reason to keep the file.
+
 ## Project identity and source of truth
 
 Read `docs/conductor-projection.md` before changing cross-repository project data.


### PR DESCRIPTION
### Task
conductor/interface-vision t-089: component-deletion checklist for non-obvious dependents (kind: software)

### What changed / what I produced
- Added a "Deleting a superseded component" section to `AGENTS.md`, right before "Project identity and source of truth".
- Checklist: (1) grep the deleted filename across the whole repo, not just import sites, (2) check `.github/workflows/*.yml` `paths:` trigger blocks, (3) check `plugins/*.client.ts` for DOM-scraping selector strings keyed off the component's rendered markup, (4) check `docs/wonderlab-component-retirement-policy.md` if the component has published museum reviews.

### How I verified
- Docs-only change (no code touched); read the file back to confirm placement and formatting are consistent with the rest of `AGENTS.md`.

### Stakes
reversible

### Notes for reviewer
Kaizen from interface-vision/t-026's close-out (kind_robots PR #1405, deleting `conductor-art-gallery.vue` in favor of `entity-art-manager.vue`): a plain import-site grep missed `plugins/project-art-prompt-suggest.client.ts` (DOM-scraped the deleted component's specific markup) and `.github/workflows/entity-art-manager-contract.yml` (named the file directly in its `paths:` trigger list, caught by CI's `verifyWorkflowPaths.ts` rather than by review).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vwx14gpsFKaYyy3tLDRrfy)_