### PR TITLE
layout: migrate server-manager overview and lab-interact onto kr-panes (t-058)

### DIFF
--- a/components/servers/server-manager.vue
+++ b/components/servers/server-manager.vue
@@ -24,53 +24,7 @@
       </button>
     </div>
 
-    <section
-      v-if="activeTab === 'overview'"
-      class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-12"
-    >
-      <div class="flex min-h-0 flex-col gap-4 overflow-y-auto xl:col-span-5">
-        <server-gallery
-          mode="art"
-          variant="dropdown"
-          :show-header="false"
-          :show-controls="false"
-          :show-card-actions="false"
-          :show-descriptions="true"
-          :show-meta="true"
-          :show-capabilities="false"
-          :show-use-buttons="false"
-          :show-workflow="false"
-          :show-defaults="false"
-          :show-status="false"
-        />
-
-        <server-gallery
-          mode="text"
-          variant="dropdown"
-          :show-header="false"
-          :show-controls="false"
-          :show-card-actions="false"
-          :show-descriptions="true"
-          :show-meta="true"
-          :show-capabilities="false"
-          :show-use-buttons="false"
-          :show-workflow="false"
-          :show-defaults="false"
-          :show-status="false"
-        />
-
-        <checkpoint-gallery
-          variant="compact"
-          :show-header="false"
-          :show-controls="false"
-          :show-status="false"
-        />
-      </div>
-
-      <div class="min-h-0 overflow-y-auto xl:col-span-7">
-        <server-interact />
-      </div>
-    </section>
+    <server-overview v-if="activeTab === 'overview'" />
 
     <server-gallery
       v-else-if="activeTab === 'art'"

--- a/components/servers/server-overview.vue
+++ b/components/servers/server-overview.vue
@@ -1,0 +1,58 @@
+<!-- /components/servers/server-overview.vue -->
+<!--
+  Server manager's "overview" tab: a genuine two-owner grid (galleries column
+  + interact column, both mounted and scrolling concurrently). Extracted out
+  of server-manager.vue (interface-vision t-058) so the .kr-panes/.kr-pane-scroll
+  primitive lives in a file that declares ONLY the multi-owner shape -- mixing
+  it with server-manager.vue's other, genuinely single-owner tabs in one file
+  is what the one-scroll rule forbids, and rightly so: the other five tabs are
+  mutually-exclusive v-else-if branches with one real scroll region each.
+-->
+<template>
+  <section
+    class="kr-panes grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-12"
+  >
+    <div class="kr-pane-scroll flex flex-col gap-4 xl:col-span-5">
+      <server-gallery
+        mode="art"
+        variant="dropdown"
+        :show-header="false"
+        :show-controls="false"
+        :show-card-actions="false"
+        :show-descriptions="true"
+        :show-meta="true"
+        :show-capabilities="false"
+        :show-use-buttons="false"
+        :show-workflow="false"
+        :show-defaults="false"
+        :show-status="false"
+      />
+
+      <server-gallery
+        mode="text"
+        variant="dropdown"
+        :show-header="false"
+        :show-controls="false"
+        :show-card-actions="false"
+        :show-descriptions="true"
+        :show-meta="true"
+        :show-capabilities="false"
+        :show-use-buttons="false"
+        :show-workflow="false"
+        :show-defaults="false"
+        :show-status="false"
+      />
+
+      <checkpoint-gallery
+        variant="compact"
+        :show-header="false"
+        :show-controls="false"
+        :show-status="false"
+      />
+    </div>
+
+    <div class="kr-pane-scroll xl:col-span-7">
+      <server-interact />
+    </div>
+  </section>
+</template>

--- a/components/wonderlab/lab-interact.vue
+++ b/components/wonderlab/lab-interact.vue
@@ -100,18 +100,17 @@
     </header>
 
     <section
+      class="kr-panes gap-3"
       :class="[
-        'grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-hidden',
+        'grid-cols-1',
         selectedComponent
           ? 'xl:grid-cols-[minmax(300px,360px)_minmax(0,1fr)]'
           : '',
       ]"
     >
       <aside
-        :class="[
-          'min-h-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100',
-          selectedComponent ? 'hidden xl:flex' : 'flex',
-        ]"
+        class="kr-pane rounded-2xl border border-base-300 bg-base-100"
+        :class="[selectedComponent ? 'hidden xl:flex' : 'flex']"
       >
         <div class="shrink-0 border-b border-base-300 p-3">
           <div class="grid gap-2">
@@ -232,7 +231,7 @@
           </div>
         </div>
 
-        <div class="min-h-0 flex-1 overflow-y-auto p-2">
+        <div class="kr-pane-scroll p-2">
           <div
             v-if="isLoading"
             class="flex h-full items-center justify-center py-12"
@@ -272,7 +271,7 @@
 
       <main
         v-if="selectedComponent"
-        class="min-h-0 overflow-y-auto rounded-2xl border border-base-300 bg-base-100 p-3"
+        class="kr-pane-scroll rounded-2xl border border-base-300 bg-base-100 p-3"
       >
         <article class="flex flex-col gap-4">
           <section class="rounded-2xl border border-base-300 bg-base-200 p-4">

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -9,9 +9,7 @@
       "components/butterfly/butterfly-sanctuary.vue",
       "components/dreams/dream-brainstorm.vue",
       "components/navigation/channel-select.vue",
-      "components/servers/server-manager.vue",
       "components/stages/stage-manager.vue",
-      "components/wonderlab/lab-interact.vue",
       "components/wonderlab/mural-manager.vue"
     ],
     "no-viewport": [],


### PR DESCRIPTION
### Task
interface-vision/t-058: Give one-scroll Shape B a two-owner grid primitive, and stop counting Shapes A/D (kind: software)

### What changed / what I produced
- Re-audited the current one-scroll flagged list after the prior slice (PR #1429) taught the verifier v-if/v-else-if/v-else exclusivity. Baseline was already at 9 (down from 10), having dropped `memory-dungeon.vue` and `chat-gallery.vue` for free; `animation-manager.vue` newly appeared as a genuine violation (unrelated to this task's scope — noted for a future slice, not touched here).
- **server-manager.vue**: the note's own "fixed-shape-known" case. Its "overview" tab is a genuine two-owner grid (gallery column + `server-interact` column, both mounted concurrently); its other five tabs are mutually-exclusive `v-else-if` branches, each with one real scroll region. Extracting the overview grid into a new `components/servers/server-overview.vue` (using `.kr-panes`/`.kr-pane-scroll`) was necessary rather than optional — the one-scroll rule deliberately rejects mixing the multi-owner primitive with single-owner scrolling (`kr-scroll`/raw `overflow-y-auto`) in the *same file*, so simply wrapping the overview markup in `kr-panes` in place would still have tripped the rule via the other five tabs. This matches the third slice's own finding (documented in the roadmap note) that a partial in-place edit couldn't be ratcheted out.
- **lab-interact.vue**: aside (component list, with a non-scrolling filter header) + main (selected-component detail, `v-if`) — the same shape already migrated in `character-interact.vue`/`art-interact.vue`. Converted the list body and detail panel to `kr-pane-scroll`, the grid container to `kr-panes`.
- Baseline ratchets one-scroll from 9 to 7.

### How I verified
- `npm run test:layout-contract` — 9 → 7, `--update` applied cleanly (only shrinking rules), re-ran without `--update` afterward to confirm it holds with no new violations.
- `npx eslint components/servers/server-manager.vue components/servers/server-overview.vue components/wonderlab/lab-interact.vue` — clean, no output.
- `npm run test` (`vue-tsc --noEmit`) — clean, exit 0.
- `git diff origin/main --stat` after rebase — confirmed the diff is scoped to exactly the 4 intended files (the 3 touched components + baseline JSON).

### Stakes
reversible

### Flags for Reviewer
- Investigated `stage-manager.vue` and `butterfly-sanctuary.vue` as further candidates but judged both too risky to migrate blind (no live preview available in this sandbox):
  - `stage-manager.vue`: sidebar scrolls independently of a main area whose "run" card needs a fixed (non-scrolling) footer bar (chat-style composer) — collapsing this to a single pane risks breaking that footer.
  - `butterfly-sanctuary.vue`: has a genuinely *nested* scroll (an outer `aside` that itself scrolls, wrapping an inner roster list that also scrolls), tangled with `v-show` panel toggling rather than `v-if`/`v-else`. This is a distinct bug shape from the clean two-owner-grid cases and deserves its own investigation.
  - `channel-select.vue` and `dream-brainstorm.vue` remain explicitly out of scope per the task note (need visual verification this sandbox cannot do).
  - `mural-manager.vue` (3 concurrent panes) remains the named hardest case, untouched.
  - `animation-manager.vue` newly appeared in the flagged list (wasn't there in the prior slice's audit) — worth a look in a future slice, but out of scope for this one.

### Kaizen suggestion
Add a `--verbose`/`--why` mode to `verifyLayoutContract.ts` that prints, per flagged file, whether the violation comes from a single subtree (concurrent siblings) or a mixed pane/single-owner conflict — would have saved the manual trace-through needed to confirm server-manager.vue's tabs required extraction rather than in-place `kr-panes` wrapping.

### Notes for reviewer
Session ran in a worktree-isolated sandbox where git commands cannot target the shared `conductor` checkout directly (only kind_robots git operations are unrestricted); conductor-side roadmap/TALKBACK updates go through `set_task_field.py`/`close_task.py`'s Python-level file edits and git plumbing instead of shell `cd`/`git -C`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QyUDH8UqTkEJUHB1653zRN)_