### PR TITLE
Backfill Project placements after Build-to-Play cutover

### DIFF
--- a/prisma/migrations/20260804090000_merge_build_channel_into_play/migration.sql
+++ b/prisma/migrations/20260804090000_merge_build_channel_into_play/migration.sql
@@ -1,0 +1,27 @@
+-- Keep existing Kind Robots Project presentation rows aligned with the
+-- Build-to-Play navigation cutover. This is a targeted, reversible data
+-- correction keyed by the stable Conductor join key.
+
+UPDATE `Project`
+SET `channelKey` = 'play', `tabKey` = 'brainstorm', `liveUrl` = '/brainstorm'
+WHERE `conductorSlug` = 'brainstorm';
+
+UPDATE `Project`
+SET `channelKey` = 'play', `tabKey` = 'model-builder', `liveUrl` = '/model-builder'
+WHERE `conductorSlug` = 'model-builder';
+
+UPDATE `Project`
+SET `channelKey` = 'play', `tabKey` = 'packs', `liveUrl` = '/packs'
+WHERE `conductorSlug` = 'packmaker';
+
+UPDATE `Project`
+SET `channelKey` = 'play', `tabKey` = 'mural', `liveUrl` = '/build/mural'
+WHERE `conductorSlug` = 'mural-design';
+
+UPDATE `Project`
+SET `channelKey` = 'play', `tabKey` = 'hair-studio', `liveUrl` = '/build/hair-studio'
+WHERE `conductorSlug` = 'superkate-hairstyle-ai';
+
+UPDATE `Project`
+SET `channelKey` = 'play', `tabKey` = 'animation-manager', `liveUrl` = '/build/animation-manager'
+WHERE `conductorSlug` = 'animation-manager';

--- a/utils/projectPlacements.ts
+++ b/utils/projectPlacements.ts
@@ -52,6 +52,11 @@ export const PROJECT_PLACEMENTS: Record<string, ProjectPlacement> = {
     tabKey: 'model-builder',
     route: '/model-builder',
   },
+  'animation-manager': {
+    channelKey: 'play',
+    tabKey: 'animation-manager',
+    route: '/build/animation-manager',
+  },
   storybook: {
     channelKey: 'play',
     tabKey: 'storybook',


### PR DESCRIPTION
Follow-up to #1419.

The content-driven channel navigation is already live, but six existing Project rows still carry pre-cutover presentation metadata. This PR:

- adds the missing `animation-manager` entry to the canonical Project placement map
- applies a targeted data migration for Brainstorm, Model Builder, Packmaker, Mural Design, Superkate Hairstyle AI, and Animation Manager
- sets each row's `channelKey`, `tabKey`, and `liveUrl` to its live Play destination

The migration is reversible, keyed by stable `conductorSlug`, and does not alter lifecycle or Conductor-projected coordination fields.