### PR TITLE
layout: kr-panes/kr-pane/kr-pane-scroll multi-owner scroll primitive

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -302,6 +302,37 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply flex min-h-0 flex-1 flex-col overflow-hidden;
   }
 
+  /*
+   * ── Multi-owner scroll primitives (interface-vision t-058) ───────────
+   * .kr-scroll above is capped at exactly one per .kr-surface by design --
+   * some layouts (a two-pane inspector, a three-pane editor) legitimately
+   * need more than one region scrolling independently at once. These three
+   * are that documented exception: adopting .kr-panes is what legitimizes
+   * multiple scroll owners in one component (see the `one-scroll` rule in
+   * utils/scripts/verifyLayoutContract.ts) -- undeclared/ad-hoc multi-scroll
+   * still violates the contract.
+   */
+
+  /* Grid container for N independent panes. Caller supplies grid-cols
+     (responsive column templates are layout-specific, not primitive-owned). */
+  .kr-panes {
+    @apply grid min-h-0 flex-1 gap-4 overflow-hidden;
+  }
+
+  /* One pane's non-scrolling shell -- same role .kr-surface plays for a
+     whole page, scoped to a single grid cell. Give it its own .kr-toolbar
+     row above a .kr-pane-scroll child when the pane needs one. */
+  .kr-pane {
+    @apply flex min-h-0 min-w-0 flex-col overflow-hidden;
+  }
+
+  /* One pane's scroll owner -- the .kr-scroll idiom, scoped to a pane. A
+     pane with nothing else in it may carry this directly instead of an
+     empty wrapping .kr-pane. */
+  .kr-pane-scroll {
+    @apply min-h-0 flex-1 overflow-y-auto overscroll-contain;
+  }
+
   /* Root-satisfying marker with NO overflow/height behavior of its own
      (interface-vision t-057/t-059). For MDC-mounted -page.vue components
      rendered inside pages/[...slug].vue's own scrolling content-host: that

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -130,10 +130,10 @@
 
     <div
       v-else
-      class="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-hidden xl:grid-cols-[minmax(280px,420px)_minmax(0,1fr)]"
+      class="kr-panes gap-3 grid-cols-1 xl:grid-cols-[minmax(280px,420px)_minmax(0,1fr)]"
     >
       <!-- Aside: image preview -->
-      <aside class="flex min-h-0 flex-col gap-3 overflow-auto">
+      <aside class="kr-pane-scroll flex flex-col gap-3">
         <image-card
           :art-image="currentArtImage"
           :selected="true"
@@ -198,7 +198,7 @@
 
       <!-- Main: editing panel -->
       <main
-        class="min-h-0 overflow-auto rounded-2xl border border-base-300 bg-base-100"
+        class="kr-pane-scroll rounded-2xl border border-base-300 bg-base-100"
       >
         <div class="grid gap-3 p-3">
           <!-- Quick Edit -->

--- a/components/characters/character-interact.vue
+++ b/components/characters/character-interact.vue
@@ -28,9 +28,9 @@
 
     <section
       v-else
-      class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-[minmax(320px,440px)_minmax(0,1fr)]"
+      class="kr-panes grid-cols-1 xl:grid-cols-[minmax(320px,440px)_minmax(0,1fr)]"
     >
-      <aside class="flex min-h-0 flex-col gap-4 overflow-y-auto">
+      <aside class="kr-pane-scroll flex flex-col gap-4">
         <section class="rounded-2xl border border-base-300 bg-base-100 p-3">
           <div class="mb-3 flex items-center justify-between gap-3">
             <div class="min-w-0">
@@ -178,7 +178,7 @@
         </section>
       </aside>
 
-      <main class="flex min-h-0 min-w-0 flex-col gap-4 overflow-hidden">
+      <main class="kr-pane gap-4">
         <div
           class="flex shrink-0 flex-wrap gap-2 rounded-2xl border border-base-300 bg-base-100 p-2"
         >
@@ -197,7 +197,7 @@
           </button>
         </div>
 
-        <section class="min-h-0 flex-1 overflow-y-auto">
+        <section class="kr-pane-scroll">
           <article
             v-if="activeMode === 'chat'"
             class="rounded-2xl border border-base-300 bg-base-100 p-4"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -5,9 +5,7 @@
     "one-header": [],
     "one-scroll": [
       "components/art/art-gallery.vue",
-      "components/art/art-interact.vue",
       "components/butterfly/butterfly-sanctuary.vue",
-      "components/characters/character-interact.vue",
       "components/dreams/dream-brainstorm.vue",
       "components/navigation/channel-select.vue",
       "components/pages/memory-dungeon.vue",

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -19,7 +19,8 @@
  *
  * THE RULES (see conductor projects/interface-vision/DESIGN-BRIEF.md)
  *   1. one-header    — the shell renders the page title; a page component never does
- *   2. one-scroll    — a component owns at most one scrolling region
+ *   2. one-scroll    — a component owns at most one scrolling region, unless it
+ *                       declares the .kr-panes multi-owner primitive (t-058)
  *   3. no-viewport   — no h-screen/100vh inside a shell that is already h-dvh
  *   4. one-mdc       — a content page mounts one component, not several
  *   5. ghost-prop    — don't pass :show-header to a component that never declared it
@@ -146,6 +147,8 @@ function staticClassLists(template: string): string[] {
  * A static max-h-* region is deliberately bounded inside its parent (log tail,
  * JSON preview, swatch grid), so it is not a competing page-level scroll owner.
  * kr-scroll always counts because it is the explicit full-region primitive.
+ * kr-pane-scroll is deliberately excluded here -- it is the multi-owner
+ * primitive's scroll marker and is counted separately, below.
  */
 function scrollRegionCount(template: string): number {
   return staticClassLists(template).filter((classList) => {
@@ -156,6 +159,25 @@ function scrollRegionCount(template: string): number {
     const isBounded = tokens.some((token) => token.startsWith('max-h-'))
     return hasKrScroll || (hasRawScroll && !isBounded)
   }).length
+}
+
+/*
+ * .kr-pane-scroll (interface-vision t-058) is the multi-owner primitive's
+ * scroll marker -- a component may declare more than one, but only once it
+ * has also declared the .kr-panes grid container that makes multiple owners
+ * legitimate. Mixing it with the single-owner primitive (kr-scroll / raw
+ * overflow-y-auto) in the same component is not allowed -- pick one pattern.
+ */
+function paneScrollRegionCount(template: string): number {
+  return staticClassLists(template).filter((classList) =>
+    classList.split(/\s+/).filter(Boolean).includes('kr-pane-scroll'),
+  ).length
+}
+
+function hasKrPanes(template: string): boolean {
+  return staticClassLists(template).some((classList) =>
+    classList.split(/\s+/).filter(Boolean).includes('kr-panes'),
+  )
 }
 
 /*
@@ -191,6 +213,35 @@ function verifyScrollRegionCountFixture(): void {
   const count = scrollRegionCount(templateOf(fixture))
   if (count !== 2) {
     throw new Error(`Scroll-region fixture was not classified correctly: ${count}`)
+  }
+}
+
+function verifyPaneScrollFixture(): void {
+  const withPanes = templateOf(`
+    <template>
+      <section class="kr-panes grid-cols-2">
+        <aside class="kr-pane-scroll"></aside>
+        <main class="kr-pane-scroll"></main>
+      </section>
+    </template>
+  `)
+  const withoutPanes = templateOf(`
+    <template>
+      <section>
+        <aside class="kr-pane-scroll"></aside>
+        <main class="kr-pane-scroll"></main>
+      </section>
+    </template>
+  `)
+
+  if (paneScrollRegionCount(withPanes) !== 2) {
+    throw new Error('Pane-scroll fixture was not classified correctly (count).')
+  }
+  if (!hasKrPanes(withPanes)) {
+    throw new Error('Pane-scroll fixture was not classified correctly (kr-panes present).')
+  }
+  if (hasKrPanes(withoutPanes)) {
+    throw new Error('Pane-scroll fixture was not classified correctly (kr-panes absent).')
   }
 }
 
@@ -269,11 +320,24 @@ function collect(): Record<RuleId, string[]> {
      * that adopts it declares its scroll region through the class, not a raw
      * overflow-y-auto utility string. Bounded max-h-* regions are intentionally
      * nested previews, not page-level owners, and do not count toward one-scroll.
+     *
+     * .kr-pane-scroll (interface-vision t-058) is the multi-owner escape
+     * hatch: any number of them is fine once .kr-panes is also declared, but
+     * mixing them with the single-owner primitive in the same component, or
+     * using .kr-pane-scroll without .kr-panes, is still a violation.
      */
     const scrollers = scrollRegionCount(template)
+    const paneScrollers = paneScrollRegionCount(template)
+    const declaresPanes = hasKrPanes(template)
+
     if (scrollers > 1) violations['one-scroll'].push(r)
+    else if (paneScrollers > 0 && (!declaresPanes || scrollers > 0)) {
+      violations['one-scroll'].push(r)
+    }
+
     if (
       scrollers === 0 &&
+      paneScrollers === 0 &&
       pageComponent &&
       !mdcMountedComponents.has(basename(file, '.vue'))
     ) {
@@ -340,6 +404,7 @@ function main(): void {
   const args = process.argv.slice(2)
   verifyRootClassListFixture()
   verifyScrollRegionCountFixture()
+  verifyPaneScrollFixture()
   const current = collect()
   const baseline = loadBaseline()
 


### PR DESCRIPTION
### Task
interface-vision/t-058: Give one-scroll Shape B a two-owner grid primitive (kind: software)

### What changed / what I produced
- `assets/css/tailwind.css`: new `.kr-panes` / `.kr-pane` / `.kr-pane-scroll` primitives — the documented multi-owner exception to `.kr-surface`/`.kr-scroll`'s "exactly one scroll owner" rule, for layouts (a two-pane inspector, character sheet + chat) that legitimately need more than one independently-scrolling region.
- `utils/scripts/verifyLayoutContract.ts`: the `one-scroll` rule now allows any number of `.kr-pane-scroll` regions once `.kr-panes` is declared, but still flags `.kr-pane-scroll` used without `.kr-panes`, and flags mixing it with the single-owner primitive in the same component. Added a self-verifying fixture test for the new logic (`verifyPaneScrollFixture`), matching the file's existing fixture-test style.
- Migrated the two cleanest two-owner cases named in t-058's task note: `components/characters/character-interact.vue` and `components/art/art-interact.vue` (aside + main, both independently scrolling).
- Ratcheted `utils/scripts/layout-contract-baseline.json`'s `one-scroll` bucket from 13 → 11 entries via `npm run test:layout-contract -- --update`.

### How I verified
- `npm run test:layout-contract` — passes, contract holds, no new violations.
- `npx vue-tsc --noEmit -p tsconfig.json` — clean, no errors.
- `npx eslint` on all three touched source files — the two errors reported (`character-interact.vue`'s unused `userStore`, `verifyLayoutContract.ts`'s unused `countMatches`) are pre-existing; confirmed via `git stash` that both errors are present on `main` before this change too, unrelated to this diff.

### Stakes
reversible

### Flags for Reviewer
- Scope: t-058's note also asks for (a) `verifyLayoutContract.ts` v-if/branch-exclusivity awareness (Shape A) and (b) migrating the remaining ~10 Shape B files plus the three-pane `mural-manager.vue` hard case. Neither is done here — this PR is deliberately the primitive + the two cleanest examples, so the roadmap task returns to `ready` for a follow-on pass on the remainder, same shape as the prior t-058 slice.
- `.kr-pane`'s min-w-0 addition (not present in kr-surface) is intentional — grid children need it to prevent content-driven track overflow; kr-surface's flex children don't have the same failure mode as strongly.

### Kaizen suggestion
`verifyLayoutContract.ts`'s pane-scroll check is template-text-based (no real DOM/component-tree parsing), so `.kr-panes` and `.kr-pane-scroll` only have to appear anywhere in the same file, not in an actual ancestor relationship — a future pass could tighten this if it turns out to matter in practice (structural regex over the template string, similar to how `rootClassList` already parses the literal first element).

### Notes for reviewer
This session self-assigned the `worker` role per `select_role.py` (no open PRs to review, no stale/stranded branches, no overdue site audit — see the redesigned role-assignment section in AGENTS.md that decouples role from platform trigger).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5jRJdJss5AEUh5DRx4pUW)_