### PR TITLE
test(layout): lock mixed pane primitives

### DIFF
--- a/.github/workflows/layout-contract.yml
+++ b/.github/workflows/layout-contract.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Verify layout contract
         run: npm run test:layout-contract
+
+      - name: Verify mixed pane primitive fixture
+        run: npx tsx utils/scripts/verifyMixedPanePrimitivesFixture.ts

--- a/utils/scripts/verifyMixedPanePrimitivesFixture.ts
+++ b/utils/scripts/verifyMixedPanePrimitivesFixture.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'node:child_process'
+import { rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+const FIXTURE_RELATIVE_PATH =
+  'components/__layout-contract-mixed-pane-primitives-fixture.vue'
+const FIXTURE_PATH = join(ROOT, FIXTURE_RELATIVE_PATH)
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+const fixture = `<template>
+  <section class="kr-panes kr-anchor-panes">
+    <aside class="kr-pane-scroll"></aside>
+    <div class="kr-anchor-scroll"></div>
+  </section>
+</template>
+`
+
+try {
+  writeFileSync(FIXTURE_PATH, fixture)
+  const output = execFileSync(
+    npm,
+    ['run', 'test:layout-contract', '--', '--report'],
+    {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  if (!output.includes(FIXTURE_RELATIVE_PATH)) {
+    throw new Error(
+      'A component mixing kr-panes and kr-anchor-panes was not reported as a one-scroll violation.',
+    )
+  }
+
+  console.log(
+    'Mixed pane primitive fixture holds: kr-panes and kr-anchor-panes cannot be combined.',
+  )
+} finally {
+  rmSync(FIXTURE_PATH, { force: true })
+}


### PR DESCRIPTION
## Summary

Completes `interface-vision/t-098` with an executable regression fixture for the layout contract.

- creates a temporary Vue component that declares both `kr-panes` and `kr-anchor-panes`
- gives it one `kr-pane-scroll` and one `kr-anchor-scroll` owner
- runs the real `verifyLayoutContract.ts --report` collector
- fails unless the mixed component is reported as a `one-scroll` violation
- removes the temporary component in a `finally` block
- runs the fixture in the existing Layout Contract workflow

This protects the actual end-to-end gating conditional rather than duplicating helper-only assertions.

## Validation

- Layout Contract workflow
- TypeScript Type Check
- repository contract workflows triggered by the PR

## Conductor

Task `interface-vision/t-098` was claimed and moved to `review` by session `2026-08-04T191148Z-interface-vision-t098-j4q8` before this PR opened.