### PR TITLE
interface-vision/t-082: add isPublic/isMature toggle UI to Scenario edit form

### DIFF
--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -120,6 +120,40 @@
       </section>
 
       <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
+        <div class="mb-4">
+          <h2 class="text-xl font-bold text-base-content">Publishing</h2>
+          <p class="text-sm text-base-content/70">
+            Control who can discover this scenario and whether mature-content
+            filtering applies.
+          </p>
+        </div>
+
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label
+            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
+          >
+            <span class="label-text font-bold">Public</span>
+            <input
+              v-model="scenarioStore.scenarioForm.isPublic"
+              type="checkbox"
+              class="toggle toggle-success"
+            />
+          </label>
+
+          <label
+            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
+          >
+            <span class="label-text font-bold">Mature</span>
+            <input
+              v-model="scenarioStore.scenarioForm.isMature"
+              type="checkbox"
+              class="toggle toggle-warning"
+            />
+          </label>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-base-300 bg-base-100 p-4">
         <div class="mb-4 flex items-center justify-between gap-2">
           <div>
             <h2 class="text-xl font-bold text-base-content">Opening Choices</h2>
@@ -470,6 +504,8 @@ function resetForAdd() {
     artPrompt: '',
     imagePath: null,
     artImageId: null,
+    isPublic: true,
+    isMature: false,
     userId: userStore.authenticatedUserId,
   }
 


### PR DESCRIPTION
### Task
interface-vision/t-082: Add isPublic/isMature toggle UI to the Scenario edit form (kind: software)

### What changed / what I produced
- `components/scenarios/add-scenario.vue`: added a "Publishing" section (Public/Mature toggle checkboxes) mirroring the one `add-reward.vue` gained in t-080, bound to `scenarioStore.scenarioForm.isPublic`/`isMature`.
- `resetForAdd()` now defaults `isPublic: true, isMature: false` (matching the `Scenario` Prisma model's own column defaults), same as the pre-existing pattern for the other form fields.
- No store changes needed: `scenarioStore.toScenarioPayload()` already spreads the whole form into the save payload, and `toScenarioForm()` already spreads the full `Scenario` record (which carries `isPublic`/`isMature`) when editing, so both fields already round-trip correctly once the UI exists.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint components/scenarios/add-scenario.vue` — clean
- `npx prettier --check components/scenarios/add-scenario.vue` — clean (ran `--write` once to match repo style)
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, no new violations (still 6 multi-scroll components, unchanged)
- `npx tsx utils/scripts/verifyGalleryConsistency.ts` — all 7 checks pass

### Stakes
reversible

### Flags for Reviewer
- Split out from t-080 (kind_robots PR #1393) after its Scenario half was left undone; this closes that half.
- Placed the Publishing section directly after the Facets/Inspirations/genre-tags grid and before "Opening Choices," matching where `add-reward.vue` places its own Publishing section relative to its analogous sections.

### Kaizen suggestion
None beyond scope — this is a small, self-contained mirror of an already-reviewed pattern.

### Notes for reviewer
Conductor: interface-vision/t-082

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jci1XymN45X4vLgVdLgbCk)_