### PR TITLE
test(contracts): ignore comments in three forbid scanners

### DIFF
--- a/utils/scripts/verifyArtImagePatchOwnerTransfer.ts
+++ b/utils/scripts/verifyArtImagePatchOwnerTransfer.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { containsCode } from './lib/sourceText'
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
 function read(path: string): string {
@@ -15,7 +17,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyBotMutationOwnership.ts
+++ b/utils/scripts/verifyBotMutationOwnership.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { containsCode } from './lib/sourceText'
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
 function read(path: string): string {
@@ -15,7 +17,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }

--- a/utils/scripts/verifyCharacterMutationInputParity.ts
+++ b/utils/scripts/verifyCharacterMutationInputParity.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { containsCode } from './lib/sourceText'
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
 function read(path: string): string {
@@ -15,7 +17,7 @@ function requireText(source: string, text: string, label: string): void {
 }
 
 function forbidText(source: string, text: string, label: string): void {
-  if (source.includes(text)) {
+  if (containsCode(source, text)) {
     throw new Error(`${label}: forbidden text found ${JSON.stringify(text)}`)
   }
 }


### PR DESCRIPTION
## Summary

Advances Conductor `interface-vision/t-068` with a bounded migration slice.

- routes `verifyArtImagePatchOwnerTransfer.ts` forbid checks through shared `containsCode()`
- routes `verifyBotMutationOwnership.ts` forbid checks through shared `containsCode()`
- routes `verifyCharacterMutationInputParity.ts` forbid checks through shared `containsCode()`
- leaves every require-style assertion on raw source, so comments cannot satisfy required-token contracts

## Why

These scripts still scanned raw whole-file text for forbidden fragments, so a nearby explanatory comment could fail CI despite no executable occurrence. The shared scanner and its focused regression test already landed in PR #1407.

## Verification

- Conductor claim and `status: review` processed for session `2026-08-04T101327Z-interface-vision-t-068-r6k3`
- branch diff is limited to the three named verifier scripts
- GitHub Actions must complete successfully before merge

## Handoff

This is intentionally not the full t-068 sweep. After merge, return the task to `ready` with the remaining forbid-style verifiers still in scope.