### PR TITLE
interface-vision/t-058: exempt fixed-inset-0 modal overlays from the one-scroll rule

### DIFF
--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -4,7 +4,6 @@
   "violations": {
     "one-header": [],
     "one-scroll": [
-      "components/art/art-gallery.vue",
       "components/butterfly/butterfly-sanctuary.vue",
       "components/dreams/dream-brainstorm.vue",
       "components/navigation/channel-select.vue",

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -250,7 +250,26 @@ function ownScrollCount(node: TemplateNode): number {
   return hasKrScroll || (hasRawScroll && !isBounded) ? 1 : 0
 }
 
+/*
+ * `fixed inset-0` takes an element out of normal document flow and layers it
+ * over the entire viewport (interface-vision t-058's Shape B follow-on: a
+ * modal/lightbox, not a co-resident grid pane). Its content is never visible
+ * or interactive alongside the page's base scroll region the way a real
+ * Shape B aside+main pair is -- the two can't compete for the user's scroll
+ * gesture at the same time -- so a scroll region inside one doesn't compete
+ * with the page's own owner. Unlike swapping h-screen for h-dvh (t-017's
+ * documented gaming risk), `fixed inset-0` isn't a quiet drop-in substitute
+ * for anything else: it fundamentally changes how the element renders, so
+ * it isn't a plausible way to dodge this rule while keeping the same shape.
+ */
+function isFixedOverlay(node: TemplateNode): boolean {
+  return (
+    node.classTokens.includes('fixed') && node.classTokens.includes('inset-0')
+  )
+}
+
 function subtreeScrollCount(node: TemplateNode): number {
+  if (isFixedOverlay(node)) return 0
   return ownScrollCount(node) + combineScrollCounts(node.children)
 }
 
@@ -404,6 +423,50 @@ function verifyScrollExclusivityFixture(): void {
   if (scrollRegionCount(literalGtInExpression) !== 1) {
     throw new Error(
       "Scroll-exclusivity fixture (literal '>' inside a v-if expression) was not classified correctly.",
+    )
+  }
+}
+
+function verifyFixedOverlayFixture(): void {
+  const overlayOverBaseScroll = templateOf(`
+    <template>
+      <section class="overflow-y-auto"></section>
+      <div v-if="open" class="fixed inset-0">
+        <div class="overflow-y-auto"></div>
+      </div>
+    </template>
+  `)
+  if (scrollRegionCount(overlayOverBaseScroll) !== 1) {
+    throw new Error(
+      'Fixed-overlay fixture (modal over base scroll) was not classified correctly.',
+    )
+  }
+
+  const twoScrollsInsideOverlay = templateOf(`
+    <template>
+      <div class="fixed inset-0">
+        <div class="overflow-y-auto"></div>
+        <div class="overflow-y-auto"></div>
+      </div>
+    </template>
+  `)
+  if (scrollRegionCount(twoScrollsInsideOverlay) !== 0) {
+    throw new Error(
+      'Fixed-overlay fixture (nested scrolls all exempt) was not classified correctly.',
+    )
+  }
+
+  const fixedWithoutInset0 = templateOf(`
+    <template>
+      <section class="overflow-y-auto"></section>
+      <div class="fixed bottom-4 right-4">
+        <div class="overflow-y-auto"></div>
+      </div>
+    </template>
+  `)
+  if (scrollRegionCount(fixedWithoutInset0) !== 2) {
+    throw new Error(
+      'Fixed-overlay fixture (fixed without inset-0 still counts) was not classified correctly.',
     )
   }
 }
@@ -601,6 +664,7 @@ function main(): void {
   verifyRootClassListFixture()
   verifyScrollRegionCountFixture()
   verifyScrollExclusivityFixture()
+  verifyFixedOverlayFixture()
   verifyPaneScrollFixture()
   const current = collect()
   const baseline = loadBaseline()


### PR DESCRIPTION
### Task
interface-vision/t-058: Give one-scroll Shape B a two-owner grid primitive, and stop counting Shapes A/D (kind: software)

### What changed / what I produced
- `art-gallery.vue`'s second `overflow-auto` region lives inside a `fixed inset-0` lightbox overlay (the selected-image modal), not a co-resident Shape B grid pane like `character-interact.vue`/`art-interact.vue` — the background gallery and the modal's own scroll region are never simultaneously visible/interactive the way a real aside+main pair is.
- Taught `utils/scripts/verifyLayoutContract.ts`'s one-scroll rule to exempt the whole subtree of any `fixed`+`inset-0` wrapper, the same way bounded `max-h-*` regions and `v-if`/`v-else-if`/`v-else` branches are already exempt (both prior t-058 slices).
- Added fixture coverage in `verifyFixedOverlayFixture()`: a modal over base scroll (exempt), two scrolls both inside one overlay (both exempt), and a negative case — `fixed` *without* `inset-0` still counts — so this isn't a blanket fixed-position exemption.
- Ratcheted the `one-scroll` baseline from 6 to 5 (`art-gallery.vue` removed).
- **No component markup changed** — this is a verifier-only fix, zero production layout risk.

### How I verified
- `npm run test:layout-contract -- --report` — `art-gallery.vue` drops out, no other file's count changed, all fixture assertions (including the new ones) pass since the script runs to completion without throwing.
- `npm run test:layout-contract -- --update` — baseline ratchets 6 → 5 cleanly.
- `npx vue-tsc --noEmit` — clean.
- `npx eslint utils/scripts/verifyLayoutContract.ts` — clean.

### Stakes
reversible

### Flags for Reviewer
- This intentionally does NOT touch the remaining 5 `one-scroll` entries (`butterfly-sanctuary.vue`, `dream-brainstorm.vue`, `channel-select.vue`, `stage-manager.vue`, `mural-manager.vue`). Prior t-058 slices already judged each of those too risky to migrate without live visual verification — `channel-select.vue` in particular is a global-nav dropdown where a bad `kr-panes`/`overflow-hidden` migration would be highly visible, so I deliberately left those for a slice with either a live preview check or a smaller, more isolated migration than a global nav component.
- The `isFixedOverlay` guard checks for both `fixed` and `inset-0` tokens together specifically so it can't be triggered by an incidental `fixed` utility (e.g. a fixed FAB button) — see the negative fixture.

### Kaizen suggestion
`server-manager.vue`'s "overview" tab already needed extracting into its own component (`server-overview.vue`, prior slice) because the one-scroll rule rejects mixing `kr-panes` with sibling single-owner `v-else-if` tabs in one file. Worth checking whether any of the 5 remaining flagged files hit the same shape (a two-owner region living alongside otherwise-single-owner tabs) before assuming each needs a from-scratch investigation.

### Notes for reviewer
This is the conductor-directed session's t-058 slice; the conductor roadmap task will be moved to `status: review` and closed out in a companion conductor PR once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1eci7c4QFZK14Tc3C3UDj)_