### PR TITLE
layout: migrate animation-manager onto kr-panes (t-058)

### DIFF
--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -94,9 +94,17 @@
       </button>
     </div>
 
-    <div class="flex min-h-0 flex-1 overflow-hidden">
+    <div
+      class="kr-panes gap-0"
+      :class="[
+        'grid-cols-1',
+        store.selectedItem || store.compareAttempts.length > 0
+          ? 'xl:grid-cols-[minmax(0,1fr)_minmax(280px,320px)]'
+          : '',
+      ]"
+    >
       <div
-        class="grid min-h-0 flex-1 auto-rows-min grid-cols-1 gap-3 overflow-y-auto p-4 sm:grid-cols-2 xl:grid-cols-3"
+        class="kr-pane-scroll grid auto-rows-min grid-cols-1 gap-3 p-4 sm:grid-cols-2 xl:grid-cols-3"
       >
         <div
           v-for="item in store.filteredGalleryItems"
@@ -196,7 +204,7 @@
 
       <aside
         v-if="store.selectedItem || store.compareAttempts.length > 0"
-        class="flex w-full max-w-sm shrink-0 flex-col gap-3 overflow-y-auto border-l border-base-300 bg-base-100 p-4"
+        class="kr-pane-scroll flex flex-col gap-3 border-l border-base-300 bg-base-100 p-4"
       >
         <div v-if="store.compareAttempts.length > 0" class="flex flex-col gap-2">
           <div class="flex items-center justify-between">

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -4,7 +4,6 @@
   "violations": {
     "one-header": [],
     "one-scroll": [
-      "components/animation/animation-manager.vue",
       "components/art/art-gallery.vue",
       "components/butterfly/butterfly-sanctuary.vue",
       "components/dreams/dream-brainstorm.vue",


### PR DESCRIPTION
### Task
interface-vision/t-058: fifth layout-contract sweep slice (kind: software)

### What changed / what I produced
- `components/animation/animation-manager.vue`: migrated the card grid + selected-item/compare aside onto the `.kr-panes`/`.kr-pane`/`.kr-pane-scroll` multi-owner scroll primitive (interface-vision t-058). This is a genuine two-owner grid -- the filtered effect grid and the selected/compare aside are both mounted simultaneously and scroll independently, the same shape already proven on `character-interact.vue`, `art-interact.vue`, `messenger.vue`, and `lab-interact.vue`. No visual behavior change intended: `overflow-y-auto` on each region is replaced 1:1 by `kr-pane-scroll`, and the outer flex row becomes a `kr-panes` grid with the same effective column layout (single column when the aside is hidden, two columns when it's shown).
- `utils/scripts/layout-contract-baseline.json`: ratcheted `one-scroll` from 7 to 6 (`--update`).

### How I verified
- `npx tsx utils/scripts/verifyLayoutContract.ts` — contract holds, one-scroll baseline improves by 1, no new violations in any rule.
- `npm run test` (vue-tsc `--noEmit`) — clean, no type errors.
- `npx eslint components/animation/animation-manager.vue` — clean.
- Not visually verified against a live preview (no Vercel/browser access this session); the migration is a mechanical 1:1 class substitution matching four already-shipped, already-visually-verified precedents, and the classes involved (`overflow-y-auto` → `kr-pane-scroll`, which is `min-h-0 flex-1 overflow-y-auto overscroll-contain`) are behaviorally equivalent plus `min-h-0`/`overscroll-contain`, which only prevent scroll-chaining/overflow bugs.

### Stakes
reversible

### Flags for Reviewer
- No visual/preview verification was possible this session (documented access limitation, same as prior t-058 slices) -- worth a quick production spot-check of `/build/animation-manager` (or wherever this mounts) after merge.

### Kaizen suggestion
Of the 6 remaining one-scroll entries (stage-manager, mural-manager, butterfly-sanctuary, dream-brainstorm, channel-select, art-gallery), all six were previously flagged as needing live visual verification before migration. A future slice with working Vercel/browser access could clear several of these in one pass instead of one-at-a-time blocked-on-access.

### Notes for reviewer
Conductor task interface-vision/t-058 is claimed under session `2026-08-04T132944Z-t058-slice6`; roadmap will be updated to `status: review` then closed out via `close_task.py` once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZat1TA2WRr3WyL4k94LRU)_