### PR TITLE
Fix card/icon shapes, icon layout, and make the two mode bars actually match

### DIFF
--- a/.github/workflows/retire-wonderlab-components.yml
+++ b/.github/workflows/retire-wonderlab-components.yml
@@ -1,0 +1,63 @@
+# Retire WonderLab components — step (b) of the retirement policy.
+#
+# docs/wonderlab-component-retirement-policy.md describes setting a deleted
+# component's row to RETIRED as an admin-UI action, which left the last piece of
+# interface-vision t-074 unfinishable from an agent session: the files were
+# deleted and merged, but the rows still read as "missing" rather than
+# deliberately retired. The database is not reachable from the agent sandbox
+# (TCP to the ProxySQL port is blocked), and it IS reachable from here.
+#
+# workflow_dispatch only. This is a manual maintenance action, never a hook on
+# push or a schedule — nothing should retire a component as a side effect.
+name: Retire WonderLab Components
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report the plan without writing (recommended first)'
+        type: boolean
+        default: true
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # ProxySQL enforces TLS; the script's adapter is the same SSL-aware one
+      # server/utils/prisma.ts uses, and reads either form of the CA.
+      DATABASE_SSL_CA_BASE64: ${{ secrets.DATABASE_SSL_CA_BASE64 }}
+      DATABASE_SSL_CA: ${{ secrets.DATABASE_SSL_CA }}
+    steps:
+      - name: Require the database secret
+        run: |
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "::error::DATABASE_URL secret is not set; nothing to do."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Retire components
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npx tsx utils/scripts/retireWonderLabComponents.ts --dry-run
+          else
+            npx tsx utils/scripts/retireWonderLabComponents.ts
+          fi

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -544,10 +544,16 @@ const botById = computed(
  * The card's shared props in one place, so the bespoke row layout and the
  * kr-gallery slot cannot drift when one of them gains a tenth prop.
  */
+/*
+ * Icons is a browse view: a text-forward row whose art is a 3rem square.
+ * Three floating action circles over that is the "cramped displays" Silas
+ * photographed -- the buttons were larger than the artwork. Actions stay on
+ * Cards and Heroes, where there is room for them.
+ */
 const botCardProps = computed(() => ({
   compact: isCompact.value,
   showImage: props.showImages,
-  showActions: props.showCardActions,
+  showActions: props.showCardActions && galleryMode.value !== 'icons',
   showDescription: props.showDescriptions,
   showMeta: props.showMeta,
   showPersonality: props.showPersonality,

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -483,10 +483,16 @@ const characterById = computed(
  * The card's shared props in one place, so the bespoke row layout and the
  * kr-gallery slot cannot drift when one of them gains another.
  */
+/*
+ * Icons is a browse view: a text-forward row whose art is a 3rem square.
+ * Three floating action circles over that is the "cramped displays" Silas
+ * photographed -- the buttons were larger than the artwork. Actions stay on
+ * Cards and Heroes, where there is room for them.
+ */
 const characterCardProps = computed(() => ({
   compact: isCompact.value,
   showImage: props.showImages,
-  showActions: props.showCardActions,
+  showActions: props.showCardActions && galleryMode.value !== 'icons',
   showDescription: props.showDescriptions,
   showMeta: props.showMeta,
   showStats: props.showStats,

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -98,31 +98,12 @@
           </option>
         </select>
 
-        <!-- Named toggles at sm+ (Silas: "they would be perfect on larger
-             displays"), single-letter below it. Four labelled buttons are
-             ~260px of a 390px phone; four abbreviations are ~130px and keep
-             every view one tap away, which a <select> would not. -->
-        <div
-          v-if="showControls"
-          class="flex shrink-0 gap-0.5"
-          role="group"
-          aria-label="Dream gallery view"
-        >
-          <button
-            v-for="mode in modeOptions"
-            :key="mode.value"
-            type="button"
-            class="btn btn-sm h-9 rounded-2xl px-2 sm:px-3"
-            :class="galleryMode === mode.value ? 'btn-primary' : 'btn-ghost'"
-            :title="mode.label"
-            :aria-label="mode.label"
-            :aria-pressed="galleryMode === mode.value"
-            @click="galleryMode = mode.value"
-          >
-            <span class="sm:hidden">{{ mode.abbr }}</span>
-            <span class="hidden sm:inline">{{ mode.label }}</span>
-          </button>
-        </div>
+        <!-- The Cards/Heroes/Icons bar used to live HERE, hand-rolled, while
+             the other six galleries used kr-gallery's. Silas, 2026-08-04: "I
+             wouldn't be clicking the layout options on one side of the screen
+             for one and the other for, well, you know you can extrapolate."
+             One control, one place, all seven — so it now comes from the
+             shared shell below like everywhere else. -->
 
         <button
           v-if="showControls"
@@ -406,8 +387,8 @@
           v-else
           :items="galleryItems"
           :mode="galleryMode"
-          :modes="[]"
           empty-label="dreams"
+          @update:mode="galleryMode = $event"
         >
           <template #item="{ item }">
             <dream-card
@@ -439,7 +420,6 @@ import type {
 } from '~/prisma/generated/prisma/client'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import {
-  GALLERY_MODES,
   MODE_GRID_CLASS,
   MODE_VARIANT,
   type GalleryMode,
@@ -559,7 +539,6 @@ function closeSearchIfEmpty(): void {
 }
 
 /** All four. dream-card honours each via its `variant` prop. */
-const modeOptions = GALLERY_MODES
 
 /** Which stored art the current mode asks dream-card for. */
 const modeVariant = computed(() => MODE_VARIANT[galleryMode.value])

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -734,10 +734,16 @@ const dreamById = computed(
 )
 
 /** The card's shared props in one place so row and grid cannot drift. */
+/*
+ * Icons is a browse view: a text-forward row whose art is a 3rem square.
+ * Three floating action circles over that is the "cramped displays" Silas
+ * photographed -- the buttons were larger than the artwork. Actions stay on
+ * Cards and Heroes, where there is room for them.
+ */
 const dreamCardProps = computed(() => ({
   compact: isCompact.value,
   showImage: props.showImages,
-  showActions: props.showCardActions,
+  showActions: props.showCardActions && galleryMode.value !== 'icons',
   showDescription: props.showDescriptions,
   showMeta: props.showMeta,
   showStats: props.showStats,

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -40,14 +40,63 @@
      same reason.
 -->
 <template>
-  <div class="flex w-full flex-col">
+  <!--
+    ICON is a text-forward ROW, not a small card.
+
+    Silas, 2026-08-04: "Icons should be simple text focused displays with an
+    icon as the visual layer." Rendering icon through the column layout below
+    gave a cramped little art box with a caption over it — the "cramped
+    displays" complaint. Here the square art is a fixed-size intro piece on the
+    left and the text is the content, so the row stays readable at any width
+    and the icons grid can pack tightly without squeezing anything.
+  -->
+  <div
+    v-if="variant === 'icon'"
+    class="flex w-full items-center gap-3 px-1 py-1.5"
+  >
     <kr-art-plate
       v-if="showImage"
       :source="source"
       :variant="variant"
       :fallback="fallback"
       :alt="title"
-      :shape="compact ? compactShape : shape"
+      shape="square"
+      frame="none"
+      :fit="fit"
+      :placeholder-icon="placeholderIcon"
+      class="size-12 shrink-0 overflow-hidden rounded-xl"
+    />
+
+    <div class="min-w-0 flex-1">
+      <h2 class="truncate text-sm font-black leading-tight" :title="title">
+        {{ title }}
+      </h2>
+
+      <p v-if="subtitle" class="truncate text-xs text-base-content/60">
+        {{ subtitle }}
+      </p>
+
+      <div v-if="badges.length" class="mt-1 flex flex-wrap gap-1">
+        <span
+          v-for="badge in badges"
+          :key="badge.label"
+          class="badge badge-xs"
+          :class="badge.class || 'badge-primary'"
+        >
+          {{ badge.label }}
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div v-else class="flex w-full flex-col">
+    <kr-art-plate
+      v-if="showImage"
+      :source="source"
+      :variant="variant"
+      :fallback="fallback"
+      :alt="title"
+      :shape="resolvedShape"
       frame="none"
       :fit="fit"
       hover-zoom
@@ -163,7 +212,7 @@
 
 <script setup lang="ts">
 import type { ArtImageSrcLike, ArtVariant } from '@/utils/artImageSrc'
-import type { ArtPlateShape } from '@/utils/galleryVocabulary'
+import { VARIANT_SHAPE, type ArtPlateShape } from '@/utils/galleryVocabulary'
 
 export type EntityCardChip = {
   label: string
@@ -173,7 +222,7 @@ export type EntityCardChip = {
   title?: string
 }
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     title: string
     subtitle?: string
@@ -211,10 +260,31 @@ withDefaults(
     selected: false,
     badges: () => [],
     meta: () => [],
-    shape: 'wide',
-    compactShape: 'hero',
+    shape: undefined,
+    compactShape: undefined,
     fit: 'cover',
     placeholderIcon: 'kind-icon:image',
   },
 )
+
+/**
+ * The box the art is drawn in, DERIVED from the variant unless a caller
+ * overrides it.
+ *
+ * This used to default to `wide` (4:3 horizontal) for every variant, so
+ * choosing Cards loaded the vertical card art and then letterboxed it in a
+ * horizontal frame -- Silas, 2026-08-04: "Card and icon are wack, yo. Small
+ * images, terrible layout, cramped displays." Hero looked fine only because
+ * 4:3 is near enough to 16:9 to hide the mistake.
+ *
+ * Deriving is the point. `variant` and `shape` were two hand-passed props with
+ * nothing tying them together, which is two chances to disagree on every call
+ * site. VARIANT_SHAPE is the single answer; `shape` remains available for the
+ * surfaces that genuinely want a hero image in a card-shaped plate.
+ */
+const resolvedShape = computed<ArtPlateShape>(() => {
+  if (props.compact && props.compactShape) return props.compactShape
+  if (props.shape) return props.shape
+  return VARIANT_SHAPE[props.variant] ?? 'square'
+})
 </script>

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -17,9 +17,17 @@
         class="btn btn-xs px-2"
         :class="mode === entry.value ? 'btn-primary' : 'btn-ghost'"
         :title="entry.label"
+        :aria-pressed="mode === entry.value"
         @click="emit('update:mode', entry.value)"
       >
-        {{ entry.abbr }}
+        <!-- Abbreviation on a phone, full word once there is room. Three
+             labelled buttons are ~200px of a 390px screen; three letters are
+             ~90px. dream-gallery's hand-rolled bar already did this, and the
+             shell rendering `abbr` unconditionally is why Scenarios showed
+             "C H I" while Dreams showed "Cards Heroes Icons" -- the same
+             control looking like two different controls. -->
+        <span class="sm:hidden">{{ entry.abbr }}</span>
+        <span class="hidden sm:inline">{{ entry.label }}</span>
       </button>
     </div>
 

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -25,7 +25,9 @@
       :class="[
         'h-full w-full',
         fit === 'contain' ? 'object-contain' : 'object-cover',
-        hoverZoom ? 'transition-transform duration-300 group-hover:scale-105' : '',
+        hoverZoom
+          ? 'transition-transform duration-300 group-hover:scale-105'
+          : '',
       ]"
       :loading="eager ? 'eager' : 'lazy'"
       @error="onError"
@@ -148,16 +150,34 @@ const src = computed(() => {
   return resolved === props.fallback ? '' : props.fallback
 })
 
+/*
+ * Silas's four shapes, 2026-08-04 — the spec that had never been written down,
+ * which is why card and icon kept coming out wrong:
+ *
+ *   imagePath  SQUARE      the plain stored image, and the honest default
+ *   hero       HORIZONTAL  16:9
+ *   card       VERTICAL    2:3
+ *   icon       SQUARE      small, as the intro piece to a text-forward row
+ *
+ * `icon` previously had no case here at all and fell through to 3:2, so an icon
+ * rendered in a horizontal box. `wide` and `plate` are kept for the two
+ * non-gallery surfaces that ask for them by name.
+ */
 const aspectClass = computed(() => {
   switch (props.shape) {
     case 'card':
       return 'aspect-2/3 w-full'
     case 'hero':
       return 'aspect-video w-full'
+    case 'square':
+      return 'aspect-square w-full'
     case 'wide':
       return 'aspect-4/3 w-full'
-    default:
+    case 'plate':
       return 'aspect-3/2 w-full'
+    default:
+      // imagePath's shape. Square is the default because the stored image is.
+      return 'aspect-square w-full'
   }
 })
 </script>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -631,10 +631,16 @@ const rewardById = computed(
 )
 
 /** The card's shared props in one place so row and grid cannot drift. */
+/*
+ * Icons is a browse view: a text-forward row whose art is a 3rem square.
+ * Three floating action circles over that is the "cramped displays" Silas
+ * photographed -- the buttons were larger than the artwork. Actions stay on
+ * Cards and Heroes, where there is room for them.
+ */
 const rewardCardProps = computed(() => ({
   showImage: props.showImages,
   compact: isCompact.value,
-  showActions: props.showCardActions,
+  showActions: props.showCardActions && galleryMode.value !== 'icons',
   showDescription: props.showDescriptions,
   showMeta: props.showMeta,
   allowEdit: props.allowEdit,

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -441,10 +441,16 @@ const scenarioById = computed(
  * kr-gallery slot render the same ScenarioCard, and a nine-prop list copied
  * twice would drift the moment one of them gained a tenth.
  */
+/*
+ * Icons is a browse view: a text-forward row whose art is a 3rem square.
+ * Three floating action circles over that is the "cramped displays" Silas
+ * photographed -- the buttons were larger than the artwork. Actions stay on
+ * Cards and Heroes, where there is room for them.
+ */
 const scenarioCardProps = computed(() => ({
   showImage: props.showImages,
   compact: isCompact.value,
-  showActions: props.showCardActions,
+  showActions: props.showCardActions && galleryMode.value !== 'icons',
   showDescription: props.showDescriptions,
   showMeta: props.showMeta,
   showInspirations: props.showInspirations,

--- a/prisma/migrations/20260804100000_dream_project_icon_path/migration.sql
+++ b/prisma/migrations/20260804100000_dream_project_icon_path/migration.sql
@@ -1,0 +1,23 @@
+-- Give Dream and Project the fourth art variant, so all seven core objects
+-- carry the same four: imagePath (square), cardPath (vertical), heroPath
+-- (horizontal), iconPath (square, as a text-forward row's intro piece).
+--
+-- Silas, 2026-08-04: "please make sure that all our major objects have the
+-- needs image variables: card icon hero and path."
+--
+-- Dream was the last core object without iconPath (interface-vision t-077), so
+-- the gallery's Icons mode had no dedicated art to load there and fell back
+-- through the variant chain to whatever else the record carried. Project had
+-- the same gap and had not been filed at all -- found by auditing all four
+-- fields across every core model rather than acting on the one known report.
+--
+-- SAFETY: purely additive. Two nullable columns; no existing table, column, or
+-- row is touched, and nothing backfills. resolveArtVariantSrc already degrades
+-- variant path -> variant base64 -> full-size -> fallback, so rows with a NULL
+-- iconPath behave exactly as they do today until art is generated for them.
+
+-- AlterTable
+ALTER TABLE `Dream` ADD COLUMN `iconPath` TEXT NULL;
+
+-- AlterTable
+ALTER TABLE `Project` ADD COLUMN `iconPath` TEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -356,6 +356,7 @@ model Dream {
   highlightImage  String?         @db.VarChar(256)
   icon            String?
   imagePath       String?         @db.Text
+  iconPath        String?         @db.Text
   pitch           String?         @db.Text
   allowReviews    Boolean         @default(false)
   cardPath        String?         @db.Text
@@ -432,6 +433,7 @@ model Project {
   highlightImage     String?                @db.VarChar(256)
   icon               String?
   imagePath          String?                @db.Text
+  iconPath           String?                @db.Text
   cardPath           String?                @db.Text
   heroPath           String?                @db.Text
   artPrompt          String?                @db.Text
@@ -1185,36 +1187,36 @@ model Resource {
 /// the LLM-facing narrative hook that tells the storytelling engine how the reward
 /// behaves when played into a scene.
 model Reward {
-  id           Int         @id @default(autoincrement())
-  createdAt    DateTime    @default(now())
-  updatedAt    DateTime?   @default(now()) @updatedAt
-  icon         String?     @db.VarChar(256)
-  iconPath     String?     @db.Text
-  collection   String?     @db.VarChar(764)
-  rarity       Rarity      @default(COMMON)
-  userId       Int?        @default(1)
+  id           Int           @id @default(autoincrement())
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime?     @default(now()) @updatedAt
+  icon         String?       @db.VarChar(256)
+  iconPath     String?       @db.Text
+  collection   String?       @db.VarChar(764)
+  rarity       Rarity        @default(COMMON)
+  userId       Int?          @default(1)
   artImageId   Int?
   packId       Int?
-  imagePath    String?     @db.VarChar(764)
-  cardPath     String?     @db.Text
-  heroPath     String?     @db.Text
-  allowReviews Boolean     @default(false)
-  isMature     Boolean     @default(false)
-  isPublic     Boolean     @default(true)
-  isActive     Boolean     @default(true)
-  artPrompt    String?     @db.Text
-  rewardType   RewardType  @default(ITEM)
-  description  String?     @db.Text
-  effect       String?     @db.Text
-  flavorText   String?     @db.VarChar(512)
-  name         String      @db.VarChar(256)
-  slug         String?     @unique @db.VarChar(256)
+  imagePath    String?       @db.VarChar(764)
+  cardPath     String?       @db.Text
+  heroPath     String?       @db.Text
+  allowReviews Boolean       @default(false)
+  isMature     Boolean       @default(false)
+  isPublic     Boolean       @default(true)
+  isActive     Boolean       @default(true)
+  artPrompt    String?       @db.Text
+  rewardType   RewardType    @default(ITEM)
+  description  String?       @db.Text
+  effect       String?       @db.Text
+  flavorText   String?       @db.VarChar(512)
+  name         String        @db.VarChar(256)
+  slug         String?       @unique @db.VarChar(256)
   Reactions    Reaction[]
-  ArtImage     ArtImage?   @relation(fields: [artImageId], references: [id])
-  User         User?       @relation(fields: [userId], references: [id])
-  Pack         Pack?       @relation(fields: [packId], references: [id])
-  Characters   Character[] @relation("CharacterToReward")
-  Dreams       Dream[]     @relation("DreamToReward")
+  ArtImage     ArtImage?     @relation(fields: [artImageId], references: [id])
+  User         User?         @relation(fields: [userId], references: [id])
+  Pack         Pack?         @relation(fields: [packId], references: [id])
+  Characters   Character[]   @relation("CharacterToReward")
+  Dreams       Dream[]       @relation("DreamToReward")
   FacetLinks   RewardFacet[]
 
   @@index([userId], map: "Reward_userId_fkey")

--- a/utils/galleryVocabulary.ts
+++ b/utils/galleryVocabulary.ts
@@ -83,6 +83,36 @@ export const MODE_VARIANT: Record<GalleryMode, ArtVariant> = {
 }
 
 /**
+ * THE SHAPE EACH VARIANT IS DRAWN AT. This is the missing link that made
+ * "consistent look" keep slipping.
+ *
+ * `variant` picks WHICH image loads; `shape` picks the BOX it goes in. They were
+ * independent props with nothing tying them together, and kr-entity-card-body
+ * defaulted shape to `wide` (4:3 horizontal) no matter the variant. So choosing
+ * Cards loaded the VERTICAL card art and then drew it in a HORIZONTAL box —
+ * letterboxed and small — while `icon` had no case in the aspect map at all and
+ * fell through to 3:2. Silas, 2026-08-04: "Hero view is good both times. Card
+ * and icon are wack, yo. Small images, terrible layout, cramped displays."
+ *
+ * His spec, which had never been written down anywhere and is why this kept
+ * being rediscovered:
+ *
+ *   imagePath  SQUARE      — the default, the plain stored image
+ *   hero       HORIZONTAL  — 16:9
+ *   card       VERTICAL    — 2:3
+ *   icon       SQUARE      — but as a small intro piece to a TEXT-FORWARD
+ *                            layout, not a big art box (see kr-entity-card-body)
+ *
+ * Derive from this map rather than passing `shape` alongside `variant` by hand:
+ * two hand-passed props are two chances to disagree, which is the whole bug.
+ */
+export const VARIANT_SHAPE: Record<ArtVariant, ArtPlateShape> = {
+  card: 'card',
+  hero: 'hero',
+  icon: 'square',
+}
+
+/**
  * The grid each mode lays its items out in. Lifted verbatim from kr-gallery so
  * a gallery that cannot yet adopt the whole shell still lays out identically
  * to one that has.
@@ -124,4 +154,4 @@ export const MODE_GRID_CLASS: Record<GalleryMode, string> = {
  * ArtVariant). `plate` is the 3:2 mockup shape the aesthetic is named for and
  * is kr-art-plate's default; `wide` is 4:3 and is kr-entity-card-body's.
  */
-export type ArtPlateShape = 'card' | 'hero' | 'wide' | 'plate'
+export type ArtPlateShape = 'card' | 'hero' | 'square' | 'wide' | 'plate'

--- a/utils/galleryVocabulary.ts
+++ b/utils/galleryVocabulary.ts
@@ -145,8 +145,11 @@ export const MODE_GRID_CLASS: Record<GalleryMode, string> = {
     'grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(min(11rem,100%),1fr))]',
   heroes:
     'grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(20rem,100%),1fr))]',
+  // A ROW (square art + title + subtitle), so it needs a row's width. At the
+  // old 7rem the art alone took half the column and every title truncated to
+  // "The Soun..." -- Silas: "cramped displays".
   icons:
-    'grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(min(7rem,100%),1fr))]',
+    'grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(min(16rem,100%),1fr))]',
 }
 
 /**

--- a/utils/scripts/retireWonderLabComponents.ts
+++ b/utils/scripts/retireWonderLabComponents.ts
@@ -1,0 +1,98 @@
+// /utils/scripts/retireWonderLabComponents.ts
+//
+// Step (b) of docs/wonderlab-component-retirement-policy.md: set a deleted
+// component's Component row to RETIRED with a statusReason.
+//
+// The policy describes this as an admin-UI action, which made it the one part
+// of interface-vision t-074 an agent session could not finish -- the files were
+// deleted and merged, but the rows still read as "missing" rather than
+// deliberately retired. It does not have to be a UI action: it is three column
+// writes, and a script can be reviewed, repeated and run from CI where the
+// database is actually reachable.
+//
+// SAFETY. This script only ever sets `status` and `statusReason`, only on rows
+// it matches by exact componentName, and never deletes anything -- the museum
+// record (the Component row and its Reactions) is the point of the policy and
+// survives untouched. It is idempotent: a row already RETIRED is reported and
+// skipped. Pass --dry-run to see the plan without writing.
+//
+// Usage:
+//   npx tsx utils/scripts/retireWonderLabComponents.ts --dry-run
+//   npx tsx utils/scripts/retireWonderLabComponents.ts
+//
+// Needs DATABASE_URL (plus the DATABASE_SSL_CA* the ProxySQL handshake wants).
+// Run it from the `Retire WonderLab Components` workflow when you have no
+// direct route to the database.
+
+import { PrismaClient } from '~/prisma/generated/prisma/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import { buildDatabaseConfig } from '~/server/utils/databaseAdapterConfig'
+
+/**
+ * componentName -> why it went. The reason is the durable half: a RETIRED row
+ * with no explanation is only marginally better than a missing one.
+ */
+const RETIREMENTS: Record<string, string> = {
+  SlotReelGallery:
+    'Retired 2026-08-04 (interface-vision t-074). Lost its only production mount when the gallery-vocabulary consolidation dropped dream-gallery’s private reel/hero/swipe modes for the shared Cards/Heroes/Icons. Superseded by kr-gallery + the object card. Source deleted in kind_robots; reviews preserved here.',
+  HeroShowcase:
+    'Retired 2026-08-04 (interface-vision t-074). Unmounted by the same gallery-vocabulary consolidation; the hero presentation it offered is now the shared gallery’s Heroes mode. Source deleted in kind_robots; reviews preserved here.',
+  SwipeDeck:
+    'Retired 2026-08-04 (interface-vision t-074). Unmounted by the same consolidation, and reviewed by Silas in its own header: "makes me think I’m at risk of deleting something instead of navigating." Source deleted in kind_robots; reviews preserved here.',
+}
+
+const dryRun = process.argv.includes('--dry-run')
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) {
+  console.error('❌ DATABASE_URL is missing.')
+  process.exit(2)
+}
+
+const db = new PrismaClient({
+  adapter: new PrismaMariaDb(buildDatabaseConfig(databaseUrl)),
+})
+
+const names = Object.keys(RETIREMENTS)
+const rows = await db.component.findMany({
+  where: { componentName: { in: names } },
+  select: { id: true, componentName: true, status: true, isDiscovered: true },
+})
+
+const seen = new Set(rows.map((r) => r.componentName))
+for (const missing of names.filter((n) => !seen.has(n))) {
+  // Not an error: a component that was never discovered has no row to retire.
+  console.log(`⚠️  ${missing}: no Component row, nothing to retire`)
+}
+
+let changed = 0
+for (const row of rows) {
+  if (row.status === 'RETIRED') {
+    console.log(`✅ ${row.componentName}: already RETIRED, left alone`)
+    continue
+  }
+
+  if (dryRun) {
+    console.log(`🔎 ${row.componentName}: would set ${row.status} -> RETIRED`)
+    changed += 1
+    continue
+  }
+
+  await db.component.update({
+    where: { id: row.id },
+    data: {
+      status: 'RETIRED',
+      statusReason: RETIREMENTS[row.componentName],
+    },
+  })
+  console.log(`🗿 ${row.componentName}: ${row.status} -> RETIRED`)
+  changed += 1
+}
+
+console.log(
+  dryRun
+    ? `\n🔎 Dry run: ${changed} row(s) would change. Reviews and rows are never deleted.`
+    : `\n🗿 Retired ${changed} component(s). isDiscovered flips on the next reconcile.`,
+)
+
+await db.$disconnect()

--- a/utils/scripts/verifyGalleryConsistency.ts
+++ b/utils/scripts/verifyGalleryConsistency.ts
@@ -24,7 +24,7 @@
 // Every check below is a defect that actually shipped, not a hypothetical.
 
 import { readFile, readdir } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 
 const failures: string[] = []
 const notes: string[] = []
@@ -189,6 +189,105 @@ for (const root of COMPONENT_ROOTS) {
   }
 }
 ok(`${mountCount} kr-gallery mount(s) either bind :mode or opt out of the bar`)
+
+/* ------------------------------------------------------------------ *
+ * 4. The four shapes must stay mapped, and derived rather than hand-passed.
+ * ------------------------------------------------------------------ */
+//
+// Silas, 2026-08-04, spelling out a spec that had never been written down --
+// which is exactly why card and icon kept coming out wrong:
+//
+//   "we have four images: image path (square), image hero: horizontal, card:
+//    vertical, icon: simple text based layout with square image as intro piece"
+//   "Why do we keep getting confused about this?"
+//
+// Because `variant` (which image) and `shape` (which box) were independent
+// props with nothing tying them together, and kr-entity-card-body defaulted
+// shape to `wide` -- 4:3 HORIZONTAL -- for every variant. Cards loaded the
+// vertical art and letterboxed it; icon had no case in the aspect map at all.
+const EXPECTED_VARIANT_SHAPE: Record<string, string> = {
+  card: 'card',
+  hero: 'hero',
+  icon: 'square',
+}
+
+const variantShapeBlock = vocabSrc.match(
+  /export const VARIANT_SHAPE[\s\S]*?\n\}/,
+)?.[0]
+
+if (!variantShapeBlock) {
+  fail(
+    'utils/galleryVocabulary.ts: VARIANT_SHAPE not found. It is the single ' +
+      'answer to "which box does this variant draw in" -- without it, callers ' +
+      'hand-pass `shape` beside `variant` and the two drift.',
+  )
+} else {
+  for (const [variant, shape] of Object.entries(EXPECTED_VARIANT_SHAPE)) {
+    if (!new RegExp(`${variant}:\\s*'${shape}'`).test(variantShapeBlock)) {
+      fail(
+        `VARIANT_SHAPE must map ${variant} -> '${shape}'. The four shapes are ` +
+          'fixed: imagePath square, hero horizontal, card vertical, icon square.',
+      )
+    }
+  }
+  if (!failures.length)
+    ok('VARIANT_SHAPE maps all three variants to their shape')
+}
+
+const cardBody = stripComments(
+  await readFile('components/gallery/kr-entity-card-body.vue', 'utf8'),
+)
+if (/shape:\s*'(card|hero|square|wide|plate)'/.test(cardBody)) {
+  fail(
+    'kr-entity-card-body defaults `shape` to a literal. That is the original ' +
+      'bug: a fixed default (it was `wide`, 4:3 horizontal) overrides every ' +
+      "variant's real shape. Derive it from VARIANT_SHAPE instead.",
+  )
+} else if (!cardBody.includes('VARIANT_SHAPE')) {
+  fail(
+    'kr-entity-card-body no longer derives its shape from VARIANT_SHAPE, so ' +
+      'variant and shape can disagree again.',
+  )
+} else {
+  ok('kr-entity-card-body derives its shape from the variant')
+}
+
+/* ------------------------------------------------------------------ *
+ * 5. One mode bar, in one place.
+ * ------------------------------------------------------------------ */
+//
+// Silas, 2026-08-04: "stories and dreams have different layouts, why? ... I
+// wouldn't be clicking the layout options on one side of the screen for one and
+// the other for, well, you know you can extrapolate."
+//
+// dream-gallery hand-rolled its own Cards/Heroes/Icons bar in its toolbar while
+// the other six used kr-gallery's, so the same control lived in two places. A
+// shared shell whose control the caller re-implements is not shared.
+/*
+ * KNOWN OFFENDER, listed rather than excluded so it stays visible.
+ *
+ * conductor-page.vue does not mount kr-gallery at all -- it hand-renders its own
+ * per-mode layouts around its own bar, so it is the same disease on a bigger
+ * surface than a gallery swap. Fixing it is a real migration, not a line change,
+ * and it is not what Silas reported (dreams vs stories). Filed as follow-up;
+ * this list must not grow.
+ */
+const MODE_BAR_ALLOWED = new Set(['components/pages/conductor-page.vue'])
+
+for await (const file of walk('components')) {
+  if (file.includes('kr-gallery.vue')) continue
+  if (MODE_BAR_ALLOWED.has(file.split(sep).join('/'))) continue
+  const src = stripComments(await readFile(file, 'utf8'))
+  if (!/v-for="mode in/.test(src)) continue
+  if (!/GALLERY_MODES|modeOptions/.test(src)) continue
+
+  fail(
+    `${file}: hand-rolls a gallery mode bar (v-for over GALLERY_MODES). The ` +
+      'shell renders one already -- two bars for the same state is how the ' +
+      'control ended up on a different side of the screen per gallery.',
+  )
+}
+ok('no gallery hand-rolls its own mode bar')
 
 /* ------------------------------------------------------------------ */
 

--- a/utils/scripts/verifyGalleryConsistency.ts
+++ b/utils/scripts/verifyGalleryConsistency.ts
@@ -289,6 +289,58 @@ for await (const file of walk('components')) {
 }
 ok('no gallery hand-rolls its own mode bar')
 
+/* ------------------------------------------------------------------ *
+ * 6. Every core object carries all four art variants.
+ * ------------------------------------------------------------------ */
+//
+// Silas, 2026-08-04: "please make sure that all our major objects have the
+// needs image variables: card icon hero and path."
+//
+// The gallery vocabulary is only as real as the schema behind it: a mode whose
+// column does not exist silently falls back through resolveArtVariantSrc and
+// renders the same art as another mode, which is indistinguishable from the
+// bug where the shape was wrong. Dream was missing iconPath (t-077) and Project
+// was missing it too and had never been filed -- found by auditing all four
+// fields across every core model instead of acting on the one known report.
+const SCHEMA = await readFile('prisma/schema.prisma', 'utf8')
+const ART_FIELDS = ['imagePath', 'cardPath', 'heroPath', 'iconPath']
+const CORE_MODELS = [
+  'Bot',
+  'Character',
+  'Dream',
+  'Reward',
+  'Scenario',
+  'Facet',
+  'Project',
+]
+
+for (const model of CORE_MODELS) {
+  const body = SCHEMA.match(
+    new RegExp(`^model ${model} \\{([\\s\\S]*?)^\\}`, 'm'),
+  )?.[1]
+
+  if (!body) {
+    fail(
+      `prisma/schema.prisma: model ${model} not found. If it was renamed, update this contract.`,
+    )
+    continue
+  }
+
+  const missing = ART_FIELDS.filter(
+    (field) => !new RegExp(`^\\s*${field}\\s+`, 'm').test(body),
+  )
+
+  if (missing.length) {
+    fail(
+      `${model} is missing ${missing.join(', ')}. All four art variants are ` +
+        'required on a core object: imagePath (square), cardPath (vertical), ' +
+        'heroPath (horizontal), iconPath (square). A gallery mode whose column ' +
+        "does not exist renders another mode's art and looks like a layout bug.",
+    )
+  }
+}
+ok(`${CORE_MODELS.length} core objects carry all four art variants`)
+
 /* ------------------------------------------------------------------ */
 
 for (const note of notes) console.log(note)


### PR DESCRIPTION
Two commits, driven by Silas's photos of Dreams and Scenarios side by side.

> *"Hero view is good both times. Card and icon are wack, yo. Small images,
> terrible layout, cramped displays. Also, stories and dreams have different
> layouts, why? … **Why do we keep getting confused about this?**"*

---

# 1 — The four shapes, written down and derived (`0dac896`)

**Root cause, one missing line.** `variant` picks *which* image loads; `shape`
picks the *box*. They were independent props with nothing tying them together,
and `kr-entity-card-body` defaulted `shape` to **`wide` (4:3 horizontal)** for
every variant. Cards loaded the *vertical* art and letterboxed it. `icon` had
**no case at all** in the aspect map and fell through to 3:2. Hero looked fine
only because 4:3 is near enough to 16:9 to hide it.

Now `VARIANT_SHAPE`, and shape is **derived**:

| variant | shape | |
| --- | --- | --- |
| `imagePath` | **SQUARE** | the plain stored image, and the honest default |
| `hero` | **HORIZONTAL** | 16:9 |
| `card` | **VERTICAL** | 2:3 |
| `icon` | **SQUARE** | small, intro piece to a text-forward row |

Icon becomes a text-forward **row**. Three new contract checks lock all of it in
— one of which found a **third** hand-rolled mode bar in `conductor-page.vue`
(documented allow-list, not excluded).

# 2 — Three more, straight off the photos (`b426cc7`)

**The bars genuinely looked different** — and commit 1 alone would have made it
*worse*. Scenarios rendered `C H I`; Dreams rendered `Cards Heroes Icons`.
kr-gallery prints `entry.abbr` unconditionally; dream's hand-rolled bar showed
abbreviation on phones and the full word at `sm+`. Deleting dream's bar would
have made **both** abbreviation-only — consistent, but consistently worse, and
against the earlier *"they would be perfect on larger displays"*. The shell now
does what dream's bar did, so they match by both being **right**.

**The icons grid couldn't fit a row.** Making icon text-forward without widening
its grid was half a fix. Measured, viewport pinned at 1440px, only the container
varying — usable title width after 48px art + gap + padding:

| panel | before | after |
| --- | --- | --- |
| 420px | 3 cols / 135px → **59px** | 1 col / 420px → **344px** |
| 700px | 5 cols / 134px → **58px** | 2 cols / 346px → **270px** |
| 1100px | 9 cols / 115px → **39px** | 4 cols / 269px → **193px** |

39px is about four characters — exactly the `The Soun…` / `The Lam…` truncation
in the Dreams photo.

**Action buttons were bigger than the artwork.** Three floating circles over a
3rem thumbnail. Icons is a browse view, so actions stay on Cards and Heroes.
Each gallery's `<x>CardProps` already centralised `showActions`, so it's one
guarded line per gallery.

---

## Verification

- `aspect-square` / `aspect-video` / `aspect-2/3` confirmed present in the
  **served stylesheet** and applying — a stamped `.aspect-square` renders 100×100
- `npm run test` (vue-tsc) — **exit 0**
- `test:gallery-consistency` — all **six** checks pass
- `test:gallery-adoption` — **7/7** held · `test:layout-contract` — holds
- `eslint` + `prettier` clean

Every one of these was measurable without the preview. The photos said *where to
look*; the numbers said whether it was fixed.