### PR TITLE
interface-vision/t-058: add overlay-safe kr-anchor-panes/kr-anchor-scroll primitive

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -333,6 +333,29 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply min-h-0 flex-1 overflow-y-auto overscroll-contain;
   }
 
+  /*
+   * Anchor + overlay multi-owner scroll marker (interface-vision t-058
+   * follow-on, conductor issue #1690): an anchored control (e.g. a dropdown
+   * menu) with an absolutely-positioned flyout sibling, where both are
+   * genuinely interactive and independently scrollable at the same time.
+   * Unlike .kr-panes this applies NO grid/overflow-hidden -- clipping the
+   * anchor would clip the overlay child that is positioned outside its
+   * bounds by design. .kr-anchor-panes only legitimizes .kr-anchor-scroll
+   * children for the one-scroll rule; it carries no layout behavior of its
+   * own beyond guaranteeing it never clips.
+   */
+  .kr-anchor-panes {
+    @apply overflow-visible;
+  }
+
+  /* One anchor-group scroll owner -- the .kr-scroll idiom, without the
+     flex-1/min-h-0 sizing .kr-pane-scroll assumes, since anchor/overlay
+     menus size themselves via an explicit max-height style rather than
+     flex growth. */
+  .kr-anchor-scroll {
+    @apply overflow-y-auto overscroll-contain;
+  }
+
   /* Root-satisfying marker with NO overflow/height behavior of its own
      (interface-vision t-057/t-059). For MDC-mounted -page.vue components
      rendered inside pages/[...slug].vue's own scrolling content-host: that

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -41,12 +41,12 @@
 
     <div
       tabindex="0"
-      class="dropdown-content z-110 mt-2"
+      class="dropdown-content z-110 mt-2 kr-anchor-panes"
       @focusin="scheduleChannelMenuViewportUpdate"
     >
       <ul
         ref="channelMenu"
-        class="menu w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="menu w-[min(22rem,calc(100vw-1rem))] flex-nowrap overflow-x-hidden kr-anchor-scroll rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
         :style="{
           maxHeight: `${channelMenuMaxHeight}px`,
           scrollbarGutter: 'stable',
@@ -181,7 +181,7 @@
       <ul
         v-if="expandedChannel && submenuMode === 'flyout'"
         ref="channelFlyout"
-        class="channel-submenu menu absolute left-full z-120 ml-2 w-80 overflow-x-hidden overflow-y-auto overscroll-contain rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
+        class="channel-submenu menu absolute left-full z-120 ml-2 w-80 overflow-x-hidden kr-anchor-scroll rounded-2xl border border-base-300 bg-base-100 p-2 shadow-2xl"
         :style="{
           top: `${channelFlyoutTop}px`,
           maxHeight: `${channelFlyoutMaxHeight}px`,

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -5,7 +5,6 @@
     "one-header": [],
     "one-scroll": [
       "components/butterfly/butterfly-sanctuary.vue",
-      "components/navigation/channel-select.vue",
       "components/stages/stage-manager.vue",
       "components/wonderlab/mural-manager.vue"
     ],

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -331,6 +331,27 @@ function hasKrPanes(template: string): boolean {
 }
 
 /*
+ * .kr-anchor-scroll (interface-vision t-058 follow-on, conductor issue
+ * #1690) is the overlay-safe sibling of .kr-pane-scroll: legitimate for an
+ * anchored control (e.g. a dropdown menu) whose absolutely-positioned
+ * flyout child is simultaneously interactive and independently scrollable.
+ * Gated behind .kr-anchor-panes exactly like .kr-pane-scroll is gated
+ * behind .kr-panes, so an arbitrary absolutely-positioned element can't
+ * opt itself out of the one-scroll rule without also declaring the marker.
+ */
+function anchorScrollRegionCount(template: string): number {
+  return staticClassLists(template).filter((classList) =>
+    classList.split(/\s+/).filter(Boolean).includes('kr-anchor-scroll'),
+  ).length
+}
+
+function hasKrAnchorPanes(template: string): boolean {
+  return staticClassLists(template).some((classList) =>
+    classList.split(/\s+/).filter(Boolean).includes('kr-anchor-panes'),
+  )
+}
+
+/*
  * This checks the literal first element inside <template>, not whichever nested
  * wrapper looks visually dominant. Put the kr-* marker on that opening tag.
  */
@@ -504,6 +525,49 @@ function verifyPaneScrollFixture(): void {
   }
 }
 
+function verifyAnchorScrollFixture(): void {
+  const withAnchorPanes = templateOf(`
+    <template>
+      <div class="dropdown-content kr-anchor-panes">
+        <ul class="kr-anchor-scroll"></ul>
+        <ul class="absolute left-full kr-anchor-scroll"></ul>
+      </div>
+    </template>
+  `)
+  const withoutAnchorPanes = templateOf(`
+    <template>
+      <div class="dropdown-content">
+        <ul class="kr-anchor-scroll"></ul>
+        <ul class="absolute left-full kr-anchor-scroll"></ul>
+      </div>
+    </template>
+  `)
+
+  if (anchorScrollRegionCount(withAnchorPanes) !== 2) {
+    throw new Error(
+      'Anchor-scroll fixture was not classified correctly (count).',
+    )
+  }
+  if (!hasKrAnchorPanes(withAnchorPanes)) {
+    throw new Error(
+      'Anchor-scroll fixture was not classified correctly (kr-anchor-panes present).',
+    )
+  }
+  if (hasKrAnchorPanes(withoutAnchorPanes)) {
+    throw new Error(
+      'Anchor-scroll fixture was not classified correctly (kr-anchor-panes absent).',
+    )
+  }
+
+  /* An arbitrary absolutely-positioned element cannot bypass the
+     one-scroll rule just by borrowing the .kr-anchor-scroll class name
+     without its component ever declaring .kr-anchor-panes (conductor
+     issue #1690's item 4) -- this is asserted end-to-end via `collect()`
+     in the one-scroll rule itself, not just these two helpers, since a
+     lone .kr-anchor-scroll with no .kr-anchor-panes anywhere in the file
+     must still surface as a violation. */
+}
+
 function collect(): Record<RuleId, string[]> {
   const vueFiles = [
     ...walk(join(ROOT, 'components'), '.vue'),
@@ -584,19 +648,32 @@ function collect(): Record<RuleId, string[]> {
      * hatch: any number of them is fine once .kr-panes is also declared, but
      * mixing them with the single-owner primitive in the same component, or
      * using .kr-pane-scroll without .kr-panes, is still a violation.
+     *
+     * .kr-anchor-scroll (t-058 follow-on, conductor issue #1690) is the
+     * overlay-safe sibling escape hatch for an anchor + absolutely-positioned
+     * flyout shape (.kr-panes' overflow-hidden would clip the flyout). Same
+     * gating rule, scoped to .kr-anchor-panes instead of .kr-panes.
      */
     const scrollers = scrollRegionCount(template)
     const paneScrollers = paneScrollRegionCount(template)
     const declaresPanes = hasKrPanes(template)
+    const anchorScrollers = anchorScrollRegionCount(template)
+    const declaresAnchorPanes = hasKrAnchorPanes(template)
 
     if (scrollers > 1) violations['one-scroll'].push(r)
     else if (paneScrollers > 0 && (!declaresPanes || scrollers > 0)) {
+      violations['one-scroll'].push(r)
+    } else if (
+      anchorScrollers > 0 &&
+      (!declaresAnchorPanes || scrollers > 0 || paneScrollers > 0)
+    ) {
       violations['one-scroll'].push(r)
     }
 
     if (
       scrollers === 0 &&
       paneScrollers === 0 &&
+      anchorScrollers === 0 &&
       pageComponent &&
       !mdcMountedComponents.has(basename(file, '.vue'))
     ) {
@@ -666,6 +743,7 @@ function main(): void {
   verifyScrollExclusivityFixture()
   verifyFixedOverlayFixture()
   verifyPaneScrollFixture()
+  verifyAnchorScrollFixture()
   const current = collect()
   const baseline = loadBaseline()
 


### PR DESCRIPTION
### Task
interface-vision/t-058: Give one-scroll Shape B a two-owner grid primitive, and stop counting Shapes A/D (kind: software)

Resolves conductor issue #1690 (channel-select.vue's flyout needed an overlay-safe variant of the existing multi-owner primitive).

### What changed / what I produced
- `assets/css/tailwind.css`: new `.kr-anchor-panes` / `.kr-anchor-scroll` primitive pair — same gating shape as `.kr-panes`/`.kr-pane-scroll`, but with **no** grid/`overflow-hidden` behavior of its own (explicitly `overflow-visible`), since `components/navigation/channel-select.vue`'s dropdown menu and its absolutely-positioned `left-full` tab flyout are two simultaneously interactive scroll owners, and clipping the anchor would clip the flyout.
- `utils/scripts/verifyLayoutContract.ts`: teaches the `one-scroll` rule to recognize `.kr-anchor-scroll` regions as legitimate once `.kr-anchor-panes` is declared, mirroring the existing `kr-panes`/`kr-pane-scroll` gating — including the guard against mixing multi-owner primitives, and against a lone `.kr-anchor-scroll` with no `.kr-anchor-panes` anywhere in the file bypassing the rule (conductor issue #1690 item 4). New `verifyAnchorScrollFixture()` covers both directions.
- `components/navigation/channel-select.vue`: replaces the two scroll regions' raw `overflow-y-auto overscroll-contain` utility classes with `kr-anchor-scroll` (functionally identical CSS via the new component class), and marks their shared `.dropdown-content` ancestor `kr-anchor-panes`. No layout/behavior change — a pure class rename.
- `utils/scripts/layout-contract-baseline.json`: ratchets `one-scroll` from 4 to 3 (removes `components/navigation/channel-select.vue`).

### How I verified
- `npm run test:layout-contract` — clean, all fixtures (including the new `verifyAnchorScrollFixture`) pass; confirms the ratchet (4 → 3) rather than gaming it.
- `npx vue-tsc --noEmit` — clean, no errors.
- `npx eslint components/navigation/channel-select.vue utils/scripts/verifyLayoutContract.ts` — clean.
- Read-traced daisyUI's `.dropdown-content` (already `position: absolute`, so the flyout's `absolute left-full` positioning is unaffected) and confirmed `.kr-anchor-scroll`'s CSS (`overflow-y-auto overscroll-contain`) is byte-identical to the utility classes it replaces — this is a pure rename, not a behavioral change, so no live/Vercel visual check was needed for this slice (unlike the migrations still pending for stage-manager/mural-manager/butterfly-sanctuary, which do change layout).

### Stakes
reversible

### Flags for Reviewer
- Did not attempt a live browser/Vercel check — the change swaps utility classes for a CSS class with byte-identical declarations, so there is no visual delta to confirm. Flagging in case the Reviewer wants a Vercel preview check anyway before merge.
- Conductor issue #1690 is resolved by this primitive; leaving it open is fine if the Reviewer wants to keep it as the durable record, or it can be closed once merged.

### Kaizen suggestion
Three one-scroll entries remain (`stage-manager.vue`, `mural-manager.vue`, `butterfly-sanctuary.vue`), all previously flagged as needing live layout verification before migration rather than a mechanical class swap like this one. Worth budgeting real Vercel-preview time for the next slice.

### Notes for reviewer
This is a conductor-directed session's t-058 implementation; the conductor roadmap task will be updated and closed out in a companion conductor commit/PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3dzSedhRPQHE328xHrgdT)_