### PR TITLE
layout: migrate messenger.vue onto the kr-panes two-owner primitive (t-058)

### DIFF
--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -5,10 +5,12 @@
   conversationStore (lastReadAt-driven). Bot/forum chat stays on chatStore.
 -->
 <template>
-  <section class="mx-auto flex h-[70vh] w-full max-w-5xl gap-3 p-3">
+  <section
+    class="kr-panes mx-auto h-[70vh] w-full max-w-5xl grid-cols-[auto_minmax(0,1fr)] p-3"
+  >
     <!-- Conversation list -->
     <aside
-      class="flex w-full max-w-xs flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100 sm:w-72"
+      class="kr-pane w-full max-w-xs rounded-2xl border border-base-300 bg-base-100 sm:w-72"
     >
       <header
         class="flex items-center justify-between border-b border-base-300 p-3"
@@ -22,7 +24,7 @@
           <Icon name="kind-icon:refresh" class="h-4 w-4" />
         </button>
       </header>
-      <div class="flex-1 overflow-y-auto">
+      <div class="kr-pane-scroll">
         <p
           v-if="!convo.conversations.length && !convo.isLoadingList"
           class="p-4 text-sm text-base-content/50"
@@ -64,9 +66,7 @@
     </aside>
 
     <!-- Active thread -->
-    <div
-      class="flex min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
-    >
+    <div class="kr-pane min-w-0 rounded-2xl border border-base-300 bg-base-100">
       <template v-if="convo.activeId">
         <header class="flex items-center gap-2 border-b border-base-300 p-3">
           <div class="avatar">
@@ -83,7 +83,7 @@
           }}</span>
         </header>
 
-        <div ref="scrollBox" class="flex-1 space-y-2 overflow-y-auto p-3">
+        <div ref="scrollBox" class="kr-pane-scroll space-y-2 p-3">
           <p
             v-if="convo.isLoadingThread"
             class="text-center text-sm text-base-content/50"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -12,7 +12,6 @@
       "components/servers/server-manager.vue",
       "components/stages/stage-manager.vue",
       "components/user/chat-gallery.vue",
-      "components/user/messenger.vue",
       "components/wonderlab/lab-interact.vue",
       "components/wonderlab/mural-manager.vue"
     ],


### PR DESCRIPTION
## Summary

- Third slice of interface-vision/t-058 (Shape B): `messenger.vue`'s conversation list and active message thread are two genuinely independent, simultaneously-mounted scroll regions — exactly what the `.kr-panes`/`.kr-pane`/`.kr-pane-scroll` primitive (kind_robots PR #1423) exists for.
- Converted the flex two-column layout to `kr-panes`, with `kr-pane`/`kr-pane-scroll` on each pane (conversation list, message thread) in place of raw `overflow-y-auto`.
- Ratchets `utils/scripts/layout-contract-baseline.json`'s `one-scroll` bucket from 11 entries to 10.

**Scoping note for the next slice:** the remaining Shape B files (`butterfly-sanctuary`, `chat-gallery`, `dream-brainstorm`, `channel-select`, `memory-dungeon`, `server-manager`, `stage-manager`, `lab-interact`, `art-gallery`, `mural-manager`) weren't touched here. Several (`server-manager.vue` confirmed by testing) mix a genuine multi-owner region with mutually-exclusive `v-if`/`v-else-if` single-owner branches that `verifyLayoutContract.ts`'s static scan currently double-counts (it has no branch-exclusivity awareness yet — t-058's own still-open "FIRST" work item), so a partial fix wouldn't actually clear them from the baseline. `channel-select.vue`'s second scroll region is an absolutely-positioned flyout overlay rather than a real grid pane; applying `kr-panes`' `overflow-hidden` there risks clipping it, so it's left for a session that can visually verify the change first.

## Test plan

- [x] `npm run test` (vue-tsc typecheck) — clean
- [x] `npx eslint components/user/messenger.vue` — clean
- [x] `npx prettier --check` on changed files — clean
- [x] `npm run test:layout-contract` — passes, `one-scroll` ratchets 11 → 10
- [ ] Visual verification on a preview deployment (not attempted this session)

conductor: interface-vision/t-058

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WEM6RUcm9X3ZvJuLh1o4sV)_