### PR TITLE
interface-vision/t-058: migrate dream-brainstorm onto kr-panes

### DIFF
--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -69,10 +69,10 @@
     </header>
 
     <div
-      class="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-hidden xl:grid-cols-[22rem_minmax(0,1fr)_22rem]"
+      class="kr-panes grid-cols-1 xl:grid-cols-[22rem_minmax(0,1fr)_22rem]"
     >
       <aside
-        class="flex min-h-0 flex-col overflow-hidden rounded-2xl border border-base-300 bg-base-100"
+        class="kr-pane rounded-2xl border border-base-300 bg-base-100"
       >
         <div class="shrink-0 border-b border-base-300 bg-base-200 p-3">
           <div class="flex items-center justify-between gap-2">
@@ -105,7 +105,7 @@
           </label>
         </div>
 
-        <div class="min-h-0 flex-1 overflow-y-auto p-2">
+        <div class="kr-pane-scroll p-2">
           <div v-if="filteredDreams.length" class="grid gap-2">
             <button
               v-for="dream in filteredDreams"
@@ -142,9 +142,7 @@
         </div>
       </aside>
 
-      <main
-        class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-2xl border border-base-300 bg-base-100"
-      >
+      <main class="kr-pane rounded-2xl border border-base-300 bg-base-100">
         <section class="shrink-0 border-b border-base-300 bg-base-200 p-3">
           <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
             <label class="form-control">
@@ -216,7 +214,7 @@
           </label>
         </section>
 
-        <section class="min-h-0 overflow-y-auto p-3">
+        <section class="kr-pane-scroll p-3">
           <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
             <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
               <div>
@@ -400,7 +398,7 @@
       </main>
 
       <aside
-        class="flex min-h-0 flex-col gap-3 overflow-hidden rounded-2xl border border-base-300 bg-base-100 p-3"
+        class="kr-pane gap-3 rounded-2xl border border-base-300 bg-base-100 p-3"
       >
         <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
           <h2 class="mb-3 text-lg font-black">Text Server</h2>

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -5,7 +5,6 @@
     "one-header": [],
     "one-scroll": [
       "components/butterfly/butterfly-sanctuary.vue",
-      "components/dreams/dream-brainstorm.vue",
       "components/navigation/channel-select.vue",
       "components/stages/stage-manager.vue",
       "components/wonderlab/mural-manager.vue"


### PR DESCRIPTION
### Task
interface-vision/t-058: Give one-scroll Shape B a two-owner grid primitive, and stop counting Shapes A/D (kind: software)

### What changed / what I produced
- Eighth t-058 slice: `dream-brainstorm.vue`'s aside/main/aside grid is a genuine two-owner Shape B case — the source-Dreams list (left aside) and the Fresh Ideas body (nested inside `main`) both scroll independently at the same time.
- Migrated onto `kr-panes`/`kr-pane`/`kr-pane-scroll`, the same shape already proven on `character-interact.vue`, `art-interact.vue`, `messenger.vue`, `lab-interact.vue`, and `animation-manager.vue`.
- `main`'s header/scroll-body/footer rows moved from an explicit `grid grid-rows-[auto_minmax(0,1fr)_auto]` layout to `kr-pane`'s flex-col shape — an identical visual result, since each row was already effectively auto/1fr/auto sized, and `kr-pane` bakes in `flex flex-col`, which would otherwise fight with an explicit `grid` display on the same element.
- No visual or behavioral change to any of the three panes' own content — only the scroll-ownership wrapper classes changed.
- Ratchets `utils/scripts/layout-contract-baseline.json`'s `one-scroll` allow-list from 5 to 4.

### How I verified
- `npx tsx utils/scripts/verifyLayoutContract.ts` — confirmed the fix (`-1` on `one-scroll`), then `--update` to ratchet the baseline.
- `npm run test` (`vue-tsc --noEmit`) — clean.
- `npx eslint components/dreams/dream-brainstorm.vue` — clean.
- Did not have a live preview to visually confirm pixel-identical layout in this pass — flagged below.

### Stakes
reversible

### Flags for Reviewer
- No live browser/Vercel-preview check was done before opening this PR (sandbox time budget). The transformation is mechanical (grid-rows → flex-col with identical row sizing, raw `overflow-y-auto` → `kr-pane-scroll`) and mirrors five already-merged, already-verified migrations of the exact same shape, but a preview check post-merge (or before, if reviewing this live) would remove all doubt for this specific file.
- Remaining one-scroll allow-list entries after this slice, all still needing separate investigation per prior slices' findings: `butterfly-sanctuary.vue` (nested scroll tangled with `v-show`, distinct bug shape), `channel-select.vue` (global-nav flyout overlay — genuine two-owner case needing visual confirmation the flyout isn't clipped), `mural-manager.vue` (3-pane, the hardest case), `stage-manager.vue` (footer-composer risk).

### Kaizen suggestion
Now that six files have used the identical `kr-panes` aside(list)+main(header/scroll/footer) shape (character-interact, art-interact, messenger, lab-interact, animation-manager, dream-brainstorm), consider whether a lightweight visual-regression snapshot (even a static DOM/class assertion, not full pixel diff) could catch a future `kr-pane` + explicit `grid`/`flex` class conflict automatically, rather than relying on each migration's author to notice `flex` and `grid` living on the same element.

### Notes for reviewer
This is the conductor-directed session's t-058 implementation; the conductor roadmap task will be moved to `status: review` and closed out in a companion conductor PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_013LDqhrxB4Qe4KNp8BqJ2v5)_