### PR TITLE
fix(art): remove fixed ArtJob queue mount height

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -94,7 +94,7 @@
         <template v-else-if="activeTab === 'artjob'">
           <artjob-failed-page-requeue class="2xl:col-span-2" />
           <artjob-queue-browser
-            class="min-h-[720px] overflow-hidden 2xl:min-h-0"
+            class="min-h-0 overflow-hidden"
           />
           <artjob-feedback-manager
             class="min-h-[560px] overflow-hidden 2xl:min-h-0"


### PR DESCRIPTION
## Summary
- replace the ArtJob queue mount's fixed `min-h-[720px]` with `min-h-0`
- let the queue participate in the existing flex/grid sizing contract instead of forcing a 720px box
- keep the change scoped to `interface-vision/t-084`

## Verification
- TypeScript Type Check
- Layout Contract
- Contract Tests

## Conductor handoff
- Project/task: `interface-vision/t-084`
- Session: `2026-08-04T142435Z-interface-vision-t-084-q7m2`
- Roadmap was moved to `review` before this PR opened.
