### PR TITLE
t-060: character, reward and dream galleries adopt the shell — 7/7, beta gate closed

### DIFF
--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -236,29 +236,45 @@
         </button>
       </div>
 
-      <div v-else :class="layoutClass">
+      <!-- Row stays bespoke: a horizontal filmstrip is not one of kr-gallery's
+           cards/heroes/icons grids. -->
+      <div v-else-if="isRowMode" :class="layoutClass">
         <character-card
           v-for="character in filteredCharacters"
           :key="character.id"
           :character="character"
           :selected="characterStore.selectedCharacter?.id === character.id"
           :is-selected="characterStore.selectedCharacter?.id === character.id"
-          :compact="isCompact"
-          :show-image="showImages"
-          :show-actions="showCardActions"
-          :show-description="showDescriptions"
-          :show-meta="showMeta"
-          :show-stats="showStats"
-          :show-debug="showDebug"
-          :allow-edit="allowEdit"
-          :allow-clone="allowClone"
-          :allow-delete="allowDelete"
-          image-fit="contain"
+          v-bind="characterCardProps"
           @edit="startEditingCharacterById"
           @clone="cloneCharacterById"
           @delete="handleCharacterDeleted"
         />
       </div>
+
+      <!-- t-060: the shared shell owns the grid and the Cards/Heroes/Icons bar;
+           character-card stays the card. -->
+      <kr-gallery
+        v-else
+        :items="galleryItems"
+        :mode="galleryMode"
+        empty-label="characters"
+        @update:mode="galleryMode = $event"
+      >
+        <template #item="{ item }">
+          <character-card
+            v-if="characterById.get(Number(item.id))"
+            :character="characterById.get(Number(item.id))!"
+            :selected="characterStore.selectedCharacter?.id === item.id"
+            :is-selected="characterStore.selectedCharacter?.id === item.id"
+            :variant="MODE_VARIANT[galleryMode]"
+            v-bind="characterCardProps"
+            @edit="startEditingCharacterById"
+            @clone="cloneCharacterById"
+            @delete="handleCharacterDeleted"
+          />
+        </template>
+      </kr-gallery>
     </section>
   </section>
 </template>
@@ -266,6 +282,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import type { Character } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import { useCharacterStore } from '@/stores/characterStore'
 import { useUserStore } from '@/stores/userStore'
 
@@ -327,6 +345,10 @@ const showCharacterForm = ref(false)
 const formMode = ref<'add' | 'edit'>('add')
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
+const isRowMode = computed(() => props.variant === 'row')
+
+/** Which of Cards/Heroes/Icons the shared grid is showing. */
+const galleryMode = ref<GalleryMode>('cards')
 
 const isCompact = computed(() => {
   return props.compact || props.variant === 'row' || isDropdownMode.value
@@ -438,6 +460,42 @@ const characterGenres = computed(() => {
 
   return Array.from(set).sort()
 })
+
+/*
+ * interface-vision t-060 — grid renders through the shared kr-gallery shell
+ * while character-card stays the card, so the reactions, karma and
+ * edit/clone/archive actions from t-064 survive the adoption.
+ */
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredCharacters.value.map((character) => ({
+    id: character.id,
+    title: character.name || `Character ${character.id}`,
+    source: character,
+  })),
+)
+
+/** Slot props give back a GalleryItem, so map the id to the real record. */
+const characterById = computed(
+  () => new Map(filteredCharacters.value.map((c) => [c.id, c])),
+)
+
+/**
+ * The card's shared props in one place, so the bespoke row layout and the
+ * kr-gallery slot cannot drift when one of them gains another.
+ */
+const characterCardProps = computed(() => ({
+  compact: isCompact.value,
+  showImage: props.showImages,
+  showActions: props.showCardActions,
+  showDescription: props.showDescriptions,
+  showMeta: props.showMeta,
+  showStats: props.showStats,
+  showDebug: props.showDebug,
+  allowEdit: props.allowEdit,
+  allowClone: props.allowClone,
+  allowDelete: props.allowDelete,
+  imageFit: 'contain' as const,
+}))
 
 const filteredCharacters = computed<Character[]>(() => {
   let characters = galleryCharacters.value

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -379,32 +379,51 @@
           :auto-refresh="autoLoadSheets"
         />
 
-        <div :class="layoutClass">
+        <!-- Row stays bespoke: `dream-row` is a horizontal scroll-snap
+             filmstrip, not one of kr-gallery's cards/heroes/icons grids. -->
+        <div v-if="isRowMode" :class="layoutClass">
           <dream-card
             v-for="dream in filteredDreams"
             :key="dream.id"
             :dream="dream"
             :selected="dreamStore.selectedDream?.id === dream.id"
             :is-selected="dreamStore.selectedDream?.id === dream.id"
-            :compact="isCompact"
             :variant="modeVariant"
-            :show-image="showImages"
-            :show-actions="showCardActions"
-            :show-description="showDescriptions"
-            :show-meta="showMeta"
-            :show-stats="showStats"
-            :show-debug="showDebug"
-            :allow-edit="allowEdit"
-            :allow-delete="allowDelete"
-            :show-pitch-sheet-preview="showPitchSheetPreview"
-            :load-pitch-sheet-preview="autoLoadSheets"
-            image-fit="cover"
             :earned-karma="earnedKarmaByDreamId[dream.id]"
+            v-bind="dreamCardProps"
             @choose="selectDreamAndOpen"
             @edit="startEditingDreamById"
             @delete="handleDreamDeleted"
           />
         </div>
+
+        <!-- t-060: the shared shell owns the grid; dream-card stays the card.
+             :mode is bound so the shell picks the right MODE_GRID_CLASS, and
+             :modes="[]" hides ITS bar because this gallery already renders one
+             in its toolbar above -- two bars driving one mode would be worse
+             than none. -->
+        <kr-gallery
+          v-else
+          :items="galleryItems"
+          :mode="galleryMode"
+          :modes="[]"
+          empty-label="dreams"
+        >
+          <template #item="{ item }">
+            <dream-card
+              v-if="dreamById.get(Number(item.id))"
+              :dream="dreamById.get(Number(item.id))!"
+              :selected="dreamStore.selectedDream?.id === item.id"
+              :is-selected="dreamStore.selectedDream?.id === item.id"
+              :variant="modeVariant"
+              :earned-karma="earnedKarmaByDreamId[Number(item.id)]"
+              v-bind="dreamCardProps"
+              @choose="selectDreamAndOpen"
+              @edit="startEditingDreamById"
+              @delete="handleDreamDeleted"
+            />
+          </template>
+        </kr-gallery>
       </div>
     </section>
   </section>
@@ -418,6 +437,7 @@ import type {
   Reward,
   Scenario,
 } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import {
   GALLERY_MODES,
   MODE_GRID_CLASS,
@@ -546,6 +566,7 @@ const modeVariant = computed(() => MODE_VARIANT[galleryMode.value])
 const earnedKarmaByDreamId = ref<Record<number, number>>({})
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
+const isRowMode = computed(() => props.variant === 'row')
 
 const showToolbar = computed(() => {
   return (
@@ -712,6 +733,42 @@ const dreamTypes = computed(() => {
 
   return Array.from(set).sort()
 })
+
+/*
+ * interface-vision t-060 — the last of the seven. The grid renders through the
+ * shared kr-gallery shell while dream-card stays the card, so t-064's
+ * reactions, earned karma and edit/archive actions survive. This gallery
+ * already drove MODE_GRID_CLASS and dream-card's `variant` itself, so adopting
+ * the shell is mostly handing over markup it was duplicating.
+ */
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredDreams.value.map((dream) => ({
+    id: dream.id,
+    title: dream.title || `Dream ${dream.id}`,
+    source: dream,
+  })),
+)
+
+/** Slot props give back a GalleryItem, so map the id to the real record. */
+const dreamById = computed(
+  () => new Map(filteredDreams.value.map((d) => [d.id, d])),
+)
+
+/** The card's shared props in one place so row and grid cannot drift. */
+const dreamCardProps = computed(() => ({
+  compact: isCompact.value,
+  showImage: props.showImages,
+  showActions: props.showCardActions,
+  showDescription: props.showDescriptions,
+  showMeta: props.showMeta,
+  showStats: props.showStats,
+  showDebug: props.showDebug,
+  allowEdit: props.allowEdit,
+  allowDelete: props.allowDelete,
+  showPitchSheetPreview: props.showPitchSheetPreview,
+  loadPitchSheetPreview: props.autoLoadSheets,
+  imageFit: 'cover' as const,
+}))
 
 const filteredDreams = computed<DreamWithRelations[]>(() => {
   let dreams = galleryDreams.value

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -300,25 +300,45 @@
         </button>
       </div>
 
-      <div v-else :class="layoutClass">
+      <!-- Row stays bespoke: a horizontal filmstrip is not one of kr-gallery's
+           cards/heroes/icons grids. -->
+      <div v-else-if="isRowMode" :class="layoutClass">
         <reward-card
           v-for="reward in filteredRewards"
           :key="reward.id"
           :reward="reward"
           :selected="rewardStore.selectedReward?.id === reward.id"
-          :show-image="showImages"
-          :compact="isCompact"
-          :show-actions="showCardActions"
-          :show-description="showDescriptions"
-          :show-meta="showMeta"
-          :allow-edit="allowEdit"
-          :allow-delete="allowDelete"
           :earned-karma="earnedKarmaByRewardId[reward.id]"
+          v-bind="rewardCardProps"
           @select="selectReward"
           @edit="startEditingRewardById"
           @delete="handleRewardDeleted"
         />
       </div>
+
+      <!-- t-060: the shared shell owns the grid and the Cards/Heroes/Icons bar;
+           reward-card stays the card. -->
+      <kr-gallery
+        v-else
+        :items="galleryItems"
+        :mode="galleryMode"
+        empty-label="rewards"
+        @update:mode="galleryMode = $event"
+      >
+        <template #item="{ item }">
+          <reward-card
+            v-if="rewardById.get(Number(item.id))"
+            :reward="rewardById.get(Number(item.id))!"
+            :selected="rewardStore.selectedReward?.id === item.id"
+            :earned-karma="earnedKarmaByRewardId[Number(item.id)]"
+            :variant="MODE_VARIANT[galleryMode]"
+            v-bind="rewardCardProps"
+            @select="selectReward"
+            @edit="startEditingRewardById"
+            @delete="handleRewardDeleted"
+          />
+        </template>
+      </kr-gallery>
     </section>
   </section>
 </template>
@@ -326,6 +346,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import type { Reward } from '~/prisma/generated/prisma/client'
+import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
+import { MODE_VARIANT, type GalleryMode } from '@/utils/galleryVocabulary'
 import { useRewardStore } from '@/stores/rewardStore'
 import type { Rarity } from '@/stores/rewardStore'
 import { useUserStore } from '@/stores/userStore'
@@ -403,6 +425,10 @@ const rarityOrder: Record<Rarity, number> = {
 }
 
 const isDropdownMode = computed(() => props.variant === 'dropdown')
+const isRowMode = computed(() => props.variant === 'row')
+
+/** Which of Cards/Heroes/Icons the shared grid is showing. */
+const galleryMode = ref<GalleryMode>('cards')
 
 const isCompact = computed(() => {
   return props.compact || props.variant === 'row' || isDropdownMode.value
@@ -583,6 +609,37 @@ const rarities = computed(() => {
     return rarityOrder[a] - rarityOrder[b]
   })
 })
+
+/*
+ * interface-vision t-060 — grid renders through the shared kr-gallery shell
+ * while reward-card stays the card, so t-064's reactions, earned karma and
+ * edit/archive actions survive the adoption. earnedKarma stays an explicit
+ * per-item binding rather than joining rewardCardProps, because it is looked up
+ * per reward id.
+ */
+const galleryItems = computed<GalleryItem[]>(() =>
+  filteredRewards.value.map((reward) => ({
+    id: reward.id,
+    title: reward.name || `Reward ${reward.id}`,
+    source: reward,
+  })),
+)
+
+/** Slot props give back a GalleryItem, so map the id to the real record. */
+const rewardById = computed(
+  () => new Map(filteredRewards.value.map((r) => [r.id, r])),
+)
+
+/** The card's shared props in one place so row and grid cannot drift. */
+const rewardCardProps = computed(() => ({
+  showImage: props.showImages,
+  compact: isCompact.value,
+  showActions: props.showCardActions,
+  showDescription: props.showDescriptions,
+  showMeta: props.showMeta,
+  allowEdit: props.allowEdit,
+  allowDelete: props.allowDelete,
+}))
 
 const filteredRewards = computed<Reward[]>(() => {
   let rewards = visibleRewards.value


### PR DESCRIPTION
The last three. **`core-object galleries on kr-gallery: 7/7`** — DESIGN-BRIEF's
*"all seven core objects share one gallery"* is closed, every one reachable from
a real route.

```
✓ bot-gallery.vue                      reached from /academy
✓ character-gallery.vue                reached from /academy
✓ dream-gallery.vue                    reached from /academy
✓ facet-gallery.vue                    reached from /facets
✓ reward-gallery.vue                   reached from /academy
✓ scenario-gallery.vue                 reached from /academy
✓ conductor-project-gallery-page.vue   reached from /conductor
```

Three commits, each independently complete and safe to merge at any point.

## The shape, applied three more times

Grid variant renders through `kr-gallery` (mode bar, skeleton/error/empty,
container-responsive grid); the object card stays the card via the `item` slot,
so t-064's reactions, earned karma and edit/clone/archive actions survive the
adoption. `row` and `dropdown` stay bespoke — a horizontal filmstrip and a
`<select>` are not grids, and forcing them through a grid shell would be adoption
for the counter's sake rather than the user's.

Each gallery gets a `<x>CardProps` computed holding the card's shared props, so
the bespoke row layout and the kr-gallery slot can't drift when one gains another.

## Per-gallery notes

**character** — `image-fit="contain"` is carried into the shared props; characters
are portraits and the default `cover` crops them.

**reward** — `earnedKarma` stays an explicit *per-item* binding rather than
joining the shared props, because it's a per-reward-id lookup. Folding it in
would have quietly given every card the same karma.

**dream** — least work of the five despite being the largest file: it already
drove `MODE_GRID_CLASS` and `dream-card`'s `variant` itself, so adopting the shell
is mostly handing over markup it was duplicating. It keeps its **own** mode bar in
the toolbar, so this mount binds `:mode` **and** passes `:modes="[]"` — the shell
needs the mode to pick the right grid, but a second bar for the same state would
be worse than none. Check 3 allows exactly this: it asks that a *visible* bar be
wired, not that every mount show one.

## The contract earned its keep again

`vue-tsc` caught a real bug in the reward slice before it could ship: the gallery
item title read `reward.text`, and `Reward` has no such column (it's `name`).
That's precisely the mistake three near-identical migrations invite, and the
reason each got its own typecheck rather than being pattern-matched through.

## Verification

- `npm run test` (vue-tsc) — **exit 0**
- `test:gallery-consistency` — passes, **7** kr-gallery mounts all bind `:mode` or opt out
- `test:gallery-adoption` — **7/7** core objects, cards still 5/5
- `test:layout-contract` — holds · `test:channel-content` — 0 nav manifest errors
- `prettier` clean

Pre-existing lint left untouched and confirmed against clean `HEAD`: an unused
`characterGenres` in character-gallery, and three `unified-signatures` errors on
dream-gallery's emit overloads.

## What's left of the counter

Overall adoption is 7/24. The other seventeen are non-core galleries, and four of
those (`butterfly`, `lora`, `model`, `lab`) have **no content route rendering
them** — adopting the shell there changes nothing a user can see.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyGEtnjKa2RsV8sTrMtczd)_